### PR TITLE
docs(packages): remove repetitive module captions

### DIFF
--- a/packages/acp-core/src/error-format.ts
+++ b/packages/acp-core/src/error-format.ts
@@ -1,4 +1,3 @@
-// ACP Core helper module supports error format behavior.
 import {
   CREDENTIAL_STYLE_HEADER_REDACT_PATTERN,
   HTTP_AUTH_HEADER_BOUNDARY_PATTERN,

--- a/packages/acp-core/src/meta.ts
+++ b/packages/acp-core/src/meta.ts
@@ -1,4 +1,3 @@
-// ACP Core module implements meta behavior.
 import { asFiniteNumber, asSafeIntegerInRange } from "@openclaw/normalization-core/number-coercion";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 

--- a/packages/acp-core/src/runtime/error-text.ts
+++ b/packages/acp-core/src/runtime/error-text.ts
@@ -1,4 +1,3 @@
-// ACP Core module implements error text behavior.
 import { type AcpRuntimeErrorCode, AcpRuntimeError, toAcpRuntimeError } from "./errors.js";
 
 function resolveAcpRuntimeErrorNextStep(error: AcpRuntimeError): string | undefined {

--- a/packages/acp-core/src/runtime/errors.ts
+++ b/packages/acp-core/src/runtime/errors.ts
@@ -1,4 +1,3 @@
-// ACP Core module implements errors behavior.
 import { redactSensitiveText, stringifyNonErrorCause } from "../error-format.js";
 
 export const ACP_ERROR_CODES = [

--- a/packages/acp-core/src/runtime/session-identifiers.ts
+++ b/packages/acp-core/src/runtime/session-identifiers.ts
@@ -1,4 +1,3 @@
-// ACP Core module implements session identifiers behavior.
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString as normalizeText,

--- a/packages/acp-core/src/runtime/session-identity.ts
+++ b/packages/acp-core/src/runtime/session-identity.ts
@@ -1,4 +1,3 @@
-// ACP Core module implements session identity behavior.
 import { normalizeOptionalString as normalizeText } from "@openclaw/normalization-core/string-coerce";
 import type { SessionAcpIdentity, SessionAcpIdentitySource, SessionAcpMeta } from "../types.js";
 import type { AcpRuntimeHandle, AcpRuntimeStatus } from "./types.js";

--- a/packages/acp-core/src/session-interaction-mode.ts
+++ b/packages/acp-core/src/session-interaction-mode.ts
@@ -1,4 +1,3 @@
-// ACP Core module implements session interaction mode behavior.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
 type AcpSessionInteractionMode = "interactive" | "parent-owned-background";

--- a/packages/acp-core/src/session-lineage-meta.ts
+++ b/packages/acp-core/src/session-lineage-meta.ts
@@ -1,4 +1,3 @@
-// ACP Core module implements session lineage meta behavior.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
 const SUBAGENT_ROLES = ["orchestrator", "leaf"] as const;

--- a/packages/acp-core/src/session.ts
+++ b/packages/acp-core/src/session.ts
@@ -1,4 +1,3 @@
-// ACP Core module implements session behavior.
 import { randomUUID } from "node:crypto";
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import type { AcpSession } from "./types.js";

--- a/packages/agent-core/src/agent.ts
+++ b/packages/agent-core/src/agent.ts
@@ -1,4 +1,3 @@
-// Agent Core module implements agent behavior.
 import type {
   ImageContent,
   Message,

--- a/packages/agent-core/src/harness/compaction/branch-summarization.ts
+++ b/packages/agent-core/src/harness/compaction/branch-summarization.ts
@@ -1,4 +1,3 @@
-// Agent Core module implements branch summarization behavior.
 import type { Model, StreamFn } from "@openclaw/llm-core";
 import {
   type AgentCoreCompletionRuntimeDeps,

--- a/packages/agent-core/src/harness/compaction/compaction.ts
+++ b/packages/agent-core/src/harness/compaction/compaction.ts
@@ -5,7 +5,6 @@ import {
   type StreamFn,
   type Usage,
 } from "@openclaw/llm-core";
-// Agent Core module implements compaction behavior.
 import {
   CHARS_PER_TOKEN_ESTIMATE,
   estimateStringChars,

--- a/packages/agent-core/src/harness/env/kill-tree.ts
+++ b/packages/agent-core/src/harness/env/kill-tree.ts
@@ -1,4 +1,3 @@
-// Agent Core module implements kill tree behavior.
 import { spawn, spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 

--- a/packages/agent-core/src/harness/messages.ts
+++ b/packages/agent-core/src/harness/messages.ts
@@ -1,4 +1,3 @@
-// Agent Core module implements messages behavior.
 import type { ImageContent, Message, TextContent } from "@openclaw/llm-core";
 import { parseDateStringTimestampMs as parseSessionTimestampMs } from "@openclaw/normalization-core/number-coercion";
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";

--- a/packages/agent-core/src/harness/utils/truncate.ts
+++ b/packages/agent-core/src/harness/utils/truncate.ts
@@ -1,4 +1,3 @@
-// Agent Core module implements truncate behavior.
 export const DEFAULT_MAX_LINES = 2000;
 export const DEFAULT_MAX_BYTES = 50 * 1024; // 50KB
 export const GREP_MAX_LINE_LENGTH = 500; // Max chars per grep match line

--- a/packages/agent-core/src/runtime-deps.ts
+++ b/packages/agent-core/src/runtime-deps.ts
@@ -1,4 +1,3 @@
-// Agent Core module implements runtime deps behavior.
 import type { CompleteSimpleFn, StreamFn, Usage } from "@openclaw/llm-core";
 
 /** Runtime functions injected by host packages so agent-core stays provider-agnostic. */

--- a/packages/ai/src/api-registry.ts
+++ b/packages/ai/src/api-registry.ts
@@ -1,4 +1,3 @@
-// LLM Runtime module implements api registry behavior.
 import type {
   Api,
   AssistantMessageEventStreamContract,

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -1,4 +1,3 @@
-// LLM Runtime module implements stream behavior.
 import type {
   Api,
   AssistantMessage,

--- a/packages/gateway-client/src/device-auth.ts
+++ b/packages/gateway-client/src/device-auth.ts
@@ -1,4 +1,3 @@
-// Gateway Client module implements device auth behavior.
 export function normalizeDeviceMetadataForAuth(value?: string | null): string {
   if (typeof value !== "string") {
     return "";

--- a/packages/gateway-client/src/event-loop-ready.ts
+++ b/packages/gateway-client/src/event-loop-ready.ts
@@ -1,4 +1,3 @@
-// Gateway Client module implements event loop ready behavior.
 import { resolveFiniteTimeoutDelayMs } from "./timeouts.js";
 
 /** Readiness probe outcome with timing data for diagnosing event-loop stalls. */

--- a/packages/gateway-client/src/readiness.ts
+++ b/packages/gateway-client/src/readiness.ts
@@ -1,4 +1,3 @@
-// Gateway Client module implements readiness behavior.
 import type { GatewayClientOptions } from "./client.js";
 import {
   waitForEventLoopReady,

--- a/packages/gateway-client/src/timeouts.ts
+++ b/packages/gateway-client/src/timeouts.ts
@@ -1,4 +1,3 @@
-// Gateway Client module implements timeouts behavior.
 function parsePositiveTimeoutSetting(value: string): number | undefined {
   const trimmed = value.trim();
   if (!/^\+?\d+$/u.test(trimmed)) {

--- a/packages/llm-core/src/utils/diagnostics.ts
+++ b/packages/llm-core/src/utils/diagnostics.ts
@@ -1,4 +1,3 @@
-// LLM Core module implements diagnostics behavior.
 export interface DiagnosticErrorInfo {
   name?: string;
   message: string;

--- a/packages/llm-core/src/validation.ts
+++ b/packages/llm-core/src/validation.ts
@@ -1,4 +1,3 @@
-// LLM Core module implements validation behavior.
 import { Compile } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
 import type { Tool, ToolCall } from "./types.js";

--- a/packages/markdown-core/src/chunk-text.ts
+++ b/packages/markdown-core/src/chunk-text.ts
@@ -1,4 +1,3 @@
-// Markdown Core module implements chunk text behavior.
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import { avoidTrailingHighSurrogateBreak } from "@openclaw/normalization-core/utf16-slice";
 

--- a/packages/markdown-core/src/code-spans.ts
+++ b/packages/markdown-core/src/code-spans.ts
@@ -1,4 +1,3 @@
-// Markdown Core module implements code spans behavior.
 import { scanFenceSpans, type FenceScanState, type FenceSpan } from "./fences.js";
 
 /** Incremental inline-code scanner state carried across chunk boundaries. */

--- a/packages/markdown-core/src/frontmatter.ts
+++ b/packages/markdown-core/src/frontmatter.ts
@@ -1,4 +1,3 @@
-// Markdown Core module implements frontmatter behavior.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { isAlias, isMap, isNode, isScalar, parseDocument } from "yaml";
 

--- a/packages/markdown-core/src/ir.ts
+++ b/packages/markdown-core/src/ir.ts
@@ -1,4 +1,3 @@
-// Markdown Core module implements ir behavior.
 import { avoidTrailingHighSurrogateBreak } from "@openclaw/normalization-core/utf16-slice";
 import MarkdownIt, {
   type MarkdownIt as MarkdownItParser,

--- a/packages/markdown-core/src/render-aware-chunking.ts
+++ b/packages/markdown-core/src/render-aware-chunking.ts
@@ -1,6 +1,5 @@
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import { avoidTrailingHighSurrogateBreak } from "./chunk-text.js";
-// Markdown Core module implements render aware chunking behavior.
 import { annotateAssistantTranscriptRoleMessageBoundary } from "./ir-annotations.js";
 import { mergeAnnotationSpans, mergeStyleSpans } from "./ir-spans.js";
 import { appendMarkdownIR, sliceMarkdownIR, type MarkdownIR } from "./ir.js";

--- a/packages/markdown-core/src/render.ts
+++ b/packages/markdown-core/src/render.ts
@@ -5,7 +5,6 @@ import {
   isAutoLinkedMarkdownLink,
   type MarkdownAnnotationSpan,
 } from "./ir-spans.js";
-// Markdown Core module implements render behavior.
 import type { MarkdownIR, MarkdownLinkSpan, MarkdownStyle, MarkdownStyleSpan } from "./ir.js";
 
 /** Marker pair used to wrap a styled Markdown span in the target renderer. */

--- a/packages/media-core/src/file-name.ts
+++ b/packages/media-core/src/file-name.ts
@@ -1,4 +1,3 @@
-// Media Core module implements file name behavior.
 import path from "node:path";
 
 /** Returns the final filename segment for either POSIX or Windows-style paths. */

--- a/packages/media-core/src/inbound-path-policy.ts
+++ b/packages/media-core/src/inbound-path-policy.ts
@@ -1,4 +1,3 @@
-// Media Core module implements inbound path policy behavior.
 import path from "node:path";
 
 const WILDCARD_SEGMENT = "*";

--- a/packages/media-core/src/inline-image-data-url.ts
+++ b/packages/media-core/src/inline-image-data-url.ts
@@ -1,4 +1,3 @@
-// Media Core module implements inline image data url behavior.
 import { canonicalizeBase64 } from "./base64.js";
 
 /** Prefix used to distinguish inline data URLs from remote/local image references. */

--- a/packages/media-core/src/media-source-url.ts
+++ b/packages/media-core/src/media-source-url.ts
@@ -1,4 +1,3 @@
-// Media Core module implements media source url behavior.
 const HTTP_URL_RE = /^https?:\/\//i;
 const MXC_URL_RE = /^mxc:\/\//i;
 const BUFFER_URL_RE = /^buffer:\/\//i;

--- a/packages/media-core/src/mime.ts
+++ b/packages/media-core/src/mime.ts
@@ -1,4 +1,3 @@
-// Media Core module implements mime behavior.
 import path from "node:path";
 import { type MediaKind, mediaKindFromMime } from "./constants.js";
 import { extnameFromAnyPath } from "./file-name.js";

--- a/packages/media-generation-core/src/capability-model-ref.ts
+++ b/packages/media-generation-core/src/capability-model-ref.ts
@@ -1,4 +1,3 @@
-// Media Generation Core module implements capability model ref behavior.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 
 /** Provider catalog entry shape used when resolving capability-scoped model references. */

--- a/packages/media-generation-core/src/catalog.ts
+++ b/packages/media-generation-core/src/catalog.ts
@@ -1,4 +1,3 @@
-// Media Generation Core module implements catalog behavior.
 import { normalizeUniqueTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 
 // Shared media-generation catalog contracts and static entry synthesis.

--- a/packages/media-generation-core/src/model-ref.ts
+++ b/packages/media-generation-core/src/model-ref.ts
@@ -1,4 +1,3 @@
-// Media Generation Core module implements model ref behavior.
 import {
   parseProviderModelRef,
   type ProviderModelRef,

--- a/packages/media-understanding-common/src/defaults.ts
+++ b/packages/media-understanding-common/src/defaults.ts
@@ -1,4 +1,3 @@
-// Media Understanding Common module implements defaults behavior.
 import type { MediaUnderstandingCapability } from "./types.js";
 
 // Shared defaults for media-understanding limits, prompts, and concurrency.

--- a/packages/media-understanding-common/src/provider-supports.ts
+++ b/packages/media-understanding-common/src/provider-supports.ts
@@ -1,4 +1,3 @@
-// Media Understanding Common module implements provider supports behavior.
 import type { MediaUnderstandingCapability } from "./types.js";
 
 type MediaCapabilityProvider = {

--- a/packages/media-understanding-common/src/video.ts
+++ b/packages/media-understanding-common/src/video.ts
@@ -1,4 +1,3 @@
-// Media Understanding Common module implements video behavior.
 import { DEFAULT_VIDEO_MAX_BASE64_BYTES } from "./defaults.js";
 
 // Video payload size helpers for base64-expanded request bodies.

--- a/packages/memory-host-sdk/src/host/batch-error-utils.ts
+++ b/packages/memory-host-sdk/src/host/batch-error-utils.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK helper module supports batch error utils behavior.
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { EmbeddingBatchOutputLine } from "./batch-output.js";
 import { formatErrorMessage } from "./error-utils.js";

--- a/packages/memory-host-sdk/src/host/batch-http.ts
+++ b/packages/memory-host-sdk/src/host/batch-http.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements batch http behavior.
 import { retryAsync } from "@openclaw/retry";
 import type { SsrFPolicy } from "./openclaw-runtime-network.js";
 import { postJson } from "./post-json.js";

--- a/packages/memory-host-sdk/src/host/batch-provider-common.ts
+++ b/packages/memory-host-sdk/src/host/batch-provider-common.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK helper module supports batch provider common behavior.
 import type { EmbeddingBatchOutputLine } from "./batch-output.js";
 
 // Common OpenAI-compatible batch shapes shared by remote embedding providers.

--- a/packages/memory-host-sdk/src/host/batch-runner.ts
+++ b/packages/memory-host-sdk/src/host/batch-runner.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements batch runner behavior.
 import { resolveSafeTimeoutDelayMs } from "../../../gateway-client/src/timeouts.js";
 import { formatBatchErrorDetail } from "./batch-error-utils.js";
 import { applyEmbeddingBatchOutputLine, readEmbeddingBatchJsonl } from "./batch-output.js";

--- a/packages/memory-host-sdk/src/host/batch-upload.ts
+++ b/packages/memory-host-sdk/src/host/batch-upload.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements batch upload behavior.
 import { buildBatchHeaders, type BatchHttpClientConfig } from "./batch-utils.js";
 import { resolveEmbeddingEndpointUrl } from "./embeddings-remote-client.js";
 import { formatErrorMessage } from "./error-utils.js";

--- a/packages/memory-host-sdk/src/host/batch-utils.ts
+++ b/packages/memory-host-sdk/src/host/batch-utils.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK helper module supports batch utils behavior.
 import type { SsrFPolicy } from "./openclaw-runtime-network.js";
 
 // Common HTTP and grouping helpers for remote embedding batch clients.

--- a/packages/memory-host-sdk/src/host/config-utils.ts
+++ b/packages/memory-host-sdk/src/host/config-utils.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK helper module supports config utils behavior.
 import path from "node:path";
 import { normalizeAgentId } from "@openclaw/normalization-core/agent-id";
 import {

--- a/packages/memory-host-sdk/src/host/embedding-chunk-limits.ts
+++ b/packages/memory-host-sdk/src/host/embedding-chunk-limits.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements embedding chunk limits behavior.
 import { estimateUtf8Bytes, splitTextToUtf8ByteLimit } from "./embedding-input-limits.js";
 import { hasNonTextEmbeddingParts } from "./embedding-inputs.js";
 import { resolveEmbeddingMaxInputTokens } from "./embedding-model-limits.js";

--- a/packages/memory-host-sdk/src/host/embedding-input-limits.ts
+++ b/packages/memory-host-sdk/src/host/embedding-input-limits.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements embedding input limits behavior.
 import type { EmbeddingInput } from "./embedding-inputs.js";
 
 // Helpers for enforcing embedding model input size limits.

--- a/packages/memory-host-sdk/src/host/embedding-model-limits.ts
+++ b/packages/memory-host-sdk/src/host/embedding-model-limits.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements embedding model limits behavior.
 import type { EmbeddingProvider } from "./embeddings.types.js";
 
 // Provider input limits are byte-based approximations for pre-embedding chunk splitting.

--- a/packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.ts
+++ b/packages/memory-host-sdk/src/host/embedding-provider-adapter-utils.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK helper module supports embedding provider adapter utils behavior.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
 // Adapter helpers shared by remote embedding provider implementations.

--- a/packages/memory-host-sdk/src/host/embeddings-debug.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-debug.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements embeddings debug behavior.
 import { parseBoolean } from "@openclaw/normalization-core/boolean-coercion";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 

--- a/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-client.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements embeddings remote client behavior.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import type { EmbeddingProviderOptions } from "./embeddings.types.js";
 import { requireApiKey, resolveApiKeyForProvider } from "./openclaw-runtime-auth.js";

--- a/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-fetch.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements embeddings remote fetch behavior.
 import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { readEmbeddingVectors } from "./embedding-vectors.js";
 import type { SsrFPolicy } from "./openclaw-runtime-network.js";

--- a/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
+++ b/packages/memory-host-sdk/src/host/embeddings-remote-provider.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements embeddings remote provider behavior.
 import {
   resolveEmbeddingEndpointUrl,
   resolveRemoteEmbeddingBearerClient,

--- a/packages/memory-host-sdk/src/host/error-utils.ts
+++ b/packages/memory-host-sdk/src/host/error-utils.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK helper module supports error utils behavior.
 import { formatErrorMessage as formatSharedErrorMessage } from "@openclaw/normalization-core/error-coercion";
 // Import the canonical redactor directly, not via openclaw-runtime-io: that
 // facade pulls the full core runtime (execa reach), and this module sits in the

--- a/packages/memory-host-sdk/src/host/fs-utils.ts
+++ b/packages/memory-host-sdk/src/host/fs-utils.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK helper module supports fs utils behavior.
 import { configureFsSafeNative } from "@openclaw/fs-safe/config";
 // fs-safe facade with native acceleration disabled by default for this package's
 // host-side memory file operations.

--- a/packages/memory-host-sdk/src/host/hash.ts
+++ b/packages/memory-host-sdk/src/host/hash.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements hash behavior.
 import crypto from "node:crypto";
 
 /** SHA-256 hash helper for stable cache/content keys. */

--- a/packages/memory-host-sdk/src/host/internal.ts
+++ b/packages/memory-host-sdk/src/host/internal.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements internal behavior.
 import crypto from "node:crypto";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";

--- a/packages/memory-host-sdk/src/host/memory-schema.ts
+++ b/packages/memory-host-sdk/src/host/memory-schema.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements memory schema behavior.
 import type { DatabaseSync } from "node:sqlite";
 import { formatErrorMessage } from "./error-utils.js";
 import {

--- a/packages/memory-host-sdk/src/host/multimodal.ts
+++ b/packages/memory-host-sdk/src/host/multimodal.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements multimodal behavior.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
 // Multimodal memory settings and file classification helpers.

--- a/packages/memory-host-sdk/src/host/openclaw-runtime-auth.ts
+++ b/packages/memory-host-sdk/src/host/openclaw-runtime-auth.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements openclaw runtime auth behavior.
 import { requireApiKey } from "../../../../src/agents/model-auth-runtime-shared.js";
 import type { resolveApiKeyForProviderCore as ResolveApiKeyForProvider } from "../../../../src/agents/model-auth.js";
 

--- a/packages/memory-host-sdk/src/host/post-json.ts
+++ b/packages/memory-host-sdk/src/host/post-json.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements post json behavior.
 import { formatErrorMessage } from "./error-utils.js";
 import type { SsrFPolicy } from "./openclaw-runtime-network.js";
 import { withRemoteHttpResponse } from "./remote-http.js";

--- a/packages/memory-host-sdk/src/host/query-expansion.ts
+++ b/packages/memory-host-sdk/src/host/query-expansion.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements query expansion behavior.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
 /**

--- a/packages/memory-host-sdk/src/host/read-file-shared.ts
+++ b/packages/memory-host-sdk/src/host/read-file-shared.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements read file shared behavior.
 import { resolveIntegerOption } from "@openclaw/normalization-core/number-coercion";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { MemoryReadResult } from "./types.js";

--- a/packages/memory-host-sdk/src/host/read-file.ts
+++ b/packages/memory-host-sdk/src/host/read-file.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements read file behavior.
 import fs from "node:fs/promises";
 import path from "node:path";
 import {

--- a/packages/memory-host-sdk/src/host/read-retry.ts
+++ b/packages/memory-host-sdk/src/host/read-retry.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements read retry behavior.
 import { retryAsync } from "@openclaw/retry";
 
 // Retry helper for transient filesystem reads observed on memory stores.

--- a/packages/memory-host-sdk/src/host/remote-http.ts
+++ b/packages/memory-host-sdk/src/host/remote-http.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements remote http behavior.
 import {
   fetchWithSsrFGuard,
   shouldUseEnvHttpProxyForUrl,

--- a/packages/memory-host-sdk/src/host/response-snippet.ts
+++ b/packages/memory-host-sdk/src/host/response-snippet.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements response snippet behavior.
 import { consumeResponseBytes, decodeTextPrefix } from "@openclaw/normalization-core";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 

--- a/packages/memory-host-sdk/src/host/secret-input.ts
+++ b/packages/memory-host-sdk/src/host/secret-input.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements secret input behavior.
 import {
   hasConfiguredSecretInput,
   normalizeResolvedSecretInputString,

--- a/packages/memory-host-sdk/src/host/sqlite-vec-platform-variant.ts
+++ b/packages/memory-host-sdk/src/host/sqlite-vec-platform-variant.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements sqlite vec platform variant behavior.
 import { createRequire } from "node:module";
 
 // Resolves optional sqlite-vec native extension packages for the current platform.

--- a/packages/memory-host-sdk/src/host/sqlite-vec.ts
+++ b/packages/memory-host-sdk/src/host/sqlite-vec.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements sqlite vec behavior.
 import type { DatabaseSync } from "node:sqlite";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { formatErrorMessage } from "./error-utils.js";

--- a/packages/memory-host-sdk/src/host/sqlite.ts
+++ b/packages/memory-host-sdk/src/host/sqlite.ts
@@ -1,4 +1,3 @@
-// Memory Host SDK module implements sqlite behavior.
 import { createRequire } from "node:module";
 import type { DatabaseSync } from "node:sqlite";
 import { formatErrorMessage } from "./error-utils.js";

--- a/packages/model-catalog-core/src/model-catalog-normalize.ts
+++ b/packages/model-catalog-core/src/model-catalog-normalize.ts
@@ -1,4 +1,3 @@
-// Model Catalog Core helper module supports model catalog normalize behavior.
 import {
   asFiniteNumber as normalizeFiniteNumber,
   asNonNegativeFiniteNumber as normalizeNonNegativeNumber,

--- a/packages/model-catalog-core/src/model-catalog-refs.ts
+++ b/packages/model-catalog-core/src/model-catalog-refs.ts
@@ -1,4 +1,3 @@
-// Model Catalog Core module implements model catalog refs behavior.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { normalizeProviderId } from "./provider-id.js";
 

--- a/packages/model-catalog-core/src/provider-id.ts
+++ b/packages/model-catalog-core/src/provider-id.ts
@@ -1,4 +1,3 @@
-// Model Catalog Core module implements provider id behavior.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
 export function normalizeProviderId(provider: string): string {

--- a/packages/model-catalog-core/src/provider-model-id-normalization.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalization.ts
@@ -1,4 +1,3 @@
-// Model Catalog Core module implements provider model id normalization behavior.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { parseModelCatalogRef } from "./model-catalog-refs.js";
 import {

--- a/packages/model-catalog-core/src/provider-model-id-normalize.ts
+++ b/packages/model-catalog-core/src/provider-model-id-normalize.ts
@@ -1,4 +1,3 @@
-// Model Catalog Core helper module supports provider model id normalize behavior.
 const ANTIGRAVITY_BARE_PRO_IDS = new Set(["gemini-3-pro", "gemini-3.1-pro", "gemini-3-1-pro"]);
 const GOOGLE_PROVIDER_PREFIX = "google/";
 

--- a/packages/net-policy/src/ip-test-fixtures.ts
+++ b/packages/net-policy/src/ip-test-fixtures.ts
@@ -1,2 +1,1 @@
-// Network Policy module implements ip test fixtures behavior.
 export const blockedIpv6MulticastLiterals = ["ff02::1", "ff05::1:3", "[ff02::1]"] as const;

--- a/packages/net-policy/src/ip.ts
+++ b/packages/net-policy/src/ip.ts
@@ -1,4 +1,3 @@
-// Network Policy module implements ip behavior.
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,

--- a/packages/net-policy/src/ipv4.ts
+++ b/packages/net-policy/src/ipv4.ts
@@ -1,4 +1,3 @@
-// Network Policy module implements ipv4 behavior.
 import { isCanonicalDottedDecimalIPv4 } from "./ip.js";
 
 /** Validates the custom-bind IPv4 input and returns the user-facing error text. */

--- a/packages/net-policy/src/redact-sensitive-url.ts
+++ b/packages/net-policy/src/redact-sensitive-url.ts
@@ -1,4 +1,3 @@
-// Network Policy module implements redact sensitive url behavior.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 
 type ConfigUiHintTags = {

--- a/packages/normalization-core/src/string-normalization.ts
+++ b/packages/normalization-core/src/string-normalization.ts
@@ -1,4 +1,3 @@
-// Normalization Core module implements string normalization behavior.
 import { normalizeOptionalLowercaseString, normalizeOptionalString } from "./string-coerce.js";
 
 /** Detects C0 and DEL without rejecting C1 or other Unicode text. */

--- a/packages/sdk/src/event-hub.ts
+++ b/packages/sdk/src/event-hub.ts
@@ -1,4 +1,3 @@
-// OpenClaw SDK module implements event hub behavior.
 import type { GatewayEvent } from "./types.js";
 
 // Async event hub with bounded replay for SDK event streams.

--- a/packages/sdk/src/transport.ts
+++ b/packages/sdk/src/transport.ts
@@ -1,4 +1,3 @@
-// OpenClaw SDK module implements transport behavior.
 import { GatewayClient, type GatewayClientOptions } from "@openclaw/gateway-client";
 import { EventHub } from "./event-hub.js";
 import type {

--- a/packages/terminal-core/src/decorative-emoji.ts
+++ b/packages/terminal-core/src/decorative-emoji.ts
@@ -1,4 +1,3 @@
-// Terminal Core module implements decorative emoji behavior.
 import { splitGraphemes } from "./ansi.js";
 
 // Decorative emoji helpers that degrade cleanly on terminals without reliable emoji support.

--- a/packages/terminal-core/src/health-style.ts
+++ b/packages/terminal-core/src/health-style.ts
@@ -1,4 +1,3 @@
-// Terminal Core module implements health style behavior.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { theme } from "./theme.js";
 

--- a/packages/terminal-core/src/links.ts
+++ b/packages/terminal-core/src/links.ts
@@ -1,4 +1,3 @@
-// Terminal Core module implements links behavior.
 import { formatTerminalLink } from "./terminal-link.js";
 
 function resolveDocsRoot(): string {

--- a/packages/terminal-core/src/note.ts
+++ b/packages/terminal-core/src/note.ts
@@ -1,4 +1,3 @@
-// Terminal Core module implements note behavior.
 import { AsyncLocalStorage } from "node:async_hooks";
 import { note as clackNote } from "@clack/prompts";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";

--- a/packages/terminal-core/src/prompt-select-styled-params.ts
+++ b/packages/terminal-core/src/prompt-select-styled-params.ts
@@ -1,4 +1,3 @@
-// Terminal Core module implements prompt select styled params behavior.
 import { stylePromptHint, stylePromptMessage } from "./prompt-style.js";
 
 // Pure prompt parameter styler used by interactive prompts and tests.

--- a/packages/terminal-core/src/prompt-select-styled.ts
+++ b/packages/terminal-core/src/prompt-select-styled.ts
@@ -1,4 +1,3 @@
-// Terminal Core module implements prompt select styled behavior.
 import { select } from "@clack/prompts";
 import { styleSelectParams } from "./prompt-select-styled-params.js";
 

--- a/packages/terminal-core/src/prompt-style.ts
+++ b/packages/terminal-core/src/prompt-style.ts
@@ -1,4 +1,3 @@
-// Terminal Core module implements prompt style behavior.
 import { isRich, theme } from "./theme.js";
 
 // Shared styling helpers for interactive prompt copy.

--- a/packages/terminal-core/src/restore.ts
+++ b/packages/terminal-core/src/restore.ts
@@ -1,4 +1,3 @@
-// Terminal Core module implements restore behavior.
 import { clearActiveProgressLine } from "./progress-line.js";
 
 const RESET_SEQUENCE =

--- a/packages/terminal-core/src/safe-text.ts
+++ b/packages/terminal-core/src/safe-text.ts
@@ -1,4 +1,3 @@
-// Terminal Core module implements safe text behavior.
 import { stripAnsi } from "./ansi.js";
 
 /** Return whether text contains C0 or C1 terminal control characters. */

--- a/packages/terminal-core/src/theme.ts
+++ b/packages/terminal-core/src/theme.ts
@@ -1,4 +1,3 @@
-// Terminal Core module implements theme behavior.
 import chalk, { Chalk } from "chalk";
 import { LOBSTER_PALETTE } from "./palette.js";
 

--- a/packages/tool-call-repair/src/payload.ts
+++ b/packages/tool-call-repair/src/payload.ts
@@ -5,7 +5,6 @@ import {
   type PlainTextToolCallParseOptions,
   type PlainTextToolCallProtectedRangeResolver,
 } from "./contracts.js";
-// Tool Call Repair module implements payload behavior.
 import {
   consumeLineBreak,
   consumeStructuralLineBreakAfterHorizontalWhitespace,

--- a/packages/tool-call-repair/src/promote.ts
+++ b/packages/tool-call-repair/src/promote.ts
@@ -1,6 +1,5 @@
 import { asOptionalObjectRecord as asRecord } from "@openclaw/normalization-core/record-coerce";
 import type { PlainTextToolCallProtectedRangeResolver } from "./contracts.js";
-// Tool Call Repair module implements promote behavior.
 import { parseStandalonePlainTextToolCallBlocks, type PlainTextToolCallBlock } from "./payload.js";
 
 /** Resolves model-emitted tool names to the exact names allowed by the provider request. */


### PR DESCRIPTION
Closes #141498

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Package source files contain 98 repetitive filename-paraphrasing captions that repeat the filename, such as “module implements … behavior,” without explaining a contract. This maintainer-requested cleanup removes that noise beside useful documentation.

## Why This Change Was Made

Delete only the recorded captions. Meaningful JSDoc, licensing, ownership/lifecycle comments, declarations, imports and every executable byte remain unchanged.

## User Impact

No runtime or public API change. This removes 97 comment lines from production files and one from a test fixture; executable-code and test-case deltas are zero. Related plugin-policy cleanup #139771 covers different files.

## Evidence

- All 98 complete files match their original bytes after deleting exactly the one recorded caption; before/after hashes are retained.
- Formatting checks on all changed files and whitespace validation pass.
- Final independent P2 review is scoped-clean with no actionable findings.
- No runtime test, build, live service or performance claim is made for this documentation-only change. Required exact-head CI remains mandatory before landing.

Compatibility review: configuration, defaults, schema, migration and persistence code are byte-for-byte unchanged. The complete 98-file comparison covers the full introduced patch, including the fixture; only ordinary line comments were removed. The review’s generic `unknown-truncated-pull-files` warning does not identify a data-model change, so no migration or upgrade exercise applies to this patch. The independent source review also confirms complete-file preservation.
