### PR TITLE
fix: show completed fallback models in session diagnostics

### DIFF
--- a/src/auto-reply/reply/agent-runner-result-accounting.fallback.test.ts
+++ b/src/auto-reply/reply/agent-runner-result-accounting.fallback.test.ts
@@ -1,0 +1,226 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterAll, beforeAll, expect, it } from "vitest";
+import {
+  loadSessionEntry,
+  persistSessionTranscriptTurn,
+  replaceSessionEntry,
+} from "../../config/sessions/session-accessor.js";
+import { drainSessionStoreWriterQueuesForTest } from "../../config/sessions/store-writer-state.js";
+import type { InternalSessionEntry } from "../../config/sessions/types.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { buildGatewaySessionRow } from "../../gateway/session-utils-row.js";
+import { disposeOpenClawAgentDatabaseByPath } from "../../state/openclaw-agent-db.js";
+import { accountAgentTurn } from "./agent-runner-result-accounting.js";
+import { createMockFollowupRun } from "./test-helpers.js";
+
+const diagnostic = { provider: "primary-fixture", model: "thinking" };
+let root: string;
+let storePath: string;
+let sequence = 0;
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-fallback-projection-"));
+  storePath = path.join(root, "openclaw-agent.sqlite");
+});
+afterAll(async () => {
+  await drainSessionStoreWriterQueuesForTest();
+  disposeOpenClawAgentDatabaseByPath(storePath);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+async function createFixture() {
+  const id = ++sequence;
+  const sessionKey = `agent:main:fallback-${id}`;
+  const entry: InternalSessionEntry = {
+    sessionId: `fallback-session-${id}`,
+    lifecycleRevision: "generation-1",
+    updatedAt: 1,
+    modelProvider: diagnostic.provider,
+    model: diagnostic.model,
+  };
+  const cfg: OpenClawConfig = { session: { store: storePath } };
+  await replaceSessionEntry({ storePath, sessionKey }, entry);
+  const context: Parameters<typeof accountAgentTurn>[0] = {
+    activeSessionEntry: entry,
+    activeSessionStore: { [sessionKey]: entry },
+    blockReplyPipeline: null,
+    cfg,
+    defaultModel: diagnostic.model,
+    followupRun: createMockFollowupRun({
+      run: {
+        sessionId: entry.sessionId,
+        sessionKey,
+        agentDir: root,
+        workspaceDir: root,
+        config: cfg,
+        provider: diagnostic.provider,
+        model: diagnostic.model,
+      },
+    }),
+    isHeartbeat: false,
+    pendingToolTasks: new Set(),
+    preflightCompactionApplied: false,
+    resolvedVerboseLevel: "off",
+    execution: {
+      kind: "settled",
+      status: "ok",
+      result: { payloads: [{ text: "done" }], meta: { durationMs: 1 } },
+      resolved: { provider: diagnostic.provider, model: diagnostic.model },
+      fallback: { exhausted: false, attempts: [] },
+      autoCompactionCount: 0,
+      didLogHeartbeatStrip: false,
+    },
+    runId: `fallback-run-${id}`,
+    runStartedAt: Date.now(),
+    sessionCtx: {},
+    sessionKey,
+    shouldInjectGroupIntro: false,
+    storePath,
+  };
+  return {
+    context,
+    read: () => loadSessionEntry({ storePath, sessionKey, readConsistency: "latest" }),
+    replace: (next: InternalSessionEntry) => replaceSessionEntry({ storePath, sessionKey }, next),
+    account: async (route: { provider: string; model: string }) => {
+      context.execution.result.meta.agentMeta = {
+        sessionId: entry.sessionId,
+        contextTokens: 1_000,
+        ...route,
+      };
+      return accountAgentTurn(context);
+    },
+  };
+}
+
+it.each([false, true])(
+  "projects a completed fallback with stored primary=%s",
+  async (storedPrimary) => {
+    const fixture = await createFixture();
+    const { context } = fixture;
+    const entry = context.activeSessionEntry!;
+    if (!storedPrimary) {
+      delete entry.model;
+      delete entry.modelProvider;
+    }
+    await fixture.replace(entry);
+    context.cfg.agents = {
+      defaults: { model: { primary: `${diagnostic.provider}/${diagnostic.model}` } },
+    };
+    context.execution.resolved = { provider: "fallback-fixture", model: "plain" };
+    context.execution.fallback.attempts = [
+      { provider: diagnostic.provider, model: diagnostic.model, error: "model not found" },
+    ];
+
+    await fixture.account({ provider: "fallback-fixture", model: "plain" });
+    await persistSessionTranscriptTurn(
+      { agentId: "main", storePath, sessionKey: context.sessionKey!, sessionId: entry.sessionId },
+      {
+        config: context.cfg,
+        expectedSessionId: entry.sessionId,
+        runId: context.runId,
+        messages: [
+          {
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "done" }],
+              provider: "fallback-fixture",
+              model: "plain",
+              stopReason: "stop",
+            },
+          },
+        ],
+        sessionLifecyclePatch: { status: "done", lastRunId: context.runId },
+      },
+    );
+
+    const stored = fixture.read()!;
+    expect(stored.fallbackNotice).toMatchObject({
+      selectedModel: `${diagnostic.provider}/${diagnostic.model}`,
+      activeModel: "fallback-fixture/plain",
+    });
+    const project = (rowEntry: InternalSessionEntry) =>
+      buildGatewaySessionRow({
+        cfg: context.cfg,
+        agentId: "main",
+        skipTranscriptUsageFallback: true,
+        lightweightListRow: true,
+        storePath,
+        store: { [context.sessionKey!]: rowEntry },
+        key: context.sessionKey!,
+        entry: rowEntry,
+      });
+    expect(project(stored)).toMatchObject({
+      modelProvider: diagnostic.provider,
+      model: diagnostic.model,
+      activeModelProvider: "fallback-fixture",
+      activeModel: "plain",
+    });
+    for (const changed of [
+      { status: "running" as const },
+      { lastRunId: "another-run" },
+      { sessionId: "another-session" },
+      { providerOverride: "another-provider", modelOverride: "another-model" },
+    ]) {
+      const row = project({ ...stored, ...changed });
+      expect(row.activeModel, JSON.stringify(changed)).toBeUndefined();
+      expect(row.activeModelProvider, JSON.stringify(changed)).toBeUndefined();
+    }
+
+    const recoveryRunId = `${context.runId}-recovery`;
+    await persistSessionTranscriptTurn(
+      { agentId: "main", storePath, sessionKey: context.sessionKey!, sessionId: entry.sessionId },
+      {
+        config: context.cfg,
+        expectedSessionId: entry.sessionId,
+        runId: context.runId,
+        messages: [
+          {
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "hidden answer" }],
+              display: false,
+              provider: "fallback-fixture",
+              model: "plain",
+              stopReason: "stop",
+            },
+          },
+        ],
+      },
+    );
+    expect(project(fixture.read()!).activeModel).toBeUndefined();
+    await persistSessionTranscriptTurn(
+      { agentId: "main", storePath, sessionKey: context.sessionKey!, sessionId: entry.sessionId },
+      {
+        config: context.cfg,
+        expectedSessionId: entry.sessionId,
+        runId: recoveryRunId,
+        messages: [
+          {
+            message: {
+              role: "assistant",
+              content: [{ type: "text", text: "recovered" }],
+              provider: diagnostic.provider,
+              model: diagnostic.model,
+              stopReason: "length",
+            },
+          },
+        ],
+        sessionLifecyclePatch: { status: "done", lastRunId: recoveryRunId },
+      },
+    );
+    // The newer completed primary answer rejects the old notice even before accounting clears it.
+    const recovered = fixture.read()!;
+    expect(recovered.fallbackNotice).toEqual(stored.fallbackNotice);
+    expect(project(recovered)).toMatchObject({
+      modelProvider: diagnostic.provider,
+      model: diagnostic.model,
+      activeModelProvider: undefined,
+      activeModel: undefined,
+    });
+    context.execution.resolved = { provider: diagnostic.provider, model: diagnostic.model };
+    context.execution.fallback.attempts = [];
+    await fixture.account({ provider: diagnostic.provider, model: diagnostic.model });
+    expect(fixture.read()?.fallbackNotice).toBeUndefined();
+  },
+);

--- a/src/auto-reply/reply/agent-runner-result-accounting.fallback.test.ts
+++ b/src/auto-reply/reply/agent-runner-result-accounting.fallback.test.ts
@@ -109,7 +109,12 @@ it.each([false, true])(
     };
     context.execution.resolved = { provider: "fallback-fixture", model: "plain" };
     context.execution.fallback.attempts = [
-      { provider: diagnostic.provider, model: diagnostic.model, error: "model not found" },
+      {
+        provider: diagnostic.provider,
+        model: diagnostic.model,
+        error: "model not found",
+        reason: "model_not_found",
+      },
     ];
 
     await fixture.account({ provider: "fallback-fixture", model: "plain" });

--- a/src/gateway/session-transcript-readers.ts
+++ b/src/gateway/session-transcript-readers.ts
@@ -4,6 +4,7 @@ import { SessionManager } from "../agents/sessions/session-manager.js";
 import {
   isSessionTranscriptProjectionUnavailableError,
   readRecentSessionTranscriptMessageEvents,
+  readSessionTranscriptBoundedMessageTailPage,
   readSessionTranscriptMessageEvents,
   resolveConcreteSessionStorePath,
   resolveSessionTranscriptReadTarget,
@@ -22,6 +23,8 @@ import {
   readSessionTranscriptHistoryEvents,
 } from "../config/sessions/session-accessor.sqlite-history-events.js";
 import { resolveAgentIdFromSessionKey } from "../routing/session-key.js";
+import { readSessionTranscriptRunId } from "../sessions/transcript-events.js";
+import { projectSessionDisplayMessage } from "./session-display-projection.js";
 import { aggregateSessionTranscriptUsage } from "./session-transcript-derived-readers.js";
 import { projectTranscriptEntryMessage } from "./session-transcript-message.js";
 import type {
@@ -437,6 +440,35 @@ export function readRecentSessionUsageFromTranscript(
     maxMessages: 1000,
   });
   return aggregateSessionTranscriptUsage(extractMessagePayloads(page.events));
+}
+
+/** Reads the answering model only when the latest visible message belongs to this settled run. */
+export function readSessionTerminalModelFromTranscript(
+  scope: SessionTranscriptReadScope,
+  runId: string,
+): { modelProvider: string; model: string } | undefined {
+  try {
+    const page = readSessionTranscriptBoundedMessageTailPage(scope, {
+      maxBytes: 256 * 1024,
+      maxMessages: 1,
+      offset: 0,
+    });
+    const message = asOptionalRecord(asOptionalRecord(page.events[0]?.event)?.message);
+    if (
+      (message?.stopReason === "stop" || message?.stopReason === "length") &&
+      readSessionTranscriptRunId(message) === runId &&
+      projectSessionDisplayMessage(message)?.role === "assistant" &&
+      typeof message.provider === "string" &&
+      typeof message.model === "string"
+    ) {
+      return { modelProvider: message.provider, model: message.model };
+    }
+  } catch (error) {
+    if (!isSessionTranscriptProjectionUnavailableError(error)) {
+      throw error;
+    }
+  }
+  return undefined;
 }
 
 /** Reads a bounded display or canonical model-context preview before discarding metadata. */

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -44,6 +44,7 @@ import {
 import { isSessionPermissionChangePending } from "./session-permission-change.js";
 import { resolveStoredSessionKeyForAgentStore } from "./session-store-key.js";
 import { buildSessionSwarmSummary } from "./session-swarm-summary.js";
+import { readSessionTerminalModelFromTranscript } from "./session-transcript-readers.js";
 import { readSessionTitleFieldsFromTranscript as readScopedSessionTitleFieldsFromTranscript } from "./session-transcript-title-reader.js";
 import type { SessionListRowContext } from "./session-utils-contracts.js";
 import {
@@ -209,10 +210,17 @@ export function buildGatewaySessionRow(params: {
     rowContext: params.rowContext,
   });
   // Display aliases do not change the selected route's catalog or runtime policy.
+  const completedModel =
+    entry?.status === "done" && entry.lastRunId && entry.fallbackNotice
+      ? readSessionTerminalModelFromTranscript(
+          { agentId: sessionAgentId, sessionKey: key, sessionId: entry.sessionId, storePath },
+          entry.lastRunId,
+        )
+      : undefined;
   const runtimeModels = resolveSelectedAndActiveModel({
     selectedProvider: rowModelProvider,
     selectedModel: rowModel,
-    sessionEntry: entry,
+    sessionEntry: completedModel ?? entry,
   });
   const activeFallback = resolveActiveFallbackState({
     selectedModelRef: runtimeModels.selected.label,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where chat model controls could omit the model that answered after the selected primary failed. The selected model stayed correct, but the existing active-model fields were empty even after a visible, successful fallback.

## Why This Change Was Made

Fallback accounting deliberately preserves the session's selection fields. Session diagnostics now read the answering model from the latest canonical transcript message for the completed session and exact run, then apply the existing fallback-notice and alias checks. The read uses the existing one-message, 256 KiB materialization bound and requires a visible terminal assistant message.

## User Impact

Users can distinguish the selected primary from the fallback that answered. The next turn still starts from the selected primary, and successful primary recovery clears the active fallback. Selection, thinking defaults, model metadata, authentication, and persistent-store semantics are unchanged.

## Evidence

- Current-main regression reproduced the missing active fields through real accounting, transcript persistence, and lightweight session-row projection, starting without a stored runtime model pair.
- Four focused tests pass: fresh and previous-primary fallback sequences plus existing active/stale projection controls. The sequences cover changed selection, other runs/sessions, running state, hidden output, and primary recovery while an old notice remains.
- An authenticated source-mode Gateway with a synthetic loopback provider made exactly three model requests: primary 404, fallback 200, primary recovery 200. Public settled receipts, history, and session lists agreed on the answering model. Selection, thinking defaults, and model metadata stayed unchanged; recovery cleared both active fields.
- Scoped formatting, lint, and diff checks pass. Typechecking and required CI run on the PR head.

Production changes are +41/-1 lines. The additional reader preserves exact run and visibility checks without changing stored selection state. A focused regression file keeps the accounting fixture and failure/recovery sequence together. Diagnostics remain unavailable when the bounded latest-message read cannot establish the answering model.
