### PR TITLE
test: make doctor archive checks portable across runtimes

### DIFF
--- a/extensions/codex/doctor-contract-api.test.ts
+++ b/extensions/codex/doctor-contract-api.test.ts
@@ -527,7 +527,7 @@ describe("codex doctor contract", () => {
         storePath: fixture.storePath,
       }),
     ).toMatchObject({ agentHarnessId: "codex" });
-    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${fixture.sidecarPath}.migrated`);
 
     await removeCodexDoctorFixture(fixture.stateDir);
   });
@@ -571,7 +571,7 @@ describe("codex doctor contract", () => {
         }),
       ),
     ).resolves.toMatchObject({ sessionId: "explicit-ops-owner" });
-    await expect(fs.access(`${fixture.sidecarPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${fixture.sidecarPath}.migrated`);
 
     await removeCodexDoctorFixture(fixture.stateDir);
   });

--- a/extensions/memory-core/doctor-contract-api.test.ts
+++ b/extensions/memory-core/doctor-contract-api.test.ts
@@ -1844,7 +1844,7 @@ describe("memory-core doctor dreaming migration", () => {
       { id: "chunk-1", text: "remember this" },
     ]);
     await expect(fs.access(sharedAgentPath)).rejects.toThrow();
-    await expect(fs.access(`${legacyPath}.migrated`)).resolves.toBeUndefined();
+    await fs.access(`${legacyPath}.migrated`);
   });
 
   it("ignores transient memory SQLite files when discovering default sidecars", async () => {


### PR DESCRIPTION
## What Problem This Solves

Three positive doctor migration fixtures fail under Bun when an archive exists because they expect the successful return value of native filesystem access to be `undefined` rather than `null`.

## Why This Change Was Made

Await access to the expected archive directly in three assertions across the Codex and memory-core fixtures. Existing migrated content, source-absence, ownership results, and cleanup assertions remain unchanged. Seventeen other access sites are untouched.

## User Impact

These selected archive checks validate successful file access under both Node and Bun. No production, data format, schema, dependency, timeout, or protocol changes.

## Evidence

- Three existing positive migration cases passed under Node before the repair; Bun failed all three specifically on `null` versus `undefined`. All three pass under both runtimes afterward.
- Runs used isolated temporary HOME/state, the established macOS SQLite preload for Bun, original deadlines, and bounded process monitoring. All processes joined without caps. Other cases were not run locally.
- The full two-file changed gate passed, including all selected static/type/lint checks, with no additional runtime tests or full build. Fresh independent P0–P2 review passed with no actionable findings.
- The final two source hashes were verified before staging. Initial zero-selection startup attempts and the fail-fast baseline routing are retained and are not credited as passing proof.

This is limited fixture portability evidence, not a full doctor-suite or upstream runtime compatibility claim. Exact-head CI34141420084 and pull_request WorkflowSanity34141352194 passed, and hosted review is ready with no actionable findings.
