### PR TITLE
improve(agents): steer sessions_spawn collect toward large fan-out

### DIFF
--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -76,7 +76,8 @@ completion path described in the accepted receipt:
 - Ordinary announcing runs return an internal completion event to the requester,
   which reviews the result and decides whether a user-facing update is needed.
 - [Swarm collectors](/tools/swarm) return results through explicit collection,
-  not completion notifications.
+  not completion notifications; reserve them for large parallel fan-out (several
+  similar children, about five or more), and use ordinary spawns for one or a few.
 - Thread-bound session runs with a deliverable bound route reply directly to that
   thread, without a separate parent announcement.
 - Caller-managed quiet runs send no completion notification.

--- a/docs/tools/swarm.md
+++ b/docs/tools/swarm.md
@@ -18,6 +18,15 @@ There is no graph DSL and no separate workflow format. The program is the
 orchestration. Swarm adds awaitable collector children, structured results,
 bounded concurrency, and progress reporting to that program.
 
+## When to use Swarm
+
+Use ordinary `sessions_spawn` announcing runs for one or a few children. Reserve
+Swarm for large parallel fan-out: several similar children (about five or more),
+typically driven by Code Mode `agents.run` with control flow such as `Promise.all`.
+Collectors (`collect: true`) send no completion notification and cannot be steered;
+their results must be explicitly collected. Use `outputSchema` for structured
+results and `groupId` to group a batch.
+
 ## Enable Swarm
 
 Swarm needs no enablement setting. Omitted `tools.swarm`, an empty object, or

--- a/src/agents/code-mode-namespaces.ts
+++ b/src/agents/code-mode-namespaces.ts
@@ -451,7 +451,7 @@ interface AgentRunOptions {
 }
 
 interface AgentsApi {
-  /** Child failures have name "SwarmAgentError", runId, status, and message; SwarmAgentError is not a global constructor. */
+  /** Reserve agents.run fan-out for batches; a single child uses sessions_spawn directly (announcing run). Child failures have name "SwarmAgentError", runId, status, and message; SwarmAgentError is not a global constructor. */
   run(prompt: string, options?: AgentRunOptions & { schema?: undefined }): Promise<string>;
   run<T>(prompt: string, options: AgentRunOptions & { schema: AgentJsonSchema }): Promise<T>;
 }

--- a/src/agents/subagents/spawn/subagent-spawn-request.ts
+++ b/src/agents/subagents/spawn/subagent-spawn-request.ts
@@ -46,6 +46,7 @@ type ResolvedSubagentSpawnRequest = {
     groupId?: string;
     schedulerGroupKey?: string;
     launchReplayKey?: string;
+    soleImplicitMember: boolean;
     reservationPending: boolean;
   };
   admission: {
@@ -270,8 +271,10 @@ export function resolveSubagentSpawnRequest(
         .slice(0, 32)}`
     : crypto.randomUUID();
   let reservationPending = false;
+  let soleImplicitMember = false;
   if (params.collect && swarmGroupId && swarmSchedulerGroupKey) {
     const groupRuns = listSwarmRunsForGroup(swarmGroupId, requesterInternalKey, requesterAgentId);
+    soleImplicitMember = !explicitSwarmGroupId && !swarmLaunchReplayKey && groupRuns.length === 0;
     // Swarm reservation can reconcile existing lane state even when it rejects a duplicate.
     ctx.onSpawnEffectsStart?.();
     if (
@@ -318,6 +321,7 @@ export function resolveSubagentSpawnRequest(
         groupId: swarmGroupId,
         schedulerGroupKey: swarmSchedulerGroupKey,
         launchReplayKey: swarmLaunchReplayKey,
+        soleImplicitMember,
         reservationPending,
       },
       admission: {

--- a/src/agents/subagents/spawn/subagent-spawn.test.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.test.ts
@@ -461,6 +461,9 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(result.status).toBe("accepted");
     expect(result.sessionKey).toBe(result.childSessionKey);
     expect(result.expectsCompletionMessage).toBe(false);
+    expect(result.note).toContain(
+      "This is the only collector child in its group so far; unless more parallel children follow, an ordinary spawn (omit collect) is simpler and can be steered.",
+    );
     const registerInput = firstRegisteredSubagentRun();
     expect(registerInput).toMatchObject({
       runId: result.runId,
@@ -501,6 +504,39 @@ describe("spawnSubagentDirect seam flow", () => {
     expect(agentParams.extraSystemPrompt).toContain("at most one retry");
     await vi.waitFor(() =>
       expect(hoisted.startQueuedSubagentRunMock).toHaveBeenCalledWith(result.runId, "run-1"),
+    );
+
+    hoisted.listSwarmRunsForGroupMock.mockReturnValue([
+      { ...registerInput, execution: { status: "running" } },
+    ]);
+    const second = await spawnSubagentDirect(
+      { task: "collect parallel evidence", collect: true },
+      { agentSessionKey: "agent:main:main", requesterRunId: "parent-run" },
+    );
+    expect(second.status).toBe("accepted");
+    expect(second.note).toBe(
+      "Collector run: no completion notification is sent. The requester must explicitly collect this run's result with the available collector wait capability, using its run id.",
+    );
+  });
+
+  it.each([
+    { name: "explicit group", params: { collect: true, groupId: "chosen-group" } },
+    {
+      name: "Code Mode implicit group",
+      params: { collect: true, swarmLaunchReplayKey: "cm-receipt:bridge:1" },
+    },
+    { name: "ordinary spawn", params: { collect: false } },
+  ])("keeps the existing receipt for $name", async ({ params }) => {
+    hoisted.configOverride = createConfigOverride({ tools: { swarm: true } });
+    const result = await spawnSubagentDirect(
+      { task: "receipt guidance", ...params },
+      { agentSessionKey: "agent:main:main", requesterRunId: "parent-run" },
+    );
+    expect(result.status).toBe("accepted");
+    expect(result.note).toBe(
+      params.collect
+        ? "Collector run: no completion notification is sent. The requester must explicitly collect this run's result with the available collector wait capability, using its run id."
+        : "The final reply returns to the requester as a completion event. Continue any independent work. Wait for completion events for ALL required children before your final answer; never busy-poll. If a completion arrives after your final answer, reply ONLY with NO_REPLY.",
     );
   });
 

--- a/src/agents/subagents/spawn/subagent-spawn.ts
+++ b/src/agents/subagents/spawn/subagent-spawn.ts
@@ -115,6 +115,7 @@ export async function spawnSubagentDirect(
       groupId: swarmGroupId,
       schedulerGroupKey: swarmSchedulerGroupKey,
       launchReplayKey: swarmLaunchReplayKey,
+      soleImplicitMember,
       reservationPending,
     },
     admission: {
@@ -268,6 +269,7 @@ export async function spawnSubagentDirect(
           : "quiet";
     const envelope = buildSubagentSpawnEnvelope({
       completionMode,
+      soleCollectorChild: soleImplicitMember,
       spawnMode,
       task,
       requesterSessionKey,

--- a/src/agents/subagents/spawn/subagent-system-prompt.test.ts
+++ b/src/agents/subagents/spawn/subagent-system-prompt.test.ts
@@ -35,6 +35,16 @@ describe("subagent spawn envelope", () => {
       expect(`${systemPrompt}\n${message}`.match(/UNIQUE_SUBAGENT_TASK/g)).toHaveLength(1);
       expect(systemPrompt).toMatch(/\[Subagent Task\].*current child session/);
       expect(systemPrompt).toMatch(/inherited task envelopes.*background reference/);
+      const soleChild = buildEnvelope({ completionMode, soleCollectorChild: true });
+      expect(soleChild.systemPrompt).toBe(systemPrompt);
+      expect(soleChild.message).toBe(message);
+      if (completionMode === "collector") {
+        expect(soleChild.acceptedNote).toBe(
+          `${acceptedNote} This is the only collector child in its group so far; unless more parallel children follow, an ordinary spawn (omit collect) is simpler and can be steered.`,
+        );
+      } else {
+        expect(soleChild.acceptedNote).toBe(acceptedNote);
+      }
     },
   );
 

--- a/src/agents/subagents/spawn/subagent-system-prompt.ts
+++ b/src/agents/subagents/spawn/subagent-system-prompt.ts
@@ -20,6 +20,7 @@ const COMPLETION_NOTES = {
 
 export function buildSubagentSpawnEnvelope(params: {
   completionMode: SubagentCompletionMode;
+  soleCollectorChild?: boolean;
   spawnMode: "run" | "session";
   task: string;
   requesterSessionKey?: string;
@@ -128,6 +129,9 @@ export function buildSubagentSpawnEnvelope(params: {
       ? undefined
       : [
           completionNote,
+          params.completionMode === "collector" && params.soleCollectorChild
+            ? "This is the only collector child in its group so far; unless more parallel children follow, an ordinary spawn (omit collect) is simpler and can be steered."
+            : undefined,
           params.completionMode === "announce"
             ? "Continue any independent work. Wait for completion events for ALL required children before your final answer; never busy-poll. If a completion arrives after your final answer, reply ONLY with NO_REPLY."
             : undefined,

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -116,7 +116,7 @@ export function describeSubagentSpawnContext(threadAvailable: boolean): string {
 }
 
 export const SESSIONS_SPAWN_COLLECTOR_GUIDANCE =
-  "`collect=true` (swarm): parallel fan-out collector children with no completion notification; explicitly collect their results; structured result per `outputSchema`; `groupId` groups a batch.";
+  "Default to ordinary spawn for one or a few children. Reserve `collect=true` (swarm) for large parallel fan-out (several similar children, about five or more). Collectors send no completion notification and cannot be steered; explicitly collect their results; structured result per `outputSchema`; `groupId` groups a batch.";
 
 /** Describes the sessions_spawn tool for model-facing instructions. */
 export function describeSessionsSpawnTool(options?: {

--- a/src/agents/tools/sessions-spawn-tool.ts
+++ b/src/agents/tools/sessions-spawn-tool.ts
@@ -239,7 +239,7 @@ function createSessionsSpawnToolSchema(params: {
           collect: Type.Optional(
             Type.Boolean({
               description:
-                "Swarm collector child for parallel fan-out; no completion notification.",
+                "Swarm collector child for large parallel fan-out, not one or a few children; no completion notification.",
             }),
           ),
           outputSchema: Type.Optional(


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where an agent asked to do one bounded task spawned a single helper with `sessions_spawn collect=true`, turning it into a Swarm collector. The chat then showed a "Parallel tasks" progress card for one child, the parent could not steer the child (`sessions_send` is refused for active collectors), and it had to poll with `agents_wait` instead of receiving a completion event. Swarm is designed for large parallel fan-out, but nothing the model saw said so.

## Why This Change Was Made

The only model-facing text about `collect` was one neutral sentence that presented collectors as an equal alternative to ordinary spawns. This change makes the intended split explicit everywhere the model reads it: the shared `sessions_spawn` guidance and the `collect` parameter description now say ordinary spawn is the default for one or a few children and reserve `collect=true` for several parallel children (about five or more), noting that collectors send no completion notification and cannot be steered. The Code Mode `agents.run` typing carries the same steer, and the Swarm and sub-agent docs gain a short "When to use Swarm" section. As a runtime-free safety net, the accepted spawn receipt adds one sentence when a collector is spawned directly into an implicit group that has no other members yet, so the model reconsiders at the moment it matters. The nudge is skipped for explicit `groupId` batches and for Code Mode `agents.run` launches, which are the intended fan-out paths, and it never rejects the spawn.

## User Impact

Agents keep using ordinary, steerable sub-agents for single or small delegations, so operators see normal sub-agent rows and completion handoffs instead of a one-child Swarm card. Swarm behavior, limits, and results are unchanged for real parallel batches.

## Evidence

- Receipt note for a sole direct collector (new): the existing collector note followed by "This is the only collector child in its group so far; unless more parallel children follow, an ordinary spawn (omit collect) is simpler and can be steered." Tests cover the nudge and each exclusion: a second collector in the same implicit group, an explicit `groupId`, a Code Mode launch, and non-collector spawns.
- `node scripts/run-vitest.mjs src/agents/subagents/spawn/subagent-spawn.test.ts src/agents/subagents/spawn/subagent-system-prompt.test.ts src/agents/tools/sessions-spawn-tool.test.ts src/agents/tool-description-presets.test.ts`: 4 files, 249 tests passed. The Swarm wait-guidance string contract (`agents_wait` suffix replacement and strip) is covered by the existing tests and still passes.
- `pnpm check:changed`: passed.
- Independent code review: clean at P2.

## Known Gaps

Guidance steers the model; it does not prevent a deliberate single-collector spawn. A first child of a genuine multi-child fan-out spawned directly (not via `agents.run` or `groupId`) also receives the nudge, which is acceptable since the sentence is conditional.
