### PR TITLE
fix(ui): keep sidebar child rows visible during roster refreshes

### DIFF
--- a/docs/web/control-ui/sessions-and-sidebar.md
+++ b/docs/web/control-ui/sessions-and-sidebar.md
@@ -67,6 +67,8 @@ The sidebar organizes everything around the agent. The identity row at the top i
 
 Switching agents refreshes the session list even while other conversations are active. A confirmed permission change remains visible if its follow-up list refresh fails.
 
+Expanded child rows stay visible while session-list refreshes fetch updated child data in the background. A loading placeholder appears only when the parent has no loaded child rows yet. Child-load errors remain visible until you choose **Retry** or collapse and reopen the parent.
+
 Session previews are hidden by default for compact, single-line rows. Enable **Show message preview** in the **Sessions** filter menu to restore routine status text and message previews. The browser remembers your choice. Errors and requests for attention remain visible with previews off.
 
 Enable **Hide empty groups** in the same menu to hide custom groups with no sessions in the current sidebar view. It is off by default, and the browser remembers your choice. Collapsed groups with sessions stay visible. Hidden groups keep their membership and order and remain available in **Move to group**; turn the setting off to use their headers as drag targets again.

--- a/docs/web/control-ui/sessions-and-sidebar.md
+++ b/docs/web/control-ui/sessions-and-sidebar.md
@@ -67,7 +67,7 @@ The sidebar organizes everything around the agent. The identity row at the top i
 
 Switching agents refreshes the session list even while other conversations are active. A confirmed permission change remains visible if its follow-up list refresh fails.
 
-Expanded child rows stay visible while session-list refreshes fetch updated child data in the background. A loading placeholder appears only when the parent has no loaded child rows yet. Child-load errors remain visible until you choose **Retry** or collapse and reopen the parent.
+Loaded child rows stay visible while an expanded or selected parent fetches updated child data after a session-list refresh. Collapsed, unselected parents drop stale child snapshots on refresh and reload when reopened; the selected session's ancestry stays available. A loading placeholder appears only when the parent has no loaded child rows yet. Child-load errors remain visible until you choose **Retry** or collapse and reopen the parent.
 
 Session previews are hidden by default for compact, single-line rows. Enable **Show message preview** in the **Sessions** filter menu to restore routine status text and message previews. The browser remembers your choice. Errors and requests for attention remain visible with previews off.
 

--- a/ui/src/components/app-sidebar-child-session-data.ts
+++ b/ui/src/components/app-sidebar-child-session-data.ts
@@ -100,7 +100,7 @@ function mergeChildSessionRows(
 }
 
 /** Retain only the routed ancestry when a refreshed child list omits it (archived or filtered). */
-export function preserveActiveSessionLineageRows(
+function preserveActiveSessionLineageRows(
   sessionKey: string | null,
   rowsByParent: Readonly<Record<string, readonly GatewaySessionRow[]>>,
 ): Readonly<Record<string, readonly GatewaySessionRow[]>> {
@@ -119,6 +119,59 @@ export function preserveActiveSessionLineageRows(
     childKey = parent[0];
   }
   return preserved;
+}
+
+export function mergeRefreshedChildSessionRows(
+  sessionKey: string | null,
+  rowsByParent: Readonly<Record<string, readonly GatewaySessionRow[]>>,
+  parentKey: string,
+  rows: GatewaySessionRow[],
+): Readonly<Record<string, readonly GatewaySessionRow[]>> {
+  const lineage = preserveActiveSessionLineageRows(sessionKey, rowsByParent)[parentKey] ?? [];
+  return {
+    ...rowsByParent,
+    ...mergeChildSessionRows({ [parentKey]: rows }, { [parentKey]: lineage }),
+  };
+}
+
+export function retireStaleChildSessionRows(
+  owner: {
+    childSessionRowsByParent: Readonly<Record<string, readonly GatewaySessionRow[]>>;
+    loadedChildSessionKeys: ReadonlySet<string>;
+    loadingChildSessionKeys: ReadonlySet<string>;
+    childSessionErrorsByParent: ReadonlyMap<string, string>;
+    requestSessionDataUpdate(): void;
+  },
+  sessionKey: string | null,
+  revalidating: ReadonlySet<string>,
+): void {
+  const lineage = preserveActiveSessionLineageRows(sessionKey, owner.childSessionRowsByParent);
+  const next = { ...owner.childSessionRowsByParent };
+  let changed = false;
+  for (const [parentKey, rows] of Object.entries(next)) {
+    if (
+      owner.loadedChildSessionKeys.has(parentKey) ||
+      owner.loadingChildSessionKeys.has(parentKey) ||
+      owner.childSessionErrorsByParent.has(parentKey) ||
+      revalidating.has(parentKey)
+    ) {
+      continue;
+    }
+    const retained = lineage[parentKey];
+    if (retained?.length === rows.length) {
+      continue;
+    }
+    if (retained) {
+      next[parentKey] = retained;
+    } else {
+      delete next[parentKey];
+    }
+    changed = true;
+  }
+  if (changed) {
+    owner.childSessionRowsByParent = next;
+    owner.requestSessionDataUpdate();
+  }
 }
 
 export function publishActiveSessionLineage(

--- a/ui/src/components/app-sidebar-child-session-data.ts
+++ b/ui/src/components/app-sidebar-child-session-data.ts
@@ -99,7 +99,7 @@ function mergeChildSessionRows(
   return merged;
 }
 
-/** Retain only the routed ancestry while a canonical refresh invalidates other child snapshots. */
+/** Retain only the routed ancestry when a refreshed child list omits it (archived or filtered). */
 export function preserveActiveSessionLineageRows(
   sessionKey: string | null,
   rowsByParent: Readonly<Record<string, readonly GatewaySessionRow[]>>,

--- a/ui/src/components/app-sidebar-session-navigation.ts
+++ b/ui/src/components/app-sidebar-session-navigation.ts
@@ -223,6 +223,7 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
     if (isSessionRouteId(this.activeRouteId)) {
       void this.sessionData.loadActiveSessionLineage(activeRouteKey);
     }
+    const revalidating = new Set<string>();
     const pending = [...this.visibleSessionRowsInOrder()];
     while (pending.length > 0) {
       const session = pending.shift();
@@ -232,25 +233,19 @@ export class AppSidebarSessionNavigationElement extends AppSidebarBase {
       pending.push(...session.children);
       if (
         session.childSessionKeys.length > 0 &&
-        (session.visuallyActive || this.isSessionChildrenExpanded(session)) &&
-        !this.sessionData.loadedChildSessionKeys.has(session.key) &&
-        !this.sessionData.childSessionErrorsByParent.has(session.key) &&
-        !this.sessionData.loadingChildSessionKeys.has(session.key)
+        (session.visuallyActive || this.isSessionChildrenExpanded(session))
       ) {
+        revalidating.add(session.key);
         // Selected collapsed rows need child liveness so delegated work does not look finished.
         void this.sessionData.loadChildSessions(session.key);
       }
     }
     const mainRow = this.mainSessionRow();
-    if (
-      mainRow &&
-      (mainRow.childSessions?.length ?? 0) > 0 &&
-      !this.sessionData.loadedChildSessionKeys.has(mainRow.key) &&
-      !this.sessionData.childSessionErrorsByParent.has(mainRow.key) &&
-      !this.sessionData.loadingChildSessionKeys.has(mainRow.key)
-    ) {
+    if (mainRow && (mainRow.childSessions?.length ?? 0) > 0) {
+      revalidating.add(mainRow.key);
       void this.sessionData.loadChildSessions(mainRow.key);
     }
+    this.sessionData.retireStaleChildSessions(revalidating);
   }
 
   setSessionOwnerFilter = (ownerId: string | null, involvingMe = false) =>

--- a/ui/src/components/app-sidebar.child-snapshot-freshness.test.ts
+++ b/ui/src/components/app-sidebar.child-snapshot-freshness.test.ts
@@ -51,6 +51,32 @@ async function mountParent() {
 }
 
 describe("sidebar child snapshot freshness", () => {
+  it("clears a collapsed parent's cached child running indicator after a canonical refresh", async () => {
+    const { harness, sidebar, expand } = await mountParent();
+    harness.list.mockResolvedValueOnce(
+      result([{ ...child, status: "running", hasActiveRun: true }]),
+    );
+    expand();
+    await waitForFast(() =>
+      expect(sidebar.querySelectorAll(".sidebar-recent-session--child")).toHaveLength(1),
+    );
+    expand();
+    await sidebar.updateComplete;
+    const toggle = () => sidebar.querySelector<HTMLButtonElement>("[data-child-session-toggle]")!;
+    expect(toggle().getAttribute("aria-expanded")).toBe("false");
+    expect(toggle().classList.contains("sidebar-child-session-toggle--running")).toBe(true);
+
+    harness.publishList({
+      result: result([
+        { key: parentKey, kind: "direct", childSessions: [childKey], hasActiveSubagentRun: false },
+      ]),
+    });
+    await sidebar.updateComplete;
+    await sidebar.updateComplete;
+    expect(toggle().classList.contains("sidebar-child-session-toggle--running")).toBe(false);
+    expect(harness.list).toHaveBeenCalledTimes(1);
+  });
+
   it("keeps loaded children visible while a canonical refresh revalidates them", async () => {
     const { harness, sidebar, publishParent, expand } = await mountParent();
     const sibling = { ...child, key: "agent:worker:sibling", label: "Removed sibling" };

--- a/ui/src/components/app-sidebar.child-snapshot-freshness.test.ts
+++ b/ui/src/components/app-sidebar.child-snapshot-freshness.test.ts
@@ -1,0 +1,110 @@
+/* @vitest-environment jsdom */
+
+import { describe, expect, it } from "vitest";
+import type { GatewayBrowserClient } from "../api/gateway.ts";
+import type { SessionsListResult } from "../api/types.ts";
+import {
+  createGateway,
+  createSessionsHarness,
+  deferred,
+  mountSidebar,
+} from "../test-helpers/app-sidebar.ts";
+import "../test-helpers/app-sidebar-suite.ts";
+import { waitForFast } from "../test-helpers/wait-for.ts";
+import "./app-sidebar.ts";
+
+const parentKey = "agent:main:parent";
+const childKey = "agent:worker:child";
+const child = {
+  key: childKey,
+  spawnedBy: parentKey,
+  kind: "direct" as const,
+  label: "Original child",
+  updatedAt: 1,
+};
+
+function result(sessions: SessionsListResult["sessions"]): SessionsListResult {
+  return {
+    ts: 10,
+    path: "",
+    count: sessions.length,
+    defaults: { modelProvider: null, model: null, contextTokens: null },
+    sessions,
+  };
+}
+
+async function mountParent() {
+  const harness = createSessionsHarness("main", [parentKey]);
+  const { sidebar } = await mountSidebar(
+    createGateway({} as GatewayBrowserClient),
+    harness.sessions,
+  );
+  const publishParent = () =>
+    harness.publishList({
+      result: result([{ key: parentKey, kind: "direct", childSessions: [childKey] }]),
+    });
+  publishParent();
+  await sidebar.updateComplete;
+  const expand = () =>
+    sidebar.querySelector<HTMLButtonElement>("[data-child-session-toggle]")!.click();
+  return { harness, sidebar, publishParent, expand };
+}
+
+describe("sidebar child snapshot freshness", () => {
+  it("keeps loaded children visible while a canonical refresh revalidates them", async () => {
+    const { harness, sidebar, publishParent, expand } = await mountParent();
+    const sibling = { ...child, key: "agent:worker:sibling", label: "Removed sibling" };
+    harness.list.mockResolvedValueOnce(result([child, sibling]));
+    expand();
+    await waitForFast(() =>
+      expect(sidebar.querySelectorAll(".sidebar-recent-session--child")).toHaveLength(2),
+    );
+
+    const refresh = deferred<SessionsListResult>();
+    harness.list.mockReturnValue(refresh.promise);
+    publishParent();
+    await waitForFast(() => expect(harness.list).toHaveBeenCalledTimes(2));
+    await sidebar.updateComplete;
+    expect(sidebar.querySelectorAll(".sidebar-recent-session--child")).toHaveLength(2);
+    expect(sidebar.querySelector(".sidebar-session-tree__loading")).toBeNull();
+    expect(sidebar.querySelector(`[data-session-key="${childKey}"]`)?.textContent).toContain(
+      "Original child",
+    );
+
+    refresh.resolve(result([{ ...child, label: "Updated child", updatedAt: 20 }]));
+    await waitForFast(() =>
+      expect(sidebar.querySelector(`[data-session-key="${childKey}"]`)?.textContent).toContain(
+        "Updated child",
+      ),
+    );
+    expect(sidebar.querySelectorAll(`[data-session-key="${childKey}"]`)).toHaveLength(1);
+    // A child the server no longer lists (deleted or archived) leaves with the refresh.
+    expect(sidebar.querySelector(`[data-session-key="${sibling.key}"]`)).toBeNull();
+  });
+
+  it("ignores a child response from before a canonical refresh", async () => {
+    const { harness, sidebar, publishParent, expand } = await mountParent();
+    const stale = deferred<SessionsListResult>();
+    const current = deferred<SessionsListResult>();
+    harness.list.mockReturnValueOnce(stale.promise).mockReturnValueOnce(current.promise);
+    const oldLoad = sidebar.sessionData.loadChildSessions(parentKey);
+    expand();
+    await sidebar.updateComplete;
+
+    publishParent();
+    const newLoad = sidebar.sessionData.loadChildSessions(parentKey);
+    current.resolve(result([{ ...child, label: "Current child", updatedAt: 20 }]));
+    await newLoad;
+    await waitForFast(() => expect(sidebar.textContent).toContain("Current child"));
+
+    stale.resolve(result([{ ...child, label: "Retired child", updatedAt: 10 }]));
+    await oldLoad;
+    await sidebar.updateComplete;
+    expect(sidebar.querySelector(`[data-session-key="${childKey}"]`)?.textContent).toContain(
+      "Current child",
+    );
+    expect(sidebar.textContent).not.toContain("Retired child");
+    expect(sidebar.querySelector(".sidebar-session-tree__loading")).toBeNull();
+    expect(harness.list).toHaveBeenCalledTimes(2);
+  });
+});

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -24,8 +24,9 @@ import {
   evictArchivedSessionLineage,
   fetchChildSessionRows,
   fetchSessionLineage,
-  preserveActiveSessionLineageRows,
+  mergeRefreshedChildSessionRows,
   publishActiveSessionLineage,
+  retireStaleChildSessionRows,
 } from "./app-sidebar-child-session-data.ts";
 import { SessionCatalogLiveState } from "./app-sidebar-session-catalog-live.ts";
 import { bindAdoptedCatalogSession } from "./app-sidebar-session-catalogs.ts";
@@ -408,8 +409,8 @@ export class SessionDataController implements ReactiveController, SessionCatalog
           ? preserveRosterPresentationMetadata(canonical, previous)
           : (previous ?? null);
       }
-      // Keep child snapshots visible while expanded parents revalidate; the generation fences
-      // in-flight results. Operator-owned failures still block automatic refetches.
+      // Navigation retains snapshots for expanded or selected parents that revalidate and
+      // retires collapsed snapshots until reopened. Generation fencing and operator errors persist.
       this.resetChildSessionState(true);
       this.requestSessionDataUpdate();
     }
@@ -558,6 +559,10 @@ export class SessionDataController implements ReactiveController, SessionCatalog
     return refreshSidebarSessionList(this, this.sessionsAgentId, true);
   }
 
+  retireStaleChildSessions(revalidating: ReadonlySet<string>): void {
+    retireStaleChildSessionRows(this, this.activeSessionLineageRouteKey, revalidating);
+  }
+
   async loadChildSessions(parentKey: string): Promise<void> {
     if (
       !parentKey ||
@@ -583,17 +588,12 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       }
       // Server rows replace the snapshot, so removed children disappear; only the
       // routed lineage survives omission because the selected pane still needs it.
-      const lineage =
-        preserveActiveSessionLineageRows(
-          this.activeSessionLineageRouteKey,
-          this.childSessionRowsByParent,
-        )[parentKey] ?? [];
-      for (const existing of lineage) {
-        if (!rows.some((row) => row.key === existing.key)) {
-          rows.push(existing);
-        }
-      }
-      this.childSessionRowsByParent = { ...this.childSessionRowsByParent, [parentKey]: rows };
+      this.childSessionRowsByParent = mergeRefreshedChildSessionRows(
+        this.activeSessionLineageRouteKey,
+        this.childSessionRowsByParent,
+        parentKey,
+        rows,
+      );
       this.loadedChildSessionKeys = new Set([...this.loadedChildSessionKeys, parentKey]);
     } catch (error) {
       if (generation !== this.childSessionGeneration || sessions !== this.context?.sessions) {

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -376,15 +376,10 @@ export class SessionDataController implements ReactiveController, SessionCatalog
 
   private resetChildSessionState(preserveOperatorContext = false): void {
     this.childSessionGeneration += 1;
-    this.childSessionRowsByParent = preserveOperatorContext
-      ? preserveActiveSessionLineageRows(
-          this.activeSessionLineageRouteKey,
-          this.childSessionRowsByParent,
-        )
-      : {};
     this.loadedChildSessionKeys = new Set();
     this.loadingChildSessionKeys = new Set();
     if (!preserveOperatorContext) {
+      this.childSessionRowsByParent = {};
       this.childSessionErrorsByParent = new Map();
       this.activeSessionLineageRoot = null;
       this.activeSessionLineageSelectedRow = null;
@@ -413,8 +408,8 @@ export class SessionDataController implements ReactiveController, SessionCatalog
           ? preserveRosterPresentationMetadata(canonical, previous)
           : (previous ?? null);
       }
-      // Canonical root changes invalidate successful child snapshots, not operator-owned failures.
-      // Expanded parents refetch only when no failure blocks them.
+      // Keep child snapshots visible while expanded parents revalidate; the generation fences
+      // in-flight results. Operator-owned failures still block automatic refetches.
       this.resetChildSessionState(true);
       this.requestSessionDataUpdate();
     }
@@ -586,7 +581,14 @@ export class SessionDataController implements ReactiveController, SessionCatalog
       if (!rows || !isCurrent()) {
         return;
       }
-      for (const existing of this.childSessionRowsByParent[parentKey] ?? []) {
+      // Server rows replace the snapshot, so removed children disappear; only the
+      // routed lineage survives omission because the selected pane still needs it.
+      const lineage =
+        preserveActiveSessionLineageRows(
+          this.activeSessionLineageRouteKey,
+          this.childSessionRowsByParent,
+        )[parentKey] ?? [];
+      for (const existing of lineage) {
         if (!rows.some((row) => row.key === existing.key)) {
           rows.push(existing);
         }

--- a/ui/src/e2e/sidebar-session-stability.e2e.test.ts
+++ b/ui/src/e2e/sidebar-session-stability.e2e.test.ts
@@ -24,7 +24,7 @@ suite.define(() => {
     { colorScheme: "light", pointer: "coarse", textScale: 100, width: 390 },
     { colorScheme: "dark", pointer: "fine", textScale: 140, width: 1440 },
   ] as const)(
-    "keeps one $colorScheme child-row placeholder stable at $width px with a $pointer pointer and $textScale% text",
+    "keeps $colorScheme child rows stable through loading and refresh at $width px with a $pointer pointer and $textScale% text",
     async ({ colorScheme, pointer, textScale, width }) => {
       const baseTime = Date.parse("2026-09-04T12:00:00.000Z");
       const activeKey = "agent:main:loading-active";
@@ -140,6 +140,32 @@ suite.define(() => {
         expect(childGeometry.left).toBe(loadingGeometry.left);
         // Chromium can quantize empty and text line boxes 1/64 CSS px apart.
         expect(childGeometry.rowHeight).toBeCloseTo(loadingGeometry.rowHeight, 1);
+
+        const childMatch = { spawnedBy: parentKey };
+        const childRequests = (await gateway.getRequests("sessions.list", childMatch)).length;
+        await gateway.deferNext("sessions.list", childMatch);
+        await gateway.emitGatewayEvent("sessions.changed", {
+          key: activeKey,
+          sessionKey: activeKey,
+          reason: "run",
+          updatedAt: baseTime + 2,
+        });
+        await gateway.waitForRequest("sessions.list", {
+          after: childRequests,
+          match: childMatch,
+        });
+        expect(await page.locator(".sidebar-session-tree__loading").count()).toBe(0);
+        expect(await child.isVisible()).toBe(true);
+
+        await gateway.resolveDeferred(
+          "sessions.list",
+          sessionsListResponse([
+            { ...childRow, label: "Updated research", updatedAt: baseTime + 3 },
+          ]),
+        );
+        await expect.poll(() => child.textContent()).toContain("Updated research");
+        expect(await page.locator(".sidebar-session-tree__loading").count()).toBe(0);
+        expect(await child.count()).toBe(1);
       } finally {
         await context.close();
       }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where expanded parent sessions in the Control UI sidebar showed a grey loading skeleton instead of their child session rows, for several parents at once and for long stretches while any session was active. The row shifts that came with it also left Chromium's hover state stuck on rows and on the collapse chevron, which then looked permanently highlighted.

## Why This Change Was Made

Every canonical session-list refresh discarded all successfully loaded child snapshots except the routed lineage and cleared the loaded flags, so expanded parents refetched their children and re-rendered the skeleton once per refresh. During activity the roster refreshes about once a second, so the skeleton was effectively permanent. Child snapshots now stay visible while expanded or selected parents revalidate them: the generation counter still fences in-flight results, expanded parents still refetch, and the loading skeleton only appears when a parent has no snapshot yet. Because snapshots persist, the merge that applies a refreshed child list is now lineage-scoped: server rows replace the snapshot, and only the routed lineage survives when the server omits it, which is the same set the old reset used to preserve. Navigation identifies the parents that revalidate, including the hidden main row; the controller retires other stale snapshots while preserving routed ancestry and operator-owned child-load errors.

## User Impact

Expanded child sessions stay visible and update in place during background refreshes. Collapsed, unselected parents drop stale snapshots on refresh and reload when reopened, so finished children no longer leave their disclosure marked running. The loading placeholder appears when no snapshot is available. Removed or archived children disappear with the next refresh as before. Hover and chevron highlights no longer stick because rows stop jumping.

## Evidence

- New `ui/src/components/app-sidebar.child-snapshot-freshness.test.ts`: children remain rendered with no skeleton during a deferred refresh, an updated row replaces the stale label without duplication, an omitted sibling is removed, and a response from before the refresh is discarded. The loaded-children case failed on the previous code (0 children instead of 2 during revalidation).
- `node scripts/run-vitest.mjs` over the new file plus `app-sidebar.test.ts`, `app-sidebar.lineage-freshness.test.ts`, `app-sidebar-session-navigation-logic.test.ts`, `session-data-controller.event-refresh.test.ts`: 5 files, 400 tests passed, including the existing child-load error retention cases.
- Playwright `ui/src/e2e/sidebar-session-stability.e2e.test.ts` (extended with a roster-refresh scenario across all seven variants) and `child-session-load-errors.e2e.test.ts`: 9 tests passed; the refresh scenario failed on the previous code with one skeleton instead of zero.
- `pnpm check:changed`: passed.
- Independent pre-publication review of the collapsed-parent fix: clean at P2 after checking routed-lineage ownership and retirement idempotence.
- Added a collapsed-parent regression: a cached running child no longer keeps its collapsed parent marked running after a canonical refresh, with no background child-list request. It failed before the fix and passes after; updated totals are 400 focused tests and 9 browser E2E tests.

## Known Gaps

CSS, hover-marquee, and chevron reveal rules are unchanged; legitimate roster changes can still move rows under a stationary cursor.
