### PR TITLE
fix(memory): memory search adds seconds per query from KNN helper startup

### DIFF
--- a/extensions/memory-core/src/memory/manager-search-knn.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn.ts
@@ -1,7 +1,7 @@
 // Memory Core plugin module implements the synchronous sqlite-vec KNN query body.
 import type { DatabaseSync } from "node:sqlite";
-import { truncateUtf16Safe } from "openclaw/plugin-sdk/memory-core-host-engine-foundation";
 import type { MemorySource } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
+import { truncateUtf16Safe } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { vectorToBlob } from "./vector-blob.js";
 
 const VECTOR_KNN_OVERSAMPLE_FACTOR = 8;


### PR DESCRIPTION
Closes #140681

## What Problem This Solves

Fixes an issue where users with memory search enabled would wait seconds for every `memory.search` result when the sqlite-vec index is in use. Each search starts a short-lived helper process, and that process spent most of its life loading modules rather than searching — the reporter measured ~2.3 s of pure startup against a ~70 ms query, making server-side search ~3 s median where it used to be roughly one embedding round-trip. This affects the memory search tool and anything built on it (chat recall, `memory.search` callers), on every query rather than occasionally.

## Why This Change Was Made

The KNN helper needs exactly one small string helper, `truncateUtf16Safe`, but it was importing it from the broad `memory-core-host-engine-foundation` SDK barrel. Naming that barrel is enough to keep it in the helper's module graph — the bundler resolved the symbol to the narrow chunk but still emitted a bare side-effect import of the whole barrel, so every helper process evaluated agent scope, config paths, sessions transcript events, logging, and singleton modules before it could run a query. Tree-shaking cannot remove it because the barrel is not side-effect-free.

The fix imports the same function from `openclaw/plugin-sdk/string-coerce-runtime`, already the seam used by six other memory-core modules. Explicit non-goal: the subprocess itself is kept. It is intentional ("bounded, OS-killable child") and the isolation is worth keeping — this only makes it cheap to start. Scope is limited to the one module on the child's import path; other memory-core modules keep the barrel because they run in the Gateway process where it is already loaded.

## User Impact

Memory search returns noticeably sooner, and the win is on every query. On the machine used here the helper's startup dropped from a median of 640 ms to 218 ms; on the reporter's slower 4 vCPU Linux host the same startup was ~2.3 s, so the saving there is larger. Search results, ranking, and truncation behavior are unchanged — only the waiting is shorter. No configuration change or migration is needed.

## Evidence

Built with `pnpm build` and timed the actual child binary the Gateway spawns, with empty stdin so it exits on EOF. Same machine, same harness, n=15 per build; the two builds differ only by this commit.

| Build | min | **median** | p90 |
|---|---|---|---|
| current `main` (`e0ecca35a58`) | 533 ms | **640 ms** | 672 ms |
| this branch | 209 ms | **218 ms** | 412 ms |

Isolated module-load timings that localize the cost:

```
memory-core-host-engine-foundation chunk   real 1.19   (barrel that was being pulled in)
utf16-slice chunk                          real 0.04   (all the helper actually needs)
manager-search-knn chunk  BEFORE           real 1.30
manager-search-knn chunk  AFTER            real 0.03
node -e ""                                 real 0.03   (floor)
```

The built chunk before the change carried the barrel as a side-effect import:

```js
// dist/manager-search-knn-BAslbObE.mjs  (main)
import { r as truncateUtf16Safe } from "./utf16-slice-D_ngcYKd.mjs";
import "./memory-core-host-engine-foundation-D6DWxqmh.mjs";
```

and after the change it does not:

```js
// dist/manager-search-knn-k2RGRty1.mjs  (this branch)
import { r as truncateUtf16Safe } from "./utf16-slice-D_ngcYKd.mjs";
import "./string-coerce-runtime-C_MKhRVt.mjs";
```

Supporting checks:

- `pnpm test extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts extensions/memory-core/src/memory/manager-search.test.ts extensions/memory-core/src/memory/manager-search-generation.test.ts` — 56 passed, including the real-source-child WAL/source-filter case that exercises the spawned child end to end.
- `pnpm check:changed` — passed (format, typecheck lanes, plugin-sdk boundary, dead-export scan, import cycles).
- `codex review --base origin/main` — no findings.

Environment: macOS arm64, Node 24.20.0. Not run on Linux; the remaining ~218 ms here is dominated by `sqlite-runtime` (~0.45 s isolated) and the sqlite-vec load, which this change does not touch.

Notes: no regression test added, because a test asserting an import specifier would mirror the implementation rather than protect behavior. If you want a guard, the natural home is a build-time check in the spirit of `scripts/check-cli-bootstrap-imports.mts` asserting that runtime child/worker entrypoints do not reach broad SDK barrels — happy to add that as a follow-up. `CHANGELOG.md` left untouched since `AGENTS.md` marks it release-owned. AI-assisted: yes; fully tested locally.
