### PR TITLE
refactor(image): share CLI and tool option parsing

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2010,7 +2010,7 @@ src/agents/tools/gateway-tool.ts	5
 src/agents/tools/gateway.ts	1
 src/agents/tools/goal-tools.ts	4
 src/agents/tools/heartbeat-response-tool.ts	1
-src/agents/tools/image-generate-tool.ts	14
+src/agents/tools/image-generate-tool.ts	2
 src/agents/tools/image-tool.helpers.ts	2
 src/agents/tools/image-tool.ts	3
 src/agents/tools/in-process-gateway.ts	1
@@ -2252,7 +2252,7 @@ src/cli/acp-cli.ts	7
 src/cli/attach-cli.ts	3
 src/cli/capability-cli/audio.ts	3
 src/cli/capability-cli/embedding.ts	3
-src/cli/capability-cli/image.ts	17
+src/cli/capability-cli/image.ts	12
 src/cli/capability-cli/model.ts	4
 src/cli/capability-cli/shared.ts	4
 src/cli/capability-cli/tts.ts	6

--- a/src/agents/tools/image-generate-tool.ts
+++ b/src/agents/tools/image-generate-tool.ts
@@ -12,8 +12,6 @@ import {
 import type {
   ImageGenerationIgnoredOverride,
   ImageGenerationBackground,
-  ImageGenerationOpenAIBackground,
-  ImageGenerationOpenAIModeration,
   ImageGenerationOpenAIOptions,
   ImageGenerationOutputFormat,
   ImageGenerationProvider,
@@ -30,6 +28,7 @@ import { resolveGeneratedMediaMaxBytes } from "../../media/configured-max-bytes.
 import { getImageMetadata } from "../../media/media-services.js";
 import { saveMediaBuffer } from "../../media/store.js";
 import { readSnakeCaseParamRaw } from "../../param-key.js";
+import { createEnumOptionParser } from "../../shared/enum-option.js";
 import type { DeliveryContext } from "../../utils/delivery-context.types.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import {
@@ -93,7 +92,6 @@ const SUPPORTED_OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
 const SUPPORTED_BACKGROUNDS = ["transparent", "opaque", "auto"] as const;
 const SUPPORTED_OPENAI_MODERATIONS = ["low", "auto"] as const;
 const SUPPORTED_FAL_CREATIVITY = ["raw", "low", "medium", "high"] as const;
-type FalCreativity = (typeof SUPPORTED_FAL_CREATIVITY)[number];
 const SUPPORTED_ASPECT_RATIOS = new Set([
   "1:1",
   "2:1",
@@ -258,75 +256,7 @@ function normalizeAspectRatio(raw: string | undefined): string | undefined {
   );
 }
 
-function normalizeQuality(raw: string | undefined): ImageGenerationQuality | undefined {
-  const normalized = raw?.trim().toLowerCase();
-  if (!normalized) {
-    return undefined;
-  }
-  if ((SUPPORTED_QUALITIES as readonly string[]).includes(normalized)) {
-    return normalized as ImageGenerationQuality;
-  }
-  throw new ToolInputError("quality must be one of low, medium, high, or auto");
-}
-
-function normalizeOutputFormat(raw: string | undefined): ImageGenerationOutputFormat | undefined {
-  const normalized = raw?.trim().toLowerCase();
-  if (!normalized) {
-    return undefined;
-  }
-  if ((SUPPORTED_OUTPUT_FORMATS as readonly string[]).includes(normalized)) {
-    return normalized as ImageGenerationOutputFormat;
-  }
-  throw new ToolInputError("outputFormat must be one of png, jpeg, or webp");
-}
-
-function normalizeOpenAIBackground(
-  raw: string | undefined,
-): ImageGenerationOpenAIBackground | undefined {
-  const normalized = raw?.trim().toLowerCase();
-  if (!normalized) {
-    return undefined;
-  }
-  if ((SUPPORTED_BACKGROUNDS as readonly string[]).includes(normalized)) {
-    return normalized as ImageGenerationOpenAIBackground;
-  }
-  throw new ToolInputError("openai.background must be one of transparent, opaque, or auto");
-}
-
-function normalizeBackground(raw: string | undefined): ImageGenerationBackground | undefined {
-  const normalized = raw?.trim().toLowerCase();
-  if (!normalized) {
-    return undefined;
-  }
-  if ((SUPPORTED_BACKGROUNDS as readonly string[]).includes(normalized)) {
-    return normalized as ImageGenerationBackground;
-  }
-  throw new ToolInputError("background must be one of transparent, opaque, or auto");
-}
-
-function normalizeOpenAIModeration(
-  raw: string | undefined,
-): ImageGenerationOpenAIModeration | undefined {
-  const normalized = raw?.trim().toLowerCase();
-  if (!normalized) {
-    return undefined;
-  }
-  if ((SUPPORTED_OPENAI_MODERATIONS as readonly string[]).includes(normalized)) {
-    return normalized as ImageGenerationOpenAIModeration;
-  }
-  throw new ToolInputError("openai.moderation must be one of low or auto");
-}
-
-function normalizeFalCreativity(raw: string | undefined): FalCreativity | undefined {
-  const normalized = raw?.trim().toLowerCase();
-  if (!normalized) {
-    return undefined;
-  }
-  if ((SUPPORTED_FAL_CREATIVITY as readonly string[]).includes(normalized)) {
-    return normalized as FalCreativity;
-  }
-  throw new ToolInputError("fal.creativity must be one of raw, low, medium, or high");
-}
+const parseImageOption = createEnumOptionParser(ToolInputError);
 
 function readRecordParam(params: Record<string, unknown>, key: string): Record<string, unknown> {
   const raw = params[key];
@@ -337,8 +267,16 @@ function readRecordParam(params: Record<string, unknown>, key: string): Record<s
 
 function normalizeOpenAIOptions(args: Record<string, unknown>): ImageGenerationOpenAIOptions {
   const raw = readRecordParam(args, "openai");
-  const background = normalizeOpenAIBackground(readToolStringParam(raw, "background"));
-  const moderation = normalizeOpenAIModeration(readToolStringParam(raw, "moderation"));
+  const background = parseImageOption(
+    readToolStringParam(raw, "background"),
+    SUPPORTED_BACKGROUNDS,
+    "openai.background",
+  );
+  const moderation = parseImageOption(
+    readToolStringParam(raw, "moderation"),
+    SUPPORTED_OPENAI_MODERATIONS,
+    "openai.moderation",
+  );
   if (readSnakeCaseParamRaw(raw, "outputCompression") === null) {
     throw new ToolInputError("openai.outputCompression must be between 0 and 100");
   }
@@ -361,7 +299,11 @@ function normalizeProviderOptions(
   args: Record<string, unknown>,
 ): ImageGenerationProviderOptions | undefined {
   const falRaw = readRecordParam(args, "fal");
-  const falCreativity = normalizeFalCreativity(readToolStringParam(falRaw, "creativity"));
+  const falCreativity = parseImageOption(
+    readToolStringParam(falRaw, "creativity"),
+    SUPPORTED_FAL_CREATIVITY,
+    "fal.creativity",
+  );
   const openai = normalizeOpenAIOptions(args);
   const fal = falCreativity ? { creativity: falCreativity } : undefined;
   return fal || Object.keys(openai).length > 0
@@ -834,9 +776,21 @@ export function createImageGenerateTool(options?: {
       const aspectRatio = normalizeAspectRatio(readToolStringParam(params, "aspectRatio"));
       const explicitResolution = normalizeResolution(readToolStringParam(params, "resolution"));
       const timeoutMs = readGenerationTimeoutMs(params) ?? imageGenerationModelConfig.timeoutMs;
-      const quality = normalizeQuality(readToolStringParam(params, "quality"));
-      const outputFormat = normalizeOutputFormat(readToolStringParam(params, "outputFormat"));
-      const background = normalizeBackground(readToolStringParam(params, "background"));
+      const quality = parseImageOption(
+        readToolStringParam(params, "quality"),
+        SUPPORTED_QUALITIES,
+        "quality",
+      );
+      const outputFormat = parseImageOption(
+        readToolStringParam(params, "outputFormat"),
+        SUPPORTED_OUTPUT_FORMATS,
+        "outputFormat",
+      );
+      const background = parseImageOption(
+        readToolStringParam(params, "background"),
+        SUPPORTED_BACKGROUNDS,
+        "background",
+      );
       const providerOptions = normalizeProviderOptions(params);
       const imageGenerationProviders =
         preparedProviders ?? listRuntimeImageGenerationProviders({ config: effectiveCfg });

--- a/src/cli/capability-cli/image.ts
+++ b/src/cli/capability-cli/image.ts
@@ -1,9 +1,6 @@
 import path from "node:path";
 import { detectMime } from "@openclaw/media-core/mime";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { Command } from "commander";
 import { resolveAgentDir } from "../../agents/agent-scope.js";
 import { runWithImageModelFallback } from "../../agents/model-fallback-image.js";
@@ -26,6 +23,7 @@ import {
 } from "../../media-understanding/runtime.js";
 import { getImageMetadata } from "../../media/media-services.js";
 import { defaultRuntime } from "../../runtime.js";
+import { createEnumOptionParser } from "../../shared/enum-option.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { getModelsCommandSecretTargetIds } from "../command-secret-targets.js";
 import { readInputFiles, writeOutputAsset } from "../media-output.js";
@@ -46,6 +44,9 @@ import {
 
 const IMAGE_OUTPUT_FORMATS = ["png", "jpeg", "webp"] as const;
 const IMAGE_BACKGROUNDS = ["transparent", "opaque", "auto"] as const;
+const IMAGE_QUALITIES = ["low", "medium", "high", "auto"] as const;
+const IMAGE_MODERATIONS = ["low", "auto"] as const;
+const parseImageOption = createEnumOptionParser();
 
 async function runImageGenerate(params: {
   capability: "image.generate" | "image.edit";
@@ -230,62 +231,6 @@ async function runImageDescribe(params: {
   } satisfies CapabilityEnvelope;
 }
 
-function normalizeImageOutputFormat(
-  raw: string | undefined,
-): ImageGenerationOutputFormat | undefined {
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
-  if (!normalized) {
-    return undefined;
-  }
-  if ((IMAGE_OUTPUT_FORMATS as readonly string[]).includes(normalized)) {
-    return normalized as ImageGenerationOutputFormat;
-  }
-  throw new Error("--output-format must be one of png, jpeg, or webp");
-}
-
-function normalizeImageBackground(
-  raw: string | undefined,
-  label = "--background",
-): ImageGenerationBackground | undefined {
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
-  if (!normalized) {
-    return undefined;
-  }
-  if ((IMAGE_BACKGROUNDS as readonly string[]).includes(normalized)) {
-    return normalized as ImageGenerationBackground;
-  }
-  throw new Error(`${label} must be one of transparent, opaque, or auto`);
-}
-
-function normalizeImageQuality(raw: string | undefined): ImageGenerationQuality | undefined {
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
-  if (!normalized) {
-    return undefined;
-  }
-  if (
-    normalized === "low" ||
-    normalized === "medium" ||
-    normalized === "high" ||
-    normalized === "auto"
-  ) {
-    return normalized;
-  }
-  throw new Error("--quality must be one of low, medium, high, or auto");
-}
-
-function normalizeOpenAIModeration(
-  raw: string | undefined,
-): ImageGenerationOpenAIModeration | undefined {
-  const normalized = normalizeLowercaseStringOrEmpty(raw);
-  if (!normalized) {
-    return undefined;
-  }
-  if (normalized === "low" || normalized === "auto") {
-    return normalized;
-  }
-  throw new Error("--openai-moderation must be one of low or auto");
-}
-
 function resolveImageDescribeInput(filePath: string): string {
   const trimmed = filePath.trim();
   return /^https?:\/\//i.test(trimmed) ? trimmed : path.resolve(filePath);
@@ -312,11 +257,6 @@ function addImageGenerationOptions(command: Command): Command {
     .option("--json", "Output JSON", false);
 }
 
-function readStringOption(opts: Record<string, unknown>, key: string): string | undefined {
-  const value = opts[key];
-  return typeof value === "string" ? value : undefined;
-}
-
 function resolveImageGenerationOptions(opts: Record<string, unknown>, command: Command) {
   return {
     agent: resolveCapabilityAgentOption(command, opts.agent),
@@ -325,14 +265,19 @@ function resolveImageGenerationOptions(opts: Record<string, unknown>, command: C
     size: opts.size as string | undefined,
     aspectRatio: opts.aspectRatio as string | undefined,
     resolution: opts.resolution as "1K" | "2K" | "4K" | undefined,
-    outputFormat: normalizeImageOutputFormat(readStringOption(opts, "outputFormat")),
-    background: normalizeImageBackground(readStringOption(opts, "background")),
-    openaiBackground: normalizeImageBackground(
-      opts.openaiBackground as string | undefined,
+    outputFormat: parseImageOption(opts.outputFormat, IMAGE_OUTPUT_FORMATS, "--output-format"),
+    background: parseImageOption(opts.background, IMAGE_BACKGROUNDS, "--background"),
+    openaiBackground: parseImageOption(
+      opts.openaiBackground,
+      IMAGE_BACKGROUNDS,
       "--openai-background",
     ),
-    openaiModeration: normalizeOpenAIModeration(readStringOption(opts, "openaiModeration")),
-    quality: normalizeImageQuality(readStringOption(opts, "quality")),
+    openaiModeration: parseImageOption(
+      opts.openaiModeration,
+      IMAGE_MODERATIONS,
+      "--openai-moderation",
+    ),
+    quality: parseImageOption(opts.quality, IMAGE_QUALITIES, "--quality"),
     timeoutMs: parseOptionalTimeoutMs(opts.timeoutMs as string | number | undefined),
     output: opts.output as string | undefined,
   };

--- a/src/shared/enum-option.ts
+++ b/src/shared/enum-option.ts
@@ -1,0 +1,16 @@
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import { formatHumanList } from "./human-list.js";
+
+export function createEnumOptionParser(ErrorType: new (message: string) => Error = Error) {
+  return <T extends string>(raw: unknown, allowed: readonly T[], label: string): T | undefined => {
+    const normalized = normalizeOptionalLowercaseString(raw);
+    if (!normalized) {
+      return undefined;
+    }
+    const value = allowed.find((entry) => entry.toLowerCase() === normalized);
+    if (value === undefined) {
+      throw new ErrorType(`${label} must be one of ${formatHumanList(allowed)}`);
+    }
+    return value;
+  };
+}


### PR DESCRIPTION
Related: #122436

## What Problem This Solves

Image generation's CLI and agent tool repeat the same optional enum parsing across ten private normalizers. Keeping accepted values, canonicalization and errors consistent currently requires editing both surfaces.

## Why This Change Was Made

Use one internal parser, bound separately to the CLI's ordinary Error and the tool's trusted ToolInputError. Each caller supplies its existing allowed values and diagnostic label. The redundant CLI string reader is absorbed into the shared parser; tool parameter readers retain their admission rules and ordering.

This builds on @masatohoshino's enum-normalization approach in #122436. That PR's separately assigned resolution-validation work remains intact.

## User Impact

Accepted inputs, exact diagnostic messages, defaults, alias precedence and resolution/aspect behavior are unchanged. The shared parser returns the declared canonical value. This consolidation removes 76 production code lines (85 physical lines) and 17 unsafe assertions, with no permanent test changes or new public SDK surface.

## Evidence

All 299 existing CLI/tool tests pass before and after. The same 4,249 complete boundary observations are byte-identical across the original code, the shared parser with the CLI reader retained, and the final reader removal. These checks cover requests, synthetic image files, results, error classes/status/trust and event order.

The complete selected core/coreTests/tooling gate and independent P2 review pass. The assertion baseline changes only the two corresponding counts, from 14 to 2 and 17 to 12. Verification uses isolated synthetic fixtures; no live provider call or generated user image is claimed.
