### PR TITLE
perf(shared): reuse edit-distance row storage

### DIFF
--- a/src/shared/levenshtein-distance.ts
+++ b/src/shared/levenshtein-distance.ts
@@ -21,36 +21,36 @@ export function levenshteinDistance(
     return null;
   }
 
-  let previous = new Uint32Array(right.length + 1);
-  let current = new Uint32Array(right.length + 1);
+  const row = new Uint32Array(right.length + 1);
   for (let index = 0; index <= right.length; index += 1) {
-    previous[index] = index;
+    row[index] = index;
   }
   for (let leftIndex = 0; leftIndex < left.length; leftIndex += 1) {
-    current[0] = leftIndex + 1;
+    let diagonal = leftIndex;
+    row[0] = leftIndex + 1;
     const leftCode = left.charCodeAt(leftIndex);
     for (let rightIndex = 0; rightIndex < right.length; rightIndex += 1) {
       const cost = leftCode === right.charCodeAt(rightIndex) ? 0 : 1;
-      current[rightIndex + 1] = Math.min(
-        expectDefined(current[rightIndex], "current entry at right index") + 1,
-        expectDefined(previous[rightIndex + 1], "previous entry at right index + 1") + 1,
-        expectDefined(previous[rightIndex], "previous entry at right index") + cost,
+      // The saved old cell becomes the next column's diagonal after this overwrite.
+      const above = expectDefined(row[rightIndex + 1], "previous entry at right index + 1");
+      row[rightIndex + 1] = Math.min(
+        expectDefined(row[rightIndex], "current entry at right index") + 1,
+        above + 1,
+        diagonal + cost,
       );
+      diagonal = above;
     }
     // Keep cutoff work outside the inner loop used by full-distance callers.
     if (maxDistance !== undefined) {
       let rowMin = Number.POSITIVE_INFINITY;
-      for (const distance of current) {
+      for (const distance of row) {
         rowMin = Math.min(rowMin, distance);
       }
       if (rowMin > maxDistance) {
         return null;
       }
     }
-    const nextPrevious = current;
-    current = previous;
-    previous = nextPrevious;
   }
-  const distance = expectDefined(previous[right.length], "previous entry at right.length");
+  const distance = expectDefined(row[right.length], "previous entry at right.length");
   return maxDistance !== undefined && distance > maxDistance ? null : distance;
 }


### PR DESCRIPTION
## What Problem This Solves

Suggestions for mistyped commands repeatedly calculate edit distances across the available command names. Larger command lists increase the work before suggestions can be returned; the shared calculation also serves model selection and other fuzzy-match callers.

## Why This Change Was Made

Reuse one dynamic-programming row instead of allocating and alternating two rows. Saving the old cell before overwriting it preserves the next diagonal, so the existing UTF-16 distance, empty-input conventions, length cutoff and completed-row cutoff remain unchanged. This removes one typed-array allocation from each non-short-circuited calculation without changing suggestion ordering or selection policy.

The production change is net zero lines (13 added, 13 removed). Existing tests are unchanged; no new dependency, cache, API, configuration or persistence behavior is introduced.

## User Impact

Suggestions remain identical. A fixed source-caller cohort showed lower batch medians for 64-command lists (12.84% / 17.76%) and 256-command lists (18.56% / 23.51%) in forward/reverse order. Results for smaller controls and model selection are mixed, so this is a bounded allocation cleanup with a demonstrated larger-list benefit, not a general latency improvement.

## Evidence

The same 17 existing distance tests passed on baseline and candidate. All 96 sibling cases passed across activation-name, model-selection, edit-diff and read-tool files. The normal changed-file gate passed all 28 checks in 283.826 seconds. Formatting passed in 86 ms after an earlier pre-target disk-space refusal; that refusal is retained separately. Scoped code review was clean (0.99 confidence).

A single fixed cohort completed verification baseline/candidate, decoded parity, B0/C0/C1/B1, and offline reduction. All 6,496 complete returned values matched literal expectations and cross-phase values, including 32 untimed verification calls. It retained 6,464 clocked caller invocations and 768 eight-call means. All eight native phases closed successfully and the candidate source was restored; the root terminal joined successfully. An independent saved-data audit verified every full return, clock, reduction, input/dependency pin and resource record. It also confirmed all 15 observed PIDs and eight process groups absent after restoration.

Each interval wraps the actual exported CLI-suggestion or model-directive caller, including its fixture invocation closure. Imports, fixture/policy preparation, output capture and assertions are outside those intervals. Each batch mean sums eight individual clocks with evidence work between calls. First-call measurements start after setup and are not cold-start measurements. The source caller exercise does not claim an end-to-end CLI process, live Gateway/provider or recognition improvement.

<details>
<summary>All 32 paired batch medians, including 14 regressions</summary>

Lower is better; positive changes are regressions. Forward compares B0 → C0; reverse compares B1 → C1. The fixed 128-/256-entry cases are stress fixtures.

| Caller case | Forward median, ns (B → C) | Forward change | Reverse median, ns (B → C) | Reverse change |
|---|---:|---:|---:|---:|
| CLI blank input | 218.6875 → 234.3750 | +15.6875 ns (+7.173%) | 239.4375 → 239.6250 | +0.1875 ns (+0.078%) |
| CLI no candidates | 380.0625 → 390.5625 | +10.5000 ns (+2.763%) | 460.9375 → 380.1875 | -80.7500 ns (-17.519%) |
| CLI exact match | 638.0000 → 692.8125 | +54.8125 ns (+8.591%) | 656.1875 → 716.1875 | +60.0000 ns (+9.144%) |
| CLI explicit alias | 1,869.7500 → 2,286.5000 | +416.7500 ns (+22.289%) | 2,135.3750 → 1,830.6875 | -304.6875 ns (-14.269%) |
| CLI lexical tie | 4,843.8750 → 4,143.3125 | -700.5625 ns (-14.463%) | 4,455.7500 → 4,385.4375 | -70.3125 ns (-1.578%) |
| CLI small list | 2,815.0625 → 2,794.2500 | -20.8125 ns (-0.739%) | 2,870.0000 → 2,783.8750 | -86.1250 ns (-3.001%) |
| CLI 64 commands | 36,976.5625 → 32,229.1875 | -4,747.3750 ns (-12.839%) | 38,710.6875 → 31,836.0625 | -6,874.6250 ns (-17.759%) |
| CLI 256 commands | 118,935.1875 → 96,859.5000 | -22,075.6875 ns (-18.561%) | 118,682.2500 → 90,776.0000 | -27,906.2500 ns (-23.513%) |
| CLI astral text | 1,960.9375 → 1,841.1875 | -119.7500 ns (-6.107%) | 1,869.6875 → 1,893.3125 | +23.6250 ns (+1.264%) |
| CLI subcommand | 2,065.1875 → 2,044.3750 | -20.8125 ns (-1.008%) | 2,208.4375 → 2,273.3750 | +64.9375 ns (+2.940%) |
| Model exact / 32 | 538,461.0000 → 536,257.8125 | -2,203.1875 ns (-0.409%) | 588,054.8125 → 582,859.3125 | -5,195.5000 ns (-0.884%) |
| Model fuzzy / 1 | 469,531.1250 → 501,372.4375 | +31,841.3125 ns (+6.782%) | 498,533.9375 → 498,856.8750 | +322.9375 ns (+0.065%) |
| Model fuzzy / 32 | 518,289.1250 → 513,408.8750 | -4,880.2500 ns (-0.942%) | 516,208.3750 → 523,599.0000 | +7,390.6250 ns (+1.432%) |
| Model fuzzy / 128 | 630,265.5625 → 661,895.7500 | +31,630.1875 ns (+5.019%) | 653,955.8750 → 645,075.3750 | -8,880.5000 ns (-1.358%) |
| Provider-qualified fuzzy / 32 | 509,942.5625 → 525,210.7500 | +15,268.1875 ns (+2.994%) | 498,765.6250 → 514,580.7500 | +15,815.1250 ns (+3.171%) |
| Model denied / 32 | 515,028.6250 → 494,770.8750 | -20,257.7500 ns (-3.933%) | 508,101.7500 → 495,177.0625 | -12,924.6875 ns (-2.544%) |

</details>

Across all labelled aggregates, 84/224 comparisons regressed: first call 14/32; warm median 11/32, warm mean 11/32, warm maximum 11/32; batch median 14/32, batch mean 13/32, batch maximum 10/32. Indexed comparisons retained 1,449/3,616 adverse observations: 1,285/3,232 individual-call pairs and 164/384 batch-mean pairs. All outcomes, including blank/exact/alias controls and worse model rows, remain in the dataset. There was no numeric threshold, pooled speedup or favorable rerun.

<details>
<summary>All ten whole-host resource comparisons</summary>

| Whole-host metric | Forward B → C | Change | Reverse B → C | Change |
|---|---:|---:|---:|---:|
| Wall | 14.480937 → 14.391314 s | -0.619% | 14.454907 → 14.439182 s | -0.109% |
| User CPU | 16.745057 → 16.610947 s | -0.801% | 16.728771 → 16.711255 s | -0.105% |
| System CPU | 2.547384 → 2.514862 s | -1.277% | 2.538859 → 2.523324 s | -0.612% |
| Kernel child peak RSS | 1,150,107,648 → 969,752,576 B | -15.682% | 1,128,333,312 → 1,008,451,584 B | -10.625% |
| Sampled process-tree peak RSS | 1,167,327,232 → 998,129,664 B | -14.494% | 1,148,256,256 → 1,033,732,096 B | -9.974% |

All ten comparisons improved in this cohort, but whole-host resources include startup, imports, fixture setup, caller execution and evidence capture. In particular, the roughly 14-second wall durations are whole-child durations, not isolated import measurements. These observations do not establish that removing one typed array caused the RSS changes or a general memory improvement.

</details>

The original pre-admission wording that assumed an additional bounded outer wrapper was corrected before execution and retained unchanged in the preservation directory. Actual enforcement uses the existing native child owner and parent deadline/acceptance checks; no independent execution-session timeout is claimed. Source and corpus were unchanged by that correction. Full journals, V8 graphs, all adverse comparisons, native receipts and the original disk refusal are retained locally; no raw dataset is uploaded by this draft.
