### PR TITLE
fix(gateway): trim mentions.dismiss ids before exact inbox match

### DIFF
--- a/src/gateway/mention-dismiss-id-trim.e2e.test.ts
+++ b/src/gateway/mention-dismiss-id-trim.e2e.test.ts
@@ -1,0 +1,109 @@
+import { createHash, randomUUID } from "node:crypto";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  GATEWAY_OWNER_PROFILE_ID,
+  validateMentionsListResult,
+  type MentionsListResult,
+} from "../../packages/gateway-protocol/src/index.js";
+import { MENTION_RETENTION_MS, writeMentionStoreChanges } from "./mention-inbox-store.js";
+import { READ_SCOPE } from "./operator-scopes.js";
+import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
+import { ensureGatewayOwnerProfile, ensureProfileForEmail, setDisplayName } from "../state/user-profiles.js";
+import { connectGatewayClient, disconnectGatewayClient } from "./test-helpers.e2e.js";
+import { installGatewayTestHooks, testState, withGatewayServer, writeSessionStore } from "./test-helpers.js";
+
+installGatewayTestHooks({ scope: "suite" });
+
+const GATEWAY_TOKEN = "mention-dismiss-trim-e2e-token";
+const SESSION_KEY = "agent:main:main";
+const SESSION_ID = "mention-dismiss-trim-session";
+
+describe("mentions.dismiss Gateway E2E", () => {
+  it("dismisses a live mention when mentions.dismiss receives a padded id", async () => {
+    const stateDir = process.env.OPENCLAW_STATE_DIR;
+    if (!stateDir) {
+      throw new Error("OPENCLAW_STATE_DIR is required for mention dismiss E2E fixtures");
+    }
+    testState.gatewayAuth = { mode: "token", token: GATEWAY_TOKEN };
+    testState.sessionStorePath = path.join(stateDir, "sessions.sqlite");
+
+    ensureGatewayOwnerProfile("mention-trim-owner");
+    const sender = ensureProfileForEmail("sender@mentions.example.test");
+    setDisplayName(sender.id, "Sender");
+    expect(sender.id).not.toBe(GATEWAY_OWNER_PROFILE_ID);
+
+    const mentionId = randomUUID();
+    const sourceKey = createHash("sha256").update("mention-dismiss-trim-source").digest("hex");
+    const createdAt = Date.now();
+
+    await withGatewayServer(async ({ port }) => {
+      await writeSessionStore({
+        entries: {
+          [SESSION_KEY]: {
+            sessionId: SESSION_ID,
+            updatedAt: Date.now(),
+            visibility: "shared",
+            createdActor: { type: "human", source: "profile", id: GATEWAY_OWNER_PROFILE_ID },
+          },
+        },
+      });
+      runOpenClawStateWriteTransaction(({ db }) => {
+        writeMentionStoreChanges(
+          db,
+          { revision: 0, nextSequence: 1 },
+          new Map([
+            [
+              sourceKey,
+              {
+                key: sourceKey,
+                sequence: 0,
+                expiresAt: createdAt + MENTION_RETENTION_MS,
+                recipients: [[GATEWAY_OWNER_PROFILE_ID, mentionId]],
+                message: {
+                  sessionId: SESSION_ID,
+                  content: {
+                    senderProfileId: sender.id,
+                    sessionKey: SESSION_KEY,
+                    agentId: "main",
+                    messageId: "mention-dismiss-trim-message",
+                    createdAt,
+                    excerpt: "@Owner review this change",
+                  },
+                },
+              },
+            ],
+          ]),
+        );
+      });
+
+      const client = await connectGatewayClient({
+        url: `ws://127.0.0.1:${port}`,
+        token: GATEWAY_TOKEN,
+        scopes: [READ_SCOPE],
+        timeoutMs: 60_000,
+      });
+      try {
+        const listed = await client.request<MentionsListResult>("mentions.list", {});
+        expect(validateMentionsListResult(listed)).toBe(true);
+        expect(listed.items.map((item) => item.id)).toContain(mentionId);
+
+        const padded = ` ${mentionId} `;
+        expect(padded).not.toBe(mentionId);
+        const dismissed = await client.request<MentionsListResult>("mentions.dismiss", {
+          ids: [padded],
+        });
+        expect(validateMentionsListResult(dismissed)).toBe(true);
+        expect(dismissed.items.map((item) => item.id)).not.toContain(mentionId);
+
+        const remaining = await client.request<MentionsListResult>("mentions.list", {});
+        expect(remaining.items.map((item) => item.id)).not.toContain(mentionId);
+        console.log(
+          `[mentions.dismiss Gateway client E2E] listed=true dismissed=true remaining=0 padded=${JSON.stringify(padded)} exact=${mentionId}`,
+        );
+      } finally {
+        await disconnectGatewayClient(client);
+      }
+    });
+  }, 120_000);
+});

--- a/src/gateway/mention-inbox.test.ts
+++ b/src/gateway/mention-inbox.test.ts
@@ -913,3 +913,27 @@ describe("human mention directory", () => {
     });
   });
 });
+
+describe("mentions.dismiss padded ids", () => {
+  it("dismisses a live mention when mentions.dismiss receives a padded id", async () => {
+    await withInbox(async (f) => {
+      for (const client of f.clients) {
+        read(f.inbox, client);
+      }
+      f.post("padded-dismiss-source");
+      const listed = await f.call("mentions.list", {}, f.bobClient);
+      expect(listed.ok).toBe(true);
+      const items = (listed.payload as { items: Array<{ id: string }> }).items;
+      expect(items).toHaveLength(1);
+      const exactId = items[0]!.id;
+      const padded = ` ${exactId} `;
+      // Schema accepts surrounding whitespace; exact Set/Map keys do not.
+      expect(padded).not.toBe(exactId);
+
+      const dismissed = await f.call("mentions.dismiss", { ids: [padded] }, f.bobClient);
+      expect(dismissed.ok).toBe(true);
+      const remaining = read(f.inbox, f.bobClient);
+      expect(remaining.items.map((item) => item.id)).not.toContain(exactId);
+    });
+  });
+});

--- a/src/gateway/mention-inbox.ts
+++ b/src/gateway/mention-inbox.ts
@@ -467,8 +467,10 @@ export function createMentionInbox(params: {
           const current = readView(client, params.getRuntimeConfig(), false);
           if (current.ok) {
             const owned = new Set(current.value.items.map((item) => item.id));
-            for (const id of ids) {
-              if (owned.has(id)) {
+            for (const rawId of ids) {
+              // Exact Set/Map match; clipboard/RPC padding must not skip a live mention.
+              const id = rawId.trim();
+              if (id && owned.has(id)) {
                 removeItem(items.get(id));
               }
             }


### PR DESCRIPTION
## What Problem This Solves

`mentions.dismiss` matched inbox IDs with exact Set lookup. Clipboard-padded IDs (`" <uuid> "`) missed a live mention even though the schema accepts surrounding whitespace.

## Why This Change Was Made

Trim each dismiss ID before the exact inbox match. Proof is a real Gateway WebSocket client: seed a durable mention for the token-auth owner, then padded `mentions.dismiss` clears it.

## User Impact

**Before:** Pasting a mention ID with surrounding whitespace left the mention in the inbox.

**After:** Padded `mentions.dismiss` removes the live mention; stored IDs stay unpadded.

## Evidence

- Changed: `src/gateway/mention-inbox.ts`, `src/gateway/mention-inbox.test.ts`, `src/gateway/mention-dismiss-id-trim.e2e.test.ts`
- Production path: `connectGatewayClient` → `mentions.list` → `mentions.dismiss({ ids: [" ${id} "] })` → `mentions.list` empty
- Compatibility: stored mention IDs remain unpadded; only RPC input is trimmed

## Real behavior proof

- **Behavior or issue addressed:** A running Gateway accepts a clipboard-padded `mentions.dismiss` ID and updates the live inbox.
- **Canonical reachability path:** Real `GatewayClient` token auth (owner profile) → `mentions.list` sees the seeded mention → padded `mentions.dismiss` → `mentions.list` no longer contains that ID.
- **Boundary crossed:** Real Gateway WebSocket RPC + durable mention store (not a mocked handler callback).
- **Shared helper / provider constraint check:** Trim happens in `mentionInbox.dismiss` before exact Set/Map match. Schema still accepts the padded string.
- **Real environment tested:** Local trusted source checkout; Vitest e2e project; `withGatewayServer` + real `connectGatewayClient` on loopback.
- **Exact steps or command run after this patch:**

```bash
OPENCLAW_E2E_SKIP_BUILD=1 node scripts/run-vitest.mjs src/gateway/mention-dismiss-id-trim.e2e.test.ts --reporter=verbose
```

- **Evidence after fix:**

```text
✓ src/gateway/mention-dismiss-id-trim.e2e.test.ts > mentions.dismiss Gateway E2E > dismisses a live mention when mentions.dismiss receives a padded id 10842ms

 Test Files  1 passed (1)
      Tests  1 passed (1)
```

- **Observed result after fix:** Padded dismiss removes the exact stored mention; a follow-up list is empty for that ID.
- **What was not tested:** Control UI clipboard paste; multi-recipient dismiss in one RPC.
- **Fix classification:** Root cause fix

- [x] AI-assisted (Cursor)
- [x] I understand what the code does
- [x] Change is focused and does not mix unrelated concerns
