### PR TITLE
feat(agents): export and import portable agent templates

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -1308,6 +1308,10 @@
     "target": "智能体"
   },
   {
+    "source": "Agent templates",
+    "target": "智能体模板"
+  },
+  {
     "source": "fs-safe Cleanup Plan",
     "target": "fs-safe Cleanup Plan"
   },

--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -3,6 +3,7 @@ summary: "CLI reference for `openclaw agents` (roles, teams, workspaces, routing
 read_when:
   - You want multiple isolated agents (workspaces + routing + auth)
   - You want to create an agent from a role or set up a coordinated team
+  - You want to export or import a portable agent template
 title: "Agents"
 ---
 
@@ -25,6 +26,8 @@ openclaw agents add work --workspace ~/.openclaw/workspace-work
 openclaw agents add work --workspace ~/.openclaw/workspace-work --bind telegram:*
 openclaw agents add ops --workspace ~/.openclaw/workspace-ops --bind telegram:ops --non-interactive
 openclaw agents add research --role researcher --non-interactive
+openclaw agents export research --out ./research-template
+openclaw agents import ./research-template --id research-copy --non-interactive
 openclaw agents team create --non-interactive
 openclaw agents bindings
 openclaw agents bind --agent work --bind telegram:ops
@@ -76,6 +79,56 @@ standard specialist ids; use the team command to create and wire all four agents
 Unknown roles are rejected with the available role names. A workspace with an
 unfinished bootstrap cannot adopt a role; complete its bootstrap or choose a
 new workspace.
+
+<a id="agents-export" />
+
+### `agents export <id>`
+
+Options: `--out <dir>` (required), `--force`, `--json`.
+
+Exports a portable template directory containing `manifest.json`,
+`workspace/AGENTS.md`, `workspace/SOUL.md`, `workspace/IDENTITY.md`, and optional
+`automations.json`. The manifest carries identity, explicit agent-level skills
+and model settings, and delegation settings. It does not copy inherited skills
+or model defaults.
+
+The output directory must be empty unless `--force` is supplied. The omissions
+report identifies excluded material, including `USER.md`, memory, credentials,
+sessions, and unsupported automations. Only `agentTurn` jobs both owned by and
+executed by the exported agent qualify; `systemEvent`, `command`, and `script`
+payloads are skipped. Automations omit delivery destinations and runtime state.
+
+Export refuses probable secrets in Markdown or JSON and reports the file and
+line without printing the matched value. Remove the secret from the source and
+retry; there is no `--allow-secrets` bypass. Detection is a conservative check,
+so review the bundle for sensitive content before sharing it. Embedded absolute
+local paths must also be removed for portability.
+
+### `agents import <dir>`
+
+Options: `--id <newId>`, `--workspace <dir>`, `--non-interactive`, `--json`.
+
+When omitted, `--id` defaults to the normalized identity name from the manifest;
+`--workspace` uses the normal workspace default for that agent id.
+
+Validates a template, shows a summary, and confirms before writing in interactive
+mode. Use `--non-interactive` for unattended import. `--json` returns a structured
+summary. Import refuses an existing agent id or a workspace containing files;
+choose a new id and workspace instead of overwriting an existing agent.
+
+The new agent receives the template identity and workspace program files,
+explicit skills and model settings, and `delegationMode` unchanged. Delegation
+targets remain agent ids: import keeps only ids already present in the target
+installation and warns with the dropped ids. If all targets are dropped,
+`subagents.allowAgents` is omitted. No role-name matching occurs.
+
+Imported automations are created **disabled**, with their owner and execution
+agent retargeted to the new id. Review their instructions and schedules before
+enabling them. Import skips the identity ceremony and creates no `BOOTSTRAP.md`.
+
+Both commands enforce file size and path restrictions. See the
+[Agent template format](/reference/agent-templates) for the exact manifest,
+automation fields, exclusions, and limits.
 
 ### `agents team create`
 

--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -102,7 +102,9 @@ Export refuses probable secrets in Markdown or JSON and reports the file and
 line without printing the matched value. Remove the secret from the source and
 retry; there is no `--allow-secrets` bypass. Detection is a conservative check,
 so review the bundle for sensitive content before sharing it. Embedded absolute
-local paths must also be removed for portability.
+local paths produce warnings while export proceeds: `Review before sharing:`
+lines in human output and a `warnings` array with `--json`. Replace
+machine-specific paths before sharing. Import preserves embedded paths.
 
 ### `agents import <dir>`
 

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -159,6 +159,38 @@ separate workspaces. All ids are checked for conflicts before creation. See
 [`agents team create`](/cli/agents#agents-team-create) for flags and examples,
 or use the team choice during [onboarding](/start/wizard#choose-one-agent-or-a-team).
 
+## Sharing an agent
+
+Export an agent's reusable instructions and settings as a portable template:
+
+```bash
+openclaw agents export researcher --out ./research-template
+```
+
+Review the bundle and omissions report before sharing the directory. It contains
+the agent's identity, `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, explicit skills and
+model settings, delegation settings, and supported agent-turn automations.
+Personal files, `USER.md`, memory, credentials, sessions, and routing bindings
+are excluded. Probable secrets and embedded absolute local paths cause export
+to fail so you can remove them first.
+
+On the receiving installation, import into a new agent and workspace:
+
+```bash
+openclaw agents import ./research-template --id research-copy --workspace ~/agents/research-copy
+openclaw agents list
+```
+
+Import confirms a summary before writing. It preserves only delegation target
+ids that already exist locally and warns about the others; it does not resolve
+roles or create missing specialists. Skills are an allowlist, not bundled skill
+code, and model credentials must already be available on the receiving install.
+Imported automations start disabled and require review before enabling. The
+workspace has its identity set and needs no bootstrap ceremony.
+
+See [Template commands](/cli/agents#agents-export) for flags and
+[Agent template format](/reference/agent-templates) for the portable contract.
+
 ## Quick start
 
 <Steps>

--- a/docs/concepts/multi-agent.md
+++ b/docs/concepts/multi-agent.md
@@ -171,8 +171,9 @@ Review the bundle and omissions report before sharing the directory. It contains
 the agent's identity, `AGENTS.md`, `SOUL.md`, `IDENTITY.md`, explicit skills and
 model settings, delegation settings, and supported agent-turn automations.
 Personal files, `USER.md`, memory, credentials, sessions, and routing bindings
-are excluded. Probable secrets and embedded absolute local paths cause export
-to fail so you can remove them first.
+are excluded. Probable secrets cause export to fail so you can remove them
+first. Embedded absolute local paths produce review warnings; export and import
+preserve the content. Replace machine-specific references before sharing.
 
 On the receiving installation, import into a new agent and workspace:
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2325,6 +2325,7 @@
               {
                 "group": "Templates",
                 "pages": [
+                  "reference/agent-templates",
                   "reference/AGENTS.default",
                   "reference/templates/AGENTS",
                   "reference/templates/BOOT",

--- a/docs/reference/agent-templates.md
+++ b/docs/reference/agent-templates.md
@@ -101,14 +101,17 @@ run history, and execution state are not transferred.
 
 Bundles are limited to 32 regular files including metadata, 256 KiB per file,
 and 2 MiB total. Version 1 accepts only the files in the directory layout above.
-Paths must be relative and contained in the bundle: absolute paths, `..`
-segments, symlinks, and unexpected files are rejected. Embedded absolute local
-paths are also refused to keep the template portable.
+Bundle file paths must be relative and contained in the bundle: absolute paths,
+`..` segments, symlinks, and unexpected files are rejected. Absolute local paths
+embedded in Markdown or JSON content are preserved by export and import. Export
+reports them with file and line in the summary: `Review before sharing:` lines
+in human output and a `warnings` array with `--json` (empty when none are found).
+Review these references and replace machine-specific paths before sharing.
 
 Path checks are conservative around prose punctuation. Use percent-encoded
 punctuation in a legitimate URL if it is mistaken for a local path.
 
-Export scans Markdown and JSON for probable secrets. A refusal identifies the
+Export and import scan Markdown and JSON for probable secrets. A refusal identifies the
 file and line without echoing the suspected value; remove it from the source and
 retry. There is no secret-check bypass. Pattern matching cannot prove the absence
 of sensitive content, so inspect the bundle before sharing it.

--- a/docs/reference/agent-templates.md
+++ b/docs/reference/agent-templates.md
@@ -1,0 +1,121 @@
+---
+summary: "Portable agent template manifests, workspace files, automation fields, and validation limits"
+title: "Agent templates"
+read_when:
+  - You are writing a tool that creates or reads portable agent templates
+  - You need the exact export and import bundle contract
+---
+
+# Agent templates
+
+A portable agent template is a directory consumed by `openclaw agents import`
+and produced by `openclaw agents export`. It uses the same version 1 manifest as
+the bundled role catalog. For command usage, see [Agents](/cli/agents).
+
+## Directory layout
+
+```text
+research-template/
+  manifest.json
+  workspace/
+    AGENTS.md
+    SOUL.md
+    IDENTITY.md
+  automations.json       # optional
+```
+
+Only these files are accepted. The manifest's `files` entries are relative to
+`workspace/`, not the bundle root. Each required workspace file appears exactly
+once; directories and extra artifacts cannot be listed in its place.
+
+## Manifest
+
+```json
+{
+  "schemaVersion": 1,
+  "title": "Research assistant",
+  "summary": "Gather evidence and prepare a cited research brief.",
+  "identity": { "name": "Research assistant", "emoji": "🔎", "theme": "Evidence first" },
+  "skills": ["web-research"],
+  "subagents": { "allowAgents": ["reviewer"], "delegationMode": "prefer" },
+  "files": ["AGENTS.md", "SOUL.md", "IDENTITY.md"]
+}
+```
+
+| Field                      | Contract                                                                                                                                                                                  |
+| -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `schemaVersion`            | Required; exactly `1`.                                                                                                                                                                    |
+| `role`                     | Optional catalog role: `coordinator`, `researcher`, `writer`, or `reviewer`. Import does not use it to resolve delegation targets.                                                        |
+| `title`, `summary`         | Required non-empty strings describing the template.                                                                                                                                       |
+| `identity`                 | Required object with a non-empty `name`; `emoji` and `theme` are optional non-empty strings.                                                                                              |
+| `skills`                   | Optional array of non-empty skill names. Export includes it only when explicitly set on the agent, including an empty allowlist. Skill implementation files are not bundled.              |
+| `model`                    | Optional model string or object with optional `primary` and `fallbacks` fields. Export includes only an explicit agent-level choice, not inherited defaults or credentials.               |
+| `subagents.allowAgents`    | Optional array of agent ids, exported as configured. Import retains only ids already in the target roster and warns about dropped ids. If all targets are dropped, this field is omitted. |
+| `subagents.delegationMode` | Optional `"suggest"` or `"prefer"`, preserved on import.                                                                                                                                  |
+| `files`                    | Required array listing `AGENTS.md`, `SOUL.md`, and `IDENTITY.md` exactly once.                                                                                                            |
+
+Unknown fields are rejected. No role-origin metadata is persisted.
+
+## Automations
+
+`automations.json`, when present, is an array of sanitized agent-turn jobs:
+
+```json
+[
+  {
+    "name": "Weekly research brief",
+    "schedule": { "kind": "cron", "expr": "0 9 * * 1", "tz": "UTC" },
+    "payload": {
+      "kind": "agentTurn",
+      "message": "Prepare a research brief from the current workspace instructions.",
+      "timeoutSeconds": 300
+    }
+  }
+]
+```
+
+Each job carries `name`, optional `description`, `schedule`, optional `pacing`,
+and `payload`. Schedules use the `at`, `every`, or `cron` forms documented in
+[Cron jobs](/automation/cron-jobs). `pacing` contains optional `min` and `max`
+durations. The payload contains `kind: "agentTurn"`, `message`, and optional
+`model`, `thinking`, and `timeoutSeconds`. No other job or payload fields are
+portable. Pacing is valid only with `every` or `cron` schedules.
+
+| Schedule kind | Fields                                                                                                      |
+| ------------- | ----------------------------------------------------------------------------------------------------------- |
+| `at`          | `at`: an absolute timestamp.                                                                                |
+| `every`       | `everyMs`: a positive integer interval; optional `anchorMs`: a nonnegative timestamp in milliseconds.       |
+| `cron`        | `expr`: a cron expression; optional `tz`: a timezone and `staggerMs`: a nonnegative integer stagger window. |
+
+Export includes a job only when both `owner.agentId` and the execution `agentId`
+match the exported agent. Unsupported payloads (`systemEvent`, `command`, and
+`script`) are skipped and counted in the omissions report. Process-driven
+schedules are not portable.
+
+Import creates fresh job ids, sets the owner and execution agent to the new
+agent id, and creates every job **disabled**. Review instructions and schedules
+before enabling them. Delivery destinations, session keys, authorization data,
+run history, and execution state are not transferred.
+
+## Validation and exclusions
+
+Bundles are limited to 32 regular files including metadata, 256 KiB per file,
+and 2 MiB total. Version 1 accepts only the files in the directory layout above.
+Paths must be relative and contained in the bundle: absolute paths, `..`
+segments, symlinks, and unexpected files are rejected. Embedded absolute local
+paths are also refused to keep the template portable.
+
+Path checks are conservative around prose punctuation. Use percent-encoded
+punctuation in a legitimate URL if it is mistaken for a local path.
+
+Export scans Markdown and JSON for probable secrets. A refusal identifies the
+file and line without echoing the suspected value; remove it from the source and
+retry. There is no secret-check bypass. Pattern matching cannot prove the absence
+of sensitive content, so inspect the bundle before sharing it.
+
+Export never copies `USER.md`, `MEMORY.md`, `memory/`, `BOOTSTRAP.md`, other
+personal workspace files, auth profiles, sessions, or anything under `agentDir`.
+It also excludes channel bindings, skill code, inherited agent settings, and
+command/script environment, arguments, working directories, and standard input.
+Import requires a new agent id and a workspace without existing files, validates
+the resulting agent configuration, and uses the normal agent creation path.

--- a/src/agents/agent-create.ts
+++ b/src/agents/agent-create.ts
@@ -17,6 +17,7 @@ import { migrateLegacyMainSessionKeys } from "../config/sessions/legacy-main-ses
 import { resolveSessionTranscriptsDirForAgent } from "../config/sessions/paths.js";
 import type { OptionalBootstrapFileName } from "../config/types.agent-defaults.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { hasErrnoCode } from "../infra/errors.js";
 import { FsSafeError, root } from "../infra/fs-safe.js";
 import { normalizeAgentId, normalizeAgentIdStrict } from "../routing/session-key.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
@@ -26,7 +27,11 @@ import { resolveUserPath } from "../utils.js";
 import { claimCompletedAgentDeletion } from "./agent-lifecycle-registry.js";
 import { toAgentEntriesRecord } from "./agent-scope-config.js";
 import { resolveAgentDir, resolveAgentWorkspaceDir } from "./agent-scope.js";
-import { loadAgentTemplate } from "./agent-templates.js";
+import {
+  AGENT_TEMPLATE_MAX_FILE_BYTES,
+  loadAgentTemplate,
+  type AgentTemplate,
+} from "./agent-templates.js";
 import { resolveSharedAuthStoreOwnership } from "./auth-profiles/path-resolve.js";
 import {
   createAgentIdentityConfig,
@@ -73,6 +78,7 @@ type ConfigCommitRollback = () => void | Promise<void>;
 type CreateAgentParams = {
   name?: string;
   role?: string;
+  template?: AgentTemplate;
   entry?: CreateAgentEntry;
   /** Internal authorization for onboarding to materialize the sole implicit `main` agent. */
   bootstrapMain?: boolean;
@@ -254,7 +260,7 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
   const agentId = validation.agentId;
   const isBootstrapMain = agentId === BOOTSTRAP_AGENT_ID && params.bootstrapMain === true;
 
-  const template = params.role ? await loadAgentTemplate(params.role) : undefined;
+  const template = params.role ? await loadAgentTemplate(params.role) : params.template;
   const safeName = sanitizeAgentIdentityLine(rawName);
   const model = normalizeOptionalString(params.model);
   const identity = template?.manifest.identity ??
@@ -433,6 +439,22 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
           const skipBootstrap = template
             ? false
             : (params.skipBootstrap ?? nextConfig.agents?.defaults?.skipBootstrap);
+          if (params.template) {
+            // Imported programs must never merge with an existing workspace.
+            const existing = await fs.lstat(workspaceDir).catch((error: unknown) => {
+              if (!hasErrnoCode(error, "ENOENT")) {
+                throw error;
+              }
+            });
+            if (
+              existing &&
+              (!existing.isDirectory() ||
+                existing.isSymbolicLink() ||
+                (await fs.readdir(workspaceDir)).length)
+            ) {
+              throw new Error("Template import requires a new or empty workspace directory.");
+            }
+          }
           params.beforePersistentApply?.();
           const workspace = await ensureAgentWorkspace({
             dir: workspaceDir,
@@ -446,6 +468,20 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
           });
           if (template && workspace.bootstrapPending) {
             throw new UnfinishedRoleBootstrapError();
+          }
+          if (params.template) {
+            const workspaceRoot = await root(workspace.dir);
+            for (const file of params.template.manifest.files) {
+              const { buffer } = await workspaceRoot.read(file, {
+                symlinks: "reject",
+                hardlinks: "reject",
+                maxBytes: AGENT_TEMPLATE_MAX_FILE_BYTES,
+                nonBlockingRead: true,
+              });
+              if (buffer.toString("utf8") !== params.template.files[file]) {
+                throw new Error(`Template workspace file changed during import: ${file}`);
+              }
+            }
           }
           if (workspace.dir !== workspaceDir) {
             const entries = listAgentEntries(nextConfig);

--- a/src/agents/agent-template-automations.ts
+++ b/src/agents/agent-template-automations.ts
@@ -1,0 +1,187 @@
+import { z } from "zod";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { CronServiceDeps } from "../cron/service/state.js";
+import type { CronJob, CronJobCreate } from "../cron/types.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import { listAgentIds } from "./agent-scope-config.js";
+
+const text = z.string().min(1);
+const timestamp = z.number().int().nonnegative().max(8_640_000_000_000_000);
+const scheduleSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("at"), at: text }).strict(),
+  z
+    .object({
+      kind: z.literal("every"),
+      everyMs: z.number().int().positive(),
+      anchorMs: timestamp.optional(),
+    })
+    .strict(),
+  z
+    .object({
+      kind: z.literal("cron"),
+      expr: text,
+      tz: text.optional(),
+      staggerMs: z.number().int().nonnegative().optional(),
+    })
+    .strict(),
+]);
+
+export const agentTemplateAutomationsSchema = z.array(
+  z
+    .object({
+      name: text.refine((value) => value.trim().length > 0),
+      description: z.string().optional(),
+      schedule: scheduleSchema,
+      pacing: z.object({ min: text.optional(), max: text.optional() }).strict().optional(),
+      payload: z
+        .object({
+          kind: z.literal("agentTurn"),
+          message: text,
+          model: text.optional(),
+          thinking: text.optional(),
+          timeoutSeconds: z.number().int().nonnegative().optional(),
+        })
+        .strict(),
+    })
+    .strict(),
+);
+
+export type AgentTemplateAutomation = z.infer<typeof agentTemplateAutomationsSchema>[number];
+
+export function exportAgentTemplateAutomations(jobs: readonly CronJob[], agentId: string) {
+  const automations: AgentTemplateAutomation[] = [];
+  let unsupportedPayload = 0;
+  let unsupportedSchedule = 0;
+  let omittedTriggers = 0;
+  for (const job of jobs) {
+    if (job.agentId !== agentId || job.owner?.agentId !== agentId) {
+      continue;
+    }
+    if (job.payload.kind !== "agentTurn") {
+      unsupportedPayload++;
+      continue;
+    }
+    if (job.schedule.kind === "on-exit" || job.schedule.kind === "stream") {
+      unsupportedSchedule++;
+      continue;
+    }
+    if (job.trigger) {
+      omittedTriggers++;
+    }
+    const { name, description } = job;
+    const { kind, message, model, thinking, timeoutSeconds } = job.payload;
+    const schedule = job.schedule;
+    automations.push({
+      name,
+      description,
+      schedule:
+        schedule.kind === "at"
+          ? { kind: "at", at: schedule.at }
+          : schedule.kind === "every"
+            ? { kind: "every", everyMs: schedule.everyMs, anchorMs: schedule.anchorMs }
+            : { kind: "cron", expr: schedule.expr, tz: schedule.tz, staggerMs: schedule.staggerMs },
+      ...(job.pacing ? { pacing: { min: job.pacing.min, max: job.pacing.max } } : {}),
+      payload: { kind, message, model, thinking, timeoutSeconds },
+    });
+  }
+  const omissions = [
+    ...(unsupportedPayload
+      ? [`${unsupportedPayload} automation(s) skipped: unsupported payload for portable templates`]
+      : []),
+    ...(unsupportedSchedule
+      ? [`${unsupportedSchedule} automation(s) skipped: executable schedule for portable templates`]
+      : []),
+    ...(omittedTriggers ? [`${omittedTriggers} automation trigger(s) not exported`] : []),
+  ];
+  return { automations: agentTemplateAutomationsSchema.parse(automations), omissions };
+}
+
+export type AgentTemplateAutomationImportOutcome =
+  | { name: string; status: "created"; id: string }
+  | { name: string; status: "failed"; error: string };
+
+async function templateCronDependencies(cfg: OpenClawConfig): Promise<CronServiceDeps> {
+  const { resolveCronJobsStorePathFromConfig } = await import("../cron/store.js");
+  const noop = () => {};
+  return {
+    storePath: resolveCronJobsStorePathFromConfig(cfg),
+    cronEnabled: false,
+    cronConfig: cfg.cron,
+    isAgentAvailable: (id) => listAgentIds(cfg).includes(id),
+    log: { debug: noop, info: noop, warn: noop, error: noop },
+    enqueueSystemEvent: () => false,
+    requestHeartbeat: noop,
+    runIsolatedAgentJob: async () => ({
+      status: "skipped",
+      error: "Template import does not run automations",
+    }),
+  };
+}
+
+function templateCronInput(agentId: string, automation: AgentTemplateAutomation): CronJobCreate {
+  return {
+    ...automation,
+    agentId,
+    owner: { agentId },
+    enabled: false,
+    sessionTarget: "isolated",
+    wakeMode: "next-heartbeat",
+    delivery: { mode: "none" },
+  };
+}
+
+/** Use the add-path validator in memory before agent creation publishes any state. */
+export async function validateAgentTemplateAutomations(
+  cfg: OpenClawConfig,
+  agentId: string,
+  automations: AgentTemplateAutomation[],
+): Promise<void> {
+  if (!automations.length) {
+    return;
+  }
+  const [{ createJob }, { createCronServiceState }, { assertCronStoreCanPersist }, deps] =
+    await Promise.all([
+      import("../cron/service/jobs.js"),
+      import("../cron/service/state.js"),
+      import("../cron/store/row-codec.js"),
+      templateCronDependencies(cfg),
+    ]);
+  const state = createCronServiceState(deps);
+  const jobs = automations.map((automation) =>
+    createJob(state, templateCronInput(agentId, automation)),
+  );
+  assertCronStoreCanPersist({ version: 1, jobs });
+}
+
+export async function importAgentTemplateAutomations(
+  cfg: OpenClawConfig,
+  agentId: string,
+  automations: AgentTemplateAutomation[],
+): Promise<AgentTemplateAutomationImportOutcome[]> {
+  if (!automations.length) {
+    return [];
+  }
+  const [{ CronService }, deps] = await Promise.all([
+    import("../cron/service.js"),
+    templateCronDependencies(cfg),
+  ]);
+  const service = new CronService(deps);
+  const outcomes: AgentTemplateAutomationImportOutcome[] = [];
+  try {
+    for (const automation of automations) {
+      try {
+        const job = await service.add(templateCronInput(agentId, automation));
+        outcomes.push({ name: automation.name, status: "created", id: job.id });
+      } catch (error) {
+        outcomes.push({
+          name: automation.name,
+          status: "failed",
+          error: formatErrorMessage(error),
+        });
+      }
+    }
+  } finally {
+    service.stop();
+  }
+  return outcomes;
+}

--- a/src/agents/agent-template-bundle.ts
+++ b/src/agents/agent-template-bundle.ts
@@ -1,0 +1,269 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { resolveStateDir } from "../config/paths.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { hasErrnoCode } from "../infra/errors.js";
+import { canonicalPathFromExistingAncestor } from "../infra/fs-safe.js";
+import { isPathInside } from "../infra/path-guards.js";
+import { scanSkillContent } from "../skills/security/scanner.js";
+import { resolveUserPath } from "../utils.js";
+import { listAgentEntries } from "./agent-scope-config.js";
+import { resolveAgentDir, resolveAgentWorkspaceDir } from "./agent-scope.js";
+import {
+  agentTemplateAutomationsSchema,
+  exportAgentTemplateAutomations,
+  validateAgentTemplateAutomations,
+  type AgentTemplateAutomation,
+} from "./agent-template-automations.js";
+import { AGENT_TEMPLATE_FILES, agentTemplateManifestSchema } from "./agent-template-schema.js";
+import {
+  AGENT_TEMPLATE_MAX_FILES,
+  AGENT_TEMPLATE_MAX_FILE_BYTES,
+  AGENT_TEMPLATE_MAX_TOTAL_BYTES,
+  loadAgentTemplateDirectory,
+  readAgentTemplateFile,
+  type AgentTemplate,
+} from "./agent-templates.js";
+import { parseIdentityMarkdown } from "./identity-file.js";
+
+type Bundle = { template: AgentTemplate; automations: AgentTemplateAutomation[] };
+const bundlePaths = new Set([
+  "manifest.json",
+  ...AGENT_TEMPLATE_FILES.map((file) => `workspace/${file}`),
+  "automations.json",
+]);
+
+function bundleContents({ template, automations }: Bundle): Map<string, string> {
+  const contents = new Map<string, string>([
+    ["manifest.json", `${JSON.stringify(template.manifest, null, 2)}\n`],
+    ...AGENT_TEMPLATE_FILES.map((file): [string, string] => [
+      `workspace/${file}`,
+      template.files[file],
+    ]),
+  ]);
+  if (automations.length) {
+    contents.set("automations.json", `${JSON.stringify(automations, null, 2)}\n`);
+  }
+  return contents;
+}
+
+function assertPortableContents(contents: Map<string, string>): void {
+  let total = 0;
+  const problems: string[] = [];
+  if (contents.size > AGENT_TEMPLATE_MAX_FILES) {
+    throw new Error("Template exceeds 32 files.");
+  }
+  for (const [file, content] of contents) {
+    const size = Buffer.byteLength(content);
+    total += size;
+    if (size > AGENT_TEMPLATE_MAX_FILE_BYTES || total > AGENT_TEMPLATE_MAX_TOTAL_BYTES) {
+      throw new Error(`Template exceeds the 256 KiB per-file or 2 MiB total limit: ${file}`);
+    }
+    for (const finding of scanSkillContent(content, file)) {
+      if (finding.ruleId === "literal-secret") {
+        problems.push(`${file}:${finding.line}: probable secret; remove it before exporting`);
+      }
+    }
+    // Portable programs cannot retain machine-local paths embedded in prose or JSON strings.
+    for (const [line, text] of content.split("\n").entries()) {
+      const localText = text.replace(
+        /(?<![\p{L}\p{M}\p{N}])(?!file:)[a-z][a-z\d+.-]{1,31}:\/\/[\p{L}\p{M}\p{N}.%:/?#=&-]+/giu,
+        " ",
+      );
+      if (
+        /\bfile:\/\/|(?:^|[^\p{L}\p{M}\p{N}._~/\\-]|\\[nrt])[_~]*(?:\/[^\s"'`<>]|[a-z]:[\\/]|\\\\|~\/)/iu.test(
+          localText,
+        )
+      ) {
+        problems.push(`${file}:${line + 1}: absolute local path; replace it with a relative path`);
+      }
+    }
+  }
+  if (problems.length) {
+    throw new Error(`Template is not portable:\n${problems.join("\n")}`);
+  }
+}
+
+export async function loadAgentTemplateBundle(directory: string): Promise<Bundle> {
+  let total = 0;
+  let count = 0;
+  async function inspect(relative: string): Promise<void> {
+    const absolute = path.join(directory, relative);
+    const stat = await fs.lstat(absolute);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`Template symlinks are not allowed: ${relative || "."}`);
+    }
+    if (stat.isDirectory() && (relative === "" || relative === "workspace")) {
+      const entries = await fs.opendir(absolute);
+      for await (const entry of entries) {
+        await inspect(relative ? `${relative}/${entry.name}` : entry.name);
+      }
+      return;
+    }
+    if (!stat.isFile() || !bundlePaths.has(relative)) {
+      throw new Error(`Unexpected template file: ${relative}`);
+    }
+    total += stat.size;
+    if (
+      ++count > AGENT_TEMPLATE_MAX_FILES ||
+      stat.size > AGENT_TEMPLATE_MAX_FILE_BYTES ||
+      total > AGENT_TEMPLATE_MAX_TOTAL_BYTES
+    ) {
+      throw new Error("Template exceeds 32 files, 256 KiB per file, or 2 MiB total.");
+    }
+  }
+  await inspect("");
+  const template = await loadAgentTemplateDirectory(directory);
+  const automationText = await readAgentTemplateFile(directory, "automations.json").catch(
+    (error: unknown) => {
+      if (
+        hasErrnoCode(error, "ENOENT") ||
+        (error instanceof Error && "code" in error && error.code === "not-found")
+      ) {
+        return undefined;
+      }
+      throw error;
+    },
+  );
+  let automations: AgentTemplateAutomation[] = [];
+  if (automationText !== undefined) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(automationText);
+    } catch {
+      throw new Error("Invalid automations.json JSON.");
+    }
+    const result = agentTemplateAutomationsSchema.safeParse(parsed);
+    if (!result.success) {
+      throw new Error(
+        "Invalid automations.json: expected sanitized agent-turn jobs with valid time schedules.",
+      );
+    }
+    automations = result.data;
+  }
+  const bundle = { template, automations };
+  assertPortableContents(bundleContents(bundle));
+  return bundle;
+}
+
+export async function exportAgentTemplateBundle(
+  cfg: OpenClawConfig,
+  agentId: string,
+  out: string,
+  force = false,
+) {
+  const entry = listAgentEntries(cfg).find((agent) => agent.id === agentId);
+  if (!entry) {
+    throw new Error(`Agent "${agentId}" does not exist.`);
+  }
+  const workspace = resolveAgentWorkspaceDir(cfg, agentId);
+  const files = {
+    "AGENTS.md": await readAgentTemplateFile(workspace, "AGENTS.md"),
+    "SOUL.md": await readAgentTemplateFile(workspace, "SOUL.md"),
+    "IDENTITY.md": await readAgentTemplateFile(workspace, "IDENTITY.md"),
+  };
+  const parsedIdentity = parseIdentityMarkdown(files["IDENTITY.md"]);
+  const identity = { ...parsedIdentity, ...entry.identity };
+  const manifest = agentTemplateManifestSchema.parse({
+    schemaVersion: 1,
+    title: entry.name || identity.name || agentId,
+    summary: entry.description || `Portable template for ${entry.name || identity.name || agentId}`,
+    identity: {
+      name: identity.name || entry.name || agentId,
+      emoji: identity.emoji,
+      theme: identity.theme,
+    },
+    ...(entry.skills !== undefined ? { skills: entry.skills } : {}),
+    ...(entry.model !== undefined ? { model: entry.model } : {}),
+    ...(entry.subagents
+      ? {
+          subagents: {
+            allowAgents: entry.subagents.allowAgents,
+            delegationMode: entry.subagents.delegationMode,
+          },
+        }
+      : {}),
+    files: [...AGENT_TEMPLATE_FILES],
+  });
+  const { resolveCronJobsStorePathFromConfig, loadCronJobsStoreWithConfigJobsReadOnly } =
+    await import("../cron/store.js");
+  const loaded = await loadCronJobsStoreWithConfigJobsReadOnly(
+    resolveCronJobsStorePathFromConfig(cfg),
+  );
+  const { automations, omissions } = exportAgentTemplateAutomations(loaded.store.jobs, agentId);
+  const contents = bundleContents({ template: { manifest, files }, automations });
+  assertPortableContents(contents);
+  await validateAgentTemplateAutomations(cfg, agentId, automations);
+  const destination = resolveUserPath(out);
+  // A forced export may replace its output directory, never the source or installation root.
+  const parent = await canonicalPathFromExistingAncestor(path.dirname(destination));
+  const requestedOutput = path.join(parent, path.basename(destination));
+  const existing = await fs.lstat(requestedOutput).catch((error: unknown) => {
+    if (!hasErrnoCode(error, "ENOENT")) {
+      throw error;
+    }
+  });
+  if (existing && (!existing.isDirectory() || existing.isSymbolicLink())) {
+    throw new Error("Export output must be a real directory, not a symlink.");
+  }
+  const output = existing ? await fs.realpath(requestedOutput) : requestedOutput;
+  for (const protectedPath of [workspace, resolveAgentDir(cfg, agentId), resolveStateDir()]) {
+    const canonical = await canonicalPathFromExistingAncestor(protectedPath);
+    if (
+      output === canonical ||
+      isPathInside(output, canonical) ||
+      (protectedPath !== resolveStateDir() && isPathInside(canonical, output))
+    ) {
+      throw new Error("Export output overlaps the source workspace or agent state.");
+    }
+  }
+  if (existing && (await fs.readdir(output)).length && !force) {
+    throw new Error("Export output is not empty; use --force to replace it.");
+  }
+  await fs.mkdir(parent, { recursive: true });
+  const staging = await fs.mkdtemp(path.join(parent, ".agent-template-"));
+  const backup = `${staging}.previous`;
+  let moved = false;
+  try {
+    await fs.mkdir(path.join(staging, "workspace"));
+    for (const [file, content] of contents) {
+      await fs.writeFile(path.join(staging, file), content, { flag: "wx", mode: 0o600 });
+    }
+    if (existing && !force) {
+      // The directory must still be empty at publication, even after staging awaited IO.
+      await fs.rmdir(output);
+    } else if (existing) {
+      await fs.rename(output, backup);
+      moved = true;
+    }
+    try {
+      await fs.rename(staging, output);
+    } catch (error) {
+      if (moved) {
+        await fs.rename(backup, output);
+        moved = false;
+      }
+      throw error;
+    }
+    if (moved) {
+      await fs.rm(backup, { recursive: true });
+    }
+  } finally {
+    await fs.rm(staging, { recursive: true, force: true });
+  }
+  return {
+    agentId,
+    out: output,
+    files: [...contents.keys()],
+    automations: automations.length,
+    omissions: [
+      "USER.md not exported",
+      "MEMORY.md and memory/ not exported",
+      "BOOTSTRAP.md not exported",
+      "Credentials, auth profiles, sessions, agentDir, and other personal files not exported",
+      "Automation delivery, session bindings, tool policy, and runtime state not exported",
+      ...(identity.avatar ? ["Identity avatar not exported"] : []),
+      ...omissions,
+    ],
+  };
+}

--- a/src/agents/agent-template-bundle.ts
+++ b/src/agents/agent-template-bundle.ts
@@ -47,9 +47,10 @@ function bundleContents({ template, automations }: Bundle): Map<string, string> 
   return contents;
 }
 
-function assertPortableContents(contents: Map<string, string>): void {
+function checkPortableContents(contents: Map<string, string>): string[] {
   let total = 0;
   const problems: string[] = [];
+  const warnings: string[] = [];
   if (contents.size > AGENT_TEMPLATE_MAX_FILES) {
     throw new Error("Template exceeds 32 files.");
   }
@@ -64,7 +65,7 @@ function assertPortableContents(contents: Map<string, string>): void {
         problems.push(`${file}:${finding.line}: probable secret; remove it before exporting`);
       }
     }
-    // Portable programs cannot retain machine-local paths embedded in prose or JSON strings.
+    // Embedded paths need review before sharing, but do not prevent a round-trip.
     for (const [line, text] of content.split("\n").entries()) {
       const localText = text.replace(
         /(?<![\p{L}\p{M}\p{N}])(?!file:)[a-z][a-z\d+.-]{1,31}:\/\/[\p{L}\p{M}\p{N}.%:/?#=&-]+/giu,
@@ -75,13 +76,14 @@ function assertPortableContents(contents: Map<string, string>): void {
           localText,
         )
       ) {
-        problems.push(`${file}:${line + 1}: absolute local path; replace it with a relative path`);
+        warnings.push(`${file}:${line + 1}: absolute local path; replace it with a relative path`);
       }
     }
   }
   if (problems.length) {
     throw new Error(`Template is not portable:\n${problems.join("\n")}`);
   }
+  return warnings;
 }
 
 export async function loadAgentTemplateBundle(directory: string): Promise<Bundle> {
@@ -142,7 +144,7 @@ export async function loadAgentTemplateBundle(directory: string): Promise<Bundle
     automations = result.data;
   }
   const bundle = { template, automations };
-  assertPortableContents(bundleContents(bundle));
+  checkPortableContents(bundleContents(bundle));
   return bundle;
 }
 
@@ -192,7 +194,7 @@ export async function exportAgentTemplateBundle(
   );
   const { automations, omissions } = exportAgentTemplateAutomations(loaded.store.jobs, agentId);
   const contents = bundleContents({ template: { manifest, files }, automations });
-  assertPortableContents(contents);
+  const warnings = checkPortableContents(contents);
   await validateAgentTemplateAutomations(cfg, agentId, automations);
   const destination = resolveUserPath(out);
   // A forced export may replace its output directory, never the source or installation root.
@@ -256,6 +258,7 @@ export async function exportAgentTemplateBundle(
     out: output,
     files: [...contents.keys()],
     automations: automations.length,
+    warnings,
     omissions: [
       "USER.md not exported",
       "MEMORY.md and memory/ not exported",

--- a/src/agents/agent-template-schema.ts
+++ b/src/agents/agent-template-schema.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
+import { AgentModelSchema } from "../config/zod-schema.agent-model.js";
 
 export const AGENT_TEMPLATE_ROLES = ["coordinator", "researcher", "writer", "reviewer"] as const;
-const AGENT_TEMPLATE_FILES = ["AGENTS.md", "SOUL.md", "IDENTITY.md"] as const;
+export const AGENT_TEMPLATE_FILES = ["AGENTS.md", "SOUL.md", "IDENTITY.md"] as const;
 const roleSchema = z.enum(AGENT_TEMPLATE_ROLES);
 const agentIdSchema = z.string().regex(/^[a-z0-9][a-z0-9_-]{0,63}$/);
 const textSchema = z.string().trim().min(1);
@@ -9,14 +10,19 @@ const textSchema = z.string().trim().min(1);
 export const agentTemplateManifestSchema = z
   .object({
     schemaVersion: z.literal(1),
-    role: roleSchema,
+    role: roleSchema.optional(),
     title: textSchema,
     summary: textSchema,
-    identity: z.object({ name: textSchema, emoji: textSchema, theme: textSchema }).strict(),
+    identity: z
+      .object({ name: textSchema, emoji: textSchema.optional(), theme: textSchema.optional() })
+      .strict(),
+    model: AgentModelSchema.optional(),
     skills: z.array(textSchema).optional(),
     subagents: z
       .object({
-        allowAgents: z.array(agentIdSchema).optional(),
+        allowAgents: z
+          .array(z.string().regex(/^(?:[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}|\*)$/))
+          .optional(),
         delegationMode: z.enum(["suggest", "prefer"]).optional(),
       })
       .strict()

--- a/src/agents/agent-templates.ts
+++ b/src/agents/agent-templates.ts
@@ -1,8 +1,10 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { root } from "../infra/fs-safe.js";
 import { pathExists } from "../utils.js";
 import {
   AGENT_TEMPLATE_ROLES,
+  AGENT_TEMPLATE_FILES,
   agentTeamPresetSchema,
   agentTemplateManifestSchema,
   type AgentTemplateFile,
@@ -14,6 +16,47 @@ export type AgentTemplate = {
   manifest: AgentTemplateManifest;
   files: Record<AgentTemplateFile, string>;
 };
+
+export const AGENT_TEMPLATE_MAX_FILE_BYTES = 256 * 1024;
+export const AGENT_TEMPLATE_MAX_TOTAL_BYTES = 2 * 1024 * 1024;
+export const AGENT_TEMPLATE_MAX_FILES = 32;
+
+export async function readAgentTemplateFile(directory: string, file: string): Promise<string> {
+  const directoryStat = await fs.lstat(directory);
+  if (!directoryStat.isDirectory() || directoryStat.isSymbolicLink()) {
+    throw new Error("Template directory must be a real directory, not a symlink.");
+  }
+  const directoryRoot = await root(directory);
+  const { buffer } = await directoryRoot.read(file, {
+    symlinks: "reject",
+    hardlinks: "reject",
+    nonBlockingRead: true,
+    maxBytes: AGENT_TEMPLATE_MAX_FILE_BYTES,
+  });
+  return new TextDecoder("utf-8", { fatal: true }).decode(buffer);
+}
+
+/** Catalog roles and portable bundles share the same manifest and workspace loader. */
+export async function loadAgentTemplateDirectory(directory: string): Promise<AgentTemplate> {
+  const content = await readAgentTemplateFile(directory, "manifest.json");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(content);
+  } catch {
+    throw new Error("Invalid template manifest.json JSON.");
+  }
+  const validated = agentTemplateManifestSchema.safeParse(parsed);
+  if (!validated.success) {
+    throw new Error(
+      "Invalid template manifest.json: check schemaVersion, identity, settings, and workspace file paths.",
+    );
+  }
+  const manifest = validated.data;
+  const [agents, soul, identity] = await Promise.all(
+    AGENT_TEMPLATE_FILES.map((file) => readAgentTemplateFile(directory, `workspace/${file}`)),
+  );
+  return { manifest, files: { "AGENTS.md": agents!, "SOUL.md": soul!, "IDENTITY.md": identity! } };
+}
 
 async function resolveCatalogFile(...segments: string[]): Promise<string> {
   for (const templatesDir of await resolveWorkspaceTemplateSearchDirs()) {
@@ -32,20 +75,13 @@ export async function loadAgentTemplate(role: string): Promise<AgentTemplate> {
     );
   }
   const manifestPath = await resolveCatalogFile(role, "manifest.json");
-  const manifest = agentTemplateManifestSchema.parse(
-    JSON.parse(await fs.readFile(manifestPath, "utf8")),
-  );
-  if (manifest.role !== role) {
-    throw new Error(`Agent template "${role}" declares a different role: ${manifest.role}`);
+  const template = await loadAgentTemplateDirectory(path.dirname(manifestPath));
+  if (template.manifest.role !== role) {
+    throw new Error(
+      `Agent template "${role}" declares a different role: ${template.manifest.role}`,
+    );
   }
-  const workspaceDir = path.join(path.dirname(manifestPath), "workspace");
-  const read = (file: AgentTemplateFile) => fs.readFile(path.join(workspaceDir, file), "utf8");
-  const [agents, soul, identity] = await Promise.all([
-    read("AGENTS.md"),
-    read("SOUL.md"),
-    read("IDENTITY.md"),
-  ]);
-  return { manifest, files: { "AGENTS.md": agents, "SOUL.md": soul, "IDENTITY.md": identity } };
+  return template;
 }
 
 export async function loadAgentTeamPreset(preset = "team") {

--- a/src/agents/identity-file.ts
+++ b/src/agents/identity-file.ts
@@ -102,7 +102,7 @@ function isIdentityPlaceholder(value: string): boolean {
 }
 
 /** Parse rich identity fields from human-authored markdown content. */
-function parseIdentityMarkdown(content: string): AgentIdentityFile {
+export function parseIdentityMarkdown(content: string): AgentIdentityFile {
   const identity: AgentIdentityFile = {};
   const lines = content.split(/\r?\n/);
   for (const line of lines) {

--- a/src/agents/workspace.ts
+++ b/src/agents/workspace.ts
@@ -1204,6 +1204,7 @@ export async function ensureAgentWorkspace(params?: {
         })
       : false;
     if (
+      params?.templates ||
       hasRecentAttestedCustomization ||
       (await workspaceProfileLooksConfigured({
         dir,

--- a/src/cli/program/register.agent.ts
+++ b/src/cli/program/register.agent.ts
@@ -207,6 +207,42 @@ export function registerAgentsCommands(program: Command): void {
     });
 
   agents
+    .command("export <id>")
+    .description("Export a portable, secret-free agent template")
+    .requiredOption("--out <dir>", "Output bundle directory")
+    .option("--force", "Replace a non-empty output directory", false)
+    .option("--json", "Output JSON summary", false)
+    .action(
+      async (id: string, opts: { out: string; force: boolean; json: boolean }): Promise<void> => {
+        await runAgentsCommandAction(async (runtime) => {
+          const { agentsExportCommand } =
+            await import("../../commands/agents.commands.templates.js");
+          await agentsExportCommand({ id, ...opts }, runtime);
+        });
+      },
+    );
+
+  agents
+    .command("import <dir>")
+    .description("Create an agent from a portable template")
+    .option("--id <newId>", "Agent id (defaults to the template identity name)")
+    .option("--workspace <dir>", "New or empty workspace directory")
+    .option("--non-interactive", "Import without confirmation", false)
+    .option("--json", "Output JSON summary", false)
+    .action(
+      async (
+        directory: string,
+        opts: { id?: string; workspace?: string; nonInteractive: boolean; json: boolean },
+      ): Promise<void> => {
+        await runAgentsCommandAction(async (runtime) => {
+          const { agentsImportCommand } =
+            await import("../../commands/agents.commands.templates.js");
+          await agentsImportCommand({ directory, ...opts }, runtime);
+        });
+      },
+    );
+
+  agents
     .command("team")
     .description("Create a coordinated team of agents")
     .command("create")

--- a/src/commands/agents.commands.templates.ts
+++ b/src/commands/agents.commands.templates.ts
@@ -1,0 +1,172 @@
+import { createAgent, validateAgentIdInput } from "../agents/agent-create.js";
+import { listAgentEntries } from "../agents/agent-scope-config.js";
+import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
+import {
+  importAgentTemplateAutomations,
+  validateAgentTemplateAutomations,
+} from "../agents/agent-template-automations.js";
+import {
+  exportAgentTemplateBundle,
+  loadAgentTemplateBundle,
+} from "../agents/agent-template-bundle.js";
+import { isTerminalInteractive } from "../cli/terminal-interactivity.js";
+import { readConfigFileSnapshot, resolveConfigSnapshotHash } from "../config/config.js";
+import { OpenClawSchema } from "../config/zod-schema.js";
+import { defaultRuntime, type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
+import { resolveUserPath } from "../utils.js";
+import { createClackPrompter } from "../wizard/clack-prompter.js";
+
+export type AgentsExportOptions = { id: string; out: string; force?: boolean; json?: boolean };
+export type AgentsImportOptions = {
+  directory: string;
+  id?: string;
+  workspace?: string;
+  nonInteractive?: boolean;
+  json?: boolean;
+};
+
+async function templateConfigSnapshot() {
+  const snapshot = await readConfigFileSnapshot({ observe: false });
+  if (!snapshot.valid) {
+    throw new Error("OpenClaw config is invalid; run openclaw config validate.");
+  }
+  return snapshot;
+}
+
+export async function agentsExportCommand(
+  opts: AgentsExportOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+): Promise<void> {
+  const { config } = await templateConfigSnapshot();
+  const summary = await exportAgentTemplateBundle(config, opts.id, opts.out, opts.force);
+  if (opts.json) {
+    writeRuntimeJson(runtime, summary);
+    return;
+  }
+  runtime.log(`Exported agent "${summary.agentId}" to ${summary.out}`);
+  runtime.log(`Files: ${summary.files.join(", ")}`);
+  runtime.log(`Automations: ${summary.automations}`);
+  runtime.log(`Omissions:\n${summary.omissions.map((line) => `- ${line}`).join("\n")}`);
+}
+
+export async function agentsImportCommand(
+  opts: AgentsImportOptions,
+  runtime: RuntimeEnv = defaultRuntime,
+): Promise<void> {
+  const bundle = await loadAgentTemplateBundle(resolveUserPath(opts.directory));
+  const { manifest } = bundle.template;
+  const validatedId = validateAgentIdInput(opts.id ?? manifest.identity.name);
+  if (!validatedId.ok) {
+    throw new Error(validatedId.message);
+  }
+  const agentId = validatedId.agentId;
+  const snapshot = await templateConfigSnapshot();
+  const cfg = snapshot.config;
+  const roster = new Set(listAgentEntries(cfg).map((entry) => entry.id));
+  if (roster.has(agentId)) {
+    throw new Error(`Agent "${agentId}" already exists.`);
+  }
+  const requested = manifest.subagents?.allowAgents;
+  const retained = requested?.filter((id) => roster.has(id));
+  const dropped = requested?.filter((id) => !roster.has(id)) ?? [];
+  const warnings = dropped.length
+    ? [`Dropped delegation targets absent from this install: ${dropped.join(", ")}`]
+    : [];
+  const subagents = manifest.subagents
+    ? {
+        ...(retained?.length || requested?.length === 0 ? { allowAgents: retained } : {}),
+        ...(manifest.subagents.delegationMode
+          ? { delegationMode: manifest.subagents.delegationMode }
+          : {}),
+      }
+    : undefined;
+  const workspace = opts.workspace
+    ? resolveUserPath(opts.workspace)
+    : resolveAgentWorkspaceDir(cfg, agentId);
+  const entry = {
+    id: agentId,
+    name: manifest.title,
+    description: manifest.summary,
+    workspace,
+    identity: manifest.identity,
+    ...(manifest.skills !== undefined ? { skills: manifest.skills } : {}),
+    ...(manifest.model !== undefined ? { model: manifest.model } : {}),
+    ...(subagents ? { subagents } : {}),
+  };
+  const { id: _id, ...configEntry } = entry;
+  const { list: _list, ...agentsConfig } = cfg.agents ?? {};
+  const prospective = OpenClawSchema.safeParse({
+    ...cfg,
+    agents: {
+      ...agentsConfig,
+      entries: { ...cfg.agents?.entries, [agentId]: configEntry },
+    },
+  });
+  if (!prospective.success) {
+    throw new Error("Template would produce an invalid OpenClaw config.");
+  }
+  await validateAgentTemplateAutomations(cfg, agentId, bundle.automations);
+  const review = "Review before enabling: imported automations are disabled.";
+  if (!opts.nonInteractive) {
+    const output = opts.json ? process.stderr : process.stdout;
+    if (!isTerminalInteractive(output)) {
+      throw new Error(
+        "Template import requires confirmation; use --non-interactive without a terminal.",
+      );
+    }
+    const summary = `Import "${manifest.title}" as ${agentId}\nWorkspace: ${workspace}\nFiles: ${manifest.files.join(", ")}\nIdentity: ${JSON.stringify(manifest.identity)}\nSkills: ${JSON.stringify(manifest.skills ?? "inherit")}\nModel: ${JSON.stringify(manifest.model ?? "inherit")}\nDelegation: ${JSON.stringify(subagents ?? "inherit")}\nAutomations: ${bundle.automations.length} disabled\n${[...warnings, review].join("\n")}`;
+    if (!(await createClackPrompter(output).confirm({ message: summary, initialValue: false }))) {
+      if (opts.json) {
+        writeRuntimeJson(runtime, { status: "cancelled", agentId });
+      } else {
+        runtime.log("Template import cancelled; no files or config written.");
+      }
+      return;
+    }
+  }
+  const created = await createAgent({
+    entry,
+    template: { ...bundle.template, manifest: { ...manifest, subagents } },
+    expectedConfigHash: resolveConfigSnapshotHash(snapshot) ?? null,
+  });
+  if (created.status !== "created") {
+    throw new Error(
+      created.status === "error" ? created.message : `Agent "${agentId}" already exists.`,
+    );
+  }
+  const automations = await importAgentTemplateAutomations(
+    created.config,
+    agentId,
+    bundle.automations,
+  );
+  const failed = automations.filter((outcome) => outcome.status === "failed");
+  const summary = {
+    status: failed.length ? "partial" : "created",
+    agentId,
+    workspace: created.workspace,
+    identity: manifest.identity,
+    files: manifest.files,
+    warnings,
+    automations,
+    review,
+  };
+  if (opts.json) {
+    writeRuntimeJson(runtime, summary);
+  } else {
+    runtime.log(`Imported agent "${agentId}" into ${created.workspace}`);
+    for (const warning of warnings) {
+      runtime.log(`Warning: ${warning}`);
+    }
+    for (const outcome of automations) {
+      runtime.log(
+        outcome.status === "created"
+          ? `Automation "${outcome.name}": ${outcome.id} (disabled)`
+          : `Automation "${outcome.name}" failed: ${outcome.error}`,
+      );
+    }
+    runtime.log(review);
+  }
+  if (failed.length) {
+    runtime.exit(1, { resetStream: process.stderr });
+  }
+}

--- a/src/commands/agents.commands.templates.ts
+++ b/src/commands/agents.commands.templates.ts
@@ -46,6 +46,9 @@ export async function agentsExportCommand(
   runtime.log(`Exported agent "${summary.agentId}" to ${summary.out}`);
   runtime.log(`Files: ${summary.files.join(", ")}`);
   runtime.log(`Automations: ${summary.automations}`);
+  for (const warning of summary.warnings) {
+    runtime.log(`Review before sharing: ${warning}`);
+  }
   runtime.log(`Omissions:\n${summary.omissions.map((line) => `- ${line}`).join("\n")}`);
 }
 

--- a/src/commands/agents.templates.test.ts
+++ b/src/commands/agents.templates.test.ts
@@ -85,14 +85,14 @@ describe("portable agent templates", () => {
       expect(entry).toBeDefined();
       Object.assign(entry!, {
         identity,
-        description: "A careful research assistant",
+        description: "Research notes in /opt/research/notes",
         skills: ["notes"],
         model: { primary: "local/research", fallbacks: [] },
         subagents: { allowAgents: ["ambient", "missing"], delegationMode: "prefer" },
       });
       await fs.writeFile(configPath, JSON.stringify(initial));
       resetConfigRuntimeState();
-      const program = "# Program\nPreserve sources and distinguish claims from evidence.\n";
+      const program = "# Program\nRead /opt/research/notes and distinguish claims from evidence.\n";
       await fs.writeFile(path.join(workspace, "AGENTS.md"), program);
       await fs.writeFile(path.join(workspace, "USER.md"), "Personal owner biography");
       await fs.writeFile(path.join(workspace, "MEMORY.md"), "Personal long-term memory");
@@ -119,7 +119,7 @@ describe("portable agent templates", () => {
         wakeMode: "now",
         payload: {
           kind: "agentTurn",
-          message: "Review the sources",
+          message: "Review /opt/research/notes",
           model: "local/research",
           thinking: "low",
           timeoutSeconds: 30,
@@ -154,6 +154,11 @@ describe("portable agent templates", () => {
       await agentsExportCommand({ id: "source", out, json: true }, exported.runtime);
       expect(JSON.parse(exported.logs.join("\n"))).toMatchObject({
         automations: 1,
+        warnings: [
+          expect.stringMatching(/^manifest.json:\d+: absolute local path/),
+          expect.stringContaining("workspace/AGENTS.md:2: absolute local path"),
+          expect.stringMatching(/^automations.json:\d+: absolute local path/),
+        ],
         omissions: expect.arrayContaining([
           "USER.md not exported",
           "3 automation(s) skipped: unsupported payload for portable templates",
@@ -189,7 +194,7 @@ describe("portable agent templates", () => {
       expect(next.valid).toBe(true);
       expect(next.config.agents?.entries?.copy).toMatchObject({
         identity,
-        description: "A careful research assistant",
+        description: "Research notes in /opt/research/notes",
         skills: ["notes"],
         model: { primary: "local/research", fallbacks: [] },
         subagents: { allowAgents: ["ambient"], delegationMode: "prefer" },
@@ -213,7 +218,7 @@ describe("portable agent templates", () => {
         owner: { agentId: "copy" },
         sessionTarget: "isolated",
         delivery: { mode: "none" },
-        payload: { kind: "agentTurn", message: "Review the sources", timeoutSeconds: 30 },
+        payload: { kind: "agentTurn", message: "Review /opt/research/notes", timeoutSeconds: 30 },
       });
       expect(importedJobs[0]?.id).not.toBe(job.id);
     });
@@ -263,7 +268,12 @@ describe("portable agent templates", () => {
         /not empty/,
       );
       expect(await fs.readFile(path.join(out, "old.txt"), "utf8")).toBe("Prior output");
-      await agentsExportCommand({ id: "source", out, force: true }, runtime);
+      await fs.writeFile(path.join(workspace, "SOUL.md"), "Read /opt/research/notes\n");
+      const exported = createCapturingTestRuntime();
+      await agentsExportCommand({ id: "source", out, force: true }, exported.runtime);
+      expect(exported.logs).toContain(
+        "Review before sharing: workspace/SOUL.md:1: absolute local path; replace it with a relative path",
+      );
       expect(await fs.readdir(out)).toEqual(["manifest.json", "workspace"]);
       const { template } = await loadAgentTemplateBundle(out);
       expect(template.manifest.skills).toBeUndefined();
@@ -272,25 +282,23 @@ describe("portable agent templates", () => {
     });
   });
 
-  it("rejects secrets and local paths in decoded JSON before writing an imported agent", async () => {
+  it("rejects secrets in decoded JSON before writing an imported agent", async () => {
     await withState(async (directory, configPath) => {
       const { bundle, template } = await makeBundle(directory);
       const before = await fs.readFile(configPath, "utf8");
-      const key = ["sk", "proj", "a".repeat(40)].join("-");
-      for (const summary of [key, "Local instructions\n/private/work/notes"]) {
-        const serialized = JSON.stringify({ ...template.manifest, summary }).replace(
-          "sk-proj",
-          "\\u0073k-proj",
-        );
-        await fs.writeFile(path.join(bundle, "manifest.json"), serialized);
-        await expect(
-          agentsImportCommand(
-            { directory: bundle, id: "copy", nonInteractive: true },
-            createCapturingTestRuntime().runtime,
-          ),
-        ).rejects.toThrow(/probable secret|absolute local path/);
-        expect(await fs.readFile(configPath, "utf8")).toBe(before);
-      }
+      const summary = ["sk", "proj", "a".repeat(40)].join("-");
+      const serialized = JSON.stringify({ ...template.manifest, summary }).replace(
+        "sk-proj",
+        "\\u0073k-proj",
+      );
+      await fs.writeFile(path.join(bundle, "manifest.json"), serialized);
+      await expect(
+        agentsImportCommand(
+          { directory: bundle, id: "copy", nonInteractive: true },
+          createCapturingTestRuntime().runtime,
+        ),
+      ).rejects.toThrow(/probable secret/);
+      expect(await fs.readFile(configPath, "utf8")).toBe(before);
     });
   });
 
@@ -444,14 +452,18 @@ describe("portable agent templates", () => {
     { reference: "https://example.org/%2C/docs", portable: true },
     { reference: "_https://example.org/docs_", portable: true },
   ])("checks portability of embedded reference $reference", async ({ reference, portable }) => {
-    const directory = await tempDirs.make();
-    const { bundle } = await makeBundle(directory);
-    const content = `Read ${reference}\n`;
-    await fs.writeFile(path.join(bundle, "workspace", "AGENTS.md"), content);
-    if (portable) {
-      expect((await loadAgentTemplateBundle(bundle)).template.files["AGENTS.md"]).toBe(content);
-    } else {
-      await expect(loadAgentTemplateBundle(bundle)).rejects.toThrow(/absolute local path/);
-    }
+    await withState(async (directory) => {
+      const workspace = path.join(directory, "source");
+      await createAgent({ name: "source", role: "researcher", workspace });
+      const content = `Read ${reference}\n`;
+      await fs.writeFile(path.join(workspace, "AGENTS.md"), content);
+      const out = path.join(directory, "portable");
+      const { runtime, logs } = createCapturingTestRuntime();
+      await agentsExportCommand({ id: "source", out, json: true }, runtime);
+      expect(JSON.parse(logs.join("\n")).warnings).toEqual(
+        portable ? [] : [expect.stringContaining("workspace/AGENTS.md:1: absolute local path")],
+      );
+      expect(await fs.readFile(path.join(out, "workspace", "AGENTS.md"), "utf8")).toBe(content);
+    });
   });
 });

--- a/src/commands/agents.templates.test.ts
+++ b/src/commands/agents.templates.test.ts
@@ -1,0 +1,457 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createAgent } from "../agents/agent-create.js";
+import { loadAgentTemplateBundle } from "../agents/agent-template-bundle.js";
+import { AGENT_TEMPLATE_FILES } from "../agents/agent-template-schema.js";
+import { loadAgentTemplate } from "../agents/agent-templates.js";
+import { readConfigFileSnapshot, resetConfigRuntimeState } from "../config/config.js";
+import {
+  loadCronJobsStoreWithConfigJobsReadOnly,
+  resolveCronJobsStorePathFromConfig,
+  saveCronJobsStore,
+} from "../cron/store.js";
+import type { CronJob } from "../cron/types.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
+import { withEnvAsync } from "../test-utils/env.js";
+import { agentsExportCommand, agentsImportCommand } from "./agents.commands.templates.js";
+import { createCapturingTestRuntime } from "./test-runtime-config-helpers.js";
+
+const tempDirs = createSuiteTempRootTracker({ prefix: "openclaw-agent-templates-" });
+beforeAll(async () => {
+  await tempDirs.setup();
+});
+afterAll(async () => {
+  await tempDirs.cleanup();
+});
+
+async function withState(run: (directory: string, configPath: string) => Promise<void>) {
+  const directory = await tempDirs.make();
+  const configPath = path.join(directory, "openclaw.json");
+  await withEnvAsync(
+    {
+      OPENCLAW_STATE_DIR: directory,
+      OPENCLAW_CONFIG_PATH: configPath,
+      OPENCLAW_WORKSPACE_DIR: undefined,
+      OPENCLAW_HOME: directory,
+    },
+    async () => {
+      resetConfigRuntimeState();
+      try {
+        await fs.writeFile(
+          configPath,
+          JSON.stringify({
+            agents: {
+              ownership: "explicit",
+              entries: {
+                ambient: { workspace: path.join(directory, "ambient") },
+              },
+            },
+          }),
+        );
+        await run(directory, configPath);
+      } finally {
+        closeOpenClawAgentDatabasesForTest();
+        closeOpenClawStateDatabaseForTest();
+        resetConfigRuntimeState();
+      }
+    },
+  );
+}
+
+async function makeBundle(directory: string) {
+  const bundle = path.join(directory, "bundle");
+  const template = await loadAgentTemplate("researcher");
+  await fs.mkdir(path.join(bundle, "workspace"), { recursive: true });
+  await fs.writeFile(path.join(bundle, "manifest.json"), JSON.stringify(template.manifest));
+  for (const file of AGENT_TEMPLATE_FILES) {
+    await fs.writeFile(path.join(bundle, "workspace", file), template.files[file]);
+  }
+  return { bundle, template };
+}
+
+describe("portable agent templates", () => {
+  it("round-trips the program and explicit settings, excludes private state, and imports only disabled owned agent turns", async () => {
+    await withState(async (directory, configPath) => {
+      const workspace = path.join(directory, "source");
+      const identity = { name: "Archivist", emoji: "📚", theme: "Careful research" };
+      const created = await createAgent({ name: "source", role: "researcher", workspace });
+      expect(created.status).toBe("created");
+      const snapshot = await readConfigFileSnapshot();
+      const initial = snapshot.sourceConfig ?? snapshot.config;
+      const entry = initial.agents?.entries?.source;
+      expect(entry).toBeDefined();
+      Object.assign(entry!, {
+        identity,
+        description: "A careful research assistant",
+        skills: ["notes"],
+        model: { primary: "local/research", fallbacks: [] },
+        subagents: { allowAgents: ["ambient", "missing"], delegationMode: "prefer" },
+      });
+      await fs.writeFile(configPath, JSON.stringify(initial));
+      resetConfigRuntimeState();
+      const program = "# Program\nPreserve sources and distinguish claims from evidence.\n";
+      await fs.writeFile(path.join(workspace, "AGENTS.md"), program);
+      await fs.writeFile(path.join(workspace, "USER.md"), "Personal owner biography");
+      await fs.writeFile(path.join(workspace, "MEMORY.md"), "Personal long-term memory");
+      await fs.mkdir(path.join(workspace, "memory"));
+      await fs.writeFile(path.join(workspace, "memory", "today.md"), "Private daily notes");
+      if (created.status !== "created") {
+        throw new Error("fixture agent not created");
+      }
+      await fs.mkdir(created.agentDir, { recursive: true });
+      await fs.writeFile(path.join(created.agentDir, "auth-profiles.json"), "Private auth fixture");
+      await fs.writeFile(path.join(workspace, "BOOTSTRAP.md"), "Private bootstrap");
+      const job: CronJob = {
+        id: "turn",
+        agentId: "source",
+        owner: { agentId: "source", accountId: "private-account" },
+        name: "Review notes",
+        description: "Summarize research",
+        enabled: true,
+        createdAtMs: 1,
+        updatedAtMs: 1,
+        schedule: { kind: "every", everyMs: 60_000 },
+        pacing: { min: "1m", max: "10m" },
+        sessionTarget: "isolated",
+        wakeMode: "now",
+        payload: {
+          kind: "agentTurn",
+          message: "Review the sources",
+          model: "local/research",
+          thinking: "low",
+          timeoutSeconds: 30,
+          allowUnsafeExternalContent: true,
+        },
+        delivery: { mode: "announce", channel: "last", to: "private-recipient" },
+        state: {},
+      };
+      const jobs: CronJob[] = [
+        job,
+        { ...job, id: "other-owner", owner: { agentId: "ambient" } },
+        { ...job, id: "other-executor", agentId: "ambient" },
+        {
+          ...job,
+          id: "event",
+          sessionTarget: "main",
+          payload: { kind: "systemEvent", text: "Private event" },
+        },
+        {
+          ...job,
+          id: "command",
+          payload: { kind: "command", argv: ["echo", "private"], env: { PRIVATE: "fixture" } },
+        },
+        { ...job, id: "script", payload: { kind: "script", script: "return 1" } },
+        { ...job, id: "watcher", schedule: { kind: "on-exit", command: "private executable" } },
+      ];
+      const storePath = resolveCronJobsStorePathFromConfig(initial);
+      await saveCronJobsStore(storePath, { version: 1, jobs });
+      const beforeJobs = await loadCronJobsStoreWithConfigJobsReadOnly(storePath);
+      const out = path.join(directory, "portable");
+      const exported = createCapturingTestRuntime();
+      await agentsExportCommand({ id: "source", out, json: true }, exported.runtime);
+      expect(JSON.parse(exported.logs.join("\n"))).toMatchObject({
+        automations: 1,
+        omissions: expect.arrayContaining([
+          "USER.md not exported",
+          "3 automation(s) skipped: unsupported payload for portable templates",
+          "1 automation(s) skipped: executable schedule for portable templates",
+        ]),
+      });
+      expect(await fs.readdir(out)).toEqual(["automations.json", "manifest.json", "workspace"]);
+      expect(await fs.readdir(path.join(out, "workspace"))).toEqual([
+        "AGENTS.md",
+        "IDENTITY.md",
+        "SOUL.md",
+      ]);
+      const automationText = await fs.readFile(path.join(out, "automations.json"), "utf8");
+      expect(automationText).not.toMatch(
+        /private|allowUnsafeExternalContent|owner|agentId|enabled|delivery/,
+      );
+      expect((await loadCronJobsStoreWithConfigJobsReadOnly(storePath)).store.jobs).toEqual(
+        beforeJobs.store.jobs,
+      );
+      const destination = path.join(directory, "imported");
+      const imported = createCapturingTestRuntime();
+      await agentsImportCommand(
+        { directory: out, id: "copy", workspace: destination, nonInteractive: true, json: true },
+        imported.runtime,
+      );
+      expect(JSON.parse(imported.logs.join("\n"))).toMatchObject({
+        status: "created",
+        agentId: "copy",
+        warnings: [expect.stringContaining("missing")],
+        review: expect.stringContaining("Review before enabling"),
+      });
+      const next = await readConfigFileSnapshot();
+      expect(next.valid).toBe(true);
+      expect(next.config.agents?.entries?.copy).toMatchObject({
+        identity,
+        description: "A careful research assistant",
+        skills: ["notes"],
+        model: { primary: "local/research", fallbacks: [] },
+        subagents: { allowAgents: ["ambient"], delegationMode: "prefer" },
+      });
+      expect(await fs.readFile(path.join(destination, "AGENTS.md"), "utf8")).toBe(program);
+      for (const file of ["SOUL.md", "IDENTITY.md"]) {
+        expect(await fs.readFile(path.join(destination, file), "utf8")).toBe(
+          await fs.readFile(path.join(workspace, file), "utf8"),
+        );
+      }
+      await expect(fs.access(path.join(destination, "BOOTSTRAP.md"))).rejects.toMatchObject({
+        code: "ENOENT",
+      });
+      const importedJobs = (
+        await loadCronJobsStoreWithConfigJobsReadOnly(storePath)
+      ).store.jobs.filter((candidate) => candidate.agentId === "copy");
+      expect(importedJobs).toHaveLength(1);
+      expect(importedJobs[0]).toMatchObject({
+        enabled: false,
+        agentId: "copy",
+        owner: { agentId: "copy" },
+        sessionTarget: "isolated",
+        delivery: { mode: "none" },
+        payload: { kind: "agentTurn", message: "Review the sources", timeoutSeconds: 30 },
+      });
+      expect(importedJobs[0]?.id).not.toBe(job.id);
+    });
+  });
+
+  it("refuses probable secrets with file and line before replacing an output directory", async () => {
+    await withState(async (directory) => {
+      const workspace = path.join(directory, "source");
+      await createAgent({ name: "source", role: "researcher", workspace });
+      const secret = ["sk", "proj", "a".repeat(40)].join("-");
+      await fs.writeFile(path.join(workspace, "SOUL.md"), `# Soul\n${secret}\n`);
+      const out = path.join(directory, "portable");
+      await fs.mkdir(out);
+      await fs.writeFile(path.join(out, "keep.txt"), "untouched");
+      const failure = agentsExportCommand(
+        { id: "source", out, force: true },
+        createCapturingTestRuntime().runtime,
+      );
+      await expect(failure).rejects.toThrow(/workspace\/SOUL.md:2: probable secret/);
+      await expect(failure).rejects.not.toThrow(secret);
+      expect(await fs.readFile(path.join(out, "keep.txt"), "utf8")).toBe("untouched");
+    });
+  });
+
+  it("exports only explicit settings and replaces output only with force", async () => {
+    await withState(async (directory, configPath) => {
+      const snapshot = await readConfigFileSnapshot();
+      const cfg = snapshot.sourceConfig ?? snapshot.config;
+      await fs.writeFile(
+        configPath,
+        JSON.stringify({
+          ...cfg,
+          agents: {
+            ...cfg.agents,
+            defaults: { skills: ["inherited-skill"], model: "local/inherited" },
+          },
+        }),
+      );
+      resetConfigRuntimeState();
+      const workspace = path.join(directory, "source");
+      await createAgent({ name: "source", role: "researcher", workspace });
+      const out = path.join(directory, "portable");
+      await fs.mkdir(out);
+      await fs.writeFile(path.join(out, "old.txt"), "Prior output");
+      const { runtime } = createCapturingTestRuntime();
+      await expect(agentsExportCommand({ id: "source", out }, runtime)).rejects.toThrow(
+        /not empty/,
+      );
+      expect(await fs.readFile(path.join(out, "old.txt"), "utf8")).toBe("Prior output");
+      await agentsExportCommand({ id: "source", out, force: true }, runtime);
+      expect(await fs.readdir(out)).toEqual(["manifest.json", "workspace"]);
+      const { template } = await loadAgentTemplateBundle(out);
+      expect(template.manifest.skills).toBeUndefined();
+      expect(template.manifest.model).toBeUndefined();
+      expect(template.manifest.role).toBeUndefined();
+    });
+  });
+
+  it("rejects secrets and local paths in decoded JSON before writing an imported agent", async () => {
+    await withState(async (directory, configPath) => {
+      const { bundle, template } = await makeBundle(directory);
+      const before = await fs.readFile(configPath, "utf8");
+      const key = ["sk", "proj", "a".repeat(40)].join("-");
+      for (const summary of [key, "Local instructions\n/private/work/notes"]) {
+        const serialized = JSON.stringify({ ...template.manifest, summary }).replace(
+          "sk-proj",
+          "\\u0073k-proj",
+        );
+        await fs.writeFile(path.join(bundle, "manifest.json"), serialized);
+        await expect(
+          agentsImportCommand(
+            { directory: bundle, id: "copy", nonInteractive: true },
+            createCapturingTestRuntime().runtime,
+          ),
+        ).rejects.toThrow(/probable secret|absolute local path/);
+        expect(await fs.readFile(configPath, "utf8")).toBe(before);
+      }
+    });
+  });
+
+  it.each(["../AGENTS.md", "/AGENTS.md", "C:\\AGENTS.md"])(
+    "rejects manifest path %s before creating state",
+    async (unsafe) => {
+      await withState(async (directory, configPath) => {
+        const { bundle, template } = await makeBundle(directory);
+        await fs.writeFile(
+          path.join(bundle, "manifest.json"),
+          JSON.stringify({ ...template.manifest, files: [unsafe, "SOUL.md", "IDENTITY.md"] }),
+        );
+        const before = await fs.readFile(configPath, "utf8");
+        await expect(
+          agentsImportCommand(
+            { directory: bundle, id: "copy", nonInteractive: true },
+            createCapturingTestRuntime().runtime,
+          ),
+        ).rejects.toThrow(/manifest/);
+        expect(await fs.readFile(configPath, "utf8")).toBe(before);
+      });
+    },
+  );
+
+  it.each(["symlink", "oversize", "unexpected"])("rejects %s bundle material", async (kind) => {
+    const directory = await tempDirs.make();
+    const { bundle } = await makeBundle(directory);
+    const soul = path.join(bundle, "workspace", "SOUL.md");
+    if (kind === "symlink") {
+      await fs.unlink(soul);
+      await fs.symlink("AGENTS.md", soul);
+    } else if (kind === "oversize") {
+      await fs.writeFile(soul, "x".repeat(256 * 1024 + 1));
+    } else {
+      await fs.writeFile(path.join(bundle, "USER.md"), "Personal file");
+    }
+    await expect(loadAgentTemplateBundle(bundle)).rejects.toThrow(/symlinks|exceeds|Unexpected/);
+  });
+
+  it("preserves explicit empty skills and omits delegation when every requested target is missing", async () => {
+    await withState(async (directory) => {
+      const { bundle, template } = await makeBundle(directory);
+      await fs.writeFile(
+        path.join(bundle, "manifest.json"),
+        JSON.stringify({
+          ...template.manifest,
+          skills: [],
+          subagents: { allowAgents: ["absent", "*"], delegationMode: "suggest" },
+        }),
+      );
+      const { runtime, logs } = createCapturingTestRuntime();
+      await agentsImportCommand(
+        {
+          directory: bundle,
+          id: "copy",
+          workspace: path.join(directory, "copy"),
+          nonInteractive: true,
+          json: true,
+        },
+        runtime,
+      );
+      const entry = (await readConfigFileSnapshot()).config.agents?.entries?.copy;
+      expect(entry?.skills).toEqual([]);
+      expect(entry?.model).toBeUndefined();
+      expect(entry?.subagents).toEqual({ delegationMode: "suggest" });
+      expect(JSON.parse(logs.join("\n")).warnings).toEqual([expect.stringContaining("absent, *")]);
+    });
+  });
+
+  it("refuses existing ids and nonempty workspaces without modifying config or files", async () => {
+    await withState(async (directory, configPath) => {
+      const { bundle } = await makeBundle(directory);
+      const workspace = path.join(directory, "occupied");
+      await fs.mkdir(workspace);
+      await fs.writeFile(path.join(workspace, "AGENTS.md"), "Existing program");
+      const before = await fs.readFile(configPath, "utf8");
+      for (const id of ["ambient", "copy"]) {
+        await expect(
+          agentsImportCommand(
+            { directory: bundle, id, workspace, nonInteractive: true },
+            createCapturingTestRuntime().runtime,
+          ),
+        ).rejects.toThrow(/already exists|new or empty/);
+      }
+      expect(await fs.readFile(configPath, "utf8")).toBe(before);
+      expect(await fs.readFile(path.join(workspace, "AGENTS.md"), "utf8")).toBe("Existing program");
+    });
+  });
+
+  it("rejects an invalid automation before creating the agent or workspace", async () => {
+    await withState(async (directory, configPath) => {
+      const { bundle } = await makeBundle(directory);
+      await fs.writeFile(
+        path.join(bundle, "automations.json"),
+        JSON.stringify([
+          {
+            name: "Blank instruction",
+            schedule: { kind: "every", everyMs: 60_000 },
+            payload: { kind: "agentTurn", message: "   " },
+          },
+        ]),
+      );
+      const before = await fs.readFile(configPath, "utf8");
+      const workspace = path.join(directory, "copy");
+      await expect(
+        agentsImportCommand(
+          { directory: bundle, id: "copy", workspace, nonInteractive: true },
+          createCapturingTestRuntime().runtime,
+        ),
+      ).rejects.toThrow();
+      expect(await fs.readFile(configPath, "utf8")).toBe(before);
+      await expect(fs.access(workspace)).rejects.toMatchObject({ code: "ENOENT" });
+    });
+  });
+
+  it("recognizes an existing case alias as a protected output directory", async (context) => {
+    await withState(async (directory) => {
+      const workspace = path.join(directory, "source");
+      await createAgent({ name: "source", role: "researcher", workspace });
+      const alias = path.join(directory, "SOURCE");
+      if (!(await fs.stat(alias).catch(() => undefined))) {
+        context.skip();
+        return;
+      }
+      await expect(
+        agentsExportCommand({ id: "source", out: alias }, createCapturingTestRuntime().runtime),
+      ).rejects.toThrow(/overlaps/);
+      expect(await fs.readdir(workspace)).toContain("AGENTS.md");
+    });
+  });
+
+  it.each([
+    { reference: "file:///Users/example/project", portable: false },
+    { reference: "Path:/Users/example/project", portable: false },
+    { reference: "|/Users/example/project|", portable: false },
+    { reference: "**/Users/example/project**", portable: false },
+    { reference: "«/Users/example/project»", portable: false },
+    { reference: "_/Users/example/project_", portable: false },
+    { reference: "~~/Users/example/project~~", portable: false },
+    { reference: "C://Users/example/project", portable: false },
+    { reference: "https://example.org»/Users/example/project", portable: false },
+    { reference: "https://example.org,/Users/example/project", portable: false },
+    { reference: "_https://example.org_/Users/example/project_", portable: false },
+    { reference: "~~https://example.org~~/Users/example/project", portable: false },
+    { reference: "https://example.org/docs", portable: true },
+    { reference: "https://example.org/#/agent", portable: true },
+    { reference: "https://example.org/?next=/docs", portable: true },
+    { reference: "./notes/reference.md", portable: true },
+    { reference: "notes_/reference.md", portable: true },
+    { reference: "https://example.org/%C2%BB/docs", portable: true },
+    { reference: "https://example.org/%2C/docs", portable: true },
+    { reference: "_https://example.org/docs_", portable: true },
+  ])("checks portability of embedded reference $reference", async ({ reference, portable }) => {
+    const directory = await tempDirs.make();
+    const { bundle } = await makeBundle(directory);
+    const content = `Read ${reference}\n`;
+    await fs.writeFile(path.join(bundle, "workspace", "AGENTS.md"), content);
+    if (portable) {
+      expect((await loadAgentTemplateBundle(bundle)).template.files["AGENTS.md"]).toBe(content);
+    } else {
+      await expect(loadAgentTemplateBundle(bundle)).rejects.toThrow(/absolute local path/);
+    }
+  });
+});


### PR DESCRIPTION
Stacked on #141174 (role templates and team preset); this PR targets that branch and will retarget to `main` once it lands.

## What Problem This Solves

There is no way to hand a configured agent to someone else, or to move one between installs, without copying workspace files by hand and re-deriving identity, skills, model, and delegation config. Anything copied by hand also risks carrying credentials, memory, or personal files along.

## Why This Change Was Made

Adds a portable, secret-free agent template bundle and two commands built on the shared creation path and the role-template manifest from #141174:

- **`openclaw agents export <id> --out <dir> [--force] [--json]`** writes `manifest.json` (identity, title/summary, explicitly configured skills allowlist, agent-level model, `subagents.allowAgents` as ids plus `delegationMode`), `workspace/{AGENTS.md,SOUL.md,IDENTITY.md}`, and optional `automations.json` with sanitized agent-turn jobs owned and executed by that agent (name, schedule, prompt, model/thinking/timeout only). It never includes `USER.md`, `MEMORY.md`, `memory/`, `BOOTSTRAP.md`, auth profiles, sessions, agentDir, delivery targets, tool policy, or command/script/system-event jobs, and it prints an omissions report saying so. Export refuses when the secret scanner finds a probable literal secret (no bypass flag); embedded absolute paths are reported as review warnings, not refusals. Output never overlaps the source workspace, agent state, or state dir; a non-empty output needs `--force` and is replaced atomically.
- **`openclaw agents import <dir> [--id <newId>] [--workspace <dir>] [--non-interactive] [--json]`** validates the bundle (strict manifest, exact file set, 32 files / 256 KiB per file / 2 MiB total, no symlinks, no path escape), creates the agent through `createAgent` with identity completed (no `BOOTSTRAP.md`), seeds the workspace program files, applies skills/model/delegation (only delegation ids that exist in the target roster are kept; dropped ids are listed), and creates automations disabled and retargeted to the new id with a "review before enabling" line. Interactive runs confirm the summary first.

No new config keys. The bundle format is documented for tool authors in `docs/reference/agent-templates.md`.

## User Impact

Share an agent with a link to a folder, install one from someone else, or move an agent between machines with `export`/`import`, without ever copying credentials or memory. Role agents from #141174 round-trip unchanged.

## Evidence

| Before | After |
| --- | --- |
| ![before](https://github.com/user-attachments/assets/c6e76e21-69ee-4d63-a011-169a7253447c) | ![after](https://github.com/user-attachments/assets/21eb92db-0ec8-4d2f-a7b6-b6d048179df6) |

Round trip in an isolated state dir (role agent → export → import as a new id):

![round trip](https://github.com/user-attachments/assets/37437159-9328-40c1-957c-bb79243b966e)

- Focused tests (templates command suite, template catalog, CLI registration, command JSON classification): 71 passed on the final head; the full templates suite covers exact exported file set and exclusions, secret refusal on a planted fake key, identity/skills/automation round trip with disabled retargeted jobs, path-escape and oversize rejection, and existing-id refusal. `node scripts/check-changed.mjs` passed.
- Independent review pass on the branch: no actionable findings.

Line delta (task only, on top of #141174): production +749, tests +469, docs +217. The growth is the bundle IO/validation, cron conversion, and two commands; nearby cleanup removed duplicate catalog file loading and reused the existing identity parser and cron validators.

## Known Gaps

- Pattern-based secret detection is conservative, not proof; the docs tell operators to inspect a bundle before sharing.
- Import is not a single transaction across workspace, config, and automations: an automation write failure after the agent exists reports per-item outcomes and exits non-zero rather than rolling back.
- Role origin is not persisted, so delegation targets travel as ids, not role names.
