### PR TITLE
fix(gateway): retain owned run loop through failed restarts

### DIFF
--- a/src/cli/cli-entrypoint.test-support.ts
+++ b/src/cli/cli-entrypoint.test-support.ts
@@ -44,6 +44,11 @@ export const gatewayDirectStopEntrypoints = {
     sourceWorkerName: "gateway-cli/run-loop",
     distWorkerPath: "cli/gateway-cli/run-loop.js",
   },
+  restartPolicy: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "../infra/restart",
+    distWorkerPath: "infra/restart.js",
+  },
   workAdmission: {
     currentModuleUrl: import.meta.url,
     sourceWorkerName: "../process/gateway-work-admission",

--- a/src/cli/gateway-cli/run-loop.restart-liveness.process.test.ts
+++ b/src/cli/gateway-cli/run-loop.restart-liveness.process.test.ts
@@ -12,11 +12,7 @@ import { gatewayDirectStopEntrypoints } from "../cli-entrypoint.test-support.js"
 const tempDirs = createTempDirTracker();
 const children = new Map<ChildProcess, Promise<unknown[]>>();
 const runLoopUrl = resolveRuntimeWorkerUrl(gatewayDirectStopEntrypoints.runLoop).href;
-const restartUrl = resolveRuntimeWorkerUrl({
-  currentModuleUrl: import.meta.url,
-  sourceWorkerName: "../../infra/restart",
-  distWorkerPath: "infra/restart.js",
-}).href;
+const restartUrl = resolveRuntimeWorkerUrl(gatewayDirectStopEntrypoints.restartPolicy).href;
 
 const childScript = `
   import fs from "node:fs";

--- a/src/cli/gateway-cli/run-loop.restart-liveness.process.test.ts
+++ b/src/cli/gateway-cli/run-loop.restart-liveness.process.test.ts
@@ -1,0 +1,187 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import { once } from "node:events";
+import fs from "node:fs";
+import path from "node:path";
+import { setTimeout as delay } from "node:timers/promises";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { withTestTimeout } from "../../../test/helpers/promise.js";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
+import { gatewayDirectStopEntrypoints } from "../cli-entrypoint.test-support.js";
+
+const tempDirs = createTempDirTracker();
+const children = new Map<ChildProcess, Promise<unknown[]>>();
+const runLoopUrl = resolveRuntimeWorkerUrl(gatewayDirectStopEntrypoints.runLoop).href;
+const restartUrl = resolveRuntimeWorkerUrl({
+  currentModuleUrl: import.meta.url,
+  sourceWorkerName: "../../infra/restart",
+  distWorkerPath: "infra/restart.js",
+}).href;
+
+const childScript = `
+  import fs from "node:fs";
+  import http from "node:http";
+  import { runGatewayLoop } from ${JSON.stringify(runLoopUrl)};
+  import { setGatewaySigusr1RestartPolicy } from ${JSON.stringify(restartUrl)};
+  const faultPath = process.argv[1];
+  setGatewaySigusr1RestartPolicy({ allowExternal: true });
+  let starts = 0;
+  try {
+    await runGatewayLoop({
+      ownsProcessLifecycle: true,
+      start: async () => {
+        const attempt = ++starts;
+        process.stdout.write("start:" + attempt + "\\n");
+        if (fs.existsSync(faultPath)) throw new Error("fixture startup refused");
+        const server = http.createServer((_request, response) => response.end("ready"));
+        await new Promise((resolve, reject) => {
+          server.once("error", reject);
+          server.listen(0, "127.0.0.1", resolve);
+        });
+        process.stdout.write("ready:" + attempt + "\\n");
+        return {
+          getTailscaleIngressEndpoint: () => undefined,
+          startupSettled: Promise.resolve(),
+          close: async () => {
+            await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
+            process.stdout.write("closed:" + attempt + "\\n");
+          },
+        };
+      },
+      runtime: {
+        log: () => {},
+        error: (...args) => console.error(...args),
+        exit: code => process.exit(code),
+      },
+    });
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  }
+`;
+
+afterEach(async () => {
+  for (const child of children.keys()) {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill("SIGKILL");
+    }
+  }
+  const results = await withTestTimeout(
+    Promise.allSettled(children.values()),
+    5_000,
+    "restart liveness children did not close; retaining their fixture directories",
+  );
+  const errors = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+  if (errors.length) {
+    throw new AggregateError(errors, "restart liveness cleanup failed");
+  }
+  children.clear();
+  tempDirs.cleanup();
+});
+
+function startFixture(initialFailure = false) {
+  const directory = tempDirs.make("openclaw-restart-liveness-");
+  const home = path.join(directory, "home");
+  fs.mkdirSync(home);
+  const faultPath = path.join(directory, "startup-fault");
+  if (initialFailure) {
+    fs.writeFileSync(faultPath, "refuse");
+  }
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", "--input-type=module", "--eval", childScript, faultPath],
+    {
+      env: {
+        PATH: process.env.PATH,
+        HOME: home,
+        TMPDIR: directory,
+        OPENCLAW_STATE_DIR: path.join(directory, "state"),
+        OPENCLAW_CONFIG_PATH: path.join(directory, "openclaw.json"),
+        OPENCLAW_NO_RESPAWN: "1",
+        NODE_DISABLE_COMPILE_CACHE: "1",
+        TSX_DISABLE_CACHE: "1",
+        ESBUILD_WORKER_THREADS: "0",
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const closed = once(child, "close");
+  children.set(child, closed);
+  void closed.catch(() => {});
+  let output = "";
+  child.stdout?.on("data", (chunk: Buffer) => (output += chunk.toString()));
+  child.stderr?.on("data", (chunk: Buffer) => (output += chunk.toString()));
+  const waitForOutput = (text: string) =>
+    vi.waitFor(() => expect(output).toContain(text), { timeout: 45_000, interval: 25 });
+  return { child, closed, faultPath, waitForOutput, output: () => output };
+}
+
+async function expectFailedRestartWaiting(
+  fixture: ReturnType<typeof startFixture>,
+  attempt: number,
+) {
+  expect(fixture.child.kill("SIGUSR1")).toBe(true);
+  await fixture.waitForOutput(`start:${attempt}`);
+  await vi.waitFor(
+    () =>
+      expect(
+        fixture.output().split("Process will stay alive; fix the issue and restart.").length - 1,
+      ).toBe(attempt - 1),
+    { timeout: 5_000, interval: 25 },
+  );
+  // Only the parent observes an idle interval. A child timer or IPC channel
+  // would hide the lost-process regression after its real listener closes.
+  expect(
+    await Promise.race([
+      fixture.closed.then((exit) => ({ exit })),
+      delay(750).then(() => "waiting"),
+    ]),
+    fixture.output(),
+  ).toBe("waiting");
+}
+
+describe("runGatewayLoop failed-restart process lifetime", () => {
+  const posixIt = process.platform === "win32" ? it.skip : it;
+
+  posixIt(
+    "recovers in the same process after repeated operator-triggered startup failures",
+    async () => {
+      const fixture = startFixture();
+      await fixture.waitForOutput("ready:1");
+      fs.writeFileSync(fixture.faultPath, "refuse");
+      await expectFailedRestartWaiting(fixture, 2);
+      await expectFailedRestartWaiting(fixture, 3);
+      fs.unlinkSync(fixture.faultPath);
+      expect(fixture.child.kill("SIGUSR1")).toBe(true);
+      await fixture.waitForOutput("ready:4");
+      expect(fixture.child.kill("SIGTERM")).toBe(true);
+      expect(await fixture.closed, fixture.output()).toEqual([0, null]);
+    },
+    60_000,
+  );
+
+  posixIt.each(["SIGTERM", "SIGINT"] as const)(
+    "exits cleanly on %s while waiting after a failed restart",
+    async (signal) => {
+      const fixture = startFixture();
+      await fixture.waitForOutput("ready:1");
+      fs.writeFileSync(fixture.faultPath, "refuse");
+      await expectFailedRestartWaiting(fixture, 2);
+      expect(fixture.child.kill(signal)).toBe(true);
+      expect(await fixture.closed, fixture.output()).toEqual([0, null]);
+      expect(fixture.output()).not.toContain("start:3");
+    },
+    60_000,
+  );
+
+  posixIt(
+    "releases process ownership when initial startup rejects",
+    async () => {
+      const fixture = startFixture(true);
+      expect(await fixture.closed, fixture.output()).toEqual([1, null]);
+      expect(fixture.output()).toContain("fixture startup refused");
+      expect(fixture.output()).not.toContain("Process will stay alive");
+    },
+    60_000,
+  );
+});

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -3,6 +3,7 @@ import type { ChildProcess } from "node:child_process";
 import { randomUUID } from "node:crypto";
 import net from "node:net";
 import { performance } from "node:perf_hooks";
+import { MessageChannel } from "node:worker_threads";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { clearRuntimeConfigSnapshot } from "../../config/runtime-snapshot.js";
 import {
@@ -190,6 +191,10 @@ export async function runGatewayLoop(params: {
     { includeLinuxOpenClawGatewayServiceMarker: true },
   );
   let lock = await acquireGatewayLock({ port: params.lockPort });
+  // Process-owned signal handling must survive gaps with no listening server.
+  // Node's signal listeners and pending promises do not retain the event loop.
+  const processLifetime = params.ownsProcessLifecycle ? new MessageChannel() : undefined;
+  processLifetime?.port1.ref();
   let server: Awaited<ReturnType<typeof startGatewayServer>> | null = null;
   let hostLifecycle: ReturnType<typeof createGatewayHostLifecycle> | undefined;
   let startupOperations = createGatewayStartupOperations();
@@ -222,6 +227,8 @@ export async function runGatewayLoop(params: {
     process.removeListener("SIGTERM", onSigterm);
     process.removeListener("SIGINT", onSigint);
     process.removeListener("SIGUSR1", onSigusr1);
+    processLifetime?.port1.close();
+    processLifetime?.port2.close();
   };
   const exitProcess = (code: number) => {
     void hostLifecycle?.retire();

--- a/test/vitest/vitest.cli-process-paths.mjs
+++ b/test/vitest/vitest.cli-process-paths.mjs
@@ -14,6 +14,7 @@ export const cliProcessTestFiles = [
   "src/cli/plugins-authoring.process.test.ts",
   "src/cli/mcp-cli.import-boundary.test.ts",
   "src/cli/gateway-cli/run-loop.direct-stop-active-work.process.test.ts",
+  "src/cli/gateway-cli/run-loop.restart-liveness.process.test.ts",
   "src/cli/update-dry-run-state.process.test.ts",
   "src/cli/doctor-output.process.test.ts",
   "src/cli/update-cli/update-command-handoff.test.ts",


### PR DESCRIPTION
## What Problem This Solves

After a foreground Gateway closed its listener for restart and startup failed, it promised to remain alive but could exit with code 13 before the operator could retry.

## Why This Change Was Made

The CLI run loop keeps a referenced message port for the signal lifetime it already owns. Existing cleanup closes both ports. Restart timing, retry policy, and initial-start rejection stay with their current owners.

## User Impact

The foreground Gateway remains available for another restart attempt after refused startup and exits normally when stopped. No configuration or migration is required.

## Evidence

The real source CLI reproduced exit 13 after restart with missing encryption certificate files. With the fix, the same process survived two refused restarts, recovered after correcting configuration, returned authenticated health, and exited 0 on termination. Four subprocess tests cover repeated recovery, both termination signals, and initial-start rejection. Formatting, lint, whitespace checks, and required continuous integration passed. Packaged installation and Windows signals were not exercised.
