### PR TITLE
fix(config): apply environment changes after in-process restart

### DIFF
--- a/src/config/config-env-vars.ts
+++ b/src/config/config-env-vars.ts
@@ -362,8 +362,15 @@ export function initializePublishedConfigRuntimeEnv(
   pendingConfigRuntimeEnvPublication = null;
 }
 
-export function resetPublishedConfigRuntimeEnv(): void {
-  publishedConfigRuntimeEnvState = { generation: 0, ownedEnv: {}, sourceConfig: null };
+export function resetPublishedConfigRuntimeEnv(
+  options: { preserveOwnership?: boolean } = {},
+): void {
+  publishedConfigRuntimeEnvState = options.preserveOwnership
+    ? {
+        ...publishedConfigRuntimeEnvState,
+        generation: publishedConfigRuntimeEnvState.generation + 1,
+      }
+    : { generation: 0, ownedEnv: {}, sourceConfig: null };
   publishedConfigRuntimeEnvEpoch += 1;
   pendingConfigRuntimeEnvPublication = null;
 }

--- a/src/config/runtime-snapshot.env.test.ts
+++ b/src/config/runtime-snapshot.env.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  applyConfigEnvVars,
+  collectConfigRuntimeEnvOwnership,
+  getPublishedConfigRuntimeEnvState,
+  initializePublishedConfigRuntimeEnv,
+  prepareConfigRuntimeEnv,
+} from "./config-env-vars.js";
+import {
+  clearRuntimeConfigSnapshot,
+  resetConfigRuntimeState,
+  setAppliedRuntimeConfigSnapshot,
+} from "./runtime-snapshot.js";
+
+describe("config environment across in-process restart", () => {
+  afterEach(() => {
+    resetConfigRuntimeState();
+    vi.unstubAllEnvs();
+  });
+
+  it.each([
+    { operation: "replacement", nextValue: "second" },
+    { operation: "removal", nextValue: undefined },
+  ])("applies config-owned value $operation after restart", ({ nextValue }) => {
+    vi.stubEnv("OPENCLAW_TEST_RESTART_VALUE", undefined);
+    vi.stubEnv("OPENCLAW_TEST_RESTART_AMBIENT", "ambient");
+    const initial = {
+      env: {
+        vars: {
+          OPENCLAW_TEST_RESTART_VALUE: "first",
+          OPENCLAW_TEST_RESTART_AMBIENT: "config-default",
+        },
+      },
+    };
+    const beforeStartup = { ...process.env };
+    applyConfigEnvVars(initial);
+    initializePublishedConfigRuntimeEnv(initial, {
+      ownedEnv: collectConfigRuntimeEnvOwnership(initial, beforeStartup, process.env),
+    });
+    setAppliedRuntimeConfigSnapshot(initial, initial);
+
+    clearRuntimeConfigSnapshot();
+    // Server shutdown and the run loop both clear snapshots before the next boot.
+    clearRuntimeConfigSnapshot();
+    const beforeRestartedStartup = { ...process.env };
+    applyConfigEnvVars(initial);
+    initializePublishedConfigRuntimeEnv(initial, {
+      ownedEnv: collectConfigRuntimeEnvOwnership(initial, beforeRestartedStartup, process.env),
+      preserveExistingOwnership: true,
+    });
+    const next = {
+      env: {
+        vars: {
+          ...(nextValue ? { OPENCLAW_TEST_RESTART_VALUE: nextValue } : {}),
+          OPENCLAW_TEST_RESTART_AMBIENT: "changed-config-default",
+        },
+      },
+    };
+    const publication = prepareConfigRuntimeEnv({
+      previousConfig: initial,
+      nextConfig: next,
+    }).publish();
+    publication.commit();
+
+    expect(process.env.OPENCLAW_TEST_RESTART_VALUE).toBe(nextValue);
+    expect(process.env.OPENCLAW_TEST_RESTART_AMBIENT).toBe("ambient");
+  });
+
+  it("preserves an ambient replacement of a formerly config-owned value", () => {
+    vi.stubEnv("OPENCLAW_TEST_RESTART_VALUE", "config-value");
+    const initial = { env: { vars: { OPENCLAW_TEST_RESTART_VALUE: "config-value" } } };
+    initializePublishedConfigRuntimeEnv(initial, {
+      ownedEnv: { OPENCLAW_TEST_RESTART_VALUE: "config-value" },
+    });
+    process.env.OPENCLAW_TEST_RESTART_VALUE = "new-ambient";
+
+    clearRuntimeConfigSnapshot();
+    const publication = prepareConfigRuntimeEnv({
+      previousConfig: initial,
+      nextConfig: {},
+    }).publish();
+    publication.commit();
+
+    expect(process.env.OPENCLAW_TEST_RESTART_VALUE).toBe("new-ambient");
+  });
+
+  it("keeps process-stable config selection in the environment during restart", () => {
+    vi.stubEnv("OPENCLAW_CONFIG_PATH", "/synthetic/restart/openclaw.json");
+    const initial = { env: { vars: { OPENCLAW_CONFIG_PATH: "/synthetic/restart/openclaw.json" } } };
+    initializePublishedConfigRuntimeEnv(initial, {
+      ownedEnv: { OPENCLAW_CONFIG_PATH: "/synthetic/restart/openclaw.json" },
+    });
+
+    clearRuntimeConfigSnapshot();
+
+    expect(process.env.OPENCLAW_CONFIG_PATH).toBe("/synthetic/restart/openclaw.json");
+  });
+
+  it("fences a late rollback while retaining the published environment for restart", () => {
+    vi.stubEnv("OPENCLAW_TEST_RESTART_VALUE", "first");
+    const initial = { env: { vars: { OPENCLAW_TEST_RESTART_VALUE: "first" } } };
+    const next = { env: { vars: { OPENCLAW_TEST_RESTART_VALUE: "second" } } };
+    initializePublishedConfigRuntimeEnv(initial, {
+      ownedEnv: { OPENCLAW_TEST_RESTART_VALUE: "first" },
+    });
+    const rollback = prepareConfigRuntimeEnv({
+      previousConfig: initial,
+      nextConfig: next,
+    }).publish();
+
+    clearRuntimeConfigSnapshot();
+    rollback();
+
+    expect(process.env.OPENCLAW_TEST_RESTART_VALUE).toBe("second");
+    const publication = prepareConfigRuntimeEnv({ previousConfig: next, nextConfig: {} }).publish();
+    publication.commit();
+    expect(process.env.OPENCLAW_TEST_RESTART_VALUE).toBeUndefined();
+  });
+
+  it("still clears environment ownership on an explicit full runtime reset", () => {
+    vi.stubEnv("OPENCLAW_TEST_RESTART_VALUE", "owned");
+    const initial = { env: { vars: { OPENCLAW_TEST_RESTART_VALUE: "owned" } } };
+    initializePublishedConfigRuntimeEnv(initial, {
+      ownedEnv: { OPENCLAW_TEST_RESTART_VALUE: "owned" },
+    });
+
+    resetConfigRuntimeState();
+
+    expect(getPublishedConfigRuntimeEnvState().ownedEnv).toEqual({});
+    expect(getPublishedConfigRuntimeEnvState().sourceConfig).toBeNull();
+  });
+});

--- a/src/config/runtime-snapshot.ts
+++ b/src/config/runtime-snapshot.ts
@@ -218,18 +218,20 @@ export function setRuntimeConfigSourceSnapshotIfCurrent(params: {
   return true;
 }
 
-export function resetConfigRuntimeState(): void {
+export function resetConfigRuntimeState(options: { preserveConfigEnv?: boolean } = {}): void {
   clearExecutablePathCache();
   runtimeConfigSnapshot = null;
   runtimeConfigSourceSnapshot = null;
   runtimeConfigSnapshotMetadata = null;
   runtimeConfigAppliedHash = null;
   runtimeConfigSnapshotRevision = 0;
-  resetPublishedConfigRuntimeEnv();
+  resetPublishedConfigRuntimeEnv({ preserveOwnership: options.preserveConfigEnv });
 }
 
 export function clearRuntimeConfigSnapshot(): void {
-  resetConfigRuntimeState();
+  // Snapshot cleanup leaves process.env intact. Retain its config-owned layer so
+  // the next startup/reload can replace it without treating it as ambient input.
+  resetConfigRuntimeState({ preserveConfigEnv: true });
 }
 
 export function getRuntimeConfigSnapshot(): OpenClawConfig | null {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where changing or removing configured environment values after an in-process Gateway restart left the process using old values.

## Why This Change Was Made

Keep environment ownership through snapshot cleanup so the next startup does not mistake surviving configured values for inherited settings. Fence old rollback transactions while retaining explicit full-reset behavior.

## User Impact

Accepted configuration changes replace or remove owned environment values after restart. Inherited values keep precedence, and configuration-selected locations stay stable.

## Evidence

A real Gateway reproduced the stale value after a same-process restart. The candidate completed restart, replacement and removal: public reads showed the new value, then the unresolved placeholder, while the inherited control stayed unchanged. Fifty-eight focused tests covered rollback, precedence, aliases, casing, blocked variables and reset. Required checks passed; no provider call was used.
