### PR TITLE
test(ui): split markdown render-cache tests out of markdown.test.ts

### DIFF
--- a/ui/src/components/markdown.cache.test.ts
+++ b/ui/src/components/markdown.cache.test.ts
@@ -1,0 +1,105 @@
+// Control UI tests cover markdown behavior.
+import { describe, expect, it, vi } from "vitest";
+import { i18n } from "../i18n/index.ts";
+import { toSanitizedMarkdownHtml } from "./markdown.ts";
+
+function htmlFragment(html: string): HTMLElement {
+  const container = document.createElement("div");
+  container.innerHTML = html;
+  return container;
+}
+
+describe("toSanitizedMarkdownHtml", () => {
+  describe("code blocks", () => {
+    const jsonBlock = (lineCount: number) => {
+      const values = Array.from({ length: lineCount - 2 }, (_, index) => `  ${index},`);
+      values[values.length - 1] = values.at(-1)?.slice(0, -1) ?? "";
+      return `\`\`\`json\n[\n${values.join("\n")}\n]\n\`\`\``;
+    };
+
+    it("separates cached GitHub references by repository and absent context", () => {
+      const source = "PR #141270";
+      for (const githubRepo of [
+        { owner: "first", repo: "one" },
+        { owner: "second", repo: "one" },
+        { owner: "second", repo: "two" },
+        null,
+      ]) {
+        const fragment = htmlFragment(toSanitizedMarkdownHtml(source, { githubRepo }));
+        expect(fragment.querySelector("a")?.getAttribute("href") ?? null).toBe(
+          githubRepo
+            ? `https://github.com/${githubRepo.owner}/${githubRepo.repo}/pull/141270`
+            : null,
+        );
+      }
+    });
+
+    it("keeps the no-chrome code-block cache separate from copy-enabled rendering", () => {
+      const markdown = "```\ncode\n```";
+      const plain = toSanitizedMarkdownHtml(markdown, { codeBlockChrome: "none" });
+      const copyable = toSanitizedMarkdownHtml(markdown);
+
+      expect(htmlFragment(plain).querySelector(".code-block-copy")).toBeNull();
+      expect(htmlFragment(copyable).querySelector(".code-block-copy")).toBeInstanceOf(
+        HTMLButtonElement,
+      );
+    });
+
+    it("keeps the interactive code-block cache separate from static rendering", () => {
+      const markdown = jsonBlock(41);
+      const staticHtml = toSanitizedMarkdownHtml(markdown);
+      const interactiveHtml = toSanitizedMarkdownHtml(markdown, {
+        codeBlockInteraction: "interactive",
+      });
+
+      expect(htmlFragment(staticHtml).querySelector(".code-block-expand")).toBeNull();
+      expect(htmlFragment(interactiveHtml).querySelector(".code-block-expand")).toBeInstanceOf(
+        HTMLButtonElement,
+      );
+    });
+  });
+
+  describe("large text handling", () => {
+    it("does not build cache keys for replies larger than the cache limit", () => {
+      const locale = vi.spyOn(i18n, "getLocale");
+
+      expect(toSanitizedMarkdownHtml("x".repeat(50_001))).toContain("x".repeat(100));
+      expect(locale).not.toHaveBeenCalled();
+      locale.mockRestore();
+    });
+
+    it("uses plain text fallback for oversized content", () => {
+      // MARKDOWN_PARSE_LIMIT is 40_000 chars
+      const input = Array.from(
+        { length: 220 },
+        (_, i) =>
+          `Paragraph ${i + 1}: ${Array.from({ length: 8 }, () => "Long plain-text reply.").join(
+            " ",
+          )}`,
+      ).join("\n\n");
+      const html = toSanitizedMarkdownHtml(input);
+      const fallback = htmlFragment(html).firstElementChild;
+      expect(fallback?.tagName).toBe("DIV");
+      expect(fallback?.className).toBe("markdown-plain-text-fallback");
+      expect(fallback?.textContent).toBe(input);
+    });
+
+    it("preserves indentation in plain text fallback", () => {
+      const input = `${"Header line\n".repeat(3400)}\n    indented log line\n        deeper indent`;
+      const html = toSanitizedMarkdownHtml(input);
+      const fallback = htmlFragment(html).firstElementChild;
+      expect(fallback?.className).toBe("markdown-plain-text-fallback");
+      expect(fallback?.textContent).toBe(input);
+    });
+
+    it("caches oversized fallback results", () => {
+      const input =
+        Array.from({ length: 240 }, (_, i) => `P${i}`).join("\n\n") + "x".repeat(45_000);
+      const first = toSanitizedMarkdownHtml(input);
+      const second = toSanitizedMarkdownHtml(input);
+      expect(input.length).toBeGreaterThan(40_000);
+      expect(htmlFragment(first).firstElementChild?.className).toBe("markdown-plain-text-fallback");
+      expect(second).toBe(first);
+    });
+  });
+});

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -396,47 +396,6 @@ PY
       expect(fragment.querySelector("pre code")?.textContent).toBe(source);
     });
 
-    it("separates cached GitHub references by repository and absent context", () => {
-      const source = "PR #141270";
-      for (const githubRepo of [
-        { owner: "first", repo: "one" },
-        { owner: "second", repo: "one" },
-        { owner: "second", repo: "two" },
-        null,
-      ]) {
-        const fragment = htmlFragment(toSanitizedMarkdownHtml(source, { githubRepo }));
-        expect(fragment.querySelector("a")?.getAttribute("href") ?? null).toBe(
-          githubRepo
-            ? `https://github.com/${githubRepo.owner}/${githubRepo.repo}/pull/141270`
-            : null,
-        );
-      }
-    });
-
-    it("keeps the no-chrome code-block cache separate from copy-enabled rendering", () => {
-      const markdown = "```\ncode\n```";
-      const plain = toSanitizedMarkdownHtml(markdown, { codeBlockChrome: "none" });
-      const copyable = toSanitizedMarkdownHtml(markdown);
-
-      expect(htmlFragment(plain).querySelector(".code-block-copy")).toBeNull();
-      expect(htmlFragment(copyable).querySelector(".code-block-copy")).toBeInstanceOf(
-        HTMLButtonElement,
-      );
-    });
-
-    it("keeps the interactive code-block cache separate from static rendering", () => {
-      const markdown = jsonBlock(41);
-      const staticHtml = toSanitizedMarkdownHtml(markdown);
-      const interactiveHtml = toSanitizedMarkdownHtml(markdown, {
-        codeBlockInteraction: "interactive",
-      });
-
-      expect(htmlFragment(staticHtml).querySelector(".code-block-expand")).toBeNull();
-      expect(htmlFragment(interactiveHtml).querySelector(".code-block-expand")).toBeInstanceOf(
-        HTMLButtonElement,
-      );
-    });
-
     it("keeps short code blocks fully visible in interactive hosts", () => {
       const fragment = htmlFragment(
         toSanitizedMarkdownHtml(jsonBlock(7), { codeBlockInteraction: "interactive" }),
@@ -853,50 +812,6 @@ PY
 
       expect(elapsed).toBeLessThan(500);
       expect(html.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe("large text handling", () => {
-    it("does not build cache keys for replies larger than the cache limit", () => {
-      const locale = vi.spyOn(i18n, "getLocale");
-
-      expect(toSanitizedMarkdownHtml("x".repeat(50_001))).toContain("x".repeat(100));
-      expect(locale).not.toHaveBeenCalled();
-      locale.mockRestore();
-    });
-
-    it("uses plain text fallback for oversized content", () => {
-      // MARKDOWN_PARSE_LIMIT is 40_000 chars
-      const input = Array.from(
-        { length: 220 },
-        (_, i) =>
-          `Paragraph ${i + 1}: ${Array.from({ length: 8 }, () => "Long plain-text reply.").join(
-            " ",
-          )}`,
-      ).join("\n\n");
-      const html = toSanitizedMarkdownHtml(input);
-      const fallback = htmlFragment(html).firstElementChild;
-      expect(fallback?.tagName).toBe("DIV");
-      expect(fallback?.className).toBe("markdown-plain-text-fallback");
-      expect(fallback?.textContent).toBe(input);
-    });
-
-    it("preserves indentation in plain text fallback", () => {
-      const input = `${"Header line\n".repeat(3400)}\n    indented log line\n        deeper indent`;
-      const html = toSanitizedMarkdownHtml(input);
-      const fallback = htmlFragment(html).firstElementChild;
-      expect(fallback?.className).toBe("markdown-plain-text-fallback");
-      expect(fallback?.textContent).toBe(input);
-    });
-
-    it("caches oversized fallback results", () => {
-      const input =
-        Array.from({ length: 240 }, (_, i) => `P${i}`).join("\n\n") + "x".repeat(45_000);
-      const first = toSanitizedMarkdownHtml(input);
-      const second = toSanitizedMarkdownHtml(input);
-      expect(input.length).toBeGreaterThan(40_000);
-      expect(htmlFragment(first).firstElementChild?.className).toBe("markdown-plain-text-fallback");
-      expect(second).toBe(first);
     });
   });
 });


### PR DESCRIPTION
Related: #141431, #141369

## What Problem This Solves

Resolves a problem where main's `check-lint-core-2` job fails and blocks landings because `markdown.test.ts` exceeds the 1000-line lint limit. PRs #141431 and #141369 passed separately but combined to bring the file to 1011 counted lines.

Update: while this PR was in CI, #141466 separately extracted streaming tests and already relieved the main lint failure. This requested cache split adds further headroom and keeps cache-related coverage together.

## Why This Change Was Made

Move the three render-cache separation tests and the related large-text handling group into `markdown.cache.test.ts`. This test-only split preserves every test name and assertion, duplicates only the tiny DOM-fragment and JSON-block helpers, and leaves production code, lint configuration, thresholds, and ignores unchanged.

## User Impact

None. This restores CI headroom without changing product behavior or test coverage.

## Evidence

- Original failure reproduced locally: 1011 counted lines, limit 1000. [Failing main job](https://github.com/openclaw/openclaw/actions/runs/34154404744/job/101843563077).
- `node scripts/run-oxlint.mjs --tsconfig config/tsconfig/oxlint.core.json ui/src/components/markdown.test.ts ui/src/components/markdown.cache.test.ts`: passed with no max-lines finding. The requested `ui/tsconfig.json` does not exist; the repository's core lint config includes UI files. Physical line counts after splitting: 1090 and 105.
- `node scripts/run-vitest.mjs ui/src/components/markdown.test.ts ui/src/components/markdown.cache.test.ts`: 115 passed (108 + 7), matching the original file's 115 passed. All seven moved test bodies and the full test-name multiset are unchanged.
- `pnpm check:changed`: passed. Independent review: clean at P2.
