### PR TITLE
refactor(gateway): dedupe node event text compaction

### DIFF
--- a/src/gateway/server-node-events.test.ts
+++ b/src/gateway/server-node-events.test.ts
@@ -1509,6 +1509,22 @@ describe("notifications changed events", () => {
     });
   });
 
+  it("compacts notification text without splitting surrogate pairs", async () => {
+    const ctx = buildCtx();
+    await handleNodeEvent(ctx, "node-n1", {
+      event: "notifications.changed",
+      payloadJSON: JSON.stringify({
+        change: "posted",
+        key: "notif-long",
+        title: ` \n${"A".repeat(117)}   🫠 tail `,
+      }),
+    });
+
+    expect(mockCallArg(enqueueSystemEventMock)).toBe(
+      `Notification posted (node=node-n1 key=notif-long): ${"A".repeat(117)} …`,
+    );
+  });
+
   it("enqueues notifications.changed removed events", async () => {
     const ctx = buildCtx();
     await handleNodeEvent(ctx, "node-n2", {

--- a/src/gateway/server-node-events.ts
+++ b/src/gateway/server-node-events.ts
@@ -406,27 +406,12 @@ function pruneBoundedTimestampMap(
   pruneMapToMaxSize(map, params.maxEntries);
 }
 
-function compactExecEventOutput(raw: string) {
+function compactNodeEventText(raw: string, maxChars: number) {
   const normalized = raw.replace(/\s+/g, " ").trim();
-  if (!normalized) {
-    return "";
-  }
-  if (normalized.length <= MAX_EXEC_EVENT_OUTPUT_CHARS) {
+  if (normalized.length <= maxChars) {
     return normalized;
   }
-  const safe = Math.max(1, MAX_EXEC_EVENT_OUTPUT_CHARS - 1);
-  return `${sliceUtf16Safe(normalized, 0, safe)}…`;
-}
-
-function compactNotificationEventText(raw: string) {
-  const normalized = raw.replace(/\s+/g, " ").trim();
-  if (!normalized) {
-    return "";
-  }
-  if (normalized.length <= MAX_NOTIFICATION_EVENT_TEXT_CHARS) {
-    return normalized;
-  }
-  const safe = Math.max(1, MAX_NOTIFICATION_EVENT_TEXT_CHARS - 1);
+  const safe = Math.max(1, maxChars - 1);
   return `${sliceUtf16Safe(normalized, 0, safe)}…`;
 }
 
@@ -1000,8 +985,14 @@ export const handleNodeEvent = async (
       }
       const packageNameRaw = normalizeOptionalString(obj.packageName);
       const packageName = packageNameRaw ?? null;
-      const title = compactNotificationEventText(normalizeOptionalString(obj.title) ?? "");
-      const text = compactNotificationEventText(normalizeOptionalString(obj.text) ?? "");
+      const title = compactNodeEventText(
+        normalizeOptionalString(obj.title) ?? "",
+        MAX_NOTIFICATION_EVENT_TEXT_CHARS,
+      );
+      const text = compactNodeEventText(
+        normalizeOptionalString(obj.text) ?? "",
+        MAX_NOTIFICATION_EVENT_TEXT_CHARS,
+      );
 
       let summary = `Notification ${change} (node=${nodeId} key=${key}`;
       if (packageName) {
@@ -1123,7 +1114,7 @@ export const handleNodeEvent = async (
         }
       } else if (evt.event === "exec.finished") {
         const exitLabel = timedOut ? "timeout" : `code ${exitCode ?? "?"}`;
-        const compactOutput = compactExecEventOutput(output);
+        const compactOutput = compactNodeEventText(output, MAX_EXEC_EVENT_OUTPUT_CHARS);
         const shouldNotify = timedOut || exitCode !== 0 || compactOutput.length > 0;
         if (!shouldNotify) {
           return undefined;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainer-authored branch; edits by maintainers are allowed.

</details>

## What Problem This Solves

Gateway node events maintained two copies of the same whitespace normalization and UTF-16-safe truncation behavior. Keeping notification and exec compaction separate made their shared invariant easier to drift while adding maintenance cost.

## Why This Change Was Made

This consolidates both paths into one private compactor while keeping the notification and exec limits caller-owned at 120 and 180 characters. It adds one notification-boundary test for whitespace collapse, limit wiring, ellipsis, and surrogate safety; no protocol or public API changes.

## User Impact

No intended user-visible behavior change. Notification summaries and exec completion output retain their existing formatting and bounds.

## Evidence

- `node scripts/run-vitest.mjs src/gateway/server-node-events.test.ts` — 83 tests passed.
- `node scripts/check-changed.mjs --dry-run -- src/gateway/server-node-events.ts src/gateway/server-node-events.test.ts` — selected core and core-test lanes.
- `node scripts/check-changed.mjs -- ...` — all checks through the core typecheck passed; local typecheck then stopped at the expected external compiler-symlink checkout guard. Exact-head CI/Testbox will provide physical-checkout type proof.
- `git diff --check` — clean.
- Scoped autoreview — clean, no P0/P1 findings.
- Production delta: 12 additions, 21 deletions (net -9).
