### PR TITLE
fix(ai): tool calls fail with "malformed JSON arguments" when streamed input has raw control characters or invalid escapes

### DIFF
--- a/packages/ai/src/transports/anthropic-stream-reducer.ts
+++ b/packages/ai/src/transports/anthropic-stream-reducer.ts
@@ -624,12 +624,16 @@ export async function consumeAnthropicStream(params: {
     if ([...blockIndexes.values()].some((index) => blocks[index]?.type === "toolCall")) {
       throw new Error("Provider completed stream with an incomplete tool call");
     }
+    // Fine-grained tool streaming delivers tool input without server-side JSON
+    // validation, so repair invalid string literals before rejecting the turn.
     finalizeTerminalToolCallArguments(
       sealedToolCalls.map(({ block }) => block),
       (block) =>
         block.partialJson && block.partialJson.length > 0
           ? block.partialJson
           : seededToolArguments.get(block),
+      undefined,
+      { repairStringLiterals: true },
     );
     for (const sealed of sealedToolCalls) {
       delete sealed.block.partialJson;

--- a/packages/ai/src/transports/anthropic-transport-stream.terminal-repair.integration.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.terminal-repair.integration.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Drives the Anthropic Messages transport over real HTTP against a loopback SSE server,
+ * without mocking fetch, to observe terminal tool-argument repair and rejection through
+ * the actual transport client.
+ */
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it } from "vitest";
+import { configureAiTransportHost } from "../host.js";
+import type { Model } from "../types.js";
+import { createAnthropicMessagesTransportStreamFn } from "./anthropic-transport-stream.js";
+
+type StreamFn = ReturnType<typeof createAnthropicMessagesTransportStreamFn>;
+type StreamContext = Parameters<StreamFn>[1];
+type StreamOptions = NonNullable<Parameters<StreamFn>[2]>;
+
+function makeModel(baseUrl: string): Model<"anthropic-messages"> {
+  return {
+    id: "claude-opus-5",
+    name: "Claude Opus 5",
+    provider: "anthropic",
+    api: "anthropic-messages",
+    baseUrl,
+    reasoning: true,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 200_000,
+    maxTokens: 4_096,
+  };
+}
+
+function serializeSse(events: Record<string, unknown>[]): string {
+  return events
+    .map((event) => `event: ${String(event.type)}\ndata: ${JSON.stringify(event)}\n\n`)
+    .join("");
+}
+
+function toolUseStream(toolBlocks: Array<{ id: string; name: string; partialJson: string }>) {
+  const events: Record<string, unknown>[] = [
+    {
+      type: "message_start",
+      message: {
+        id: "msg_loopback",
+        type: "message",
+        role: "assistant",
+        model: "claude-opus-5",
+        content: [],
+        stop_reason: null,
+        usage: { input_tokens: 4, output_tokens: 0 },
+      },
+    },
+  ];
+  toolBlocks.forEach((block, index) => {
+    events.push(
+      {
+        type: "content_block_start",
+        index,
+        content_block: { type: "tool_use", id: block.id, name: block.name, input: {} },
+      },
+      {
+        type: "content_block_delta",
+        index,
+        delta: { type: "input_json_delta", partial_json: block.partialJson },
+      },
+      { type: "content_block_stop", index },
+    );
+  });
+  events.push(
+    {
+      type: "message_delta",
+      delta: { stop_reason: "tool_use", stop_sequence: null },
+      usage: { output_tokens: 8 },
+    },
+    { type: "message_stop" },
+  );
+  return serializeSse(events);
+}
+
+async function startSseServer(body: string): Promise<{ server: Server; baseUrl: string }> {
+  const server = createServer((request, response) => {
+    let payload = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      payload += chunk;
+    });
+    request.on("end", () => {
+      // Assert the request really reached us over HTTP with the tool projection attached.
+      expect(request.method).toBe("POST");
+      expect(request.url).toBe("/v1/messages");
+      expect(JSON.parse(payload)).toMatchObject({ model: "claude-opus-5", stream: true });
+      response.writeHead(200, {
+        "content-type": "text/event-stream; charset=utf-8",
+        "cache-control": "no-cache",
+      });
+      response.end(body);
+    });
+  });
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+  const address = server.address() as AddressInfo;
+  return { server, baseUrl: `http://127.0.0.1:${address.port}` };
+}
+
+async function runTransport(baseUrl: string) {
+  const streamFn = createAnthropicMessagesTransportStreamFn();
+  const stream = await Promise.resolve(
+    streamFn(
+      makeModel(baseUrl),
+      {
+        messages: [{ role: "user", content: "edit the file", timestamp: 1 }],
+        tools: [
+          {
+            name: "edit",
+            description: "Edit a file",
+            parameters: { type: "object", properties: {} },
+          },
+        ],
+      } as unknown as StreamContext,
+      { apiKey: "sk-ant-api03-loopback" } as StreamOptions, // pragma: allowlist secret
+    ),
+  );
+  const eventTypes: string[] = [];
+  const toolCallEnds: Record<string, unknown>[] = [];
+  for await (const event of stream) {
+    eventTypes.push(event.type);
+    if (event.type === "toolcall_end") {
+      toolCallEnds.push(event.toolCall.arguments);
+    }
+  }
+  const result = await stream.result();
+  return { eventTypes, toolCallEnds, result };
+}
+
+describe("anthropic transport terminal tool-argument repair over loopback HTTP", () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    configureAiTransportHost({});
+    if (server) {
+      await new Promise<void>((resolve, reject) => {
+        server?.close((error) => (error ? reject(error) : resolve()));
+      });
+      server = undefined;
+    }
+  });
+
+  it("repairs a raw newline in one call and preserves a valid escape in its sibling", async () => {
+    // Real network client: the host fetch is the platform fetch, not a stub.
+    configureAiTransportHost({ buildModelFetch: () => globalThis.fetch });
+    const started = await startSseServer(
+      toolUseStream([
+        { id: "call_read", name: "read", partialJson: '{"path":"README.md"}' },
+        {
+          id: "call_edit",
+          name: "edit",
+          // oldText carries a valid \n escape after a "C:" prefix; newText carries a raw newline.
+          partialJson: '{"path":"a.py","oldText":"C:\\nnext","newText":"x = 1\ny = 2"}',
+        },
+      ]),
+    );
+    server = started.server;
+
+    const { eventTypes, toolCallEnds, result } = await runTransport(started.baseUrl);
+
+    expect(result.stopReason).toBe("toolUse");
+    expect(result.errorMessage).toBeUndefined();
+    expect(eventTypes.filter((type) => type === "toolcall_end")).toHaveLength(2);
+    expect(eventTypes.at(-1)).toBe("done");
+    expect(toolCallEnds).toEqual([
+      { path: "README.md" },
+      { path: "a.py", oldText: "C:\nnext", newText: "x = 1\ny = 2" },
+    ]);
+  });
+
+  it("still fails closed on a truncated sibling and surfaces bounded diagnostics", async () => {
+    configureAiTransportHost({ buildModelFetch: () => globalThis.fetch });
+    const truncated = '{"path":"SECRET.md"';
+    const started = await startSseServer(
+      toolUseStream([
+        { id: "call_read", name: "read", partialJson: '{"path":"README.md"}' },
+        { id: "call_truncated", name: "read", partialJson: truncated },
+      ]),
+    );
+    server = started.server;
+
+    const { eventTypes, toolCallEnds, result } = await runTransport(started.baseUrl);
+
+    expect(result.stopReason).toBe("error");
+    expect(result.errorMessage).toBe("Provider completed tool call with malformed JSON arguments");
+    expect(result.errorCode).toBe("malformed_tool_call_arguments");
+    expect(JSON.parse(result.errorBody ?? "{}")).toMatchObject({
+      code: "malformed_tool_call_arguments",
+      argumentChars: truncated.length,
+      repairAttempted: true,
+    });
+    expect(`${result.errorMessage}${result.errorBody}`).not.toContain("SECRET.md");
+    expect(toolCallEnds).toEqual([]);
+    expect(eventTypes).not.toContain("toolcall_end");
+    expect(eventTypes).not.toContain("done");
+  });
+});

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -1990,6 +1990,15 @@ describe("anthropic transport stream", () => {
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toBe("Provider completed tool call with malformed JSON arguments");
     expect(result.errorMessage).not.toContain("SECRET.md");
+    // Bounded diagnostics survive projection onto the terminal message without the content.
+    expect(result.errorCode).toBe("malformed_tool_call_arguments");
+    expect(JSON.parse(result.errorBody ?? "{}")).toEqual({
+      code: "malformed_tool_call_arguments",
+      argumentChars: '{"path":"SECRET.md"'.length,
+      argumentHash: expect.stringMatching(/^[0-9a-z]+$/),
+      repairAttempted: true,
+    });
+    expect(result.errorBody).not.toContain("SECRET.md");
     expect(eventTypes).not.toContain("toolcall_end");
     expect(eventTypes).not.toContain("done");
   });
@@ -2019,10 +2028,11 @@ describe("anthropic transport stream", () => {
           input: {},
         }),
         // Fine-grained tool streaming skips server-side JSON validation, so a finished
-        // block can carry a literal newline inside a string value.
+        // block can carry a literal newline inside a string value. The sibling oldText
+        // holds a valid \n escape after a "C:" prefix that the repair must leave intact.
         anthropicContentBlockDelta(1, {
           type: "input_json_delta",
-          partial_json: '{"path":"a.py","oldText":"x = 1","newText":"x = 1\ny = 2"}',
+          partial_json: '{"path":"a.py","oldText":"C:\\nnext","newText":"x = 1\ny = 2"}',
         }),
         { type: "content_block_stop", index: 1 },
         anthropicMessageDelta({ stop_reason: "tool_use" }, { input_tokens: 2, output_tokens: 2 }),
@@ -2049,7 +2059,7 @@ describe("anthropic transport stream", () => {
     expect(result.errorMessage).toBeUndefined();
     expect(toolCallEnds).toEqual([
       { path: "README.md" },
-      { path: "a.py", oldText: "x = 1", newText: "x = 1\ny = 2" },
+      { path: "a.py", oldText: "C:\nnext", newText: "x = 1\ny = 2" },
     ]);
   });
 

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -1994,6 +1994,65 @@ describe("anthropic transport stream", () => {
     expect(eventTypes).not.toContain("done");
   });
 
+  it("repairs complete terminal tool JSON with raw control characters instead of failing the turn", async () => {
+    guardedFetchMock.mockResolvedValueOnce(
+      createSseResponse([
+        anthropicMessageStart({
+          id: "msg_repairable_tools",
+          usage: { input_tokens: 2, output_tokens: 0 },
+        }),
+        anthropicContentBlockStart(0, {
+          type: "tool_use",
+          id: "call_valid",
+          name: "read",
+          input: {},
+        }),
+        anthropicContentBlockDelta(0, {
+          type: "input_json_delta",
+          partial_json: '{"path":"README.md"}',
+        }),
+        { type: "content_block_stop", index: 0 },
+        anthropicContentBlockStart(1, {
+          type: "tool_use",
+          id: "call_repairable",
+          name: "edit",
+          input: {},
+        }),
+        // Fine-grained tool streaming skips server-side JSON validation, so a finished
+        // block can carry a literal newline inside a string value.
+        anthropicContentBlockDelta(1, {
+          type: "input_json_delta",
+          partial_json: '{"path":"a.py","oldText":"x = 1","newText":"x = 1\ny = 2"}',
+        }),
+        { type: "content_block_stop", index: 1 },
+        anthropicMessageDelta({ stop_reason: "tool_use" }, { input_tokens: 2, output_tokens: 2 }),
+        { type: "message_stop" },
+      ]),
+    );
+    const streamFn = createAnthropicMessagesTransportStreamFn();
+    const stream = await Promise.resolve(
+      streamFn(
+        makeAnthropicTransportModel(),
+        { messages: [{ role: "user", content: "edit" }] } as AnthropicStreamContext,
+        { apiKey: "sk-ant-api" } as AnthropicStreamOptions,
+      ),
+    );
+    const toolCallEnds: unknown[] = [];
+    for await (const event of stream) {
+      if (event.type === "toolcall_end") {
+        toolCallEnds.push(event.toolCall.arguments);
+      }
+    }
+    const result = await stream.result();
+
+    expect(result.stopReason).toBe("toolUse");
+    expect(result.errorMessage).toBeUndefined();
+    expect(toolCallEnds).toEqual([
+      { path: "README.md" },
+      { path: "a.py", oldText: "x = 1", newText: "x = 1\ny = 2" },
+    ]);
+  });
+
   it("rejects an active tool call that never receives content_block_stop", async () => {
     guardedFetchMock.mockResolvedValueOnce(
       createSseResponse([

--- a/packages/ai/src/transports/transport-stream-shared.test.ts
+++ b/packages/ai/src/transports/transport-stream-shared.test.ts
@@ -6,6 +6,16 @@ import {
 
 const MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE =
   "Provider completed tool call with malformed JSON arguments";
+const REPAIR = { repairStringLiterals: true } as const;
+
+function captureError(run: () => unknown): Error & { errorCode?: string; errorBody?: string } {
+  try {
+    run();
+  } catch (error) {
+    return error as Error & { errorCode?: string; errorBody?: string };
+  }
+  throw new Error("expected a throw");
+}
 
 describe("parseTerminalToolCallArguments", () => {
   it("preserves unsafe integer literals in complete object arguments", () => {
@@ -16,57 +26,77 @@ describe("parseTerminalToolCallArguments", () => {
     expect(parseTerminalToolCallArguments({})).toEqual({});
   });
 
-  it("repairs raw control characters inside complete string values", () => {
+  it("stays strict by default: raw control characters are rejected without repair", () => {
+    const thrown = captureError(() =>
+      parseTerminalToolCallArguments('{"path":"a.py","newText":"x = 1\ny = 2"}'),
+    );
+    expect(thrown.message).toBe(MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE);
+    expect(thrown.cause).toMatchObject({ repairAttempted: false });
+  });
+
+  it("repairs raw control characters inside complete string values when opted in", () => {
     // Fine-grained tool streaming can deliver a finished block whose string values
     // contain literal newlines/tabs instead of \n / \t escapes.
-    expect(parseTerminalToolCallArguments('{"path":"a.py","newText":"x = 1\ny = 2\tend"}')).toEqual(
-      { path: "a.py", newText: "x = 1\ny = 2\tend" },
-    );
+    expect(
+      parseTerminalToolCallArguments(
+        '{"path":"a.py","newText":"x = 1\ny = 2\tend"}',
+        undefined,
+        REPAIR,
+      ),
+    ).toEqual({ path: "a.py", newText: "x = 1\ny = 2\tend" });
   });
 
   it("repairs invalid escapes by preserving the backslash the model meant", () => {
     // JS string is: {"command":"grep -E \d+ file"} — an unescaped regex backslash.
-    expect(parseTerminalToolCallArguments('{"command":"grep -E \\d+ file"}')).toEqual({
-      command: "grep -E \\d+ file",
+    expect(
+      parseTerminalToolCallArguments('{"command":"grep -E \\d+ file"}', undefined, REPAIR),
+    ).toEqual({ command: "grep -E \\d+ file" });
+  });
+
+  it("preserves valid control escapes in sibling fields, even after a path-like prefix", () => {
+    // oldText legitimately contains a newline (a valid \n escape after "C:"); newText has a raw
+    // newline that needs repair. The repair must not turn oldText into a literal backslash-n.
+    const raw = '{"path":"C:\\\\app\\\\a.py","oldText":"C:\\nnext","newText":"x = 1\ny = 2"}';
+    expect(parseTerminalToolCallArguments(raw, undefined, REPAIR)).toEqual({
+      path: "C:\\app\\a.py",
+      oldText: "C:\nnext",
+      newText: "x = 1\ny = 2",
     });
   });
 
   it("keeps unsafe integers intact when a repair was needed", () => {
-    expect(parseTerminalToolCallArguments('{"id":9223372036854775807,"note":"a\nb"}')).toEqual({
-      id: "9223372036854775807",
-      note: "a\nb",
-    });
+    expect(
+      parseTerminalToolCallArguments('{"id":9223372036854775807,"note":"a\nb"}', undefined, REPAIR),
+    ).toEqual({ id: "9223372036854775807", note: "a\nb" });
   });
 
   it.each(["", "   ", '{"secret":"do-not-echo"', "[]", "null", null])(
     "rejects non-object or malformed terminal input %# without exposing it",
     (value) => {
-      let thrown: unknown;
-      try {
-        parseTerminalToolCallArguments(value);
-      } catch (error) {
-        thrown = error;
+      for (const options of [undefined, REPAIR]) {
+        const thrown = captureError(() =>
+          parseTerminalToolCallArguments(value, undefined, options),
+        );
+        expect(thrown).toMatchObject({ message: MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE });
+        expect(String(thrown)).not.toContain("do-not-echo");
+        expect(JSON.stringify(thrown.cause ?? null)).not.toContain("do-not-echo");
+        expect(thrown.errorBody ?? "").not.toContain("do-not-echo");
       }
-      expect(thrown).toMatchObject({ message: MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE });
-      expect(String(thrown)).not.toContain("do-not-echo");
-      expect(JSON.stringify((thrown as Error).cause ?? null)).not.toContain("do-not-echo");
     },
   );
 
-  it("attaches privacy-safe diagnostics as the error cause", () => {
+  it("attaches privacy-safe diagnostics as cause, errorCode, and errorBody", () => {
     const truncated = '{"secret":"do-not-echo"';
-    let thrown: unknown;
-    try {
-      parseTerminalToolCallArguments(truncated);
-    } catch (error) {
-      thrown = error;
-    }
-    expect((thrown as Error).cause).toEqual({
+    const thrown = captureError(() => parseTerminalToolCallArguments(truncated, undefined, REPAIR));
+    const expected = {
       code: "malformed_tool_call_arguments",
       argumentChars: truncated.length,
       argumentHash: expect.stringMatching(/^[0-9a-z]+$/),
       repairAttempted: true,
-    });
+    };
+    expect(thrown.cause).toEqual(expected);
+    expect(thrown.errorCode).toBe("malformed_tool_call_arguments");
+    expect(JSON.parse(thrown.errorBody ?? "{}")).toEqual(expected);
   });
 });
 
@@ -84,7 +114,7 @@ describe("finalizeTerminalToolCallArguments", () => {
         partialJson: '{"path":"a.py","newText":"x\ny"}',
       },
     ];
-    finalizeTerminalToolCallArguments(calls, (call) => call.partialJson);
+    finalizeTerminalToolCallArguments(calls, (call) => call.partialJson, undefined, REPAIR);
     expect(calls[0]?.arguments).toEqual({ path: "README.md" });
     expect(calls[1]?.arguments).toEqual({ path: "a.py", newText: "x\ny" });
   });
@@ -102,9 +132,9 @@ describe("finalizeTerminalToolCallArguments", () => {
         partialJson: '{"path":"SECRET.md"',
       },
     ];
-    expect(() => finalizeTerminalToolCallArguments(calls, (call) => call.partialJson)).toThrow(
-      MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE,
-    );
+    expect(() =>
+      finalizeTerminalToolCallArguments(calls, (call) => call.partialJson, undefined, REPAIR),
+    ).toThrow(MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE);
     expect(calls[0]?.arguments).toEqual({});
     expect(calls[1]?.arguments).toEqual({});
   });

--- a/packages/ai/src/transports/transport-stream-shared.test.ts
+++ b/packages/ai/src/transports/transport-stream-shared.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { parseTerminalToolCallArguments } from "./transport-stream-shared.js";
+import {
+  finalizeTerminalToolCallArguments,
+  parseTerminalToolCallArguments,
+} from "./transport-stream-shared.js";
 
 const MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE =
   "Provider completed tool call with malformed JSON arguments";
@@ -13,6 +16,28 @@ describe("parseTerminalToolCallArguments", () => {
     expect(parseTerminalToolCallArguments({})).toEqual({});
   });
 
+  it("repairs raw control characters inside complete string values", () => {
+    // Fine-grained tool streaming can deliver a finished block whose string values
+    // contain literal newlines/tabs instead of \n / \t escapes.
+    expect(parseTerminalToolCallArguments('{"path":"a.py","newText":"x = 1\ny = 2\tend"}')).toEqual(
+      { path: "a.py", newText: "x = 1\ny = 2\tend" },
+    );
+  });
+
+  it("repairs invalid escapes by preserving the backslash the model meant", () => {
+    // JS string is: {"command":"grep -E \d+ file"} — an unescaped regex backslash.
+    expect(parseTerminalToolCallArguments('{"command":"grep -E \\d+ file"}')).toEqual({
+      command: "grep -E \\d+ file",
+    });
+  });
+
+  it("keeps unsafe integers intact when a repair was needed", () => {
+    expect(parseTerminalToolCallArguments('{"id":9223372036854775807,"note":"a\nb"}')).toEqual({
+      id: "9223372036854775807",
+      note: "a\nb",
+    });
+  });
+
   it.each(["", "   ", '{"secret":"do-not-echo"', "[]", "null", null])(
     "rejects non-object or malformed terminal input %# without exposing it",
     (value) => {
@@ -24,6 +49,63 @@ describe("parseTerminalToolCallArguments", () => {
       }
       expect(thrown).toMatchObject({ message: MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE });
       expect(String(thrown)).not.toContain("do-not-echo");
+      expect(JSON.stringify((thrown as Error).cause ?? null)).not.toContain("do-not-echo");
     },
   );
+
+  it("attaches privacy-safe diagnostics as the error cause", () => {
+    const truncated = '{"secret":"do-not-echo"';
+    let thrown: unknown;
+    try {
+      parseTerminalToolCallArguments(truncated);
+    } catch (error) {
+      thrown = error;
+    }
+    expect((thrown as Error).cause).toEqual({
+      code: "malformed_tool_call_arguments",
+      argumentChars: truncated.length,
+      argumentHash: expect.stringMatching(/^[0-9a-z]+$/),
+      repairAttempted: true,
+    });
+  });
+});
+
+describe("finalizeTerminalToolCallArguments", () => {
+  it("repairs a sibling call without touching already-valid siblings", () => {
+    const calls = [
+      {
+        name: "read",
+        arguments: {} as Record<string, unknown>,
+        partialJson: '{"path":"README.md"}',
+      },
+      {
+        name: "edit",
+        arguments: {} as Record<string, unknown>,
+        partialJson: '{"path":"a.py","newText":"x\ny"}',
+      },
+    ];
+    finalizeTerminalToolCallArguments(calls, (call) => call.partialJson);
+    expect(calls[0]?.arguments).toEqual({ path: "README.md" });
+    expect(calls[1]?.arguments).toEqual({ path: "a.py", newText: "x\ny" });
+  });
+
+  it("does not mutate any sibling when one call stays malformed", () => {
+    const calls = [
+      {
+        name: "read",
+        arguments: {} as Record<string, unknown>,
+        partialJson: '{"path":"README.md"}',
+      },
+      {
+        name: "read",
+        arguments: {} as Record<string, unknown>,
+        partialJson: '{"path":"SECRET.md"',
+      },
+    ];
+    expect(() => finalizeTerminalToolCallArguments(calls, (call) => call.partialJson)).toThrow(
+      MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE,
+    );
+    expect(calls[0]?.arguments).toEqual({});
+    expect(calls[1]?.arguments).toEqual({});
+  });
 });

--- a/packages/ai/src/transports/transport-stream-shared.test.ts
+++ b/packages/ai/src/transports/transport-stream-shared.test.ts
@@ -70,20 +70,27 @@ describe("parseTerminalToolCallArguments", () => {
     ).toEqual({ id: "9223372036854775807", note: "a\nb" });
   });
 
-  it.each(["", "   ", '{"secret":"do-not-echo"', "[]", "null", null])(
-    "rejects non-object or malformed terminal input %# without exposing it",
-    (value) => {
-      for (const options of [undefined, REPAIR]) {
-        const thrown = captureError(() =>
-          parseTerminalToolCallArguments(value, undefined, options),
-        );
-        expect(thrown).toMatchObject({ message: MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE });
-        expect(String(thrown)).not.toContain("do-not-echo");
-        expect(JSON.stringify(thrown.cause ?? null)).not.toContain("do-not-echo");
-        expect(thrown.errorBody ?? "").not.toContain("do-not-echo");
-      }
-    },
-  );
+  it.each([
+    "",
+    "   ",
+    '{"secret":"do-not-echo"',
+    "[]",
+    "null",
+    null,
+    // Truncated free-text arguments must never be "repaired" into a shorter, executable
+    // command (a cut-off `rm -rf /srv/app/tmp/build-cache` would otherwise become `rm -rf /`).
+    '{"command":"rm -rf /',
+    '{"command":"rm -rf /srv/app/tmp/bu',
+    '{"command":"rm -rf /srv/app/tmp/build-cache","timeout":6',
+  ])("rejects non-object or malformed terminal input %# without exposing it", (value) => {
+    for (const options of [undefined, REPAIR]) {
+      const thrown = captureError(() => parseTerminalToolCallArguments(value, undefined, options));
+      expect(thrown).toMatchObject({ message: MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE });
+      const surfaced = `${String(thrown)}${JSON.stringify(thrown.cause ?? null)}${thrown.errorBody ?? ""}`;
+      expect(surfaced).not.toContain("do-not-echo");
+      expect(surfaced).not.toContain("rm -rf");
+    }
+  });
 
   it("attaches privacy-safe diagnostics as cause, errorCode, and errorBody", () => {
     const truncated = '{"secret":"do-not-echo"';

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -85,58 +85,74 @@ export class IncompleteToolCallError extends Error {
 const MALFORMED_TOOL_CALL_TERMINAL_ERROR_CODE = "malformed_tool_call_arguments";
 
 /**
- * Privacy-safe terminal parse diagnostics attached as the error `cause`: enough to
- * correlate and size a failure across reports without echoing tool arguments.
+ * Bounded, content-free diagnostics for a rejected terminal argument buffer. Carried as the
+ * error `cause` and mirrored onto the error's `errorCode` / `errorBody` fields so
+ * `projectProviderError` surfaces them on the terminal assistant message.
  */
-export type MalformedToolCallArgumentsCause = {
+type MalformedToolCallArgumentsDiagnostics = {
   code: typeof MALFORMED_TOOL_CALL_TERMINAL_ERROR_CODE;
   argumentChars: number;
   argumentHash: string;
   repairAttempted: boolean;
 };
 
-function createMalformedToolCallArgumentsError(value: unknown, errorMessage: string): Error {
+function createMalformedToolCallArgumentsError(
+  value: unknown,
+  errorMessage: string,
+  repairAttempted: boolean,
+): Error {
   const text = typeof value === "string" ? value : undefined;
-  const cause: MalformedToolCallArgumentsCause = {
+  const diagnostics: MalformedToolCallArgumentsDiagnostics = {
     code: MALFORMED_TOOL_CALL_TERMINAL_ERROR_CODE,
     argumentChars: text?.length ?? 0,
     argumentHash: text === undefined ? "" : shortHash(text),
-    repairAttempted: text !== undefined,
+    repairAttempted,
   };
-  return new Error(errorMessage, { cause });
+  const error = new Error(errorMessage, { cause: diagnostics });
+  Object.assign(error, {
+    errorCode: MALFORMED_TOOL_CALL_TERMINAL_ERROR_CODE,
+    errorBody: JSON.stringify(diagnostics),
+  });
+  return error;
 }
 
 /**
- * Repair a complete-but-invalid terminal argument buffer. Fine-grained tool streaming
- * skips server-side JSON validation, so a finished tool_use block can still carry raw
- * control characters or invalid escapes inside string values. Only string-literal
- * repairs are applied; truncated or non-object buffers stay rejected so a cut-off
- * write never executes with partial arguments.
+ * Repair a complete-but-invalid terminal argument buffer. Anthropic fine-grained tool
+ * streaming skips server-side JSON validation, so a finished tool_use block can carry raw
+ * control characters or invalid escapes inside string values. Only string-literal repairs
+ * are applied and every valid escape is preserved as written; truncated or non-object
+ * buffers stay rejected so a cut-off write never executes with partial arguments.
  */
 function repairTerminalToolCallArguments(value: string): Record<string, unknown> | null {
-  const repaired = repairJson(value);
+  const repaired = repairJson(value, { preserveValidControlEscapes: true });
   if (repaired === value) {
     return null;
   }
   return parseJsonObjectPreservingUnsafeIntegers(repaired);
 }
 
-/** Admit only complete object-shaped terminal tool arguments; partial parsing is preview-only. */
+/**
+ * Admit only complete object-shaped terminal tool arguments; partial parsing is preview-only.
+ * `repairStringLiterals` opts a stream whose provider may deliver unvalidated tool input into
+ * string-literal repair before rejection.
+ */
 export function parseTerminalToolCallArguments(
   value: unknown,
   errorMessage = MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE,
+  options?: { repairStringLiterals?: boolean },
 ): Record<string, unknown> {
   const parsed = parseJsonObjectPreservingUnsafeIntegers(value);
   if (parsed) {
     return parsed;
   }
-  if (typeof value === "string") {
+  const repairStringLiterals = options?.repairStringLiterals === true && typeof value === "string";
+  if (repairStringLiterals) {
     const repaired = repairTerminalToolCallArguments(value);
     if (repaired) {
       return repaired;
     }
   }
-  throw createMalformedToolCallArgumentsError(value, errorMessage);
+  throw createMalformedToolCallArgumentsError(value, errorMessage, repairStringLiterals);
 }
 
 /** Validate a complete sibling set before mutating any call into executable state. */
@@ -144,9 +160,11 @@ export function finalizeTerminalToolCallArguments<T extends { arguments: Record<
   calls: readonly T[],
   readArguments: (call: T) => unknown,
   errorMessage?: string,
+  options?: { repairStringLiterals?: boolean },
 ): void {
   const validated = calls.map(
-    (call) => [call, parseTerminalToolCallArguments(readArguments(call), errorMessage)] as const,
+    (call) =>
+      [call, parseTerminalToolCallArguments(readArguments(call), errorMessage, options)] as const,
   );
   for (const [call, argumentsValue] of validated) {
     call.arguments = argumentsValue;

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -18,7 +18,9 @@ import {
   projectDiagnosticValue,
 } from "../utils/diagnostics.js";
 import { createAssistantMessageEventStream } from "../utils/event-stream.js";
+import { shortHash } from "../utils/hash.js";
 import { headersToRecord } from "../utils/headers.js";
+import { repairJson } from "../utils/json-parse.js";
 import { projectProviderError, type ProviderErrorProjection } from "../utils/provider-error.js";
 import { isTransientNetworkError } from "../utils/retryable-network-errors.js";
 import { sanitizeSurrogates } from "../utils/sanitize-unicode.js";
@@ -80,16 +82,61 @@ export class IncompleteToolCallError extends Error {
   readonly code = "incomplete_tool_call";
 }
 
+const MALFORMED_TOOL_CALL_TERMINAL_ERROR_CODE = "malformed_tool_call_arguments";
+
+/**
+ * Privacy-safe terminal parse diagnostics attached as the error `cause`: enough to
+ * correlate and size a failure across reports without echoing tool arguments.
+ */
+export type MalformedToolCallArgumentsCause = {
+  code: typeof MALFORMED_TOOL_CALL_TERMINAL_ERROR_CODE;
+  argumentChars: number;
+  argumentHash: string;
+  repairAttempted: boolean;
+};
+
+function createMalformedToolCallArgumentsError(value: unknown, errorMessage: string): Error {
+  const text = typeof value === "string" ? value : undefined;
+  const cause: MalformedToolCallArgumentsCause = {
+    code: MALFORMED_TOOL_CALL_TERMINAL_ERROR_CODE,
+    argumentChars: text?.length ?? 0,
+    argumentHash: text === undefined ? "" : shortHash(text),
+    repairAttempted: text !== undefined,
+  };
+  return new Error(errorMessage, { cause });
+}
+
+/**
+ * Repair a complete-but-invalid terminal argument buffer. Fine-grained tool streaming
+ * skips server-side JSON validation, so a finished tool_use block can still carry raw
+ * control characters or invalid escapes inside string values. Only string-literal
+ * repairs are applied; truncated or non-object buffers stay rejected so a cut-off
+ * write never executes with partial arguments.
+ */
+function repairTerminalToolCallArguments(value: string): Record<string, unknown> | null {
+  const repaired = repairJson(value);
+  if (repaired === value) {
+    return null;
+  }
+  return parseJsonObjectPreservingUnsafeIntegers(repaired);
+}
+
 /** Admit only complete object-shaped terminal tool arguments; partial parsing is preview-only. */
 export function parseTerminalToolCallArguments(
   value: unknown,
   errorMessage = MALFORMED_TOOL_CALL_TERMINAL_ERROR_MESSAGE,
 ): Record<string, unknown> {
   const parsed = parseJsonObjectPreservingUnsafeIntegers(value);
-  if (!parsed) {
-    throw new Error(errorMessage);
+  if (parsed) {
+    return parsed;
   }
-  return parsed;
+  if (typeof value === "string") {
+    const repaired = repairTerminalToolCallArguments(value);
+    if (repaired) {
+      return repaired;
+    }
+  }
+  throw createMalformedToolCallArgumentsError(value, errorMessage);
 }
 
 /** Validate a complete sibling set before mutating any call into executable state. */

--- a/packages/ai/src/utils/json-parse.test.ts
+++ b/packages/ai/src/utils/json-parse.test.ts
@@ -25,6 +25,16 @@ describe("json-parse repairJson invalid \\u escapes", () => {
     expect(parseJsonWithRepair(input)).toEqual({ path: expected });
   });
 
+  it("preserves valid control escapes after a Windows-path prefix when asked to", () => {
+    // JS string is: {"oldText":"C:\nnext"} — a legitimately escaped newline after "C:".
+    const escaped = '{"oldText":"C:\\nnext","raw":"a\nb"}';
+    expect(parseJsonWithRepair(escaped)).toEqual({ oldText: "C:\\nnext", raw: "a\nb" });
+    expect(JSON.parse(repairJson(escaped, { preserveValidControlEscapes: true }))).toEqual({
+      oldText: "C:\nnext",
+      raw: "a\nb",
+    });
+  });
+
   it("preserves legitimate JSON control escapes outside Windows paths", () => {
     expect(parseJsonWithRepair('{"message":"line\\nnext\\ttabbed"}')).toEqual({
       message: "line\nnext\ttabbed",

--- a/packages/ai/src/utils/json-parse.ts
+++ b/packages/ai/src/utils/json-parse.ts
@@ -31,8 +31,17 @@ function escapeControlCharacter(char: string): string {
  * Repairs malformed JSON string literals by:
  * - escaping raw control characters inside strings
  * - doubling backslashes before invalid escape characters
+ *
+ * By default a valid control escape (`\n`, `\t`, ...) that follows a Windows-path-looking
+ * prefix is treated as an unescaped path separator and doubled. Pass
+ * `preserveValidControlEscapes` when the text is authoritative (for example a completed
+ * tool-call argument buffer) and every valid escape must survive as written.
  */
-export function repairJson(json: string): string {
+export function repairJson(
+  json: string,
+  options?: { preserveValidControlEscapes?: boolean },
+): string {
+  const preserveValidControlEscapes = options?.preserveValidControlEscapes === true;
   let repaired = "";
   let inString = false;
   let stringValuePrefix = "";
@@ -80,7 +89,11 @@ export function repairJson(json: string): string {
         continue;
       }
 
-      if (JSON_CONTROL_ESCAPES.has(nextChar) && looksLikeWindowsPathPrefix(stringValuePrefix)) {
+      if (
+        !preserveValidControlEscapes &&
+        JSON_CONTROL_ESCAPES.has(nextChar) &&
+        looksLikeWindowsPathPrefix(stringValuePrefix)
+      ) {
         repaired += "\\\\";
         stringValuePrefix += "\\";
         continue;


### PR DESCRIPTION
Related: #135111

## What Problem This Solves

Fixes an issue where an agent turn fails with `LLM request failed` (raw error `Provider completed tool call with malformed JSON arguments`) when a Claude tool call finishes streaming with a string value that contains a raw control character (for example a literal newline in an `edit` tool's `newText`) or an invalid escape (for example `\d` in an `exec` command). The whole turn is discarded, the user sees a generic failure in Telegram / webchat, and retrying usually reproduces it because the model emits the same tool call again. Model fallback does not engage because the failure is classified as `unclassified`.

Every direct Anthropic request from OpenClaw opts into fine-grained tool streaming (per-tool `eager_input_streaming`, or the legacy beta header when `compat.supportsEagerToolInputStreaming` is off). Anthropic's documentation for that feature states the API "does not buffer or validate a tool's input before streaming it, so you might receive partial or invalid JSON". Since 2026.8.1 (#126391) the terminal parse in `transport-stream-shared.ts` fails closed on any parse error, so this class of provider output aborts the turn instead of being repaired.

## Why This Change Was Made

- **Opt-in string-literal repair, Anthropic reducer only.** `parseTerminalToolCallArguments` / `finalizeTerminalToolCallArguments` accept `{ repairStringLiterals: true }`; only the Anthropic Messages stream reducer passes it, because that is the transport whose provider documents unvalidated tool input. The OpenAI Chat Completions, Responses, and Mistral terminals keep their existing strict contract unchanged (their fail-closed tests for invalid escapes and control characters still pass).
- **Valid escapes are never rewritten.** `repairJson` gains `preserveValidControlEscapes`, which skips its Windows-path heuristic (that heuristic doubles a legitimate `\n` after a `C:`-looking prefix and would have turned a valid `oldText` into a literal backslash-n while repairing a sibling field). Terminal repair always uses this mode, so only raw control characters and invalid escapes are touched.
- **Truncation still fails closed.** Truncated buffers, arrays, `null`, and empty input are rejected exactly as before, atomically for the whole sibling set, so a tool call cut off mid-argument never executes with partial arguments.
- **Diagnostics reach the terminal message.** The thrown error keeps its exact message and never echoes tool arguments. It now carries bounded diagnostics (`code`, `argumentChars`, `argumentHash`, `repairAttempted`) as `cause` **and** on `errorCode` / `errorBody`, which `projectProviderError` propagates onto the returned assistant message (`result.errorCode`, `result.errorBody`). Asserted at the transport boundary, not only on the parser exception.

Non-goals: no lenient/partial parsing at the terminal boundary, no new dependencies, no change to preview parsing during streaming, no change for non-Anthropic transports.

## User Impact

On Anthropic Messages streams, tool calls whose arguments are complete but contain raw control characters or invalid escapes now execute instead of failing the turn, and legitimate escaped text in sibling fields is left exactly as the model wrote it. Genuinely truncated or non-object tool arguments behave as before. When a turn still fails, the terminal message carries `errorCode: "malformed_tool_call_arguments"` and a content-free `errorBody` with the argument length and hash for log correlation.

## Evidence

### Real transport client over HTTP (no fetch mock)

New `anthropic-transport-stream.terminal-repair.integration.test.ts` starts a loopback `node:http` SSE server, points `createAnthropicMessagesTransportStreamFn` at it with the platform `fetch` as the host fetch, and asserts on the events and terminal message that come back through the actual client. The server asserts the request arrived as `POST /v1/messages` with `stream: true`.

Observed output from that test run (a temporary `console.info` of the returned values was added for this capture and is not part of the committed test; loopback ports are ephemeral):

```
stdout | ... > repairs a raw newline in one call and preserves a valid escape in its sibling
[loopback http://127.0.0.1:51355] events=start,toolcall_start,toolcall_delta,toolcall_start,toolcall_delta,toolcall_end,toolcall_end,done
  stopReason=toolUse errorMessage=undefined errorCode=undefined errorBody=undefined
  toolcall_end arguments=[{"path":"README.md"},{"path":"a.py","oldText":"C:\nnext","newText":"x = 1\ny = 2"}]

stdout | ... > still fails closed on a truncated sibling and surfaces bounded diagnostics
[loopback http://127.0.0.1:51357] events=error
  stopReason=error errorMessage="Provider completed tool call with malformed JSON arguments" errorCode="malformed_tool_call_arguments" errorBody="{\"code\":\"malformed_tool_call_arguments\",\"argumentChars\":19,\"argumentHash\":\"jiqoxq1e07seo\",\"repairAttempted\":true}"
  toolcall_end arguments=[]

 ✓ ... > repairs a raw newline in one call and preserves a valid escape in its sibling 19ms
 ✓ ... > still fails closed on a truncated sibling and surfaces bounded diagnostics 6ms
 Test Files  1 passed (1)   Tests  2 passed (2)
```

The second case streams `{"path":"SECRET.md"` (19 chars) as the truncated sibling; the string `SECRET.md` appears nowhere in `errorMessage` or `errorBody`.

### Same tests against three source states (Vitest 5, tests held constant)

| Source under test | Result |
|---|---|
| `upstream/main` (fd67ed8fba) | **12 failed** / 154 passed: every new repair, strict-default, diagnostics, and loopback test fails; the truncated-rejection test fails only on the new `errorCode`/`errorBody` assertions |
| First revision of this PR (3a3e003859) | **8 failed** / 158 passed, including `preserves valid control escapes in sibling fields, even after a path-like prefix` and `attaches privacy-safe diagnostics as cause, errorCode, and errorBody` (the two review findings), plus `stays strict by default` |
| This revision | **166 passed** / 0 failed |

Wider run across the touched callers (`transport-stream-shared`, `anthropic-transport-stream`, the loopback integration test, `json-parse`, `openai-completions.legacy-function-call`, `provider-transport-parity`, `providers/anthropic`, `providers/mistral*`, `openai-responses-stream-terminal*`): 12 files, **494 passed**, 1 skipped, 0 failed. The two OpenAI Chat Completions tests that the first CI run broke (`rejects an authoritative modern tool terminal with invalid string escape` / `... unescaped control character`) pass again because repair is no longer applied on that transport.

Formatting checked with the repo's pinned `oxfmt` 0.65.0. `MalformedToolCallArgumentsCause` (knip "unused exported type" in the first CI run) is no longer exported.

### Live occurrence that motivated this

My gateway, OpenClaw 2026.8.1, `anthropic/claude-opus-5` direct to `api.anthropic.com` (setup-token auth, no proxy), 2026-09-07. Three failures with identical `rawErrorHash sha256:312050b5c5fd`, all HTTP 200 from the provider, each on the same pending multi-line `edit` of a Python script after a dozen smaller tool calls in the same session had succeeded:

```
13:06:08Z embedded_run_agent_end isError=true error="LLM request failed." failoverReason=null model=claude-opus-5
          rawErrorPreview="Provider completed tool call with malformed JSON arguments" providerRuntimeFailureKind=unclassified
13:43:00Z (retry, same thread)  same rawErrorHash, lastCallUsage output=1507
13:51:10Z (retry, same thread)  same rawErrorHash, lastCallUsage output=1329
```

Trajectory data for the failed runs: `aborted=false timedOut=false stopReason=error assistantTexts=[]`, output tokens ~1.2k–1.5k against a 64k `maxTokens`, so not a `max_tokens` cut-off. Scope note: these logs show the failing terminal parse but not the raw buffer, so they do not prove which malformation class every occurrence in #135111 belongs to. That is exactly what the new `errorCode`/`errorBody` diagnostics are for: after this change an unrepaired occurrence reports its length and hash without exposing content, so the remaining classes can be characterized from redacted logs.

### CI note

`checks-node-compact-large-12` failed in the first run on `src/agents/subagents/spawn/acp-spawn.authority.test.ts` ("cleanup completes before spawn returns"), which is the known flaky test tracked in #141028 and untouched by this PR.

Local runs used a standalone Vitest harness resolving the workspace packages from source (my local Node is below the repo engine floor for a full `pnpm install`); CI is the authoritative run for `pnpm check`.
