### PR TITLE
improve(status): speed up summarized Gateway logs

### DIFF
--- a/src/commands/status-all/gateway.test.ts
+++ b/src/commands/status-all/gateway.test.ts
@@ -14,6 +14,55 @@ afterEach(() => {
 });
 
 describe("summarizeLogTail", () => {
+  it.each([
+    {
+      name: "ordinary whitespace and adjacent duplicates",
+      input: ["  first \t", "", " \t", "  first", "second  ", "  first"],
+      expected: ["  first", "second", "  first"],
+    },
+    {
+      name: "orphan JSON fragments without dropping bracketed or comment lines",
+      input: ['  "field": "value",', "  } trailing", " {", "[gateway] {kept}", "# {kept}"],
+      expected: ["[gateway] {kept}", "# {kept}"],
+    },
+    {
+      name: "reordered request identifiers and error suffixes",
+      input: [
+        "[gws] errorCode=UNAVAILABLE OAuth token refresh failed runId=r1 conn=c1 id=i1 error=Error: first",
+        "[gws] errorCode=UNAVAILABLE OAuth token refresh failed id=i2 runId=r2 conn=c2 error=Error: second",
+      ],
+      expected: ["[gws] errorCode=UNAVAILABLE OAuth token refresh failed ×2"],
+    },
+    {
+      name: "case-sensitive identifier names",
+      input: ["[gws] errorCode=UNAVAILABLE OAuth token refresh failed RunId=r CONN=c ID=i"],
+      expected: ["[gws] errorCode=UNAVAILABLE OAuth token refresh failed RunId=r CONN=c ID=i"],
+    },
+    {
+      name: "field-like text without a whitespace boundary",
+      input: [
+        "[gws] errorCode=UNAVAILABLE OAuth token refresh failed/runId=keep note=conn=keep xid=keep id=drop",
+      ],
+      expected: [
+        "[gws] errorCode=UNAVAILABLE OAuth token refresh failed/runId=keep note=conn=keep xid=keep",
+      ],
+    },
+    {
+      name: "field-like text inside identifier values",
+      input: [
+        "[gws] errorCode=UNAVAILABLE OAuth token refresh failed runId=id=conn=value conn=runId=value id=conn=value",
+      ],
+      expected: ["[gws] errorCode=UNAVAILABLE OAuth token refresh failed"],
+    },
+    {
+      name: "nonqualifying gateway errors",
+      input: ["[gws] errorCode=OTHER OAuth token refresh failed id=keep"],
+      expected: ["[gws] errorCode=OTHER OAuth token refresh failed id=keep"],
+    },
+  ])("preserves $name", ({ input, expected }) => {
+    expect(summarizeLogTail(input)).toEqual(expected);
+  });
+
   it("marks permanent OAuth refresh failures as reauth-required", () => {
     const lines = summarizeLogTail([
       "[openai] Token refresh failed: 401 {",

--- a/src/commands/status-all/gateway.ts
+++ b/src/commands/status-all/gateway.ts
@@ -28,9 +28,7 @@ function shorten(message: string, maxLen: number): string {
 function normalizeGwsLine(line: string): string {
   // Remove per-request ids so repeated gateway websocket errors group into one summary.
   return line
-    .replace(/\s+runId=[^\s]+/g, "")
-    .replace(/\s+conn=[^\s]+/g, "")
-    .replace(/\s+id=[^\s]+/g, "")
+    .replace(/\s+(?:runId|conn|id)=[^\s]+/g, "")
     .replace(/\s+error=Error:.*$/g, "")
     .trim();
 }
@@ -73,26 +71,14 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
     out.push(base);
   };
 
-  const addLine = (line: string) => {
-    const trimmed = line.trimEnd();
-    if (!trimmed) {
-      return;
-    }
-    out.push(trimmed);
-  };
-
   const lines = rawLines.map((line) => line.trimEnd()).filter(Boolean);
   for (let i = 0; i < lines.length; i += 1) {
     const line = lines[i] ?? "";
     const trimmedStart = line.trimStart();
     if (
-      (trimmedStart.startsWith('"') ||
-        trimmedStart === "}" ||
-        trimmedStart === "{" ||
-        trimmedStart.startsWith("}") ||
-        trimmedStart.startsWith("{")) &&
-      !trimmedStart.startsWith("[") &&
-      !trimmedStart.startsWith("#")
+      trimmedStart.startsWith('"') ||
+      trimmedStart.startsWith("}") ||
+      trimmedStart.startsWith("{")
     ) {
       // Tail can cut in the middle of a JSON blob; drop orphaned JSON fragments.
       continue;
@@ -143,7 +129,7 @@ export function summarizeLogTail(rawLines: string[], opts?: { maxLines?: number 
       continue;
     }
 
-    addLine(line);
+    out.push(line);
   }
 
   for (const g of groups.values()) {


### PR DESCRIPTION
## What Problem This Solves

Preparing the summarized Gateway logs in `openclaw status --all` does avoidable formatting work, particularly for repeated WebSocket errors.

## Why This Change Was Made

Keep normalization in the existing summary owner: reuse lines already trimmed and filtered, combine the three request-ID removal scans, and simplify equivalent orphan-fragment conditions. This removes 14 production lines without changing grouping, output order, JSON framing, truncation, file reading, or the redactor.

## User Impact

Displayed diagnostics remain the same. In the fixed local cohort, WebSocket summary medians improved 21.24% and 22.67% in opposite orders; summary-plus-redaction rendering improved 16.73% and 19.71%. Results are mixed elsewhere, and this is not a claim about complete status-command latency, file I/O, or Gateway turns.

## Evidence

The same 17 tests passed on baseline and candidate production. All 29 normal changed-file checks passed, as did independent P0–P2 review. Tests add seven literal public-output cases for whitespace, orphan fragments, request-ID order/case/boundaries, and unrelated errors; no private test seam. Production −14 lines; tests +49.

Validation: `pnpm test src/commands/status-all/gateway.test.ts` and the normal `pnpm check:changed` selection for both changed files.

The fixed B0/C0/C1/B1 cohort exercises the actual summary and redactor exports on eight synthetic fixtures, retaining all 2,496 complete array returns. An independent audit verified literal output parity, input preservation, all 576 four-call batches, and every timing/resource comparison. No numeric failure or rerun occurred.

27 of 32 median comparisons improved; five regressed. Incomplete JSON summary regressed in both orders. In the reverse pair its median rose 5.03%, mean 517.91%, and maximum batch mean 3,225.05% (16.146→536.854 µs). Both sampled tree-RSS comparisons rose, by 0.61% and 1.48%. These observations are retained, not filtered. Maximum means the maximum of nine four-call batch means, not a per-call percentile. The first baseline child also included Git/Xcode initialization, so its larger whole-child wall difference is not attributed to this patch.

### Review follow-through

The review's measurement limitation is accepted and remains explicit: this PR does not establish faster total status-command latency, and incomplete-JSON summary medians regressed in both orders. The maintainer decision is to keep the bounded component improvement and simplification: diagnostic output is identical across the complete cohort, the JSON parser/consumption path and downstream redactor are unchanged, ordinary/WebSocket summary work improves, and all adverse samples remain visible above. This is not a claim of a uniform gain or a reason to rerun until the regressions disappear. No additional end-to-end timing claim is being added.

<details>
<summary>All paired timing and whole-child resource results</summary>

| Pair | Row | Median Δ | Mean Δ | Minimum Δ | Maximum Δ |
| --- | --- | ---: | ---: | ---: | ---: |
| B0→C0 | empty/summary | -18.421% | +34.969% | -33.807% | +171.847% |
| B0→C0 | empty/render | -19.670% | -24.667% | -24.131% | -25.907% |
| B0→C0 | single/summary | -29.876% | -30.732% | -31.554% | -21.818% |
| B0→C0 | single/render | -41.219% | -45.044% | -14.427% | -57.542% |
| B0→C0 | ordinary30/summary | -15.358% | -9.033% | -4.105% | -3.053% |
| B0→C0 | ordinary30/render | +2.998% | +9.717% | -3.595% | +87.285% |
| B0→C0 | duplicates40/summary | -13.101% | -15.824% | -11.508% | -37.776% |
| B0→C0 | duplicates40/render | -5.167% | -0.822% | -5.289% | -1.638% |
| B0→C0 | gws30/summary | -21.242% | -18.639% | -17.297% | -19.070% |
| B0→C0 | gws30/render | -16.732% | -17.099% | -16.079% | -18.547% |
| B0→C0 | oauth30/summary | -4.502% | -72.656% | +6.878% | -92.726% |
| B0→C0 | oauth30/render | +8.563% | +5.840% | -3.739% | +7.965% |
| B0→C0 | mixed40/summary | -10.640% | -18.505% | -9.077% | -38.852% |
| B0→C0 | mixed40/render | -4.625% | -8.461% | -5.328% | -14.708% |
| B0→C0 | incomplete40/summary | +17.054% | +23.023% | -7.433% | +76.660% |
| B0→C0 | incomplete40/render | -1.961% | -1.596% | -6.510% | +6.261% |
| B1→C1 | empty/summary | -16.650% | -8.228% | -24.255% | -2.700% |
| B1→C1 | empty/render | -25.009% | -19.537% | -27.410% | -1.613% |
| B1→C1 | single/summary | -20.261% | -22.457% | -19.741% | -23.365% |
| B1→C1 | single/render | -16.519% | -24.677% | -18.798% | -41.698% |
| B1→C1 | ordinary30/summary | -13.785% | -11.014% | -9.306% | -16.917% |
| B1→C1 | ordinary30/render | -5.331% | -5.743% | -5.429% | -6.001% |
| B1→C1 | duplicates40/summary | -12.109% | -24.922% | -11.194% | -63.940% |
| B1→C1 | duplicates40/render | -5.330% | -1.950% | -5.618% | +15.081% |
| B1→C1 | gws30/summary | -22.665% | -24.582% | -18.059% | -42.301% |
| B1→C1 | gws30/render | -19.714% | -19.412% | -19.096% | -21.673% |
| B1→C1 | oauth30/summary | +6.001% | +4.921% | -2.699% | -3.512% |
| B1→C1 | oauth30/render | -4.990% | -5.022% | -5.837% | +0.947% |
| B1→C1 | mixed40/summary | -6.346% | -5.419% | -6.118% | -2.588% |
| B1→C1 | mixed40/render | -3.659% | -12.309% | -1.935% | -40.912% |
| B1→C1 | incomplete40/summary | +5.035% | +517.907% | +1.001% | +3225.048% |
| B1→C1 | incomplete40/render | -1.042% | -9.229% | +0.481% | -42.403% |



| Phase | Wall s | User CPU s | System CPU s | Total CPU s | Kernel max RSS MiB | Sampled tree peak MiB |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| B0 | 2.389158708 | 2.366699 | 0.733248 | 3.099947 | 359.375 | 373.938 |
| C0 | 2.017291000 | 2.360417 | 0.689448 | 3.049865 | 357.688 | 376.203 |
| C1 | 2.013168708 | 2.329978 | 0.692053 | 3.022031 | 353.750 | 372.125 |
| B1 | 2.029346250 | 2.410296 | 0.697328 | 3.107624 | 371.141 | 366.688 |
| reduce | 0.044128500 | 0.035569 | 0.009272 | 0.044841 | 47.750 | 0.656 |

| Pair | Wall Δ | User CPU Δ | System CPU Δ | Total CPU Δ | Kernel RSS Δ | Sampled tree RSS Δ |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| B0→C0 | -15.565% | -0.265% | -5.973% | -1.616% | -0.470% | +0.606% |
| B1→C1 | -0.797% | -3.332% | -0.756% | -2.754% | -4.686% | +1.483% |



</details>
