### PR TITLE
fix(lmstudio): reload evicted embedding models

### DIFF
--- a/docs/providers/lmstudio.md
+++ b/docs/providers/lmstudio.md
@@ -153,6 +153,9 @@ enough context for the selected model budget. A newly loaded instance is address
 identifier returned by LM Studio. Your configured model reference and conversation model identity
 keep the canonical model key.
 
+With preload enabled, embedding requests also check that their model is loaded. This lets memory
+embeddings recover after model eviction even when LM Studio JIT loading is disabled.
+
 ### Disabling preload
 
 LM Studio supports just-in-time (JIT) model loading, loading models on first request. OpenClaw

--- a/extensions/lmstudio/src/embedding-provider.integration.test.ts
+++ b/extensions/lmstudio/src/embedding-provider.integration.test.ts
@@ -102,3 +102,163 @@ describe("LM Studio embedding request headers", () => {
     }
   });
 });
+
+it.each(["single", "documents", "queries", "cancelled"] as const)(
+  "reloads evicted embedding models before %s requests while holding the service lease",
+  async (kind) => {
+    vi.stubEnv("NO_PROXY", "127.0.0.1");
+    vi.stubEnv("no_proxy", "127.0.0.1");
+    let holdLoad = false;
+    let signalLoadStarted: () => void = () => {};
+    const loadStarted = new Promise<void>((resolve) => {
+      signalLoadStarted = resolve;
+    });
+    let loaded = false;
+    let leases = 0;
+    const requests: string[] = [];
+    const server = createServer((request, response) => {
+      let text = "";
+      request.on("data", (chunk: unknown) => {
+        if (!Buffer.isBuffer(chunk)) {
+          throw new Error("Expected request bytes");
+        }
+        text += chunk.toString("utf8");
+      });
+      request.once("end", () => {
+        requests.push(request.url ?? "");
+        expect(leases).toBeGreaterThan(0);
+        response.setHeader("content-type", "application/json");
+        if (request.url === "/api/v1/models") {
+          response.end(
+            JSON.stringify({
+              models: [
+                {
+                  key: "embedding-model",
+                  type: "embedding",
+                  max_context_length: 2048,
+                  loaded_instances: loaded
+                    ? [{ id: "embedding-model", config: { context_length: 2048 } }]
+                    : [],
+                },
+              ],
+            }),
+          );
+        } else if (request.url === "/api/v1/models/load") {
+          if (holdLoad) {
+            signalLoadStarted();
+            return;
+          }
+          loaded = true;
+          response.end(JSON.stringify({ status: "loaded", instance_id: "embedding-model" }));
+        } else if (request.url === "/v1/embeddings" && loaded) {
+          const body: unknown = JSON.parse(text);
+          if (
+            !body ||
+            typeof body !== "object" ||
+            !("model" in body) ||
+            !("input" in body) ||
+            !Array.isArray(body.input)
+          ) {
+            throw new Error("Invalid embedding request");
+          }
+          expect(body.model).toBe("embedding-model");
+          response.end(
+            JSON.stringify({ data: body.input.map((_, index) => ({ index, embedding: [1, 0] })) }),
+          );
+        } else {
+          response.statusCode = 400;
+          response.end(JSON.stringify({ error: "No models loaded" }));
+        }
+      });
+    });
+    server.listen(0, "127.0.0.1");
+    await once(server, "listening");
+    try {
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        throw new Error("Missing fixture address");
+      }
+      const { provider, client } = await createLmstudioEmbeddingProvider({
+        provider: "lmstudio",
+        model: "embedding-model",
+        fallback: "none",
+        remote: { apiKey: "lmstudio-local" },
+        config: {
+          models: {
+            providers: {
+              lmstudio: {
+                baseUrl: `http://127.0.0.1:${address.port}/v1`,
+                apiKey: "lmstudio-local",
+                localService: { command: "/usr/bin/lms" },
+                models: [],
+              },
+            },
+          },
+        },
+        acquireLocalService: async () => {
+          leases++;
+          return {
+            release: () => {
+              leases--;
+            },
+          };
+        },
+      });
+      expect(leases).toBe(0);
+      await expect(provider.embed("first")).resolves.toEqual([1, 0]);
+      loaded = false;
+      requests.length = 0;
+      if (kind === "cancelled") {
+        holdLoad = true;
+        const activeController = new AbortController();
+        const active = provider.embed("active", { signal: activeController.signal });
+        await loadStarted;
+        const queuedController = new AbortController();
+        const queued = provider.embed("queued", { signal: queuedController.signal });
+        await vi.waitFor(() => expect(leases).toBe(2));
+        queuedController.abort(new Error("cancelled while queued"));
+        await expect(queued).rejects.toThrow("cancelled while queued");
+        expect(leases).toBe(1);
+        expect(requests).toEqual(["/api/v1/models", "/api/v1/models/load"]);
+        const recovered = provider.embed("recovered");
+        holdLoad = false;
+        activeController.abort(new Error("cancelled active load"));
+        await expect(active).rejects.toThrow("cancelled active load");
+        await expect(recovered).resolves.toEqual([1, 0]);
+        expect(requests.filter((url) => url === "/v1/embeddings")).toHaveLength(1);
+      } else if (kind === "single") {
+        await expect(provider.embed("second")).resolves.toEqual([1, 0]);
+      } else {
+        await expect(
+          provider.embedBatch(["second", "third"], {
+            inputType: kind === "queries" ? "query" : "document",
+          }),
+        ).resolves.toEqual([
+          [1, 0],
+          [1, 0],
+        ]);
+      }
+      expect(requests.indexOf("/api/v1/models/load")).toBeGreaterThanOrEqual(0);
+      expect(requests.indexOf("/api/v1/models/load")).toBeLessThan(
+        requests.indexOf("/v1/embeddings"),
+      );
+      expect(leases).toBe(0);
+      expect(provider.model).toBe("embedding-model");
+      expect(client.model).toBe("embedding-model");
+      requests.length = 0;
+      await expect(provider.embedBatch([])).resolves.toEqual([]);
+      expect(requests).toEqual([]);
+      const aborted = AbortSignal.abort(new Error("cancelled before preload"));
+      await expect(provider.embed("cancelled", { signal: aborted })).rejects.toThrow(
+        "cancelled before preload",
+      );
+      expect(requests).toEqual([]);
+      expect(leases).toBe(0);
+    } finally {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    }
+  },
+);

--- a/extensions/lmstudio/src/embedding-provider.ts
+++ b/extensions/lmstudio/src/embedding-provider.ts
@@ -1,4 +1,6 @@
 // Lmstudio provider module implements model/runtime integration.
+import { createAsyncLock } from "openclaw/plugin-sdk/async-lock-runtime";
+import { toErrorObject } from "openclaw/plugin-sdk/error-runtime";
 import { createSubsystemLogger } from "openclaw/plugin-sdk/logging-core";
 import {
   buildRemoteBaseUrlPolicy,
@@ -246,45 +248,93 @@ export async function createLmstudioEmbeddingProvider(
     signal: AbortSignal | undefined,
     action: () => Promise<T>,
   ): Promise<T> => {
+    signal?.throwIfAborted();
     const lease =
       localServiceTarget && acquireLocalService
         ? await acquireLocalService(localServiceTarget, signal)
         : undefined;
     try {
+      signal?.throwIfAborted();
       return await action();
     } finally {
       lease?.release();
     }
   };
 
-  // The provider-owned JIT opt-out applies to embeddings as well as chat.
-  if (providerConfig?.params?.preload !== false) {
-    await withLocalServiceLease(undefined, async () => {
+  const withPreloadLock = createAsyncLock();
+  const preloadModel = async (signal?: AbortSignal, initializeIdentity = false) => {
+    if (providerConfig?.params?.preload === false) {
+      return;
+    }
+    // Serialize discovery/load, keeping embedding requests themselves concurrent.
+    let entered = false;
+    const preparation = withPreloadLock(async () => {
+      entered = true;
+      signal?.throwIfAborted();
       try {
-        client.model = await ensureLmstudioModelLoaded({
+        const modelKey = await ensureLmstudioModelLoaded({
           baseUrl,
           apiKey,
           headers: headerOverrides,
           ssrfPolicy,
-          modelKey: model,
+          modelKey: client.model,
           requestedContextLength,
           timeoutMs: 120_000,
+          signal,
         });
+        if (initializeIdentity) {
+          client.model = modelKey;
+        }
       } catch (error) {
-        // Discovery still identifies the wire model when the subsequent load fails.
-        if (error instanceof Error && "resolvedModelKey" in error) {
+        signal?.throwIfAborted();
+        // Cache identity is frozen at construction, including after a failed load.
+        if (initializeIdentity && error instanceof Error && "resolvedModelKey" in error) {
           const resolvedModelKey = error.resolvedModelKey;
           if (typeof resolvedModelKey === "string" && resolvedModelKey.trim()) {
             client.model = resolvedModelKey.trim();
           }
         }
-        log.warn("lmstudio embeddings warmup failed; continuing without preload", {
-          baseUrl,
-          model,
-          error: formatErrorMessage(error),
-        });
+        const details = { baseUrl, model: client.model, error: formatErrorMessage(error) };
+        if (initializeIdentity) {
+          log.warn("lmstudio embeddings warmup failed; continuing without preload", details);
+        } else {
+          log.debug("lmstudio embeddings preload failed; continuing without preload", details);
+        }
       }
     });
+    if (!signal) {
+      await preparation;
+      return;
+    }
+    // A queued cancellation owns no load. Once entered, wait for transport cleanup
+    // before the caller releases its service lease.
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        if (!entered) {
+          signal.removeEventListener("abort", onAbort);
+          reject(toErrorObject(signal.reason, "LM Studio preload aborted"));
+        }
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      void preparation.then(
+        () => {
+          signal.removeEventListener("abort", onAbort);
+          resolve();
+        },
+        (error: unknown) => {
+          signal.removeEventListener("abort", onAbort);
+          reject(toErrorObject(error, "LM Studio model preload failed"));
+        },
+      );
+      if (signal.aborted) {
+        onAbort();
+      }
+    });
+  };
+
+  // Resolve the canonical embedding/cache identity before returning the provider.
+  if (providerConfig?.params?.preload !== false) {
+    await withLocalServiceLease(undefined, async () => await preloadModel(undefined, true));
   } else if (model.includes("@")) {
     // Variant aliases are not accepted by LM Studio's inference routes. Resolve
     // only the stable wire/cache identity here; JIT still owns the actual load.
@@ -314,14 +364,21 @@ export async function createLmstudioEmbeddingProvider(
   });
   const embed: MemoryEmbeddingProvider["embed"] = async (input, callOptions) =>
     await withLocalServiceLease(callOptions?.signal, async () => {
+      await preloadModel(callOptions?.signal);
+      callOptions?.signal?.throwIfAborted();
       return await remoteProvider.embed(input, callOptions);
     });
   const embedBatch: MemoryEmbeddingProvider["embedBatch"] = async (inputs, callOptions) => {
+    if (inputs.length === 0) {
+      return [];
+    }
     if (callOptions?.inputType === "query") {
       // Promise.all rejects before sibling requests settle, so every query keeps its own lease.
       return await Promise.all(inputs.map((input) => embed(input, callOptions)));
     }
     return await withLocalServiceLease(callOptions?.signal, async () => {
+      await preloadModel(callOptions?.signal);
+      callOptions?.signal?.throwIfAborted();
       return await remoteProvider.embedBatch(inputs, callOptions);
     });
   };

--- a/extensions/lmstudio/src/models.fetch.ts
+++ b/extensions/lmstudio/src/models.fetch.ts
@@ -76,7 +76,9 @@ async function fetchLmstudioEndpoint(params: {
   fetchImpl?: typeof fetch;
   ssrfPolicy?: SsrFPolicy;
   auditContext: string;
+  signal?: AbortSignal;
 }): Promise<{ response: Response; release: () => Promise<void> }> {
+  params.signal?.throwIfAborted();
   const timeoutMs = resolveTimerTimeoutMs(params.timeoutMs, 1);
   let response: Response;
   let release: () => Promise<void>;
@@ -85,6 +87,7 @@ async function fetchLmstudioEndpoint(params: {
       url: params.url,
       init: params.init,
       timeoutMs,
+      signal: params.signal,
       fetchImpl: params.fetchImpl,
       policy: params.ssrfPolicy,
       auditContext: params.auditContext,
@@ -95,7 +98,9 @@ async function fetchLmstudioEndpoint(params: {
     const fetchFn = params.fetchImpl ?? fetch;
     response = await fetchFn(params.url, {
       ...params.init,
-      signal: AbortSignal.timeout(timeoutMs),
+      signal: params.signal
+        ? AbortSignal.any([params.signal, AbortSignal.timeout(timeoutMs)])
+        : AbortSignal.timeout(timeoutMs),
     });
     release = async () => undefined;
   }
@@ -131,6 +136,7 @@ export async function fetchLmstudioModels(params: {
   headers?: Record<string, string>;
   ssrfPolicy?: SsrFPolicy;
   timeoutMs?: number;
+  signal?: AbortSignal;
   /** Injectable fetch implementation; defaults to the global fetch. */
   fetchImpl?: typeof fetch;
 }): Promise<FetchLmstudioModelsResult> {
@@ -146,6 +152,7 @@ export async function fetchLmstudioModels(params: {
         }),
       },
       timeoutMs,
+      signal: params.signal,
       fetchImpl: params.fetchImpl,
       ssrfPolicy: params.ssrfPolicy,
       auditContext: "lmstudio-model-discovery",
@@ -242,6 +249,7 @@ type LmstudioModelLoadParams = {
   modelKey: string;
   requestedContextLength?: number;
   timeoutMs?: number;
+  signal?: AbortSignal;
   /** Injectable fetch implementation; defaults to the global fetch. */
   fetchImpl?: typeof fetch;
 };
@@ -272,8 +280,10 @@ export async function prepareLmstudioModelForInference(
     headers: params.headers,
     ssrfPolicy: params.ssrfPolicy,
     timeoutMs,
+    signal: params.signal,
     fetchImpl: params.fetchImpl,
   });
+  params.signal?.throwIfAborted();
   if (!preflight.reachable) {
     throw new Error(`LM Studio model discovery failed: ${String(preflight.error)}`);
   }
@@ -326,6 +336,7 @@ export async function prepareLmstudioModelForInference(
         }),
       },
       timeoutMs,
+      signal: params.signal,
       fetchImpl: params.fetchImpl,
       ssrfPolicy: params.ssrfPolicy,
       auditContext: "lmstudio-model-load",


### PR DESCRIPTION
Closes #141430.

## What Problem This Solves

LM Studio memory embeddings fail after their model is evicted when server JIT loading is disabled. OpenClaw preloads at provider construction but previously sent later embedding requests without checking readiness, producing HTTP 400 even though preload remained enabled.

## Why This Change Was Made

Recheck model readiness before embedding requests. Serialize preparation within the provider while leaving inference concurrent, propagate cancellation through native discovery/load, and keep the service lease until an active preparation has settled. Cancelled queued requests never start a load. The canonical model identity is resolved only at construction, preserving embedding cache identity.

## User Impact

Memory embedding requests recover after eviction without a restart or manual model load. Single requests and query/document batches are covered. The existing preload opt-out and empty-batch behavior remain intact.

## Evidence

- Real isolated headless LM Studio 0.0.23-1 with Nomic Embed Text v1.5 Q4_K_M: initial embeddings succeeded with 768 dimensions, eviction caused the old provider to return HTTP 400, and a manual native load restored it. Default server JIT was also tested as a working control.
- The final live run matched this PR source tree and recovered single requests and both batch types with 768-dimensional vectors, with exactly one native reload per batch. The preload opt-out remained delegated. All 45 observed task processes stopped; both test leases were released.
- The eviction regression failed on the original source for single/document/query requests. Final isolated validation passes all 58 focused tests, including active and queued cancellation, lease lifetime, canonical identity and empty batches. Both typechecks, targeted lint, and all remaining selected repository guards passed after correcting four lint findings.
- Final independent review found no actionable P0–P2 findings, including the error normalization and cancellation paths. Test services are isolated from operator state.

## Data compatibility

The stored-data warning is a false positive for this diff: no schema, serialization, migration, cache-key producer, model default, embedding dimension, or vector conversion algorithm changes. `packages/memory-host-sdk`, `extensions/memory-core`, `src/state`, and `src/config` are unchanged from the PR base.

The unchanged `extensions/lmstudio/memory-embedding-adapter.ts` still builds `cacheKeyData` from provider ID, base URL, canonical model, and sanitized headers. Construction resolves the canonical model exactly as before; request-time preparation never changes `client.model`. The existing canonical/variant/cache-identity tests pass, and the new eviction integration test verifies both `provider.model` and `client.model` remain unchanged after recovery. The shared embedding request/vector path is also unchanged.

Existing indexes and cached vectors therefore retain their identity and format; this lifecycle repair requires no migration or reindex. The final live run used the same model and returned the same 768-dimensional contract before and after eviction.
