### PR TITLE
fix(inworld): redact credentials in TTS/voices API error bodies

### DIFF
--- a/extensions/inworld/tts.test.ts
+++ b/extensions/inworld/tts.test.ts
@@ -217,6 +217,29 @@ describe("inworldTTS", () => {
     });
   });
 
+  it("redacts reflected Basic credentials from HTTP error bodies", async () => {
+    const uniqueSecret = "inworld-loopback-secret-9876543210";
+    const apiKey = `proof-prefix-${uniqueSecret}-proof-suffix`;
+    queueGuardedResponse(
+      new Response(`proxy failure Authorization: Basic ${apiKey}; request rejected`, {
+        status: 502,
+      }),
+    );
+
+    let caught: Error | undefined;
+    try {
+      await inworldTTS({ text: "test", apiKey });
+    } catch (error) {
+      caught = error as Error;
+    }
+
+    expect(caught?.message).toContain("Inworld TTS API error (502)");
+    expect(caught?.message).toContain("proxy failure");
+    expect(caught?.message).toContain("Authorization:");
+    expect(caught?.message).not.toContain(apiKey);
+    expect(caught?.message).not.toContain(uniqueSecret);
+  });
+
   it("throws on in-stream errors", async () => {
     const body = JSON.stringify({
       error: { code: 3, message: "Invalid voice ID" },

--- a/extensions/inworld/tts.ts
+++ b/extensions/inworld/tts.ts
@@ -1,5 +1,6 @@
 // Inworld plugin module implements tts behavior.
 import { readResponseWithLimit } from "openclaw/plugin-sdk/response-limit-runtime";
+import { redactSensitiveText } from "openclaw/plugin-sdk/security-runtime";
 import type { SpeechVoiceOption } from "openclaw/plugin-sdk/speech-core";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/speech-provider";
 import type { SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
@@ -45,10 +46,13 @@ async function readInworldErrorBodySnippet(response: Response): Promise<string> 
   }
 
   const collapsed = buffer.toString("utf8").replace(/\s+/g, " ").trim();
-  if (collapsed.length > INWORLD_ERROR_BODY_MAX_CHARS) {
-    return `${truncateUtf16Safe(collapsed, INWORLD_ERROR_BODY_MAX_CHARS)}…`;
+  // Match voice-call provider error snippets: upstream/proxy bodies can reflect
+  // Basic Authorization credentials into the diagnostic text.
+  const redacted = redactSensitiveText(collapsed, { mode: "tools" });
+  if (redacted.length > INWORLD_ERROR_BODY_MAX_CHARS) {
+    return `${truncateUtf16Safe(redacted, INWORLD_ERROR_BODY_MAX_CHARS)}…`;
   }
-  return collapsed;
+  return redacted;
 }
 
 export const INWORLD_TTS_MODELS = [


### PR DESCRIPTION
## Summary
- `readInworldErrorBodySnippet` bounded and UTF-16-truncated Inworld TTS/voices error bodies but did not redact them.
- Those requests send `Authorization: Basic <apiKey>`, and proxy/upstream error text can reflect the credential (same incomplete coverage as voice-call provider error snippets, which already redact).
- XS fix: apply `redactSensitiveText(..., { mode: "tools" })` before returning the diagnostic snippet used by both TTS and voices failure paths.

## Concrete scenario
1. Inworld TTS/voices call uses a Basic API key.
2. A non-OK response body echoes `Authorization: Basic <apiKey>`.
3. Before: thrown `Inworld TTS API error (...): ...` / voices equivalent contains the live credential.
4. After: status/context remain, credential material is redacted.

## Test plan
- [x] Before-fail / after-pass: `extensions/inworld/tts.test.ts` — “redacts reflected Basic credentials from HTTP error bodies”
- [x] Full `extensions/inworld/tts.test.ts` suite passes after the fix