### PR TITLE
improve: reduce cold SDK loading for model fetches

### DIFF
--- a/docs/reference/openclaw-ai.md
+++ b/docs/reference/openclaw-ai.md
@@ -66,6 +66,11 @@ A runnable version lives in the repository at `examples/ai-chat`.
 | `./providers`    | `registerBuiltInApiProviders`, `resetApiProviders`                             |
 | `./types`        | Model/message/tool/stream types                                                |
 | `./validation`   | Tool argument validation                                                       |
-| `./diagnostics`  | Diagnostics contracts                                                          |
+| `./diagnostics`  | Diagnostics contracts, transport logging, and sanitized URL formatting         |
 | `./event-stream` | Shared `EventStream` implementation                                            |
 | `./internal/*`   | OpenClaw-internal, no semver guarantee                                         |
+
+Use `@openclaw/ai/diagnostics` for `emitModelTransportDebug`,
+`formatModelTransportDebugUrl`, and `formatModelTransportDebugBaseUrl` when
+you only need logging helpers. This entrypoint keeps provider transport
+implementations out of the import graph.

--- a/packages/ai/src/utils/diagnostics.ts
+++ b/packages/ai/src/utils/diagnostics.ts
@@ -7,3 +7,9 @@ export {
   isTransientNetworkError,
   WEBSOCKET_NON_RETRYABLE_CLOSE_ERROR_CODE,
 } from "./retryable-network-errors.js";
+
+export { emitModelTransportDebug } from "../transports/model-transport-debug.js";
+export {
+  formatModelTransportDebugBaseUrl,
+  formatModelTransportDebugUrl,
+} from "../transports/model-transport-url.js";

--- a/src/agents/model-transport-debug.test.ts
+++ b/src/agents/model-transport-debug.test.ts
@@ -1,4 +1,4 @@
-import { emitModelTransportDebug } from "@openclaw/ai/transports";
+import { emitModelTransportDebug } from "@openclaw/ai/diagnostics";
 import { describe, expect, it, vi } from "vitest";
 
 describe("emitModelTransportDebug", () => {
@@ -6,7 +6,7 @@ describe("emitModelTransportDebug", () => {
     const info = vi.fn();
     const debug = vi.fn();
     return {
-      log: { info, debug } as unknown as Parameters<typeof emitModelTransportDebug>[0],
+      log: { info, debug },
       info,
       debug,
     };

--- a/src/agents/model-transport-url.test.ts
+++ b/src/agents/model-transport-url.test.ts
@@ -1,7 +1,7 @@
 import {
   formatModelTransportDebugBaseUrl,
   formatModelTransportDebugUrl,
-} from "@openclaw/ai/transports";
+} from "@openclaw/ai/diagnostics";
 /**
  * Regression coverage for model transport debug URL formatting.
  * Ensures credentials, query strings, and fragments stay out of diagnostics.

--- a/src/agents/provider-transport-fetch.ts
+++ b/src/agents/provider-transport-fetch.ts
@@ -1,10 +1,10 @@
+import { emitModelTransportDebug, formatModelTransportDebugUrl } from "@openclaw/ai/diagnostics";
 /**
  * Guarded provider fetch transport utilities.
  *
  * Applies request timeouts, proxy/TLS overrides, SSRF policy, local-service leases, retry hints, and SSE normalization.
  */
 import { parseRetryAfterHeadersSeconds as parseRetryAfterSeconds } from "@openclaw/ai/internal/retry-after";
-import { emitModelTransportDebug, formatModelTransportDebugUrl } from "@openclaw/ai/transports";
 import {
   isCloudMetadataIpAddress,
   isLinkLocalIpAddress,


### PR DESCRIPTION
## What Problem This Solves

Source-mode SDK loading pulls in the full provider transport barrel just to obtain two logging helpers. In the existing simple-completion integration suite, the first acquired case took 18.46s while the remaining cases took 34–65ms.

## Why This Change Was Made

Expose the existing model transport logging and sanitized URL helpers through the existing `@openclaw/ai/diagnostics` entrypoint, and use that entrypoint in the fetch wrapper. The helper implementations and existing transport exports remain unchanged. This removes an unnecessary import edge without adding a cache, dependency, package subpath, or shard.

The logging and URL-redaction tests exercise the diagnostics exports. The SDK/HTTP ownership suite keeps all seven original cases and assertions. The package reference documents the lightweight entrypoint.

## User Impact

Developer tests and source-mode plugins avoid loading unrelated provider transport implementations merely for logging. Fetch policy, timeouts, retries, redaction, and worker/lifecycle behavior are unchanged.

## Evidence

- Untouched seven-case baseline: first acquired case 18.463s; full command 57.25s. Clean candidate: 13.305s and 37.61s. All seven case names and order match. Host load and filesystem warmth vary, so these are observed local timings rather than a portable ratio.
- Temporary phase timers isolated 20.002s in SDK require, versus 186ms for the first real local HTTP completion and 4ms for the second. The candidate measured 10.630s in SDK require. Restoring only the old import, while retaining the new diagnostics exports, brought SDK require back to 16.916s. All seven cases passed in each run; instrumentation was removed afterward.
- A separate CPU profile located the broad transport barrel under the fetch wrapper's logging import, with 6.418s inclusive sampled time. Inclusive timings overlap; they are not additive.
- All 107 adjacent logging, URL-redaction, fetch, and real local HTTP sentinel checks passed.
- Independent P2 review found no actionable issues.

- Full `pnpm build` passed. A fresh Node process loaded the built diagnostics entrypoint and verified logging plus URL sanitization; its observed graph contained nine modules and loaded in 66ms.
- The full changed-file gate passed, including core/test types, lint, static guards, and zero runtime import cycles.

The remaining cold metadata/bootstrap and validation work is a follow-up; this PR does not claim to eliminate all SDK initialization cost. Production grows by six export lines, tests have zero net growth, and no helper implementation is duplicated.

Initial CI passed all seven SDK cases (9.736s for the cold acquired case) but failed an unrelated Markdown test file-length limit. The branch now includes the already-merged test split from #141466; all five files authored here remain byte-for-byte unchanged. [Refreshed exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34156579689) passed in 10m13s, including the previously failing lint lane and all seven SDK cases (11.559s for the cold acquired case).
