### PR TITLE
fix(desktop): bind observer tickets and viewers to the requesting Gateway connection

### DIFF
--- a/docs/gateway/config-browser-ui-desktop.md
+++ b/docs/gateway/config-browser-ui-desktop.md
@@ -180,6 +180,11 @@ machine. It can attach to an existing loopback RFB server, or supervise a
 headless TigerVNC/XFCE desktop on Linux. It is a Labs feature and is off by
 default.
 
+Observer tokens and observer connections are bound to the Gateway connection
+that requested them. Ending or revoking that connection refuses unused tokens
+and closes its observers with `4006 authority_revoked`. Internal callers without
+a Gateway connection keep TTL-only tokens.
+
 ```json5
 {
   desktop: {

--- a/src/gateway/desktop/host-source.ts
+++ b/src/gateway/desktop/host-source.ts
@@ -10,6 +10,7 @@ import {
   type ManagedLinuxDesktopStatus,
 } from "./managed-linux.js";
 import { mintDesktopObserverToken } from "./observe-bridge.js";
+import type { DesktopObserveRequester } from "./observe-requester.js";
 import { classifyRfbSecurity, probeRfbServer, type RfbProbeResult } from "./rfb-probe.js";
 import type { DesktopSessionRegistry } from "./session-registry.js";
 
@@ -292,6 +293,7 @@ export function createHostDesktopSource(params: {
 export type HostDesktopService = {
   observe(params: {
     control: boolean;
+    requester?: DesktopObserveRequester;
     credentials?: { username?: string; password?: string };
   }): Promise<{
     transport: "rfb";
@@ -357,6 +359,7 @@ export function createHostDesktopService(params: {
         sourceKey: "host",
         ownerEpoch: 0,
         control: observeParams.control,
+        requester: observeParams.requester,
         attachment: acquired.attachment,
         ...(preauth ? { preauth } : {}),
       });

--- a/src/gateway/desktop/node-source.test.ts
+++ b/src/gateway/desktop/node-source.test.ts
@@ -8,6 +8,7 @@ import { NodeRegistry } from "../node-registry.js";
 import type { GatewayWsClient } from "../server/ws-types.js";
 import { createNodeDesktopService } from "./node-source.js";
 import { createNodeDesktopStreamBroker } from "./node-stream-broker.js";
+import * as observeBridge from "./observe-bridge.js";
 import { createDesktopSessionRegistry } from "./session-registry.js";
 
 const cleanups: Array<() => Promise<void>> = [];
@@ -122,6 +123,33 @@ function createFixture(boundary: "activation" | "pairing" | "attachment") {
 }
 
 describe("node desktop runtime policy", () => {
+  it("keeps requester authority on the observer ticket after node attachment", async () => {
+    const fixture = createFixture("attachment");
+    const mint = vi.spyOn(observeBridge, "mintDesktopObserverToken");
+    const controller = new AbortController();
+    const client = { invalidated: false };
+    const requester = {
+      signal: controller.signal,
+      isCurrent: () => !client.invalidated,
+    };
+    const observed = fixture.service.observe({
+      nodeId: "node",
+      control: false,
+      credentials: { password: "synthetic-password" },
+      requester,
+    });
+    await fixture.reached;
+    fixture.attached.resolve({ stream: new PassThrough(), auth: "vnc-password" });
+
+    await expect(observed).resolves.toMatchObject({ transport: "rfb", control: false });
+    const mintedRequester = mint.mock.calls[0]?.[0].requester;
+    expect(mintedRequester).toBe(requester);
+    expect(mintedRequester?.isCurrent()).toBe(true);
+    client.invalidated = true;
+    expect(mintedRequester?.isCurrent()).toBe(false);
+    expect(controller.signal.aborted).toBe(false);
+  });
+
   it.each(["activation", "pairing"] as const)(
     "does not dispatch after policy changes during %s",
     async (boundary) => {

--- a/src/gateway/desktop/node-source.ts
+++ b/src/gateway/desktop/node-source.ts
@@ -6,6 +6,7 @@ import type { NodeRegistry, NodeSession } from "../node-registry.js";
 import { DesktopCredentialsRequiredError } from "./host-source-errors.js";
 import type { NodeDesktopStreamBroker } from "./node-stream-broker.js";
 import { mintDesktopObserverToken } from "./observe-bridge.js";
+import type { DesktopObserveRequester } from "./observe-requester.js";
 import type { RfbPreauthDescriptor } from "./rfb-preauth.js";
 import type { DesktopSessionRegistry } from "./session-registry.js";
 
@@ -155,6 +156,7 @@ export function createNodeDesktopService(params: {
     async observe(request: {
       nodeId: string;
       control: boolean;
+      requester?: DesktopObserveRequester;
       credentials?: { username?: string; password?: string };
     }): Promise<NodeDesktopObserveResult> {
       const node = params.nodeRegistry.get(request.nodeId);
@@ -263,6 +265,7 @@ export function createNodeDesktopService(params: {
           sourceKey,
           ownerEpoch: session.ownerEpoch,
           control: request.control,
+          requester: request.requester,
           attachment,
           preauth,
         });

--- a/src/gateway/desktop/observe-bridge.test.ts
+++ b/src/gateway/desktop/observe-bridge.test.ts
@@ -14,6 +14,7 @@ import {
   handleDesktopObserveUpgrade,
   mintDesktopObserverToken,
 } from "./observe-bridge.js";
+import type { DesktopObserveRequester } from "./observe-requester.js";
 import type { RfbPreauthDescriptor } from "./rfb-preauth.js";
 
 const cleanup: Array<() => Promise<void>> = [];
@@ -63,6 +64,7 @@ async function createProxyHarness(
     getBufferedAmount?: (ws: WebSocket) => number;
     stream?: Duplex;
     preauth?: RfbPreauthDescriptor;
+    requester?: DesktopObserveRequester;
   } = {},
 ) {
   // macOS sockaddr_un cannot hold the test runner's nested temporary path.
@@ -125,6 +127,7 @@ async function createProxyHarness(
       ? { kind: "stream", streamId: "synthetic-stream" }
       : { kind: "unix-socket", socketPath: localSocketPath },
     ...(params.preauth ? { preauth: params.preauth } : {}),
+    requester: params.requester,
   });
   const ws = new WebSocket(
     `ws://127.0.0.1:${address.port}${DESKTOP_OBSERVE_PATH}?token=${minted.token}`,
@@ -246,6 +249,105 @@ describe.runIf(process.platform !== "win32")("worker desktop observer proxy", ()
     await expectUnauthorizedObserver(observerUrl.toString());
     observerUrl.searchParams.set("token", "0".repeat(48));
     await expectUnauthorizedObserver(observerUrl.toString());
+  });
+
+  it.each([
+    "invalidated",
+    "invalidate-after-mint",
+    "abort-before-mint",
+    "abort-after-mint",
+  ] as const)(
+    "refuses an unused requester token before its TTL expires (%s)",
+    async (revocation) => {
+      const harness = await createProxyHarness();
+      const controller = new AbortController();
+      let invalidated = revocation === "invalidated";
+      if (revocation === "abort-before-mint") {
+        controller.abort();
+      }
+      const minted = mintDesktopObserverToken({
+        sourceKey: "worker:revoked",
+        ownerEpoch: 1,
+        control: false,
+        attachment: { kind: "unix-socket", socketPath: "/tmp/revoked-desktop.sock" },
+        requester: {
+          signal: controller.signal,
+          isCurrent: () => !invalidated && !controller.signal.aborted,
+        },
+      });
+      if (revocation === "abort-after-mint") {
+        controller.abort();
+      }
+      invalidated = true;
+      expect(controller.signal.aborted).toBe(revocation.startsWith("abort-"));
+      expect(minted.expiresAtMs).toBeGreaterThan(Date.now());
+      const observerUrl = new URL(harness.observerUrl);
+      observerUrl.searchParams.set("token", minted.token);
+      await expectUnauthorizedObserver(observerUrl.toString());
+    },
+  );
+
+  it.each(["desktop", "browser", "abort"] as const)(
+    "retires an attached requester before relaying revoked bytes (%s)",
+    async (trigger) => {
+      const controller = new AbortController();
+      const client = { invalidated: false };
+      const received: Buffer[] = [];
+      const stream = new Duplex({
+        read() {},
+        write(chunk, _encoding, callback) {
+          received.push(Buffer.from(chunk));
+          callback();
+        },
+      });
+      const harness = await createProxyHarness({
+        control: true,
+        stream,
+        requester: {
+          signal: controller.signal,
+          isCurrent: () => !client.invalidated && !controller.signal.aborted,
+        },
+      });
+      const frames: Buffer[] = [];
+      harness.ws.on("message", (data) => frames.push(Buffer.from(data as Buffer)));
+      const closed = new Promise<[number, string]>((resolve) => {
+        harness.ws.once("close", (code, reason) => resolve([code, reason.toString()]));
+      });
+      client.invalidated = true;
+      if (trigger === "abort") {
+        controller.abort();
+      } else if (trigger === "desktop") {
+        stream.push(Buffer.from("revoked framebuffer"));
+        harness.ws.send(Buffer.from([4, 1, 0, 0, 0, 0, 0, 65]));
+      } else {
+        harness.ws.send(Buffer.from([4, 1, 0, 0, 0, 0, 0, 65]));
+      }
+      await expect.poll(() => harness.ws.readyState).toBe(WebSocket.CLOSED);
+      await expect(closed).resolves.toEqual([4006, "authority_revoked"]);
+      expect(frames).toEqual([]);
+      expect(received).toEqual([]);
+      expect(controller.signal.aborted).toBe(trigger === "abort");
+      expect(stream.destroyed).toBe(true);
+      expect(harness.release).toHaveBeenCalledOnce();
+    },
+  );
+
+  it("keeps relaying both directions while the requester remains current", async () => {
+    const controller = new AbortController();
+    const harness = await createProxyHarness({
+      control: true,
+      requester: { signal: controller.signal, isCurrent: () => true },
+    });
+    const greeting = Buffer.from("RFB 003.008\n");
+    const fromDesktop = new Promise<Buffer>((resolve) => {
+      harness.ws.once("message", (data) => resolve(Buffer.from(data as Buffer)));
+    });
+    harness.desktopPeer.write(greeting);
+    await expect(fromDesktop).resolves.toEqual(greeting);
+    const fromBrowser = readSocketBytes(harness.desktopPeer, greeting.length);
+    harness.ws.send(greeting);
+    await expect(fromBrowser).resolves.toEqual(greeting);
+    expect(harness.release).not.toHaveBeenCalled();
   });
 
   it("drops view-only input while forwarding framebuffer requests", async () => {

--- a/src/gateway/desktop/observe-bridge.ts
+++ b/src/gateway/desktop/observe-bridge.ts
@@ -6,6 +6,7 @@ import { createOneTimeTicketStore } from "../../shared/one-time-ticket-store.js"
 import { rejectWebSocketUpgrade } from "../../shared/websocket-upgrade-reject.js";
 import { startWebSocketKeepalive } from "../websocket-keepalive.js";
 import { connectRfbAttachment, type DesktopRfbAttachment } from "./attachment.js";
+import type { DesktopObserveRequester } from "./observe-requester.js";
 import {
   preauthenticateRfb,
   RfbPreauthBuffer,
@@ -29,6 +30,7 @@ type DesktopCloseTrigger =
   | "browser-error"
   | "stream-close"
   | "stream-error"
+  | "authority-revoked"
   | "invalid-view-only-stream"
   | "authentication-failed";
 
@@ -38,6 +40,7 @@ type DesktopObserverTokenEntry = {
   control: boolean;
   attachment: DesktopRfbAttachment;
   preauth?: RfbPreauthDescriptor;
+  requester?: DesktopObserveRequester;
 };
 
 const observerTokens = createOneTimeTicketStore<DesktopObserverTokenEntry>({ ttlMs: TOKEN_TTL_MS });
@@ -49,10 +52,15 @@ export function mintDesktopObserverToken(params: {
   control: boolean;
   attachment: DesktopRfbAttachment;
   preauth?: RfbPreauthDescriptor;
+  requester?: DesktopObserveRequester;
   nowMs?: number;
 }): { token: string; expiresAtMs: number } {
   const { nowMs, ...payload } = params;
-  return observerTokens.mint(payload, { nowMs });
+  return observerTokens.mint(payload, {
+    nowMs,
+    revokeSignal:
+      params.requester?.isCurrent() === false ? AbortSignal.abort() : params.requester?.signal,
+  });
 }
 
 function consumeDesktopObserverToken(
@@ -148,7 +156,7 @@ export function handleDesktopObserveUpgrade(
   }
   const token = resource.searchParams.get("token") ?? "";
   const entry = consumeDesktopObserverToken(token);
-  if (!entry) {
+  if (!entry || entry.requester?.isCurrent() === false) {
     rejectWebSocketUpgrade(socket, { status: 401 });
     return true;
   }
@@ -193,6 +201,7 @@ export function handleDesktopObserveUpgrade(
       }
       // Keep the first cleanup decision when its destroyed stream emits a later close.
       closeCause = { trigger, code };
+      entry.requester?.signal?.removeEventListener("abort", onRequesterGone);
       stopKeepalive();
       clearInterval(resumeTimer);
       resumeTimer = undefined;
@@ -205,6 +214,7 @@ export function handleDesktopObserveUpgrade(
         ws.close(code, reason);
       }
     };
+    const onRequesterGone = () => closeBoth(4006, "authority_revoked", "authority-revoked");
 
     const startSplice = (browserRemainder: Buffer = Buffer.alloc(0), preauthenticated = false) => {
       const clientMessageFilter = entry.control
@@ -213,6 +223,10 @@ export function handleDesktopObserveUpgrade(
             startPhase: preauthenticated ? "clientInit" : "version",
           });
       const forwardClientChunk = (chunk: Buffer) => {
+        if (entry.requester?.isCurrent() === false) {
+          onRequesterGone();
+          return;
+        }
         const result = clientMessageFilter?.filter(chunk);
         if (result && "error" in result) {
           closeBoth(1008, "invalid view-only RFB stream", "invalid-view-only-stream");
@@ -231,6 +245,10 @@ export function handleDesktopObserveUpgrade(
       });
       desktopSocket.on("data", (chunk) => {
         if (closeCause || ws.readyState !== WebSocket.OPEN) {
+          return;
+        }
+        if (entry.requester?.isCurrent() === false) {
+          onRequesterGone();
           return;
         }
         ws.send(chunk, { binary: true });
@@ -273,6 +291,12 @@ export function handleDesktopObserveUpgrade(
         "stream-error",
       ),
     );
+
+    entry.requester?.signal?.addEventListener("abort", onRequesterGone, { once: true });
+    if (entry.requester?.signal?.aborted || entry.requester?.isCurrent() === false) {
+      onRequesterGone();
+      return;
+    }
 
     if (!entry.preauth) {
       startSplice();

--- a/src/gateway/desktop/observe-requester.ts
+++ b/src/gateway/desktop/observe-requester.ts
@@ -1,0 +1,26 @@
+import type { GatewayClient } from "../server-methods/client-types.js";
+
+export type DesktopObserveRequester = {
+  connId?: string;
+  signal?: AbortSignal;
+  isCurrent: () => boolean;
+};
+
+export function resolveDesktopObserveRequester(options: {
+  client: GatewayClient | null;
+  hasCurrentClientAuthority?: () => boolean;
+}): DesktopObserveRequester | undefined {
+  const { client, hasCurrentClientAuthority } = options;
+  if (!client) {
+    return undefined;
+  }
+  // Invalidation precedes the transport close event and its abort signal.
+  return {
+    connId: client.connId,
+    signal: client.connectionSignal,
+    isCurrent: () =>
+      client.invalidated !== true &&
+      !client.connectionSignal?.aborted &&
+      hasCurrentClientAuthority?.() !== false,
+  };
+}

--- a/src/gateway/server-methods/environments.desktop.test.ts
+++ b/src/gateway/server-methods/environments.desktop.test.ts
@@ -1,25 +1,50 @@
 import net from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GATEWAY_CLIENT_IDS } from "../../../packages/gateway-protocol/src/client-info.js";
 import { ErrorCodes } from "../../../packages/gateway-protocol/src/index.js";
 import { HostDesktopCredentialsRequiredError } from "../desktop/host-source-errors.js";
 import { createHostDesktopService } from "../desktop/host-source.js";
 import { NODE_DESKTOP_SERVICE_CONTEXT } from "../desktop/node-source-context.js";
+import * as observeBridge from "../desktop/observe-bridge.js";
+import type { DesktopObserveRequester } from "../desktop/observe-requester.js";
 import { createDesktopSessionRegistry } from "../desktop/session-registry.js";
+import type { GatewayClient } from "./client-types.js";
 import { environmentsHandlers } from "./environments.js";
 
 const cleanups: Array<() => Promise<void>> = [];
 
 afterEach(async () => {
   await Promise.all(cleanups.splice(0).map((cleanup) => cleanup()));
+  vi.restoreAllMocks();
 });
+
+function createRequesterClient(signal: AbortSignal): GatewayClient {
+  return {
+    connId: "desktop-requester",
+    connectionSignal: signal,
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: { id: GATEWAY_CLIENT_IDS.CLI, version: "test", platform: "test", mode: "cli" },
+    },
+  };
+}
 
 async function invoke(
   method: "desktop.observe" | "worker.desktop.observe",
   params: unknown,
   context: object,
+  client: GatewayClient | null = null,
+  hasCurrentClientAuthority?: () => boolean,
 ) {
   const respond = vi.fn();
-  await environmentsHandlers[method]?.({ params, respond, context } as never);
+  await environmentsHandlers[method]?.({
+    params,
+    respond,
+    context,
+    client,
+    hasCurrentClientAuthority,
+  } as never);
   const call = respond.mock.calls.at(0);
   if (!call) {
     throw new Error("expected desktop handler response");
@@ -28,6 +53,60 @@ async function invoke(
 }
 
 describe("desktop gateway methods", () => {
+  it.each([
+    { source: "host", method: "desktop.observe", params: { source: { kind: "host" } } },
+    {
+      source: "node",
+      method: "desktop.observe",
+      params: { source: { kind: "node", nodeId: "node-1" } },
+    },
+    {
+      source: "environment",
+      method: "desktop.observe",
+      params: { source: { kind: "environment", environmentId: "worker:one" } },
+    },
+    {
+      source: "worker alias",
+      method: "worker.desktop.observe",
+      params: { environmentId: "worker:one" },
+    },
+  ] as const)("binds $source observers to live requester authority", async ({ method, params }) => {
+    const controller = new AbortController();
+    const client = createRequesterClient(controller.signal);
+    let authorityCurrent = true;
+    const observe = vi.fn(async (_request: { requester?: DesktopObserveRequester }) => ({
+      transport: "rfb",
+      wsPath: "/desktop/observe?token=fixed",
+      expiresAtMs: 42,
+    }));
+    const [ok] = await invoke(
+      method,
+      params,
+      {
+        getRuntimeConfig: () => ({ desktop: { host: { enabled: true } } }),
+        hostDesktopService: { observe },
+        [NODE_DESKTOP_SERVICE_CONTEXT]: { observe },
+        workerEnvironmentService: { observeDesktop: observe },
+      },
+      client,
+      () => authorityCurrent,
+    );
+    expect(ok).toBe(true);
+    const requester = observe.mock.calls[0]?.[0].requester;
+    expect(requester).toMatchObject({ connId: client.connId, signal: controller.signal });
+    expect(requester?.isCurrent()).toBe(true);
+    client.invalidated = true;
+    expect(controller.signal.aborted).toBe(false);
+    expect(requester?.isCurrent()).toBe(false);
+    client.invalidated = false;
+    authorityCurrent = false;
+    expect(requester?.isCurrent()).toBe(false);
+    authorityCurrent = true;
+    expect(requester?.isCurrent()).toBe(true);
+    controller.abort();
+    expect(requester?.isCurrent()).toBe(false);
+  });
+
   it("names the Labs config and restart when host desktop is disabled", async () => {
     const [ok, , error] = await invoke(
       "desktop.observe",
@@ -43,6 +122,9 @@ describe("desktop gateway methods", () => {
   });
 
   it("returns a host observer token and auth from a real loopback RFB server", async () => {
+    const mint = vi.spyOn(observeBridge, "mintDesktopObserverToken");
+    const controller = new AbortController();
+    const client = createRequesterClient(controller.signal);
     const sockets = new Set<net.Socket>();
     const server = net.createServer((socket) => {
       sockets.add(socket);
@@ -77,6 +159,7 @@ describe("desktop gateway methods", () => {
         getRuntimeConfig: () => ({ desktop: { host: config } }),
         hostDesktopService: createHostDesktopService({ config, registry }),
       },
+      client,
     );
     expect(ok).toBe(true);
     expect(result).toMatchObject({
@@ -85,6 +168,12 @@ describe("desktop gateway methods", () => {
       auth: "vnc-password",
     });
     expect(result.wsPath).toMatch(/^\/desktop\/observe\?token=[a-f0-9]{48}$/u);
+    const requester = mint.mock.calls[0]?.[0].requester;
+    expect(requester?.signal).toBe(controller.signal);
+    expect(requester?.isCurrent()).toBe(true);
+    client.invalidated = true;
+    expect(requester?.isCurrent()).toBe(false);
+    expect(controller.signal.aborted).toBe(false);
   });
 
   it("keeps the worker alias identical to the generic environment arm", async () => {

--- a/src/gateway/server-methods/environments.ts
+++ b/src/gateway/server-methods/environments.ts
@@ -20,6 +20,10 @@ import { NODE_DESKTOP_STREAM_COMMAND } from "../../shared/node-desktop-stream.js
 import type { NodeListNode } from "../../shared/node-list-types.js";
 import { isDesktopCredentialsRequiredError } from "../desktop/host-source-errors.js";
 import { getNodeDesktopService } from "../desktop/node-source-context.js";
+import {
+  resolveDesktopObserveRequester,
+  type DesktopObserveRequester,
+} from "../desktop/observe-requester.js";
 import { WRITE_SCOPE, authorizeOperatorScopesForRequiredScope } from "../method-scopes.js";
 import { createKnownNodeCatalog, listKnownNodes } from "../node-catalog.js";
 import {
@@ -271,6 +275,7 @@ async function respondDesktopObserve(params: {
   request: DesktopObserveParams;
   respond: RespondFn;
   context: GatewayRequestContext;
+  requester?: DesktopObserveRequester;
 }) {
   if (params.request.source.kind === "host") {
     if (params.context.getRuntimeConfig().desktop?.host?.enabled !== true) {
@@ -300,6 +305,7 @@ async function respondDesktopObserve(params: {
         true,
         await params.context.hostDesktopService.observe({
           control: params.request.control ?? false,
+          requester: params.requester,
           ...("credentials" in params.request && params.request.credentials
             ? { credentials: params.request.credentials }
             : {}),
@@ -353,6 +359,7 @@ async function respondDesktopObserve(params: {
         await service.observe({
           nodeId: params.request.source.nodeId,
           control: params.request.control ?? false,
+          requester: params.requester,
           ...("credentials" in params.request && params.request.credentials
             ? { credentials: params.request.credentials }
             : {}),
@@ -395,6 +402,7 @@ async function respondDesktopObserve(params: {
     const result = await service.observeDesktop({
       environmentId: params.request.source.environmentId,
       control: params.request.control ?? false,
+      requester: params.requester,
     });
     params.respond(true, result, undefined);
   } catch (error) {
@@ -577,7 +585,13 @@ export const environmentsHandlers: GatewayRequestHandlers = {
       "worker environment destruction failed",
     );
   },
-  "worker.desktop.observe": async ({ params, respond, context }) => {
+  "worker.desktop.observe": async ({
+    params,
+    respond,
+    context,
+    client,
+    hasCurrentClientAuthority,
+  }) => {
     if (
       !assertValidParams(
         params,
@@ -595,6 +609,7 @@ export const environmentsHandlers: GatewayRequestHandlers = {
       },
       respond,
       context,
+      requester: resolveDesktopObserveRequester({ client, hasCurrentClientAuthority }),
     });
   },
   "worker.desktop.launch": async ({ params, respond, context }) => {
@@ -615,11 +630,16 @@ export const environmentsHandlers: GatewayRequestHandlers = {
       context,
     });
   },
-  "desktop.observe": async ({ params, respond, context }) => {
+  "desktop.observe": async ({ params, respond, context, client, hasCurrentClientAuthority }) => {
     if (!assertValidParams(params, validateDesktopObserveParams, "desktop.observe", respond)) {
       return;
     }
-    await respondDesktopObserve({ request: params, respond, context });
+    await respondDesktopObserve({
+      request: params,
+      respond,
+      context,
+      requester: resolveDesktopObserveRequester({ client, hasCurrentClientAuthority }),
+    });
   },
   "desktop.launch": async ({ params, respond, context }) => {
     if (!assertValidParams(params, validateDesktopLaunchParams, "desktop.launch", respond)) {

--- a/src/gateway/worker-environments/environment-access.test.ts
+++ b/src/gateway/worker-environments/environment-access.test.ts
@@ -1,9 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
 } from "../../state/openclaw-state-db.js";
+import * as observeBridge from "../desktop/observe-bridge.js";
 import { STALE_WORKER_BUILD_REASON } from "./admission.js";
 import type { WorkerNodeDesktopCarrier } from "./node-desktop-carrier.js";
 import { createWorkerNodePortalCarrier } from "./portal-node-carrier.js";
@@ -16,6 +17,7 @@ type WorkerEnvironmentServiceError = support.WorkerEnvironmentServiceError;
 
 describe("worker environment service", () => {
   support.setupWorkerEnvironmentServiceSuite();
+  afterEach(() => vi.restoreAllMocks());
 
   it("drains all tunnel owners before reporting an independent shutdown failure", async () => {
     const shutdownError = new Error("SSH tunnel shutdown failed");
@@ -537,6 +539,12 @@ describe("worker environment service", () => {
   });
 
   it("acquires a desktop tunnel and mints a one-shot websocket path", async () => {
+    const mint = vi.spyOn(observeBridge, "mintDesktopObserverToken");
+    const client = { invalidated: false };
+    const requester = {
+      signal: new AbortController().signal,
+      isCurrent: () => !client.invalidated,
+    };
     const record = support.seedReadyDesktop("worker-desktop-observe");
     const desktopPassword = ["desktop", String.fromCharCode(45), "secret"].join("");
     const acquire = vi.fn(async () => ({
@@ -558,7 +566,11 @@ describe("worker environment service", () => {
     const workerService = support.createService(support.createProvider(), { tunnelManager });
 
     await expect(
-      workerService.observeDesktop({ environmentId: record.environmentId, control: true }),
+      workerService.observeDesktop({
+        environmentId: record.environmentId,
+        control: true,
+        requester,
+      }),
     ).resolves.toMatchObject({
       transport: "rfb",
       wsPath: expect.stringMatching(/^\/desktop\/observe\?token=[a-f0-9]{48}$/u),
@@ -575,9 +587,16 @@ describe("worker environment service", () => {
         resolveIdentity: expect.any(Function),
       }),
     );
+    const mintedRequester = mint.mock.calls[0]?.[0].requester;
+    expect(mintedRequester).toBe(requester);
+    expect(mintedRequester?.isCurrent()).toBe(true);
+    client.invalidated = true;
+    expect(mintedRequester?.isCurrent()).toBe(false);
+    expect(requester.signal.aborted).toBe(false);
   });
 
   it("routes a node-backed desktop through its durable node carrier without SSH", async () => {
+    const requester = { signal: new AbortController().signal, isCurrent: () => true };
     const record = support.seedReadyNodeDesktop("worker-node-desktop-access");
     const order: string[] = [];
     const observe = vi.fn(async () => ({
@@ -611,7 +630,11 @@ describe("worker environment service", () => {
     });
 
     await expect(
-      workerService.observeDesktop({ environmentId: record.environmentId, control: true }),
+      workerService.observeDesktop({
+        environmentId: record.environmentId,
+        control: true,
+        requester,
+      }),
     ).resolves.toEqual({
       transport: "rfb",
       wsPath: "/desktop/observe?token=node-carrier",
@@ -626,6 +649,7 @@ describe("worker environment service", () => {
         desktop: support.DESKTOP,
       }),
       control: true,
+      requester,
     });
 
     await expect(

--- a/src/gateway/worker-environments/environment-access.ts
+++ b/src/gateway/worker-environments/environment-access.ts
@@ -1,6 +1,7 @@
 import type { OpenClawConfig } from "../../config/types.js";
 import { withTimeout } from "../../infra/fs-safe.js";
 import type { WorkerProvider } from "../../plugins/types.js";
+import type { DesktopObserveRequester } from "../desktop/observe-requester.js";
 import {
   StaleWorkerBuildError,
   verifyWorkerAdmissionHandshake,
@@ -227,6 +228,7 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
   const observeDesktop = async (request: {
     environmentId: string;
     control: boolean;
+    requester?: DesktopObserveRequester;
   }): Promise<WorkerDesktopObserveResult> => {
     const stopping = options.isStopping();
     if (options.getConfig().cloudWorkers?.desktop !== true) {
@@ -265,6 +267,7 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
         nodeStartup = nodeDesktop.observe({
           record,
           control: request.control,
+          requester: request.requester,
         });
         return;
       }
@@ -283,6 +286,7 @@ export function createWorkerEnvironmentAccess(options: WorkerEnvironmentAccessOp
       sourceKey: request.environmentId,
       ownerEpoch,
       control: request.control,
+      requester: request.requester,
       attachment: acquired.attachment,
       nowMs: now(),
     });

--- a/src/gateway/worker-environments/node-desktop-carrier.test.ts
+++ b/src/gateway/worker-environments/node-desktop-carrier.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { GATEWAY_CLIENT_IDS } from "../../../packages/gateway-protocol/src/client-info.js";
 import { NODE_WORKER_SUPERVISOR_PROTOCOL_FEATURE } from "../../infra/node-runner-inventory.js";
 import type { NodeDesktopStreamBroker } from "../desktop/node-stream-broker.js";
+import * as observeBridge from "../desktop/observe-bridge.js";
 import { createDesktopSessionRegistry } from "../desktop/session-registry.js";
 import type {
   NodeWorkerSupervisorNodeProof,
@@ -105,6 +106,12 @@ describe("worker node desktop carrier", () => {
   afterEach(() => vi.restoreAllMocks());
 
   it("observes an exact durable node desktop without SSH and preauthenticates it", async () => {
+    const mint = vi.spyOn(observeBridge, "mintDesktopObserverToken");
+    const client = { invalidated: false };
+    const requester = {
+      signal: new AbortController().signal,
+      isCurrent: () => !client.invalidated,
+    };
     const record = support.seedReadyNodeDesktop("worker-node-desktop-observe");
     let nowMs = 1_000;
     vi.spyOn(Date, "now").mockImplementation(() => nowMs);
@@ -120,7 +127,7 @@ describe("worker node desktop carrier", () => {
     });
     carrier.bindRuntime({ transport: transport.transport, streamBroker: streamed.broker });
 
-    const observing = carrier.observe({ record, control: false });
+    const observing = carrier.observe({ record, control: false, requester });
     await support.waitForFast(() => expect(transport.invoke).toHaveBeenCalledOnce());
     nowMs = 50_000;
     streamed.attachNext();
@@ -132,6 +139,12 @@ describe("worker node desktop carrier", () => {
       control: false,
     });
     expect(await observing).not.toHaveProperty("vncPassword");
+    const mintedRequester = mint.mock.calls[0]?.[0].requester;
+    expect(mintedRequester).toBe(requester);
+    expect(mintedRequester?.isCurrent()).toBe(true);
+    client.invalidated = true;
+    expect(mintedRequester?.isCurrent()).toBe(false);
+    expect(requester.signal.aborted).toBe(false);
     expect(transport.invoke).toHaveBeenCalledWith(
       expect.objectContaining({
         params: {

--- a/src/gateway/worker-environments/node-desktop-carrier.ts
+++ b/src/gateway/worker-environments/node-desktop-carrier.ts
@@ -5,6 +5,7 @@ import {
 } from "../../infra/node-commands.js";
 import type { WorkerDesktopApp, WorkerDesktopEndpoint } from "../../plugins/types.js";
 import type { NodeDesktopStreamBroker } from "../desktop/node-stream-broker.js";
+import type { DesktopObserveRequester } from "../desktop/observe-requester.js";
 import {
   DesktopSessionStaleOwnerError,
   type DesktopSessionRegistry,
@@ -263,6 +264,7 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
   const observe = async (request: {
     record: WorkerEnvironmentRecord;
     control: boolean;
+    requester?: DesktopObserveRequester;
   }): Promise<WorkerDesktopObserveResult> => {
     const binding = snapshotNodeDesktopBinding(request.record);
     const active: ActiveNodeDesktopStream = {
@@ -350,6 +352,7 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
         sourceKey: binding.environmentId,
         ownerEpoch: binding.ownerEpoch,
         control: request.control,
+        requester: request.requester,
         attachment,
         preauth: {
           auth: "vnc-password",

--- a/src/gateway/worker-environments/service-contract.ts
+++ b/src/gateway/worker-environments/service-contract.ts
@@ -5,6 +5,7 @@ import type {
   WorkerMachineOption,
   WorkerProfile,
 } from "../../plugins/capability-provider.types.js";
+import type { DesktopObserveRequester } from "../desktop/observe-requester.js";
 import type {
   WorkerPlacementMoveSource,
   WorkerPlacementMoveTarget,
@@ -81,6 +82,7 @@ export type WorkerEnvironmentServiceContract = {
   observeDesktop(request: {
     environmentId: string;
     control: boolean;
+    requester?: DesktopObserveRequester;
   }): Promise<WorkerDesktopObserveResult>;
   launchDesktopApp(request: {
     environmentId: string;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where a Desktop panel observer could outlive its operator's authority: `desktop.observe` minted a one-shot token and relayed RFB bytes on a separate WebSocket, but neither the unconsumed token nor the attached observer was bound to the Gateway connection that requested it. A device whose token was revoked, or any client that disconnected, could still redeem the token within its 60 s TTL and keep receiving framebuffer bytes (and, with `control`, keep sending input). PR #141031 closed the same class of gap for the browser screencast; this brings the desktop observer to parity.

## Why This Change Was Made

The `desktop.observe` handler now derives a requester from the calling client (`connectionSignal` plus a live predicate over the synchronous `invalidated` marker and current client authority) and threads it through the host, node, and worker-environment sources into the observer bridge. Unconsumed tokens are revoked when the connection ends (via the shared ticket store's `revokeSignal`), redemption is refused when the requester is no longer current, and both relay directions are fenced per chunk: a revoked requester's observer closes with `4006 authority_revoked` before the next frame is forwarded and before any further input reaches the desktop. Internal callers without a connection keep TTL-only tokens, as documented.

## User Impact

Revoking a device token or disconnecting an operator now ends that operator's desktop observation immediately, including observers whose socket close handshake is still pending. No change for ordinary sessions.

## Evidence

- Suites: `node scripts/run-vitest.mjs src/gateway/desktop src/gateway/worker-environments/environment-access.test.ts src/gateway/worker-environments/node-desktop-carrier.test.ts src/gateway/server-methods/environments.desktop.test.ts src/shared/one-time-ticket-store.test.ts` → 182 + 17 passed. New cases: stale requester refused at redemption before its signal aborts and within TTL; signal abort revokes an unconsumed token; an attached observer whose requester is invalidated while its socket close never fires gets no further desktop chunk, forwards no input, and closes with `[4006, "authority_revoked"]`; a current requester keeps relaying; requester reaches the mint for host, node, and environment sources.
- `node scripts/check-changed.mjs` clean (core-only change).
- Live proof (loopback RFB 3.8 stub with VncAuth, isolated Gateway built from this branch, repository Gateway client): (1) mint via a connection, close it, then attempt the observer upgrade → **HTTP 401**; (2) mint on a live connection, attach, receive `RFB 003.008` plus five more frames, then close the minting connection → observer closed with **4006 `authority_revoked` in 1 ms**, **0 frames** during the following 1.1 s quiet window.
- Codex autoreview (P0/P1): scoped-clean, no P0/P1 findings.
