### PR TITLE
fix: close prepared model runtimes before auth teardown

### DIFF
--- a/src/agents/embedded-agent-runner/compaction-runtime-admission.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-admission.test.ts
@@ -25,12 +25,12 @@ import { resolveCompactionRuntimeSelection } from "./compaction-runtime-preparat
 
 let state: OpenClawTestState;
 beforeEach(async () => {
-  resetPreparedModelRuntimeSnapshotsForTest();
+  await resetPreparedModelRuntimeSnapshotsForTest();
   state = await createOpenClawTestState({ label: "compaction-provider-owner" });
   useNoBundledPlugins();
 });
 afterEach(async () => {
-  resetPreparedModelRuntimeSnapshotsForTest();
+  await resetPreparedModelRuntimeSnapshotsForTest();
   resetPluginLoaderTestStateForTest();
   await state.cleanup();
 });

--- a/src/agents/mcp-connection-resolver.test.ts
+++ b/src/agents/mcp-connection-resolver.test.ts
@@ -440,7 +440,7 @@ describe("mcp connection resolver helpers", () => {
     } finally {
       await disposeAllSessionMcpRuntimes();
       clearCurrentProviderAuthState();
-      resetPreparedModelRuntimeSnapshotsForTest();
+      await resetPreparedModelRuntimeSnapshotsForTest();
       setGatewaySigusr1RestartPolicy({ allowExternal: previousExternalRestartPolicy });
       await proof.close();
     }

--- a/src/agents/prepared-model-catalog-worker.integration.test.ts
+++ b/src/agents/prepared-model-catalog-worker.integration.test.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { setImmediate as nextTurn } from "node:timers/promises";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { buildModelsListResult } from "../gateway/server-methods/models-list-result.js";
@@ -10,6 +11,7 @@ import {
   loadPreparedGatewayModelCatalogSnapshot,
 } from "../gateway/server-model-catalog.js";
 import { loadPluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
 import { unregisterResolvedAgentDir } from "./agent-dir-registry.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "./agent-scope-config.js";
 import { OPENAI_CODEX_DEFAULT_PROFILE_ID } from "./auth-profiles/constants.js";
@@ -472,33 +474,58 @@ describe("prepared model catalog worker boundary", () => {
     },
   );
 
-  it("aborts and joins parent auth preparation before retiring a superseded catalog", async () => {
-    const fixture = await createStaticSnapshot(0, {}, { asyncSyntheticAuth: true });
-    const hold = path.join(fixture.root, "synthetic-auth-hold");
-    const started = path.join(fixture.root, "synthetic-auth-owner.txt");
-    const cancelled = path.join(fixture.root, "synthetic-auth-cancel.txt");
-    fs.rmSync(started, { force: true });
-    fs.writeFileSync(hold, "");
-    let settled = false;
-    const catalog = fixture.snapshot.loadFullModelCatalog!().finally(() => {
-      settled = true;
-    });
-    void catalog.catch(() => {});
-    try {
-      await waitForMarker(started);
-      fixture.supersede();
-      await waitForMarker(cancelled);
-      expect(settled).toBe(false);
-      fs.rmSync(hold);
-      await expect(catalog).rejects.toThrow("superseded");
-      expect(fs.readFileSync(cancelled, "utf8")).toBe("abort\njoined\n");
-      await waitForWorkers();
-    } finally {
-      fs.rmSync(hold, { force: true });
-      fixture.supersede();
-      await Promise.allSettled([catalog]);
-    }
-  });
+  it.each([
+    { retirement: "superseded", request: "catalog" },
+    { retirement: "process close", request: "catalog" },
+    { retirement: "process close", request: "auth" },
+  ])(
+    "aborts and joins parent $request preparation before $retirement completes",
+    async ({ retirement, request }) => {
+      const fixture = await createStaticSnapshot(0, {}, { asyncSyntheticAuth: true });
+      await loadPreparedModelRuntimeAuth(fixture.snapshot, { providerIds: [] });
+      const hold = path.join(fixture.root, "synthetic-auth-hold");
+      const started = path.join(fixture.root, "synthetic-auth-owner.txt");
+      const cancelled = path.join(fixture.root, "synthetic-auth-cancel.txt");
+      fs.rmSync(started, { force: true });
+      fs.writeFileSync(hold, "");
+      let settled = false;
+      const catalog = (
+        request === "auth"
+          ? loadPreparedModelRuntimeAuth(fixture.snapshot, { providerIds: [] })
+          : fixture.snapshot.loadFullModelCatalog!()
+      ).finally(() => {
+        settled = true;
+      });
+      void catalog.catch(() => {});
+      let closing: Promise<void> | undefined;
+      try {
+        await waitForMarker(started);
+        if (retirement === "process close") {
+          let closed = false;
+          closing = drainGlobalSingletonLifecycleState("close").then(() => {
+            closed = true;
+          });
+          await nextTurn();
+          expect(closed).toBe(false);
+        } else {
+          fixture.supersede();
+        }
+        await waitForMarker(cancelled);
+        expect(settled).toBe(false);
+        fs.rmSync(hold);
+        await expect(catalog).rejects.toThrow(
+          retirement === "superseded" ? "superseded" : "closed",
+        );
+        await closing;
+        expect(fs.readFileSync(cancelled, "utf8")).toBe("abort\njoined\n");
+        await waitForWorkers();
+      } finally {
+        fs.rmSync(hold, { force: true });
+        fixture.supersede();
+        await Promise.allSettled([catalog, closing]);
+      }
+    },
+  );
 
   it("refreshes durable auth before provider hooks decide catalog membership", async () => {
     const fixture = await createStaticSnapshot(0);

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -29,6 +29,7 @@ import type {
 import { PreparedModelRuntimePublicationSupersededError } from "./prepared-model-runtime.errors.js";
 import { fingerprintPreparedRuntimeFacts } from "./prepared-model-runtime.facts.js";
 import { markPreparedModelCatalogFull } from "./prepared-model-runtime.full-catalog.js";
+import { registerPreparedModelRuntimeClose } from "./prepared-model-runtime.lifecycle.js";
 import type { PreparedModelRuntimeInput } from "./prepared-model-runtime.types.js";
 import type { AuthStorageData } from "./sessions/auth-storage.js";
 
@@ -216,6 +217,7 @@ export function createPreparedModelCatalogWorker(
     );
   let generationPoll: NodeJS.Timeout | undefined;
   let stoppedError: Error | undefined;
+  let releaseProcessLifetime: (() => void) | undefined;
   let expectedFingerprint: string | undefined;
   const captures = new Map<AbortController, Promise<PreparedSyntheticAuthFacts>>();
   const assertCurrent = () => {
@@ -275,6 +277,8 @@ export function createPreparedModelCatalogWorker(
     // Native probes live in the parent; drain them before retiring the compute worker.
     await Promise.allSettled(captures.values());
     await pool?.close(stoppedError);
+    releaseProcessLifetime?.();
+    releaseProcessLifetime = undefined;
   };
   const request = async (
     command: PreparedModelWorkerCommand,
@@ -288,6 +292,7 @@ export function createPreparedModelCatalogWorker(
     );
     try {
       assertCurrent();
+      releaseProcessLifetime ??= registerPreparedModelRuntimeClose(stop);
       generationPoll ??= setInterval(() => {
         if (!params.isCurrent()) {
           void stop(superseded());

--- a/src/agents/prepared-model-runtime-config-stamp.test.ts
+++ b/src/agents/prepared-model-runtime-config-stamp.test.ts
@@ -31,7 +31,7 @@ let state: OpenClawTestState;
 describe("prepared model runtime config stamps", () => {
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
-    resetPreparedModelRuntimeHarness(state);
+    await resetPreparedModelRuntimeHarness(state);
     mocks.configuredAgentIds = ["default"];
   });
 

--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -29,6 +29,7 @@ import {
 import type { PreparedModelRuntimeLeaseOptions } from "./prepared-model-runtime.types.js";
 
 type PreparedModelRuntimeLeaseContext = {
+  captureLifetime(): () => void;
   owners: Map<string, PreparedModelRuntimeOwner>;
   agentBuildCompletions: Map<string, Promise<void>>;
   retainedDirectRunOwners: PreparedModelRuntimeOwnerRetention;
@@ -38,14 +39,6 @@ type PreparedModelRuntimeLeaseContext = {
   getPendingReplacement(): PreparedModelRuntimeReplacement | undefined;
   prepareSnapshot(input: PreparedModelRuntimeInput): Promise<PreparedModelRuntimeSnapshot>;
 };
-
-function throwIfLeaseAdmissionAborted(signal?: AbortSignal): void {
-  if (signal?.aborted) {
-    throw createAbortError("Prepared model runtime lease admission aborted", {
-      cause: signal.reason,
-    });
-  }
-}
 
 function createPreparedModelRuntimeAdmissionClaim(context: PreparedModelRuntimeLeaseContext) {
   let claimed: { key: string; owner: PreparedModelRuntimeOwner } | undefined;
@@ -89,6 +82,15 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
   context: PreparedModelRuntimeLeaseContext,
   options: PreparedModelRuntimeLeaseOptions = {},
 ): Promise<PreparedModelRuntimeLease> {
+  const assertLifetime = context.captureLifetime();
+  const assertAdmission = () => {
+    assertLifetime();
+    if (options.abortSignal?.aborted) {
+      throw createAbortError("Prepared model runtime lease admission aborted", {
+        cause: options.abortSignal.reason,
+      });
+    }
+  };
   const deriveSelections = options.deriveRuntimePluginSelections;
   // Caller choices belong to this invocation; only config-derived choices may change after a wait.
   const requestedSelections = deriveSelections
@@ -105,7 +107,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
   const admission = createPreparedModelRuntimeAdmissionClaim(context);
   for (;;) {
     admission.release();
-    throwIfLeaseAdmissionAborted(options.abortSignal);
+    assertAdmission();
     // Replacement owns publication from synchronous staling through atomic generation commit.
     // Dynamic work arriving inside that window must retry after the new owners become visible.
     const replacement = context.getPendingReplacement();
@@ -114,7 +116,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
       if (context.getPendingReplacement()) {
         continue;
       }
-      throwIfLeaseAdmissionAborted(options.abortSignal);
+      assertAdmission();
     }
     if (
       provenance === "run" &&
@@ -209,7 +211,7 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
         ) {
           // A turn may finish under its still-open parent lease after reload. Its historic
           // generation must never publish over the configured owner for newly admitted work.
-          throwIfLeaseAdmissionAborted(options.abortSignal);
+          assertAdmission();
           return {
             snapshot: borrowed,
             pluginGeneration: options.pluginGeneration,
@@ -305,12 +307,12 @@ export async function acquirePreparedModelRuntimeLeaseFromOwners(
     break;
   }
   try {
-    throwIfLeaseAdmissionAborted(options.abortSignal);
+    assertAdmission();
     const pluginGeneration = owner.pluginGeneration!;
     if (owner.provenance !== provenance) {
       return { snapshot, pluginGeneration, release: () => {} };
     }
-    throwIfLeaseAdmissionAborted(options.abortSignal);
+    assertAdmission();
     if (provenance === "run" && options.retainIdleRunOwner) {
       context.retainedDirectRunOwners.retain(key, owner, context.owners);
     } else if (provenance === "run" && context.getGatewayLifecycleActive()) {

--- a/src/agents/prepared-model-runtime.cancelled-admission.test.ts
+++ b/src/agents/prepared-model-runtime.cancelled-admission.test.ts
@@ -6,8 +6,10 @@ import {
   getPreparedModelRuntimeTestApi,
   resetPreparedModelRuntimeHarness,
 } from "./prepared-model-runtime.test-harness.js";
+import { setImmediate as nextTurn } from "node:timers/promises";
 import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
 import {
   createOpenClawTestState,
   type OpenClawTestState,
@@ -15,6 +17,11 @@ import {
 import * as runtimeBuild from "./prepared-model-runtime.build.js";
 import {
   acquireAgentRunPreparedModelRuntime,
+  activateStandalonePreparedModelRuntime,
+  getPreparedModelRuntimeSnapshot,
+  loadPublishedGatewayReplyDispatchRuntime,
+  prepareModelRuntimeSnapshot,
+  registerPreparedModelRuntimePublicationListener,
   acquireReadOnlyPreparedModelRuntime,
   refreshPreparedModelRuntimeSnapshots,
   type PreparedModelRuntimeInput,
@@ -24,6 +31,13 @@ import {
 const mocks = getPreparedModelRuntimeMocks();
 const testApi = getPreparedModelRuntimeTestApi();
 let state: OpenClawTestState;
+const configuredInput = () => ({
+  config: {},
+  agentId: "default",
+  agentDir: state.agentDir("default"),
+  inheritedAuthDir: state.agentDir("default"),
+});
+
 let buildBatchSpy: Mock<typeof runtimeBuild.startSerializedSnapshotBuildBatch>;
 let pendingBuildReleases: Array<{ resolve: () => void }>;
 
@@ -72,7 +86,7 @@ const coldAdmissionCases: Array<{
 describe("prepared model runtime cancelled admission ownership", () => {
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "prepared-runtime-cancelled-admission" });
-    resetPreparedModelRuntimeHarness(state);
+    await resetPreparedModelRuntimeHarness(state);
     pendingBuildReleases = [];
     buildBatchSpy = vi.spyOn(runtimeBuild, "startSerializedSnapshotBuildBatch");
   });
@@ -248,6 +262,122 @@ describe("prepared model runtime cancelled admission ownership", () => {
       catalogMode: "static",
     });
     expect(testApi.getPreparedModelRuntimeOwnerCountForTest()).toBe(1);
+  });
+  it.each(["close", "restart"] as const)(
+    "retires model publication before auth snapshots are cleared during %s",
+    async (event) => {
+      mocks.configuredAgentIds = ["default"];
+      await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
+      const prepared = getPreparedModelRuntimeSnapshot(configuredInput());
+      expect(prepared).toBeDefined();
+      await drainGlobalSingletonLifecycleState(event);
+      const builds = mocks.ensureOpenClawModelsJson.mock.calls.length;
+      mocks.mutationListener?.({ affectsInheritedStores: true, profileSetChanged: true });
+      await nextTurn();
+      expect(getPreparedModelRuntimeSnapshot(configuredInput())).toBeUndefined();
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(builds);
+      expect(prepared?.isCurrent()).toBe(false);
+      await expect(
+        loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }),
+      ).resolves.toBeUndefined();
+    },
+  );
+
+  it.each(["auth", "config"] as const)(
+    "joins the raw %s publication before completing process close",
+    async (source) => {
+      mocks.configuredAgentIds = ["default"];
+      await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
+      const entered = createDeferred();
+      const release = createDeferred();
+      const published = vi.fn();
+      const unregister = registerPreparedModelRuntimePublicationListener((event) => {
+        if (event.phase === "published") {
+          published();
+        }
+      });
+      mocks.ensureOpenClawModelsJson.mockImplementationOnce(async (_config, agentDir) => {
+        entered.resolve();
+        await release.promise;
+        return { agentDir: String(agentDir), wrote: false };
+      });
+      let refresh: Promise<void> | undefined;
+      if (source === "auth") {
+        mocks.mutationListener?.({ affectsInheritedStores: true });
+      } else {
+        refresh = refreshPreparedModelRuntimeSnapshots({});
+        void refresh.catch(() => {});
+      }
+      await entered.promise;
+      const reader = prepareModelRuntimeSnapshot(configuredInput());
+      void reader.catch(() => {});
+      let closed = false;
+      const closing = drainGlobalSingletonLifecycleState("close").then(() => {
+        closed = true;
+      });
+      try {
+        await nextTurn();
+        expect(closed).toBe(false);
+        release.resolve();
+        await closing;
+        await expect(reader).rejects.toThrow(/closed|superseded/);
+        expect(getPreparedModelRuntimeSnapshot(configuredInput())).toBeUndefined();
+        expect(published).not.toHaveBeenCalled();
+      } finally {
+        release.resolve();
+        await Promise.allSettled([refresh, reader, closing]);
+        unregister();
+      }
+    },
+  );
+
+  it("preserves immutable leased data and allows a fresh standalone activation after close", async () => {
+    const input = { config: {}, agentDir: state.agentDir("direct") };
+    const previous = await acquireAgentRunPreparedModelRuntime(input, { retainIdleRunOwner: true });
+    try {
+      await drainGlobalSingletonLifecycleState("close");
+      expect(previous.snapshot.isCurrent()).toBe(false);
+      expect(previous.snapshot.createStores()).toBeDefined();
+      const next = await acquireAgentRunPreparedModelRuntime(input, { retainIdleRunOwner: true });
+      try {
+        expect(next.snapshot).not.toBe(previous.snapshot);
+        previous.release();
+        expect(getPreparedModelRuntimeSnapshot(input)).toBe(next.snapshot);
+        expect(next.snapshot.isCurrent()).toBe(true);
+      } finally {
+        next.release();
+      }
+    } finally {
+      previous.release();
+    }
+  });
+
+  it("does not revive a queued standalone activation after its process lifetime closes", async () => {
+    const entered = createDeferred();
+    const release = createDeferred();
+    const input = { config: {}, agentDir: state.agentDir("queued") };
+    mocks.ensureOpenClawModelsJson.mockImplementationOnce(async (_config, agentDir) => {
+      entered.resolve();
+      await release.promise;
+      return { agentDir: String(agentDir), wrote: false };
+    });
+    const first = activateStandalonePreparedModelRuntime(input);
+    void first.catch(() => {});
+    await entered.promise;
+    const second = activateStandalonePreparedModelRuntime(input);
+    void second.catch(() => {});
+    const closing = drainGlobalSingletonLifecycleState("close");
+    try {
+      release.resolve();
+      await closing;
+      await expect(first).rejects.toThrow(/closed|superseded/);
+      await expect(second).rejects.toThrow(/closed|superseded/);
+      expect(getPreparedModelRuntimeSnapshot(input)).toBeUndefined();
+      expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledOnce();
+    } finally {
+      release.resolve();
+      await Promise.allSettled([first, second, closing]);
+    }
   });
 });
 

--- a/src/agents/prepared-model-runtime.catalog-owner.test.ts
+++ b/src/agents/prepared-model-runtime.catalog-owner.test.ts
@@ -40,7 +40,7 @@ const mocks = getPreparedModelRuntimeMocks();
 let state: OpenClawTestState;
 beforeEach(async () => {
   state = await createOpenClawTestState({ label: "prepared-model-runtime" });
-  resetPreparedModelRuntimeHarness(state);
+  await resetPreparedModelRuntimeHarness(state);
 });
 afterEach(async ({ task }) => {
   await cleanupPreparedModelRuntimeHarness(state, task.result?.state === "fail");

--- a/src/agents/prepared-model-runtime.inbound-registry.test.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.test.ts
@@ -34,7 +34,7 @@ let state: OpenClawTestState;
 describe("prepared reply dispatch runtime", () => {
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
-    resetPreparedModelRuntimeHarness(state);
+    await resetPreparedModelRuntimeHarness(state);
   });
 
   it("returns undefined while the Gateway lifecycle is inactive", async () => {

--- a/src/agents/prepared-model-runtime.lifecycle.test.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.test.ts
@@ -33,7 +33,7 @@ let state: OpenClawTestState;
 describe("prepared model runtime snapshots", () => {
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
-    resetPreparedModelRuntimeHarness(state);
+    await resetPreparedModelRuntimeHarness(state);
   });
 
   it("does not discover missing owners from a gateway request", async () => {

--- a/src/agents/prepared-model-runtime.lifecycle.ts
+++ b/src/agents/prepared-model-runtime.lifecycle.ts
@@ -1,0 +1,58 @@
+/** Process close owns every admitted model runtime and native catalog worker. */
+import { createDeferredCore } from "../shared/deferred.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+
+type ModelRuntimeClose = (error: Error) => Promise<void>;
+class ProcessModelRuntimeLifetimes {
+  readonly closeCallbacks = new Set<ModelRuntimeClose>();
+  epoch = 0;
+  closing?: Promise<void>;
+}
+
+const lifetimes = resolveGlobalSingleton(
+  Symbol.for("openclaw.preparedModelRuntimeLifetimes"),
+  () => new ProcessModelRuntimeLifetimes(),
+  () => closePreparedModelRuntimeSnapshots(),
+);
+
+export function capturePreparedModelRuntimeLifetime(): () => void {
+  const epoch = lifetimes.epoch;
+  const assertCurrent = () => {
+    if (lifetimes.closing || epoch !== lifetimes.epoch) {
+      throw new Error("prepared model runtime process lifetime closed");
+    }
+  };
+  assertCurrent();
+  return assertCurrent;
+}
+
+export function registerPreparedModelRuntimeClose(close: ModelRuntimeClose): () => void {
+  capturePreparedModelRuntimeLifetime();
+  lifetimes.closeCallbacks.add(close);
+  return () => lifetimes.closeCallbacks.delete(close);
+}
+
+/** Fence admission before abort callbacks run; old publications cannot enter the next lifetime. */
+export function closePreparedModelRuntimeSnapshots(): Promise<void> {
+  if (lifetimes.closing) {
+    return lifetimes.closing;
+  }
+  const closed = createDeferredCore();
+  lifetimes.closing = closed.promise;
+  lifetimes.epoch += 1;
+  const error = new Error("prepared model runtime process lifetime closed");
+  void Promise.allSettled([...lifetimes.closeCallbacks].map((close) => close(error))).then(
+    (results) => {
+      const failures = results.flatMap((result) =>
+        result.status === "rejected" ? [result.reason] : [],
+      );
+      if (failures.length) {
+        closed.reject(new AggregateError(failures, "Prepared model runtime failed to close"));
+      } else {
+        lifetimes.closing = undefined;
+        closed.resolve();
+      }
+    },
+  );
+  return closed.promise;
+}

--- a/src/agents/prepared-model-runtime.owner-selection.test.ts
+++ b/src/agents/prepared-model-runtime.owner-selection.test.ts
@@ -33,7 +33,7 @@ let state: OpenClawTestState;
 describe("prepared model runtime owner selection", () => {
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
-    resetPreparedModelRuntimeHarness(state);
+    await resetPreparedModelRuntimeHarness(state);
   });
 
   it("serializes live catalog sources for owners sharing one agent directory", async () => {

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -385,6 +385,27 @@ export function resolvePublishedOwner(
   return candidates.length === 1 ? candidates[0] : undefined;
 }
 
+/** Reads an already-published generation without admitting discovery. */
+export function readPublishedModelRuntimeSnapshot(
+  owners: Map<string, PreparedModelRuntimeOwner>,
+  rawInput: PreparedModelRuntimeInput,
+): PreparedModelRuntimeSnapshot | undefined {
+  const input = normalizePreparedModelRuntimeInput(rawInput);
+  const owner = resolvePublishedOwner(owners, input, {
+    allowConfiguredWorkspaceFallback:
+      rawInput.workspaceDir === undefined ||
+      rawInput.agentId === undefined ||
+      rawInput.runtimePluginSelections === undefined,
+  });
+  if (!owner?.snapshot || owner.needsRefresh || owner.pending) {
+    return undefined;
+  }
+  if (input.readOnly && !preparedModelRuntimeConfigsMatch(owner.input.config, input.config)) {
+    return undefined;
+  }
+  return owner.snapshot;
+}
+
 export function hasSameLifecycleInput(
   left: PreparedModelRuntimeInput,
   right: PreparedModelRuntimeInput,

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -29,7 +29,7 @@ let state: OpenClawTestState;
 describe("prepared model runtime reload auth adoption", () => {
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
-    resetPreparedModelRuntimeHarness(state);
+    await resetPreparedModelRuntimeHarness(state);
   });
 
   it("refreshes stale catalog content only when an explicit read requests it", async () => {

--- a/src/agents/prepared-model-runtime.reply-fallback.test.ts
+++ b/src/agents/prepared-model-runtime.reply-fallback.test.ts
@@ -52,7 +52,7 @@ let state: OpenClawTestState;
 describe("prepared reply fallback ownership", () => {
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
-    resetPreparedModelRuntimeHarness(state);
+    await resetPreparedModelRuntimeHarness(state);
     vi.clearAllMocks();
     const actual = await vi.importActual<typeof import("./agent-scope.js")>("./agent-scope.js");
     vi.spyOn(agentScope, "resolveAgentConfig").mockImplementation(actual.resolveAgentConfig);

--- a/src/agents/prepared-model-runtime.scoped-refresh.test.ts
+++ b/src/agents/prepared-model-runtime.scoped-refresh.test.ts
@@ -56,7 +56,7 @@ async function prepareCatalogOwner(
 describe("prepared model runtime scoped refresh", () => {
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
-    resetPreparedModelRuntimeHarness(state);
+    await resetPreparedModelRuntimeHarness(state);
   });
 
   it.each([undefined, "provider-a:default"])(

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -241,8 +241,8 @@ const { resetPreparedModelRuntimeSnapshotsForTest } =
   await import("./prepared-model-runtime.test-support.js");
 const { resolveThinkingProfile } = await import("../auto-reply/thinking.js");
 
-beforeEach(() => {
-  resetPreparedModelRuntimeSnapshotsForTest();
+beforeEach(async () => {
+  await resetPreparedModelRuntimeSnapshotsForTest();
   mocks.loadAgentRuntimePluginRegistryHandle
     .mockReset()
     .mockReturnValue(createEmptyPluginRegistry());

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -384,7 +384,7 @@ vi.mock("../logging/subsystem.js", () => ({
 
 type PreparedModelRuntimeTestApi = {
   getPreparedModelRuntimeOwnerCountForTest(): number;
-  resetPreparedModelRuntimeSnapshotsForTest(): void;
+  resetPreparedModelRuntimeSnapshotsForTest(): Promise<void>;
   setModelRuntimeBuildTimeoutMsForTest(timeoutMs: number): void;
 };
 
@@ -398,8 +398,8 @@ export function getPreparedModelRuntimeTestApi(): PreparedModelRuntimeTestApi {
   ] as PreparedModelRuntimeTestApi;
 }
 
-export function resetPreparedModelRuntimeHarness(state: OpenClawTestState): void {
-  getPreparedModelRuntimeTestApi().resetPreparedModelRuntimeSnapshotsForTest();
+export async function resetPreparedModelRuntimeHarness(state: OpenClawTestState): Promise<void> {
+  await getPreparedModelRuntimeTestApi().resetPreparedModelRuntimeSnapshotsForTest();
   agentScopeMocks.resolveAgentDir
     .mockReset()
     .mockImplementation(
@@ -478,6 +478,6 @@ export async function cleanupPreparedModelRuntimeHarness(
     console.warn(`Retained prepared-model fixture after failed test: ${state.root}`);
     return;
   }
-  getPreparedModelRuntimeTestApi().resetPreparedModelRuntimeSnapshotsForTest();
+  await getPreparedModelRuntimeTestApi().resetPreparedModelRuntimeSnapshotsForTest();
   await state.cleanup();
 }

--- a/src/agents/prepared-model-runtime.test-support.ts
+++ b/src/agents/prepared-model-runtime.test-support.ts
@@ -1,11 +1,11 @@
 type PreparedModelRuntimeTestApi = {
-  resetPreparedModelRuntimeSnapshotsForTest(): void;
+  resetPreparedModelRuntimeSnapshotsForTest(): Promise<void>;
 };
 
 /** Clears prepared model owners when the production module is loaded in this test worker. */
-export function resetPreparedModelRuntimeSnapshotsForTest(): void {
+export async function resetPreparedModelRuntimeSnapshotsForTest(): Promise<void> {
   const api = (globalThis as Record<PropertyKey, unknown>)[
     Symbol.for("openclaw.preparedModelRuntimeTestApi")
   ] as PreparedModelRuntimeTestApi | undefined;
-  api?.resetPreparedModelRuntimeSnapshotsForTest();
+  await api?.resetPreparedModelRuntimeSnapshotsForTest();
 }

--- a/src/agents/prepared-model-runtime.test.ts
+++ b/src/agents/prepared-model-runtime.test.ts
@@ -37,7 +37,7 @@ let state: OpenClawTestState;
 describe("prepared model runtime snapshots", () => {
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
-    resetPreparedModelRuntimeHarness(state);
+    await resetPreparedModelRuntimeHarness(state);
   });
 
   it("materializes Claude CLI thinking capabilities on the prepared logical row", async () => {

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -16,6 +16,11 @@ import {
 import { preparedModelInventoryKey } from "./prepared-model-runtime.facts.js";
 import { isPreparedModelCatalogFull } from "./prepared-model-runtime.full-catalog.js";
 import {
+  capturePreparedModelRuntimeLifetime,
+  closePreparedModelRuntimeSnapshots,
+  registerPreparedModelRuntimeClose,
+} from "./prepared-model-runtime.lifecycle.js";
+import {
   PreparedModelRuntimeOwnerNotPublishedError,
   PreparedModelRuntimeOwnerRetention,
   PreparedModelRuntimePublicationSupersededError,
@@ -33,6 +38,7 @@ import {
   resolvePreparedModelRuntimeOwnerBySnapshot,
   resolveConfiguredOwnerPublication,
   resolvePublishedOwner,
+  readPublishedModelRuntimeSnapshot,
   type PreparedModelRuntimeOwner,
   type PreparedModelRuntimeInput,
   type PreparedModelRuntimePublicationOptions,
@@ -102,6 +108,32 @@ const replyDispatchPublication = new PreparedReplyDispatchPublicationOwner({
 });
 export const loadPublishedGatewayReplyDispatchRuntime = replyDispatchPublication.load;
 
+let releaseProcessLifetime: (() => void) | undefined;
+function captureModelRuntimeLifetime(): () => void {
+  const assertCurrent = capturePreparedModelRuntimeLifetime();
+  releaseProcessLifetime ??= registerPreparedModelRuntimeClose(closeModelRuntime);
+  return assertCurrent;
+}
+
+async function closeModelRuntime(error: Error): Promise<void> {
+  refreshRequestEpoch += 1;
+  authPublication.reset(error);
+  pendingModelRuntimeReplacement?.reject(error);
+  pendingModelRuntimeReplacement = undefined;
+  owners.clear();
+  retainedDirectRunOwners.clear(owners);
+  retainedGatewayRunOwners.clear(owners);
+  gatewayLifecycleActive = false;
+  replyDispatchPublication.clear();
+  await Promise.all([
+    refreshTail,
+    ...agentBuildCompletions.values(),
+    ...standaloneActivationTails.values(),
+  ]);
+  releaseProcessLifetime?.();
+  releaseProcessLifetime = undefined;
+}
+
 /** Advances model-neutral config identity without rebuilding prepared generation artifacts. */
 export function advancePreparedModelRuntimeConfig(config: OpenClawConfig): void {
   for (const owner of owners.values()) {
@@ -118,12 +150,14 @@ export function advancePreparedModelRuntimeConfig(config: OpenClawConfig): void 
 export async function loadPreparedModelRuntimeSnapshot(
   rawInput: PreparedModelRuntimeInput,
 ): Promise<PreparedModelRuntimeSnapshot> {
+  const assertLifetime = captureModelRuntimeLifetime();
   let input = normalizePreparedModelRuntimeInput({
     ...rawInput,
     preserveWorkspaceDirOnRefresh:
       rawInput.preserveWorkspaceDirOnRefresh ?? rawInput.workspaceDir !== undefined,
   });
   for (;;) {
+    assertLifetime();
     const replacement = pendingModelRuntimeReplacement;
     if (replacement) {
       await replacement.promise;
@@ -143,6 +177,7 @@ export async function loadPreparedModelRuntimeSnapshot(
     if (pendingModelRuntimeReplacement) {
       continue;
     }
+    assertLifetime();
     const activated = await activateStandalonePreparedModelRuntime(input);
     if (pendingModelRuntimeReplacement) {
       continue;
@@ -166,23 +201,9 @@ export async function loadPreparedModelRuntimeSnapshot(
 export function getPreparedModelRuntimeSnapshot(
   rawInput: PreparedModelRuntimeInput,
 ): PreparedModelRuntimeSnapshot | undefined {
-  if (pendingModelRuntimeReplacement) {
-    return undefined;
-  }
-  const input = normalizePreparedModelRuntimeInput(rawInput);
-  const owner = resolvePublishedOwner(owners, input, {
-    allowConfiguredWorkspaceFallback:
-      rawInput.workspaceDir === undefined ||
-      rawInput.agentId === undefined ||
-      rawInput.runtimePluginSelections === undefined,
-  });
-  if (!owner?.snapshot || owner.needsRefresh || owner.pending) {
-    return undefined;
-  }
-  if (input.readOnly && !preparedModelRuntimeConfigsMatch(owner.input.config, input.config)) {
-    return undefined;
-  }
-  return owner.snapshot;
+  return pendingModelRuntimeReplacement
+    ? undefined
+    : readPublishedModelRuntimeSnapshot(owners, rawInput);
 }
 
 /** Publishes one owner from an explicit startup/activation lifecycle boundary. */
@@ -190,6 +211,7 @@ export async function publishPreparedModelRuntimeSnapshot(
   rawInput: PreparedModelRuntimeInput,
   options: PreparedModelRuntimePublicationOptions = {},
 ): Promise<PreparedModelRuntimeSnapshot> {
+  captureModelRuntimeLifetime();
   const input = normalizePreparedModelRuntimeInput(rawInput);
   const existing = owners.get(ownerKey(input));
   if (existing?.pending) {
@@ -227,13 +249,14 @@ export async function publishPreparedModelRuntimeSnapshot(
 export async function activateStandalonePreparedModelRuntime(
   rawInput: PreparedModelRuntimeInput,
 ): Promise<PreparedModelRuntimeSnapshot | undefined> {
+  const assertLifetime = captureModelRuntimeLifetime();
   const input = normalizePreparedModelRuntimeInput(rawInput);
   const key = ownerKey(input);
   const previous = standaloneActivationTails.get(key) ?? Promise.resolve();
   // One writer per owner key prevents conflicting config activations from alternately
   // superseding each other's generation while preserving each caller's requested snapshot.
   const activation = previous.then(
-    async () => await activateStandalonePreparedModelRuntimeNow(input),
+    async () => await activateStandalonePreparedModelRuntimeNow(input, assertLifetime),
   );
   const tail = activation.then(
     () => undefined,
@@ -251,8 +274,10 @@ export async function activateStandalonePreparedModelRuntime(
 
 async function activateStandalonePreparedModelRuntimeNow(
   input: PreparedModelRuntimeInput,
+  assertLifetime: () => void,
 ): Promise<PreparedModelRuntimeSnapshot | undefined> {
   for (;;) {
+    assertLifetime();
     const overlapsConfiguredOwner = [...owners.values()].some(
       (owner) =>
         owner.provenance === "configured" &&
@@ -286,6 +311,7 @@ async function activateStandalonePreparedModelRuntimeNow(
 }
 
 const preparedModelRuntimeLeaseContext = {
+  captureLifetime: captureModelRuntimeLifetime,
   owners,
   agentBuildCompletions,
   retainedDirectRunOwners,
@@ -327,11 +353,13 @@ export async function acquireReadOnlyPreparedModelRuntime(
 export async function prepareModelRuntimeSnapshot(
   rawInput: PreparedModelRuntimeInput,
 ): Promise<PreparedModelRuntimeSnapshot> {
+  const assertLifetime = captureModelRuntimeLifetime();
   const replacement = pendingModelRuntimeReplacement;
   if (replacement) {
     // Individual owners may finish before a multi-owner publication commits. The lifecycle gate
     // makes the generation visible atomically only after every owner and auth mutation is ready.
     await replacement.promise;
+    assertLifetime();
     return await prepareModelRuntimeSnapshot(rawInput);
   }
   const input = normalizePreparedModelRuntimeInput(rawInput);
@@ -358,6 +386,7 @@ export async function prepareModelRuntimeSnapshot(
     } catch {
       // Re-read the owner below so a superseding generation wins over this result or error.
     }
+    assertLifetime();
     return await prepareModelRuntimeSnapshot(rawInput);
   }
   if (existing?.needsRefresh) {
@@ -406,6 +435,7 @@ export function markPreparedModelRuntimeSnapshotsStale(
     agentIds?: ReadonlySet<string>;
   } = {},
 ): PreparedModelRuntimeReplacementGateId | undefined {
+  captureModelRuntimeLifetime();
   replyDispatchPublication.clear();
   if (options.waitForReplacement) {
     const superseded = pendingModelRuntimeReplacement;
@@ -725,22 +755,8 @@ function invalidateForAuthMutation(event: PreparedModelRuntimeAuthMutation): voi
 registerRuntimeAuthProfileStoreMutationListener(invalidateForAuthMutation);
 registerPreparedRuntimeAuthMaterializationPublisher(owners, notifyPreparedModelRuntimePublication);
 
-function resetPreparedModelRuntimeSnapshotsForTest(): void {
-  authPublication.reset(
-    new PreparedModelRuntimePublicationSupersededError(
-      "prepared model runtime auth publication reset for test",
-    ),
-  );
-  pendingModelRuntimeReplacement?.resolve();
-  pendingModelRuntimeReplacement = undefined;
-  owners.clear();
-  agentBuildCompletions.clear();
-  standaloneActivationTails.clear();
-  retainedGatewayRunOwners.clear(owners);
-  gatewayLifecycleActive = false;
-  refreshTail = Promise.resolve();
-  refreshRequestEpoch = 0;
-  replyDispatchPublication.clear();
+async function resetPreparedModelRuntimeSnapshotsForTest(): Promise<void> {
+  await closePreparedModelRuntimeSnapshots();
   resetPreparedModelRuntimePublicationListenersForTest();
   modelRuntimeBuildTimeoutMs = DEFAULT_MODEL_RUNTIME_BUILD_TIMEOUT_MS;
 }

--- a/src/agents/simple-completion-runtime.plugin-scope.test.ts
+++ b/src/agents/simple-completion-runtime.plugin-scope.test.ts
@@ -89,8 +89,8 @@ module.exports = {
   return { ...fixture, reconcileFailureMarker };
 }
 
-afterEach(() => {
-  resetPreparedModelRuntimeSnapshotsForTest();
+afterEach(async () => {
+  await resetPreparedModelRuntimeSnapshotsForTest();
   clearPluginMetadataLifecycleCaches();
   resetPluginLoaderTestStateForTest();
   tempRoots.cleanup();

--- a/src/agents/subagents/spawn/subagent-spawn.production-boundary.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.production-boundary.test.ts
@@ -106,7 +106,7 @@ async function writeTestConfig() {
 
 beforeEach(async () => {
   state = await createOpenClawTestState({ label: "spawn-production-boundary" });
-  resetPreparedModelRuntimeHarness(state);
+  await resetPreparedModelRuntimeHarness(state);
   runEmbeddedAgent.mockReset();
   stateDir = state.stateDir;
   runtimeConfig = await writeTestConfig();

--- a/src/agents/test-helpers/prepared-model-catalog-worker-fixture.ts
+++ b/src/agents/test-helpers/prepared-model-catalog-worker-fixture.ts
@@ -39,7 +39,7 @@ export function usePreparedCatalogWorkerFixtures() {
         retire();
       }
       retirements.clear();
-      resetPreparedModelRuntimeSnapshotsForTest();
+      await resetPreparedModelRuntimeSnapshotsForTest();
       try {
         await waitForWorkers();
       } finally {

--- a/src/agents/tools-effective-inventory.cold-provider.test.ts
+++ b/src/agents/tools-effective-inventory.cold-provider.test.ts
@@ -89,7 +89,7 @@ async function withColdFixture(run: (fixture: ReturnType<typeof createFixture>) 
           OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
         },
         async () => {
-          resetPreparedModelRuntimeSnapshotsForTest();
+          await resetPreparedModelRuntimeSnapshotsForTest();
           clearPluginMetadataLifecycleCaches();
           testing.resetToolsEffectiveCacheForTest();
           try {
@@ -102,7 +102,7 @@ async function withColdFixture(run: (fixture: ReturnType<typeof createFixture>) 
             expect(ownerCount()).toBe(0);
           } finally {
             testing.resetToolsEffectiveCacheForTest();
-            resetPreparedModelRuntimeSnapshotsForTest();
+            await resetPreparedModelRuntimeSnapshotsForTest();
             clearPluginMetadataLifecycleCaches();
             resetPluginLoaderTestStateForTest();
             cleanupPluginLoaderFixturesForTest();

--- a/src/cli/config-model-validation.runtime.test.ts
+++ b/src/cli/config-model-validation.runtime.test.ts
@@ -25,8 +25,8 @@ const primary = "pin-alpha/exact-supported";
 const fallback = "pin-beta/exact-supported";
 const providerIds = ["pin-alpha", "pin-beta", "pin-unrelated"];
 
-function clearRuntimeState() {
-  resetPreparedModelRuntimeSnapshotsForTest();
+async function clearRuntimeState() {
+  await resetPreparedModelRuntimeSnapshotsForTest();
   clearPluginLoaderCache();
 }
 
@@ -108,26 +108,26 @@ module.exports = {
       try {
         await run({ config, state, imported });
       } finally {
-        clearRuntimeState();
+        await clearRuntimeState();
       }
     },
   );
 }
 
 describe("config model validation with provider runtime", () => {
-  beforeEach(() => {
-    clearRuntimeState();
+  beforeEach(async () => {
+    await clearRuntimeState();
     vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
       throw new Error("Unexpected network request during config model validation");
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     try {
       expect(globalThis.fetch).not.toHaveBeenCalled();
     } finally {
       vi.restoreAllMocks();
-      clearRuntimeState();
+      await clearRuntimeState();
     }
   });
 

--- a/src/gateway/server-aux-handlers.test.ts
+++ b/src/gateway/server-aux-handlers.test.ts
@@ -324,7 +324,7 @@ beforeEach(async () => {
   // These channel-only snapshots are not model fixtures; the real publication boundary is
   // exercised in server-secrets-reload.model-runtime.test.ts.
   vi.spyOn(modelRuntimeReload, "refreshModelRuntimeAfterHotReload").mockResolvedValue(undefined);
-  resetPreparedModelRuntimeSnapshotsForTest();
+  await resetPreparedModelRuntimeSnapshotsForTest();
   delete process.env.OPENCLAW_SKIP_CHANNELS;
   delete process.env.OPENCLAW_SKIP_PROVIDERS;
   secretStoreMocks.deleteEntry.mockReset();
@@ -339,7 +339,7 @@ afterEach(async () => {
   }
   auxiliaries.length = 0;
   vi.restoreAllMocks();
-  resetPreparedModelRuntimeSnapshotsForTest();
+  await resetPreparedModelRuntimeSnapshotsForTest();
   clearSecretsRuntimeSnapshot();
   await fixture?.cleanup();
   fixture = undefined;

--- a/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.integration.test.ts
@@ -73,7 +73,7 @@ let sidecars: GatewayPostReadySidecarHandle[] = [];
 beforeEach(async () => {
   vi.stubEnv("OPENAI_API_KEY", "");
   state = await createOpenClawTestState({ label: "prepared-model-runtime" });
-  resetPreparedModelRuntimeHarness(state);
+  await resetPreparedModelRuntimeHarness(state);
   mocks.configuredAgentIds = ["main"];
   mocks.authStorage.getAll.mockReturnValue({
     openai: {

--- a/src/gateway/server-methods/sessions-mutations.catalog-queue.test.ts
+++ b/src/gateway/server-methods/sessions-mutations.catalog-queue.test.ts
@@ -31,8 +31,8 @@ import { sessionMutationHandlers } from "./sessions-mutations.js";
 import { sessionLog } from "./sessions-shared.js";
 import type { GatewayRequestContext } from "./types.js";
 
-afterEach(() => {
-  resetPreparedModelRuntimeSnapshotsForTest();
+afterEach(async () => {
+  await resetPreparedModelRuntimeSnapshotsForTest();
   closeOpenClawAgentDatabasesForTest();
 });
 

--- a/src/gateway/server-model-catalog.ts
+++ b/src/gateway/server-model-catalog.ts
@@ -63,7 +63,7 @@ export async function resetPreparedModelCatalogStateForTest(): Promise<void> {
       import("../agents/prepared-model-runtime.test-support.js"),
       import("../agents/model-catalog.js"),
     ]);
-  resetPreparedModelRuntimeSnapshotsForTest();
+  await resetPreparedModelRuntimeSnapshotsForTest();
   resetModelCatalogBuilderCacheForTest();
 }
 

--- a/src/gateway/server-secrets-reload.model-runtime.test.ts
+++ b/src/gateway/server-secrets-reload.model-runtime.test.ts
@@ -77,7 +77,7 @@ function requireRuntimeConfig(): OpenClawConfig {
 }
 
 beforeEach(async () => {
-  resetPreparedModelRuntimeSnapshotsForTest();
+  await resetPreparedModelRuntimeSnapshotsForTest();
   clearSecretsRuntimeSnapshot();
   state = await createOpenClawTestState({ label: "secrets-model-publication" });
   vi.stubEnv("TEST_RELOADED_MODEL_KEY", undefined);
@@ -85,7 +85,7 @@ beforeEach(async () => {
 });
 
 afterEach(async () => {
-  resetPreparedModelRuntimeSnapshotsForTest();
+  await resetPreparedModelRuntimeSnapshotsForTest();
   clearSecretsRuntimeSnapshot();
   vi.unstubAllEnvs();
   vi.restoreAllMocks();

--- a/src/gateway/server.context-prewarm.remote-proof.test.ts
+++ b/src/gateway/server.context-prewarm.remote-proof.test.ts
@@ -19,9 +19,9 @@ import {
 
 installGatewayTestHooks();
 
-afterEach(() => {
+afterEach(async () => {
   resetContextWindowCacheForTest();
-  resetPreparedModelRuntimeSnapshotsForTest();
+  await resetPreparedModelRuntimeSnapshotsForTest();
 });
 
 describe("Gateway context cache remote proof", () => {

--- a/src/tui/embedded-prepared-runtime.test.ts
+++ b/src/tui/embedded-prepared-runtime.test.ts
@@ -19,7 +19,7 @@ let state: OpenClawTestState;
 describe("EmbeddedPreparedModelRuntimeHost", () => {
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
-    resetPreparedModelRuntimeHarness(state);
+    await resetPreparedModelRuntimeHarness(state);
   });
 
   it("reuses its configured publication across two actual run admissions", async () => {

--- a/test/e2e/gateway-transcripts-discord-capture.e2e.test.ts
+++ b/test/e2e/gateway-transcripts-discord-capture.e2e.test.ts
@@ -437,7 +437,7 @@ describe("Gateway admitted Discord transcript capture", () => {
             await drainSessionStoreWriterQueuesForTest();
           } finally {
             clearSessionStoreCacheForTest();
-            resetPreparedModelRuntimeSnapshotsForTest();
+            await resetPreparedModelRuntimeSnapshotsForTest();
             closeOpenClawStateDatabaseByPath(path.join(stateDir, "state", "openclaw.sqlite"));
             resetConfigOverrides();
             clearRuntimeConfigSnapshot();

--- a/test/setup-openclaw-runtime.ts
+++ b/test/setup-openclaw-runtime.ts
@@ -365,7 +365,7 @@ afterEach(async () => {
   resetFileLockStateForTest();
   resetContextWindowCacheForTest();
   resetModelsJsonReadyCacheForTest();
-  resetPreparedModelRuntimeSnapshotsForTest();
+  await resetPreparedModelRuntimeSnapshotsForTest();
   await installDefaultPluginRegistry();
 });
 


### PR DESCRIPTION
Gateway shutdown could clear auth snapshots while prepared model owners were still listening, starting fresh discovery during teardown. Shutdown could also finish before an admitted catalog worker’s parent auth probe settled.

Close and restart now fence model admission, retire pending publications, and join the existing model builds and native worker cleanup before completing. Model snapshots and auth bindings stay in their original module; a process coordinator holds the actual cleanup callbacks. Test cleanup uses the same awaited path, replacing the duplicated reset that discarded pending queues.

Validation: causal lifecycle and native-worker failures before the fix; 283 owner/native/Gateway tests; 47 selector/cancellation tests after an equivalent helper extraction; the full changed-file gate; build; and an isolated built Gateway proving health, configured model visibility, graceful SIGTERM, and complete process cleanup. Independent P2 review found no actionable issues; the final helper extraction preserves the reviewed selection body exactly and has separate focused verification.

Production LOC: +102 for the missing process-close, admission, and cleanup ownership, including the owner-selection extraction; tests: +157. This is an independently useful prerequisite for the plugin lifecycle work in #135599.
