### PR TITLE
fix(lmstudio): route chat to the prepared model instance

### DIFF
--- a/docs/providers/lmstudio.md
+++ b/docs/providers/lmstudio.md
@@ -146,6 +146,13 @@ still has `off`/`on` reasoning maps.
 }
 ```
 
+### Model instances and context
+
+With preload enabled, OpenClaw routes chat requests to a loaded instance with
+enough context for the selected model budget. A newly loaded instance is addressed by the
+identifier returned by LM Studio. Your configured model reference and conversation model identity
+keep the canonical model key.
+
 ### Disabling preload
 
 LM Studio supports just-in-time (JIT) model loading, loading models on first request. OpenClaw

--- a/extensions/lmstudio/src/models.fetch.ts
+++ b/extensions/lmstudio/src/models.fetch.ts
@@ -45,6 +45,7 @@ function redactLmstudioLoadError(value: string, headers: Record<string, string> 
 
 type LmstudioLoadResponse = {
   status?: string;
+  instance_id?: string;
 };
 
 type LmstudioResolvedModelKeyError = {
@@ -233,8 +234,7 @@ export async function discoverLmstudioModels(
     .filter((entry): entry is ModelDefinitionConfig => entry !== null);
 }
 
-/** Ensures a model is loaded in LM Studio before first real inference/embedding call. */
-export async function ensureLmstudioModelLoaded(params: {
+type LmstudioModelLoadParams = {
   baseUrl?: string;
   apiKey?: string;
   headers?: Record<string, string>;
@@ -244,7 +244,21 @@ export async function ensureLmstudioModelLoaded(params: {
   timeoutMs?: number;
   /** Injectable fetch implementation; defaults to the global fetch. */
   fetchImpl?: typeof fetch;
-}): Promise<string> {
+};
+
+export type LmstudioPreparedModel = {
+  modelKey: string;
+  instanceId?: string;
+};
+
+/** Keeps the public model/cache identity stable for embedding and SDK callers. */
+export async function ensureLmstudioModelLoaded(params: LmstudioModelLoadParams): Promise<string> {
+  return (await prepareLmstudioModelForInference(params)).modelKey;
+}
+
+export async function prepareLmstudioModelForInference(
+  params: LmstudioModelLoadParams,
+): Promise<LmstudioPreparedModel> {
   const modelKey = params.modelKey.trim();
   if (!modelKey) {
     throw new Error("LM Studio model key is required");
@@ -282,7 +296,16 @@ export async function ensureLmstudioModelLoaded(params: {
           advertisedContextLimit,
         );
   if (loadedContextWindow !== null && loadedContextWindow >= contextLengthForLoad) {
-    return canonicalModelKey;
+    const instances = Array.isArray(matchingModel?.loaded_instances)
+      ? matchingModel.loaded_instances
+      : [];
+    const instance = instances.find(
+      (entry) =>
+        typeof entry?.id === "string" &&
+        entry.id.trim().length > 0 &&
+        (asPositiveSafeInteger(entry.config?.context_length) ?? 0) >= contextLengthForLoad,
+    );
+    return { modelKey: canonicalModelKey, instanceId: instance?.id?.trim() };
   }
 
   try {
@@ -331,11 +354,17 @@ export async function ensureLmstudioModelLoaded(params: {
         const status = redactLmstudioLoadError(payload.status, requestHeaders);
         throw new Error(`LM Studio model load returned unexpected status: ${status}`);
       }
+      return {
+        modelKey: canonicalModelKey,
+        instanceId:
+          typeof payload.instance_id === "string"
+            ? payload.instance_id.trim() || undefined
+            : undefined,
+      };
     } finally {
       await release();
     }
   } catch (error) {
     throw withResolvedLmstudioModelKey(error, canonicalModelKey);
   }
-  return canonicalModelKey;
 }

--- a/extensions/lmstudio/src/models.test.ts
+++ b/extensions/lmstudio/src/models.test.ts
@@ -107,7 +107,7 @@ describe("lmstudio-models", () => {
         });
       }
       if (String(url).endsWith("/api/v1/models/load")) {
-        return jsonResponse({ status: "loaded" });
+        return jsonResponse({ status: "loaded", instance_id: "inst-loaded" });
       }
       throw new Error(`Unexpected fetch URL: ${String(url)}`);
     });

--- a/extensions/lmstudio/src/stream.instances.test.ts
+++ b/extensions/lmstudio/src/stream.instances.test.ts
@@ -1,0 +1,104 @@
+import type { StreamFn } from "openclaw/plugin-sdk/agent-core";
+import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
+import { afterEach, expect, it, vi } from "vitest";
+import { wrapLmstudioInferencePreload } from "./stream.js";
+
+vi.mock("openclaw/plugin-sdk/ssrf-runtime", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("openclaw/plugin-sdk/ssrf-runtime")>()),
+  fetchWithSsrFGuard: async ({ url, init }: { url: string; init?: RequestInit }) => ({
+    response: await fetch(url, init),
+    release: async () => undefined,
+  }),
+}));
+
+vi.mock("./runtime.js", () => ({
+  buildLmstudioAuthHeaders: () => ({ "Content-Type": "application/json" }),
+  resolveLmstudioRuntimeApiKey: async () => undefined,
+  resolveLmstudioProviderHeaders: async () => undefined,
+}));
+
+afterEach(() => vi.unstubAllGlobals());
+
+it.each([
+  { needsLoad: false, replacePayload: false },
+  { needsLoad: true, replacePayload: false },
+  { needsLoad: false, replacePayload: true },
+])(
+  "routes inference to the matching instance with stable identity (load=$needsLoad, replace=$replacePayload)",
+  async ({ needsLoad, replacePayload }) => {
+    const key = "qwen3.5-0.8b";
+    const instanceId = "openclaw-long-context";
+    const calls: Array<{ path: string; body: unknown }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string, init?: RequestInit) => {
+        calls.push({
+          path: new URL(url).pathname,
+          body: typeof init?.body === "string" ? JSON.parse(init.body) : undefined,
+        });
+        if (url.endsWith("/api/v1/models/load")) {
+          return Response.json({ status: "loaded", instance_id: instanceId });
+        }
+        return Response.json({
+          models: [
+            {
+              type: "llm",
+              key,
+              max_context_length: 262144,
+              loaded_instances: [
+                { id: key, config: { context_length: 4096 } },
+                ...(!needsLoad ? [{ id: instanceId, config: { context_length: 16384 } }] : []),
+              ],
+            },
+          ],
+        });
+      }),
+    );
+    const payload: Record<string, unknown> = { model: key };
+    const observed = vi.fn();
+    let dispatched: unknown;
+    const streamFn: StreamFn = async (model, _context, options) => {
+      observed(model);
+      dispatched = (await options?.onPayload?.(payload, model)) ?? payload;
+      const stream = createAssistantMessageEventStream();
+      stream.end();
+      return stream;
+    };
+    const baseUrl = `http://instance-${needsLoad}-${replacePayload}.localhost:1234/v1`;
+    const wrapped = wrapLmstudioInferencePreload({
+      provider: "lmstudio",
+      modelId: key,
+      config: { models: { providers: { lmstudio: { baseUrl, models: [] } } } },
+      streamFn,
+    });
+    const model: Parameters<StreamFn>[0] = {
+      id: key,
+      name: "Qwen3.5 0.8B",
+      provider: "lmstudio",
+      api: "openai-completions",
+      baseUrl,
+      contextWindow: 262144,
+      contextTokens: 16384,
+      maxTokens: 8192,
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    };
+    const onPayload = vi.fn(async () =>
+      replacePayload ? { model: key, temperature: 0.25 } : undefined,
+    );
+    await wrapped(model, { messages: [] }, { onPayload });
+    expect(dispatched).toEqual({
+      model: instanceId,
+      ...(replacePayload ? { temperature: 0.25 } : {}),
+    });
+    expect(model.id).toBe(key);
+    expect(observed.mock.calls[0]?.[0].id).toBe(key);
+    expect(onPayload).toHaveBeenCalledWith(payload, expect.objectContaining({ id: key }));
+    expect(calls.filter((call) => call.path.endsWith("/load"))).toEqual(
+      needsLoad
+        ? [{ path: "/api/v1/models/load", body: { model: key, context_length: 16384 } }]
+        : [],
+    );
+  },
+);

--- a/extensions/lmstudio/src/stream.test.ts
+++ b/extensions/lmstudio/src/stream.test.ts
@@ -8,7 +8,7 @@ let wrapLmstudioInferencePreload: typeof import("./stream.js").wrapLmstudioInfer
 let defaultBaseUrl: string;
 let defaultBaseUrlSequence = 0;
 
-const ensureLmstudioModelLoadedMock = vi.hoisted(() => vi.fn());
+const prepareLmstudioModelForInferenceMock = vi.hoisted(() => vi.fn());
 const resolveLmstudioProviderHeadersMock = vi.hoisted(() =>
   vi.fn(async (_params?: unknown) => undefined),
 );
@@ -17,7 +17,8 @@ const resolveLmstudioRuntimeApiKeyMock = vi.hoisted(() =>
 );
 
 vi.mock("./models.fetch.js", () => ({
-  ensureLmstudioModelLoaded: (params: unknown) => ensureLmstudioModelLoadedMock(params),
+  prepareLmstudioModelForInference: (params: unknown) =>
+    prepareLmstudioModelForInferenceMock(params),
 }));
 
 vi.mock("./runtime.js", () => ({
@@ -66,7 +67,10 @@ function requireMockCallArg(mock: { mock: { calls: unknown[][] } }, label: strin
 }
 
 function expectEnsureLoadedFields(fields: Record<string, unknown>) {
-  const [params] = requireMockCallArg(ensureLmstudioModelLoadedMock, "ensureLmstudioModelLoaded");
+  const [params] = requireMockCallArg(
+    prepareLmstudioModelForInferenceMock,
+    "ensureLmstudioModelLoaded",
+  );
   const record = requireRecord(params, "ensureLmstudioModelLoaded params");
   for (const [key, value] of Object.entries(fields)) {
     if (key === "ssrfPolicy") {
@@ -203,7 +207,7 @@ describe("lmstudio stream wrapper", () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
-    ensureLmstudioModelLoadedMock.mockReset();
+    prepareLmstudioModelForInferenceMock.mockReset();
     resolveLmstudioProviderHeadersMock.mockReset();
     resolveLmstudioRuntimeApiKeyMock.mockReset();
     resolveLmstudioProviderHeadersMock.mockResolvedValue(undefined);
@@ -223,7 +227,7 @@ describe("lmstudio stream wrapper", () => {
     const events = await collectEvents(stream);
 
     expectSingleDoneEvent(events);
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(1);
     expectEnsureLoadedFields({
       baseUrl: "http://lmstudio.internal:1234/v1",
       modelKey: "qwen3-8b-instruct",
@@ -234,7 +238,9 @@ describe("lmstudio stream wrapper", () => {
   });
 
   it("streams with the canonical model key returned by preload", async () => {
-    ensureLmstudioModelLoadedMock.mockResolvedValueOnce("gemma-4-e4b-it-ultra-uncensored-heretic");
+    prepareLmstudioModelForInferenceMock.mockResolvedValueOnce({
+      modelKey: "gemma-4-e4b-it-ultra-uncensored-heretic",
+    });
     const baseStream = buildDoneStreamFn();
     const wrapped = createWrappedLmstudioStream(baseStream);
     const variantKey = "gemma-4-e4b-it-ultra-uncensored-heretic@q4_k_m";
@@ -265,7 +271,7 @@ describe("lmstudio stream wrapper", () => {
     const events = await collectEvents(stream);
 
     expectSingleDoneEvent(events);
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(1);
     expectEnsureLoadedFields({
       baseUrl: "http://lmstudio.internal:1234/v1",
       modelKey: "qwen3-8b-instruct",
@@ -291,7 +297,7 @@ describe("lmstudio stream wrapper", () => {
     const events = await collectEvents(stream);
 
     expectSingleDoneEvent(events);
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(1);
     expectEnsureLoadedFields({
       baseUrl: "http://lmstudio.internal:1234/v1",
       modelKey: "qwen3-8b-instruct",
@@ -302,7 +308,7 @@ describe("lmstudio stream wrapper", () => {
   });
 
   it("continues inference when preload fails", async () => {
-    ensureLmstudioModelLoadedMock.mockRejectedValueOnce(new Error("load failed"));
+    prepareLmstudioModelForInferenceMock.mockRejectedValueOnce(new Error("load failed"));
     const baseStream = buildDoneStreamFn();
     const wrapped = wrapLmstudioInferencePreload({
       provider: "lmstudio",
@@ -335,7 +341,7 @@ describe("lmstudio stream wrapper", () => {
   });
 
   it("streams with the canonical model key when preload fails after discovery", async () => {
-    ensureLmstudioModelLoadedMock.mockRejectedValueOnce(
+    prepareLmstudioModelForInferenceMock.mockRejectedValueOnce(
       Object.assign(new Error("load failed"), {
         resolvedModelKey: "gemma-4-e4b-it-ultra-uncensored-heretic",
       }),
@@ -360,7 +366,7 @@ describe("lmstudio stream wrapper", () => {
     const variantModel = {
       id: `lmstudio/${canonicalKey}@q4_k_m`,
     };
-    ensureLmstudioModelLoadedMock.mockRejectedValueOnce(
+    prepareLmstudioModelForInferenceMock.mockRejectedValueOnce(
       Object.assign(new Error("load failed"), {
         resolvedModelKey: canonicalKey,
       }),
@@ -373,7 +379,7 @@ describe("lmstudio stream wrapper", () => {
 
     expectSingleDoneEvent(firstEvents);
     expectSingleDoneEvent(secondEvents);
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(1);
     expect(baseStream).toHaveBeenCalledTimes(2);
     expectBaseStreamCallModelFields(baseStream, 0, {
       provider: "lmstudio",
@@ -417,7 +423,7 @@ describe("lmstudio stream wrapper", () => {
     );
 
     expectSingleDoneEvent(events);
-    expect(ensureLmstudioModelLoadedMock).not.toHaveBeenCalled();
+    expect(prepareLmstudioModelForInferenceMock).not.toHaveBeenCalled();
     expect(baseStream).toHaveBeenCalledTimes(1);
     const [model] = requireMockCallArg(
       baseStream as unknown as { mock: { calls: unknown[][] } },
@@ -430,7 +436,7 @@ describe("lmstudio stream wrapper", () => {
 
   it("dedupes concurrent preload requests for the same model and context", async () => {
     let resolvePreload: (() => void) | undefined;
-    ensureLmstudioModelLoadedMock.mockImplementationOnce(
+    prepareLmstudioModelForInferenceMock.mockImplementationOnce(
       () =>
         new Promise<void>((resolve) => {
           resolvePreload = resolve;
@@ -489,7 +495,7 @@ describe("lmstudio stream wrapper", () => {
 
     expectSingleDoneEvent(firstEvents);
     expectSingleDoneEvent(secondEvents);
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(1);
   });
 
   it("does not start model preload for an already-aborted inference", async () => {
@@ -504,13 +510,13 @@ describe("lmstudio stream wrapper", () => {
     );
 
     await expect(stream).rejects.toBe(abortReason);
-    expect(ensureLmstudioModelLoadedMock).not.toHaveBeenCalled();
+    expect(prepareLmstudioModelForInferenceMock).not.toHaveBeenCalled();
     expect(baseStream).not.toHaveBeenCalled();
   });
 
   it("cancels one shared preload waiter without cancelling another inference", async () => {
     let resolvePreload: (() => void) | undefined;
-    ensureLmstudioModelLoadedMock.mockImplementationOnce(
+    prepareLmstudioModelForInferenceMock.mockImplementationOnce(
       () =>
         new Promise<void>((resolve) => {
           resolvePreload = resolve;
@@ -541,7 +547,7 @@ describe("lmstudio stream wrapper", () => {
         timeout: 250,
       });
       expect(baseStream).not.toHaveBeenCalled();
-      expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+      expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(1);
 
       resolvePreload?.();
 
@@ -554,7 +560,7 @@ describe("lmstudio stream wrapper", () => {
   });
 
   it("skips preload on the second attempt while the failure backoff is active", async () => {
-    ensureLmstudioModelLoadedMock.mockRejectedValue(new Error("out of memory"));
+    prepareLmstudioModelForInferenceMock.mockRejectedValue(new Error("out of memory"));
     const baseStream = buildDoneStreamFn();
     const wrapped = wrapLmstudioInferencePreload({
       provider: "lmstudio",
@@ -584,7 +590,7 @@ describe("lmstudio stream wrapper", () => {
       ),
     );
     expectSingleDoneEvent(firstEvents);
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(1);
 
     const secondEvents = await collectEvents(
       wrapped(
@@ -600,12 +606,12 @@ describe("lmstudio stream wrapper", () => {
     expectSingleDoneEvent(secondEvents);
     // The second call must NOT retry preload because cooldown is active, but
     // the underlying stream must still run so the user gets a response.
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(1);
     expect(baseStream).toHaveBeenCalledTimes(2);
   });
 
   it("preserves all 29 agent tools while preload failure backoff remains active", async () => {
-    ensureLmstudioModelLoadedMock.mockRejectedValueOnce(new Error("out of memory"));
+    prepareLmstudioModelForInferenceMock.mockRejectedValueOnce(new Error("out of memory"));
     const baseStream = buildDoneStreamFn();
     const wrapped = createWrappedLmstudioStream(baseStream);
     const tools = Array.from({ length: 29 }, (_, index) => ({
@@ -625,13 +631,13 @@ describe("lmstudio stream wrapper", () => {
       expect(requireRecord(call?.[1], "base stream context").tools).toEqual(tools);
     }
 
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(1);
     expect(baseStream).toHaveBeenCalledTimes(2);
   });
 
   it("retries preload once the cooldown expires", async () => {
-    ensureLmstudioModelLoadedMock.mockRejectedValueOnce(new Error("out of memory"));
-    ensureLmstudioModelLoadedMock.mockResolvedValueOnce(undefined);
+    prepareLmstudioModelForInferenceMock.mockRejectedValueOnce(new Error("out of memory"));
+    prepareLmstudioModelForInferenceMock.mockResolvedValueOnce(undefined);
     const baseStream = buildDoneStreamFn();
     const wrapped = wrapLmstudioInferencePreload({
       provider: "lmstudio",
@@ -665,7 +671,7 @@ describe("lmstudio stream wrapper", () => {
         undefined as never,
       ),
     );
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(1);
 
     // Move the clock past the initial 5s cooldown window so the next call is
     // allowed to retry preload.
@@ -681,39 +687,39 @@ describe("lmstudio stream wrapper", () => {
         undefined as never,
       ),
     );
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(2);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(2);
     nowSpy.mockRestore();
   });
 
   it("keeps increasing preload backoff across expired consecutive failures", async () => {
-    ensureLmstudioModelLoadedMock.mockRejectedValue(new Error("out of memory"));
+    prepareLmstudioModelForInferenceMock.mockRejectedValue(new Error("out of memory"));
     const baseStream = buildDoneStreamFn();
     const wrapped = createWrappedLmstudioStream(baseStream);
     const baseTime = 1_000_000;
     const nowSpy = vi.spyOn(Date, "now").mockReturnValue(baseTime);
 
     await collectEvents(runWrappedLmstudioStream(wrapped, {}));
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(1);
 
     nowSpy.mockReturnValue(baseTime + 5_001);
     await collectEvents(runWrappedLmstudioStream(wrapped, {}));
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(2);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(2);
 
     nowSpy.mockReturnValue(baseTime + 10_001);
     await collectEvents(runWrappedLmstudioStream(wrapped, {}));
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(2);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(2);
 
     nowSpy.mockReturnValue(baseTime + 15_002);
     await collectEvents(runWrappedLmstudioStream(wrapped, {}));
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(3);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(3);
 
     nowSpy.mockReturnValue(baseTime + 30_002);
     await collectEvents(runWrappedLmstudioStream(wrapped, {}));
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(3);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(3);
 
     nowSpy.mockReturnValue(baseTime + 35_003);
     await collectEvents(runWrappedLmstudioStream(wrapped, {}));
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(4);
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(4);
     expect(baseStream).toHaveBeenCalledTimes(6);
   });
 
@@ -837,7 +843,7 @@ describe("lmstudio stream wrapper", () => {
       ),
     );
 
-    expect(ensureLmstudioModelLoadedMock).not.toHaveBeenCalled();
+    expect(prepareLmstudioModelForInferenceMock).not.toHaveBeenCalled();
     const [model] = requireMockCallArg(
       baseStream as unknown as { mock: { calls: unknown[][] } },
       "base stream",

--- a/extensions/lmstudio/src/stream.ts
+++ b/extensions/lmstudio/src/stream.ts
@@ -14,7 +14,7 @@ import {
   uniqueStrings,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { LMSTUDIO_PROVIDER_ID } from "./defaults.js";
-import { ensureLmstudioModelLoaded } from "./models.fetch.js";
+import { prepareLmstudioModelForInference, type LmstudioPreparedModel } from "./models.fetch.js";
 import { resolveLmstudioInferenceBase } from "./models.js";
 import { resolveLmstudioProviderHeaders, resolveLmstudioRuntimeApiKey } from "./runtime.js";
 
@@ -23,7 +23,7 @@ const log = createSubsystemLogger("extensions/lmstudio/stream");
 type StreamOptions = Parameters<StreamFn>[2];
 type StreamModel = Parameters<StreamFn>[0];
 
-const preloadInFlight = new Map<string, Promise<string | undefined>>();
+const preloadInFlight = new Map<string, Promise<LmstudioPreparedModel | undefined>>();
 
 /**
  * Cooldown state for the LM Studio preload endpoint.
@@ -184,9 +184,9 @@ function toLmstudioPreloadError(reason: unknown, message: string): Error {
 }
 
 function waitForLmstudioPreload(
-  preload: Promise<string | undefined>,
+  preload: Promise<LmstudioPreparedModel | undefined>,
   signal?: AbortSignal,
-): Promise<string | undefined> {
+): Promise<LmstudioPreparedModel | undefined> {
   if (!signal) {
     return preload;
   }
@@ -217,7 +217,7 @@ async function ensureLmstudioModelLoadedBestEffort(params: {
   options: StreamOptions;
   ctx: ProviderWrapStreamFnContext;
   modelHeaders?: Record<string, string>;
-}): Promise<string> {
+}): Promise<LmstudioPreparedModel> {
   const providerConfig = params.ctx.config?.models?.providers?.[LMSTUDIO_PROVIDER_ID];
   const providerHeaders = { ...providerConfig?.headers, ...params.modelHeaders };
   const runtimeApiKey =
@@ -237,7 +237,7 @@ async function ensureLmstudioModelLoadedBestEffort(params: {
           headers: providerHeaders,
         });
 
-  return await ensureLmstudioModelLoaded({
+  return await prepareLmstudioModelForInference({
     baseUrl: params.baseUrl,
     apiKey: runtimeApiKey ?? configuredApiKey,
     headers,
@@ -284,7 +284,7 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
 
     const cooldownEntry = isPreloadCoolingDown(preloadKey, Date.now());
     const existing = preloadInFlight.get(preloadKey);
-    const preloadPromise: Promise<string | undefined> | undefined =
+    const preloadPromise: Promise<LmstudioPreparedModel | undefined> | undefined =
       existing ??
       (cooldownEntry
         ? undefined
@@ -298,9 +298,9 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
               modelHeaders: resolveModelHeaders(model),
             })
               .then(
-                (resolvedModelKey) => {
+                (preparedModel) => {
                   recordPreloadSuccess(preloadKey);
-                  return resolvedModelKey;
+                  return preparedModel;
                 },
                 (error: unknown) => {
                   const resolvedModelKey = resolveLmstudioModelKeyFromError(error);
@@ -321,10 +321,10 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
           })());
 
     return (async () => {
-      let resolvedModelKey: string | undefined;
+      let preparedModel: LmstudioPreparedModel | undefined;
       if (preloadPromise) {
         try {
-          resolvedModelKey = await waitForLmstudioPreload(preloadPromise, options?.signal);
+          preparedModel = await waitForLmstudioPreload(preloadPromise, options?.signal);
         } catch (error) {
           // A caller owns its wait, not the shared model load needed by other
           // in-flight requests; cancellation must never become preload backoff.
@@ -334,7 +334,8 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
             consecutiveFailures?: number;
             cooldownMs?: number;
           };
-          resolvedModelKey = resolveLmstudioModelKeyFromError(error);
+          const resolvedModelKey = resolveLmstudioModelKeyFromError(error);
+          preparedModel = resolvedModelKey ? { modelKey: resolvedModelKey } : undefined;
           const cause = annotated.cause ?? error;
           const failures = annotated.consecutiveFailures ?? 1;
           const cooldownSec = Math.max(0, Math.round((annotated.cooldownMs ?? 0) / 1000));
@@ -345,7 +346,8 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
           );
         }
       } else if (cooldownEntry) {
-        resolvedModelKey = cooldownEntry.resolvedModelKey;
+        const resolvedModelKey = cooldownEntry.resolvedModelKey;
+        preparedModel = resolvedModelKey ? { modelKey: resolvedModelKey } : undefined;
         log.debug(
           `LM Studio inference preload for "${modelKey}" skipped while backoff active (${cooldownEntry.consecutiveFailures} prior failures)`,
         );
@@ -353,11 +355,23 @@ export function wrapLmstudioInferencePreload(ctx: ProviderWrapStreamFnContext): 
       // LM Studio uses OpenAI-compatible streaming usage payloads when requested via
       // `stream_options.include_usage`. Force this compat flag at call time so usage
       // reporting remains enabled even when catalog entries omitted compat metadata.
-      const streamModel = withLmstudioResolvedModelKey(model, resolvedModelKey);
+      const streamModel = withLmstudioResolvedModelKey(model, preparedModel?.modelKey);
+      const instanceId = preparedModel?.instanceId;
       const stream = streamWithThinkingLevel(
         withLmstudioUsageCompat(streamModel),
         context,
-        options,
+        instanceId
+          ? {
+              ...options,
+              async onPayload(payload, payloadModel) {
+                // Instance IDs route this request; model and transcript identity stay canonical.
+                asRecord(payload).model = instanceId;
+                const replacement = await options?.onPayload?.(payload, payloadModel);
+                asRecord(replacement ?? payload).model = instanceId;
+                return replacement;
+              },
+            }
+          : options,
       );
       const resolvedStream = stream instanceof Promise ? await stream : stream;
       return resolvedStream;


### PR DESCRIPTION
Closes #141357.

## What Problem This Solves

When the same LM Studio model has multiple loaded instances, OpenClaw can budget against the larger instance but send chat to the smaller one. A real 5,777-token prompt failed with HTTP 400 against the canonical 4,096-token instance even though discovery reported an available 16,384-token instance.

## Why This Change Was Made

Select a loaded instance with enough context, or use the instance ID returned by a new native load. Apply that ID only to the effective completion payload, including replacement payloads from asynchronous callbacks. Keep the canonical model key for configuration, conversation identity and the existing public loading helper used by embeddings.

## User Impact

With preload enabled, chat uses the capacity selected during discovery instead of failing against another smaller instance. Existing model references and preload opt-out behavior remain intact.

## Evidence

- Real before-fix Testbox proof with headless LM Studio 0.0.23-1 and Qwen3.5-0.8B Q4_K_M: 4,096 and 16,384-context instances loaded simultaneously; the production wrapper failed against 4,096, while the identical prompt addressed directly to the larger instance succeeded with `OK` (5,777 input / 1 output token).
- New wrapper regression failed on the original source for both an already loaded suitable instance and a new load. A separate regression reproduced an independently constructed replacement callback discarding the selected ID; the finalizer now preserves it.
- 100 focused model, stream and embedding tests passed. The final fixture-only type narrowing passed its three routing cases. Final independent review found no actionable P0–P2 findings.
- After-fix live Testbox proof passed on the exact changed production-file hashes: the wrapper routed the 5,777-token prompt to the existing 16K instance and returned `OK`. After that instance was evicted, it loaded at 16K and used the new `instance_id` returned by the native API; the second completion also returned `OK` (5,777 input / 1 output token each). The callback deliberately returned a fresh payload containing the canonical model key; final request routing still selected the correct instance. Conversation model identity stayed canonical. All 61 observed task processes stopped.
- Changed-file validation completed: production/test typechecks and unused-export scans passed; after correcting a fixture-only lint issue, targeted lint, database/media/sidecar/import-cycle guards, six-file formatting and diff checks all passed. The live snapshot differs from this commit only by that test-fixture string narrowing; both changed production-file hashes match exactly.
