### PR TITLE
refactor(tests): isolate repair effects from Slack activation

### DIFF
--- a/src/infra/update-managed-service-handoff-repair.test-support.ts
+++ b/src/infra/update-managed-service-handoff-repair.test-support.ts
@@ -44,8 +44,7 @@ export async function releaseManagedRepairInference(
 export function managedRepairConfig(baseUrl: string): OpenClawConfig {
   const modelRef = "repair-test/repair-model";
   return {
-    commands: { ownerAllowFrom: ["slack:owner"] },
-    channels: { slack: { enabled: true } },
+    commands: { ownerAllowFrom: ["owner"] },
     plugins: { slots: { memory: "none" } },
     agents: {
       defaults: {
@@ -292,7 +291,7 @@ export async function runManagedRepairAuthorityBoundary(
         result = await runBoundary("systemd", {
           controlDisconnect: "transferred",
           validationResult: "skipped",
-          requester: { channel: "slack", accountId: "primary", senderId: "owner" },
+          requester: { channel: "synthetic", accountId: "primary", senderId: "owner" },
           ledger: true,
           helperExitCode: revoke ? 1 : 0,
           repair: { phase, baseUrl, revoke, inferencePending, releaseInference },


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The generic repair-effect revocation tests configure Slack even though they exercise requester authority around real exec/write effects, causing repeated Slack plugin activation during repair admission and rehearsal setup.

## Why This Change Was Made

Uses the established synthetic external requester and explicit bare owner in these four fixtures, omitting their incidental Slack configuration. The requester remains external, fresh policy checks still revoke subsequent effects, and both validating and verifying paths retain their original assertions, response gates, isolated state, child lifetimes, and source/compiled-runtime selection.

Separate handoff controls retain real Slack revoked/unchanged ownership coverage, alongside internal and channel-less controls. Requester-authority and fresh-worker tests retain configuration/load-failure handling and cross-process authority checks. No production authorization policy, registry mock, or activation flag changes.

## User Impact

No product behavior change. Removes one net test/support line and avoids incidental transport activation in generic repair fixtures.

## Evidence

- Focused baseline and candidate each passed 16 cases with identical names and results: four repair-effect cases, four ownership controls, three requester-authority cases, and five fresh-worker cases.
- Full lifecycle/command proof passed all 171 retained cases with no skips; the mapped changed gate, deslop, and independent P2 review passed.
- In the local focused comparison, the four repair cases decreased from 112.34 to 79.78 seconds (32.56 seconds, about 29%). Existing CLI registry-load spans decreased from 30.99 to 3.36 seconds in aggregate. Build time is excluded; these observations are not a global test-suite improvement claim, and no cross-version full-suite timing comparison is used.
