### PR TITLE
refactor(agents): share replay tool-call input predicate

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.ts
@@ -17,6 +17,7 @@ import { isThinkingLikeBlock } from "../../thinking-block.js";
 import {
   extractToolCallsFromAssistant,
   extractToolResultIds,
+  hasToolCallInput,
   sanitizeToolCallIdsForCloudCodeAssist,
   type ToolCallIdMode,
 } from "../../tool-call-id.js";
@@ -59,7 +60,7 @@ function isReplaySafeThinkingTurn(content: unknown[], allowedToolNames?: Set<str
     }
     const replayBlock = block;
     const toolCallId = typeof replayBlock.id === "string" ? replayBlock.id.trim() : "";
-    if (!replayToolCallHasInput(replayBlock) || !toolCallId || seenToolCallIds.has(toolCallId)) {
+    if (!hasToolCallInput(replayBlock) || !toolCallId || seenToolCallIds.has(toolCallId)) {
       return false;
     }
     seenToolCallIds.add(toolCallId);
@@ -77,13 +78,6 @@ function isReplayToolCallBlock(block: unknown): block is ReplayToolCallBlock {
     return false;
   }
   return isRunnerToolCallBlockType((block as { type?: unknown }).type);
-}
-
-function replayToolCallHasInput(block: ReplayToolCallBlock): boolean {
-  const hasInput = "input" in block ? block.input !== undefined && block.input !== null : false;
-  const hasArguments =
-    "arguments" in block ? block.arguments !== undefined && block.arguments !== null : false;
-  return hasInput || hasArguments;
 }
 
 function collectFollowingToolResults(
@@ -197,7 +191,7 @@ function sanitizeReplayToolCallInputs(
       }
       const replayBlock = block as ReplayToolCallBlock;
 
-      if (!replayToolCallHasInput(replayBlock) || !replayToolCallNonEmptyString(replayBlock.id)) {
+      if (!hasToolCallInput(replayBlock) || !replayToolCallNonEmptyString(replayBlock.id)) {
         changed = true;
         messageChanged = true;
         continue;

--- a/src/agents/session-transcript-repair.ts
+++ b/src/agents/session-transcript-repair.ts
@@ -16,7 +16,11 @@ import {
   normalizeLegacyToolResultId,
 } from "../../packages/agent-core/src/harness/session/tool-result-pairing.js";
 import { isThinkingLikeBlock } from "./thinking-block.js";
-import { extractToolCallsFromAssistant, extractToolResultIds } from "./tool-call-id.js";
+import {
+  extractToolCallsFromAssistant,
+  extractToolResultIds,
+  hasToolCallInput,
+} from "./tool-call-id.js";
 import { isAllowedToolCallName, normalizeAllowedToolNames } from "./tool-call-shared.js";
 
 type RawToolCallBlock = {
@@ -48,13 +52,6 @@ function isRawToolCallBlock(block: unknown): block is RawToolCallBlock {
   }
   const type = (block as { type?: unknown }).type;
   return typeof type === "string" && RAW_TOOL_CALL_BLOCK_TYPES.has(type);
-}
-
-function hasToolCallInput(block: RawToolCallBlock): boolean {
-  const hasInput = "input" in block ? block.input !== undefined && block.input !== null : false;
-  const hasArguments =
-    "arguments" in block ? block.arguments !== undefined && block.arguments !== null : false;
-  return hasInput || hasArguments;
 }
 
 function hasToolCallId(block: RawToolCallBlock): boolean {

--- a/src/agents/tool-call-id.ts
+++ b/src/agents/tool-call-id.ts
@@ -84,7 +84,7 @@ export function extractToolResultIds(msg: Extract<AgentMessage, { role: "toolRes
   return extractPairingToolResultIds(msg);
 }
 
-function hasToolCallInput(block: ReplaySafeToolCallBlock): boolean {
+export function hasToolCallInput(block: ReplaySafeToolCallBlock): boolean {
   const hasInput = "input" in block ? block.input !== undefined && block.input !== null : false;
   const hasArguments =
     "arguments" in block ? block.arguments !== undefined && block.arguments !== null : false;


### PR DESCRIPTION
## What Problem This Solves

Tool-call replay has three separate copies of the same input-presence predicate. This maintainer-requested deduplication removes a drift risk between transcript repair, signed-thinking replay checks, and outbound replay sanitization.

## Why This Change Was Made

Reuse the existing `hasToolCallInput` through runtime imports that both consumers already have. Its signature and body are unchanged: inherited properties remain eligible, only missing/null/undefined values count as absent, and the input check still precedes the arguments check without skipping it.

No provider policy, surrounding guards, normalization, public SDK exports, package exports, or module dependency edges change. The patch touches three production files, with 9 added and 18 removed lines.

## User Impact

No intended behavior change. Replay paths now share one implementation of the existing input-presence rule.

## Evidence

- All four focused test files passed using `node scripts/run-vitest.mjs`: `session-transcript-repair.test.ts`, `session-transcript-repair.attachments.test.ts`, `tool-call-id.test.ts` (26 tests), and `attempt-tool-call-replay-sanitization.test.ts` (16 tests). No aggregate count was retained for the two transcript suites; neither was rerun solely to count tests.
- The `wrapStreamFnSanitizeMalformedToolCalls` group in `attempt.test.ts` passed all 34 selected tests; 87 unrelated tests were excluded by the name filter.
- Existing tests exercise missing-input rejection, payload preservation, signed-thinking IDs, outbound context identity, and the real replay wrapper. Falsy, inherited-property, and getter combinations were not individually added or claimed as tested.
- A TypeScript AST comparison verified that all three original predicate bodies and the retained body are byte-identical. The retained signature and import module specifiers are unchanged.
- Scoped formatting, oxlint, `git diff --check`, and fresh autoreview through P2 passed.
- `node scripts/check-changed.mjs` passed its preliminary formatting, ratchet, dependency, plugin-boundary, and core graph-boundary checks, then stopped at the local tsgo guard rejecting the shared compiler symlink. Local typechecking and the remainder of that command are not claimed as passed.
- Initial transcript-suite loading failed because the new worktree lacked a link to already-installed markdown dependencies. Adding that package-local link resolved the failure; no dependency files or installed packages were changed. The runner emitted non-fatal unresolved phone-library bundle warnings.
- Exact-head [CI run 34145940771](https://github.com/openclaw/openclaw/actions/runs/34145940771) passed on `e4bd64742a20261175b1015ded10136cc40cc660`: 107 jobs passed, 17 intentionally skipped, zero failures. Hosted production and test typechecks passed, and the required `openclaw/ci-gate` was green.
- ClawSweeper's [exact-head review](https://github.com/openclaw/openclaw/pull/141371#issuecomment-5573790179) found no actionable defects.
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run` accepted hosted CI/Testbox evidence without changing or repushing the head. Native `scripts/pr merge-run` squash-merged [7600a4f571b10aaba679dba0f61100ea8c75fc5e](https://github.com/openclaw/openclaw/commit/7600a4f571b10aaba679dba0f61100ea8c75fc5e), with the completed receipt verified.
- Main advanced during validation, including a state/logging test-shard split that native merge reported as infrastructure drift. The three target files were unchanged at the squash parent; their reviewed, landed, and current-main blobs matched exactly after landing. No rebase or gate override was used.
- No remote lease or live-provider test was run; the remote evidence above is hosted CI accepted by the native Testbox gate.
