### PR TITLE
fix(lmstudio): prevent embedding truncation through smaller instances

### DIFF
--- a/docs/providers/lmstudio.md
+++ b/docs/providers/lmstudio.md
@@ -153,8 +153,10 @@ enough context for the selected model budget. A newly loaded instance is address
 identifier returned by LM Studio. Your configured model reference and conversation model identity
 keep the canonical model key.
 
-With preload enabled, embedding requests also check that their model is loaded. This lets memory
-embeddings recover after model eviction even when LM Studio JIT loading is disabled.
+With preload enabled, embedding requests also check that their model is loaded and route to the
+instance prepared for the configured context length. This avoids truncating input through a smaller
+loaded instance and lets memory embeddings recover after model eviction even when LM Studio JIT
+loading is disabled. Embedding model and cache identity keep the canonical model key.
 
 ### Disabling preload
 

--- a/extensions/lmstudio/src/embedding-provider.integration.test.ts
+++ b/extensions/lmstudio/src/embedding-provider.integration.test.ts
@@ -104,7 +104,7 @@ describe("LM Studio embedding request headers", () => {
 });
 
 it.each(["single", "documents", "queries", "cancelled"] as const)(
-  "reloads evicted embedding models before %s requests while holding the service lease",
+  "routes %s embeddings to sufficient-context instances across eviction while holding the service lease",
   async (kind) => {
     vi.stubEnv("NO_PROXY", "127.0.0.1");
     vi.stubEnv("no_proxy", "127.0.0.1");
@@ -113,7 +113,8 @@ it.each(["single", "documents", "queries", "cancelled"] as const)(
     const loadStarted = new Promise<void>((resolve) => {
       signalLoadStarted = resolve;
     });
-    let loaded = false;
+    let loaded = true;
+    let instanceNumber = 2;
     let leases = 0;
     const requests: string[] = [];
     const server = createServer((request, response) => {
@@ -137,7 +138,13 @@ it.each(["single", "documents", "queries", "cancelled"] as const)(
                   type: "embedding",
                   max_context_length: 2048,
                   loaded_instances: loaded
-                    ? [{ id: "embedding-model", config: { context_length: 2048 } }]
+                    ? [
+                        { id: "embedding-model", config: { context_length: 1024 } },
+                        {
+                          id: `embedding-model:${instanceNumber}`,
+                          config: { context_length: 2048 },
+                        },
+                      ]
                     : [],
                 },
               ],
@@ -149,7 +156,10 @@ it.each(["single", "documents", "queries", "cancelled"] as const)(
             return;
           }
           loaded = true;
-          response.end(JSON.stringify({ status: "loaded", instance_id: "embedding-model" }));
+          instanceNumber++;
+          response.end(
+            JSON.stringify({ status: "loaded", instance_id: `embedding-model:${instanceNumber}` }),
+          );
         } else if (request.url === "/v1/embeddings" && loaded) {
           const body: unknown = JSON.parse(text);
           if (
@@ -161,9 +171,9 @@ it.each(["single", "documents", "queries", "cancelled"] as const)(
           ) {
             throw new Error("Invalid embedding request");
           }
-          expect(body.model).toBe("embedding-model");
+          const embedding = body.model === `embedding-model:${instanceNumber}` ? [1, 0] : [0, 1];
           response.end(
-            JSON.stringify({ data: body.input.map((_, index) => ({ index, embedding: [1, 0] })) }),
+            JSON.stringify({ data: body.input.map((_, index) => ({ index, embedding })) }),
           );
         } else {
           response.statusCode = 400;
@@ -190,7 +200,17 @@ it.each(["single", "documents", "queries", "cancelled"] as const)(
                 baseUrl: `http://127.0.0.1:${address.port}/v1`,
                 apiKey: "lmstudio-local",
                 localService: { command: "/usr/bin/lms" },
-                models: [],
+                models: [
+                  {
+                    id: "embedding-model",
+                    name: "Embedding model",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    maxTokens: 0,
+                    contextTokens: 2048,
+                  },
+                ],
               },
             },
           },
@@ -206,6 +226,7 @@ it.each(["single", "documents", "queries", "cancelled"] as const)(
       });
       expect(leases).toBe(0);
       await expect(provider.embed("first")).resolves.toEqual([1, 0]);
+      expect(requests).not.toContain("/api/v1/models/load");
       loaded = false;
       requests.length = 0;
       if (kind === "cancelled") {

--- a/extensions/lmstudio/src/embedding-provider.test.ts
+++ b/extensions/lmstudio/src/embedding-provider.test.ts
@@ -4,10 +4,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { lmstudioMemoryEmbeddingProviderAdapter } from "../memory-embedding-adapter.js";
 import { createLmstudioEmbeddingProvider } from "./embedding-provider.js";
 
-const ensureLmstudioModelLoadedMock = vi.hoisted(() =>
-  vi.fn(
-    async (_params?: { requestedContextLength?: number }) => "text-embedding-nomic-embed-text-v1.5",
-  ),
+const prepareLmstudioModelForInferenceMock = vi.hoisted(() =>
+  vi.fn(async (_params?: { requestedContextLength?: number }) => ({
+    modelKey: "text-embedding-nomic-embed-text-v1.5",
+  })),
 );
 const fetchLmstudioModelsMock = vi.hoisted(() =>
   vi.fn(async (_params?: unknown) => ({
@@ -60,8 +60,8 @@ vi.mock("./models.fetch.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("./models.fetch.js")>();
   return {
     ...actual,
-    ensureLmstudioModelLoaded: (params: { requestedContextLength?: number }) =>
-      ensureLmstudioModelLoadedMock(params),
+    prepareLmstudioModelForInference: (params: { requestedContextLength?: number }) =>
+      prepareLmstudioModelForInferenceMock(params),
     fetchLmstudioModels: (params: unknown) => fetchLmstudioModelsMock(params),
   };
 });
@@ -101,13 +101,13 @@ async function readRequestedContextLength(config: OpenClawConfig): Promise<unkno
     model: EMBEDDING_MODEL,
     fallback: "none",
   });
-  expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledTimes(1);
-  return ensureLmstudioModelLoadedMock.mock.calls[0]?.[0]?.requestedContextLength;
+  expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledTimes(1);
+  return prepareLmstudioModelForInferenceMock.mock.calls[0]?.[0]?.requestedContextLength;
 }
 
 describe("createLmstudioEmbeddingProvider preload context length", () => {
   beforeEach(() => {
-    ensureLmstudioModelLoadedMock.mockClear();
+    prepareLmstudioModelForInferenceMock.mockClear();
     fetchLmstudioModelsMock.mockClear();
     fetchLmstudioModelsMock.mockResolvedValue({ reachable: true, status: 200, models: [] });
     createRemoteEmbeddingProviderMock.mockClear();
@@ -159,7 +159,7 @@ describe("createLmstudioEmbeddingProvider preload context length", () => {
         acquireLocalService,
       });
 
-      expect(ensureLmstudioModelLoadedMock).not.toHaveBeenCalled();
+      expect(prepareLmstudioModelForInferenceMock).not.toHaveBeenCalled();
       expect(fetchLmstudioModelsMock).not.toHaveBeenCalled();
       expect(acquireLocalService).not.toHaveBeenCalled();
 
@@ -272,7 +272,7 @@ describe("createLmstudioEmbeddingProvider preload context length", () => {
       throw new Error("expected LM Studio embedding provider");
     }
 
-    expect(ensureLmstudioModelLoadedMock).not.toHaveBeenCalled();
+    expect(prepareLmstudioModelForInferenceMock).not.toHaveBeenCalled();
     expect(fetchLmstudioModelsMock).toHaveBeenCalledOnce();
     expect(acquireLocalService).toHaveBeenCalledOnce();
     expect(release).toHaveBeenCalledOnce();
@@ -295,7 +295,7 @@ describe("createLmstudioEmbeddingProvider preload context length", () => {
       fallback: "none",
     });
 
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledWith(
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledWith(
       expect.objectContaining({ modelKey: requestedVariant }),
     );
     expect(createRemoteEmbeddingProviderMock).toHaveBeenCalledWith(
@@ -307,7 +307,7 @@ describe("createLmstudioEmbeddingProvider preload context length", () => {
 
   it("retains the discovered canonical model when its preload subsequently fails", async () => {
     const requestedVariant = `${EMBEDDING_MODEL}@q4_k_m`;
-    ensureLmstudioModelLoadedMock.mockRejectedValueOnce(
+    prepareLmstudioModelForInferenceMock.mockRejectedValueOnce(
       Object.assign(new Error("fixture preload rejected"), { resolvedModelKey: EMBEDDING_MODEL }),
     );
 
@@ -327,7 +327,9 @@ describe("createLmstudioEmbeddingProvider preload context length", () => {
 
   it("keeps the requested model when preload fails before discovering its identity", async () => {
     const requestedVariant = `${EMBEDDING_MODEL}@q4_k_m`;
-    ensureLmstudioModelLoadedMock.mockRejectedValueOnce(new Error("fixture discovery unavailable"));
+    prepareLmstudioModelForInferenceMock.mockRejectedValueOnce(
+      new Error("fixture discovery unavailable"),
+    );
 
     const { client } = await createLmstudioEmbeddingProvider({
       config: buildConfig({ model: { id: requestedVariant } }),
@@ -372,7 +374,7 @@ describe("createLmstudioEmbeddingProvider preload context length", () => {
     const { provider } = await createLmstudioEmbeddingProvider(options);
     await expect(provider.embed("hello", { inputType: "query" })).resolves.toEqual([1, 0]);
 
-    expect(ensureLmstudioModelLoadedMock).toHaveBeenCalledWith(
+    expect(prepareLmstudioModelForInferenceMock).toHaveBeenCalledWith(
       expect.objectContaining({ apiKey: "spark-key" }),
     );
     expect(resolveLmstudioRuntimeApiKeyMock).not.toHaveBeenCalled();

--- a/extensions/lmstudio/src/embedding-provider.ts
+++ b/extensions/lmstudio/src/embedding-provider.ts
@@ -14,7 +14,11 @@ import { resolveMemorySecretInputString } from "openclaw/plugin-sdk/memory-core-
 import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
 import { formatErrorMessage, type SsrFPolicy } from "openclaw/plugin-sdk/ssrf-runtime";
 import { LMSTUDIO_DEFAULT_EMBEDDING_MODEL, LMSTUDIO_PROVIDER_ID } from "./defaults.js";
-import { ensureLmstudioModelLoaded, fetchLmstudioModels } from "./models.fetch.js";
+import {
+  fetchLmstudioModels,
+  prepareLmstudioModelForInference,
+  type LmstudioPreparedModel,
+} from "./models.fetch.js";
 import {
   normalizeLmstudioConfiguredCatalogEntries,
   resolveLmstudioCanonicalModelKey,
@@ -262,9 +266,12 @@ export async function createLmstudioEmbeddingProvider(
   };
 
   const withPreloadLock = createAsyncLock();
-  const preloadModel = async (signal?: AbortSignal, initializeIdentity = false) => {
+  const preloadModel = async (
+    signal?: AbortSignal,
+    initializeIdentity = false,
+  ): Promise<LmstudioPreparedModel | undefined> => {
     if (providerConfig?.params?.preload === false) {
-      return;
+      return undefined;
     }
     // Serialize discovery/load, keeping embedding requests themselves concurrent.
     let entered = false;
@@ -272,7 +279,7 @@ export async function createLmstudioEmbeddingProvider(
       entered = true;
       signal?.throwIfAborted();
       try {
-        const modelKey = await ensureLmstudioModelLoaded({
+        const prepared = await prepareLmstudioModelForInference({
           baseUrl,
           apiKey,
           headers: headerOverrides,
@@ -283,8 +290,9 @@ export async function createLmstudioEmbeddingProvider(
           signal,
         });
         if (initializeIdentity) {
-          client.model = modelKey;
+          client.model = prepared.modelKey;
         }
+        return prepared;
       } catch (error) {
         signal?.throwIfAborted();
         // Cache identity is frozen at construction, including after a failed load.
@@ -300,15 +308,15 @@ export async function createLmstudioEmbeddingProvider(
         } else {
           log.debug("lmstudio embeddings preload failed; continuing without preload", details);
         }
+        return undefined;
       }
     });
     if (!signal) {
-      await preparation;
-      return;
+      return await preparation;
     }
     // A queued cancellation owns no load. Once entered, wait for transport cleanup
     // before the caller releases its service lease.
-    await new Promise<void>((resolve, reject) => {
+    return await new Promise<LmstudioPreparedModel | undefined>((resolve, reject) => {
       const onAbort = () => {
         if (!entered) {
           signal.removeEventListener("abort", onAbort);
@@ -317,9 +325,9 @@ export async function createLmstudioEmbeddingProvider(
       };
       signal.addEventListener("abort", onAbort, { once: true });
       void preparation.then(
-        () => {
+        (prepared) => {
           signal.removeEventListener("abort", onAbort);
-          resolve();
+          resolve(prepared);
         },
         (error: unknown) => {
           signal.removeEventListener("abort", onAbort);
@@ -362,11 +370,20 @@ export async function createLmstudioEmbeddingProvider(
     client,
     errorPrefix: "lmstudio embeddings failed",
   });
+  const resolveRequestProvider = (prepared: LmstudioPreparedModel | undefined) =>
+    prepared?.instanceId
+      ? createRemoteEmbeddingProvider({
+          id: LMSTUDIO_PROVIDER_ID,
+          // Route only this operation to the prepared instance; cache identity stays canonical.
+          client: { ...client, model: prepared.instanceId },
+          errorPrefix: "lmstudio embeddings failed",
+        })
+      : remoteProvider;
   const embed: MemoryEmbeddingProvider["embed"] = async (input, callOptions) =>
     await withLocalServiceLease(callOptions?.signal, async () => {
-      await preloadModel(callOptions?.signal);
+      const prepared = await preloadModel(callOptions?.signal);
       callOptions?.signal?.throwIfAborted();
-      return await remoteProvider.embed(input, callOptions);
+      return await resolveRequestProvider(prepared).embed(input, callOptions);
     });
   const embedBatch: MemoryEmbeddingProvider["embedBatch"] = async (inputs, callOptions) => {
     if (inputs.length === 0) {
@@ -377,9 +394,9 @@ export async function createLmstudioEmbeddingProvider(
       return await Promise.all(inputs.map((input) => embed(input, callOptions)));
     }
     return await withLocalServiceLease(callOptions?.signal, async () => {
-      await preloadModel(callOptions?.signal);
+      const prepared = await preloadModel(callOptions?.signal);
       callOptions?.signal?.throwIfAborted();
-      return await remoteProvider.embedBatch(inputs, callOptions);
+      return await resolveRequestProvider(prepared).embedBatch(inputs, callOptions);
     });
   };
   const provider: MemoryEmbeddingProvider = {


### PR DESCRIPTION
Closes #141510

## What Problem This Solves

Fixes an issue where memory embeddings silently lose trailing text when LM Studio has multiple instances of the same model loaded with different context lengths. A configured 2,048-token budget could still send the request through a 1,024-token instance.

## Why This Change Was Made

Embedding readiness already prepares a suitable instance. Each operation now carries that identifier into a request-local embedding client. The public provider and cache keep the canonical model identity, and eviction recovery continues to select the newly prepared instance.

## User Impact

New embedding requests use the prepared context capacity, including single requests and document/query batches. Existing cached vectors are not automatically recomputed. Preload opt-out, cancellation, and managed-service lifetime retain their existing behavior.

## Evidence

- Four extended HTTP lifecycle cases fail before the fix for wrong-instance output; all 58 focused and sibling tests pass afterward.
- Complete changed-code gate and whitespace checks pass.
- Real LM Studio llmster 0.0.23-1 with Nomic Embed Text v1.5 Q4_K_M, loaded at 1,024 and 2,048 tokens: daemon logs confirm baseline truncation from 1,206 to 1,024 tokens. Distinct suffixes produce identical vectors through the baseline but different vectors through the explicit 2,048-instance control.
- Patched production requests exactly match the 2,048-token control, retain suffix differences in single/document/query operations, and reload at the requested capacity after eviction. Preload opt-out control remains unchanged.
- [Baseline live run](https://github.com/openclaw/openclaw/actions/runs/34154843769) and [candidate live run](https://github.com/openclaw/openclaw/actions/runs/34155672988). Final source differs from the live-tested source only by an explicit return type and equivalent `return undefined` normalization; final focused tests and changed checks cover those bytes.
- All owned test processes and leases were stopped. No operator configuration, model service, or production index was changed.

### Stored-data compatibility

No stored-data model changes or migration are required. The diff changes only the LM Studio request owner, its tests, and provider documentation; database schema, cache key generation, and vector metadata are unchanged. The long-lived provider/client retain the canonical model key, which the HTTP lifecycle regressions and real-runtime identity observations verify before and after eviction. Only a temporary per-operation client receives the instance ID. Previously cached vectors remain readable and are not automatically recomputed. This addresses the automated compatibility prompt without introducing an unnecessary migration.
