### PR TITLE
fix(ui): read text attachments directly in Files

### DIFF
--- a/docs/web/control-ui/chat.md
+++ b/docs/web/control-ui/chat.md
@@ -152,6 +152,13 @@ Chat error banners, including cloud runner failures, show short messages in full
 
 ### Source previews and copying code
 
+Select **Open** on a text attachment to read it directly in the **Files** side
+panel. Same-origin text attachments, including pasted `.txt` files, Markdown,
+CSV, and JSON, display as selectable, read-only text with line breaks and
+indentation preserved. HTML and other markup remain literal text, never an
+embedded page. Previews require UTF-8 content no larger than 256 KiB; unsupported,
+external, oversized, or unavailable files keep their **Download** action.
+
 **View Raw Text** keeps Markdown notation literal, including nested code fences.
 Decoded text artifacts use the same literal preview. **Copy code** preserves the
 code's leading whitespace and final newline when present. Indented Markdown code

--- a/ui/src/e2e/chat-text-attachment.e2e.test.ts
+++ b/ui/src/e2e/chat-text-attachment.e2e.test.ts
@@ -1,0 +1,90 @@
+import path from "node:path";
+import { expect, it } from "vitest";
+import { createChatFlowE2eSuite, installMockGateway } from "./chat-flow.test-support.ts";
+import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+const text =
+  "Release checklist\n\nRead the attached notes without leaving the conversation.\n\n  Keep indentation and line breaks.\n  Unicode text: café 🦞\n\n<script>Displayed as text, never executed.</script>\n";
+
+suite.define(() => {
+  it.each([1280, 390])(
+    "reads a pasted text file in the side panel at %ipx and keeps download available",
+    async (width) => {
+      const context = await suite.newBrowserContext({
+        ...createControlUiE2eContextOptions(),
+        viewport: { width, height: 900 },
+      });
+      const page = await context.newPage();
+      const mediaUrl = "/__openclaw__/assistant-media?source=notes.txt&mediaTicket=text-preview";
+      let reads = 0;
+      let downloads = 0;
+      page.on("download", () => {
+        downloads += 1;
+      });
+      await page.route("**/__openclaw__/assistant-media?**", async (route) => {
+        reads += 1;
+        expect(route.request().headers().authorization).toBeUndefined();
+        await route.fulfill({
+          contentType: "text/plain; charset=utf-8",
+          headers: { "Content-Disposition": 'attachment; filename="pasted-notes.txt"' },
+          body: text,
+        });
+      });
+      const gateway = await installMockGateway(page, {
+        historyMessages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "Please review these notes." },
+              {
+                type: "attachment",
+                attachment: {
+                  kind: "document",
+                  label: "pasted-notes.txt",
+                  mimeType: "text/plain",
+                  url: mediaUrl,
+                },
+              },
+            ],
+            timestamp: Date.now(),
+          },
+        ],
+      });
+      try {
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await gateway.waitForRequest("chat.startup");
+        const card = page
+          .locator(".chat-assistant-attachment-card--compact")
+          .filter({ hasText: "pasted-notes.txt" });
+        await card
+          .getByRole("button", { name: "Open pasted-notes.txt in the side panel", exact: true })
+          .click();
+        const panel = page.locator("openclaw-chat-detail-panel:visible");
+        await panel.locator("a[download]").waitFor();
+        await page.screenshot({ path: path.join(suite.artifactDir, `text-preview-${width}.png`) });
+        await panel.locator("pre").waitFor();
+        expect(await panel.locator("pre").textContent()).toBe(text);
+        expect(await panel.locator("script, iframe").count()).toBe(0);
+        expect(downloads).toBe(0);
+        expect(reads).toBe(1);
+        expect(
+          await panel
+            .locator("pre")
+            .evaluate((element) => element.scrollWidth <= element.clientWidth),
+        ).toBe(true);
+        await page.screenshot({
+          path: path.join(suite.artifactDir, `text-preview-${width}-readable.png`),
+        });
+        const [download] = await Promise.all([
+          page.waitForEvent("download"),
+          panel.locator("a[download]").click(),
+        ]);
+        expect(download.suggestedFilename()).toBe("pasted-notes.txt");
+        expect(await download.failure()).toBeNull();
+      } finally {
+        await suite.closeBrowserContext(context);
+      }
+    },
+  );
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5712,6 +5712,8 @@ export const en: TranslationMap & {
       expand: "Open {filename} in the side panel",
       open: "Open",
       previewUnavailable: "Preview unavailable",
+      textPreviewUnavailable:
+        "Could not preview this file. Text previews require UTF-8 files up to 256 KiB. Download it to read the full file.",
       readFailed: "Could not attach: {names}{more}",
       tooLarge: "Too large to send: {names}{more}",
       showInTextField: "Show in text field",

--- a/ui/src/pages/chat/components/chat-sidebar-content.ts
+++ b/ui/src/pages/chat/components/chat-sidebar-content.ts
@@ -41,6 +41,7 @@ import "./chat-video-player.ts";
 import { openResolvedImage } from "./chat-message-image-open.ts";
 import type { AttachmentSidebarRuntime, SidebarContent } from "./chat-sidebar-content-types.ts";
 import { renderSidebarFile, type FileViewControls } from "./chat-sidebar-file-view.ts";
+import { isTextAttachment } from "./chat-text-attachment.ts";
 import "./session-diff-panel.ts";
 
 type ChatDetailPanelContent = Exclude<SidebarContent, { kind: "task" }>;
@@ -108,6 +109,15 @@ function renderSidebarAttachment(
     (content.attachmentKind === "image" || mimeType.startsWith("image/"))
   ) {
     return html`<img class="sidebar-attachment-preview__image" src=${src} alt=${content.title} />`;
+  }
+  if (isTextAttachment(mimeType, content.title) && !isCrossOriginHttpSource(src)) {
+    return html`<openclaw-chat-text-attachment
+      .src=${src}
+      .sourceIdentity=${content.sourceIdentity ?? src}
+      .label=${content.title}
+      .mimeType=${content.mimeType ?? ""}
+      .sizeBytes=${source?.sizeBytes ?? content.sizeBytes}
+    ></openclaw-chat-text-attachment>`;
   }
   return renderCompactAttachmentCard({
     kind: content.attachmentKind ?? "document",

--- a/ui/src/pages/chat/components/chat-sidebar.test.ts
+++ b/ui/src/pages/chat/components/chat-sidebar.test.ts
@@ -509,8 +509,8 @@ describe("markdown sidebar", () => {
 
   it.each([
     ["external.html", "https://files.example/external.html", "text/html"],
-    ["preview.html", "/__openclaw__/media/preview.html", "text/html"],
-    ["wide.csv", "/__openclaw__/media/wide.csv", "text/csv"],
+    ["external.txt", "https://files.example/external.txt", "text/plain"],
+    ["bundle.zip", "/__openclaw__/media/bundle.zip", "application/zip"],
     ["brief.pdf", "/__openclaw__/media/brief.pdf", "application/pdf"],
   ] as const)(
     "renders document %s as a Files card without previewing it",

--- a/ui/src/pages/chat/components/chat-text-attachment.test.ts
+++ b/ui/src/pages/chat/components/chat-text-attachment.test.ts
@@ -1,0 +1,201 @@
+/* @vitest-environment jsdom */
+
+import { afterEach, expect, it, vi } from "vitest";
+import type { SidebarContent } from "./chat-sidebar-content-types.ts";
+import "./chat-sidebar.ts";
+
+async function mountAttachment(
+  overrides: Partial<Extract<SidebarContent, { kind: "attachment" }>> = {},
+) {
+  const panel = document.createElement("openclaw-chat-detail-panel") as HTMLElement & {
+    content: SidebarContent;
+    updateComplete: Promise<unknown>;
+  };
+  panel.content = {
+    kind: "attachment",
+    attachmentKind: "document",
+    title: "notes.txt",
+    src: "/__openclaw__/assistant-media?mediaTicket=text-preview",
+    mimeType: "text/plain",
+    ...overrides,
+  };
+  document.body.append(panel);
+  await panel.updateComplete;
+  return panel;
+}
+
+afterEach(() => {
+  document.body.replaceChildren();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+});
+
+it("reads a text attachment in Files without downloading or interpreting its contents", async () => {
+  const text = "Pasted notes 🦞\n  preserve indentation\n<script>not executable</script>\n";
+  const fetchMock = vi.fn<typeof fetch>().mockResolvedValue(new Response(text));
+  vi.stubGlobal("fetch", fetchMock);
+  const panel = await mountAttachment();
+
+  await vi.waitFor(() => expect(panel.querySelector("pre")?.textContent).toBe(text));
+  expect(panel.querySelector("script, iframe, textarea")).toBeNull();
+  expect(panel.querySelector<HTMLAnchorElement>("a[download]")?.getAttribute("href")).toBe(
+    "/__openclaw__/assistant-media?mediaTicket=text-preview",
+  );
+  expect(fetchMock).toHaveBeenCalledOnce();
+  expect(new Headers(fetchMock.mock.calls[0]?.[1]?.headers).has("Authorization")).toBe(false);
+});
+
+it.each([
+  ["notes.md", "text/markdown; charset=utf-8", "# literal Markdown\n"],
+  ["preview.html", "text/html", "<h1>literal HTML</h1>"],
+  ["rows.csv", "text/csv", "name,status\nalpha,ready\n"],
+  ["settings.json", "application/json", '{"ready":true}\n'],
+  ["config.xml", "application/xml", "<ready>true</ready>"],
+  ["notes.txt", "application/octet-stream", "Text with generic metadata"],
+  ["empty.txt", "", ""],
+])("previews %s as literal text", async (title, mimeType, text) => {
+  vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(new Response(text)));
+  const panel = await mountAttachment({ title, mimeType });
+  await vi.waitFor(() => expect(panel.querySelector("pre")?.textContent).toBe(text));
+  expect(panel.querySelector("iframe, h1, table")).toBeNull();
+});
+
+it.each([
+  { title: "notes.txt", mimeType: "application/pdf" },
+  { title: "archive.bin", mimeType: "application/octet-stream" },
+  { title: "notes.txt", src: "https://files.example/notes.txt" },
+])("does not fetch unsupported or external documents: $title $mimeType $src", async (content) => {
+  const fetchMock = vi.fn<typeof fetch>();
+  vi.stubGlobal("fetch", fetchMock);
+  const panel = await mountAttachment(content);
+  expect(panel.querySelector("pre")).toBeNull();
+  expect(panel.querySelector("a[download]")).not.toBeNull();
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+
+it("declines a known oversized text file without fetching", async () => {
+  const fetchMock = vi.fn<typeof fetch>();
+  vi.stubGlobal("fetch", fetchMock);
+  const panel = await mountAttachment({ sizeBytes: 256 * 1024 + 1 });
+  await vi.waitFor(() => expect(panel.textContent).toContain("Download it to read the full file"));
+  expect(fetchMock).not.toHaveBeenCalled();
+});
+
+it.each(["advertised", "streamed"])(
+  "cancels %s oversized responses and preserves download",
+  async (sizeSource) => {
+    const cancel = vi.fn();
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.enqueue(new Uint8Array(256 * 1024 + 1));
+        },
+        cancel,
+      }),
+      { headers: sizeSource === "advertised" ? { "Content-Length": "262145" } : {} },
+    );
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(response));
+    const panel = await mountAttachment();
+    await vi.waitFor(() =>
+      expect(panel.textContent).toContain("Download it to read the full file"),
+    );
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(panel.querySelector("pre")).toBeNull();
+    expect(panel.querySelector("a[download]")).not.toBeNull();
+  },
+);
+
+it.each([new Uint8Array([0xff]), new Uint8Array([0x61, 0x00, 0x62])])(
+  "does not lossily decode non-text bytes",
+  async (bytes) => {
+    vi.stubGlobal("fetch", vi.fn<typeof fetch>().mockResolvedValue(new Response(bytes)));
+    const panel = await mountAttachment();
+    await vi.waitFor(() =>
+      expect(panel.textContent).toContain("Download it to read the full file"),
+    );
+    expect(panel.querySelector("pre")).toBeNull();
+  },
+);
+
+it("shows a download fallback for an unavailable response", async () => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn<typeof fetch>().mockResolvedValue(new Response("denied", { status: 403 })),
+  );
+  const panel = await mountAttachment();
+  await vi.waitFor(() => expect(panel.textContent).toContain("Download it to read the full file"));
+  expect(panel.querySelector("pre")).toBeNull();
+});
+
+it("aborts a superseded read and never displays its late contents", async () => {
+  let resolveOld!: (response: Response) => void;
+  const fetchMock = vi
+    .fn<typeof fetch>()
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOld = resolve;
+        }),
+    )
+    .mockResolvedValueOnce(new Response("Current file"));
+  vi.stubGlobal("fetch", fetchMock);
+  const panel = await mountAttachment();
+  await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+  const signal = fetchMock.mock.calls[0]?.[1]?.signal;
+  panel.content = {
+    kind: "attachment",
+    title: "next.txt",
+    src: "/next.txt",
+    mimeType: "text/plain",
+  };
+  await vi.waitFor(() => expect(panel.querySelector("pre")?.textContent).toBe("Current file"));
+  expect(signal?.aborted).toBe(true);
+  resolveOld(new Response("Old file"));
+  await vi.waitFor(() => expect(fetchMock.mock.settledResults[0]?.type).toBe("fulfilled"));
+  await panel.querySelector("openclaw-chat-text-attachment")?.updateComplete;
+  expect(panel.querySelector("pre")?.textContent).toBe("Current file");
+});
+
+it("aborts a closed preview and reloads it after remount", async () => {
+  const fetchMock = vi
+    .fn<typeof fetch>()
+    .mockImplementationOnce(
+      (_input, init) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener("abort", () =>
+            reject(new DOMException("Aborted", "AbortError")),
+          );
+        }),
+    )
+    .mockResolvedValueOnce(new Response("Reloaded text"));
+  vi.stubGlobal("fetch", fetchMock);
+  const panel = await mountAttachment();
+  await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
+  panel.remove();
+  expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
+  document.body.append(panel);
+  await vi.waitFor(() => expect(panel.querySelector("pre")?.textContent).toBe("Reloaded text"));
+});
+
+it("times out even when a response stalls while reading its body", async () => {
+  vi.useFakeTimers();
+  vi.stubGlobal(
+    "fetch",
+    vi.fn<typeof fetch>().mockImplementation(
+      async (_input, init) =>
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              init?.signal?.addEventListener("abort", () =>
+                controller.error(new DOMException("Aborted", "AbortError")),
+              );
+            },
+          }),
+        ),
+    ),
+  );
+  const panel = await mountAttachment();
+  await vi.advanceTimersByTimeAsync(10_000);
+  expect(panel.textContent).toContain("Download it to read the full file");
+  expect(panel.querySelector("pre")).toBeNull();
+});

--- a/ui/src/pages/chat/components/chat-text-attachment.ts
+++ b/ui/src/pages/chat/components/chat-text-attachment.ts
@@ -1,0 +1,142 @@
+import { html, type PropertyValues } from "lit";
+import { property, state } from "lit/decorators.js";
+import { t } from "../../../i18n/index.ts";
+import { OpenClawLightDomContentsElement } from "../../../lit/openclaw-element.ts";
+import { renderCompactAttachmentCard } from "./chat-attachment-card.ts";
+import { readResponseBytesWithinLimit } from "./chat-response-bytes.ts";
+
+const TEXT_PREVIEW_MAX_BYTES = 256 * 1024;
+const TEXT_PREVIEW_TIMEOUT_MS = 10_000;
+
+export function isTextAttachment(mimeType: string, filename: string): boolean {
+  if (mimeType.startsWith("text/")) {
+    return true;
+  }
+  if (
+    /^application\/(?:(?:[\w.-]+\+)?(?:json|xml)|javascript|x-javascript|yaml|x-yaml)$/.test(
+      mimeType,
+    )
+  ) {
+    return true;
+  }
+  return (
+    (!mimeType || mimeType === "application/octet-stream") &&
+    /\.(?:txt|md|markdown|log|csv|tsv|json|jsonl|xml|yaml|yml)$/i.test(filename)
+  );
+}
+
+class ChatTextAttachment extends OpenClawLightDomContentsElement {
+  @property() src = "";
+  @property() sourceIdentity = "";
+  @property() label = "";
+  @property() mimeType = "";
+  @property({ type: Number }) sizeBytes: number | undefined;
+
+  @state() private text: string | null = null;
+  @state() private failed = false;
+
+  private loadVersion = 0;
+  private abortController: AbortController | undefined;
+
+  override connectedCallback(): void {
+    super.connectedCallback();
+    this.requestUpdate("src");
+  }
+
+  override disconnectedCallback(): void {
+    this.cancelLoad();
+    super.disconnectedCallback();
+  }
+
+  override willUpdate(changed: PropertyValues<this>): void {
+    if (changed.has("src") || changed.has("sourceIdentity") || changed.has("sizeBytes")) {
+      this.cancelLoad();
+      this.text = null;
+      this.failed = false;
+      void this.loadText();
+    }
+  }
+
+  private cancelLoad(): void {
+    this.loadVersion += 1;
+    this.abortController?.abort();
+    this.abortController = undefined;
+  }
+
+  private async loadText(): Promise<void> {
+    if (this.sizeBytes !== undefined && this.sizeBytes > TEXT_PREVIEW_MAX_BYTES) {
+      this.failed = true;
+      return;
+    }
+    const version = this.loadVersion;
+    const controller = new AbortController();
+    this.abortController = controller;
+    const timeout = setTimeout(() => controller.abort(), TEXT_PREVIEW_TIMEOUT_MS);
+    try {
+      // The caller supplies a resolved media ticket or blob, never a reusable credential.
+      const response = await fetch(this.src, {
+        credentials: "same-origin",
+        redirect: "error",
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        await response.body?.cancel();
+        throw new Error("Text attachment unavailable");
+      }
+      const bytes = await readResponseBytesWithinLimit(response, TEXT_PREVIEW_MAX_BYTES);
+      if (!bytes) {
+        throw new Error("Text attachment exceeds preview limit");
+      }
+      const text = new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+      if (text.includes("\0")) {
+        throw new Error("Binary attachment");
+      }
+      if (version === this.loadVersion && this.isConnected) {
+        this.text = text;
+      }
+    } catch {
+      if (version === this.loadVersion && this.isConnected) {
+        this.failed = true;
+      }
+    } finally {
+      clearTimeout(timeout);
+      if (this.abortController === controller) {
+        this.abortController = undefined;
+      }
+    }
+  }
+
+  override render() {
+    return html`
+      ${renderCompactAttachmentCard({
+        kind: "document",
+        label: this.label,
+        mimeType: this.mimeType,
+        sizeBytes: this.sizeBytes,
+        downloadHref: this.src,
+      })}
+      ${
+        this.failed
+          ? html`<p class="muted" role="status">${t("chat.attachments.textPreviewUnavailable")}</p>`
+          : this.text === null
+            ? html`<p class="muted" role="status">${t("common.loading")}</p>`
+            : html`<pre
+                class="sidebar-attachment-preview__text"
+                tabindex="0"
+                aria-label=${this.label}
+              >
+${this.text}</pre>`
+      }
+    `;
+  }
+}
+
+if (!customElements.get("openclaw-chat-text-attachment")) {
+  customElements.define("openclaw-chat-text-attachment", ChatTextAttachment);
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "openclaw-chat-text-attachment": ChatTextAttachment;
+  }
+}

--- a/ui/src/styles/chat/sidebar.css
+++ b/ui/src/styles/chat/sidebar.css
@@ -1409,6 +1409,21 @@ openclaw-session-discussion {
   min-height: 0;
 }
 
+.sidebar-attachment-preview__text {
+  min-width: 0;
+  margin: 16px 0 0;
+  padding: 16px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  color: var(--text);
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.6;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  tab-size: 4;
+}
+
 .sidebar-attachment-preview__image {
   display: block;
   width: 100%;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening a pasted text attachment in chat would see only another download card in the Files side panel. Reading a small `.txt` attachment required downloading it first.

## Why This Change Was Made

The attachment panel already owns image/audio/video previews but sent every document to its download-only fallback. It now reads supported same-origin or blob text attachments through a bounded, read-only text component, preserving the existing media-ticket resolver and explicit Download action.

Contents render literally with whitespace preserved; HTML is never embedded or executed. The reader enforces a 256 KiB limit on both metadata and streamed bytes, requires valid UTF-8 without NUL bytes, times out stalled reads, and aborts/ignores superseded or disconnected reads. Unsupported or external documents keep the existing download-only behavior. No Gateway permissions, media response headers, configuration, dependencies, or persistent state change.

## User Impact

Click **Open** on a pasted `.txt` file and read/select its contents inside Files without leaving the conversation. Markdown, CSV, JSON, XML, and other supported text formats also have a literal preview. Download remains available, including when a preview cannot be shown. Text wraps within desktop and phone-sized panels.

## Evidence

- Regression reproduced before the renderer change: the focused text-preview test failed because no text was rendered; the built Control UI E2E failed at both 1280 px and 390 px after opening the download-only Files card.
- 112 focused unit tests passed across attachment rendering, sidebar behavior, bounded reads, literal decoding, cancellation, remounts, and download fallbacks.
- 11 built Control UI E2E tests passed across the new desktop/mobile preview flow and existing media-file flows. They verify that Open makes no download, sends no bearer credential, preserves exact text, and that explicit Download still succeeds.
- `node scripts/check-changed.mjs` passed, including core-test/UI typechecking, formatting, i18n verification, dead-export scans, lint, and styles. The initial run caught a missing DOM test type annotation; the corrected run passed.
- Independent Codex autoreview: no actionable P0–P2 findings.
- Before/after captures below contain only synthetic test fixtures. Browser proof uses the mocked Gateway; the reported production team server was not restarted or deployed.
- Maintainer-side visual inspection completed for all three linked captures: before is download-only; desktop and phone after-captures show readable, correctly wrapped literal text with the Download control retained. This resolves the screenshot-retrieval limitation noted in the [ClawSweeper review](https://github.com/openclaw/openclaw/pull/141469#issuecomment-5574790866). A supplemental manual Browser-pane interaction with the real source component also confirmed the text and Download control.
- The initial [hosted run](https://github.com/openclaw/openclaw/actions/runs/34154348181/job/101843091026) failed solely on an unrelated current-main `eslint(max-lines)` error in `ui/src/components/markdown.test.ts` (1011 lines). The unrelated limit failure was resolved on main by [#141466](https://github.com/openclaw/openclaw/pull/141466) in `7a1f677e3cb5d4882c0cff0d76dd4af196c27c58`, which relocated the streaming Markdown tests without weakening the limit. This PR was mechanically rebased onto that repaired main; all eight files retain the identical introduced changes. Fresh exact-head [hosted CI](https://github.com/openclaw/openclaw/actions/runs/34156207274) passed on attempt 2. Attempt 1 hit an unrelated `spawn ETXTBSY` while starting a node-host timeout-test fixture; one same-run failed-job rerun passed without any code, timeout, assertion, or baseline change.

![Before: opening a text attachment shows only Download](https://github.com/user-attachments/assets/0817125d-2ebb-4b8f-bbef-be9467f44760)

![After: text is readable directly in Files](https://github.com/user-attachments/assets/353df966-57d2-44bc-b345-48ce9683bd0d)

![After: readable text at phone width](https://github.com/user-attachments/assets/6b4567a2-8996-446f-99e6-914264154968)

