### PR TITLE
docs: clarify what Read Only permission mode governs

### DIFF
--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5371,7 +5371,8 @@ export const en: TranslationMap & {
       modes: {
         "read-only": {
           label: "Read Only",
-          description: "Read within the session root; writes and commands are blocked.",
+          description:
+            "Agent tools can read within the session root, but cannot write or run commands.",
         },
         guarded: {
           label: "Guarded",


### PR DESCRIPTION
## What Problem This Solves

The Read Only picker describes filesystem and command restrictions without naming their scope. It can read more broadly than the permission-mode documentation, which describes OpenClaw-managed agent tools.

## Why This Change Was Made

Clarifies the existing English description: “Agent tools can read within the session root, but cannot write or run commands.” The mode key, other descriptions, selection behavior, and permission enforcement stay unchanged. Generated translations remain with the existing locale workflow.

## User Impact

Operators can see what Read Only governs without implying that it revokes separate durable widget capabilities or changes independently controlled native-harness tools.

## Evidence

- Captured the official Control UI with its maintained mock Gateway before and after the change at 1280×960 and 390×844. The full description wraps cleanly in the existing picker.
- Selected and reopened Read Only, Guarded, Workspace, Full Access, and Default on both versions. The displayed selections and `sessions.patch` values remain unchanged; Default clears the override.
- All 54 existing permission-control and localization tests passed.
- Keyless localization verification, the source-copy baseline check, targeted formatting, syntax and boundary lint, and the normal native pre-commit hook passed.
- The integrated commit preserves the contributor's ancestry. Its tree exactly matches the source used for the browser captures and native checks.

Browser evidence verifies the real renderer, picker interactions, and mock Gateway requests. Unchanged source establishes the permission-enforcement scope; these mock runs do not claim live filesystem enforcement or database durability. The contributor's original before/after screenshots remain in the discussion.
