### PR TITLE
fix(tlon): honor Content-Disposition filenames on outbound image upload

### DIFF
--- a/extensions/tlon/src/urbit/upload.content-disposition.http.test.ts
+++ b/extensions/tlon/src/urbit/upload.content-disposition.http.test.ts
@@ -1,0 +1,98 @@
+// Production uploadImageFromUrl against a real Content-Disposition HTTP response.
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { readRemoteMediaBuffer } from "openclaw/plugin-sdk/media-runtime";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { uploadFile } from "../tlon-api.js";
+import { uploadImageFromUrl } from "./upload.js";
+
+const actualReadRemoteMediaBuffer = vi.hoisted(() => ({
+  current: null as typeof readRemoteMediaBuffer | null,
+}));
+
+vi.mock("openclaw/plugin-sdk/media-runtime", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/media-runtime")>();
+  actualReadRemoteMediaBuffer.current = actual.readRemoteMediaBuffer;
+  return {
+    ...actual,
+    readRemoteMediaBuffer: vi.fn((opts: Parameters<typeof actual.readRemoteMediaBuffer>[0]) => {
+      const origin = new URL(opts.url).origin;
+      return actual.readRemoteMediaBuffer({
+        ...opts,
+        // Loopback reflectors are private; production CDN fetches use the same downloader.
+        ssrfPolicy: { allowedOrigins: [origin] },
+      });
+    }),
+  };
+});
+
+vi.mock("../tlon-api.js", () => ({
+  uploadFile: vi.fn(),
+}));
+
+const mockUploadFile = vi.mocked(uploadFile);
+
+const PNG_1X1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=",
+  "base64",
+);
+
+async function withImageServer(
+  respond: (request: IncomingMessage, response: ServerResponse) => void,
+  run: (origin: string) => Promise<void>,
+): Promise<void> {
+  const server = createServer(respond);
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === "string") {
+    throw new Error("expected an ephemeral loopback address");
+  }
+  const origin = `http://127.0.0.1:${(address as AddressInfo).port}`;
+  try {
+    await run(origin);
+  } finally {
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+  }
+}
+
+describe("uploadImageFromUrl Content-Disposition HTTP", () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("stores the Content-Disposition filename from a real HTTP download", async () => {
+    mockUploadFile.mockResolvedValue({ url: "https://memex.tlon.network/uploaded.png" });
+    await withImageServer(
+      (_request, response) => {
+        response.writeHead(200, {
+          "content-type": "image/png",
+          "content-disposition": 'attachment; filename="photo.png"',
+        });
+        response.end(PNG_1X1);
+      },
+      async (origin) => {
+        const imageUrl = `${origin}/download?id=123`;
+        const result = await uploadImageFromUrl(imageUrl);
+        const [call] = mockUploadFile.mock.calls;
+        if (!call) {
+          throw new Error("expected Tlon uploadFile call");
+        }
+        const [uploadParams] = call;
+        expect(result).toBe("https://memex.tlon.network/uploaded.png");
+        expect(uploadParams?.fileName).toBe("photo.png");
+        expect(actualReadRemoteMediaBuffer.current).not.toBeNull();
+        console.log(
+          `[tlon content-disposition proof] stored_filename=${uploadParams?.fileName} source=${imageUrl}`,
+        );
+      },
+    );
+  });
+});

--- a/extensions/tlon/src/urbit/upload.test.ts
+++ b/extensions/tlon/src/urbit/upload.test.ts
@@ -16,13 +16,17 @@ vi.mock("../tlon-api.js", () => ({
 const mockReadRemoteMediaBuffer = vi.mocked(readRemoteMediaBuffer);
 const mockUploadFile = vi.mocked(uploadFile);
 
-async function setupSuccessfulUpload(params?: { contentType?: string; uploadedUrl?: string }) {
+async function setupSuccessfulUpload(params?: {
+  contentType?: string;
+  uploadedUrl?: string;
+  fileName?: string | null;
+}) {
   const contentType = params?.contentType ?? "image/png";
   const buffer = Buffer.from("fake-image");
   mockReadRemoteMediaBuffer.mockResolvedValue({
     buffer,
     contentType,
-    fileName: "image.png",
+    ...(params?.fileName === null ? {} : { fileName: params?.fileName ?? "image.png" }),
   });
   if (params?.uploadedUrl) {
     mockUploadFile.mockResolvedValue({ url: params.uploadedUrl });
@@ -132,6 +136,7 @@ describe("uploadImageFromUrl", () => {
   it("extracts filename from URL path", async () => {
     await setupSuccessfulUpload({
       contentType: "image/jpeg",
+      fileName: null,
     });
     mockUploadFile.mockResolvedValue({ url: "https://memex.tlon.network/uploaded.jpg" });
 
@@ -140,9 +145,22 @@ describe("uploadImageFromUrl", () => {
     expect(requireUploadParams().fileName).toBe("my-image.jpg");
   });
 
+  it("uses the fetched Content-Disposition filename when the URL has no suffix", async () => {
+    await setupSuccessfulUpload({
+      contentType: "image/png",
+      fileName: "photo.png",
+    });
+    mockUploadFile.mockResolvedValue({ url: "https://memex.tlon.network/uploaded.png" });
+
+    await uploadImageFromUrl("https://cdn.example/download?id=123");
+
+    expect(requireUploadParams().fileName).toBe("photo.png");
+  });
+
   it("uses default filename when URL has no path", async () => {
     await setupSuccessfulUpload({
       contentType: "image/png",
+      fileName: null,
     });
     mockUploadFile.mockResolvedValue({ url: "https://memex.tlon.network/uploaded.png" });
 

--- a/extensions/tlon/src/urbit/upload.ts
+++ b/extensions/tlon/src/urbit/upload.ts
@@ -33,9 +33,10 @@ export async function uploadImageFromUrl(imageUrl: string, maxBytes?: number): P
     const contentType = fetched.contentType || "image/png";
     const blob = new Blob([bufferToBlobPart(fetched.buffer)], { type: contentType });
 
-    // Extract filename from URL or use a default
+    // Prefer the fetch helper's Content-Disposition name; URL path is fallback.
     const urlPath = new URL(imageUrl).pathname;
-    const fileName = urlPath.split("/").pop() || `upload-${Date.now()}.png`;
+    const fileName =
+      fetched.fileName?.trim() || urlPath.split("/").pop()?.trim() || `upload-${Date.now()}.png`;
 
     // Upload to Tlon storage
     const result = await uploadFile({


### PR DESCRIPTION
## What Problem This Solves

Tlon outbound image uploads named the stored file from the source URL path only. A CDN URL like `/download?id=123` with `Content-Disposition: attachment; filename="photo.png"` uploaded as `download` (or a generated default) instead of `photo.png`.

## Why This Change Was Made

`uploadImageFromUrl` already receives `fileName` from `readRemoteMediaBuffer`, which parses Content-Disposition. Use that fetched name first, then the URL basename, then a generated default. Byte caps, SSRF policy, and upload fallback are unchanged.

## User Impact

**Before:** Outbound images from extensionless download URLs lost the publisher filename in Tlon storage.

**After:** The Content-Disposition filename is the stored Tlon upload name when the downloader provides one.

## Evidence

- Changed: `extensions/tlon/src/urbit/upload.ts`
- Production path: live loopback HTTP → production `readRemoteMediaBuffer` → `uploadImageFromUrl` → captured `uploadFile({ fileName })`
- Tests: `extensions/tlon/src/urbit/upload.content-disposition.http.test.ts`, `extensions/tlon/src/urbit/upload.test.ts`

## Real behavior proof

- **Behavior or issue addressed:** Outbound Tlon uploads ignored Content-Disposition filenames from the shared media downloader.
- **Canonical reachability path:** Production `uploadImageFromUrl` against a real `node:http` server that sends `Content-Disposition: attachment; filename="photo.png"` on `/download?id=123`.
- **Boundary crossed:** Bytes on the wire through production `readRemoteMediaBuffer`. Tlon `uploadFile` is captured at the storage boundary (no live Tlon account). Loopback is allowlisted only so the local reflector is reachable; public CDN fetches use the same downloader.
- **Shared helper / provider constraint check:** Filename selection stays in the Tlon upload owner; media fetch parsing is unchanged.
- **Real environment tested:** Local Vitest extension-messaging lane with loopback HTTP and a 1×1 PNG body.
- **Exact steps or command run after this patch:**

```text
$ git diff --check
$ node scripts/run-vitest.mjs extensions/tlon/src/urbit/upload.content-disposition.http.test.ts --reporter=verbose
$ node scripts/run-vitest.mjs extensions/tlon/src/urbit/upload.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
stdout | extensions/tlon/src/urbit/upload.content-disposition.http.test.ts > uploadImageFromUrl Content-Disposition HTTP > stores the Content-Disposition filename from a real HTTP download
[tlon content-disposition proof] stored_filename=photo.png source=http://127.0.0.1:52996/download?id=123

 ✓ |extension-messaging| extensions/tlon/src/urbit/upload.content-disposition.http.test.ts > uploadImageFromUrl Content-Disposition HTTP > stores the Content-Disposition filename from a real HTTP download 91ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
[test] passed 1 Vitest shard in 7.56s
```

- **Observed result after fix:** `/download?id=123` with `filename="photo.png"` is stored as `photo.png`, not `download`.
- **What was not tested:** A live Tlon/Urbit ship upload session.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
