### PR TITLE
refactor(e2e): exercise the production log-tail limit

### DIFF
--- a/scripts/e2e/parallels/filesystem.ts
+++ b/scripts/e2e/parallels/filesystem.ts
@@ -4,7 +4,7 @@ import { access, mkdir, open, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { repoRoot } from "./host-command.ts";
 
-const DEFAULT_TEXT_FILE_TAIL_BYTES = 4 * 1024 * 1024;
+const TEXT_FILE_TAIL_BYTES = 4 * 1024 * 1024;
 const OPENCLAW_VERSION_PATTERN = /OpenClaw\s+([0-9][^\s]*)/gi;
 
 export async function exists(filePath: string): Promise<boolean> {
@@ -20,17 +20,14 @@ export async function readJson<T>(filePath: string): Promise<T> {
   return JSON.parse(await readFile(filePath, "utf8")) as T;
 }
 
-async function readTextFileTail(
-  filePath: string,
-  maxBytes = DEFAULT_TEXT_FILE_TAIL_BYTES,
-): Promise<string> {
+async function readTextFileTail(filePath: string): Promise<string> {
   const file = await open(filePath, "r").catch(() => null);
   if (!file) {
     return "";
   }
   try {
     const stats = await file.stat();
-    const start = Math.max(0, stats.size - maxBytes);
+    const start = Math.max(0, stats.size - TEXT_FILE_TAIL_BYTES);
     const length = stats.size - start;
     if (length <= 0) {
       return "";
@@ -46,9 +43,8 @@ async function readTextFileTail(
 export async function extractLastOpenClawVersionFromLog(
   logPath: string,
   pattern = OPENCLAW_VERSION_PATTERN,
-  maxBytes = DEFAULT_TEXT_FILE_TAIL_BYTES,
 ): Promise<string> {
-  const text = await readTextFileTail(logPath, maxBytes);
+  const text = await readTextFileTail(logPath);
   const flags = pattern.flags.includes("g") ? pattern.flags : `${pattern.flags}g`;
   const globalPattern = new RegExp(pattern.source, flags);
   return [...text.matchAll(globalPattern)].at(-1)?.[1] ?? "";

--- a/test/scripts/parallels-smoke-model.test.ts
+++ b/test/scripts/parallels-smoke-model.test.ts
@@ -494,11 +494,11 @@ describe("Parallels smoke model selection", () => {
   it("extracts the last OpenClaw version from a bounded log tail", async () => {
     const tempDir = makeTempDir(tempDirs, "openclaw-parallels-log-tail-");
     const logPath = join(tempDir, "phase.log");
-    writeFileSync(logPath, ["OpenClaw 0.0.1", "x".repeat(4096), "OpenClaw 2026.6.7"].join("\n"));
+    writeFileSync(logPath, ["OpenClaw 0.0.1", "x".repeat(4 * 1024 * 1024)].join("\n"));
+    await expect(extractLastOpenClawVersionFromLog(logPath)).resolves.toBe("");
 
-    await expect(extractLastOpenClawVersionFromLog(logPath, undefined, 128)).resolves.toBe(
-      "2026.6.7",
-    );
+    writeFileSync(logPath, "\nOpenClaw 2026.6.6\nOpenClaw 2026.6.7", { flag: "a" });
+    await expect(extractLastOpenClawVersionFromLog(logPath)).resolves.toBe("2026.6.7");
   });
 
   it("keeps the public shell entrypoints as thin TypeScript launchers", () => {


### PR DESCRIPTION
## What Problem This Solves

The Parallels version-log test would pass even if the bounded reader scanned the entire file. Its custom 128-byte test setting also kept size parameters that no smoke workflow uses.

## Why This Change Was Made

Use the existing 4 MiB limit directly and strengthen the same case: a stale version outside the tail must not be selected, then two appended versions must select the latest. The fixture sets its boundary independently of the implementation constant.

The asynchronous reader still owns the positional read, returned-byte decoding and file closure. Linux's custom version pattern, other platform callers and existing error behavior remain unchanged. The separate synchronous diagnostic reader has different error and UTF-8 contracts and remains separate.

Tooling: +4/-8 (net -4). Tests: +4/-4 (net zero), with no case removed. This is a maintainer-requested test-seam cleanup; it does not claim a user-facing regression fix.

## User Impact

Normal smoke summaries and the 4 MiB version scan are unchanged. Maintainers get coverage that detects unbounded version selection without a test-only size override.

## Evidence

- Before and after: four selected cases pass, with the same complete 114-case inventory and 110 unselected cases retained.
- Sensitivity control: intentionally reading from offset zero passes the old test, but fails the strengthened test on stale `0.0.1` versus the expected empty result. The control was removed and the final candidate passes.
- The strengthened case uses a real local file and took about 5 ms in the focused run. It proves suffix exclusion and latest-match selection; it does not instrument allocations, every threshold, short reads or concurrent rotation.
- Independent Codex review is clean through P2. No VM or provider execution is claimed for this internal file-reader refactor.

Focused command:

```sh
node scripts/run-vitest.mjs test/scripts/parallels-smoke-model.test.ts test/scripts/e2e-text-file-utils.test.ts -t 'extracts the last OpenClaw version from a bounded log tail|e2e text file utilities'
```

The normal changed gate passed all 19 checks, including both TypeScript graphs and scoped lint, on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/34153897256). The one-shot runner stopped successfully; its isolated checkout and recorded local processes are gone.

### CI recovery on current main

Rebased cleanly onto main `ccd3a4414e5f941665679172d5e9f83a8a3ae14f`, producing `1703a9aab5e69a2ae09cc920b5d148d6944dd140`. The two-file patch is unchanged in behavior. Fresh proof: **114 tests across both complete test files pass**, as do scoped oxlint on 64 changed/main-overlap/control paths, formatting, static guards, script erasability and `git diff --check`. Fresh independent Codex P2 review is clean. Local scripts typechecking refuses the nested shared dependency installation; [exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/34176035064) passed, including the aggregate required gate.

The earlier line-limit failure belonged to stale main files; no unrelated markdown changes were added here. The data-model compatibility checklist remains inapplicable: JSON readers/writers, summary serialization, temporary directory creation and stored representations are unchanged. The existing [maintainer source qualification](https://github.com/openclaw/openclaw/pull/141470#issuecomment-5577090825) documents that conclusion. No VM execution is claimed for unchanged workflow behavior.
