### PR TITLE
docs: explain public session sharing

### DIFF
--- a/docs/concepts/multi-user.md
+++ b/docs/concepts/multi-user.md
@@ -18,6 +18,22 @@ If people must not access each other's sessions, tools, credentials, or files, g
 
 An authenticated Control UI administrator with `operator.admin` can [manage any automation conversationally](/automation/cron-jobs#conversational-management) on that Gateway, including jobs created from another channel or by another person. This authority comes from the admitted administrator turn, without matching channel identities to Gateway profiles. It does not transfer the job's creator attribution or scheduled execution policy.
 
+## World-readable session links
+
+Authenticated teammate visibility and public transcript access are separate.
+Changing a session between **Shared**, **Read-only**, **Suggest**, and **Draft**
+controls signed-in collaborators; none of those settings creates a public link.
+
+The session creator or a Gateway admin can explicitly enable **Public access**.
+Anyone with the resulting bearer URL can then read existing and future conversation
+text without signing in, while tools, reasoning, files, images, widgets, hidden
+messages, and internal metadata remain excluded. Assigning a different owner does
+not transfer this authority. Disable public access to revoke every URL for that
+publication, remembering that downloaded copies cannot be recalled. See
+[Share a session publicly](/web/control-ui/sessions-and-sidebar#share-a-session-publicly)
+for the user flow and [Public session transcripts](/web/urls#public-session-transcripts)
+for the security and deployment contract.
+
 ## The three ownership layers
 
 Every session carries up to three layers of attribution:

--- a/docs/web/control-ui/security-model.md
+++ b/docs/web/control-ui/security-model.md
@@ -1,7 +1,8 @@
 ---
-summary: "Content security policy, authenticated media routes, and approval links"
+summary: "Content security policy, public transcript boundaries, authenticated media routes, and approval links"
 read_when:
   - Reviewing Control UI browser security
+  - Exposing public session links through a login proxy
   - Debugging a blocked avatar or assistant media request
   - Forwarding an approval link
 title: "Security model"
@@ -26,6 +27,26 @@ In practice:
 - Remote avatar URLs emitted by channel metadata are stripped at the Control UI's avatar helpers and replaced with the built-in logo/badge, so a compromised or malicious channel cannot force arbitrary remote image fetches from an operator browser.
 
 The browser-side CSP restriction itself is always on and not configurable.
+
+## Public transcript boundary
+
+The authenticated Control UI does not become public when a session is published.
+Public transcript links use the dedicated `/share/session?token=<opaque>` route;
+the encrypted token is the read capability and does not reveal the agent, session
+key, session ID, or publication ID. Anonymous visitors cannot use it to connect
+to the Gateway, send messages, invoke tools, or open other Control UI routes.
+
+The public renderer reads only user messages and assistant final-answer text.
+It omits tools, reasoning, files, images, widgets, hidden messages, and internal
+metadata, and applies credential-pattern redaction. Responses use a restrictive
+content security policy, `Cache-Control: no-store`, and `Referrer-Policy: no-referrer`.
+Treat the complete URL as public: anyone who receives it can read existing and
+future published text until the creator or a Gateway admin disables access.
+
+When a login proxy protects the host, bypass authentication only for the Control
+UI's `/share/*` namespace. Keep the WebSocket, bootstrap, API, dashboard, and all
+other routes protected. The detailed deployment, token, revocation, and restore
+contract is in [Public session transcripts](/web/urls#public-session-transcripts).
 
 ## Avatar route auth
 

--- a/docs/web/control-ui/sessions-and-sidebar.md
+++ b/docs/web/control-ui/sessions-and-sidebar.md
@@ -2,6 +2,7 @@
 summary: "Sidebar zones, session menus, and the New session page"
 read_when:
   - Finding, grouping, or renaming sessions
+  - Sharing a session with teammates or through a public read-only link
   - Starting a session on a device, worktree, or cloud profile
   - Starting a native Codex or Claude Code terminal
 title: "Sessions and sidebar"
@@ -89,7 +90,23 @@ The menu groups routine actions first: **Pin/Unpin**, **Rename**, **Mark as unre
 - **Move to group** includes **New group** and **Remove from group**. Multi-user gateways also offer **Assign to** ([session ownership](/concepts/multi-user#assigning-an-owner)).
 - **Fork conversation** creates a separate conversation; while a run is active, it forks from the last completed message.
 - **Copy** offers a session link, conversation text as Markdown, and the session ID. The link requires normal Gateway authentication and session access; copying it does not grant access. Markdown loads the available conversation history, not just the messages currently visible. Both copied Markdown and `/export` downloads retain the conversation's sender labels, so messages from different participants remain distinguishable.
+- The chat header's **Session sharing** control manages authenticated teammate visibility and membership. For a saved, non-incognito session, its creator or a Gateway admin can also enable world-readable, read-only public access.
 - **Open in** offers a new browser tab or window. Desktop chat also offers **Split right** and **Split below**. Eligible local workspaces expose native editor destinations, and the chat header includes **Continue in terminal** in this submenu.
+
+### Share a session publicly
+
+1. Open the saved session and select **Session sharing** in the chat header. In the compact header menu, select **Session sharing** there instead.
+2. Under **Public access**, select **Enable public access…**, review the warning, then select **Make public**.
+3. Select **Copy public link**. The **Public** badge in the chat header remains visible while the transcript is published.
+4. Open the copied URL in a signed-out browser to verify that it shows the intended conversation text. New user messages and assistant final answers become visible there automatically.
+5. Return to **Session sharing** and select **Disable public access** when the link should stop working. The same URL then returns an unavailable page; disabling access cannot recall copies that recipients already saved.
+
+The public page excludes tools, reasoning, files, images, widgets, hidden messages,
+and internal metadata. Credential-pattern redaction is best effort, so review the
+conversation itself before publishing. Public access does not let visitors send
+messages or open the authenticated Control UI. For token lifecycle, pagination,
+backup behavior, and login-proxy configuration, see
+[Public session transcripts](/web/urls#public-session-transcripts).
 
 ### Session placement
 

--- a/docs/web/urls.md
+++ b/docs/web/urls.md
@@ -2,6 +2,8 @@
 summary: "Control UI routes, focus presentations, stable session links, and connection handoff parameters"
 read_when:
   - You need to bookmark or share a Control UI session
+  - You need to publish or revoke a world-readable session transcript
+  - You run the Control UI behind a login proxy and need social previews to unfurl
   - You are adding or changing a Control UI route
   - You need a terminal, desktop, approval, onboarding, or remote Gateway URL
 title: "Control UI URLs"
@@ -196,11 +198,17 @@ access from this feature.
 
 ## Public session transcripts
 
-Session owners and Gateway admins can open the session's sharing menu and select
+Session creators and Gateway admins can open the session's sharing menu and select
 **Public access → Enable public access**. Confirming publishes the session's
 existing and future conversation text to anyone with its public URL. Recipients
 do not need an account or Gateway credentials. **Copy public link** copies that
-URL; **Disable public access** revokes it.
+URL; **Disable public access** revokes it. The chat header shows **Public** while
+access is enabled.
+
+Assigning another owner does not transfer public-sharing authority. If the public
+controls are unavailable, confirm that the session is saved, is not incognito,
+and you are its creator or a Gateway admin. See
+[Multi-user mode](/concepts/multi-user#world-readable-session-links).
 
 Public access is separate from teammate visibility and editing permissions.
 Publishing does not let anonymous visitors send messages, invoke tools, open


### PR DESCRIPTION
## What Problem This Solves

Users could find the full public-session contract only under Control UI URL documentation. The session-menu guide and security/multi-user pages did not show the publishing workflow, and the reference described an assigned session owner as having publication authority even though that authority remains with the creator.

## Why This Change Was Made

This adds a task-oriented publish, verify, and revoke guide at the session menu; documents the anonymous renderer and login-proxy security boundary; distinguishes authenticated teammate visibility from world-readable links; and links each entry point back to the canonical URL and token contract.

## User Impact

Session creators and Gateway administrators can now find the exact public-sharing workflow from the Control UI docs, understand what becomes visible, verify a link while signed out, and revoke it safely. Assigned owners are no longer told they inherit publication authority.

## Evidence

- `pnpm docs:check-mdx`
- `pnpm docs:check-links` — 9,046 internal links, zero broken
- `pnpm docs:check-i18n-glossary`
- `pnpm format:docs:check`
- `pnpm docs:list --headings`
- `git diff --check`
- Independent autoreview through P2: no findings
