### PR TITLE
refactor: remove duplicate QA request retention run

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -560,13 +560,19 @@ describe("qa mock openai server", () => {
     });
 
     const retained = requireArray(
-      await fetch(`${server.baseUrl}/debug/requests`).then((response) => response.json()),
+      await getJson(server, "/debug/requests"),
       "retained debug requests",
     );
     expect(retained).toHaveLength(debugRequestLimit);
     expect(requireRecord(retained[0], "retained request 0").cursor).toBe(2);
     expect(requireRecord(retained.at(-1), "last retained request").cursor).toBe(
       debugRequestLimit + 1,
+    );
+    expect(String(requireRecord(retained[0], "retained request 0").allInputText)).toContain(
+      "cursor request 1",
+    );
+    expect(String(requireRecord(retained.at(-1), "last retained request").allInputText)).toContain(
+      "cursor request overflow",
     );
 
     const nextRequests = requireArray(
@@ -601,25 +607,6 @@ describe("qa mock openai server", () => {
     expect(await invalid.json()).toEqual({
       error: "after must be a non-negative safe integer",
     });
-  });
-
-  it("retains enough debug requests for long shared QA runs", async () => {
-    const server = await startMockServer();
-
-    for (let index = 0; index < 250; index += 1) {
-      await expectOpenAiNonStreamingResponsesJson(server, {
-        input: [makeUserInput(`debug retention request ${index}`)],
-      });
-    }
-
-    const requestLog = requireArray(await getJson(server, "/debug/requests"), "debug requests");
-    expect(requestLog).toHaveLength(250);
-    expect(String(requireRecord(requestLog[0], "debug request 0").allInputText)).toContain(
-      "debug retention request 0",
-    );
-    expect(String(requireRecord(requestLog[249], "debug request 249").allInputText)).toContain(
-      "debug retention request 249",
-    );
   });
 
   it("serves health and streamed responses", async () => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The mock OpenAI suite repeats 250 HTTP requests to check debug-log retention, even though its cursor-rollover case already sends 2,001 requests and verifies the stronger 2,000-record retention boundary.

## Why This Change Was Made

Remove the older retention case and carry its first/last request-content assertions into the rollover case. Use the existing JSON helper so the full-log GET still checks HTTP 200. Keep the explicit retention bound and every cursor-filtering and error assertion.

## User Impact

No production changes. This maintainer-requested cleanup removes one duplicate case and 13 net test lines, avoiding 250 POSTs, one GET, and one mock-server lifecycle. No overall runtime improvement is claimed.

## Evidence

- Whole-file baseline: 284 cases passed. Final suite: all 283 retained cases passed.
- A controlled 200-record cap fails the retained 2,000-record assertion; corrupted request text fails the carried content assertion. Original production files were restored before the final passing suite.
- Full-file comparison confirms all other test text is unchanged. Case inventory differs by exactly the removed retention test.
- Formatting, deslop, the full changed-file gate, and fresh P2 review passed.
