### PR TITLE
fix: preserve recovered terminal upload expiry

### DIFF
--- a/docs/web/control-ui/panels.md
+++ b/docs/web/control-ui/panels.md
@@ -59,6 +59,8 @@ Drag one or more files onto the active terminal, or use the paperclip button to 
 
 Images, PDFs, archives, and other file types are accepted up to 16 MiB per file. New uploads must fit within shared limits of 256 MiB and 64 files per staging directory, including files from other terminal tabs and previous processes. When either limit is reached, move or remove staged files, or wait for cleanup, then retry. Existing unexpired files are not evicted to make room, including uploads retained above these limits after an upgrade. Staged files use a private system-temporary directory on POSIX hosts (directory mode `0700`, file mode `0600`) or a directory under the user-profile ACL boundary on Windows, plus a 24-hour cleanup timer, so move or copy anything you need to keep.
 
+Renaming staged files or retrying failed cleanup does not restart an already scheduled cleanup deadline.
+
 If staging stays locked after a process crash, follow the lock error's recovery steps: stop all Gateway and node-host processes using that staging directory, remove only the lock directory named in the error, and restart them. This leaves staged files intact. An incomplete lock record is never cleared automatically because it cannot prove that another writer has stopped.
 
 Path insertion supports PowerShell, `cmd.exe`, and recognized POSIX shells (`sh`, Bash, Dash, Ash, Ksh, Zsh, and Fish), including Git Bash on Windows. Other shell overrides are refused because their quoting rules cannot be inferred safely; run the Gateway inside WSL for a native WSL terminal and Linux upload paths. `cmd.exe` paths containing `%` or `!` are also refused because that shell expands those characters even inside double quotes.

--- a/src/infra/terminal-file-upload.test.ts
+++ b/src/infra/terminal-file-upload.test.ts
@@ -223,42 +223,61 @@ describe("terminal file upload", () => {
     },
   );
 
-  it("does not apply a recovered expiry to a replacement directory at the same path", async () => {
-    vi.useFakeTimers({ now: Date.now() + 60_000 });
-    const root = tempDirs.make("openclaw-terminal-upload-replacement-recovery-test-");
-    const directory = path.join(root, "openclaw-terminal-upload-replaced");
-    const movedDirectory = path.join(root, "operator-kept");
-    const retentionMs = 24 * 60 * 60 * 1000;
-    const remainingMs = 2 * 60 * 60 * 1000;
-    try {
-      await mkdir(directory, { mode: 0o700 });
-      await writeFile(path.join(directory, "original.bin"), "keep outside staging");
-      const originalTime = new Date(Date.now() - retentionMs + remainingMs);
-      await utimes(directory, originalTime, originalTime);
-      await ensureTerminalUploadCleanup({ tempRoot: root });
+  it.each([
+    { identity: "native", largeFileIds: false },
+    { identity: "64-bit", largeFileIds: true },
+  ])(
+    "gives a replacement directory its own expiry with $identity file identifiers",
+    async ({ largeFileIds }) => {
+      vi.useFakeTimers({ now: Date.now() + 60_000 });
+      const root = tempDirs.make("openclaw-terminal-upload-replacement-recovery-test-");
+      const directory = path.join(root, "openclaw-terminal-upload-replaced");
+      const movedDirectory = path.join(root, "operator-kept");
+      const retentionMs = 24 * 60 * 60 * 1000;
+      const remainingMs = 2 * 60 * 60 * 1000;
+      const lstatMock = vi.mocked(lstat);
+      let inode = 2n ** 54n;
+      try {
+        if (largeFileIds) {
+          lstatMock.mockImplementation(async (target, options) => {
+            const stats = await actualFs.lstat(target, options);
+            if (String(target) === directory) {
+              stats.ino = typeof stats.ino === "bigint" ? inode : Number(inode);
+            }
+            return stats;
+          });
+        }
+        await mkdir(directory, { mode: 0o700 });
+        await writeFile(path.join(directory, "original.bin"), "keep outside staging");
+        const originalTime = new Date(Date.now() - retentionMs + remainingMs);
+        await utimes(directory, originalTime, originalTime);
+        await ensureTerminalUploadCleanup({ tempRoot: root });
 
-      await rename(directory, movedDirectory);
-      await mkdir(directory, { mode: 0o700 });
-      await writeFile(path.join(directory, "replacement.bin"), "new upload directory");
-      const replacementTime = new Date(Date.now());
-      await utimes(directory, replacementTime, replacementTime);
-      await vi.advanceTimersByTimeAsync(remainingMs);
-      await ensureTerminalUploadCleanup({ tempRoot: root });
+        await rename(directory, movedDirectory);
+        inode += 1n;
+        await mkdir(directory, { mode: 0o700 });
+        await writeFile(path.join(directory, "replacement.bin"), "new upload directory");
+        const replacementTime = new Date(Date.now());
+        await utimes(directory, replacementTime, replacementTime);
+        await vi.advanceTimersByTimeAsync(remainingMs);
+        await ensureTerminalUploadCleanup({ tempRoot: root });
 
-      expect(await readFile(path.join(directory, "replacement.bin"), "utf8")).toBe(
-        "new upload directory",
-      );
-      await vi.advanceTimersByTimeAsync(retentionMs - remainingMs);
-      await vi.waitFor(async () => {
-        await expect(stat(directory)).rejects.toMatchObject({ code: "ENOENT" });
-      });
-      expect(await readFile(path.join(movedDirectory, "original.bin"), "utf8")).toBe(
-        "keep outside staging",
-      );
-    } finally {
-      vi.useRealTimers();
-    }
-  });
+        expect(await readFile(path.join(directory, "replacement.bin"), "utf8")).toBe(
+          "new upload directory",
+        );
+        await vi.advanceTimersByTimeAsync(retentionMs - remainingMs);
+        await vi.waitFor(async () => {
+          await expect(stat(directory)).rejects.toMatchObject({ code: "ENOENT" });
+        });
+        expect(await readFile(path.join(movedDirectory, "original.bin"), "utf8")).toBe(
+          "keep outside staging",
+        );
+      } finally {
+        lstatMock.mockImplementation(actualFs.lstat);
+        vi.useRealTimers();
+      }
+    },
+  );
 
   it("expires a future-dated upload without extending retention on each recovery scan", async () => {
     const nowMs = Date.UTC(2026, 8, 7, 12);

--- a/src/infra/terminal-file-upload.test.ts
+++ b/src/infra/terminal-file-upload.test.ts
@@ -4,6 +4,7 @@ import {
   mkdir,
   readFile,
   readdir,
+  rename,
   rm,
   stat,
   truncate,
@@ -187,6 +188,78 @@ describe("terminal file upload", () => {
     await expect(stat(directory)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it.each([1, directoryLimit + 1])(
+    "keeps the original recovered expiry after renames in %i upload directories",
+    async (count) => {
+      vi.useFakeTimers({ now: Date.now() + 60_000 });
+      const root = tempDirs.make("openclaw-terminal-upload-rename-recovery-test-");
+      const remainingMs = 2 * 60 * 60 * 1000;
+      try {
+        const files = await createRetainedUploads(
+          root,
+          Array.from({ length: count }, () => 0),
+        );
+        const originalTime = new Date(Date.now() - 22 * 60 * 60 * 1000);
+        await Promise.all(
+          files.map((file) => utimes(path.dirname(file), originalTime, originalTime)),
+        );
+        await ensureTerminalUploadCleanup({ tempRoot: root });
+
+        const renamed = files.map((file) => path.join(path.dirname(file), "renamed.bin"));
+        await Promise.all(files.map((file, index) => rename(file, renamed[index]!)));
+        await vi.advanceTimersByTimeAsync(remainingMs - 1);
+        expect(await retainedDirectories(root)).toHaveLength(count);
+        expect(vi.getTimerCount()).toBe(1);
+
+        await vi.advanceTimersByTimeAsync(1);
+
+        await vi.waitFor(async () => {
+          expect(await retainedDirectories(root)).toHaveLength(0);
+        });
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it("does not apply a recovered expiry to a replacement directory at the same path", async () => {
+    vi.useFakeTimers({ now: Date.now() + 60_000 });
+    const root = tempDirs.make("openclaw-terminal-upload-replacement-recovery-test-");
+    const directory = path.join(root, "openclaw-terminal-upload-replaced");
+    const movedDirectory = path.join(root, "operator-kept");
+    const retentionMs = 24 * 60 * 60 * 1000;
+    const remainingMs = 2 * 60 * 60 * 1000;
+    try {
+      await mkdir(directory, { mode: 0o700 });
+      await writeFile(path.join(directory, "original.bin"), "keep outside staging");
+      const originalTime = new Date(Date.now() - retentionMs + remainingMs);
+      await utimes(directory, originalTime, originalTime);
+      await ensureTerminalUploadCleanup({ tempRoot: root });
+
+      await rename(directory, movedDirectory);
+      await mkdir(directory, { mode: 0o700 });
+      await writeFile(path.join(directory, "replacement.bin"), "new upload directory");
+      const replacementTime = new Date(Date.now());
+      await utimes(directory, replacementTime, replacementTime);
+      await vi.advanceTimersByTimeAsync(remainingMs);
+      await ensureTerminalUploadCleanup({ tempRoot: root });
+
+      expect(await readFile(path.join(directory, "replacement.bin"), "utf8")).toBe(
+        "new upload directory",
+      );
+      await vi.advanceTimersByTimeAsync(retentionMs - remainingMs);
+      await vi.waitFor(async () => {
+        await expect(stat(directory)).rejects.toMatchObject({ code: "ENOENT" });
+      });
+      expect(await readFile(path.join(movedDirectory, "original.bin"), "utf8")).toBe(
+        "keep outside staging",
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("expires a future-dated upload without extending retention on each recovery scan", async () => {
     const nowMs = Date.UTC(2026, 8, 7, 12);
     const retentionMs = 1_000;
@@ -269,7 +342,8 @@ describe("terminal file upload", () => {
     expect(await retainedDirectories(root)).toHaveLength(sizes.length + 2);
   });
 
-  it("keeps expired uploads charged until cleanup actually removes them", async () => {
+  it("keeps partially removed expired uploads charged and retries at the original deadline", async () => {
+    vi.useFakeTimers({ now: Date.now() + 60_000 });
     const root = tempDirs.make("openclaw-terminal-upload-cleanup-budget-test-");
     const files = await createRetainedUploads(
       root,
@@ -277,10 +351,13 @@ describe("terminal file upload", () => {
     );
     const expiredFile = files[0]!;
     const expiredDirectory = path.dirname(expiredFile);
+    const removableFile = path.join(expiredDirectory, "removed-before-failure.bin");
+    await writeFile(removableFile, "");
     await utimes(expiredDirectory, new Date(0), new Date(0));
     const rmMock = vi.mocked(rm);
     rmMock.mockImplementation(async (target, options) => {
       if (String(target) === expiredDirectory) {
+        await actualFs.rm(removableFile, { force: true });
         throw Object.assign(new Error("cleanup busy"), { code: "EBUSY" });
       }
       return actualFs.rm(target, options);
@@ -291,13 +368,17 @@ describe("terminal file upload", () => {
       await expect(
         stageTerminalUpload({ name: "too-early.bin", contentBase64: "AA==" }, { tempRoot: root }),
       ).rejects.toThrow();
+      await expect(stat(removableFile)).rejects.toMatchObject({ code: "ENOENT" });
+      expect((await stat(expiredDirectory)).mtimeMs).toBeGreaterThan(0);
       expect((await stat(expiredFile)).size).toBe(storageLimitBytes / directoryLimit);
       expect(await retainedDirectories(root)).toHaveLength(directoryLimit);
 
       rmMock.mockImplementation(actualFs.rm);
-      await ensureTerminalUploadCleanup({ tempRoot: root });
+      await vi.advanceTimersByTimeAsync(60 * 60 * 1000);
 
-      await expect(stat(expiredDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+      await vi.waitFor(async () => {
+        await expect(stat(expiredDirectory)).rejects.toMatchObject({ code: "ENOENT" });
+      });
       const accepted = await stageTerminalUpload(
         { name: "after-cleanup.bin", contentBase64: "AA==" },
         { tempRoot: root },
@@ -306,6 +387,7 @@ describe("terminal file upload", () => {
       expect(await retainedDirectories(root)).toHaveLength(directoryLimit);
     } finally {
       rmMock.mockImplementation(actualFs.rm);
+      vi.useRealTimers();
     }
   });
 

--- a/src/infra/terminal-file-upload.ts
+++ b/src/infra/terminal-file-upload.ts
@@ -42,7 +42,8 @@ const uploadQueue = new BoundedSerialQueue({
 
 type CleanupState = {
   retentionMs: number;
-  deadlines: Map<string, number>;
+  // One deadline per observed upload, including legacy inventories above the admission limit.
+  deadlines: Map<string, { dev: number; ino: number; expiresAt: number }>;
   timer?: ReturnType<typeof setTimeout>;
   nextAt?: number;
 };
@@ -274,14 +275,21 @@ async function scanUploads(
         continue;
       }
       unseen.delete(directory);
-      let expiresAt = state.deadlines.get(directory) ?? stats.mtimeMs + state.retentionMs;
-      if (stats.mtimeMs > nowMs) {
-        // Persist the clamp so later root scans cannot keep extending a future-dated upload.
-        await assertHeld();
-        await lutimes(directory, stats.atime, new Date(nowMs));
-        state.deadlines.delete(directory);
-        expiresAt = nowMs + state.retentionMs;
+      let deadline = state.deadlines.get(directory);
+      if (!deadline || deadline.dev !== stats.dev || deadline.ino !== stats.ino) {
+        if (stats.mtimeMs > nowMs) {
+          // Persist the clamp so another process cannot extend a future-dated upload.
+          await assertHeld();
+          await lutimes(directory, stats.atime, new Date(nowMs));
+        }
+        deadline = {
+          dev: stats.dev,
+          ino: stats.ino,
+          expiresAt: Math.min(stats.mtimeMs, nowMs) + state.retentionMs,
+        };
+        state.deadlines.set(directory, deadline);
       }
+      const { expiresAt } = deadline;
       if (expiresAt <= nowMs) {
         await assertHeld();
         if (await removeTerminalUploadDirectory(directory)) {
@@ -410,26 +418,31 @@ export async function stageTerminalUpload(
         await assertHeld();
         const directory = await mkdtemp(path.join(root, TERMINAL_UPLOAD_PREFIX));
         const targetPath = path.join(directory, sanitizeTerminalUploadName(name));
+        let identity: { dev: number; ino: number } | undefined;
         try {
+          const { dev, ino } = await lstat(directory);
+          identity = { dev, ino };
           await assertHeld();
           await writeFile(targetPath, Buffer.from(contentBase64, "base64"), {
             flag: "wx",
             mode: 0o600,
           });
+          const expiresAt = Date.now() + (options?.cleanupAfterMs ?? TERMINAL_UPLOAD_RETENTION_MS);
+          state.deadlines.set(directory, { ...identity, expiresAt });
+          cleanupRoots.set(root, state);
+          scheduleCleanup(root, state, expiresAt);
+          return { path: targetPath, size };
         } catch (error) {
           if (!(await removeTerminalUploadDirectory(directory))) {
             const retryAt = Date.now() + TERMINAL_UPLOAD_CLEANUP_RETRY_MS;
-            state.deadlines.set(directory, retryAt);
+            if (identity) {
+              state.deadlines.set(directory, { ...identity, expiresAt: retryAt });
+            }
             cleanupRoots.set(root, state);
             scheduleCleanup(root, state, retryAt);
           }
           throw error;
         }
-        const expiresAt = Date.now() + (options?.cleanupAfterMs ?? TERMINAL_UPLOAD_RETENTION_MS);
-        state.deadlines.set(directory, expiresAt);
-        cleanupRoots.set(root, state);
-        scheduleCleanup(root, state, expiresAt);
-        return { path: targetPath, size };
       });
     },
     { weight: contentBase64.length, sealOnOverflow: false },

--- a/src/infra/terminal-file-upload.ts
+++ b/src/infra/terminal-file-upload.ts
@@ -43,7 +43,7 @@ const uploadQueue = new BoundedSerialQueue({
 type CleanupState = {
   retentionMs: number;
   // One deadline per observed upload, including legacy inventories above the admission limit.
-  deadlines: Map<string, { dev: number; ino: number; expiresAt: number }>;
+  deadlines: Map<string, { dev: bigint; ino: bigint; expiresAt: number }>;
   timer?: ReturnType<typeof setTimeout>;
   nextAt?: number;
 };
@@ -261,7 +261,7 @@ async function scanUploads(
       const directory = path.join(root, entry.name);
       let stats;
       try {
-        stats = await lstat(directory);
+        stats = await lstat(directory, { bigint: true });
       } catch (error) {
         if (hasErrnoCode(error, "ENOENT")) {
           continue;
@@ -270,14 +270,17 @@ async function scanUploads(
       }
       if (
         !stats.isDirectory() ||
-        (typeof process.getuid === "function" && stats.uid !== process.getuid())
+        (typeof process.getuid === "function" && stats.uid !== BigInt(process.getuid()))
       ) {
         continue;
       }
       unseen.delete(directory);
       let deadline = state.deadlines.get(directory);
       if (!deadline || deadline.dev !== stats.dev || deadline.ino !== stats.ino) {
-        if (stats.mtimeMs > nowMs) {
+        // Keep fractional milliseconds so recovery cannot expire an upload early.
+        const mtimeMs =
+          Number(stats.mtimeNs / 1_000_000n) + Number(stats.mtimeNs % 1_000_000n) / 1_000_000;
+        if (mtimeMs > nowMs) {
           // Persist the clamp so another process cannot extend a future-dated upload.
           await assertHeld();
           await lutimes(directory, stats.atime, new Date(nowMs));
@@ -285,7 +288,7 @@ async function scanUploads(
         deadline = {
           dev: stats.dev,
           ino: stats.ino,
-          expiresAt: Math.min(stats.mtimeMs, nowMs) + state.retentionMs,
+          expiresAt: Math.min(mtimeMs, nowMs) + state.retentionMs,
         };
         state.deadlines.set(directory, deadline);
       }
@@ -418,9 +421,9 @@ export async function stageTerminalUpload(
         await assertHeld();
         const directory = await mkdtemp(path.join(root, TERMINAL_UPLOAD_PREFIX));
         const targetPath = path.join(directory, sanitizeTerminalUploadName(name));
-        let identity: { dev: number; ino: number } | undefined;
+        let identity: { dev: bigint; ino: bigint } | undefined;
         try {
-          const { dev, ino } = await lstat(directory);
+          const { dev, ino } = await lstat(directory, { bigint: true });
           identity = { dev, ino };
           await assertHeld();
           await writeFile(targetPath, Buffer.from(contentBase64, "base64"), {


### PR DESCRIPTION
Related: #137116

## What Problem This Solves

Fixes an issue where recovered terminal uploads could remain for an extra day after a file rename or a partially failed cleanup.

## Why This Change Was Made

The cleanup owner retains each observed directory's original expiry and full-precision filesystem identity. Records are removed when uploads disappear, and one timer continues to manage the staging root, including existing inventories above the admission limit. Timestamp conversion preserves fractional milliseconds.

## User Impact

Renaming a staged file and retrying failed cleanup preserve its scheduled deadline. A replacement directory at the same path receives its own deadline, including on filesystems with large 64-bit identifiers. The existing 24-hour retention and upload storage limits are unchanged.

## Evidence

- All 20 upload-owner tests pass locally and on native Windows Server 2022, covering renames in one and 65 directories, partial cleanup, directory replacement, large file identifiers, future timestamps, byte/count admission, unreadable inventory and write failures.
- Real filesystem probes confirm deletion at the original recovered deadline and the scheduled cleanup retry after permission recovery. On native Windows, a replacement with an identifier beyond JavaScript Number precision survives the old deadline and expires at its own deadline.
- Linux probes retain 1,024 legacy directories with one unreferenced timer; the timer retires when the removed inventory is observed.
- All 119 Linux owner/Gateway/node-invoke tests, the complete three-path `check:changed` gate, and exact-head hosted CI pass. Independent review is clean through P2.
