### PR TITLE
refactor(native): share Apple discovery bookkeeping

### DIFF
--- a/apps/ios/Sources/Gateway/GatewayDiscoveryModel.swift
+++ b/apps/ios/Sources/Gateway/GatewayDiscoveryModel.swift
@@ -46,9 +46,8 @@ final class GatewayDiscoveryModel {
     var statusText: String = GatewayDiscoveryStatusText.idle
     private(set) var debugLog: [DebugLogEntry] = []
 
-    private var browsers: [String: NWBrowser] = [:]
+    private let browserSession = GatewayDiscoveryBrowserSession()
     private var gatewaysByDomain: [String: [DiscoveredGateway]] = [:]
-    private var statesByDomain: [String: NWBrowser.State] = [:]
     private var debugLoggingEnabled = false
     private var lastStableIDs = Set<GatewayStableIdentifier.Key>()
 
@@ -64,63 +63,52 @@ final class GatewayDiscoveryModel {
     }
 
     func start() {
-        if !self.browsers.isEmpty { return }
+        if self.browserSession.isRunning { return }
         self.appendDebugLog("start()")
 
-        for domain in OpenClawBonjour.gatewayServiceDomains {
-            let browser = GatewayDiscoveryBrowserSupport.makeBrowser(
-                serviceType: OpenClawBonjour.gatewayServiceType,
-                domain: domain,
-                queueLabelPrefix: "ai.openclawfoundation.app.gateway-discovery",
-                onState: { [weak self] state in
-                    guard let self else { return }
-                    self.statesByDomain[domain] = state
-                    self.updateStatusText()
-                    self.appendDebugLog("state[\(domain)]: \(Self.prettyState(state))")
-                },
-                onResults: { [weak self] results in
-                    guard let self else { return }
-                    self.gatewaysByDomain[domain] = results.compactMap { result -> DiscoveredGateway? in
-                        switch result.endpoint {
-                        case let .service(name, _, _, _):
-                            let decodedName = BonjourEscapes.decode(name)
-                            let txt = result.endpoint.txtRecord?.dictionary ?? [:]
-                            let advertisedName = txt["displayName"]
-                            let prettyAdvertised = advertisedName
-                                .map(Self.prettifyInstanceName)
-                                .flatMap { $0.isEmpty ? nil : $0 }
-                            let prettyName = prettyAdvertised ?? Self.prettifyInstanceName(decodedName)
-                            return DiscoveredGateway(
-                                name: prettyName,
-                                endpoint: result.endpoint,
-                                stableID: GatewayEndpointID.stableID(result.endpoint),
-                                debugID: GatewayEndpointID.prettyDescription(result.endpoint),
-                                lanHost: Self.txtValue(txt, key: "lanHost"),
-                                tailnetDns: Self.txtValue(txt, key: "tailnetDns"),
-                                gatewayPort: Self.txtIntValue(txt, key: "gatewayPort"),
-                                tlsEnabled: Self.txtBoolValue(txt, key: "gatewayTls"),
-                                tlsFingerprintSha256: Self.txtValue(txt, key: "gatewayTlsSha256"),
-                                cliPath: Self.txtValue(txt, key: "cliPath"))
-                        default:
-                            return nil
-                        }
+        self.browserSession.start(
+            queueLabelPrefix: "ai.openclawfoundation.app.gateway-discovery",
+            onState: { [weak self] domain, state, status in
+                guard let self else { return }
+                self.statusText = status
+                self.appendDebugLog("state[\(domain)]: \(Self.prettyState(state))")
+            },
+            onResults: { [weak self] domain, results in
+                guard let self else { return }
+                self.gatewaysByDomain[domain] = results.compactMap { result -> DiscoveredGateway? in
+                    switch result.endpoint {
+                    case let .service(name, _, _, _):
+                        let decodedName = BonjourEscapes.decode(name)
+                        let txt = result.endpoint.txtRecord?.dictionary ?? [:]
+                        let advertisedName = txt["displayName"]
+                        let prettyAdvertised = advertisedName
+                            .map(GatewayDiscoveryText.prettifyInstanceName)
+                            .flatMap { $0.isEmpty ? nil : $0 }
+                        let prettyName = prettyAdvertised ?? GatewayDiscoveryText.prettifyInstanceName(decodedName)
+                        return DiscoveredGateway(
+                            name: prettyName,
+                            endpoint: result.endpoint,
+                            stableID: GatewayEndpointID.stableID(result.endpoint),
+                            debugID: GatewayEndpointID.prettyDescription(result.endpoint),
+                            lanHost: GatewayDiscoveryText.txtValue(txt, key: "lanHost"),
+                            tailnetDns: GatewayDiscoveryText.txtValue(txt, key: "tailnetDns"),
+                            gatewayPort: GatewayDiscoveryText.txtValue(txt, key: "gatewayPort").flatMap { Int($0) },
+                            tlsEnabled: GatewayDiscoveryText.txtBoolValue(txt, key: "gatewayTls"),
+                            tlsFingerprintSha256: GatewayDiscoveryText.txtValue(txt, key: "gatewayTlsSha256"),
+                            cliPath: GatewayDiscoveryText.txtValue(txt, key: "cliPath"))
+                    default:
+                        return nil
                     }
-                    .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
-                    self.recomputeGateways()
-                })
-
-            self.browsers[domain] = browser
-        }
+                }
+                .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+                self.recomputeGateways()
+            })
     }
 
     func stop() {
         self.appendDebugLog("stop()")
-        for browser in self.browsers.values {
-            browser.cancel()
-        }
-        self.browsers = [:]
+        self.browserSession.stop()
         self.gatewaysByDomain = [:]
-        self.statesByDomain = [:]
         self.gateways = []
         self.statusText = GatewayDiscoveryStatusText.stopped
     }
@@ -138,12 +126,6 @@ final class GatewayDiscoveryModel {
         }
         self.lastStableIDs = nextIDs
         self.gateways = next
-    }
-
-    private func updateStatusText() {
-        self.statusText = GatewayDiscoveryStatusText.make(
-            states: Array(self.statesByDomain.values),
-            hasBrowsers: !self.browsers.isEmpty)
     }
 
     private static func prettyState(_ state: NWBrowser.State) -> String {
@@ -169,27 +151,5 @@ final class GatewayDiscoveryModel {
         if self.debugLog.count > 200 {
             self.debugLog.removeFirst(self.debugLog.count - 200)
         }
-    }
-
-    private static func prettifyInstanceName(_ decodedName: String) -> String {
-        let normalized = decodedName.split(whereSeparator: \.isWhitespace).joined(separator: " ")
-        let stripped = normalized.replacingOccurrences(of: " (OpenClaw)", with: "")
-            .replacingOccurrences(of: #"\s+\(\d+\)$"#, with: "", options: .regularExpression)
-        return stripped.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private static func txtValue(_ dict: [String: String], key: String) -> String? {
-        let raw = dict[key]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return raw.isEmpty ? nil : raw
-    }
-
-    private static func txtIntValue(_ dict: [String: String], key: String) -> Int? {
-        guard let raw = self.txtValue(dict, key: key) else { return nil }
-        return Int(raw)
-    }
-
-    private static func txtBoolValue(_ dict: [String: String], key: String) -> Bool {
-        guard let raw = self.txtValue(dict, key: key)?.lowercased() else { return false }
-        return raw == "1" || raw == "true" || raw == "yes"
     }
 }

--- a/apps/macos/Sources/OpenClawDiscovery/GatewayDiscoveryModel.swift
+++ b/apps/macos/Sources/OpenClawDiscovery/GatewayDiscoveryModel.swift
@@ -71,10 +71,9 @@ public final class GatewayDiscoveryModel {
     public var gateways: [DiscoveredGateway] = []
     public var statusText: String = GatewayDiscoveryStatusText.idle
 
-    private var browsers: [String: NWBrowser] = [:]
+    private let browserSession = GatewayDiscoveryBrowserSession()
     private var resultsByDomain: [String: Set<NWBrowser.Result>] = [:]
     private var gatewaysByDomain: [String: [DiscoveredGateway]] = [:]
-    private var statesByDomain: [String: NWBrowser.State] = [:]
     private var localIdentity: LocalIdentity
     @ObservationIgnored private var localIdentityTask: Task<Void, Never>?
     private let filterLocalGateways: Bool
@@ -100,28 +99,21 @@ public final class GatewayDiscoveryModel {
     }
 
     public func start() {
-        if !self.browsers.isEmpty { return }
+        if self.browserSession.isRunning { return }
         // Host resolution belongs to active discovery, not discarded SwiftUI models.
         self.refreshLocalIdentity()
 
-        for domain in OpenClawBonjour.gatewayServiceDomains {
-            let browser = GatewayDiscoveryBrowserSupport.makeBrowser(
-                serviceType: OpenClawBonjour.gatewayServiceType,
-                domain: domain,
-                queueLabelPrefix: "ai.openclaw.macos.gateway-discovery",
-                onState: { [weak self] state in
-                    guard let self else { return }
-                    self.statesByDomain[domain] = state
-                    self.updateStatusText()
-                },
-                onResults: { [weak self] results in
-                    guard let self else { return }
-                    self.resultsByDomain[domain] = results
-                    self.updateGateways(for: domain)
-                    self.recomputeGateways()
-                })
-            self.browsers[domain] = browser
-        }
+        self.browserSession.start(
+            queueLabelPrefix: "ai.openclaw.macos.gateway-discovery",
+            onState: { [weak self] _, _, status in
+                self?.statusText = status
+            },
+            onResults: { [weak self] domain, results in
+                guard let self else { return }
+                self.resultsByDomain[domain] = results
+                self.updateGateways(for: domain)
+                self.recomputeGateways()
+            })
 
         self.scheduleWideAreaFallback()
         self.scheduleTailscaleServeFallback()
@@ -160,13 +152,9 @@ public final class GatewayDiscoveryModel {
     public func stop() {
         self.localIdentityTask?.cancel()
         self.localIdentityTask = nil
-        for browser in self.browsers.values {
-            browser.cancel()
-        }
-        self.browsers = [:]
+        self.browserSession.stop()
         self.resultsByDomain = [:]
         self.gatewaysByDomain = [:]
-        self.statesByDomain = [:]
         self.resolvedServiceByID = [:]
         self.pendingServiceResolvers.values.forEach { $0.cancel() }
         self.pendingServiceResolvers = [:]
@@ -268,7 +256,7 @@ public final class GatewayDiscoveryModel {
                 uniquingKeysWith: { _, new in new })
 
             let advertisedName = txt["displayName"]
-                .map(Self.prettifyInstanceName)
+                .map(GatewayDiscoveryText.prettifyInstanceName)
                 .flatMap { $0.isEmpty ? nil : $0 }
             let prettyName =
                 advertisedName ?? Self.prettifyServiceName(decodedName)
@@ -439,12 +427,6 @@ public final class GatewayDiscoveryModel {
         }
     }
 
-    private func updateStatusText() {
-        self.statusText = GatewayDiscoveryStatusText.make(
-            states: Array(self.statesByDomain.values),
-            hasBrowsers: !self.browsers.isEmpty)
-    }
-
     private static func txtDictionary(from result: NWBrowser.Result) -> [String: String] {
         var merged: [String: String] = [:]
 
@@ -470,29 +452,20 @@ public final class GatewayDiscoveryModel {
     }
 
     public static func parseGatewayTXT(_ txt: [String: String]) -> GatewayTXT {
-        func nonEmptyString(_ key: String) -> String? {
-            guard let value = txt[key]?.trimmingCharacters(in: .whitespacesAndNewlines) else { return nil }
-            return value.isEmpty ? nil : value
-        }
-
         func positiveInteger(_ key: String) -> Int? {
-            guard let value = nonEmptyString(key), let parsed = Int(value), parsed > 0 else { return nil }
+            guard let value = GatewayDiscoveryText.txtValue(txt, key: key), let parsed = Int(value),
+                  parsed > 0 else { return nil }
             return parsed
         }
 
-        func booleanValue(_ key: String) -> Bool {
-            guard let normalized = nonEmptyString(key)?.lowercased() else { return false }
-            return normalized == "1" || normalized == "true" || normalized == "yes"
-        }
-
         return GatewayTXT(
-            lanHost: nonEmptyString("lanHost"),
-            tailnetDns: nonEmptyString("tailnetDns"),
+            lanHost: GatewayDiscoveryText.txtValue(txt, key: "lanHost"),
+            tailnetDns: GatewayDiscoveryText.txtValue(txt, key: "tailnetDns"),
             sshPort: positiveInteger("sshPort") ?? 22,
             gatewayPort: positiveInteger("gatewayPort"),
-            gatewayTls: booleanValue("gatewayTls"),
-            gatewayDirectReachable: booleanValue("gatewayDirectReachable"),
-            cliPath: nonEmptyString("cliPath"))
+            gatewayTls: GatewayDiscoveryText.txtBoolValue(txt, key: "gatewayTls"),
+            gatewayDirectReachable: GatewayDiscoveryText.txtBoolValue(txt, key: "gatewayDirectReachable"),
+            cliPath: GatewayDiscoveryText.txtValue(txt, key: "cliPath"))
     }
 
     public static func buildSSHTarget(user: String, host: String, port: Int) -> String {
@@ -536,15 +509,8 @@ public final class GatewayDiscoveryModel {
         resolver.start()
     }
 
-    private nonisolated static func prettifyInstanceName(_ decodedName: String) -> String {
-        let normalized = decodedName.split(whereSeparator: \.isWhitespace).joined(separator: " ")
-        let stripped = normalized.replacingOccurrences(of: " (OpenClaw)", with: "")
-            .replacingOccurrences(of: #"\s+\(\d+\)$"#, with: "", options: .regularExpression)
-        return stripped.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
     private nonisolated static func prettifyServiceName(_ decodedName: String) -> String {
-        let normalized = Self.prettifyInstanceName(decodedName)
+        let normalized = GatewayDiscoveryText.prettifyInstanceName(decodedName)
         var cleaned = normalized.replacingOccurrences(of: #"\s*-?gateway$"#, with: "", options: .regularExpression)
         cleaned = cleaned
             .replacingOccurrences(of: "_", with: " ")
@@ -661,7 +627,7 @@ public final class GatewayDiscoveryModel {
 
     private nonisolated static func normalizeDisplayToken(_ raw: String?) -> String? {
         guard let raw else { return nil }
-        let prettified = Self.prettifyInstanceName(raw)
+        let prettified = GatewayDiscoveryText.prettifyInstanceName(raw)
         let trimmed = prettified.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty { return nil }
         return trimmed.lowercased()
@@ -669,7 +635,7 @@ public final class GatewayDiscoveryModel {
 
     private nonisolated static func normalizeServiceHostToken(_ raw: String?) -> String? {
         guard let raw else { return nil }
-        let prettified = Self.prettifyInstanceName(raw)
+        let prettified = GatewayDiscoveryText.prettifyInstanceName(raw)
         let strippedGateway = prettified.replacingOccurrences(
             of: #"\s*-?\s*gateway$"#,
             with: "",

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryBrowserSession.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryBrowserSession.swift
@@ -1,0 +1,43 @@
+import Network
+
+@MainActor
+public final class GatewayDiscoveryBrowserSession {
+    private var browsers: [String: NWBrowser] = [:]
+    private var states: [String: NWBrowser.State] = [:]
+
+    public init() {}
+
+    public var isRunning: Bool {
+        !self.browsers.isEmpty
+    }
+
+    public func start(
+        queueLabelPrefix: String,
+        onState: @escaping @MainActor (String, NWBrowser.State, String) -> Void,
+        onResults: @escaping @MainActor (String, Set<NWBrowser.Result>) -> Void)
+    {
+        guard !self.isRunning else { return }
+        for domain in OpenClawBonjour.gatewayServiceDomains {
+            self.browsers[domain] = GatewayDiscoveryBrowserSupport.makeBrowser(
+                serviceType: OpenClawBonjour.gatewayServiceType,
+                domain: domain,
+                queueLabelPrefix: queueLabelPrefix,
+                onState: { [weak self] state in
+                    guard let self else { return }
+                    self.states[domain] = state
+                    let status = GatewayDiscoveryStatusText.make(
+                        states: Array(self.states.values), hasBrowsers: self.isRunning)
+                    onState(domain, state, status)
+                },
+                onResults: { results in onResults(domain, results) })
+        }
+    }
+
+    public func stop() {
+        for browser in self.browsers.values {
+            browser.cancel()
+        }
+        self.browsers = [:]
+        self.states = [:]
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryBrowserSupport.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryBrowserSupport.swift
@@ -1,9 +1,9 @@
 import Foundation
 import Network
 
-public enum GatewayDiscoveryBrowserSupport {
+enum GatewayDiscoveryBrowserSupport {
     @MainActor
-    public static func makeBrowser(
+    static func makeBrowser(
         serviceType: String,
         domain: String,
         queueLabelPrefix: String,

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryText.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/GatewayDiscoveryText.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+public enum GatewayDiscoveryText {
+    public static func prettifyInstanceName(_ decodedName: String) -> String {
+        let normalized = decodedName.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        let stripped = normalized.replacingOccurrences(of: " (OpenClaw)", with: "")
+            .replacingOccurrences(of: #"\s+\(\d+\)$"#, with: "", options: .regularExpression)
+        return stripped.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public static func txtValue(_ dict: [String: String], key: String) -> String? {
+        let raw = dict[key]?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return raw.isEmpty ? nil : raw
+    }
+
+    public static func txtBoolValue(_ dict: [String: String], key: String) -> Bool {
+        guard let raw = self.txtValue(dict, key: key)?.lowercased() else { return false }
+        return raw == "1" || raw == "true" || raw == "yes"
+    }
+}


### PR DESCRIPTION
## What Problem This Solves

The macOS and iOS discovery models separately own the same per-domain browser lifecycle and status bookkeeping, and repeat instance-name and TXT text normalization. Changes to these common rules can drift between Apple clients.

## Why This Change Was Made

OpenClawKit's `GatewayDiscoveryBrowserSession` now owns each model's browsers and browser states, using the existing browser factory and MainActor delivery. `GatewayDiscoveryText` owns identical instance-name cleanup and TXT string/boolean parsing. This removes 11 production lines while giving those rules one implementation.

The app adapters retain result mapping and publication timing. macOS retains resolved TXT precedence, SRV routing, positive-only port parsing, local filtering, deduplication, and fallback discovery. iOS retains endpoint-only TXT input, its existing integer parsing, TLS fingerprint metadata, and bounded debug logging. Public macOS parsing APIs remain available. The browser factory is now internal because the shared session owns its only upstream call. Global and organization code searches found no indexed consumer of this upstream API: matching applications compile their own vendored helpers, including the distinct Day1Labs/OpenAva transport caller. No compatibility wrapper is needed for those independent copies.

## User Impact

No intended user-visible change. Discovery starts, stops, names gateways, and handles platform-specific routing as before. Start does not eagerly change status; stop still publishes Stopped after the platform cleanup.

## Evidence

- OpenClawKit `swift test`: 1,656 tests in 127 suites passed after the visibility fix (51.299 seconds).
- An earlier full run hit two unchanged ChatViewModel tests: `current session mutations refresh selected model availability` and `late model completion does not replay current session selection into previous session`. Both passed the focused rerun, followed by the passing full suite. Their source is unchanged from the earlier green baseline; no assertion or timeout was changed.
- `swift build --package-path apps/macos --build-system native --product OpenClaw`: passed after the visibility fix (57.06 seconds).
- iOS simulator build: passed after project generation, with `/opt/homebrew/opt/rustup/bin` on PATH for the pinned Watch Rust toolchain.
- `pnpm native:i18n:check` and `pnpm protocol:check:swift`: passed.
- `periphery scan --config .periphery.yml --strict -- --build-system native` in apps/macos: passed, no unused code.
- Fresh independent Codex review through P2: scoped-clean, zero accepted/actionable findings.
- Existing parser, status, local-identity and debug tests are retained. No live multicast discovery flow was added for this refactor.
- `node scripts/check-changed.mjs`: passed, including 1,132 tests and native state schema guard v16.

Prior-head [CI 34132837916](https://github.com/openclaw/openclaw/actions/runs/34132837916) passed, including macOS Swift tests and the iOS build. Replacement-head [CI 34136799949](https://github.com/openclaw/openclaw/actions/runs/34136799949) passed on attempt 2 for a0524cf58d3ffa3d3d10f4ee5a2c044fb4ba6fa3.

The first shared-kit Periphery run reported two redundant-public findings for the moved browser factory. The enum and method are now internal; no suppression or baseline change was added.

The replacement-head [shared-kit Periphery run](https://github.com/openclaw/openclaw/actions/runs/34136799927) passed. Required CI initially failed one of 2,080 Mac tests: the two-second initial readiness wait in `CronGatewayOwnershipTests` (`active replacement`), before the route-replacement assertions. That test uses injected WebSocket fixtures, and the test plus connection/store owners match the prior green head byte-for-byte. The single failed-job rerun passed without source, assertion, or timeout changes.
