### PR TITLE
fix(update): skip automatic triage after a verified rollback

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -41,6 +41,8 @@ launcher scripts).
 
 Failed update and repair attempts enter [recovery triage](/cli/update#recover-a-failed-update)
 after service recovery and cleanup finish.
+A verified rollback does not start triage: the previous generation is running
+again, and the report keeps the failing check as the reason.
 
 After a final interactive update failure, **Diagnose update failure** and
 **Report update failure** are separate choices. Reporting first shows the exact

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -760,6 +760,8 @@ diagnose a failed check. Recovery guidance reports whether the Gateway is runnin
 or stopped from the latest service observation, even when a running candidate did
 not pass verification. A restored Gateway must pass its own verification checks
 before the run can finish as `rolled-back`.
+Automatic triage never follows a verified rollback; it runs only when the update
+ends failed.
 
 If the config file changed after the activation Doctor pass or the databases are
 not schema-neutral, rollback is refused with

--- a/src/cli/update-cli/update-command-result.ts
+++ b/src/cli/update-cli/update-command-result.ts
@@ -74,7 +74,14 @@ export function resolveAutomaticUpdateTriage(
     preManagedServiceStop?: Pick<PreManagedServiceStop, "serviceMutationAllowed">;
   },
 ): TriageFailureContext | undefined {
+  // Triage follows a failed update, never a verified rollback: the restored
+  // generation is serving, and an autonomous repair turn there is unwanted.
+  const verifiedRollback =
+    result.recovery?.serviceRestartSafe === true &&
+    result.recovery.packageRollbackVerified === true &&
+    result.recovery.service === "healthy";
   const eligible =
+    !verifiedRollback &&
     (params.mutationStarted || result.reason === "restart-unhealthy") &&
     result.reason !== "service-revalidation-failed" &&
     !(

--- a/src/cli/update-cli/update-command-triage.test.ts
+++ b/src/cli/update-cli/update-command-triage.test.ts
@@ -104,6 +104,32 @@ it.each<{
     },
     allowed: false,
   },
+  {
+    name: "verified rollback",
+    result: {
+      reason: "restart-unhealthy",
+      recovery: {
+        serviceRestartSafe: true,
+        packageRollbackVerified: true,
+        version: "2026.9.1",
+        service: "healthy",
+      },
+    },
+    allowed: false,
+  },
+  {
+    name: "restored generation still unverified",
+    result: {
+      reason: "restart-unhealthy",
+      recovery: {
+        serviceRestartSafe: true,
+        packageRollbackVerified: true,
+        version: "2026.9.1",
+        service: "failed",
+      },
+    },
+    allowed: true,
+  },
 ])("keeps automatic admission within update ownership: $name", (trial) => {
   const context = resolveAutomaticUpdateTriage({ ...failedUpdate, ...trial.result }, undefined, {
     root: "/installation",


### PR DESCRIPTION
Related: #141219, #140725, #124396

## What Problem This Solves

After a failed update was rolled back and the previous generation verified as running again, the updater still launched the automatic triage agent turn ("you are repairing THIS machine's OpenClaw installation") on the restored install. Observed live on the AWS packaged-update lane: every rolled-back run was followed by one triage model request against a healthy gateway. Maintainer decision (2026-09-07): automatic triage follows a failed update, never a verified rollback.

## Why This Change Was Made

`resolveAutomaticUpdateTriage` owns admission for automatic triage. It now refuses when the result carries a verified rollback (`recovery.serviceRestartSafe === true`, `packageRollbackVerified === true`, `service === "healthy"`), which is exactly the state the rollback owner records after the restored generation passes its restart verification. A restored generation whose verification failed keeps triage, because the machine is still broken. No other admission rule changed; manual `openclaw triage` guidance in the report is unchanged.

## User Impact

A rolled-back update no longer spends a model turn or runs an autonomous repair agent on the healthy previous generation. The report still names the failing check and the manual triage command. Failed updates that could not be rolled back behave as before.

## Evidence

- Regression cases added to `update-command-triage.test.ts`: a verified rollback is not admitted; a restored-but-unverified generation still is. The verified-rollback case fails on `origin/main` (admitted) and passes with this change.
- `pnpm test src/cli/update-cli/update-command-triage.test.ts src/cli/update-cli/update-command-post-update-recovery.test.ts src/cli/update-cli/update-command-result.test.ts`, `pnpm check:changed`, Codex autoreview P1 clean (results in the landing comment).
- Live: AWS packaged-update lane on this head with rollback as the first-ever update on a fresh install; the lane now asserts zero automatic triage requests after a rolled-back run (result in the landing comment).
