### PR TITLE
refactor(tui): remove retired orphan bookkeeping

### DIFF
--- a/src/tui/tui-session-run-coordinator.ts
+++ b/src/tui/tui-session-run-coordinator.ts
@@ -68,7 +68,6 @@ export class TuiSessionRunCoordinator {
 
   private readonly historyReloadRuns = new Map<string, TuiHistoryReloadRun>();
   private readonly confirmedStreamRunIds = new Set<string>();
-  private readonly retiredOrphanRunIds = new Map<string, number>();
   private rejectUnconfirmedRuns = false;
   private readonly historyReloadRunner = createTuiRefreshCoalescer(() =>
     this.drainHistoryReloadQueue(),
@@ -132,7 +131,6 @@ export class TuiSessionRunCoordinator {
       return;
     }
     if (confirmedRun) {
-      this.retiredOrphanRunIds.delete(runId);
       this.confirmedStreamRunIds.add(runId);
       if (this.confirmedStreamRunIds.size > MAX_TRACKED_RUNS) {
         for (const protectedRunId of this.confirmedStreamRunIds) {
@@ -151,10 +149,7 @@ export class TuiSessionRunCoordinator {
   }
 
   isRetiredOrphanRun(runId: string): boolean {
-    return (
-      this.retiredOrphanRunIds.has(runId) ||
-      (this.rejectUnconfirmedRuns && !this.sessionRuns.has(runId))
-    );
+    return this.rejectUnconfirmedRuns && !this.sessionRuns.has(runId);
   }
 
   isHistoryTerminalDiagnosticRun(runId: string): boolean {
@@ -237,9 +232,7 @@ export class TuiSessionRunCoordinator {
           continue;
         }
         this.forgetSessionRun(candidateRunId);
-        this.retiredOrphanRunIds.set(candidateRunId, Date.now());
       }
-      this.pruneRunMap(this.retiredOrphanRunIds);
     }
   }
 
@@ -475,7 +468,6 @@ export class TuiSessionRunCoordinator {
     this.postFinalizingRuns.clear();
     this.historyReloadRuns.clear();
     this.confirmedStreamRunIds.clear();
-    this.retiredOrphanRunIds.clear();
     this.rejectUnconfirmedRuns = false;
     this.historyReloadQueued = false;
     this.pendingHistoryRefresh = false;


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Maintainer-requested cleanup of redundant TUI recovery bookkeeping. Retired-orphan status already follows the recovery rejection flag and authoritative session-run membership; a second timestamped map adds insertion, pruning, confirmation and reset work without contributing another reachable decision.

## Why This Change Was Made

Remove that private map and keep the existing `rejectUnconfirmedRuns && !sessionRuns.has(runId)` predicate. The coordinator remains the owner of run admission and recovery. Sequenced/local-run exemptions, confirmed membership, reconnect reconciliation, terminal settlement and reset ordering stay unchanged.

This is one production file: **+1/-9 lines, net -8**. Tests: **0 changed lines**. No API, configuration, protocol, storage, dependency or packaging change.

## User Impact

No intended user-visible change. This removes redundant internal state, not a reported streaming or reconnect bug. Existing terminal behavior and fake-backend calls are covered by the unchanged focused and PTY suites.

## Evidence

Signed source commit: `20a4e5451cde7221ad39b6a3d2599c2c6554da80`. Its tree is exactly the tested `2b80e67ac9b18d614a68ced9d76f36e320f7b257`, based on `e9a2a0298557451d28704b900bf3c4dfb0a4a99d`; signing changed no tested bytes.

- Whole-diff P3 autoreview: no actionable findings. Independent source and final proof reviews passed.
- Existing pinned Oxfmt 0.65.0 and `git diff --check`: passed.
- Three full focused files: **242 passed**, no failures or skips. Coordinator 23; event handlers 195; stream assembler 24.
- All eight fake-backend PTY files: **99 passed**, no failures, with the one existing Darwin-native-paste variant skipped on Linux. Coverage includes terminal input/output, session identity, reconnect and reset transitions, picker cancellation, auth-child cleanup, hyperlinks, task suggestions and error rendering.
- Normal changed-check aggregate: **all 28 selected gates passed**, including core/core-test types, targeted lint/format and production, full-tree and script Knip scans, each with zero unused-export entries.
- Remote environment: Node 24.19.0 on Linux x64, Vitest 5.0.0 with the tracked patch, pi-tui 0.84.4 and native node-pty 1.2.0-beta.15. Installed implementation and native binding were inspected before either test lane.
- Both test lanes used normal private-worker compilation: **8,575 inputs / 4,288 outputs** per generation. Completed-generation verification and joined cleanup passed. The single owned validation lease was stopped afterward.

Commands:

```sh
node scripts/run-vitest.mjs src/tui/tui-session-run-coordinator.test.ts src/tui/tui-event-handlers.test.ts src/tui/tui-stream-assembler.test.ts
node scripts/run-vitest.mjs run --config test/vitest/vitest.tui-pty.config.ts
node scripts/check-changed.mjs --base origin/main -- src/tui/tui-session-run-coordinator.ts
```

The remote comparison ref resolved to `10b82027b9eca63f6a5f87f19a4f3a64c917f9fa`; it is a validation transport/comparison base, not a claim about current main. Every payload verified the candidate source and tested tree.

No separate prepublication `pnpm build` was run: this private bookkeeping removal changes no import/export, lazy-loading, packaging or published boundary. Actual private-worker compilation, execution and the prescribed static gates passed. Attached exact-head CI subsequently passed the real build, artifact verification and Node/Bun smoke checks.

The fake-backend PTY lane runs the real TUI loop but does **not** prove Gateway transport, embedded backend runtime, real providers, session persistence or live streaming. Portal status synchronization emitted timeout warnings; the actual payloads completed successfully with complete results and normal resource closure.

Attached [CI run 34150230780, attempt 1](https://github.com/openclaw/openclaw/actions/runs/34150230780) completed successfully for this unchanged head: 107 successful jobs, 17 intentionally unselected skips and a successful aggregate gate. [ClawSweeper's exact-head review](https://github.com/openclaw/openclaw/pull/141425#issuecomment-5574320107) has no findings, security issues, before-merge tasks or remaining rank-up moves. Native review, preparation and squash merge completed for this unchanged head; the landed commit is `20d6526c7ade064a0ead4de9e00d7872e8d75705`.
