### PR TITLE
fix(release): let new plugins publish at their approved stable version

### DIFF
--- a/.agents/skills/release-openclaw-maintainer/references/first-package.md
+++ b/.agents/skills/release-openclaw-maintainer/references/first-package.md
@@ -7,12 +7,13 @@ ClawHub package.
   reachable stable/beta release tag. For every newly publishable package
   (`openclaw.release.publishToNpm: true` or `publishToClawHub: true`) whose
   package name did not exist in the base tag, verify the target registry package
-  already exists in npm/ClawHub or stop and help the owner mint/prepublish the
-  package first. Do not hide or disable release surfaces just to unblock a
+  already exists in npm/ClawHub or prepare the supported first-publication
+  route with the owner before dispatch. Do not hide or disable release surfaces just to unblock a
   train unless the owner explicitly decides the plugin should not ship in that
   release; first-package registry ownership is release prep, not product
   rollback. The mint/prepublish path must either be the real release publish
-  path for the auto-bumped beta version, or a deliberately non-consuming
+  path for the auto-bumped beta version, the exact approved regular stable
+  version described below, or a deliberately non-consuming
   registry-prep step that cannot occupy the next beta version/tag. Confirm
   registry owner, npm scope/package-creation permission, provenance path, and
   first-package publish plan before the full release publish continues. Useful
@@ -20,6 +21,18 @@ ClawHub package.
   `npm view <package-name> version dist-tags --json --prefer-online`; a 404 for
   a package newly added to the release is a release-prep blocker, not something
   to discover from the publish job.
+- For a new regular stable npm package, the protected Release Publish parent
+  requires complete stable/full validation, `npm_dist_tag=latest`, and an exact
+  final release tag. It attests the selected publishable package set, target,
+  tooling, parent attempt, and validation tuple. Plugin NPM Release consumes
+  that approval and its independently verified immutable tarball through the
+  protected `NPM_TOKEN` bootstrap route. Confirm scope/package-creation access
+  first; do not create placeholder versions or a fake beta. Alpha,
+  extended-stable, unselected packages, and direct stable bootstrap without the
+  attested parent remain unsupported. Configure the package's GitHub trusted
+  publisher for `plugin-npm-release.yml` / `npm-release` after first publication,
+  then run its read-only OIDC preflight before the next release. Same-byte
+  retries do not republish; a selector mismatch needs selector recovery.
 - Bootstrap a new ClawHub package only from the trusted workflow source:
   `gh workflow run plugin-clawhub-new.yml --ref main -f plugins=@openclaw/name -f ref=<full-release-sha> -f pretag_validation=true -f dry_run=true`.
   The workflow source stays on `main`; `ref` is the exact release target. A

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -1351,7 +1351,7 @@ jobs:
           retention-days: 30
 
       - name: Prepare stable npm bootstrap approval
-        if: ${{ inputs.npm_dist_tag == 'latest' && inputs.release_evidence_mode == 'full-release-validation' }}
+        if: ${{ inputs.npm_dist_tag == 'latest' && inputs.release_evidence_mode == 'full-release-validation' && (needs.resolve_release_target.outputs.release_profile == 'stable' || needs.resolve_release_target.outputs.release_profile == 'full') }}
         env:
           RELEASE_TAG: ${{ inputs.tag }}
           TARGET_SHA: ${{ needs.resolve_release_target.outputs.sha }}
@@ -1396,13 +1396,13 @@ jobs:
           NODE
 
       - name: Attest stable npm bootstrap approval
-        if: ${{ inputs.npm_dist_tag == 'latest' && inputs.release_evidence_mode == 'full-release-validation' }}
+        if: ${{ inputs.npm_dist_tag == 'latest' && inputs.release_evidence_mode == 'full-release-validation' && (needs.resolve_release_target.outputs.release_profile == 'stable' || needs.resolve_release_target.outputs.release_profile == 'full') }}
         uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
         with:
           subject-path: ${{ runner.temp }}/npm-stable-bootstrap-approval/approval.json
 
       - name: Upload stable npm bootstrap approval
-        if: ${{ inputs.npm_dist_tag == 'latest' && inputs.release_evidence_mode == 'full-release-validation' }}
+        if: ${{ inputs.npm_dist_tag == 'latest' && inputs.release_evidence_mode == 'full-release-validation' && (needs.resolve_release_target.outputs.release_profile == 'stable' || needs.resolve_release_target.outputs.release_profile == 'full') }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: npm-stable-bootstrap-approval-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/openclaw-release-publish.yml
+++ b/.github/workflows/openclaw-release-publish.yml
@@ -136,6 +136,7 @@ jobs:
       prepared_docker_artifact_name: ${{ steps.full_manifest.outputs.prepared_docker_artifact_name }}
       prepared_docker_manifest_sha256: ${{ steps.full_manifest.outputs.prepared_docker_manifest_sha256 }}
       coverage_policy: ${{ steps.full_manifest.outputs.coverage_policy }}
+      release_profile: ${{ steps.full_manifest.outputs.release_profile }}
       android_pin_version: ${{ steps.ref.outputs.android_pin_version }}
       android_pin_matches: ${{ steps.ref.outputs.android_pin_matches }}
       android_release_note: ${{ steps.ref.outputs.android_release_note }}
@@ -1346,6 +1347,66 @@ jobs:
         with:
           name: clawhub-bootstrap-approval-${{ github.run_id }}-${{ github.run_attempt }}
           path: ${{ runner.temp }}/clawhub-bootstrap-approval/approval.json
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Prepare stable npm bootstrap approval
+        if: ${{ inputs.npm_dist_tag == 'latest' && inputs.release_evidence_mode == 'full-release-validation' }}
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          TARGET_SHA: ${{ needs.resolve_release_target.outputs.sha }}
+          RELEASE_PROFILE: ${{ needs.resolve_release_target.outputs.release_profile }}
+          VALIDATION_RUN_ID: ${{ inputs.full_release_validation_run_id }}
+          VALIDATION_RUN_ATTEMPT: ${{ needs.resolve_release_target.outputs.full_release_validation_run_attempt }}
+          PLUGIN_PUBLISH_SCOPE: ${{ inputs.plugin_publish_scope }}
+          PLUGINS: ${{ inputs.plugins }}
+        run: |
+          set -euo pipefail
+          mkdir -p "${RUNNER_TEMP}/npm-stable-bootstrap-approval"
+          node --import tsx --input-type=module <<'NODE'
+          import { writeFileSync } from "node:fs";
+          import { collectPublishablePluginPackages, resolveSelectedPublishablePluginPackages } from "./.release-harness/scripts/lib/plugin-npm-release.ts";
+          import { createStablePluginNpmBootstrapApproval } from "./.release-harness/scripts/plugin-npm-bootstrap-approval.mjs";
+
+          const plugins = collectPublishablePluginPackages();
+          const selection = (process.env.PLUGINS ?? "").split(",").map((name) => name.trim()).filter(Boolean);
+          const scope = process.env.PLUGIN_PUBLISH_SCOPE;
+          if ((scope !== "selected" && scope !== "all-publishable") ||
+              (scope === "selected" && selection.length === 0) ||
+              (scope === "all-publishable" && selection.length > 0)) {
+            throw new Error("Stable npm bootstrap requires an explicit complete plugin selection.");
+          }
+          const packages = resolveSelectedPublishablePluginPackages({ plugins, selection });
+          const approval = createStablePluginNpmBootstrapApproval({
+            repository: process.env.GITHUB_REPOSITORY,
+            parentRunId: process.env.GITHUB_RUN_ID,
+            parentRunAttempt: Number(process.env.GITHUB_RUN_ATTEMPT),
+            workflowBranch: process.env.GITHUB_REF_NAME,
+            workflowFullRef: process.env.GITHUB_REF,
+            parentWorkflowSha: process.env.GITHUB_SHA,
+            releaseTag: process.env.RELEASE_TAG,
+            targetSha: process.env.TARGET_SHA,
+            publishTag: "latest",
+            releaseProfile: process.env.RELEASE_PROFILE,
+            validationRunId: process.env.VALIDATION_RUN_ID,
+            validationRunAttempt: Number(process.env.VALIDATION_RUN_ATTEMPT),
+            packages: packages.map((plugin) => plugin.packageName),
+          });
+          writeFileSync(`${process.env.RUNNER_TEMP}/npm-stable-bootstrap-approval/approval.json`, `${JSON.stringify(approval, null, 2)}\n`);
+          NODE
+
+      - name: Attest stable npm bootstrap approval
+        if: ${{ inputs.npm_dist_tag == 'latest' && inputs.release_evidence_mode == 'full-release-validation' }}
+        uses: actions/attest@1e69f48acb82d1966a394da916b4c1698aa569d6 # v4.2.2
+        with:
+          subject-path: ${{ runner.temp }}/npm-stable-bootstrap-approval/approval.json
+
+      - name: Upload stable npm bootstrap approval
+        if: ${{ inputs.npm_dist_tag == 'latest' && inputs.release_evidence_mode == 'full-release-validation' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: npm-stable-bootstrap-approval-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/npm-stable-bootstrap-approval/approval.json
           if-no-files-found: error
           retention-days: 30
 

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -29,6 +29,7 @@ on:
       - "scripts/lib/actions-artifact-archive.mjs"
       - "scripts/plugin-npm-publish.sh"
       - "scripts/plugin-publication-artifact.mjs"
+      - "scripts/plugin-npm-bootstrap-approval.mjs"
       - "scripts/release-tooling-identity.d.mts"
       - "scripts/release-tooling-identity.mjs"
       - "scripts/plugin-npm-release-check.ts"
@@ -1252,6 +1253,7 @@ jobs:
     environment: npm-release
     permissions:
       actions: read
+      attestations: read
       contents: read
       id-token: write
     strategy:
@@ -1632,6 +1634,55 @@ jobs:
           console.log("already_published=true");
           NODE
 
+      - name: Download stable npm bootstrap approval
+        if: ${{ steps.publication_evidence.outputs.publish_route == 'npm-token-bootstrap' && steps.publication_evidence.outputs.publish_tag == 'latest' }}
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: npm-stable-bootstrap-approval-${{ inputs.release_publish_run_id }}-${{ inputs.release_publish_run_attempt }}
+          path: ${{ runner.temp }}/npm-stable-bootstrap-approval
+          repository: ${{ github.repository }}
+          run-id: ${{ inputs.release_publish_run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Authorize bootstrap release
+        if: steps.publication_evidence.outputs.publish_route == 'npm-token-bootstrap'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PACKAGE_NAME: ${{ steps.publication_evidence.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.publication_evidence.outputs.package_version }}
+          PUBLISH_TAG: ${{ steps.publication_evidence.outputs.publish_tag }}
+          RELEASE_TARGET_SHA: ${{ needs.preview_plugins_npm.outputs.ref_revision }}
+          RELEASE_PUBLISH_RUN_ID: ${{ inputs.release_publish_run_id }}
+          EXPECTED_RUN_ATTEMPT: ${{ inputs.release_publish_run_attempt }}
+          EXPECTED_WORKFLOW_BRANCH: ${{ inputs.release_publish_branch }}
+          EXPECTED_WORKFLOW_FULL_REF: ${{ inputs.release_publish_full_ref }}
+          EXPECTED_WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          if [[ "$PACKAGE_VERSION" == *"-beta."* && "$PUBLISH_TAG" == "beta" ]]; then
+            exit 0
+          fi
+          [[ "$PUBLISH_TAG" == "latest" ]] || {
+            echo "npm bootstrap requires beta or an attested regular stable/latest approval." >&2
+            exit 1
+          }
+          approval="${RUNNER_TEMP}/npm-stable-bootstrap-approval/approval.json"
+          gh attestation verify "$approval" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "$GITHUB_REPOSITORY/.github/workflows/openclaw-release-publish.yml" \
+            --signer-digest "$EXPECTED_WORKFLOW_SHA" \
+            --source-digest "$EXPECTED_WORKFLOW_SHA" \
+            --source-ref "$EXPECTED_WORKFLOW_FULL_REF" \
+            --deny-self-hosted-runners
+          direct_recovery=false
+          if [[ "$GITHUB_ACTOR" != "github-actions[bot]" ]]; then
+            direct_recovery=true
+          fi
+          gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RELEASE_PUBLISH_RUN_ID}" \
+            --jq '{workflowName: .name, headBranch: .head_branch, headSha: .head_sha, event, status, conclusion, url: .html_url, runAttempt: .run_attempt, repository: .repository.full_name, path}' |
+            APPROVAL_PATH="$approval" RELEASE_APPROVAL_KIND=npm-stable-bootstrap \
+              DIRECT_RELEASE_RECOVERY="$direct_recovery" node scripts/validate-release-publish-approval.mjs
+
       - name: Publish approved bootstrap tarball
         if: steps.publication_evidence.outputs.publish_route == 'npm-token-bootstrap' && steps.bootstrap_npm_package_version.outputs.already_published != 'true'
         env:
@@ -1652,10 +1703,6 @@ jobs:
           WORKFLOW_SHA: ${{ github.workflow_sha }}
         run: |
           set -euo pipefail
-          [[ "$PACKAGE_VERSION" == *"-beta."* && "$PUBLISH_TAG" == "beta" ]] || {
-            echo "npm token bootstrap requires an approved beta package and beta tag." >&2
-            exit 1
-          }
           [[ -n "${NPM_TOKEN// }" ]] || {
             echo "npm token bootstrap requires the protected npm release token." >&2
             exit 1
@@ -1710,14 +1757,31 @@ jobs:
           PACKAGE_VERSION: ${{ steps.publication_evidence.outputs.package_version }}
         run: node --import tsx scripts/verify-plugin-npm-published-runtime.mts "${PACKAGE_NAME}@${PACKAGE_VERSION}"
 
-      - name: Record Meta trusted publisher checkpoint
+      - name: Verify bootstrap npm dist-tag
+        if: steps.publication_evidence.outputs.publish_route == 'npm-token-bootstrap'
+        env:
+          PACKAGE_NAME: ${{ steps.publication_evidence.outputs.package_name }}
+          PACKAGE_VERSION: ${{ steps.publication_evidence.outputs.package_version }}
+          PUBLISH_TAG: ${{ steps.publication_evidence.outputs.publish_tag }}
+        run: |
+          set -euo pipefail
+          npm view "$PACKAGE_NAME" dist-tags --json --prefer-online |
+            node --input-type=module -e '
+              import { readFileSync } from "node:fs";
+              const tags = JSON.parse(readFileSync(0, "utf8"));
+              if (tags[process.env.PUBLISH_TAG] !== process.env.PACKAGE_VERSION) {
+                throw new Error("Bootstrap dist-tag does not match the approved version; use credential-isolated selector recovery without republishing.");
+              }
+            '
+
+      - name: Record plugin trusted publisher checkpoint
         if: steps.publication_evidence.outputs.publish_route == 'npm-token-bootstrap'
         env:
           ALREADY_PUBLISHED: ${{ steps.bootstrap_npm_package_version.outputs.already_published }}
           PACKAGE_NAME: ${{ steps.publication_evidence.outputs.package_name }}
         run: |
           {
-            echo "## Meta npm bootstrap follow-up"
+            echo "## Plugin npm bootstrap follow-up"
             echo
             if [[ "$ALREADY_PUBLISHED" == "true" ]]; then
               echo "- Verified existing \`${PACKAGE_NAME}\` against the approved immutable tarball."

--- a/scripts/lib/plugin-publication-candidates.ts
+++ b/scripts/lib/plugin-publication-candidates.ts
@@ -36,6 +36,7 @@ export const PLUGIN_NPM_RELEASE_AUTHORITY_PATHS = [
   "scripts/plugin-npm-release-check.ts",
   "scripts/plugin-npm-release-plan.ts",
   "scripts/plugin-publication-artifact.mjs",
+  "scripts/plugin-npm-bootstrap-approval.mjs",
   "scripts/release-tooling-identity.d.mts",
   "scripts/release-tooling-identity.mjs",
   "scripts/verify-plugin-npm-published-runtime.mts",

--- a/scripts/plugin-npm-bootstrap-approval.mjs
+++ b/scripts/plugin-npm-bootstrap-approval.mjs
@@ -1,0 +1,91 @@
+import { parseReleaseVersion } from "./lib/release-version.mjs";
+
+const SHA = /^[a-f0-9]{40}$/u;
+const PACKAGE = /^@openclaw\/[a-z0-9][a-z0-9._-]*$/u;
+
+export function createStablePluginNpmBootstrapApproval(input) {
+  const version = typeof input.releaseTag === "string" ? input.releaseTag.slice(1) : "";
+  const parsed = parseReleaseVersion(version);
+  if (
+    input.releaseTag !== `v${version}` ||
+    parsed?.channel !== "stable" ||
+    parsed.patch >= 33 ||
+    input.publishTag !== "latest" ||
+    !["stable", "full"].includes(input.releaseProfile)
+  ) {
+    throw new Error(
+      "Stable npm bootstrap requires a regular stable tag, latest, and stable/full validation.",
+    );
+  }
+  if (
+    input.repository !== "openclaw/openclaw" ||
+    !SHA.test(input.targetSha ?? "") ||
+    !SHA.test(input.parentWorkflowSha ?? "") ||
+    !new RegExp(`^release-publish/${input.parentWorkflowSha.slice(0, 12)}-[1-9][0-9]*$`, "u").test(
+      input.workflowBranch,
+    ) ||
+    input.workflowFullRef !== `refs/tags/${input.workflowBranch}` ||
+    !/^[1-9][0-9]*$/u.test(input.parentRunId ?? "") ||
+    !Number.isSafeInteger(input.parentRunAttempt) ||
+    input.parentRunAttempt < 1 ||
+    !/^[1-9][0-9]*$/u.test(input.validationRunId ?? "") ||
+    !Number.isSafeInteger(input.validationRunAttempt) ||
+    input.validationRunAttempt < 1
+  ) {
+    throw new Error(
+      "Stable npm bootstrap requires an exact protected parent and validation tuple.",
+    );
+  }
+  if (
+    !Array.isArray(input.packages) ||
+    input.packages.length === 0 ||
+    input.packages.some((name) => typeof name !== "string" || !PACKAGE.test(name)) ||
+    new Set(input.packages).size !== input.packages.length
+  ) {
+    throw new Error("Stable npm bootstrap requires a unique publishable @openclaw package set.");
+  }
+  return {
+    version: 1,
+    kind: "npm-stable-bootstrap",
+    repository: input.repository,
+    parentRunId: input.parentRunId,
+    parentRunAttempt: input.parentRunAttempt,
+    workflowBranch: input.workflowBranch,
+    workflowFullRef: input.workflowFullRef,
+    parentWorkflowSha: input.parentWorkflowSha,
+    releaseTag: input.releaseTag,
+    targetSha: input.targetSha,
+    publishTag: input.publishTag,
+    releaseProfile: input.releaseProfile,
+    validationRunId: input.validationRunId,
+    validationRunAttempt: input.validationRunAttempt,
+    packages: input.packages.toSorted(),
+  };
+}
+
+export function validateStablePluginNpmBootstrapApproval(approval, expected) {
+  const canonical = createStablePluginNpmBootstrapApproval(approval);
+  if (JSON.stringify(approval) !== JSON.stringify(canonical)) {
+    throw new Error("Stable npm bootstrap approval is not canonical.");
+  }
+  for (const key of [
+    "repository",
+    "parentRunId",
+    "parentRunAttempt",
+    "workflowBranch",
+    "workflowFullRef",
+    "parentWorkflowSha",
+    "targetSha",
+    "publishTag",
+  ]) {
+    if (approval[key] !== expected[key]) {
+      throw new Error(`Stable npm bootstrap approval ${key} does not match this publication.`);
+    }
+  }
+  if (
+    approval.releaseTag !== `v${expected.packageVersion}` ||
+    !approval.packages.includes(expected.packageName)
+  ) {
+    throw new Error("Stable npm bootstrap approval does not cover this package and version.");
+  }
+}

--- a/scripts/validate-release-publish-approval.mjs
+++ b/scripts/validate-release-publish-approval.mjs
@@ -3,6 +3,7 @@
 import { execFileSync } from "node:child_process";
 import fs from "node:fs";
 import { verifyAndroidNativeCi } from "./android-native-ci.mjs";
+import { validateStablePluginNpmBootstrapApproval } from "./plugin-npm-bootstrap-approval.mjs";
 import {
   runReleaseToolingGh,
   validateReleasePublishParentRun,
@@ -49,8 +50,10 @@ function positiveRunAttempt(value) {
   return Number(value);
 }
 
-if (approvalKind === "clawhub-bootstrap" && !approvalPath) {
-  fail("ClawHub bootstrap approval requires an attested approval artifact.");
+if (["clawhub-bootstrap", "npm-stable-bootstrap"].includes(approvalKind) && !approvalPath) {
+  fail(
+    `${approvalKind === "clawhub-bootstrap" ? "ClawHub" : "Stable npm"} bootstrap approval requires an attested approval artifact.`,
+  );
 }
 
 if (approvalPath) {
@@ -92,6 +95,41 @@ if (approvalPath) {
     };
     mismatchMessage =
       "Attested ClawHub bootstrap approval does not match this release target and package set.";
+  } else if (approvalKind === "npm-stable-bootstrap") {
+    validateStablePluginNpmBootstrapApproval(approval, {
+      repository: process.env.GITHUB_REPOSITORY,
+      parentRunId: releasePublishRunId,
+      parentRunAttempt: positiveRunAttempt(expectedRunAttempt),
+      workflowBranch: expectedBranch,
+      workflowFullRef: expectedWorkflowFullRef,
+      parentWorkflowSha: expectedWorkflowSha,
+      targetSha: process.env.RELEASE_TARGET_SHA,
+      packageName: process.env.PACKAGE_NAME,
+      packageVersion: process.env.PACKAGE_VERSION,
+      publishTag: process.env.PUBLISH_TAG,
+    });
+    expectedApproval = approval;
+    mismatchMessage = "Stable npm bootstrap approval mismatch.";
+    const refs = execFileSync(
+      "git",
+      [
+        "ls-remote",
+        "--tags",
+        "origin",
+        `refs/tags/${approval.releaseTag}`,
+        `refs/tags/${approval.releaseTag}^{}`,
+      ],
+      { encoding: "utf8", timeout: 60_000, maxBuffer: 1024 * 1024 },
+    )
+      .trim()
+      .split("\n")
+      .map((line) => line.split(/\s+/u));
+    const tagSha =
+      refs.find(([, ref]) => ref === `refs/tags/${approval.releaseTag}^{}`)?.[0] ??
+      refs.find(([, ref]) => ref === `refs/tags/${approval.releaseTag}`)?.[0];
+    if (tagSha !== approval.targetSha) {
+      fail("Stable npm bootstrap release tag no longer matches the approved target.");
+    }
   } else {
     fail(`Unsupported release approval kind: ${approvalKind}`);
   }

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -9,10 +9,11 @@ import {
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { dirname, join } from "node:path";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { PLUGIN_NPM_RELEASE_AUTHORITY_PATHS } from "../../scripts/lib/plugin-publication-candidates.ts";
+import { createStablePluginNpmBootstrapApproval } from "../../scripts/plugin-npm-bootstrap-approval.mjs";
 import { requireNodeTool } from "../helpers/node-toolchain.js";
 
 const workflowPath = ".github/workflows/plugin-npm-release.yml";
@@ -75,7 +76,150 @@ function workflowPathPatternCovers(pattern: string, path: string): boolean {
   return path === pattern;
 }
 
+function runStableBootstrapAdmission(
+  overrides: {
+    approval?: Record<string, unknown>;
+    env?: Record<string, string>;
+    run?: Record<string, unknown>;
+    attestationExit?: number;
+    tagSha?: string;
+  } = {},
+) {
+  const root = mkdtempSync(join(tmpdir(), "npm-bootstrap-approval-"));
+  try {
+    const toolingSha = "b".repeat(40);
+    const targetSha = "a".repeat(40);
+    const branch = `release-publish/${toolingSha.slice(0, 12)}-123`;
+    const approval = createStablePluginNpmBootstrapApproval({
+      repository: "openclaw/openclaw",
+      parentRunId: "123",
+      parentRunAttempt: 2,
+      workflowBranch: branch,
+      workflowFullRef: `refs/tags/${branch}`,
+      parentWorkflowSha: toolingSha,
+      targetSha,
+      releaseTag: "v2026.9.3",
+      publishTag: "latest",
+      releaseProfile: "stable",
+      validationRunId: "456",
+      validationRunAttempt: 3,
+      packages: ["@openclaw/team-reports"],
+    });
+    const approvalDir = join(root, "npm-stable-bootstrap-approval");
+    mkdirSync(approvalDir);
+    writeFileSync(
+      join(approvalDir, "approval.json"),
+      JSON.stringify({ ...approval, ...overrides.approval }),
+    );
+    const run = {
+      workflowName: "OpenClaw Release Publish",
+      headBranch: branch,
+      headSha: toolingSha,
+      event: "workflow_dispatch",
+      status: "in_progress",
+      conclusion: null,
+      runAttempt: 2,
+      repository: "openclaw/openclaw",
+      path: `.github/workflows/openclaw-release-publish.yml@refs/tags/${branch}`,
+      ...overrides.run,
+    };
+    const bin = join(root, "bin");
+    mkdirSync(bin);
+    writeFileSync(
+      join(bin, "gh"),
+      `#!${process.execPath}\nif(process.argv[2] === "attestation") process.exit(${overrides.attestationExit ?? 0}); process.stdout.write(${JSON.stringify(JSON.stringify(run))});\n`,
+      { mode: 0o755 },
+    );
+    const refs = `${overrides.tagSha ?? targetSha}\trefs/tags/v2026.9.3^{}\n`;
+    writeFileSync(
+      join(bin, "git"),
+      `#!${process.execPath}\nprocess.stdout.write(${JSON.stringify(refs)});\n`,
+      { mode: 0o755 },
+    );
+    return spawnSync(
+      "/bin/bash",
+      ["-c", step(workflow().jobs?.publish_plugins_npm, "Authorize bootstrap release").run!],
+      {
+        encoding: "utf8",
+        timeout: 15_000,
+        env: {
+          PATH: `${bin}:${dirname(process.execPath)}:/usr/bin:/bin`,
+          RUNNER_TEMP: root,
+          GITHUB_REPOSITORY: "openclaw/openclaw",
+          GITHUB_ACTOR: "github-actions[bot]",
+          PACKAGE_NAME: "@openclaw/team-reports",
+          PACKAGE_VERSION: "2026.9.3",
+          PUBLISH_TAG: "latest",
+          RELEASE_TARGET_SHA: targetSha,
+          RELEASE_PUBLISH_RUN_ID: "123",
+          EXPECTED_RUN_ATTEMPT: "2",
+          EXPECTED_WORKFLOW_BRANCH: branch,
+          EXPECTED_WORKFLOW_FULL_REF: `refs/tags/${branch}`,
+          EXPECTED_WORKFLOW_SHA: toolingSha,
+          ...overrides.env,
+        },
+      },
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
 describe("plugin npm extended-stable workflow", () => {
+  it.skipIf(process.platform === "win32")(
+    "admits exact attested stable/full bootstrap and retains beta",
+    () => {
+      for (const releaseProfile of ["stable", "full"]) {
+        const result = runStableBootstrapAdmission({ approval: { releaseProfile } });
+        expect(result.status, result.stderr).toBe(0);
+      }
+      const beta = runStableBootstrapAdmission({
+        env: { PACKAGE_VERSION: "2026.9.3-beta.1", PUBLISH_TAG: "beta" },
+        attestationExit: 1,
+      });
+      expect(beta.status, beta.stderr).toBe(0);
+    },
+  );
+
+  it.skipIf(process.platform === "win32").each([
+    ["package scope", { env: { PACKAGE_NAME: "@openclaw/unselected" } }],
+    ["version", { env: { PACKAGE_VERSION: "2026.9.4" } }],
+    ["selector", { env: { PUBLISH_TAG: "beta" } }],
+    ["alpha", { env: { PACKAGE_VERSION: "2026.9.3-alpha.1", PUBLISH_TAG: "alpha" } }],
+    [
+      "extended-stable",
+      { approval: { releaseTag: "v2026.9.33" }, env: { PACKAGE_VERSION: "2026.9.33" } },
+    ],
+    ["profile", { approval: { releaseProfile: "beta" } }],
+    ["attestation", { attestationExit: 1 }],
+    ["tag moved", { tagSha: "c".repeat(40) }],
+    ["target", { approval: { targetSha: "c".repeat(40) } }],
+    ["parent attempt", { run: { runAttempt: 3 } }],
+    ["cancelled parent", { run: { status: "completed", conclusion: "cancelled" } }],
+    ["tooling", { run: { headSha: "c".repeat(40) } }],
+    [
+      "direct main",
+      { env: { EXPECTED_WORKFLOW_BRANCH: "main", EXPECTED_WORKFLOW_FULL_REF: "refs/heads/main" } },
+    ],
+  ] as const)("rejects changed stable bootstrap %s", (_name, overrides) => {
+    const result = runStableBootstrapAdmission(overrides);
+    expect(result.status, result.stderr).not.toBe(0);
+  });
+
+  it("authorizes bootstrap recovery and verifies selectors even when bytes already exist", () => {
+    const publish = workflow().jobs?.publish_plugins_npm;
+    expect(step(publish, "Authorize bootstrap release").if).toBe(
+      "steps.publication_evidence.outputs.publish_route == 'npm-token-bootstrap'",
+    );
+    expect(step(publish, "Verify bootstrap npm dist-tag").if).toBe(
+      "steps.publication_evidence.outputs.publish_route == 'npm-token-bootstrap'",
+    );
+    expect(publish?.permissions?.attestations).toBe("read");
+    const approval = step(publish, "Download stable npm bootstrap approval");
+    expect(approval.with?.name).toContain(
+      "${{ inputs.release_publish_run_id }}-${{ inputs.release_publish_run_attempt }}",
+    );
+  });
   it("keeps push triggers aligned with npm publication authorities", () => {
     const triggerPaths = (workflow().on?.push?.paths ?? []).filter(
       (path) => path !== "extensions/**",

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -10,6 +10,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
+import { runInNewContext } from "node:vm";
 import { describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { PLUGIN_NPM_RELEASE_AUTHORITY_PATHS } from "../../scripts/lib/plugin-publication-candidates.ts";
@@ -166,6 +167,40 @@ function runStableBootstrapAdmission(
 }
 
 describe("plugin npm extended-stable workflow", () => {
+  it.each([
+    ["selected existing-package repair", "", "latest", "full-release-validation", false],
+    ["qualified stable publication", "stable", "latest", "full-release-validation", true],
+    ["qualified full publication", "full", "latest", "full-release-validation", true],
+    ["beta publication", "beta", "beta", "full-release-validation", false],
+    ["focused beta evidence", "beta", "latest", "authorized-beta-focused-v1", false],
+  ])(
+    "creates bootstrap approval only with qualified evidence: %s",
+    (_name, profile, distTag, evidenceMode, expected) => {
+      const parent = parse(
+        readFileSync(".github/workflows/openclaw-release-publish.yml", "utf8"),
+      ) as Workflow;
+      for (const name of [
+        "Prepare stable npm bootstrap approval",
+        "Attest stable npm bootstrap approval",
+        "Upload stable npm bootstrap approval",
+      ]) {
+        const condition = step(parent.jobs?.publish, name).if!;
+        expect(
+          runInNewContext(condition.slice(3, -2), {
+            inputs: {
+              npm_dist_tag: distTag,
+              release_evidence_mode: evidenceMode,
+              publish_openclaw_npm: false,
+              plugin_publish_scope: "selected",
+            },
+            needs: { resolve_release_target: { outputs: { release_profile: profile } } },
+          }),
+          name,
+        ).toBe(expected);
+      }
+    },
+  );
+
   it.skipIf(process.platform === "win32")(
     "admits exact attested stable/full bootstrap and retains beta",
     () => {

--- a/test/scripts/test-projects.test.ts
+++ b/test/scripts/test-projects.test.ts
@@ -1190,6 +1190,7 @@ describe("scripts/test-projects changed-target routing", () => {
         "test/scripts/authorized-beta-focused-evidence.test.ts",
         "test/scripts/clawhub-parent-authorization.test.ts",
         "test/scripts/clawhub-postpublish.test.ts",
+        "test/scripts/plugin-npm-extended-stable-workflow.test.ts",
         "test/scripts/release-candidate-checklist.test.ts",
         "test/scripts/release-no-push-workflow.test.ts",
         "test/scripts/release-plan-producer.test.ts",


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where newly introduced plugins cannot first publish during a regular stable release. npm preflight correctly selects bootstrap for a missing package, but the publisher rejects every non-beta version. This blocks `@openclaw/team-reports@2026.9.3`.

## Why This Change Was Made

Allow regular stable/latest bootstrap only with an attested approval from the qualified, protected Release Publish parent. The receipt binds selected packages, exact tag/source, stable/full validation, Tooling SHA and parent attempt. The child verifies that receipt, the live tag and parent, and existing immutable package evidence before publishing. Beta behavior stays intact; alpha, extended-stable and mismatched scopes or identities remain rejected.

Selected existing-package repairs without Full Release Validation continue through their existing OIDC path; the bootstrap receipt is generated only when the parent has qualified stable/full evidence. Same-byte recovery never republishes and now verifies the selected dist-tag explicitly. The first-package guide documents this flow and subsequent OIDC setup.

## User Impact

Release operators can publish a new plugin at its actual approved stable version without inventing a placeholder or beta. Package-creation permission remains required; the configured token's actual creation entitlement has not been exercised by this change.

## Evidence

Reproduced the old stable rejection by executing the original workflow step. The original owner/approval/artifact and package-acceptance workflow runs passed 569 tests. After correcting selected-repair admission, all 37 publisher-workflow tests and both changed/workflow gates passed again. The new selected-repair regression failed before that correction. The three release-workflow routing cases also pass with the new regression owner included. Independent P2 reviews found no remaining actionable issues. No registry writes were used for these tests.
