### PR TITLE
fix(agents): rate-limit copy drops the provider reset hint on a failed chain

### DIFF
--- a/src/agents/failover/message-patterns.ts
+++ b/src/agents/failover/message-patterns.ts
@@ -408,3 +408,25 @@ export function isServerErrorMessage(raw: string): boolean {
   }
   return matchesErrorPatterns(scrubbed, ERROR_PATTERNS.serverError);
 }
+
+/** `All models failed (3): provider/model: text | provider/model: text` */
+const FAILOVER_AGGREGATE_PREFIX_RE = /^all(?: [\w-]+)? models failed \(\d+\):\s*/i;
+const FAILOVER_AGGREGATE_LEG_SPLIT_RE = /\s\|\s|;\s(?=\S+\/\S+:\s)/;
+/** `anthropic/claude-opus-5: You've hit your session limit` */
+const FAILOVER_LEG_ROUTE_PREFIX_RE = /^\S+\/\S+:\s+/;
+
+/**
+ * A chain summary concatenates every leg, so it outgrows the length guard that keeps
+ * provider text bounded, and a hint the provider did give is thrown away. Read the legs
+ * individually, preferring the first, which is the route the user actually chose.
+ */
+export function splitFailoverAggregateLegs(raw: string): string[] {
+  const withoutPrefix = raw.trim().replace(FAILOVER_AGGREGATE_PREFIX_RE, "");
+  if (withoutPrefix === raw.trim()) {
+    return [];
+  }
+  return withoutPrefix
+    .split(FAILOVER_AGGREGATE_LEG_SPLIT_RE)
+    .map((leg) => leg.trim().replace(FAILOVER_LEG_ROUTE_PREFIX_RE, "").trim())
+    .filter(Boolean);
+}

--- a/src/agents/failover/user-copy.test.ts
+++ b/src/agents/failover/user-copy.test.ts
@@ -145,3 +145,27 @@ describe("failover user copy", () => {
     );
   });
 });
+
+describe("rate limit copy from a failover chain summary", () => {
+  const aggregate =
+    "All models failed (3): anthropic/claude-opus-5: You've hit your session limit · resets 6:20pm (Europe/London) (unknown) | " +
+    "claude-cli/claude-sonnet-5: You've hit your session limit · resets 6:20pm (Europe/London) (unknown) | " +
+    "openai/gpt-5.6-sol: Codex error: The usage limit has been reached (rate_limit)";
+
+  it("keeps the provider reset hint when the summary exceeds the length guard", () => {
+    // The summary is over the 300 char bound, so reading it whole discards a hint the
+    // provider did give. The first leg is the route the user picked.
+    expect(aggregate.length).toBeGreaterThan(300);
+    const copy = renderRateLimitOrOverloadedCopy({ reason: "rate_limit", raw: aggregate });
+    expect(copy).toContain("resets 6:20pm (Europe/London)");
+    expect(copy).not.toBe("⚠️ API rate limit reached. Please try again later.");
+  });
+
+  it("still falls back to the generic message when no leg carries a hint", () => {
+    const copy = renderRateLimitOrOverloadedCopy({
+      reason: "rate_limit",
+      raw: "All models failed (2): anthropic/claude: 429 (rate_limit) | openai/gpt-5.4: 429 (rate_limit)",
+    });
+    expect(copy).toContain("API rate limit reached");
+  });
+});

--- a/src/agents/failover/user-copy.ts
+++ b/src/agents/failover/user-copy.ts
@@ -18,6 +18,7 @@ import {
   isPeriodicUsageLimitErrorMessage,
   isProviderCompletedErrorFinishReasonMessage,
 } from "./classify.js";
+import { splitFailoverAggregateLegs } from "./message-patterns.js";
 import {
   classifyProviderRequestFacets,
   type ProviderRequestFacet,
@@ -122,28 +123,6 @@ function extractProviderRateLimitMessage(raw: string): string | undefined {
     return undefined;
   }
   return `⚠️ ${trimmed}`;
-}
-
-/** `All models failed (3): provider/model: text | provider/model: text` */
-const FAILOVER_AGGREGATE_PREFIX_RE = /^all(?: [\w-]+)? models failed \(\d+\):\s*/i;
-const FAILOVER_AGGREGATE_LEG_SPLIT_RE = /\s\|\s|;\s(?=\S+\/\S+:\s)/;
-/** `anthropic/claude-opus-5: You've hit your session limit` */
-const FAILOVER_LEG_ROUTE_PREFIX_RE = /^\S+\/\S+:\s+/;
-
-/**
- * A chain summary concatenates every leg, so it outgrows the length guard that keeps
- * provider text bounded, and a hint the provider did give is thrown away. Read the legs
- * individually, preferring the first, which is the route the user actually chose.
- */
-function splitFailoverAggregateLegs(raw: string): string[] {
-  const withoutPrefix = raw.trim().replace(FAILOVER_AGGREGATE_PREFIX_RE, "");
-  if (withoutPrefix === raw.trim()) {
-    return [];
-  }
-  return withoutPrefix
-    .split(FAILOVER_AGGREGATE_LEG_SPLIT_RE)
-    .map((leg) => leg.trim().replace(FAILOVER_LEG_ROUTE_PREFIX_RE, "").trim())
-    .filter(Boolean);
 }
 
 function renderRateLimitBaseCopy(context: FailoverUserCopyContext): string {

--- a/src/agents/failover/user-copy.ts
+++ b/src/agents/failover/user-copy.ts
@@ -124,12 +124,44 @@ function extractProviderRateLimitMessage(raw: string): string | undefined {
   return `⚠️ ${trimmed}`;
 }
 
+/** `All models failed (3): provider/model: text | provider/model: text` */
+const FAILOVER_AGGREGATE_PREFIX_RE = /^all(?: [\w-]+)? models failed \(\d+\):\s*/i;
+const FAILOVER_AGGREGATE_LEG_SPLIT_RE = /\s\|\s|;\s(?=\S+\/\S+:\s)/;
+/** `anthropic/claude-opus-5: You've hit your session limit` */
+const FAILOVER_LEG_ROUTE_PREFIX_RE = /^\S+\/\S+:\s+/;
+
+/**
+ * A chain summary concatenates every leg, so it outgrows the length guard that keeps
+ * provider text bounded, and a hint the provider did give is thrown away. Read the legs
+ * individually, preferring the first, which is the route the user actually chose.
+ */
+function splitFailoverAggregateLegs(raw: string): string[] {
+  const withoutPrefix = raw.trim().replace(FAILOVER_AGGREGATE_PREFIX_RE, "");
+  if (withoutPrefix === raw.trim()) {
+    return [];
+  }
+  return withoutPrefix
+    .split(FAILOVER_AGGREGATE_LEG_SPLIT_RE)
+    .map((leg) => leg.trim().replace(FAILOVER_LEG_ROUTE_PREFIX_RE, "").trim())
+    .filter(Boolean);
+}
+
 function renderRateLimitBaseCopy(context: FailoverUserCopyContext): string {
   const raw = context.raw ?? "";
   if (MODEL_CAPACITY_ERROR_RE.test(raw)) {
     return MODEL_CAPACITY_ERROR_USER_MESSAGE;
   }
-  return extractProviderRateLimitMessage(raw) ?? RATE_LIMIT_ERROR_USER_MESSAGE;
+  const direct = extractProviderRateLimitMessage(raw);
+  if (direct) {
+    return direct;
+  }
+  for (const leg of splitFailoverAggregateLegs(raw)) {
+    const fromLeg = extractProviderRateLimitMessage(leg);
+    if (fromLeg) {
+      return fromLeg;
+    }
+  }
+  return RATE_LIMIT_ERROR_USER_MESSAGE;
 }
 
 const FAILOVER_REASON_BASE_COPY = {

--- a/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
+++ b/src/auto-reply/reply/agent-runner-execution-terminal-failures.test.ts
@@ -61,6 +61,32 @@ describe("executeAgentTurn: terminal failures", () => {
     }
   });
 
+  it("keeps the provider reset hint when the chain summary exceeds the length guard", async () => {
+    // Three legs of ordinary provider text push the summary past the bound that keeps
+    // provider strings from dumping HTML or JSON. This is the mid-turn surfacing path in
+    // agent-runner-execution, where a run returns no usable text and the raw upstream
+    // error is rendered for the user.
+    const hint = "You've hit your session limit \u00b7 resets 6:20pm (Europe/London)";
+    const message =
+      `All models failed (3): anthropic/claude-opus-5: ${hint} (unknown) | ` +
+      `claude-cli/claude-sonnet-5: ${hint} (unknown) | ` +
+      "openai/gpt-5.6-sol: Codex error: The usage limit has been reached (rate_limit)";
+    expect(message.length).toBeGreaterThan(300);
+    state.runWithModelFallbackMock.mockResolvedValueOnce({
+      result: { payloads: [], meta: { error: new Error(message) } },
+      provider: "anthropic",
+      model: "claude-opus-5",
+      attempts: [],
+    });
+
+    const executeAgentTurn = await getExecuteAgentTurnForTest();
+    const result = await executeAgentTurn(createFailureRunAgentTurnParams());
+
+    const rendered = JSON.stringify(result);
+    expect(rendered).toContain("resets 6:20pm (Europe/London)");
+    expect(rendered).not.toContain("API rate limit reached. Please try again later.");
+  });
+
   it("surfaces Codex usage-limit reset details for pure fallback exhaustion", async () => {
     const codexMessage =
       "You've reached your Codex subscription usage limit. Next reset in 42 minutes (2026-05-04T21:34:00.000Z). Run /codex account for current usage details.";


### PR DESCRIPTION
## What Problem This Solves

Fixes #141260.

When a model fallback chain exhausts, the user is told "try again later" even though the provider said exactly when the limit resets.

The rate-limit copy is rendered from the aggregate summary rather than from any single leg:

`src/agents/failover/user-copy.ts`

```ts
function renderRateLimitBaseCopy(context: FailoverUserCopyContext): string {
  const raw = context.raw ?? "";
  ...
  return extractProviderRateLimitMessage(raw) ?? RATE_LIMIT_ERROR_USER_MESSAGE;
}
```

`extractProviderRateLimitMessage` bounds provider text at 300 characters so an HTML error page or a JSON blob never reaches the user. That bound is right, but the aggregate is not provider text, it is every leg concatenated:

```
All models failed (3): anthropic/claude-opus-5: You've hit your session limit · resets 6:20pm (Europe/London) (unknown) | claude-cli/claude-sonnet-5: ... | openai/gpt-5.6-sol: ...
```

That is 302 characters for three legs, so the hint regex matches and the length check then throws the match away. The first leg on its own is 61 characters and carries the whole hint. Longer chains and more verbose provider text make this more certain, not less.

## Why This Change Was Made

The legs are read individually when the summary carries the aggregate prefix, preferring the first, which is the route the user actually chose.

The full string is still tried first, so a single-leg failure behaves exactly as before and nothing about non-aggregate copy changes. The 300 character bound still applies to each candidate, so the guard against HTML and JSON payloads is intact; the change only stops one long string from hiding the short messages inside it.

Splitting is anchored on the `All models failed (N):` prefix rather than on separators alone, so an ordinary provider message that happens to contain a pipe is never split. Both separators that appear in existing fixtures are handled, and the `provider/model:` route label is stripped from each leg so the user sees the provider's sentence rather than routing detail.

## User Impact

A user whose chain exhausts on a rate limit now sees the provider's own hint:

```
⚠️ You've hit your session limit · resets 6:20pm (Europe/London)
```

instead of `⚠️ API rate limit reached. Please try again later.` When no leg carries a hint, the generic message is still what they get.

## Evidence

Production change is +33/-1 in one file.

The regression test fails on unfixed code. Restoring only `user-copy.ts` from main:

```
× keeps the provider reset hint when the summary exceeds the length guard
  → expected '⚠️ API rate limit reached. Please try…' to contain 'resets 6:20pm (Europe/London)'
  Tests  1 failed | 17 passed (18)
```

With the change, `src/agents/failover/user-copy.test.ts` passes 18. The second new test, that a chain with no hint in any leg still returns the generic copy, passes both before and after, so it shows the fallback path was not weakened rather than merely following the change.

```
node scripts/run-vitest.mjs src/agents/failover/user-copy.test.ts        18 passed
node scripts/run-tsgo.mjs -p tsconfig.core.json                              clean
./node_modules/.bin/oxfmt --check <both touched files>                       clean
```

One gap I should state rather than paper over: I could not run the test-types lane or oxlint locally. Both die on this machine for environmental reasons, `tsgo -p test/tsconfig/tsconfig.core.test.json` with exit 137 and oxlint's `tsgolint` crashing, and they behave the same way on an unmodified checkout of main. CI is authoritative for those two. The test file adds no type assertions and calls an existing exported function with a literal `reason`, so the type surface it introduces is small, but I have not verified that locally and did not want to imply otherwise.

### Real reply-path proof, and a correction

Added coverage at the path this change actually serves: the mid-turn surfacing branch in `src/auto-reply/reply/agent-runner-execution.ts:462-480`, where a run produces no usable text and the raw upstream error is rendered for the user through `renderRateLimitOrOverloadedCopy`. The new case in `agent-runner-execution-terminal-failures.test.ts` drives `executeAgentTurn` with an exhausted three leg chain and asserts the delivered reply carries the hint.

It fails on unfixed source for the right reason. Restoring only `user-copy.ts` and `message-patterns.ts` from main:

```
× keeps the provider reset hint when the chain summary exceeds the length guard
  → expected '{"kind":"success","runId":"16442fdd-c…' to contain 'resets 6:20pm (Europe/London)'
  Tests  1 failed | 27 passed (28)
```

With the change, that file passes 28 and `user-copy.test.ts` passes 18.

The correction: my earlier User Impact claim was broader than what this fixes. While building the proof I found there are two rate-limit reply paths, and they do not share a renderer.

- `agent-runner-execution.ts:477` renders through `renderRateLimitOrOverloadedCopy`, so it reaches the guarded extractor. **This is the path this PR fixes, and the one now proven.**
- `agent-runner-failure-reply.ts:110-131` uses `renderRateLimitReplyCopy` for `rate_limit`, reserving `renderRateLimitOrOverloadedCopy` for `overloaded` only. `renderRateLimitReplyCopy` never consults the provider text at all; it returns cooldown or "all attempted models were rate-limited" copy from the attempts list. **That path is unchanged by this PR and still shows no provider hint.**

So this repairs the reported renderer and the path that produced the reported string, but it does not make every rate-limit reply carry the hint. Whether the second path should also surface it looks like a separate decision, and I did not want to widen this diff to make that call. Happy to follow up if you want them unified.

Line budgets checked since CI flagged one earlier: `user-copy.ts` is 692 counted against its 700 limit, and the touched test files are 765 and 306 against the 1000 limit that applies to `*.test.*`.

AI-assisted: yes. I traced the source path by hand and ran every command above myself.

