### PR TITLE
fix(discord): pass owned runTarget for voice agent control

### DIFF
--- a/.pr-bodies/discord-voice-run-target.md
+++ b/.pr-bodies/discord-voice-run-target.md
@@ -1,0 +1,132 @@
+## What Problem This Solves
+
+Discord voice `maybeControlDiscordVoiceAgentRun` / `handleAgentControlToolCall`
+omitted `runTarget` when calling `controlRealtimeVoiceAgentRun`, so control fell
+into the session-key legacy path (`resolveActiveEmbeddedRunSessionId` →
+abort/queue by sessionId) without verifying `route.agentId`. A foreign agent
+registered on the same sessionKey could be cancelled/steered. Gateway Talk
+already passes an owned `runTarget`.
+
+## Why This Change Was Made
+
+Discord-only: always pass an owned `runTarget`, or `runTarget: null` when
+ownership cannot be proven (fail-closed). Add a plugin-sdk seam
+`resolveOwnedActiveRealtimeVoiceRunTargetForAgent` (sessionKey + agentId) and a
+Discord-local resolver that also fences voice session lifecycle. Do not change
+`abortEmbeddedAgentRun` (#141379) or Talk gateway ownership (#132129).
+
+## User Impact
+
+**Before:** Saying “cancel” in Discord voice could abort another agent’s run
+that collided on the same sessionKey.
+
+**After:** Discord voice control only affects a run proven to match
+`route.sessionKey` + `route.agentId` on a live voice session; otherwise it
+fail-closes with no active run.
+
+## Evidence
+
+- Changed: `src/talk/realtime-voice-run-target.ts`,
+  `src/talk/realtime-voice-run-target.test.ts`,
+  `src/plugin-sdk/realtime-voice.ts`,
+  `extensions/discord/src/voice/agent-run-target.ts`,
+  `extensions/discord/src/voice/agent-control.ts`,
+  `extensions/discord/src/voice/agent-control.test.ts`,
+  `extensions/discord/src/voice/agent-control.run-target.test.ts`,
+  `extensions/discord/src/voice/realtime-consults.ts`,
+  plus expectation updates in Discord voice tests
+- Production path: Discord voice transcript/tool control →
+  `controlDiscordVoiceAgentRun` →
+  `resolveDiscordVoiceAgentRunTarget` →
+  `resolveOwnedActiveRealtimeVoiceRunTargetForAgent` →
+  `controlRealtimeVoiceAgentRun({ runTarget })`
+- Compatibility: Talk/`resolveOwnedActiveTalkRunTarget` unchanged; omitting
+  `runTarget` elsewhere retains legacy behavior
+- Dedup: ≠ #132129 (Talk ownership), ≠ #141379 (embedded abort agent scope)
+
+## Real behavior proof
+
+### Behavior or issue addressed
+
+Foreign agentId `ops` on Discord sessionKey is not aborted; matching `main`
+owned run is cancelled; stopped voice session fail-closes; callers always pass
+`runTarget` (never `{sessionKey,text}` only).
+
+### Canonical reachability path
+
+Discord voice `maybeControlDiscordVoiceAgentRun` /
+`handleAgentControlToolCall` → `controlDiscordVoiceAgentRun` → owned/null
+`runTarget` → `controlRealtimeVoiceAgentRun`
+
+### Shared helper / provider constraint check
+
+Owner check lives in the new plugin-sdk seam + Discord lifecycle fence. No
+change to `abortEmbeddedAgentRun` signature or Talk `clientConnId` ownership.
+
+### Real environment tested
+
+Local trusted source checkout at PR head; Vitest unit + extension-discord;
+real `setActiveEmbeddedRun` registry + production Discord callers.
+
+### Exact steps or command run after this patch
+
+```bash
+node scripts/run-vitest.mjs src/talk/realtime-voice-run-target.test.ts extensions/discord/src/voice/agent-control.test.ts extensions/discord/src/voice/agent-control.run-target.test.ts --reporter=verbose
+```
+
+### Evidence after fix
+
+```text
+[test] starting test/vitest/vitest.unit.config.ts
+
+ RUN  v5.0.0 /workspace/openclaw-nocodet
+
+[vitest-workers] prepared 5736a0429020 in 5686ms (8596 inputs, 4303 outputs)
+ ✓ |unit| src/talk/realtime-voice-run-target.test.ts > resolveOwnedActiveRealtimeVoiceRunTargetForAgent > returns null for a foreign agentId on the same sessionKey (fail-closed) 14ms
+ ✓ |unit| src/talk/realtime-voice-run-target.test.ts > resolveOwnedActiveRealtimeVoiceRunTargetForAgent > admits the exact owned run for matching sessionKey+agentId 3ms
+ ✓ |unit| src/talk/realtime-voice-run-target.test.ts > resolveOwnedActiveRealtimeVoiceRunTargetForAgent > returns null when the voice session lifecycle fence fails 2ms
+ ✓ |unit| src/talk/realtime-voice-run-target.test.ts > controlRealtimeVoiceAgentRun with Discord-shaped ownership > null runTarget refuses legacy abort of a foreign-owned run 3ms
+ ✓ |unit| src/talk/realtime-voice-run-target.test.ts > controlRealtimeVoiceAgentRun with Discord-shaped ownership > owned runTarget cancels only the matching agent run 13ms
+
+ Test Files  1 passed (1)
+      Tests  5 passed (5)
+   Start at  17:41:40
+   Duration  9.66s (transform 82%, import 13%, worker 3%, setup 1%)
+
+[test] starting test/vitest/vitest.extension-discord.config.ts
+
+ RUN  v5.0.0 /workspace/openclaw-nocodet
+
+ ✓ |extension-discord| extensions/discord/src/voice/agent-control.test.ts > maybeControlDiscordVoiceAgentRun > falls back for inactive cancel-like phrases 25ms
+ ✓ |extension-discord| extensions/discord/src/voice/agent-control.test.ts > maybeControlDiscordVoiceAgentRun > handles active cancel requests with an explicit runTarget 2ms
+ ✓ |extension-discord| extensions/discord/src/voice/agent-control.test.ts > maybeControlDiscordVoiceAgentRun > passes an owned runTarget when the Discord resolver admits one 2ms
+ ✓ |extension-discord| extensions/discord/src/voice/agent-control.test.ts > maybeControlDiscordVoiceAgentRun > ignores non-control phrases 3ms
+ ✓ |extension-discord| extensions/discord/src/voice/agent-control.run-target.test.ts > Discord voice control runTarget ownership (caller path) > fail-closed: foreign agent on the same sessionKey is not aborted 12ms
+ ✓ |extension-discord| extensions/discord/src/voice/agent-control.run-target.test.ts > Discord voice control runTarget ownership (caller path) > owned agent cancel aborts the matching embedded run 8ms
+ ✓ |extension-discord| extensions/discord/src/voice/agent-control.run-target.test.ts > Discord voice control runTarget ownership (caller path) > stopped voice session refuses ownership (null fail-closed) 2ms
+
+ Test Files  2 passed (2)
+      Tests  7 passed (7)
+   Start at  17:41:50
+   Duration  16.83s (transform 77%, import 16%, worker 6%)
+
+[vitest-workers] verifying completed generation before cleanup
+[test] passed 2 Vitest shards in 28.75s
+```
+
+### Observed result after fix
+
+Talk ownership tests 5/5 and Discord caller-path tests 7/7 passed; foreign
+agent not aborted; owned cancel works; stopped session fail-closes; callers
+always include `runTarget`.
+
+### What was not tested
+
+No live Discord VC or Gateway WebSocket session.
+
+## Checklist
+
+- Synced with upstream/main; single commit; conflict-free
+- Quota / dedup / owner / fresh-main gates clear
+- Template body + Real behavior proof filled; caller-path proof pasted
+- AI-assisted; maintainers can edit; no CHANGELOG edit

--- a/extensions/discord/src/voice/agent-control.run-target.test.ts
+++ b/extensions/discord/src/voice/agent-control.run-target.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Caller-path proof: Discord voice active-run control always passes owned
+ * runTarget or null (fail-closed). Foreign agentId on the same sessionKey must
+ * not be aborted via session-key legacy control.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearActiveEmbeddedRun,
+  setActiveEmbeddedRun,
+} from "openclaw/plugin-sdk/agent-harness-runtime";
+import {
+  isEmbeddedAgentRunActive,
+} from "../../../../src/agents/embedded-agent-runner/runs.js";
+import {
+  createEmbeddedRunHandle,
+  testing as runsTesting,
+} from "../../../../src/agents/embedded-agent-runner/runs.test-support.js";
+import { controlDiscordVoiceAgentRun } from "./agent-control.js";
+
+function createEntry(agentId = "main") {
+  return {
+    route: {
+      agentId,
+      sessionKey: "agent:main:discord:channel:c1",
+    },
+    generation: 1,
+    sessionLifecycle: { status: "active" as const },
+  };
+}
+
+describe("Discord voice control runTarget ownership (caller path)", () => {
+  const sessionKey = "agent:main:discord:channel:c1";
+  const sessionId = "shared-colliding-session-id";
+
+  beforeEach(() => {
+    runsTesting.resetActiveEmbeddedRuns();
+  });
+
+  afterEach(() => {
+    runsTesting.resetActiveEmbeddedRuns();
+  });
+
+  it("fail-closed: foreign agent on the same sessionKey is not aborted", async () => {
+    const abortSpy = vi.fn();
+    setActiveEmbeddedRun(
+      sessionId,
+      createEmbeddedRunHandle({ abort: abortSpy, runId: "run-ops" }),
+      sessionKey,
+      undefined,
+      "ops",
+    );
+
+    const result = await controlDiscordVoiceAgentRun({
+      entry: createEntry("main"),
+      text: "cancel that",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      active: false,
+      reason: "no_active_run",
+    });
+    expect(abortSpy).not.toHaveBeenCalled();
+    expect(isEmbeddedAgentRunActive(sessionId)).toBe(true);
+    clearActiveEmbeddedRun(sessionId);
+  });
+
+  it("owned agent cancel aborts the matching embedded run", async () => {
+    const abortSpy = vi.fn();
+    setActiveEmbeddedRun(
+      sessionId,
+      createEmbeddedRunHandle({ abort: abortSpy, runId: "run-main" }),
+      sessionKey,
+      undefined,
+      "main",
+    );
+
+    const result = await controlDiscordVoiceAgentRun({
+      entry: createEntry("main"),
+      text: "cancel that",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      active: true,
+      aborted: true,
+      sessionId,
+    });
+    expect(abortSpy).toHaveBeenCalled();
+  });
+
+  it("stopped voice session refuses ownership (null fail-closed)", async () => {
+    const abortSpy = vi.fn();
+    setActiveEmbeddedRun(
+      sessionId,
+      createEmbeddedRunHandle({ abort: abortSpy, runId: "run-main" }),
+      sessionKey,
+      undefined,
+      "main",
+    );
+
+    const result = await controlDiscordVoiceAgentRun({
+      entry: {
+        ...createEntry("main"),
+        sessionLifecycle: { status: "stopped", reason: "left" },
+      },
+      text: "cancel that",
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      active: false,
+      reason: "no_active_run",
+    });
+    expect(abortSpy).not.toHaveBeenCalled();
+    expect(isEmbeddedAgentRunActive(sessionId)).toBe(true);
+  });
+});

--- a/extensions/discord/src/voice/agent-control.test.ts
+++ b/extensions/discord/src/voice/agent-control.test.ts
@@ -5,23 +5,35 @@ import { maybeControlDiscordVoiceAgentRun } from "./agent-control.js";
 const mocks = vi.hoisted(() => ({
   controlRealtimeVoiceAgentRun: vi.fn(),
   shouldAutoControlRealtimeVoiceAgentText: vi.fn(),
+  resolveOwnedActiveRealtimeVoiceRunTargetForAgent: vi.fn(() => null),
 }));
 
-vi.mock("openclaw/plugin-sdk/realtime-voice", () => ({
-  controlRealtimeVoiceAgentRun: mocks.controlRealtimeVoiceAgentRun,
-  shouldAutoControlRealtimeVoiceAgentText: mocks.shouldAutoControlRealtimeVoiceAgentText,
-}));
+vi.mock("openclaw/plugin-sdk/realtime-voice", async () => {
+  const actual = await vi.importActual<typeof import("openclaw/plugin-sdk/realtime-voice")>(
+    "openclaw/plugin-sdk/realtime-voice",
+  );
+  return {
+    ...actual,
+    controlRealtimeVoiceAgentRun: mocks.controlRealtimeVoiceAgentRun,
+    shouldAutoControlRealtimeVoiceAgentText: mocks.shouldAutoControlRealtimeVoiceAgentText,
+    resolveOwnedActiveRealtimeVoiceRunTargetForAgent:
+      mocks.resolveOwnedActiveRealtimeVoiceRunTargetForAgent,
+  };
+});
 
 function createEntry() {
-  return { route: { sessionKey: "discord:g1:c1" } } as Parameters<
-    typeof maybeControlDiscordVoiceAgentRun
-  >[0]["entry"];
+  return {
+    route: { sessionKey: "discord:g1:c1", agentId: "agent-1" },
+    generation: 1,
+    sessionLifecycle: { status: "active" as const },
+  } as Parameters<typeof maybeControlDiscordVoiceAgentRun>[0]["entry"];
 }
 
 describe("maybeControlDiscordVoiceAgentRun", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.shouldAutoControlRealtimeVoiceAgentText.mockReturnValue(true);
+    mocks.resolveOwnedActiveRealtimeVoiceRunTargetForAgent.mockReturnValue(null);
   });
 
   it("falls back for inactive cancel-like phrases", async () => {
@@ -42,9 +54,14 @@ describe("maybeControlDiscordVoiceAgentRun", () => {
         text: "cancel my meeting tomorrow",
       }),
     ).resolves.toEqual({ handled: false, result });
+    expect(mocks.controlRealtimeVoiceAgentRun).toHaveBeenCalledExactlyOnceWith({
+      sessionKey: "discord:g1:c1",
+      runTarget: null,
+      text: "cancel my meeting tomorrow",
+    });
   });
 
-  it("handles active cancel requests", async () => {
+  it("handles active cancel requests with an explicit runTarget", async () => {
     const result = {
       ok: true,
       active: true,
@@ -65,6 +82,42 @@ describe("maybeControlDiscordVoiceAgentRun", () => {
       handled: true,
       result,
       speakText: "Cancelled the active OpenClaw run.",
+    });
+    const args = mocks.controlRealtimeVoiceAgentRun.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(args).toEqual({
+      sessionKey: "discord:g1:c1",
+      runTarget: null,
+      text: "cancel that",
+    });
+    expect(args).toHaveProperty("runTarget");
+  });
+
+  it("passes an owned runTarget when the Discord resolver admits one", async () => {
+    const runTarget = {
+      runId: "owned-run",
+      signal: new AbortController().signal,
+      isCurrent: () => true,
+    };
+    mocks.resolveOwnedActiveRealtimeVoiceRunTargetForAgent.mockReturnValue(runTarget);
+    mocks.controlRealtimeVoiceAgentRun.mockResolvedValue({
+      ok: true,
+      active: true,
+      mode: "cancel",
+      sessionKey: "discord:g1:c1",
+      message: "Cancelled the active OpenClaw run.",
+      speak: true,
+      suppress: false,
+    });
+
+    await maybeControlDiscordVoiceAgentRun({
+      entry: createEntry(),
+      text: "cancel that",
+    });
+
+    expect(mocks.controlRealtimeVoiceAgentRun).toHaveBeenCalledExactlyOnceWith({
+      sessionKey: "discord:g1:c1",
+      runTarget,
+      text: "cancel that",
     });
   });
 

--- a/extensions/discord/src/voice/agent-control.ts
+++ b/extensions/discord/src/voice/agent-control.ts
@@ -4,7 +4,13 @@ import {
   shouldAutoControlRealtimeVoiceAgentText,
   type RealtimeVoiceAgentControlResult,
 } from "openclaw/plugin-sdk/realtime-voice";
+import { resolveDiscordVoiceAgentRunTarget } from "./agent-run-target.js";
 import type { VoiceSessionEntry } from "./session.js";
+
+type DiscordVoiceAgentControlEntry = Pick<
+  VoiceSessionEntry,
+  "route" | "generation" | "sessionLifecycle"
+>;
 
 type DiscordVoiceAgentControlOutcome =
   | {
@@ -17,17 +23,28 @@ type DiscordVoiceAgentControlOutcome =
       result?: RealtimeVoiceAgentControlResult;
     };
 
+/** Always pass owned runTarget or null — never omit into session-key legacy. */
+export async function controlDiscordVoiceAgentRun(params: {
+  entry: DiscordVoiceAgentControlEntry;
+  text: string;
+  mode?: unknown;
+}): Promise<RealtimeVoiceAgentControlResult> {
+  return controlRealtimeVoiceAgentRun({
+    sessionKey: params.entry.route.sessionKey,
+    runTarget: resolveDiscordVoiceAgentRunTarget(params.entry),
+    text: params.text,
+    ...(params.mode === undefined ? {} : { mode: params.mode }),
+  });
+}
+
 export async function maybeControlDiscordVoiceAgentRun(params: {
-  entry: Pick<VoiceSessionEntry, "route">;
+  entry: DiscordVoiceAgentControlEntry;
   text: string;
 }): Promise<DiscordVoiceAgentControlOutcome> {
   if (!shouldAutoControlRealtimeVoiceAgentText(params.text)) {
     return { handled: false };
   }
-  const result = await controlRealtimeVoiceAgentRun({
-    sessionKey: params.entry.route.sessionKey,
-    text: params.text,
-  });
+  const result = await controlDiscordVoiceAgentRun(params);
 
   if (!result.active) {
     return { handled: false, result };

--- a/extensions/discord/src/voice/agent-run-target.ts
+++ b/extensions/discord/src/voice/agent-run-target.ts
@@ -1,0 +1,21 @@
+// Discord-local owned runTarget for active-run voice control.
+import {
+  resolveOwnedActiveRealtimeVoiceRunTargetForAgent,
+  type RealtimeVoiceAgentRunTarget,
+} from "openclaw/plugin-sdk/realtime-voice";
+import type { VoiceSessionEntry } from "./session.js";
+
+export type DiscordVoiceAgentRunTarget = RealtimeVoiceAgentRunTarget | null;
+
+/** Exact owned run for this voice session route, or null (fail-closed). */
+export function resolveDiscordVoiceAgentRunTarget(
+  entry: Pick<VoiceSessionEntry, "route" | "generation" | "sessionLifecycle">,
+): DiscordVoiceAgentRunTarget {
+  const generation = entry.generation;
+  return resolveOwnedActiveRealtimeVoiceRunTargetForAgent({
+    sessionKey: entry.route.sessionKey,
+    agentId: entry.route.agentId,
+    isSessionCurrent: () =>
+      entry.generation === generation && entry.sessionLifecycle.status === "active",
+  });
+}

--- a/extensions/discord/src/voice/realtime-consults.ts
+++ b/extensions/discord/src/voice/realtime-consults.ts
@@ -3,7 +3,6 @@ import {
   buildRealtimeVoiceAgentErrorProviderResult,
   classifyRealtimeVoiceConsultToolCall,
   classifySkippableRealtimeVoiceConsultTranscript,
-  controlRealtimeVoiceAgentRun,
   createRealtimeVoiceAgentTalkbackQueue,
   parseRealtimeVoiceAgentControlToolArgs,
   REALTIME_VOICE_AGENT_CONSULT_TOOL_NAME,
@@ -19,7 +18,10 @@ import {
 } from "openclaw/plugin-sdk/realtime-voice";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/runtime-env";
 import { formatErrorMessage } from "openclaw/plugin-sdk/ssrf-runtime";
-import { maybeControlDiscordVoiceAgentRun } from "./agent-control.js";
+import {
+  controlDiscordVoiceAgentRun,
+  maybeControlDiscordVoiceAgentRun,
+} from "./agent-control.js";
 import { formatVoiceLogPreview } from "./log-preview.js";
 import { formatVoiceIngressPrompt } from "./prompt.js";
 import type { DiscordRealtimePlaybackPort } from "./realtime-playback.js";
@@ -313,8 +315,8 @@ export class DiscordRealtimeConsults {
     let result: RealtimeVoiceAgentControlResult;
     try {
       const parsed = parseRealtimeVoiceAgentControlToolArgs(event.args);
-      result = await controlRealtimeVoiceAgentRun({
-        sessionKey: this.params.entry.route.sessionKey,
+      result = await controlDiscordVoiceAgentRun({
+        entry: this.params.entry,
         text: parsed.text,
         mode: parsed.mode,
       });

--- a/extensions/discord/src/voice/realtime-playback.test.ts
+++ b/extensions/discord/src/voice/realtime-playback.test.ts
@@ -132,6 +132,7 @@ defineDiscordVoiceTests(
       await vi.waitFor(() =>
         expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledWith({
           sessionKey: "discord:g1:c1",
+          runTarget: null,
           text: "revísalo en WebUI",
           mode: "steer",
         }),

--- a/extensions/discord/src/voice/realtime-turns.test.ts
+++ b/extensions/discord/src/voice/realtime-turns.test.ts
@@ -187,6 +187,7 @@ defineDiscordVoiceTests(
       await vi.waitFor(() =>
         expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledWith({
           sessionKey: "discord:g1:c1",
+          runTarget: null,
           text: "cancel that",
         }),
       );
@@ -451,6 +452,7 @@ defineDiscordVoiceTests(
 
       expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledWith({
         sessionKey: "discord:g1:c1",
+        runTarget: null,
         text: "how is it going",
       });
       expect(lastAgentCommandArgs().message).toContain("how is it going");
@@ -475,6 +477,7 @@ defineDiscordVoiceTests(
 
       expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledWith({
         sessionKey: "discord:g1:c1",
+        runTarget: null,
         text: "how is it going",
       });
       expect(lastAgentCommandArgs().message).toContain("how is it going");
@@ -769,6 +772,7 @@ defineDiscordVoiceTests(
 
       expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledWith({
         sessionKey: "discord:g1:c1",
+        runTarget: null,
         text: "how is it going",
       });
       expect(lastAgentCommandArgs().message).toContain("how is it going");
@@ -916,6 +920,7 @@ defineDiscordVoiceTests(
 
       expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledWith({
         sessionKey: "discord:g1:c1",
+        runTarget: null,
         text: "how is it going",
       });
       expect(lastAgentCommandArgs().message).toContain("how is it going");

--- a/extensions/discord/src/voice/transcripts-readiness.test.ts
+++ b/extensions/discord/src/voice/transcripts-readiness.test.ts
@@ -324,6 +324,7 @@ defineDiscordVoiceTests(
           if (origin === "native" && mode === "stt-tts") {
             expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledExactlyOnceWith({
               sessionKey: expectDefined(entry.route?.sessionKey, "voice session route"),
+              runTarget: null,
               text: "Do not\nsend the update",
             });
             expect(agentCommandMock).toHaveBeenCalledOnce();

--- a/extensions/discord/src/voice/transcripts-recording.test.ts
+++ b/extensions/discord/src/voice/transcripts-recording.test.ts
@@ -466,6 +466,7 @@ defineDiscordVoiceTests((harness) => {
       } else if (dispatch === "control") {
         expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledExactlyOnceWith({
           sessionKey,
+          runTarget: null,
           text: texts.join("\n"),
         });
         expect(agentCommandMock).not.toHaveBeenCalled();

--- a/extensions/discord/src/voice/voice-runtime.e2e.test.ts
+++ b/extensions/discord/src/voice/voice-runtime.e2e.test.ts
@@ -221,6 +221,7 @@ defineDiscordVoiceTests(
 
       expect(controlRealtimeVoiceAgentRunMock).toHaveBeenCalledWith({
         sessionKey: entry.route?.sessionKey,
+        runTarget: null,
         text: "use the smaller implementation",
       });
       expect(agentCommandMock).not.toHaveBeenCalled();

--- a/src/plugin-sdk/realtime-voice.ts
+++ b/src/plugin-sdk/realtime-voice.ts
@@ -175,6 +175,10 @@ export {
   type RealtimeVoiceAgentControlResult,
 } from "../talk/agent-run-control.js";
 export {
+  resolveOwnedActiveRealtimeVoiceRunTargetForAgent,
+  type RealtimeVoiceAgentRunTarget,
+} from "../talk/realtime-voice-run-target.js";
+export {
   resolveRealtimeVoiceFastContextConsult,
   type RealtimeVoiceFastContextConfig,
   type RealtimeVoiceFastContextConsultResult,

--- a/src/talk/realtime-voice-run-target.test.ts
+++ b/src/talk/realtime-voice-run-target.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearActiveEmbeddedRun,
+  isEmbeddedAgentRunActive,
+  setActiveEmbeddedRun,
+} from "../agents/embedded-agent-runner/runs.js";
+import { createEmbeddedRunHandle, testing as runsTesting } from "../agents/embedded-agent-runner/runs.test-support.js";
+import { controlRealtimeVoiceAgentRun } from "./agent-run-control.js";
+import { resolveOwnedActiveRealtimeVoiceRunTargetForAgent } from "./realtime-voice-run-target.js";
+
+describe("resolveOwnedActiveRealtimeVoiceRunTargetForAgent", () => {
+  const sessionKey = "agent:main:discord:channel:c1";
+  const sessionId = "shared-colliding-session-id";
+
+  beforeEach(() => {
+    runsTesting.resetActiveEmbeddedRuns();
+  });
+
+  afterEach(() => {
+    runsTesting.resetActiveEmbeddedRuns();
+  });
+
+  it("returns null for a foreign agentId on the same sessionKey (fail-closed)", () => {
+    const abortSpy = vi.fn();
+    setActiveEmbeddedRun(
+      sessionId,
+      createEmbeddedRunHandle({ abort: abortSpy, runId: "run-ops" }),
+      sessionKey,
+      undefined,
+      "ops",
+    );
+
+    expect(
+      resolveOwnedActiveRealtimeVoiceRunTargetForAgent({
+        sessionKey,
+        agentId: "main",
+      }),
+    ).toBeNull();
+    expect(abortSpy).not.toHaveBeenCalled();
+    expect(isEmbeddedAgentRunActive(sessionId)).toBe(true);
+  });
+
+  it("admits the exact owned run for matching sessionKey+agentId", () => {
+    setActiveEmbeddedRun(
+      sessionId,
+      createEmbeddedRunHandle({ runId: "run-main" }),
+      sessionKey,
+      undefined,
+      "main",
+    );
+
+    const runTarget = resolveOwnedActiveRealtimeVoiceRunTargetForAgent({
+      sessionKey,
+      agentId: "main",
+    });
+    expect(runTarget).toMatchObject({ runId: "run-main" });
+    expect(runTarget?.isCurrent()).toBe(true);
+    expect(runTarget?.isCurrent(sessionId)).toBe(true);
+  });
+
+  it("returns null when the voice session lifecycle fence fails", () => {
+    setActiveEmbeddedRun(
+      sessionId,
+      createEmbeddedRunHandle({ runId: "run-main" }),
+      sessionKey,
+      undefined,
+      "main",
+    );
+
+    expect(
+      resolveOwnedActiveRealtimeVoiceRunTargetForAgent({
+        sessionKey,
+        agentId: "main",
+        isSessionCurrent: () => false,
+      }),
+    ).toBeNull();
+  });
+});
+
+describe("controlRealtimeVoiceAgentRun with Discord-shaped ownership", () => {
+  const sessionKey = "agent:main:discord:channel:c1";
+  const sessionId = "shared-colliding-session-id";
+  let abortSpy: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    runsTesting.resetActiveEmbeddedRuns();
+    abortSpy = vi.fn();
+  });
+
+  afterEach(() => {
+    runsTesting.resetActiveEmbeddedRuns();
+  });
+
+  it("null runTarget refuses legacy abort of a foreign-owned run", async () => {
+    setActiveEmbeddedRun(
+      sessionId,
+      createEmbeddedRunHandle({ abort: abortSpy, runId: "run-ops" }),
+      sessionKey,
+      undefined,
+      "ops",
+    );
+
+    const result = await controlRealtimeVoiceAgentRun({
+      sessionKey,
+      text: "cancel that",
+      runTarget: null,
+    });
+
+    expect(result).toMatchObject({
+      ok: false,
+      active: false,
+      reason: "no_active_run",
+    });
+    expect(abortSpy).not.toHaveBeenCalled();
+    expect(isEmbeddedAgentRunActive(sessionId)).toBe(true);
+    clearActiveEmbeddedRun(sessionId);
+  });
+
+  it("owned runTarget cancels only the matching agent run", async () => {
+    setActiveEmbeddedRun(
+      sessionId,
+      createEmbeddedRunHandle({ abort: abortSpy, runId: "run-main" }),
+      sessionKey,
+      undefined,
+      "main",
+    );
+    const runTarget = resolveOwnedActiveRealtimeVoiceRunTargetForAgent({
+      sessionKey,
+      agentId: "main",
+    });
+    expect(runTarget).not.toBeNull();
+
+    const result = await controlRealtimeVoiceAgentRun({
+      sessionKey,
+      text: "cancel that",
+      runTarget,
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      active: true,
+      aborted: true,
+      sessionId,
+    });
+    expect(abortSpy).toHaveBeenCalled();
+  });
+});

--- a/src/talk/realtime-voice-run-target.ts
+++ b/src/talk/realtime-voice-run-target.ts
@@ -1,0 +1,102 @@
+/**
+ * Exact owned runTarget for realtime voice control when the caller has an
+ * agent id + session key but no browser/client connection id.
+ *
+ * Talk gateway ownership stays on resolveOwnedActiveTalkRunTarget (clientConnId).
+ * Callers that omit runTarget fall into session-key legacy control; pass null
+ * instead when ownership cannot be proven (fail-closed).
+ */
+import { resolveActiveEmbeddedRunSessionId } from "../agents/embedded-agent-runner/active-run-projections.js";
+import {
+  ACTIVE_EMBEDDED_RUNS,
+  ACTIVE_EMBEDDED_RUN_REGISTRATIONS,
+} from "../agents/embedded-agent-runner/run-state.js";
+import { resolveActiveEmbeddedRunOwnerByRunId } from "../agents/embedded-agent-runner/runs.js";
+import { normalizeAgentId, parseAgentSessionKey } from "../routing/session-key.js";
+
+export type RealtimeVoiceAgentRunTarget = {
+  runId: string;
+  signal: AbortSignal;
+  isCurrent: (sessionId?: string) => boolean;
+};
+
+function resolveRecordedAgentId(recorded: {
+  agentId?: string;
+  sessionKey?: string;
+}): string | undefined {
+  const raw = recorded.agentId ?? parseAgentSessionKey(recorded.sessionKey)?.agentId;
+  return raw ? normalizeAgentId(raw) : undefined;
+}
+
+/** Admit an exact embedded run for sessionKey+agentId, or null when unproven. */
+export function resolveOwnedActiveRealtimeVoiceRunTargetForAgent(params: {
+  sessionKey: string;
+  agentId: string;
+  isSessionCurrent?: () => boolean;
+}): RealtimeVoiceAgentRunTarget | null {
+  const sessionKey = params.sessionKey.trim();
+  const agentId = normalizeAgentId(params.agentId);
+  if (!sessionKey || !agentId) {
+    return null;
+  }
+  if (params.isSessionCurrent && !params.isSessionCurrent()) {
+    return null;
+  }
+
+  const sessionId = resolveActiveEmbeddedRunSessionId(sessionKey);
+  if (!sessionId) {
+    return null;
+  }
+
+  const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  const registration = handle ? ACTIVE_EMBEDDED_RUN_REGISTRATIONS.get(handle) : undefined;
+  const runId = handle?.runId?.trim();
+  if (!handle || !registration || !runId) {
+    return null;
+  }
+  if (registration.sessionKey !== undefined && registration.sessionKey !== sessionKey) {
+    return null;
+  }
+  // Prefer the registration's recorded agentId so a colliding foreign owner on
+  // the same sessionKey cannot be admitted from the key's embedded agent segment.
+  if (resolveRecordedAgentId(registration) !== agentId) {
+    return null;
+  }
+  if (!resolveActiveEmbeddedRunOwnerByRunId(runId)) {
+    return null;
+  }
+
+  // Voice session lifecycle is the liveness fence; isCurrent rechecks the exact
+  // admitted handle so a replacement run cannot inherit this claim.
+  const signal = new AbortController().signal;
+  const isCurrent = (resolvedSessionId?: string) => {
+    if (params.isSessionCurrent && !params.isSessionCurrent()) {
+      return false;
+    }
+    if (signal.aborted) {
+      return false;
+    }
+    const liveHandle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+    const liveRegistration = liveHandle
+      ? ACTIVE_EMBEDDED_RUN_REGISTRATIONS.get(liveHandle)
+      : undefined;
+    if (
+      liveHandle !== handle ||
+      liveRegistration !== registration ||
+      liveHandle.runId !== runId ||
+      resolveRecordedAgentId(liveRegistration ?? {}) !== agentId ||
+      (liveRegistration?.sessionKey !== undefined && liveRegistration.sessionKey !== sessionKey)
+    ) {
+      return false;
+    }
+    if (resolvedSessionId !== undefined && resolvedSessionId !== sessionId) {
+      return false;
+    }
+    return Boolean(resolveActiveEmbeddedRunOwnerByRunId(runId));
+  };
+
+  if (!isCurrent()) {
+    return null;
+  }
+  return { runId, signal, isCurrent };
+}


### PR DESCRIPTION
## What Problem This Solves

Discord voice `maybeControlDiscordVoiceAgentRun` / `handleAgentControlToolCall`
omitted `runTarget` when calling `controlRealtimeVoiceAgentRun`, so control fell
into the session-key legacy path (`resolveActiveEmbeddedRunSessionId` →
abort/queue by sessionId) without verifying `route.agentId`. A foreign agent
registered on the same sessionKey could be cancelled/steered. Gateway Talk
already passes an owned `runTarget`.

## Why This Change Was Made

Discord-only: always pass an owned `runTarget`, or `runTarget: null` when
ownership cannot be proven (fail-closed). Add a plugin-sdk seam
`resolveOwnedActiveRealtimeVoiceRunTargetForAgent` (sessionKey + agentId) and a
Discord-local resolver that also fences voice session lifecycle. Do not change
`abortEmbeddedAgentRun` (#141379) or Talk gateway ownership (#132129).

## User Impact

**Before:** Saying “cancel” in Discord voice could abort another agent’s run
that collided on the same sessionKey.

**After:** Discord voice control only affects a run proven to match
`route.sessionKey` + `route.agentId` on a live voice session; otherwise it
fail-closes with no active run.

## Evidence

- Changed: `src/talk/realtime-voice-run-target.ts`,
  `src/talk/realtime-voice-run-target.test.ts`,
  `src/plugin-sdk/realtime-voice.ts`,
  `extensions/discord/src/voice/agent-run-target.ts`,
  `extensions/discord/src/voice/agent-control.ts`,
  `extensions/discord/src/voice/agent-control.test.ts`,
  `extensions/discord/src/voice/agent-control.run-target.test.ts`,
  `extensions/discord/src/voice/realtime-consults.ts`,
  plus expectation updates in Discord voice tests
- Production path: Discord voice transcript/tool control →
  `controlDiscordVoiceAgentRun` →
  `resolveDiscordVoiceAgentRunTarget` →
  `resolveOwnedActiveRealtimeVoiceRunTargetForAgent` →
  `controlRealtimeVoiceAgentRun({ runTarget })`
- Compatibility: Talk/`resolveOwnedActiveTalkRunTarget` unchanged; omitting
  `runTarget` elsewhere retains legacy behavior
- Dedup: ≠ #132129 (Talk ownership), ≠ #141379 (embedded abort agent scope)

## Real behavior proof

### Behavior or issue addressed

Foreign agentId `ops` on Discord sessionKey is not aborted; matching `main`
owned run is cancelled; stopped voice session fail-closes; callers always pass
`runTarget` (never `{sessionKey,text}` only).

### Canonical reachability path

Discord voice `maybeControlDiscordVoiceAgentRun` /
`handleAgentControlToolCall` → `controlDiscordVoiceAgentRun` → owned/null
`runTarget` → `controlRealtimeVoiceAgentRun`

### Shared helper / provider constraint check

Owner check lives in the new plugin-sdk seam + Discord lifecycle fence. No
change to `abortEmbeddedAgentRun` signature or Talk `clientConnId` ownership.

### Real environment tested

Local trusted source checkout at PR head; Vitest unit + extension-discord;
real `setActiveEmbeddedRun` registry + production Discord callers.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/talk/realtime-voice-run-target.test.ts extensions/discord/src/voice/agent-control.test.ts extensions/discord/src/voice/agent-control.run-target.test.ts --reporter=verbose
```

### Evidence after fix

```text
[test] starting test/vitest/vitest.unit.config.ts

 RUN  v5.0.0 /workspace/openclaw-nocodet

[vitest-workers] prepared 5736a0429020 in 5686ms (8596 inputs, 4303 outputs)
 ✓ |unit| src/talk/realtime-voice-run-target.test.ts > resolveOwnedActiveRealtimeVoiceRunTargetForAgent > returns null for a foreign agentId on the same sessionKey (fail-closed) 14ms
 ✓ |unit| src/talk/realtime-voice-run-target.test.ts > resolveOwnedActiveRealtimeVoiceRunTargetForAgent > admits the exact owned run for matching sessionKey+agentId 3ms
 ✓ |unit| src/talk/realtime-voice-run-target.test.ts > resolveOwnedActiveRealtimeVoiceRunTargetForAgent > returns null when the voice session lifecycle fence fails 2ms
 ✓ |unit| src/talk/realtime-voice-run-target.test.ts > controlRealtimeVoiceAgentRun with Discord-shaped ownership > null runTarget refuses legacy abort of a foreign-owned run 3ms
 ✓ |unit| src/talk/realtime-voice-run-target.test.ts > controlRealtimeVoiceAgentRun with Discord-shaped ownership > owned runTarget cancels only the matching agent run 13ms

 Test Files  1 passed (1)
      Tests  5 passed (5)
   Start at  17:41:40
   Duration  9.66s (transform 82%, import 13%, worker 3%, setup 1%)

[test] starting test/vitest/vitest.extension-discord.config.ts

 RUN  v5.0.0 /workspace/openclaw-nocodet

 ✓ |extension-discord| extensions/discord/src/voice/agent-control.test.ts > maybeControlDiscordVoiceAgentRun > falls back for inactive cancel-like phrases 25ms
 ✓ |extension-discord| extensions/discord/src/voice/agent-control.test.ts > maybeControlDiscordVoiceAgentRun > handles active cancel requests with an explicit runTarget 2ms
 ✓ |extension-discord| extensions/discord/src/voice/agent-control.test.ts > maybeControlDiscordVoiceAgentRun > passes an owned runTarget when the Discord resolver admits one 2ms
 ✓ |extension-discord| extensions/discord/src/voice/agent-control.test.ts > maybeControlDiscordVoiceAgentRun > ignores non-control phrases 3ms
 ✓ |extension-discord| extensions/discord/src/voice/agent-control.run-target.test.ts > Discord voice control runTarget ownership (caller path) > fail-closed: foreign agent on the same sessionKey is not aborted 12ms
 ✓ |extension-discord| extensions/discord/src/voice/agent-control.run-target.test.ts > Discord voice control runTarget ownership (caller path) > owned agent cancel aborts the matching embedded run 8ms
 ✓ |extension-discord| extensions/discord/src/voice/agent-control.run-target.test.ts > Discord voice control runTarget ownership (caller path) > stopped voice session refuses ownership (null fail-closed) 2ms

 Test Files  2 passed (2)
      Tests  7 passed (7)
   Start at  17:41:50
   Duration  16.83s (transform 77%, import 16%, worker 6%)

[vitest-workers] verifying completed generation before cleanup
[test] passed 2 Vitest shards in 28.75s
```

### Observed result after fix

Talk ownership tests 5/5 and Discord caller-path tests 7/7 passed; foreign
agent not aborted; owned cancel works; stopped session fail-closes; callers
always include `runTarget`.

### What was not tested

No live Discord VC or Gateway WebSocket session.

## Checklist

- Synced with upstream/main; single commit; conflict-free
- Quota / dedup / owner / fresh-main gates clear
- Template body + Real behavior proof filled; caller-path proof pasted
- AI-assisted; maintainers can edit; no CHANGELOG edit
