### PR TITLE
fix(sessions): retain SQLite write failure details in logs

### DIFF
--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -51,6 +51,13 @@ openclaw logs --follow
 - Embedded-run `continue_normal` decisions log at `debug`; retry, profile-rotation, model-fallback, and error decisions remain warnings.
 - Trace logging also includes diagnostic timing summaries for selected hot paths, such as plugin tool factory preparation. See [/tools/plugin#slow-plugin-tool-setup](/tools/plugin#slow-plugin-tool-setup).
 
+### SQLite session writes
+
+Failed SQLite session writes include a bounded, redacted `error` summary in
+their structured file-log record, with cause and error-code details when
+available. Long summaries are truncated; the record retains its write timing
+and store fields.
+
 ### Slow cron list pages
 
 A cron list page taking at least one second emits `cron: slow list page` through

--- a/src/config/sessions/session-accessor.sqlite-scope.test.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.test.ts
@@ -1,6 +1,9 @@
+import assert from "node:assert/strict";
 import { AsyncLocalStorage } from "node:async_hooks";
+import fs from "node:fs/promises";
 import { performance } from "node:perf_hooks";
-import { isMainThread, threadId } from "node:worker_threads";
+import { isMainThread, threadId, Worker } from "node:worker_threads";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, expect, test, vi } from "vitest";
 import * as logging from "../../logging/logger.js";
 import { createDeferredCore } from "../../shared/deferred.js";
@@ -10,6 +13,86 @@ import { runExclusiveSqliteSessionWrite } from "./session-accessor.sqlite-scope.
 import { drainSessionStoreWriterQueuesForTest } from "./store-writer-state.js";
 
 afterEach(() => vi.restoreAllMocks());
+
+async function readFailedWriterLog(failure: unknown) {
+  return await withOpenClawTestState(
+    { scenario: "minimal", env: { OPENCLAW_TEST_FILE_LOG: "1" } },
+    async (state) => {
+      const logPath = state.path("sqlite-write.log");
+      logging.setLoggerOverride({ level: "warn", file: logPath });
+      try {
+        await expect(
+          runExclusiveSqliteSessionWrite({ agentId: "main", env: state.env }, async () => {
+            throw failure;
+          }),
+        ).rejects.toBe(failure);
+        await logging.flushLogger();
+        const content = await fs.readFile(logPath, "utf8");
+        const record: unknown = JSON.parse(content.trim());
+        assert.ok(isRecord(record));
+        const details = record["2"];
+        assert.ok(isRecord(details));
+        expect(record["1"]).toBe("SQLite session write failed");
+        return { content, error: details.error };
+      } finally {
+        await logging.flushLogger();
+        logging.resetLogger();
+      }
+    },
+  );
+}
+
+test.each([false, true])(
+  "failed writer file logs preserve redacted error details, worker=%s",
+  async (inWorker) => {
+    const secret = "synthetic-writer-credential-value";
+    const message = "synthetic writer failure";
+    const causeMessage = `synthetic storage failure; Authorization: Bearer ${secret}`;
+    let failure: unknown;
+    if (inWorker) {
+      const worker = new Worker(
+        `const { workerData } = require("node:worker_threads");
+       throw Object.assign(new Error(workerData.message, { cause: new Error(workerData.causeMessage) }), { code: "SQLITE_BUSY" });`,
+        { eval: true, execArgv: [], workerData: { message, causeMessage } },
+      );
+      try {
+        failure = await new Promise<unknown>((resolve, reject) => {
+          let received: unknown;
+          let receivedError = false;
+          worker.once("error", (error) => {
+            received = error;
+            receivedError = true;
+          });
+          worker.once("exit", () => {
+            if (receivedError) {
+              resolve(received);
+            } else {
+              reject(new Error("Synthetic worker exited without its expected error"));
+            }
+          });
+        });
+      } finally {
+        await worker.terminate();
+      }
+    } else {
+      failure = Object.assign(new Error(message, { cause: new Error(causeMessage) }), {
+        code: "SQLITE_BUSY",
+      });
+    }
+    const record = await readFailedWriterLog(failure);
+    expect(record.error).toBeTypeOf("string");
+    expect(record.error).toContain(message);
+    expect(record.error).toContain("synthetic storage failure");
+    expect(record.error).toContain("SQLITE_BUSY");
+    expect(record.content).not.toContain(secret);
+  },
+);
+
+test("failed writer error summaries are bounded without splitting a surrogate pair", async () => {
+  const prefix = "x".repeat(2_047);
+  const record = await readFailedWriterLog(new Error(`${prefix}🦞 trailing details`));
+  expect(record.error).toBe(prefix);
+});
 
 test.each([false, true])(
   "slow writer diagnostics separate waiting and execution without changing failure=%s",
@@ -113,7 +196,7 @@ test.each([false, true])(
         expect(record?.args[1]).not.toHaveProperty("reclamationKind");
         expect(record?.args[1]).not.toHaveProperty("workerThreadId");
         if (fail) {
-          expect(record?.args[1]).toHaveProperty("error", failure);
+          expect(record?.args[1]).toHaveProperty("error", failure.message);
         }
         await expect(runExclusiveSqliteSessionWrite(scope, async () => "successor")).resolves.toBe(
           "successor",

--- a/src/config/sessions/session-accessor.sqlite-scope.ts
+++ b/src/config/sessions/session-accessor.sqlite-scope.ts
@@ -3,6 +3,8 @@
 import path from "node:path";
 import { performance } from "node:perf_hooks";
 import { isMainThread, threadId } from "node:worker_threads";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { formatErrorMessageWithCode } from "../../infra/errors.js";
 import { getNodeSqliteKysely } from "../../infra/kysely-sync.js";
 import { getChildLogger } from "../../logging/logger.js";
 import {
@@ -93,6 +95,7 @@ export type SessionSqliteTargetResolutionCache = Map<
 >;
 
 const SQLITE_SESSION_SLOW_WRITE_MS = 1_000;
+const SQLITE_SESSION_WRITE_ERROR_MAX_CHARS = 2_048;
 const SQLITE_TRANSCRIPT_READ_QUERY_CHUNK_SIZE = 400;
 
 export function getSessionKysely(database: import("node:sqlite").DatabaseSync) {
@@ -146,7 +149,10 @@ export async function runExclusiveSqliteSessionWrite<T>(
     getChildLogger({ subsystem: "session-sqlite" }).warn("SQLite session write failed", {
       agentId: scope.agentId,
       ...timingFields(performance.now()),
-      error,
+      error: truncateUtf16Safe(
+        formatErrorMessageWithCode(error),
+        SQLITE_SESSION_WRITE_ERROR_MAX_CHARS,
+      ),
       storePath,
     });
     throw error;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators investigating failed SQLite session writes see an empty `error: {}` in structured file logs instead of the failure message and cause. An enumerable error code can survive alone, while the useful explanation disappears.

## Why This Change Was Made

The existing write owner now formats its caught error with the shared redaction-aware message/code formatter and caps the summary at 2,048 UTF-16 code units without splitting surrogate pairs. This fixes the producer's nested-Error serialization mismatch. The original thrown value, timing and store fields, FIFO behavior, and global logger/redactor remain unchanged. There are no database-schema, persistence, retention, or concurrency changes.

## User Impact

Future failed writes include a bounded, redacted summary with available cause and code details. This improves diagnosis; it does not recover details already lost from historical records or resolve the underlying write failures or stalls. The logging documentation describes the summary and truncation.

## Evidence

- Three real owner-to-file-logger regressions fail on the original source for code-only/empty error output. All six cases in the existing owner suite now pass, including standard and Worker-originated errors, cause/code retention, credential masking, UTF-safe truncation, original rethrow identity, and existing timing/FIFO behavior.
- Documentation MDX validation passed for 864 files. Independent final Codex P0–P2 review found no actionable findings. The full changed gate passed, including both typecheck lanes, lint, import-cycle checks, and repository guards.
- The [Linux Testbox boundary run](https://github.com/openclaw/openclaw/actions/runs/34155326332) used Node 24.19.0, normal isolated logging configuration, the actual write owner and file sink, and no logger mocks or overrides. The baseline genuinely exited 1 on the diagnostic-string assertion after its known `{}`/code-only loss was recorded. The candidate exited 0, preserving standard and actual Worker causes, `SQLITE_BUSY`, credential redaction, the 2,048-character ASCII cap, and the 2,047-character result when a surrogate pair crosses the cap.
- All five original-value identity checks and all five already-queued writer continuations passed on both Linux variants. Timing/store metadata survived; no database or Gateway was opened. The orchestrator required the exact expected baseline failure plus the candidate pass and exited 0; the lease is confirmed closed. Source hashes and all 16 retained artifacts were independently verified.
