### PR TITLE
fix(telegram): recognize images sent as documents

### DIFF
--- a/extensions/telegram/src/bot/delivery.resolve-media-image-document.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-image-document.test.ts
@@ -1,0 +1,104 @@
+import fs from "node:fs/promises";
+import { withOpenClawTestState } from "openclaw/plugin-sdk/test-state";
+import { describe, expect, it } from "vitest";
+import { resolveMedia } from "./delivery.resolve-media.js";
+import type { TelegramContext } from "./types.js";
+
+// Complete 1x1 images, not just MIME signatures: the store must inspect real bytes.
+const PNG = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVR4nGP4z8AAAAMBAQDJ/pLvAAAAAElFTkSuQmCC",
+  "base64",
+);
+const JPEG = Buffer.from(
+  "/9j/4AAQSkZJRgABAQAAAQABAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/2wBDAQkJCQwLDBgNDRgyIRwhMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjIyMjL/wAARCAABAAEDASIAAhEBAxEB/8QAHwAAAQUBAQEBAQEAAAAAAAAAAAECAwQFBgcICQoL/8QAtRAAAgEDAwIEAwUFBAQAAAF9AQIDAAQRBRIhMUEGE1FhByJxFDKBkaEII0KxwRVS0fAkM2JyggkKFhcYGRolJicoKSo0NTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNkZWZnaGlqc3R1dnd4eXqDhIWGh4iJipKTlJWWl5iZmqKjpKWmp6ipqrKztLW2t7i5usLDxMXGx8jJytLT1NXW19jZ2uHi4+Tl5ufo6erx8vP09fb3+Pn6/8QAHwEAAwEBAQEBAQEBAQAAAAAAAAECAwQFBgcICQoL/8QAtREAAgECBAQDBAcFBAQAAQJ3AAECAxEEBSExBhJBUQdhcRMiMoEIFEKRobHBCSMzUvAVYnLRChYkNOEl8RcYGRomJygpKjU2Nzg5OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6goOEhYaHiImKkpOUlZaXmJmaoqOkpaanqKmqsrO0tba3uLm6wsPExcbHyMnK0tPU1dbX2Nna4uPk5ebn6Onq8vP09fb3+Pn6/9oADAMBAAIRAxEAPwDi6KKK+ZP3E//Z",
+  "base64",
+);
+const PDF = Buffer.from("%PDF-1.4\n1 0 obj\n<< /Type /Catalog >>\nendobj\n%%EOF\n");
+
+describe("Telegram downloaded image documents", () => {
+  it.each([
+    {
+      label: "a PNG document",
+      bytes: PNG,
+      fileName: "diagram.png",
+      mimeType: "image/png",
+      contentType: "image/png",
+      kind: "image",
+    },
+    {
+      label: "a JPEG document with generic metadata",
+      bytes: JPEG,
+      fileName: "upload.bin",
+      mimeType: "application/octet-stream",
+      contentType: "image/jpeg",
+      kind: "image",
+    },
+    {
+      label: "a PDF document",
+      bytes: PDF,
+      fileName: "report.pdf",
+      mimeType: "application/pdf",
+      contentType: "application/pdf",
+      kind: "document",
+    },
+    {
+      label: "a plain-text document",
+      bytes: Buffer.from("These are document notes.\n"),
+      fileName: "notes.txt",
+      mimeType: "text/plain",
+      contentType: "text/plain",
+      kind: "document",
+    },
+    {
+      label: "PDF bytes mislabeled as an image",
+      bytes: PDF,
+      fileName: "report.png",
+      mimeType: "image/png",
+      contentType: "application/pdf",
+      kind: "document",
+    },
+  ])("preserves the detected media kind for $label", async (fixture) => {
+    await withOpenClawTestState({ label: "telegram-image-document" }, async (state) => {
+      const sourcePath = state.path(fixture.fileName);
+      await fs.writeFile(sourcePath, fixture.bytes);
+      const fileId = "document-fixture";
+      const ctx: TelegramContext = {
+        message: {
+          message_id: 1,
+          date: 0,
+          chat: { id: 1, type: "private", first_name: "Fixture" },
+          document: {
+            file_id: fileId,
+            file_unique_id: fileId,
+            file_name: fixture.fileName,
+            mime_type: fixture.mimeType,
+          },
+        },
+        getFile: async () => ({
+          file_id: fileId,
+          file_unique_id: fileId,
+          file_path: sourcePath,
+        }),
+      };
+      const result = await resolveMedia({
+        ctx,
+        token: "12345:fixture-token",
+        maxBytes: 1_024,
+        trustedLocalFileRoots: [state.root],
+      });
+
+      expect(result).not.toBeNull();
+      if (!result) {
+        throw new Error("Expected the document to be saved");
+      }
+      expect(result.path).not.toBe(sourcePath);
+      expect(await fs.readFile(result.path)).toEqual(fixture.bytes);
+      expect(result).toMatchObject({
+        contentType: fixture.contentType,
+        fileName: fixture.fileName,
+        size: fixture.bytes.length,
+        kind: fixture.kind,
+      });
+    });
+  });
+});

--- a/extensions/telegram/src/bot/delivery.resolve-media-local.test.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media-local.test.ts
@@ -853,7 +853,7 @@ describe("resolveMedia getFile retry", () => {
     expectResolvedMediaFields(result, "trusted local dot-prefixed document", {
       path: "/tmp/inbound/photo.jpg",
       contentType: "image/jpeg",
-      kind: "document",
+      kind: "image",
     });
   });
 

--- a/extensions/telegram/src/bot/delivery.resolve-media.ts
+++ b/extensions/telegram/src/bot/delivery.resolve-media.ts
@@ -522,7 +522,9 @@ export async function resolveMedia(params: {
       ? nativeKind
       : saved.contentType?.startsWith("audio/")
         ? "audio"
-        : nativeKind;
+        : nativeKind === "document" && saved.contentType?.startsWith("image/")
+          ? "image"
+          : nativeKind;
   return {
     id: saved.id,
     path: saved.path,


### PR DESCRIPTION
Closes #141291

## What Problem This Solves

Fixes an issue where users sending PNG/JPEG images to Telegram as files would have their attachments omitted from automatic vision input. The files download successfully, but Telegram's document kind overrides the image MIME detected from the saved bytes.

## Why This Change Was Made

Classify an image-valued Telegram document as an image after saving and detecting its content type. Preserve the existing audio/sticker precedence and ordinary document handling. Core explicit-kind policy, download limits, authentication, reply context and transport behavior are unchanged.

This is one Telegram normalization fix: three added production lines, the existing filename-test expectation, and a real-byte regression file. Source analogue: [Hermes #21173](https://github.com/NousResearch/hermes-agent/pull/21173).

## User Impact

Supported image documents can reach the existing image-capable model input without being resent as Telegram photos. PDFs and text files remain documents, including PDF bytes mislabeled as an image. This restores automatic image selection; it does not claim every model supports every image type or that manual file-reading was previously impossible.

## Evidence

Baseline: `00fd5d6a404939da829ceae80e01d941a729cf06`. The unchanged resolver blob was rechecked against live main before publication.

| Real stored fixture | Before: kind / native image blocks | After: kind / native image blocks |
| --- | --- | --- |
| PNG | document / 0 | image / 1 |
| JPEG with generic metadata | document / 0 | image / 1 |
| PDF | document / 0 | document / 0 |
| Plain text | document / 0 | document / 0 |
| PDF mislabeled image/png | document / 0 | document / 0 |

The committed regression uses the actual resolver, filesystem and media store, with only `getFile` supplied as the Telegram boundary fixture. It asserts saved bytes, detected MIME, original filename and size before kind. Against unchanged production, both image cases fail and all three document controls pass.

```sh
node scripts/run-vitest.mjs \
  extensions/telegram/src/bot/delivery.resolve-media-image-document.test.ts \
  extensions/telegram/src/bot/delivery.resolve-media-local.test.ts \
  extensions/telegram/src/bot/delivery.resolve-media-retry.test.ts --reporter=verbose
```

Final result: **59/59 passed across 3 files, wrapper exit 0**. Existing local-root guards, download/retry, audio and sticker cases remain green.

Additional non-shipping local integration proof feeds the real resolver facts into `normalizeAttachments` / `selectAttachments`, `collectMediaImageRefs`, and `detectAndLoadPromptImages`. PNG/JPEG change from zero selected references/native images to one each, with zero load failures and preserved image MIME/data (69-byte PNG; 633-byte JPEG). Document controls remain at zero. No Telegram service or model-provider call was made; this is not live Telegram E2E.

Formatting and diff checks passed. One final scoped P0–P2 Codex AutoReview exited 0 with no findings. No review-driven scope expansion or split is needed.

Local extension lint/type checking was attempted but stopped **before lint** at the shared-dependency compiler provenance gate; it is not reported as passing. The full changed gate was not completed locally. Hosted CI on this PR still needs to confirm those lanes.

Maintainer edits are enabled. No private account data, credentials or transcripts are included.
