### PR TITLE
feat(telegram): send photo attachments as native albums

### DIFF
--- a/docs/channels/telegram.md
+++ b/docs/channels/telegram.md
@@ -695,7 +695,26 @@ curl "https://api.telegram.org/bot<bot_token>/getUpdates"
 
   </Accordion>
 
-  <Accordion title="Audio, video, and stickers">
+  <Accordion title="Photo albums, audio, video, and stickers">
+    ### Photo albums
+
+    Send multiple image attachments in one `message` tool call. OpenClaw groups consecutive photos into Telegram albums of up to 10 images, in their original order. Automatic replies with multiple photos use the same grouping. A single photo, including a final remainder of one, is sent separately.
+
+```json5
+{
+  action: "send",
+  channel: "telegram",
+  to: "123456789",
+  message: "Trip photos",
+  attachments: [
+    { type: "image", media: "https://example.com/photo-1.jpg" },
+    { type: "image", media: "https://example.com/photo-2.jpg" },
+  ],
+}
+```
+
+    The caption goes on the first photo. Text that exceeds the caption limit follows the album as a separate message. Photos sent as documents, other media types, and messages with inline buttons keep separate sends so their existing controls and delivery behavior are preserved.
+
     ### Audio messages
 
     Telegram distinguishes voice notes from audio files. Default: audio-file behavior; tag `[[audio_as_voice]]` in the agent reply to force a voice-note send. Inbound voice-note transcripts are framed as machine-generated, untrusted text in agent context, but mention detection still uses the raw transcript so mention-gated voice messages keep working.

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -426,6 +426,19 @@ through the outbound/message adapter. Use `actions.handleAction(...)` for send
 only as a compatibility fallback for payloads that cannot be serialized and
 retried.
 
+For send actions, preserve the trusted context's `onPlatformSendDispatch`,
+`assertDirectAdapterHandoff`, and `skipQueue` when calling
+`sendDurableMessageBatch(...)`. These fields come from the host, not action
+arguments. Await the dispatch callback before each physical send, then call
+the synchronous assertion after preparation or throttling waits and immediately
+before platform I/O. A closed owner must stop every remaining send.
+
+`skipQueue: true` keeps sends tied to a live run out of replayable recovery.
+The separate `deliveryRetryOwner` field controls who handles failed delivery;
+it does not extend the run's authority. Operator sends retain normal durable
+queueing. Do not serialize either authority callback or expose these fields in
+the model-facing action schema.
+
 ### Session conversation grammar
 
 If your platform stores extra scope inside conversation ids, keep that parsing

--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -409,6 +409,16 @@ inbound context. When a plugin must authorize local media reads, import
 
 ### Native payload shaping
 
+Set `outbound.sendPayloadGroupsMedia: true` only when the payload sender owns
+multi-attachment grouping. Core then preserves a multi-media list for that
+sender when its durable payload and reconciliation capabilities permit it.
+Without this explicit opt-in, ordinary attachments keep per-item delivery.
+
+Grouped senders must check the outbound context's `signal` before each physical
+send and after awaited preparation, and retain the platform-dispatch and
+current-owner callbacks at each send boundary. Declaring general payload
+support alone does not opt a plugin into this responsibility.
+
 If your channel needs provider-specific shaping for `message(action="send")`,
 prefer `actions.prepareSendPayload(...)`. Put native cards, blocks, embeds, or
 other durable data under `payload.channelData.<channel>` and let core send

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -435,6 +435,9 @@ export async function handleTelegramAction(
     inboundEventKind?: string;
     gatewayClientScopes?: readonly string[];
     deliveryRetryOwner?: ChannelMessageActionContext["deliveryRetryOwner"];
+    onPlatformSendDispatch?: ChannelMessageActionContext["onPlatformSendDispatch"];
+    assertDirectAdapterHandoff?: ChannelMessageActionContext["assertDirectAdapterHandoff"];
+    skipQueue?: boolean;
     conversationReadOrigin?: ConversationReadInvocationOrigin;
     requesterAccountId?: string | null;
     reply?: ChannelMessageActionContext["reply"];
@@ -747,6 +750,9 @@ export async function handleTelegramAction(
       durability: "required",
       gatewayClientScopes: options?.gatewayClientScopes,
       deliveryRetryOwner: options?.deliveryRetryOwner,
+      onPlatformSendDispatch: options?.onPlatformSendDispatch,
+      assertDirectAdapterHandoff: options?.assertDirectAdapterHandoff,
+      skipQueue: options?.skipQueue,
       ...(mediaAccess ? { mediaAccess } : {}),
       ...(outboundSession ? { session: outboundSession } : {}),
     });

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -440,7 +440,7 @@ async function deliverMediaReply(params: {
                 message: part.result,
                 messageId: part.result.message_id,
                 fallbackChatId: params.chatId,
-                successfulSendThread: params.thread,
+                ...(params.thread ? { successfulSendThread: params.thread } : {}),
                 kind: "media",
               }),
             ),

--- a/extensions/telegram/src/bot/delivery.replies.ts
+++ b/extensions/telegram/src/bot/delivery.replies.ts
@@ -4,6 +4,7 @@ import type { Message } from "grammy/types";
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import {
   createOutboundPayloadPlan,
+  createMessageReceiptFromOutboundResults,
   projectOutboundPayloadPlanForDelivery,
 } from "openclaw/plugin-sdk/channel-outbound";
 import type { MarkdownTableMode, ReplyToMode } from "openclaw/plugin-sdk/config-contracts";
@@ -36,6 +37,7 @@ import {
   canonicalizeTelegramPresentationPayload,
   resolveTelegramInteractiveTextFallback,
 } from "../interactive-fallback.js";
+import { planTelegramMediaBatches } from "../outbound-media-batches.js";
 import {
   prepareTelegramOutboundMedia,
   resolveTelegramOutboundMediaSenders,
@@ -47,9 +49,13 @@ import { TELEGRAM_RICH_TEXT_LIMIT } from "../rich-message.js";
 import { isTelegramEmptyContentError } from "../rich-plain-fallback.js";
 import {
   isTelegramCaptionTooLongError,
+  isTelegramPhotoLimitError,
   isTelegramVoiceMessagesForbiddenError,
 } from "../send-error-predicates.js";
-import { reportTelegramProviderDelivery } from "../send-outbound.js";
+import {
+  buildTelegramProviderDeliveryResult,
+  reportTelegramProviderDelivery,
+} from "../send-outbound.js";
 import {
   createTelegramPreparedSender,
   createTelegramReplyRequest,
@@ -310,6 +316,28 @@ async function deliverMediaReply(params: {
     };
     await params.progress.promptContext?.accept(promptContextMessage);
   };
+  const observeMedia = async (
+    { result: message, messageId, plainText }: TelegramPreparedSender["parts"][number],
+    captionRemoved?: true,
+  ) => {
+    if (params.thread?.id !== undefined) {
+      await reportTelegramProviderDelivery({
+        message,
+        messageId,
+        fallbackChatId: params.chatId,
+        successfulSendThread: params.thread,
+        kind: "media",
+      });
+    }
+    firstDeliveredMessageId ??= messageId;
+    firstDeliveredCaption ??= plainText || undefined;
+    if (captionRemoved) {
+      visibleFallbackText = "";
+    }
+    params.recordMessageId(messageId);
+    await recordPromptContextMessage(message, plainText || undefined);
+    markDelivered(params.progress);
+  };
   const deliverAcceptedMedia = async (options: {
     sender: TelegramOutboundMediaSender<Message>;
     documentSender?: TelegramOutboundMediaSender<Message>;
@@ -318,25 +346,8 @@ async function deliverMediaReply(params: {
     plainCaption?: string;
   }) => {
     const delivery = await params.sender.sendMedia(options);
-    await params.sender.accept(delivery, async ({ result: message, messageId, plainText }) => {
-      mediaUrls.push(options.mediaUrl);
-      if (params.thread?.id !== undefined) {
-        await reportTelegramProviderDelivery({
-          message,
-          messageId,
-          fallbackChatId: params.chatId,
-          successfulSendThread: params.thread,
-        });
-      }
-      firstDeliveredMessageId ??= messageId;
-      firstDeliveredCaption ??= plainText || undefined;
-      if (delivery.captionRemoved) {
-        visibleFallbackText = "";
-      }
-      params.recordMessageId(messageId);
-      await recordPromptContextMessage(message, plainText || undefined);
-      markDelivered(params.progress);
-    });
+    mediaUrls.push(options.mediaUrl);
+    await params.sender.accept(delivery, (part) => observeMedia(part, delivery.captionRemoved));
   };
   const createVoiceFallbackProgress = (): DeliveryProgress => ({
     hasReplied: false,
@@ -344,7 +355,7 @@ async function deliverMediaReply(params: {
     deliveredCount: 0,
     ...(params.progress.promptContext ? { promptContext: params.progress.promptContext } : {}),
   });
-  for (const [index, mediaUrl] of params.mediaList.entries()) {
+  const prepareMedia = async (mediaUrl: string, index: number) => {
     const isFirstMedia = index === 0;
     const media = await params.mediaLoader(
       mediaUrl,
@@ -367,6 +378,12 @@ async function deliverMediaReply(params: {
       plan: mediaPlan,
       asVoice: params.reply.audioAsVoice,
     });
+    return { index, mediaUrl, media, mediaPlan, mediaSender, documentSender };
+  };
+  type PreparedMedia = Awaited<ReturnType<typeof prepareMedia>>;
+  const deliverMediaBatch = async (batch: [PreparedMedia, ...PreparedMedia[]]): Promise<void> => {
+    const { index, mediaUrl, media, mediaPlan, mediaSender, documentSender } = batch[0];
+    const isFirstMedia = index === 0;
     const { htmlCaption, plainCaption, followUpText } = mediaPlan;
     const replyToMessageId = resolveReplyToForSend({
       replyToId: params.replyToId,
@@ -391,7 +408,48 @@ async function deliverMediaReply(params: {
         silent: params.silent,
       }),
     };
-    if (mediaSender.label === "voice") {
+    if (batch.length > 1) {
+      let album: Awaited<ReturnType<TelegramPreparedSender["sendPhotoAlbum"]>>;
+      try {
+        album = await params.sender.sendPhotoAlbum({
+          files: batch.map((item) => item.mediaPlan.file),
+          requestParams: mediaParams,
+          plainCaption,
+        });
+      } catch (error) {
+        if (!isTelegramPhotoLimitError(error)) {
+          throw error;
+        }
+        // A rejected album accepted no messages. Singleton sends retain the
+        // existing photo-to-document recovery without retrying uncertain sends.
+        mediaPlan.followUpText = undefined;
+        batch.reduce((_previous, item) => item).mediaPlan.followUpText = followUpText;
+        for (const item of batch) {
+          await deliverMediaBatch([item]);
+        }
+        return;
+      }
+      mediaUrls.push(...batch.map((item) => item.mediaUrl));
+      await params.sender.acceptMany(
+        album.parts,
+        (part) => observeMedia(part, album.captionRemoved),
+        () => ({
+          receipt: createMessageReceiptFromOutboundResults({
+            results: album.parts.map((part) =>
+              buildTelegramProviderDeliveryResult({
+                message: part.result,
+                messageId: part.result.message_id,
+                fallbackChatId: params.chatId,
+                successfulSendThread: params.thread,
+                kind: "media",
+              }),
+            ),
+            kind: "media",
+          }),
+          visibleReplySent: true,
+        }),
+      );
+    } else if (mediaSender.label === "voice") {
       const sendVoiceMedia = async (requestParams: typeof mediaParams) => {
         const hasCaption = typeof requestParams.caption === "string";
         await deliverAcceptedMedia({
@@ -462,7 +520,7 @@ async function deliverMediaReply(params: {
           visibleFallbackText = fallbackText;
           markReplyApplied(params.progress, voiceFallbackReplyTo);
           markDelivered(params.progress);
-          continue;
+          return;
         }
         if (isTelegramCaptionTooLongError(voiceErr)) {
           logVerbose(
@@ -492,7 +550,7 @@ async function deliverMediaReply(params: {
             }
           }
           markReplyApplied(params.progress, replyToMessageId);
-          continue;
+          return;
         }
         throw voiceErr;
       }
@@ -541,6 +599,14 @@ async function deliverMediaReply(params: {
         }
       }
     }
+  };
+  for await (const batch of planTelegramMediaBatches({
+    mediaUrls: params.mediaList,
+    prepare: prepareMedia,
+    // Albums do not accept reply_markup; retain the existing control-bearing sends.
+    canGroup: (item) => item.mediaSender.label === "photo" && !params.replyMarkup,
+  })) {
+    await deliverMediaBatch(batch);
   }
   return { firstDeliveredMessageId, visibleFallbackText, mediaUrls };
 }

--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -160,6 +160,13 @@ function mockMediaLoad(fileName: string, contentType: string, data: string) {
   });
 }
 
+function mockPhotoMedia(count = 2) {
+  return Array.from({ length: count }, (_, index) => {
+    mockMediaLoad(`photo-${index}.jpg`, "image/jpeg", `photo-${index}`);
+    return `https://example.com/photo-${index}.jpg`;
+  });
+}
+
 function createObservedPromptContextSequence(
   record: (value: unknown) => void,
   source?: { transcriptMessageId: string },
@@ -1151,6 +1158,245 @@ describe("deliverReplies", () => {
     expect(sendMessage).not.toHaveBeenCalled();
   });
 
+  it.each([2, 10, 11])(
+    "delivers %s photos as bounded albums with one caption and reply",
+    async (count) => {
+      const mediaUrls = mockPhotoMedia(count);
+      const messages = Array.from({ length: count }, (_, index) => ({
+        message_id: 100 + index,
+        message_thread_id: 42,
+        chat: { id: "123", type: "supergroup" },
+      }));
+      const sendMediaGroup = vi.fn().mockResolvedValue(messages.slice(0, 10));
+      const sendPhoto = vi.fn().mockResolvedValue(messages.at(-1));
+      const transcriptMirror = vi.fn();
+      const record = vi.fn();
+      const promptContextSequence = createObservedPromptContextSequence(record, {
+        transcriptMessageId: "assistant-photos",
+      });
+
+      await expect(
+        deliverWith({
+          replies: [{ text: "hi **boss**", mediaUrls, replyToId: "900" }],
+          runtime: createRuntime(),
+          bot: createBot({ sendMediaGroup, sendPhoto }),
+          thread: { id: 42, scope: "forum" },
+          replyToMode: "first",
+          replyQuoteMessageId: 900,
+          replyQuoteText: "quoted",
+          silent: true,
+          transcriptMirror,
+          promptContextSequence,
+        }),
+      ).resolves.toEqual({ delivered: true });
+      await promptContextSequence.finish();
+
+      expect(sendMediaGroup).toHaveBeenCalledOnce();
+      expect(sendMediaGroup).toHaveBeenCalledWith(
+        "123",
+        Array.from({ length: Math.min(count, 10) }, (_, index) => ({
+          type: "photo",
+          media: expect.objectContaining({
+            filename: `photo-${index}.jpg`,
+            buffer: Buffer.from(`photo-${index}`),
+          }),
+          ...(index === 0 ? { caption: "hi <b>boss</b>", parse_mode: "HTML" } : {}),
+        })),
+        {
+          message_thread_id: 42,
+          disable_notification: true,
+          reply_parameters: { message_id: 900, quote: "quoted", allow_sending_without_reply: true },
+        },
+      );
+      expect(sendPhoto).toHaveBeenCalledTimes(count === 11 ? 1 : 0);
+      if (count === 11) {
+        expect(sendPhoto).toHaveBeenCalledWith(
+          "123",
+          expect.objectContaining({ filename: "photo-10.jpg" }),
+          {
+            caption: undefined,
+            message_thread_id: 42,
+            disable_notification: true,
+          },
+        );
+      }
+      expect(recordSentMessage.mock.calls.map((call) => call[1])).toEqual(
+        messages.map((message) => message.message_id),
+      );
+      expect(record.mock.calls.map(([value]) => value)).toEqual(
+        messages.map((message, index) =>
+          expect.objectContaining({
+            messageId: message.message_id,
+            message,
+            ...(index === 0 ? { text: "hi **boss**" } : {}),
+            projection: {
+              transcriptMessageId: "assistant-photos",
+              partIndex: index,
+              finalPart: index === count - 1,
+            },
+          }),
+        ),
+      );
+      expect(transcriptMirror).toHaveBeenCalledWith({ text: "hi **boss**", mediaUrls });
+    },
+  );
+
+  it("keeps controls on the first photo instead of dropping them into an album", async () => {
+    const mediaUrls = mockPhotoMedia();
+    const buttons = [[{ text: "Retry", callback_data: "retry" }]];
+    const sendMediaGroup = vi.fn();
+    const sendPhoto = vi
+      .fn()
+      .mockResolvedValueOnce({ message_id: 101, chat: { id: "123" } })
+      .mockResolvedValueOnce({ message_id: 102, chat: { id: "123" } });
+
+    await deliverWith({
+      replies: [{ text: "Choose", mediaUrls, channelData: { telegram: { buttons } } }],
+      runtime: createRuntime(),
+      bot: createBot({ sendPhoto, sendMediaGroup }),
+    });
+
+    expect(sendMediaGroup).not.toHaveBeenCalled();
+    expect(sendPhoto).toHaveBeenCalledTimes(2);
+    expectRecordFields(mockCallArg(sendPhoto, 0, 2), {
+      caption: "Choose",
+      reply_markup: { inline_keyboard: buttons },
+    });
+    expect(mockCallArg(sendPhoto, 1, 2)).not.toHaveProperty("reply_markup");
+  });
+
+  it.each([false, true])(
+    "sends oversized album text after every photo when rejected=%s",
+    async (rejected) => {
+      const mediaUrls = mockPhotoMedia();
+      const text = "x".repeat(1025);
+      const sendMediaGroup = vi.fn().mockResolvedValue([
+        { message_id: 101, chat: { id: "123" } },
+        { message_id: 102, chat: { id: "123" } },
+      ]);
+      if (rejected) {
+        sendMediaGroup.mockRejectedValue(createChunkRejection("PHOTO_INVALID_DIMENSIONS"));
+      }
+      const sendPhoto = vi
+        .fn()
+        .mockResolvedValueOnce({ message_id: 101, chat: { id: "123" } })
+        .mockResolvedValueOnce({ message_id: 102, chat: { id: "123" } });
+      const sendMessage = vi.fn(async () => {
+        expect(recordSentMessage.mock.calls.map((call) => call[1])).toEqual([101, 102]);
+        return { message_id: 103, chat: { id: "123" } };
+      });
+
+      await deliverWith({
+        replies: [{ text, mediaUrls, replyToId: "900" }],
+        runtime: createRuntime(),
+        bot: createBot({ sendMediaGroup, sendPhoto, sendMessage }),
+        replyToMode: "first",
+      });
+
+      expect(sendMediaGroup).toHaveBeenCalledWith(
+        "123",
+        [
+          { type: "photo", media: expect.objectContaining({ filename: "photo-0.jpg" }) },
+          { type: "photo", media: expect.objectContaining({ filename: "photo-1.jpg" }) },
+        ],
+        { reply_to_message_id: 900, allow_sending_without_reply: true },
+      );
+      expect(sendPhoto).toHaveBeenCalledTimes(rejected ? 2 : 0);
+      expect(sendMessage).toHaveBeenCalledOnce();
+      expect(firstSendText(sendMessage)).toBe(text);
+      expect(firstMockCallArg(sendMessage, 2)).not.toHaveProperty("reply_to_message_id");
+      expect(recordSentMessage.mock.calls.map((call) => call[1])).toEqual([101, 102, 103]);
+    },
+  );
+
+  it("keeps every accepted album id when the first bookkeeping observer fails", async () => {
+    const mediaUrls = mockPhotoMedia();
+    const failure = new Error("sent-message cache unavailable");
+    const sendMediaGroup = vi.fn().mockResolvedValue([
+      { message_id: 101, chat: { id: "123" } },
+      { message_id: 102, chat: { id: "123" } },
+    ]);
+    const sendPhoto = vi.fn();
+    recordSentMessage.mockImplementationOnce(() => {
+      throw failure;
+    });
+
+    await expect(
+      deliverWith({
+        replies: [{ mediaUrls }],
+        runtime: createRuntime(),
+        bot: createBot({ sendMediaGroup, sendPhoto }),
+      }),
+    ).rejects.toMatchObject({
+      deliveryResult: {
+        messageIds: ["101", "102"],
+        visibleReplySent: true,
+        receipt: {
+          platformMessageIds: ["101", "102"],
+          parts: [
+            { platformMessageId: "101", kind: "media", index: 0 },
+            { platformMessageId: "102", kind: "media", index: 1 },
+          ],
+        },
+      },
+    });
+    expect(sendMediaGroup).toHaveBeenCalledOnce();
+    expect(sendPhoto).not.toHaveBeenCalled();
+    expect(recordSentMessage).toHaveBeenCalledOnce();
+  });
+
+  it("uses single-photo document recovery after a definite album photo-limit rejection", async () => {
+    const mediaUrls = mockPhotoMedia();
+    const failure = createChunkRejection("PHOTO_INVALID_DIMENSIONS");
+    const sendMediaGroup = vi.fn().mockRejectedValue(failure);
+    const sendPhoto = vi
+      .fn()
+      .mockRejectedValueOnce(failure)
+      .mockResolvedValueOnce({ message_id: 102, chat: { id: "123" } });
+    const sendDocument = vi.fn().mockResolvedValue({ message_id: 101, chat: { id: "123" } });
+
+    await expect(
+      deliverWith({
+        replies: [{ text: "Caption", mediaUrls }],
+        runtime: createRuntime(),
+        bot: createBot({ sendMediaGroup, sendPhoto, sendDocument }),
+      }),
+    ).resolves.toEqual({ delivered: true });
+
+    expect(sendMediaGroup).toHaveBeenCalledOnce();
+    expect(sendPhoto).toHaveBeenCalledTimes(2);
+    expect(sendDocument).toHaveBeenCalledWith(
+      "123",
+      expect.objectContaining({
+        filename: "photo-0.jpg",
+        buffer: Buffer.from("photo-0"),
+      }),
+      { caption: "Caption", parse_mode: "HTML" },
+    );
+    expect(mockCallArg(sendPhoto, 1, 1)).toMatchObject({ filename: "photo-1.jpg" });
+    expect(recordSentMessage.mock.calls.map((call) => call[1])).toEqual([101, 102]);
+  });
+
+  it("does not replay an album after an ambiguous upload failure", async () => {
+    const mediaUrls = mockPhotoMedia();
+    const failure = createPlainHttpError("sendMediaGroup");
+    const sendMediaGroup = vi.fn().mockRejectedValue(failure);
+    const sendPhoto = vi.fn();
+    const sendDocument = vi.fn();
+
+    await expect(
+      deliverWith({
+        replies: [{ mediaUrls }],
+        runtime: createRuntime(),
+        bot: createBot({ sendMediaGroup, sendPhoto, sendDocument }),
+      }),
+    ).rejects.toBe(failure);
+    expect(sendMediaGroup).toHaveBeenCalledOnce();
+    expect(sendPhoto).not.toHaveBeenCalled();
+    expect(sendDocument).not.toHaveBeenCalled();
+    expect(recordSentMessage).not.toHaveBeenCalled();
+  });
+
   it("stops a media follow-up when the provider returns the wrong topic", async () => {
     const runtime = createRuntime();
     const sendPhoto = vi.fn().mockResolvedValue({
@@ -1189,20 +1435,20 @@ describe("deliverReplies", () => {
     expect(recordSentMessage).not.toHaveBeenCalled();
   });
 
-  it("keeps earlier media ids when a later item lands in the wrong topic", async () => {
+  it("keeps every album id when a later item lands in the wrong topic", async () => {
     const runtime = createRuntime();
-    const sendPhoto = vi
-      .fn()
-      .mockResolvedValueOnce({
+    const sendMediaGroup = vi.fn().mockResolvedValueOnce([
+      {
         message_id: 61,
         message_thread_id: 42,
         chat: { id: "123", type: "supergroup" },
-      })
-      .mockResolvedValueOnce({
+      },
+      {
         message_id: 62,
         message_thread_id: 43,
         chat: { id: "123", type: "supergroup" },
-      });
+      },
+    ]);
     const observer = vi.fn();
     const promptContextSequence = createObservedPromptContextSequence(observer);
     mockMediaLoad("one.jpg", "image/jpeg", "one");
@@ -1213,7 +1459,7 @@ describe("deliverReplies", () => {
       await deliverWith({
         replies: [{ mediaUrls: ["https://example.com/one.jpg", "https://example.com/two.jpg"] }],
         runtime,
-        bot: createBot({ sendPhoto }),
+        bot: createBot({ sendMediaGroup }),
         thread: { id: 42, scope: "forum" },
         promptContextSequence,
       });
@@ -1226,9 +1472,13 @@ describe("deliverReplies", () => {
     if (!isChannelPartialDeliveryError(observed)) {
       throw observed;
     }
-    expect(sendPhoto).toHaveBeenCalledTimes(2);
+    expect(sendMediaGroup).toHaveBeenCalledOnce();
     expect(observed.deliveryResult.messageIds).toEqual(["61", "62"]);
-    expect(observed.deliveryResult.receipt?.threadId).toBe("43");
+    expect(observed.deliveryResult.receipt?.threadId).toBeUndefined();
+    expect(observed.deliveryResult.receipt?.parts).toMatchObject([
+      { platformMessageId: "61", kind: "media", index: 0, threadId: "42" },
+      { platformMessageId: "62", kind: "media", index: 1, threadId: "43" },
+    ]);
     expect(observer).toHaveBeenCalledOnce();
     expect(recordSentMessage).toHaveBeenCalledOnce();
   });
@@ -1262,7 +1512,11 @@ describe("deliverReplies", () => {
       .mockResolvedValueOnce({ message_id: 71, chat: { id: "123" } })
       .mockRejectedValueOnce(rejection);
     mockMediaLoad(testCase.fileName, testCase.contentType, "first");
-    mockMediaLoad(testCase.fileName, testCase.contentType, "second");
+    mockMediaLoad(
+      testCase.kind === "photo" ? "report.pdf" : testCase.fileName,
+      testCase.kind === "photo" ? "application/pdf" : testCase.contentType,
+      "second",
+    );
 
     let observed: unknown;
     try {
@@ -1274,7 +1528,10 @@ describe("deliverReplies", () => {
           },
         ],
         runtime: createRuntime(),
-        bot: createBot({ [testCase.method]: sendMedia }),
+        bot: createBot({
+          [testCase.method]: sendMedia,
+          ...(testCase.kind === "photo" ? { sendDocument: sendMedia } : {}),
+        }),
       });
     } catch (error) {
       observed = error;
@@ -1382,13 +1639,11 @@ describe("deliverReplies", () => {
   );
 
   it("preserves media and accepted caption-follow-up ids when later media fails", async () => {
-    const sendPhoto = vi
-      .fn()
-      .mockResolvedValueOnce({ message_id: 75, chat: { id: "123" } })
-      .mockRejectedValueOnce(new Error("later photo failed"));
+    const sendPhoto = vi.fn().mockResolvedValueOnce({ message_id: 75, chat: { id: "123" } });
+    const sendDocument = vi.fn().mockRejectedValueOnce(new Error("later document failed"));
     const sendMessage = vi.fn().mockResolvedValueOnce({ message_id: 76, chat: { id: "123" } });
     mockMediaLoad("photo.jpg", "image/jpeg", "first");
-    mockMediaLoad("photo.jpg", "image/jpeg", "second");
+    mockMediaLoad("report.pdf", "application/pdf", "second");
 
     let observed: unknown;
     try {
@@ -1400,7 +1655,7 @@ describe("deliverReplies", () => {
           },
         ],
         runtime: createRuntime(),
-        bot: createBot({ sendPhoto, sendMessage }),
+        bot: createBot({ sendPhoto, sendDocument, sendMessage }),
       });
     } catch (error) {
       observed = error;
@@ -3213,19 +3468,20 @@ describe("deliverReplies", () => {
     }
   });
 
-  it("replyToMode 'first' only applies reply-to to first media item", async () => {
+  it("replyToMode 'first' only applies reply-to to the first mixed-media item", async () => {
     const runtime = createRuntime();
     const sendPhoto = vi.fn().mockResolvedValue({
       message_id: 30,
       chat: { id: "123" },
     });
-    const bot = createBot({ sendPhoto });
+    const sendDocument = vi.fn().mockResolvedValue({ message_id: 31, chat: { id: "123" } });
+    const bot = createBot({ sendPhoto, sendDocument });
 
     mockMediaLoad("a.jpg", "image/jpeg", "img1");
-    mockMediaLoad("b.jpg", "image/jpeg", "img2");
+    mockMediaLoad("b.pdf", "application/pdf", "document");
 
     await deliverReplies({
-      replies: [{ mediaUrls: ["https://a.jpg", "https://b.jpg"], replyToId: "900" }],
+      replies: [{ mediaUrls: ["https://a.jpg", "https://b.pdf"], replyToId: "900" }],
       chatId: "123",
       token: "tok",
       runtime,
@@ -3234,14 +3490,15 @@ describe("deliverReplies", () => {
       textLimit: 4000,
     });
 
-    expect(sendPhoto).toHaveBeenCalledTimes(2);
+    expect(sendPhoto).toHaveBeenCalledOnce();
+    expect(sendDocument).toHaveBeenCalledOnce();
     // First media should have reply_to_message_id
     expectRecordFields(mockCallArg(sendPhoto, 0, 2), {
       reply_to_message_id: 900,
       allow_sending_without_reply: true,
     });
     // Second media should NOT have reply_to_message_id
-    expect(mockCallArg(sendPhoto, 1, 2)).not.toHaveProperty("reply_to_message_id");
+    expect(mockCallArg(sendDocument, 0, 2)).not.toHaveProperty("reply_to_message_id");
   });
 
   it("pins the first delivered text message when telegram pin is requested", async () => {

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -249,6 +249,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     requesterAccountId,
     gatewayClientScopes,
     deliveryRetryOwner,
+    onPlatformSendDispatch,
+    assertDirectAdapterHandoff,
+    skipQueue,
   }) => {
     const telegramAction = resolveTelegramMessageActionName(action);
     if (!telegramAction) {
@@ -284,6 +287,9 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
         inboundEventKind,
         gatewayClientScopes,
         deliveryRetryOwner,
+        onPlatformSendDispatch,
+        assertDirectAdapterHandoff,
+        skipQueue,
         ...(conversationReadOrigin ? { conversationReadOrigin } : {}),
         ...(requesterAccountId ? { requesterAccountId } : {}),
         ...(reply ? { reply } : {}),

--- a/extensions/telegram/src/channel.message-adapter.test.ts
+++ b/extensions/telegram/src/channel.message-adapter.test.ts
@@ -157,10 +157,20 @@ describe("telegram channel message adapter", () => {
 
     const proveBatch = async () => {
       const startCallCount = sendMessageTelegramMock.mock.calls.length;
-      sendMessageTelegramMock
-        .mockResolvedValueOnce({ messageId: "tg-batch-1", chatId: "12345" })
-        .mockResolvedValueOnce({ messageId: "tg-batch-2", chatId: "12345" });
-      await adapter.send!.payload!({
+      sendMessageTelegramMock.mockResolvedValueOnce({
+        messageId: "tg-batch-2",
+        chatId: "12345",
+        receipt: {
+          primaryPlatformMessageId: "tg-batch-1",
+          platformMessageIds: ["tg-batch-1", "tg-batch-2"],
+          parts: [
+            { platformMessageId: "tg-batch-1", kind: "media", index: 0 },
+            { platformMessageId: "tg-batch-2", kind: "media", index: 1 },
+          ],
+          sentAt: 123,
+        },
+      });
+      const result = await adapter.send!.payload!({
         cfg: {} as never,
         to: "12345",
         text: "batch",
@@ -173,48 +183,20 @@ describe("telegram channel message adapter", () => {
         },
         deps: { sendTelegram: sendMessageTelegramMock },
       });
-      const batchCalls = sendMessageTelegramMock.mock.calls.slice(startCallCount);
-      expect(batchCalls[0]).toEqual([
-        "12345",
-        "batch",
-        {
-          cfg: {},
-          verbose: false,
-          messageThreadId: undefined,
-          replyToMessageId: 900,
-          replyToIdSource: "implicit",
-          replyToMode: "first",
-          accountId: undefined,
-          silent: undefined,
-          gatewayClientScopes: undefined,
-          mediaLocalRoots: undefined,
-          mediaReadFile: undefined,
-          forceDocument: false,
-          quoteText: undefined,
-          mediaUrl: "https://example.com/a.png",
-          buttons: undefined,
-        },
+      expect(sendMessageTelegramMock.mock.calls.slice(startCallCount)).toEqual([
+        [
+          "12345",
+          "batch",
+          expect.objectContaining({
+            mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+            replyToMessageId: 900,
+            replyToIdSource: "implicit",
+            replyToMode: "first",
+          }),
+        ],
       ]);
-      expect(batchCalls[1]).toEqual([
-        "12345",
-        "",
-        {
-          cfg: {},
-          verbose: false,
-          messageThreadId: undefined,
-          replyToMessageId: undefined,
-          replyToIdSource: undefined,
-          replyToMode: undefined,
-          accountId: undefined,
-          silent: undefined,
-          gatewayClientScopes: undefined,
-          mediaLocalRoots: undefined,
-          mediaReadFile: undefined,
-          forceDocument: false,
-          quoteText: undefined,
-          mediaUrl: "https://example.com/b.png",
-        },
-      ]);
+      expect(result.receipt.platformMessageIds).toEqual(["tg-batch-1", "tg-batch-2"]);
+      expect(result.receipt.parts.map((part) => part.kind)).toEqual(["media", "media"]);
     };
 
     await verifyChannelMessageAdapterCapabilityProofs({
@@ -255,12 +237,9 @@ describe("telegram channel message adapter", () => {
     });
   });
 
-  it("keeps implicit first replies on the first delivered payload media", async () => {
+  it("normalizes the full media list before forwarding implicit reply ownership", async () => {
     const adapter = requireTelegramMessageAdapter();
-    sendMessageTelegramMock
-      .mockResolvedValueOnce({ messageId: "tg-media-1", chatId: "12345" })
-      .mockResolvedValueOnce({ messageId: "tg-media-2", chatId: "12345" });
-
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-media-2", chatId: "12345" });
     await adapter.send!.payload!({
       cfg: {} as never,
       to: "12345",
@@ -274,15 +253,17 @@ describe("telegram channel message adapter", () => {
       },
       deps: { sendTelegram: sendMessageTelegramMock },
     });
-
-    const firstOpts = sendMessageTelegramMock.mock.calls[0]?.[2] as
-      | { replyToMessageId?: number }
-      | undefined;
-    const secondOpts = sendMessageTelegramMock.mock.calls[1]?.[2] as
-      | { replyToMessageId?: number }
-      | undefined;
-    expect(firstOpts?.replyToMessageId).toBe(900);
-    expect(secondOpts?.replyToMessageId).toBeUndefined();
+    expect(sendMessageTelegramMock).toHaveBeenCalledOnce();
+    expect(sendMessageTelegramMock).toHaveBeenCalledWith(
+      "12345",
+      "batch",
+      expect.objectContaining({
+        mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+        replyToMessageId: 900,
+        replyToIdSource: "implicit",
+        replyToMode: "first",
+      }),
+    );
   });
 
   it("backs declared live preview finalizer capabilities with adapter proofs", async () => {

--- a/extensions/telegram/src/chunk-delivery.test.ts
+++ b/extensions/telegram/src/chunk-delivery.test.ts
@@ -1,11 +1,43 @@
+import { createChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
+import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
 import { describe, expect, it } from "vitest";
-import { isTelegramSkippableChunkSendError } from "./chunk-delivery.js";
+import {
+  isTelegramSkippableChunkSendError,
+  mergeTelegramPartialDeliveryError,
+} from "./chunk-delivery.js";
 
 const telegramError = (errorCode: number, message: string) =>
   Object.assign(new Error(message), { error_code: errorCode });
 
 describe("Telegram chunk delivery", () => {
+  it("retains every album receipt part when the first accepted-message observer fails", () => {
+    const receipt = createMessageReceiptFromOutboundResults({
+      results: [{ messageId: "41" }, { messageId: "42" }],
+      kind: "media",
+      threadId: "7",
+    });
+    const error = createChannelPartialDeliveryError(new Error("observer failed"), {
+      messageIds: ["41"],
+      receipt: createMessageReceiptFromOutboundResults({
+        results: [{ messageId: "41" }],
+        kind: "media",
+        threadId: "7",
+      }),
+      visibleReplySent: true,
+    });
+    const merged = mergeTelegramPartialDeliveryError(error, {
+      messageIds: ["41", "42"],
+      receipt,
+      visibleReplySent: true,
+    });
+    expect(merged.deliveryResult.messageIds).toEqual(["41", "42"]);
+    expect(merged.deliveryResult.receipt?.platformMessageIds).toEqual(["41", "42"]);
+    expect(merged.deliveryResult.receipt?.parts).toMatchObject([
+      { platformMessageId: "41", kind: "media", index: 0, threadId: "7" },
+      { platformMessageId: "42", kind: "media", index: 1, threadId: "7" },
+    ]);
+  });
   it.each([
     [telegramError(400, "content rejected"), true],
     [Object.assign(new Error("dns failed"), { code: "ENOTFOUND" }), true],

--- a/extensions/telegram/src/chunk-delivery.ts
+++ b/extensions/telegram/src/chunk-delivery.ts
@@ -2,6 +2,7 @@ import {
   createChannelPartialDeliveryError,
   isChannelPartialDeliveryError,
 } from "openclaw/plugin-sdk/channel-inbound";
+import { createMessageReceiptFromOutboundResults } from "openclaw/plugin-sdk/channel-outbound";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { isSafeToRetrySendError, isTelegramBadRequestError } from "./network-errors.js";
 
@@ -25,10 +26,30 @@ export function mergeTelegramPartialDeliveryError(
       ...(currentDeliveryResult.messageIds ?? []),
     ]),
   ];
+  let receipt = currentDeliveryResult.receipt ?? priorDeliveryResult.receipt;
+  if (priorDeliveryResult.receipt && currentDeliveryResult.receipt) {
+    receipt = createMessageReceiptFromOutboundResults({
+      results: [
+        { receipt: priorDeliveryResult.receipt },
+        { receipt: currentDeliveryResult.receipt },
+      ],
+    });
+    // A per-message observer receipt can overlap a whole accepted album.
+    // Keep every physical part once, with the observer's actual placement metadata.
+    const parts = new Map<string, (typeof receipt.parts)[number]>();
+    for (const part of receipt.parts) {
+      parts.set(part.platformMessageId, { ...parts.get(part.platformMessageId), ...part });
+    }
+    receipt.parts = [...parts.values()];
+    for (const [index, part] of receipt.parts.entries()) {
+      part.index = index;
+    }
+  }
   return createChannelPartialDeliveryError(error, {
     ...priorDeliveryResult,
     ...currentDeliveryResult,
     ...(messageIds.length > 0 ? { messageIds } : {}),
+    ...(receipt ? { receipt } : {}),
     visibleReplySent: true,
   });
 }

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -111,10 +111,8 @@ describe("telegramOutbound", () => {
     expect(result).toEqual({ channel: "telegram", messageId: "tg-media" });
   });
 
-  it("sends payload media in sequence and keeps buttons on the first message only", async () => {
-    sendMessageTelegramMock
-      .mockResolvedValueOnce({ messageId: "tg-1", chatId: "12345" })
-      .mockResolvedValueOnce({ messageId: "tg-2", chatId: "12345" });
+  it("passes the complete media payload and controls to the public send owner", async () => {
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-2", chatId: "12345" });
     const mediaAccess = { localRoots: ["/tmp/media"], workspaceDir: "/tmp/media" };
 
     const result = await telegramOutbound.sendPayload!({
@@ -144,9 +142,9 @@ describe("telegramOutbound", () => {
       deps: { sendTelegram: sendMessageTelegramMock },
     });
 
-    expect(sendMessageTelegramMock).toHaveBeenCalledTimes(2);
+    expect(sendMessageTelegramMock).toHaveBeenCalledTimes(1);
     const firstOptions = callOptionsAt(sendMessageTelegramMock, 0, "12345", "Approval required");
-    expect(firstOptions.mediaUrl).toBe("chart.png");
+    expect(firstOptions.mediaUrls).toEqual(["chart.png", "chart-2.png"]);
     expect(firstOptions.mediaAccess).toBe(mediaAccess);
     expect(firstOptions.mediaLocalRoots).toEqual(["/tmp/media"]);
     expect(firstOptions.quoteText).toBe("quoted");
@@ -161,27 +159,8 @@ describe("telegramOutbound", () => {
         nextPartIndex: 0,
         complete: true,
       },
-      finalPart: false,
-    });
-    const secondOptions = callOptionsAt(sendMessageTelegramMock, 1, "12345", "");
-    expect(secondOptions.mediaUrl).toBe("chart-2.png");
-    expect(secondOptions.mediaAccess).toBe(mediaAccess);
-    expect(secondOptions.mediaLocalRoots).toEqual(["/tmp/media"]);
-    expect(secondOptions.quoteText).toBe("quoted");
-    expect(secondOptions.buttons).toBeUndefined();
-    expect(secondOptions.promptContextProjectionPlan).toMatchObject({
-      cursor: {
-        source: {
-          transcriptMessageId: "assistant-media",
-        },
-        nextPartIndex: 0,
-        complete: true,
-      },
       finalPart: true,
     });
-    expect((firstOptions.promptContextProjectionPlan as { cursor: unknown }).cursor).toBe(
-      (secondOptions.promptContextProjectionPlan as { cursor: unknown }).cursor,
-    );
     expect(result).toEqual({
       channel: "telegram",
       messageId: "tg-2",
@@ -914,9 +893,7 @@ describe("telegramOutbound", () => {
       expect(options.silent).toBe(true);
     };
     const proveBatch = async () => {
-      sendMessageTelegramMock
-        .mockResolvedValueOnce({ messageId: "tg-batch-1", chatId: "12345" })
-        .mockResolvedValueOnce({ messageId: "tg-batch-2", chatId: "12345" });
+      sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-batch-2", chatId: "12345" });
       await telegramOutbound.sendPayload!({
         cfg: {} as never,
         to: "12345",
@@ -927,10 +904,8 @@ describe("telegramOutbound", () => {
         },
         deps: { sendTelegram: sendMessageTelegramMock },
       });
-      const firstOptions = callOptionsFromEnd(sendMessageTelegramMock, 2, "12345", "batch");
-      expect(firstOptions.mediaUrl).toBe("https://example.com/a.png");
-      const secondOptions = callOptionsFromEnd(sendMessageTelegramMock, 1, "12345", "");
-      expect(secondOptions.mediaUrl).toBe("https://example.com/b.png");
+      const options = callOptionsFromEnd(sendMessageTelegramMock, 1, "12345", "batch");
+      expect(options.mediaUrls).toEqual(["https://example.com/a.png", "https://example.com/b.png"]);
     };
 
     await verifyDurableFinalCapabilityProofs({

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -457,6 +457,33 @@ describe("telegramOutbound", () => {
     );
   });
 
+  it("does not publish a reaction or album after cancellation during dispatch", async () => {
+    const abort = new AbortController();
+    const failure = new Error("turn canceled");
+    reactMessageTelegramMock.mockResolvedValueOnce({ ok: true });
+    sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-photo", chatId: "12345" });
+    await expect(
+      telegramOutbound.sendPayload!({
+        cfg: {},
+        to: "12345",
+        text: "Photos",
+        replyToId: "777",
+        signal: abort.signal,
+        onPlatformSendDispatch: async () => {
+          abort.abort(failure);
+        },
+        payload: {
+          text: "Photos",
+          mediaUrls: ["https://example.com/a.png", "https://example.com/b.png"],
+          channelData: { telegram: { reaction: { emoji: "✅" } } },
+        },
+        deps: { sendTelegram: sendMessageTelegramMock },
+      }),
+    ).rejects.toBe(failure);
+    expect(reactMessageTelegramMock).not.toHaveBeenCalled();
+    expect(sendMessageTelegramMock).not.toHaveBeenCalled();
+  });
+
   it("rejects text plus reaction payloads without a reply target", async () => {
     await expect(
       telegramOutbound.sendPayload!({

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -300,12 +300,16 @@ describe("telegramOutbound", () => {
 
   it("applies reaction-only payloads without sending empty Telegram text", async () => {
     reactMessageTelegramMock.mockResolvedValueOnce({ ok: true });
+    const controller = new AbortController();
+    const assertDirectAdapterHandoff = vi.fn();
 
     const result = await telegramOutbound.sendPayload!({
       cfg: {} as never,
       to: "12345",
       text: "",
       replyToId: "777",
+      signal: controller.signal,
+      assertDirectAdapterHandoff,
       payload: {
         channelData: {
           telegram: {
@@ -321,6 +325,8 @@ describe("telegramOutbound", () => {
       verbose: false,
       accountId: undefined,
       gatewayClientScopes: undefined,
+      signal: controller.signal,
+      assertPlatformSendAuthorized: assertDirectAdapterHandoff,
     });
     expect(sendMessageTelegramMock).not.toHaveBeenCalled();
     expect(result).toEqual({

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -12,11 +12,7 @@ import {
 } from "openclaw/plugin-sdk/channel-send-result";
 import { parseStrictPositiveInteger } from "openclaw/plugin-sdk/number-runtime";
 import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
-import {
-  resolveSendableOutboundReplyParts,
-  sendPayloadMediaSequenceOrFallback,
-} from "openclaw/plugin-sdk/reply-payload";
-import { isSingleUseReplyToMode } from "openclaw/plugin-sdk/reply-reference";
+import { resolveSendableOutboundReplyParts } from "openclaw/plugin-sdk/reply-payload";
 import type { ReplyPayload } from "openclaw/plugin-sdk/reply-runtime";
 import { sanitizeAssistantVisibleText } from "openclaw/plugin-sdk/text-chunking";
 import { mergeTelegramAccountConfig, resolveDefaultTelegramAccountId } from "./accounts.js";
@@ -306,7 +302,7 @@ export async function sendTelegramPayloadMessages(params: {
   react: TelegramReactionFn;
   to: string;
   payload: ReplyPayload;
-  baseOpts: Omit<NonNullable<TelegramSendOpts>, "buttons" | "mediaUrl" | "quoteText">;
+  baseOpts: Omit<NonNullable<TelegramSendOpts>, "buttons" | "mediaUrl" | "mediaUrls" | "quoteText">;
 }): Promise<Awaited<ReturnType<TelegramSendFn>>> {
   const payload = canonicalizeTelegramPresentationPayload(params.payload, {
     allowWebAppButtons: parseTelegramTarget(params.to).chatType === "direct",
@@ -386,19 +382,6 @@ export async function sendTelegramPayloadMessages(params: {
   if (payload.videoAsNote === true && mediaUrls.length !== 1) {
     throw new Error("Telegram video notes require exactly one media attachment.");
   }
-  const shouldConsumeImplicitReplyTarget =
-    payloadOpts.replyToIdSource === "implicit" &&
-    payloadOpts.replyToMode !== undefined &&
-    isSingleUseReplyToMode(payloadOpts.replyToMode);
-  const consumedImplicitReplyPayloadOpts = shouldConsumeImplicitReplyTarget
-    ? {
-        ...payloadOpts,
-        replyToMessageId: undefined,
-        replyToIdSource: undefined,
-        replyToMode: undefined,
-      }
-    : payloadOpts;
-  let implicitReplyTargetAvailable = true;
   if (reactionEmoji) {
     if (typeof replyToMessageId !== "number") {
       throw new Error("Telegram reaction requires a reply target");
@@ -419,30 +402,15 @@ export async function sendTelegramPayloadMessages(params: {
     return { messageId: String(replyToMessageId), chatId: params.to };
   }
 
-  // Telegram allows reply_markup on media; attach buttons only to the first send.
-  return await sendPayloadMediaSequenceOrFallback({
-    text,
-    mediaUrls,
-    fallbackResult: { messageId: "unknown", chatId: params.to },
-    sendNoMedia: async () =>
-      await params.send(params.to, text, {
-        ...payloadOpts,
-        ...projectionOptions(true),
-        buttons,
-      }),
-    send: async ({ text: textLocal, mediaUrl, index, isFirst }) => {
-      const mediaPayloadOpts =
-        shouldConsumeImplicitReplyTarget && !implicitReplyTargetAvailable
-          ? consumedImplicitReplyPayloadOpts
-          : payloadOpts;
-      implicitReplyTargetAvailable = false;
-      return await params.send(params.to, textLocal, {
-        ...mediaPayloadOpts,
-        ...projectionOptions(index === mediaUrls.length - 1),
-        mediaUrl,
-        ...(isFirst ? { buttons } : {}),
-      });
-    },
+  return await params.send(params.to, text, {
+    ...payloadOpts,
+    ...projectionOptions(true),
+    ...(mediaUrls.length === 1
+      ? { mediaUrl: mediaUrls[0] }
+      : mediaUrls.length > 1
+        ? { mediaUrls }
+        : {}),
+    buttons,
   });
 }
 

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -79,6 +79,7 @@ async function resolveTelegramSendContext(params: {
   threadId?: string | number | null;
   formatting?: OutboundDeliveryFormattingOptions;
   silent?: boolean;
+  signal?: AbortSignal;
   gatewayClientScopes?: readonly string[];
   onDeliveryResult?: Parameters<
     NonNullable<ChannelOutboundAdapter["sendText"]>
@@ -99,6 +100,7 @@ async function resolveTelegramSendContext(params: {
     replyToMode?: TelegramSendOpts["replyToMode"];
     accountId?: string;
     silent?: boolean;
+    signal?: AbortSignal;
     gatewayClientScopes?: readonly string[];
     onDeliveryResult?: TelegramSendOpts["onDeliveryResult"];
     onPlatformSendDispatch?: TelegramSendOpts["onPlatformSendDispatch"];
@@ -117,6 +119,7 @@ async function resolveTelegramSendContext(params: {
       ...(params.replyToMode !== undefined ? { replyToMode: params.replyToMode } : {}),
       accountId: params.accountId ?? undefined,
       silent: params.silent,
+      signal: params.signal,
       gatewayClientScopes: params.gatewayClientScopes,
       onDeliveryResult: params.onDeliveryResult
         ? async (result) => {
@@ -387,6 +390,7 @@ export async function sendTelegramPayloadMessages(params: {
       throw new Error("Telegram reaction requires a reply target");
     }
     await params.baseOpts.onPlatformSendDispatch?.();
+    params.baseOpts.signal?.throwIfAborted();
     params.baseOpts.assertPlatformSendAuthorized?.();
     const reactionResult = await params.react(params.to, replyToMessageId, reactionEmoji, {
       cfg: params.baseOpts.cfg,
@@ -422,6 +426,7 @@ export function createTelegramOutboundAdapter(
 
   return {
     deliveryMode: "direct",
+    sendPayloadGroupsMedia: true,
     chunker: chunkTelegramOutboundText,
     chunkerMode: "markdown",
     extractMarkdownImages: true,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -396,6 +396,8 @@ export async function sendTelegramPayloadMessages(params: {
       cfg: params.baseOpts.cfg,
       accountId: params.baseOpts.accountId,
       gatewayClientScopes: params.baseOpts.gatewayClientScopes,
+      signal: params.baseOpts.signal,
+      assertPlatformSendAuthorized: params.baseOpts.assertPlatformSendAuthorized,
       verbose: false,
     });
     if (!reactionResult.ok) {

--- a/extensions/telegram/src/outbound-media-batches.ts
+++ b/extensions/telegram/src/outbound-media-batches.ts
@@ -1,0 +1,43 @@
+// Telegram Bot API sendMediaGroup accepts 2–10 items per album.
+const TELEGRAM_MEDIA_GROUP_LIMIT = 10;
+
+export async function* planTelegramMediaBatches<T>(params: {
+  mediaUrls: readonly string[];
+  prepare: (mediaUrl: string, index: number) => Promise<T>;
+  canGroup: (item: T, index: number) => boolean;
+}): AsyncGenerator<[T, ...T[]]> {
+  let photos: [T, ...T[]] | undefined;
+  for (const [index, mediaUrl] of params.mediaUrls.entries()) {
+    let item: T;
+    try {
+      item = await params.prepare(mediaUrl, index);
+    } catch (error) {
+      // Preserve the preceding attachments when loading a later file fails.
+      // The caller records their acceptance before this failure propagates.
+      if (photos) {
+        yield photos;
+      }
+      throw error;
+    }
+    if (!params.canGroup(item, index)) {
+      if (photos) {
+        yield photos;
+        photos = undefined;
+      }
+      yield [item];
+      continue;
+    }
+    if (photos) {
+      photos.push(item);
+    } else {
+      photos = [item];
+    }
+    if (photos.length === TELEGRAM_MEDIA_GROUP_LIMIT) {
+      yield photos;
+      photos = undefined;
+    }
+  }
+  if (photos) {
+    yield photos;
+  }
+}

--- a/extensions/telegram/src/send-actions.ts
+++ b/extensions/telegram/src/send-actions.ts
@@ -22,7 +22,7 @@ import {
 } from "./status-reaction-variants.js";
 import { parseTelegramTarget } from "./targets.js";
 
-type TelegramReactionOpts = TelegramApiCallOpts & {
+type TelegramReactionOpts = Omit<TelegramMessageActionOpts, "notify"> & {
   remove?: boolean;
 };
 

--- a/extensions/telegram/src/send-context.ts
+++ b/extensions/telegram/src/send-context.ts
@@ -406,6 +406,8 @@ function resolveTelegramApiContext(opts: {
   accountId?: string;
   api?: TelegramApiOverride;
   cfg: OpenClawConfig;
+  signal?: AbortSignal;
+  assertPlatformSendAuthorized?: () => void;
 }): TelegramApiContext {
   const cfg = requireRuntimeConfig(opts.cfg, "Telegram API context");
   const account = resolveTelegramAccount({
@@ -423,6 +425,15 @@ function resolveTelegramApiContext(opts: {
     // and retries) so eviction cannot close the transport mid-operation.
     clientOptionsLease = client.lease();
     const bot = new Bot(token, client.clientOptions ? { client: client.clientOptions } : undefined);
+    if (opts.signal || opts.assertPlatformSendAuthorized) {
+      // grammY wraps later transformers around earlier ones. Check authority
+      // after the account queue drains, immediately before its HTTP client runs.
+      bot.api.config.use((prev, method, payload, signal) => {
+        opts.signal?.throwIfAborted();
+        opts.assertPlatformSendAuthorized?.();
+        return prev(method, payload, signal);
+      });
+    }
     bot.api.config.use(getOrCreateAccountThrottler(token).transformer);
     api = bot.api;
   }

--- a/extensions/telegram/src/send-message-types.ts
+++ b/extensions/telegram/src/send-message-types.ts
@@ -13,6 +13,7 @@ export type TelegramSendOpts = {
   accountId?: string;
   verbose?: boolean;
   mediaUrl?: string;
+  mediaUrls?: readonly string[];
   mediaAccess?: OutboundMediaAccess;
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;

--- a/extensions/telegram/src/send-message-types.ts
+++ b/extensions/telegram/src/send-message-types.ts
@@ -68,7 +68,8 @@ export type TelegramApiCallOpts = Pick<
 export type TelegramThreadedSendOpts = TelegramApiCallOpts &
   Pick<TelegramSendOpts, "replyToMessageId" | "messageThreadId">;
 
-export type TelegramMessageActionOpts = TelegramApiCallOpts & { notify?: boolean };
+export type TelegramMessageActionOpts = TelegramApiCallOpts &
+  Pick<TelegramSendOpts, "signal" | "assertPlatformSendAuthorized"> & { notify?: boolean };
 
 export type TelegramSendResult = {
   messageId: string;

--- a/extensions/telegram/src/send-message-types.ts
+++ b/extensions/telegram/src/send-message-types.ts
@@ -52,6 +52,8 @@ export type TelegramSendOpts = {
   forceDocument?: boolean;
   /** Persist each concrete platform send before any later chunk can fail. */
   onDeliveryResult?: (result: TelegramSendResult) => Promise<void> | void;
+  /** @internal Cancel remaining physical sends for the current delivery. */
+  signal?: AbortSignal;
   /** @internal Revalidate durable custody before a send operation, not after throttle waits. */
   onPlatformSendDispatch?: () => Promise<void>;
   /** @internal Synchronously fence custody after refresh and immediately before Telegram I/O. */

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -11,6 +11,7 @@ import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
 import { telegramCaptionDeliveryMetadata } from "./caption.js";
 import { renderTelegramHtmlText } from "./format.js";
 import { buildInlineKeyboard } from "./inline-keyboard.js";
+import { planTelegramMediaBatches } from "./outbound-media-batches.js";
 import {
   prepareTelegramOutboundMedia,
   resolveTelegramOutboundMediaSenders,
@@ -27,11 +28,18 @@ import {
   toAcceptedThreadScopedParams,
   withTelegramApiContext,
 } from "./send-context.js";
-import { isTelegramVoiceMessagesForbiddenError } from "./send-error-predicates.js";
+import {
+  isTelegramPhotoLimitError,
+  isTelegramVoiceMessagesForbiddenError,
+} from "./send-error-predicates.js";
 import { createTelegramTextSender } from "./send-message-text.js";
 import type { TelegramSendOpts, TelegramSendResult } from "./send-message-types.js";
-import { prepareTelegramOutbound, reportTelegramProviderDelivery } from "./send-outbound.js";
-import { createTelegramPreparedSender } from "./send-prepared.js";
+import {
+  buildTelegramProviderDeliveryResult,
+  prepareTelegramOutbound,
+  reportTelegramProviderDelivery,
+} from "./send-outbound.js";
+import { createTelegramPreparedSender, type TelegramPreparedSendPart } from "./send-prepared.js";
 import {
   buildOutboundMediaLoadOptions,
   getImageMetadata,
@@ -71,6 +79,8 @@ export async function sendMessageTelegram(
       },
       request: { kind: "nonIdempotent" },
     });
+    const deliveryResults: TelegramSendResult[] = [];
+    let finalMediaBatch = true;
     const reportDelivery = async (
       messageId: string | number,
       deliveredChatId: string | number,
@@ -86,7 +96,15 @@ export async function sendMessageTelegram(
         successfulSendThread: threadSpec,
         ...(meta ? { meta } : {}),
         ...(kind ? { kind } : {}),
-        ...(onPrepared ? { onPrepared } : {}),
+        onPrepared: (delivery) => {
+          deliveryResults.push({
+            ...delivery,
+            receipt:
+              delivery.receipt ??
+              createMessageReceiptFromOutboundResults({ results: [delivery], kind }),
+          });
+          onPrepared?.(delivery);
+        },
         onDeliveryResult: opts.onDeliveryResult,
       });
     };
@@ -98,7 +116,7 @@ export async function sendMessageTelegram(
       finalPart: boolean,
     ) => {
       const plan = opts.promptContextProjectionPlan;
-      const projection = plan?.cursor.take(plan.finalPart && finalPart);
+      const projection = plan?.cursor.take(plan.finalPart && finalPart && finalMediaBatch);
       const recorded = await recordOutboundMessageForPromptContext({
         cfg,
         ownerAgentId,
@@ -116,7 +134,9 @@ export async function sendMessageTelegram(
         plan?.cursor.invalidate();
       }
     };
-    const mediaUrl = opts.mediaUrl?.trim();
+    const mediaUrls = (opts.mediaUrls?.length ? opts.mediaUrls : [opts.mediaUrl ?? ""])
+      .map((url) => url.trim())
+      .filter(Boolean);
     const mediaMaxBytes =
       opts.maxBytes ??
       (typeof account.config.mediaMaxMb === "number" ? account.config.mediaMaxMb : 100) *
@@ -164,6 +184,39 @@ export async function sendMessageTelegram(
       },
       assertPlatformSendAuthorized: opts.assertPlatformSendAuthorized,
     });
+    const buildMediaReceipt = () => {
+      const deliveries = new Map(deliveryResults.map((delivery) => [delivery.messageId, delivery]));
+      const results = sender.parts.map((part) => {
+        const messageId = String(part.messageId);
+        const delivery =
+          deliveries.get(messageId) ??
+          buildTelegramProviderDeliveryResult({
+            message: part.result,
+            messageId,
+            fallbackChatId: chatId,
+            successfulSendThread: threadSpec,
+            kind: "media",
+          });
+        const replyToId = resolveAcceptedReplyToMessageId(
+          toAcceptedThreadScopedParams(part.acceptedParams),
+        )?.toString();
+        return {
+          ...delivery,
+          receipt: createMessageReceiptFromOutboundResults({
+            results: [delivery],
+            kind: "media",
+            ...(replyToId ? { replyToId } : {}),
+          }),
+        };
+      });
+      const receipt = createMessageReceiptFromOutboundResults({ results, kind: "media" });
+      receipt.parts = receipt.parts.map((part, index) => ({ ...part, index }));
+      const replyToId = receipt.parts.find((part) => part.replyToId)?.replyToId;
+      if (replyToId) {
+        receipt.replyToId = replyToId;
+      }
+      return receipt;
+    };
     const { sendChunkedText } = createTelegramTextSender({
       cfg,
       ownerAgentId,
@@ -217,7 +270,7 @@ export async function sendMessageTelegram(
       }
     }
 
-    if (mediaUrl) {
+    const prepareMedia = async (mediaUrl: string, index: number) => {
       const media = await loadWebMedia(
         mediaUrl,
         buildOutboundMediaLoadOptions({
@@ -230,7 +283,7 @@ export async function sendMessageTelegram(
       );
       const mediaPlan = prepareTelegramOutboundMedia({
         media,
-        text,
+        text: index === 0 ? text : "",
         textMode,
         tableMode,
         forceDocument: opts.forceDocument,
@@ -249,17 +302,26 @@ export async function sendMessageTelegram(
         asVoice: opts.asVoice,
         sendImageAsPhoto,
       });
+      return { index, media, mediaPlan, mediaSender, documentSender };
+    };
+    type PreparedMedia = Awaited<ReturnType<typeof prepareMedia>>;
+    const sendMediaBatch = async (
+      batch: [PreparedMedia, ...PreparedMedia[]],
+    ): Promise<TelegramSendResult> => {
+      const first = batch[0];
+      const { media, mediaPlan, mediaSender, documentSender } = first;
+      const batchReplyMarkup = first.index === 0 ? replyMarkup : undefined;
+      finalMediaBatch = first.index + batch.length === mediaUrls.length;
       const { htmlCaption, plainCaption, followUpText } = mediaPlan;
       // If text exceeds Telegram's caption limit, send media without caption
       // then send text as a separate follow-up message.
       const needsSeparateText = Boolean(followUpText);
       // When splitting, put reply_markup only on the follow-up text (the "main" content),
       // not on the media message.
-      const mediaThreadParams = preparedThreadParams;
-      const mediaUsedReplyTo = resolveAcceptedReplyToMessageId(mediaThreadParams) !== undefined;
+      const mediaThreadParams = buildThreadParams(!singleUseReplyTo || sender.parts.length === 0);
       const baseMediaParams = {
         ...mediaThreadParams,
-        ...(!needsSeparateText && replyMarkup ? { reply_markup: replyMarkup } : {}),
+        ...(!needsSeparateText && batchReplyMarkup ? { reply_markup: batchReplyMarkup } : {}),
       };
       const videoDimensions =
         mediaPlan.deliveryKind === "video" && !mediaPlan.isVideoNote
@@ -273,24 +335,58 @@ export async function sendMessageTelegram(
           ? { width: videoDimensions.width, height: videoDimensions.height }
           : {}),
       };
-      let mediaDelivery: Awaited<ReturnType<typeof sender.sendMedia>>;
+      let mediaParts: [TelegramPreparedSendPart, ...TelegramPreparedSendPart[]];
+      let operation = mediaSender.operation;
+      let deliveryKind = mediaSender.label;
       try {
-        mediaDelivery = await sender.sendMedia({
-          sender: mediaSender,
-          documentSender,
-          requestParams: mediaParams,
-          plainCaption: htmlCaption ? plainCaption : undefined,
-        });
+        if (batch.length > 1) {
+          try {
+            const album = await sender.sendPhotoAlbum({
+              files: batch.map((item) => item.mediaPlan.file),
+              requestParams: mediaParams,
+              plainCaption: htmlCaption ? plainCaption : undefined,
+            });
+            mediaParts = album.parts;
+            operation = "sendMediaGroup";
+          } catch (error) {
+            if (!isTelegramPhotoLimitError(error)) {
+              throw error;
+            }
+            // A definite photo-limit rejection accepts no album. Reuse singleton
+            // delivery so Telegram can identify which photo requires a document.
+            // The album's long caption follows every fallback attachment.
+            first.mediaPlan.followUpText = undefined;
+            batch.reduce((_previous, item) => item).mediaPlan.followUpText = followUpText;
+            let result = await sendMediaBatch([first]);
+            for (const item of batch.slice(1)) {
+              result = await sendMediaBatch([item]);
+            }
+            return result;
+          }
+        } else {
+          const delivery = await sender.sendMedia({
+            sender: mediaSender,
+            documentSender,
+            requestParams: mediaParams,
+            plainCaption: htmlCaption ? plainCaption : undefined,
+          });
+          mediaParts = [delivery];
+          operation = delivery.sender.operation;
+          deliveryKind = delivery.sender.label;
+        }
       } catch (error) {
         if (
           mediaSender.label === "voice" &&
           isTelegramVoiceMessagesForbiddenError(error) &&
+          first.index === 0 &&
           text.trim()
         ) {
           logVerbose(
             "telegram sendVoice forbidden by recipient privacy settings; falling back to text",
           );
-          const textResult = await sendChunkedText(text, "voice fallback text send");
+          const textResult = await sendChunkedText(text, "voice fallback text send", {
+            replyToAlreadyUsed: singleUseReplyTo && sender.parts.length > 0,
+          });
           recordChannelActivity({
             channel: "telegram",
             accountId: account.accountId,
@@ -301,73 +397,80 @@ export async function sendMessageTelegram(
         opts.promptContextProjectionPlan?.cursor.invalidate();
         throw error;
       }
-      const result = mediaDelivery.result;
-      const deliveredCaption = mediaDelivery.plainText || undefined;
-      const acceptedMediaParams = toAcceptedThreadScopedParams(mediaDelivery.acceptedParams);
-      const mediaMessageId = resolveTelegramMessageIdOrThrow(result, "media send");
-      const resolvedChatId = String(result?.chat?.id ?? chatId);
+      const lastMedia = mediaParts.reduce((_previous, part) => part);
       let mediaDeliveryResult: TelegramSendResult | undefined;
-      let mediaPromptRecorded = false;
-      const reportMediaDelivery = async (hasInlineKeyboard: boolean) => {
-        const meta = {
-          ...(deliveredCaption ? { telegramDeliveredText: deliveredCaption } : {}),
-          telegramHasInlineKeyboard: hasInlineKeyboard,
-        };
-        telegramCaptionDeliveryMetadata.add(meta);
-        mediaDeliveryResult = await reportDelivery(
-          mediaMessageId,
-          resolvedChatId,
-          result,
-          meta,
-          "media",
-          (delivery) => {
-            mediaDeliveryResult = delivery;
+      const recordedMedia = new Set<Message>();
+      const recordMediaPromptPart = async (part: TelegramPreparedSendPart, finalPart: boolean) => {
+        if (recordedMedia.has(part.result)) {
+          return;
+        }
+        const acceptedParams = toAcceptedThreadScopedParams(part.acceptedParams);
+        await recordDeliveredPromptContext(
+          {
+            message: part.result,
+            messageId: part.result.message_id,
+            ...(part.plainText ? { text: part.plainText } : {}),
+            ...(acceptedParams?.message_thread_id !== undefined
+              ? { messageThreadId: acceptedParams.message_thread_id }
+              : {}),
           },
+          finalPart,
         );
+        recordedMedia.add(part.result);
       };
       const recordMediaPromptContext = async (finalPart: boolean) => {
-        if (!mediaPromptRecorded) {
-          await recordDeliveredPromptContext(
-            {
-              message: result,
-              messageId: mediaMessageId,
-              ...(deliveredCaption ? { text: deliveredCaption } : {}),
-              ...(acceptedMediaParams?.message_thread_id !== undefined
-                ? { messageThreadId: acceptedMediaParams.message_thread_id }
-                : {}),
-            },
-            finalPart,
-          );
-          mediaPromptRecorded = true;
+        for (const [index, part] of mediaParts.entries()) {
+          await recordMediaPromptPart(part, finalPart && index === mediaParts.length - 1);
         }
       };
-      await sender.accept(
-        mediaDelivery,
-        async () => {
-          recordSentMessage(chatId, mediaMessageId, cfg, {
+      await sender.acceptMany(
+        mediaParts,
+        async (part) => {
+          const deliveredCaption = part.plainText || undefined;
+          const acceptedParams = toAcceptedThreadScopedParams(part.acceptedParams);
+          const resolvedChatId = String(part.result.chat?.id ?? chatId);
+          const meta = {
+            ...(deliveredCaption ? { telegramDeliveredText: deliveredCaption } : {}),
+            telegramHasInlineKeyboard: part.hasInlineKeyboard,
+          };
+          telegramCaptionDeliveryMetadata.add(meta);
+          recordSentMessage(chatId, part.messageId, cfg, {
             accountId: account.accountId,
             agentId: ownerAgentId,
           });
-          await reportMediaDelivery(!needsSeparateText && Boolean(replyMarkup));
-          if (!needsSeparateText) {
-            await recordMediaPromptContext(true);
+          await reportDelivery(
+            part.messageId,
+            resolvedChatId,
+            part.result,
+            meta,
+            "media",
+            (delivery) => {
+              mediaDeliveryResult = delivery;
+            },
+          );
+          const lastPart = part.result === lastMedia.result;
+          if (!needsSeparateText || !lastPart) {
+            await recordMediaPromptPart(part, lastPart);
           }
+          logTelegramOutboundSendOk({
+            accountId: account.accountId,
+            chatId: resolvedChatId,
+            messageId: String(part.messageId),
+            operation,
+            deliveryKind,
+            messageThreadId: acceptedParams?.message_thread_id,
+            replyToMessageId: opts.replyToMessageId,
+            silent: opts.silent,
+          });
         },
         () => ({
-          ...(mediaDeliveryResult?.receipt ? { receipt: mediaDeliveryResult.receipt } : {}),
+          receipt: buildMediaReceipt(),
           visibleReplySent: true,
         }),
       );
-      logTelegramOutboundSendOk({
-        accountId: account.accountId,
-        chatId: resolvedChatId,
-        messageId: String(mediaMessageId),
-        operation: mediaDelivery.sender.operation,
-        deliveryKind: mediaDelivery.sender.label,
-        messageThreadId: acceptedMediaParams?.message_thread_id,
-        replyToMessageId: opts.replyToMessageId,
-        silent: opts.silent,
-      });
+      const mediaMessageId = resolveTelegramMessageIdOrThrow(lastMedia.result, "media send");
+      const resolvedChatId = String(lastMedia.result.chat?.id ?? chatId);
+      const acceptedMediaParams = toAcceptedThreadScopedParams(lastMedia.acceptedParams);
       recordChannelActivity({
         channel: "telegram",
         accountId: account.accountId,
@@ -380,17 +483,17 @@ export async function sendMessageTelegram(
         let textResult: TelegramSendResult;
         try {
           textResult = await sendChunkedText(followUpText, "text follow-up send", {
-            replyToAlreadyUsed: singleUseReplyTo && mediaUsedReplyTo,
+            replyToAlreadyUsed: singleUseReplyTo,
             beforeFirstAccepted: () => recordMediaPromptContext(false),
           });
         } catch (error) {
           if (!isChannelPartialDeliveryError(error) && isTelegramEmptyContentError(error)) {
             let hasInlineKeyboard = false;
             let keyboardError: unknown;
-            if (replyMarkup) {
+            if (batchReplyMarkup) {
               try {
                 await api.editMessageReplyMarkup(resolvedChatId, mediaMessageId, {
-                  reply_markup: replyMarkup,
+                  reply_markup: batchReplyMarkup,
                 });
                 hasInlineKeyboard = true;
               } catch (editError) {
@@ -453,6 +556,39 @@ export async function sendMessageTelegram(
             chatId: resolvedChatId,
             ...(mediaDeliveryResult?.receipt ? { receipt: mediaDeliveryResult.receipt } : {}),
           };
+    };
+
+    if (mediaUrls.length > 0) {
+      if (opts.asVideoNote && mediaUrls.length !== 1) {
+        throw new Error("Telegram video notes require exactly one media attachment.");
+      }
+      try {
+        for await (const batch of planTelegramMediaBatches({
+          mediaUrls,
+          prepare: prepareMedia,
+          // Telegram albums cannot carry inline controls. Preserve the first
+          // attachment's keyboard through the existing singleton path.
+          canGroup: (item) => !replyMarkup && item.mediaSender.label === "photo",
+        })) {
+          const result = await sendMediaBatch(batch);
+          if (batch[0].index + batch.length === mediaUrls.length) {
+            if (mediaUrls.length === 1) {
+              return result;
+            }
+            const receipt = buildMediaReceipt();
+            const keyboardResult = deliveryResults.find(
+              (delivery) => delivery.meta?.telegramHasInlineKeyboard,
+            );
+            return { ...(keyboardResult ?? result), receipt };
+          }
+        }
+      } catch (error) {
+        opts.promptContextProjectionPlan?.cursor.invalidate();
+        return sender.fail(error, 0, {
+          receipt: buildMediaReceipt(),
+          visibleReplySent: sender.parts.length > 0,
+        });
+      }
     }
 
     if (!text || !text.trim()) {

--- a/extensions/telegram/src/send-message.ts
+++ b/extensions/telegram/src/send-message.ts
@@ -182,7 +182,10 @@ export async function sendMessageTelegram(
         await opts.onPlatformSendDispatch?.();
         return requestWithChatNotFound(send, label, options);
       },
-      assertPlatformSendAuthorized: opts.assertPlatformSendAuthorized,
+      assertPlatformSendAuthorized: () => {
+        opts.signal?.throwIfAborted();
+        opts.assertPlatformSendAuthorized?.();
+      },
     });
     const buildMediaReceipt = () => {
       const deliveries = new Map(deliveryResults.map((delivery) => [delivery.messageId, delivery]));
@@ -586,7 +589,7 @@ export async function sendMessageTelegram(
         opts.promptContextProjectionPlan?.cursor.invalidate();
         return sender.fail(error, 0, {
           receipt: buildMediaReceipt(),
-          visibleReplySent: sender.parts.length > 0,
+          visibleReplySent: true,
         });
       }
     }

--- a/extensions/telegram/src/send-outbound.ts
+++ b/extensions/telegram/src/send-outbound.ts
@@ -40,23 +40,21 @@ type PreparedTelegramOutbound = {
 type PreparedTelegramOutboundWithMessageId<T> = PreparedTelegramOutbound &
   (T extends string | number ? { messageId: number } : { messageId?: undefined });
 
-export async function reportTelegramProviderDelivery(params: {
+export function buildTelegramProviderDeliveryResult(params: {
   message: TelegramOutboundPromptContextMessage;
   messageId: string | number;
   fallbackChatId: string | number;
   successfulSendThread?: TelegramThreadSpec;
   kind?: MessageReceiptPartKind;
   meta?: TelegramSendResult["meta"];
-  onPrepared?: (delivery: TelegramSendResult) => void;
-  onDeliveryResult?: TelegramSendOpts["onDeliveryResult"];
-}): Promise<TelegramSendResult> {
+}): TelegramSendResult {
   const messageId = String(params.messageId);
   const chatId = String(params.message.chat?.id ?? params.fallbackChatId);
   const providerThreadId = resolveTelegramProviderObservedThreadId({
     message: params.message,
     successfulSendThread: params.successfulSendThread,
   });
-  const delivery: TelegramSendResult = {
+  return {
     messageId,
     chatId,
     ...(providerThreadId !== undefined
@@ -70,6 +68,15 @@ export async function reportTelegramProviderDelivery(params: {
       : {}),
     ...(params.meta ? { meta: params.meta } : {}),
   };
+}
+
+export async function reportTelegramProviderDelivery(
+  params: Parameters<typeof buildTelegramProviderDeliveryResult>[0] & {
+    onPrepared?: (delivery: TelegramSendResult) => void;
+    onDeliveryResult?: TelegramSendOpts["onDeliveryResult"];
+  },
+): Promise<TelegramSendResult> {
+  const delivery = buildTelegramProviderDeliveryResult(params);
   params.onPrepared?.(delivery);
   await params.onDeliveryResult?.(delivery);
   try {
@@ -79,7 +86,7 @@ export async function reportTelegramProviderDelivery(params: {
     });
   } catch (error) {
     throw createChannelPartialDeliveryError(error, {
-      messageIds: [messageId],
+      messageIds: [delivery.messageId],
       ...(delivery.receipt ? { receipt: delivery.receipt } : {}),
       visibleReplySent: true,
     });

--- a/extensions/telegram/src/send-prepared.ts
+++ b/extensions/telegram/src/send-prepared.ts
@@ -1,3 +1,4 @@
+import type { InputFile } from "grammy";
 import type { InlineKeyboardMarkup, Message } from "grammy/types";
 import { createChannelApiRetryRunner } from "openclaw/plugin-sdk/retry-runtime";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
@@ -107,19 +108,29 @@ export function createTelegramPreparedSender(config: {
     parts.push(accepted);
     return accepted;
   };
-  const accept = async (
-    part: TelegramPreparedSendPart,
+  const acceptMany = async (
+    delivered: readonly TelegramPreparedSendPart[],
     observe: ObservePart,
     details?: () => PartialDeliveryResult,
     start = 0,
   ) => {
-    const accepted = recordAcceptance(part);
+    // One album request accepts every returned message at once. Record all IDs
+    // before any receipt/cache observer can fail, preventing a replay of its tail.
+    const accepted = delivered.map(recordAcceptance);
     try {
-      await observe(accepted);
+      for (const part of accepted) {
+        await observe(part);
+      }
     } catch (error) {
       fail(error, start, details?.());
     }
   };
+  const accept = (
+    part: TelegramPreparedSendPart,
+    observe: ObservePart,
+    details?: () => PartialDeliveryResult,
+    start = 0,
+  ) => acceptMany([part], observe, details, start);
   const request = <T>(
     label: string,
     requestParams: Record<string, unknown>,
@@ -328,7 +339,54 @@ export function createTelegramPreparedSender(config: {
       sender: delivery.sender,
     };
   };
-  return { parts, accept, fail, sendText, sendMedia };
+  const sendPhotoAlbum = async (params: {
+    files: readonly InputFile[];
+    requestParams: Record<string, unknown>;
+    plainCaption?: string;
+  }) => {
+    await config.beforeMedia?.();
+    const delivery = await sendTelegramCaptionedMediaWithFallback({
+      operation: "sendMediaGroup",
+      requestParams: params.requestParams,
+      plainCaption: params.plainCaption,
+      send: (requestParams, shouldLog) =>
+        request(
+          "sendMediaGroup",
+          requestParams,
+          (effective) => {
+            const { caption, parse_mode, ...groupParams } = effective;
+            return config.api.sendMediaGroup(
+              config.chatId,
+              params.files.map((media, index) => ({
+                type: "photo" as const,
+                media,
+                ...(index === 0 && typeof caption === "string" ? { caption } : {}),
+                ...(index === 0 && parse_mode === "HTML" ? { parse_mode: "HTML" as const } : {}),
+              })),
+              groupParams,
+            );
+          },
+          { shouldLog },
+        ),
+    });
+    const prepared = delivery.result.result.map((result, index): TelegramPreparedSendPart => ({
+      result,
+      acceptedParams: delivery.result.acceptedParams,
+      plainText: index === 0 ? (delivery.deliveredCaption ?? "") : "",
+    }));
+    const [first, ...remaining] = prepared;
+    if (!first) {
+      throw new Error("Telegram sendMediaGroup returned no messages");
+    }
+    return {
+      parts: [first, ...remaining] satisfies [
+        TelegramPreparedSendPart,
+        ...TelegramPreparedSendPart[],
+      ],
+      ...(delivery.captionRemoved ? { captionRemoved: true as const } : {}),
+    };
+  };
+  return { parts, accept, acceptMany, fail, sendText, sendMedia, sendPhotoAlbum };
 }
 
 export type TelegramPreparedSender = ReturnType<typeof createTelegramPreparedSender>;

--- a/extensions/telegram/src/send.telegram-http.test.ts
+++ b/extensions/telegram/src/send.telegram-http.test.ts
@@ -7,9 +7,12 @@ import { Bot } from "grammy";
 import { isChannelPartialDeliveryError } from "openclaw/plugin-sdk/channel-inbound";
 import { sanitizeForPlainText } from "openclaw/plugin-sdk/channel-outbound";
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterAll, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { getOrCreateAccountThrottler } from "./account-throttler.js";
+import { apiThrottler } from "./bot.runtime.js";
 import { deliverReplies } from "./bot/delivery.js";
-import { sendMessageTelegram } from "./send.js";
+import { resetTelegramClientOptionsCacheForTests, sendMessageTelegram } from "./send.js";
 
 describe("Telegram physical send acceptance over HTTP", () => {
   let server: Server;
@@ -20,6 +23,12 @@ describe("Telegram physical send acceptance over HTTP", () => {
   const requests: Array<{ method: string; fields: Record<string, unknown> }> = [];
   const events: string[] = [];
   const rejections: string[] = [];
+  let requestHold:
+    | {
+        arrived: ReturnType<typeof createDeferred<void>>;
+        release: ReturnType<typeof createDeferred<void>>;
+      }
+    | undefined;
   const cfg = { channels: { telegram: { botToken: "123456:telegram-send-http-fixture" } } };
   const buttons = [[{ text: "Continue", callback_data: "continue" }]];
 
@@ -49,6 +58,12 @@ describe("Telegram physical send acceptance over HTTP", () => {
         const method = request.url?.split("/").at(-1) ?? "";
         requests.push({ method, fields });
         events.push("http");
+        const held = requestHold;
+        requestHold = undefined;
+        if (held) {
+          held.arrived.resolve();
+          await held.release.promise;
+        }
         response.setHeader("content-type", "application/json");
         const rejection = rejections.shift();
         if (rejection) {
@@ -97,6 +112,7 @@ describe("Telegram physical send acceptance over HTTP", () => {
   });
 
   afterAll(async () => {
+    resetTelegramClientOptionsCacheForTests();
     for (const socket of sockets) {
       socket.destroy();
     }
@@ -167,6 +183,70 @@ describe("Telegram physical send acceptance over HTTP", () => {
 
     expect(requests.at(-1)?.fields.text).toBe("Manual");
   });
+
+  it.each(["active", "closed", "aborted"])(
+    "checks %s send authority after the real account queue drains",
+    async (state) => {
+      const token = `123456:telegram-queue-${state}`;
+      getOrCreateAccountThrottler(token, () =>
+        apiThrottler({ global: { maxConcurrent: 1 }, out: { maxConcurrent: 1 } }),
+      );
+      const queuedCfg = {
+        channels: {
+          telegram: {
+            botToken: token,
+            apiRoot: `http://127.0.0.1:${(server.address() as AddressInfo).port}`,
+          },
+        },
+      };
+      const held = { arrived: createDeferred<void>(), release: createDeferred<void>() };
+      requestHold = held;
+      const blocker = sendMessageTelegram("123", "queue blocker", { cfg: queuedCfg });
+      await held.arrived.promise;
+      const checkedBeforeQueue = createDeferred<void>();
+      const controller = new AbortController();
+      const revoked = new Error("Send authority closed while queued");
+      let authorityActive = true;
+      const outcome = sendMessageTelegram("123", "queued message", {
+        cfg: queuedCfg,
+        signal: controller.signal,
+        assertPlatformSendAuthorized: () => {
+          if (!authorityActive) {
+            throw revoked;
+          }
+          checkedBeforeQueue.resolve();
+        },
+      }).then(
+        (result) => ({ result }),
+        (error: unknown) => ({ error }),
+      );
+      try {
+        await checkedBeforeQueue.promise;
+        expect(requests.map(({ fields }) => fields.text)).toEqual(["queue blocker"]);
+        authorityActive = state !== "closed";
+        if (state === "aborted") {
+          controller.abort();
+        }
+        held.release.resolve();
+        await blocker;
+        if (state === "active") {
+          await expect(outcome).resolves.toMatchObject({ result: { messageId: "2" } });
+          expect(requests.map(({ fields }) => fields.text)).toEqual([
+            "queue blocker",
+            "queued message",
+          ]);
+        } else {
+          await expect(outcome).resolves.toMatchObject({
+            error: state === "closed" ? revoked : { name: "AbortError" },
+          });
+          expect(requests.map(({ fields }) => fields.text)).toEqual(["queue blocker"]);
+        }
+      } finally {
+        held.release.resolve();
+        await Promise.allSettled([blocker, outcome]);
+      }
+    },
+  );
 
   it("fences provider-owned delivery after async dispatch refresh and before HTTP", async () => {
     const authorityRevoked = new Error("delivery authority revoked after dispatch refresh");

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2442,6 +2442,64 @@ describe("sendMessageTelegram", () => {
     expect(result.receipt?.parts.at(-1)?.replyToId).toBeUndefined();
   });
 
+  it.each([
+    "active",
+    "aborted after album",
+    "aborted during dispatch",
+    "owner lost during dispatch",
+  ])("sends the next album batch only while authority remains %s", async (state) => {
+    const mediaUrls = Array.from({ length: 11 }, (_, index) => `https://example.com/${index}.jpg`);
+    mediaUrls.forEach(() => mockLoadedMedia({ contentType: "image/jpeg" }));
+    const ids = Array.from({ length: 10 }, (_, index) => String(100 + index));
+    const sendMediaGroup = vi
+      .fn()
+      .mockResolvedValue(ids.map((id) => ({ message_id: Number(id), chat: { id: 123 } })));
+    const sendPhoto = vi.fn().mockResolvedValue({ message_id: 110, chat: { id: 123 } });
+    const controller = new AbortController();
+    let ownsSend = true;
+    let delivered = 0;
+    const onDeliveryResult = vi.fn(() => {
+      delivered += 1;
+      if (delivered === 10 && state === "aborted after album") {
+        controller.abort();
+      }
+    });
+    const sending = sendMessageTelegram("123", "caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      mediaUrls,
+      signal: controller.signal,
+      api: makeTelegramApiTestMock({ sendMediaGroup, sendPhoto }),
+      onDeliveryResult,
+      onPlatformSendDispatch: async () => {
+        await Promise.resolve();
+        if (delivered === 10 && state === "aborted during dispatch") {
+          controller.abort();
+        }
+        if (delivered === 10 && state === "owner lost during dispatch") {
+          ownsSend = false;
+        }
+      },
+      assertPlatformSendAuthorized: () => {
+        if (!ownsSend) {
+          throw new Error("Send owner lost authority");
+        }
+      },
+    });
+    if (state === "active") {
+      expect(await sending).toMatchObject({ receipt: { platformMessageIds: [...ids, "110"] } });
+      expect(sendPhoto).toHaveBeenCalledTimes(1);
+      expect(onDeliveryResult).toHaveBeenCalledTimes(11);
+    } else {
+      await expect(sending).rejects.toMatchObject({
+        deliveryResult: { messageIds: ids, receipt: { platformMessageIds: ids } },
+      });
+      expect(sendPhoto).not.toHaveBeenCalled();
+      expect(onDeliveryResult).toHaveBeenCalledTimes(10);
+    }
+    expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+  });
+
   it.each(["observer", "later load", "later send"])(
     "retains all album IDs after a %s failure",
     async (failure) => {

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2342,6 +2342,315 @@ describe("sendMessageTelegram", () => {
     ).rejects.toThrow(/returned no message_id/i);
   });
 
+  it.each([
+    { count: 1, albums: [], singles: 1 },
+    { count: 2, albums: [2], singles: 0 },
+    { count: 10, albums: [10], singles: 0 },
+    { count: 11, albums: [10], singles: 1 },
+    { count: 21, albums: [10, 10], singles: 1 },
+  ])(
+    "sends $count photos in bounded albums and records every message",
+    async ({ count, albums, singles }) => {
+      const mediaUrls = Array.from(
+        { length: count },
+        (_, index) => "https://example.com/photo-" + index + ".jpg",
+      );
+      for (const url of mediaUrls) {
+        mockLoadedMedia({ contentType: "image/jpeg", fileName: url.split("/").at(-1) });
+      }
+      let nextId = 100;
+      const sendMediaGroup = vi
+        .fn()
+        .mockImplementation(async (_chat, media) =>
+          media.map(() => ({ message_id: nextId++, chat: { id: 123 } })),
+        );
+      const sendPhoto = vi
+        .fn()
+        .mockImplementation(async () => ({ message_id: nextId++, chat: { id: 123 } }));
+      const onDeliveryResult = vi.fn();
+      const result = await sendMessageTelegram("123", "**Album caption**", {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        mediaUrls,
+        api: makeTelegramApiTestMock({ sendMediaGroup, sendPhoto }),
+        onDeliveryResult,
+      });
+      expect(sendMediaGroup.mock.calls.map((call) => call[1].length)).toEqual(albums);
+      expect(sendPhoto).toHaveBeenCalledTimes(singles);
+      expect(onDeliveryResult.mock.calls.map((call) => call[0].messageId)).toEqual(
+        mediaUrls.map((_, index) => String(100 + index)),
+      );
+      if (count > 1) {
+        expect(result.receipt?.platformMessageIds).toEqual(
+          mediaUrls.map((_, index) => String(100 + index)),
+        );
+        expect(result.receipt?.parts.map((part) => part.index)).toEqual(
+          mediaUrls.map((_, index) => index),
+        );
+        const firstAlbum = sendMediaGroup.mock.calls[0]![1];
+        expect(firstAlbum[0]).toMatchObject({
+          type: "photo",
+          caption: "<b>Album caption</b>",
+          parse_mode: "HTML",
+        });
+        expect(
+          firstAlbum.slice(1).every((item: { caption?: string }) => item.caption === undefined),
+        ).toBe(true);
+      }
+    },
+  );
+
+  it("keeps album topics, silence, and first-mode native reply on the first batch only", async () => {
+    const mediaUrls = Array.from(
+      { length: 11 },
+      (_, index) => "https://example.com/" + index + ".jpg",
+    );
+    mediaUrls.forEach(() => mockLoadedMedia({ contentType: "image/jpeg" }));
+    const sendMediaGroup = vi.fn().mockResolvedValue(
+      Array.from({ length: 10 }, (_, index) => ({
+        message_id: 100 + index,
+        chat: { id: -100123 },
+        message_thread_id: 12,
+      })),
+    );
+    const sendPhoto = vi
+      .fn()
+      .mockResolvedValue({ message_id: 110, chat: { id: -100123 }, message_thread_id: 12 });
+    const result = await sendMessageTelegram("-100123", "caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      mediaUrls,
+      messageThreadId: 12,
+      replyToMessageId: 90,
+      quoteText: "quoted text",
+      replyToIdSource: "implicit",
+      replyToMode: "first",
+      silent: true,
+      api: makeTelegramApiTestMock({ sendMediaGroup, sendPhoto }),
+    });
+    expect(sendMediaGroup.mock.calls[0]![2]).toMatchObject({
+      message_thread_id: 12,
+      disable_notification: true,
+      reply_parameters: { message_id: 90, quote: "quoted text" },
+    });
+    expect(sendPhoto.mock.calls[0]![2]).toMatchObject({
+      message_thread_id: 12,
+      disable_notification: true,
+    });
+    expect(sendPhoto.mock.calls[0]![2].reply_parameters).toBeUndefined();
+    expect(sendPhoto.mock.calls[0]![2].reply_to_message_id).toBeUndefined();
+    expect(result.receipt?.parts.at(-1)?.replyToId).toBeUndefined();
+  });
+
+  it.each(["observer", "later load", "later send"])(
+    "retains all album IDs after a %s failure",
+    async (failure) => {
+      const mediaUrls = Array.from(
+        { length: 11 },
+        (_, index) => "https://example.com/" + index + ".jpg",
+      );
+      mediaUrls.slice(0, 10).forEach(() => mockLoadedMedia({ contentType: "image/jpeg" }));
+      if (failure === "later load") {
+        loadWebMedia.mockRejectedValueOnce(new Error("later load failed"));
+      } else {
+        mockLoadedMedia({ contentType: "image/jpeg" });
+      }
+      const ids = Array.from({ length: 10 }, (_, index) => String(100 + index));
+      const sendMediaGroup = vi.fn().mockResolvedValue(
+        ids.map((id) => ({
+          message_id: Number(id),
+          chat: { id: -100123 },
+          message_thread_id: 12,
+        })),
+      );
+      const sendPhoto = vi.fn().mockRejectedValue(new Error("later send failed"));
+      const onDeliveryResult =
+        failure === "observer" ? vi.fn().mockRejectedValue(new Error("observer failed")) : vi.fn();
+      await expect(
+        sendMessageTelegram("-100123", "caption", {
+          cfg: TELEGRAM_TEST_CFG,
+          token: "tok",
+          mediaUrls,
+          messageThreadId: 12,
+          retry: { attempts: 1 },
+          api: makeTelegramApiTestMock({ sendMediaGroup, sendPhoto }),
+          onDeliveryResult,
+        }),
+      ).rejects.toMatchObject({
+        deliveryResult: {
+          messageIds: ids,
+          receipt: {
+            platformMessageIds: ids,
+            threadId: "12",
+            parts: ids.map((platformMessageId) => ({ platformMessageId, threadId: "12" })),
+          },
+        },
+      });
+      expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+      if (failure === "observer") {
+        expect(sendPhoto).not.toHaveBeenCalled();
+      }
+    },
+  );
+
+  it("preserves buttons on the first photo and leaves subsequent photos unadorned", async () => {
+    mockLoadedMedia({ contentType: "image/jpeg" });
+    mockLoadedMedia({ contentType: "image/jpeg" });
+    const sendMediaGroup = vi.fn();
+    const sendPhoto = vi
+      .fn()
+      .mockResolvedValueOnce({ message_id: 100, chat: { id: 123 } })
+      .mockResolvedValueOnce({ message_id: 101, chat: { id: 123 } });
+    const buttons = [[{ text: "Continue", callback_data: "continue" }]];
+    const result = await sendMessageTelegram("123", "caption", {
+      cfg: TELEGRAM_TEST_CFG,
+      token: "tok",
+      mediaUrls: ["https://example.com/a.jpg", "https://example.com/b.jpg"],
+      buttons,
+      api: makeTelegramApiTestMock({ sendMediaGroup, sendPhoto }),
+    });
+    expect(sendMediaGroup).not.toHaveBeenCalled();
+    expect(sendPhoto.mock.calls[0]![2].reply_markup).toEqual({ inline_keyboard: buttons });
+    expect(sendPhoto.mock.calls[1]![2].reply_markup).toBeUndefined();
+    expect(result).toMatchObject({
+      messageId: "100",
+      meta: { telegramHasInlineKeyboard: true },
+      receipt: { platformMessageIds: ["100", "101"] },
+    });
+  });
+
+  it.each([false, true])(
+    "preserves mixed-media order with forceDocument=%s",
+    async (forceDocument) => {
+      const mediaUrls = ["a.jpg", "b.jpg", "file.pdf", "c.jpg", "d.jpg"];
+      mediaUrls.forEach((fileName) =>
+        mockLoadedMedia({
+          fileName,
+          contentType: fileName.endsWith("pdf") ? "application/pdf" : "image/jpeg",
+        }),
+      );
+      const delivered: string[] = [];
+      let messageId = 100;
+      const sendMediaGroup = vi.fn().mockImplementation(async (_chat, media) => {
+        delivered.push(
+          ...media.map((item: { media: { filename: string } }) => item.media.filename),
+        );
+        return media.map(() => ({ message_id: messageId++, chat: { id: 123 } }));
+      });
+      const sendDocument = vi.fn().mockImplementation(async (_chat, file) => {
+        delivered.push(file.filename);
+        return { message_id: messageId++, chat: { id: 123 } };
+      });
+      await sendMessageTelegram("123", "caption", {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        mediaUrls,
+        forceDocument,
+        api: makeTelegramApiTestMock({ sendMediaGroup, sendDocument }),
+      });
+      expect(delivered).toEqual(mediaUrls);
+      expect(sendMediaGroup).toHaveBeenCalledTimes(forceDocument ? 0 : 2);
+      expect(sendDocument).toHaveBeenCalledTimes(forceDocument ? 5 : 1);
+    },
+  );
+
+  it.each([true, false])(
+    "falls back from albums only for definite photo-limit rejection: %s",
+    async (photoLimit) => {
+      mockLoadedMedia({ contentType: "image/jpeg" });
+      mockLoadedMedia({ contentType: "image/jpeg" });
+      const error = new Error(
+        photoLimit ? "400: Bad Request: PHOTO_INVALID_DIMENSIONS" : "network disconnected",
+      );
+      const sendMediaGroup = vi.fn().mockRejectedValue(error);
+      const sendPhoto = vi
+        .fn()
+        .mockRejectedValueOnce(error)
+        .mockResolvedValueOnce({ message_id: 101, chat: { id: 123 } });
+      const sendDocument = vi.fn().mockResolvedValue({ message_id: 100, chat: { id: 123 } });
+      const sending = sendMessageTelegram("123", "caption", {
+        cfg: TELEGRAM_TEST_CFG,
+        token: "tok",
+        mediaUrls: ["https://example.com/a.jpg", "https://example.com/b.jpg"],
+        retry: { attempts: 1 },
+        api: makeTelegramApiTestMock({ sendMediaGroup, sendPhoto, sendDocument }),
+      });
+      if (photoLimit) {
+        expect(await sending).toMatchObject({ receipt: { platformMessageIds: ["100", "101"] } });
+        expect(sendPhoto).toHaveBeenCalledTimes(2);
+        expect(sendDocument.mock.calls[0]![2]).toMatchObject({ caption: "caption" });
+      } else {
+        await expect(sending).rejects.toThrow("network disconnected");
+        expect(sendPhoto).not.toHaveBeenCalled();
+        expect(sendDocument).not.toHaveBeenCalled();
+      }
+      expect(sendMediaGroup).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it.each([false, true])(
+    "delivers an oversized caption after all photos with album rejection=%s",
+    async (albumRejected) => {
+      const storePath = `/tmp/openclaw-telegram-album-projection-${process.pid}-${Date.now()}.json`;
+      const cursor = createTelegramPromptContextProjectionCursor({
+        transcriptMessageId: "album-reply",
+      });
+      mockLoadedMedia({ contentType: "image/jpeg" });
+      mockLoadedMedia({ contentType: "image/jpeg" });
+      const messages = [
+        { message_id: 100, chat: { id: 123 } },
+        { message_id: 101, chat: { id: 123 } },
+      ];
+      const sendMediaGroup = albumRejected
+        ? vi.fn().mockRejectedValue(new Error("400: Bad Request: PHOTO_INVALID_DIMENSIONS"))
+        : vi.fn().mockResolvedValue(messages);
+      const sendPhoto = vi
+        .fn()
+        .mockResolvedValueOnce(messages[0])
+        .mockResolvedValueOnce(messages[1]);
+      const sendMessage = vi.fn().mockResolvedValue({ message_id: 102, chat: { id: 123 } });
+      const result = await sendMessageTelegram("123", "x".repeat(1100), {
+        cfg: { session: { store: storePath } },
+        token: "tok",
+        mediaUrls: ["https://example.com/a.jpg", "https://example.com/b.jpg"],
+        api: makeTelegramApiTestMock({ sendMediaGroup, sendPhoto, sendMessage }),
+        replyToMessageId: 90,
+        replyToIdSource: "implicit",
+        replyToMode: "first",
+        promptContextProjectionPlan: { cursor, finalPart: true },
+      });
+      expect(
+        sendMediaGroup.mock.calls[0]![1].every(
+          (item: { caption?: string }) => item.caption === undefined,
+        ),
+      ).toBe(true);
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      expect(sendMessage.mock.calls[0]![2].reply_to_message_id).toBeUndefined();
+      if (albumRejected) {
+        expect(sendPhoto).toHaveBeenCalledTimes(2);
+        expect(sendPhoto.mock.invocationCallOrder[1]).toBeLessThan(
+          sendMessage.mock.invocationCallOrder[0]!,
+        );
+      } else {
+        expect(sendPhoto).not.toHaveBeenCalled();
+      }
+      expect(result.receipt?.platformMessageIds).toEqual(["100", "101", "102"]);
+      expect(result.receipt?.parts.map((part) => part.kind)).toEqual(["media", "media", "text"]);
+      const cache = createTelegramMessageCache({
+        scope: resolveTelegramMessageCacheScope(storePath),
+      });
+      for (const [index, messageId] of ["100", "101", "102"].entries()) {
+        expect(
+          (await cache.get({ accountId: "default", chatId: "123", messageId }))
+            ?.promptContextProjectionMarker,
+        ).toEqual({
+          kind: "valid",
+          projection: { ...cursor.source, partIndex: index, finalPart: index === 2 },
+        });
+      }
+    },
+  );
+
   it("fails when Telegram media send returns no message_id", async () => {
     mockLoadedMedia({ contentType: "image/png", fileName: "photo.png" });
     const sendPhoto = vi.fn().mockResolvedValue({

--- a/src/channels/plugins/outbound.types.ts
+++ b/src/channels/plugins/outbound.types.ts
@@ -40,6 +40,8 @@ export type ChannelOutboundContext = {
   identity?: OutboundIdentity;
   deps?: OutboundSendDeps;
   silent?: boolean;
+  /** Live cancellation signal; check before each physical send and after awaited preparation. */
+  signal?: AbortSignal;
   gatewayClientScopes?: readonly string[];
   /** @internal Opaque durable intent id for exact provider-side send reconciliation. */
   deliveryQueueId?: string;
@@ -207,6 +209,11 @@ export type ChannelOutboundAdapter = {
     params: ChannelOutboundNormalizePayloadBatchParams,
   ) => ReadonlyArray<ReplyPayload | null>;
   sendTextOnlyErrorPayloads?: boolean;
+  /**
+   * Route ordinary multi-media payloads intact to sendPayload for native grouping.
+   * The adapter must check cancellation and revalidate authority before every physical send.
+   */
+  sendPayloadGroupsMedia?: boolean;
   shouldSkipPlainTextSanitization?: (params: { payload: ReplyPayload }) => boolean;
   resolveEffectiveTextChunkLimit?: (params: {
     cfg: OpenClawConfig;

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -758,6 +758,12 @@ export type ChannelMessageActionContext = {
    * them. Plugins forward it into durable sends so recovery does not replay too.
    */
   deliveryRetryOwner?: "caller";
+  /** Host-owned live authority check; never read from model-controlled params. */
+  onPlatformSendDispatch?: () => Promise<void>;
+  /** Revalidate the same owner synchronously after waits and immediately before platform I/O. */
+  assertDirectAdapterHandoff?: () => void;
+  /** Ephemeral-authority sends must not enter replayable recovery. */
+  skipQueue?: boolean;
 };
 
 export type ChannelToolSend = {

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -1460,6 +1460,7 @@ describe("gateway send mirroring", () => {
       // queue row replayable is what duplicated the send (#124279), and marking
       // a reporting-only caller would strand its row instead (#100979).
       expect(lastDispatchChannelMessageActionCall()?.deliveryRetryOwner).toBe(expected);
+      expect(lastDispatchChannelMessageActionCall()?.skipQueue).toBe(isAgentRuntime);
     },
   );
 
@@ -1529,45 +1530,125 @@ describe("gateway send mirroring", () => {
     expect(mocks.ensureOutboundSessionEntry).not.toHaveBeenCalled();
   });
 
-  it("does not send or queue after delegated authority closes during delivery preflight", async () => {
-    const enteredDelivery = createDeferred<null>();
-    const resumeDelivery = createDeferred<null>();
-    const platformSend = vi.fn();
-    mocks.deliverOutboundPayloads.mockImplementationOnce(
-      async (params: { onPlatformSendDispatch?: () => Promise<void> }) => {
-        enteredDelivery.resolve(null);
-        await resumeDelivery.promise;
-        await params.onPlatformSendDispatch?.();
-        platformSend();
-        return [{ channel: "slack", messageId: "must-not-send" }];
-      },
-    );
-    let authorityActive = true;
-    const context = {
-      ...makeContext(),
-      validateAgentRuntimeApprovalAuthority: () => authorityActive,
-    } as GatewayRequestContext;
-    const request = runSendWithClient(
-      {
-        channel: "slack",
-        to: "channel:C1",
-        message: "must not escape",
-        sessionKey: "agent:main:slack:channel:C1",
-        idempotencyKey: "idem-send-delivery-authority-race",
-      },
-      agentRuntimeClient("agent:main:slack:channel:C1"),
-      context,
-    );
-    await enteredDelivery.promise;
-    authorityActive = false;
-    resumeDelivery.resolve(null);
+  it.each([false, true])(
+    "keeps Telegram plugin action sends bound to their live owner (close during first send: %s)",
+    async (closeDuringFirstSend) => {
+      const { telegramMessageActions } =
+        await import("../../../extensions/telegram/runtime-api.js");
+      const { dispatchChannelMessageAction } = await vi.importActual<
+        typeof import("../../channels/plugins/message-action-dispatch.js")
+      >("../../channels/plugins/message-action-dispatch.js");
+      const plugin = registerMessageActionPlugin({ registrySuffix: "telegram-live-owner" });
+      plugin.actions = telegramMessageActions;
+      mocks.dispatchChannelMessageAction.mockImplementationOnce(dispatchChannelMessageAction);
+      const firstSendStarted = createDeferred<void>();
+      const releaseFirstSend = createDeferred<void>();
+      const physicalSends: string[] = [];
+      mocks.deliverOutboundPayloads.mockImplementationOnce(
+        async (params: {
+          onPlatformSendDispatch?: () => Promise<void>;
+          assertDirectAdapterHandoff?: () => void;
+        }) => {
+          const results = [];
+          for (const messageId of ["album", "last-photo"]) {
+            await params.onPlatformSendDispatch?.();
+            params.assertDirectAdapterHandoff?.();
+            physicalSends.push(messageId);
+            if (messageId === "album") {
+              firstSendStarted.resolve();
+              await releaseFirstSend.promise;
+            }
+            results.push({ channel: "telegram", messageId, chatId: "12345" });
+          }
+          return results;
+        },
+      );
+      let authorityActive = true;
+      const sessionKey = "agent:main:telegram:direct:12345";
+      const request = runMessageActionRequest(
+        {
+          channel: "telegram",
+          action: "send",
+          params: {
+            to: "12345",
+            message: "photos",
+            mediaUrls: ["https://example.com/one.jpg", "https://example.com/two.jpg"],
+          },
+          sessionKey,
+          idempotencyKey: `telegram-live-owner-${closeDuringFirstSend}`,
+        },
+        agentRuntimeClient(sessionKey),
+        {
+          ...makeContext(),
+          getRuntimeConfig: () => ({ channels: { telegram: { botToken: "123456:fixture" } } }),
+          validateAgentRuntimeApprovalAuthority: () => authorityActive,
+        },
+      );
+      await firstSendStarted.promise;
+      authorityActive = !closeDuringFirstSend;
+      releaseFirstSend.resolve();
+      const { respond } = await request;
 
-    const { respond } = await request;
-    expect(firstRespondCall(respond)[0]).toBe(false);
-    expect(firstRespondCall(respond)[2]?.message).toContain("authority is no longer active");
-    expect(deliveryCall()?.skipQueue).toBe(true);
-    expect(platformSend).not.toHaveBeenCalled();
-  });
+      expect(physicalSends).toEqual(closeDuringFirstSend ? ["album"] : ["album", "last-photo"]);
+      expect(deliveryCall()?.skipQueue).toBe(true);
+      expect(firstRespondCall(respond)[0]).toBe(!closeDuringFirstSend);
+      if (closeDuringFirstSend) {
+        expect(firstRespondCall(respond)[2]?.message).toContain("authority is no longer active");
+      }
+    },
+  );
+
+  it.each(["dispatch", "handoff"])(
+    "does not send or queue after delegated authority closes during delivery preflight (%s)",
+    async (boundary) => {
+      const enteredDelivery = createDeferred<null>();
+      const resumeDelivery = createDeferred<null>();
+      const platformSend = vi.fn();
+      mocks.deliverOutboundPayloads.mockImplementationOnce(
+        async (params: {
+          onPlatformSendDispatch?: () => Promise<void>;
+          assertDirectAdapterHandoff?: () => void;
+        }) => {
+          if (boundary === "handoff") {
+            await params.onPlatformSendDispatch?.();
+          }
+          enteredDelivery.resolve(null);
+          await resumeDelivery.promise;
+          if (boundary === "dispatch") {
+            await params.onPlatformSendDispatch?.();
+          }
+          params.assertDirectAdapterHandoff?.();
+          platformSend();
+          return [{ channel: "slack", messageId: "must-not-send" }];
+        },
+      );
+      let authorityActive = true;
+      const context = {
+        ...makeContext(),
+        validateAgentRuntimeApprovalAuthority: () => authorityActive,
+      } as GatewayRequestContext;
+      const request = runSendWithClient(
+        {
+          channel: "slack",
+          to: "channel:C1",
+          message: "must not escape",
+          sessionKey: "agent:main:slack:channel:C1",
+          idempotencyKey: "idem-send-delivery-authority-race",
+        },
+        agentRuntimeClient("agent:main:slack:channel:C1"),
+        context,
+      );
+      await enteredDelivery.promise;
+      authorityActive = false;
+      resumeDelivery.resolve(null);
+
+      const { respond } = await request;
+      expect(firstRespondCall(respond)[0]).toBe(false);
+      expect(firstRespondCall(respond)[2]?.message).toContain("authority is no longer active");
+      expect(deliveryCall()?.skipQueue).toBe(true);
+      expect(platformSend).not.toHaveBeenCalled();
+    },
+  );
 
   it("does not send after turn capability closes while delegated authority remains active", async () => {
     const enteredDelivery = createDeferred<null>();
@@ -4591,39 +4672,47 @@ describe("gateway send mirroring", () => {
       expect(mocks.deliverOutboundPayloads).not.toHaveBeenCalled();
     });
 
-    it("fences canonical outbound send when runtime authority closes during preparation", async () => {
-      let authorityActive = true;
-      const platformSend = vi.fn();
-      mocks.deliverOutboundPayloads.mockImplementationOnce(
-        async (params: { onPlatformSendDispatch?: () => Promise<void> }) => {
-          authorityActive = false;
-          await params.onPlatformSendDispatch?.();
-          platformSend();
-          return [{ channel: "twitch", messageId: "must-not-send" }];
-        },
-      );
-      const sessionKey = "agent:main:twitch:group:explicit-room";
-      const { respond } = await runMessageActionRequest(
-        {
-          channel: "twitch",
-          action: "send",
-          params: { to: "explicit-room", message: "must not escape" },
-          sessionKey,
-          idempotencyKey: "canonical-send-authority-race",
-        },
-        agentRuntimeClient(sessionKey),
-        {
-          ...makeContext(),
-          validateAgentRuntimeApprovalAuthority: () => authorityActive,
-        } as GatewayRequestContext,
-      );
+    it.each(["dispatch", "handoff"])(
+      "fences canonical outbound send at %s when runtime authority closes",
+      async (boundary) => {
+        let authorityActive = true;
+        const platformSend = vi.fn();
+        mocks.deliverOutboundPayloads.mockImplementationOnce(
+          async (params: {
+            onPlatformSendDispatch?: () => Promise<void>;
+            assertDirectAdapterHandoff?: () => void;
+          }) => {
+            authorityActive = boundary !== "dispatch";
+            await params.onPlatformSendDispatch?.();
+            authorityActive = false;
+            params.assertDirectAdapterHandoff?.();
+            platformSend();
+            return [{ channel: "twitch", messageId: "must-not-send" }];
+          },
+        );
+        const sessionKey = "agent:main:twitch:group:explicit-room";
+        const { respond } = await runMessageActionRequest(
+          {
+            channel: "twitch",
+            action: "send",
+            params: { to: "explicit-room", message: "must not escape" },
+            sessionKey,
+            idempotencyKey: "canonical-send-authority-race",
+          },
+          agentRuntimeClient(sessionKey),
+          {
+            ...makeContext(),
+            validateAgentRuntimeApprovalAuthority: () => authorityActive,
+          } as GatewayRequestContext,
+        );
 
-      expect(firstRespondCall(respond)[0]).toBe(false);
-      expect(firstRespondCall(respond)[2]?.message).toContain("authority is no longer active");
-      expect(deliveryCall()?.skipQueue).toBe(true);
-      expect(platformSend).not.toHaveBeenCalled();
-      expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
-    });
+        expect(firstRespondCall(respond)[0]).toBe(false);
+        expect(firstRespondCall(respond)[2]?.message).toContain("authority is no longer active");
+        expect(deliveryCall()?.skipQueue).toBe(true);
+        expect(platformSend).not.toHaveBeenCalled();
+        expect(mocks.appendAssistantMessageToSessionTranscript).not.toHaveBeenCalled();
+      },
+    );
   });
 
   it("falls back once to canonical outbound poll delivery when plugin actions decline", async () => {

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -27,6 +27,7 @@ import { OutboundDeliveryError } from "../../infra/outbound/deliver-types.js";
 import { resolveOutboundTargetWithPlugin } from "../../infra/outbound/targets-resolve-shared.js";
 import { buildOutboundMediaLoadOptions } from "../../media/load-options.js";
 import { loadWebMediaRaw } from "../../media/web-media.js";
+import { loadBundledPluginPublicSurface } from "../../plugin-sdk/test-helpers/public-surface-loader.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import { AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE } from "../../sessions/agent-harness-session-key.js";
 import { ensureProfileForEmail } from "../../state/user-profiles.js";
@@ -1533,16 +1534,17 @@ describe("gateway send mirroring", () => {
   it.each([false, true])(
     "keeps Telegram plugin action sends bound to their live owner (close during first send: %s)",
     async (closeDuringFirstSend) => {
-      const { telegramMessageActions } =
-        await import("../../../extensions/telegram/runtime-api.js");
+      const { telegramMessageActions } = await loadBundledPluginPublicSurface<{
+        telegramMessageActions: NonNullable<ChannelPlugin["actions"]>;
+      }>({ pluginId: "telegram", artifactBasename: "runtime-api.js" });
       const { dispatchChannelMessageAction } = await vi.importActual<
         typeof import("../../channels/plugins/message-action-dispatch.js")
       >("../../channels/plugins/message-action-dispatch.js");
       const plugin = registerMessageActionPlugin({ registrySuffix: "telegram-live-owner" });
       plugin.actions = telegramMessageActions;
       mocks.dispatchChannelMessageAction.mockImplementationOnce(dispatchChannelMessageAction);
-      const firstSendStarted = createDeferred<void>();
-      const releaseFirstSend = createDeferred<void>();
+      const firstSendStarted = createDeferred();
+      const releaseFirstSend = createDeferred();
       const physicalSends: string[] = [];
       mocks.deliverOutboundPayloads.mockImplementationOnce(
         async (params: {

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -950,6 +950,10 @@ export const sendHandlers: GatewayRequestHandlers = {
       requestedOrigin: request.conversationReadOrigin,
     });
     const agentRuntimeAuthority = createAgentRuntimeAuthorityGuard(client, context, respond);
+    const assertDirectAdapterHandoff = agentRuntimeAuthority.commitGuard;
+    const onPlatformSendDispatch = assertDirectAdapterHandoff
+      ? async () => assertDirectAdapterHandoff()
+      : undefined;
     await withMessageOperationRoute({
       context,
       prefix: "message.action",
@@ -1150,6 +1154,14 @@ export const sendHandlers: GatewayRequestHandlers = {
             toolContext: trustedContext.toolContext,
             dryRun: false,
             gatewayClientScopes,
+            ...(request.action === "send"
+              ? {
+                  onPlatformSendDispatch,
+                  assertDirectAdapterHandoff,
+                  // Recovery cannot retain a live run's closure-bound send authority.
+                  skipQueue: client?.internal?.agentRuntimeIdentity !== undefined,
+                }
+              : {}),
           };
           let payload: unknown;
           if (canonicalAction) {
@@ -1165,8 +1177,6 @@ export const sendHandlers: GatewayRequestHandlers = {
                     actionOrigin: trustedContext.runtimeAgentId
                       ? ("message-tool" as const)
                       : undefined,
-                    skipQueue: client?.internal?.agentRuntimeIdentity !== undefined,
-                    onPlatformSendDispatch: async () => agentRuntimeAuthority.commitGuard?.(),
                   }
                 : {}),
               params: {
@@ -1504,6 +1514,7 @@ export const sendHandlers: GatewayRequestHandlers = {
             // Runtime-bound sends cannot outlive their operational run. Keep
             // recovery from replaying them after the live authority closes.
             onPlatformSendDispatch,
+            assertDirectAdapterHandoff: commitAgentRuntimeAuthority,
             skipQueue: hasAgentRuntimeAuthority,
             mirror: outboundSessionKey
               ? {

--- a/src/infra/outbound/deliver-channel.ts
+++ b/src/infra/outbound/deliver-channel.ts
@@ -184,18 +184,14 @@ function createPluginHandler(
   const messageMedia = params.message?.send?.media;
   const messagePayload = params.message?.send?.payload;
   const messageLifecycle = params.message?.send?.lifecycle;
+  const durableFinal = params.message?.durableFinal;
+  const supportsUnknownSendKind = (kind: ChannelMessageSendAttemptKind): boolean =>
+    !params.requiredUnknownSendReconciliation ||
+    durableFinal?.capabilities?.reconcileUnknownSend !== true ||
+    durableFinal.reconcileUnknownSendKinds === undefined ||
+    durableFinal.reconcileUnknownSendKinds[kind] === true;
   const assertUnknownSendReconciliationKind = (kind: ChannelMessageSendAttemptKind): void => {
-    const durableFinal = params.message?.durableFinal;
-    if (
-      !params.requiredUnknownSendReconciliation ||
-      durableFinal?.capabilities?.reconcileUnknownSend !== true
-    ) {
-      return;
-    }
-    if (
-      durableFinal.reconcileUnknownSendKinds !== undefined &&
-      durableFinal.reconcileUnknownSendKinds[kind] !== true
-    ) {
+    if (!supportsUnknownSendKind(kind)) {
       throw new Error(
         `Required durable message send became unsupported after outbound transforms: ${kind} unknown-send reconciliation is unavailable for ${params.channel}`,
       );
@@ -324,6 +320,11 @@ function createPluginHandler(
     // over sendMedia), so leaving it out here silently drops media for
     // formatted-only adapters and records the fallback as a plain sent text.
     supportsMedia: Boolean(messageMedia ?? sendMedia ?? outbound?.sendFormattedMedia),
+    // Whole media payloads are optional; keep exact media-only reconciliation
+    // on its declared transport even when a fallback payload method exists.
+    supportsMediaPayload:
+      (durableFinal?.capabilities ?? outbound?.deliveryCapabilities?.durableFinal)?.payload ===
+        true && supportsUnknownSendKind("payload"),
     sanitizeText: outbound?.sanitizeText
       ? (payload) =>
           outbound.sanitizeText!({

--- a/src/infra/outbound/deliver-channel.ts
+++ b/src/infra/outbound/deliver-channel.ts
@@ -323,8 +323,10 @@ function createPluginHandler(
     // Whole media payloads are optional; keep exact media-only reconciliation
     // on its declared transport even when a fallback payload method exists.
     supportsMediaPayload:
+      outbound?.sendPayloadGroupsMedia === true &&
       (durableFinal?.capabilities ?? outbound?.deliveryCapabilities?.durableFinal)?.payload ===
-        true && supportsUnknownSendKind("payload"),
+        true &&
+      supportsUnknownSendKind("payload"),
     sanitizeText: outbound?.sanitizeText
       ? (payload) =>
           outbound.sanitizeText!({

--- a/src/infra/outbound/deliver-contracts.ts
+++ b/src/infra/outbound/deliver-contracts.ts
@@ -77,6 +77,7 @@ export type ChannelHandler = {
   textChunkLimit?: number;
   preserveMarkdownDetails?: boolean;
   supportsMedia: boolean;
+  supportsMediaPayload?: boolean;
   sanitizeText?: (payload: ReplyPayload) => string;
   normalizePayload?: (payload: ReplyPayload) => ReplyPayload | null;
   normalizePayloadBatch?: (

--- a/src/infra/outbound/deliver-core.ts
+++ b/src/infra/outbound/deliver-core.ts
@@ -365,9 +365,10 @@ export async function deliverOutboundPayloadsCore(
       let mediaMessageIds: { first?: string; last?: string } | undefined;
       if (
         deliveryHandler.sendPayload &&
-        payloadRequiresDurablePayloadTransport(effectivePayload, {
-          sendTextOnlyErrorPayloads: deliveryHandler.sendTextOnlyErrorPayloads,
-        })
+        ((deliveryHandler.supportsMediaPayload && payloadSummary.mediaUrls.length > 1) ||
+          payloadRequiresDurablePayloadTransport(effectivePayload, {
+            sendTextOnlyErrorPayloads: deliveryHandler.sendTextOnlyErrorPayloads,
+          }))
       ) {
         const delivery = await deliveryHandler.sendPayload(
           effectivePayload,

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1607,7 +1607,11 @@ describe("deliverOutboundPayloads", () => {
           },
           send: { text: vi.fn(), media: messageSendMedia, payload: sendPayload },
         },
-        { sendPayload, deliveryCapabilities: { durableFinal: { payload: true } } },
+        {
+          sendPayload,
+          sendPayloadGroupsMedia: true,
+          deliveryCapabilities: { durableFinal: { payload: true } },
+        },
       );
 
       await expect(
@@ -1623,12 +1627,12 @@ describe("deliverOutboundPayloads", () => {
         }),
       ).resolves.toHaveLength(2);
       expect(messageSendMedia.mock.calls.map(([ctx]) => ctx.deliveryPartIndex)).toEqual([0, 1]);
-      expect(
-        messageSendMedia.mock.calls.map(([ctx]) => [ctx.kind, ctx.text, ctx.deliveryPartCount]),
-      ).toEqual([
-        ["media", "caption", 2],
-        ["media", "", 2],
-      ]);
+      expect(messageSendMedia.mock.calls.map(([ctx]) => [ctx.text, ctx.deliveryPartCount])).toEqual(
+        [
+          ["caption", 2],
+          ["", 2],
+        ],
+      );
       expect(sendPayload).not.toHaveBeenCalled();
     },
   );
@@ -1641,11 +1645,13 @@ describe("deliverOutboundPayloads", () => {
         results: [{ messageId: "media-1" }, { messageId: "media-2" }],
         kind: "media",
       });
-      const sendPayload = vi.fn<OutboundPayloadSender>(async () => ({
-        channel: "matrix",
-        messageId: "media-2",
-        receipt,
-      }));
+      const sendPayload = vi.fn(
+        async (_ctx: Pick<Parameters<OutboundPayloadSender>[0], "payload">) => ({
+          channel: "matrix" as const,
+          messageId: "media-2",
+          receipt,
+        }),
+      );
       const sendMedia = vi.fn<OutboundMediaSender>(async () => ({
         channel: "matrix",
         messageId: "single",
@@ -1654,6 +1660,7 @@ describe("deliverOutboundPayloads", () => {
       const outbound = {
         sendPayload,
         sendMedia,
+        sendPayloadGroupsMedia: true,
         deliveryCapabilities: { durableFinal: capabilities },
       };
       if (adapter === "message") {
@@ -1697,6 +1704,74 @@ describe("deliverOutboundPayloads", () => {
       await deliverMatrix({ payloads: [{ text: "single caption", mediaUrl: mediaUrls[0] }] });
       expect(sendPayload).toHaveBeenCalledOnce();
       expect(sendMedia).toHaveBeenCalledOnce();
+    },
+  );
+
+  it.each(["cancellation", "owner loss"])(
+    "stops a payload-capable channel's media sequence after %s without group opt-in",
+    async (stop) => {
+      const firstSendStarted = createDeferredCore();
+      const finishFirstSend = createDeferredCore();
+      const abortController = new AbortController();
+      let ownerIsCurrent = true;
+      let acceptedUploads = 0;
+      const sendMedia = vi.fn<OutboundMediaSender>(async ({ mediaUrl }) => {
+        if (mediaUrl === "https://example.com/first.png") {
+          firstSendStarted.resolve();
+          await finishFirstSend.promise;
+        }
+        return { channel: "msteams", messageId: `media-${++acceptedUploads}` };
+      });
+      const sendPayload = vi.fn<OutboundPayloadSender>(async (ctx) => {
+        const first = await sendMedia({ ...ctx, mediaUrl: "https://example.com/first.png" });
+        await ctx.onDeliveryResult?.(first);
+        return await sendMedia({ ...ctx, text: "", mediaUrl: "https://example.com/second.png" });
+      });
+      setTestOutbound(
+        {
+          sendMedia,
+          sendPayload,
+          deliveryCapabilities: { durableFinal: { text: true, media: true, payload: true } },
+        },
+        "msteams",
+      );
+      const delivery = deliverOutboundPayloads({
+        cfg: {},
+        channel: "msteams",
+        to: "conversation:test",
+        payloads: [
+          {
+            text: "caption",
+            mediaUrls: ["https://example.com/first.png", "https://example.com/second.png"],
+          },
+        ],
+        skipQueue: true,
+        abortSignal: abortController.signal,
+        assertDirectAdapterHandoff: () => {
+          if (!ownerIsCurrent) {
+            throw new Error("delivery owner closed");
+          }
+        },
+      });
+      const outcome = delivery.then(
+        () => "sent",
+        (error: unknown) => error,
+      );
+      await firstSendStarted.promise;
+      if (stop === "cancellation") {
+        abortController.abort();
+      } else {
+        ownerIsCurrent = false;
+      }
+      finishFirstSend.resolve();
+
+      expect(await outcome).toMatchObject({
+        message: expect.stringContaining(
+          stop === "cancellation" ? "Operation aborted" : "delivery owner closed",
+        ),
+      });
+      expect(sendMedia).toHaveBeenCalledOnce();
+      expect(sendPayload).not.toHaveBeenCalled();
     },
   );
 

--- a/src/infra/outbound/deliver.test.ts
+++ b/src/infra/outbound/deliver.test.ts
@@ -1581,34 +1581,124 @@ describe("deliverOutboundPayloads", () => {
     expect(messageSendText).toHaveBeenCalledOnce();
   });
 
-  it("passes stable part indexes to exact multi-media sends", async () => {
-    const messageSendMedia = vi.fn(async (ctx: ChannelMessageSendMediaContext) =>
-      createMatrixMessageSendResult(`media-${ctx.deliveryPartIndex}`, "media"),
-    );
-    setMatrixMessageAdapter({
-      id: "matrix",
-      durableFinal: {
-        capabilities: { text: true, media: true, reconcileUnknownSend: true },
-        reconcileUnknownSendKinds: { media: true },
-        reconcileUnknownSend: async () => ({ status: "not_sent" }),
-      },
-      send: { text: vi.fn(), media: messageSendMedia },
-    });
-
-    await expect(
-      deliverMatrix({
-        payloads: [
-          {
-            text: "caption",
-            mediaUrls: ["https://example.com/first.png", "https://example.com/second.png"],
+  it.each([
+    { payloadCapable: false, requireReconciliation: false },
+    { payloadCapable: false, requireReconciliation: true },
+    { payloadCapable: true, requireReconciliation: true },
+  ])(
+    "keeps multi-media on its declared transport ($payloadCapable, $requireReconciliation)",
+    async ({ payloadCapable, requireReconciliation }) => {
+      const messageSendMedia = vi.fn(async (ctx: ChannelMessageSendMediaContext) =>
+        createMatrixMessageSendResult(`media-${ctx.deliveryPartIndex}`, "media"),
+      );
+      const sendPayload = vi.fn();
+      setMatrixMessageAdapter(
+        {
+          id: "matrix",
+          durableFinal: {
+            capabilities: {
+              text: true,
+              media: true,
+              payload: payloadCapable,
+              reconcileUnknownSend: true,
+            },
+            reconcileUnknownSendKinds: { media: true },
+            reconcileUnknownSend: async () => ({ status: "not_sent" }),
           },
-        ],
-        queuePolicy: "required",
-        requireUnknownSendReconciliation: true,
-      }),
-    ).resolves.toHaveLength(2);
-    expect(messageSendMedia.mock.calls.map(([ctx]) => ctx.deliveryPartIndex)).toEqual([0, 1]);
-  });
+          send: { text: vi.fn(), media: messageSendMedia, payload: sendPayload },
+        },
+        { sendPayload, deliveryCapabilities: { durableFinal: { payload: true } } },
+      );
+
+      await expect(
+        deliverMatrix({
+          payloads: [
+            {
+              text: "caption",
+              mediaUrls: ["https://example.com/first.png", "https://example.com/second.png"],
+            },
+          ],
+          queuePolicy: "required",
+          requireUnknownSendReconciliation: requireReconciliation,
+        }),
+      ).resolves.toHaveLength(2);
+      expect(messageSendMedia.mock.calls.map(([ctx]) => ctx.deliveryPartIndex)).toEqual([0, 1]);
+      expect(
+        messageSendMedia.mock.calls.map(([ctx]) => [ctx.kind, ctx.text, ctx.deliveryPartCount]),
+      ).toEqual([
+        ["media", "caption", 2],
+        ["media", "", 2],
+      ]);
+      expect(sendPayload).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(["outbound", "message"] as const)(
+    "preserves a whole media list for declared %s payload transport",
+    async (adapter) => {
+      const mediaUrls = ["https://example.com/first.png", "https://example.com/second.png"];
+      const receipt = createMessageReceiptFromOutboundResults({
+        results: [{ messageId: "media-1" }, { messageId: "media-2" }],
+        kind: "media",
+      });
+      const sendPayload = vi.fn<OutboundPayloadSender>(async () => ({
+        channel: "matrix",
+        messageId: "media-2",
+        receipt,
+      }));
+      const sendMedia = vi.fn<OutboundMediaSender>(async () => ({
+        channel: "matrix",
+        messageId: "single",
+      }));
+      const capabilities = { text: true, media: true, payload: true };
+      const outbound = {
+        sendPayload,
+        sendMedia,
+        deliveryCapabilities: { durableFinal: capabilities },
+      };
+      if (adapter === "message") {
+        setMatrixMessageAdapter(
+          {
+            id: "matrix",
+            durableFinal: { capabilities },
+            send: {
+              text: vi.fn(),
+              payload: async (ctx) => ({ ...(await sendPayload(ctx)), receipt }),
+            },
+          },
+          outbound,
+        );
+      } else {
+        setTestOutbound(outbound);
+      }
+      const onPayloadDeliveryOutcome = vi.fn();
+
+      const results = await deliverMatrix({
+        payloads: [{ text: "caption", mediaUrls }],
+        onPayloadDeliveryOutcome,
+      });
+
+      expect(sendPayload).toHaveBeenCalledOnce();
+      expect(sendPayload).toHaveBeenCalledWith(
+        expect.objectContaining({
+          kind: "payload",
+          payload: expect.objectContaining({ text: "caption", mediaUrls }),
+        }),
+      );
+      expect(sendMedia).not.toHaveBeenCalled();
+      expect(results[0]?.receipt?.platformMessageIds).toEqual(["media-1", "media-2"]);
+      expect(onPayloadDeliveryOutcome).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "sent",
+          deliveryKind: "media",
+        }),
+      );
+
+      await deliverMatrix({ payloads: [{ text: "single caption", mediaUrl: mediaUrls[0] }] });
+      expect(sendPayload).toHaveBeenCalledOnce();
+      expect(sendMedia).toHaveBeenCalledOnce();
+    },
+  );
 
   it("freezes reply-hook media fan-out into the exact prepared send", async () => {
     hookMocks.runner.hasHooks.mockImplementation(

--- a/src/infra/outbound/message-action-contracts.ts
+++ b/src/infra/outbound/message-action-contracts.ts
@@ -105,6 +105,8 @@ export type MessageActionInput = {
   onDeliveryResult?: (result: OutboundDeliveryResult) => Promise<void> | void;
   /** @internal Revalidates caller authority immediately before recipient-visible I/O. */
   onPlatformSendDispatch?: () => Promise<void>;
+  /** @internal Synchronously fence the live owner after waits and before platform I/O. */
+  assertDirectAdapterHandoff?: () => void;
   /** @internal Keep ephemeral-authority sends out of replayable recovery. */
   skipQueue?: boolean;
   /** @internal Runs when broadcast converts a typed target denial into result text. */

--- a/src/infra/outbound/message.ts
+++ b/src/infra/outbound/message.ts
@@ -129,6 +129,8 @@ type MessageSendParams = {
   onDeliveryResult?: (result: OutboundDeliveryResult) => Promise<void> | void;
   /** @internal Revalidates caller authority immediately before recipient-visible I/O. */
   onPlatformSendDispatch?: () => Promise<void>;
+  /** @internal Synchronously fence the live owner after waits and before platform I/O. */
+  assertDirectAdapterHandoff?: () => void;
   /** @internal Keep ephemeral-authority sends out of replayable recovery. */
   skipQueue?: boolean;
   mirror?: OutboundMirror;
@@ -310,6 +312,7 @@ async function callMessageGateway<T>(params: {
   method: string;
   params: Record<string, unknown>;
   onPlatformSendDispatch?: () => Promise<void>;
+  assertDirectAdapterHandoff?: () => void;
 }): Promise<T> {
   const { callGatewayLeastPrivilege } = await loadMessageGatewayRuntime();
   const gateway = resolveGatewayOptions(params.gateway);
@@ -317,6 +320,7 @@ async function callMessageGateway<T>(params: {
   // by the Gateway's live operational-run validator, not token freshness.
   const agentRuntimeIdentityToken = await params.gateway?.resolveAgentRuntimeIdentityToken?.();
   await params.onPlatformSendDispatch?.();
+  params.assertDirectAdapterHandoff?.();
   return await callGatewayLeastPrivilege<T>({
     url: gateway.url,
     token: gateway.token,
@@ -466,6 +470,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
       ...(params.onPlatformSendDispatch
         ? { onPlatformSendDispatch: params.onPlatformSendDispatch }
         : {}),
+      assertDirectAdapterHandoff: params.assertDirectAdapterHandoff,
       skipQueue: params.skipQueue,
       ...(params.onDeliveredPayload ? { onDeliveredPayload: params.onDeliveredPayload } : {}),
       mirror: params.mirror
@@ -506,6 +511,7 @@ export async function sendMessage(params: MessageSendParams): Promise<MessageSen
     gateway: params.gateway,
     method: "send",
     onPlatformSendDispatch: params.onPlatformSendDispatch,
+    assertDirectAdapterHandoff: params.assertDirectAdapterHandoff,
     params: {
       to: params.to,
       message: params.content,

--- a/src/infra/outbound/outbound-send-service.ts
+++ b/src/infra/outbound/outbound-send-service.ts
@@ -143,6 +143,7 @@ async function sendCoreMessage(params: {
       await params.ctx.input.onDeliveryResult?.(evidence);
     },
     onPlatformSendDispatch: params.ctx.input.onPlatformSendDispatch,
+    assertDirectAdapterHandoff: params.ctx.input.assertDirectAdapterHandoff,
     skipQueue: params.ctx.input.skipQueue,
     onDeliveredPayload: (payload) => deliveredPayloads.push(payload),
   });
@@ -240,6 +241,13 @@ function createChannelActionContext(params: {
     gateway: params.ctx.gateway,
     toolContext: params.ctx.input.toolContext,
     dryRun: params.ctx.dryRun,
+    ...(params.action === "send"
+      ? {
+          onPlatformSendDispatch: params.ctx.input.onPlatformSendDispatch,
+          assertDirectAdapterHandoff: params.ctx.input.assertDirectAdapterHandoff,
+          skipQueue: params.ctx.input.skipQueue,
+        }
+      : {}),
   };
 }
 


### PR DESCRIPTION
Related: #13620, #135545, #135553.

## What Problem This Solves

A message-tool call with multiple photos sent separate Telegram messages instead of a native album. Cancellation could also allow a trailing photo after an already accepted album.

## Why This Change Was Made

Telegram opts into shared batches of 2–10 consecutive photos and records every accepted message before observers run. Both Gateway send paths carry current execution authority into delivery; owned clients recheck it after throttle waits. Uncertain sends are not replayed.

## User Impact

Two or ten photos form one album; eleven form an album plus one photo. Captions stay on the first photo; buttons, other media and forced documents remain individual sends. No new configuration or schema.

## Evidence

Real message-tool calls delivered all 23 photos in order across 2/10/11-photo cases. Live cancellation preserved the accepted album but prevented photo 11; the visible stop acknowledgement arrived after the held response returned. Focused batching, delivery and cancellation tests passed. Borrowed-client throttle checks and complete tool-result message IDs remain separate limitations.
