### PR TITLE
fix(memory): show llama.cpp diagnostics for memory status --index

### DIFF
--- a/extensions/memory-core/src/cli-status.runtime.ts
+++ b/extensions/memory-core/src/cli-status.runtime.ts
@@ -148,6 +148,8 @@ export async function runMemoryStatus(
   hostOptions?: MemoryCoreRuntimeHost,
 ) {
   setVerbose(Boolean(opts.verbose));
+  // `--index` implies `--deep`: gate the probes and the deep-only output on the same flag.
+  const deep = Boolean(opts.deep || opts.index);
   const allResults: Array<{
     agentId: string;
     status: ReturnType<MemoryManager["status"]>;
@@ -168,7 +170,6 @@ export async function runMemoryStatus(
     inspectSources: true,
     ...hostOptions,
     run: async ({ manager, agentId }) => {
-      const deep = Boolean(opts.deep || opts.index);
       let embeddingProbe: MemoryEmbeddingProbeResult | undefined;
       let indexError: string | undefined;
       const syncFn = manager.sync ? manager.sync.bind(manager) : undefined;
@@ -341,7 +342,7 @@ export async function runMemoryStatus(
         lines.push(`${label("Embeddings error")} ${warn(embeddingProbe.error)}`);
       }
     }
-    const llamaCppRuntime = opts.deep ? readLlamaCppRuntimeStatus(status) : null;
+    const llamaCppRuntime = deep ? readLlamaCppRuntimeStatus(status) : null;
     if (llamaCppRuntime) {
       const runtime = llamaCppRuntime;
       const backend = runtime.backend ?? "unknown";

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -1251,6 +1251,85 @@ describe("memory cli", () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it("prints llama.cpp diagnostics when --index implies deep", async () => {
+    const close = vi.fn(async () => {});
+    const sync = vi.fn(async () => {});
+    const probeVectorStoreAvailability = vi.fn(async () => true);
+    const probeVectorAvailability = vi.fn(async () => true);
+    const probeEmbeddingAvailability = vi.fn(async () => ({ ok: true }));
+    mockManager({
+      probeVectorStoreAvailability,
+      probeVectorAvailability,
+      probeEmbeddingAvailability,
+      sync,
+      status: () =>
+        makeMemoryStatus({
+          files: 1,
+          chunks: 1,
+          custom: {
+            llamaCppRuntime: {
+              engine: "llama.cpp",
+              state: "ready",
+              backend: "metal",
+              buildInfo: "b10357 (689e227db)",
+              model: {
+                id: "embeddinggemma-300m-qat-q8_0",
+                path: "/models/embedding.gguf",
+              },
+              capabilities: { vision: false, draft: false },
+              endpoints: {
+                health: "ready",
+                models: "ready",
+                props: "ready",
+                metrics: "ready",
+              },
+              loadError: "context shift disabled",
+            },
+          },
+        }),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status", "--index"]);
+
+    expectCliSync(sync);
+    expect(probeEmbeddingAvailability).toHaveBeenCalled();
+    expectLogged(log, "llama.cpp server: metal (b10357 (689e227db))");
+    expectLogged(log, "Server model: embeddinggemma-300m-qat-q8_0");
+    expectLogged(log, "Model path: /models/embedding.gguf");
+    expectLogged(log, "Capabilities: text only");
+    expectLogged(log, "Endpoints: health=ready models=ready props=ready metrics=ready");
+    expectLogged(log, "llama.cpp error: context shift disabled");
+    expect(close).toHaveBeenCalled();
+  });
+
+  it("omits llama.cpp diagnostics from plain status", async () => {
+    const close = vi.fn(async () => {});
+    mockManager({
+      status: () =>
+        makeMemoryStatus({
+          files: 1,
+          chunks: 1,
+          custom: {
+            llamaCppRuntime: {
+              engine: "llama.cpp",
+              state: "ready",
+              backend: "metal",
+              buildInfo: "b10357 (689e227db)",
+            },
+          },
+        }),
+      close,
+    });
+
+    const log = spyRuntimeLogs(defaultRuntime);
+    await runMemoryCli(["status"]);
+
+    expectNotLogged(log, "llama.cpp server");
+    expect(close).toHaveBeenCalled();
+  });
+
   it("prints vector store separately from embedding readiness when deep", async () => {
     const close = vi.fn(async () => {});
     const probeVectorStoreAvailability = vi.fn(async () => true);


### PR DESCRIPTION
Closes #141349

## What Problem This Solves

Fixes an issue where users running `openclaw memory status --index` would see no llama.cpp runtime diagnostics, even though `--index` is documented to imply `--deep` and the deep probes had already run.

Operators troubleshooting a local llama.cpp embedding provider had to run the command twice — once with `--index` to reindex, and again with `--deep` to actually see the server backend, model id, model path, capabilities, endpoint states, and load error.

## Why This Change Was Made

`runMemoryStatus` computed `Boolean(opts.deep || opts.index)` inside the per-agent `run` callback to decide whether to probe, but the human-readable llama.cpp block later gated on the raw `opts.deep`. The two gates disagreed, so `--index` paid for the probes and then discarded their output.

The deep flag is now computed once for the whole command and used by both, so probing and rendering agree.

Scope is deliberately narrow:

- Plain `openclaw memory status` stays unprobed and still omits the block.
- `--json` output is untouched (it already carried the structured facts).
- No change to indexing, provider readiness, storage, or routing.

## User Impact

`openclaw memory status --index` now prints the same llama.cpp diagnostics that explicit `--deep` prints — server backend and build, model id and path, capabilities, endpoint states, and any load error. One command instead of two when diagnosing a local embedding provider.

## Evidence

Two tests added in `extensions/memory-core/src/cli.test.ts`:

- `prints llama.cpp diagnostics when --index implies deep` — the regression test.
- `omits llama.cpp diagnostics from plain status` — pins the unprobed default so the fix cannot leak the block into plain status.

The regression test fails on the unfixed source and passes with the fix:

```
# with only the test applied, source unchanged
× memory cli > prints llama.cpp diagnostics when --index implies deep
AssertionError: expected 'Memory index updated (main): 1 file i…' to contain 'llama.cpp server: metal (b10357 (689e…'
  Tests  1 failed | 1 passed | 119 skipped (121)
```

Full file green with the fix, plus typecheck, lint, and format:

```
$ pnpm vitest run extensions/memory-core/src/cli.test.ts
  Test Files  1 passed (1)
       Tests  121 passed (121)

$ node scripts/run-tsgo.mjs -p tsconfig.extensions.json            # exit 0
$ node scripts/run-tsgo.mjs -p test/tsconfig/tsconfig.extensions.test.json  # exit 0
$ pnpm oxlint  <changed files>                                     # clean
$ pnpm oxfmt --check <changed files>                               # clean
$ node scripts/check-changed.mjs                                   # exit 0
```