### PR TITLE
fix(ollama): reject embedding-only chat setup

### DIFF
--- a/docs/providers/ollama.md
+++ b/docs/providers/ollama.md
@@ -98,6 +98,12 @@ OpenAI-SDK-style examples, but new config should use `baseUrl`.
 
     `--custom-base-url` and `--custom-model-id` are optional; omitting them uses the local default host and the `gemma4` suggested model.
 
+    A local model advertised as embedding-only cannot be selected as the chat
+    default. Setup reports an error and leaves the existing configuration intact;
+    reset preflight also rejects an explicitly selected embedding-only model or
+    an inventory advertised as entirely embedding-only. Models that support both
+    completion and embeddings remain eligible.
+
   </Tab>
 
   <Tab title="Manual setup">

--- a/extensions/ollama/index.test.ts
+++ b/extensions/ollama/index.test.ts
@@ -465,6 +465,41 @@ describe("ollama plugin", () => {
       models: ["qwen2.5-coder:7b"],
     },
     {
+      name: "rejects an explicitly selected embedding-only model before reset",
+      models: ["embedding-model"],
+      customModelId: "embedding-model",
+      capabilities: ["embedding"],
+      omitListedCapabilities: true,
+      error: "Ollama model embedding-model only supports embeddings. Choose a chat model instead.",
+    },
+    {
+      name: "retains known embedding-only metadata when inspection is unavailable",
+      models: ["embedding-model"],
+      customModelId: "embedding-model",
+      capabilities: ["embedding"],
+      inspectionFailed: true,
+      error: "Ollama model embedding-model only supports embeddings. Choose a chat model instead.",
+    },
+    {
+      name: "keeps legacy model selection when capability metadata is unavailable",
+      models: ["legacy-model"],
+      customModelId: "legacy-model",
+      inspectionFailed: true,
+    },
+    {
+      name: "rejects an inventory known to contain only embedding models before reset",
+      models: ["embedding-model"],
+      capabilities: ["embedding"],
+      error:
+        "No Ollama chat models are available at http://ollama-host:11434.\nPull a chat model first, then re-run setup.",
+    },
+    {
+      name: "accepts a model supporting both completion and embeddings before reset",
+      models: ["dual-model"],
+      customModelId: "dual-model",
+      capabilities: ["completion", "embedding"],
+    },
+    {
       name: "refuses to pull an unavailable local model during destructive-reset preflight",
       models: [],
       customModelId: "gemma4",
@@ -512,13 +547,36 @@ describe("ollama plugin", () => {
     reachable?: boolean;
     customBaseUrl?: string;
     customModelId?: string;
+    capabilities?: string[];
+    omitListedCapabilities?: boolean;
+    inspectionFailed?: boolean;
     cloud?: "confirmed" | "unauthenticated" | "unconfirmed";
     error?: string;
-  }>)("$name", async ({ models, reachable = true, customBaseUrl, customModelId, cloud, error }) => {
+  }>)("$name", async (testCase) => {
+    const {
+      models,
+      reachable = true,
+      customBaseUrl,
+      customModelId,
+      capabilities,
+      omitListedCapabilities,
+      inspectionFailed,
+      cloud,
+      error,
+    } = testCase;
     fetchOllamaModelsMock.mockResolvedValue({
       reachable,
-      models: models.map((name) => ({ name })),
+      models: models.map((name) => ({
+        name,
+        capabilities: omitListedCapabilities ? undefined : capabilities,
+      })),
     });
+    if (capabilities) {
+      queryOllamaModelShowInfoMock.mockResolvedValue({ capabilities });
+    }
+    if (inspectionFailed) {
+      queryOllamaModelShowInfoMock.mockResolvedValue({ showInspectionFailed: true });
+    }
     if (cloud === "unauthenticated") {
       fetchWithSsrFGuardMock.mockResolvedValue({
         response: new Response(JSON.stringify({ signin_url: "https://ollama.com/signin" }), {

--- a/extensions/ollama/src/setup.non-interactive-auth.test.ts
+++ b/extensions/ollama/src/setup.non-interactive-auth.test.ts
@@ -78,6 +78,32 @@ describe("Ollama non-interactive onboarding", () => {
     upsertAuthProfileWithLock.mockClear();
   });
 
+  it.each([{ capabilities: ["embedding"] }, { capabilities: ["embedding", "tools"] }])(
+    "rejects an explicitly selected embedding-only model with capabilities $capabilities",
+    async ({ capabilities }) => {
+      vi.stubGlobal(
+        "fetch",
+        createOllamaFetchMock({
+          tags: ["embedding-model"],
+          capabilities: { "embedding-model": capabilities },
+        }),
+      );
+      const runtime = createRuntime();
+      const nextConfig = { agents: { defaults: { model: { primary: "ollama/qwen3:1.7b" } } } };
+      const result = await configureOllamaNonInteractive({
+        nextConfig,
+        opts: { customBaseUrl: "http://127.0.0.1:11434", customModelId: "embedding-model" },
+        runtime,
+      });
+      expect(result).toBe(nextConfig);
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+      expect(runtime.error).toHaveBeenCalledWith(
+        "Ollama model embedding-model only supports embeddings. Choose a chat model instead.",
+      );
+      expect(upsertAuthProfileWithLock).not.toHaveBeenCalled();
+    },
+  );
+
   it.each([
     {
       label: "Ollama reports a pull failure",
@@ -171,7 +197,10 @@ describe("Ollama non-interactive onboarding", () => {
   });
 
   it("persists only installed local models when selecting a discovered custom model", async () => {
-    const fetchMock = createOllamaFetchMock({ tags: ["qwen3:1.7b"] });
+    const fetchMock = createOllamaFetchMock({
+      tags: ["qwen3:1.7b"],
+      capabilities: { "qwen3:1.7b": ["completion", "embedding"] },
+    });
     vi.stubGlobal("fetch", fetchMock);
     const runtime = createRuntime();
 

--- a/extensions/ollama/src/setup.runtime.ts
+++ b/extensions/ollama/src/setup.runtime.ts
@@ -501,9 +501,28 @@ export async function validateOllamaNonInteractive(
       `No Ollama models are available at ${baseUrl}.\nPull a model first, then re-run setup.`,
     );
   }
-  if (requestedModel && !findAvailableOllamaModelName(requestedModel, availableModelNames)) {
+  if (requestedModel) {
+    const availableName = findAvailableOllamaModelName(requestedModel, availableModelNames);
+    if (!availableName) {
+      return fail(
+        `Ollama model ${requestedModel} was not found at ${baseUrl}.\nAvailable models: ${availableModelNames.join(", ")}`,
+      );
+    }
+    const listedModel = discovery.models.find((model) => model.name === availableName);
+    const inspectedModel = await queryOllamaModelShowInfo(baseUrl, availableName);
+    if (
+      isOllamaEmbeddingOnlyModel({
+        name: availableName,
+        capabilities: inspectedModel.capabilities ?? listedModel?.capabilities,
+      })
+    ) {
+      return fail(
+        `Ollama model ${availableName} only supports embeddings. Choose a chat model instead.`,
+      );
+    }
+  } else if (discovery.models.every(isOllamaEmbeddingOnlyModel)) {
     return fail(
-      `Ollama model ${requestedModel} was not found at ${baseUrl}.\nAvailable models: ${availableModelNames.join(", ")}`,
+      `No Ollama chat models are available at ${baseUrl}.\nPull a chat model first, then re-run setup.`,
     );
   }
   return true;
@@ -619,7 +638,14 @@ export async function configureOllamaNonInteractive(params: {
   }
 
   if (!requestedCloudModel) {
-    await inspectAvailableModel(defaultModelId);
+    const selectedModel = await inspectAvailableModel(defaultModelId);
+    if (isOllamaEmbeddingOnlyModel(selectedModel)) {
+      params.runtime.error(
+        `Ollama model ${defaultModelId} only supports embeddings. Choose a chat model instead.`,
+      );
+      params.runtime.exit(1);
+      return params.nextConfig;
+    }
   }
 
   const config = applyOllamaProviderConfig(


### PR DESCRIPTION
Closes #141424.

## What Problem This Solves

Non-interactive Ollama setup can select an embedding-only model as the agent's chat default and report success, even though the server rejects every chat request for that model. Reset validation also accepts the explicit invalid choice or an inventory advertised as entirely embedding-only.

## Why This Change Was Made

Reuse the existing embedding-only capability predicate before configuration application and reset. Inspect an explicitly selected installed model using its canonical name, prefer authoritative model metadata, and retain list metadata if inspection is unavailable. Missing capability metadata remains compatible with older servers; models advertising both completion and embeddings remain eligible.

## User Impact

Invalid local chat selections stop with an actionable error before setup changes the configuration. Existing chat selections, cloud checks, model aliases and failed-download fallback behavior are preserved.

## Evidence

- Four regressions fail on the original source for the invalid choices. Final setup/registration suites pass 182 tests, and the onboarding ingress suite passes 95 tests.
- Real isolated Ollama 0.33.3: all-minilm:22m reports embedding-only, chat returns HTTP 400, embeddings return HTTP 200 with 384 dimensions. Patched production setup and reset-validation owners reject it; synthetic configuration remains unchanged. A real qwen3:0.6b positive control validates, selects and completes chat with HTTP 200.
- Full changed-code checks passed, including production/test typechecks, formatting, lint, unused-export analysis and repository guards. Independent P2 review found no actionable findings.
- Both test daemons and model runners stopped; ports are closed. Live proof exercised the production provider owners with real servers, without running a destructive reset or writing operator configuration.
