### PR TITLE
improve(tests): join Windows Startup fixture children before cleanup

### DIFF
--- a/src/daemon/schtasks.env-case.real.test.ts
+++ b/src/daemon/schtasks.env-case.real.test.ts
@@ -1,46 +1,70 @@
+import type { ChildProcess, SpawnOptions } from "node:child_process";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { PassThrough } from "node:stream";
-import { describe, expect, it } from "vitest";
-import { waitForDead } from "../../test/helpers/process-wait.js";
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, onTestFinished, vi } from "vitest";
+import { withTestTimeout } from "../../test/helpers/promise.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { buildTaskScript, encodeWindowsLauncherScript } from "./schtasks-layout.js";
 import { startStartupEntry } from "./schtasks-runtime.js";
 
 type ChildEnvironment = { pid: number; value?: string; control?: string };
+type LaunchedChild = {
+  child: ChildProcess;
+  closed: Promise<{ code: number | null; signal: NodeJS.Signals | null }>;
+};
 
-async function waitForChildEnvironment(filePath: string): Promise<ChildEnvironment> {
-  const deadline = Date.now() + 10_000;
-  for (;;) {
-    try {
-      return JSON.parse(await fs.readFile(filePath, "utf8"));
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== "ENOENT" || Date.now() >= deadline) {
-        throw error;
-      }
-    }
-    await new Promise((resolve) => {
-      setTimeout(resolve, 25);
-    });
-  }
-}
+const launchCapture = vi.hoisted(() => ({
+  observe: undefined as ((child: ChildProcess, options?: SpawnOptions) => void) | undefined,
+}));
+vi.mock("node:child_process", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:child_process")>();
+  return {
+    ...actual,
+    spawn: (...args: Parameters<typeof actual.spawn>) => {
+      const child = actual.spawn(...args);
+      launchCapture.observe?.(child, args[2]);
+      return child;
+    },
+  };
+});
 
-describe.runIf(process.platform === "win32")("Windows Startup fallback environment", () => {
-  it.each([
+describe("Windows Startup fallback environment", () => {
+  it.for([
     { name: "different casing", key: "openclaw_test_fallback_case" },
     { name: "matching casing", key: "OPENCLAW_TEST_FALLBACK_CASE" },
-  ])("preserves the saved override with $name", async ({ key }) => {
+  ])("preserves the saved override with $name", async ({ key }, context) => {
+    if (process.platform !== "win32" && key !== key.toUpperCase()) {
+      context.skip("Case-insensitive environment names require Windows");
+    }
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw fallback env "));
     const output = new PassThrough();
     output.resume();
-    let childExited = false;
-    try {
-      const reportPath = path.join(dir, "child.json");
-      const childPath = path.join(dir, "report-env.cjs");
-      await fs.writeFile(
-        childPath,
-        `
+    const children: LaunchedChild[] = [];
+    onTestFinished(async () => {
+      launchCapture.observe = undefined;
+      output.end();
+      for (const { child } of children) {
+        if (child.exitCode === null && child.signalCode === null) {
+          child.kill();
+        }
+      }
+      // Join the owned instances even after an assertion fails. An uncertain
+      // close retains their inputs instead of treating PID disappearance as cleanup.
+      await withTestTimeout(
+        Promise.all(children.map(({ closed }) => closed)),
+        10_000,
+        "Startup fixture child did not close; retaining its directory",
+      );
+      await fs.rm(dir, { recursive: true });
+    });
+    const reportPath = path.join(dir, "child.json");
+    const childPath = path.join(dir, "report-env.cjs");
+    await fs.writeFile(
+      childPath,
+      `
 const fs = require("node:fs");
 const file = process.argv[2];
 fs.writeFileSync(file + ".tmp", JSON.stringify({
@@ -50,36 +74,46 @@ fs.writeFileSync(file + ".tmp", JSON.stringify({
 }));
 fs.renameSync(file + ".tmp", file);
 `,
-      );
-      const scriptPath = path.join(dir, "gateway.cmd");
-      await fs.writeFile(
-        scriptPath,
-        encodeWindowsLauncherScript({
-          format: "cmd",
-          content: buildTaskScript({
-            programArguments: [process.execPath, childPath, reportPath],
-            workingDirectory: dir,
-            environment: {
-              [key]: "configured",
-              OPENCLAW_TEST_FALLBACK_CONTROL: "control",
-            },
-          }),
+    );
+    const scriptPath = path.join(dir, "gateway.cmd");
+    await fs.writeFile(
+      scriptPath,
+      encodeWindowsLauncherScript({
+        format: "cmd",
+        content: buildTaskScript({
+          programArguments: [process.execPath, childPath, reportPath],
+          workingDirectory: dir,
+          environment: {
+            [key]: "configured",
+            OPENCLAW_TEST_FALLBACK_CONTROL: "control",
+          },
         }),
-      );
-      await withEnvAsync({ OPENCLAW_TEST_FALLBACK_CASE: "inherited" }, async () => {
-        await startStartupEntry({ OPENCLAW_TASK_SCRIPT: scriptPath }, output);
-        const observed = await waitForChildEnvironment(reportPath);
-        expect(Number.isSafeInteger(observed.pid) && observed.pid > 0).toBe(true);
-        await waitForDead(observed.pid, 10_000);
-        childExited = true;
-        expect(observed.control).toBe("control");
-        expect(observed.value, "PR122658_ENV_OVERRIDE_LOST").toBe("configured");
-      });
-    } finally {
-      output.end();
-      if (childExited) {
-        await fs.rm(dir, { recursive: true });
+      }),
+    );
+    launchCapture.observe = (child, options) => {
+      if (options?.cwd !== dir && options?.env?.OPENCLAW_TASK_SCRIPT !== scriptPath) {
+        return;
       }
-    }
+      // Observe close at spawn, before Startup discards its child handle.
+      const closed = new Promise<{ code: number | null; signal: NodeJS.Signals | null }>(
+        (resolve) => {
+          child.once("close", (code, signal) => resolve({ code, signal }));
+        },
+      );
+      children.push({ child, closed });
+    };
+    await withEnvAsync({ OPENCLAW_TEST_FALLBACK_CASE: "inherited" }, async () => {
+      await startStartupEntry({ OPENCLAW_TASK_SCRIPT: scriptPath }, output);
+      expect(children).toHaveLength(1);
+      const { child, closed } = expectDefined(children[0], "Startup fixture child");
+      expect(await withTestTimeout(closed, 10_000, "Startup fixture child did not close")).toEqual({
+        code: 0,
+        signal: null,
+      });
+      const observed: ChildEnvironment = JSON.parse(await fs.readFile(reportPath, "utf8"));
+      expect(observed.pid).toBe(child.pid);
+      expect(observed.control).toBe("control");
+      expect(observed.value, "PR122658_ENV_OVERRIDE_LOST").toBe("configured");
+    });
   });
 });


### PR DESCRIPTION
Related: #141217 (node-session finalization batching), #132180 (split node-session landing series). Separate maintainer-side validation repair; this does not close either PR.

## What Problem This Solves

Resolves a problem where the real Windows Startup-fallback environment fixture deletes its working directory without joining the service process it launched. An `EBUSY` cleanup failure blocked the Windows validation of the node-session change, and the fixture's `finally` cleanup could replace an earlier assertion failure.

The missing process join is established by source inspection. The exact handle responsible for the observed `EBUSY` is **not yet proven**; this PR must not be treated as a demonstrated fix for that lock merely because another run passes.

## Why This Change Was Made

Observe the real child at spawn, retain its completion promise, and require successful completion before reading its environment report. Cleanup joins the same owned child instances before removing their inputs, including after an assertion fails; uncertain completion retains the directory. Test-finished cleanup lets Vitest report assertion and cleanup failures separately.

Production service startup still returns after launch and detaches its long-running service. The test uses a transparent call-through observer, not a replacement launcher or a new production injection seam. Report polling and numeric-PID disappearance polling are removed.

## User Impact

No product behavior changes. Both Windows casing cases and both environment assertions remain. The existing matching-casing case now also exercises the real launch on POSIX; the case-insensitive case stays Windows-only. There are no deletion retries, larger execution deadlines, dependency changes, configuration options, or storage changes.

One test file changes: **+89/-55, net +34 test lines; production delta 0**.

## Evidence

The original failure is retained in [Windows job 101795559281, run 34138611016](https://github.com/openclaw/openclaw/actions/runs/34138611016/job/101795559281). Its daemon group reported 84 passes and one directory-removal failure. The affected fixture and launcher already existed in the node-session PR's base; the finalization patch did not change them.

On candidate tree `90379b2e9f9fdfc41ffb3b3336002e17c0844c20`, based on `9ab0b1434edc991ea42a2dbeb92edbef5d738c5e`:

- **94 tests passed, one Windows-only skip**, in 16.15 seconds. The matching-casing case launches a real Node child, observes a successful close, matches its PID to the report, and verifies both environment values.
- Required changed checks passed in **231.92 seconds** on that exact tree.
- Fresh isolated Codex review returned **scoped-clean at P0** in 20.346 seconds.
- Current-main inspection found no drift in the failing fixture, launcher/parser, spawn owner, environment merger, bounded wait, or daemon test configuration.

```bash
node scripts/run-vitest.mjs src/daemon/schtasks.env-case.real.test.ts src/daemon/schtasks.startup-fallback.test.ts src/infra/process-env.test.ts
```

```bash
node scripts/check-changed.mjs --staged
```

Dependency inspection distinguishes [the retained Windows process-handle wait](https://github.com/nodejs/node/blob/v22.23.2/deps/uv/src/win/process.c#L1128-L1142) from [the zero-signal PID liveness probe](https://github.com/nodejs/node/blob/v22.23.2/deps/uv/src/win/process.c#L1335-L1355). Neither that distinction nor a passing macOS run identifies the old lock holder.

**Native Windows candidate validation passed.** [CI run 34144941586](https://github.com/openclaw/openclaw/actions/runs/34144941586) completed successfully on head `124aba7c1a185997c1eb99ecc780cc82fbbdc32e`, including both Windows jobs. [Windows test-1, job 101814982318](https://github.com/openclaw/openclaw/actions/runs/34144941586/job/101814982318), passed both real environment cases: different casing in 69 ms and matching casing in 45 ms. The daemon file order matches the failed run: Startup-fallback sibling tests, then the real environment fixture. [Windows test-2, job 101814982347](https://github.com/openclaw/openclaw/actions/runs/34144941586/job/101814982347), also passed. This is native Windows fixture proof, not signed-app acceptance or a production rollout.

### Maintainer scope decision

The [review's remaining uncertainty](https://github.com/openclaw/openclaw/pull/141360#issuecomment-5573695015) is accurate: the original `EBUSY` lock holder remains unidentified. Accept this as the independently proven fixture-ownership repair, not a universal directory-lock remedy. The change repairs the missing join without making production startup wait, masking removal failures, or retrying deletion. Any unrelated lock still fails cleanup visibly, and the original assertion failure is preserved separately. Further lock-holder investigation is needed if `EBUSY` recurs after the owned join; identifying every possible external lock is not a prerequisite for fixing this demonstrated lifetime gap.
