### PR TITLE
fix: keep the Mentions Inbox across Gateway restarts

### DIFF
--- a/docs/concepts/multi-user.md
+++ b/docs/concepts/multi-user.md
@@ -135,13 +135,15 @@ The picker includes known Gateway profiles eligible to read the session, includi
 
 Mentions work for ordinary messages, queued or steered input, and the first message of a new session, including a remotely placed session. They are unavailable in incognito, Goal, catalog, suggestion-only, command-send, or terminal-launch modes. If selected mentions remain after switching to an unsupported mode, the composer blocks the send and asks you to remove them or return to a normal chat. It does not silently discard selected recipients.
 
-## Temporary mentions Inbox
+<a id="temporary-mentions-inbox" />
+
+## Mentions Inbox
 
 Open **Inbox → Mentions** to see messages addressed to your signed-in profile across accessible agents. Opening a mention opens its session without dismissing it. Select **Dismiss** to remove the entry from your Inbox; that change follows the same profile across connected browsers, without deleting the chat message.
 
-Mentions are kept in Gateway memory for **up to seven days**, with at most **100 entries per profile**. Older entries can be evicted earlier by capacity limits. Refreshing or reconnecting to the same running Gateway reloads its current Inbox. A Gateway restart, including one during an upgrade, clears it. Old transcript messages do not repopulate the Inbox after restart. This is a temporary attention list, not a durable notification archive or delivery guarantee.
+Mentions and dismissals survive Gateway restarts and upgrades. Entries keep their original identifiers and expiry times: **up to seven days**, with at most **100 entries per profile** and **10,000 across the Gateway**. Older entries can be evicted earlier by capacity limits. Refreshing or reconnecting reloads the retained Inbox without resending old browser alerts. Old transcript messages are not scanned to rebuild missing entries.
 
-Human mentions add no SQLite tables, columns, or schema migration. The Inbox and its dismissals stay in memory; mention annotations use the existing message JSON, and notification preferences use existing preference records.
+The Inbox and its replay bookkeeping use the shared database's existing machine-state records, with no SQLite schema change. Mention annotations stay in the existing message JSON, and notification preferences use existing preference records. See [Inbox storage and retention](/reference/database-schemas#mentions-inbox).
 
 The Inbox works without browser notification permission. For optional alerts while away from the Control UI, enable **Someone mentions me** in [Notifications](/web/notifications#receive-human-mention-alerts). See [WebChat](/web/webchat#human-mention-delivery) for the send and retry contract.
 

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -20,6 +20,22 @@ OpenClaw stores control-plane state in a global SQLite database and agent data i
 
 The task registry uses the global control-plane database. Runtime trajectory events live with their sessions in the per-agent database or a configured shared session SQLite store.
 
+### Mentions Inbox
+
+The [mentions Inbox](/concepts/multi-user#temporary-mentions-inbox) uses existing
+`config_machine_state` rows in `state/openclaw.sqlite`.
+`notifications.mentions.source.*` records retain typed source identities,
+recipients, mention identifiers, expiry times, and dismissal bookkeeping;
+`notifications.mentions.head` records the revision and sequence. Writes use the
+existing table and primary key, with no new tables, columns, indexes, or schema
+version change.
+
+Retention remains seven days from creation, capped at 100 entries per profile,
+10,000 entries globally, and 10,000 source identities for duplicate suppression.
+Restarts preserve retained entries, dismissals, and their original expiry times.
+Loading stored state does not replay browser notifications or scan transcripts
+to reconstruct old mentions.
+
 ### ACP replay accounting
 
 The shared `acp_replay_sessions` and `acp_replay_events` tables retain bridge

--- a/docs/web/notifications.md
+++ b/docs/web/notifications.md
@@ -69,7 +69,7 @@ After subscribing in a supported browser or installed Control UI PWA, turn on **
 
 Only browsers bound to the mentioned profile receive the alert. Each delivery rechecks the device, current profile and role, read scope, and session visibility, then applies the category setting, quiet hours, and agent filter. Being online is not required. With **Private** detail, the alert says only that someone mentioned you in a conversation; **Names only** and **Detailed** may include the sanitized sender and session labels, never the message excerpt. Selecting it opens the session through the normal authenticated Control UI route.
 
-Your [mentions Inbox](/concepts/multi-user#temporary-mentions-inbox) does not depend on Web Push permission or this setting. Opening the Inbox or reconnecting does not resend its old entries as browser notifications. The service worker displays browser alerts; the live Inbox update does not create a second OS notification. Human mention alerts are not implemented through the native macOS or iOS/Android push paths.
+Your [mentions Inbox](/concepts/multi-user#temporary-mentions-inbox) does not depend on Web Push permission or this setting. Its entries and dismissals survive Gateway restarts within the seven-day retention window. Opening the Inbox, reconnecting, or restarting the Gateway does not resend old entries as browser notifications. The service worker displays browser alerts; the live Inbox update does not create a second OS notification. Human mention alerts are not implemented through the native macOS or iOS/Android push paths.
 
 To verify targeting, have another eligible signed-in person select you from the chat `@` picker and send a normal message. Check **Inbox → Mentions**, then check the enabled browser alert. **Send test** only checks browser push transport and can reach every registered subscription; it does not prove that a human mention was selected, committed, or addressed to your profile. Delivery is best-effort, not an exactly-once guarantee.
 
@@ -134,7 +134,7 @@ For a single PWA that switches among Gateways, also verify that every Gateway us
 
 Confirm the sender selected your profile from the picker rather than only typing your name, and that the original message reached the transcript. Sign in with the same profile and check that you still have access to the session. Incognito, Goal, catalog, suggestion-only, and command-send modes do not support human mentions.
 
-If the entry is in **Inbox → Mentions**, check this browser's subscription, **Someone mentions me**, quiet hours, mute overrides, and agent filter. An Inbox entry does not imply permission to display a browser notification. If the entry disappeared, it may have been dismissed from another browser using your profile, expired, evicted, or cleared by a Gateway restart. The retained chat message is independent of that temporary Inbox entry.
+If the entry is in **Inbox → Mentions**, check this browser's subscription, **Someone mentions me**, quiet hours, mute overrides, and agent filter. An Inbox entry does not imply permission to display a browser notification. If the entry disappeared, it may have been dismissed from another browser using your profile, expired, evicted, or become inaccessible after a session access change. Gateway restarts preserve retained entries and dismissals. The retained chat message is independent of the Inbox entry; entries already lost before durable storage was introduced are not recovered from old messages.
 
 ## Related
 

--- a/docs/web/webchat.md
+++ b/docs/web/webchat.md
@@ -89,7 +89,7 @@ The supporting RPCs require `operator.read` and use the authenticated profile, n
 | `mentions.dismiss`  | Pass `{ ids }` containing up to 100 distinct visible entry ids. Returns the same snapshot shape after dismissal.                                                                                                                           |
 | `mentions.changed`  | Targeted `{ gatewayInstanceId, revision }` invalidation; fetch `mentions.list` again. Revisions describe that connection's authorized view, not global Gateway activity.                                                                   |
 
-Delivery is best-effort. The Inbox and replay bookkeeping are bounded and process-local; a restart clears them, and capacity limits can skip alerts. Notification failures do not retry or undo the posted chat message. Browser push does not provide exactly-once delivery. See [temporary Inbox retention](/concepts/multi-user#temporary-mentions-inbox) and [notification preferences](/web/notifications#receive-human-mention-alerts).
+Delivery is best-effort. The Inbox and replay bookkeeping survive Gateway restarts within their retention limits; capacity limits can still skip alerts. Restarting or reconnecting does not resend old browser notifications or restore dismissed entries. Notification failures do not retry or undo the posted chat message. Browser push does not provide exactly-once delivery. See [Inbox retention](/concepts/multi-user#temporary-mentions-inbox) and [notification preferences](/web/notifications#receive-human-mention-alerts).
 
 ## Control UI agents tools panel
 

--- a/src/gateway/mention-inbox-store.ts
+++ b/src/gateway/mention-inbox-store.ts
@@ -1,0 +1,182 @@
+import type { DatabaseSync } from "node:sqlite";
+import { z } from "zod";
+import { MAX_HUMAN_MENTIONS } from "../../packages/gateway-protocol/src/index.js";
+import {
+  executeSqliteQuerySync,
+  executeSqliteQueryTakeFirstSync,
+  getNodeSqliteKysely,
+} from "../infra/kysely-sync.js";
+import { runSqliteDeferredTransactionSync } from "../infra/sqlite-transaction.js";
+import type { ConfigMachineStateDatabase } from "../state/config-machine-state.js";
+import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
+
+export const MENTION_RETENTION_MS = 7 * 24 * 60 * 60_000;
+export const MAX_MENTION_SOURCES = 10_000;
+
+const HEAD_KEY = "notifications.mentions.head";
+const SOURCE_PREFIX = "notifications.mentions.source.";
+const SOURCE_END = "notifications.mentions.source/";
+const reference = z.string().min(1).max(256);
+const timestamp = z.number().int().nonnegative().max(Number.MAX_SAFE_INTEGER);
+const headSchema = z.object({ revision: timestamp, nextSequence: timestamp });
+const messageSchema = z.object({
+  sessionId: reference,
+  content: z.object({
+    senderProfileId: reference,
+    sessionKey: z.string().min(1).max(512),
+    agentId: reference,
+    messageId: reference,
+    createdAt: timestamp,
+    excerpt: z.string().max(280).optional(),
+  }),
+});
+const sourceSchema = z.object({
+  key: z.string().regex(/^[a-f0-9]{64}$/),
+  sequence: timestamp,
+  expiresAt: timestamp,
+  recipients: z.array(z.tuple([reference, reference.nullable()])).max(MAX_HUMAN_MENTIONS),
+  message: messageSchema.optional(),
+});
+
+export type MentionStoreHead = z.infer<typeof headSchema>;
+export type MentionStoreSource = z.infer<typeof sourceSchema>;
+export type MentionStoreMessage = z.infer<typeof messageSchema>;
+export type MentionStoreSnapshot = {
+  head: MentionStoreHead;
+  sources: MentionStoreSource[];
+};
+
+/** The existing machine-state primary key owns lookup; this feature creates no schema. */
+export function readMentionStoreSnapshot(
+  revision: number,
+  activeDatabase?: DatabaseSync,
+): MentionStoreSnapshot | undefined {
+  const read = (database: DatabaseSync) => {
+    const db = getNodeSqliteKysely<ConfigMachineStateDatabase>(database);
+    const headRow = executeSqliteQueryTakeFirstSync(
+      database,
+      db.selectFrom("config_machine_state").select("value_json").where("state_key", "=", HEAD_KEY),
+    );
+    const head = headRow
+      ? headSchema.parse(JSON.parse(headRow.value_json))
+      : { revision: 0, nextSequence: 0 };
+    if (head.revision === revision) {
+      return undefined;
+    }
+    const rows = executeSqliteQuerySync(
+      database,
+      db
+        .selectFrom("config_machine_state")
+        .select(["state_key", "value_json"])
+        .where("state_key", ">=", SOURCE_PREFIX)
+        .where("state_key", "<", SOURCE_END)
+        .limit(MAX_MENTION_SOURCES + 1),
+    ).rows;
+    if (rows.length > MAX_MENTION_SOURCES) {
+      throw new Error("Mention retention exceeds its source budget");
+    }
+    const ids = new Set<string>();
+    const sequences = new Set<number>();
+    let itemCount = 0;
+    const sources = rows.map((row) => {
+      // Reject unreadable state instead of overwriting it with an empty Inbox.
+      if (row.value_json.length > 32_768) {
+        throw new Error("Mention source exceeds its record budget");
+      }
+      const source = sourceSchema.parse(JSON.parse(row.value_json));
+      if (
+        row.state_key !== `${SOURCE_PREFIX}${source.key}` ||
+        source.sequence >= head.nextSequence ||
+        sequences.has(source.sequence) ||
+        new Set(source.recipients.map(([profileId]) => profileId)).size !== source.recipients.length
+      ) {
+        throw new Error("Invalid mention source identity");
+      }
+      sequences.add(source.sequence);
+      for (const [, id] of source.recipients) {
+        if (id === null) {
+          continue;
+        }
+        if (!source.message || ids.has(id)) {
+          throw new Error("Invalid retained mention");
+        }
+        ids.add(id);
+        itemCount++;
+      }
+      if (
+        source.message &&
+        source.expiresAt !== source.message.content.createdAt + MENTION_RETENTION_MS
+      ) {
+        throw new Error("Invalid mention retention window");
+      }
+      return source;
+    });
+    if (itemCount > MAX_MENTION_SOURCES) {
+      throw new Error("Mention retention exceeds its item budget");
+    }
+    return { head, sources: sources.toSorted((left, right) => left.sequence - right.sequence) };
+  };
+  if (activeDatabase) {
+    return read(activeDatabase);
+  }
+  const result = withExistingOpenClawStateDatabaseReadOnly(({ db }) => ({
+    snapshot: runSqliteDeferredTransactionSync(db, () => read(db), {
+      operationLabel: "mentions.read",
+    }),
+  }));
+  return result
+    ? result.snapshot
+    : revision === 0
+      ? undefined
+      : { head: { revision: 0, nextSequence: 0 }, sources: [] };
+}
+
+/** Called inside the admitting Inbox's synchronous shared-state write transaction. */
+export function writeMentionStoreChanges(
+  database: DatabaseSync,
+  head: MentionStoreHead,
+  changes: ReadonlyMap<string, MentionStoreSource | undefined>,
+): MentionStoreHead {
+  if (changes.size === 0) {
+    return head;
+  }
+  const next = headSchema.parse({ ...head, revision: head.revision + 1 });
+  const db = getNodeSqliteKysely<ConfigMachineStateDatabase>(database);
+  const updatedAtMs = Date.now();
+  for (const [key, source] of changes) {
+    const stateKey = `${SOURCE_PREFIX}${key}`;
+    if (!source) {
+      executeSqliteQuerySync(
+        database,
+        db.deleteFrom("config_machine_state").where("state_key", "=", stateKey),
+      );
+      continue;
+    }
+    const valueJson = JSON.stringify(source);
+    executeSqliteQuerySync(
+      database,
+      db
+        .insertInto("config_machine_state")
+        .values({ state_key: stateKey, value_json: valueJson, updated_at_ms: updatedAtMs })
+        .onConflict((conflict) =>
+          conflict.column("state_key").doUpdateSet({
+            value_json: valueJson,
+            updated_at_ms: updatedAtMs,
+          }),
+        ),
+    );
+  }
+  executeSqliteQuerySync(
+    database,
+    db
+      .insertInto("config_machine_state")
+      .values({ state_key: HEAD_KEY, value_json: JSON.stringify(next), updated_at_ms: updatedAtMs })
+      .onConflict((conflict) =>
+        conflict.column("state_key").doUpdateSet({
+          value_json: JSON.stringify(next),
+          updated_at_ms: updatedAtMs,
+        }),
+      ),
+  );
+  return next;
+}

--- a/src/gateway/mention-inbox.test.ts
+++ b/src/gateway/mention-inbox.test.ts
@@ -8,6 +8,7 @@ import type { SessionEntry } from "../config/sessions.js";
 import { upsertSessionEntryCore } from "../config/sessions/session-accessor.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { emitSessionIdentityMutation } from "../sessions/session-lifecycle-events.js";
+import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import {
   ensureGatewayOwnerProfile,
   ensureProfileForEmail,
@@ -27,26 +28,27 @@ import { usersMentionableHandlers } from "./server-methods/users-mentionable.js"
 const SESSION_KEY = "agent:main:dashboard:mention-test";
 const SESSION_ID = "mention-test-session";
 const handlers = { ...mentionHandlers, ...usersMentionableHandlers };
+type InboxFixtureOptions = { notifications?: boolean; beforeInbox?: () => void };
 
 afterEach(() => vi.useRealTimers());
 
 async function withInbox(
   run: (fixture: Awaited<ReturnType<typeof createFixture>>) => Promise<void>,
   cfg: OpenClawConfig = {},
-  options: { notifications?: boolean } = {},
+  options: InboxFixtureOptions = {},
 ) {
   await withOpenClawTestState({ scenario: "minimal" }, async () => {
     const fixture = await createFixture(cfg, options);
     try {
       await run(fixture);
     } finally {
-      fixture.inbox.dispose();
+      fixture.dispose();
       vi.useRealTimers();
     }
   });
 }
 
-async function createFixture(cfg: OpenClawConfig, options: { notifications?: boolean }) {
+async function createFixture(cfg: OpenClawConfig, options: InboxFixtureOptions) {
   const alice = ensureProfileForEmail("alice@mentions.example.test");
   const bob = ensureProfileForEmail("bob@mentions.example.test");
   const carol = ensureProfileForEmail("carol@mentions.example.test");
@@ -72,13 +74,20 @@ async function createFixture(cfg: OpenClawConfig, options: { notifications?: boo
       },
     );
   await setSession({ displayName: "Design review" });
-  const inbox = createMentionInbox({
-    gatewayInstanceId: "mention-gateway",
-    getRuntimeConfig: () => cfg,
-    getClients: () => clients,
-    broadcastToConnIds: broadcast,
-    onMentionCreated: options.notifications === false ? undefined : push,
-  });
+  const inboxes = new Set<MentionInbox>();
+  const openInbox = (gatewayInstanceId = "mention-gateway") => {
+    const inbox = createMentionInbox({
+      gatewayInstanceId,
+      getRuntimeConfig: () => cfg,
+      getClients: () => clients,
+      broadcastToConnIds: broadcast,
+      onMentionCreated: options.notifications === false ? undefined : push,
+    });
+    inboxes.add(inbox);
+    return inbox;
+  };
+  options.beforeInbox?.();
+  const inbox = openInbox();
   const context = { mentionInbox: inbox } as GatewayRequestContext;
   async function call(method: string, params: Record<string, unknown>, client = bobClient) {
     let response: { ok: boolean; payload?: unknown; error?: ErrorShape } | undefined;
@@ -115,8 +124,14 @@ async function createFixture(cfg: OpenClawConfig, options: { notifications?: boo
     broadcast,
     push,
     setSession,
-    post(sourceId = "source-one", overrides: Partial<MentionCommittedInput> = {}) {
-      inbox.recordCommittedInput({
+    openInbox,
+    dispose() {
+      for (const instance of inboxes) {
+        instance.dispose();
+      }
+    },
+    post(sourceId = "source-one", overrides: Partial<MentionCommittedInput> = {}, target = inbox) {
+      target.recordCommittedInput({
         sourceId,
         sessionKey: SESSION_KEY,
         agentId: "main",
@@ -141,6 +156,209 @@ function read(inbox: MentionInbox, client: GatewayClient) {
 }
 
 describe("temporary human mention Inbox", () => {
+  it("retains original ids, order, and expiry across Gateway restart without replaying push", async () => {
+    await withInbox(async (f) => {
+      vi.useFakeTimers();
+      f.post("first");
+      await vi.advanceTimersByTimeAsync(1_000);
+      f.post("second");
+      const retained = read(f.inbox, f.bobClient).items;
+      expect(retained.map((item) => item.messageId)).toEqual(["message-second", "message-first"]);
+      f.inbox.dispose();
+      f.push.mockClear();
+      await vi.advanceTimersByTimeAsync(6 * 24 * 60 * 60_000);
+      const restarted = f.openInbox("restarted-gateway");
+
+      expect(read(restarted, f.bobClient)).toMatchObject({
+        gatewayInstanceId: "restarted-gateway",
+        items: retained,
+      });
+      f.post("first", {}, restarted);
+      f.post("second", {}, restarted);
+      expect(f.push).not.toHaveBeenCalled();
+      await vi.advanceTimersByTimeAsync(24 * 60 * 60_000 - 1_000);
+      expect(read(restarted, f.bobClient).items).toEqual([retained[0]]);
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(read(restarted, f.bobClient).items).toEqual([]);
+    });
+  });
+
+  it.each(["normal", "transient failure", "dispose after failure"] as const)(
+    "restarts expiry cleanup without a connected client or an Inbox read (%s)",
+    async (scenario) => {
+      await withInbox(async (f) => {
+        vi.useFakeTimers();
+        f.clients.length = 0;
+        const { db } = openOpenClawStateDatabase();
+        const storedSources = () =>
+          db
+            .prepare(
+              "SELECT state_key FROM config_machine_state WHERE state_key GLOB 'notifications.mentions.source.*'",
+            )
+            .all();
+        f.post("original-deadline");
+        expect(storedSources()).toHaveLength(1);
+        f.inbox.dispose();
+        await vi.advanceTimersByTimeAsync(6 * 24 * 60 * 60_000);
+        const restarted = f.openInbox("restarted-gateway");
+        expect(storedSources()).toHaveLength(1);
+        if (scenario !== "normal") {
+          db.exec(`CREATE TEMP TRIGGER reject_mention_expiry BEFORE DELETE ON config_machine_state
+            WHEN OLD.state_key GLOB 'notifications.mentions.source.*'
+            BEGIN SELECT RAISE(ABORT, 'synthetic mention expiry failure'); END`);
+        }
+        try {
+          await vi.advanceTimersByTimeAsync(24 * 60 * 60_000);
+          expect(storedSources()).toHaveLength(scenario === "normal" ? 0 : 1);
+        } finally {
+          if (scenario !== "normal") {
+            db.exec("DROP TRIGGER reject_mention_expiry");
+          }
+        }
+        if (scenario !== "normal") {
+          if (scenario === "dispose after failure") {
+            restarted.dispose();
+          }
+          await vi.advanceTimersByTimeAsync(60_000);
+          expect(storedSources()).toHaveLength(scenario === "dispose after failure" ? 1 : 0);
+          if (scenario === "dispose after failure") {
+            f.openInbox("next-gateway");
+            expect(storedSources()).toEqual([]);
+          }
+        }
+        expect(f.push).toHaveBeenCalledTimes(1);
+      });
+    },
+  );
+
+  it("keeps dismissed and evicted sources consumed across restart", async () => {
+    await withInbox(async (f) => {
+      f.clients.length = 0;
+      for (let index = 0; index < 101; index++) {
+        f.post(`retained-${index}`);
+      }
+      const retained = read(f.inbox, f.bobClient).items;
+      expect(retained).toHaveLength(100);
+      expect(retained.at(-1)?.messageId).toBe("message-retained-1");
+      expect(f.inbox.dismiss(f.bobClient, [retained[0]!.id]).ok).toBe(true);
+      const expected = retained.slice(1);
+      f.inbox.dispose();
+      f.push.mockClear();
+      const restarted = f.openInbox("restarted-gateway");
+
+      expect(read(restarted, f.bobClient).items).toEqual(expected);
+      for (const source of ["retained-0", "retained-100", "retained-50"]) {
+        f.post(source, {}, restarted);
+      }
+      expect(read(restarted, f.bobClient).items).toEqual(expected);
+      expect(f.push).not.toHaveBeenCalled();
+    });
+  });
+
+  it("merges alternating owners' writes without resurrecting dismissals or losing new input", async () => {
+    await withInbox(async (f) => {
+      vi.useFakeTimers();
+      f.post("first");
+      const first = read(f.inbox, f.bobClient).items[0]!;
+      const peer = f.openInbox("peer-gateway");
+      expect(read(peer, f.bobClient).items).toEqual([first]);
+      expect(f.inbox.dismiss(f.bobClient, [first.id]).ok).toBe(true);
+      await vi.advanceTimersByTimeAsync(1);
+      f.post("second", {}, peer);
+      const second = read(peer, f.bobClient).items[0]!;
+      expect(read(f.inbox, f.bobClient).items).toEqual([second]);
+      await vi.advanceTimersByTimeAsync(1);
+      f.post("third");
+      const both = read(f.inbox, f.bobClient).items;
+      expect(both.map((item) => item.messageId)).toEqual(["message-third", "message-second"]);
+      expect(read(peer, f.bobClient).items).toEqual(both);
+      expect(peer.dismiss(f.bobClient, [second.id]).ok).toBe(true);
+      expect(read(f.inbox, f.bobClient).items).toEqual([both[0]]);
+      expect(f.push.mock.calls[0]?.[0].isCurrent()).toBe(false);
+      expect(f.push.mock.calls[1]?.[0].isCurrent()).toBe(false);
+      f.inbox.dispose();
+      peer.dispose();
+      f.push.mockClear();
+      const restarted = f.openInbox("restarted-gateway");
+
+      f.post("first", {}, restarted);
+      f.post("second", {}, restarted);
+      expect(read(restarted, f.bobClient).items).toEqual([both[0]]);
+      expect(f.push).not.toHaveBeenCalled();
+    });
+  });
+
+  it("persists entries and dismissal without changing sqlite_schema or user_version", async () => {
+    const schema = () => {
+      const { db } = openOpenClawStateDatabase();
+      return {
+        schema: db.prepare("SELECT * FROM sqlite_schema ORDER BY type, name").all(),
+        userVersion: db.prepare("PRAGMA user_version").get(),
+      };
+    };
+    let before: ReturnType<typeof schema> | undefined;
+    await withInbox(
+      async (f) => {
+        f.post("dismissed");
+        f.post("retained");
+        const original = read(f.inbox, f.bobClient).items;
+        expect(f.inbox.dismiss(f.bobClient, [original[1]!.id]).ok).toBe(true);
+        f.inbox.dispose();
+        const restarted = f.openInbox("restarted-gateway");
+        expect(read(restarted, f.bobClient).items).toEqual([original[0]]);
+        expect(schema()).toEqual(before);
+      },
+      {},
+      { beforeInbox: () => (before = schema()) },
+    );
+  });
+
+  it.each(["dismissal", "new input"] as const)(
+    "retains committed state and withholds push when storage rejects %s",
+    async (operation) => {
+      await withInbox(async (f) => {
+        f.post("original");
+        const retained = read(f.inbox, f.bobClient).items;
+        const { db } = openOpenClawStateDatabase();
+        for (const action of ["INSERT", "UPDATE", "DELETE"]) {
+          db.exec(`CREATE TEMP TRIGGER reject_mention_${action} BEFORE ${action} ON config_machine_state
+            WHEN ${action === "DELETE" ? "OLD" : "NEW"}.state_key LIKE 'notifications.mentions.%'
+            BEGIN SELECT RAISE(ABORT, 'synthetic mention write failure'); END`);
+        }
+        f.push.mockClear();
+        f.broadcast.mockClear();
+        try {
+          if (operation === "dismissal") {
+            expect(f.inbox.dismiss(f.bobClient, [retained[0]!.id])).toMatchObject({
+              ok: false,
+              error: { code: "UNAVAILABLE" },
+            });
+          } else {
+            expect(() => f.post("retryable-source")).not.toThrow();
+          }
+          expect(read(f.inbox, f.bobClient).items).toEqual(retained);
+          expect(f.push).not.toHaveBeenCalled();
+          expect(f.broadcast).not.toHaveBeenCalled();
+        } finally {
+          for (const action of ["INSERT", "UPDATE", "DELETE"]) {
+            db.exec(`DROP TRIGGER reject_mention_${action}`);
+          }
+        }
+        f.inbox.dispose();
+        const restarted = f.openInbox("restarted-gateway");
+        expect(read(restarted, f.bobClient).items).toEqual(retained);
+        if (operation === "dismissal") {
+          expect(restarted.dismiss(f.bobClient, [retained[0]!.id]).ok).toBe(true);
+          expect(read(restarted, f.bobClient).items).toEqual([]);
+        } else {
+          f.post("retryable-source", {}, restarted);
+          expect(read(restarted, f.bobClient).items).toHaveLength(2);
+          expect(f.push).toHaveBeenCalledTimes(1);
+        }
+      });
+    },
+  );
+
   it("targets only the named person, synchronizes dismissal, and does not replay consumed input", async () => {
     await withInbox(async (f) => {
       for (const client of f.clients) {
@@ -237,30 +455,45 @@ describe("temporary human mention Inbox", () => {
     });
   });
 
-  it("retains acknowledgement across profile merges and projects current sender labels", async () => {
-    await withInbox(async (f) => {
-      const old = ensureProfileForEmail("bob-old@mentions.example.test");
-      const oldClient = { ...identifiedClient(old.id, "Bob"), connId: "old-bob" };
-      f.clients.push(oldClient);
-      f.post("two-profiles", { recipientProfileIds: [old.id, f.bob.id] });
-      const item = read(f.inbox, oldClient).items[0];
-      if (!item) {
-        throw new Error("Old profile did not receive the mention");
-      }
-      f.inbox.dismiss(oldClient, [item.id]);
-      linkEmail("bob-old@mentions.example.test", f.bob.id);
-      await Promise.resolve();
-      expect(read(f.inbox, f.bobClient).items).toEqual([]);
-      expect(read(f.inbox, oldClient).items).toEqual([]);
-      f.post("two-profiles", { recipientProfileIds: [old.id, f.bob.id] });
-      expect(f.push).toHaveBeenCalledTimes(2);
-      f.post("after-merge", { recipientProfileIds: [old.id, f.bob.id] });
-      expect(read(f.inbox, oldClient).items).toHaveLength(1);
-      setDisplayName(f.alice.id, "Alice Updated");
-      await Promise.resolve();
-      expect(read(f.inbox, f.bobClient).items[0]?.senderLabel).toBe("Alice Updated");
-    });
-  });
+  it.each([true, false])(
+    "retains acknowledgement across profile merges and projects current sender labels (dismissed first: %s)",
+    async (dismissedFirst) => {
+      await withInbox(async (f) => {
+        const old = ensureProfileForEmail("bob-old@mentions.example.test");
+        const oldClient = { ...identifiedClient(old.id, "Bob"), connId: "old-bob" };
+        const recipientProfileIds = dismissedFirst ? [old.id, f.bob.id] : [f.bob.id, old.id];
+        f.clients.push(oldClient);
+        f.post("two-profiles", { recipientProfileIds });
+        const item = read(f.inbox, oldClient).items[0];
+        if (!item) {
+          throw new Error("Old profile did not receive the mention");
+        }
+        f.inbox.dismiss(oldClient, [item.id]);
+        linkEmail("bob-old@mentions.example.test", f.bob.id);
+        await Promise.resolve();
+        expect(read(f.inbox, f.bobClient).items).toEqual([]);
+        expect(read(f.inbox, oldClient).items).toEqual([]);
+        f.post("two-profiles", { recipientProfileIds });
+        expect(f.push).toHaveBeenCalledTimes(2);
+        f.post("after-merge", { recipientProfileIds });
+        expect(read(f.inbox, oldClient).items).toHaveLength(1);
+        setDisplayName(f.alice.id, "Alice Updated");
+        await Promise.resolve();
+        const retained = read(f.inbox, f.bobClient).items;
+        expect(retained[0]?.senderLabel).toBe("Alice Updated");
+        f.inbox.dispose();
+        f.push.mockClear();
+        const restarted = f.openInbox("restarted-gateway");
+
+        expect(read(restarted, f.bobClient).items).toEqual(retained);
+        expect(read(restarted, oldClient).items).toEqual(retained);
+        f.post("two-profiles", { recipientProfileIds }, restarted);
+        f.post("after-merge", { recipientProfileIds }, restarted);
+        expect(read(restarted, f.bobClient).items).toEqual(retained);
+        expect(f.push).not.toHaveBeenCalled();
+      });
+    },
+  );
 
   it("keeps recipients independent when they share a committed message", async () => {
     await withInbox(async (f) => {
@@ -522,6 +755,7 @@ describe("human mention directory", () => {
       sessionKey: SESSION_KEY,
       entry: { visibility: "draft" },
       visible: true,
+      storedSources: 1,
     },
     {
       name: "owner-only recipient of a shared session",
@@ -529,6 +763,7 @@ describe("human mention directory", () => {
       sessionKey: SESSION_KEY,
       entry: { visibility: "shared" },
       visible: false,
+      storedSources: 1,
     },
     {
       name: "administrator in an entry-flag incognito session",
@@ -536,6 +771,7 @@ describe("human mention directory", () => {
       sessionKey: "agent:main:dashboard:mention-incognito-flag",
       entry: { visibility: "shared", incognito: true },
       visible: false,
+      storedSources: 0,
     },
     {
       name: "administrator in a canonical-key incognito session",
@@ -543,10 +779,11 @@ describe("human mention directory", () => {
       sessionKey: "agent:main:dashboard:incognito-mention-key",
       entry: { visibility: "shared" },
       visible: false,
+      storedSources: 0,
     },
   ] as const)(
     "applies offline recipient policy across directory, admission, and delivery: $name",
-    async ({ role, sessionKey, entry, visible }) => {
+    async ({ role, sessionKey, entry, visible, storedSources }) => {
       const cfg: OpenClawConfig = {
         gateway: {
           roles: {
@@ -585,11 +822,17 @@ describe("human mention directory", () => {
           accepted: admission.ok,
           inboxKeys: read(f.inbox, f.bobClient).items.map((item) => item.sessionKey),
           pushedRecipients: f.push.mock.calls.map(([mention]) => mention.recipientProfileId),
+          storedSources: openOpenClawStateDatabase()
+            .db.prepare(
+              "SELECT state_key FROM config_machine_state WHERE state_key GLOB 'notifications.mentions.source.*'",
+            )
+            .all().length,
         }).toEqual({
           users: visible ? [[f.bob.id, false]] : [],
           accepted: visible,
           inboxKeys: visible ? [sessionKey] : [],
           pushedRecipients: visible ? [f.bob.id] : [],
+          storedSources,
         });
       }, cfg);
     },

--- a/src/gateway/mention-inbox.ts
+++ b/src/gateway/mention-inbox.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from "node:crypto";
+import type { DatabaseSync } from "node:sqlite";
 import { flattenMarkdownToPlainText } from "@openclaw/normalization-core/markdown-plain-text";
 import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
@@ -13,34 +14,39 @@ import {
 } from "../../packages/gateway-protocol/src/index.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { isIncognitoSessionKey } from "../routing/session-key.js";
 import { onSessionIdentityMutation } from "../sessions/session-lifecycle-events.js";
+import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { onUserProfilesChanged, readUserProfileVersion } from "../state/user-profile-events.js";
 import { createHumanMentionPolicy, humanMentionDisplayLabel } from "./human-mention-policy.js";
+import {
+  MAX_MENTION_SOURCES,
+  MENTION_RETENTION_MS,
+  readMentionStoreSnapshot,
+  writeMentionStoreChanges,
+  type MentionStoreHead,
+  type MentionStoreMessage,
+  type MentionStoreSource,
+} from "./mention-inbox-store.js";
 import type { MentionCommittedInput, MentionInbox } from "./mention-inbox.types.js";
 import type { GatewayBroadcastToConnIdsFn } from "./server-broadcast-types.js";
 import type { GatewayClient } from "./server-methods/types.js";
 import { resolveSessionSharingTarget } from "./session-sharing.js";
 import { deriveSessionTitle } from "./session-utils-core.js";
 
-const RETENTION_MS = 7 * 24 * 60 * 60_000;
 const MAX_GLOBAL_ITEMS = 10_000;
-const MAX_PROCESSED_SOURCES = 10_000;
 const log = createSubsystemLogger("gateway/mentions");
 
 type StoredMention = {
   id: string;
   recipientProfileId: string;
   source: ProcessedSource;
-  message: {
-    sessionId: string;
-    content: Omit<
-      MentionInboxItem,
-      "id" | "senderLabel" | "senderAvatarUrl" | "sessionTitle" | "expiresAt"
-    >;
-  };
+  message: MentionStoreMessage;
 };
 
 type ProcessedSource = {
+  key: string;
+  sequence: number;
   expiresAt: number;
   /** Null retains consumption after dismissal, eviction, or intentional non-delivery. */
   recipients: Map<string, StoredMention | null>;
@@ -56,7 +62,7 @@ type MentionNotification = {
   isCurrent: () => boolean;
 };
 
-/** One Gateway lifetime owns temporary mention retention, acknowledgement, and replay suppression. */
+/** Durable sources own retention and replay; each Gateway keeps disposable projection indexes. */
 export function createMentionInbox(params: {
   gatewayInstanceId: string;
   getRuntimeConfig: () => OpenClawConfig;
@@ -68,6 +74,8 @@ export function createMentionInbox(params: {
   const items = new Map<string, StoredMention>();
   const itemsByProfile = new Map<string, Set<StoredMention>>();
   const processed = new Map<string, ProcessedSource>();
+  const dirtySources = new Set<string>();
+  let head: MentionStoreHead = { revision: -1, nextSequence: 0 };
   const views = new WeakMap<GatewayClient, { signature: string; revision: number }>();
   let active = true;
   let profileVersion = readUserProfileVersion();
@@ -75,6 +83,94 @@ export function createMentionInbox(params: {
   let capacityReported = false;
   let profileInvalidationPending = false;
   let nextExpiryAt = Infinity;
+
+  function synchronize(database?: DatabaseSync): boolean {
+    const snapshot = readMentionStoreSnapshot(head.revision, database);
+    if (!snapshot) {
+      return false;
+    }
+    items.clear();
+    itemsByProfile.clear();
+    processed.clear();
+    dirtySources.clear();
+    nextExpiryAt = Infinity;
+    for (const stored of snapshot.sources) {
+      const source: ProcessedSource = {
+        key: stored.key,
+        sequence: stored.sequence,
+        expiresAt: stored.expiresAt,
+        recipients: new Map(),
+      };
+      processed.set(source.key, source);
+      nextExpiryAt = Math.min(nextExpiryAt, source.expiresAt);
+      for (const [profileId, id] of stored.recipients) {
+        const item: StoredMention | null =
+          id && stored.message
+            ? { id, recipientProfileId: profileId, source, message: stored.message }
+            : null;
+        source.recipients.set(profileId, item);
+        if (item) {
+          items.set(item.id, item);
+          indexItem(item, false);
+        }
+      }
+    }
+    head = snapshot.head;
+    // A restart or another writer may have preceded this process's profile events.
+    profileVersion = -1;
+    return true;
+  }
+
+  function mutate<T>(operation: () => T): T {
+    try {
+      return runOpenClawStateWriteTransaction(
+        ({ db }) => {
+          synchronize(db);
+          expireItems();
+          reconcileProfiles();
+          const result = operation();
+          const changes = new Map<string, MentionStoreSource | undefined>();
+          for (const key of dirtySources) {
+            const source = processed.get(key);
+            if (!source) {
+              changes.set(key, undefined);
+              continue;
+            }
+            const message = [...source.recipients.values()].find((item) => item !== null)?.message;
+            changes.set(key, {
+              key,
+              sequence: source.sequence,
+              expiresAt: source.expiresAt,
+              recipients: [...source.recipients].map(([profileId, item]) => [
+                profileId,
+                item?.id ?? null,
+              ]),
+              ...(message ? { message } : {}),
+            });
+          }
+          head = writeMentionStoreChanges(db, head, changes);
+          return result;
+        },
+        {},
+        { operationLabel: "mentions.write" },
+      );
+    } catch (error) {
+      // Uncommitted indexes are never published; the next read rebuilds from durable state.
+      head = { revision: -1, nextSequence: 0 };
+      throw error;
+    } finally {
+      dirtySources.clear();
+    }
+  }
+
+  function maintain(): boolean {
+    const changed = synchronize();
+    const maintenance = Date.now() >= nextExpiryAt || profileVersion !== readUserProfileVersion();
+    if (maintenance) {
+      mutate(() => undefined);
+    }
+    return changed || maintenance;
+  }
 
   function removeItem(item: StoredMention | null | undefined): boolean {
     if (!item || !items.delete(item.id)) {
@@ -86,6 +182,7 @@ export function createMentionInbox(params: {
       itemsByProfile.delete(item.recipientProfileId);
     }
     item.source.recipients.set(item.recipientProfileId, null);
+    dirtySources.add(item.source.key);
     return true;
   }
 
@@ -99,11 +196,13 @@ export function createMentionInbox(params: {
     }
   }
 
-  function indexItem(item: StoredMention): void {
+  function indexItem(item: StoredMention, trim = true): void {
     const retained = itemsByProfile.get(item.recipientProfileId) ?? new Set<StoredMention>();
     retained.add(item);
     itemsByProfile.set(item.recipientProfileId, retained);
-    trimItems(retained, MENTION_INBOX_MAX_ITEMS);
+    if (trim) {
+      trimItems(retained, MENTION_INBOX_MAX_ITEMS);
+    }
   }
 
   function expireItems(): boolean {
@@ -123,9 +222,10 @@ export function createMentionInbox(params: {
         changed = removeItem(item) || changed;
       }
       processed.delete(key);
+      dirtySources.add(key);
     }
     nextExpiryAt = next;
-    if (processed.size < MAX_PROCESSED_SOURCES) {
+    if (processed.size < MAX_MENTION_SOURCES) {
       capacityReported = false;
     }
     return changed;
@@ -141,6 +241,9 @@ export function createMentionInbox(params: {
       const recipients = new Map<string, StoredMention | null>();
       for (const [profileId, item] of source.recipients) {
         const canonical = policy.readProfile(profileId)?.profileId ?? profileId;
+        if (canonical !== profileId || recipients.has(canonical)) {
+          dirtySources.add(source.key);
+        }
         if (!recipients.has(canonical)) {
           recipients.set(canonical, item);
           if (item) {
@@ -161,11 +264,9 @@ export function createMentionInbox(params: {
     }
     itemsByProfile.clear();
     for (const item of items.values()) {
-      if (policy.readProfile(item.recipientProfileId)) {
-        indexItem(item);
-      } else {
-        removeItem(item);
-      }
+      // An unresolved display can mean a transient read failure, not a deleted profile.
+      // Current authorization hides it; original retention still owns durable deletion.
+      indexItem(item);
     }
   }
 
@@ -230,6 +331,7 @@ export function createMentionInbox(params: {
   function readView(
     client: GatewayClient | null,
     cfg = params.getRuntimeConfig(),
+    remember = true,
   ): Result<MentionsListResult, ErrorShape> {
     const identified = policy.identify(client, cfg);
     if (!identified.ok) {
@@ -250,7 +352,7 @@ export function createMentionInbox(params: {
       .digest("hex");
     const previous = client && views.get(client);
     const revision = previous ? previous.revision + Number(signature !== previous.signature) : 0;
-    if (client) {
+    if (client && remember) {
       views.set(client, { signature, revision });
     }
     return ok({ gatewayInstanceId: params.gatewayInstanceId, revision, items: visible });
@@ -278,8 +380,8 @@ export function createMentionInbox(params: {
     }
   }
 
-  function scheduleExpiry(): void {
-    if (expiryTimer || processed.size === 0 || !active) {
+  function scheduleExpiry(retryAfterMs?: number): void {
+    if (expiryTimer || !active || (processed.size === 0 && retryAfterMs === undefined)) {
       return;
     }
     expiryTimer = setTimeout(
@@ -287,7 +389,7 @@ export function createMentionInbox(params: {
         expiryTimer = undefined;
         refresh();
       },
-      Math.max(1, nextExpiryAt - Date.now()),
+      retryAfterMs ?? Math.max(1, nextExpiryAt - Date.now()),
     );
     expiryTimer.unref?.();
   }
@@ -297,12 +399,13 @@ export function createMentionInbox(params: {
       return;
     }
     try {
-      expireItems();
-      reconcileProfiles();
+      maintain();
       refreshConnectedViews();
       scheduleExpiry();
     } catch {
-      log.warn("Unable to refresh the temporary mention Inbox; current reads will retry.");
+      log.warn("Unable to refresh the mention Inbox; current reads will retry.");
+      // A failed expiry write must not retire cleanup while the Gateway remains alive.
+      scheduleExpiry(60_000);
     }
   }
 
@@ -329,7 +432,7 @@ export function createMentionInbox(params: {
       try {
         return operation();
       } catch {
-        log.warn("The temporary mention Inbox could not read its current authorization.");
+        log.warn("The mention Inbox could not read or save its current state. Reconnect to retry.");
       }
     }
     return err(
@@ -339,6 +442,8 @@ export function createMentionInbox(params: {
     );
   }
 
+  refresh();
+
   return {
     mentionable: (...args: Parameters<typeof policy.mentionable>) =>
       readOperation(() => policy.mentionable(...args)),
@@ -346,10 +451,10 @@ export function createMentionInbox(params: {
       readOperation(() => policy.validateRecipients(...args)),
     list(client: GatewayClient | null): Result<MentionsListResult, ErrorShape> {
       return readOperation(() => {
-        reconcileProfiles();
-        if (expireItems()) {
+        if (maintain()) {
           refreshConnectedViews();
         }
+        scheduleExpiry();
         return readView(client);
       });
     },
@@ -358,17 +463,20 @@ export function createMentionInbox(params: {
       ids: readonly string[],
     ): Result<MentionsListResult, ErrorShape> {
       return readOperation(() => {
-        reconcileProfiles();
-        expireItems();
-        const current = readView(client);
-        if (!current.ok) {
-          return current;
-        }
-        const owned = new Set(current.value.items.map((item) => item.id));
-        for (const id of ids) {
-          if (owned.has(id)) {
-            removeItem(items.get(id));
+        const result = mutate(() => {
+          const current = readView(client, params.getRuntimeConfig(), false);
+          if (current.ok) {
+            const owned = new Set(current.value.items.map((item) => item.id));
+            for (const id of ids) {
+              if (owned.has(id)) {
+                removeItem(items.get(id));
+              }
+            }
           }
+          return current;
+        });
+        if (!result.ok) {
+          return result;
         }
         refresh();
         return readView(client);
@@ -394,112 +502,125 @@ export function createMentionInbox(params: {
           log.warn("Skipped mention delivery with invalid committed references.");
           return;
         }
-        expireItems();
-        reconcileProfiles();
-        const cfg = params.getRuntimeConfig();
-        const resolved = resolveSessionSharingTarget({
-          cfg,
-          sessionKey: input.sessionKey,
-          agentId: input.agentId,
-        });
-        if (!resolved || resolved.entry.sessionId !== input.sessionId) {
-          log.debug("Skipped mention delivery because its committed session changed.");
-          return;
-        }
-        const sourceKey = createHash("sha256")
-          .update(
-            JSON.stringify([
-              resolved.agentId,
-              resolved.canonicalKey,
-              input.sessionId,
-              input.sourceId,
-            ]),
-          )
-          .digest("hex");
-        if (processed.has(sourceKey)) {
-          return;
-        }
-        // Never evict consumption early to make room: doing so could re-alert a dismissed message.
-        if (processed.size >= MAX_PROCESSED_SOURCES) {
-          if (!capacityReported) {
-            log.warn(
-              "Temporary mention retention reached its replay budget; new mention alerts are skipped until retained sources expire.",
-            );
-            capacityReported = true;
+        const committed = mutate<StoredMention[]>(() => {
+          const cfg = params.getRuntimeConfig();
+          const resolved = resolveSessionSharingTarget({
+            cfg,
+            sessionKey: input.sessionKey,
+            agentId: input.agentId,
+          });
+          if (
+            !resolved ||
+            resolved.entry.sessionId !== input.sessionId ||
+            resolved.entry.incognito === true ||
+            isIncognitoSessionKey(resolved.canonicalKey)
+          ) {
+            log.debug("Skipped mention delivery because its committed session changed.");
+            return [];
           }
-          return;
-        }
-        const now = Date.now();
-        const source: ProcessedSource = { expiresAt: now + RETENTION_MS, recipients: new Map() };
-        processed.set(sourceKey, source);
-        nextExpiryAt = Math.min(nextExpiryAt, source.expiresAt);
-        const sender = policy.readProfile(input.senderProfileId);
-        const target = {
-          agentId: resolved.agentId,
-          sessionKey: resolved.canonicalKey,
-          entry: resolved.entry,
-        };
-        const excerpt = input.excerpt
-          ? truncateUtf16Safe(
-              flattenMarkdownToPlainText(truncateUtf16Safe(input.excerpt, 2_048))
-                .replace(/[\p{Cc}\p{Cf}]/gu, " ")
-                .replace(/\s+/gu, " ")
-                .trim(),
-              280,
+          const sourceKey = createHash("sha256")
+            .update(
+              JSON.stringify([
+                resolved.agentId,
+                resolved.canonicalKey,
+                input.sessionId,
+                input.sourceId,
+              ]),
             )
-          : undefined;
-        // Recipients share immutable message data; consumed sources retain only replay tombstones.
-        const message: StoredMention["message"] = {
-          sessionId: input.sessionId,
-          content: {
-            senderProfileId: sender?.profileId ?? input.senderProfileId,
-            sessionKey: target.sessionKey,
-            agentId: target.agentId,
-            messageId: input.messageId,
-            createdAt: now,
-            ...(excerpt ? { excerpt } : {}),
-          },
-        };
-        const created: StoredMention[] = [];
-        let unavailableRecipients = 0;
-        for (const profileId of input.recipientProfileIds) {
-          const recipient = policy.recipientProfile(profileId, target, cfg);
-          const canonicalId = recipient?.profileId ?? profileId;
-          if (source.recipients.has(canonicalId)) {
-            continue;
+            .digest("hex");
+          if (processed.has(sourceKey)) {
+            return [];
           }
-          source.recipients.set(canonicalId, null);
-          if (!sender || !recipient || sender.profileId === recipient.profileId) {
-            unavailableRecipients += 1;
-            continue;
+          // Never evict consumption early to make room: doing so could re-alert a dismissed message.
+          if (processed.size >= MAX_MENTION_SOURCES) {
+            if (!capacityReported) {
+              log.warn(
+                "Mention retention reached its replay budget; new mention alerts are skipped until retained sources expire.",
+              );
+              capacityReported = true;
+            }
+            return [];
           }
-          const item: StoredMention = {
-            id: randomUUID(),
-            recipientProfileId: recipient.profileId,
-            source,
-            message,
+          const now = Date.now();
+          const source: ProcessedSource = {
+            key: sourceKey,
+            sequence: head.nextSequence++,
+            expiresAt: now + MENTION_RETENTION_MS,
+            recipients: new Map(),
           };
-          items.set(item.id, item);
-          source.recipients.set(recipient.profileId, item);
-          indexItem(item);
-          trimItems(items, MAX_GLOBAL_ITEMS);
-          created.push(item);
-        }
-        if (unavailableRecipients > 0) {
-          log.debug(
-            `Skipped ${unavailableRecipients} unavailable mention recipients for committed input.`,
-          );
-        }
+          processed.set(sourceKey, source);
+          dirtySources.add(sourceKey);
+          nextExpiryAt = Math.min(nextExpiryAt, source.expiresAt);
+          const sender = policy.readProfile(input.senderProfileId);
+          const target = {
+            agentId: resolved.agentId,
+            sessionKey: resolved.canonicalKey,
+            entry: resolved.entry,
+          };
+          const excerpt = input.excerpt
+            ? truncateUtf16Safe(
+                flattenMarkdownToPlainText(truncateUtf16Safe(input.excerpt, 2_048))
+                  .replace(/[\p{Cc}\p{Cf}]/gu, " ")
+                  .replace(/\s+/gu, " ")
+                  .trim(),
+                280,
+              )
+            : undefined;
+          // Recipients share immutable message data; consumed sources retain only replay tombstones.
+          const message: StoredMention["message"] = {
+            sessionId: input.sessionId,
+            content: {
+              senderProfileId: sender?.profileId ?? input.senderProfileId,
+              sessionKey: target.sessionKey,
+              agentId: target.agentId,
+              messageId: input.messageId,
+              createdAt: now,
+              ...(excerpt ? { excerpt } : {}),
+            },
+          };
+          const created: StoredMention[] = [];
+          let unavailableRecipients = 0;
+          for (const profileId of input.recipientProfileIds) {
+            const recipient = policy.recipientProfile(profileId, target, cfg);
+            const canonicalId = recipient?.profileId ?? profileId;
+            if (source.recipients.has(canonicalId)) {
+              continue;
+            }
+            source.recipients.set(canonicalId, null);
+            if (!sender || !recipient || sender.profileId === recipient.profileId) {
+              unavailableRecipients += 1;
+              continue;
+            }
+            const item: StoredMention = {
+              id: randomUUID(),
+              recipientProfileId: recipient.profileId,
+              source,
+              message,
+            };
+            items.set(item.id, item);
+            source.recipients.set(recipient.profileId, item);
+            indexItem(item);
+            trimItems(items, MAX_GLOBAL_ITEMS);
+            created.push(item);
+          }
+          if (unavailableRecipients > 0) {
+            log.debug(
+              `Skipped ${unavailableRecipients} unavailable mention recipients for committed input.`,
+            );
+          }
+          return created;
+        });
         refresh();
         if (!params.onMentionCreated) {
           return;
         }
-        for (const item of created) {
-          const current = currentTarget(item, params.getRuntimeConfig());
-          if (!current) {
+        for (const item of committed) {
+          const retained = items.get(item.id);
+          const current = retained && currentTarget(retained, params.getRuntimeConfig());
+          if (!retained || !current) {
             continue;
           }
-          const projected = projectItem(item, current);
+          const projected = projectItem(retained, current);
           params.onMentionCreated({
             id: item.id,
             recipientProfileId: current.recipient.profileId,
@@ -509,7 +630,12 @@ export function createMentionInbox(params: {
             sessionTitle: projected.sessionTitle,
             isCurrent: () => {
               try {
-                return Boolean(currentTarget(item, params.getRuntimeConfig()));
+                if (!active) {
+                  return false;
+                }
+                maintain();
+                const latest = items.get(item.id);
+                return Boolean(latest && currentTarget(latest, params.getRuntimeConfig()));
               } catch {
                 return false;
               }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -3985,7 +3985,7 @@ export const en: TranslationMap & {
       emptyTitle: "No mentions yet",
       emptyBody: "When someone mentions you in a chat, it appears here.",
       retention:
-        "Mentions are temporary: kept for up to seven days and cleared when the Gateway restarts.",
+        "Mentions are kept for up to seven days. Gateway restarts preserve your Inbox and dismissals.",
       notifications: "Notification settings",
       loading: "Loading mentions…",
       unavailable: "Sign in and connect to the Gateway to see your mentions.",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users lose still-relevant Mentions Inbox entries and acknowledgement/replay state when a Gateway restarts, including during upgrades. Retained mentions and dismissals now survive restarts with their original identifiers and expiry times.

## Why This Change Was Made

Use typed records in the existing `config_machine_state` table: one bounded record per committed source, plus an atomic revision/arrival sequence record. In-memory recipient indexes remain disposable projections. Each mutation rereads the current revision inside the existing synchronous state transaction, writes only changed records, and publishes after commit. Failed writes return unavailable or withhold new delivery; they do not publish uncommitted state.

Maintainer-approved scope is persistence without a SQLite schema change. There are no new tables, columns, indexes, triggers, schema/database versions, configuration options, or dependencies. The existing machine-state owner already supports typed runtime snapshots and notification deduplication. Retention remains seven days, 100 entries per profile, 10,000 entries globally, and 10,000 consumed sources. Empty sources retain only replay receipts; expiry resumes at startup and retries transient storage failures while its owner remains active. Incognito sources never enter durable storage. Older compatible builds that lack this feature ignore its keys; their in-memory changes are not backfilled.

## User Impact

Restarting or upgrading no longer clears the retained Inbox or revives dismissed/evicted mentions. Loading saved state does not send old browser alerts or scan old transcripts. Current profile, role, session visibility, and session-incarnation checks still control every read and push. The UI and documentation explain the retained Inbox and preserve the existing documentation anchor.

Follow-up to #141081. This retains the existing best-effort boundary after transcript commit; it does not add a transactional chat-delivery outbox.

## Evidence

- Six initial regressions failed on the original implementation. Additional red/green checks cover startup expiry without readers, incognito storage exclusion, and retry/cancellation after failed expiry writes.
- The broader Gateway proof passed 105 tests and hit one cold kernel-start timeout. That exact test subsequently passed unchanged in a focused run (36.42 seconds total, including transforms), with no timeout increase. The Inbox-containing startup phase measured 2.8 ms. Both profile-merge recipient orders and restart persistence pass in focused proof.
- `sqlite_schema` and `PRAGMA user_version` remain byte-for-byte/equivalently unchanged after admission, dismissal, and reopening. Cross-instance tests protect against stale writes resurrecting dismissals or losing new inputs; temporary abort triggers prove write rollback without push or invalidation publication.
- Real source Gateway proof used two synthetic authenticated profiles and a deterministic local model. Two chat sends created mentions; one was dismissed. The owned Gateway was killed with SIGKILL and replaced with a new PID/boot ID over the same state. The retained item kept its exact ID and expiry, the dismissal remained effective, and a fresh mention and dismissal worked after recovery. The fixture was cleaned up afterward.
- Control UI production build, core/UI/test typechecks, localization verification, changed-file lint and `node scripts/check-changed.mjs` passed. Required CI passed on the published head in [run34148249455](https://github.com/openclaw/openclaw/actions/runs/34148249455), attempt1.
- Independent Codex review raised a profile-merge ordering concern. The existing collision branch explicitly makes a consumed receipt win in either order; both orders now have restart regression proof. No production change was needed for that finding.
- Browser automation repeatedly lost its debugger attachment, so no new GUI screenshots or native-app delivery proof are claimed. Live evidence above uses the actual Gateway chat/Inbox RPC flow; restored push suppression is covered at its delivery callback boundary.
