### PR TITLE
fix(codex): preserve turn context on reused sessions

### DIFF
--- a/extensions/codex/src/app-server/turn-router.test.ts
+++ b/extensions/codex/src/app-server/turn-router.test.ts
@@ -1,3 +1,4 @@
+import { AsyncLocalStorage, AsyncResource } from "node:async_hooks";
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { CodexAppServerClient } from "./client.js";
@@ -40,6 +41,80 @@ describe("CodexAppServerTurnRouter", () => {
     expect(addRequestHandler).toHaveBeenCalledTimes(1);
     expect(addCloseHandler).toHaveBeenCalledTimes(1);
   });
+
+  it.each(["reserve", "activate"] as const)(
+    "runs %s callbacks in each attempt's context on a reused transport",
+    async (registration) => {
+      const context = new AsyncLocalStorage<string>();
+      const transport = context.run("first", () => new AsyncResource("codex-test-transport"));
+      const harness = createHarness();
+      const router = getCodexAppServerTurnRouter(harness.client);
+      try {
+        for (const owner of ["first", "second"]) {
+          const notifications: Array<{ owner: string | undefined; unbound: boolean }> = [];
+          const receipts: Array<{ owner: string | undefined; originalReceiver: boolean }> = [];
+          const handlers = {
+            async onRequest(this: unknown) {
+              await Promise.resolve();
+              return { owner: context.getStore() ?? "missing", unbound: this === undefined };
+            },
+            async onNotification(this: unknown) {
+              await Promise.resolve();
+              notifications.push({ owner: context.getStore(), unbound: this === undefined });
+            },
+            onNotificationReceived(this: unknown) {
+              receipts.push({
+                owner: context.getStore(),
+                originalReceiver: this === originalHandlers,
+              });
+            },
+          };
+          const options = { threadId: "shared-thread", ...handlers };
+          const originalHandlers: object = registration === "reserve" ? options : handlers;
+          const route = context.run(registration === "reserve" ? owner : "reservation", () =>
+            router.reserveThread(
+              registration === "reserve" ? options : { threadId: "shared-thread" },
+            ),
+          );
+          try {
+            if (registration === "activate") {
+              await context.run(owner, () => route.activate(handlers));
+            }
+            route.armTurn();
+            await route.bindTurn(owner);
+            const notification = {
+              method: "item/agentMessage/delta",
+              params: { threadId: "shared-thread", turnId: owner, delta: owner },
+            };
+            transport.runInAsyncScope(() => {
+              harness.send(notification);
+              harness.send({
+                id: owner,
+                method: "item/tool/call",
+                params: { threadId: "shared-thread", turnId: owner, tool: "message" },
+              });
+            });
+            expect(await waitForResponse(harness, owner)).toMatchObject({
+              result: { owner, unbound: true },
+            });
+            await route.drain();
+            expect(notifications).toEqual([{ owner, unbound: true }]);
+            expect(receipts).toEqual([{ owner, originalReceiver: true }]);
+            route.release();
+            transport.runInAsyncScope(() => harness.send(notification));
+            await settleInput();
+            expect(notifications).toHaveLength(1);
+            expect(receipts).toHaveLength(1);
+          } finally {
+            route.release();
+          }
+        }
+      } finally {
+        transport.emitDestroy();
+        context.disable();
+      }
+    },
+  );
 
   it("delivers global startup warnings to the next reserved thread", async () => {
     const harness = createHarness();

--- a/extensions/codex/src/app-server/turn-router.ts
+++ b/extensions/codex/src/app-server/turn-router.ts
@@ -1,4 +1,5 @@
 /** Keyed routing for all turn traffic on one shared Codex app-server client. */
+import { AsyncResource } from "node:async_hooks";
 import { embeddedAgentLog } from "openclaw/plugin-sdk/agent-harness-runtime";
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import type { CodexAppServerClient } from "./client.js";
@@ -292,7 +293,14 @@ class ClientTurnRouter implements CodexAppServerTurnRouter {
     if (!handlers.onNotification && !handlers.onRequest) {
       throw new Error("codex app-server thread route requires a notification or request handler");
     }
-    route.handlers = handlers;
+    // The shared transport outlives attempts; callbacks belong to this activation.
+    route.handlers = {
+      onRequest: handlers.onRequest && AsyncResource.bind(handlers.onRequest),
+      onNotification: handlers.onNotification && AsyncResource.bind(handlers.onNotification),
+      onNotificationReceived:
+        handlers.onNotificationReceived &&
+        AsyncResource.bind(handlers.onNotificationReceived, undefined, handlers),
+    };
     if (!handlers.onNotification) {
       route.pending.length = 0;
     } else if (route.gate !== "armed") {


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Callbacks on a reused Codex session can inherit an earlier attempt's async context. Later requests or notifications then run with stale run-local state. This is a two-file independent extraction from the larger cleanup campaign; it does not require that framework.

## Why This Change Was Made

Bind each route's callbacks when its attempt activates. The shared transport keeps its existing lifetime, while request and notification callbacks preserve their receivers, routing guards, and original returned promises. This follows Node's [documented event-listener context binding](https://nodejs.org/api/async_context.html#integrating-asyncresource-with-eventemitter).

## User Impact

Reused sessions keep callbacks associated with the current attempt. No tool schema, prompt, protocol, configuration, dependency, or host-floor change is included.

## Evidence

- Both registration paths failed on current main: the second generation observed the first generation's async context.
- 31 router/lifecycle tests passed, covering both paths, receivers, notifications, and released routes.
- The unchanged real three-turn Gateway/Codex delivery-cache test passed: three delivered messages, one native session, stable instruction/tool bytes. The case took 22.830 seconds; its maintained wrapper, including QA preparation, took 120.408 seconds.
- All selected local checks passed after one test-only `const` correction. Deslop and independent P0–P2 review are clean.
- Proof uses isolated synthetic state and a scripted provider through the real Gateway and native-session flow; it does not claim external-model compliance.

The branch was rebased onto `ca10e17c` to include the already-merged unrelated UI test split from #141466. The patch, checked runtime contracts, and dependency manifests are unchanged; the existing local and live evidence retains its original source pin. Native interrupt/unsubscribe behavior was also checked directly in upstream [turn processing](https://github.com/openai/codex/blob/ade0ccacf9182e665cf784de041c51a79e35bc31/codex-rs/app-server/src/request_processors/turn_processor.rs#L1555) and [thread processing](https://github.com/openai/codex/blob/ade0ccacf9182e665cf784de041c51a79e35bc31/codex-rs/app-server/src/request_processors/thread_processor.rs#L1011); this changes no wire contract.
