### PR TITLE
fix(gateway): trim artifacts.get/download artifactId before exact lookup

### DIFF
--- a/src/gateway/artifacts-artifactid-trim.e2e.test.ts
+++ b/src/gateway/artifacts-artifactid-trim.e2e.test.ts
@@ -1,0 +1,112 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { createManagedOutgoingMediaBlocks } from "./managed-image-attachments.js";
+import { connectGatewayClient, disconnectGatewayClient } from "./test-helpers.e2e.js";
+import { installGatewayTestHooks, testState, withGatewayServer, writeSessionStore } from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const GATEWAY_TOKEN = "artifacts-artifactid-trim-e2e-token";
+const SESSION_KEY = "agent:main:main";
+
+describe("artifacts.get/download Gateway E2E", () => {
+  it("gets and downloads a live transcript artifact when artifactId is padded", async () => {
+    const stateDir = process.env.OPENCLAW_STATE_DIR;
+    if (!stateDir) {
+      throw new Error("OPENCLAW_STATE_DIR is required for artifact trim E2E fixtures");
+    }
+    testState.gatewayAuth = { mode: "token", token: GATEWAY_TOKEN };
+    const storePath = path.join(stateDir, "sessions.sqlite");
+    testState.sessionStorePath = storePath;
+
+    const source = await fs.readFile(
+      path.join(process.cwd(), "docs/assets/openclaw-banner-dark.png"),
+    );
+    const messageId = "artifacts-artifactid-trim-message";
+    const blocks = await createManagedOutgoingMediaBlocks({
+      sessionKey: SESSION_KEY,
+      messageId,
+      items: [
+        {
+          url: `data:image/png;base64,${source.toString("base64")}`,
+          trustedLocal: false,
+        },
+      ],
+      stateDir,
+    });
+    const block = blocks.find(
+      (candidate) => candidate.type === "image" && typeof candidate.artifactId === "string",
+    );
+    if (!block || typeof block.artifactId !== "string") {
+      throw new Error("managed image fixture did not produce an artifact");
+    }
+    const artifactId = block.artifactId;
+    const paddedId = ` ${artifactId} `;
+    expect(paddedId).not.toBe(artifactId);
+
+    const sessionId = "artifacts-artifactid-trim-session";
+    const transcriptPath = path.join(stateDir, `${sessionId}.jsonl`);
+    const timestamp = new Date().toISOString();
+    await fs.writeFile(
+      transcriptPath,
+      `${[
+        { type: "session", version: 3, id: sessionId, timestamp, cwd: stateDir },
+        {
+          type: "message",
+          id: messageId,
+          parentId: null,
+          timestamp,
+          message: {
+            role: "assistant",
+            content: blocks,
+            timestamp: Date.now(),
+            __openclaw: { id: messageId },
+          },
+        },
+      ]
+        .map((event) => JSON.stringify(event))
+        .join("\n")}\n`,
+    );
+    await writeSessionStore({
+      entries: {
+        [SESSION_KEY]: {
+          sessionId,
+          sessionFile: transcriptPath,
+          updatedAt: Date.now(),
+        },
+      },
+    });
+
+    await withGatewayServer(async ({ port }) => {
+      const client = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token: GATEWAY_TOKEN,
+        scopes: ["operator.read"],
+        timeoutMs: 60_000,
+      });
+      try {
+        const got = await client.request<{ artifact?: { id?: string } }>("artifacts.get", {
+          sessionKey: SESSION_KEY,
+          artifactId: paddedId,
+        });
+        expect(got.artifact).toMatchObject({ id: artifactId });
+
+        const download = await client.request<{
+          artifact?: { id?: string };
+          url?: string;
+        }>("artifacts.download", {
+          sessionKey: SESSION_KEY,
+          artifactId: paddedId,
+        });
+        expect(download.artifact).toMatchObject({ id: artifactId });
+        expect(download.url).toEqual(expect.any(String));
+        console.log(
+          `[artifacts artifactId trim Gateway client E2E] get_ok=true download_ok=true padded=${JSON.stringify(paddedId)} exact=${artifactId}`,
+        );
+      } finally {
+        await disconnectGatewayClient(client);
+      }
+    });
+  }, 120_000);
+});

--- a/src/gateway/server-methods/artifacts.test.ts
+++ b/src/gateway/server-methods/artifacts.test.ts
@@ -158,6 +158,38 @@ describe("artifacts RPC handlers", () => {
     });
   }
 
+  it("gets and downloads a transcript artifact when artifactId has clipboard padding", async () => {
+    const listed = await listArtifacts({ sessionKey: "agent:main:main" });
+    const artifact = expectFirstArtifact(listed.calls);
+    const artifactId = requireNonEmptyString(artifact?.id, "expected artifact id");
+    const paddedId = ` ${artifactId} `;
+
+    // Negative control: exact id compare misses padding before handler normalize.
+    expect(artifactId === paddedId).toBe(false);
+
+    const get = await getArtifact({ sessionKey: "agent:main:main", artifactId: paddedId });
+    expect(get.calls[0]?.ok).toBe(true);
+    expectFields((expectOkPayload(get.calls) as { artifact?: Record<string, unknown> }).artifact, {
+      id: artifactId,
+      type: "image",
+      title: "result.png",
+    });
+
+    const download = await downloadArtifact({
+      sessionKey: "agent:main:main",
+      artifactId: paddedId,
+    });
+    expect(download.calls[0]?.ok).toBe(true);
+    const payload = expectOkPayload(download.calls) as {
+      artifact?: Record<string, unknown>;
+      encoding?: string;
+      data?: string;
+    };
+    expectFields(payload.artifact, { id: artifactId, type: "image" });
+    expect(payload.encoding).toBe("base64");
+    expect(typeof payload.data).toBe("string");
+  });
+
   it("lists stable transcript artifact summaries by sessionKey", async () => {
     const { calls } = await listArtifacts({ sessionKey: "agent:main:main" }, { id: "1" });
 

--- a/src/gateway/server-methods/artifacts.ts
+++ b/src/gateway/server-methods/artifacts.ts
@@ -400,6 +400,12 @@ async function runArtifactSessionOperation<T>(
   }
 }
 
+function withNormalizedArtifactId<T extends { artifactId: string }>(params: T): T | null {
+  // Exact transcript/managed id match; clipboard/RPC padding must not invent a miss.
+  const artifactId = asNonEmptyString(params.artifactId);
+  return artifactId ? { ...params, artifactId } : null;
+}
+
 async function findArtifact(
   params: ArtifactsGetParams,
   cfg?: OpenClawConfig,
@@ -459,8 +465,13 @@ export const artifactsHandlers: GatewayRequestHandlers = {
     if (!requireQueryable(params, respond)) {
       return;
     }
+    const normalized = withNormalizedArtifactId(params);
+    if (!normalized) {
+      respondArtifactNotFound(respond, params.artifactId);
+      return;
+    }
     const cfg = context.getRuntimeConfig?.();
-    const admittedQuery = admitArtifactQuery(params, cfg, respond);
+    const admittedQuery = admitArtifactQuery(normalized, cfg, respond);
     if (!admittedQuery) {
       return;
     }
@@ -472,7 +483,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
     }
     const { artifact } = found.value;
     if (!artifact) {
-      respondArtifactNotFound(respond, params.artifactId);
+      respondArtifactNotFound(respond, normalized.artifactId);
       return;
     }
     respond(true, { artifact: toSummary(artifact) });
@@ -486,8 +497,13 @@ export const artifactsHandlers: GatewayRequestHandlers = {
     if (!requireQueryable(params, respond)) {
       return;
     }
+    const normalized = withNormalizedArtifactId(params);
+    if (!normalized) {
+      respondArtifactNotFound(respond, params.artifactId);
+      return;
+    }
     const cfg = context.getRuntimeConfig?.();
-    const admittedQuery = admitArtifactQuery(params, cfg, respond);
+    const admittedQuery = admitArtifactQuery(normalized, cfg, respond);
     if (!admittedQuery) {
       return;
     }
@@ -495,7 +511,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
       admittedQuery.sessionKey &&
       !admittedQuery.runId &&
       !admittedQuery.taskId &&
-      parseManagedOutgoingArtifactId(params.artifactId)
+      parseManagedOutgoingArtifactId(normalized.artifactId)
     ) {
       const resolvedResult = await runArtifactSessionOperation(respond, () =>
         resolveAuthorizedArtifactSession(admittedQuery, cfg, client),
@@ -512,7 +528,7 @@ export const artifactsHandlers: GatewayRequestHandlers = {
             sessionKey: resolved.sessionKey,
             ...(resolved.agentId ? { agentId: resolved.agentId } : {}),
             ...(defaultAgentId ? { defaultAgentId } : {}),
-            artifactId: params.artifactId,
+            artifactId: normalized.artifactId,
           })
         : null;
       if (managed) {
@@ -532,18 +548,18 @@ export const artifactsHandlers: GatewayRequestHandlers = {
         });
         return;
       }
-      respondArtifactNotFound(respond, params.artifactId);
+      respondArtifactNotFound(respond, normalized.artifactId);
       return;
     }
     const found = await runArtifactSessionOperation(respond, () =>
-      findArtifact(admittedQuery, cfg, { downloadArtifactId: params.artifactId }, client),
+      findArtifact(admittedQuery, cfg, { downloadArtifactId: normalized.artifactId }, client),
     );
     if (!found.ok) {
       return;
     }
     const { artifact } = found.value;
     if (!artifact) {
-      respondArtifactNotFound(respond, params.artifactId);
+      respondArtifactNotFound(respond, normalized.artifactId);
       return;
     }
     if (artifact.download.mode === "unsupported") {


### PR DESCRIPTION
## What Problem This Solves

`artifacts.get` / `artifacts.download` forwarded the raw `artifactId` into exact transcript/managed lookup. Clipboard-padded IDs missed a live artifact even though sibling handlers already normalize strings.

## Why This Change Was Made

Read `artifactId` through `normalizeOptionalString` before lookup. Proof is a real Gateway WebSocket client: a managed transcript image is created, then padded `artifacts.get` / `artifacts.download` return the exact stored id.

## User Impact

**Before:** Pasting an artifact id with surrounding whitespace returned not-found.

**After:** Padded get/download hit the live artifact; stored ids stay unpadded.

## Evidence

- Changed: `src/gateway/server-methods/artifacts.ts`, `src/gateway/server-methods/artifacts.test.ts`, `src/gateway/artifacts-artifactid-trim.e2e.test.ts`
- Production path: `connectGatewayClient` → `artifacts.get({ artifactId: " ${id} " })` → `artifacts.download({ artifactId: " ${id} " })`

## Real behavior proof

- **Behavior or issue addressed:** A running Gateway accepts clipboard-padded artifact IDs for get and download.
- **Canonical reachability path:** Real `GatewayClient` token auth → padded `artifacts.get` → padded `artifacts.download` on a live transcript artifact.
- **Boundary crossed:** Real Gateway WebSocket RPC + real transcript/managed image bytes (not a mocked storage visitor).
- **Shared helper / provider constraint check:** Reuses `normalizeOptionalString` as `asNonEmptyString` before exact id match.
- **Real environment tested:** Local trusted source checkout; Vitest e2e project; `withGatewayServer` + real `connectGatewayClient` on loopback.
- **Exact steps or command run after this patch:**

```bash
OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/gateway/artifacts-artifactid-trim.e2e.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
✓ src/gateway/artifacts-artifactid-trim.e2e.test.ts > artifacts.get/download Gateway E2E > gets and downloads a live transcript artifact when artifactId is padded 8854ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

- **Observed result after fix:** Padded get and download both return the exact stored artifact id.
- **What was not tested:** Task-scoped artifacts; Control UI clipboard paste.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
