### PR TITLE
fix(gateway): trim node.pair approve/reject requestId

### DIFF
--- a/src/gateway/server-methods/nodes.pairing.ts
+++ b/src/gateway/server-methods/nodes.pairing.ts
@@ -232,7 +232,7 @@ export const nodePairingHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateNodePairApproveParams, "node.pair.approve", respond)) {
       return;
     }
-    const { requestId } = params;
+    const requestId = params.requestId.trim();
     // Intentionally fail closed for RPC callers without an explicit scoped session.
     const callerScopes = Array.isArray(client?.connect?.scopes) ? client.connect.scopes : [];
     await respondUnavailableOnThrow(respond, async () => {
@@ -334,7 +334,7 @@ export const nodePairingHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateNodePairRejectParams, "node.pair.reject", respond)) {
       return;
     }
-    const { requestId } = params;
+    const requestId = params.requestId.trim();
     await respondUnavailableOnThrow(respond, async () => {
       if (
         !(await enforcePendingNodePairingOwnership({

--- a/src/gateway/server.node-pairing-authz.test.ts
+++ b/src/gateway/server.node-pairing-authz.test.ts
@@ -596,6 +596,40 @@ describe("gateway node pairing authorization", () => {
       }
     });
 
+    test("approves a pending node pair when requestId has clipboard padding", async () => {
+      const victimNodeId = "node-padded-request-id-victim";
+      const request = await requestVictimNodeSurface(victimNodeId);
+      const operator = await issueOperatorToken({
+        name: "node-padded-request-id-operator",
+        approvedScopes: ["operator.pairing", "operator.write"],
+      });
+
+      const ws = await openTrackedWs(getStarted().port);
+      try {
+        await connectOk(ws, {
+          token: "secret",
+          deviceIdentityPath: operator.identityPath,
+          scopes: ["operator.pairing", "operator.write"],
+        });
+
+        const approve = await rpcReq(ws, "node.pair.approve", {
+          requestId: `  ${request.request.requestId}  `,
+        });
+        expect(approve.ok).toBe(true);
+        expect(approve.payload).toEqual(
+          expect.objectContaining({
+            requestId: request.request.requestId,
+            node: expect.objectContaining({ nodeId: victimNodeId }),
+          }),
+        );
+        await expect(findPairedNode(victimNodeId)).resolves.toMatchObject({
+          commands: [NODE_MCP_TOOLS_CALL_COMMAND],
+        });
+      } finally {
+        ws.close();
+      }
+    });
+
     test("allows an admin device-token session to manage another device's node surface", async () => {
       const victimNodeId = "node-admin-device-victim";
       const request = await requestVictimNodeSurface(victimNodeId);


### PR DESCRIPTION
## What Problem This Solves

`node.pair.approve` and `node.pair.reject` passed `params.requestId` through without
trimming. Schema validation only requires a non-empty string, so clipboard padding
like `" req-… "` validated but missed the pending pairing key and returned
`unknown requestId`. Sibling handlers already trim: `gateway.suspend.prepare` trims
`requestId`, and device waitUpgrade / suspend follow the same contract. #110848
covers `device.pair` only.

## Why This Change Was Made

Trim `requestId` once at the start of both handlers after validation, then use the
trimmed id for ownership enforcement, pending lookup, approve/reject, and broadcast.
No schema or stored-key change.

## User Impact

**Before:** Approving/rejecting with `" req-… "` failed as unknown even when the
pending pair existed.

**After:** Surrounding whitespace is ignored; the pending pairing key still matches.

## Evidence

- Changed: `src/gateway/server-methods/nodes.pairing.ts`,
  `src/gateway/server-methods/nodes.test.ts`,
  `src/gateway/server.node-pairing-authz.test.ts`
- Production path: `nodePairingHandlers["node.pair.approve"|"node.pair.reject"]`
  → `requestId.trim()` → `enforcePendingNodePairingOwnership` /
  `approveNodePairing` / `rejectNodePairing`
- Sibling: `src/gateway/server-methods/suspend.ts` (`gateway.suspend.prepare`
  trims `requestId`); device waitUpgrade / #110848 device.pair

## Real behavior proof

- **Behavior or issue addressed:** Padded `node.pair.approve` `requestId` missed the
  pending node-pairing key on a live Gateway.
- **Canonical reachability path:** live Gateway plant pending node pair →
  `node.pair.approve` with `{ requestId: \` ${id} \` }` → pending resolves approved.
- **Boundary crossed:** Gateway RPC param normalization before pending-store lookup
  on a real in-process Gateway (`installGatewayTestHooks` +
  `describeWithGatewayServer`).
- **Shared helper / provider constraint check:** No new helper; matches existing
  suspend prepare / device waitUpgrade trim contract. Callers pass the trimmed id
  into `enforcePendingNodePairingOwnership` → `getPendingNodePairing`.
- **Real environment tested:** Local Vitest live Gateway harness under an isolated
  worktree state dir, not a mocked pairing store for the live case. Unit regressions
  exercise the real handlers against the real pairing store under test state.
- **Exact steps or command run after this patch:**

```text
$ node scripts/run-vitest.mjs src/gateway/server-methods/nodes.test.ts src/gateway/server.node-pairing-authz.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
 ✓ |gateway-server| src/gateway/server.node-pairing-authz.test.ts > gateway node pairing authorization > cross-device management guard > approves a pending node pair when requestId has clipboard padding 101ms
 ✓ |gateway-methods| src/gateway/server-methods/nodes.test.ts > nodeHandlers node.pair.approve > approves a pending request when requestId has clipboard padding 100ms
 ✓ |gateway-methods| src/gateway/server-methods/nodes.test.ts > nodeHandlers node.pair.reject > rejects a pending request when requestId has clipboard padding 122ms

 Test Files  2 passed (2)
      Tests  43 passed (43)
   Start at  22:22:00
   Duration  66.59s (transform 48%, tests 40%, import 7%, worker 4%)

[test] passed 1 Vitest shard in 72.97s
```

- **Observed result after fix:** Live `node.pair.approve` with
  `{ requestId: \` ${pending.requestId} \` }`succeeds and returns the trimmed`requestId` with the paired node. Unit approve/reject handlers succeed against the
  real pairing store with the same padding.
- **What was not tested:** Manual Control UI clipboard paste against an
  operator-managed Gateway process; live padded `node.pair.reject` RPC (covered by
  unit handler + real store).
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
