### PR TITLE
fix(ui): selected owner overlaps the Specific owner label in the sessions filter menu

### DIFF
--- a/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
+++ b/ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts
@@ -32,7 +32,7 @@ suite.define(() => {
             sessionRow("agent:main:bob", "Bob operations", 1),
           ]),
           owners: [
-            { type: "human", id: "profile-ada", label: "Ada" },
+            { type: "human", id: "profile-ada", label: "Ada Lovelace Byron" },
             { type: "human", id: "profile-bob", label: "Bob" },
             { type: "human", id: "profile-carol", label: "Carol" },
             { type: "human", id: "profile-dave", label: "Dave" },
@@ -150,26 +150,43 @@ suite.define(() => {
       await expect
         .poll(() =>
           page
-            .getByRole("menuitem", { name: "Specific owner: Ada", exact: true })
+            .getByRole("menuitem", { name: "Specific owner: Ada Lovelace Byron", exact: true })
             .locator(".sidebar-session-owner-selection .viewer-avatar")
             .count(),
         )
         .toBe(1);
       const selectedOwnerSubmenu = page.getByRole("menuitem", {
-        name: "Specific owner: Ada",
+        name: "Specific owner: Ada Lovelace Byron",
         exact: true,
       });
       await expect
         .poll(() =>
           selectedOwnerSubmenu.locator(".sidebar-session-owner-selection__name").textContent(),
         )
-        .toBe("Ada");
+        .toBe("Ada Lovelace Byron");
       await expect
         .poll(() => page.locator('[value="owner:"]').getAttribute("aria-checked"))
         .toBe("false");
       expect(
         await trailingGap(selectedOwnerSubmenu, ".sidebar-session-owner-selection__name"),
       ).toBeLessThanOrEqual(8);
+      // The long owner name must truncate; the row label keeps its full text
+      // and never runs underneath the avatar and name rail.
+      const { labelClipped, overlap } = await selectedOwnerSubmenu.evaluate((element) => {
+        const label = element.querySelector<HTMLElement>(":scope > .session-menu__text");
+        const details = element.querySelector<HTMLElement>(":scope > [slot='details']");
+        if (!label || !details) {
+          throw new Error("expected owner label and selection rail");
+        }
+        const range = document.createRange();
+        range.selectNodeContents(label);
+        return {
+          labelClipped: label.scrollWidth > label.clientWidth,
+          overlap: range.getBoundingClientRect().right - details.getBoundingClientRect().left,
+        };
+      });
+      expect(labelClipped).toBe(false);
+      expect(overlap).toBeLessThanOrEqual(0);
     } finally {
       await context.close();
     }

--- a/ui/src/styles/sidebar-menus.css
+++ b/ui/src/styles/sidebar-menus.css
@@ -50,6 +50,28 @@ wa-dropdown-item.sidebar-session-owner-submenu::part(submenu-icon) {
   color: var(--text);
 }
 
+/* Web Awesome's details part is fixed-size and end-justified, so a selection
+   rail wider than its column spills leftward across the row label. Give the
+   row label its own width (capped so it can still truncate), let the details
+   part absorb the remaining width, and let the rail shrink into it so the
+   selected owner's name truncates before the label does. */
+wa-dropdown-item.sidebar-session-owner-submenu::part(label) {
+  display: flex;
+  flex: 0 0 auto;
+  align-items: center;
+  min-width: 0;
+  max-width: 60%;
+}
+
+/* Web Awesome also forces a 2em start margin on the slotted rail, which the
+   light DOM cannot outrank. Pull the part back by that margin so the rail keeps
+   the row's 8px gutter instead of stacking a ~30px one. */
+wa-dropdown-item.sidebar-session-owner-submenu::part(details) {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin-inline-start: -2em;
+}
+
 .session-menu__shortcut.sidebar-session-owner-count {
   min-width: 0;
   margin-inline-end: -2px;
@@ -58,6 +80,7 @@ wa-dropdown-item.sidebar-session-owner-submenu::part(submenu-icon) {
 
 .session-menu__shortcut.sidebar-session-owner-selection {
   display: inline-flex;
+  flex: 0 1 auto;
   align-items: center;
   gap: 4px;
   min-width: 0;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users who picked a specific owner in the sessions sidebar **Filter & sort** menu would see that owner's avatar and name drawn on top of the **Specific owner** row label, so the label read as "Specific ow" with the avatar covering the rest.

## Why This Change Was Made

The selected-owner rail sits in Web Awesome's `details` column, which is fixed-size and end-justified. The rail inherited `flex: 0 0 auto` from the keycap shortcut idiom and refused to shrink, so any name longer than the column spilled leftward across the label. The label part is a plain block in the shadow row, so the label's own ellipsis rules never applied either.

The row now gives the label part its own width (capped so it can still truncate), lets the details part absorb the rest of the row, and lets the rail shrink into it so the owner name truncates before the label does. The details part is pulled back by Web Awesome's forced 2em slotted margin so the row keeps its normal 8px gutter instead of stacking a ~30px one. Desktop menu only; the compact/mobile variant already lays out its details inside the label part and was unaffected.

## User Impact

The **Specific owner** row stays fully readable with the selected owner's avatar and truncated name to its right. Nothing else in the menu moves; sibling row labels keep the same left edge and the chevron keeps its spacing.

## Evidence

Mock Gateway, 220px desktop filter menu, owner "Peter Steinberger" selected.

| Before | After |
| --- | --- |
| ![Specific owner row with avatar and name overlapping the label](https://github.com/user-attachments/assets/e8543cd3-8420-40db-b5e0-1e2de4be114e) | ![Specific owner row with label intact and truncated owner name](https://github.com/user-attachments/assets/7994c51c-906b-4349-a677-11cba8a7db05) |

Measured on the row before the fix: the label text ran 17.7px underneath the selection rail. After: the rail starts 6px right of the label, the name truncates, and the chevron gap is unchanged.

- `ui/src/e2e/session-owner-filter-keyboard.e2e.test.ts` now selects a long owner name ("Ada Lovelace Byron") and asserts the row label is not clipped and its text bounds end before the selection rail begins. The new assertion fails on the original CSS (overlap 17.6px) and passes with the fix. The existing label-alignment, trailing-gap, large-roster, and RTL assertions still pass.
- `node scripts/check-changed.mjs`: green (typecheck, UI stylelint, i18n verify, knip).
- Codex autoreview (P0–P2): scoped-clean.
