### PR TITLE
refactor(native): share validated TTS request construction

### DIFF
--- a/apps/ios/Sources/Voice/TalkModeManager.swift
+++ b/apps/ios/Sources/Voice/TalkModeManager.swift
@@ -2962,7 +2962,7 @@ final class TalkModeManager: NSObject {
                 if let modelId {
                     GatewayDiagnostics.log("talk tts: modelId=\(modelId)")
                 }
-                let request = self.makeElevenLabsTTSRequest(
+                let request = ElevenLabsTTSRequest(
                     text: cleaned,
                     directive: directive,
                     modelId: modelId,
@@ -2981,7 +2981,7 @@ final class TalkModeManager: NSObject {
                 { mp3Format in
                     client.streamSynthesize(
                         voiceId: voiceId,
-                        request: self.makeElevenLabsTTSRequest(
+                        request: ElevenLabsTTSRequest(
                             text: cleaned,
                             directive: directive,
                             modelId: modelId,
@@ -3137,28 +3137,6 @@ final class TalkModeManager: NSObject {
         let resolvedKey = configuredKey
         #endif
         return resolvedKey?.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    private func makeElevenLabsTTSRequest(
-        text: String,
-        directive: TalkDirective?,
-        modelId: String?,
-        outputFormat: String?,
-        language: String?) -> ElevenLabsTTSRequest
-    {
-        ElevenLabsTTSRequest(
-            text: text,
-            modelId: modelId,
-            outputFormat: outputFormat,
-            speed: TalkTTSValidation.resolveSpeed(speed: directive?.speed, rateWPM: directive?.rateWPM),
-            stability: TalkTTSValidation.validatedStability(directive?.stability, modelId: modelId),
-            similarity: TalkTTSValidation.validatedUnit(directive?.similarity),
-            style: TalkTTSValidation.validatedUnit(directive?.style),
-            speakerBoost: directive?.speakerBoost,
-            seed: TalkTTSValidation.validatedSeed(directive?.seed),
-            normalize: ElevenLabsTTSClient.validatedNormalize(directive?.normalize),
-            language: language,
-            latencyTier: TalkTTSValidation.validatedLatencyTier(directive?.latencyTier))
     }
 
     private func startSpeechInterruptionRecognitionIfNeeded() {
@@ -3389,10 +3367,12 @@ final class TalkModeManager: NSObject {
     private func startIncrementalPrefetch(segment: String, context: IncrementalSpeechContext) {
         guard context.canUseElevenLabs, let apiKey = context.apiKey, let voiceId = context.voiceId else { return }
         let prefetchOutputFormat = self.resolveIncrementalPrefetchOutputFormat(context: context)
-        let request = self.makeIncrementalTTSRequest(
+        let request = ElevenLabsTTSRequest(
             text: segment,
-            context: context,
-            outputFormat: prefetchOutputFormat)
+            directive: context.directive,
+            modelId: context.modelId,
+            outputFormat: prefetchOutputFormat,
+            language: context.language)
         let id = UUID()
         let task = Task { [weak self] in
             let stream = ElevenLabsTTSClient(apiKey: apiKey).streamSynthesize(voiceId: voiceId, request: request)
@@ -3634,30 +3614,6 @@ final class TalkModeManager: NSObject {
             canUseElevenLabs: canUseElevenLabs)
     }
 
-    private func makeIncrementalTTSRequest(
-        text: String,
-        context: IncrementalSpeechContext,
-        outputFormat: String?) -> ElevenLabsTTSRequest
-    {
-        ElevenLabsTTSRequest(
-            text: text,
-            modelId: context.modelId,
-            outputFormat: outputFormat,
-            speed: TalkTTSValidation.resolveSpeed(
-                speed: context.directive?.speed,
-                rateWPM: context.directive?.rateWPM),
-            stability: TalkTTSValidation.validatedStability(
-                context.directive?.stability,
-                modelId: context.modelId),
-            similarity: TalkTTSValidation.validatedUnit(context.directive?.similarity),
-            style: TalkTTSValidation.validatedUnit(context.directive?.style),
-            speakerBoost: context.directive?.speakerBoost,
-            seed: TalkTTSValidation.validatedSeed(context.directive?.seed),
-            normalize: ElevenLabsTTSClient.validatedNormalize(context.directive?.normalize),
-            language: context.language,
-            latencyTier: TalkTTSValidation.validatedLatencyTier(context.directive?.latencyTier))
-    }
-
     /// Returns `mp3_44100_128` when the API has already rejected PCM, otherwise `pcm_44100`.
     private var effectiveDefaultOutputFormat: String {
         self.pcmFormatUnavailable ? "mp3_44100_128" : "pcm_44100"
@@ -3733,10 +3689,12 @@ final class TalkModeManager: NSObject {
         }
 
         let client = ElevenLabsTTSClient(apiKey: apiKey)
-        let request = self.makeIncrementalTTSRequest(
+        let request = ElevenLabsTTSRequest(
             text: text,
-            context: context,
-            outputFormat: context.outputFormat)
+            directive: context.directive,
+            modelId: context.modelId,
+            outputFormat: context.outputFormat,
+            language: context.language)
         let rawStream: AsyncThrowingStream<Data, Error> = if let prefetchedAudio, !prefetchedAudio.chunks.isEmpty {
             Self.makeBufferedAudioStream(chunks: prefetchedAudio.chunks)
         } else {
@@ -3749,10 +3707,12 @@ final class TalkModeManager: NSObject {
         { mp3Format in
             client.streamSynthesize(
                 voiceId: voiceId,
-                request: self.makeIncrementalTTSRequest(
+                request: ElevenLabsTTSRequest(
                     text: text,
-                    context: context,
-                    outputFormat: mp3Format))
+                    directive: context.directive,
+                    modelId: context.modelId,
+                    outputFormat: mp3Format,
+                    language: context.language))
         }
         guard self.isCurrentSpeechGeneration(speechGeneration) else { return }
         if !result.finished, let interruptedAt = result.interruptedAt {

--- a/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
+++ b/apps/macos/Sources/OpenClaw/TalkModeRuntime.swift
@@ -1035,21 +1035,10 @@ extension TalkModeRuntime {
         func makeRequest(outputFormat: String?) -> ElevenLabsTTSRequest {
             ElevenLabsTTSRequest(
                 text: input.cleanedText,
+                directive: input.directive,
                 modelId: modelId,
                 outputFormat: outputFormat,
-                speed: TalkTTSValidation.resolveSpeed(
-                    speed: input.directive?.speed,
-                    rateWPM: input.directive?.rateWPM),
-                stability: TalkTTSValidation.validatedStability(
-                    input.directive?.stability,
-                    modelId: modelId),
-                similarity: TalkTTSValidation.validatedUnit(input.directive?.similarity),
-                style: TalkTTSValidation.validatedUnit(input.directive?.style),
-                speakerBoost: input.directive?.speakerBoost,
-                seed: TalkTTSValidation.validatedSeed(input.directive?.seed),
-                normalize: ElevenLabsTTSClient.validatedNormalize(input.directive?.normalize),
-                language: input.language,
-                latencyTier: TalkTTSValidation.validatedLatencyTier(input.directive?.latencyTier))
+                language: input.language)
         }
 
         let request = makeRequest(outputFormat: outputFormat)

--- a/apps/shared/OpenClawKit/Sources/OpenClawKit/ElevenLabsKitShim.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawKit/ElevenLabsKitShim.swift
@@ -7,4 +7,28 @@ public typealias TalkTTSValidation = ElevenLabsKit.TalkTTSValidation
 public typealias StreamingAudioPlayer = ElevenLabsKit.StreamingAudioPlayer
 public typealias PCMStreamingAudioPlayer = ElevenLabsKit.PCMStreamingAudioPlayer
 public typealias StreamingPlaybackResult = ElevenLabsKit.StreamingPlaybackResult
+
+extension ElevenLabsTTSRequest {
+    public init(
+        text: String,
+        directive: TalkDirective?,
+        modelId: String?,
+        outputFormat: String?,
+        language: String?)
+    {
+        self.init(
+            text: text,
+            modelId: modelId,
+            outputFormat: outputFormat,
+            speed: TalkTTSValidation.resolveSpeed(speed: directive?.speed, rateWPM: directive?.rateWPM),
+            stability: TalkTTSValidation.validatedStability(directive?.stability, modelId: modelId),
+            similarity: TalkTTSValidation.validatedUnit(directive?.similarity),
+            style: TalkTTSValidation.validatedUnit(directive?.style),
+            speakerBoost: directive?.speakerBoost,
+            seed: TalkTTSValidation.validatedSeed(directive?.seed),
+            normalize: ElevenLabsTTSClient.validatedNormalize(directive?.normalize),
+            language: language,
+            latencyTier: TalkTTSValidation.validatedLatencyTier(directive?.latencyTier))
+    }
+}
 #endif

--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ElevenLabsTTSValidationTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/ElevenLabsTTSValidationTests.swift
@@ -17,5 +17,40 @@ final class ElevenLabsTTSValidationTests: XCTestCase {
         XCTAssertEqual(ElevenLabsTTSClient.validatedNormalize("AUTO"), "auto")
         XCTAssertNil(ElevenLabsTTSClient.validatedNormalize("maybe"))
     }
+
+    func testBuildsElevenLabsRequestFromResolvedOptions() {
+        let directive = TalkDirective(
+            modelId: "eleven_multilingual_v2",
+            speed: 1.5,
+            rateWPM: 175,
+            stability: 0.7,
+            similarity: -0.1,
+            style: 1.1,
+            speakerBoost: false,
+            seed: -1,
+            normalize: "invalid",
+            language: "fr",
+            outputFormat: "pcm_44100",
+            latencyTier: 5)
+        let request = ElevenLabsTTSRequest(
+            text: "Resolved speech",
+            directive: directive,
+            modelId: "eleven_v3",
+            outputFormat: "mp3_44100_128",
+            language: "en")
+
+        XCTAssertEqual(request.text, "Resolved speech")
+        XCTAssertEqual(request.modelId, "eleven_v3")
+        XCTAssertEqual(request.outputFormat, "mp3_44100_128")
+        XCTAssertEqual(request.language, "en")
+        XCTAssertEqual(request.speed, 1)
+        XCTAssertNil(request.stability)
+        XCTAssertNil(request.similarity)
+        XCTAssertNil(request.style)
+        XCTAssertEqual(request.speakerBoost, false)
+        XCTAssertNil(request.seed)
+        XCTAssertNil(request.normalize)
+        XCTAssertNil(request.latencyTier)
+    }
 }
 #endif


### PR DESCRIPTION
## What Problem This Solves

macOS Talk and two iOS speech paths independently assemble the same validated ElevenLabs request fields. The three copies can drift in how they apply directives to an already-resolved model, output format, and language.

## Why This Change Was Made

A directive-aware initializer on OpenClawKit's existing ElevenLabsTTSRequest alias owns that projection. Both private iOS builders are removed, and the Mac recovery closure delegates to the same initializer. Validation follows the pinned ElevenLabsKit contract, including words-per-minute precedence and model-specific stability values.

## User Impact

No intended user-visible change. Callers still own voice selection, one-shot overrides, transport choice, playback, interruption, and their distinct PCM/MP3 recovery policies. The existing Talk feature boundary and public aliases remain.

## Evidence

- The new `testBuildsElevenLabsRequestFromResolvedOptions` XCTest executed and passed under the default Talk feature. It checks literal values for caller-resolved options, words-per-minute precedence, invalid-field omission, and explicit false speaker boost.
- The first full shared suite hit a timeout in the unchanged chat test `late model patch updates captured canonical alias after agent switch`. That test and its chat source are byte-identical to the prior green head. The focused case passed in 0.060 seconds without changes; the full suite rerun passed 1,657 tests in 127 suites (52.483 seconds) after platform builds finished, with the new XCTest passing again.
- `swift build --package-path apps/macos --build-system native --product OpenClaw`: passed (77.53 seconds).
- iOS simulator build: passed after `pnpm ios:gen`, with `/opt/homebrew/opt/rustup/bin` on PATH for the pinned Watch Rust toolchain.
- `pnpm native:i18n:check` and `pnpm protocol:check:swift`: passed.
- `periphery scan --config .periphery.yml --strict -- --build-system native` in apps/macos: passed with no unused code.
- Fresh independent Codex review through P2: scoped-clean, zero actionable findings.
- `node scripts/check-changed.mjs`: passed, including 1,132 tests and native schema guard v16.

The change removes 27 production lines and adds 35 test lines. Pinned ElevenLabsKit 0.1.1 request/validation source was inspected. No live provider flow is claimed for this behavior-preserving request projection.


<details>
<summary>Pinned ElevenLabsKit source evidence</summary>

The maintainer directly inspected the installed dependency checkout and verified its HEAD is `0f1e4c039bd0e22b03c0cb7f43c00c1865858f0b` (ElevenLabsKit 0.1.1). This resolves the review's missing dependency-source evidence; no dependency update is involved.

- [The request initializer](https://github.com/steipete/ElevenLabsKit/blob/0f1e4c039bd0e22b03c0cb7f43c00c1865858f0b/Sources/ElevenLabsKit/ElevenLabsTTS.swift#L44) only assigns its arguments to stored fields (lines 58–69). It does not choose another model, format, or language, and preserves optional false speaker boost.
- [The numeric validators](https://github.com/steipete/ElevenLabsKit/blob/0f1e4c039bd0e22b03c0cb7f43c00c1865858f0b/Sources/ElevenLabsKit/TalkTTSValidation.swift#L1) give positive WPM precedence, reject speed at or beyond 0.5/2, restrict v3 stability to 0/0.5/1, reject units outside 0…1, reject seeds outside UInt32, and reject latency outside 0…4. Invalid values are omitted, not clamped.
- [Normalization](https://github.com/steipete/ElevenLabsKit/blob/0f1e4c039bd0e22b03c0cb7f43c00c1865858f0b/Sources/ElevenLabsKit/ElevenLabsTTS.swift#L305) trims/lowercases the value and accepts only `auto`, `on`, or `off`.

The decisive implementation excerpts from that exact revision are:

```swift
private static let v3StabilityValues: Set<Double> = [0.0, 0.5, 1.0]

public static func resolveSpeed(speed: Double?, rateWPM: Int?) -> Double? {
    if let rateWPM, rateWPM > 0 {
        let resolved = Double(rateWPM) / 175.0
        if resolved <= 0.5 || resolved >= 2.0 { return nil }
        return resolved
    }
    if let speed {
        if speed <= 0.5 || speed >= 2.0 { return nil }
        return speed
    }
    return nil
}

public static func validatedStability(_ value: Double?, modelId: String?) -> Double? {
    guard let value else { return nil }
    let normalizedModel = (modelId ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
    if normalizedModel == "eleven_v3" {
        return v3StabilityValues.contains(value) ? value : nil
    }
    return validatedUnit(value)
}
```

The new initializer calls these same methods with the same arguments as the three deleted assemblies. The contract test checks WPM 175 → speed 1 despite explicit speed 1.5; stability 0.7 is omitted for the caller-resolved v3 model despite a different directive model; caller-resolved MP3/language win; invalid unit/seed/normalization/latency values are omitted; and false speaker boost remains present.

</details>

Exact-head [CI 34145929934](https://github.com/openclaw/openclaw/actions/runs/34145929934) passed on attempt 1 for `868589d45f035e7f270f3e7314e24e4d15fa23b2`, including macOS Swift tests and iOS build. [Shared-kit Periphery 34145929950](https://github.com/openclaw/openclaw/actions/runs/34145929950) also passed. The non-Swift rebase before publication left all app source byte-identical.

The completed ClawSweeper review found no introduced defect. Its dependency-source inspection gap is addressed by the verified pinned checkout, immutable links and source excerpts above; the inspected files also match the pinned commit without local edits. A rereview of that additional evidence was requested.
