### PR TITLE
fix(update): validate workspace plugins against the staged host

### DIFF
--- a/src/infra/update-candidate-plugin-tree.ts
+++ b/src/infra/update-candidate-plugin-tree.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs/promises";
 import path from "node:path";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolvePathViaExistingAncestorSync } from "./boundary-path.js";
+import { tryReadJson } from "./json-files.js";
+import { parseRegistryNpmSpec } from "./npm-registry-spec.js";
 import { hasNodeErrorCode, isPathInside } from "./path-guards.js";
 import {
   readRuntimeModulesManifest,
@@ -8,8 +11,6 @@ import {
   type RuntimeRelocation,
 } from "./update-runtime-relocation.js";
 
-const isHostEdge = (file: string) =>
-  path.basename(file) === "openclaw" && path.basename(path.dirname(file)) === "node_modules";
 const isHostLauncher = (file: string) =>
   path.basename(path.dirname(file)) === ".bin" &&
   ["openclaw", "openclaw.cmd", "openclaw.ps1"].includes(path.basename(file));
@@ -56,7 +57,7 @@ export async function copyUpdateCandidatePluginTrees(params: {
   project: (source: string) => string;
   targetStateDir: string;
   candidateRoot: string;
-}): Promise<{ copies: Array<[string, string]>; hostLinks: Set<string> }> {
+}): Promise<Array<[string, string]>> {
   const roots = new Map(params.roots);
   const privateRoot = resolvePathViaExistingAncestorSync(path.resolve(params.targetStateDir));
   const candidateRoot = resolvePathViaExistingAncestorSync(path.resolve(params.candidateRoot));
@@ -65,15 +66,75 @@ export async function copyUpdateCandidatePluginTrees(params: {
   const hosts = new Set<string>();
   const hostRoots = new Set<string>();
   const stores = new Set<string>();
+  const moduleAliases = new Map<string, string>();
+  const moduleOwners = new Set<string>();
+  const isOwnedHostEdge = (file: string) =>
+    path.basename(file) === "openclaw" && moduleOwners.has(path.dirname(file));
   const covered = (file: string) => [...roots.keys()].some((root) => isPathInside(root, file));
+  const insideHost = (file: string) => [...hosts].some((root) => isPathInside(root, file));
+  const excludesInferredRoot = (root: string) =>
+    !params.roots.has(root) && (insideHost(root) || hostRoots.has(root));
   function addRoot(source: string) {
-    if (!covered(source)) {
+    if (!roots.has(source)) {
       roots.set(source, params.project(source));
     }
   }
   function assertSource(source: string) {
     if (isPathInside(source, privateRoot) || isPathInside(privateRoot, source)) {
       throw new Error("Plugin copy source overlaps candidate state");
+    }
+  }
+  async function discoverHoistedDependencies(directory: string): Promise<void> {
+    const manifest = await tryReadJson<unknown>(path.join(directory, "package.json"));
+    if (!isRecord(manifest)) {
+      return;
+    }
+    const names = new Set<string>();
+    for (const field of ["dependencies", "optionalDependencies", "peerDependencies"]) {
+      const dependencies = manifest[field];
+      if (isRecord(dependencies)) {
+        for (const [name, spec] of Object.entries(dependencies)) {
+          const parsed = parseRegistryNpmSpec(name);
+          if (typeof spec === "string" && parsed?.name === name && parsed.selectorKind === "none") {
+            names.add(name);
+          }
+        }
+      }
+    }
+    for (const name of names) {
+      for (let ancestor = directory; ; ancestor = path.dirname(ancestor)) {
+        // Node skips a redundant node_modules/node_modules lookup.
+        if (path.basename(ancestor) !== "node_modules") {
+          const modulesDir = path.join(ancestor, "node_modules");
+          const dependency = path.join(modulesDir, ...name.split("/"));
+          const exists = await fs.stat(dependency).then(
+            () => true,
+            (error: unknown) => {
+              if (hasNodeErrorCode(error, "ENOENT") || hasNodeErrorCode(error, "ENOTDIR")) {
+                return false;
+              }
+              throw error;
+            },
+          );
+          if (exists) {
+            // Copy the reached module owner, not its repository. Its projected
+            // ancestry preserves both nearest-package shadowing and sibling imports.
+            const realModules = await fs.realpath(modulesDir);
+            assertSource(modulesDir);
+            assertSource(realModules);
+            moduleOwners.add(realModules);
+            addRoot(realModules);
+            if (realModules !== modulesDir) {
+              moduleAliases.set(modulesDir, realModules);
+            }
+            break;
+          }
+        }
+        if (path.dirname(ancestor) === ancestor) {
+          // Missing optional dependencies remain absent; validation owns required ones.
+          break;
+        }
+      }
     }
   }
   async function scan(directory: string): Promise<void> {
@@ -85,6 +146,10 @@ export async function copyUpdateCandidatePluginTrees(params: {
     if (!(await fs.stat(directory)).isDirectory()) {
       return;
     }
+    if (path.basename(directory) === "node_modules") {
+      moduleOwners.add(directory);
+    }
+    await discoverHoistedDependencies(directory);
     // Read before link discovery, so custom external stores retain their owner.
     const modules = await readRuntimeModulesManifest(path.join(directory, ".modules.yaml"));
     if (typeof modules?.manifest.virtualStoreDir === "string") {
@@ -92,19 +157,35 @@ export async function copyUpdateCandidatePluginTrees(params: {
       stores.add(store);
       addRoot(store);
     }
-    for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
-      const file = path.join(directory, entry.name);
-      if (isHostEdge(file)) {
-        hosts.add(file);
-        const root = await fs.realpath(file).catch((error: unknown) => {
-          if (hasNodeErrorCode(error, "ENOENT")) {
-            return undefined;
+    const entries = await fs.readdir(directory, { withFileTypes: true });
+    // Register identities before visiting siblings: a physical module directory
+    // may sort before the node_modules alias that establishes its ownership.
+    for (const entry of entries) {
+      if (entry.name === "node_modules" && (entry.isDirectory() || entry.isSymbolicLink())) {
+        const owner = await fs
+          .realpath(path.join(directory, entry.name))
+          .catch((error: unknown) => {
+            if (hasNodeErrorCode(error, "ENOENT") || hasNodeErrorCode(error, "ELOOP")) {
+              return undefined;
+            }
+            throw error;
+          });
+        if (owner) {
+          const source = path.join(directory, entry.name);
+          assertSource(owner);
+          moduleOwners.add(owner);
+          addRoot(owner);
+          if (source !== owner) {
+            moduleAliases.set(source, owner);
           }
-          throw error;
-        });
-        if (root) {
-          hostRoots.add(root);
         }
+      }
+    }
+    for (const entry of entries) {
+      const file = path.join(directory, entry.name);
+      if (isOwnedHostEdge(file)) {
+        // The complete-wave owner pass records the authoritative host identity.
+        continue;
       } else if (entry.isDirectory()) {
         await scan(file);
       } else if (entry.isSymbolicLink()) {
@@ -119,6 +200,64 @@ export async function copyUpdateCandidatePluginTrees(params: {
       }
     }
   }
+  async function refreshHostEdges(): Promise<void> {
+    const discovered: Array<{ source: string; real?: string }> = [];
+    for (const owner of moduleOwners) {
+      const source = path.join(owner, "openclaw");
+      const exists = await fs.lstat(source).then(
+        () => true,
+        (error: unknown) => {
+          if (hasNodeErrorCode(error, "ENOENT") || hasNodeErrorCode(error, "ENOTDIR")) {
+            return false;
+          }
+          throw error;
+        },
+      );
+      if (!exists) {
+        continue;
+      }
+      const real = await fs.realpath(source).catch((error: unknown) => {
+        if (hasNodeErrorCode(error, "ENOENT")) {
+          return undefined;
+        }
+        throw error;
+      });
+      discovered.push({ source, real });
+    }
+    hosts.clear();
+    hostRoots.clear();
+    for (const host of discovered) {
+      if (
+        discovered.some(
+          (other) => other.source !== host.source && isPathInside(other.source, host.source),
+        )
+      ) {
+        continue;
+      }
+      hosts.add(host.source);
+      if (host.real) {
+        hostRoots.add(host.real);
+      }
+    }
+    // A later module alias can identify a host subtree that an earlier root
+    // already scanned. Its discoveries must not become private dependency copies
+    // or nested aliases beneath the immutable staged host edge.
+    for (const root of roots.keys()) {
+      if (excludesInferredRoot(root)) {
+        roots.delete(root);
+      }
+    }
+    for (const file of edges.keys()) {
+      if (insideHost(file)) {
+        edges.delete(file);
+      }
+    }
+    for (const source of moduleAliases.keys()) {
+      if (insideHost(source)) {
+        moduleAliases.delete(source);
+      }
+    }
+  }
   // A locator can itself name a package inside a pnpm store or hoisted tree.
   for (const source of params.roots.keys()) {
     if (source.split(path.sep).includes("node_modules")) {
@@ -129,10 +268,13 @@ export async function copyUpdateCandidatePluginTrees(params: {
     for (const root of roots.keys()) {
       await scan(root);
     }
+    // Module ownership is a complete-wave fact, independent of root order.
+    await refreshHostEdges();
     let added = false;
     for (const [file, { real }] of edges) {
       if (
         covered(real) ||
+        hostRoots.has(real) ||
         (isHostLauncher(file) && [...hostRoots].some((root) => isPathInside(root, real)))
       ) {
         continue;
@@ -145,6 +287,11 @@ export async function copyUpdateCandidatePluginTrees(params: {
         (await dependencyOwner(real).catch((cause: unknown) => {
           throw new Error(`Cannot privately copy plugin dependency ${file} -> ${real}`, { cause });
         }));
+      if (excludesInferredRoot(owner)) {
+        throw new Error(
+          `Cannot privately copy host-owned plugin link ${file} -> ${real}; use the openclaw package/SDK import or a separately owned plugin dependency.`,
+        );
+      }
       assertSource(owner);
       addRoot(owner);
       added = true;
@@ -168,14 +315,19 @@ export async function copyUpdateCandidatePluginTrees(params: {
     sourceRoot,
     destinationRoot,
   }));
+  for (const [sourceRoot, real] of moduleAliases) {
+    relocations.push({ sourceRoot, destinationRoot: projected(real) });
+  }
   for (const root of hostRoots) {
     relocations.push({ sourceRoot: root, destinationRoot: candidateRoot });
   }
   for (const host of hosts) {
     relocations.push({ sourceRoot: host, destinationRoot: candidateRoot });
   }
-  for (const { target, real } of edges.values()) {
-    const host = [...hostRoots].find((root) => isPathInside(root, real));
+  for (const [file, { target, real }] of edges) {
+    const host = [...hostRoots].find(
+      (root) => real === root || (isHostLauncher(file) && isPathInside(root, real)),
+    );
     relocations.push({
       sourceRoot: target,
       destinationRoot: host ? path.join(candidateRoot, path.relative(host, real)) : projected(real),
@@ -196,7 +348,7 @@ export async function copyUpdateCandidatePluginTrees(params: {
     await fs.cp(source, target, {
       recursive: true,
       verbatimSymlinks: true,
-      filter: (file) => !isHostEdge(file),
+      filter: (file) => !hosts.has(file),
     });
   }
   for (const [source, target] of copies) {
@@ -204,27 +356,90 @@ export async function copyUpdateCandidatePluginTrees(params: {
       await relocateRuntimeTree(target, source, target, relocations);
     }
   }
-  async function verify(directory: string): Promise<void> {
-    if (!(await fs.stat(directory)).isDirectory()) {
+  // Projection owns these private links. Installer peer-link policy expects a
+  // literal node_modules directory and cannot bind a relocated module owner.
+  for (const link of hostLinks) {
+    if (!isPathInside(privateRoot, resolvePathViaExistingAncestorSync(path.dirname(link)))) {
+      throw new Error("Plugin host link escapes candidate state");
+    }
+    await fs.mkdir(path.dirname(link), { recursive: true });
+    const existing = await fs.lstat(link).catch((error: unknown) => {
+      if (hasNodeErrorCode(error, "ENOENT")) {
+        return undefined;
+      }
+      throw error;
+    });
+    if (existing) {
+      if (
+        !existing.isSymbolicLink() ||
+        path.resolve(path.dirname(link), await fs.readlink(link)) !== candidateRoot
+      ) {
+        throw new Error("Plugin host link conflicts with its candidate owner");
+      }
+    } else {
+      await fs.symlink(candidateRoot, link, process.platform === "win32" ? "junction" : "dir");
+    }
+  }
+  const privateAliases: string[] = [];
+  for (const [source, real] of moduleAliases) {
+    const owner = copies.find(([root]) => isPathInside(root, source));
+    const alias = owner
+      ? path.join(owner[1], path.relative(owner[0], source))
+      : params.project(source);
+    const target = projected(real);
+    if (!isPathInside(privateRoot, resolvePathViaExistingAncestorSync(path.dirname(alias)))) {
+      throw new Error("Plugin module alias escapes candidate state");
+    }
+    const existing = await fs.lstat(alias).catch((error: unknown) => {
+      if (hasNodeErrorCode(error, "ENOENT")) {
+        return undefined;
+      }
+      throw error;
+    });
+    if (existing) {
+      if ((await fs.realpath(alias)) !== (await fs.realpath(target))) {
+        throw new Error("Plugin module alias conflicts with its private owner");
+      }
+    } else {
+      await fs.mkdir(path.dirname(alias), { recursive: true });
+      await fs.symlink(target, alias, process.platform === "win32" ? "junction" : "dir");
+    }
+    privateAliases.push(alias);
+  }
+  async function verify(file: string): Promise<void> {
+    const stat = await fs.lstat(file);
+    if (hostLinks.has(file)) {
+      if (
+        !stat.isSymbolicLink() ||
+        path.resolve(path.dirname(file), await fs.readlink(file)) !== candidateRoot
+      ) {
+        throw new Error("Copied plugin host link does not target the candidate");
+      }
       return;
     }
-    for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
-      const file = path.join(directory, entry.name);
-      if (entry.isDirectory()) {
-        await verify(file);
-      } else if (entry.isSymbolicLink()) {
-        const target = path.resolve(directory, await fs.readlink(file));
-        if (
-          !isPathInside(privateRoot, target) &&
-          !(isHostLauncher(file) && isPathInside(candidateRoot, target))
-        ) {
-          throw new Error("Copied plugin symlink escapes candidate state");
-        }
+    // Inspect the entry before traversal, including standalone module aliases;
+    // following a copied root link can otherwise accept an entirely live tree.
+    if (stat.isSymbolicLink()) {
+      const target = path.resolve(path.dirname(file), await fs.readlink(file));
+      if (
+        !isPathInside(privateRoot, target) &&
+        !(isHostLauncher(file) && isPathInside(candidateRoot, target))
+      ) {
+        throw new Error("Copied plugin symlink escapes candidate state");
+      }
+      return;
+    }
+    if (stat.isDirectory()) {
+      for (const entry of await fs.readdir(file)) {
+        await verify(path.join(file, entry));
       }
     }
+  }
+  for (const alias of privateAliases) {
+    await verify(alias);
   }
   for (const [, target] of copies) {
     await verify(target);
   }
-  return { copies, hostLinks };
+  return copies;
 }

--- a/src/infra/update-candidate-plugins.ts
+++ b/src/infra/update-candidate-plugins.ts
@@ -7,6 +7,7 @@ import type { PluginInstallRecord } from "../config/types.plugins.js";
 import { INSTALLED_PLUGIN_INDEX_STATE_KEY } from "../plugins/installed-plugin-index-row.js";
 import type { ConfigMachineStateDatabase } from "../state/config-machine-state.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import { resolvePathViaExistingAncestorSync } from "./boundary-path.js";
 import { sameFileIdentity } from "./fs-safe-advanced.js";
 import { resolveUserPath } from "./home-dir.js";
 import {
@@ -49,7 +50,8 @@ export async function projectUpdateCandidatePlugins(params: {
   env?: NodeJS.ProcessEnv;
 }): Promise<Record<string, string>> {
   const sourceRoot = path.resolve(params.stateDir);
-  const shared = path.join(params.targetStateDir, "state", "openclaw.sqlite");
+  const targetStateDir = resolvePathViaExistingAncestorSync(path.resolve(params.targetStateDir));
+  const shared = path.join(targetStateDir, "state", "openclaw.sqlite");
   let value: Record<string, unknown> | undefined;
   let records: Record<string, PluginInstallRecord> = params.config.plugins?.installs ?? {};
   if (
@@ -98,7 +100,7 @@ export async function projectUpdateCandidatePlugins(params: {
     throw error;
   });
   const project = (source: string) =>
-    resolveUpdateCandidatePluginPath(canonicalStateRoot, params.targetStateDir, source);
+    resolveUpdateCandidatePluginPath(canonicalStateRoot, targetStateDir, source);
   const locators: Array<{ source: string; real: string; file: boolean }> = [];
   const roots = new Map<string, string>();
   const npmProjects = path.join(canonicalStateRoot, "npm", "projects");
@@ -134,7 +136,6 @@ export async function projectUpdateCandidatePlugins(params: {
     const real = await fs.realpath(source);
     const file = stat.isFile();
     locators.push({ source, real, file });
-    const managed = isPathInside(npmProjects, real) || isPathInside(npmModules, real);
     // Copy the whole managed project so hoisted dependencies remain available.
     const owner = isPathInside(npmProjects, real)
       ? path.join(npmProjects, path.relative(npmProjects, real).split(path.sep)[0]!)
@@ -144,13 +145,13 @@ export async function projectUpdateCandidatePlugins(params: {
           ? await resolvePluginFilePackageRoot(real)
           : real;
     if (!roots.has(owner)) {
-      roots.set(owner, project(managed || file ? owner : source));
+      roots.set(owner, project(owner));
     }
   }
-  const { copies, hostLinks } = await copyUpdateCandidatePluginTrees({
+  const copies = await copyUpdateCandidatePluginTrees({
     roots,
     project,
-    targetStateDir: params.targetStateDir,
+    targetStateDir,
     candidateRoot: params.candidateRoot,
   });
   for (const { source, real, file } of locators) {
@@ -159,9 +160,9 @@ export async function projectUpdateCandidatePlugins(params: {
       throw new Error("Plugin payload has no private copy root");
     }
     const target = path.join(copy[1], path.relative(copy[0], real));
-    const alias = file && path.basename(source) !== path.basename(real) ? project(source) : target;
+    const alias = path.basename(source) !== path.basename(real) ? project(source) : target;
     if (alias !== target) {
-      // Preserve the entry filename/ID, while Node resolves relative imports beside its copied target.
+      // Preserve the entry basename/ID while Node resolves imports from its canonical copied owner.
       const [existing, targetIdentity] = await Promise.all([
         fs.stat(alias, { bigint: true }).catch((error: unknown) => {
           if (hasNodeErrorCode(error, "ENOENT")) {
@@ -175,22 +176,14 @@ export async function projectUpdateCandidatePlugins(params: {
       if (!existing || !sameFileIdentity(existing, targetIdentity)) {
         await fs.mkdir(path.dirname(alias), { recursive: true });
         await fs.rm(alias, { force: true });
-        await fs.symlink(target, alias, "file");
+        await fs.symlink(
+          target,
+          alias,
+          file ? "file" : process.platform === "win32" ? "junction" : "dir",
+        );
       }
     }
     pluginPaths[source] = alias;
-  }
-  for (const link of hostLinks) {
-    const { linkOpenClawPeerDependencies } = await import("../plugins/plugin-peer-link.js");
-    const result = await linkOpenClawPeerDependencies({
-      installedDir: path.dirname(path.dirname(link)),
-      hostRoot: params.candidateRoot,
-      peerDependencies: { openclaw: "*" },
-      logger: {},
-    });
-    if (result.skipped) {
-      throw new Error("Could not bind copied plugin to candidate host");
-    }
   }
   if (value) {
     const projected = structuredClone(records);

--- a/src/infra/update-candidate-rehearsal.ts
+++ b/src/infra/update-candidate-rehearsal.ts
@@ -140,7 +140,9 @@ export async function prepareUpdateCandidateRehearsal(params: {
     }
     return milliseconds;
   };
-  const tempDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-canary-"));
+  const tempDir = await fs.realpath(
+    await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-update-canary-")),
+  );
   const sourceEnv = params.env ?? process.env;
   const configPath = path.join(tempDir, "openclaw.json");
   const workspaceDir = path.join(tempDir, "workspace");

--- a/src/infra/update-candidate-state.test.ts
+++ b/src/infra/update-candidate-state.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
-import { pathToFileURL } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { afterEach, beforeEach, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { runCommandBuffered } from "../process/exec.js";
@@ -16,6 +16,7 @@ import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { hasNodeErrorCode } from "./path-guards.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
+import { projectUpdateCandidatePlugins } from "./update-candidate-plugins.js";
 import { prepareUpdateCandidateRehearsal } from "./update-candidate-rehearsal.js";
 import {
   readUpdateStateSchemaVersions,
@@ -748,3 +749,269 @@ it.skipIf(process.platform === "win32")(
     }
   },
 );
+
+it.each([
+  { alias: false, shadow: false, linkedModules: false, sharedOrder: "none" },
+  { alias: true, shadow: false, linkedModules: false, sharedOrder: "none" },
+  { alias: false, shadow: true, linkedModules: false, sharedOrder: "none" },
+  { alias: false, shadow: false, linkedModules: true, sharedOrder: "none" },
+  { alias: false, shadow: false, linkedModules: false, sharedOrder: "owner-first" },
+  { alias: false, shadow: false, linkedModules: false, sharedOrder: "owner-last" },
+])(
+  "preserves declared workspace hoists without copying repository files (alias=$alias, shadow=$shadow, linkedModules=$linkedModules, sharedOrder=$sharedOrder)",
+  async ({ alias, shadow, linkedModules, sharedOrder }) => {
+    const repo = path.join(root, "workspace");
+    const plugin = path.join(repo, "packages", "demo");
+    const shared = sharedOrder !== "none";
+    const sharedOwner = path.join(repo, "packages", "owner");
+    const modules = shared
+      ? path.join(sharedOwner, "cache")
+      : linkedModules
+        ? path.join(root, "external-modules")
+        : path.join(repo, "node_modules");
+    const dependency = path.join(modules, "@demo", "dependency");
+    const liveHost = shared ? path.join(modules, "openclaw") : path.join(root, "live-host");
+    const sourceHostLink = path.join(shared ? plugin : repo, "node_modules", "openclaw");
+    const candidateHost = path.join(root, "candidate-host");
+    const expected = shadow ? "nearest" : "hoisted";
+    await fs.mkdir(plugin, { recursive: true });
+    await fs.mkdir(dependency, { recursive: true });
+    if (shared) {
+      await fs.symlink(modules, path.join(plugin, "node_modules"), "junction");
+      await fs.writeFile(
+        path.join(sharedOwner, "package.json"),
+        '{"name":"owner","type":"module"}',
+      );
+      await fs.writeFile(
+        path.join(sharedOwner, "index.js"),
+        'console.log(JSON.stringify({value:"owner",host:"owner",dependency:import.meta.url}));',
+      );
+    } else if (linkedModules) {
+      await fs.symlink(modules, path.join(repo, "node_modules"), "junction");
+    }
+    for (const [directory, value] of [
+      [liveHost, "serving"],
+      [candidateHost, "candidate"],
+    ] as const) {
+      await fs.mkdir(directory);
+      await fs.writeFile(
+        path.join(directory, "package.json"),
+        JSON.stringify({ name: "openclaw", type: "module", exports: "./index.js" }),
+      );
+      await fs.writeFile(
+        path.join(directory, "index.js"),
+        `export default ${JSON.stringify(value)};`,
+      );
+    }
+    if (!shared) {
+      await fs.symlink(liveHost, sourceHostLink, "junction");
+    }
+    await fs.writeFile(
+      path.join(repo, "package.json"),
+      JSON.stringify({ private: true, workspaces: ["packages/*"] }),
+    );
+    await fs.writeFile(path.join(repo, "unrelated.txt"), "do not copy repository files");
+    await fs.writeFile(
+      path.join(plugin, "package.json"),
+      JSON.stringify({
+        name: "demo",
+        version: "1.0.0",
+        type: "module",
+        dependencies: { "@demo/dependency": "1.0.0" },
+        optionalDependencies: { absent: "1.0.0" },
+        peerDependencies: { openclaw: "*" },
+      }),
+    );
+    await fs.writeFile(
+      path.join(plugin, "index.js"),
+      'import value from "@demo/dependency"; import host from "openclaw"; console.log(JSON.stringify({value, host, dependency: import.meta.resolve("@demo/dependency")}));',
+    );
+    await fs.writeFile(
+      path.join(dependency, "package.json"),
+      JSON.stringify({
+        name: "@demo/dependency",
+        version: "1.0.0",
+        type: "module",
+        exports: "./index.js",
+      }),
+    );
+    await fs.writeFile(path.join(dependency, "index.js"), 'export default "hoisted";');
+    if (shadow) {
+      const nearest = path.join(plugin, "node_modules", "@demo", "dependency");
+      await fs.cp(dependency, nearest, { recursive: true });
+      await fs.writeFile(path.join(nearest, "index.js"), 'export default "nearest";');
+    }
+    const locator = alias ? path.join(root, "linked-demo") : plugin;
+    if (alias) {
+      await fs.symlink(plugin, locator, "junction");
+    }
+    const readPlugin = async (directory: string) => {
+      const result = await runCommandBuffered(
+        [process.execPath, path.join(directory, "index.js")],
+        { timeoutMs: 10_000 },
+      );
+      expect(result.code, result.stderr.toString()).toBe(0);
+      return JSON.parse(result.stdout.toString()) as {
+        value: string;
+        dependency: string;
+        host: string;
+      };
+    };
+    expect(await readPlugin(locator)).toMatchObject({ value: expected, host: "serving" });
+    const paths = !shared
+      ? [locator]
+      : sharedOrder === "owner-first"
+        ? [sharedOwner, locator]
+        : [locator, sharedOwner];
+    if (shared) {
+      expect((await readPlugin(sharedOwner)).value).toBe("owner");
+    }
+    const rehearsal = await prepareUpdateCandidateRehearsal({
+      config: { plugins: { load: { paths } } },
+      stateDir: path.join(root, "source-state"),
+      candidateRoot: candidateHost,
+    });
+    try {
+      const config: OpenClawConfig = JSON.parse(await fs.readFile(rehearsal.configPath, "utf8"));
+      const copied = config.plugins!.load!.paths![paths.indexOf(locator)]!;
+      if (shared) {
+        expect(
+          (await readPlugin(config.plugins!.load!.paths![paths.indexOf(sharedOwner)]!)).value,
+        ).toBe("owner");
+      }
+      expect(path.basename(copied)).toBe(path.basename(locator));
+      const result = await readPlugin(copied);
+      expect(result).toMatchObject({ value: expected, host: "candidate" });
+      const copiedDependency = await fs.realpath(fileURLToPath(result.dependency));
+      expect(copiedDependency.startsWith(rehearsal.stateDir + path.sep)).toBe(true);
+      expect(
+        (await fs.readdir(rehearsal.stateDir, { recursive: true })).some(
+          (entry) => path.basename(entry) === "unrelated.txt",
+        ),
+      ).toBe(false);
+      await fs.writeFile(copiedDependency, 'export default "private";');
+      expect((await readPlugin(copied)).value).toBe("private");
+      expect((await readPlugin(locator)).value).toBe(expected);
+      expect(await fs.realpath(sourceHostLink)).toBe(liveHost);
+      if (alias) {
+        expect(await fs.realpath(locator)).toBe(plugin);
+      }
+    } finally {
+      await rehearsal.cleanup();
+    }
+  },
+);
+
+it("projects through an aliased temporary state directory without changing source links", async () => {
+  const source = path.join(root, "source");
+  const plugin = path.join(source, "extensions", "demo");
+  const dependency = path.join(root, "dependency");
+  const physical = path.join(root, "physical-state");
+  const alias = path.join(root, "state-alias");
+  await fs.mkdir(path.join(plugin, "node_modules"), { recursive: true });
+  await fs.mkdir(dependency);
+  await fs.mkdir(physical);
+  await fs.symlink(physical, alias, "junction");
+  await fs.writeFile(path.join(plugin, "package.json"), '{"name":"demo"}');
+  await fs.writeFile(path.join(dependency, "package.json"), '{"name":"dependency"}');
+  await fs.writeFile(path.join(dependency, "value.txt"), "source");
+  await fs.symlink(dependency, path.join(plugin, "node_modules", "dependency"), "junction");
+  const paths = await projectUpdateCandidatePlugins({
+    config: { plugins: { load: { paths: [plugin] } } },
+    stateDir: source,
+    targetStateDir: path.join(alias, "candidate"),
+    candidateRoot: root,
+  });
+  const copied = path.join(paths[plugin]!, "node_modules", "dependency", "value.txt");
+  expect((await fs.realpath(copied)).startsWith(physical + path.sep)).toBe(true);
+  await fs.writeFile(copied, "private");
+  expect(await fs.readFile(path.join(dependency, "value.txt"), "utf8")).toBe("source");
+  expect(await fs.realpath(path.join(plugin, "node_modules", "dependency"))).toBe(dependency);
+});
+
+it("keeps an optional-only linked node_modules copy bounded to its module owner", async () => {
+  const repo = path.join(root, "repository");
+  const plugin = path.join(repo, "plugin");
+  const modules = path.join(repo, "external-modules");
+  await fs.mkdir(plugin, { recursive: true });
+  await fs.mkdir(modules);
+  await fs.writeFile(path.join(repo, "package.json"), '{"private":true}');
+  await fs.writeFile(path.join(repo, "unrelated.txt"), "repository data");
+  await fs.writeFile(
+    path.join(plugin, "package.json"),
+    JSON.stringify({ name: "demo", type: "module", optionalDependencies: { missing: "1.0.0" } }),
+  );
+  await fs.writeFile(path.join(plugin, "index.js"), 'console.log("optional plugin ready");');
+  await fs.writeFile(path.join(modules, "marker.txt"), "source");
+  await fs.symlink(modules, path.join(plugin, "node_modules"), "junction");
+  const readEntry = async (directory: string) => {
+    const result = await runCommandBuffered([process.execPath, path.join(directory, "index.js")], {
+      timeoutMs: 10_000,
+    });
+    expect(result.code, result.stderr.toString()).toBe(0);
+    return result.stdout.toString().trim();
+  };
+  expect(await readEntry(plugin)).toBe("optional plugin ready");
+  const rehearsal = await prepareUpdateCandidateRehearsal({
+    config: { plugins: { load: { paths: [plugin] } } },
+    stateDir: path.join(root, "source-state"),
+    candidateRoot: root,
+  });
+  try {
+    const config: OpenClawConfig = JSON.parse(await fs.readFile(rehearsal.configPath, "utf8"));
+    const copied = config.plugins!.load!.paths![0]!;
+    expect(await readEntry(copied)).toBe("optional plugin ready");
+    expect(
+      (await fs.readdir(rehearsal.stateDir, { recursive: true })).some(
+        (entry) => path.basename(entry) === "unrelated.txt",
+      ),
+    ).toBe(false);
+    const marker = path.join(copied, "node_modules", "marker.txt");
+    expect((await fs.realpath(marker)).startsWith(rehearsal.stateDir + path.sep)).toBe(true);
+    await fs.writeFile(marker, "private");
+    expect(await fs.readFile(path.join(modules, "marker.txt"), "utf8")).toBe("source");
+    expect(await fs.realpath(path.join(plugin, "node_modules"))).toBe(modules);
+  } finally {
+    await rehearsal.cleanup();
+  }
+});
+
+it("rejects an ordinary link that would repeatedly copy an immutable host package", async () => {
+  const plugin = path.join(root, "plugin");
+  const host = path.join(root, "live-host");
+  const candidate = path.join(root, "candidate-host");
+  await fs.mkdir(path.join(plugin, "node_modules"), { recursive: true });
+  await fs.mkdir(path.join(host, "docs"), { recursive: true });
+  await fs.mkdir(candidate);
+  await fs.writeFile(
+    path.join(plugin, "package.json"),
+    JSON.stringify({ name: "demo", type: "module", peerDependencies: { openclaw: "*" } }),
+  );
+  await fs.writeFile(
+    path.join(host, "package.json"),
+    JSON.stringify({ name: "openclaw", type: "module", exports: "./index.js" }),
+  );
+  await fs.writeFile(path.join(host, "index.js"), 'export default "serving";');
+  await fs.writeFile(
+    path.join(plugin, "index.js"),
+    'import host from "openclaw"; console.log(host);',
+  );
+  await fs.writeFile(path.join(host, "docs", "marker.txt"), "source");
+  await fs.symlink(host, path.join(plugin, "node_modules", "openclaw"), "junction");
+  await fs.symlink(path.join(host, "docs"), path.join(plugin, "manual"), "junction");
+  const source = await runCommandBuffered([process.execPath, path.join(plugin, "index.js")], {
+    timeoutMs: 10_000,
+  });
+  expect(source.code, source.stderr.toString()).toBe(0);
+  expect(source.stdout.toString().trim()).toBe("serving");
+  await expect(
+    prepareUpdateCandidateRehearsal({
+      config: { plugins: { load: { paths: [plugin] } } },
+      stateDir: path.join(root, "source-state"),
+      candidateRoot: candidate,
+      timeoutMs: 10_000,
+    }),
+  ).rejects.toThrow("Cannot privately copy host-owned plugin link");
+  expect(await fs.readFile(path.join(host, "docs", "marker.txt"), "utf8")).toBe("source");
+  expect(await fs.realpath(path.join(plugin, "node_modules", "openclaw"))).toBe(host);
+}, 20_000);


### PR DESCRIPTION
Follow-up to #141175.

## What Problem This Solves

Workspace plugins can load successfully before an update but fail candidate validation when their dependencies are hoisted into an ancestor directory. Shared or symlinked module directories could also leave the candidate using the serving host, depending on configured plugin order.

## Why This Change Was Made

Record the actual module owners, copy those directories with their lookup relationships, and preserve private directory aliases. Derive host edges after owner discovery, then bind them directly to the staged candidate. Canonical temporary paths keep filesystem aliases consistent across copying and verification.

Use one exclusion policy for both pruning and expansion. Links requiring an excluded host package now fail promptly with guidance instead of repeatedly adding and removing the same owner. Reached module directories may include unused dependencies; unrelated repository files are excluded.

## User Impact

Candidate validation uses the staged host while serving plugin files and links remain unchanged. Hoisted dependencies, local shadowing, directory aliases, and optional-only installations retain their existing behavior.

## Evidence

- Real snapshot-worker and Node import regressions cover hoists, both shared-owner scan orders, staged-versus-serving host identity, source immutability, optional dependencies, and aliased module/temporary directories.
- The complete final owner/native-stage suite passed 47 tests on this exact head. The nontermination predecessor hit its 10-second test deadline; the repaired worker returned its explicit error in 754 ms.
- Full changed checks passed for the repair, with final affected test, type and lint checks rerun after policy unification. Independent P2 review is clean.
- A standalone Mac proof passes through the real `/var/folders` filesystem alias. Exact rebuilt-package qualification remains part of release validation; it is not claimed by these source-level checks.
