### PR TITLE
fix(compaction): prevent low context counts after server compaction

### DIFF
--- a/src/agents/embedded-agent-runner/compact.delegate.test.ts
+++ b/src/agents/embedded-agent-runner/compact.delegate.test.ts
@@ -10,6 +10,7 @@ import {
 import type { ProviderConfigInput } from "../sessions/model-registry.js";
 import {
   applyExtraParamsToAgentMock,
+  buildEmbeddedSystemPromptMock,
   hookRunner,
   limitHistoryTurnsMock,
   loadCompactHooksHarness,
@@ -33,6 +34,8 @@ let databases: typeof import("../../state/openclaw-agent-db.js");
 let streamResolution: typeof import("./stream-resolution.js");
 let replay: typeof import("../openai-transport-stream.test-support.js").testing;
 let accounting: typeof import("./run/compaction-accounting-bridge.js");
+let requestBudgets: typeof import("../sessions/compaction/request-budget.js");
+let pressure: typeof import("./run/preemptive-compaction.js");
 const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
   afterEach(() => {
     databases.closeOpenClawAgentDatabasesForTest();
@@ -62,6 +65,8 @@ beforeAll(async () => {
     streamResolution,
     { testing: replay },
     accounting,
+    requestBudgets,
+    pressure,
   ] = await Promise.all([
     import("../../context-engine/delegate.js"),
     import("../sessions/index.js"),
@@ -70,6 +75,8 @@ beforeAll(async () => {
     import("./stream-resolution.js"),
     import("../openai-transport-stream.test-support.js"),
     import("./run/compaction-accounting-bridge.js"),
+    import("../sessions/compaction/request-budget.js"),
+    import("./run/preemptive-compaction.js"),
   ]);
 });
 
@@ -176,6 +183,143 @@ async function createFixture(operation: "summary" | "endpoint", globalAlias = fa
 }
 
 describe("direct compactor through the context-engine delegate", () => {
+  it.each([
+    { budget: "absent", pendingPrompt: "" },
+    { budget: "foreground", pendingPrompt: "" },
+    { budget: "foreground with pending input", pendingPrompt: "Unrecorded request. ".repeat(500) },
+  ])(
+    "records server checkpoint pressure with $budget budget",
+    async ({ budget, pendingPrompt }) => {
+      const fixture = await createFixture("endpoint");
+      const compactorPrompt = "Summarize the deployment discussion.";
+      buildEmbeddedSystemPromptMock.mockReturnValue(compactorPrompt);
+      const requestBudget = requestBudgets.createCompactionRequestBudget({
+        contextWindow: model.contextWindow,
+        reserveTokens: 16_384,
+        systemPrompt: "Help the operator deploy safely using the available tools.",
+        tools: [
+          {
+            name: "lookup_deployment",
+            description: "Available deployment target and its constraints. ".repeat(500),
+            parameters: { type: "object", properties: { target: { type: "string" } } },
+          },
+        ],
+        pendingPrompt,
+      });
+      const hasBudget = budget !== "absent";
+      accounting.attachCompactionAccountingRecorder(fixture.runtimeContext, {
+        ...(hasBudget ? { requestBudget } : {}),
+        recordUsage: fixture.recordUsage,
+        recordCompaction: fixture.recordCompaction,
+      });
+      const manager = sessions.SessionManager.open(fixture.target, workspaceDir);
+      const discardedAssistantText = "Old deployment diagnostic material. ".repeat(3_000);
+      manager.appendMessage({ role: "user", content: "Read the deployment log.", timestamp: 2 });
+      manager.appendMessage(
+        createAssistant(model, [{ type: "text", text: discardedAssistantText }]),
+      );
+      manager.appendMessage({
+        role: "user",
+        content: "Continue with the next step.",
+        timestamp: 3,
+      });
+      manager.appendMessage(createAssistant(model, [{ type: "text", text: "Ready to continue." }]));
+      manager.flushPendingPersistence();
+      const retainedUsers = manager
+        .buildSessionContext()
+        .messages.filter((message) => message.role === "user")
+        .map((message) => {
+          if (typeof message.content !== "string") {
+            throw new Error("Expected plain-text fixture input");
+          }
+          return {
+            type: "message" as const,
+            role: "user" as const,
+            content: [{ type: "input_text" as const, text: message.content }],
+          };
+        });
+      const checkpoint = {
+        type: "compaction" as const,
+        id: "cmp_budget",
+        encrypted_content: "opaque",
+      };
+      const output = [...retainedUsers, checkpoint];
+      requestPreparedCompaction.mockImplementationOnce(
+        async (_stream, requestModel, _context, options) => ({
+          item: checkpoint,
+          output,
+          historyMode: "retained-users",
+          usage: { input_tokens: 30_000, output_tokens: 200 },
+          model: requestModel,
+          replayMetadata: replay.buildOpenAIResponsesReasoningReplayMetadata(requestModel, options),
+        }),
+      );
+
+      const result = await delegate({
+        sessionId: fixture.target.sessionId,
+        sessionKey: fixture.target.sessionKey,
+        sessionTarget: fixture.target,
+        runtimeContext: fixture.runtimeContext,
+      });
+      expect(result, JSON.stringify(result)).toMatchObject({ ok: true, compacted: true });
+      expect(result.result?.details).toMatchObject({ compactionKind: "server-endpoint" });
+      databases.closeOpenClawAgentDatabasesForTest();
+      const messages = sessions.SessionManager.open(fixture.target).buildSessionContext().messages;
+      expect(messages.at(-1)).toMatchObject({
+        providerReplay: {
+          type: "openai-responses-retained-compaction",
+          data: "opaque",
+          compactedWindow: { state: "ready", output: JSON.stringify(output) },
+        },
+      });
+      expect(
+        messages.some(
+          (message) =>
+            message.role === "assistant" &&
+            message.content.some(
+              (block) => block.type === "text" && block.text === discardedAssistantText,
+            ),
+        ),
+      ).toBe(true);
+      const endpointCall = requestPreparedCompaction.mock.calls[0];
+      if (!endpointCall) {
+        throw new Error("Expected the provider endpoint to receive the compaction request");
+      }
+      const replayContext = {
+        model: endpointCall[1],
+        sessionId: endpointCall[3].sessionId,
+        authProfileId: endpointCall[3].authProfileId,
+        enabled: true,
+      };
+      const replayHistory =
+        pressure.estimateLlmBoundaryTokenPressure({ messages, prompt: "", replay: replayContext }) -
+        pressure.estimateRenderedLlmBoundaryTokenPressure({ prompt: "" });
+      const expected = hasBudget
+        ? requestBudget.fixedTokens + replayHistory
+        : pressure.estimateLlmBoundaryTokenPressure({
+            messages,
+            systemPrompt: compactorPrompt,
+            prompt: "",
+            replay: replayContext,
+          });
+      // The large stored prefix is retained for audit, but only the accepted window
+      // plus foreground fixed cost belongs in the committed context snapshot.
+      expect(requestBudgets.estimateCompactionHistoryTokens(messages)).toBeGreaterThan(20_000);
+      expect(replayHistory).toBeGreaterThan(0);
+      expect(replayHistory).toBeLessThan(1_000);
+      expect(requestBudget.fixedTokens).toBeGreaterThan(5_000);
+      if (pendingPrompt) {
+        expect(requestBudget.pendingTokens).toBeGreaterThan(1_000);
+      } else {
+        expect(requestBudget.pendingTokens).toBe(0);
+      }
+      expect(result.result?.tokensAfter).toBe(expected);
+      expect(fixture.recordCompaction).toHaveBeenCalledExactlyOnceWith(expected);
+      expect(requestPreparedCompaction).toHaveBeenCalledOnce();
+      expect(fixture.stream).not.toHaveBeenCalled();
+    },
+  );
+
   it.each([
     { operation: "summary", partial: false, threadId: "thread-route" },
     { operation: "summary", partial: true, threadId: 0 },

--- a/src/agents/embedded-agent-runner/compaction-session-execution.ts
+++ b/src/agents/embedded-agent-runner/compaction-session-execution.ts
@@ -486,7 +486,7 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
             // replacement window synchronously with its accepted rewrite.
             serverTokensAfter = estimateLlmBoundaryTokenPressure({
               messages: sessionManager.buildSessionContext().messages,
-              systemPrompt: systemPromptText,
+              systemPrompt: accountingRecorder?.requestBudget ? undefined : systemPromptText,
               prompt: "",
               replay: {
                 model: effectiveModel,
@@ -495,6 +495,11 @@ export async function executePreparedCompactionSession(runtime: PreparedCompacti
                 enabled: compactionReplayEnabled,
               },
             });
+            // Keep replay-aware history, but charge the foreground system/tools.
+            serverTokensAfter += accountingRecorder?.requestBudget
+              ? accountingRecorder.requestBudget.fixedTokens -
+                estimateLlmBoundaryTokenPressure({ messages: [], prompt: "" })
+              : 0;
             accountingRecorder?.recordCompaction?.(serverTokensAfter);
           };
           const serverResult = params.transcriptBytePreflightAuthority


### PR DESCRIPTION
Closes #141340

## What Problem This Solves

Fixes an issue where users with sizeable tool definitions can see an understated fresh context estimate after server-endpoint compaction. The accepted checkpoint remains valid, but missing foreground request overhead can delay later preemptive compaction.

## Why This Change Was Made

The existing server accounting callback now combines its replay-aware accepted window with the foreground request's fixed budget, removing the already-counted empty request boundary. It excludes the separate compactor prompt when that foreground budget is present and leaves the no-budget path unchanged.

This is one accounting correction. It does not change replay/auth fences, endpoint policy, checkpoint persistence, estimator APIs or host write-race behavior. Pending input is not part of this committed-context snapshot.

## User Impact

Successful server compaction retains system/tool overhead in the fresh context estimate without counting the large original history kept only for audit. The committed count is the same whether or not a future input has been reserved.

## Evidence

### Real OpenAI server-compaction observation

Tested clean commit `7dbfd15399fcfa5b8ced8c31ddfc2b970b454cf6`, before and after the run, on Windows x64 / Node **24.19.0**, using public model **openai/gpt-5.2**. The run completed on **2026-09-09 13:32:56–13:33:37 UTC**.

[Reproducible proof driver, redacted receipt, and instructions](https://gist.github.com/ooiuuii/f8a1fe62add176d6e6508fa47b7088e0).

The standalone source-owner harness calls the real prepared-compaction execution, constructs the real session/model registry/runtime plan, uses the real OpenAI transport, and closes/reopens an isolated SQLite session. **The provider endpoint and accepted checkpoint are not mocked.** Its model-fetch observation recorded exactly one `POST https://api.openai.com/v1/responses/compact`, HTTP **200**, with no retry or replacement response.

Copied values from the redacted receipt:

```text
serverEndpointAccepted: true
checkpointReopened: true
auditHistoryRetained: true
fixedForegroundTokens: 10586
replayHistoryTokens: 1908
expectedTokensAfter: 12494
observedTokensAfter: 12494
recordedCompactions: [12494]
pendingTokensExcluded: 1080
oldFormulaSameAcceptedWindow: 1966
assertions: 10/10 true
worker.exitCode: 0
worker.timedOut: false
```

Thus the result and injected accounting callback both report **12,494 = 10,586 foreground fixed tokens + 1,908 replay-history tokens**. The **1,080 pending tokens** are excluded. The real accepted checkpoint is ready after SQLite reopen, while original audit history remains stored without being charged again as live replay history.

The **1,966** old-formula value is a counterfactual estimator calculation on the **same post-fix accepted window**, not a separate before-patch live API run. The controlled before/after regression below supplies the deterministic baseline.

The attached driver is byte-identical to the executed driver, SHA-256 `9aa15633f298fc5534bc55ce28eaf4629f4786f55bbedcca0b57672c93451ba7`. It checks the exact clean HEAD and seven critical source blobs before/after. Generalized command (credential supplied through a secure process-only environment, not command arguments):

```text
node compaction-proof.mjs run --repo "<checkout>" --expected-head 7dbfd15399fcfa5b8ced8c31ddfc2b970b454cf6 --model gpt-5.2
```

**Proof limits:** synthetic conversation, foreground system/tool budget, model metadata, and in-memory recorder callback; manual compaction trigger. This proves the prepared-compaction/provider/checkpoint/accounting boundary, not an installed Gateway/full foreground-chat E2E, automatic pressure trigger, overflow recovery, downstream persisted/user-visible accounting, OAuth, other providers/models, or concurrency behavior. The receipt is author-provided evidence, not remote attestation or a process-wide packet capture. Credentials, request identifiers, raw databases and opaque checkpoint contents are not published.

### Controlled regression and focused gates

The prior controlled baseline on `00fd5d6a404939da829ceae80e01d941a729cf06` exercised the actual delegate, session constructor, SQLite checkpoint and observer, with only the external endpoint result mocked:

- Before fix: no-budget case passed; both foreground-budget cases failed **222 vs 10,078**, wrapper exit 1.
- After fix: no-budget remains **222**; both foreground cases return and record **10,078**.
- Coverage includes SQLite close/reopen, accepted replay bounds, retained audit history, exactly one accounting notification, pending-input exclusion and no client-side summary call.

On the current tested head, **21/21 tests passed** (delegate 11, endpoint 8, replay 2; two sequential shards; wrapper exit 0; 110.35 seconds):

```sh
node scripts/run-vitest.mjs src/agents/embedded-agent-runner/compact.delegate.test.ts src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts src/agents/embedded-agent-runner/run/preemptive-compaction.replay.test.ts
```

Two-file formatting and `git diff --check` passed. A fresh scoped type-aware lint run on Node 24.19.0 also exited 0:

```sh
node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json --type-aware src/agents/embedded-agent-runner/compaction-session-execution.ts src/agents/embedded-agent-runner/compact.delegate.test.ts
```

The full changed-file gate and full repository typecheck/build/test suite were not run locally; hosted CI is tracked separately.

One final structured Codex review of `7dbfd15399fcfa5b8ced8c31ddfc2b970b454cf6` against `5c70f9f5382311588df24b88501f5d907b2db04a` completed with helper exit 0:

```text
autoreview scoped-clean: no accepted/actionable findings in the selected Git scope and priority
```

The selected priority range was P0–P2. The diff remains **2 files, +150/-1**, with production **+6/-1**; no additional refactor, API, persistence-format or unrelated CI changes were added. The base refresh inherits upstream CI repairs; it does not claim the old failed CI run passed. Fresh exact-head CI and maintainer review remain required.
