### PR TITLE
refactor(plugins): share active hook and skill root selection

### DIFF
--- a/src/hooks/plugin-hooks.ts
+++ b/src/hooks/plugin-hooks.ts
@@ -1,13 +1,8 @@
 // Plugin hook helpers discover hooks contributed by installed plugins.
 import path from "node:path";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  normalizePluginsConfigWithResolver,
-  resolvePolicyPluginActivationState,
-} from "../plugins/config-policy.js";
-import { resolveMemorySlotDecision } from "../plugins/config-state.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
-import { hasKind } from "../plugins/slots.js";
+import { iteratePluginRootContributions } from "../plugins/plugin-root-contributions.js";
 
 type PluginHookDirEntry = {
   dir: string;
@@ -34,46 +29,15 @@ export function resolvePluginHookDirs(params: {
     return [];
   }
 
-  const normalizedPlugins = normalizePluginsConfigWithResolver(
-    params.config?.plugins,
-    metadataSnapshot.normalizePluginId,
-  );
-  const memorySlot = normalizedPlugins.slots.memory;
-  let selectedMemoryPluginId: string | null = null;
   const seen = new Set<string>();
   const resolved: PluginHookDirEntry[] = [];
 
-  for (const record of registry.plugins) {
-    if (!record.hooks || record.hooks.length === 0) {
-      continue;
-    }
-    const activationState = resolvePolicyPluginActivationState({
-      id: record.id,
-      origin: record.origin,
-      channelIds: record.channels,
-      config: normalizedPlugins,
-      rootConfig: params.config,
-    });
-    if (!activationState.activated) {
-      continue;
-    }
-
-    const memoryDecision = resolveMemorySlotDecision({
-      id: record.id,
-      kind: record.kind,
-      slot: memorySlot,
-      selectedId: selectedMemoryPluginId,
-    });
-    if (!memoryDecision.enabled) {
-      continue;
-    }
-    // Memory plugin hooks follow the same slot winner as runtime memory
-    // providers so disabled memory implementations cannot register hooks.
-    if (memoryDecision.selected && hasKind(record.kind, "memory")) {
-      selectedMemoryPluginId = record.id;
-    }
-
-    for (const raw of record.hooks) {
+  for (const { record, roots } of iteratePluginRootContributions({
+    metadataSnapshot,
+    config: params.config,
+    contribution: "hooks",
+  })) {
+    for (const raw of roots) {
       const trimmed = raw.trim();
       if (!trimmed) {
         continue;

--- a/src/plugins/plugin-root-contributions.test.ts
+++ b/src/plugins/plugin-root-contributions.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it } from "vitest";
+import type { PluginManifestRecord } from "./manifest-registry.types.js";
+import { iteratePluginRootContributions } from "./plugin-root-contributions.js";
+
+function plugin(id: string, overrides: Partial<PluginManifestRecord> = {}): PluginManifestRecord {
+  return {
+    id,
+    channels: [],
+    providers: [],
+    cliBackends: [],
+    skills: ["./skills"],
+    hooks: ["./hooks"],
+    origin: "global",
+    rootDir: `/plugins/${id}`,
+    source: `/plugins/${id}/index.js`,
+    manifestPath: `/plugins/${id}/openclaw.plugin.json`,
+    ...overrides,
+  };
+}
+
+function metadata(plugins: PluginManifestRecord[]) {
+  return {
+    manifestRegistry: { plugins, diagnostics: [] },
+    normalizePluginId: (id: string) => id,
+  };
+}
+
+describe("plugin root contribution selection", () => {
+  it.each([
+    { contribution: "skills" as const, expected: ["bundled"] },
+    { contribution: "hooks" as const, expected: [] },
+  ])("preserves manifest default activation for $contribution", ({ contribution, expected }) => {
+    const selected = iteratePluginRootContributions({
+      metadataSnapshot: metadata([
+        plugin("bundled", { origin: "bundled", enabledByDefault: true }),
+      ]),
+      contribution,
+    });
+    expect(Array.from(selected, ({ record }) => record.id)).toEqual(expected);
+  });
+
+  it("checks contribution eligibility and activation before availability, then applies the slot", () => {
+    const checked: string[] = [];
+    const selected = iteratePluginRootContributions({
+      metadataSnapshot: metadata([
+        plugin("empty", { skills: [] }),
+        plugin("disabled"),
+        plugin("acpx", { kind: "memory" }),
+        plugin("other-memory", { kind: "memory" }),
+        plugin("memory-core", { kind: "memory" }),
+        plugin("ordinary"),
+      ]),
+      config: { plugins: { entries: { disabled: { enabled: false } } } },
+      contribution: "skills",
+      isAvailable: (record) => {
+        checked.push(record.id);
+        return record.id !== "acpx";
+      },
+    });
+
+    expect(Array.from(selected, ({ record }) => record.id)).toEqual(["memory-core", "ordinary"]);
+    expect(checked).toEqual(["acpx", "other-memory", "memory-core", "ordinary"]);
+  });
+
+  it.each([
+    { slot: undefined, expected: ["memory-core", "dual", "ordinary"] },
+    { slot: "alternate", expected: ["alternate", "dual", "ordinary"] },
+    { slot: "none", expected: ["dual", "ordinary"] },
+  ])("preserves memory slot $slot and other roles of dual-kind plugins", ({ slot, expected }) => {
+    const selected = iteratePluginRootContributions({
+      metadataSnapshot: metadata([
+        plugin("memory-core", { kind: "memory" }),
+        plugin("alternate", { kind: "memory" }),
+        plugin("dual", { kind: ["memory", "context-engine"] }),
+        plugin("ordinary"),
+      ]),
+      config: { plugins: { slots: { memory: slot } } },
+      contribution: "hooks",
+    });
+
+    expect(Array.from(selected, ({ record }) => record.id)).toEqual(expected);
+  });
+
+  it("keeps declared root order and values for consumer-owned validation", () => {
+    const selected = iteratePluginRootContributions({
+      metadataSnapshot: metadata([
+        plugin("first", { hooks: [" ", "./missing", "../outside", "./missing"] }),
+        plugin("second", { hooks: ["./hooks"] }),
+      ]),
+      contribution: "hooks",
+    });
+
+    expect(Array.from(selected, ({ record, roots }) => ({ id: record.id, roots }))).toEqual([
+      { id: "first", roots: [" ", "./missing", "../outside", "./missing"] },
+      { id: "second", roots: ["./hooks"] },
+    ]);
+  });
+});

--- a/src/plugins/plugin-root-contributions.ts
+++ b/src/plugins/plugin-root-contributions.ts
@@ -1,0 +1,56 @@
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  normalizePluginsConfigWithResolver,
+  resolvePolicyPluginActivationState,
+} from "./config-policy.js";
+import { resolveMemorySlotDecision } from "./config-state.js";
+import type { PluginManifestRecord } from "./manifest-registry.types.js";
+import type { PluginMetadataSnapshot } from "./plugin-metadata-snapshot.types.js";
+import { hasKind } from "./slots.js";
+
+/** Select active root contributions while leaving path validation and publication to consumers. */
+export function* iteratePluginRootContributions(params: {
+  metadataSnapshot: Pick<PluginMetadataSnapshot, "manifestRegistry" | "normalizePluginId">;
+  config?: OpenClawConfig;
+  contribution: "skills" | "hooks";
+  /** Availability is checked after activation and before claiming a memory slot. */
+  isAvailable?: (record: PluginManifestRecord) => boolean;
+}): IterableIterator<{ record: PluginManifestRecord; roots: string[] }> {
+  const normalizedPlugins = normalizePluginsConfigWithResolver(
+    params.config?.plugins,
+    params.metadataSnapshot.normalizePluginId,
+  );
+  const memorySlot = normalizedPlugins.slots.memory;
+  let selectedMemoryPluginId: string | null = null;
+  for (const record of params.metadataSnapshot.manifestRegistry.plugins) {
+    const roots = record[params.contribution];
+    if (!roots || roots.length === 0) {
+      continue;
+    }
+    const activationState = resolvePolicyPluginActivationState({
+      id: record.id,
+      origin: record.origin,
+      channelIds: record.channels,
+      config: normalizedPlugins,
+      rootConfig: params.config,
+      // Skill roots honor manifest defaults; hook roots leave that activation input unset.
+      ...(params.contribution === "skills" ? { enabledByDefault: record.enabledByDefault } : {}),
+    });
+    if (!activationState.activated || (params.isAvailable && !params.isAvailable(record))) {
+      continue;
+    }
+    const memoryDecision = resolveMemorySlotDecision({
+      id: record.id,
+      kind: record.kind,
+      slot: memorySlot,
+      selectedId: selectedMemoryPluginId,
+    });
+    if (!memoryDecision.enabled) {
+      continue;
+    }
+    if (memoryDecision.selected && hasKind(record.kind, "memory")) {
+      selectedMemoryPluginId = record.id;
+    }
+    yield { record, roots };
+  }
+}

--- a/src/skills/loading/plugin-skills.ts
+++ b/src/skills/loading/plugin-skills.ts
@@ -5,11 +5,6 @@ import { isAcpRuntimeSpawnAvailable } from "../../acp/runtime/availability.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isMissingPathError } from "../../infra/errors.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
-import {
-  normalizePluginsConfigWithResolver,
-  resolvePolicyPluginActivationState,
-} from "../../plugins/config-policy.js";
-import { resolveMemorySlotDecision } from "../../plugins/config-state.js";
 import { shouldRejectHardlinkedPluginFiles } from "../../plugins/hardlink-policy.js";
 import {
   pluginCacheExistsSync,
@@ -21,7 +16,7 @@ import { getPluginMetadataSnapshotCache, withPluginCache } from "../../plugins/p
 import { registerPluginMetadataProcessMemoLifecycleClear } from "../../plugins/plugin-metadata-lifecycle.js";
 import { resolvePluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
-import { hasKind } from "../../plugins/slots.js";
+import { iteratePluginRootContributions } from "../../plugins/plugin-root-contributions.js";
 import { isPathInside } from "../../security/scan-paths.js";
 import { CONFIG_DIR } from "../../utils.js";
 
@@ -92,51 +87,21 @@ function resolvePluginSkillRootsInOwner(
     return [];
   }
   const acpRuntimeAvailable = isAcpRuntimeSpawnAvailable({ config });
-  const normalizedPlugins = normalizePluginsConfigWithResolver(
-    config.plugins,
-    metadataSnapshot.normalizePluginId,
-  );
-  const memorySlot = normalizedPlugins.slots.memory;
-  let selectedMemoryPluginId: string | null = null;
   const seen = new Set<string>();
   const resolved: PluginSkillRoot[] = [];
 
-  for (const record of registry.plugins) {
-    if (!record.skills || record.skills.length === 0) {
-      continue;
-    }
-    const activationState = resolvePolicyPluginActivationState({
-      id: record.id,
-      origin: record.origin,
-      channelIds: record.channels,
-      config: normalizedPlugins,
-      rootConfig: config,
-      enabledByDefault: record.enabledByDefault,
-    });
-    if (!activationState.activated) {
-      continue;
-    }
+  for (const { record, roots } of iteratePluginRootContributions({
+    metadataSnapshot,
+    config,
+    contribution: "skills",
     // ACP router skills should not be attached unless ACP can actually spawn.
-    if (!acpRuntimeAvailable && record.id === "acpx") {
-      continue;
-    }
-    const memoryDecision = resolveMemorySlotDecision({
-      id: record.id,
-      kind: record.kind,
-      slot: memorySlot,
-      selectedId: selectedMemoryPluginId,
-    });
-    if (!memoryDecision.enabled) {
-      continue;
-    }
-    if (memoryDecision.selected && hasKind(record.kind, "memory")) {
-      selectedMemoryPluginId = record.id;
-    }
+    isAvailable: (candidate) => acpRuntimeAvailable || candidate.id !== "acpx",
+  })) {
     const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
       origin: record.origin,
       rootDir: record.rootDir,
     });
-    for (const raw of record.skills) {
+    for (const raw of roots) {
       const trimmed = raw.trim();
       if (!trimmed) {
         continue;


### PR DESCRIPTION
## What Problem This Solves

Plugin hook and skill discovery independently select active manifest contributions and apply memory-slot policy. These copies can drift when activation or slot handling changes.

## Why This Change Was Made

One metadata-owned iterator selects the original records and declared roots. It preserves manifest order and the sequence of contribution eligibility, activation, caller availability, memory-slot selection, and consumer processing.

Skills continue to honor manifest `enabledByDefault`; hooks retain their existing omission of that input. ACP availability stays skill-owned and is checked before slot selection. The iterator uses the supplied snapshot and adds no metadata loading, filesystem lookup, or cache.

## User Impact

No intended behavior change. Skill validation, hardlink/containment rules, bundle expansion, publication, and cleanup remain in the skill loader. Hook discovery still returns missing selected roots so a failed reload can retain its previously committed hooks. Existing public exports and configuration remain unchanged.

Production shrinks by 15 lines; the canonical owner's policy cases add 98 test lines. The existing 955-line skill suite is unchanged.

## Evidence

`node scripts/run-vitest.mjs src/plugins/plugin-root-contributions.test.ts src/hooks/plugin-hooks.test.ts src/skills/loading/plugin-skills.test.ts src/plugins/config-policy.test.ts src/plugins/config-state.test.ts`: **115 passed**, four shards in **25.48s**. Independent autoreview is clean through P3. Existing hook and skill tests cover active roots, immutable metadata reuse, missing hook roots, live ACP availability, aliases, containment, and generated-link cleanup. The new owner cases cover distinct default activation, availability/slot order, default/pinned/disabled memory slots, dual-kind plugins, and raw root order.

The initial changed check caught one callback parameter shadowing the loop binding. Renaming that parameter preserves behavior; the full `node scripts/check-changed.mjs` then passed. The affected skill suite passed again (**36 tests**), `pnpm check:madge-import-cycles` reports **0 cycles**, and final autoreview is clean through P3. `pnpm build` passed in **4m27.6s**.

The commit rebased patch-identically onto `43bc88f6f784`; the root-selection and activation dependencies are unchanged on that base. No SDK entrypoint, public export, persistent row, cache owner, or config field changes.

Exact-head [CI run 34137344392](https://github.com/openclaw/openclaw/actions/runs/34137344392) passed for `3f9b5c31a5e4dd95380d5aef88e18c09955e014e`; no rerun. Final review found no actionable defect or before-merge item.
