### PR TITLE
refactor(skills): share ordered array equality

### DIFF
--- a/src/skills/runtime/ordered-array-equality.ts
+++ b/src/skills/runtime/ordered-array-equality.ts
@@ -1,0 +1,6 @@
+export const areOrderedArraysEqual = <T>(
+  left: readonly T[],
+  right: readonly T[],
+  equals: (left: T, right: T) => boolean,
+): boolean =>
+  left.length === right.length && left.every((value, index) => equals(value, right[index]!));

--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -21,6 +21,7 @@ import {
   tryRealpath,
 } from "../loading/symlink-targets.js";
 import { createWorkshopWatcherKey, resolveWorkshopWatchRoots } from "../workshop/skills-root.js";
+import { areOrderedArraysEqual } from "./ordered-array-equality.js";
 import {
   bumpSkillsSnapshotVersion,
   clearSkillsSnapshotVersionForWorkspace,
@@ -477,20 +478,6 @@ function resolveSkillsWatcherUsePolling(): boolean {
   return Boolean(normalized) && normalized !== "false" && normalized !== "0";
 }
 
-// Requires resolveWatchTargets to produce a stable-order result (it returns a
-// sorted array); positional comparison is intentional for hot-path efficiency.
-function sameWatchTargets(a: WatchTarget[], b: WatchTarget[]): boolean {
-  return (
-    a.length === b.length &&
-    a.every(
-      (target, index) =>
-        target.path === b[index]?.path &&
-        target.watchRoot === b[index]?.watchRoot &&
-        target.depth === b[index]?.depth,
-    )
-  );
-}
-
 function createSkillsPathWatcher(target: WatchTarget): SkillsPathWatchState {
   const usePolling = resolveSkillsWatcherUsePolling();
   // Chokidar's missing-root fallback retains only the final basename, so it
@@ -730,7 +717,15 @@ export function ensureSkillsWatcher(params: {
     watcherKey,
     params.pluginMetadataSnapshot,
   );
-  const targetsUnchanged = sameWatchTargets(previousTargets, watchTargets);
+  // resolveWatchTargets returns stable sorted order, so positional equality is intentional.
+  const targetsUnchanged = areOrderedArraysEqual(
+    previousTargets,
+    watchTargets,
+    (previous, next) =>
+      previous.path === next.path &&
+      previous.watchRoot === next.watchRoot &&
+      previous.depth === next.depth,
+  );
   const watcherDepthsCoverTargets = watchTargets.every(
     (watchTarget) => (pathWatchers.get(watchTarget.path)?.depth ?? -1) >= watchTarget.depth,
   );

--- a/src/skills/runtime/remote-skills.test.ts
+++ b/src/skills/runtime/remote-skills.test.ts
@@ -303,7 +303,7 @@ metadata:
     expect(warningText).toContain("BAD_INDENT");
   });
 
-  it("replaces a node catalog and invalidates the snapshot", () => {
+  it("replaces a changed node catalog without invalidating an identical catalog", () => {
     recordRemoteSkillNodeInfo({
       nodeId: "node-1",
       connId: "conn-1",
@@ -314,6 +314,12 @@ metadata:
       skills: [{ name: "first", description: "First", content: content("first", "First") }],
     });
     const firstVersion = getSkillsSnapshotVersion();
+
+    replaceRemoteNodeSkills({
+      nodeId: "node-1",
+      skills: [{ name: "first", description: "First", content: content("first", "First") }],
+    });
+    expect(getSkillsSnapshotVersion()).toBe(firstVersion);
 
     replaceRemoteNodeSkills({
       nodeId: "node-1",

--- a/src/skills/runtime/remote-skills.ts
+++ b/src/skills/runtime/remote-skills.ts
@@ -4,6 +4,7 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { resolveNodeIdFromNodeList } from "../../shared/node-resolve.js";
 import { parseSkillFrontmatter, resolveSkillInvocationPolicy } from "../loading/frontmatter.js";
 import type { ParsedSkillFrontmatter, SkillEntry } from "../types.js";
+import { areOrderedArraysEqual } from "./ordered-array-equality.js";
 import { bumpSkillsSnapshotVersion } from "./refresh-state.js";
 
 type PreparedNodeSkill = NodeSkillDescriptor & {
@@ -58,21 +59,6 @@ function prepareNodeSkills(
   return prepared;
 }
 
-function sameSkills(
-  left: readonly PreparedNodeSkill[],
-  right: readonly PreparedNodeSkill[],
-): boolean {
-  return (
-    left.length === right.length &&
-    left.every(
-      (skill, index) =>
-        skill.name === right[index]?.name &&
-        skill.description === right[index]?.description &&
-        skill.content === right[index]?.content,
-    )
-  );
-}
-
 export function recordRemoteSkillNodeInfo(node: {
   nodeId: string;
   connId?: string;
@@ -110,7 +96,14 @@ export function replaceRemoteNodeSkills(params: {
   const changed =
     !existing?.connected ||
     existing.displayName !== params.displayName ||
-    !sameSkills(existing.skills, nextSkills);
+    !areOrderedArraysEqual(
+      existing.skills,
+      nextSkills,
+      (previous, next) =>
+        previous.name === next.name &&
+        previous.description === next.description &&
+        previous.content === next.content,
+    );
   remoteSkillNodes.set(params.nodeId, {
     nodeId: params.nodeId,
     connId: existing?.connId,


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Maintainer-authored branch; edits by maintainers are allowed.

</details>

## What Problem This Solves

Skills watcher reconciliation and remote node skill catalogs maintained separate copies of ordered array equality logic. Keeping those implementations separate made their length and ordering semantics easier to drift while both paths control snapshot invalidation.

## Why This Change Was Made

Adds one private skills-runtime comparator for ordered, length-sensitive arrays. Watch targets still compare `path`, `watchRoot`, and `depth`; remote skills still compare `name`, `description`, and `content`. No public API, SDK, storage, protocol, configuration, or security behavior changes.

## User Impact

No user-visible behavior changes. Identical watcher targets and remote skill catalogs continue to avoid unnecessary snapshot invalidation, with one owner-local implementation of the shared comparison contract.

## Evidence

- Focused watcher and remote-skill tests: 52 passed.
- Added coverage proving an identical ordered remote catalog does not bump the skills snapshot version.
- Targeted Oxc lint and `git diff --check`: passed.
- `check:changed` passed all gates through the core typecheck step; local typecheck correctly stopped because the task worktree uses externally symlinked dependencies. Hosted exact-head CI/Testbox supplied physical-checkout proof.
- Exact-head run `34134643743` first failed only `checks-node-compact-small-31` job `101782886419`: `test/openai-model-discovery-auth-order.test.ts` timed out at 120000 ms in `retains the chutes catalog when all 1 OAuth profiles fail preparation`, while the other 1,124 shard tests passed.
- The exact failing test and case passed unchanged on then-current `main` at `43bc88f6f78410b86548ac29ec3f13a762481ae9` in 82.089 seconds, confirming an unrelated load-sensitive timeout.
- Only the failed surface was retried. Attempt 2 job `101791982104` passed, and exact-head run `34134643743` completed successfully at `df2f190d84f09495931f499e505ce8041f019950`.
- Scoped autoreview and ClawSweeper: clean, no findings.
- Production delta: 25 additions, 31 deletions (net -6).
