### PR TITLE
fix(desktop): abort node observe attach when requester disconnects before mint

### DIFF
--- a/src/gateway/desktop/node-source.test.ts
+++ b/src/gateway/desktop/node-source.test.ts
@@ -183,4 +183,52 @@ describe("node desktop runtime policy", () => {
     expect(await observed).toBe(false);
     expect(stream.destroyed).toBe(true);
   });
+
+  it("aborts attach/invoke when the Gateway requester disconnects before mint", async () => {
+    const fixture = createFixture("attachment");
+    const mint = vi.spyOn(observeBridge, "mintDesktopObserverToken");
+    const controller = new AbortController();
+    const requester = {
+      signal: controller.signal,
+      isCurrent: () => !controller.signal.aborted,
+    };
+    const observed = fixture.service.observe({
+      nodeId: "node",
+      control: false,
+      credentials: { password: "synthetic-password" },
+      requester,
+    });
+    await fixture.reached;
+    expect(fixture.forwarded).toEqual([NODE_DESKTOP_STREAM_COMMAND]);
+    controller.abort();
+
+    await expect(observed).rejects.toThrow(
+      /requester is no longer current|cancelled|aborted|closed/i,
+    );
+    expect(mint).not.toHaveBeenCalled();
+  });
+
+  it("refuses mint when requester is invalidated during delayed attachment", async () => {
+    const fixture = createFixture("attachment");
+    const mint = vi.spyOn(observeBridge, "mintDesktopObserverToken");
+    const client = { invalidated: false };
+    const requester = {
+      signal: new AbortController().signal,
+      isCurrent: () => !client.invalidated,
+    };
+    const observed = fixture.service.observe({
+      nodeId: "node",
+      control: false,
+      credentials: { password: "synthetic-password" },
+      requester,
+    });
+    await fixture.reached;
+    client.invalidated = true;
+    const stream = new PassThrough();
+    fixture.attached.resolve({ stream, auth: "vnc-password" });
+
+    await expect(observed).rejects.toThrow(/requester is no longer current|superseded/i);
+    expect(mint).not.toHaveBeenCalled();
+    expect(stream.destroyed).toBe(true);
+  });
 });

--- a/src/gateway/desktop/node-source.ts
+++ b/src/gateway/desktop/node-source.ts
@@ -6,7 +6,11 @@ import type { NodeRegistry, NodeSession } from "../node-registry.js";
 import { DesktopCredentialsRequiredError } from "./host-source-errors.js";
 import type { NodeDesktopStreamBroker } from "./node-stream-broker.js";
 import { mintDesktopObserverToken } from "./observe-bridge.js";
-import type { DesktopObserveRequester } from "./observe-requester.js";
+import {
+  isDesktopObserveRequesterCurrent,
+  watchDesktopObserveRequesterGone,
+  type DesktopObserveRequester,
+} from "./observe-requester.js";
 import type { RfbPreauthDescriptor } from "./rfb-preauth.js";
 import type { DesktopSessionRegistry } from "./session-registry.js";
 
@@ -194,7 +198,18 @@ export function createNodeDesktopService(params: {
         throw new Error("node desktop observer limit reached");
       }
       session.active.add(active);
+      const stopForRequesterGone = () => {
+        void stopActiveStream(active).then(() => session.active.delete(active));
+      };
+      let unwatchRequester = () => {};
       try {
+        if (!isDesktopObserveRequesterCurrent(request.requester)) {
+          throw new Error("desktop observe requester is no longer current");
+        }
+        unwatchRequester = watchDesktopObserveRequesterGone(
+          request.requester,
+          stopForRequesterGone,
+        );
         active.ticket = params.streamBroker.mint({
           nodeId: request.nodeId,
           connId: node.connId,
@@ -220,9 +235,17 @@ export function createNodeDesktopService(params: {
         void invocationFinished.catch(() => undefined);
 
         const attached = await Promise.race([active.ticket.attached, invocationFinished]);
-        if (active.stopped || sessions.get(request.nodeId) !== session) {
+        if (
+          active.stopped ||
+          sessions.get(request.nodeId) !== session ||
+          !isDesktopObserveRequesterCurrent(request.requester)
+        ) {
           attached.stream.destroy();
-          throw new Error("node desktop session was superseded before attachment");
+          throw new Error(
+            !isDesktopObserveRequesterCurrent(request.requester) || active.stopped
+              ? "desktop observe requester is no longer current"
+              : "node desktop session was superseded before attachment",
+          );
         }
         active.stream = attached.stream;
         assertAuthorized();
@@ -261,6 +284,13 @@ export function createNodeDesktopService(params: {
           throw new Error("node desktop session was superseded before publication");
         }
         active.reservationTransferred = true;
+        if (
+          active.stopped ||
+          !isDesktopObserveRequesterCurrent(request.requester) ||
+          sessions.get(request.nodeId) !== session
+        ) {
+          throw new Error("desktop observe requester is no longer current");
+        }
         const minted = mintDesktopObserverToken({
           sourceKey,
           ownerEpoch: session.ownerEpoch,
@@ -280,6 +310,7 @@ export function createNodeDesktopService(params: {
         active.unclaimedTimer.unref?.();
         void active.invocation
           .finally(() => {
+            unwatchRequester();
             retireActiveStream(active);
             session.active.delete(active);
           })
@@ -293,6 +324,7 @@ export function createNodeDesktopService(params: {
           preauthenticated: true,
         };
       } catch (error) {
+        unwatchRequester();
         await stopActiveStream(active);
         session.active.delete(active);
         throw error;

--- a/src/gateway/desktop/observe-requester.ts
+++ b/src/gateway/desktop/observe-requester.ts
@@ -24,3 +24,37 @@ export function resolveDesktopObserveRequester(options: {
       hasCurrentClientAuthority?.() !== false,
   };
 }
+
+/** True when no requester constraint applies, or the requester is still live. */
+export function isDesktopObserveRequesterCurrent(
+  requester: DesktopObserveRequester | undefined,
+): boolean {
+  if (!requester) {
+    return true;
+  }
+  return requester.isCurrent() !== false && requester.signal?.aborted !== true;
+}
+
+/**
+ * Invokes `onGone` when the Gateway requester aborts (or is already gone).
+ * Returns an unsubscribe that is safe to call more than once.
+ */
+export function watchDesktopObserveRequesterGone(
+  requester: DesktopObserveRequester | undefined,
+  onGone: () => void,
+): () => void {
+  if (!requester) {
+    return () => {};
+  }
+  if (!isDesktopObserveRequesterCurrent(requester)) {
+    onGone();
+    return () => {};
+  }
+  const signal = requester.signal;
+  if (!signal) {
+    return () => {};
+  }
+  const onAbort = () => onGone();
+  signal.addEventListener("abort", onAbort, { once: true });
+  return () => signal.removeEventListener("abort", onAbort);
+}

--- a/src/gateway/desktop/observe-requester.ts
+++ b/src/gateway/desktop/observe-requester.ts
@@ -32,7 +32,7 @@ export function isDesktopObserveRequesterCurrent(
   if (!requester) {
     return true;
   }
-  return requester.isCurrent() !== false && requester.signal?.aborted !== true;
+  return requester.isCurrent() && !requester.signal?.aborted;
 }
 
 /**

--- a/src/gateway/worker-environments/node-desktop-carrier.test.ts
+++ b/src/gateway/worker-environments/node-desktop-carrier.test.ts
@@ -163,6 +163,63 @@ describe("worker node desktop carrier", () => {
     expect(streamed.streams[0]?.destroyed).toBe(true);
   });
 
+  it("aborts pending observe when requester disconnects before mint", async () => {
+    const mint = vi.spyOn(observeBridge, "mintDesktopObserverToken");
+    const controller = new AbortController();
+    const requester = {
+      signal: controller.signal,
+      isCurrent: () => !controller.signal.aborted,
+    };
+    const record = support.seedReadyNodeDesktop("worker-node-desktop-requester-abort");
+    const proof = nodeProof(record.nodeDeviceId!);
+    const transport = pendingTransport({ proof, isProofCurrent: () => true });
+    const streamed = fakeBroker();
+    const carrier = createWorkerNodeDesktopCarrier({
+      store: support.testState.store,
+      desktopRegistry: createDesktopSessionRegistry({ lingerMs: 1 }),
+    });
+    carrier.bindRuntime({ transport: transport.transport, streamBroker: streamed.broker });
+
+    const observing = carrier.observe({ record, control: false, requester });
+    await support.waitForFast(() => expect(transport.invoke).toHaveBeenCalledOnce());
+    const invokeSignal = transport.invoke.mock.calls[0]?.[0].signal;
+    expect(invokeSignal?.aborted).toBe(false);
+    controller.abort();
+    await support.waitForFast(() => expect(invokeSignal?.aborted).toBe(true));
+
+    await expect(observing).rejects.toThrow(
+      /requester is no longer current|ticket cancelled|invoke aborted|operation aborted|owner stopped/i,
+    );
+    expect(mint).not.toHaveBeenCalled();
+  });
+
+  it("refuses mint when requester is invalidated during delayed attachment", async () => {
+    const mint = vi.spyOn(observeBridge, "mintDesktopObserverToken");
+    const client = { invalidated: false };
+    const requester = {
+      signal: new AbortController().signal,
+      isCurrent: () => !client.invalidated,
+    };
+    const record = support.seedReadyNodeDesktop("worker-node-desktop-requester-invalidate");
+    const proof = nodeProof(record.nodeDeviceId!);
+    const transport = pendingTransport({ proof, isProofCurrent: () => true });
+    const streamed = fakeBroker();
+    const carrier = createWorkerNodeDesktopCarrier({
+      store: support.testState.store,
+      desktopRegistry: createDesktopSessionRegistry({ lingerMs: 1 }),
+    });
+    carrier.bindRuntime({ transport: transport.transport, streamBroker: streamed.broker });
+
+    const observing = carrier.observe({ record, control: false, requester });
+    await support.waitForFast(() => expect(transport.invoke).toHaveBeenCalledOnce());
+    client.invalidated = true;
+    const stream = streamed.attachNext();
+
+    await expect(observing).rejects.toThrow(/requester is no longer current/i);
+    expect(mint).not.toHaveBeenCalled();
+    expect(stream.destroyed).toBe(true);
+  });
+
   it.each([
     ["lease", (record: WorkerEnvironmentRecord) => ({ ...record, leaseId: "lease:replacement" })],
     [

--- a/src/gateway/worker-environments/node-desktop-carrier.ts
+++ b/src/gateway/worker-environments/node-desktop-carrier.ts
@@ -5,7 +5,11 @@ import {
 } from "../../infra/node-commands.js";
 import type { WorkerDesktopApp, WorkerDesktopEndpoint } from "../../plugins/types.js";
 import type { NodeDesktopStreamBroker } from "../desktop/node-stream-broker.js";
-import type { DesktopObserveRequester } from "../desktop/observe-requester.js";
+import {
+  isDesktopObserveRequesterCurrent,
+  watchDesktopObserveRequesterGone,
+  type DesktopObserveRequester,
+} from "../desktop/observe-requester.js";
 import {
   DesktopSessionStaleOwnerError,
   type DesktopSessionRegistry,
@@ -275,7 +279,14 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
     };
     // Publish ownership before discovery can yield so drain/destroy can abort this attempt.
     activeStreams.add(active);
+    let unwatchRequester = () => {};
     try {
+      if (!isDesktopObserveRequesterCurrent(request.requester)) {
+        throw new Error("desktop observe requester is no longer current");
+      }
+      unwatchRequester = watchDesktopObserveRequesterGone(request.requester, () => {
+        void stopStream(active);
+      });
       await claimOwner(binding);
       active.controller.signal.throwIfAborted();
       await options.desktopRegistry.activate({
@@ -325,10 +336,19 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
       });
       void invocationFinished.catch(() => undefined);
       const attached = await Promise.race([active.ticket.attached, invocationFinished]);
-      active.stream = attached.stream;
-      if (!bindingIsCurrent(binding, capturedRuntime, node)) {
-        throw new Error("Worker environment node desktop owner changed before attachment");
+      if (
+        active.stopped ||
+        !isDesktopObserveRequesterCurrent(request.requester) ||
+        !bindingIsCurrent(binding, capturedRuntime, node)
+      ) {
+        attached.stream.destroy();
+        throw new Error(
+          active.stopped || !isDesktopObserveRequesterCurrent(request.requester)
+            ? "desktop observe requester is no longer current"
+            : "Worker environment node desktop owner changed before attachment",
+        );
       }
+      active.stream = attached.stream;
       if (attached.auth !== "vnc-password" || !attached.vncPassword) {
         throw new Error("Worker environment node desktop did not provide VNC authentication");
       }
@@ -347,6 +367,9 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
         throw new Error("Worker environment node desktop owner changed before publication");
       }
       active.reservationTransferred = true;
+      if (active.stopped || !isDesktopObserveRequesterCurrent(request.requester)) {
+        throw new Error("desktop observe requester is no longer current");
+      }
       const issuedAtMs = Date.now();
       const minted = mintDesktopObserverToken({
         sourceKey: binding.environmentId,
@@ -369,7 +392,12 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
         Math.max(0, minted.expiresAtMs - Date.now()),
       );
       active.unclaimedTimer.unref?.();
-      void active.invocation.finally(() => retireStream(active)).catch(() => undefined);
+      void active.invocation
+        .finally(() => {
+          unwatchRequester();
+          retireStream(active);
+        })
+        .catch(() => undefined);
       return {
         transport: "rfb",
         wsPath: `${DESKTOP_OBSERVE_PATH}?token=${minted.token}`,
@@ -377,6 +405,7 @@ export function createWorkerNodeDesktopCarrier(options: WorkerNodeDesktopCarrier
         control: request.control,
       };
     } catch (error) {
+      unwatchRequester();
       await stopStream(active);
       throw error;
     }


### PR DESCRIPTION
## What Problem This Solves

`desktop.observe` / `worker.desktop.observe` bind observer tickets to the
requesting Gateway connection only at `mintDesktopObserverToken` (#141336).
Before mint, `node-source.observe` and `node-desktop-carrier.observe` keep an
active attach/invoke/reservation whose `AbortController` is not subscribed to
`requester.signal`, so a disconnect or invalidation leaves the stream live.
Screencast `#141031` already fences with `requesterGone()` before mint.

## Why This Change Was Made

Bridge `requester.signal` (and fence `isCurrent()===false`) onto the owner
active stream before attach/invoke in `node-source` and `node-desktop-carrier`,
and fence again immediately before mint. Shared helpers live on
`observe-requester` — not in observe-bridge (no duplicate cleanup of unminted
actives; no global RPC disconnect cancel).

## User Impact

**Before:** Ending the Gateway connection during node/worker desktop attach
could leave invoke/reservation/ticket active until other timeouts.

**After:** Requester abort or invalidation stops/retires the pre-mint stream
and refuses mint; post-mint authority remains owned by #141336.

## Evidence

- Changed: `src/gateway/desktop/observe-requester.ts`,
  `src/gateway/desktop/node-source.ts`,
  `src/gateway/desktop/node-source.test.ts`,
  `src/gateway/worker-environments/node-desktop-carrier.ts`,
  `src/gateway/worker-environments/node-desktop-carrier.test.ts`
- Production path: `desktop.observe` / `worker.desktop.observe` →
  `resolveDesktopObserveRequester` → `createNodeDesktopService.observe` /
  `createWorkerNodeDesktopCarrier.observe` → attach/invoke →
  `mintDesktopObserverToken`
- Compatibility: internal callers without a requester keep TTL-only behavior
- Dedup: #141336 merged (post-mint only); no open PR owns pre-mint
  `mintDesktopObserverToken` / node-source / node-desktop-carrier cancel
- Not mixed with #141379 (embedded abort agent scope)

## Real behavior proof

### Behavior or issue addressed

Delayed attachment + abort/invalidate requester before mint cancels invoke,
releases reservation/ticket, rejects observe, and does not mint.

### Canonical reachability path

Gateway RPC `desktop.observe` / `worker.desktop.observe` →
`resolveDesktopObserveRequester` → node-source / node-desktop-carrier
`observe` → watch requester → stop active on abort → fence before mint

### Shared helper / provider constraint check

Owner is node-source / node-desktop-carrier active stream. observe-bridge only
handles post-mint token/viewer revoke (#141336). Helpers added on
`observe-requester` only.

### Real environment tested

Local trusted source checkout at PR head; Vitest gateway-core project;
production `createNodeDesktopService` / `createWorkerNodeDesktopCarrier`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/gateway/desktop/node-source.test.ts src/gateway/worker-environments/node-desktop-carrier.test.ts --reporter=verbose
```

### Evidence after fix

```text
[test] starting test/vitest/vitest.gateway.config.ts

 RUN  v5.0.0 /workspace/openclaw-nocodet

 ✓ |gateway-core| src/gateway/desktop/node-source.test.ts > node desktop runtime policy > keeps requester authority on the observer ticket after node attachment 61ms
 ✓ |gateway-core| src/gateway/desktop/node-source.test.ts > node desktop runtime policy > does not dispatch after policy changes during activation 3ms
 ✓ |gateway-core| src/gateway/desktop/node-source.test.ts > node desktop runtime policy > does not dispatch after policy changes during pairing 2ms
 ✓ |gateway-core| src/gateway/desktop/node-source.test.ts > node desktop runtime policy > destroys a late attachment instead of publishing a revoked desktop 3ms
 ✓ |gateway-core| src/gateway/desktop/node-source.test.ts > node desktop runtime policy > aborts attach/invoke when the Gateway requester disconnects before mint 4ms
 ✓ |gateway-core| src/gateway/desktop/node-source.test.ts > node desktop runtime policy > refuses mint when requester is invalidated during delayed attachment 3ms
[vitest-workers] prepared c15bf726ade9 in 6055ms (8596 inputs, 4305 outputs)
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > observes an exact durable node desktop without SSH and preauthenticates it 162ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > aborts pending observe when requester disconnects before mint 82ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > refuses mint when requester is invalidated during delayed attachment 85ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > rejects an attach after the durable lease changes 81ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > rejects an attach after the durable node changes 76ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > rejects an attach after the durable epoch changes 77ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > rejects an attach after the durable state changes 83ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > rejects an attach after the durable destroy intent changes 89ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > rejects an attach after the durable desktop descriptor changes 78ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > rejects an attach after the node pairing proof changes 79ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > deduplicates one exact launch and aborts it on owner teardown 81ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > validates the closed node launcher ready result 74ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > validates the closed node launcher missing receipt result 72ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > validates the closed node launcher open receipt result 73ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > rejects a successful launch receipt after the durable owner becomes stale 76ms
 ✓ |gateway-core| src/gateway/worker-environments/node-desktop-carrier.test.ts > worker node desktop carrier > rejects a successful launch receipt after the pairing proof becomes stale 73ms

 Test Files  2 passed (2)
      Tests  22 passed (22)
   Start at  17:26:07
   Duration  11.88s (transform 68%, import 15%, tests 11%, worker 5%, setup 1%)

[vitest-workers] verifying completed generation before cleanup
[test] passed 1 Vitest shard in 13.94s
```

### Observed result after fix

New pre-mint abort/invalidate tests passed on both node-source and
node-desktop-carrier; existing requester-authority and owner-fence tests still
pass (22/22).

### What was not tested

No full Gateway WebSocket session; SSH environment tunnel acquire abort is
out of scope for this minimal PR (same mint fence remains post-acquire).

### Fix classification

Root cause fix.

## Checklist

- [x] AI-assisted
- [x] Allow edits from maintainers
- [x] Single concern / single commit
- [x] No CHANGELOG.md edit
