### PR TITLE
fix(cli): keep progress spinners within terminal width

### DIFF
--- a/src/cli/progress.test.ts
+++ b/src/cli/progress.test.ts
@@ -1,6 +1,8 @@
+import { EventEmitter } from "node:events";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 // Progress tests cover CLI progress rendering and lifecycle cleanup.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { stripAnsi, visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import { createCliProgress, shouldUseInteractiveProgressSpinner } from "./progress.js";
 
 const clackMocks = vi.hoisted(() => {
@@ -8,12 +10,21 @@ const clackMocks = vi.hoisted(() => {
     start: vi.fn(),
     message: vi.fn(),
     stop: vi.fn(),
+    clear: vi.fn(),
   };
   return {
     spinner: vi.fn(() => spinnerInstance),
     spinnerInstance,
   };
 });
+
+function progressStream(columns?: number) {
+  return Object.assign(new EventEmitter(), {
+    isTTY: true,
+    columns,
+    write: vi.fn(),
+  }) as unknown as NodeJS.WriteStream & { write: ReturnType<typeof vi.fn> };
+}
 
 vi.mock("@clack/prompts", () => ({
   spinner: clackMocks.spinner,
@@ -42,7 +53,155 @@ describe("cli progress", () => {
     clackMocks.spinnerInstance.start.mockClear();
     clackMocks.spinnerInstance.message.mockClear();
     clackMocks.spinnerInstance.stop.mockClear();
+    clackMocks.spinnerInstance.clear.mockClear();
   });
+
+  it.each([
+    "Checking channel status (probe)…",
+    "\u001b[36m检查频道 👩‍💻 状态检查频道状态检查频道状态\u001b[0m",
+  ])("keeps initial and updated spinner labels within the display width: %s", (label) => {
+    const stream = progressStream(32);
+    const progress = createCliProgress({ label, stream });
+    try {
+      const initial = clackMocks.spinnerInstance.start.mock.calls.at(-1)?.[0] as string;
+      expect(visibleWidth(initial)).toBeLessThanOrEqual(25);
+      expect(stripAnsi(initial)).toMatch(/…$/u);
+      progress.setLabel(`Updated ${label}`);
+      const updated = clackMocks.spinnerInstance.message.mock.calls.at(-1)?.[0] as string;
+      expect(visibleWidth(updated)).toBeLessThanOrEqual(25);
+      expect(stripAnsi(updated)).toMatch(/^Updated .*…$/u);
+    } finally {
+      progress.done();
+    }
+    expect(stream.listenerCount("resize")).toBe(0);
+  });
+
+  it.each([80, undefined, 0, Number.NaN, Number.POSITIVE_INFINITY])(
+    "preserves fitting or unknown-width spinner labels at %s columns",
+    (columns) => {
+      const stream = progressStream(columns);
+      const label = "Checking channel status (probe)…";
+      const progress = createCliProgress({ label, stream });
+      try {
+        expect(stripAnsi(clackMocks.spinnerInstance.start.mock.calls.at(-1)?.[0] as string)).toBe(
+          label,
+        );
+      } finally {
+        progress.done();
+      }
+      expect(stream.listenerCount("resize")).toBe(0);
+    },
+  );
+
+  it("tightens the spinner width on resize without exceeding its original cleanup width", () => {
+    const stream = progressStream(32);
+    const progress = createCliProgress({ label: "Checking channel status (probe)…", stream });
+    try {
+      expect(stream.listenerCount("resize")).toBe(1);
+      stream.columns = 80;
+      stream.emit("resize");
+      progress.setLabel("Checking channel status (probe)…");
+      expect(
+        visibleWidth(clackMocks.spinnerInstance.message.mock.calls.at(-1)?.[0] as string),
+      ).toBeLessThanOrEqual(25);
+      stream.columns = 20;
+      stream.emit("resize");
+      expect(
+        visibleWidth(clackMocks.spinnerInstance.message.mock.calls.at(-1)?.[0] as string),
+      ).toBeLessThanOrEqual(13);
+      stream.columns = 80;
+      stream.emit("resize");
+      progress.setLabel("Another long channel status message");
+      expect(
+        visibleWidth(clackMocks.spinnerInstance.message.mock.calls.at(-1)?.[0] as string),
+      ).toBeLessThanOrEqual(13);
+    } finally {
+      progress.done();
+    }
+    expect(stream.listenerCount("resize")).toBe(0);
+    const calls = clackMocks.spinnerInstance.message.mock.calls.length;
+    stream.emit("resize");
+    expect(clackMocks.spinnerInstance.message).toHaveBeenCalledTimes(calls);
+  });
+
+  it.each([1, 6, 7])("retains OSC progress without a spinner at %s columns", (columns) => {
+    vi.stubEnv("TERM_PROGRAM", "ghostty");
+    const stream = progressStream(columns);
+    const label = "Checking channel status (probe)…";
+    const progress = createCliProgress({ label, stream });
+    try {
+      expect(clackMocks.spinner).not.toHaveBeenCalled();
+      expect(stream.listenerCount("resize")).toBe(0);
+      expect(stream.write).toHaveBeenCalledWith(`\u001b]9;4;3;;${label}\u001b\\`);
+      progress.setPercent(50);
+      expect(stream.write).toHaveBeenCalledWith(`\u001b]9;4;1;50;${label}\u001b\\`);
+    } finally {
+      progress.done();
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it("clears a spinner once on tiny resize while keeping OSC progress alive", () => {
+    vi.stubEnv("TERM_PROGRAM", "ghostty");
+    const stream = progressStream(32);
+    const progress = createCliProgress({ label: "Checking channel status (probe)…", stream });
+    try {
+      stream.columns = 6;
+      stream.emit("resize");
+      expect(clackMocks.spinnerInstance.clear).toHaveBeenCalledTimes(1);
+      expect(clackMocks.spinnerInstance.stop).not.toHaveBeenCalled();
+      expect(stream.listenerCount("resize")).toBe(0);
+      stream.columns = 80;
+      stream.emit("resize");
+      progress.setLabel("Still working");
+      progress.setPercent(50);
+      expect(stream.write).toHaveBeenCalledWith("\u001b]9;4;1;50;Still working\u001b\\");
+      expect(clackMocks.spinnerInstance.start).toHaveBeenCalledTimes(1);
+    } finally {
+      progress.done();
+      progress.done();
+      vi.unstubAllEnvs();
+    }
+    expect(clackMocks.spinnerInstance.clear).toHaveBeenCalledTimes(1);
+    expect(clackMocks.spinnerInstance.stop).not.toHaveBeenCalled();
+  });
+
+  it("removes the spinner resize listener when finished before its delayed start", () => {
+    vi.useFakeTimers();
+    const stream = progressStream(32);
+    const progress = createCliProgress({ label: "Delayed", stream, delayMs: 100 });
+    try {
+      progress.done();
+      stream.emit("resize");
+      vi.runAllTimers();
+      expect(stream.listenerCount("resize")).toBe(0);
+      expect(clackMocks.spinnerInstance.start).not.toHaveBeenCalled();
+    } finally {
+      progress.done();
+      vi.useRealTimers();
+    }
+  });
+
+  it.each(["line", "log", "none"] as const)(
+    "does not clamp labels or listen for resize with fallback=%s",
+    (fallback) => {
+      const stream = progressStream(10);
+      stream.isTTY = fallback !== "log";
+      const label = "Checking channel status (probe)…";
+      const progress = createCliProgress({ label, stream, fallback });
+      try {
+        expect(clackMocks.spinner).not.toHaveBeenCalled();
+        expect(stream.listenerCount("resize")).toBe(0);
+        if (fallback !== "none") {
+          expect(
+            stream.write.mock.calls.some(([chunk]) => stripAnsi(String(chunk)).includes(label)),
+          ).toBe(true);
+        }
+      } finally {
+        progress.done();
+      }
+    },
+  );
 
   it("logs progress when non-tty and fallback=log", () => {
     const writes: string[] = [];

--- a/src/cli/progress.test.ts
+++ b/src/cli/progress.test.ts
@@ -1,15 +1,14 @@
-import { EventEmitter } from "node:events";
+import { Writable } from "node:stream";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 // Progress tests cover CLI progress rendering and lifecycle cleanup.
-import { beforeEach, describe, expect, it, vi } from "vitest";
-import { stripAnsi, visibleWidth } from "../../packages/terminal-core/src/ansi.js";
+import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { theme } from "../../packages/terminal-core/src/theme.js";
 import { createCliProgress, shouldUseInteractiveProgressSpinner } from "./progress.js";
 
 const clackMocks = vi.hoisted(() => {
   const spinnerInstance = {
     start: vi.fn(),
     message: vi.fn(),
-    stop: vi.fn(),
     clear: vi.fn(),
   };
   return {
@@ -18,17 +17,25 @@ const clackMocks = vi.hoisted(() => {
   };
 });
 
-function progressStream(columns?: number) {
-  return Object.assign(new EventEmitter(), {
-    isTTY: true,
-    columns,
-    write: vi.fn(),
-  }) as unknown as NodeJS.WriteStream & { write: ReturnType<typeof vi.fn> };
-}
-
-vi.mock("@clack/prompts", () => ({
+vi.mock("@clack/prompts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@clack/prompts")>()),
   spinner: clackMocks.spinner,
 }));
+
+function createOutput(
+  isTTY: boolean,
+  write: (chunk: string) => void = () => {},
+  columns?: number,
+): NodeJS.WriteStream {
+  const output = new Writable({
+    write(chunk: Buffer, _encoding, callback) {
+      write(chunk.toString());
+      callback();
+    },
+  });
+  Object.assign(output, { isTTY, columns });
+  return output as NodeJS.WriteStream;
+}
 
 function withStdinIsRaw<T>(isRaw: boolean, run: () => T): T {
   const original = Object.getOwnPropertyDescriptor(process.stdin, "isRaw");
@@ -52,165 +59,41 @@ describe("cli progress", () => {
     clackMocks.spinner.mockClear();
     clackMocks.spinnerInstance.start.mockClear();
     clackMocks.spinnerInstance.message.mockClear();
-    clackMocks.spinnerInstance.stop.mockClear();
     clackMocks.spinnerInstance.clear.mockClear();
   });
 
-  it.each([
-    "Checking channel status (probe)…",
-    "\u001b[36m检查频道 👩‍💻 状态检查频道状态检查频道状态\u001b[0m",
-  ])("keeps initial and updated spinner labels within the display width: %s", (label) => {
-    const stream = progressStream(32);
-    const progress = createCliProgress({ label, stream });
-    try {
-      const initial = clackMocks.spinnerInstance.start.mock.calls.at(-1)?.[0] as string;
-      expect(visibleWidth(initial)).toBeLessThanOrEqual(25);
-      expect(stripAnsi(initial)).toMatch(/…$/u);
-      progress.setLabel(`Updated ${label}`);
-      const updated = clackMocks.spinnerInstance.message.mock.calls.at(-1)?.[0] as string;
-      expect(visibleWidth(updated)).toBeLessThanOrEqual(25);
-      expect(stripAnsi(updated)).toMatch(/^Updated .*…$/u);
-    } finally {
-      progress.done();
-    }
+  it.each<[number, string]>([
+    [32, "Checking channel status …"],
+    [36, "Checking channel status (pro…"],
+    [80, "Checking channel status (probe)…"],
+  ])("bounds spinner at %i columns", (columns, expected) => {
+    const stream = createOutput(true, undefined, columns);
+    const progress = createCliProgress({ label: "Checking channel status (probe)…", stream });
+    onTestFinished(() => progress.done());
+
+    expect(clackMocks.spinnerInstance.start).toHaveBeenCalledWith(theme.accent(expected));
+    progress.done();
     expect(stream.listenerCount("resize")).toBe(0);
   });
 
-  it.each([80, undefined, 0, Number.NaN, Number.POSITIVE_INFINITY])(
-    "preserves fitting or unknown-width spinner labels at %s columns",
-    (columns) => {
-      const stream = progressStream(columns);
-      const label = "Checking channel status (probe)…";
-      const progress = createCliProgress({ label, stream });
-      try {
-        expect(stripAnsi(clackMocks.spinnerInstance.start.mock.calls.at(-1)?.[0] as string)).toBe(
-          label,
-        );
-      } finally {
-        progress.done();
-      }
-      expect(stream.listenerCount("resize")).toBe(0);
-    },
-  );
+  it("suppresses animation below the frame budget", () => {
+    const stream = createOutput(true, undefined, 6);
+    const progress = createCliProgress({ label: "Loading", stream });
+    onTestFinished(() => progress.done());
 
-  it("tightens the spinner width on resize without exceeding its original cleanup width", () => {
-    const stream = progressStream(32);
-    const progress = createCliProgress({ label: "Checking channel status (probe)…", stream });
-    try {
-      expect(stream.listenerCount("resize")).toBe(1);
-      stream.columns = 80;
-      stream.emit("resize");
-      progress.setLabel("Checking channel status (probe)…");
-      expect(
-        visibleWidth(clackMocks.spinnerInstance.message.mock.calls.at(-1)?.[0] as string),
-      ).toBeLessThanOrEqual(25);
-      stream.columns = 20;
-      stream.emit("resize");
-      expect(
-        visibleWidth(clackMocks.spinnerInstance.message.mock.calls.at(-1)?.[0] as string),
-      ).toBeLessThanOrEqual(13);
-      stream.columns = 80;
-      stream.emit("resize");
-      progress.setLabel("Another long channel status message");
-      expect(
-        visibleWidth(clackMocks.spinnerInstance.message.mock.calls.at(-1)?.[0] as string),
-      ).toBeLessThanOrEqual(13);
-    } finally {
-      progress.done();
-    }
+    expect(clackMocks.spinnerInstance.start).not.toHaveBeenCalled();
+    progress.done();
     expect(stream.listenerCount("resize")).toBe(0);
-    const calls = clackMocks.spinnerInstance.message.mock.calls.length;
-    stream.emit("resize");
-    expect(clackMocks.spinnerInstance.message).toHaveBeenCalledTimes(calls);
   });
-
-  it.each([1, 6, 7])("retains OSC progress without a spinner at %s columns", (columns) => {
-    vi.stubEnv("TERM_PROGRAM", "ghostty");
-    const stream = progressStream(columns);
-    const label = "Checking channel status (probe)…";
-    const progress = createCliProgress({ label, stream });
-    try {
-      expect(clackMocks.spinner).not.toHaveBeenCalled();
-      expect(stream.listenerCount("resize")).toBe(0);
-      expect(stream.write).toHaveBeenCalledWith(`\u001b]9;4;3;;${label}\u001b\\`);
-      progress.setPercent(50);
-      expect(stream.write).toHaveBeenCalledWith(`\u001b]9;4;1;50;${label}\u001b\\`);
-    } finally {
-      progress.done();
-      vi.unstubAllEnvs();
-    }
-  });
-
-  it("clears a spinner once on tiny resize while keeping OSC progress alive", () => {
-    vi.stubEnv("TERM_PROGRAM", "ghostty");
-    const stream = progressStream(32);
-    const progress = createCliProgress({ label: "Checking channel status (probe)…", stream });
-    try {
-      stream.columns = 6;
-      stream.emit("resize");
-      expect(clackMocks.spinnerInstance.clear).toHaveBeenCalledTimes(1);
-      expect(clackMocks.spinnerInstance.stop).not.toHaveBeenCalled();
-      expect(stream.listenerCount("resize")).toBe(0);
-      stream.columns = 80;
-      stream.emit("resize");
-      progress.setLabel("Still working");
-      progress.setPercent(50);
-      expect(stream.write).toHaveBeenCalledWith("\u001b]9;4;1;50;Still working\u001b\\");
-      expect(clackMocks.spinnerInstance.start).toHaveBeenCalledTimes(1);
-    } finally {
-      progress.done();
-      progress.done();
-      vi.unstubAllEnvs();
-    }
-    expect(clackMocks.spinnerInstance.clear).toHaveBeenCalledTimes(1);
-    expect(clackMocks.spinnerInstance.stop).not.toHaveBeenCalled();
-  });
-
-  it("removes the spinner resize listener when finished before its delayed start", () => {
-    vi.useFakeTimers();
-    const stream = progressStream(32);
-    const progress = createCliProgress({ label: "Delayed", stream, delayMs: 100 });
-    try {
-      progress.done();
-      stream.emit("resize");
-      vi.runAllTimers();
-      expect(stream.listenerCount("resize")).toBe(0);
-      expect(clackMocks.spinnerInstance.start).not.toHaveBeenCalled();
-    } finally {
-      progress.done();
-      vi.useRealTimers();
-    }
-  });
-
-  it.each(["line", "log", "none"] as const)(
-    "does not clamp labels or listen for resize with fallback=%s",
-    (fallback) => {
-      const stream = progressStream(10);
-      stream.isTTY = fallback !== "log";
-      const label = "Checking channel status (probe)…";
-      const progress = createCliProgress({ label, stream, fallback });
-      try {
-        expect(clackMocks.spinner).not.toHaveBeenCalled();
-        expect(stream.listenerCount("resize")).toBe(0);
-        if (fallback !== "none") {
-          expect(
-            stream.write.mock.calls.some(([chunk]) => stripAnsi(String(chunk)).includes(label)),
-          ).toBe(true);
-        }
-      } finally {
-        progress.done();
-      }
-    },
-  );
 
   it("logs progress when non-tty and fallback=log", () => {
     const writes: string[] = [];
-    const stream = {
-      isTTY: false,
-      write: vi.fn((chunk: string) => {
+    const stream = createOutput(
+      false,
+      vi.fn((chunk: string) => {
         writes.push(chunk);
       }),
-    } as unknown as NodeJS.WriteStream;
+    );
 
     const progress = createCliProgress({
       label: "Indexing memory...",
@@ -226,10 +109,7 @@ describe("cli progress", () => {
 
   it("does not log without a tty when fallback is none", () => {
     const write = vi.fn();
-    const stream = {
-      isTTY: false,
-      write,
-    } as unknown as NodeJS.WriteStream;
+    const stream = createOutput(false, write);
 
     const progress = createCliProgress({
       label: "Nope",
@@ -245,12 +125,12 @@ describe("cli progress", () => {
 
   it("does not render progress updates after the reporter is finished", () => {
     const writes: string[] = [];
-    const stream = {
-      isTTY: false,
-      write: vi.fn((chunk: string) => {
+    const stream = createOutput(
+      false,
+      vi.fn((chunk: string) => {
         writes.push(chunk);
       }),
-    } as unknown as NodeJS.WriteStream;
+    );
 
     const progress = createCliProgress({
       label: "Indexing memory...",
@@ -267,33 +147,23 @@ describe("cli progress", () => {
   });
 
   it("does not stop an interactive spinner more than once", () => {
-    const stream = {
-      isTTY: true,
-      write: vi.fn(),
-    } as unknown as NodeJS.WriteStream;
-
+    const write = vi.fn();
+    const stream = createOutput(true, write);
     const progress = createCliProgress({ label: "Loading", stream });
     progress.done();
+    const completedWrites = write.mock.calls.length;
+    expect(completedWrites).toBeGreaterThan(0);
     progress.done();
 
-    expect(clackMocks.spinnerInstance.stop).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledTimes(completedWrites);
   });
 
   it("does not let a finished reporter clear or unlock a newer progress line", () => {
-    const firstStream = {
-      isTTY: true,
-      write: vi.fn(),
-    } as unknown as NodeJS.WriteStream;
+    const firstStream = createOutput(true, vi.fn());
     const secondWrite = vi.fn();
-    const secondStream = {
-      isTTY: true,
-      write: secondWrite,
-    } as unknown as NodeJS.WriteStream;
+    const secondStream = createOutput(true, secondWrite);
     const thirdWrite = vi.fn();
-    const thirdStream = {
-      isTTY: true,
-      write: thirdWrite,
-    } as unknown as NodeJS.WriteStream;
+    const thirdStream = createOutput(true, thirdWrite);
 
     const first = createCliProgress({
       label: "First",
@@ -345,10 +215,7 @@ describe("cli progress", () => {
   });
 
   it("routes clack spinner output through the progress stream", () => {
-    const stream = {
-      isTTY: true,
-      write: vi.fn(),
-    } as unknown as NodeJS.WriteStream;
+    const stream = createOutput(true, vi.fn());
 
     const progress = createCliProgress({
       label: "Loading",
@@ -360,17 +227,16 @@ describe("cli progress", () => {
     expect(clackMocks.spinnerInstance.start).toHaveBeenCalledWith(
       expect.stringContaining("Loading"),
     );
-    expect(clackMocks.spinnerInstance.stop).toHaveBeenCalledTimes(1);
   });
 
   it("does not write terminal controls when raw TUI input suppresses the default spinner", () => {
     const writes: string[] = [];
-    const stream = {
-      isTTY: true,
-      write: vi.fn((chunk: string) => {
+    const stream = createOutput(
+      true,
+      vi.fn((chunk: string) => {
         writes.push(chunk);
       }),
-    } as unknown as NodeJS.WriteStream;
+    );
 
     withStdinIsRaw(true, () => {
       const progress = createCliProgress({
@@ -388,16 +254,13 @@ describe("cli progress", () => {
 
   it("unregisters a delayed tty progress line when done before start", () => {
     const firstWrites: string[] = [];
-    const firstStream = {
-      isTTY: true,
-      write: vi.fn((chunk: string) => {
+    const firstStream = createOutput(
+      true,
+      vi.fn((chunk: string) => {
         firstWrites.push(chunk);
       }),
-    } as unknown as NodeJS.WriteStream;
-    const secondStream = {
-      isTTY: true,
-      write: vi.fn(),
-    } as unknown as NodeJS.WriteStream;
+    );
+    const secondStream = createOutput(true, vi.fn());
 
     const delayed = createCliProgress({
       label: "Delayed",
@@ -418,10 +281,7 @@ describe("cli progress", () => {
   });
 
   it("clamps oversized delayed progress timers", () => {
-    const stream = {
-      isTTY: true,
-      write: vi.fn(),
-    } as unknown as NodeJS.WriteStream;
+    const stream = createOutput(true, vi.fn());
     const setTimeoutSpy = vi.spyOn(globalThis, "setTimeout");
     try {
       const progress = createCliProgress({

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -1,6 +1,7 @@
 // Terminal progress reporter used by long-running CLI commands.
 import { spinner } from "@clack/prompts";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
+import { truncateToVisibleWidth, visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import {
   createOscProgressController,
   supportsOscProgress,
@@ -13,6 +14,22 @@ import {
 import { theme } from "../../packages/terminal-core/src/theme.js";
 
 const DEFAULT_DELAY_MS = 0;
+// Clack adds a frame, two spaces and up to three dots; leave one spare column.
+const SPINNER_DECORATION_COLUMNS = 7;
+
+function readProgressColumns(stream: NodeJS.WriteStream): number | undefined {
+  return Number.isFinite(stream.columns) && stream.columns > 0
+    ? Math.floor(stream.columns)
+    : undefined;
+}
+
+function clampSpinnerLabel(label: string, columns: number | undefined): string {
+  if (columns === undefined) {
+    return label;
+  }
+  const width = columns - SPINNER_DECORATION_COLUMNS;
+  return visibleWidth(label) <= width ? label : `${truncateToVisibleWidth(label, width - 1)}…`;
+}
 // Only one active progress renderer may own the terminal line at a time.
 let activeProgress = 0;
 
@@ -110,7 +127,11 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
       })
     : null;
 
-  const spin = allowSpinner ? spinner({ output: stream }) : null;
+  let spinnerColumns = readProgressColumns(stream);
+  let spin =
+    allowSpinner && (spinnerColumns === undefined || spinnerColumns > SPINNER_DECORATION_COLUMNS)
+      ? spinner({ output: stream })
+      : null;
   const renderLine = allowLine
     ? () => {
         if (!started) {
@@ -156,7 +177,7 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
       }
     }
     if (spin) {
-      spin.message(theme.accent(label));
+      spin.message(theme.accent(clampSpinnerLabel(label, spinnerColumns)));
     }
     if (renderLine) {
       renderLine();
@@ -166,13 +187,32 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
     }
   };
 
+  const onResize = () => {
+    const columns = readProgressColumns(stream);
+    if (columns === undefined || spinnerColumns === undefined) {
+      return;
+    }
+    // Clack captures its cleanup width at construction, so never expand past it.
+    spinnerColumns = Math.min(spinnerColumns, columns);
+    if (spinnerColumns <= SPINNER_DECORATION_COLUMNS) {
+      spin?.clear();
+      spin = null;
+      stream.off("resize", onResize);
+      return;
+    }
+    applyState();
+  };
+  if (spin && spinnerColumns !== undefined) {
+    stream.on("resize", onResize);
+  }
+
   const start = () => {
     if (started) {
       return;
     }
     started = true;
     if (spin) {
-      spin.start(theme.accent(label));
+      spin.start(theme.accent(clampSpinnerLabel(label, spinnerColumns)));
     }
     applyState();
   };
@@ -209,6 +249,9 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
       return;
     }
     finished = true;
+    if (spinnerColumns !== undefined && allowSpinner) {
+      stream.off("resize", onResize);
+    }
     if (timer) {
       clearTimeout(timer);
       timer = null;

--- a/src/cli/progress.ts
+++ b/src/cli/progress.ts
@@ -1,5 +1,5 @@
 // Terminal progress reporter used by long-running CLI commands.
-import { spinner } from "@clack/prompts";
+import { log, spinner, symbol } from "@clack/prompts";
 import { resolveTimerTimeoutMs } from "@openclaw/normalization-core/number-coercion";
 import { truncateToVisibleWidth, visibleWidth } from "../../packages/terminal-core/src/ansi.js";
 import {
@@ -13,23 +13,67 @@ import {
 } from "../../packages/terminal-core/src/progress-line.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 
+/** Keep animated labels inside Clack's captured erase width. */
+export function createProgressSpinner(
+  options: Parameters<typeof spinner>[0] & { output: NodeJS.WriteStream },
+  decorationColumns: number,
+) {
+  const { output } = options;
+  const readColumns = () =>
+    Number.isFinite(output.columns) && output.columns > 0 ? Math.floor(output.columns) : undefined;
+  let columns = readColumns();
+  let label = "";
+  let finished = false;
+  const spin = spinner(options);
+  const render = (message: string) => {
+    label = message;
+    const width = columns === undefined ? undefined : columns - decorationColumns;
+    return theme.accent(
+      width === undefined || visibleWidth(label) <= width
+        ? label
+        : width <= 0
+          ? ""
+          : `${truncateToVisibleWidth(label, width - 1)}…`,
+    );
+  };
+  const resize = () => {
+    const next = readColumns();
+    if (columns === undefined || next === undefined || next >= columns) {
+      return;
+    }
+    columns = next;
+    if (columns <= decorationColumns) {
+      spin.clear();
+    } else {
+      spin.message(render(label));
+    }
+  };
+  return {
+    start: (message: string) => {
+      resize();
+      if (columns === undefined || columns > decorationColumns) {
+        if (columns !== undefined) {
+          output.on("resize", resize);
+        }
+        spin.start(render(message));
+      }
+    },
+    message: (message: string) => spin.message(render(message)),
+    stop: (message?: string) => {
+      if (finished) {
+        return;
+      }
+      finished = true;
+      output.off("resize", resize);
+      spin.clear();
+      if (message !== undefined) {
+        log.message([`${symbol("submit")}  ${message}`], { output, spacing: 0, withGuide: false });
+      }
+    },
+  };
+}
+
 const DEFAULT_DELAY_MS = 0;
-// Clack adds a frame, two spaces and up to three dots; leave one spare column.
-const SPINNER_DECORATION_COLUMNS = 7;
-
-function readProgressColumns(stream: NodeJS.WriteStream): number | undefined {
-  return Number.isFinite(stream.columns) && stream.columns > 0
-    ? Math.floor(stream.columns)
-    : undefined;
-}
-
-function clampSpinnerLabel(label: string, columns: number | undefined): string {
-  if (columns === undefined) {
-    return label;
-  }
-  const width = columns - SPINNER_DECORATION_COLUMNS;
-  return visibleWidth(label) <= width ? label : `${truncateToVisibleWidth(label, width - 1)}…`;
-}
 // Only one active progress renderer may own the terminal line at a time.
 let activeProgress = 0;
 
@@ -127,11 +171,7 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
       })
     : null;
 
-  let spinnerColumns = readProgressColumns(stream);
-  let spin =
-    allowSpinner && (spinnerColumns === undefined || spinnerColumns > SPINNER_DECORATION_COLUMNS)
-      ? spinner({ output: stream })
-      : null;
+  const spin = allowSpinner ? createProgressSpinner({ output: stream }, 7) : null;
   const renderLine = allowLine
     ? () => {
         if (!started) {
@@ -176,9 +216,7 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
         controller.setPercent(label, percent);
       }
     }
-    if (spin) {
-      spin.message(theme.accent(clampSpinnerLabel(label, spinnerColumns)));
-    }
+    spin?.message(label);
     if (renderLine) {
       renderLine();
     }
@@ -187,33 +225,12 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
     }
   };
 
-  const onResize = () => {
-    const columns = readProgressColumns(stream);
-    if (columns === undefined || spinnerColumns === undefined) {
-      return;
-    }
-    // Clack captures its cleanup width at construction, so never expand past it.
-    spinnerColumns = Math.min(spinnerColumns, columns);
-    if (spinnerColumns <= SPINNER_DECORATION_COLUMNS) {
-      spin?.clear();
-      spin = null;
-      stream.off("resize", onResize);
-      return;
-    }
-    applyState();
-  };
-  if (spin && spinnerColumns !== undefined) {
-    stream.on("resize", onResize);
-  }
-
   const start = () => {
     if (started) {
       return;
     }
     started = true;
-    if (spin) {
-      spin.start(theme.accent(clampSpinnerLabel(label, spinnerColumns)));
-    }
+    spin?.start(label);
     applyState();
   };
 
@@ -249,9 +266,6 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
       return;
     }
     finished = true;
-    if (spinnerColumns !== undefined && allowSpinner) {
-      stream.off("resize", onResize);
-    }
     if (timer) {
       clearTimeout(timer);
       timer = null;
@@ -266,9 +280,7 @@ export function createCliProgress(options: ProgressOptions): ProgressReporter {
     if (controller) {
       controller.clear();
     }
-    if (spin) {
-      spin.stop();
-    }
+    spin?.stop("");
     clearActiveProgressLine();
     if (isTty) {
       unregisterActiveProgressLine(stream);

--- a/src/wizard/clack-prompter.test.ts
+++ b/src/wizard/clack-prompter.test.ts
@@ -1,6 +1,16 @@
 // Clack prompter tests cover prompt rendering, validation, and cancellation.
-import type { SpinnerOptions } from "@clack/prompts";
-import { afterAll, afterEach, describe, expect, it, onTestFinished, vi } from "vitest";
+import { symbol, type SpinnerOptions } from "@clack/prompts";
+import {
+  afterAll,
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  onTestFinished,
+  vi,
+  type MockInstance,
+} from "vitest";
 
 const themeMocks = vi.hoisted(() => ({
   isRich: vi.fn(() => false),
@@ -49,7 +59,6 @@ const clackMocks = vi.hoisted(() => ({
     start: vi.fn(),
     message: vi.fn(),
     clear: vi.fn(),
-    stop: vi.fn(),
   })),
   text: vi.fn(),
 }));
@@ -72,7 +81,8 @@ vi.mock("../../packages/terminal-core/src/theme.js", async (importOriginal) => {
   };
 });
 
-vi.mock("@clack/prompts", () => ({
+vi.mock("@clack/prompts", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("@clack/prompts")>()),
   autocomplete: clackMocks.autocomplete,
   autocompleteMultiselect: clackMocks.autocompleteMultiselect,
   cancel: clackMocks.cancel,
@@ -88,7 +98,8 @@ vi.mock("@clack/prompts", () => ({
   text: clackMocks.text,
 }));
 
-vi.mock("../cli/progress.js", () => ({
+vi.mock("../cli/progress.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../cli/progress.js")>()),
   createCliProgress: cliProgressMocks.createCliProgress,
 }));
 
@@ -163,6 +174,11 @@ describe("tokenizedOptionFilter", () => {
 });
 
 describe("createClackPrompter", () => {
+  let stdoutWriteSpy: MockInstance<typeof process.stdout.write>;
+
+  beforeEach(() => {
+    stdoutWriteSpy = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+  });
   it("clamps long progress labels by display width without splitting grapheme clusters", () => {
     stubStdoutColumns(20);
     const prompter = createClackPrompter();
@@ -175,7 +191,6 @@ describe("createClackPrompter", () => {
     const osc = cliProgressMocks.createCliProgress.mock.results[0]!.value;
     expect(spin.start).toHaveBeenCalledWith(theme.accent("12345678…"));
     expect(spin.message).toHaveBeenCalledWith(theme.accent("正在扫描…"));
-    expect(spin.stop).toHaveBeenCalledWith("1234567890ABC");
     expect(cliProgressMocks.createCliProgress).toHaveBeenCalledWith(
       expect.objectContaining({ label: "12345678😀ABC" }),
     );
@@ -234,15 +249,44 @@ describe("createClackPrompter", () => {
     expect(spin.start).toHaveBeenCalledWith(theme.accent("Loading"));
   });
 
-  it("uses an empty progress label when decoration consumes the terminal width", () => {
-    stubStdoutColumns(10);
-    const prompter = createClackPrompter();
+  it.each([undefined, "", "First line\nSecond line"])(
+    "preserves tiny completion %j once",
+    (message) => {
+      stubStdoutIsTTY(true);
+      stubStdoutColumns(6);
+      vi.stubEnv("CI", "");
+      vi.stubEnv("VITEST", "");
+      themeMocks.isRich.mockReturnValue(true);
+      const progress = createClackPrompter().progress("Loading");
+      onTestFinished(() => progress.stop());
+      const spin = clackMocks.spinner.mock.results[0]!.value;
 
-    const progress = prompter.progress("Loading");
+      expect(spin.start).not.toHaveBeenCalled();
+      progress.update("Still loading");
+      progress.stop(message);
+      const expected = message === undefined ? [] : [[`${symbol("submit")}  ${message}\n`]];
+      expect(stdoutWriteSpy.mock.calls).toEqual(expected);
+      progress.stop("Unexpected second completion");
+      expect(stdoutWriteSpy.mock.calls).toEqual(expected);
+      expect(process.stdout.listeners("resize")).toEqual(initialSuiteResizeListeners);
+    },
+  );
+
+  it("keeps completion after clearing tiny animation", () => {
+    stubStdoutColumns(20);
+    const progress = createClackPrompter().progress("Loading");
     onTestFinished(() => progress.stop());
-
     const spin = clackMocks.spinner.mock.results[0]!.value;
-    expect(spin.start).toHaveBeenCalledWith(theme.accent(""));
+    stubStdoutColumns(6);
+    process.stdout.emit("resize");
+    expect(spin.clear).toHaveBeenCalled();
+    stubStdoutColumns(30);
+    process.stdout.emit("resize");
+    progress.update("Still loading");
+    expect(spin.start).toHaveBeenCalledTimes(1);
+
+    progress.stop("Finished after resize");
+    expect(stdoutWriteSpy).toHaveBeenCalledWith(`${symbol("submit")}  Finished after resize\n`);
   });
 
   it("uses the claw spinner on rich interactive terminals", () => {

--- a/src/wizard/clack-prompter.ts
+++ b/src/wizard/clack-prompter.ts
@@ -12,15 +12,10 @@ import {
   password,
   select,
   settings,
-  spinner,
   text,
 } from "@clack/prompts";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import {
-  stripAnsi,
-  truncateToVisibleWidth,
-  visibleWidth,
-} from "../../packages/terminal-core/src/ansi.js";
+import { stripAnsi } from "../../packages/terminal-core/src/ansi.js";
 import { noteToStream as emitNote } from "../../packages/terminal-core/src/note.js";
 import { styleSelectParams } from "../../packages/terminal-core/src/prompt-select-styled-params.js";
 import {
@@ -28,7 +23,7 @@ import {
   stylePromptTitle,
 } from "../../packages/terminal-core/src/prompt-style.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
-import { createCliProgress } from "../cli/progress.js";
+import { createCliProgress, createProgressSpinner } from "../cli/progress.js";
 import {
   autocompleteMultiselectWithNavigationFooter,
   autocompleteWithNavigationFooter,
@@ -44,30 +39,6 @@ import { WizardCancelledError, WizardNavigationError } from "./prompts.js";
 // Same species as the pixel-mascot banner, compressed into a four-column
 // spinner for long-running wizard steps.
 const CLAW_SPINNER_FRAMES = ["(\\/)", "(||)", "(--)", "(||)"];
-const SPINNER_DECORATION_COLUMNS = 10;
-
-function readProgressColumns(output: NodeJS.WriteStream): number | undefined {
-  const columns = output.columns;
-  if (typeof columns !== "number" || !Number.isFinite(columns) || columns <= 0) {
-    return undefined;
-  }
-  return columns;
-}
-
-function clampProgressLabel(label: string, columns: number | undefined): string {
-  if (columns === undefined) {
-    return label;
-  }
-  const maxLabelWidth = columns - SPINNER_DECORATION_COLUMNS;
-  if (maxLabelWidth <= 0) {
-    return "";
-  }
-  if (visibleWidth(label) <= maxLabelWidth) {
-    return label;
-  }
-  return `${truncateToVisibleWidth(label, maxLabelWidth - 1)}…`;
-}
-
 // Clack-backed WizardPrompter implementation for interactive CLI setup. It
 // converts the generic wizard prompt contract into styled Clack prompts.
 function guardCancel<T>(value: T | symbol, output: NodeJS.WriteStream, signal?: AbortSignal): T {
@@ -421,33 +392,13 @@ export function createClackPrompter(
       ),
     progress: (label: string): WizardProgress => {
       const useClawSpinner = output.isTTY && isRich() && !process.env.CI && !process.env.VITEST;
-      const spin = useClawSpinner
-        ? spinner({
-            frames: CLAW_SPINNER_FRAMES,
-            delay: 120,
-            styleFrame: theme.accent,
-            output,
-          })
-        : spinner({ output });
-      let currentLabel = label;
-      let maxColumns = readProgressColumns(output);
-      const renderLabel = () => theme.accent(clampProgressLabel(currentLabel, maxColumns));
-      const handleResize = () => {
-        const columns = readProgressColumns(output);
-        if (maxColumns === undefined || columns === undefined || columns >= maxColumns) {
-          return;
-        }
-        // Clack snapshots its erase width when the spinner is created. Only
-        // tighten our label budget so later terminal growth cannot exceed it.
-        maxColumns = columns;
-        spin.message(renderLabel());
-      };
-      if (maxColumns !== undefined) {
-        output.on("resize", handleResize);
-      }
-      // Clack erases using bare-message wrapping but writes the frame and dots too.
-      // Keeping animated labels to one row prevents long scans from leaking a line each tick.
-      spin.start(renderLabel());
+      const spin = createProgressSpinner(
+        useClawSpinner
+          ? { frames: CLAW_SPINNER_FRAMES, delay: 120, styleFrame: theme.accent, output }
+          : { output },
+        10,
+      );
+      spin.start(label);
       const osc = createCliProgress({
         label,
         indeterminate: true,
@@ -459,18 +410,12 @@ export function createClackPrompter(
       // display command progress outside the prompt line.
       return {
         update: (message) => {
-          currentLabel = message;
-          spin.message(renderLabel());
+          spin.message(message);
           osc.setLabel(message);
         },
         stop: (message) => {
-          output.off("resize", handleResize);
           osc.done();
-          if (message === undefined) {
-            spin.clear();
-          } else {
-            spin.stop(message);
-          }
+          spin.stop(message);
         },
       };
     },


### PR DESCRIPTION
Fixes #141400. Related: #112413.

Progress labels could fit the nominal terminal width while the spinner frame and animated dots pushed the painted line onto another row. Subsequent redraws left stale rows behind. At very small widths, the wizard could also keep animating an empty label and fill the terminal with frames.

Both progress paths now share one renderer that budgets for their decorations and refreshes the width before a delayed start. It suppresses animation when the frame cannot fit while preserving full progress metadata and exactly one requested completion message, including empty and multiline messages. Removing the duplicate wizard renderer keeps production at **77 additions / 77 deletions**.

Validation: 50 focused tests and 12 real PTY scenarios passed, covering narrow and wide terminals, pre-start resize, whole graphemes, full progress metadata, tiny-width suppression, completion text and repeated stop. All PTY children and observers completed cleanup. The [retained functional run](https://github.com/steipete/openclaw/actions/runs/34169880359/job/101888055019) later failed on two test spy aliases; the fixture now retains its existing spy handle with a unique name. The [final native lint and eight remaining static checks](https://github.com/steipete/openclaw/actions/runs/34180345656/job/101918017259) passed on the repaired candidate. The images are rendered projections of captured PTY data, not native screenshots or active-resize reflow proof.

Thanks @ooiuuii for the original report and contribution.

![Rendered captured PTY rows before and after: core progress at32 columns](https://github.com/user-attachments/assets/475082b6-3b54-47ec-8e2f-9acc34fcdc66)

![Rendered captured PTY rows before and after: core progress at36 columns](https://github.com/user-attachments/assets/8d769dbb-0ec9-4b56-8b52-60c0f3ea6412)

![Rendered captured PTY rows before and after: wizard progress at6 columns](https://github.com/user-attachments/assets/1be69367-8163-49d4-8307-4e04bc65d71d)