### PR TITLE
feat(qa): update persistent Telegram fixture references

### DIFF
--- a/qa/convex-credential-broker/README.md
+++ b/qa/convex-credential-broker/README.md
@@ -12,6 +12,7 @@ This broker exposes:
 - `POST /qa-credentials/v1/admin/add`
 - `POST /qa-credentials/v1/admin/remove`
 - `POST /qa-credentials/v1/admin/list`
+- `POST /qa-credentials/v1/admin/telegram-fixtures`
 
 The implementation matches the contract documented in
 `docs/help/testing.md` for `--credential-source convex`.
@@ -76,6 +77,64 @@ pnpm openclaw qa credentials remove --credential-id <credential-id>
 ```
 
 Admin endpoints require `OPENCLAW_QA_CONVEX_SECRET_MAINTAINER`.
+
+## Update persistent Telegram fixtures
+
+After verifying a dedicated normal group and forum group with the QA user and
+SUT bot, call `POST /qa-credentials/v1/admin/telegram-fixtures` with the
+maintainer bearer secret and this JSON body:
+
+```json
+{
+  "credentialId": "<existing-credential-id>",
+  "actorId": "local-maintainer",
+  "sutBotId": "123",
+  "testerUserId": "456",
+  "expectedGroupId": "-123",
+  "groupId": "-456",
+  "forumGroupId": "-100789"
+}
+```
+
+Include `expectedForumGroupId` when the current payload has a forum reference.
+The operation accepts only active `telegram-test-userbot` credentials with
+schema version 1 and environment `test`. Both new references must be distinct
+negative group IDs. The caller verifies actual Telegram group types,
+membership and topic permissions before publishing these references.
+
+The broker compares the expected bot, tester and current references inside the
+same transaction that updates storage. A live lease returns `LEASE_ACTIVE`;
+changed references return `FIXTURE_CONFLICT`; changed identities return
+`IDENTITY_MISMATCH`. Read the current record and resolve the conflict before
+trying a changed request. The operation never replaces or enables a credential.
+
+Successful responses contain `status: "ok"`, `changed` and a redacted
+credential summary. Matching current references produce `changed: false`.
+As with the other broker operations, inspect the JSON status even for HTTP 200.
+Authentication and request-validation errors use HTTP 401/403 and 400.
+
+Only the logical `groupId` and `forumGroupId` payload fields change. Large
+payloads are repacked atomically through the existing chunk format; their
+session archives and other logical values remain unchanged. Row identity,
+status, notes and lease-selection history are preserved. Disabled and
+untargeted records and chunks are untouched. Normal lease consumers receive
+the updated pair without a new payload protocol.
+
+## Synthetic broker tests
+
+The HTTP integration suite uses a disposable anonymous local Convex backend,
+never a cloud deployment or pool credentials. In a fresh copy of this folder:
+
+```bash
+npm install
+CONVEX_AGENT_MODE=anonymous npx convex dev --once --tail-logs disable --start \
+  'npx convex env set OPENCLAW_QA_CONVEX_SECRET_MAINTAINER synthetic-maintainer && npx convex env set OPENCLAW_QA_CONVEX_SECRET_CI synthetic-ci && npm test'
+```
+
+Inspect the Node test result as well as the outer CLI exit status. The suite
+covers inline/chunked round trips, authorization, conflicts, active leases,
+concurrent acquisition, no-op updates and preservation of untargeted records.
+Delete the disposable backend state after retaining the test output.
 
 ## Local request examples
 

--- a/qa/convex-credential-broker/convex/credentials.ts
+++ b/qa/convex-credential-broker/convex/credentials.ts
@@ -4,6 +4,7 @@ import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import type { MutationCtx, QueryCtx } from "./_generated/server";
 import { internalMutation, internalQuery } from "./_generated/server";
+import { normalizeTelegramFixtureReferences } from "./payload_validation";
 
 const LEASE_EVENT_RETENTION_MS = 2 * 24 * 60 * 60 * 1_000;
 const ADMIN_EVENT_RETENTION_MS = 30 * 24 * 60 * 60 * 1_000;
@@ -30,7 +31,12 @@ type ActorRole = "ci" | "maintainer";
 type CredentialStatus = "active" | "disabled";
 type ListStatus = CredentialStatus | "all";
 type LeaseEventType = "acquire" | "acquire_failed" | "release";
-type AdminEventType = "add" | "disable" | "disable_failed";
+type AdminEventType =
+  | "add"
+  | "disable"
+  | "disable_failed"
+  | "telegram_fixtures_update"
+  | "telegram_fixtures_update_failed";
 
 type BrokerErrorResult = {
   status: "error";
@@ -710,6 +716,120 @@ export const disableCredentialSet = internalMutation({
       status: "ok",
       changed: true,
       credential: toCredentialSummary(updated, false),
+    };
+  },
+});
+
+export const updateTelegramFixtures = internalMutation({
+  args: {
+    credentialId: v.id("credential_sets"),
+    sutBotId: v.string(),
+    testerUserId: v.string(),
+    expectedGroupId: v.string(),
+    expectedForumGroupId: v.optional(v.string()),
+    groupId: v.string(),
+    forumGroupId: v.string(),
+    actorId: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const nowMs = Date.now();
+    const actorId = normalizeActorId(args.actorId);
+    const row = await ctx.db.get(args.credentialId);
+    const reject = async (code: string, message: string) => {
+      await insertAdminEvent({
+        ctx,
+        eventType: "telegram_fixtures_update_failed",
+        actorRole: "maintainer",
+        actorId,
+        occurredAtMs: nowMs,
+        credentialId: args.credentialId,
+        ...(row ? { kind: row.kind } : {}),
+        code,
+        message,
+      });
+      return brokerError(code, message);
+    };
+    if (!row) {
+      return await reject("CREDENTIAL_NOT_FOUND", "Credential record does not exist.");
+    }
+    if (row.kind !== "telegram-test-userbot") {
+      return await reject(
+        "KIND_MISMATCH",
+        "Only Telegram Test Server userbot fixtures can be updated.",
+      );
+    }
+    if (row.status !== "active") {
+      return await reject("CREDENTIAL_DISABLED", "Disabled credential fixtures cannot be updated.");
+    }
+    if (leaseIsActive(row.lease, nowMs)) {
+      return await reject("LEASE_ACTIVE", "Credential is currently leased and cannot be updated.");
+    }
+    const resolved = await readCredentialPayload(ctx, row);
+    if (!resolved || typeof resolved !== "object" || Array.isArray(resolved)) {
+      return await reject("INVALID_PAYLOAD", "Credential payload must be an object.");
+    }
+    const payload = resolved as Record<string, unknown>;
+    if (payload.schemaVersion !== 1 || payload.environment !== "test") {
+      return await reject(
+        "INVALID_PAYLOAD",
+        "Credential must use the Telegram Test Server schema.",
+      );
+    }
+    if (payload.sutBotId !== args.sutBotId || payload.testerUserId !== args.testerUserId) {
+      return await reject("IDENTITY_MISMATCH", "Credential bot or tester identity changed.");
+    }
+    if (
+      payload.groupId !== args.expectedGroupId ||
+      payload.forumGroupId !== args.expectedForumGroupId
+    ) {
+      return await reject(
+        "FIXTURE_CONFLICT",
+        "Credential fixture references changed; read them again.",
+      );
+    }
+    const references = normalizeTelegramFixtureReferences(args);
+    if (
+      payload.groupId === references.groupId &&
+      payload.forumGroupId === references.forumGroupId
+    ) {
+      return { status: "ok", changed: false, credential: toCredentialSummary(row, false) };
+    }
+
+    // Convex commits the lease check, repacked payload and audit together. The
+    // existing marker/chunk protocol remains unchanged for every lease consumer.
+    const storage = createCredentialPayloadStorage({ ...payload, ...references });
+    const oldChunks = await ctx.db
+      .query("credential_payload_chunks")
+      .withIndex("by_credential_index", (q) => q.eq("credentialId", args.credentialId))
+      .collect();
+    for (const chunk of oldChunks) {
+      await ctx.db.delete(chunk._id);
+    }
+    for (const [index, data] of storage.chunks.entries()) {
+      await ctx.db.insert("credential_payload_chunks", {
+        credentialId: args.credentialId,
+        index,
+        data,
+        createdAtMs: nowMs,
+      });
+    }
+    await ctx.db.patch(args.credentialId, { payload: storage.payload, updatedAtMs: nowMs });
+    await insertAdminEvent({
+      ctx,
+      eventType: "telegram_fixtures_update",
+      actorRole: "maintainer",
+      actorId,
+      occurredAtMs: nowMs,
+      credentialId: args.credentialId,
+      kind: row.kind,
+    });
+    return {
+      status: "ok",
+      changed: true,
+      credential: toCredentialSummary(
+        { ...row, payload: storage.payload, updatedAtMs: nowMs },
+        false,
+      ),
     };
   },
 });

--- a/qa/convex-credential-broker/convex/http.ts
+++ b/qa/convex-credential-broker/convex/http.ts
@@ -3,7 +3,10 @@ import { httpRouter } from "convex/server";
 import { internal } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import { httpAction } from "./_generated/server";
-import { normalizeCredentialPayloadForKind } from "./payload_validation";
+import {
+  normalizeCredentialPayloadForKind,
+  normalizeTelegramFixtureReferences,
+} from "./payload_validation";
 
 type ActorRole = "ci" | "maintainer";
 
@@ -444,6 +447,36 @@ http.route({
         credentialId: normalizeCredentialId(
           requireString(body, "credentialId"),
         ) as Id<"credential_sets">,
+        actorId: readOptionalHttpString(body, "actorId"),
+      });
+      return jsonResponse(200, result);
+    } catch (error) {
+      const normalized = normalizeError(error);
+      return jsonResponse(normalized.httpStatus, normalized.payload);
+    }
+  }),
+});
+
+http.route({
+  path: "/qa-credentials/v1/admin/telegram-fixtures",
+  method: "POST",
+  handler: httpAction(async (ctx, request) => {
+    try {
+      assertMaintainerAdminAuth(parseBearerToken(request));
+      const body = await parseJsonObject(request);
+      const references = normalizeTelegramFixtureReferences(
+        body,
+        (httpStatus, code, message) => new BrokerHttpError(httpStatus, code, message),
+      );
+      const result = await ctx.runMutation(internal.credentials.updateTelegramFixtures, {
+        credentialId: normalizeCredentialId(
+          requireString(body, "credentialId"),
+        ) as Id<"credential_sets">,
+        sutBotId: requireString(body, "sutBotId"),
+        testerUserId: requireString(body, "testerUserId"),
+        expectedGroupId: requireString(body, "expectedGroupId"),
+        expectedForumGroupId: readOptionalHttpString(body, "expectedForumGroupId"),
+        ...references,
         actorId: readOptionalHttpString(body, "actorId"),
       });
       return jsonResponse(200, result);

--- a/qa/convex-credential-broker/convex/payload_validation.ts
+++ b/qa/convex-credential-broker/convex/payload_validation.ts
@@ -25,6 +25,25 @@ const SHA256_HEX_RE = /^[a-f0-9]{64}$/u;
 const TELEGRAM_CHAT_ID_RE = /^-?\d+$/u;
 const TELEGRAM_USER_ID_RE = /^\d+$/u;
 
+export function normalizeTelegramFixtureReferences(
+  payload: Record<string, unknown>,
+  createFailure: PayloadValidationFailureFactory = createCredentialPayloadValidationError,
+) {
+  const kind = "telegram-test-userbot";
+  const groupId = requirePayloadString(payload, "groupId", kind, createFailure);
+  const forumGroupId = requirePayloadString(payload, "forumGroupId", kind, createFailure);
+  if (!/^-[1-9]\d*$/u.test(groupId) || !/^-[1-9]\d*$/u.test(forumGroupId)) {
+    throwPayloadError(
+      createFailure,
+      "Telegram fixture references must be negative group ID strings.",
+    );
+  }
+  if (groupId === forumGroupId) {
+    throwPayloadError(createFailure, "Telegram normal and forum fixtures must be distinct groups.");
+  }
+  return { groupId, forumGroupId };
+}
+
 function createCredentialPayloadValidationError(httpStatus: number, code: string, message: string) {
   return new CredentialPayloadValidationError(httpStatus, code, message);
 }

--- a/qa/convex-credential-broker/convex/schema.ts
+++ b/qa/convex-credential-broker/convex/schema.ts
@@ -9,7 +9,13 @@ const leaseEventType = v.union(
   v.literal("acquire_failed"),
   v.literal("release"),
 );
-const adminEventType = v.union(v.literal("add"), v.literal("disable"), v.literal("disable_failed"));
+const adminEventType = v.union(
+  v.literal("add"),
+  v.literal("disable"),
+  v.literal("disable_failed"),
+  v.literal("telegram_fixtures_update"),
+  v.literal("telegram_fixtures_update_failed"),
+);
 
 export default defineSchema({
   credential_sets: defineTable({

--- a/qa/convex-credential-broker/package.json
+++ b/qa/convex-credential-broker/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dashboard": "convex dashboard",
     "deploy": "convex deploy",
-    "dev": "convex dev"
+    "dev": "convex dev",
+    "test": "node --test tests/*.test.mjs"
   },
   "dependencies": {
     "convex": "1.45.0",

--- a/qa/convex-credential-broker/tests/telegram-fixtures.test.mjs
+++ b/qa/convex-credential-broker/tests/telegram-fixtures.test.mjs
@@ -1,0 +1,272 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import test from "node:test";
+import { isDeepStrictEqual } from "node:util";
+import { ConvexHttpClient } from "convex/browser";
+import { makeFunctionReference } from "convex/server";
+
+// Run only against a disposable backend created by CONVEX_AGENT_MODE=anonymous.
+const config = JSON.parse(fs.readFileSync(".convex/local/default/config.json", "utf8"));
+assert.ok(config.deploymentName.startsWith("anonymous-"));
+const cloud = `http://127.0.0.1:${config.ports.cloud}`;
+const site = `http://127.0.0.1:${config.ports.site}/qa-credentials/v1/`;
+const maintainer = "synthetic-maintainer";
+const ci = "synthetic-ci";
+const client = new ConvexHttpClient(cloud);
+client.setAdminAuth(config.adminKey);
+const kind = "telegram-test-userbot";
+const fixture = (archive = "dGVzdA==") => ({
+  schemaVersion: 1,
+  environment: "test",
+  groupId: "-123",
+  sutBotId: "123",
+  testerUserId: "456",
+  sutToken: "synthetic-token",
+  sutUsername: "synthetic_bot",
+  tdlibArchiveBase64: archive,
+  tdlibArchiveSha256: createHash("sha256").update(Buffer.from(archive, "base64")).digest("hex"),
+  tdlibVersion: "1.8.67",
+  preservedExtra: { enabled: true, labels: ["one", "two"] },
+});
+const fingerprint = (value) => createHash("sha256").update(JSON.stringify(value)).digest("hex");
+const internal = (name, args) =>
+  client.function(makeFunctionReference(`credentials:${name}`), undefined, args);
+async function post(route, body, token = maintainer) {
+  const response = await fetch(site + route, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      ...(token ? { authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(10000),
+  });
+  const text = await response.text();
+  return {
+    status: response.status,
+    body: response.headers.get("content-type")?.includes("application/json")
+      ? JSON.parse(text)
+      : { message: text },
+  };
+}
+async function snapshot() {
+  const response = await fetch(cloud + "/api/run_test_function", {
+    method: "POST",
+    headers: { authorization: `Convex ${config.adminKey}`, "content-type": "application/json" },
+    body: JSON.stringify({
+      adminKey: config.adminKey,
+      args: {},
+      format: "convex_encoded_json",
+      bundle: {
+        path: "testQuery.js",
+        source:
+          'import { query } from "convex:/_system/repl/wrappers.js"; export default query({handler: async ctx => ({rows: await ctx.db.query("credential_sets").collect(), chunks: await ctx.db.query("credential_payload_chunks").collect(), events: await ctx.db.query("admin_events").collect()})});',
+      },
+    }),
+    signal: AbortSignal.timeout(10000),
+  });
+  const result = await response.json();
+  assert.equal(result.status, "success");
+  return result.value;
+}
+const update = (credentialId, patch = {}) =>
+  post("admin/telegram-fixtures", {
+    credentialId,
+    sutBotId: "123",
+    testerUserId: "456",
+    expectedGroupId: "-123",
+    groupId: "-456",
+    forumGroupId: "-100789",
+    actorId: "synthetic-proof",
+    ...patch,
+  });
+async function add(payload, options = {}) {
+  const result = await internal("addCredentialSet", {
+    kind,
+    payload,
+    note: "preserve this note",
+    ...options,
+  });
+  assert.equal(result.status, "ok");
+  return result.credential.credentialId;
+}
+async function acquire() {
+  const identity = { kind, ownerId: "synthetic-consumer", actorRole: "ci" };
+  const acquired = await post("acquire", identity, ci);
+  assert.equal(acquired.body.status, "ok");
+  const lease = {
+    ...identity,
+    credentialId: acquired.body.credentialId,
+    leaseToken: acquired.body.leaseToken,
+  };
+  return { acquired: acquired.body, lease, release: () => post("release", lease, ci) };
+}
+async function consume({ acquired, lease }) {
+  if (acquired.payload.__openclawQaCredentialPayloadChunksV1 !== true) return acquired.payload;
+  const parts = [];
+  for (let index = 0; index < acquired.payload.chunkCount; index++) {
+    const part = await post("payload-chunk", { ...lease, index }, ci);
+    assert.equal(part.body.status, "ok");
+    parts.push(part.body.data);
+  }
+  const serialized = parts.join("");
+  assert.equal(Buffer.byteLength(serialized), acquired.payload.byteLength);
+  return JSON.parse(serialized);
+}
+
+test(
+  "maintainer fixture updates preserve payloads and serialize with leases",
+  { timeout: 90000 },
+  async (t) => {
+    const disabled = await add(fixture(Buffer.alloc(240000, 71).toString("base64")), {
+      status: "disabled",
+    });
+    const other = await add({ preserved: "other kind" }, { kind: "synthetic-other" });
+    const original = await snapshot();
+    const untouched = (state) => ({
+      rows: state.rows.filter((row) => [disabled, other].includes(row._id)),
+      chunks: state.chunks.filter((row) => [disabled, other].includes(row.credentialId)),
+    });
+    for (const [label, payload] of [
+      ["inline", fixture()],
+      ["chunked", fixture(Buffer.alloc(240000, 65).toString("base64"))],
+    ]) {
+      await t.test(`${label} round trip, conflicts, no-op and preservation`, async () => {
+        const id = await add(payload);
+        try {
+          const before = await snapshot();
+          const rowBefore = before.rows.find((row) => row._id === id);
+          const changed = await update(id);
+          assert.equal(changed.status, 200);
+          assert.equal(changed.body.status, "ok");
+          assert.equal(changed.body.changed, true);
+          assert.equal(changed.body.credential.credentialId, id);
+          assert.equal("payload" in changed.body.credential, false);
+          const after = await snapshot();
+          const rowAfter = after.rows.find((row) => row._id === id);
+          const preserved = ({ payload: _payload, updatedAtMs: _updated, ...rest }) => rest;
+          assert.deepEqual(preserved(rowAfter), preserved(rowBefore));
+          const listed = await post("admin/list", { kind, status: "active", includePayload: true });
+          const expected = { ...payload, groupId: "-456", forumGroupId: "-100789" };
+          assert.ok(
+            isDeepStrictEqual(
+              listed.body.credentials.find((row) => row.credentialId === id).payload,
+              expected,
+            ),
+            "complete listed payload must be preserved",
+          );
+          assert.equal((await update(id)).body.code, "FIXTURE_CONFLICT");
+          const noOp = await update(id, {
+            expectedGroupId: "-456",
+            expectedForumGroupId: "-100789",
+          });
+          assert.equal(noOp.body.changed, false);
+          const afterNoOp = await snapshot();
+          assert.deepEqual(afterNoOp.rows, after.rows);
+          assert.equal(fingerprint(afterNoOp.chunks), fingerprint(after.chunks));
+          const current = await acquire();
+          try {
+            assert.equal(current.acquired.credentialId, id);
+            assert.ok(
+              isDeepStrictEqual(await consume(current), expected),
+              "complete leased payload must be preserved",
+            );
+            assert.equal((await post("heartbeat", current.lease, ci)).body.status, "ok");
+            assert.equal(
+              (await update(id, { expectedGroupId: "-456", expectedForumGroupId: "-100789" })).body
+                .code,
+              "LEASE_ACTIVE",
+            );
+          } finally {
+            assert.equal((await current.release()).body.status, "ok");
+          }
+        } finally {
+          assert.equal((await post("admin/remove", { credentialId: id })).body.status, "ok");
+        }
+      });
+    }
+    await t.test(
+      "rejects unauthorized, invalid and mismatched requests without data changes",
+      async () => {
+        const id = await add(fixture());
+        const before = await snapshot();
+        const request = {
+          credentialId: id,
+          sutBotId: "123",
+          testerUserId: "456",
+          expectedGroupId: "-123",
+          groupId: "-456",
+          forumGroupId: "-100789",
+        };
+        for (const [token, status] of [
+          [undefined, 401],
+          ["wrong-secret", 401],
+          [ci, 403],
+        ]) {
+          assert.equal(
+            (await post("admin/telegram-fixtures", request, token ?? "")).status,
+            status,
+          );
+        }
+        for (const patch of [
+          { groupId: "0" },
+          { groupId: "123" },
+          { forumGroupId: "not-an-id" },
+          { forumGroupId: "-456" },
+        ]) {
+          assert.equal((await update(id, patch)).status, 400);
+        }
+        assert.equal((await update(id, { sutBotId: "999" })).body.code, "IDENTITY_MISMATCH");
+        assert.equal((await update(id, { testerUserId: "999" })).body.code, "IDENTITY_MISMATCH");
+        assert.equal((await update(disabled)).body.code, "CREDENTIAL_DISABLED");
+        assert.equal((await update(other)).body.code, "KIND_MISMATCH");
+        const after = await snapshot();
+        assert.deepEqual(after.rows, before.rows);
+        assert.equal(fingerprint(after.chunks), fingerprint(before.chunks));
+        assert.equal((await post("admin/remove", { credentialId: id })).body.status, "ok");
+        const nonTest = await add({ ...fixture(), environment: "production" });
+        assert.equal((await update(nonTest)).body.code, "INVALID_PAYLOAD");
+        assert.equal((await post("admin/remove", { credentialId: nonTest })).body.status, "ok");
+      },
+    );
+    await t.test(
+      "concurrent acquisition sees one complete payload or prevents the update",
+      async () => {
+        const payload = fixture(Buffer.alloc(240000, 66).toString("base64"));
+        const id = await add(payload);
+        const [changed, current] = await Promise.all([update(id), acquire()]);
+        try {
+          assert.equal(current.acquired.credentialId, id);
+          if (changed.body.status === "ok") {
+            assert.ok(
+              isDeepStrictEqual(await consume(current), {
+                ...payload,
+                groupId: "-456",
+                forumGroupId: "-100789",
+              }),
+              "acquisition must see the complete updated payload",
+            );
+          } else {
+            assert.equal(changed.body.code, "LEASE_ACTIVE");
+            assert.ok(
+              isDeepStrictEqual(await consume(current), payload),
+              "a rejected update must preserve the complete original payload",
+            );
+          }
+        } finally {
+          assert.equal((await current.release()).body.status, "ok");
+        }
+      },
+    );
+    const final = await snapshot();
+    assert.equal(fingerprint(untouched(final)), fingerprint(untouched(original)));
+    assert.equal(
+      final.rows.some((row) => row.lease),
+      false,
+    );
+    const updates = final.events.filter((event) => event.eventType === "telegram_fixtures_update");
+    assert.ok(updates.length >= 2);
+    assert.equal(JSON.stringify(updates).includes("synthetic-token"), false);
+  },
+);


### PR DESCRIPTION
Closes #141313

**Draft for owner review.** The current fixture publication completed through the existing broker operations. This new endpoint was not deployed, and further endpoint work is paused. The authored source, tested CI filename correction and review history are retained for an owner decision.

## What Problem This Solves

The QA broker cannot save a persistent normal-group and forum-group pair on an existing Telegram Test Server credential. Replacing the credential would discard its stable identity and lease-selection history.

## Why This Change Was Made

Add a maintainer-authenticated fixture update that checks the expected bot, tester and current references and rejects active leases. The existing storage owner atomically repacks the target payload and records a redacted admin event. Secret/session values, unrelated payload fields and untargeted records remain unchanged.

## User Impact

QA maintainers can publish verified reusable Telegram fixtures, and normal lease consumers receive the updated pair through the existing inline/chunk protocol. Callers verify group type, membership and topic permissions before publishing references.

## Evidence

- Real anonymous Convex baseline: credential creation succeeded; the missing update route returned HTTP 404.
- Real HTTP/storage integration suite passed, covering inline/chunked consumption, authentication, invalid inputs, identity/reference conflicts, no-op updates, active leases, concurrent acquisition and preservation.
- Broker TypeScript check and all 19 existing payload-validation tests passed remotely.
- Pinned formatting/whitespace checks passed; independent code review found no actionable P0–P2 findings.
- Independent synthetic acceptance passed clauses covering authentication, inline/chunked preservation, leases, concurrent updates and retention. Production deployment of this endpoint was not part of that pass.
- CI on the published head failed because the standalone backend suite had a normal unit-test filename. The tested correction follows the existing `.e2e.test.mjs` convention, keeps all assertions and remains selected by the package test script. That correction is retained locally and has not been pushed because this endpoint is no longer needed for the current goal.
- The full Testbox typecheck passed. A 20-minute command bound interrupted a later repository guard; the overall changed-file check is not claimed green. This draft is not ready to merge.
- A separate operator completed the current fixture publication using the existing authenticated add/remove route and verified normal lease consumption. No new endpoint deployment was needed for that completed operation.
