### PR TITLE
refactor(sdk): project Gateway options from client contracts

### DIFF
--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -1,5 +1,5 @@
 // OpenClaw SDK module implements transport behavior.
-import { GatewayClient } from "@openclaw/gateway-client";
+import { GatewayClient, type GatewayClientOptions } from "@openclaw/gateway-client";
 import { EventHub } from "./event-hub.js";
 import type {
   ConnectableOpenClawTransport,
@@ -10,51 +10,46 @@ import type {
 
 // Gateway transport adapter that converts the lower-level GatewayClient into the
 // SDK transport interface and replays raw events for late subscribers.
-type GatewayClientLike = {
-  request<T = unknown>(
-    method: string,
-    params?: unknown,
-    options?: GatewayRequestOptions,
-  ): Promise<T>;
-  stopAndWait(): Promise<void>;
-};
+type GatewayClientLike = Pick<GatewayClient, "request" | "stopAndWait">;
 
 const RAW_EVENT_REPLAY_LIMIT = 1000;
 
-/** Options passed through to the Gateway websocket client. */
-type GatewayClientTransportOptions = {
-  url?: string;
-  connectChallengeTimeoutMs?: number;
-  preauthHandshakeTimeoutMs?: number;
-  tickWatchMinIntervalMs?: number;
-  requestTimeoutMs?: number;
-  token?: string;
-  bootstrapToken?: string;
-  deviceToken?: string;
-  password?: string;
-  instanceId?: string;
+/** Explicit SDK projection with its broader identity and callback contracts preserved. */
+type GatewayClientTransportOptions = Pick<
+  GatewayClientOptions,
+  | "url"
+  | "connectChallengeTimeoutMs"
+  | "preauthHandshakeTimeoutMs"
+  | "tickWatchMinIntervalMs"
+  | "requestTimeoutMs"
+  | "token"
+  | "bootstrapToken"
+  | "deviceToken"
+  | "password"
+  | "instanceId"
+  | "clientDisplayName"
+  | "clientVersion"
+  | "platform"
+  | "deviceFamily"
+  | "role"
+  | "scopes"
+  | "caps"
+  | "commands"
+  | "permissions"
+  | "pathEnv"
+  | "minProtocol"
+  | "maxProtocol"
+  | "tlsFingerprint"
+  | "onConnectError"
+  | "onGap"
+> & {
   clientName?: string;
-  clientDisplayName?: string;
-  clientVersion?: string;
-  platform?: string;
-  deviceFamily?: string;
   mode?: string;
-  role?: string;
-  scopes?: string[];
-  caps?: string[];
-  commands?: string[];
-  permissions?: Record<string, boolean>;
-  pathEnv?: string;
   deviceIdentity?: unknown;
-  minProtocol?: number;
-  maxProtocol?: number;
-  tlsFingerprint?: string;
   onEvent?: (evt: GatewayEvent) => void;
   onHelloOk?: (hello: unknown) => void;
-  onConnectError?: (err: Error) => void;
   onReconnectPaused?: (info: unknown) => void;
   onClose?: (code: number, reason: string) => void;
-  onGap?: (info: { expected: number; received: number }) => void;
 };
 
 function toGatewayEvent(event: unknown): GatewayEvent {

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -1,5 +1,6 @@
 // Public SDK data contracts for Gateway transport, runs, sessions, tools,
 // artifacts, tasks, environments, and normalized event streams.
+import type { GatewayClientRequestOptions } from "@openclaw/gateway-client";
 import type {
   ArtifactSummary as GatewayArtifactSummaryType,
   ArtifactsDownloadResult as GatewayArtifactsDownloadResultType,
@@ -39,11 +40,8 @@ export type {
 
 export type JsonObject = Record<string, unknown>;
 
-/** Per-request options accepted by SDK transports. */
-export type GatewayRequestOptions = {
-  expectFinal?: boolean;
-  timeoutMs?: number | null;
-};
+/** SDK request projection; additional GatewayClient lifecycle hooks stay client-owned. */
+export type GatewayRequestOptions = Pick<GatewayClientRequestOptions, "expectFinal" | "timeoutMs">;
 
 /** Raw event payload emitted by the Gateway transport. */
 export type GatewayEvent = {


### PR DESCRIPTION
## What Problem This Solves

The SDK repeats Gateway connection and request option types already owned by gateway-client. Independent copies can drift while the SDK also has broader public input contracts that must remain compatible.

## Why This Change Was Made

The SDK explicitly selects its 25 shared connection fields and two request fields from gateway-client. Its seven broader identity and callback fields remain explicit SDK overrides. The private client view selects the existing request and stop methods instead of repeating their signatures.

## User Impact

No runtime change. The constructor still accepts no argument or the same 32 optional fields. Arbitrary client names/modes, unknown device identities and callback payloads, and the two-argument `onClose` contract remain accepted. Request options remain only `expectFinal` and nullable `timeoutMs`; lower-level lifecycle callbacks and signals are not added to the SDK surface. No export or dependency changes.

Production shrinks by seven lines. Existing constructors and runtime statements, including the existing adapter assertion, are unchanged.

## Evidence

`node scripts/run-vitest.mjs packages/sdk/src/transport.test.ts packages/sdk/src/transport.websocket.test.ts packages/sdk/src/index.test.ts packages/gateway-client/src/client.request-timeout.test.ts`: **53 passed**, two shards in **3.91s**. Independent autoreview is clean through P3.

A read-only TypeScript compiler comparison against the original sources at `6b61530eee45` confirms identical option property sets, optionality and types: **32 constructor fields**, **2 request fields**, nullable timeout, optional constructor argument, two-argument `onClose`, and the unchanged public generic request signature. `node scripts/check-changed.mjs` passed completely, including production/test types, lint, dead-export scans and runtime/storage guards. `pnpm build` passed in **8m57.3s**; the separate `pnpm --filter @openclaw/sdk build` passed in **1996ms**. The emitted `index.d.mts` retains the 25 shared fields plus seven overrides, optional constructor argument and unchanged request contracts.

The commit rebased patch-identically onto `fd67ed8fbaff`; relevant SDK and gateway-client source owners are unchanged. No public symbol is removed, renamed, or narrowed, so no compatibility re-export is needed.

Exact-head [CI run 34140262986](https://github.com/openclaw/openclaw/actions/runs/34140262986) passed for `1001f36158d095d9b9a42907b6a41bf5648a5549`, without a rerun. Final review found no actionable defect or before-merge item.
