### PR TITLE
refactor(feishu): use the attachment saving owner directly

### DIFF
--- a/extensions/feishu/src/bot-content.ts
+++ b/extensions/feishu/src/bot-content.ts
@@ -7,7 +7,6 @@ import { saveMessageResourceFeishu } from "./media.js";
 import { isFeishuBroadcastMention } from "./mention.js";
 import { formatFeishuMediaContent } from "./message-content.js";
 import { parsePostContent } from "./post.js";
-import { getFeishuRuntime } from "./runtime.js";
 import type { FeishuChatType, FeishuMediaInfo } from "./types.js";
 
 type FeishuMention = {
@@ -259,28 +258,6 @@ function toMessageResourceType(messageType: string): "image" | "file" {
   return messageType === "image" ? "image" : "file";
 }
 
-async function resolveSavedFeishuMedia(params: {
-  result:
-    | Awaited<ReturnType<typeof saveMessageResourceFeishu>>
-    | { buffer: Buffer; contentType?: string; fileName?: string };
-  maxBytes: number;
-  originalFilename?: string;
-}) {
-  if ("saved" in params.result) {
-    return params.result.saved;
-  }
-  const core = getFeishuRuntime();
-  const contentType =
-    params.result.contentType ?? (await core.media.detectMime({ buffer: params.result.buffer }));
-  return await core.channel.media.saveMediaBuffer(
-    params.result.buffer,
-    contentType,
-    "inbound",
-    params.maxBytes,
-    params.result.fileName ?? params.originalFilename,
-  );
-}
-
 function resolveFeishuMediaKind(messageType: string): FeishuMediaInfo["kind"] {
   switch (messageType) {
     case "image":
@@ -330,17 +307,12 @@ export async function resolveFeishuMediaList(params: {
       const fileName = attachment.kind === "file" ? attachment.fileName : undefined;
       const mediaKind = attachment.kind === "image" ? "image" : "video";
       try {
-        const result = await saveMessageResourceFeishu({
+        const { saved } = await saveMessageResourceFeishu({
           cfg,
           messageId,
           fileKey: attachment.key,
           type: attachment.kind,
           accountId,
-          maxBytes,
-          ...(fileName ? { originalFilename: fileName } : {}),
-        });
-        const saved = await resolveSavedFeishuMedia({
-          result,
           maxBytes,
           ...(fileName ? { originalFilename: fileName } : {}),
         });
@@ -372,17 +344,12 @@ export async function resolveFeishuMediaList(params: {
     if (!fileKey) {
       return [{ kind: resolveFeishuMediaKind(messageType) }];
     }
-    const result = await saveMessageResourceFeishu({
+    const { saved } = await saveMessageResourceFeishu({
       cfg,
       messageId,
       fileKey,
       type: toMessageResourceType(messageType),
       accountId,
-      maxBytes,
-      originalFilename: mediaKeys.fileName,
-    });
-    const saved = await resolveSavedFeishuMedia({
-      result,
       maxBytes,
       originalFilename: mediaKeys.fileName,
     });

--- a/extensions/feishu/src/bot.test.ts
+++ b/extensions/feishu/src/bot.test.ts
@@ -347,9 +347,12 @@ const {
   mockGetMessageFeishu: vi.fn().mockResolvedValue(null),
   mockListFeishuThreadMessages: vi.fn().mockResolvedValue([]),
   mockDownloadMessageResourceFeishu: vi.fn().mockResolvedValue({
-    buffer: Buffer.from("video"),
-    contentType: "video/mp4",
-    fileName: "clip.mp4",
+    saved: {
+      id: "inbound-clip.mp4",
+      path: "/tmp/inbound-clip.mp4",
+      size: Buffer.byteLength("video"),
+      contentType: "video/mp4",
+    },
   }),
   mockCreateFeishuClient: vi.fn(),
   mockResolveAgentRoute: vi.fn((_params?: unknown) => createFeishuTestRoute()),
@@ -1062,13 +1065,6 @@ describe("handleFeishuMessage command authorization", () => {
   const mockUpsertPairingRequest = vi.fn().mockResolvedValue({ code: "ABCDEFGH", created: false });
   const mockBuildPairingReply = vi.fn(() => "Pairing response");
   const mockEnqueueSystemEvent = vi.fn();
-  const mockSaveMediaBuffer = vi.fn().mockResolvedValue({
-    id: "inbound-clip.mp4",
-    path: "/tmp/inbound-clip.mp4",
-    size: Buffer.byteLength("video"),
-    contentType: "video/mp4",
-  });
-
   beforeEach(() => {
     vi.clearAllMocks();
     mockDispatchReplyFromConfig.mockReset().mockResolvedValue({
@@ -1132,12 +1128,6 @@ describe("handleFeishuMessage command authorization", () => {
             upsertPairingRequest: mockUpsertPairingRequest,
             buildPairingReply: mockBuildPairingReply,
           },
-          media: {
-            saveMediaBuffer: mockSaveMediaBuffer,
-          },
-        },
-        media: {
-          detectMime: vi.fn(async () => "application/octet-stream"),
         },
       }),
     );
@@ -2338,15 +2328,12 @@ describe("handleFeishuMessage command authorization", () => {
   it("transcribes inbound audio before building the agent turn", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockDownloadMessageResourceFeishu.mockResolvedValueOnce({
-      buffer: Buffer.from("voice"),
-      contentType: "audio/ogg",
-      fileName: "voice.ogg",
-    });
-    mockSaveMediaBuffer.mockResolvedValueOnce({
-      id: "inbound-voice.ogg",
-      path: "/tmp/inbound-voice.ogg",
-      size: Buffer.byteLength("voice"),
-      contentType: "audio/ogg",
+      saved: {
+        id: "inbound-voice.ogg",
+        path: "/tmp/inbound-voice.ogg",
+        size: Buffer.byteLength("voice"),
+        contentType: "audio/ogg",
+      },
     });
     mockTranscribeFirstAudio.mockResolvedValueOnce("voice transcript");
 
@@ -2409,7 +2396,6 @@ describe("handleFeishuMessage command authorization", () => {
       fileKey: "file_video_payload",
       imageKey: "img_thumb_payload",
       fileName: "clip.mp4",
-      savedFileName: "clip.mp4",
     },
     {
       name: "uses media message_type file_key (not thumbnail image_key) for inbound mobile video download",
@@ -2418,9 +2404,8 @@ describe("handleFeishuMessage command authorization", () => {
       fileKey: "file_media_payload",
       imageKey: "img_media_thumb",
       fileName: "mobile.mp4",
-      savedFileName: "clip.mp4",
     },
-  ])("$name", async ({ messageId, messageType, fileKey, imageKey, fileName, savedFileName }) => {
+  ])("$name", async ({ messageId, messageType, fileKey, imageKey, fileName }) => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     await dispatchMessage({
       cfg: createFeishuTestConfig({ dmPolicy: "open" }),
@@ -2440,20 +2425,27 @@ describe("handleFeishuMessage command authorization", () => {
     expect(downloadRequest.messageId).toBe(messageId);
     expect(downloadRequest.fileKey).toBe(fileKey);
     expect(downloadRequest.type).toBe("file");
-    const mediaBuffer = mockCallArg<Buffer>(mockSaveMediaBuffer, 0, 0);
-    expect(Buffer.isBuffer(mediaBuffer)).toBe(true);
-    expect(mediaBuffer.toString()).toBe("video");
-    expect(mockCallArg(mockSaveMediaBuffer, 0, 1)).toBe("video/mp4");
-    expect(mockCallArg(mockSaveMediaBuffer, 0, 2)).toBe("inbound");
-    expect(typeof mockCallArg(mockSaveMediaBuffer, 0, 3)).toBe("number");
-    expect(mockCallArg(mockSaveMediaBuffer, 0, 4)).toBe(savedFileName);
+    expect(downloadRequest).toMatchObject({
+      originalFilename: fileName,
+      maxBytes: expect.any(Number),
+    });
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        MediaPaths: ["/tmp/inbound-clip.mp4"],
+        MediaTypes: ["video/mp4"],
+      }),
+    );
   });
 
-  it("falls back to the message payload filename when download metadata omits it", async () => {
+  it("forwards the message payload filename to the resource-saving owner", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockDownloadMessageResourceFeishu.mockResolvedValueOnce({
-      buffer: Buffer.from("video"),
-      contentType: "video/mp4",
+      saved: {
+        id: "payload-name.mp4",
+        path: "/tmp/payload-name.mp4",
+        size: Buffer.byteLength("video"),
+        contentType: "video/mp4",
+      },
     });
 
     const cfg = createFeishuTestConfig({ dmPolicy: "open" });
@@ -2470,13 +2462,15 @@ describe("handleFeishuMessage command authorization", () => {
 
     await dispatchMessage({ cfg, event });
 
-    const mediaBuffer = mockCallArg<Buffer>(mockSaveMediaBuffer, 0, 0);
-    expect(Buffer.isBuffer(mediaBuffer)).toBe(true);
-    expect(mediaBuffer.toString()).toBe("video");
-    expect(mockCallArg(mockSaveMediaBuffer, 0, 1)).toBe("video/mp4");
-    expect(mockCallArg(mockSaveMediaBuffer, 0, 2)).toBe("inbound");
-    expect(typeof mockCallArg(mockSaveMediaBuffer, 0, 3)).toBe("number");
-    expect(mockCallArg(mockSaveMediaBuffer, 0, 4)).toBe("payload-name.mp4");
+    expect(mockDownloadMessageResourceFeishu).toHaveBeenCalledWith(
+      expect.objectContaining({ originalFilename: "payload-name.mp4" }),
+    );
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        MediaPaths: ["/tmp/payload-name.mp4"],
+        MediaTypes: ["video/mp4"],
+      }),
+    );
   });
 
   it("downloads embedded media tags from post messages as files", async () => {
@@ -2505,35 +2499,28 @@ describe("handleFeishuMessage command authorization", () => {
     expect(downloadRequest.messageId).toBe("msg-post-media");
     expect(downloadRequest.fileKey).toBe("file_post_media_payload");
     expect(downloadRequest.type).toBe("file");
-    const postMediaBuffer = mockCallArg<Buffer>(mockSaveMediaBuffer, 0, 0);
-    expect(Buffer.isBuffer(postMediaBuffer)).toBe(true);
-    expect(postMediaBuffer.toString()).toBe("video");
-    expect(mockCallArg(mockSaveMediaBuffer, 0, 1)).toBe("video/mp4");
-    expect(mockCallArg(mockSaveMediaBuffer, 0, 2)).toBe("inbound");
-    expect(typeof mockCallArg(mockSaveMediaBuffer, 0, 3)).toBe("number");
+    expect(downloadRequest).toMatchObject({
+      originalFilename: "embedded.mov",
+      maxBytes: expect.any(Number),
+    });
+    expect(mockFinalizeInboundContext).toHaveBeenCalledWith(
+      expect.objectContaining({
+        MediaPaths: ["/tmp/inbound-clip.mp4"],
+        MediaTypes: ["video/mp4"],
+      }),
+    );
   });
 
   it("delivers unique rich-post attachments in their original mixed-media order", async () => {
     mockShouldComputeCommandAuthorized.mockReturnValue(false);
     mockDownloadMessageResourceFeishu.mockImplementation(
       async (params: { fileKey: string; originalFilename?: string; type: "file" | "image" }) => ({
-        buffer: Buffer.from(params.fileKey),
-        contentType: params.type === "image" ? "image/png" : "video/mp4",
-        fileName: params.originalFilename ?? `${params.fileKey}.png`,
-      }),
-    );
-    mockSaveMediaBuffer.mockImplementation(
-      async (
-        buffer: Buffer,
-        contentType: string,
-        _direction: string,
-        _limit: number,
-        name: string,
-      ) => ({
-        id: name,
-        path: `/tmp/${name}`,
-        size: buffer.length,
-        contentType,
+        saved: {
+          id: params.originalFilename ?? `${params.fileKey}.png`,
+          path: `/tmp/${params.originalFilename ?? `${params.fileKey}.png`}`,
+          size: Buffer.byteLength(params.fileKey),
+          contentType: params.type === "image" ? "image/png" : "video/mp4",
+        },
       }),
     );
 


### PR DESCRIPTION
## What Problem This Solves

Feishu's inbound attachment handler retains a second file-saving path even though its download helper already returns saved media. Obsolete raw-buffer test fixtures kept that duplicate implementation alive after production callers had moved to the saving owner.

## Why This Change Was Made

Consume the existing saved-media result directly for both rich-post attachments and single-media messages. Remove the private raw-buffer saver and its unused runtime import. Update the bot fixtures to match the real producer and assert request forwarding and agent-visible media paths/types. The complete change removes 32 production code lines and 12 test code lines, with every test retained.

## User Impact

No intended behavior change. Download limits, filename recovery, the existing resource retry, attachment ordering/deduplication, missing-media placeholders, and transcription inputs retain their current owners and behavior.

## Evidence

- The normal download path and existing file-to-media retry both return the required saved-media result; both bot consumers call that owner directly.
- The same 148 bot/media tests pass before and after. Unchanged media-owner tests cover actual bounded file writes, filename fallback/recovery, stalled streams, and resource retries.
- All 25 selected check stages pass, including plugin and test typechecks, lint, dead exports, boundary guards, and runtime import cycles.
- Exact final Madge reports zero cycles; fresh two-file P2 review is scoped-clean.
- Initial [CI 34153906632](https://github.com/openclaw/openclaw/actions/runs/34153906632) failed on an unrelated main-parent UI test line limit. [#141466](https://github.com/openclaw/openclaw/pull/141466) repaired main by retaining that coverage in its streaming suite. This branch is refreshed onto the repaired main; both reviewed source files and the complete two-file patch are unchanged. Fresh [CI 34156894092](https://github.com/openclaw/openclaw/actions/runs/34156894092) passed.
