### PR TITLE
feat(gateway): accept the configured auth secret from either connect field

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -723,6 +723,8 @@ from LAN advertisements and any configured wide-area DNS-SD zone. `off` stops
 LAN advertisements while configured wide-area discovery remains enabled. The
 Bonjour plugin must already be enabled, and environment overrides still apply.
 
+The Gateway accepts its configured secret whether the client sends it as a token or a password; `gateway.auth.mode` still decides which config value is the secret.
+
 Token and password rotation hot-applies only when the effective auth mode stays
 the same. Existing clients using the old shared credential must reconnect with
 the new credential; independently paired device-token clients remain connected.

--- a/src/gateway/auth.test.ts
+++ b/src/gateway/auth.test.ts
@@ -97,6 +97,67 @@ describe("invalid Gateway tokens", () => {
   );
 });
 
+describe.each([
+  ["HTTP", authorizeHttpGatewayConnect],
+  ["Control UI HTTP read", authorizeControlUiReadHttpGatewayConnect],
+  ["WebSocket", authorizeWsControlUiGatewayConnect],
+] as const)("%s shared-secret fields", (_surface, authorize) => {
+  it.each(["token", "password"] as const)(
+    "%s mode accepts either field but only its configured secret",
+    async (mode) => {
+      const auth = {
+        mode,
+        token: "token-secret",
+        password: "password-secret",
+        allowTailscale: false,
+      };
+      const otherField = mode === "token" ? "password" : "token";
+      const limiter = createLimiterSpy();
+      for (const field of [mode, otherField]) {
+        await expect(
+          authorize({ auth, connectAuth: { [field]: auth[mode] }, rateLimiter: limiter }),
+        ).resolves.toEqual({ ok: true, method: mode });
+        await expect(
+          authorize({ auth, connectAuth: { [field]: auth[otherField] }, rateLimiter: limiter }),
+        ).resolves.toEqual({ ok: false, reason: `${mode}_mismatch` });
+      }
+      expect(limiter.reset).toHaveBeenCalledTimes(2);
+      expect(limiter.recordFailure).toHaveBeenCalledTimes(2);
+      await expect(authorize({ auth, connectAuth: {} })).resolves.toEqual({
+        ok: false,
+        reason: `${mode}_missing`,
+      });
+    },
+  );
+
+  it.each(["token", "password"] as const)(
+    "%s mode gives its matching field precedence and preserves deferred failures",
+    async (mode) => {
+      const auth = {
+        mode,
+        token: "token-secret",
+        password: "password-secret",
+        allowTailscale: false,
+      };
+      const otherField = mode === "token" ? "password" : "token";
+      const limiter = createLimiterSpy();
+      await expect(
+        authorize({
+          auth,
+          connectAuth: { [mode]: "wrong", [otherField]: auth[mode] },
+          rateLimiter: limiter,
+          deferRateLimitFailure: true,
+        }),
+      ).resolves.toEqual({ ok: false, reason: `${mode}_mismatch` });
+      expect(limiter.recordFailure).not.toHaveBeenCalled();
+      expect(limiter.reset).not.toHaveBeenCalled();
+      await expect(
+        authorize({ auth, connectAuth: { [mode]: auth[mode], [otherField]: "wrong" } }),
+      ).resolves.toEqual({ ok: true, method: mode });
+    },
+  );
+});
+
 describe("gateway auth", () => {
   async function expectTokenMismatchWithLimiter(params: {
     reqHeaders: Record<string, string>;
@@ -425,9 +486,9 @@ describe("gateway auth", () => {
     expect(mismatch.reason).toBe("password_mismatch");
   });
 
-  it("reports missing password config reason", async () => {
+  it.each([undefined, "secret"])("reports missing password config with token %j", async (token) => {
     const res = await authorizeHttpGatewayConnect({
-      auth: { mode: "password", allowTailscale: false },
+      auth: { mode: "password", token, allowTailscale: false },
       connectAuth: { password: "secret" },
     });
     expect(res.ok).toBe(false);
@@ -1129,31 +1190,37 @@ describe("gateway auth", () => {
     expect(limiter.recordFailure).not.toHaveBeenCalled();
   });
 
-  it("still records rate-limit failure for wrong token (brute-force attempt)", async () => {
-    const limiter = createLimiterSpy();
-    const res = await authorizeHttpGatewayConnect({
-      auth: { mode: "token", token: "secret", allowTailscale: false },
-      connectAuth: { token: "wrong" },
-      rateLimiter: limiter,
-    });
+  it.each(["token", "password"])(
+    "records wrong %s in token mode against the rate limit",
+    async (field) => {
+      const limiter = createLimiterSpy();
+      const res = await authorizeHttpGatewayConnect({
+        auth: { mode: "token", token: "secret", allowTailscale: false },
+        connectAuth: { [field]: "wrong" },
+        rateLimiter: limiter,
+      });
 
-    expect(res.ok).toBe(false);
-    expect(res.reason).toBe("token_mismatch");
-    expect(limiter.recordFailure).toHaveBeenCalled();
-  });
+      expect(res.ok).toBe(false);
+      expect(res.reason).toBe("token_mismatch");
+      expect(limiter.recordFailure).toHaveBeenCalled();
+    },
+  );
 
-  it("still records rate-limit failure for wrong password (brute-force attempt)", async () => {
-    const limiter = createLimiterSpy();
-    const res = await authorizeHttpGatewayConnect({
-      auth: { mode: "password", password: "secret", allowTailscale: false },
-      connectAuth: { password: "wrong" },
-      rateLimiter: limiter,
-    });
+  it.each(["token", "password"])(
+    "records wrong %s in password mode against the rate limit",
+    async (field) => {
+      const limiter = createLimiterSpy();
+      const res = await authorizeHttpGatewayConnect({
+        auth: { mode: "password", password: "secret", allowTailscale: false },
+        connectAuth: { [field]: "wrong" },
+        rateLimiter: limiter,
+      });
 
-    expect(res.ok).toBe(false);
-    expect(res.reason).toBe("password_mismatch");
-    expect(limiter.recordFailure).toHaveBeenCalled();
-  });
+      expect(res.ok).toBe(false);
+      expect(res.reason).toBe("password_mismatch");
+      expect(limiter.recordFailure).toHaveBeenCalled();
+    },
+  );
   it("throws specific error when password is a provider reference object", () => {
     const auth = resolveGatewayAuth({
       authConfig: {

--- a/src/gateway/auth.ts
+++ b/src/gateway/auth.ts
@@ -142,6 +142,14 @@ function hasExplicitSharedSecretAuth(connectAuth?: ConnectAuth | null): boolean 
   );
 }
 
+function resolveConnectSecret(
+  mode: "token" | "password",
+  connectAuth?: ConnectAuth | null,
+): string | undefined {
+  // Either client field may carry the secret; the mode alone selects the configured value.
+  return connectAuth?.[mode] ?? connectAuth?.[mode === "token" ? "password" : "token"];
+}
+
 function headerValue(value: string | string[] | undefined): string | undefined {
   return Array.isArray(value) ? value[0] : value;
 }
@@ -558,7 +566,7 @@ async function authorizeGatewayConnectCore(
   if (auth.mode === "token") {
     return await authorizeTokenAuth({
       authToken: auth.token,
-      connectToken: connectAuth?.token,
+      connectToken: resolveConnectSecret(auth.mode, connectAuth),
       limiter,
       ip: subject,
       rateLimitScope,
@@ -570,7 +578,7 @@ async function authorizeGatewayConnectCore(
   if (auth.mode === "password") {
     return await authorizePasswordAuth({
       authPassword: auth.password,
-      connectPassword: connectAuth?.password,
+      connectPassword: resolveConnectSecret(auth.mode, connectAuth),
       limiter,
       ip: subject,
       rateLimitScope,

--- a/src/gateway/server.auth.modes.suite.ts
+++ b/src/gateway/server.auth.modes.suite.ts
@@ -60,14 +60,13 @@ export function registerAuthModesSuite(): void {
       ws.close();
     });
 
-    test("rejects token credentials in password mode", async () => {
+    test("accepts the configured password in the token field", async () => {
       const ws = await openWs(port);
       const res = await connectReq(ws, {
         skipDefaultAuth: true,
         token: "secret",
       });
-      expect(res.ok).toBe(false);
-      expect(res.error?.message ?? "").toContain("unauthorized");
+      expect(res.ok).toBe(true);
       ws.close();
     });
 
@@ -120,14 +119,13 @@ export function registerAuthModesSuite(): void {
       ws.close();
     });
 
-    test("rejects password credentials in token mode", async () => {
+    test("accepts the configured token in the password field", async () => {
       const ws = await openWs(port);
       const res = await connectReq(ws, {
         skipDefaultAuth: true,
         password: "secret", // pragma: allowlist secret
       });
-      expect(res.ok).toBe(false);
-      expect(res.error?.message ?? "").toContain("unauthorized");
+      expect(res.ok).toBe(true);
       ws.close();
     });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users supplying the correct Gateway secret through the other credential field were rejected as missing credentials. CLI users had to know whether to choose `--token` or `--password`, and the Control UI exposed that distinction despite both modes using one shared secret.

## Why This Change Was Made

The shared authorization owner now selects the mode's matching connect field first, falling back to the other field only when it is absent. The mode still chooses exactly one configured secret: a configured token cannot authorize password mode, and a configured password cannot authorize token mode. Constant-time comparison, rate limiting, deferred failure accounting, success-reset policy, and mode-specific reason codes stay intact. Trusted-proxy, Tailscale, device-token, bootstrap-token, and pairing behavior are unchanged.

## User Impact

Users can provide the configured Gateway secret through either token or password input. This unblocks a single **Gateway secret** field in the Control UI and a simpler wizard as follow-ups; this PR changes server acceptance and documents the contract.

## Evidence

Before the production fix, the added unit cases produced eight expected failures: correct cross-field credentials were reported missing, and wrong cross-field credentials returned missing instead of mismatch. After the fix:

| Command / runner | Result |
| --- | --- |
| `pnpm test src/gateway/auth.test.ts` (combined invocation) | 128 passed |
| `pnpm test src/gateway/server.auth.control-ui.test.ts` (combined invocation) | 49 passed |
| `pnpm test src/gateway/server.auth.modes.test.ts` (combined invocation) | 17 passed |
| `pnpm test src/gateway/server.auth.default-token.test.ts` (combined invocation) | 23 passed |
| `pnpm build` (one invocation) | Passed; 14m 15.6s |

The Control UI runner registers `server.auth.control-ui.pairing.suite.ts`; suite files are exercised through their runner. Total: **217 tests passed across four files**.

Autoreview verdict: **scoped-clean**, no accepted/actionable P0–P2 findings; overall: **patch is correct** (confidence 0.91).

<details>
<summary>Built CLI live proof (commands and outputs; secrets redacted)</summary>

Synthetic loopback proof; isolated homes, configs, and state. Bonjour, channels, and cron disabled. Each CLI attempt uses fresh client state and a secret-free config.

```sh
OPENCLAW_HOME=<scratch>/live/token/home OPENCLAW_STATE_DIR=<scratch>/live/token/state OPENCLAW_CONFIG_PATH=<scratch>/live/token.json node openclaw.mjs gateway --port 57810
```

```sh
OPENCLAW_HOME=<scratch>/live/client-token-correct/home OPENCLAW_STATE_DIR=<scratch>/live/client-token-correct/state OPENCLAW_CONFIG_PATH=<scratch>/live/client-token-correct/config.json node openclaw.mjs devices list --url ws://127.0.0.1:57810 --password <redacted>
```
Exit: 0
```text
No device pairing entries.
```

```sh
OPENCLAW_HOME=<scratch>/live/client-token-wrong/home OPENCLAW_STATE_DIR=<scratch>/live/client-token-wrong/state OPENCLAW_CONFIG_PATH=<scratch>/live/client-token-wrong/config.json node openclaw.mjs devices list --url ws://127.0.0.1:57810 --password wrong
```
Exit: 1
```text
gateway connect failed: GatewayClientRequestError: unauthorized: gateway token mismatch (use this gateway's gateway.auth.token or pair the device)
[openclaw] Could not start the CLI.
[openclaw] Reason: unauthorized: gateway token mismatch (use this gateway's gateway.auth.token or pair the device)
[openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
[openclaw] Try: openclaw doctor
[openclaw] Help: openclaw --help
```
token Gateway stopped.

```sh
OPENCLAW_HOME=<scratch>/live/password/home OPENCLAW_STATE_DIR=<scratch>/live/password/state OPENCLAW_CONFIG_PATH=<scratch>/live/password.json node openclaw.mjs gateway --port 57922
```

```sh
OPENCLAW_HOME=<scratch>/live/client-password-correct/home OPENCLAW_STATE_DIR=<scratch>/live/client-password-correct/state OPENCLAW_CONFIG_PATH=<scratch>/live/client-password-correct/config.json node openclaw.mjs devices list --url ws://127.0.0.1:57922 --token <redacted>
```
Exit: 0
```text
No device pairing entries.
```

```sh
OPENCLAW_HOME=<scratch>/live/client-password-wrong/home OPENCLAW_STATE_DIR=<scratch>/live/client-password-wrong/state OPENCLAW_CONFIG_PATH=<scratch>/live/client-password-wrong/config.json node openclaw.mjs devices list --url ws://127.0.0.1:57922 --token wrong
```
Exit: 1
```text
gateway connect failed: GatewayClientRequestError: unauthorized: gateway password mismatch (use this gateway's gateway.auth.password)
[openclaw] Could not start the CLI.
[openclaw] Reason: unauthorized: gateway password mismatch (use this gateway's gateway.auth.password)
[openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
[openclaw] Try: openclaw doctor
[openclaw] Help: openclaw --help
```
password Gateway stopped.
Cleanup: all task-owned Gateways stopped; synthetic configs, homes, and state deleted.

</details>

`node scripts/check-changed.mjs` completed with exit 0. Successful runs suppress the timing table unless `--timed` is set; summary of the recorded checks:

| Check group | Result |
| --- | --- |
| Formatting, changed-file lint, core and core-test typechecking | Passed |
| Dependency, plugin-boundary, and ratchet guards | Passed |
| Dead exports and runtime import cycles | Passed (zero entries/cycles) |
| Native schema, storage, media, and runtime sidecar guards | Passed |
| Webhook and pairing-store/account guards | Passed |

`git diff --check` passed. Production change: 12 changed lines including the invariant comment. No changelog edit, config/schema change, client UI change, or second PR.

Compatibility review: no configuration keys, schemas, defaults, persisted data, or migrations change. Existing clients sending the matching field retain the same precedence and behavior, including when both fields are present. The auth mode continues selecting only its existing configured secret and reporting its existing method/reasons, so secret rotation and revocation ownership do not change. Upgrades add acceptance of the alternate client field; downgrades require clients using that new capability to send the mode-matching field again. This is the explicitly requested server acceptance change, not a config-format change.

Hosted CI passed on `dbc71af8b9b94097b5eee04dbd6833b513294d22`: [run 34153023893](https://github.com/openclaw/openclaw/actions/runs/34153023893). The exact-head watcher returned `GREEN`, and the fail/pending check query returned `[]`. No CI retries were required.
