### PR TITLE
fix(plugins): use declared WebSocket runtimes for Discord and Mattermost

### DIFF
--- a/extensions/discord/src/internal/gateway-websocket-options.test.ts
+++ b/extensions/discord/src/internal/gateway-websocket-options.test.ts
@@ -1,13 +1,15 @@
 // Discord tests cover gateway websocket transport options.
-import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { webSocketCtorCalls } = vi.hoisted(() => ({
-  webSocketCtorCalls: [] as Array<{ url: string; options: unknown }>,
-}));
+const { webSocketCtorCalls, mockOwner } = vi.hoisted(() => {
+  const calls: Array<{ url: string; options: unknown }> = [];
+  const owner: { constructor: unknown } = { constructor: undefined };
+  return { webSocketCtorCalls: calls, mockOwner: owner };
+});
 
-vi.mock("ws", () => ({
-  WebSocket: class MockWebSocket extends EventEmitter {
+vi.mock("./ws-runtime.js", async () => {
+  const { EventEmitter } = await import("node:events");
+  class MockWebSocket extends EventEmitter {
     readyState = 1;
     send = vi.fn();
     close = vi.fn();
@@ -16,8 +18,12 @@ vi.mock("ws", () => ({
       super();
       webSocketCtorCalls.push({ url, options });
     }
-  },
-}));
+  }
+  mockOwner.constructor = MockWebSocket;
+  return { WebSocket: MockWebSocket };
+});
+
+import { WebSocket } from "./ws-runtime.js";
 
 describe("GatewayPlugin websocket options", () => {
   let GatewayPlugin: typeof import("./gateway.js").GatewayPlugin;
@@ -28,6 +34,7 @@ describe("GatewayPlugin websocket options", () => {
   });
 
   it("bounds inbound gateway websocket payloads and the opening handshake", () => {
+    expect(WebSocket).toBe(mockOwner.constructor);
     const gateway = new GatewayPlugin({
       autoInteractions: false,
       url: "wss://gateway.example.test",

--- a/extensions/discord/src/internal/gateway.ts
+++ b/extensions/discord/src/internal/gateway.ts
@@ -17,7 +17,7 @@ import {
 } from "discord-api-types/v10";
 import { asSafeIntegerInRange, MAX_TIMER_TIMEOUT_MS } from "openclaw/plugin-sdk/number-runtime";
 import { asOptionalRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
-import * as ws from "ws";
+import type * as ws from "ws";
 import { Plugin, type Client } from "./client.js";
 import { canResumeAfterGatewayClose, isFatalGatewayCloseCode } from "./gateway-close-codes.js";
 import { dispatchVoiceGatewayEvent, mapGatewayDispatchData } from "./gateway-dispatch.js";
@@ -27,6 +27,7 @@ import { decodeGatewayMessage, ensureGatewayParams } from "./gateway-payload.js"
 import { GatewaySendLimiter } from "./gateway-rate-limit.js";
 import { DiscordGatewayVoiceStateCache } from "./gateway-voice-state-cache.js";
 import type { DiscordGatewayVoiceStateTransition } from "./gateway-voice-state-cache.js";
+import { WebSocket } from "./ws-runtime.js";
 
 export { GatewayCloseCodes };
 export const GatewayIntents = GatewayIntentBits;
@@ -196,7 +197,7 @@ export class GatewayPlugin extends Plugin {
   }
 
   protected createWebSocket(url: string): ws.WebSocket {
-    return new ws.WebSocket(url, DISCORD_GATEWAY_WS_CLIENT_OPTIONS);
+    return new WebSocket(url, DISCORD_GATEWAY_WS_CLIENT_OPTIONS);
   }
 
   private setupWebSocket(resume: boolean): void {

--- a/extensions/discord/src/internal/ws-runtime.ts
+++ b/extensions/discord/src/internal/ws-runtime.ts
@@ -1,0 +1,11 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import type WebSocketClient from "ws";
+
+const require = createRequire(import.meta.url);
+
+// Use the declared transport so Bun preserves ws payload and handshake options.
+export type WebSocket = WebSocketClient;
+export const WebSocket: typeof WebSocketClient = require(
+  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
+);

--- a/extensions/discord/src/monitor/gateway-plugin.ts
+++ b/extensions/discord/src/monitor/gateway-plugin.ts
@@ -13,8 +13,9 @@ import { danger, warn } from "openclaw/plugin-sdk/runtime-env";
 import type { RuntimeEnv } from "openclaw/plugin-sdk/runtime-env";
 import { asFiniteNumber } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
-import * as ws from "ws";
+import type * as ws from "ws";
 import * as discordGateway from "../internal/gateway.js";
+import { WebSocket } from "../internal/ws-runtime.js";
 import { createDiscordDnsLookup } from "../network-config.js";
 import { validateDiscordProxyUrl } from "../proxy-fetch.js";
 import { resolveDiscordVoiceEnabled } from "../voice/config.js";
@@ -261,7 +262,7 @@ function createGatewayPlugin(params: {
       // Avoid Node's undici-backed global WebSocket here. We have seen late
       // close-path crashes during Discord gateway teardown; the ws transport is
       // already our proxy path and behaves predictably for lifecycle cleanup.
-      const WebSocketCtor = params.testing?.webSocketCtor ?? ws.default;
+      const WebSocketCtor = params.testing?.webSocketCtor ?? WebSocket;
       const socket = new WebSocketCtor(url, {
         ...discordGateway.DISCORD_GATEWAY_WS_CLIENT_OPTIONS,
         ...(params.wsAgent ? { agent: params.wsAgent } : {}),

--- a/extensions/discord/src/monitor/provider.proxy.test.ts
+++ b/extensions/discord/src/monitor/provider.proxy.test.ts
@@ -43,6 +43,7 @@ const {
   getLastProxyAgent,
   resolveDebugProxySettingsMock,
   resetLastAgent,
+  MockWebSocket,
   webSocketSpy,
   httpsAgentSpy,
   wsProxyAgentSpy,
@@ -52,6 +53,12 @@ const {
   const globalFetchMockLocal = vi.fn();
   const baseRegisterClientSpyLocal = vi.fn();
   const webSocketSpyLocal = vi.fn();
+  function MockWebSocketLocal(
+    url: string,
+    options?: { agent?: unknown; handshakeTimeout?: number; maxPayload?: number },
+  ) {
+    webSocketSpyLocal(url, options);
+  }
   const captureHttpExchangeSpyLocal = vi.fn();
   const captureWsEventSpyLocal = vi.fn();
   const resolveDebugProxySettingsMockLocal = vi.fn(() => ({ enabled: false }));
@@ -141,6 +148,7 @@ const {
       HttpsProxyAgentLocal.lastCreated = undefined;
     },
     webSocketSpy: webSocketSpyLocal,
+    MockWebSocket: MockWebSocketLocal,
     wsProxyAgentSpy: wsProxyAgentSpyLocal,
   };
 });
@@ -156,14 +164,11 @@ vi.mock("node:https", () => ({
   Agent: HttpsAgent,
 }));
 
-vi.mock("ws", () => ({
-  default: function MockWebSocket(
-    url: string,
-    options?: { agent?: unknown; handshakeTimeout?: number; maxPayload?: number },
-  ) {
-    webSocketSpy(url, options);
-  },
+vi.mock("../internal/ws-runtime.js", () => ({
+  WebSocket: MockWebSocket,
 }));
+
+import { WebSocket } from "../internal/ws-runtime.js";
 
 vi.mock("openclaw/plugin-sdk/proxy-capture", () => ({
   captureHttpExchange: captureHttpExchangeSpy,
@@ -379,6 +384,7 @@ describe("createDiscordGatewayPlugin", () => {
   });
 
   it("uses ws for gateway sockets even without proxy", () => {
+    expect(WebSocket).toBe(MockWebSocket);
     const runtime = createRuntime();
     const plugin = createDiscordGatewayPlugin({
       discordConfig: {},
@@ -404,6 +410,7 @@ describe("createDiscordGatewayPlugin", () => {
   });
 
   it("allocates a fresh websocket flow id for each gateway socket", () => {
+    expect(WebSocket).toBe(MockWebSocket);
     const runtime = createRuntime();
     const plugin = createDiscordGatewayPlugin({
       discordConfig: {},
@@ -569,6 +576,7 @@ describe("createDiscordGatewayPlugin", () => {
   });
 
   it("keeps gateway WebSocket direct when only ambient proxy env is configured", () => {
+    expect(WebSocket).toBe(MockWebSocket);
     vi.stubEnv("https_proxy", "env-proxy.test:8080");
     const runtime = createRuntime();
     const plugin = createDiscordGatewayPlugin({

--- a/extensions/mattermost/src/mattermost/monitor-websocket.ts
+++ b/extensions/mattermost/src/mattermost/monitor-websocket.ts
@@ -7,11 +7,12 @@ import {
   createDebugProxyWebSocketAgent,
   resolveDebugProxySettings,
 } from "openclaw/plugin-sdk/proxy-capture";
-import WebSocket, { type ClientOptions } from "ws";
+import type { ClientOptions, RawData } from "ws";
 import { z } from "zod";
 import { MattermostPostSchema, type MattermostPost } from "./client.js";
 import { rawDataToString } from "./monitor-helpers.js";
 import type { ChannelAccountSnapshot, RuntimeEnv } from "./runtime-api.js";
+import { WebSocket } from "./ws-runtime.js";
 
 export type MattermostEventPayload = {
   event?: string;
@@ -36,7 +37,7 @@ export type MattermostEventPayload = {
 
 type MattermostWebSocketLike = {
   on(event: "open", listener: () => void): void;
-  on(event: "message", listener: (data: WebSocket.RawData) => void | Promise<void>): void;
+  on(event: "message", listener: (data: RawData) => void | Promise<void>): void;
   on(event: "pong", listener: (data: Buffer) => void): void;
   on(event: "close", listener: (code: number, reason: Buffer) => void): void;
   on(event: "error", listener: (err: unknown) => void): void;

--- a/extensions/mattermost/src/mattermost/ws-runtime.ts
+++ b/extensions/mattermost/src/mattermost/ws-runtime.ts
@@ -1,0 +1,11 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import type WebSocketClient from "ws";
+
+const require = createRequire(import.meta.url);
+
+// Use the declared transport so Bun preserves ws payload and handshake options.
+export type WebSocket = WebSocketClient;
+export const WebSocket: typeof WebSocketClient = require(
+  path.join(path.dirname(require.resolve("ws/package.json")), "index.js"),
+);


### PR DESCRIPTION
## What Problem This Solves

Discord and Mattermost import bare `ws`, which Bun resolves to a compatibility binding instead of each plugin's declared package. Their existing Node-style WebSocket options therefore reach a different implementation.

## Why This Change Was Made

Use plugin-local installed-package loaders following the existing Signal pattern. Route both the Discord internal constructor and its serving wrapper through the loader, along with Mattermost's default factory. Existing injected constructors, types, options, and protocol behavior remain intact.

The Discord options fixture mocks the local loader, owns its EventEmitter import inside the mock factory, and checks constructor identity before connecting.

## User Impact

Both plugins consistently select the declared WebSocket implementation under Node and Bun, including the Discord serving path that overrides the base factory. There are no dependency, configuration, or timeout changes.

## Evidence

- Import-only checks show the original bare/installed mismatch under Bun and confirm both new loaders resolve to the installed constructor under Node and Bun.
- Three exact inert cases passed under each runtime: Discord constructor options, Mattermost injected-factory options, and Discord injected current-socket activity. No real sockets, payload-limit, stalled-handshake, credential, or service cases ran locally.
- The original six-file P0–P2 review, changed-file gate, and complete pnpm build passed; those six file hashes remain unchanged. All monitored processes joined without caps. Final source and patch hashes were verified before commit.
- Read-only emitted-code inspection confirms installed-package selection at both Discord base/serving constructors and Mattermost's default factory. No emitted artifact was executed for this audit.
- The earlier five-file build exposed a missed Discord serving override; that superseded candidate and its evidence are retained. An initial lint resource stop and a mock-hoisting collection failure are also retained; final lint and proof passed after the corresponding corrections.

This establishes constructor ownership, inert option forwarding, and emitted binding selection. It does not claim live payload/deadline enforcement or complete plugin/Bun compatibility. Exact final-head CI34155897174 and pull_request Workflow Sanity34155897173 passed; the completed hosted review is bound to b5296926 and reports no findings. Native admission remains required.

## CI fixture follow-up

CI follow-up: the first six-file candidate's Node job failed three provider proxy fixture cases because their old bare-ws mock no longer intercepted the plugin-local constructor. The real installed constructor rejected the fixture's fake HTTPSAgent. Align that existing mock with the named WebSocket export of the local owner and assert constructor identity at the start of the three affected bodies.

The local baseline deliberately did not rerun the unguarded constructor calls: all three cases failed the new identity guard on Node and Bun before any body or connection attempt. After retargeting the mock, exactly those three cases passed on both runtimes, retaining all original option, flow-id and ambient-env assertions. Other proxy, security and metadata cases were not run locally. The original six candidate file hashes are unchanged, so their successful build and emitted-source audit remain applicable; only the seventh test file changed. The final full seven-file review and gate are recorded separately.

Fresh full seven-file P0–P2 review, configured lint, and the complete seven-file changed gate passed at b5296926. All descendants joined without resource caps; final seven hashes were verified. The separate UI line-limit issue was already repaired upstream in #141466; this PR contains no UI change. No repeat production build is needed for this test-only correction because the six prior candidate files and their emitted bindings are unchanged.
