### PR TITLE
fix(ios): retain intent metadata during dead-code scans

### DIFF
--- a/apps/ios/Sources/StartLiveVoiceIntent.swift
+++ b/apps/ios/Sources/StartLiveVoiceIntent.swift
@@ -2,6 +2,7 @@ import AppIntents
 
 struct StartLiveVoiceIntent: AppIntent {
     static let title: LocalizedStringResource = "Start Live Voice"
+    // periphery:ignore - App Intents consumes this metadata for Siri and Shortcuts.
     static let description: IntentDescription? = IntentDescription(
         "Open the current chat in OpenClaw and start a voice conversation.")
     static let openAppWhenRun = true


### PR DESCRIPTION
Related: #141003, #140988

## What Problem This Solves

Resolves a problem where the iOS Periphery Dead Code workflow fails on the Siri and Shortcuts intent's description metadata. Run [34107728415](https://github.com/openclaw/openclaw/actions/runs/34107728415) reports exactly one unused declaration, `StartLiveVoiceIntent.description`.

## Why This Change Was Made

Preserve the description and add the existing member-level `periphery:ignore` annotation with its framework-consumption reason. Apple's [AppIntent.description contract](https://developer.apple.com/documentation/appintents/appintent/description) and the inspected SDK interface declare this property as intent metadata with a default implementation; removing the override would discard the custom description. There are no other iOS AppIntent declarations to copy. The same narrow annotation syntax is already used for framework callbacks in the macOS app.

## User Impact

Siri and Shortcuts retain the Start Live Voice description and existing behavior. Dead-code checking continues to cover the rest of the intent and app without a broader exclusion or configuration change.

## Evidence

- Downloaded `ios-periphery-dead-code-34107728415-1`: one `var.static description` finding at `Sources/StartLiveVoiceIntent.swift:5:16`; Periphery exit status 1.
- Independently reviewed the one-comment patch: no actionable findings through P2.
- `git diff --check`, the changed-file check lane, focused SwiftFormat, and SwiftLint passed (0 violations across 395 Swift files). The first changed-file attempt stopped at missing pinned Swift tooling; installed it and reran successfully.
- [Full iOS Periphery run 34141402880](https://github.com/openclaw/openclaw/actions/runs/34141402880) passed on head `520da5cce7d0440f10ece7bb62b0c94d05863226`, using pinned Periphery 3.8.0 and Xcode 26.6. Repository command from `apps/ios`: `periphery scan --config .periphery.yml --strict --format json --write-results <artifact>/periphery.json`. Downloaded `ios-periphery-dead-code-34141402880-1` and verified `periphery.json` is `[]` and `periphery.status` is `0`.
- [iOS smoke build and required CI gate](https://github.com/openclaw/openclaw/actions/runs/34141402901) passed. [Shared OpenClawKit Periphery](https://github.com/openclaw/openclaw/actions/runs/34141402864) passed on both platforms.
- ClawSweeper reviewed the same head and found no actionable correctness or security issues.
