### PR TITLE
fix: reduce single-session update overhead in large stores

### DIFF
--- a/src/gateway/session-sharing-policy.ts
+++ b/src/gateway/session-sharing-policy.ts
@@ -74,6 +74,7 @@ export function resolveSessionSharingTarget(params: {
   cfg: OpenClawConfig;
   sessionKey: string;
   agentId?: string;
+  exactRead?: boolean;
   storeCache?: GatewaySessionStoreCache;
   targetDiscoveryCache?: GatewaySessionStoreDiscoveryCache;
 }): SessionSharingTarget | null {
@@ -86,7 +87,7 @@ export function resolveSessionSharingTarget(params: {
     projection: "list",
     // Batch callers reuse one store snapshot; single-target checks must not
     // materialize unrelated sessions for every task or authorization recheck.
-    exactRead: !params.storeCache,
+    exactRead: params.exactRead ?? !params.storeCache,
     ...(params.storeCache ? { storeCache: params.storeCache } : {}),
     ...(params.targetDiscoveryCache ? { targetDiscoveryCache: params.targetDiscoveryCache } : {}),
   });

--- a/src/gateway/session-sharing-store-cache.test.ts
+++ b/src/gateway/session-sharing-store-cache.test.ts
@@ -48,6 +48,53 @@ function identifiedClient(userId: string): GatewayClient {
 }
 
 describe("session mutation authorization store caches", () => {
+  it.each(["sessions.patch", "chat.send", "sessions.patchMany"])(
+    "bounds single-target metadata work and refreshes every %s guard",
+    async (method) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const sessionKey = "agent:main:scalar-authorization";
+        const entry = { sessionId: "scalar-authorization", updatedAt: 1 };
+        await sessionAccessor.upsertSessionEntryCore({ agentId: "main", sessionKey }, entry);
+        for (let index = 0; index < 24; index += 1) {
+          await sessionAccessor.upsertSessionEntryCore(
+            { agentId: "main", sessionKey: `agent:main:unrelated-${index}` },
+            { sessionId: `unrelated-${index}`, updatedAt: 1 },
+          );
+        }
+        sessionAccessor.listSessionEntriesCore({
+          agentId: "main",
+          clone: false,
+          projection: "list",
+        });
+        const inventory = vi.spyOn(sessionAccessor, "listSessionEntriesCore");
+        const result = resolveSessionMutationAuthorization({
+          client: identifiedClient("viewer@example.test"),
+          method,
+          requestParams:
+            method === "sessions.patchMany"
+              ? { targets: [{ key: sessionKey }], patch: { unread: false } }
+              : method === "sessions.patch"
+                ? { key: sessionKey, unread: false }
+                : { sessionKey },
+          context: { chatAbortControllers: new Map(), getRuntimeConfig: () => ({}) } as never,
+        });
+        expect(result.error).toBeNull();
+        expect(result.authorization).toBeDefined();
+        expect(() => result.authorization!.assertCurrent()).not.toThrow();
+        expect(() => result.authorization!.assertCurrent()).not.toThrow();
+        expect(inventory).not.toHaveBeenCalled();
+
+        await sessionAccessor.upsertSessionEntryCore(
+          { agentId: "main", sessionKey },
+          { ...entry, updatedAt: 2, visibility: "draft" },
+        );
+        expect(() => result.authorization!.assertCurrent()).toThrow(
+          "session is draft for this connection",
+        );
+      });
+    },
+  );
+
   it.each([
     { key: "agent:research:main", agentId: undefined, expectedAgent: "research" },
     { key: "global", agentId: "research", expectedAgent: "research" },

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -147,6 +147,7 @@ export function resolveSessionMutationAuthorization(params: {
   let lookupCaches: ReturnType<typeof createLookupCaches> | undefined;
   const resolveAuthorizedTarget = (
     targetRef: SessionMutationTarget,
+    targetCount: number,
   ): { target: SessionSharingTarget | null } | { error: ErrorShape } => {
     try {
       return {
@@ -155,6 +156,7 @@ export function resolveSessionMutationAuthorization(params: {
           sessionKey: targetRef.sessionKey,
           agentId: targetRef.agentId,
           ...(lookupCaches ??= createLookupCaches()),
+          exactRead: targetCount === 1,
         }),
       };
     } catch (error) {
@@ -204,7 +206,7 @@ export function resolveSessionMutationAuthorization(params: {
     : (talkTargets?.filter((target) => isIncognitoSessionKey(target.sessionKey)) ??
       resolveDirectIncognitoTargets(params.method, params.requestParams));
   for (const targetRef of protectedTargets) {
-    const resolved = resolveAuthorizedTarget(targetRef);
+    const resolved = resolveAuthorizedTarget(targetRef, protectedTargets.length);
     if ("error" in resolved) {
       return { error: resolved.error };
     }
@@ -258,7 +260,7 @@ export function resolveSessionMutationAuthorization(params: {
   }
   const authorizedTargets: AuthorizedSessionMutationTarget[] = [];
   for (const targetRef of targetRefs) {
-    const resolved = resolveAuthorizedTarget(targetRef);
+    const resolved = resolveAuthorizedTarget(targetRef, targetRefs.length);
     if ("error" in resolved) {
       return { error: resolved.error };
     }
@@ -362,6 +364,7 @@ export function resolveSessionMutationAuthorization(params: {
           sessionKey: targetRef.sessionKey,
           agentId: targetRef.agentId,
           ...currentLookupCaches,
+          exactRead: !currentLookupCaches || authorizedTargets.length === 1,
         });
         // The guarded ensure may mint this row/id. Its result permits only that
         // materialization, never a replacement of an already admitted session.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users updating one session or sending a chat message paid authorization overhead proportional to the entire session inventory. The cost remained even when listing metadata was warm, because each authorization phase enumerated and rebuilt the full cached inventory.

## Why This Change Was Made

Singleton authorization phases now read only their exact canonical candidates while retaining request-local store and discovery caches. Each commit guard still starts a fresh authorization epoch, and multi-target requests retain the existing shared-snapshot path and ordered decisions.

## User Impact

Single-session actions avoid unnecessary inventory work in large session stores. Canonical-key validation, fresh access checks, and writer serialization remain intact; cold validation and writer contention can still contribute to total request latency.

## Evidence

The regression failed on unchanged production source for `sessions.patch`, `chat.send`, and one-target `sessions.patchMany`, with three full inventory reads across admission and two guards. All three now pass without inventory reads and reject a later visibility change. The focused authorization, sharing, global-owner lookup, and patch orchestration suites pass all 69 tests, including queued alias races and isolated batch authorization failures.

The complete changed gate passed, including core and test typechecks, lint, and repository guards. Independent P0–P2 autoreview found no actionable findings. A local smoke using the real Gateway WebSocket API verified a non-admin profile, scalar updates, 100-target batch outcomes, an unauthorized-target denial, durable readback, and clean closure.

The first [Blacksmith Testbox comparison](https://github.com/openclaw/openclaw/actions/runs/34144371553) completed on Linux/Node 24.19.0 using the real Gateway WebSocket API, with 248/248 successful scalar and batch response receipts. Each of six isolated runs verified the authenticated profile, exact read/write scopes, an unauthorized-target denial, persisted results, and closure. The entire baseline source manifest and candidate patch were verified before execution.

| Metadata rows | Warm scalar RPC median, before → after | Warm authorization + two guards median, before → after |
| --- | --- | --- |
| 64 | 6.60 → 3.23 ms | 0.243 → 0.330 ms |
| 512 | 11.72 → 5.72 ms | 0.749 → 0.260 ms |
| 2,048 | 19.38 → 14.80 ms | 3.215 → 0.272 ms |

This is one ordered comparison, with 30 measured scalar calls per size. The 512-row scalar p95 increased from 25.90 to 40.86 ms, and the small-store isolated authorization median increased by 0.087 ms. The 100-target batch path has six samples per variant with overlapping ranges; its 2,048-row median increased from 1,015 to 1,109 ms. The [reverse-order confirmation](https://github.com/openclaw/openclaw/actions/runs/34145332136) then ran 512 and 2,048 rows with 60 measured scalar calls and 20 batch samples per variant. It verified another 352/352 successful mutation responses, four matched non-admin profiles, four unauthorized-target denials, and four persisted readbacks/closures.

| Metadata rows | Reverse-run scalar median, before → after | Reverse-run authorization + two guards median, before → after |
| --- | --- | --- |
| 512 | 13.91 → 4.99 ms | 0.721 → 0.239 ms |
| 2,048 | 14.55 → 10.26 ms | 2.666 → 0.236 ms |

The first batch shift did not repeat at the same magnitude: the reverse 2,048-row batch median was 868.77 → 876.09 ms (+0.84%) and p95 913.85 → 927.73 ms (+1.52%). The 512-row scalar p95 was 27.04 → 14.58 ms in this confirmation. These runs support the eliminated inventory work and improved large-store scalar medians; they do not establish a general tail-latency guarantee or resolve cold validation and writer contention.

The first 2,048-row run also logged one baseline and six candidate slow SQLite transaction-hold warnings; neither reverse run logged one. Those console records lack timing/trace details, so request-versus-seeding attribution remains unresolved. Dense 100-target batches still approach one second.

Both Testbox commands completed with explicit exit 0 / succeeded receipts, complete response evidence, and stopped/completed leases. Their hosting Actions workflows are separate runner-lifecycle records: the first is marked cancelled and is not being presented as green CI. The command receipts and retained response records establish the comparisons; no cancellation actor is inferred.

[Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34144973798) is green for `0cc75a94d876bd35d54a758effd8db501fe5a8ec`. ClawSweeper completed that head with no actionable correctness/security findings and no before-merge actions. Across the two Testboxes, all 600 requested mutation responses and all 10 authorization-denial/persistence/closure checks passed.
