### PR TITLE
improve(ports): reduce repeated work in listener diagnostics

### DIFF
--- a/src/infra/ports-format.test.ts
+++ b/src/infra/ports-format.test.ts
@@ -119,6 +119,48 @@ describe("ports-format", () => {
     expect(buildPortHints(listeners, 18789)).toEqual([]);
   });
 
+  it.each([
+    { addresses: ["[::ffff:127.0.0.1]:18789"], expected: true, dual: false, specific: false },
+    {
+      addresses: ["[::ffff:127.0.0.1]:18789", "[::1]:18789"],
+      expected: true,
+      dual: true,
+      specific: false,
+    },
+    {
+      addresses: ["127.0.0.1:18789", "[::ffff:127.0.0.1]:18789"],
+      expected: false,
+      dual: false,
+      specific: false,
+    },
+    {
+      addresses: ["192.0.2.1:18789", "[::ffff:127.0.0.1]:18789"],
+      expected: true,
+      dual: false,
+      specific: true,
+    },
+  ])("preserves mapped listener classification for $addresses", (entry) => {
+    const orders =
+      entry.addresses.length === 1
+        ? [entry.addresses]
+        : [entry.addresses, entry.addresses.toReversed()];
+    for (const addresses of orders) {
+      const listeners = addresses.map((address) => ({
+        pid: 4242,
+        commandLine: "openclaw-gateway",
+        address,
+      }));
+      expect(isExpectedGatewayListeners(listeners, 18789)).toBe(entry.expected);
+      expect(isDualStackLoopbackGatewayListeners(listeners, 18789)).toBe(entry.dual);
+      expect(isSameProcessSpecificIpv4WithLoopbackListeners(listeners, 18789, "192.0.2.1")).toBe(
+        entry.specific,
+      );
+      expect(buildPortHints(listeners, 18789)).toEqual(
+        entry.expected ? [] : [gatewayAlreadyRunningHint, multipleListenersHint],
+      );
+    }
+  });
+
   it("checks exact alias ownership without relying on process display metadata", () => {
     const listeners = [
       { pid: 4242, commandLine: "opaque-wrapper", address: "100.64.0.1:18789" },

--- a/src/infra/ports-format.ts
+++ b/src/infra/ports-format.ts
@@ -45,18 +45,14 @@ export function classifyPortListener(listener: PortListener, _port: number): Por
   return "unknown";
 }
 
-// Dual-stack listener output can include IPv4-mapped IPv6 addresses; keep them
-// in the IPv6 family so the benign loopback-pair detection stays conservative.
+// The parser folds one mapped prefix but does not validate host syntax.
+// Preserve the classification of any mapped-loopback spelling that remains.
 function classifyLoopbackAddressFamily(host: string): "ipv4" | "ipv6" | null {
   if (host === "127.0.0.1" || host === "localhost") {
     return "ipv4";
   }
-  if (host === "::1") {
+  if (host === "::1" || host === "::ffff:127.0.0.1") {
     return "ipv6";
-  }
-  if (host.startsWith("::ffff:")) {
-    const mapped = host.slice("::ffff:".length);
-    return mapped === "127.0.0.1" ? "ipv6" : null;
   }
   return null;
 }
@@ -100,15 +96,6 @@ function parseGatewayListeners(
   return parsePortListeners(listeners, port);
 }
 
-/** Returns true for one Gateway listener bound to an expected loopback or wildcard address. */
-function isSingleExpectedGatewayListener(listeners: PortListener[], port: number): boolean {
-  if (listeners.length !== 1) {
-    return false;
-  }
-  const parsed = parseGatewayListeners(listeners, port);
-  return Boolean(parsed?.[0] && isExpectedGatewayBindAddress(parsed[0].host));
-}
-
 /** Returns true for one Gateway process represented by separate IPv4 and IPv6 loopback rows. */
 export function isDualStackLoopbackGatewayListeners(
   listeners: PortListener[],
@@ -121,32 +108,23 @@ export function isDualStackLoopbackGatewayListeners(
   if (!parsed) {
     return false;
   }
+  return parsedListenersAreDualStackLoopback(parsed);
+}
+
+function parsedListenersAreDualStackLoopback(parsed: ParsedGatewayListener[]): boolean {
   const pids = new Set(parsed.map(({ pid }) => pid));
   const families = new Set(parsed.map(({ host }) => classifyLoopbackAddressFamily(host)));
   return pids.size === 1 && !families.has(null) && families.has("ipv4") && families.has("ipv6");
 }
 
 function parsedListenersOwnSpecificIpv4WithLoopback(parsed: ParsedGatewayListener[]): boolean {
-  if (new Set(parsed.map(({ pid }) => pid)).size !== 1) {
-    return false;
-  }
-  const hosts = new Set(parsed.map(({ host }) => host));
-  const specificHosts = [...hosts].filter(
-    (host) => host !== "127.0.0.1" && net.isIP(host) === 4 && !isWildcardAddress(host),
+  return (
+    parsed.every(({ pid }) => pid === parsed[0]?.pid) &&
+    parsed.some(({ host }) => host === "127.0.0.1") &&
+    parsed.some(
+      ({ host }) => host !== "127.0.0.1" && net.isIP(host) === 4 && !isWildcardAddress(host),
+    )
   );
-  return hosts.has("127.0.0.1") && specificHosts.length > 0;
-}
-
-/** Checks one Gateway PID owns both an exact IPv4 interface and canonical loopback. */
-function isSpecificIpv4WithLoopbackGatewayListeners(
-  listeners: PortListener[],
-  port: number,
-): boolean {
-  if (listeners.length !== 2) {
-    return false;
-  }
-  const parsed = parseGatewayListeners(listeners, port);
-  return Boolean(parsed && parsedListenersOwnSpecificIpv4WithLoopback(parsed));
 }
 
 /** Checks one PID owns an expected IPv4 interface and canonical loopback. */
@@ -168,10 +146,16 @@ export function isSameProcessSpecificIpv4WithLoopbackListeners(
 
 /** Returns true when listener rows describe a benign Gateway bind pattern. */
 export function isExpectedGatewayListeners(listeners: PortListener[], port: number): boolean {
+  const parsed = parseGatewayListeners(listeners, port);
+  if (!parsed) {
+    return false;
+  }
+  if (parsed.length === 1) {
+    return Boolean(parsed[0] && isExpectedGatewayBindAddress(parsed[0].host));
+  }
   return (
-    isSingleExpectedGatewayListener(listeners, port) ||
-    isDualStackLoopbackGatewayListeners(listeners, port) ||
-    isSpecificIpv4WithLoopbackGatewayListeners(listeners, port)
+    parsedListenersAreDualStackLoopback(parsed) ||
+    (parsed.length === 2 && parsedListenersOwnSpecificIpv4WithLoopback(parsed))
   );
 }
 


### PR DESCRIPTION
## What Problem This Solves

Port diagnostics repeat listener parsing when checking whether a Gateway owns an expected pair of interface and loopback bindings. This adds redundant work to status and diagnostic preparation.

## Why This Change Was Made

Parse the listener facts once at the existing owner, share the dual-stack predicate and remove the single/specific wrapper paths. Specific-IPv4 ownership checks answer existence questions directly instead of constructing Sets and intermediate arrays. The mapped-loopback branch becomes an equivalent equality, and its stale comment now reflects the canonical parser's one-prefix normalization.

Production: **−16 lines**. Tests: **+42 lines**. No discovery, endpoint parsing, process identification, authorization, network or configuration changes. The exact-host and same-PID checks used by the Control UI remain intact.

## User Impact

Less CPU preparation for the measured paired-listener diagnostics, with unchanged booleans and ordered hints. This does not claim faster OS port discovery, authentication, service readiness or whole CLI commands. Some empty/single/control cases cost more.

## Evidence

- 136 tests passed across four complete port/diagnosis/Control UI handoff suites; one Windows-native tasklist CSV case was skipped on macOS. All 29 selected normal checks passed.
- Independent managed P0–P2 review found no actionable findings. New tests cover four mapped-address cases in seven orderings through public predicates and hints.
- Fixed baseline/candidate/candidate/baseline measurements use 23 literal inventories and three distinct operations. Every one of 75,348 returned values matches its full oracle and paired decoded value. There are 70,656 timed operations, 2,208 retained means and 150,696 total direct public-entry calls; those counts are distinct.
- Independent audit recomputed all 414 statistics: 100/138 medians improve, 38 regress; 39 means and 50 maximum batch means also regress. All results remain retained. Timing records are eight means of 32 operations per row, not individual-call durations or tail percentiles.

Specific-interface plus loopback hints→diagnostics improve 38.56%/35.61% (600.250/506.500 ns). Empty direct classification costs 95.047/130.844 ns more; single-IPv4 hints→diagnostics costs 360.688/135.406 ns more. All median pairs are below, including control regressions. Negative percentages mean faster; each cell is forward / reverse, with absolute candidate-minus-baseline ns in parentheses.

<details>
<summary>All fixed-case median comparisons</summary>

| Inventory | Expected listener | Three-predicate tuple | Hints → diagnostics |
|---|---|---|---|
| empty | +107.34% (+95.0) / +136.70% (+130.8) | +218.66% (+252.0) / +254.81% (+260.4) | -12.90% (-18.2) / +5.44% (+8.5) |
| unknown-status | +215.98% (+61.9) / +263.71% (+80.7) | +72.79% (+48.8) / +95.36% (+67.0) | -9.57% (-5.9) / +8.66% (+5.2) |
| single-ipv4 | +8.17% (+46.2) / -4.14% (-24.8) | +30.80% (+150.4) / +8.87% (+43.6) | +55.35% (+360.7) / +21.35% (+135.4) |
| single-ipv6 | +6.62% (+19.5) / +12.12% (+35.8) | -2.20% (-6.5) / -0.22% (-0.7) | -5.18% (-41.0) / +9.92% (+69.7) |
| single-wildcard | +1.48% (+4.5) / +17.89% (+47.5) | -0.01% (-0.0) / -2.27% (-7.2) | +1.17% (+5.2) / -0.56% (-2.6) |
| single-mapped | +1.88% (+5.2) / -13.46% (-42.3) | +2.42% (+7.2) / +1.82% (+5.2) | +4.43% (+18.9) / +69.29% (+298.2) |
| specific-loopback | -31.90% (-396.5) / -13.28% (-170.6) | -49.26% (-1832.0) / -56.64% (-2048.8) | -38.56% (-600.2) / -35.61% (-506.5) |
| specific-reversed | -59.42% (-858.8) / -47.93% (-746.8) | -39.39% (-1156.9) / -41.86% (-1236.3) | -25.73% (-401.0) / -35.43% (-483.0) |
| dual-stack | -8.66% (-52.1) / -0.12% (-0.7) | -30.35% (-675.1) / -16.93% (-381.5) | -11.63% (-134.1) / +0.33% (+3.9) |
| dual-reversed | +34.48% (+207.7) / +13.92% (+73.6) | +7.16% (+130.8) / -8.59% (-132.1) | -0.47% (-3.9) / -1.86% (-15.0) |
| mapped-dual | -1.58% (-9.1) / +15.91% (+86.6) | -5.30% (-87.2) / -6.31% (-102.2) | +19.76% (+169.9) / +15.05% (+113.3) |
| duplicate-family | -54.43% (-640.0) / -44.60% (-473.3) | -39.68% (-961.6) / -28.72% (-578.1) | -13.44% (-326.2) / -21.96% (-554.1) |
| specific-mapped | -27.40% (-299.5) / -42.42% (-451.8) | -20.14% (-422.5) / -39.58% (-921.9) | -25.31% (-385.4) / -33.80% (-503.3) |
| localhost-dual | +24.97% (+117.2) / -7.70% (-36.5) | -6.96% (-99.0) / -3.59% (-44.9) | -4.70% (-35.8) / -8.40% (-68.4) |
| mixed-pids | -38.37% (-349.0) / -41.24% (-334.0) | -17.14% (-256.5) / -29.17% (-456.4) | -26.82% (-551.4) / -27.28% (-582.7) |
| wrong-port | -50.66% (-472.0) / -59.33% (-614.6) | -1.67% (-20.2) / -7.74% (-95.0) | -18.42% (-284.5) / -18.93% (-299.5) |
| missing-pid | -53.31% (-266.9) / -47.89% (-222.0) | +2.31% (+11.1) / -18.15% (-90.5) | -5.41% (-65.8) / -6.04% (-74.9) |
| invalid-address | -48.82% (-187.5) / -47.72% (-177.7) | -25.19% (-155.0) / -32.92% (-210.3) | -12.68% (-160.2) / -16.95% (-217.4) |
| opaque-owner | -49.79% (-231.8) / -53.19% (-265.6) | -12.93% (-123.1) / -16.83% (-166.0) | -16.95% (-144.5) / -31.38% (-347.7) |
| mixed-kinds | +1.74% (+2.6) / -7.75% (-12.4) | -2.36% (-7.2) / +0.46% (+1.3) | -3.14% (-45.6) / -4.77% (-69.0) |
| socat-forward | -48.08% (-65.1) / -47.99% (-61.9) | -27.78% (-170.6) / -12.79% (-77.5) | -7.95% (-87.9) / -10.60% (-129.5) |
| wrong-selected-host | -50.89% (-669.2) / -33.77% (-401.7) | -26.24% (-475.2) / -30.86% (-601.6) | -34.20% (-453.8) / -36.79% (-489.6) |
| eight-mixed-pids | -13.64% (-240.2) / -22.76% (-465.5) | -21.91% (-867.8) / -0.70% (-28.0) | +1.03% (+39.1) / -8.49% (-356.8) |

</details>

Native whole-process wall improves 19.31%/1.78%, including imports, setup and serialization. Resources remain mixed: forward sampled tree RSS +17.01%; reverse native kernel RSS +0.18%, sampled tree RSS +0.91%, system CPU +2.36%. The separately captured Node system CPU also rises 1.13% in reverse order. No general memory benefit or stable latency distribution is claimed.

V8 bytes are retained for integrity and decoded values are compared semantically; serialization bytes are not assumed canonical. The synthetic three-predicate tuple is a sibling check, not an authentication flow. The original source is restored to the candidate after all owned processes close.
