### PR TITLE
feat(team-reports): adopt Carapace visual contract and GitHub avatars

### DIFF
--- a/docs/plugins/team-reports.md
+++ b/docs/plugins/team-reports.md
@@ -120,9 +120,20 @@ page includes **Open in a new window** with that page's own URL. If the browser
 blocks that action too, copy the link into a new tab. Gateway authentication
 still applies there.
 
-Pages render on the server, work without JavaScript, and follow the browser's
-light or dark color preference. The index shows recent reports and a 28-day
-activity trend; people pages show each member's recent daily history.
+Pages render on the server and work without JavaScript. They use the Carapace
+visual contract, with a dark default and a light palette when your operating
+system prefers light mode. The embedded page follows that preference independently
+of the Control UI theme. The index shows recent reports and a 28-day activity
+trend; people pages show each member's recent daily history. Closed and partial
+periods have distinct status badges, and coverage and summary warnings remain
+visible alongside the report.
+
+Roster members and other GitHub actors show GitHub avatars from
+`avatars.githubusercontent.com`, using the primary GitHub login. Images load
+lazily without sending a referrer. Initials remain visible when an image cannot
+load; invalid logins use initials only. Display names and Discord IDs are never
+used to construct avatar URLs. The pages bundle their styles and use system
+fonts, so no external stylesheets, web fonts, or scripts are needed.
 
 ## Configuration
 

--- a/extensions/team-reports/src/http.test.ts
+++ b/extensions/team-reports/src/http.test.ts
@@ -9,7 +9,7 @@ import { describePeriod } from "./periods.js";
 import { renderMarkdown } from "./render/markdown.js";
 import { githubCounts } from "./reports.fixtures.js";
 import { createTeamReportsStore, type TeamReportsStore } from "./store.js";
-import type { Period, ReportDocument, SummaryDocument } from "./types.js";
+import type { Period, Person, ReportDocument, SummaryDocument } from "./types.js";
 
 const runtimeScopeMock = vi.hoisted(() => vi.fn());
 vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
@@ -17,7 +17,15 @@ vi.mock("openclaw/plugin-sdk/plugin-runtime", () => ({
 }));
 
 const maliciousTitle = '<script>alert("report")</script>';
+const hostileLogin = 'bad"><img src=x onerror=alert(1)>';
+const hostileDisplay = '"Quoted <Name>';
 const counts = githubCounts(1);
+const avatarPeople: Person[] = [
+  { github: ["invalid.login", "invalid-alias"], display: "Fallback Name" },
+  { github: [hostileLogin, "hostile-alias"], display: hostileDisplay },
+  { github: ["safe-login"], display: hostileDisplay },
+  { github: ["a".repeat(40), "long-login-alias"], display: "Long Login" },
+];
 
 function report(period: Period, key: string, partial = false): ReportDocument {
   const descriptor = describePeriod(period, key);
@@ -53,7 +61,7 @@ function report(period: Period, key: string, partial = false): ReportDocument {
         discord: { total: 0, channels: {}, excerpts: [] },
       },
     ],
-    otherActors: [],
+    otherActors: [{ login: "bob", github: counts }],
     unmatchedDiscord: [],
     sources: { github: { ok: true, warnings: ["Fixture coverage warning"], stats: {} } },
   };
@@ -107,7 +115,22 @@ function fetchPath(
 beforeAll(async () => {
   directory = fs.mkdtempSync(path.join(os.tmpdir(), "team-reports-http-"));
   store = createTeamReportsStore({ stateDir: directory });
+  const avatarReport = report("day", "2026-08-19");
+  avatarReport.members = avatarPeople.map((person) => ({
+    login: person.github[0] ?? "",
+    display: person.display ?? "",
+    aliases: person.github.slice(1),
+    access: [],
+    areas: [],
+    github: { ...counts, items: [] },
+    discord: { total: 0, channels: {}, excerpts: [] },
+  }));
+  avatarReport.memberCount = avatarPeople.length;
+  avatarReport.activeMembers = avatarPeople.length;
+  avatarReport.totals.github = githubCounts(avatarPeople.length);
+  avatarReport.otherActors.push({ login: hostileLogin, github: counts });
   for (const document of [
+    avatarReport,
     report("day", "2026-08-20"),
     report("day", "2026-08-21", true),
     report("week", "2026-W34"),
@@ -126,7 +149,9 @@ beforeAll(async () => {
         display: "Alice",
         status: "archived",
         archivedAt: "2026-08-22",
+        discordUserId: "1234567890",
       },
+      ...avatarPeople,
     ],
   });
   server = createServer(handler);
@@ -216,9 +241,11 @@ describe("Team Reports HTTP responses", () => {
     expect(response.headers["referrer-policy"]).toBe("no-referrer");
     expect(response.headers["x-frame-options"]).toBeUndefined();
     const csp = response.headers["content-security-policy"];
-    expect(csp).toContain("default-src 'none'");
     const nonce = typeof csp === "string" ? /style-src 'nonce-([^']+)'/.exec(csp)?.[1] : undefined;
     expect(nonce).toBeTruthy();
+    expect(csp).toBe(
+      `default-src 'none'; style-src 'nonce-${nonce}'; img-src https://avatars.githubusercontent.com data:; base-uri 'none'; form-action 'none'`,
+    );
     expect(response.body).toContain(`<style nonce="${nonce}">`);
     expect(response.body).toContain("&lt;script&gt;alert(&quot;report&quot;)&lt;/script&gt;");
     expect(response.body).not.toContain("<script>");
@@ -229,9 +256,117 @@ describe("Team Reports HTTP responses", () => {
     expect(response.body).toContain('href="/reports/people/alice/"');
     expect(response.body).toContain("Deterministic summary");
     expect(response.body).toContain("Fixture coverage warning");
-    expect(response.body).toContain(
-      '<p class="notice">Model summary unavailable: completion failed</p>',
+    expect(response.body).toContain("Model summary unavailable: completion failed");
+    expect(response.body).toMatch(
+      /class="[^"]*oc-banner-warning[^"]*"[^>]*>[\s\S]*?Coverage notes/,
     );
+    expect(response.body).toMatch(
+      /class="[^"]*oc-banner-info[^"]*"[^>]*>[\s\S]*?<p>Deterministic summary/,
+    );
+  });
+
+  it.each([
+    { url: "/reports/day/2026-08-20/", login: "alice", size: 40, variant: "md" },
+    { url: "/reports/day/2026-08-20/", login: "bob", size: 20, variant: "xs" },
+    { url: "/reports/people/", login: "alice", size: 40, variant: "md" },
+    { url: "/reports/people/alice-alias/", login: "alice", size: 72, variant: "xl" },
+  ])(
+    "renders a $size px GitHub avatar for $login on $url",
+    async ({ url, login, size, variant }) => {
+      const response = await fetchPath(url);
+      expect(response.status).toBe(200);
+      const avatars = response.body.match(/<span class="oc-avatar\b[^>]*>[\s\S]*?<\/span>/g) ?? [];
+      const avatar = avatars.find((markup) =>
+        markup.includes(`src="https://avatars.githubusercontent.com/${login}?s=${size}"`),
+      );
+      expect(avatar).toContain(`class="oc-avatar oc-avatar-${variant}"`);
+      expect(avatar).toMatch(/data-initials="[^"]+"/);
+      for (const attribute of [
+        `width="${size}"`,
+        `height="${size}"`,
+        'alt=""',
+        'loading="lazy"',
+        'decoding="async"',
+        'referrerpolicy="no-referrer"',
+      ]) {
+        expect(avatar).toContain(attribute);
+      }
+      expect(response.body).not.toContain("avatars.githubusercontent.com/alice-alias");
+      expect(response.body).not.toContain("avatars.githubusercontent.com/Alice");
+      expect(response.body).not.toContain("avatars.githubusercontent.com/1234567890");
+    },
+  );
+
+  it.each([
+    { url: "/reports/day/2026-08-19/", initials: ["FN", "LL", "&quot;&lt;"] },
+    { url: "/reports/people/", initials: ["FN", "LL", "&quot;&lt;"] },
+    { url: "/reports/people/invalid-alias/", initials: ["FN"] },
+    { url: "/reports/people/long-login-alias/", initials: ["LL"] },
+    { url: "/reports/people/hostile-alias/", initials: ["&quot;&lt;"] },
+  ])(
+    "keeps unsafe avatar identities escaped and falls back to initials on $url",
+    async ({ url, initials }) => {
+      const response = await fetchPath(url);
+      expect(response.status).toBe(200);
+      const avatars = response.body.match(/<span class="oc-avatar\b[^>]*>[\s\S]*?<\/span>/g) ?? [];
+      for (const value of initials) {
+        const fallback = avatars.find(
+          (avatar) => avatar.includes(`data-initials="${value}"`) && !avatar.includes("<img"),
+        );
+        expect(fallback).toBeDefined();
+      }
+      expect(response.body).not.toContain("avatars.githubusercontent.com/invalid.login");
+      expect(response.body).not.toContain(`avatars.githubusercontent.com/${"a".repeat(40)}`);
+      expect(response.body).not.toContain("avatars.githubusercontent.com/bad");
+      expect(response.body).not.toContain(hostileLogin);
+      expect(response.body).not.toContain(hostileDisplay);
+      expect(response.body).not.toContain("<img src=x");
+      if (!url.includes("invalid-alias") && !url.includes("long-login-alias")) {
+        expect(response.body).toContain("bad&quot;&gt;&lt;img src=x onerror=alert(1)&gt;");
+        expect(response.body).toContain("&quot;Quoted &lt;Name&gt;");
+        expect(response.body).toContain('data-initials="&quot;&lt;"');
+      }
+    },
+  );
+
+  it("uses the GitHub login for an avatar even when the display name is hostile", async () => {
+    const response = await fetchPath("/reports/people/safe-login/");
+    expect(response.status).toBe(200);
+    expect(response.body).toContain('src="https://avatars.githubusercontent.com/safe-login?s=72"');
+    expect(response.body).toContain('data-initials="&quot;&lt;"');
+    expect(response.body).toContain("&quot;Quoted &lt;Name&gt;");
+    expect(response.body).not.toContain(hostileDisplay);
+  });
+
+  it.each([
+    { key: "2026-08-20", status: "closed", variant: "success" },
+    { key: "2026-08-21", status: "partial", variant: "warning" },
+  ])("renders the $status report status as a $variant badge", async ({ key, status, variant }) => {
+    const response = await fetchPath(`/reports/day/${key}/`);
+    expect(response.body).toMatch(
+      new RegExp(`class="oc-badge oc-badge-${variant}">${status}</span>`, "i"),
+    );
+  });
+
+  it("serves dark and light semantic tokens with CSS-only avatar initials", async () => {
+    const response = await fetchPath("/reports/");
+    const styles = /<style nonce="[^"]+">([\s\S]*?)<\/style>/.exec(response.body)?.[1];
+    expect(styles).toMatch(/color-scheme:\s*dark/);
+    expect(styles).toMatch(/html\[data-theme="light"\]\s*\{[^}]*color-scheme:\s*light/);
+    expect(styles).toMatch(
+      /@media\s*\(prefers-color-scheme:\s*light\)\s*\{[^}]*color-scheme:\s*light/,
+    );
+    for (const token of [
+      "bg-page",
+      "text-primary",
+      "accent-primary",
+      "accent-secondary",
+      "status-warning-fg",
+    ]) {
+      expect(styles?.match(new RegExp(`--oc-${token}:`, "g"))?.length).toBeGreaterThanOrEqual(3);
+    }
+    expect(styles).toMatch(/\.oc-avatar::before\s*\{[^}]*content:\s*attr\(data-initials\)/);
+    expect(styles).not.toMatch(/@import|@font-face/);
   });
 
   it("supports HEAD without a body and rejects writes", async () => {
@@ -288,10 +423,11 @@ describe("Team Reports HTTP responses", () => {
   it("renders stored trends, history, archived people, index, and status", async () => {
     const index = await fetchPath("/reports/");
     expect(index.status).toBe(200);
-    expect(index.body).toContain('<svg viewBox="0 0 780 185"');
+    expect(index.body).toMatch(/<svg\b[^>]*viewBox="0 0 780 185"/);
     expect(index.body).toContain('href="/reports/week/2026-W34/"');
     const people = await fetchPath("/reports/people/");
-    expect(people.body).toContain("Archived");
+    expect(people.body).toContain('class="oc-table"');
+    expect(people.body).toMatch(/class="oc-badge oc-badge-neutral">Archived<\/span>/);
     const person = await fetchPath("/reports/people/alice-alias/");
     expect(person.status).toBe(200);
     expect(person.body).toContain("Archived on 2026-08-22");

--- a/extensions/team-reports/src/render/html.ts
+++ b/extensions/team-reports/src/render/html.ts
@@ -6,6 +6,7 @@ import {
   escapeHtml,
   ITEM_LABELS,
   memberSummary,
+  renderAvatar,
   safeExternalUrl,
 } from "./shared.js";
 import { REPORT_STYLES } from "./styles.js";
@@ -54,7 +55,7 @@ function markdownBlocks(value: string): string {
 }
 
 function shell(ctx: PageContext, title: string, body: string): string {
-  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>${escapeHtml(title)} · Team Reports</title><style nonce="${escapeHtml(ctx.nonce)}">${REPORT_STYLES}</style></head><body><header><nav aria-label="Main"><a class="brand" href="${escapeHtml(ctx.basePath)}/">Team Reports</a><a href="${escapeHtml(ctx.basePath)}/people/">People</a><a href="${escapeHtml(ctx.basePath)}/latest/">Latest closed day</a></nav><a href="${escapeHtml(ctx.absoluteUrl)}" target="_blank" rel="noopener">Open in a new window</a></header><main>${body}</main><footer>Report windows use UTC. Generation times are shown in ${escapeHtml(ctx.displayTimezone)}. Links may not open inside the Control UI frame.</footer></body></html>`;
+  return `<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1"><title>${escapeHtml(title)} · Team Reports</title><style nonce="${escapeHtml(ctx.nonce)}">${REPORT_STYLES}</style></head><body class="oc-app-surface"><header class="oc-app-surface report-toolbar"><div class="report-toolbar-inner"><nav aria-label="Main"><a class="brand" href="${escapeHtml(ctx.basePath)}/">Team Reports</a><a class="oc-action oc-action-ghost" href="${escapeHtml(ctx.basePath)}/people/">People</a><a class="oc-action oc-action-ghost" href="${escapeHtml(ctx.basePath)}/latest/">Latest closed day</a></nav><a class="oc-action oc-action-ghost" href="${escapeHtml(ctx.absoluteUrl)}" target="_blank" rel="noopener">Open in a new window</a></div></header><main>${body}</main><footer>Report windows use UTC. Generation times are shown in ${escapeHtml(ctx.displayTimezone)}. Links may not open inside the Control UI frame.</footer></body></html>`;
 }
 
 function renderTrend(days: TrendDay[]): string {
@@ -75,16 +76,35 @@ function renderTrend(days: TrendDay[]): string {
         return `${connected ? "L" : "M"}${x(index).toFixed(1)},${y(day[kind]).toFixed(1)}`;
       })
       .join(" ");
-    return `<path class="${kind}-line" d="${path}"/>${days.map((day, index) => `<circle class="${kind}-line" cx="${x(index).toFixed(1)}" cy="${y(day[kind]).toFixed(1)}" r="2"/>`).join("")}`;
+    return `<path class="oc-sparkline-line ${kind}-line" d="${path}"/>${days.map((day, index) => `<circle class="oc-sparkline-line ${kind}-line" cx="${x(index).toFixed(1)}" cy="${y(day[kind]).toFixed(1)}" r="2"/>`).join("")}`;
   };
-  return `<div class="chart"><svg viewBox="0 0 780 185" role="img" aria-label="Daily GitHub events and Discord messages; shared scale zero to ${maximum}"><title>GitHub events and Discord messages per stored day</title><line class="chart-axis" x1="42" y1="152" x2="738" y2="152"/><text class="chart-label" x="4" y="28">${maximum}</text><text class="chart-label" x="20" y="156">0</text>${line("github")}${line("discord")}<text class="chart-label" x="42" y="178">${escapeHtml(days[0]?.key ?? "")}</text><text class="chart-label" x="738" y="178" text-anchor="end">${escapeHtml(days.at(-1)?.key ?? "")}</text></svg><div class="legend"><span class="github-key">GitHub events</span><span class="discord-key">Discord messages</span></div></div>`;
+  return `<div class="chart"><svg class="oc-sparkline" viewBox="0 0 780 185" role="img" aria-label="Daily GitHub events and Discord messages; shared scale zero to ${maximum}"><title>GitHub events and Discord messages per stored day</title><line class="chart-axis" x1="42" y1="152" x2="738" y2="152"/><text class="chart-label" x="4" y="28">${maximum}</text><text class="chart-label" x="20" y="156">0</text>${line("github")}${line("discord")}<text class="chart-label" x="42" y="178">${escapeHtml(days[0]?.key ?? "")}</text><text class="chart-label" x="738" y="178" text-anchor="end">${escapeHtml(days.at(-1)?.key ?? "")}</text></svg><div class="legend"><span class="github-key">GitHub events</span><span class="discord-key">Discord messages</span></div></div>`;
+}
+
+function statusBadge(status: ReportDocument["status"]): string {
+  return `<span class="oc-badge oc-badge-${status === "closed" ? "success" : "warning"}">${escapeHtml(status)}</span>`;
+}
+
+function pills(person: Pick<Person, "affiliation" | "roleLabel" | "roleGroup">): string {
+  return [person.affiliation, person.roleLabel ?? person.roleGroup]
+    .filter((value): value is string => Boolean(value))
+    .map((value) => `<span class="oc-pill">${escapeHtml(value)}</span>`)
+    .join("");
+}
+
+function banner(tone: "warning" | "info" | "neutral", content: string): string {
+  return `<div class="oc-banner oc-banner-${tone}"><span class="oc-banner-indicator" aria-hidden="true"></span><div class="oc-banner-content">${content}</div></div>`;
+}
+
+function sectionHeading(title: string): string {
+  return `<div class="oc-section-header"><h2 class="oc-section-title">${escapeHtml(title)}</h2></div>`;
 }
 
 function history(ctx: PageContext, entries: PeriodListEntry[]): string {
   if (entries.length === 0) {
     return '<p class="muted">No reports generated yet.</p>';
   }
-  return `<ul>${entries.map((entry) => `<li><a href="${escapeHtml(href(ctx.basePath, entry.period, entry.key))}">${escapeHtml(entry.key)}</a> <span class="badge">${entry.status}</span></li>`).join("")}</ul>`;
+  return `<ul class="oc-resource-list">${entries.map((entry) => `<li class="oc-resource-list-item"><a class="oc-resource-list-link" href="${escapeHtml(href(ctx.basePath, entry.period, entry.key))}"><span class="oc-resource-list-title">${escapeHtml(entry.key)}</span>${statusBadge(entry.status)}</a></li>`).join("")}</ul>`;
 }
 
 export function renderIndexPage(
@@ -96,13 +116,13 @@ export function renderIndexPage(
   const cards = periods
     .map((period) => {
       const entry = index[period][0];
-      return `<section class="card"><h3>Latest ${period}</h3>${entry ? `<a href="${escapeHtml(href(ctx.basePath, period, entry.key))}">${escapeHtml(entry.key)}</a> <span class="badge">${entry.status}</span><p class="muted">Generated ${escapeHtml(date(entry.generatedAtMs, ctx.displayTimezone))}</p>` : "<p>No reports yet.</p>"}</section>`;
+      return `<div class="oc-card"><div class="stat-heading"><h3>Latest ${period}</h3>${entry ? statusBadge(entry.status) : ""}</div>${entry ? `<a class="stat-date" href="${escapeHtml(href(ctx.basePath, period, entry.key))}">${escapeHtml(entry.key)}</a><p class="details">Generated ${escapeHtml(date(entry.generatedAtMs, ctx.displayTimezone))}</p>` : '<p class="muted">No reports yet.</p>'}</div>`;
     })
     .join("");
   return shell(
     ctx,
     "Overview",
-    `<h1>Team activity</h1><p class="muted">GitHub contributions and Discord discussion, by day, week, and month.</p><div class="cards">${cards}</div><h2>Daily activity · last 28 days</h2>${renderTrend(days.map((day) => ({ key: day.period.key, github: day.totals.github.total, discord: day.totals.discord.messages })))}<p class="muted">Only stored days are shown. Missing days are not counted as zero activity.</p><h2>Report history</h2><div class="cards">${periods.map((period) => `<section class="card"><h3>${period === "day" ? "Days" : period === "week" ? "Weeks" : "Months"}</h3>${history(ctx, index[period])}</section>`).join("")}</div><p><a href="${escapeHtml(ctx.basePath)}/index.json">Machine-readable index</a> · <a href="${escapeHtml(ctx.basePath)}/status">Generation status</a></p>`,
+    `<section class="oc-section"><div class="oc-section-header"><div class="oc-section-heading"><p class="oc-eyebrow">Team activity</p><h1 class="oc-section-title">Overview</h1><p class="oc-section-copy">GitHub contributions and Discord discussion, by day, week, and month.</p></div></div><div class="stats">${cards}</div></section><section class="oc-section">${sectionHeading("Daily activity · last 28 days")}${renderTrend(days.map((day) => ({ key: day.period.key, github: day.totals.github.total, discord: day.totals.discord.messages })))}<p class="details">Only stored days are shown. Missing days are not counted as zero activity.</p></section><section class="oc-section">${sectionHeading("Report history")}<div class="history-columns">${periods.map((period) => `<div><h3>${period === "day" ? "Days" : period === "week" ? "Weeks" : "Months"}</h3>${history(ctx, index[period])}</div>`).join("")}</div></section><div class="actions"><a class="oc-action oc-action-ghost" href="${escapeHtml(ctx.basePath)}/index.json">Machine-readable index</a><a class="oc-action oc-action-ghost" href="${escapeHtml(ctx.basePath)}/status">Generation status</a></div>`,
   );
 }
 
@@ -123,40 +143,61 @@ export function renderReportPage(
     warnings.push("Item lists were truncated; aggregate counts are preserved.");
   }
   const summaryNotices = (summary?.warnings ?? [])
-    .map((warning) => `<p class="notice">${escapeHtml(warning)}</p>`)
+    .map((warning) => banner("warning", `<p>${escapeHtml(warning)}</p>`))
     .join("");
-  const notices = `${report.status === "partial" ? '<p class="notice">This period is still open. Activity and summaries may change as new reports are generated.</p>' : ""}${!summary || summary.source === "fallback" ? '<p class="notice">Deterministic summary: model summaries are disabled, pending, or unavailable.</p>' : ""}${warnings.length ? `<section class="notice"><h2>Coverage notes</h2><ul>${warnings.map((warning) => `<li>${escapeHtml(warning)}</li>`).join("")}</ul></section>` : ""}`;
+  const notices = [
+    report.status === "partial"
+      ? banner(
+          "warning",
+          "<p>This period is still open. Activity and summaries may change as new reports are generated.</p>",
+        )
+      : "",
+    !summary || summary.source === "fallback"
+      ? banner(
+          "info",
+          "<p>Deterministic summary: model summaries are disabled, pending, or unavailable.</p>",
+        )
+      : "",
+    warnings.length
+      ? banner(
+          "warning",
+          `<h2 class="oc-banner-title">Coverage notes</h2><ul>${warnings.map((warning) => `<li>${escapeHtml(warning)}</li>`).join("")}</ul>`,
+        )
+      : "",
+  ].join("");
   const members = report.members
     .map(
       (member) =>
-        `<article><h3><a href="${escapeHtml(href(ctx.basePath, "people", member.login))}">${escapeHtml(member.display)}</a> <small>@${escapeHtml(member.login)}</small></h3>${
-          [member.affiliation, member.roleLabel ?? member.roleGroup].filter(Boolean).length
-            ? `<p class="muted">${[member.affiliation, member.roleLabel ?? member.roleGroup]
-                .filter((value): value is string => Boolean(value))
-                .map(escapeHtml)
-                .join(" · ")}</p>`
-            : ""
-        }<p>${escapeHtml(memberSummary(member))}</p><p class="details">${escapeHtml(countDescription(member.github))} · ${member.discord.total} Discord messages</p>${member.areas.length ? `<p class="details">Areas: ${member.areas.map(escapeHtml).join(", ")}</p>` : ""}${member.access.length ? `<p class="details">Access: ${member.access.map(escapeHtml).join(", ")}</p>` : ""}${member.github.items.length ? `<details><summary>${member.github.items.length} GitHub items</summary><ul>${member.github.items.map((item) => `<li><span class="muted">${ITEM_LABELS[item.kind]} · ${escapeHtml(item.repo)}</span> — ${externalLink(item.url, item.title)}</li>`).join("")}</ul></details>` : ""}${member.discord.excerpts.length ? `<details><summary>Discord excerpts</summary>${member.discord.excerpts.map((excerpt) => `<blockquote><small>#${escapeHtml(excerpt.channel)} · ${escapeHtml(date(excerpt.atMs, ctx.displayTimezone))}</small><br>${escapeHtml(excerpt.excerpt)}</blockquote>`).join("")}</details>` : ""}</article>`,
+        `<li class="member">${renderAvatar(member.login, member.display, "md")}<article class="member-content"><div class="identity-line"><h3><a href="${escapeHtml(href(ctx.basePath, "people", member.login))}">${escapeHtml(member.display)}</a></h3><span class="muted">@${escapeHtml(member.login)}</span>${pills(member)}</div><p class="details">${escapeHtml(countDescription(member.github))} · ${member.discord.total} Discord messages</p><p>${escapeHtml(memberSummary(member))}</p>${member.areas.length ? `<p class="details">Areas: ${member.areas.map(escapeHtml).join(", ")}</p>` : ""}${member.access.length ? `<p class="details">Access: ${member.access.map(escapeHtml).join(", ")}</p>` : ""}${member.github.items.length ? `<details><summary>${member.github.items.length} GitHub items</summary><ul class="oc-resource-list member-items">${member.github.items.map((item) => `<li class="oc-resource-list-item resource-row"><span class="oc-resource-list-meta">${ITEM_LABELS[item.kind]} · ${escapeHtml(item.repo)}</span> — ${externalLink(item.url, item.title)}</li>`).join("")}</ul></details>` : ""}${member.discord.excerpts.length ? `<details><summary>Discord excerpts</summary>${member.discord.excerpts.map((excerpt) => `<blockquote><small>#${escapeHtml(excerpt.channel)} · ${escapeHtml(date(excerpt.atMs, ctx.displayTimezone))}</small><br>${escapeHtml(excerpt.excerpt)}</blockquote>`).join("")}</details>` : ""}</article></li>`,
     )
     .join("");
   const other = report.otherActors.length
-    ? `<h2>Other GitHub actors</h2><p class="muted">Activity by accounts outside the current roster.</p><ul>${report.otherActors.map((actor) => `<li>${escapeHtml(actor.login)}: ${actor.github.total} GitHub events</li>`).join("")}</ul>`
+    ? `<section class="oc-section">${sectionHeading("Other GitHub actors")}<p class="details">Activity by accounts outside the current roster.</p><ul class="oc-resource-list">${report.otherActors.map((actor) => `<li class="oc-resource-list-item resource-row"><span class="person-identity">${renderAvatar(actor.login, actor.login, "xs")}<span class="oc-resource-list-title">@${escapeHtml(actor.login)}</span></span><span class="oc-resource-list-meta">${actor.github.total} GitHub events</span></li>`).join("")}</ul></section>`
     : "";
   const unmatched = report.unmatchedDiscord.length
-    ? `<h2>Unmatched Discord authors</h2><p class="muted">These messages count toward Discord totals. No message content is included.</p><ul>${report.unmatchedDiscord.map((actor) => `<li>${escapeHtml(actor.authorId)}: ${actor.messages} messages</li>`).join("")}</ul>`
+    ? `<section class="oc-section">${sectionHeading("Unmatched Discord authors")}<p class="muted">These messages count toward Discord totals. No message content is included.</p><ul class="muted">${report.unmatchedDiscord.map((actor) => `<li>${escapeHtml(actor.authorId)}: ${actor.messages} messages</li>`).join("")}</ul></section>`
     : "";
+  const periodLabel = { day: "Day", week: "Week", month: "Month" }[report.period.period];
   return shell(
     ctx,
     report.period.title,
-    `<h1>${escapeHtml(report.period.title)} <span class="badge">${report.status}</span></h1><p class="muted">${escapeHtml(report.orgs.join(", "))} · Generated ${escapeHtml(date(report.generatedAtMs, ctx.displayTimezone))}</p><p class="details">UTC window: ${escapeHtml(new Date(report.period.sinceMs).toISOString())} – ${escapeHtml(new Date(report.period.untilMs).toISOString())} (exclusive)</p><p><a href="${escapeHtml(path)}report.md">Markdown</a> · <a href="${escapeHtml(path)}data.json">JSON</a></p>${notices}<div class="cards"><div class="card"><strong>${report.totals.github.total}</strong>GitHub events</div><div class="card"><strong>${report.totals.discord.messages}</strong>Discord messages</div><div class="card"><strong>${report.activeMembers} / ${report.memberCount}</strong>Active members</div></div>${summary ? `<section><h2>Summary</h2>${summaryNotices}${markdownBlocks(summary.globalSummary)}<h2>Highlights</h2><ul>${summary.highlights.map((highlight) => `<li>${escapeHtml(highlight)}</li>`).join("")}</ul></section>` : ""}<h2>Members</h2>${members || "<p>No members are configured for this period.</p>"}${other}${unmatched}`,
+    `<section class="oc-section"><div class="oc-section-header"><div class="oc-section-heading"><p class="oc-eyebrow">${periodLabel} · ${escapeHtml(report.orgs.join(", "))}</p><div class="identity-line"><h1 class="oc-section-title">${escapeHtml(report.period.title)}</h1>${statusBadge(report.status)}</div><p class="details">Generated ${escapeHtml(date(report.generatedAtMs, ctx.displayTimezone))}</p><p class="details">UTC window: ${escapeHtml(new Date(report.period.sinceMs).toISOString())} – ${escapeHtml(new Date(report.period.untilMs).toISOString())} (exclusive)</p></div><div class="actions"><a class="oc-action oc-action-ghost" href="${escapeHtml(path)}report.md">Markdown</a><a class="oc-action oc-action-ghost" href="${escapeHtml(path)}data.json">JSON</a></div></div><div class="stats"><div class="oc-card"><strong class="stat-value">${report.totals.github.total}</strong><span class="details">GitHub events</span></div><div class="oc-card"><strong class="stat-value">${report.totals.discord.messages}</strong><span class="details">Discord messages</span></div><div class="oc-card"><strong class="stat-value">${report.activeMembers} / ${report.memberCount}</strong><span class="details">Active members</span></div></div></section>${notices ? `<div class="notices">${notices}</div>` : ""}${summary ? `<section class="oc-section prose">${sectionHeading("Summary")}${summaryNotices ? `<div class="notices">${summaryNotices}</div>` : ""}${markdownBlocks(summary.globalSummary)}<h3>Highlights</h3><ul>${summary.highlights.map((highlight) => `<li>${escapeHtml(highlight)}</li>`).join("")}</ul></section>` : ""}<section class="oc-section">${sectionHeading("Members")}${members ? `<ul class="member-list">${members}</ul>` : "<p>No members are configured for this period.</p>"}</section>${other}${unmatched}`,
   );
 }
 
 export function renderPeoplePage(ctx: PageContext, people: Person[]): string {
+  const rows = people
+    .map((person) => {
+      const login = person.github[0] ?? "";
+      const display = person.display ?? login;
+      const path = escapeHtml(href(ctx.basePath, "people", login));
+      return `<tr><td><a class="person-identity" href="${path}">${renderAvatar(login, display, "md")}<span>${escapeHtml(display)}</span></a></td><td>@${escapeHtml(login)}</td><td>${escapeHtml(person.affiliation ?? "—")}</td><td>${escapeHtml(person.roleLabel ?? person.roleGroup ?? "—")}</td><td><span class="oc-badge oc-badge-${person.status === "archived" ? "neutral" : "success"}">${person.status === "archived" ? "Archived" : "Active"}</span></td><td><a href="${path}" aria-label="History for ${escapeHtml(display)}">History</a></td></tr>`;
+    })
+    .join("");
   return shell(
     ctx,
     "People",
-    `<h1>People</h1><p class="muted">Current roster and archived members with retained history.</p><div class="table-wrap"><table><thead><tr><th>Person</th><th>Role</th><th>Status</th></tr></thead><tbody>${people.map((person) => `<tr><td><a href="${escapeHtml(href(ctx.basePath, "people", person.github[0] ?? ""))}">${escapeHtml(person.display ?? person.github[0] ?? "")}</a>${person.affiliation ? `<br><small>${escapeHtml(person.affiliation)}</small>` : ""}</td><td>${escapeHtml(person.roleLabel ?? person.roleGroup ?? "—")}</td><td>${person.status === "archived" ? "Archived" : "Active"}</td></tr>`).join("")}</tbody></table></div>`,
+    `<section class="oc-section"><div class="oc-section-header"><div class="oc-section-heading"><p class="oc-eyebrow">Team activity</p><h1 class="oc-section-title">People</h1><p class="oc-section-copy">Current roster and archived members with retained history.</p></div></div><div class="oc-table-wrap" tabindex="0" role="region" aria-label="People"><table class="oc-table"><thead><tr><th scope="col">Person</th><th scope="col">Login</th><th scope="col">Affiliation</th><th scope="col">Role</th><th scope="col">Status</th><th scope="col">History</th></tr></thead><tbody>${rows}</tbody></table></div></section>`,
   );
 }
 
@@ -168,6 +209,6 @@ export function renderPersonPage(ctx: PageContext, person: Person, days: PersonD
   return shell(
     ctx,
     person.display ?? login,
-    `<h1>${escapeHtml(person.display ?? login)} <small>@${escapeHtml(login)}</small></h1>${person.status === "archived" ? `<p class="notice">Archived${person.archivedAt ? ` on ${escapeHtml(person.archivedAt)}` : ""}. Historical reports remain available.</p>` : ""}${person.affiliation ? `<p>${escapeHtml(person.affiliation)}</p>` : ""}${person.github.length > 1 ? `<p class="muted">Aliases: ${person.github.slice(1).map(escapeHtml).join(", ")}</p>` : ""}<h2>Daily activity</h2>${renderTrend(trend)}<h2>Last 28 days with retained history</h2>${days.length ? `<div class="table-wrap"><table><thead><tr><th>UTC day</th><th class="number">GitHub events</th><th class="number">Commits</th><th class="number">PRs merged</th><th class="number">Discord messages</th></tr></thead><tbody>${days.map((day) => `<tr><td><a href="${escapeHtml(href(ctx.basePath, "day", day.dayKey))}">${escapeHtml(day.dayKey)}</a></td><td class="number">${day.githubTotal}</td><td class="number">${day.commits}</td><td class="number">${day.prsMerged}</td><td class="number">${day.discordMessages}</td></tr>`).join("")}</tbody></table></div>` : "<p>No stored daily reports for this person yet.</p>"}`,
+    `<section class="oc-section"><div class="oc-section-header"><div class="person-identity">${renderAvatar(login, person.display ?? login, "xl")}<div class="person-heading"><h1 class="oc-section-title">${escapeHtml(person.display ?? login)}</h1><span class="muted">@${escapeHtml(login)}</span><div class="pills">${pills(person)}</div></div></div></div>${person.github.length > 1 ? `<p class="details">Aliases: ${person.github.slice(1).map(escapeHtml).join(", ")}</p>` : ""}</section>${person.status === "archived" ? banner("neutral", `<p>Archived${person.archivedAt ? ` on ${escapeHtml(person.archivedAt)}` : ""}. Historical reports remain available.</p>`) : ""}<section class="oc-section">${sectionHeading("Daily activity")}${renderTrend(trend)}</section><section class="oc-section">${sectionHeading("Last 28 days with retained history")}${days.length ? `<div class="oc-table-wrap" tabindex="0" role="region" aria-label="Daily activity history"><table class="oc-table"><thead><tr><th scope="col">UTC day</th><th scope="col" class="number">GitHub events</th><th scope="col" class="number">Commits</th><th scope="col" class="number">PRs merged</th><th scope="col" class="number">Discord messages</th></tr></thead><tbody>${days.map((day) => `<tr><td><a href="${escapeHtml(href(ctx.basePath, "day", day.dayKey))}">${escapeHtml(day.dayKey)}</a></td><td class="number">${day.githubTotal}</td><td class="number">${day.commits}</td><td class="number">${day.prsMerged}</td><td class="number">${day.discordMessages}</td></tr>`).join("")}</tbody></table></div>` : "<p>No stored daily reports for this person yet.</p>"}</section>`,
   );
 }

--- a/extensions/team-reports/src/render/shared.ts
+++ b/extensions/team-reports/src/render/shared.ts
@@ -17,6 +17,22 @@ export function escapeHtml(value: string): string {
   });
 }
 
+export function renderAvatar(login: string, display: string, size: "xs" | "md" | "xl"): string {
+  const words = (display.trim() || login).split(/\s+/);
+  const initials = (
+    words.length > 1
+      ? `${Array.from(words[0] ?? "")[0] ?? ""}${Array.from(words.at(-1) ?? "")[0] ?? ""}`
+      : Array.from(words[0] ?? "")
+          .slice(0, 2)
+          .join("")
+  ).toUpperCase();
+  const pixels = { xs: 20, md: 40, xl: 72 }[size];
+  const image = /^[A-Za-z0-9-]{1,39}$/.test(login)
+    ? `<img src="https://avatars.githubusercontent.com/${escapeHtml(login)}?s=${pixels}" width="${pixels}" height="${pixels}" alt="" loading="lazy" decoding="async" referrerpolicy="no-referrer">`
+    : "";
+  return `<span class="oc-avatar oc-avatar-${size}" data-initials="${escapeHtml(initials)}">${image}</span>`;
+}
+
 export function safeExternalUrl(value: string): string | undefined {
   try {
     const url = new URL(value);

--- a/extensions/team-reports/src/render/styles.ts
+++ b/extensions/team-reports/src/render/styles.ts
@@ -1,5 +1,209 @@
+/*
+ * Vendored Carapace v0.6.2 subset: styles/tokens.css, styles/themes.css,
+ * styles/themes/product.css, styles/typography.css, styles/components.css,
+ * and styles/candidate/{data,feedback,embed}.css. Theme values include the
+ * neutral application overrides. Use embed font stacks and the skill's square
+ * surface/control/inset geometry; no external CSS or fonts under the nonce CSP.
+ */
+const LIGHT_THEME = `
+  color-scheme: light;
+  --oc-bg-page: oklch(0.985 0 0);
+  --oc-bg-surface: oklch(0.97 0 0);
+  --oc-bg-elevated: oklch(1 0 0);
+  --oc-text-primary: oklch(0.205 0 0);
+  --oc-text-secondary: oklch(0.269 0 0);
+  --oc-text-muted: oklch(0.555 0 0);
+  --oc-text-link: var(--oc-accent-primary);
+  --oc-accent-primary: color-mix(in srgb, #c24028 60%, #9c3222 40%);
+  --oc-accent-primary-hover: color-mix(in srgb, #c24028 30%, #9c3222 70%);
+  --oc-accent-secondary: #14806e;
+  --oc-border-subtle: oklch(0.922 0 0);
+  --oc-border-strong: color-mix(in oklch, var(--oc-text-primary) 28%, transparent);
+  --oc-surface-card: oklch(1 0 0);
+  --oc-surface-card-strong: oklch(1 0 0);
+  --oc-surface-interactive: oklch(0.97 0 0);
+  --oc-surface-interactive-hover: oklch(0.922 0 0);
+  --oc-surface-accent-soft: rgb(216 74 49 / 0.12);
+  --oc-surface-secondary-soft: rgb(20 128 110 / 0.13);
+  --oc-chart-line: oklch(0.205 0 0 / 0.12);
+  --oc-focus-ring: oklch(0.15 0 0 / 0.7);
+  --oc-selection-bg: rgb(216 74 49 / 0.2);
+  --oc-status-success-bg: rgb(34 197 94 / 0.1);
+  --oc-status-success-fg: #146c37;
+  --oc-status-warning-bg: rgb(245 158 11 / 0.1);
+  --oc-status-warning-fg: #8f5100;
+  --oc-status-info-bg: rgb(37 99 235 / 0.1);
+  --oc-status-info-fg: #1d4ed8;
+`;
+
 export const REPORT_STYLES = `
-:root{color-scheme:light dark;--bg:#f6f8fb;--panel:#fff;--text:#172033;--muted:#56627a;--line:#dce2ec;--accent:#205cc8;--github:#205cc8;--discord:#9562c9;--notice:#fff3d5}
-@media(prefers-color-scheme:dark){:root{--bg:#10151e;--panel:#19212e;--text:#e7edf8;--muted:#a8b5ca;--line:#334156;--accent:#93b8ff;--github:#93b8ff;--discord:#c69aee;--notice:#3c311c}}
-*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font:16px/1.6 system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}main,header,footer{max-width:1080px;margin:auto;padding:24px}header{display:flex;gap:20px;justify-content:space-between;align-items:center;border-bottom:1px solid var(--line)}nav{display:flex;flex-wrap:wrap;gap:16px}a{color:var(--accent);overflow-wrap:anywhere}a:hover{text-decoration-thickness:2px}h1,h2,h3{line-height:1.2}h1{font-size:2.1rem}h2{margin-top:32px}h3{margin-top:0}p{margin:12px 0}.muted,small{color:var(--muted)}.brand{font-weight:700;text-decoration:none}.cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(210px,1fr));gap:16px}.card,article,.chart{background:var(--panel);border:1px solid var(--line);border-radius:12px;padding:20px;margin:16px 0}.card strong{display:block;font-size:1.8rem}.badge{display:inline-block;font-size:.8rem;border:1px solid var(--line);border-radius:20px;padding:2px 10px;vertical-align:middle}.notice{padding:14px 18px;border-radius:8px;background:var(--notice)}.table-wrap{overflow:auto}table{border-collapse:collapse;width:100%;text-align:left}th,td{padding:10px 12px;border-bottom:1px solid var(--line)}th{color:var(--muted);font-weight:600}td.number,th.number{text-align:right}ul{padding-left:24px}li{margin:6px 0}blockquote{border-left:3px solid var(--line);padding:4px 16px;margin:12px 0;overflow-wrap:anywhere}.chart svg{display:block;width:100%;height:auto}.github-line,.discord-line{fill:none;stroke-width:2.5;vector-effect:non-scaling-stroke}.github-line{stroke:var(--github)}.discord-line{stroke:var(--discord)}.github-key{color:var(--github)}.discord-key{color:var(--discord)}.chart-axis{stroke:var(--line);stroke-width:1}.chart-label{fill:var(--muted);font-size:12px}.legend{display:flex;gap:24px;font-size:.9rem}.details{font-size:.9rem}.break{overflow-wrap:anywhere}footer{font-size:.85rem;color:var(--muted)}@media(max-width:600px){header{align-items:flex-start;flex-direction:column}main,header,footer{padding:16px}h1{font-size:1.7rem}.cards{grid-template-columns:1fr}}
+:root {
+  color-scheme: dark;
+  --oc-bg-page: oklch(0.135 0 0);
+  --oc-bg-surface: oklch(0.178 0 0);
+  --oc-bg-elevated: oklch(0.205 0 0);
+  --oc-text-primary: oklch(0.985 0 0);
+  --oc-text-secondary: oklch(0.87 0 0);
+  --oc-text-muted: oklch(0.716 0 0);
+  --oc-text-link: var(--oc-accent-primary);
+  --oc-accent-primary: #f5654a;
+  --oc-accent-primary-hover: #e05540;
+  --oc-accent-secondary: #4fc8ae;
+  --oc-border-subtle: oklch(0.269 0 0);
+  --oc-border-strong: color-mix(in oklch, var(--oc-text-primary) 32%, transparent);
+  --oc-surface-card: oklch(0.178 0 0 / 0.82);
+  --oc-surface-card-strong: oklch(0.205 0 0 / 0.96);
+  --oc-surface-interactive: oklch(0.178 0 0);
+  --oc-surface-interactive-hover: oklch(0.239 0 0);
+  --oc-surface-accent-soft: rgb(245 101 74 / 0.14);
+  --oc-surface-secondary-soft: rgb(79 200 174 / 0.14);
+  --oc-chart-line: oklch(1 0 0 / 0.1);
+  --oc-focus-ring: oklch(0.935 0 0 / 0.72);
+  --oc-selection-bg: rgb(245 101 74 / 0.28);
+  --oc-status-success-bg: rgb(34 197 94 / 0.12);
+  --oc-status-success-fg: #22c55e;
+  --oc-status-warning-bg: rgb(251 191 36 / 0.12);
+  --oc-status-warning-fg: #fbbf24;
+  --oc-status-info-bg: rgb(59 130 246 / 0.14);
+  --oc-status-info-fg: #60a5fa;
+  --oc-space-1: 0.25rem;
+  --oc-space-2: 0.5rem;
+  --oc-space-3: 0.75rem;
+  --oc-space-4: 1rem;
+  --oc-space-5: 1.5rem;
+  --oc-space-6: 2rem;
+  --oc-space-7: 3rem;
+  --oc-space-8: 4rem;
+  --oc-font-size-xs: 0.75rem;
+  --oc-font-size-sm: 0.8125rem;
+  --oc-font-size-base: 0.875rem;
+  --oc-font-size-md: 0.9375rem;
+  --oc-font-size-lg: 1.0625rem;
+  --oc-font-size-xl: 1.25rem;
+  --oc-font-size-2xl: 1.5rem;
+  --oc-font-size-3xl: 2rem;
+  --oc-radius-surface: 0;
+  --oc-radius-control: 0;
+  --oc-radius-inset: 0;
+  --oc-radius-round: 999px;
+  --oc-font-embed-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI Variable Text", "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  --oc-font-embed-mono: ui-monospace, "SFMono-Regular", "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --oc-font-body: var(--oc-font-embed-sans);
+  --oc-font-display: var(--oc-font-embed-sans);
+  --oc-font-mono: var(--oc-font-embed-mono);
+}
+@media (prefers-color-scheme: light) {
+  :root:not([data-theme="dark"]) {${LIGHT_THEME}}
+}
+html[data-theme="light"] {${LIGHT_THEME}}
+
+* { box-sizing: border-box; }
+body { margin: 0; font: var(--oc-font-size-base)/1.6 var(--oc-font-body); }
+::selection { background: var(--oc-selection-bg); }
+a { color: var(--oc-text-link); overflow-wrap: anywhere; }
+a:hover { color: var(--oc-accent-primary-hover); }
+:where(a, summary, [tabindex]):focus-visible { outline: 2px solid var(--oc-focus-ring); outline-offset: 3px; }
+h1, h2, h3, p { margin: 0; }
+h3 { font-size: var(--oc-font-size-md); line-height: 1.4; }
+p + p { margin-top: var(--oc-space-2); }
+ul { padding-left: var(--oc-space-5); }
+li { overflow-wrap: anywhere; }
+small, .muted { color: var(--oc-text-muted); }
+.details { color: var(--oc-text-secondary); font-size: var(--oc-font-size-sm); }
+.oc-app-surface { min-width: 0; min-height: 100%; background: var(--oc-bg-page); color: var(--oc-text-primary); font-family: var(--oc-font-body); }
+.report-toolbar { border-bottom: 1px solid var(--oc-border-subtle); background: var(--oc-bg-surface); }
+.report-toolbar-inner, main, footer { max-width: 75rem; margin: auto; padding: var(--oc-space-5) var(--oc-space-6); }
+.report-toolbar-inner { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: var(--oc-space-2); padding-block: var(--oc-space-2); }
+nav, .actions, .identity-line, .pills { display: flex; flex-wrap: wrap; align-items: center; gap: var(--oc-space-2); }
+.brand { margin-right: var(--oc-space-4); color: var(--oc-text-primary); font-weight: 750; text-decoration: none; }
+main { display: grid; gap: var(--oc-space-6); overflow-wrap: anywhere; }
+footer { color: var(--oc-text-muted); font-size: var(--oc-font-size-xs); border-top: 1px solid var(--oc-border-subtle); }
+.oc-section { width: 100%; min-width: 0; color: var(--oc-text-primary); }
+.oc-section-header { display: flex; align-items: end; justify-content: space-between; gap: var(--oc-space-5); margin-bottom: var(--oc-space-4); }
+.oc-section-header > * { min-width: 0; }
+.oc-section-heading { display: grid; gap: var(--oc-space-2); }
+.oc-eyebrow { color: var(--oc-accent-primary); font: 700 var(--oc-font-size-xs)/1.4 var(--oc-font-mono); text-transform: uppercase; }
+.oc-section-title { color: var(--oc-text-primary); font-family: var(--oc-font-display); font-size: var(--oc-font-size-2xl); font-weight: 750; line-height: 1.2; overflow-wrap: anywhere; }
+h2.oc-section-title { font-size: var(--oc-font-size-lg); }
+.oc-section-copy { max-width: 60ch; color: var(--oc-text-secondary); overflow-wrap: anywhere; }
+.oc-card { padding: var(--oc-space-4); border: 1px solid var(--oc-border-subtle); border-radius: var(--oc-radius-surface); background: var(--oc-surface-card); color: var(--oc-text-primary); }
+.stats, .history-columns { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: var(--oc-space-3); }
+.stat-heading { display: flex; flex-wrap: wrap; justify-content: space-between; align-items: center; gap: var(--oc-space-2); margin-bottom: var(--oc-space-2); }
+.stat-value { display: block; font-size: var(--oc-font-size-2xl); font-weight: 700; font-variant-numeric: tabular-nums; line-height: 1.4; }
+.stat-date { font: 650 var(--oc-font-size-xl)/1.5 var(--oc-font-mono); }
+.oc-action { display: inline-flex; min-height: 2.5rem; align-items: center; justify-content: center; gap: var(--oc-space-2); padding: var(--oc-space-2) var(--oc-space-3); border: 1px solid transparent; border-radius: var(--oc-radius-control); font-size: var(--oc-font-size-base); font-weight: 650; line-height: 1.2; text-decoration: none; touch-action: manipulation; }
+.oc-action-ghost { background: transparent; color: var(--oc-text-secondary); }
+.oc-action-ghost:hover { background: var(--oc-surface-interactive-hover); color: var(--oc-text-primary); }
+.oc-pill { display: inline-flex; max-width: 100%; min-width: 0; min-height: 1.75rem; align-items: center; padding: var(--oc-space-1) var(--oc-space-3); border: 1px solid var(--oc-border-subtle); border-radius: var(--oc-radius-control); background: var(--oc-surface-card); color: var(--oc-text-secondary); font-size: var(--oc-font-size-xs); font-weight: 650; line-height: 1.2; overflow-wrap: anywhere; }
+.oc-badge { display: inline-flex; max-width: 100%; min-width: 0; min-height: 1.5rem; align-items: center; gap: var(--oc-space-2); padding: var(--oc-space-1) var(--oc-space-2); border: 1px solid var(--oc-border-subtle); border-radius: var(--oc-radius-control); color: var(--oc-text-secondary); background: var(--oc-bg-elevated); font-size: var(--oc-font-size-xs); font-weight: 650; line-height: 1; white-space: nowrap; vertical-align: middle; }
+.oc-badge::before { width: 0.375rem; height: 0.375rem; flex: 0 0 auto; border-radius: var(--oc-radius-round); background: currentColor; content: ""; }
+.oc-badge-neutral::before { display: none; }
+.oc-badge-success { border-color: var(--oc-status-success-fg); background: var(--oc-status-success-bg); color: var(--oc-status-success-fg); }
+.oc-badge-warning { border-color: var(--oc-status-warning-fg); background: var(--oc-status-warning-bg); color: var(--oc-status-warning-fg); }
+.notices { display: grid; gap: var(--oc-space-3); }
+.oc-banner { display: grid; grid-template-columns: auto minmax(0, 1fr); align-items: start; gap: var(--oc-space-3); padding: var(--oc-space-4); border: 1px solid var(--oc-border-subtle); border-radius: var(--oc-radius-surface); background: var(--oc-surface-card-strong); color: var(--oc-text-secondary); font-size: var(--oc-font-size-sm); line-height: 1.45; }
+.oc-banner-indicator { width: 0.375rem; height: 0.375rem; margin-top: 0.45em; border-radius: var(--oc-radius-round); background: var(--oc-text-muted); }
+.oc-banner-warning .oc-banner-indicator { background: var(--oc-status-warning-fg); }
+.oc-banner-info .oc-banner-indicator { background: var(--oc-status-info-fg); }
+.oc-banner-content { display: grid; min-width: 0; gap: var(--oc-space-1); overflow-wrap: anywhere; }
+.oc-banner-title { color: var(--oc-text-primary); font-size: inherit; font-weight: 650; }
+.oc-banner ul { margin: 0; }
+.oc-table-wrap { width: 100%; overflow-x: auto; border: 1px solid var(--oc-border-subtle); border-radius: var(--oc-radius-surface); overscroll-behavior-inline: contain; scrollbar-gutter: stable; }
+.oc-table { width: 100%; min-width: 36rem; border-collapse: collapse; background: var(--oc-surface-card); color: var(--oc-text-secondary); font-size: var(--oc-font-size-sm); }
+.oc-table :is(th, td) { padding: var(--oc-space-3) var(--oc-space-4); border-bottom: 1px solid var(--oc-border-subtle); text-align: left; }
+.oc-table th { color: var(--oc-text-muted); font-family: var(--oc-font-mono); font-size: var(--oc-font-size-xs); font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; }
+.oc-table tbody tr:last-child td { border-bottom: 0; }
+.oc-table tbody tr:focus-within, .oc-table tbody tr:hover { background: var(--oc-surface-interactive); }
+.oc-table td:first-child { color: var(--oc-text-primary); font-weight: 650; }
+.oc-table .number { text-align: right; font-variant-numeric: tabular-nums; }
+.oc-resource-list { width: 100%; margin: 0; padding: 0; overflow: hidden; border: 1px solid var(--oc-border-subtle); border-radius: var(--oc-radius-surface); background: var(--oc-surface-card); list-style: none; }
+.oc-resource-list-item { margin: 0; }
+.oc-resource-list-item + .oc-resource-list-item { border-top: 1px solid var(--oc-border-subtle); }
+.oc-resource-list-link, .resource-row { display: flex; align-items: center; justify-content: space-between; gap: var(--oc-space-3); padding: var(--oc-space-2) var(--oc-space-3); }
+.oc-resource-list-link { color: inherit; text-decoration: none; }
+.oc-resource-list-link:hover { background: var(--oc-surface-interactive); color: var(--oc-text-primary); }
+.oc-resource-list-link:focus-visible { outline-offset: -2px; }
+.oc-resource-list-title { color: var(--oc-text-primary); font-size: var(--oc-font-size-sm); overflow-wrap: anywhere; }
+.oc-resource-list-meta { color: var(--oc-text-muted); font-size: var(--oc-font-size-sm); }
+.history-columns h3 { margin-bottom: var(--oc-space-3); }
+.member-list { margin: 0; padding: 0; list-style: none; }
+.member { display: grid; grid-template-columns: auto minmax(0, 1fr); gap: var(--oc-space-3); padding: var(--oc-space-4) 0; border-top: 1px solid var(--oc-border-subtle); }
+.member-content { display: grid; gap: var(--oc-space-2); min-width: 0; overflow-wrap: anywhere; }
+.member-content p { margin: 0; }
+.member-items .resource-row { display: block; }
+summary { width: fit-content; max-width: 100%; color: var(--oc-text-secondary); cursor: pointer; font-size: var(--oc-font-size-sm); }
+details[open] > summary { margin-bottom: var(--oc-space-2); }
+blockquote { border-left: 2px solid var(--oc-border-strong); padding: var(--oc-space-2) var(--oc-space-4); margin: var(--oc-space-2) 0; overflow-wrap: anywhere; }
+.person-identity { display: flex; align-items: center; gap: var(--oc-space-3); min-width: 0; }
+.person-heading { display: grid; gap: var(--oc-space-2); min-width: 0; }
+.oc-avatar { position: relative; display: inline-grid; flex: 0 0 auto; place-items: center; overflow: hidden; border-radius: var(--oc-radius-round); background: var(--oc-surface-secondary-soft); color: var(--oc-accent-secondary); font-weight: 650; line-height: 1; }
+.oc-avatar::before { content: attr(data-initials); }
+/* Transparent failed images leave the CSS initials beneath them visible. */
+.oc-avatar img { position: absolute; inset: 0; width: 100%; height: 100%; object-fit: cover; color: transparent; font-size: 0; }
+.oc-avatar-xs { width: 20px; height: 20px; font-size: var(--oc-font-size-xs); }
+.oc-avatar-md { width: 40px; height: 40px; font-size: var(--oc-font-size-sm); }
+.oc-avatar-xl { width: 72px; height: 72px; font-size: var(--oc-font-size-2xl); }
+.chart { padding-block: var(--oc-space-3); border-block: 1px solid var(--oc-border-subtle); }
+.chart .oc-sparkline { display: block; width: 100%; height: auto; }
+.oc-sparkline-line { fill: none; stroke-width: 1.5; stroke-linecap: butt; stroke-linejoin: miter; vector-effect: non-scaling-stroke; }
+.github-line { stroke: var(--oc-accent-primary); }
+.discord-line { stroke: var(--oc-accent-secondary); }
+.chart-axis { stroke: var(--oc-chart-line); stroke-width: 1; }
+.chart-label { fill: var(--oc-text-muted); font: var(--oc-font-size-xs) var(--oc-font-mono); }
+.legend { display: flex; flex-wrap: wrap; gap: var(--oc-space-4); font-size: var(--oc-font-size-xs); }
+.github-key { color: var(--oc-accent-primary); background: var(--oc-surface-accent-soft); }
+.discord-key { color: var(--oc-accent-secondary); background: var(--oc-surface-secondary-soft); }
+.legend span { padding-inline: var(--oc-space-2); border-radius: var(--oc-radius-inset); }
+.prose { overflow-wrap: anywhere; }
+.prose h3 { margin-top: var(--oc-space-4); }
+.prose .notices { margin-bottom: var(--oc-space-3); }
+@media (max-width: 42rem) {
+  .report-toolbar-inner, main, footer { padding-inline: var(--oc-space-4); }
+  .report-toolbar-inner, .oc-section-header { align-items: start; flex-direction: column; }
+  .stats, .history-columns { grid-template-columns: 1fr; }
+  .oc-section-header { gap: var(--oc-space-3); }
+  .brand { width: 100%; }
+  .report-toolbar nav { gap: var(--oc-space-1); }
+  .report-toolbar .oc-action { padding-inline: var(--oc-space-2); }
+}
 `;


### PR DESCRIPTION
## What Problem This Solves

The Team Reports pages shipped with a generic, ad-hoc stylesheet that looked nothing like the rest of OpenClaw's surfaces, and people appeared as bare logins with no avatars, which makes a roster of 60 members slow to scan.

## Why This Change Was Made

The report, people, and person pages now follow Carapace, OpenClaw's shared visual contract (openclaw/carapace v0.6.2). Because the plugin serves self-contained HTML behind a nonce-only `style-src` policy and Carapace is a git-tag package rather than an npm dependency, the plugin vendors a faithful subset of its tokens (palette, semantic dark and light themes, status colors, spacing, radii, type scale, embed font stacks) with the source files named in the stylesheet header, and re-implements the primitives it uses under their Carapace class names: app surface toolbar, sections and eyebrows, stat cards, pills, status badges, banners, tables, resource lists, and sparkline-style chart lines. Dark is the default, light follows the OS preference or an explicit `data-theme`. Every roster member, other GitHub actor, people-table row, and person page gets a GitHub avatar from `avatars.githubusercontent.com` (already permitted by the page's `img-src`), rendered over CSS initials so a blocked image degrades without JavaScript; only syntactically valid GitHub logins produce an image URL.

## User Impact

Same routes, data, Markdown, JSON, and security headers; only the HTML and CSS changed. Reports are denser and scan faster, status is conveyed with Carapace status colors, and people are recognizable at a glance. No configuration options were added.

## Evidence

- `node scripts/run-vitest.mjs run extensions/team-reports`: 13 files, 204 tests passed (new cases: GitHub avatar for valid logins at each size, unsafe identities escaped with initials fallback, hostile display name never reaches the avatar URL, closed/partial status badge variants, dark and light token blocks with CSS-only initials).
- oxlint, oxfmt, and dead-export scans clean; both `tsgo` extension lanes report only pre-existing errors in `extensions/openshell` and `src/infra/install-package-dir.ts` from a stale local `@openclaw/fs-safe` build, none in this plugin; CI is the authoritative typecheck.
- Codex autoreview (branch vs `origin/main`, P0–P1): scoped-clean.
- Before/after screenshots from an isolated Gateway with public data only (GitHub team roster, one public Discord channel, no excerpts, no summaries) are attached below.

Overview, before (dark):

![Overview before](https://github.com/user-attachments/assets/db50eea4-257d-4bca-913f-44007270584d)

Overview, after (dark):

![Overview after](https://github.com/user-attachments/assets/4b5be456-97d5-4b71-a493-8f1501bc437c)

Day report, before (dark, top of page):

![Day report before](https://github.com/user-attachments/assets/3cb77ae1-748a-4d0d-b9c5-d6625bcd9478)

Day report, after (dark, top of page, first member row with avatar):

![Day report after](https://github.com/user-attachments/assets/711905d1-c393-455e-9d3c-8d3d6e11b3b5)

Person page, after (dark):

![Person page after](https://github.com/user-attachments/assets/833e84cd-5df7-4774-8c65-a36e8594f1ac)

Overview, after (light):

![Overview after, light](https://github.com/user-attachments/assets/0b9b9519-8f53-44f8-bb54-04469b792a62)

