### PR TITLE
fix(channels): preserve account names in agent listings

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2205,7 +2205,7 @@ src/channels/plugins/message-action-dispatch.ts	5
 src/channels/plugins/meta-normalization.ts	1
 src/channels/plugins/package-state-probes.ts	2
 src/channels/plugins/read-only-command-defaults.ts	2
-src/channels/plugins/read-only.ts	6
+src/channels/plugins/read-only.ts	4
 src/channels/plugins/registry.ts	1
 src/channels/plugins/session-thread-info-loaded.ts	1
 src/channels/plugins/setup-contract.ts	3

--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -37,6 +37,9 @@ openclaw agents delete work
 
 Options: `--json`, `--bindings` (include full routing rules, not only per-agent counts/summaries).
 
+Provider-status labels include optional account display names beside account IDs.
+Routing rules continue to identify accounts by channel and account ID.
+
 Identity fields saved in config take precedence. Fields that are not configured
 fall back to `IDENTITY.md` in the agent's workspace. Unsupported avatar values
 and unreadable local images also fall back to the workspace avatar.

--- a/src/channels/plugins/manifest-channel-plugin.types.ts
+++ b/src/channels/plugins/manifest-channel-plugin.types.ts
@@ -3,6 +3,7 @@ import type { ChannelConfigSchema } from "./types.config.js";
 
 type ManifestChannelAccount = {
   accountId: string;
+  name?: string;
   config: Record<string, unknown>;
 };
 

--- a/src/channels/plugins/read-only.test.ts
+++ b/src/channels/plugins/read-only.test.ts
@@ -3,6 +3,11 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import {
+  buildProviderStatusIndex,
+  buildProviderSummaryMetadataIndex,
+  listProvidersForAgent,
+} from "../../commands/agents.providers.js";
+import {
   cleanupPluginLoaderFixturesForTest,
   EMPTY_PLUGIN_SCHEMA,
   makePluginLoaderTempDir,
@@ -425,6 +430,114 @@ afterAll(() => {
 });
 
 describe("listReadOnlyChannelPluginsForConfig", () => {
+  it.each([
+    {
+      label: "named",
+      name: " Operations desk ",
+      expectedName: "Operations desk",
+      expected: "ops (Operations desk)",
+    },
+    { label: "unnamed", name: undefined, expectedName: undefined, expected: "ops" },
+    { label: "blank", name: "   ", expectedName: undefined, expected: "ops" },
+  ])(
+    "keeps $label concrete account labels on the real cold adapter",
+    async ({ name, expectedName, expected }) => {
+      const { bundledRoot, channelId, pluginId, setupMarker, fullMarker } =
+        writeBundledSetupChannelPlugin();
+      const cfg = {
+        agents: { entries: { main: { workspace: bundledRoot } } },
+        channels: {
+          [channelId]: {
+            enabled: true,
+            name: "Root name is not an account fallback",
+            accounts: {
+              ops: { name },
+              plain: {},
+              unbound: { name: "Unbound account" },
+            },
+          },
+        },
+        plugins: { allow: [pluginId] },
+        bindings: [
+          { type: "route", agentId: "main", match: { channel: channelId, accountId: "ops" } },
+          { type: "route", agentId: "main", match: { channel: channelId, accountId: "plain" } },
+        ],
+      } satisfies Parameters<typeof buildProviderStatusIndex>[0];
+      const originalConfig = JSON.stringify(cfg);
+
+      const providerStatus = await buildProviderStatusIndex(cfg);
+      const lines = listProvidersForAgent({
+        summaryIsDefault: true,
+        cfg,
+        bindings: cfg.bindings,
+        providerStatus,
+        providerMetadata: buildProviderSummaryMetadataIndex(cfg),
+      });
+
+      expect(lines).toEqual([
+        `Bundled Chat ${expected}: configured`,
+        "Bundled Chat plain: configured",
+      ]);
+      expect(providerStatus.has(`${channelId}:unbound`)).toBe(true);
+      const adapter = listReadOnlyChannelPluginsForConfig(cfg).find(
+        (entry) => entry.id === channelId,
+      );
+      const account = expectRecordFields(adapter?.config.resolveAccount(cfg, "ops"), {
+        accountId: "ops",
+        name: expectedName,
+      });
+      expect(account.config).toBe(cfg.channels[channelId]?.accounts.ops);
+      expect(JSON.stringify(cfg)).toBe(originalConfig);
+      expect(fs.existsSync(setupMarker)).toBe(false);
+      expect(fs.existsSync(fullMarker)).toBe(false);
+    },
+  );
+
+  it("keeps loaded inspector names ahead of manifest config names", async () => {
+    const { bundledRoot, channelId, pluginId, setupMarker, fullMarker } =
+      writeBundledSetupChannelPlugin();
+    const cfg = {
+      agents: { entries: { main: { workspace: bundledRoot } } },
+      channels: { [channelId]: { enabled: true, accounts: { ops: { name: "Cold config name" } } } },
+      plugins: { allow: [pluginId] },
+      bindings: [
+        { type: "route", agentId: "main", match: { channel: channelId, accountId: "ops" } },
+      ],
+    } satisfies Parameters<typeof buildProviderStatusIndex>[0];
+    const resolveAccount = vi.fn(() => {
+      throw new Error("loaded inspector must own account metadata");
+    });
+    const plugin = createChannelTestPluginBase({
+      id: channelId,
+      label: "Loaded Chat",
+      config: {
+        listAccountIds: () => ["ops"],
+        resolveAccount,
+        inspectAccount: (_cfg, accountId) => ({
+          accountId,
+          name: "Inspector name",
+          enabled: true,
+          configured: true,
+        }),
+      },
+    });
+    setActivePluginRegistry(createTestRegistry([{ pluginId, plugin, source: "test" }]));
+
+    const providerStatus = await buildProviderStatusIndex(cfg);
+    expect(
+      listProvidersForAgent({
+        summaryIsDefault: true,
+        cfg,
+        bindings: cfg.bindings,
+        providerStatus,
+        providerMetadata: buildProviderSummaryMetadataIndex(cfg),
+      }),
+    ).toEqual(["Loaded Chat ops (Inspector name): configured"]);
+    expect(resolveAccount).not.toHaveBeenCalled();
+    expect(fs.existsSync(setupMarker)).toBe(false);
+    expect(fs.existsSync(fullMarker)).toBe(false);
+  });
+
   it("keeps explicitly supplied metadata inventories separate for the same config", () => {
     const { pluginDir } = writeExternalSetupChannelPlugin({
       setupEntry: false,

--- a/src/channels/plugins/read-only.ts
+++ b/src/channels/plugins/read-only.ts
@@ -3,6 +3,8 @@
  *
  * Builds lightweight channel plugin views from config, manifests, and setup metadata.
  */
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
   sortUniqueStrings,
   uniqueStrings,
@@ -189,25 +191,25 @@ function resolveManifestChannelDefaultAccountId(cfg: OpenClawConfig, channelId: 
   });
 }
 
-function resolveManifestChannelAccountConfig(params: {
+function resolveManifestChannelAccount(params: {
   cfg: OpenClawConfig;
   channelId: string;
   accountId?: string | null;
-}): Record<string, unknown> {
+}): ReturnType<ManifestChannelPlugin["config"]["resolveAccount"]> {
   const channelConfig = getChannelConfigRecord(params.cfg, params.channelId);
-  const resolvedAccountId = normalizeAccountId(params.accountId);
-  const accounts = channelConfig.accounts;
-  if (accounts && typeof accounts === "object" && !Array.isArray(accounts)) {
-    const accountConfig = resolveNormalizedAccountEntry(
-      accounts as Record<string, unknown>,
-      resolvedAccountId,
-      normalizeManifestAccountConfigKey,
-    );
-    if (accountConfig && typeof accountConfig === "object" && !Array.isArray(accountConfig)) {
-      return accountConfig as Record<string, unknown>;
-    }
-  }
-  return channelConfig;
+  const accountId = normalizeAccountId(params.accountId);
+  const accounts = asOptionalRecord(channelConfig.accounts);
+  const config =
+    asOptionalRecord(
+      accounts
+        ? resolveNormalizedAccountEntry(accounts, accountId, normalizeManifestAccountConfigKey)
+        : undefined,
+    ) ?? channelConfig;
+  return {
+    accountId,
+    name: normalizeOptionalString(readOwnRecordValue(config, "name")),
+    config,
+  };
 }
 
 function buildManifestChannelPlugin(params: {
@@ -297,14 +299,8 @@ function createManifestChannelPlugin(params: {
     config: {
       listAccountIds: (cfg) => listManifestChannelAccountIds(cfg, params.channelId),
       defaultAccountId: (cfg) => resolveManifestChannelDefaultAccountId(cfg, params.channelId),
-      resolveAccount: (cfg, accountId) => ({
-        accountId: normalizeAccountId(accountId),
-        config: resolveManifestChannelAccountConfig({
-          cfg,
-          channelId: params.channelId,
-          accountId,
-        }),
-      }),
+      resolveAccount: (cfg, accountId) =>
+        resolveManifestChannelAccount({ cfg, channelId: params.channelId, accountId }),
       isEnabled: (account, cfg) =>
         getChannelConfigRecord(cfg, params.channelId).enabled !== false &&
         account.config.enabled !== false,


### PR DESCRIPTION
Closes #141263

## What Problem This Solves

Fixes an issue where users running `openclaw agents list --bindings` would see only account IDs when a manifest-backed channel account had a configured display name. The same omission affected the enriched provider labels in `agents list --json --bindings`.

## Why This Change Was Made

The cold manifest adapter kept the name inside its selected configuration, while existing label consumers read the account's top-level name. The adapter now produces the complete account: one normalized ID, its own normalized optional display name, and the original selected configuration object. This repairs the shared producer without loading channel setup or runtime code for static metadata.

Account selection, binding IDs, routing, loaded-inspector precedence, and configuration/state semantics remain unchanged. Blank names stay absent; concrete accounts do not inherit a channel-root name. Production delta is −3 lines; regression coverage adds 113 lines. The assertion-safety baseline shrinks from six casts to four.

## User Impact

Named accounts are recognizable in agent provider summaries: `Name Proof ops: configured` becomes `Name Proof ops (Operations desk): configured`. Routing and binding descriptions continue to use stable account IDs.

## Evidence

The baseline regression failed for the missing label with 49 passing controls. The fixed focused/sibling suites passed 76 cases with one Windows-only skip, and all 495 channel-contract cases passed. The complete five-file changed check passed. Independent managed review found no actionable P0–P2 findings.

The normal baseline and fixed builds passed. Each CLI proof exercised five fresh ordinary commands plus config validation, with complete structured-output checks, inert plugin import markers, and an inspected native terminal capture. The fixed output differs only by the intended account label: plain JSON, binding JSON, routing IDs, fixture config, and plugin files are unchanged. Both full artifact seals and natural process cleanup passed. This is isolated CLI evidence with synthetic configuration, not channel connectivity or provider-health proof.

The fixed build’s initial seal stopped on an extra check-generated SDK output root; its cache signature was stale after normal build changed installed AI-package chunk names. The canonical SDK generator refreshed the receipt with identical declaration bytes. The final seal verified all 19 roots, preserving both original failures.

Proof is on candidate `4029443f5201407662bc3882bcb77b58379af9cc` over `5bf5dc9c5be8366f99e0291c01cd3aafb7ab5a4a`. Source composition against main `43bc88f6f78410b86548ac29ec3f13a762481ae9` preserves the five-file patch and all account-name owner/caller contracts. The local CLI used the candidate’s fs-safe 0.8.3; it is not a live claim for main’s 0.8.5 or newer state-publication behavior.

Before:
![Account name omitted from agent provider summary](https://github.com/user-attachments/assets/026e367e-4515-4262-b2a1-070145ef58fd)

After (attached):

![Configured account name visible beside its routing ID](https://github.com/user-attachments/assets/2713059f-f42a-4767-9afe-d86bcaba67f8)