### PR TITLE
fix(agents): preserve Code Mode data within context limits

### DIFF
--- a/docs/tools/code-mode.md
+++ b/docs/tools/code-mode.md
@@ -649,6 +649,13 @@ forcing one model tool call per await.
 `exec` returns `completed` only when the guest VM has no pending work and the
 final value is JSON-compatible after OpenClaw's output adapter runs.
 
+New `exec` and `wait` result text uses compact JSON to leave more of the context
+budget for tool data. Status, continuation, replay safety, telemetry, and
+structured `details` fields are preserved. Text inside JSON strings keeps its
+original whitespace. The TUI displays these results as literal text so Markdown
+syntax and long-token formatting cannot change their values. URLs remain visible
+as text rather than becoming Markdown links.
+
 ### Source in session history
 
 In the built-in OpenClaw runtime, the JSON Code Mode tool executes the original
@@ -1194,7 +1201,8 @@ summary of that same original output.
 Model-facing `exec` and `wait` results also fit the effective model's per-result
 context and persistence limits. OpenClaw reserves the complete result envelope,
 including status, continuation, diagnostics, telemetry, and JSON formatting,
-before projecting output from its retained original source. Network-derived
+using the same compact representation for budget fitting and delivery before
+projecting output from its retained original source. Network-derived
 results retain the untrusted-content wrapper and its smaller content limit.
 These limits do not reduce the nested tool's byte allowance. Headless execution
 and low-level controls without model context retain their byte-only allowance

--- a/src/agents/code-mode-json.ts
+++ b/src/agents/code-mode-json.ts
@@ -1,7 +1,10 @@
 import { jsonUtf8Bytes } from "../infra/json-utf8-bytes.js";
 import { truncateUtf8Prefix } from "../utils/utf8-truncate.js";
 import { toolResultFitsBudget, type ToolResultBudget } from "./tool-result-limits.js";
-import { renderToolSearchControlText } from "./tool-search-control-result.js";
+import {
+  renderToolSearchControlText,
+  serializeToolSearchControlResult,
+} from "./tool-search-control-result.js";
 
 export function toCodeModeJsonSafe(value: unknown): unknown {
   if (value === undefined) {
@@ -211,7 +214,7 @@ export class CodeModeOutputState {
     const project = this.createProjector(params);
     const fits = (candidate: ReturnType<typeof project>) => {
       const rendered = renderToolSearchControlText(
-        JSON.stringify({ ...metadata, ...candidate.channels }, null, 2),
+        serializeToolSearchControlResult({ ...metadata, ...candidate.channels }, true),
         networkContent,
       );
       return !rendered.truncated && toolResultFitsBudget(rendered.text, this.modelBudget);

--- a/src/agents/code-mode.result-budget.test.ts
+++ b/src/agents/code-mode.result-budget.test.ts
@@ -144,6 +144,40 @@ afterEach(() => {
 });
 
 describe("fresh producer results through persistence and model guards", () => {
+  it("retains structured values that fit the compact result budget", async () => {
+    const context = 4_096;
+    const value = Array.from({ length: 80 }, (_, id) => ({ id, ok: true }));
+    const runtime = createAgentHarnessToolSurfaceRuntimeCore({
+      config: { tools: { codeMode: { enabled: true } } },
+      model,
+      contextTokenBudget: context,
+      modelToolsEnabled: true,
+      sessionId,
+      executeTool: async () => {
+        throw new Error("This fixture has no catalog tools");
+      },
+    });
+    try {
+      const [exec] = runtime.compactTools([]).tools;
+      const frame = message(
+        await exec!.execute("compact-value", { code: `return ${JSON.stringify(value)};` }),
+        "exec",
+      );
+      const sent = await dispatch([frame], context);
+      expect(JSON.parse(text(toolResult(sent, 0)))).toMatchObject({
+        status: "completed",
+        value,
+        output: [],
+        replaySafe: false,
+        telemetry: { callCount: 0 },
+      });
+      expect(text(toolResult(sent, 0))).toBe(text(frame));
+      expect(resultDetails(frame).value).toEqual(value);
+    } finally {
+      runtime.cleanup();
+    }
+  });
+
   it.each([
     { name: "default accented", first: "🦞".repeat(9000), last: "é".repeat(18000) },
     { name: "ASCII", first: "a".repeat(40_000), last: "b".repeat(40_000) },

--- a/src/agents/code-mode.test.ts
+++ b/src/agents/code-mode.test.ts
@@ -297,6 +297,7 @@ describe("Code Mode catalog and model-visible surface", () => {
     expect(execTool.description).toContain("Enabled tools are async global functions");
     expect(execTool.description).toContain("Await dependent calls in order");
     expect(execTool.description).toContain("independent calls may run with Promise.all");
+    expect(execTool.description).toContain("Emit output with `text(value)` or `json(value)`");
     expect(execTool.description).toContain(
       "Declared output fields may feed later calls in the same program",
     );
@@ -326,23 +327,6 @@ describe("Code Mode catalog and model-visible surface", () => {
     expect(parameters.properties?.code?.description).toContain(
       "a trailing expression yields `null`",
     );
-    expect(parameters.properties?.code?.description).toContain(
-      "Call enabled async globals directly",
-    );
-    expect(parameters.properties?.code?.description).toContain(
-      "independent calls may use Promise.all",
-    );
-    expect(parameters.properties?.code?.description).toContain(
-      "Declared output fields may feed later calls in the same program",
-    );
-    expect(parameters.properties?.code?.description).toContain(
-      'const [tool] = await catalog.search("..."); return await tool({...});',
-    );
-    expect(parameters.properties?.code?.description).toContain("`catalog.search(query)`");
-    expect(parameters.properties?.code?.description).toContain(
-      "cannot feed guessed dependent logic in the same program",
-    );
-    expect(parameters.properties?.code?.description).toContain("use a later `exec`");
     expect(parameters.properties?.code?.description).not.toContain("ALL_TOOLS");
     expect(parameters.properties?.code?.description).not.toContain("tools.call");
     expect(parameters.properties?.code?.description).toContain("`require`, or `import`");

--- a/src/agents/code-mode.ts
+++ b/src/agents/code-mode.ts
@@ -202,7 +202,7 @@ export function createCodeModeTools(ctx: CodeModeToolContext): AnyAgentTool[] {
       // model-facing field prevents schema-valid empty calls from constrained models.
       code: Type.String({
         description:
-          'Required JS/TS; no Python, shell, `require`, or `import`. Emit output with `text(value)` or `json(value)`. Use `return value`; a trailing expression yields `null`. Call enabled async globals directly; independent calls may use Promise.all. Declared output fields may feed later calls in the same program; do not spend another `exec` merely inspecting them. Unknown output (`-> ?`) cannot feed guessed dependent logic in the same program: return it raw, observe it, then use a later `exec`. For discovery, use `catalog.search(query)`: `const [tool] = await catalog.search("..."); return await tool({...});`.',
+          "Required JS/TS; no Python, shell, `require`, or `import`. Use `return value`; a trailing expression yields `null`.",
       }),
       language: optionalStringEnum(["javascript", "typescript"] as const, {
         description:
@@ -254,7 +254,10 @@ export function createCodeModeTools(ctx: CodeModeToolContext): AnyAgentTool[] {
         }),
       );
       markCodeModePermissionChangeResult(result, signal);
-      return formatToolSearchControlResult(result, runtime, undefined, result.status);
+      return formatToolSearchControlResult(result, runtime, {
+        terminalBatchStatus: result.status,
+        compact: true,
+      });
     },
   } as AnyAgentTool);
   const waitTool = markCodeModeControlTool({
@@ -290,7 +293,10 @@ export function createCodeModeTools(ctx: CodeModeToolContext): AnyAgentTool[] {
         }),
       );
       markCodeModePermissionChangeResult(result, signal);
-      return formatToolSearchControlResult(result, runtime, undefined, result.status);
+      return formatToolSearchControlResult(result, runtime, {
+        terminalBatchStatus: result.status,
+        compact: true,
+      });
     },
   } as AnyAgentTool);
   return [execTool, waitTool];

--- a/src/agents/tool-search-control-result.ts
+++ b/src/agents/tool-search-control-result.ts
@@ -3,6 +3,11 @@ import {
   wrapExternalContent,
 } from "../security/external-content.js";
 
+/** Shared by budget fitting and delivery so formatting cannot consume unreserved context. */
+export function serializeToolSearchControlResult(payload: unknown, compact = false): string {
+  return JSON.stringify(payload, null, compact ? undefined : 2);
+}
+
 /** Shared by the source projector and final formatter; no terminal receipts are consumed here. */
 export function renderToolSearchControlText(text: string, networkContent: boolean) {
   if (!networkContent) {

--- a/src/agents/tool-search-runtime.test.ts
+++ b/src/agents/tool-search-runtime.test.ts
@@ -921,11 +921,9 @@ describe("Tool Search network error boundaries", () => {
           ? await runtime.call("raw_network", {}, { parentToolCallId })
           : await runtime.callValue("raw_network", {}, { parentToolCallId });
 
-      const result = formatToolSearchControlResult(
-        payload,
-        runtime,
-        surface === "structured tool call" ? parentToolCallId : undefined,
-      );
+      const result = formatToolSearchControlResult(payload, runtime, {
+        parentToolCallId: surface === "structured tool call" ? parentToolCallId : undefined,
+      });
       const text = result.content[0]?.type === "text" ? result.content[0].text : "";
 
       expect(text.length).toBeLessThan(21_000);
@@ -938,7 +936,9 @@ describe("Tool Search network error boundaries", () => {
       expect(result.details).toBe(payload);
       expect(JSON.stringify(result.details)).toContain(huge);
 
-      const isolated = formatToolSearchControlResult({ value: "local" }, runtime, "other-parent");
+      const isolated = formatToolSearchControlResult({ value: "local" }, runtime, {
+        parentToolCallId: "other-parent",
+      });
       expect(isolated.content[0]).toEqual({
         type: "text",
         text: '{\n  "value": "local"\n}',

--- a/src/agents/tool-search-runtime.ts
+++ b/src/agents/tool-search-runtime.ts
@@ -24,7 +24,10 @@ import {
   resolveCatalog,
   visibleCatalogEntries,
 } from "./tool-search-catalog.js";
-import { renderToolSearchControlText } from "./tool-search-control-result.js";
+import {
+  renderToolSearchControlText,
+  serializeToolSearchControlResult,
+} from "./tool-search-control-result.js";
 import {
   buildLexicalIndex,
   readParameterText,
@@ -51,7 +54,7 @@ import type {
   UnknownToolErrorOptions,
   UnknownToolRecoverySurface,
 } from "./tool-search-types.js";
-import { asToolParamsRecord, jsonResult, ToolInputError } from "./tools/common.js";
+import { asToolParamsRecord, textResult, ToolInputError } from "./tools/common.js";
 
 function describeEntry(entry: ToolSearchCatalogEntry) {
   return {
@@ -655,18 +658,21 @@ export class ToolSearchRuntime {
 export function formatToolSearchControlResult<T>(
   payload: T,
   runtime: ToolSearchRuntime | undefined,
-  parentToolCallId?: string,
-  terminalBatchStatus?: "waiting" | "completed" | "failed",
+  options: {
+    parentToolCallId?: string;
+    terminalBatchStatus?: "waiting" | "completed" | "failed";
+    compact?: boolean;
+  } = {},
 ): AgentToolResult<T> {
-  let result: AgentToolResult<T> = jsonResult(payload);
-  const content = result.content[0];
-  if (runtime?.hasNetworkContent(parentToolCallId) && content?.type === "text") {
-    const { text } = renderToolSearchControlText(content.text, true);
-    result = { ...result, content: [{ ...content, text }] };
-  }
+  const serialized = serializeToolSearchControlResult(payload, options.compact);
+  const { text } = renderToolSearchControlText(
+    serialized,
+    runtime?.hasNetworkContent(options.parentToolCallId) ?? false,
+  );
+  const result = textResult(text, payload);
   const terminal =
-    terminalBatchStatus !== "waiting" &&
-    runtime?.takeTerminalTargetBatch(parentToolCallId) === true;
+    options.terminalBatchStatus !== "waiting" &&
+    runtime?.takeTerminalTargetBatch(options.parentToolCallId) === true;
   // A failed guest cannot revoke an already completed tool's explicit terminal outcome.
   return terminal ? { ...result, terminate: true } : result;
 }

--- a/src/agents/tool-search.ts
+++ b/src/agents/tool-search.ts
@@ -401,7 +401,7 @@ export function createToolSearchTools(ctx: ToolSearchToolContext): AnyAgentTool[
             ...formatToolSearchControlResult(
               { tool: { id, name, source }, result: callResult.result },
               runtime,
-              toolCallId,
+              { parentToolCallId: toolCallId },
             ),
             details: callResult,
           };

--- a/src/tui/components/tool-execution.test.ts
+++ b/src/tui/components/tool-execution.test.ts
@@ -13,6 +13,96 @@ function renderToolOutput(text: string, width: number) {
 }
 
 describe("ToolExecutionComponent", () => {
+  it.each(
+    ["exec", "wait"].flatMap((toolName) =>
+      [false, true].flatMap((pretty) =>
+        [false, true].map((partial) => ({ toolName, pretty, partial })),
+      ),
+    ),
+  )(
+    "preserves literal Code Mode $toolName output (pretty=$pretty, partial=$partial)",
+    ({ toolName, pretty, partial }) => {
+      const details = {
+        status: partial ? "waiting" : "failed",
+        telemetry: { visibleTools: ["exec", "wait"] },
+      };
+      const json = JSON.stringify(
+        {
+          status: details.status,
+          value: 'START_COMPLETED **stars** "quoted" \\path',
+          literal: "```\n# literal heading\n```",
+        },
+        null,
+        pretty ? 2 : undefined,
+      );
+      const text = `SECURITY NOTICE: EXTERNAL, UNTRUSTED source\n<<<EXTERNAL_UNTRUSTED_CONTENT>>>\n${json}\n\`\`\`\n# literal heading\n\`\`\`\n<<<END_EXTERNAL_UNTRUSTED_CONTENT>>>`;
+      const component = new ToolExecutionComponent(
+        toolName,
+        toolName === "exec" ? { code: "return value;" } : { runId: "synthetic-run" },
+      );
+      const result = { content: [{ type: "text", text }], details };
+      if (partial) {
+        component.setPartialResult(result);
+      } else {
+        component.setResult(result, { isError: true });
+      }
+      component.setExpanded(true);
+
+      const rendered = normalizeTestText(component.render(1_024).join("\n"));
+      for (const line of text.split("\n")) {
+        expect(rendered).toContain(line);
+      }
+    },
+  );
+
+  it("keeps Code Mode literal output bounded and terminal-safe through expansion", () => {
+    const attack = "\x1b]52;c;SYNTHETIC_CLIPBOARD_PAYLOAD\x07";
+    const text = `START_LITERAL ${attack}\u202eمرحبا\u202c\r\n${"**literal**".repeat(2_048)} END_LITERAL`;
+    const component = new ToolExecutionComponent("wait", { runId: "synthetic-run" });
+    component.setResult({
+      content: [{ type: "text", text }],
+      details: { status: "completed", telemetry: { visibleTools: ["exec", "wait"] } },
+    });
+
+    for (const expanded of [false, true, false]) {
+      component.setExpanded(expanded);
+      const lines = component.render(40);
+      const raw = lines.join("\n");
+      const rendered = normalizeTestText(raw);
+      expect(lines.every((line) => visibleWidth(line) <= 40)).toBe(true);
+      expect(rendered).toContain("**literal**");
+      expect(rendered.includes("END_LITERAL")).toBe(expanded);
+      if (!expanded) {
+        expect(lines.length).toBeLessThanOrEqual(MAX_COLLAPSED_COMPONENT_LINES);
+      }
+      expect(rendered).not.toContain("SYNTHETIC_CLIPBOARD_PAYLOAD");
+      expect(rendered).not.toContain("]52;c;");
+      expect(raw).not.toMatch(/[\r\u202e\u202c]/u);
+      expect(raw).toContain("\u2067");
+      expect(raw).toContain("\u2069");
+    }
+  });
+
+  it.each([
+    { name: "exec", details: undefined },
+    { name: "exec", details: { status: "completed", telemetry: { visibleTools: ["exec"] } } },
+    { name: "custom_tool", details: { telemetry: { visibleTools: ["exec", "wait"] } } },
+  ])(
+    "retains ordinary Markdown output for $name without Code Mode result identity",
+    ({ name, details }) => {
+      const component = new ToolExecutionComponent(name, { command: "echo sample" });
+      component.setResult({
+        content: [{ type: "text", text: "# Heading\n\n**emphasis**" }],
+        details,
+      });
+      const rendered = normalizeTestText(component.render(80).join("\n"));
+      expect(rendered).toContain("Heading");
+      expect(rendered).toContain("emphasis");
+      expect(rendered).not.toContain("# Heading");
+      expect(rendered).not.toContain("**emphasis**");
+    },
+  );
+
   it("keeps tool arguments, output, and running status independent across updates", () => {
     const component = new ToolExecutionComponent("read", { path: "initial.txt" });
     component.setPartialResult({ content: [{ type: "text", text: "partial output" }] });

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -1,5 +1,6 @@
 // Tool execution component renders tool call status and output in the TUI.
 import { Box, Container, Spacer, Text, truncateToWidth } from "@earendil-works/pi-tui";
+import { asOptionalObjectRecord } from "@openclaw/normalization-core/record-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { formatToolDetail, resolveToolDisplay } from "../../agents/tool-display.js";
 import { markdownTheme, tuiTheme as theme } from "../theme/theme.js";
@@ -29,13 +30,18 @@ class ToolOutputComponent extends HyperlinkMarkdown {
   private sourceText = "";
   private renderedSource: string | undefined;
   private expanded = false;
+  private literal = false;
+  private literalOutput = new Text("", 0, 0);
 
-  override setText(text: string): void {
-    const sourceText = tuiFormatters.sanitizeMarkdownSource(text);
-    if (this.sourceText === sourceText) {
+  override setText(text: string, literal = false): void {
+    const sourceText = literal
+      ? tuiFormatters.sanitizeTerminalControlsAndBinary(text)
+      : tuiFormatters.sanitizeMarkdownSource(text);
+    if (this.sourceText === sourceText && this.literal === literal) {
       return;
     }
     this.sourceText = sourceText;
+    this.literal = literal;
     this.renderedSource = undefined;
     super.invalidate();
   }
@@ -57,11 +63,17 @@ class ToolOutputComponent extends HyperlinkMarkdown {
       : truncateUtf16Safe(this.sourceText, previewBudget);
 
     if (this.renderedSource !== text) {
-      super.setText(text);
+      if (this.literal) {
+        this.literalOutput.setText(theme.toolOutput(text));
+      } else {
+        super.setText(text);
+      }
       this.renderedSource = text;
     }
 
-    const lines = super.render(safeWidth);
+    const lines = this.literal
+      ? this.literalOutput.render(safeWidth).map(tuiFormatters.isolateRtlRenderedLine)
+      : super.render(safeWidth);
     if (
       this.expanded ||
       (text.length === this.sourceText.length && lines.length <= PREVIEW_LINES)
@@ -104,6 +116,19 @@ function extractText(result?: ToolResult): string {
     }
   }
   return lines.join("\n");
+}
+
+function isCodeModeResult(toolName: string, result?: ToolResult): boolean {
+  if (toolName !== "exec" && toolName !== "wait") {
+    return false;
+  }
+  const visibleTools = asOptionalObjectRecord(result?.details?.telemetry)?.visibleTools;
+  return (
+    Array.isArray(visibleTools) &&
+    visibleTools.length === 2 &&
+    visibleTools[0] === "exec" &&
+    visibleTools[1] === "wait"
+  );
 }
 
 /** Displays a running or completed tool call with optional expandable output. */
@@ -174,6 +199,10 @@ export class ToolExecutionComponent extends Container {
       isPartial ? theme.toolPendingBg : isError ? theme.toolErrorBg : theme.toolSuccessBg,
     );
     const raw = extractText(result);
-    this.output.setText(raw.trim() ? raw : isPartial ? "…" : "");
+    // Code Mode JSON is literal data; prose normalization can change values and escapes.
+    this.output.setText(
+      raw.trim() ? raw : isPartial ? "…" : "",
+      isCodeModeResult(this.toolName, result),
+    );
   }
 }

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -88,7 +88,7 @@ export function formatTuiFooter(params: {
   return sanitizeRenderableLine(footer);
 }
 
-function sanitizeTerminalControlsAndBinary(text: string): string {
+export function sanitizeTerminalControlsAndBinary(text: string): string {
   const hasAnsi = text.includes("\u001b") || text.includes("\u009b") || text.includes("\u009d");
   const withoutAnsi = hasAnsi ? stripAnsi(text) : text;
   const withoutControlChars = withoutAnsi.replace(RENDER_CONTROL_CHARS_RE, "");


### PR DESCRIPTION
Closes #141367

## What Problem This Solves

Fixes an issue where Code Mode users receive truncated structured results when JSON indentation consumes the remaining per-result context budget. A synthetic 80-row array becomes a truncation object at a 4,096-token effective context budget even though its complete compact envelope fits.

Compact JSON also exposes a TUI display defect: prose formatting inserts spaces inside long values and interprets JSON string contents as Markdown.

## Why This Change Was Made

Use the same compact JSON serialization for Code Mode budget fitting and delivery, preserving every result field, structured details, network-content wrapping, and terminal/replay semantics. Remove repeated guidance from the `exec.code` parameter while retaining it in the full tool description.

Render Code Mode results literally in the TUI using their existing result metadata. Keep the existing output bounds and terminal-control/RTL protections; ordinary tool output retains Markdown rendering.

## User Impact

More structured tool data fits within the existing context limits. The model-visible parameter schema is 494 bytes smaller, with all orchestration guidance still available. The TUI preserves JSON values, escapes, and backticks; URLs in Code Mode output remain literal text without app-added Markdown/OSC8 links.

## Evidence

- The new tool/provider-boundary regression fails on the original implementation (`omittedBytes: 356`) and passes with all 80 rows preserved after the change.
- 354 focused core tests passed across seven files, covering result budgets, Unicode/escaping, network wrapping, terminal completion, classic Tool Search, and replay/restart recovery.
- 199 focused TUI/formatter/chat-history tests passed. Nine new literal-render regressions failed on the original source. Eight synthetic Control UI cases passed exact text and clipboard assertions across completed, waiting, failed, and network-wrapped results in both JSON formats.
- Independent P0–P2 review of the combined change is scoped-clean.
- `pnpm build` and `node scripts/check-changed.mjs` passed. The latter includes core/core-test type checks, production/test lint, dead exports, import cycles, and repository guards. Four test-only missing-brace diagnostics found during validation were fixed before publication.
- Three comparisons of the same 20 selected tasks have completed, with one attempt per task in each of four configurations. All outcomes, exceptions, resource observations and available usage remain retained. These results do not establish an improvement in task quality, token cost or end-to-end performance from this change.

| Configuration | R1: passes / 20 | R2: passes / 20 | R3: passes / 20 |
| --- | ---: | ---: | ---: |
| Native control | 9 | 11 | 13 |
| Native with this change | 8 | 10 | 11 |
| Pi Code Mode with Pi tools | 11 | 12 | 12 |
| Pi Code Mode with Codex tools | 10 | 13 | 14 |

Raw and clean pass counts are equal in these runs; neither label means that the run is free of measurement errors. The native builds share the same source base and Gateway support repair; only this context-efficiency patch differs. All three runs retain the original task limits, model settings and scoring rules and are reported separately.

R1 contained ten control-connection timeout cases. Separate model and control connections eliminated that observed pattern in R2. R3 corrected the measurement adapter's lease-time calculation and used the maintained Gateway RPC facade from a warm process; both builds passed the same five packaged lifecycle cases before scoring. Four native R3 trials nevertheless lost their verification fence when a suspension-renewal RPC exceeded its existing 10-second bound. These were both native configurations on `pytorch-model-recovery` and `torch-pipeline-parallelism`. The precise internal cause is unresolved; the original timeout and resource limits remained in force.

R3 admitted 510, 548, 387 and 488 model requests respectively. Complete token-usage coverage is 19/20, 18/20, 19/20 and 20/20 trials; missing usage is not treated as zero. The native paired outcomes were three control-only passes, one changed-build-only pass and ten shared passes. Only the changed build passed `gpt2-codegolf`; that run also involved an explicit search for a published task solution and external source ingestion, so it does not show that this patch caused the pass. No causal regression or improvement is established by these single-attempt results.

The prespecified 19-task Pi reference slice excludes only the image-input task. Its R3 pass counts are 12, 10, 12 and 13 in the same order. These previously exposed selected tasks do not establish full-benchmark parity, measured token savings or an end-to-end gain. The demonstrated benefits of this PR remain the deterministic result-retention and literal-rendering fixes above.

The images below use the same synthetic compact result and rasterize the actual TUI component's text at 80 columns, with ANSI styles omitted. They are component-rendering proof, not live PTY or Gateway proof.

Before: long values gain spaces, and backslashes/Markdown markers are interpreted.

![TUI before literal rendering](https://github.com/user-attachments/assets/a5e1f05f-fd80-4bbe-856c-1527eafb7dd7)

After: the same data remains literal.

![TUI after literal rendering](https://github.com/user-attachments/assets/aef283fe-495a-41b9-9588-95dcf08d2c5d)


### Maintainer validation

The 458 selected tests across eight Code Mode, Tool Search, and TUI files pass on both the original candidate and the rebased head. Tests with the original production implementation reproduce the 80-row truncation (`omittedBytes: 356`) and nine literal-render failures; the temporary baseline changes were restored. The JSON-encoded parameter-description reduction is independently confirmed as 494 bytes.

Independent review raised a direct-tool visibility hypothesis. Source inspection resolved it: `code-mode-state.ts` always stamps result telemetry with the `exec`/`wait` control pair, independently of the direct tools exposed by catalog compaction. Completion, waiting, and failure producers all use that telemetry owner. No source change was needed for that finding.

PR-scoped lint passes. The requested wider sweep also found two existing `oxc/no-map-spread` errors in `test/scripts/plugin-npm-security-scan.test.ts` (lines 287 and 308), a file unchanged by this PR. The configured root-test lint runner reproduces them; that file and lint configuration are also identical in successful main CI run 34174985583. They remain a separate main-maintenance follow-up. [Exact-head hosted CI passed](https://github.com/openclaw/openclaw/actions/runs/34175738017) before the native merge.

