### PR TITLE
fix(cli): preserve inherited primary in model pickers

### DIFF
--- a/src/commands/model-picker.default-agent.test.ts
+++ b/src/commands/model-picker.default-agent.test.ts
@@ -1,5 +1,6 @@
-// Model picker tests read the configured target agent without rewriting global defaults.
+// Model picker tests read the target agent without rewriting global defaults.
 import { describe, expect, it, vi } from "vitest";
+import type { AgentModelConfig } from "../config/types.agents-shared.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
 
@@ -9,39 +10,64 @@ vi.mock("./model-picker.runtime.js", () => ({
 
 import { promptDefaultModel } from "./model-picker.js";
 
-describe("promptDefaultModel default-agent ownership", () => {
-  it("offers the resolved agent override as the current model", async () => {
+const cases: Array<{ name: string; model?: AgentModelConfig; expected: string }> = [
+  {
+    name: "fallback-only agent inherits its primary",
+    model: { fallbacks: ["anthropic/backup-model"] },
+    expected: "openai/global-model",
+  },
+  {
+    name: "explicit agent primary wins",
+    model: "anthropic/ops-model",
+    expected: "anthropic/ops-model",
+  },
+  { name: "agent without an override uses the global primary", expected: "openai/global-model" },
+];
+
+describe.each(cases)("promptDefaultModel: $name", ({ model, expected }) => {
+  it.each(["__keep__", "__manual__"])("shows the effective primary for %s", async (choice) => {
     const config = {
       agents: {
         defaults: { model: "openai/global-model" },
-        entries: {
-          ops: {
-            default: true,
-            model: "anthropic/ops-model",
-          },
-        },
+        entries: { ops: { default: true, ...(model !== undefined ? { model } : {}) } },
       },
     } satisfies OpenClawConfig;
-    const select = vi.fn(async (params: { options: Array<{ value: string; label: string }> }) => {
-      const keep = params.options[0];
-      expect(keep?.label).toContain("anthropic/ops-model");
-      return keep?.value;
+    const before = structuredClone(config);
+    const text = vi.fn(async (params: { initialValue?: string }) => {
+      expect(params.initialValue).toBe(expected);
+      return expected;
     });
-    const prompter = {
-      select,
-      progress: vi.fn(() => ({ stop: vi.fn(), update: vi.fn() })),
-    } as unknown as WizardPrompter;
+    const prompter: WizardPrompter = {
+      intro: async () => {},
+      outro: async () => {},
+      note: async () => {},
+      select: async ({ options }) => {
+        if (choice === "__keep__") {
+          expect(options.find((option) => option.value === "__keep__")?.label).toContain(expected);
+        }
+        const selected = options.find((option) => option.value === choice);
+        if (!selected) {
+          throw new Error(`Missing picker option: ${choice}`);
+        }
+        return selected.value;
+      },
+      multiselect: async ({ initialValues }) => initialValues ?? [],
+      text,
+      confirm: async ({ initialValue }) => initialValue ?? false,
+      progress: () => ({ stop() {}, update() {} }),
+    };
 
-    await expect(
-      promptDefaultModel({
-        config,
-        prompter,
-        agentId: "ops",
-        agentDir: "/tmp/ops-agent",
-        workspaceDir: "/tmp/ops-workspace",
-        loadCatalog: false,
-      }),
-    ).resolves.toEqual({});
-    expect(select).toHaveBeenCalledOnce();
+    const result = await promptDefaultModel({
+      config,
+      prompter,
+      agentId: "ops",
+      agentDir: "/tmp/ops-agent",
+      workspaceDir: "/tmp/ops-workspace",
+      loadCatalog: false,
+    });
+
+    expect(result).toEqual(choice === "__keep__" ? {} : { model: expected });
+    expect(text).toHaveBeenCalledTimes(choice === "__manual__" ? 1 : 0);
+    expect(config).toEqual(before);
   });
 });

--- a/src/commands/model-picker.test.ts
+++ b/src/commands/model-picker.test.ts
@@ -1496,6 +1496,36 @@ describe("promptModelAllowlist", () => {
     expect(result.scopeKeys).toEqual(["anthropic/claude-opus-4-6"]);
   });
 
+  it("seeds scoped choices with a fallback-only agent's inherited primary", async () => {
+    const multiselect = createSelectAllMultiselect();
+    const config = {
+      agents: {
+        defaults: {
+          model: "openai/global-model",
+          models: { "anthropic/outside-scope": {} },
+        },
+        entries: { ops: { model: { fallbacks: ["openai/backup-model"] } } },
+      },
+    } satisfies OpenClawConfig;
+    const before = structuredClone(config);
+    const allowedKeys = ["openai/global-model", "openai/backup-model"];
+
+    const result = await promptModelAllowlist({
+      config,
+      prompter: makePrompter({ multiselect }),
+      agentId: "ops",
+      agentDir: "/tmp/ops-agent",
+      allowedKeys,
+      loadCatalog: false,
+    });
+
+    const prompt = multiselect.mock.calls[0]?.[0];
+    expect(optionValues(prompt.options)).toEqual(allowedKeys);
+    expect(prompt.initialValues).toEqual(allowedKeys);
+    expect(result).toEqual({ models: allowedKeys, scopeKeys: allowedKeys });
+    expect(config).toEqual(before);
+  });
+
   it("localizes the model allowlist picker", async () => {
     process.env.OPENCLAW_LOCALE = "zh-CN";
     loadModelCatalog.mockResolvedValue([catalogModel("openai", "gpt-5.5", "GPT-5.5")]);

--- a/src/flows/model-picker.ts
+++ b/src/flows/model-picker.ts
@@ -1,7 +1,11 @@
 // Model picker flow lets users select provider models for config defaults.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import { resolveAgentConfig, resolveDefaultAgentDir } from "../agents/agent-scope.js";
+import {
+  resolveAgentConfig,
+  resolveAgentEffectiveModelPrimary,
+  resolveDefaultAgentDir,
+} from "../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveAgentHarnessPolicy } from "../agents/harness/policy.js";
 import {
@@ -36,6 +40,7 @@ import {
   normalizeAgentModelRefForConfig,
   resolveAgentModelFallbackValues,
   resolveAgentModelPrimaryValue,
+  toAgentModelListLike,
 } from "../config/model-input.js";
 import { computeModelPolicyAllowlist } from "../config/model-policy-allowlist-migration.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -139,7 +144,10 @@ function resolveConfiguredModelKeys(cfg: OpenClawConfig): string[] {
 }
 
 function resolveModelPickerConfig(cfg: OpenClawConfig, agentId?: string): OpenClawConfig {
-  const agent = agentId ? resolveAgentConfig(cfg, agentId) : undefined;
+  if (!agentId) {
+    return cfg;
+  }
+  const agent = resolveAgentConfig(cfg, agentId);
   if (agent?.model === undefined && agent?.models === undefined) {
     return cfg;
   }
@@ -149,7 +157,14 @@ function resolveModelPickerConfig(cfg: OpenClawConfig, agentId?: string): OpenCl
       ...cfg.agents,
       defaults: {
         ...cfg.agents?.defaults,
-        ...(agent.model !== undefined ? { model: agent.model } : {}),
+        ...(agent.model !== undefined
+          ? {
+              model: {
+                ...toAgentModelListLike(agent.model),
+                primary: resolveAgentEffectiveModelPrimary(cfg, agentId),
+              },
+            }
+          : {}),
         ...(agent.models !== undefined
           ? { models: { ...cfg.agents?.defaults?.models, ...agent.models } }
           : {}),


### PR DESCRIPTION
Related: #136257.

## What Problem This Solves

Configuring an agent with only model fallbacks showed the built-in default instead of the inherited global primary. Manual entry and scoped picker selection also started with the wrong model.

## Why This Change Was Made

The temporary picker model uses the existing effective-primary resolver while retaining the agent's fallback list and model metadata.

## User Impact

Keep and manual entry show the effective primary. Keep makes no edit, so later global-primary changes still apply. Explicit agent primaries and scoped selections keep their existing precedence.

Consumers: configure's Keep label, manual-entry seed, and scoped picker selection now use the effective primary.

## Evidence

The registered configure command reproduced the incorrect default in a real terminal. The corrected command preserved fallback-only configuration after Keep, followed a later global-primary change, and saved an explicit manual primary without changing the global value or fallbacks. Saved-file reads and public configuration reads agreed. All seven targeted picker checks, formatting, whitespace checks, and required continuous integration passed. The proof used the source CLI with synthetic settings; no rebuilt distribution or live provider was exercised.
