### PR TITLE
refactor(sessions): reuse transcript page limit normalization

### DIFF
--- a/src/config/sessions/session-accessor.sqlite-delta.ts
+++ b/src/config/sessions/session-accessor.sqlite-delta.ts
@@ -16,6 +16,7 @@ import {
   resolveSqliteTranscriptReadScope,
   toDatabaseOptions,
 } from "./session-accessor.sqlite-scope.js";
+import { normalizeVisibleMessageLimit } from "./session-accessor.sqlite-visible-cursor.js";
 import {
   resolveSqliteSessionTranscriptReadFence,
   SessionTranscriptReadFenceError,
@@ -38,19 +39,6 @@ type RawTranscriptCursor = {
 type SessionTranscriptRawDeltaPage = Extract<SessionTranscriptRawDeltaResult, { kind: "page" }>;
 
 type ResolvedTranscriptReadScope = ReturnType<typeof resolveSqliteTranscriptReadScope>;
-
-function normalizeRawDeltaLimit(
-  value: number | undefined,
-  fallback: number,
-  maximum: number,
-  name: string,
-): number {
-  const resolved = value ?? fallback;
-  if (!Number.isInteger(resolved) || resolved < 1 || resolved > maximum) {
-    throw new RangeError(`${name} must be an integer between 1 and ${String(maximum)}`);
-  }
-  return resolved;
-}
 
 function encodeRawTranscriptCursor(cursor: RawTranscriptCursor): string {
   return Buffer.from(JSON.stringify(cursor), "utf8").toString("base64url");
@@ -109,13 +97,13 @@ export function readTranscriptRawDelta(
   limits: SessionTranscriptRawDeltaLimits = {},
 ): SessionTranscriptRawDeltaResult {
   const resolved = resolveSqliteTranscriptReadScope(scope);
-  const maxEvents = normalizeRawDeltaLimit(
+  const maxEvents = normalizeVisibleMessageLimit(
     limits.maxEvents,
     DEFAULT_RAW_TRANSCRIPT_MAX_EVENTS,
     MAX_RAW_TRANSCRIPT_EVENTS,
     "maxEvents",
   );
-  const maxBytes = normalizeRawDeltaLimit(
+  const maxBytes = normalizeVisibleMessageLimit(
     limits.maxBytes,
     DEFAULT_RAW_TRANSCRIPT_MAX_BYTES,
     MAX_RAW_TRANSCRIPT_BYTES,


### PR DESCRIPTION
## What Problem This Solves

Raw and visible transcript paging enforce the same count and byte-limit contract through duplicate normalizers. This maintainer-requested cleanup removes one place where those limits could drift during future maintenance.

## Why This Change Was Made

Reuse the existing internal `normalizeVisibleMessageLimit` for both raw-delta limits and delete the identical private implementation. The one-file change removes 12 net production lines without adding a helper, export, public SDK surface, or dependency. Defaults, caps, validation errors, getter evaluation order, cursors, read fences, and database ownership remain unchanged.

## User Impact

No user-visible behavior change. Raw transcript pages retain their existing 1,000-event and 1,000,000-byte defaults, with caps of 10,000 events and 64 MiB.

## Evidence

- The five selected suites passed through `node scripts/run-vitest.mjs`: `session-transcript-runtime.test.ts` (24), `session-transcript-runtime-visible-delta.test.ts` (3), `session-transcript-runtime.read-fence.test.ts` (2), `session-accessor.sqlite-byte-size.test.ts` (13), and `session-accessor.sqlite-history-events.test.ts` (7). Total: 49 tests, covering paging, replacement, oversized-payload exclusion, scope, read fences, and history consistency against isolated SQLite state.
- The first test invocation stopped before executing tests because the sparse worktree lacked package-local dependency links. Linking the existing installed dependencies resolved the loading failure; no install or tracked dependency change was made.
- AST comparison confirmed identical normalizer bodies and signatures, unchanged surrounding statements and call arguments, and zero imports in the reused helper module.
- Changed-file formatting, targeted oxlint, `git diff --check`, and fresh independent autoreview through P2 passed with no actionable findings.
- `check-changed` passed conflict, max-lines, assertion-safety, attribution, deprecation, wildcard-export, duplicate-coverage, dependency, formatting, plugin-boundary, wrapper, patch, and core-graph guards. It then stopped at the local typechecker containment guard because the worktree uses an external shared compiler install. No local typecheck or aggregate changed-gate pass is claimed; later gates were not run by that command.
- [Exact-head CI run 34151083519](https://github.com/openclaw/openclaw/actions/runs/34151083519) completed successfully on `50717e92f4d9f94e0d41a71351f463f962e49f4c`: 109 jobs passed, 16 skipped, zero failed. The required `openclaw/ci-gate`, production typecheck, test typecheck, and both core test-typecheck jobs passed. These hosted results are separate from the 49 focused local tests above; aggregate green CI does not claim that every selected local suite ran remotely.
- Native Testbox validation accepted that hosted evidence. No live provider run or credentialed Crabbox lease was used, and the local compiler containment guard was not bypassed.
- Native review/prepare/merge landed the unchanged PR head as squash commit [69faebcd4b9](https://github.com/openclaw/openclaw/commit/69faebcd4b9b447cb3390e3ba6388320acff5ae4), without a rebase or new PR push. The native receipt is complete, and both the changed file and reused-helper blobs match the reviewed head in the landed commit and checked current `main`.
- Native merge verification warned about intervening release/publication infrastructure changes and proceeded under its existing policy. The target and helper were revalidated as unchanged before merging; no guard settings were changed. ClawSweeper's exact-head review reported no actionable findings.

Direct invalid-limit matrices and getter-order cases are not separately covered by the selected tests. This refactor preserves the existing validation statements and call positions; it does not add implementation-mirroring tests.
