### PR TITLE
fix(gateway): flush plugin HTTP upgrade rejects before destroy

### DIFF
--- a/src/gateway/server/plugins-http.test.ts
+++ b/src/gateway/server/plugins-http.test.ts
@@ -560,6 +560,34 @@ describe("createGatewayPluginUpgradeHandler", () => {
     expect(socket.destroyed).toBe(false);
     expect(socket.chunks).toStrictEqual([]);
   });
+
+  it("flushes HTTP 503 before destroy when handleUpgrade throws", async () => {
+    const handler = createGatewayPluginUpgradeHandler({
+      registry: createGatewayTestRegistry({
+        httpRoutes: [
+          createRoute({
+            path: "/plugin/ws",
+            auth: "plugin",
+            handleUpgrade: async () => {
+              throw new Error("upgrade boom");
+            },
+          }),
+        ],
+      }),
+      log: createPluginLog(),
+    });
+    const socket = createMockUpgradeSocket();
+
+    const handled = await handler(
+      { url: "/plugin/ws" } as IncomingMessage,
+      socket,
+      Buffer.alloc(0),
+    );
+
+    expect(handled).toBe(true);
+    expect(socket.chunks.join("")).toContain("HTTP/1.1 503");
+    expect(socket.destroyed).toBe(true);
+  });
 });
 
 describe("plugin HTTP route auth checks", () => {

--- a/src/gateway/server/plugins-http.ts
+++ b/src/gateway/server/plugins-http.ts
@@ -357,7 +357,7 @@ export function createGatewayPluginUpgradeHandler(params: {
         }
       } catch (err) {
         log.warn(`plugin http upgrade failed (${route.pluginId ?? "unknown"}): ${String(err)}`);
-        socket.destroy();
+        rejectWebSocketUpgrade(socket, { status: 503 });
         return true;
       }
     }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where clients upgrading to a plugin HTTP WebSocket route would see an abrupt TCP disconnect when `handleUpgrade` threw, instead of a readable HTTP rejection status. The upgrade failure catch path called `socket.destroy()` without flushing any HTTP response bytes.

## Why This Change Was Made

Replace the bare `socket.destroy()` in `createGatewayPluginUpgradeHandler`'s upgrade failure catch with the shared `rejectWebSocketUpgrade(socket, { status: 503 })` helper already used by sibling auth-reject paths in the same file and by voice-call realtime upgrade failures. That helper ends the socket only after the rejection bytes flush (`socket.end(..., () => destroy())`).

Non-goals: no change to auth rejection status codes (still 401), route matching, or successful upgrade dispatch.

## User Impact

**Before:** A plugin `handleUpgrade` throw destroyed the socket with no HTTP status line, so clients could only observe a hard disconnect.

**After:** The same failure path flushes `HTTP/1.1 503 Service Unavailable` before destroy, matching other gateway/plugin upgrade reject paths.

## Evidence

- Production caller: `src/gateway/server/plugins-http.ts` `createGatewayPluginUpgradeHandler` catch now calls `rejectWebSocketUpgrade(socket, { status: 503 })`.
- Sibling already correct in same file: auth-blocked upgrades use `rejectWebSocketUpgrade(..., { status: 401 })`.
- Shared helper contract: `src/shared/websocket-upgrade-reject.ts` documents flush-before-destroy; status union allows `503` (not `500`).
- Sibling 503 usage: `extensions/voice-call/src/webhook/realtime-handler.ts` uses `rejectWebSocketUpgrade(socket, { status: 503 })` for similar failures.
- Unit regression: `src/gateway/server/plugins-http.test.ts` under `createGatewayPluginUpgradeHandler` asserts handled=true, chunks contain `HTTP/1.1 503`, and `destroyed === true` when `handleUpgrade` throws.
- Real TCP transport: `src/gateway/server/plugins-http.upgrade-transport.test.ts` binds a real `http.Server`, wires `createGatewayPluginUpgradeHandler` with a throwing `handleUpgrade`, connects via `net.createConnection` with a raw WebSocket upgrade request, and asserts the TCP response contains `HTTP/1.1 503` before socket close.

## Real behavior proof

- **Behavior or issue addressed:** Plugin HTTP upgrade handler failure destroyed the socket without flushing an HTTP rejection response.
- **Canonical reachability path:** `createGatewayPluginUpgradeHandler` → matched route `handleUpgrade` throws → catch → `rejectWebSocketUpgrade(..., { status: 503 })`.
- **Boundary crossed:** Gateway plugin upgrade dispatch failure → shared websocket upgrade reject helper → real Node `http.Server` upgrade event → TCP client bytes.
- **Shared helper / provider constraint check:** Reused `rejectWebSocketUpgrade` from `src/shared/websocket-upgrade-reject.ts`; no new helper; status `503` is in the helper's status union.
- **Real environment tested:** Local Vitest with a real `http.Server` listening on `127.0.0.1`, real `net.createConnection` client sending a raw WebSocket upgrade request, and production `createGatewayPluginUpgradeHandler` whose matched route `handleUpgrade` throws.
- **Exact steps or command run after this patch:**

```text
$ node scripts/run-vitest.mjs src/gateway/server/plugins-http.upgrade-transport.test.ts -t '503' --reporter=verbose
```

- **Evidence after fix:**

```text
 ✓ |gateway-core| src/gateway/server/plugins-http.upgrade-transport.test.ts > plugin HTTP upgrade transport > flushes HTTP 503 on a real TCP upgrade when handleUpgrade throws 14ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Start at  22:57:07
   Duration  7.42s (transform 86%, import 11%, worker 3%)

[test] passed 1 Vitest shard in 8.96s
```

- **Observed result after fix:** When `handleUpgrade` throws on a real TCP upgrade, the client receives `HTTP/1.1 503` response bytes before the socket closes (not a silent disconnect).
- **What was not tested:** Live browser/plugin WebSocket clients against a full Gateway under network buffering; auth-reject paths (already covered by sibling tests).
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
