### PR TITLE
fix(googlechat): cancel certs response body on non-OK

### DIFF
--- a/extensions/googlechat/src/auth.cancel.transport.test.ts
+++ b/extensions/googlechat/src/auth.cancel.transport.test.ts
@@ -1,0 +1,112 @@
+// Prove fetchChatCerts cancels an unread non-OK Response body before throwing.
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetchWithSsrFGuard: vi.fn(),
+  verifySignedJwtWithCertsAsync: vi.fn(),
+}));
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>();
+  return {
+    ...actual,
+    fetchWithSsrFGuard: mocks.fetchWithSsrFGuard,
+  };
+});
+
+vi.mock("./google-auth.runtime.js", () => ({
+  loadGoogleAuthRuntime: vi.fn().mockResolvedValue({
+    OAuth2Client: class {
+      verifySignedJwtWithCertsAsync = mocks.verifySignedJwtWithCertsAsync;
+    },
+  }),
+  getGoogleAuthTransport: vi.fn().mockResolvedValue({}),
+  resolveValidatedGoogleChatCredentials: vi.fn().mockResolvedValue(null),
+}));
+
+const { verifyGoogleChatRequest } = await import("./auth.js");
+
+let googleChatCertFetchNowMs = Date.now();
+
+function expireGoogleChatCertCache(): void {
+  googleChatCertFetchNowMs += 11 * 60 * 1000;
+  vi.spyOn(Date, "now").mockReturnValue(googleChatCertFetchNowMs);
+}
+
+function createNonOkCertResponse(status: number) {
+  let canceled = false;
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        // Keep the body unread until cancel; enqueue once so the stream is live.
+        controller.enqueue(new TextEncoder().encode("unavailable"));
+      },
+      cancel() {
+        canceled = true;
+      },
+    }),
+    {
+      status,
+      statusText: "Service Unavailable",
+      headers: { "content-type": "application/json" },
+    },
+  );
+  return {
+    response,
+    get canceled() {
+      return canceled;
+    },
+  };
+}
+
+afterEach(() => {
+  mocks.fetchWithSsrFGuard.mockReset();
+  mocks.verifySignedJwtWithCertsAsync.mockReset();
+  vi.restoreAllMocks();
+});
+
+afterAll(() => {
+  vi.doUnmock("openclaw/plugin-sdk/ssrf-runtime");
+  vi.doUnmock("./google-auth.runtime.js");
+  vi.resetModules();
+});
+
+describe("Google Chat cert fetch non-OK body cancel", () => {
+  it("cancels the unread cert Response body when status is non-OK", async () => {
+    expireGoogleChatCertCache();
+    const streamed = createNonOkCertResponse(503);
+    const release = vi.fn(async () => {});
+    mocks.fetchWithSsrFGuard.mockResolvedValueOnce({
+      response: streamed.response,
+      release,
+    });
+
+    const result = await verifyGoogleChatRequest({
+      bearer: "token",
+      audienceType: "project-number",
+      audience: "123456789",
+    });
+
+    // Allow fire-and-forget cancel() to settle on the real ReadableStream.
+    await new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      reason: "Failed to fetch Chat certs (503)",
+    });
+    expect(streamed.canceled).toBe(true);
+    expect(mocks.verifySignedJwtWithCertsAsync).not.toHaveBeenCalled();
+    expect(release).toHaveBeenCalledOnce();
+    expect(mocks.fetchWithSsrFGuard).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: "https://www.googleapis.com/service_accounts/v1/metadata/x509/chat@system.gserviceaccount.com",
+        auditContext: "googlechat.auth.certs",
+      }),
+    );
+    console.log(
+      `[googlechat certs non-ok cancel proof] canceled=${streamed.canceled} status=503 reason=${result.reason}`,
+    );
+  });
+});

--- a/extensions/googlechat/src/auth.ts
+++ b/extensions/googlechat/src/auth.ts
@@ -120,6 +120,9 @@ async function fetchChatCerts(): Promise<Record<string, string>> {
   });
   try {
     if (!response.ok) {
+      // Non-OK cert responses leave an unread body; cancel before throw so the
+      // guarded dispatcher can release without retaining the stream (matches api.ts).
+      void response.body?.cancel().catch(() => undefined);
       throw new Error(`Failed to fetch Chat certs (${response.status})`);
     }
     const certs = await readGoogleChatCertsResponse(response);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Google Chat webhook auth could leave an unread Chat certs response body open when `fetchChatCerts` threw on a non-OK HTTP status. The guarded fetch dispatcher then released without cancelling the stream, matching a hole already closed on the sibling Google Chat API path.

## Why This Change Was Made

On `!response.ok`, cancel the unread body with `void response.body?.cancel().catch(() => undefined)` before throwing, matching `extensions/googlechat/src/api.ts` best-effort cancel-before-release. Does not change the auth error surface (`Failed to fetch Chat certs (<status>)`).

## User Impact

**Before:** A non-OK Chat certs fetch threw while retaining an unread response stream until GC.

**After:** The unread non-OK body is cancelled before the throw; `release()` still runs in `finally`.

## Evidence

### Proof (exit 0)

```bash
node scripts/run-vitest.mjs extensions/googlechat/src/auth.cancel.transport.test.ts --reporter=verbose
```

```text
stdout | extensions/googlechat/src/auth.cancel.transport.test.ts > Google Chat cert fetch non-OK body cancel > cancels the unread cert Response body when status is non-OK
[googlechat certs non-ok cancel proof] canceled=true status=503 reason=Failed to fetch Chat certs (503)

 ✓ |extension-messaging| extensions/googlechat/src/auth.cancel.transport.test.ts > Google Chat cert fetch non-OK body cancel > cancels the unread cert Response body when status is non-OK 11ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

## Real behavior proof

- **Behavior or issue addressed:** Non-OK Chat certs responses cancel their unread `Response` body before `fetchChatCerts` throws, so webhook auth does not retain the stream.
- **Canonical reachability path:** `verifyGoogleChatRequest` (`audienceType: "project-number"`) → `fetchChatCerts` → `fetchWithSsrFGuard` → `!response.ok` → `response.body.cancel()` → throw → `release()`.
- **Boundary crossed:** Unread non-OK HTTP body stream → `body.cancel()` before throw; regression tracks a real `ReadableStream` `cancel()` callback (`canceled=true`).
- **Shared helper / provider constraint check:** Same `void response.body?.cancel().catch(() => undefined)` pattern as `withGoogleChatResponse` in `extensions/googlechat/src/api.ts`.
- **Real environment tested:** Local Vitest in worktree `/tmp/oc-pr5/googlechat-cancel` on branch `fix/googlechat-certs-cancel-body` (Node Response + ReadableStream cancel tracking; `fetchWithSsrFGuard` stubbed to return the tracked Response).
- **Exact steps or command run after this patch:**

```bash
node scripts/run-vitest.mjs extensions/googlechat/src/auth.cancel.transport.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
[googlechat certs non-ok cancel proof] canceled=true status=503 reason=Failed to fetch Chat certs (503)

 ✓ |extension-messaging| extensions/googlechat/src/auth.cancel.transport.test.ts > Google Chat cert fetch non-OK body cancel > cancels the unread cert Response body when status is non-OK 11ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

- **Observed result after fix:** `canceled=true` with auth reason `Failed to fetch Chat certs (503)`; JWT verification is not attempted; `release()` still runs once.
- **What was not tested:** Live googleapis.com cert endpoint; production webhook traffic; cancel rejection under debug capture tee.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
