### PR TITLE
refactor(infra): reuse SQLite data-version reader for device pairing

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2973,7 +2973,7 @@ src/infra/delivery-queue-sqlite-bound.ts	2
 src/infra/delivery-queue-sqlite.ts	2
 src/infra/delivery-queue-sqlite.types.ts	1
 src/infra/delivery-recovery.shared.ts	4
-src/infra/device-pairing-store.ts	6
+src/infra/device-pairing-store.ts	5
 src/infra/diagnostic-event-listener-presence.ts	3
 src/infra/diagnostic-events.ts	13
 src/infra/diagnostic-model-request.ts	1

--- a/src/infra/device-pairing-store.ts
+++ b/src/infra/device-pairing-store.ts
@@ -39,6 +39,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import { readSqliteDataVersion } from "./node-sqlite.js";
 import { clearApnsRegistrationFromDatabase } from "./push-apns-store-transaction.js";
 
 export type DevicePairingStoreState = {
@@ -101,14 +102,6 @@ function resolveDevicePairingStateDbOptions(baseDir?: string): OpenClawStateData
   return baseDir ? { env: { ...process.env, OPENCLAW_STATE_DIR: baseDir } } : {};
 }
 
-function readDataVersion(database: DatabaseSync): number {
-  const row = database.prepare("PRAGMA data_version").get() as { data_version?: unknown };
-  if (typeof row.data_version !== "number") {
-    throw new Error("SQLite did not return a numeric PRAGMA data_version");
-  }
-  return row.data_version;
-}
-
 function readTotalChanges(database: DatabaseSync): number {
   const row = database.prepare("SELECT total_changes() AS value").get() as { value?: unknown };
   if (typeof row.value !== "number") {
@@ -121,7 +114,7 @@ function readDevicePairingStoreValidityToken(
   database: DatabaseSync,
 ): DevicePairingStoreValidityToken {
   return {
-    dataVersion: readDataVersion(database),
+    dataVersion: readSqliteDataVersion(database),
     totalChanges: readTotalChanges(database),
   };
 }


### PR DESCRIPTION
## What Problem This Solves

This maintainer-requested deduplication removes a second implementation of the SQLite freshness reader used by the device-pairing cache, preventing the two implementations from drifting. No user-visible defect is claimed.

## Why This Change Was Made

Reuse the existing `readSqliteDataVersion` helper and remove the identical private reader. The same connection, synchronous query, numeric check, error behavior, and evaluation before `total_changes()` are preserved. The state database owner still controls connection admission, lifecycle, and transactions.

The helper module was already statically reachable through the state database owner; the new direct import follows that owner import. The only companion change lowers this file's assertion-safety baseline from 6 to 5, matching the removed assertion. No other baseline entry changes.

## User Impact

No user-visible behavior, schema, configuration, cache policy, authorization, or public API changes. The production diff removes seven net lines.

## Evidence

- `node scripts/run-vitest.mjs src/infra/device-pairing.test.ts src/gateway/server.node-pairing-memo.test.ts`: 78 pairing tests passed. The Gateway suite initially could not load omitted package-local dependency links; after linking the existing install, its focused rerun passed all 3 tests, including next-dispatch mutations and external-connection cache refresh.
- `node scripts/run-vitest.mjs src/infra/node-sqlite.test.ts src/config/sessions/session-accessor.sqlite-data-version.test.ts`: 30 SQLite helper tests and 29 session data-version tests passed.
- Total: 140 passing tests. These tests were retained, not repeated for the metadata-only baseline correction. No test source changed.
- AST comparison confirmed identical reader statements. Formatting, targeted core lint, script lint, `git diff --check`, and all non-typecheck steps selected by `check-changed` passed. The failed assertion ratchet was corrected and rerun; missing sparse-worktree UI/native inputs were exposed before successful export-scan and native-schema-guard retries. The import-cycle guard reported zero runtime value cycles.
- Independent review through P2 is clean after the exact baseline correction.
- [Exact-head CI run 34149642604](https://github.com/openclaw/openclaw/actions/runs/34149642604) succeeded for `f40a69d863b478e49770c800a0b3f99faeb6e115`: 107 successful jobs, 17 skipped, zero failed. The required `openclaw/ci-gate` passed. This aggregate result is not a claim that every named focused suite ran in CI; the 140-test proof above remains local.
- Hosted typechecking executed successfully: [production types, job 101829180104](https://github.com/openclaw/openclaw/actions/runs/34149642604/job/101829180104), [core test types stripe 1, job 101829180025](https://github.com/openclaw/openclaw/actions/runs/34149642604/job/101829180025), [stripe 2, job 101829179994](https://github.com/openclaw/openclaw/actions/runs/34149642604/job/101829179994), and [additional test types, job 101829180074](https://github.com/openclaw/openclaw/actions/runs/34149642604/job/101829180074). Exact run/head identities and successful execution steps were verified.
- [ClawSweeper's completed exact-head review](https://github.com/openclaw/openclaw/pull/141420#issuecomment-5574232332) found no actionable correctness or security issues and listed no before-merge requests.
- Fresh main revalidation at `4109aab58c14a073a39cf7cf888ebc23a0108724` found no changes to the touched files, SQLite helper, or state database owner from the tested base `c79ad267ba623c1a323f1f6e8b60228bd5a30ce5`.
- Native review, prepare, and merge completed with `OPENCLAW_TESTBOX=1`. The exact prepared head was squash-merged as `0c4e05936919780ec1e6b53556d79bc6f58f0b8c`; the retained native outcome is accepted and complete.

Local proof limitations: both core typecheck commands failed because the compiler resolves through the shared external dependency symlink. The initial test-typecheck attempt also reported sparse UI inputs, subsequently exposed. No local typecheck or aggregate changed-check pass is claimed; the exact-head hosted production and test typechecks above supply that proof.

Warm-cache external revocation and malformed PRAGMA responses are not directly covered by these tests. Remote proof is hosted CI accepted by the native Testbox gate, not a live provider run or credentialed Crabbox lease.
