### PR TITLE
chore(ui): keep Markdown code tests within lint limits

### DIFF
--- a/ui/src/components/markdown-streaming-highlight.test.ts
+++ b/ui/src/components/markdown-streaming-highlight.test.ts
@@ -119,3 +119,33 @@ describe("toStreamingMarkdownParts code fences", () => {
     expect(html).toBe(toSanitizedMarkdownHtml(markdown));
   });
 });
+
+describe("indented Markdown source", () => {
+  it.each(["    *literal*", "\t*literal*", "\n\n    *literal*"])(
+    "renders initial code: %j",
+    (source) => {
+      expect(
+        htmlFragment(toSanitizedMarkdownHtml(source)).querySelector("pre code")?.textContent,
+      ).toBe("*literal*\n");
+    },
+  );
+
+  it.each(["    a\n\n    b", "Intro\n\n    a\n\n    b"])(
+    "keeps a streamed indented block together: %j",
+    (source) => {
+      const fragment = htmlFragment(toStreamingMarkdownParts(source).join(""));
+      expect(fragment.querySelectorAll("pre code")).toHaveLength(1);
+      expect(fragment.querySelector("pre code")?.textContent).toBe("a\n\nb\n");
+    },
+  );
+
+  it("never repairs literal punctuation inside streaming indented code", () => {
+    const source = "    *literal";
+    for (let end = 5; end <= source.length; end++) {
+      const fragment = htmlFragment(
+        toStreamingMarkdownParts(source.slice(0, end), {}, "indented-prefix").join(""),
+      );
+      expect(fragment.querySelector("pre code")?.textContent).toBe(`${source.slice(4, end)}\n`);
+    }
+  });
+});

--- a/ui/src/components/markdown.test.ts
+++ b/ui/src/components/markdown.test.ts
@@ -1143,33 +1143,3 @@ describe("toStreamingMarkdownParts", () => {
     expect(html).toBe("<p>prices are $$50 and</p>\n");
   });
 });
-
-describe("indented Markdown source", () => {
-  it.each(["    *literal*", "\t*literal*", "\n\n    *literal*"])(
-    "renders initial code: %j",
-    (source) => {
-      expect(
-        htmlFragment(toSanitizedMarkdownHtml(source)).querySelector("pre code")?.textContent,
-      ).toBe("*literal*\n");
-    },
-  );
-
-  it.each(["    a\n\n    b", "Intro\n\n    a\n\n    b"])(
-    "keeps a streamed indented block together: %j",
-    (source) => {
-      const fragment = htmlFragment(toStreamingMarkdownParts(source).join(""));
-      expect(fragment.querySelectorAll("pre code")).toHaveLength(1);
-      expect(fragment.querySelector("pre code")?.textContent).toBe("a\n\nb\n");
-    },
-  );
-
-  it("never repairs literal punctuation inside streaming indented code", () => {
-    const source = "    *literal";
-    for (let end = 5; end <= source.length; end++) {
-      const fragment = htmlFragment(
-        toStreamingMarkdownParts(source.slice(0, end), {}, "indented-prefix").join(""),
-      );
-      expect(fragment.querySelector("pre code")?.textContent).toBe(`${source.slice(4, end)}\n`);
-    }
-  });
-});


### PR DESCRIPTION
Related: #141461

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where pull requests cannot complete required core lint after the indented-code regression suite pushes the shared Markdown test file above its 1,000-line limit. This separate maintainer repair is required to validate the memory diagnostics fix in #141461.

## Why This Change Was Made

Moves the complete, unchanged indented-code test group into the existing Markdown streaming suite, which already uses the same render entry points and identical fixture helper. All six cases remain covered; the test-file limit and assertions are unchanged.

## User Impact

Restores the required lint path for new fixes. Product behavior is unchanged.

## Evidence

- The unchanged baseline reproduces `eslint(max-lines)` at 1,011 counted lines in the same repo-relative file. The changed-file check, including the identical targeted lint command, passes after the move.
- Both affected suites pass all 129 tests, including all six indented-code cases at their new location.
- The full changed-file checks pass: formatting, UI test types, i18n, dependency and source guards, unused-export scans, and core lint.
- The moved group is byte-identical; production delta is zero and test delta is +30/−30. No builds or screenshots are needed for this test-only relocation.

Independent P0–P2 review completed with no actionable findings on the exact final patch.
