### PR TITLE
refactor(meeting): remove redundant fingerprint retry

### DIFF
--- a/src/meeting-bot/output-loopback-verifier.ts
+++ b/src/meeting-bot/output-loopback-verifier.ts
@@ -176,7 +176,7 @@ export function createMeetingOutputLoopbackVerifier(options: {
     nextInputStartSample = Math.max(0, inputSampleCount - rescanTailSamples);
   };
 
-  const consumePendingOutput = (allowShortReference: boolean) => {
+  const consumePendingOutput = () => {
     const pendingBytes = pendingOutputPcm.byteLength;
     for (let end = pendingBytes; end >= fullReferenceBytes; end -= fullReferenceBytes) {
       const candidate = pendingOutputPcm.subarray(end - fullReferenceBytes, end);
@@ -201,13 +201,6 @@ export function createMeetingOutputLoopbackVerifier(options: {
       pendingBytes > fullReferenceBytes
         ? pendingOutputPcm.subarray(pendingBytes - fullReferenceBytes)
         : pendingOutputPcm;
-    if (!outputFingerprint && allowShortReference && pendingOutputPcm.byteLength > 0) {
-      const fingerprint = createOutputFingerprint(pendingOutputPcm, fullReferenceBytes);
-      if (fingerprint) {
-        pendingOutputPcm = Buffer.alloc(0);
-        refreshFingerprint(fingerprint);
-      }
-    }
   };
 
   return {
@@ -299,10 +292,8 @@ export function createMeetingOutputLoopbackVerifier(options: {
       }
       const decoded = decodeMeetingAudio(audio, options.audioFormat);
       pendingOutputPcm = Buffer.concat([pendingOutputPcm, decoded]);
-      if (!outputFingerprint) {
-        consumePendingOutput(true);
-      } else if (pendingOutputPcm.byteLength >= fullReferenceBytes) {
-        consumePendingOutput(false);
+      if (!outputFingerprint || pendingOutputPcm.byteLength >= fullReferenceBytes) {
+        consumePendingOutput();
       }
     },
     getHealth(): MeetingOutputLoopbackHealth {


### PR DESCRIPTION
Closes #141502

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Meeting loopback fingerprint selection contains a final retry that cannot produce a new result. This maintainer-requested cleanup removes the redundant path and the branches kept only to select it.

## Why This Change Was Made

The earlier full-window or residual scan already examined the retained buffer. Fingerprint construction reads private PCM synchronously, with no mutation or awaited work between attempts. Remove the retry and its boolean argument while preserving the existing scan order and tail handling.

## User Impact

No behavior change is intended. Local and node audio transports retain their deadlines, generation resets, verification checks and scratch retirement. Production code shrinks by nine lines; tests and public contracts are unchanged. No performance or memory improvement is claimed.

## Evidence

- All 28 existing verifier, local transport and node transport tests pass across three suites.
- The selected changed-file gate and final independent P2 review pass.
- The exact final diff preserves residual-prefix scanning and trailing-window retention; the removed retry can only examine a previously rejected buffer.
- The earlier scratch-lifetime repair in #140750 remains intact. Required exact-head CI applies before landing.
