### PR TITLE
fix(codex): avoid duplicate prompts for unkeyed inputs

### DIFF
--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -504,14 +504,10 @@ async function mirror(params: {
           runtimeMessage: nextMessage,
           preparedMessage: preparedUserMessage,
         });
-        let messageToAppend = (
-          idempotencyKey
-            ? {
-                ...attachCodexMirrorAttestation(restoredMessage, sourceFingerprint),
-                idempotencyKey,
-              }
-            : attachCodexMirrorAttestation(restoredMessage, sourceFingerprint)
-        ) as AgentMessage;
+        let messageToAppend = {
+          ...attachCodexMirrorAttestation(restoredMessage, sourceFingerprint),
+          ...(idempotencyKey ? { idempotencyKey } : {}),
+        } as AgentMessage;
         if (mirrorIdentity) {
           // Hooks may replace the whole message. Restore the provider-owned
           // identity so retries cannot turn a stale idempotency hit into evidence.

--- a/extensions/codex/src/app-server/transcript-mirror.ts
+++ b/extensions/codex/src/app-server/transcript-mirror.ts
@@ -131,6 +131,17 @@ async function mirrorBestEffort(params: {
       turnId: params.turnId,
     });
     params.assertWriteCurrent?.();
+    const recorder = params.params.userTurnTranscriptRecorder;
+    const admission = recorder?.getAdmissionReceipt();
+    const admittedMessage = recorder?.getPersistedMessage?.();
+    const promptIdentity = `${params.turnId}:prompt`;
+    // The host already owns this admission, even when ingress supplied no dedupe key.
+    // Only mirror runtime-owned rows; reuse the annotated admission as recovery evidence.
+    const mirrorMessages = admission
+      ? messages.filter(
+          (message) => message.role !== "user" || readMirrorIdentity(message) !== promptIdentity,
+        )
+      : messages;
     const mirrorResult = await mirror({
       assertWriteCurrent: params.assertWriteCurrent,
       agentId: params.agentId,
@@ -138,7 +149,7 @@ async function mirrorBestEffort(params: {
       sessionId: params.params.sessionId,
       storePath: params.params.sessionTarget?.storePath,
       cwd: params.cwd,
-      messages,
+      messages: mirrorMessages,
       // Scope is thread-stable. Each entry in `messagesSnapshot` is tagged
       // with a per-turn `attachCodexMirrorIdentity` value carrying its own
       // turnId, so distinct turns produce distinct dedupe keys via the
@@ -160,6 +171,15 @@ async function mirrorBestEffort(params: {
       prepareAssistantTranscriptMessage: params.params.prepareAssistantTranscriptMessage,
       config: params.params.config,
     });
+    if (admission && admittedMessage && readMirrorIdentity(admittedMessage) === promptIdentity) {
+      mirrorResult.messagesPresent.unshift(admittedMessage);
+      mirrorResult.anchorsByMirrorIdentity.set(promptIdentity, admission);
+      mirrorResult.userMessageReceipts.push({
+        anchor: admission,
+        message: admittedMessage,
+        appended: false,
+      });
+    }
     for (const receipt of mirrorResult.userMessageReceipts) {
       try {
         params.notifyUserMessagePersisted(receipt);
@@ -285,6 +305,18 @@ export async function mirrorPromptAtTurnStartBestEffort(params: {
           mirrorOrigin: "codex-app-server",
           mirrorSourceFingerprint: fingerprintCodexMirrorSourceMessage(userPromptMessage),
         });
+      }
+      const admission = recorder?.getAdmissionReceipt();
+      if (admission) {
+        // Annotation enriches the host's row; appending a provider-keyed copy here
+        // would create duplicate provenance when the original has no idempotency key.
+        params.params.hostCapabilities.assertActive();
+        const message = recorder?.getPersistedMessage?.();
+        if (!message) {
+          throw new Error("current host admission message is unavailable");
+        }
+        params.notifyUserMessagePersisted({ anchor: admission, message, appended: false });
+        return;
       }
       const mirrorResult = await mirror({
         assertCurrent: params.params.hostCapabilities.assertActive,

--- a/test/canonical-descendant.integration.test.ts
+++ b/test/canonical-descendant.integration.test.ts
@@ -118,6 +118,7 @@ async function withFixture(
     desktopGenerationFingerprint?: string;
     senderIsOwner?: boolean;
     transcript?: { display?: false; excludeFromContext?: true };
+    keylessAdmission?: boolean;
     mcpResolver?: OpenClawPluginMcpServerConnectionResolver;
   } = {},
 ) {
@@ -171,7 +172,9 @@ async function withFixture(
             ...options.transcript,
             text: prompt,
             timestamp: 123,
-            idempotencyKey: buildRunUserTurnIdempotencyKey(runId),
+            idempotencyKey: options.keylessAdmission
+              ? undefined
+              : buildRunUserTurnIdempotencyKey(runId),
             senderIsOwner,
             sender: { id: senderId ?? "operator", name: "Operator" },
             transport: { channel: "webchat", messageId: "incoming" },
@@ -828,58 +831,65 @@ describe("canonical descendant lifecycle through real owners", () => {
     );
   }, 180_000);
 
-  it("annotates the pre-admitted Gateway user without replacing its event or read fence", async () => {
-    await withFixture(async (fixture, fork, _revoke, admissions) => {
-      const source = await fixture.adopt();
-      for (const text of ["repeat", "repeat"]) {
-        await fixture.turn(source.sessionKey, text);
-        const { recorder, before } = admissions.at(-1)!;
-        const admission = expectDefined(recorder.getAdmissionReceipt(), "current admission");
-        const target = {
-          ...fixture.identity(source.sessionKey),
-          sessionKey: source.sessionKey,
-          storePath: fixture.storePath,
-        };
-        const after = await loadTranscriptEvents(target);
-        const added = after.at(-1) as {
-          id: string;
-          message: { __openclaw?: Record<string, unknown> };
-        };
-        expect(added.id).toBe(admission.entryId);
-        expect(added.message["__openclaw"]).toMatchObject({
-          mirrorOrigin: "codex-app-server",
-          mirrorIdentity: expect.stringMatching(/:prompt$/),
-          upstreamUserText: text,
-          mirrorSourceFingerprint: expect.any(String),
-        });
-        const original = before.at(-1) as typeof added;
-        const meta = { ...added.message["__openclaw"] };
-        for (const key of [
-          "mirrorIdentity",
-          "upstreamUserText",
-          "mirrorOrigin",
-          "mirrorSourceFingerprint",
-          "runId",
-        ]) {
-          delete meta[key];
-        }
-        expect({ ...added, message: { ...added.message, __openclaw: meta } }).toEqual(original);
-        expect(after.slice(0, -1)).toEqual(before.slice(0, -1));
-        expect(recorder.getPersistedMessage?.()).toEqual(added.message);
-        expect(await readCodexSessionTranscriptEventsBeforeAdmission(target, admission)).toEqual(
-          before.slice(0, -1),
-        );
-        expect(
-          readClosedTranscriptTurn({
-            boundary: { admission, terminal: admission },
-            maxEvents: 100,
-            maxBytes: 100_000,
-          }),
-        ).toMatchObject({ kind: "ok", messages: [added.message] });
-        expect(await fork(source.sessionKey, admission.entryId)).toMatchObject({ ok: true });
-      }
-    });
-  }, 180_000);
+  it.each([false, true])(
+    "annotates the pre-admitted user without replacing its event or read fence (keyless=%s)",
+    async (keylessAdmission) => {
+      await withFixture(
+        async (fixture, fork, _revoke, admissions) => {
+          const source = await fixture.adopt();
+          for (const text of ["repeat", "repeat"]) {
+            await fixture.turn(source.sessionKey, text);
+            const { recorder, before } = admissions.at(-1)!;
+            const admission = expectDefined(recorder.getAdmissionReceipt(), "current admission");
+            const target = {
+              ...fixture.identity(source.sessionKey),
+              sessionKey: source.sessionKey,
+              storePath: fixture.storePath,
+            };
+            const after = await loadTranscriptEvents(target);
+            const added = after.at(-1) as {
+              id: string;
+              message: { __openclaw?: Record<string, unknown> };
+            };
+            expect(added.id).toBe(admission.entryId);
+            expect(added.message["__openclaw"]).toMatchObject({
+              mirrorOrigin: "codex-app-server",
+              mirrorIdentity: expect.stringMatching(/:prompt$/),
+              upstreamUserText: text,
+              mirrorSourceFingerprint: expect.any(String),
+            });
+            const original = before.at(-1) as typeof added;
+            const meta = { ...added.message["__openclaw"] };
+            for (const key of [
+              "mirrorIdentity",
+              "upstreamUserText",
+              "mirrorOrigin",
+              "mirrorSourceFingerprint",
+              "runId",
+            ]) {
+              delete meta[key];
+            }
+            expect({ ...added, message: { ...added.message, __openclaw: meta } }).toEqual(original);
+            expect(after.slice(0, -1)).toEqual(before.slice(0, -1));
+            expect(recorder.getPersistedMessage?.()).toEqual(added.message);
+            expect(
+              await readCodexSessionTranscriptEventsBeforeAdmission(target, admission),
+            ).toEqual(before.slice(0, -1));
+            expect(
+              readClosedTranscriptTurn({
+                boundary: { admission, terminal: admission },
+                maxEvents: 100,
+                maxBytes: 100_000,
+              }),
+            ).toMatchObject({ kind: "ok", messages: [added.message] });
+            expect(await fork(source.sessionKey, admission.entryId)).toMatchObject({ ok: true });
+          }
+        },
+        { keylessAdmission },
+      );
+    },
+    180_000,
+  );
   it.each(["source", "child", "registry"] as const)(
     "fences physical fork writes after %s revocation during configuration wait",
     async (target) => {


### PR DESCRIPTION
Related: #141233
Additional recovery evidence: #141387 (consolidated into #141233).

## What Problem This Solves

Fixes an issue where users sending input without a message idempotency key could get two durable copies of one prompt when using the Codex harness. Duplicate native identities also cause strict settled-turn recovery to reject the transcript, preventing a recovery summary.

## Why This Change Was Made

Reuse the host-owned admission after native annotation instead of appending a second provider-keyed prompt. Final mirroring retains the annotated admission as recovery evidence, and reports its existing receipt with `appended: false` so persistence notification remains intact.

The change does not deduplicate by text, relax provenance verification, alter authorization or cancellation fences, migrate storage, or rewrite historical transcripts. Hidden admissions keep their existing visibility contract.

## User Impact

New unkeyed inputs retain one canonical prompt row. Distinct turns with identical text remain distinct. This prevents the duplicate-prompt producer defect; it does not repair previously duplicated histories or claim that every recovery failure is resolved.

## Evidence

- Original ordered reproduction used real SQLite admission and the native-mock integration harness: the unkeyed case failed while the keyed control passed.
- Final admission regression: 3 passed (keyed, keyless, hidden), with 69 unrelated cases filtered out. It checks original event identity, read fences, provenance, and distinct repeated-text turns.
- Existing mirror/recovery sibling suites: 71 passed before the final persistence-notification adjustment; these are not live gateway tests.
- Independent read-only source review found no P1/P2 findings. This is separate from the CLI autoreview result.
- Whitespace check passed.

Outstanding validation: full timeout-to-summary integration, changed-file gate terminal result, and CLI autoreview completion. An earlier CLI review failed before a verdict due to an OAuth refresh error. No live deployment or historical transcript repair has been performed.
