### PR TITLE
refactor(gateway): separate embeddings lifetime from HTTP

### DIFF
--- a/src/gateway/embeddings-http.test.ts
+++ b/src/gateway/embeddings-http.test.ts
@@ -63,7 +63,7 @@ let embedBatchMock: ReturnType<
 >;
 let closeEmbeddingProviderMock: ReturnType<typeof vi.fn<() => Promise<void> | void>>;
 let openAiAdapter: MemoryEmbeddingProviderAdapter;
-let drainRetainedOpenAiEmbeddingProviders: typeof import("./embeddings-http.js").drainRetainedOpenAiEmbeddingProviders;
+let drainRetainedOpenAiEmbeddingProviders: typeof import("./embeddings-provider-lifetime.js").drainRetainedOpenAiEmbeddingProviders;
 let clearEmbeddingProviders: typeof import("../plugins/embedding-providers.js").clearEmbeddingProviders;
 let registerEmbeddingProvider: typeof import("../plugins/embedding-providers.js").registerEmbeddingProvider;
 let enabledServer: Awaited<ReturnType<typeof startOpenAiCompatGatewayServer>>;
@@ -135,7 +135,7 @@ async function startGenericEmbeddingServer(): Promise<{
 }
 
 beforeAll(async () => {
-  ({ drainRetainedOpenAiEmbeddingProviders } = await import("./embeddings-http.js"));
+  ({ drainRetainedOpenAiEmbeddingProviders } = await import("./embeddings-provider-lifetime.js"));
   ({ clearEmbeddingProviders, registerEmbeddingProvider } =
     await import("../plugins/embedding-providers.js"));
   embedBatchMock = vi.fn(async (inputs: EmbeddingInput[]) =>

--- a/src/gateway/embeddings-http.ts
+++ b/src/gateway/embeddings-http.ts
@@ -19,6 +19,10 @@ import type { MemoryEmbeddingProvider } from "../plugins/memory-embedding-provid
 import type { AuthRateLimiter } from "./auth-rate-limit.js";
 import type { ResolvedGatewayAuth } from "./auth.js";
 import {
+  acquireEmbeddingProviderLease,
+  closeEmbeddingProvider,
+} from "./embeddings-provider-lifetime.js";
+import {
   parseGatewayJsonRequest,
   sendInvalidRequest,
   sendJson,
@@ -65,121 +69,6 @@ type MemorySearchEmbeddingConfig = Pick<
   NonNullable<ReturnType<typeof resolveMemorySearchConfig>>,
   "local" | "remote" | "inputType" | "queryInputType" | "documentInputType"
 >;
-
-const EMBEDDING_PROVIDER_RETIREMENTS = new Map<string, Set<MemoryEmbeddingProvider>>();
-const EMBEDDING_PROVIDER_ADMISSION_TAILS = new Map<string, Promise<void>>();
-
-async function acquireEmbeddingProviderLease(
-  scopeKey: string,
-  signal: AbortSignal,
-  create: () => Promise<MemoryEmbeddingProvider>,
-  holdForCleanup: (provider: MemoryEmbeddingProvider) => boolean,
-): Promise<{ provider: MemoryEmbeddingProvider; release: () => void }> {
-  const previous = EMBEDDING_PROVIDER_ADMISSION_TAILS.get(scopeKey) ?? Promise.resolve();
-  const createLease = async () => {
-    signal.throwIfAborted();
-    await drainEmbeddingProviderRetirements(scopeKey);
-    // Keep the cleanup fence intact, but do not create a provider for an aborted waiter.
-    signal.throwIfAborted();
-    const provider = await create();
-    if (signal.aborted) {
-      await closeEmbeddingProvider(scopeKey, provider);
-      signal.throwIfAborted();
-    }
-    if (!holdForCleanup(provider)) {
-      return { provider, lifecycle: Promise.resolve(), release: () => {} };
-    }
-    let release: () => void = () => {};
-    const lifecycle = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    return { provider, lifecycle, release };
-  };
-  const acquired = previous.then(createLease, createLease);
-  const tail = acquired
-    .then(async ({ lifecycle }) => await lifecycle)
-    .then(
-      () => undefined,
-      () => undefined,
-    );
-  EMBEDDING_PROVIDER_ADMISSION_TAILS.set(scopeKey, tail);
-  void tail.then(() => {
-    if (EMBEDDING_PROVIDER_ADMISSION_TAILS.get(scopeKey) === tail) {
-      EMBEDDING_PROVIDER_ADMISSION_TAILS.delete(scopeKey);
-    }
-  });
-  const { provider, release } = await acquired;
-  return { provider, release };
-}
-
-async function drainEmbeddingProviderRetirements(scopeKey: string): Promise<void> {
-  const pending = EMBEDDING_PROVIDER_RETIREMENTS.get(scopeKey);
-  if (!pending || pending.size === 0) {
-    return;
-  }
-  let firstError: unknown;
-  let closeFailed = false;
-  for (const provider of pending) {
-    try {
-      await provider.close?.();
-      pending.delete(provider);
-    } catch (err) {
-      if (!closeFailed) {
-        firstError = err;
-      }
-      closeFailed = true;
-    }
-  }
-  if (pending.size === 0) {
-    EMBEDDING_PROVIDER_RETIREMENTS.delete(scopeKey);
-  }
-  if (closeFailed) {
-    throw firstError;
-  }
-}
-
-function retainEmbeddingProviderForRetirement(
-  scopeKey: string,
-  provider: MemoryEmbeddingProvider,
-): void {
-  const pending = EMBEDDING_PROVIDER_RETIREMENTS.get(scopeKey) ?? new Set();
-  pending.add(provider);
-  EMBEDDING_PROVIDER_RETIREMENTS.set(scopeKey, pending);
-}
-
-async function closeEmbeddingProvider(
-  scopeKey: string,
-  provider: MemoryEmbeddingProvider,
-): Promise<void> {
-  try {
-    await provider.close?.();
-  } catch (closeErr) {
-    retainEmbeddingProviderForRetirement(scopeKey, provider);
-    logWarn(`openai-compat: failed to close embeddings provider: ${formatErrorMessage(closeErr)}`);
-  }
-}
-
-export async function drainRetainedOpenAiEmbeddingProviders(): Promise<void> {
-  const activeLifecycles = Array.from(EMBEDDING_PROVIDER_ADMISSION_TAILS.values());
-  if (activeLifecycles.length > 0) {
-    await Promise.allSettled(activeLifecycles);
-  }
-  let firstError: unknown;
-  let closeFailed = false;
-  for (const scopeKey of Array.from(EMBEDDING_PROVIDER_RETIREMENTS.keys())) {
-    try {
-      await drainEmbeddingProviderRetirements(scopeKey);
-    } catch (err) {
-      if (!closeFailed) {
-        firstError = err;
-      }
-      closeFailed = true;
-    }
-  }
-  if (closeFailed) {
-    throw firstError;
-  }
-}
 
 function resolveInputTexts(input: unknown): string[] | null {
   if (typeof input === "string") {

--- a/src/gateway/embeddings-provider-lifetime.ts
+++ b/src/gateway/embeddings-provider-lifetime.ts
@@ -1,0 +1,118 @@
+import { formatErrorMessage } from "../infra/errors.js";
+import { logWarn } from "../logger.js";
+import type { MemoryEmbeddingProvider } from "../plugins/memory-embedding-providers.js";
+
+const EMBEDDING_PROVIDER_RETIREMENTS = new Map<string, Set<MemoryEmbeddingProvider>>();
+const EMBEDDING_PROVIDER_ADMISSION_TAILS = new Map<string, Promise<void>>();
+
+export async function acquireEmbeddingProviderLease(
+  scopeKey: string,
+  signal: AbortSignal,
+  create: () => Promise<MemoryEmbeddingProvider>,
+  holdForCleanup: (provider: MemoryEmbeddingProvider) => boolean,
+): Promise<{ provider: MemoryEmbeddingProvider; release: () => void }> {
+  const previous = EMBEDDING_PROVIDER_ADMISSION_TAILS.get(scopeKey) ?? Promise.resolve();
+  const createLease = async () => {
+    signal.throwIfAborted();
+    await drainEmbeddingProviderRetirements(scopeKey);
+    // Keep the cleanup fence intact, but do not create a provider for an aborted waiter.
+    signal.throwIfAborted();
+    const provider = await create();
+    if (signal.aborted) {
+      await closeEmbeddingProvider(scopeKey, provider);
+      signal.throwIfAborted();
+    }
+    if (!holdForCleanup(provider)) {
+      return { provider, lifecycle: Promise.resolve(), release: () => {} };
+    }
+    let release: () => void = () => {};
+    const lifecycle = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    return { provider, lifecycle, release };
+  };
+  const acquired = previous.then(createLease, createLease);
+  const tail = acquired
+    .then(async ({ lifecycle }) => await lifecycle)
+    .then(
+      () => undefined,
+      () => undefined,
+    );
+  EMBEDDING_PROVIDER_ADMISSION_TAILS.set(scopeKey, tail);
+  void tail.then(() => {
+    if (EMBEDDING_PROVIDER_ADMISSION_TAILS.get(scopeKey) === tail) {
+      EMBEDDING_PROVIDER_ADMISSION_TAILS.delete(scopeKey);
+    }
+  });
+  const { provider, release } = await acquired;
+  return { provider, release };
+}
+
+async function drainEmbeddingProviderRetirements(scopeKey: string): Promise<void> {
+  const pending = EMBEDDING_PROVIDER_RETIREMENTS.get(scopeKey);
+  if (!pending || pending.size === 0) {
+    return;
+  }
+  let firstError: unknown;
+  let closeFailed = false;
+  for (const provider of pending) {
+    try {
+      await provider.close?.();
+      pending.delete(provider);
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+    }
+  }
+  if (pending.size === 0) {
+    EMBEDDING_PROVIDER_RETIREMENTS.delete(scopeKey);
+  }
+  if (closeFailed) {
+    throw firstError;
+  }
+}
+
+function retainEmbeddingProviderForRetirement(
+  scopeKey: string,
+  provider: MemoryEmbeddingProvider,
+): void {
+  const pending = EMBEDDING_PROVIDER_RETIREMENTS.get(scopeKey) ?? new Set();
+  pending.add(provider);
+  EMBEDDING_PROVIDER_RETIREMENTS.set(scopeKey, pending);
+}
+
+export async function closeEmbeddingProvider(
+  scopeKey: string,
+  provider: MemoryEmbeddingProvider,
+): Promise<void> {
+  try {
+    await provider.close?.();
+  } catch (closeErr) {
+    retainEmbeddingProviderForRetirement(scopeKey, provider);
+    logWarn(`openai-compat: failed to close embeddings provider: ${formatErrorMessage(closeErr)}`);
+  }
+}
+
+export async function drainRetainedOpenAiEmbeddingProviders(): Promise<void> {
+  const activeLifecycles = Array.from(EMBEDDING_PROVIDER_ADMISSION_TAILS.values());
+  if (activeLifecycles.length > 0) {
+    await Promise.allSettled(activeLifecycles);
+  }
+  let firstError: unknown;
+  let closeFailed = false;
+  for (const scopeKey of Array.from(EMBEDDING_PROVIDER_RETIREMENTS.keys())) {
+    try {
+      await drainEmbeddingProviderRetirements(scopeKey);
+    } catch (err) {
+      if (!closeFailed) {
+        firstError = err;
+      }
+      closeFailed = true;
+    }
+  }
+  if (closeFailed) {
+    throw firstError;
+  }
+}

--- a/src/gateway/server-close.test.ts
+++ b/src/gateway/server-close.test.ts
@@ -106,7 +106,7 @@ vi.mock("../agents/agent-bundle-lsp-runtime.js", async () => ({
   disposeAllBundleLspRuntimes: mocks.disposeAllBundleLspRuntimes,
 }));
 
-vi.mock("./embeddings-http.js", () => ({
+vi.mock("./embeddings-provider-lifetime.js", () => ({
   drainRetainedOpenAiEmbeddingProviders: mocks.drainRetainedEmbeddingProviders,
 }));
 

--- a/src/gateway/server-shutdown.runtime.test.ts
+++ b/src/gateway/server-shutdown.runtime.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from "vitest";
 const state = vi.hoisted(() => ({
   loaded: [] as string[],
   prepareClose: vi.fn(),
+  drainEmbeddingProviders: vi.fn(),
   completeClose: vi.fn(),
   flushSessionChanges: vi.fn(),
   stopPlugins: vi.fn(),
@@ -44,8 +45,11 @@ vi.mock("../agents/agent-bundle-lsp-runtime.js", () => {
   return { disposeAllBundleLspRuntimes: vi.fn() };
 });
 vi.mock("./embeddings-http.js", () => {
+  throw new Error("shutdown preparation must not load embeddings HTTP");
+});
+vi.mock("./embeddings-provider-lifetime.js", () => {
   state.loaded.push("embeddings");
-  return { drainRetainedOpenAiEmbeddingProviders: vi.fn() };
+  return { drainRetainedOpenAiEmbeddingProviders: state.drainEmbeddingProviders };
 });
 vi.mock("../hooks/gmail-watcher.js", () => {
   state.loaded.push("gmail-watcher");
@@ -90,6 +94,7 @@ describe("gateway shutdown runtime", () => {
       ].toSorted(),
     );
     expect(runtime.prepareGatewayClose).toBe(state.prepareClose);
+    expect(runtime.drainRetainedOpenAiEmbeddingProviders).toBe(state.drainEmbeddingProviders);
     expect(runtime.completeGatewayClose).toBe(state.completeClose);
     expect(runtime.flushPendingSessionsChangedEvents).toBe(state.flushSessionChanges);
     expect(runtime.runGlobalGatewayStopSafely).toBe(state.stopPlugins);

--- a/src/gateway/server-shutdown.runtime.ts
+++ b/src/gateway/server-shutdown.runtime.ts
@@ -25,7 +25,7 @@ export async function prepareGatewayShutdownRuntime() {
     import("../tasks/task-registry.maintenance.js"),
     import("../agents/main-session-recovery/main-session-restart-recovery.js"),
     import("../agents/agent-bundle-lsp-runtime.js"),
-    import("./embeddings-http.js"),
+    import("./embeddings-provider-lifetime.js"),
     import("../hooks/gmail-watcher.js"),
     import("../agents/code-mode-state.js"),
     import("../agents/provider-transport-dispatcher-pool.js"),


### PR DESCRIPTION
## What Problem This Solves

Gateway startup prepares shutdown dependencies while the installation is healthy, so an in-place update cannot strand cleanup on missing chunks. That preparation also loads the embeddings HTTP request module even when the endpoint is never used.

## Why This Change Was Made

Move the existing embeddings admission, retirement, close, and drain state into one lightweight lifetime owner. HTTP requests and shutdown share that owner. Shutdown dependencies are still prepared and retained eagerly; there is no teardown-time import, duplicate state owner, or compatibility wrapper.

The compiled lifetime body and remaining HTTP body are unchanged. Request validation, routing, provider selection, abort/close ordering, and error handling remain intact. The change adds 7 production lines and 5 test lines for the import boundary and its preservation test. The local compiled HTTP/lifetime/facade total grows by 670 bytes; this is not a bundle-size reduction.

## User Impact

Gateways no longer initialize the embeddings HTTP module solely to prepare its cleanup. The first embeddings request pays the deferred initialization cost. This is a bounded ownership/import cleanup, with small measured startup savings and a slower first request—not evidence of a general Gateway speedup.

## Evidence

- 119 baseline and 119 candidate tests pass across the embeddings and shutdown owners; all 29 normal changed checks pass.
- Both normal full builds pass. Compiled import/export inspection verifies one shared lifetime state owner and preserved eager shutdown preparation. Fresh Codex review through P2 is scoped-clean with no findings (0.98 confidence).
- Twelve actual compiled Gateway lifetimes using the existing synthetic loopback backend complete startup, three HTTP requests each, and natural shutdown. All 36 downstream responses and 36 upstream request journals match the complete expected model/input/dimensions/vector/usage contracts. This backend is synthetic, not real OpenAI.
- Twenty-four separate import-control children and two loader diagnostics complete. Diagnostics confirm the HTTP owner is absent from candidate shutdown preparation; their timings are excluded from numerical comparisons. All 38 native receipts report successful closure.

Fixed B0/C0/C1/B1 order, with three fresh samples per cell. Candidate-versus-baseline median changes:

| Measurement | Forward pair | Reverse pair |
| --- | ---: | ---: |
| Gateway readiness | −0.83% | −0.36% |
| Shutdown-preparation startup trace | −2.52% | −1.05% |
| First full embeddings HTTP request | **+2.15% slower** | **+11.02% slower** |
| Gateway spawn → first complete HTTP response | −0.82% | −0.26% |
| Actual close-total trace | −8.57% | −9.38% |

The first-request regressions are about 0.57 ms and 2.74 ms. Both startup-plus-first-response improvements are **under 1%**. Standalone cold preparation medians improve 0.73%/1.61%, while the later HTTP import shifts from about 0.025 ms to 3.8–3.9 ms. HTTP-first preparation controls are slightly slower. Shared config/Zod dependencies still load through other preparation paths.

The full audit retains **169 adverse comparisons out of 400** primary timing/resource statistics, including **54 adverse native-resource comparisons out of 120**; 37 of 100 median comparisons are adverse. All original samples and mean/median/min/max reductions remain included. Gateway-host median system CPU increases in both orders, and the forward pair's peak RSS increases. Whole-child resource measurements include the host, synthetic backend, checks, imports, and cleanup; they are not isolated Gateway CPU measurements.

An unrelated same-host Git fast-forward pull overlapped B1 and remains a possible I/O confound. Three-sample medians, warm filesystem contents, and changed import placement limit attribution; no significance or tail-latency claim is made. No admitted outcome was removed or repeated. The synthetic adapter does not exercise a nonempty local-provider close obligation; existing lifecycle/error tests cover that boundary.

The separate real-OpenAI 18-turn campaign baseline is preserved. Its final campaign-wide real-OpenAI run is still pending and is not claimed as evidence for this PR's latency results.


## Review follow-through

The automated data-model compatibility flag does not identify a persisted-data change in this diff. The extracted owner contains only two process-local maps holding live provider references and admission promises. Their keys, value types, admission/retirement logic, and cleanup ordering are moved unchanged; neither map is serialized or restored across processes. No SQLite schema, vector-store format, embedding metadata representation, migration, or configuration field changes.

No data migration applies. Request and response representations remain in the unchanged HTTP body, and both builds plus all 36 complete response/request pairs preserve their model, dimensions, input type, vector values, and usage fields. The existing eager shutdown-preparation contract remains: cleanup functions are captured while the installation is healthy and retained through close, without a teardown-time module import. The change only defers initialization of the HTTP request module until that endpoint is used.
