### PR TITLE
fix: preserve state when gateway startup is refused

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2532,7 +2532,7 @@ src/config/io.clobber-snapshot.ts	2
 src/config/io.context.ts	1
 src/config/io.health-state.ts	1
 src/config/io.load.ts	2
-src/config/io.observe-recovery.ts	11
+src/config/io.observe-recovery.ts	7
 src/config/io.observe.ts	1
 src/config/io.read-helpers.ts	3
 src/config/io.session-store-owner.ts	2

--- a/src/cli/gateway-cli/future-config-guard.ts
+++ b/src/cli/gateway-cli/future-config-guard.ts
@@ -54,12 +54,6 @@ function resolveGatewayRunFutureConfigBlock(params: GatewayRunFutureConfigGuardP
   return block ? { block, exitCode: futureAction.exitCode, serviceMode } : null;
 }
 
-export function isGatewayRunFutureConfigAllowed(
-  params: GatewayRunFutureConfigGuardParams,
-): boolean {
-  return resolveGatewayRunFutureConfigBlock(params) === null;
-}
-
 export function enforceGatewayRunFutureConfigGuard(
   params: GatewayRunFutureConfigGuardParams & { runtime: RuntimeEnv },
 ): boolean {

--- a/src/cli/gateway-cli/pre-bootstrap.process.test.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.process.test.ts
@@ -26,6 +26,99 @@ function stateManifest(root: string): Record<string, string> {
 }
 
 describe("Gateway config selection before migration admission", () => {
+  it.each([
+    { name: "future backup before reset", code: 1 },
+    { name: "future current config", code: 1 },
+    { name: "future service-mode backup", code: 78 },
+    { name: "future backup after config selection changes", code: 1 },
+    { name: "discarded clobbered environment", code: 0 },
+  ])(
+    "prepares recovery safely for $name",
+    async ({ name, code }) => {
+      const root = fs.realpathSync(tempDirs.make("openclaw-recovery-selection-"));
+      const runtimeRoot = createSourceRuntime(root);
+      const stateDir = path.join(root, "state");
+      fs.mkdirSync(stateDir);
+      const configPath = path.join(stateDir, "openclaw.json");
+      const healthy = {
+        gateway: { mode: "local" },
+        plugins: { enabled: false },
+        meta: { lastTouchedVersion: "1.0.0" },
+      };
+      const future = { ...healthy, meta: { lastTouchedVersion: "9999.1.1" } };
+      const clobbered = { update: { channel: "stable" } };
+      let current: Record<string, unknown> = clobbered;
+      let backup: Record<string, unknown> = future;
+      if (name === "future current config") {
+        current = future;
+        backup = healthy;
+      } else if (name === "future service-mode backup") {
+        backup = { ...future, env: { vars: { OPENCLAW_SERVICE_MARKER: "openclaw" } } };
+      } else if (name === "future backup after config selection changes") {
+        const selectedPath = path.join(stateDir, "selected.json");
+        backup = { ...healthy, env: { vars: { OPENCLAW_CONFIG_PATH: selectedPath } } };
+        fs.writeFileSync(selectedPath, JSON.stringify(clobbered));
+        fs.writeFileSync(`${selectedPath}.bak`, JSON.stringify(future));
+      } else if (name === "discarded clobbered environment") {
+        current = {
+          gateway: { mode: "local" },
+          env: { vars: { OPENCLAW_GATEWAY_TOKEN: "discarded-test-token" } },
+        };
+        backup = healthy;
+      }
+      fs.writeFileSync(configPath, JSON.stringify(current));
+      fs.writeFileSync(`${configPath}.bak`, JSON.stringify(backup));
+      const before = stateManifest(stateDir);
+      const result = await runIsolatedModuleScript(
+        {
+          ...process.env,
+          HOME: root,
+          USERPROFILE: root,
+          OPENCLAW_HOME: root,
+          OPENCLAW_STATE_DIR: stateDir,
+          OPENCLAW_CONFIG_PATH: undefined,
+          OPENCLAW_WORKSPACE_DIR: path.join(root, "workspace"),
+          OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "bundled"),
+          OPENCLAW_SERVICE_MARKER: undefined,
+          OPENCLAW_GATEWAY_TOKEN: undefined,
+          OPENCLAW_PROXY_ACTIVE: "1",
+          OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS:
+            name === "future service-mode backup" ? "1" : undefined,
+        },
+        `
+        const { selectGatewayRunEnvironment } = await import("./src/cli/gateway-cli/pre-bootstrap.ts");
+        const { ExitError } = await import("./src/runtime.ts");
+        let code = 0;
+        try {
+          await selectGatewayRunEnvironment({
+            opts: ${JSON.stringify(name === "future backup before reset" ? { dev: true, reset: true } : {})},
+            runtime: { log() {}, error: console.error, exit(code) { throw new ExitError(code); } },
+          });
+        } catch (error) {
+          if (!(error instanceof ExitError)) throw error;
+          code = error.code;
+        }
+        process.stdout.write("__RESULT__" + JSON.stringify({ code,
+          tokenPresent: Boolean(process.env.OPENCLAW_GATEWAY_TOKEN),
+          proxyRetained: process.env.OPENCLAW_PROXY_ACTIVE === "1",
+        }) + "\\n");
+      `,
+        { runtimeRoot, timeoutMs: 60_000 },
+      );
+      const output = `${result.stdout}\n${result.stderr}`;
+      const line = result.stdout.split("\n").find((entry) => entry.startsWith("__RESULT__"));
+      expect(line, output).toBeDefined();
+      expect(JSON.parse(line!.slice("__RESULT__".length)), output).toEqual({
+        code,
+        tokenPresent: false,
+        proxyRetained: true,
+      });
+      expect(stateManifest(stateDir)).toEqual(before);
+    },
+    75_000,
+  );
+
   it.each([false, true])(
     "preserves every state artifact with backup=%s",
     async (withBackup) => {

--- a/src/cli/gateway-cli/pre-bootstrap.process.test.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.process.test.ts
@@ -1,0 +1,167 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import {
+  createSourceRuntime,
+  runIsolatedModuleScript,
+} from "../../commands/doctor-config-preflight.process.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterAll);
+
+function stateManifest(root: string): Record<string, string> {
+  return Object.fromEntries(
+    fs
+      .readdirSync(root, { recursive: true, withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => {
+        const filename = path.join(entry.parentPath, entry.name);
+        return [
+          path.relative(root, filename),
+          createHash("sha256").update(fs.readFileSync(filename)).digest("hex"),
+        ];
+      }),
+  );
+}
+
+describe("Gateway config selection before migration admission", () => {
+  it.each([false, true])(
+    "preserves every state artifact with backup=%s",
+    async (withBackup) => {
+      const root = fs.realpathSync(tempDirs.make("openclaw-readonly-bootstrap-"));
+      const runtimeRoot = createSourceRuntime(root);
+      const stateDir = path.join(root, "state");
+      fs.mkdirSync(stateDir);
+      const configPath = path.join(stateDir, "openclaw.json");
+      fs.writeFileSync(
+        configPath,
+        JSON.stringify({ gateway: { mode: "local" }, plugins: { enabled: false } }),
+      );
+      if (withBackup) {
+        fs.writeFileSync(
+          `${configPath}.bak`,
+          JSON.stringify({
+            gateway: { mode: "local" },
+            agents: { defaults: { workspace: path.join(root, "workspace") } },
+            messages: { ackReaction: "synthetic long-lived config baseline" },
+            plugins: { enabled: false },
+          }),
+        );
+      }
+      const before = stateManifest(stateDir);
+      const env = {
+        ...process.env,
+        HOME: root,
+        USERPROFILE: root,
+        OPENCLAW_HOME: root,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_WORKSPACE_DIR: path.join(root, "workspace"),
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "bundled"),
+        OPENCLAW_TEST_FAST: "1",
+      };
+      const result = await runIsolatedModuleScript(
+        env,
+        `
+      const { selectGatewayRunEnvironment, prepareGatewayRunBootstrap } = await import("./src/cli/gateway-cli/pre-bootstrap.ts");
+      const runtime = { log() {}, error() {}, exit(code) { throw new Error("unexpected exit " + code); } };
+      if (!await selectGatewayRunEnvironment({ opts: {}, runtime })) throw new Error("selection refused");
+      if (!await prepareGatewayRunBootstrap({ opts: {}, runtime })) throw new Error("preparation refused");
+      console.log("prepared");
+    `,
+        { runtimeRoot, timeoutMs: 60_000 },
+      );
+      expect(result.stdout).toContain("prepared");
+      expect(stateManifest(stateDir)).toEqual(before);
+    },
+    90_000,
+  );
+
+  it.each([
+    {
+      flag: "--allow-unconfigured",
+      dispatch: "fast",
+      suffix: [],
+      dev: false,
+      allowUnconfigured: true,
+    },
+    {
+      flag: "--allow-unconfigured",
+      dispatch: "Commander",
+      suffix: ["--"],
+      dev: false,
+      allowUnconfigured: true,
+    },
+    { flag: "--dev", dispatch: "fast", suffix: [], dev: true, allowUnconfigured: false },
+    { flag: "--dev", dispatch: "Commander", suffix: ["--"], dev: true, allowUnconfigured: false },
+  ])(
+    "passes $flag through $dispatch startup admission without config",
+    async ({ flag, suffix, dev, allowUnconfigured }) => {
+      const root = fs.realpathSync(tempDirs.make("openclaw-startup-allowance-"));
+      const runtimeRoot = createSourceRuntime(root);
+      const stateDir = path.join(root, "state");
+      fs.mkdirSync(stateDir);
+      const configPath = path.join(stateDir, "openclaw.json");
+      const env = {
+        PATH: process.env.PATH,
+        HOME: root,
+        USERPROFILE: root,
+        OPENCLAW_HOME: root,
+        OPENCLAW_STATE_DIR: stateDir,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_WORKSPACE_DIR: path.join(root, "workspace"),
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "bundled"),
+        OPENCLAW_HIDE_BANNER: "1",
+        OPENCLAW_GATEWAY_TOKEN: "synthetic-startup-allowance-token",
+        XDG_CONFIG_HOME: path.join(root, "xdg-config"),
+        XDG_DATA_HOME: path.join(root, "xdg-data"),
+        XDG_STATE_HOME: path.join(root, "xdg-state"),
+        XDG_CACHE_HOME: path.join(root, "cache"),
+        NPM_CONFIG_USERCONFIG: path.join(root, "npmrc"),
+        TMPDIR: root,
+        NO_COLOR: "1",
+      };
+      // Keep parsing, environment selection, preaction, and config admission real.
+      // Replace only the final Gateway action; the built rig proves listener startup.
+      const result = await runIsolatedModuleScript(
+        env,
+        `
+      import { registerHooks } from "node:module";
+      const calls = globalThis[Symbol.for("openclaw.test.startupAllowanceCalls")] = [];
+      registerHooks({
+        resolve(specifier, context, nextResolve) {
+          const parent = context.parentURL ?? "";
+          if (specifier === "./run.js" &&
+              (parent.endsWith("/cli/gateway-cli/run-command.ts") || parent.endsWith("/cli/gateway-cli/run-command.js"))) {
+            return {
+              shortCircuit: true,
+              url: "data:text/javascript," + encodeURIComponent(
+                'export async function runGatewayCommand(opts) {' +
+                'globalThis[Symbol.for("openclaw.test.startupAllowanceCalls")].push({' +
+                'dev: opts.dev === true, allowUnconfigured: opts.allowUnconfigured === true }); }'
+              ),
+            };
+          }
+          return nextResolve(specifier, context);
+        },
+      });
+      const { runCli } = await import("./src/cli/run-main.ts");
+      process.argv = [process.execPath, "openclaw", "gateway", "run", "--port", "18736", ${JSON.stringify(flag)}, ...${JSON.stringify(suffix)}];
+      await runCli(process.argv);
+      process.stdout.write("__RESULT__" + JSON.stringify(calls) + "\\n");
+    `,
+        { runtimeRoot, timeoutMs: 60_000 },
+      );
+      const output = `${result.stdout}\n${result.stderr}`;
+      const results = result.stdout.split("\n").filter((line) => line.startsWith("__RESULT__"));
+      expect(results, output).toHaveLength(1);
+      expect(JSON.parse(results[0]!.slice("__RESULT__".length))).toEqual([
+        { dev, allowUnconfigured },
+      ]);
+    },
+    75_000,
+  );
+});

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -1,16 +1,20 @@
+import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import * as startupRepair from "../../commands/doctor/shared/automatic-startup-config-repair.js";
 import { resetPublishedConfigRuntimeEnv } from "../../config/config-env-vars.js";
 // Gateway startup checks that must run before shared CLI bootstrap can migrate state.
 import { ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV } from "../../config/future-version-guard.js";
 import { GATEWAY_CONFIG_SELECTION_ENV_KEYS } from "../../config/gateway-env-selection.js";
+import { CONFIG_AUDIT_STORE_LABEL } from "../../config/io.audit.js";
 import type { ConfigFileSnapshot } from "../../config/types.js";
 import { ExitError, type RuntimeEnv } from "../../runtime.js";
+import { formatCliCommand } from "../command-format.js";
 import type { GatewayRunPreBootstrapOptions } from "./future-config-guard.js";
 import { enforceGatewayRunFutureConfigGuard } from "./future-config-guard.js";
+import type { GatewayRunOpts } from "./run-options.js";
 import { getGatewayRunRuntimeHooks } from "./runtime-hooks.js";
 
 type GatewayRunGuardParams = {
-  opts: GatewayRunPreBootstrapOptions;
+  opts: GatewayRunPreBootstrapOptions & Pick<GatewayRunOpts, "allowUnconfigured" | "dev">;
   runtime: RuntimeEnv;
 };
 
@@ -28,11 +32,42 @@ type PreparedGatewayRunReset = {
 let selectedGatewayRunEnvironment: GatewayRunEnvironmentSelection | undefined;
 let appliedGatewayRunConfigEnvironment: GatewayRunEnvironmentSelection | undefined;
 let lastGuardedGatewayRunSnapshot: ConfigFileSnapshot | undefined;
-let preparedGatewayRunBootstrapSnapshot: ConfigFileSnapshot | undefined;
+let preparedGatewayRunBootstrap:
+  | (Pick<GatewayRunOpts, "allowUnconfigured" | "dev"> & { snapshot: ConfigFileSnapshot })
+  | undefined;
 let preparedGatewayRunStateWasPristine = false;
 let preparedGatewayRunCoreStateWasPristine = false;
 let preparedGatewayRunReset: PreparedGatewayRunReset | undefined;
 let gatewayRunTargetSelectedByConfig = false;
+
+export function getGatewayStartGuardErrors(params: {
+  allowUnconfigured?: boolean;
+  configExists: boolean;
+  mode: string | undefined;
+}): string[] {
+  if (
+    (params.allowUnconfigured ?? preparedGatewayRunBootstrap?.allowUnconfigured) ||
+    params.mode === "local" ||
+    (!params.configExists && preparedGatewayRunBootstrap?.dev)
+  ) {
+    return [];
+  }
+  if (!params.configExists) {
+    return [
+      `Missing config. Run \`${formatCliCommand("openclaw setup")}\` or set gateway.mode=local (or pass --allow-unconfigured).`,
+    ];
+  }
+  return [
+    params.mode === undefined
+      ? [
+          "Gateway start blocked: existing config is missing gateway.mode.",
+          "Treat this as suspicious or clobbered config.",
+          `Re-run \`${formatCliCommand("openclaw onboard --mode local")}\` or \`${formatCliCommand("openclaw setup")}\`, set gateway.mode=local manually, or pass --allow-unconfigured.`,
+        ].join(" ")
+      : `Gateway start blocked: set gateway.mode=local (current: ${params.mode}) or pass --allow-unconfigured.`,
+    `Config write audit: ${CONFIG_AUDIT_STORE_LABEL}`,
+  ];
+}
 
 async function pinGatewayRunRuntimePaths(): Promise<void> {
   const [{ pinRuntimePaths }, { pinConfigDir }] = await Promise.all([
@@ -162,7 +197,11 @@ async function readGuardedGatewayRunConfig(
   params: GatewayRunGuardParams,
 ): Promise<ConfigFileSnapshot | null> {
   const { readConfigFileSnapshot } = await import("../../config/config.js");
-  const snapshot = await readConfigFileSnapshot({ isolateEnv: true, observe: false });
+  const snapshot = await readConfigFileSnapshot({
+    isolateEnv: true,
+    observe: false,
+    pluginValidation: "core-only",
+  });
   return enforceGatewayRunFutureConfigGuard({
     opts: params.opts,
     runtime: params.runtime,
@@ -197,48 +236,9 @@ function resolveGatewayConfigSelectionDeclarationSignature(
   );
 }
 
-async function recoverGuardedGatewayRunConfig(
-  params: GatewayRunGuardParams & { restoreSuspicious: boolean },
-): Promise<ConfigFileSnapshot | null> {
-  const { readConfigFileSnapshot } = await import("../../config/config.js");
-  let recoveryAllowed = true;
-  const recoveredSnapshot = await readConfigFileSnapshot({
-    isolateEnv: true,
-    recoverSuspicious: true,
-    allowSuspiciousRecovery: (config, current) => {
-      recoveryAllowed = enforceGatewayRunFutureConfigGuard({
-        opts: params.opts,
-        runtime: params.runtime,
-        config: current,
-      });
-      if (recoveryAllowed) {
-        recoveryAllowed = enforceGatewayRunFutureConfigGuard({
-          opts: params.opts,
-          runtime: params.runtime,
-          config,
-        });
-      }
-      return params.restoreSuspicious && recoveryAllowed;
-    },
-  });
-  if (!recoveryAllowed) {
-    return null;
-  }
-  // Recovery can select a different config, so enforce the same guard again before migrations.
-  return enforceGatewayRunFutureConfigGuard({
-    opts: params.opts,
-    runtime: params.runtime,
-    snapshot: recoveredSnapshot,
-  })
-    ? recoveredSnapshot
-    : null;
-}
-
 async function guardGatewayRunSelectedConfig(
   params: GatewayRunGuardParams & {
     environmentSelection?: GatewayRunEnvironmentSelection;
-    recoverSuspicious: boolean;
-    restoreSuspicious: boolean;
   },
 ): Promise<boolean> {
   lastGuardedGatewayRunSnapshot = undefined;
@@ -370,52 +370,9 @@ async function guardGatewayRunSelectedConfig(
       });
       continue;
     }
-    if (!params.recoverSuspicious) {
-      lastGuardedGatewayRunSnapshot = snapshot;
-      return true;
-    }
-    // Recovery writes audit/config state, so run it only after config and state selection is stable.
-    // It is also this startup's first state-directory write (config-health reads open the shared
-    // SQLite store, which quarantines orphaned sidecars), so a live gateway owner refuses here
-    // before any mutation instead of after the run loop's lock acquisition.
-    const { describeLiveGatewayOwnerStartupBlocker } =
-      await import("../../commands/doctor-startup-migration-refusal.js");
-    const liveOwnerBlocker = await describeLiveGatewayOwnerStartupBlocker(process.env);
-    if (liveOwnerBlocker) {
-      params.runtime.error(liveOwnerBlocker);
-      params.runtime.exit(1);
-      return false;
-    }
-    if (!snapshot.valid) {
-      // The exact stable-authored repair is written later under the startup migration lease.
-      lastGuardedGatewayRunSnapshot = snapshot;
-      return true;
-    }
-    const recoveredSnapshot = await recoverGuardedGatewayRunConfig(params);
-    if (!recoveredSnapshot) {
-      return false;
-    }
-    if (recoveredSnapshot.path !== snapshot.path || recoveredSnapshot.hash !== snapshot.hash) {
-      // Recovery replaced the selected config. Discard every env mutation from the old selection
-      // chain before converging again so rejected credentials cannot survive into the backup.
-      restoreSupersededGatewaySelectionEnv({
-        beforeCurrentPass: envBeforeTrustedApply,
-        environmentSelection: params.environmentSelection,
-      });
-      continue;
-    }
-    const envBeforeRecoveredApply = { ...process.env };
-    const recoveredSelectionSignature = resolveGatewayConfigSelectionSignature(process.env);
-    applySelectedConfigEnv(recoveredSnapshot);
-    if (resolveGatewayConfigSelectionSignature(process.env) === recoveredSelectionSignature) {
-      lastGuardedGatewayRunSnapshot = recoveredSnapshot;
-      return true;
-    }
-    restoreSupersededGatewaySelectionEnv({
-      beforeCurrentPass: envBeforeRecoveredApply,
-      environmentSelection: params.environmentSelection,
-    });
-    gatewayRunTargetSelectedByConfig = true;
+    // Migration admission owns repairs; selection cannot write config health or restore backups.
+    lastGuardedGatewayRunSnapshot = snapshot;
+    return true;
   }
 }
 
@@ -423,11 +380,7 @@ async function guardGatewayRunReset(params: GatewayRunGuardParams): Promise<bool
   gatewayRunTargetSelectedByConfig = false;
   const envBeforeGuard = { ...process.env };
   try {
-    return await guardGatewayRunSelectedConfig({
-      ...params,
-      recoverSuspicious: true,
-      restoreSuspicious: false,
-    });
+    return await guardGatewayRunSelectedConfig(params);
   } finally {
     // Config being deleted cannot authorize or retarget its own reset. Restore its env layer first,
     // then retain only invocation/trusted selectors through deletion and recreation.
@@ -481,8 +434,8 @@ export async function applyFinalGatewayRunConfigEnv(params: {
   runtime: RuntimeEnv;
   snapshot: ConfigFileSnapshot;
 }): Promise<boolean> {
-  const preparedSnapshot = preparedGatewayRunBootstrapSnapshot;
-  preparedGatewayRunBootstrapSnapshot = undefined;
+  const preparedSnapshot = preparedGatewayRunBootstrap?.snapshot;
+  preparedGatewayRunBootstrap = undefined;
   if (!params.snapshot.valid) {
     restoreAppliedGatewayRunConfigEnvironment(false);
     if (preparedSnapshot) {
@@ -626,18 +579,14 @@ export async function reloadTrustedGatewayRunEnvironment(params: {
 
 export async function selectGatewayRunEnvironment(params: GatewayRunGuardParams): Promise<boolean> {
   gatewayRunTargetSelectedByConfig = false;
-  preparedGatewayRunBootstrapSnapshot = undefined;
+  preparedGatewayRunBootstrap = undefined;
   preparedGatewayRunReset = undefined;
   restoreAppliedGatewayRunConfigEnvironment(params.opts.reset !== true);
   const envBeforeGuard = { ...process.env };
   selectedGatewayRunEnvironment = undefined;
   let guarded: boolean;
   try {
-    guarded = await guardGatewayRunSelectedConfig({
-      ...params,
-      recoverSuspicious: false,
-      restoreSuspicious: false,
-    });
+    guarded = await guardGatewayRunSelectedConfig(params);
   } finally {
     if (params.opts.reset) {
       restoreAppliedGatewayRunConfigEnvironment(false);
@@ -664,7 +613,7 @@ export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams):
   const { planPristineStartupConfigMigrations, planPristineStartupStateMigrations } =
     await import("../../commands/doctor/shared/pristine-startup-state.js");
   const pristineStatePlan = planPristineStartupStateMigrations(process.env);
-  // Stop the early proxy before recovery can select another config/state target. Its lifecycle
+  // Stop the early proxy before selection can choose another config/state target. Its lifecycle
   // restores the underlying env snapshot so the selected target's trusted dotenv can replace it.
   await getGatewayRunRuntimeHooks().releaseManagedProxy?.();
   const environmentSelection = selectedGatewayRunEnvironment;
@@ -677,11 +626,9 @@ export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams):
     : await guardGatewayRunSelectedConfig({
         ...params,
         environmentSelection,
-        recoverSuspicious: true,
-        restoreSuspicious: true,
       });
-  // Recovery can replace config without changing its selected path. Revalidate the final authored
-  // file while retaining the pre-guard physical-state fact, or stateful backup config could skip.
+  // Config can change without changing its selected path. Revalidate the final authored
+  // file while retaining the pre-guard physical-state fact, or stateful config could skip.
   const guardedConfigPlan = planPristineStartupConfigMigrations(
     guarded ? lastGuardedGatewayRunSnapshot?.parsed : undefined,
     process.env,
@@ -702,7 +649,16 @@ export async function prepareGatewayRunBootstrap(params: GatewayRunGuardParams):
   // Dev reset deletes the state directory before recreating config. Migrating first would
   // archive legacy state and then delete its imported SQLite rows.
   const shouldBootstrap = guarded && !params.opts.reset;
-  preparedGatewayRunBootstrapSnapshot = shouldBootstrap ? lastGuardedGatewayRunSnapshot : undefined;
+  preparedGatewayRunBootstrap =
+    shouldBootstrap && lastGuardedGatewayRunSnapshot
+      ? {
+          snapshot: lastGuardedGatewayRunSnapshot,
+          allowUnconfigured: params.opts.allowUnconfigured === true,
+          dev:
+            Boolean(params.opts.dev) ||
+            normalizeOptionalLowercaseString(process.env.OPENCLAW_PROFILE) === "dev",
+        }
+      : undefined;
   if (guarded && params.opts.reset && lastGuardedGatewayRunSnapshot) {
     preparedGatewayRunReset = {
       selectionEnvironment: snapshotGatewayConfigSelectionEnvironment(process.env),
@@ -734,7 +690,7 @@ export async function recheckGatewayRunBootstrap(
       throw new ExitError(code);
     },
   };
-  const expected = preparedGatewayRunBootstrapSnapshot;
+  const expected = preparedGatewayRunBootstrap?.snapshot;
   if (!expected) {
     params.runtime.error(
       "Refusing to run automatic gateway startup migrations without a prepared config snapshot. Retry startup.",

--- a/src/cli/gateway-cli/pre-bootstrap.ts
+++ b/src/cli/gateway-cli/pre-bootstrap.ts
@@ -1,12 +1,16 @@
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import * as startupRepair from "../../commands/doctor/shared/automatic-startup-config-repair.js";
-import { resetPublishedConfigRuntimeEnv } from "../../config/config-env-vars.js";
+import {
+  cloneEnvWithPlatformSemantics,
+  resetPublishedConfigRuntimeEnv,
+} from "../../config/config-env-vars.js";
 // Gateway startup checks that must run before shared CLI bootstrap can migrate state.
 import { ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV } from "../../config/future-version-guard.js";
 import { GATEWAY_CONFIG_SELECTION_ENV_KEYS } from "../../config/gateway-env-selection.js";
 import { CONFIG_AUDIT_STORE_LABEL } from "../../config/io.audit.js";
 import type { ConfigFileSnapshot } from "../../config/types.js";
 import { ExitError, type RuntimeEnv } from "../../runtime.js";
+import { withArtifactPreservingStateReads } from "../../state/openclaw-state-db-readonly.js";
 import { formatCliCommand } from "../command-format.js";
 import type { GatewayRunPreBootstrapOptions } from "./future-config-guard.js";
 import { enforceGatewayRunFutureConfigGuard } from "./future-config-guard.js";
@@ -197,18 +201,26 @@ async function readGuardedGatewayRunConfig(
   params: GatewayRunGuardParams,
 ): Promise<ConfigFileSnapshot | null> {
   const { readConfigFileSnapshot } = await import("../../config/config.js");
-  const snapshot = await readConfigFileSnapshot({
-    isolateEnv: true,
-    observe: false,
-    pluginValidation: "core-only",
+  const { createConfigIO } = await import("../../config/io.factory.js");
+  return await withArtifactPreservingStateReads(async () => {
+    const current = await readConfigFileSnapshot({
+      isolateEnv: true,
+      observe: false,
+      pluginValidation: "core-only",
+    });
+    const guard = (snapshot: ConfigFileSnapshot) =>
+      enforceGatewayRunFutureConfigGuard({ ...params, snapshot });
+    if (!guard(current)) {
+      return null;
+    }
+    const recovery = await createConfigIO({
+      configPath: current.path,
+      env: cloneEnvWithPlatformSemantics(process.env),
+      observe: false,
+      pluginValidation: "core-only",
+    }).prepareConfigRecovery(current);
+    return recovery ? (guard(recovery.snapshot) ? recovery.snapshot : null) : current;
   });
-  return enforceGatewayRunFutureConfigGuard({
-    opts: params.opts,
-    runtime: params.runtime,
-    snapshot,
-  })
-    ? snapshot
-    : null;
 }
 
 async function isSameGatewayRunConfigSnapshot(

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -100,11 +100,7 @@ const readBestEffortConfig = vi.fn(async () => configState.cfg);
 type ConfigSnapshotReadOptionsStub = {
   isolateEnv?: boolean;
   lowerPrecedenceEnv?: Readonly<Record<string, string>>;
-  recoverSuspicious?: boolean;
-  allowSuspiciousRecovery?: (
-    candidate: Record<string, unknown>,
-    current: Record<string, unknown>,
-  ) => boolean | Promise<boolean>;
+  observe?: boolean;
 };
 const readConfigFileSnapshotWithPluginMetadata = vi.fn(
   async (_options?: ConfigSnapshotReadOptionsStub) => ({
@@ -1456,79 +1452,6 @@ describe("gateway run option collisions", () => {
     });
   });
 
-  it("blocks a future-version late recovery candidate before gateway startup", async () => {
-    readConfigFileSnapshotWithPluginMetadata.mockImplementationOnce(async (options) => {
-      await options?.allowSuspiciousRecovery?.(
-        {
-          gateway: { mode: "local" },
-          meta: { lastTouchedVersion: "9999.1.1" },
-        },
-        { gateway: { mode: "local" } },
-      );
-      return { snapshot: configState.snapshot };
-    });
-
-    await expect(runGatewayCli(["gateway", "run", "--allow-unconfigured"])).rejects.toThrow(
-      "__exit__:1",
-    );
-
-    expect(startGatewayServer).not.toHaveBeenCalled();
-    expect(runtimeErrors.join("\n")).toContain("run automatic gateway startup migrations");
-  });
-
-  it("blocks a future-version service-mode late recovery candidate before restore", async () => {
-    let recoveryAllowed: boolean | undefined;
-    await withEnvAsync(
-      {
-        OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1",
-        OPENCLAW_SERVICE_MARKER: undefined,
-      },
-      async () => {
-        readConfigFileSnapshotWithPluginMetadata.mockImplementationOnce(async (options) => {
-          recoveryAllowed = await options?.allowSuspiciousRecovery?.(
-            {
-              env: { vars: { OPENCLAW_SERVICE_MARKER: "gateway" } },
-              gateway: { mode: "local" },
-              meta: { lastTouchedVersion: "9999.1.1" },
-            },
-            { gateway: { mode: "local" } },
-          );
-          return { snapshot: configState.snapshot };
-        });
-
-        await expect(runGatewayCli(["gateway", "run", "--allow-unconfigured"])).rejects.toThrow(
-          "__exit__:78",
-        );
-      },
-    );
-
-    expect(recoveryAllowed).toBe(false);
-    expect(startGatewayServer).not.toHaveBeenCalled();
-    expect(runtimeErrors.join("\n")).toContain("start the gateway service");
-  });
-
-  it("blocks a future-version current config before suspicious recovery", async () => {
-    let recoveryAllowed: boolean | undefined;
-    readConfigFileSnapshotWithPluginMetadata.mockImplementationOnce(async (options) => {
-      recoveryAllowed = await options?.allowSuspiciousRecovery?.(
-        { gateway: { mode: "local" } },
-        {
-          gateway: { mode: "local" },
-          meta: { lastTouchedVersion: "9999.1.1" },
-        },
-      );
-      return { snapshot: configState.snapshot };
-    });
-
-    await expect(runGatewayCli(["gateway", "run", "--allow-unconfigured"])).rejects.toThrow(
-      "__exit__:1",
-    );
-
-    expect(recoveryAllowed).toBe(false);
-    expect(startGatewayServer).not.toHaveBeenCalled();
-    expect(runtimeErrors.join("\n")).toContain("run automatic gateway startup migrations");
-  });
-
   it("blocks a final startup snapshot that changes guarded config selection", async () => {
     await withEnvAsync({ OPENCLAW_STATE_DIR: undefined }, async () => {
       configState.snapshot = {
@@ -1614,8 +1537,7 @@ describe("gateway run option collisions", () => {
     expect(readConfigFileSnapshotWithPluginMetadata).toHaveBeenCalledTimes(1);
     expect(readConfigFileSnapshotWithPluginMetadata).toHaveBeenCalledWith({
       isolateEnv: true,
-      recoverSuspicious: true,
-      allowSuspiciousRecovery: expect.any(Function),
+      observe: false,
     });
     expect(resolveShellEnvExpectedKeys).not.toHaveBeenCalled();
     expect(readBestEffortConfig).not.toHaveBeenCalled();

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -15,7 +15,6 @@ import type {
   ReadConfigFileSnapshotWithPluginMetadataResult,
 } from "../../config/config.js";
 import { ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS_ENV } from "../../config/future-version-guard.js";
-import { CONFIG_AUDIT_STORE_LABEL } from "../../config/io.audit.js";
 import {
   isDoctorRecoverableInvalidConfigError,
   isInvalidConfigError,
@@ -75,10 +74,8 @@ import {
   isTerminalInteractive,
   NON_INTERACTIVE_GATEWAY_RUN_FORCE_MESSAGE,
 } from "../terminal-interactivity.js";
-import {
-  enforceGatewayRunFutureConfigGuard,
-  isGatewayRunFutureConfigAllowed,
-} from "./future-config-guard.js";
+import { enforceGatewayRunFutureConfigGuard } from "./future-config-guard.js";
+import { getGatewayStartGuardErrors } from "./pre-bootstrap.js";
 import { installQaParentWatchdog } from "./qa-parent-watchdog.js";
 import { runGatewayLoop } from "./run-loop.js";
 import type { GatewayRunOpts } from "./run-options.js";
@@ -250,39 +247,8 @@ function shouldBlockGatewayBindWithoutExplicitAuth(params: {
   );
 }
 
-function getGatewayStartGuardErrors(params: {
-  allowUnconfigured?: boolean;
-  configExists: boolean;
-  configAuditLocation: string;
-  mode: string | undefined;
-}): string[] {
-  if (params.allowUnconfigured || params.mode === "local") {
-    return [];
-  }
-  if (!params.configExists) {
-    return [
-      `Missing config. Run \`${formatCliCommand("openclaw setup")}\` or set gateway.mode=local (or pass --allow-unconfigured).`,
-    ];
-  }
-  if (params.mode === undefined) {
-    return [
-      [
-        "Gateway start blocked: existing config is missing gateway.mode.",
-        "Treat this as suspicious or clobbered config.",
-        `Re-run \`${formatCliCommand("openclaw onboard --mode local")}\` or \`${formatCliCommand("openclaw setup")}\`, set gateway.mode=local manually, or pass --allow-unconfigured.`,
-      ].join(" "),
-      `Config write audit: ${params.configAuditLocation}`,
-    ];
-  }
-  return [
-    `Gateway start blocked: set gateway.mode=local (current: ${params.mode}) or pass --allow-unconfigured.`,
-    `Config write audit: ${params.configAuditLocation}`,
-  ];
-}
-
 async function readGatewayStartupConfig(params: {
   lowerPrecedenceEnv: Readonly<Record<string, string>>;
-  opts: GatewayRunOpts;
   startupTrace: ReturnType<typeof createGatewayCliStartupTrace>;
 }): Promise<{
   cfg: OpenClawConfig;
@@ -290,35 +256,16 @@ async function readGatewayStartupConfig(params: {
   startupConfigSnapshotRead?: ReadConfigFileSnapshotWithPluginMetadataResult;
 }> {
   const { readConfigFileSnapshotWithPluginMetadata } = await import("../../config/config.js");
-  let blockedRecoveryConfig: OpenClawConfig | null = null;
   const snapshotRead: ReadConfigFileSnapshotWithPluginMetadataResult | null =
     await params.startupTrace.measure("cli.config-snapshot", () =>
       readConfigFileSnapshotWithPluginMetadata({
         isolateEnv: true,
+        observe: false,
         ...(Object.keys(params.lowerPrecedenceEnv).length > 0
           ? { lowerPrecedenceEnv: params.lowerPrecedenceEnv }
           : {}),
-        recoverSuspicious: true,
-        allowSuspiciousRecovery: (config, current) => {
-          const blockedConfig = [current, config].find(
-            (candidate) =>
-              !isGatewayRunFutureConfigAllowed({ opts: params.opts, config: candidate }),
-          );
-          if (!blockedConfig) {
-            return true;
-          }
-          blockedRecoveryConfig = blockedConfig;
-          return false;
-        },
       }).catch(() => null),
     );
-  if (blockedRecoveryConfig) {
-    enforceGatewayRunFutureConfigGuard({
-      opts: params.opts,
-      runtime: defaultRuntime,
-      config: blockedRecoveryConfig,
-    });
-  }
   const snapshot: ConfigFileSnapshot | null = snapshotRead?.snapshot ?? null;
   const cfg = snapshot?.config ?? {};
   return {
@@ -401,7 +348,6 @@ function gatewayRunShellEnvFallbackPlanSignature(plan: GatewayRunShellEnvFallbac
 }
 
 async function readGatewayStartupConfigWithShellEnv(params: {
-  opts: GatewayRunOpts;
   startupTrace: ReturnType<typeof createGatewayCliStartupTrace>;
 }): Promise<
   Awaited<ReturnType<typeof readGatewayStartupConfig>> & {
@@ -414,7 +360,6 @@ async function readGatewayStartupConfigWithShellEnv(params: {
     for (let readCount = 0; readCount < GATEWAY_SHELL_ENV_CONVERGENCE_MAX_READS; readCount += 1) {
       const startupConfig = await readGatewayStartupConfig({
         lowerPrecedenceEnv,
-        opts: params.opts,
         startupTrace: params.startupTrace,
       });
       const plan = await resolveGatewayRunShellEnvFallbackPlan(
@@ -715,7 +660,6 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
   gatewayLog.info("loading configuration…");
   const { cfg, lowerPrecedenceEnv, snapshot, startupConfigSnapshotRead } =
     await readGatewayStartupConfigWithShellEnv({
-      opts,
       startupTrace,
     });
   if (
@@ -941,7 +885,6 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
   const guardErrors = getGatewayStartGuardErrors({
     allowUnconfigured: opts.allowUnconfigured,
     configExists,
-    configAuditLocation: CONFIG_AUDIT_STORE_LABEL,
     mode,
   });
   if (guardErrors.length > 0) {

--- a/src/cli/program/config-guard.test.ts
+++ b/src/cli/program/config-guard.test.ts
@@ -410,6 +410,7 @@ describe("ensureConfigReady", () => {
         migrateLegacyConfig: false,
         invalidConfigNote: false,
         requireStartupMigrationCheckpoint: true,
+        validateStartupConfig: expect.any(Function),
       });
       expect(getProcessPluginCache() === preflightCache).toBe(true);
       // Cache reuse must not freeze the Gateway inventory before its final config read.

--- a/src/cli/program/config-guard.ts
+++ b/src/cli/program/config-guard.ts
@@ -259,7 +259,21 @@ export async function ensureConfigReady(
         ...(params.measure ? { measure: params.measure } : {}),
         ...(commandName === "status" ? { observe: false } : {}),
         ...(shouldRequireStartupMigrationCheckpoint(commandPath)
-          ? { requireStartupMigrationCheckpoint: true }
+          ? {
+              requireStartupMigrationCheckpoint: true,
+              validateStartupConfig: async (snapshot) => {
+                const { getGatewayStartGuardErrors } =
+                  await import("../gateway-cli/pre-bootstrap.js");
+                const errors = getGatewayStartGuardErrors({
+                  allowUnconfigured: params.allowInvalid,
+                  configExists: snapshot.exists,
+                  mode: snapshot.config.gateway?.mode,
+                });
+                if (errors.length > 0) {
+                  throw new Error(errors.join("\n"));
+                }
+              },
+            }
           : { requireStateMigrationCheckpoint: true }),
         ...(params.beforeStateMigrations
           ? { beforeStateMigrations: params.beforeStateMigrations }
@@ -276,6 +290,11 @@ export async function ensureConfigReady(
         ? await runDoctorConfigPreflight()
         : await withSuppressedNotes(runDoctorConfigPreflight);
     } catch (error) {
+      if (shouldRequireStartupMigrationCheckpoint(commandPath)) {
+        await (
+          await import("../gateway-cli/startup-maintenance.js")
+        ).handleGatewayStartupMaintenance(error);
+      }
       if (error instanceof ExitError) {
         // The migration owner has unwound its lease and heartbeat before this handoff.
         params.runtime.exit(error.code);

--- a/src/cli/program/preaction.test.ts
+++ b/src/cli/program/preaction.test.ts
@@ -402,7 +402,7 @@ describe("registerPreActionHooks", () => {
     }
 
     expect(prepareGatewayRunBootstrapMock).toHaveBeenCalledWith({
-      opts: { force: true, reset: false },
+      opts: expect.objectContaining({ force: true, reset: false }),
       runtime: runtimeMock,
     });
     expect(ensureConfigReadyMock).not.toHaveBeenCalled();
@@ -426,7 +426,7 @@ describe("registerPreActionHooks", () => {
     const beforeStateMigrations = ensureConfigReadyMock.mock.calls[0]?.[0]?.beforeStateMigrations;
     await beforeStateMigrations?.();
     expect(recheckGatewayRunBootstrapMock).toHaveBeenCalledWith({
-      opts: { force: false, reset: false },
+      opts: expect.objectContaining({ force: false, reset: false }),
       runtime: runtimeMock,
     });
     expect(reloadTrustedGatewayRunEnvironmentMock).toHaveBeenCalledWith({

--- a/src/cli/program/preaction.ts
+++ b/src/cli/program/preaction.ts
@@ -205,10 +205,7 @@ export function registerPreActionHooks(program: Command, programVersion: string)
       const { resolveGatewayRunOptions } = await import("../gateway-cli/run-options.js");
       const resolvedOptions = resolveGatewayRunOptions(actionCommand.opts(), actionCommand);
       allowInvalid ||= resolvedOptions.allowUnconfigured === true;
-      const opts = {
-        force: resolvedOptions.force === true,
-        reset: resolvedOptions.reset === true,
-      };
+      const opts = resolvedOptions;
       const shouldBootstrap = await prepareGatewayRunBootstrap({ opts, runtime: defaultRuntime });
       if (!shouldBootstrap) {
         return;

--- a/src/cli/run-main.exit.test.ts
+++ b/src/cli/run-main.exit.test.ts
@@ -6,6 +6,7 @@ import process from "node:process";
 import { expectDefined } from "@openclaw/normalization-core";
 import { CommanderError } from "commander";
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConfigSnapshotReadOptions } from "../config/io.types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { GATEWAY_SERVICE_RUNTIME_PID_ENV } from "../daemon/constants.js";
 import { flushDiagnosticsTimeline } from "../infra/diagnostics-timeline.js";
@@ -39,16 +40,6 @@ type ConfigSnapshotStub = {
   raw?: string | null;
   valid: boolean;
   sourceConfig: Record<string, unknown>;
-};
-
-type ConfigSnapshotReadOptionsStub = {
-  isolateEnv?: boolean;
-  observe?: boolean;
-  recoverSuspicious?: boolean;
-  allowSuspiciousRecovery?: (
-    candidate: Record<string, unknown>,
-    current: Record<string, unknown>,
-  ) => boolean | Promise<boolean>;
 };
 
 const tryRouteCliMock = vi.hoisted(() => vi.fn());
@@ -123,7 +114,7 @@ const restoreRuntimeTerminalStateMock = vi.hoisted(() => vi.fn());
 const hasEnvHttpProxyAgentConfiguredMock = vi.hoisted(() => vi.fn(() => false));
 const ensureGlobalUndiciEnvProxyDispatcherMock = vi.hoisted(() => vi.fn());
 const readConfigFileSnapshotMock = vi.hoisted(() =>
-  vi.fn<(options?: ConfigSnapshotReadOptionsStub) => Promise<ConfigSnapshotStub>>(async () => ({
+  vi.fn<(options?: ConfigSnapshotReadOptions) => Promise<ConfigSnapshotStub>>(async () => ({
     exists: true,
     valid: true,
     sourceConfig: { gateway: { mode: "local" } },
@@ -1016,7 +1007,9 @@ describe("runCli exit behavior", () => {
   it("configures the gateway foreground fast path with the standard CLI bootstrap", async () => {
     await runCli(["node", "openclaw", "gateway", "--force"]);
 
-    expect(readConfigFileSnapshotMock.mock.calls).toEqual([[{ isolateEnv: true, observe: false }]]);
+    expect(readConfigFileSnapshotMock.mock.calls).toEqual([
+      [{ isolateEnv: true, observe: false, pluginValidation: "core-only" }],
+    ]);
     const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
       | { beforeRun?: (opts: { reset?: boolean }) => Promise<void> }
       | undefined;
@@ -1029,15 +1022,14 @@ describe("runCli exit behavior", () => {
         loadPlugins: false,
       }),
     );
-    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({
-      isolateEnv: true,
-      recoverSuspicious: true,
-      allowSuspiciousRecovery: expect.any(Function),
-    });
-    const recoveryOrder = readConfigFileSnapshotMock.mock.invocationCallOrder[2] ?? 0;
+    expect(readConfigFileSnapshotMock.mock.calls).toEqual([
+      [{ isolateEnv: true, observe: false, pluginValidation: "core-only" }],
+      [{ isolateEnv: true, observe: false, pluginValidation: "core-only" }],
+    ]);
+    const admissionOrder = readConfigFileSnapshotMock.mock.invocationCallOrder[1] ?? 0;
     const bootstrapOrder = ensureCliExecutionBootstrapMock.mock.invocationCallOrder[0] ?? 0;
-    expect(recoveryOrder).toBeGreaterThan(0);
-    expect(bootstrapOrder).toBeGreaterThan(recoveryOrder);
+    expect(admissionOrder).toBeGreaterThan(0);
+    expect(bootstrapOrder).toBeGreaterThan(admissionOrder);
   });
 
   it("defers config-drift exit to the migration owner before startup migrations", async () => {
@@ -1213,7 +1205,7 @@ describe("runCli exit behavior", () => {
       expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining(params.expectedAction));
       expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
       expect(readConfigFileSnapshotMock.mock.calls).toEqual([
-        [{ isolateEnv: true, observe: false }],
+        [{ isolateEnv: true, observe: false, pluginValidation: "core-only" }],
       ]);
       if (params.marker) {
         expect(process.env.OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS).toBeUndefined();
@@ -1414,127 +1406,6 @@ describe("runCli exit behavior", () => {
       );
     } finally {
       await fs.rm(homeDir, { recursive: true, force: true });
-    }
-  });
-
-  it("blocks a future-config recovery candidate before destructive gateway reset", async () => {
-    const currentSnapshot = {
-      exists: true,
-      valid: true,
-      sourceConfig: { gateway: { mode: "local" } },
-    };
-    readConfigFileSnapshotMock.mockImplementation(async (options) => {
-      if (options?.recoverSuspicious) {
-        await options?.allowSuspiciousRecovery?.(
-          {
-            meta: { lastTouchedVersion: "9999.1.1" },
-            gateway: { mode: "local" },
-          },
-          currentSnapshot.sourceConfig,
-        );
-      }
-      return currentSnapshot;
-    });
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-      throw new Error(`exit:${String(code)}`);
-    }) as typeof process.exit);
-    try {
-      await runCli(["node", "openclaw", "gateway", "--dev", "--reset"]);
-      const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
-        | { beforeRun?: (opts: { reset?: boolean }) => Promise<void> }
-        | undefined;
-      await expect(hooks?.beforeRun?.({ reset: true })).rejects.toThrow("exit:1");
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("Refusing to reset the dev gateway state"),
-      );
-      expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
-    } finally {
-      exitSpy.mockRestore();
-      errorSpy.mockRestore();
-    }
-  });
-
-  it("blocks a future current config before pre-bootstrap suspicious recovery", async () => {
-    const currentSnapshot = {
-      exists: true,
-      valid: true,
-      sourceConfig: { gateway: { mode: "local" } },
-    };
-    readConfigFileSnapshotMock.mockImplementation(async (options) => {
-      if (options?.recoverSuspicious) {
-        await options.allowSuspiciousRecovery?.(
-          { gateway: { mode: "local" } },
-          {
-            meta: { lastTouchedVersion: "9999.1.1" },
-            gateway: { mode: "local" },
-          },
-        );
-      }
-      return currentSnapshot;
-    });
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-      throw new Error(`exit:${String(code)}`);
-    }) as typeof process.exit);
-    try {
-      await runCli(["node", "openclaw", "gateway"]);
-      const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
-        | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
-        | undefined;
-      await expect(hooks?.beforeRun?.({})).rejects.toThrow("exit:1");
-      expect(errorSpy).toHaveBeenCalledWith(
-        expect.stringContaining("run automatic gateway startup migrations"),
-      );
-      expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
-    } finally {
-      exitSpy.mockRestore();
-      errorSpy.mockRestore();
-    }
-  });
-
-  it("blocks a future service-mode candidate before pre-bootstrap suspicious recovery", async () => {
-    const currentSnapshot = {
-      exists: true,
-      valid: true,
-      sourceConfig: { gateway: { mode: "local" } },
-    };
-    readConfigFileSnapshotMock.mockImplementation(async (options) => {
-      if (options?.recoverSuspicious) {
-        await options.allowSuspiciousRecovery?.(
-          {
-            env: { vars: { OPENCLAW_SERVICE_MARKER: "gateway" } },
-            gateway: { mode: "local" },
-            meta: { lastTouchedVersion: "9999.1.1" },
-          },
-          { gateway: { mode: "local" } },
-        );
-      }
-      return currentSnapshot;
-    });
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-      throw new Error(`exit:${String(code)}`);
-    }) as typeof process.exit);
-    try {
-      await withEnvAsync(
-        {
-          OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: "1",
-          OPENCLAW_SERVICE_MARKER: undefined,
-        },
-        async () => {
-          await runCli(["node", "openclaw", "gateway"]);
-          const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
-            | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
-            | undefined;
-          await expect(hooks?.beforeRun?.({})).rejects.toThrow("exit:78");
-        },
-      );
-      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("start the gateway service"));
-      expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
-    } finally {
-      exitSpy.mockRestore();
-      errorSpy.mockRestore();
     }
   });
 
@@ -1745,123 +1616,6 @@ describe("runCli exit behavior", () => {
     }
   });
 
-  it("re-inspects recovery after recovery changes config selection", async () => {
-    await withEnvAsync({ OPENCLAW_CONFIG_PATH: undefined }, async () => {
-      const selectedConfigPath = "/tmp/openclaw-recovered-selection.json";
-      const currentSnapshot = {
-        exists: true,
-        valid: true,
-        sourceConfig: { gateway: { mode: "local" } },
-      };
-      let recoveryReads = 0;
-      readConfigFileSnapshotMock.mockImplementation(async (options) => {
-        if (!options?.recoverSuspicious) {
-          return currentSnapshot;
-        }
-        recoveryReads += 1;
-        if (recoveryReads === 1) {
-          const recoveredSnapshot = {
-            exists: true,
-            valid: true,
-            sourceConfig: {
-              env: { vars: { OPENCLAW_CONFIG_PATH: selectedConfigPath } },
-              gateway: { mode: "local" },
-            },
-          };
-          await options.allowSuspiciousRecovery?.(
-            recoveredSnapshot.sourceConfig,
-            currentSnapshot.sourceConfig,
-          );
-          return recoveredSnapshot;
-        }
-        await options.allowSuspiciousRecovery?.(
-          {
-            meta: { lastTouchedVersion: "9999.1.1" },
-            gateway: { mode: "local" },
-          },
-          currentSnapshot.sourceConfig,
-        );
-        return currentSnapshot;
-      });
-      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-      const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
-        throw new Error(`exit:${String(code)}`);
-      }) as typeof process.exit);
-      try {
-        await runCli(["node", "openclaw", "gateway"]);
-        const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
-          | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
-          | undefined;
-        await expect(hooks?.beforeRun?.({})).rejects.toThrow("exit:1");
-        expect(errorSpy).toHaveBeenCalledWith(
-          expect.stringContaining("run automatic gateway startup migrations"),
-        );
-        expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
-        expect(recoveryReads).toBe(2);
-      } finally {
-        exitSpy.mockRestore();
-        errorSpy.mockRestore();
-      }
-    });
-  });
-
-  it("discards env from a config replaced by suspicious recovery", async () => {
-    await withEnvAsync(
-      { OPENCLAW_GATEWAY_TOKEN: undefined, OPENCLAW_PROXY_ACTIVE: undefined },
-      async () => {
-        const clobberedSnapshot = {
-          exists: true,
-          valid: true,
-          sourceConfig: {
-            env: { vars: { OPENCLAW_GATEWAY_TOKEN: "discarded-token" } },
-            gateway: { mode: "local" },
-          },
-          hash: "clobbered",
-          path: "/tmp/openclaw.json",
-        };
-        const recoveredSnapshot = {
-          exists: true,
-          valid: true,
-          sourceConfig: { gateway: { mode: "local" } },
-          hash: "recovered",
-          path: "/tmp/openclaw.json",
-        };
-        const initialSnapshot = {
-          exists: true,
-          valid: true,
-          sourceConfig: { gateway: { mode: "local" } },
-          hash: "initial",
-          path: "/tmp/openclaw.json",
-        };
-        let currentSnapshot = initialSnapshot;
-        let recovered = false;
-        readConfigFileSnapshotMock.mockImplementation(async (options) => {
-          if (!options?.recoverSuspicious) {
-            return recovered ? recoveredSnapshot : currentSnapshot;
-          }
-          recovered = true;
-          await options.allowSuspiciousRecovery?.(
-            recoveredSnapshot.sourceConfig,
-            currentSnapshot.sourceConfig,
-          );
-          return recoveredSnapshot;
-        });
-        await runCli(["node", "openclaw", "gateway"]);
-
-        currentSnapshot = clobberedSnapshot;
-        process.env.OPENCLAW_PROXY_ACTIVE = "1";
-        const hooks = addGatewayRunCommandMock.mock.calls[0]?.[1] as
-          | { beforeRun?: (opts: { force?: boolean }) => Promise<void> }
-          | undefined;
-        await hooks?.beforeRun?.({});
-
-        expect(process.env.OPENCLAW_GATEWAY_TOKEN).toBeUndefined();
-        expect(process.env.OPENCLAW_PROXY_ACTIVE).toBe("1");
-        expect(ensureCliExecutionBootstrapMock).toHaveBeenCalledOnce();
-      },
-    );
-  });
-
   it("does not apply environment variables from invalid config snapshots", async () => {
     await withEnvAsync({ OPENCLAW_INCLUDE_ROOTS: undefined }, async () => {
       readConfigFileSnapshotMock.mockResolvedValue({
@@ -1883,8 +1637,8 @@ describe("runCli exit behavior", () => {
 
       expect(process.env.OPENCLAW_INCLUDE_ROOTS).toBeUndefined();
       expect(readConfigFileSnapshotMock.mock.calls).toEqual([
-        [{ isolateEnv: true, observe: false }],
-        [{ isolateEnv: true, observe: false }],
+        [{ isolateEnv: true, observe: false, pluginValidation: "core-only" }],
+        [{ isolateEnv: true, observe: false, pluginValidation: "core-only" }],
       ]);
       expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
     });
@@ -2277,7 +2031,11 @@ describe("runCli exit behavior", () => {
       | undefined;
     await hooks?.beforeRun?.({ reset: true });
 
-    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({ isolateEnv: true, observe: false });
+    expect(readConfigFileSnapshotMock).toHaveBeenCalledWith({
+      isolateEnv: true,
+      observe: false,
+      pluginValidation: "core-only",
+    });
     expect(ensureCliExecutionBootstrapMock).not.toHaveBeenCalled();
   });
 

--- a/src/commands/doctor-config-preflight-startup.test.ts
+++ b/src/commands/doctor-config-preflight-startup.test.ts
@@ -1,0 +1,39 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expect, it } from "vitest";
+import { readConfigFileSnapshot } from "../config/io.js";
+import { readStartupMigrationSnapshot } from "./doctor-config-preflight-startup.js";
+import { withDoctorConfigPreflightHome } from "./doctor-config-preflight.test-support.js";
+import { planAutomaticConfigRepair } from "./doctor/shared/automatic-startup-config-repair.js";
+
+it("refuses a session-store change between core admission and the full config read", async () => {
+  await withDoctorConfigPreflightHome(async (home) => {
+    const stateDir = process.env.OPENCLAW_STATE_DIR ?? path.join(home, ".openclaw");
+    const configPath = process.env.OPENCLAW_CONFIG_PATH ?? path.join(stateDir, "openclaw.json");
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    const config = { gateway: { mode: "local" }, plugins: { enabled: false } };
+    fs.writeFileSync(configPath, JSON.stringify(config));
+    const legacyStore = path.join(home, "other", "sessions.json");
+    fs.mkdirSync(path.dirname(legacyStore));
+    fs.writeFileSync(legacyStore, "{}\n");
+    const changedConfig = JSON.stringify({ ...config, session: { store: legacyStore } });
+
+    await expect(
+      readStartupMigrationSnapshot({
+        env: process.env,
+        readSnapshot: async () => {
+          // Simulate an operator edit while the asynchronous admission read is in flight.
+          fs.writeFileSync(configPath, changedConfig);
+          return {
+            snapshot: await readConfigFileSnapshot({ observe: false }),
+            pluginMigrationFingerprint: null,
+          };
+        },
+        planRepair: ({ snapshot }) => planAutomaticConfigRepair(snapshot),
+      }),
+    ).rejects.toMatchObject({ code: 78, message: expect.stringContaining("inputs changed") });
+    expect(fs.readFileSync(configPath, "utf8")).toBe(changedConfig);
+    expect(fs.readFileSync(legacyStore, "utf8")).toBe("{}\n");
+    expect(fs.existsSync(path.join(stateDir, "state"))).toBe(false);
+  });
+});

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -1,15 +1,15 @@
 import { isDeepStrictEqual } from "node:util";
 import { note } from "../../packages/terminal-core/src/note.js";
-import type { ConfigSnapshotReadMeasure } from "../config/io.js";
+import { readConfigFileSnapshot, type ConfigSnapshotReadMeasure } from "../config/io.js";
 import type { ConfigFileSnapshot } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { formatErrorMessage } from "../infra/errors.js";
 import type {
   MigrationCheckpointIdentity,
   StartupMigrationLease,
 } from "../infra/startup-migration-checkpoint.js";
 import {
   DoctorStateMigrationRefusalError,
-  formatStartupMigrationFailure,
   recordStartupMigrationWarnings,
   throwIfDoctorStateMigrationRefused,
 } from "../infra/state-migrations.messages.js";
@@ -30,10 +30,80 @@ import {
   runStartupUpgradeConvergence,
 } from "./doctor-config-preflight-plugin-verification.js";
 import {
+  refuseStartupMigrationsForLiveGatewayOwner,
   throwStartupMigrationGuardRejected,
   throwStartupMigrationIdentityChanged,
   throwStartupMigrationRefusal,
 } from "./doctor-startup-migration-refusal.js";
+import {
+  type planAutomaticConfigRepair,
+  resolveStartupConfigSnapshot,
+} from "./doctor/shared/automatic-startup-config-repair.js";
+
+/** Admit the same config and state before the lease and again before migration writes. */
+export async function readStartupMigrationSnapshot(params: {
+  env: NodeJS.ProcessEnv;
+  readSnapshot: () => Promise<DoctorConfigPreflightPluginSnapshotRead>;
+  planRepair: (
+    read: DoctorConfigPreflightPluginSnapshotRead,
+  ) => ReturnType<typeof planAutomaticConfigRepair>;
+  validateConfig?: (snapshot: ConfigFileSnapshot) => void | Promise<void>;
+}): Promise<DoctorConfigPreflightPluginSnapshotRead> {
+  await refuseStartupMigrationsForLiveGatewayOwner(params.env);
+  try {
+    const selected = await readConfigFileSnapshot({
+      observe: false,
+      pluginValidation: "core-only",
+    });
+    await assertStartupStateMigrationReady({
+      cfg: selected.sourceConfig ?? selected.config,
+      env: params.env,
+    });
+    // Core readiness must be decided before plugin metadata opens shared state.
+    const startupConfig = resolveStartupConfigSnapshot(selected);
+    if (startupConfig) {
+      await params.validateConfig?.(startupConfig);
+    }
+    const read = await params.readSnapshot();
+    const repair = read.snapshot.valid ? null : params.planRepair(read);
+    if (!read.snapshot.valid && !repair) {
+      throw new Error('OpenClaw config is invalid; run "openclaw doctor --fix" before startup.');
+    }
+    await params.validateConfig?.(repair?.snapshot ?? read.snapshot);
+    return read;
+  } catch (error) {
+    return throwStartupMigrationRefusal(formatErrorMessage(error), error);
+  }
+}
+
+/** Admission runs before lease acquisition: even acquiring a lease commits SQLite writes. */
+async function assertStartupStateMigrationReady(params: {
+  cfg: OpenClawConfig;
+  env: NodeJS.ProcessEnv;
+}): Promise<void> {
+  const { assertOpenClawDatabasesReady } = await import("../state/openclaw-database-preflight.js");
+  await assertOpenClawDatabasesReady({
+    env: params.env,
+    config: params.cfg,
+    operation: "gateway-startup",
+  });
+  const { assertSessionStoreMigrationComplete } =
+    await import("../config/sessions/startup-migration.js");
+  const { resolveAllAgentSessionStoreCandidateTargetsSync } =
+    await import("../config/sessions/targets.js");
+  const { inspectOpenClawRegisteredAgentDatabases } =
+    await import("../state/openclaw-agent-db-registry.js");
+  const targets = resolveAllAgentSessionStoreCandidateTargetsSync(params.cfg, {
+    env: params.env,
+    registeredDatabases: inspectOpenClawRegisteredAgentDatabases({
+      env: params.env,
+      includeIncompatibleSchemaVersions: true,
+    }),
+  });
+  assertSessionStoreMigrationComplete({ ...params, targets });
+  const { assertConfiguredWorkspaceStateReady } = await import("../agents/workspace-state-dirs.js");
+  assertConfiguredWorkspaceStateReady(params);
+}
 
 type MigrationCheckpoint = {
   recordSuccessfulStateMigrations: (params?: {
@@ -147,13 +217,6 @@ export async function completeStartupMigrationPreflight(params: {
     });
   }
   if (params.gatewayStartupCheckpointRequired) {
-    if (params.shouldRecordStartupCheckpoint && !snapshot.valid) {
-      throwStartupMigrationRefusal(
-        formatStartupMigrationFailure([
-          'OpenClaw config is invalid; run "openclaw doctor --fix" before startup.',
-        ]),
-      );
-    }
     if (snapshot.valid && params.shouldRecordStartupCheckpoint) {
       const convergedSnapshotRead = await params.readConfigSnapshotForPreflight(false);
       const convergedBaseConfig =

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -18,6 +18,7 @@ import type {
   MigrationMessages,
 } from "../infra/state-migrations.types.js";
 import { setActiveDegradedPlugins } from "../plugins/runtime-degraded-state.js";
+import { withArtifactPreservingStateReads } from "../state/openclaw-state-db-readonly.js";
 import {
   migrationCheckpointIdentitiesMatch,
   resolveMigrationCheckpointIdentity,
@@ -49,31 +50,33 @@ export async function readStartupMigrationSnapshot(params: {
   ) => ReturnType<typeof planAutomaticConfigRepair>;
   validateConfig?: (snapshot: ConfigFileSnapshot) => void | Promise<void>;
 }): Promise<DoctorConfigPreflightPluginSnapshotRead> {
-  await refuseStartupMigrationsForLiveGatewayOwner(params.env);
-  try {
-    const selected = await readConfigFileSnapshot({
-      observe: false,
-      pluginValidation: "core-only",
-    });
-    await assertStartupStateMigrationReady({
-      cfg: selected.sourceConfig ?? selected.config,
-      env: params.env,
-    });
-    // Core readiness must be decided before plugin metadata opens shared state.
-    const startupConfig = resolveStartupConfigSnapshot(selected);
-    if (startupConfig) {
-      await params.validateConfig?.(startupConfig);
+  return await withArtifactPreservingStateReads(async () => {
+    await refuseStartupMigrationsForLiveGatewayOwner(params.env);
+    try {
+      const selected = await readConfigFileSnapshot({
+        observe: false,
+        pluginValidation: "core-only",
+      });
+      const startupConfig = resolveStartupConfigSnapshot(selected);
+      await assertStartupStateMigrationReady({
+        cfg: startupConfig?.sourceConfig ?? selected.sourceConfig ?? selected.config,
+        env: params.env,
+      });
+      // Core readiness must be decided before plugin metadata opens shared state.
+      if (startupConfig) {
+        await params.validateConfig?.(startupConfig);
+      }
+      const read = await params.readSnapshot();
+      const repair = read.snapshot.valid ? null : params.planRepair(read);
+      if (!read.snapshot.valid && !repair) {
+        throw new Error('OpenClaw config is invalid; run "openclaw doctor --fix" before startup.');
+      }
+      await params.validateConfig?.(repair?.snapshot ?? read.snapshot);
+      return read;
+    } catch (error) {
+      return throwStartupMigrationRefusal(formatErrorMessage(error), error);
     }
-    const read = await params.readSnapshot();
-    const repair = read.snapshot.valid ? null : params.planRepair(read);
-    if (!read.snapshot.valid && !repair) {
-      throw new Error('OpenClaw config is invalid; run "openclaw doctor --fix" before startup.');
-    }
-    await params.validateConfig?.(repair?.snapshot ?? read.snapshot);
-    return read;
-  } catch (error) {
-    return throwStartupMigrationRefusal(formatErrorMessage(error), error);
-  }
+  });
 }
 
 /** Admission runs before lease acquisition: even acquiring a lease commits SQLite writes. */

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -1,6 +1,9 @@
 import { isDeepStrictEqual } from "node:util";
 import { note } from "../../packages/terminal-core/src/note.js";
+import { cloneEnvWithPlatformSemantics } from "../config/config-env-vars.js";
+import { createConfigIO } from "../config/io.factory.js";
 import { readConfigFileSnapshot, type ConfigSnapshotReadMeasure } from "../config/io.js";
+import type { PreparedConfigRecovery } from "../config/io.types.js";
 import type { ConfigFileSnapshot } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -18,6 +21,7 @@ import type {
   MigrationMessages,
 } from "../infra/state-migrations.types.js";
 import { setActiveDegradedPlugins } from "../plugins/runtime-degraded-state.js";
+import { ExitError } from "../runtime.js";
 import { withArtifactPreservingStateReads } from "../state/openclaw-state-db-readonly.js";
 import {
   migrationCheckpointIdentitiesMatch,
@@ -49,32 +53,67 @@ export async function readStartupMigrationSnapshot(params: {
     read: DoctorConfigPreflightPluginSnapshotRead,
   ) => ReturnType<typeof planAutomaticConfigRepair>;
   validateConfig?: (snapshot: ConfigFileSnapshot) => void | Promise<void>;
-}): Promise<DoctorConfigPreflightPluginSnapshotRead> {
+  beforeStateMigrations?: (snapshot: ConfigFileSnapshot) => Promise<boolean>;
+}): Promise<DoctorConfigPreflightPluginSnapshotRead & { recovery?: PreparedConfigRecovery }> {
   return await withArtifactPreservingStateReads(async () => {
     await refuseStartupMigrationsForLiveGatewayOwner(params.env);
     try {
       const selected = await readConfigFileSnapshot({
         observe: false,
+        isolateEnv: true,
         pluginValidation: "core-only",
       });
-      const startupConfig = resolveStartupConfigSnapshot(selected);
+      const recoveryOptions = { configPath: selected.path, observe: false, env: params.env };
+      const coreRecovery = await createConfigIO({
+        ...recoveryOptions,
+        pluginValidation: "core-only",
+      }).prepareConfigRecovery(selected);
+      const candidate = coreRecovery?.snapshot ?? selected;
+      const startupConfig = resolveStartupConfigSnapshot(candidate);
       await assertStartupStateMigrationReady({
-        cfg: startupConfig?.sourceConfig ?? selected.sourceConfig ?? selected.config,
+        cfg: startupConfig?.sourceConfig ?? candidate.sourceConfig ?? candidate.config,
         env: params.env,
       });
       // Core readiness must be decided before plugin metadata opens shared state.
       if (startupConfig) {
         await params.validateConfig?.(startupConfig);
       }
-      const read = await params.readSnapshot();
+      let read: DoctorConfigPreflightPluginSnapshotRead = coreRecovery
+        ? {
+            ...(await createConfigIO({
+              ...recoveryOptions,
+              env: cloneEnvWithPlatformSemantics(params.env),
+            }).readConfigFileSnapshotWithPluginMetadata({ allowCurrentPluginMetadata: false })),
+            pluginMigrationFingerprint: null,
+          }
+        : await params.readSnapshot();
       assertStartupConfigUnchanged(selected, read.snapshot);
+      const recovery = await createConfigIO(recoveryOptions).prepareConfigRecovery(read.snapshot);
+      if (Boolean(coreRecovery) !== Boolean(recovery)) {
+        throwStartupMigrationIdentityChanged();
+      }
+      if (recovery) {
+        assertStartupConfigUnchanged(candidate, recovery.snapshot);
+        read = {
+          snapshot: recovery.snapshot,
+          pluginMetadataSnapshot: recovery.pluginMetadataSnapshot,
+          pluginMigrationFingerprint:
+            recovery.pluginMetadataSnapshot?.configFingerprint?.trim() || null,
+        };
+      }
       const repair = read.snapshot.valid ? null : params.planRepair(read);
       if (!read.snapshot.valid && !repair) {
         throw new Error('OpenClaw config is invalid; run "openclaw doctor --fix" before startup.');
       }
       await params.validateConfig?.(repair?.snapshot ?? read.snapshot);
-      return read;
+      if (params.beforeStateMigrations && !(await params.beforeStateMigrations(read.snapshot))) {
+        throwStartupMigrationGuardRejected();
+      }
+      return { ...read, ...(recovery ? { recovery } : {}) };
     } catch (error) {
+      if (error instanceof ExitError) {
+        throw error;
+      }
       return throwStartupMigrationRefusal(formatErrorMessage(error), error);
     }
   });

--- a/src/commands/doctor-config-preflight-startup.ts
+++ b/src/commands/doctor-config-preflight-startup.ts
@@ -67,6 +67,7 @@ export async function readStartupMigrationSnapshot(params: {
         await params.validateConfig?.(startupConfig);
       }
       const read = await params.readSnapshot();
+      assertStartupConfigUnchanged(selected, read.snapshot);
       const repair = read.snapshot.valid ? null : params.planRepair(read);
       if (!read.snapshot.valid && !repair) {
         throw new Error('OpenClaw config is invalid; run "openclaw doctor --fix" before startup.');
@@ -77,6 +78,15 @@ export async function readStartupMigrationSnapshot(params: {
       return throwStartupMigrationRefusal(formatErrorMessage(error), error);
     }
   });
+}
+
+function assertStartupConfigUnchanged(before: ConfigFileSnapshot, after: ConfigFileSnapshot): void {
+  if (
+    before.path !== after.path ||
+    !isDeepStrictEqual(before.sourceConfig ?? before.config, after.sourceConfig ?? after.config)
+  ) {
+    throwStartupMigrationIdentityChanged();
+  }
 }
 
 /** Admission runs before lease acquisition: even acquiring a lease commits SQLite writes. */
@@ -152,16 +162,7 @@ export async function prepareStartupMigrationPlugins(params: {
     return params.snapshotRead;
   }
   const refreshed = await params.readRefreshedSnapshot();
-  const snapshot = params.snapshotRead.snapshot;
-  if (
-    snapshot.path !== refreshed.snapshot.path ||
-    !isDeepStrictEqual(
-      snapshot.sourceConfig ?? snapshot.config,
-      refreshed.snapshot.sourceConfig ?? refreshed.snapshot.config,
-    )
-  ) {
-    throwStartupMigrationIdentityChanged();
-  }
+  assertStartupConfigUnchanged(params.snapshotRead.snapshot, refreshed.snapshot);
   if (
     params.beforeStateMigrations &&
     !(await measureDoctorConfigPreflightStep(

--- a/src/commands/doctor-config-preflight.admission.process.test.ts
+++ b/src/commands/doctor-config-preflight.admission.process.test.ts
@@ -1,0 +1,220 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { gunzipSync } from "node:zlib";
+import { afterAll, describe, expect, it } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { repairAuditEventsSchema } from "../state/openclaw-state-db-audit-migration.js";
+import {
+  createSourceRuntime,
+  runSourceRuntime,
+} from "./doctor-config-preflight.process.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterAll);
+
+function manifest(root: string): Record<string, string> {
+  // Coordinator locks under tmp/ are lifecycle scratch, not persisted operator state.
+  // SQLite WAL readers update the shared-memory reader index (*-shm).
+  // Accept that reader noise; main databases, WALs, and all other files stay byte-identical.
+  return Object.fromEntries(
+    fs
+      .readdirSync(root, { recursive: true, withFileTypes: true })
+      .filter((entry) => entry.isFile())
+      .map((entry) => path.relative(root, path.join(entry.parentPath, entry.name)))
+      .filter((relative) => relative.split(path.sep)[0] !== "tmp" && !relative.endsWith("-shm"))
+      .toSorted()
+      .map((relative) => [
+        relative,
+        createHash("sha256")
+          .update(fs.readFileSync(path.join(root, relative)))
+          .digest("hex"),
+      ]),
+  );
+}
+
+function schemaMetadata(databasePath: string) {
+  // Inspect a private copy: opening a consolidated WAL database can itself create a WAL.
+  const root = tempDirs.make("openclaw-admission-schema-");
+  const copy = path.join(root, "database.sqlite");
+  for (const suffix of ["", "-wal", "-shm"]) {
+    if (fs.existsSync(`${databasePath}${suffix}`)) {
+      fs.copyFileSync(`${databasePath}${suffix}`, `${copy}${suffix}`);
+    }
+  }
+  const db = new DatabaseSync(copy);
+  try {
+    return {
+      userVersion: db.prepare("PRAGMA user_version").get()?.user_version,
+      schemaMeta: db.prepare("SELECT * FROM schema_meta ORDER BY rowid").all(),
+    };
+  } finally {
+    db.close();
+  }
+}
+
+describe("startup admission before persistent writes", () => {
+  it.each([
+    {
+      name: "legacy workspace",
+      workspace: true,
+      repairable: false,
+      config: "local",
+      reason: "Legacy workspace setup state requires migration",
+    },
+    {
+      name: "legacy workspace with repairable config",
+      workspace: true,
+      repairable: true,
+      config: "local",
+      reason: "Legacy workspace setup state requires migration",
+    },
+    {
+      name: "missing config",
+      workspace: false,
+      repairable: false,
+      config: "absent",
+      reason: "Missing config",
+    },
+    {
+      name: "missing config without an existing WAL",
+      workspace: false,
+      repairable: false,
+      config: "absent",
+      consolidated: true,
+      reason: "Missing config",
+    },
+    {
+      name: "invalid plugin without an existing WAL",
+      workspace: false,
+      repairable: true,
+      config: "local",
+      consolidated: true,
+      invalidPlugin: true,
+      reason: "OpenClaw config is invalid",
+    },
+    {
+      name: "missing gateway.mode",
+      workspace: false,
+      repairable: false,
+      config: "missing-mode",
+      reason: "existing config is missing gateway.mode",
+    },
+    {
+      name: "remote gateway.mode",
+      workspace: false,
+      repairable: false,
+      config: "remote",
+      reason: "set gateway.mode=local (current: remote)",
+    },
+  ])(
+    "preserves shipped schema and every persistent artifact on $name refusal",
+    ({ workspace, repairable, config, reason, consolidated, invalidPlugin }) => {
+      const root = fs.realpathSync(tempDirs.make("openclaw-startup-admission-"));
+      const runtimeRoot = createSourceRuntime(root);
+      const stateDir = path.join(root, "state");
+      const workspaceDir = path.join(stateDir, "workspace");
+      const configPath = path.join(stateDir, "openclaw.json");
+      const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+      fs.mkdirSync(path.dirname(databasePath), { recursive: true });
+      fs.mkdirSync(path.join(stateDir, "agents", "main", "agent"), { recursive: true });
+      fs.mkdirSync(workspaceDir);
+      fs.writeFileSync(
+        databasePath,
+        gunzipSync(fs.readFileSync("test/fixtures/sqlite/openclaw-state-v2026.7.1-2.sqlite.gz")),
+      );
+      // Repair only the audit blocker; released schema 1 still needs automatic migration.
+      // Keeping this idle connection open retains a real WAL in the manifest.
+      const prepared = new DatabaseSync(databasePath);
+      try {
+        prepared.exec("PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0");
+        repairAuditEventsSchema(prepared);
+        if (consolidated) {
+          prepared.close();
+        }
+        if (config !== "absent") {
+          fs.writeFileSync(
+            configPath,
+            JSON.stringify({
+              gateway: config === "missing-mode" ? {} : { mode: config },
+              plugins: invalidPlugin
+                ? { load: { paths: [path.join(root, "missing-plugin")] } }
+                : { enabled: false },
+              agents: { defaults: { workspace: workspaceDir } },
+              ...(repairable ? { session: { idleMinutes: 45 } } : {}),
+            }),
+          );
+        }
+        if (workspace) {
+          fs.writeFileSync(
+            path.join(workspaceDir, "openclaw-workspace-state.json"),
+            JSON.stringify({
+              version: 1,
+              bootstrapSeededAt: "2026-07-02T00:00:00.000Z",
+              setupCompletedAt: "2026-07-02T00:00:00.000Z",
+            }),
+          );
+        }
+        fs.writeFileSync(
+          path.join(stateDir, "agents", "main", "agent", "auth-profiles.json"),
+          '{"version":1,"profiles":{}}\n',
+        );
+        const schemaBefore = schemaMetadata(databasePath);
+        const before = manifest(stateDir);
+        expect(schemaBefore.userVersion).toBe(1);
+        expect(Boolean(before[path.join("state", "openclaw.sqlite-wal")])).toBe(!consolidated);
+        const entry = workspace
+          ? `
+        const { runDoctorConfigPreflight } = await import("./src/commands/doctor-config-preflight.ts");
+        await runDoctorConfigPreflight({ migrateState: true, migrateLegacyConfig: false, requireStartupMigrationCheckpoint: true });
+      `
+          : `
+        const { ensureConfigReady } = await import("./src/cli/program/config-guard.ts");
+        const { ExitError } = await import("./src/runtime.ts");
+        await ensureConfigReady({
+          commandPath: ["gateway", "run"],
+          runtime: { log: console.log, error: console.error, exit(code) { throw new ExitError(code); } },
+        });
+      `;
+        const result = runSourceRuntime(
+          runtimeRoot,
+          {
+            PATH: process.env.PATH,
+            HOME: root,
+            USERPROFILE: root,
+            OPENCLAW_STATE_DIR: stateDir,
+            OPENCLAW_CONFIG_PATH: configPath,
+            OPENCLAW_WORKSPACE_DIR: workspaceDir,
+            OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+            OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "bundled"),
+            NO_COLOR: "1",
+          },
+          [
+            "--input-type=module",
+            "--eval",
+            `
+        try {
+          ${entry}
+        } catch (error) {
+          console.error(error.message);
+          process.exitCode = typeof error.code === "number" ? error.code : 1;
+        }
+      `,
+          ],
+          60_000,
+        );
+        const output = `${result.stdout}\n${result.stderr}`;
+        expect(result.error, output).toBeUndefined();
+        expect(result.status, output).toBe(78);
+        expect(output).toContain(reason);
+        expect(manifest(stateDir)).toEqual(before);
+        expect(schemaMetadata(databasePath)).toEqual(schemaBefore);
+      } finally {
+        if (prepared.isOpen) {
+          prepared.close();
+        }
+      }
+    },
+    75_000,
+  );
+});

--- a/src/commands/doctor-config-preflight.admission.process.test.ts
+++ b/src/commands/doctor-config-preflight.admission.process.test.ts
@@ -70,6 +70,14 @@ describe("startup admission before persistent writes", () => {
       reason: "Legacy workspace setup state requires migration",
     },
     {
+      name: "session store selected by repaired agent ID",
+      workspace: false,
+      repairedSession: true,
+      repairable: false,
+      config: "local",
+      reason: "Legacy session store requires migration",
+    },
+    {
       name: "missing config",
       workspace: false,
       repairable: false,
@@ -109,7 +117,7 @@ describe("startup admission before persistent writes", () => {
     },
   ])(
     "preserves shipped schema and every persistent artifact on $name refusal",
-    ({ workspace, repairable, config, reason, consolidated, invalidPlugin }) => {
+    ({ workspace, repairable, config, reason, consolidated, invalidPlugin, repairedSession }) => {
       const root = fs.realpathSync(tempDirs.make("openclaw-startup-admission-"));
       const runtimeRoot = createSourceRuntime(root);
       const stateDir = path.join(root, "state");
@@ -140,10 +148,25 @@ describe("startup admission before persistent writes", () => {
               plugins: invalidPlugin
                 ? { load: { paths: [path.join(root, "missing-plugin")] } }
                 : { enabled: false },
-              agents: { defaults: { workspace: workspaceDir } },
-              ...(repairable ? { session: { idleMinutes: 45 } } : {}),
+              agents: repairedSession
+                ? { list: [{ id: "" }] }
+                : { defaults: { workspace: workspaceDir } },
+              ...(repairedSession
+                ? {
+                    session: {
+                      store: path.join(stateDir, "external", "{agentId}", "sessions.json"),
+                    },
+                  }
+                : repairable
+                  ? { session: { idleMinutes: 45 } }
+                  : {}),
             }),
           );
+        }
+        if (repairedSession) {
+          const legacyStore = path.join(stateDir, "external", "agent", "sessions.json");
+          fs.mkdirSync(path.dirname(legacyStore), { recursive: true });
+          fs.writeFileSync(legacyStore, "{}\n");
         }
         if (workspace) {
           fs.writeFileSync(
@@ -163,12 +186,13 @@ describe("startup admission before persistent writes", () => {
         const before = manifest(stateDir);
         expect(schemaBefore.userVersion).toBe(1);
         expect(Boolean(before[path.join("state", "openclaw.sqlite-wal")])).toBe(!consolidated);
-        const entry = workspace
-          ? `
+        const entry =
+          workspace || repairedSession
+            ? `
         const { runDoctorConfigPreflight } = await import("./src/commands/doctor-config-preflight.ts");
         await runDoctorConfigPreflight({ migrateState: true, migrateLegacyConfig: false, requireStartupMigrationCheckpoint: true });
       `
-          : `
+            : `
         const { ensureConfigReady } = await import("./src/cli/program/config-guard.ts");
         const { ExitError } = await import("./src/runtime.ts");
         await ensureConfigReady({

--- a/src/commands/doctor-config-preflight.admission.process.test.ts
+++ b/src/commands/doctor-config-preflight.admission.process.test.ts
@@ -56,6 +56,21 @@ function schemaMetadata(databasePath: string) {
 describe("startup admission before persistent writes", () => {
   it.each([
     {
+      name: "clobbered config with a healthy backup",
+      workspace: false,
+      repairable: false,
+      config: "clobbered",
+      restored: true,
+      reason: "Config auto-restored from backup",
+    },
+    {
+      name: "clobbered config with a legacy workspace in its backup",
+      workspace: true,
+      repairable: false,
+      config: "clobbered",
+      reason: "Legacy workspace setup state requires migration",
+    },
+    {
       name: "legacy workspace",
       workspace: true,
       repairable: false,
@@ -116,12 +131,24 @@ describe("startup admission before persistent writes", () => {
       reason: "set gateway.mode=local (current: remote)",
     },
   ])(
-    "preserves shipped schema and every persistent artifact on $name refusal",
-    ({ workspace, repairable, config, reason, consolidated, invalidPlugin, repairedSession }) => {
+    "admits or preserves shipped state for $name",
+    ({
+      workspace,
+      repairable,
+      config,
+      reason,
+      consolidated,
+      invalidPlugin,
+      repairedSession,
+      restored,
+    }) => {
       const root = fs.realpathSync(tempDirs.make("openclaw-startup-admission-"));
       const runtimeRoot = createSourceRuntime(root);
       const stateDir = path.join(root, "state");
-      const workspaceDir = path.join(stateDir, "workspace");
+      const workspaceDir = path.join(
+        stateDir,
+        config === "clobbered" ? "recovered-workspace" : "workspace",
+      );
       const configPath = path.join(stateDir, "openclaw.json");
       const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
       fs.mkdirSync(path.dirname(databasePath), { recursive: true });
@@ -144,7 +171,10 @@ describe("startup admission before persistent writes", () => {
           fs.writeFileSync(
             configPath,
             JSON.stringify({
-              gateway: config === "missing-mode" ? {} : { mode: config },
+              gateway:
+                config === "missing-mode"
+                  ? {}
+                  : { mode: config === "clobbered" ? "local" : config },
               plugins: invalidPlugin
                 ? { load: { paths: [path.join(root, "missing-plugin")] } }
                 : { enabled: false },
@@ -162,6 +192,13 @@ describe("startup admission before persistent writes", () => {
                   : {}),
             }),
           );
+          if (config === "clobbered") {
+            fs.copyFileSync(configPath, `${configPath}.bak`);
+            fs.writeFileSync(
+              configPath,
+              '{"update":{"channel":"stable"},"env":{"vars":{"OPENCLAW_GATEWAY_TOKEN":"discarded-test-token"}}}\n',
+            );
+          }
         }
         if (repairedSession) {
           const legacyStore = path.join(stateDir, "external", "agent", "sessions.json");
@@ -199,6 +236,9 @@ describe("startup admission before persistent writes", () => {
           commandPath: ["gateway", "run"],
           runtime: { log: console.log, error: console.error, exit(code) { throw new ExitError(code); } },
         });
+        if (${Boolean(restored)} && process.env.OPENCLAW_GATEWAY_TOKEN) {
+          throw new Error("Discarded clobbered config environment leaked through admission.");
+        }
       `;
         const result = runSourceRuntime(
           runtimeRoot,
@@ -208,7 +248,8 @@ describe("startup admission before persistent writes", () => {
             USERPROFILE: root,
             OPENCLAW_STATE_DIR: stateDir,
             OPENCLAW_CONFIG_PATH: configPath,
-            OPENCLAW_WORKSPACE_DIR: workspaceDir,
+            OPENCLAW_WORKSPACE_DIR:
+              config === "clobbered" ? path.join(stateDir, "empty-workspace") : workspaceDir,
             OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
             OPENCLAW_BUNDLED_PLUGINS_DIR: path.join(root, "bundled"),
             NO_COLOR: "1",
@@ -229,10 +270,17 @@ describe("startup admission before persistent writes", () => {
         );
         const output = `${result.stdout}\n${result.stderr}`;
         expect(result.error, output).toBeUndefined();
-        expect(result.status, output).toBe(78);
+        expect(result.status, output).toBe(restored ? 0 : 78);
         expect(output).toContain(reason);
-        expect(manifest(stateDir)).toEqual(before);
-        expect(schemaMetadata(databasePath)).toEqual(schemaBefore);
+        if (restored) {
+          expect(fs.readFileSync(configPath, "utf8")).toBe(
+            fs.readFileSync(`${configPath}.bak`, "utf8"),
+          );
+          expect(schemaMetadata(databasePath).userVersion).toBe(16);
+        } else {
+          expect(manifest(stateDir)).toEqual(before);
+          expect(schemaMetadata(databasePath)).toEqual(schemaBefore);
+        }
       } finally {
         if (prepared.isOpen) {
           prepared.close();

--- a/src/commands/doctor-config-preflight.process.test.ts
+++ b/src/commands/doctor-config-preflight.process.test.ts
@@ -858,7 +858,7 @@ describe("gateway startup-migration refusal", () => {
           ownerId: "live-owner-refusal-test",
           createdAt: new Date().toISOString(),
           configPath,
-          port: 18789,
+          port: 18720,
           stateDir,
           ...(startTime !== null ? { startTime } : {}),
         }),
@@ -868,7 +868,7 @@ describe("gateway startup-migration refusal", () => {
       const result = runBuiltRuntime(
         runtimeRoot,
         env,
-        ["gateway", "run", "--allow-unconfigured"],
+        ["gateway", "run", "--port", "18720", "--allow-unconfigured"],
         30_000,
       );
       const output = `${result.stderr}\n${result.stdout}`;
@@ -880,7 +880,7 @@ describe("gateway startup-migration refusal", () => {
       expect(fs.existsSync(path.join(stateDir, "agents", "main", "agent")), output).toBe(false);
       // No orphan-sidecar quarantine copy either: write admission never ran.
       expect(fs.readdirSync(sharedStateDbDir), output).toEqual(["openclaw.sqlite-wal"]);
-      expect(result.status, output).toBe(1);
+      expect(result.status, output).toBe(78);
       expect(result.stderr, output).toContain("already owns this state directory");
       expect(hasActiveStartupMigrationLease({ env })).toBe(false);
     } finally {

--- a/src/commands/doctor-config-preflight.recovery.test.ts
+++ b/src/commands/doctor-config-preflight.recovery.test.ts
@@ -88,3 +88,50 @@ it.each(["backup", "active config"] as const)(
     });
   },
 );
+
+it.each(["expired", "reassigned"] as const)(
+  "does not restore a backup after the migration lease is %s during admission",
+  async (loss) => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      const stateDir = path.join(home, ".openclaw");
+      const configPath = path.join(stateDir, "openclaw.json");
+      await fs.mkdir(stateDir, { recursive: true });
+      const original = '{"update":{"channel":"stable"}}\n';
+      await fs.writeFile(configPath, original);
+      await fs.writeFile(
+        `${configPath}.bak`,
+        JSON.stringify({ gateway: { mode: "local" }, plugins: { enabled: false } }),
+      );
+      openOpenClawStateDatabase({ path: path.join(stateDir, "state", "openclaw.sqlite") });
+      closeOpenClawStateDatabaseForTest();
+      let replacement: checkpoint.StartupMigrationLease | undefined;
+      vi.spyOn(checkpoint, "acquireStartupMigrationLeaseWithWait").mockImplementationOnce(
+        async (params) => {
+          const stale = checkpoint.acquireStartupMigrationLease({
+            ...params,
+            nowMs: Date.now() - checkpoint.STARTUP_MIGRATION_LEASE_TTL_MS - 1,
+          });
+          if (loss === "reassigned") {
+            replacement = checkpoint.acquireStartupMigrationLease(params);
+          }
+          return stale;
+        },
+      );
+      try {
+        const refusal = await runDoctorConfigPreflight({
+          migrateLegacyConfig: false,
+          requireStartupMigrationCheckpoint: true,
+        }).catch((error: unknown) => error);
+        expect(await fs.readFile(configPath, "utf8")).toBe(original);
+        expect((await fs.readdir(stateDir)).filter((name) => name.includes(".clobbered."))).toEqual(
+          [],
+        );
+        expect(refusal).toBeInstanceOf(Error);
+        expect(String(refusal)).toContain("startup migration lease was lost");
+        replacement?.heartbeat();
+      } finally {
+        replacement?.release();
+      }
+    });
+  },
+);

--- a/src/commands/doctor-config-preflight.recovery.test.ts
+++ b/src/commands/doctor-config-preflight.recovery.test.ts
@@ -1,0 +1,90 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, expect, it, vi } from "vitest";
+import {
+  prepareGatewayRunBootstrap,
+  recheckGatewayRunBootstrap,
+} from "../cli/gateway-cli/pre-bootstrap.js";
+import { withEnvOverride } from "../config/test-helpers.js";
+import * as checkpoint from "../infra/startup-migration-checkpoint.js";
+import { ExitError } from "../runtime.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { runDoctorConfigPreflight } from "./doctor-config-preflight.js";
+import { withDoctorConfigPreflightHome } from "./doctor-config-preflight.test-support.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  closeOpenClawStateDatabaseForTest();
+});
+
+it.each(["backup", "active config"] as const)(
+  "refuses changed %s under the lease before any repair",
+  async (kind) => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      const stateDir = path.join(home, ".openclaw");
+      const configPath = path.join(stateDir, "openclaw.json");
+      await fs.mkdir(stateDir, { recursive: true });
+      const backup = { gateway: { mode: "local" }, plugins: { enabled: false } };
+      const original =
+        kind === "backup" ? '{"update":{"channel":"stable"}}\n' : JSON.stringify(backup);
+      const replacement = JSON.stringify(
+        kind === "backup"
+          ? {
+              ...backup,
+              meta: { lastTouchedVersion: "9999.1.1" },
+              env: { vars: { OPENCLAW_SERVICE_MARKER: "openclaw" } },
+            }
+          : {
+              ...backup,
+              agents: { defaults: { workspace: path.join(home, "changed-workspace") } },
+            },
+      );
+      openOpenClawStateDatabase({ path: path.join(stateDir, "state", "openclaw.sqlite") });
+      closeOpenClawStateDatabaseForTest();
+      const stateMigration = await import("../infra/state-migrations.state-dir.js");
+      const migrateStateDir = vi.spyOn(stateMigration, "autoMigrateLegacyStateDir");
+      await fs.writeFile(configPath, original);
+      if (kind === "backup") {
+        await fs.writeFile(`${configPath}.bak`, JSON.stringify(backup));
+      }
+      const runtime = {
+        log() {},
+        error() {},
+        exit(code: number): never {
+          throw new ExitError(code);
+        },
+      };
+      await withEnvOverride(
+        { OPENCLAW_ALLOW_OLDER_BINARY_DESTRUCTIVE_ACTIONS: undefined },
+        async () => {
+          expect(await prepareGatewayRunBootstrap({ opts: {}, runtime })).toBe(true);
+          const acquire = checkpoint.acquireStartupMigrationLeaseWithWait;
+          vi.spyOn(checkpoint, "acquireStartupMigrationLeaseWithWait").mockImplementationOnce(
+            async (params) => {
+              const lease = await acquire(params);
+              await fs.writeFile(kind === "backup" ? `${configPath}.bak` : configPath, replacement);
+              return lease;
+            },
+          );
+          const refusal = await runDoctorConfigPreflight({
+            migrateLegacyConfig: false,
+            requireStartupMigrationCheckpoint: true,
+            beforeStateMigrations: (snapshot) =>
+              recheckGatewayRunBootstrap({ opts: {}, runtime, snapshot }),
+          }).catch((error: unknown) => error);
+          expect(migrateStateDir).not.toHaveBeenCalled();
+          expect(refusal).toMatchObject({ code: kind === "backup" ? 78 : 1 });
+          expect(await fs.readFile(configPath, "utf8")).toBe(
+            kind === "backup" ? original : replacement,
+          );
+          expect(
+            (await fs.readdir(stateDir)).filter((name) => name.includes(".clobbered.")),
+          ).toEqual([]);
+        },
+      );
+    });
+  },
+);

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -398,7 +398,6 @@ describe("runDoctorConfigPreflight state migration", () => {
 
     expect(readMigrationCheckpointStatus).not.toHaveBeenCalled();
     expect(acquireStartupMigrationLeaseWithWait).not.toHaveBeenCalled();
-    expect(readConfigFileSnapshot).not.toHaveBeenCalled();
   });
 
   it("releases the startup lease when the fresh config guard rejects", async () => {
@@ -890,9 +889,8 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(autoMigrateLegacyState).not.toHaveBeenCalled();
     expect(autoMigrateLegacyPluginDoctorState).not.toHaveBeenCalled();
     expect(autoMigrateLegacyTaskStateSidecars).not.toHaveBeenCalled();
-    expect(beforeStateMigrations).toHaveBeenNthCalledWith(1);
     expect(beforeStateMigrations).toHaveBeenNthCalledWith(
-      2,
+      1,
       expect.objectContaining({ valid: true }),
     );
     expect(recordSuccessfulStartupMigrations).toHaveBeenCalledOnce();

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -818,14 +818,10 @@ describe("runDoctorConfigPreflight state migration", () => {
 
   it("keeps ownerless install-record failures blocking", async () => {
     readMigrationCheckpointStatus.mockReturnValue("stale");
-    queueConfigSnapshot(
-      readConfigFileSnapshot,
-      makePreflightConfigSnapshot({
-        gateway: { mode: "local", port: 19091 },
-        plugins: { entries: { discord: { enabled: true } } },
-      }),
-      3,
-    );
+    const snapshot = makePreflightConfigSnapshot({
+      gateway: { mode: "local", port: 19091 },
+      plugins: { entries: { discord: { enabled: true } } },
+    });
     runPostCorePluginConvergence.mockResolvedValueOnce(
       makeStartupConvergenceResult({
         errored: true,
@@ -847,8 +843,12 @@ describe("runDoctorConfigPreflight state migration", () => {
       }),
     );
 
-    await expect(runDoctorConfigPreflight(startupCheckpointOptions)).rejects.toThrow(
-      'Plugin "discord" has no install path.',
+    await readConfigFileSnapshot.withImplementation(
+      async () => snapshot,
+      () =>
+        expect(runDoctorConfigPreflight(startupCheckpointOptions)).rejects.toThrow(
+          'Plugin "discord" has no install path.',
+        ),
     );
 
     expect(listActiveDegradedPlugins()).toEqual([]);
@@ -1030,14 +1030,10 @@ describe("runDoctorConfigPreflight state migration", () => {
 
   it("quarantines a plugin payload verification failure and checkpoints readiness", async () => {
     readMigrationCheckpointStatus.mockReturnValue("stale");
-    queueConfigSnapshot(
-      readConfigFileSnapshot,
-      makePreflightConfigSnapshot({
-        gateway: { mode: "local", port: 19091 },
-        plugins: { entries: { discord: { enabled: true } } },
-      }),
-      5,
-    );
+    const snapshot = makePreflightConfigSnapshot({
+      gateway: { mode: "local", port: 19091 },
+      plugins: { entries: { discord: { enabled: true } } },
+    });
     runPostCorePluginConvergence.mockResolvedValueOnce(
       makeStartupConvergenceResult({
         errored: true,
@@ -1063,7 +1059,10 @@ describe("runDoctorConfigPreflight state migration", () => {
       }),
     );
 
-    await runDoctorConfigPreflight(startupCheckpointOptions);
+    await readConfigFileSnapshot.withImplementation(
+      async () => snapshot,
+      () => runDoctorConfigPreflight(startupCheckpointOptions),
+    );
 
     expect(listActiveDegradedPlugins()).toEqual([
       {
@@ -1088,23 +1087,29 @@ describe("runDoctorConfigPreflight state migration", () => {
     expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
   });
 
-  it("does not checkpoint startup migrations when the config snapshot is invalid", async () => {
+  it("refuses invalid config before acquiring the startup lease or running migrations", async () => {
     readMigrationCheckpointStatus.mockReturnValue("stale");
-    queueConfigSnapshot(
-      readConfigFileSnapshot,
-      {
-        ...makePreflightConfigSnapshot({ gateway: { mode: "local", port: "bad" } }),
-        valid: false,
-        issues: [{ path: "gateway.port", message: "invalid" }],
-      },
-      3,
+    const snapshot = {
+      ...makePreflightConfigSnapshot({ gateway: { mode: "local", port: "bad" } }),
+      valid: false,
+      issues: [{ path: "gateway.port", message: "invalid" }],
+    };
+    await readConfigFileSnapshot.withImplementation(
+      async () => snapshot,
+      () =>
+        expect(runDoctorConfigPreflight(startupCheckpointOptions)).rejects.toThrow(
+          "OpenClaw config is invalid",
+        ),
     );
 
-    await expect(runDoctorConfigPreflight(startupCheckpointOptions)).rejects.toThrow(
-      "OpenClaw config is invalid",
-    );
-
+    expect(acquireStartupMigrationLeaseWithWait).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyStateDir).not.toHaveBeenCalled();
+    expect(repairLegacyCronStoreWithoutPrompt).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyState).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyPluginDoctorState).not.toHaveBeenCalled();
+    expect(autoMigrateLegacyTaskStateSidecars).not.toHaveBeenCalled();
+    expect(recordSuccessfulStateMigrations).not.toHaveBeenCalled();
     expect(recordSuccessfulStartupMigrations).not.toHaveBeenCalled();
-    expect(startupMigrationLeaseRelease).toHaveBeenCalledOnce();
+    expect(startupMigrationLeaseRelease).not.toHaveBeenCalled();
   });
 });

--- a/src/commands/doctor-config-preflight.state-migration.test.ts
+++ b/src/commands/doctor-config-preflight.state-migration.test.ts
@@ -701,7 +701,7 @@ describe("runDoctorConfigPreflight state migration", () => {
     });
 
     await expect(runDoctorConfigPreflight(startupCheckpointOptions)).rejects.toThrow(
-      "plugin migration inputs changed during startup convergence",
+      "migration inputs changed during startup",
     );
 
     expect(autoMigrateLegacyState).not.toHaveBeenCalled();
@@ -719,7 +719,7 @@ describe("runDoctorConfigPreflight state migration", () => {
     );
 
     await expect(runDoctorConfigPreflight(startupCheckpointOptions)).rejects.toThrow(
-      "plugin migration inputs changed during startup convergence",
+      "migration inputs changed during startup",
     );
 
     expect(recordSuccessfulStateMigrations).toHaveBeenCalledWith({

--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -166,7 +166,9 @@ describe("runDoctorConfigPreflight", () => {
             if (!snapshot) {
               return true;
             }
-            expect(hasActiveStartupMigrationLease()).toBe(true);
+            if (snapshot.valid) {
+              expect(hasActiveStartupMigrationLease()).toBe(true);
+            }
             return !snapshot.valid || isStartupConfigRepairResult(before, snapshot);
           },
         });

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -65,9 +65,7 @@ const loadStateDirMigrations = createLazyRuntimeModule(
   () => import("../infra/state-migrations.state-dir.js"),
 );
 
-const loadLegacyCronRepair = createLazyRuntimeModule(
-  () => import("./doctor/cron/legacy-repair.js"),
-);
+const loadCronRepair = createLazyRuntimeModule(() => import("./doctor/cron/legacy-repair.js"));
 
 const configLog = createSubsystemLogger("config");
 
@@ -159,7 +157,7 @@ export async function runDoctorConfigPreflight(
   let postSessionPluginMigrationPlanBound = false;
   let doctorMediaPersistenceAttempted = false;
   let legacyConfigMigrationComplete = false;
-  let configSnapshotRead: DoctorConfigPreflightPluginSnapshotRead | undefined;
+  let configSnapshotRead: Awaited<ReturnType<typeof readStartupMigrationSnapshot>> | undefined;
   const { run: runWithPluginMetadataSnapshot } = createDoctorPluginMetadataSnapshotScope({
     getBaseSnapshot: () => configSnapshotRead?.pluginMetadataSnapshot,
     env: process.env,
@@ -203,7 +201,8 @@ export async function runDoctorConfigPreflight(
     if (
       !shouldRecordStateCheckpoint &&
       !shouldRecordStartupCheckpoint &&
-      !shouldPersistRefreshedPluginIndex
+      !shouldPersistRefreshedPluginIndex &&
+      !configSnapshotRead.recovery
     ) {
       startupMigrationLease.release();
       startupMigrationLease = undefined;
@@ -220,6 +219,8 @@ export async function runDoctorConfigPreflight(
       }
     }, 60_000);
     startupMigrationHeartbeat.unref?.();
+    // Restore only the backup admitted under this lease, before any other repair.
+    await configSnapshotRead.recovery?.apply();
   };
   const noteStartupStateMigrationResult = (result: MigrationMessages) => {
     startupMigrationWarnings.push(...result.warnings);
@@ -286,6 +287,7 @@ export async function runDoctorConfigPreflight(
           : planScopedConfigRepair(read.snapshot);
       },
       validateConfig: options.validateStartupConfig,
+      beforeStateMigrations: options.beforeStateMigrations,
     });
   try {
     if (migrationCheckpoint && !skipPristineStartupStateMigrations) {
@@ -305,17 +307,14 @@ export async function runDoctorConfigPreflight(
       // until command execution reaches a real state consumer.
       migrationCheckpoint = undefined;
     }
-    // The gateway uses this last-moment guard to ensure its prepared config did not change before
-    // any automatic migration mutates state. A rejected guard skips every state migration stage.
+    // Gateway admission owns its prepared-snapshot guard; other callers guard migrations here.
     const stateMigrationsAllowed =
       !stateMigrationsRequested ||
+      gatewayStartupCheckpointRequired ||
       options.beforeStateMigrations === undefined ||
       (await measurePreflightStep("state-migration-guard", () =>
         withArtifactPreservingStateReads(() => options.beforeStateMigrations?.()),
       ));
-    if (gatewayStartupCheckpointRequired && !stateMigrationsAllowed) {
-      throwStartupMigrationGuardRejected();
-    }
     if (migrationCheckpoint) {
       if (!gatewayStartupCheckpointRequired) {
         await migrateLegacyConfigIfNeeded();
@@ -329,7 +328,8 @@ export async function runDoctorConfigPreflight(
       if (
         shouldRecordStateCheckpoint ||
         shouldRecordStartupCheckpoint ||
-        shouldPersistRefreshedPluginIndex
+        shouldPersistRefreshedPluginIndex ||
+        configSnapshotRead.recovery
       ) {
         await ensureStartupMigrationLease();
       }
@@ -553,7 +553,7 @@ export async function runDoctorConfigPreflight(
           const {
             collectCronCodexRuntimePolicyTargetsReadOnly,
             repairLegacyCronStoreWithoutPrompt,
-          } = await measurePreflightStep("cron-repair-import", loadLegacyCronRepair);
+          } = await measurePreflightStep("cron-repair-import", loadCronRepair);
           const cronResult = await measurePreflightStep("cron-repair", () =>
             repairLegacyCronStoreWithoutPrompt({
               cfg: cronMigration.withLegacyConfig(migrationConfig, pluginDoctorConfig),
@@ -606,7 +606,7 @@ export async function runDoctorConfigPreflight(
             // cron.store is still the sole authority for selecting and preserving that partition.
             const { repairLegacyCronStoreWithoutPrompt } = await measurePreflightStep(
               "cron-repair-import",
-              loadLegacyCronRepair,
+              loadCronRepair,
             );
             noteStartupStateMigrationResult(
               await measurePreflightStep("cron-repair", () =>

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -218,7 +218,7 @@ export async function runDoctorConfigPreflight(
     }, 60_000);
     startupMigrationHeartbeat.unref?.();
     // Restore only the backup admitted under this lease, before any other repair.
-    await configSnapshotRead.recovery?.apply();
+    await configSnapshotRead.recovery?.apply(startupMigrationLease.heartbeat);
   };
   const noteStartupStateMigrationResult = (result: MigrationMessages) => {
     startupMigrationWarnings.push(...result.warnings);

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -29,6 +29,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import { createLazyRuntimeModule } from "../shared/lazy-runtime.js";
+import { withArtifactPreservingStateReads } from "../state/openclaw-state-db-readonly.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { assertOpenClawStateWriteAllowedAtPath } from "../state/openclaw-state-ownership.js";
 import { noteIncludeConfinementWarning } from "./doctor-config-analysis.js";
@@ -310,7 +311,7 @@ export async function runDoctorConfigPreflight(
       !stateMigrationsRequested ||
       options.beforeStateMigrations === undefined ||
       (await measurePreflightStep("state-migration-guard", () =>
-        options.beforeStateMigrations?.(),
+        withArtifactPreservingStateReads(() => options.beforeStateMigrations?.()),
       ));
     if (gatewayStartupCheckpointRequired && !stateMigrationsAllowed) {
       throwStartupMigrationGuardRejected();

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -43,16 +43,14 @@ import {
 } from "./doctor-config-preflight-plugin-index.js";
 import {
   assertDoctorPreflightMigrationsComplete,
+  readStartupMigrationSnapshot,
   completeStartupMigrationPreflight,
   noteStateMigrationResult,
   prepareStartupMigrationPlugins,
 } from "./doctor-config-preflight-startup.js";
 import * as cronMigration from "./doctor-config-preflight.cron.js";
 import { maybeRepairPluginOpenClawHostLinks } from "./doctor-plugin-host-links.js";
-import {
-  refuseStartupMigrationsForLiveGatewayOwner,
-  throwStartupMigrationGuardRejected,
-} from "./doctor-startup-migration-refusal.js";
+import { throwStartupMigrationGuardRejected } from "./doctor-startup-migration-refusal.js";
 import { noteStaleUpdateRuns } from "./doctor-update-run.js";
 import type { CronCodexRuntimePolicyTarget } from "./doctor/cron/store-migration.js";
 import {
@@ -106,6 +104,8 @@ export async function runDoctorConfigPreflight(
     measure?: ConfigSnapshotReadMeasure;
     /** Return false or reject on config drift; the preflight always unwinds owned resources. */
     beforeStateMigrations?: (snapshot?: ConfigFileSnapshot) => Promise<boolean>;
+    /** CLI readiness policy evaluates the dry repaired config before any startup writes. */
+    validateStartupConfig?: (snapshot: ConfigFileSnapshot) => void | Promise<void>;
     requireStateMigrationCheckpoint?: boolean;
     requireStartupMigrationCheckpoint?: boolean;
     /** Load one authoritative plugin metadata snapshot for the caller's full lifecycle. */
@@ -122,15 +122,11 @@ export async function runDoctorConfigPreflight(
   const gatewayStartupCheckpointRequired = options.requireStartupMigrationCheckpoint === true;
   // Startup publishes one aggregate report; ordinary Doctor calls keep their per-stage output.
   const migrationLog = gatewayStartupCheckpointRequired ? { info() {}, warn() {} } : undefined;
-  if (gatewayStartupCheckpointRequired) {
-    // First preflight operation: state write admission below already quarantines orphaned
-    // SQLite sidecars, so the live-owner refusal must precede every mutation-capable step.
-    await refuseStartupMigrationsForLiveGatewayOwner(process.env);
-  }
   if (stateMigrationsRequested) {
     await assertOpenClawStateWriteAllowedAtPath({
       databasePath: resolveOpenClawStateSqlitePath(process.env),
       env: process.env,
+      recoverOrphanedSidecars: !gatewayStartupCheckpointRequired,
     });
   }
   noteStaleUpdateRuns(options);
@@ -194,17 +190,14 @@ export async function runDoctorConfigPreflight(
     if (startupMigrationLease || !migrationCheckpoint) {
       return;
     }
-    if (gatewayStartupCheckpointRequired) {
-      // Re-probe past the entry gate: the lease wait below can block behind a sibling
-      // startup that becomes the live owner before our migrations would mutate its state.
-      await refuseStartupMigrationsForLiveGatewayOwner(startupMigrationEnv);
-    }
     startupMigrationLease = await migrationCheckpoint.acquireStartupMigrationLeaseWithWait({
       env: startupMigrationEnv,
     });
     // Another process may have completed the same work between our pre-lease read and acquisition.
     // Refresh every checkpoint input under the lease so only work still missing from state runs.
-    configSnapshotRead = await readConfigSnapshotForPreflight(false);
+    configSnapshotRead = gatewayStartupCheckpointRequired
+      ? await readAdmittedStartupSnapshot()
+      : await readConfigSnapshotForPreflight(false);
     refreshMigrationCheckpoint(migrationCheckpoint, configSnapshotRead);
     if (
       !shouldRecordStateCheckpoint &&
@@ -257,13 +250,10 @@ export async function runDoctorConfigPreflight(
       planAutomaticConfigRepair(snapshot),
     );
   const migrateLegacyConfigIfNeeded = async () => {
-    if (legacyConfigMigrationComplete) {
+    if (legacyConfigMigrationComplete || options.migrateLegacyConfig === false) {
       return;
     }
     legacyConfigMigrationComplete = true;
-    if (options.migrateLegacyConfig === false) {
-      return;
-    }
     const legacyConfigChanges = await measurePreflightStep(
       "legacy-config-migration",
       maybeMigrateLegacyConfig,
@@ -279,11 +269,23 @@ export async function runDoctorConfigPreflight(
         includePluginMetadata:
           Boolean(migrationCheckpoint) || options.preparePluginMetadataSnapshot === true,
         measure: options.measure,
-        observe: options.observe,
+        observe: gatewayStartupCheckpointRequired ? false : options.observe,
         preparePluginMetadataSnapshot: options.preparePluginMetadataSnapshot === true,
         skipPluginValidation: shouldSkipPluginValidationForDoctorConfigPreflight(),
       }),
     );
+  const readAdmittedStartupSnapshot = () =>
+    readStartupMigrationSnapshot({
+      env: startupMigrationEnv,
+      readSnapshot: () => readConfigSnapshotForPreflight(false),
+      planRepair: (read) => {
+        configSnapshotRead = read;
+        return shouldSkipPluginValidationForDoctorConfigPreflight()
+          ? null
+          : planScopedConfigRepair(read.snapshot);
+      },
+      validateConfig: options.validateStartupConfig,
+    });
   try {
     if (migrationCheckpoint && !skipPristineStartupStateMigrations) {
       // Capture pristine state before command bootstrap can prepare runtime state.
@@ -314,8 +316,12 @@ export async function runDoctorConfigPreflight(
       throwStartupMigrationGuardRejected();
     }
     if (migrationCheckpoint) {
-      await migrateLegacyConfigIfNeeded();
-      configSnapshotRead = await readConfigSnapshotForPreflight();
+      if (!gatewayStartupCheckpointRequired) {
+        await migrateLegacyConfigIfNeeded();
+      }
+      configSnapshotRead = gatewayStartupCheckpointRequired
+        ? await readAdmittedStartupSnapshot()
+        : await readConfigSnapshotForPreflight();
       // Later config reads can apply state selectors. Pin the accepted lease target for its lifetime.
       startupMigrationEnv = cloneEnvWithPlatformSemantics(process.env);
       refreshMigrationCheckpoint(migrationCheckpoint, configSnapshotRead);
@@ -666,14 +672,6 @@ export async function runDoctorConfigPreflight(
       configSnapshotRead = await readConfigSnapshotForPreflight(false);
       snapshot = configSnapshotRead.snapshot;
       baseConfig = snapshot.sourceConfig ?? snapshot.config ?? {};
-      if (
-        options.beforeStateMigrations &&
-        !(await measurePreflightStep("repaired-config-guard", () =>
-          options.beforeStateMigrations?.(snapshot),
-        ))
-      ) {
-        throwStartupMigrationGuardRejected();
-      }
       if (migrationCheckpoint) {
         refreshMigrationCheckpoint(migrationCheckpoint, configSnapshotRead);
       }

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -61,9 +61,7 @@ import {
 import { resolveStateMigrationConfigInput } from "./doctor/shared/legacy-config-state-migration-input.js";
 import { createDoctorPluginMetadataSnapshotScope } from "./doctor/shared/plugin-metadata-snapshot-scope.js";
 
-const loadStateDirMigrations = createLazyRuntimeModule(
-  () => import("../infra/state-migrations.state-dir.js"),
-);
+const loadState = createLazyRuntimeModule(() => import("../infra/state-migrations.state-dir.js"));
 
 const loadCronRepair = createLazyRuntimeModule(() => import("./doctor/cron/legacy-repair.js"));
 
@@ -340,7 +338,7 @@ export async function runDoctorConfigPreflight(
       stateMigrationsRequested &&
       (!migrationCheckpoint || shouldRecordStateCheckpoint) &&
       !skipPristineStartupStateMigrations
-        ? await measurePreflightStep("state-migrations-import", loadStateDirMigrations)
+        ? await measurePreflightStep("state-migrations-import", loadState)
         : undefined;
     if (stateDirMigrations && stateMigrationsAllowed) {
       const { autoMigrateLegacyStateDir } = stateDirMigrations;
@@ -467,10 +465,7 @@ export async function runDoctorConfigPreflight(
         ) {
           shouldRecordStateCheckpoint = true;
           if (!stateDirMigrations && !skipPristineStartupStateMigrations) {
-            stateDirMigrations = await measurePreflightStep(
-              "state-migrations-import",
-              loadStateDirMigrations,
-            );
+            stateDirMigrations = await measurePreflightStep("state-migrations-import", loadState);
           }
         }
         // The refreshed package inventory now owns both state migration and its checkpoint.

--- a/src/commands/doctor-startup-migration-refusal.test.ts
+++ b/src/commands/doctor-startup-migration-refusal.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolveGatewayStartupMaintenanceReason } from "../cli/gateway-cli/startup-maintenance.js";
+import { OpenClawStateDatabaseSchemaMigrationRequiredError } from "../state/openclaw-state-db-schema-migration-required.js";
+import { throwStartupMigrationRefusal } from "./doctor-startup-migration-refusal.js";
+
+describe("startup refusal handoff", () => {
+  it("preserves maintenance classification after the preflight exit", () => {
+    const cause = new OpenClawStateDatabaseSchemaMigrationRequiredError(
+      "audit-events-v2",
+      "/synthetic/state/openclaw.sqlite",
+    );
+    const output = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    let refusal: unknown;
+    try {
+      throwStartupMigrationRefusal("Startup admission failed.", cause);
+    } catch (error) {
+      refusal = error;
+    } finally {
+      output.mockRestore();
+    }
+    expect(resolveGatewayStartupMaintenanceReason(refusal)).toBe("state database schema migration");
+  });
+});

--- a/src/commands/doctor-startup-migration-refusal.ts
+++ b/src/commands/doctor-startup-migration-refusal.ts
@@ -15,7 +15,7 @@ export function throwStartupMigrationGuardRejected(): never {
 
 export function throwStartupMigrationIdentityChanged(): never {
   throwStartupMigrationRefusal(
-    "OpenClaw plugin migration inputs changed during startup convergence; refusing to report the gateway ready. Restart OpenClaw so state migrations run against the final config and plugin inventory.",
+    "OpenClaw migration inputs changed during startup; refusing to report the gateway ready. Restart OpenClaw so state migrations run against the final config and plugin inventory.",
   );
 }
 

--- a/src/commands/doctor-startup-migration-refusal.ts
+++ b/src/commands/doctor-startup-migration-refusal.ts
@@ -1,10 +1,10 @@
 // Gateway startup-migration readiness refusals shared by doctor config preflight.
 import { ExitError } from "../runtime.js";
 
-export function throwStartupMigrationRefusal(message: string): never {
+export function throwStartupMigrationRefusal(message: string, cause?: unknown): never {
   // ExitError bypasses entry.ts's generic failure formatter, so report the owned reason here.
   console.error(message);
-  throw new ExitError(1, message);
+  throw Object.assign(new ExitError(78, message), { cause });
 }
 
 export function throwStartupMigrationGuardRejected(): never {
@@ -27,7 +27,7 @@ export function throwStartupMigrationIdentityChanged(): never {
  * Test runs skip the probe like acquireGatewayLock does (locks are disabled under Vitest).
  * Returns the refusal message so each mutation boundary can report through its own runtime.
  */
-export async function describeLiveGatewayOwnerStartupBlocker(
+async function describeLiveGatewayOwnerStartupBlocker(
   env: NodeJS.ProcessEnv,
 ): Promise<string | undefined> {
   if (env.VITEST || env.NODE_ENV === "test") {

--- a/src/commands/doctor/shared/automatic-startup-config-repair.test.ts
+++ b/src/commands/doctor/shared/automatic-startup-config-repair.test.ts
@@ -129,9 +129,8 @@ describe("automatic startup config repair", () => {
     ).toBe(false);
   });
 
-  it("admits a config whose only migration is plugin-owned", () => {
-    // Regression: the pre-bootstrap trust check must reach plugin doctor contracts
-    // (here the bundled Active Memory retired-QMD removal), not only core migrations.
+  it("plans a config whose only migration is plugin-owned after state admission", () => {
+    // The full planner owns plugin contracts; pre-bootstrap uses core-only selection.
     const snapshot = invalidSnapshot({
       config: {
         plugins: { entries: { "active-memory": { config: { qmd: { enabled: true } } } } },
@@ -139,7 +138,7 @@ describe("automatic startup config repair", () => {
       issuePaths: ["plugins.entries.active-memory.config.qmd"],
     });
 
-    const resolved = resolveStartupConfigSnapshot(snapshot);
+    const resolved = planAutomaticConfigRepair(snapshot)?.snapshot;
 
     expect(resolved?.valid).toBe(true);
     expect(resolved?.sourceConfig.plugins?.entries?.["active-memory"]?.config).toEqual({});

--- a/src/commands/doctor/shared/automatic-startup-config-repair.ts
+++ b/src/commands/doctor/shared/automatic-startup-config-repair.ts
@@ -33,11 +33,50 @@ function admitAutomaticConfigRepairSnapshot(snapshot: ConfigFileSnapshot): boole
   );
 }
 
-function buildAutomaticConfigRepairPlan(
+function prepareAutomaticConfigRepairWrite(snapshot: ConfigFileSnapshot, config: OpenClawConfig) {
+  const unsetPaths = resolveManagedUnsetPathsForWrite(undefined);
+  return stampConfigWriteMetadata(
+    applyUnsetPathsForWrite(
+      prepareConfigWriteTopology({
+        snapshot,
+        nextConfig: config,
+        options: { persistCanonicalAgentRoster: true },
+        unsetPaths,
+        env: process.env,
+      }).nextConfig,
+      unsetPaths,
+    ),
+    undefined,
+    undefined,
+    snapshot.parsed,
+  );
+}
+
+function planConfigRepair(
   snapshot: ConfigFileSnapshot,
-  config: OpenClawConfig,
-  changes: string[],
-): AutomaticConfigRepairPlan {
+  pluginContracts: boolean,
+): AutomaticConfigRepairPlan | null {
+  if (!admitAutomaticConfigRepairSnapshot(snapshot)) {
+    return null;
+  }
+  const { next: config, changes } = applyLegacyDoctorMigrations(
+    snapshot.sourceConfig,
+    { authoredRaw: snapshot.parsed, resolvedRaw: snapshot.sourceConfig },
+    { pluginContracts },
+  );
+  if (!config || isDeepStrictEqual(config, snapshot.sourceConfig)) {
+    return null;
+  }
+  const valid = pluginContracts
+    ? validateConfigObjectWithPlugins(prepareAutomaticConfigRepairWrite(snapshot, config)).ok
+    : validateConfigObjectRaw(config).ok;
+  const issues = (pluginContracts ? findDoctorLegacyConfigIssues : findLegacyConfigIssues)(
+    config,
+    config,
+  );
+  if (!valid || issues.length > 0) {
+    return null;
+  }
   return {
     config,
     changes,
@@ -58,74 +97,18 @@ function buildAutomaticConfigRepairPlan(
 export function planAutomaticConfigRepair(
   snapshot: ConfigFileSnapshot,
 ): AutomaticConfigRepairPlan | null {
-  if (!admitAutomaticConfigRepairSnapshot(snapshot)) {
-    return null;
-  }
-
-  const { next: config, changes } = applyLegacyDoctorMigrations(snapshot.sourceConfig, {
-    authoredRaw: snapshot.parsed,
-    resolvedRaw: snapshot.sourceConfig,
-  });
-  if (
-    !config ||
-    isDeepStrictEqual(config, snapshot.sourceConfig) ||
-    !validateConfigObjectWithPlugins(config).ok ||
-    findDoctorLegacyConfigIssues(config, config).length > 0
-  ) {
-    return null;
-  }
-
-  return buildAutomaticConfigRepairPlan(snapshot, config, changes);
+  return planConfigRepair(snapshot, true);
 }
 
 /**
- * State-free repairable preview for callers that run before the shared state database
- * may be touched (gateway pre-bootstrap selection, backup discovery). It skips plugin
- * doctor contracts and plugin validation, so it can admit a snapshot the full planner
- * later refuses — the preflight committer and canonical-write matcher stay authoritative,
- * and a refused commit keeps today's fail-closed startup refusal.
- */
-function planStartupConfigRepairPreview(
-  snapshot: ConfigFileSnapshot,
-): AutomaticConfigRepairPlan | null {
-  if (!admitAutomaticConfigRepairSnapshot(snapshot)) {
-    return null;
-  }
-
-  const { next: config, changes } = applyLegacyDoctorMigrations(
-    snapshot.sourceConfig,
-    { authoredRaw: snapshot.parsed, resolvedRaw: snapshot.sourceConfig },
-    { pluginContracts: false },
-  );
-  if (
-    !config ||
-    isDeepStrictEqual(config, snapshot.sourceConfig) ||
-    !validateConfigObjectRaw(config).ok ||
-    findLegacyConfigIssues(config, config).length > 0
-  ) {
-    return null;
-  }
-
-  return buildAutomaticConfigRepairPlan(snapshot, config, changes);
-}
-
-/**
- * Repairable-snapshot trust check for callers that run before startup state admission
- * (gateway pre-bootstrap selection, backup discovery). The full planner covers
- * plugin-contract migrations but reads the installed-plugin registry from the shared
- * state database; when that store is unreachable, fall back to the state-free preview
- * so core-key repairs stay reachable and everything else keeps today's fail-closed
- * refusal. The preflight committer and canonical-write matcher stay authoritative.
+ * Pre-bootstrap selection must not open state while deciding whether startup is safe.
+ * Full plugin-contract validation belongs to the admitted preflight's repair plan.
  */
 export function resolveStartupConfigSnapshot(snapshot: ConfigFileSnapshot) {
   if (snapshot.valid) {
     return snapshot;
   }
-  try {
-    return planAutomaticConfigRepair(snapshot)?.snapshot;
-  } catch {
-    return planStartupConfigRepairPreview(snapshot)?.snapshot;
-  }
+  return planConfigRepair(snapshot, false)?.snapshot;
 }
 
 /** Matches only the canonical writer result for a previously admitted startup repair. */
@@ -134,24 +117,7 @@ export function isStartupConfigRepairResult(
   after: ConfigFileSnapshot,
 ): boolean {
   const plan = planAutomaticConfigRepair(before);
-  const unsetPaths = resolveManagedUnsetPathsForWrite(undefined);
-  const expected = plan
-    ? stampConfigWriteMetadata(
-        applyUnsetPathsForWrite(
-          prepareConfigWriteTopology({
-            snapshot: before,
-            nextConfig: plan.config,
-            options: { persistCanonicalAgentRoster: true },
-            unsetPaths,
-            env: process.env,
-          }).nextConfig,
-          unsetPaths,
-        ),
-        undefined,
-        undefined,
-        before.parsed,
-      )
-    : null;
+  const expected = plan ? prepareAutomaticConfigRepairWrite(before, plan.config) : null;
   return Boolean(
     expected &&
     after.valid &&

--- a/src/config/io.factory.ts
+++ b/src/config/io.factory.ts
@@ -6,6 +6,7 @@ import {
 } from "./io.observe-recovery.js";
 import { recoverConfigFromJsonRootSuffixWithContext } from "./io.recovery.js";
 import {
+  prepareConfigRecoveryFromContext,
   readBestEffortConfigSnapshotFromContext,
   readConfigFileSnapshotForWriteFromContext,
   readConfigFileSnapshotFromContext,
@@ -35,6 +36,8 @@ export function createConfigIO(options: ConfigIoFactoryOptions = {}) {
     readConfigFileSnapshotWithPluginMetadata: (readOptions: ConfigSnapshotReadOptions = {}) =>
       readConfigFileSnapshotWithPluginMetadataFromContext(context, readOptions),
     readConfigFileSnapshotForWrite: () => readConfigFileSnapshotForWriteFromContext(context),
+    prepareConfigRecovery: (current: ConfigFileSnapshot) =>
+      prepareConfigRecoveryFromContext(context, current),
     promoteConfigSnapshotToLastKnownGood: (snapshot: ConfigFileSnapshot) =>
       promoteConfigSnapshotToLastKnownGoodCore({
         deps: context.deps,

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -328,15 +328,19 @@ type SuspiciousConfigRecoveryPlan = {
 /** Prepare the existing recovery without observing or writing the selected config. */
 export async function prepareSuspiciousConfigRead(params: ConfigReadRecoveryParams): Promise<{
   candidate: ConfigReadRecoveryResult;
-  apply: () => Promise<void>;
+  apply: (beforeCommit?: () => void) => Promise<void>;
 } | null> {
   const plan = await runConfigRecoveryAsync(planSuspiciousConfigRead(params));
   return (
     plan && {
       candidate: plan.candidate,
-      apply: async () => {
-        plan.assertUnchanged();
-        const result = await runConfigRecoveryAsync(plan.apply(plan.assertUnchanged));
+      apply: async (beforeCommit) => {
+        const assertAllowed = () => {
+          beforeCommit?.();
+          plan.assertUnchanged();
+        };
+        assertAllowed();
+        const result = await runConfigRecoveryAsync(plan.apply(assertAllowed));
         if (!result.restored) {
           throw result.error;
         }

--- a/src/config/io.observe-recovery.ts
+++ b/src/config/io.observe-recovery.ts
@@ -31,6 +31,7 @@ import type {
 } from "./io.types.js";
 import { formatConfigIssueSummary } from "./issue-format.js";
 import { warnIfJSON5CommentsWillBeStripped } from "./json5-comments.js";
+import { ConfigMutationConflictError } from "./mutation-conflict.js";
 import {
   isPluginLocalInvalidConfigSnapshot,
   shouldAttemptLastKnownGoodRecovery,
@@ -58,13 +59,7 @@ async function chmodConfigBestEffort(params: {
   try {
     await params.deps.fs.promises.chmod?.(params.configPath, 0o600);
   } catch (error) {
-    params.deps.logger.warn(
-      formatConfigPermissionHardeningWarning({
-        configPath: params.configPath,
-        context: params.context,
-        error,
-      }),
-    );
+    params.deps.logger.warn(formatConfigPermissionHardeningWarning({ ...params, error }));
   }
 }
 
@@ -76,13 +71,7 @@ function chmodConfigBestEffortSync(params: {
   try {
     params.deps.fs.chmodSync?.(params.configPath, 0o600);
   } catch (error) {
-    params.deps.logger.warn(
-      formatConfigPermissionHardeningWarning({
-        configPath: params.configPath,
-        context: params.context,
-        error,
-      }),
-    );
+    params.deps.logger.warn(formatConfigPermissionHardeningWarning({ ...params, error }));
   }
 }
 type ConfigReadRecoveryParams = {
@@ -103,7 +92,9 @@ function createRecoveryCommitEffect(params: {
   deps: ObserveRecoveryDeps;
   configPath: string;
   raw: string;
+  beforeCommit?: () => void;
 }): ConfigRecoveryEffect<void> {
+  const beforeCommit = params.beforeCommit;
   const options = {
     filePath: params.configPath,
     content: params.raw,
@@ -117,7 +108,24 @@ function createRecoveryCommitEffect(params: {
       replaceFileAtomicSync(options);
     },
     async: async () => {
-      await replaceFileAtomic(options);
+      await replaceFileAtomic(
+        beforeCommit
+          ? {
+              ...options,
+              // Every rename attempt must revalidate; copy fallback has no final guard.
+              copyFallbackOnPermissionError: false,
+              fileSystem: {
+                promises: {
+                  ...params.deps.fs.promises,
+                  rename: (source: fs.PathLike, destination: fs.PathLike) => {
+                    beforeCommit();
+                    return params.deps.fs.promises.rename(source, destination);
+                  },
+                },
+              },
+            }
+          : options,
+      );
     },
   };
 }
@@ -142,15 +150,10 @@ function extractRestoreErrorDetails(error: unknown): {
   if (!error || typeof error !== "object") {
     return { code: null, message: typeof error === "string" ? error : null };
   }
-  const code =
-    "code" in error && typeof (error as { code?: unknown }).code === "string"
-      ? (error as { code: string }).code
-      : null;
-  const message =
-    "message" in error && typeof (error as { message?: unknown }).message === "string"
-      ? (error as { message: string }).message
-      : null;
-  return { code, message };
+  return {
+    code: "code" in error && typeof error.code === "string" ? error.code : null,
+    message: "message" in error && typeof error.message === "string" ? error.message : null,
+  };
 }
 
 function returnOriginalConfigRead(params: ConfigReadRecoveryParams): ConfigReadRecoveryResult {
@@ -166,26 +169,6 @@ function parseBackupConfigRaw(
   } catch {
     return null;
   }
-}
-
-function logBackupRestoreResult(params: {
-  deps: ObserveRecoveryDeps;
-  configPath: string;
-  suspicious: string[];
-  restoredFromBackup: boolean;
-  restoreErrorMessage: string | null;
-}): void {
-  if (params.restoredFromBackup) {
-    params.deps.logger.warn(
-      `Config auto-restored from backup: ${params.configPath} (${params.suspicious.join(", ")})`,
-    );
-    return;
-  }
-  params.deps.logger.warn(
-    `Config auto-restore from backup failed: ${params.configPath} (${params.suspicious.join(", ")}${
-      params.restoreErrorMessage ? `; ${params.restoreErrorMessage}` : ""
-    })`,
-  );
 }
 
 function createBackupRestoreAuditAppendParams(params: {
@@ -298,7 +281,10 @@ function collectPollutedSecretPlaceholders(
 export async function maybeRecoverSuspiciousConfigRead(
   params: ConfigReadRecoveryParams,
 ): Promise<ConfigReadRecoveryResult> {
-  const recovery = recoverSuspiciousConfigRead(params);
+  return await runConfigRecoveryAsync(recoverSuspiciousConfigRead(params));
+}
+
+async function runConfigRecoveryAsync<T>(recovery: ConfigRecoveryOperation<T>): Promise<T> {
   let step = recovery.next();
   while (!step.done) {
     try {
@@ -329,6 +315,55 @@ type ConfigRecoveryEffect<T> = {
   sync: () => T;
   async: () => T | Promise<T>;
 };
+
+type ConfigRecoveryOperation<T> = Generator<ConfigRecoveryEffect<unknown>, T, unknown>;
+type SuspiciousConfigRecoveryPlan = {
+  candidate: ConfigReadRecoveryResult;
+  assertUnchanged: () => void;
+  apply: (
+    beforeCommit?: () => void,
+  ) => ConfigRecoveryOperation<{ restored: boolean; error: unknown }>;
+};
+
+/** Prepare the existing recovery without observing or writing the selected config. */
+export async function prepareSuspiciousConfigRead(params: ConfigReadRecoveryParams): Promise<{
+  candidate: ConfigReadRecoveryResult;
+  apply: () => Promise<void>;
+} | null> {
+  const plan = await runConfigRecoveryAsync(planSuspiciousConfigRead(params));
+  return (
+    plan && {
+      candidate: plan.candidate,
+      apply: async () => {
+        plan.assertUnchanged();
+        const result = await runConfigRecoveryAsync(plan.apply(plan.assertUnchanged));
+        if (!result.restored) {
+          throw result.error;
+        }
+      },
+    }
+  );
+}
+
+function* recoverSuspiciousConfigRead(
+  params: ConfigReadRecoveryParams,
+): ConfigRecoveryOperation<ConfigReadRecoveryResult> {
+  const plan = yield* planSuspiciousConfigRead(params);
+  if (!plan) {
+    return returnOriginalConfigRead(params);
+  }
+  if (params.allowBackupRecovery) {
+    const allowed = (yield {
+      sync: () => true,
+      async: () => params.allowBackupRecovery?.() ?? true,
+    }) as boolean;
+    if (!allowed) {
+      return returnOriginalConfigRead(params);
+    }
+  }
+  yield* plan.apply();
+  return plan.candidate;
+}
 
 function createConfigRecoveryStatEffect(
   deps: ObserveRecoveryDeps,
@@ -362,9 +397,9 @@ function createConfigBackupReadEffect(
   };
 }
 
-function* recoverSuspiciousConfigRead(
+function* planSuspiciousConfigRead(
   params: ConfigReadRecoveryParams,
-): Generator<ConfigRecoveryEffect<unknown>, ConfigReadRecoveryResult, unknown> {
+): ConfigRecoveryOperation<SuspiciousConfigRecoveryPlan | null> {
   const { deps, configPath, raw, parsed } = params;
   const stat = (yield createConfigRecoveryStatEffect(deps, configPath)) as fs.Stats | null;
   const now = new Date().toISOString();
@@ -391,16 +426,16 @@ function* recoverSuspiciousConfigRead(
     backupBaseline,
   });
   if (!recoveryContext) {
-    return returnOriginalConfigRead(params);
+    return null;
   }
   const { suspicious, suspiciousSignature } = recoveryContext;
   const backupRaw = (yield createConfigBackupReadEffect(deps, backupPath)) as string | null;
   if (!backupRaw) {
-    return returnOriginalConfigRead(params);
+    return null;
   }
   const backupParse = parseBackupConfigRaw(deps, backupRaw);
   if (!backupParse) {
-    return returnOriginalConfigRead(params);
+    return null;
   }
   const backupCandidate = { raw: backupRaw, parsed: backupParse.parsed };
   const prepared = (yield {
@@ -408,7 +443,7 @@ function* recoverSuspiciousConfigRead(
     async: () => params.prepareBackup(backupCandidate),
   }) as ConfigRecoveryCandidatePreparation;
   if (!prepared.ok) {
-    return returnOriginalConfigRead(params);
+    return null;
   }
   const preparedCandidate = prepared.candidate;
   // Eligibility must describe the approved backup bytes, never an older healthy config.
@@ -419,83 +454,110 @@ function* recoverSuspiciousConfigRead(
     stat: backupStat,
   });
   if (!backup.gatewayMode) {
-    return returnOriginalConfigRead(params);
+    return null;
   }
-  if (params.allowBackupRecovery) {
-    const allowed = (yield {
-      sync: () => true,
-      async: () => params.allowBackupRecovery?.() ?? true,
-    }) as boolean;
-    if (!allowed) {
-      return returnOriginalConfigRead(params);
-    }
-  }
-  const snapshotParams = {
-    deps,
-    configPath,
-    raw,
-    observedAt: now,
-  };
-  const clobberedPath = (yield {
-    sync: () => persistBoundedClobberedConfigSnapshotSync(snapshotParams),
-    async: () => persistBoundedClobberedConfigSnapshot(snapshotParams),
-  }) as string | null;
-  let restoredFromBackup = false;
-  let restoreError: unknown;
-  try {
-    if (preparedCandidate.raw !== backupRaw) {
-      warnIfJSON5CommentsWillBeStripped({
-        raw: backupRaw,
-        filePath: configPath,
-        warn: (message) => deps.logger.warn(message),
+  return {
+    candidate: preparedCandidate,
+    assertUnchanged: () => {
+      for (const [pathname, expectedRaw, expectedStat] of [
+        [configPath, raw, stat],
+        [backupPath, backupRaw, backupStat],
+      ] as const) {
+        const actualRaw = createConfigBackupReadEffect(deps, pathname).sync();
+        const actualStat = createConfigRecoveryStatEffect(deps, pathname).sync();
+        if (
+          actualRaw !== expectedRaw ||
+          !actualStat ||
+          !expectedStat ||
+          actualStat.dev !== expectedStat.dev ||
+          actualStat.ino !== expectedStat.ino ||
+          actualStat.mtimeMs !== expectedStat.mtimeMs ||
+          actualStat.size !== expectedStat.size
+        ) {
+          throw new ConfigMutationConflictError(
+            "config recovery source changed since preparation",
+            {
+              retryable: false,
+            },
+          );
+        }
+      }
+    },
+    *apply(beforeCommit) {
+      const snapshotParams = {
+        deps,
+        configPath,
+        raw,
+        observedAt: now,
+      };
+      const clobberedPath = (yield {
+        sync: () => persistBoundedClobberedConfigSnapshotSync(snapshotParams),
+        async: () => persistBoundedClobberedConfigSnapshot(snapshotParams),
+      }) as string | null;
+      let restoredFromBackup = false;
+      let restoreError: unknown;
+      try {
+        if (preparedCandidate.raw !== backupRaw) {
+          warnIfJSON5CommentsWillBeStripped({
+            raw: backupRaw,
+            filePath: configPath,
+            warn: (message) => deps.logger.warn(message),
+          });
+        }
+        yield createRecoveryCommitEffect({
+          deps,
+          configPath,
+          raw: preparedCandidate.raw,
+          beforeCommit,
+        });
+        const chmodParams = { deps, configPath, context: "backup restore" };
+        yield {
+          sync: () => chmodConfigBestEffortSync(chmodParams),
+          async: () => chmodConfigBestEffort(chmodParams),
+        };
+        restoredFromBackup = true;
+      } catch (error) {
+        restoreError = error;
+      }
+      const restoreErrorDetails = restoredFromBackup
+        ? { code: null, message: null }
+        : extractRestoreErrorDetails(restoreError);
+      const result = restoredFromBackup
+        ? "auto-restored from backup"
+        : "auto-restore from backup failed";
+      const detail =
+        !restoredFromBackup && restoreErrorDetails.message
+          ? `; ${restoreErrorDetails.message}`
+          : "";
+      deps.logger.warn(`Config ${result}: ${configPath} (${suspicious.join(", ")}${detail})`);
+      const audit = createBackupRestoreAuditAppendParams({
+        deps,
+        configPath,
+        restoredFromBackup,
+        current,
+        suspicious,
+        entry,
+        backup,
+        clobberedPath,
+        backupPath,
+        restoreErrorDetails,
       });
-    }
-    yield createRecoveryCommitEffect({ deps, configPath, raw: preparedCandidate.raw });
-    const chmodParams = { deps, configPath, context: "backup restore" };
-    yield {
-      sync: () => chmodConfigBestEffortSync(chmodParams),
-      async: () => chmodConfigBestEffort(chmodParams),
-    };
-    restoredFromBackup = true;
-  } catch (error) {
-    restoreError = error;
-  }
-  const restoreErrorDetails = restoredFromBackup
-    ? { code: null, message: null }
-    : extractRestoreErrorDetails(restoreError);
-  logBackupRestoreResult({
-    deps,
-    configPath,
-    suspicious,
-    restoredFromBackup,
-    restoreErrorMessage: restoreErrorDetails.message,
-  });
-  const audit = createBackupRestoreAuditAppendParams({
-    deps,
-    configPath,
-    restoredFromBackup,
-    current,
-    suspicious,
-    entry,
-    backup,
-    clobberedPath,
-    backupPath,
-    restoreErrorDetails,
-  });
-  yield {
-    sync: () => appendConfigAuditRecordSync(audit),
-    async: () => appendConfigAuditRecord(audit),
+      yield {
+        sync: () => appendConfigAuditRecordSync(audit),
+        async: () => appendConfigAuditRecord(audit),
+      };
+      if (restoredFromBackup) {
+        writeConfigHealthStateToStore(
+          deps,
+          updateConfigHealthEntry(healthState, configPath, {
+            ...entry,
+            lastObservedSuspiciousSignature: suspiciousSignature,
+          }),
+        );
+      }
+      return { restored: restoredFromBackup, error: restoreError };
+    },
   };
-  if (restoredFromBackup) {
-    writeConfigHealthStateToStore(
-      deps,
-      updateConfigHealthEntry(healthState, configPath, {
-        ...entry,
-        lastObservedSuspiciousSignature: suspiciousSignature,
-      }),
-    );
-  }
-  return preparedCandidate;
 }
 
 export async function promoteConfigSnapshotToLastKnownGoodCore(params: {
@@ -577,15 +639,13 @@ export async function recoverConfigFromLastKnownGoodCore(params: {
   if (!backupRaw || hashConfigRaw(backupRaw) !== promoted.hash) {
     return false;
   }
-  let backupParsed: unknown;
-  try {
-    backupParsed = deps.json5.parse(backupRaw);
-  } catch {
+  const backupParse = parseBackupConfigRaw(deps, backupRaw);
+  if (!backupParse) {
     return false;
   }
   // Historical bytes become live config only after their owner has migrated and validated them.
   // This prevents Doctor recovery from exposing a schema-invalid intermediate file.
-  const originalCandidate = { raw: backupRaw, parsed: backupParsed };
+  const originalCandidate = { raw: backupRaw, parsed: backupParse.parsed };
   const prepared = params.prepareCandidate(originalCandidate);
   if (!prepared.ok) {
     deps.logger.warn(
@@ -611,9 +671,10 @@ export async function recoverConfigFromLastKnownGoodCore(params: {
     stat,
     observedAt: now,
   });
-  const clobberedPath = await preserveConfigSnapshotAsClobberedCore({
+  const clobberedPath = await persistBoundedClobberedConfigSnapshot({
     deps,
-    snapshot,
+    configPath: snapshot.path,
+    raw: snapshot.raw,
     observedAt: now,
   });
   if (recoveryCandidate.raw !== backupRaw) {
@@ -660,20 +721,4 @@ export async function recoverConfigFromLastKnownGoodCore(params: {
     }),
   );
   return true;
-}
-
-async function preserveConfigSnapshotAsClobberedCore(params: {
-  deps: ObserveRecoveryDeps;
-  snapshot: ConfigFileSnapshot;
-  observedAt?: string;
-}): Promise<string | null> {
-  if (!params.snapshot.exists || typeof params.snapshot.raw !== "string") {
-    return null;
-  }
-  return await persistBoundedClobberedConfigSnapshot({
-    deps: params.deps,
-    configPath: params.snapshot.path,
-    raw: params.snapshot.raw,
-    observedAt: params.observedAt ?? new Date().toISOString(),
-  });
 }

--- a/src/config/io.snapshot.recovery.test.ts
+++ b/src/config/io.snapshot.recovery.test.ts
@@ -1,0 +1,197 @@
+import { createHash } from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
+import { withArtifactPreservingStateReads } from "../state/openclaw-state-db-readonly.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  openOpenClawStateDatabase,
+} from "../state/openclaw-state-db.js";
+import { createConfigIO } from "./io.factory.js";
+import type { ConfigIoFactoryOptions } from "./io.types.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+afterEach(() => {
+  clearPluginMetadataLifecycleCaches();
+  closeOpenClawStateDatabaseForTest();
+});
+
+function manifest(root: string) {
+  return fs
+    .readdirSync(root, { recursive: true, encoding: "utf8" })
+    .toSorted()
+    .filter((entry) => fs.statSync(path.join(root, entry)).isFile())
+    .map((entry) => [
+      entry,
+      createHash("sha256")
+        .update(fs.readFileSync(path.join(root, entry)))
+        .digest("hex"),
+    ]);
+}
+
+function fixture(options: ConfigIoFactoryOptions = {}) {
+  const root = tempDirs.make("openclaw-prepared-config-recovery-");
+  const configPath = path.join(root, "openclaw.json");
+  const original = '{ "update": { "channel": "beta" } }\n';
+  const backup = JSON.stringify({
+    gateway: { mode: "local", port: 18720 },
+    env: { vars: { RECOVERY_MARKER: "backup" } },
+  });
+  fs.writeFileSync(configPath, original);
+  fs.writeFileSync(`${configPath}.bak`, backup);
+  const env = {
+    HOME: root,
+    USERPROFILE: root,
+    OPENCLAW_CONFIG_PATH: configPath,
+    OPENCLAW_STATE_DIR: root,
+    OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+    VITEST: "true",
+  };
+  const databasePath = openOpenClawStateDatabase({ env }).path;
+  closeOpenClawStateDatabaseForTest();
+  const io = createConfigIO({
+    env,
+    configPath,
+    homedir: () => root,
+    observe: false,
+    logger: { warn: vi.fn(), error: vi.fn() },
+    ...options,
+  });
+  return { root, configPath, original, backup, databasePath, env, io };
+}
+
+async function prepare(io: ReturnType<typeof createConfigIO>) {
+  const current = await withArtifactPreservingStateReads(() => io.readConfigFileSnapshot());
+  return io.prepareConfigRecovery(current);
+}
+
+describe("prepared config recovery", () => {
+  it.each(["full", "core-only"] as const)(
+    "previews %s recovery without writes, then restores the admitted bytes",
+    async (pluginValidation) => {
+      const { root, configPath, original, backup, databasePath, env, io } = fixture({
+        pluginValidation,
+      });
+      // No sidecars are excluded: a read must not create even an empty WAL.
+      expect(fs.existsSync(`${databasePath}-wal`)).toBe(false);
+      const before = manifest(root);
+      const plan = await prepare(io);
+      expect(plan).not.toBeNull();
+      expect(plan!.snapshot.raw).toBe(backup);
+      expect(plan!.snapshot.path).toBe(configPath);
+      expect(plan!.snapshot.config.gateway).toMatchObject({ mode: "local", port: 18720 });
+      expect(plan!.snapshot.config.agents?.defaults?.compaction?.mode).toBe("safeguard");
+      expect(Boolean(plan!.pluginMetadataSnapshot)).toBe(pluginValidation === "full");
+      expect(env).not.toHaveProperty("RECOVERY_MARKER");
+      expect(manifest(root)).toEqual(before);
+
+      await plan!.apply();
+      expect(fs.readFileSync(configPath, "utf8")).toBe(backup);
+      const clobbered = fs
+        .readdirSync(root)
+        .filter((name) => name.startsWith("openclaw.json.clobbered."));
+      expect(clobbered).toHaveLength(1);
+      expect(fs.readFileSync(path.join(root, clobbered[0]!), "utf8")).toBe(original);
+      const persisted = await io.readConfigFileSnapshotWithPluginMetadata();
+      expect(persisted.snapshot).toEqual(plan!.snapshot);
+    },
+  );
+
+  it.each(["config", "backup", "replaced-backup"] as const)(
+    "refuses %s drift before any recovery write",
+    async (drift) => {
+      const { root, configPath, backup, io } = fixture();
+      const plan = await prepare(io);
+      expect(plan).not.toBeNull();
+      if (drift === "replaced-backup") {
+        const replacement = path.join(root, "replacement");
+        fs.writeFileSync(replacement, backup);
+        fs.renameSync(replacement, `${configPath}.bak`);
+      } else {
+        fs.writeFileSync(
+          drift === "config" ? configPath : `${configPath}.bak`,
+          '{ "gateway": { "mode": "remote" } }\n',
+        );
+      }
+      const beforeApply = manifest(root);
+      await expect(plan!.apply()).rejects.toThrow(
+        "config recovery source changed since preparation",
+      );
+      expect(manifest(root)).toEqual(beforeApply);
+    },
+  );
+
+  it.each(["config", "backup"] as const)(
+    "refuses %s changes while archiving the clobbered config",
+    async (changedSource) => {
+      const { root, configPath, original, env } = fixture();
+      const changedPath = changedSource === "config" ? configPath : `${configPath}.bak`;
+      const concurrentRaw = '{ "gateway": { "mode": "local", "port": 18721 } }\n';
+      const io = createConfigIO({
+        configPath,
+        env,
+        observe: false,
+        homedir: () => root,
+        logger: { warn: vi.fn(), error: vi.fn() },
+        fs: {
+          ...fs,
+          promises: {
+            ...fs.promises,
+            writeFile: async (pathname, data, options) => {
+              await fs.promises.writeFile(pathname, data, options);
+              if (typeof pathname === "string" && pathname.startsWith(`${configPath}.clobbered.`)) {
+                await fs.promises.writeFile(changedPath, concurrentRaw);
+              }
+            },
+          },
+        },
+      });
+      const plan = await prepare(io);
+      expect(plan).not.toBeNull();
+      await expect(plan!.apply()).rejects.toThrow(
+        "config recovery source changed since preparation",
+      );
+      expect(fs.readFileSync(changedPath, "utf8")).toBe(concurrentRaw);
+      expect(fs.readFileSync(configPath, "utf8")).toBe(
+        changedSource === "config" ? concurrentRaw : original,
+      );
+      const clobbered = fs
+        .readdirSync(root)
+        .filter((name) => name.startsWith("openclaw.json.clobbered."));
+      expect(clobbered).toHaveLength(1);
+      expect(fs.readFileSync(path.join(root, clobbered[0]!), "utf8")).toBe(original);
+    },
+  );
+
+  it("rejects failed replacement while retaining the original and its clobbered snapshot", async () => {
+    const { root, configPath, original, env } = fixture();
+    const io = createConfigIO({
+      configPath,
+      env,
+      observe: false,
+      homedir: () => root,
+      logger: { warn: vi.fn(), error: vi.fn() },
+      fs: {
+        ...fs,
+        promises: {
+          ...fs.promises,
+          rename: async (source, target) => {
+            if (target === configPath) {
+              throw Object.assign(new Error("recovery replacement denied"), { code: "EACCES" });
+            }
+            await fs.promises.rename(source, target);
+          },
+        },
+      },
+    });
+    const plan = await prepare(io);
+    expect(plan).not.toBeNull();
+    await expect(plan!.apply()).rejects.toThrow("recovery replacement denied");
+    expect(fs.readFileSync(configPath, "utf8")).toBe(original);
+    expect(
+      fs.readdirSync(root).filter((name) => name.startsWith("openclaw.json.clobbered.")),
+    ).toHaveLength(1);
+  });
+});

--- a/src/config/io.snapshot.recovery.test.ts
+++ b/src/config/io.snapshot.recovery.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { acquireStartupMigrationLease } from "../infra/startup-migration-checkpoint.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { withArtifactPreservingStateReads } from "../state/openclaw-state-db-readonly.js";
 import {
@@ -131,10 +132,11 @@ describe("prepared config recovery", () => {
     },
   );
 
-  it.each(["config", "backup"] as const)(
+  it.each(["config", "backup", "lease"] as const)(
     "refuses %s changes while archiving the clobbered config",
     async (changedSource) => {
       const { root, configPath, original, env } = fixture();
+      const lease = changedSource === "lease" ? acquireStartupMigrationLease({ env }) : undefined;
       const changedPath = changedSource === "config" ? configPath : `${configPath}.bak`;
       const concurrentRaw = '{ "gateway": { "mode": "local", "port": 18721 } }\n';
       const io = createConfigIO({
@@ -150,7 +152,11 @@ describe("prepared config recovery", () => {
             writeFile: async (pathname, data, options) => {
               await fs.promises.writeFile(pathname, data, options);
               if (typeof pathname === "string" && pathname.startsWith(`${configPath}.clobbered.`)) {
-                await fs.promises.writeFile(changedPath, concurrentRaw);
+                if (lease) {
+                  lease.release();
+                } else {
+                  await fs.promises.writeFile(changedPath, concurrentRaw);
+                }
               }
             },
           },
@@ -158,10 +164,14 @@ describe("prepared config recovery", () => {
       });
       const plan = await prepare(io);
       expect(plan).not.toBeNull();
-      await expect(plan!.apply()).rejects.toThrow(
-        "config recovery source changed since preparation",
+      await expect(plan!.apply(lease?.heartbeat)).rejects.toThrow(
+        lease
+          ? "startup migration lease was lost"
+          : "config recovery source changed since preparation",
       );
-      expect(fs.readFileSync(changedPath, "utf8")).toBe(concurrentRaw);
+      if (!lease) {
+        expect(fs.readFileSync(changedPath, "utf8")).toBe(concurrentRaw);
+      }
       expect(fs.readFileSync(configPath, "utf8")).toBe(
         changedSource === "config" ? concurrentRaw : original,
       );

--- a/src/config/io.snapshot.recovery.test.ts
+++ b/src/config/io.snapshot.recovery.test.ts
@@ -68,6 +68,14 @@ async function prepare(io: ReturnType<typeof createConfigIO>) {
 }
 
 describe("prepared config recovery", () => {
+  it("keeps an unobserved best-effort config read free of source sidecars", async () => {
+    const { root, databasePath, io } = fixture();
+    expect(fs.existsSync(`${databasePath}-wal`)).toBe(false);
+    const before = manifest(root);
+    await io.readBestEffortConfig();
+    expect(manifest(root)).toEqual(before);
+  });
+
   it.each(["full", "core-only"] as const)(
     "previews %s recovery without writes, then restores the admitted bytes",
     async (pluginValidation) => {

--- a/src/config/io.snapshot.ts
+++ b/src/config/io.snapshot.ts
@@ -1,14 +1,19 @@
 import { formatErrorMessage } from "../infra/errors.js";
 import { findStartupMaintenanceRequiredError } from "../infra/startup-maintenance-required.js";
 import { withPluginMetadataSnapshotScope } from "../plugins/current-plugin-metadata-snapshot.js";
+import { withArtifactPreservingStateReads } from "../state/openclaw-state-db-readonly.js";
 import {
   includeContributionOwnsAgentRoster,
   includeContributionOwnsBindings,
 } from "./agent-roster-provenance.js";
+import { cloneEnvWithPlatformSemantics } from "./config-env-vars.js";
 import { resolveManagedUnsetPathsForWrite } from "./config-path-mutation.js";
 import { ConfigIncludeError } from "./includes.js";
-import type { ConfigIoContext } from "./io.context.js";
-import { maybeRecoverSuspiciousConfigRead } from "./io.observe-recovery.js";
+import { createConfigIoContext, type ConfigIoContext } from "./io.context.js";
+import {
+  maybeRecoverSuspiciousConfigRead,
+  prepareSuspiciousConfigRead,
+} from "./io.observe-recovery.js";
 import {
   coerceConfig,
   containsConfigIncludeDirective,
@@ -29,6 +34,7 @@ import {
 import type {
   BestEffortConfigSnapshot,
   ConfigSnapshotReadOptions,
+  PreparedConfigRecovery,
   ReadConfigFileSnapshotForWriteResult,
   ReadConfigFileSnapshotInternalResult,
   ReadConfigFileSnapshotWithPluginMetadataResult,
@@ -61,11 +67,12 @@ function listResolvedIncludePaths(includeFilePathsForWatch: ReadonlySet<string>)
 export async function readConfigFileSnapshotInternal(
   context: ConfigIoContext,
   options: InternalReadOptions = {},
+  sourceRaw?: string,
 ): Promise<ReadConfigFileSnapshotInternalResult> {
   const { deps, configPath, pathResolution } = context;
   maybeLoadDotEnvForConfig(deps.env);
   const envBeforeRead = snapshotEnv(deps.env);
-  if (!deps.fs.existsSync(configPath)) {
+  if (sourceRaw === undefined && !deps.fs.existsSync(configPath)) {
     const migrated = migratePersistedImplicitMainRoster({});
     const config = coerceConfig(migrated.config);
     const metadata = context.createValidationPluginMetadataSnapshotLoader({
@@ -114,8 +121,9 @@ export async function readConfigFileSnapshotInternal(
   let bindingsIncludeOwned = false;
 
   try {
-    const raw = await deps.measure("config.snapshot.read.file", () =>
-      deps.fs.readFileSync(configPath, "utf-8"),
+    const raw = await deps.measure(
+      "config.snapshot.read.file",
+      () => sourceRaw ?? deps.fs.readFileSync(configPath, "utf-8"),
     );
     const rawHash = await deps.measure("config.snapshot.read.hash", () => hashConfigRaw(raw));
     fallbackRaw = raw;
@@ -403,6 +411,60 @@ export async function readConfigFileSnapshotInternal(
       includeFileTargetsForWrite,
     });
   }
+}
+
+/** Preview recovery through the ordinary snapshot pipeline at the selected config path. */
+export async function prepareConfigRecoveryFromContext(
+  context: ConfigIoContext,
+  current: ConfigFileSnapshot,
+): Promise<PreparedConfigRecovery | null> {
+  return await withArtifactPreservingStateReads(async () => {
+    if (
+      !current.exists ||
+      !current.valid ||
+      typeof current.raw !== "string" ||
+      containsConfigIncludeDirective(current.parsed)
+    ) {
+      return null;
+    }
+    if (current.path !== context.configPath) {
+      throw new ConfigMutationConflictError("config recovery path changed since last load", {
+        retryable: false,
+      });
+    }
+    const previewContext = createConfigIoContext({
+      ...context.options,
+      configPath: context.configPath,
+      env: cloneEnvWithPlatformSemantics(context.deps.env),
+      observe: false,
+    });
+    const plan = await prepareSuspiciousConfigRead({
+      deps: previewContext.deps,
+      configPath: context.configPath,
+      raw: current.raw,
+      parsed: current.parsed,
+      prepareBackup: previewContext.prepareRecoveryBackupCandidate,
+    });
+    if (!plan) {
+      return null;
+    }
+    const envBeforeRead = snapshotEnv(previewContext.deps.env);
+    try {
+      const { snapshot, pluginMetadataSnapshot } = await readConfigFileSnapshotInternal(
+        previewContext,
+        { allowCurrentPluginMetadata: false },
+        plan.candidate.raw,
+      );
+      return snapshot.valid ? { snapshot, pluginMetadataSnapshot, apply: plan.apply } : null;
+    } finally {
+      // The prepared writer keeps the selected environment; candidate env.vars are preview-only.
+      restoreEnvChangesIfUnchanged({
+        env: previewContext.deps.env,
+        before: envBeforeRead,
+        after: snapshotEnv(previewContext.deps.env),
+      });
+    }
+  });
 }
 
 export async function readConfigFileSnapshotFromContext(

--- a/src/config/io.snapshot.ts
+++ b/src/config/io.snapshot.ts
@@ -535,23 +535,27 @@ export async function readConfigFileSnapshotForWriteFromContext(
 export async function readBestEffortConfigSnapshotFromContext(
   context: ConfigIoContext,
 ): Promise<BestEffortConfigSnapshot> {
-  const result = await readConfigFileSnapshotInternal(context);
-  if (!result.snapshot.valid) {
+  const operation = async () => {
+    const result = await readConfigFileSnapshotInternal(context);
+    if (!result.snapshot.valid) {
+      return {
+        config: result.snapshot.config,
+        sourceConfig: result.snapshot.sourceConfig,
+        configDiagnostics: {
+          path: result.snapshot.path,
+          issues: result.snapshot.issues,
+        },
+      };
+    }
     return {
-      config: result.snapshot.config,
+      // The snapshot already materialized under the caller's plugin-validation policy.
+      config: context.finalizeLoadedRuntimeConfig(result.snapshot.config),
       sourceConfig: result.snapshot.sourceConfig,
-      configDiagnostics: {
-        path: result.snapshot.path,
-        issues: result.snapshot.issues,
-      },
+      configDiagnostics: null,
     };
-  }
-  return {
-    // The snapshot already materialized under the caller's plugin-validation policy.
-    config: context.finalizeLoadedRuntimeConfig(result.snapshot.config),
-    sourceConfig: result.snapshot.sourceConfig,
-    configDiagnostics: null,
   };
+  // Unobserved CLI reads resolve plugin metadata before command-specific admission.
+  return await (context.deps.observe ? operation() : withArtifactPreservingStateReads(operation));
 }
 
 export async function readSourceConfigBestEffortFromContext(

--- a/src/config/io.types.ts
+++ b/src/config/io.types.ts
@@ -156,7 +156,7 @@ export type ReadConfigFileSnapshotWithPluginMetadataResult = {
 };
 
 export type PreparedConfigRecovery = ReadConfigFileSnapshotWithPluginMetadataResult & {
-  apply: () => Promise<void>;
+  apply: (beforeCommit?: () => void) => Promise<void>;
 };
 
 export type BestEffortConfigSnapshot = {

--- a/src/config/io.types.ts
+++ b/src/config/io.types.ts
@@ -155,6 +155,10 @@ export type ReadConfigFileSnapshotWithPluginMetadataResult = {
   pluginMetadataSnapshot?: PluginMetadataSnapshot;
 };
 
+export type PreparedConfigRecovery = ReadConfigFileSnapshotWithPluginMetadataResult & {
+  apply: () => Promise<void>;
+};
+
 export type BestEffortConfigSnapshot = {
   config: OpenClawConfig;
   sourceConfig: OpenClawConfig;

--- a/src/gateway/server-kernel.test.ts
+++ b/src/gateway/server-kernel.test.ts
@@ -703,13 +703,6 @@ describe("createGatewayKernel", () => {
           return attributes?.traceName ?? event.name;
         });
       expect(measureNames).toEqual([
-        "state.ownership",
-        "state.runtime-imports",
-        "state.schema-preflight",
-        "runtime.network-imports",
-        "runtime.network-bootstrap",
-        "config.runtime-imports",
-        "config.snapshot",
         "config.snapshot.read",
         "config.snapshot.read.file",
         "config.snapshot.read.hash",
@@ -721,6 +714,13 @@ describe("createGatewayKernel", () => {
         "plugins.metadata.freeze",
         "config.snapshot.read.materialize",
         "config.snapshot.read.observe",
+        "state.ownership",
+        "state.runtime-imports",
+        "state.schema-preflight",
+        "runtime.network-imports",
+        "runtime.network-bootstrap",
+        "config.runtime-imports",
+        "config.snapshot",
         "config.auth",
         "config.auth.snapshot-validate",
         "config.auth.runtime-overrides",

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -12,6 +12,7 @@ import { assertGatewayConfigEnvSelectionUnchanged } from "../config/gateway-env-
 import {
   getRuntimeConfigSourceSnapshot,
   readConfigFileSnapshot,
+  readConfigFileSnapshotWithPluginMetadata,
   setAppliedRuntimeConfigSnapshot,
 } from "../config/io.js";
 import { normalizeStateDirEnv } from "../config/paths.js";
@@ -43,6 +44,7 @@ import { getGatewayPluginMetadataSnapshot } from "../plugins/current-plugin-meta
 import { getTotalQueueSize } from "../process/command-queue.js";
 import { getActiveGatewayRootWorkCount } from "../process/gateway-work-admission.js";
 import { createLazyPromise } from "../shared/lazy-runtime.js";
+import { withArtifactPreservingStateReads } from "../state/openclaw-state-db-readonly.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { assertOpenClawStateWriteAllowedAtPath } from "../state/openclaw-state-ownership.js";
 import { ADMIN_SCOPE } from "./method-scopes.js";
@@ -82,12 +84,18 @@ export async function prepareGatewayServerBootstrap(input: {
 }) {
   const { port, opts, log, logSecrets, loadWorkerEnvironmentStartupModule } = input;
   const { assertConfiguredWorkspaceStateReady } = await import("../agents/workspace-state-dirs.js");
-  // Direct callers and repeated server starts also need admission before bootstrap writes.
-  const workspaceSnapshot = await readConfigFileSnapshot({
-    observe: false,
-    pluginValidation: "core-only",
+  // Derive defaults and admit exactly the snapshot that bootstrap will consume.
+  process.env.OPENCLAW_GATEWAY_PORT = String(port);
+  const envBeforeStartupConfigLoad = { ...process.env };
+  const startupConfigSnapshotRead = await withArtifactPreservingStateReads(async () => {
+    const read =
+      opts.startupConfigSnapshotRead ??
+      (await readConfigFileSnapshotWithPluginMetadata({ observe: false }));
+    assertConfiguredWorkspaceStateReady({
+      cfg: captureConfigOverrideApplier()(read.snapshot.config),
+    });
+    return read;
   });
-  assertConfiguredWorkspaceStateReady({ cfg: workspaceSnapshot.config });
   const formatRuntimeGatewayAuthTokenWarning = input.formatRuntimeGatewayAuthTokenWarning;
   const traceOriginAt = opts.processStartedAt ?? opts.startupStartedAt;
   const startupElapsedMs =
@@ -176,8 +184,6 @@ export async function prepareGatewayServerBootstrap(input: {
     isVitestRuntimeEnv() && process.env.OPENCLAW_TEST_MINIMAL_GATEWAY === "1";
   const ambientEnvTriggers = opts.ambientEnvTriggers ?? "suppress";
 
-  // Ensure all default port derivations (browser/canvas) see the actual runtime port.
-  process.env.OPENCLAW_GATEWAY_PORT = String(port);
   logAcceptedEnvOption({
     key: "OPENCLAW_RAW_STREAM",
     description: "raw stream logging enabled",
@@ -206,15 +212,12 @@ export async function prepareGatewayServerBootstrap(input: {
   });
   const { loadGatewayStartupConfigSnapshot } = await startupConfigModulePromise;
 
-  const envBeforeStartupConfigLoad = { ...process.env };
   const startupConfigLoad = await startupTrace.measure("config.snapshot", () =>
     loadGatewayStartupConfigSnapshot({
       minimalTestGateway,
       log,
       measure: (name, run) => startupTrace.measure(name, run),
-      ...(opts.startupConfigSnapshotRead
-        ? { initialSnapshotRead: opts.startupConfigSnapshotRead }
-        : {}),
+      initialSnapshotRead: startupConfigSnapshotRead,
     }),
   );
   const configSnapshot = startupConfigLoad.snapshot;

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -87,15 +87,6 @@ export async function prepareGatewayServerBootstrap(input: {
   // Derive defaults and admit exactly the snapshot that bootstrap will consume.
   process.env.OPENCLAW_GATEWAY_PORT = String(port);
   const envBeforeStartupConfigLoad = { ...process.env };
-  const startupConfigSnapshotRead = await withArtifactPreservingStateReads(async () => {
-    const read =
-      opts.startupConfigSnapshotRead ??
-      (await readConfigFileSnapshotWithPluginMetadata({ observe: false }));
-    assertConfiguredWorkspaceStateReady({
-      cfg: captureConfigOverrideApplier()(read.snapshot.config),
-    });
-    return read;
-  });
   const formatRuntimeGatewayAuthTokenWarning = input.formatRuntimeGatewayAuthTokenWarning;
   const traceOriginAt = opts.processStartedAt ?? opts.startupStartedAt;
   const startupElapsedMs =
@@ -112,6 +103,28 @@ export async function prepareGatewayServerBootstrap(input: {
   if (startupElapsedMs > 0) {
     startupTrace.mark("process.bootstrap");
   }
+  const startupConfigSnapshotRead = await withArtifactPreservingStateReads(async () => {
+    if (!resumeGatewayRestartTraceFromEnv(process.env, [["source", "env"]])) {
+      const restartHandoff = readGatewayRestartHandoffSync();
+      resumeGatewayRestartTraceFromHandoff(restartHandoff?.restartTrace, [
+        ["source", restartHandoff?.source],
+        ["restartKind", restartHandoff?.restartKind],
+        ["supervisorMode", restartHandoff?.supervisorMode],
+      ]);
+    }
+    const read =
+      opts.startupConfigSnapshotRead ??
+      (await startupTrace.measure("config.snapshot.read", () =>
+        readConfigFileSnapshotWithPluginMetadata({
+          observe: false,
+          measure: (name, run) => startupTrace.measure(name, run),
+        }),
+      ));
+    assertConfiguredWorkspaceStateReady({
+      cfg: captureConfigOverrideApplier()(read.snapshot.config),
+    });
+    return read;
+  });
   const inspectStateOwnership = async (signal?: AbortSignal) => {
     normalizeStateDirEnv(process.env);
     await assertOpenClawStateWriteAllowedAtPath({
@@ -192,14 +205,6 @@ export async function prepareGatewayServerBootstrap(input: {
     key: "OPENCLAW_RAW_STREAM_PATH",
     description: "raw stream log path override",
   });
-  if (!resumeGatewayRestartTraceFromEnv(process.env, [["source", "env"]])) {
-    const restartHandoff = readGatewayRestartHandoffSync();
-    resumeGatewayRestartTraceFromHandoff(restartHandoff?.restartTrace, [
-      ["source", restartHandoff?.source],
-      ["restartKind", restartHandoff?.restartKind],
-      ["supervisorMode", restartHandoff?.supervisorMode],
-    ]);
-  }
   if (!minimalTestGateway) {
     await startupTrace.measure("runtime.agent-cli", () => prepareGatewayAgentCliShim());
   }

--- a/src/gateway/server-startup-bootstrap.ts
+++ b/src/gateway/server-startup-bootstrap.ts
@@ -81,6 +81,13 @@ export async function prepareGatewayServerBootstrap(input: {
   formatRuntimeGatewayAuthTokenWarning: () => string;
 }) {
   const { port, opts, log, logSecrets, loadWorkerEnvironmentStartupModule } = input;
+  const { assertConfiguredWorkspaceStateReady } = await import("../agents/workspace-state-dirs.js");
+  // Direct callers and repeated server starts also need admission before bootstrap writes.
+  const workspaceSnapshot = await readConfigFileSnapshot({
+    observe: false,
+    pluginValidation: "core-only",
+  });
+  assertConfiguredWorkspaceStateReady({ cfg: workspaceSnapshot.config });
   const formatRuntimeGatewayAuthTokenWarning = input.formatRuntimeGatewayAuthTokenWarning;
   const traceOriginAt = opts.processStartedAt ?? opts.startupStartedAt;
   const startupElapsedMs =
@@ -422,7 +429,6 @@ export async function prepareGatewayServerBootstrap(input: {
     ]);
     return next;
   };
-  const { assertConfiguredWorkspaceStateReady } = await import("../agents/workspace-state-dirs.js");
   const prepareReloadCandidate = (params: {
     runtimeConfig: OpenClawConfig;
     sourceConfig: OpenClawConfig;

--- a/src/gateway/server-startup-plugins.ts
+++ b/src/gateway/server-startup-plugins.ts
@@ -59,8 +59,6 @@ export async function runGatewayStartupMaintenance(params: {
   minimalTestGateway: boolean;
   log: GatewayPluginBootstrapLog;
 }): Promise<void> {
-  const { assertConfiguredWorkspaceStateReady } = await import("../agents/workspace-state-dirs.js");
-  assertConfiguredWorkspaceStateReady({ cfg: params.cfgAtStart });
   const startupMaintenanceConfig = resolveGatewayStartupMaintenanceConfig({
     cfgAtStart: params.cfgAtStart,
     startupRuntimeConfig: params.startupRuntimeConfig,

--- a/src/gateway/server-startup-workspace-readiness.test.ts
+++ b/src/gateway/server-startup-workspace-readiness.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { resolveAgentWorkspaceDir } from "../agents/agent-scope.js";
 import { ensureAgentWorkspace } from "../agents/workspace.js";
 import { getRuntimeConfig, writeConfigFile, type OpenClawConfig } from "../config/config.js";
+import { readConfigFileSnapshotWithPluginMetadata } from "../config/io.js";
 import {
   detectLegacyWorkspaceState,
   migrateLegacyWorkspaceState,
@@ -27,7 +28,7 @@ describe("Gateway workspace migration readiness", () => {
   });
   beforeEach(async () => {
     state = await createOpenClawTestState({
-      label: "gateway-workspace-readiness",
+      label: "ws-readiness",
       env: {
         OPENCLAW_GATEWAY_TOKEN: undefined,
         OPENCLAW_GATEWAY_PASSWORD: undefined,
@@ -56,55 +57,83 @@ describe("Gateway workspace migration readiness", () => {
     expect(requestRecoveryRestart).not.toHaveBeenCalled();
   });
 
-  const start = (port: number) =>
+  const start = (
+    port: number,
+    startupConfigSnapshotRead?: Awaited<
+      ReturnType<typeof readConfigFileSnapshotWithPluginMetadata>
+    >,
+  ) =>
     startGatewayServer(port, {
       auth: { mode: "none" },
       bind: "loopback",
       controlUiEnabled: false,
       hotReloadRecovery: requestRecoveryRestart,
+      startupConfigSnapshotRead,
     });
 
-  it("refuses startup for a secondary workspace until Doctor removes its legacy state", async () => {
-    const stateDir = state.stateDir;
-    const workspaceDir = path.join(stateDir, "workspace-secondary");
-    const cfg: OpenClawConfig = {
-      gateway: { mode: "local", bind: "loopback", auth: { mode: "none" } },
-      agents: {
-        ownership: "explicit",
-        entries: {
-          main: { workspace: path.join(stateDir, "workspace-main") },
-          secondary: { workspace: workspaceDir },
+  it.each(["disk", "supplied snapshot"])(
+    "refuses a secondary workspace from %s until Doctor migrates it",
+    async (source) => {
+      const stateDir = state.stateDir;
+      const workspaceDir = path.join(stateDir, "workspace-secondary");
+      const cfg: OpenClawConfig = {
+        gateway: { mode: "local", bind: "loopback", auth: { mode: "none" } },
+        agents: {
+          ownership: "explicit",
+          entries: {
+            main: { workspace: path.join(stateDir, "workspace-main") },
+            secondary: { workspace: workspaceDir },
+          },
         },
-      },
-    };
-    await writeConfigFile(cfg);
-    await fs.mkdir(workspaceDir, { recursive: true });
-    const sourcePath = path.join(workspaceDir, "openclaw-workspace-state.json");
-    await fs.writeFile(
-      sourcePath,
-      JSON.stringify({ version: 1, setupCompletedAt: "2026-07-15T00:00:00.000Z" }),
-    );
-    const port = await getFreePort();
+      };
+      await writeConfigFile(cfg);
+      await fs.mkdir(workspaceDir, { recursive: true });
+      const sourcePath = path.join(workspaceDir, "openclaw-workspace-state.json");
+      await fs.writeFile(
+        sourcePath,
+        JSON.stringify({ version: 1, setupCompletedAt: "2026-07-15T00:00:00.000Z" }),
+      );
+      const initialSnapshotRead =
+        source === "supplied snapshot"
+          ? await readConfigFileSnapshotWithPluginMetadata({ observe: false })
+          : undefined;
+      if (initialSnapshotRead) {
+        await writeConfigFile({
+          ...cfg,
+          agents: {
+            ...cfg.agents,
+            entries: {
+              ...cfg.agents?.entries,
+              secondary: { workspace: path.join(stateDir, "workspace-clean") },
+            },
+          },
+        });
+      }
+      const port = await getFreePort();
+      const attempt = start(port, initialSnapshotRead).then((started) => {
+        server = started;
+        return started;
+      });
+      await expect(attempt).rejects.toThrow("Legacy workspace setup state requires migration");
+      await expect(fetch(`http://127.0.0.1:${port}/readyz`)).rejects.toThrow();
+      await expect(fs.stat(sourcePath)).resolves.toBeDefined();
 
-    await expect(start(port)).rejects.toThrow("Legacy workspace setup state requires migration");
-    await expect(fetch(`http://127.0.0.1:${port}/readyz`)).rejects.toThrow();
-    await expect(fs.stat(sourcePath)).resolves.toBeDefined();
-
-    const migration = await migrateLegacyWorkspaceState({
-      stateDir,
-      detected: detectLegacyWorkspaceState({
-        cfg,
+      const migration = await migrateLegacyWorkspaceState({
         stateDir,
-        homedir: os.homedir,
-        doctorOnlyStateMigrations: true,
-      }),
-    });
-    expect(migration.warnings).toEqual([]);
-    server = await start(port);
-    const ready = await fetch(`http://127.0.0.1:${port}/readyz`);
-    expect(ready.status).toBe(200);
-    await expect(fs.stat(sourcePath)).rejects.toHaveProperty("code", "ENOENT");
-  });
+        detected: detectLegacyWorkspaceState({
+          cfg,
+          stateDir,
+          homedir: os.homedir,
+          doctorOnlyStateMigrations: true,
+        }),
+      });
+      expect(migration.warnings).toEqual([]);
+      server = await start(port, initialSnapshotRead);
+      const ready = await fetch(`http://127.0.0.1:${port}/readyz`);
+      expect(ready.status).toBe(200);
+      await expect(fs.stat(sourcePath)).rejects.toHaveProperty("code", "ENOENT");
+    },
+  );
 
   it.each(["managed write", "file watcher"])(
     "rejects an unmigrated workspace switch before publication via %s",
@@ -113,7 +142,7 @@ describe("Gateway workspace migration readiness", () => {
       state.envVars.OPENCLAW_TEST_MINIMAL_GATEWAY = undefined;
       state.applyEnv();
       const oldWorkspace = state.workspaceDir;
-      const nextWorkspace = state.path("retained-workspace");
+      const nextWorkspace = state.path("retained");
       const reloadError = vi.spyOn(gatewayKernelLogs.logReload, "error");
       const cfg: OpenClawConfig = {
         gateway: { mode: "local", bind: "loopback", auth: { mode: "none" } },

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -1,5 +1,7 @@
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
+import { gunzipSync } from "node:zlib";
 import { afterEach, describe, expect, it } from "vitest";
 import packageJson from "../../package.json" with { type: "json" };
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
@@ -7,6 +9,7 @@ import { requireNodeSqlite } from "../infra/node-sqlite.js";
 import { collectSqliteSchemaIssues } from "../infra/sqlite-schema-contract.js";
 import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.js";
 import { createUpdateRun } from "../infra/update-run-ledger.js";
+import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "./openclaw-agent-db-migration-required.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   OPENCLAW_AGENT_SCHEMA_VERSION,
@@ -17,7 +20,9 @@ import {
   preflightOpenClawStateDatabasePath,
   preflightOpenClawDatabaseSchemas,
 } from "./openclaw-database-preflight.js";
+import { repairAuditEventsSchema } from "./openclaw-state-db-audit-migration.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
+import { OpenClawStateDatabaseSchemaMigrationRequiredError } from "./openclaw-state-db-schema-migration-required.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -77,6 +82,107 @@ describe("OpenClaw database schema preflight", () => {
     }
     return databasePath;
   }
+
+  function sourceManifest(stateDir: string) {
+    // Coordinator tmp/ files are lifecycle scratch; persistent artifacts must not change.
+    return fs
+      .readdirSync(stateDir, { recursive: true, encoding: "utf8" })
+      .filter((entry) => !entry.startsWith(`tmp${path.sep}`))
+      .filter((entry) => fs.statSync(path.join(stateDir, entry)).isFile())
+      .toSorted()
+      .map((entry) => [
+        entry,
+        createHash("sha256")
+          .update(fs.readFileSync(path.join(stateDir, entry)))
+          .digest("hex"),
+      ]);
+  }
+
+  function createReleasedStateDatabase() {
+    const stateDir = tempDirs.make("openclaw-startup-database-admission-");
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const statePath = resolveOpenClawStateSqlitePath(env);
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(
+      statePath,
+      gunzipSync(
+        fs.readFileSync(
+          new URL(
+            "../../test/fixtures/sqlite/openclaw-state-v2026.7.1-2.sqlite.gz",
+            import.meta.url,
+          ),
+        ),
+      ),
+    );
+    fs.writeFileSync(path.join(stateDir, "openclaw.json"), "{}\n");
+    return { env, stateDir, statePath };
+  }
+
+  it("refuses released legacy audit state before changing any persistent artifact", async () => {
+    const { env, stateDir, statePath } = createReleasedStateDatabase();
+    const before = sourceManifest(stateDir);
+    await expect(
+      assertOpenClawDatabasesReady({ env, operation: "gateway-startup", config: {} }),
+    ).rejects.toBeInstanceOf(OpenClawStateDatabaseSchemaMigrationRequiredError);
+    expect(sourceManifest(stateDir)).toEqual(before);
+    await expect(preflightOpenClawStateDatabasePath(statePath)).resolves.toMatchObject({
+      foundVersion: 1,
+    });
+  });
+
+  it.each(["configured", "registered"] as const)(
+    "refuses a %s legacy agent database without mutating its WAL or creating stores",
+    async (layout) => {
+      const stateDir = tempDirs.make("openclaw-agent-startup-admission-");
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const agentPath =
+        layout === "configured"
+          ? path.join(stateDir, "custom", "sessions.sqlite")
+          : path.join(stateDir, "agents", "retired", "agent", "openclaw-agent.sqlite");
+      const agentId = layout === "configured" ? "main" : "retired";
+      openOpenClawAgentDatabase({ agentId, path: agentPath, env });
+      closeOpenClawAgentDatabasesForTest();
+      closeOpenClawStateDatabaseForTest();
+      const { DatabaseSync } = requireNodeSqlite();
+      const writer = new DatabaseSync(agentPath);
+      try {
+        writer.exec(
+          "PRAGMA journal_mode = WAL; PRAGMA wal_autocheckpoint = 0; PRAGMA user_version = 15; UPDATE schema_meta SET schema_version = 15;",
+        );
+        const config =
+          layout === "configured"
+            ? { session: { store: path.join(stateDir, "custom", "sessions.json") } }
+            : {};
+        const before = sourceManifest(stateDir);
+        await expect(
+          assertOpenClawDatabasesReady({ env, operation: "gateway-startup", config }),
+        ).rejects.toBeInstanceOf(OpenClawAgentDatabaseMediaMigrationRequiredError);
+        expect(sourceManifest(stateDir)).toEqual(before);
+      } finally {
+        writer.close();
+      }
+    },
+  );
+
+  it("admits supported forward state migration after the Doctor-owned audit repair", async () => {
+    const { env, stateDir, statePath } = createReleasedStateDatabase();
+    const { DatabaseSync } = requireNodeSqlite();
+    const database = new DatabaseSync(statePath);
+    try {
+      expect(repairAuditEventsSchema(database)).toBe(true);
+    } finally {
+      database.close();
+    }
+    const before = sourceManifest(stateDir);
+    await expect(
+      assertOpenClawDatabasesReady({ env, operation: "gateway-startup", config: {} }),
+    ).resolves.toBeUndefined();
+    expect(sourceManifest(stateDir)).toEqual(before);
+    const migrated = openOpenClawStateDatabase({ env });
+    expect(migrated.db.prepare("PRAGMA user_version").get()).toEqual({
+      user_version: OPENCLAW_STATE_SCHEMA_VERSION,
+    });
+  });
 
   it("reports an exact current schema for one explicit copied database", async () => {
     const stateDir = tempDirs.make("openclaw-runtime-state-preflight-");

--- a/src/state/openclaw-database-preflight.test.ts
+++ b/src/state/openclaw-database-preflight.test.ts
@@ -164,6 +164,30 @@ describe("OpenClaw database schema preflight", () => {
     },
   );
 
+  it("rejects a canonical configured agent path owned by another agent before writes", async () => {
+    const root = tempDirs.make("openclaw-configured-agent-owner-");
+    const env = { OPENCLAW_STATE_DIR: path.join(root, "active") };
+    const agentDir = path.join(root, "external", "agents", "alpha");
+    const agentPath = path.join(agentDir, "agent", "openclaw-agent.sqlite");
+    const store = path.join(agentDir, "sessions", "sessions.json");
+    openOpenClawAgentDatabase({
+      agentId: "beta",
+      path: agentPath,
+      env: { OPENCLAW_STATE_DIR: path.join(root, "donor") },
+    });
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    const before = sourceManifest(root);
+    await expect(
+      assertOpenClawDatabasesReady({
+        env,
+        operation: "gateway-startup",
+        config: { session: { store } },
+      }),
+    ).rejects.toThrow("belongs to agent beta; requested agent alpha");
+    expect(sourceManifest(root)).toEqual(before);
+  });
+
   it("admits supported forward state migration after the Doctor-owned audit repair", async () => {
     const { env, stateDir, statePath } = createReleasedStateDatabase();
     const { DatabaseSync } = requireNodeSqlite();
@@ -289,6 +313,41 @@ describe("OpenClaw database schema preflight", () => {
       ],
     });
   });
+
+  it.each([false, true])(
+    "admits legacy additive columns without writes, rejecting genuine drift=%s",
+    async (drift) => {
+      const initialPath = createExplicitStateDatabase();
+      const stateDir = path.dirname(initialPath);
+      const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+      fs.mkdirSync(path.dirname(databasePath));
+      fs.renameSync(initialPath, databasePath);
+      const database = new (requireNodeSqlite().DatabaseSync)(databasePath);
+      database.exec(
+        "ALTER TABLE task_runs DROP COLUMN tool_use_count; ALTER TABLE task_runs DROP COLUMN last_tool_name; ALTER TABLE apns_registrations DROP COLUMN relay_origin;",
+      );
+      if (drift) {
+        database.exec("ALTER TABLE task_runs ADD COLUMN unrecognized INTEGER NOT NULL DEFAULT 0");
+      }
+      database.close();
+      const before = snapshotSourceFamily(databasePath);
+      expect(await preflightOpenClawStateDatabasePath(databasePath)).toMatchObject({
+        foundVersion: OPENCLAW_STATE_SCHEMA_VERSION,
+        status: drift ? "incompatible" : "startup-repairable",
+      });
+      const admission = assertOpenClawDatabasesReady({
+        env: { OPENCLAW_STATE_DIR: stateDir },
+        operation: "gateway-startup",
+        config: {},
+      });
+      if (drift) {
+        await expect(admission).rejects.toThrow("requires repair");
+      } else {
+        await expect(admission).resolves.toBeUndefined();
+      }
+      expect(snapshotSourceFamily(databasePath)).toEqual(before);
+    },
+  );
 
   it("classifies the same-version run-end cleanup column as startup-repairable without touching the source", async () => {
     const sourcePath = createExplicitStateDatabase(

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -1,6 +1,7 @@
 import { existsSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { resolveUnsuffixedSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import { resolveConfiguredAgentDatabaseCandidatePaths } from "../config/sessions/targets.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
@@ -600,6 +601,7 @@ export async function preflightOpenClawDatabaseSchemas(options: {
         )
       : []),
     ...(options.configuredAgentDatabaseCandidatePaths ?? []).map((candidatePath) => ({
+      agentId: resolveUnsuffixedSqliteTargetFromSessionStorePath(candidatePath).agentId,
       path: candidatePath,
     })),
   ];

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -601,7 +601,9 @@ export async function preflightOpenClawDatabaseSchemas(options: {
         )
       : []),
     ...(options.configuredAgentDatabaseCandidatePaths ?? []).map((candidatePath) => ({
-      agentId: resolveUnsuffixedSqliteTargetFromSessionStorePath(candidatePath).agentId,
+      agentId: options.requireStartupMigrationReadiness
+        ? resolveUnsuffixedSqliteTargetFromSessionStorePath(candidatePath).agentId
+        : undefined,
       path: candidatePath,
     })),
   ];

--- a/src/state/openclaw-database-preflight.ts
+++ b/src/state/openclaw-database-preflight.ts
@@ -1,6 +1,8 @@
 import { existsSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
+import { resolveConfiguredAgentDatabaseCandidatePaths } from "../config/sessions/targets.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import {
   clearNodeSqliteKyselyCacheForDatabase,
@@ -24,6 +26,10 @@ import { discoverAgentDatabaseMigrationTargets } from "../infra/state-migrations
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
 import { assertOpenClawAgentDatabaseForMaintenance } from "./openclaw-agent-db-maintenance.js";
 import { isPersistentOpenClawAgentDatabasePath } from "./openclaw-agent-db-registry.js";
+import {
+  assertCanonicalAgentPersistenceVersion,
+  readExistingAgentSchemaMeta,
+} from "./openclaw-agent-db-schema-helpers.js";
 import type { OpenClawSchemaVersions } from "./openclaw-schema-versions.js";
 import {
   OPENCLAW_DATABASE_SCHEMA_DOCS_URL,
@@ -33,7 +39,9 @@ import {
 import {
   assertOpenClawStateDatabaseOwner,
   assertOpenClawStateDatabaseForMaintenance,
+  openClawStateMigrationAssertions,
 } from "./openclaw-state-db-maintenance.js";
+import { assertCanonicalStateSchemaShape } from "./openclaw-state-db-schema-repair.js";
 import { readStateSchemaContentVersion } from "./openclaw-state-db-schema-version.js";
 import type { DB as OpenClawStateKyselyDatabase } from "./openclaw-state-db.generated.js";
 import {
@@ -167,6 +175,7 @@ export async function assertOpenClawDatabasesReady(
         onDeferredSchemaPublication?: (publication: DeferredStateSchemaPublication) => void;
       }
     | { operation: "gateway-restart" }
+    | { operation: "gateway-startup"; config: OpenClawConfig }
   ),
 ): Promise<void> {
   const schemas = await preflightOpenClawDatabaseSchemas({
@@ -176,6 +185,18 @@ export async function assertOpenClawDatabasesReady(
       agent: OPENCLAW_AGENT_SCHEMA_VERSION,
     },
     verifyCurrentSchemaShape: true,
+    ...(options.operation === "gateway-startup"
+      ? {
+          requireStartupMigrationReadiness: true,
+          // Inspect candidate owners from preserved snapshots: runtime target
+          // resolution opens custom stores directly and can create WAL sidecars.
+          configuredAgentDatabaseTargets: [],
+          configuredAgentDatabaseCandidatePaths: resolveConfiguredAgentDatabaseCandidatePaths(
+            options.config,
+            { env: options.env },
+          ),
+        }
+      : {}),
     ...(options.operation === "doctor"
       ? { configuredAgentDatabaseTargets: options.configuredAgentDatabaseTargets }
       : {}),
@@ -198,7 +219,11 @@ export async function assertOpenClawDatabasesReady(
     .map((database) => `${database.kind} ${database.path}: ${database.reason}`);
   const omitted = schemas.indeterminate.length - shown.length;
   const action =
-    options.operation === "doctor" ? "Doctor could not complete repair" : "Gateway refused restart";
+    options.operation === "doctor"
+      ? "Doctor could not complete repair"
+      : options.operation === "gateway-startup"
+        ? "Gateway refused startup"
+        : "Gateway refused restart";
   throw new Error(
     `${action} because persisted database readiness could not be verified: ${shown.join("; ")}${omitted > 0 ? `; +${omitted} more` : ""}. ${options.operation === "doctor" ? "Stop OpenClaw processes, then restore the affected database from a verified backup." : "Stop the Gateway and other OpenClaw processes, run openclaw doctor --fix, then retry."}`,
   );
@@ -252,6 +277,42 @@ function deduplicateSchemaIssues(issues: readonly SqliteSchemaIssue[]): SqliteSc
       issues.map((issue) => [`${issue.code}\0${issue.objectName}`, issue] as const),
     ).values(),
   ];
+}
+
+function inspectCurrentStateStartupSchema(
+  database: DatabaseSync,
+  databasePath: string,
+  foundVersion: number,
+) {
+  assertOpenClawStateDatabaseOwner(database, { pathname: databasePath });
+  const metadata = database
+    .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
+    .get() as { schema_version?: unknown } | undefined;
+  if (metadata?.schema_version !== foundVersion) {
+    throw new Error(
+      `OpenClaw state database ${databasePath} metadata schema version ${typeof metadata?.schema_version === "number" ? metadata.schema_version : "invalid"} does not match ${foundVersion}.`,
+    );
+  }
+  const issues = deduplicateSchemaIssues([
+    ...collectSqliteSchemaIssues(
+      database,
+      OPENCLAW_STATE_SCHEMA_SQL,
+      OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
+    ),
+    ...collectSqliteSchemaIssues(
+      database,
+      getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: false }),
+      STATE_PERSISTENT_SCHEMA_COMPATIBILITY,
+    ),
+  ]);
+  return {
+    blockingIssues: issues.filter(
+      (issue) =>
+        !isOpenClawStateStartupRepairableSchemaIssue(issue) &&
+        !isOpenClawStateFirstUseSchemaIssue(issue),
+    ),
+    startupRepairableIssues: issues.filter(isOpenClawStateStartupRepairableSchemaIssue),
+  };
 }
 
 /** Compare one explicit SQLite file with this release's canonical shared-state schema. */
@@ -330,47 +391,14 @@ export async function preflightOpenClawStateDatabasePath(
         contentVersion,
       );
     }
-    assertOpenClawStateDatabaseOwner(database, { pathname: resolvedPath });
-    const metadata = database
-      .prepare("SELECT schema_version FROM schema_meta WHERE meta_key = 'primary' LIMIT 1")
-      .get() as { schema_version?: unknown } | undefined;
-    if (metadata?.schema_version !== foundVersion) {
-      throw new Error(
-        `OpenClaw state database ${resolvedPath} metadata schema version ${typeof metadata?.schema_version === "number" ? metadata.schema_version : "invalid"} does not match ${foundVersion}.`,
-      );
-    }
-    const maintenanceIssues = collectSqliteSchemaIssues(
+    const { blockingIssues, startupRepairableIssues } = inspectCurrentStateStartupSchema(
       database,
-      OPENCLAW_STATE_SCHEMA_SQL,
-      OPENCLAW_STATE_MAINTENANCE_SCHEMA_COMPATIBILITY,
-    );
-    const blockingIssues = maintenanceIssues.filter(
-      (issue) =>
-        !isOpenClawStateStartupRepairableSchemaIssue(issue) &&
-        !isOpenClawStateFirstUseSchemaIssue(issue),
+      resolvedPath,
+      foundVersion,
     );
     if (blockingIssues.length > 0) {
-      return result("incompatible", { issues: deduplicateSchemaIssues(blockingIssues) });
+      return result("incompatible", { issues: blockingIssues });
     }
-    const projectedRuntimeIssues = collectSqliteSchemaIssues(
-      database,
-      getOpenClawStateRuntimeSchema({ includeVersionLazyAdditiveTables: false }),
-      STATE_PERSISTENT_SCHEMA_COMPATIBILITY,
-    );
-    const projectedRuntimeBlockingIssues = projectedRuntimeIssues.filter(
-      (issue) =>
-        !isOpenClawStateStartupRepairableSchemaIssue(issue) &&
-        !isOpenClawStateFirstUseSchemaIssue(issue),
-    );
-    if (projectedRuntimeBlockingIssues.length > 0) {
-      return result("incompatible", {
-        issues: deduplicateSchemaIssues(projectedRuntimeBlockingIssues),
-      });
-    }
-    const startupRepairableIssues = deduplicateSchemaIssues([
-      ...maintenanceIssues.filter(isOpenClawStateStartupRepairableSchemaIssue),
-      ...projectedRuntimeIssues.filter(isOpenClawStateStartupRepairableSchemaIssue),
-    ]);
     return result(startupRepairableIssues.length > 0 ? "startup-repairable" : "exact", {
       issues: startupRepairableIssues,
       requiresWrite: startupRepairableIssues.length > 0,
@@ -389,6 +417,7 @@ export async function preflightOpenClawDatabaseSchemas(options: {
   signal?: AbortSignal;
   supportedVersions: OpenClawSchemaVersions;
   verifyCurrentSchemaShape?: boolean;
+  requireStartupMigrationReadiness?: boolean;
   configuredAgentDatabaseTargets?:
     | readonly { agentId: string; path: string }[]
     | ((
@@ -466,6 +495,28 @@ export async function preflightOpenClawDatabaseSchemas(options: {
         );
       }
       if (
+        options.requireStartupMigrationReadiness &&
+        contentVersion <= OPENCLAW_STATE_SCHEMA_VERSION
+      ) {
+        assertSqliteIntegrity(stateDatabase, statePath);
+        assertCanonicalStateSchemaShape(stateDatabase, statePath);
+        if (contentVersion === OPENCLAW_STATE_SCHEMA_VERSION) {
+          const { blockingIssues } = inspectCurrentStateStartupSchema(
+            stateDatabase,
+            statePath,
+            stateVersion,
+          );
+          if (blockingIssues.length > 0) {
+            throw new Error(
+              `OpenClaw state database ${statePath} requires repair: ${blockingIssues.map((issue) => issue.message).join("; ")}; run openclaw doctor --fix.`,
+            );
+          }
+        } else {
+          openClawStateMigrationAssertions.get(contentVersion)?.(stateDatabase, {
+            pathname: statePath,
+          });
+        }
+      } else if (
         options.verifyCurrentSchemaShape === true &&
         contentVersion === OPENCLAW_STATE_SCHEMA_VERSION
       ) {
@@ -497,7 +548,7 @@ export async function preflightOpenClawDatabaseSchemas(options: {
   } catch (error) {
     // Accepted stop must not turn cancellation or failed cleanup into a
     // warn-and-continue result that launches the remaining startup runtime.
-    if (options.signal?.aborted) {
+    if (options.signal?.aborted || options.requireStartupMigrationReadiness) {
       throw error;
     }
     result.indeterminate.push({
@@ -598,11 +649,22 @@ export async function preflightOpenClawDatabaseSchemas(options: {
         });
       }
       if (agentVersion <= options.supportedVersions.agent) {
-        if (options.verifyCurrentSchemaShape === true && row.agentId !== undefined) {
-          // Existing agent databases require Doctor-owned migration before
-          // startup; a successor cannot safely repair them after close.
+        if (options.requireStartupMigrationReadiness) {
+          assertSqliteIntegrity(agentDatabase, agentPath);
+          assertCanonicalAgentPersistenceVersion(agentDatabase, agentPath, agentVersion);
+        }
+        const agentId =
+          row.agentId ??
+          (options.requireStartupMigrationReadiness
+            ? readExistingAgentSchemaMeta(agentDatabase)?.agentId
+            : undefined);
+        if (
+          options.verifyCurrentSchemaShape === true &&
+          agentId != null &&
+          (!options.requireStartupMigrationReadiness || agentVersion > 0)
+        ) {
           assertOpenClawAgentDatabaseForMaintenance(agentDatabase, {
-            agentId: row.agentId,
+            agentId,
             pathname: agentPath,
           });
         }
@@ -618,7 +680,7 @@ export async function preflightOpenClawDatabaseSchemas(options: {
         ...(writerAppVersion ? { writerAppVersion } : {}),
       });
     } catch (error) {
-      if (options.signal?.aborted) {
+      if (options.signal?.aborted || options.requireStartupMigrationReadiness) {
         throw error;
       }
       result.indeterminate.push({

--- a/src/state/openclaw-state-db-additive-columns.ts
+++ b/src/state/openclaw-state-db-additive-columns.ts
@@ -1,77 +1,174 @@
 type BareNullableSqliteDatatype = "ANY" | "BLOB" | "INT" | "INTEGER" | "REAL" | "TEXT";
-type LazyAdditiveStateColumnDefinition = {
-  columnName: string;
-  dataType: BareNullableSqliteDatatype;
-  tableName: string;
-};
+type LazyColumn = readonly [
+  tableName: string,
+  columnName: string,
+  dataType: BareNullableSqliteDatatype,
+  firstUseOnly?: true,
+];
 
-// Added after v6 shipped. Every definition stays bare and nullable so older v6
-// writers can omit it safely when a newer build has already ensured the column.
-export const CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS = [
-  { columnName: "bootstrap_content_digest", dataType: "TEXT", tableName: "claw_installs" },
-  { columnName: "bootstrap_source_path", dataType: "TEXT", tableName: "claw_installs" },
-  { columnName: "desktop_json", dataType: "TEXT", tableName: "worker_environments" },
-  { columnName: "bootstrap_install_kind", dataType: "TEXT", tableName: "worker_environments" },
-  { columnName: "extension_adapter_identity", dataType: "TEXT", tableName: "claw_package_refs" },
-  { columnName: "extension_detected_format", dataType: "TEXT", tableName: "claw_package_refs" },
-  { columnName: "extension_format", dataType: "TEXT", tableName: "claw_package_refs" },
-  { columnName: "extension_id", dataType: "TEXT", tableName: "claw_package_refs" },
-  { columnName: "extension_mapped_json", dataType: "TEXT", tableName: "claw_package_refs" },
-  { columnName: "extension_unavailable_json", dataType: "TEXT", tableName: "claw_package_refs" },
-  { columnName: "shared_host", dataType: "INTEGER", tableName: "worker_environments" },
-  { columnName: "node_setup_id", dataType: "TEXT", tableName: "worker_environments" },
-  { columnName: "node_device_id", dataType: "TEXT", tableName: "worker_environments" },
-  { columnName: "terminal_reason", dataType: "TEXT", tableName: "worker_session_placements" },
-  { columnName: "terminal_at_ms", dataType: "INTEGER", tableName: "worker_session_placements" },
-  {
-    columnName: "repository_workspace_id",
-    dataType: "TEXT",
-    tableName: "worker_workspace_pending_results",
-  },
-  {
-    columnName: "abandon_source",
-    dataType: "INTEGER",
-    tableName: "worker_session_placement_moves",
-  },
-  {
-    columnName: "target_machine_class",
-    dataType: "TEXT",
-    tableName: "worker_session_placement_moves",
-  },
-  { columnName: "run_end_cleanup_json", dataType: "TEXT", tableName: "worktrees" },
-  { columnName: "setup_id", dataType: "TEXT", tableName: "device_bootstrap_tokens" },
-  { columnName: "cwd", dataType: "TEXT", tableName: "session_groups" },
-  { columnName: "worktree", dataType: "INTEGER", tableName: "session_groups" },
-  { columnName: "allowed_hosts", dataType: "TEXT", tableName: "secret_store_entries" },
-  { columnName: "device_id", dataType: "TEXT", tableName: "web_push_subscriptions" },
-  { columnName: "user_profile_id", dataType: "TEXT", tableName: "web_push_subscriptions" },
-  { columnName: "preferences_json", dataType: "TEXT", tableName: "web_push_subscriptions" },
-] as const satisfies readonly LazyAdditiveStateColumnDefinition[];
+// Added after v6 shipped; first-use-only columns stay absent until their feature writes.
+const lazyColumns = [
+  ["claw_installs", "bootstrap_content_digest", "TEXT"],
+  ["claw_installs", "bootstrap_source_path", "TEXT"],
+  ["worker_environments", "desktop_json", "TEXT"],
+  ["worker_environments", "bootstrap_install_kind", "TEXT"],
+  ["claw_package_refs", "extension_adapter_identity", "TEXT"],
+  ["claw_package_refs", "extension_detected_format", "TEXT"],
+  ["claw_package_refs", "extension_format", "TEXT"],
+  ["claw_package_refs", "extension_id", "TEXT"],
+  ["claw_package_refs", "extension_mapped_json", "TEXT"],
+  ["claw_package_refs", "extension_unavailable_json", "TEXT"],
+  ["worker_environments", "shared_host", "INTEGER"],
+  ["worker_environments", "node_setup_id", "TEXT"],
+  ["worker_environments", "node_device_id", "TEXT"],
+  ["worker_session_placements", "terminal_reason", "TEXT"],
+  ["worker_session_placements", "terminal_at_ms", "INTEGER"],
+  ["worker_workspace_pending_results", "repository_workspace_id", "TEXT", true],
+  ["worker_session_placement_moves", "abandon_source", "INTEGER", true],
+  ["worker_session_placement_moves", "target_machine_class", "TEXT", true],
+  ["worktrees", "run_end_cleanup_json", "TEXT"],
+  ["device_bootstrap_tokens", "setup_id", "TEXT", true],
+  ["session_groups", "cwd", "TEXT", true],
+  ["session_groups", "worktree", "INTEGER", true],
+  ["secret_store_entries", "allowed_hosts", "TEXT"],
+  ["web_push_subscriptions", "device_id", "TEXT", true],
+  ["web_push_subscriptions", "user_profile_id", "TEXT", true],
+  ["web_push_subscriptions", "preferences_json", "TEXT", true],
+] as const satisfies readonly LazyColumn[];
 
-function isFirstUseAdditiveStateColumn({
-  columnName,
-  tableName,
-}: LazyAdditiveStateColumnDefinition): boolean {
-  return (
-    (tableName === "device_bootstrap_tokens" && columnName === "setup_id") ||
-    (tableName === "worker_workspace_pending_results" &&
-      columnName === "repository_workspace_id") ||
-    (tableName === "worker_session_placement_moves" &&
-      (columnName === "abandon_source" || columnName === "target_machine_class")) ||
-    (tableName === "session_groups" && (columnName === "cwd" || columnName === "worktree")) ||
-    (tableName === "web_push_subscriptions" &&
-      (columnName === "device_id" ||
-        columnName === "user_profile_id" ||
-        columnName === "preferences_json"))
-  );
+function lazyColumnDefinitions(firstUseOnly?: boolean) {
+  return lazyColumns
+    .filter((definition) => firstUseOnly === undefined || Boolean(definition[3]) === firstUseOnly)
+    .map(([tableName, columnName, dataType]) => ({ columnName, dataType, tableName }));
 }
 
-// Most same-version columns repair during a writable shared-state open. These
-// feature-owned columns stay absent until their feature first uses them.
-export const CLAW_STARTUP_ADDITIVE_STATE_COLUMN_DEFINITIONS =
-  CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS.filter(
-    (definition) => !isFirstUseAdditiveStateColumn(definition),
-  );
+export const CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS = lazyColumnDefinitions();
+export const CLAW_STARTUP_ADDITIVE_STATE_COLUMN_DEFINITIONS = lazyColumnDefinitions(false);
+export const CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_DEFINITIONS = lazyColumnDefinitions(true);
 
-export const CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_DEFINITIONS =
-  CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS.filter(isFirstUseAdditiveStateColumn);
+// Historical repairs retain these groups at their original backfill boundaries.
+export const ORDERED_STARTUP_ADDITIVE_STATE_COLUMNS = {
+  packageUpdatedAt: [["claw_package_refs", "updated_at_ms INTEGER NOT NULL DEFAULT 0"]],
+  packageIntegrity: [
+    [
+      "claw_package_refs",
+      "package_integrity TEXT NOT NULL DEFAULT 'sha256:0000000000000000000000000000000000000000000000000000000000000000'",
+    ],
+  ],
+  diagnosticSequence: [["diagnostic_events", "sequence INTEGER NOT NULL DEFAULT 0"]],
+  cronRunLogs: [
+    ["worktrees", "provisioned_paths_json TEXT"],
+    ["apns_registrations", "relay_origin TEXT"],
+    ["device_pairing_pending", "refreshed_at_ms INTEGER"],
+    ["device_pairing_pending", "browser_origin TEXT"],
+    ["device_pairing_paired", "approved_via TEXT"],
+    ["device_pairing_paired", "browser_origin TEXT"],
+    ["device_pairing_paired", "operator_label TEXT"],
+    ["device_pairing_paired", "node_surface_json TEXT"],
+    ["device_pairing_paired", "pending_node_surface_json TEXT"],
+    ["cron_run_logs", "status TEXT"],
+    ["cron_run_logs", "error TEXT"],
+    ["cron_run_logs", "summary TEXT"],
+    ["cron_run_logs", "diagnostics_summary TEXT"],
+    ["cron_run_logs", "delivery_status TEXT"],
+    ["cron_run_logs", "delivery_error TEXT"],
+    ["cron_run_logs", "delivered INTEGER"],
+    ["cron_run_logs", "session_id TEXT"],
+    ["cron_run_logs", "session_key TEXT"],
+    ["cron_run_logs", "run_id TEXT"],
+    ["cron_run_logs", "run_at_ms INTEGER"],
+    ["cron_run_logs", "duration_ms INTEGER"],
+    ["cron_run_logs", "next_run_at_ms INTEGER"],
+    ["cron_run_logs", "model TEXT"],
+    ["cron_run_logs", "provider TEXT"],
+    ["cron_run_logs", "total_tokens INTEGER"],
+    ["cron_run_logs", "entry_json TEXT NOT NULL DEFAULT '{}'"],
+    ["cron_run_logs", "created_at INTEGER NOT NULL DEFAULT 0"],
+  ],
+  acpReplay: [
+    ["acp_replay_events", "estimated_bytes INTEGER NOT NULL DEFAULT 0"],
+    ["acp_replay_sessions", "estimated_bytes INTEGER NOT NULL DEFAULT 0"],
+  ],
+  cronJobs: [
+    ["cron_jobs", "description TEXT"],
+    ["cron_jobs", "declaration_key TEXT"],
+    ["cron_jobs", "owner_agent_id TEXT"],
+    ["cron_jobs", "name TEXT NOT NULL DEFAULT ''"],
+    ["cron_jobs", "enabled INTEGER NOT NULL DEFAULT 1"],
+    ["cron_jobs", "agent_id TEXT"],
+    ["cron_jobs", "payload_kind TEXT NOT NULL DEFAULT 'message'"],
+    ["cron_jobs", "state_json TEXT NOT NULL DEFAULT '{}'"],
+    ["cron_jobs", "runtime_updated_at_ms INTEGER"],
+    ["cron_jobs", "schedule_identity TEXT"],
+    ["cron_jobs", "sort_order INTEGER NOT NULL DEFAULT 0"],
+  ],
+  deliveryQueue: [
+    ["sandbox_registry_entries", "session_key TEXT"],
+    ["sandbox_registry_entries", "backend_id TEXT"],
+    ["sandbox_registry_entries", "runtime_label TEXT"],
+    ["sandbox_registry_entries", "image TEXT"],
+    ["sandbox_registry_entries", "created_at_ms INTEGER"],
+    ["sandbox_registry_entries", "last_used_at_ms INTEGER"],
+    ["sandbox_registry_entries", "config_label_kind TEXT"],
+    ["sandbox_registry_entries", "config_hash TEXT"],
+    ["sandbox_registry_entries", "cdp_port INTEGER"],
+    ["sandbox_registry_entries", "no_vnc_port INTEGER"],
+    ["delivery_queue_entries", "entry_kind TEXT"],
+    ["delivery_queue_entries", "session_key TEXT"],
+    ["delivery_queue_entries", "channel TEXT"],
+    ["delivery_queue_entries", "target TEXT"],
+    ["delivery_queue_entries", "account_id TEXT"],
+    ["delivery_queue_entries", "retry_count INTEGER NOT NULL DEFAULT 0"],
+    ["delivery_queue_entries", "last_attempt_at INTEGER"],
+    ["delivery_queue_entries", "last_error TEXT"],
+    ["delivery_queue_entries", "recovery_state TEXT"],
+    ["delivery_queue_entries", "platform_send_started_at INTEGER"],
+  ],
+  originalMediaRoot: [
+    ["managed_outgoing_image_records", "original_media_root TEXT NOT NULL DEFAULT ''"],
+  ],
+  beforeTaskAttribution: [
+    ["managed_outgoing_image_records", "agent_id TEXT"],
+    [
+      "managed_outgoing_image_records",
+      "cleanup_pending INTEGER NOT NULL DEFAULT 0 CHECK (cleanup_pending IN (0, 1))",
+    ],
+    ["current_conversation_bindings", "conversation_kind TEXT NOT NULL DEFAULT 'channel'"],
+    ["device_bootstrap_tokens", "pending_profile_json TEXT"],
+    ["gateway_restart_handoff", "restart_trace_started_at INTEGER"],
+    ["gateway_restart_handoff", "restart_trace_last_at INTEGER"],
+    ["gateway_restart_intent", "reason TEXT"],
+    ["gateway_restart_sentinel", "delivery_channel TEXT"],
+    ["gateway_restart_sentinel", "delivery_to TEXT"],
+    ["gateway_restart_sentinel", "delivery_account_id TEXT"],
+    ["gateway_restart_sentinel", "message TEXT"],
+    ["gateway_restart_sentinel", "continuation_json TEXT"],
+    ["gateway_restart_sentinel", "doctor_hint TEXT"],
+    ["gateway_restart_sentinel", "stats_json TEXT"],
+    ["gateway_boot_lifecycle", "startup_reason TEXT"],
+    ["official_external_plugin_catalog_snapshots", "trust_mode TEXT"],
+    ["official_external_plugin_catalog_snapshots", "trust_key_id TEXT"],
+    ["official_external_plugin_catalog_snapshots", "trust_signature_count INTEGER"],
+    ["official_external_plugin_catalog_snapshots", "trust_threshold INTEGER"],
+    ["official_external_plugin_catalog_snapshots", "trust_verified_at TEXT"],
+  ],
+  taskRequester: [["task_runs", "requester_agent_id TEXT"]],
+  taskRunDetails: [
+    ["task_runs", "tool_use_count INTEGER"],
+    ["task_runs", "last_tool_name TEXT"],
+    ["task_runs", "detail_json TEXT"],
+  ],
+  workerEnvironments: [
+    ["worker_environments", "bootstrap_bundle_hash TEXT"],
+    ["worker_environments", "bootstrap_openclaw_version TEXT"],
+    ["worker_environments", "bootstrap_protocol_features_json TEXT"],
+    ["worker_environments", "bootstrap_install_kind TEXT"],
+    ["worker_environments", "owner_epoch INTEGER NOT NULL DEFAULT 0 CHECK (owner_epoch >= 0)"],
+    ["worker_environments", "ssh_host_key TEXT"],
+    ["worker_workspace_pending_results", "staged_result_ref TEXT"],
+    [
+      "worker_environments",
+      "teardown_terminal_state TEXT CHECK (teardown_terminal_state IN ('destroyed', 'failed'))",
+    ],
+  ],
+} as const;

--- a/src/state/openclaw-state-db-readonly.test.ts
+++ b/src/state/openclaw-state-db-readonly.test.ts
@@ -6,6 +6,7 @@ import { withTempDir } from "../test-utils/temp-dir.js";
 import {
   withExistingOpenClawStateDatabaseArtifactPreservingReadOnly,
   withExistingOpenClawStateDatabaseReadOnly,
+  withArtifactPreservingStateReads,
 } from "./openclaw-state-db-readonly.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -23,10 +24,14 @@ afterEach(() => {
   closeOpenClawStateDatabaseForTest();
 });
 
-describe.each([
-  ["shared", withExistingOpenClawStateDatabaseReadOnly],
-  ["artifact-preserving", withExistingOpenClawStateDatabaseArtifactPreservingReadOnly],
-] as const)("%s read-only state reads", (_name, readState) => {
+describe.each(["admission", "explicit"] as const)("%s read-only state reads", (mode) => {
+  const readState: typeof withExistingOpenClawStateDatabaseReadOnly =
+    mode === "admission"
+      ? (operation, options) =>
+          withArtifactPreservingStateReads(() =>
+            withExistingOpenClawStateDatabaseReadOnly(operation, options),
+          )
+      : withExistingOpenClawStateDatabaseArtifactPreservingReadOnly;
   it("reads a consolidated WAL database without creating source sidecars", async () => {
     await withTempDir("openclaw-state-readonly-sidecars-", async (stateDir) => {
       const options = createOptions(stateDir);

--- a/src/state/openclaw-state-db-readonly.test.ts
+++ b/src/state/openclaw-state-db-readonly.test.ts
@@ -1,8 +1,12 @@
+import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it } from "vitest";
 import { withTempDir } from "../test-utils/temp-dir.js";
-import { withExistingOpenClawStateDatabaseArtifactPreservingReadOnly } from "./openclaw-state-db-readonly.js";
+import {
+  withExistingOpenClawStateDatabaseArtifactPreservingReadOnly,
+  withExistingOpenClawStateDatabaseReadOnly,
+} from "./openclaw-state-db-readonly.js";
 import {
   closeOpenClawStateDatabaseForTest,
   openOpenClawStateDatabase,
@@ -19,7 +23,29 @@ afterEach(() => {
   closeOpenClawStateDatabaseForTest();
 });
 
-describe("artifact-preserving shared-state reads", () => {
+describe.each([
+  ["shared", withExistingOpenClawStateDatabaseReadOnly],
+  ["artifact-preserving", withExistingOpenClawStateDatabaseArtifactPreservingReadOnly],
+] as const)("%s read-only state reads", (_name, readState) => {
+  it("reads a consolidated WAL database without creating source sidecars", async () => {
+    await withTempDir("openclaw-state-readonly-sidecars-", async (stateDir) => {
+      const options = createOptions(stateDir);
+      fs.mkdirSync(path.dirname(options.path), { recursive: true });
+      const writer = new DatabaseSync(options.path);
+      writer.exec(
+        "PRAGMA journal_mode = WAL; CREATE TABLE held(value TEXT); INSERT INTO held VALUES ('committed');",
+      );
+      writer.close();
+      const before = fs.readFileSync(options.path);
+      expect(fs.readdirSync(path.dirname(options.path))).toEqual(["openclaw.sqlite"]);
+
+      expect(readState(({ db }) => db.prepare("SELECT value FROM held").all(), options)).toEqual([
+        { value: "committed" },
+      ]);
+      expect(fs.readdirSync(path.dirname(options.path))).toEqual(["openclaw.sqlite"]);
+      expect(fs.readFileSync(options.path)).toEqual(before);
+    });
+  });
   it.each(["cached", "uncached"])(
     "reads committed rows without joining a %s transaction",
     async (cacheState) => {
@@ -33,14 +59,11 @@ describe("artifact-preserving shared-state reads", () => {
         const writer = cacheState === "cached" ? opened.db : new DatabaseSync(options.path);
         writer.exec("BEGIN; UPDATE held SET value = 'uncommitted';");
         try {
-          const result = withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(
-            ({ db, path: pathname }) => {
-              expect(db).not.toBe(writer);
-              expect(pathname).toBe(options.path);
-              return db.prepare("SELECT value FROM held").all();
-            },
-            options,
-          );
+          const result = readState(({ db, path: pathname }) => {
+            expect(db).not.toBe(writer);
+            expect(pathname).toBe(options.path);
+            return db.prepare("SELECT value FROM held").all();
+          }, options);
           expect(result).toEqual([{ value: "original" }]);
           expect(writer.isTransaction).toBe(true);
           expect(writer.prepare("SELECT value FROM held").all()).toEqual([
@@ -62,7 +85,7 @@ describe("artifact-preserving shared-state reads", () => {
       const opened = openOpenClawStateDatabase(options);
       opened.db.exec("CREATE TABLE held(value TEXT); INSERT INTO held VALUES ('original');");
 
-      const result = withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(({ db }) => {
+      const result = readState(({ db }) => {
         expect(db).toBe(opened.db);
         return db.prepare("SELECT value FROM held").all();
       }, options);

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -71,18 +71,24 @@ function withFreshOpenClawStateDatabaseReadOnly<T>(
   operation: (database: OpenClawStateReadOnlyDatabase) => T,
   options: OpenClawStateDatabaseOptions,
   pathname: string,
-  location = pathname,
 ): T {
   const env = options.env ?? process.env;
   openClawStateDatabaseCache.assertOpenClawStateDatabaseFreshOpenAllowedAtPath(pathname, env);
-  const db = openNodeSqliteDatabase(location, { readOnly: true });
+  // Even read-only SQLite opens can create a missing WAL. The existing worker
+  // snapshots committed WAL pages without touching source sidecars or caller-held locks.
+  const prepared = prepareSqliteReadOnlyLocationSync(pathname);
   try {
-    db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
-    assertSupportedStateSchemaVersion(db, pathname);
-    return operation({ db, path: pathname });
+    const db = openNodeSqliteDatabase(prepared.location, { readOnly: true });
+    try {
+      db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
+      assertSupportedStateSchemaVersion(db, pathname);
+      return operation({ db, path: pathname });
+    } finally {
+      clearNodeSqliteKyselyCacheForDatabase(db);
+      db.close();
+    }
   } finally {
-    clearNodeSqliteKyselyCacheForDatabase(db);
-    db.close();
+    prepared.cleanup();
   }
 }
 
@@ -124,31 +130,4 @@ export function withExistingOpenClawStateDatabaseReadOnly<T>(
     : withFreshOpenClawStateDatabaseReadOnly(operation, options, existingPath);
 }
 
-/** Read existing shared state without creating or updating its SQLite sidecars. */
-export function withExistingOpenClawStateDatabaseArtifactPreservingReadOnly<T>(
-  operation: (database: OpenClawStateReadOnlyDatabase) => T,
-  options: OpenClawStateDatabaseOptions = {},
-): T | undefined {
-  const pathname = resolveReadOnlyPath(options);
-  const reused = withOpenClawStateDatabaseReadOnlyIfOpen(operation, pathname);
-  if (reused.reused) {
-    return reused.value;
-  }
-  const existingPath = existingPathOrUndefined(pathname);
-  if (existingPath === undefined) {
-    return undefined;
-  }
-  // Cache absence cannot rule out caller-owned SQLite handles. Copy in a child
-  // so closing a source descriptor cannot release this process's POSIX locks.
-  const prepared = prepareSqliteReadOnlyLocationSync(existingPath);
-  try {
-    return withFreshOpenClawStateDatabaseReadOnly(
-      operation,
-      options,
-      existingPath,
-      prepared.location,
-    );
-  } finally {
-    prepared.cleanup();
-  }
-}
+export { withExistingOpenClawStateDatabaseReadOnly as withExistingOpenClawStateDatabaseArtifactPreservingReadOnly };

--- a/src/state/openclaw-state-db-readonly.ts
+++ b/src/state/openclaw-state-db-readonly.ts
@@ -1,9 +1,11 @@
+import { AsyncLocalStorage } from "node:async_hooks";
 import { statSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { clearNodeSqliteKyselyCacheForDatabase } from "../infra/kysely-sync-cache-state.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { prepareSqliteReadOnlyLocationSync } from "../infra/sqlite-readonly-location.js";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 import { openClawStateDatabaseCache } from "./openclaw-state-db-cache.js";
 import {
   OPENCLAW_SQLITE_BUSY_TIMEOUT_MS,
@@ -11,6 +13,16 @@ import {
 } from "./openclaw-state-db-contract.js";
 import { assertSupportedStateSchemaVersion } from "./openclaw-state-db-schema-version.js";
 import { resolveOpenClawStateSqlitePath } from "./openclaw-state-db.paths.js";
+
+const artifactPreservingReads = resolveGlobalSingleton(
+  Symbol.for("openclaw.artifactPreservingStateReads"),
+  () => new AsyncLocalStorage<boolean>(),
+);
+
+/** Admission scopes every nested reader without changing normal live-read semantics. */
+export function withArtifactPreservingStateReads<T>(operation: () => T): T {
+  return artifactPreservingReads.run(true, operation);
+}
 
 type OpenClawStateReadOnlyDatabase = {
   db: DatabaseSync;
@@ -55,10 +67,8 @@ function withOpenClawStateDatabaseReadOnlyIfOpen<T>(
     return { reused: false };
   }
   try {
-    // Process-local terminal failures evict this handle. Persisted quarantine
-    // is checked on the next physical open so hot reads do not poll metadata.
-    // A newer build can migrate this file while the handle stays open, so the
-    // forward-compatibility gate still runs before any reused read.
+    // Cached reads skip persisted quarantine checks; terminal failures evict handles.
+    // Another process can migrate the file, so version admission still runs.
     assertSupportedStateSchemaVersion(opened.db, pathname);
     return { reused: true, value: operation(opened) };
   } catch (error) {
@@ -76,9 +86,11 @@ function withFreshOpenClawStateDatabaseReadOnly<T>(
   openClawStateDatabaseCache.assertOpenClawStateDatabaseFreshOpenAllowedAtPath(pathname, env);
   // Even read-only SQLite opens can create a missing WAL. The existing worker
   // snapshots committed WAL pages without touching source sidecars or caller-held locks.
-  const prepared = prepareSqliteReadOnlyLocationSync(pathname);
+  const prepared = artifactPreservingReads.getStore()
+    ? prepareSqliteReadOnlyLocationSync(pathname)
+    : undefined;
   try {
-    const db = openNodeSqliteDatabase(prepared.location, { readOnly: true });
+    const db = openNodeSqliteDatabase(prepared?.location ?? pathname, { readOnly: true });
     try {
       db.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
       assertSupportedStateSchemaVersion(db, pathname);
@@ -88,25 +100,18 @@ function withFreshOpenClawStateDatabaseReadOnly<T>(
       db.close();
     }
   } finally {
-    prepared.cleanup();
+    prepared?.cleanup();
   }
 }
 
-/**
- * Read shared state without joining the writable lifecycle.
- *
- * CLI metadata reads can overlap a live Gateway. Keep them off schema repair,
- * journal-mode setup, checkpoints, and permission mutation owned by writers.
- */
+/** Read shared state without joining writers; admission inherits artifact preservation. */
 export function withOpenClawStateDatabaseReadOnly<T>(
   operation: (database: OpenClawStateReadOnlyDatabase) => T,
   options: OpenClawStateDatabaseOptions = {},
 ): T {
   const pathname = resolveReadOnlyPath(options);
-  // Reusing a handle this process already holds keeps row loops cheap: opening
-  // and closing a connection per call made shared-state reads scale with row
-  // count. An in-flight transaction is skipped so callers never observe
-  // uncommitted rows a fresh read-only connection could not have seen.
+  // Reuse idle handles for row loops; never expose an in-flight transaction's
+  // uncommitted rows to a reader that would otherwise open a fresh connection.
   const reused = withOpenClawStateDatabaseReadOnlyIfOpen(operation, pathname);
   if (reused.reused) {
     return reused.value;
@@ -130,4 +135,11 @@ export function withExistingOpenClawStateDatabaseReadOnly<T>(
     : withFreshOpenClawStateDatabaseReadOnly(operation, options, existingPath);
 }
 
-export { withExistingOpenClawStateDatabaseReadOnly as withExistingOpenClawStateDatabaseArtifactPreservingReadOnly };
+export function withExistingOpenClawStateDatabaseArtifactPreservingReadOnly<T>(
+  operation: (database: OpenClawStateReadOnlyDatabase) => T,
+  options: OpenClawStateDatabaseOptions = {},
+): T | undefined {
+  return withArtifactPreservingStateReads(() =>
+    withExistingOpenClawStateDatabaseReadOnly(operation, options),
+  );
+}

--- a/src/state/openclaw-state-db-schema-additive.ts
+++ b/src/state/openclaw-state-db-schema-additive.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
+  ORDERED_STARTUP_ADDITIVE_STATE_COLUMNS as columns,
   CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_DEFINITIONS,
   CLAW_STARTUP_ADDITIVE_STATE_COLUMN_DEFINITIONS,
 } from "./openclaw-state-db-additive-columns.js";
@@ -409,6 +410,15 @@ export function ensureFirstUseAdditiveStateColumnsForStrictMigration(db: Databas
   }
 }
 
+function ensureColumns(
+  db: DatabaseSync,
+  definitions: readonly (readonly [string, string])[],
+): void {
+  for (const definition of definitions) {
+    ensureColumn(db, ...definition);
+  }
+}
+
 export function ensureAdditiveStateColumns(db: DatabaseSync): void {
   ensureWorkerSessionToolStateSchema(db);
   for (const {
@@ -418,19 +428,11 @@ export function ensureAdditiveStateColumns(db: DatabaseSync): void {
   } of CLAW_STARTUP_ADDITIVE_STATE_COLUMN_DEFINITIONS) {
     ensureColumn(db, tableName, `${columnName} ${dataType}`);
   }
-  if (ensureColumn(db, "claw_package_refs", "updated_at_ms INTEGER NOT NULL DEFAULT 0")) {
+  if (ensureColumn(db, ...columns.packageUpdatedAt[0])) {
     db.exec("UPDATE claw_package_refs SET updated_at_ms = installed_at_ms;");
   }
-  ensureColumn(
-    db,
-    "claw_package_refs",
-    "package_integrity TEXT NOT NULL DEFAULT 'sha256:0000000000000000000000000000000000000000000000000000000000000000'",
-  );
-  const addedDiagnosticEventSequence = ensureColumn(
-    db,
-    "diagnostic_events",
-    "sequence INTEGER NOT NULL DEFAULT 0",
-  );
+  ensureColumns(db, columns.packageIntegrity);
+  const addedDiagnosticEventSequence = ensureColumn(db, ...columns.diagnosticSequence[0]);
   if (addedDiagnosticEventSequence) {
     // Preserve the legacy (created_at, rowid) order before the new sequence
     // index becomes authoritative, including stable ties within each scope.
@@ -453,136 +455,32 @@ export function ensureAdditiveStateColumns(db: DatabaseSync): void {
     `);
   }
   db.exec("DROP INDEX IF EXISTS idx_diagnostic_events_scope_created;");
-  ensureColumn(db, "worktrees", "provisioned_paths_json TEXT");
-  ensureColumn(db, "apns_registrations", "relay_origin TEXT");
-  ensureColumn(db, "device_pairing_pending", "refreshed_at_ms INTEGER");
-  ensureColumn(db, "device_pairing_pending", "browser_origin TEXT");
-  ensureColumn(db, "device_pairing_paired", "approved_via TEXT");
-  ensureColumn(db, "device_pairing_paired", "browser_origin TEXT");
-  ensureColumn(db, "device_pairing_paired", "operator_label TEXT");
-  ensureColumn(db, "device_pairing_paired", "node_surface_json TEXT");
-  ensureColumn(db, "device_pairing_paired", "pending_node_surface_json TEXT");
-  ensureColumn(db, "cron_run_logs", "status TEXT");
-  ensureColumn(db, "cron_run_logs", "error TEXT");
-  ensureColumn(db, "cron_run_logs", "summary TEXT");
-  ensureColumn(db, "cron_run_logs", "diagnostics_summary TEXT");
-  ensureColumn(db, "cron_run_logs", "delivery_status TEXT");
-  ensureColumn(db, "cron_run_logs", "delivery_error TEXT");
-  ensureColumn(db, "cron_run_logs", "delivered INTEGER");
-  ensureColumn(db, "cron_run_logs", "session_id TEXT");
-  ensureColumn(db, "cron_run_logs", "session_key TEXT");
-  ensureColumn(db, "cron_run_logs", "run_id TEXT");
-  ensureColumn(db, "cron_run_logs", "run_at_ms INTEGER");
-  ensureColumn(db, "cron_run_logs", "duration_ms INTEGER");
-  ensureColumn(db, "cron_run_logs", "next_run_at_ms INTEGER");
-  ensureColumn(db, "cron_run_logs", "model TEXT");
-  ensureColumn(db, "cron_run_logs", "provider TEXT");
-  ensureColumn(db, "cron_run_logs", "total_tokens INTEGER");
-  ensureColumn(db, "cron_run_logs", "entry_json TEXT NOT NULL DEFAULT '{}'");
-  ensureColumn(db, "cron_run_logs", "created_at INTEGER NOT NULL DEFAULT 0");
+  ensureColumns(db, columns.cronRunLogs);
   backfillCronRunLogEntryJson(db);
-  ensureColumn(db, "acp_replay_events", "estimated_bytes INTEGER NOT NULL DEFAULT 0");
-  ensureColumn(db, "acp_replay_sessions", "estimated_bytes INTEGER NOT NULL DEFAULT 0");
+  ensureColumns(db, columns.acpReplay);
   backfillAcpReplayEstimatedBytes(db);
-  ensureColumn(db, "cron_jobs", "description TEXT");
-  ensureColumn(db, "cron_jobs", "declaration_key TEXT");
-  ensureColumn(db, "cron_jobs", "owner_agent_id TEXT");
-  ensureColumn(db, "cron_jobs", "name TEXT NOT NULL DEFAULT ''");
-  ensureColumn(db, "cron_jobs", "enabled INTEGER NOT NULL DEFAULT 1");
-  ensureColumn(db, "cron_jobs", "agent_id TEXT");
-  ensureColumn(db, "cron_jobs", "payload_kind TEXT NOT NULL DEFAULT 'message'");
-  ensureColumn(db, "cron_jobs", "state_json TEXT NOT NULL DEFAULT '{}'");
-  ensureColumn(db, "cron_jobs", "runtime_updated_at_ms INTEGER");
-  ensureColumn(db, "cron_jobs", "schedule_identity TEXT");
-  ensureColumn(db, "cron_jobs", "sort_order INTEGER NOT NULL DEFAULT 0");
+  ensureColumns(db, columns.cronJobs);
   backfillCronJobsFromJobJson(db);
-  ensureColumn(db, "sandbox_registry_entries", "session_key TEXT");
-  ensureColumn(db, "sandbox_registry_entries", "backend_id TEXT");
-  ensureColumn(db, "sandbox_registry_entries", "runtime_label TEXT");
-  ensureColumn(db, "sandbox_registry_entries", "image TEXT");
-  ensureColumn(db, "sandbox_registry_entries", "created_at_ms INTEGER");
-  ensureColumn(db, "sandbox_registry_entries", "last_used_at_ms INTEGER");
-  ensureColumn(db, "sandbox_registry_entries", "config_label_kind TEXT");
-  ensureColumn(db, "sandbox_registry_entries", "config_hash TEXT");
-  ensureColumn(db, "sandbox_registry_entries", "cdp_port INTEGER");
-  ensureColumn(db, "sandbox_registry_entries", "no_vnc_port INTEGER");
-  ensureColumn(db, "delivery_queue_entries", "entry_kind TEXT");
-  ensureColumn(db, "delivery_queue_entries", "session_key TEXT");
-  ensureColumn(db, "delivery_queue_entries", "channel TEXT");
-  ensureColumn(db, "delivery_queue_entries", "target TEXT");
-  ensureColumn(db, "delivery_queue_entries", "account_id TEXT");
-  ensureColumn(db, "delivery_queue_entries", "retry_count INTEGER NOT NULL DEFAULT 0");
-  ensureColumn(db, "delivery_queue_entries", "last_attempt_at INTEGER");
-  ensureColumn(db, "delivery_queue_entries", "last_error TEXT");
-  ensureColumn(db, "delivery_queue_entries", "recovery_state TEXT");
-  ensureColumn(db, "delivery_queue_entries", "platform_send_started_at INTEGER");
+  ensureColumns(db, columns.deliveryQueue);
   backfillDeliveryQueueEntriesFromEntryJson(db);
   // The shipped JSON runtime predeclared this table but never populated it.
   // The transitional default makes ADD COLUMN portable; schema-v2 tables are
   // rebuilt from canonical STRICT SQL immediately afterward, removing it.
-  const addedOriginalMediaRoot = ensureColumn(
-    db,
-    "managed_outgoing_image_records",
-    "original_media_root TEXT NOT NULL DEFAULT ''",
-  );
+  const addedOriginalMediaRoot = ensureColumn(db, ...columns.originalMediaRoot[0]);
   if (addedOriginalMediaRoot) {
     backfillLegacyManagedImageRoots(db);
   }
-  ensureColumn(db, "managed_outgoing_image_records", "agent_id TEXT");
-  ensureColumn(
-    db,
-    "managed_outgoing_image_records",
-    "cleanup_pending INTEGER NOT NULL DEFAULT 0 CHECK (cleanup_pending IN (0, 1))",
-  );
-  ensureColumn(
-    db,
-    "current_conversation_bindings",
-    "conversation_kind TEXT NOT NULL DEFAULT 'channel'",
-  );
-  ensureColumn(db, "device_bootstrap_tokens", "pending_profile_json TEXT");
-  ensureColumn(db, "gateway_restart_handoff", "restart_trace_started_at INTEGER");
-  ensureColumn(db, "gateway_restart_handoff", "restart_trace_last_at INTEGER");
-  ensureColumn(db, "gateway_restart_intent", "reason TEXT");
-  ensureColumn(db, "gateway_restart_sentinel", "delivery_channel TEXT");
-  ensureColumn(db, "gateway_restart_sentinel", "delivery_to TEXT");
-  ensureColumn(db, "gateway_restart_sentinel", "delivery_account_id TEXT");
-  ensureColumn(db, "gateway_restart_sentinel", "message TEXT");
-  ensureColumn(db, "gateway_restart_sentinel", "continuation_json TEXT");
-  ensureColumn(db, "gateway_restart_sentinel", "doctor_hint TEXT");
-  ensureColumn(db, "gateway_restart_sentinel", "stats_json TEXT");
-  ensureColumn(db, "gateway_boot_lifecycle", "startup_reason TEXT");
-  ensureColumn(db, "official_external_plugin_catalog_snapshots", "trust_mode TEXT");
-  ensureColumn(db, "official_external_plugin_catalog_snapshots", "trust_key_id TEXT");
-  ensureColumn(db, "official_external_plugin_catalog_snapshots", "trust_signature_count INTEGER");
-  ensureColumn(db, "official_external_plugin_catalog_snapshots", "trust_threshold INTEGER");
-  ensureColumn(db, "official_external_plugin_catalog_snapshots", "trust_verified_at TEXT");
-  const addedTaskRequesterAgentId = ensureColumn(db, "task_runs", "requester_agent_id TEXT");
+  ensureColumns(db, columns.beforeTaskAttribution);
+  const addedTaskRequesterAgentId = ensureColumn(db, ...columns.taskRequester[0]);
   if (addedTaskRequesterAgentId) {
     repairLegacyTaskAgentAttribution(db);
   }
   repairLegacyTaskDeliveryStatuses(db);
-  ensureColumn(db, "task_runs", "tool_use_count INTEGER");
-  ensureColumn(db, "task_runs", "last_tool_name TEXT");
-  ensureColumn(db, "task_runs", "detail_json TEXT");
+  ensureColumns(db, columns.taskRunDetails);
   repairLegacySubagentSuspensionReasons(db);
   repairLegacySubagentExecutionPayloads(db);
   repairLegacySubagentTaskBindings(db);
   repairLegacySubagentRetainedResults(db);
-  ensureColumn(db, "worker_environments", "bootstrap_bundle_hash TEXT");
-  ensureColumn(db, "worker_environments", "bootstrap_openclaw_version TEXT");
-  ensureColumn(db, "worker_environments", "bootstrap_protocol_features_json TEXT");
-  ensureColumn(db, "worker_environments", "bootstrap_install_kind TEXT");
-  ensureColumn(
-    db,
-    "worker_environments",
-    "owner_epoch INTEGER NOT NULL DEFAULT 0 CHECK (owner_epoch >= 0)",
-  );
-  ensureColumn(db, "worker_environments", "ssh_host_key TEXT");
-  ensureColumn(db, "worker_workspace_pending_results", "staged_result_ref TEXT");
-  ensureColumn(
-    db,
-    "worker_environments",
-    "teardown_terminal_state TEXT CHECK (teardown_terminal_state IN ('destroyed', 'failed'))",
-  );
+  ensureColumns(db, columns.workerEnvironments);
   ensureOperatorApprovalResolutionRefs(db);
 }

--- a/src/state/openclaw-state-schema-compatibility.ts
+++ b/src/state/openclaw-state-schema-compatibility.ts
@@ -4,6 +4,7 @@ import {
   type SqliteSchemaIssue,
 } from "../infra/sqlite-schema-contract.js";
 import {
+  ORDERED_STARTUP_ADDITIVE_STATE_COLUMNS,
   CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_DEFINITIONS,
   CLAW_LAZY_ADDITIVE_STATE_COLUMN_DEFINITIONS,
   CLAW_STARTUP_ADDITIVE_STATE_COLUMN_DEFINITIONS,
@@ -28,11 +29,14 @@ const CLAW_FIRST_USE_ADDITIVE_STATE_COLUMNS = CLAW_FIRST_USE_ADDITIVE_STATE_COLU
 const CLAW_FIRST_USE_ADDITIVE_STATE_COLUMN_SET = new Set<string>(
   CLAW_FIRST_USE_ADDITIVE_STATE_COLUMNS,
 );
-const CLAW_STARTUP_ADDITIVE_STATE_COLUMN_SET = new Set<string>(
-  CLAW_STARTUP_ADDITIVE_STATE_COLUMN_DEFINITIONS.map(
+const CLAW_STARTUP_ADDITIVE_STATE_COLUMN_SET = new Set<string>([
+  ...CLAW_STARTUP_ADDITIVE_STATE_COLUMN_DEFINITIONS.map(
     ({ columnName, tableName }) => `${tableName}.${columnName}`,
   ),
-);
+  ...Object.values(ORDERED_STARTUP_ADDITIVE_STATE_COLUMNS)
+    .flat()
+    .map(([tableName, definition]) => `${tableName}.${definition.split(" ", 1)[0]}`),
+]);
 const CLAW_STARTUP_ADDITIVE_STATE_TABLES = [
   "worker_session_tool_operations",
   "worker_turn_tool_authorities",


### PR DESCRIPTION
## What Problem This Solves

A Gateway upgrade could migrate databases and rewrite configuration before refusing startup, leaving the previous package unable to boot even though the upgraded Gateway never became ready.

Reported by @Rocky_Chuck: https://x.com/Rocky_Chuck/status/2096970154622267418

Related: #133984 #139105

## Why This Change Was Made

Read-only admission now runs before the persistent migration lease, then repeats under it. It checks state and agent databases, legacy sessions and workspaces, Gateway readiness, and the complete dry config-repair result before migration writes. Direct server startup admits and consumes the same full snapshot, including caller-supplied snapshots.

Automatic recovery of clobbered configuration remains available. The existing recovery owner prepares the candidate backup without writes; admission validates that candidate and the state it selects. Restoration is the first repair under the lease. Config/backup identities and live migration ownership are checked before archival and at the final rename, preserving concurrent edits and rejecting stale owners. Ordinary recovery and Doctor's separate last-known-good path retain their behavior.

Admission reads use the shared reader's existing WAL-aware snapshot worker, including the CLI's preliminary unobserved config read. Ordinary live reads retain their fast path. There is no new reader, configuration option, environment variable, dependency, or schema version.

The additive declaration refactor is **routing existing canonical identifiers to the right classifier, an implementation repair, not a database change**. It adds no column, table, index, or constraint and changes neither version metadata nor what any `ensureColumn` does. Ninety-six existing declarations retain their order and backfill boundaries; return-sensitive operations remain explicit.

## User Impact

An initial Doctor-required refusal exits 78 and preserves configuration, databases, agent stores, sidecars, and the plugin index. Supported migrations, retired-key repair, and healthy-backup restoration still run automatically. `--allow-unconfigured` and fresh `--dev` retain both parser paths. Detailed startup/restart tracing remains intact.

After an admitted migration, downgrade requires the operator's pre-update `openclaw backup`. The rollback proof below uses unchanged state from a refused boot. A concurrent change can be refused during the under-lease recheck after the lease itself has written; no restoration or migration may consume unadmitted inputs.

## Evidence

The complete shipped-package rig passed against built commit `d356beac564430c5eabb605701fed98cd4961644` (`pnpm build`, 3m51s). It uses actual npm 7.1-2/9.2 packages in scratch prefixes, built `dist/entry.js`, isolated home/npmrc/state/config/workspace, synthetic credentials, and ports 18720–18739. Every successful boot stopped normally. The real-home guard reported **0 changed files**, find exit0.

| Case | Before | Built candidate |
| --- | --- | --- |
| Legacy workspace/state blocker | Shipped9.2 exit1; schema1→15 and manifest changed | Exit78; config, manifest, user_version and schema_meta identical |
| Retired key plus blocker | Shipped9.2 rewrote/stamped config before exit1 | Exit78; config and manifest identical |
| Missing config | Shipped9.2 exit78 after DB changes | Exit78; config absence, manifest and schema identical |
| Missing/remote mode; invalid plugin without WAL | Earlier candidate created an empty WAL | Exit78; manifest/schema/WAL absence identical |
| Clobbered config + healthy backup | Earlier candidate incorrectly refused | Exact backup bytes restored, clobbered input preserved; ready/exit0 |
| Clobbered + backup-only legacy workspace | Earlier candidate missed the selected workspace | Exit78; entire manifest and clobbered bytes identical |
| No blockers / same-version additive repair | Supported existing state | Forward schema1→16 or additive repair without version bump; ready/exit0 |
| Retired key without blocker | Deprecated session key | Repaired/stamped; ready/exit0 |
| Stopped Gateway → doctor --fix → boot | Legacy inputs | Doctor0; boot ready/exit0 |
| Exact refused state → shipped7.1-2 | Untouched refusal state | Ready/exit0 |

Manifest exclusions are only coordinator `tmp/` scratch and SQLite `*-shm` WAL reader indexes. The two-line test comment records that accepted tradeoff. Main DBs, WALs including absence, agent stores, config, other sidecars, and plugin index remain covered. Config-owner preparation tests exclude no sidecars.

Boundary tests failed before the corresponding fixes: healthy-backup refusal, backup-only workspace omission, absent-WAL creation, stale config/backup identities, direct-server supplied-snapshot admission, and lost startup read-trace spans. Real SQLite lease tests additionally proved that expired/reassigned admission leases and lease loss during awaited archival could restore configuration; all three now reject before restoration. Existing exit-code/identity expectations remain intact.

Validation includes 410 config/CLI/command/Gateway cases, 33 reader cases, the final 102 recovery/migration cases, and 16 tracing/workspace/kernel cases. After the main rebase, all112 affected integration cases passed. The complete changed-file gate and the subsequent five-file lease-fix gate both exited0 without skips. Fresh autoreviews throughP2 have no accepted/actionable findings. The original/new additive migration comparison produced identical **262 SQLite operations**, resulting schemas, user_version, and complete schema_meta.

The final rig supersedes earlier runs whose Python default captured an older dist path. Correcting that harness exposed the preliminary-read WAL defect, which was regression-tested and fixed before the complete successful runs.

## Scope and Review

Candidate delta: production **+177** (990+/813−), tests **+873** (1322+/449−), plus a 1+/1− assertion-baseline tightening. Retaining default recovery accounts for the growth beyond the earlier near-zero candidate:

| Recovery/final-fix owner | Net growth | Reason |
| --- | ---: | --- |
| `io.observe-recovery.ts` | +49 | Shared prepare/apply flow and source/lease fencing; retains immediate recovery APIs and removes redundant helpers |
| `io.snapshot.ts` | +66 | Reuses the real parser/metadata pipeline with isolated environment and artifact-preserving reads |
| `io.factory.ts` / `io.types.ts` | +7 | Exposes and types the prepared operation |
| `pre-bootstrap.ts` | +12 | Guards current/prepared config before runtime environment selection |
| `doctor-config-preflight-startup.ts` | +39 | Admits prepared selectors and revalidates identity; retains controlled exits |
| `doctor-config-preflight.ts` | −5 | Applies admitted restoration under the lease and removes the earlier duplicate guard |
| `server-startup-bootstrap.ts` | +8 | Consumes the admitted snapshot and retains its detailed trace spans |

Routing#141416, UI split#141494, doctor/docs#141412 and QA fix#141555 are included. The main rebase replayed all eight commits patch-identically. Latest completed ClawSweeper review atd356beac is ready for maintainer review with no before-merge moves; its recovery-ownership finding is fixed and regression-proven. The unrelated update-command lint failure is fixed on main by#141671 (4140743e31f);#141680 was closed as superseded. This PR does not edit that file. The final rebase also replayed all eight commits patch-identically. Current head: e2bc67087ae9d1cac435cfb5772bc8a1112b559f. Native preparation remains gated on green exact-head CI.

Final-head compatibility confirmation: the original-versus-refactored additive owner was rerun on e2bc67087ae against identical main-shaped SQLite fixtures missing task_runs.tool_use_count, task_runs.last_tool_name and apns_registrations.relay_origin. Both executions produced exactly262 SQL operations and identical sqlite_schema, user_version and complete schema_meta; existing nullable declaration lists also compared equal. This fulfills the final ClawSweeper compatibility-proof move. No code changes were needed.
