### PR TITLE
refactor(reply): narrow pending dispatcher registration

### DIFF
--- a/src/auto-reply/reply/dispatcher-registry.ts
+++ b/src/auto-reply/reply/dispatcher-registry.ts
@@ -5,38 +5,26 @@
 import { resolveGlobalSet } from "../../shared/global-singleton.js";
 
 type TrackedDispatcher = {
-  readonly id: string;
   readonly pending: () => number;
-  readonly waitForIdle: () => Promise<void>;
 };
 
 const activeDispatchers = resolveGlobalSet<TrackedDispatcher>(
   Symbol.for("openclaw.activeReplyDispatchers"),
   "close-only",
 );
-let nextId = 0;
 
 /**
  * Register a reply dispatcher for global tracking.
  * Returns an unregister function to call when the dispatcher is no longer needed.
  */
-export function registerDispatcher(dispatcher: {
-  readonly pending: () => number;
-  readonly waitForIdle: () => Promise<void>;
-}): { id: string; unregister: () => void } {
-  const id = `dispatcher-${++nextId}`;
-  const tracked: TrackedDispatcher = {
-    id,
-    pending: dispatcher.pending,
-    waitForIdle: dispatcher.waitForIdle,
-  };
+export function registerDispatcher(pending: () => number): () => void {
+  // Separate registrations must remain distinct even when they share a callback.
+  const tracked: TrackedDispatcher = { pending };
   activeDispatchers.add(tracked);
 
-  const unregister = () => {
+  return () => {
     activeDispatchers.delete(tracked);
   };
-
-  return { id, unregister };
 }
 
 /**

--- a/src/auto-reply/reply/reply-dispatcher.ts
+++ b/src/auto-reply/reply/reply-dispatcher.ts
@@ -311,10 +311,7 @@ export function createReplyDispatcher(options: ReplyDispatcherOptions): ReplyDis
     ...(hasPendingDelivery ? { hasPendingDelivery: true } : {}),
   });
 
-  const { unregister } = registerDispatcher({
-    pending: () => pending,
-    waitForIdle,
-  });
+  const unregister = registerDispatcher(() => pending);
 
   const reportObserverError = (err: unknown, info: ReplyDispatchRuntimeInfo) => {
     void Promise.resolve(options.onError?.(err, info)).catch(() => undefined);


### PR DESCRIPTION
## What Problem This Solves

Reply-dispatch registration generated an ID and retained an idle-wait callback even though the registry’s only consumers read pending counts. The dispatcher already owns actual delivery and settlement waiting.

## Why This Change Was Made

Narrow registration to the live pending-count getter and its unregister function. Remove the unused ID, counter, callback and return wrapper. Each registration still has distinct object identity, and the shared registry keeps its existing close-only lifetime so restart checks retain pending work.

## User Impact

Reply delivery and Gateway restart behavior stay the same, with one smaller internal registration contract. This maintainer-requested cleanup removes 15 production lines without changing tests or public APIs.

## Evidence

The same 19 existing tests passed before and after across Gateway restart/reservation, projected reply dispatch and singleton lifecycle coverage. All 28 selected repository checks pass, including core/test types, lint, dead exports and import-cycle checks. Independent review through P2 found no actionable findings. No live Gateway/provider run or performance gain is claimed.
