### PR TITLE
improve(test): reduce reporter contract test overhead

### DIFF
--- a/test/vitest-reporters-config.test.ts
+++ b/test/vitest-reporters-config.test.ts
@@ -26,8 +26,7 @@ describe("Vitest reporter contracts", () => {
     "reports completed agent tests and preserves overrides with GITHUB_ACTIONS=%s",
     (githubActions) => {
       // Resolve imported configs in a fresh process: shared config and std-env
-      // capture their environment on import. Native resolution needs no proxy
-      // config files or repeated bundling of the same dependency graph.
+      // capture their environment on import.
       const result = spawnNodeEvalSync(
         `
           import path from "node:path";
@@ -42,7 +41,14 @@ describe("Vitest reporter contracts", () => {
             const options = { root, config: false };
             const normal = await resolveConfig(options, imported);
             const cli = parseCLI(["vitest", "--reporter=json"]).options;
-            const override = await resolveConfig({ ...cli, ...options }, imported);
+            let cliConfig = imported;
+            if (config === "vitest.config.ts") {
+              // The default resolution validates the full matrix in both environments.
+              // Reporter CLI overrides do not propagate to child projects.
+              cliConfig = { ...imported, test: { ...imported.test } };
+              delete cliConfig.test.projects;
+            }
+            const override = await resolveConfig({ ...cli, ...options }, cliConfig);
             defaults.push({ config, reporters: normal.test.reporters, cli: override.test.reporters });
           }
           const customConfig = {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Reporter contract tests repeat the full root project-matrix resolution for each CLI override, adding avoidable work to the suite and reducing timeout headroom.

## Why This Change Was Made

Keep the complete default root resolution in both `GITHUB_ACTIONS` cases, then check the root CLI reporter override with a copied config that omits child projects. Vitest does not forward reporter CLI overrides to child projects. All 19 public resolution calls per case, other config inputs, reporter arrays, custom options, deduplication, environment assertions, and the 120-second deadline remain.

## User Impact

Less test overhead; no runtime behavior change. Full root-matrix validation remains in both environment cases.

## Evidence

- Existing two-case test passes before and after: 19.75s → 10.77s in one local Node 26 pair. This is a focused observation, not a Linux or overall-suite performance claim.
- Separate temporary diagnostics preserved complete reporter result arrays and verified all 19 calls. Synthetic duplicate project names still failed the retained default matrix; a CLI reporter mutation still failed the original reporter oracle.
- Mapped changed checks and fresh independent P2 review passed. No production files changed.
