### PR TITLE
feat(workboard): make card note and comment URLs clickable

### DIFF
--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -87,6 +87,12 @@ operator see how a card moved through the board without opening the linked
 session; it is local operating context, not a replacement for session
 transcripts or GitHub issue history.
 
+Displayed card notes and operator comments stay literal plaintext except for
+two link forms: Markdown `[label](https://example.com)` and bare `http://` or
+`https://` URLs. Those render as external links in compact cards, the detail
+drawer, and the edit-card comment list. Other Markdown, HTML, and non-HTTP(S)
+schemes stay visible as typed. Stored values are not rewritten.
+
 The plugin and Control UI use one Workboard card contract. Dashboard refreshes
 therefore preserve workspace provenance and authority, claim state, diagnostic
 actions, and notification sequence numbers instead of projecting a smaller

--- a/docs/plugins/workboard.md
+++ b/docs/plugins/workboard.md
@@ -90,8 +90,11 @@ transcripts or GitHub issue history.
 Displayed card notes and operator comments stay literal plaintext except for
 two link forms: Markdown `[label](https://example.com)` and bare `http://` or
 `https://` URLs. Those render as external links in compact cards, the detail
-drawer, and the edit-card comment list. Other Markdown, HTML, and non-HTTP(S)
-schemes stay visible as typed. Stored values are not rewritten.
+drawer, and the edit-card comment list. Balanced parentheses inside a
+destination are kept, so paths such as
+`https://en.wikipedia.org/wiki/Function_(mathematics)` stay intact. Trailing
+`.,;:!?` on a bare URL stays outside the href. Other Markdown, HTML, and
+non-HTTP(S) schemes stay visible as typed. Stored values are not rewritten.
 
 The plugin and Control UI use one Workboard card contract. Dashboard refreshes
 therefore preserve workspace provenance and authority, claim state, diagnostic

--- a/extensions/workboard/browser/lib/linkify-text.test.ts
+++ b/extensions/workboard/browser/lib/linkify-text.test.ts
@@ -30,6 +30,25 @@ describe("renderLinkedPlainText", () => {
     expect(container.textContent).toBe("Open https://example.com/docs.");
   });
 
+  it("keeps wrapping parentheses around a bare URL", () => {
+    const container = renderLinked("See (https://example.com)");
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("https://example.com");
+    expect(container.textContent).toBe("See (https://example.com)");
+  });
+
+  it("links http markdown and localhost URLs", () => {
+    const container = renderLinked("Try [local](http://127.0.0.1:8080/status) today.");
+    const link = container.querySelector("a");
+    expect(link?.textContent).toBe("local");
+    expect(link?.getAttribute("href")).toBe("http://127.0.0.1:8080/status");
+  });
+
+  it("still autolinks a URL inside malformed markdown", () => {
+    const container = renderLinked("Broken [docs](https://example.com still text.");
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("https://example.com");
+    expect(container.textContent).toBe("Broken [docs](https://example.com still text.");
+  });
+
   it("does not turn javascript or data URLs into anchors", () => {
     const container = renderLinked(
       "Ignore [xss](javascript:alert(1)) and [file](data:text/html,hi) please.",
@@ -37,6 +56,19 @@ describe("renderLinkedPlainText", () => {
     expect(container.querySelector("a")).toBeNull();
     expect(container.textContent).toContain("[xss](javascript:alert(1))");
     expect(container.textContent).toContain("[file](data:text/html,hi)");
+  });
+
+  it.each([
+    ["ftp markdown", "See [files](ftp://files.example/doc) first."],
+    ["mailto markdown", "Email [us](mailto:hi@example.com) maybe."],
+    ["non-url markdown", "Broken [docs](not-a-url) still text."],
+    ["empty host", "Skip [bad](https://) entirely."],
+    ["www without scheme", "Visit www.example.com later."],
+    ["bold markdown", "Keep **bold** and `code` literal."],
+  ])("leaves %s unchanged", (_name, text) => {
+    const container = renderLinked(text);
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toBe(text);
   });
 
   it("leaves ordinary notes unchanged", () => {

--- a/extensions/workboard/browser/lib/linkify-text.test.ts
+++ b/extensions/workboard/browser/lib/linkify-text.test.ts
@@ -36,6 +36,22 @@ describe("renderLinkedPlainText", () => {
     expect(container.textContent).toBe("See (https://example.com)");
   });
 
+  it("preserves balanced parentheses in bare and markdown destinations", () => {
+    const wiki = "https://en.wikipedia.org/wiki/Function_(mathematics)";
+    const bare = renderLinked(`Read ${wiki}.`);
+    expect(bare.querySelector("a")?.getAttribute("href")).toBe(wiki);
+    expect(bare.textContent).toBe(`Read ${wiki}.`);
+
+    const markdown = renderLinked(`See [wiki](${wiki}) next.`);
+    expect(markdown.querySelector("a")?.textContent).toBe("wiki");
+    expect(markdown.querySelector("a")?.getAttribute("href")).toBe(wiki);
+    expect(markdown.textContent).toBe("See wiki next.");
+
+    const wrapped = renderLinked(`See (${wiki})`);
+    expect(wrapped.querySelector("a")?.getAttribute("href")).toBe(wiki);
+    expect(wrapped.textContent).toBe(`See (${wiki})`);
+  });
+
   it("links http markdown and localhost URLs", () => {
     const container = renderLinked("Try [local](http://127.0.0.1:8080/status) today.");
     const link = container.querySelector("a");

--- a/extensions/workboard/browser/lib/linkify-text.test.ts
+++ b/extensions/workboard/browser/lib/linkify-text.test.ts
@@ -1,0 +1,47 @@
+import "../test/dom.setup.ts";
+import { html, render } from "lit";
+import { describe, expect, it } from "vitest";
+import { renderLinkedPlainText } from "./linkify-text.ts";
+
+function renderLinked(text: string): HTMLElement {
+  const container = document.createElement("div");
+  render(html`<p>${renderLinkedPlainText(text)}</p>`, container);
+  return container;
+}
+
+describe("renderLinkedPlainText", () => {
+  it("turns markdown links and bare https URLs into external anchors", () => {
+    const container = renderLinked("See [Anrop](https://anrop.no/) and https://www.smuv.no/.");
+    const links = [...container.querySelectorAll("a")];
+    expect(links).toHaveLength(2);
+    expect(links[0]?.textContent).toBe("Anrop");
+    expect(links[0]?.getAttribute("href")).toBe("https://anrop.no/");
+    expect(links[0]?.getAttribute("target")).toBe("_blank");
+    expect(links[0]?.getAttribute("rel")).toBe("noopener noreferrer");
+    expect(links[1]?.textContent).toBe("https://www.smuv.no/");
+    expect(links[1]?.getAttribute("href")).toBe("https://www.smuv.no/");
+    expect(container.textContent).toBe("See Anrop and https://www.smuv.no/.");
+  });
+
+  it("keeps surrounding punctuation on autolinked URLs", () => {
+    const container = renderLinked("Open https://example.com/docs.");
+    const link = container.querySelector("a");
+    expect(link?.getAttribute("href")).toBe("https://example.com/docs");
+    expect(container.textContent).toBe("Open https://example.com/docs.");
+  });
+
+  it("does not turn javascript or data URLs into anchors", () => {
+    const container = renderLinked(
+      "Ignore [xss](javascript:alert(1)) and [file](data:text/html,hi) please.",
+    );
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toContain("[xss](javascript:alert(1))");
+    expect(container.textContent).toContain("[file](data:text/html,hi)");
+  });
+
+  it("leaves ordinary notes unchanged", () => {
+    const container = renderLinked("No links here, just triage notes.");
+    expect(container.querySelector("a")).toBeNull();
+    expect(container.textContent).toBe("No links here, just triage notes.");
+  });
+});

--- a/extensions/workboard/browser/lib/linkify-text.ts
+++ b/extensions/workboard/browser/lib/linkify-text.ts
@@ -8,13 +8,19 @@ import { html, type TemplateResult } from "lit";
 // - Bare http:// and https:// URLs
 //
 // Everything else stays literal, including other Markdown, HTML, ftp/mailto/
-// javascript/data URLs, and www. hosts without a scheme. Trailing ) , . ; : ! ?
-// on a bare URL is kept as surrounding text.
+// javascript/data URLs, and www. hosts without a scheme. Balanced parentheses
+// inside a destination are kept. Trailing .,;:!? on a bare URL is kept as
+// surrounding text.
 
-const LINK_PATTERN = /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)|(https?:\/\/[^\s<>"']+)/g;
-const TRAILING_PUNCTUATION = /[),.;:!?]+$/;
+const TRAILING_BARE_URL_PUNCTUATION = /[.,;:!?]+$/;
 
 export type LinkedPlainTextNode = string | TemplateResult;
+
+type ParsedLink = {
+  href: string;
+  label: string;
+  end: number;
+};
 
 function isSafeHttpUrl(value: string): boolean {
   try {
@@ -25,11 +31,106 @@ function isSafeHttpUrl(value: string): boolean {
   }
 }
 
-function trimBareUrl(value: string): { href: string; trailing: string } {
-  const trailing = value.match(TRAILING_PUNCTUATION)?.[0] ?? "";
+function httpSchemeLength(text: string, start: number): number {
+  if (text.startsWith("https://", start)) {
+    return "https://".length;
+  }
+  if (text.startsWith("http://", start)) {
+    return "http://".length;
+  }
+  return 0;
+}
+
+function isUrlStopCharacter(char: string): boolean {
+  return (
+    char === " " ||
+    char === "\t" ||
+    char === "\n" ||
+    char === "\r" ||
+    char === "<" ||
+    char === ">" ||
+    char === '"' ||
+    char === "'"
+  );
+}
+
+function readBalancedHttpUrl(text: string, start: number): { href: string; end: number } | null {
+  const schemeLength = httpSchemeLength(text, start);
+  if (schemeLength === 0) {
+    return null;
+  }
+  let index = start + schemeLength;
+  let depth = 0;
+  while (index < text.length) {
+    const char = text[index];
+    if (!char || isUrlStopCharacter(char)) {
+      break;
+    }
+    if (char === "(") {
+      depth += 1;
+      index += 1;
+      continue;
+    }
+    if (char === ")") {
+      if (depth === 0) {
+        break;
+      }
+      depth -= 1;
+      index += 1;
+      continue;
+    }
+    index += 1;
+  }
+  if (index <= start + schemeLength) {
+    return null;
+  }
   return {
-    href: trailing ? value.slice(0, -trailing.length) : value,
-    trailing,
+    href: text.slice(start, index),
+    end: index,
+  };
+}
+
+function tryParseMarkdownLink(text: string, start: number): ParsedLink | null {
+  if (text[start] !== "[") {
+    return null;
+  }
+  const labelEnd = text.indexOf("](", start + 1);
+  if (labelEnd < 0) {
+    return null;
+  }
+  const label = text.slice(start + 1, labelEnd);
+  if (!label || label.includes("[") || label.includes("\n")) {
+    return null;
+  }
+  const urlStart = labelEnd + 2;
+  const destination = readBalancedHttpUrl(text, urlStart);
+  if (!destination || text[destination.end] !== ")") {
+    return null;
+  }
+  if (!isSafeHttpUrl(destination.href)) {
+    return null;
+  }
+  return {
+    href: destination.href,
+    label,
+    end: destination.end + 1,
+  };
+}
+
+function tryParseBareUrl(text: string, start: number): ParsedLink | null {
+  const destination = readBalancedHttpUrl(text, start);
+  if (!destination) {
+    return null;
+  }
+  const trailing = destination.href.match(TRAILING_BARE_URL_PUNCTUATION)?.[0] ?? "";
+  const href = trailing ? destination.href.slice(0, -trailing.length) : destination.href;
+  if (!isSafeHttpUrl(href)) {
+    return null;
+  }
+  return {
+    href,
+    label: href,
+    end: start + href.length,
   };
 }
 
@@ -53,34 +154,34 @@ export function renderLinkedPlainText(text: string): LinkedPlainTextNode[] {
     return [text];
   }
   const nodes: LinkedPlainTextNode[] = [];
-  let cursor = 0;
-  for (const match of text.matchAll(LINK_PATTERN)) {
-    const index = match.index ?? 0;
-    if (index > cursor) {
-      nodes.push(text.slice(cursor, index));
+  let index = 0;
+  let literalStart = 0;
+
+  const flushLiteral = (end: number) => {
+    if (end > literalStart) {
+      nodes.push(text.slice(literalStart, end));
     }
-    const markdownLabel = match[1];
-    const markdownHref = match[2];
-    const bareUrl = match[3];
-    if (markdownLabel && markdownHref && isSafeHttpUrl(markdownHref)) {
-      nodes.push(renderExternalLink(markdownHref, markdownLabel));
-    } else if (bareUrl) {
-      const { href, trailing } = trimBareUrl(bareUrl);
-      if (isSafeHttpUrl(href)) {
-        nodes.push(renderExternalLink(href, href));
-        if (trailing) {
-          nodes.push(trailing);
-        }
-      } else {
-        nodes.push(match[0]);
-      }
-    } else {
-      nodes.push(match[0]);
+  };
+
+  while (index < text.length) {
+    const markdown = tryParseMarkdownLink(text, index);
+    if (markdown) {
+      flushLiteral(index);
+      nodes.push(renderExternalLink(markdown.href, markdown.label));
+      index = markdown.end;
+      literalStart = index;
+      continue;
     }
-    cursor = index + match[0].length;
+    const bareUrl = tryParseBareUrl(text, index);
+    if (bareUrl) {
+      flushLiteral(index);
+      nodes.push(renderExternalLink(bareUrl.href, bareUrl.href));
+      index = bareUrl.end;
+      literalStart = index;
+      continue;
+    }
+    index += 1;
   }
-  if (cursor < text.length) {
-    nodes.push(text.slice(cursor));
-  }
+  flushLiteral(text.length);
   return nodes.length > 0 ? nodes : [text];
 }

--- a/extensions/workboard/browser/lib/linkify-text.ts
+++ b/extensions/workboard/browser/lib/linkify-text.ts
@@ -1,5 +1,16 @@
 import { html, type TemplateResult } from "lit";
 
+// Display-only linker for Workboard notes and comments.
+// Stored card text is never rewritten.
+//
+// Recognized forms:
+// - Markdown: [label](http://…) or [label](https://…)
+// - Bare http:// and https:// URLs
+//
+// Everything else stays literal, including other Markdown, HTML, ftp/mailto/
+// javascript/data URLs, and www. hosts without a scheme. Trailing ) , . ; : ! ?
+// on a bare URL is kept as surrounding text.
+
 const LINK_PATTERN = /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)|(https?:\/\/[^\s<>"']+)/g;
 const TRAILING_PUNCTUATION = /[),.;:!?]+$/;
 
@@ -22,8 +33,19 @@ function trimBareUrl(value: string): { href: string; trailing: string } {
   };
 }
 
+function stopCardSurfaceActivation(event: Event) {
+  event.stopPropagation();
+}
+
 function renderExternalLink(href: string, label: string): TemplateResult {
-  return html`<a href=${href} target="_blank" rel="noopener noreferrer">${label}</a>`;
+  return html`<a
+    href=${href}
+    target="_blank"
+    rel="noopener noreferrer"
+    @click=${stopCardSurfaceActivation}
+    @keydown=${stopCardSurfaceActivation}
+    >${label}</a
+  >`;
 }
 
 export function renderLinkedPlainText(text: string): LinkedPlainTextNode[] {

--- a/extensions/workboard/browser/lib/linkify-text.ts
+++ b/extensions/workboard/browser/lib/linkify-text.ts
@@ -1,0 +1,64 @@
+import { html, type TemplateResult } from "lit";
+
+const LINK_PATTERN = /\[([^\]]+)\]\((https?:\/\/[^)\s]+)\)|(https?:\/\/[^\s<>"']+)/g;
+const TRAILING_PUNCTUATION = /[),.;:!?]+$/;
+
+export type LinkedPlainTextNode = string | TemplateResult;
+
+function isSafeHttpUrl(value: string): boolean {
+  try {
+    const url = new URL(value);
+    return (url.protocol === "http:" || url.protocol === "https:") && Boolean(url.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function trimBareUrl(value: string): { href: string; trailing: string } {
+  const trailing = value.match(TRAILING_PUNCTUATION)?.[0] ?? "";
+  return {
+    href: trailing ? value.slice(0, -trailing.length) : value,
+    trailing,
+  };
+}
+
+function renderExternalLink(href: string, label: string): TemplateResult {
+  return html`<a href=${href} target="_blank" rel="noopener noreferrer">${label}</a>`;
+}
+
+export function renderLinkedPlainText(text: string): LinkedPlainTextNode[] {
+  if (!text) {
+    return [text];
+  }
+  const nodes: LinkedPlainTextNode[] = [];
+  let cursor = 0;
+  for (const match of text.matchAll(LINK_PATTERN)) {
+    const index = match.index ?? 0;
+    if (index > cursor) {
+      nodes.push(text.slice(cursor, index));
+    }
+    const markdownLabel = match[1];
+    const markdownHref = match[2];
+    const bareUrl = match[3];
+    if (markdownLabel && markdownHref && isSafeHttpUrl(markdownHref)) {
+      nodes.push(renderExternalLink(markdownHref, markdownLabel));
+    } else if (bareUrl) {
+      const { href, trailing } = trimBareUrl(bareUrl);
+      if (isSafeHttpUrl(href)) {
+        nodes.push(renderExternalLink(href, href));
+        if (trailing) {
+          nodes.push(trailing);
+        }
+      } else {
+        nodes.push(match[0]);
+      }
+    } else {
+      nodes.push(match[0]);
+    }
+    cursor = index + match[0].length;
+  }
+  if (cursor < text.length) {
+    nodes.push(text.slice(cursor));
+  }
+  return nodes.length > 0 ? nodes : [text];
+}

--- a/extensions/workboard/browser/pages/workboard/view-card-details.ts
+++ b/extensions/workboard/browser/pages/workboard/view-card-details.ts
@@ -3,6 +3,7 @@ import { renderDashboard, renderDialog } from "../../components/host-components.
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { formatUiExternalText } from "../../lib/format-error.ts";
+import { renderLinkedPlainText } from "../../lib/linkify-text.ts";
 import {
   addWorkboardCardComment,
   getWorkboardDependencyState,
@@ -328,8 +329,8 @@ export function renderCardDetailsPanel(props: WorkboardProps) {
             card.notes
               ? html`
                   <section class="workboard-detail__section">
-                    <h3>${t("workboard.fieldNotes")}</h3>
-                    <p>${card.notes}</p>
+                  <h3>${t("workboard.fieldNotes")}</h3>
+                  <p>${renderLinkedPlainText(card.notes)}</p>
                   </section>
                 `
               : nothing
@@ -352,7 +353,9 @@ export function renderCardDetailsPanel(props: WorkboardProps) {
               comments.length
                 ? html`
                     <ol class="workboard-detail__list">
-                      ${comments.slice(-6).map((comment) => html`<li>${comment.body}</li>`)}
+                      ${comments
+                        .slice(-6)
+                        .map((comment) => html`<li>${renderLinkedPlainText(comment.body)}</li>`)}
                     </ol>
                   `
                 : html`<p>${t("workboard.detailNoNotes")}</p>`

--- a/extensions/workboard/browser/pages/workboard/view-card-details.ts
+++ b/extensions/workboard/browser/pages/workboard/view-card-details.ts
@@ -329,8 +329,8 @@ export function renderCardDetailsPanel(props: WorkboardProps) {
             card.notes
               ? html`
                   <section class="workboard-detail__section">
-                  <h3>${t("workboard.fieldNotes")}</h3>
-                  <p>${renderLinkedPlainText(card.notes)}</p>
+                    <h3>${t("workboard.fieldNotes")}</h3>
+                    <p>${renderLinkedPlainText(card.notes)}</p>
                   </section>
                 `
               : nothing

--- a/extensions/workboard/browser/pages/workboard/view-card-modal.ts
+++ b/extensions/workboard/browser/pages/workboard/view-card-modal.ts
@@ -3,6 +3,7 @@ import { live } from "lit/directives/live.js";
 import { renderAgentPicker, renderDialog } from "../../components/host-components.ts";
 import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
+import { renderLinkedPlainText } from "../../lib/linkify-text.ts";
 import { workboardCardSessionKey } from "../../lib/workboard/card-state.ts";
 import {
   addWorkboardCardComment,
@@ -373,7 +374,9 @@ export function renderCardModal(props: WorkboardProps) {
                       comments.length
                         ? html`
                             <ol>
-                              ${comments.map((comment) => html`<li>${comment.body}</li>`)}
+                              ${comments.map(
+                                (comment) => html`<li>${renderLinkedPlainText(comment.body)}</li>`,
+                              )}
                             </ol>
                           `
                         : nothing

--- a/extensions/workboard/browser/pages/workboard/view-card.ts
+++ b/extensions/workboard/browser/pages/workboard/view-card.ts
@@ -3,6 +3,7 @@ import { icons } from "../../components/icons.ts";
 import { t } from "../../i18n/index.ts";
 import { formatUiExternalText } from "../../lib/format-error.ts";
 import { clampText } from "../../lib/format.ts";
+import { renderLinkedPlainText } from "../../lib/linkify-text.ts";
 import {
   isActiveWorkboardCard,
   nextWorkboardCardPosition,
@@ -356,8 +357,10 @@ function renderCard(props: WorkboardProps, card: WorkboardCard, surface: Workboa
         }
         ${live ? html`<span class="workboard-live">${t("workboard.live")}</span>` : nothing}
       </div>
-      <h3>${card.title}</h3>
-      ${card.notes ? html`<p>${card.notes}</p>` : nothing} ${renderLifecycle(card, props, task)}
+          <h3>${card.title}</h3>
+          ${
+            card.notes ? html`<p>${renderLinkedPlainText(card.notes)}</p>` : nothing
+          } ${renderLifecycle(card, props, task)}
       ${renderDependencyBadges(dependencies)}
       ${
         card.labels.length

--- a/extensions/workboard/browser/pages/workboard/view-card.ts
+++ b/extensions/workboard/browser/pages/workboard/view-card.ts
@@ -357,11 +357,9 @@ function renderCard(props: WorkboardProps, card: WorkboardCard, surface: Workboa
         }
         ${live ? html`<span class="workboard-live">${t("workboard.live")}</span>` : nothing}
       </div>
-          <h3>${card.title}</h3>
-          ${
-            card.notes ? html`<p>${renderLinkedPlainText(card.notes)}</p>` : nothing
-          } ${renderLifecycle(card, props, task)}
-      ${renderDependencyBadges(dependencies)}
+      <h3>${card.title}</h3>
+      ${card.notes ? html`<p>${renderLinkedPlainText(card.notes)}</p>` : nothing}
+      ${renderLifecycle(card, props, task)} ${renderDependencyBadges(dependencies)}
       ${
         card.labels.length
           ? html`<div class="workboard-labels">

--- a/extensions/workboard/browser/pages/workboard/view.test.ts
+++ b/extensions/workboard/browser/pages/workboard/view.test.ts
@@ -556,6 +556,43 @@ describe("renderWorkboard", () => {
     expect(container.querySelector(".workboard-health")?.textContent).toContain("running");
   });
 
+  it("turns note and comment URLs into external links", () => {
+    const { state, container, renderView } = createWorkboardView();
+    state.cards = [
+      createWorkboardCard({
+        title: "Research competitors",
+        notes: "See [Anrop](https://anrop.no/) and https://www.smuv.no/.",
+        metadata: {
+          comments: [{ id: "comment-1", body: "Also https://www.ringli.no/.", createdAt: 2 }],
+        },
+      }),
+    ];
+    renderView();
+
+    const compactLink = container.querySelector(".workboard-card p a");
+    expect(compactLink?.textContent).toBe("Anrop");
+    expect(compactLink?.getAttribute("href")).toBe("https://anrop.no/");
+    expect(compactLink?.getAttribute("target")).toBe("_blank");
+    expect(compactLink?.getAttribute("rel")).toBe("noopener noreferrer");
+
+    compactLink?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    expect(state.detailCardId).toBeNull();
+
+    state.detailCardId = "card-1";
+    renderView();
+
+    const noteLinks = [
+      ...container.querySelectorAll<HTMLAnchorElement>(".workboard-detail__section p a"),
+    ];
+    expect(noteLinks.map((link) => link.getAttribute("href"))).toEqual([
+      "https://anrop.no/",
+      "https://www.smuv.no/",
+    ]);
+    expect(container.querySelector(".workboard-detail__list a")?.getAttribute("href")).toBe(
+      "https://www.ringli.no/",
+    );
+  });
+
   it("distinguishes the dragged card from its available drop columns", () => {
     const { state, container, renderView } = createWorkboardView({ canWrite: true });
     state.cards = [

--- a/extensions/workboard/browser/pages/workboard/view.test.ts
+++ b/extensions/workboard/browser/pages/workboard/view.test.ts
@@ -591,6 +591,12 @@ describe("renderWorkboard", () => {
     expect(container.querySelector(".workboard-detail__list a")?.getAttribute("href")).toBe(
       "https://www.ringli.no/",
     );
+
+    buttonByLabel(container, "Edit card")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    renderView();
+    expect(container.querySelector(".workboard-draft ol a")?.getAttribute("href")).toBe(
+      "https://www.ringli.no/",
+    );
   });
 
   it("distinguishes the dragged card from its available drop columns", () => {

--- a/extensions/workboard/browser/pages/workboard/view.test.ts
+++ b/extensions/workboard/browser/pages/workboard/view.test.ts
@@ -596,7 +596,9 @@ describe("renderWorkboard", () => {
       "https://www.ringli.no/",
     );
 
-    buttonByLabel(container, "Edit card")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    buttonByLabel(container, "Edit card")?.dispatchEvent(
+      new MouseEvent("click", { bubbles: true }),
+    );
     renderView();
     expect(container.querySelector(".workboard-draft ol a")?.getAttribute("href")).toBe(
       "https://www.ringli.no/",

--- a/extensions/workboard/browser/pages/workboard/view.test.ts
+++ b/extensions/workboard/browser/pages/workboard/view.test.ts
@@ -577,6 +577,10 @@ describe("renderWorkboard", () => {
 
     compactLink?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
     expect(state.detailCardId).toBeNull();
+    compactLink?.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    expect(state.detailCardId).toBeNull();
+    compactLink?.dispatchEvent(new KeyboardEvent("keydown", { key: " ", bubbles: true }));
+    expect(state.detailCardId).toBeNull();
 
     state.detailCardId = "card-1";
     renderView();

--- a/extensions/workboard/browser/styles/workboard.css
+++ b/extensions/workboard/browser/styles/workboard.css
@@ -840,6 +840,13 @@
   overflow: hidden;
 }
 
+.workboard-card p a,
+.workboard-detail__section a {
+  color: var(--accent);
+  text-decoration: underline;
+  overflow-wrap: anywhere;
+}
+
 .workboard-card__top,
 .workboard-card__meta {
   justify-content: space-between;

--- a/extensions/workboard/browser/styles/workboard.css
+++ b/extensions/workboard/browser/styles/workboard.css
@@ -841,7 +841,8 @@
 }
 
 .workboard-card p a,
-.workboard-detail__section a {
+.workboard-detail__section a,
+.workboard-draft ol a {
   color: var(--accent);
   text-decoration: underline;
   overflow-wrap: anywhere;

--- a/extensions/workboard/openclaw.plugin.json
+++ b/extensions/workboard/openclaw.plugin.json
@@ -220,9 +220,9 @@
     "properties": {}
   },
   "controlUi": {
-    "entry": "dist/control-ui/045246ad28fee377c4f2114901761aa38047053350e65f7cd6b238dabb5c764e/index.js",
+    "entry": "dist/control-ui/055c176656ce8dc706415ea550a24c4c0895a707dbf211d13b2afe7d7c812d0c/index.js",
     "styles": [
-      "dist/control-ui/045246ad28fee377c4f2114901761aa38047053350e65f7cd6b238dabb5c764e/index.css"
+      "dist/control-ui/055c176656ce8dc706415ea550a24c4c0895a707dbf211d13b2afe7d7c812d0c/index.css"
     ]
   }
 }


### PR DESCRIPTION
Closes #141472

## What Problem This Solves

Fixes an issue where Workboard users who paste URLs or markdown links into card notes or operator comments would see dead plaintext in the Control UI, even though the notes placeholder already says "Notes, acceptance criteria, links."

The same text is shown on compact cards, in the detail drawer, and in the edit-card comment list. Operators currently have to copy the URL out by hand during triage.

## Why This Change Was Made

Workboard now linkifies two conservative patterns in notes and comments:

- Markdown links: `[Anrop](https://anrop.no/)`
- Bare `http://` and `https://` URLs

Links open in a new tab with `rel="noopener noreferrer"`. Other text, including newlines, stays unchanged. This is not full markdown: no bold, lists, headings, images, or HTML, and no `innerHTML`. `javascript:` / `data:` URLs stay plaintext.

Balanced parentheses inside a destination are kept, so Wikipedia-style paths such as `https://en.wikipedia.org/wiki/Function_(mathematics)` stay intact in both the markdown and bare-URL forms. Trailing `.,;:!?` on a bare URL stays outside the href. A wrapping `(https://example.com)` still leaves the surrounding parentheses as text.

Clicking a link on a compact card does not open the detail drawer (the existing `a` action-target guard). Native `<a>` links remain keyboard-activatable.

The edit-card comment list uses the same linker as the drawer, so the three surfaces stay consistent.

## User Impact

Operators can click research, docs, PR, and competitor URLs directly from Workboard cards instead of copying them out of notes.

## Evidence

**Before** (current Control UI): notes interpolate as escaped plaintext.

![Workboard notes before, with markdown and a raw URL shown as text](https://github.com/schjonhaug/openclaw/releases/download/workboard-pr-141481-proof/workboard-notes-before.png)

**After, production compact card:** markdown labels and bare https URLs become anchors on the real Workboard card renderer. Clicking `Example` opened `https://example.com/` in a new tab and did not open the detail drawer. Dummy fixture only (`example.com` / `example.org`).

![Workboard compact card after, with Example and example.org as clickable links](https://github.com/schjonhaug/openclaw/releases/download/workboard-pr-141481-proof/workboard-compact-card-after.png)

Focused Control UI unit tests passed on this revision:

- `vitest --project unit` on `linkify-text.test.ts` and `view.test.ts`, including:
  - markdown + bare https become `<a target="_blank" rel="noopener noreferrer">`
  - balanced parentheses in bare and markdown destinations (`Function_(mathematics)`)
  - wrapping parentheses around a bare URL stay outside the href
  - trailing punctuation stays outside autolinked URLs
  - `javascript:` / `data:` markdown is not turned into anchors
  - compact-card link click / Enter / Space do not open the detail drawer
  - edit-modal comments use the same linker

This revision also formats the Workboard view files (`oxfmt`) and regenerates `extensions/workboard/openclaw.plugin.json` so the bundled control-ui asset hash matches the source.

Observed on OpenClaw 2026.9.2 before this change: card detail notes render as `<p>${card.notes}</p>`, so a note such as `[Anrop](https://anrop.no/)` is escaped text. After this renderer, that note is a real anchor.