### PR TITLE
refactor(skills): share leaf materialization and metadata type

### DIFF
--- a/src/skills/loading/local-loader.ts
+++ b/src/skills/loading/local-loader.ts
@@ -7,12 +7,9 @@ import {
   readFileDescriptorBoundedSync,
 } from "../../infra/boundary-file-read.js";
 import type { ParsedSkillFrontmatter } from "../types.js";
-import { parseSkillFrontmatter, resolveSkillInvocationPolicy } from "./frontmatter.js";
-import {
-  createSyntheticSourceInfo,
-  resolveSkillDisplayName,
-  type Skill,
-} from "./skill-contract.js";
+import { parseSkillFrontmatter } from "./frontmatter.js";
+import type { Skill } from "./skill-contract.js";
+import { materializeSkill } from "./skill-materializer.js";
 
 export type LoadedLocalSkill = {
   skill: Skill;
@@ -115,26 +112,20 @@ export function loadSingleSkillDirectory(params: {
     });
     return null;
   }
-  const invocation = resolveSkillInvocationPolicy(frontmatter);
   const filePath = path.resolve(skillFilePath);
   const baseDir = path.resolve(params.skillDir);
 
   return {
-    skill: {
+    skill: materializeSkill({
+      content: raw,
+      frontmatter,
       name,
-      displayName: resolveSkillDisplayName(raw, name),
       description,
       filePath,
       baseDir,
       source: params.source,
-      sourceInfo: createSyntheticSourceInfo(filePath, {
-        source: params.source,
-        baseDir,
-        scope: "project",
-        origin: "top-level",
-      }),
-      disableModelInvocation: invocation.disableModelInvocation,
-    },
+      sourceOptions: { source: params.source, scope: "project", origin: "top-level" },
+    }),
     frontmatter,
     content: raw,
   };

--- a/src/skills/loading/session.test.ts
+++ b/src/skills/loading/session.test.ts
@@ -4,6 +4,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { withMockedWindowsPlatform } from "../../test-utils/vitest-spies.js";
 import { parseSkillFrontmatter, resolveSkillManifestMetadata } from "./frontmatter.js";
+import { loadSingleSkillDirectory, type LocalSkillLoadDiagnostic } from "./local-loader.js";
 import { loadSkills } from "./session.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -13,6 +14,80 @@ function loadSkillsFromPath(dir: string) {
 }
 
 describe("loadSkills", () => {
+  it.each(["user", "project", "path"] as const)(
+    "preserves %s session provenance and its untrimmed fallback name beside local loading",
+    async (source) => {
+      const root = tempDirs.make("openclaw-skill-materialization-");
+      const agentDir = path.join(root, "agent");
+      const cwd = path.join(root, "project");
+      const skillRoot =
+        source === "user"
+          ? path.join(agentDir, "skills")
+          : source === "project"
+            ? path.join(cwd, ".openclaw", "skills")
+            : path.join(root, "selected");
+      const skillDir = path.join(skillRoot, " padded-name");
+      const filePath = path.join(skillDir, "SKILL.md");
+      await fs.mkdir(skillDir, { recursive: true });
+      await fs.writeFile(
+        filePath,
+        '---\ndescription: "  Padded metadata.  "\ndisable-model-invocation: true\n---\n# Shared Title\n',
+      );
+
+      const session = loadSkills({ cwd, agentDir, skillPaths: [filePath], includeDefaults: false });
+      expect(session.skills).toEqual([
+        {
+          name: " padded-name",
+          displayName: "Shared Title",
+          description: "Padded metadata.",
+          filePath,
+          baseDir: skillDir,
+          source,
+          sourceInfo: {
+            path: filePath,
+            source: "local",
+            scope: source === "path" ? "temporary" : source,
+            origin: "top-level",
+            baseDir: skillDir,
+          },
+          disableModelInvocation: true,
+        },
+      ]);
+      expect(session.diagnostics).toEqual([
+        {
+          type: "warning",
+          path: filePath,
+          message: "name contains invalid characters (must be lowercase a-z, 0-9, hyphens only)",
+        },
+      ]);
+
+      const diagnostics: LocalSkillLoadDiagnostic[] = [];
+      const local = loadSingleSkillDirectory({
+        skillDir,
+        source: "workspace",
+        rootRealPath: await fs.realpath(skillDir),
+        onDiagnostic: (diagnostic) => diagnostics.push(diagnostic),
+      });
+      expect(local?.skill).toEqual({
+        name: "padded-name",
+        displayName: "Shared Title",
+        description: "Padded metadata.",
+        filePath,
+        baseDir: skillDir,
+        source: "workspace",
+        sourceInfo: {
+          path: filePath,
+          source: "workspace",
+          scope: "project",
+          origin: "top-level",
+          baseDir: skillDir,
+        },
+        disableModelInvocation: true,
+      });
+      expect(diagnostics).toEqual([]);
+    },
+  );
+
   it("reports directory scan failures as diagnostics", async () => {
     const tempDir = tempDirs.make("openclaw-skill-scan-");
     const regularFile = path.join(tempDir, "not-a-directory");

--- a/src/skills/loading/session.ts
+++ b/src/skills/loading/session.ts
@@ -2,7 +2,6 @@ import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { basename, dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { CONFIG_DIR_NAME, getAgentDir } from "../../agents/config.js";
 import type { ResourceDiagnostic } from "../../agents/sessions/diagnostics.js";
-import { createSyntheticSourceInfo, type SourceInfo } from "../../agents/sessions/source-info.js";
 import { canonicalizePath } from "../../agents/utils/paths.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import {
@@ -12,8 +11,9 @@ import {
 } from "../../shared/ignore-rules.js";
 // Session skill helpers resolve skills attached to a session and its transcript state.
 import { expandTildePath } from "../../shared/tilde-path.js";
-import { parseSkillFrontmatter, resolveSkillInvocationPolicy } from "./frontmatter.js";
-import { resolveSkillDisplayName } from "./skill-contract.js";
+import { parseSkillFrontmatter } from "./frontmatter.js";
+import type { Skill } from "./skill-contract.js";
+import { materializeSkill } from "./skill-materializer.js";
 import { formatSkillsForPromptBounded } from "./skill-prompt-limits.js";
 
 /** Max name length per spec */
@@ -22,19 +22,7 @@ const MAX_NAME_LENGTH = 64;
 /** Max description length per spec */
 const MAX_DESCRIPTION_LENGTH = 1024;
 
-export interface Skill {
-  name: string;
-  /** Human-readable title from the first Markdown H1, falling back to the identifier. */
-  displayName?: string;
-  description: string;
-  filePath: string;
-  baseDir: string;
-  /** @deprecated Ignored; retained for API compatibility until the next Plugin SDK major. */
-  promptVersion?: string;
-  source: string;
-  sourceInfo: SourceInfo;
-  disableModelInvocation: boolean;
-}
+export type { Skill } from "./skill-contract.js";
 
 interface LoadSkillsResult {
   skills: Skill[];
@@ -82,28 +70,13 @@ function validateDescription(description: string | undefined): string[] {
   return errors;
 }
 
-function createSkillSourceInfo(filePath: string, baseDir: string, source: string): SourceInfo {
-  switch (source) {
-    case "user":
-      return createSyntheticSourceInfo(filePath, {
-        source: "local",
-        scope: "user",
-        baseDir,
-      });
-    case "project":
-      return createSyntheticSourceInfo(filePath, {
-        source: "local",
-        scope: "project",
-        baseDir,
-      });
-    case "path":
-      return createSyntheticSourceInfo(filePath, {
-        source: "local",
-        baseDir,
-      });
-    default:
-      return createSyntheticSourceInfo(filePath, { source, baseDir });
+function resolveSkillSourceOptions(
+  source: string,
+): Parameters<typeof materializeSkill>[0]["sourceOptions"] {
+  if (source === "user" || source === "project") {
+    return { source: "local", scope: source };
   }
+  return { source: source === "path" ? "local" : source };
 }
 
 function loadSkillsFromDirInternal(
@@ -223,7 +196,6 @@ function loadSkillFromFile(
   try {
     const rawContent = readFileSync(filePath, "utf-8");
     const frontmatter = parseSkillFrontmatter(rawContent);
-    const invocation = resolveSkillInvocationPolicy(frontmatter);
     const skillDir = dirname(filePath);
     const parentDirName = basename(skillDir);
 
@@ -248,16 +220,16 @@ function loadSkillFromFile(
     }
 
     return {
-      skill: {
+      skill: materializeSkill({
+        content: rawContent,
+        frontmatter,
         name,
-        displayName: resolveSkillDisplayName(rawContent, name),
         description: frontmatter.description,
         filePath,
         baseDir: skillDir,
         source,
-        sourceInfo: createSkillSourceInfo(filePath, skillDir, source),
-        disableModelInvocation: invocation.disableModelInvocation,
-      },
+        sourceOptions: resolveSkillSourceOptions(source),
+      }),
       diagnostics,
     };
   } catch (error) {

--- a/src/skills/loading/skill-contract.ts
+++ b/src/skills/loading/skill-contract.ts
@@ -13,6 +13,8 @@ export interface Skill {
   readContent?: string;
   filePath: string;
   baseDir: string;
+  /** @deprecated Ignored; retained for API compatibility until the next Plugin SDK major. */
+  promptVersion?: string;
   sourceInfo: SourceInfo;
   disableModelInvocation: boolean;
   // Preserve legacy source reads while keeping the canonical upstream shape.

--- a/src/skills/loading/skill-materializer.ts
+++ b/src/skills/loading/skill-materializer.ts
@@ -1,0 +1,32 @@
+import type { ParsedSkillFrontmatter } from "../types.js";
+import { resolveSkillInvocationPolicy } from "./frontmatter.js";
+import {
+  createSyntheticSourceInfo,
+  resolveSkillDisplayName,
+  type Skill,
+} from "./skill-contract.js";
+
+export function materializeSkill(params: {
+  content: string;
+  frontmatter: ParsedSkillFrontmatter;
+  name: string;
+  description: string;
+  filePath: string;
+  baseDir: string;
+  source: string;
+  sourceOptions: Omit<Parameters<typeof createSyntheticSourceInfo>[1], "baseDir">;
+}): Skill {
+  return {
+    name: params.name,
+    displayName: resolveSkillDisplayName(params.content, params.name),
+    description: params.description,
+    filePath: params.filePath,
+    baseDir: params.baseDir,
+    source: params.source,
+    sourceInfo: createSyntheticSourceInfo(params.filePath, {
+      ...params.sourceOptions,
+      baseDir: params.baseDir,
+    }),
+    disableModelInvocation: resolveSkillInvocationPolicy(params.frontmatter).disableModelInvocation,
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Session and local skill loaders independently construct the same skill metadata, and the session loader also duplicates the structural Skill interface. New fields or provenance fixes can drift between those paths.

## Why This Change Was Made

One private materializer builds the admitted leaf metadata using the existing display-name, source-info, and invocation-policy owners. Each loader retains its scanning, filesystem guards, validation, diagnostics, name/description normalization, and provenance selection. `skill-contract.ts` owns the structural type, with the existing session export forwarding it.

## User Impact

No intended runtime change. The session loader keeps untrimmed fallback names and its user/project/path provenance; local loading keeps its trimmed names and source policy. Existing export names remain. The deprecated optional `promptVersion` field and its exact next-Plugin-SDK-major retention comment stay intact. The shared type also carries its existing optional `locationNote` and `readContent` string fields; declaration compatibility is checked canonically.

Production shrinks by 3 lines; tests add 75 lines. This consolidates leaf construction and type ownership without unifying the distinct scanners.

## Evidence

- `node scripts/run-vitest.mjs src/skills/loading/session.test.ts src/skills/loading/skill-contract.test.ts src/skills/loading/workspace-skill-loader.test.ts src/skills/loading/skill-root-discovery.test.ts src/skills/loading/skill-path-containment.test.ts`: **75 passed**.
- Shared real-file cases cover user, project, and explicit-path provenance, differing fallback-name normalization, display titles, descriptions, paths, and the model-invocation flag. Existing promptVersion formatting tests remain unchanged.
- `pnpm plugin-sdk:check-exports` and `pnpm plugin-sdk:surface:check` passed at **152 public entrypoints / 4445 exports / 2627 callables**, with no budget change.
- `pnpm check:madge-import-cycles`: **0 cycles**.
- An inferred source-scope string was corrected with an explicit return type derived from the materializer's parameter contract, without a cast or runtime change. Final autoreview is scoped-clean through P3.
- `node scripts/check-changed.mjs` passed completely after the type annotation correction. `pnpm build` passed in **7m46.5s**. Canonical API comparison `dcc733dc20e→0f5da2de427` shows **0 entrypoint changes, 0 added/removed/directly changed exports**, and **233 exports with reachable declaration changes** across three declaration differences. The session interface becomes a re-export of the canonical type, and `promptVersion` is retained in that type. Acknowledgement digest: **`55d45598`**. Final declaration graph: **3477315 / 5315536 bytes**, within the unchanged budget.

Sibling #131584's skill-repair receipt work was inspected and does not overlap these loader files. File paths, source metadata and invocation flags it relies on remain unchanged. #141207's 2026.9.2 SDK compatibility changes do not overlap this type ownership change; no new unconditional SDK import or public entrypoint is added.


The first hosted run failed only an unchanged Doctor process test with `spawnSync ETIMEDOUT` at its existing 60000ms child limit, after 7114 CLI tests passed. The selected case passed locally in 26.57s (37.04s including the harness); the workspace-check path inspects Git ancestry and memory guidance and is unchanged by this PR. The one maintainer-authorized failed-job rerun passed on the same head, including the Doctor process subshard and final CI gate; no code, mock, or timeout changed. Run: https://github.com/openclaw/openclaw/actions/runs/34129334458.
