### PR TITLE
fix(subagents): completion can fail when requester key is unscoped

### DIFF
--- a/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle-announce-cleanup.ts
@@ -1,6 +1,7 @@
 import { getGatewayContextResolver } from "../../../plugins/runtime/gateway-request-scope.js";
 import { defaultRuntime } from "../../../runtime.js";
 import { normalizeDeliveryContext } from "../../../utils/delivery-context.shared.js";
+import { resolveSubagentRequesterAgentId } from "../../subagent-requester-owner.js";
 import {
   ensureCompletionState,
   ensureDeliveryState,
@@ -544,6 +545,7 @@ export const startSubagentAnnounceCleanupFlow = (
     childSessionKey: pendingPayload.childSessionKey,
     childRunId: pendingPayload.childRunId,
     requesterSessionKey: pendingPayload.requesterSessionKey,
+    requesterAgentId: resolveSubagentRequesterAgentId(params.getRuntimeConfig(), entry),
     requesterOrigin,
     requesterDisplayKey: pendingPayload.requesterDisplayKey,
     task: pendingPayload.task,

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -736,6 +736,33 @@ describe("subagent registry lifecycle hardening", () => {
     );
   });
 
+  it("hands announce dispatch the durable requester agent id on a multi-agent roster", async () => {
+    // Two agents and no default marker: resolveDefaultAgentId cannot pick one, so any
+    // consumer that re-derives the requester owner instead of reading the persisted
+    // one throws AGENT_SELECTION_REQUIRED. Spawn already captured the owner, so
+    // dispatch has to carry it.
+    const cfg = { agents: { list: [{ id: "alpha" }, { id: "beta" }] } };
+    const entry = createRunEntry({
+      expectsCompletionMessage: true,
+      // Unscoped on purpose: nothing downstream can parse the owner out of this key.
+      requesterSessionKey: "main",
+      requesterAgentId: "beta",
+    });
+    const runSubagentAnnounceFlow = vi.fn(
+      async (_announceParams: { requesterAgentId?: string }) => "delivered" as AnnounceFlowOutcome,
+    );
+    const controller = createLifecycleController({
+      entry,
+      getRuntimeConfig: () => cfg,
+      runSubagentAnnounceFlow,
+    });
+
+    await completeRun(controller, entry, { triggerCleanup: true });
+    await waitForLifecycleState(() => expect(runSubagentAnnounceFlow).toHaveBeenCalledOnce());
+
+    expect(runSubagentAnnounceFlow.mock.calls[0]?.[0]?.requesterAgentId).toBe("beta");
+  });
+
   it("merges late visible reply evidence into an already-terminal completion", async () => {
     const entry = createRunEntry({ expectsCompletionMessage: true });
     const captureSubagentCompletionReply = vi.fn(async () => "legacy fallback");

--- a/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
+++ b/src/agents/subagents/registry/subagent-registry-lifecycle.test.ts
@@ -737,14 +737,9 @@ describe("subagent registry lifecycle hardening", () => {
   });
 
   it("hands announce dispatch the durable requester agent id on a multi-agent roster", async () => {
-    // Two agents and no default marker: resolveDefaultAgentId cannot pick one, so any
-    // consumer that re-derives the requester owner instead of reading the persisted
-    // one throws AGENT_SELECTION_REQUIRED. Spawn already captured the owner, so
-    // dispatch has to carry it.
-    const cfg = { agents: { list: [{ id: "alpha" }, { id: "beta" }] } };
+    const cfg = { agents: { ownership: "explicit" as const, entries: { alpha: {}, beta: {} } } };
     const entry = createRunEntry({
       expectsCompletionMessage: true,
-      // Unscoped on purpose: nothing downstream can parse the owner out of this key.
       requesterSessionKey: "main",
       requesterAgentId: "beta",
     });

--- a/test/pr141480-requester-agent-id-proof.e2e.test.ts
+++ b/test/pr141480-requester-agent-id-proof.e2e.test.ts
@@ -1,0 +1,455 @@
+// E2E proof for PR #141480: on a real multi-agent Gateway, a subagent completion
+// is delivered to the requester agent that spawn recorded, even when the requester
+// session key carries no agent segment.
+//
+// The failure this pins: completion dispatch used to build its announce parameters
+// without the captured requesterAgentId, so announce re-derived the owner from the
+// unscoped key alone, reached default agent selection on a two-agent roster, and
+// threw AGENT_SELECTION_REQUIRED into a catch that leaves the run retryable.
+import { readFile } from "node:fs/promises";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { writeSubagentSessionEntry } from "../src/agents/subagents/registry/subagent-registry.persistence.test-support.js";
+import {
+  loadSubagentRegistryFromSqlite,
+  saveSubagentRegistryToSqlite,
+} from "../src/agents/subagents/registry/subagent-registry.store.sqlite.js";
+import type { SubagentRunRecord } from "../src/agents/subagents/registry/subagent-registry.types.js";
+import type { OpenClawConfig } from "../src/config/types.openclaw.js";
+import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
+import { closeOpenClawStateDatabaseForTest } from "../src/state/openclaw-state-db.js";
+import { writeOpenAiResponsesSse } from "./helpers/openai-responses-sse.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "./helpers/openclaw-test-instance.js";
+
+const TEST_TIMEOUT_MS = 180_000;
+const MODEL_REF = "pr141480/pr141480";
+// No "agent:<id>:" segment. resolveRequesterStoreKey only short-circuits on a key
+// that already carries one, so this is the shape that forces owner resolution.
+const UNSCOPED_REQUESTER_KEY = "pr141480-requester";
+const REQUESTER_AGENT_ID = "beta";
+const OTHER_AGENT_ID = "alpha";
+const PARENT_PROMPT = "PR141480 parent: spawn one worker and finish without waiting.";
+const CHILD_TASK = "PR141480 child task: reply with the agreed child token.";
+const CHILD_MARKER = "PR141480-CHILD-OK";
+const ANNOUNCE_FAILURE_MARKER = "Subagent announce failed";
+// The restored-row lane. A row written before requester keys were agent-scoped keeps
+// an unscoped requesterSessionKey, which is the state resolveSubagentRequesterAgentId
+// exists for ("legacy rows that predate requesterAgentId").
+const LEGACY_RUN_ID = "run-pr141480-legacy";
+const LEGACY_REQUESTER_KEY = "pr141480-legacy-requester";
+const LEGACY_CHILD_RESULT = "PR141480-LEGACY-CHILD-RESULT";
+
+type SseEvent = Record<string, unknown>;
+
+type ProofModelServer = {
+  bodies: () => readonly string[];
+  close: () => Promise<void>;
+  countRequestsContaining: (marker: string) => number;
+  requestCount: () => number;
+  url: string;
+};
+
+const instances: OpenClawTestInstance[] = [];
+const modelServers: ProofModelServer[] = [];
+
+afterEach(async () => {
+  await Promise.allSettled(instances.splice(0).map((instance) => instance.cleanup()));
+  await Promise.allSettled(modelServers.splice(0).map((server) => server.close()));
+});
+
+describe("PR141480 requester agent id survives completion dispatch", () => {
+  it(
+    "delivers a child completion to the recorded requester agent for an unscoped key",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const modelServer = await startProofModelServer();
+      modelServers.push(modelServer);
+      const instance = await createOpenClawTestInstance({
+        name: "pr141480-requester-agent-id",
+        config: createTestConfig(modelServer.url),
+        env: { OPENCLAW_SKIP_PROVIDERS: undefined, OPENCLAW_TEST_MINIMAL_GATEWAY: undefined },
+      });
+      instances.push(instance);
+
+      // (b) The requester session key carries no agent segment.
+      expect(UNSCOPED_REQUESTER_KEY).not.toMatch(/^agent:/);
+      expect(UNSCOPED_REQUESTER_KEY.split(":")[0]).not.toBe("agent");
+
+      // (a) The Gateway boots on a two-agent roster with no default owner. Assert on
+      // the config file the Gateway actually loaded, not on the object we passed in.
+      const bootedConfig = JSON.parse(
+        await readFile(instance.configPath, "utf8"),
+      ) as OpenClawConfig;
+      const roster = bootedConfig.agents?.list ?? [];
+      expect(roster.map((entry) => entry.id)).toEqual([OTHER_AGENT_ID, REQUESTER_AGENT_ID]);
+      expect(roster.filter((entry) => entry.default === true)).toEqual([]);
+      expect(bootedConfig.agents?.ownership).toBe("explicit");
+
+      instance.state.applyEnv();
+      try {
+        await writeSubagentSessionEntry({
+          stateDir: instance.stateDir,
+          agentId: REQUESTER_AGENT_ID,
+          sessionKey: UNSCOPED_REQUESTER_KEY,
+          sessionId: "pr141480-requester-session",
+          defaultSessionId: "pr141480-requester-session",
+        });
+      } finally {
+        closeOpenClawStateDatabaseForTest();
+      }
+
+      await instance.startGateway();
+      const client = await connectGatewayClient({
+        url: instance.url,
+        token: instance.gatewayToken,
+      });
+      try {
+        const parent = client.request(
+          "agent",
+          {
+            sessionKey: UNSCOPED_REQUESTER_KEY,
+            agentId: REQUESTER_AGENT_ID,
+            idempotencyKey: "pr141480-parent-turn",
+            message: PARENT_PROMPT,
+            deliver: false,
+          },
+          { expectFinal: true },
+        );
+        void parent.catch(() => {});
+        // The child token only ever appears in a request body once the completion has
+        // been announced back into the requester's session, so this is delivery
+        // evidence rather than a spawn acknowledgement.
+        await vi.waitFor(
+          () => expect(modelServer.countRequestsContaining(CHILD_MARKER)).toBeGreaterThan(0),
+          { interval: 50, timeout: 90_000 },
+        );
+        await Promise.allSettled([parent]);
+      } finally {
+        await disconnectGatewayClient(client);
+        await instance.stopGateway();
+      }
+
+      const logs = instance.logs();
+      instance.state.applyEnv();
+      try {
+        const runs = [...loadSubagentRegistryFromSqlite().values()];
+        expect(runs, logs).toHaveLength(1);
+        const run = runs[0]!;
+        // (c) Spawn persisted the owner. Proven from the durable row, not assumed.
+        expect(run.requesterAgentId, logs).toBe(REQUESTER_AGENT_ID);
+        expect(run.requesterSessionKey, logs).toContain(UNSCOPED_REQUESTER_KEY);
+        // (d) The child completed.
+        expect(run.execution.status, logs).toBe("terminal");
+        expect(run.execution.outcome, logs).toMatchObject({ status: "ok" });
+        // (e) The completion reached the requester and nothing is left to retry.
+        expect(run.delivery?.status, logs).toBe("delivered");
+        expect(run.requesterSettleWake, logs).toBeUndefined();
+      } finally {
+        closeOpenClawStateDatabaseForTest();
+      }
+      expect(logs).not.toContain(ANNOUNCE_FAILURE_MARKER);
+    },
+  );
+
+  it(
+    "settles a restored run whose requester key carries no agent segment",
+    { timeout: TEST_TIMEOUT_MS },
+    async () => {
+      const modelServer = await startProofModelServer();
+      modelServers.push(modelServer);
+      const instance = await createOpenClawTestInstance({
+        name: "pr141480-legacy-unscoped-requester",
+        config: createTestConfig(modelServer.url),
+        env: { OPENCLAW_SKIP_PROVIDERS: undefined, OPENCLAW_TEST_MINIMAL_GATEWAY: undefined },
+      });
+      instances.push(instance);
+
+      expect(LEGACY_REQUESTER_KEY).not.toMatch(/^agent:/);
+
+      instance.state.applyEnv();
+      try {
+        const endedAt = Date.now();
+        const restored: SubagentRunRecord = {
+          runId: LEGACY_RUN_ID,
+          childSessionKey: `agent:${REQUESTER_AGENT_ID}:subagent:pr141480-legacy`,
+          requesterSessionKey: LEGACY_REQUESTER_KEY,
+          requesterDisplayKey: LEGACY_REQUESTER_KEY,
+          requesterAgentId: REQUESTER_AGENT_ID,
+          task: "PR141480 legacy restored completion",
+          cleanup: "keep",
+          createdAt: endedAt - 2_000,
+          endedReason: "subagent-complete",
+          execution: {
+            status: "terminal",
+            startedAt: endedAt - 1_000,
+            endedAt,
+            outcome: { status: "ok" },
+          },
+          expectsCompletionMessage: true,
+          completion: { required: true, resultText: LEGACY_CHILD_RESULT, capturedAt: endedAt },
+          delivery: { status: "pending" },
+        };
+        saveSubagentRegistryToSqlite(new Map([[restored.runId, restored]]));
+        await writeSubagentSessionEntry({
+          stateDir: instance.stateDir,
+          agentId: REQUESTER_AGENT_ID,
+          sessionKey: LEGACY_REQUESTER_KEY,
+          sessionId: "pr141480-legacy-session",
+          defaultSessionId: "pr141480-legacy-session",
+        });
+        // Restore prunes a row whose child session entry is gone, so the row has to
+        // look like what it is: a real child that ended and never delivered.
+        await writeSubagentSessionEntry({
+          stateDir: instance.stateDir,
+          agentId: REQUESTER_AGENT_ID,
+          sessionKey: restored.childSessionKey,
+          sessionId: "pr141480-legacy-child-session",
+          defaultSessionId: "pr141480-legacy-child-session",
+        });
+        // The fix can only pass on what the durable row actually carries, so prove the
+        // round trip before the Gateway ever reads it.
+        const seeded = loadSubagentRegistryFromSqlite().get(LEGACY_RUN_ID);
+        expect(seeded?.requesterAgentId).toBe(REQUESTER_AGENT_ID);
+        expect(seeded?.requesterSessionKey).toBe(LEGACY_REQUESTER_KEY);
+        expect(seeded?.delivery?.status).toBe("pending");
+      } finally {
+        closeOpenClawStateDatabaseForTest();
+      }
+
+      await instance.startGateway();
+      try {
+        // Delivery evidence: the child's result only enters a model request body when
+        // the completion has been announced into the requester's own session.
+        await vi.waitFor(
+          () =>
+            expect(
+              modelServer.countRequestsContaining(LEGACY_CHILD_RESULT),
+              instance.logs(),
+            ).toBeGreaterThan(0),
+          { interval: 50, timeout: 25_000 },
+        );
+      } finally {
+        await instance.stopGateway();
+      }
+
+      const logs = instance.logs();
+      expect(logs).not.toContain(ANNOUNCE_FAILURE_MARKER);
+      instance.state.applyEnv();
+      try {
+        const run = loadSubagentRegistryFromSqlite().get(LEGACY_RUN_ID);
+        expect(run?.requesterAgentId, logs).toBe(REQUESTER_AGENT_ID);
+        expect(run?.requesterSessionKey, logs).toBe(LEGACY_REQUESTER_KEY);
+        expect(run?.delivery?.status, logs).toBe("delivered");
+      } finally {
+        closeOpenClawStateDatabaseForTest();
+      }
+    },
+  );
+});
+
+function createTestConfig(baseUrl: string): OpenClawConfig {
+  return {
+    plugins: { enabled: false },
+    agents: {
+      // Explicit ownership is the supported multi-agent shape and is exactly the
+      // state in which resolveDefaultAgentId cannot pick an owner.
+      ownership: "explicit",
+      list: [{ id: OTHER_AGENT_ID }, { id: REQUESTER_AGENT_ID }],
+      defaults: {
+        heartbeat: { every: "0m" },
+        maxConcurrent: 8,
+        model: { primary: MODEL_REF },
+        models: { [MODEL_REF]: { agentRuntime: { id: "openclaw" } } },
+        skipBootstrap: true,
+        skills: [],
+      },
+    },
+    tools: { profile: "coding" },
+    models: {
+      mode: "replace",
+      providers: {
+        pr141480: {
+          baseUrl: `${baseUrl}/v1`,
+          apiKey: "test-token-placeholder",
+          api: "openai-responses",
+          request: { allowPrivateNetwork: true },
+          models: [
+            {
+              id: "pr141480",
+              name: "pr141480",
+              api: "openai-responses",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 128_000,
+              maxTokens: 4_096,
+            },
+          ],
+        },
+      },
+    },
+  };
+}
+
+let responseSequence = 0;
+
+function buildAssistantEvents(text: string): SseEvent[] {
+  const sequence = ++responseSequence;
+  const responseId = `resp_pr141480_${sequence}`;
+  const itemId = `msg_pr141480_${sequence}`;
+  const part = { type: "output_text", text, annotations: [] };
+  const item = {
+    type: "message",
+    id: itemId,
+    role: "assistant",
+    status: "completed",
+    content: [part],
+  };
+  const position = { item_id: itemId, output_index: 0, content_index: 0 };
+  return [
+    {
+      type: "response.created",
+      response: { id: responseId, object: "response", status: "in_progress", output: [] },
+    },
+    {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: { ...item, content: [], status: "in_progress" },
+    },
+    { type: "response.content_part.added", ...position, part: { ...part, text: "" } },
+    { type: "response.output_text.delta", ...position, delta: text },
+    { type: "response.output_text.done", ...position, text },
+    { type: "response.content_part.done", ...position, part },
+    { type: "response.output_item.done", output_index: 0, item },
+    {
+      type: "response.completed",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 8, output_tokens: 4, total_tokens: 12 },
+      },
+    },
+  ];
+}
+
+function buildToolCallEvents(name: string, args: Record<string, unknown>): SseEvent[] {
+  const sequence = ++responseSequence;
+  const responseId = `resp_pr141480_tool_${sequence}`;
+  const itemId = `fc_pr141480_${sequence}`;
+  const callId = `call_pr141480_${sequence}`;
+  const argumentsText = JSON.stringify(args);
+  const item = {
+    type: "function_call",
+    id: itemId,
+    call_id: callId,
+    name,
+    arguments: argumentsText,
+  };
+  return [
+    {
+      type: "response.created",
+      response: { id: responseId, object: "response", status: "in_progress", output: [] },
+    },
+    { type: "response.output_item.added", output_index: 0, item: { ...item, arguments: "" } },
+    {
+      type: "response.function_call_arguments.delta",
+      item_id: itemId,
+      output_index: 0,
+      delta: argumentsText,
+    },
+    {
+      type: "response.function_call_arguments.done",
+      item_id: itemId,
+      output_index: 0,
+      arguments: argumentsText,
+    },
+    { type: "response.output_item.done", output_index: 0, item },
+    {
+      type: "response.completed",
+      response: {
+        id: responseId,
+        object: "response",
+        status: "completed",
+        output: [item],
+        usage: { input_tokens: 8, output_tokens: 4, total_tokens: 12 },
+      },
+    },
+  ];
+}
+
+async function startProofModelServer(): Promise<ProofModelServer> {
+  const requestBodies: string[] = [];
+  const server = createServer((request, response) => {
+    void handleModelRequest(request, response).catch((error: unknown) => {
+      if (!response.headersSent) {
+        response.writeHead(500, { "content-type": "application/json" });
+      }
+      response.end(JSON.stringify({ error: { message: String(error) } }));
+    });
+  });
+
+  async function handleModelRequest(
+    request: IncomingMessage,
+    response: ServerResponse,
+  ): Promise<void> {
+    const url = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (request.method === "GET" && url.pathname === "/v1/models") {
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ data: [{ id: "pr141480", object: "model" }] }));
+      return;
+    }
+    if (request.method !== "POST" || url.pathname !== "/v1/responses") {
+      response.writeHead(404).end();
+      return;
+    }
+    let body = "";
+    for await (const chunk of request) {
+      body += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    }
+    requestBodies.push(body);
+    // The child turn carries the spawn task and no prior tool output.
+    if (body.includes(CHILD_TASK) && !body.includes("function_call_output")) {
+      writeOpenAiResponsesSse(response, buildAssistantEvents(CHILD_MARKER));
+      return;
+    }
+    // The parent's first turn asks for one worker.
+    if (body.includes(PARENT_PROMPT) && !body.includes("function_call_output")) {
+      writeOpenAiResponsesSse(
+        response,
+        buildToolCallEvents("sessions_spawn", {
+          task: CHILD_TASK,
+          label: "pr141480-child",
+          thread: false,
+          mode: "run",
+        }),
+      );
+      return;
+    }
+    writeOpenAiResponsesSse(response, buildAssistantEvents("PR141480-PARENT-OK"));
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    bodies: () => requestBodies,
+    countRequestsContaining: (marker) =>
+      requestBodies.filter((entry) => entry.includes(marker)).length,
+    requestCount: () => requestBodies.length,
+    url: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      server.closeAllConnections();
+      await new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      });
+    },
+  };
+}

--- a/test/subagent-requester-owner.e2e.test.ts
+++ b/test/subagent-requester-owner.e2e.test.ts
@@ -1,12 +1,3 @@
-// E2E proof for PR #141480: on a real multi-agent Gateway, a subagent completion
-// is delivered to the requester agent that spawn recorded, even when the requester
-// session key carries no agent segment.
-//
-// The failure this pins: completion dispatch used to build its announce parameters
-// without the captured requesterAgentId, so announce re-derived the owner from the
-// unscoped key alone, reached default agent selection on a two-agent roster, and
-// threw AGENT_SELECTION_REQUIRED into a catch that leaves the run retryable.
-import { readFile } from "node:fs/promises";
 import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -19,29 +10,27 @@ import type { SubagentRunRecord } from "../src/agents/subagents/registry/subagen
 import type { OpenClawConfig } from "../src/config/types.openclaw.js";
 import { connectGatewayClient, disconnectGatewayClient } from "../src/gateway/test-helpers.e2e.js";
 import { closeOpenClawStateDatabaseForTest } from "../src/state/openclaw-state-db.js";
-import { writeOpenAiResponsesSse } from "./helpers/openai-responses-sse.js";
+import {
+  writeOpenAiResponsesSse,
+  writeOpenAiResponsesText,
+} from "./helpers/openai-responses-sse.js";
 import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
 } from "./helpers/openclaw-test-instance.js";
 
 const TEST_TIMEOUT_MS = 180_000;
-const MODEL_REF = "pr141480/pr141480";
-// No "agent:<id>:" segment. resolveRequesterStoreKey only short-circuits on a key
-// that already carries one, so this is the shape that forces owner resolution.
-const UNSCOPED_REQUESTER_KEY = "pr141480-requester";
+const MODEL_REF = "requester-owner/synthetic";
+const REQUESTER_KEY = "requester-owner-requester";
 const REQUESTER_AGENT_ID = "beta";
 const OTHER_AGENT_ID = "alpha";
-const PARENT_PROMPT = "PR141480 parent: spawn one worker and finish without waiting.";
-const CHILD_TASK = "PR141480 child task: reply with the agreed child token.";
-const CHILD_MARKER = "PR141480-CHILD-OK";
+const PARENT_PROMPT = "REQUESTER-OWNER parent: spawn one worker and finish without waiting.";
+const CHILD_TASK = "REQUESTER-OWNER child task: reply with the agreed child token.";
+const CHILD_MARKER = "REQUESTER-OWNER-CHILD-OK";
 const ANNOUNCE_FAILURE_MARKER = "Subagent announce failed";
-// The restored-row lane. A row written before requester keys were agent-scoped keeps
-// an unscoped requesterSessionKey, which is the state resolveSubagentRequesterAgentId
-// exists for ("legacy rows that predate requesterAgentId").
-const LEGACY_RUN_ID = "run-pr141480-legacy";
-const LEGACY_REQUESTER_KEY = "pr141480-legacy-requester";
-const LEGACY_CHILD_RESULT = "PR141480-LEGACY-CHILD-RESULT";
+const RESTORED_RUN_ID = "run-requester-owner-legacy";
+const RESTORED_REQUESTER_KEY = "requester-owner-legacy-requester";
+const RESTORED_CHILD_RESULT = "REQUESTER-OWNER-LEGACY-CHILD-RESULT";
 
 type SseEvent = Record<string, unknown>;
 
@@ -57,46 +46,38 @@ const instances: OpenClawTestInstance[] = [];
 const modelServers: ProofModelServer[] = [];
 
 afterEach(async () => {
-  await Promise.allSettled(instances.splice(0).map((instance) => instance.cleanup()));
-  await Promise.allSettled(modelServers.splice(0).map((server) => server.close()));
+  const results = await Promise.allSettled([
+    ...instances.splice(0).map((instance) => instance.cleanup()),
+    ...modelServers.splice(0).map((server) => server.close()),
+  ]);
+  const errors = results.flatMap((result) => (result.status === "rejected" ? [result.reason] : []));
+  if (errors.length > 0) {
+    throw new AggregateError(errors, "Requester fixture cleanup failed");
+  }
 });
 
-describe("PR141480 requester agent id survives completion dispatch", () => {
+describe("REQUESTER-OWNER requester agent id survives completion dispatch", () => {
   it(
-    "delivers a child completion to the recorded requester agent for an unscoped key",
+    "preserves the requester owner through a fresh normalized spawn",
     { timeout: TEST_TIMEOUT_MS },
     async () => {
       const modelServer = await startProofModelServer();
       modelServers.push(modelServer);
       const instance = await createOpenClawTestInstance({
-        name: "pr141480-requester-agent-id",
+        name: "requester-owner-requester-agent-id",
         config: createTestConfig(modelServer.url),
         env: { OPENCLAW_SKIP_PROVIDERS: undefined, OPENCLAW_TEST_MINIMAL_GATEWAY: undefined },
       });
       instances.push(instance);
-
-      // (b) The requester session key carries no agent segment.
-      expect(UNSCOPED_REQUESTER_KEY).not.toMatch(/^agent:/);
-      expect(UNSCOPED_REQUESTER_KEY.split(":")[0]).not.toBe("agent");
-
-      // (a) The Gateway boots on a two-agent roster with no default owner. Assert on
-      // the config file the Gateway actually loaded, not on the object we passed in.
-      const bootedConfig = JSON.parse(
-        await readFile(instance.configPath, "utf8"),
-      ) as OpenClawConfig;
-      const roster = bootedConfig.agents?.list ?? [];
-      expect(roster.map((entry) => entry.id)).toEqual([OTHER_AGENT_ID, REQUESTER_AGENT_ID]);
-      expect(roster.filter((entry) => entry.default === true)).toEqual([]);
-      expect(bootedConfig.agents?.ownership).toBe("explicit");
 
       instance.state.applyEnv();
       try {
         await writeSubagentSessionEntry({
           stateDir: instance.stateDir,
           agentId: REQUESTER_AGENT_ID,
-          sessionKey: UNSCOPED_REQUESTER_KEY,
-          sessionId: "pr141480-requester-session",
-          defaultSessionId: "pr141480-requester-session",
+          sessionKey: REQUESTER_KEY,
+          sessionId: "requester-owner-requester-session",
+          defaultSessionId: "requester-owner-requester-session",
         });
       } finally {
         closeOpenClawStateDatabaseForTest();
@@ -111,23 +92,43 @@ describe("PR141480 requester agent id survives completion dispatch", () => {
         const parent = client.request(
           "agent",
           {
-            sessionKey: UNSCOPED_REQUESTER_KEY,
+            sessionKey: REQUESTER_KEY,
             agentId: REQUESTER_AGENT_ID,
-            idempotencyKey: "pr141480-parent-turn",
+            idempotencyKey: "requester-owner-parent-turn",
             message: PARENT_PROMPT,
             deliver: false,
           },
           { expectFinal: true },
         );
         void parent.catch(() => {});
-        // The child token only ever appears in a request body once the completion has
-        // been announced back into the requester's session, so this is delivery
-        // evidence rather than a spawn acknowledgement.
         await vi.waitFor(
           () => expect(modelServer.countRequestsContaining(CHILD_MARKER)).toBeGreaterThan(0),
           { interval: 50, timeout: 90_000 },
         );
-        await Promise.allSettled([parent]);
+        expect(await parent).toMatchObject({ status: "ok" });
+        instance.state.applyEnv();
+        await vi.waitFor(
+          () => {
+            const runs = [...loadSubagentRegistryFromSqlite().values()];
+            expect(runs).toHaveLength(1);
+            expect(runs[0]?.delivery?.status).toBe("delivered");
+          },
+          { interval: 50, timeout: 25_000 },
+        );
+        const requester = await client.request<{ messages: unknown[] }>("chat.history", {
+          sessionKey: REQUESTER_KEY,
+          agentId: REQUESTER_AGENT_ID,
+          limit: 30,
+        });
+        const other = await client.request<{ messages: unknown[] }>("chat.history", {
+          sessionKey: REQUESTER_KEY,
+          agentId: OTHER_AGENT_ID,
+          limit: 30,
+        });
+        expect(
+          requester.messages.filter((message) => JSON.stringify(message).includes(CHILD_MARKER)),
+        ).toHaveLength(1);
+        expect(other.messages).toEqual([]);
       } finally {
         await disconnectGatewayClient(client);
         await instance.stopGateway();
@@ -139,13 +140,10 @@ describe("PR141480 requester agent id survives completion dispatch", () => {
         const runs = [...loadSubagentRegistryFromSqlite().values()];
         expect(runs, logs).toHaveLength(1);
         const run = runs[0]!;
-        // (c) Spawn persisted the owner. Proven from the durable row, not assumed.
         expect(run.requesterAgentId, logs).toBe(REQUESTER_AGENT_ID);
-        expect(run.requesterSessionKey, logs).toContain(UNSCOPED_REQUESTER_KEY);
-        // (d) The child completed.
+        expect(run.requesterSessionKey, logs).toBe(`agent:${REQUESTER_AGENT_ID}:${REQUESTER_KEY}`);
         expect(run.execution.status, logs).toBe("terminal");
         expect(run.execution.outcome, logs).toMatchObject({ status: "ok" });
-        // (e) The completion reached the requester and nothing is left to retry.
         expect(run.delivery?.status, logs).toBe("delivered");
         expect(run.requesterSettleWake, logs).toBeUndefined();
       } finally {
@@ -156,30 +154,28 @@ describe("PR141480 requester agent id survives completion dispatch", () => {
   );
 
   it(
-    "settles a restored run whose requester key carries no agent segment",
+    "delivers a restored unscoped completion once across Gateway restarts",
     { timeout: TEST_TIMEOUT_MS },
     async () => {
       const modelServer = await startProofModelServer();
       modelServers.push(modelServer);
       const instance = await createOpenClawTestInstance({
-        name: "pr141480-legacy-unscoped-requester",
+        name: "requester-owner-legacy-unscoped-requester",
         config: createTestConfig(modelServer.url),
         env: { OPENCLAW_SKIP_PROVIDERS: undefined, OPENCLAW_TEST_MINIMAL_GATEWAY: undefined },
       });
       instances.push(instance);
 
-      expect(LEGACY_REQUESTER_KEY).not.toMatch(/^agent:/);
-
       instance.state.applyEnv();
       try {
         const endedAt = Date.now();
         const restored: SubagentRunRecord = {
-          runId: LEGACY_RUN_ID,
-          childSessionKey: `agent:${REQUESTER_AGENT_ID}:subagent:pr141480-legacy`,
-          requesterSessionKey: LEGACY_REQUESTER_KEY,
-          requesterDisplayKey: LEGACY_REQUESTER_KEY,
+          runId: RESTORED_RUN_ID,
+          childSessionKey: `agent:${REQUESTER_AGENT_ID}:subagent:requester-owner-legacy`,
+          requesterSessionKey: RESTORED_REQUESTER_KEY,
+          requesterDisplayKey: RESTORED_REQUESTER_KEY,
           requesterAgentId: REQUESTER_AGENT_ID,
-          task: "PR141480 legacy restored completion",
+          task: "REQUESTER-OWNER legacy restored completion",
           cleanup: "keep",
           createdAt: endedAt - 2_000,
           endedReason: "subagent-complete",
@@ -190,59 +186,84 @@ describe("PR141480 requester agent id survives completion dispatch", () => {
             outcome: { status: "ok" },
           },
           expectsCompletionMessage: true,
-          completion: { required: true, resultText: LEGACY_CHILD_RESULT, capturedAt: endedAt },
+          completion: { required: true, resultText: RESTORED_CHILD_RESULT, capturedAt: endedAt },
           delivery: { status: "pending" },
         };
         saveSubagentRegistryToSqlite(new Map([[restored.runId, restored]]));
         await writeSubagentSessionEntry({
           stateDir: instance.stateDir,
           agentId: REQUESTER_AGENT_ID,
-          sessionKey: LEGACY_REQUESTER_KEY,
-          sessionId: "pr141480-legacy-session",
-          defaultSessionId: "pr141480-legacy-session",
+          sessionKey: RESTORED_REQUESTER_KEY,
+          sessionId: "requester-owner-legacy-session",
+          defaultSessionId: "requester-owner-legacy-session",
         });
-        // Restore prunes a row whose child session entry is gone, so the row has to
-        // look like what it is: a real child that ended and never delivered.
         await writeSubagentSessionEntry({
           stateDir: instance.stateDir,
           agentId: REQUESTER_AGENT_ID,
           sessionKey: restored.childSessionKey,
-          sessionId: "pr141480-legacy-child-session",
-          defaultSessionId: "pr141480-legacy-child-session",
+          sessionId: "requester-owner-legacy-child-session",
+          defaultSessionId: "requester-owner-legacy-child-session",
         });
-        // The fix can only pass on what the durable row actually carries, so prove the
-        // round trip before the Gateway ever reads it.
-        const seeded = loadSubagentRegistryFromSqlite().get(LEGACY_RUN_ID);
+        const seeded = loadSubagentRegistryFromSqlite().get(RESTORED_RUN_ID);
         expect(seeded?.requesterAgentId).toBe(REQUESTER_AGENT_ID);
-        expect(seeded?.requesterSessionKey).toBe(LEGACY_REQUESTER_KEY);
+        expect(seeded?.requesterSessionKey).toBe(RESTORED_REQUESTER_KEY);
         expect(seeded?.delivery?.status).toBe("pending");
       } finally {
         closeOpenClawStateDatabaseForTest();
       }
 
-      await instance.startGateway();
-      try {
-        // Delivery evidence: the child's result only enters a model request body when
-        // the completion has been announced into the requester's own session.
-        await vi.waitFor(
-          () =>
-            expect(
-              modelServer.countRequestsContaining(LEGACY_CHILD_RESULT),
-              instance.logs(),
-            ).toBeGreaterThan(0),
-          { interval: 50, timeout: 25_000 },
-        );
-      } finally {
-        await instance.stopGateway();
+      let settledRequests: number | undefined;
+      for (let boot = 0; boot < 2; boot += 1) {
+        await instance.startGateway();
+        const client = await connectGatewayClient({
+          url: instance.url,
+          token: instance.gatewayToken,
+        });
+        try {
+          instance.state.applyEnv();
+          await vi.waitFor(
+            () => {
+              const run = loadSubagentRegistryFromSqlite().get(RESTORED_RUN_ID);
+              expect(run?.delivery?.status, instance.logs()).toBe("delivered");
+              expect(run?.execution.outcome).toMatchObject({ status: "ok" });
+              expect(run?.requesterSettleWake).toBeUndefined();
+            },
+            { interval: 50, timeout: 25_000 },
+          );
+          const requester = await client.request<{ messages: unknown[] }>("chat.history", {
+            sessionKey: RESTORED_REQUESTER_KEY,
+            agentId: REQUESTER_AGENT_ID,
+            limit: 30,
+          });
+          const other = await client.request<{ messages: unknown[] }>("chat.history", {
+            sessionKey: RESTORED_REQUESTER_KEY,
+            agentId: OTHER_AGENT_ID,
+            limit: 30,
+          });
+          expect(
+            requester.messages.filter((message) =>
+              JSON.stringify(message).includes(RESTORED_CHILD_RESULT),
+            ),
+          ).toHaveLength(1);
+          expect(other.messages).toEqual([]);
+          expect(modelServer.countRequestsContaining(RESTORED_CHILD_RESULT)).toBe(1);
+          if (settledRequests !== undefined) {
+            expect(modelServer.requestCount()).toBe(settledRequests);
+          }
+          settledRequests = modelServer.requestCount();
+        } finally {
+          await disconnectGatewayClient(client);
+          await instance.stopGateway();
+        }
       }
 
       const logs = instance.logs();
       expect(logs).not.toContain(ANNOUNCE_FAILURE_MARKER);
       instance.state.applyEnv();
       try {
-        const run = loadSubagentRegistryFromSqlite().get(LEGACY_RUN_ID);
+        const run = loadSubagentRegistryFromSqlite().get(RESTORED_RUN_ID);
         expect(run?.requesterAgentId, logs).toBe(REQUESTER_AGENT_ID);
-        expect(run?.requesterSessionKey, logs).toBe(LEGACY_REQUESTER_KEY);
+        expect(run?.requesterSessionKey, logs).toBe(RESTORED_REQUESTER_KEY);
         expect(run?.delivery?.status, logs).toBe("delivered");
       } finally {
         closeOpenClawStateDatabaseForTest();
@@ -255,10 +276,8 @@ function createTestConfig(baseUrl: string): OpenClawConfig {
   return {
     plugins: { enabled: false },
     agents: {
-      // Explicit ownership is the supported multi-agent shape and is exactly the
-      // state in which resolveDefaultAgentId cannot pick an owner.
       ownership: "explicit",
-      list: [{ id: OTHER_AGENT_ID }, { id: REQUESTER_AGENT_ID }],
+      entries: { [OTHER_AGENT_ID]: {}, [REQUESTER_AGENT_ID]: {} },
       defaults: {
         heartbeat: { every: "0m" },
         maxConcurrent: 8,
@@ -272,15 +291,15 @@ function createTestConfig(baseUrl: string): OpenClawConfig {
     models: {
       mode: "replace",
       providers: {
-        pr141480: {
+        "requester-owner": {
           baseUrl: `${baseUrl}/v1`,
           apiKey: "test-token-placeholder",
           api: "openai-responses",
           request: { allowPrivateNetwork: true },
           models: [
             {
-              id: "pr141480",
-              name: "pr141480",
+              id: "synthetic",
+              name: "requester-owner",
               api: "openai-responses",
               reasoning: false,
               input: ["text"],
@@ -297,52 +316,11 @@ function createTestConfig(baseUrl: string): OpenClawConfig {
 
 let responseSequence = 0;
 
-function buildAssistantEvents(text: string): SseEvent[] {
-  const sequence = ++responseSequence;
-  const responseId = `resp_pr141480_${sequence}`;
-  const itemId = `msg_pr141480_${sequence}`;
-  const part = { type: "output_text", text, annotations: [] };
-  const item = {
-    type: "message",
-    id: itemId,
-    role: "assistant",
-    status: "completed",
-    content: [part],
-  };
-  const position = { item_id: itemId, output_index: 0, content_index: 0 };
-  return [
-    {
-      type: "response.created",
-      response: { id: responseId, object: "response", status: "in_progress", output: [] },
-    },
-    {
-      type: "response.output_item.added",
-      output_index: 0,
-      item: { ...item, content: [], status: "in_progress" },
-    },
-    { type: "response.content_part.added", ...position, part: { ...part, text: "" } },
-    { type: "response.output_text.delta", ...position, delta: text },
-    { type: "response.output_text.done", ...position, text },
-    { type: "response.content_part.done", ...position, part },
-    { type: "response.output_item.done", output_index: 0, item },
-    {
-      type: "response.completed",
-      response: {
-        id: responseId,
-        object: "response",
-        status: "completed",
-        output: [item],
-        usage: { input_tokens: 8, output_tokens: 4, total_tokens: 12 },
-      },
-    },
-  ];
-}
-
 function buildToolCallEvents(name: string, args: Record<string, unknown>): SseEvent[] {
   const sequence = ++responseSequence;
-  const responseId = `resp_pr141480_tool_${sequence}`;
-  const itemId = `fc_pr141480_${sequence}`;
-  const callId = `call_pr141480_${sequence}`;
+  const responseId = `resp_requester-owner_tool_${sequence}`;
+  const itemId = `fc_requester-owner_${sequence}`;
+  const callId = `call_requester-owner_${sequence}`;
   const argumentsText = JSON.stringify(args);
   const item = {
     type: "function_call",
@@ -401,7 +379,7 @@ async function startProofModelServer(): Promise<ProofModelServer> {
     const url = new URL(request.url ?? "/", "http://127.0.0.1");
     if (request.method === "GET" && url.pathname === "/v1/models") {
       response.writeHead(200, { "content-type": "application/json" });
-      response.end(JSON.stringify({ data: [{ id: "pr141480", object: "model" }] }));
+      response.end(JSON.stringify({ data: [{ id: "requester-owner", object: "model" }] }));
       return;
     }
     if (request.method !== "POST" || url.pathname !== "/v1/responses") {
@@ -413,25 +391,43 @@ async function startProofModelServer(): Promise<ProofModelServer> {
       body += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
     }
     requestBodies.push(body);
-    // The child turn carries the spawn task and no prior tool output.
-    if (body.includes(CHILD_TASK) && !body.includes("function_call_output")) {
-      writeOpenAiResponsesSse(response, buildAssistantEvents(CHILD_MARKER));
+    const completion = [RESTORED_CHILD_RESULT, CHILD_MARKER].find((marker) =>
+      body.includes(marker),
+    );
+    if (completion) {
+      writeOpenAiResponsesText(response, {
+        text: completion,
+        responseId: `response-${++responseSequence}`,
+        messageId: `message-${responseSequence}`,
+      });
       return;
     }
-    // The parent's first turn asks for one worker.
+
+    if (body.includes(CHILD_TASK) && !body.includes("function_call_output")) {
+      writeOpenAiResponsesText(response, {
+        text: CHILD_MARKER,
+        responseId: `response-${++responseSequence}`,
+        messageId: `message-${responseSequence}`,
+      });
+      return;
+    }
     if (body.includes(PARENT_PROMPT) && !body.includes("function_call_output")) {
       writeOpenAiResponsesSse(
         response,
         buildToolCallEvents("sessions_spawn", {
           task: CHILD_TASK,
-          label: "pr141480-child",
+          label: "requester-owner-child",
           thread: false,
           mode: "run",
         }),
       );
       return;
     }
-    writeOpenAiResponsesSse(response, buildAssistantEvents("PR141480-PARENT-OK"));
+    writeOpenAiResponsesText(response, {
+      text: "REQUESTER-OWNER-PARENT-OK",
+      responseId: `response-${++responseSequence}`,
+      messageId: `message-${responseSequence}`,
+    });
   }
 
   await new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Related: #137332

## What Problem This Solves

A completed child can fail to deliver its result on a multi-agent Gateway when its stored requester session key is unscoped. Even with a recorded requester agent, announcement raises `AgentSelectionRequiredError` and keeps the successful child pending for delivery.

## Why This Change Was Made

Pass the existing captured requester owner through completion cleanup using the same resolver as requester-settle wake. Preserve the existing legacy resolution and lifecycle guards. This addresses the missing-owner handoff described in #137332; the broader requester-settle behavior remains separate.

## User Impact

Restored child completions reach the recorded requester without choosing a default agent. Fresh spawning keeps its existing normalized-key behavior.

## Evidence

- Pinned main `d59108045ffc5dd368a47559beadb442fdc0a933`: a real two-agent Gateway with explicit ownership, task-owned SQLite and a deterministic loopback HTTP provider failed restored delivery with `AgentSelectionRequiredError`. Child execution stayed successful; delivery stayed pending; both requester histories were empty.
- Candidate and its proof-only integration with that pin delivered once to beta, left alpha empty, cleared delivery debt, and preserved the same result after another Gateway restart.
- Fresh public spawning passed on both builds. Legacy scoped-key, configured fixed-store, sole-agent, ownerless, retired-owner, stale-generation and concurrent-child controls exercised the real Gateway. A completed multi-child batch produces its existing separate settlement turn.
- 188 lifecycle tests, 296 announcement-delivery tests, 2 requester-owner tests and 2 real Gateway tests passed. The unit and restored Gateway regressions failed on the actual pinned baseline for the intended cause. Changed-file lint and line/assertion ratchets passed.
- The Gateway tests now check parent success, durable settlement, both agents' histories and restart idempotency, reuse the existing text-stream helper, and surface cleanup failures.
- A deliberately inconsistent persisted owner/scoped-key tuple exposed an existing lookup-to-dispatch gap on both baseline and candidate. That negative control remains a documented limitation; bare fixed-store conflicts still fail closed. This PR does not define a new precedence policy for corrupted ownership records.

An independent source-blind validator exercised 15 fresh fixtures across 28 Gateway boots, including the baseline failure and candidate recovery, with 19 provider requests. It confirmed the observable owner-routing results and recorded the limits of source-only and unforced race claims for code review. Exact-head hosted CI remains a separate landing gate. No external provider credentials or production state were used.
