### PR TITLE
feat(macos): bundle openclaw-mac and add app gateway control CLI

### DIFF
--- a/apps/.i18n/native-source.json
+++ b/apps/.i18n/native-source.json
@@ -1882,6 +1882,7 @@
     {"id":"native.apple.cfcd671a54b772db","source":"Browser import requires Local mode","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift"}]},
     {"id":"native.apple.70c05e8289e9b917","source":"Browser import unavailable","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/macos/Sources/OpenClaw/BrowserProfileImportModel.swift"}]},
     {"id":"native.apple.c4826797af1aff18","source":"Browser logins imported","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/macos/Sources/OpenClaw/BrowserProfileImportBannerView.swift"}]},
+    {"id":"native.apple.0644a7702bb80de1","source":"Browser sign-in expired. Reconnect this Gateway.","surface":"apple","sites":[{"kind":"conditional-branch","path":"apps/macos/Sources/OpenClaw/MacControlLiveOwner.swift"}]},
     {"id":"native.apple.d85980958d4a09a7","source":"Bubbling","surface":"apple","sites":[{"kind":"ui-localized-call","path":"apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatWorkingProgress.swift"}]},
     {"id":"native.apple.26fd12b42c3d33b5","source":"CLI","surface":"apple","sites":[{"kind":"ui-call","path":"apps/macos/Sources/OpenClaw/DebugSettings.swift"}]},
     {"id":"native.apple.19ab2b90949fa777","source":"CLI install failed","surface":"apple","sites":[{"kind":"conditional-branch","path":"apps/macos/Sources/OpenClaw/CLIInstallPrompter.swift"}]},

--- a/apps/macos/Package.swift
+++ b/apps/macos/Package.swift
@@ -89,6 +89,7 @@ let package = Package(
         .executableTarget(
             name: "OpenClawMacCLI",
             dependencies: [
+                "OpenClawIPC",
                 "OpenClawDiscovery",
                 .product(name: "OpenClawKit", package: "OpenClawKit"),
                 .product(name: "OpenClawProtocol", package: "OpenClawKit"),

--- a/apps/macos/Sources/OpenClaw/AppProfile.swift
+++ b/apps/macos/Sources/OpenClaw/AppProfile.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import OpenClawIPC
 
 struct AppProfile: Equatable, Sendable {
     struct ValidationError: LocalizedError, Equatable, Sendable {
@@ -12,7 +13,6 @@ struct AppProfile: Equatable, Sendable {
     }
 
     static let current = Self(environment: ProcessInfo.processInfo.environment)
-    private static let reservedLaunchAgentNames: Set<String> = ["gateway", "mac", "node"]
 
     let name: String?
     let validationError: ValidationError?
@@ -24,7 +24,7 @@ struct AppProfile: Equatable, Sendable {
             self.validationError = nil
             return
         }
-        if let reason = Self.invalidReason(raw) {
+        if let reason = MacControlProfile.validationReason(raw) {
             self.name = nil
             self.validationError = ValidationError(rawValue: raw, reason: reason)
             return
@@ -57,8 +57,7 @@ struct AppProfile: Equatable, Sendable {
     }
 
     func stateDirectoryURL(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) -> URL {
-        let directory = self.name.map { ".openclaw-\($0)" } ?? ".openclaw"
-        return homeDirectory.appendingPathComponent(directory, isDirectory: true)
+        MacControlProfile.stateDirectoryURL(name: self.name, homeDirectory: homeDirectory)
     }
 
     var cliRootArguments: [String] {
@@ -89,27 +88,6 @@ struct AppProfile: Equatable, Sendable {
             hash = (hash ^ UInt32(byte)) &* 16_777_619
         }
         return 20000 + Int(hash % 40000)
-    }
-
-    private static func invalidReason(_ value: String) -> String? {
-        // Mirror src/cli/profile-utils.ts, then apply the stricter macOS native-service rules.
-        guard value.utf8.count <= 64,
-              value.utf8.first.map(self.isASCIIAlphanumeric) == true,
-              value.utf8.allSatisfy({ Self.isASCIIAlphanumeric($0) || $0 == 45 || $0 == 95 })
-        else {
-            return "use 1-64 letters, numbers, underscores, or hyphens, starting with a letter or number"
-        }
-        guard value == value.lowercased() else {
-            return "macOS profile names must be lowercase so state and LaunchAgent identities cannot collide"
-        }
-        guard !self.reservedLaunchAgentNames.contains(value) else {
-            return "\"\(value)\" is reserved by an existing OpenClaw LaunchAgent"
-        }
-        return nil
-    }
-
-    private static func isASCIIAlphanumeric(_ byte: UInt8) -> Bool {
-        (48...57).contains(byte) || (65...90).contains(byte) || (97...122).contains(byte)
     }
 }
 

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -62,7 +62,7 @@ final class AppState {
     private static let logger = Logger(subsystem: "ai.openclaw", category: "app-state")
 
     let isPreview: Bool
-    @ObservationIgnored private let gatewayConfigSaver: ([String: Any]) -> Bool
+    @ObservationIgnored private let gatewayConfigSaver: ([String: Any], Bool) -> Bool
     @ObservationIgnored let bundleLocationAllowsPersistentIntegration: Bool
     @ObservationIgnored private var isHydratingLaunchAtLogin = false
     private var isInitializing = true
@@ -453,7 +453,9 @@ final class AppState {
 
     init(
         preview: Bool = false,
-        gatewayConfigSaver: @escaping ([String: Any]) -> Bool = { OpenClawConfigFile.saveDict($0) })
+        gatewayConfigSaver: @escaping ([String: Any], Bool) -> Bool = {
+            OpenClawConfigFile.saveDict($0, allowGatewayModeRemoval: $1)
+        })
     {
         let isPreview = preview || ProcessInfo.processInfo.isRunningTests
         self.isPreview = isPreview
@@ -1316,7 +1318,7 @@ extension AppState {
         let changed = Self.configFingerprint(currentRoot) != Self.configFingerprint(replacement.root)
         self.gatewayConfigSyncTask?.cancel()
         self.setGatewayConfigSyncState(.pending)
-        guard !changed || self.gatewayConfigSaver(replacement.root) else {
+        guard !changed || self.gatewayConfigSaver(replacement.root, configuration.isClear) else {
             self.setGatewayConfigSyncState(previousSyncState)
             throw PrimaryGatewayControlError.persistenceFailed
         }
@@ -1337,10 +1339,8 @@ extension AppState {
                 }
             }
         }
-        if case .clear = configuration {
-            self.onboardingSeen = false
-        } else {
-            self.onboardingSeen = true
+        self.onboardingSeen = !configuration.isClear
+        if self.onboardingSeen {
             self.ifNotPreview {
                 AppDefaults.standard.set(currentOnboardingVersion, forKey: onboardingVersionKey)
             }
@@ -1381,7 +1381,7 @@ extension AppState {
             currentRoot: currentRoot,
             draft: draft,
             primaryGateway: primaryGateway)
-        guard !synced.changed || self.gatewayConfigSaver(synced.root) else {
+        guard !synced.changed || self.gatewayConfigSaver(synced.root, false) else {
             self.setGatewayConfigSyncState(primaryGateway == nil ? .failed : previousSyncState)
             Self.logger.warning("gateway config sync rejected to protect persisted gateway auth/mode")
             return false

--- a/apps/macos/Sources/OpenClaw/AppState.swift
+++ b/apps/macos/Sources/OpenClaw/AppState.swift
@@ -1297,6 +1297,63 @@ extension AppState {
         self.syncGatewayConfigNow(primaryGateway: configuration)
     }
 
+    func setPrimaryGateway(_ configuration: PrimaryGatewayControlConfiguration) throws {
+        guard self.gatewayConfigSyncIsEnabled, !self.isInitializing else {
+            throw PrimaryGatewayControlError.unavailable
+        }
+        let previousSyncState = self.gatewayConfigSyncState
+        let currentRoot = OpenClawConfigFile.loadDict()
+        self.applyConfigOverrides(currentRoot)
+        guard self.conflictedGatewayConfigFields.isEmpty else {
+            throw PrimaryGatewayControlError.conflictingEdits
+        }
+        let effectiveLocalPort = GatewayEnvironment.resolvedGatewayPort(
+            environment: ProcessInfo.processInfo.environment,
+            configPort: configuration.requestedLocalPort ?? OpenClawConfigFile.gatewayPort(root: currentRoot),
+            storedPort: GatewayEnvironment.gatewayPort(),
+            profile: .current)
+        let replacement = try configuration.replacingRoot(currentRoot, effectiveLocalPort: effectiveLocalPort)
+        let changed = Self.configFingerprint(currentRoot) != Self.configFingerprint(replacement.root)
+        self.gatewayConfigSyncTask?.cancel()
+        self.setGatewayConfigSyncState(.pending)
+        guard !changed || self.gatewayConfigSaver(replacement.root) else {
+            self.setGatewayConfigSyncState(previousSyncState)
+            throw PrimaryGatewayControlError.persistenceFailed
+        }
+
+        // Publish defaults and runtime routing only after the whole auth/route bundle commits.
+        self.dirtyGatewayConfigFields.removeAll()
+        self.conflictedGatewayConfigFields.removeAll()
+        self.lastObservedGatewayConfig = Self.gatewayConfigSnapshot(replacement.root)
+        self.applyGatewayConfigView(replacement.root, forcing: Set(GatewayConfigField.allCases))
+        if replacement.clearsTargetDefaults {
+            self.remoteProjectRoot = ""
+            self.remoteCliPath = ""
+            self.ifNotPreview {
+                AppDefaults.standard.removeObject(forKey: remoteProjectRootKey)
+                AppDefaults.standard.removeObject(forKey: remoteCliPathKey)
+                if self.remoteIdentity.isEmpty {
+                    AppDefaults.standard.removeObject(forKey: remoteIdentityKey)
+                }
+            }
+        }
+        if case .clear = configuration {
+            self.onboardingSeen = false
+        } else {
+            self.onboardingSeen = true
+            self.ifNotPreview {
+                AppDefaults.standard.set(currentOnboardingVersion, forKey: onboardingVersionKey)
+            }
+        }
+        self.lastConfigFingerprint = Self.configFingerprint(replacement.root)
+        self.setGatewayConfigSyncState(.current)
+        if changed {
+            GatewayDiscoveryPreferences.setPreferredStableID(nil)
+            WebChatManager.shared.resetPrimaryConnections()
+            NotificationCenter.default.post(name: .openclawConfigDidChange, object: nil)
+        }
+    }
+
     private func syncGatewayConfigNow(primaryGateway: PrimaryGatewayConfiguration?) -> Bool {
         guard self.gatewayConfigSyncIsEnabled, !self.isInitializing else { return true }
         let previousSyncState = self.gatewayConfigSyncState

--- a/apps/macos/Sources/OpenClaw/CLIInstaller.swift
+++ b/apps/macos/Sources/OpenClaw/CLIInstaller.swift
@@ -375,6 +375,12 @@ enum CLIInstaller {
                         "or retry after the channel is updated.")
                 return false
             }
+            do {
+                try self.installBundledMacCLI(prefix: prefix)
+            } catch {
+                await statusHandler("Install failed: \(error.localizedDescription)")
+                return false
+            }
             let parsed = self.parseInstallEvents(response.stdout)
             let installedVersion = parsed.last { $0.event == "done" }?.version
             let summary = installedVersion.map { "Installed openclaw \($0)." } ?? "Installed openclaw."
@@ -393,6 +399,21 @@ enum CLIInstaller {
         let fallback = response.errorMessage ?? "install failed"
         await statusHandler("Install failed: \(detail.isEmpty ? fallback : detail)")
         return false
+    }
+
+    private static func installBundledMacCLI(prefix: String) throws {
+        let fileManager = FileManager.default
+        let source = Bundle.main.bundleURL.appendingPathComponent("Contents/MacOS/openclaw-mac")
+        guard fileManager.isExecutableFile(atPath: source.path) else {
+            throw CocoaError(.fileNoSuchFile, userInfo: [NSFilePathErrorKey: source.path])
+        }
+        let destination = URL(fileURLWithPath: prefix).appendingPathComponent("bin/openclaw-mac")
+        if let existing = try? fileManager.destinationOfSymbolicLink(atPath: destination.path) {
+            if existing == source.path { return }
+            try fileManager.removeItem(at: destination)
+        }
+        // Creation fails on an existing non-link so installation preserves operator-owned files.
+        try fileManager.createSymbolicLink(at: destination, withDestinationURL: source)
     }
 
     static func channelInstallIsCompatible(

--- a/apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift
+++ b/apps/macos/Sources/OpenClaw/DashboardGatewayCatalog.swift
@@ -56,6 +56,7 @@ struct MacGatewayCatalogProfile: Equatable, Sendable {
     var usesBrowserIdentity = false
     var browserSessionExpiresAt: Date?
     var authKind: AuthKind?
+    var browserSessionSubject: String?
 }
 
 enum DashboardGatewayCatalog {

--- a/apps/macos/Sources/OpenClaw/ExecApprovalsSocketServer.swift
+++ b/apps/macos/Sources/OpenClaw/ExecApprovalsSocketServer.swift
@@ -3,116 +3,13 @@ import Darwin
 import Foundation
 import OSLog
 
-private final class ExecApprovalsSocketLifecycleLease: @unchecked Sendable {
-    private static let processLock = NSLock()
-    private nonisolated(unsafe) static var reservedPaths = Set<String>()
-
-    private let descriptor: Int32
-    private let path: String
-    private let stateLock = NSLock()
-    private var released = false
-
-    private init(descriptor: Int32, path: String) {
-        self.descriptor = descriptor
-        self.path = path
-    }
-
-    static func acquire(for socketPath: String) throws -> ExecApprovalsSocketLifecycleLease {
-        let socketURL = URL(fileURLWithPath: socketPath).standardizedFileURL
-        let canonicalSocketPath = socketURL.deletingLastPathComponent()
-            .resolvingSymlinksInPath()
-            .appendingPathComponent(socketURL.lastPathComponent)
-            .path
-        let lockPath = "\(canonicalSocketPath).lifecycle.lock"
-        let reserved = self.processLock.withLock { () -> Bool in
-            guard !self.reservedPaths.contains(lockPath) else { return false }
-            self.reservedPaths.insert(lockPath)
-            return true
-        }
-        guard reserved else {
-            throw ExecApprovalsSocketPathGuardError.lifecycleLockBusy(path: lockPath)
-        }
-
-        let descriptor = open(
-            lockPath,
-            O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
-            S_IRUSR | S_IWUSR)
-        guard descriptor >= 0 else {
-            self.releaseProcessReservation(lockPath)
-            throw ExecApprovalsSocketPathGuardError.lifecycleLockOpenFailed(
-                path: lockPath,
-                code: errno)
-        }
-
-        do {
-            var descriptorStatus = stat()
-            var pathStatus = stat()
-            guard fstat(descriptor, &descriptorStatus) == 0,
-                  lstat(lockPath, &pathStatus) == 0,
-                  descriptorStatus.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG),
-                  descriptorStatus.st_uid == geteuid(),
-                  descriptorStatus.st_nlink == 1,
-                  descriptorStatus.st_mode & mode_t(0o022) == 0,
-                  descriptorStatus.st_dev == pathStatus.st_dev,
-                  descriptorStatus.st_ino == pathStatus.st_ino
-            else {
-                throw ExecApprovalsSocketPathGuardError.lifecycleLockInvalid(path: lockPath)
-            }
-            guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
-                throw ExecApprovalsSocketPathGuardError.lifecycleLockBusy(path: lockPath)
-            }
-            return ExecApprovalsSocketLifecycleLease(
-                descriptor: descriptor,
-                path: lockPath)
-        } catch {
-            close(descriptor)
-            self.releaseProcessReservation(lockPath)
-            throw error
-        }
-    }
-
-    func release() {
-        let shouldRelease = self.stateLock.withLock { () -> Bool in
-            guard !self.released else { return false }
-            self.released = true
-            return true
-        }
-        guard shouldRelease else { return }
-        _ = flock(self.descriptor, LOCK_UN)
-        close(self.descriptor)
-        Self.releaseProcessReservation(self.path)
-    }
-
-    deinit {
-        self.release()
-    }
-
-    private static func releaseProcessReservation(_ path: String) {
-        _ = self.processLock.withLock {
-            self.reservedPaths.remove(path)
-        }
-    }
-}
-
 final class ExecApprovalsSocketServer: @unchecked Sendable {
-    private struct OpenedSocket {
-        let fd: Int32
-        let identity: ExecApprovalsSocketPathIdentity
-        let lifecycleLease: ExecApprovalsSocketLifecycleLease
-    }
-
     private let logger = Logger(subsystem: "ai.openclaw", category: "exec-approvals.socket")
-    private let socketPath: String
     private let token: String
     private let onPrompt: @Sendable (ExecApprovalPromptRequest) async -> ExecApprovalDecision?
     private let onExec: @Sendable (ExecHostRequest) async -> ExecHostResponse
     private let onUnexpectedStop: @Sendable (ExecApprovalsSocketServer) -> Void
-    private let stateLock = NSLock()
-    private var openedSocket: OpenedSocket?
-    private var acceptTask: Task<Void, Never>?
-    private var clients: [UUID: ExecApprovalsSocketClientSession] = [:]
-    private var shutdownTask: Task<Void, Never>?
-    private var isRunning = false
+    private let listener: LocalSocketServer
 
     init(
         socketPath: String,
@@ -121,161 +18,30 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
         onExec: @escaping @Sendable (ExecHostRequest) async -> ExecHostResponse,
         onUnexpectedStop: @escaping @Sendable (ExecApprovalsSocketServer) -> Void)
     {
-        self.socketPath = socketPath
         self.token = token
         self.onPrompt = onPrompt
         self.onExec = onExec
         self.onUnexpectedStop = onUnexpectedStop
+        self.listener = LocalSocketServer(
+            socketPath: socketPath,
+            logger: Logger(subsystem: "ai.openclaw", category: "exec-approvals.socket"))
     }
 
     var isListening: Bool {
-        self.stateLock.withLock { self.isRunning && self.openedSocket != nil }
+        self.listener.isListening
     }
 
     func start() async -> Bool {
-        let shouldStart = self.stateLock.withLock {
-            guard !Task.isCancelled, !self.isRunning, self.shutdownTask == nil else { return false }
-            self.isRunning = true
-            return true
-        }
-        guard shouldStart else {
-            return self.stateLock.withLock { self.openedSocket != nil }
-        }
-
-        return await withCheckedContinuation { continuation in
-            let task = Task.detached { [weak self] in
-                guard let self else {
-                    continuation.resume(returning: false)
-                    return
-                }
-                await self.runAcceptLoop { ready in
-                    continuation.resume(returning: ready)
-                }
-            }
-            self.stateLock.withLock {
-                self.acceptTask = task
-                if !self.isRunning {
-                    task.cancel()
-                }
-            }
-        }
+        await self.listener.start(handler: { handle in
+            await self.handleClient(handle: handle)
+        }, onUnexpectedStop: {
+            self.onUnexpectedStop(self)
+        })
     }
 
     @discardableResult
     func stop() -> Task<Void, Never> {
-        self.stateLock.withLock {
-            if let shutdownTask { return shutdownTask }
-            self.isRunning = false
-            let acceptTask = self.acceptTask
-            self.acceptTask = nil
-            let clients = Array(self.clients.values)
-            self.clients.removeAll()
-            let openedSocket = self.openedSocket
-            self.openedSocket = nil
-            acceptTask?.cancel()
-            for client in clients {
-                client.cancel()
-            }
-            if let openedSocket {
-                self.closeOwnedSocket(openedSocket)
-            }
-            // Hold the path lease until all admitted work has unwound. A new
-            // listener must not overlap commands still owned by this generation.
-            let shutdownTask = Task.detached {
-                await acceptTask?.value
-                for client in clients {
-                    await client.wait()
-                }
-                openedSocket?.lifecycleLease.release()
-            }
-            self.shutdownTask = shutdownTask
-            return shutdownTask
-        }
-    }
-
-    private func runAcceptLoop(onReady: @escaping @Sendable (Bool) -> Void) async {
-        let shouldOpen = self.stateLock.withLock { self.isRunning && !Task.isCancelled }
-        guard shouldOpen, let openedSocket = self.openSocket() else {
-            self.stateLock.withLock {
-                self.isRunning = false
-                self.acceptTask = nil
-            }
-            onReady(false)
-            return
-        }
-        let fd = openedSocket.fd
-
-        let shouldAccept = self.stateLock.withLock {
-            guard self.isRunning, !Task.isCancelled else { return false }
-            self.openedSocket = openedSocket
-            return true
-        }
-        guard shouldAccept else {
-            self.closeOwnedSocket(openedSocket)
-            openedSocket.lifecycleLease.release()
-            onReady(false)
-            return
-        }
-
-        onReady(true)
-        while self.stateLock.withLock({ self.isRunning }), !Task.isCancelled {
-            var addr = sockaddr_un()
-            var len = socklen_t(MemoryLayout.size(ofValue: addr))
-            let client = withUnsafeMutablePointer(to: &addr) { ptr in
-                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { rebound in
-                    accept(fd, rebound, &len)
-                }
-            }
-            if client < 0 {
-                if errno == EINTR {
-                    continue
-                }
-                break
-            }
-            self.stateLock.withLock {
-                guard self.isRunning, self.openedSocket?.fd == fd else {
-                    close(client)
-                    return
-                }
-                do {
-                    let session = try ExecApprovalsSocketClientSession(fd: client)
-                    let id = UUID()
-                    self.clients[id] = session
-                    session.start(operation: { [weak self] handle in
-                        await self?.handleClient(handle: handle)
-                    }, onFinished: { [weak self] in
-                        guard let self else { return }
-                        _ = self.stateLock.withLock { self.clients.removeValue(forKey: id) }
-                    })
-                } catch {
-                    close(client)
-                    self.logger
-                        .error(
-                            "exec approvals client monitoring failed: \(error.localizedDescription, privacy: .public)")
-                }
-            }
-        }
-
-        let stoppedUnexpectedly = self.stateLock.withLock { self.isRunning && !Task.isCancelled }
-        self.stop()
-        if stoppedUnexpectedly {
-            self.onUnexpectedStop(self)
-        }
-    }
-
-    private func closeOwnedSocket(_ socket: OpenedSocket) {
-        _ = shutdown(socket.fd, SHUT_RDWR)
-        close(socket.fd)
-        do {
-            // The caller retains the lease through this identity check and unlink;
-            // shutdown also keeps it until admitted work has drained.
-            try ExecApprovalsSocketPathGuard.removeSocket(
-                at: self.socketPath,
-                ifIdentityMatches: socket.identity)
-        } catch {
-            self.logger
-                .warning("exec approvals socket cleanup failed: \(error.localizedDescription, privacy: .public)")
-        }
+        self.listener.stop()
     }
 
     #if DEBUG
@@ -285,91 +51,6 @@ final class ExecApprovalsSocketServer: @unchecked Sendable {
         self.onUnexpectedStop(self)
     }
     #endif
-
-    private func openSocket() -> OpenedSocket? {
-        let lifecycleLease: ExecApprovalsSocketLifecycleLease
-        do {
-            try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: self.socketPath)
-            lifecycleLease = try ExecApprovalsSocketLifecycleLease.acquire(for: self.socketPath)
-            do {
-                try ExecApprovalsSocketPathGuard.removeExistingSocket(at: self.socketPath)
-            } catch {
-                lifecycleLease.release()
-                throw error
-            }
-        } catch {
-            self.logger
-                .error("exec approvals socket path hardening failed: \(error.localizedDescription, privacy: .public)")
-            return nil
-        }
-        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
-        guard fd >= 0 else {
-            self.logger.error("exec approvals socket create failed")
-            lifecycleLease.release()
-            return nil
-        }
-        var addr = sockaddr_un()
-        addr.sun_family = sa_family_t(AF_UNIX)
-        let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
-        if self.socketPath.utf8.count >= maxLen {
-            self.logger.error("exec approvals socket path too long")
-            close(fd)
-            lifecycleLease.release()
-            return nil
-        }
-        self.socketPath.withCString { cstr in
-            withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
-                let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: Int8.self)
-                memset(raw, 0, maxLen)
-                strncpy(raw, cstr, maxLen - 1)
-            }
-        }
-        let size = socklen_t(MemoryLayout.size(ofValue: addr))
-        let result = withUnsafePointer(to: &addr) { ptr in
-            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { rebound in
-                bind(fd, rebound, size)
-            }
-        }
-        if result != 0 {
-            self.logger.error("exec approvals socket bind failed")
-            close(fd)
-            lifecycleLease.release()
-            return nil
-        }
-        let identity: ExecApprovalsSocketPathIdentity
-        do {
-            guard let boundIdentity = try ExecApprovalsSocketPathGuard.socketIdentity(at: self.socketPath) else {
-                self.logger.error("exec approvals socket identity unavailable after bind")
-                close(fd)
-                try? ExecApprovalsSocketPathGuard.removeExistingSocket(at: self.socketPath)
-                lifecycleLease.release()
-                return nil
-            }
-            identity = boundIdentity
-        } catch {
-            self.logger.error(
-                "exec approvals socket identity failed: \(error.localizedDescription, privacy: .public)")
-            close(fd)
-            try? ExecApprovalsSocketPathGuard.removeExistingSocket(at: self.socketPath)
-            lifecycleLease.release()
-            return nil
-        }
-        let openedSocket = OpenedSocket(fd: fd, identity: identity, lifecycleLease: lifecycleLease)
-        if chmod(self.socketPath, 0o600) != 0 {
-            self.logger.error("exec approvals socket chmod failed")
-            self.closeOwnedSocket(openedSocket)
-            lifecycleLease.release()
-            return nil
-        }
-        if listen(fd, 16) != 0 {
-            self.logger.error("exec approvals socket listen failed")
-            self.closeOwnedSocket(openedSocket)
-            lifecycleLease.release()
-            return nil
-        }
-        self.logger.info("exec approvals socket listening at \(self.socketPath, privacy: .public)")
-        return openedSocket
-    }
 
     private func handleClient(handle: FileHandle) async {
         let fd = handle.fileDescriptor

--- a/apps/macos/Sources/OpenClaw/GatewayConnection.swift
+++ b/apps/macos/Sources/OpenClaw/GatewayConnection.swift
@@ -1321,6 +1321,11 @@ extension GatewayConnection {
         return trimmed.isEmpty ? nil : trimmed
     }
 
+    func connectionSummary() -> (connected: Bool, gatewayVersion: String?) {
+        guard case .connected = self.connectionPublication.value else { return (false, nil) }
+        return (true, self.cachedGatewayVersion())
+    }
+
     func cachedGatewayVersion(ifCurrentServerLease lease: ServerLease) async -> String? {
         guard await self.isCurrentServerLease(lease) else { return nil }
         return self.cachedGatewayVersion()

--- a/apps/macos/Sources/OpenClaw/LocalSocketServer.swift
+++ b/apps/macos/Sources/OpenClaw/LocalSocketServer.swift
@@ -1,0 +1,365 @@
+import Darwin
+import Foundation
+import OSLog
+
+private final class LocalSocketLifecycleLease: @unchecked Sendable {
+    private static let processLock = NSLock()
+    private nonisolated(unsafe) static var reservedPaths = Set<String>()
+
+    private let descriptor: Int32
+    private let path: String
+    private let stateLock = NSLock()
+    private var released = false
+
+    private init(descriptor: Int32, path: String) {
+        self.descriptor = descriptor
+        self.path = path
+    }
+
+    static func acquire(for socketPath: String) throws -> LocalSocketLifecycleLease {
+        let socketURL = URL(fileURLWithPath: socketPath).standardizedFileURL
+        let canonicalSocketPath = socketURL.deletingLastPathComponent()
+            .resolvingSymlinksInPath()
+            .appendingPathComponent(socketURL.lastPathComponent)
+            .path
+        let lockPath = "\(canonicalSocketPath).lifecycle.lock"
+        let reserved = self.processLock.withLock { () -> Bool in
+            guard !self.reservedPaths.contains(lockPath) else { return false }
+            self.reservedPaths.insert(lockPath)
+            return true
+        }
+        guard reserved else {
+            throw ExecApprovalsSocketPathGuardError.lifecycleLockBusy(path: lockPath)
+        }
+
+        let descriptor = open(
+            lockPath,
+            O_RDWR | O_CREAT | O_CLOEXEC | O_NOFOLLOW,
+            S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else {
+            self.releaseProcessReservation(lockPath)
+            throw ExecApprovalsSocketPathGuardError.lifecycleLockOpenFailed(
+                path: lockPath,
+                code: errno)
+        }
+
+        do {
+            var descriptorStatus = stat()
+            var pathStatus = stat()
+            guard fstat(descriptor, &descriptorStatus) == 0,
+                  lstat(lockPath, &pathStatus) == 0,
+                  descriptorStatus.st_mode & mode_t(S_IFMT) == mode_t(S_IFREG),
+                  descriptorStatus.st_uid == geteuid(),
+                  descriptorStatus.st_nlink == 1,
+                  descriptorStatus.st_mode & mode_t(0o022) == 0,
+                  descriptorStatus.st_dev == pathStatus.st_dev,
+                  descriptorStatus.st_ino == pathStatus.st_ino
+            else {
+                throw ExecApprovalsSocketPathGuardError.lifecycleLockInvalid(path: lockPath)
+            }
+            guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+                throw ExecApprovalsSocketPathGuardError.lifecycleLockBusy(path: lockPath)
+            }
+            return LocalSocketLifecycleLease(
+                descriptor: descriptor,
+                path: lockPath)
+        } catch {
+            close(descriptor)
+            self.releaseProcessReservation(lockPath)
+            throw error
+        }
+    }
+
+    func release() {
+        let shouldRelease = self.stateLock.withLock { () -> Bool in
+            guard !self.released else { return false }
+            self.released = true
+            return true
+        }
+        guard shouldRelease else { return }
+        _ = flock(self.descriptor, LOCK_UN)
+        close(self.descriptor)
+        Self.releaseProcessReservation(self.path)
+    }
+
+    deinit {
+        self.release()
+    }
+
+    private static func releaseProcessReservation(_ path: String) {
+        _ = self.processLock.withLock {
+            self.reservedPaths.remove(path)
+        }
+    }
+}
+
+/// Owns the listener generation and drains accepted requests before releasing its path.
+final class LocalSocketServer: @unchecked Sendable {
+    private struct OpenedSocket {
+        let fd: Int32
+        let identity: ExecApprovalsSocketPathIdentity
+        let lifecycleLease: LocalSocketLifecycleLease
+    }
+
+    private let logger: Logger
+    private let socketPath: String
+    private let stateLock = NSLock()
+    private var openedSocket: OpenedSocket?
+    private var acceptTask: Task<Void, Never>?
+    private var clients: [UUID: ExecApprovalsSocketClientSession] = [:]
+    private var shutdownTask: Task<Void, Never>?
+    private var isRunning = false
+
+    init(socketPath: String, logger: Logger) {
+        self.socketPath = socketPath
+        self.logger = logger
+    }
+
+    var isListening: Bool {
+        self.stateLock.withLock { self.isRunning && self.openedSocket != nil }
+    }
+
+    func start(
+        prepare: @escaping @Sendable () throws -> Void = {},
+        handler: @escaping @Sendable (FileHandle) async -> Void,
+        onUnexpectedStop: @escaping @Sendable () -> Void) async -> Bool
+    {
+        let shouldStart = self.stateLock.withLock {
+            guard !Task.isCancelled, !self.isRunning, self.shutdownTask == nil else { return false }
+            self.isRunning = true
+            return true
+        }
+        guard shouldStart else {
+            return self.stateLock.withLock { self.openedSocket != nil }
+        }
+
+        return await withCheckedContinuation { continuation in
+            let task = Task.detached { [weak self] in
+                guard let self else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                await self.runAcceptLoop(
+                    prepare: prepare,
+                    handler: handler,
+                    onUnexpectedStop: onUnexpectedStop,
+                    onReady: { ready in
+                        continuation.resume(returning: ready)
+                    })
+            }
+            self.stateLock.withLock {
+                self.acceptTask = task
+                if !self.isRunning {
+                    task.cancel()
+                }
+            }
+        }
+    }
+
+    @discardableResult
+    func stop() -> Task<Void, Never> {
+        self.stateLock.withLock {
+            if let shutdownTask { return shutdownTask }
+            self.isRunning = false
+            let acceptTask = self.acceptTask
+            self.acceptTask = nil
+            let clients = Array(self.clients.values)
+            self.clients.removeAll()
+            let openedSocket = self.openedSocket
+            self.openedSocket = nil
+            acceptTask?.cancel()
+            for client in clients {
+                client.cancel()
+            }
+            if let openedSocket {
+                self.closeOwnedSocket(openedSocket)
+            }
+            // Hold the path lease until all admitted work has unwound. A new
+            // listener must not overlap commands still owned by this generation.
+            let shutdownTask = Task.detached {
+                await acceptTask?.value
+                for client in clients {
+                    await client.wait()
+                }
+                openedSocket?.lifecycleLease.release()
+            }
+            self.shutdownTask = shutdownTask
+            return shutdownTask
+        }
+    }
+
+    private func runAcceptLoop(
+        prepare: @escaping @Sendable () throws -> Void,
+        handler: @escaping @Sendable (FileHandle) async -> Void,
+        onUnexpectedStop: @escaping @Sendable () -> Void,
+        onReady: @escaping @Sendable (Bool) -> Void) async
+    {
+        let shouldOpen = self.stateLock.withLock { self.isRunning && !Task.isCancelled }
+        guard shouldOpen, let openedSocket = self.openSocket(prepare: prepare) else {
+            self.stateLock.withLock {
+                self.isRunning = false
+                self.acceptTask = nil
+            }
+            onReady(false)
+            return
+        }
+        let fd = openedSocket.fd
+
+        let shouldAccept = self.stateLock.withLock {
+            guard self.isRunning, !Task.isCancelled else { return false }
+            self.openedSocket = openedSocket
+            return true
+        }
+        guard shouldAccept else {
+            self.closeOwnedSocket(openedSocket)
+            openedSocket.lifecycleLease.release()
+            onReady(false)
+            return
+        }
+
+        onReady(true)
+        while self.stateLock.withLock({ self.isRunning }), !Task.isCancelled {
+            var addr = sockaddr_un()
+            var len = socklen_t(MemoryLayout.size(ofValue: addr))
+            let client = withUnsafeMutablePointer(to: &addr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { rebound in
+                    accept(fd, rebound, &len)
+                }
+            }
+            if client < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                break
+            }
+            self.stateLock.withLock {
+                guard self.isRunning, self.openedSocket?.fd == fd else {
+                    close(client)
+                    return
+                }
+                do {
+                    let session = try ExecApprovalsSocketClientSession(fd: client)
+                    let id = UUID()
+                    self.clients[id] = session
+                    session.start(operation: handler, onFinished: { [weak self] in
+                        guard let self else { return }
+                        _ = self.stateLock.withLock { self.clients.removeValue(forKey: id) }
+                    })
+                } catch {
+                    close(client)
+                    self.logger
+                        .error(
+                            "local client monitoring failed: \(error.localizedDescription, privacy: .public)")
+                }
+            }
+        }
+
+        let stoppedUnexpectedly = self.stateLock.withLock { self.isRunning && !Task.isCancelled }
+        self.stop()
+        if stoppedUnexpectedly {
+            onUnexpectedStop()
+        }
+    }
+
+    private func closeOwnedSocket(_ socket: OpenedSocket) {
+        _ = shutdown(socket.fd, SHUT_RDWR)
+        close(socket.fd)
+        do {
+            // The caller retains the lease through this identity check and unlink;
+            // shutdown also keeps it until admitted work has drained.
+            try ExecApprovalsSocketPathGuard.removeSocket(
+                at: self.socketPath,
+                ifIdentityMatches: socket.identity)
+        } catch {
+            self.logger
+                .warning("local socket cleanup failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func openSocket(prepare: @Sendable () throws -> Void) -> OpenedSocket? {
+        let lifecycleLease: LocalSocketLifecycleLease
+        do {
+            try ExecApprovalsSocketPathGuard.hardenParentDirectory(for: self.socketPath)
+            lifecycleLease = try LocalSocketLifecycleLease.acquire(for: self.socketPath)
+            do {
+                try ExecApprovalsSocketPathGuard.removeExistingSocket(at: self.socketPath)
+                // The credential must be complete before clients can observe a listening socket.
+                try prepare()
+            } catch {
+                lifecycleLease.release()
+                throw error
+            }
+        } catch {
+            self.logger
+                .error("local socket path hardening failed: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            self.logger.error("local socket create failed")
+            lifecycleLease.release()
+            return nil
+        }
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
+        if self.socketPath.utf8.count >= maxLen {
+            self.logger.error("local socket path too long")
+            close(fd)
+            lifecycleLease.release()
+            return nil
+        }
+        self.socketPath.withCString { cstr in
+            withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+                let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: Int8.self)
+                memset(raw, 0, maxLen)
+                strncpy(raw, cstr, maxLen - 1)
+            }
+        }
+        let size = socklen_t(MemoryLayout.size(ofValue: addr))
+        let result = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { rebound in
+                bind(fd, rebound, size)
+            }
+        }
+        if result != 0 {
+            self.logger.error("local socket bind failed")
+            close(fd)
+            lifecycleLease.release()
+            return nil
+        }
+        let identity: ExecApprovalsSocketPathIdentity
+        do {
+            guard let boundIdentity = try ExecApprovalsSocketPathGuard.socketIdentity(at: self.socketPath) else {
+                self.logger.error("local socket identity unavailable after bind")
+                close(fd)
+                try? ExecApprovalsSocketPathGuard.removeExistingSocket(at: self.socketPath)
+                lifecycleLease.release()
+                return nil
+            }
+            identity = boundIdentity
+        } catch {
+            self.logger.error(
+                "local socket identity failed: \(error.localizedDescription, privacy: .public)")
+            close(fd)
+            try? ExecApprovalsSocketPathGuard.removeExistingSocket(at: self.socketPath)
+            lifecycleLease.release()
+            return nil
+        }
+        let openedSocket = OpenedSocket(fd: fd, identity: identity, lifecycleLease: lifecycleLease)
+        if chmod(self.socketPath, 0o600) != 0 {
+            self.logger.error("local socket chmod failed")
+            self.closeOwnedSocket(openedSocket)
+            lifecycleLease.release()
+            return nil
+        }
+        if listen(fd, 16) != 0 {
+            self.logger.error("local socket listen failed")
+            self.closeOwnedSocket(openedSocket)
+            lifecycleLease.release()
+            return nil
+        }
+        self.logger.info("local socket listening at \(self.socketPath, privacy: .public)")
+        return openedSocket
+    }
+}

--- a/apps/macos/Sources/OpenClaw/MacControlLiveOwner.swift
+++ b/apps/macos/Sources/OpenClaw/MacControlLiveOwner.swift
@@ -1,5 +1,6 @@
 import Foundation
 import OpenClawIPC
+import OpenClawKit
 
 @MainActor
 final class MacControlLiveOwner: MacControlOwner {
@@ -28,12 +29,11 @@ final class MacControlLiveOwner: MacControlOwner {
         } else {
             mode == .local ? "ws://127.0.0.1:\(GatewayEnvironment.gatewayPort())" : ""
         }
-        let connection = switch ControlChannel.shared.state {
-        case .disconnected: MacControlConnectionStatus(state: "disconnected")
-        case .connecting: MacControlConnectionStatus(state: "connecting")
-        case .connected: MacControlConnectionStatus(state: "connected", gatewayVersion: summary.gatewayVersion)
-        case .degraded: MacControlConnectionStatus(state: "degraded", error: "Gateway connection needs attention.")
-        }
+        let connection = Self.primaryConnectionStatus(
+            mode: mode,
+            paused: state.isPaused,
+            channelState: ControlChannel.shared.state,
+            gatewayVersion: summary.gatewayVersion)
         return MacControlPrimaryStatus(
             mode: mode.rawValue,
             transport: mode == .remote ? state.remoteTransport.rawValue : nil,
@@ -43,6 +43,23 @@ final class MacControlLiveOwner: MacControlOwner {
                 ? GatewayRemoteConfig.resolveRemotePort(root: OpenClawConfigFile.loadDict()) : nil,
             tunnel: MacControlTunnelStatus(running: tunnel.running, localPort: tunnel.localPort.map(Int.init)),
             connection: connection)
+    }
+
+    static func primaryConnectionStatus(
+        mode: AppState.ConnectionMode,
+        paused: Bool,
+        channelState: ControlChannel.ConnectionState,
+        gatewayVersion: String?) -> MacControlConnectionStatus
+    {
+        guard mode != .unconfigured, !paused else {
+            return MacControlConnectionStatus(state: "disconnected")
+        }
+        return switch channelState {
+        case .disconnected: MacControlConnectionStatus(state: "disconnected")
+        case .connecting: MacControlConnectionStatus(state: "connecting")
+        case .connected: MacControlConnectionStatus(state: "connected", gatewayVersion: gatewayVersion)
+        case .degraded: MacControlConnectionStatus(state: "degraded", error: "Gateway connection needs attention.")
+        }
     }
 
     func setPrimary(_ configuration: PrimaryGatewayControlConfiguration) async throws -> MacControlPrimaryStatus {
@@ -110,7 +127,42 @@ final class MacControlLiveOwner: MacControlOwner {
             address: request.url ?? "",
             token: request.token ?? "",
             password: request.password ?? "")
-        return try await self.gateway(id: profile.id)
+        let gateway = try await self.gateway(id: profile.id)
+        return try await Self.connectSavedGateway(gateway, deadline: request.deadline) {
+            try Task.checkCancellation()
+            let binding = try await MacGatewayConnectionFleet.shared.binding(profileID: profile.id)
+            try Task.checkCancellation()
+            _ = try await binding.connection.acquireServerLease()
+            try Task.checkCancellation()
+            let summary = await binding.connection.connectionSummary()
+            return MacControlConnectionStatus(
+                state: summary.connected ? "connected" : "disconnected", gatewayVersion: summary.gatewayVersion)
+        }
+    }
+
+    static func connectSavedGateway(
+        _ gateway: MacControlGatewayStatus,
+        deadline: Date?,
+        connect: @escaping @Sendable () async throws -> MacControlConnectionStatus) async throws
+        -> MacControlGatewayStatus
+    {
+        guard gateway.auth != "browser" else { return gateway }
+        var result = gateway
+        do {
+            try Task.checkCancellation()
+            let remaining = min(310, deadline?.timeIntervalSinceNow ?? 310)
+            guard remaining > 0 else { throw CancellationError() }
+            result.connection = try await AsyncTimeout.withTimeout(
+                seconds: remaining,
+                onTimeout: { CancellationError() },
+                operation: connect)
+        } catch {
+            try Task.checkCancellation()
+            // Saving succeeded; connectivity failure must not turn it into a failed add or expose credentials.
+            result.connection = MacControlConnectionStatus(
+                state: "disconnected", error: "Connection unavailable. Check Gateway settings and reconnect.")
+        }
+        return result
     }
 
     func removeGateway(id: String) async throws {

--- a/apps/macos/Sources/OpenClaw/MacControlLiveOwner.swift
+++ b/apps/macos/Sources/OpenClaw/MacControlLiveOwner.swift
@@ -1,0 +1,149 @@
+import Foundation
+import OpenClawIPC
+
+@MainActor
+final class MacControlLiveOwner: MacControlOwner {
+    func status() async throws -> MacControlStatus {
+        let primary = try await self.primaryStatus()
+        let gateways = try await self.gateways()
+        return MacControlStatus(
+            primary: primary,
+            gateways: gateways,
+            app: MacControlAppStatus(
+                version: Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown",
+                build: Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown",
+                profile: AppProfile.current.name ?? "default"))
+    }
+
+    func primaryStatus() async throws -> MacControlPrimaryStatus {
+        let tunnel = await RemoteTunnelManager.shared.controlTunnelStatus()
+        let endpoint = await GatewayEndpointStore.shared.currentState()
+        let summary = await GatewayConnection.shared.connectionSummary()
+        let state = AppStateStore.shared
+        let mode = state.connectionMode
+        let url: String = if case let .ready(_, endpointURL, _, _, _) = endpoint {
+            endpointURL.absoluteString
+        } else if mode == .remote {
+            state.remoteUrl
+        } else {
+            mode == .local ? "ws://127.0.0.1:\(GatewayEnvironment.gatewayPort())" : ""
+        }
+        let connection = switch ControlChannel.shared.state {
+        case .disconnected: MacControlConnectionStatus(state: "disconnected")
+        case .connecting: MacControlConnectionStatus(state: "connecting")
+        case .connected: MacControlConnectionStatus(state: "connected", gatewayVersion: summary.gatewayVersion)
+        case .degraded: MacControlConnectionStatus(state: "degraded", error: "Gateway connection needs attention.")
+        }
+        return MacControlPrimaryStatus(
+            mode: mode.rawValue,
+            transport: mode == .remote ? state.remoteTransport.rawValue : nil,
+            sshTarget: mode == .remote && state.remoteTransport == .ssh ? state.remoteTarget : nil,
+            url: url,
+            remotePort: mode == .remote && state.remoteTransport == .ssh
+                ? GatewayRemoteConfig.resolveRemotePort(root: OpenClawConfigFile.loadDict()) : nil,
+            tunnel: MacControlTunnelStatus(running: tunnel.running, localPort: tunnel.localPort.map(Int.init)),
+            connection: connection)
+    }
+
+    func setPrimary(_ configuration: PrimaryGatewayControlConfiguration) async throws -> MacControlPrimaryStatus {
+        try Task.checkCancellation()
+        let state = AppStateStore.shared
+        try state.setPrimaryGateway(configuration)
+        let generation = state.gatewayRoutingGeneration
+        await RemoteTunnelManager.shared.stopAll()
+        try self.requireCurrentPrimary(generation)
+        await ControlChannel.shared.disconnect()
+        try self.requireCurrentPrimary(generation)
+        await GatewayEndpointStore.shared.refresh()
+        try self.requireCurrentPrimary(generation)
+        await ConnectionModeCoordinator.shared.apply(mode: state.connectionMode, paused: state.isPaused)
+        try self.requireCurrentPrimary(generation)
+        return try await self.primaryStatus()
+    }
+
+    private func requireCurrentPrimary(_ generation: UInt64) throws {
+        try Task.checkCancellation()
+        guard AppStateStore.shared.gatewayRoutingGeneration == generation else {
+            throw MacControlError(
+                code: "superseded",
+                message: "The primary Gateway changed during this request. Inspect status before retrying.")
+        }
+    }
+
+    func gateways() async throws -> [MacControlGatewayStatus] {
+        let profiles = try await MacGatewayProfileStore.shared.catalogProfiles()
+        var result: [MacControlGatewayStatus] = []
+        for profile in profiles {
+            let connection = await MacGatewayConnectionFleet.shared.existingConnection(profileID: profile.profile.id)
+            let summary = await connection?.connectionSummary()
+            let expired = profile.browserSessionExpiresAt.map { $0 <= Date() } ?? false
+            let identity: MacControlIdentity? = if let subject = profile.browserSessionSubject,
+                                                   let expiry = profile.browserSessionExpiresAt
+            {
+                MacControlIdentity(subject: subject, expiresAt: expiry.ISO8601Format())
+            } else {
+                nil
+            }
+            // Legacy unauthenticated profiles have no credential field; token is the existing shared-secret route.
+            let auth = switch profile.authKind {
+            case .browser: "browser"
+            case .password: "password"
+            case .token, nil: "token"
+            }
+            result.append(MacControlGatewayStatus(
+                id: profile.profile.id,
+                name: profile.profile.name,
+                url: profile.profile.url.absoluteString,
+                auth: auth,
+                identity: identity,
+                connection: MacControlConnectionStatus(
+                    state: summary?.connected == true && !expired ? "connected" : "disconnected",
+                    error: expired ? "Browser sign-in expired. Reconnect this Gateway." : nil)))
+        }
+        return result
+    }
+
+    func addGateway(_ request: MacControlRequest) async throws -> MacControlGatewayStatus {
+        try Task.checkCancellation()
+        let profile = try await GatewayBrowserSignInCoordinator.connect(
+            name: request.name ?? "",
+            address: request.url ?? "",
+            token: request.token ?? "",
+            password: request.password ?? "")
+        return try await self.gateway(id: profile.id)
+    }
+
+    func removeGateway(id: String) async throws {
+        try Task.checkCancellation()
+        _ = try await MacGatewayProfileStore.shared.remove(profileID: id)
+    }
+
+    func reconnectGateway(id: String) async throws -> MacControlGatewayStatus {
+        let profiles = try await MacGatewayProfileStore.shared.catalogProfiles()
+        guard let profile = profiles.first(where: { $0.profile.id == id }) else {
+            throw MacGatewayProfileError.profileNotFound
+        }
+        try Task.checkCancellation()
+        if profile.usesBrowserIdentity {
+            _ = try await GatewayBrowserSignInCoordinator.connect(
+                name: profile.profile.name,
+                address: profile.profile.url.absoluteString,
+                token: "",
+                password: "")
+        } else {
+            let binding = try await MacGatewayConnectionFleet.shared.binding(profileID: id)
+            try Task.checkCancellation()
+            await binding.connection.shutdown(ifCurrent: { !Task.isCancelled })
+            try Task.checkCancellation()
+            _ = try await binding.connection.acquireServerLease()
+        }
+        return try await self.gateway(id: id)
+    }
+
+    private func gateway(id: String) async throws -> MacControlGatewayStatus {
+        guard let profile = try await self.gateways().first(where: { $0.id == id }) else {
+            throw MacGatewayProfileError.profileNotFound
+        }
+        return profile
+    }
+}

--- a/apps/macos/Sources/OpenClaw/MacControlRequestHandler.swift
+++ b/apps/macos/Sources/OpenClaw/MacControlRequestHandler.swift
@@ -1,0 +1,220 @@
+import Foundation
+import OpenClawIPC
+
+@MainActor
+protocol MacControlOwner {
+    func status() async throws -> MacControlStatus
+    func setPrimary(_ configuration: PrimaryGatewayControlConfiguration) async throws -> MacControlPrimaryStatus
+    func gateways() async throws -> [MacControlGatewayStatus]
+    func addGateway(_ request: MacControlRequest) async throws -> MacControlGatewayStatus
+    func removeGateway(id: String) async throws
+    func reconnectGateway(id: String) async throws -> MacControlGatewayStatus
+}
+
+/// Dispatch stays independent of app singletons; the live owner holds all persistence and lifecycle authority.
+@MainActor
+final class MacControlRequestHandler {
+    private let owner: any MacControlOwner
+    private var mutationInProgress = false
+
+    init(owner: any MacControlOwner) {
+        self.owner = owner
+    }
+
+    func handle(_ request: MacControlRequest) async -> Data {
+        do {
+            try Task.checkCancellation()
+            switch request.operation {
+            case "status":
+                var status = try await self.owner.status()
+                status.primary = Self.redacted(status.primary)
+                status.gateways = status.gateways.map(Self.redacted)
+                return try Self.encode(status)
+            case "gateway.list":
+                return try await Self.encode(self.owner.gateways().map(Self.redacted))
+            case "primary.set", "primary.clear", "gateway.add", "gateway.remove", "gateway.reconnect":
+                guard !self.mutationInProgress else {
+                    throw MacControlError(
+                        code: "busy",
+                        message: "Another Gateway change is in progress. Try again when it finishes.")
+                }
+                self.mutationInProgress = true
+                defer { self.mutationInProgress = false }
+                return try await self.mutate(request)
+            default:
+                throw MacControlError(code: "invalid_request", message: "Unknown control operation.")
+            }
+        } catch {
+            return Self.encodeError(error)
+        }
+    }
+
+    private func mutate(_ request: MacControlRequest) async throws -> Data {
+        switch request.operation {
+        case "primary.set", "primary.clear":
+            let configuration = request.operation == "primary.clear"
+                ? PrimaryGatewayControlConfiguration.clear
+                : try Self.primaryConfiguration(request)
+            try Task.checkCancellation()
+            return try await Self.encode(Self.redacted(self.owner.setPrimary(configuration)))
+        case "gateway.add":
+            guard let name = request.name, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                  let address = request.url, !address.isEmpty,
+                  request.browser == true ||
+                  request.token?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false ||
+                  request.password?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false
+            else {
+                throw MacControlError(
+                    code: "invalid_request",
+                    message: "Provide a name and URL; choose --browser or token/password file or stdin authentication.")
+            }
+            try Task.checkCancellation()
+            return try await Self.encode(Self.redacted(self.owner.addGateway(request)))
+        case "gateway.remove", "gateway.reconnect":
+            guard let query = request.idOrName, !query.isEmpty else {
+                throw MacControlError(code: "invalid_request", message: "Provide the saved Gateway ID or name.")
+            }
+            let profiles = try await self.owner.gateways()
+            let profile = try Self.resolve(query, in: profiles)
+            try Task.checkCancellation()
+            if request.operation == "gateway.remove" {
+                try await self.owner.removeGateway(id: profile.id)
+                return try Self.encode(RemovalResult(id: profile.id, removed: true))
+            }
+            return try await Self.encode(Self.redacted(self.owner.reconnectGateway(id: profile.id)))
+        default:
+            throw MacControlError(code: "invalid_request", message: "Unknown control operation.")
+        }
+    }
+
+    private struct RemovalResult: Codable, Sendable {
+        let id: String
+        let removed: Bool
+    }
+
+    private static func primaryConfiguration(_ request: MacControlRequest) throws
+    -> PrimaryGatewayControlConfiguration {
+        if request.mode == "local", request.transport == nil, request.url == nil, request.sshTarget == nil,
+           request.token == nil, request.password == nil, request.remotePort == nil, request.localPort == nil,
+           request.identityPath == nil, request.hostKeyPolicy == nil, request.tlsFingerprint == nil
+        {
+            return .local
+        }
+        guard request.mode == nil else {
+            throw MacControlError(code: "invalid_request", message: "Choose local mode or one remote transport.")
+        }
+        switch request.transport {
+        case "direct":
+            guard let raw = request.url, let url = URL(string: raw), request.sshTarget == nil,
+                  request.remotePort == nil, request.localPort == nil, request.identityPath == nil,
+                  request.hostKeyPolicy == nil
+            else {
+                throw MacControlError(
+                    code: "invalid_request",
+                    message: "Direct transport requires a WebSocket URL and no SSH options.")
+            }
+            return .direct(
+                url: url,
+                token: request.token,
+                password: request.password,
+                tlsFingerprint: request.tlsFingerprint)
+        case "ssh":
+            guard let target = request.sshTarget, request.url == nil, request.tlsFingerprint == nil else {
+                throw MacControlError(
+                    code: "invalid_request",
+                    message: "SSH transport requires an SSH target and no direct URL options.")
+            }
+            let policy = request.hostKeyPolicy.flatMap(CommandResolver.SSHHostKeyPolicy.init(rawValue:))
+            guard request.hostKeyPolicy == nil || policy != nil else {
+                throw MacControlError(
+                    code: "invalid_request",
+                    message: "SSH host-key policy must be strict or openssh.")
+            }
+            return .ssh(
+                target: target,
+                remotePort: request.remotePort,
+                localPort: request.localPort,
+                identity: request.identityPath,
+                hostKeyPolicy: policy,
+                token: request.token,
+                password: request.password)
+        default:
+            throw MacControlError(
+                code: "invalid_request",
+                message: "Choose local mode, SSH transport, or direct transport.")
+        }
+    }
+
+    private static func resolve(
+        _ query: String,
+        in profiles: [MacControlGatewayStatus]) throws -> MacControlGatewayStatus
+    {
+        if let exact = profiles.first(where: { $0.id == query }) { return exact }
+        let matches = profiles.filter { $0.name.caseInsensitiveCompare(query) == .orderedSame }
+        if matches.count == 1, let match = matches.first { return match }
+        guard !matches.isEmpty else {
+            throw MacControlError(code: "not_found", message: "No saved Gateway matches that ID or name.")
+        }
+        let candidates = matches.map { "\($0.name) (\($0.id))" }.sorted().joined(separator: ", ")
+        throw MacControlError(code: "ambiguous_name", message: "Gateway name is ambiguous. Use an ID: \(candidates)")
+    }
+
+    static func redactedURL(_ raw: String) -> String {
+        guard var parts = URLComponents(string: raw),
+              ["ws", "wss"].contains(parts.scheme?.lowercased() ?? ""),
+              parts.host?.isEmpty == false
+        else { return "" }
+        parts.user = nil
+        parts.password = nil
+        parts.query = nil
+        parts.fragment = nil
+        return parts.url?.absoluteString ?? ""
+    }
+
+    private static func redacted(_ primary: MacControlPrimaryStatus) -> MacControlPrimaryStatus {
+        var value = primary
+        value.url = self.redactedURL(value.url)
+        value.connection = self.redacted(value.connection)
+        return value
+    }
+
+    private static func redacted(_ gateway: MacControlGatewayStatus) -> MacControlGatewayStatus {
+        var value = gateway
+        value.url = self.redactedURL(value.url)
+        value.connection = self.redacted(value.connection)
+        return value
+    }
+
+    private static func redacted(_ connection: MacControlConnectionStatus) -> MacControlConnectionStatus {
+        var value = connection
+        if value.error != nil {
+            value.error = "Connection unavailable. Check Gateway settings and reconnect."
+        }
+        return value
+    }
+
+    private static func encode(_ result: some Codable & Sendable) throws -> Data {
+        try JSONEncoder().encode(MacControlResponse(result: result))
+    }
+
+    private static func encodeError(_ error: Error) -> Data {
+        let safe: MacControlError = switch error {
+        case let error as MacControlError:
+            error
+        case is CancellationError:
+            MacControlError(code: "cancelled", message: "The control request was cancelled.")
+        case let error as PrimaryGatewayControlError:
+            MacControlError(code: "primary_failed", message: error.localizedDescription)
+        case let error as MacGatewayProfileError:
+            MacControlError(code: "gateway_failed", message: error.localizedDescription)
+        case let error as GatewayBrowserSessionError:
+            MacControlError(code: "sign_in_failed", message: error.localizedDescription)
+        default:
+            MacControlError(
+                code: "operation_failed",
+                message: "The app could not complete the Gateway operation. Check Gateway settings and try again.")
+        }
+        return (try? JSONEncoder().encode(MacControlResponse<String>(error: safe))) ??
+            Data(#"{"ok":false,"error":{"code":"operation_failed","message":"Could not encode the response."}}"#.utf8)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/MacControlServer.swift
+++ b/apps/macos/Sources/OpenClaw/MacControlServer.swift
@@ -1,0 +1,153 @@
+import Darwin
+import Foundation
+import OpenClawIPC
+import OSLog
+
+/// A nonce is consumed before dispatch, so a signed mutation cannot be replayed within its TTL.
+actor MacControlRequestAuthenticator {
+    private var nonces: [String: Date] = [:]
+
+    func authenticate(
+        _ envelope: MacControlEnvelope,
+        token: String,
+        peerUID: uid_t,
+        ownerUID: uid_t,
+        now: Date = Date()) throws -> MacControlRequest
+    {
+        guard peerUID == ownerUID, envelope.authenticated(token: token, now: now) else {
+            throw MacControlError(code: "authentication_failed", message: "App control authentication failed.")
+        }
+        self.nonces = self.nonces.filter { $0.value >= now }
+        guard self.nonces[envelope.nonce] == nil else {
+            throw MacControlError(code: "authentication_failed", message: "App control request was already used.")
+        }
+        guard self.nonces.count < 1024 else {
+            throw MacControlError(code: "busy", message: "Too many app control requests; try again shortly.")
+        }
+        let request = try JSONDecoder().decode(MacControlRequest.self, from: Data(envelope.requestJson.utf8))
+        self.nonces[envelope.nonce] = Date(timeIntervalSince1970: Double(envelope.ts) / 1000 + 15)
+        return request
+    }
+}
+
+@MainActor
+final class MacControlServer {
+    static let shared = MacControlServer()
+    private nonisolated static let logger = Logger(subsystem: "ai.openclaw", category: "mac-control")
+
+    private var listener: LocalSocketServer?
+    private var startup: Task<Void, Never>?
+    private var cleanup: Task<Void, Never>?
+    private var generation: UInt64 = 0
+
+    func start() {
+        guard self.listener == nil, self.startup == nil,
+              AppProfile.current.validationError == nil else { return }
+        self.generation &+= 1
+        let generation = self.generation
+        let directory = AppProfile.current.stateDirectoryURL()
+        let tokenURL = directory.appendingPathComponent(MacControlCredentials.tokenFilename)
+        let listener = LocalSocketServer(
+            socketPath: directory.appendingPathComponent(MacControlCredentials.socketFilename).path,
+            logger: Self.logger)
+        let handler = MacControlRequestHandler(owner: MacControlLiveOwner())
+        let authenticator = MacControlRequestAuthenticator()
+        let previousCleanup = self.cleanup
+        self.listener = listener
+        self.startup = Task { [weak self] in
+            await previousCleanup?.value
+            guard !Task.isCancelled else { return }
+            let ready = await withTaskCancellationHandler {
+                await listener.start(
+                    prepare: { _ = try MacControlCredentials.createIfMissing(at: tokenURL) },
+                    handler: { handle in
+                        await Self.handleClient(
+                            handle, tokenURL: tokenURL, authenticator: authenticator, handler: handler)
+                    },
+                    onUnexpectedStop: {
+                        Self.logger.error("App control listener stopped unexpectedly; restart the app to restore it.")
+                    })
+            } onCancel: {
+                listener.stop()
+            }
+            guard let self, self.generation == generation, !Task.isCancelled else {
+                await listener.stop().value
+                return
+            }
+            self.startup = nil
+            if !ready {
+                Self.logger
+                    .error("App control listener could not start; check the profile socket and credential permissions.")
+                self.cleanup = listener.stop()
+                self.listener = nil
+            }
+        }
+    }
+
+    @discardableResult
+    func stop() -> Task<Void, Never>? {
+        self.generation &+= 1
+        let startup = self.startup
+        startup?.cancel()
+        let shutdown = self.listener?.stop()
+        self.startup = nil
+        self.listener = nil
+        guard startup != nil || shutdown != nil else { return self.cleanup }
+        let previous = self.cleanup
+        let cleanup = Task {
+            await previous?.value
+            await startup?.value
+            await shutdown?.value
+        }
+        self.cleanup = cleanup
+        return cleanup
+    }
+
+    private nonisolated static func handleClient(
+        _ handle: FileHandle,
+        tokenURL: URL,
+        authenticator: MacControlRequestAuthenticator,
+        handler: MacControlRequestHandler) async
+    {
+        do {
+            try Task.checkCancellation()
+            let fd = handle.fileDescriptor
+            var uid = uid_t(0)
+            var gid = gid_t(0)
+            guard getpeereid(fd, &uid, &gid) == 0, uid == geteuid() else {
+                throw MacControlError(code: "authentication_failed", message: "App control requires the app's user.")
+            }
+            try configureSocketTimeouts(fd, timeoutMs: 15000)
+            guard let line = try readLineFromSocket(fd, maxBytes: MacControlCredentials.maximumFrameBytes) else {
+                return
+            }
+            let envelope = try JSONDecoder().decode(MacControlEnvelope.self, from: Data(line.utf8))
+            // Read on every request: a missing or replaced credential never falls back to a cached token.
+            let token = try MacControlCredentials.read(at: tokenURL)
+            let request = try await authenticator.authenticate(
+                envelope, token: token, peerUID: uid, ownerUID: geteuid())
+            try Task.checkCancellation()
+            let response = await handler.handle(request)
+            try Task.checkCancellation()
+            try self.send(response, to: handle)
+        } catch {
+            guard !Task.isCancelled else { return }
+            let failure = error as? MacControlError ?? MacControlError(
+                code: "invalid_request", message: "Could not read a valid app control request.")
+            if let data = try? JSONEncoder().encode(MacControlResponse<Bool>(error: failure)) {
+                try? self.send(data, to: handle)
+            }
+        }
+    }
+
+    private nonisolated static func send(_ data: Data, to handle: FileHandle) throws {
+        guard data.count < MacControlCredentials.maximumFrameBytes else {
+            throw MacControlError(
+                code: "response_too_large",
+                message: "The app control result exceeds the response limit.")
+        }
+        var frame = data
+        frame.append(0x0A)
+        try handle.write(contentsOf: frame)
+    }
+}

--- a/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
+++ b/apps/macos/Sources/OpenClaw/MacGatewayProfiles.swift
@@ -351,7 +351,8 @@ actor MacGatewayProfileStore {
                 canPromote: token?.isEmpty == false,
                 usesBrowserIdentity: browserSession != nil,
                 browserSessionExpiresAt: browserSession?.expiresAt,
-                authKind: authKind)
+                authKind: authKind,
+                browserSessionSubject: browserSession?.subject)
         }
     }
 
@@ -573,6 +574,10 @@ actor MacGatewayConnectionFleet {
     struct Binding {
         let connection: GatewayConnection
         let chatStoreID: String
+    }
+
+    func existingConnection(profileID: String) -> GatewayConnection? {
+        self.connections[profileID]?.connection
     }
 
     func connection(profileID: String) async -> GatewayConnection {

--- a/apps/macos/Sources/OpenClaw/MenuBar.swift
+++ b/apps/macos/Sources/OpenClaw/MenuBar.swift
@@ -152,6 +152,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private let webChatAutoLogger = Logger(subsystem: "ai.openclaw", category: "Chat")
     private static func cleanUpProcesses() async {
         let execHostCleanup = ExecApprovalsPromptServer.shared.stop()
+        let macControlCleanup = MacControlServer.shared.stop()
         // Start tunnel retirement before helper drains can consume the quit deadline.
         async let tunnelCleanup: Void = RemoteTunnelManager.shared.shutdown()
         async let gatewayCleanup: Void = GatewayConnection.shared.shutdown()
@@ -164,6 +165,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         await MacNodeModeCoordinator.shared.stopAndWait()
         _ = await (tunnelCleanup, gatewayCleanup, profileCleanup)
         await execHostCleanup?.value
+        await macControlCleanup?.value
     }
 
     var openDashboardAction: @MainActor () -> Void = { AppNavigationActions.openDashboard() }
@@ -354,6 +356,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             NodePairingApprovalPrompter.shared.start()
             DevicePairingApprovalPrompter.shared.start()
             ExecApprovalsPromptServer.shared.start()
+            MacControlServer.shared.start()
             ExecApprovalsGatewayPrompter.shared.start()
             if let state {
                 CookieSyncManager.shared.start(state: state)
@@ -401,6 +404,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         NodePairingApprovalPrompter.shared.stop()
         DevicePairingApprovalPrompter.shared.stop()
         ExecApprovalsPromptServer.shared.stop()
+        MacControlServer.shared.stop()
         ExecApprovalsGatewayPrompter.shared.stop()
         MacNodeModeCoordinator.shared.stop()
         CookieSyncManager.shared.stop()

--- a/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
+++ b/apps/macos/Sources/OpenClaw/OpenClawConfigFile.swift
@@ -78,7 +78,8 @@ enum OpenClawConfigFile {
     static func saveDict(
         _ dict: [String: Any],
         preserveExistingKeys: Bool = false,
-        allowGatewayAuthMutation: Bool = false)
+        allowGatewayAuthMutation: Bool = false,
+        allowGatewayModeRemoval: Bool = false)
         -> Bool
     {
         self.withFileLock {
@@ -144,7 +145,9 @@ enum OpenClawConfigFile {
                 if preservedGatewayAuth {
                     suspicious.append("gateway-auth-preserved")
                 }
-                let blocking = self.configWriteBlockingReasons(suspicious)
+                let blocking = self.configWriteBlockingReasons(suspicious).filter {
+                    !(allowGatewayModeRemoval && $0 == "gateway-mode-removed")
+                }
                 if !blocking.isEmpty {
                     let rejectedPath = self.persistRejectedConfigWrite(data: data, configURL: url)
                     self.logger.warning("config write rejected (\(blocking.joined(separator: ", "))) at \(url.path)")

--- a/apps/macos/Sources/OpenClaw/PrimaryGatewayControlConfiguration.swift
+++ b/apps/macos/Sources/OpenClaw/PrimaryGatewayControlConfiguration.swift
@@ -45,6 +45,11 @@ enum PrimaryGatewayControlConfiguration: Sendable {
         let clearsTargetDefaults: Bool
     }
 
+    var isClear: Bool {
+        if case .clear = self { return true }
+        return false
+    }
+
     var requestedLocalPort: Int? {
         switch self {
         case let .ssh(_, _, localPort, _, _, _, _): localPort

--- a/apps/macos/Sources/OpenClaw/PrimaryGatewayControlConfiguration.swift
+++ b/apps/macos/Sources/OpenClaw/PrimaryGatewayControlConfiguration.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+enum PrimaryGatewayControlError: LocalizedError {
+    case invalidURL
+    case invalidSSHTarget
+    case invalidPort
+    case unavailable
+    case conflictingEdits
+    case persistenceFailed
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidURL:
+            "Use a Gateway WebSocket URL without embedded credentials, query, or fragment; public hosts require wss://."
+        case .invalidSSHTarget:
+            "Use a valid SSH target in the form user@host[:port]."
+        case .invalidPort:
+            "Gateway ports must be between 1 and 65535."
+        case .unavailable:
+            "The app is not ready to change its primary Gateway."
+        case .conflictingEdits:
+            "Resolve the connection settings conflict in the app before changing the primary Gateway."
+        case .persistenceFailed:
+            "The app could not save the primary Gateway configuration."
+        }
+    }
+}
+
+/// Complete primary selections use the AppState persistence owner, including its conflict and publication fence.
+enum PrimaryGatewayControlConfiguration: Sendable {
+    case local
+    case clear
+    case direct(url: URL, token: String?, password: String?, tlsFingerprint: String?)
+    case ssh(
+        target: String,
+        remotePort: Int?,
+        localPort: Int?,
+        identity: String?,
+        hostKeyPolicy: CommandResolver.SSHHostKeyPolicy?,
+        token: String?,
+        password: String?)
+
+    struct Replacement {
+        let root: [String: Any]
+        let clearsTargetDefaults: Bool
+    }
+
+    var requestedLocalPort: Int? {
+        switch self {
+        case let .ssh(_, _, localPort, _, _, _, _): localPort
+        case .local, .clear, .direct: nil
+        }
+    }
+
+    func replacingRoot(_ current: [String: Any], effectiveLocalPort: Int) throws -> Replacement {
+        var root = current
+        var gateway = root["gateway"] as? [String: Any] ?? [:]
+        let previousRemote = gateway["remote"] as? [String: Any] ?? [:]
+        let clearsTargetDefaults: Bool
+        switch self {
+        case .clear:
+            gateway.removeValue(forKey: "mode")
+            gateway.removeValue(forKey: "remote")
+            clearsTargetDefaults = true
+        case .local:
+            gateway["mode"] = "local"
+            clearsTargetDefaults = false
+        case let .direct(url, token, password, fingerprint):
+            guard let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                  components.user == nil, components.password == nil,
+                  components.query == nil, components.fragment == nil,
+                  let normalized = GatewayRemoteConfig.normalizeGatewayUrl(url.absoluteString)
+            else { throw PrimaryGatewayControlError.invalidURL }
+            clearsTargetDefaults = GatewayRemoteConfig.resolveTransport(root: current) != .direct ||
+                GatewayRemoteConfig.resolveGatewayUrl(root: current) != normalized
+            gateway["mode"] = "remote"
+            var remote = Self.replacingRemoteRoute(previousRemote)
+            remote["transport"] = "direct"
+            remote["url"] = normalized.absoluteString
+            remote["token"] = Self.nonempty(token)
+            remote["password"] = Self.nonempty(password)
+            remote["tlsFingerprint"] = Self.nonempty(fingerprint)
+            gateway["remote"] = remote
+        case let .ssh(target, remotePort, localPort, identity, hostKeyPolicy, token, password):
+            let target = target.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard CommandResolver.sshTargetValidationMessage(target) == nil,
+                  let parsedTarget = CommandResolver.parseSSHTarget(target)
+            else { throw PrimaryGatewayControlError.invalidSSHTarget }
+            for port in [remotePort, localPort].compactMap(\.self) {
+                guard (1...65535).contains(port) else { throw PrimaryGatewayControlError.invalidPort }
+            }
+            clearsTargetDefaults = GatewayRemoteConfig.resolveTransport(root: current) != .ssh ||
+                (previousRemote["sshTarget"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) != target
+            var remote = Self.replacingRemoteRoute(previousRemote)
+            guard (1...65535).contains(effectiveLocalPort) else { throw PrimaryGatewayControlError.invalidPort }
+            let previousRemotePort = clearsTargetDefaults ? nil : RemotePortTunnel.resolveRemotePortOverride(
+                defaultRemotePort: effectiveLocalPort,
+                for: parsedTarget.host,
+                root: current) ?? effectiveLocalPort
+            let resolvedRemotePort = remotePort ?? previousRemotePort ?? 18789
+            let previousPolicy = (previousRemote["sshHostKeyPolicy"] as? String)
+                .flatMap(CommandResolver.SSHHostKeyPolicy.init(rawValue:))
+            remote["transport"] = "ssh"
+            remote["url"] = "ws://127.0.0.1:\(effectiveLocalPort)"
+            remote["remotePort"] = resolvedRemotePort
+            remote["sshTarget"] = target
+            remote["sshIdentity"] = identity.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) } ??
+                (clearsTargetDefaults ? nil : previousRemote["sshIdentity"] as? String)
+            remote["sshHostKeyPolicy"] = (hostKeyPolicy ??
+                (clearsTargetDefaults ? nil : previousPolicy) ?? .strict).rawValue
+            remote["token"] = Self.nonempty(token)
+            remote["password"] = Self.nonempty(password)
+            gateway["mode"] = "remote"
+            if let localPort { gateway["port"] = localPort }
+            gateway["remote"] = remote
+        }
+        if gateway.isEmpty {
+            root.removeValue(forKey: "gateway")
+        } else {
+            root["gateway"] = gateway
+        }
+        return Replacement(root: root, clearsTargetDefaults: clearsTargetDefaults)
+    }
+
+    private static func replacingRemoteRoute(_ previous: [String: Any]) -> [String: Any] {
+        var remote = previous
+        for key in [
+            "transport", "url", "token", "password", "tlsFingerprint", "sshTarget", "sshIdentity",
+            "sshHostKeyPolicy", "remotePort",
+        ] {
+            remote.removeValue(forKey: key)
+        }
+        return remote
+    }
+
+    private static func nonempty(_ value: String?) -> String? {
+        guard let value, !value.isEmpty else { return nil }
+        return value
+    }
+}

--- a/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
+++ b/apps/macos/Sources/OpenClaw/RemotePortTunnel.swift
@@ -18,6 +18,21 @@ final class RemotePortTunnel: @unchecked Sendable {
         let identity: String
         let remotePort: Int
         let hostKeyPolicy: CommandResolver.SSHHostKeyPolicy
+        let preferredLocalPort: UInt16?
+
+        init(
+            target: CommandResolver.SSHParsedTarget,
+            identity: String,
+            remotePort: Int,
+            hostKeyPolicy: CommandResolver.SSHHostKeyPolicy,
+            preferredLocalPort: UInt16? = nil)
+        {
+            self.target = target
+            self.identity = identity
+            self.remotePort = remotePort
+            self.hostKeyPolicy = hostKeyPolicy
+            self.preferredLocalPort = preferredLocalPort
+        }
     }
 
     let localPort: UInt16?
@@ -78,11 +93,22 @@ final class RemotePortTunnel: @unchecked Sendable {
             defaultRemotePort: remotePort,
             for: sshHost,
             root: root) ?? remotePort
+        // Named profiles reserve their startup port; an explicit config preference can still change live.
+        let preferredLocalPort = OpenClawConfigFile.gatewayPort(root: root)
+            .flatMap(UInt16.init(exactly:))
+            .map { port in
+                UInt16(GatewayEnvironment.resolvedGatewayPort(
+                    environment: ProcessInfo.processInfo.environment,
+                    configPort: Int(port),
+                    storedPort: 0,
+                    profile: .current))
+            }
         return Configuration(
             target: target,
             identity: settings.identity.trimmingCharacters(in: .whitespacesAndNewlines),
             remotePort: resolvedRemotePort,
-            hostKeyPolicy: settings.sshHostKeyPolicy)
+            hostKeyPolicy: settings.sshHostKeyPolicy,
+            preferredLocalPort: preferredLocalPort)
     }
 
     static func create(

--- a/apps/macos/Sources/OpenClaw/RemoteTunnelManager.swift
+++ b/apps/macos/Sources/OpenClaw/RemoteTunnelManager.swift
@@ -37,6 +37,13 @@ actor RemoteTunnelManager {
     private var lastRestartAt: Date?
     private let restartBackoffSeconds: TimeInterval = 2.0
 
+    func controlTunnelStatus() -> (running: Bool, localPort: UInt16?) {
+        guard !self.isShutDown, self.retirementInFlight == nil,
+              let active = self.controlTunnel, active.tunnel.isRunning
+        else { return (false, nil) }
+        return (true, active.tunnel.localPort)
+    }
+
     func controlTunnelRouteIfRunning() async -> Route? {
         guard !self.isShutDown, self.retirementInFlight == nil else { return nil }
         guard let configuration = try? RemotePortTunnel.configuration(
@@ -211,7 +218,7 @@ actor RemoteTunnelManager {
                   self.createInFlight == nil, currentConfiguration == configuration
             else { continue }
 
-            let desiredPort = UInt16(GatewayEnvironment.gatewayPort())
+            let desiredPort = configuration.preferredLocalPort ?? UInt16(GatewayEnvironment.gatewayPort())
             let token = UUID()
             let task = Task {
                 try await RemotePortTunnel.create(

--- a/apps/macos/Sources/OpenClawIPC/MacControlAuthentication.swift
+++ b/apps/macos/Sources/OpenClawIPC/MacControlAuthentication.swift
@@ -1,0 +1,95 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+public struct MacControlEnvelope: Codable, Sendable {
+    public var id: String
+    public var nonce: String
+    public var ts: Int64
+    public var requestJson: String
+    public var hmac: String
+
+    public init(request: MacControlRequest, token: String, now: Date = Date()) throws {
+        self.id = UUID().uuidString
+        self.nonce = UUID().uuidString
+        self.ts = Int64(now.timeIntervalSince1970 * 1000)
+        guard let requestJson = try String(data: JSONEncoder().encode(request), encoding: .utf8) else {
+            throw MacControlError(code: "invalid_request", message: "Could not encode the control request.")
+        }
+        self.requestJson = requestJson
+        self.hmac = Self.signature(nonce: self.nonce, ts: self.ts, requestJson: self.requestJson, token: token)
+    }
+
+    public func authenticated(token: String, now: Date = Date()) -> Bool {
+        let nowMs = now.timeIntervalSince1970 * 1000
+        guard !token.isEmpty, !self.nonce.isEmpty, self.nonce.utf8.count <= 128,
+              abs(nowMs - Double(self.ts)) <= 15000,
+              self.hmac.utf8.count == 64
+        else { return false }
+        let expected = Self.signature(nonce: self.nonce, ts: self.ts, requestJson: self.requestJson, token: token)
+        var difference: UInt8 = 0
+        for (lhs, rhs) in zip(expected.utf8, self.hmac.utf8) {
+            difference |= lhs ^ rhs
+        }
+        return difference == 0
+    }
+
+    private static func signature(nonce: String, ts: Int64, requestJson: String, token: String) -> String {
+        HMAC<SHA256>.authenticationCode(
+            for: Data("\(nonce):\(ts):\(requestJson)".utf8),
+            using: SymmetricKey(data: Data(token.utf8)))
+            .map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+public enum MacControlCredentials {
+    public static let tokenFilename = "mac-control.token"
+    public static let socketFilename = "mac-control.sock"
+    public static let maximumFrameBytes = 64 * 1024
+
+    public static func read(at url: URL, ownerUID: uid_t = geteuid()) throws -> String {
+        let fd = open(url.path, O_RDONLY | O_NOFOLLOW | O_CLOEXEC | O_NONBLOCK)
+        guard fd >= 0 else { throw self.invalidCredentials() }
+        defer { close(fd) }
+        var info = stat()
+        guard fstat(fd, &info) == 0,
+              info.st_mode & S_IFMT == S_IFREG,
+              info.st_mode & 0o777 == 0o600,
+              info.st_uid == ownerUID,
+              info.st_nlink == 1,
+              info.st_size > 0, info.st_size <= 256
+        else { throw self.invalidCredentials() }
+        var bytes = [UInt8](repeating: 0, count: Int(info.st_size))
+        let count = bytes.withUnsafeMutableBytes { Darwin.read(fd, $0.baseAddress, $0.count) }
+        guard count == bytes.count,
+              let token = String(bytes: bytes, encoding: .utf8)?.trimmingCharacters(in: .newlines),
+              !token.isEmpty
+        else { throw self.invalidCredentials() }
+        return token
+    }
+
+    /// Called only by the app while it owns the socket's lifecycle lease.
+    public static func createIfMissing(at url: URL) throws -> String {
+        let fd = open(url.path, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC, 0o600)
+        guard fd >= 0 else {
+            if errno == EEXIST { return try self.read(at: url) }
+            throw self.invalidCredentials()
+        }
+        defer { close(fd) }
+        let token = SymmetricKey(size: .bits256).withUnsafeBytes { bytes in
+            bytes.map { String(format: "%02x", $0) }.joined()
+        }
+        let data = Data(token.utf8)
+        guard fchmod(fd, 0o600) == 0,
+              data.withUnsafeBytes({ Darwin.write(fd, $0.baseAddress, $0.count) }) == data.count
+        else {
+            unlink(url.path)
+            throw self.invalidCredentials()
+        }
+        return token
+    }
+
+    private static func invalidCredentials() -> MacControlError {
+        MacControlError(code: "authentication_failed", message: "App control credentials are missing or unsafe.")
+    }
+}

--- a/apps/macos/Sources/OpenClawIPC/MacControlProfile.swift
+++ b/apps/macos/Sources/OpenClawIPC/MacControlProfile.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+public struct MacControlProfile: Equatable, Sendable {
+    public let name: String?
+
+    public init(rawValue: String?) throws {
+        let value = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if value.isEmpty || value.lowercased() == "default" {
+            self.name = nil
+            return
+        }
+        if let reason = Self.validationReason(value) {
+            throw MacControlError(code: "invalid_profile", message: "Invalid profile: \(reason)")
+        }
+        self.name = value
+    }
+
+    public static func validationReason(_ value: String) -> String? {
+        guard value.utf8.count <= 64,
+              value.utf8.first.map(self.isASCIIAlphanumeric) == true,
+              value.utf8.allSatisfy({ self.isASCIIAlphanumeric($0) || $0 == 45 || $0 == 95 })
+        else {
+            return "use 1-64 letters, numbers, underscores, or hyphens, starting with a letter or number"
+        }
+        guard value == value.lowercased() else {
+            return "macOS profile names must be lowercase so state and LaunchAgent identities cannot collide"
+        }
+        guard !["gateway", "mac", "node"].contains(value) else {
+            return "\"\(value)\" is reserved by an existing OpenClaw LaunchAgent"
+        }
+        return nil
+    }
+
+    public func stateDirectoryURL(homeDirectory: URL) -> URL {
+        Self.stateDirectoryURL(name: self.name, homeDirectory: homeDirectory)
+    }
+
+    public static func stateDirectoryURL(name: String?, homeDirectory: URL) -> URL {
+        homeDirectory.appendingPathComponent(name.map { ".openclaw-\($0)" } ?? ".openclaw", isDirectory: true)
+    }
+
+    private static func isASCIIAlphanumeric(_ byte: UInt8) -> Bool {
+        (48...57).contains(byte) || (65...90).contains(byte) || (97...122).contains(byte)
+    }
+}

--- a/apps/macos/Sources/OpenClawIPC/MacControlProtocol.swift
+++ b/apps/macos/Sources/OpenClawIPC/MacControlProtocol.swift
@@ -16,6 +16,7 @@ public struct MacControlRequest: Codable, Sendable {
     public var name: String?
     public var browser: Bool?
     public var idOrName: String?
+    public var deadline: Date?
 
     public init(operation: String) {
         self.operation = operation

--- a/apps/macos/Sources/OpenClawIPC/MacControlProtocol.swift
+++ b/apps/macos/Sources/OpenClawIPC/MacControlProtocol.swift
@@ -1,0 +1,178 @@
+import Foundation
+
+public struct MacControlRequest: Codable, Sendable {
+    public var operation: String
+    public var mode: String?
+    public var transport: String?
+    public var sshTarget: String?
+    public var remotePort: Int?
+    public var localPort: Int?
+    public var identityPath: String?
+    public var hostKeyPolicy: String?
+    public var url: String?
+    public var token: String?
+    public var password: String?
+    public var tlsFingerprint: String?
+    public var name: String?
+    public var browser: Bool?
+    public var idOrName: String?
+
+    public init(operation: String) {
+        self.operation = operation
+    }
+}
+
+public struct MacControlConnectionStatus: Codable, Sendable {
+    public var state: String
+    public var gatewayVersion: String?
+    public var error: String?
+
+    public init(state: String, gatewayVersion: String? = nil, error: String? = nil) {
+        self.state = state
+        self.gatewayVersion = gatewayVersion
+        self.error = error
+    }
+}
+
+public struct MacControlTunnelStatus: Codable, Sendable {
+    public var running: Bool
+    public var localPort: Int?
+
+    public init(running: Bool, localPort: Int? = nil) {
+        self.running = running
+        self.localPort = localPort
+    }
+}
+
+public struct MacControlPrimaryStatus: Codable, Sendable {
+    public var mode: String
+    public var transport: String?
+    public var sshTarget: String?
+    public var url: String
+    public var remotePort: Int?
+    public var tunnel: MacControlTunnelStatus
+    public var connection: MacControlConnectionStatus
+
+    public init(
+        mode: String,
+        transport: String?,
+        sshTarget: String? = nil,
+        url: String,
+        remotePort: Int? = nil,
+        tunnel: MacControlTunnelStatus,
+        connection: MacControlConnectionStatus)
+    {
+        self.mode = mode
+        self.transport = transport
+        self.sshTarget = sshTarget
+        self.url = url
+        self.remotePort = remotePort
+        self.tunnel = tunnel
+        self.connection = connection
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case mode, transport, sshTarget, url, remotePort, tunnel, connection
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.mode, forKey: .mode)
+        try container.encode(self.transport, forKey: .transport)
+        try container.encodeIfPresent(self.sshTarget, forKey: .sshTarget)
+        try container.encode(self.url, forKey: .url)
+        try container.encodeIfPresent(self.remotePort, forKey: .remotePort)
+        try container.encode(self.tunnel, forKey: .tunnel)
+        try container.encode(self.connection, forKey: .connection)
+    }
+}
+
+public struct MacControlIdentity: Codable, Sendable {
+    public var provider: String
+    public var subject: String
+    public var expiresAt: String
+
+    public init(provider: String = "cloudflareAccess", subject: String, expiresAt: String) {
+        self.provider = provider
+        self.subject = subject
+        self.expiresAt = expiresAt
+    }
+}
+
+public struct MacControlGatewayStatus: Codable, Sendable {
+    public var id: String
+    public var name: String
+    public var url: String
+    public var auth: String
+    public var identity: MacControlIdentity?
+    public var connection: MacControlConnectionStatus
+
+    public init(
+        id: String,
+        name: String,
+        url: String,
+        auth: String,
+        identity: MacControlIdentity? = nil,
+        connection: MacControlConnectionStatus)
+    {
+        self.id = id
+        self.name = name
+        self.url = url
+        self.auth = auth
+        self.identity = identity
+        self.connection = connection
+    }
+}
+
+public struct MacControlAppStatus: Codable, Sendable {
+    public var version: String
+    public var build: String
+    public var profile: String
+
+    public init(version: String, build: String, profile: String) {
+        self.version = version
+        self.build = build
+        self.profile = profile
+    }
+}
+
+public struct MacControlStatus: Codable, Sendable {
+    public var primary: MacControlPrimaryStatus
+    public var gateways: [MacControlGatewayStatus]
+    public var app: MacControlAppStatus
+
+    public init(primary: MacControlPrimaryStatus, gateways: [MacControlGatewayStatus], app: MacControlAppStatus) {
+        self.primary = primary
+        self.gateways = gateways
+        self.app = app
+    }
+}
+
+public struct MacControlError: Codable, LocalizedError, Sendable {
+    public var code: String
+    public var message: String
+    public var errorDescription: String? {
+        self.message
+    }
+
+    public init(code: String, message: String) {
+        self.code = code
+        self.message = message
+    }
+}
+
+public struct MacControlResponse<Result: Codable & Sendable>: Codable, Sendable {
+    public var ok: Bool
+    public var result: Result?
+    public var error: MacControlError?
+
+    public init(result: Result) {
+        self.ok = true
+        self.result = result
+    }
+
+    public init(error: MacControlError) {
+        self.ok = false
+        self.error = error
+    }
+}

--- a/apps/macos/Sources/OpenClawMacCLI/ConfigureRemoteCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/ConfigureRemoteCommand.swift
@@ -87,6 +87,8 @@ func runConfigureRemote(_ args: [String]) {
               openclaw-mac configure-remote --direct-url <ws://host:port|wss://host> [--token <token>]
                                           [--password <password>] [--project-root <path>] [--cli-path <path>] [--json]
 
+            Offline preconfiguration; prefer openclaw-mac primary set when the app is running.
+
             Options:
               --ssh-target <t>    SSH target for the remote gateway host.
               --direct-url <url>  Direct remote gateway URL; skips SSH tunneling.
@@ -170,7 +172,7 @@ private func configureSSHRemote(
     root["gateway"] = gateway
 
     try saveConfigRoot(root, to: configURL)
-    writeAppDefaults(opts: opts, target: target, suites: defaultsSuites)
+    writeAppDefaults(opts: opts, target: target, targetChanged: existingTarget != target, suites: defaultsSuites)
 
     return ConfigureRemoteOutput(
         status: "ok",
@@ -206,6 +208,8 @@ private func configureDirectRemote(
     var gateway = root["gateway"] as? [String: Any] ?? [:]
     var remote = gateway["remote"] as? [String: Any] ?? [:]
 
+    let targetChanged = remote["transport"] as? String != "direct"
+        || remote["url"] as? String != directURL.absoluteString
     gateway["mode"] = "remote"
     remote["transport"] = "direct"
     remote["url"] = directURL.absoluteString
@@ -219,7 +223,7 @@ private func configureDirectRemote(
     root["gateway"] = gateway
 
     try saveConfigRoot(root, to: configURL)
-    writeAppDefaults(opts: opts, target: "", suites: defaultsSuites)
+    writeAppDefaults(opts: opts, target: "", targetChanged: targetChanged, suites: defaultsSuites)
 
     return ConfigureRemoteOutput(
         status: "ok",
@@ -246,9 +250,15 @@ private func saveConfigRoot(_ root: [String: Any], to url: URL) throws {
     try data.write(to: url, options: [.atomic])
 }
 
-private func writeAppDefaults(opts: ConfigureRemoteOptions, target: String, suites: [String]) {
+private func writeAppDefaults(opts: ConfigureRemoteOptions, target: String, targetChanged: Bool, suites: [String]) {
     for suite in suites {
         guard let defaults = UserDefaults(suiteName: suite) else { continue }
+        let previousTarget = defaults.string(forKey: "openclaw.remoteTarget") ?? ""
+        if targetChanged || previousTarget != target {
+            for key in ["openclaw.remoteIdentity", "openclaw.remoteProjectRoot", "openclaw.remoteCliPath"] {
+                defaults.removeObject(forKey: key)
+            }
+        }
         defaults.set("remote", forKey: "openclaw.connectionMode")
         setDefaultString(defaults, key: "openclaw.remoteTarget", value: target)
         defaults.set(true, forKey: "openclaw.onboardingSeen")

--- a/apps/macos/Sources/OpenClawMacCLI/EntryPoint.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/EntryPoint.swift
@@ -7,6 +7,7 @@ struct RootCommand: Equatable {
 
 enum RootCommandAction: Equatable {
     case usage
+    case control([String])
     case connect([String])
     case configureRemote([String])
     case discover([String])
@@ -21,6 +22,8 @@ struct OpenClawMacCLI {
         switch resolveRootCommandAction(args) {
         case .usage:
             printUsage()
+        case let .control(commandArgs):
+            runMacControl(commandArgs)
         case let .connect(commandArgs):
             await runConnect(commandArgs)
         case let .configureRemote(commandArgs):
@@ -44,10 +47,12 @@ func parseRootCommand(_ args: [String]) -> RootCommand? {
 
 func resolveRootCommandAction(_ args: [String]) -> RootCommandAction {
     guard let command = parseRootCommand(args) else {
-        return .usage
+        return .control(args)
     }
 
     switch command.name {
+    case "status", "primary", "gateway", "--profile", "--json", "--timeout", "--launch", "--no-launch":
+        return .control(args)
     case "-h", "--help", "help":
         return .usage
     case "connect":
@@ -68,6 +73,10 @@ private func printUsage() {
     openclaw-mac
 
     Usage:
+      openclaw-mac status [--json] [--profile <name>] [--no-launch]
+      openclaw-mac primary show|set|clear [options]
+      openclaw-mac gateway list|add|remove|reconnect [options]
+        Run openclaw-mac primary --help for app control options.
       openclaw-mac connect [--url <ws://host:port>] [--token <token>] [--password <password>]
                            [--mode <local|remote>] [--timeout <ms>] [--probe] [--json]
                            [--client-id <id>] [--client-mode <mode>] [--display-name <name>]

--- a/apps/macos/Sources/OpenClawMacCLI/MacControlClient.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/MacControlClient.swift
@@ -14,6 +14,10 @@ struct MacControlClient {
         defer { close(fd) }
         let token = try MacControlCredentials
             .read(at: directory.appendingPathComponent(MacControlCredentials.tokenFilename))
+        var request = request
+        let remaining = ContinuousClock.now.duration(to: deadline).components
+        request.deadline = Date().addingTimeInterval(
+            Double(remaining.seconds) + Double(remaining.attoseconds) / 1e18)
         var data = try JSONEncoder().encode(MacControlEnvelope(request: request, token: token))
         data.append(0x0A)
         guard data.count <= MacControlCredentials.maximumFrameBytes else {

--- a/apps/macos/Sources/OpenClawMacCLI/MacControlClient.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/MacControlClient.swift
@@ -1,0 +1,180 @@
+import Darwin
+import Foundation
+import OpenClawIPC
+
+struct MacControlClient {
+    let options: MacControlOptions
+
+    func send(_ request: MacControlRequest) throws -> Data {
+        let directory = self.options.profile
+            .stateDirectoryURL(homeDirectory: FileManager.default.homeDirectoryForCurrentUser)
+        let socketURL = directory.appendingPathComponent(MacControlCredentials.socketFilename)
+        let deadline = ContinuousClock.now + .milliseconds(self.options.timeoutMs)
+        let fd = try self.reachableSocket(at: socketURL, deadline: deadline)
+        defer { close(fd) }
+        let token = try MacControlCredentials
+            .read(at: directory.appendingPathComponent(MacControlCredentials.tokenFilename))
+        var data = try JSONEncoder().encode(MacControlEnvelope(request: request, token: token))
+        data.append(0x0A)
+        guard data.count <= MacControlCredentials.maximumFrameBytes else {
+            throw MacControlOptions.usage("Request is too large.")
+        }
+        var offset = 0
+        while offset < data.count {
+            try Self.wait(fd, events: Int16(POLLOUT), deadline: deadline)
+            let sent = data.withUnsafeBytes { bytes in
+                Darwin.send(fd, bytes.baseAddress!.advanced(by: offset), data.count - offset, 0)
+            }
+            if sent < 0, errno == EINTR || errno == EAGAIN { continue }
+            guard sent > 0 else { throw Self.unreachable() }
+            offset += sent
+        }
+        var response = Data()
+        while response.count < MacControlCredentials.maximumFrameBytes {
+            try Self.wait(fd, events: Int16(POLLIN), deadline: deadline)
+            var bytes = [UInt8](
+                repeating: 0,
+                count: min(4096, MacControlCredentials.maximumFrameBytes - response.count))
+            let count = bytes.withUnsafeMutableBytes { recv(fd, $0.baseAddress, $0.count, 0) }
+            if count < 0, errno == EINTR || errno == EAGAIN { continue }
+            guard count > 0 else { throw Self.unreachable() }
+            response.append(contentsOf: bytes.prefix(count))
+            if let newline = response.firstIndex(of: 0x0A) {
+                return response.prefix(upTo: newline)
+            }
+        }
+        throw MacControlError(code: "invalid_response", message: "The app returned an oversized response.")
+    }
+
+    private func reachableSocket(at url: URL, deadline: ContinuousClock.Instant) throws -> Int32 {
+        if let fd = try? Self.connect(at: url, deadline: deadline) { return fd }
+        guard self.options.launch else { throw Self.unreachable() }
+        try self.launchApp(deadline: deadline)
+        while ContinuousClock.now < deadline {
+            if let fd = try? Self.connect(at: url, deadline: deadline) { return fd }
+            usleep(100_000)
+        }
+        throw Self.unreachable()
+    }
+
+    private static func connect(at url: URL, deadline: ContinuousClock.Instant) throws -> Int32 {
+        var info = stat()
+        guard lstat(url.path, &info) == 0, info.st_mode & S_IFMT == S_IFSOCK,
+              info.st_uid == geteuid(), info.st_mode & 0o777 == 0o600
+        else { throw Self.unreachable() }
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let path = Array(url.path.utf8CString)
+        guard path.count <= MemoryLayout.size(ofValue: address.sun_path) else {
+            throw MacControlError(code: "unreachable", message: "The app control socket path is too long.")
+        }
+        withUnsafeMutableBytes(of: &address.sun_path) { destination in
+            path.withUnsafeBytes { source in destination.copyBytes(from: source) }
+        }
+        address.sun_len = UInt8(MemoryLayout<sockaddr_un>.size)
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw Self.unreachable() }
+        do {
+            guard fcntl(fd, F_SETFL, O_NONBLOCK) == 0, fcntl(fd, F_SETFD, FD_CLOEXEC) == 0 else {
+                throw Self.unreachable()
+            }
+            var noSignal: Int32 = 1
+            guard setsockopt(
+                fd,
+                SOL_SOCKET,
+                SO_NOSIGPIPE,
+                &noSignal,
+                socklen_t(MemoryLayout.size(ofValue: noSignal))) ==
+                0
+            else {
+                throw Self.unreachable()
+            }
+            let result = withUnsafePointer(to: &address) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    Darwin.connect(fd, $0, socklen_t(MemoryLayout<sockaddr_un>.size))
+                }
+            }
+            if result != 0 {
+                guard errno == EINPROGRESS else { throw Self.unreachable() }
+                try Self.wait(fd, events: Int16(POLLOUT), deadline: deadline)
+                var error: Int32 = 0
+                var size = socklen_t(MemoryLayout.size(ofValue: error))
+                guard getsockopt(fd, SOL_SOCKET, SO_ERROR, &error, &size) == 0, error == 0 else {
+                    throw Self.unreachable()
+                }
+            }
+            var peerUID: uid_t = 0
+            var peerGID: gid_t = 0
+            guard getpeereid(fd, &peerUID, &peerGID) == 0, peerUID == geteuid() else {
+                throw Self.unreachable()
+            }
+            return fd
+        } catch {
+            close(fd)
+            throw error
+        }
+    }
+
+    private static func wait(_ fd: Int32, events: Int16, deadline: ContinuousClock.Instant) throws {
+        while true {
+            let remaining = ContinuousClock.now.duration(to: deadline)
+            guard remaining > .zero else { throw Self.operationTimedOut() }
+            let components = remaining.components
+            let milliseconds = min(
+                Int64(Int32.max),
+                components.seconds * 1000 + components.attoseconds / 1_000_000_000_000_000)
+            var descriptor = pollfd(fd: fd, events: events, revents: 0)
+            let result = poll(&descriptor, 1, Int32(max(1, milliseconds)))
+            if result < 0, errno == EINTR { continue }
+            if result == 0 { throw Self.operationTimedOut() }
+            guard result > 0, descriptor.revents & events != 0 else { throw Self.unreachable() }
+            return
+        }
+    }
+
+    static func applicationBundle(executableURL: URL) -> URL {
+        let executable = executableURL.resolvingSymlinksInPath()
+        let bundle = executable.deletingLastPathComponent().deletingLastPathComponent().deletingLastPathComponent()
+        if bundle.pathExtension == "app", executable.deletingLastPathComponent().lastPathComponent == "MacOS" {
+            return bundle
+        }
+        return URL(fileURLWithPath: "/Applications/OpenClaw.app")
+    }
+
+    private func launchApp(deadline: ContinuousClock.Instant) throws {
+        let executable = Bundle.main.executableURL ?? URL(fileURLWithPath: CommandLine.arguments[0])
+        let bundle = Self.applicationBundle(executableURL: executable)
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+        // A different profile may already own the same bundle id. The app's per-profile lock arbitrates duplicates.
+        process.arguments = [
+            "-gj", "-n", "-a", bundle.path,
+            "--env", "OPENCLAW_PROFILE=\(self.options.profile.name ?? "default")", "--args", "--background-only",
+        ]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do { try process.run() } catch { throw Self.unreachable() }
+        while process.isRunning, ContinuousClock.now < deadline {
+            usleep(10000)
+        }
+        if process.isRunning { process.terminate()
+            throw Self.unreachable()
+        }
+        guard process.terminationStatus == 0 else { throw Self.unreachable() }
+    }
+
+    private static func operationTimedOut() -> MacControlError {
+        MacControlError(
+            code: "operation_timeout",
+            message: "Timed out waiting for the app. The operation may still be running; check status before retrying.")
+    }
+
+    private static func unreachable() -> MacControlError {
+        MacControlError(
+            code: "unreachable",
+            message: """
+            OpenClaw app is not reachable for this profile. \
+            Start the app or retry with --launch and a longer --timeout.
+            """)
+    }
+}

--- a/apps/macos/Sources/OpenClawMacCLI/MacControlCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/MacControlCommand.swift
@@ -1,0 +1,175 @@
+import Darwin
+import Foundation
+import OpenClawIPC
+
+func runMacControl(_ args: [String]) {
+    do {
+        var options = try MacControlOptions.parse(args, environment: ProcessInfo.processInfo.environment)
+        if options.help { printMacControlUsage()
+            return
+        }
+        if options.request.operation == "gateway.remove", !options.yes {
+            guard isatty(STDIN_FILENO) == 1 else {
+                throw MacControlOptions.usage("gateway remove requires --yes when standard input is not a terminal.")
+            }
+            fputs("Remove this saved Gateway and its credentials? [y/N] ", stderr)
+            guard let answer = readLine()?.lowercased(), answer == "y" || answer == "yes" else {
+                throw MacControlError(code: "cancelled", message: "Gateway removal cancelled.")
+            }
+        }
+        options.request.token = try readMacControlSecret(options.tokenSource)
+        options.request.password = try readMacControlSecret(options.passwordSource)
+        if options.request.browser == true, options.request.token == nil, options.request.password == nil {
+            fputs("Complete sign-in in your browser…\n", stderr)
+        }
+        let response = try MacControlClient(options: options).send(options.request)
+        let result = try macControlResult(response, primaryOnly: options.primaryOnly)
+        if options.json {
+            guard let text = String(data: result, encoding: .utf8) else {
+                throw MacControlError(code: "invalid_response", message: "The app returned invalid text.")
+            }
+            print(text)
+        } else {
+            try printMacControlResult(result, operation: options.request.operation, primaryOnly: options.primaryOnly)
+        }
+    } catch {
+        let controlError = error as? MacControlError
+            ?? MacControlError(code: "operation_failed", message: "The app control operation failed.")
+        if args.contains("--json"),
+           let data = try? JSONEncoder().encode(MacControlResponse<String>(error: controlError)),
+           let text = String(data: data, encoding: .utf8)
+        {
+            fputs(text + "\n", stderr)
+        } else {
+            fputs("openclaw-mac: \(controlError.message)\n", stderr)
+        }
+        exit(controlError.code == "usage" || controlError
+            .code == "invalid_profile" ? 1 : (controlError.code == "unreachable" ? 2 : 3))
+    }
+}
+
+func macControlResult(_ response: Data, primaryOnly: Bool) throws -> Data {
+    guard let object = try JSONSerialization.jsonObject(with: response) as? [String: Any],
+          let ok = object["ok"] as? Bool
+    else { throw MacControlError(code: "invalid_response", message: "The app returned an invalid response.") }
+    if !ok {
+        guard let error = object["error"] as? [String: String], let code = error["code"],
+              let message = error["message"]
+        else {
+            throw MacControlError(code: "invalid_response", message: "The app returned an invalid error.")
+        }
+        throw MacControlError(code: code, message: message)
+    }
+    guard var result = object["result"] else {
+        throw MacControlError(code: "invalid_response", message: "The app returned no result.")
+    }
+    if primaryOnly {
+        guard let primary = (result as? [String: Any])?["primary"] else {
+            throw MacControlError(code: "invalid_response", message: "The app returned no primary status.")
+        }
+        result = primary
+    }
+    return try JSONSerialization.data(withJSONObject: result, options: [.sortedKeys, .fragmentsAllowed])
+}
+
+func readMacControlSecret(_ source: MacControlOptions.SecretSource?) throws -> String? {
+    guard let source else { return nil }
+    let handle: FileHandle
+    switch source {
+    case .stdin: handle = .standardInput
+    case let .file(path):
+        guard let file = FileHandle(forReadingAtPath: NSString(string: path).expandingTildeInPath) else {
+            throw MacControlOptions.usage("Could not read the secret file.")
+        }
+        handle = file
+    }
+    defer { if source != .stdin { try? handle.close() } }
+    var data = Data()
+    do {
+        while data.count <= MacControlCredentials.maximumFrameBytes {
+            let remaining = MacControlCredentials.maximumFrameBytes + 1 - data.count
+            let chunk = try handle.read(upToCount: min(4096, remaining)) ?? Data()
+            if chunk.isEmpty { break }
+            data.append(chunk)
+        }
+    } catch {
+        throw MacControlOptions.usage("Could not read the secret input.")
+    }
+    guard data.count <= MacControlCredentials.maximumFrameBytes, var value = String(data: data, encoding: .utf8) else {
+        throw MacControlOptions.usage("Secret input must be bounded UTF-8 text.")
+    }
+    while value.last == "\n" || value.last == "\r" {
+        value.removeLast()
+    }
+    guard !value.isEmpty else { throw MacControlOptions.usage("Secret input is empty.") }
+    return value
+}
+
+private func printMacControlResult(_ data: Data, operation: String, primaryOnly: Bool) throws {
+    let decoder = JSONDecoder()
+    if operation == "status", !primaryOnly {
+        let status = try decoder.decode(MacControlStatus.self, from: data)
+        print("OpenClaw \(status.app.version) (\(status.app.build)) · profile \(status.app.profile)")
+        print("NAME\tCONNECTION\tURL")
+        print("Primary (\(status.primary.mode))\t\(status.primary.connection.state)\t\(status.primary.url)")
+        for gateway in status.gateways {
+            printMacControlGateway(gateway)
+        }
+    } else if operation.hasPrefix("primary.") || primaryOnly {
+        let primary = try decoder.decode(MacControlPrimaryStatus.self, from: data)
+        print("MODE\tTRANSPORT\tCONNECTION\tURL")
+        print("\(primary.mode)\t\(primary.transport ?? "—")\t\(primary.connection.state)\t\(primary.url)")
+    } else if operation == "gateway.list" {
+        print("NAME\tCONNECTION\tURL")
+        for gateway in try decoder
+            .decode([MacControlGatewayStatus].self, from: data)
+        {
+            printMacControlGateway(gateway)
+        }
+    } else if operation == "gateway.remove" {
+        print("Gateway removed.")
+    } else {
+        try printMacControlGateway(decoder.decode(MacControlGatewayStatus.self, from: data))
+    }
+}
+
+private func printMacControlGateway(_ gateway: MacControlGatewayStatus) {
+    print("\(gateway.name)\t\(gateway.connection.state)\t\(gateway.url)")
+    if let identity = gateway.identity {
+        print("  \(identity.subject) · expires \(identity.expiresAt)")
+    }
+}
+
+private func printMacControlUsage() {
+    print("""
+    openclaw-mac app control
+
+    Usage:
+      openclaw-mac status
+      openclaw-mac primary show|clear
+      openclaw-mac primary set --ssh-target user@host[:port]
+        [--remote-port PORT] [--local-port PORT] [--identity PATH]
+        [--ssh-host-key-policy strict|openssh] [secret options]
+      openclaw-mac primary set --direct-url ws://host|wss://host [--tls-fingerprint SHA256] [secret options]
+      openclaw-mac primary set --local
+      openclaw-mac gateway list
+      openclaw-mac gateway add NAME --url https://host[/base]|wss://host [--browser] [secret options]
+      openclaw-mac gateway remove ID_OR_NAME [--yes]
+      openclaw-mac gateway reconnect ID_OR_NAME
+
+    Global options (before or after commands):
+      --profile NAME     Overrides OPENCLAW_PROFILE; default profile when unset.
+      --json             Print the result as JSON; errors are JSON on stderr.
+      --timeout MS       Deadline: 15000 ms; gateway add/reconnect default to 310000 ms.
+      --launch           Launch the app in the background if needed (default).
+      --no-launch        Fail if the app is not reachable.
+
+    Secret options:
+      --token-file PATH | --token-stdin
+      --password-file PATH | --password-stdin
+      Secrets are read once; trailing newlines are removed. Do not pass secrets in arguments.
+
+    Browser sign-in remains open until completed, failed, or timed out (up to 300 seconds).
+    configure-remote remains available for offline preconfiguration.
+    """)
+}

--- a/apps/macos/Sources/OpenClawMacCLI/MacControlOptions.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/MacControlOptions.swift
@@ -1,0 +1,195 @@
+import Foundation
+import OpenClawIPC
+
+struct MacControlOptions {
+    enum SecretSource: Equatable {
+        case file(String)
+        case stdin
+    }
+
+    var request: MacControlRequest
+    var profile: MacControlProfile
+    var json = false
+    var launch = true
+    var timeoutMs = 15000
+    var yes = false
+    var help = false
+    var primaryOnly = false
+    var tokenSource: SecretSource?
+    var passwordSource: SecretSource?
+
+    static func parse(_ args: [String], environment: [String: String] = [:]) throws -> Self {
+        let (values, flags, words) = try self.tokenize(args)
+        let profile = try MacControlProfile(rawValue: values["--profile"] ?? environment["OPENCLAW_PROFILE"])
+        let command = words.first ?? "status"
+        let subcommand = words.count > 1 ? words[1] : ""
+        let operation = try self.operation(
+            command: command,
+            subcommand: subcommand,
+            help: flags.contains("--help") || flags.contains("-h"))
+        var options = Self(request: MacControlRequest(operation: operation), profile: profile)
+        options.primaryOnly = command == "primary" && subcommand == "show"
+        options.json = flags.contains("--json")
+        options.launch = !flags.contains("--no-launch")
+        options.yes = flags.contains("--yes")
+        options.help = flags.contains("--help") || flags.contains("-h")
+        if options.help { return options }
+        guard !(flags.contains("--launch") && flags.contains("--no-launch")) else {
+            throw self.usage("Choose --launch or --no-launch.")
+        }
+        options.timeoutMs = operation == "gateway.add" || operation == "gateway.reconnect" ? 310_000 : 15000
+        if let timeout = values["--timeout"] {
+            guard let milliseconds = Int(timeout), (1...3_600_000).contains(milliseconds) else {
+                throw self.usage("--timeout must be an integer from 1 to 3600000 milliseconds.")
+            }
+            options.timeoutMs = milliseconds
+        }
+        options.tokenSource = try self.secretSource(values: values, flags: flags, kind: "token")
+        options.passwordSource = try self.secretSource(values: values, flags: flags, kind: "password")
+        guard !(options.tokenSource == .stdin && options.passwordSource == .stdin) else {
+            throw self.usage("Standard input can supply only one secret.")
+        }
+        let globals: Set = ["--profile", "--timeout", "--json", "--launch", "--no-launch"]
+        let secrets: Set = ["--token-file", "--password-file", "--token-stdin", "--password-stdin"]
+        var allowed = globals
+        switch operation {
+        case "primary.set":
+            allowed.formUnion(secrets)
+            allowed.formUnion([
+                "--ssh-target", "--remote-port", "--local-port", "--identity", "--ssh-host-key-policy",
+                "--direct-url", "--tls-fingerprint", "--local",
+            ])
+            try options.configurePrimary(values: values, flags: flags)
+        case "gateway.add":
+            allowed.formUnion(secrets)
+            allowed.formUnion(["--url", "--browser"])
+            guard words.count == 3, let url = values["--url"], !url.isEmpty else {
+                throw self.usage("gateway add requires a name and --url.")
+            }
+            options.request.name = words[2]
+            options.request.url = url
+            options.request.browser = flags.contains("--browser")
+                || (options.tokenSource == nil && options.passwordSource == nil)
+        case "gateway.remove", "gateway.reconnect":
+            if operation == "gateway.remove" { allowed.insert("--yes") }
+            guard words.count == 3 else { throw self.usage("A Gateway id or name is required.") }
+            options.request.idOrName = words[2]
+        default: break
+        }
+        guard Set(values.keys).union(flags).isSubset(of: allowed) else {
+            throw self.usage("An option is not supported by this command. Use --help.")
+        }
+        let expectedWords = command == "status" ? 1 :
+            (operation.hasPrefix("gateway.") && operation != "gateway.list" ? 3 : 2)
+        guard words.count == expectedWords || words.isEmpty else { throw self.usage("Unexpected command arguments.") }
+        return options
+    }
+
+    private static func operation(command: String, subcommand: String, help: Bool) throws -> String {
+        switch (command, subcommand) {
+        case ("status", ""): return "status"
+        case ("primary", "show"): return "status"
+        case ("primary", "set"): return "primary.set"
+        case ("primary", "clear"): return "primary.clear"
+        case ("gateway", "list"): return "gateway.list"
+        case ("gateway", "add"): return "gateway.add"
+        case ("gateway", "remove"): return "gateway.remove"
+        case ("gateway", "reconnect"): return "gateway.reconnect"
+        default:
+            if help { return "status" }
+            throw self.usage("Expected status, primary show|set|clear, or gateway list|add|remove|reconnect.")
+        }
+    }
+
+    private static func tokenize(_ args: [String]) throws -> ([String: String], Set<String>, [String]) {
+        var values: [String: String] = [:]
+        var flags = Set<String>()
+        var words: [String] = []
+        let valueFlags: Set = [
+            "--profile", "--timeout", "--ssh-target", "--remote-port", "--local-port", "--identity",
+            "--ssh-host-key-policy", "--direct-url", "--tls-fingerprint", "--url", "--token-file", "--password-file",
+        ]
+        let switchFlags: Set = [
+            "--json", "--launch", "--no-launch", "--local", "--browser", "--token-stdin", "--password-stdin",
+            "--yes", "--help", "-h",
+        ]
+        var index = 0
+        while index < args.count {
+            let argument = args[index]
+            if argument == "--token" || argument == "--password"
+                || argument.hasPrefix("--token=") || argument.hasPrefix("--password=")
+            {
+                throw self.usage("Secrets must use --token-file/--token-stdin or --password-file/--password-stdin.")
+            }
+            if valueFlags.contains(argument) {
+                guard values[argument] == nil, index + 1 < args.count, !args[index + 1].hasPrefix("--") else {
+                    throw self.usage("A value is required exactly once for \(argument).")
+                }
+                index += 1
+                values[argument] = args[index]
+            } else if switchFlags.contains(argument) {
+                flags.insert(argument)
+            } else if argument.hasPrefix("-") {
+                throw self.usage("Unknown option. Use --help for supported options.")
+            } else {
+                words.append(argument)
+            }
+            index += 1
+        }
+        return (values, flags, words)
+    }
+
+    private mutating func configurePrimary(values: [String: String], flags: Set<String>) throws {
+        let modes = [values["--ssh-target"] != nil, values["--direct-url"] != nil, flags.contains("--local")]
+        guard modes.filter(\.self).count == 1 else {
+            throw Self.usage("Choose exactly one of --ssh-target, --direct-url, or --local.")
+        }
+        self.request.mode = flags.contains("--local") ? "local" : nil
+        self.request
+            .transport = values["--ssh-target"] != nil ? "ssh" : (values["--direct-url"] != nil ? "direct" : nil)
+        self.request.sshTarget = values["--ssh-target"]
+        self.request.url = values["--direct-url"]
+        self.request.identityPath = values["--identity"]
+        self.request.hostKeyPolicy = values["--ssh-host-key-policy"]
+        self.request.tlsFingerprint = values["--tls-fingerprint"]
+        self.request.remotePort = try Self.port(values["--remote-port"])
+        self.request.localPort = try Self.port(values["--local-port"])
+        if let policy = self.request.hostKeyPolicy, !["strict", "openssh"].contains(policy) {
+            throw Self.usage("--ssh-host-key-policy must be strict or openssh.")
+        }
+        let sshFlags = ["--remote-port", "--local-port", "--identity", "--ssh-host-key-policy"]
+        guard self.request.transport == "ssh" || !sshFlags.contains(where: { values[$0] != nil }) else {
+            throw Self.usage("SSH options require --ssh-target.")
+        }
+        guard self.request.transport == "direct" || values["--tls-fingerprint"] == nil else {
+            throw Self.usage("--tls-fingerprint requires --direct-url.")
+        }
+        guard self.request.mode != "local" || (self.tokenSource == nil && self.passwordSource == nil)
+        else {
+            throw Self.usage("--local does not accept remote credentials.")
+        }
+    }
+
+    private static func secretSource(
+        values: [String: String],
+        flags: Set<String>,
+        kind: String) throws -> SecretSource?
+    {
+        let file = values["--\(kind)-file"]
+        let stdin = flags.contains("--\(kind)-stdin")
+        guard file == nil || !stdin else { throw self.usage("Choose a file or standard input for each secret.") }
+        return file.map(SecretSource.file) ?? (stdin ? .stdin : nil)
+    }
+
+    private static func port(_ raw: String?) throws -> Int? {
+        guard let raw else { return nil }
+        guard let port = Int(raw), (1...65535).contains(port) else {
+            throw self.usage("Ports must be integers from 1 to 65535.")
+        }
+        return port
+    }
+
+    static func usage(_ message: String) -> MacControlError {
+        MacControlError(code: "usage", message: message)
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/AppStateRemoteConfigTests.swift
@@ -415,7 +415,7 @@ struct AppStateRemoteConfigTests {
             ]))
             let original = OpenClawConfigFile.loadDict()
             var saveAttempts = 0
-            let state = AppState(preview: true, gatewayConfigSaver: { _ in
+            let state = AppState(preview: true, gatewayConfigSaver: { _, _ in
                 saveAttempts += 1
                 return false
             })
@@ -458,7 +458,7 @@ struct AppStateRemoteConfigTests {
                     ],
                 ],
             ]))
-            let state = AppState(preview: true, gatewayConfigSaver: { _ in false })
+            let state = AppState(preview: true, gatewayConfigSaver: { _, _ in false })
             state._testEnableGatewayConfigSync()
 
             state.remoteToken = "app-token"
@@ -569,7 +569,7 @@ struct AppStateRemoteConfigTests {
             var rejectSaves = false
             let state = AppState(
                 preview: true,
-                gatewayConfigSaver: { root in
+                gatewayConfigSaver: { root, _ in
                     rejectSaves ? false : OpenClawConfigFile.saveDict(root)
                 })
             state.remoteIdentity = "/tmp/app-identity"

--- a/apps/macos/Tests/OpenClawIPCTests/ConfigureRemoteCommandTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConfigureRemoteCommandTests.swift
@@ -63,6 +63,51 @@ struct ConfigureRemoteCommandTests {
         }
     }
 
+    @Test @MainActor func `configure remote clears host defaults only when target changes`() async throws {
+        let configURL = FileManager().temporaryDirectory
+            .appendingPathComponent("openclaw-configure-retarget-\(UUID().uuidString).json")
+        let suite = "ConfigureRemoteCommandTests.retarget.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suite))
+        defer {
+            try? FileManager().removeItem(at: configURL)
+            defaults.removePersistentDomain(forName: suite)
+        }
+
+        try await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configURL.path]) {
+            try configureRemote(
+                .init(
+                    sshTarget: "alice@first.example",
+                    identity: "/tmp/first-identity",
+                    projectRoot: "/srv/first",
+                    cliPath: "/opt/first/openclaw"),
+                defaultsSuites: [suite])
+            try configureRemote(.init(sshTarget: "alice@first.example"), defaultsSuites: [suite])
+            #expect(defaults.string(forKey: "openclaw.remoteIdentity") == "/tmp/first-identity")
+            #expect(defaults.string(forKey: "openclaw.remoteProjectRoot") == "/srv/first")
+            #expect(defaults.string(forKey: "openclaw.remoteCliPath") == "/opt/first/openclaw")
+
+            try configureRemote(
+                .init(sshTarget: "alice@second.example", cliPath: "/opt/second/openclaw"),
+                defaultsSuites: [suite])
+            #expect(defaults.string(forKey: "openclaw.remoteIdentity") == nil)
+            #expect(defaults.string(forKey: "openclaw.remoteProjectRoot") == nil)
+            #expect(defaults.string(forKey: "openclaw.remoteCliPath") == "/opt/second/openclaw")
+
+            try configureRemote(.init(directUrl: "wss://third.example"), defaultsSuites: [suite])
+            #expect(defaults.string(forKey: "openclaw.remoteTarget") == nil)
+            #expect(defaults.string(forKey: "openclaw.remoteIdentity") == nil)
+            #expect(defaults.string(forKey: "openclaw.remoteProjectRoot") == nil)
+            #expect(defaults.string(forKey: "openclaw.remoteCliPath") == nil)
+
+            try configureRemote(
+                .init(directUrl: "wss://third.example", projectRoot: "/srv/third"), defaultsSuites: [suite])
+            try configureRemote(.init(directUrl: "wss://third.example"), defaultsSuites: [suite])
+            #expect(defaults.string(forKey: "openclaw.remoteProjectRoot") == "/srv/third")
+            try configureRemote(.init(directUrl: "wss://fourth.example"), defaultsSuites: [suite])
+            #expect(defaults.string(forKey: "openclaw.remoteProjectRoot") == nil)
+        }
+    }
+
     @Test @MainActor func `configure remote preserves existing optional credentials when flags omitted`() async throws {
         let configURL = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-configure-remote-preserve-\(UUID().uuidString).json")

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayEndpointStoreTests.swift
@@ -1564,6 +1564,14 @@ extension GatewayEndpointStoreTests {
                 identity: routeA.identity,
                 remotePort: routeA.remotePort,
                 hostKeyPolicy: .openssh)))
+        #expect(!RemoteTunnelManager._testCanReuse(
+            routeA,
+            for: .init(
+                target: routeA.target,
+                identity: routeA.identity,
+                remotePort: routeA.remotePort,
+                hostKeyPolicy: routeA.hostKeyPolicy,
+                preferredLocalPort: 23000)))
     }
 
     @Test func `ssh restart backoff propagates cancellation`() async {

--- a/apps/macos/Tests/OpenClawIPCTests/GatewayLocalMutationRoutingTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/GatewayLocalMutationRoutingTests.swift
@@ -21,7 +21,7 @@ struct GatewayLocalMutationRoutingTests {
             "OPENCLAW_GATEWAY_PASSWORD": nil,
         ]) {
             var canPersist = false
-            let state = AppState(preview: true, gatewayConfigSaver: { root in
+            let state = AppState(preview: true, gatewayConfigSaver: { root, _ in
                 canPersist && OpenClawConfigFile.saveDict(root)
             })
             try #require(state.remoteTransport == .direct)

--- a/apps/macos/Tests/OpenClawIPCTests/MacControlCommandTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacControlCommandTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import OpenClawIPC
+import Testing
+@testable import OpenClawMacCLI
+
+struct MacControlCommandTests {
+    @Test func `new command parsing routes globals and profile override without reading secrets`() throws {
+        for arguments in [[], ["status"], ["--profile", "fleet", "primary", "show"], ["gateway", "list"]] {
+            #expect(resolveRootCommandAction(arguments) == .control(arguments))
+        }
+        let options = try MacControlOptions.parse([
+            "--profile", "fleet", "primary", "set", "--ssh-target", "alice@gateway.example:2222",
+            "--remote-port", "19000", "--local-port", "19001", "--identity", "/tmp/identity",
+            "--ssh-host-key-policy", "strict", "--token-file", "/does-not-exist", "--json", "--no-launch",
+        ], environment: ["OPENCLAW_PROFILE": "other"])
+        #expect(options.profile.name == "fleet")
+        #expect(options.request.operation == "primary.set")
+        #expect(options.request.transport == "ssh")
+        #expect(options.request.sshTarget == "alice@gateway.example:2222")
+        #expect(options.request.remotePort == 19000)
+        #expect(options.request.localPort == 19001)
+        #expect(options.request.identityPath == "/tmp/identity")
+        #expect(options.request.hostKeyPolicy == "strict")
+        #expect(options.tokenSource == .file("/does-not-exist"))
+        #expect(options.request.token == nil)
+        #expect(options.json && !options.launch)
+    }
+
+    @Test(arguments: [
+        ["primary", "set", "--local", "--token", "synthetic-secret"],
+        ["gateway", "add", "Demo", "--url", "wss://gateway.example", "--password=synthetic-secret"],
+        ["primary", "set", "--local", "--direct-url", "wss://gateway.example"],
+        ["primary", "set", "--direct-url", "wss://gateway.example", "--remote-port", "19000"],
+        ["primary", "set", "--ssh-target", "alice@gateway.example", "--local-port", "65536"],
+        ["primary", "set", "--local", "--token-stdin"],
+        ["status", "--token-file", "/tmp/token"],
+        ["gateway", "add", "Demo", "--url", "wss://gateway.example", "--token-stdin", "--password-stdin"],
+        ["gateway", "add", "Demo", "--url", "wss://gateway.example", "--token-file", "/tmp/token", "--token-stdin"],
+    ])
+    func `invalid invocations fail before reaching the app and do not echo secrets`(_ arguments: [String]) throws {
+        do {
+            _ = try MacControlOptions.parse(arguments)
+            Issue.record("Expected a usage error")
+        } catch let error as MacControlError {
+            #expect(error.code == "usage")
+            #expect(!error.message.contains("synthetic-secret"))
+        }
+    }
+
+    @Test func `browser commands have enough time for sign in and retain explicit deadline`() throws {
+        let browser = try MacControlOptions.parse([
+            "gateway", "add", "Demo", "--url", "https://gateway.example/base", "--browser",
+        ])
+        #expect(browser.request.browser == true)
+        #expect(browser.timeoutMs == 310_000)
+        #expect(try MacControlOptions.parse([
+            "gateway", "add", "Demo", "--url", "https://gateway.example",
+        ]).request.browser == true)
+        #expect(try MacControlOptions.parse([
+            "gateway", "add", "Demo", "--url", "https://gateway.example", "--token-stdin",
+        ]).request.browser == false)
+        #expect(try MacControlOptions.parse(["gateway", "reconnect", "Demo"]).timeoutMs == 310_000)
+        #expect(try MacControlOptions.parse(["gateway", "reconnect", "Demo", "--timeout", "500"]).timeoutMs == 500)
+        #expect(try MacControlOptions.parse(["status"]).timeoutMs == 15000)
+    }
+
+    @Test func `JSON success returns the requested status shape and errors retain structured code`() throws {
+        let response = Data(#"{"ok":true,"result":{"primary":{"mode":"unconfigured","transport":null},"gateways":[]}}"#
+            .utf8)
+        let status = try #require(JSONSerialization.jsonObject(with: macControlResult(
+            response,
+            primaryOnly: false)) as? [String: Any])
+        #expect(status["ok"] == nil)
+        #expect(status["gateways"] is [Any])
+        let primary = try #require(JSONSerialization.jsonObject(with: macControlResult(
+            response,
+            primaryOnly: true)) as? [String: Any])
+        #expect(primary["mode"] as? String == "unconfigured")
+        #expect(primary["transport"] is NSNull)
+        let failure = Data(#"{"ok":false,"error":{"code":"ambiguous_gateway","message":"Choose an id."}}"#.utf8)
+        do {
+            _ = try macControlResult(failure, primaryOnly: false)
+            Issue.record("Expected the app error")
+        } catch let error as MacControlError {
+            #expect(error.code == "ambiguous_gateway")
+            #expect(error.message == "Choose an id.")
+        }
+    }
+
+    @Test func `profile paths share validation with the app and bundle launch stays in its containing app`() throws {
+        let options = try MacControlOptions.parse(["status"], environment: ["OPENCLAW_PROFILE": "fleet"])
+        #expect(options.profile.stateDirectoryURL(homeDirectory: URL(fileURLWithPath: "/private/home"))
+            .path == "/private/home/.openclaw-fleet")
+        for invalid in ["../other", "Fleet", "mac", "node", "gateway"] {
+            #expect(throws: Error.self) { try MacControlOptions.parse(["--profile", invalid, "status"]) }
+        }
+        let bundle = MacControlClient
+            .applicationBundle(executableURL: URL(fileURLWithPath: "/Example/OpenClaw.app/Contents/MacOS/openclaw-mac"))
+        #expect(bundle.path == "/Example/OpenClaw.app")
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/MacControlLiveOwnerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacControlLiveOwnerTests.swift
@@ -1,0 +1,80 @@
+import Foundation
+import OpenClawIPC
+import Testing
+@testable import OpenClaw
+
+@MainActor
+struct MacControlLiveOwnerTests {
+    @Test(arguments: [AppState.ConnectionMode.unconfigured, .local, .remote], [false, true])
+    func `inactive primary status suppresses stale channel errors`(mode: AppState.ConnectionMode, paused: Bool) {
+        let connection = MacControlLiveOwner.primaryConnectionStatus(
+            mode: mode, paused: paused, channelState: .degraded("secret"), gatewayVersion: "1.0")
+        let inactive = mode == .unconfigured || paused
+        #expect(connection.state == (inactive ? "disconnected" : "degraded"))
+        #expect((connection.error == nil) == inactive)
+        #expect(connection.error?.contains("secret") != true)
+    }
+
+    @Test(arguments: ["token", "password"])
+    func `saved credentials wait for connection proof`(auth: String) async throws {
+        let result = try await MacControlLiveOwner.connectSavedGateway(Self.gateway(auth: auth), deadline: nil) {
+            MacControlConnectionStatus(state: "connected", gatewayVersion: "1.0")
+        }
+        #expect(result.id == "saved")
+        #expect(result.connection.state == "connected")
+        #expect(result.connection.gatewayVersion == "1.0")
+        #expect(result.connection.error == nil)
+    }
+
+    @Test(arguments: ["token", "password"])
+    func `connection failure retains saved profile with a safe error`(auth: String) async throws {
+        let result = try await MacControlLiveOwner.connectSavedGateway(Self.gateway(auth: auth), deadline: nil) {
+            throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "token secret"])
+        }
+        #expect(result.id == "saved")
+        #expect(result.connection.state == "disconnected")
+        #expect(result.connection.error != nil)
+        #expect(result.connection.error?.contains("secret") == false)
+    }
+
+    @Test func `browser add keeps its validated status without another connection attempt`() async throws {
+        var gateway = Self.gateway(auth: "browser")
+        gateway.connection = MacControlConnectionStatus(state: "connected")
+        let result = try await MacControlLiveOwner.connectSavedGateway(gateway, deadline: nil) {
+            Issue.record("Browser sign-in must not acquire another lease")
+            throw CancellationError()
+        }
+        #expect(result.connection.state == "connected")
+    }
+
+    @Test func `expired deadline retains the profile without starting a connection`() async throws {
+        let result = try await MacControlLiveOwner.connectSavedGateway(
+            Self.gateway(auth: "token"), deadline: .distantPast)
+        {
+            Issue.record("Expired add must not start a connection")
+            return MacControlConnectionStatus(state: "connected")
+        }
+        #expect(result.id == "saved")
+        #expect(result.connection.state == "disconnected")
+        #expect(result.connection.error != nil)
+    }
+
+    @Test func `deadline cancels a pending connection while retaining the saved profile`() async throws {
+        let result = try await MacControlLiveOwner.connectSavedGateway(
+            Self.gateway(auth: "password"), deadline: Date().addingTimeInterval(0.05))
+        {
+            try await Task.sleep(for: .seconds(30))
+            Issue.record("Connection attempt outlived its deadline")
+            return MacControlConnectionStatus(state: "connected")
+        }
+        #expect(result.id == "saved")
+        #expect(result.connection.state == "disconnected")
+        #expect(result.connection.error != nil)
+    }
+
+    private static func gateway(auth: String) -> MacControlGatewayStatus {
+        MacControlGatewayStatus(
+            id: "saved", name: "Research", url: "wss://gateway.example/", auth: auth,
+            connection: MacControlConnectionStatus(state: "disconnected"))
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/MacControlProtocolTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacControlProtocolTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import OpenClawIPC
+import Testing
+
+struct MacControlProtocolTests {
+    @Test func `authenticated request survives the JSONL wire and rejects tampering or stale timestamp`() throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        var request = MacControlRequest(operation: "gateway.add")
+        request.name = "Demo"
+        request.url = "wss://gateway.example"
+        request.token = "synthetic-gateway-credential"
+        let signed = try MacControlEnvelope(request: request, token: "synthetic-control-credential", now: now)
+        let received = try JSONDecoder().decode(MacControlEnvelope.self, from: JSONEncoder().encode(signed))
+        #expect(received.authenticated(token: "synthetic-control-credential", now: now))
+        #expect(!received.authenticated(token: "wrong-token", now: now))
+        #expect(!received.authenticated(token: "", now: now))
+        #expect(!received.authenticated(token: "synthetic-control-credential", now: now.addingTimeInterval(16)))
+        #expect(!received.authenticated(token: "synthetic-control-credential", now: now.addingTimeInterval(-16)))
+        var tampered = received
+        tampered.requestJson = #"{"operation":"primary.clear"}"#
+        #expect(!tampered.authenticated(token: "synthetic-control-credential", now: now))
+        let decoded = try JSONDecoder().decode(MacControlRequest.self, from: Data(received.requestJson.utf8))
+        #expect(decoded.operation == "gateway.add")
+        #expect(decoded.name == "Demo")
+        #expect(decoded.token == "synthetic-gateway-credential")
+    }
+
+    @Test func `status wire always includes nullable transport and only public connection metadata`() throws {
+        let primary = MacControlPrimaryStatus(
+            mode: "unconfigured", transport: nil, url: "",
+            tunnel: MacControlTunnelStatus(running: false),
+            connection: MacControlConnectionStatus(state: "disconnected"))
+        let gateway = MacControlGatewayStatus(
+            id: "demo", name: "Demo", url: "wss://gateway.example", auth: "browser",
+            identity: MacControlIdentity(subject: "operator@example.test", expiresAt: "2026-09-06T00:00:00Z"),
+            connection: MacControlConnectionStatus(state: "connected"))
+        let status = MacControlStatus(
+            primary: primary, gateways: [gateway], app: MacControlAppStatus(
+                version: "1",
+                build: "2",
+                profile: "default"))
+        let data = try JSONEncoder().encode(MacControlResponse(result: status))
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let result = try #require(object["result"] as? [String: Any])
+        #expect((result["primary"] as? [String: Any])?["transport"] is NSNull)
+        let publicGateway = try #require((result["gateways"] as? [[String: Any]])?.first)
+        #expect(publicGateway["token"] == nil)
+        #expect(publicGateway["password"] == nil)
+        #expect((publicGateway["identity"] as? [String: Any])?["subject"] as? String == "operator@example.test")
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/MacControlRequestAuthenticatorTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacControlRequestAuthenticatorTests.swift
@@ -1,0 +1,32 @@
+import Foundation
+import OpenClawIPC
+import Testing
+@testable import OpenClaw
+
+struct MacControlRequestAuthenticatorTests {
+    @Test func `rejects wrong user without consuming request and rejects replay`() async throws {
+        let authenticator = MacControlRequestAuthenticator()
+        let now = Date(timeIntervalSince1970: 1000)
+        let envelope = try MacControlEnvelope(
+            request: MacControlRequest(operation: "primary.clear"),
+            token: "fixture",
+            now: now)
+        await #expect(throws: MacControlError.self) {
+            try await authenticator.authenticate(envelope, token: "fixture", peerUID: 502, ownerUID: 501, now: now)
+        }
+        let accepted = try await authenticator.authenticate(
+            envelope, token: "fixture", peerUID: 501, ownerUID: 501, now: now)
+        #expect(accepted.operation == "primary.clear")
+        await #expect(throws: MacControlError.self) {
+            try await authenticator.authenticate(envelope, token: "fixture", peerUID: 501, ownerUID: 501, now: now)
+        }
+    }
+
+    @Test func `missing token does not authorize request`() async throws {
+        let authenticator = MacControlRequestAuthenticator()
+        let envelope = try MacControlEnvelope(request: MacControlRequest(operation: "status"), token: "fixture")
+        await #expect(throws: MacControlError.self) {
+            try await authenticator.authenticate(envelope, token: "", peerUID: 501, ownerUID: 501)
+        }
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/MacControlRequestHandlerTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/MacControlRequestHandlerTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import OpenClawIPC
+import Testing
+@testable import OpenClaw
+
+@Suite(.serialized)
+@MainActor
+struct MacControlRequestHandlerTests {
+    @Test func `status removes credentials and raw connection errors from JSON`() async throws {
+        let owner = FakeMacControlOwner()
+        let sensitiveURL = "wss://operator:password-value@gateway.example/path?token=query-secret#fragment-secret"
+        owner.primary.url = sensitiveURL
+        owner.primary.connection.error = "Authorization failed with token error-secret"
+        owner.profiles = [Self.profile(id: "one", name: "Research", url: sensitiveURL)]
+        let handler = MacControlRequestHandler(owner: owner)
+        let data = await handler.handle(MacControlRequest(operation: "status"))
+        let response = try JSONDecoder().decode(MacControlResponse<MacControlStatus>.self, from: data)
+        let status = try #require(response.result)
+        #expect(response.ok)
+        #expect(status.primary.url == "wss://gateway.example/path")
+        #expect(status.gateways.first?.url == "wss://gateway.example/path")
+        let json = String(decoding: data, as: UTF8.self)
+        for secret in ["password-value", "query-secret", "fragment-secret", "error-secret"] {
+            #expect(!json.contains(secret))
+        }
+        #expect(status.primary.connection.error != nil)
+        #expect(owner.removedIDs.isEmpty)
+    }
+
+    @Test func `name resolution prefers exact IDs and rejects ambiguous names before removal`() async throws {
+        let owner = FakeMacControlOwner()
+        owner.profiles = [
+            Self.profile(id: "first", name: "Research"),
+            Self.profile(id: "second", name: "research"),
+            Self.profile(id: "Research", name: "Production"),
+        ]
+        let handler = MacControlRequestHandler(owner: owner)
+        var request = MacControlRequest(operation: "gateway.remove")
+        request.idOrName = "RESEARCH"
+        let ambiguous = try await Self.error(handler, request)
+        #expect(ambiguous.code == "ambiguous_name")
+        #expect(ambiguous.message.contains("first"))
+        #expect(ambiguous.message.contains("second"))
+        #expect(owner.removedIDs.isEmpty)
+        request.idOrName = "Research"
+        _ = await handler.handle(request)
+        #expect(owner.removedIDs == ["Research"])
+        request.idOrName = "missing"
+        #expect(try await Self.error(handler, request).code == "not_found")
+        request.idOrName = "production"
+        _ = await handler.handle(request)
+        #expect(owner.removedIDs == ["Research", "Research"])
+    }
+
+    @Test func `primary set passes the complete request to its owner and returns only status`() async throws {
+        let owner = FakeMacControlOwner()
+        let handler = MacControlRequestHandler(owner: owner)
+        var request = MacControlRequest(operation: "primary.set")
+        request.transport = "ssh"
+        request.sshTarget = "alice@gateway.example:2222"
+        request.remotePort = 18789
+        request.localPort = 19089
+        request.identityPath = "/keys/gateway"
+        request.hostKeyPolicy = "openssh"
+        request.token = "submitted-secret"
+        let data = await handler.handle(request)
+        let response = try JSONDecoder().decode(MacControlResponse<MacControlPrimaryStatus>.self, from: data)
+        #expect(response.ok)
+        #expect(!String(decoding: data, as: UTF8.self).contains("submitted-secret"))
+        guard case let .ssh(target, remotePort, localPort, identity, hostKeyPolicy, token, password) = owner.selection
+        else {
+            Issue.record("Primary selection was not passed to its owner")
+            return
+        }
+        #expect(target == "alice@gateway.example:2222")
+        #expect(remotePort == 18789)
+        #expect(localPort == 19089)
+        #expect(identity == "/keys/gateway")
+        #expect(hostKeyPolicy == .openssh)
+        #expect(token == "submitted-secret")
+        #expect(password == nil)
+    }
+
+    @Test func `invalid operations and mixed configuration do not reach mutation owners`() async throws {
+        let owner = FakeMacControlOwner()
+        let handler = MacControlRequestHandler(owner: owner)
+        var request = MacControlRequest(operation: "primary.set")
+        request.mode = "local"
+        request.transport = "ssh"
+        #expect(try await Self.error(handler, request).code == "invalid_request")
+        #expect(owner.selection == nil)
+        var add = MacControlRequest(operation: "gateway.add")
+        add.name = "Research"
+        add.url = "https://gateway.example"
+        #expect(try await Self.error(handler, add).code == "invalid_request")
+        #expect(owner.addCount == 0)
+        #expect(try await Self.error(handler, MacControlRequest(operation: "exec")).code == "invalid_request")
+    }
+
+    @Test func `in flight browser sign in rejects another mutation but permits status`() async throws {
+        let owner = FakeMacControlOwner()
+        owner.holdSignIn = true
+        let handler = MacControlRequestHandler(owner: owner)
+        var add = MacControlRequest(operation: "gateway.add")
+        add.name = "Research"
+        add.url = "https://gateway.example"
+        add.browser = true
+        let first = Task { await handler.handle(add) }
+        while owner.signInContinuation == nil {
+            await Task.yield()
+        }
+        let blocked = try await Self.error(handler, MacControlRequest(operation: "primary.clear"))
+        #expect(blocked.code == "busy")
+        let statusData = await handler.handle(MacControlRequest(operation: "status"))
+        #expect(try JSONDecoder().decode(MacControlResponse<MacControlStatus>.self, from: statusData).ok)
+        owner.signInContinuation?.resume()
+        owner.signInContinuation = nil
+        let data = await first.value
+        #expect(try JSONDecoder().decode(MacControlResponse<MacControlGatewayStatus>.self, from: data).ok)
+        _ = await handler.handle(MacControlRequest(operation: "primary.clear"))
+        guard case .clear = owner.selection else {
+            Issue.record("Mutation admission did not reopen after browser sign-in")
+            return
+        }
+    }
+
+    @Test func `underlying failures never echo submitted secrets and release mutation admission`() async throws {
+        let owner = FakeMacControlOwner()
+        owner.failure = NSError(
+            domain: "test",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "token submitted-secret"])
+        let handler = MacControlRequestHandler(owner: owner)
+        var request = MacControlRequest(operation: "gateway.add")
+        request.name = "Research"
+        request.url = "https://gateway.example"
+        request.token = "submitted-secret"
+        let error = try await Self.error(handler, request)
+        #expect(error.code == "operation_failed")
+        #expect(!error.message.contains("submitted-secret"))
+        owner.failure = nil
+        let data = await handler.handle(request)
+        #expect(try JSONDecoder().decode(MacControlResponse<MacControlGatewayStatus>.self, from: data).ok)
+    }
+
+    private static func error(
+        _ handler: MacControlRequestHandler,
+        _ request: MacControlRequest) async throws -> MacControlError
+    {
+        let data = await handler.handle(request)
+        let response = try JSONDecoder().decode(MacControlResponse<String>.self, from: data)
+        #expect(!response.ok)
+        return try #require(response.error)
+    }
+
+    fileprivate static func profile(
+        id: String, name: String, url: String = "wss://gateway.example/") -> MacControlGatewayStatus
+    {
+        MacControlGatewayStatus(
+            id: id, name: name, url: url, auth: "token", connection: MacControlConnectionStatus(state: "disconnected"))
+    }
+}
+
+@MainActor
+private final class FakeMacControlOwner: MacControlOwner {
+    var primary = MacControlPrimaryStatus(
+        mode: "unconfigured", transport: nil, url: "",
+        tunnel: MacControlTunnelStatus(running: false), connection: MacControlConnectionStatus(state: "disconnected"))
+    var profiles: [MacControlGatewayStatus] = []
+    var selection: PrimaryGatewayControlConfiguration?
+    var removedIDs: [String] = []
+    var addCount = 0
+    var failure: Error?
+    var holdSignIn = false
+    var signInContinuation: CheckedContinuation<Void, Never>?
+
+    func status() async throws -> MacControlStatus {
+        MacControlStatus(
+            primary: self.primary, gateways: self.profiles,
+            app: MacControlAppStatus(version: "1", build: "1", profile: "test"))
+    }
+
+    func setPrimary(_ configuration: PrimaryGatewayControlConfiguration) async throws -> MacControlPrimaryStatus {
+        self.selection = configuration
+        return self.primary
+    }
+
+    func gateways() async throws -> [MacControlGatewayStatus] {
+        self.profiles
+    }
+
+    func addGateway(_ request: MacControlRequest) async throws -> MacControlGatewayStatus {
+        self.addCount += 1
+        if let failure { throw failure }
+        if self.holdSignIn {
+            await withCheckedContinuation { self.signInContinuation = $0 }
+        }
+        return MacControlRequestHandlerTests.profile(id: "saved", name: request.name ?? "")
+    }
+
+    func removeGateway(id: String) async throws {
+        self.removedIDs.append(id)
+    }
+
+    func reconnectGateway(id: String) async throws -> MacControlGatewayStatus {
+        MacControlRequestHandlerTests.profile(id: id, name: "Research")
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/OpenClawConfigFileTests.swift
@@ -556,7 +556,7 @@ struct OpenClawConfigFileTests {
 
     @MainActor
     @Test
-    func `save dict rejects gateway mode removal and keeps previous config`() async throws {
+    func `save dict requires explicit allowance for primary clear and keeps other writers guarded`() async throws {
         let stateDir = FileManager().temporaryDirectory
             .appendingPathComponent("openclaw-state-\(UUID().uuidString)", isDirectory: true)
         let configPath = stateDir.appendingPathComponent("openclaw.json")
@@ -612,6 +612,24 @@ struct OpenClawConfigFileTests {
             } else {
                 Issue.record("Missing rejected payload path")
             }
+
+            let selection = PrimaryGatewayControlConfiguration.clear
+            let replacement = try selection.replacingRoot(OpenClawConfigFile.loadDict(), effectiveLocalPort: 18789)
+            #expect(OpenClawConfigFile.saveDict(replacement.root, allowGatewayModeRemoval: selection.isClear))
+            let cleared = OpenClawConfigFile.loadDict()
+            let gateway = try #require(cleared["gateway"] as? [String: Any])
+            #expect(gateway["mode"] == nil)
+            #expect(gateway["remote"] == nil)
+            #expect((gateway["auth"] as? [String: String])?["token"] == "test-token")
+
+            let direct = try PrimaryGatewayControlConfiguration.direct(
+                url: #require(URL(string: "wss://gateway.example/")),
+                token: nil, password: nil, tlsFingerprint: nil)
+                .replacingRoot(cleared, effectiveLocalPort: 18789)
+            #expect(OpenClawConfigFile.saveDict(direct.root))
+            #expect(GatewayRemoteConfig
+                .resolveUrlString(root: OpenClawConfigFile.loadDict()) == "wss://gateway.example/")
+            #expect(!OpenClawConfigFile.saveDict(replacement.root))
         }
     }
 }

--- a/apps/macos/Tests/OpenClawIPCTests/PrimaryGatewayControlConfigurationTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PrimaryGatewayControlConfigurationTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Testing
+@testable import OpenClaw
+
+struct PrimaryGatewayControlConfigurationTests {
+    private let previous: [String: Any] = [
+        "agents": ["defaults": ["workspace": "/example/workspace"]],
+        "gateway": [
+            "mode": "remote",
+            "port": 19000,
+            "auth": ["token": "local-credential"],
+            "remote": [
+                "transport": "ssh",
+                "url": "ws://127.0.0.1:19000",
+                "remotePort": 19100,
+                "sshTarget": "operator@old.example",
+                "sshIdentity": "/example/old-key",
+                "sshHostKeyPolicy": "openssh",
+                "token": "old-token",
+                "password": "old-password",
+                "tlsFingerprint": "old-pin",
+            ],
+        ],
+    ]
+
+    @Test
+    func `direct replacement owns authentication and retains local gateway settings`() throws {
+        let selection = try PrimaryGatewayControlConfiguration.direct(
+            url: #require(URL(string: "wss://new.example/operator/")),
+            token: nil,
+            password: "replacement-password",
+            tlsFingerprint: "replacement-pin")
+        let replacement = try selection.replacingRoot(self.previous, effectiveLocalPort: 19000)
+        #expect(replacement.clearsTargetDefaults)
+        #expect(GatewayRemoteConfig.resolvePasswordString(root: replacement.root) == "replacement-password")
+        #expect(GatewayRemoteConfig.resolveTokenString(root: replacement.root) == nil)
+        #expect(GatewayRemoteConfig.resolveTLSFingerprint(root: replacement.root) == "replacement-pin")
+        let gateway = try #require(replacement.root["gateway"] as? [String: Any])
+        let remote = try #require(gateway["remote"] as? [String: Any])
+        #expect(remote["sshTarget"] == nil)
+        #expect(remote["sshIdentity"] == nil)
+        #expect(remote["remotePort"] == nil)
+        #expect(gateway["port"] as? Int == 19000)
+        #expect((gateway["auth"] as? [String: String])?["token"] == "local-credential")
+        #expect(replacement.root["agents"] as? [String: [String: String]] ==
+            self.previous["agents"] as? [String: [String: String]])
+    }
+
+    @Test(arguments: [false, true])
+    func `ssh replacement resets host scoped options only when the target changes`(changesTarget: Bool) throws {
+        let selection = PrimaryGatewayControlConfiguration.ssh(
+            target: changesTarget ? "operator@new.example" : "operator@old.example",
+            remotePort: nil,
+            localPort: nil,
+            identity: nil,
+            hostKeyPolicy: nil,
+            token: "new-token",
+            password: nil)
+        let replacement = try selection.replacingRoot(self.previous, effectiveLocalPort: 19000)
+        let gateway = try #require(replacement.root["gateway"] as? [String: Any])
+        let remote = try #require(gateway["remote"] as? [String: Any])
+        #expect(replacement.clearsTargetDefaults == changesTarget)
+        #expect(remote["sshIdentity"] as? String == (changesTarget ? nil : "/example/old-key"))
+        #expect(remote["sshHostKeyPolicy"] as? String == (changesTarget ? "strict" : "openssh"))
+        #expect(GatewayRemoteConfig.resolveRemotePort(root: replacement.root) == (changesTarget ? 18789 : 19100))
+        #expect(GatewayRemoteConfig.resolveTokenString(root: replacement.root) == "new-token")
+        #expect(GatewayRemoteConfig.resolvePasswordString(root: replacement.root) == nil)
+        #expect(GatewayRemoteConfig.resolveTLSFingerprint(root: replacement.root) == nil)
+    }
+
+    @Test
+    func `explicit SSH options replace the previous route as one selection`() throws {
+        let selection = PrimaryGatewayControlConfiguration.ssh(
+            target: "operator@new.example:2222",
+            remotePort: 22000,
+            localPort: 23000,
+            identity: "/example/new-key",
+            hostKeyPolicy: .openssh,
+            token: nil,
+            password: "new-password")
+        let replacement = try selection.replacingRoot(self.previous, effectiveLocalPort: 23000)
+        let gateway = try #require(replacement.root["gateway"] as? [String: Any])
+        let remote = try #require(gateway["remote"] as? [String: Any])
+        #expect(gateway["port"] as? Int == 23000)
+        #expect(remote["url"] as? String == "ws://127.0.0.1:23000")
+        #expect(remote["remotePort"] as? Int == 22000)
+        #expect(remote["sshIdentity"] as? String == "/example/new-key")
+        #expect(remote["sshHostKeyPolicy"] as? String == "openssh")
+        #expect(remote["password"] as? String == "new-password")
+    }
+
+    @Test
+    func `fresh SSH selection uses the prepared named profile port`() throws {
+        let selection = PrimaryGatewayControlConfiguration.ssh(
+            target: "operator@new.example", remotePort: nil, localPort: nil,
+            identity: nil, hostKeyPolicy: nil, token: nil, password: nil)
+        let replacement = try selection.replacingRoot([:], effectiveLocalPort: 19789)
+        let gateway = try #require(replacement.root["gateway"] as? [String: Any])
+        let remote = try #require(gateway["remote"] as? [String: Any])
+        #expect(remote["url"] as? String == "ws://127.0.0.1:19789")
+        #expect(remote["remotePort"] as? Int == 18789)
+        #expect(gateway["port"] == nil)
+    }
+
+    @Test
+    func `SSH URL follows environment precedence while preserving the requested config port`() throws {
+        let selection = PrimaryGatewayControlConfiguration.ssh(
+            target: "operator@new.example", remotePort: nil, localPort: 23000,
+            identity: nil, hostKeyPolicy: nil, token: nil, password: nil)
+        let effectiveLocalPort = GatewayEnvironment.resolvedGatewayPort(
+            environment: ["OPENCLAW_GATEWAY_PORT": "23456"],
+            configPort: selection.requestedLocalPort,
+            storedPort: 19789,
+            profile: AppProfile(environment: ["OPENCLAW_PROFILE": "control-test"]))
+        let replacement = try selection.replacingRoot([:], effectiveLocalPort: effectiveLocalPort)
+        let gateway = try #require(replacement.root["gateway"] as? [String: Any])
+        let remote = try #require(gateway["remote"] as? [String: Any])
+        #expect(remote["url"] as? String == "ws://127.0.0.1:23456")
+        #expect(gateway["port"] as? Int == 23000)
+    }
+
+    @Test
+    func `clearing removes the remote URL that would reenable remote mode`() throws {
+        let replacement = try PrimaryGatewayControlConfiguration.clear.replacingRoot(
+            self.previous, effectiveLocalPort: 19000)
+        let gateway = try #require(replacement.root["gateway"] as? [String: Any])
+        #expect(gateway["mode"] == nil)
+        #expect(GatewayRemoteConfig.resolveUrlString(root: replacement.root) == nil)
+        #expect(gateway["remote"] == nil)
+        #expect(gateway["auth"] as? [String: String] == ["token": "local-credential"])
+        #expect(replacement.clearsTargetDefaults)
+    }
+
+    @Test(arguments: ["ws://public.example", "wss://user:secret@public.example", "wss://public.example?token=secret"])
+    func `invalid direct selections fail before persistence`(address: String) throws {
+        let selection = try PrimaryGatewayControlConfiguration.direct(
+            url: #require(URL(string: address)), token: nil, password: nil, tlsFingerprint: nil)
+        #expect(throws: PrimaryGatewayControlError.self) {
+            try selection.replacingRoot(self.previous, effectiveLocalPort: 19000)
+        }
+    }
+
+    @Test(arguments: [0, 65536])
+    func `invalid SSH ports fail before persistence`(port: Int) {
+        let selection = PrimaryGatewayControlConfiguration.ssh(
+            target: "operator@new.example", remotePort: port, localPort: nil,
+            identity: nil, hostKeyPolicy: nil, token: nil, password: nil)
+        #expect(throws: PrimaryGatewayControlError.self) {
+            try selection.replacingRoot(self.previous, effectiveLocalPort: 19000)
+        }
+    }
+}

--- a/apps/macos/Tests/OpenClawIPCTests/PrimaryGatewayControlConfigurationTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/PrimaryGatewayControlConfigurationTests.swift
@@ -120,7 +120,7 @@ struct PrimaryGatewayControlConfigurationTests {
     }
 
     @Test
-    func `clearing removes the remote URL that would reenable remote mode`() throws {
+    func `clearing removes the remote URL and permits a subsequent direct selection`() throws {
         let replacement = try PrimaryGatewayControlConfiguration.clear.replacingRoot(
             self.previous, effectiveLocalPort: 19000)
         let gateway = try #require(replacement.root["gateway"] as? [String: Any])
@@ -129,6 +129,12 @@ struct PrimaryGatewayControlConfigurationTests {
         #expect(gateway["remote"] == nil)
         #expect(gateway["auth"] as? [String: String] == ["token": "local-credential"])
         #expect(replacement.clearsTargetDefaults)
+
+        let direct = try PrimaryGatewayControlConfiguration.direct(
+            url: #require(URL(string: "wss://new.example/")), token: nil, password: nil, tlsFingerprint: nil)
+            .replacingRoot(replacement.root, effectiveLocalPort: 19000)
+        #expect((direct.root["gateway"] as? [String: Any])?["mode"] as? String == "remote")
+        #expect(GatewayRemoteConfig.resolveUrlString(root: direct.root) == "wss://new.example/")
     }
 
     @Test(arguments: ["ws://public.example", "wss://user:secret@public.example", "wss://public.example?token=secret"])

--- a/apps/macos/Tests/OpenClawIPCTests/RootCommandParserTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/RootCommandParserTests.swift
@@ -14,7 +14,7 @@ struct RootCommandParserTests {
     }
 
     @Test func `help aliases resolve to usage`() {
-        for args in [[], ["-h"], ["--help"], ["help"]] {
+        for args in [["-h"], ["--help"], ["help"]] {
             #expect(resolveRootCommandAction(args) == .usage)
         }
     }

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -150,8 +150,22 @@ moving back to local storage. See
 
 ## Debug app connectivity
 
-Use the macOS debug CLI from a source checkout to exercise the same Gateway
-WebSocket handshake and discovery logic the app uses:
+Inspect the running app with the bundled macOS CLI:
+
+```bash
+openclaw-mac status --json
+openclaw-mac primary show --json
+openclaw-mac gateway list --json
+```
+
+The app's CLI installer links `openclaw-mac` beside its profile-managed
+`openclaw` command. You can also run
+`/Applications/OpenClaw.app/Contents/MacOS/openclaw-mac` directly. See
+[remote control](/platforms/mac/remote#macos-app-setup) for `primary set`,
+saved-Gateway commands, profiles, and credential input.
+
+For standalone Gateway WebSocket handshake and discovery probes from a source
+checkout, the existing debug commands remain available:
 
 ```bash
 cd apps/macos

--- a/docs/platforms/mac/remote.md
+++ b/docs/platforms/mac/remote.md
@@ -168,6 +168,7 @@ For a Gateway using a shared token, replace `--browser` with
 `--token-file /path/to/gateway-token`; passwords use
 `--password-file /path/to/gateway-password`. The same URL validation as the
 Gateways tab applies, including secure `wss://` for public hosts.
+Token/password adds wait for a connection attempt within the request timeout; if it fails, the profile remains saved and the command exits with code `0`, reporting `disconnected` with a sanitized error.
 
 ```bash
 openclaw-mac gateway reconnect Research

--- a/docs/platforms/mac/remote.md
+++ b/docs/platforms/mac/remote.md
@@ -93,7 +93,7 @@ the primary connection.
 
 The app disables SSH connection multiplexing and post-authentication backgrounding for its own SSH processes so it can monitor and restart the exact process, even if the selected alias enables `ControlMaster` or `ForkAfterAuthentication`.
 
-SSH host-key verification is strict by default because gateway credentials travel through this tunnel. To opt into a managed SSH alias's own trust behavior, set `--ssh-host-key-policy openssh` via `openclaw-mac configure-remote`, or set `gateway.remote.sshHostKeyPolicy` to `"openssh"` directly. Review the alias and any matching `Host *` or system configuration before opting in. Changing the SSH target (in the app or via `configure-remote`) resets the policy back to `strict` unless you explicitly opt in again for the new target.
+SSH host-key verification is strict by default because gateway credentials travel through this tunnel. To opt into a managed SSH alias's own trust behavior, set `--ssh-host-key-policy openssh` via `openclaw-mac primary set`, or set `gateway.remote.sshHostKeyPolicy` to `"openssh"` directly. Review the alias and any matching `Host *` or system configuration before opting in. Changing the SSH target (in the app or via `openclaw-mac`) resets the policy back to `strict` unless you explicitly opt in again for the new target.
 
 In SSH tunnel mode, discovered LAN/tailnet hostnames save as `gateway.remote.sshTarget`. The app keeps `gateway.remote.url` on the local tunnel endpoint (for example `ws://127.0.0.1:18789`) so CLI, Web Chat, and the local node-host service all use the same loopback transport. When discovery returns both raw Tailnet IPs and stable hostnames, the app prefers Tailscale MagicDNS or LAN names so connections survive address changes better. If the local tunnel port differs from the remote gateway port, set `gateway.remote.remotePort` to the port on the remote host.
 
@@ -107,25 +107,138 @@ The Mac app's node combines native capabilities with system, browser, plugin, sk
 
 ## macOS app setup
 
-To preconfigure the app without the welcome flow, over SSH:
+Use the bundled `openclaw-mac` command to inspect or change the running app's
+connections from Terminal or over SSH. The app's CLI installer links it beside
+its profile-managed `openclaw` command. You can also call it directly at
+`/Applications/OpenClaw.app/Contents/MacOS/openclaw-mac`.
+
+Inspect the primary connection, saved Gateways, and app version:
+
+```bash
+openclaw-mac status --json
+openclaw-mac primary show
+openclaw-mac gateway list
+```
+
+Configure the primary Gateway over SSH:
+
+```bash
+openclaw-mac primary set \
+  --ssh-target user@gateway-host \
+  --local-port 18789 \
+  --remote-port 18789 \
+  --token-file /path/to/gateway-token
+```
+
+Or connect directly to a trusted LAN or Tailnet endpoint:
+
+```bash
+openclaw-mac primary set \
+  --direct-url ws://192.168.0.202:18789 \
+  --token-file /path/to/gateway-token
+```
+
+The app applies the change and restarts its primary connection and SSH tunnel
+as needed. Changing targets clears the previous SSH identity, remote project
+root, and remote CLI path; supply `--identity /path/to/key` for an SSH identity
+on the new target. Host-key verification defaults to `strict`; use
+`--ssh-host-key-policy openssh` only for an alias whose OpenSSH trust policy
+you accept. Use `primary set --local` for a Gateway on this Mac, or
+`primary clear` to return the primary connection to its unconfigured state.
+Saved Gateways remain separate from this primary connection.
+
+### Add and manage saved Gateways
+
+For a Gateway protected by Cloudflare Access:
+
+```bash
+openclaw-mac gateway add Research \
+  --url https://gateway.example.com/operator/ \
+  --browser
+```
+
+The command prints `Complete sign-in in your browser…` to stderr and waits
+while the app runs its bundled browser sign-in helper. Complete authentication
+in the Mac's default browser. The request remains open until sign-in succeeds,
+fails, or reaches the helper's 300-second limit. On success, the command
+reports the saved Gateway and its identity subject and expiry. An SSH session
+can initiate this flow, but browser interaction still happens on the Mac.
+
+For a Gateway using a shared token, replace `--browser` with
+`--token-file /path/to/gateway-token`; passwords use
+`--password-file /path/to/gateway-password`. The same URL validation as the
+Gateways tab applies, including secure `wss://` for public hosts.
+
+```bash
+openclaw-mac gateway reconnect Research
+openclaw-mac gateway remove Research --yes
+```
+
+Reconnect renews browser authentication for browser profiles and reconnects
+token/password profiles. Remove signs out and removes the app's saved
+credentials and dashboard browser data. Commands accept an exact Gateway ID
+or a unique case-insensitive name; ambiguous names produce an error listing
+candidates. Without `--yes`, removal asks once in an interactive terminal;
+noninteractive removal requires `--yes`.
+
+### Secrets, profiles, and app launch
+
+On `primary set` and `gateway add`, pass secrets only with `--token-file`,
+`--token-stdin`, `--password-file`, or `--password-stdin`. File/stdin input is
+read once and trailing newlines are removed. Keep credential files private.
+The new commands reject `--token` and `--password` to keep secrets out of
+process arguments. Status and saved-Gateway output never contain credentials.
+
+Use `--profile <name>` or `OPENCLAW_PROFILE` to select the app profile. For
+example:
+
+```bash
+openclaw-mac --profile research status --json
+openclaw-mac --no-launch status --json
+```
+
+The CLI starts its containing app bundle in the background when needed,
+falling back to `/Applications/OpenClaw.app`. Use `--no-launch` to require an
+already-running app. `--timeout <ms>` bounds waiting for the app and operation.
+The default is 15 seconds, or 310 seconds for `gateway add` and
+`gateway reconnect` to allow browser sign-in to finish. Global flags can appear
+before or after the command; `--profile` takes precedence over the environment.
+The control socket follows the app profile: `~/.openclaw/mac-control.sock`
+for the default profile and `~/.openclaw-<name>/mac-control.sock` for a named
+profile. `OPENCLAW_STATE_DIR` and `OPENCLAW_CONFIG_PATH` do not relocate it.
+
+With `--json`, successful commands print the requested result to stdout.
+Failures print `{ "ok": false, "error": { "code": "…", "message": "…" } }`
+to stderr. Exit codes are `0` for success, `1` for usage errors, `2` when the
+app is unreachable, and `3` when an operation fails.
+
+### Offline preconfiguration
+
+Keep `configure-remote` for preparing a primary connection before the app
+starts. It writes configuration and app defaults directly; it cannot manage
+saved Gateways or restart a running app's connection. Prefer `primary set`
+when the app is running.
 
 ```bash
 openclaw-mac configure-remote \
   --ssh-target user@gateway-host \
   --local-port 18789 \
-  --remote-port 18789 \
-  --token "$OPENCLAW_GATEWAY_TOKEN"
+  --remote-port 18789
 ```
 
-Or for a gateway already reachable on a trusted LAN or Tailnet, skip SSH entirely:
+The legacy `connect`, `wizard`, and `configure-remote` commands resolve config
+in this order: `OPENCLAW_CONFIG_PATH`, then
+`$OPENCLAW_STATE_DIR/openclaw.json`, then `~/.openclaw/openclaw.json`.
+`configure-remote` supports SSH and `--direct-url` transports, marks onboarding
+complete, and leaves the app to use the selected transport on its next start.
+Its ports default to `18789`. Additional options include `--identity`,
+`--ssh-host-key-policy`, `--project-root`, `--cli-path`, and `--json`.
+Its legacy `--token`/`--password` arguments remain supported, but expose
+credentials through process arguments; use the running app's file/stdin
+commands for credential changes. Run `configure-remote --help` for its full
+reference.
 
-```bash
-openclaw-mac configure-remote \
-  --direct-url ws://192.168.0.202:18789 \
-  --token "$OPENCLAW_GATEWAY_TOKEN"
-```
-
-`openclaw-mac connect`, `wizard`, and `configure-remote` resolve the active config in this order: `OPENCLAW_CONFIG_PATH`, then `$OPENCLAW_STATE_DIR/openclaw.json`, then `~/.openclaw/openclaw.json`. Both configuration forms write that active file, mark onboarding complete, and let the app own the selected transport on next start. `--local-port`/`--remote-port` default to `18789`. Other flags: `--password`, `--identity <path>`, `--ssh-host-key-policy <strict|openssh>`, `--project-root <path>`, `--cli-path <path>`, `--json`. Run `openclaw-mac configure-remote --help` for the full reference.
+### Configure in the app
 
 To configure from the UI instead:
 

--- a/docs/platforms/mac/xpc.md
+++ b/docs/platforms/mac/xpc.md
@@ -7,7 +7,7 @@ title: "macOS IPC"
 
 # OpenClaw macOS IPC architecture
 
-A local Unix socket connects the node host service to the macOS app for exec approvals and `system.run`. An `openclaw-mac` debug CLI (`apps/macos/Sources/OpenClawMacCLI`) exists for discovery/connect checks; agent actions still flow through the Gateway WebSocket and `node.invoke`. The node-backed `computer.act` path runs embedded Peekaboo automation in-process; standalone Peekaboo clients use PeekabooBridge.
+A local Unix socket connects the node host service to the macOS app for exec approvals and `system.run`. The bundled `openclaw-mac` CLI uses a separate local control socket to inspect and configure primary and saved Gateway connections. Agent actions still flow through the Gateway WebSocket and `node.invoke`. The node-backed `computer.act` path runs embedded Peekaboo automation in-process; standalone Peekaboo clients use PeekabooBridge.
 
 ## Goals
 
@@ -40,6 +40,65 @@ Agent -> Gateway -> Node Service (WS)
                       v
                   Mac App (UI + TCC + system.run)
 ```
+
+### App control socket
+
+`openclaw-mac` sends one JSONL request and receives one JSONL response per
+Unix-domain connection. The running app starts and stops this listener with
+its exec-approvals lifecycle owner. The shared listener owns the socket path
+lease, guarded filesystem cleanup, connection framing, and shutdown drainage.
+It exposes only these operations:
+
+| Operation           | Result and effect                                                                                                                   |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `status`            | Primary connection, saved Gateways, and app version/build/profile.                                                                  |
+| `primary.set`       | Set local mode, SSH transport, or direct transport through the app's native connection owners; return the resulting primary status. |
+| `primary.clear`     | Return the primary connection to its unconfigured state; return primary status.                                                     |
+| `gateway.list`      | List saved Gateways and their connection status.                                                                                    |
+| `gateway.add`       | Validate and connect through the Gateways tab's sign-in coordinator; return the saved Gateway and identity when present.            |
+| `gateway.remove`    | Resolve an ID/name and use the profile store's Remove path, including credential and dashboard-data cleanup.                        |
+| `gateway.reconnect` | Repeat browser sign-in for browser profiles or reconnect the saved token/password connection.                                       |
+
+Requests identify the operation with an `operation` string. Primary SSH
+settings include `sshTarget`, optional ports, `identityPath`, and
+`hostKeyPolicy` (`strict` or `openssh`); direct settings include `url` and an
+optional `tlsFingerprint`. Credential-bearing operations accept `token` or
+`password` inside the authenticated request; the CLI reads these from files
+or stdin. Saved-Gateway requests use `name`, `url`, and `browser`, or
+`idOrName` for removal/reconnection. Matching tries an exact ID first, then a
+unique case-insensitive name. Ambiguity is an error with candidate names/IDs.
+
+The default profile uses `~/.openclaw/mac-control.sock` and
+`~/.openclaw/mac-control.token`. Named profiles use the corresponding
+`~/.openclaw-<name>/` directory. These paths follow
+`AppProfile.stateDirectoryURL`, independently of config/state environment
+overrides. The app owns token creation. The token must be a regular,
+user-owned file with mode `0600`; missing or unsafe credentials reject
+requests. Clients must have the app's peer UID (`getpeereid`). The JSON
+envelope carries a nonce, millisecond timestamp, encoded request, and
+HMAC-SHA256 over the nonce, timestamp, and exact request bytes. Requests have a
+15-second authentication TTL; a successfully authenticated browser sign-in
+may remain open for the coordinator's bounded 300-second operation.
+
+Socket responses use `{ok:true,result:...}` or
+`{ok:false,error:{code,message}}`. The CLI's `--json` success output unwraps
+`result`. `status` contains:
+
+- `primary`: mode, nullable transport, URL, optional SSH target/remote port,
+  tunnel state/local port, and connection state/version/error.
+- `gateways`: ID, name, URL, authentication kind (`token`, `password`, or
+  `browser`), optional Cloudflare Access identity subject/expiry, and
+  connection state/error.
+- `app`: version, build, and profile.
+
+Responses never include tokens, passwords, browser-session credentials, or
+Keychain contents. Saved-Gateway mutations execute inside the signed app,
+where the profile store owns Keychain access, connection retirement,
+dashboard cookies, and device-token cleanup. The CLI never writes the
+saved-Gateway registry.
+
+See [remote control](/platforms/mac/remote#macos-app-setup) for shell examples,
+profile selection, safe credential input, and background app launch.
 
 ### PeekabooBridge (UI automation)
 

--- a/scripts/build-and-run-mac.sh
+++ b/scripts/build-and-run-mac.sh
@@ -66,6 +66,7 @@ stop_existing_local_app() {
 printf "\n▶️  Building $PRODUCT (debug, build path: $BUILD_PATH)\n"
 node "$ROOT_DIR/scripts/prepare-apple-mermaid.mjs"
 swift build -c debug --product "$PRODUCT" --build-path "$BUILD_PATH"
+swift build -c debug --product openclaw-mac --build-path "$BUILD_PATH"
 
 printf "\n⏹  Stopping existing $PRODUCT...\n"
 if ! stop_existing_local_app; then

--- a/scripts/codesign-mac-app.sh
+++ b/scripts/codesign-mac-app.sh
@@ -431,6 +431,11 @@ fi
 run_bundle_mutation xattr -cr "$APP_BUNDLE" 2>/dev/null || true
 
 # Sign bundled helper binaries before signing the app bundle.
+MAC_CONTROL_CLI="$APP_BUNDLE/Contents/MacOS/openclaw-mac"
+if [ -f "$MAC_CONTROL_CLI" ]; then
+  echo "Signing macOS control CLI"; sign_plain_item "$MAC_CONTROL_CLI"
+fi
+
 MLX_TTS_HELPER="$APP_BUNDLE/Contents/MacOS/openclaw-mlx-tts"
 if [ -f "$MLX_TTS_HELPER" ]; then
   echo "Signing MLX TTS helper"; sign_plain_item "$MLX_TTS_HELPER"

--- a/scripts/lib/mac-swift-build.sh
+++ b/scripts/lib/mac-swift-build.sh
@@ -8,6 +8,10 @@ bin_for_arch() {
   echo "$(build_path_for_arch "$1")/$BUILD_CONFIG/$PRODUCT"
 }
 
+mac_cli_bin_for_arch() {
+  echo "$(build_path_for_arch "$1")/$BUILD_CONFIG/openclaw-mac"
+}
+
 helper_build_path_for_arch() {
   echo "$MLX_TTS_HELPER_BUILD_ROOT/$1"
 }
@@ -471,6 +475,9 @@ build_swift_architecture() {
   echo "🔨 Building $PRODUCT ($BUILD_CONFIG) [$arch]"
   verify_snapshot_swift_lock
   swift build -c "$BUILD_CONFIG" --jobs "$SWIFT_BUILD_JOBS" --product "$PRODUCT" --build-path "$BUILD_PATH" --arch "$arch" -Xlinker -rpath -Xlinker @executable_path/../Frameworks
+  verify_snapshot_swift_lock
+  echo "🔨 Building openclaw-mac ($BUILD_CONFIG) [$arch]"
+  swift build -c "$BUILD_CONFIG" --jobs "$SWIFT_BUILD_JOBS" --product openclaw-mac --build-path "$BUILD_PATH" --arch "$arch" -Xlinker -rpath -Xlinker @executable_path/../Frameworks
   verify_snapshot_swift_lock
   arch_peekaboo_commit="$(compiled_peekaboo_commit "$PEEKABOO_SNAPSHOT_MOUNT" "$PEEKABOO_LOCKED_SOURCE_COMMIT")"
   printf '%s\n' "$arch_peekaboo_commit" > "$SWIFT_WORK_ROOT/peekaboo-commit"

--- a/scripts/package-mac-app.sh
+++ b/scripts/package-mac-app.sh
@@ -371,6 +371,18 @@ chmod +x "$APP_ROOT/Contents/MacOS/OpenClaw"
 # SwiftPM outputs ad-hoc signed binaries; strip the signature before install_name_tool to avoid warnings.
 /usr/bin/codesign --remove-signature "$APP_ROOT/Contents/MacOS/OpenClaw" 2>/dev/null || true
 
+echo "🚚 Copying macOS control CLI"
+cp "$(mac_cli_bin_for_arch "$PRIMARY_ARCH")" "$APP_ROOT/Contents/MacOS/openclaw-mac"
+if [[ "${#BUILD_ARCHS[@]}" -gt 1 ]]; then
+  MAC_CLI_BIN_INPUTS=()
+  for arch in "${BUILD_ARCHS[@]}"; do
+    MAC_CLI_BIN_INPUTS+=("$(mac_cli_bin_for_arch "$arch")")
+  done
+  /usr/bin/lipo -create "${MAC_CLI_BIN_INPUTS[@]}" -output "$APP_ROOT/Contents/MacOS/openclaw-mac"
+fi
+chmod +x "$APP_ROOT/Contents/MacOS/openclaw-mac"
+/usr/bin/codesign --remove-signature "$APP_ROOT/Contents/MacOS/openclaw-mac" 2>/dev/null || true
+
 if [[ "$SKIP_MLX_TTS" == "1" ]]; then
   echo "🔇 Skipping MLX TTS helper copy (OPENCLAW_SKIP_MLX_TTS=1) — bundle omits Contents/MacOS/$MLX_TTS_HELPER_PRODUCT"
 else

--- a/test/scripts/codesign-mac-app.test.ts
+++ b/test/scripts/codesign-mac-app.test.ts
@@ -117,6 +117,7 @@ describe("codesign-mac-app temp file hygiene", () => {
       await mkdir(path.join(app, "Contents", "MacOS"), { recursive: true });
       await mkdir(binDir);
       await mkdir(captureDir);
+      await writeFile(path.join(app, "Contents", "MacOS", "openclaw-mac"), "#!/bin/sh\n");
       await writeFile(path.join(app, "Contents", "MacOS", "openclaw-mlx-tts"), "#!/bin/sh\n");
       await writeFile(path.join(app, "Contents", "MacOS", "OpenClaw"), "#!/bin/sh\n");
       await installFakeCodesign(binDir);
@@ -139,12 +140,13 @@ describe("codesign-mac-app temp file hygiene", () => {
       expect(result.stdout).toContain(`Codesign complete for ${app}`);
 
       const signLines = readFileSync(logPath, "utf8").trim().split("\n");
-      expect(signLines).toHaveLength(2);
-      expect(signLines[0]).toBe(
+      expect(signLines).toHaveLength(3);
+      expect(signLines[0]).toBe(`plain\t${path.join(app, "Contents", "MacOS", "openclaw-mac")}`);
+      expect(signLines[1]).toBe(
         `plain\t${path.join(app, "Contents", "MacOS", "openclaw-mlx-tts")}`,
       );
-      expect(signLines[1]).toContain(`entitled\t${app}\t`);
-      for (const line of signLines.slice(1)) {
+      expect(signLines[2]).toContain(`entitled\t${app}\t`);
+      for (const line of signLines.slice(2)) {
         const columns = line.split("\t");
         const entitlementPath = columns[2];
         const copiedEntitlementsPath = columns[3];

--- a/test/scripts/package-mac-app.test.ts
+++ b/test/scripts/package-mac-app.test.ts
@@ -1361,6 +1361,28 @@ describe("package-mac-app plist stamping", () => {
     },
   );
 
+  it("builds and bundles the macOS control CLI for every requested architecture", () => {
+    const script = readFileSync(scriptPath, "utf8");
+    const buildLoop = readFileSync(swiftScriptPath, "utf8");
+    const cliCopy = script.slice(
+      script.indexOf('echo "🚚 Copying macOS control CLI"'),
+      script.indexOf(
+        'if [[ "$SKIP_MLX_TTS" == "1" ]]; then',
+        script.indexOf('echo "🚚 Copying binary"'),
+      ),
+    );
+
+    expect(buildLoop).toContain('--product openclaw-mac --build-path "$BUILD_PATH" --arch "$arch"');
+    expect(cliCopy).toContain(
+      'cp "$(mac_cli_bin_for_arch "$PRIMARY_ARCH")" "$APP_ROOT/Contents/MacOS/openclaw-mac"',
+    );
+    expect(cliCopy).toContain('/usr/bin/lipo -create "${MAC_CLI_BIN_INPUTS[@]}"');
+    expect(cliCopy).toContain('chmod +x "$APP_ROOT/Contents/MacOS/openclaw-mac"');
+    expect(cliCopy).toContain(
+      '/usr/bin/codesign --remove-signature "$APP_ROOT/Contents/MacOS/openclaw-mac"',
+    );
+  });
+
   it.runIf(process.platform === "darwin")(
     "merges framework Mach-O binaries when the checkout path contains glob metacharacters",
     () => {


### PR DESCRIPTION
## Problem

The Mac app already had an `openclaw-mac` Swift CLI (`connect`, `configure-remote`, `discover`, `wizard`), but it was never packaged into OpenClaw.app, so it does not exist on any shipped Mac. Even from a source checkout it only covered the primary connection by writing `openclaw.json` and UserDefaults directly, left stale `remoteIdentity`/`remoteProjectRoot`/`remoteCliPath` defaults behind when the target changed, and took secrets in argv. Saved Gateways (the Gateways tab: token/password or Cloudflare Access browser sign-in) could only be managed in the GUI, because their registry is a Keychain item whose ACL is bound to the app's code signature and whose mutations retire connections, rotate dashboard cookies, clear device tokens, and run the bundled browser sign-in. A fleet audit or a repoint therefore meant clicking through windows on every Mac (or hand-editing config, as happened while chasing a shared-owner presence ghost on the team gateway).

## Solution

- **Bundle the CLI.** `scripts/package-mac-app.sh` builds `openclaw-mac` per architecture, lipo-merges it, and ships it as `Contents/MacOS/openclaw-mac`; `scripts/codesign-mac-app.sh` signs it as a plain helper; the in-app CLI installer links it beside the installed `openclaw` command.
- **App control socket.** The running app serves `<profile state dir>/mac-control.sock` through a shared local listener extracted from the exec-approvals socket (path guard, lifecycle lock, cancellation, drain). Requests need the app's peer UID, an owner-only 0600 token file, HMAC-SHA256 over nonce/timestamp/request, a 15 s TTL, a fresh nonce, and a 64 KiB frame bound. Only seven operations exist: `status`, `primary.set`, `primary.clear`, `gateway.list`, `gateway.add`, `gateway.remove`, `gateway.reconnect`.
- **CLI commands.** `openclaw-mac status`, `primary show|set|clear` (`--ssh-target` / `--direct-url` / `--local`), `gateway list|add|remove|reconnect`, with `--profile`, `--json`, `--timeout`, `--launch/--no-launch`, and secrets only via `--token-file/--token-stdin/--password-file/--password-stdin` (argv secrets are rejected). Exit codes: 0 ok, 1 usage, 2 app unreachable, 3 operation failed.
- **Ownership stays in the app.** Primary changes commit through `AppState`'s existing saver (target changes clear the three stale defaults; `clear` carries an explicit `allowGatewayModeRemoval` past the config writer's mode-removal corruption guard, which stays intact for every other writer). Saved-Gateway operations run inside the signed app through the existing profile store, browser sign-in coordinator, and connection fleet; the CLI never touches the Keychain registry.
- `configure-remote` stays as the offline preconfiguration path and now also clears stale defaults on target change.

## Impact

Operators can inspect and repoint any Mac's primary connection and saved Gateways from a shell or over SSH, including Cloudflare Access sign-in (the CLI drives the app's browser flow and reports the verified identity). No UI changes. Docs: `docs/platforms/mac/remote.md`, `docs/platforms/mac/xpc.md`, `docs/platforms/mac/bundled-gateway.md`.

## Evidence

- `swift build` for `OpenClaw`, `openclaw-mac`, and `--build-tests`; `scripts/lint-swift.sh macos`; `scripts/format-swift.sh macos`; `pnpm native:i18n:verify`; `git diff --check`: all pass.
- `node scripts/check-changed.mjs` on the changed files: 1,126 tests passed.
- `test/scripts/package-mac-app.test.ts` + `test/scripts/codesign-mac-app.test.ts`: 168 passed; the one failure (`merges framework Mach-O binaries when the checkout path contains glob metacharacters`) fails identically on an untouched `main` checkout on this macOS 27 host (`/bin/ls` is `x86_64 arm64e`) and is unrelated.
- Codex autoreview of the whole branch against `origin/main` at P1: scoped-clean, no findings.
- **Live proof** with the packaged, Developer ID-signed debug bundle (`ai.openclaw.mac.debug`) under a throwaway app profile against an isolated token-auth dev Gateway on `127.0.0.1:18871` (no operator state touched):
  - `--profile nosuchprofile --no-launch status` → exit 2; `primary set … --token x` → exit 1 with the file/stdin hint.
  - `status` launched the app in the background under the profile and returned JSON.
  - `primary set --direct-url ws://127.0.0.1:18871 --token-file …` → `{"mode":"remote","transport":"direct","connection":{"state":"connected","gatewayVersion":"2026.8.1"}}`.
  - `gateway add DevGW --url ws://127.0.0.1:18871 --token-file …` → saved profile `manual-…`, `auth:"token"`, `connection.state:"connected"`; `gateway list`, `gateway reconnect DevGW`, `gateway remove devgw --yes` (case-insensitive name) → `{"removed":true}`; list afterwards `[]`.
  - `primary set --ssh-target steipete@127.0.0.1 --remote-port 18871 --local-port 28871 --token-file …` → SSH transport, `tunnel:{"running":true,"localPort":28871}`, connected; an `ssh -N -L 28871:127.0.0.1:18871` process was running.
  - `primary clear` → `{"mode":"unconfigured","transport":null,"connection":{"state":"disconnected"}}` (the first round surfaced the config-writer guard rejecting mode removal; fixed in the last commit), then `primary set --direct-url …` again → connected, then `clear` again.
  - Socket and token files are `0600`/owner-only; status output never contains credentials.
- Not exercised live: Cloudflare Access `gateway add --browser` (needs an interactive identity-provider login); it reuses the unchanged GUI coordinator. Full native Swift suites run in the `macos-swift` CI lane per the isolation rules.

## Notes

`configure-remote --token/--password` remain accepted for the offline path but are documented as leaking through process arguments; the running-app commands only take file/stdin secrets.
