### PR TITLE
fix(agents): scope embedded abort/active to agent owner

### DIFF
--- a/src/agents/embedded-agent-runner/runs.ts
+++ b/src/agents/embedded-agent-runner/runs.ts
@@ -851,23 +851,73 @@ function prepareEmbeddedAgentQueueMessage(
  * - With a sessionId, aborts that single run.
  * - With no sessionId, supports targeted abort modes (for example, compacting runs only).
  */
-export function abortEmbeddedAgentRun(sessionId: string): boolean;
+export type EmbeddedRunOwnerScope = { agentId?: string; defaultAgentId?: string };
+
+type AbortEmbeddedAgentRunOpts = {
+  mode?: "all" | "compacting";
+  reason?: "restart";
+} & EmbeddedRunOwnerScope;
+
+function hasEmbeddedRunOwnerFilter(owner?: EmbeddedRunOwnerScope): boolean {
+  return Boolean(owner?.agentId || owner?.defaultAgentId);
+}
+
+function matchesEmbeddedOrReplyRunOwner(
+  sessionId: string,
+  owner: EmbeddedRunOwnerScope,
+): { embedded: boolean; reply: boolean } {
+  const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  const registration = handle ? ACTIVE_EMBEDDED_RUN_REGISTRATIONS.get(handle) : undefined;
+  const replyOperation = resolveActiveReplyOperationForSessionId(sessionId);
+  return {
+    embedded: Boolean(handle && registration && matchesSessionProgressOwner(owner, registration)),
+    reply: Boolean(
+      replyOperation &&
+      matchesSessionProgressOwner(owner, {
+        agentId: replyOperation.agentId,
+        sessionKey: replyOperation.key,
+      }),
+    ),
+  };
+}
+
+export function abortEmbeddedAgentRun(sessionId: string, opts?: EmbeddedRunOwnerScope): boolean;
 export function abortEmbeddedAgentRun(
   sessionId: undefined,
-  opts: { mode: "all" | "compacting"; reason?: "restart" },
+  opts: { mode: "all" | "compacting"; reason?: "restart" } & EmbeddedRunOwnerScope,
 ): boolean;
 export function abortEmbeddedAgentRun(
   sessionId?: string,
-  opts?: { mode?: "all" | "compacting"; reason?: "restart" },
+  opts?: AbortEmbeddedAgentRunOpts,
 ): boolean {
   if (typeof sessionId === "string" && sessionId.length > 0) {
+    const ownerFilter = hasEmbeddedRunOwnerFilter(opts)
+      ? { agentId: opts?.agentId, defaultAgentId: opts?.defaultAgentId }
+      : undefined;
     const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
     if (!handle) {
+      if (ownerFilter) {
+        const match = matchesEmbeddedOrReplyRunOwner(sessionId, ownerFilter);
+        if (!match.reply) {
+          diag.debug(`abort skipped: sessionId=${sessionId} reason=owner_mismatch`);
+          return false;
+        }
+      }
       if (abortReplyRunBySessionId(sessionId)) {
         return true;
       }
       diag.debug(`abort failed: sessionId=${sessionId} reason=no_active_run`);
       return false;
+    }
+    if (ownerFilter) {
+      const match = matchesEmbeddedOrReplyRunOwner(sessionId, ownerFilter);
+      if (!match.embedded) {
+        if (match.reply) {
+          return abortReplyRunBySessionId(sessionId);
+        }
+        diag.debug(`abort skipped: sessionId=${sessionId} reason=owner_mismatch`);
+        return false;
+      }
     }
     if (!isEmbeddedRunHandleAbortable(sessionId, handle)) {
       diag.debug(`abort failed: sessionId=${sessionId} reason=not_abortable`);
@@ -963,8 +1013,17 @@ export async function preemptAndDrainEmbeddedHeartbeatRun(
   return (await drainPromise) ? "drained" : "timed-out";
 }
 
-export function isEmbeddedAgentRunActive(sessionId: string): boolean {
-  const active = ACTIVE_EMBEDDED_RUNS.has(sessionId) || isReplyRunActiveForSessionId(sessionId);
+export function isEmbeddedAgentRunActive(
+  sessionId: string,
+  owner?: EmbeddedRunOwnerScope,
+): boolean {
+  let active: boolean;
+  if (hasEmbeddedRunOwnerFilter(owner)) {
+    const match = matchesEmbeddedOrReplyRunOwner(sessionId, owner!);
+    active = match.embedded || match.reply;
+  } else {
+    active = ACTIVE_EMBEDDED_RUNS.has(sessionId) || isReplyRunActiveForSessionId(sessionId);
+  }
   if (active) {
     diag.debug(`run active check: sessionId=${sessionId} active=true`);
   }
@@ -978,7 +1037,7 @@ export function resolveEmbeddedAgentRunProgressState(
   return resolveEmbeddedRunProgressState(sessionId, "operational");
 }
 
-type SessionProgressOwner = { agentId?: string; defaultAgentId?: string };
+type SessionProgressOwner = EmbeddedRunOwnerScope;
 
 function matchesSessionProgressOwner(
   owner: SessionProgressOwner,
@@ -1041,7 +1100,13 @@ function resolveEmbeddedRunProgressState(
   return replyInProgress ? "queued" : undefined;
 }
 
-export function isEmbeddedAgentRunInProgress(sessionId: string): boolean {
+export function isEmbeddedAgentRunInProgress(
+  sessionId: string,
+  owner?: EmbeddedRunOwnerScope,
+): boolean {
+  if (hasEmbeddedRunOwnerFilter(owner)) {
+    return resolveEmbeddedAgentSessionProgressState(sessionId, owner!) !== undefined;
+  }
   return resolveEmbeddedAgentRunProgressState(sessionId) !== undefined;
 }
 
@@ -1262,12 +1327,13 @@ function waitForCurrentEmbeddedAgentRunEnd(
 export async function waitForEmbeddedAgentRunEnd(
   sessionId: string,
   timeoutMs: number | null = 15_000,
+  owner?: EmbeddedRunOwnerScope,
 ): Promise<boolean> {
   if (!sessionId) {
     return true;
   }
   const deadline = timeoutMs === null ? undefined : Date.now() + timeoutMs;
-  while (isEmbeddedAgentRunActive(sessionId)) {
+  while (isEmbeddedAgentRunActive(sessionId, owner)) {
     const remainingMs = deadline === undefined ? null : deadline - Date.now();
     if (remainingMs !== null && remainingMs <= 0) {
       return false;

--- a/src/gateway/server-methods/session-run-interruption.ts
+++ b/src/gateway/server-methods/session-run-interruption.ts
@@ -29,17 +29,22 @@ export async function interruptSessionRunIfActive(params: {
   excludeRunIds?: ReadonlySet<string>;
 }): Promise<{ interrupted: boolean; error?: ReturnType<typeof errorShape> }> {
   const cfg = params.context.getRuntimeConfig();
+  const defaultAgentId = tryResolveSessionCompatibilityOwnerAgentId(cfg, params.canonicalKey);
+  const embeddedOwner = {
+    ...(params.agentId ? { agentId: params.agentId } : {}),
+    ...(defaultAgentId ? { defaultAgentId } : {}),
+  };
   const hasTrackedRun = hasTrackedActiveSessionRun({
     context: params.context,
     requestedKey: params.requestedKey,
     canonicalKey: params.canonicalKey,
     agentId: params.agentId,
-    defaultAgentId: tryResolveSessionCompatibilityOwnerAgentId(cfg, params.canonicalKey),
+    defaultAgentId,
     excludeRunIds: params.excludeRunIds,
   });
   const hasEmbeddedRun =
     typeof params.sessionId === "string" && params.sessionId
-      ? isEmbeddedAgentRunActive(params.sessionId)
+      ? isEmbeddedAgentRunActive(params.sessionId, embeddedOwner)
       : false;
   const hasWorkerRun =
     typeof params.sessionId === "string" && params.sessionId
@@ -60,7 +65,7 @@ export async function interruptSessionRunIfActive(params: {
       requestedKey: params.requestedKey,
       canonicalKey: params.canonicalKey,
       agentId: params.agentId,
-      defaultAgentId: tryResolveSessionCompatibilityOwnerAgentId(cfg, params.canonicalKey),
+      defaultAgentId,
     });
 
     await handleChatAbortRequestWithLifecycle(
@@ -91,13 +96,13 @@ export async function interruptSessionRunIfActive(params: {
   }
 
   if (hasEmbeddedRun && params.sessionId) {
-    abortEmbeddedAgentRun(params.sessionId);
+    abortEmbeddedAgentRun(params.sessionId, embeddedOwner);
   }
 
   clearSessionQueues([params.requestedKey, params.canonicalKey, params.sessionId]);
 
   if (hasEmbeddedRun && params.sessionId) {
-    const ended = await waitForEmbeddedAgentRunEnd(params.sessionId, 15_000);
+    const ended = await waitForEmbeddedAgentRunEnd(params.sessionId, 15_000, embeddedOwner);
     if (!ended) {
       return {
         interrupted: true,

--- a/src/gateway/server-methods/sessions-abort.ts
+++ b/src/gateway/server-methods/sessions-abort.ts
@@ -389,10 +389,15 @@ export const sessionAbortHandlers: GatewayRequestHandlers = {
             }
             // Persisted channel replies are active session work even when they
             // have no connection-owned chat controller.
-            const wasActive = persistedSessionId && isEmbeddedAgentRunActive(persistedSessionId);
+            const embeddedOwner = {
+              agentId: targetAgentId,
+              ...(stableTargetOwner ? { defaultAgentId: stableTargetOwner } : {}),
+            };
+            const wasActive =
+              persistedSessionId && isEmbeddedAgentRunActive(persistedSessionId, embeddedOwner);
             const embeddedAborted =
               persistedSessionId && canonicalKey !== "global"
-                ? abortEmbeddedAgentRun(persistedSessionId)
+                ? abortEmbeddedAgentRun(persistedSessionId, embeddedOwner)
                 : false;
             if (
               (clearQueued || canonicalKey === "global") &&

--- a/src/gateway/server-methods/sessions-lifecycle-drain.ts
+++ b/src/gateway/server-methods/sessions-lifecycle-drain.ts
@@ -78,7 +78,13 @@ function hasAuthoritativeSessionWork(
     isCompetingSessionWorkAdmissionActive(params.storePath, params.lifecycleIdentities) ||
     params.sessionKeys.some((key) => replyRunRegistry.isActive(key)) ||
     Boolean(sessionId && isReplyRunActiveForSessionId(sessionId)) ||
-    Boolean(sessionId && isEmbeddedAgentRunInProgress(sessionId)) ||
+    Boolean(
+      sessionId &&
+      isEmbeddedAgentRunInProgress(sessionId, {
+        agentId: params.agentId,
+        defaultAgentId: params.defaultAgentId,
+      }),
+    ) ||
     hasPendingFollowupQueueWork(workIdentities) ||
     workIdentities.some(
       (key) => getCommandLaneSnapshot(resolveEmbeddedSessionLane(key)).queuedCount > 0,
@@ -184,7 +190,11 @@ export async function prepareSessionLifecycleDrain(
             }
             if (params.sessionId) {
               aborted = abortReplyRunBySessionId(params.sessionId) || aborted;
-              aborted = abortEmbeddedAgentRun(params.sessionId) || aborted;
+              aborted =
+                abortEmbeddedAgentRun(params.sessionId, {
+                  agentId: params.agentId,
+                  defaultAgentId: params.defaultAgentId,
+                }) || aborted;
             }
             return aborted;
           },
@@ -209,7 +219,10 @@ export async function prepareSessionLifecycleDrain(
       ...(params.sessionId ? [waitForReplyRunEndBySessionId(params.sessionId, timeoutMs)] : []),
     ]).then((results) => results.every(Boolean));
     const embeddedWork = params.sessionId
-      ? waitForEmbeddedAgentRunEnd(params.sessionId, timeoutMs)
+      ? waitForEmbeddedAgentRunEnd(params.sessionId, timeoutMs, {
+          agentId: params.agentId,
+          defaultAgentId: params.defaultAgentId,
+        })
       : Promise.resolve(true);
     const placementService: LifecyclePlacementService | undefined =
       params.context.workerSessionPlacementService;

--- a/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
@@ -68,9 +68,12 @@ vi.mock("../../agents/embedded-agent-runner/runs.js", async () => {
   );
   return {
     ...actual,
-    abortEmbeddedAgentRun: (sessionId: string) => {
-      abortEmbeddedAgentRunMock(sessionId);
-      return actual.abortEmbeddedAgentRun(sessionId);
+    abortEmbeddedAgentRun: (
+      sessionId: string,
+      opts?: { agentId?: string; defaultAgentId?: string },
+    ) => {
+      abortEmbeddedAgentRunMock(sessionId, opts);
+      return actual.abortEmbeddedAgentRun(sessionId, opts);
     },
     isEmbeddedAgentRunInProgress: (...args: unknown[]) => isEmbeddedAgentRunInProgressMock(...args),
     resolveEmbeddedAgentRunProgressState: (...args: unknown[]) =>
@@ -579,7 +582,10 @@ describe("sessions.abort agent scope", () => {
         undefined,
       );
       expect(clearSessionQueuesMock).not.toHaveBeenCalled();
-      expect(abortEmbeddedAgentRunMock).toHaveBeenCalledWith("weixin-session");
+      expect(abortEmbeddedAgentRunMock).toHaveBeenCalledWith(
+        "weixin-session",
+        expect.objectContaining({ agentId: expect.any(String) }),
+      );
       expect(weixinOperation.abortSignal.aborted).toBe(true);
       expect(telegramOperation.abortSignal.aborted).toBe(false);
       expect(broadcastToConnIds).toHaveBeenCalledWith(
@@ -633,7 +639,10 @@ describe("sessions.abort agent scope", () => {
       );
 
       expect(clearSessionQueuesMock).not.toHaveBeenCalled();
-      expect(abortEmbeddedAgentRunMock).toHaveBeenCalledWith("weixin-session");
+      expect(abortEmbeddedAgentRunMock).toHaveBeenCalledWith(
+        "weixin-session",
+        expect.objectContaining({ agentId: expect.any(String) }),
+      );
       expect(weixinOperation.abortSignal.aborted).toBe(true);
       expect(telegramOperation.abortSignal.aborted).toBe(false);
       expect(respond).toHaveBeenCalledWith(
@@ -679,7 +688,10 @@ describe("sessions.abort agent scope", () => {
       "agent:main:openclaw-weixin:direct:queued-user",
       "queued-session",
     ]);
-    expect(abortEmbeddedAgentRunMock).toHaveBeenCalledWith("queued-session");
+    expect(abortEmbeddedAgentRunMock).toHaveBeenCalledWith(
+      "queued-session",
+      expect.objectContaining({ agentId: expect.any(String) }),
+    );
     expect(respond).toHaveBeenCalledWith(
       true,
       { ok: true, abortedRunId: null, status: "aborted" },

--- a/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.abort-agent-scope.test.ts
@@ -1,3 +1,4 @@
+/* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */
 /**
  * Tests that session abort requests stay scoped to the targeted agent.
  */

--- a/src/gateway/server-methods/sessions.embedded-abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.embedded-abort-agent-scope.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Caller-path regression: abort / interrupt / lifecycle drain must not cancel
+ * an embedded run that only shares a colliding sessionId with another agent.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EmbeddedAgentQueueHandle } from "../../agents/embedded-agent-runner/run-state.js";
+import {
+  clearActiveEmbeddedRun,
+  isEmbeddedAgentRunActive,
+  setActiveEmbeddedRun,
+} from "../../agents/embedded-agent-runner/runs.js";
+import { testing as runsTesting } from "../../agents/embedded-agent-runner/runs.test-support.js";
+import { interruptSessionRunIfActive } from "./session-run-interruption.js";
+import { sessionAbortHandlers } from "./sessions-abort.js";
+import { prepareSessionLifecycleDrain } from "./sessions-lifecycle-drain.js";
+import { createContext } from "./sessions.abort-agent-scope.test-support.js";
+import type { GatewayRequestContext, RespondFn } from "./types.js";
+
+const chatAbortMock = vi.fn();
+const loadSessionEntryMock = vi.fn();
+
+vi.mock("./chat-abort-handler.js", () => ({
+  handleChatAbortRequestWithLifecycle: (...args: unknown[]) => chatAbortMock(...args),
+}));
+
+vi.mock("../session-utils.js", async () => {
+  const actual = await vi.importActual<typeof import("../session-utils.js")>("../session-utils.js");
+  return {
+    ...actual,
+    loadSessionEntry: (...args: unknown[]) =>
+      loadSessionEntryMock(...(args as [string, { agentId?: string }?])),
+    loadGatewaySessionEntryReadOnly: (...args: unknown[]) =>
+      loadSessionEntryMock(...(args as [string, { agentId?: string }?])),
+  };
+});
+
+function createRespond(): RespondFn {
+  return vi.fn() as unknown as RespondFn;
+}
+
+function mockChatSuccess(): void {
+  chatAbortMock.mockImplementationOnce(
+    (
+      { respond }: { respond: RespondFn },
+      lifecycle?: { onAuthorizedAfterQueuedAbort?: () => boolean },
+    ) => {
+      const additionalAborted = lifecycle?.onAuthorizedAfterQueuedAbort?.() ?? false;
+      respond(
+        true,
+        additionalAborted
+          ? { ok: true, aborted: true, runIds: [] }
+          : { ok: true, aborted: false, runIds: [] },
+      );
+    },
+  );
+}
+
+function createHandle(abort = vi.fn()): EmbeddedAgentQueueHandle {
+  return {
+    runId: "run-ops-colliding",
+    abort,
+    isAborted: () => false,
+    isCompacting: () => false,
+    isStreaming: () => true,
+    queueMessage: async () => undefined,
+  };
+}
+
+describe("embedded abort agent scope (colliding sessionId)", () => {
+  const collidingSessionId = "shared-unknown-session-id";
+  const opsKey = "agent:ops:telegram:direct:ops-user";
+  const researchKey = "agent:research:telegram:direct:research-user";
+  let handle: EmbeddedAgentQueueHandle;
+  let abortSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    chatAbortMock.mockReset();
+    loadSessionEntryMock.mockReset();
+    runsTesting.resetActiveEmbeddedRuns();
+    abortSpy = vi.fn();
+    handle = createHandle(abortSpy);
+    setActiveEmbeddedRun(collidingSessionId, handle, opsKey, undefined, "ops");
+  });
+
+  afterEach(() => {
+    clearActiveEmbeddedRun(collidingSessionId, handle, opsKey);
+    runsTesting.resetActiveEmbeddedRuns();
+  });
+
+  it("sessions.abort for another agent leaves the colliding embedded run alive", async () => {
+    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+      canonicalKey: sessionKey,
+      entry: { sessionId: collidingSessionId },
+    }));
+    mockChatSuccess();
+    const respond = createRespond();
+    const context = createContext({
+      agents: [{ id: "main", default: true }, { id: "ops" }, { id: "research" }],
+      extra: { getSessionEventSubscriberConnIds: () => new Set() },
+    });
+
+    await sessionAbortHandlers["sessions.abort"]!({
+      req: { type: "req", id: "req-foreign-abort", method: "sessions.abort" },
+      params: { key: researchKey, agentId: "research" },
+      respond,
+      context,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(abortSpy).not.toHaveBeenCalled();
+    expect(isEmbeddedAgentRunActive(collidingSessionId, { agentId: "ops" })).toBe(true);
+    expect(isEmbeddedAgentRunActive(collidingSessionId, { agentId: "research" })).toBe(false);
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ ok: true }),
+      undefined,
+      undefined,
+    );
+  });
+
+  it("interruptSessionRunIfActive for another agent does not abort the colliding run", async () => {
+    const context = createContext({
+      agents: [{ id: "main", default: true }, { id: "ops" }, { id: "research" }],
+    }) as GatewayRequestContext;
+
+    const result = await interruptSessionRunIfActive({
+      req: { type: "req", id: "req-foreign-interrupt", method: "sessions.compact" } as never,
+      context,
+      client: null,
+      isWebchatConnect: () => false,
+      requestedKey: researchKey,
+      canonicalKey: researchKey,
+      agentId: "research",
+      sessionId: collidingSessionId,
+    });
+
+    expect(result).toEqual({ interrupted: false });
+    expect(abortSpy).not.toHaveBeenCalled();
+    expect(isEmbeddedAgentRunActive(collidingSessionId, { agentId: "ops" })).toBe(true);
+  });
+
+  it("prepareSessionLifecycleDrain for another agent does not abort the colliding run", async () => {
+    const context = {
+      agentRunSeq: new Map(),
+      broadcast: vi.fn(),
+      cancelRunBoundApprovals: vi.fn(),
+      chatAbortControllers: new Map(),
+      chatQueuedTurns: new Map(),
+      chatRunState: { resolveBuffer: () => ({ text: "" }) } as never,
+      dedupe: new Map(),
+      getRuntimeConfig: () => ({
+        agents: { list: [{ id: "main", default: true }, { id: "ops" }, { id: "research" }] },
+      }),
+      logGateway: { warn: vi.fn() },
+      nodeSendToSession: vi.fn(),
+      removeChatRun: vi.fn(),
+      getSessionEventSubscriberConnIds: () => new Set(),
+    } as unknown as GatewayRequestContext;
+
+    const drain = await prepareSessionLifecycleDrain({
+      action: "delete",
+      context,
+      storePath: "/tmp/openclaw-research-sessions.json",
+      sessionKeys: [researchKey],
+      sessionId: collidingSessionId,
+      agentId: "research",
+      defaultAgentId: "main",
+      sessionKey: researchKey,
+      lifecycleIdentities: [researchKey, collidingSessionId],
+    });
+
+    expect(abortSpy).not.toHaveBeenCalled();
+    expect(isEmbeddedAgentRunActive(collidingSessionId, { agentId: "ops" })).toBe(true);
+    expect(drain.hasAuthoritativeWork()).toBe(false);
+    drain.release();
+  });
+
+  it("sessions.abort for the owning agent still aborts the colliding sessionId run", async () => {
+    loadSessionEntryMock.mockImplementation((sessionKey: string) => ({
+      canonicalKey: sessionKey,
+      entry: { sessionId: collidingSessionId },
+    }));
+    mockChatSuccess();
+    const respond = createRespond();
+    const context = createContext({
+      agents: [{ id: "main", default: true }, { id: "ops" }, { id: "research" }],
+      extra: { getSessionEventSubscriberConnIds: () => new Set() },
+    });
+
+    await sessionAbortHandlers["sessions.abort"]!({
+      req: { type: "req", id: "req-owner-abort", method: "sessions.abort" },
+      params: { key: opsKey, agentId: "ops" },
+      respond,
+      context,
+      client: null,
+      isWebchatConnect: () => false,
+    });
+
+    expect(abortSpy).toHaveBeenCalledOnce();
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ ok: true, status: "aborted" }),
+      undefined,
+      undefined,
+    );
+  });
+});

--- a/src/gateway/server-methods/sessions.embedded-abort-agent-scope.test.ts
+++ b/src/gateway/server-methods/sessions.embedded-abort-agent-scope.test.ts
@@ -55,7 +55,7 @@ function mockChatSuccess(): void {
   );
 }
 
-function createHandle(abort = vi.fn()): EmbeddedAgentQueueHandle {
+function createHandle(abort: () => void = () => {}): EmbeddedAgentQueueHandle {
   return {
     runId: "run-ops-colliding",
     abort,
@@ -71,13 +71,13 @@ describe("embedded abort agent scope (colliding sessionId)", () => {
   const opsKey = "agent:ops:telegram:direct:ops-user";
   const researchKey = "agent:research:telegram:direct:research-user";
   let handle: EmbeddedAgentQueueHandle;
-  let abortSpy: ReturnType<typeof vi.fn>;
+  let abortSpy: ReturnType<typeof vi.fn<() => void>>;
 
   beforeEach(() => {
     chatAbortMock.mockReset();
     loadSessionEntryMock.mockReset();
     runsTesting.resetActiveEmbeddedRuns();
-    abortSpy = vi.fn();
+    abortSpy = vi.fn<() => void>();
     handle = createHandle(abortSpy);
     setActiveEmbeddedRun(collidingSessionId, handle, opsKey, undefined, "ops");
   });


### PR DESCRIPTION
## What Problem This Solves

`#141247` scoped list/Activity progress to the requesting agent via
`matchesSessionProgressOwner`, but abort / active / in-progress helpers used by
`sessions.abort`, `interruptSessionRunIfActive`, and `prepareSessionLifecycleDrain`
still matched by `sessionId` alone. A colliding unknown `sessionId` owned by
agent A could be cancelled when agent B aborted, interrupted, or drained.

## Why This Change Was Made

Extend the shared embedded-run owner helpers with optional
`{ agentId, defaultAgentId? }` and pass the caller’s already-resolved agent
scope through. Mismatch is a no-op / false; omitting the owner keeps today’s
sessionId-only behavior. Reuse `matchesSessionProgressOwner` so list/Activity
filtering is not regressed.

## User Impact

**Before:** Aborting or deleting a session for agent B could cancel agent A’s
live embedded run when both shared the same raw `sessionId`.

**After:** Abort / interrupt / lifecycle drain only touch embedded (and reply)
runs that match the requested agent owner.

## Evidence

- Changed: `src/agents/embedded-agent-runner/runs.ts`,
  `src/gateway/server-methods/sessions-abort.ts`,
  `src/gateway/server-methods/session-run-interruption.ts`,
  `src/gateway/server-methods/sessions-lifecycle-drain.ts`,
  `src/gateway/server-methods/sessions.embedded-abort-agent-scope.test.ts`,
  `src/gateway/server-methods/sessions.abort-agent-scope.test.ts`
- Production path: `sessions.abort` / `interruptSessionRunIfActive` /
  `prepareSessionLifecycleDrain` → owner-scoped
  `isEmbeddedAgentRunActive` / `abortEmbeddedAgentRun` /
  `isEmbeddedAgentRunInProgress` (+ owner-aware wait)
- Compatibility: callers that omit owner keep prior sessionId-only semantics
- Dedup: open `#95700` touches `runs.ts` for `preserveReplyRun` (different
  invariant); no open PR owns abort agent-scope filtering

## Real behavior proof

### Behavior or issue addressed

Colliding unknown `sessionId` registered to agent `ops` is left alive when
agent `research` runs `sessions.abort`, `interruptSessionRunIfActive`, or
`prepareSessionLifecycleDrain`; the owning agent’s abort still cancels it.

### Canonical reachability path

Gateway `sessions.abort` / checkpoint interrupt /
archive-delete drain → optional owner on shared embedded-run helpers →
`matchesSessionProgressOwner` against `ACTIVE_EMBEDDED_RUN_REGISTRATIONS.agentId`

### Shared helper / provider constraint check

Owner filter lives only in `runs.ts` (shared owner). Callers pass existing
`agentId` / `defaultAgentId`; no duplicate caller-side cleanup; list/Activity
`matchesSessionProgressOwner` path unchanged.

### Real environment tested

Local trusted source checkout at PR head; Vitest gateway-methods project;
real `setActiveEmbeddedRun` registry + production callers (abort / interrupt /
drain).

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/gateway/server-methods/sessions.embedded-abort-agent-scope.test.ts --reporter=verbose
```

### Evidence after fix

```text
[test] starting test/vitest/vitest.gateway.config.ts

 RUN  v5.0.0 /workspace/openclaw-nocodet

[vitest-workers] prepared 545350e120e1 in 5293ms (8597 inputs, 4304 outputs)
 ✓ |gateway-methods| src/gateway/server-methods/sessions.embedded-abort-agent-scope.test.ts > embedded abort agent scope (colliding sessionId) > sessions.abort for another agent leaves the colliding embedded run alive 15ms
 ✓ |gateway-methods| src/gateway/server-methods/sessions.embedded-abort-agent-scope.test.ts > embedded abort agent scope (colliding sessionId) > interruptSessionRunIfActive for another agent does not abort the colliding run 3ms
 ✓ |gateway-methods| src/gateway/server-methods/sessions.embedded-abort-agent-scope.test.ts > embedded abort agent scope (colliding sessionId) > prepareSessionLifecycleDrain for another agent does not abort the colliding run 8ms
 ✓ |gateway-methods| src/gateway/server-methods/sessions.embedded-abort-agent-scope.test.ts > embedded abort agent scope (colliding sessionId) > sessions.abort for the owning agent still aborts the colliding sessionId run 4ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  17:10:50
   Duration  11.84s (transform 75%, import 21%, worker 3%, setup 1%)

[vitest-workers] verifying completed generation before cleanup
[test] passed 1 Vitest shard in 14.05s
```

### Observed result after fix

All four caller-path cases passed: foreign abort / interrupt / drain leave the
ops-owned colliding run alive; owning-agent abort still cancels it.

### What was not tested

No full Gateway WebSocket client session; proof uses production gateway
handlers / helpers in-process with a seeded embedded-run registry.

### Fix classification

Root cause fix.

## Checklist

- [x] AI-assisted
- [x] Allow edits from maintainers
- [x] Single concern / single commit
- [x] No CHANGELOG.md edit
