### PR TITLE
refactor(cli): share local provider inventory setup

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2256,7 +2256,7 @@ src/cli/capability-cli/model.ts	4
 src/cli/capability-cli/shared.ts	4
 src/cli/capability-cli/tts.ts	6
 src/cli/capability-cli/video.ts	7
-src/cli/capability-cli/web.ts	6
+src/cli/capability-cli/web.ts	5
 src/cli/channel-auth.ts	4
 src/cli/channel-options.ts	1
 src/cli/channels-cli.ts	5

--- a/src/cli/capability-cli/audio.ts
+++ b/src/cli/capability-cli/audio.ts
@@ -1,7 +1,6 @@
 import path from "node:path";
 import type { Command } from "commander";
 import { resolveAgentDir } from "../../agents/agent-scope.js";
-import { getRuntimeConfig } from "../../config/config.js";
 import { inspectLocalAudioSelection } from "../../media-understanding/local-audio.js";
 import { buildMediaUnderstandingRegistry } from "../../media-understanding/provider-registry.js";
 import { transcribeAudioFile } from "../../media-understanding/runtime.js";
@@ -14,6 +13,7 @@ import type { CapabilityEnvelope } from "./metadata.js";
 import { emitJsonOrText, formatEnvelopeForText, providerSummaryText } from "./output.js";
 import {
   providerHasGenericConfig,
+  registerLocalProvidersCommand,
   requireProviderModelOverride,
   resolveCapabilityAgentOption,
   resolveCapabilityProviderAgentId,
@@ -89,59 +89,51 @@ export function registerAudioCapabilityCommands(capability: Command): void {
       });
     });
 
-  audio
-    .command("providers")
-    .description("List audio transcription providers")
-    .option("--agent <id>", "Agent whose provider state should be inspected")
-    .option("--json", "Output JSON", false)
-    .action(async (opts, command) => {
-      await runCommandWithRuntime(defaultRuntime, async () => {
-        const cfg = getRuntimeConfig();
-        const agentId = resolveCapabilityProviderAgentId(
-          cfg,
-          resolveCapabilityAgentOption(command, opts.agent),
-        );
-        const remoteProviders = [...buildMediaUnderstandingRegistry(undefined, cfg).values()]
-          .filter((provider) => provider.capabilities?.includes("audio"))
-          .map((provider) => ({
-            available: true,
-            configured: providerHasGenericConfig({
-              cfg,
-              providerId: provider.id,
-              agentId,
-              envVars: getProviderEnvVars(provider.id, {
-                config: cfg,
-                includeUntrustedWorkspacePlugins: false,
-              }),
+  registerLocalProvidersCommand(
+    audio,
+    "List audio transcription providers",
+    async (cfg, agentId) => {
+      const remoteProviders = [...buildMediaUnderstandingRegistry(undefined, cfg).values()]
+        .filter((provider) => provider.capabilities?.includes("audio"))
+        .map((provider) => ({
+          available: true,
+          configured: providerHasGenericConfig({
+            cfg,
+            providerId: provider.id,
+            agentId,
+            envVars: getProviderEnvVars(provider.id, {
+              config: cfg,
+              includeUntrustedWorkspacePlugins: false,
             }),
-            selected: false,
-            id: provider.id,
-            capabilities: provider.capabilities,
-            defaultModels: provider.defaultModels,
-          }));
-        const localSelection = await inspectLocalAudioSelection();
-        const localProviders = localSelection.candidates
-          .filter((candidate) => candidate.available)
-          .map((candidate) =>
-            Object.assign(
-              {
-                available: candidate.available,
-                configured: candidate.ready,
-                selected: false,
-                localFallbackSelected: candidate.selected,
-                id: `local/${candidate.id}`,
-                transport: "local-cli",
-                command: candidate.command,
-                observedBackend: candidate.observedBackend ?? "unknown",
-                evidence: candidate.evidence,
-              },
-              candidate.capableBackend ? { capableBackend: candidate.capableBackend } : {},
-              candidate.requestedBackend ? { requestedBackend: candidate.requestedBackend } : {},
-              candidate.reason ? { reason: candidate.reason } : {},
-            ),
-          );
-        const providers = [...remoteProviders, ...localProviders];
-        emitJsonOrText(defaultRuntime, Boolean(opts.json), providers, providerSummaryText);
-      });
-    });
+          }),
+          selected: false,
+          id: provider.id,
+          capabilities: provider.capabilities,
+          defaultModels: provider.defaultModels,
+        }));
+      const localSelection = await inspectLocalAudioSelection();
+      const localProviders = localSelection.candidates
+        .filter((candidate) => candidate.available)
+        .map((candidate) =>
+          Object.assign(
+            {
+              available: candidate.available,
+              configured: candidate.ready,
+              selected: false,
+              localFallbackSelected: candidate.selected,
+              id: `local/${candidate.id}`,
+              transport: "local-cli",
+              command: candidate.command,
+              observedBackend: candidate.observedBackend ?? "unknown",
+              evidence: candidate.evidence,
+            },
+            candidate.capableBackend ? { capableBackend: candidate.capableBackend } : {},
+            candidate.requestedBackend ? { requestedBackend: candidate.requestedBackend } : {},
+            candidate.reason ? { reason: candidate.reason } : {},
+          ),
+        );
+      return [...remoteProviders, ...localProviders];
+    },
+    providerSummaryText,
+  );
 }

--- a/src/cli/capability-cli/embedding.ts
+++ b/src/cli/capability-cli/embedding.ts
@@ -2,7 +2,6 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { Command } from "commander";
 import { resolveAgentDir } from "../../agents/agent-scope.js";
 import { resolveMemorySearchConfig } from "../../agents/memory-search.js";
-import { getRuntimeConfig } from "../../config/config.js";
 import { createEmbeddingProvider } from "../../plugin-sdk/memory-core-bundled-runtime.js";
 import { listEmbeddingProviders } from "../../plugins/embedding-provider-runtime.js";
 import { listRegisteredMemoryEmbeddingProviderAdapters } from "../../plugins/memory-embedding-provider-runtime.js";
@@ -14,6 +13,7 @@ import type { CapabilityEnvelope } from "./metadata.js";
 import { emitJsonOrText, formatEnvelopeForText, providerSummaryText } from "./output.js";
 import {
   providerHasGenericConfig,
+  registerLocalProvidersCommand,
   requireProviderModelOverride,
   resolveCapabilityAgentOption,
   resolveCapabilityProviderAgentId,
@@ -129,68 +129,60 @@ export function registerEmbeddingCapabilityCommands(capability: Command): void {
       });
     });
 
-  embedding
-    .command("providers")
-    .description("List embedding providers")
-    .option("--agent <id>", "Agent whose provider state should be inspected")
-    .option("--json", "Output JSON", false)
-    .action(async (opts, command) => {
-      await runCommandWithRuntime(defaultRuntime, async () => {
-        const cfg = getRuntimeConfig();
-        const agentId = resolveCapabilityProviderAgentId(
-          cfg,
-          resolveCapabilityAgentOption(command, opts.agent),
-        );
-        const resolvedMemory = resolveMemorySearchConfig(cfg, agentId);
-        const selectedProvider = resolvedMemory?.provider;
-        const providers = new Map(
-          listRegisteredMemoryEmbeddingProviderAdapters().map((provider) => [
-            provider.id,
-            {
-              id: provider.id,
-              defaultModel: provider.defaultModel,
-              transport: provider.transport,
-              autoSelectPriority: provider.autoSelectPriority,
-            },
-          ]),
-        );
-        for (const provider of listEmbeddingProviders(cfg)) {
-          if (providers.has(provider.id)) {
-            continue;
-          }
-          providers.set(provider.id, {
+  registerLocalProvidersCommand(
+    embedding,
+    "List embedding providers",
+    (cfg, agentId) => {
+      const resolvedMemory = resolveMemorySearchConfig(cfg, agentId);
+      const selectedProvider = resolvedMemory?.provider;
+      const providers = new Map(
+        listRegisteredMemoryEmbeddingProviderAdapters().map((provider) => [
+          provider.id,
+          {
             id: provider.id,
             defaultModel: provider.defaultModel,
             transport: provider.transport,
-            autoSelectPriority: undefined,
-          });
+            autoSelectPriority: provider.autoSelectPriority,
+          },
+        ]),
+      );
+      for (const provider of listEmbeddingProviders(cfg)) {
+        if (providers.has(provider.id)) {
+          continue;
         }
-        if (selectedProvider && !providers.has(selectedProvider)) {
-          providers.set(selectedProvider, {
-            id: selectedProvider,
-            defaultModel: resolvedMemory?.model || undefined,
-            transport: providerHasGenericConfig({ cfg, providerId: selectedProvider, agentId })
-              ? "remote"
-              : undefined,
-            autoSelectPriority: undefined,
-          });
-        }
-        const result = Array.from(providers.values()).map((provider) => ({
-          available: true,
-          configured:
-            provider.id === selectedProvider ||
-            providerHasGenericConfig({
-              cfg,
-              providerId: provider.id,
-              agentId,
-            }),
-          selected: provider.id === selectedProvider,
+        providers.set(provider.id, {
           id: provider.id,
           defaultModel: provider.defaultModel,
           transport: provider.transport,
-          autoSelectPriority: provider.autoSelectPriority,
-        }));
-        emitJsonOrText(defaultRuntime, Boolean(opts.json), result, providerSummaryText);
-      });
-    });
+          autoSelectPriority: undefined,
+        });
+      }
+      if (selectedProvider && !providers.has(selectedProvider)) {
+        providers.set(selectedProvider, {
+          id: selectedProvider,
+          defaultModel: resolvedMemory?.model || undefined,
+          transport: providerHasGenericConfig({ cfg, providerId: selectedProvider, agentId })
+            ? "remote"
+            : undefined,
+          autoSelectPriority: undefined,
+        });
+      }
+      return Array.from(providers.values()).map((provider) => ({
+        available: true,
+        configured:
+          provider.id === selectedProvider ||
+          providerHasGenericConfig({
+            cfg,
+            providerId: provider.id,
+            agentId,
+          }),
+        selected: provider.id === selectedProvider,
+        id: provider.id,
+        defaultModel: provider.defaultModel,
+        transport: provider.transport,
+        autoSelectPriority: provider.autoSelectPriority,
+      }));
+    },
+    providerSummaryText,
+  );
 }

--- a/src/cli/capability-cli/image.ts
+++ b/src/cli/capability-cli/image.ts
@@ -4,7 +4,6 @@ import { normalizeOptionalString } from "@openclaw/normalization-core/string-coe
 import type { Command } from "commander";
 import { resolveAgentDir } from "../../agents/agent-scope.js";
 import { runWithImageModelFallback } from "../../agents/model-fallback-image.js";
-import { getRuntimeConfig } from "../../config/config.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import {
   generateImage,
@@ -35,6 +34,7 @@ import {
   parseOptionalPositiveInteger,
   parseOptionalTimeoutMs,
   providerHasGenericConfig,
+  registerLocalProvidersCommand,
   requireProviderModelOverride,
   resolveCapabilityAgentOption,
   resolveCapabilityProviderAgentId,
@@ -376,34 +376,26 @@ export function registerImageCapabilityCommands(capability: Command): void {
       });
     });
 
-  image
-    .command("providers")
-    .description("List image generation providers")
-    .option("--agent <id>", "Agent whose provider state should be inspected")
-    .option("--json", "Output JSON", false)
-    .action(async (opts, command) => {
-      await runCommandWithRuntime(defaultRuntime, async () => {
-        const cfg = getRuntimeConfig();
-        const agentId = resolveCapabilityProviderAgentId(
-          cfg,
-          resolveCapabilityAgentOption(command, opts.agent),
-        );
-        const selectedProvider = resolveSelectedProviderFromModelRef(
-          resolveAgentModelPrimaryValue(cfg.agents?.defaults?.mediaModels?.image),
-        );
-        const result = listRuntimeImageGenerationProviders({ config: cfg }).map((provider) => ({
-          available: true,
-          configured:
-            selectedProvider === provider.id ||
-            providerHasGenericConfig({ cfg, providerId: provider.id, agentId }),
-          selected: selectedProvider === provider.id,
-          id: provider.id,
-          label: provider.label,
-          defaultModel: provider.defaultModel,
-          models: provider.models ?? [],
-          capabilities: provider.capabilities,
-        }));
-        emitJsonOrText(defaultRuntime, Boolean(opts.json), result, providerSummaryText);
-      });
-    });
+  registerLocalProvidersCommand(
+    image,
+    "List image generation providers",
+    (cfg, agentId) => {
+      const selectedProvider = resolveSelectedProviderFromModelRef(
+        resolveAgentModelPrimaryValue(cfg.agents?.defaults?.mediaModels?.image),
+      );
+      return listRuntimeImageGenerationProviders({ config: cfg }).map((provider) => ({
+        available: true,
+        configured:
+          selectedProvider === provider.id ||
+          providerHasGenericConfig({ cfg, providerId: provider.id, agentId }),
+        selected: selectedProvider === provider.id,
+        id: provider.id,
+        label: provider.label,
+        defaultModel: provider.defaultModel,
+        models: provider.models ?? [],
+        capabilities: provider.capabilities,
+      }));
+    },
+    providerSummaryText,
+  );
 }

--- a/src/cli/capability-cli/shared.ts
+++ b/src/cli/capability-cli/shared.ts
@@ -20,10 +20,36 @@ import {
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { defaultRuntime } from "../../runtime.js";
 import { getProviderEnvVars } from "../../secrets/provider-env-vars.js";
+import { runCommandWithRuntime } from "../cli-utils.js";
 import { resolveCommandConfigWithSecrets } from "../command-config-resolution.js";
 import { inheritOptionFromParent } from "../command-options.js";
 import { parseTimeoutMsWithFallback } from "../parse-timeout.js";
 import type { CapabilityTransport } from "./metadata.js";
+import { emitJsonOrText } from "./output.js";
+
+export function registerLocalProvidersCommand<T>(
+  parent: Command,
+  description: string,
+  collect: (cfg: OpenClawConfig, agentId: string) => T | Promise<T>,
+  format: (value: T) => string,
+): void {
+  parent
+    .command("providers")
+    .description(description)
+    .option("--agent <id>", "Agent whose provider state should be inspected")
+    .option("--json", "Output JSON", false)
+    .action(async (opts, command) => {
+      await runCommandWithRuntime(defaultRuntime, async () => {
+        const cfg = getRuntimeConfig();
+        const agentId = resolveCapabilityProviderAgentId(
+          cfg,
+          resolveCapabilityAgentOption(command, opts.agent),
+        );
+        const result = await collect(cfg, agentId);
+        emitJsonOrText(defaultRuntime, Boolean(opts.json), result, format);
+      });
+    });
+}
 
 export function resolveTransport(opts: {
   local?: boolean;

--- a/src/cli/capability-cli/video.ts
+++ b/src/cli/capability-cli/video.ts
@@ -10,7 +10,6 @@ import {
   assertOkOrThrowHttpError,
   assertProviderBinaryResponseContent,
 } from "../../agents/provider-http-errors.js";
-import { getRuntimeConfig } from "../../config/config.js";
 import { resolveAgentModelPrimaryValue } from "../../config/model-input.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { readResponseWithLimit } from "../../infra/http-body.js";
@@ -37,6 +36,7 @@ import {
   parseOptionalFiniteNumber,
   parseOptionalTimeoutMs,
   providerHasGenericConfig,
+  registerLocalProvidersCommand,
   requireProviderModelOverride,
   resolveCapabilityAgentOption,
   resolveCapabilityProviderAgentId,
@@ -325,48 +325,38 @@ export function registerVideoCapabilityCommands(capability: Command): void {
       });
     });
 
-  video
-    .command("providers")
-    .description("List video generation and description providers")
-    .option("--agent <id>", "Agent whose provider state should be inspected")
-    .option("--json", "Output JSON", false)
-    .action(async (opts, command) => {
-      await runCommandWithRuntime(defaultRuntime, async () => {
-        const cfg = getRuntimeConfig();
-        const agentId = resolveCapabilityProviderAgentId(
-          cfg,
-          resolveCapabilityAgentOption(command, opts.agent),
-        );
-        const selectedGenerationProvider = resolveSelectedProviderFromModelRef(
-          resolveAgentModelPrimaryValue(cfg.agents?.defaults?.mediaModels?.video),
-        );
-        const result = {
-          generation: listRuntimeVideoGenerationProviders({ config: cfg }).map((provider) => ({
+  registerLocalProvidersCommand(
+    video,
+    "List video generation and description providers",
+    (cfg, agentId) => {
+      const selectedGenerationProvider = resolveSelectedProviderFromModelRef(
+        resolveAgentModelPrimaryValue(cfg.agents?.defaults?.mediaModels?.video),
+      );
+      return {
+        generation: listRuntimeVideoGenerationProviders({ config: cfg }).map((provider) => ({
+          available: true,
+          configured:
+            selectedGenerationProvider === provider.id ||
+            providerHasGenericConfig({ cfg, providerId: provider.id, agentId }),
+          selected: selectedGenerationProvider === provider.id,
+          id: provider.id,
+          label: provider.label,
+          defaultModel: provider.defaultModel,
+          models: provider.models ?? [],
+          capabilities: provider.capabilities,
+        })),
+        description: [...buildMediaUnderstandingRegistry(undefined, cfg).values()]
+          .filter((provider) => provider.capabilities?.includes("video"))
+          .map((provider) => ({
             available: true,
-            configured:
-              selectedGenerationProvider === provider.id ||
-              providerHasGenericConfig({ cfg, providerId: provider.id, agentId }),
-            selected: selectedGenerationProvider === provider.id,
+            configured: providerHasGenericConfig({ cfg, providerId: provider.id, agentId }),
+            selected: false,
             id: provider.id,
-            label: provider.label,
-            defaultModel: provider.defaultModel,
-            models: provider.models ?? [],
             capabilities: provider.capabilities,
+            defaultModels: provider.defaultModels,
           })),
-          description: [...buildMediaUnderstandingRegistry(undefined, cfg).values()]
-            .filter((provider) => provider.capabilities?.includes("video"))
-            .map((provider) => ({
-              available: true,
-              configured: providerHasGenericConfig({ cfg, providerId: provider.id, agentId }),
-              selected: false,
-              id: provider.id,
-              capabilities: provider.capabilities,
-              defaultModels: provider.defaultModels,
-            })),
-        };
-        emitJsonOrText(defaultRuntime, Boolean(opts.json), result, (value) =>
-          JSON.stringify(value, null, 2),
-        );
-      });
-    });
+      };
+    },
+    (value) => JSON.stringify(value, null, 2),
+  );
 }

--- a/src/cli/capability-cli/web.ts
+++ b/src/cli/capability-cli/web.ts
@@ -22,7 +22,7 @@ import type { CapabilityEnvelope } from "./metadata.js";
 import { emitJsonOrText, formatEnvelopeForText } from "./output.js";
 import {
   parseOptionalPositiveInteger,
-  resolveCapabilityProviderAgentId,
+  registerLocalProvidersCommand,
   resolveLocalCapabilityRuntimeConfig,
 } from "./shared.js";
 
@@ -176,43 +176,36 @@ export function registerWebCapabilityCommands(capability: Command): void {
       }
     });
 
-  web
-    .command("providers")
-    .description("List web providers")
-    .option("--agent <id>", "Agent whose provider state should be inspected")
-    .option("--json", "Output JSON", false)
-    .action(async (opts) => {
-      await runCommandWithRuntime(defaultRuntime, async () => {
-        const cfg = getRuntimeConfig();
-        const agentId = resolveCapabilityProviderAgentId(cfg, opts.agent as string | undefined);
-        const agentDir = resolveAgentDir(cfg, agentId);
-        const selectedSearchProvider =
-          typeof cfg.tools?.web?.search?.provider === "string"
-            ? normalizeLowercaseStringOrEmpty(cfg.tools.web.search.provider)
-            : "";
-        const selectedFetchProvider =
-          typeof cfg.tools?.web?.fetch?.provider === "string"
-            ? normalizeLowercaseStringOrEmpty(cfg.tools.web.fetch.provider)
-            : "";
-        const result = {
-          search: listWebSearchProviders({ config: cfg }).map((provider) => ({
-            available: true,
-            configured: isWebSearchProviderConfigured({ provider, config: cfg, agentDir }),
-            selected: provider.id === selectedSearchProvider,
-            id: provider.id,
-            envVars: provider.envVars,
-          })),
-          fetch: listWebFetchProviders({ config: cfg }).map((provider) => ({
-            available: true,
-            configured: isWebFetchProviderConfigured({ provider, config: cfg }),
-            selected: provider.id === selectedFetchProvider,
-            id: provider.id,
-            envVars: provider.envVars,
-          })),
-        };
-        emitJsonOrText(defaultRuntime, Boolean(opts.json), result, (value) =>
-          JSON.stringify(value, null, 2),
-        );
-      });
-    });
+  registerLocalProvidersCommand(
+    web,
+    "List web providers",
+    (cfg, agentId) => {
+      const agentDir = resolveAgentDir(cfg, agentId);
+      const selectedSearchProvider =
+        typeof cfg.tools?.web?.search?.provider === "string"
+          ? normalizeLowercaseStringOrEmpty(cfg.tools.web.search.provider)
+          : "";
+      const selectedFetchProvider =
+        typeof cfg.tools?.web?.fetch?.provider === "string"
+          ? normalizeLowercaseStringOrEmpty(cfg.tools.web.fetch.provider)
+          : "";
+      return {
+        search: listWebSearchProviders({ config: cfg }).map((provider) => ({
+          available: true,
+          configured: isWebSearchProviderConfigured({ provider, config: cfg, agentDir }),
+          selected: provider.id === selectedSearchProvider,
+          id: provider.id,
+          envVars: provider.envVars,
+        })),
+        fetch: listWebFetchProviders({ config: cfg }).map((provider) => ({
+          available: true,
+          configured: isWebFetchProviderConfigured({ provider, config: cfg }),
+          selected: provider.id === selectedFetchProvider,
+          id: provider.id,
+          envVars: provider.envVars,
+        })),
+      };
+    },
+    (value) => JSON.stringify(value, null, 2),
+  );
 }


### PR DESCRIPTION
Closes #141508

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

Five local inference provider inventories repeat the same command setup and output lifecycle. This maintainer-requested cleanup gives that common flow one owner while keeping inventory rules with their domains.

## Why This Change Was Made

Share provider-command registration, runtime error handling, config lookup, agent selection and output emission in the existing capability CLI module. Audio, embedding, image, video and web keep their inventory builders, ordering, selected/configured facts and text/JSON formats.

## User Impact

Commands, flags, help and output remain unchanged. Production code shrinks by 15 lines; TTS, model inventories, lazy domain loading, credentials and persisted state retain their existing behavior. No performance improvement is claimed.

## Evidence

- All 264 existing capability CLI and lazy-loading tests pass across two files.
- The full changed gate and normal build pass, including type/lint/import-cycle checks.
- Actual isolated provider --help invocations pass for all five domains with empty synthetic config and the help fast path disabled. Inventory actions are covered by mocked CLI tests; no live provider requests were made.
- Final independent P2 review is scoped-clean. No tests changed; the only baseline change is the exact web assertion shrink from six to five after removing the cast.

Compatibility review: the changed embedding providers handler remains a read-only provider inventory. Its inventory expressions, ordering, fields, formatters and existing agent-owner resolution are preserved. No embedding data is generated or stored by this handler, and no schema, default, persistence or migration code changes. The only baseline edit is the exact static assertion-count shrink for the removed web cast. Source inspection and the 264 existing tests establish compatibility; a filename-based embedding-metadata classification does not identify a data-model change requiring migration proof.
