### PR TITLE
fix(gateway): trim terminal sessionId lookups before Map match

### DIFF
--- a/src/gateway/server-methods/terminal.session-id-trim.test.ts
+++ b/src/gateway/server-methods/terminal.session-id-trim.test.ts
@@ -1,0 +1,89 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import { TerminalSessionManager } from "../terminal/session-manager.js";
+import { makeFakePty } from "../terminal/session-manager.test-helpers.js";
+import { terminalHandlers } from "./terminal.js";
+
+describe("terminal.close/attach padded sessionId", () => {
+  it("closes a live connection-owned PTY when terminal.close receives a padded sessionId", async () => {
+    const backend = makeFakePty();
+    const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: async () => backend });
+    const opened = await manager.open({
+      owner: { kind: "conn", connId: "conn-pad" },
+      agentId: "main",
+      cwd: "/tmp",
+      shell: "/bin/sh",
+      cols: 80,
+      rows: 24,
+    });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) {
+      return;
+    }
+
+    const padded = ` ${opened.sessionId} `;
+    // Negative control: exact Map key differs from clipboard-padded RPC input.
+    expect(padded).not.toBe(opened.sessionId);
+    expect(manager.size).toBe(1);
+
+    const respond = vi.fn();
+    await expectDefined(terminalHandlers["terminal.close"], "terminal.close")({
+      params: { sessionId: padded },
+      respond,
+      context: {
+        terminalSessions: manager,
+        isTerminalEnabled: () => true,
+        getRuntimeConfig: () => ({ gateway: { terminal: { enabled: true } } }),
+      },
+      client: { connId: "conn-pad", connect: {} },
+      isWebchatConnect: () => false,
+      req: { type: "req", id: "2", method: "terminal.close" },
+    } as never);
+
+    expect(respond).toHaveBeenCalledWith(true, { ok: true });
+    expect(manager.size).toBe(0);
+  });
+
+  it("attaches to a detached session when terminal.attach receives a padded sessionId", async () => {
+    const backend = makeFakePty();
+    const manager = new TerminalSessionManager({
+      emit: vi.fn(),
+      spawn: async () => backend,
+      detachGraceMs: 60_000,
+    });
+    const opened = await manager.open({
+      owner: { kind: "conn", connId: "conn-owner" },
+      agentId: "main",
+      cwd: "/tmp",
+      shell: "/bin/sh",
+      cols: 80,
+      rows: 24,
+    });
+    expect(opened.ok).toBe(true);
+    if (!opened.ok) {
+      return;
+    }
+    manager.handleDisconnect("conn-owner");
+
+    const padded = ` ${opened.sessionId} `;
+    const respond = vi.fn();
+    await expectDefined(terminalHandlers["terminal.attach"], "terminal.attach")({
+      params: { sessionId: padded },
+      respond,
+      context: {
+        terminalSessions: manager,
+        isTerminalEnabled: () => true,
+        getRuntimeConfig: () => ({ gateway: { terminal: { enabled: true } } }),
+        logGateway: { info: vi.fn() },
+      },
+      client: { connId: "conn-owner", connect: {} },
+      isWebchatConnect: () => false,
+      req: { type: "req", id: "3", method: "terminal.attach" },
+    } as never);
+
+    expect(respond).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ sessionId: opened.sessionId }),
+    );
+  });
+});

--- a/src/gateway/server-methods/terminal.session-id-trim.test.ts
+++ b/src/gateway/server-methods/terminal.session-id-trim.test.ts
@@ -1,21 +1,20 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import { TerminalSessionManager } from "../terminal/session-manager.js";
-import { makeFakePty } from "../terminal/session-manager.test-helpers.js";
+import { baseOpenRequest, makeFakePty } from "../terminal/session-manager.test-helpers.js";
 import { terminalHandlers } from "./terminal.js";
 
 describe("terminal.close/attach padded sessionId", () => {
   it("closes a live connection-owned PTY when terminal.close receives a padded sessionId", async () => {
     const backend = makeFakePty();
     const manager = new TerminalSessionManager({ emit: vi.fn(), spawn: async () => backend });
-    const opened = await manager.open({
-      owner: { kind: "conn", connId: "conn-pad" },
-      agentId: "main",
-      cwd: "/tmp",
-      shell: "/bin/sh",
-      cols: 80,
-      rows: 24,
-    });
+    const opened = await manager.open(
+      baseOpenRequest({
+        owner: { kind: "conn", connId: "conn-pad" },
+        cwd: "/tmp",
+        shell: "/bin/sh",
+      }),
+    );
     expect(opened.ok).toBe(true);
     if (!opened.ok) {
       return;
@@ -54,14 +53,13 @@ describe("terminal.close/attach padded sessionId", () => {
       spawn: async () => backend,
       detachGraceMs: 60_000,
     });
-    const opened = await manager.open({
-      owner: { kind: "conn", connId: "conn-owner" },
-      agentId: "main",
-      cwd: "/tmp",
-      shell: "/bin/sh",
-      cols: 80,
-      rows: 24,
-    });
+    const opened = await manager.open(
+      baseOpenRequest({
+        owner: { kind: "conn", connId: "conn-owner" },
+        cwd: "/tmp",
+        shell: "/bin/sh",
+      }),
+    );
     expect(opened.ok).toBe(true);
     if (!opened.ok) {
       return;

--- a/src/gateway/server-methods/terminal.session-id-trim.test.ts
+++ b/src/gateway/server-methods/terminal.session-id-trim.test.ts
@@ -27,7 +27,10 @@ describe("terminal.close/attach padded sessionId", () => {
     expect(manager.size).toBe(1);
 
     const respond = vi.fn();
-    await expectDefined(terminalHandlers["terminal.close"], "terminal.close")({
+    await expectDefined(
+      terminalHandlers["terminal.close"],
+      "terminal.close",
+    )({
       params: { sessionId: padded },
       respond,
       context: {
@@ -67,7 +70,10 @@ describe("terminal.close/attach padded sessionId", () => {
 
     const padded = ` ${opened.sessionId} `;
     const respond = vi.fn();
-    await expectDefined(terminalHandlers["terminal.attach"], "terminal.attach")({
+    await expectDefined(
+      terminalHandlers["terminal.attach"],
+      "terminal.attach",
+    )({
       params: { sessionId: padded },
       respond,
       context: {

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -88,6 +88,16 @@ export class TerminalSessionManager {
     this.scrollbackChars = options.scrollbackChars ?? DEFAULT_SCROLLBACK_CHARS;
   }
 
+
+  /** Clipboard/RPC padding must not miss exact Map keys stored at create time. */
+  private normalizeSessionLookupId(sessionId: string): string {
+    return sessionId.trim();
+  }
+
+  private getSession(sessionId: string): TerminalSession | undefined {
+    return this.sessions.get(this.normalizeSessionLookupId(sessionId));
+  }
+
   /** Number of live sessions; used by tests and health surfaces. */
   get size(): number {
     return this.sessions.size;
@@ -413,7 +423,7 @@ export class TerminalSessionManager {
 
   /** Closes one session on operator request. */
   close(connId: string, sessionId: string): boolean {
-    const session = this.sessions.get(sessionId);
+    const session = this.getSession(sessionId);
     if (!session) {
       return false;
     }
@@ -485,7 +495,7 @@ export class TerminalSessionManager {
    * agent-owned sessions gain shared viewers.
    */
   attach(connId: string, sessionId: string): TerminalAttachSummary | undefined {
-    const session = this.sessions.get(sessionId);
+    const session = this.getSession(sessionId);
     if (!session || session.closed) {
       return undefined;
     }
@@ -529,7 +539,7 @@ export class TerminalSessionManager {
 
   /** Raw buffered output for one session, or undefined when it is gone. */
   snapshot(sessionId: string): string | undefined {
-    const session = this.sessions.get(sessionId);
+    const session = this.getSession(sessionId);
     if (!session || session.closed) {
       return undefined;
     }
@@ -772,7 +782,7 @@ export class TerminalSessionManager {
   }
 
   private interactiveSession(connId: string, sessionId: string): TerminalSession | undefined {
-    const session = this.sessions.get(sessionId);
+    const session = this.getSession(sessionId);
     if (!session || session.closed) {
       return undefined;
     }
@@ -791,7 +801,7 @@ export class TerminalSessionManager {
     owner: AgentTerminalOwner,
     sessionId: string,
   ): TerminalSession | undefined {
-    const session = this.sessions.get(sessionId);
+    const session = this.getSession(sessionId);
     if (!session || session.closed || !agentTerminalOwnerMatches(session.owner, owner)) {
       return undefined;
     }

--- a/src/gateway/terminal/session-manager.ts
+++ b/src/gateway/terminal/session-manager.ts
@@ -88,7 +88,6 @@ export class TerminalSessionManager {
     this.scrollbackChars = options.scrollbackChars ?? DEFAULT_SCROLLBACK_CHARS;
   }
 
-
   /** Clipboard/RPC padding must not miss exact Map keys stored at create time. */
   private normalizeSessionLookupId(sessionId: string): string {
     return sessionId.trim();


### PR DESCRIPTION
## What Problem This Solves

`terminal.close` / `terminal.attach` / `terminal.input` / `terminal.resize`
(and related manager lookups) forwarded `params.sessionId` into exact
`TerminalSessionManager` Map keys. The store does not normalize ids and the
schema only requires `NonEmptyString`, so a clipboard-padded id
(`" <session-uuid> "`) missed a live PTY (close returned `{ ok: false }`,
attach reported unknown session). Sibling handlers already normalize
(`portal.close`, `wizard.next/cancel/status`, Talk session registry).

## Why This Change Was Made

Normalize sessionId once with `.trim()` inside `TerminalSessionManager`
lookup helpers before Map get, covering close/attach/write/resize/snapshot
and agent-owned paths without changing stored keys.

## User Impact

**Before:** Closing or attaching with surrounding whitespace missed the live
terminal session (or required a second exact-id call).

**After:** Surrounding whitespace is ignored; the live PTY is found.

## Evidence

- Changed: `src/gateway/terminal/session-manager.ts`,
  `src/gateway/server-methods/terminal.session-id-trim.test.ts`
- Production path: gateway RPC `terminal.close` / `terminal.attach` →
  `TerminalSessionManager.getSession(trim(sessionId))` → exact Map lookup
- Compatibility: stored session ids remain unpadded; only lookup input is
  normalized
- Dedup: no open PR owns terminal sessionId trim
- Schema note: `NonEmptyString` accepts padded ids

## Real behavior proof

### Behavior or issue addressed

Caller-path gateway harness: padded `terminal.close` closes a live
connection-owned PTY; padded `terminal.attach` reattaches after detach grace.
Negative control: padded id is not equal to the stored exact key.

### Canonical reachability path

Gateway RPC `terminal.close` / `terminal.attach` → manager lookup trim →
exact Map key

### Shared helper / provider constraint check

Same normalize-at-store-owner pattern as the unified Talk session registry;
terminal manager has no prior shared normalize owner for RPC sessionIds.

### Real environment tested

Local trusted source checkout at PR head; Vitest gateway-methods project;
production `terminalHandlers` + real `TerminalSessionManager` with fake PTY.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/gateway/server-methods/terminal.session-id-trim.test.ts --reporter=verbose
```

### Evidence after fix

```text
 RUN  v5.0.0 /workspace/openclaw-prB2
 ✓ |gateway-methods| src/gateway/server-methods/terminal.session-id-trim.test.ts > terminal.close/attach padded sessionId > closes a live connection-owned PTY when terminal.close receives a padded sessionId 11ms
 ✓ |gateway-methods| src/gateway/server-methods/terminal.session-id-trim.test.ts > terminal.close/attach padded sessionId > attaches to a detached session when terminal.attach receives a padded sessionId 4ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
[test] passed 1 Vitest shard in 17.41s
```

### Observed result after fix

New caller-path tests passed: padded sessionId closes the live PTY and
reattaches after disconnect detach grace.

### What was not tested

No full Gateway WebSocket session; proof uses the production
`terminalHandlers` caller path with a real in-process session manager.

### Fix classification

Root cause fix.

## Checklist

- [x] AI-assisted
- [x] Allow edits from maintainers
- [x] Single concern / single commit
- [x] No CHANGELOG.md edit
