### PR TITLE
fix(telegram): preserve complete plugin commands in help

### DIFF
--- a/extensions/telegram/src/bot-handlers.callback-router.ts
+++ b/extensions/telegram/src/bot-handlers.callback-router.ts
@@ -51,6 +51,7 @@ import {
   startTelegramCallbackQueryAnswer,
 } from "./callback-query-answer-state.js";
 import { buildCommandsPaginationKeyboard, buildTelegramModelsMenuButtons } from "./command-ui.js";
+import { markdownToTelegramHtml } from "./format.js";
 import { resolveTelegramInlineButtonsScope } from "./inline-buttons.js";
 import {
   buildModelsKeyboard,
@@ -495,7 +496,10 @@ async function handleTelegramModelCallback(params: {
           )
         : undefined;
     try {
-      await editCallbackMessage(result.text, keyboard ? { reply_markup: keyboard } : undefined);
+      await editCallbackMessage(markdownToTelegramHtml(result.text), {
+        parse_mode: "HTML",
+        ...(keyboard ? { reply_markup: keyboard } : {}),
+      });
     } catch (editErr) {
       if (!String(editErr).includes("message is not modified")) {
         throw new TelegramRetryableCallbackError(editErr);

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -2552,8 +2552,13 @@ describe("createTelegramBot", () => {
           handler: async () => ({ text: "memory" }),
         }),
       ).toEqual({ ok: true });
-      createTelegramBot({ token: "tok" });
-      const page = buildCommandsMessagePaginated(loadConfig(), [], {
+      const config = makeTelegramConfig(
+        { dmPolicy: "open", allowFrom: ["*"] },
+        { agents: { defaults: { userTimezone: "UTC" } } },
+      );
+      loadConfig.mockReturnValue(config);
+      createTelegramBot({ token: "tok", config });
+      const page = buildCommandsMessagePaginated(config, [], {
         surface: "telegram",
         forcePaginatedList: true,
         page: Number.MAX_SAFE_INTEGER,

--- a/extensions/telegram/src/bot.test.ts
+++ b/extensions/telegram/src/bot.test.ts
@@ -1,7 +1,13 @@
+import {
+  createEmptyPluginRegistry,
+  withPluginRuntimeRegistryScope,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import { buildCommandsMessagePaginated } from "openclaw/plugin-sdk/command-status";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
 import {
   clearPluginInteractiveHandlers,
   registerPluginInteractiveHandler,
+  registerPluginCommand,
 } from "openclaw/plugin-sdk/plugin-runtime";
 import type { PluginStateKeyedStore } from "openclaw/plugin-sdk/plugin-state-runtime";
 import {
@@ -2524,6 +2530,7 @@ describe("createTelegramBot", () => {
     expect(renderedMessageId).toBe(messageId);
     expect(String(text)).toContain(`${INFO_EMOJI} Commands (2/`);
     expect(params).toEqual({
+      parse_mode: "HTML",
       reply_markup: {
         inline_keyboard: [
           [
@@ -2533,6 +2540,42 @@ describe("createTelegramBot", () => {
           ],
         ],
       },
+    });
+  });
+
+  it("keeps hyphenated plugin names as code when command pagination is edited", async () => {
+    await withPluginRuntimeRegistryScope(createEmptyPluginRegistry(), async () => {
+      expect(
+        registerPluginCommand("memory-fixture", {
+          name: "active-memory",
+          description: "Inspect memory <scope>",
+          handler: async () => ({ text: "memory" }),
+        }),
+      ).toEqual({ ok: true });
+      createTelegramBot({ token: "tok" });
+      const page = buildCommandsMessagePaginated(loadConfig(), [], {
+        surface: "telegram",
+        forcePaginatedList: true,
+        page: Number.MAX_SAFE_INTEGER,
+      });
+      expect(page.text).toContain("active-memory");
+      await getTelegramCallbackHandlerForTests()(
+        createTelegramCallbackContext({
+          id: "cbq-command-code",
+          data: `commands_page_${page.currentPage}:main`,
+          message: { message_id: 17 },
+        }),
+      );
+      const [chatId, messageId, text, params] = mockCall(
+        editMessageTextSpy,
+        0,
+        "edit command page",
+      );
+      expect(chatId).toBe(1234);
+      expect(messageId).toBe(17);
+      expect(text).toContain("<code>/active-memory</code>");
+      expect(text).toContain("Inspect memory &lt;scope&gt;");
+      expect(params).toMatchObject({ parse_mode: "HTML" });
     });
   });
 

--- a/extensions/telegram/src/command-ui.test.ts
+++ b/extensions/telegram/src/command-ui.test.ts
@@ -1,6 +1,41 @@
 // Telegram tests cover command ui plugin behavior.
+import {
+  createEmptyPluginRegistry,
+  withPluginRuntimeRegistryScope,
+} from "openclaw/plugin-sdk/channel-test-helpers";
+import {
+  buildCommandsMessage,
+  buildCommandsMessagePaginated,
+} from "openclaw/plugin-sdk/command-status";
+import { createPluginCommandRuntime } from "openclaw/plugin-sdk/plugin-command-runtime";
+import { matchPluginCommand, registerPluginCommand } from "openclaw/plugin-sdk/plugin-runtime";
 import { describe, expect, it } from "vitest";
+import { buildPluginTelegramMenuCommands } from "./bot-native-command-menu.js";
 import { buildCommandsPaginationKeyboard } from "./command-ui.js";
+import { inputRichBlocksToPlainText } from "./rich-block-model.js";
+import { planTelegramTextDeliveryPages } from "./telegram-text-delivery.js";
+
+function registerCommand(name: string, nativeNames?: Record<string, string>) {
+  expect(
+    registerPluginCommand(name, {
+      name,
+      description: `Run ${name}`,
+      acceptsArgs: true,
+      nativeNames,
+      handler: async () => ({ text: name }),
+    }),
+  ).toEqual({ ok: true });
+}
+
+function commandPages() {
+  const first = buildCommandsMessagePaginated(undefined, undefined, { forcePaginatedList: true });
+  return Array.from({ length: first.totalPages }, (_, index) =>
+    buildCommandsMessagePaginated(undefined, undefined, {
+      forcePaginatedList: true,
+      page: index + 1,
+    }),
+  );
+}
 
 describe("telegram command ui", () => {
   it("adds agent id to command pagination callback data when provided", () => {
@@ -11,4 +46,85 @@ describe("telegram command ui", () => {
       { text: "Next ▶", callback_data: "commands_page_3:agent-main" },
     ]);
   });
+
+  it.each([false, true])(
+    "preserves command owners when normalized names collide (reverse=%s)",
+    (reverse) => {
+      withPluginRuntimeRegistryScope(createEmptyPluginRegistry(), () => {
+        const names = reverse ? ["foo_bar", "foo-bar"] : ["foo-bar", "foo_bar"];
+        for (const name of names) {
+          registerCommand(name);
+        }
+        const plainList = buildCommandsMessage();
+        const paginatedList = commandPages()
+          .map((page) => page.text)
+          .join("\n");
+        for (const text of [plainList, paginatedList]) {
+          expect(text).toContain("`/foo-bar` (foo-bar) - Run foo-bar");
+          expect(text).toContain("/foo_bar (foo_bar) - Run foo_bar");
+        }
+        expect(matchPluginCommand("/foo-bar status")?.command.name).toBe("foo-bar");
+        expect(matchPluginCommand("/foo_bar status")?.command.name).toBe("foo_bar");
+        const catalog = buildPluginTelegramMenuCommands({
+          specs: createPluginCommandRuntime().listNativeCandidates("telegram"),
+          existingCommands: new Set(),
+        });
+        expect(catalog.commands).toEqual([{ command: "foo_bar", description: "Run foo_bar" }]);
+      });
+    },
+  );
+
+  it("preserves explicit native aliases without relabeling canonical text commands", () => {
+    withPluginRuntimeRegistryScope(createEmptyPluginRegistry(), () => {
+      registerCommand("foo-bar", { telegram: "other_name" });
+      registerCommand("foo_bar");
+      expect(buildCommandsMessage()).toContain("`/foo-bar` (foo-bar)");
+      expect(matchPluginCommand("/foo-bar status")?.command.name).toBe("foo-bar");
+      expect(matchPluginCommand("/other_name status", { channel: "telegram" })?.command.name).toBe(
+        "foo-bar",
+      );
+      const catalog = buildPluginTelegramMenuCommands({
+        specs: createPluginCommandRuntime().listNativeCandidates("telegram"),
+        existingCommands: new Set(),
+      });
+      expect(catalog.commands).toEqual([
+        { command: "foo_bar", description: "Run foo_bar" },
+        { command: "other_name", description: "Run foo-bar" },
+      ]);
+    });
+  });
+
+  it.each([false, true])(
+    "encodes registered command names as code in initial delivery (rich=%s)",
+    (richMessages) => {
+      withPluginRuntimeRegistryScope(createEmptyPluginRegistry(), () => {
+        registerCommand("active-memory");
+        const page = commandPages().find((entry) => entry.text.includes("active-memory"));
+        if (!page) {
+          throw new Error("registered command was not listed");
+        }
+        const deliveries = planTelegramTextDeliveryPages({
+          text: page.text,
+          maxChars: 4096,
+          richMessages,
+        });
+        if (richMessages) {
+          const blocks = deliveries.flatMap((delivery) => delivery.richMessage?.blocks ?? []);
+          expect(inputRichBlocksToPlainText(blocks)).toContain("/active-memory");
+          expect(blocks).toContainEqual(
+            expect.objectContaining({
+              type: "paragraph",
+              text: expect.arrayContaining([
+                expect.objectContaining({ type: "code", text: "/active-memory" }),
+              ]),
+            }),
+          );
+        } else {
+          expect(deliveries.map((delivery) => delivery.htmlText).join("\n")).toContain(
+            "<code>/active-memory</code>",
+          );
+        }
+      });
+    },
+  );
 });

--- a/src/auto-reply/command-status-builders.ts
+++ b/src/auto-reply/command-status-builders.ts
@@ -158,9 +158,11 @@ function buildCommandItems(
 
   for (const command of pluginCommands) {
     const pluginLabel = command.pluginId ? ` (${command.pluginId})` : "";
+    // Preserve the canonical spelling without auto-linking only its prefix or guessing an alias.
+    const commandName = command.name.includes("-") ? `\`/${command.name}\`` : `/${command.name}`;
     items.push({
       label: "Plugins",
-      text: `/${command.name}${pluginLabel} - ${command.description}`,
+      text: `${commandName}${pluginLabel} - ${command.description}`,
     });
   }
 


### PR DESCRIPTION
Closes #141331.

## What Problem This Solves

Fixes an issue where users reading `/commands` in Telegram see only a prefix highlighted for hyphenated plugin commands such as `/active-memory`. The real command remains accessible through the native menu or complete text input; the central help list misleadingly exposes a different clickable token.

## Why This Change Was Made

Render canonical hyphenated plugin names as inline code, and preserve the existing Markdown-to-Telegram HTML formatting when command pages are edited. This is one presentation fix across initial delivery and pagination; no command renaming, guessed aliases, registration, authorization, native-menu collision policy or SDK changes.

The generic list uses code styling on other surfaces too, preserving exact spelling. Simple underscore names retain their existing presentation. This deliberately avoids the canonical rename rejected in #75102 and does not change individual plugins' own help text.

## User Impact

Users can read/copy the exact canonical plugin command without mistaking its prefix for the full command. Existing `/foo_bar` menu ownership and explicit native aliases remain intact, even when `foo-bar` and `foo_bar` are separate registered commands. Next/Previous pages keep code formatting and safely render placeholders such as `<scope>`.

## Evidence

Baseline `00fd5d6a404939da829ceae80e01d941a729cf06`; both production owner blobs matched live main before publication preparation. Local tests use actual plugin registration, command builders, Telegram menu selection/matching, formatting and callback routing; the Bot API boundary is mocked.

| Boundary | Before | After |
| --- | --- | --- |
| Initial ordinary delivery | plain `/active-memory` | `<code>/active-memory</code>` |
| Initial rich delivery | ordinary text | native inline-code item |
| Edited command page | raw command text, no parse mode | code markup with `parse_mode: HTML` |
| Canonical/native collision and explicit alias | existing exact-owner matching | unchanged |

Baseline command-ui run: **5 expected failures, 1 control passed**, wrapper exit 1. Baseline callback run: **1 expected failure**, wrapper exit 1. Failure was the actual missing code formatting, not infrastructure.

```sh
node scripts/run-vitest.mjs extensions/telegram/src/command-ui.test.ts extensions/telegram/src/bot.test.ts --testNamePattern="telegram command ui|command pagination|falls back to the default agent without an agent suffix" --reporter=default
```

After patch: **9 selected tests passed in 2 files, wrapper exit 0** (141 unselected). Covers both collision registration orders, explicit native aliases, legacy HTML and native-rich formatting, and actual edited-page payload.

The additional full `bot.test.ts` run passed all **144 test assertions**, including both existing agent-selection pagination controls, but suite cleanup failed on Windows with `EBUSY` removing a SQLite shared-memory file. **That full run exited 1 and is not reported as green.** No assertion was weakened and no SQLite cleanup change is included.

Formatting and `git diff --check` passed. Canonical scoped core type-aware lint passed for the command builder: `node --import ./scripts/tsx.mjs scripts/run-oxlint.mts --tsconfig config/tsconfig/oxlint.core.json src/auto-reply/command-status-builders.ts` (exit 0). Extension lint and the full changed-files gate were not run because their additional heavy preparation exceeded the serialized local validation budget; hosted CI remains required.

One final structured review of the exact staged four-file patch: `python .agents/skills/autoreview/scripts/autoreview --mode local --base 00fd5d6a404939da829ceae80e01d941a729cf06 --engine codex --max-priority P2` with frozen scope/evidence context. Helper exit 0: `autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority`. No review-driven code expansion.

No live Telegram Test Server/client tap was performed. The truncated-token consequence is derived from Telegram's documented command grammar and TDLib parser, not from a fabricated client event. Hosted CI and optional live-client confirmation remain separate validation.

### CI follow-up: typed callback fixture

The initial head's hosted test-typecheck caught TS2348 at the new direct `loadConfig()` mock call. Runtime Vitest success did not establish compile-time validity: the shared mock type also permits constructors. The callback regression now supplies the same explicit typed configuration to the mock, bot and page builder. This changes only the test fixture (+7/-2), with all behavior assertions and production code unchanged.

The same focused command passed again: **9 tests / 2 files, wrapper exit 0**, 181.20 seconds. The canonical local extension typecheck was attempted but refused the shared compiler installation before compilation because declaration inputs resolve outside the checkout; no guard was bypassed and no full typecheck success is claimed. The next hosted CI run remains authoritative for TS2348 clearance.

One isolated fixture-only structured Codex review completed final verification with helper exit 0, `scoped-clean`, and no actionable P0–P2 findings. No additional code changes resulted from the review.
