### PR TITLE
fix(tui): scope steer injection to active embedded agent owner

### DIFF
--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -1,6 +1,11 @@
 // Covers embedded backend behavior used by the TUI runtime.
 import fs from "node:fs/promises";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  ACTIVE_EMBEDDED_RUN_REGISTRATIONS,
+  ACTIVE_EMBEDDED_RUNS,
+  type EmbeddedAgentQueueHandle,
+} from "../agents/embedded-agent-runner/run-state.js";
 import { QuestionAnswerUnconfirmedError } from "../agents/harness/gateway-question-dispatch.js";
 import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
@@ -1985,6 +1990,140 @@ describe("EmbeddedTuiBackend", () => {
 
     first.resolve({ payloads: [{ text: "done" }], meta: {} });
     await flushMicrotasks();
+  });
+
+  it("does not steer selected-global sends into another agent's active embedded run", async () => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+    });
+    const first = deferred<EmbeddedAgentResult>();
+    const second = deferred<EmbeddedAgentResult>();
+    agentCommandFromIngressMock
+      .mockReturnValueOnce(first.promise)
+      .mockReturnValueOnce(second.promise);
+    resolveActiveEmbeddedRunSessionIdMock.mockReturnValue("active-session-main");
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
+      cfg: {},
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
+      canonicalKey: sessionKey === "global" ? "global" : sessionKey,
+      storePath: `/tmp/openclaw-${opts?.agentId ?? "main"}-sessions.json`,
+      store: {},
+      entry: {},
+    }));
+    const foreignHandle = {
+      runId: "run-foreign-main",
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: () => {},
+    } as EmbeddedAgentQueueHandle;
+    ACTIVE_EMBEDDED_RUNS.set("active-session-main", foreignHandle);
+    ACTIVE_EMBEDDED_RUN_REGISTRATIONS.set(foreignHandle, {
+      sessionId: "active-session-main",
+      sessionKey: "global",
+      agentId: "main",
+    });
+
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+    try {
+      await backend.sendChat({
+        sessionKey: "global",
+        agentId: "work",
+        message: "first",
+        runId: "run-work-first",
+      });
+      const result = await backend.sendChat({
+        sessionKey: "global",
+        agentId: "work",
+        message: "steer across agents",
+        runId: "run-work-second",
+      });
+
+      // Mismatch falls through to followup: a local successor run is admitted,
+      // but it must not inject into the foreign active embedded owner.
+      expect(result).toEqual({ runId: "run-work-second" });
+      expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).not.toHaveBeenCalled();
+      expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+
+      first.resolve({ payloads: [{ text: "first done" }], meta: {} });
+      await vi.waitFor(() => {
+        expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(2);
+      });
+      expect(agentCommandFromIngressMock.mock.calls[1]?.[0]).toMatchObject({
+        runId: "run-work-second",
+        message: "steer across agents",
+      });
+      second.resolve({ payloads: [{ text: "second done" }], meta: {} });
+      await flushMicrotasks();
+    } finally {
+      ACTIVE_EMBEDDED_RUNS.delete("active-session-main");
+    }
+  });
+
+  it("still steers selected-global sends into the same agent's active embedded run", async () => {
+    getRuntimeConfigMock.mockReturnValue({
+      agents: { list: [{ id: "main", default: true }, { id: "work" }] },
+    });
+    const first = deferred<EmbeddedAgentResult>();
+    agentCommandFromIngressMock.mockReturnValueOnce(first.promise);
+    resolveActiveEmbeddedRunSessionIdMock.mockReturnValue("active-session-work");
+    loadSessionEntryMock.mockImplementation((sessionKey: string, opts?: { agentId?: string }) => ({
+      cfg: {},
+      agentId: opts?.agentId ?? parseAgentSessionKey(sessionKey)?.agentId ?? "main",
+      canonicalKey: sessionKey === "global" ? "global" : sessionKey,
+      storePath: `/tmp/openclaw-${opts?.agentId ?? "main"}-sessions.json`,
+      store: {},
+      entry: {},
+    }));
+    queueEmbeddedAgentMessageWithOutcomeAsyncMock.mockResolvedValue({
+      queued: true,
+      sessionId: "active-session-work",
+      target: "embedded_run",
+      gatewayHealth: "live",
+    });
+    const ownedHandle = {
+      runId: "run-owned-work",
+      queueMessage: async () => {},
+      isStreaming: () => true,
+      isCompacting: () => false,
+      abort: () => {},
+    } as EmbeddedAgentQueueHandle;
+    ACTIVE_EMBEDDED_RUNS.set("active-session-work", ownedHandle);
+    ACTIVE_EMBEDDED_RUN_REGISTRATIONS.set(ownedHandle, {
+      sessionId: "active-session-work",
+      sessionKey: "global",
+      agentId: "work",
+    });
+
+    const backend = new EmbeddedTuiBackend();
+    backend.start();
+    try {
+      await backend.sendChat({
+        sessionKey: "global",
+        agentId: "work",
+        message: "first",
+        runId: "run-work-owned-first",
+      });
+      const result = await backend.sendChat({
+        sessionKey: "global",
+        agentId: "work",
+        message: "steer same agent",
+        runId: "run-work-owned-second",
+      });
+
+      expect(result).toEqual({ runId: "run-work-owned-first" });
+      expect(queueEmbeddedAgentMessageWithOutcomeAsyncMock).toHaveBeenCalledWith(
+        "active-session-work",
+        "steer same agent",
+        { steeringMode: "all", debounceMs: 500, isInboundUserMessage: true },
+      );
+      expect(agentCommandFromIngressMock).toHaveBeenCalledTimes(1);
+      first.resolve({ payloads: [{ text: "done" }], meta: {} });
+      await flushMicrotasks();
+    } finally {
+      ACTIVE_EMBEDDED_RUNS.delete("active-session-work");
+    }
   });
 
   it("surfaces uncertain question input without queuing it again", async () => {

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -22,7 +22,12 @@ import {
 import { ensureContextWindowCacheLoaded } from "../agents/context.js";
 import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveActiveEmbeddedRunSessionId } from "../agents/embedded-agent-runner/active-run-projections.js";
+import {
+  ACTIVE_EMBEDDED_RUN_REGISTRATIONS,
+  ACTIVE_EMBEDDED_RUNS,
+} from "../agents/embedded-agent-runner/run-state.js";
 import { queueEmbeddedAgentMessageWithOutcomeAsync } from "../agents/embedded-agent-runner/runs.js";
+import { resolveActiveReplyOperationForSessionId } from "../auto-reply/reply/reply-run-registry.registry.js";
 import { QuestionAnswerUnconfirmedError } from "../agents/harness/gateway-question-dispatch.js";
 import {
   buildAllowedModelSet,
@@ -94,7 +99,11 @@ import {
   setEmbeddedPluginApprovalBroker,
 } from "../infra/embedded-plugin-approval-broker.js";
 import { logInfo, logWarn } from "../logger.js";
-import { agentSessionKeysMatchByRequestKey, normalizeAgentId } from "../routing/session-key.js";
+import {
+  agentSessionKeysMatchByRequestKey,
+  normalizeAgentId,
+  parseAgentSessionKey,
+} from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import { INTERNAL_MESSAGE_CHANNEL } from "../utils/message-channel.js";
 import {
@@ -351,6 +360,24 @@ async function waitForQueuedLocalRun(previousRun: QueuedSessionRun, runId: strin
   }
 }
 
+
+/** Prefer registration.agentId, then reply-op agent, then sessionKey parse. */
+function resolveActiveSteerOwnerAgentId(sessionId: string): string | undefined {
+  const handle = ACTIVE_EMBEDDED_RUNS.get(sessionId);
+  const registration = handle ? ACTIVE_EMBEDDED_RUN_REGISTRATIONS.get(handle) : undefined;
+  if (registration?.agentId) {
+    return registration.agentId;
+  }
+  const replyOperation = resolveActiveReplyOperationForSessionId(sessionId);
+  if (replyOperation?.agentId) {
+    return replyOperation.agentId;
+  }
+  return (
+    parseAgentSessionKey(registration?.sessionKey)?.agentId ??
+    parseAgentSessionKey(replyOperation?.key)?.agentId
+  );
+}
+
 export class EmbeddedTuiBackend implements TuiBackend {
   readonly connection = { url: "local embedded" };
 
@@ -491,22 +518,32 @@ export class EmbeddedTuiBackend implements TuiBackend {
       if (queueSettings.mode === "steer") {
         const activeSessionId = resolveActiveEmbeddedRunSessionId(canonicalKey);
         if (activeSessionId) {
-          const outcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
-            activeSessionId,
-            opts.message,
-            {
-              steeringMode: "all",
-              debounceMs: queueSettings.debounceMs ?? DEFAULT_QUEUE_DEBOUNCE_MS,
-              isInboundUserMessage: true,
-            },
-          ).catch((error: unknown) => {
-            if (error instanceof QuestionAnswerUnconfirmedError) {
-              throw error;
+          // Mirror abortChat's global agent filter: do not inject into another
+          // agent's active embedded/reply owner for the same canonical key.
+          const defaultAgentId = resolveDefaultAgentId(getRuntimeConfig());
+          const requestedAgentId = normalizeAgentId(agentId);
+          const recordedAgentId = resolveActiveSteerOwnerAgentId(activeSessionId);
+          const activeAgentId = recordedAgentId
+            ? normalizeAgentId(recordedAgentId)
+            : defaultAgentId;
+          if (activeAgentId === requestedAgentId) {
+            const outcome = await queueEmbeddedAgentMessageWithOutcomeAsync(
+              activeSessionId,
+              opts.message,
+              {
+                steeringMode: "all",
+                debounceMs: queueSettings.debounceMs ?? DEFAULT_QUEUE_DEBOUNCE_MS,
+                isInboundUserMessage: true,
+              },
+            ).catch((error: unknown) => {
+              if (error instanceof QuestionAnswerUnconfirmedError) {
+                throw error;
+              }
+              return undefined;
+            });
+            if (outcome?.queued) {
+              return { runId: queuedAfter.runId };
             }
-            return undefined;
-          });
-          if (outcome?.queued) {
-            return { runId: queuedAfter.runId };
           }
         }
         queueSettings = { ...queueSettings, mode: "followup" };

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -27,7 +27,6 @@ import {
   ACTIVE_EMBEDDED_RUNS,
 } from "../agents/embedded-agent-runner/run-state.js";
 import { queueEmbeddedAgentMessageWithOutcomeAsync } from "../agents/embedded-agent-runner/runs.js";
-import { resolveActiveReplyOperationForSessionId } from "../auto-reply/reply/reply-run-registry.registry.js";
 import { QuestionAnswerUnconfirmedError } from "../agents/harness/gateway-question-dispatch.js";
 import {
   buildAllowedModelSet,
@@ -45,6 +44,7 @@ import {
   DEFAULT_QUEUE_DROP,
 } from "../auto-reply/reply/queue/state.js";
 import type { QueueSettings } from "../auto-reply/reply/queue/types.js";
+import { resolveActiveReplyOperationForSessionId } from "../auto-reply/reply/reply-run-registry.registry.js";
 import { createDefaultDeps } from "../cli/deps.js";
 import { getRuntimeConfig, registerConfigWriteListener } from "../config/config.js";
 import type { SessionEntry } from "../config/sessions.js";
@@ -359,7 +359,6 @@ async function waitForQueuedLocalRun(previousRun: QueuedSessionRun, runId: strin
     }
   }
 }
-
 
 /** Prefer registration.agentId, then reply-op agent, then sessionKey parse. */
 function resolveActiveSteerOwnerAgentId(sessionId: string): string | undefined {


### PR DESCRIPTION
## What Problem This Solves

TUI `sendChat` in steer mode resolves the active embedded run with
`resolveActiveEmbeddedRunSessionId(canonicalKey)` and injects via
`queueEmbeddedAgentMessageWithOutcomeAsync` without checking the active owner’s
`agentId`. For selected-global sessions, agent B can steer into agent A’s live
embedded run when both share canonical key `global`. Local `abortChat` already
filters global runs by `opts.agentId`.

## Why This Change Was Made

Add a TUI-side gate symmetric with `abortChat`: after resolving the active
session id, compare registration / reply-op agent (falling back to the default
agent id) with the requesting agent. On mismatch, skip injection and keep the
existing followup fallback. Same-agent steer is unchanged.

## User Impact

**Before:** A selected-global steer from agent `work` could inject into a
`main`-owned active embedded run under key `global`.

**After:** Cross-agent steer falls back to followup; same-agent steer still
targets the active embedded run.

## Evidence

- Changed: `src/tui/embedded-backend.ts`, `src/tui/embedded-backend.test.ts`
- Production path: Embedded TUI `sendChat` → steer branch → owner gate →
  `queueEmbeddedAgentMessageWithOutcomeAsync` or followup fallback
- Compatibility: matching agent / default-agent same-session steer unchanged
- Dedup: open `#141379` scopes gateway abort/active helpers (different surface);
  no open PR owns TUI sendChat steer×agentId

## Real behavior proof

### Behavior or issue addressed

Selected-global `sendChat` from agent `work` must not call
`queueEmbeddedAgentMessageWithOutcomeAsync` when the active embedded registration
is owned by `main`; same-agent `work` steer still queues into the owned run.

### Canonical reachability path

Embedded TUI `sendChat` (queue mode steer) →
`resolveActiveEmbeddedRunSessionId(canonicalKey)` → registration/reply-op agent
compare → queue only on match; else followup

### Shared helper / provider constraint check

Gate lives in the TUI caller (`embedded-backend.ts`). Reads existing
`ACTIVE_EMBEDDED_RUN_REGISTRATIONS` / reply-op `agentId`; does not change the
shared queue API or make TUI blindly trust BY_KEY alone. Distinct from
`#141379` gateway abort/active owner scoping.

### Real environment tested

Local trusted source checkout at PR head; Vitest TUI project; real
`ACTIVE_EMBEDDED_RUNS` / registration seeding plus production
`EmbeddedTuiBackend.sendChat`.

### Exact steps or command run after this patch

```bash
node scripts/run-vitest.mjs src/tui/embedded-backend.test.ts --reporter=verbose -t "does not steer selected-global|still steers selected-global|steers same-session sends|does not abort selected-global"
```

### Evidence after fix

```text
[test] starting test/vitest/vitest.tui.config.ts

 RUN  v5.0.0 /workspace/openclaw-nocodet

[vitest-workers] prepared 05f19d3f2326 in 5628ms (8596 inputs, 4303 outputs)
 ✓ |tui| src/tui/embedded-backend.test.ts > EmbeddedTuiBackend > steers same-session sends into the active local run 18ms
 ✓ |tui| src/tui/embedded-backend.test.ts > EmbeddedTuiBackend > does not steer selected-global sends into another agent's active embedded run 58ms
 ✓ |tui| src/tui/embedded-backend.test.ts > EmbeddedTuiBackend > still steers selected-global sends into the same agent's active embedded run 4ms
 ✓ |tui| src/tui/embedded-backend.test.ts > EmbeddedTuiBackend > does not abort selected-global run ids across default-agent boundaries 5ms

 Test Files  1 passed (1)
      Tests  4 passed | 119 skipped (123)
   Start at  17:48:43
   Duration  10.02s (transform 77%, import 13%, tests 6%, worker 3%, setup 1%)

[vitest-workers] verifying completed generation before cleanup
[test] passed 1 Vitest shard in 11.80s
```

### Observed result after fix

Cross-agent selected-global steer skipped queue injection and fell through to
followup; same-agent selected-global steer and same-session main steer still
queued; existing selected-global abort filter stayed green.

### What was not tested

No full interactive TUI process; proof uses production `EmbeddedTuiBackend.sendChat`
in-process with a seeded embedded-run registration and mocked active-session id
lookup / queue outcome.

### Fix classification

Root cause fix.

## Checklist

- [x] AI-assisted
- [x] Allow edits from maintainers
- [x] Single concern / single commit
- [x] No CHANGELOG.md edit
