### PR TITLE
fix(ui): preserve indented code in chat

### DIFF
--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -154,7 +154,9 @@ Chat error banners, including cloud runner failures, show short messages in full
 
 **View Raw Text** keeps Markdown notation literal, including nested code fences.
 Decoded text artifacts use the same literal preview. **Copy code** preserves the
-code's leading whitespace and final newline when present.
+code's leading whitespace and final newline when present. Indented Markdown code
+blocks also work at the start of a message and remain literal while streaming,
+including blank lines within the block.
 
 **Copy URL** in browser tab cards also works on plain HTTP connections where the
 browser does not provide its Clipboard API.

--- a/src/chat/canvas-render.test.ts
+++ b/src/chat/canvas-render.test.ts
@@ -98,7 +98,7 @@ describe("extractCanvasShortcodes", () => {
     // The visible text between the self-closing embed and the stray close
     // marker must be preserved, not silently stripped.
     expect(text).toContain("keep me");
-    expect(text).toBe("keep me [/embed]");
+    expect(text).toBe(" keep me [/embed]");
   });
 
   it("still extracts a normal block embed and strips only the shortcode span", () => {
@@ -117,5 +117,13 @@ describe("extractCanvasShortcodes", () => {
     expect(previews).toHaveLength(1);
     expect(previews[0]?.url).toBe("https://b.com");
     expect(text).toBe("see  end");
+  });
+});
+
+it("removes a shortcode without rewriting surrounding literal whitespace", () => {
+  const source = '    a\n\n\n    b\n\n[embed ref="doc1" /]';
+  expect(extractCanvasShortcodes(source)).toMatchObject({
+    text: "    a\n\n\n    b\n\n",
+    previews: [{ viewId: "doc1" }],
   });
 });

--- a/src/chat/canvas-render.ts
+++ b/src/chat/canvas-render.ts
@@ -333,7 +333,7 @@ export function extractCanvasShortcodes(text: string | undefined): {
   }
   stripped += text.slice(cursor);
   return {
-    text: stripped.replace(/\n{3,}/g, "\n\n").trim(),
+    text: stripped,
     previews,
   };
 }

--- a/src/shared/chat-message-content.test.ts
+++ b/src/shared/chat-message-content.test.ts
@@ -237,3 +237,14 @@ describe("resolveAssistantMessagePhase", () => {
     ).toBeUndefined();
   });
 });
+
+it.each(["    code", "\tcode", "\n\n    code"])("retains selected phase source: %j", (text) => {
+  expect(extractAssistantPhaseText({ role: "assistant", content: text })).toBe(text);
+  expect(
+    extractAssistantPhaseText({
+      role: "assistant",
+      phase: "final_answer",
+      content: [{ type: "text", text }],
+    }),
+  ).toBe(text);
+});

--- a/src/shared/chat-message-content.ts
+++ b/src/shared/chat-message-content.ts
@@ -149,7 +149,8 @@ export function extractAssistantTextForPhase(
   const sanitizeBlockText = (text: string) => (sanitizeText ? sanitizeText(text) : text);
   const inlineText = typeof entry.text === "string" ? entry.text : entry.content;
   if (typeof inlineText === "string") {
-    return messagePhase === phase ? sanitizeBlockText(inlineText).trim() || undefined : undefined;
+    const text = messagePhase === phase ? sanitizeBlockText(inlineText) : undefined;
+    return text?.trim() ? text : undefined;
   }
 
   if (!Array.isArray(entry.content)) {
@@ -191,7 +192,7 @@ export function extractAssistantTextForPhase(
       }
     }
   }
-  return parts.join(joinWith).trim() || undefined;
+  return parts.length ? parts.join(joinWith) : undefined;
 }
 
 /** Returns user-visible assistant text, preferring final answers over legacy unphased text. */

--- a/src/shared/text/assistant-visible-text.test.ts
+++ b/src/shared/text/assistant-visible-text.test.ts
@@ -70,7 +70,7 @@ describe("stripAssistantInternalScaffolding", () => {
       expected: "Hello\n",
     },
     {
-      name: "trims leading whitespace after stripping scaffolding",
+      name: "removes leading blank lines after stripping scaffolding",
       input: [
         "<thinking>",
         "secret",
@@ -81,7 +81,7 @@ describe("stripAssistantInternalScaffolding", () => {
         "</relevant-memories>",
         "  Visible",
       ].join("\n"),
-      expected: "Visible",
+      expected: "  Visible",
     },
     {
       name: "preserves unfinished reasoning text while still stripping memory blocks",
@@ -1075,4 +1075,11 @@ describe("stripDowngradedToolCallText", () => {
 
     expect(stripDowngradedToolCallText(input)).toBe("Visible answer");
   });
+});
+
+it("preserves indentation after removing leading assistant scaffolding", () => {
+  expect(stripAssistantInternalScaffolding("<thinking>hidden</thinking>\n\n    *literal*")).toBe(
+    "    *literal*",
+  );
+  expect(stripAssistantInternalScaffolding("    *literal*")).toBe("    *literal*");
 });

--- a/src/shared/text/assistant-visible-text.ts
+++ b/src/shared/text/assistant-visible-text.ts
@@ -10,7 +10,12 @@ import { stripPlainTextToolCallBlocks } from "../../../packages/tool-call-repair
 import { findCodeRegions, isInsideCode, stripLinesOutsideCode } from "./code-regions.js";
 import { stripModelSpecialTokens } from "./model-special-tokens.js";
 import { stripReasoningTagsFromText } from "./reasoning-tags.js";
-import { applyTextFilters, trimTextFilter, type TextFilter } from "./text-projection.js";
+import {
+  applyTextFilters,
+  leadingEmptyLinesTextFilter,
+  trimTextFilter,
+  type TextFilter,
+} from "./text-projection.js";
 
 const MEMORY_TAG_RE = /<\s*(\/?)\s*relevant[-_]memories\b[^<>]*>/gi;
 const MEMORY_TAG_QUICK_RE = /<\s*\/?\s*relevant[-_]memories\b/i;
@@ -748,7 +753,7 @@ export function assistantVisibleTextFilters(
     return cached;
   }
   const preserve = profile === "internal-scaffolding";
-  const trim = preserve ? "start" : profile === "history" ? "none" : "both";
+  const trim = preserve || profile === "history" ? "none" : "both";
   const reasoning: TextFilter = {
     activationTokens: ["<"],
     transform: (text) =>
@@ -783,7 +788,7 @@ export function assistantVisibleTextFilters(
   } else {
     filters.push(reasoning);
   }
-  filters.push(trimTextFilter(trim));
+  filters.push(preserve ? leadingEmptyLinesTextFilter : trimTextFilter(trim));
   profileFilters.set(key, filters);
   return filters;
 }

--- a/ui/src/components/markdown-streaming.ts
+++ b/ui/src/components/markdown-streaming.ts
@@ -1,5 +1,8 @@
 import remend, { type RemendOptions } from "remend";
-import { findMarkdownCodeSpans } from "../../../packages/markdown-core/src/reasoning-tags.js";
+import {
+  findMarkdownCodeSpans,
+  findMarkdownCodeRegions,
+} from "../../../packages/markdown-core/src/reasoning-tags.js";
 import {
   markdownDisclosureTagKind,
   MAX_MARKDOWN_DETAILS_DEPTH,
@@ -150,7 +153,22 @@ function scanStableStreamingMarkdown(
   let lineMode = cursor.lineMode;
   let openFence = cursor.openFence;
   const detailsStack: DetailsFrame[] = [];
-  let codeSpans: ReturnType<typeof findMarkdownCodeSpans> | undefined;
+  // Completed fences cannot gain indentation ownership from later prose. Keep
+  // list containers and unfinished fences intact when parsing the retained suffix.
+  const codeStart = cursor.openFence
+    ? 0
+    : Math.min(cursor.lastFenceOffset, cursor.firstListOffset ?? cursor.lastFenceOffset);
+  const codeInput = markdownLocal.slice(codeStart);
+  const codeRegions = / {4}|\t/u.test(codeInput)
+    ? findMarkdownCodeRegions(codeInput).map((region) => ({
+        start: region.start + codeStart,
+        end: region.end + codeStart,
+        block: region.block,
+      }))
+    : [];
+  let codeSpans: ReturnType<typeof findMarkdownCodeSpans> | undefined = codeRegions.length
+    ? codeRegions.map(({ start, end }) => [start, end])
+    : undefined;
   let resumeCursor = cursor;
 
   while (index < markdownLocal.length) {
@@ -239,11 +257,24 @@ function scanStableStreamingMarkdown(
     boundary = Math.min(boundary, firstListOffset);
   }
 
+  // Blank lines inside indented code do not retire the block, and prose repair
+  // must never complete punctuation in any parser-owned code block.
+  let lastCodeEnd = lastFenceOffset;
+  for (const region of codeRegions) {
+    if (!region.block) {
+      continue;
+    }
+    if (region.start < boundary && boundary < region.end) {
+      boundary = region.start;
+    }
+    lastCodeEnd = Math.max(lastCodeEnd, region.end);
+  }
+
   return {
     cursor: resumeCursor,
     result: {
       boundary,
-      tailRepairStart: openFence ? null : Math.max(boundary, lastFenceOffset),
+      tailRepairStart: openFence ? null : Math.max(boundary, lastCodeEnd),
     },
   };
 }

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -1126,3 +1126,33 @@ describe("toStreamingMarkdownParts", () => {
     expect(html).toBe("<p>prices are $$50 and</p>\n");
   });
 });
+
+describe("indented Markdown source", () => {
+  it.each(["    *literal*", "\t*literal*", "\n\n    *literal*"])(
+    "renders initial code: %j",
+    (source) => {
+      expect(
+        htmlFragment(toSanitizedMarkdownHtml(source)).querySelector("pre code")?.textContent,
+      ).toBe("*literal*\n");
+    },
+  );
+
+  it.each(["    a\n\n    b", "Intro\n\n    a\n\n    b"])(
+    "keeps a streamed indented block together: %j",
+    (source) => {
+      const fragment = htmlFragment(toStreamingMarkdownParts(source).join(""));
+      expect(fragment.querySelectorAll("pre code")).toHaveLength(1);
+      expect(fragment.querySelector("pre code")?.textContent).toBe("a\n\nb\n");
+    },
+  );
+
+  it("never repairs literal punctuation inside streaming indented code", () => {
+    const source = "    *literal";
+    for (let end = 5; end <= source.length; end++) {
+      const fragment = htmlFragment(
+        toStreamingMarkdownParts(source.slice(0, end), {}, "indented-prefix").join(""),
+      );
+      expect(fragment.querySelector("pre code")?.textContent).toBe(`${source.slice(4, end)}\n`);
+    }
+  });
+});

--- a/ui/src/components/markdown.ts
+++ b/ui/src/components/markdown.ts
@@ -542,15 +542,13 @@ export function toSanitizedMarkdownHtml(
   options: MarkdownRenderOptions = {},
 ): string {
   const renderOptions = normalizeMarkdownRenderOptions(options);
-  const rawInput = normalizeMarkdownLineBreaks(
+  const renderInput = normalizeMarkdownLineBreaks(
     stripUnsupportedCitationControlMarkers(markdownLocal),
   );
-  const input = rawInput.trim();
-  if (!input) {
+  if (!renderInput.trim()) {
     return "";
   }
-  const renderInput = isMarkdownBlockArtText(rawInput) ? rawInput : input;
-  if (input.length > MARKDOWN_CACHE_MAX_CHARS) {
+  if (renderInput.length > MARKDOWN_CACHE_MAX_CHARS) {
     return renderSanitizedMarkdown(renderInput, renderOptions);
   }
   const cacheKey = `${i18n.getLocale()}\0${renderOptions.assistantTranscriptRoleHeaders}\0${renderOptions.codeBlockChrome}\0${renderOptions.codeBlockInteraction}\0${renderOptions.fileLinks}\0${renderOptions.interactiveImages}\0${renderOptions.linkFavicons}\0${renderOptions.progressBars}\0${renderOptions.mode}\0${renderOptions.remoteImages}\0${renderOptions.sessionLinks}\0${renderOptions.tableInteractions}\0${renderInput}`;
@@ -585,11 +583,10 @@ export function toStreamingMarkdownParts(
     return ["", renderSanitizedMarkdown(rawInput, renderOptions)];
   }
 
-  const trimmedInput = rawInput.trim();
-  if (!trimmedInput) {
+  if (!rawInput.trim()) {
     return ["", ""];
   }
-  const truncated = truncateText(trimmedInput, MARKDOWN_CHAR_LIMIT);
+  const truncated = truncateText(rawInput, MARKDOWN_CHAR_LIMIT);
   const input = appendMarkdownTruncationNotice(truncated);
 
   const { boundary, tailRepairStart } = splitStableStreamingMarkdown(

--- a/ui/src/e2e/chat-code-block-fences.e2e.test.ts
+++ b/ui/src/e2e/chat-code-block-fences.e2e.test.ts
@@ -76,6 +76,79 @@ describeControlUiE2e("Control UI fenced code blocks", () => {
     await server?.close();
   });
 
+  it("preserves indented code from history through streaming and copying", async () => {
+    const context = await browser.newContext({
+      locale: "en-US",
+      serviceWorkers: "block",
+      viewport: { height: 900, width: 1280 },
+    });
+    const page = await context.newPage();
+    const gateway = await installMockGateway(page, {
+      historyMessages: [
+        { role: "user", content: "    *user literal*", timestamp: 1000 },
+        { role: "assistant", content: "    *assistant literal*", timestamp: 2000 },
+      ],
+    });
+    await page.addInitScript(() => {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: async (text: string) => {
+            document.documentElement.dataset.copiedCode = text;
+          },
+        },
+      });
+    });
+    try {
+      await page.goto(`${server.baseUrl}chat`);
+      await page.locator(".chat-group.assistant .chat-text").waitFor();
+      if (captureProof) {
+        await page.screenshot({
+          path: path.join(artifactDir, `${proofStage}-indented-history.png`),
+        });
+      }
+      expect(await page.locator(".chat-group.user pre code").textContent()).toBe(
+        "*user literal*\n",
+      );
+      expect(await page.locator(".chat-group.assistant pre code").textContent()).toBe(
+        "*assistant literal*\n",
+      );
+      await page
+        .locator(".agent-chat__composer-combobox textarea")
+        .fill("Show an indented example");
+      await page.getByRole("button", { name: "Send message" }).click();
+      const request = await gateway.waitForRequest("chat.send");
+      const runId = requireString(requireRecord(request.params).idempotencyKey, "run id");
+      const first = "    *first";
+      const second = `${first}\n\n    second`;
+      for (const text of [first, second]) {
+        await gateway.emitGatewayEvent("chat", {
+          message: { role: "assistant", content: [{ type: "text", text }] },
+          runId,
+          sessionKey: "main",
+          state: "delta",
+        });
+        const code = page.locator(".chat-bubble.streaming pre code");
+        await expect
+          .poll(() => code.allTextContents())
+          .toEqual([text.replace(/^ {4}/gm, "") + "\n"]);
+      }
+      await page.locator(".chat-bubble.streaming .code-block-copy").click();
+      expect(await page.locator("html").getAttribute("data-copied-code")).toBe("*first\n\nsecond");
+      if (captureProof) {
+        await page.screenshot({
+          path: path.join(artifactDir, `${proofStage}-indented-stream.png`),
+        });
+      }
+      await gateway.emitChatFinal({ runId, text: second });
+      await expect
+        .poll(() => page.locator(".chat-group.assistant pre code").allTextContents())
+        .toContain("*first\n\nsecond\n");
+    } finally {
+      await context.close();
+    }
+  });
+
   it("highlights a streamed code fence only after its closing marker arrives", async () => {
     const context = await browser.newContext({
       locale: "en-US",

--- a/ui/src/lib/format.test.ts
+++ b/ui/src/lib/format.test.ts
@@ -190,9 +190,9 @@ describe("stripThinkingTags", () => {
     expect(stripThinkingTags("Hello\n</think>")).toBe("Hello\n");
   });
 
-  it("drops malformed reasoning before orphan close tags when final text follows", () => {
+  it("drops malformed reasoning while preserving the visible suffix spacing", () => {
     expect(stripThinkingTags("private chain of thought </think> Visible answer")).toBe(
-      "Visible answer",
+      " Visible answer",
     );
   });
 

--- a/ui/src/pages/chat/chat-thread.test.ts
+++ b/ui/src/pages/chat/chat-thread.test.ts
@@ -4676,7 +4676,7 @@ describe("buildCachedChatItems", () => {
       groups.flatMap((group) =>
         group.messages.flatMap(({ message }) => normalizeMessage(message).content),
       ),
-    ).toContainEqual({ type: "text", text: "Ready." });
+    ).toContainEqual({ type: "text", text: "\n\nReady." });
     expect(assistant).toEqual(original);
   });
 

--- a/ui/src/pages/chat/components/chat-imported-history.test.ts
+++ b/ui/src/pages/chat/components/chat-imported-history.test.ts
@@ -121,25 +121,30 @@ describe.each(["user", "assistant"])("imported %s history presentation", (role) 
     expect(normalizeMessage(message).content).toEqual(
       normalizeMessage({ role, content: body }).content,
     );
-    expect(displayed(message)).toBe(body.trim());
+    expect(displayed(message)).toBe(role === "assistant" ? "  First\r\n\r\nSecond" : body);
   });
 
   it.each(["\n", "\r\n", "Thinking\n\n\n"])(
     "preserves extra leading separators %j instead of treating them as import framing",
     (prefix) => {
-      const content = prefix + wrap("Keep this body");
+      const framed = wrap("Keep this body");
+      const content = prefix + framed;
       const message = { role, content, __openclaw: { idempotencyKey: importKey } };
       expect(projectImportedMessageForDisplay(message)).toEqual(message);
-      expect(displayed(message)).toBe(content.trim());
+      // Assistant display removes leading blank lines, without unwrapping an ineligible frame.
+      expect(displayed(message)).toBe(
+        role === "assistant" && (prefix === "\n" || prefix === "\r\n") ? framed : content,
+      );
       expect(extractText(message)).toContain("EXTERNAL_UNTRUSTED_CONTENT");
     },
   );
 
   it.each(["\n", "\r\n"])("preserves extra trailing separators %j", (suffix) => {
-    const content = wrap("Keep this body") + suffix;
+    const framed = wrap("Keep this body");
+    const content = framed + suffix;
     const message = { role, content, __openclaw: { idempotencyKey: importKey } };
     expect(projectImportedMessageForDisplay(message)).toEqual(message);
-    expect(displayed(message)).toBe(content.trim());
+    expect(displayed(message)).toBe(role === "assistant" ? framed : content);
     expect(extractText(message)).toContain("EXTERNAL_UNTRUSTED_CONTENT");
   });
 

--- a/ui/src/pages/chat/components/chat-message-markdown.test.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.test.ts
@@ -5,9 +5,11 @@
 import { render } from "lit";
 import { describe, expect, it, vi } from "vitest";
 import { handleMarkdownCodeBlockClick } from "../../../components/markdown-code-blocks.ts";
+import { extractText } from "../../../lib/chat/message-extract.ts";
+import { normalizeMessage } from "../../../lib/chat/message-normalizer.ts";
 import { persistedMessageEntryId } from "../chat-thread-items.ts";
 import { resolveMessageActionDetails } from "./chat-message-markdown.ts";
-import { renderMessageMarkdown } from "./chat-message-text.ts";
+import { renderMessageMarkdown, resolveMessageDisplayMarkdown } from "./chat-message-text.ts";
 
 const cappedMeta = { id: "msg-1", truncated: true, reason: "display-cap" };
 
@@ -216,5 +218,34 @@ describe("streaming message Markdown", () => {
     expect(container.querySelectorAll(".chat-duplicate-count")).toHaveLength(1);
     expect(container.querySelector(`${owner} > .chat-duplicate-count`)?.textContent).toBe("×3");
     expect(container.querySelector("code .chat-duplicate-count")).toBeNull();
+  });
+});
+
+describe("message Markdown source preservation", () => {
+  it.each(["user", "assistant"])("preserves initial code for %s messages", (role) => {
+    for (const source of ["    *literal*", "\t*literal*", "\n\n    *literal*"]) {
+      const message = { role, content: [{ type: "text", text: source }] };
+      const markdown = resolveMessageDisplayMarkdown(message, normalizeMessage(message));
+      for (const isStreaming of [false, true]) {
+        const container = document.createElement("div");
+        render(renderMessageMarkdown(markdown, "indent", { role, isStreaming }, {}), container);
+        expect(container.querySelector("pre code")?.textContent).toBe("*literal*\n");
+        expect(container.querySelector("em")).toBeNull();
+      }
+    }
+  });
+
+  it("preserves assistant snapshot indentation and recovered Markdown for copying", () => {
+    const source = "    *literal*";
+    const message = { role: "assistant", content: source, __openclaw: cappedMeta };
+    expect(extractText(message)).toBe(source);
+    const details = resolveMessageActionDetails({
+      message,
+      messageId: "msg-1",
+      canFetchFullMessage: true,
+      getAssistantMessageExpansion: () => ({ status: "loaded", markdown: source, revision: 1 }),
+      senderLabel: "assistant",
+    });
+    expect(details?.markdown).toBe(source);
   });
 });

--- a/ui/src/pages/chat/components/chat-message-markdown.ts
+++ b/ui/src/pages/chat/components/chat-message-markdown.ts
@@ -72,7 +72,7 @@ export function resolveMessageActionDetails(params: {
   const expansion = fullMessage?.state;
   const expandedMarkdown = expansion?.status === "loaded" ? expansion.markdown : previewMarkdown;
   const visibleMarkdown =
-    role === "assistant" ? stripThinkingTags(expandedMarkdown).trim() : expandedMarkdown;
+    role === "assistant" ? stripThinkingTags(expandedMarkdown) : expandedMarkdown;
   const markdown = role === "assistant" || pendingInput ? visibleMarkdown : undefined;
   const replyText =
     onReply && !pendingInput

--- a/ui/src/pages/chat/components/chat-message-text.ts
+++ b/ui/src/pages/chat/components/chat-message-text.ts
@@ -85,8 +85,8 @@ export function resolveMessageDisplayMarkdown(
     .flatMap((item) => (item.type === "text" && typeof item.text === "string" ? [item.text] : []))
     .join("\n");
   return normalizeRoleForGrouping(normalizedMessage.role) === "assistant"
-    ? stripThinkingTags(markdown).trim()
-    : markdown.trim();
+    ? stripThinkingTags(markdown)
+    : markdown;
 }
 
 // Character length owns normal disclosure; this high line cap only bounds newline-heavy prompts.


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where users reading Control UI messages saw indented code rendered as prose when the code appeared at the start of a message. For example, `    *literal*` appeared italicized. Streaming could also split one code block at blank lines and add formatting punctuation to its literal source.

## Why This Change Was Made

Preserve Markdown source through message extraction, display, recovered-message copying, and rendering, and use the existing Markdown parser's code ranges to keep streamed blocks intact. Existing fence/list cursors retain completed prefixes, while shortcode removal changes only the shortcode's own span.

## User Impact

User and assistant messages retain initial indented code, including tabs, literal punctuation, and blank lines inside a streamed block. Copying preserves the displayed source, and removing an embed leaves surrounding Markdown whitespace intact.

## Evidence

The reviewed candidate passes 290 focused Markdown/message, sanitizer, phase-extraction, and shortcode tests after the original-code regressions failed. After the branch refresh, 132 Markdown/message tests, 3 Chromium clipboard-lifetime cases, and the actual Control UI history/snapshot-stream/copy/final flow pass. Clipboard proof uses a page-local substitute and synthetic Gateway fixtures.

The unchanged reviewed patch also passed full changed-file checks, owning test type graphs, full-file lint/format, and independent P0–P2 review. A retained-prefix probe with a completed 400-line code fence and 150 later prose updates measured 52.47 ms for the candidate versus 55.29 ms for the baseline.

The initial full CI run exposed 13 stale whitespace expectations in imported-history, reasoning-suffix, and shortcode fixtures. The test-only correction preserves exact source bytes and retains all framing, provenance, metadata, and immutability assertions; all 373 tests in the three affected files pass. Both owning test type graphs and full-file lint/format pass, and the fixture-only P0–P2 review is scoped-clean. The original 14-file candidate remains byte-for-byte unchanged.

The typecheck rerun first identified a stale private dependency install (`@openclaw/fs-safe` 0.8.1 installed versus pinned 0.8.3). A frozen install aligned dependencies without changing the lockfile or source; the 373-test and typecheck passes above were repeated after that alignment.

![Before: initial indented messages render as emphasis](https://github.com/user-attachments/assets/cd04b012-43f5-4960-8b66-47bbac00e8f4)

![Integrated: initial indented messages retain literal code](https://github.com/user-attachments/assets/6a61338e-7de0-47c6-866f-6897f8752741)

![Integrated: streaming/copy retains punctuation and blank lines](https://github.com/user-attachments/assets/3a1aecd7-80d5-45f6-af8d-0e934f700462)
