### PR TITLE
fix(sessions): keep edits responsive during cleanup validation

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -469,6 +469,12 @@ the durable write succeeds. A future network-backed owner must preserve that
 ordering while awaiting its driver.
 
 Session reclamation keeps its deletion transaction on a worker connection.
+The worker opens its database under the session writer, then releases that writer
+while full integrity and foreign-key checks run on the same connection. Unrelated
+session writes can continue during those checks. It reacquires the writer and
+revalidates current authority before index repair, schema work, or deletion.
+The connection and lease remain owned throughout admission; refusal unwinds that
+owner, and final writer admission remains held until the worker exits.
 Archive publication and cascading deletion remain atomic. Before COMMIT, the
 worker publishes its authorization request in shared memory and waits for the
 parent's current owner check. Synchronous writers service that request at the shared

--- a/src/config/sessions/session-accessor.sqlite-archive.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.ts
@@ -7,6 +7,7 @@ import { syncDirectoryBestEffortSync } from "../../infra/directory-durability.js
 import { runtimeProcessEntrypoints } from "../../infra/runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerUrl } from "../../infra/runtime-worker-url.js";
 import { KeyedAsyncQueue } from "../../plugin-sdk/keyed-async-queue.js";
+import { createDeferredCore, type Deferred } from "../../shared/deferred.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import {
   encodeSessionArchiveContent,
@@ -297,6 +298,9 @@ function spawnSqliteTranscriptArchiveWorkerOperation<Result>(params: {
   diagnostics?: { workerThreadId?: number };
   expectedMessageType: "done" | "published" | "reclaimed";
   onCommitRequest?: () => void;
+  withWriteAdmission?: (
+    run: (refusal?: { error: unknown }) => Promise<Result[] | undefined>,
+  ) => Promise<void>;
   transferList?: ArrayBuffer[];
   workerData: object;
 }): Promise<Result[]> {
@@ -322,13 +326,84 @@ function spawnSqliteTranscriptArchiveWorkerOperation<Result>(params: {
   return new Promise((resolve, reject) => {
     let results: Result[] | undefined;
     let workerError: Error | undefined;
-    worker.on("message", (message: { results: Result[]; type: string }) => {
+    let admission: { id: number; released: Deferred } | undefined;
+    let admissionId = 0;
+    let exited = false;
+    let exitCode: number | undefined;
+    const admissionTasks: Promise<void>[] = [];
+    worker.on("message", (message: { results: Result[]; type: string; admissionId?: number }) => {
       if (message.type === "commit-request") {
         try {
           params.onCommitRequest?.();
         } catch (error) {
           workerError = toStringifiedError(error);
         }
+      } else if (message.type === "admission-request") {
+        const withWriteAdmission = params.withWriteAdmission;
+        if (!withWriteAdmission || admission || message.admissionId !== admissionId + 1) {
+          workerError ??= new Error(
+            "SQLite reclamation Worker requested invalid write admission; cleanup is uncertain, restart OpenClaw before deleting the owning agent",
+          );
+          void worker.terminate();
+          return;
+        }
+        const requested = { id: ++admissionId, released: createDeferredCore() };
+        admission = requested;
+        const task = withWriteAdmission(async (refusal) => {
+          if (exited) {
+            return undefined;
+          }
+          if (refusal) {
+            workerError ??= toStringifiedError(refusal.error);
+          }
+          worker.postMessage(
+            {
+              type: "admission",
+              admissionId: requested.id,
+              allowed: refusal === undefined && workerError === undefined,
+            },
+            [],
+          );
+          // Denial still owns this FIFO section while the Worker unwinds its
+          // partially opened handle. Final admission is released only on exit.
+          await requested.released.promise;
+          if (exited && exitCode === 0 && !workerError) {
+            return results;
+          }
+          return undefined;
+        }).catch(async (error: unknown) => {
+          workerError ??= toStringifiedError(error);
+          if (!exited && admission === requested) {
+            try {
+              // An unavailable scheduler cannot authorize repair. Let the
+              // suspended owner unwind its handle and lease before exit.
+              worker.postMessage(
+                { type: "admission", admissionId: requested.id, allowed: false },
+                [],
+              );
+            } catch (dispatchError) {
+              workerError = new AggregateError(
+                [workerError, dispatchError],
+                "SQLite reclamation admission failed and Worker cleanup is uncertain; restart OpenClaw before deleting the owning agent",
+                { cause: workerError },
+              );
+              await worker.terminate();
+            }
+          }
+          await requested.released.promise;
+        });
+        admissionTasks.push(task);
+      } else if (message.type === "admission-release") {
+        if (!admission || message.admissionId !== admission.id) {
+          workerError ??= new Error(
+            "SQLite reclamation Worker released invalid write admission; cleanup is uncertain, restart OpenClaw before deleting the owning agent",
+          );
+          void worker.terminate();
+          return;
+        }
+        const released = admission;
+        admission = undefined;
+        released.released.resolve();
       } else if (message.type === params.expectedMessageType) {
         (results ??= []).push(...message.results);
       }
@@ -339,20 +414,21 @@ function spawnSqliteTranscriptArchiveWorkerOperation<Result>(params: {
       workerError ??= toStringifiedError(error);
     });
     worker.once("exit", (code) => {
+      exited = true;
+      exitCode = code;
+      admission?.released.resolve();
       worker.removeAllListeners();
-      if (workerError) {
-        reject(workerError);
-        return;
-      }
-      if (code !== 0) {
-        reject(new Error(`SQLite transcript archive worker exited with code ${code}`));
-        return;
-      }
-      if (!results) {
-        reject(new Error("SQLite transcript archive worker exited without results"));
-        return;
-      }
-      resolve(results);
+      void Promise.all(admissionTasks).then(() => {
+        if (workerError) {
+          reject(workerError);
+        } else if (code !== 0) {
+          reject(new Error(`SQLite transcript archive worker exited with code ${code}`));
+        } else if (!results) {
+          reject(new Error("SQLite transcript archive worker exited without results"));
+        } else {
+          resolve(results);
+        }
+      }, reject);
     });
   });
 }
@@ -366,6 +442,9 @@ export function runSqliteTranscriptArchiveWorkerOperation<Result>(params: {
   diagnostics?: { workerThreadId?: number };
   expectedMessageType: "done" | "published" | "reclaimed";
   onCommitRequest?: () => void;
+  withWriteAdmission?: (
+    run: (refusal?: { error: unknown }) => Promise<Result[] | undefined>,
+  ) => Promise<void>;
   transferList?: ArrayBuffer[];
   workerData: object;
 }): Promise<Result[]> {

--- a/src/config/sessions/session-accessor.sqlite-archive.worker.ts
+++ b/src/config/sessions/session-accessor.sqlite-archive.worker.ts
@@ -16,7 +16,9 @@ import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db
 import type { DB as OpenClawAgentKyselyDatabase } from "../../state/openclaw-agent-db.generated.js";
 import {
   settleOpenClawAgentDatabaseWorkerClose,
+  withOpenClawAgentDatabaseAdmission,
   type OpenClawAgentDatabaseWorkerCloseResult,
+  type OpenClawAgentDatabaseWriteAdmission,
 } from "../../state/openclaw-agent-db.js";
 import {
   hashSessionArchiveBytes,
@@ -425,27 +427,69 @@ async function runReclamationWorkerPort(
 ): Promise<void> {
   let result: ReturnType<typeof reclaimSqliteSessionInTransaction>;
   const commitGate = data.commitGate;
-  try {
-    let transactionDatabase: DatabaseSync | undefined;
-    try {
-      result = reclaimSqliteSessionInTransaction(data.plan, {
-        onCommit: commitGate
-          ? (database) => {
-              transactionDatabase = database.db;
-              waitForSqliteReclamationCommit(commitGate, () =>
-                port.postMessage({ type: "commit-request" }),
-              );
-            }
-          : undefined,
-      });
-    } finally {
-      if (
-        transactionDatabase &&
-        (!transactionDatabase.isOpen || !transactionDatabase.isTransaction)
-      ) {
-        markSqliteReclamationSettled(commitGate);
+  let admissionId = 0;
+  let finalAdmission = false;
+  const withAdmission: OpenClawAgentDatabaseWriteAdmission = async (run) => {
+    const requestedId = ++admissionId;
+    const allowed = await new Promise<boolean>((resolve, reject) => {
+      const receive = (message: { type: string; admissionId: number; allowed: boolean }) => {
+        cleanup();
+        if (message.type !== "admission" || message.admissionId !== requestedId) {
+          reject(new Error("SQLite reclamation Worker received invalid write admission"));
+          return;
+        }
+        resolve(message.allowed);
+      };
+      const closed = () => {
+        cleanup();
+        reject(new Error("SQLite reclamation parent closed during database admission"));
+      };
+      const cleanup = () => {
+        port.off("message", receive);
+        port.off("close", closed);
+      };
+      port.on("message", receive);
+      port.once("close", closed);
+      port.postMessage({ type: "admission-request", admissionId: requestedId });
+    });
+    const value = await run(() => {
+      if (!allowed) {
+        throw new Error("SQLite reclamation database admission was revoked");
       }
+    });
+    if (!finalAdmission) {
+      port.postMessage({ type: "admission-release", admissionId: requestedId });
     }
+    return value;
+  };
+  try {
+    result = await withOpenClawAgentDatabaseAdmission(
+      data.plan.databaseOptions,
+      withAdmission,
+      () => {
+        finalAdmission = true;
+        let transactionDatabase: DatabaseSync | undefined;
+        try {
+          return reclaimSqliteSessionInTransaction(data.plan, {
+            onCommit: commitGate
+              ? (database) => {
+                  transactionDatabase = database.db;
+                  waitForSqliteReclamationCommit(commitGate, () =>
+                    port.postMessage({ type: "commit-request" }),
+                  );
+                }
+              : undefined,
+          });
+        } finally {
+          if (
+            transactionDatabase &&
+            (!transactionDatabase.isOpen || !transactionDatabase.isTransaction)
+          ) {
+            markSqliteReclamationSettled(commitGate);
+          }
+        }
+      },
+    );
   } catch (error) {
     const cleanup = await settleReclamationDatabase(data.plan.databaseOptions.path);
     if (cleanup.settled) {

--- a/src/config/sessions/session-accessor.sqlite-lifecycle.ts
+++ b/src/config/sessions/session-accessor.sqlite-lifecycle.ts
@@ -153,31 +153,22 @@ export async function cleanupSessionLifecycleArtifactsCore(
       await runExclusiveSqliteSessionReclamation(async () => {
         const materializedPlans = await materializeSessionStateDeletePlans(cleanupPlan.deletePlans);
         const diagnostics: SqliteSessionReclamationDiagnostics = {};
-        return await runExclusiveSqliteSessionWrite(
-          resolved,
-          async () => {
-            assertCurrent();
-            const plan = createLifecycleArtifactReclamationPlan({
-              agentId: resolved.agentId,
-              databaseOptions,
-              entries: cleanupPlan.entries,
-              materializedPlans,
-            });
-            const reclaimed = await runSqliteSessionReclamation({
-              diagnostics,
-              assertCommitAllowed: assertCurrent,
-              forceInProcess: hasPreparedNativeSessionDeletion(),
-              plan,
-            });
-            if (reclaimed.kind !== plan.kind) {
-              throw new Error(
-                `SQLite session reclamation returned ${reclaimed.kind} for ${plan.kind}`,
-              );
-            }
-            return reclaimed.value;
-          },
+        const plan = createLifecycleArtifactReclamationPlan({
+          agentId: resolved.agentId,
+          databaseOptions,
+          entries: cleanupPlan.entries,
+          materializedPlans,
+        });
+        const reclaimed = await runSqliteSessionReclamation({
           diagnostics,
-        );
+          assertCommitAllowed: assertCurrent,
+          forceInProcess: hasPreparedNativeSessionDeletion(),
+          plan,
+        });
+        if (reclaimed.kind !== plan.kind) {
+          throw new Error(`SQLite session reclamation returned ${reclaimed.kind} for ${plan.kind}`);
+        }
+        return reclaimed.value;
       }),
     { additionalIdentities: cleanupPlan.deletePlans.map((plan) => plan.sessionId) },
   );
@@ -448,7 +439,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
         const archivedGeneration = await runExclusiveSqliteSessionReclamation(async () => {
           const materializedGeneration = await materializeSessionStateDeletePlans([plan]);
           const diagnostics: SqliteSessionReclamationDiagnostics = {};
-          return await runExclusiveSqliteSessionWrite(
+          const reclamationPlan = await runExclusiveSqliteSessionWrite(
             resolved,
             async () => {
               params.commitGuard?.();
@@ -470,7 +461,7 @@ async function deleteSqliteSessionEntryLifecycleLocked(
                   `cannot delete session history while work is in flight for ${sessionId}; retry after the run completes`,
                 );
               }
-              const reclamationPlan = createHistoricalGenerationReclamationPlan({
+              return createHistoricalGenerationReclamationPlan({
                 databaseOptions: toDatabaseOptions(resolved),
                 deleteParams: params,
                 materializedPlans: materializedGeneration,
@@ -478,25 +469,28 @@ async function deleteSqliteSessionEntryLifecycleLocked(
                 protectedSessionIds,
                 sessionId,
               });
-              const reclaimed = await runSqliteSessionReclamation({
-                diagnostics,
-                assertCommitAllowed: () => {
-                  params.commitGuard?.();
-                  assertCurrent();
-                },
-                forceInProcess: hasPreparedNativeSessionDeletion(),
-                onInProcessCommit: recordCommit,
-                plan: reclamationPlan,
-              });
-              if (reclaimed.kind !== reclamationPlan.kind) {
-                throw new Error(
-                  `SQLite session reclamation returned ${reclaimed.kind} for ${reclamationPlan.kind}`,
-                );
-              }
-              return reclaimed.value;
             },
             diagnostics,
           );
+          if (reclamationPlan === DELETE_EXPECTED_ENTRY_MISMATCH) {
+            return DELETE_EXPECTED_ENTRY_MISMATCH;
+          }
+          const reclaimed = await runSqliteSessionReclamation({
+            diagnostics,
+            assertCommitAllowed: () => {
+              params.commitGuard?.();
+              assertCurrent();
+            },
+            forceInProcess: hasPreparedNativeSessionDeletion(),
+            onInProcessCommit: recordCommit,
+            plan: reclamationPlan,
+          });
+          if (reclaimed.kind !== reclamationPlan.kind) {
+            throw new Error(
+              `SQLite session reclamation returned ${reclaimed.kind} for ${reclamationPlan.kind}`,
+            );
+          }
+          return reclaimed.value;
         });
         if (archivedGeneration === DELETE_EXPECTED_ENTRY_MISMATCH) {
           return expectedEntryMismatchResult(historicalArchivedTranscripts);
@@ -523,36 +517,28 @@ async function deleteSqliteSessionEntryLifecycleLocked(
       const result = await runExclusiveSqliteSessionReclamation(async () => {
         const materializedPlans = await materializeSessionStateDeletePlans(prepared.entryPlans);
         const diagnostics: SqliteSessionReclamationDiagnostics = {};
-        return await runExclusiveSqliteSessionWrite(
-          resolved,
-          async () => {
+        const reclamationPlan = createSessionEntryReclamationPlan({
+          databaseOptions: toDatabaseOptions(resolved),
+          deleteParams: params,
+          materializedPlans,
+          preparedTargetSnapshot: prepared.targetSnapshot,
+        });
+        const reclaimed = await runSqliteSessionReclamation({
+          diagnostics,
+          assertCommitAllowed: () => {
             params.commitGuard?.();
             assertCurrent();
-            const reclamationPlan = createSessionEntryReclamationPlan({
-              databaseOptions: toDatabaseOptions(resolved),
-              deleteParams: params,
-              materializedPlans,
-              preparedTargetSnapshot: prepared.targetSnapshot,
-            });
-            const reclaimed = await runSqliteSessionReclamation({
-              diagnostics,
-              assertCommitAllowed: () => {
-                params.commitGuard?.();
-                assertCurrent();
-              },
-              forceInProcess: hasPreparedNativeSessionDeletion(),
-              onInProcessCommit: recordCommit,
-              plan: reclamationPlan,
-            });
-            if (reclaimed.kind !== reclamationPlan.kind) {
-              throw new Error(
-                `SQLite session reclamation returned ${reclaimed.kind} for ${reclamationPlan.kind}`,
-              );
-            }
-            return reclaimed.value;
           },
-          diagnostics,
-        );
+          forceInProcess: hasPreparedNativeSessionDeletion(),
+          onInProcessCommit: recordCommit,
+          plan: reclamationPlan,
+        });
+        if (reclaimed.kind !== reclamationPlan.kind) {
+          throw new Error(
+            `SQLite session reclamation returned ${reclaimed.kind} for ${reclamationPlan.kind}`,
+          );
+        }
+        return reclaimed.value;
       });
       if (result.deleted) {
         markCommitted();

--- a/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
@@ -11,15 +11,25 @@ import { SqliteBoardStore } from "../../boards/sqlite-board-store.js";
 import { configureSqliteWalMaintenance } from "../../infra/sqlite-wal.js";
 import { flushLogger, setLoggerOverride } from "../../logging/logger.js";
 import { onSessionIdentityMutation } from "../../sessions/session-lifecycle-events.js";
+import { withOpenClawAgentDatabaseReadOnly } from "../../state/openclaw-agent-db-readonly.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   closeOpenClawAgentDatabasesForTest,
+  getOpenClawAgentDatabaseIfOpen,
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../state/openclaw-state-db.js";
 import { loadTranscriptEvents } from "./session-accessor.js";
 import { runSqliteTranscriptArchiveWorkerOperation } from "./session-accessor.sqlite-archive.js";
 import type { SqliteSessionReclamationDiagnostics } from "./session-accessor.sqlite-contract.js";
-import { loadSessionEntry, replaceSessionEntrySync } from "./session-accessor.sqlite-entry.js";
+import {
+  loadSessionEntry,
+  loadSessionEntryReadOnly,
+  replaceSessionEntrySync,
+} from "./session-accessor.sqlite-entry.js";
 import { ensureSessionEntrySync } from "./session-accessor.sqlite-initial-entry.js";
 import {
   createHistoryEvictionReclamationPlan,
@@ -285,6 +295,111 @@ test("captures removal identity when a synchronous writer authorizes reclamation
     unsubscribe();
   }
 });
+
+test.each([false, true])(
+  "in-process reclamation checks authority before cold database admission (revoked: %s)",
+  async (revoked) => {
+    const { database, databaseOptions, scopes } = createFixture();
+    const removed = scopes[0]!;
+    const survivor = scopes[1]!;
+    expect(appendTranscriptEventSync(removed, { type: "session", id: removed.sessionId })).toEqual({
+      ok: true,
+      value: true,
+    });
+    const current = { ...removed, sessionId: "parent-current" };
+    replaceSessionEntrySync(current, { sessionId: current.sessionId, updatedAt: 2 });
+    expect(appendTranscriptEventSync(current, { type: "session", id: current.sessionId })).toEqual({
+      ok: true,
+      value: true,
+    });
+    const expectedEntry = loadSessionEntry(current);
+    if (!expectedEntry) {
+      throw new Error("expected the native removal fixture entry");
+    }
+    const plan = createLifecycleArtifactReclamationPlan({
+      agentId: databaseOptions.agentId,
+      databaseOptions,
+      entries: [{ sessionKey: removed.sessionKey, expectedEntry }],
+      materializedPlans: [],
+    });
+    const stateDatabase = openOpenClawStateDatabase({ env: databaseOptions.env });
+    const inspect = () => {
+      const opened = withOpenClawAgentDatabaseReadOnly(
+        ({ db }) => ({
+          entries: db
+            .prepare("SELECT session_key, entry_json FROM session_nodes ORDER BY session_key")
+            .all(),
+          windows: db
+            .prepare(
+              "SELECT session_id, session_key, previous_session_id FROM session_windows ORDER BY session_id",
+            )
+            .all(),
+          events: db
+            .prepare(
+              "SELECT session_id, seq, event_json FROM transcript_events ORDER BY session_id, seq",
+            )
+            .all(),
+          repairIndex: db
+            .prepare("SELECT name FROM sqlite_schema WHERE type = 'index' AND name = ?")
+            .get("idx_agent_cache_expiry"),
+        }),
+        databaseOptions,
+      );
+      if (!opened.found) {
+        throw new Error("expected the existing native reclamation database");
+      }
+      return {
+        ...opened.value,
+        writerOpen: getOpenClawAgentDatabaseIfOpen(databaseOptions)?.db.isOpen ?? false,
+        leases: stateDatabase.db
+          .prepare("SELECT lease_id FROM agent_database_leases WHERE path = ? ORDER BY lease_id")
+          .all(database.path),
+      };
+    };
+    // The prepared operation loses its warm handle before it can enter the FIFO.
+    database.db.exec("DROP INDEX idx_agent_cache_expiry");
+    expect(closeOpenClawAgentDatabaseByPath(database.path)).toBe(true);
+    const before = inspect();
+    expect(before).toMatchObject({ writerOpen: false, leases: [], repairIndex: undefined });
+    const survivorEntry = loadSessionEntryReadOnly(survivor);
+    try {
+      const operation = runSqliteSessionReclamation({
+        forceInProcess: true,
+        plan,
+        assertCommitAllowed: () => {
+          if (revoked) {
+            throw new Error("native reclamation authority revoked");
+          }
+        },
+      });
+      if (revoked) {
+        await expect(operation).rejects.toThrow("native reclamation authority revoked");
+        // Read-only observation must not itself reopen or repair the rejected target.
+        expect(inspect()).toEqual(before);
+        expect(loadSessionEntryReadOnly(current)).toEqual(expectedEntry);
+      } else {
+        await expect(operation).resolves.toMatchObject({
+          kind: "lifecycle-artifacts",
+          value: { removedEntries: 1 },
+        });
+        const after = inspect();
+        expect(after).toMatchObject({
+          writerOpen: true,
+          repairIndex: { name: "idx_agent_cache_expiry" },
+          events: before.events,
+          windows: before.windows,
+        });
+        expect(after.leases).toHaveLength(1);
+        expect(loadSessionEntryReadOnly(current)).toBeUndefined();
+      }
+      expect(database.db.isOpen).toBe(false);
+      expect(loadSessionEntryReadOnly(survivor)).toEqual(survivorEntry);
+    } finally {
+      closeOpenClawAgentDatabaseByPath(database.path);
+      closeOpenClawStateDatabaseForTest();
+    }
+  },
+);
 
 test.runIf(process.platform !== "win32")(
   "keeps the opened database and its canonical writer queue after an alias retarget",

--- a/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.test.ts
@@ -33,25 +33,40 @@ import {
 } from "./session-accessor.sqlite-transcript-write.js";
 import { reclaimSqliteFreePages } from "./session-history-archive-pruning.js";
 
-const hooks = vi.hoisted(() => ({ beforeAuthorization: undefined as (() => void) | undefined }));
+const hooks = vi.hoisted(() => ({
+  beforeAuthorization: undefined as (() => void) | undefined,
+  afterWriteAdmission: undefined as (() => Promise<void>) | undefined,
+}));
 vi.mock("./session-accessor.sqlite-archive.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./session-accessor.sqlite-archive.js")>();
   return {
     ...actual,
     runSqliteTranscriptArchiveWorkerOperation: (
       params: Parameters<typeof actual.runSqliteTranscriptArchiveWorkerOperation>[0],
-    ) =>
-      actual.runSqliteTranscriptArchiveWorkerOperation({
+    ) => {
+      const withWriteAdmission = params.withWriteAdmission;
+      return actual.runSqliteTranscriptArchiveWorkerOperation({
         ...params,
+        ...(withWriteAdmission
+          ? {
+              withWriteAdmission: (run: Parameters<typeof withWriteAdmission>[0]) =>
+                withWriteAdmission(async (refusal) => {
+                  await hooks.afterWriteAdmission?.();
+                  return await run(refusal);
+                }),
+            }
+          : {}),
         onCommitRequest: () => {
           hooks.beforeAuthorization?.();
           params.onCommitRequest?.();
         },
-      }),
+      });
+    },
   };
 });
 afterEach(() => {
   hooks.beforeAuthorization = undefined;
+  hooks.afterWriteAdmission = undefined;
 });
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -127,11 +142,13 @@ test.each(
     const appends: unknown[] = [];
     const appendErrors: unknown[] = [];
     let commitChecks = 0;
-    let retired = false;
+    let commitRequested = false;
+    let checksDuringWriters = 0;
     const owner = new AsyncLocalStorage<string>();
     hooks.beforeAuthorization = () =>
       owner.run("transcript-writer", () => {
-        retired = rejected;
+        commitRequested = true;
+        const checksBeforeWriters = commitChecks;
         // The worker owns BEGIN IMMEDIATE and is waiting for the parent. Both sync
         // runtimes must service that request before its queued handler can return.
         for (const scope of scopes) {
@@ -162,25 +179,21 @@ test.each(
             appendErrors.push(error);
           }
         }
+        checksDuringWriters = commitChecks - checksBeforeWriters;
       });
     const reclamation = owner.run("reclamation-owner", () =>
-      runExclusiveSqliteSessionWrite(
-        databaseOptions,
-        () =>
-          runSqliteSessionReclamation({
-            diagnostics,
-            forceInProcess: false,
-            plan,
-            assertCommitAllowed: () => {
-              commitChecks += 1;
-              expect(owner.getStore()).toBe("reclamation-owner");
-              if (retired) {
-                throw new Error("reclamation owner retired");
-              }
-            },
-          }),
+      runSqliteSessionReclamation({
         diagnostics,
-      ),
+        forceInProcess: false,
+        plan,
+        assertCommitAllowed: () => {
+          commitChecks += 1;
+          expect(owner.getStore()).toBe("reclamation-owner");
+          if (rejected && commitRequested) {
+            throw new Error("reclamation owner retired");
+          }
+        },
+      }),
     );
     try {
       if (rejected) {
@@ -198,7 +211,7 @@ test.each(
     expect(workers[0]?.id).toBeGreaterThan(0);
     expect(diagnostics).toEqual({ kind: "history-eviction", workerThreadId: workers[0]?.id });
     expect(workers[0]?.worker.threadId).toBe(-1);
-    expect(commitChecks).toBe(2);
+    expect(checksDuringWriters).toBeGreaterThan(0);
     expect(appendErrors).toEqual([]);
     expect(appends).toEqual(
       operation === "entry"
@@ -262,9 +275,7 @@ test("captures removal identity when a synchronous writer authorizes reclamation
   };
   try {
     await expect(
-      runExclusiveSqliteSessionWrite(databaseOptions, () =>
-        runSqliteSessionReclamation({ forceInProcess: false, plan }),
-      ),
+      runSqliteSessionReclamation({ forceInProcess: false, plan }),
     ).resolves.toMatchObject({ kind: "lifecycle-artifacts", value: { removedEntries: 1 } });
     expect(removedSessionIds).toEqual([removed.sessionId]);
     await expect(loadTranscriptEvents(writer)).resolves.toEqual([
@@ -274,6 +285,63 @@ test("captures removal identity when a synchronous writer authorizes reclamation
     unsubscribe();
   }
 });
+
+test.runIf(process.platform !== "win32")(
+  "keeps the opened database and its canonical writer queue after an alias retarget",
+  async () => {
+    const { databaseOptions, scopes } = createFixture(true);
+    const removed = scopes[0]!;
+    const aliasPath = removed.storePath;
+    const expectedEntry = loadSessionEntry(removed);
+    if (!aliasPath || !expectedEntry) {
+      throw new Error("expected the aliased removal fixture entry");
+    }
+    const replacementPath = path.join(path.dirname(databaseOptions.path), "replacement.sqlite");
+    const replacementScope = { ...removed, storePath: replacementPath };
+    replaceSessionEntrySync(replacementScope, expectedEntry);
+    const plan = createLifecycleArtifactReclamationPlan({
+      agentId: databaseOptions.agentId,
+      databaseOptions: { ...databaseOptions, path: aliasPath },
+      entries: [{ sessionKey: removed.sessionKey, expectedEntry }],
+      materializedPlans: [],
+    });
+    let canonicalWrite: Promise<void> | undefined;
+    let canonicalWriteRan = false;
+    hooks.afterWriteAdmission = async () => {
+      hooks.afterWriteAdmission = undefined;
+      // The claim and Worker plan already belong to the original open database.
+      await fs.unlink(aliasPath);
+      symlinkSync(replacementPath, aliasPath);
+      canonicalWrite = runExclusiveSqliteSessionWrite(databaseOptions, async () => {
+        canonicalWriteRan = true;
+      });
+      await yieldToEventLoop();
+      expect(canonicalWriteRan).toBe(false);
+    };
+    const reclamation = runSqliteSessionReclamation({ forceInProcess: false, plan });
+    try {
+      await expect(reclamation).resolves.toMatchObject({
+        kind: "lifecycle-artifacts",
+        value: { removedEntries: 1 },
+      });
+      expect(canonicalWrite).toBeDefined();
+      await canonicalWrite;
+      expect(canonicalWriteRan).toBe(true);
+      expect(
+        loadSessionEntry({
+          ...removed,
+          storePath: databaseOptions.path,
+          readConsistency: "latest",
+        }),
+      ).toBeUndefined();
+      expect(loadSessionEntry({ ...replacementScope, readConsistency: "latest" })).toEqual(
+        expectedEntry,
+      );
+    } finally {
+      await Promise.allSettled([reclamation, ...(canonicalWrite ? [canonicalWrite] : [])]);
+    }
+  },
+);
 
 test.each([false, true])(
   "periodic vacuum services reclamation approval (rejected: %s)",
@@ -295,8 +363,8 @@ test.each([false, true])(
     });
     const maintenanceErrors: unknown[] = [];
     let commitChecks = 0;
+    let commitRequested = false;
     let checksDuringMaintenance = 0;
-    let retired = false;
     vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
     const maintenance = configureSqliteWalMaintenance(database.db, {
       busyTimeoutMs: 1_000,
@@ -305,9 +373,10 @@ test.each([false, true])(
     });
     hooks.beforeAuthorization = () => {
       // The worker holds the writer lock and cannot commit until this thread approves it.
-      retired = rejected;
+      commitRequested = true;
+      const checksBeforeMaintenance = commitChecks;
       vi.advanceTimersByTime(1);
-      checksDuringMaintenance = commitChecks;
+      checksDuringMaintenance = commitChecks - checksBeforeMaintenance;
     };
     try {
       const reclamation = runSqliteSessionReclamation({
@@ -315,7 +384,7 @@ test.each([false, true])(
         plan,
         assertCommitAllowed: () => {
           commitChecks += 1;
-          if (retired) {
+          if (rejected && commitRequested) {
             throw new Error("reclamation owner retired");
           }
         },
@@ -329,8 +398,7 @@ test.each([false, true])(
         });
       }
       expect(maintenanceErrors).toEqual([]);
-      expect(checksDuringMaintenance).toBe(2);
-      expect(commitChecks).toBe(2);
+      expect(checksDuringMaintenance).toBeGreaterThan(0);
       const reclaimed = before - freePages();
       expect(reclaimed).toBeGreaterThan(0);
       expect(reclaimed).toBeLessThanOrEqual(512);
@@ -392,20 +460,15 @@ test("queued and different-store reclamations retain only their own worker ident
   const diagnostics: SqliteSessionReclamationDiagnostics[] = [{}, {}, {}];
   const operations = [first, first, other].map((fixture, index) => {
     const record = diagnostics[index];
-    return runExclusiveSqliteSessionWrite(
-      fixture.databaseOptions,
-      () =>
-        runSqliteSessionReclamation({
-          forceInProcess: false,
-          plan: fixture.plan,
-          diagnostics: record,
-        }),
-      record,
-    );
+    return runSqliteSessionReclamation({
+      forceInProcess: false,
+      plan: fixture.plan,
+      diagnostics: record,
+    });
   });
   try {
-    // The same-store successor has not entered its callback or claimed a worker.
-    expect(diagnostics[1]).toEqual({});
+    // The queued successor has not claimed a worker.
+    expect(diagnostics[1]).not.toHaveProperty("workerThreadId");
     await Promise.all(operations);
     expect(diagnostics.map((record) => record.kind)).toEqual([
       "history-eviction",
@@ -445,18 +508,17 @@ test("file warnings link an awaited native worker without attributing it to the 
   const observeWorker = (worker: Worker) => workers.push({ worker, id: worker.threadId });
   setLoggerOverride({ level: "info", file });
   process.on("worker", observeWorker);
-  const first = runExclusiveSqliteSessionWrite(
-    databaseOptions,
-    async () => {
-      // Exercise the real slow-warning threshold without a large database or a fake clock.
-      await delay(1_100);
-      return runSqliteSessionReclamation({ forceInProcess: false, plan, diagnostics });
-    },
-    diagnostics,
-  );
-  const second = runExclusiveSqliteSessionWrite(databaseOptions, async () => "successor");
+  let second: Promise<string> | undefined;
+  hooks.afterWriteAdmission = async () => {
+    hooks.afterWriteAdmission = undefined;
+    second = runExclusiveSqliteSessionWrite(databaseOptions, async () => "successor");
+    // Hold the actual Worker's admission across the real slow-warning threshold.
+    await delay(1_100);
+  };
+  const first = runSqliteSessionReclamation({ forceInProcess: false, plan, diagnostics });
   try {
     await expect(first).resolves.toMatchObject({ kind: "history-eviction" });
+    expect(second).toBeDefined();
     await expect(second).resolves.toBe("successor");
     await flushLogger();
     const records = (await fs.readFile(file, "utf8"))

--- a/src/config/sessions/session-accessor.sqlite-reclamation.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.ts
@@ -47,7 +47,11 @@ import type { SessionEntryRemovalPlan } from "./session-accessor.sqlite-lifecycl
 import { deleteSessionDeliveryArtifacts } from "./session-accessor.sqlite-node-artifacts.js";
 import { withSqliteReclamationAuthorization } from "./session-accessor.sqlite-reclamation-commit.js";
 import { isRecentHistoricalSessionId } from "./session-accessor.sqlite-references.js";
-import { cloneSessionEntry, getSessionKysely } from "./session-accessor.sqlite-scope.js";
+import {
+  cloneSessionEntry,
+  getSessionKysely,
+  runExclusiveSqliteSessionWrite,
+} from "./session-accessor.sqlite-scope.js";
 import type { InternalSessionEntry as SessionEntry } from "./types.js";
 
 type SessionBoardCleanupDatabase = Pick<
@@ -420,18 +424,26 @@ export async function runSqliteSessionReclamation(params: {
       env: params.plan.databaseOptions.env,
     })
   ) {
-    return reclaimSqliteSessionInTransaction(params.plan, {
-      beforeMutation: params.assertCommitAllowed,
-      onCommit: (database) => {
-        const publish = prepareReclamationPublication(params.plan);
-        if (publish) {
-          deferOpenClawAgentPostCommitPublication(database, publish);
-        }
-        params.onInProcessCommit?.(database);
-      },
-    });
+    return await runExclusiveSqliteSessionWrite(
+      params.plan.databaseOptions,
+      async () =>
+        reclaimSqliteSessionInTransaction(params.plan, {
+          beforeMutation: params.assertCommitAllowed,
+          onCommit: (database) => {
+            const publish = prepareReclamationPublication(params.plan);
+            if (publish) {
+              deferOpenClawAgentPostCommitPublication(database, publish);
+            }
+            params.onInProcessCommit?.(database);
+          },
+        }),
+      params.diagnostics,
+    );
   }
-  const retained = retainOpenClawAgentDatabaseReadOnly(params.plan.databaseOptions);
+  const retained = await runExclusiveSqliteSessionWrite(params.plan.databaseOptions, async () => {
+    params.assertCommitAllowed?.();
+    return retainOpenClawAgentDatabaseReadOnly(params.plan.databaseOptions);
+  });
   if (!retained.found) {
     throw new Error("SQLite session reclamation lost its prepared database");
   }
@@ -466,6 +478,24 @@ export async function runSqliteSessionReclamation(params: {
           diagnostics: params.diagnostics,
           expectedMessageType: "reclaimed",
           onCommitRequest: () => recoveredCommitErrors.push(...authorize()),
+          withWriteAdmission: async (run) =>
+            await runExclusiveSqliteSessionWrite(
+              plan.databaseOptions,
+              async () => {
+                let refusal: { error: unknown } | undefined;
+                try {
+                  assertCommitAllowed();
+                } catch (error) {
+                  refusal = { error };
+                }
+                const completed = await run(refusal);
+                if (completed?.[0]) {
+                  // Publish captured identities after native exit, before releasing the writer.
+                  publishCommitted?.();
+                }
+              },
+              params.diagnostics,
+            ),
           transferList: prepareReclamationWorkerTransferList(plan),
           workerData: {
             commitGate,
@@ -499,8 +529,6 @@ export async function runSqliteSessionReclamation(params: {
         path: params.plan.databaseOptions.path,
       });
     }
-    // Publish the removal identities captured at authorization only after confirmed settlement.
-    publishCommitted?.();
     return workerResult.result;
   } finally {
     claim.release();

--- a/src/config/sessions/session-accessor.sqlite-reclamation.ts
+++ b/src/config/sessions/session-accessor.sqlite-reclamation.ts
@@ -426,8 +426,9 @@ export async function runSqliteSessionReclamation(params: {
   ) {
     return await runExclusiveSqliteSessionWrite(
       params.plan.databaseOptions,
-      async () =>
-        reclaimSqliteSessionInTransaction(params.plan, {
+      async () => {
+        params.assertCommitAllowed?.();
+        return reclaimSqliteSessionInTransaction(params.plan, {
           beforeMutation: params.assertCommitAllowed,
           onCommit: (database) => {
             const publish = prepareReclamationPublication(params.plan);
@@ -436,7 +437,8 @@ export async function runSqliteSessionReclamation(params: {
             }
             params.onInProcessCommit?.(database);
           },
-        }),
+        });
+      },
       params.diagnostics,
     );
   }

--- a/src/config/sessions/session-history-eviction.ts
+++ b/src/config/sessions/session-history-eviction.ts
@@ -548,11 +548,11 @@ async function enforceSessionHistoryMaintenanceSerialized(
         const committedArchives = await runExclusiveSqliteSessionReclamation(async () => {
           const materialized = await materializeSessionStateDeletePlans([plan]);
           const diagnostics: SqliteSessionReclamationDiagnostics = {};
-          return await runExclusiveSqliteSessionWrite(
+          const reclamationPlan = await runExclusiveSqliteSessionWrite(
             resolved,
             async () => {
               const database = openOpenClawAgentDatabase(databaseOptions);
-              const reclamationPlan = createHistoryEvictionReclamationPlan({
+              return createHistoryEvictionReclamationPlan({
                 databaseOptions,
                 diskBudget: { preserveRecentMs: params.maintenance.preserveRecentMs },
                 materializedPlans: materialized,
@@ -564,23 +564,23 @@ async function enforceSessionHistoryMaintenanceSerialized(
                 }),
                 sessionId,
               });
-              const reclaimed = await runSqliteSessionReclamation({
-                diagnostics,
-                forceInProcess: false,
-                plan: reclamationPlan,
-              });
-              if (reclaimed.kind !== reclamationPlan.kind) {
-                throw new Error(
-                  `SQLite session reclamation returned ${reclaimed.kind} for ${reclamationPlan.kind}`,
-                );
-              }
-              if (!reclaimed.value.deleted) {
-                return null;
-              }
-              return reclaimed.value.archivedTranscripts;
             },
             diagnostics,
           );
+          const reclaimed = await runSqliteSessionReclamation({
+            diagnostics,
+            forceInProcess: false,
+            plan: reclamationPlan,
+          });
+          if (reclaimed.kind !== reclamationPlan.kind) {
+            throw new Error(
+              `SQLite session reclamation returned ${reclaimed.kind} for ${reclamationPlan.kind}`,
+            );
+          }
+          if (!reclaimed.value.deleted) {
+            return null;
+          }
+          return reclaimed.value.archivedTranscripts;
         });
         if (!committedArchives) {
           return null;

--- a/src/gateway/server/__tests__/server.sessions.reclamation-admission.test.ts
+++ b/src/gateway/server/__tests__/server.sessions.reclamation-admission.test.ts
@@ -1,0 +1,307 @@
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
+import type { WorkerOptions } from "node:worker_threads";
+import { afterEach, expect, test, vi } from "vitest";
+import { withTestTimeout } from "../../../../test/helpers/promise.js";
+import {
+  deleteSessionEntryLifecycle,
+  loadSessionEntry,
+} from "../../../config/sessions/session-accessor.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../../../config/sessions/session-sqlite-target.js";
+import { beginSessionWorkAdmission } from "../../../sessions/session-lifecycle-admission.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../../../state/openclaw-agent-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../../../state/openclaw-state-db.js";
+import { rpcReq, writeSessionStore } from "../../test-helpers.js";
+import {
+  loadSeededTranscriptEvents,
+  seedLinearSessionTranscript,
+  sessionStoreEntry,
+  setupGatewaySessionsTestHarness,
+} from "../../test/server-sessions.test-helpers.js";
+
+const reclamation = vi.hoisted(() => ({
+  gate: undefined as SharedArrayBuffer | undefined,
+  exits: [] as Promise<number>[],
+  exitCodes: [] as number[],
+}));
+
+vi.mock("node:worker_threads", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:worker_threads")>();
+  return {
+    ...actual,
+    Worker: class extends actual.Worker {
+      constructor(filename: string | URL, options: WorkerOptions = {}) {
+        const gate = options.workerData?.operation === "reclaim" ? reclamation.gate : undefined;
+        let workerOptions = options;
+        if (gate) {
+          // Hold the real Worker's native validation, with no fake database or
+          // production hook. Both checks still execute on this same handle.
+          const preload = `
+            import { realpathSync } from 'node:fs';
+            import { DatabaseSync } from 'node:sqlite';
+            import { workerData } from 'node:worker_threads';
+            const gate = new Int32Array(workerData.reclamationTestGate);
+            const databasePath = realpathSync(workerData.plan.databaseOptions.path);
+            const validated = new WeakSet();
+            const prepare = DatabaseSync.prototype.prepare;
+            DatabaseSync.prototype.prepare = function (sql) {
+              const statement = prepare.call(this, sql);
+              if (sql !== 'PRAGMA integrity_check;' && sql !== 'PRAGMA foreign_key_check;') {
+                return statement;
+              }
+              const target = prepare.call(this, 'PRAGMA database_list').all().some(
+                (row) => row.name === 'main' && row.file && realpathSync(row.file) === databasePath,
+              );
+              if (!target) return statement;
+              const database = this;
+              if (sql === 'PRAGMA integrity_check;') {
+                const all = statement.all.bind(statement);
+                statement.all = (...args) => {
+                  Atomics.add(gate, 0, 1);
+                  Atomics.notify(gate, 0);
+                  if (Atomics.wait(gate, 1, 0, 15000) === 'timed-out') {
+                    throw new Error('reclamation test gate was not released');
+                  }
+                  const result = all(...args);
+                  validated.add(database);
+                  Atomics.add(gate, 2, 1);
+                  return result;
+                };
+              } else if (sql === 'PRAGMA foreign_key_check;') {
+                const iterate = statement.iterate.bind(statement);
+                statement.iterate = function* (...args) {
+                  yield* iterate(...args);
+                  if (validated.has(database)) Atomics.add(gate, 3, 1);
+                };
+              }
+              return statement;
+            };
+          `;
+          workerOptions = {
+            ...options,
+            workerData: { ...options.workerData, reclamationTestGate: gate },
+            execArgv: [
+              ...(options.execArgv ?? []),
+              "--import",
+              `data:text/javascript,${encodeURIComponent(preload)}`,
+            ],
+          };
+        }
+        super(filename, workerOptions);
+        if (gate) {
+          reclamation.exits.push(
+            new Promise((resolve) => {
+              this.once("exit", (code) => {
+                reclamation.exitCodes.push(code);
+                resolve(code);
+              });
+            }),
+          );
+        }
+      }
+    },
+  };
+});
+
+const { createSessionStoreDir, openClient } = setupGatewaySessionsTestHarness();
+
+afterEach(() => {
+  reclamation.gate = undefined;
+  reclamation.exits = [];
+  reclamation.exitCodes = [];
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
+
+function holdReclamationValidation() {
+  const gate = new Int32Array(new SharedArrayBuffer(4 * Int32Array.BYTES_PER_ELEMENT));
+  reclamation.gate = gate.buffer;
+  const pending: Promise<unknown>[] = [];
+  const release = () => {
+    Atomics.store(gate, 1, 1);
+    Atomics.notify(gate, 1);
+  };
+  return {
+    gate,
+    release,
+    own<T>(operation: Promise<T>): Promise<T> {
+      pending.push(operation);
+      void operation.catch(() => {});
+      return operation;
+    },
+    async entered(operation: Promise<unknown>) {
+      // RPCs retain their own timeout; an early response must not masquerade as
+      // a held native check. The direct lifecycle sibling supplies the same bound.
+      const waiting = new AbortController();
+      const held = (async () => {
+        while (Atomics.load(gate, 0) === 0) {
+          if (waiting.signal.aborted) {
+            return undefined;
+          }
+          await yieldToEventLoop();
+        }
+        return "held";
+      })();
+      try {
+        const result = await Promise.race([held, operation]);
+        expect(result).toBe("held");
+        expect(Atomics.load(gate, 0)).toBeGreaterThan(0);
+      } finally {
+        waiting.abort();
+        await held;
+      }
+    },
+    async close() {
+      release();
+      await Promise.allSettled(pending);
+      await Promise.all(reclamation.exits);
+    },
+  };
+}
+
+test("sessions.delete admits unrelated same-store patches during Worker validation", async () => {
+  const targetKey = "agent:main:validation-delete";
+  const unrelatedKey = "agent:main:validation-patch";
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({
+    entries: {
+      [targetKey]: sessionStoreEntry("validation-delete"),
+      [unrelatedKey]: sessionStoreEntry("validation-patch"),
+    },
+    storePath,
+  });
+  const { ws } = await openClient();
+  const validation = holdReclamationValidation();
+  const { gate } = validation;
+  try {
+    expect(await rpcReq(ws, "sessions.patch", { key: unrelatedKey, label: "warm" })).toMatchObject({
+      ok: true,
+    });
+    const deletion = validation.own(rpcReq(ws, "sessions.delete", { key: targetKey }));
+    await validation.entered(deletion);
+    expect(loadSessionEntry({ sessionKey: targetKey, storePath })?.sessionId).toBe(
+      "validation-delete",
+    );
+
+    let admissionSettled = false;
+    const assertTargetExists = () => {
+      if (!loadSessionEntry({ sessionKey: targetKey, storePath })) {
+        throw new Error("deleted session cannot accept new work");
+      }
+    };
+    const admission = validation.own(
+      beginSessionWorkAdmission({
+        scope: storePath,
+        identities: [targetKey, "validation-delete"],
+        assertAllowed: assertTargetExists,
+        revalidateAllowed: assertTargetExists,
+      }).then(
+        (lease) => {
+          lease.release();
+          admissionSettled = true;
+          return "admitted";
+        },
+        (error: unknown) => {
+          admissionSettled = true;
+          return error instanceof Error ? error.message : String(error);
+        },
+      ),
+    );
+    const patch = validation.own(
+      rpcReq(ws, "sessions.patch", { key: unrelatedKey, label: "progressed" }),
+    );
+    await expect(
+      withTestTimeout(patch, 2_000, "unrelated same-store patch waited for reclamation validation"),
+    ).resolves.toMatchObject({ ok: true });
+    expect(loadSessionEntry({ sessionKey: unrelatedKey, storePath })?.label).toBe("progressed");
+    expect(admissionSettled).toBe(false);
+    expect(Atomics.load(gate, 2)).toBe(0);
+
+    validation.release();
+    await expect(deletion).resolves.toMatchObject({ ok: true, payload: { deleted: true } });
+    await expect(admission).resolves.toBe("deleted session cannot accept new work");
+    expect(loadSessionEntry({ sessionKey: targetKey, storePath })).toBeUndefined();
+    expect(Atomics.load(gate, 2)).toBeGreaterThan(0);
+    expect(Atomics.load(gate, 3)).toBeGreaterThan(0);
+    expect(reclamation.exitCodes).toEqual([0]);
+  } finally {
+    await validation.close();
+    ws.close();
+  }
+});
+
+test("sessions.delete rejects revoked authority before repairing the same database", async () => {
+  const sessionKey = "agent:main:validation-revoked";
+  const sessionId = "validation-revoked";
+  const { storePath } = await createSessionStoreDir();
+  await writeSessionStore({ entries: { [sessionKey]: sessionStoreEntry(sessionId) }, storePath });
+  const transcriptScope = { agentId: "main", sessionKey, sessionId, storePath };
+  await seedLinearSessionTranscript({ ...transcriptScope, contents: ["retained transcript"] });
+  const originalEntry = loadSessionEntry(transcriptScope);
+  const originalTranscript = await loadSeededTranscriptEvents(transcriptScope);
+  const databaseOptions = {
+    agentId: "main",
+    path: resolveSqliteTargetFromSessionStorePath(storePath, { agentId: "main" }).path,
+  };
+  const database = openOpenClawAgentDatabase(databaseOptions);
+  const stateDatabase = openOpenClawStateDatabase();
+  const readLeases = () =>
+    stateDatabase.db
+      .prepare("SELECT lease_id FROM agent_database_leases WHERE path = ? ORDER BY lease_id")
+      .all(database.path);
+  const originalLeases = readLeases();
+  expect(originalLeases).toHaveLength(1);
+  // A late commit guard can roll back deletion but cannot undo an earlier
+  // database-open repair. Keep the original cached handle warm throughout.
+  database.db.exec("DROP INDEX idx_agent_cache_expiry");
+  const readRepairIndex = () =>
+    database.db
+      .prepare("SELECT name FROM sqlite_schema WHERE type = 'index' AND name = ?")
+      .get("idx_agent_cache_expiry");
+  expect(readRepairIndex()).toBeUndefined();
+  const validation = holdReclamationValidation();
+  let authorized = true;
+  let guardCalls = 0;
+  try {
+    const deletion = validation.own(
+      deleteSessionEntryLifecycle({
+        archiveTranscript: true,
+        storePath,
+        target: { canonicalKey: sessionKey, storeKeys: [sessionKey] },
+        commitGuard: () => {
+          guardCalls += 1;
+          if (!authorized) {
+            throw new Error("caller authority revoked during Worker validation");
+          }
+        },
+      }),
+    );
+    await validation.entered(
+      withTestTimeout(deletion, 10_000, "reclamation Worker did not enter native validation"),
+    );
+    expect(openOpenClawAgentDatabase(databaseOptions)).toBe(database);
+    expect(database.db.isOpen).toBe(true);
+    expect(readLeases()).toHaveLength(originalLeases.length + 1);
+    const callsBeforeRevocation = guardCalls;
+    authorized = false;
+    validation.release();
+
+    await expect(deletion).rejects.toThrow("caller authority revoked during Worker validation");
+    expect(guardCalls).toBeGreaterThan(callsBeforeRevocation);
+    expect(openOpenClawAgentDatabase(databaseOptions)).toBe(database);
+    expect(loadSessionEntry(transcriptScope)).toEqual(originalEntry);
+    await expect(loadSeededTranscriptEvents(transcriptScope)).resolves.toEqual(originalTranscript);
+    expect(Atomics.load(validation.gate, 2)).toBeGreaterThan(0);
+    expect(Atomics.load(validation.gate, 3)).toBeGreaterThan(0);
+    expect(reclamation.exitCodes).toHaveLength(1);
+    expect(readLeases()).toEqual(originalLeases);
+    expect(readRepairIndex()).toBeUndefined();
+  } finally {
+    await validation.close();
+  }
+});

--- a/src/state/openclaw-agent-db-admission.ts
+++ b/src/state/openclaw-agent-db-admission.ts
@@ -1,0 +1,290 @@
+import type { DatabaseSync } from "node:sqlite";
+import { assertSqliteIntegrityInWorker } from "../infra/sqlite-integrity-worker.js";
+import { assertSqliteIntegrity, type SqliteIntegrityOperation } from "../infra/sqlite-integrity.js";
+import { normalizeAgentId } from "../routing/session-key.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import {
+  assertAgentDeletionDatabaseCleanupAccess,
+  getAgentDeletionDatabaseCleanup,
+} from "./agent-deletion-cleanup.js";
+import type {
+  OpenClawAgentDatabase,
+  OpenClawAgentDatabaseOptions,
+} from "./openclaw-agent-db-contract.js";
+import {
+  agentDatabaseLifecycle as cache,
+  retainAgentDatabase,
+  type PendingAgentDatabaseOpen,
+} from "./openclaw-agent-db-lifecycle.js";
+import {
+  assertExistingAgentSchemaOwner,
+  assertSupportedAgentSchemaVersion,
+  readExistingAgentSchemaMeta,
+} from "./openclaw-agent-db-schema-helpers.js";
+import { resolveOpenClawAgentSqlitePath } from "./openclaw-agent-db.paths.js";
+import { OPENCLAW_SQLITE_BUSY_TIMEOUT_MS } from "./openclaw-state-db-contract.js";
+
+/** Denial still invokes run under admission, with a throwing authority check, to permit cleanup. */
+export type OpenClawAgentDatabaseWriteAdmission = <T>(
+  run: (assertCurrent: () => void) => T | Promise<T>,
+) => Promise<T>;
+
+/** Bind both admission drivers to the canonical private database-open generator. */
+export function createOpenClawAgentDatabaseAdmissionOwner(
+  openSteps: (
+    options: OpenClawAgentDatabaseOptions,
+    pending: PendingAgentDatabaseOpen,
+  ) => SqliteIntegrityOperation<OpenClawAgentDatabase>,
+) {
+  /** Retain the verified connection through an async caller's operation; disposal still revokes it. */
+  function withOpenClawAgentDatabaseAsync<T>(
+    inputOptions: OpenClawAgentDatabaseOptions,
+    operation: (database: OpenClawAgentDatabase) => T | Promise<T>,
+  ): Promise<T> {
+    // Admission retains its original path, registration, and permission inputs across awaits.
+    const options = { ...inputOptions, env: { ...(inputOptions.env ?? process.env) } };
+    const agentId = normalizeAgentId(options.agentId);
+    const pathname = resolveOpenClawAgentSqlitePath({ ...options, agentId });
+    const existing = cache.pending.get(pathname);
+    if (existing?.agentId !== undefined && existing.agentId !== agentId) {
+      return Promise.reject(
+        new Error(`Agent database ${pathname} is opening for ${existing.agentId}`),
+      );
+    }
+    if (existing?.controller.signal.aborted) {
+      return existing.promise.then(
+        () => withOpenClawAgentDatabaseAsync(options, operation),
+        () => withOpenClawAgentDatabaseAsync(options, operation),
+      );
+    }
+    const pending = existing ?? startOpenClawAgentDatabaseAdmission(options, agentId, pathname);
+    pending.operations += 1;
+    return pending.promise
+      .then((database) => {
+        pending.controller.signal.throwIfAborted();
+        if (cache.databases.get(pathname) !== database || !database.db.isOpen) {
+          throw new Error(`Agent database closed before its admitted operation: ${pathname}`);
+        }
+        // Coalesced callers keep their own scope; admission cannot lend its cleanup authority.
+        assertAgentDeletionDatabaseCleanupAccess(database, options);
+        return operation(database);
+      })
+      .finally(() => {
+        // Every registered operation retains the publication borrow through its own
+        // settlement, including wrapper/adoption awaits before it reaches the writer.
+        pending.operations -= 1;
+        if (!pending.operations) {
+          pending.releaseBorrow?.();
+        }
+      });
+  }
+
+  /** Run on a Worker to keep its same-connection integrity check outside the parent writer. */
+  async function withOpenClawAgentDatabaseAdmission<T>(
+    inputOptions: OpenClawAgentDatabaseOptions,
+    withAdmission: OpenClawAgentDatabaseWriteAdmission,
+    operation: (database: OpenClawAgentDatabase) => T | Promise<T>,
+  ): Promise<T> {
+    const options = { ...inputOptions, env: { ...(inputOptions.env ?? process.env) } };
+    const agentId = normalizeAgentId(options.agentId);
+    const pathname = resolveOpenClawAgentSqlitePath({ ...options, agentId });
+    const existing = cache.pending.get(pathname);
+    if (existing) {
+      if (existing.agentId !== agentId) {
+        throw new Error(`Agent database ${pathname} is opening for ${existing.agentId}`);
+      }
+      try {
+        await existing.promise;
+      } catch (error) {
+        if (!existing.controller.signal.aborted) {
+          throw error;
+        }
+      }
+      return withOpenClawAgentDatabaseAdmission(options, withAdmission, operation);
+    }
+    const admission = createOpenClawAgentDatabaseAdmission(agentId, pathname);
+    const { pending } = admission;
+    // This caller receives its scoped operation result; lifecycle disposal joins the open promise.
+    void pending.promise.catch(() => {});
+    pending.operations += 1;
+    const steps = openSteps(options, pending);
+    let check: { database: DatabaseSync; databaseLabel: string } | undefined;
+    let failure: { error: unknown } | undefined;
+    let suspended = false;
+    try {
+      while (true) {
+        const outcome = await withAdmission(async (assertCurrent) => {
+          try {
+            assertCurrent();
+            assertOpenClawAgentDatabaseAdmissionCurrent(options, pending, check?.database);
+          } catch (error) {
+            // Revocation takes precedence over repairable integrity damage.
+            failure = {
+              error: new Error(error instanceof Error ? error.message : String(error), {
+                cause: error,
+              }),
+            };
+          }
+          suspended = false;
+          const step = failure ? steps.throw(failure.error) : steps.next();
+          if (!step.done) {
+            suspended = true;
+            return { done: false as const, check: step.value };
+          }
+          pending.releaseBorrow = retainAgentDatabase(step.value.db);
+          admission.complete(step.value);
+          assertAgentDeletionDatabaseCleanupAccess(step.value, options);
+          return { done: true as const, result: await operation(step.value) };
+        });
+        if (outcome.done) {
+          return outcome.result;
+        }
+        check = outcome.check;
+        failure = undefined;
+        try {
+          pending.controller.signal.throwIfAborted();
+          assertSqliteIntegrity(check.database, check.databaseLabel);
+        } catch (error) {
+          failure = { error };
+        }
+      }
+    } catch (error) {
+      const failures = [error];
+      if (suspended) {
+        const cancellation = new Error(`Agent database admission failed: ${pathname}`, {
+          cause: error,
+        });
+        try {
+          // A lost scheduler cannot grant another permit. A generic refusal only
+          // unwinds this owner's handle and lease; it cannot enter index repair.
+          steps.throw(cancellation);
+        } catch (cleanupError) {
+          if (cleanupError !== cancellation) {
+            failures.push(cleanupError);
+          }
+        }
+      }
+      const terminalFailure =
+        failures.length === 1
+          ? error
+          : new AggregateError(failures, "Agent database admission and cleanup failed", {
+              cause: error,
+            });
+      admission.fail(terminalFailure);
+      throw terminalFailure;
+    } finally {
+      pending.operations -= 1;
+      if (!pending.operations) {
+        pending.releaseBorrow?.();
+      }
+    }
+  }
+
+  function createOpenClawAgentDatabaseAdmission(agentId: string, pathname: string) {
+    const completion = createDeferredCore<OpenClawAgentDatabase>();
+    const pending: PendingAgentDatabaseOpen = {
+      agentId,
+      path: pathname,
+      controller: new AbortController(),
+      promise: completion.promise,
+      operations: 0,
+    };
+    cache.pending.set(pathname, pending);
+    cache.activePending.add(pending);
+    const retire = () => {
+      if (cache.pending.get(pathname) === pending) {
+        cache.pending.delete(pathname);
+      }
+      cache.activePending.delete(pending);
+    };
+    return {
+      pending,
+      complete: (database: OpenClawAgentDatabase) => {
+        retire();
+        if (
+          pending.controller.signal.aborted ||
+          cache.databases.get(pathname) !== database ||
+          !database.db.isOpen
+        ) {
+          const error =
+            pending.controller.signal.reason ??
+            new Error(`Agent database closed before admission completed: ${pathname}`);
+          completion.reject(error);
+          throw error;
+        }
+        completion.resolve(database);
+      },
+      fail: (error: unknown) => {
+        retire();
+        completion.reject(error);
+      },
+    };
+  }
+
+  function assertOpenClawAgentDatabaseAdmissionCurrent(
+    options: OpenClawAgentDatabaseOptions,
+    pending: PendingAgentDatabaseOpen,
+    database?: DatabaseSync,
+  ): void {
+    const pathname = pending.path;
+    pending.controller.signal.throwIfAborted();
+    if (cache.pending.get(pathname) !== pending) {
+      throw new Error(`Agent database open was replaced: ${pathname}`);
+    }
+    // Cleanup may end during the native check; reject before schema repair can resume.
+    getAgentDeletionDatabaseCleanup(options)?.assertCurrent();
+    pending.assertHeld?.();
+    if (database) {
+      assertSupportedAgentSchemaVersion(database, pathname);
+      assertExistingAgentSchemaOwner(
+        readExistingAgentSchemaMeta(database),
+        pending.agentId,
+        pathname,
+      );
+    }
+  }
+
+  function startOpenClawAgentDatabaseAdmission(
+    options: OpenClawAgentDatabaseOptions,
+    agentId: string,
+    pathname: string,
+  ): PendingAgentDatabaseOpen {
+    const admission = createOpenClawAgentDatabaseAdmission(agentId, pathname);
+    const { pending } = admission;
+    const operation = openSteps(options, pending);
+    void (async () => {
+      let step = operation.next();
+      while (!step.done) {
+        let failure: unknown;
+        let failed = false;
+        try {
+          await assertSqliteIntegrityInWorker(
+            pathname,
+            OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
+            pending.controller.signal,
+          );
+        } catch (error) {
+          failure = error;
+          failed = true;
+        }
+        try {
+          assertOpenClawAgentDatabaseAdmissionCurrent(options, pending, step.value.database);
+        } catch (error) {
+          failure = error;
+          failed = true;
+        }
+        // Resuming, or throwing into, the same owner preserves repair and unwind policy.
+        step = failed ? operation.throw(failure) : operation.next();
+      }
+      // A peer may publish before promise consumers run. Their operation owner,
+      // not promise scheduling depth, releases this exact connection borrow.
+      pending.releaseBorrow = retainAgentDatabase(step.value.db);
+      return step.value;
+    })()
+      .then(admission.complete, admission.fail)
+      .catch(admission.fail);
+    return pending;
+  }
+
+  return { withOpenClawAgentDatabaseAsync, withOpenClawAgentDatabaseAdmission };
+}

--- a/src/state/openclaw-agent-db.lease-owner.test.ts
+++ b/src/state/openclaw-agent-db.lease-owner.test.ts
@@ -1,15 +1,19 @@
 import fs from "node:fs";
 import path from "node:path";
+import type { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import * as nodeSqlite from "../infra/node-sqlite.js";
 import {
   closeOpenClawAgentDatabaseByPath,
   closeOpenClawAgentDatabasesForTest,
+  getOpenClawAgentDatabaseIfOpen,
   listOpenClawRegisteredAgentDatabases,
   openOpenClawAgentDatabase,
   recordOpenClawAgentDatabaseOpenFailure,
   settleOpenClawAgentDatabaseWorkerClose,
+  withOpenClawAgentDatabaseAdmission,
+  type OpenClawAgentDatabaseWriteAdmission,
 } from "./openclaw-agent-db.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -18,10 +22,17 @@ import {
 import { claimOpenClawStateOwnership } from "./openclaw-state-ownership-operations.js";
 
 const tempDirs = createTempDirTracker();
+const connections: DatabaseSync[] = [];
+const admitted: OpenClawAgentDatabaseWriteAdmission = async (run) => run(() => {});
 
 afterEach(() => {
   vi.restoreAllMocks();
   closeOpenClawAgentDatabasesForTest();
+  for (const connection of connections.splice(0)) {
+    if (connection.isOpen) {
+      connection.close();
+    }
+  }
   closeOpenClawStateDatabaseForTest();
   vi.unstubAllEnvs();
   tempDirs.cleanup();
@@ -37,6 +48,108 @@ function createOwner() {
 }
 
 describe("agent database lease acquisition owner", () => {
+  it("rejects initial authority denial without creating a database or changing its directory", async () => {
+    const owner = createOwner();
+    const directory = path.join(owner.stateDir, "custom");
+    fs.mkdirSync(directory);
+    fs.chmodSync(directory, 0o750);
+    const mode = fs.statSync(directory).mode;
+    const options = {
+      agentId: "worker",
+      env: owner.env,
+      path: path.join(directory, "agent.sqlite"),
+    };
+    const denied = new Error("synthetic write authority revoked");
+    const operation = vi.fn();
+
+    await expect(
+      withOpenClawAgentDatabaseAdmission(
+        options,
+        async (run) =>
+          run(() => {
+            throw denied;
+          }),
+        operation,
+      ),
+    ).rejects.toMatchObject({ message: denied.message, cause: denied });
+
+    expect(operation).not.toHaveBeenCalled();
+    expect(fs.readdirSync(directory)).toEqual([]);
+    expect(fs.statSync(directory).mode).toBe(mode);
+    expect(owner.leases()).toEqual([]);
+    expect(getOpenClawAgentDatabaseIfOpen(options)).toBeUndefined();
+    await expect(
+      withOpenClawAgentDatabaseAdmission(options, admitted, (database) => database.agentId),
+    ).resolves.toBe(options.agentId);
+  });
+
+  it("unwinds an unfinished physical open when the scheduler rejects the next permit", async () => {
+    const owner = createOwner();
+    const options = { agentId: "worker", env: owner.env };
+    const original = openOpenClawAgentDatabase(options);
+    original.db.exec(`
+      INSERT INTO cache_entries (scope,key,value_json,expires_at,updated_at)
+        VALUES ('admission','retained','{"retained":true}',100,1);
+      DROP INDEX idx_agent_cache_expiry;
+    `);
+    expect(closeOpenClawAgentDatabaseByPath(original.path)).toBe(true);
+    const nativeOpen = nodeSqlite.openNodeSqliteDatabase;
+    let opened: DatabaseSync | undefined;
+    const open = vi
+      .spyOn(nodeSqlite, "openNodeSqliteDatabase")
+      .mockImplementation((location, config) => {
+        const connection = nativeOpen(location, config);
+        if (location === original.path) {
+          opened = connection;
+          connections.push(connection);
+        }
+        return connection;
+      });
+    const lostScheduler = new Error("synthetic parent closed during database admission");
+    let permits = 0;
+    const withAdmission: OpenClawAgentDatabaseWriteAdmission = async (run) => {
+      if (++permits === 2) {
+        expect(owner.leases()).toHaveLength(1);
+        expect(opened?.isOpen).toBe(true);
+        throw lostScheduler;
+      }
+      return run(() => {});
+    };
+    const operation = vi.fn();
+
+    await expect(
+      withOpenClawAgentDatabaseAdmission(options, withAdmission, operation),
+    ).rejects.toBe(lostScheduler);
+
+    expect(permits).toBe(2);
+    expect(operation).not.toHaveBeenCalled();
+    expect(opened?.isOpen).toBe(false);
+    expect(getOpenClawAgentDatabaseIfOpen(options)).toBeUndefined();
+    expect(owner.leases()).toEqual([]);
+    open.mockRestore();
+    const retained = nativeOpen(original.path, { readOnly: true });
+    try {
+      expect(
+        retained.prepare("SELECT sql FROM sqlite_schema WHERE name='idx_agent_cache_expiry'").get(),
+      ).toBeUndefined();
+      expect(retained.prepare("SELECT * FROM cache_entries").all()).toEqual([
+        {
+          scope: "admission",
+          key: "retained",
+          value_json: '{"retained":true}',
+          blob: null,
+          expires_at: 100,
+          updated_at: 1,
+        },
+      ]);
+    } finally {
+      retained.close();
+    }
+    await expect(
+      withOpenClawAgentDatabaseAdmission(options, admitted, (database) => database.agentId),
+    ).resolves.toBe(options.agentId);
+  });
+
   it("resets a recreated fixture root without retiring another root", () => {
     const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
     const owner = createOwner();

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -11,7 +11,6 @@ import {
 } from "../infra/node-sqlite.js";
 import type { SqliteFileGeneration } from "../infra/sqlite-file-generation.js";
 import { quarantineOrphanedSqliteSidecars } from "../infra/sqlite-files.js";
-import { assertSqliteIntegrityInWorker } from "../infra/sqlite-integrity-worker.js";
 import {
   confirmSqliteFileIntegrity,
   isTerminalSqliteIntegrityError,
@@ -35,13 +34,13 @@ import {
   type SqliteWalMaintenance,
 } from "../infra/sqlite-wal.js";
 import { normalizeAgentId } from "../routing/session-key.js";
-import { createDeferredCore } from "../shared/deferred.js";
 import {
   assertAgentDeletionCleanupAliases,
   assertAgentDeletionDatabaseCleanupAccess,
   getAgentDeletionDatabaseCleanup,
   registerAgentDeletionDatabaseCleanup,
 } from "./agent-deletion-cleanup.js";
+import { createOpenClawAgentDatabaseAdmissionOwner } from "./openclaw-agent-db-admission.js";
 import type {
   OpenClawAgentDatabase,
   OpenClawAgentDatabaseOptions,
@@ -188,134 +187,9 @@ export function openOpenClawAgentDatabase(
   return runSqliteIntegrityOperationSync(openOpenClawAgentDatabaseSteps(options));
 }
 
-/** Retain the verified connection through an async caller's operation; disposal still revokes it. */
-export function withOpenClawAgentDatabaseAsync<T>(
-  inputOptions: OpenClawAgentDatabaseOptions,
-  operation: (database: OpenClawAgentDatabase) => T | Promise<T>,
-): Promise<T> {
-  // Admission retains its original path, registration, and permission inputs across awaits.
-  const options = { ...inputOptions, env: { ...(inputOptions.env ?? process.env) } };
-  const agentId = normalizeAgentId(options.agentId);
-  const pathname = resolveOpenClawAgentSqlitePath({ ...options, agentId });
-  const existing = cache.pending.get(pathname);
-  if (existing?.agentId !== undefined && existing.agentId !== agentId) {
-    return Promise.reject(
-      new Error(`Agent database ${pathname} is opening for ${existing.agentId}`),
-    );
-  }
-  if (existing?.controller.signal.aborted) {
-    return existing.promise.then(
-      () => withOpenClawAgentDatabaseAsync(options, operation),
-      () => withOpenClawAgentDatabaseAsync(options, operation),
-    );
-  }
-  const pending = existing ?? startOpenClawAgentDatabaseAdmission(options, agentId, pathname);
-  pending.operations += 1;
-  return pending.promise
-    .then((database) => {
-      pending.controller.signal.throwIfAborted();
-      if (cache.databases.get(pathname) !== database || !database.db.isOpen) {
-        throw new Error(`Agent database closed before its admitted operation: ${pathname}`);
-      }
-      // Coalesced callers keep their own scope; admission cannot lend its cleanup authority.
-      assertAgentDeletionDatabaseCleanupAccess(database, options);
-      return operation(database);
-    })
-    .finally(() => {
-      // Every registered operation retains the publication borrow through its own
-      // settlement, including wrapper/adoption awaits before it reaches the writer.
-      pending.operations -= 1;
-      if (!pending.operations) {
-        pending.releaseBorrow?.();
-      }
-    });
-}
-
-function startOpenClawAgentDatabaseAdmission(
-  options: OpenClawAgentDatabaseOptions,
-  agentId: string,
-  pathname: string,
-): PendingAgentDatabaseOpen {
-  const completion = createDeferredCore<OpenClawAgentDatabase>();
-  const pending: PendingAgentDatabaseOpen = {
-    agentId,
-    path: pathname,
-    controller: new AbortController(),
-    promise: completion.promise,
-    operations: 0,
-  };
-  cache.pending.set(pathname, pending);
-  cache.activePending.add(pending);
-  const operation = openOpenClawAgentDatabaseSteps(options, pending);
-  void (async () => {
-    let step = operation.next();
-    while (!step.done) {
-      let failure: unknown;
-      let failed = false;
-      try {
-        await assertSqliteIntegrityInWorker(
-          pathname,
-          OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
-          pending.controller.signal,
-        );
-      } catch (error) {
-        failure = error;
-        failed = true;
-      }
-      try {
-        pending.controller.signal.throwIfAborted();
-        if (cache.pending.get(pathname) !== pending) {
-          throw new Error(`Agent database open was replaced: ${pathname}`);
-        }
-        // Cleanup may end during the native check; reject before schema repair can resume.
-        getAgentDeletionDatabaseCleanup(options)?.assertCurrent();
-        pending.assertHeld?.();
-        assertSupportedAgentSchemaVersion(step.value.database, pathname);
-        assertExistingAgentSchemaOwner(
-          readExistingAgentSchemaMeta(step.value.database),
-          agentId,
-          pathname,
-        );
-      } catch (error) {
-        failure = error;
-        failed = true;
-      }
-      // Resuming, or throwing into, the same owner preserves repair and unwind policy.
-      step = failed ? operation.throw(failure) : operation.next();
-    }
-    // A peer may publish before promise consumers run. Their operation owner,
-    // not promise scheduling depth, releases this exact connection borrow.
-    pending.releaseBorrow = retainAgentDatabase(step.value.db);
-    return step.value;
-  })().then(
-    (database) => {
-      if (cache.pending.get(pathname) === pending) {
-        cache.pending.delete(pathname);
-      }
-      cache.activePending.delete(pending);
-      if (
-        pending.controller.signal.aborted ||
-        cache.databases.get(pathname) !== database ||
-        !database.db.isOpen
-      ) {
-        completion.reject(
-          pending.controller.signal.reason ??
-            new Error(`Agent database closed before admission completed: ${pathname}`),
-        );
-      } else {
-        completion.resolve(database);
-      }
-    },
-    (error: unknown) => {
-      if (cache.pending.get(pathname) === pending) {
-        cache.pending.delete(pathname);
-      }
-      cache.activePending.delete(pending);
-      completion.reject(error);
-    },
-  );
-  return pending;
-}
+export type { OpenClawAgentDatabaseWriteAdmission } from "./openclaw-agent-db-admission.js";
+export const { withOpenClawAgentDatabaseAsync, withOpenClawAgentDatabaseAdmission } =
+  createOpenClawAgentDatabaseAdmissionOwner(openOpenClawAgentDatabaseSteps);
 
 function* openOpenClawAgentDatabaseSteps(
   options: OpenClawAgentDatabaseOptions,


### PR DESCRIPTION
Related: #126035, #139469, #139689, #140897.

## What Problem This Solves

Fixes an issue where editing another conversation waits for session cleanup to verify a large SQLite database. Cleanup already runs its expensive database checks on a Worker, but the parent holds the session writer for the entire Worker lifetime, so unrelated session changes queue behind the scan.

## Why This Change Was Made

The same Worker and native connection now enter the session writer for initial database/lease admission, release it for full integrity and foreign-key checks, then reacquire it before index repair, schema work and deletion. The canonical database owner retains the incomplete connection and lease throughout; current authority is checked before resumption and again before COMMIT, and the final writer section remains held through Worker cleanup and exit. Initial refusal and a lost scheduler unwind that same owner without permitting repair.

This bounded concurrency design was explicitly accepted by the maintainer on September 7, 2026. Full validation, archive/deletion atomicity, native and incognito handling, retention, and the existing global archive/reclamation queues remain intact. No schema, index, configuration, dependency, pool, or version change is included. Existing async admission shares the same lifecycle owner. Native in-process cleanup also checks caller authority inside writer admission before opening a cold database, then retains its transaction-time guard.

The integration preserves #138451: the parent retains the read-only database claim; all later writer admissions use the opened database's frozen canonical options; current ownership is checked at every permit and COMMIT; removal identities are captured at actual authorization, including authorization serviced by synchronous writers; and confirmed removal publication runs inside final writer admission before release. A new alias-retarget case proves that reclamation keeps the original database and canonical FIFO while preserving the replacement database. In-process publication retains its deferred post-commit owner.

## User Impact

Other conversation edits can finish while cleanup verifies its database. Deletion itself still waits for complete verification and its durable result. This addresses the shared-writer wait; it does not establish a general steady-state speedup or completion of broader performance work.

## Evidence

Current integrated head: `6d7f9b6ef20094549245f2bfe2ddbd8a816c33db`, based on `13bfce042dcf4bd6a560fc08acec9e38976cd9d3`.

This final refresh picks up the already-landed main repair for an unrelated Markdown test file exceeding its existing line limit in the earlier test merge. All 11 reviewed feature/test/documentation files are byte-identical to verified `163d42337e327b380da269ba9e27bf987db68d03`, the dependency lock is unchanged, and the affected database/admission owners did not change between bases. The focused and Linux receipts below executed on `163d423`; fresh CI verifies the refreshed integration. The newer patch-engine/effects access-invalidation change was inspected separately, and all four focused Gateway and native admission cases passed on this base.

- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34157070217) passed on `6d7f9b6ef20094549245f2bfe2ddbd8a816c33db`. The prior test merge failed an unrelated main-owned Markdown test-size check; this refresh includes the already-landed repair with its original threshold preserved.
- **261 distinct focused tests passed; 4 existing skips were retained and are not counted as passes.** Seven owner/archive/reclamation/history suites passed 246 cases, including all 34 history-eviction cases; identity/lease and Gateway admission suites add 15 distinct cases. Coverage includes integrity/schema/refusal behavior, async admission and cache ownership, archive conservation, lifecycle fences, synchronous writers and vacuum, commit settlement, failed-open leases, retained database identity, alias retargeting and removal publication.
- The unchanged 307-line Gateway regression fails twice on pristine `fae6778b125c51e1a3ca765b01d487b6d8300f80`: an unrelated real `sessions.patch` misses the unchanged 2-second liveness bound while the exact agent connection's native integrity check is held, and revoking authority during that check still allows index repair before the old late guard rejects deletion. Both cases pass on the integrated candidate, with full integrity/FK execution, target fencing, exact data and parent-owner preservation, Worker exit and durable-lease restoration. This independent pair used its own checkout and physical frozen dependency install.
- Fresh canonical `check:changed` passed with exit 0 after the cold-admission correction, including production and all core-test types, lint, export checks, storage and runtime guards, and zero runtime import cycles. The existing 720-root limits remain intact; no baseline or ignore was broadened.
- Fresh managed review of the complete corrected candidate through P2 is scoped-clean with no accepted/actionable findings. Independent owner review and the alias/FIFO regression also cover the substantive rebase integration.
- [The corrected-head paired Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/34155434461) completed normal **`pnpm build`**, including global and plugin SDK declarations, export/CLI guards and UI, then passed both native cold-admission cases and all six ordinary RPC cases with payload exit 0. The wrapper verified the integrated source and materialized tree. The one-shot Testbox stopped successfully; its backing workflow cancellation during teardown is not represented as green PR CI.

The corrected-head Linux native cases verified allowed cold cleanup and exact preservation after rejected cold admission; both passed (126 ms and 65 ms). These are behavior checks, not latency thresholds. The wrapper verified source `163d42337e327b380da269ba9e27bf987db68d03` before execution.

The paired probe used Linux Node 24.19.0 / libuv 1.52.1, 64 metadata rows, an empty deletion target and retained unrelated history. Every case verified RPC receipts, durable label/deletion results, conservation, integrity and foreign keys. Each listed warm case observed one Worker; the probe triggers the patch on the first process Worker event. Exact validation overlap is independently established by the controlled regression above. The cold zero-history case observed an additional Worker and is excluded from this timing comparison; its incomplete process-wide exit observation remains recorded.

| Seeded unrelated messages | Baseline warm patches | Candidate warm patches | Patch during cleanup, baseline → candidate | Deletion, baseline → candidate |
| --- | --- | --- | --- | --- |
| 1,024 | 4.7–6.1 ms | 4.0–5.0 ms | 489.3 → 5.0 ms | 527.4 → 473.3 ms |
| 8,192 | 3.8–4.8 ms | 3.6–4.8 ms | 373.9 → 4.1 ms | 401.0 → 399.4 ms |

These are single paired observations per shape, with three warm controls each. Retained transcript totals were 1,025 and 8,193 rows, including bootstrap events. This run lowered deletion time at 1,024 messages and changed it little at 8,192. Earlier observations remain relevant: [the prior integrated run](https://github.com/openclaw/openclaw/actions/runs/34152967838) had slower deletion at 1,024 (460.7 → 560.9 ms) and noisier candidate warm controls, and [the pre-rebase run](https://github.com/openclaw/openclaw/actions/runs/34148034847) had slower candidate deletion at both warm shapes (496.5 → 540.8 ms and 404.2 → 444.6 ms). All raw observations are retained. The consistent demonstrated benefit is overlapping edit progress; these samples do not establish a general deletion speedup. No production CPU attribution, latency SLO, or sustained deployment acceptance is claimed.

Production: **+564/−261 lines (net +303)**. Tests: **+652/−55 (net +597)**. Documentation: **+6**. Production growth carries staged parent/Worker permits, failure cleanup and exit ownership. Existing async admission is extracted into a shared database owner, and the one-shot Worker architecture is retained. Private probe and review artifacts are outside this PR.

ClawSweeper’s review of `a91576bde6d` accepted the integration and identified a real in-process sibling regression: cold database opening could repair an index, acquire a durable lease and cache a writer before a revoked caller reached the transaction guard. This follow-up restores the pre-open check inside writer admission while retaining the later guard. An unchanged real cold-handle test passes its allowed case and reproduces those three forbidden effects on `a91576bde6d`; after the correction both allowed and revoked cases pass. Read-only final observation confirms exact session/transcript preservation and no writer, lease or index repair after rejection. The test adds no production hook. All prior timing and deletion qualifications remain explicit.
