### PR TITLE
fix(voice-call): retain SDK 2026.9.2 realtime compatibility

### DIFF
--- a/docs/plugins/sdk-migration.md
+++ b/docs/plugins/sdk-migration.md
@@ -102,6 +102,13 @@ an available newer helper. Remove these fallbacks only when the declared plugin
 API floor no longer includes 2026.9.2; test built plugin imports against that
 minimum host before changing unconditional SDK imports.
 
+Voice Call also retains its declared 2026.9.2 host support. Its realtime upgrade
+handler keeps the two HTTP rejection responses local because that SDK has no
+`websocket-runtime` subpath. Rejection bytes flush before the socket is destroyed,
+and socket errors retain their normal cleanup behavior. Remove this local
+transport compatibility code only when the declared plugin API floor excludes
+2026.9.2.
+
 Retained compatibility entrypoints keep their shipped caller names:
 `inbound-envelope` uses `resolveStorePath`, `provider-catalog-runtime` exports
 `resolvePluginProviders`, and `agent-runtime`'s

--- a/extensions/voice-call/src/webhook/realtime-handler.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.ts
@@ -29,7 +29,6 @@ import {
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { sliceUtf16Safe, truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
 import { normalizeWebhookPath } from "openclaw/plugin-sdk/webhook-ingress";
-import { rejectWebSocketUpgrade } from "openclaw/plugin-sdk/websocket-runtime";
 import { resolveVoiceCallPublicPathPrefix, type VoiceCallRealtimeConfig } from "../config.js";
 import type { CallManager } from "../manager.js";
 import { REALTIME_VOICE_END_CALL_TOOL_NAME } from "../realtime-call-control.js";
@@ -365,6 +364,19 @@ function appendRecentTalkEventMetadata(
   call.metadata = metadata;
 }
 
+// The declared 2026.9.2 host has no WebSocket SDK subpath. Keep these two
+// rejection statuses local until that host leaves the supported plugin API range.
+function rejectRealtimeUpgrade(socket: Duplex, status: 401 | 503): void {
+  const reason = status === 401 ? "Unauthorized" : "Service Unavailable";
+  try {
+    // Reused HTTP sockets can buffer writes; destroy only after the response flushes.
+    socket.end(`HTTP/1.1 ${status} ${reason}\r\nConnection: close\r\n\r\n`, () => socket.destroy());
+  } catch (error) {
+    socket.destroy();
+    throw error;
+  }
+}
+
 export class RealtimeCallHandler {
   private readonly toolHandlers = new Map<string, ToolHandlerFn>();
   private readonly pendingStreamTokens = new Map<string, PendingStreamToken>();
@@ -439,7 +451,7 @@ export class RealtimeCallHandler {
     // HTTP no longer owns socket errors after handing off an upgrade.
     socket.once("error", () => socket.destroy());
     if (this.closing) {
-      rejectWebSocketUpgrade(socket, { status: 503 });
+      rejectRealtimeUpgrade(socket, 503);
       return;
     }
 
@@ -447,7 +459,7 @@ export class RealtimeCallHandler {
     const token = url.pathname.split("/").pop() ?? null;
     const callerMeta = token ? this.consumeStreamToken(token) : null;
     if (!callerMeta) {
-      rejectWebSocketUpgrade(socket, { status: 401 });
+      rejectRealtimeUpgrade(socket, 401);
       return;
     }
 

--- a/extensions/voice-call/src/webhook/realtime-handler.upgrade.test.ts
+++ b/extensions/voice-call/src/webhook/realtime-handler.upgrade.test.ts
@@ -1,0 +1,120 @@
+import { once } from "node:events";
+import { IncomingMessage } from "node:http";
+import { Socket } from "node:net";
+import { Duplex } from "node:stream";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { describe, expect, it, vi } from "vitest";
+import { VoiceCallConfigSchema } from "../config.js";
+import { CallManager } from "../manager.js";
+import { RealtimeCallHandler } from "./realtime-handler.js";
+
+// The published minimum host has no WebSocket SDK subpath at all.
+vi.mock("openclaw/plugin-sdk/websocket-runtime", () => {
+  throw new Error("websocket-runtime is not exported by OpenClaw 2026.9.2");
+});
+
+function createHandler() {
+  const config = VoiceCallConfigSchema.parse({ realtime: { enabled: true } });
+  const resolveRegistration = vi.fn((): never => {
+    throw new Error("Rejected upgrades must not acquire a provider");
+  });
+  const handler = new RealtimeCallHandler(
+    config.realtime,
+    new CallManager(config),
+    resolveRegistration,
+    "/voice/webhook",
+    { connect() {}, disconnect() {}, retire() {} },
+  );
+  return { handler, resolveRegistration };
+}
+
+function upgradeRequest() {
+  const transport = new Socket();
+  const request = new IncomingMessage(transport);
+  request.url = "/voice/stream/realtime/invalid-token";
+  return { request, transport };
+}
+
+describe("realtime upgrade rejection on the minimum SDK", () => {
+  it.each([
+    [401, "Unauthorized"],
+    [503, "Service Unavailable"],
+  ] as const)(
+    "flushes HTTP %s before closing without acquiring a provider",
+    async (status, reason) => {
+      const { handler, resolveRegistration } = createHandler();
+      const { request, transport } = upgradeRequest();
+      const shutdown = createDeferred<void>();
+      const closing = status === 503 ? handler.close(shutdown.promise) : undefined;
+      let flush = () => {};
+      let response = "";
+      const socket = new Duplex({
+        read() {},
+        write(chunk: Buffer, _encoding, callback) {
+          response += chunk.toString();
+          flush = callback;
+        },
+      });
+      const closed = once(socket, "close");
+      try {
+        handler.handleWebSocketUpgrade(request, socket, Buffer.alloc(0));
+        expect(response).toBe(`HTTP/1.1 ${status} ${reason}\r\nConnection: close\r\n\r\n`);
+        expect(socket.destroyed).toBe(false);
+        expect(resolveRegistration).not.toHaveBeenCalled();
+        flush();
+        await closed;
+        expect(socket.destroyed).toBe(true);
+      } finally {
+        flush();
+        socket.destroy();
+        transport.destroy();
+        shutdown.resolve();
+        await closing;
+        await handler.close();
+      }
+    },
+  );
+
+  it("destroys the rejected socket and preserves a synchronous write failure", async () => {
+    const { handler, resolveRegistration } = createHandler();
+    const { request, transport } = upgradeRequest();
+    const socket = new Duplex({ read() {} });
+    const failure = new Error("synthetic socket write failure");
+    vi.spyOn(socket, "end").mockImplementation(() => {
+      throw failure;
+    });
+    try {
+      expect(() => handler.handleWebSocketUpgrade(request, socket, Buffer.alloc(0))).toThrow(
+        failure,
+      );
+      expect(socket.destroyed).toBe(true);
+      expect(resolveRegistration).not.toHaveBeenCalled();
+    } finally {
+      socket.destroy();
+      transport.destroy();
+      await handler.close();
+    }
+  });
+
+  it("owns raw socket errors while rejection bytes are buffered", async () => {
+    const { handler } = createHandler();
+    const { request, transport } = upgradeRequest();
+    let flush = () => {};
+    const socket = new Duplex({
+      read() {},
+      write(_chunk, _encoding, callback) {
+        flush = callback;
+      },
+    });
+    try {
+      handler.handleWebSocketUpgrade(request, socket, Buffer.alloc(0));
+      expect(() => socket.emit("error", new Error("synthetic raw socket failure"))).not.toThrow();
+      expect(socket.destroyed).toBe(true);
+    } finally {
+      flush();
+      socket.destroy();
+      transport.destroy();
+      await handler.close();
+    }
+  });
+});


### PR DESCRIPTION
Voice Call declares support for OpenClaw 2026.9.2, but its realtime handler imported the newer `websocket-runtime` SDK subpath. That subpath is absent from the published minimum host, so loading the realtime handler failed before a call could start.

Keep the two rejected-upgrade responses in the plugin until its supported SDK range excludes 2026.9.2. This preserves the current HTTP 401/503 bytes, flushes buffered responses before destroying the socket, and retains synchronous write-error and raw-socket cleanup behavior. No SDK floor, package version, configuration, or admission-policy changes.

Validation: the maintained plugin package build reproduces the missing-subpath failure against the integrity-verified official 2026.9.2 package, then loads the complete plugin/runtime/realtime-handler graph after the repair. Native Duplex probes verify response ordering and cleanup without acquiring a provider; 24 focused upgrade/lifecycle tests pass. Canonical changed checks pass, including production/test types, typed lint, dead-export checks, and runtime cycles. No real carrier or model service was used.

A separate minimum-host issue remains in Codex: its full package entry fails on the newer `agent-harness-registration` subpath introduced by #139911 (071f606eae77). This PR does not change that registration contract or claim Codex compatibility is fixed.
