### PR TITLE
refactor(skills): share catalog construction

### DIFF
--- a/src/skills/loading/skill-contract.ts
+++ b/src/skills/loading/skill-contract.ts
@@ -115,19 +115,17 @@ export function compactSkillsPromptForContext(prompt: string, contextTokenBudget
   return result.length < prompt.length ? result : prompt;
 }
 
-/**
- * Keep this formatter's XML layout byte-for-byte aligned with the upstream
- * Agent Skills formatter so we can avoid importing the full session runtime
- * package root on the cold skills path. Visibility policy is applied upstream
- * before calling this helper.
- */
-export function formatSkillsForPromptCore(skills: Skill[]): string {
+function formatSkillCatalog(
+  skills: Skill[],
+  loadingInstructions: string,
+  descriptionForSkill: (skill: Skill) => string | undefined,
+): string {
   if (skills.length === 0) {
     return "";
   }
   const lines = [
     "\n\nThe following skills provide specialized instructions for specific tasks.",
-    "Read a skill's file at its listed location when the task matches its description.",
+    loadingInstructions,
     "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
     "",
     "<available_skills>",
@@ -135,7 +133,10 @@ export function formatSkillsForPromptCore(skills: Skill[]): string {
   for (const skill of skills) {
     lines.push("  <skill>");
     lines.push(`    <name>${escapeSkillXml(skill.name)}</name>`);
-    lines.push(`    <description>${escapeSkillXml(skill.description)}</description>`);
+    const description = descriptionForSkill(skill);
+    if (description !== undefined) {
+      lines.push(`    <description>${escapeSkillXml(description)}</description>`);
+    }
     lines.push(`    <location>${escapeSkillXml(skill.filePath)}</location>`);
     if (skill.locationNote) {
       lines.push(`    <location_note>${escapeSkillXml(skill.locationNote)}</location_note>`);
@@ -144,6 +145,15 @@ export function formatSkillsForPromptCore(skills: Skill[]): string {
   }
   lines.push("</available_skills>");
   return lines.join("\n");
+}
+
+/** Render the full catalog without importing the session runtime or reapplying visibility. */
+export function formatSkillsForPromptCore(skills: Skill[]): string {
+  return formatSkillCatalog(
+    skills,
+    "Read a skill's file at its listed location when the task matches its description.",
+    (skill) => skill.description,
+  );
 }
 
 /** Compact prompt catalog with descriptions bounded independently from identities. */
@@ -158,30 +168,14 @@ export function formatSkillsCompactForPrompt(
     0,
     Math.floor(opts?.descriptionMaxChars ?? COMPACT_DESCRIPTION_MAX_CHARS),
   );
-  const lines = [
-    "\n\nThe following skills provide specialized instructions for specific tasks.",
+  return formatSkillCatalog(
+    skills,
     descriptionMaxChars > 0
       ? "Read a skill's file at its listed location when the task matches its name or description."
       : "Read a skill's file at its listed location when the task matches its name.",
-    "When a skill file references a relative path, resolve it against the skill directory (parent of SKILL.md / dirname of the path) and use that absolute path in tool commands.",
-    "",
-    "<available_skills>",
-  ];
-  for (const skill of skills) {
-    lines.push("  <skill>");
-    lines.push(`    <name>${escapeSkillXml(skill.name)}</name>`);
-    if (descriptionMaxChars > 0) {
-      const description = truncateSkillDescription(skill.description, descriptionMaxChars);
-      if (description) {
-        lines.push(`    <description>${escapeSkillXml(description)}</description>`);
-      }
-    }
-    lines.push(`    <location>${escapeSkillXml(skill.filePath)}</location>`);
-    if (skill.locationNote) {
-      lines.push(`    <location_note>${escapeSkillXml(skill.locationNote)}</location_note>`);
-    }
-    lines.push("  </skill>");
-  }
-  lines.push("</available_skills>");
-  return lines.join("\n");
+    (skill) =>
+      descriptionMaxChars > 0
+        ? truncateSkillDescription(skill.description, descriptionMaxChars) || undefined
+        : undefined,
+  );
 }

--- a/src/skills/loading/workspace-skill-loader.ts
+++ b/src/skills/loading/workspace-skill-loader.ts
@@ -149,6 +149,29 @@ function filterSkillEntries(
   return filtered;
 }
 
+function createSkillEntry(record: LoadedSkillRecord): SkillEntry {
+  const { skill, frontmatter } = record;
+  const invocation = resolveSkillInvocationPolicy(frontmatter);
+  const entry: SkillEntry = {
+    skill,
+    frontmatter,
+    metadata: resolveSkillEntryMetadata({ frontmatter, skillDir: skill.baseDir }),
+    invocation,
+    exposure: {
+      includeInRuntimeRegistry: true,
+      includeInAvailableSkillsPrompt: !invocation.disableModelInvocation,
+      userInvocable: invocation.userInvocable ?? true,
+    },
+  };
+  if (record.syncSourceDir !== undefined) {
+    entry.syncSourceDir = record.syncSourceDir;
+  }
+  if (record.syncDirName !== undefined) {
+    entry.syncDirName = record.syncDirName;
+  }
+  return entry;
+}
+
 function loadSkillEntries(
   workspaceDir: string,
   opts?: {
@@ -309,28 +332,7 @@ function loadSkillEntries(
 
   const entries = Array.from(merged.values())
     .toSorted((a, b) => a.skill.name.localeCompare(b.skill.name, "en"))
-    .map((record) => {
-      const { skill, frontmatter } = record;
-      const invocation = resolveSkillInvocationPolicy(frontmatter);
-      const entry: SkillEntry = {
-        skill,
-        frontmatter,
-        metadata: resolveSkillEntryMetadata({ frontmatter, skillDir: skill.baseDir }),
-        invocation,
-        exposure: {
-          includeInRuntimeRegistry: true,
-          includeInAvailableSkillsPrompt: !invocation.disableModelInvocation,
-          userInvocable: invocation.userInvocable ?? true,
-        },
-      };
-      if (record.syncSourceDir !== undefined) {
-        entry.syncSourceDir = record.syncSourceDir;
-      }
-      if (record.syncDirName !== undefined) {
-        entry.syncDirName = record.syncDirName;
-      }
-      return entry;
-    });
+    .map(createSkillEntry);
   skillEntryCache.set(cacheKey, entries);
   pruneMapToMaxSize(skillEntryCache, MAX_SKILL_ENTRY_CACHE_SIZE);
   return entries;
@@ -511,23 +513,8 @@ export function loadBundledSkillEntryByName(
   if (!loaded || loaded.skill.name.trim().toLowerCase() !== normalizedName) {
     return undefined;
   }
-  const invocation = resolveSkillInvocationPolicy(loaded.frontmatter);
-  const entry: SkillEntry = {
-    skill: loaded.skill,
-    frontmatter: loaded.frontmatter,
-    metadata: resolveSkillEntryMetadata({
-      frontmatter: loaded.frontmatter,
-      skillDir: loaded.skill.baseDir,
-    }),
-    invocation,
-    exposure: {
-      includeInRuntimeRegistry: true,
-      includeInAvailableSkillsPrompt: !invocation.disableModelInvocation,
-      userInvocable: invocation.userInvocable ?? true,
-    },
-  };
   return filterSkillEntries(
-    [entry],
+    [createSkillEntry(loaded)],
     opts?.config,
     resolveEffectiveWorkspaceSkillFilter(opts),
     undefined,


### PR DESCRIPTION
## What Problem This Solves

Skill catalog maintenance repeats the same entry projection in bulk discovery and direct bundled-skill lookup, and the same XML structure in full and compact prompts. Updating either copy independently can make those paths drift. This is a maintainer-requested consolidation; it does not fix a claimed user-visible regression.

## Why This Change Was Made

Use one private entry projector and one private catalog renderer inside their existing modules. Preserve full versus compact descriptions and loading guidance, skill ordering, escaping, location notes, source precedence, filtering, and optional synchronization metadata. The complete change removes 16 production code lines (19 physical lines), with no new modules or public APIs.

## User Impact

No intended behavior change. Skill discovery, direct bundled-skill lookup, prompt catalogs, and Code Mode keep their existing contracts. Full catalogs still include an empty description; compact catalogs can omit it.

## Evidence

- All 237 existing skill-loading and Code Mode tests pass before and after; no tests changed.
- 1,560 differential observations compare the exact old and new formatter source with the same real dependencies. Full/compact catalogs and downstream context compaction are byte-identical across escaping, whitespace, Unicode, empty descriptions, location notes, ordering, and budget boundaries.
- Formatter module inputs and public export names are unchanged.
- Independent P2 review is scoped-clean.
- All 28 selected check stages pass, including core/test typechecks, dead exports, lint, and runtime import cycles.
