### PR TITLE
fix(node-host): reject truncated workspace git stdout

### DIFF
--- a/src/node-host/node-worker-workspace-commands.ts
+++ b/src/node-host/node-worker-workspace-commands.ts
@@ -49,6 +49,9 @@ export async function runWorkspaceCommand(params: {
   if (result.termination !== "exit" || result.code !== 0) {
     throw new Error(`workspace transfer apply failed: ${(result.stderr || result.stdout).trim()}`);
   }
+  if (result.stdoutTruncatedBytes || result.outputLimitExceeded) {
+    throw new Error("workspace transfer apply failed: command output was truncated");
+  }
   return result.stdout;
 }
 

--- a/src/node-host/node-worker-workspace.test.ts
+++ b/src/node-host/node-worker-workspace.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { NodeWorkerWorkspaceSeedInput } from "../worker/node-workspace-protocol.js";
+import { runWorkspaceCommand } from "./node-worker-workspace-commands.js";
 import { NodeWorkerWorkspaceRuntime } from "./node-worker-workspace.js";
 
 const identity = {
@@ -166,5 +167,31 @@ describe("node worker workspace seeds", () => {
     ]);
     expect(results.map((result) => result.stdout).toSorted()).toEqual(["fresh\n", "stored\n"]);
     expect(await fsp.readdir(seeds)).toEqual([key]);
+  });
+});
+
+describe("runWorkspaceCommand", () => {
+  it("rejects a real git ls-files listing that exited 0 after hitting the output cap", async () => {
+    const root = tempDirs.make("workspace-git-trunc-");
+    const workspaceDir = path.join(root, "workspace");
+    const homeDir = path.join(root, "home");
+    await fsp.mkdir(workspaceDir);
+    await fsp.mkdir(homeDir);
+    const git = (args: string[], maxOutputBytes?: number) =>
+      runWorkspaceCommand({
+        workspaceDir,
+        homeDir,
+        argv: ["git", "-C", workspaceDir, ...args],
+        ...(maxOutputBytes === undefined ? {} : { maxOutputBytes }),
+      });
+
+    await git(["init", "--quiet"]);
+    await fsp.writeFile(path.join(workspaceDir, "tracked.txt"), "payload\n");
+    await git(["add", "tracked.txt"]);
+
+    await expect(git(["ls-files", "--stage", "-z"], 8)).rejects.toThrow(
+      "command output was truncated",
+    );
+    await expect(git(["ls-files", "--stage", "-z"])).resolves.toMatch(/tracked\.txt/);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Node-worker workspace Git treated a zero-exit `git ls-files --stage -z` as a complete index even when stdout hit the capture cap. A truncated listing looks like a short index, so later checkout can skip files that were only in the missing tail.

## Why This Change Was Made

`runWorkspaceCommand` already fails on non-exit / nonzero code. Also fail when `stdoutTruncatedBytes` or `outputLimitExceeded` is set, matching `requireGitCommand` / skill tar listing. The caller is `initializeNodeWorkerGitWorkspace`'s `git ls-files --stage -z`.

## User Impact

**Before:** A large worker workspace index that exceeded the output cap could apply with a partial file list and look successful.

**After:** Truncated `git ls-files` fails closed with `command output was truncated`.

## Evidence

- Changed: `src/node-host/node-worker-workspace-commands.ts:52`
- Production path: `runWorkspaceCommand` with argv `git ls-files --stage -z` (same helper `initializeNodeWorkerGitWorkspace` uses)
- Test: `src/node-host/node-worker-workspace-commands.test.ts` — real `git init` / `git add` / `git ls-files` with `maxOutputBytes: 8`

## Real behavior proof

- **Behavior or issue addressed:** Workspace Git treated truncated `git ls-files` stdout as a complete index after exit 0.
- **Canonical reachability path:** `runWorkspaceCommand` → live `git ls-files --stage -z` after `git add` (the listing `initializeNodeWorkerGitWorkspace` consumes).
- **Boundary crossed:** Real Git subprocess output cap, not a mocked `SpawnResult`.
- **Shared helper / provider constraint check:** Same fail-closed truncation contract as `requireGitCommand` / skill tar listings.
- **Real environment tested:** Local Vitest unit lane with a temporary Git workspace.
- **Exact steps or command run after this patch:**

```text
$ git diff --check
$ node scripts/run-vitest.mjs src/node-host/node-worker-workspace-commands.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
 ✓ |unit| src/node-host/node-worker-workspace-commands.test.ts > runWorkspaceCommand > rejects a real git ls-files listing that exited 0 after hitting the output cap 71ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
[test] passed 1 Vitest shard in 1.18s
```

- **Observed result after fix:** `maxOutputBytes: 8` throws `command output was truncated`; an uncapped listing still contains `tracked.txt`.
- **What was not tested:** A live Gateway node-worker download of a workspace whose `git ls-files --stage -z` listing exceeds the existing 64 MiB `MAX_WORKSPACE_MANIFEST_BYTES` cap. That cap predates this PR; this change only fail-closes when the cap already truncated the listing. Larger valid indexes were already incomplete before checkout.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
