### PR TITLE
fix(gateway): trim approval.get/resolve id before exact lookup

### DIFF
--- a/src/gateway/operator-approvals-client.e2e.test.ts
+++ b/src/gateway/operator-approvals-client.e2e.test.ts
@@ -321,4 +321,93 @@ describe("operator approval gateway client e2e", () => {
     expect(validateApprovalHistoryResult(history)).toBe(true);
     expect(history.items).toContainEqual(allowResult.approval);
   }, 120_000);
+
+  it("looks up and denies a live approval when approval.get/resolve receive a padded id", async () => {
+    const envSnapshot = captureEnv(TEST_ENV_KEYS);
+    cleanup.push(() => envSnapshot.restore());
+    deleteTestEnvValue("OPENCLAW_CONFIG_PATH");
+    deleteTestEnvValue("OPENCLAW_GATEWAY_URL");
+    deleteTestEnvValue("OPENCLAW_GATEWAY_TOKEN");
+    deleteTestEnvValue("OPENCLAW_GATEWAY_PASSWORD");
+
+    const tempHome = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-approval-id-trim-e2e-"));
+    cleanup.push(() => fs.rm(tempHome, { recursive: true, force: true, maxRetries: 5 }));
+
+    const stateDir = path.join(tempHome, ".openclaw");
+    await fs.mkdir(stateDir, { recursive: true });
+    setTestEnvValue("HOME", tempHome);
+    setTestEnvValue("OPENCLAW_STATE_DIR", stateDir);
+    configureManualGatewayBackgroundEnv(tempHome);
+
+    const requesterIdentity = loadOrCreateDeviceIdentity({
+      path: path.join(stateDir, "test-device-identities", "approval-trim-requester.sqlite"),
+    });
+    const reviewerIdentity = loadOrCreateDeviceIdentity({
+      path: path.join(stateDir, "test-device-identities", "approval-trim-reviewer.sqlite"),
+    });
+    expect(requesterIdentity.deviceId).not.toBe(reviewerIdentity.deviceId);
+
+    const port = await getGatewayE2ePortBlock();
+    const token = "approval-id-trim-e2e-token";
+    const url = `ws://127.0.0.1:${port}`;
+    setTestEnvValue("OPENCLAW_GATEWAY_PORT", String(port));
+
+    const server = await startGatewayServer(port, {
+      bind: "loopback",
+      auth: { mode: "token", token },
+      controlUiEnabled: false,
+      sidecarStartup: "defer",
+    });
+    cleanup.push(() => server.close());
+
+    const requester = await connectGatewayClient({
+      url,
+      token,
+      clientDisplayName: "approval trim requester",
+      scopes: [APPROVALS_SCOPE],
+      deviceIdentity: requesterIdentity,
+      timeoutMs: 60_000,
+    });
+    cleanup.push(() => disconnectGatewayClient(requester));
+
+    const reviewer = await connectGatewayClient({
+      url,
+      token,
+      clientDisplayName: "approval trim reviewer",
+      scopes: [APPROVALS_SCOPE],
+      deviceIdentity: reviewerIdentity,
+      timeoutMs: 60_000,
+    });
+    cleanup.push(() => disconnectGatewayClient(reviewer));
+
+    const approvalId = "padded-approval-gateway-lookup";
+    await requestExecApproval({ requester, id: approvalId });
+
+    const paddedId = ` ${approvalId} `;
+    const pending = await reviewer.request<ApprovalGetResult>("approval.get", { id: paddedId });
+    expect(validateApprovalGetResult(pending)).toBe(true);
+    expect(pending.approval).toMatchObject({
+      id: approvalId,
+      status: "pending",
+      presentation: { kind: "exec" },
+    });
+
+    const denied = await reviewer.request<ApprovalResolveResult>("approval.resolve", {
+      id: paddedId,
+      kind: "exec",
+      decision: "deny",
+    });
+    expect(validateApprovalResolveResult(denied)).toBe(true);
+    expect(denied).toMatchObject({
+      applied: true,
+      approval: { id: approvalId, status: "denied", decision: "deny" },
+    });
+
+    const terminal = await requester.request<ApprovalGetResult>("approval.get", { id: paddedId });
+    expect(validateApprovalGetResult(terminal)).toBe(true);
+    expect(terminal.approval).toEqual(denied.approval);
+    console.log(
+      `[approval id trim Gateway client E2E] get_ok=true resolve_denied=true padded=${JSON.stringify(paddedId)} exact=${approvalId}`,
+    );
+  }, 120_000);
 });

--- a/src/gateway/server-methods/approval.test.ts
+++ b/src/gateway/server-methods/approval.test.ts
@@ -856,6 +856,221 @@ describe("unified approval handlers", () => {
     expect(response.error).toMatchObject({ code: "INVALID_REQUEST" });
   });
 
+  it("looks up and resolves a live approval when approval.get/resolve receive a padded id", async () => {
+    const databaseOptions = createDatabaseOptions();
+    const managers = createManagers(databaseOptions);
+    const pending = registerExec(managers.exec, { id: "padded-approval-lookup" });
+    const handlers = createApprovalHandlers({
+      execApprovalManager: managers.exec,
+      pluginApprovalManager: managers.plugin,
+      databaseOptions,
+    });
+    const paddedId = ` ${pending.record.id} `;
+
+    // Negative control: live Map lookup is exact and misses clipboard padding.
+    expect(managers.exec.getLiveSnapshot(paddedId)).toBeNull();
+
+    const got = await invoke({
+      handlers,
+      method: "approval.get",
+      body: { id: paddedId },
+      client: createClient({ deviceId: "reviewer" }),
+    });
+    expect(got.ok).toBe(true);
+    expect(got.result).toMatchObject({
+      approval: { id: pending.record.id, status: "pending" },
+    });
+
+    const resolved = await invoke({
+      handlers,
+      method: "approval.resolve",
+      body: { id: paddedId, kind: "exec", decision: "deny" },
+      client: createClient({ deviceId: "reviewer" }),
+    });
+    expect(resolved.ok).toBe(true);
+    expect(resolved.result).toMatchObject({
+      applied: true,
+      approval: { id: pending.record.id, status: "denied", decision: "deny" },
+    });
+    await expect(pending.decision).resolves.toBe("deny");
+  });
+
+  it("prefers an exact whitespace-bearing approval id over the trimmed spelling", async () => {
+    const databaseOptions = createDatabaseOptions();
+    const managers = createManagers(databaseOptions);
+    const nowMs = Date.now();
+    insertOperatorApproval({
+      approval: {
+        id: " approval-edge ",
+        kind: "exec",
+        presentation: {
+          kind: "exec",
+          commandText: "exact padded key",
+          allowedDecisions: ["allow-once", "deny"],
+        },
+        runtimeEpoch: "approval-handler-test",
+        createdAtMs: nowMs,
+        expiresAtMs: nowMs + 60_000,
+        reviewerDeviceIds: ["reviewer"],
+      },
+      databaseOptions,
+    });
+    insertOperatorApproval({
+      approval: {
+        id: "approval-edge",
+        kind: "exec",
+        presentation: {
+          kind: "exec",
+          commandText: "trimmed fallback key",
+          allowedDecisions: ["allow-once", "deny"],
+        },
+        runtimeEpoch: "approval-handler-test",
+        createdAtMs: nowMs + 1,
+        expiresAtMs: nowMs + 60_000,
+        reviewerDeviceIds: ["reviewer"],
+      },
+      databaseOptions,
+    });
+    const handlers = createApprovalHandlers({
+      execApprovalManager: managers.exec,
+      pluginApprovalManager: managers.plugin,
+      databaseOptions,
+    });
+
+    const got = await invoke({
+      handlers,
+      method: "approval.get",
+      body: { id: " approval-edge " },
+      client: createClient({ deviceId: "reviewer" }),
+    });
+    expect(got.ok).toBe(true);
+    expect(got.result).toMatchObject({
+      approval: { id: " approval-edge ", status: "pending" },
+    });
+    expect(
+      (got.result as { approval?: { presentation?: { commandText?: string } } }).approval,
+    ).toMatchObject({ presentation: { commandText: "exact padded key" } });
+  });
+
+  it("does not fall back to the trimmed approval when the exact padded id is unauthorized", async () => {
+    const databaseOptions = createDatabaseOptions();
+    const managers = createManagers(databaseOptions);
+    const nowMs = Date.now();
+    insertOperatorApproval({
+      approval: {
+        id: " approval-edge ",
+        kind: "exec",
+        presentation: {
+          kind: "exec",
+          commandText: "exact padded key",
+          allowedDecisions: ["allow-once", "deny"],
+        },
+        runtimeEpoch: "approval-handler-test",
+        createdAtMs: nowMs,
+        expiresAtMs: nowMs + 60_000,
+        reviewerDeviceIds: ["other-reviewer"],
+      },
+      databaseOptions,
+    });
+    insertOperatorApproval({
+      approval: {
+        id: "approval-edge",
+        kind: "exec",
+        presentation: {
+          kind: "exec",
+          commandText: "trimmed fallback key",
+          allowedDecisions: ["allow-once", "deny"],
+        },
+        runtimeEpoch: "approval-handler-test",
+        createdAtMs: nowMs + 1,
+        expiresAtMs: nowMs + 60_000,
+        reviewerDeviceIds: ["reviewer"],
+      },
+      databaseOptions,
+    });
+    const handlers = createApprovalHandlers({
+      execApprovalManager: managers.exec,
+      pluginApprovalManager: managers.plugin,
+      databaseOptions,
+    });
+
+    const got = await invoke({
+      handlers,
+      method: "approval.get",
+      body: { id: " approval-edge " },
+      client: createClient({ deviceId: "reviewer" }),
+    });
+    expect(got.ok).toBe(false);
+    expect(got.error).toMatchObject({ code: "INVALID_REQUEST" });
+  });
+
+  it("does not fall back to the trimmed approval when the exact padded id is corrupt", async () => {
+    const databaseOptions = createDatabaseOptions();
+    const managers = createManagers(databaseOptions);
+    const nowMs = Date.now();
+    insertOperatorApproval({
+      approval: {
+        id: " approval-edge ",
+        kind: "exec",
+        presentation: {
+          kind: "exec",
+          commandText: "exact padded key",
+          allowedDecisions: ["allow-once", "deny"],
+        },
+        runtimeEpoch: "approval-handler-test",
+        createdAtMs: nowMs,
+        expiresAtMs: nowMs + 60_000,
+        reviewerDeviceIds: ["reviewer"],
+      },
+      databaseOptions,
+    });
+    corruptDurableApprovalPresentation(databaseOptions, " approval-edge ");
+    const trimmed = registerExec(managers.exec, { id: "approval-edge" });
+    const handlers = createApprovalHandlers({
+      execApprovalManager: managers.exec,
+      pluginApprovalManager: managers.plugin,
+      databaseOptions,
+    });
+    const client = createClient({ deviceId: "reviewer" });
+
+    const got = await invoke({
+      handlers,
+      method: "approval.get",
+      body: { id: " approval-edge " },
+      client,
+    });
+    expect(got.ok).toBe(false);
+    expect(got.error).toMatchObject({ code: "INVALID_REQUEST" });
+
+    const resolved = await invoke({
+      handlers,
+      method: "approval.resolve",
+      body: { id: " approval-edge ", kind: "exec", decision: "deny" },
+      client,
+    });
+    expect(resolved.ok).toBe(false);
+    expect(resolved.error).toMatchObject({ code: "INVALID_REQUEST" });
+    const neighborLive = managers.exec.getLiveSnapshot(trimmed.record.id);
+    expect(neighborLive).toMatchObject({ id: trimmed.record.id });
+    expect(neighborLive).not.toHaveProperty("terminalReason");
+    let neighborSettled = false;
+    void trimmed.decision.then(() => {
+      neighborSettled = true;
+    });
+    await Promise.resolve();
+    expect(neighborSettled).toBe(false);
+    const neighbor = await invoke({
+      handlers,
+      method: "approval.get",
+      body: { id: trimmed.record.id },
+      client,
+    });
+    expect(neighbor.ok).toBe(true);
+    expect(neighbor.result).toMatchObject({
+      approval: { id: trimmed.record.id, status: "pending" },
+    });
+  });
+
   it.for(["approval.get", "approval.resolve"] as const)(
     "returns sanitized UNAVAILABLE when %s cannot read durable state",
     async (method, testContext) => {

--- a/src/gateway/server-methods/approval.ts
+++ b/src/gateway/server-methods/approval.ts
@@ -111,57 +111,44 @@ function respondApprovalNotFound(respond: RespondFn): void {
   );
 }
 
-function readExactApprovalId(params: unknown): string | null {
+function readApprovalRequestId(params: unknown): string | null {
   if (!isRecord(params) || typeof params.id !== "string") {
     return null;
   }
-  const id = params.id;
-  return isWellFormedApprovalId(id) ? id : null;
+  const raw = params.id;
+  if (isWellFormedApprovalId(raw)) {
+    return raw;
+  }
+  const trimmed = normalizeOptionalString(raw);
+  return trimmed && isWellFormedApprovalId(trimmed) ? raw : null;
 }
 
-function loadVisibleApproval(params: {
-  id: string;
-  client: GatewayClient | null;
-  cfg: OpenClawConfig;
-  allowApprovalRuntime?: boolean;
-  allowTransportRef?: boolean;
-  execApprovalManager: ExecApprovalManager;
-  pluginApprovalManager: ExecApprovalManager<PluginApprovalRequestPayload>;
-  systemAgentApprovalManager?: ExecApprovalManager<SystemAgentApprovalRequestPayload>;
-  databaseOptions?: OpenClawStateDatabaseOptions;
-}): OperatorApprovalRecord | null {
-  // Reconciliation can settle a live waiter, so authorization must precede
-  // every durable read and no unauthorized lookup may reach the bridge.
-  const authorized = params.allowApprovalRuntime
-    ? canResolveOperatorApproval(params.client)
-    : canReviewOperatorApproval(params.client);
-  if (!authorized) {
-    return null;
-  }
+function loadVisibleApprovalForId(
+  params: Parameters<typeof loadVisibleApproval>[0],
+):
+  | { status: "found"; record: OperatorApprovalRecord }
+  | { status: "denied" }
+  | { status: "missing" } {
   const liveRecord =
     params.execApprovalManager.getLiveSnapshot(params.id) ??
     params.pluginApprovalManager.getLiveSnapshot(params.id) ??
     params.systemAgentApprovalManager?.getLiveSnapshot(params.id);
-  if (
-    liveRecord &&
-    !canAccessApprovalSession({
-      cfg: params.cfg,
-      client: params.client,
-      sessionKey: liveRecord.request.sessionKey,
-      agentId: liveRecord.request.agentId,
-    })
-  ) {
-    return null;
-  }
-  if (
-    liveRecord &&
-    !canAccessOperatorApproval({
-      client: params.client,
-      allowApprovalRuntime: params.allowApprovalRuntime,
-      binding: { reviewerDeviceIds: liveRecord.approvalReviewerDeviceIds },
-    })
-  ) {
-    return null;
+  if (liveRecord) {
+    if (
+      !canAccessApprovalSession({
+        cfg: params.cfg,
+        client: params.client,
+        sessionKey: liveRecord.request.sessionKey,
+        agentId: liveRecord.request.agentId,
+      }) ||
+      !canAccessOperatorApproval({
+        client: params.client,
+        allowApprovalRuntime: params.allowApprovalRuntime,
+        binding: { reviewerDeviceIds: liveRecord.approvalReviewerDeviceIds },
+      })
+    ) {
+      return { status: "denied" };
+    }
   }
   let lookup: ReturnType<typeof getOperatorApprovalDetailed>;
   try {
@@ -184,18 +171,14 @@ function loadVisibleApproval(params: {
         client: params.client,
         sessionKey: lookup.record.source.sessionKey,
         agentId: lookup.record.source.agentId,
-      })
-    ) {
-      return null;
-    }
-    if (
+      }) ||
       !canAccessOperatorApproval({
         client: params.client,
         allowApprovalRuntime: params.allowApprovalRuntime,
         binding: { reviewerDeviceIds: lookup.record.reviewerDeviceIds },
       })
     ) {
-      return null;
+      return { status: "denied" };
     }
     const manager =
       lookup.record.kind === "exec"
@@ -203,9 +186,8 @@ function loadVisibleApproval(params: {
         : lookup.record.kind === "plugin"
           ? params.pluginApprovalManager
           : params.systemAgentApprovalManager;
-    // Durable truth can advance outside this manager. Settle only an existing
-    // same-kind waiter; reconcileDurableLookup never recreates executable state.
-    return manager?.reconcileDurableLookup(lookup) ?? null;
+    const record = manager?.reconcileDurableLookup(lookup) ?? null;
+    return record ? { status: "found", record } : { status: "denied" };
   }
   const missing = {
     outcome: lookup.outcome === "corrupt" ? "corrupt" : "missing",
@@ -214,7 +196,40 @@ function loadVisibleApproval(params: {
   params.execApprovalManager.reconcileDurableLookup(missing);
   params.pluginApprovalManager.reconcileDurableLookup(missing);
   params.systemAgentApprovalManager?.reconcileDurableLookup(missing);
-  return null;
+  // Corrupt exact keys are not absence. Trim fallback would retarget a
+  // different approval, so fail closed even when no live waiter exists.
+  return liveRecord || lookup.outcome === "corrupt" ? { status: "denied" } : { status: "missing" };
+}
+
+function loadVisibleApproval(params: {
+  id: string;
+  client: GatewayClient | null;
+  cfg: OpenClawConfig;
+  allowApprovalRuntime?: boolean;
+  allowTransportRef?: boolean;
+  execApprovalManager: ExecApprovalManager;
+  pluginApprovalManager: ExecApprovalManager<PluginApprovalRequestPayload>;
+  systemAgentApprovalManager?: ExecApprovalManager<SystemAgentApprovalRequestPayload>;
+  databaseOptions?: OpenClawStateDatabaseOptions;
+}): OperatorApprovalRecord | null {
+  // Reconciliation can settle a live waiter, so authorization must precede
+  // every durable read and no unauthorized lookup may reach the bridge.
+  const authorized = params.allowApprovalRuntime
+    ? canResolveOperatorApproval(params.client)
+    : canReviewOperatorApproval(params.client);
+  if (!authorized) {
+    return null;
+  }
+  const exact = loadVisibleApprovalForId(params);
+  if (exact.status !== "missing") {
+    return exact.status === "found" ? exact.record : null;
+  }
+  const trimmed = normalizeOptionalString(params.id);
+  if (!trimmed || trimmed === params.id || !isWellFormedApprovalId(trimmed)) {
+    return null;
+  }
+  const fallback = loadVisibleApprovalForId({ ...params, id: trimmed });
+  return fallback.status === "found" ? fallback.record : null;
 }
 
 type ApplyApprovalDecisionResult<TPayload> =
@@ -345,7 +360,7 @@ export function createApprovalHandlers(
         );
         return;
       }
-      const id = readExactApprovalId(rawParams);
+      const id = readApprovalRequestId(rawParams);
       let record: OperatorApprovalRecord | null;
       try {
         record = id
@@ -382,7 +397,7 @@ export function createApprovalHandlers(
         respondApprovalNotFound(respond);
         return;
       }
-      const id = readExactApprovalId(rawParams);
+      const id = readApprovalRequestId(rawParams);
       let record: OperatorApprovalRecord | null;
       try {
         record = id


### PR DESCRIPTION
## What Problem This Solves

`approval.get` / `approval.resolve` forwarded the raw request id into exact Map/SQL lookup. Clipboard-padded ids missed a live approval. Unconditional trim-first would also collide with opaque store keys that legitimately include surrounding whitespace (`" approval-edge "` vs `"approval-edge"`).

## Why This Change Was Made

Keep the caller-supplied id. Look up the exact key first; trim only when that exact key is missing. If the exact key exists but the caller is unauthorized, do not fall back. Resolve/cleanup use the selected record's stored id. Proof is a real Gateway WebSocket client plus handler coverage for colliding keys.

## User Impact

**Before:** Pasting an approval id with surrounding whitespace returned not-found and left the approval pending.

**After:** Padded get/resolve hit the live generated approval. A stored whitespace-bearing id stays distinct from its trimmed spelling; an unauthorized exact key does not leak the trimmed neighbor.

## Evidence

- Changed: `src/gateway/server-methods/approval.ts`, `src/gateway/server-methods/approval.test.ts`, `src/gateway/operator-approvals-client.e2e.test.ts`
- Production path: `connectGatewayClient` → `exec.approval.request` → padded `approval.get` → padded `approval.resolve` deny
- Compatibility: generated stored ids stay unpadded; opaque store keys remain exact; only missing exact keys use trim fallback

## Real behavior proof

- **Behavior or issue addressed:** A running Gateway accepts clipboard-padded `approval.get` / `approval.resolve` ids and denies the live approval without collapsing distinct opaque keys.
- **Canonical reachability path:** Real `GatewayClient` token auth → `exec.approval.request` → padded `approval.get` → padded `approval.resolve` deny → padded `approval.get` returns the denied snapshot.
- **Boundary crossed:** Real Gateway WebSocket RPC + live exec-approval manager (not a mocked handler callback).
- **Shared helper / provider constraint check:** `readApprovalRequestId` preserves the raw string when the trimmed form is well-formed. `loadVisibleApproval` is exact-first; denied or corrupt exact lookups do not trim-fall-back. Supplemental handler tests cover `" approval-edge "` vs `"approval-edge"`, unauthorized exact keys, and a corrupt exact key that must not retarget the trimmed neighbor.
- **Real environment tested:** Local trusted source checkout; Vitest e2e project; `startGatewayServer` + real `connectGatewayClient` on loopback.
- **Exact steps or command run after this patch:**

```bash
OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/gateway/operator-approvals-client.e2e.test.ts -t "padded id" --reporter=verbose
```

- **Evidence after fix:**

```text
 src/gateway/operator-approvals-client.e2e.test.ts > operator approval gateway client e2e > looks up and denies a live approval when approval.get/resolve receive a padded id 6891ms

 Test Files  1 passed (1)
      Tests  1 passed | 2 skipped (3)
```

- **Observed result after fix:** Padded get returns the pending approval with the exact stored id; padded deny applies; colliding opaque keys stay distinct.
- **What was not tested:** Plugin and system-agent approval kinds; Control UI clipboard paste.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
