### PR TITLE
fix(cli): explain failed local secret resolution

### DIFF
--- a/src/cli/command-secret-gateway.test.ts
+++ b/src/cli/command-secret-gateway.test.ts
@@ -688,17 +688,21 @@ describe("resolveCommandSecretRefsViaGateway", () => {
     const envKey = "TALK_API_KEY_FAILFAST";
     await withEnvValue(envKey, undefined, async () => {
       callGateway.mockRejectedValueOnce(new Error("gateway closed"));
-      await expect(
-        resolveCommandSecretRefsViaGateway({
-          config: buildTalkTestProviderConfig({
-            source: "env",
-            provider: "default",
-            id: envKey,
-          }),
-          commandName: "memory status",
-          targetIds: new Set(["talk.providers.*.apiKey"]),
+      const resolution = resolveCommandSecretRefsViaGateway({
+        config: buildTalkTestProviderConfig({
+          source: "env",
+          provider: "default",
+          id: envKey,
         }),
-      ).rejects.toThrow(/failed to resolve secrets from the active gateway snapshot/i);
+        commandName: "memory status",
+        targetIds: new Set(["talk.providers.*.apiKey"]),
+      });
+      await expect(resolution).rejects.toThrow(
+        /failed to resolve secrets from the active gateway snapshot/i,
+      );
+      await expect(resolution).rejects.toThrow(/local resolution also failed/i);
+      await expect(resolution).rejects.toThrow(/check the configured secret sources/i);
+      await expect(resolution).rejects.not.toThrow(envKey);
     });
   });
 

--- a/src/cli/command-secret-gateway.ts
+++ b/src/cli/command-secret-gateway.ts
@@ -991,7 +991,7 @@ export async function resolveCommandSecretRefsViaGateway(params: {
       );
     }
     throw new Error(
-      `${params.commandName}: failed to resolve secrets from the active gateway snapshot (${formatErrorMessage(err)}). Start the gateway and retry.`,
+      `${params.commandName}: failed to resolve secrets from the active gateway snapshot (${formatErrorMessage(err)}). Local resolution also failed. Check the configured secret sources and gateway access, then retry.`,
       { cause: err },
     );
   }


### PR DESCRIPTION
When Gateway secret resolution is unavailable and local resolution also fails, strict commands only advised starting the Gateway. The final error now identifies the local failure too and advises checking configured secret sources and Gateway access. Strict rejection, the JSON error shape and the existing Gateway context stay intact; no local error, reference or secret value is added to output.

Validation:

- The new regression assertion fails on main `4b1f467dff76`; five focused strict, local-success and incomplete-snapshot controls pass with the fix.
- Real source CLI `models status --json --check`: a missing secret file still exits 1 with both resolution failures explained; a valid local file still exits 0 without a Gateway. Both outputs preserve secret-value masking.
- Pinned formatting, syntax-only lint, assertion-safety and max-lines ratchets pass. Full type checks remain CI-owned.

Production changes one message with no net line growth. AI-assisted.
