### PR TITLE
feat(control-ui): reconnect automatically after pairing approval

### DIFF
--- a/docs/web/control-ui/connect-and-pair.md
+++ b/docs/web/control-ui/connect-and-pair.md
@@ -27,6 +27,8 @@ After gateway auth succeeds, connecting from a new browser or device usually req
   </Step>
 </Steps>
 
+Keep the page open while approval is pending. It retries automatically and connects on its own once the request is approved; **Check now** lets you retry immediately.
+
 If the browser retries pairing with changed auth details (role/scopes/public key), the previous pending request is superseded and a new `requestId` is created; re-run `openclaw devices list` before approving.
 
 Switching an already-paired browser from read access to write/admin access through ordinary stored or shared credentials is treated as an approval upgrade, not a silent reconnect: OpenClaw keeps the old approval active, blocks the broader reconnect, and asks you to approve the new scope set explicitly. The narrow exception is a fresh owner handoff issued on the Gateway host by `openclaw dashboard` or graphical onboarding; it can upgrade only the same signed browser that redeems that one-time handoff.

--- a/src/gateway/server.auth.control-ui.pairing.suite.ts
+++ b/src/gateway/server.auth.control-ui.pairing.suite.ts
@@ -21,9 +21,126 @@ import {
   readConnectChallengeNonce,
   restoreGatewayToken,
   TEST_OPERATOR_CLIENT,
+  testState,
 } from "./server.auth.test-helpers.js";
 
 export function registerControlUiPairingSuite(): void {
+  test("keeps pending Control UI operator pairing reconnecting without enabling ordinary node retries", async () => {
+    const { mutateConfigFile } = await import("../config/config.js");
+    const { publicKeyRawBase64UrlFromPem } = await import("../infra/device-identity.js");
+    const { approveDevicePairing } = await import("../infra/device-pairing-approval.js");
+    const { listDevicePairing, requestDevicePairing } = await import("../infra/device-pairing.js");
+    const origin = "https://control-ui.example.test";
+    testState.gatewayControlUi = { allowedOrigins: [origin] };
+    await mutateConfigFile({
+      mutate(config) {
+        config.gateway = {
+          ...config.gateway,
+          trustedProxies: ["127.0.0.1"],
+          controlUi: { ...config.gateway?.controlUi, allowedOrigins: [origin] },
+        };
+      },
+      afterWrite: { mode: "auto" },
+    });
+    await withControlUiServer(async ({ port }) => {
+      const connectBrowser = async (
+        identityPath: string,
+        role: "operator" | "node",
+        scopes: string[],
+      ) => {
+        const socket = await openWs(port, {
+          origin,
+          "x-forwarded-for": "203.0.113.50",
+        });
+        try {
+          return await connectReq(socket, {
+            token: "secret",
+            role,
+            scopes,
+            client: CONTROL_UI_CLIENT,
+            device: await buildSignedDeviceForIdentity({
+              identityPath,
+              client: CONTROL_UI_CLIENT,
+              role,
+              scopes,
+              nonce: await readConnectChallengeNonce(socket),
+            }),
+          });
+        } finally {
+          socket.close();
+        }
+      };
+
+      for (const reason of [
+        "not-paired",
+        "role-upgrade",
+        "scope-upgrade",
+        "metadata-upgrade",
+      ] as const) {
+        const { identityPath, identity } = await createOperatorIdentityFixture(
+          `openclaw-control-ui-retry-${reason}-`,
+        );
+        if (reason !== "not-paired") {
+          const seeded = await requestDevicePairing({
+            deviceId: identity.deviceId,
+            publicKey: publicKeyRawBase64UrlFromPem(identity.publicKeyPem),
+            role: reason === "role-upgrade" ? "node" : "operator",
+            scopes:
+              reason === "role-upgrade"
+                ? []
+                : reason === "scope-upgrade"
+                  ? ["operator.read"]
+                  : ["operator.admin"],
+            clientId: CONTROL_UI_CLIENT.id,
+            clientMode: CONTROL_UI_CLIENT.mode,
+            platform:
+              reason === "metadata-upgrade" ? "previous-platform" : CONTROL_UI_CLIENT.platform,
+          });
+          expect(
+            (
+              await approveDevicePairing(seeded.request.requestId, {
+                callerScopes: ["operator.admin"],
+              })
+            )?.status,
+          ).toBe("approved");
+        }
+
+        let requestId: string | undefined;
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          const response = await connectBrowser(identityPath, "operator", ["operator.admin"]);
+          expect(response.ok).toBe(false);
+          const pending = (await listDevicePairing()).pending.filter(
+            (entry) => entry.deviceId === identity.deviceId,
+          );
+          expect(pending).toHaveLength(1);
+          requestId ??= pending[0]?.requestId;
+          expect(pending[0]?.requestId).toBe(requestId);
+          expect(response.error?.details).toMatchObject({
+            code: "PAIRING_REQUIRED",
+            reason,
+            requestId,
+            recommendedNextStep: "wait_then_retry",
+            retryable: true,
+            pauseReconnect: false,
+          });
+        }
+      }
+      const { identityPath } = await createOperatorIdentityFixture(
+        "openclaw-control-ui-node-retry-",
+      );
+      const response = await connectBrowser(identityPath, "node", []);
+      expect(response.ok).toBe(false);
+      expect(response.error?.details).toMatchObject({
+        code: "PAIRING_REQUIRED",
+        reason: "not-paired",
+        requestId: expect.any(String),
+      });
+      expect(response.error?.details).not.toHaveProperty("recommendedNextStep");
+      expect(response.error?.details).not.toHaveProperty("retryable");
+      expect(response.error?.details).not.toHaveProperty("pauseReconnect");
+    });
+  });
+
   const tamperPairedMetadata = async (
     deviceId: string,
     mutate: (metadata: Record<string, unknown>) => void,

--- a/src/gateway/server/ws-connection/connect-device-pairing.ts
+++ b/src/gateway/server/ws-connection/connect-device-pairing.ts
@@ -431,17 +431,20 @@ export async function authorizeGatewayConnectDevice(
           role === "node" &&
           scopes.length === 0 &&
           !existingPairedDevice;
-        // Keep the node retrying while a detached approval can still land
-        // (bootstrap redemption or a running ssh-verify probe); default
-        // pairing-required behavior pauses the client reconnect loop.
-        const retryWhileDetachedApprovalPending =
-          retryAfterBootstrapPairingApproval || sshVerifyStarted;
+        const retryWhileControlUiApprovalPending =
+          state.isControlUi && role === "operator" && Boolean(recoveryRequestId);
+        // Retry detached node approvals and pending browser approvals without
+        // changing which connects require approval or what access they receive.
+        const retryWhileApprovalPending =
+          retryAfterBootstrapPairingApproval ||
+          sshVerifyStarted ||
+          retryWhileControlUiApprovalPending;
         failPairingHandshake({
           message: buildPairingConnectErrorMessage(reason),
           details: buildPairingConnectErrorDetails({
             reason,
             requestId: recoveryRequestId,
-            ...(retryWhileDetachedApprovalPending
+            ...(retryWhileApprovalPending
               ? {
                   recommendedNextStep: "wait_then_retry",
                   retryable: true,

--- a/ui/src/app/app-root.ts
+++ b/ui/src/app/app-root.ts
@@ -599,6 +599,9 @@ export class OpenClawApp extends OpenClawLightDomElement {
             resourceBasePath: context.resourceBasePath,
             connected: gatewayConnected,
             lastError: gatewaySnapshot.lastError,
+            reconnectPending:
+              gatewaySnapshot.lastError !== null &&
+              (gatewaySnapshot.phase === "connecting" || gatewaySnapshot.phase === "reconnecting"),
             lastErrorCode: gatewaySnapshot.lastErrorCode,
             lastErrorAuthReason: gatewaySnapshot.lastErrorAuthReason,
             hasToken: Boolean(this.loginToken.trim()),

--- a/ui/src/components/login-gate-feedback.ts
+++ b/ui/src/components/login-gate-feedback.ts
@@ -67,6 +67,7 @@ export type LoginFailureFeedback = {
 
 export type LoginFailureFeedbackParams = Parameters<typeof resolveAuthHintKind>[0] & {
   gatewayUrl?: string;
+  reconnectPending?: boolean;
 };
 
 export const PASSWORD_MODE_CODES = new Set<string>([
@@ -203,7 +204,7 @@ export function resolveLoginFailureFeedback(
       stepKeys: [
         ...(pairing.requestId ? [] : ["login.failure.pairing.stepLatest"]),
         { key: "login.failure.pairing.stepDashboard", commands: ["openclaw dashboard"] },
-        "login.failure.pairing.stepReconnect",
+        ...(params.reconnectPending ? [] : ["login.failure.pairing.stepReconnect"]),
       ],
       stepParams: { host },
     });

--- a/ui/src/components/login-gate.test.ts
+++ b/ui/src/components/login-gate.test.ts
@@ -319,6 +319,32 @@ describe("login gate failure recovery", () => {
     expect(element.querySelectorAll("button.login-gate__connect")).toHaveLength(1);
   });
 
+  it("shows automatic pairing recovery only while reconnect is pending", async () => {
+    const element = await mountFailure(
+      "pairing required",
+      ConnectErrorDetailCodes.PAIRING_REQUIRED,
+    );
+    element.props = { ...element.props, reconnectPending: true };
+    await element.updateComplete;
+
+    expect(element.textContent).toContain(
+      "Waiting for approval… this page connects on its own once the request is approved.",
+    );
+    expect(element.textContent).not.toContain("Once approved, click Connect.");
+    expect(element.querySelector('[aria-hidden="true"].session-run-spinner')).not.toBeNull();
+    const checkNow = element.querySelector<HTMLButtonElement>(".login-gate__connect")!;
+    expect(checkNow.textContent?.trim()).toBe("Check now");
+    checkNow.click();
+    expect(element.props.onConnect).toHaveBeenCalledOnce();
+
+    element.props = { ...element.props, reconnectPending: false };
+    await element.updateComplete;
+    expect(element.textContent).toContain("Once approved, click Connect.");
+    expect(element.textContent).not.toContain("Waiting for approval…");
+    expect(element.querySelector(".session-run-spinner")).toBeNull();
+    expect(checkNow.textContent?.trim()).toBe("Connect");
+  });
+
   it("renders only a normalized pairing request in the approve command", async () => {
     const safe = await mountFailure(
       "scope upgrade pending approval (requestId: req-123)",

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -307,6 +307,7 @@ function renderStatusBody(params: {
   onCredentialMode: (mode: CredentialMode) => void;
 }) {
   const { props, feedback } = params;
+  const waitingForPairing = feedback.kind === "pairing-required" && props.reconnectPending;
   return html`
     <section
       class="login-gate__body login-gate__failure"
@@ -333,10 +334,18 @@ function renderStatusBody(params: {
           : nothing
       }
       ${renderSteps(feedback)}
+      ${
+        waitingForPairing
+          ? html`<p class="login-gate__failure-summary">
+              <span class="session-run-spinner" aria-hidden="true"></span>
+              ${t("login.failure.pairing.waiting")}
+            </p>`
+          : nothing
+      }
       <div class="login-gate__actions">
         ${renderRefreshAction(feedback)}
         <button class="btn login-gate__connect" @click=${props.onConnect}>
-          ${t("common.connect")}
+          ${waitingForPairing ? t("login.failure.pairing.checkNow") : t("common.connect")}
         </button>
       </div>
       <details class="login-gate__connection">

--- a/ui/src/e2e/login-gate.e2e.test.ts
+++ b/ui/src/e2e/login-gate.e2e.test.ts
@@ -364,6 +364,53 @@ suite.define(() => {
     }
   });
 
+  it("retries pending pairing and enters the app after approval without clicks", async () => {
+    const context = await suite.browser.newContext({ viewport: { height: 900, width: 1280 } });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, { deferredMethods: ["connect"] });
+    const pairingError = {
+      code: "NOT_PAIRED",
+      message: "pairing required (requestId: req-pending)",
+      details: {
+        code: ConnectErrorDetailCodes.PAIRING_REQUIRED,
+        recommendedNextStep: "wait_then_retry",
+        retryable: true,
+        pauseReconnect: false,
+      },
+    };
+
+    try {
+      await page.goto(suite.server.baseUrl);
+      await gateway.waitForRequest("connect");
+      await gateway.deferNext("connect");
+      await gateway.rejectDeferred("connect", pairingError);
+      const failure = page.locator('.login-gate__failure[data-kind="pairing-required"]');
+      await failure.waitFor();
+      await gateway.waitForRequest("connect", { after: 1 });
+      await page.screenshot({
+        path: path.join(RECOVERY_ARTIFACT_DIR, "pairing-wait.png"),
+        fullPage: true,
+      });
+      expect(await failure.textContent()).toContain(
+        "Waiting for approval… this page connects on its own once the request is approved.",
+      );
+      expect(
+        await failure.getByRole("button", { name: "Check now", exact: true }).isEnabled(),
+      ).toBe(true);
+      expect(await page.locator("openclaw-app-shell").count()).toBe(0);
+
+      await gateway.deferNext("connect");
+      await gateway.rejectDeferred("connect", pairingError);
+      await gateway.waitForRequest("connect", { after: 2 });
+      expect(await failure.isVisible()).toBe(true);
+      await gateway.resolveDeferred("connect");
+      await page.locator("openclaw-app-shell").waitFor();
+      expect(await page.locator("openclaw-login-gate").count()).toBe(0);
+    } finally {
+      await closeContext(context);
+    }
+  });
+
   it("copies an exact recovery command from the application gateway snapshot", async () => {
     const context = await suite.browser.newContext({
       permissions: ["clipboard-read", "clipboard-write"],

--- a/ui/src/i18n/locales/en-login.ts
+++ b/ui/src/i18n/locales/en-login.ts
@@ -100,6 +100,9 @@ const enLogin = {
         stepLatest:
           "That command prints the exact approve command for the newest pending request; run that one as well.",
         stepReconnect: "Once approved, click Connect.",
+        waiting:
+          "Waiting for approval… this page connects on its own once the request is approved.",
+        checkNow: "Check now",
       },
       insecure: {
         title: "Secure browser context required",


### PR DESCRIPTION
Related: #141087 (login gate redesign follow-up).

<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers with repository push access can edit it.

</details>

## What Problem This Solves

Fixes an issue where Control UI operators had to click Connect again after approving browser pairing on the Gateway host, even though the browser already knew that approval was pending.

## Why This Change Was Made

The Gateway sends `wait_then_retry` hints to signed Control UI operator browsers with a live pending pairing request, using the existing reconnect backoff. The login gate shows a waiting state and a **Check now** action while reconnect is active; paused reconnect states retain manual Connect guidance. Approval requirements, granted access, and existing bootstrap/SSH node behavior remain unchanged.

## User Impact

Keep the browser page open, approve its pairing request on the host, and the page connects automatically without another click. This also covers pending role, scope, and metadata upgrades.

## Evidence

Fresh validation after rebasing the single follow-up commit onto main:

| Proof | Result |
|---|---|
| Login-gate unit tests | 25 passed |
| Login-gate browser E2E | 21 passed |
| Full Gateway Control UI auth runner | 49 passed |
| UI typecheck (`pnpm tsgo:ui`) | Passed |
| Changed-file checks (`node scripts/check-changed.mjs`) | Passed, exit 0; all 32 checks below |
| Diff whitespace check | Passed |

The Gateway suite is registered by `src/gateway/server.auth.control-ui.test.ts`; that complete runner was used. It verifies all four pairing reasons, reuse of one unchanged pending request, and the ordinary-node exclusion. The browser E2E proves repeated connect attempts and entry to the app shell without clicks. No source amendments were needed after the rebase.

Codex autoreview: **scoped-clean**, no actionable P0–P2 findings; overall verdict: patch is correct. The review used the pinned rebase base to keep the scope stable after the shared main ref advanced.

<details>
<summary>Changed-file check summary</summary>

| Check | Result |
|---|---|
| conflict markers | Passed |
| max-lines suppression ratchet | Passed |
| assertion SAFETY comment ratchet | Passed |
| changelog attributions | Passed |
| doctor deprecation registry | Passed |
| guarded extension wildcard re-exports | Passed |
| plugin-sdk wildcard re-exports | Passed |
| duplicate scan target coverage | Passed |
| dependency pin guard | Passed |
| format changed files | Passed |
| plugin boundaries | Passed |
| wrapper shadowing | Passed |
| package patch guard | Passed |
| test temp creation report (warning-only) | Passed |
| core tsgo graph boundary | Passed |
| Control UI i18n catalog | Passed |
| typecheck core | Passed |
| typecheck core tests | Passed |
| typecheck UI | Passed |
| coercion helper declaration guard | Passed |
| deprecated API usage | Passed |
| dead export scan (skip with OPENCLAW_CHECK_CHANGED_SKIP_DEADCODE=1) | Passed |
| lint core changed files | Passed |
| lint UI changed style files | Passed |
| native state schema version guard | Passed |
| database-first legacy-store guard | Passed |
| media download helper guard | Passed |
| runtime sidecar loader guard | Passed |
| runtime import cycles | Passed |
| webhook body guard | Passed |
| pairing store guard | Passed |
| pairing account guard | Passed |

</details>

The retained live LAN proof was captured on the original follow-up before rebasing. A fresh Chromium context connected to a built, isolated Gateway with scratch-only configuration, state, workspace, and credentials. It made **three automatic connect attempts against one pending request ID** while awaiting approval. CLI approval of that exact request was followed by connect attempt four entering the app shell **2.47 seconds after the CLI approval invocation**, with no browser click. Both owned Gateway process groups were stopped, their ports were verified closed, and scratch state was deleted. The post-rebase patch preserves that behavior and has fresh unit, browser E2E, and Gateway validation above.

The captures were inspected and contain only the isolated test Gateway state. The connected capture shows the fresh Gateway's model-setup shell.

![Browser waiting for pairing approval with automatic retries and Check now](https://github.com/user-attachments/assets/0107acc4-8485-470d-a113-468e2a539b87)

![App shell reached automatically after CLI pairing approval](https://github.com/user-attachments/assets/6c38f2e1-c950-4dc8-b761-cce3625582e0)
