### PR TITLE
refactor(plugins): share disabled install preparation

### DIFF
--- a/src/plugins/bundled-install.ts
+++ b/src/plugins/bundled-install.ts
@@ -1,9 +1,9 @@
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { BundledPluginSource } from "./bundled-sources.js";
 import {
   persistPluginInstall,
+  prepareConfigForDisabledInstall,
   type ConfigSnapshotForInstallPersist,
 } from "./install-persistence.js";
 import { validateJsonSchemaValue } from "./schema-validator.js";
@@ -41,25 +41,6 @@ function resolveBundledPluginConfigEnablement(params: {
     : { mode: "invalid", error: result.errors[0]?.text ?? "invalid plugin config" };
 }
 
-function prepareConfigForDisabledBundledInstall(
-  config: OpenClawConfig,
-  pluginId: string,
-): OpenClawConfig {
-  const entry = config.plugins?.entries?.[pluginId];
-  const policy = isRecord(entry) ? { ...entry } : {};
-  delete policy.config;
-  return {
-    ...config,
-    plugins: {
-      ...config.plugins,
-      entries: {
-        ...config.plugins?.entries,
-        [pluginId]: { ...policy, enabled: false },
-      },
-    },
-  };
-}
-
 export async function installBundledPluginSource(params: {
   snapshot: ConfigSnapshotForInstallPersist;
   rawSpec: string;
@@ -83,7 +64,7 @@ export async function installBundledPluginSource(params: {
   const shouldEnable = configEnablement.mode === "ready";
   const configBase = shouldEnable
     ? params.snapshot.config
-    : prepareConfigForDisabledBundledInstall(params.snapshot.config, params.bundledSource.pluginId);
+    : prepareConfigForDisabledInstall(params.snapshot.config, params.bundledSource.pluginId);
   const configWarning = shouldEnable
     ? undefined
     : `Installed bundled plugin "${params.bundledSource.pluginId}" without enabling it because it requires configuration first. Configure it, then run \`openclaw plugins enable ${params.bundledSource.pluginId}\`.`;

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -431,17 +431,17 @@ function resolveReplacedManagedInstallRemoval(params: {
   return plan.directoryRemoval;
 }
 
-function prepareConfigForDisabledInstall(config: OpenClawConfig, pluginId: string): OpenClawConfig {
-  const entry = config.plugins?.entries?.[pluginId];
+export function prepareConfigForDisabledInstall(cfg: OpenClawConfig, id: string): OpenClawConfig {
+  const entry = cfg.plugins?.entries?.[id];
   const policy = isRecord(entry) ? { ...entry } : {};
   delete policy.config;
   return {
-    ...config,
+    ...cfg,
     plugins: {
-      ...config.plugins,
+      ...cfg.plugins,
       entries: {
-        ...config.plugins?.entries,
-        [pluginId]: { ...policy, enabled: false },
+        ...cfg.plugins?.entries,
+        [id]: { ...policy, enabled: false },
       },
     },
   };


### PR DESCRIPTION
## What Problem This Solves

Bundled and persisted plugin installs maintain separate copies of the same disabled-install configuration preparation. This maintainer-requested deduplication removes a drift risk in the handling of plugins that require configuration before enablement.

## Why This Change Was Made

Reuse the existing persistence-owned helper through an existing runtime import. The helper still shallow-copies the relevant configuration, removes only the target entry's `config`, preserves non-config policy and sibling references, and sets `enabled: false` without mutating the input.

The helper-local parameter names become `cfg` and `id`, retaining explicit types and a single-line signature within the existing lint limit. Validators, runtime-child ownership, accumulated configuration, enablement ordering, warnings, allow/deny policy, slot selection, and commit logic are unchanged. No new module edge, public API, SDK surface, configuration option, storage behavior, dependency, or test is introduced.

## User Impact

No intended user-visible behavior change. Both install paths use one implementation of the existing disabled-install policy.

## Evidence

- Two production files only; raw Git diff is 8 additions and 27 deletions.
- TypeScript symbol-aware equivalence check reversed only parameter-bound body references (`cfg`: 4, `id`: 2). The resulting body matches both original helpers byte-for-byte at base `fe2f796e95e87773bdd2e038f45aa6191acff66e`; `policy.config` and explicit parameter/return types are unchanged.
- Formatting, scoped oxlint (including `max-lines`), and `git diff --check` pass.
- Fresh independent autoreview of the amended diff is scoped-clean through P2, with no actionable findings.
- `node scripts/run-vitest.mjs src/plugins/install-persistence.enablement.test.ts src/cli/plugins-cli.install.test.ts`: CLI install **250 passed**; persistence enablement **7 passed, 2 failed**. All missing/invalid/disabled-configuration cases pass.

The two persistence failures also reproduce on the clean base, with the same assertions:

1. `scopes runtime kind lookup to the selected plugin when metadata omits kind`: line 142 expects `registry.plugins` to equal `[{ id: "legacy-memory", kind: "memory" }]`.
2. `uses cold metadata for manifest-kind slot selection without loading runtime siblings`: line 218 expects `registry.plugins` to equal `[{ id: "memory-b", kind: "memory" }]`.

Both receive the expected ID/kind plus full manifest fields and the install-owner symbol. The existing slot-selection implementation preserves the selected manifest; these exact-shape assertion failures are not caused or fixed by this helper extraction. Neither the tests nor slot-selection code is changed.

- `node scripts/check-changed.mjs -- src/plugins/bundled-install.ts src/plugins/install-persistence.ts` passes its preliminary formatting, ratchet, dependency, and plugin-boundary checks, then stops at the local tsgo guard rejecting an external compiler symlink. Local typechecking is not claimed as passed.
- [Exact-head hosted CI run 34144724944](https://github.com/openclaw/openclaw/actions/runs/34144724944) completed successfully at `03baebf7a410480df79970ad0354e9d8d424f379`: **107 jobs passed, 17 intentionally skipped, zero failed**. The exact-head watcher exited green. This matrix result does not claim that the two locally failing persistence cases passed.
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 141358` accepted the hosted CI/Testbox evidence and completed at the same head without a rebase or push. No remote lease or live-provider test has been run.
- ClawSweeper's completed review of the same head reported no actionable findings or before-merge actions.
- Landed through the native squash workflow as `4032753c9e91af0c94b0bd83107d00a44d0887ee`. The retained native outcome is complete and accepted; remote merge state, main ancestry, and both source blobs were verified against the reviewed head.
- Follow-up: https://github.com/openclaw/openclaw/pull/141386 landed the test-contract repair for the two baseline assertion failures recorded above; its exact-head hosted job `101822173094` executed all nine enablement cases successfully. All original run results and caveats above remain unchanged.
