### PR TITLE
refactor(ui): share worktree action completion

### DIFF
--- a/ui/src/pages/worktrees/worktrees-page.ts
+++ b/ui/src/pages/worktrees/worktrees-page.ts
@@ -24,6 +24,7 @@ import { renderSettingsWorkspace } from "../../components/settings-workspace.ts"
 import { t } from "../../i18n/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { formatRelativeTimestamp } from "../../lib/format.ts";
+import type { GatewayConnectionScope } from "../../lib/gateway-connection-lifecycle.ts";
 import { shouldHandleNavigationClick } from "../../lib/navigation-click.ts";
 import { repoName } from "../../lib/session-display.ts";
 import {
@@ -160,6 +161,22 @@ class WorktreesPage extends OpenClawLightDomElement {
     await this.listTask.run([client]);
   }
 
+  private async runOperation(scope: GatewayConnectionScope, action: () => Promise<unknown>) {
+    this.error = null;
+    try {
+      await action();
+    } catch (error) {
+      if (this.gateway.isCurrent(scope)) {
+        this.error = formatUiError(error);
+      }
+    } finally {
+      if (this.gateway.isCurrent(scope)) {
+        this.invalidateOperations();
+        await this.load({ preserveError: true });
+      }
+    }
+  }
+
   private async removeWorktree(record: WorktreeRecord) {
     const scope = this.gateway.capture();
     if (!scope || !this.canAdmin || this.operationPending) {
@@ -180,8 +197,7 @@ class WorktreesPage extends OpenClawLightDomElement {
     // Both attempts belong to one Gateway epoch. A force retry must never jump
     // to a replacement client after the first request reports snapshot failure.
     this.busyId = record.id;
-    this.error = null;
-    try {
+    await this.runOperation(scope, async () => {
       const result = await scope.client.request<WorktreesRemoveResult>("worktrees.remove", {
         id: record.id,
       });
@@ -201,29 +217,14 @@ class WorktreesPage extends OpenClawLightDomElement {
         this.error = reason || null;
         return;
       }
-      try {
-        const forced = await scope.client.request<WorktreesRemoveResult>("worktrees.remove", {
-          id: record.id,
-          force: true,
-        });
-        if (this.gateway.isCurrent(scope)) {
-          this.error = forced.snapshotError ?? null;
-        }
-      } catch (forceError) {
-        if (this.gateway.isCurrent(scope)) {
-          this.error = formatUiError(forceError);
-        }
-      }
-    } catch (error) {
+      const forced = await scope.client.request<WorktreesRemoveResult>("worktrees.remove", {
+        id: record.id,
+        force: true,
+      });
       if (this.gateway.isCurrent(scope)) {
-        this.error = formatUiError(error);
+        this.error = forced.snapshotError ?? null;
       }
-    } finally {
-      if (this.gateway.isCurrent(scope)) {
-        this.busyId = null;
-        await this.load({ preserveError: true });
-      }
-    }
+    });
   }
 
   private async restore(record: WorktreeRecord) {
@@ -232,19 +233,9 @@ class WorktreesPage extends OpenClawLightDomElement {
       return;
     }
     this.busyId = record.id;
-    this.error = null;
-    try {
-      await scope.client.request("worktrees.restore", { id: record.id });
-    } catch (error) {
-      if (this.gateway.isCurrent(scope)) {
-        this.error = formatUiError(error);
-      }
-    } finally {
-      if (this.gateway.isCurrent(scope)) {
-        this.busyId = null;
-        await this.load({ preserveError: true });
-      }
-    }
+    await this.runOperation(scope, () =>
+      scope.client.request("worktrees.restore", { id: record.id }),
+    );
   }
 
   private async gc() {
@@ -253,19 +244,7 @@ class WorktreesPage extends OpenClawLightDomElement {
       return;
     }
     this.gcLoading = true;
-    this.error = null;
-    try {
-      await scope.client.request("worktrees.gc", {});
-    } catch (error) {
-      if (this.gateway.isCurrent(scope)) {
-        this.error = formatUiError(error);
-      }
-    } finally {
-      if (this.gateway.isCurrent(scope)) {
-        this.gcLoading = false;
-        await this.load({ preserveError: true });
-      }
-    }
+    await this.runOperation(scope, () => scope.client.request("worktrees.gc", {}));
   }
 
   private toggleCreate() {
@@ -299,8 +278,7 @@ class WorktreesPage extends OpenClawLightDomElement {
       return;
     }
     this.creating = true;
-    this.error = null;
-    try {
+    await this.runOperation(scope, async () => {
       await createManagedWorktree(scope.client, {
         repoRoot,
         name: this.createName,
@@ -310,16 +288,7 @@ class WorktreesPage extends OpenClawLightDomElement {
         this.createOpen = false;
         this.createName = "";
       }
-    } catch (error) {
-      if (this.gateway.isCurrent(scope)) {
-        this.error = formatUiError(error);
-      }
-    } finally {
-      if (this.gateway.isCurrent(scope)) {
-        this.creating = false;
-        await this.load({ preserveError: true });
-      }
-    }
+    });
   }
 
   private renderOwner(record: WorktreeRecord) {


### PR DESCRIPTION
Closes #141505

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

The Worktrees page repeats operation completion handling across remove, restore, garbage collection and create. This maintainer-requested cleanup gives that shared lifecycle one owner so future changes stay consistent.

## Why This Change Was Made

A private helper clears the previous error, handles errors from the current Gateway connection, releases the serialized busy state, and refreshes the list while preserving mutation errors. Action admission, both deletion confirmations, client ownership and action-specific request data remain in their existing owners.

## User Impact

Existing behavior is preserved, including restore failure feedback after successful reconciliation and protection against stale completions after reconnect. Production code shrinks by 31 lines. Rendering, tests and public contracts are unchanged.

## Evidence

- The existing 20-test Worktrees suite passes on both the original and final source.
- The full selected changed gate and independent P2 review pass.
- An isolated mocked Chromium flow exercises restore failure/reconciliation, pending create, garbage collection and forced deletion; four before/after image pairs are byte-identical.
- The attached synthetic restore-error pair demonstrates preserved error feedback, not a visual change. No live Gateway or performance claim is made.

![Before: preserved restore error after list reconciliation (synthetic)](https://github.com/user-attachments/assets/bd28f842-ad5d-4ce7-be9d-2524bf8a3955)

![After: preserved restore error after list reconciliation (synthetic)](https://github.com/user-attachments/assets/db46d01b-3f7c-4e41-b42b-222124a577c7)
Maintainer validation scope: this maintainer-authored PR changes only the page-local completion flow. Gateway handlers, RPC parameters, authorization and stores are unchanged. The 20 existing page tests cover serialization, reconnect ownership, permission loss during confirmation and completion/error state. The real Worktrees element was also exercised in Chromium with mocked Gateway responses for restore failure/reconciliation, pending create, garbage collection and forced deletion. This is the accepted changed-boundary proof for the behavior-preserving extraction. No real Gateway run is claimed; the external-contributor proof requirement does not apply to this maintainer-authored scope.
