### PR TITLE
fix(gateway): keep SSH error filenames intact across pipe reads

### DIFF
--- a/src/infra/ssh-tunnel.test.ts
+++ b/src/infra/ssh-tunnel.test.ts
@@ -1,6 +1,7 @@
 // Covers SSH target parsing and tunnel startup preflight behavior.
 import { EventEmitter } from "node:events";
 import net from "node:net";
+import { PassThrough } from "node:stream";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 
@@ -426,6 +427,42 @@ describe("startSshPortForward", () => {
       }
     },
   );
+
+  it("preserves diagnostic lines split across stderr chunks at startup failure", async () => {
+    const child = Object.assign(new EventEmitter(), {
+      stderr: new PassThrough(),
+      kill: vi.fn(() => {
+        queueMicrotask(() => child.emit("close", 255, null));
+        return true;
+      }),
+    });
+    const connect = vi.spyOn(net, "connect").mockImplementation(() => new net.Socket());
+    mocks.spawn.mockImplementationOnce(() => {
+      queueMicrotask(() => {
+        child.stderr.write("Warning: file /tmp/qa clé ");
+        child.stderr.write("name not found.\r");
+        child.stderr.write("\nFinal diagnostic without newline");
+        child.stderr.end();
+        child.emit("exit", 255, null);
+      });
+      return child;
+    });
+    try {
+      await expect(
+        startSshPortForward({
+          target: "synthetic.example",
+          localPortPreferred: 43210,
+          remotePort: 18789,
+          timeoutMs: 250,
+        }),
+      ).rejects.toThrow(
+        "ssh exited (255)\nWarning: file /tmp/qa clé name not found.\nFinal diagnostic without newline",
+      );
+    } finally {
+      connect.mockRestore();
+      child.stderr.destroy();
+    }
+  });
 
   it.each(["active", "teardown"] as const)(
     "does not crash when stderr errors while the tunnel is %s",

--- a/src/infra/ssh-tunnel.ts
+++ b/src/infra/ssh-tunnel.ts
@@ -202,10 +202,7 @@ export async function startSshPortForward(opts: {
   // stream error cannot become an uncaught exception during active use or teardown.
   stderrStream?.on("error", () => {});
   stderrStream?.setEncoding("utf8");
-  stderrStream?.on("data", (chunk) => {
-    const lines = normalizeStringEntries(String(chunk).split("\n"));
-    stderr.push(...lines);
-  });
+  stderrStream?.on("data", (chunk: string) => stderr.push(chunk));
 
   const exited = new Promise<void>((resolve) => {
     child.once("exit", () => resolve());
@@ -263,7 +260,9 @@ export async function startSshPortForward(opts: {
     if (isAbortError(err)) {
       throw err;
     }
-    const suffix = stderr.length > 0 ? `\n${stderr.join("\n")}` : "";
+    // Pipe chunks can split diagnostic lines; normalize only after joining them.
+    const lines = normalizeStringEntries(stderr.join("").split("\n"));
+    const suffix = lines.length > 0 ? `\n${lines.join("\n")}` : "";
     throw new Error(`${formatErrorMessage(err)}${suffix}`, { cause: err });
   }
 


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled for this PR.

</details>

## What Problem This Solves

Fixes an issue where operators running a gateway probe through SSH would see a filename or sentence split into false diagnostic lines when stderr arrived in multiple pipe reads.

## Why This Change Was Made

The collector keeps decoded chunks intact and applies the existing line normalization once when constructing the startup error. This removes per-chunk trimming and splitting while preserving the existing startup and teardown behavior.

## User Impact

SSH failure warnings preserve complete diagnostic text, including internal spaces, CRLF lines, and a final unterminated line that has reached the collector.

## Evidence

The new full startup-error regression failed on the original implementation. All 24 SSH tunnel tests and 9 gateway-output tests pass on the final candidate. Controlled local child output and the actual warning formatter confirm that a split filename remains intact. The canonical infra test type graph, full-file type-aware lint, formatting, diff checks, and independent P2 autoreview pass.

Existing isolated loopback fixtures were used; no remote SSH connection or operator service was accessed. This proof covers framing of received output. It does not establish that the startup path drains stderr arriving after child exit; `ssh-startup-post-exit-diagnostic-drain` remains a named, unqualified follow-up. Production delta: -1 line; tests: +37 lines. Aggregate publication/merge gates remain separate.
