### PR TITLE
fix(memory-lancedb): recall against the current prompt

### DIFF
--- a/docs/plugins/memory-lancedb.md
+++ b/docs/plugins/memory-lancedb.md
@@ -211,10 +211,9 @@ local server returns context-length errors.
 
 `recallMaxChars` bounds the `before_prompt_build` auto-recall query, the
 `memory_recall` tool, the `memory_forget` query path, and `openclaw ltm search`.
-Auto-recall embeds the latest user message from the turn and falls back to the
-full prompt only when no user message is present, keeping channel metadata and
-large prompt blocks out of the embedding request. It also bounds each recalled
-item after prompt escaping before that text reaches the model.
+Auto-recall embeds the current turn's prompt after removing media attachment
+notes and normalizing whitespace. The same limit bounds each recalled item
+after prompt escaping before that text reaches the model.
 
 `captureMaxChars` gates whether a user message from the turn's `agent_end`
 event is short enough to be considered for auto-capture. `memory_store` rejects

--- a/extensions/memory-lancedb/auto-recall.ts
+++ b/extensions/memory-lancedb/auto-recall.ts
@@ -10,7 +10,6 @@ import type { MemoryDB } from "./lancedb-store.js";
 import { dropMediaNoteLines } from "./memory-capture-sanitization.js";
 import {
   cleanMemorySearchResults,
-  extractLatestUserText,
   formatRelevantMemoriesContext,
   normalizeRecallQuery,
 } from "./memory-policy.js";
@@ -77,10 +76,8 @@ export function createAutoRecallHook(params: {
     }
 
     try {
-      const recallQuery = normalizeRecallQuery(
-        dropMediaNoteLines(extractLatestUserText(event.messages) ?? event.prompt),
-        recallMaxChars,
-      );
+      // Prompt hooks receive prior history separately from the current request.
+      const recallQuery = normalizeRecallQuery(dropMediaNoteLines(event.prompt), recallMaxChars);
       if (!recallQuery) {
         return undefined;
       }

--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -1505,18 +1505,14 @@ describe("memory plugin e2e", () => {
         )?.[1];
         expect(beforePromptBuild).toBeTypeOf("function");
 
-        const latestUserText = `what editor should i use? ${"with a very long channel metadata tail ".repeat(10)}`;
-        const expectedRecallQuery = normalizeRecallQuery(latestUserText, 120);
+        const currentUserText = `what editor should i use? ${"for a large TypeScript project ".repeat(10)}`;
+        const expectedRecallQuery = normalizeRecallQuery(currentUserText, 120);
         const result = await beforePromptBuild?.(
           {
-            prompt: `discord metadata ${"ignored ".repeat(100)}`,
+            prompt: `[media attached: /tmp/editor.png (image/png)]\n${currentUserText}`,
             messages: [
-              { role: "user", content: "old preference question" },
-              { role: "assistant", content: "old answer" },
-              {
-                role: "user",
-                content: `[media attached: /tmp/what editor should i use.png (image/png)]\n${latestUserText}`,
-              },
+              { role: "user", content: "what seat should i book for a long flight?" },
+              { role: "assistant", content: "An aisle seat." },
             ],
           },
           withAllowedMemoryRecallAuthority({ agentId: "main" }),

--- a/extensions/memory-lancedb/memory-policy.ts
+++ b/extensions/memory-lancedb/memory-policy.ts
@@ -37,16 +37,6 @@ export function extractUserTextContent(message: unknown): string[] {
   return texts;
 }
 
-export function extractLatestUserText(messages: unknown[]): string | undefined {
-  for (let index = messages.length - 1; index >= 0; index--) {
-    const text = extractUserTextContent(messages[index]).join("\n").trim();
-    if (text) {
-      return text;
-    }
-  }
-  return undefined;
-}
-
 export function normalizeRecallQuery(
   text: string,
   maxChars: number = DEFAULT_RECALL_MAX_CHARS,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where LanceDB auto-recall could search for memories about the previous user turn instead of the current question once a conversation had history. The prompt hook supplies the current request separately from prepared prior messages.

## Why This Change Was Made

Use the hook’s current prompt as the recall query, preserving media-note removal, whitespace normalization and the configured character bound. Remove the unused reverse-history reader and correct the existing hook fixture and documentation. Agent scope, tool policy, cooldown, timeouts, stored vectors and search/result behavior remain unchanged.

## User Impact

Automatic memory recall follows the current question when a conversation changes topic. No configuration or data migration is required.

## Evidence

The existing registered-hook test now matches production ordering: prior travel question/answer in history, current editor question in the prompt. Before the repair, the embedding-request assertion received the prior travel question. The identical case passes after the repair, including media-note removal, the 120-character limit and normal memory injection.

All 189 plugin tests and two existing current-user preparation boundary cases pass. All 25 selected repository checks pass, and independent review through P2 found no actionable findings. This is synthetic hook/embedding-request boundary proof; no live embedding provider or operator database was used. Production shrinks by 13 lines, tests by 4, and documentation by 1.
