### PR TITLE
fix(ci): keep Markdown regression tests within the file limit

### DIFF
--- a/ui/src/components/markdown-indented-code.test.ts
+++ b/ui/src/components/markdown-indented-code.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { toSanitizedMarkdownHtml, toStreamingMarkdownParts } from "./markdown.ts";
+
+function htmlFragment(html: string): HTMLElement {
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  return container;
+}
+
+describe("indented Markdown source", () => {
+  it.each(["    *literal*", "\t*literal*", "\n\n    *literal*"])(
+    "renders initial code: %j",
+    (source) => {
+      expect(
+        htmlFragment(toSanitizedMarkdownHtml(source)).querySelector("pre code")?.textContent,
+      ).toBe("*literal*\n");
+    },
+  );
+
+  it.each(["    a\n\n    b", "Intro\n\n    a\n\n    b"])(
+    "keeps a streamed indented block together: %j",
+    (source) => {
+      const fragment = htmlFragment(toStreamingMarkdownParts(source).join(""));
+      expect(fragment.querySelectorAll("pre code")).toHaveLength(1);
+      expect(fragment.querySelector("pre code")?.textContent).toBe("a\n\nb\n");
+    },
+  );
+
+  it("never repairs literal punctuation inside streaming indented code", () => {
+    const source = "    *literal";
+    for (let end = 5; end <= source.length; end++) {
+      const fragment = htmlFragment(
+        toStreamingMarkdownParts(source.slice(0, end), {}, "indented-prefix").join(""),
+      );
+      expect(fragment.querySelector("pre code")?.textContent).toBe(`${source.slice(4, end)}\n`);
+    }
+  });
+});

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -1143,33 +1143,3 @@ describe("toStreamingMarkdownParts", () => {
     expect(html).toBe("<p>prices are $$50 and</p>\n");
   });
 });
-
-describe("indented Markdown source", () => {
-  it.each(["    *literal*", "\t*literal*", "\n\n    *literal*"])(
-    "renders initial code: %j",
-    (source) => {
-      expect(
-        htmlFragment(toSanitizedMarkdownHtml(source)).querySelector("pre code")?.textContent,
-      ).toBe("*literal*\n");
-    },
-  );
-
-  it.each(["    a\n\n    b", "Intro\n\n    a\n\n    b"])(
-    "keeps a streamed indented block together: %j",
-    (source) => {
-      const fragment = htmlFragment(toStreamingMarkdownParts(source).join(""));
-      expect(fragment.querySelectorAll("pre code")).toHaveLength(1);
-      expect(fragment.querySelector("pre code")?.textContent).toBe("a\n\nb\n");
-    },
-  );
-
-  it("never repairs literal punctuation inside streaming indented code", () => {
-    const source = "    *literal";
-    for (let end = 5; end <= source.length; end++) {
-      const fragment = htmlFragment(
-        toStreamingMarkdownParts(source.slice(0, end), {}, "indented-prefix").join(""),
-      );
-      expect(fragment.querySelector("pre code")?.textContent).toBe(`${source.slice(4, end)}\n`);
-    }
-  });
-});


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where current-main lint fails because `ui/src/components/markdown.test.ts` contains 1011 counted lines, exceeding the existing 1000-line limit. This blocks otherwise unrelated PRs, including [#141469](https://github.com/openclaw/openclaw/pull/141469).

## Why This Change Was Made

Moves the existing indented-Markdown describe group into a clearly named sibling test file. Every test input and assertion remains unchanged. No production code, lint limit, suppression, configuration, or baseline changes.

## User Impact

No runtime behavior changes. This restores the lint gate while preserving all Markdown regression coverage, allowing unrelated fixes to land normally.

## Evidence

- Confirmed failure in [the hosted lint job](https://github.com/openclaw/openclaw/actions/runs/34154348181/job/101843091026): `markdown.test.ts:1175:4`, `eslint(max-lines)`, 1011 counted lines.
- Reproduced the same failure locally before the split with `oxlint --config .oxlintrc.json ui/src/components/markdown.test.ts`.
- Both split files pass the same lint check and formatting.
- `node scripts/run-vitest.mjs ui/src/components/markdown.test.ts ui/src/components/markdown-indented-code.test.ts`: 115 tests passed.
- `node scripts/check-changed.mjs` and `git diff --check` passed.
- Fresh independent Codex autoreview: no actionable P0–P2 findings. The moved group was also verified byte-identical to its original source.
