### PR TITLE
fix(models): use resolved runtime headers for catalog hooks

### DIFF
--- a/src/agents/models-config.providers.catalog-context.ts
+++ b/src/agents/models-config.providers.catalog-context.ts
@@ -1,4 +1,7 @@
-import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import {
+  findNormalizedProviderValue,
+  normalizeProviderId,
+} from "@openclaw/model-catalog-core/provider-id";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
   ProviderCatalogOutcome,
@@ -9,6 +12,7 @@ import {
   type runProviderCatalog,
 } from "../plugins/provider-discovery.js";
 import { matchesProviderPluginRef } from "../plugins/provider-registry-shared.js";
+import type { ProviderPlugin } from "../plugins/types.js";
 import { isTrustedSecretSurfaceUnavailableError } from "../secrets/runtime-degraded-state.js";
 import type { AuthProfileStore } from "./auth-profiles/types.js";
 import type { ProviderConfig } from "./models-config.providers.secret-helpers.js";
@@ -16,22 +20,34 @@ import { resolveProviderIdForAuth } from "./provider-auth-aliases.js";
 
 type CatalogContext = {
   config?: OpenClawConfig;
-  env: NodeJS.ProcessEnv;
+  discoveryAuthConfig?: OpenClawConfig;
   explicitProviders?: Record<string, ProviderConfig> | null;
 };
 
-export function buildPluginCatalogConfig(ctx: CatalogContext): OpenClawConfig {
-  if (!ctx.explicitProviders || Object.keys(ctx.explicitProviders).length === 0) {
+export function buildPluginCatalogConfig(
+  ctx: CatalogContext,
+  provider: ProviderPlugin,
+): OpenClawConfig {
+  const providers = { ...ctx.config?.models?.providers, ...ctx.explicitProviders };
+  if (Object.keys(providers).length === 0) {
     return ctx.config ?? {};
+  }
+  for (const [providerId, source] of Object.entries(providers)) {
+    const runtime = findNormalizedProviderValue(
+      ctx.discoveryAuthConfig?.models?.providers,
+      providerId,
+    );
+    if (runtime && matchesProviderPluginRef(provider, providerId)) {
+      // Keep source auth selection and other providers private; only this hook's
+      // request surfaces consume the matching materialized runtime values.
+      providers[providerId] = { ...source, headers: runtime.headers, request: runtime.request };
+    }
   }
   return {
     ...ctx.config,
     models: {
       ...ctx.config?.models,
-      providers: {
-        ...ctx.config?.models?.providers,
-        ...ctx.explicitProviders,
-      },
+      providers,
     },
   };
 }

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -216,7 +216,6 @@ async function resolvePluginImplicitProviders(
 ): Promise<Record<string, ProviderConfig> | undefined> {
   const byOrder = groupPluginDiscoveryProvidersByOrder(providers);
   const discovered: Record<string, ProviderConfig> = {};
-  const catalogConfig = buildPluginCatalogConfig(ctx);
   const selectedProviderIds = ctx.providerDiscoveryScope
     ? new Set([...ctx.providerDiscoveryScope.values()].flat())
     : undefined;
@@ -240,6 +239,7 @@ async function resolvePluginImplicitProviders(
     if (providerIds?.length === 0) {
       continue;
     }
+    const catalogConfig = buildPluginCatalogConfig(ctx, provider);
     const resolveCatalogProviderApiKey = (providerId?: string) => {
       const resolvedProviderId = providerId?.trim() || provider.id;
       const resolved = ctx.resolveProviderApiKey(resolvedProviderId);

--- a/src/agents/models-config.providers.runtime-headers.test.ts
+++ b/src/agents/models-config.providers.runtime-headers.test.ts
@@ -1,0 +1,191 @@
+// Verifies catalog hooks consume runtime headers without persisting plaintext.
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ProviderPlugin } from "../plugins/types.js";
+
+const discovery = vi.hoisted(() => ({ providers: new Array<ProviderPlugin>() }));
+vi.mock("../plugins/provider-discovery.runtime.js", () => ({
+  resolvePluginDiscoveryProvidersRuntime: () => discovery.providers,
+}));
+vi.mock("../plugins/provider-runtime.js", () => ({
+  normalizeProviderConfigWithPlugin: (params: { context?: { providerConfig?: object } }) =>
+    params.context?.providerConfig,
+  resolveProviderConfigApiKeyWithPlugin: () => undefined,
+  resolveProviderSyntheticAuthWithPlugin: () => undefined,
+}));
+
+beforeEach(() => {
+  discovery.providers = [];
+  vi.doUnmock("../plugins/manifest-registry.js");
+  vi.doUnmock("../secrets/provider-env-vars.js");
+});
+
+describe("models-config catalog runtime headers", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  it("passes resolved catalog headers while persisting their source markers", async () => {
+    const { planOpenClawModelsJson } = await import("./models-config.plan.js");
+    const sourceConfig = {
+      models: {
+        providers: {
+          "catalog-fixture": {
+            baseUrl: "https://catalog.example/v1",
+            api: "openai-completions",
+            apiKey: { source: "env", provider: "default", id: "CATALOG_AUTH_TOKEN" },
+            headers: {
+              "X-Catalog-Token": { source: "env", provider: "default", id: "CATALOG_TOP_TOKEN" },
+            },
+            request: {
+              headers: {
+                "X-Request-Token": {
+                  source: "env",
+                  provider: "default",
+                  id: "CATALOG_REQUEST_TOKEN",
+                },
+              },
+            },
+            models: [],
+          },
+          "other-fixture": {
+            baseUrl: "https://other.example/v1",
+            headers: {
+              "X-Other-Token": { source: "env", provider: "default", id: "CATALOG_OTHER_TOKEN" },
+            },
+            models: [],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    const runtimeConfig: OpenClawConfig = {
+      models: {
+        providers: {
+          "catalog-fixture": {
+            ...sourceConfig.models.providers["catalog-fixture"],
+            apiKey: "activated-auth-material",
+            headers: { "X-Catalog-Token": "activated-catalog-material" },
+            request: { headers: { "X-Request-Token": "activated-request-material" } },
+          },
+          "other-fixture": {
+            ...sourceConfig.models.providers["other-fixture"],
+            headers: { "X-Other-Token": "other-private-material" },
+          },
+        },
+      },
+    };
+    const before = structuredClone(sourceConfig);
+    const observed: unknown[] = [];
+    discovery.providers = [
+      {
+        id: "catalog-fixture",
+        pluginId: "catalog-fixture",
+        label: "Catalog fixture",
+        auth: [],
+        catalog: {
+          order: "simple",
+          run: async (ctx) => {
+            const provider = expectDefined(
+              ctx.config.models?.providers?.["catalog-fixture"],
+              "catalog callback provider",
+            );
+            observed.push({
+              apiKey: provider.apiKey,
+              headers: provider.headers,
+              request: provider.request,
+              otherHeaders: ctx.config.models?.providers?.["other-fixture"]?.headers,
+            });
+            return { provider: { baseUrl: provider.baseUrl, api: provider.api, models: [] } };
+          },
+        },
+      },
+    ];
+    const plan = await planOpenClawModelsJson({
+      context: {
+        cfg: sourceConfig,
+        discoveryAuthConfig: runtimeConfig,
+        sourceConfigForSecrets: sourceConfig,
+        agentDir: tempDirs.make("catalog-runtime-headers-"),
+        env: { CATALOG_TOP_TOKEN: "unactivated-env-material" },
+        envFingerprint: "catalog-runtime-headers",
+        providerDiscoveryProviderIds: ["catalog-fixture"],
+      },
+      authStore: { version: 1, profiles: {} },
+      existingRaw: "",
+      existingParsed: null,
+    });
+
+    expect(observed).toEqual([
+      {
+        apiKey: { source: "env", provider: "default", id: "CATALOG_AUTH_TOKEN" },
+        headers: { "X-Catalog-Token": "activated-catalog-material" },
+        request: { headers: { "X-Request-Token": "activated-request-material" } },
+        otherHeaders: {
+          "X-Other-Token": { source: "env", provider: "default", id: "CATALOG_OTHER_TOKEN" },
+        },
+      },
+    ]);
+    expect(plan.action).toBe("write");
+    expect(JSON.stringify(plan)).toContain("CATALOG_TOP_TOKEN");
+    expect(JSON.stringify(plan)).toContain("CATALOG_REQUEST_TOKEN");
+    expect(JSON.stringify(plan)).not.toContain("activated-catalog-material");
+    expect(JSON.stringify(plan)).not.toContain("activated-request-material");
+    expect(JSON.stringify(plan)).not.toContain("activated-auth-material");
+    expect(JSON.stringify(plan)).not.toContain("other-private-material");
+    expect(sourceConfig).toEqual(before);
+  });
+
+  it("keeps unresolved catalog headers fail-closed", async () => {
+    const { planOpenClawModelsJson } = await import("./models-config.plan.js");
+    const { normalizeResolvedSecretInputString } = await import("../config/types.secrets.js");
+    const config = {
+      models: {
+        providers: {
+          "catalog-fixture": {
+            baseUrl: "https://catalog.example/v1",
+            headers: {
+              "X-Catalog-Token": { source: "env", provider: "default", id: "CATALOG_TOP_TOKEN" },
+            },
+            models: [],
+          },
+        },
+      },
+    } satisfies OpenClawConfig;
+    discovery.providers = [
+      {
+        id: "catalog-fixture",
+        pluginId: "catalog-fixture",
+        label: "Catalog fixture",
+        auth: [],
+        catalog: {
+          order: "simple",
+          run: async (ctx) => {
+            normalizeResolvedSecretInputString({
+              value:
+                ctx.config.models?.providers?.["catalog-fixture"]?.headers?.["X-Catalog-Token"],
+              path: "models.providers.catalog-fixture.headers.X-Catalog-Token",
+            });
+            throw new Error("Unresolved catalog request was admitted");
+          },
+        },
+      },
+    ];
+
+    await expect(
+      planOpenClawModelsJson({
+        context: {
+          cfg: config,
+          discoveryAuthConfig: structuredClone(config),
+          sourceConfigForSecrets: config,
+          agentDir: tempDirs.make("catalog-unresolved-headers-"),
+          env: {},
+          envFingerprint: "catalog-unresolved-headers",
+          providerDiscoveryProviderIds: ["catalog-fixture"],
+        },
+        authStore: { version: 1, profiles: {} },
+        existingRaw: "",
+        existingParsed: null,
+      }),
+    ).rejects.toThrow("unresolved SecretRef");
+  });
+});


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where valid provider-header secret references were reported unresolved during catalog discovery even after runtime secret resolution.

## Why This Change Was Made

The shared catalog context gives the active provider hook its matching runtime headers and request settings. Source credential selection and other providers’ configuration remain separate; generated planning preserves authored secret markers.

## User Impact

Catalog discovery can use resolved headers without replacing authored references or changing credential ordering, validation or endpoint policy.

## Evidence

The actual planning/discovery callback reproduced the failure. The resolved-runtime case and genuine-unresolved control passed after the fix, along with 95 authentication/provenance tests, 11 persistence tests and four header controls. A source command made authenticated requests to a synthetic service and listed the returned model while preserving references. Earlier Gateway attempts stopped at loader setup; no external provider account or inference was tested.
