### PR TITLE
fix(gateway): trim wizard next/cancel/status sessionId before Map lookup

### DIFF
--- a/src/gateway/gateway-wizard-cancel.e2e.test.ts
+++ b/src/gateway/gateway-wizard-cancel.e2e.test.ts
@@ -128,6 +128,43 @@ async function withWizardGateway(
 
 describe("gateway wizard cancellation lifecycle", () => {
   it(
+    "cancels a live wizard when wizard.cancel receives a padded sessionId",
+    { timeout: GATEWAY_E2E_TIMEOUT_MS },
+    async () => {
+      const runnerSettled = createDeferred();
+      await withWizardGateway(
+        async (_opts, _runtime, prompter) => {
+          prompter.progress("working");
+          await runnerSettled.promise;
+        },
+        () => {
+          runnerSettled.resolve();
+        },
+        async ({ connect }) => {
+          const client = await connect();
+          const start = await client.request<WizardStartResult>("wizard.start", { mode: "local" });
+          expect(start).toMatchObject({ done: false, status: "running" });
+          expect(start.sessionId).toBeTruthy();
+
+          const paddedSessionId = ` ${start.sessionId} `;
+          const status = await client.request<{ status: string }>("wizard.status", {
+            sessionId: paddedSessionId,
+          });
+          expect(status).toMatchObject({ status: "running" });
+
+          await expect(
+            client.request("wizard.cancel", { sessionId: paddedSessionId }),
+          ).resolves.toMatchObject({ status: "cancelled" });
+          console.log(
+            `[wizard sessionId trim Gateway client E2E] status_running=true cancelled=true padded=${JSON.stringify(paddedSessionId)} exact=${start.sessionId}`,
+          );
+          runnerSettled.resolve();
+        },
+      );
+    },
+  );
+
+  it(
     "keeps a cancelled wizard owner until settlement before allowing a replacement",
     { timeout: GATEWAY_E2E_TIMEOUT_MS },
     async () => {

--- a/src/gateway/server-methods/wizard.session-id-trim.test.ts
+++ b/src/gateway/server-methods/wizard.session-id-trim.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import {
+  getActiveGatewayRootWorkCount,
+  resetGatewayWorkAdmission,
+  runWithGatewayIndependentRootWorkAdmission,
+} from "../../process/gateway-work-admission.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import type { WizardPrompter } from "../../wizard/prompts.js";
+import { WizardSession } from "../../wizard/session.js";
+import { bindWizardLoginOwner, createWizardSessionTracker } from "../server-wizard-sessions.js";
+import type { GatewayClient } from "./client-types.js";
+import { whenAdmittedWizardSessionSettled } from "./setup-admission.js";
+import { wizardHandlers } from "./wizard.js";
+
+afterEach(() => {
+  resetGatewayWorkAdmission();
+});
+
+describe("wizard.cancel padded sessionId", () => {
+  it("cancels a live wizard when sessionId has surrounding whitespace", async () => {
+    const runnerSettled = createDeferred();
+    const tracker = createWizardSessionTracker();
+    const context = {
+      ...tracker,
+      wizardRunner: async (_opts: unknown, _runtime: RuntimeEnv, prompter: WizardPrompter) => {
+        prompter.progress("working");
+        await runnerSettled.promise;
+      },
+    };
+
+    let sessionId = "";
+    await runWithGatewayIndependentRootWorkAdmission(async () => {
+      const respond = vi.fn();
+      await wizardHandlers["wizard.start"]!({
+        params: { mode: "local" },
+        respond,
+        context,
+      } as never);
+      sessionId = String(respond.mock.calls[0]?.[1]?.sessionId ?? "");
+    });
+    expect(sessionId).not.toBe("");
+    expect(tracker.wizardSessions.has(sessionId)).toBe(true);
+    expect(getActiveGatewayRootWorkCount()).toBe(1);
+
+    const cancelRespond = vi.fn();
+    await wizardHandlers["wizard.cancel"]!({
+      params: { sessionId: ` ${sessionId} ` },
+      respond: cancelRespond,
+      context,
+    } as never);
+
+    expect(cancelRespond.mock.calls[0]?.[0]).toBe(true);
+    expect(cancelRespond.mock.calls[0]?.[1]).toMatchObject({ status: "cancelled" });
+
+    runnerSettled.resolve();
+    const session = tracker.wizardSessions.get(sessionId);
+    if (session) {
+      await whenAdmittedWizardSessionSettled(session).catch(() => undefined);
+    }
+  });
+
+  it("prefers an exact caller-supplied padded session over the trimmed spelling", async () => {
+    const paddedHold = createDeferred();
+    const trimmedHold = createDeferred();
+    const tracker = createWizardSessionTracker();
+    const padded = new WizardSession(async () => {
+      await paddedHold.promise;
+    });
+    const trimmed = new WizardSession(async () => {
+      await trimmedHold.promise;
+    });
+    tracker.wizardSessions.set(" login ", padded);
+    tracker.wizardSessions.set("login", trimmed);
+
+    const respond = vi.fn();
+    await wizardHandlers["wizard.cancel"]!({
+      params: { sessionId: " login " },
+      respond,
+      context: tracker,
+    } as never);
+
+    expect(respond.mock.calls[0]?.[0]).toBe(true);
+    expect(respond.mock.calls[0]?.[1]).toMatchObject({ status: "cancelled" });
+    expect(padded.getStatus()).toBe("cancelled");
+    expect(trimmed.getStatus()).toBe("running");
+    expect(tracker.wizardSessions.get("login")).toBe(trimmed);
+
+    paddedHold.resolve();
+    trimmedHold.resolve();
+    await whenAdmittedWizardSessionSettled(padded).catch(() => undefined);
+    await whenAdmittedWizardSessionSettled(trimmed).catch(() => undefined);
+  });
+
+  it("does not fall back to the trimmed wizard when the exact padded session is unauthorized", async () => {
+    const paddedHold = createDeferred();
+    const trimmedHold = createDeferred();
+    const tracker = createWizardSessionTracker();
+    const padded = new WizardSession(async () => {
+      await paddedHold.promise;
+    });
+    const trimmed = new WizardSession(async () => {
+      await trimmedHold.promise;
+    });
+    const owner = { connId: "wizard-owner", invalidated: false } as GatewayClient;
+    const other = { connId: "wizard-other", invalidated: false } as GatewayClient;
+    bindWizardLoginOwner(padded, owner);
+    tracker.wizardSessions.set(" login ", padded);
+    tracker.wizardSessions.set("login", trimmed);
+
+    const respond = vi.fn();
+    await wizardHandlers["wizard.status"]!({
+      params: { sessionId: " login " },
+      respond,
+      context: tracker,
+      client: other,
+    } as never);
+
+    expect(respond.mock.calls[0]?.[0]).toBe(false);
+    expect(respond.mock.calls[0]?.[2]).toMatchObject({
+      details: { code: "WIZARD_NOT_FOUND" },
+    });
+    expect(tracker.wizardSessions.get(" login ")).toBe(padded);
+    expect(tracker.wizardSessions.get("login")).toBe(trimmed);
+    expect(trimmed.getStatus()).toBe("running");
+
+    paddedHold.resolve();
+    trimmedHold.resolve();
+    await whenAdmittedWizardSessionSettled(padded).catch(() => undefined);
+    await whenAdmittedWizardSessionSettled(trimmed).catch(() => undefined);
+  });
+});

--- a/src/gateway/server-methods/wizard.ts
+++ b/src/gateway/server-methods/wizard.ts
@@ -1,7 +1,10 @@
 // Wizard gateway methods manage interactive setup wizard sessions and route
 // start/next/status/cancel RPCs through the wizard runtime.
 import { randomUUID } from "node:crypto";
-import { readStringValue } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeOptionalString,
+  readStringValue,
+} from "@openclaw/normalization-core/string-coerce";
 import {
   ErrorCodes,
   errorShape,
@@ -91,9 +94,8 @@ function findWizardSessionOrRespond(params: {
   respond: RespondFn;
   sessionId: string;
   client: GatewayClient | null;
-}): WizardSession | null {
-  const session = params.context.wizardSessions.get(params.sessionId);
-  if (!session || !canAccessWizardSession(session, params.client)) {
+}): { session: WizardSession; sessionId: string } | null {
+  const respondNotFound = () => {
     params.respond(
       false,
       undefined,
@@ -102,8 +104,22 @@ function findWizardSessionOrRespond(params: {
       }),
     );
     return null;
+  };
+  const raw = params.sessionId;
+  const exact = params.context.wizardSessions.get(raw);
+  if (exact) {
+    return canAccessWizardSession(exact, params.client)
+      ? { session: exact, sessionId: raw }
+      : respondNotFound();
   }
-  return session;
+  const trimmed = normalizeOptionalString(raw);
+  if (trimmed && trimmed !== raw) {
+    const fallback = params.context.wizardSessions.get(trimmed);
+    if (fallback && canAccessWizardSession(fallback, params.client)) {
+      return { session: fallback, sessionId: trimmed };
+    }
+  }
+  return respondNotFound();
 }
 
 /** Gateway handlers for the interactive setup wizard session lifecycle. */
@@ -163,11 +179,16 @@ export const wizardHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateWizardNextParams, "wizard.next", respond)) {
       return;
     }
-    const sessionId = params.sessionId;
-    const session = findWizardSessionOrRespond({ context, respond, sessionId, client });
-    if (!session) {
+    const resolved = findWizardSessionOrRespond({
+      context,
+      respond,
+      sessionId: params.sessionId,
+      client,
+    });
+    if (!resolved) {
       return;
     }
+    const { session, sessionId } = resolved;
     const answer = params.answer as { stepId?: string; value?: unknown } | undefined;
     if (answer) {
       if (session.getStatus() !== "running") {
@@ -204,11 +225,16 @@ export const wizardHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateWizardCancelParams, "wizard.cancel", respond)) {
       return;
     }
-    const sessionId = params.sessionId;
-    const session = findWizardSessionOrRespond({ context, respond, sessionId, client });
-    if (!session) {
+    const resolved = findWizardSessionOrRespond({
+      context,
+      respond,
+      sessionId: params.sessionId,
+      client,
+    });
+    if (!resolved) {
       return;
     }
+    const { session, sessionId } = resolved;
     if (params.closeInput) {
       session.close(new Error("The setup window was closed."));
       await whenAdmittedWizardSessionSettled(session);
@@ -229,11 +255,16 @@ export const wizardHandlers: GatewayRequestHandlers = {
     if (!assertValidParams(params, validateWizardStatusParams, "wizard.status", respond)) {
       return;
     }
-    const sessionId = params.sessionId;
-    const session = findWizardSessionOrRespond({ context, respond, sessionId, client });
-    if (!session) {
+    const resolved = findWizardSessionOrRespond({
+      context,
+      respond,
+      sessionId: params.sessionId,
+      client,
+    });
+    if (!resolved) {
       return;
     }
+    const { session, sessionId } = resolved;
     const status = readWizardStatus(session);
     if (status.status !== "running") {
       await whenAdmittedWizardSessionSettled(session);


### PR DESCRIPTION
## What Problem This Solves

`wizard.next` / `wizard.cancel` / `wizard.status` forwarded the raw `sessionId` into an exact Map lookup. Clipboard-padded ids missed a live setup session. Unconditional trim-first would also collide with a caller-supplied key such as `" login "` when `"login"` is a different live session.

## Why This Change Was Made

Keep the caller-supplied sessionId. Look up the exact Map key first; trim only when that exact key is missing. If the exact session exists but `canAccessWizardSession` fails, do not fall back. Purge/cancel use the selected key. Proof is a real Gateway WebSocket client plus handler coverage for colliding keys.

## User Impact

**Before:** Pasting a wizard session id with surrounding whitespace returned not-found and left the setup session running.

**After:** Padded status/cancel hit the generated live session. A caller-supplied padded key stays distinct from its trimmed neighbor; an unauthorized exact session does not leak the trimmed one.

## Evidence

- Changed: `src/gateway/server-methods/wizard.ts`, `src/gateway/server-methods/wizard.session-id-trim.test.ts`, `src/gateway/gateway-wizard-cancel.e2e.test.ts`
- Production path: `connectGatewayClient` → `wizard.start` → padded `wizard.status` / `wizard.cancel`
- Compatibility: generated session ids stay unpadded; caller-supplied Map keys remain exact; only missing exact keys use trim fallback

## Real behavior proof

- **Behavior or issue addressed:** A running Gateway accepts clipboard-padded wizard session ids for status and cancel without collapsing distinct caller-supplied keys.
- **Canonical reachability path:** Real `GatewayClient` token auth → `wizard.start` → padded `wizard.status` (`running`) → padded `wizard.cancel` (`cancelled`).
- **Boundary crossed:** Real Gateway WebSocket RPC + live wizard runner (not a mocked handler callback).
- **Shared helper / provider constraint check:** `findWizardSessionOrRespond` is exact-first; unauthorized exact sessions return `WIZARD_NOT_FOUND` without trim fallback. Supplemental handler tests cover `" login "` vs `"login"` and owner mismatch.
- **Real environment tested:** Local trusted source checkout; Vitest e2e project; `startGatewayServer` + real `connectGatewayClient` on loopback.
- **Exact steps or command run after this patch:**

```bash
OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/gateway/gateway-wizard-cancel.e2e.test.ts -t "padded sessionId" --reporter=verbose
```

- **Evidence after fix:**

```text
 src/gateway/gateway-wizard-cancel.e2e.test.ts > gateway wizard cancellation lifecycle > cancels a live wizard when wizard.cancel receives a padded sessionId 4373ms

 Test Files  1 passed (1)
      Tests  1 passed | 3 skipped (4)
```

- **Observed result after fix:** Padded status returns `running`; padded cancel returns `cancelled`; colliding exact/trimmed keys stay distinct.
- **What was not tested:** `wizard.next` answers through a real client.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
