### PR TITLE
fix(gateway): redact credentials in MCP loopback tools/call content

### DIFF
--- a/src/gateway/mcp-http.handlers.redact.test.ts
+++ b/src/gateway/mcp-http.handlers.redact.test.ts
@@ -1,0 +1,101 @@
+// MCP loopback tools/call must redact model-visible credentials without
+// dropping image payloads (sanitizeToolResult's object path strips images).
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { AnyAgentTool } from "../agents/tools/common.js";
+import * as loggingConfigModule from "../logging/config.js";
+import { handleMcpJsonRpc } from "./mcp-http.handlers.js";
+
+// Synthetic, non-usable credential fixture for model-visible redaction coverage.
+const SYNTHETIC_BEARER_CREDENTIAL = "abcdef0123456789QWERTY=";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function createTool(execute: AnyAgentTool["execute"]): AnyAgentTool {
+  return {
+    name: "redact_probe",
+    label: "Redact probe",
+    description: "Probe model-visible redaction",
+    parameters: { type: "object", properties: {} } as never,
+    execute,
+  };
+}
+
+async function callLoopbackTool(tool: AnyAgentTool) {
+  const response = await handleMcpJsonRpc({
+    message: {
+      jsonrpc: "2.0",
+      id: 1,
+      method: "tools/call",
+      params: { name: tool.name, arguments: {} },
+    },
+    tools: [tool],
+    toolSchema: [
+      { name: tool.name, description: tool.description, inputSchema: { type: "object" } },
+    ],
+  });
+  return response as {
+    result: {
+      content: Array<Record<string, unknown>>;
+      isError: boolean;
+    };
+  };
+}
+
+describe("Gateway MCP loopback tools/call redaction", () => {
+  it("redacts Bearer credentials in text while preserving image blocks", async () => {
+    const imageBlock = { type: "image", data: "aW1hZ2U=", mimeType: "image/png" };
+    const response = await callLoopbackTool(
+      createTool(async () => ({
+        content: [
+          {
+            type: "text",
+            text: `Deployment finished.\nAuthorization: Bearer ${SYNTHETIC_BEARER_CREDENTIAL}`,
+          },
+          imageBlock,
+          {
+            type: "resource",
+            resource: {
+              uri: "memo://one",
+              text: `memo Authorization: Bearer ${SYNTHETIC_BEARER_CREDENTIAL}`,
+              mimeType: "text/plain",
+            },
+          },
+        ],
+      })),
+    );
+
+    expect(response.result.isError).toBe(false);
+    const [textBlock, preservedImage, resourceBlock] = response.result.content;
+    expect(textBlock).toMatchObject({ type: "text" });
+    expect(String(textBlock.text)).not.toContain(SYNTHETIC_BEARER_CREDENTIAL);
+    expect(String(textBlock.text)).toContain("Authorization: Bearer");
+    expect(String(textBlock.text)).toContain("Deployment finished.");
+    expect(preservedImage).toEqual(imageBlock);
+    expect(resourceBlock).toMatchObject({ type: "resource" });
+    const resource = resourceBlock.resource as { text: string };
+    expect(resource.text).not.toContain(SYNTHETIC_BEARER_CREDENTIAL);
+    expect(resource.text).toContain("Authorization: Bearer");
+  });
+
+  it("redacts Bearer credentials from thrown tool errors even when redactPatterns do not match", async () => {
+    // Configured patterns replace the logging list surface, but model-visible
+    // sanitize merges builtins so Bearer redaction still applies.
+    vi.spyOn(loggingConfigModule, "readLoggingConfig").mockReturnValue({
+      redactPatterns: ["never-match-custom-pattern-xyz"],
+    });
+
+    const response = await callLoopbackTool(
+      createTool(async () => {
+        throw new Error(`Upstream failed: Authorization: Bearer ${SYNTHETIC_BEARER_CREDENTIAL}`);
+      }),
+    );
+
+    expect(response.result.isError).toBe(true);
+    const text = String(response.result.content[0]?.text ?? "");
+    expect(text).not.toContain(SYNTHETIC_BEARER_CREDENTIAL);
+    expect(text).toContain("Authorization: Bearer");
+    expect(text).toContain("Upstream failed");
+  });
+});

--- a/src/gateway/mcp-http.handlers.ts
+++ b/src/gateway/mcp-http.handlers.ts
@@ -4,6 +4,7 @@ import crypto from "node:crypto";
 import { ContentBlockSchema, type ContentBlock } from "@modelcontextprotocol/sdk/types.js";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { runBeforeToolCallHook, type HookContext } from "../agents/agent-tools.before-tool-call.js";
+import { sanitizeToolResult } from "../agents/embedded-agent-tool-results.js";
 import { copyInternalToolResultState } from "../agents/runtime/internal-hooks.js";
 import {
   formatToolExecutionErrorMessage,
@@ -56,6 +57,26 @@ function normalizeToolCallContent(result: unknown): ContentBlock[] {
       text: stringifyMcpContent(result),
     },
   ];
+}
+
+/** Redact model-visible text in MCP content without stripping image/binary payloads. */
+function sanitizeMcpToolCallContent(content: ContentBlock[]): ContentBlock[] {
+  return content.map((block) => {
+    if (block.type === "text") {
+      return Object.assign({}, block, { text: sanitizeToolResult(block.text) });
+    }
+    if (block.type === "resource" && "resource" in block && block.resource) {
+      const resource = block.resource;
+      if ("text" in resource && typeof resource.text === "string") {
+        return Object.assign({}, block, {
+          resource: Object.assign({}, resource, {
+            text: sanitizeToolResult(resource.text),
+          }),
+        });
+      }
+    }
+    return block;
+  });
 }
 
 /** Handles one MCP loopback JSON-RPC message and returns a response or notification null. */
@@ -180,7 +201,7 @@ export async function handleMcpJsonRpc(params: {
               : { outcome: disposition },
           );
           return jsonRpcResult(id, {
-            content: [{ type: "text", text: hookResult.reason }],
+            content: [{ type: "text", text: sanitizeToolResult(hookResult.reason) }],
             isError: true,
           });
         }
@@ -217,7 +238,7 @@ export async function handleMcpJsonRpc(params: {
         return copyInternalToolResultState(
           result,
           jsonRpcResult(id, {
-            content: normalizeToolCallContent(result),
+            content: sanitizeMcpToolCallContent(normalizeToolCallContent(result)),
             isError: failureKind !== undefined,
           }),
         );
@@ -230,7 +251,12 @@ export async function handleMcpJsonRpc(params: {
         });
         const message = formatToolExecutionErrorMessage(error, "tool execution failed");
         return jsonRpcResult(id, {
-          content: [{ type: "text", text: message || "tool execution failed" }],
+          content: [
+            {
+              type: "text",
+              text: sanitizeToolResult(message || "tool execution failed"),
+            },
+          ],
           isError: true,
         });
       }


### PR DESCRIPTION
## Summary
- MCP loopback `tools/call` was returning model-visible tool content, blocked-hook reasons, and catch error messages without `sanitizeToolResult`.
- Redact text / resource-text content in place (do not whole-object sanitize, which strips image bytes).
- Sanitize blocked `reason` and catch `formatToolExecutionErrorMessage` strings the same way.

## Why
Credentials such as `Authorization: Bearer …` could leak into MCP client-visible payloads even when logging `redactPatterns` are customized (model-visible sanitize merges builtins).

## Before / after
- **Before:** success text + image kept Bearer tokens; catch errors with Bearer passed through; custom non-matching `redactPatterns` did not restore builtins.
- **After:** Bearer tokens redacted in text/resource blocks; image blocks preserved; catch path still redacts with builtins under non-matching custom patterns.

## Test plan
- [x] `src/gateway/mcp-http.handlers.redact.test.ts` — success Bearer + image kept; catch Bearer + spy nonmatching `redactPatterns`
- [ ] CI gateway shard

Not #141271 / #141299.