### PR TITLE
fix: avoid duplicate agent turns for acknowledged completions

### DIFF
--- a/src/infra/heartbeat-runner-delivery.ts
+++ b/src/infra/heartbeat-runner-delivery.ts
@@ -265,6 +265,7 @@ export async function finalizeHeartbeatOutcome(params: {
   opts: HeartbeatRunOptions;
   wake: ReadyHeartbeatWake;
   prepared: PreparedHeartbeatRun;
+  inspectedSystemEventsToConsume: CompletedHeartbeatAgentRun["inspectedSystemEventsToConsume"];
   outcome: ClassifiedHeartbeatOutcome;
   replyPayloadSource: CompletedHeartbeatAgentRun["replyPayload"];
   maybeSendHeartbeatOk: () => Promise<boolean>;
@@ -291,9 +292,9 @@ export async function finalizeHeartbeatOutcome(params: {
     if (
       consumeEvents &&
       params.wake.preflight.shouldInspectPendingEvents &&
-      params.prepared.inspectedSystemEventsToConsume.length
+      params.inspectedSystemEventsToConsume.length
     ) {
-      consumeSelectedSystemEventEntries(sessionKey, params.prepared.inspectedSystemEventsToConsume);
+      consumeSelectedSystemEventEntries(sessionKey, params.inspectedSystemEventsToConsume);
     }
     return { status: "ran", durationMs: Date.now() - startedAt } as const;
   };

--- a/src/infra/heartbeat-runner-execution.ts
+++ b/src/infra/heartbeat-runner-execution.ts
@@ -69,6 +69,7 @@ import {
   resolveHeartbeatPreflight,
   resolveHeartbeatRunPrompt,
   shouldPreflightWakeBeforeBusy,
+  shouldSkipConsumedExecWake,
 } from "./heartbeat-runner-prompt.js";
 import {
   resolveHeartbeatSession,
@@ -85,6 +86,7 @@ import {
   areHeartbeatsEnabled,
   getHeartbeatWakeAbortSignal,
   HEARTBEAT_SKIP_CRON_IN_PROGRESS,
+  HEARTBEAT_SKIP_NO_PENDING_EVENT,
   HEARTBEAT_SKIP_REQUESTS_IN_FLIGHT,
   type HeartbeatScheduledTask,
   type HeartbeatWakeIntent,
@@ -95,13 +97,14 @@ import {
   resolveHeartbeatDeliveryTargetWithSessionRoute,
   resolveHeartbeatSenderContext,
 } from "./outbound/targets.js";
+import { peekSelectedSystemEventEntries } from "./system-events.js";
 
 const log = heartbeatLog;
 const CRON_COMMAND_LANE: string = CommandLane.Cron;
 
 export type HeartbeatDeps = OutboundSendDeps &
   ChannelHeartbeatDeps & {
-    getReplyFromConfig?: typeof import("./heartbeat-runner.runtime.js").getHeartbeatReplyFromConfig;
+    getReplyFromConfig?: typeof import("../auto-reply/reply.js").getReplyFromConfig;
     runtime?: RuntimeEnv;
     getQueueSize?: (lane?: string) => number;
     isReplyRunActive?: (sessionKey: string) => boolean;
@@ -378,7 +381,7 @@ export type ReadyHeartbeatWake = StageResult<ReturnType<typeof resolveHeartbeatW
 
 export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
   const { cfg, agentId, heartbeat, preflight } = wake;
-  const { scheduledTasks, startedAt } = wake;
+  const { startedAt } = wake;
   const { listActiveEmbeddedRuns, isReplyRunActive } = wake;
   const { entry, sessionKey, run, conversationEntry } = preflight.session;
   const previousUpdatedAt = entry?.updatedAt;
@@ -409,7 +412,7 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     delivery.reason === "no-route" &&
     (wake.wakeSource === undefined || wake.wakeSource === "interval") &&
     preflight.pendingEventEntries.length === 0 &&
-    scheduledTasks.length === 0
+    wake.scheduledTasks.length === 0
   ) {
     return skippedHeartbeatStage("no-route", startedAt);
   }
@@ -441,9 +444,6 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     channel: delivery.channel !== "none" ? delivery.channel : undefined,
     accountId: delivery.accountId,
   });
-  const canRelayToUser = Boolean(
-    delivery.channel !== "none" && delivery.to && visibility.showAlerts,
-  );
   let useHeartbeatResponseToolPrompt = shouldUseHeartbeatResponseToolPrompt({
     cfg,
     agentId,
@@ -451,16 +451,6 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     entry,
     sessionKey,
     chatType: delivery.chatType,
-  });
-  let heartbeatRunPrompt = resolveHeartbeatRunPrompt({
-    cfg,
-    heartbeat,
-    preflight,
-    canRelayToUser,
-    startedAt,
-    scheduledTasks,
-    heartbeatScratchContent: preflight.heartbeatScratchContent,
-    useHeartbeatResponseTool: useHeartbeatResponseToolPrompt,
   });
 
   const runSessionKey = run.sessionKey;
@@ -533,7 +523,7 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     }
     outboundPolicySessionKey = isolatedBaseSessionKey;
 
-    const actualUseHeartbeatResponseToolPrompt = shouldUseHeartbeatResponseToolPrompt({
+    useHeartbeatResponseToolPrompt = shouldUseHeartbeatResponseToolPrompt({
       cfg,
       agentId,
       heartbeat,
@@ -541,20 +531,8 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
       sessionKey: runSessionKey,
       chatType: delivery.chatType,
     });
-    if (actualUseHeartbeatResponseToolPrompt !== useHeartbeatResponseToolPrompt) {
-      useHeartbeatResponseToolPrompt = actualUseHeartbeatResponseToolPrompt;
-      heartbeatRunPrompt = resolveHeartbeatRunPrompt({
-        cfg,
-        heartbeat,
-        preflight,
-        canRelayToUser,
-        startedAt,
-        scheduledTasks,
-        heartbeatScratchContent: preflight.heartbeatScratchContent,
-        useHeartbeatResponseTool: useHeartbeatResponseToolPrompt,
-      });
-    }
   }
+
   return {
     kind: "ready",
     ...preflight.session,
@@ -565,7 +543,7 @@ export async function prepareHeartbeatRunStage(wake: ReadyHeartbeatWake) {
     replyPrefix,
     runSessionKey,
     outboundPolicySessionKey,
-    ...heartbeatRunPrompt,
+    useHeartbeatResponseTool: useHeartbeatResponseToolPrompt,
   } as const;
 }
 
@@ -580,15 +558,44 @@ export async function invokeHeartbeatAgentRun(
   prepared: PreparedHeartbeatRun,
 ) {
   const { cfg, agentId, heartbeat, startedAt, preflight } = wake;
-  const { delivery, hasExecCompletion, hasCronEvents, prompt } = prepared;
+  const { delivery } = prepared;
   const { replyPrefix, runSessionKey, sender, suppressOriginatingContext } = prepared;
-  const { usesHeartbeatResponseTool } = prepared;
   const replyOperationRunState: ReplyOperationRunState = {};
   const heartbeatModelOverride = normalizeOptionalString(heartbeat?.model);
+  const heartbeatWakeAbortSignal = getHeartbeatWakeAbortSignal();
   const getReplyFromConfig =
     opts.deps?.getReplyFromConfig ??
-    (await loadHeartbeatRunnerRuntime()).getHeartbeatReplyFromConfig;
-  const heartbeatWakeAbortSignal = getHeartbeatWakeAbortSignal();
+    (await (
+      await loadHeartbeatRunnerRuntime()
+    ).resolveHeartbeatReplyFromConfig({
+      agentId,
+      abortSignal: heartbeatWakeAbortSignal,
+    }));
+  // Routing, isolated-session setup, typing and runtime loading can all yield.
+  // Revalidate the original occurrences now; successors belong to a later wake.
+  const currentPreflight = {
+    ...preflight,
+    pendingEventEntries: peekSelectedSystemEventEntries(
+      preflight.session.sessionKey,
+      preflight.pendingEventEntries,
+    ),
+  };
+  if (shouldSkipConsumedExecWake(currentPreflight, wake.scheduledTasks)) {
+    return skippedHeartbeatStage(HEARTBEAT_SKIP_NO_PENDING_EVENT, startedAt);
+  }
+  const runPrompt = resolveHeartbeatRunPrompt({
+    cfg,
+    heartbeat,
+    preflight: currentPreflight,
+    canRelayToUser: Boolean(
+      delivery.channel !== "none" && delivery.to && prepared.visibility.showAlerts,
+    ),
+    startedAt,
+    scheduledTasks: wake.scheduledTasks,
+    heartbeatScratchContent: preflight.heartbeatScratchContent,
+    useHeartbeatResponseTool: prepared.useHeartbeatResponseTool,
+  });
+  const { prompt, hasExecCompletion, hasCronEvents, usesHeartbeatResponseTool } = runPrompt;
   const heartbeatContext = {
     Body: appendCronStyleCurrentTimeLine(prompt, cfg, startedAt),
     From: sender,
@@ -625,7 +632,7 @@ export async function invokeHeartbeatAgentRun(
     },
     {
       sessionKey: prepared.inspectsRunQueue ? prepared.sessionKey : runSessionKey,
-      events: prepared.inspectsRunQueue ? prepared.genericEvents : [],
+      events: prepared.inspectsRunQueue ? runPrompt.genericEvents : [],
     },
   );
   const replyResult = await getReplyFromConfig(heartbeatContext, replyOpts, cfg);
@@ -672,6 +679,8 @@ export async function invokeHeartbeatAgentRun(
   }
   return {
     kind: "completed",
+    hasRelayableExecCompletion: runPrompt.hasRelayableExecCompletion,
+    inspectedSystemEventsToConsume: runPrompt.inspectedSystemEventsToConsume,
     heartbeatToolResponse,
     heartbeatTerminalToolFailure,
     agentRunFailed,

--- a/src/infra/heartbeat-runner-prompt.ts
+++ b/src/infra/heartbeat-runner-prompt.ts
@@ -51,7 +51,6 @@ type HeartbeatPreflight = HeartbeatWakePayloadFlags & {
   session: ReturnType<typeof resolveHeartbeatSessionSelection>;
   pendingEventEntries: ReturnType<typeof peekSystemEventEntries>;
   turnSourceDeliveryContext: ReturnType<typeof resolveSystemEventDeliveryContext>;
-  hasTaggedCronEvents: boolean;
   shouldInspectPendingEvents: boolean;
   authoritativeScheduledTick: boolean;
   skipReason?: HeartbeatSkipReason;
@@ -136,7 +135,6 @@ export async function resolveHeartbeatPreflight(params: {
     session,
     pendingEventEntries,
     turnSourceDeliveryContext,
-    hasTaggedCronEvents,
     shouldInspectPendingEvents,
     authoritativeScheduledTick:
       typeof params.scheduledEveryMs === "number" &&
@@ -158,13 +156,7 @@ export async function resolveHeartbeatPreflight(params: {
 
   // The exec completion can be acknowledged by process poll after its wake is
   // queued. Treat that stale wake as consumed without touching unrelated events.
-  if (
-    wakeFlags.isExecEventWake &&
-    !basePreflight.authoritativeScheduledTick &&
-    !params.scheduledTasks?.length &&
-    !hasTaggedCronEvents &&
-    !pendingEventEntries.some((event) => isExecCompletionEvent(event.text))
-  ) {
+  if (shouldSkipConsumedExecWake(basePreflight, params.scheduledTasks ?? [])) {
     return {
       ...basePreflight,
       skipReason: HEARTBEAT_SKIP_NO_PENDING_EVENT,
@@ -190,6 +182,23 @@ export async function resolveHeartbeatPreflight(params: {
     };
   }
   return basePreflight;
+}
+
+export function shouldSkipConsumedExecWake(
+  preflight: Pick<
+    HeartbeatPreflight,
+    "isExecEventWake" | "authoritativeScheduledTick" | "pendingEventEntries"
+  >,
+  scheduledTasks: readonly HeartbeatScheduledTask[],
+): boolean {
+  return (
+    preflight.isExecEventWake &&
+    !preflight.authoritativeScheduledTick &&
+    scheduledTasks.length === 0 &&
+    !preflight.pendingEventEntries.some(
+      (event) => event.contextKey?.startsWith("cron:") || isExecCompletionEvent(event.text),
+    )
+  );
 }
 
 type HeartbeatPromptResolution = {

--- a/src/infra/heartbeat-runner-run.ts
+++ b/src/infra/heartbeat-runner-run.ts
@@ -43,7 +43,7 @@ export async function runHeartbeatOnce(opts: HeartbeatRunOptions): Promise<Heart
   }
   const { cfg, agentId, startedAt } = wake;
   const { delivery, visibility, replyPrefix, runSessionKey } = prepared;
-  const { outboundPolicySessionKey, hasRelayableExecCompletion } = prepared;
+  const { outboundPolicySessionKey } = prepared;
 
   if (!visibility.showAlerts && !visibility.showOk && !visibility.useIndicator) {
     emitHeartbeatEvent({
@@ -140,6 +140,9 @@ export async function runHeartbeatOnce(opts: HeartbeatRunOptions): Promise<Heart
   try {
     await heartbeatTyping?.onReplyStart();
     const agentRun = await invokeHeartbeatAgentRun(opts, wake, prepared);
+    if (agentRun.kind === "skipped") {
+      return { status: "skipped", reason: agentRun.reason };
+    }
     if (agentRun.kind !== "completed") {
       const reason =
         agentRun.kind === "busy"
@@ -152,7 +155,7 @@ export async function runHeartbeatOnce(opts: HeartbeatRunOptions): Promise<Heart
     }
     const outcome = classifyHeartbeatAgentOutcome({
       agentRun,
-      hasRelayableExecCompletion,
+      hasRelayableExecCompletion: agentRun.hasRelayableExecCompletion,
       suppressUnmarkedSourceReplies:
         resolveSourceReplyDeliveryMode({
           cfg,
@@ -165,6 +168,7 @@ export async function runHeartbeatOnce(opts: HeartbeatRunOptions): Promise<Heart
       opts,
       wake,
       prepared,
+      inspectedSystemEventsToConsume: agentRun.inspectedSystemEventsToConsume,
       outcome,
       replyPayloadSource: agentRun.replyPayload,
       maybeSendHeartbeatOk,

--- a/src/infra/heartbeat-runner.runtime.ts
+++ b/src/infra/heartbeat-runner.runtime.ts
@@ -4,18 +4,16 @@ import { loadPublishedGatewayReplyDispatchRuntime } from "../agents/prepared-mod
 import { getReplyFromConfig as resolveReplyFromConfig } from "../auto-reply/reply.js";
 import { bindPreparedReplyDispatchRuntime } from "../auto-reply/reply/prepared-reply-dispatch-context.js";
 
-export async function getHeartbeatReplyFromConfig(
-  ...args: Parameters<typeof resolveReplyFromConfig>
-): ReturnType<typeof resolveReplyFromConfig> {
-  const [ctx, opts, configOverride] = args;
-  const agentId = ctx.AgentId?.trim();
-  const runtime = agentId
-    ? await loadPublishedGatewayReplyDispatchRuntime({
-        agentId,
-        abortSignal: opts?.abortSignal,
-      })
-    : undefined;
-  return runtime
-    ? bindPreparedReplyDispatchRuntime(runtime, resolveReplyFromConfig)(ctx, opts)
-    : resolveReplyFromConfig(ctx, opts, configOverride);
+/** Resolve heartbeat-owned runtime preparation before selecting the final event prompt. */
+export async function resolveHeartbeatReplyFromConfig(params: {
+  agentId: string;
+  abortSignal?: AbortSignal;
+}): Promise<typeof resolveReplyFromConfig> {
+  const runtime = await loadPublishedGatewayReplyDispatchRuntime(params);
+  if (!runtime) {
+    return resolveReplyFromConfig;
+  }
+  const reply = bindPreparedReplyDispatchRuntime(runtime, resolveReplyFromConfig);
+  // A published runtime owns its config; retain the existing override-free dispatch.
+  return (ctx, opts) => reply(ctx, opts);
 }

--- a/src/infra/heartbeat-runner.stale-exec.test.ts
+++ b/src/infra/heartbeat-runner.stale-exec.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as preparedModelRuntime from "../agents/prepared-model-runtime.js";
+import { getReplyFromConfig as dispatchReply } from "../auto-reply/reply.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import type { OpenClawConfig } from "../config/config.js";
 import { resetGatewayWorkAdmission } from "../process/gateway-work-admission.js";
@@ -20,12 +22,22 @@ import {
   requestHeartbeat,
   setHeartbeatWakeHandler as setRuntimeHeartbeatWakeHandler,
 } from "./heartbeat-wake.js";
-import { enqueueSystemEvent, peekSystemEvents, resetSystemEventsForTest } from "./system-events.js";
+import * as heartbeatTargets from "./outbound/targets.js";
+import {
+  enqueueSystemEvent,
+  enqueueSystemEventWithReceipt,
+  peekSystemEventEntries,
+  peekSystemEvents,
+  resetSystemEventsForTest,
+} from "./system-events.js";
+
+// Keep the heartbeat facade real; replace only the generic reply dispatch.
+vi.mock("../auto-reply/reply.js", () => ({ getReplyFromConfig: vi.fn() }));
 
 describe("stale exec heartbeat wakes", () => {
   type WakeRequest = Parameters<typeof requestHeartbeat>[0];
   type WakeHandler = Parameters<typeof setRuntimeHeartbeatWakeHandler>[0];
-  const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR"]);
+  const envSnapshot = captureEnv(["OPENCLAW_STATE_DIR", "HOME", "USERPROFILE", "OPENCLAW_HOME"]);
   let currentHandlerDisposer: (() => void) | undefined;
 
   function setHeartbeatWakeHandler(handler: WakeHandler): void {
@@ -43,6 +55,8 @@ describe("stale exec heartbeat wakes", () => {
 
   beforeEach(() => {
     setupTelegramHeartbeatPluginRuntimeForTests();
+    vi.mocked(dispatchReply).mockReset();
+    vi.mocked(dispatchReply).mockResolvedValue({ text: "HEARTBEAT_OK" });
     resetSystemEventsForTest();
     resetGatewayWorkAdmission();
   });
@@ -436,5 +450,180 @@ describe("stale exec heartbeat wakes", () => {
 
     expect(runSpy).toHaveBeenCalledTimes(2);
     runner.stop();
+  });
+
+  it.each([
+    { remaining: "none", expectedSource: undefined, failure: "none" },
+    { remaining: "exec", expectedSource: "exec", failure: "none" },
+    { remaining: "exec", expectedSource: "exec", failure: "dispatch" },
+    { remaining: "exec", expectedSource: "exec", failure: "delivery" },
+    { remaining: "cron", expectedSource: "cron", failure: "none" },
+    { remaining: "cadence", expectedSource: "heartbeat", failure: "none" },
+    { remaining: "task", expectedSource: "heartbeat", failure: "none" },
+  ] as const)(
+    "revalidates acknowledged completions with $remaining work and $failure failure",
+    async ({ remaining, expectedSource, failure }) => {
+      await withTempHeartbeatSandbox(async ({ tmpDir, storePath, replySpy }) => {
+        const cfg: OpenClawConfig = {
+          agents: {
+            defaults: { workspace: tmpDir, heartbeat: { every: "5m", target: "telegram" } },
+          },
+          channels: { telegram: { allowFrom: ["*"] } },
+          session: { store: storePath },
+        };
+        const sessionKey = await seedMainSessionStore(storePath, cfg, {
+          lastChannel: "telegram",
+          lastProvider: "telegram",
+          lastTo: "-100155462274",
+        });
+        const completed = "Exec completed (first-job, code 0) :: already observed";
+        const acknowledge = enqueueSystemEventWithReceipt(completed, { sessionKey });
+        const survivingEvent =
+          remaining === "exec"
+            ? "Exec completed (second-job, code 0) :: unobserved result"
+            : remaining === "cron"
+              ? "Reminder: Check the overnight report"
+              : undefined;
+        if (survivingEvent) {
+          enqueueSystemEvent(survivingEvent, {
+            sessionKey,
+            ...(remaining === "cron" ? { contextKey: "cron:overnight" } : {}),
+          });
+        }
+        enqueueSystemEvent("Unrelated queued event", { sessionKey });
+        const original = peekSystemEventEntries(sessionKey);
+        const resolveTarget = heartbeatTargets.resolveHeartbeatDeliveryTargetWithSessionRoute;
+        vi.spyOn(
+          heartbeatTargets,
+          "resolveHeartbeatDeliveryTargetWithSessionRoute",
+        ).mockImplementationOnce(async (...args) => {
+          const route = await resolveTarget(...args);
+          expect(acknowledge?.()).toBe(true);
+          // Same-text successor must not inherit the acknowledged occurrence's selection.
+          enqueueSystemEvent(completed, { sessionKey });
+          expect(peekSystemEventEntries(sessionKey).at(-1)?.id).not.toBe(original[0]?.id);
+          return route;
+        });
+        const telegram = vi.fn().mockRejectedValue(new Error("Synthetic delivery failure"));
+        replySpy.mockImplementation(async (ctx) => {
+          expect(ctx.Body).not.toContain(completed);
+          expect(ctx.InternalTurnSource).toBe(expectedSource);
+          if (survivingEvent) {
+            expect(ctx.Body).toContain(survivingEvent);
+          }
+          if (remaining === "task") {
+            expect(ctx.Body).toContain("Check the task inbox");
+          }
+          // Selection is read-only until the result is handled successfully.
+          expect(peekSystemEvents(sessionKey)).toContain(completed);
+          if (survivingEvent) {
+            expect(peekSystemEvents(sessionKey)).toContain(survivingEvent);
+          }
+          if (failure === "dispatch") {
+            throw new Error("Synthetic dispatch failure");
+          }
+          return { text: failure === "delivery" ? "Remaining command completed" : "HEARTBEAT_OK" };
+        });
+        const result = await runHeartbeatOnce({
+          cfg,
+          agentId: "main",
+          source: "exec-event",
+          intent: "event",
+          reason: "exec-event",
+          ...(remaining === "cadence" ? { scheduledEveryMs: 5 * 60_000 } : {}),
+          ...(remaining === "task"
+            ? { tasks: [{ jobId: "inbox", name: "Inbox", prompt: "Check the task inbox" }] }
+            : {}),
+          deps: { getReplyFromConfig: replySpy, telegram },
+        });
+        if (remaining === "none") {
+          expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_NO_PENDING_EVENT });
+          expect(replySpy).not.toHaveBeenCalled();
+        } else if (failure !== "none") {
+          expect(result).toMatchObject({
+            status: "failed",
+            reason:
+              failure === "dispatch" ? "Synthetic dispatch failure" : "Synthetic delivery failure",
+          });
+          expect(replySpy).toHaveBeenCalledOnce();
+          if (failure === "delivery") {
+            expect(telegram).toHaveBeenCalledOnce();
+          }
+        } else {
+          expect(result.status).toBe("ran");
+          expect(replySpy).toHaveBeenCalledOnce();
+        }
+        expect(peekSystemEvents(sessionKey)).toEqual([
+          ...(failure !== "none" ? [survivingEvent] : []),
+          "Unrelated queued event",
+          completed,
+        ]);
+      });
+    },
+  );
+
+  it.each([
+    { name: "skips an acknowledged completion", acknowledgeDuringPreparation: true },
+    { name: "dispatches a pending completion", acknowledgeDuringPreparation: false },
+  ])("$name after preparing the published runtime", async ({ acknowledgeDuringPreparation }) => {
+    await withTempHeartbeatSandbox(async ({ tmpDir, storePath }) => {
+      for (const key of ["HOME", "USERPROFILE", "OPENCLAW_HOME"]) {
+        setTestEnvValue(key, tmpDir);
+      }
+      const cfg: OpenClawConfig = {
+        agents: {
+          defaults: {
+            workspace: tmpDir,
+            heartbeat: { every: "0m", target: "telegram" },
+          },
+        },
+        channels: { telegram: { allowFrom: ["*"] } },
+        session: { store: storePath },
+      };
+      const sessionKey = await seedMainSessionStore(storePath, cfg, {
+        lastChannel: "telegram",
+        lastProvider: "telegram",
+        lastTo: "-100155462274",
+      });
+      const completion = "Exec completed (runtime-proof, code 0) :: Synthetic result";
+      const acknowledge = enqueueSystemEventWithReceipt(completion, { sessionKey });
+      if (!acknowledge) {
+        throw new Error("Expected a queued completion receipt");
+      }
+      const prepareRuntime = vi
+        .spyOn(preparedModelRuntime, "loadPublishedGatewayReplyDispatchRuntime")
+        .mockImplementationOnce(async () => {
+          // The real facade is awaiting runtime preparation after preflight took its snapshot.
+          await Promise.resolve();
+          expect(peekSystemEvents(sessionKey)).toEqual([completion]);
+          if (acknowledgeDuringPreparation) {
+            expect(acknowledge()).toBe(true);
+          }
+          return undefined;
+        });
+
+      const result = await runHeartbeatOnce({
+        cfg,
+        agentId: "main",
+        source: "exec-event",
+        intent: "event",
+        reason: "exec-event",
+        deps: { telegram: vi.fn().mockResolvedValue({ messageId: "m1", chatId: "155462274" }) },
+      });
+
+      expect(prepareRuntime).toHaveBeenCalledOnce();
+      if (acknowledgeDuringPreparation) {
+        expect(result).toEqual({ status: "skipped", reason: HEARTBEAT_SKIP_NO_PENDING_EVENT });
+        expect(dispatchReply).not.toHaveBeenCalled();
+      } else {
+        expect(result.status).toBe("ran");
+        expect(dispatchReply).toHaveBeenCalledOnce();
+        expect(vi.mocked(dispatchReply).mock.calls[0]?.[0]).toMatchObject({
+          Body: expect.stringContaining(completion),
+          InternalTurnSource: "exec",
+        });
+      }
+      expect(peekSystemEvents(sessionKey)).toEqual([]);
+    });
   });
 });

--- a/src/infra/system-events.ts
+++ b/src/infra/system-events.ts
@@ -372,6 +372,17 @@ export function peekSystemEventEntries(sessionKey: string): SystemEvent[] {
   return getSessionQueue(sessionKey)?.queue.map(cloneSystemEvent) ?? [];
 }
 
+/** Read the still-pending occurrences from a prior selection without acknowledging them. */
+export function peekSelectedSystemEventEntries(
+  sessionKey: string,
+  selectedEntries: readonly SystemEvent[],
+): SystemEvent[] {
+  const queue = getSessionQueue(sessionKey)?.queue ?? [];
+  return selectedEntries
+    .filter((selected) => queue.some((event) => matchesConsumedSystemEvent(event, selected)))
+    .map(cloneSystemEvent);
+}
+
 export function peekSystemEvents(sessionKey: string): string[] {
   return getSessionQueue(sessionKey)?.queue.map((event) => event.text) ?? [];
 }


### PR DESCRIPTION
Related: #141202

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled.

</details>

## What Problem This Solves

Resolves a problem where reading a completed background command can still be followed by another agent turn if its completion is acknowledged while heartbeat preparation awaits routing or runtime setup. The extra turn receives an obsolete completion notice and can repeat expensive long-context inference.

## Why This Change Was Made

Build the event prompt after heartbeat preparation and revalidate the original queue occurrences immediately before generic reply dispatch. Outcome classification and successful handling consume that same executed selection. Identical successor events keep their own identities and remain queued; no grace timer or early acknowledgement is added.

## User Impact

Already-observed completions no longer trigger this redundant follow-up. Unobserved completions, tagged cron work, due tasks, and scheduled cadence continue to run. Dispatch and delivery failures retain unread events for recovery.

Thanks to @wpu911 for the report and ordering examples in #141202.

## Evidence

- On unmodified main `5bba4d8b8802304968116fac4e44c6500095b82b`, the final regression file has **7 failures / 12 passes**: consumed completion text survives routing, and acknowledgement during published-runtime preparation still dispatches. With the fix, **19/19 pass**.
- **230 focused tests passed**, covering heartbeat event routing, isolated sessions, structured delivery, model/tool settings, queue receipts, terminal poll persistence, and direct bash polling.
- Independent `autoreview` completed with no actionable P0–P2 findings.
- Full `pnpm build` passed on macOS / Node 26.7.0.
- Full `node scripts/check-changed.mjs` passed: production and all sixteen core-test typecheck groups, formatting, lint, dead-export checks, import-cycle checks, and repository guards.
- `git diff --check` passed.

Proof uses the real heartbeat runner, queue receipts, temporary SQLite session state, and heartbeat runtime facade, with controlled routing/runtime/model/transport boundaries. It does not reproduce the reporter's live Windows/provider trace or claim their timing measurement. Existing route selection is preserved; this does not retract a turn after generic reply dispatch has begun.
