### PR TITLE
fix(models): stop reporting resolved config credentials as missing

### DIFF
--- a/src/commands/models/list.auth-overview.secret-ref.test.ts
+++ b/src/commands/models/list.auth-overview.secret-ref.test.ts
@@ -1,0 +1,88 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { NON_ENV_SECRETREF_MARKER } from "../../agents/model-auth-markers.js";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../../config/runtime-snapshot.js";
+import type { OpenClawConfig } from "../../config/types.js";
+import { resolveProviderAuthOverview } from "./list.auth-overview.js";
+
+const credential = "synthetic-resolved-provider-credential";
+
+function sourceConfig(id = "provider-key") {
+  return {
+    models: {
+      providers: {
+        diagnostic: {
+          baseUrl: "https://diagnostic.invalid/v1",
+          api: "openai-completions",
+          apiKey: { source: "exec", provider: "diagnostic", id },
+          models: [],
+        },
+      },
+    },
+    secrets: {
+      providers: {
+        diagnostic: { source: "exec", command: "/synthetic/credential-provider" },
+      },
+    },
+  } satisfies OpenClawConfig;
+}
+
+function publishResolvedConfig(source: ReturnType<typeof sourceConfig>) {
+  const resolved = {
+    ...source,
+    models: {
+      providers: {
+        diagnostic: { ...source.models.providers.diagnostic, apiKey: credential },
+      },
+    },
+  };
+  setRuntimeConfigSnapshot(resolved, source);
+  return resolved;
+}
+
+function overview(cfg: OpenClawConfig) {
+  return resolveProviderAuthOverview({
+    provider: "diagnostic",
+    cfg,
+    store: { version: 1, profiles: {} },
+    modelsPath: "/synthetic/models.json",
+    aliasMap: {},
+    envCandidateMap: { diagnostic: [] },
+    authEvidenceMap: { diagnostic: [] },
+  });
+}
+
+describe("resolved non-env config credentials in the auth overview", () => {
+  afterEach(() => clearRuntimeConfigSnapshot());
+
+  it("shows the resolved config source without exposing its credential", () => {
+    const cfg = publishResolvedConfig(sourceConfig());
+
+    const result = overview(cfg);
+
+    expect(result.effective).toEqual({
+      kind: "models.json",
+      detail: `marker(${NON_ENV_SECRETREF_MARKER})`,
+    });
+    expect(result.modelsJson?.value).toBe(`marker(${NON_ENV_SECRETREF_MARKER})`);
+    expect(JSON.stringify(result)).not.toContain(credential);
+  });
+
+  it("keeps a cold configured reference missing without resolved material", () => {
+    const result = overview(sourceConfig());
+
+    expect(result.effective).toEqual({ kind: "missing", detail: "missing" });
+    expect(result.modelsJson?.value).toBe(`marker(${NON_ENV_SECRETREF_MARKER})`);
+  });
+
+  it("does not borrow resolved material after the configured reference changes", () => {
+    publishResolvedConfig(sourceConfig("old-reference"));
+
+    const result = overview(sourceConfig("new-reference"));
+
+    expect(result.effective).toEqual({ kind: "missing", detail: "missing" });
+    expect(JSON.stringify(result)).not.toContain(credential);
+  });
+});

--- a/src/commands/models/list.auth-overview.ts
+++ b/src/commands/models/list.auth-overview.ts
@@ -11,8 +11,13 @@ import { loadPersistedAuthProfileStore } from "../../agents/auth-profiles/persis
 import { listProfilesForProvider } from "../../agents/auth-profiles/profiles.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import { resolveProfileUnusableUntilForDisplay } from "../../agents/auth-profiles/usage.js";
-import { isNonSecretApiKeyMarker, isOAuthApiKeyMarker } from "../../agents/model-auth-markers.js";
+import {
+  isNonSecretApiKeyMarker,
+  isOAuthApiKeyMarker,
+  NON_ENV_SECRETREF_MARKER,
+} from "../../agents/model-auth-markers.js";
 import { resolveProviderConfigSecretInput } from "../../agents/model-auth-provider-config.js";
+import { resolveManagedSecretRefRuntimeProviderAuth } from "../../agents/model-auth-runtime-config.js";
 import {
   getCustomProviderApiKey,
   resolveEnvApiKey,
@@ -164,6 +169,12 @@ export function resolveProviderAuthOverview(params: {
 
   const effective: ProviderAuthOverview["effective"] = (() => {
     if (providerApiKeyRef) {
+      if (
+        providerApiKeyRef.source !== "env" &&
+        resolveManagedSecretRefRuntimeProviderAuth({ cfg, provider })
+      ) {
+        return { kind: "models.json", detail: formatMarkerOrSecret(NON_ENV_SECRETREF_MARKER) };
+      }
       if (!usableCustomKey) {
         return { kind: "missing", detail: "missing" };
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw models status --check` saw `effective=missing:missing` after the same command successfully resolved a configured exec credential reference.

## Why This Change Was Made

The overview now reads the existing matching runtime credential fact and displays its non-secret marker. It does not execute the reference again or change credential selection, readiness, masking, or check exits. Cold references and references changed since resolution remain missing.

## User Impact

Human and JSON status identify an already-resolved configured credential source correctly. The existing environment-reference result stays unchanged.

## Evidence

- Real source CLI baseline: the artificial exec reference resolves once and `models status --check` exits 0, but displays `effective=missing:missing`. The matched environment reference displays its source.
- Candidate: matched exec and environment human commands plus exec `--json --check` all exit 0. Exec output now reports `models.json:marker(secretref-managed)`; each exec command resolves once, and no complete credential value appears in output.
- Three focused regression checks: baseline 1 failed / 2 passed; candidate 3 passed. Cold and changed-reference controls retain missing status. All 12 existing overview checks also pass.
- Pinned formatting, focused non-type-aware lint, and diff checks pass. Synthetic isolated state and a private network namespace were used; no real provider call or local build was needed.

Production grows by 11 lines to reuse the canonical runtime-auth reader; 88 test lines cover the regression, output secrecy, and the two ownership controls. AI-assisted.
