### PR TITLE
fix(clickclack): ingest message attachments

### DIFF
--- a/docs/channels/clickclack.md
+++ b/docs/channels/clickclack.md
@@ -300,7 +300,7 @@ safety bound can omit an older active thread.
 ## Reply modes
 
 - `replyMode: "agent"` (default) dispatches inbound messages through the normal agent pipeline, including session recording and tool policy.
-- `replyMode: "model"` skips the agent pipeline and uses the plugin runtime's `llm.complete` for direct bot replies, optionally shaped by `model` and `systemPrompt`. The selected provider and model own the completion budget.
+- `replyMode: "model"` skips the agent pipeline and uses the plugin runtime's `llm.complete` for direct text-only bot replies, optionally shaped by `model` and `systemPrompt`. Because that completion API has no media input, attachment messages receive a visible unsupported-media notice and never gain agent or tool authority. The selected provider and model own the completion budget.
 
 Both modes honor `responsePrefix` at the channel or account level. Account
 values win, including `""` to disable an inherited prefix. Use `"auto"` for
@@ -541,8 +541,8 @@ upload and message part, then retry attachment association with those same
 objects. See [Durable media delivery](#durable-media-delivery) for the server
 contract and recovery behavior.
 
-Inbound ClickClack attachments are downloaded with the bot token and staged in
-OpenClaw's managed media store before the agent turn starts. The configured
+Inbound ClickClack attachments in agent mode are downloaded with the bot token
+and staged in OpenClaw's managed media store before the agent turn starts. The configured
 `mediaMaxMb` limit and ClickClack's 64 MiB ceiling both apply. ClickClack servers
 that support atomic `upload_id` message creation publish `message.created` only
 after the attachment link exists, preventing consumers from seeing a transient

--- a/docs/channels/clickclack.md
+++ b/docs/channels/clickclack.md
@@ -541,6 +541,13 @@ upload and message part, then retry attachment association with those same
 objects. See [Durable media delivery](#durable-media-delivery) for the server
 contract and recovery behavior.
 
+Inbound ClickClack attachments are downloaded with the bot token and staged in
+OpenClaw's managed media store before the agent turn starts. The configured
+`mediaMaxMb` limit and ClickClack's 64 MiB ceiling both apply. ClickClack servers
+that support atomic `upload_id` message creation publish `message.created` only
+after the attachment link exists, preventing consumers from seeing a transient
+text-only message.
+
 Examples:
 
 ```bash

--- a/extensions/clickclack/src/gateway.ts
+++ b/extensions/clickclack/src/gateway.ts
@@ -126,6 +126,7 @@ async function processEvent(params: {
     config: params.config,
     message,
     access,
+    abortSignal: params.abortSignal,
     buildContext: params.buildContext,
     ...(correlationId ? { correlationId } : {}),
   });

--- a/extensions/clickclack/src/http-client.ts
+++ b/extensions/clickclack/src/http-client.ts
@@ -15,23 +15,10 @@ import type {
   ClickClackEvent,
   ClickClackMessage,
   ClickClackMessageProvenance,
+  ClickClackUpload,
   ClickClackUser,
   ClickClackWorkspace,
 } from "./types.js";
-
-type ClickClackUpload = {
-  id: string;
-  workspace_id: string;
-  owner_id: string;
-  nonce?: string;
-  filename: string;
-  content_type: string;
-  byte_size: number;
-  width: number;
-  height: number;
-  duration_ms: number;
-  created_at: string;
-};
 
 /**
  * Serializes optional provenance into the wire fields. Unknown JSON fields
@@ -72,6 +59,7 @@ const CLICKCLACK_INBOUND_JSON_LIMIT_BYTES = 16 * 1024 * 1024;
 // never upgrades, pinning the monitor reconnect loop.
 const CLICKCLACK_WEBSOCKET_HANDSHAKE_TIMEOUT_MS = 30_000;
 const CLICKCLACK_EPHEMERAL_REQUEST_TIMEOUT_MS = 15_000;
+const CLICKCLACK_UPLOAD_HEADER_TIMEOUT_MS = 30_000;
 const CLICKCLACK_MESSAGE_PAGE_LIMIT = 200;
 const CLICKCLACK_DISCUSSION_ROOT_PAGE_LIMIT = 8;
 const CLICKCLACK_DISCUSSION_THREAD_REQUEST_LIMIT = 24;
@@ -383,12 +371,10 @@ export function createClickClackClient(options: ClientOptions) {
       await request<{ root: ClickClackMessage; replies: ClickClackMessage[] }>(
         `/api/messages/${encodeURIComponent(messageId)}/thread`,
       ),
-    message: async (
-      messageId: string,
-    ): Promise<ClickClackMessage & { attachments?: Array<{ id: string }> }> => {
-      const data = await request<{
-        message: ClickClackMessage & { attachments?: Array<{ id: string }> };
-      }>(`/api/messages/${encodeURIComponent(messageId)}`);
+    message: async (messageId: string): Promise<ClickClackMessage> => {
+      const data = await request<{ message: ClickClackMessage }>(
+        `/api/messages/${encodeURIComponent(messageId)}`,
+      );
       return data.message;
     },
     findMessageByNonce: async (params: {
@@ -486,6 +472,42 @@ export function createClickClackClient(options: ClientOptions) {
         body: form,
       });
       return data.upload;
+    },
+    consumeUpload: async <T>(
+      uploadId: string,
+      consume: (response: Response) => Promise<T>,
+      signal?: AbortSignal,
+    ): Promise<T> => {
+      const controller = new AbortController();
+      const abort = () => controller.abort(signal?.reason);
+      if (signal?.aborted) {
+        abort();
+      } else {
+        signal?.addEventListener("abort", abort, { once: true });
+      }
+      const timeout = setTimeout(() => controller.abort(), CLICKCLACK_UPLOAD_HEADER_TIMEOUT_MS);
+      try {
+        const uploadHeaders = new Headers(headers);
+        uploadHeaders.set("Accept", "*/*");
+        const response = await fetcher(`${baseUrl}/api/uploads/${encodeURIComponent(uploadId)}`, {
+          headers: uploadHeaders,
+          redirect: "error",
+          signal: controller.signal,
+        });
+        clearTimeout(timeout);
+        if (!response.ok) {
+          const detail = await readResponseTextLimited(response, CLICKCLACK_ERROR_BODY_LIMIT_BYTES);
+          throw new ClickClackHttpError(
+            response.status,
+            redactToolPayloadText(detail),
+            new Headers(response.headers),
+          );
+        }
+        return await consume(response);
+      } finally {
+        clearTimeout(timeout);
+        signal?.removeEventListener("abort", abort);
+      }
     },
     findUploadByNonce: async (params: {
       workspaceId: string;

--- a/extensions/clickclack/src/inbound.media.test.ts
+++ b/extensions/clickclack/src/inbound.media.test.ts
@@ -1,10 +1,17 @@
 import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import { MediaFetchError } from "openclaw/plugin-sdk/media-runtime";
 import { buildAgentSessionKey, resolveAgentRoute } from "openclaw/plugin-sdk/routing";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { handleClickClackInbound } from "./inbound.js";
 import { setClickClackRuntime } from "./runtime.js";
 import type { ClickClackMessage, ResolvedClickClackAccount } from "./types.js";
+
+const sendClickClackTextMock = vi.hoisted(() => vi.fn());
+
+vi.mock("./outbound.js", () => ({
+  sendClickClackText: sendClickClackTextMock,
+}));
 
 function createRuntime(): PluginRuntime {
   return createPluginRuntimeMock({
@@ -42,7 +49,6 @@ function createAccount(replyMode: "agent" | "model" = "agent"): ResolvedClickCla
     token: "test-token-placeholder",
     workspace: "wsp_1",
     replyMode,
-    toolsAllow: [],
     defaultTo: "channel:general",
     allowFrom: ["*"],
     allowBots: false,
@@ -95,6 +101,7 @@ function createMessage(uploadId: string, byteSize: number): ClickClackMessage {
 
 describe("ClickClack inbound media", () => {
   afterEach(() => {
+    sendClickClackTextMock.mockReset();
     vi.unstubAllGlobals();
   });
 
@@ -138,15 +145,11 @@ describe("ClickClack inbound media", () => {
     ]);
   });
 
-  it("uses the agent pipeline for media in text-only model mode", async () => {
+  it("keeps media in text-only model mode from gaining agent or tool authority", async () => {
     const runtime = createRuntime();
     setClickClackRuntime(runtime);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(
-        async () => new Response(new Uint8Array([1]), { headers: { "Content-Type": "image/png" } }),
-      ),
-    );
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
 
     await handleClickClackInbound({
       account: createAccount("model"),
@@ -155,6 +158,68 @@ describe("ClickClack inbound media", () => {
     });
 
     expect(runtime.llm.complete).not.toHaveBeenCalled();
-    expect(runtime.channel.inbound.dispatch).toHaveBeenCalledTimes(1);
+    expect(runtime.channel.inbound.dispatch).not.toHaveBeenCalled();
+    expect(runtime.agent.runEmbeddedAgent).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(sendClickClackTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining("text-only model replies") }),
+    );
+  });
+
+  it("turns a permanent media limit failure into a visible terminal reply", async () => {
+    const runtime = createRuntime();
+    setClickClackRuntime(runtime);
+    vi.mocked(runtime.channel.media.saveResponseMedia).mockRejectedValueOnce(
+      new MediaFetchError("max_bytes", "payload exceeds maxBytes"),
+    );
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () => new Response(new Uint8Array([1]), { headers: { "Content-Type": "image/png" } }),
+      ),
+    );
+
+    await handleClickClackInbound({
+      account: createAccount(),
+      config: {},
+      message: createMessage("upl_too_large", 1),
+    });
+
+    expect(runtime.channel.inbound.dispatch).not.toHaveBeenCalled();
+    expect(sendClickClackTextMock).toHaveBeenCalledWith(
+      expect.objectContaining({ text: expect.stringContaining("media limit") }),
+    );
+  });
+
+  it("does not dispatch when shutdown wins during final media staging", async () => {
+    const runtime = createRuntime();
+    const controller = new AbortController();
+    setClickClackRuntime(runtime);
+    vi.mocked(runtime.channel.media.saveResponseMedia).mockImplementationOnce(async () => {
+      controller.abort();
+      return {
+        id: "test-media.jpg",
+        path: "/tmp/test-media.jpg",
+        size: 1,
+        contentType: "image/jpeg",
+      };
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () => new Response(new Uint8Array([1]), { headers: { "Content-Type": "image/png" } }),
+      ),
+    );
+
+    await handleClickClackInbound({
+      account: createAccount(),
+      config: {},
+      message: createMessage("upl_shutdown", 1),
+      abortSignal: controller.signal,
+    });
+
+    expect(runtime.channel.inbound.dispatch).not.toHaveBeenCalled();
+    expect(runtime.agent.runEmbeddedAgent).not.toHaveBeenCalled();
+    expect(sendClickClackTextMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/clickclack/src/inbound.media.test.ts
+++ b/extensions/clickclack/src/inbound.media.test.ts
@@ -1,0 +1,160 @@
+import { createPluginRuntimeMock } from "openclaw/plugin-sdk/channel-test-helpers";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import { buildAgentSessionKey, resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { handleClickClackInbound } from "./inbound.js";
+import { setClickClackRuntime } from "./runtime.js";
+import type { ClickClackMessage, ResolvedClickClackAccount } from "./types.js";
+
+function createRuntime(): PluginRuntime {
+  return createPluginRuntimeMock({
+    agent: {
+      runEmbeddedAgent: vi.fn().mockResolvedValue({
+        payloads: [{ text: "service bot online" }],
+        meta: {},
+      }),
+      session: {
+        getSessionEntry: vi.fn(() => ({ sessionId: "session-id", updatedAt: 1 })),
+      },
+    },
+    channel: {
+      routing: {
+        resolveAgentRoute: vi.fn(
+          (params: Parameters<PluginRuntime["channel"]["routing"]["resolveAgentRoute"]>[0]) =>
+            resolveAgentRoute(params),
+        ),
+        buildAgentSessionKey: vi.fn(
+          (params: Parameters<PluginRuntime["channel"]["routing"]["buildAgentSessionKey"]>[0]) =>
+            buildAgentSessionKey(params),
+        ),
+      },
+    },
+  } as unknown as PluginRuntime);
+}
+
+function createAccount(replyMode: "agent" | "model" = "agent"): ResolvedClickClackAccount {
+  return {
+    accountId: "default",
+    enabled: true,
+    configured: true,
+    baseUrl: "http://127.0.0.1:8080",
+    apiEndpoint: "http://127.0.0.1:8080",
+    token: "test-token-placeholder",
+    workspace: "wsp_1",
+    replyMode,
+    toolsAllow: [],
+    defaultTo: "channel:general",
+    allowFrom: ["*"],
+    allowBots: false,
+    reconnectMs: 1_500,
+    agentActivity: false,
+    nativeProgress: false,
+    commandMenu: true,
+    discussions: { enabled: false, workspace: "wsp_1", section: "Sessions" },
+    requireMention: false,
+    mentionPatterns: [],
+    groups: {},
+    config: { allowFrom: ["*"] },
+  };
+}
+
+function createMessage(uploadId: string, byteSize: number): ClickClackMessage {
+  return {
+    id: "msg_1",
+    workspace_id: "wsp_1",
+    direct_conversation_id: "dm_1",
+    author_id: "usr_owner",
+    thread_root_id: "msg_1",
+    body: "inspect this plan",
+    body_format: "markdown",
+    created_at: "2026-05-09T12:00:00.000Z",
+    author: {
+      id: "usr_owner",
+      kind: "human",
+      display_name: "Peter",
+      handle: "steipete",
+      avatar_url: "",
+      created_at: "2026-05-09T12:00:00.000Z",
+    },
+    attachments: [
+      {
+        id: uploadId,
+        workspace_id: "wsp_1",
+        owner_id: "usr_owner",
+        filename: "floor-plan.png",
+        content_type: "image/png",
+        byte_size: byteSize,
+        width: 100,
+        height: 80,
+        duration_ms: 0,
+        created_at: "2026-05-09T12:00:00.000Z",
+      },
+    ],
+  };
+}
+
+describe("ClickClack inbound media", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("stages authenticated attachments before dispatching the agent turn", async () => {
+    const runtime = createRuntime();
+    setClickClackRuntime(runtime);
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(new Uint8Array([1, 2, 3]), {
+          headers: { "Content-Type": "image/png" },
+        }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await handleClickClackInbound({
+      account: createAccount(),
+      config: {},
+      message: createMessage("upl_plan", 3),
+      correlationId: "fakeco.media_1",
+    });
+
+    const [url, init] = fetchMock.mock.calls[0] ?? [];
+    expect(url).toBe("http://127.0.0.1:8080/api/uploads/upl_plan");
+    expect(new Headers(init?.headers).get("Authorization")).toBe("Bearer test-token-placeholder");
+    expect(runtime.channel.media.saveResponseMedia).toHaveBeenCalledWith(
+      expect.any(Response),
+      expect.objectContaining({
+        sourceUrl: "http://127.0.0.1:8080/api/uploads/upl_plan",
+        filePathHint: "floor-plan.png",
+        fallbackContentType: "image/png",
+        subdir: "inbound",
+      }),
+    );
+    const dispatchTurn = vi.mocked(runtime.channel.inbound.dispatch);
+    expect(dispatchTurn.mock.calls[0]?.[0].ctxPayload.media).toEqual([
+      expect.objectContaining({
+        path: "/tmp/test-media.jpg",
+        contentType: "image/jpeg",
+        messageId: "msg_1",
+      }),
+    ]);
+  });
+
+  it("uses the agent pipeline for media in text-only model mode", async () => {
+    const runtime = createRuntime();
+    setClickClackRuntime(runtime);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () => new Response(new Uint8Array([1]), { headers: { "Content-Type": "image/png" } }),
+      ),
+    );
+
+    await handleClickClackInbound({
+      account: createAccount("model"),
+      config: {},
+      message: createMessage("upl_model_plan", 1),
+    });
+
+    expect(runtime.llm.complete).not.toHaveBeenCalled();
+    expect(runtime.channel.inbound.dispatch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/extensions/clickclack/src/inbound.model-loop.test.ts
+++ b/extensions/clickclack/src/inbound.model-loop.test.ts
@@ -59,6 +59,49 @@ function createAccount(): ResolvedClickClackAccount {
   };
 }
 
+function createBotMessage(params: {
+  id: string;
+  conversationId: string;
+  attachmentBytes?: number;
+}): ClickClackMessage {
+  return {
+    id: params.id,
+    workspace_id: "wsp_model_loop",
+    direct_conversation_id: params.conversationId,
+    author_id: "usr_model_sender",
+    thread_root_id: params.id,
+    body: "hello from the other bot",
+    body_format: "markdown",
+    created_at: "2026-05-09T12:00:00.000Z",
+    author: {
+      id: "usr_model_sender",
+      kind: "bot",
+      display_name: "Model sender",
+      handle: "model-sender",
+      avatar_url: "",
+      created_at: "2026-05-09T12:00:00.000Z",
+    },
+    ...(params.attachmentBytes === undefined
+      ? {}
+      : {
+          attachments: [
+            {
+              id: `upl_${params.id.slice(4)}`,
+              workspace_id: "wsp_model_loop",
+              owner_id: "usr_model_sender",
+              filename: "plan.png",
+              content_type: "image/png",
+              byte_size: params.attachmentBytes,
+              width: 100,
+              height: 80,
+              duration_ms: 0,
+              created_at: "2026-05-09T12:00:00.000Z",
+            },
+          ],
+        }),
+  };
+}
+
 describe("ClickClack direct-model response prefix", () => {
   beforeEach(() => {
     sendClickClackTextMock.mockClear();
@@ -170,24 +213,10 @@ describe("ClickClack direct-model bot loop protection", () => {
     const runtime = createRuntime();
     setClickClackRuntime(runtime);
     const account = createAccount();
-    const message = {
+    const message = createBotMessage({
       id: "msg_01arz3ndektsv4rrffq69g5fbx",
-      workspace_id: "wsp_model_loop",
-      direct_conversation_id: "dm_model_loop_suppression",
-      author_id: "usr_model_sender",
-      thread_root_id: "msg_01arz3ndektsv4rrffq69g5fbx",
-      body: "hello from the other bot",
-      body_format: "markdown" as const,
-      created_at: "2026-05-09T12:00:00.000Z",
-      author: {
-        id: "usr_model_sender",
-        kind: "bot" as const,
-        display_name: "Model sender",
-        handle: "model-sender",
-        avatar_url: "",
-        created_at: "2026-05-09T12:00:00.000Z",
-      },
-    } satisfies ClickClackMessage;
+      conversationId: "dm_model_loop_suppression",
+    });
 
     await handleClickClackInbound({
       account,
@@ -210,24 +239,10 @@ describe("ClickClack direct-model bot loop protection", () => {
     complete.mockRejectedValueOnce(new Error("transient model failure"));
     setClickClackRuntime(runtime);
     const account = createAccount();
-    const message = {
+    const message = createBotMessage({
       id: "msg_01arz3ndektsv4rrffq69g5fbz",
-      workspace_id: "wsp_model_loop",
-      direct_conversation_id: "dm_model_loop_retry",
-      author_id: "usr_model_sender",
-      thread_root_id: "msg_01arz3ndektsv4rrffq69g5fbz",
-      body: "retry this message",
-      body_format: "markdown" as const,
-      created_at: "2026-05-09T12:00:00.000Z",
-      author: {
-        id: "usr_model_sender",
-        kind: "bot" as const,
-        display_name: "Model sender",
-        handle: "model-sender",
-        avatar_url: "",
-        created_at: "2026-05-09T12:00:00.000Z",
-      },
-    } satisfies ClickClackMessage;
+      conversationId: "dm_model_loop_retry",
+    });
 
     await expect(
       handleClickClackInbound({ account, config: {} as CoreConfig, message }),
@@ -235,6 +250,67 @@ describe("ClickClack direct-model bot loop protection", () => {
     await handleClickClackInbound({ account, config: {} as CoreConfig, message });
 
     expect(complete).toHaveBeenCalledTimes(2);
+    expect(sendClickClackTextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("suppresses the second text-only model attachment notice", async () => {
+    const runtime = createRuntime();
+    setClickClackRuntime(runtime);
+    const account = createAccount();
+    const message = createBotMessage({
+      id: "msg_01arz3ndektsv4rrffq69g5fc1",
+      conversationId: "dm_model_media_suppression",
+      attachmentBytes: 1,
+    });
+
+    await handleClickClackInbound({ account, config: {} as CoreConfig, message });
+    await handleClickClackInbound({
+      account,
+      config: {} as CoreConfig,
+      message: { ...message, id: "msg_01arz3ndektsv4rrffq69g5fc2" },
+    });
+
+    expect(runtime.llm.complete).not.toHaveBeenCalled();
+    expect(sendClickClackTextMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("allows the same attachment notice to retry without consuming another loop slot", async () => {
+    const runtime = createRuntime();
+    setClickClackRuntime(runtime);
+    sendClickClackTextMock.mockRejectedValueOnce(new Error("transient notice failure"));
+    const account = createAccount();
+    const message = createBotMessage({
+      id: "msg_01arz3ndektsv4rrffq69g5fc3",
+      conversationId: "dm_model_media_retry",
+      attachmentBytes: 1,
+    });
+
+    await expect(
+      handleClickClackInbound({ account, config: {} as CoreConfig, message }),
+    ).rejects.toThrow("transient notice failure");
+    await handleClickClackInbound({ account, config: {} as CoreConfig, message });
+
+    expect(sendClickClackTextMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("suppresses the second permanent media-limit notice", async () => {
+    const runtime = createRuntime();
+    setClickClackRuntime(runtime);
+    const account = { ...createAccount(), replyMode: "agent" as const };
+    const message = createBotMessage({
+      id: "msg_01arz3ndektsv4rrffq69g5fc4",
+      conversationId: "dm_agent_media_limit_suppression",
+      attachmentBytes: 65 * 1024 * 1024,
+    });
+
+    await handleClickClackInbound({ account, config: {} as CoreConfig, message });
+    await handleClickClackInbound({
+      account,
+      config: {} as CoreConfig,
+      message: { ...message, id: "msg_01arz3ndektsv4rrffq69g5fc5" },
+    });
+
+    expect(runtime.channel.inbound.dispatch).not.toHaveBeenCalled();
     expect(sendClickClackTextMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/extensions/clickclack/src/inbound.ts
+++ b/extensions/clickclack/src/inbound.ts
@@ -1,7 +1,9 @@
+import { resolveChannelMediaMaxBytes } from "openclaw/plugin-sdk/account-helpers";
 import {
   buildChannelInboundEventContext,
   createChannelInboundEnvelopeBuilder,
   recordChannelBotPairLoopAndCheckSuppression,
+  toInboundMediaFacts,
 } from "openclaw/plugin-sdk/channel-inbound";
 import {
   createChannelMessageReplyPipeline,
@@ -30,6 +32,8 @@ import type {
 
 const CHANNEL_ID = "clickclack" as const;
 const CLICKCLACK_MESSAGE_ID_PATTERN = /^msg_[0-9a-hjkmnp-tv-z]{26}$/u;
+const CLICKCLACK_MAX_UPLOAD_BYTES = 64 * 1024 * 1024;
+const CLICKCLACK_UPLOAD_READ_IDLE_TIMEOUT_MS = 30_000;
 
 function hasClickClackReplyMedia(payload: {
   mediaUrl?: string;
@@ -43,6 +47,63 @@ function hasClickClackReplyMedia(payload: {
 
 function resolveClickClackAgentRunId(messageId: string): string | undefined {
   return CLICKCLACK_MESSAGE_ID_PATTERN.test(messageId) ? `${CHANNEL_ID}:${messageId}` : undefined;
+}
+
+async function stageClickClackInboundMedia(params: {
+  account: ResolvedClickClackAccount;
+  cfg: CoreConfig;
+  message: ClickClackMessage;
+  correlationId?: string;
+  abortSignal?: AbortSignal;
+}) {
+  const attachments = params.message.attachments ?? [];
+  if (attachments.length === 0) {
+    return [];
+  }
+  const runtime = getClickClackRuntime();
+  const client = createClickClackClient({
+    baseUrl: params.account.apiEndpoint,
+    token: params.account.token,
+    correlationId: params.correlationId,
+  });
+  const maxBytes = Math.min(
+    resolveChannelMediaMaxBytes({
+      cfg: params.cfg,
+      accountId: params.account.accountId,
+      resolveChannelLimitMb: () => params.account.config.mediaMaxMb,
+    }) ?? CLICKCLACK_MAX_UPLOAD_BYTES,
+    CLICKCLACK_MAX_UPLOAD_BYTES,
+  );
+  const staged: Array<{ path: string; contentType: string; messageId: string }> = [];
+  for (const attachment of attachments) {
+    if (params.abortSignal?.aborted) {
+      throw params.abortSignal.reason ?? new Error("ClickClack attachment staging aborted");
+    }
+    if (attachment.byte_size > maxBytes) {
+      throw new Error(`ClickClack attachment ${attachment.id} exceeds the configured media limit`);
+    }
+    const sourceUrl = `${params.account.apiEndpoint}/api/uploads/${encodeURIComponent(attachment.id)}`;
+    const saved = await client.consumeUpload(
+      attachment.id,
+      (response) =>
+        runtime.channel.media.saveResponseMedia(response, {
+          sourceUrl,
+          filePathHint: attachment.filename,
+          originalFilename: attachment.filename,
+          fallbackContentType: attachment.content_type,
+          maxBytes,
+          readIdleTimeoutMs: CLICKCLACK_UPLOAD_READ_IDLE_TIMEOUT_MS,
+          subdir: "inbound",
+        }),
+      params.abortSignal,
+    );
+    staged.push({
+      path: saved.path,
+      contentType: saved.contentType ?? attachment.content_type,
+      messageId: params.message.id,
+    });
+  }
+  return toInboundMediaFacts(staged);
 }
 
 async function dispatchModelReply(params: {
@@ -113,6 +174,7 @@ export async function handleClickClackInbound(params: {
   message: ClickClackMessage;
   access?: ClickClackInboundAccess;
   correlationId?: string;
+  abortSignal?: AbortSignal;
   buildContext?: typeof buildChannelInboundEventContext;
 }) {
   const runtime = getClickClackRuntime();
@@ -132,6 +194,13 @@ export async function handleClickClackInbound(params: {
     return;
   }
   const { discussionRoute, isDirect, route, target } = access.preparedRoute;
+  const media = await stageClickClackInboundMedia({
+    account: params.account,
+    cfg: params.config,
+    message,
+    correlationId: params.correlationId,
+    abortSignal: params.abortSignal,
+  });
   const progress = params.account.nativeProgress
     ? createClickClackAgentProgressPublisher({
         client: createClickClackClient({
@@ -155,7 +224,7 @@ export async function handleClickClackInbound(params: {
         },
       })
     : undefined;
-  if (params.account.replyMode === "model" && !discussionRoute) {
+  if (params.account.replyMode === "model" && !discussionRoute && media.length === 0) {
     if (access.botLoopProtection) {
       const loopResult = recordChannelBotPairLoopAndCheckSuppression(access.botLoopProtection);
       if (loopResult.suppressed) {
@@ -253,6 +322,7 @@ export async function handleClickClackInbound(params: {
       threadParentId: message.parent_message_id ? message.thread_root_id : undefined,
     },
     message: { body, bodyForAgent: message.body, rawBody: message.body, commandBody: message.body },
+    media,
     access: {
       commands: { authorized: access.commandAuthorized },
       mentions: access.mentionFacts,

--- a/extensions/clickclack/src/inbound.ts
+++ b/extensions/clickclack/src/inbound.ts
@@ -14,6 +14,7 @@ import {
  * routes resulting outbound text back to ClickClack.
  */
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
+import { MediaFetchError } from "openclaw/plugin-sdk/media-runtime";
 import { resolveClickClackInboundAccess, type ClickClackInboundAccess } from "./access.js";
 import { createClickClackActivityPublisher, type ClickClackActivityPublisher } from "./activity.js";
 import { createClickClackClient } from "./http-client.js";
@@ -34,6 +35,13 @@ const CHANNEL_ID = "clickclack" as const;
 const CLICKCLACK_MESSAGE_ID_PATTERN = /^msg_[0-9a-hjkmnp-tv-z]{26}$/u;
 const CLICKCLACK_MAX_UPLOAD_BYTES = 64 * 1024 * 1024;
 const CLICKCLACK_UPLOAD_READ_IDLE_TIMEOUT_MS = 30_000;
+
+class ClickClackPermanentMediaError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ClickClackPermanentMediaError";
+  }
+}
 
 function hasClickClackReplyMedia(payload: {
   mediaUrl?: string;
@@ -80,7 +88,9 @@ async function stageClickClackInboundMedia(params: {
       throw params.abortSignal.reason ?? new Error("ClickClack attachment staging aborted");
     }
     if (attachment.byte_size > maxBytes) {
-      throw new Error(`ClickClack attachment ${attachment.id} exceeds the configured media limit`);
+      throw new ClickClackPermanentMediaError(
+        `ClickClack attachment ${attachment.id} exceeds the configured media limit`,
+      );
     }
     const sourceUrl = `${params.account.apiEndpoint}/api/uploads/${encodeURIComponent(attachment.id)}`;
     const saved = await client.consumeUpload(
@@ -104,6 +114,32 @@ async function stageClickClackInboundMedia(params: {
     });
   }
   return toInboundMediaFacts(staged);
+}
+
+function isPermanentMediaRejection(error: unknown): boolean {
+  return (
+    error instanceof ClickClackPermanentMediaError ||
+    (error instanceof MediaFetchError && error.code === "max_bytes")
+  );
+}
+
+async function sendClickClackInboundNotice(params: {
+  account: ResolvedClickClackAccount;
+  cfg: CoreConfig;
+  message: ClickClackMessage;
+  target: string;
+  text: string;
+  correlationId?: string;
+}) {
+  await sendClickClackText({
+    cfg: params.cfg,
+    accountId: params.account.accountId,
+    to: params.target,
+    text: params.text,
+    threadId: params.message.parent_message_id ? params.message.thread_root_id : undefined,
+    replyToId: params.message.id,
+    correlationId: params.correlationId,
+  });
 }
 
 async function dispatchModelReply(params: {
@@ -194,13 +230,50 @@ export async function handleClickClackInbound(params: {
     return;
   }
   const { discussionRoute, isDirect, route, target } = access.preparedRoute;
-  const media = await stageClickClackInboundMedia({
-    account: params.account,
-    cfg: params.config,
-    message,
-    correlationId: params.correlationId,
-    abortSignal: params.abortSignal,
-  });
+  if (params.abortSignal?.aborted) {
+    return;
+  }
+  const hasAttachments = (message.attachments?.length ?? 0) > 0;
+  if (params.account.replyMode === "model" && !discussionRoute && hasAttachments) {
+    await sendClickClackInboundNotice({
+      account: params.account,
+      cfg: params.config,
+      message,
+      target,
+      text: "This ClickClack bot is configured for text-only model replies and cannot process attachments.",
+      correlationId: params.correlationId,
+    });
+    return;
+  }
+  let media: ReturnType<typeof toInboundMediaFacts>;
+  try {
+    media = await stageClickClackInboundMedia({
+      account: params.account,
+      cfg: params.config,
+      message,
+      correlationId: params.correlationId,
+      abortSignal: params.abortSignal,
+    });
+  } catch (error) {
+    if (!isPermanentMediaRejection(error)) {
+      throw error;
+    }
+    if (params.abortSignal?.aborted) {
+      return;
+    }
+    await sendClickClackInboundNotice({
+      account: params.account,
+      cfg: params.config,
+      message,
+      target,
+      text: "I could not process this attachment because it exceeds this bot's media limit.",
+      correlationId: params.correlationId,
+    });
+    return;
+  }
+  if (params.abortSignal?.aborted) {
+    return;
+  }
   const progress = params.account.nativeProgress
     ? createClickClackAgentProgressPublisher({
         client: createClickClackClient({
@@ -224,7 +297,7 @@ export async function handleClickClackInbound(params: {
         },
       })
     : undefined;
-  if (params.account.replyMode === "model" && !discussionRoute && media.length === 0) {
+  if (params.account.replyMode === "model" && !discussionRoute) {
     if (access.botLoopProtection) {
       const loopResult = recordChannelBotPairLoopAndCheckSuppression(access.botLoopProtection);
       if (loopResult.suppressed) {

--- a/extensions/clickclack/src/inbound.ts
+++ b/extensions/clickclack/src/inbound.ts
@@ -142,6 +142,28 @@ async function sendClickClackInboundNotice(params: {
   });
 }
 
+function isClickClackDirectReplySuppressed(params: {
+  access: ClickClackInboundAccess;
+  accountId: string;
+}): boolean {
+  if (!params.access.botLoopProtection) {
+    return false;
+  }
+  const loopResult = recordChannelBotPairLoopAndCheckSuppression(params.access.botLoopProtection);
+  if (!loopResult.suppressed) {
+    return false;
+  }
+  getClickClackRuntime()
+    .logging.getChildLogger({ plugin: "clickclack", feature: "bot-loop-protection" })
+    .warn(
+      `[${params.accountId}] ClickClack bot-pair loop suppressed for ${Math.max(
+        0,
+        Math.ceil((loopResult.cooldownUntilMs - Date.now()) / 1000),
+      )}s`,
+    );
+  return true;
+}
+
 async function dispatchModelReply(params: {
   account: ResolvedClickClackAccount;
   cfg: OpenClawConfig;
@@ -235,6 +257,14 @@ export async function handleClickClackInbound(params: {
   }
   const hasAttachments = (message.attachments?.length ?? 0) > 0;
   if (params.account.replyMode === "model" && !discussionRoute && hasAttachments) {
+    if (
+      isClickClackDirectReplySuppressed({
+        access,
+        accountId: params.account.accountId,
+      })
+    ) {
+      return;
+    }
     await sendClickClackInboundNotice({
       account: params.account,
       cfg: params.config,
@@ -259,6 +289,14 @@ export async function handleClickClackInbound(params: {
       throw error;
     }
     if (params.abortSignal?.aborted) {
+      return;
+    }
+    if (
+      isClickClackDirectReplySuppressed({
+        access,
+        accountId: params.account.accountId,
+      })
+    ) {
       return;
     }
     await sendClickClackInboundNotice({
@@ -298,19 +336,13 @@ export async function handleClickClackInbound(params: {
       })
     : undefined;
   if (params.account.replyMode === "model" && !discussionRoute) {
-    if (access.botLoopProtection) {
-      const loopResult = recordChannelBotPairLoopAndCheckSuppression(access.botLoopProtection);
-      if (loopResult.suppressed) {
-        runtime.logging
-          .getChildLogger({ plugin: "clickclack", feature: "bot-loop-protection" })
-          .warn(
-            `[${params.account.accountId}] ClickClack bot-pair loop suppressed for ${Math.max(
-              0,
-              Math.ceil((loopResult.cooldownUntilMs - Date.now()) / 1000),
-            )}s`,
-          );
-        return;
-      }
+    if (
+      isClickClackDirectReplySuppressed({
+        access,
+        accountId: params.account.accountId,
+      })
+    ) {
+      return;
     }
     progress?.start();
     try {

--- a/extensions/clickclack/src/types.ts
+++ b/extensions/clickclack/src/types.ts
@@ -192,6 +192,21 @@ export type ClickClackChannel = {
   created_at: string;
 };
 
+/** Upload metadata returned with ClickClack messages. */
+export type ClickClackUpload = {
+  id: string;
+  workspace_id: string;
+  owner_id: string;
+  nonce?: string;
+  filename: string;
+  content_type: string;
+  byte_size: number;
+  width: number;
+  height: number;
+  duration_ms: number;
+  created_at: string;
+};
+
 /** Message object returned by ClickClack channel, DM, and thread endpoints. */
 export type ClickClackMessage = {
   id: string;
@@ -208,6 +223,7 @@ export type ClickClackMessage = {
   created_at: string;
   kind?: "message" | "agent_commentary" | "agent_tool";
   author?: ClickClackUser;
+  attachments?: ClickClackUpload[];
   thread_state?: {
     root_message_id: string;
     reply_count: number;


### PR DESCRIPTION
## What Problem This Solves

ClickClack message events are fetched authoritatively, but the connector discarded attachment metadata. Image messages therefore reached the agent as text only, causing the bot to claim that no image was attached even though ClickClack stored it.

## Summary

- type attachment metadata returned with ClickClack messages
- download inbound uploads with the bot bearer token and reject credential-forwarding redirects
- stage responses through the managed channel media runtime with size and idle-read limits
- pass ordered media facts into agent turns
- preserve text-only `replyMode: "model"`: attachment messages receive a visible unsupported-media reply without download, LLM completion, agent dispatch, or tool authority
- turn permanent media-limit rejections into a visible terminal reply so the account cursor can advance, while transient failures remain retryable
- re-check cancellation after asynchronous staging so shutdown cannot dispatch a late turn
- apply the existing bot-pair loop budget to unsupported-media and size-limit notices while preserving same-message retries
- propagate gateway cancellation into attachment downloads

The companion ClickClack server change makes new message and attachment creation atomic: https://github.com/openclaw/clickclack/pull/239

## Evidence

Run locally from this PR head against the companion ClickClack branch and the repository QA OpenAI provider:

1. Uploaded the incident screenshot as a 215,174-byte PNG and created a channel message with `upload_id` in one request.
2. The returned `message.created` message already contained that upload.
3. The real OpenClaw gateway consumed the ClickClack event, stored a managed inbound file of exactly 215,174 bytes, and staged the same file into the agent workspace.
4. The QA provider `/debug/requests` recorded one request whose user content contained both `input_text` and `input_image`; the image was a data URL and the media fact named the staged PNG.
5. ClickClack received bot message `CLICKCLACK_MEDIA_PROOF_OK`, quoting the exact image-bearing source message.

This exercises actual ClickClack event consumption, authenticated attachment retrieval, managed-media staging, multimodal agent input, provider dispatch, and ClickClack reply delivery. All resources and credentials were synthetic and local.

### Checks

- complete ClickClack extension suite: 36 files, 412 tests passed
- bot-loop regressions cover second-notice suppression for text-only model mode and permanent media-limit rejection, plus same-message notice retry accounting
- extension production typecheck passed
- extension test typecheck passed
- extension lint passed
- focused formatting check and `git diff --check` passed
- prior focused plugin-SDK boundary check passed; the current package-boundary run compiled ClickClack successfully before the unrelated all-plugin sweep was stopped to avoid redundant work
- companion server HTTP proof verified atomic create, exact nonce replay without a duplicate event, and rollback on invalid upload

The production incident showed `message.created` arriving about 68 ms before the attachment update; the authoritative message contained no attachment at the moment the connector dispatched the turn. The server-side companion PR removes that producer race, while this PR ensures attachments present on the authoritative message are delivered to the agent.
