### PR TITLE
fix: surface subagent worktree setup failures and stop per-blob fetches during worktree sizing

### DIFF
--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -42,13 +42,15 @@ The repository fingerprint is the first 16 hexadecimal characters of a SHA-256 h
 
 OpenClaw creates branch `openclaw/<name>` at the requested base ref. Without a base ref, it fetches `origin`, uses the remote default branch when available, and falls back to local `HEAD` when the repository is offline or has no usable remote.
 
-Each `git worktree add` checkout during creation or snapshot restore has a five-minute timeout, including a creation retry from local `HEAD`. Other managed-worktree Git commands keep their two-minute timeout. The separate `.openclaw/worktree-setup.sh` step also keeps its own two-minute timeout.
+Each `git worktree add` checkout during creation or snapshot restore has a five-minute timeout, including a creation retry from local `HEAD`. Fetching missing objects for the size estimate uses the same five-minute budget. Other managed-worktree Git commands keep their two-minute timeout. The separate `.openclaw/worktree-setup.sh` step also keeps its own two-minute timeout.
 
 ## Capacity and disk space
 
 OpenClaw uses 100 live managed worktrees per state directory as a cleanup target, not an admission cap. Count alone never blocks creation or snapshot restore; available disk space still bounds new allocations. Creation never evicts another session to make room. Manual and protected worktrees can keep the total above the cleanup target.
 
 Before allocating a checkout, OpenClaw checks its destination, Git metadata, source checkout, and state volumes. It keeps 10% of each volume free, with a minimum reserve of 4 GiB and a maximum of 16 GiB, plus twice the estimated Git checkout and provisioned-file size. An executable setup script requires additional room equal to the larger of 4 GiB or the current source checkout footprint excluding Git metadata. Space is checked again before provisioning/setup and after setup. An unavailable capacity reading stops allocation with an actionable error.
+
+For partial clones, OpenClaw inventories missing objects before estimating checkout size and fetches them from the clone's promisor remote in one batch. The size inventory cannot trigger per-object lazy fetches. If objects are missing without a promisor remote, fetch or repair the clone before retrying. A Git timeout reports its budget and suggests checking remote reachability, repository locks, and partial-clone behavior.
 
 Creation, restore, and snapshot removal share one allocation lease across repositories and processes using the same state directory. Costs on the same volume are added together. These checks are conservative estimates, not a disk quota: other OpenClaw state directories, shell commands, deployment tools, and arbitrary setup/build output can still consume space. Reusing an existing valid checkout does not allocate another checkout. Worktrees created directly through Git are outside the managed cleanup lifecycle.
 
@@ -79,6 +81,8 @@ A nonzero exit aborts creation and removes the new worktree and branch. This is 
 Setup failures report the exit code or termination signal, or an actual timeout after 120 seconds, with a bounded excerpt of recent output rather than the full setup log. If setup times out, inspect `.openclaw/worktree-setup.sh` and its dependencies for slow downloads, unavailable services, or commands waiting for interactive input.
 
 ## Session worktrees
+
+If worktree preparation fails before the first model reply, the session records the failure reason. The Control UI shows it with the failed session and in the chat, and the transcript retains a failure notice. Command failures identify the command and its exit or timeout reason, so a Git setup timeout is distinguishable from a model-provider timeout.
 
 Start an isolated chat from a Git-backed folder with a worktree session: on the Control UI's New session page, use the **Place** picker to choose a Gateway source folder, then select **Worktree** (with an optional base branch and worktree name). Choosing a paired device or cloud profile with a Gateway folder selected uses this managed-worktree path; remote placement never browses or binds an arbitrary node working directory. When the name is omitted, OpenClaw derives it from the explicit session label or the concise title generated from the first message, then falls back to a crustacean-themed name. iOS exposes the same choice from Chat actions, and Android exposes it beside New Chat, when the active agent workspace is Git-backed.
 

--- a/docs/tools/subagents.md
+++ b/docs/tools/subagents.md
@@ -54,7 +54,11 @@ the raw full transcript.
 
 In the Control UI, parent sessions with recent child runs have an expandable
 sidebar row. The nested rows show child status and runtime, and selecting one
-opens that child's chat while preserving the parent hierarchy.
+opens that child's chat while preserving the parent hierarchy. Failed or timed-out
+children retain a bounded failure reason, including failures during worktree
+preparation before any model reply. The child's transcript includes a durable
+failure notice when no assistant reply was recorded for that run. A later
+successful run clears the previous failure reason.
 
 ### Thread binding controls
 

--- a/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
+++ b/src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts
@@ -6,6 +6,8 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import { markInboundContextLabel } from "../auto-reply/reply/inbound-context-marker.js";
+import { createCommandError } from "../process/command-error.js";
+import type { SpawnResult } from "../process/exec-result.js";
 import {
   downgradeOpenAIFunctionCallReasoningPairs,
   dropStaleOpenAIReasoning,
@@ -212,6 +214,53 @@ describe("sanitizeUserFacingText", () => {
       }),
     ).toBe("LLM request failed: connection refused by the provider endpoint.");
   });
+
+  it("preserves the production Git inventory timeout and its hint instead of provider copy", () => {
+    const header =
+      "Error: git ls-tree -r --format=%(objectsize) c79ad267ba623c1a323f1f6e8b60228bd5a30ce5 -- failed (timed out after 120 seconds; signal SIGTERM):";
+    const hint = "Check repository access and disk space.";
+    const text = `${header}\n…\n4514\n4168\n…\n${hint}`;
+    const rendered = renderUserFacingText(text, { errorContext: true });
+    expect(rendered).toBe(`${header} ${hint}`);
+    expect(rendered).not.toBe("LLM request timed out.");
+  });
+
+  it.each([
+    ["Error: fetch failed", "LLM request failed: network connection error."],
+    ["Error: request timed out", "LLM request timed out."],
+  ])("keeps provider presentation for unmarked errors: %s", (text, expected) => {
+    expect(renderUserFacingText(text, { errorContext: true })).toBe(expected);
+  });
+
+  it.each([
+    { termination: "exit", code: 23, signal: null },
+    { termination: "no-output-timeout", code: null, signal: "SIGTERM" },
+    { termination: "signal", code: null, signal: "SIGKILL" },
+    { termination: "signal", code: null, signal: null },
+    { termination: "exit", code: null, signal: null, outputLimitExceeded: true },
+    { termination: "exit", code: null, signal: null },
+  ] satisfies Array<Partial<SpawnResult>>)(
+    "preserves command failure metadata and the bounded recovery tail: %j",
+    (metadata) => {
+      const error = createCommandError(
+        "worktree setup",
+        {
+          stdout: "",
+          stderr: `Provider rate limit reached\nCreate   the fixture input and retry ${"x".repeat(600)}`,
+          killed: false,
+          ...metadata,
+        },
+        { timeoutMs: 120_000 },
+      );
+      const header = String(error).split("\n", 1)[0];
+      const rendered = renderUserFacingText(String(error), { errorContext: true });
+      expect(rendered).toContain(`${header} Create the fixture input and retry`);
+      expect(rendered).not.toContain("Provider rate limit");
+      expect(rendered).not.toMatch(/\s{2,}/u);
+      expect(rendered.length).toBeLessThanOrEqual(500);
+      expect(rendered).toMatch(/\.\.\.$/u);
+    },
+  );
 
   it.each(["disk full", "ENOSPC: no space left on device"])(
     "rewrites disk-space failures with errorContext: %s",

--- a/src/agents/failover/user-copy.ts
+++ b/src/agents/failover/user-copy.ts
@@ -1,6 +1,7 @@
 import { stableStringify } from "@openclaw/normalization-core";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { formatCommandErrorForUser } from "../../process/command-error.js";
 import {
   extractErrorHttpStatus,
   extractLeadingHttpStatus,
@@ -300,6 +301,10 @@ export function renderSanitizedUserFacingText(
     return shouldRewriteRawPayloadWithoutErrorContext(trimmed)
       ? formatRawAssistantErrorForUi(trimmed)
       : sanitized;
+  }
+  const commandError = formatCommandErrorForUser(trimmed);
+  if (commandError) {
+    return commandError;
   }
   const execDenied = formatExecDeniedUserMessage(trimmed);
   if (execDenied) {

--- a/src/agents/subagents/registry/subagent-registry-helpers.ts
+++ b/src/agents/subagents/registry/subagent-registry-helpers.ts
@@ -16,6 +16,10 @@ import { patchSessionEntryCore } from "../../../config/sessions/session-accessor
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { computeBackoff } from "../../../infra/backoff.js";
 import { defaultRuntime } from "../../../runtime.js";
+import {
+  recordGatewaySessionRunFailure,
+  resolveSessionRunError,
+} from "../../../sessions/session-run-error.js";
 import { truncateUtf8Prefix } from "../../../utils/utf8-truncate.js";
 import {
   getDeliveryAttemptCount,
@@ -127,7 +131,10 @@ export async function persistSubagentSessionTiming(
       : getSubagentSessionRuntimeMs(entry);
   const status = resolveSubagentSessionStatus(entry);
 
-  await patchSessionEntryCore(
+  const lastRunError = status
+    ? resolveSessionRunError(entry.execution.outcome ?? {}, status)
+    : undefined;
+  const persisted = await patchSessionEntryCore(
     { storePath, sessionKey: childSessionKey },
     (sessionEntry) => {
       // Recheck under the session-store write lock. A completion may have
@@ -176,6 +183,11 @@ export async function persistSubagentSessionTiming(
       } else {
         delete next.status;
       }
+      if (lastRunError) {
+        next.lastRunError = lastRunError;
+      } else if (status === "done") {
+        delete next.lastRunError;
+      }
       if (status && status !== "killed") {
         delete next.abortedLastRun;
       }
@@ -186,6 +198,20 @@ export async function persistSubagentSessionTiming(
       replaceEntry: true,
     },
   );
+  if (persisted && lastRunError) {
+    await recordGatewaySessionRunFailure({
+      target: {
+        agentId,
+        storePath,
+        sessionKey: childSessionKey,
+        sessionId: persisted.sessionId,
+        expectedLifecycleRevision: persisted.lifecycleRevision,
+      },
+      runId: entry.runId,
+      error: entry.execution.outcome?.error,
+      assertCommitAllowed: options?.assertCommitAllowed,
+    });
+  }
 }
 
 // Attachment cleanup must stay within the recorded root even if paths were

--- a/src/agents/subagents/registry/subagent-registry.persistence.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.persistence.test.ts
@@ -6,7 +6,10 @@ import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "./subagent-registry.mocks.shared.js";
 import { createDeferred } from "../../../../test/helpers/promise.js";
-import { replaceSessionEntry } from "../../../config/sessions/session-accessor.js";
+import {
+  patchSessionEntryCore,
+  replaceSessionEntry,
+} from "../../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../../config/sessions/types.js";
 import { callGateway } from "../../../gateway/call.js";
 import { onAgentEvent } from "../../../infra/agent-events.js";
@@ -277,6 +280,9 @@ describe("subagent registry persistence", () => {
       sessionId: "sess-timing",
       updatedAt: startedAt - 1,
     });
+    await patchSessionEntryCore({ storePath, sessionKey: "agent:main:subagent:timing" }, () => ({
+      lastRunError: "Previous setup failed",
+    }));
     await persistSubagentSessionTiming({
       runId: "run-session-timing",
       childSessionKey: "agent:main:subagent:timing",
@@ -295,6 +301,7 @@ describe("subagent registry persistence", () => {
     expect(persisted?.endedAt).toBe(endedAt);
     expect(persisted?.runtimeMs).toBe(500);
     expect(persisted?.status).toBe("done");
+    expect(persisted?.lastRunError).toBeUndefined();
     expect(persisted?.startedAt).toBeGreaterThanOrEqual(startedAt);
     expect(persisted?.startedAt).toBeLessThanOrEqual(endedAt);
   });

--- a/src/agents/subagents/registry/subagent-registry.session-failure.test.ts
+++ b/src/agents/subagents/registry/subagent-registry.session-failure.test.ts
@@ -1,0 +1,82 @@
+import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { describe, expect, it } from "vitest";
+import {
+  loadSessionEntry,
+  loadTranscriptEvents,
+  upsertSessionEntryCore,
+} from "../../../config/sessions/session-accessor.js";
+import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
+import { persistSubagentSessionTiming } from "./subagent-registry-helpers.js";
+import type { SubagentRunRecord } from "./subagent-registry.types.js";
+
+describe("subagent session failures", () => {
+  it.each(["error", "timeout"] as const)(
+    "persists a bounded %s reason and one durable child notice, then clears only on success",
+    async (outcomeStatus) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async (state) => {
+        const target = {
+          agentId: "main",
+          sessionKey: "agent:main:subagent:setup-failure",
+          sessionId: "sess-setup-failure",
+          storePath: path.join(state.sessionsDir(), "sessions.json"),
+        };
+        await upsertSessionEntryCore(target, {
+          sessionId: target.sessionId,
+          updatedAt: Date.now(),
+        });
+        const reason = `Repository base ref is missing. ${"details ".repeat(80)}`.trim();
+        const record: SubagentRunRecord = {
+          runId: "run-setup-failure",
+          childSessionKey: target.sessionKey,
+          requesterSessionKey: "agent:main:main",
+          requesterDisplayKey: "main",
+          task: "prepare child worktree",
+          cleanup: "keep",
+          createdAt: 1_000,
+          execution: {
+            status: "terminal",
+            startedAt: 1_001,
+            endedAt: 2_000,
+            outcome: {
+              status: outcomeStatus,
+              error: `[tool calls omitted]\n<final>${reason}</final>`,
+            },
+          },
+        };
+        await persistSubagentSessionTiming(record);
+        expect(loadSessionEntry(target)).toMatchObject({
+          status: outcomeStatus === "error" ? "failed" : "timeout",
+          lastRunError: reason.slice(0, 160),
+        });
+        await persistSubagentSessionTiming(record);
+        expect(
+          (await loadTranscriptEvents(target)).filter(
+            (event) => isRecord(event) && event.type === "custom_message",
+          ),
+        ).toMatchObject([
+          {
+            customType: "run-failed-before-reply",
+            display: true,
+            details: { runId: record.runId, error: reason.slice(0, 512) },
+          },
+        ]);
+
+        for (const executionStatus of ["running", "queued"] as const) {
+          await persistSubagentSessionTiming({
+            ...record,
+            execution: { status: executionStatus },
+          });
+          expect(loadSessionEntry(target)?.lastRunError).toBe(reason.slice(0, 160));
+        }
+        await persistSubagentSessionTiming({ ...record, endedReason: "subagent-killed" });
+        expect(loadSessionEntry(target)?.lastRunError).toBe(reason.slice(0, 160));
+        await persistSubagentSessionTiming({
+          ...record,
+          execution: { ...record.execution, outcome: { status: "ok" } },
+        });
+        expect(loadSessionEntry(target)?.lastRunError).toBeUndefined();
+      });
+    },
+  );
+});

--- a/src/agents/worktrees/capacity.test.ts
+++ b/src/agents/worktrees/capacity.test.ts
@@ -1,0 +1,117 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import * as gitExec from "../../infra/git-exec.js";
+import { estimateWorktreeGitBytes } from "./capacity.js";
+import { runGit } from "./git.js";
+
+const execFileAsync = promisify(execFile);
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+  return stdout.trim();
+}
+
+describe("worktree Git size estimates", () => {
+  const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllEnvs();
+  });
+
+  async function partialClone() {
+    const root = tempDirs.make("openclaw-partial-worktree-");
+    const source = path.join(root, "source");
+    const origin = path.join(root, "origin.git");
+    const clone = path.join(root, "clone");
+    await git(root, "init", "--template=", "-b", "main", source);
+    await git(source, "config", "user.name", "OpenClaw Test");
+    await git(source, "config", "user.email", "openclaw-test@example.invalid");
+    await git(source, "config", "commit.gpgSign", "false");
+    await fs.writeFile(path.join(source, "base.txt"), "base\n");
+    await git(source, "add", ".");
+    await git(source, "commit", "-m", "initial");
+    await git(root, "clone", "--bare", source, origin);
+    await git(origin, "config", "uploadpack.allowFilter", "true");
+    await git(origin, "config", "uploadpack.allowAnySHA1InWant", "true");
+    await git(root, "clone", "--filter=blob:none", pathToFileURL(origin).href, clone);
+    await fs.writeFile(path.join(source, "small.txt"), "small\n");
+    await fs.writeFile(path.join(source, "large.txt"), "x".repeat(5000));
+    await git(source, "add", ".");
+    await git(source, "commit", "-m", "add absent blobs");
+    await git(source, "push", origin, "main");
+    await git(clone, "fetch", "origin");
+    const commit = await git(clone, "rev-parse", "origin/main");
+    vi.stubEnv("GIT_NO_LAZY_FETCH", "1");
+    const missing = (
+      await git(
+        clone,
+        "rev-list",
+        "--objects",
+        "--missing=print",
+        "--no-object-names",
+        "--max-count=1",
+        commit,
+      )
+    )
+      .split("\n")
+      .filter((line) => line.startsWith("?"))
+      .map((line) => line.slice(1));
+    expect(missing).toHaveLength(2);
+    // The production executor inherits this guard, so old objectsize cannot hydrate the fixture.
+    await expect(runGit(clone, ["cat-file", "-e", missing[0]!])).resolves.toMatchObject({
+      code: 1,
+    });
+    return { clone, commit, missing };
+  }
+
+  it.each(["remote promisor", "partialclone extension"])(
+    "prefetches missing blobs once from the %s and skips fetching local objects",
+    async (remoteConfig) => {
+      const { clone, commit, missing } = await partialClone();
+      if (remoteConfig === "partialclone extension") {
+        await git(clone, "config", "extensions.partialclone", "origin");
+        await git(clone, "config", "--unset", "remote.origin.promisor");
+      }
+      const commandSpy = vi.spyOn(gitExec, "executeGitCommand");
+      await expect(estimateWorktreeGitBytes(clone, commit)).resolves.toBe(16_384);
+      const fetches = commandSpy.mock.calls.filter(([, args]) => args[0] === "fetch");
+      expect(fetches).toHaveLength(1);
+      expect(fetches[0]).toEqual([
+        clone,
+        [
+          "fetch",
+          "origin",
+          "--no-tags",
+          "--no-write-fetch-head",
+          "--recurse-submodules=no",
+          "--stdin",
+        ],
+        expect.objectContaining({ timeoutMs: 300_000, input: `${missing.join("\n")}\n` }),
+      ]);
+      expect(
+        commandSpy.mock.calls.find(([, args]) => args[0] === "ls-tree")?.[2]?.env,
+      ).toMatchObject({
+        GIT_NO_LAZY_FETCH: "1",
+      });
+      commandSpy.mockClear();
+      await expect(estimateWorktreeGitBytes(clone, commit)).resolves.toBe(16_384);
+      expect(commandSpy.mock.calls.filter(([, args]) => args[0] === "fetch")).toHaveLength(0);
+    },
+  );
+
+  it("explains missing objects when no promisor remote can repair the clone", async () => {
+    const { clone, commit } = await partialClone();
+    await git(clone, "config", "--unset", "remote.origin.promisor");
+    const commandSpy = vi.spyOn(gitExec, "executeGitCommand");
+    await expect(estimateWorktreeGitBytes(clone, commit)).rejects.toThrow(
+      `Repository is missing 2 objects for ${commit}; fetch or repair the clone.`,
+    );
+    expect(commandSpy.mock.calls.filter(([, args]) => args[0] === "fetch")).toHaveLength(0);
+  });
+});

--- a/src/agents/worktrees/capacity.ts
+++ b/src/agents/worktrees/capacity.ts
@@ -3,7 +3,8 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { formatDiskSpaceBytes, tryReadDiskSpace } from "../../infra/disk-space.js";
 import { isMissingPathError } from "../../infra/errors.js";
-import { requireGit } from "./git.js";
+import { requireGitCommandOutput } from "../../infra/git-exec.js";
+import { requireGit, runGit, WORKTREE_CHECKOUT_TIMEOUT_MS } from "./git.js";
 
 const GiB = 1024 ** 3;
 export const WORKTREE_SETUP_HEADROOM_BYTES = 4 * GiB;
@@ -53,6 +54,31 @@ export function requireWorktreeDiskSpace(
   }
 }
 
+async function missingCommitObjects(repoRoot: string, commit: string): Promise<string[]> {
+  const objects = await requireGit(
+    repoRoot,
+    ["rev-list", "--objects", "--missing=print", "--no-object-names", "--max-count=1", commit],
+    { env: { GIT_NO_LAZY_FETCH: "1" } },
+  );
+  return objects
+    .split("\n")
+    .filter((line) => line.startsWith("?"))
+    .map((line) => line.slice(1));
+}
+
+async function readOptionalGitConfig(repoRoot: string, args: string[]): Promise<string> {
+  const result = await runGit(repoRoot, ["config", ...args]);
+  return result.termination === "exit" && result.code === 1
+    ? ""
+    : requireGitCommandOutput(`git config ${args.join(" ")}`, result).trim();
+}
+
+function missingObjectsError(commit: string, count: number): Error {
+  return new Error(
+    `Repository is missing ${count} objects for ${commit}; fetch or repair the clone.`,
+  );
+}
+
 export async function estimateWorktreeGitBytes(repoRoot: string, ref: string): Promise<number> {
   const commit = await requireGit(repoRoot, [
     "rev-parse",
@@ -60,27 +86,56 @@ export async function estimateWorktreeGitBytes(repoRoot: string, ref: string): P
     "--end-of-options",
     `${ref === "-" ? "@{-1}" : ref}^{commit}`,
   ]);
-  const sizes = await requireGit(repoRoot, [
-    "ls-tree",
-    "-r",
-    "--format=%(objectsize)",
-    commit,
-    "--",
-  ]);
-  let bytes = 0;
-  for (const size of sizes.split("\n")) {
-    if (!size || size === "-") {
-      continue;
+  const missing = await missingCommitObjects(repoRoot, commit);
+  if (missing.length > 0) {
+    const remote =
+      (await readOptionalGitConfig(repoRoot, ["--get", "extensions.partialclone"])) ||
+      /^remote\.(.+)\.promisor true$/m.exec(
+        await readOptionalGitConfig(repoRoot, [
+          "--bool",
+          "--get-regexp",
+          "^remote\\..*\\.promisor$",
+        ]),
+      )?.[1];
+    if (!remote) {
+      throw missingObjectsError(commit, missing.length);
     }
-    const value = Number(size);
-    if (!Number.isSafeInteger(value) || value < 0) {
-      throw new Error(
-        "Cannot estimate worktree checkout size; inspect the repository objects and retry.",
-      );
-    }
-    bytes += Math.max(4096, Math.ceil(value / 4096) * 4096);
+    // Hydrate once under the checkout budget; objectsize must never fetch one blob at a time.
+    await requireGit(
+      repoRoot,
+      ["fetch", remote, "--no-tags", "--no-write-fetch-head", "--recurse-submodules=no", "--stdin"],
+      { input: `${missing.join("\n")}\n`, timeoutMs: WORKTREE_CHECKOUT_TIMEOUT_MS },
+    );
   }
-  return bytes;
+  try {
+    const sizes = await requireGit(
+      repoRoot,
+      ["ls-tree", "-r", "--format=%(objectsize)", commit, "--"],
+      {
+        env: { GIT_NO_LAZY_FETCH: "1" },
+      },
+    );
+    let bytes = 0;
+    for (const size of sizes.split("\n")) {
+      if (!size || size === "-") {
+        continue;
+      }
+      const value = Number(size);
+      if (!Number.isSafeInteger(value) || value < 0) {
+        throw new Error(
+          "Cannot estimate worktree checkout size; inspect the repository objects and retry.",
+        );
+      }
+      bytes += Math.max(4096, Math.ceil(value / 4096) * 4096);
+    }
+    return bytes;
+  } catch (error) {
+    const remaining = await missingCommitObjects(repoRoot, commit);
+    if (remaining.length > 0) {
+      throw missingObjectsError(commit, remaining.length);
+    }
+    throw error;
+  }
 }
 
 /** Measure without following links; unreadable trees must never be counted as empty. */

--- a/src/agents/worktrees/git.ts
+++ b/src/agents/worktrees/git.ts
@@ -15,6 +15,9 @@ import { mergeProcessEnv, resolveEnvironmentValue } from "../../infra/process-en
 
 export type GitResult = Awaited<ReturnType<typeof executeGitCommand>>;
 
+// Materializing checkout objects gets extra time without extending other Git commands or setup.
+export const WORKTREE_CHECKOUT_TIMEOUT_MS = 300_000;
+
 type WorktreeListEntry = {
   path: string;
   lockedReason?: string;

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -34,6 +34,7 @@ import {
   requireGit,
   requireGitBuffer,
   runGit,
+  WORKTREE_CHECKOUT_TIMEOUT_MS,
   type GitResult,
 } from "./git.js";
 import { worktreeOwnerMatches } from "./owner.js";
@@ -85,8 +86,6 @@ const NAME_PATTERN = /^[a-z0-9][a-z0-9-]{0,63}$/;
 const WORKTREE_CREATE_LEASE_SCOPE = "core:managed-worktrees:create";
 const WORKTREE_CREATE_LEASE_MS = 60_000;
 const WORKTREE_CREATE_LEASE_WAIT_MS = 5 * 60_000;
-// Materializing a checkout gets extra time without extending other Git commands or setup.
-const WORKTREE_CHECKOUT_TIMEOUT_MS = 300_000;
 
 /** Removal aborted because snapshot loss was not permitted. */
 export class WorktreeSnapshotError extends Error {

--- a/src/gateway/server-methods/chat-restart-recovery.ts
+++ b/src/gateway/server-methods/chat-restart-recovery.ts
@@ -28,14 +28,12 @@ import { findRestartRecoveryUnsafeChatAdmissionHook } from "../../plugins/restar
 import { isCronSessionKey, isSubagentSessionKey } from "../../routing/session-key.js";
 import { isAgentHarnessSessionKey } from "../../sessions/agent-harness-session-key.js";
 import { isAcpSessionKey, resolveSessionDispatchKind } from "../../sessions/session-key-utils.js";
+import { recordGatewaySessionRunFailure } from "../../sessions/session-run-error.js";
 import { sessionDeliveryChannel } from "../../utils/delivery-context.shared.js";
 import { parseInlineDirectives } from "../../utils/directive-tags.js";
 import { resolveChatRunOwnerAgentId } from "../chat-run-owner.js";
 import type { GatewayRecoveryRuntime } from "../server-instance-runtime.types.js";
-import {
-  deriveGatewaySessionLifecycleSnapshot,
-  recordGatewaySessionRunFailure,
-} from "../session-lifecycle-state.js";
+import { deriveGatewaySessionLifecycleSnapshot } from "../session-lifecycle-state.js";
 import { boundedWorkerError } from "../worker-environments/worker-error.js";
 import { resolveChatSendActiveScopeKey } from "./chat-origin-routing.js";
 import type { GatewayRequestContext } from "./types.js";

--- a/src/gateway/server-methods/chat-send-dispatch-errors.test.ts
+++ b/src/gateway/server-methods/chat-send-dispatch-errors.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import { SessionTranscriptProjectionUnavailableError } from "../../config/sessions/session-transcript-projection-error.js";
 import { onAgentRuntimeEvent } from "../../infra/agent-events.js";
+import * as sessionRunError from "../../sessions/session-run-error.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import { abortChatRunById, registerChatAbortController } from "../chat-abort.js";
 import { createChatRunState } from "../server-chat-state.js";
@@ -166,13 +167,13 @@ describe("createChatSendDispatchErrorLifecycle", () => {
         });
 
         await lifecycle.handleError(new Error("Cloud worker unavailable"));
+        expect(previewGroup?.signal.aborted).toBe(false);
+        await lifecycle.finalize();
         expect(broadcast).toHaveBeenLastCalledWith(
           "chat",
           expect.objectContaining({ state: "error" }),
           expect.objectContaining({ liveText: { group: previewGroup?.signal } }),
         );
-        expect(previewGroup?.signal.aborted).toBe(false);
-        await lifecycle.finalize();
         expect(chatRunState.runs.has(runId)).toBe(false);
         expect(previewGroup?.signal.aborted).toBe(true);
 
@@ -227,7 +228,7 @@ describe("createChatSendDispatchErrorLifecycle", () => {
         restartRecoveryDeliveryRunId: "settled-run",
       });
       const report = vi
-        .spyOn(sessionLifecycleState, "recordGatewaySessionRunFailure")
+        .spyOn(sessionRunError, "recordGatewaySessionRunFailure")
         .mockRejectedValueOnce(new Error("notice write failed"));
       try {
         expect(
@@ -464,6 +465,7 @@ describe("createChatSendDispatchErrorLifecycle", () => {
     });
 
     await lifecycle.handleError(new Error("dispatch rejected after restart"));
+    await lifecycle.finalize();
 
     expect(dedupe.get("chat:signal-only-dispatch-rejection")).toMatchObject({
       ok: false,
@@ -564,6 +566,8 @@ describe("createChatSendDispatchErrorLifecycle", () => {
       });
     const cleanupAdmittedRun = vi.fn();
     const activeRunCleanup = vi.fn();
+    const broadcast = vi.fn();
+    const dedupe = new Map();
     const clientRunId = "failed-ops-global-send";
     const chatAbortControllers = new Map([
       [
@@ -591,11 +595,11 @@ describe("createChatSendDispatchErrorLifecycle", () => {
         },
         context: {
           agentRunSeq: new Map(),
-          broadcast: vi.fn(),
+          broadcast,
           broadcastToConnIds: vi.fn(),
           chatAbortControllers,
           chatRunState: createChatRunState(),
-          dedupe: new Map(),
+          dedupe,
           getRuntimeConfig: () => cfg,
           getSessionEventSubscriberConnIds: () => new Set<string>(),
           logGateway: { warn: vi.fn() },
@@ -621,6 +625,8 @@ describe("createChatSendDispatchErrorLifecycle", () => {
       await lifecycle.handleError(new Error("dispatch rejected"));
       const finalization = lifecycle.finalize();
       await persistenceEntered.promise;
+      expect(dedupe.get(`chat:${clientRunId}`)).toBeUndefined();
+      expect(broadcast).not.toHaveBeenCalled();
       expect(persistLifecycleEvent).toHaveBeenCalledWith({
         sessionKey: "global",
         agentId: "ops",
@@ -633,6 +639,15 @@ describe("createChatSendDispatchErrorLifecycle", () => {
       expect(cleanupAdmittedRun).not.toHaveBeenCalled();
       releasePersistence.resolve();
       await finalization;
+      expect(dedupe.get(`chat:${clientRunId}`)).toMatchObject({
+        ok: false,
+        payload: { runId: clientRunId, status: "error" },
+      });
+      expect(broadcast).toHaveBeenCalledWith(
+        "chat",
+        expect.objectContaining({ runId: clientRunId, state: "error" }),
+        expect.anything(),
+      );
       expect(activeRunCleanup).toHaveBeenCalledExactlyOnceWith();
       expect(cleanupAdmittedRun).toHaveBeenCalledOnce();
     } finally {

--- a/src/gateway/server-methods/chat-send-dispatch-errors.ts
+++ b/src/gateway/server-methods/chat-send-dispatch-errors.ts
@@ -131,6 +131,7 @@ export function createChatSendDispatchErrorLifecycle(params: {
   const { agentId, backingSessionId, cfg, clientRunId, now, rawSessionKey, sessionKey } = session;
   let pendingDispatchLifecycleError: PendingDispatchLifecycleError | undefined;
   let persistDispatchErrorUserTurn: (() => Promise<void>) | undefined;
+  let publishDispatchError: (() => void) | undefined;
 
   const handleError = async (err: unknown) => {
     const errorMessage = String(err);
@@ -259,28 +260,37 @@ export function createChatSendDispatchErrorLifecycle(params: {
     if (!agentTerminalPersistenceOwnedAtDispatchReject || params.isReplyDispatchRun?.()) {
       // Native lifecycle owns its replay result; dispatched runtimes leave
       // failure projection to this owner, including transcript-write failures.
-      const error = errorShape(ErrorCodes.UNAVAILABLE, errorMessage);
-      setGatewayDedupeEntry({
-        dedupe: context.dedupe,
-        key: `chat:${clientRunId}`,
-        entry: {
-          ts: Date.now(),
-          ok: false,
-          payload: {
-            runId: clientRunId,
-            status: "error" as const,
-            summary: errorMessage,
+      const publish = () => {
+        const error = errorShape(ErrorCodes.UNAVAILABLE, errorMessage);
+        setGatewayDedupeEntry({
+          dedupe: context.dedupe,
+          key: `chat:${clientRunId}`,
+          entry: {
+            ts: Date.now(),
+            ok: false,
+            payload: {
+              runId: clientRunId,
+              status: "error" as const,
+              summary: errorMessage,
+            },
+            error,
           },
-          error,
-        },
-      });
-      broadcastChatError({
-        context,
-        runId: clientRunId,
-        sessionKey,
-        agentId,
-        errorMessage,
-      });
+        });
+        broadcastChatError({
+          context,
+          runId: clientRunId,
+          sessionKey,
+          agentId,
+          errorMessage,
+        });
+      };
+      if (pendingDispatchLifecycleError) {
+        // agent.wait consumes the cached terminal immediately. Commit the lifecycle
+        // first so registry completion cannot race it with a later start timestamp.
+        publishDispatchError = publish;
+      } else {
+        publish();
+      }
     }
   };
 
@@ -288,11 +298,14 @@ export function createChatSendDispatchErrorLifecycle(params: {
     const dispatchError = pendingDispatchLifecycleError;
     // Commands and reply-dispatch runtimes have already published their terminal.
     // Native agent events keep ownership until their own terminal delivery completes.
-    if (!params.isAgentRunStarted() || params.isReplyDispatchRun?.()) {
-      context.chatRunState.clearRun(clientRunId);
-      context.agentRunSeq.delete(clientRunId);
-    }
+    const clearRun = () => {
+      if (!params.isAgentRunStarted() || params.isReplyDispatchRun?.()) {
+        context.chatRunState.clearRun(clientRunId);
+        context.agentRunSeq.delete(clientRunId);
+      }
+    };
     if (!dispatchError) {
+      clearRun();
       cleanupAdmittedRun();
       // Reply-dispatch lifecycle events deliberately retain these until delivery settles.
       clearAgentRunContext(clientRunId, lifecycleGeneration);
@@ -351,7 +364,12 @@ export function createChatSendDispatchErrorLifecycle(params: {
         `webchat session lifecycle continuation failed: ${formatForLog(continuationErr)}`,
       );
     } finally {
-      cleanupAdmittedRun();
+      try {
+        publishDispatchError?.();
+      } finally {
+        clearRun();
+        cleanupAdmittedRun();
+      }
     }
   };
 

--- a/src/gateway/server.chat.gateway-server-chat.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat.test.ts
@@ -1302,7 +1302,6 @@ describe("gateway server chat", () => {
           });
           markGatewayRestartDraining();
           rejectDispatch.resolve();
-          await errorPromise;
           await persistenceEntered.promise;
           const restartInspectors = {
             getQueueSize: () => 0,
@@ -1318,6 +1317,7 @@ describe("gateway server chat", () => {
             counts: { rootRequests: 1 },
           });
           releasePersistence.resolve();
+          await errorPromise;
           const changed = await sessionChangedPromise;
           await waitForFast(() => {
             expect(createSafeGatewayRestartPreflight(restartInspectors).safe).toBe(true);

--- a/src/gateway/server.sessions.create-worktree-spawn.test.ts
+++ b/src/gateway/server.sessions.create-worktree-spawn.test.ts
@@ -2,10 +2,16 @@ import { execFile } from "node:child_process";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { promisify } from "node:util";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, beforeEach, expect, test, vi } from "vitest";
 import { ErrorCodes, errorShape } from "../../packages/gateway-protocol/src/index.js";
+import { persistSubagentSessionTiming } from "../agents/subagents/registry/subagent-registry-helpers.js";
 import { managedWorktrees } from "../agents/worktrees/service.js";
-import { loadSessionEntry, replaceSessionEntrySync } from "../config/sessions/session-accessor.js";
+import {
+  loadSessionEntry,
+  loadTranscriptEvents,
+  replaceSessionEntrySync,
+} from "../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import { onAgentEvent } from "../infra/agent-events.js";
 import { withTimeout } from "../infra/fs-safe.js";
@@ -14,6 +20,7 @@ import {
   getSessionWorkAdmissionRelease,
   SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS,
 } from "../sessions/session-lifecycle-admission.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../utils/message-channel.js";
@@ -279,6 +286,131 @@ test("trusted worktree spawns roll back when the parent changes during preparati
   await expect(createChild({ key })).rejects.toThrow("Spawn parent managed worktree changed");
   expect(managedWorktrees.findLiveByOwner("session", key)).toBeUndefined();
   expect(loadSessionEntry({ agentId: "main", sessionKey: key, storePath })).toBeUndefined();
+});
+
+test("publishes a failed worktree spawn only after its durable session failure", async () => {
+  const key = "agent:main:dashboard:failed-worktree-child";
+  const target = { agentId: "main", sessionKey: key, storePath };
+  const preparation = createDeferredCore<never>();
+  const createWorktree = vi
+    .spyOn(managedWorktrees, "create")
+    .mockReturnValueOnce(preparation.promise);
+  const failure = new Error(
+    "git ls-tree -r --format=%(objectsize) c79ad267ba623c1a323f1f6e8b60228bd5a30ce5 -- failed (timed out after 120 seconds; signal SIGTERM):\n4514\n4168\nCheck repository access and disk space.",
+  );
+  let registryStartedAt = 0;
+  let publishedEntry: SessionEntry | undefined;
+  let registryProjection: Promise<void> | undefined;
+  const context = {
+    chatAbortControllers: new Map<string, ChatAbortControllerEntry>(),
+    dedupe: new Map(),
+    broadcast: vi.fn((event: string, payload: unknown) => {
+      if (
+        event !== "chat" ||
+        !isRecord(payload) ||
+        payload.state !== "error" ||
+        typeof payload.runId !== "string"
+      ) {
+        return;
+      }
+      publishedEntry = loadSessionEntry(target);
+      // The completion waiter observes the terminal after the spawn ACK registered
+      // its own later start time. Exercise the real registry projection as it settles.
+      registryProjection = persistSubagentSessionTiming({
+        runId: payload.runId,
+        childSessionKey: key,
+        requesterSessionKey: parentKey,
+        requesterDisplayKey: parentKey,
+        task: "Read README.md",
+        cleanup: "keep",
+        createdAt: registryStartedAt,
+        sessionStartedAt: registryStartedAt,
+        execution: {
+          status: "terminal",
+          startedAt: registryStartedAt,
+          endedAt: Date.now(),
+          outcome: { status: "error", error: String(failure) },
+        },
+        completion: { required: false },
+        delivery: { status: "not_required" },
+        endedReason: "subagent-error",
+      });
+    }),
+  };
+  const client = spawnClient();
+  const created = await directSessionReq<{
+    key: string;
+    sessionId: string;
+    runId: string;
+    runStarted: boolean;
+  }>(
+    "sessions.create",
+    {
+      key,
+      agentId: "main",
+      label: "Failed worktree child",
+      parentSessionKey: parentKey,
+      spawnDepth: 1,
+      worktree: true,
+      worktreeName: "failed-child",
+      task: "Read README.md",
+    },
+    {
+      client: {
+        ...client,
+        connect: {
+          ...client.connect,
+          minProtocol: 1,
+          maxProtocol: 1,
+          client: {
+            id: GATEWAY_CLIENT_NAMES.GATEWAY_CLIENT,
+            version: "test",
+            platform: "node",
+            mode: GATEWAY_CLIENT_MODES.BACKEND,
+          },
+        },
+      },
+      context,
+    },
+  );
+  expect(created.ok, JSON.stringify(created.error)).toBe(true);
+  expect(created.payload?.runStarted).toBe(true);
+  const { runId, sessionId } = created.payload!;
+  const admittedRun = context.chatAbortControllers.get(runId)!;
+  registryStartedAt = Math.max(Date.now(), admittedRun.startedAtMs + 1);
+  const released = getSessionWorkAdmissionRelease({ scope: storePath, identities: [key] });
+  expect(released).toBeDefined();
+  expect(loadSessionEntry(target)?.pendingWorktree?.workspace).toBe(repository);
+  await vi.waitFor(() => expect(createWorktree).toHaveBeenCalledOnce());
+  preparation.reject(failure);
+  await withTimeout(released!, SESSION_WORK_ADMISSION_DRAIN_TIMEOUT_MS, "failed workspace proof");
+  await registryProjection;
+
+  expect.soft(publishedEntry).toMatchObject({
+    sessionId,
+    status: "failed",
+    lastRunId: runId,
+    lastRunError: expect.stringContaining("git ls-tree"),
+  });
+  expect.soft(loadSessionEntry(target)).toMatchObject({
+    status: "failed",
+    lastRunId: runId,
+    lastRunError: expect.stringContaining("timed out after 120 seconds"),
+  });
+  expect(dispatchInboundMessageMock).not.toHaveBeenCalled();
+  const notices = (await loadTranscriptEvents({ ...target, sessionId })).filter(
+    (event) => isRecord(event) && event.customType === "run-failed-before-reply",
+  );
+  expect(notices).toMatchObject([
+    { details: { runId, error: expect.stringContaining("git ls-tree") }, display: true },
+  ]);
+  const listed = await directSessionReq<{
+    sessions: Array<{ key: string; lastRunError?: string }>;
+  }>("sessions.list", { agentId: "main" }, adminRequest);
+  expect(listed.ok, JSON.stringify(listed.error)).toBe(true);
+  expect(listed.payload?.sessions.find((row) => row.key === key)).toMatchObject({
+    lastRunError: expect.stringContaining("git ls-tree"),
+  });
 });
 
 test.each(["archive", "replace", "rebind", "stale-child"] as const)(

--- a/src/gateway/session-lifecycle-state.ts
+++ b/src/gateway/session-lifecycle-state.ts
@@ -1,6 +1,4 @@
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString as normalizeLifecycleRunId } from "@openclaw/normalization-core/string-coerce";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import type { SessionRunStatus } from "../../packages/gateway-protocol/src/schema/sessions-row.js";
 import { isAgentLifecycleYieldedWaiting } from "../agents/agent-lifecycle-parent-state.js";
 import {
@@ -8,23 +6,21 @@ import {
   classifyAgentRunTerminalOutcome,
   type AgentRunTerminalOutcome,
 } from "../agents/agent-run-terminal-outcome.js";
-import { renderUserFacingText } from "../agents/embedded-agent-helpers/user-facing-text.js";
 import {
   isMainSessionRecoveryLifecycleEvent,
   projectMainSessionRecoveryLifecycle,
 } from "../agents/main-session-recovery/main-session-recovery-lifecycle.js";
 import type { InternalSessionEntry as SessionEntry } from "../config/sessions.js";
-import {
-  appendSessionTranscriptReport,
-  patchSessionEntryCore,
-  type SessionTranscriptWriteScope,
-} from "../config/sessions/session-accessor.js";
+import { patchSessionEntryCore } from "../config/sessions/session-accessor.js";
 import { getAgentEventLifecycleGeneration, type AgentEventPayload } from "../infra/agent-events.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { parseCronRunScopeSuffix } from "../sessions/session-key-utils.js";
+import {
+  recordGatewaySessionRunFailure,
+  resolveSessionRunError,
+} from "../sessions/session-run-error.js";
 import { loadSessionEntry } from "./session-utils.js";
 import type { GatewaySessionRow } from "./session-utils.types.js";
-import { boundedWorkerError } from "./worker-environments/worker-error.js";
 
 const restartRecoveryLog = createSubsystemLogger("main-session-restart-recovery");
 
@@ -81,9 +77,6 @@ type PersistedLifecycleSessionShape = Pick<
 
 type GatewaySessionLifecycleSnapshot = Partial<Pick<SessionEntry, keyof LifecycleSessionShape>>;
 
-const SESSION_RUN_ERROR_MAX_CHARS = 160;
-const RUN_FAILED_BEFORE_REPLY_TRANSCRIPT_TYPE = "run-failed-before-reply";
-
 function isFiniteTimestamp(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
 }
@@ -128,52 +121,6 @@ function resolveSettledLifecycleTerminalOutcome(
   })
     ? undefined
     : outcome;
-}
-
-function sanitizeSessionRunError(error: unknown): string {
-  return renderUserFacingText(error, { errorContext: true }).replace(/\s+/g, " ").trim();
-}
-
-/** Shared transcript outcome for owners that already committed a failed run. */
-export async function recordGatewaySessionRunFailure(params: {
-  target: SessionTranscriptWriteScope & { sessionId: string };
-  runId: string;
-  error: unknown;
-  assertCommitAllowed?: () => void;
-}): Promise<void> {
-  const { runId } = params;
-  const error = boundedWorkerError(sanitizeSessionRunError(params.error), 512);
-  const result = await appendSessionTranscriptReport(params.target, {
-    kind: "custom",
-    customTypes: [RUN_FAILED_BEFORE_REPLY_TRANSCRIPT_TYPE],
-    suppressWhenAssistantRun: runId,
-    selectReport: (latest) => {
-      params.assertCommitAllowed?.();
-      if (isRecord(latest?.details) && latest.details.runId === runId) {
-        return undefined;
-      }
-      return {
-        customType: RUN_FAILED_BEFORE_REPLY_TRANSCRIPT_TYPE,
-        content: `This turn did not run: ${error}.`,
-        display: true,
-        details: { runId, error },
-      };
-    },
-  });
-  if (!result.ok) {
-    throw new Error(`Failed run notice could not be appended: ${result.error.code}`);
-  }
-}
-
-function resolveSessionRunError(
-  outcome: AgentRunTerminalOutcome,
-  status: SessionRunStatus,
-): string | undefined {
-  if ((status !== "failed" && status !== "timeout") || !outcome.error) {
-    return undefined;
-  }
-  const sanitized = sanitizeSessionRunError(outcome.error);
-  return sanitized ? truncateUtf16Safe(sanitized, SESSION_RUN_ERROR_MAX_CHARS) : undefined;
 }
 
 function resolveLifecycleStartedAt(

--- a/src/infra/git-exec.test.ts
+++ b/src/infra/git-exec.test.ts
@@ -77,7 +77,11 @@ it.each([
   const args = ["worktree", "add"];
   const result = await executeGitCommand("/repo", args, { timeoutMs });
   const label = `timed out after ${seconds} seconds`;
-  expect(createGitCommandError("git worktree add", result).message).toContain(label);
+  const message = createGitCommandError("git worktree add", result).message;
+  expect(message).toContain(label);
+  expect(message).toContain(
+    `Git did not finish within its ${seconds}s budget; check remote reachability, repository locks, and clone shape (partial clones fetch missing objects lazily).`,
+  );
   await expect(requireGitCommand("/repo", args, { timeoutMs })).rejects.toThrow(label);
   expect(
     commandSpy.mock.calls.map(([, options]) =>
@@ -190,7 +194,9 @@ describe.each([
       expect(message.length).toBeLessThan(400);
       expect(message).toContain("Updating files: 999/1000");
       if (metadata.termination === "timeout") {
-        expect(message).toContain("Check repository access and disk space.");
+        expect(message).toContain(
+          "Git did not finish within its 120s budget; check remote reachability, repository locks, and clone shape (partial clones fetch missing objects lazily).",
+        );
       } else {
         expect(message).not.toMatch(/timed out|timeout/i);
       }

--- a/src/infra/git-exec.ts
+++ b/src/infra/git-exec.ts
@@ -75,11 +75,12 @@ export function createGitCommandError(
   result: (SpawnResult | Awaited<ReturnType<typeof runCommandBuffered>>) & { timeoutMs?: number },
 ): Error {
   // Buffered Git uses the fixed default; text results carry their applied budget.
+  const timeoutMs = result.timeoutMs ?? GIT_TIMEOUT_MS;
   const error = createCommandError(command, result, {
-    timeoutMs: result.timeoutMs ?? GIT_TIMEOUT_MS,
+    timeoutMs,
   });
   if (result.termination === "timeout") {
-    error.message += "\nCheck repository access and disk space.";
+    error.message += `\nGit did not finish within its ${timeoutMs / 1000}s budget; check remote reachability, repository locks, and clone shape (partial clones fetch missing objects lazily).`;
   }
   return error;
 }

--- a/src/process/command-error.ts
+++ b/src/process/command-error.ts
@@ -4,6 +4,22 @@ import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text
 import type { SpawnResult } from "./exec-result.js";
 import type { runCommandBuffered } from "./exec.js";
 
+const COMMAND_ERROR_NAME = "CommandExecutionError";
+// Older serialized failures have no marker; recognize their explicit termination header.
+const COMMAND_ERROR_HEADER_RE =
+  /^(?:Error:\s*)?.+ failed \((?:timed out after [\d.]+ seconds|timed out waiting for output|output limit exceeded|exit code -?\d+|terminated|signal SIG[A-Z0-9]+)(?:; signal SIG[A-Z0-9]+)?\):?$/u;
+
+export function formatCommandErrorForUser(text: string): string | undefined {
+  const lines = text.trim().split(/\r?\n/u);
+  const header = lines[0] ?? "";
+  if (!header.startsWith(`${COMMAND_ERROR_NAME}: `) && !COMMAND_ERROR_HEADER_RE.test(header)) {
+    return undefined;
+  }
+  const tail = lines.length > 1 ? lines.at(-1)?.trim() : undefined;
+  const summary = [header, tail].filter(Boolean).join(" ").replace(/\s+/gu, " ").trim();
+  return summary.length > 500 ? `${truncateUtf16Safe(summary, 497)}...` : summary;
+}
+
 export function formatCommandOutput(output: string | Buffer, maxChars = 800): string {
   // CR redraws replace the current frame; trim before making edge tabs visible.
   // Anchor each CR run/frame so unmatched runs do not repeatedly scan their suffixes.
@@ -63,5 +79,9 @@ export function createCommandError(
   }[result.termination];
   const reason = [primary, signal].filter(Boolean).join("; ");
   const label = truncateUtf16Safe(stripAnsi(command).replace(/[\r\n]+/g, " "), 256);
-  return new Error(`${label} failed${reason ? ` (${reason})` : ""}${detail ? `:\n${detail}` : ""}`);
+  const error = new Error(
+    `${label} failed${reason ? ` (${reason})` : ""}${detail ? `:\n${detail}` : ""}`,
+  );
+  error.name = COMMAND_ERROR_NAME;
+  return error;
 }

--- a/src/sessions/session-run-error.ts
+++ b/src/sessions/session-run-error.ts
@@ -1,0 +1,62 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { SessionRunStatus } from "../../packages/gateway-protocol/src/schema/sessions-row.js";
+import { renderUserFacingText } from "../agents/embedded-agent-helpers/user-facing-text.js";
+import {
+  appendSessionTranscriptReport,
+  type SessionTranscriptWriteScope,
+} from "../config/sessions/session-accessor.js";
+import { redactSensitiveText } from "../logging/redact.js";
+
+const SESSION_RUN_ERROR_MAX_CHARS = 160;
+const RUN_FAILED_BEFORE_REPLY_TRANSCRIPT_TYPE = "run-failed-before-reply";
+
+function sanitizeSessionRunError(error: unknown, maxChars: number): string {
+  const text = renderUserFacingText(error, { errorContext: true }).replace(/\s+/g, " ").trim();
+  return truncateUtf16Safe(redactSensitiveText(text, { mode: "tools" }), maxChars);
+}
+
+/** Shared transcript outcome for owners that already committed a failed run. */
+export async function recordGatewaySessionRunFailure(params: {
+  target: SessionTranscriptWriteScope & { sessionId: string };
+  runId: string;
+  error: unknown;
+  assertCommitAllowed?: () => void;
+}): Promise<void> {
+  const { runId } = params;
+  const error = sanitizeSessionRunError(params.error, 512) || "unknown error";
+  const result = await appendSessionTranscriptReport(params.target, {
+    kind: "custom",
+    customTypes: [RUN_FAILED_BEFORE_REPLY_TRANSCRIPT_TYPE],
+    suppressWhenAssistantRun: runId,
+    selectReport: (latest) => {
+      params.assertCommitAllowed?.();
+      if (isRecord(latest?.details) && latest.details.runId === runId) {
+        return undefined;
+      }
+      return {
+        customType: RUN_FAILED_BEFORE_REPLY_TRANSCRIPT_TYPE,
+        content: `This turn did not run: ${error}.`,
+        display: true,
+        details: { runId, error },
+      };
+    },
+  });
+  if (!result.ok) {
+    throw new Error(`Failed run notice could not be appended: ${result.error.code}`);
+  }
+}
+
+export function resolveSessionRunError(
+  outcome: { error?: string },
+  status: SessionRunStatus,
+): string | undefined {
+  if (
+    (status !== "failed" && status !== "timeout") ||
+    typeof outcome.error !== "string" ||
+    !outcome.error.trim()
+  ) {
+    return undefined;
+  }
+  return sanitizeSessionRunError(outcome.error, SESSION_RUN_ERROR_MAX_CHARS) || undefined;
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a spawned child session whose managed worktree could not be prepared would show only a warning glyph in the Control UI sidebar, with "Unknown error" on hover, an empty chat pane, and no trace of the failure in its transcript. The actual reason lived only in the subagent run record. On a blobless partial clone the preparation itself failed because the disk-space size estimate fetched every missing blob one network round trip at a time until the two-minute Git budget expired, and its hint blamed disk space.

## Why This Change Was Made

Failed and timed-out child runs now project their bounded reason into the session entry and append the same per-run "This turn did not run" transcript notice the gateway already uses, through one shared session-layer formatter. The chat.send dispatch-error owner now publishes its fallback terminal only after its lifecycle write settles, because publishing first let the registry record a later start time and the gateway rejected its own failure as stale. Command-execution errors keep their command and termination reason instead of being rendered as provider timeouts. The worktree size estimate inventories missing objects without lazy fetching, hydrates them from the promisor remote in one batch under the checkout budget, and forbids per-object lazy fetches during sizing. The Git timeout hint reports the applied budget and points to reachability, locks, and clone shape. Non-goals: no UI changes (the UI already renders `lastRunError`), no changes to provider failover classification, no schema or config changes.

## User Impact

Operators see why a child session failed before its first reply: the sidebar warning carries the reason, the chat pane shows the error, and the transcript keeps a durable notice. A Git setup timeout now reads as a Git timeout with the failed command, not "LLM request timed out." Worktree creation from partial clones no longer stalls on per-blob fetches.

## Evidence

Production incident (team Gateway, 2026-09-07): child session failed after 123 s in `git ls-tree -r --format=%(objectsize)` on a shallow blobless clone; entry had `status: failed` and no `lastRunError`; measured lazy fetch cost ~0.3 s per missing blob, 0.7 s for the full inventory once objects are local.

Regression tests, each shown to fail on the pre-fix code for the intended reason:
- `src/agents/worktrees/capacity.test.ts`: real `--filter=blob:none` clone, one batch prefetch, no fetch when nothing is missing, actionable no-promisor error, `GIT_NO_LAZY_FETCH=1` on the inventory.
- `src/agents/subagents/registry/subagent-registry.session-failure.test.ts`: bounded error/timeout reasons, exactly one durable notice, success clears the reason.
- `src/gateway/server.sessions.create-worktree-spawn.test.ts`: real spawn path with a rejected worktree creation and the real registry projection; asserts entry, notice, and `sessions.list` exposure.
- `src/gateway/server-methods/chat-send-dispatch-errors.test.ts`: terminal publication waits for lifecycle persistence.
- `src/agents/embedded-agent-helpers.sanitizeuserfacingtext.test.ts`, `src/infra/git-exec.test.ts`: faithful command-error rendering; new timeout hint.

`node scripts/check-changed.mjs` passed (0 runtime import cycles); focused suites: 442 passed, 1 pre-existing Windows-only skip. Codex-backed autoreview at P1 run before landing.

## Known Gaps

The shallow-boundary `rev-parse <ref>^` during snapshot restore is unchanged. Windows execution was not exercised natively.
