### PR TITLE
feat(beam): delete beamed sessions from the sidebar row menu

### DIFF
--- a/docs/plugins/beam.md
+++ b/docs/plugins/beam.md
@@ -134,11 +134,19 @@ A continuation belongs to the authenticated operator who creates it. From then o
 
 User turns are attributed to the verified publisher of the current snapshot, using their current profile name and avatar, including merged profiles. Beam's upload format does not identify individual authors within a multi-user transcript. The uploader reference shares the snapshot's seven-day retention and is replaced on each upload. Shared-token uploads, failed profile resolution, and older snapshots without a recorded uploader display **User**; they never inherit the viewer's identity or a previous uploader's identity. Reupload an older snapshot through personal authentication to attribute it.
 
+### Delete
+
+Any operator with `operator.write` can delete a Beam from its sidebar row menu.
+Deletion is permanent and immediate. Re-uploading the same `beamId` recreates the
+row, whether through the manual skill or a still-active mirror's next upload.
+Mirrors skip unchanged snapshots, so recreation does not necessarily happen on
+the next poll. Deleting a Beam does not affect continuations already created from it.
+
 ## Security boundary
 
 Beam publication is not remote control.
 
-- Continuing makes an independent Gateway-owned session. Beam itself has no archive, terminal, tool, or node capability.
+- Continuing makes an independent Gateway-owned session. Beam itself has no filesystem, terminal, tool, or node capability.
 - It accepts text-only normalized transcript items, not HTML, scripts, archives, attachments, or server-fetched URLs.
 - The official skill removes raw tool results, reasoning, prompts, local paths, credentials, cookies, and auth material before upload.
 - The receiver treats every transcript as untrusted text. The first message in the Beam composer is the explicit operator action that copies it into a new session.

--- a/extensions/beam/src/beam.test.ts
+++ b/extensions/beam/src/beam.test.ts
@@ -49,6 +49,21 @@ const writeClient = () => ({ clientIp: "127.0.0.1", scopes: ["operator.write"] }
 const rootControlUiBasePath = () => undefined;
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
+function persistentStore() {
+  resetPluginStateStoreForTests();
+  const keyedStore = createPluginStateKeyedStoreForTests<BeamStoredSession>("beam", {
+    namespace: "sessions",
+    maxEntries: BEAM_MAX_SESSIONS,
+    overflowPolicy: "evict-oldest",
+    defaultTtlMs: BEAM_RETENTION_MS,
+    env: { OPENCLAW_STATE_DIR: tempDirs.make("beam-store-") },
+  });
+  const store = createBeamStore({
+    state: { openKeyedStore: () => keyedStore },
+  } as unknown as PluginRuntime);
+  return { keyedStore, store };
+}
+
 function memoryStore(): BeamStore & { values: Map<string, BeamStoredSession> } {
   const values = new Map<string, BeamStoredSession>();
   return {
@@ -62,6 +77,7 @@ function memoryStore(): BeamStore & { values: Map<string, BeamStoredSession> } {
       return true;
     },
     get: async (beamId) => values.get(beamId),
+    delete: async (beamId) => values.delete(beamId),
     list: async () => [...values.values()],
   };
 }
@@ -248,17 +264,7 @@ describe("Beam receiver", () => {
   });
 
   it("orders replacement snapshots without refreshing stale state", async () => {
-    resetPluginStateStoreForTests();
-    const keyedStore = createPluginStateKeyedStoreForTests<BeamStoredSession>("beam", {
-      namespace: "sessions",
-      maxEntries: BEAM_MAX_SESSIONS,
-      overflowPolicy: "evict-oldest",
-      defaultTtlMs: BEAM_RETENTION_MS,
-      env: { OPENCLAW_STATE_DIR: tempDirs.make("beam-snapshot-ordering-") },
-    });
-    const store = createBeamStore({
-      state: { openKeyedStore: () => keyedStore },
-    } as unknown as PluginRuntime);
+    const { keyedStore, store } = persistentStore();
     let receivedAt = 100;
     let profileId = "terminal-publisher";
     const endpoint = await serve(store, {
@@ -577,6 +583,41 @@ describe("Beam mirror receiver boundary", () => {
 });
 
 describe("Beam session catalog", () => {
+  it("permanently deletes only known gateway sessions and allows re-upload", async () => {
+    const { store } = persistentStore();
+    const endpoint = await serve(store);
+    const catalog = createBeamSessionCatalog(store);
+    const params = {
+      agentId: "main",
+      hostId: "gateway",
+      threadId: sampleUpload().beamId,
+      confirmNoOtherRunner: true as const,
+    };
+
+    try {
+      expect((await postUpload(endpoint)).status).toBe(200);
+      await expect(catalog.archive?.({ ...params, hostId: "other-host" })).rejects.toThrow(
+        "unknown Beam host: other-host",
+      );
+      await expect(catalog.read(params)).resolves.toMatchObject({ threadId: params.threadId });
+      await expect(catalog.archive?.({ ...params, threadId: "missing" })).rejects.toThrow(
+        "unknown Beam session: missing",
+      );
+
+      await expect(catalog.archive?.(params)).resolves.toEqual({ ok: true });
+      const [host] = await catalog.list({ agentId: "main" });
+      expect(host?.sessions).toEqual([]);
+      await expect(catalog.read(params)).rejects.toThrow(
+        `unknown Beam session: ${params.threadId}`,
+      );
+
+      expect((await postUpload(endpoint)).status).toBe(200);
+      await expect(catalog.read(params)).resolves.toMatchObject({ threadId: params.threadId });
+    } finally {
+      resetPluginStateStoreForTests();
+    }
+  });
+
   it("queries Beam ids by strict share-prefix without choosing between collisions", async () => {
     const store = memoryStore();
     const ids = [
@@ -658,7 +699,7 @@ describe("Beam session catalog", () => {
       status: "live",
       source: "claude",
       canContinue: true,
-      canArchive: false,
+      canArchive: true,
     });
     expect(host.nextCursor).toBe("1");
     expect(catalog.audience).toBe("gateway-operators");
@@ -731,7 +772,6 @@ describe("Beam session catalog", () => {
         cursor: transcript.nextCursor,
       }),
     ).rejects.toThrow("stale Beam transcript cursor");
-    expect(catalog.archive).toBeUndefined();
     expect(catalog.openTerminal).toBeUndefined();
   });
 });

--- a/extensions/beam/src/mirror-retry.test.ts
+++ b/extensions/beam/src/mirror-retry.test.ts
@@ -192,6 +192,7 @@ describe("Beam terminal retry policy", () => {
           return session;
         }),
       get: (beamId) => keyedStore.lookup(beamId),
+      delete: (beamId) => keyedStore.delete(beamId),
       list: async () => (await keyedStore.entries()).map((entry) => entry.value),
     };
     let requestNumber = 0;

--- a/extensions/beam/src/session-catalog.ts
+++ b/extensions/beam/src/session-catalog.ts
@@ -95,7 +95,7 @@ export function createBeamSessionCatalog(store: BeamStore): SessionCatalogProvid
             source: session.source,
             archived: false,
             canContinue: true,
-            canArchive: false,
+            canArchive: true,
           })),
           ...(offset + page.length < sessions.length
             ? { nextCursor: String(offset + page.length) }
@@ -140,6 +140,15 @@ export function createBeamSessionCatalog(store: BeamStore): SessionCatalogProvid
           .toReversed(),
         ...(start > 0 ? { nextCursor: encodeTranscriptCursor({ revision, end: start }) } : {}),
       };
+    },
+    async archive(params) {
+      if (params.hostId !== BEAM_HOST_ID) {
+        throw new Error(`unknown Beam host: ${params.hostId}`);
+      }
+      if (!(await store.delete(params.threadId))) {
+        throw new Error(`unknown Beam session: ${params.threadId}`);
+      }
+      return { ok: true };
     },
     async copyToGatewaySession(params) {
       if (params.hostId !== BEAM_HOST_ID) {

--- a/extensions/beam/src/store.ts
+++ b/extensions/beam/src/store.ts
@@ -8,6 +8,7 @@ export type BeamStore = {
     updateValue: (current: BeamStoredSession | undefined) => BeamStoredSession | undefined,
   ) => Promise<boolean>;
   get: (beamId: string) => Promise<BeamStoredSession | undefined>;
+  delete: (beamId: string) => Promise<boolean>;
   list: () => Promise<BeamStoredSession[]>;
 };
 
@@ -21,6 +22,7 @@ export function createBeamStore(runtime: PluginRuntime): BeamStore {
   return {
     update: (beamId, updateValue) => store.update!(beamId, updateValue),
     get: (beamId) => store.lookup(beamId),
+    delete: (beamId) => store.delete(beamId),
     list: async () => (await store.entries()).map((entry) => entry.value),
   };
 }

--- a/src/gateway/server-methods/session-catalog-progress.test.ts
+++ b/src/gateway/server-methods/session-catalog-progress.test.ts
@@ -150,6 +150,107 @@ describe("session catalog progress ownership", () => {
     }
   });
 
+  it.each(["settled", "in-flight"] as const)(
+    "refreshes %s lists immediately after archiving a session",
+    async (listingState) => {
+      const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
+      const gate = createDeferredCore();
+      const started = createDeferredCore();
+      const late = createDeferredCore();
+      const publications: Promise<void>[] = [];
+      const broadcastToConnIds = vi.fn();
+      const session = {
+        threadId: "deleted-thread",
+        status: "stored",
+        archived: false,
+        canContinue: false,
+        canArchive: true,
+      };
+      const host = {
+        hostId: "gateway:local",
+        label: "Local",
+        kind: "gateway" as const,
+        connected: true,
+        sessions: [session],
+      };
+      let archived = false;
+      const list = vi.fn<SessionCatalogProvider["list"]>(async ({ onHost, waitUntil }) => {
+        const resultHost = { ...host, sessions: archived ? [] : [session] };
+        const publication = late.promise.then(() => onHost?.(resultHost));
+        publications.push(publication);
+        waitUntil?.(publication);
+        started.resolve();
+        await gate.promise;
+        return [resultHost];
+      });
+      hoisted.activeRegistry.sessionCatalogs = [
+        {
+          provider: provider("fixture", {
+            list,
+            archive: async () => {
+              archived = true;
+              return { ok: true };
+            },
+          }),
+        },
+      ];
+      const config = {};
+      const client = { connId: "requester" };
+      const original = startCall(
+        "sessions.catalog.list",
+        { progressId: "before-delete" },
+        config,
+        client,
+        { broadcastToConnIds },
+      );
+      try {
+        await started.promise;
+        if (listingState === "settled") {
+          gate.resolve();
+          await original.completion;
+        }
+        const deletion = await call(
+          "sessions.catalog.archive",
+          {
+            catalogId: "fixture",
+            hostId: host.hostId,
+            threadId: session.threadId,
+            confirmNoOtherRunner: true,
+          },
+          config,
+          client,
+        );
+        expect(deletion).toHaveBeenCalledWith(true, { ok: true });
+        late.resolve();
+        await publications[0];
+        gate.resolve();
+        await original.completion;
+        expect(original.respond).toHaveBeenCalledWith(true, {
+          catalogs: [expect.objectContaining({ hosts: [host] })],
+        });
+
+        const refreshed = await call(
+          "sessions.catalog.list",
+          { progressId: "after-delete" },
+          config,
+          client,
+          { broadcastToConnIds: vi.fn() },
+        );
+        expect(refreshed).toHaveBeenCalledWith(true, {
+          catalogs: [expect.objectContaining({ hosts: [{ ...host, sessions: [] }] })],
+        });
+        expect(list).toHaveBeenCalledTimes(2);
+        expect(broadcastToConnIds).not.toHaveBeenCalled();
+      } finally {
+        gate.resolve();
+        late.resolve();
+        await original.completion;
+        await Promise.allSettled(publications);
+        now.mockRestore();
+      }
+    },
+  );
+
   it("retires pending progress when aggregate projection fails", async () => {
     const late = createDeferredCore();
     const broadcastToConnIds = vi.fn();

--- a/src/gateway/server-methods/session-catalog.ts
+++ b/src/gateway/server-methods/session-catalog.ts
@@ -714,14 +714,20 @@ export const sessionCatalogHandlers: GatewayRequestHandlers = {
         return;
       }
       const { catalogId: _catalogId, ...providerRequest } = request;
-      respond(
-        true,
-        await provider.archive({
-          ...providerRequest,
-          agentId: authorization.agentId,
-          allowProcessHomeFallback: authorization.allowProcessHomeFallback,
-        }),
-      );
+      const result = await provider.archive({
+        ...providerRequest,
+        agentId: authorization.agentId,
+        allowProcessHomeFallback: authorization.allowProcessHomeFallback,
+      });
+      const cache = catalogListsByConfig.get(context.getRuntimeConfig())?.entries;
+      if (cache) {
+        // Host publications can outlive the aggregate response and still contain the deleted row.
+        for (const entry of cache.values()) {
+          entry.progress.retire();
+        }
+        cache.clear();
+      }
+      respond(true, result);
     } catch (error) {
       const details = catalogError(error);
       respond(

--- a/ui/src/components/app-sidebar-catalog-menu.test.ts
+++ b/ui/src/components/app-sidebar-catalog-menu.test.ts
@@ -14,6 +14,10 @@ describe("SidebarCatalogMenuController", () => {
       requestUpdate: vi.fn(),
       terminalAvailable: () => true,
       navigate: vi.fn(),
+      beginMutation: vi.fn(),
+      isMutationCurrent: vi.fn(),
+      archive: vi.fn(),
+      afterDelete: vi.fn(),
     });
 
     controller.open(
@@ -23,6 +27,8 @@ describe("SidebarCatalogMenuController", () => {
         routeId: "chat",
         navigation: {},
         canOpenTerminal: true,
+        canDelete: false,
+        name: "Shared session",
         meta: "now",
       },
       10,

--- a/ui/src/components/app-sidebar-catalog-menu.ts
+++ b/ui/src/components/app-sidebar-catalog-menu.ts
@@ -1,8 +1,13 @@
 // Owns catalog-row menu state, actions, focus anchor, and rendering for AppSidebar.
+import type { SessionsCatalogArchiveParams } from "@openclaw/gateway-protocol";
 import { html, nothing } from "lit";
+import { t } from "../i18n/index.ts";
+import { formatUiError } from "../lib/format-error.ts";
 import type { CatalogSessionKey } from "../lib/sessions/catalog-key.ts";
 import { openCatalogSessionInTerminal } from "../lib/sessions/catalog-terminal.ts";
+import { showToast } from "../lib/toast.ts";
 import type { CatalogSessionMenuRequest } from "./app-sidebar-session-catalogs.ts";
+import type { SidebarSessionMutationScope } from "./app-sidebar-session-types.ts";
 import "./catalog-session-menu.ts";
 import type { CatalogSessionMenuAction } from "./catalog-session-menu.ts";
 import { SESSION_MENU_OPEN_EVENT } from "./session-progress-hovercard-target.ts";
@@ -18,6 +23,13 @@ export class SidebarCatalogMenuController {
       beforeOpen: () => void;
       requestUpdate: () => void;
       terminalAvailable: () => boolean;
+      beginMutation: () => SidebarSessionMutationScope | null;
+      isMutationCurrent: (scope: SidebarSessionMutationScope) => boolean;
+      archive: (
+        scope: SidebarSessionMutationScope,
+        params: SessionsCatalogArchiveParams,
+      ) => Promise<unknown>;
+      afterDelete: (scope: SidebarSessionMutationScope, key: CatalogSessionKey) => Promise<void>;
       navigate: (request: Pick<CatalogSessionMenuRequest, "navigation" | "routeId">) => void;
     },
   ) {}
@@ -82,7 +94,49 @@ export class SidebarCatalogMenuController {
       }
       return;
     }
+    if (action === "delete") {
+      if (menu.canDelete) {
+        void this.deleteSession(menu);
+      }
+      return;
+    }
     this.hooks.navigate(menu);
+  }
+
+  private async deleteSession(menu: SidebarCatalogSessionMenuState): Promise<void> {
+    const scope = this.hooks.beginMutation();
+    if (!scope) {
+      return;
+    }
+    try {
+      const { showConfirmDialog } = await import("./confirm-dialog.ts");
+      const confirmed = await showConfirmDialog({
+        message: t("chat.catalog.deleteSessionConfirm"),
+        details: menu.name,
+        confirmLabel: t("chat.catalog.deleteSession"),
+        danger: true,
+        signal: scope.signal,
+      });
+      if (!this.hooks.isMutationCurrent(scope)) {
+        showToast({
+          message: t("sessionsView.deleteSessionStale", { session: menu.name }),
+        });
+        return;
+      }
+      if (!confirmed) {
+        return;
+      }
+      await this.hooks.archive(scope, {
+        ...menu.key,
+        agentId: menu.agentId,
+        confirmNoOtherRunner: true,
+      });
+      if (this.hooks.isMutationCurrent(scope)) {
+        await this.hooks.afterDelete(scope, menu.key);
+      }
+    } catch (error) {
+      showToast({ message: formatUiError(error) });
+    }
   }
 
   render() {
@@ -96,6 +150,7 @@ export class SidebarCatalogMenuController {
         .y=${menu.y}
         .trigger=${this.trigger}
         .lastActive=${menu.meta}
+        .canDelete=${menu.canDelete}
         .terminalDisabled=${!menu.canOpenTerminal || !this.hooks.terminalAvailable()}
         .onAction=${(action: CatalogSessionMenuAction) => this.handleAction(menu, action)}
         .onClose=${() => this.close()}

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -575,6 +575,8 @@ function renderCatalogSessionRow(
         routeId,
         navigation,
         canOpenTerminal: session.canOpenTerminal === true,
+        canDelete: session.canArchive && catalog.capabilities.archive,
+        name: session.name ?? session.threadId,
         meta,
       },
       x,

--- a/ui/src/components/app-sidebar-session-catalogs.ts
+++ b/ui/src/components/app-sidebar-session-catalogs.ts
@@ -156,6 +156,8 @@ export type CatalogSessionMenuRequest = {
   routeId: "chat" | "new-session";
   navigation: ApplicationNavigationOptions;
   canOpenTerminal: boolean;
+  canDelete: boolean;
+  name: string;
   meta: string;
 };
 

--- a/ui/src/components/catalog-session-menu.ts
+++ b/ui/src/components/catalog-session-menu.ts
@@ -7,7 +7,7 @@ import { icons } from "./icons.ts";
 import { promoteToPopoverTopLayer } from "./menu-surface.ts";
 import "./web-awesome.ts";
 
-export type CatalogSessionMenuAction = "viewer" | "terminal";
+export type CatalogSessionMenuAction = "viewer" | "terminal" | "delete";
 
 class CatalogSessionMenu extends OpenClawLightDomElement {
   @property({ attribute: false }) x = 0;
@@ -15,6 +15,7 @@ class CatalogSessionMenu extends OpenClawLightDomElement {
   @property({ attribute: false }) trigger: HTMLElement | null = null;
   @property({ attribute: false }) lastActive = "";
   @property({ attribute: false }) terminalDisabled = false;
+  @property({ attribute: false }) canDelete = false;
   @property({ attribute: false }) onAction: (action: CatalogSessionMenuAction) => void = () => {};
   @property({ attribute: false }) onClose: () => void = () => {};
   readonly menuLifecycle = new DropdownMenuController(this, {
@@ -51,7 +52,7 @@ class CatalogSessionMenu extends OpenClawLightDomElement {
 
   override render() {
     const menuWidth = 240;
-    const menuMaxHeight = 140;
+    const menuMaxHeight = this.canDelete ? 180 : 140;
     const x = Math.max(8, Math.min(this.x, window.innerWidth - menuWidth - 8));
     const y = Math.max(8, Math.min(this.y, window.innerHeight - menuMaxHeight - 8));
     const menuLabel = t("chat.catalog.sessionMenu");
@@ -95,6 +96,20 @@ class CatalogSessionMenu extends OpenClawLightDomElement {
           <span slot="icon" class="session-menu__icon" aria-hidden="true">${icons.terminal}</span>
           <span class="session-menu__text">${t("chat.catalog.openInTerminal")}</span>
         </wa-dropdown-item>
+        ${
+          this.canDelete
+            ? html`<wa-dropdown-item
+                class="session-menu__item session-menu__item--destructive"
+                variant="danger"
+                value="delete"
+              >
+                <span slot="icon" class="session-menu__icon" aria-hidden="true"
+                  >${icons.trash}</span
+                >
+                <span class="session-menu__text">${t("chat.catalog.deleteSession")}</span>
+              </wa-dropdown-item>`
+            : ""
+        }
       </wa-dropdown>
     `;
   }

--- a/ui/src/components/session-data-controller-catalog.ts
+++ b/ui/src/components/session-data-controller-catalog.ts
@@ -7,6 +7,7 @@ import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { RouteId } from "../app-route-paths.ts";
 import type { ApplicationContext } from "../app/context.ts";
 import { isGatewayMethodAdvertised } from "../lib/gateway-methods.ts";
+import type { CatalogSessionContinuedDetail } from "../lib/sessions/catalog-key.ts";
 import { normalizeAgentId } from "../lib/sessions/session-key.ts";
 import {
   refreshSessionCatalogsLive,
@@ -18,6 +19,7 @@ import {
   mergeSessionCatalogPage,
   sessionCatalogRequestError,
 } from "./app-sidebar-session-catalog-state.ts";
+import { bindAdoptedCatalogSession } from "./app-sidebar-session-catalogs.ts";
 import { sessionCatalogHostKey } from "./app-sidebar-session-types.ts";
 import type {
   SidebarSessionOwnerFilter,
@@ -125,17 +127,24 @@ export function scheduleSessionCatalogRefresh(
     return;
   }
   owner.sessionCatalogLive.scheduleActivation(queueIfActive, (shouldQueue) => {
-    const snapshot = owner.context?.gateway.snapshot;
-    owner.sessionCatalogLive.requestRefresh({
-      visible: document.visibilityState !== "hidden",
-      connected:
-        owner.isSessionDataHostConnected &&
-        owner.sessionCatalogAgentId !== null &&
-        Boolean(sessionCatalogListClient(snapshot, owner.sessionDataHostConnected)),
-      generation: owner.sessionScopeGeneration,
-      queueIfActive: shouldQueue,
-      refresh: () => void owner.refreshSessionCatalogs(),
-    });
+    requestSessionCatalogRefresh(owner, shouldQueue);
+  });
+}
+
+export function requestSessionCatalogRefresh(
+  owner: SessionCatalogDataOwner,
+  queueIfActive: boolean,
+): void {
+  const snapshot = owner.context?.gateway.snapshot;
+  owner.sessionCatalogLive.requestRefresh({
+    visible: document.visibilityState !== "hidden",
+    connected:
+      owner.isSessionDataHostConnected &&
+      owner.sessionCatalogAgentId !== null &&
+      Boolean(sessionCatalogListClient(snapshot, owner.sessionDataHostConnected)),
+    generation: owner.sessionScopeGeneration,
+    queueIfActive,
+    refresh: () => void owner.refreshSessionCatalogs(),
   });
 }
 
@@ -194,6 +203,29 @@ export function applySessionCatalogHostEvent(
       () => void owner.refreshSessionCatalogs(),
     );
   }
+}
+
+export function applySessionCatalogContinuation(
+  owner: SessionCatalogDataOwner,
+  detail: CatalogSessionContinuedDetail,
+): void {
+  const rawAgentId = typeof detail?.agentId === "string" ? detail.agentId.trim() : "";
+  const eventAgentId = rawAgentId ? normalizeAgentId(rawAgentId) : null;
+  const currentAgentId = owner.sessionCatalogAgentId
+    ? normalizeAgentId(owner.sessionCatalogAgentId)
+    : null;
+  if (!detail?.sessionKey || !eventAgentId || eventAgentId !== currentAgentId) {
+    return;
+  }
+  owner.sessionCatalogs = bindAdoptedCatalogSession(owner.sessionCatalogs, detail);
+  owner.requestSessionDataUpdate();
+  // Invalidate in-flight polls and load-more merges so a pre-adoption
+  // snapshot cannot clobber the patched rows; the 30s poll reconfirms.
+  owner.sessionCatalogRevision += 1;
+  owner.sessionCatalogRevisions.set(
+    detail.catalogId,
+    (owner.sessionCatalogRevisions.get(detail.catalogId) ?? 0) + 1,
+  );
 }
 
 export async function refreshSessionCatalogs(owner: SessionCatalogDataOwner): Promise<void> {

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -338,6 +338,9 @@ export class SessionDataController implements ReactiveController, SessionCatalog
 
   invalidateSessionCatalogs(): void {
     this.sessionCatalogRevision += 1;
+    for (const { id } of this.sessionCatalogs) {
+      this.sessionCatalogRevisions.set(id, (this.sessionCatalogRevisions.get(id) ?? 0) + 1);
+    }
     requestSessionCatalogRefresh(this, true);
   }
 

--- a/ui/src/components/session-data-controller.ts
+++ b/ui/src/components/session-data-controller.ts
@@ -29,17 +29,18 @@ import {
   retireStaleChildSessionRows,
 } from "./app-sidebar-child-session-data.ts";
 import { SessionCatalogLiveState } from "./app-sidebar-session-catalog-live.ts";
-import { bindAdoptedCatalogSession } from "./app-sidebar-session-catalogs.ts";
 import type {
   SidebarSessionMutationScope,
   SidebarSessionsScrollState,
 } from "./app-sidebar-session-types.ts";
 import { createPanelRefreshStatus, type PanelRefreshStatus } from "./panel-refresh-status.ts";
 import {
+  applySessionCatalogContinuation,
   applySessionCatalogHostEvent as applySessionCatalogHostEventToData,
   applySessionCatalogPresence as applySessionCatalogPresenceToData,
   loadMoreSessionCatalog as loadMoreSessionCatalogData,
   refreshSessionCatalogs as refreshSessionCatalogData,
+  requestSessionCatalogRefresh,
   resolveSessionCatalogAgentId,
   scheduleSessionCatalogRefresh,
   type SessionCatalogDataOwner,
@@ -328,29 +329,17 @@ export class SessionDataController implements ReactiveController, SessionCatalog
   private readonly handleCatalogSessionContinued = (
     event: CustomEvent<CatalogSessionContinuedDetail>,
   ) => {
-    const detail = event.detail;
-    const rawAgentId = typeof detail?.agentId === "string" ? detail.agentId.trim() : "";
-    const eventAgentId = rawAgentId ? normalizeAgentId(rawAgentId) : null;
-    const currentAgentId = this.sessionCatalogAgentId
-      ? normalizeAgentId(this.sessionCatalogAgentId)
-      : null;
-    if (!detail?.sessionKey || !eventAgentId || eventAgentId !== currentAgentId) {
-      return;
-    }
-    this.sessionCatalogs = bindAdoptedCatalogSession(this.sessionCatalogs, detail);
-    this.requestSessionDataUpdate();
-    // Invalidate in-flight polls and load-more merges so a pre-adoption
-    // snapshot cannot clobber the patched rows; the 30s poll reconfirms.
-    this.sessionCatalogRevision += 1;
-    this.sessionCatalogRevisions.set(
-      detail.catalogId,
-      (this.sessionCatalogRevisions.get(detail.catalogId) ?? 0) + 1,
-    );
+    applySessionCatalogContinuation(this, event.detail);
   };
 
   private readonly handleSessionCatalogPageActivation = (event: Event) => {
     scheduleSessionCatalogRefresh(this, event.type === "visibilitychange");
   };
+
+  invalidateSessionCatalogs(): void {
+    this.sessionCatalogRevision += 1;
+    requestSessionCatalogRefresh(this, true);
+  }
 
   refreshSessionCatalogs(): Promise<void> {
     return refreshSessionCatalogData(this);

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -110,7 +110,7 @@ interface SidebarMenusControllerHost
       | "sessionResultsByAgent"
       | "sessionsLoading"
       | "sessionsResult"
-      | "refreshSessionCatalogs"
+      | "invalidateSessionCatalogs"
     >;
   readonly sessionDataContext: ApplicationContext<RouteId> | undefined;
   readonly sessionOrganizer: SessionOrganizerController;
@@ -212,7 +212,7 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
       isMutationCurrent: (scope) => host.sessionData.isSessionMutationScopeCurrent(scope),
       archive: (scope, params) => scope.client.request("sessions.catalog.archive", params),
       afterDelete: async (scope, key) => {
-        await host.sessionData.refreshSessionCatalogs();
+        host.sessionData.invalidateSessionCatalogs();
         if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
           return;
         }

--- a/ui/src/components/sidebar-menus-controller.ts
+++ b/ui/src/components/sidebar-menus-controller.ts
@@ -16,6 +16,7 @@ import {
   SESSION_PULL_REQUESTS_SUBSCRIBE_METHOD,
   sessionPullRequestsForGateway,
 } from "../lib/session-pull-requests.ts";
+import { parseCatalogSessionKey } from "../lib/sessions/catalog-key.ts";
 import type { CatalogProjectGrouping } from "../lib/sessions/catalog-project-grouping.ts";
 import type { SidebarSessionsGrouping } from "../lib/sessions/grouping.ts";
 import { sessionNavigationTarget } from "../lib/sessions/route-navigation.ts";
@@ -109,6 +110,7 @@ interface SidebarMenusControllerHost
       | "sessionResultsByAgent"
       | "sessionsLoading"
       | "sessionsResult"
+      | "refreshSessionCatalogs"
     >;
   readonly sessionDataContext: ApplicationContext<RouteId> | undefined;
   readonly sessionOrganizer: SessionOrganizerController;
@@ -206,6 +208,28 @@ export class SidebarMenusController implements ReactiveController, SidebarMenusC
       beforeOpen: () => void this.dismissTransientMenus(),
       requestUpdate: () => host.requestUpdate(),
       terminalAvailable: () => host.terminalAvailable,
+      beginMutation: () => host.sessionData.beginSessionMutation(),
+      isMutationCurrent: (scope) => host.sessionData.isSessionMutationScopeCurrent(scope),
+      archive: (scope, params) => scope.client.request("sessions.catalog.archive", params),
+      afterDelete: async (scope, key) => {
+        await host.sessionData.refreshSessionCatalogs();
+        if (!host.sessionData.isSessionMutationScopeCurrent(scope)) {
+          return;
+        }
+        const active = parseCatalogSessionKey(host.getRouteSessionKey());
+        if (
+          host.activeRouteId === "chat" &&
+          active?.catalogId === key.catalogId &&
+          active.hostId === key.hostId &&
+          active.threadId === key.threadId
+        ) {
+          host.onNavigate?.("chat", {
+            pathname: pathForRoute("chat", host.basePath),
+            search: "",
+            hash: "",
+          });
+        }
+      },
       navigate: ({ routeId, navigation }) => host.onNavigate?.(routeId, navigation),
     });
   }

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4901,7 +4901,7 @@ export const en: TranslationMap & {
       openInTerminal: "Open in terminal",
       deleteSession: "Delete",
       deleteSessionConfirm:
-        "Delete this external session? Make sure no other runner is using it. This cannot be undone.",
+        "Delete this external session from OpenClaw? Make sure no other runner is using it. Beamed sessions are deleted permanently. Sessions kept by another tool, such as Codex, are archived there and may be restorable.",
       terminalUnavailable: "Terminal opening is unavailable for this session.",
     },
     taskSuggestions: {

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4899,6 +4899,9 @@ export const en: TranslationMap & {
       sessionMenu: "External session actions",
       openInOpenClaw: "Open in OpenClaw",
       openInTerminal: "Open in terminal",
+      deleteSession: "Delete",
+      deleteSessionConfirm:
+        "Delete this external session? Make sure no other runner is using it. This cannot be undone.",
       terminalUnavailable: "Terminal opening is unavailable for this session.",
     },
     taskSuggestions: {

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-terminal-owner.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-terminal-owner.ts
@@ -8,6 +8,11 @@ import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { TERMINAL_PANEL_TOGGLE_EVENT } from "../../components/panel-toggle-contract.ts";
 import { CATALOG_SESSION_CONTINUED_EVENT } from "../../lib/sessions/catalog-key.ts";
 import { createGatewayHarness, createSessions, mountSidebar } from "../app-sidebar.ts";
+import {
+  answerConfirmDialog,
+  installDialogPolyfill,
+  waitForConfirmDialogActions,
+} from "../modal-dialog.ts";
 import "../../components/app-sidebar.ts";
 
 const catalogList = (sessions: Array<Record<string, unknown>>): SessionsCatalogListResult => ({
@@ -38,8 +43,8 @@ const catalogList = (sessions: Array<Record<string, unknown>>): SessionsCatalogL
 async function mountWithCatalog(
   result: SessionsCatalogListResult,
   sessionKeys = ["agent:main:main"],
+  request = vi.fn().mockResolvedValue(result),
 ) {
-  const request = vi.fn().mockResolvedValue(result);
   const gateway = createGatewayHarness({ request } as unknown as GatewayBrowserClient);
   gateway.publish({
     hello: {
@@ -187,4 +192,97 @@ describe("AppSidebar catalog terminal ownership", () => {
       vi.useRealTimers();
     }
   });
+});
+
+describe("AppSidebar catalog deletion", () => {
+  it.each([
+    { canArchive: true, archive: true, visible: true },
+    { canArchive: false, archive: true, visible: false },
+    { canArchive: true, archive: false, visible: false },
+  ])(
+    "gates Delete on row and catalog capabilities: %j",
+    async ({ canArchive, archive, visible }) => {
+      vi.useFakeTimers();
+      try {
+        const result = catalogList([{ threadId: "thread-1", name: "Shared session", canArchive }]);
+        result.catalogs[0]!.capabilities.archive = archive;
+        const sidebar = await mountWithCatalog(result);
+        sidebar
+          .querySelector('[data-session-key*="thread-1"]')!
+          .dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+        await vi.advanceTimersByTimeAsync(0);
+        expect(Boolean(sidebar.querySelector('wa-dropdown-item[value="delete"]'))).toBe(visible);
+      } finally {
+        vi.useRealTimers();
+      }
+    },
+  );
+
+  it.each([true, false])(
+    "confirms catalog deletion and refreshes rows (open: %s)",
+    async (open) => {
+      vi.useFakeTimers();
+      const restoreDialog = installDialogPolyfill();
+      try {
+        const result = catalogList([{ threadId: "thread-1", name: "Shared session" }]);
+        const request = vi.fn().mockResolvedValue(result);
+        const sidebar = await mountWithCatalog(result, undefined, request);
+        sidebar.sessionKey = open
+          ? "agent:main:catalog:codex:gateway%3Alocal:thread-1"
+          : "agent:main:main";
+        sidebar.activeRouteId = "chat";
+        sidebar.onNavigate = vi.fn();
+        await sidebar.updateComplete;
+        const selectDelete = async () => {
+          sidebar
+            .querySelector('[data-session-key*="thread-1"]')!
+            .dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+          await vi.advanceTimersByTimeAsync(0);
+          const item = sidebar.querySelector('wa-dropdown-item[value="delete"]');
+          expect(item).not.toBeNull();
+          item!.dispatchEvent(
+            new CustomEvent("wa-select", {
+              bubbles: true,
+              detail: { item: { value: "delete" } },
+            }),
+          );
+          return waitForConfirmDialogActions();
+        };
+        const cancelled = await selectDelete();
+        expect(request).not.toHaveBeenCalledWith("sessions.catalog.archive", expect.anything());
+        answerConfirmDialog(cancelled, "cancel");
+        await vi.advanceTimersByTimeAsync(0);
+        expect(request).not.toHaveBeenCalledWith("sessions.catalog.archive", expect.anything());
+        request.mockClear();
+        request.mockResolvedValue(catalogList([]));
+        const actions = await selectDelete();
+        answerConfirmDialog(actions, "confirm");
+        await vi.advanceTimersByTimeAsync(0);
+        expect(request).toHaveBeenCalledWith("sessions.catalog.archive", {
+          catalogId: "codex",
+          hostId: "gateway:local",
+          threadId: "thread-1",
+          agentId: "main",
+          confirmNoOtherRunner: true,
+        });
+        expect(request.mock.calls.map(([method]) => method)).toEqual([
+          "sessions.catalog.archive",
+          "sessions.catalog.list",
+        ]);
+        expect(sidebar.querySelector('[data-session-key*="thread-1"]')).toBeNull();
+        if (open) {
+          expect(sidebar.onNavigate).toHaveBeenCalledWith("chat", {
+            pathname: "/chat",
+            search: "",
+            hash: "",
+          });
+        } else {
+          expect(sidebar.onNavigate).not.toHaveBeenCalled();
+        }
+      } finally {
+        restoreDialog();
+        vi.useRealTimers();
+      }
+    },
+  );
 });

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-terminal-owner.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-terminal-owner.ts
@@ -288,51 +288,72 @@ describe("AppSidebar catalog deletion", () => {
     },
   );
 
-  it("discards an in-flight pre-delete list and immediately requests fresh rows", async () => {
-    vi.useFakeTimers();
-    const restoreDialog = installDialogPolyfill();
-    try {
-      const result = catalogList([{ threadId: "thread-1", name: "Shared session" }]);
-      const request = vi.fn().mockResolvedValue(result);
-      const sidebar = await mountWithCatalog(result, undefined, request);
-      await vi.advanceTimersByTimeAsync(50);
-      const staleList = deferred<SessionsCatalogListResult>();
-      const archive = deferred<unknown>();
-      const freshList = deferred<SessionsCatalogListResult>();
-      request.mockClear();
-      request
-        .mockReturnValueOnce(staleList.promise)
-        .mockReturnValueOnce(archive.promise)
-        .mockReturnValueOnce(freshList.promise);
-      await vi.advanceTimersByTimeAsync(30_000);
-      expect(request.mock.calls.map(([method]) => method)).toEqual(["sessions.catalog.list"]);
+  it.each(["poll", "page"])(
+    "discards a pre-delete %s response and requests fresh rows",
+    async (source) => {
+      vi.useFakeTimers();
+      const restoreDialog = installDialogPolyfill();
+      try {
+        const result = catalogList([{ threadId: "thread-1", name: "Shared session" }]);
+        if (source === "page") {
+          result.catalogs[0]!.hosts[0]!.nextCursor = "page-2";
+        }
+        const request = vi.fn().mockResolvedValue(result);
+        const sidebar = await mountWithCatalog(result, undefined, request);
+        await vi.advanceTimersByTimeAsync(50);
+        const staleList = deferred<SessionsCatalogListResult>();
+        const archive = deferred<unknown>();
+        const freshList = deferred<SessionsCatalogListResult>();
+        request.mockClear();
+        request
+          .mockReturnValueOnce(staleList.promise)
+          .mockReturnValueOnce(archive.promise)
+          .mockReturnValueOnce(freshList.promise);
+        if (source === "page") {
+          const loadMore = sidebar.querySelector<HTMLButtonElement>(
+            '[data-session-catalog-load-more="codex"]',
+          );
+          expect(loadMore).not.toBeNull();
+          loadMore!.click();
+          await vi.advanceTimersByTimeAsync(0);
+          expect(request).toHaveBeenCalledWith("sessions.catalog.list", {
+            agentId: "main",
+            catalogId: "codex",
+            hostIds: ["gateway:local"],
+            cursors: { "gateway:local": "page-2" },
+          });
+        } else {
+          await vi.advanceTimersByTimeAsync(30_000);
+        }
+        expect(request.mock.calls.map(([method]) => method)).toEqual(["sessions.catalog.list"]);
 
-      const actions = await selectCatalogDelete(sidebar);
-      answerConfirmDialog(actions, "confirm");
-      await vi.advanceTimersByTimeAsync(0);
-      expect(request.mock.calls.map(([method]) => method)).toEqual([
-        "sessions.catalog.list",
-        "sessions.catalog.archive",
-      ]);
-      archive.resolve({});
-      await vi.advanceTimersByTimeAsync(0);
-      staleList.resolve(catalogList([{ threadId: "thread-1", name: "Stale deleted session" }]));
-      await vi.advanceTimersByTimeAsync(1);
-      await sidebar.updateComplete;
-      expect(sidebar.textContent).not.toContain("Stale deleted session");
-      expect(request.mock.calls.map(([method]) => method)).toEqual([
-        "sessions.catalog.list",
-        "sessions.catalog.archive",
-        "sessions.catalog.list",
-      ]);
+        const actions = await selectCatalogDelete(sidebar);
+        answerConfirmDialog(actions, "confirm");
+        await vi.advanceTimersByTimeAsync(0);
+        expect(request.mock.calls.map(([method]) => method)).toEqual([
+          "sessions.catalog.list",
+          "sessions.catalog.archive",
+        ]);
+        archive.resolve({});
+        await vi.advanceTimersByTimeAsync(0);
+        staleList.resolve(catalogList([{ threadId: "thread-1", name: "Stale deleted session" }]));
+        await vi.advanceTimersByTimeAsync(1);
+        await sidebar.updateComplete;
+        expect(sidebar.textContent).not.toContain("Stale deleted session");
+        expect(request.mock.calls.map(([method]) => method)).toEqual([
+          "sessions.catalog.list",
+          "sessions.catalog.archive",
+          "sessions.catalog.list",
+        ]);
 
-      freshList.resolve(catalogList([]));
-      await vi.advanceTimersByTimeAsync(0);
-      await sidebar.updateComplete;
-      expect(sidebar.querySelector('[data-session-key*="thread-1"]')).toBeNull();
-    } finally {
-      restoreDialog();
-      vi.useRealTimers();
-    }
-  });
+        freshList.resolve(catalogList([]));
+        await vi.advanceTimersByTimeAsync(0);
+        await sidebar.updateComplete;
+        expect(sidebar.querySelector('[data-session-key*="thread-1"]')).toBeNull();
+      } finally {
+        restoreDialog();
+        vi.useRealTimers();
+      }
+    },
+  );
 });

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-terminal-owner.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-terminal-owner.ts
@@ -7,7 +7,7 @@ import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/context.ts";
 import { TERMINAL_PANEL_TOGGLE_EVENT } from "../../components/panel-toggle-contract.ts";
 import { CATALOG_SESSION_CONTINUED_EVENT } from "../../lib/sessions/catalog-key.ts";
-import { createGatewayHarness, createSessions, mountSidebar } from "../app-sidebar.ts";
+import { createGatewayHarness, createSessions, deferred, mountSidebar } from "../app-sidebar.ts";
 import {
   answerConfirmDialog,
   installDialogPolyfill,
@@ -194,6 +194,22 @@ describe("AppSidebar catalog terminal ownership", () => {
   });
 });
 
+async function selectCatalogDelete(sidebar: Awaited<ReturnType<typeof mountWithCatalog>>) {
+  sidebar
+    .querySelector('[data-session-key*="thread-1"]')!
+    .dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
+  await vi.advanceTimersByTimeAsync(0);
+  const item = sidebar.querySelector('wa-dropdown-item[value="delete"]');
+  expect(item).not.toBeNull();
+  item!.dispatchEvent(
+    new CustomEvent("wa-select", {
+      bubbles: true,
+      detail: { item: { value: "delete" } },
+    }),
+  );
+  return waitForConfirmDialogActions();
+}
+
 describe("AppSidebar catalog deletion", () => {
   it.each([
     { canArchive: true, archive: true, visible: true },
@@ -233,29 +249,15 @@ describe("AppSidebar catalog deletion", () => {
         sidebar.activeRouteId = "chat";
         sidebar.onNavigate = vi.fn();
         await sidebar.updateComplete;
-        const selectDelete = async () => {
-          sidebar
-            .querySelector('[data-session-key*="thread-1"]')!
-            .dispatchEvent(new MouseEvent("contextmenu", { bubbles: true, cancelable: true }));
-          await vi.advanceTimersByTimeAsync(0);
-          const item = sidebar.querySelector('wa-dropdown-item[value="delete"]');
-          expect(item).not.toBeNull();
-          item!.dispatchEvent(
-            new CustomEvent("wa-select", {
-              bubbles: true,
-              detail: { item: { value: "delete" } },
-            }),
-          );
-          return waitForConfirmDialogActions();
-        };
-        const cancelled = await selectDelete();
+        const cancelled = await selectCatalogDelete(sidebar);
         expect(request).not.toHaveBeenCalledWith("sessions.catalog.archive", expect.anything());
         answerConfirmDialog(cancelled, "cancel");
         await vi.advanceTimersByTimeAsync(0);
         expect(request).not.toHaveBeenCalledWith("sessions.catalog.archive", expect.anything());
+        await vi.advanceTimersByTimeAsync(50);
         request.mockClear();
         request.mockResolvedValue(catalogList([]));
-        const actions = await selectDelete();
+        const actions = await selectCatalogDelete(sidebar);
         answerConfirmDialog(actions, "confirm");
         await vi.advanceTimersByTimeAsync(0);
         expect(request).toHaveBeenCalledWith("sessions.catalog.archive", {
@@ -285,4 +287,52 @@ describe("AppSidebar catalog deletion", () => {
       }
     },
   );
+
+  it("discards an in-flight pre-delete list and immediately requests fresh rows", async () => {
+    vi.useFakeTimers();
+    const restoreDialog = installDialogPolyfill();
+    try {
+      const result = catalogList([{ threadId: "thread-1", name: "Shared session" }]);
+      const request = vi.fn().mockResolvedValue(result);
+      const sidebar = await mountWithCatalog(result, undefined, request);
+      await vi.advanceTimersByTimeAsync(50);
+      const staleList = deferred<SessionsCatalogListResult>();
+      const archive = deferred<unknown>();
+      const freshList = deferred<SessionsCatalogListResult>();
+      request.mockClear();
+      request
+        .mockReturnValueOnce(staleList.promise)
+        .mockReturnValueOnce(archive.promise)
+        .mockReturnValueOnce(freshList.promise);
+      await vi.advanceTimersByTimeAsync(30_000);
+      expect(request.mock.calls.map(([method]) => method)).toEqual(["sessions.catalog.list"]);
+
+      const actions = await selectCatalogDelete(sidebar);
+      answerConfirmDialog(actions, "confirm");
+      await vi.advanceTimersByTimeAsync(0);
+      expect(request.mock.calls.map(([method]) => method)).toEqual([
+        "sessions.catalog.list",
+        "sessions.catalog.archive",
+      ]);
+      archive.resolve({});
+      await vi.advanceTimersByTimeAsync(0);
+      staleList.resolve(catalogList([{ threadId: "thread-1", name: "Stale deleted session" }]));
+      await vi.advanceTimersByTimeAsync(1);
+      await sidebar.updateComplete;
+      expect(sidebar.textContent).not.toContain("Stale deleted session");
+      expect(request.mock.calls.map(([method]) => method)).toEqual([
+        "sessions.catalog.list",
+        "sessions.catalog.archive",
+        "sessions.catalog.list",
+      ]);
+
+      freshList.resolve(catalogList([]));
+      await vi.advanceTimersByTimeAsync(0);
+      await sidebar.updateComplete;
+      expect(sidebar.querySelector('[data-session-key*="thread-1"]')).toBeNull();
+    } finally {
+      restoreDialog();
+      vi.useRealTimers();
+    }
+  });
 });

--- a/ui/src/test-helpers/app-sidebar-cases/interactions.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/interactions.ts
@@ -642,7 +642,11 @@ describe("AppSidebar catalog session rows", () => {
       };
       await menu.updateComplete;
       const items = menu.querySelectorAll<HTMLElement & { disabled: boolean }>("wa-dropdown-item");
-      expect(items).toHaveLength(2);
+      expect([...items].map((item) => item.getAttribute("value"))).toEqual([
+        "viewer",
+        "terminal",
+        "delete",
+      ]);
       expect(items[1]?.disabled).toBe(true);
       const menuButton = row.querySelector<HTMLElement>("[data-catalog-session-menu]");
       expect(menuButton).not.toBeNull();


### PR DESCRIPTION
## What Problem This Solves

Beamed sessions could not be removed from the Control UI. The sidebar row menu under **Beam** only offered "Open in OpenClaw" and "Open in terminal", so a beamed transcript stayed listed until its seven-day retention expired or the 500-entry catalog evicted it. Operators asked how to delete or archive a beam and there was no answer.

## Why This Change Was Made

The Gateway already exposes `sessions.catalog.archive` for external session catalogs, and the Codex catalog implements it, but the Beam catalog advertised `canArchive: false` and registered no hook, and no Control UI surface called the method at all.

- **Beam plugin:** the catalog now advertises `canArchive` and implements `archive` as a permanent delete of the stored row through the existing keyed plugin-state store. Unknown hosts and unknown ids fail with the same error shape the read path uses. No retention, bounds, schema, or protocol changes; the Gateway's `operator.write` authorization and parameter validation stay authoritative.
- **Control UI:** the external-session row menu gains a destructive **Delete** item, shown only when both the row's `canArchive` and the catalog's `archive` capability are true, so Claude Code and acpx rows are unchanged. Delete goes through the shared confirm dialog, calls `sessions.catalog.archive`, invalidates the catalog snapshot so an in-flight list response cannot re-show the deleted row, queues an immediate refresh behind any active request, and navigates to the plain chat route if the deleted session was open. Failures surface as a toast. Stale connection scopes abort the mutation, matching the sidebar's existing session-mutation guard.
- **Docs:** `docs/plugins/beam.md` documents deletion, that re-uploading the same `beamId` (manual skill or a still-active mirror on its next changed upload) recreates the row, and that existing continuations are unaffected.

The generic menu item also becomes the first UI surface for the Codex catalog's existing archive hook, which archives the local Codex rollout rather than erasing it. The confirm copy states that beamed sessions are deleted permanently while sessions kept by another tool are archived there and may be restorable, and asks the operator to make sure no other runner is using the session, matching the `confirmNoOtherRunner` contract.

## User Impact

Operators with `operator.write` can delete a beamed session from its sidebar row menu. Deletion is immediate and permanent. Rows from catalogs that cannot archive show no Delete item.

## Evidence

Before/after from `pnpm dev:ui:mock` with a synthetic Beam fixture (the "before" row is the same fixture with the archive capability off, which renders exactly as main does):

| Before | After |
| --- | --- |
| ![Beam row menu before: only Open in OpenClaw and Open in terminal](https://github.com/user-attachments/assets/b7fe4622-5e97-4bb4-a529-c88bf8b647f6) | ![Beam row menu after: adds a red Delete item](https://github.com/user-attachments/assets/924fdb94-60dc-4b61-ab52-8fdc869d1220) |

Confirm dialog names the session title:

![Delete confirmation dialog for a beamed session](https://github.com/user-attachments/assets/e1cd423d-debc-443d-969b-35a7d6ce9568)

- `extensions/beam/src/beam.test.ts`: new regression against the real SQLite-backed keyed store covers wrong host, unknown id, delete removes the row from list and read, and re-upload recreates it. It failed on main for the intended reason (`archive` undefined, `canArchive` false). 14 passed.
- `ui/src/components/app-sidebar.test.ts` + `app-sidebar-catalog-menu.test.ts`: Delete item gated on row and catalog capability, cancel sends no RPC, confirm sends exact `sessions.catalog.archive` params then refreshes, navigation only when the deleted session is open. 347 passed.
- `pnpm ui:i18n:baseline`, `git diff --check`, oxfmt clean. `pnpm check:changed` passes every lane except the extension lint lane, which fails in this nested worktree on the known environmental "Declaration input escapes checkout" boundary; CI is authoritative for that lane.
- ClawSweeper's two P2 findings on the first head (stale in-flight catalog snapshot after delete; permanent-deletion wording for recoverable Codex archives) are fixed in the follow-up commit with a regression covering the list-starts, delete-completes, stale-list-arrives ordering.
- Codex autoreview on the final diff: no actionable findings.

Known gap: no live Gateway run; proof is unit and mock-Gateway UI. The native apps do not expose the catalog row menu and are unchanged.
