### PR TITLE
fix(agents): honor exec allowlists for Claude native Bash

### DIFF
--- a/docs/gateway/cli-backends.md
+++ b/docs/gateway/cli-backends.md
@@ -167,7 +167,7 @@ the field and retry. Invalid questions do not prompt the user. If the user
 skips a valid question, Claude instead continues with its best judgment.
 
 When the effective exec ask setting is `on-miss` or `always`, OpenClaw relays
-native or extension tool requests as interactive approvals to the session's
+native or extension tool requests that need approval to the session's
 channel: **Allow once** permits the single call, **Allow always** permits that
 tool name for the same warm live session while each subsequent turn's policy
 and available tools still allow it, and **Deny**, a timeout, an unreachable
@@ -175,6 +175,37 @@ approval route, or a closed turn all deny the call. Grants stay in memory, end
 when that exact live session is replaced, and never apply to Bash. Policies
 that never prompt keep their existing behavior: `security: "deny"` rejects
 every request, and ask `off` with less than full security denies without asking.
+
+### Native Bash and the exec allowlist
+
+With `ask: "on-miss"`, the `claude-cli` backend checks native `Bash` commands
+against the agent's [exec allowlist](/tools/exec-approvals). For example:
+
+```bash
+openclaw approvals allowlist add --agent main /usr/local/bin/gog
+```
+
+OpenClaw reuses its exec shell evaluator and allows a call without prompting
+only when every command segment resolves to an explicitly allowlisted binary
+and can be fully classified and bound. Executables may be absolute paths or
+resolved through the CLI launch PATH with the agent's configured exec PATH
+prepends; approved input pins the
+resolved executable paths. Successful matches update allowlist usage metadata.
+Bindable misses prompt with the first unmatched segment or classification
+reason. Commands the approval binding guard cannot bind, including pipelines,
+command substitutions, subshells, write redirections, and unparsable syntax,
+remain denied before a prompt. Environment-prefix overrides, shell expansions,
+and `eval`/`exec`/`source` wrappers do not auto-allow.
+
+`ask: "always"` still prompts for allowlisted commands. `security: "deny"`
+still denies, and `ask: "off"` keeps the behavior described above. **Allow
+always** remains unavailable for Bash, and truncated Bash approval descriptions
+still fail closed.
+
+This is argument-level policy applied to the command Claude Code will run,
+not sandboxed execution by OpenClaw. Claude Code owns cwd, PATH, environment,
+and sandboxing. Use a [paired node](/nodes) or the embedded runtime with
+[sandboxing](/gateway/sandboxing) when sandboxed execution is required.
 
 ### Claude browser tools and 1Password sign-in
 

--- a/docs/tools/exec-approvals.md
+++ b/docs/tools/exec-approvals.md
@@ -39,6 +39,12 @@ Exec approvals are enforced locally on the execution host:
 - **Gateway host** -> `openclaw` process on the gateway machine.
 - **Node host** -> node runner (macOS companion app or headless node host).
 
+The `claude-cli` backend also checks native Bash commands against the agent's
+exec allowlist when `ask: "on-miss"`. This authorizes command arguments while
+Claude Code owns execution; it does not provide OpenClaw sandboxing. See
+[Native Bash and the exec allowlist](/gateway/cli-backends#native-bash-and-the-exec-allowlist)
+for matching, prompting, and binding restrictions.
+
 ### Trust model
 
 - Gateway-authenticated callers are trusted operators for that Gateway.

--- a/extensions/anthropic/cli-runtime.test-support.ts
+++ b/extensions/anthropic/cli-runtime.test-support.ts
@@ -195,7 +195,7 @@ for await (const line of createInterface({ input: process.stdin })) {
       privateContext = response.hookSpecificOutput?.additionalContext;
       request("pre-" + turn, { subtype: "hook_callback",
         callback_id: hooks.PreToolUse[0].hookCallbackIds[0], tool_use_id: "tool-" + turn,
-        input: { hook_event_name: "PreToolUse", tool_name: scenario === "user-question" ? "AskUserQuestion" : scenario === "mcp-hook" ? "mcp__openclaw__message" : "Read",
+        input: { cwd: process.cwd(), hook_event_name: "PreToolUse", tool_name: scenario === "user-question" ? "AskUserQuestion" : scenario === "mcp-hook" ? "mcp__openclaw__message" : "Read",
           tool_input: scenario === "user-question" ? questionInput : { file_path: "fixture.txt" },
           tool_use_id: "tool-" + turn } });
     } else if (id === "pre-" + turn) {

--- a/extensions/anthropic/cli-runtime.test.ts
+++ b/extensions/anthropic/cli-runtime.test.ts
@@ -481,7 +481,11 @@ describe("Claude native stdio boundary", () => {
     expect(handle?.isIdle()).toBe(true);
     expect(context.requestToolPermission).toHaveBeenCalledTimes(4);
     expect(context.requestToolPermission).toHaveBeenCalledWith(
-      expect.objectContaining({ toolName: "Read", toolInput: { file_path: "fixture.txt" } }),
+      expect.objectContaining({
+        cwd: context.cwd,
+        toolName: "Read",
+        toolInput: { file_path: "fixture.txt" },
+      }),
     );
   });
 

--- a/extensions/anthropic/cli.runtime.ts
+++ b/extensions/anthropic/cli.runtime.ts
@@ -81,6 +81,7 @@ async function authorizeTool(
         : await turn.context.requestToolPermission({
             toolName,
             toolInput: input,
+            cwd: typeof request.cwd === "string" ? request.cwd : undefined,
             toolCallId: toolUseId,
             abortSignal,
           });
@@ -137,6 +138,7 @@ async function handleRequest(
       {
         tool_name: input.tool_name,
         input: input.tool_input,
+        cwd: input.cwd,
         tool_use_id: request.tool_use_id ?? input.tool_use_id,
       },
       signal,

--- a/src/agents/cli-runner/cli-native-tool-approval.test.ts
+++ b/src/agents/cli-runner/cli-native-tool-approval.test.ts
@@ -3,6 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  makeExecutable,
+  makeExecApprovalsTempDir,
+} from "../../infra/exec-approvals-test-helpers.js";
+import { loadExecApprovals, saveExecApprovals } from "../../infra/exec-approvals.js";
+import {
   DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS,
   PLUGIN_APPROVAL_DETAIL_MAX_LENGTH,
 } from "../../infra/plugin-approvals.js";
@@ -20,6 +25,7 @@ vi.mock("../tools/gateway.js", () => ({
 const mockCallGatewayTool = vi.mocked(callGatewayTool);
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   mockCallGatewayTool.mockReset();
   vi.restoreAllMocks();
   vi.useRealTimers();
@@ -43,6 +49,142 @@ describe("resolveCliNativeToolApprovalPlan", () => {
 });
 
 describe("requestCliNativeToolApproval", () => {
+  it.each(["gog calendar list", "absolute"])(
+    "auto-allows and records an allowlisted native command: %s",
+    async (input) => {
+      const dir = makeExecApprovalsTempDir();
+      vi.stubEnv("OPENCLAW_STATE_DIR", dir);
+      const binary = makeExecutable(dir, "gog");
+      saveExecApprovals({ version: 1, agents: { main: { allowlist: [{ pattern: binary }] } } });
+      const command = input === "absolute" ? `${binary} calendar list` : input;
+      const outcome = await requestCliNativeToolApproval({
+        toolName: "Bash",
+        toolInput: { command },
+        pluginId: "claude-cli",
+        agentId: "main",
+        cwd: dir,
+        env: { PATH: dir },
+        ask: "on-miss",
+      });
+      expect(outcome).toMatchObject({ kind: "allow", grantAlways: false });
+      expect(mockCallGatewayTool).not.toHaveBeenCalled();
+      expect(loadExecApprovals().agents?.main?.allowlist?.[0]).toMatchObject({
+        lastUsedCommand: command,
+        lastUsedAt: expect.any(Number),
+      });
+    },
+  );
+
+  it.each([
+    ["gog calendar list | missing-binary", "pipeline", false],
+    ["gog | gog", "pipeline", false],
+    ["gog $(date)", "command-substitution", false],
+    ["gog '", "syntax-error", false],
+    ["MODE=test gog", "MODE=test gog", true],
+    ["gog > output.txt", "redirect", false],
+    ["(gog)", "subshell", false],
+    ["exec gog", "exec", true],
+    ["gog *", "shell expansion", true],
+  ])(
+    "keeps the binding guard and explains allowlist misses for %s",
+    async (command, reason, prompts) => {
+      const dir = makeExecApprovalsTempDir();
+      vi.stubEnv("OPENCLAW_STATE_DIR", dir);
+      const binary = makeExecutable(dir, "gog");
+      saveExecApprovals({ version: 1, agents: { main: { allowlist: [{ pattern: binary }] } } });
+      mockCallGatewayTool.mockResolvedValueOnce({ id: "native-miss", decision: "deny" });
+      const outcome = await requestCliNativeToolApproval({
+        toolName: "Bash",
+        toolInput: { command },
+        pluginId: "claude-cli",
+        agentId: "main",
+        cwd: dir,
+        env: { PATH: dir },
+        ask: "on-miss",
+      });
+      if (prompts) {
+        expect(mockCallGatewayTool.mock.calls[0]?.[2]).toMatchObject({
+          description: expect.stringContaining(reason),
+          allowedDecisions: ["allow-once", "deny"],
+        });
+      } else {
+        expect(mockCallGatewayTool).not.toHaveBeenCalled();
+        expect(outcome).toMatchObject({
+          kind: "deny",
+          reason: "operand-binding",
+          message: expect.stringContaining(reason),
+        });
+      }
+      expect(loadExecApprovals().agents?.main?.allowlist?.[0]?.lastUsedAt).toBeUndefined();
+    },
+  );
+
+  it("still prompts for an allowlisted Bash command when ask is always", async () => {
+    const dir = makeExecApprovalsTempDir();
+    vi.stubEnv("OPENCLAW_STATE_DIR", dir);
+    const binary = makeExecutable(dir, "gog");
+    saveExecApprovals({ version: 1, agents: { main: { allowlist: [{ pattern: binary }] } } });
+    mockCallGatewayTool.mockResolvedValueOnce({ id: "always", decision: "allow-once" });
+    expect(
+      await requestCliNativeToolApproval({
+        toolName: "Bash",
+        toolInput: { command: `${binary} calendar list` },
+        pluginId: "claude-cli",
+        agentId: "main",
+        cwd: dir,
+        ask: "always",
+      }),
+    ).toEqual({ kind: "allow", grantAlways: false });
+    expect(mockCallGatewayTool.mock.calls[0]?.[2]).toMatchObject({
+      allowedDecisions: ["allow-once", "deny"],
+    });
+    expect(loadExecApprovals().agents?.main?.allowlist?.[0]?.lastUsedAt).toBeUndefined();
+  });
+
+  it("binds manual approval to the native PATH when exec prepends differ", async () => {
+    const dir = makeExecApprovalsTempDir();
+    const nativeDir = makeExecApprovalsTempDir();
+    vi.stubEnv("OPENCLAW_STATE_DIR", dir);
+    makeExecutable(dir, "gog");
+    const nativeBinary = makeExecutable(nativeDir, "gog");
+    saveExecApprovals({ version: 1, agents: { main: { allowlist: [] } } });
+    mockCallGatewayTool.mockImplementationOnce(async () => {
+      fs.writeFileSync(nativeBinary, "changed during approval");
+      return { id: "path-drift", decision: "allow-once" };
+    });
+    expect(
+      await requestCliNativeToolApproval({
+        toolName: "Bash",
+        toolInput: { command: "gog" },
+        pluginId: "claude-cli",
+        agentId: "main",
+        cwd: dir,
+        ask: "on-miss",
+        env: { PATH: dir },
+        bindingEnv: { PATH: nativeDir },
+      }),
+    ).toMatchObject({ kind: "deny", reason: "operand-binding" });
+  });
+
+  it("rechecks current grants before recording an auto-allow", async () => {
+    const dir = makeExecApprovalsTempDir();
+    vi.stubEnv("OPENCLAW_STATE_DIR", dir);
+    const binary = makeExecutable(dir, "gog");
+    saveExecApprovals({ version: 1, agents: { main: { allowlist: [{ pattern: binary }] } } });
+    const outcome = await requestCliNativeToolApproval({
+      toolName: "Bash",
+      toolInput: { command: binary },
+      pluginId: "claude-cli",
+      agentId: "main",
+      cwd: dir,
+      ask: "on-miss",
+      assertActive: () => saveExecApprovals({ version: 1, agents: { main: { allowlist: [] } } }),
+    });
+    expect(outcome).toEqual({ kind: "deny", reason: "unavailable" });
+    expect(loadExecApprovals().agents?.main?.allowlist).toEqual([]);
+    expect(mockCallGatewayTool).not.toHaveBeenCalled();
+  });
+
   it("registers and waits for a matching approval decision", async () => {
     mockCallGatewayTool
       .mockResolvedValueOnce({ id: "approval-1", status: "pending" })
@@ -72,7 +214,7 @@ describe("requestCliNativeToolApproval", () => {
         agentId: "main",
         sessionKey: "agent:main:main",
         title: "claude-cli native tool: Bash",
-        description: '{"command":"ls"}',
+        description: '{"command":"ls"}\nExec allowlist miss: ls',
         detail: '{"command":"ls"}',
         severity: "warning",
         allowedDecisions: ["allow-once", "deny"],

--- a/src/agents/cli-runner/cli-native-tool-approval.ts
+++ b/src/agents/cli-runner/cli-native-tool-approval.ts
@@ -1,9 +1,19 @@
 import { addTimerTimeoutGraceMs } from "@openclaw/normalization-core/number-coercion";
+import { logVerbose } from "../../globals.js";
+import { racePromiseWithAbortSignal } from "../../infra/abort-signal.js";
 import {
   exceedsApprovalTextLimit,
   sanitizeExecApprovalWarningTextWithStatus,
 } from "../../infra/exec-approval-text-sanitize.js";
-import type { ExecAsk, ExecSecurity } from "../../infra/exec-approvals.js";
+import { evaluateShellAllowlistWithAuthorization } from "../../infra/exec-approvals-allowlist.js";
+import {
+  loadExecApprovals,
+  recordAllowlistMatchesUse,
+  resolveExecApprovalsFromFile,
+  type ExecAsk,
+  type ExecSecurity,
+} from "../../infra/exec-approvals.js";
+import { buildAuthorizedShellCommandFromPlan } from "../../infra/exec-authorization-render.js";
 import {
   DEFAULT_PLUGIN_APPROVAL_TIMEOUT_MS,
   PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH,
@@ -18,10 +28,8 @@ import {
 import { sliceUtf16Safe, truncateUtf16Safe } from "../../utils.js";
 import { callGatewayTool } from "../tools/gateway.js";
 
-type CliNativeToolApprovalPlan = "allow" | "deny" | "prompt";
-type CliNativeToolApprovalDecision = "allow-once" | "allow-always" | "deny";
 type CliNativeToolApprovalOutcome =
-  | { kind: "allow"; grantAlways: boolean }
+  | { kind: "allow"; grantAlways: boolean; updatedInput?: Record<string, unknown> }
   | {
       kind: "deny";
       reason: "operand-binding" | "policy-oversized" | "user" | "unavailable";
@@ -33,17 +41,6 @@ const CLI_NATIVE_TOOL_DESCRIPTION_TAIL_CHARS = 80;
 const CLI_NATIVE_TOOL_DESCRIPTION_MAX_CHARS =
   CLI_NATIVE_TOOL_DESCRIPTION_HEAD_CHARS + CLI_NATIVE_TOOL_DESCRIPTION_TAIL_CHARS;
 const CLI_NATIVE_TOOL_APPROVAL_GATEWAY_GRACE_MS = 10_000;
-const CLI_NATIVE_TOOL_ALLOWED_DECISIONS = [
-  "allow-once",
-  "allow-always",
-  "deny",
-] as const satisfies readonly CliNativeToolApprovalDecision[];
-// A standing grant must never be minted from a partially displayed input, so
-// oversized inputs offer one-shot decisions only.
-const CLI_NATIVE_TOOL_TRUNCATED_DECISIONS = [
-  "allow-once",
-  "deny",
-] as const satisfies readonly CliNativeToolApprovalDecision[];
 // Bash is arbitrary shell execution, so a name-wide grant is unrestricted.
 // Bash fails closed when even the reviewer-only detail cannot show the complete input.
 const CLI_NATIVE_TOOL_ARBITRARY_EXECUTION_TOOL = "Bash";
@@ -51,7 +48,7 @@ const CLI_NATIVE_TOOL_ARBITRARY_EXECUTION_TOOL = "Bash";
 export function resolveCliNativeToolApprovalPlan(execPermission: {
   security: ExecSecurity;
   ask: ExecAsk;
-}): CliNativeToolApprovalPlan {
+}): "allow" | "deny" | "prompt" {
   if (execPermission.security === "deny") {
     return "deny";
   }
@@ -89,72 +86,6 @@ function formatCliNativeToolDescription(
   };
 }
 
-function formatCliNativeToolTitle(pluginId: string, toolName: string): string {
-  return truncateUtf16Safe(
-    `${pluginId} native tool: ${toolName}`,
-    PLUGIN_APPROVAL_TITLE_MAX_LENGTH,
-  );
-}
-
-function resolveCliNativeToolAllowedDecisions(params: {
-  ask: ExecAsk;
-  toolName: string;
-  descriptionTruncated: boolean;
-}): readonly CliNativeToolApprovalDecision[] {
-  return params.ask === "always" ||
-    params.toolName === CLI_NATIVE_TOOL_ARBITRARY_EXECUTION_TOOL ||
-    params.descriptionTruncated
-    ? CLI_NATIVE_TOOL_TRUNCATED_DECISIONS
-    : CLI_NATIVE_TOOL_ALLOWED_DECISIONS;
-}
-
-function toAbortError(reason: unknown): Error {
-  return reason instanceof Error ? reason : new Error("CLI native tool approval aborted");
-}
-
-async function raceCliNativeToolApprovalAbort<T>(
-  promise: Promise<T>,
-  abortSignal: AbortSignal | undefined,
-): Promise<T> {
-  if (!abortSignal) {
-    return promise;
-  }
-  let onAbort: (() => void) | undefined;
-  const abortPromise = new Promise<never>((_, reject) => {
-    if (abortSignal.aborted) {
-      reject(toAbortError(abortSignal.reason));
-      return;
-    }
-    onAbort = () => reject(toAbortError(abortSignal.reason));
-    abortSignal.addEventListener("abort", onAbort, { once: true });
-  });
-  try {
-    return await Promise.race([promise, abortPromise]);
-  } finally {
-    if (onAbort) {
-      abortSignal.removeEventListener("abort", onAbort);
-    }
-  }
-}
-
-function waitForCliNativeToolApproval(params: {
-  id: string;
-  gatewayTimeoutMs: number;
-  abortSignal?: AbortSignal;
-}): Promise<{ id?: string; decision?: unknown }> {
-  return raceCliNativeToolApprovalAbort(
-    callGatewayTool(
-      "plugin.approval.waitDecision",
-      { timeoutMs: params.gatewayTimeoutMs },
-      { id: params.id },
-      // Abort must reach the RPC too, or the gateway keeps the approval prompt
-      // live for its full timeout after the admitted CLI run already ended.
-      { signal: params.abortSignal },
-    ),
-    params.abortSignal,
-  );
-}
-
 export async function requestCliNativeToolApproval(params: {
   toolName: string;
   toolInput: Record<string, unknown>;
@@ -163,6 +94,10 @@ export async function requestCliNativeToolApproval(params: {
   agentId?: string;
   toolCallId?: string;
   cwd?: string;
+  fallbackCwd?: string;
+  env?: NodeJS.ProcessEnv;
+  bindingEnv?: NodeJS.ProcessEnv;
+  assertActive?: () => void;
   abortSignal?: AbortSignal;
   ask: ExecAsk;
 }): Promise<CliNativeToolApprovalOutcome> {
@@ -172,11 +107,6 @@ export async function requestCliNativeToolApproval(params: {
       addTimerTimeoutGraceMs(timeoutMs, CLI_NATIVE_TOOL_APPROVAL_GATEWAY_GRACE_MS) ??
       timeoutMs + CLI_NATIVE_TOOL_APPROVAL_GATEWAY_GRACE_MS;
     const description = formatCliNativeToolDescription(params.toolInput);
-    const detail = truncatePluginApprovalDetail(description.compact);
-    const detailSanitization =
-      params.toolName === CLI_NATIVE_TOOL_ARBITRARY_EXECUTION_TOOL
-        ? sanitizeExecApprovalWarningTextWithStatus(description.compact)
-        : null;
     // Sanitization escapes control/bidi characters into longer visible
     // sequences, so a short raw command can still overflow the 512-char
     // description bound after sanitization and get truncated at render time.
@@ -191,8 +121,6 @@ export async function requestCliNativeToolApproval(params: {
     if (
       params.toolName === CLI_NATIVE_TOOL_ARBITRARY_EXECUTION_TOOL &&
       (description.truncated ||
-        detailSanitization?.truncated === true ||
-        detailSanitization?.oversized === true ||
         summarySanitization?.truncated === true ||
         summarySanitization?.oversized === true ||
         (summarySanitization &&
@@ -208,29 +136,118 @@ export async function requestCliNativeToolApproval(params: {
       typeof params.toolInput.command === "string"
         ? params.toolInput.command
         : undefined;
+    let autoAllow: (() => CliNativeToolApprovalOutcome) | undefined;
+    if (
+      params.ask === "on-miss" &&
+      params.pluginId === "claude-cli" &&
+      bashCommand &&
+      params.agentId
+    ) {
+      const file = loadExecApprovals();
+      const { allowlist } = resolveExecApprovalsFromFile({ file, agentId: params.agentId });
+      const analysis = await evaluateShellAllowlistWithAuthorization({
+        command: bashCommand,
+        allowlist,
+        safeBins: new Set(),
+        cwd: params.cwd,
+        env: params.env,
+      });
+      const plan = analysis.authorizationPlan;
+      const candidates = plan?.groups.flatMap((group) => group.candidates) ?? [];
+      const miss = candidates.findIndex(
+        (candidate, index) =>
+          candidate.transport.kind !== "direct" ||
+          candidate.trustMode !== "executable" ||
+          !candidate.sourceSegment.resolution?.execution.resolvedPath ||
+          candidate.sourceSegment.resolution.wrapperChain?.length ||
+          analysis.segmentSatisfiedBy[index] !== "allowlist",
+      );
+      const rendered =
+        plan?.ok && params.cwd && candidates.length > 0 && miss === -1
+          ? buildAuthorizedShellCommandFromPlan({
+              plan,
+              mode: "enforced",
+              segmentSatisfiedBy: analysis.segmentSatisfiedBy,
+            })
+          : {
+              ok: false as const,
+              reason:
+                plan && !plan.ok
+                  ? plan.reason
+                  : (candidates[miss]?.sourceStep.text ?? "no classified executable"),
+            };
+      if (rendered.ok) {
+        autoAllow = () => {
+          params.abortSignal?.throwIfAborted();
+          params.assertActive?.();
+          // Require current grants even when the caller policy is full with prompting.
+          recordAllowlistMatchesUse({
+            approvals: file,
+            agentId: params.agentId,
+            matches: analysis.allowlistMatches,
+            command: bashCommand,
+            resolvedPath:
+              candidates[0]?.sourceSegment.resolution?.execution.resolvedPath ?? undefined,
+            authorization: {
+              source: "current-policy",
+              security: "allowlist",
+              ask: params.ask,
+              allowlistSatisfied: true,
+            },
+          });
+          logVerbose("Claude CLI native Bash auto-allowed via exec allowlist");
+          return {
+            kind: "allow",
+            grantAlways: false,
+            updatedInput: { ...params.toolInput, command: rendered.command },
+          };
+        };
+      } else {
+        const reason = sanitizeExecApprovalWarningTextWithStatus(rendered.reason).text;
+        description.text += `\nExec allowlist miss: ${truncateUtf16Safe(reason, 100)}`;
+      }
+    }
     let mutableFileBinding: SystemRunMutableFileBinding | undefined;
     if (params.toolName === CLI_NATIVE_TOOL_ARBITRARY_EXECUTION_TOOL) {
       // Bind script bytes before the out-of-band approval wait. Text-identical
       // Bash input can otherwise execute a rewritten file after approval.
       const prepared = await prepareSystemRunMutableFileBinding({
         command: { kind: "shell", text: bashCommand ?? "" },
-        cwd: params.cwd,
+        cwd: params.cwd ?? params.fallbackCwd,
+        env: autoAllow ? params.env : (params.bindingEnv ?? params.env),
       });
       if (!prepared.ok) {
-        return { kind: "deny", reason: "operand-binding", message: prepared.message };
+        return {
+          kind: "deny",
+          reason: "operand-binding",
+          message: sanitizeExecApprovalWarningTextWithStatus(
+            `${prepared.message}\n${description.text}`,
+          ).text,
+        };
       }
       mutableFileBinding = prepared.binding.operands.length > 0 ? prepared.binding : undefined;
     }
-    const allowedDecisions = resolveCliNativeToolAllowedDecisions({
-      ask: params.ask,
-      toolName: params.toolName,
-      descriptionTruncated: description.truncated,
-    });
-    const requestResult: {
-      id?: string;
-      decision?: unknown;
-    } = await raceCliNativeToolApprovalAbort(
-      callGatewayTool(
+    if (autoAllow) {
+      return autoAllow();
+    }
+    if (
+      bashCommand &&
+      exceedsApprovalTextLimit(
+        sanitizeExecApprovalWarningTextWithStatus(description.text).text,
+        PLUGIN_APPROVAL_DESCRIPTION_MAX_LENGTH,
+      )
+    ) {
+      return { kind: "deny", reason: "policy-oversized" };
+    }
+    // Standing grants require a complete description and never cover arbitrary Bash.
+    const allowedDecisions =
+      params.ask === "always" ||
+      params.toolName === CLI_NATIVE_TOOL_ARBITRARY_EXECUTION_TOOL ||
+      description.truncated
+        ? ["allow-once", "deny"]
+        : ["allow-once", "allow-always", "deny"];
+    const requestResult = await racePromiseWithAbortSignal(
+      callGatewayTool<{ id?: string; decision?: unknown }>(
         "plugin.approval.request",
         { timeoutMs: gatewayTimeoutMs },
         {
@@ -239,9 +256,12 @@ export async function requestCliNativeToolApproval(params: {
           toolCallId: params.toolCallId,
           agentId: params.agentId,
           sessionKey: params.sessionKey,
-          title: formatCliNativeToolTitle(params.pluginId, params.toolName),
+          title: truncateUtf16Safe(
+            `${params.pluginId} native tool: ${params.toolName}`,
+            PLUGIN_APPROVAL_TITLE_MAX_LENGTH,
+          ),
           description: description.text,
-          detail,
+          detail: truncatePluginApprovalDetail(description.compact),
           severity: "warning",
           allowedDecisions,
           timeoutMs,
@@ -259,11 +279,16 @@ export async function requestCliNativeToolApproval(params: {
     if (Object.hasOwn(requestResult ?? {}, "decision")) {
       decision = requestResult.decision;
     } else {
-      const waitResult = await waitForCliNativeToolApproval({
-        id,
-        gatewayTimeoutMs,
-        abortSignal: params.abortSignal,
-      });
+      // Abort must cancel the RPC so the Gateway removes the pending prompt.
+      const waitResult = await racePromiseWithAbortSignal(
+        callGatewayTool<{ id?: string; decision?: unknown }>(
+          "plugin.approval.waitDecision",
+          { timeoutMs: gatewayTimeoutMs },
+          { id },
+          { signal: params.abortSignal },
+        ),
+        params.abortSignal,
+      );
       decision = waitResult?.id === id ? waitResult.decision : undefined;
     }
     if (params.abortSignal?.aborted) {
@@ -274,22 +299,19 @@ export async function requestCliNativeToolApproval(params: {
       // spawn, so reject bytes that changed during the approval wait.
       const binding = await revalidateSystemRunMutableFileBinding({
         binding: mutableFileBinding,
-        cwd: params.cwd,
+        cwd: params.cwd ?? params.fallbackCwd,
       });
       if (!binding.ok) {
         return { kind: "deny", reason: "operand-binding", message: binding.message };
       }
     }
-    if (decision === "allow-once") {
-      return { kind: "allow", grantAlways: false };
+    if (
+      decision === "allow-once" ||
+      (decision === "allow-always" && allowedDecisions.includes(decision))
+    ) {
+      return { kind: "allow", grantAlways: decision === "allow-always" };
     }
-    if (decision === "allow-always" && allowedDecisions.includes(decision)) {
-      return { kind: "allow", grantAlways: true };
-    }
-    if (decision === "deny") {
-      return { kind: "deny", reason: "user" };
-    }
-    return { kind: "deny", reason: "unavailable" };
+    return { kind: "deny", reason: decision === "deny" ? "user" : "unavailable" };
   } catch {
     return { kind: "deny", reason: "unavailable" };
   }

--- a/src/agents/cli-runner/execute-plugin-native-bash.test.ts
+++ b/src/agents/cli-runner/execute-plugin-native-bash.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  makeExecutable,
+  makeExecApprovalsTempDir,
+} from "../../infra/exec-approvals-test-helpers.js";
+import { loadExecApprovals, saveExecApprovals } from "../../infra/exec-approvals.js";
+import type { CliBackendToolPermissionResult } from "../../plugins/cli-backend.types.js";
+import { callGatewayTool } from "../tools/gateway.js";
+import {
+  closePluginTestAdmissions,
+  createExecution,
+  runPlugin,
+  SUCCESS_RESULT,
+} from "./execute-plugin.test-support.js";
+
+vi.mock("../tools/gateway.js", () => ({ callGatewayTool: vi.fn() }));
+const mockCallGatewayTool = vi.mocked(callGatewayTool);
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  closePluginTestAdmissions();
+  mockCallGatewayTool.mockReset();
+});
+
+describe("native Bash execution policy", () => {
+  it.each([
+    ["allowlist", "on-miss", "allow"],
+    ["deny", "on-miss", "deny"],
+    ["allowlist", "off", "deny"],
+  ] as const)(
+    "applies %s/%s to native Bash with configured PATH",
+    async (security, ask, behavior) => {
+      const dir = makeExecApprovalsTempDir();
+      vi.stubEnv("OPENCLAW_STATE_DIR", dir);
+      const binary = makeExecutable(dir, "gog");
+      saveExecApprovals({ version: 1, agents: { main: { allowlist: [{ pattern: binary }] } } });
+      const { context } = await createExecution({
+        config: { tools: { exec: { security, ask, pathPrepend: [dir] } } },
+        nativeTools: ["Bash"],
+      });
+      let decision: CliBackendToolPermissionResult | undefined;
+      await runPlugin(context, async function* (execution) {
+        decision = await execution.requestToolPermission({
+          toolName: "Bash",
+          toolInput: { command: "gog calendar list" },
+          cwd: dir,
+        });
+        yield SUCCESS_RESULT;
+      });
+      expect(decision?.behavior).toBe(behavior);
+      expect(mockCallGatewayTool).not.toHaveBeenCalled();
+      if (decision?.behavior === "allow") {
+        expect(decision.updatedInput?.command).toContain(binary);
+        expect(loadExecApprovals().agents?.main?.allowlist?.[0]?.lastUsedAt).toEqual(
+          expect.any(Number),
+        );
+      } else {
+        expect(loadExecApprovals().agents?.main?.allowlist?.[0]?.lastUsedAt).toBeUndefined();
+      }
+    },
+  );
+});

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -2,11 +2,6 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import {
-  makeExecutable,
-  makeExecApprovalsTempDir,
-} from "../../infra/exec-approvals-test-helpers.js";
-import { loadExecApprovals, saveExecApprovals } from "../../infra/exec-approvals.js";
 import type {
   CliBackendExecute,
   CliBackendExecuteContext,
@@ -73,7 +68,6 @@ function waitUntilAborted(execution: CliBackendExecuteContext): Promise<void> {
 }
 
 afterEach(() => {
-  vi.unstubAllEnvs();
   for (const session of activeSessions) {
     session.close("restart");
   }
@@ -543,43 +537,6 @@ describe("plugin-owned CLI execution host boundary", () => {
     }
     expect(mockCallGatewayTool).not.toHaveBeenCalled();
   });
-
-  it.each([
-    ["allowlist", "on-miss", "allow"],
-    ["deny", "on-miss", "deny"],
-    ["allowlist", "off", "deny"],
-  ] as const)(
-    "applies %s/%s to native Bash with configured PATH",
-    async (security, ask, behavior) => {
-      const dir = makeExecApprovalsTempDir();
-      vi.stubEnv("OPENCLAW_STATE_DIR", dir);
-      const binary = makeExecutable(dir, "gog");
-      saveExecApprovals({ version: 1, agents: { main: { allowlist: [{ pattern: binary }] } } });
-      const { context } = await createExecution({
-        config: { tools: { exec: { security, ask, pathPrepend: [dir] } } },
-        nativeTools: ["Bash"],
-      });
-      let decision: CliBackendToolPermissionResult | undefined;
-      await runPlugin(context, async function* (execution) {
-        decision = await execution.requestToolPermission({
-          toolName: "Bash",
-          toolInput: { command: "gog calendar list" },
-          cwd: dir,
-        });
-        yield SUCCESS_RESULT;
-      });
-      expect(decision?.behavior).toBe(behavior);
-      expect(mockCallGatewayTool).not.toHaveBeenCalled();
-      if (decision?.behavior === "allow") {
-        expect(decision.updatedInput?.command).toContain(binary);
-        expect(loadExecApprovals().agents?.main?.allowlist?.[0]?.lastUsedAt).toEqual(
-          expect.any(Number),
-        );
-      } else {
-        expect(loadExecApprovals().agents?.main?.allowlist?.[0]?.lastUsedAt).toBeUndefined();
-      }
-    },
-  );
 
   it("fails closed for unnamed and unavailable native tools before requesting approval", async () => {
     const { context } = await createExecution({ nativeTools: ["Read"] });

--- a/src/agents/cli-runner/execute-plugin.test.ts
+++ b/src/agents/cli-runner/execute-plugin.test.ts
@@ -2,6 +2,11 @@ import { SYSTEM_PROMPT_CACHE_BOUNDARY } from "@openclaw/ai/internal/shared";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  makeExecutable,
+  makeExecApprovalsTempDir,
+} from "../../infra/exec-approvals-test-helpers.js";
+import { loadExecApprovals, saveExecApprovals } from "../../infra/exec-approvals.js";
 import type {
   CliBackendExecute,
   CliBackendExecuteContext,
@@ -68,6 +73,7 @@ function waitUntilAborted(execution: CliBackendExecuteContext): Promise<void> {
 }
 
 afterEach(() => {
+  vi.unstubAllEnvs();
   for (const session of activeSessions) {
     session.close("restart");
   }
@@ -537,6 +543,43 @@ describe("plugin-owned CLI execution host boundary", () => {
     }
     expect(mockCallGatewayTool).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ["allowlist", "on-miss", "allow"],
+    ["deny", "on-miss", "deny"],
+    ["allowlist", "off", "deny"],
+  ] as const)(
+    "applies %s/%s to native Bash with configured PATH",
+    async (security, ask, behavior) => {
+      const dir = makeExecApprovalsTempDir();
+      vi.stubEnv("OPENCLAW_STATE_DIR", dir);
+      const binary = makeExecutable(dir, "gog");
+      saveExecApprovals({ version: 1, agents: { main: { allowlist: [{ pattern: binary }] } } });
+      const { context } = await createExecution({
+        config: { tools: { exec: { security, ask, pathPrepend: [dir] } } },
+        nativeTools: ["Bash"],
+      });
+      let decision: CliBackendToolPermissionResult | undefined;
+      await runPlugin(context, async function* (execution) {
+        decision = await execution.requestToolPermission({
+          toolName: "Bash",
+          toolInput: { command: "gog calendar list" },
+          cwd: dir,
+        });
+        yield SUCCESS_RESULT;
+      });
+      expect(decision?.behavior).toBe(behavior);
+      expect(mockCallGatewayTool).not.toHaveBeenCalled();
+      if (decision?.behavior === "allow") {
+        expect(decision.updatedInput?.command).toContain(binary);
+        expect(loadExecApprovals().agents?.main?.allowlist?.[0]?.lastUsedAt).toEqual(
+          expect.any(Number),
+        );
+      } else {
+        expect(loadExecApprovals().agents?.main?.allowlist?.[0]?.lastUsedAt).toBeUndefined();
+      }
+    },
+  );
 
   it("fails closed for unnamed and unavailable native tools before requesting approval", async () => {
     const { context } = await createExecution({ nativeTools: ["Read"] });

--- a/src/agents/cli-runner/execute-plugin.ts
+++ b/src/agents/cli-runner/execute-plugin.ts
@@ -3,6 +3,7 @@ import { clampPositiveTimerTimeoutMs } from "@openclaw/normalization-core/number
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { toErrorObject } from "../../infra/errors.js";
 import { resolveExecutablePath } from "../../infra/executable-path.js";
+import { mergePathPrepend } from "../../infra/path-prepend.js";
 import { BLOCKED_TOOL_CALL_ABORT_FLOOR_MS } from "../../logging/diagnostic-run-activity.js";
 import type {
   CliBackendExecute,
@@ -19,6 +20,7 @@ import { FailoverError, isSignalTimeoutReason } from "../failover-error.js";
 import { withAgentQuestionAnswerAuthority } from "../harness/host-private-capabilities.js";
 import { runStructuredInput } from "../harness/structured-input-execution.js";
 import { compileStructuredInputQuestions } from "../harness/structured-input.js";
+import { resolveExecToolConfig } from "../lazy-exec-tool.js";
 import { recordAgentCleanupFailure } from "../run-cleanup-timeout.js";
 import { resolveToolLoopDetectionConfig } from "../tool-loop-detection-config.js";
 import { normalizeToolPolicyName } from "../tool-policy.js";
@@ -47,6 +49,7 @@ function createPluginToolPermissionHandler(params: {
   context: PreparedCliRunContext;
   abortSignal: AbortSignal;
   onPendingApproval: (delta: 1 | -1) => void;
+  env: NodeJS.ProcessEnv;
 }): (request: CliBackendToolPermissionRequest) => Promise<CliBackendToolPermissionResult> {
   const run = params.context.params;
   const permission = resolveExecDefaults({
@@ -216,7 +219,17 @@ function createPluginToolPermissionHandler(params: {
         sessionKey: run.sessionKey,
         agentId: run.agentId,
         toolCallId: request.toolCallId,
-        cwd: params.context.cwd ?? params.context.workspaceDir,
+        cwd: request.cwd,
+        fallbackCwd: params.context.cwd ?? params.context.workspaceDir,
+        bindingEnv: params.env,
+        env: {
+          ...params.env,
+          PATH: mergePathPrepend(
+            params.env.PATH,
+            resolveExecToolConfig({ cfg: run.config, agentId: run.agentId }).pathPrepend ?? [],
+          ),
+        },
+        assertActive,
         abortSignal: signal,
         ask: permission.ask,
       });
@@ -241,7 +254,7 @@ function createPluginToolPermissionHandler(params: {
     if (outcome.grantAlways) {
       currentGrants.add(toolName);
     }
-    return { behavior: "allow", updatedInput: toolInput };
+    return { behavior: "allow", updatedInput: outcome.updatedInput ?? toolInput };
   };
 }
 
@@ -582,6 +595,7 @@ export async function executePluginOwnedProcess(params: {
         context: params.context,
         abortSignal: signal,
         onPendingApproval: updatePendingApproval,
+        env: params.env,
       }),
       requestUserInput: createPluginUserInputHandler({
         context: params.context,

--- a/src/plugins/cli-backend.types.ts
+++ b/src/plugins/cli-backend.types.ts
@@ -168,6 +168,8 @@ export type CliBackendToolAvailability = {
 
 /** Native action a plugin-owned runtime asks the admitted host run to authorize. */
 export type CliBackendToolPermissionRequest = {
+  /** Actual working directory reported by the native permission hook. */
+  cwd?: string;
   toolName: string;
   toolInput: Record<string, unknown>;
   toolCallId?: string;


### PR DESCRIPTION
Related: #140473. Reported by @docfernando.

## What Problem This Solves

Fixes an issue where operators using the Claude CLI backend had to approve every native Bash invocation even after allowlisting the binary for their agent. This blocked unattended CLI automation.

## Why This Change Was Made

The native permission path previously considered only exec security and ask settings. It now reuses the exec shell evaluator, authorization renderer, and current-grant usage recorder. With `ask: on-miss`, fully classified commands whose binaries explicitly match the agent allowlist can auto-allow; the returned native input pins the resolved executable paths. Actual hook cwd and configured exec PATH prepends participate in evaluation. Manual approvals retain the native launch environment for file binding.

The existing binding owner still denies pipelines, substitutions, subshells, write redirections, and unparseable commands before prompting. Bindable misses explain the first unmatched segment or classification failure. `ask: always`, `security: deny`, ask-off policy, Bash allow-always refusal, description bounds, and current run authority remain enforced.

Ordinary sessions continue to use native Bash. The mediated exec seam remains scoped to its existing restricted runs. This is argument-level policy for the command Claude Code runs; cwd, environment, PATH, and sandboxing remain Claude Code's. Use a paired node or the embedded runtime with sandboxing when sandboxed execution is required.

## User Impact

Operators can use an existing per-agent exec allowlist for unattended native Bash calls under `ask: on-miss`. Commands requiring manual approval still offer only allow-once or deny for Bash. Both CLI-backend and exec-approval documentation describe the boundary.

## Evidence

- Pre-fix synthetic regression: an explicitly allowlisted absolute executable returned deny/unavailable through the unfulfilled approval path instead of auto-allowing.
- Focused tests: 105 passed across native approval, execution-host permission, and Claude native runtime suites. Covers absolute/PATH matches, configured PATH prepends, usage metadata, mandatory prompting, pipeline/binding denials, grant revocation, native executable drift, and cwd forwarding.
- Production delta: +160/-120, net +40. Tests and test support: +211/-3, net +208. Docs: +38/-1, net +37.
- Independent Codex autoreview: scoped-clean at P0–P2, including the test-file split.
- `node scripts/check-changed.mjs` and `git diff --check`: PASS. The changed gate includes formatting, core/plugin and test typechecks, lint, max-lines and other repository guards, and dead-export scans.
- Refreshed candidate head: `d5c905919abca6a6720aea8e17bfa46eef6800e8`. This is a patch-identical rebase onto repaired main; `git range-diff` reports both original commits unchanged. The focused tests, live proof, and independent review above were performed before that mechanical rebase; the refreshed head passed [required hosted CI](https://github.com/openclaw/openclaw/actions/runs/34156194807/job/101850292203).

The live proof used an isolated state directory, fresh loopback Gateway, and the committed production build through `node openclaw.mjs`. The API-key profile existed before startup and was explicitly selected for the CLI route. A diagnostic preload observed credential-fingerprint creation and the API-key FD selection without logging credentials or changing the returned values. The first probe omitted the client approvals capability; after correcting that fixture, both real native Bash calls completed with the expected policy outcomes. No operator Gateway was touched.

Sanitized Gateway/probe excerpts:

```text
{"event":"Claude credential prepared","fingerprintPresent":true}
2026-09-07T12:01:25.721-07:00 Claude CLI native Bash auto-allowed via exec allowlist
2026-09-07T12:01:31.963-07:00 [ws] → event plugin.approval.requested seq=per-client clients=2 targets=1 dropIfSlow=true
ALLOWLISTED_TURN {"status":"ok","text":["2026"],"tools":{"calls":1,"tools":["Bash"],"failures":0},"authMode":"auth-profile"}
APPROVAL_REQUEST {"phase":"non-allowlisted","title":"claude-cli native tool: Bash","description":"{\"command\":\"/usr/bin/uname -s\",\"description\":\"Print kernel name\"}\nExec allowlist miss: /usr/bin/uname -s","allowedDecisions":["allow-once","deny"]}
NON_ALLOWLISTED_TURN {"status":"ok","text":["It didn't run — the command was denied. Per your instructions I won't retry."],"tools":{"calls":1,"tools":["Bash"],"failures":1}}
SAW_MISS_APPROVAL true
```

Root-cause owner: `src/agents/cli-runner/cli-native-tool-approval.ts`; effective policy and PATH composition: `src/agents/cli-runner/execute-plugin.ts`. Hook cwd comes from `extensions/anthropic/cli.runtime.ts`. This deliberately reuses existing evaluator/renderer/binding owners rather than introducing another parser or exposing mediated local exec to ordinary CLI sessions.

Focused proof command (105 passed):

```sh
node scripts/run-vitest.mjs src/agents/cli-runner/cli-native-tool-approval.test.ts src/agents/cli-runner/execute-plugin.test.ts src/agents/cli-runner/execute-plugin-native-bash.test.ts extensions/anthropic/cli-runtime.test.ts
```

The original hosted run was blocked by [check-lint-core-2](https://github.com/openclaw/openclaw/actions/runs/34154363280/job/101843157073): an unrelated main-file max-lines failure in `ui/src/components/markdown.test.ts`. That guard was repaired on main by #141466 in `7a1f677e3cb5d4882c0cff0d76dd4af196c27c58`. Verified the landed split preserves all original suite bodies, passes all 115 Markdown tests and changed-file lint, and remains below the unchanged 1,000-line limit. The parallel focused repair #141486 was closed as superseded. This PR was then rebased without patch changes to obtain fresh exact-head CI evidence.

Native prepare and merge completed successfully. Landed as `e57e375a40266b93fd1c9e66b9f0dc03da7d368a`; main ancestry and all ten landed file contents were verified before closing #140473.
