### PR TITLE
refactor(native): share Talk configuration snapshots

### DIFF
--- a/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
+++ b/apps/ios/Sources/Voice/TalkModeGatewayConfig.swift
@@ -212,16 +212,16 @@ enum TalkModeRoutingResolver {
             .realtimeWebRTC
         } else if parsed.executionMode == .realtimeRelay {
             .realtimeRelay
-        } else if Self.normalized(parsed.activeProvider) == Self.normalized(defaultProvider) {
+        } else if Self.normalized(parsed.snapshot.activeProvider) == Self.normalized(defaultProvider) {
             .localElevenLabs
         } else {
             .gatewayTalkSpeak
         }
 
         return TalkModeResolvedRouting(
-            activeProvider: parsed.activeProvider,
+            activeProvider: parsed.snapshot.activeProvider,
             executionMode: Self.executionMode(for: route),
-            realtimeProvider: parsed.realtimeProvider,
+            realtimeProvider: parsed.snapshot.realtime.provider,
             realtimeModelId: parsed.realtimeModelId,
             route: route)
     }
@@ -243,23 +243,15 @@ enum TalkModeRoutingResolver {
 }
 
 struct TalkModeGatewayConfigState {
-    let activeProvider: String
-    let normalizedPayload: Bool
-    let missingResolvedPayload: Bool
+    let snapshot: TalkConfigSnapshot
     let executionMode: TalkModeExecutionMode
     let requiresGatewayRealtimeTransport: Bool
     let defaultVoiceId: String?
-    let voiceAliases: [String: String]
     let configuredModelId: String?
     let defaultModelId: String
     let defaultOutputFormat: String?
-    let realtimeProvider: String?
     let realtimeModelId: String?
-    let realtimeVoiceId: String?
     let rawConfigApiKey: String?
-    let interruptOnSpeech: Bool?
-    let silenceTimeoutMs: Int
-    let speechLocaleID: String?
 }
 
 enum TalkModeGatewayConfigParser {
@@ -271,97 +263,60 @@ enum TalkModeGatewayConfigParser {
         defaultSilenceTimeoutMs: Int) -> TalkModeGatewayConfigState
     {
         let talk = TalkConfigParsing.bridgeFoundationDictionary(config["talk"] as? [String: Any])
-        let selection = TalkConfigParsing.selectProviderConfig(
+        let snapshot = TalkConfigSnapshot(
             talk,
             defaultProvider: defaultProvider,
+            defaultSilenceTimeoutMs: defaultSilenceTimeoutMs,
             allowLegacyFallback: false)
-        let activeProvider = selection?.provider ?? defaultProvider
-        let activeConfig = selection?.config
-        let voiceAliases = TalkVoiceAliases.normalizedMap(activeConfig?["voiceAliases"])
+        let activeConfig = snapshot.providerConfig
         let model = TalkConfigParsing.firstNonEmptyString(activeConfig, keys: ["modelId", "model"])
         let defaultModelId = (model?.isEmpty == false) ? model! : defaultModelIdFallback
         let defaultVoiceId = TalkConfigParsing.firstNonEmptyString(activeConfig, keys: ["voiceId", "voice"])
         let defaultOutputFormat = TalkConfigParsing.firstNonEmptyString(activeConfig, keys: ["outputFormat"])
-        let realtime = talk?["realtime"]?.dictionaryValue
-        let realtimeProviders = realtime?["providers"]?.dictionaryValue
-        let realtimeProvider = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["provider"])
-            ?? TalkConfigParsing.singleRealtimeProviderID(realtimeProviders)
-        let realtimeProviderConfig = TalkConfigParsing.realtimeProviderConfig(
-            providers: realtimeProviders,
-            provider: realtimeProvider)
+        let realtime = snapshot.realtime
         let realtimeClientHints = TalkConfigParsing.bridgeFoundationDictionary(
             (config["clientHints"] as? [String: Any])?["realtime"] as? [String: Any])
         let gatewayOwnsRealtimeModel =
             TalkConfigParsing.firstNonEmptyString(realtimeClientHints, keys: ["modelSource"]) == "gateway"
-        let realtimeModel = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["model"])
-            ?? TalkConfigParsing.firstNonEmptyString(realtimeProviderConfig, keys: ["model"])
         let realtimeModelId = gatewayOwnsRealtimeModel
-            ? realtimeModel
-            : (realtimeModel ?? defaultRealtimeModelIdFallback)
-        let realtimeVoiceId = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["voice"])
-            ?? TalkConfigParsing.firstNonEmptyString(realtimeProviderConfig, keys: ["voice"])
-        let realtimeTransport = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["transport"])?.lowercased()
+            ? realtime.modelId
+            : (realtime.modelId ?? defaultRealtimeModelIdFallback)
         // Direct provider WebRTC can answer before consulting the agent, so this explicit
         // policy must stay on the relay that enforces final-transcript consultations.
-        let requiresForcedAgentConsultRelay = Self.requiresForcedAgentConsultRelay(realtime)
+        let requiresForcedAgentConsultRelay = realtime.consultRouting == "force-agent-consult"
         let requiresGatewayRealtimeTransport = requiresForcedAgentConsultRelay
-            || realtimeTransport == "gateway-relay"
-            || realtimeTransport == "provider-websocket"
-            || Self.usesAzureOpenAI(provider: realtimeProvider, config: realtimeProviderConfig)
+            || realtime.transport == "gateway-relay"
+            || realtime.transport == "provider-websocket"
+            || Self.usesAzureOpenAI(provider: realtime.provider, config: realtime.providerConfig)
         let executionMode = Self.resolvedExecutionMode(
             realtime,
             requiresGatewayRealtimeTransport: requiresGatewayRealtimeTransport)
         let rawConfigApiKey = activeConfig?["apiKey"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let interruptOnSpeech = talk?["interruptOnSpeech"]?.boolValue
-        let silenceTimeoutMs = TalkConfigParsing.resolvedSilenceTimeoutMs(
-            talk,
-            fallback: defaultSilenceTimeoutMs)
-        let speechLocaleID = TalkConfigParsing.resolvedSpeechLocaleID(talk)
 
         return TalkModeGatewayConfigState(
-            activeProvider: activeProvider,
-            normalizedPayload: selection?.normalizedPayload == true,
-            missingResolvedPayload: talk != nil && selection == nil,
+            snapshot: snapshot,
             executionMode: executionMode,
             requiresGatewayRealtimeTransport: requiresGatewayRealtimeTransport,
             defaultVoiceId: defaultVoiceId,
-            voiceAliases: voiceAliases,
             configuredModelId: model,
             defaultModelId: defaultModelId,
             defaultOutputFormat: defaultOutputFormat,
-            realtimeProvider: realtimeProvider,
             realtimeModelId: realtimeModelId,
-            realtimeVoiceId: realtimeVoiceId,
-            rawConfigApiKey: rawConfigApiKey,
-            interruptOnSpeech: interruptOnSpeech,
-            silenceTimeoutMs: silenceTimeoutMs,
-            speechLocaleID: speechLocaleID)
-    }
-
-    private static func requiresForcedAgentConsultRelay(_ realtime: [String: AnyCodable]?) -> Bool {
-        TalkConfigParsing.firstNonEmptyString(realtime, keys: ["consultRouting"])?.lowercased() == "force-agent-consult"
+            rawConfigApiKey: rawConfigApiKey)
     }
 
     private static func resolvedExecutionMode(
-        _ realtime: [String: AnyCodable]?,
+        _ realtime: TalkRealtimeConfigSnapshot,
         requiresGatewayRealtimeTransport: Bool) -> TalkModeExecutionMode
     {
-        guard let realtime else { return .native }
-        let mode = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["mode"])?.lowercased()
-        let transport = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["transport"])?.lowercased()
-        let provider = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["provider"])?.lowercased()
-            ?? TalkConfigParsing.singleRealtimeProviderID(realtime["providers"]?.dictionaryValue)?.lowercased()
-        let brain = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["brain"])?.lowercased()
-        guard mode == "realtime" else {
-            return .native
-        }
-        if brain != nil, brain != "agent-consult" {
+        guard realtime.mode == "realtime" else { return .native }
+        if realtime.brain != nil, realtime.brain != "agent-consult" {
             return .native
         }
         if requiresGatewayRealtimeTransport {
             return .realtimeRelay
         }
-        switch transport {
+        switch realtime.transport {
         case "managed-room":
             return .native
         case "gateway-relay":
@@ -369,11 +324,11 @@ enum TalkModeGatewayConfigParser {
         case "provider-websocket":
             return .realtimeRelay
         case "webrtc":
-            if provider != "openai" {
+            if realtime.provider?.lowercased() != "openai" {
                 return .realtimeRelay
             }
         case nil:
-            if provider != "openai" {
+            if realtime.provider?.lowercased() != "openai" {
                 return .realtimeRelay
             }
         default:

--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -4255,7 +4255,7 @@ extension TalkModeManager {
                 defaultModelIdFallback: Self.defaultModelIdFallback,
                 defaultRealtimeModelIdFallback: Self.defaultRealtimeModelIdFallback,
                 defaultSilenceTimeoutMs: Self.defaultSilenceTimeoutMs)
-            if parsed.missingResolvedPayload {
+            if parsed.snapshot.missingResolvedPayload {
                 GatewayDiagnostics.log(
                     "talk config ignored: normalized payload missing talk.resolved")
             }
@@ -4312,14 +4312,14 @@ extension TalkModeManager {
         let routing = TalkModeRoutingResolver.resolve(
             parsed: parsed,
             defaultProvider: Self.defaultTalkProvider)
-        let realtimeVoiceId = parsed.realtimeVoiceId
+        let realtimeVoiceId = parsed.snapshot.realtime.voice
         self.executionMode = routing.executionMode
         self.runtimeRoute = routing.route
         self.realtimeProvider = routing.realtimeProvider
         self.realtimeModelId = routing.realtimeModelId
         self.realtimeVoiceId = realtimeVoiceId
         self.defaultVoiceId = parsed.defaultVoiceId
-        self.voiceAliases = parsed.voiceAliases
+        self.voiceAliases = parsed.snapshot.voiceAliases
         if !self.voiceOverrideActive {
             self.currentVoiceId = self.defaultVoiceId
         }
@@ -4348,14 +4348,14 @@ extension TalkModeManager {
             redactedFallbackMissingScope: redactedFallbackMissingScope,
             gatewayOwnedVoiceProvider: gatewayOwnedVoiceProvider)
 
-        if let interrupt = parsed.interruptOnSpeech {
+        if let interrupt = parsed.snapshot.interruptOnSpeech {
             self.interruptOnSpeech = interrupt
         }
-        self.gatewaySpeechLocaleID = parsed.speechLocaleID
-        self.silenceWindow = TimeInterval(parsed.silenceTimeoutMs) / 1000
-        if parsed.normalizedPayload || parsed.defaultVoiceId != nil || parsed.rawConfigApiKey != nil {
+        self.gatewaySpeechLocaleID = parsed.snapshot.speechLocaleID
+        self.silenceWindow = TimeInterval(parsed.snapshot.silenceTimeoutMs) / 1000
+        if parsed.snapshot.normalizedPayload || parsed.defaultVoiceId != nil || parsed.rawConfigApiKey != nil {
             GatewayDiagnostics.log(
-                "talk config provider=\(routing.activeProvider) silenceTimeoutMs=\(parsed.silenceTimeoutMs)")
+                "talk config provider=\(routing.activeProvider) silenceTimeoutMs=\(parsed.snapshot.silenceTimeoutMs)")
         }
     }
 

--- a/apps/ios/Tests/Logic/TalkConfigParsingTests.swift
+++ b/apps/ios/Tests/Logic/TalkConfigParsingTests.swift
@@ -1,11 +1,11 @@
 import Foundation
-import OpenClawKit
 import Testing
+@testable import OpenClawKit
 
 private let iOSSilenceTimeoutMs = 900
 
-@Suite struct TalkConfigParsingTests {
-    @Test func rejectsNormalizedTalkProviderPayloadWithoutResolved() {
+struct TalkConfigParsingTests {
+    @Test func `rejects normalized talk provider payload without resolved`() {
         let talk: [String: Any] = [
             "provider": "elevenlabs",
             "providers": [
@@ -23,7 +23,7 @@ private let iOSSilenceTimeoutMs = 900
         #expect(selection == nil)
     }
 
-    @Test func ignoresLegacyTalkFieldsWhenNormalizedPayloadMissing() {
+    @Test func `ignores legacy talk fields when normalized payload missing`() {
         let talk: [String: Any] = [
             "voiceId": "voice-legacy",
             "apiKey": "legacy-key", // pragma: allowlist secret
@@ -36,7 +36,7 @@ private let iOSSilenceTimeoutMs = 900
         #expect(selection == nil)
     }
 
-    @Test func readsConfiguredSilenceTimeoutMs() {
+    @Test func `reads configured silence timeout ms`() {
         let talk: [String: Any] = [
             "silenceTimeoutMs": 1500,
         ]
@@ -47,7 +47,7 @@ private let iOSSilenceTimeoutMs = 900
                 fallback: iOSSilenceTimeoutMs) == 1500)
     }
 
-    @Test func readsConfiguredSpeechLocale() {
+    @Test func `reads configured speech locale`() {
         let talk: [String: Any] = [
             "speechLocale": " ru-RU ",
         ]
@@ -57,11 +57,11 @@ private let iOSSilenceTimeoutMs = 900
                 TalkConfigParsing.bridgeFoundationDictionary(talk)) == "ru-RU")
     }
 
-    @Test func defaultsSilenceTimeoutMsWhenMissing() {
+    @Test func `defaults silence timeout ms when missing`() {
         #expect(TalkConfigParsing.resolvedSilenceTimeoutMs(nil, fallback: iOSSilenceTimeoutMs) == iOSSilenceTimeoutMs)
     }
 
-    @Test func defaultsSilenceTimeoutMsWhenInvalid() {
+    @Test func `defaults silence timeout ms when invalid`() {
         let talk: [String: Any] = [
             "silenceTimeoutMs": 0,
         ]
@@ -72,7 +72,7 @@ private let iOSSilenceTimeoutMs = 900
                 fallback: iOSSilenceTimeoutMs) == iOSSilenceTimeoutMs)
     }
 
-    @Test func defaultsSilenceTimeoutMsWhenBool() {
+    @Test func `defaults silence timeout ms when bool`() {
         let talk: [String: Any] = [
             "silenceTimeoutMs": true,
         ]

--- a/apps/ios/Tests/TalkModeConfigParsingTests.swift
+++ b/apps/ios/Tests/TalkModeConfigParsingTests.swift
@@ -235,13 +235,13 @@ struct TalkModeManagerTests {
 
         let parsed = Self.parse(config)
 
-        #expect(parsed.activeProvider == "elevenlabs")
+        #expect(parsed.snapshot.activeProvider == "elevenlabs")
         #expect(parsed.executionMode == .realtimeRelay)
         #expect(parsed.defaultModelId == "eleven_v3")
         #expect(parsed.defaultVoiceId == "eleven-voice")
-        #expect(parsed.realtimeProvider == "openai")
+        #expect(parsed.snapshot.realtime.provider == "openai")
         #expect(parsed.realtimeModelId == "gpt-realtime-2")
-        #expect(parsed.realtimeVoiceId == "marin")
+        #expect(parsed.snapshot.realtime.voice == "marin")
     }
 
     @Test func `infers realtime provider when provider map has single entry`() {
@@ -251,7 +251,7 @@ struct TalkModeManagerTests {
             transport: "webrtc")
 
         #expect(parsed.executionMode == .realtimeWebRTC)
-        #expect(parsed.realtimeProvider == "openai")
+        #expect(parsed.snapshot.realtime.provider == "openai")
         #expect(parsed.realtimeModelId == "gpt-realtime-2")
     }
 
@@ -277,7 +277,7 @@ struct TalkModeManagerTests {
         #expect(parsed.executionMode == .realtimeRelay)
         #expect(parsed.defaultModelId == "eleven_v3")
         #expect(parsed.realtimeModelId == "gpt-realtime-2")
-        #expect(parsed.realtimeVoiceId == nil)
+        #expect(parsed.snapshot.realtime.voice == nil)
     }
 
     @Test func `omits model override when gateway owns redacted selection`() {
@@ -890,11 +890,11 @@ struct TalkModeManagerTests {
 
         let parsed = Self.parse(config)
 
-        #expect(parsed.activeProvider == "elevenlabs")
+        #expect(parsed.snapshot.activeProvider == "elevenlabs")
         #expect(parsed.executionMode == .realtimeWebRTC)
-        #expect(parsed.realtimeProvider == "openai")
+        #expect(parsed.snapshot.realtime.provider == "openai")
         #expect(parsed.realtimeModelId == "gpt-realtime-2")
-        #expect(parsed.realtimeVoiceId == "cedar")
+        #expect(parsed.snapshot.realtime.voice == "cedar")
         #expect(parsed.rawConfigApiKey == "__OPENCLAW_REDACTED__")
     }
 

--- a/apps/macos/Sources/OpenClaw/TalkModeGatewayConfig.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeGatewayConfig.swift
@@ -2,31 +2,23 @@ import Foundation
 import OpenClawKit
 
 struct TalkModeGatewayConfigState {
-    let activeProvider: String
-    let normalizedPayload: Bool
-    let missingResolvedPayload: Bool
+    let snapshot: TalkConfigSnapshot
     let voiceId: String?
-    let voiceAliases: [String: String]
     let modelId: String?
     let outputFormat: String?
-    let interruptOnSpeech: Bool
-    let silenceTimeoutMs: Int
-    let speechLocaleID: String?
     let apiKey: String?
     let referenceAudioPath: String?
     let referenceText: String?
     let seamColorHex: String?
-    let realtimeProvider: String?
-    let realtimeModelId: String?
-    let realtimeSpeakerVoice: String?
-    let realtimeMode: String?
-    let realtimeTransport: String?
-    let realtimeBrain: String?
+
+    var interruptOnSpeech: Bool {
+        self.snapshot.interruptOnSpeech ?? true
+    }
 
     var hasGatewayRealtimeRelayTuple: Bool {
-        self.realtimeMode == "realtime" &&
-            self.realtimeTransport == "gateway-relay" &&
-            self.realtimeBrain == "agent-consult"
+        self.snapshot.realtime.mode == "realtime" &&
+            self.snapshot.realtime.transport == "gateway-relay" &&
+            self.snapshot.realtime.brain == "agent-consult"
     }
 }
 
@@ -41,16 +33,13 @@ enum TalkModeGatewayConfigParser {
         envApiKey: String?) -> TalkModeGatewayConfigState
     {
         let talk = snapshot.config?["talk"]?.dictionaryValue
-        let selection = TalkConfigParsing.selectProviderConfig(talk, defaultProvider: defaultProvider)
-        let activeProvider = selection?.provider ?? defaultProvider
-        let activeConfig = selection?.config
-        let silenceTimeoutMs = TalkConfigParsing.resolvedSilenceTimeoutMs(
-            talk,
-            fallback: defaultSilenceTimeoutMs)
+        let common = TalkConfigSnapshot(
+            talk, defaultProvider: defaultProvider, defaultSilenceTimeoutMs: defaultSilenceTimeoutMs)
+        let activeProvider = common.activeProvider
+        let activeConfig = common.providerConfig
         let ui = snapshot.config?["ui"]?.dictionaryValue
         let rawSeam = ui?["seamColor"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         let voice = activeConfig?["voiceId"]?.stringValue
-        let resolvedAliases = TalkVoiceAliases.normalizedMap(activeConfig?["voiceAliases"])
         let model = activeConfig?["modelId"]?.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines)
         let resolvedModel: String? = if model?.isEmpty == false {
             model!
@@ -60,32 +49,11 @@ enum TalkModeGatewayConfigParser {
             nil
         }
         let outputFormat = activeConfig?["outputFormat"]?.stringValue
-        let interrupt = talk?["interruptOnSpeech"]?.boolValue
-        let speechLocaleID = TalkConfigParsing.resolvedSpeechLocaleID(talk)
         let apiKey = activeConfig?["apiKey"]?.stringValue
         let referenceAudioPath = activeConfig?["referenceAudioPath"]?.stringValue?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         let referenceText = activeConfig?["referenceText"]?.stringValue?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let realtime = talk?["realtime"]?.dictionaryValue
-        let realtimeProviders = realtime?["providers"]?.dictionaryValue
-        let realtimeProvider = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["provider"])
-            ?? TalkConfigParsing.singleRealtimeProviderID(realtimeProviders)
-        let realtimeProviderConfig = TalkConfigParsing.realtimeProviderConfig(
-            providers: realtimeProviders,
-            provider: realtimeProvider)
-        let realtimeModelId = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["model"])
-            ?? TalkConfigParsing.firstNonEmptyString(realtimeProviderConfig, keys: ["model"])
-        let realtimeSpeakerVoice = TalkConfigParsing.firstNonEmptyString(
-            realtime,
-            keys: ["speakerVoice", "voice"])
-            ?? TalkConfigParsing.firstNonEmptyString(
-                realtimeProviderConfig,
-                keys: ["speakerVoice", "voice"])
-        let realtimeMode = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["mode"])?.lowercased()
-        let realtimeTransport =
-            TalkConfigParsing.firstNonEmptyString(realtime, keys: ["transport"])?.lowercased()
-        let realtimeBrain = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["brain"])?.lowercased()
         let resolvedVoice: String? = if activeProvider == defaultProvider {
             (voice?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ? voice : nil) ??
                 (envVoice?.isEmpty == false ? envVoice : nil) ??
@@ -101,26 +69,14 @@ enum TalkModeGatewayConfigParser {
         }
 
         return TalkModeGatewayConfigState(
-            activeProvider: activeProvider,
-            normalizedPayload: selection?.normalizedPayload == true,
-            missingResolvedPayload: talk != nil && selection == nil,
+            snapshot: common,
             voiceId: resolvedVoice,
-            voiceAliases: resolvedAliases,
             modelId: resolvedModel,
             outputFormat: outputFormat,
-            interruptOnSpeech: interrupt ?? true,
-            silenceTimeoutMs: silenceTimeoutMs,
-            speechLocaleID: speechLocaleID,
             apiKey: resolvedApiKey,
             referenceAudioPath: referenceAudioPath?.isEmpty == false ? referenceAudioPath : nil,
             referenceText: referenceText?.isEmpty == false ? referenceText : nil,
-            seamColorHex: rawSeam.isEmpty ? nil : rawSeam,
-            realtimeProvider: realtimeProvider,
-            realtimeModelId: realtimeModelId,
-            realtimeSpeakerVoice: realtimeSpeakerVoice,
-            realtimeMode: realtimeMode,
-            realtimeTransport: realtimeTransport,
-            realtimeBrain: realtimeBrain)
+            seamColorHex: rawSeam.isEmpty ? nil : rawSeam)
     }
 
     static func fallback(
@@ -136,25 +92,14 @@ enum TalkModeGatewayConfigParser {
         let resolvedApiKey = envApiKey?.isEmpty == false ? envApiKey : nil
 
         return TalkModeGatewayConfigState(
-            activeProvider: "elevenlabs",
-            normalizedPayload: false,
-            missingResolvedPayload: false,
+            snapshot: TalkConfigSnapshot(
+                nil, defaultProvider: "elevenlabs", defaultSilenceTimeoutMs: defaultSilenceTimeoutMs),
             voiceId: resolvedVoice,
-            voiceAliases: [:],
             modelId: defaultModelIdFallback,
             outputFormat: nil,
-            interruptOnSpeech: true,
-            silenceTimeoutMs: defaultSilenceTimeoutMs,
-            speechLocaleID: nil,
             apiKey: resolvedApiKey,
             referenceAudioPath: nil,
             referenceText: nil,
-            seamColorHex: nil,
-            realtimeProvider: nil,
-            realtimeModelId: nil,
-            realtimeSpeakerVoice: nil,
-            realtimeMode: nil,
-            realtimeTransport: nil,
-            realtimeBrain: nil)
+            seamColorHex: nil)
     }
 }

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -1446,21 +1446,21 @@ extension TalkModeRuntime {
             envVoice: envVoice,
             sagVoice: sagVoice,
             envApiKey: envApiKey)
-        if parsed.missingResolvedPayload {
+        if parsed.snapshot.missingResolvedPayload {
             self.ttsLogger.info("talk config ignored: normalized payload missing talk.resolved")
         }
-        if parsed.activeProvider == Self.defaultTalkProvider {
+        if parsed.snapshot.activeProvider == Self.defaultTalkProvider {
             self.ttsLogger.info("talk config provider from talk.resolved")
-        } else if parsed.activeProvider == Self.mlxTalkProvider ||
-            parsed.activeProvider == Self.systemTalkProvider
+        } else if parsed.snapshot.activeProvider == Self.mlxTalkProvider ||
+            parsed.snapshot.activeProvider == Self.systemTalkProvider
         {
             self.ttsLogger.info(
-                "talk provider \(parsed.activeProvider, privacy: .public) active")
+                "talk provider \(parsed.snapshot.activeProvider, privacy: .public) active")
         } else {
             self.ttsLogger
                 .info(
                     """
-                    talk provider \(parsed.activeProvider, privacy: .public) uses gateway talk.speak \
+                    talk provider \(parsed.snapshot.activeProvider, privacy: .public) uses gateway talk.speak \
                     with system voice fallback
                     """)
         }
@@ -1499,7 +1499,7 @@ extension TalkModeRuntime {
 
     func commitTalkConfig(_ cfg: TalkModeGatewayConfigState, locale: String) {
         self.defaultVoiceId = cfg.voiceId
-        self.voiceAliases = cfg.voiceAliases
+        self.voiceAliases = cfg.snapshot.voiceAliases
         if !self.voiceOverrideActive {
             self.currentVoiceId = cfg.voiceId
         }
@@ -1509,15 +1509,15 @@ extension TalkModeRuntime {
         }
         self.defaultOutputFormat = cfg.outputFormat
         self.interruptOnSpeech = cfg.interruptOnSpeech
-        self.activeTalkProvider = cfg.activeProvider
-        self.realtimeProvider = cfg.realtimeProvider
-        self.realtimeModelId = cfg.realtimeModelId
-        self.realtimeSpeakerVoice = cfg.realtimeSpeakerVoice
-        self.realtimeMode = cfg.realtimeMode
-        self.realtimeTransport = cfg.realtimeTransport
-        self.realtimeBrain = cfg.realtimeBrain
+        self.activeTalkProvider = cfg.snapshot.activeProvider
+        self.realtimeProvider = cfg.snapshot.realtime.provider
+        self.realtimeModelId = cfg.snapshot.realtime.modelId
+        self.realtimeSpeakerVoice = cfg.snapshot.realtime.speakerVoice
+        self.realtimeMode = cfg.snapshot.realtime.mode
+        self.realtimeTransport = cfg.snapshot.realtime.transport
+        self.realtimeBrain = cfg.snapshot.realtime.brain
         self.hasGatewayRealtimeRelayTuple = cfg.hasGatewayRealtimeRelayTuple
-        let configuredSilenceMs = cfg.silenceTimeoutMs
+        let configuredSilenceMs = cfg.snapshot.silenceTimeoutMs
         let isCJKLocale = locale.hasPrefix("ko") || locale.hasPrefix("ja") || locale.hasPrefix("zh")
         let effectiveSilenceMs = isCJKLocale ? max(configuredSilenceMs, 2000) : configuredSilenceMs
         if isCJKLocale, configuredSilenceMs < 2000 {
@@ -1527,7 +1527,7 @@ extension TalkModeRuntime {
                         "\(configuredSilenceMs, privacy: .public)ms -> 2000ms")
         }
         self.silenceWindow = TimeInterval(effectiveSilenceMs) / 1000
-        self.speechLocaleID = cfg.speechLocaleID
+        self.speechLocaleID = cfg.snapshot.speechLocaleID
         self.apiKey = cfg.apiKey
         self.mlxReferenceAudioPath = cfg.referenceAudioPath
         self.mlxReferenceText = cfg.referenceText
@@ -1536,17 +1536,17 @@ extension TalkModeRuntime {
         let modelLabel = cfg.modelId.flatMap { $0.isEmpty ? nil : $0 } ?? "none"
         self.logger
             .info(
-                "talk config provider=\(cfg.activeProvider, privacy: .public) " +
+                "talk config provider=\(cfg.snapshot.activeProvider, privacy: .public) " +
                     "talk config voiceId=\(voiceLabel, privacy: .public) " +
                     "modelId=\(modelLabel, privacy: .public) " +
                     "referenceAudio=\(cfg.referenceAudioPath != nil, privacy: .public) " +
                     "apiKey=\(hasApiKey, privacy: .public) " +
                     "interrupt=\(cfg.interruptOnSpeech, privacy: .public) " +
-                    "silenceTimeoutMs=\(cfg.silenceTimeoutMs, privacy: .public) " +
-                    "speechLocale=\(cfg.speechLocaleID ?? "device", privacy: .public) " +
-                    "realtimeMode=\(cfg.realtimeMode ?? "off", privacy: .public) " +
-                    "realtimeTransport=\(cfg.realtimeTransport ?? "default", privacy: .public) " +
-                    "realtimeBrain=\(cfg.realtimeBrain ?? "default", privacy: .public) " +
+                    "silenceTimeoutMs=\(cfg.snapshot.silenceTimeoutMs, privacy: .public) " +
+                    "speechLocale=\(cfg.snapshot.speechLocaleID ?? "device", privacy: .public) " +
+                    "realtimeMode=\(cfg.snapshot.realtime.mode ?? "off", privacy: .public) " +
+                    "realtimeTransport=\(cfg.snapshot.realtime.transport ?? "default", privacy: .public) " +
+                    "realtimeBrain=\(cfg.snapshot.realtime.brain ?? "default", privacy: .public) " +
                     "macOSRealtimeOptIn=\(self.macOSRealtimeRelayOptIn, privacy: .public)")
     }
 

--- a/apps/macos/Tests/OpenClawIPCTests/TalkModeGatewayConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/TalkModeGatewayConfigTests.swift
@@ -45,11 +45,11 @@ struct TalkModeGatewayConfigTests {
             sagVoice: "sag-voice",
             envApiKey: "env-key")
 
-        #expect(parsed.activeProvider == "mlx")
+        #expect(parsed.snapshot.activeProvider == "mlx")
         #expect(parsed.modelId == "mlx-community/fish-audio-s2-pro-8bit")
         #expect(parsed.apiKey == nil)
         #expect(parsed.voiceId == "unused-voice")
-        #expect(parsed.speechLocaleID == "ru-RU")
+        #expect(parsed.snapshot.speechLocaleID == "ru-RU")
         #expect(parsed.referenceAudioPath == "/tmp/reference.wav")
         #expect(parsed.referenceText == "reference transcript")
     }
@@ -74,12 +74,12 @@ struct TalkModeGatewayConfigTests {
 
         let parsed = Self.parse(snapshot)
 
-        #expect(parsed.realtimeProvider == "OpenAI")
-        #expect(parsed.realtimeModelId == "gpt-live-test-canary")
-        #expect(parsed.realtimeSpeakerVoice == "cedar")
-        #expect(parsed.realtimeMode == "realtime")
-        #expect(parsed.realtimeTransport == "gateway-relay")
-        #expect(parsed.realtimeBrain == "agent-consult")
+        #expect(parsed.snapshot.realtime.provider == "OpenAI")
+        #expect(parsed.snapshot.realtime.modelId == "gpt-live-test-canary")
+        #expect(parsed.snapshot.realtime.speakerVoice == "cedar")
+        #expect(parsed.snapshot.realtime.mode == "realtime")
+        #expect(parsed.snapshot.realtime.transport == "gateway-relay")
+        #expect(parsed.snapshot.realtime.brain == "agent-consult")
         #expect(parsed.hasGatewayRealtimeRelayTuple)
     }
 
@@ -98,12 +98,12 @@ struct TalkModeGatewayConfigTests {
 
         let parsed = Self.parse(snapshot)
 
-        #expect(parsed.realtimeProvider == "openai")
-        #expect(parsed.realtimeModelId == "gpt-realtime-2.1")
-        #expect(parsed.realtimeSpeakerVoice == "marin")
-        #expect(parsed.realtimeMode == "realtime")
-        #expect(parsed.realtimeTransport == nil)
-        #expect(parsed.realtimeBrain == nil)
+        #expect(parsed.snapshot.realtime.provider == "openai")
+        #expect(parsed.snapshot.realtime.modelId == "gpt-realtime-2.1")
+        #expect(parsed.snapshot.realtime.speakerVoice == "marin")
+        #expect(parsed.snapshot.realtime.mode == "realtime")
+        #expect(parsed.snapshot.realtime.transport == nil)
+        #expect(parsed.snapshot.realtime.brain == nil)
         #expect(!parsed.hasGatewayRealtimeRelayTuple)
     }
 
@@ -122,9 +122,9 @@ struct TalkModeGatewayConfigTests {
 
         let parsed = Self.parse(snapshot)
 
-        #expect(parsed.realtimeProvider == "OPENAI")
-        #expect(parsed.realtimeModelId == "gpt-live-test-canary")
-        #expect(parsed.realtimeSpeakerVoice == "cedar")
+        #expect(parsed.snapshot.realtime.provider == "OPENAI")
+        #expect(parsed.snapshot.realtime.modelId == "gpt-live-test-canary")
+        #expect(parsed.snapshot.realtime.speakerVoice == "cedar")
     }
 
     @Test func `fallback has no realtime selection`() {
@@ -135,12 +135,12 @@ struct TalkModeGatewayConfigTests {
             sagVoice: nil,
             envApiKey: nil)
 
-        #expect(parsed.realtimeProvider == nil)
-        #expect(parsed.realtimeModelId == nil)
-        #expect(parsed.realtimeSpeakerVoice == nil)
-        #expect(parsed.realtimeMode == nil)
-        #expect(parsed.realtimeTransport == nil)
-        #expect(parsed.realtimeBrain == nil)
+        #expect(parsed.snapshot.realtime.provider == nil)
+        #expect(parsed.snapshot.realtime.modelId == nil)
+        #expect(parsed.snapshot.realtime.speakerVoice == nil)
+        #expect(parsed.snapshot.realtime.mode == nil)
+        #expect(parsed.snapshot.realtime.transport == nil)
+        #expect(parsed.snapshot.realtime.brain == nil)
     }
 
     @Test func `redacted gateway model remains omitted`() {
@@ -168,7 +168,7 @@ struct TalkModeGatewayConfigTests {
             ],
             issues: nil)
 
-        #expect(Self.parse(snapshot).realtimeModelId == nil)
+        #expect(Self.parse(snapshot).snapshot.realtime.modelId == nil)
     }
 
     @Test func `released realtime model remains available`() {
@@ -183,8 +183,8 @@ struct TalkModeGatewayConfigTests {
         ])
 
         let parsed = Self.parse(snapshot)
-        #expect(parsed.realtimeModelId == "gpt-live-1-codex")
-        #expect(parsed.realtimeSpeakerVoice == "spruce")
+        #expect(parsed.snapshot.realtime.modelId == "gpt-live-1-codex")
+        #expect(parsed.snapshot.realtime.speakerVoice == "spruce")
     }
 
     private static func snapshot(talk: [String: Any]) -> ConfigSnapshot {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkConfigParsing.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkConfigParsing.swift
@@ -17,6 +17,8 @@ public enum TalkConfigParsing {
         raw?.mapValues(AnyCodable.init)
     }
 
+    /// Rem-Assistant/Rem's voice settings consume this API through its OpenClaw fork.
+    /// Keep it public until that consumer migrates.
     public static func selectProviderConfig(
         _ talk: [String: AnyCodable]?,
         defaultProvider: String,
@@ -49,13 +51,13 @@ public enum TalkConfigParsing {
         return nil
     }
 
-    public static func singleRealtimeProviderID(_ providers: [String: AnyCodable]?) -> String? {
+    static func singleRealtimeProviderID(_ providers: [String: AnyCodable]?) -> String? {
         guard let providers, providers.count == 1 else { return nil }
         let provider = providers.keys.first?.trimmingCharacters(in: .whitespacesAndNewlines)
         return provider?.isEmpty == false ? provider : nil
     }
 
-    public static func realtimeProviderConfig(
+    static func realtimeProviderConfig(
         providers: [String: AnyCodable]?,
         provider: String?) -> [String: AnyCodable]?
     {
@@ -91,7 +93,7 @@ public enum TalkConfigParsing {
         return trimmed.isEmpty ? nil : trimmed.replacingOccurrences(of: "_", with: "-")
     }
 
-    public static func resolvedSpeechLocaleID(
+    static func resolvedSpeechLocaleID(
         _ talk: [String: AnyCodable]?,
         fallback: String? = nil) -> String?
     {

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkConfigSnapshot.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkConfigSnapshot.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+public struct TalkConfigSnapshot: Sendable {
+    public let activeProvider: String
+    public let providerConfig: [String: AnyCodable]?
+    public let normalizedPayload: Bool
+    public let missingResolvedPayload: Bool
+    public let voiceAliases: [String: String]
+    public let interruptOnSpeech: Bool?
+    public let silenceTimeoutMs: Int
+    public let speechLocaleID: String?
+    public let realtime: TalkRealtimeConfigSnapshot
+
+    public init(
+        _ talk: [String: AnyCodable]?,
+        defaultProvider: String,
+        defaultSilenceTimeoutMs: Int,
+        allowLegacyFallback: Bool = true)
+    {
+        let selection = TalkConfigParsing.selectProviderConfig(
+            talk, defaultProvider: defaultProvider, allowLegacyFallback: allowLegacyFallback)
+        self.activeProvider = selection?.provider ?? defaultProvider
+        self.providerConfig = selection?.config
+        self.normalizedPayload = selection?.normalizedPayload == true
+        self.missingResolvedPayload = talk != nil && selection == nil
+        self.voiceAliases = TalkVoiceAliases.normalizedMap(selection?.config["voiceAliases"])
+        self.interruptOnSpeech = talk?["interruptOnSpeech"]?.boolValue
+        self.silenceTimeoutMs = TalkConfigParsing.resolvedSilenceTimeoutMs(talk, fallback: defaultSilenceTimeoutMs)
+        self.speechLocaleID = TalkConfigParsing.resolvedSpeechLocaleID(talk)
+        self.realtime = TalkRealtimeConfigSnapshot(talk?["realtime"]?.dictionaryValue)
+    }
+}
+
+public struct TalkRealtimeConfigSnapshot: Sendable {
+    public let provider: String?
+    public let providerConfig: [String: AnyCodable]?
+    public let modelId: String?
+    public let voice: String?
+    public let speakerVoice: String?
+    public let mode: String?
+    public let transport: String?
+    public let brain: String?
+    public let consultRouting: String?
+
+    init(_ realtime: [String: AnyCodable]?) {
+        let providers = realtime?["providers"]?.dictionaryValue
+        let provider = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["provider"])
+            ?? TalkConfigParsing.singleRealtimeProviderID(providers)
+        let providerConfig = TalkConfigParsing.realtimeProviderConfig(providers: providers, provider: provider)
+        self.provider = provider
+        self.providerConfig = providerConfig
+        self.modelId = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["model"])
+            ?? TalkConfigParsing.firstNonEmptyString(providerConfig, keys: ["model"])
+        self.voice = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["voice"])
+            ?? TalkConfigParsing.firstNonEmptyString(providerConfig, keys: ["voice"])
+        // macOS accepts speakerVoice; iOS consumes only voice. Keep both projections.
+        self.speakerVoice = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["speakerVoice", "voice"])
+            ?? TalkConfigParsing.firstNonEmptyString(providerConfig, keys: ["speakerVoice", "voice"])
+        self.mode = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["mode"])?.lowercased()
+        self.transport = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["transport"])?.lowercased()
+        self.brain = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["brain"])?.lowercased()
+        self.consultRouting = TalkConfigParsing.firstNonEmptyString(realtime, keys: ["consultRouting"])?.lowercased()
+    }
+}

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkDirective.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/TalkDirective.swift
@@ -62,7 +62,7 @@ public struct TalkDirectiveParseResult: Equatable, Sendable {
 }
 
 public enum TalkVoiceAliases {
-    public static func normalizedMap(_ value: AnyCodable?) -> [String: String] {
+    static func normalizedMap(_ value: AnyCodable?) -> [String: String] {
         value?.dictionaryValue?.reduce(into: [:]) { result, entry in
             let key = entry.key.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             let value = entry.value.stringValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkConfigParsingTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/TalkConfigParsingTests.swift
@@ -1,8 +1,8 @@
-import OpenClawKit
 import Testing
+@testable import OpenClawKit
 
 struct TalkConfigParsingTests {
-    @Test func prefersCanonicalResolvedTalkProviderPayload() {
+    @Test func `prefers canonical resolved talk provider payload`() {
         let talk: [String: AnyCodable] = [
             "resolved": AnyCodable([
                 "provider": "elevenlabs",
@@ -24,7 +24,7 @@ struct TalkConfigParsingTests {
         #expect(selection?.config["voiceId"]?.stringValue == "voice-resolved")
     }
 
-    @Test func rejectsNormalizedTalkProviderPayloadWithoutResolved() {
+    @Test func `rejects normalized talk provider payload without resolved`() {
         let talk: [String: AnyCodable] = [
             "provider": AnyCodable("elevenlabs"),
             "providers": AnyCodable([
@@ -39,7 +39,7 @@ struct TalkConfigParsingTests {
         #expect(selection == nil)
     }
 
-    @Test func fallsBackToLegacyTalkFieldsWhenNormalizedPayloadMissing() {
+    @Test func `falls back to legacy talk fields when normalized payload missing`() {
         let talk: [String: AnyCodable] = [
             "voiceId": AnyCodable("voice-legacy"),
             "apiKey": AnyCodable("legacy-key"),
@@ -52,7 +52,7 @@ struct TalkConfigParsingTests {
         #expect(selection?.config["apiKey"]?.stringValue == "legacy-key")
     }
 
-    @Test func canDisableLegacyFallback() {
+    @Test func `can disable legacy fallback`() {
         let talk: [String: AnyCodable] = [
             "voiceId": AnyCodable("voice-legacy"),
         ]
@@ -64,7 +64,7 @@ struct TalkConfigParsingTests {
         #expect(selection == nil)
     }
 
-    @Test func rejectsNormalizedPayloadWhenProviderMissingFromProviders() {
+    @Test func `rejects normalized payload when provider missing from providers`() {
         let talk: [String: AnyCodable] = [
             "provider": AnyCodable("acme"),
             "providers": AnyCodable([
@@ -78,7 +78,7 @@ struct TalkConfigParsingTests {
         #expect(selection == nil)
     }
 
-    @Test func rejectsNormalizedPayloadWhenMultipleProvidersAndNoProvider() {
+    @Test func `rejects normalized payload when multiple providers and no provider`() {
         let talk: [String: AnyCodable] = [
             "providers": AnyCodable([
                 "acme": [
@@ -94,7 +94,7 @@ struct TalkConfigParsingTests {
         #expect(selection == nil)
     }
 
-    @Test func bridgesFoundationDictionary() {
+    @Test func `bridges foundation dictionary`() {
         let raw: [String: Any] = [
             "provider": "elevenlabs",
             "providers": [
@@ -110,19 +110,20 @@ struct TalkConfigParsingTests {
         #expect(nested?["voiceId"]?.stringValue == "voice-normalized")
     }
 
-    @Test func resolvesPositiveIntegerTimeout() {
+    @Test func `resolves positive integer timeout`() {
         #expect(TalkConfigParsing.resolvedPositiveInt(AnyCodable(1500), fallback: 700) == 1500)
         #expect(TalkConfigParsing.resolvedPositiveInt(AnyCodable(0), fallback: 700) == 700)
         #expect(TalkConfigParsing.resolvedPositiveInt(AnyCodable(true), fallback: 700) == 700)
         #expect(TalkConfigParsing.resolvedPositiveInt(AnyCodable("1500"), fallback: 700) == 700)
     }
 
-    @Test func resolvesSpeechLocaleID() {
+    @Test func `resolves speech locale ID`() {
         #expect(TalkConfigParsing.resolvedSpeechLocaleID(["speechLocale": AnyCodable(" ru_RU ")]) == "ru-RU")
-        #expect(TalkConfigParsing.resolvedSpeechLocaleID(["speechLocale": AnyCodable("")], fallback: "en-US") == "en-US")
+        #expect(TalkConfigParsing
+            .resolvedSpeechLocaleID(["speechLocale": AnyCodable("")], fallback: "en-US") == "en-US")
     }
 
-    @Test func resolvesSpeechRecognitionLocaleFromSupportedFallbacks() {
+    @Test func `resolves speech recognition locale from supported fallbacks`() {
         let locale = TalkConfigParsing.resolvedSpeechRecognitionLocaleID(
             preferredLocaleIDs: ["zz-ZZ", "fr-FR"],
             supportedLocaleIDs: ["fr-FR", "en-US"])
@@ -132,5 +133,37 @@ struct TalkConfigParsingTests {
 
         #expect(locale == "fr-FR")
         #expect(fallback == "en-US")
+    }
+
+    @Test func `snapshot keeps speaker voice precedence separate from voice`() {
+        let talk: [String: AnyCodable] = [
+            "realtime": AnyCodable([
+                "provider": " OpenAI ",
+                "model": " top-model ",
+                "voice": " top-voice ",
+                "providers": ["openai": [
+                    "model": "provider-model",
+                    "speakerVoice": "provider-speaker",
+                    "voice": "provider-voice",
+                ]],
+            ]),
+        ]
+        let snapshot = TalkConfigSnapshot(talk, defaultProvider: "elevenlabs", defaultSilenceTimeoutMs: 900)
+        #expect(snapshot.realtime.provider == "OpenAI")
+        #expect(snapshot.realtime.modelId == "top-model")
+        #expect(snapshot.realtime.voice == "top-voice")
+        #expect(snapshot.realtime.speakerVoice == "top-voice")
+        #expect(snapshot.interruptOnSpeech == nil)
+
+        let speakerOnly = TalkConfigSnapshot([
+            "interruptOnSpeech": AnyCodable(false),
+            "realtime": AnyCodable([
+                "speakerVoice": " top-speaker ",
+                "providers": ["openai": ["voice": "provider-voice"]],
+            ]),
+        ], defaultProvider: "elevenlabs", defaultSilenceTimeoutMs: 900)
+        #expect(speakerOnly.realtime.voice == "provider-voice")
+        #expect(speakerOnly.realtime.speakerVoice == "top-speaker")
+        #expect(speakerOnly.interruptOnSpeech == false)
     }
 }


### PR DESCRIPTION
## What Problem This Solves

The Apple Talk clients separately project the same normalized provider, timing, locale, and realtime fields. Maintaining those copies risks drift in how the clients read the Gateway's existing configuration contract.

## Why This Change Was Made

OpenClawKit now owns those shared facts in an immutable TalkConfigSnapshot. The platform parsers embed that snapshot and retain their selection policy: macOS keeps environment/legacy/MLX defaults and speakerVoice precedence; iOS keeps voice-only projection, optional interruption updates, Gateway-owned model omission, and transport/Azure/consultation routing.

This removes 34 production lines and builds on the iOS routing changes in #139514. Four helpers whose callers moved inside Kit become internal after global and organization consumer searches. The public selectProviderConfig and TalkProviderConfigSelection contract remains for Rem-Assistant/Rem, whose voice settings consume it through its maintained OpenClaw fork; the source records that compatibility requirement and removal condition. Existing public timeout and locale-policy helpers still used by app callers remain.

## User Impact

No intended user-visible change. Provider, voice, model, timing, locale, and route decisions retain their current platform behavior. No configuration, protocol, dependency, or persisted-state format changes.

## Evidence

- OpenClawKit `swift test`: 1,657 tests in 127 suites passed (52.059 seconds), including the new voice-precedence and optional-interruption case.
- `swift build --package-path apps/macos --build-system native --product OpenClaw`: passed (43.79 seconds).
- iOS simulator build and build-for-testing: passed after `pnpm ios:gen`, with `/opt/homebrew/opt/rustup/bin` on PATH. Tests were compiled, not launched on the host.
- `pnpm native:i18n:check` and `pnpm protocol:check:swift`: passed.
- `periphery scan --config .periphery.yml --strict -- --build-system native` in apps/macos: passed with no unused code.
- Independent Codex review through P2: scoped-clean, zero actionable findings.
- Existing app expectations remain. Repository formatting normalized names in the two touched parsing test files without changing their assertions.
- `node scripts/check-changed.mjs`: passed, including 1,132 tests and native schema guard v16.

A supplementary shared-kit comparison using local Xcode 27 indexes reports three unchanged SwiftUI declarations (`ChatMarkdownDisclosureView.isExpanded`, the session sheet initializer, and its body). They already appear in the baseline local Mac report and are absent from the green CI iOS report for the same source under Xcode 26.6. There are no Talk findings in that comparison. This local diagnostic is not claimed as a passing shared-kit gate; the canonical [shared-kit CI scan 34142556124](https://github.com/openclaw/openclaw/actions/runs/34142556124) passed for this exact head, with no shared dead-code findings. An initial app-only index also lacked four test-owned references, resolved by build-for-testing. No retention rule, suppression, or baseline was changed.

No live provider flow is claimed for this parsing consolidation.

Exact-head [CI 34142556240](https://github.com/openclaw/openclaw/actions/runs/34142556240) passed on the first attempt for `9d9f994b63e7ec832d00daf90004a925d8279451`, including macOS Swift tests and iOS build. ClawSweeper reviewed the same head with no actionable finding. The rebase before publication changed only non-Swift main content; all app source was byte-identical across it.
