### PR TITLE
improve(reply): reduce repeated preparation for replies with attachments

### DIFF
--- a/src/auto-reply/media-note.ts
+++ b/src/auto-reply/media-note.ts
@@ -133,7 +133,7 @@ type InboundMediaNoteProjection = {
   text?: string;
   media: MediaFact[];
   /** Original ctx.media fact positions aligned with `media`, for index-based identity. */
-  mediaIndexes?: number[];
+  mediaIndexes: number[];
 };
 
 /** Formats prompt-visible attachment text and retains facts that still need native hydration. */

--- a/src/auto-reply/reply/get-reply-run-admission.ts
+++ b/src/auto-reply/reply/get-reply-run-admission.ts
@@ -229,14 +229,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
     sessionEntryHandle?.replaceCurrent(sessionEntry);
   }
   const skillsSnapshot = skillResult.skillsSnapshot;
-  let {
-    prefixedCommandBody,
-    queuedBody,
-    transcriptBody,
-    transcriptCommandBody,
-    media: promptMedia,
-    currentInboundContext,
-  } = await traceRunPhase("reply.build_prompt_bodies", () => rebuildPromptBodies());
+  let promptBodies = await traceRunPhase("reply.build_prompt_bodies", () => rebuildPromptBodies());
   const isRoomEvent = inboundEventKind === "room_event";
   if (!resolvedThinkLevel) {
     resolvedThinkLevel = await traceRunPhase("reply.resolve_default_thinking", () =>
@@ -625,14 +618,9 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
         // The interrupted run may have changed goal or suggestion state while admission waited.
         await refreshInboundContextAfterAdmissionWait();
         sessionEntry = context.getSessionEntry();
-        ({
-          prefixedCommandBody,
-          queuedBody,
-          transcriptBody,
-          transcriptCommandBody,
-          media: promptMedia,
-          currentInboundContext,
-        } = await traceRunPhase("reply.build_prompt_bodies", () => rebuildPromptBodies()));
+        promptBodies = await traceRunPhase("reply.build_prompt_bodies", () =>
+          rebuildPromptBodies(),
+        );
       },
       resolveBusyState: resolveQueueBusyState,
     });
@@ -643,16 +631,18 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
   }
   if (activeRunQueueAction !== "drop") {
     await traceRunPhase("reply.drain_system_events", () => drainSystemEventBlocks());
-    ({
-      prefixedCommandBody,
-      queuedBody,
-      transcriptBody,
-      transcriptCommandBody,
-      media: promptMedia,
-      currentInboundContext,
-    } = await traceRunPhase("reply.build_prompt_bodies", () => rebuildPromptBodies()));
+    promptBodies = await traceRunPhase("reply.build_prompt_bodies", () => rebuildPromptBodies());
   }
 
+  const {
+    prefixedCommandBody,
+    queuedBody,
+    transcriptBody,
+    transcriptCommandBody,
+    media: promptMedia,
+    inboundMediaIndexes,
+    currentInboundContext,
+  } = promptBodies;
   return {
     kind: "ready",
     context,
@@ -666,6 +656,7 @@ export async function prepareReplyRunAdmission(context: PreparedReplyRunContext)
     transcriptBody,
     transcriptCommandBody,
     promptMedia,
+    inboundMediaIndexes,
     currentInboundContext,
     isRoomEvent,
     providedReplyOperation,

--- a/src/auto-reply/reply/get-reply-run-execute.ts
+++ b/src/auto-reply/reply/get-reply-run-execute.ts
@@ -28,7 +28,6 @@ import {
 } from "../../sessions/user-turn-transcript.js";
 import { buildChannelUserTurnSender } from "../../sessions/user-turn-transcript.metadata.js";
 import { isReasoningTagProvider } from "../../utils/provider-utils.js";
-import { buildInboundMediaNoteProjection } from "../media-note.js";
 import type { OriginatingChannelType } from "../templating.js";
 import { resolveCurrentTurnImages } from "./current-turn-images.js";
 import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
@@ -67,6 +66,7 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     transcriptBody,
     transcriptCommandBody,
     promptMedia,
+    inboundMediaIndexes,
     currentInboundContext,
     isRoomEvent,
     providedReplyOperation,
@@ -226,7 +226,6 @@ export async function executePreparedReplyRun(state: PreparedReplyRunAdmission) 
     unresolvedSourceIndexes.has(index) ? { ...fact, hydrationSuppressed: true } : fact,
   );
   const userTurnMediaForPersistence = [...persistedCtxMedia, ...(opts?.media ?? [])];
-  const inboundMediaIndexes = buildInboundMediaNoteProjection(ctx).mediaIndexes ?? [];
   const promptMediaForRun = suppressUnresolvedPromptMedia({
     promptMedia: promptMedia ?? [],
     inboundMediaIndexes,

--- a/src/auto-reply/reply/get-reply-run.media-only.test.ts
+++ b/src/auto-reply/reply/get-reply-run.media-only.test.ts
@@ -2277,6 +2277,68 @@ describe("runPreparedReply media-only handling", () => {
     });
   });
 
+  it.each([false, true])(
+    "keeps duplicate-path image positions after admission wait=%s",
+    async (wait) => {
+      const sharedPath = "/tmp/shared-media-index.png";
+      const sessionId = "prepared-media-index-session";
+      const queueSettings = await import("./queue/settings-runtime.js");
+      vi.mocked(queueSettings.resolveQueueSettings).mockReturnValueOnce({ mode: "interrupt" });
+      const previousRun = wait
+        ? createReplyOperation({ sessionId, sessionKey: "session-key", resetTriggered: false })
+        : undefined;
+      previousRun?.setPhase("running");
+      resolveCurrentTurnImagesMock.mockResolvedValueOnce({
+        images: [{ type: "image", data: "c3ludGhldGlj", mimeType: "image/png" }],
+        imageOrder: ["inline"],
+        imageSourceIndexes: [1],
+        unresolvedSourceIndexes: [2],
+      });
+      const running = runPrepared({
+        isNewSession: false,
+        sessionId,
+        ctx: {
+          ...createInboundTurn("inspect both images", "webchat", "direct"),
+          media: [
+            { path: "/tmp/voice.ogg", contentType: "audio/ogg", transcribed: true },
+            { path: sharedPath, contentType: "image/png" },
+            { path: sharedPath, contentType: "image/png" },
+          ],
+        },
+        sessionCtx: createSessionTurn("inspect both images", "webchat", "direct"),
+      });
+      try {
+        if (previousRun) {
+          await vi.waitFor(() => expect(previousRun.abortSignal.aborted).toBe(true));
+          previousRun.complete();
+        }
+        await expect(running).resolves.toEqual({ text: "ok" });
+      } finally {
+        previousRun?.complete();
+        await running.catch(() => undefined);
+      }
+
+      const { followupRun } = requireRunReplyAgentCall();
+      expect(followupRun.media).toHaveLength(2);
+      expect(followupRun.media?.[0]).not.toHaveProperty("hydrationSuppressed");
+      expect(followupRun).toMatchObject({
+        media: [{ path: sharedPath }, { path: sharedPath, hydrationSuppressed: true }],
+        mediaImageLayout: {
+          slots: [{ kind: "inline", factIndex: 0 }],
+          suppressedFactIndexes: [1],
+        },
+      });
+      expect(followupRun.userTurnTranscriptRecorder?.message).toMatchObject({
+        __openclaw: {
+          mediaImageLayout: {
+            slots: [{ kind: "inline", factIndex: 1 }],
+            suppressedFactIndexes: [2],
+          },
+        },
+      });
+    },
+  );
+
   it("does not send a standalone reset notice for reply-producing /new turns", async () => {
     await runPrepared({
       ctx: {

--- a/src/auto-reply/reply/prompt-prelude.test.ts
+++ b/src/auto-reply/reply/prompt-prelude.test.ts
@@ -327,6 +327,7 @@ describe("buildReplyPromptEnvelope", () => {
     expect(envelope.prefixedCommandBody).toBe(body);
     expect(envelope.queuedBody).toBe(body);
     expect(envelope.transcriptCommandBody).toBe(body);
+    expect(envelope.inboundMediaIndexes).toEqual([]);
     expect(envelope.media).toEqual([
       {
         path: "/tmp/tlon.png",
@@ -336,6 +337,54 @@ describe("buildReplyPromptEnvelope", () => {
         transcribed: false,
         messageId: undefined,
       },
+    ]);
+  });
+
+  it("keeps sparse inbound positions separate from appended preprojected media", () => {
+    const sharedPath = "/tmp/shared.png";
+    const sessionCtx = finalizeInboundContext({
+      Body: "inspect these",
+      media: [
+        {},
+        { path: "/tmp/voice.ogg", contentType: "audio/ogg", transcribed: true },
+        { path: sharedPath, contentType: "image/png" },
+        { path: sharedPath, contentType: "image/png" },
+      ],
+    });
+    const params = {
+      ctx: sessionCtx,
+      sessionCtx,
+      baseBody: "inspect these",
+      hasUserBody: true,
+      inboundUserContext: "",
+      isBareSessionReset: false,
+      startupAction: "new" as const,
+      media: [{ path: "/tmp/preprojected.pdf", contentType: "application/pdf" }],
+    };
+    const first = buildReplyPromptEnvelope(params);
+    const rebuilt = buildReplyPromptEnvelope({
+      ...params,
+      ctx: { ...sessionCtx, media: [...(sessionCtx.media ?? []), { path: "/tmp/later.png" }] },
+      systemEventBlocks: ["context changed"],
+    });
+
+    expect(first.inboundMediaIndexes).toEqual([2, 3]);
+    expect(first.media?.map((fact) => fact.path)).toEqual([
+      sharedPath,
+      sharedPath,
+      "/tmp/preprojected.pdf",
+    ]);
+    expect(rebuilt.inboundMediaIndexes).toEqual([2, 3, 4]);
+    expect(first.prefixedCommandBody).toBe(
+      `[media attached: 2 files]\n[media attached 1/2: ${sharedPath} (image/png)]\n[media attached 2/2: ${sharedPath} (image/png)]\ninspect these`,
+    );
+    expect(first.queuedBody).toBe(first.prefixedCommandBody);
+    expect(first.transcriptCommandBody).toBe(first.prefixedCommandBody);
+    expect(sessionCtx.media?.map((fact) => fact.path)).toEqual([
+      undefined,
+      "/tmp/voice.ogg",
+      sharedPath,
+      sharedPath,
     ]);
   });
 

--- a/src/auto-reply/reply/prompt-prelude.ts
+++ b/src/auto-reply/reply/prompt-prelude.ts
@@ -35,6 +35,8 @@ function buildReplyPromptBodies(params: {
 }): {
   mediaNote?: string;
   media?: MediaFact[];
+  /** Original ctx.media positions; preprojected additions have no inbound index. */
+  inboundMediaIndexes: readonly number[];
   prefixedCommandBody: string;
   queuedBody: string;
   transcriptCommandBody: string;
@@ -61,6 +63,7 @@ function buildReplyPromptBodies(params: {
       : "";
   return {
     mediaNote,
+    inboundMediaIndexes: generatedMedia.mediaIndexes,
     ...(media.length > 0 ? { media } : {}),
     prefixedCommandBody: annotateInterSessionPromptText(
       prefixedCommandBodyRaw,


### PR DESCRIPTION
## What Problem This Solves

Replies with attachments repeat media-note preparation immediately before the agent run, even though admission has already prepared the prompt and attachment positions. This adds avoidable processing, especially for multiple images and admission rebuilds.

## Why This Change Was Made

Carry the existing inbound media positions with the prompt/media snapshot. Admission replaces that snapshot at the same initial, post-wait and post-system-event points, then destructures it once. Execution consumes those positions instead of rebuilding and discarding the full media note.

The indexes remain original inbound positions and exclude appended preprojected media. Duplicate paths, filtered transcribed audio and partial hydration retain positional identity. No await moves, authority changes, configuration, protocol, storage or dependency changes.

Production: **−7 lines**; tests: **+111 lines**. The old reconstruction and repeated admission destructuring are removed.

## User Impact

Less preparation in the measured attachment-reply paths, with unchanged prompts, media ordering and hydration suppression. This does not claim faster provider responses or uniformly lower Gateway latency.

## Evidence

- Six complete suites: 253 baseline tests and 256 candidate tests; all 29 selected normal checks passed. New cases cover sparse positions, preprojected additions, duplicate paths and the actual wait/interrupt admission path.
- Independent managed P0–P2 review found no actionable findings across two passes.
- Fixed baseline/candidate/candidate/baseline comparisons through actual runPreparedReply using the existing test harness: 912 complete calls, 59 retained raw graphs and complete decoded call/transcript/media snapshot parity. Independent data audit checked all outputs and arithmetic. Functions/accessors are opaque descriptors; this is not callable-authority proof, real media I/O or live-provider evidence.

All paired median changes are below. Negative means faster. Each median uses eight two-call batch means; first calls, warmups and maxima are retained separately.

| Scenario | Forward | Reverse |
|---|---:|---:|
| plain | -5.91% | -4.83% |
| images-1 | -13.09% | -20.31% |
| images-8 | -23.32% | -14.25% |
| images-32 | -31.99% | -19.04% |
| sparse | -8.05% | -14.85% |
| duplicate-path-partial | -4.33% | -9.38% |
| audio-before-image | +1.14% | +6.32% |
| preprojected | +0.80% | -9.06% |
| described-image | -15.76% | -10.29% |
| all-transcribed | -13.73% | +7.04% |
| system-event-rebuild | -22.20% | -31.83% |
| interrupt-rebuild | -16.19% | -2.48% |

Twenty of 24 medians improve. One image saves 28.667/46.104 microseconds; eight images save 98.062/50.552 microseconds. All four adverse medians remain: audio-before-image in both orders, forward preprojected media and reverse all-transcribed audio (maximum 8.511 microseconds). Across all recorded first/median/batch-maximum comparisons, 21/72 regress; additional individual maxima and index-aligned observations are retained too. One fixed cohort does not establish stable tails.

Whole-process wall improves only 0.671%/0.166% and includes Vitest/import/setup/capture. Four of ten resource comparisons regress: forward user CPU +0.0371%, kernel peak RSS +0.0199%, sampled tree RSS +1.972%; reverse kernel peak RSS +0.5333%. No general memory improvement is claimed.

The initial benchmark stopped after 22 calls because it incorrectly required identical V8-serialized bytes for equal snapshots. Both differing captures independently decoded to equal values; [Node documents that equal values can serialize differently](https://nodejs.org/api/v8.html#serialization-api). The corrected cohort snapshots once and compares complete decoded values, retaining raw hashes for integrity. The incomplete initial run and all its timings remain separate and unpooled. Corpus, timed operation, limits and production code were unchanged.

Initial hosted CI stopped before tests when an unchanged Matrix native dependency download returned HTTP 504; its vendor error handler then threw a secondary ReferenceError. The failed jobs are being retried on the unchanged commit. The vendor error-path cleanup is a separate follow-up; no dependency or security-guard change is included here.
