### PR TITLE
fix(gateway): trim device.pair approve/reject requestId

### DIFF
--- a/src/gateway/server-methods/devices.test.ts
+++ b/src/gateway/server-methods/devices.test.ts
@@ -417,6 +417,58 @@ describe("device management", () => {
     );
   });
 
+  it("approves a pending request when requestId has clipboard padding", async () => {
+    approveDevicePairingMock.mockResolvedValue({
+      status: "approved",
+      requestId: "req-padded-approve",
+      device: {
+        deviceId: "device-1",
+        publicKey: "pk-1",
+        approvedAtMs: 100,
+        createdAtMs: 50,
+      },
+    });
+    const notify = vi.fn();
+    const base = createOptions(
+      "device.pair.approve",
+      { requestId: "  req-padded-approve  " },
+      {
+        client: createClient(["operator.admin"], "device-admin", { isDeviceTokenAuth: true }),
+      },
+    );
+    const opts = {
+      ...base,
+      context: {
+        ...base.context,
+        scopeUpgradeCoordinator: { notify },
+      },
+    };
+
+    await expectDefined(
+      deviceHandlers["device.pair.approve"],
+      'deviceHandlers["device.pair.approve"] test invariant',
+    )(opts);
+
+    expect(approveDevicePairingMock).toHaveBeenCalledWith("req-padded-approve", {
+      callerScopes: ["operator.admin"],
+    });
+    expect(notify).toHaveBeenCalledWith("req-padded-approve", "approved");
+    expect(opts.respond).toHaveBeenCalledWith(
+      true,
+      {
+        requestId: "req-padded-approve",
+        device: {
+          deviceId: "device-1",
+          publicKey: "pk-1",
+          approvedAtMs: 100,
+          createdAtMs: 50,
+          tokens: undefined,
+        },
+      },
+      undefined,
+    );
+  });
+
   it("allows shared-auth operator sessions to approve operator roles within caller scopes", async () => {
     getPendingDevicePairingMock.mockResolvedValue({
       requestId: "req-1",
@@ -634,6 +686,42 @@ describe("device management", () => {
     expect(opts.respond).toHaveBeenCalledWith(
       true,
       { requestId: "req-1", deviceId: "device-1", rejectedAtMs: 123 },
+      undefined,
+    );
+  });
+
+  it("rejects a pending request when requestId has clipboard padding", async () => {
+    rejectDevicePairingMock.mockResolvedValue({
+      requestId: "req-padded-reject",
+      deviceId: "device-2",
+      rejectedAtMs: 456,
+    });
+    const notify = vi.fn();
+    const base = createOptions(
+      "device.pair.reject",
+      { requestId: "  req-padded-reject  " },
+      {
+        client: createClient(["operator.admin"], "device-admin", { isDeviceTokenAuth: true }),
+      },
+    );
+    const opts = {
+      ...base,
+      context: {
+        ...base.context,
+        scopeUpgradeCoordinator: { notify },
+      },
+    };
+
+    await expectDefined(
+      deviceHandlers["device.pair.reject"],
+      'deviceHandlers["device.pair.reject"] test invariant',
+    )(opts);
+
+    expect(rejectDevicePairingMock).toHaveBeenCalledWith("req-padded-reject");
+    expect(notify).toHaveBeenCalledWith("req-padded-reject", "rejected");
+    expect(opts.respond).toHaveBeenCalledWith(
+      true,
+      { requestId: "req-padded-reject", deviceId: "device-2", rejectedAtMs: 456 },
       undefined,
     );
   });

--- a/src/gateway/server-methods/devices.ts
+++ b/src/gateway/server-methods/devices.ts
@@ -259,7 +259,9 @@ export const deviceHandlers: GatewayRequestHandlers = {
     ) {
       return;
     }
-    const { requestId } = params as { requestId: string };
+    // Match gateway.suspend.prepare / device.scopes.waitUpgrade: clipboard padding
+    // must not miss a live pending pairing requestId.
+    const requestId = (params as { requestId: string }).requestId.trim();
     const authz = resolveDeviceSessionAuthz(client);
     if (!authz.isAdminCaller) {
       const pending = await getPendingDevicePairing(requestId);
@@ -372,7 +374,9 @@ export const deviceHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateDevicePairRejectParams, "device.pair.reject", respond)) {
       return;
     }
-    const { requestId } = params as { requestId: string };
+    // Match gateway.suspend.prepare / device.scopes.waitUpgrade: clipboard padding
+    // must not miss a live pending pairing requestId.
+    const requestId = (params as { requestId: string }).requestId.trim();
     const authz = resolveDeviceSessionAuthz(client);
     if (authz.callerDeviceId && !authz.isAdminCaller) {
       const pending = await getPendingDevicePairing(requestId);


### PR DESCRIPTION
## Summary
- `device.pair.approve` / `device.pair.reject` looked up pending pairings by exact `requestId` and did not trim clipboard/UI padding.
- Same incomplete coverage pattern as `gateway.suspend.prepare`, `device.scopes.waitUpgrade`, and `node.pair.approve/reject`.
- XS fix: trim `requestId` once at the handler boundary so store lookup, scope-upgrade notify, and response identity all use the canonical id.

## Concrete scenario
1. Device creates a pending pairing; operator copies `requestId` with leading/trailing spaces.
2. Operator calls `device.pair.approve` / `reject` with the padded id.
3. Before: exact `pendingById[requestId]` miss → `unknown requestId` / approval denied while pending remains.
4. After: handler trims, approve/reject and `scopeUpgradeCoordinator.notify` hit the live request.

## Test plan
- [x] Unit: padded approve/reject requestId before-fail / after-pass (`devices.test.ts` clipboard padding cases)
- [x] Store proof: padded id MISS; trimmed id approves (`scripts/device-pair-requestid-trim-proof.mts`)