### PR TITLE
fix: disable desktop keyboard until connected control is ready

### DIFF
--- a/ui/src/components/desktop/desktop-document-view.ts
+++ b/ui/src/components/desktop/desktop-document-view.ts
@@ -56,6 +56,7 @@ export function renderDesktopDocumentView(options: DesktopDocumentViewOptions) {
         spellcheck="false"
         tabindex="-1"
         aria-label=${t("desktop.keyboardInput")}
+        ?disabled=${options.state !== "connected" || !options.controlling}
         .value=${options.keyboardInputValue}
         @keydown=${options.onKeyboardEvent}
         @keyup=${options.onKeyboardEvent}
@@ -80,6 +81,7 @@ export function renderDesktopDocumentView(options: DesktopDocumentViewOptions) {
           class="desktop-touch-action"
           type="button"
           aria-label=${t("desktop.keyboard")}
+          ?disabled=${options.state !== "connected" || !options.controlling}
           @click=${options.onKeyboardFocus}
         >
           <span class="desktop-touch-action__icon" aria-hidden="true">${KEYBOARD_GLYPH}</span>

--- a/ui/src/components/desktop/desktop-panel-styles.ts
+++ b/ui/src/components/desktop/desktop-panel-styles.ts
@@ -72,7 +72,8 @@ const desktopPanelStyles = css`
     border-color: var(--accent, #ff5c5c);
     color: var(--accent, #ff5c5c);
   }
-  .desktop-button:disabled {
+  .desktop-button:disabled,
+  .desktop-touch-action:disabled {
     opacity: 0.5;
   }
   .desktop-session {

--- a/ui/src/e2e/desktop-keyboard.e2e.test.ts
+++ b/ui/src/e2e/desktop-keyboard.e2e.test.ts
@@ -1,5 +1,7 @@
-import type { Page } from "playwright";
+import path from "node:path";
+import type { Locator, Page } from "playwright";
 import { expect, it } from "vitest";
+import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 import { installScriptedRfbServer } from "./desktop-rfb-test-support.ts";
@@ -9,17 +11,19 @@ const suite = createControlUiE2eSuite({
   startServerBeforeBrowser: true,
 });
 
-async function openKeyboard(page: Page) {
+const desktopObserve = {
+  transport: "rfb",
+  wsPath: "/desktop/observe?token=synthetic-keyboard",
+  expiresAtMs: 60_000,
+  control: true,
+};
+
+async function openKeyboard(page: Page, beforeReady?: (panel: Locator) => Promise<void>) {
   const gateway = await installMockGateway(page, {
-    deferredMethods: ["environments.list"],
+    deferredMethods: ["environments.list", "desktop.observe"],
     featureMethods: ["desktop.observe", "environments.list"],
     methodResponses: {
-      "desktop.observe": {
-        transport: "rfb",
-        wsPath: "/desktop/observe?token=synthetic-keyboard",
-        expiresAtMs: 60_000,
-        control: true,
-      },
+      "desktop.observe": desktopObserve,
     },
   });
   await page.goto(`${suite.server.baseUrl}focus/desktop/control/source/gateway`);
@@ -29,11 +33,16 @@ async function openKeyboard(page: Page) {
     environments: [{ id: "gateway", type: "local", status: "available", desktop: true }],
   });
   const panel = page.locator("openclaw-desktop-panel");
+  await gateway.waitForRequest("desktop.observe");
+  await beforeReady?.(panel);
+  await gateway.resolveDeferred("desktop.observe");
   await panel.locator(".desktop-surface canvas").waitFor();
   await expect.poll(peer.events).toEqual(["authenticated:1"]);
-  await panel.getByText("Connecting to desktop…", { exact: true }).waitFor({ state: "hidden" });
+  await panel
+    .getByRole("status", { name: "Connecting to desktop…", exact: true })
+    .waitFor({ state: "hidden" });
   await panel.getByRole("button", { name: "Keyboard", exact: true }).click();
-  return { peer, input: panel.locator(".desktop-keyboard-input") };
+  return { gateway, panel, peer, input: panel.locator(".desktop-keyboard-input") };
 }
 
 function keyPresses(keysyms: readonly number[]) {
@@ -44,9 +53,29 @@ function keyPresses(keysyms: readonly number[]) {
 }
 
 suite.define(() => {
-  it("preserves all 32 pasted ASCII characters through padding reset and Backspace", async () => {
+  it("accepts 32 pasted ASCII characters only after connected control and disables view-only input", async () => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
-      const { peer, input } = await openKeyboard(page);
+      await page.setViewportSize({ width: 720, height: 540 });
+      const artifactDirectory = createControlUiE2eArtifactDir("desktop-keyboard-readiness");
+      const { gateway, panel, peer, input } = await openKeyboard(page, async (connectingPanel) => {
+        await connectingPanel
+          .getByRole("status", { name: "Connecting to desktop…", exact: true })
+          .waitFor();
+        const keyboard = connectingPanel.getByRole("button", { name: "Keyboard", exact: true });
+        const pendingInput = connectingPanel.locator(".desktop-keyboard-input");
+        const padding = await pendingInput.inputValue();
+        const bounds = await keyboard.boundingBox();
+        if (!bounds) {
+          throw new Error("Expected the visible desktop Keyboard button");
+        }
+        await page.mouse.click(bounds.x + bounds.width / 2, bounds.y + bounds.height / 2);
+        await page.keyboard.insertText("early");
+        await page.screenshot({ path: path.join(artifactDirectory, "connecting.png") });
+        expect(await pendingInput.inputValue()).toBe(padding);
+        expect(await keyboard.isDisabled()).toBe(true);
+        expect(await pendingInput.isDisabled()).toBe(true);
+      });
+      expect(await peer.keyEvents()).toEqual([]);
       const padding = await input.inputValue();
       const text = "Aa7!z?Bb8@x#Cc9$w%Dd0^v&Ee1*f(G)";
       const expected = keyPresses(Array.from(text, (character) => character.charCodeAt(0)));
@@ -58,6 +87,20 @@ suite.define(() => {
       await page.keyboard.insertText("Z");
       await page.keyboard.press("Backspace");
       await expect.poll(peer.keyEvents).toEqual([...expected, ...keyPresses([0x5a, 0xff08])]);
+      await page.screenshot({ path: path.join(artifactDirectory, "connected-control.png") });
+
+      await gateway.setMethodResponse("desktop.observe", { ...desktopObserve, control: false });
+      await panel.getByRole("button", { name: "Switch to view only", exact: true }).click();
+      await gateway.waitForRequest("desktop.observe", { after: 1 });
+      await expect.poll(peer.events).toContain("authenticated:2");
+      await panel
+        .getByRole("status", { name: "Connecting to desktop…", exact: true })
+        .waitFor({ state: "hidden" });
+      expect(await panel.getByRole("button", { name: "Keyboard", exact: true }).isDisabled()).toBe(
+        true,
+      );
+      expect(await input.isDisabled()).toBe(true);
+      await page.screenshot({ path: path.join(artifactDirectory, "connected-view-only.png") });
     });
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users could open the desktop keyboard and type while the desktop was still connecting. The text changed the hidden mobile input locally but never reached the desktop.

## Why This Change Was Made

The Keyboard button and its textarea now remain disabled until the desktop is connected and in control mode. The button reuses the existing disabled appearance so that unavailable input is visible. Connected control typing follows the same input path; nothing is buffered or replayed.

## User Impact

Users can see when the desktop keyboard is ready. It stays unavailable while connecting and in view-only mode, and works normally after connected control is ready. This changes no credentials, desktop permissions, configuration, or protocol.

## Evidence

- Extended the existing browser flow to click Keyboard and type synthetic text while the mock desktop observation is deferred. Before the fix, this changed the local input; afterward, the input stays unchanged until connected control is ready.
- All 22 keyboard and desktop-document E2E tests pass. Real noVNC still emits the expected balanced events for 32 ASCII characters, Backspace, BMP/supplementary Unicode, and line endings.
- Readiness assertions now use the actual status role and accessible label; the previous text-based hidden wait could pass without observing that status.
- Full changed-file checks and fresh isolated P0–P2 review pass.

The attachments show the same synthetic connecting state before and after, in that order. No real desktop, credentials, or user data was used. This proof does not establish why a separate OS sign-in failed; live deployment and verification remain a follow-up.

![Before: Keyboard appears enabled while the desktop is connecting](https://github.com/user-attachments/assets/cb2af9ed-ab64-4e46-b5b9-1b7c316746f5)

![After: Keyboard is disabled until connected control is ready](https://github.com/user-attachments/assets/70ae4042-41bb-4ca9-8099-d0f3d41196ed)