### PR TITLE
improve: avoid repeated cold imports in catalog worker tests

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -321,7 +321,7 @@ and runtime parents on TypeScript. Importing a declared subprocess entrypoint
 compiles the fixed test entry set and its workspace dependencies into one fresh
 invocation directory under `.artifacts/vitest-workers/`.
 
-The ten declared application entries run as plain Node JavaScript without a
+The declared application entries run as plain Node JavaScript without a
 TypeScript loader: SQLite read-only snapshots, database verification, Tailscale
 route ownership, the service relay, its POSIX and Windows anchors, the memory
 plugin's KNN child, session transcript archive and reconciliation workers, and
@@ -338,8 +338,13 @@ runtime graph while retaining the durable-write race and process-exit assertions
 Doctor process output tests with bundled plugins disabled reuse that compiled CLI
 inside one lazily created package fixture per test run, keeping real UI checks on
 fixture-owned assets and each scenario’s state separate. Standalone and watch runs
-use live source inside the same fixture. Other
-Worker-thread entries and arbitrary source CLI fixtures remain outside this declared set.
+use live source inside the same fixture.
+
+The prepared model-catalog worker also uses this compiled generation. Separate
+prepared model generations still own separate worker threads, and their choice
+of source or built plugin artifacts stays independent of worker compilation.
+Other worker-thread entries and arbitrary source CLI fixtures remain outside
+this declared set.
 
 The session-title and child-link retention tests declare their title-reader,
 session-utils, and listing roots in this same generation. Each fresh

--- a/src/agents/prepared-model-catalog-worker.ts
+++ b/src/agents/prepared-model-catalog-worker.ts
@@ -4,6 +4,7 @@ import {
   serializeConfigResolutionFacts,
 } from "../config/resolution-facts.js";
 import { projectConfigOntoRuntimeSourceSnapshot } from "../config/runtime-source-projection.js";
+import { runtimeProcessEntrypoints } from "../infra/runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import { WorkerTaskError, WorkerTaskPool } from "../infra/worker-task-pool.js";
 import { resolveInstalledManifestRegistryIndexFingerprint } from "../plugins/manifest-registry-installed.js";
@@ -239,11 +240,7 @@ export function createPreparedModelCatalogWorker(
     );
   const createPool = () =>
     new WorkerTaskPool<PreparedModelWorkerRequest, PreparedModelWorkerResult>({
-      workerUrl: resolveRuntimeWorkerUrl({
-        currentModuleUrl: import.meta.url,
-        sourceWorkerName: "prepared-model-catalog.worker",
-        distWorkerPath: "agents/prepared-model-catalog.worker.js",
-      }),
+      workerUrl: resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.preparedModelCatalog),
       maxWorkers: 1,
       // Recreating this worker would import changed plugin code under the old generation.
       // Only the lifecycle owner may retire it; crashes close the generation permanently.

--- a/src/infra/runtime-process-entrypoints.ts
+++ b/src/infra/runtime-process-entrypoints.ts
@@ -22,6 +22,11 @@ export const runtimeProcessEntrypoints = {
     sourceWorkerName: "sqlite-integrity.worker",
     distWorkerPath: "infra/sqlite-integrity.worker.js",
   },
+  preparedModelCatalog: {
+    currentModuleUrl,
+    sourceWorkerName: "../agents/prepared-model-catalog.worker",
+    distWorkerPath: "agents/prepared-model-catalog.worker.js",
+  },
   updateRepair: {
     currentModuleUrl,
     sourceWorkerName: "update-repair.worker",

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -412,7 +412,6 @@ function buildCoreDistEntries(): Record<string, string> {
       "src/config/sessions/session-model-context.worker.ts",
     "config/sessions/disk-budget.worker": "src/config/sessions/disk-budget.worker.ts",
     "agents/model-provider-auth.worker": "src/agents/model-provider-auth.worker.ts",
-    "agents/prepared-model-catalog.worker": "src/agents/prepared-model-catalog.worker.ts",
     ...runtimeProcessBuildEntries,
     ...runtimeProcessDeclarationEntries,
     "system-agent/setup-inference-detection.worker":


### PR DESCRIPTION
## What Problem This Solves

Prepared model-catalog integration tests repeatedly cold-load the same TypeScript dependency graph in fresh worker threads. A phase profile measured 50.2 seconds in post-start static imports across 25 workers, versus 1.6 seconds preparing their generations.

## Why This Change Was Made

Declare the catalog worker in the shared runtime entrypoint map so the existing Vitest invocation compiler prepares it once. Remove the now-duplicate package build entry. Each prepared generation still owns a separate worker thread; plugin artifact selection, auth refresh, cancellation, and process-close ownership remain unchanged. Source and packaged entrypoint paths also remain unchanged.

This reuses the existing compiler and cleanup owner instead of adding a worker pool, cache, or more shards. Runtime source grows by two lines; build configuration shrinks by one. Tests and assertions are unchanged.

## User Impact

Faster developer and CI catalog tests. No configuration, schema, dependency, or user-facing behavior change.

## Evidence

- On the same main snapshot including #141280, all 26 existing integration cases passed with identical names and order before and after. Source-worker command: 682.62s; candidate: 82.30s. Case sums: 500.39s and 49.71s. Host load and filesystem warmth varied substantially, so these are observed local timings, not a portable speedup ratio.
- The existing cases cover configured/standalone plugin artifacts, metadata scope, auth refresh, native routes, generation replacement, and all three current cancellation/process-close scenarios.
- Earlier actual-path instrumentation verified 25 source TypeScript workers became 25 JavaScript workers from the private invocation generation. A control retained the augmented compiler graph but forced source workers; all original 24 cases passed and import costs returned. Instrumentation was removed.
- Earlier standalone source-mode selection/auth cases and adjacent catalog/worker-URL tests passed. A matched compiler-graph probe added 16,160 bytes of output.
- Independent P2 review: no actionable findings.
- Full `pnpm build` passed, including built plugin loading and all 152 public SDK exports; the shared declaration resolves to the emitted `dist/agents/prepared-model-catalog.worker.js`.
- Full `check:changed` passed: all typecheck lanes, lint, static guards, and zero runtime import cycles.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34149947557) passed in 8m36s. The [actual catalog job](https://github.com/openclaw/openclaw/actions/runs/34149947557/job/101830093505) ran all 26 cases with identical names/order: 21.289s total, 608–2072ms per case. Its model-test invocation prepared the shared generation in 5.793s. These CI logs do not emit individual worker URLs; actual-path proof comes from the local instrumentation described above.
