### PR TITLE
improve(memory): reduce tool preparation cost in large agent fleets

### DIFF
--- a/extensions/memory-core/index.test.ts
+++ b/extensions/memory-core/index.test.ts
@@ -108,6 +108,31 @@ function captureMemoryModelContract(initialConfig: OpenClawConfig) {
 }
 
 describe("buildPromptSection", () => {
+  it("prepares explicitly owned memory tools without resolving unrelated legacy defaults", () => {
+    let unrelatedDefaultReads = 0;
+    const config: OpenClawConfig = {
+      agents: {
+        list: [
+          { id: "main" },
+          {
+            id: "unrelated",
+            get default() {
+              unrelatedDefaultReads += 1;
+              return false;
+            },
+          },
+        ],
+      },
+    };
+    const { search, get, promptBuilder } = captureMemoryModelContract(config);
+    expect(search.description).toContain("MEMORY.md");
+    expect(get.description).toContain("MEMORY.md");
+    expect(
+      promptBuilder({ availableTools: new Set(["memory_search", "memory_get"]), agentId: "main" }),
+    ).toContain("## Memory Recall");
+    expect(unrelatedDefaultReads).toBe(0);
+  });
+
   it("returns empty when no memory tools are available", () => {
     expect(buildMemoryPromptSection({ availableTools: new Set() })).toStrictEqual([]);
   });

--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -1,4 +1,4 @@
-import { resolveSessionAgentIdsStrict } from "openclaw/plugin-sdk/agent-scope-runtime";
+import { resolveSessionAgentIdStrict } from "openclaw/plugin-sdk/agent-scope-runtime";
 import { createLazyRuntimeModule } from "openclaw/plugin-sdk/lazy-runtime";
 // Memory Core plugin entrypoint registers its OpenClaw integration.
 import {
@@ -109,7 +109,7 @@ function createLazyStandingIntentTool(
     reportUnavailable("runtime config is unavailable for this turn");
     return null;
   }
-  const { sessionAgentId: agentId } = resolveSessionAgentIdsStrict({
+  const agentId = resolveSessionAgentIdStrict({
     sessionKey: ctx.sessionKey,
     config: cfg,
     agentId: ctx.agentId,
@@ -296,7 +296,7 @@ export default definePluginEntry({
           return undefined;
         }
         const config = (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig;
-        const { sessionAgentId: agentId } = resolveSessionAgentIdsStrict({
+        const agentId = resolveSessionAgentIdStrict({
           sessionKey: ctx.sessionKey,
           config,
           agentId: ctx.agentId,
@@ -332,7 +332,7 @@ export default definePluginEntry({
         try {
           const module = await loadStandingIntentsModule();
           const config = (api.runtime.config?.current?.() ?? api.config) as OpenClawConfig;
-          const { sessionAgentId: agentId } = resolveSessionAgentIdsStrict({
+          const agentId = resolveSessionAgentIdStrict({
             sessionKey: ctx.sessionKey,
             config,
             agentId: ctx.agentId,

--- a/extensions/memory-core/src/memory-tool-contract.ts
+++ b/extensions/memory-core/src/memory-tool-contract.ts
@@ -1,4 +1,4 @@
-import { resolveSessionAgentIdsStrict } from "openclaw/plugin-sdk/agent-scope-runtime";
+import { resolveSessionAgentIdStrict } from "openclaw/plugin-sdk/agent-scope-runtime";
 import {
   resolveMemorySearchIndexConfig,
   type MemoryPromptSectionBuilder,
@@ -68,7 +68,7 @@ export function resolveMemoryToolContext(options: MemoryToolOptions) {
   if (!cfg) {
     return null;
   }
-  const { sessionAgentId: agentId } = resolveSessionAgentIdsStrict({
+  const agentId = resolveSessionAgentIdStrict({
     sessionKey: options.agentSessionKey,
     config: cfg,
     agentId: options.agentId,

--- a/src/agents/agent-scope.ts
+++ b/src/agents/agent-scope.ts
@@ -304,15 +304,19 @@ export function clearAutoFallbackPrimaryProbeSelection(
 
 export { resolveAgentIdFromSessionKey };
 
-export function resolveSessionAgentIdsStrict(params: {
+type SessionAgentResolutionParams = {
   sessionKey?: string;
   config?: OpenClawConfig;
   agentId?: string | undefined;
   fallbackAgentId?: string;
-}): {
-  defaultAgentId: string;
-  sessionAgentId: string;
-} {
+};
+
+const SESSION_AGENT_SELECTION_CONTEXT = {
+  surface: "session agent resolution",
+  hint: "Pass an agentId, an agent-scoped session key, or a prepared fallbackAgentId.",
+};
+
+function resolveSelectedSessionAgentId(params: SessionAgentResolutionParams): string | undefined {
   const explicitAgentIdRaw = normalizeLowercaseStringOrEmpty(params.agentId);
   const explicitAgentId = explicitAgentIdRaw ? normalizeAgentId(explicitAgentIdRaw) : null;
   const fallbackAgentIdRaw = normalizeLowercaseStringOrEmpty(params.fallbackAgentId);
@@ -347,29 +351,39 @@ export function resolveSessionAgentIdsStrict(params: {
       hint: `The shared fixed-store row belongs to "${persistedStoreOwner.agentId}", not "${requestedUnscopedAgentId}".`,
     });
   }
-  const compatibilityAgentId = tryResolveLegacyCompatibilityAgentId(cfg);
-  const sessionAgentId =
+  return (
     sessionKeyAgentId ??
     (persistedStoreOwner.kind === "configured" ? persistedStoreOwner.agentId : undefined) ??
     requestedUnscopedAgentId ??
+    undefined
+  );
+}
+
+export function resolveSessionAgentIdsStrict(params: SessionAgentResolutionParams): {
+  defaultAgentId: string;
+  sessionAgentId: string;
+} {
+  const selectedAgentId = resolveSelectedSessionAgentId(params);
+  const cfg = params.config ?? {};
+  const compatibilityAgentId = tryResolveLegacyCompatibilityAgentId(cfg);
+  const sessionAgentId =
+    selectedAgentId ??
     compatibilityAgentId ??
-    resolveDefaultAgentId(cfg, {
-      surface: "session agent resolution",
-      hint: "Pass an agentId, an agent-scoped session key, or a prepared fallbackAgentId.",
-    });
+    resolveDefaultAgentId(cfg, SESSION_AGENT_SELECTION_CONTEXT);
   const defaultAgentId = compatibilityAgentId ?? sessionAgentId;
   return { defaultAgentId, sessionAgentId };
 }
 
 export const resolveSessionAgentIds = resolveSessionAgentIdsStrict;
 
-export function resolveSessionAgentIdStrict(params: {
-  sessionKey?: string;
-  config?: OpenClawConfig;
-  agentId?: string;
-  fallbackAgentId?: string;
-}): string {
-  return resolveSessionAgentIdsStrict(params).sessionAgentId;
+export function resolveSessionAgentIdStrict(params: SessionAgentResolutionParams): string {
+  const selectedAgentId = resolveSelectedSessionAgentId(params);
+  const cfg = params.config ?? {};
+  return (
+    selectedAgentId ??
+    tryResolveLegacyCompatibilityAgentId(cfg) ??
+    resolveDefaultAgentId(cfg, SESSION_AGENT_SELECTION_CONTEXT)
+  );
 }
 
 export const resolveSessionAgentId = resolveSessionAgentIdStrict;

--- a/src/agents/embedded-agent-runner.resolvesessionagentids.test.ts
+++ b/src/agents/embedded-agent-runner.resolvesessionagentids.test.ts
@@ -1,10 +1,44 @@
 // Covers resolving the active agent id from session keys and explicit config.
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
+import { setRetainedLegacyDefaultAgentId } from "../config/legacy.default-agent-owner-state.js";
 import { AgentSelectionRequiredError } from "./agent-scope-config.js";
-import { resolveSessionAgentIds } from "./agent-scope.js";
+import {
+  resolveSessionAgentIdStrict,
+  resolveSessionAgentIds as resolvePairedSessionAgentIds,
+} from "./agent-scope.js";
 
-describe("resolveSessionAgentIds", () => {
+describe("resolveSessionAgentIdStrict", () => {
+  it.each([{ agentId: "main" }, { sessionKey: "agent:main:main" }, { fallbackAgentId: "main" }])(
+    "does not read unrelated roster entries for a prepared owner: %j",
+    (owner) => {
+      let unrelatedEntryReads = 0;
+      const config: OpenClawConfig = {
+        agents: {
+          entries: {
+            main: {},
+            get unrelated() {
+              unrelatedEntryReads += 1;
+              return {};
+            },
+          },
+        },
+      };
+      expect(resolveSessionAgentIdStrict({ config, ...owner })).toBe("main");
+      expect(unrelatedEntryReads).toBe(0);
+    },
+  );
+});
+
+describe.each([
+  { name: "resolveSessionAgentIds", resolve: resolvePairedSessionAgentIds },
+  {
+    name: "resolveSessionAgentIdStrict",
+    resolve: (params: Parameters<typeof resolveSessionAgentIdStrict>[0]) => ({
+      sessionAgentId: resolveSessionAgentIdStrict(params),
+    }),
+  },
+])("$name", ({ resolve: resolveSessionAgentIds }) => {
   const cfg = {
     agents: {
       entries: { main: {}, beta: {} },
@@ -20,6 +54,27 @@ describe("resolveSessionAgentIds", () => {
 
   it("requires an owner when sessionKey is missing", () => {
     expect(() => resolveSessionAgentIds({ config: cfg })).toThrow(AgentSelectionRequiredError);
+  });
+
+  it.each([
+    { config: {}, expected: "main" },
+    { config: { agents: { entries: { beta: {} } } }, expected: "beta" },
+    {
+      config: { agents: { list: [{ id: "main" }, { id: "beta", default: true }] } },
+      expected: "beta",
+    },
+  ])("preserves ownerless fallback for %j", ({ config, expected }) => {
+    expect(resolveSessionAgentIds({ config }).sessionAgentId).toBe(expected);
+  });
+
+  it("uses the retained migration owner only while it remains configured", () => {
+    const config: OpenClawConfig = {
+      agents: { ownership: "explicit", entries: { main: {}, beta: {} } },
+    };
+    setRetainedLegacyDefaultAgentId(config, "beta");
+    expect(resolveSessionAgentIds({ config }).sessionAgentId).toBe("beta");
+    setRetainedLegacyDefaultAgentId(config, "retired");
+    expect(() => resolveSessionAgentIds({ config })).toThrow(AgentSelectionRequiredError);
   });
 
   it("requires an owner when sessionKey is non-agent", () => {
@@ -206,4 +261,18 @@ describe("resolveSessionAgentIds", () => {
     });
     expect(sessionAgentId).toBe("beta");
   });
+});
+
+it.each(["raw", "retained"])("preserves a different %s default for paired callers", (source) => {
+  const config: OpenClawConfig = {
+    agents: { entries: { main: { default: source === "raw" }, beta: {} } },
+  };
+  if (source === "retained") {
+    setRetainedLegacyDefaultAgentId(config, "main");
+  }
+  expect(resolvePairedSessionAgentIds({ config, agentId: "beta" })).toEqual({
+    defaultAgentId: "main",
+    sessionAgentId: "beta",
+  });
+  expect(resolveSessionAgentIdStrict({ config, agentId: "beta" })).toBe("beta");
 });


### PR DESCRIPTION
## What Problem This Solves

Memory tools take unnecessary CPU time to prepare in gateways with large agent fleets, even when the request already selects its agent.

## Why This Change Was Made

Strict scalar session-agent resolution now shares the existing owner validation and only looks up a legacy/default owner when no explicit, session-scoped, persisted, or prepared owner was selected. Four memory-core consumers use that existing scalar SDK helper. The paired API still computes and returns its compatibility default, and fixed-store, conflicting-owner, retired-owner, and legacy fallback behavior stay intact. This is request-time selection work: no stored fields, vector/embedding metadata, schema, store writes, or migration behavior change.

## User Impact

Memory tool preparation and other strict scalar callers avoid projecting the full roster solely to compute an unused default. Existing recall-policy and per-agent configuration lookup costs remain; this change does not make the complete memory flow constant-time.

## Evidence

The new scalar regression cases fail on the original source with two unrelated roster reads each; the memory factory/prompt regression fails with three unrelated legacy-default reads. After the fix, all 58 selector/SDK cases and 29 memory-core index cases pass. Full changed checks pass, including all four typecheck lanes, lint, plugin boundaries, and repository guards. Independent Codex P0–P2 review found no actionable findings.

Fresh paired synthetic measurements use actual `createMemoryGetTool`, canonical explicit ownership, and nine rounds on the same Linux x64 Testbox with Node 24.19.0, four visible CPUs, and 16.56 GB RAM. Median time per factory call:

| Agents | Owner position | Before | After |
| --- | --- | ---: | ---: |
| 1 | first | 3.482 µs | 3.611 µs |
| 100 | first | 25.501 µs | 14.824 µs |
| 100 | last | 31.780 µs | 22.701 µs |
| 1,000 | first | 218.114 µs | 122.917 µs |
| 1,000 | last | 292.374 µs | 189.249 µs |

The 1,000-agent factory savings are 43.6% for the first owner and 35.3% for the last; the one-agent measurement does not show a factory improvement. Strict scalar lookup itself drops from 111.287 to 0.311 µs for the first owner and 113.773 to 0.315 µs for the last. The complete benchmark command took 11.299 s before and 9.427 s after; whole-process maximum RSS was 657,088 KiB before and 632,256 KiB after. These are synthetic source benchmarks and whole-process observations, not end-to-end latency or per-call allocation measurements.

Real isolated Gateway `/tools/invoke` comparisons pass with 64 agents on both revisions: 28 verified requests total (14 per revision), covering distinct first/last owner memory contents, missing-file `not_found`, and exact conflicting-owner HTTP 400 rejection. The three changed production file hashes independently match this PR's head. Both `pnpm openclaw --version` runtime builds and benchmark phases pass; every owned runtime descendant is verified closed and the [Testbox lease](https://github.com/openclaw/openclaw/actions/runs/34144260735) is stopped.

A separate 1,000-agent startup diagnostic remains unresolved: both baseline and candidate miss the unchanged 180-second readiness budget with sustained runtime-process CPU and no ready socket. The composite remote command deliberately retains exit 1 for that failed diagnostic; it does not represent an aggregate runtime pass. The 64-agent functional receipts are separate successful phases. No startup fix or production-stall causal claim is made. Earlier pre-request harness failures and all startup outcomes are preserved.
