### PR TITLE
fix(memory): keep cleared plugin registries absent during lookup

### DIFF
--- a/src/plugins/memory-state.test.ts
+++ b/src/plugins/memory-state.test.ts
@@ -19,7 +19,11 @@ import {
   type MemoryPluginPublicArtifact,
 } from "./memory-state.test-fixtures.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
-import { withPluginRegistrationContext } from "./runtime.js";
+import {
+  clearActivePluginRegistry,
+  getActivePluginRegistry,
+  withPluginRegistrationContext,
+} from "./runtime.js";
 import { createPluginRecord } from "./status.test-helpers.js";
 
 function createMemoryRuntime() {
@@ -74,6 +78,15 @@ describe("memory plugin state", () => {
 
   it("returns empty defaults when no memory plugin state is registered", () => {
     expectClearedMemoryState();
+  });
+
+  it("keeps a cleared registry absent while reading memory capability state", async () => {
+    await clearActivePluginRegistry();
+
+    expect(getMemoryRuntime()).toBeUndefined();
+    expect(getMemoryCapabilityRegistration()).toBeUndefined();
+    expect(resolveMemoryFlushPlan({})).toBeNull();
+    expect(getActivePluginRegistry()).toBeNull();
   });
 
   it("attributes direct builder registrations to the synchronous plugin owner", () => {

--- a/src/plugins/memory-state.ts
+++ b/src/plugins/memory-state.ts
@@ -21,6 +21,7 @@ import type {
 } from "./registry-contribution-types.js";
 import type { PluginRegistry } from "./registry-types.js";
 import {
+  getPluginRegistryForContext,
   getPluginRegistrationContext,
   requireActivePluginRegistry,
   resolveDirectPluginRegistrationOwner,
@@ -87,8 +88,9 @@ export function resolveMemoryCapabilityRegistration(
   return effective;
 }
 
+// Cleanup reads must not recreate the process registry after its owner has cleared it.
 const getMemoryCapability = () =>
-  resolveMemoryCapabilityRegistration(requireActivePluginRegistry().memoryCapabilities);
+  resolveMemoryCapabilityRegistration(getPluginRegistryForContext()?.memoryCapabilities ?? []);
 
 const preparedMemoryPromptSections = new WeakSet<PreparedMemoryPromptSection>();
 const activePreparedMemoryPromptSection = new AsyncLocalStorage<PreparedMemoryPromptSection>();


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Memory capability queries recreate an empty plugin registry after the registry has been cleared. During cleanup this can restore process state that shutdown has already removed.

## Why This Change Was Made

Use the existing non-creating registry lookup for capability reads, preserving registration/request/active precedence. Registration paths still create their registry as before. This independent two-file fix contains none of the larger resource-ownership framework.

## User Impact

Cleanup and cold memory queries leave an absent registry absent. Registered memory behavior, storage, and SDK contracts are unchanged.

## Evidence

- The new regression failed on original main because a cold query recreated the registry.
- 43 memory-state/runtime tests passed.
- Native SQLite probes passed on Node 24.20 and 26.8: the registered runtime closed exactly once, its file reopened read-only with preserved data, and subsequent cold cleanup/queries left the registry absent.
- Canonical changed checks, deslop, and independent P0–P2 review passed.

The branch was rebased onto `ca10e17c` to include the already-merged unrelated UI test split from #141466. The two-file patch, checked memory/runtime contracts, and dependency manifests are unchanged; the existing proof retains its original source pin.
