### PR TITLE
fix(memory): show llama.cpp diagnostics with status --index

### DIFF
--- a/docs/cli/memory.md
+++ b/docs/cli/memory.md
@@ -52,6 +52,9 @@ configured, falls back to the default agent.
 | `--json`    | Print JSON.                                                                                                                                                                                                                                                                      |
 | `--verbose` | Emit detailed per-phase logs.                                                                                                                                                                                                                                                    |
 
+With local llama.cpp embeddings, `--deep` and `--index` also show available
+server, model, capability, and endpoint diagnostics.
+
 If the `Dreaming` line stays `off` even with `dreaming.enabled: true`, or
 scheduled sweeps never seem to run, the managed dreaming cron depends on the
 default agent's heartbeat firing to trigger reconciliation. See

--- a/extensions/memory-core/src/cli-status.runtime.ts
+++ b/extensions/memory-core/src/cli-status.runtime.ts
@@ -148,6 +148,7 @@ export async function runMemoryStatus(
   hostOptions?: MemoryCoreRuntimeHost,
 ) {
   setVerbose(Boolean(opts.verbose));
+  const deep = Boolean(opts.deep || opts.index);
   const allResults: Array<{
     agentId: string;
     status: ReturnType<MemoryManager["status"]>;
@@ -168,7 +169,6 @@ export async function runMemoryStatus(
     inspectSources: true,
     ...hostOptions,
     run: async ({ manager, agentId }) => {
-      const deep = Boolean(opts.deep || opts.index);
       let embeddingProbe: MemoryEmbeddingProbeResult | undefined;
       let indexError: string | undefined;
       const syncFn = manager.sync ? manager.sync.bind(manager) : undefined;
@@ -341,7 +341,7 @@ export async function runMemoryStatus(
         lines.push(`${label("Embeddings error")} ${warn(embeddingProbe.error)}`);
       }
     }
-    const llamaCppRuntime = opts.deep ? readLlamaCppRuntimeStatus(status) : null;
+    const llamaCppRuntime = deep ? readLlamaCppRuntimeStatus(status) : null;
     if (llamaCppRuntime) {
       const runtime = llamaCppRuntime;
       const backend = runtime.backend ?? "unknown";

--- a/extensions/memory-core/src/cli.test.ts
+++ b/extensions/memory-core/src/cli.test.ts
@@ -963,7 +963,7 @@ describe("memory cli", () => {
     expect(probeEmbeddingAvailability).not.toHaveBeenCalled();
     expectLogged(log, "Provider: auto");
     expectLogged(log, "Vector store: unknown");
-    expectNotLogged(log, "llama.cpp:");
+    expectNotLogged(log, "llama.cpp server:");
     expect(close).toHaveBeenCalled();
   });
 
@@ -1200,12 +1200,14 @@ describe("memory cli", () => {
     expect(close).toHaveBeenCalled();
   });
 
-  it("prints embeddings status when deep", async () => {
+  it.each(["--deep", "--index"])("prints local runtime details with %s", async (flag) => {
     const close = vi.fn(async () => {});
+    const sync = vi.fn(async () => {});
     const probeVectorStoreAvailability = vi.fn(async () => true);
     const probeVectorAvailability = vi.fn(async () => true);
     const probeEmbeddingAvailability = vi.fn(async () => ({ ok: true }));
     mockManager({
+      sync,
       probeVectorStoreAvailability,
       probeVectorAvailability,
       probeEmbeddingAvailability,
@@ -1237,7 +1239,9 @@ describe("memory cli", () => {
     });
 
     const log = spyRuntimeLogs(defaultRuntime);
-    await runMemoryCli(["status", "--deep"]);
+    await runMemoryCli(["status", flag]);
+
+    expect(sync).toHaveBeenCalledTimes(flag === "--index" ? 1 : 0);
 
     expect(probeVectorStoreAvailability).toHaveBeenCalled();
     expect(probeVectorAvailability).toHaveBeenCalled();


### PR DESCRIPTION
Closes #141349

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators running `openclaw memory status --index` with local llama.cpp embeddings would miss available server, model, capability, and endpoint diagnostics, even though `--index` is documented to imply `--deep` and already runs those probes.

## Why This Change Was Made

The memory status owner now reuses its existing effective deep flag for both probing and rendering. This removes the separate raw-option decision that hid the collected details. Production changes are net zero lines; the existing CLI regression covers both options, and the memory CLI documentation describes their diagnostic output.

## User Impact

Reindexing now shows the same available llama.cpp runtime details as explicit `--deep`. Plain status keeps its unprobed output, and JSON retains its existing structure.

## Evidence

- The tests-only baseline produced the intended missing-diagnostics failure for `--index`, with explicit `--deep`, plain status, and index synchronization controls passing. The complete owning CLI suite passes all 120 tests on the candidate.
- Both normal builds, the full changed-file gate, and an independent P0–P2 review passed on the original patch. Local builds and normal CLI evidence bind baseline `43bc88f6` and candidate `684f4bd5`; they are not executions of the later rebased build.
- Real normal CLI runs against an isolated loopback fixture reproduced the omission and displayed the fix. The fixture supplies synthetic embeddings and runtime diagnostics; this does not claim real-model quality or llama-server binary compatibility.
- The complete normal CLI matrix passed all eight commands (`--index`, `--deep`, plain status, and `--index --json` on each build), with actual CLI process attribution and eighteen source/build/dependency integrity checks. Plain status made no fixture requests; indexing embedded the exact synthetic document. JSON differed only in the checkout-specific path to an identical native library. All 2,615 recorded process identities and the fixture listener were absent after clean, unsignalled shutdown.
- The inspected native before/after screenshots below were captured separately on the exact same compared application builds. Runtime matrix and screenshot provenance are recorded as separate proof components.

The branch was rebased to `1e71b951` after #141466 repaired the unrelated main-branch Markdown lint failure. The complete memory patch and all three changed files remain byte-identical. Fresh required CI passed on this head (78 successful jobs), and refreshed independent review found no actionable findings: [run 34156488387](https://github.com/openclaw/openclaw/actions/runs/34156488387).

First introduction remains unverified; current source, the failing regression, and the normal CLI reproduction establish the defect.

![Before: successful indexing omits available llama.cpp diagnostics](https://github.com/user-attachments/assets/18ceb026-5c07-484d-a87a-abfed58e7cad)

![After: indexing displays the collected llama.cpp diagnostics](https://github.com/user-attachments/assets/d0daf8a1-e124-4e6b-8f77-ad262aed287c)
