### PR TITLE
refactor(memory-lancedb): share bounded recall orchestration

### DIFF
--- a/extensions/memory-lancedb/auto-recall.ts
+++ b/extensions/memory-lancedb/auto-recall.ts
@@ -5,7 +5,6 @@ import {
   type Embeddings,
   isMemoryRecallTimeoutError,
   MemoryRecallEmbeddingError,
-  runWithTimeout,
 } from "./embeddings.js";
 import type { MemoryDB } from "./lancedb-store.js";
 import { dropMediaNoteLines } from "./memory-capture-sanitization.js";
@@ -15,6 +14,7 @@ import {
   formatRelevantMemoriesContext,
   normalizeRecallQuery,
 } from "./memory-policy.js";
+import { startMemoryRecall } from "./recall-service.js";
 
 const AUTO_RECALL_TIMEOUT_MS = 15_000;
 const AUTO_RECALL_OVERFETCH_LIMIT = 10;
@@ -84,34 +84,19 @@ export function createAutoRecallHook(params: {
       if (!recallQuery) {
         return undefined;
       }
-      let recallPhase: "embedding" | "search" = "embedding";
       toolAuthority.assertActive();
-      const recall = await runWithTimeout({
+      const recallOperation = startMemoryRecall({
         timeoutMs: AUTO_RECALL_TIMEOUT_MS,
-        task: async (deadlineAtMs) => {
-          let vector: number[];
-          try {
-            vector = await params.embeddings.embed(
-              agentId,
-              recallQuery,
-              currentCfg.embedding,
-              Math.max(1, deadlineAtMs - Date.now()),
-            );
-          } catch (error) {
-            throw new MemoryRecallEmbeddingError(error);
-          }
-          toolAuthority.assertActive();
-          // Keep one end-to-end deadline, but only let embedding timeouts trip
-          // the shared breaker. LanceDB stalls remain retryable next turn.
-          recallPhase = "search";
-          return await params.db.search(agentId, vector, AUTO_RECALL_OVERFETCH_LIMIT, 0.3, {
-            timeoutMs: Math.max(0, deadlineAtMs - Date.now()),
-          });
-        },
+        embed: (timeoutMs) =>
+          params.embeddings.embed(agentId, recallQuery, currentCfg.embedding, timeoutMs()),
+        beforeSearch: () => toolAuthority.assertActive(),
+        search: (vector, timeoutMs) =>
+          params.db.search(agentId, vector, AUTO_RECALL_OVERFETCH_LIMIT, 0.3, { timeoutMs }),
       });
+      const recall = await recallOperation.result;
       toolAuthority.assertActive();
       if (recall.status === "timeout") {
-        if (recallPhase === "embedding") {
+        if (recallOperation.phase === "embedding") {
           params.recordCooldown(
             agentId,
             `auto-recall timed out after ${Math.round(AUTO_RECALL_TIMEOUT_MS / 1000)}s`,

--- a/extensions/memory-lancedb/index.ts
+++ b/extensions/memory-lancedb/index.ts
@@ -26,9 +26,8 @@ import {
   createEmbeddings,
   isMemoryRecallTimeoutError,
   MemoryRecallEmbeddingError,
-  runWithTimeout,
 } from "./embeddings.js";
-import { MemoryDB, type MemoryEntry, type MemorySearchResult } from "./lancedb-store.js";
+import { MemoryDB, type MemoryEntry } from "./lancedb-store.js";
 import { sanitizeForMemoryCapture } from "./memory-capture-sanitization.js";
 import { registerMemoryCli } from "./memory-cli.js";
 import {
@@ -44,6 +43,7 @@ import {
   prepareAutoCaptureMessages,
   shouldCapture,
 } from "./memory-policy.js";
+import { startMemoryRecall } from "./recall-service.js";
 
 const loadMemoryHostCoreModule = createLazyRuntimeModule(
   () => import("openclaw/plugin-sdk/memory-host-core"),
@@ -260,33 +260,23 @@ export default definePluginEntry({
             if (cooldown) {
               return buildMemoryRecallUnavailableResult(cooldown.error);
             }
-            let recallPhase: "embedding" | "search" = "embedding";
-            let recall: Awaited<ReturnType<typeof runWithTimeout<MemorySearchResult[]>>>;
+            const recallOperation = startMemoryRecall({
+              timeoutMs: DEFAULT_TOOL_RECALL_TIMEOUT_MS,
+              embed: (timeoutMs) =>
+                embeddings.embed(
+                  agentId,
+                  normalizeRecallQuery(query, recallMaxChars),
+                  currentCfg.embedding,
+                  timeoutMs(),
+                ),
+              search: (vector, timeoutMs) =>
+                db.search(agentId, vector, limit + DEFAULT_TOOL_RECALL_OVERFETCH_EXTRA, 0.1, {
+                  timeoutMs,
+                }),
+            });
+            let recall: Awaited<typeof recallOperation.result>;
             try {
-              recall = await runWithTimeout({
-                timeoutMs: DEFAULT_TOOL_RECALL_TIMEOUT_MS,
-                task: async (deadlineAtMs) => {
-                  let vector: number[];
-                  try {
-                    vector = await embeddings.embed(
-                      agentId,
-                      normalizeRecallQuery(query, recallMaxChars),
-                      currentCfg.embedding,
-                      Math.max(1, deadlineAtMs - Date.now()),
-                    );
-                  } catch (error) {
-                    throw new MemoryRecallEmbeddingError(error);
-                  }
-                  recallPhase = "search";
-                  return await db.search(
-                    agentId,
-                    vector,
-                    limit + DEFAULT_TOOL_RECALL_OVERFETCH_EXTRA,
-                    0.1,
-                    { timeoutMs: Math.max(0, deadlineAtMs - Date.now()) },
-                  );
-                },
-              });
+              recall = await recallOperation.result;
             } catch (error) {
               if (!(error instanceof MemoryRecallEmbeddingError)) {
                 throw error;
@@ -302,7 +292,7 @@ export default definePluginEntry({
             }
             if (recall.status === "timeout") {
               const message = `memory_recall timed out after ${Math.round(DEFAULT_TOOL_RECALL_TIMEOUT_MS / 1000)}s`;
-              if (recallPhase === "embedding") {
+              if (recallOperation.phase === "embedding") {
                 recordMemoryRecallCooldown(agentId, message);
               }
               api.logger.warn?.(

--- a/extensions/memory-lancedb/recall-service.ts
+++ b/extensions/memory-lancedb/recall-service.ts
@@ -1,0 +1,34 @@
+import { MemoryRecallEmbeddingError, runWithTimeout } from "./embeddings.js";
+import type { MemorySearchResult } from "./lancedb-store.js";
+
+/** Run embedding and search under one deadline; callers retain cooldown and result policy. */
+export function startMemoryRecall(params: {
+  timeoutMs: number;
+  /** Read the remaining budget after caller-side query preparation, just before dispatch. */
+  embed: (timeoutMs: () => number) => Promise<number[]>;
+  search: (vector: number[], timeoutMs: number) => Promise<MemorySearchResult[]>;
+  beforeSearch?: () => void;
+}) {
+  let phase: "embedding" | "search" = "embedding";
+  const result = runWithTimeout({
+    timeoutMs: params.timeoutMs,
+    task: async (deadlineAtMs) => {
+      let vector: number[];
+      try {
+        vector = await params.embed(() => Math.max(1, deadlineAtMs - Date.now()));
+      } catch (error) {
+        throw new MemoryRecallEmbeddingError(error);
+      }
+      params.beforeSearch?.();
+      phase = "search";
+      return await params.search(vector, Math.max(0, deadlineAtMs - Date.now()));
+    },
+  });
+  return {
+    result,
+    // Read the live phase after the caller's post-await authority check.
+    get phase(): "embedding" | "search" {
+      return phase;
+    },
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Automatic and explicit LanceDB memory recall independently own the same embedding/search deadline and timeout-phase tracking. Changes to that sequence can drift between the two paths and incorrectly suppress later recall after a database stall.

## Why This Change Was Made

A plugin-local recall service owns the absolute deadline, embedding-error boundary, pre-search callback, and live phase. Both callers retain their query preparation, authority checks, per-agent cooldown policy, score thresholds, result limits, and error/output formatting.

The operation returns the original timeout promise and a live phase getter so late settlement and the hook's post-await authority check keep their ordering. The embedding callback reads its remaining budget immediately before dispatch, after query normalization.

## User Impact

No intended behavior change. Only embedding timeouts open the shared per-agent cooldown; database timeouts remain retryable. The tool retains its default five-result cap and 0.1 minimum score, while automatic recall retains its three-result cap and 0.3 threshold. No config, public SDK export, embedding transport, vector identity, storage schema, or persistence policy changes.

The shared owner adds 34 lines and removes 25 net lines from the callers: production grows by 9 lines. That bounded tradeoff centralizes deadline and phase ownership while preserving the two callers' different authority and error handling.

## Evidence

`node scripts/run-vitest.mjs extensions/memory-lancedb/index.test.ts extensions/memory-lancedb/embeddings.lifecycle.test.ts extensions/memory-lancedb/lancedb-store.test.ts`: **204 passed** (18.90s). Independent autoreview is clean through P3. Existing registered-hook and explicit-tool cases cover query preparation, limits, authority, and unavailable results. The sequence case “shares only embedding timeout cooldown across recall paths” covers cooldown sharing, expiry, SDK timeouts, retryable database stalls, and fast provider failures. No test is added or split for this behavior-preserving extraction.

`node scripts/check-changed.mjs` passed its preceding guards, extension production/test types, and all three dead-export scans. Extension lint preparation stopped solely at the documented nested-checkout `Declaration input escapes checkout` guard for an ancestor `node_modules/punycode` manifest. No guard or ancestor install was changed; hosted CI has now passed this boundary. `pnpm build` passed in **5m22.5s**, including plugin bundles and declarations.

The commit rebased patch-identically onto `02fb5fce1e3`; the intervening update-schema fix changes none of the recall or timeout owners. No public export is removed or renamed.

Exact-head [CI run 34134352109](https://github.com/openclaw/openclaw/actions/runs/34134352109) passed for `cc27ae18b928aba2ccbc16a05095b49203a8ea4a`; no rerun was needed.

### Data-model compatibility proof

ClawSweeper found no code/security defect and requested migration compatibility confirmation based on the memory paths. This extraction changes no persisted data model. The exact base-to-head diff leaves `lancedb-store.ts`, `embeddings.ts`, `config.ts`, `doctor-contract-api.ts`, the plugin manifest, and package manifest byte-identical. The changes in `index.ts` are limited to imports and the read-only `memory_recall` sequence; store, forget, auto-capture, service teardown, live configuration, and vector-identity handling are unchanged.

The service calls the same embedding and database-search operations with the same agent, vector, count, score threshold, and remaining deadline. It adds no stored row/field, retention, migration, transaction, index, recovery, vector normalization, or embedding metadata change. No upgrade migration is applicable. The passing native-store suite covers agent-scoped store/search/list/delete/restart, rejection of incompatible persisted vector dimensions, refusal of legacy unscoped rows pending Doctor migration, and native search timeout cancellation with continued table use. These four real-storage cases are included in the 204 passing tests; hosted CI also passed.
