### PR TITLE
refactor: deslop prompt-cache landing surface

### DIFF
--- a/extensions/amazon-bedrock/bedrock-options.ts
+++ b/extensions/amazon-bedrock/bedrock-options.ts
@@ -12,7 +12,6 @@ import type {
 } from "openclaw/plugin-sdk/llm";
 import { resolveClaudeModelIdentity } from "openclaw/plugin-sdk/provider-model-shared";
 
-/** Share explicit-cache capabilities between registration and payload construction. */
 export function resolveBedrockPromptCachePolicy(
   model: Pick<Model, "id" | "params"> & { name?: string },
 ): "nova" | "claude" | undefined {

--- a/packages/ai/src/providers/anthropic.ts
+++ b/packages/ai/src/providers/anthropic.ts
@@ -98,7 +98,6 @@ const INTERLEAVED_THINKING_BETA = "interleaved-thinking-2025-05-14";
 const ANTHROPIC_MIN_THINKING_BUDGET_TOKENS = 1024;
 
 function getAnthropicCompat(model: Model<"anthropic-messages">) {
-  // Auto-detect session affinity and tool streaming support from provider.
   const isFireworks = model.provider === "fireworks";
   const isCloudflareAiGatewayAnthropic =
     model.provider === "cloudflare-ai-gateway" && model.baseUrl.includes("anthropic");

--- a/packages/ai/src/transports/anthropic-payload-policy.ts
+++ b/packages/ai/src/transports/anthropic-payload-policy.ts
@@ -173,7 +173,6 @@ export function resolveAnthropicEphemeralCacheControl(
   return { type: "ephemeral", ...(ttl ? { ttl } : {}) };
 }
 
-/** Resolve the same cache capabilities and TTL for both Messages entry points. */
 export function resolveAnthropicCacheOptions(
   model: Model<"anthropic-messages">,
   cacheRetention?: "short" | "long" | "none",

--- a/packages/ai/src/transports/openai-completions-cache-control.ts
+++ b/packages/ai/src/transports/openai-completions-cache-control.ts
@@ -30,10 +30,6 @@ export function resolveCompletionsCacheControl(
   };
 }
 
-function contentBlocks(message: Record<string, unknown>): Record<string, unknown>[] {
-  return Array.isArray(message.content) ? message.content.filter(isRecord) : [];
-}
-
 /** Shared Chat Completions policy; repeated wrapper application preserves existing checkpoints. */
 export function applyCompletionsAnthropicCacheControl(
   payload: Record<string, unknown>,
@@ -48,7 +44,9 @@ export function applyCompletionsAnthropicCacheControl(
   shapedPayloads.add(payload);
   const messages = Array.isArray(payload.messages) ? payload.messages : [];
   const tools = Array.isArray(payload.tools) ? payload.tools.filter(isRecord) : [];
-  const blocks = messages.filter(isRecord).flatMap(contentBlocks);
+  const blocks = messages
+    .filter(isRecord)
+    .flatMap((message) => (Array.isArray(message.content) ? message.content.filter(isRecord) : []));
   // This policy owns at most three breakpoints: tools, stable system, history.
   for (const block of [...tools, ...blocks]) {
     delete block.cache_control;

--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
@@ -126,10 +126,7 @@ export async function submitEmbeddedAttemptPrompt(input: {
           input.toolResultAggregateMaxChars,
           input.toolResultPromptProjectionState,
         );
-        const providerMessages =
-          providerPromptHistoryTruncation.messages !== messages
-            ? providerPromptHistoryTruncation.messages
-            : messages;
+        const providerMessages = providerPromptHistoryTruncation.messages;
         if (providerPromptHistoryTruncation.aggregateTruncatedCount > 0) {
           recordAggregateTruncation(attempt);
         }

--- a/src/agents/runtime-facts-prompt.ts
+++ b/src/agents/runtime-facts-prompt.ts
@@ -1,5 +1,5 @@
-import path from "node:path";
 /** Compact current-turn snapshots; instructions belong in the stable system prompt. */
+import path from "node:path";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadExecApprovals, resolveExecApprovalsFromFile } from "../infra/exec-approvals.js";
@@ -44,12 +44,7 @@ function buildApprovedExecutablesRuntimeContext(agentId: string): string {
     const hints = allowlist
       .flatMap((entry) => {
         const pattern = entry.pattern.trim();
-        if (
-          !pattern ||
-          pattern === "*" ||
-          pattern.startsWith("=command:") ||
-          !/[\\/~]/.test(pattern)
-        ) {
+        if (pattern.startsWith("=command:") || !/[\\/~]/.test(pattern)) {
           return [];
         }
         // Keep absolute approval tokens exact; a basename can resolve to another binary.


### PR DESCRIPTION
Related: #140781, #140804, #140799, #141077, #141090, #141060.

<details>
<summary>Additional instructions</summary>

Maintainer-requested cleanup of the landed prompt-cache program. This branch is in the upstream repository and remains available for maintainer edits. The coordinator will review and land it separately.

</details>

## What Problem This Solves

The prompt-cache landings left a few redundant expressions, a one-use helper, and comments that repeat the surrounding code. They add review overhead to code whose request bytes and replay ordering must stay stable.

## Why This Change Was Made

Review the hunks from all 21 requested landings and apply only trivial, behavior-preserving cleanup. Inline the content-block filter, remove a message-array comparison that returns the same value either way, and drop two executable-hint checks already covered by the path-character test. Remove three narrative comments and move the runtime-facts module comment above its imports. Every removed or replaced line was verified against the allowed commit SHAs.

The diff is six production files, +6/-19 lines. Payload guards, lifecycle ordering, compatibility policy, and persistence remain unchanged. The Completions builders already share their request builder, so no further extraction is needed here.

## User Impact

No user-visible behavior change. Prompt text, cache markers, schemas, configuration, and snapshots are unchanged; no docs or changelog update is needed.

## Evidence

Focused validation:

```text
node scripts/run-vitest.mjs \
  src/agents/runtime-facts-prompt.test.ts \
  src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts \
  src/agents/embedded-agent-runner/run/attempt-prompt-submit.projections.test.ts \
  packages/ai/src/transports/openai-completions-cache-markers.test.ts \
  packages/ai/src/providers/anthropic.test.ts \
  packages/ai/src/transports/anthropic-payload-policy.test.ts \
  packages/ai/src/anthropic-cache-transport-parity.test.ts \
  extensions/amazon-bedrock/index.test.ts

8 files passed; 272 tests passed; 5 Vitest shards in 712.81s; exit 0.
```

Codex autoreview against the branch merge base, high reasoning, P1 threshold: `scoped-clean`; zero accepted/actionable P0/P1 findings. Final summary: the changes preserve behavior by removing comments, inlining a helper, simplifying an equivalent assignment, and removing checks already covered by the path-character test.

`git diff --check` passed. An optional pre-edit baseline run was interrupted after roughly ten minutes in setup without completing a test; the complete final focused run above passed. No tests were added or changed because this refactor has no behavioral defect to reproduce.

Changed-file gate: `node scripts/check-changed.mjs` ran with a separate Vitest module cache and exited 1 at extension lint declaration preparation: `Declaration input escapes checkout` for `qrcode@1.5.4` through the ancestor install. This is the known nested-checkout limitation identified in the work order; CI is authoritative for that lane. All preceding checks passed, including formatting, four production/test typecheck lanes, core lint, six doctor-contract tests, and all dead-export scans. Guards scheduled after extension lint were not reached locally. No dependency, baseline, or boundary guard was changed.

Nontrivial candidates intentionally left unchanged: shared fixture casts in the context-guard, request-observation, and Bedrock tests; the xAI provider-output cast whose replacement could change malformed-input behavior; and the Bedrock capture helper's empty-message fallback. These need a separate contract review, not deletion in this cleanup.

Exact-head CI is green: [run 34147230391](https://github.com/openclaw/openclaw/actions/runs/34147230391) completed successfully for `c0edb5a35817f51a8734e9db4a0bf0e902923307`. The bounded watcher ended with `STATUS state=SUCCESS pending=0` and `GREEN`. [ClawSweeper's completed current-head review](https://github.com/openclaw/openclaw/pull/141385#issuecomment-5573956136) found no actionable correctness or security defects and marked this ready for maintainer review. No merge was performed.
