### PR TITLE
fix(update): keep non-ASCII canary diagnostics intact

### DIFF
--- a/src/infra/update-candidate-canary.test.ts
+++ b/src/infra/update-candidate-canary.test.ts
@@ -413,6 +413,68 @@ describe("update candidate canary", () => {
     await expect(fs.access(snapshotInput.targetStateDir)).rejects.toMatchObject({ code: "ENOENT" });
   });
 
+  it.each([0, 1])("bounds multibyte stdout at the byte ceiling plus %i", async (overflow) => {
+    runtimeError = true;
+    const baseSpawn = mocks.spawn.getMockImplementation()!;
+    mocks.spawn.mockImplementation((command, args: string[], options) => {
+      if (!args.includes("plugins")) {
+        return baseSpawn(command, args, options);
+      }
+      const child = new FakeChild(nextPid++);
+      const json = JSON.stringify({ plugins: [], padding: "é".repeat(500_000) });
+      const bytes = Buffer.from(
+        json + " ".repeat(1024 * 1024 + overflow - Buffer.byteLength(json)),
+      );
+      queueMicrotask(() => {
+        child.stdout.write(bytes.subarray(0, 600_000));
+        child.stdout.end(bytes.subarray(600_000));
+        child.emit("close", 0);
+      });
+      return child;
+    });
+    const result = await validateUpdateCandidateCanary({
+      root,
+      stateDir: root,
+      config: {},
+      env: {},
+      timeoutMs: 3_000,
+    });
+    expect(result).toMatchObject({ status: "error", phase: overflow ? "plugins" : "runtime" });
+  });
+
+  it("preserves split UTF-8 diagnostics and final unterminated lines on both pipes", async () => {
+    const expected = ["stdout 診断: café 🦞", "stderr 診断: café 🦞"];
+    mocks.spawn.mockImplementationOnce(() => {
+      const child = new FakeChild(nextPid++);
+      queueMicrotask(() => {
+        for (const [index, stream] of [child.stdout, child.stderr].entries()) {
+          // Real pipe chunks may end inside a code point; EOF need not follow a newline.
+          const bytes = Buffer.from(`${expected[index]}\r\n${expected[index]} final`);
+          for (const byte of bytes) {
+            stream.write(Buffer.from([byte]));
+          }
+          stream.end();
+        }
+        child.emit("close", 1);
+      });
+      return child;
+    });
+    const result = await validateUpdateCandidateCanary({
+      root,
+      stateDir: root,
+      config: {},
+      env: {},
+      timeoutMs: 3_000,
+    });
+    expect(result.status).toBe("error");
+    for (const line of expected) {
+      expect(result.logTail).toContain(line);
+      expect(result.logTail).toContain(`${line} final`);
+      expect(result.steps.at(-1)?.stderrTail).toContain(`${line}\n`);
+      expect(result.steps.at(-1)?.stderrTail).toContain(`${line} final`);
+    }
+  });
+
   it("omits the entire oversized log line across chunks while preserving following diagnostics", async () => {
     mocks.spawn.mockImplementationOnce(() => {
       const child = new FakeChild(nextPid++);

--- a/src/infra/update-candidate-canary.ts
+++ b/src/infra/update-candidate-canary.ts
@@ -153,19 +153,15 @@ export async function validateUpdateCandidateCanary(params: {
       windowsHide: true,
     });
     let stdout = "";
+    let stdoutBytes = 0;
     let outputExceeded = false;
-    child.stdout.on("data", (chunk: Buffer) => {
-      if (stdout.length + chunk.length <= 1024 * 1024) {
-        stdout += chunk.toString("utf8");
-      } else {
-        outputExceeded = true;
-      }
-    });
     const flushers = [child.stdout, child.stderr].map((stream) => {
+      // Node entrypoints emit UTF-8; pipe chunks need not end at code-point boundaries.
+      stream.setEncoding("utf8");
       let pending = "";
       let droppingLine = false;
-      stream.on("data", (chunk: Buffer) => {
-        let text = chunk.toString("utf8");
+      stream.on("data", (chunk: string) => {
+        let text = chunk;
         if (droppingLine) {
           const newline = text.indexOf("\n");
           if (newline < 0) {
@@ -193,6 +189,14 @@ export async function validateUpdateCandidateCanary(params: {
           pending = "";
         }
       };
+    });
+    child.stdout.on("data", (chunk: string) => {
+      stdoutBytes += Buffer.byteLength(chunk);
+      if (stdoutBytes <= 1024 * 1024) {
+        stdout += chunk;
+      } else {
+        outputExceeded = true;
+      }
     });
     let exited = false;
     const closed = new Promise<number | null>((resolve) => {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where operators validating an update candidate would see corrupted non-ASCII diagnostics when a child-process pipe read ended inside a UTF-8 character.

## Why This Change Was Made

The canary now uses Node's streaming UTF-8 decoder for each known-UTF-8 pipe before collecting lines and stdout. Its existing 1 MiB stdout ceiling is measured consistently in bytes, removing the previous mixture of string lengths and byte lengths.

## User Impact

Update-candidate diagnostics preserve names and messages containing multibyte characters, including CRLF-delimited text and final lines without a newline. Oversized stdout remains rejected at the byte ceiling.

## Evidence

The split-output regression failed on the original implementation; all 16 canary tests pass on the final candidate. Controlled local Node children confirm the before/after text behavior and exact/one-byte-over byte limits. The canonical infra test type graph, full-file type-aware lint, formatting, diff checks, and independent P2 autoreview pass.

No live updater or operator state was used. Production delta: +4 lines; tests: +62 lines. The full aggregate changed-check and publication/merge gates remain separate from this focused proof.
