### PR TITLE
fix(ui): avoid broken characters in download filenames

### DIFF
--- a/ui/src/e2e/managed-image-actions.e2e.test.ts
+++ b/ui/src/e2e/managed-image-actions.e2e.test.ts
@@ -20,6 +20,8 @@ beforeEach(() => {
 
 suite.define(() => {
   it("previews, downloads, and opens a ticketed generated image", async () => {
+    const filenamePrefix = "a".repeat(119);
+    const imageTitle = `${filenamePrefix}📊`;
     const context = await suite.newBrowserContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const attachmentId = crypto.randomUUID();
@@ -50,7 +52,7 @@ suite.define(() => {
               type: "image",
               artifactId,
               url: imageUrl,
-              alt: "Ticketed generated image",
+              alt: imageTitle,
               mimeType: "image/png",
               width: 1280,
               height: 358,
@@ -64,7 +66,7 @@ suite.define(() => {
           artifact: {
             id: artifactId,
             type: "image",
-            title: "Ticketed generated image",
+            title: imageTitle,
             mimeType: "image/png",
             download: { mode: "url" },
           },
@@ -76,7 +78,7 @@ suite.define(() => {
 
     try {
       await page.goto(`${suite.server.baseUrl}${controlUiBasePath.slice(1)}/chat`);
-      const image = page.getByAltText("Ticketed generated image");
+      const image = page.getByAltText(imageTitle);
       await image.waitFor({ state: "visible", timeout: 10_000 });
       await expect
         .poll(() =>
@@ -98,9 +100,7 @@ suite.define(() => {
       const imageActions = imageFrame.locator(".chat-image-actions");
       await expect.poll(() => imageActions.getByRole("button").count()).toBe(2);
       await expect
-        .poll(() =>
-          imageActions.getByRole("button", { name: "Open image Ticketed generated image" }).count(),
-        )
+        .poll(() => imageActions.getByRole("button", { name: `Open image ${imageTitle}` }).count())
         .toBe(0);
       const downloadButton = imageActions.getByRole("button", { name: "Download image" });
       await expect
@@ -124,11 +124,11 @@ suite.define(() => {
         .toMatchObject({ hit: true, pointerEvents: "auto" });
       const download = page.waitForEvent("download");
       await downloadButton.click();
-      expect((await download).suggestedFilename()).toBe("Ticketed generated image.png");
+      expect((await download).suggestedFilename()).toBe(`${filenamePrefix}.png`);
 
-      await page.getByRole("button", { name: "Open image Ticketed generated image" }).click();
+      await page.getByRole("button", { name: `Open image ${imageTitle}` }).click();
       await page
-        .getByRole("dialog", { name: "Image preview: Ticketed generated image" })
+        .getByRole("dialog", { name: `Image preview: ${imageTitle}` })
         .waitFor({ state: "visible" });
       expect(requestedVariants).toEqual(["thumbnail", "full"]);
       expect(await gateway.getRequests("artifacts.download")).toHaveLength(2);

--- a/ui/src/pages/chat/components/chat-message-images.ts
+++ b/ui/src/pages/chat/components/chat-message-images.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { html, noChange, nothing } from "lit";
 import { AsyncDirective, directive } from "lit/async-directive.js";
 import { Directive } from "lit/directive.js";
@@ -601,13 +602,13 @@ async function readManagedOutgoingImageBlob(
 
 function imageDownloadFileName(title: string, mimeType: string): string {
   const extension = mimeType === "image/jpeg" ? "jpg" : mimeType.split("/", 2)[1] || "img";
-  const stem = Array.from(title, (character) =>
+  const rawStem = Array.from(title, (character) =>
     character.codePointAt(0)! <= 0x1f || '<>:"/\\|?*'.includes(character) ? "-" : character,
   )
     .join("")
     .replace(/\.[a-z0-9]{1,10}$/iu, "")
-    .replace(/[. -]+$/u, "")
-    .slice(0, 120);
+    .replace(/[. -]+$/u, "");
+  const stem = truncateUtf16Safe(rawStem, 120);
   return `${stem || "generated-image"}.${/^[a-z0-9.+-]{1,12}$/u.test(extension) ? extension : "img"}`;
 }
 

--- a/ui/src/pages/chat/components/widget-export.test.ts
+++ b/ui/src/pages/chat/components/widget-export.test.ts
@@ -141,37 +141,18 @@ describe("widget export", () => {
     expect(fetchDocument).not.toHaveBeenCalled();
   });
 
-  it("sanitizes PNG download filenames and falls back to widget", async () => {
+  it.each([
+    ["  Quarterly / status: Q3?  ", "Quarterly-status-Q3.png"],
+    ["... <> ", "widget.png"],
+    [`${"a".repeat(119)}📊`, `${"a".repeat(119)}.png`],
+  ])("sanitizes PNG download filename %s", async (title, filename) => {
     const frame = createWidgetFrame();
     const download = vi.fn();
-    await exportWidget("download", frame, "  Quarterly / status: Q3?  ", {
+    await exportWidget("download", frame, title, {
       requestSnapshot: () => Promise.resolve(PNG_DATA_URL),
       download,
     });
-    await exportWidget("download", frame, "... <> ", {
-      requestSnapshot: () => Promise.resolve(PNG_DATA_URL),
-      download,
-    });
-    expect(download.mock.calls).toEqual([
-      [PNG_DATA_URL, "Quarterly-status-Q3.png"],
-      [PNG_DATA_URL, "widget.png"],
-    ]);
-  });
-
-  it("does not split a supplementary-plane character in PNG download filenames", async () => {
-    const frame = createWidgetFrame();
-    const names: string[] = [];
-    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
-      function clickDownload(this: HTMLAnchorElement) {
-        if (this.download) {
-          names.push(this.download);
-        }
-      },
-    );
-    await exportWidget("download", frame, `a${"📊".repeat(61)}`, {
-      requestSnapshot: () => Promise.resolve(PNG_DATA_URL),
-    });
-    expect(names).toEqual([`a${"📊".repeat(59)}.png`]);
+    expect(download.mock.calls).toEqual([[PNG_DATA_URL, filename]]);
   });
 
   it("rejects non-PNG and oversized snapshot replies", async () => {

--- a/ui/src/pages/chat/components/widget-export.test.ts
+++ b/ui/src/pages/chat/components/widget-export.test.ts
@@ -158,6 +158,22 @@ describe("widget export", () => {
     ]);
   });
 
+  it("does not split a supplementary-plane character in PNG download filenames", async () => {
+    const frame = createWidgetFrame();
+    const names: string[] = [];
+    vi.spyOn(HTMLAnchorElement.prototype, "click").mockImplementation(
+      function clickDownload(this: HTMLAnchorElement) {
+        if (this.download) {
+          names.push(this.download);
+        }
+      },
+    );
+    await exportWidget("download", frame, `a${"📊".repeat(61)}`, {
+      requestSnapshot: () => Promise.resolve(PNG_DATA_URL),
+    });
+    expect(names).toEqual([`a${"📊".repeat(59)}.png`]);
+  });
+
   it("rejects non-PNG and oversized snapshot replies", async () => {
     for (const dataUrl of [
       "data:image/jpeg;base64,aW1hZ2U=",

--- a/ui/src/pages/chat/components/widget-export.ts
+++ b/ui/src/pages/chat/components/widget-export.ts
@@ -1,3 +1,4 @@
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { beginClipboardCopy } from "../../../lib/clipboard.ts";
 
 const WIDGET_SNAPSHOT_REQUEST_TYPE = "openclaw:widget-snapshot-request";
@@ -89,19 +90,17 @@ export async function exportWidget(
   title: string | undefined,
   runtime: WidgetExportRuntime = {},
 ): Promise<"png" | "html" | "rerender-required"> {
-  const filename =
-    Array.from((title ?? "").trim(), (character) => {
-      const codePoint = character.codePointAt(0) ?? 0;
-      return codePoint <= 0x1f || codePoint === 0x7f || '<>:"/\\|?*'.includes(character)
-        ? "-"
-        : character;
-    })
-      .join("")
-      .replace(/\s+/g, "-")
-      .replace(/-+/g, "-")
-      .replace(/^[. -]+|[. -]+$/g, "")
-      .slice(0, 120)
-      .replace(/[. -]+$/g, "") || "widget";
+  const rawStem = Array.from((title ?? "").trim(), (character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 0x1f || codePoint === 0x7f || '<>:"/\\|?*'.includes(character)
+      ? "-"
+      : character;
+  })
+    .join("")
+    .replace(/\s+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^[. -]+|[. -]+$/g, "");
+  const filename = truncateUtf16Safe(rawStem, 120).replace(/[. -]+$/g, "") || "widget";
   const snapshot = (runtime.requestSnapshot ?? requestWidgetSnapshot)(
     frame,
     runtime.timeoutMs === undefined ? {} : { timeoutMs: runtime.timeoutMs },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where widget exports and generated-image downloads could receive a broken character in the filename when a long title was truncated in the middle of an emoji.

## Why This Change Was Made

Use the existing UTF-16-safe truncation helper at both 120-unit filename limits. Each surface keeps its existing sanitizer, fallback name, and extension rules. Consolidate the widget filename examples and cover the same boundary through the existing image-download browser scenario.

Production changes are neutral (+16/−16); tests are three lines smaller (+16/−19).

## User Impact

A supplementary character crossing the limit is omitted whole instead of becoming a broken character. Short names, exact-limit names, sanitization, and fallback behavior stay the same.

## Evidence

Built Control UI and Chromium checks used a synthetic mock Gateway, the real widget snapshot bridge, and actual browser downloads. For a title containing 119 ASCII `a` characters followed by `📊`, the browser suggested these names (`prefix` means those same 119 characters):

| Download | Before | After |
| --- | --- | --- |
| Widget PNG | `prefix�.png` | `prefix.png` |
| Generated image | `prefix�.png` | `prefix.png` |

Both defects were observed in the [baseline browser job](https://github.com/steipete/openclaw/actions/runs/34153109025/job/101839393088). The [candidate job](https://github.com/steipete/openclaw/actions/runs/34158305543/job/101856913400) passed nine owner tests, three browser cases, and the full changed-file gate. All twelve sibling filenames were unchanged, and all fourteen saved PNGs were byte-identical to baseline. The image scenario also retained its subpath, ticket, hit-area, and preview checks.

The inspected synthetic screenshots show the actual export/download routes. The filename comparison comes from the browser's `suggestedFilename` receipts; it is not a filename label rendered in the screenshots. Menu opening opacity is incidental to the capture.

Thanks to @hugenshen for the original repair and regression test.

![Before: actual widget export route; filename evidence is in the browser download receipts](https://github.com/user-attachments/assets/9d48f462-bab5-4c6f-8c55-f2292318287d)

![After: actual widget export route; filename evidence is in the browser download receipts](https://github.com/user-attachments/assets/d945a5a9-6b4a-4ae2-9bbc-a91c3db8cf5d)

![Before: actual generated-image download route](https://github.com/user-attachments/assets/d84fb502-274d-4dec-af8c-484891b28e06)

![After: actual generated-image download route](https://github.com/user-attachments/assets/b438388f-f02d-49cf-8867-96312a0e03ea)