### PR TITLE
improve(ai): reduce Chat Completions replay preparation

### DIFF
--- a/packages/ai/src/openai-completions-messages.test.ts
+++ b/packages/ai/src/openai-completions-messages.test.ts
@@ -80,7 +80,7 @@ describe("convertMessages assistant text replay", () => {
   });
 
   it.each([false, true])(
-    "preserves sanitized block positions with thinking-as-text %s",
+    "preserves interleaved text, thinking, and tool replay with thinking-as-text %s",
     (requiresThinkingAsText) => {
       const assistant: AssistantMessage = {
         role: "assistant",
@@ -88,20 +88,44 @@ describe("convertMessages assistant text replay", () => {
         provider: model.provider,
         model: model.id,
         content: [
-          { type: "thinking", thinking: "reason\ud800" },
+          { type: "thinking", thinking: " \t", thinkingSignature: "reasoning_text" },
+          {
+            type: "thinking",
+            thinking: "reason\ud800",
+            thinkingSignature: "reasoning_content",
+          },
           { type: "text", text: " \t" },
           { type: "text", text: "first\ud800" },
           { type: "text", text: "\udc00" },
-          { type: "thinking", thinking: "next😀" },
+          {
+            type: "toolCall",
+            id: "call_lookup",
+            name: "lookup",
+            arguments: { query: "cats" },
+            thoughtSignature: '{"type":"reasoning.encrypted","data":"synthetic"}',
+          },
+          { type: "thinking", thinking: "next😀", thinkingSignature: "reasoning_text" },
           { type: "text", text: "last😀" },
         ],
         usage: emptyUsage,
-        stopReason: "stop",
+        stopReason: "toolUse",
         timestamp: 2,
       };
       const converted = convertMessages(
         model,
-        { messages: [assistant] },
+        {
+          messages: [
+            assistant,
+            {
+              role: "toolResult",
+              toolCallId: "call_lookup",
+              toolName: "lookup",
+              content: [{ type: "text", text: "found" }],
+              isError: false,
+              timestamp: 3,
+            },
+          ],
+        },
         { ...resolveOpenAICompletionsCompat(model), requiresThinkingAsText },
       );
 
@@ -116,7 +140,17 @@ describe("convertMessages assistant text replay", () => {
                 { type: "text", text: "last😀" },
               ]
             : "first\n\nlast😀",
+          ...(!requiresThinkingAsText && { reasoning_content: "reason\ud800\nnext😀" }),
+          tool_calls: [
+            {
+              id: "call_lookup",
+              type: "function",
+              function: { name: "lookup", arguments: '{"query":"cats"}' },
+            },
+          ],
+          reasoning_details: [{ type: "reasoning.encrypted", data: "synthetic" }],
         },
+        { role: "tool", content: "found", tool_call_id: "call_lookup" },
       ]);
     },
   );

--- a/packages/ai/src/openai-completions-messages.ts
+++ b/packages/ai/src/openai-completions-messages.ts
@@ -15,7 +15,7 @@ import {
   isImageWithMediaPayload,
 } from "./providers/tool-result-text.js";
 import type { ResolvedOpenAICompletionsCompat } from "./transports/openai-completions-compat.js";
-import type { Context, Model, TextContent, ThinkingContent, ToolCall } from "./types.js";
+import type { Context, Model, ThinkingContent, ToolCall } from "./types.js";
 import { sanitizeSurrogates } from "./utils/sanitize-unicode.js";
 import { stripSystemPromptCacheBoundary } from "./utils/system-prompt-cache-boundary.js";
 
@@ -24,18 +24,6 @@ type ChatCompletionContentPartVideo = {
   type: "video_url";
   video_url: { url: string };
 };
-
-function isTextContentBlock(block: { type: string }): block is TextContent {
-  return block.type === "text";
-}
-
-function isThinkingContentBlock(block: { type: string }): block is ThinkingContent {
-  return block.type === "thinking";
-}
-
-function isToolCallBlock(block: { type: string }): block is ToolCall {
-  return block.type === "toolCall";
-}
 
 function sanitizeToolResultText(text: string, fallback: string): string {
   const sanitized = sanitizeSurrogates(text);
@@ -153,35 +141,36 @@ export function convertMessages(
         content: compat.requiresAssistantAfterToolResult ? "" : null,
       };
 
-      const assistantTexts = msg.content
-        .filter(isTextContentBlock)
-        .filter((block) => block.text.trim().length > 0)
-        .map((block) => sanitizeSurrogates(block.text));
-      // Separate content blocks are distinct utterances, so replay them the way
-      // the string-content flattener does rather than running them together.
-      const assistantText = assistantTexts.join("\n");
-
-      const nonEmptyThinkingBlocks = msg.content
-        .filter(isThinkingContentBlock)
-        .filter((block) => block.thinking.trim().length > 0);
-      if (nonEmptyThinkingBlocks.length > 0) {
-        if (compat.requiresThinkingAsText) {
-          const thinkingText = nonEmptyThinkingBlocks
-            .map((block) => sanitizeSurrogates(block.thinking))
-            .join("\n\n");
-          assistantMsg.content = [
-            { type: "text", text: thinkingText },
-            ...assistantTexts.map((text): ChatCompletionContentPartText => ({
-              type: "text",
-              text,
-            })),
-          ];
-        } else {
-          // String content is the interoperable Chat Completions replay shape;
-          // content-part arrays make some compatible servers mirror JSON.
-          if (assistantText.length > 0) {
-            assistantMsg.content = assistantText;
-          }
+      const assistantTexts: string[] = [];
+      const nonEmptyThinkingBlocks: ThinkingContent[] = [];
+      const toolCalls: ToolCall[] = [];
+      msg.content.forEach((block) => {
+        if (block.type === "text" && block.text.trim().length > 0) {
+          assistantTexts.push(sanitizeSurrogates(block.text));
+        } else if (block.type === "thinking" && block.thinking.trim().length > 0) {
+          nonEmptyThinkingBlocks.push(block);
+        } else if (block.type === "toolCall") {
+          toolCalls.push(block);
+        }
+      });
+      if (nonEmptyThinkingBlocks.length > 0 && compat.requiresThinkingAsText) {
+        const thinkingText = nonEmptyThinkingBlocks
+          .map((block) => sanitizeSurrogates(block.thinking))
+          .join("\n\n");
+        assistantMsg.content = [
+          { type: "text", text: thinkingText },
+          ...assistantTexts.map((text): ChatCompletionContentPartText => ({
+            type: "text",
+            text,
+          })),
+        ];
+      } else {
+        // Keep separate utterances apart in the interoperable string replay shape.
+        const assistantText = assistantTexts.join("\n");
+        if (assistantText.length > 0) {
+          assistantMsg.content = assistantText;
+        }
+        if (nonEmptyThinkingBlocks.length > 0) {
           let signature = nonEmptyThinkingBlocks.at(0)?.thinkingSignature;
           if (model.provider === "opencode-go" && signature === "reasoning") {
             signature = "reasoning_content";
@@ -191,11 +180,8 @@ export function convertMessages(
               nonEmptyThinkingBlocks.map((block) => block.thinking).join("\n");
           }
         }
-      } else if (assistantText.length > 0) {
-        assistantMsg.content = assistantText;
       }
 
-      const toolCalls = msg.content.filter(isToolCallBlock);
       if (toolCalls.length > 0) {
         assistantMsg.tool_calls = toolCalls.map((toolCall) => ({
           id: toolCall.id,
@@ -231,10 +217,7 @@ export function convertMessages(
         (assistantMsg as { reasoning_content?: string }).reasoning_content = "";
       }
       const content = assistantMsg.content;
-      const hasContent =
-        content !== null &&
-        content !== undefined &&
-        (typeof content === "string" ? content.length > 0 : content.length > 0);
+      const hasContent = content !== null && content !== undefined && content.length > 0;
       if (!hasContent && !assistantMsg.tool_calls) {
         continue;
       }


### PR DESCRIPTION
## What Problem This Solves

Preparing Chat Completions requests does unnecessary work when replaying assistant histories, especially longer conversations and messages containing both text and thinking. The cost appears in both direct and managed request preparation, before any provider request is sent.

## Why This Change Was Made

Classify assistant blocks once into the existing text, thinking, and tool-call collections, and join ordinary text only when the outgoing representation needs that string. This also removes three local type guards and duplicate content-assignment branches: **17 fewer production lines**.

The converter keeps its current wire contract: raw nonblank filtering precedes Unicode sanitation; text and thinking retain their different separators; the first nonblank thinking block owns the replay field; tool order, serialized arguments and encrypted signatures are preserved. Transcript transformation, compatibility policy, null/empty content, required reasoning fields and message elision remain unchanged. The existing two-mode replay test table is extended with interleaved signatures and a paired tool result (**34 added test lines**).

## User Impact

This is a bounded preparation improvement with unchanged request output. In the fixed workload, 32-turn plain histories improved direct request-builder medians by **6.65% / 10.81%** and managed-builder medians by **3.78% / 1.55%** in the two opposite orders. Interleaved thinking-as-text improved direct medians by **6.13% / 12.58%** and managed medians by **10.10% / 9.79%**.

Results are mixed: **48 of 66 median comparisons improved; 18 regressed**. Small converter inputs, some direct/managed controls and first-call/maximum-batch comparisons were adverse. This does not establish a universal provider, inference, Gateway, startup or readiness speedup, and no minimum-percentage threshold was used to discard results.

## Evidence

- **208 baseline and 208 candidate tests passed across seven owner/sibling files**, including the extended behavior table on both implementations.
- **28 normal changed-check stages passed** in the separate `changed-r2` continuation; managed P2 review was scoped-clean with no findings (reported confidence 0.98).
- The original normal gate remains recorded as a failure: after **116.467 seconds**, its native monitor reported an unproven descendant group, exited with −15 and retained `closed=false`. A later check found all **118 observed PIDs and 70 groups absent**, followed the canonical owner's exact stale-lock recovery, and ran the unchanged guard in a separate **191.122-second** successful continuation. The original failed receipt was not rewritten or counted as passing.
- Fixed **B0/C0/C1/B1** numeric runs called the actual `convertMessages` and direct/managed `buildOpenAICompletionsRequest` exports: **8,976 calls, 33 full output rows per phase**. Complete returned JSON values, literal wire strings and own-undefined-property paths matched. Fixed timestamps and paired tool results avoided synthetic repair-clock differences; inputs stayed unchanged.
- Independent data review reconciled every call, journal identity, duration and resource record, and reproduced all **198 comparisons, including 76 adverse comparisons**. All four numeric runs exited zero with joined monitoring and observed-process closure; the candidate was restored. No target or reducer rerun was used for that audit. Numeric R1 has no outputs; R2 retains the identical benchmark/corpus/reducer with separate validated recovery routing.

<details>
<summary>All median comparisons, including every adverse control category</summary>

Candidate minus baseline; negative is faster. Forward is B0→C0; reverse compares B1→C1. These are medians of eight-call batch means, not significance or tail-latency estimates.

| Mode | Fixture | Forward | Reverse |
| --- | --- | ---: | ---: |
| convert | plain-1 | +22.04% | +0.66% |
| convert | plain-8 | -9.44% | +0.71% |
| convert | plain-32 | -11.53% | -20.33% |
| convert | unicode-no-thinking | +13.23% | +4.64% |
| convert | interleaved-field | -12.44% | -0.87% |
| convert | interleaved-text | -9.95% | -10.26% |
| convert | cross-route-field | -7.19% | -4.52% |
| convert | cross-route-text | -13.14% | -6.65% |
| convert | thinking-only | -6.44% | -3.21% |
| convert | tool-only-required-fields | -14.30% | -23.64% |
| convert | managed-string-strict | -14.04% | -5.31% |
| direct | plain-1 | -16.99% | -10.13% |
| direct | plain-8 | -6.68% | +2.60% |
| direct | plain-32 | -6.65% | -10.81% |
| direct | unicode-no-thinking | -8.27% | -3.60% |
| direct | interleaved-field | -2.61% | -6.52% |
| direct | interleaved-text | -6.13% | -12.58% |
| direct | cross-route-field | +0.21% | -5.88% |
| direct | cross-route-text | -0.82% | -0.68% |
| direct | thinking-only | +0.17% | +1.07% |
| direct | tool-only-required-fields | -1.18% | +4.72% |
| direct | managed-string-strict | -1.15% | +9.07% |
| managed | plain-1 | +9.75% | -4.63% |
| managed | plain-8 | -7.97% | -2.11% |
| managed | plain-32 | -3.78% | -1.55% |
| managed | unicode-no-thinking | -5.43% | +3.89% |
| managed | interleaved-field | -10.92% | +0.15% |
| managed | interleaved-text | -10.10% | -9.79% |
| managed | cross-route-field | -4.57% | -6.65% |
| managed | cross-route-text | -8.33% | -3.33% |
| managed | thinking-only | -3.80% | +12.36% |
| managed | tool-only-required-fields | +3.84% | +11.04% |
| managed | managed-string-strict | -13.89% | +0.49% |

The first-call and maximum-batch-mean comparisons are also retained, including every adverse record; no unfavorable observation was dropped. Per-row first calls occur after shared imports and are not cold-process startup measurements.

</details>

<details>
<summary>Whole-process resource results</summary>

| Phase | Wall s | User CPU s | System CPU s | Child peak bytes | Observed tree peak bytes | Minimum free bytes |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| B0 | 1.080665 | 1.052413 | 0.391473 | 229343232 | 252182528 | 3854925824 |
| C0 | 1.079079 | 1.040700 | 0.390050 | 226967552 | 249905152 | 3850702848 |
| C1 | 1.075675 | 1.048975 | 0.396505 | 227229696 | 249675776 | 3843289088 |
| B1 | 1.060838 | 1.050396 | 0.376871 | 228884480 | 250937344 | 3833962496 |

These include imports and evidence collection, not just the converter. Forward candidate wall/user/system time is lower; reverse candidate wall and system CPU are higher, while user CPU is lower. Child and observed-tree peak RSS are lower for the candidate in both orders. Minimum free disk is the admission/cleanup observation shown above, not an allocation result. Per-call CPU/RSS records were retained and audited; CPU deltas include nearby instrumentation, and before/after RSS is not a per-call peak or heap measurement.

</details>
