### PR TITLE
refactor(agents): share terminal control character detection

### DIFF
--- a/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.completion.ts
@@ -55,7 +55,6 @@ import {
   extractExecOutput,
   extractLiveExecOutput,
   hasMessagingRichContent,
-  hasTerminalControlCharacter,
   isAsyncStartedToolResult,
   isCronAddAction,
   isMiddlewareToolResultError,
@@ -98,6 +97,7 @@ import { readMcpAppChannelView } from "./mcp-ui-resource.js";
 import type { AgentEvent } from "./runtime/index.js";
 import {
   createToolValidationErrorSummary,
+  hasTerminalControlCharacter,
   summarizeToolValidationError,
 } from "./tool-error-summary.js";
 import { resolveFileMutationToolName } from "./tool-mutation-names.js";

--- a/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
+++ b/src/agents/embedded-agent-subscribe.handlers.tools.results.ts
@@ -23,7 +23,10 @@ import {
   filterToolResultMediaUrls,
 } from "./embedded-agent-tool-media.js";
 import { extractToolResultText, truncateLiveExecOutput } from "./embedded-agent-tool-results.js";
-import type { ProcessTerminalDiagnostic } from "./tool-error-summary.js";
+import {
+  hasTerminalControlCharacter,
+  type ProcessTerminalDiagnostic,
+} from "./tool-error-summary.js";
 import { readToolResultDetails } from "./tool-result-error.js";
 import { createToolTerminalObserver } from "./tool-terminal-outcome.js";
 import { getCoreTtsToolResultMediaUrls } from "./tools/tts-tool-result-provenance.js";
@@ -66,16 +69,6 @@ export function isMiddlewareToolResultError(result: unknown): boolean {
     !Array.isArray(details) &&
     (details as { middlewareError?: unknown }).middlewareError === true,
   );
-}
-
-export function hasTerminalControlCharacter(value: string): boolean {
-  for (const char of value) {
-    const code = char.charCodeAt(0);
-    if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 const PROCESS_TERMINATION_REASONS = new Set([

--- a/src/agents/tool-error-summary.ts
+++ b/src/agents/tool-error-summary.ts
@@ -39,7 +39,7 @@ export function isExecLikeToolName(toolName: string): boolean {
 
 const MAX_ABORT_SUMMARY_LENGTH = 160;
 
-function hasUnsafeSummaryCharacter(value: string): boolean {
+export function hasTerminalControlCharacter(value: string): boolean {
   for (const char of value) {
     const code = char.charCodeAt(0);
     if (code <= 0x1f || (code >= 0x7f && code <= 0x9f)) {
@@ -55,7 +55,11 @@ export function readToolValidationErrorSummary(value: unknown): string | undefin
     return undefined;
   }
   const summary = value.trim();
-  if (!summary || summary.length > MAX_ABORT_SUMMARY_LENGTH || hasUnsafeSummaryCharacter(summary)) {
+  if (
+    !summary ||
+    summary.length > MAX_ABORT_SUMMARY_LENGTH ||
+    hasTerminalControlCharacter(summary)
+  ) {
     return undefined;
   }
   return summary;
@@ -63,7 +67,7 @@ export function readToolValidationErrorSummary(value: unknown): string | undefin
 
 /** Builds a static diagnostic from typed pre-execution validation provenance. */
 export function createToolValidationErrorSummary(toolName: string): string | undefined {
-  if (hasUnsafeSummaryCharacter(toolName)) {
+  if (hasTerminalControlCharacter(toolName)) {
     return undefined;
   }
   const normalizedToolName = toolName.replace(/\s+/g, " ").trim();


### PR DESCRIPTION
## What Problem This Solves

Tool-validation summaries and process diagnostics used identical terminal-control character predicates in separate agent modules. This maintainer-requested duplication cleanup gives those existing callers one implementation, avoiding future drift in which control characters they reject.

## Why This Change Was Made

Export the existing predicate from the lightweight tool-error summary owner and reuse it in the result and completion handlers. The body is unchanged, including `for...of`, `charCodeAt(0)`, C0 rejection through `0x1f`, and C1 rejection from `0x7f` through `0x9f`. The new runtime import reaches only a module using the same normalization-core string helper already loaded by the consumers.

No compatibility alias, barrel, SDK export, dependency, configuration, storage, protocol, or behavior change is introduced. The formatted production diff is 12 additions and 15 deletions across three files; tests are unchanged.

## User Impact

No user-visible behavior change. Tool-validation summaries, process session identifiers, signal diagnostics, and completion output retain their existing control-character handling.

## Evidence

- Existing focused suites passed: `src/agents/tool-error-summary.test.ts` (4 tests) and `src/agents/embedded-agent-subscribe.handlers.tools.test.ts` (192 tests).
- The handler suite initially stopped during dependency loading because package-local dependency symlinks were absent. Linking the existing installed package directories resolved it; no dependencies were installed or reconciled.
- A TypeScript-parser comparison verified that both original predicate bodies are byte-identical to the shared body. A scoped importer search found only the approved callers in these three files.
- Targeted `oxfmt`, `oxlint`, and `git diff --check` passed. `check-import-cycles.ts` reported zero runtime value cycles.
- `check:changed` dry-run selected core/coreTests. The actual gate passed its preliminary guards, then stopped at the existing `tsgo` guard against dependency/compiler symlinks outside the checkout. The successful hosted exact-head CI run closes this local typecheck gap; the local guard was not bypassed.
- Fresh autoreview was scoped-clean with no actionable P0-P2 findings. ClawSweeper completed its review of the same head with no actionable or security findings.
- Exact-head CI passed for `0940d0a99a162d5b730590453cd4019556fd7639`: 107 successful jobs, 17 intentionally skipped, and `openclaw/ci-gate` successful. Run: https://github.com/openclaw/openclaw/actions/runs/34142584602
- Moving-main check at `64e65c816044aa02d617a798af6344a01679741f`: the scoped source/test files, normalization leaf, and caller set are unchanged from the reviewed base.
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 141343` completed and accepted hosted CI/Testbox evidence for the exact reviewed head. The prepared and remote heads remained `0940d0a99a162d5b730590453cd4019556fd7639`; no rebase or push was needed. No separate credentialed Crabbox lease or live provider run was used.
- Native squash landing completed as `a595ce27a79596e4b36e3079268ab1fa3895dca2`. The retained native receipt records the exact attempted head, `method=squash`, and `phase=complete`; native operation-owned worktree cleanup completed. Completion receipt: https://github.com/openclaw/openclaw/pull/141343#issuecomment-5573458880
