### PR TITLE
refactor(plugins): derive internal record types from schemas

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -710,7 +710,7 @@ extensions/mattermost/src/mattermost/interactions.ts	4
 extensions/mattermost/src/mattermost/model-picker.ts	1
 extensions/mattermost/src/mattermost/monitor-reactions.ts	2
 extensions/mattermost/src/mattermost/monitor-slash.ts	1
-extensions/mattermost/src/mattermost/monitor-websocket.ts	2
+extensions/mattermost/src/mattermost/monitor-websocket.ts	1
 extensions/mattermost/src/mattermost/monitor.ts	1
 extensions/mattermost/src/mattermost/slash-commands.ts	1
 extensions/mattermost/src/mattermost/slash-state.ts	5

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -13,26 +13,7 @@ import { MattermostPostSchema, type MattermostPost } from "./client.js";
 import { rawDataToString } from "./monitor-helpers.js";
 import type { ChannelAccountSnapshot, RuntimeEnv } from "./runtime-api.js";
 
-export type MattermostEventPayload = {
-  event?: string;
-  status?: string;
-  seq_reply?: number;
-  data?: {
-    post?: unknown;
-    reaction?: string | Record<string, unknown>;
-    channel_id?: string;
-    channel_name?: string;
-    channel_display_name?: string;
-    channel_type?: string;
-    sender_name?: string;
-    team_id?: string;
-  };
-  broadcast?: {
-    channel_id?: string;
-    team_id?: string;
-    user_id?: string;
-  };
-};
+export type MattermostEventPayload = z.infer<typeof MattermostEventPayloadSchema>;
 
 type MattermostWebSocketLike = {
   on(event: "open", listener: () => void): void;
@@ -84,7 +65,7 @@ const MattermostEventPayloadSchema = z.object({
       user_id: z.string().optional(),
     })
     .optional(),
-}) as z.ZodType<MattermostEventPayload>;
+});
 
 export function parseMattermostEventPayload(raw: string): MattermostEventPayload | null {
   return safeParseJsonWithSchema(MattermostEventPayloadSchema, raw);

--- a/extensions/team-reports/src/periods.ts
+++ b/extensions/team-reports/src/periods.ts
@@ -1,8 +1,19 @@
 import { z } from "zod";
-import type { Period, PeriodDescriptor } from "./types.js";
 
 export const DAY_MS = 86_400_000;
 export const periodSchema = z.enum(["day", "week", "month"]);
+
+export type Period = z.infer<typeof periodSchema>;
+
+/** Report window. Day windows are UTC [00:00, 24:00); weeks are ISO weeks (Monday start); months are calendar months. */
+export type PeriodDescriptor = {
+  period: Period;
+  /** "2026-08-20" | "2026-W34" | "2026-08" */
+  key: string;
+  sinceMs: number;
+  untilMs: number;
+  title: string;
+};
 
 function dateKey(ms: number): string {
   return new Date(ms).toISOString().slice(0, 10);

--- a/extensions/team-reports/src/store-schema.ts
+++ b/extensions/team-reports/src/store-schema.ts
@@ -1,6 +1,5 @@
 import { z } from "zod";
 import { periodSchema } from "./periods.js";
-import type { ReportDocument, SummaryDocument } from "./types.js";
 
 export const TEAM_REPORTS_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS team_reports_schema_migrations (
@@ -62,21 +61,25 @@ const countsSchema = z.object({
   issueComments: z.number(),
   reviewComments: z.number(),
   securityAdvisories: z.number(),
+  /** "owner/name" -> count */
   repos: z.record(z.string(), z.number()),
 });
 const sourceStatusSchema = z.object({
   ok: z.boolean(),
   warnings: z.array(z.string()),
+  /** True when the source could not cover the whole window (e.g. archive/API stops early). */
   stale: z.boolean().optional(),
+  /** Diagnostic counters, e.g. apiCalls, rateLimitRemaining, reposScanned, searchSplits. */
   stats: z.record(z.string(), z.union([z.number(), z.string()])),
 });
 const summarySourceSchema = z.enum(["model", "fallback"]);
 
 // Stored JSON is an external data boundary, including after restores and upgrades.
-export const reportDocumentSchema: z.ZodType<ReportDocument> = z.object({
+export const reportDocumentSchema = z.object({
   version: z.literal(1),
   period: z.object({
     period: periodSchema,
+    /** "2026-08-20" | "2026-W34" | "2026-08" */
     key: z.string(),
     sinceMs: z.number(),
     untilMs: z.number(),
@@ -91,6 +94,7 @@ export const reportDocumentSchema: z.ZodType<ReportDocument> = z.object({
     github: countsSchema,
     discord: z.object({ messages: z.number(), channels: z.record(z.string(), z.number()) }),
   }),
+  /** Sorted by activity descending; quiet members last. */
   members: z.array(
     z.object({
       login: z.string(),
@@ -100,6 +104,7 @@ export const reportDocumentSchema: z.ZodType<ReportDocument> = z.object({
       roleLabel: z.string().optional(),
       access: z.array(z.string()),
       areas: z.array(z.string()),
+      /** Other GitHub logins mapped to this person. */
       aliases: z.array(z.string()),
       github: countsSchema.extend({
         items: z.array(
@@ -115,19 +120,24 @@ export const reportDocumentSchema: z.ZodType<ReportDocument> = z.object({
               "review_comment",
               "security_advisory",
             ]),
+            /** "owner/name" */
             repo: z.string(),
             number: z.number().optional(),
             title: z.string(),
             url: z.string(),
             atMs: z.number(),
+            /** GitHub login credited for this item (merged_by for pr_merged, comment author for comments, commit author for commits). */
             actor: z.string(),
+            /** Logins from Co-authored-by trailers (commits only). */
             coauthors: z.array(z.string()).optional(),
+            /** Raw comment body, used only for duplicate collapsing and ignore patterns; never rendered. */
             body: z.string().optional(),
           }),
         ),
       }),
       discord: z.object({
         total: z.number(),
+        /** channel name -> count */
         channels: z.record(z.string(), z.number()),
         excerpts: z.array(z.object({ channel: z.string(), atMs: z.number(), excerpt: z.string() })),
       }),
@@ -141,18 +151,22 @@ export const reportDocumentSchema: z.ZodType<ReportDocument> = z.object({
     }),
   ),
   otherActors: z.array(z.object({ login: z.string(), github: countsSchema })),
+  /** Discord authors that produced messages but map to no member (id + count only). */
   unmatchedDiscord: z.array(z.object({ authorId: z.string(), messages: z.number() })),
   sources: z.object({ github: sourceStatusSchema, discord: sourceStatusSchema.optional() }),
   truncated: z.boolean().optional(),
 });
 
-export const summaryDocumentSchema: z.ZodType<SummaryDocument> = z.object({
+export const summaryDocumentSchema = z.object({
   source: summarySourceSchema,
   warnings: z.array(z.string().max(300)).max(3).optional(),
   model: z.string().optional(),
   generatedAtMs: z.number(),
+  /** Markdown: 2-3 sentence overview followed by 4-6 "- **Workstream:** ..." bullets. */
   globalSummary: z.string(),
+  /** 4-7 one-line bullets naming concrete work streams. */
   highlights: z.array(z.string()),
+  /** sha256 of the evidence digest; regeneration is skipped while unchanged. */
   fingerprint: z.string(),
 });
 export const runPeriodsSchema = z.array(z.object({ period: periodSchema, key: z.string() }));

--- a/extensions/team-reports/src/types.ts
+++ b/extensions/team-reports/src/types.ts
@@ -1,10 +1,7 @@
 import type { z } from "zod";
 import type { reportDocumentSchema, summaryDocumentSchema } from "./store-schema.js";
 
-export type Period = "day" | "week" | "month";
-
-/** Report window. Day windows are UTC [00:00, 24:00); weeks are ISO weeks (Monday start); months are calendar months. */
-export type PeriodDescriptor = ReportDocument["period"];
+export type { Period, PeriodDescriptor } from "./periods.js";
 
 export type ActivityWindow = { sinceMs: number; untilMs: number };
 

--- a/extensions/team-reports/src/types.ts
+++ b/extensions/team-reports/src/types.ts
@@ -1,14 +1,10 @@
+import type { z } from "zod";
+import type { reportDocumentSchema, summaryDocumentSchema } from "./store-schema.js";
+
 export type Period = "day" | "week" | "month";
 
 /** Report window. Day windows are UTC [00:00, 24:00); weeks are ISO weeks (Monday start); months are calendar months. */
-export type PeriodDescriptor = {
-  period: Period;
-  /** "2026-08-20" | "2026-W34" | "2026-08" */
-  key: string;
-  sinceMs: number;
-  untilMs: number;
-  title: string;
-};
+export type PeriodDescriptor = ReportDocument["period"];
 
 export type ActivityWindow = { sinceMs: number; untilMs: number };
 
@@ -41,47 +37,11 @@ export type Roster = {
   byDiscordId: Map<string, Person>;
 };
 
-export type GithubItemKind =
-  | "commit"
-  | "pr_opened"
-  | "pr_merged"
-  | "pr_closed"
-  | "issue_opened"
-  | "issue_closed"
-  | "issue_comment"
-  | "review_comment"
-  | "security_advisory";
+export type GithubItemKind = GithubItem["kind"];
 
-export type GithubItem = {
-  kind: GithubItemKind;
-  /** "owner/name" */
-  repo: string;
-  number?: number;
-  title: string;
-  url: string;
-  atMs: number;
-  /** GitHub login credited for this item (merged_by for pr_merged, comment author for comments, commit author for commits). */
-  actor: string;
-  /** Logins from Co-authored-by trailers (commits only). */
-  coauthors?: string[];
-  /** Raw comment body, used only for duplicate collapsing and ignore patterns; never rendered. */
-  body?: string;
-};
+export type GithubItem = PersonReport["github"]["items"][number];
 
-export type GithubCounts = {
-  total: number;
-  commits: number;
-  prsOpened: number;
-  prsMerged: number;
-  prsClosed: number;
-  issuesOpened: number;
-  issuesClosed: number;
-  issueComments: number;
-  reviewComments: number;
-  securityAdvisories: number;
-  /** "owner/name" -> count */
-  repos: Record<string, number>;
-};
+export type GithubCounts = ReportDocument["totals"]["github"];
 
 export type DiscordMessage = {
   channelId: string;
@@ -95,81 +55,16 @@ export type DiscordMessage = {
   content: string;
 };
 
-type DiscordExcerpt = { channel: string; atMs: number; excerpt: string };
-
-type DiscordCounts = {
-  total: number;
-  /** channel name -> count */
-  channels: Record<string, number>;
-  excerpts: DiscordExcerpt[];
-};
-
-type PersonSummary = {
-  text: string;
-  confidence: "high" | "medium" | "low";
-  source: "model" | "fallback";
-};
-
-export type PersonReport = {
-  login: string;
-  display: string;
-  affiliation?: string;
-  roleGroup?: string;
-  roleLabel?: string;
-  access: string[];
-  areas: string[];
-  /** Other GitHub logins mapped to this person. */
-  aliases: string[];
-  github: GithubCounts & { items: GithubItem[] };
-  discord: DiscordCounts;
-  summary?: PersonSummary;
-};
+export type PersonReport = ReportDocument["members"][number];
 
 /** Non-member GitHub actor (external contributor or unmapped account): counts only, never excerpts. */
-export type OtherActor = { login: string; github: GithubCounts };
+export type OtherActor = ReportDocument["otherActors"][number];
 
-export type SourceStatus = {
-  ok: boolean;
-  warnings: string[];
-  /** True when the source could not cover the whole window (e.g. archive/API stops early). */
-  stale?: boolean;
-  /** Diagnostic counters, e.g. apiCalls, rateLimitRemaining, reposScanned, searchSplits. */
-  stats: Record<string, number | string>;
-};
+export type SourceStatus = ReportDocument["sources"]["github"];
 
-export type ReportDocument = {
-  version: 1;
-  period: PeriodDescriptor;
-  generatedAtMs: number;
-  status: "partial" | "closed";
-  orgs: string[];
-  memberCount: number;
-  activeMembers: number;
-  totals: {
-    github: GithubCounts;
-    discord: { messages: number; channels: Record<string, number> };
-  };
-  /** Sorted by activity descending; quiet members last. */
-  members: PersonReport[];
-  otherActors: OtherActor[];
-  /** Discord authors that produced messages but map to no member (id + count only). */
-  unmatchedDiscord: Array<{ authorId: string; messages: number }>;
-  sources: { github: SourceStatus; discord?: SourceStatus };
-  truncated?: boolean;
-};
+export type ReportDocument = z.infer<typeof reportDocumentSchema>;
 
-export type SummaryDocument = {
-  source: "model" | "fallback";
-  warnings?: string[];
-  model?: string;
-  generatedAtMs: number;
-  /** Markdown: 2-3 sentence overview followed by 4-6 "- **Workstream:** ..." bullets. */
-  globalSummary: string;
-  /** 4-7 one-line bullets naming concrete work streams. */
-  highlights: string[];
-  /** sha256 of the evidence digest; regeneration is skipped while unchanged. */
-  fingerprint: string;
-};
+export type SummaryDocument = z.infer<typeof summaryDocumentSchema>;
 
 type SourceLogger = {
   debug?: (message: string, meta?: Record<string, unknown>) => void;


### PR DESCRIPTION
## What Problem This Solves

Team Reports records and Mattermost websocket payloads are described twice: once by runtime validators and again by handwritten TypeScript types. Field changes require keeping both representations synchronized; Mattermost also uses a type assertion to connect them.

## Why This Change Was Made

Derive the private record types from the existing validators, retain the named aliases and field documentation, and remove the redundant Mattermost assertion. Period utilities own their independent period contracts, keeping declaration dependencies acyclic. All schema expressions, SQL, runtime imports and parsing behavior remain unchanged. No new runtime helper or SDK surface is introduced.

## User Impact

Reports, stored data, API responses and Mattermost events behave as before. This maintainer-requested consolidation removes 102 production code lines (102 physical lines), with no test-source changes. The saving is in maintained declarations.

## Evidence

All 204 existing Team Reports tests and 85 Mattermost websocket, ingress, monitor and reaction tests pass before and after. Type comparisons preserve the repository's strict compiler contract, and Team Reports retains compiler-visible field documentation. These types stay private under the documented plugin boundary; supported runtime packaging does not ship their declarations.

Both real plugin builds pass. All 23 Mattermost runtime files are byte-identical. Team Reports' three output files preserve executable syntax and imports; its main bundle gains 1,035 unminified bytes only from the 15 relocated documentation comments. Its other two chunks are byte-identical.

The complete updated branch passes all 26 selected checks and fresh P2 review. Mattermost's proof checkout also passes the full root build.

The combined branch also passes production and test typechecking for the extension graph.

Stored-data compatibility: the SQL literal bytes and all eight initializer expressions in the report schema module are unchanged. Existing durable reopen/WAL and atomic report-summary-Markdown/person-day replacement cases pass. Persisted formats, validators and write paths are unchanged; no migration is introduced.

The complete architecture command passes, including both the runtime-value and Madge import-cycle checks.
