### PR TITLE
fix: preserve diagnostics for large command output

### DIFF
--- a/src/process/command-error.ts
+++ b/src/process/command-error.ts
@@ -7,13 +7,13 @@ import type { runCommandBuffered } from "./exec.js";
 export function formatCommandOutput(output: string | Buffer, maxChars = 800): string {
   // CR redraws replace the current frame; trim before making edge tabs visible.
   // Anchor each CR run/frame so unmatched runs do not repeatedly scan their suffixes.
-  const text = stripAnsi(output.toString())
+  const lines = stripAnsi(output.toString())
     .replace(/(^|[^\r])\r+(?=\n|$)/g, "$1")
     .replace(/(^|\n)[^\n]*\r/g, "$1")
     .trim()
-    .replace(/[^\n]+/g, sanitizeTerminalText);
-  const tail = text.split("\n").slice(-12).join("\n");
-  const omitted = tail.length < text.length || tail.length > maxChars;
+    .split("\n");
+  const tail = lines.slice(-12).map(sanitizeTerminalText).join("\n");
+  const omitted = lines.length > 12 || tail.length > maxChars;
   return `${omitted ? "…\n" : ""}${sliceUtf16Safe(tail, Math.max(0, tail.length - maxChars))}`;
 }
 


### PR DESCRIPTION
## What Problem This Solves

Formatting large command output can throw `RangeError: Maximum call stack size exceeded`, hiding the original output-limit error. The existing worktree Git integration test reproduces this on current main after its normal CI file ordering with a real 17 MiB Git blob.

## Why This Change Was Made

Split normalized output into lines before sanitizing the retained 12-line tail. This removes the failing whole-output replacement while preserving carriage-return redraw handling, terminal safety, character limits, surrogate-safe slicing, and omission markers.

## User Impact

Commands that exceed their output limit report the intended bounded diagnostic instead of failing inside error formatting.

## Evidence

- Reproduced the unchanged integration assertion on main `d234f9d4d09273615508d34bb1b098e803630165`; captured the original stack in `formatCommandOutput`.
- The repaired content passed the same 136-file group and original opening order on Blacksmith Testbox: 2,769 tests passed, three skipped. The formerly failing Git case passed.
- All 87 existing command formatter and Git diagnostic tests passed, including real oversized Git blobs, control characters, carriage returns, output budgets, and surrogate boundaries.
- Changed-file formatting, lint, syntax, and diff checks passed. Independent source review and autoreview found no actionable issues.
- [Hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/34143862132), including the formerly failing shard and the aggregate gate. [Exact-head ClawSweeper review returned Platinum with no findings](https://github.com/openclaw/openclaw/pull/141353#issuecomment-5573529202).
- Exact-head Testbox production and core-test typing passed. Its aggregate check later stopped before the coercion guard because the runner lacked `corepack`; equivalent hosted checks cover the remaining applicable gates. The unchanged plugin-media and runtime-sidecar inputs were excluded from unrelated global checks.
