### PR TITLE
fix(ollama): preserve reasoning in tool follow-ups

### DIFF
--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -1069,6 +1069,11 @@ For full setup and behavior, see [Ollama Web Search](/tools/ollama-search).
     `thinking` capability expose `/think low`, `/think medium`, `/think high`,
     and `/think max`; non-thinking models expose only `/think off`.
 
+    When replaying an assistant message, native requests retain its available
+    reasoning in Ollama's separate `thinking` field alongside text and tool
+    calls. This lets tool follow-ups reuse reasoning retained by the session's
+    history policy without mixing it into visible answer text.
+
     ```bash
     openclaw agent --model ollama/gemma4 --thinking off
     openclaw agent --model ollama/gemma4 --thinking low

--- a/extensions/ollama/src/stream-runtime.test.ts
+++ b/extensions/ollama/src/stream-runtime.test.ts
@@ -664,16 +664,20 @@ describe("convertToOllamaMessages", () => {
     });
   });
 
-  it("converts assistant messages with toolCall content blocks", () => {
+  it("preserves assistant thinking alongside text and tool calls", () => {
     const result = convertAssistantContent([
+      { type: "thinking", thinking: "Check the directory.\n" },
+      { type: "thinking", thinking: "Then report its contents." },
+      { type: "thinking", thinking: "redacted reasoning", redacted: true },
       { type: "text", text: "Let me check." },
       { type: "toolCall", id: "call_1", name: "bash", arguments: { command: "ls" } },
     ]);
-    expect(requireEntry(result, 0, "first converted Ollama message").role).toBe("assistant");
-    expect(requireEntry(result, 0, "first converted Ollama message").content).toBe("Let me check.");
-    expect(requireEntry(result, 0, "first converted Ollama message").tool_calls).toEqual([
-      { id: "call_1", function: { name: "bash", arguments: { command: "ls" } } },
-    ]);
+    expect(requireEntry(result, 0, "first converted Ollama message")).toEqual({
+      role: "assistant",
+      content: "Let me check.",
+      thinking: "Check the directory.\nThen report its contents.",
+      tool_calls: [{ id: "call_1", function: { name: "bash", arguments: { command: "ls" } } }],
+    });
   });
 
   it("preserves assistant tool-call ids before Ollama replay", () => {

--- a/extensions/ollama/src/stream.runtime.ts
+++ b/extensions/ollama/src/stream.runtime.ts
@@ -390,6 +390,7 @@ interface OllamaChatRequest {
 interface OllamaChatMessage {
   role: "system" | "user" | "assistant" | "tool";
   content: string;
+  thinking?: string;
   images?: string[];
   tool_calls?: OllamaToolCall[];
   tool_name?: string;
@@ -469,6 +470,7 @@ function estimateOllamaPromptTokens(params: {
   let chars = 0;
   for (const message of params.messages) {
     chars += estimateStringChars(message.content);
+    chars += message.thinking ? estimateStringChars(message.thinking) : 0;
     chars += safeJsonLength(message.images);
     chars += safeJsonLength(message.tool_calls);
     chars += message.tool_name ? estimateStringChars(message.tool_name) : 0;
@@ -511,6 +513,7 @@ function resolveOptionalUsageCount(value: number | undefined): number | undefine
 
 type InputContentPart =
   | { type: "text"; text: string }
+  | ThinkingContent
   | { type: "image"; data: string }
   | { type: "toolCall"; id: string; name: string; arguments: unknown }
   | { type: "tool_use"; id: string; name: string; input: unknown };
@@ -535,6 +538,22 @@ function extractOllamaImages(content: unknown): string[] {
   return (content as InputContentPart[])
     .filter((part): part is { type: "image"; data: string } => part.type === "image")
     .map((part) => part.data);
+}
+
+function extractOllamaThinking(content: unknown): string {
+  if (!Array.isArray(content)) {
+    return "";
+  }
+  return content
+    .filter(
+      (part): part is ThinkingContent =>
+        isRecord(part) &&
+        part.type === "thinking" &&
+        typeof part.thinking === "string" &&
+        !part.redacted,
+    )
+    .map((part) => part.thinking)
+    .join("");
 }
 
 function ensureArgsObject(value: unknown): Record<string, unknown> {
@@ -755,10 +774,12 @@ export function convertToOllamaMessages(
 
     if (msg.role === "assistant") {
       const text = extractTextContent(msg.content);
+      const thinking = extractOllamaThinking(msg.content);
       const toolCalls = extractToolCalls(msg.content, options);
       result.push({
         role: "assistant",
         content: text,
+        ...(thinking ? { thinking } : {}),
         ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {}),
       });
       continue;


### PR DESCRIPTION
Closes #141356.

## What Problem This Solves

Native Ollama tool follow-ups discard the reasoning retained from the preceding assistant tool call. This removes part of the model's own response before it receives the tool result, even though Ollama's tool-calling protocol supports a separate `thinking` field.

## Why This Change Was Made

Preserve non-redacted assistant thinking alongside visible text and tool calls when projecting native requests. Include it in fallback prompt-usage estimates when the server omits counters. Existing session history policy still decides which reasoning is retained.

## User Impact

Reasoning-capable Ollama models receive the retained context of their tool calls without mixing it into visible answer text. No configuration change is required.

## Evidence

- Extended the existing replay regression: baseline fails with the missing `thinking` field while 194 other tests pass; final candidate passes all 233 tests across the transport and sibling stream suites.
- Real isolated Ollama 0.33.3 with `qwen3:0.6b`: the first production-stream response emitted 905 reasoning characters plus tool calls. The patched follow-up preserved those bytes exactly in the native request, with ordinary history cleanup and a read-only payload observer, and returned the correct synthetic temperature answer.
- The controlled trial generated 198 follow-up tokens before and 117 after, with increased prompt input and effectively unchanged cache counters. This single prompt does not establish a general speed or quality improvement.
- Owned model, daemon and runner were stopped; the test port is closed. Full `node scripts/check-changed.mjs` passed, including production/test typechecking, lint, formatting, unused-export analysis and repository guards. Final independent review found no actionable P0–P2 findings.
