### PR TITLE
fix(android): keep a stale operator hello from overwriting the handoff-issued device token

### DIFF
--- a/apps/android/GATEWAY_AUTH_POLICY.md
+++ b/apps/android/GATEWAY_AUTH_POLICY.md
@@ -76,6 +76,12 @@ write result. The session records the final write result for each role in this
 hello; receipt alone and preexisting tokens do not establish fresh handoff.
 Both node and operator writes must succeed before bootstrap retirement.
 
+`DeviceAuthStore` admits a write derived from a stored token only while the
+slot still holds that token. Freshly issued grants write unconditionally.
+A stale hello keeps its socket, but its persistence is refused; mismatch clears
+and recovery recommits follow the same stored-token rule. The wire regression is
+`bootstrapHandoff_staleStoredOperatorHelloCannotOverwriteFreshOperatorToken`.
+
 [`SecurePrefs.kt`](app/src/main/java/ai/openclaw/app/SecurePrefs.kt) then commits
 the existing credential bundle with only the consumed bootstrap removed. Token
 and password fields are preserved. A failed commit restores the previous
@@ -130,8 +136,9 @@ would change other Android authentication paths, outside this fix's scope:
   Gateway reports `not-paired` and explicitly advises waiting. Swift's channel
   classifies pairing-required as nonrecoverable.
 - Android may start an operator session using an old stored operator token
-  while bootstrap is present. iOS waits for the bootstrap handoff before
-  starting stored-only operator access.
+  while bootstrap is present. The store fence prevents a delayed old operator
+  hello from replacing the handoff-issued token. iOS avoids the race by waiting
+  for the bootstrap handoff before starting stored-only operator access.
 
 ## Required implementation proof
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/DeviceAuthStore.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/DeviceAuthStore.kt
@@ -35,20 +35,26 @@ interface DeviceAuthTokenStore {
     role: String,
   ): String? = loadEntry(gatewayId, deviceId, role)?.token
 
-  /** Returns true only after the token and its scope metadata are durably committed. */
+  /**
+   * Returns true only after the token and its scope metadata are durably committed.
+   * When [replacesStoredToken] is non-null, admits the write only while the slot still holds
+   * that token: a fresher grant that already replaced it wins and this write is refused.
+   */
   fun saveToken(
     gatewayId: String,
     deviceId: String,
     role: String,
     token: String,
     scopes: List<String> = emptyList(),
+    replacesStoredToken: String? = null,
   ): Boolean
 
-  /** Removes both token and metadata for the normalized device/role pair. */
+  /** Removes token and metadata; when [onlyIfToken] is non-null, only while the slot holds that token. */
   fun clearToken(
     gatewayId: String,
     deviceId: String,
     role: String,
+    onlyIfToken: String? = null,
   )
 }
 
@@ -57,6 +63,9 @@ class DeviceAuthStore(
   private val prefs: SecurePrefs,
 ) : DeviceAuthTokenStore {
   private val json = Json { ignoreUnknownKeys = true }
+
+  // Keep the stored-token comparison and mutation indivisible across competing role grants.
+  private val lock = Any()
 
   override fun loadEntry(
     gatewayId: String,
@@ -86,28 +95,37 @@ class DeviceAuthStore(
     role: String,
     token: String,
     scopes: List<String>,
-  ): Boolean {
-    val normalizedScopes = normalizeScopes(scopes)
-    val key = tokenKey(gatewayId, deviceId, role)
-    return prefs.commitSecureStrings(
-      mapOf(
-        key to token.trim(),
-        metadataKey(gatewayId, deviceId, role) to
-          json.encodeToString(
-            PersistedDeviceAuthMetadata(
-              scopes = normalizedScopes,
-              updatedAtMs = System.currentTimeMillis(),
+    replacesStoredToken: String?,
+  ): Boolean =
+    synchronized(lock) {
+      if (replacesStoredToken != null && loadEntry(gatewayId, deviceId, role)?.token != replacesStoredToken.trim()) {
+        return@synchronized false
+      }
+      val normalizedScopes = normalizeScopes(scopes)
+      val key = tokenKey(gatewayId, deviceId, role)
+      prefs.commitSecureStrings(
+        mapOf(
+          key to token.trim(),
+          metadataKey(gatewayId, deviceId, role) to
+            json.encodeToString(
+              PersistedDeviceAuthMetadata(
+                scopes = normalizedScopes,
+                updatedAtMs = System.currentTimeMillis(),
+              ),
             ),
-          ),
-      ),
-    )
-  }
+        ),
+      )
+    }
 
   override fun clearToken(
     gatewayId: String,
     deviceId: String,
     role: String,
-  ) {
+    onlyIfToken: String?,
+  ) = synchronized(lock) {
+    if (onlyIfToken != null && loadEntry(gatewayId, deviceId, role)?.token != onlyIfToken.trim()) {
+      return@synchronized
+    }
     val key = tokenKey(gatewayId, deviceId, role)
     prefs.remove(key)
     prefs.remove(metadataKey(gatewayId, deviceId, role))

--- a/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/gateway/GatewaySession.kt
@@ -1430,7 +1430,7 @@ class GatewaySession(
           selectedAuth.attemptedDeviceTokenRetry &&
           shouldClearStoredDeviceTokenAfterRetry(error)
         ) {
-          deviceAuthStore.clearToken(target.endpoint.stableId, identity.deviceId, target.options.role)
+          deviceAuthStore.clearToken(target.endpoint.stableId, identity.deviceId, target.options.role, onlyIfToken = storedToken)
         }
         throw GatewayConnectFailure(error)
       }
@@ -1479,6 +1479,7 @@ class GatewaySession(
       role: String,
       token: String,
       scopes: List<String>,
+      replacesStoredToken: String? = null,
     ): Boolean {
       val persistedScopes =
         if (authSource == GatewayConnectAuthSource.BOOTSTRAP_TOKEN) {
@@ -1487,7 +1488,7 @@ class GatewaySession(
         } else {
           scopes
         }
-      return deviceAuthStore.saveToken(target.endpoint.stableId, deviceId, role, token, persistedScopes)
+      return deviceAuthStore.saveToken(target.endpoint.stableId, deviceId, role, token, persistedScopes, replacesStoredToken)
     }
 
     private fun parseConnectSuccess(
@@ -1535,8 +1536,16 @@ class GatewaySession(
             deviceToken.trim() == selectedAuth.storedToken &&
             authRole.trim().equals(target.options.role.trim(), ignoreCase = true)
         val persistedScopes = if (sameStoredTokenRecord) selectedAuth.storedScopes else authScopes
+        val replacesStoredToken =
+          if (selectedAuth.authSource == GatewayConnectAuthSource.DEVICE_TOKEN &&
+            authRole.trim().equals(target.options.role.trim(), ignoreCase = true)
+          ) {
+            selectedAuth.storedToken
+          } else {
+            null
+          }
         persistedRoles[authRole.trim()] =
-          persistIssuedDeviceToken(selectedAuth.authSource, deviceId, authRole, deviceToken, persistedScopes)
+          persistIssuedDeviceToken(selectedAuth.authSource, deviceId, authRole, deviceToken, persistedScopes, replacesStoredToken)
       }
       if (shouldPersistBootstrapHandoffTokens(selectedAuth.authSource)) {
         // Bootstrap connects can mint role-specific device tokens; store only locally trusted handoffs.
@@ -1564,7 +1573,8 @@ class GatewaySession(
         for (role in listOf("node", "operator")) {
           if (role in persistedRoles) continue
           val entry = deviceAuthStore.loadEntry(target.endpoint.stableId, deviceId, role) ?: continue
-          persistedRoles[role] = deviceAuthStore.saveToken(target.endpoint.stableId, deviceId, role, entry.token, entry.scopes)
+          persistedRoles[role] =
+            deviceAuthStore.saveToken(target.endpoint.stableId, deviceId, role, entry.token, entry.scopes, replacesStoredToken = entry.token)
         }
       }
       if (persistedRoles["node"] == true && persistedRoles["operator"] == true) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/DeviceAuthStoreTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/DeviceAuthStoreTest.kt
@@ -7,6 +7,7 @@ import android.content.SharedPreferences
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -39,6 +40,36 @@ class DeviceAuthStoreTest {
     assertEquals("operator", entry?.role)
     assertEquals(listOf("operator.read", "operator.write"), entry?.scopes)
     assertTrue((entry?.updatedAtMs ?: 0L) > 0L)
+  }
+
+  @Test
+  fun tokenDerivedMutationsRequireTheCurrentStoredToken() {
+    val (prefs) = createPrefs()
+    val store = DeviceAuthStore(prefs)
+
+    for (expectedToken in listOf("old", " ")) {
+      assertFalse(store.saveToken("gateway-a", "device-1", "operator", "stale", replacesStoredToken = expectedToken))
+      assertNull(store.loadEntry("gateway-a", "device-1", "operator"))
+    }
+
+    assertTrue(store.saveToken("gateway-a", "device-1", "operator", " old ", listOf("operator.read")))
+    assertTrue(
+      store.saveToken("gateway-a", "device-1", "operator", "new", listOf("operator.write"), replacesStoredToken = " old "),
+    )
+    val freshEntry = store.loadEntry("gateway-a", "device-1", "operator")
+    assertEquals("new", freshEntry?.token)
+    assertEquals("operator", freshEntry?.role)
+    assertEquals(listOf("operator.write"), freshEntry?.scopes)
+    assertTrue((freshEntry?.updatedAtMs ?: 0L) > 0L)
+
+    assertFalse(
+      store.saveToken("gateway-a", "device-1", "operator", "stale", listOf("operator.admin"), replacesStoredToken = "old"),
+    )
+    assertEquals(freshEntry, store.loadEntry("gateway-a", "device-1", "operator"))
+    store.clearToken("gateway-a", "device-1", "operator", onlyIfToken = "old")
+    assertEquals(freshEntry, store.loadEntry("gateway-a", "device-1", "operator"))
+    store.clearToken("gateway-a", "device-1", "operator", onlyIfToken = " new ")
+    assertNull(store.loadEntry("gateway-a", "device-1", "operator"))
   }
 
   @Test

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionCustomHeadersTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionCustomHeadersTest.kt
@@ -55,12 +55,14 @@ private class NoopDeviceAuthStore : DeviceAuthTokenStore {
     role: String,
     token: String,
     scopes: List<String>,
+    replacesStoredToken: String?,
   ) = true
 
   override fun clearToken(
     gatewayId: String,
     deviceId: String,
     role: String,
+    onlyIfToken: String?,
   ) = Unit
 }
 

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionInvokeTest.kt
@@ -64,13 +64,14 @@ private const val CONNECT_CHALLENGE_FRAME =
 
 private class InMemoryDeviceAuthStore : DeviceAuthTokenStore {
   private val tokens = mutableMapOf<String, DeviceAuthEntry>()
+  private val lock = Any()
   var saveResult: (String, String) -> Boolean = { _, _ -> true }
 
   override fun loadEntry(
     gatewayId: String,
     deviceId: String,
     role: String,
-  ): DeviceAuthEntry? = tokens["${gatewayId.trim()}|${deviceId.trim()}|${role.trim()}"]
+  ): DeviceAuthEntry? = synchronized(lock) { tokens["${gatewayId.trim()}|${deviceId.trim()}|${role.trim()}"] }
 
   override fun saveToken(
     gatewayId: String,
@@ -78,24 +79,33 @@ private class InMemoryDeviceAuthStore : DeviceAuthTokenStore {
     role: String,
     token: String,
     scopes: List<String>,
-  ): Boolean {
-    if (!saveResult(role, token)) return false
-    tokens["${gatewayId.trim()}|${deviceId.trim()}|${role.trim()}"] =
-      DeviceAuthEntry(
-        token = token.trim(),
-        role = role.trim(),
-        scopes = scopes,
-        updatedAtMs = System.currentTimeMillis(),
-      )
-    return true
-  }
+    replacesStoredToken: String?,
+  ): Boolean =
+    synchronized(lock) {
+      if (replacesStoredToken != null && loadEntry(gatewayId, deviceId, role)?.token != replacesStoredToken.trim()) {
+        return@synchronized false
+      }
+      if (!saveResult(role, token)) return@synchronized false
+      tokens["${gatewayId.trim()}|${deviceId.trim()}|${role.trim()}"] =
+        DeviceAuthEntry(
+          token = token.trim(),
+          role = role.trim(),
+          scopes = scopes,
+          updatedAtMs = System.currentTimeMillis(),
+        )
+      true
+    }
 
   override fun clearToken(
     gatewayId: String,
     deviceId: String,
     role: String,
+    onlyIfToken: String?,
   ) {
-    tokens.remove("${gatewayId.trim()}|${deviceId.trim()}|${role.trim()}")
+    synchronized(lock) {
+      if (onlyIfToken != null && loadEntry(gatewayId, deviceId, role)?.token != onlyIfToken.trim()) return
+      tokens.remove("${gatewayId.trim()}|${deviceId.trim()}|${role.trim()}")
+    }
   }
 }
 
@@ -1136,6 +1146,160 @@ class GatewaySessionInvokeTest {
     }
 
   @Test
+  fun bootstrapHandoff_staleStoredOperatorHelloCannotOverwriteFreshOperatorToken() =
+    runBlocking {
+      for (operatorHelloToken in listOf("old-operator", "rotated-operator")) {
+        val prefs = testPrefs(RuntimeEnvironment.getApplication())
+        val store = DeviceAuthStore(prefs)
+        val operatorConnect = CompletableDeferred<JsonObject>()
+        val releaseOperatorHello = CountDownLatch(1)
+        val operatorConnected = CompletableDeferred<Unit>()
+        val operatorDisconnected = AtomicReference("")
+        val nodeConnected = CompletableDeferred<Unit>()
+        val nodeDisconnected = AtomicReference("")
+        val server =
+          startGatewayServer(testJson()) { socket, id, method, frame ->
+            if (method == "connect") {
+              val params = frame["params"]!!.jsonObject
+              if (params["role"]?.jsonPrimitive?.content == "operator") {
+                operatorConnect.complete(params)
+                releaseOperatorHello.await()
+                socket.send(
+                  connectResponseFrame(
+                    id,
+                    authJson = """{"deviceToken":"$operatorHelloToken","role":"operator","scopes":["operator.read"]}""",
+                  ),
+                )
+              } else {
+                socket.send(
+                  connectResponseFrame(
+                    id,
+                    authJson =
+                      """{"deviceToken":"new-node","role":"node","scopes":[],"deviceTokens":[{"deviceToken":"new-operator","role":"operator","scopes":["operator.read"]}]}""",
+                  ),
+                )
+              }
+            }
+          }
+        val gatewayId = gatewayIdForPort(server.port)
+        val deviceId = testDeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
+        assertTrue(operatorHelloToken, store.saveToken(gatewayId, deviceId, "operator", "old-operator", listOf("operator.read")))
+        prefs.saveGatewayCredentials(gatewayId, bootstrapToken = "setup")
+        val handoff = prefs.prepareGatewayBootstrapHandoff(gatewayId, "setup", false)
+        val operator = createNodeHarness(operatorConnected, operatorDisconnected, deviceAuthStore = store) { GatewaySession.InvokeResult.ok(null) }
+        val node = createNodeHarness(nodeConnected, nodeDisconnected, deviceAuthStore = store) { GatewaySession.InvokeResult.ok(null) }
+        try {
+          connectNodeSession(operator.session, server.port, token = null, role = "operator", scopes = listOf("operator.read"))
+          val params = withTimeout(TEST_TIMEOUT_MS) { operatorConnect.await() }
+          assertEquals(operatorHelloToken, "old-operator", params["auth"]!!.jsonObject["token"]?.jsonPrimitive?.content)
+
+          connectNodeSession(node.session, server.port, token = null, bootstrapToken = "setup", bootstrapHandoff = handoff)
+          awaitConnectedOrThrow(nodeConnected, nodeDisconnected, server)
+          assertEquals(operatorHelloToken, "new-operator", store.loadEntry(gatewayId, deviceId, "operator")?.token)
+          assertEquals(operatorHelloToken, "new-node", store.loadEntry(gatewayId, deviceId, "node")?.token)
+          assertTrue(operatorHelloToken, handoff.completed)
+          assertNull(operatorHelloToken, prefs.loadGatewayCredentials(gatewayId).bootstrapToken)
+
+          releaseOperatorHello.countDown()
+          awaitConnectedOrThrow(operatorConnected, operatorDisconnected, server)
+          assertEquals(operatorHelloToken, "new-operator", store.loadEntry(gatewayId, deviceId, "operator")?.token)
+          assertEquals(operatorHelloToken, "new-node", store.loadEntry(gatewayId, deviceId, "node")?.token)
+          assertTrue(operatorHelloToken, operator.session.isReady())
+        } finally {
+          releaseOperatorHello.countDown()
+          operator.session.disconnectAndJoin()
+          operator.sessionJob.cancelAndJoin()
+          node.session.disconnectAndJoin()
+          node.sessionJob.cancelAndJoin()
+          server.shutdown()
+        }
+      }
+    }
+
+  @Test
+  fun bootstrapHandoff_staleOperatorRetryMismatchCannotClearFreshOperatorToken() =
+    runBlocking {
+      val prefs = testPrefs(RuntimeEnvironment.getApplication())
+      val store = DeviceAuthStore(prefs)
+      val operatorAuthFrames = Channel<JsonObject>(Channel.UNLIMITED)
+      val releaseMismatch = CountDownLatch(1)
+      val retryRejected = CompletableDeferred<Unit>()
+      val nodeConnected = CompletableDeferred<Unit>()
+      val nodeDisconnected = AtomicReference("")
+      val server =
+        startGatewayServer(testJson()) { socket, id, method, frame ->
+          if (method == "connect") {
+            val params = frame["params"]!!.jsonObject
+            if (params["role"]?.jsonPrimitive?.content == "operator") {
+              val auth = params["auth"]!!.jsonObject
+              operatorAuthFrames.trySend(auth)
+              if (auth["deviceToken"] == null) {
+                socket.send(
+                  """{"type":"res","id":"$id","ok":false,"error":{"code":"UNAUTHORIZED","message":"shared token mismatch","details":{"code":"AUTH_TOKEN_MISMATCH","canRetryWithDeviceToken":true}}}""",
+                )
+              } else {
+                releaseMismatch.await()
+                socket.send(
+                  """{"type":"res","id":"$id","ok":false,"error":{"code":"UNAUTHORIZED","message":"device token mismatch","details":{"code":"AUTH_DEVICE_TOKEN_MISMATCH"}}}""",
+                )
+              }
+            } else {
+              socket.send(
+                connectResponseFrame(
+                  id,
+                  authJson =
+                    """{"deviceToken":"new-node","role":"node","scopes":[],"deviceTokens":[{"deviceToken":"new-operator","role":"operator","scopes":["operator.read"]}]}""",
+                ),
+              )
+            }
+          }
+        }
+      val gatewayId = gatewayIdForPort(server.port)
+      val deviceId = testDeviceIdentityStore(RuntimeEnvironment.getApplication()).loadOrCreate().deviceId
+      assertTrue(store.saveToken(gatewayId, deviceId, "operator", "old-operator", listOf("operator.read")))
+      prefs.saveGatewayCredentials(gatewayId, bootstrapToken = "setup")
+      val handoff = prefs.prepareGatewayBootstrapHandoff(gatewayId, "setup", false)
+      val operator =
+        createNodeHarness(
+          CompletableDeferred(),
+          AtomicReference(""),
+          deviceAuthStore = store,
+          onConnectFailure = { error, _ ->
+            if (error.details?.code == "AUTH_DEVICE_TOKEN_MISMATCH") retryRejected.complete(Unit)
+          },
+        ) { GatewaySession.InvokeResult.ok(null) }
+      val node = createNodeHarness(nodeConnected, nodeDisconnected, deviceAuthStore = store) { GatewaySession.InvokeResult.ok(null) }
+      try {
+        connectNodeSession(operator.session, server.port, token = "shared-token", role = "operator", scopes = listOf("operator.read"))
+        val firstAuth = withTimeout(TEST_TIMEOUT_MS) { operatorAuthFrames.receive() }
+        assertEquals("shared-token", firstAuth["token"]?.jsonPrimitive?.content)
+        assertNull(firstAuth["deviceToken"])
+        val retryAuth = withTimeout(TEST_TIMEOUT_MS) { operatorAuthFrames.receive() }
+        assertEquals("shared-token", retryAuth["token"]?.jsonPrimitive?.content)
+        assertEquals("old-operator", retryAuth["deviceToken"]?.jsonPrimitive?.content)
+
+        connectNodeSession(node.session, server.port, token = null, bootstrapToken = "setup", bootstrapHandoff = handoff)
+        awaitConnectedOrThrow(nodeConnected, nodeDisconnected, server)
+        val freshOperatorEntry = store.loadEntry(gatewayId, deviceId, "operator")
+        assertEquals("new-operator", freshOperatorEntry?.token)
+        assertTrue(handoff.completed)
+        assertNull(prefs.loadGatewayCredentials(gatewayId).bootstrapToken)
+
+        releaseMismatch.countDown()
+        withTimeout(TEST_TIMEOUT_MS) { retryRejected.await() }
+        assertEquals(freshOperatorEntry, store.loadEntry(gatewayId, deviceId, "operator"))
+        assertEquals("new-node", store.loadEntry(gatewayId, deviceId, "node")?.token)
+      } finally {
+        releaseMismatch.countDown()
+        operator.session.disconnectAndJoin()
+        operator.sessionJob.cancelAndJoin()
+        node.session.disconnectAndJoin()
+        node.sessionJob.cancelAndJoin()
+        server.shutdown()
+      }
+    }
+
+  @Test
   fun bootstrapHandoff_reconnectsAndRelaunchesOnlyAfterDurableRoles() =
     runBlocking {
       val prefs = testPrefs(RuntimeEnvironment.getApplication())
@@ -1984,6 +2148,7 @@ class GatewaySessionInvokeTest {
     onEvent: (event: String, payloadJson: String?) -> Unit = { _, _ -> },
     extraContext: CoroutineContext = EmptyCoroutineContext,
     deviceAuthStore: DeviceAuthTokenStore = InMemoryDeviceAuthStore(),
+    onConnectFailure: (GatewaySession.ErrorShape, Boolean) -> Unit = { _, _ -> },
     onInvoke: suspend (GatewaySession.InvokeRequest) -> GatewaySession.InvokeResult,
   ): NodeHarness {
     val app = RuntimeEnvironment.getApplication()
@@ -1999,6 +2164,7 @@ class GatewaySessionInvokeTest {
         onDisconnected = { message ->
           lastDisconnect.set(message)
         },
+        onConnectFailure = onConnectFailure,
         onEvent = onEvent,
         onInvoke = onInvoke,
       )

--- a/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/gateway/GatewaySessionReconnectTest.kt
@@ -68,12 +68,14 @@ private class ReconnectDeviceAuthStore(
     role: String,
     token: String,
     scopes: List<String>,
+    replacesStoredToken: String?,
   ) = true
 
   override fun clearToken(
     gatewayId: String,
     deviceId: String,
     role: String,
+    onlyIfToken: String?,
   ) = Unit
 }
 
@@ -94,6 +96,7 @@ private class BlockingSaveDeviceAuthStore : DeviceAuthTokenStore {
     role: String,
     token: String,
     scopes: List<String>,
+    replacesStoredToken: String?,
   ): Boolean {
     saveStarted.countDown()
     allowSave.await(LIFECYCLE_TEST_TIMEOUT_MS, TimeUnit.MILLISECONDS)
@@ -105,6 +108,7 @@ private class BlockingSaveDeviceAuthStore : DeviceAuthTokenStore {
     gatewayId: String,
     deviceId: String,
     role: String,
+    onlyIfToken: String?,
   ) = Unit
 }
 
@@ -123,6 +127,7 @@ private class RecordingDeviceAuthStore : DeviceAuthTokenStore {
     role: String,
     token: String,
     scopes: List<String>,
+    replacesStoredToken: String?,
   ): Boolean {
     savedToken.complete(token)
     return true
@@ -132,6 +137,7 @@ private class RecordingDeviceAuthStore : DeviceAuthTokenStore {
     gatewayId: String,
     deviceId: String,
     role: String,
+    onlyIfToken: String?,
   ) = Unit
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users who reconnected with a saved setup code while an older stored operator token existed could lose operator access on the next reconnect. The runtime starts the operator session on the stored operator token at the same time as the node session redeems the bootstrap token. Both hellos wrote the operator token slot, so a delayed old operator hello could overwrite the fresher token that the bootstrap handoff had just stored. The Gateway had already rotated that token away, so the next operator reconnect failed with a device-token mismatch and the app needed re-pairing. This race predates #141013 and was recorded there as a follow-up.

## Why This Change Was Made

`DeviceAuthStore` now owns admission of role-token writes. A write derived from a stored token (a stored-token hello, a recovery recommit of a loaded entry, or a mismatch-driven clear of the token that was tried) is admitted only while the slot still holds exactly that token, compared and committed under the store's own lock. Freshly issued grants (bootstrap handoff tokens and device tokens issued to shared-token or password connects) keep writing unconditionally, so the saved-bootstrap recovery from #141013 is unchanged. A stale hello keeps its live socket; only its persistence is refused.

There are no retries, timeouts, or second stores. Persisted preference keys, the serialized metadata format, configuration options, and the wire protocol are unchanged. The retained Android operator-startup policy stays as documented: the operator session may still start on the old stored token while bootstrap is present.

## User Impact

Reconnecting with a saved setup code no longer risks replacing the freshly issued operator token with a stale one. Operator access survives the next reconnect and process relaunch. No visible UI changes.

## Contract Notes

`apps/android/GATEWAY_AUTH_POLICY.md` records the write-owner rule under "Android durable handoff" and keeps the operator-startup difference accurate. `DeviceAuthTokenStore.saveToken` gains an optional `replacesStoredToken` expectation and `clearToken` an optional `onlyIfToken` expectation; both default to unconditional. No compatibility alias, schema change, release, or Google Play upload is included.

## Evidence

Both wire regressions run two `GatewaySession` instances against one real `DeviceAuthStore` and sequence the race with server-side latches, not timing.

`bootstrapHandoff_staleStoredOperatorHelloCannotOverwriteFreshOperatorToken` on unchanged production code (the intended failure, at the operator-slot assertion after the delayed operator hello):

```text
GatewaySessionInvokeTest > bootstrapHandoff_staleStoredOperatorHelloCannotOverwriteFreshOperatorToken FAILED
    org.junit.ComparisonFailure: old-operator expected:<[new]-operator> but was:<[old]-operator>
```

`bootstrapHandoff_staleOperatorRetryMismatchCannotClearFreshOperatorToken` on unchanged production code (a delayed `AUTH_DEVICE_TOKEN_MISMATCH` cleared the fresh token):

```text
GatewaySessionInvokeTest > bootstrapHandoff_staleOperatorRetryMismatchCannotClearFreshOperatorToken FAILED
    java.lang.AssertionError: expected:<DeviceAuthEntry(token=new-operator, role=operator, scopes=[operator.read], ...)> but was:<null>
```

Both pass with the repair, for the re-issued and the rotated operator token cases. `DeviceAuthStoreTest.tokenDerivedMutationsRequireTheCurrentStoredToken` covers the owner directly.

| Proof | Result |
| --- | --- |
| `ANDROID_HOME=/opt/homebrew/share/android-commandlinetools node --import ./scripts/tsx.mjs scripts/run-android-gradle.mts :app:testPlayDebugUnitTest :app:testThirdPartyDebugUnitTest` | Play 2,936 and third-party 3,067 tests; zero failures, errors, or skips |
| Touched lifecycle suites per flavor | GatewayBootstrapAuthTest 55, GatewaySessionReconnectTest 42, GatewaySessionCustomHeadersTest 7, GatewaySocketPublicationTest 2, all passing |
| `pnpm android:i18n:check` | passed |
| `ANDROID_HOME=/opt/homebrew/share/android-commandlinetools node scripts/check-changed.mjs` | passed, including Android ktlint |
| `git diff --check` | clean |

Independent Codex autoreview (branch mode against origin/main, P1 threshold): clean.

No emulator or live-Gateway proof was run for this change; the unit-level wire proof covers the changed boundary, and the live-proof requirement recorded in the policy doc for the original handoff change is untouched.
