### PR TITLE
fix(gateway): preserve length in chat completion responses

### DIFF
--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -224,7 +224,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
 
       const continueAgent = createDeferred();
       agentCommandMock.mockClear();
-      agentCommandMock.mockImplementationOnce(async (opts: unknown) => {
+      agentCommandMock.mockImplementationOnce((async (opts: unknown) => {
         if (stream) {
           const runId = (opts as { runId: string }).runId;
           emitAgentEvent({ runId, stream: "assistant", data: { delta: partialText } });
@@ -232,7 +232,7 @@ describe("OpenAI-compatible HTTP API (e2e)", () => {
           await continueAgent.promise;
         }
         return recordAgentRunTerminalOutcome(resolved.result, "completed");
-      });
+      }) as never);
 
       try {
         const response = await postChatCompletions(enabledPort, {

--- a/src/gateway/openai-http.test.ts
+++ b/src/gateway/openai-http.test.ts
@@ -12,12 +12,18 @@ import {
 } from "../agents/agent-run-terminal-outcome.js";
 import { createClientToolNameConflictError } from "../agents/agent-tool-definition-adapter.js";
 import { createAgentCommandLifecycle } from "../agents/command/lifecycle.js";
+import { resolveEmbeddedRunTerminal } from "../agents/embedded-agent-runner/run/terminal-resolution.js";
+import { makeTerminalInput } from "../agents/embedded-agent-runner/run/terminal-resolution.test-support.js";
 import {
   createStubSessionHarness,
   emitAssistantTextDelta,
 } from "../agents/embedded-agent-subscribe.e2e-harness.js";
 import { subscribeEmbeddedAgentSession } from "../agents/embedded-agent-subscribe.js";
 import { FailoverError } from "../agents/failover-error.js";
+import {
+  buildEmbeddedRunnerAssistant,
+  makeEmbeddedRunnerAttempt,
+} from "../agents/test-helpers/embedded-agent-runner-e2e-fixtures.js";
 import { HISTORY_CONTEXT_MARKER } from "../auto-reply/reply/history.js";
 import { CURRENT_MESSAGE_MARKER } from "../auto-reply/reply/mentions.js";
 import { recordAgentRunTerminalOutcome } from "../channels/turn/agent-run-terminal-outcome.js";
@@ -185,6 +191,101 @@ function firstAgentCommandOptions() {
 }
 
 describe("OpenAI-compatible HTTP API (e2e)", () => {
+  it.each([
+    { stream: false, includeUsage: false },
+    { stream: true, includeUsage: false },
+    { stream: true, includeUsage: true },
+  ])(
+    "preserves the output-budget finish reason (stream=$stream, usage=$includeUsage)",
+    async ({ stream, includeUsage }) => {
+      const partialText = "Here is the first half of the answer";
+      const assistant = buildEmbeddedRunnerAssistant({
+        stopReason: "length",
+        content: [{ type: "text", text: partialText }],
+      });
+      const resolved = await resolveEmbeddedRunTerminal(
+        makeTerminalInput({
+          attempt: makeEmbeddedRunnerAttempt({
+            assistantTexts: [partialText],
+            lastAssistant: assistant,
+            currentAttemptAssistant: assistant,
+            currentAttemptReplayMetadata: { hadPotentialSideEffects: false, replaySafe: true },
+          }),
+          attemptAssistant: assistant,
+          payloadsWithToolMedia: [{ text: partialText }],
+        }),
+      );
+      expect(resolved.action).toBe("complete");
+      if (resolved.action !== "complete") {
+        throw new Error("expected a deliverable partial response");
+      }
+      expect(resolved.result.meta.stopReason).toBe("length");
+      expect(resolved.result.meta.error).toBeUndefined();
+
+      const continueAgent = createDeferred();
+      agentCommandMock.mockClear();
+      agentCommandMock.mockImplementationOnce(async (opts: unknown) => {
+        if (stream) {
+          const runId = (opts as { runId: string }).runId;
+          emitAgentEvent({ runId, stream: "assistant", data: { delta: partialText } });
+          emitAgentEvent({ runId, stream: "lifecycle", data: { phase: "end" } });
+          await continueAgent.promise;
+        }
+        return recordAgentRunTerminalOutcome(resolved.result, "completed");
+      });
+
+      try {
+        const response = await postChatCompletions(enabledPort, {
+          stream,
+          ...(includeUsage ? { stream_options: { include_usage: true } } : {}),
+          model: "openclaw",
+          messages: [{ role: "user", content: "Explain the result." }],
+        });
+        expect(response.status).toBe(200);
+        if (!stream) {
+          const completion = (await response.json()) as OpenAI.ChatCompletion;
+          expect(completion.choices[0]?.message.content).toContain(partialText);
+          expect(completion.choices[0]?.finish_reason).toBe("length");
+          return;
+        }
+
+        if (!response.body) {
+          throw new Error("expected a streaming response body");
+        }
+        const reader = response.body.getReader();
+        const decoder = new TextDecoder();
+        let wire = "";
+        while (!wire.includes(partialText)) {
+          const { done, value } = await reader.read();
+          expect(done).toBe(false);
+          wire += decoder.decode(value, { stream: true });
+        }
+        expect(wire).not.toContain("[DONE]");
+        continueAgent.resolve();
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) {
+            wire += decoder.decode();
+            break;
+          }
+          wire += decoder.decode(value, { stream: true });
+        }
+        const data = parseSseDataLines(wire);
+        const chunks = data
+          .filter((entry) => entry !== "[DONE]")
+          .map((entry) => JSON.parse(entry) as OpenAI.ChatCompletionChunk);
+        const choices = chunks.flatMap((chunk) => chunk.choices);
+        expect(choices.map((choice) => choice.delta.content ?? "").join("")).toContain(partialText);
+        expect(choices.map((choice) => choice.finish_reason).filter(Boolean)).toEqual(["length"]);
+        expect(chunks.filter((chunk) => chunk.usage)).toHaveLength(includeUsage ? 1 : 0);
+        expect(data.filter((entry) => entry === "[DONE]")).toHaveLength(1);
+        expect(data.at(-1)).toBe("[DONE]");
+      } finally {
+        continueAgent.resolve();
+      }
+    },
+  );
+
   it.each(
     (
       [

--- a/src/gateway/openai-http.ts
+++ b/src/gateway/openai-http.ts
@@ -308,7 +308,7 @@ function writeAssistantContentChunk(
 
 function writeAssistantFinishChunk(
   res: ServerResponse,
-  params: ChatCompletionStreamIdentity & { finishReason: "stop" | "tool_calls" },
+  params: ChatCompletionStreamIdentity & { finishReason: "stop" | "length" | "tool_calls" },
 ) {
   writeChatCompletionChunk(res, params, {
     choices: [
@@ -1099,7 +1099,7 @@ export async function handleOpenAiHttpRequest(
           {
             index: 0,
             message: { role: "assistant", content },
-            finish_reason: "stop",
+            finish_reason: stopReason === "length" ? "length" : "stop",
           },
         ],
         usage,
@@ -1132,6 +1132,7 @@ export async function handleOpenAiHttpRequest(
   let assistantText: AssistantTextSnapshot = { text: "" };
   let pendingAssistantText: AssistantTextSnapshot | undefined;
   let finalResultText: string | undefined;
+  let finalFinishReason: "stop" | "length" = "stop";
   let finalToolCalls: ReturnType<typeof resolveStopReasonAndPendingToolCalls>["pendingToolCalls"];
   let finalUsage: OpenAiChatCompletionsUsage | undefined;
   let finalizeRequested = false;
@@ -1193,7 +1194,7 @@ export async function handleOpenAiHttpRequest(
       if (!wroteStopChunk) {
         writeAssistantFinishChunk(res, {
           ...streamIdentity,
-          finishReason: finalToolCalls ? "tool_calls" : "stop",
+          finishReason: finalToolCalls ? "tool_calls" : finalFinishReason,
         });
         wroteStopChunk = true;
       }
@@ -1351,6 +1352,7 @@ export async function handleOpenAiHttpRequest(
       }
 
       finalResultText = resolveAssistantResultText(result);
+      finalFinishReason = stopReason === "length" ? "length" : "stop";
       finalToolCalls =
         stopReason === "tool_calls" && pendingToolCalls?.length ? pendingToolCalls : undefined;
       requestFinalize();


### PR DESCRIPTION
Closes #141264.

A successful partial answer can reach its output budget while the public Chat Completions endpoint reports a natural `stop`. Preserve the agent's authoritative `length` reason in JSON and streaming responses. Streaming keeps that reason until the final result and usage settle; completed tool calls retain precedence.

The production change remains five added and three removed lines. It changes no output budget, retry/fallback policy, authentication, transcript ownership, provider parser, custom header, Responses API or published SDK surface.

Fresh native proof uses a real Gateway, normal configured agent, production HTTP transport and a controlled local OpenAI-compatible provider. No command result is injected, no test-trust runtime flag is used, and no vendor-model token exhaustion is claimed. The provider receives the actual cap of 4 and supplies controlled partial text and usage.

| Public request | Pinned main | Candidate | Preserved behavior |
| --- | --- | --- | --- |
| JSON | `stop` | `length` | HTTP 200, partial text and existing truncation notice |
| Stream without usage | `stop` | `length` | Partial text, one terminal choice, one final `[DONE]`, no usage chunk |
| Stream with usage | `stop` | `length` | Same text/termination, one trailing usage result |

Each length request makes one provider call. Eighteen additional paired controls preserve natural stop, completed client-tool calls, incomplete length-ended tool payload rejection, provider failure/refusal, empty output, context overflow, timeout, client disconnect and a successful request after disconnect. Both versions shut down their owned Gateway and provider cleanly. A fresh independent 20-case public batch also passes its behavioral checks, including different Unicode text, both usage modes, tools, errors, timeout and disconnect. Its four source/delivery joins are tracked separately; completed-tool precedence and unchanged policy/API surfaces are checked against their source owners.

- Baseline: `896fa451da77aa1c72fabe67283e99169efe96cc`.
- Candidate: `a00a19d9dc1e7b2f698e79a653325b9163de0e47`.
- Three focused regressions fail on main for `stop` versus `length`.
- All 221 tests in six owner/sibling suites pass, including all 129 HTTP tests.
- Native formatting, lint, size guards and normal runtime build pass. Fresh complete-source review found no actionable issue.

The existing exact-head CI run has one unrelated Git stdout-overflow assertion failure and its aggregate. The exact composed merge changes only these two HTTP files; the failing constant-blob test and its Git/process formatter dependency path do not consume this response mapping. Isolated historical-main and current-main controls pass, so the historical full-shard failure was not reproduced by those narrower probes. The original failure and its limits remain recorded; this is not a claim that all remote checks are green. A related formatter fix, #141353, is already on main. Any landing uses the guarded standing-approval path with exact run/job evidence.

Earlier contributor evidence remains available: [runtime receipt](https://github.com/user-attachments/files/31923655/http-length-real-agent-proof-public.txt) and [executed Windows script](https://github.com/user-attachments/files/31923657/http-length-real-agent-proof.mjs.txt). Its initial text assertion rejected the legitimate JSON notice, and its separate compiler attempt was refused by a provenance guard. Those failures were preserved; the new native build does not bypass that guard or reuse the script's test-trust flags.

Thanks @ooiuuii for the focused repair and regression coverage.
