### PR TITLE
test(plugins): assert the slot registry selection contract

### DIFF
--- a/src/plugins/install-persistence.enablement.test.ts
+++ b/src/plugins/install-persistence.enablement.test.ts
@@ -139,7 +139,9 @@ describe("persistPluginInstall enablement", () => {
     }) => {
       expect(params.selectedId).toBe("legacy-memory");
       expect(params.selectedKind).toBe("memory");
-      expect(params.registry?.plugins).toEqual([{ id: "legacy-memory", kind: "memory" }]);
+      expect(params.registry?.plugins.map(({ id, kind }) => ({ id, kind }))).toEqual([
+        { id: "legacy-memory", kind: "memory" },
+      ]);
       return {
         config: {
           ...params.config,
@@ -215,7 +217,9 @@ describe("persistPluginInstall enablement", () => {
     }) => {
       expect(params.selectedId).toBe("memory-b");
       expect(params.selectedKind).toBe("memory");
-      expect(params.registry?.plugins).toEqual([{ id: "memory-b", kind: "memory" }]);
+      expect(params.registry?.plugins.map(({ id, kind }) => ({ id, kind }))).toEqual([
+        { id: "memory-b", kind: "memory" },
+      ]);
       return {
         config: {
           ...params.config,


### PR DESCRIPTION
## What Problem This Solves

Resolves two plugin-install enablement test failures that reject valid slot registries merely because their selected records retain full manifest metadata. This maintainer-requested test-contract repair follows up the baseline failures recorded in https://github.com/openclaw/openclaw/pull/141358.

## Why This Change Was Made

Compare the registry's exact ordered `id`/`kind` projection instead of requiring all other manifest fields to be absent. https://github.com/openclaw/openclaw/pull/140842 intentionally retained the selected manifest for origin inspection; production metadata must not be stripped to satisfy these assertions.

Exact array equality still rejects missing, extra, duplicate, wrong-ID, and wrong-kind records. Every other assertion, fixture, and mock is unchanged, including narrow runtime diagnostics, cold metadata behavior, sibling enablement, and final slot selection. No new tests or call-count assertions were added.

## User Impact

No runtime or user-facing behavior changes. Maintainers can validate plugin-install slot selection without coupling the tests to incidental manifest shape.

## Evidence

- Fresh baseline `7600a4f571b10aaba679dba0f61100ea8c75fc5e`: `node scripts/run-vitest.mjs src/plugins/install-persistence.enablement.test.ts` reproduced **7 passed, 2 failed**. Both failures received the expected singleton ID/kind plus full manifest fields and the install-owner Symbol:
  - `scopes runtime kind lookup to the selected plugin when metadata omits kind`
  - `uses cold metadata for manifest-kind slot selection without loading runtime siblings`
- After the two-operand correction, `node scripts/run-vitest.mjs src/plugins/install-persistence.enablement.test.ts src/plugins/slots.test.ts src/plugins/status.runtime-inspection.test.ts` passed **45 tests**: enablement **9**, slots **21**, runtime inspection **15**.
- Production diff: **0 lines**. Test diff: **6 added, 2 removed**, in one file.
- Scoped formatting, lint, and `git diff --check` passed. Fresh independent autoreview was scoped-clean through P2.
- Scoped changed checks passed preliminary formatting, ratchet, dependency, plugin-boundary, graph-boundary, and coercion/deprecation guards. The initial run skipped the typecheck and stopped at dead-export analysis because this sparse worktree omitted UI config and package-local dependency links. After exposing those existing paths without installing or changing dependencies, the focused dead-export retry passed all three scans with zero entries; scoped lint also passed.
- A direct, non-skipping local typecheck stops at the guard rejecting the externally symlinked compiler. Local typechecking is not claimed as passed. Exact-head CI completed successfully at `bf9e68a68575eb3e4abf30cd330c31b63cb6b6ce`: https://github.com/openclaw/openclaw/actions/runs/34147303344, with **26 jobs passed, 20 intentionally scope-selected skipped, zero failed**. Hosted `check-prod-types` (job `101822173215`) and `check-test-types` (job `101822173232`) both passed.
- Hosted job `101822173094` (`checks-node-changed`) passed: https://github.com/openclaw/openclaw/actions/runs/34147303344/job/101822173094. Its retained log explicitly runs `src/plugins/install-persistence.enablement.test.ts` through `vitest.plugins.config.ts`, names both formerly failing cases as passed, reports **9 passed (9)**, and ends that shard with exit 0. This is direct file-level evidence, not an inference from the aggregate CI result.
- The earlier compact CI selector omitted this unchanged release-only plugin test file for the production-only change, rather than executing and passing these cases. The earlier run was https://github.com/openclaw/openclaw/actions/runs/34144724944, preflight job https://github.com/openclaw/openclaw/actions/runs/34144724944/job/101814148743. This PR directly changes the test file, and the hosted job above executed all nine cases.
- The existing singleton metadata fixtures do not establish filtering among multiple metadata siblings; this repair does not claim new coverage there.
- Native `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 141386` accepted the hosted CI/Testbox evidence at the same reviewed head without a rebase or push. No remote lease or live-provider test has been run.
- ClawSweeper's completed review of the same head reported no actionable findings or before-merge actions: https://github.com/openclaw/openclaw/pull/141386#issuecomment-5573996488.
- Landed through the native squash workflow as `6aa09cbadb594c3d46d5bd49a28c514df1b256b0`. The retained native outcome is complete and accepted. Remote merge state, main ancestry, and the exact landed patch were verified; the current-main test blob matches the reviewed head (`a233906e744c4c1a9bb14a4aa98eb550f66d97e0`).
