### PR TITLE
fix(openai): preserve reported top-level cache writes

### DIFF
--- a/packages/ai/src/transports/openai-completions-stream.integration.test.ts
+++ b/packages/ai/src/transports/openai-completions-stream.integration.test.ts
@@ -6,6 +6,7 @@ import {
   markDiagnosticRunProgress,
   resetDiagnosticRunActivityForTest,
 } from "../../../../src/logging/diagnostic-run-activity.js";
+import { streamOpenAICompletions } from "../providers/openai-completions.js";
 import { registerBuiltInApiProviders } from "../providers/register-builtins.js";
 import { createLlmRuntime } from "../stream.js";
 import { shouldEmitOpenAICompletionsReasoning } from "./openai-completions-stream.js";
@@ -15,6 +16,97 @@ import { makeCompletionsChunk, makeCompletionsModel } from "./openai-completions
 describe("openai completions stream", () => {
   afterAll(() => {
     resetDiagnosticRunActivityForTest();
+  });
+
+  describe.each([
+    { name: "direct", createStream: streamOpenAICompletions },
+    { name: "managed", createStream: createOpenAICompletionsTransportStreamFn() },
+  ])("$name cache-creation usage", ({ createStream }) => {
+    it.each([
+      ["top-level fallback", {}, 300, 0.001075, undefined],
+      ["nested writes", { cache_write_tokens: 100 }, 100, 0.001025, undefined],
+      ["nested creation", { cache_creation_input_tokens: 100 }, 100, 0.001025, undefined],
+      ["nested write zero", { cache_write_tokens: 0 }, 0, 0.001, undefined],
+      ["nested creation zero", { cache_creation_input_tokens: 0 }, 0, 0.001, undefined],
+      ["provider-billed zero", {}, 300, 0, 0],
+    ] as const)("preserves %s over HTTP", async (_name, details, cacheWrite, cost, billedCost) => {
+      let capturedPayload: Record<string, unknown> | undefined;
+      let capturedRoute: string | undefined;
+      const server = createServer((req, res) => {
+        let body = "";
+        req.setEncoding("utf8");
+        req.on("data", (chunk: string) => {
+          body += chunk;
+        });
+        req.on("end", () => {
+          capturedRoute = `${req.method} ${req.url}`;
+          capturedPayload = JSON.parse(body) as Record<string, unknown>;
+          res.writeHead(200, { "content-type": "text/event-stream; charset=utf-8" });
+          // TrueFoundry documents inclusive prompt tokens with a top-level write bucket:
+          // https://www.truefoundry.com/docs/ai-gateway/chat-completions-advanced
+          const usage = {
+            prompt_tokens: 1500,
+            completion_tokens: 200,
+            total_tokens: 1700,
+            prompt_tokens_details: { cached_tokens: 1200, ...details },
+            cache_read_input_tokens: 1200,
+            cache_creation_input_tokens: 300,
+            ...(billedCost === undefined ? {} : { cost: billedCost }),
+          };
+          for (const chunk of [
+            makeCompletionsChunk({ role: "assistant", content: "Usage preserved." }),
+            makeCompletionsChunk({}, "stop"),
+            makeCompletionsChunk({}, null, { choices: [], usage }),
+          ]) {
+            res.write(`data: ${JSON.stringify(chunk)}\n\n`);
+          }
+          res.end("data: [DONE]\n\n");
+        });
+      });
+
+      await new Promise<void>((resolve) => {
+        server.listen(0, "127.0.0.1", resolve);
+      });
+      try {
+        const address = server.address();
+        if (!address || typeof address === "string") {
+          throw new Error("Missing loopback server address");
+        }
+        const model = makeCompletionsModel({
+          provider: "compatible-proxy",
+          baseUrl: `http://127.0.0.1:${address.port}/v1`,
+          reasoning: false,
+          cost: { input: 1, output: 2, cacheRead: 0.25, cacheWrite: 1.25 },
+        });
+        const stream = await createStream(
+          model,
+          { messages: [{ role: "user", content: "Explain the usage.", timestamp: 1 }] },
+          { apiKey: "synthetic-test-key" },
+        );
+        const result = await stream.result();
+
+        expect(capturedRoute).toBe("POST /v1/chat/completions");
+        expect(capturedPayload).toMatchObject({ model: model.id, stream: true });
+        expect(result.stopReason).toBe("stop");
+        expect(result.content).toEqual([expect.objectContaining({ text: "Usage preserved." })]);
+        expect(result.usage).toMatchObject({
+          input: 300 - cacheWrite,
+          output: 200,
+          cacheRead: 1200,
+          cacheWrite,
+          totalTokens: 1700,
+        });
+        expect(result.usage.cost.cacheWrite).toBeCloseTo((cacheWrite * 1.25) / 1_000_000, 10);
+        expect(result.usage.cost.total).toBeCloseTo(cost, 10);
+        if (billedCost !== undefined) {
+          expect(result.usage.cost.totalOrigin).toBe("provider-billed");
+        }
+      } finally {
+        await new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    });
   });
 
   it("emits Qwen thinking streams when enabled without reasoning_effort support", async () => {

--- a/packages/ai/src/transports/openai-transport-shared.ts
+++ b/packages/ai/src/transports/openai-transport-shared.ts
@@ -206,6 +206,7 @@ export type MutableAssistantOutput = Omit<AssistantMessage, "content" | "usage">
 export function parseOpenAICompletionsUsage(
   rawUsage: NonNullable<ChatCompletionChunk["usage"]> & {
     cost?: unknown;
+    cache_creation_input_tokens?: number;
     prompt_cache_hit_tokens?: number;
     prompt_tokens_details?: { cache_creation_input_tokens?: number };
   },
@@ -217,6 +218,7 @@ export function parseOpenAICompletionsUsage(
   const cacheWrite =
     rawUsage.prompt_tokens_details?.cache_write_tokens ??
     rawUsage.prompt_tokens_details?.cache_creation_input_tokens ??
+    rawUsage.cache_creation_input_tokens ??
     0;
   const input = Math.max(0, (rawUsage.prompt_tokens || 0) - cacheRead - cacheWrite);
   const output = rawUsage.completion_tokens || 0;


### PR DESCRIPTION
Fixes #141374. Related #119712 remains separate.

OpenAI-compatible Chat Completions proxies can report `usage.cache_creation_input_tokens` at the top level. OpenClaw previously counted those reported cache writes as uncached input, which also used the wrong catalog price.

The shared usage owner now accepts that reported field after both existing nested write aliases. Nested values, including zero, keep precedence. Direct and managed streams use the same owner. The change adds two production lines and real HTTP regression coverage.

Application validation uses the documented `openclaw agent exec --config ... --state-dir ... --json` command with a configured custom Chat Completions provider and distinct synthetic prices. It resolves that provider, sends a real loopback `POST /v1/chat/completions` SSE request, and returns the final answer, usage and `costUsd`. Pinned main `0604bbce80797482228b275eaacec34614942731` and candidate `275d8c64e38ce01a0a5ec1bd1272eadbb5872600` ran on the same isolated Linux/Node 24.19.0 machine with OpenAI SDK 7.8.0.

| Reported prompt 1500, read 1200, write 300, output 200 | Main | Candidate |
| --- | ---: | ---: |
| Uncached input | 300 | 0 |
| Cache write | 0 | 300 |
| Total tokens | 1700 | 1700 |
| Catalog cost at distinct synthetic prices | 0.001 | 0.001075 |

The final CLI output reports cache write 300, read 1200, output 200, total 1700, and `costUsd: 0.001075`. Its existing aggregate format omits zero-valued input; the underlying provider message records input zero. Both CLI commands returned their unique fixture answer and exited successfully after one configured provider request.

Independent application acceptance adds 26 CLI runs covering both nested aliases and zeros, billed zero and positive totals, absent writes, varied counts/prices, and malformed-counter diagnostics. Read-only checks of the application-produced session databases confirm the matching assistant messages, explicit input zero, write 300, correct costs, and per-call billed origins. All CLI children, servers and connections closed. The 140 package HTTP observations and 124 independent package requests remain complementary boundary coverage.

The contributed regression tests fail in four intended write-bucket cases on main; all 63 focused candidate tests pass. Formatting, focused lint and the max-lines/environment ratchets passed. Exact-head hosted CI is green in [run 34146536650](https://github.com/openclaw/openclaw/actions/runs/34146536650).

The package HTTP tests complement the configured CLI proof; direct package calls alone do not establish application routing. This is synthetic local-provider proof, not live vendor billing or a Gateway/UI session. Malformed-counter diagnostics distinguish the package's trusted-counter behavior from application normalization; this patch changes neither numeric-validation nor pricing policy. Bare invalid JSON retains the SDK error path. No top-level cache-read support, inferred counters, new configuration, or persistence change is included.

AI-assisted verification. Contributor implementation and credit are preserved.
