### PR TITLE
fix(gateway): trim Talk sessionId lookups in the unified session registry

### DIFF
--- a/src/gateway/server-methods/talk.session-close-id-trim.test.ts
+++ b/src/gateway/server-methods/talk.session-close-id-trim.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  forgetUnifiedTalkSession,
+  getUnifiedTalkSession,
+  rememberUnifiedTalkSession,
+} from "../talk-session-registry.js";
+import { talkSessionHandlers } from "./talk-session.js";
+
+const stopTalkRealtimeRelaySession = vi.fn();
+
+vi.mock("../talk-realtime-relay.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../talk-realtime-relay.js")>();
+  return {
+    ...actual,
+    stopTalkRealtimeRelaySession: (...args: unknown[]) => stopTalkRealtimeRelaySession(...args),
+  };
+});
+
+afterEach(() => {
+  stopTalkRealtimeRelaySession.mockReset();
+  try {
+    forgetUnifiedTalkSession("relay-pad-1");
+  } catch {
+    // already forgotten
+  }
+});
+
+describe("talk.session.close padded sessionId", () => {
+  it("closes a live realtime relay when sessionId has surrounding whitespace", async () => {
+    rememberUnifiedTalkSession("relay-pad-1", {
+      kind: "realtime-relay",
+      connId: "conn-pad",
+      relaySessionId: "relay-pad-1",
+      sessionTarget: {
+        agentId: "main",
+        canonicalKey: "agent:main:main",
+        storeKey: "agent:main:main",
+        storePath: "/tmp/unused",
+      } as never,
+    });
+    expect(getUnifiedTalkSession("relay-pad-1").kind).toBe("realtime-relay");
+
+    const respond = vi.fn();
+    await talkSessionHandlers["talk.session.close"]!({
+      req: { type: "req", id: "1", method: "talk.session.close" },
+      params: { sessionId: " relay-pad-1 " },
+      client: { connId: "conn-pad" },
+      isWebchatConnect: () => false,
+      respond,
+      context: {} as never,
+    } as never);
+
+    expect(respond).toHaveBeenCalledWith(true, { ok: true }, undefined);
+    expect(stopTalkRealtimeRelaySession).toHaveBeenCalledWith({
+      relaySessionId: "relay-pad-1",
+      connId: "conn-pad",
+    });
+    expect(() => getUnifiedTalkSession("relay-pad-1")).toThrow(/Unknown Talk session/);
+  });
+});

--- a/src/gateway/talk-session-close-id-trim.e2e.test.ts
+++ b/src/gateway/talk-session-close-id-trim.e2e.test.ts
@@ -1,0 +1,72 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { ADMIN_SCOPE } from "./operator-scopes.js";
+import { getTalkHandoff } from "./talk-handoff.js";
+import { getUnifiedTalkSession } from "./talk-session-registry.js";
+import { connectGatewayClient, disconnectGatewayClient } from "./test-helpers.e2e.js";
+import {
+  installGatewayTestHooks,
+  testState,
+  withGatewayServer,
+  writeSessionStore,
+} from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const GATEWAY_TOKEN = "talk-session-close-trim-e2e-token";
+
+describe("talk.session.close Gateway E2E", () => {
+  it("closes a live managed-room Talk session when talk.session.close receives a padded sessionId", async () => {
+    const stateDir = process.env.OPENCLAW_STATE_DIR;
+    if (!stateDir) {
+      throw new Error("OPENCLAW_STATE_DIR is required for talk session close E2E fixtures");
+    }
+    testState.gatewayAuth = { mode: "token", token: GATEWAY_TOKEN };
+    testState.sessionStorePath = path.join(stateDir, "sessions.sqlite");
+
+    await withGatewayServer(async ({ port }) => {
+      await writeSessionStore({
+        entries: {
+          "agent:main:main": {
+            sessionId: "talk-session-close-trim-session",
+            updatedAt: Date.now(),
+          },
+        },
+      });
+      const client = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token: GATEWAY_TOKEN,
+        scopes: [ADMIN_SCOPE],
+        timeoutMs: 60_000,
+      });
+      try {
+        const created = await client.request<{ sessionId?: string; handoffId?: string }>(
+          "talk.session.create",
+          { transport: "managed-room", sessionKey: "agent:main:main" },
+        );
+        const sessionId = created.sessionId;
+        if (!sessionId) {
+          throw new Error("talk.session.create did not return a sessionId");
+        }
+        expect(getUnifiedTalkSession(sessionId).kind).toBe("managed-room");
+        expect(getTalkHandoff(created.handoffId ?? sessionId)).toBeDefined();
+
+        const padded = ` ${sessionId} `;
+        expect(padded).not.toBe(sessionId);
+        await expect(client.request("talk.session.close", { sessionId: padded })).resolves.toEqual({
+          ok: true,
+        });
+        expect(() => getUnifiedTalkSession(sessionId)).toThrow(/Unknown Talk session/);
+        expect(getTalkHandoff(created.handoffId ?? sessionId)).toBeUndefined();
+        await expect(client.request("talk.session.close", { sessionId })).rejects.toThrow(
+          /Unknown Talk session/,
+        );
+        console.log(
+          `[talk.session.close Gateway client E2E] created=true closed=true forgotten=true padded=${JSON.stringify(padded)} exact=${sessionId}`,
+        );
+      } finally {
+        await disconnectGatewayClient(client);
+      }
+    });
+  }, 120_000);
+});

--- a/src/gateway/talk-session-registry.test.ts
+++ b/src/gateway/talk-session-registry.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
-import { cleanupTalkConnection, registerTalkConnectionCleanup } from "./talk-session-registry.js";
+import {
+  cleanupTalkConnection,
+  forgetUnifiedTalkSession,
+  getUnifiedTalkSession,
+  registerTalkConnectionCleanup,
+  rememberUnifiedTalkSession,
+} from "./talk-session-registry.js";
 
 describe("Talk connection cleanup registry", () => {
   it("keeps one cleanup per relay kind and fences reentrant cleanup", () => {
@@ -123,5 +129,42 @@ describe("Talk connection cleanup registry", () => {
       await draining;
     }
     expect(drained).toBe(true);
+  });
+});
+
+describe("Talk session id lookup trim", () => {
+  it("resolves and forgets padded session ids against exact Map keys", () => {
+    rememberUnifiedTalkSession("talk-trim-1", {
+      kind: "managed-room",
+      handoffId: "h1",
+      token: "t",
+      roomId: "r",
+    });
+    expect(getUnifiedTalkSession(" talk-trim-1 ").kind).toBe("managed-room");
+    forgetUnifiedTalkSession(" talk-trim-1 ");
+    expect(() => getUnifiedTalkSession("talk-trim-1")).toThrow(/Unknown Talk session/);
+  });
+
+  it("talk.session.close lookup path resolves a padded realtime relay id then forgets it", () => {
+    // Mirrors talk.session.close: getUnifiedTalkSession → stop → forgetUnifiedTalkSession
+    rememberUnifiedTalkSession("relay-close-pad", {
+      kind: "realtime-relay",
+      connId: "conn-1",
+      relaySessionId: "relay-close-pad",
+      sessionTarget: {
+        agentId: "main",
+        canonicalKey: "agent:main:main",
+        storeKey: "agent:main:main",
+        storePath: "/tmp/unused",
+      } as never,
+    });
+    const session = getUnifiedTalkSession(" relay-close-pad ");
+    expect(session.kind).toBe("realtime-relay");
+    if (session.kind === "realtime-relay") {
+      expect(session.relaySessionId).toBe("relay-close-pad");
+      expect(session.connId).toBe("conn-1");
+    }
+    forgetUnifiedTalkSession(" relay-close-pad ");
+    expect(() => getUnifiedTalkSession("relay-close-pad")).toThrow(/Unknown Talk session/);
   });
 });

--- a/src/gateway/talk-session-registry.ts
+++ b/src/gateway/talk-session-registry.ts
@@ -174,9 +174,14 @@ export function rememberUnifiedTalkSession(
   unifiedTalkSessions.set(sessionId, session);
 }
 
+/** Clipboard/RPC padding must not miss exact Map keys stored at create time. */
+function normalizeTalkSessionLookupId(sessionId: string): string {
+  return sessionId.trim();
+}
+
 /** Resolves a Talk session id or throws the protocol-facing unknown-session error. */
 export function getUnifiedTalkSession(sessionId: string): UnifiedTalkSessionRecord {
-  const session = unifiedTalkSessions.get(sessionId);
+  const session = unifiedTalkSessions.get(normalizeTalkSessionLookupId(sessionId));
   if (!session) {
     throw new Error("Unknown Talk session");
   }
@@ -185,7 +190,8 @@ export function getUnifiedTalkSession(sessionId: string): UnifiedTalkSessionReco
 
 /** Retains the realtime relay's admitted target without reinterpreting current defaults. */
 export function resolveUnifiedTalkSessionTarget(sessionId: string, connId: string | undefined) {
-  const session = unifiedTalkSessions.get(sessionId);
+  const key = normalizeTalkSessionLookupId(sessionId);
+  const session = unifiedTalkSessions.get(key);
   if (session?.kind !== "realtime-relay") {
     return undefined;
   }
@@ -194,7 +200,7 @@ export function resolveUnifiedTalkSessionTarget(sessionId: string, connId: strin
   return {
     target,
     isCurrent: () =>
-      unifiedTalkSessions.get(sessionId) === session &&
+      unifiedTalkSessions.get(key) === session &&
       session.connId === connId &&
       session.sessionTarget === target,
   };
@@ -202,7 +208,7 @@ export function resolveUnifiedTalkSessionTarget(sessionId: string, connId: strin
 
 /** Removes a Talk session id after the concrete backend closes. */
 export function forgetUnifiedTalkSession(sessionId: string): void {
-  unifiedTalkSessions.delete(sessionId);
+  unifiedTalkSessions.delete(normalizeTalkSessionLookupId(sessionId));
 }
 
 /** Enforces that a relay-backed Talk session is controlled by its owner socket. */


### PR DESCRIPTION
## What Problem This Solves

`talk.session.close` forwarded the raw `sessionId` into exact Map lookup. Clipboard-padded ids missed a live Talk session even though the session was created by the same Gateway.

## Why This Change Was Made

Normalize Talk session ids with `trim()` inside the unified session registry before get/forget, so every Talk RPC that uses that owner (including `talk.session.close`) hits the stored key. Proof is a real Gateway WebSocket client: `talk.session.create` (managed-room) then padded `talk.session.close`.

## User Impact

**Before:** Pasting a Talk session id with surrounding whitespace returned unknown-session and left the room/handoff live.

**After:** Padded close stops the live session; a follow-up exact close is unknown-session and the handoff is gone.

## Evidence

- Changed: `src/gateway/talk-session-registry.ts`, `src/gateway/talk-session-registry.test.ts`, `src/gateway/server-methods/talk.session-close-id-trim.test.ts`, `src/gateway/talk-session-close-id-trim.e2e.test.ts`
- Production path: `connectGatewayClient` (admin) → `talk.session.create` (`managed-room`) → `talk.session.close({ sessionId: " ${id} " })` → registry throw + handoff gone
- Compatibility: stored Talk session ids remain unpadded; only lookup/forget normalize input

## Real behavior proof

- **Behavior or issue addressed:** A running Gateway accepts a clipboard-padded `talk.session.close` sessionId and forgets the live managed-room session.
- **Canonical reachability path:** Real `GatewayClient` token auth + admin scope → `talk.session.create` → padded `talk.session.close` `{ ok: true }` → `getUnifiedTalkSession(exact)` throws `Unknown Talk session` → `getTalkHandoff` is undefined.
- **Boundary crossed:** Real Gateway WebSocket RPC + live unified Talk registry / handoff (not a mocked handler callback).
- **Shared helper / provider constraint check:** Trim lives in `normalizeTalkSessionLookupId` on the registry owner used by `talk.session.close`. A live OpenAI realtime relay was not available in this checkout; managed-room create/close is the same-process production close path.
- **Real environment tested:** Local trusted source checkout; Vitest e2e project; `withGatewayServer` + real `connectGatewayClient` on loopback.
- **Exact steps or command run after this patch:**

```bash
OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/gateway/talk-session-close-id-trim.e2e.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
 src/gateway/talk-session-close-id-trim.e2e.test.ts > talk.session.close Gateway E2E > closes a live managed-room Talk session when talk.session.close receives a padded sessionId 3617ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
   Duration  23.84s
```

- **Observed result after fix:** Padded close returns `{ ok: true }`; the exact session id is unknown afterward; the talk handoff is gone.
- **What was not tested:** Live OpenAI realtime-relay close (no provider credentials in this checkout); Control UI clipboard paste.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
