### PR TITLE
fix(scripts): preserve multibyte command output

### DIFF
--- a/scripts/e2e/kitchen-sink-rpc-walk.mts
+++ b/scripts/e2e/kitchen-sink-rpc-walk.mts
@@ -569,10 +569,10 @@ export function runCommand(
       );
       forceKillTimer.unref();
     }, resolvedTimeoutMs);
-    child.stdout?.on("data", (chunk) => {
+    child.stdout?.setEncoding("utf8").on("data", (chunk) => {
       stdout = appendBoundedTail(stdout, chunk, outputCaptureChars);
     });
-    child.stderr?.on("data", (chunk) => {
+    child.stderr?.setEncoding("utf8").on("data", (chunk) => {
       stderr = appendBoundedTail(stderr, chunk, outputCaptureChars);
     });
     child.on("error", (error) => {

--- a/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
+++ b/scripts/e2e/lib/bundled-plugin-install-uninstall/runtime-smoke.mjs
@@ -444,10 +444,10 @@ export function runCommand(command, args, options = {}) {
     let stderr = { text: "", truncatedChars: 0 };
     let timedOut = false;
     let settled = false;
-    child.stdout?.on("data", (chunk) => {
+    child.stdout?.setEncoding("utf8").on("data", (chunk) => {
       stdout = appendBoundedTail(stdout, chunk, OUTPUT_CAPTURE_CHARS);
     });
-    child.stderr?.on("data", (chunk) => {
+    child.stderr?.setEncoding("utf8").on("data", (chunk) => {
       stderr = appendBoundedTail(stderr, chunk, OUTPUT_CAPTURE_CHARS);
     });
     const clearCommandTimer = timeoutMs

--- a/scripts/profile-extension-memory.mts
+++ b/scripts/profile-extension-memory.mts
@@ -265,10 +265,10 @@ export async function runCase({
       resolve(result);
     }
 
-    child.stdout.on("data", (chunk) => {
+    child.stdout.setEncoding("utf8").on("data", (chunk) => {
       stdout = appendBoundedTail(stdout, chunk, OUTPUT_CAPTURE_MAX_CHARS);
     });
-    child.stderr.on("data", (chunk) => {
+    child.stderr.setEncoding("utf8").on("data", (chunk) => {
       const rssScan = scanMaxRssMb(stderrRssTail, chunk, maxRssMb);
       stderrRssTail = rssScan.tail;
       maxRssMb = rssScan.maxRssMb;

--- a/scripts/resolve-openclaw-package-candidate.mts
+++ b/scripts/resolve-openclaw-package-candidate.mts
@@ -385,10 +385,10 @@ function run(command: string, args: readonly string[], options: RunOptions = {})
     let stdout = { text: "", truncatedChars: 0 };
     let stderr = { text: "", truncatedChars: 0 };
     if (options.capture) {
-      child.stdout?.on("data", (chunk: Buffer) => {
+      child.stdout?.setEncoding("utf8").on("data", (chunk: string) => {
         stdout = appendBoundedTail(stdout, chunk, COMMAND_STDOUT_CAPTURE_MAX_CHARS);
       });
-      child.stderr?.on("data", (chunk: Buffer) => {
+      child.stderr?.setEncoding("utf8").on("data", (chunk: string) => {
         stderr = appendBoundedTail(stderr, chunk, COMMAND_STDERR_CAPTURE_MAX_CHARS);
       });
     }

--- a/test/scripts/profile-extension-memory.test.ts
+++ b/test/scripts/profile-extension-memory.test.ts
@@ -12,6 +12,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { PassThrough, Transform } from "node:stream";
 import { pathToFileURL } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
@@ -304,6 +305,53 @@ describe("scripts/profile-extension-memory", () => {
     }
   });
 
+  it("preserves split UTF-8 child output through EOF and RSS accounting", async () => {
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-extension-memory-utf8-"));
+    const hookPath = path.join(root, "hook.mjs");
+    const stdout = "stdout: café 🦞";
+    const stderr = "stderr: 東京\n__OPENCLAW_MAX_RSS_KB__=2048\nfin: é";
+    const splitBytes = () =>
+      new Transform({
+        transform(chunk: Buffer, _encoding, callback) {
+          for (const byte of chunk) {
+            this.push(Buffer.from([byte]));
+          }
+          callback();
+        },
+      });
+    try {
+      writeFileSync(hookPath, "", "utf8");
+      const result = await runCase({
+        repoRoot: root,
+        env: process.env,
+        hookPath,
+        name: "utf8-output",
+        body: `process.stdout.write(${JSON.stringify(stdout)}); process.stderr.write(${JSON.stringify(stderr)});`,
+        timeoutMs: 30_000,
+        spawnImpl(command, args, options) {
+          const child = spawn(command, args, options);
+          // Preserve actual pipe bytes while forcing character boundaries apart.
+          child.stdout = child.stdout.pipe(splitBytes());
+          child.stderr = child.stderr.pipe(splitBytes());
+          return child;
+        },
+      });
+
+      expect(result).toEqual({
+        name: "utf8-output",
+        code: 0,
+        signal: null,
+        timedOut: false,
+        error: null,
+        stdout,
+        stderr,
+        maxRssMb: 2,
+      });
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("creates parent directories for nested JSON report paths", () => {
     const root = mkdtempSync(path.join(tmpdir(), "openclaw-extension-memory-test-"));
     try {
@@ -402,11 +450,11 @@ describe("scripts/profile-extension-memory", () => {
       spawnImpl: (() => {
         const child = new EventEmitter() as EventEmitter & {
           kill: () => boolean;
-          stderr: EventEmitter;
-          stdout: EventEmitter;
+          stderr: PassThrough;
+          stdout: PassThrough;
         };
-        child.stderr = new EventEmitter();
-        child.stdout = new EventEmitter();
+        child.stderr = new PassThrough();
+        child.stdout = new PassThrough();
         child.kill = () => true;
         queueMicrotask(() => child.emit("error", new Error("spawn denied")));
         return child;


### PR DESCRIPTION
## What Problem This Solves

Resolves corrupted non-ASCII command output in package-candidate preparation, plugin memory profiling, and the bundled-plugin/Kitchen Sink smoke helpers when a pipe chunk ends inside a UTF-8 character. Valid filenames or diagnostics could contain replacement characters even though the child wrote valid text.

## Why This Change Was Made

Enable Node’s streaming UTF-8 decoder on stdout and stderr before capturing text in each affected owner, matching the existing compiler-boundary helper. The shared bounded-tail helper retains its character limits, truncation accounting and UTF-16 semantics. No new buffering abstraction or dependency is needed.

## User Impact

Maintainers receive intact multilingual command output and package metadata. Existing overflow failures, RSS extraction and child cleanup behavior remain unchanged.

## Evidence

A real child writing `café 🦞 終` in separate bytes produced replacement characters on both streams before the fix. The regression uses real Node pipes with a byte-splitting transform, so its chunk boundaries are deterministic and require no sleeps. It failed before on text alone while normal exit and RSS accounting matched.

With the repair, the regression and seven existing capture/overflow/RSS tests pass across five files. All 19 selected repository checks pass, and independent review through P2 found no actionable findings. Tooling LOC is unchanged; regression and fixture support add 48 test lines. This validates command-output collection, not a full smoke deployment or live provider flow.
