### PR TITLE
refactor(copilot): forward the prepared spawn workspace

### DIFF
--- a/extensions/copilot/src/tool-bridge.test.ts
+++ b/extensions/copilot/src/tool-bridge.test.ts
@@ -31,9 +31,10 @@ type CopilotToolBridgeInput = Parameters<typeof createCopilotToolBridgeImpl>[0];
 type CopilotToolBridgeAttemptParams = NonNullable<CopilotToolBridgeInput["attemptParams"]>;
 type CopilotToolBridgeTestInput = Omit<
   CopilotToolBridgeInput,
-  "agentId" | "attemptParams" | "modelId" | "modelProvider" | "sessionId"
+  "agentId" | "attemptParams" | "modelId" | "modelProvider" | "sessionId" | "spawnWorkspaceDir"
 > &
   Partial<Pick<CopilotToolBridgeInput, "agentId" | "modelId" | "modelProvider" | "sessionId">> & {
+    spawnWorkspaceDir?: CopilotToolBridgeInput["spawnWorkspaceDir"];
     attemptParams?: Omit<CopilotToolBridgeAttemptParams, "hostCapabilities"> &
       Partial<Pick<CopilotToolBridgeAttemptParams, "hostCapabilities">>;
   };
@@ -49,6 +50,7 @@ function createCopilotToolBridge(input: CopilotToolBridgeTestInput) {
     modelId: "gpt-4o",
     modelProvider: "github-copilot",
     sessionId: "session-1",
+    spawnWorkspaceDir: undefined,
     ...baseInput,
     attemptParams: {
       ...attemptParams,
@@ -154,6 +156,7 @@ describe("createCopilotToolBridge", () => {
         modelId: "gpt-test",
         modelProvider: "github-copilot",
         sessionId: "session-1",
+        spawnWorkspaceDir: undefined,
       }),
     ).rejects.toThrow("Copilot attempt tools require host-bound capabilities");
     expect(createOpenClawCodingTools).not.toHaveBeenCalled();
@@ -1326,7 +1329,7 @@ describe("createCopilotToolBridge", () => {
       } as unknown as SandboxContext;
     }
 
-    it("defaults sandbox to undefined and derives spawnWorkspaceDir from workspaceDir when no sandbox is passed (back-compat)", async () => {
+    it("forwards an absent sandbox and prepared spawn workspace", async () => {
       const createOpenClawCodingTools = vi.fn(async () => [makeTool()]);
       await createCopilotToolBridge({
         createOpenClawCodingTools,
@@ -1340,8 +1343,6 @@ describe("createCopilotToolBridge", () => {
       };
       expect(opts.sandbox).toBeUndefined();
       expect(opts.workspaceDir).toBe("/workspace");
-      // resolveAttemptSpawnWorkspaceDir returns undefined for the
-      // no-sandbox path; the back-compat fallback emits that.
       expect(opts.spawnWorkspaceDir).toBeUndefined();
     });
 
@@ -1363,26 +1364,6 @@ describe("createCopilotToolBridge", () => {
       expect(opts.sandbox).toBe(sandbox);
       expect(opts.workspaceDir).toBe("/sandbox/copy");
       expect(opts.spawnWorkspaceDir).toBe("/original-workspace");
-    });
-
-    it("derives spawnWorkspaceDir from sandbox when caller omits it (fallback path)", async () => {
-      const sandbox = makeSandboxStub({ workspaceAccess: "ro" });
-      const createOpenClawCodingTools = vi.fn(async () => [makeTool()]);
-      await createCopilotToolBridge({
-        createOpenClawCodingTools,
-        sandbox,
-        sessionKey: "session-1",
-        workspaceDir: "/sandbox/copy",
-      });
-      const opts = (createOpenClawCodingTools.mock.calls[0] as unknown[] | undefined)?.[0] as {
-        spawnWorkspaceDir?: unknown;
-      };
-      // Fallback derives spawnWorkspaceDir from (effective) workspaceDir
-      // since the caller didn't pre-compute one. For a ro/none sandbox
-      // this yields the effective dir (= sandbox copy). Production
-      // callers (attempt.ts) always pre-compute spawnWorkspaceDir from
-      // the original workspace; the fallback is for test fixtures.
-      expect(opts.spawnWorkspaceDir).toBe("/sandbox/copy");
     });
   });
 

--- a/extensions/copilot/src/tool-bridge.ts
+++ b/extensions/copilot/src/tool-bridge.ts
@@ -18,7 +18,6 @@ import {
   getPluginToolSideEffectOwnerKey,
   isSubagentSessionKey,
   isToolResultError,
-  resolveAttemptSpawnWorkspaceDir,
   resolveEmbeddedAttemptToolConstructionPlan,
   resolveModelAuthMode,
   sanitizeToolResult,
@@ -104,15 +103,10 @@ interface CopilotToolBridgeInput {
    */
   sandbox?: SandboxContext | null;
   /**
-   * Pre-computed `spawnWorkspaceDir` for subagent inheritance. The caller
-   * derives this from the *original* workspace via
-   * `resolveAttemptSpawnWorkspaceDir({ sandbox, resolvedWorkspace })`.
-   * When omitted, the bridge falls back to computing it from the
-   * (possibly sandbox-effective) `workspaceDir` it sees; production
-   * callers should pass it explicitly so `ro`/`none` sandboxes are
-   * handled correctly.
+   * Spawn workspace prepared by the attempt from the original workspace.
+   * Undefined keeps normal workspace wiring for absent or rw sandboxes.
    */
-  spawnWorkspaceDir?: string;
+  spawnWorkspaceDir: string | undefined;
   abortSignal?: AbortSignal;
   /**
    * Full PI-parity attempt parameters. When set, the bridge forwards
@@ -377,21 +371,8 @@ function buildOpenClawCodingToolsOptions(
   const workspaceDir = input.workspaceDir ?? a.workspaceDir;
   const cwd = input.cwd ?? a.cwd;
   const agentDir = input.agentDir ?? a.agentDir;
-  // Sandbox forwarded from the caller (attempt.ts derives it via
-  // `resolveSandboxContext`). Wrapped tools that opt into sandbox-aware
-  // behavior now see the same policy PI provides. Spawn workspace falls
-  // through to the caller-provided value when supplied; otherwise we
-  // derive it locally from the (possibly sandbox-effective) workspaceDir
-  // — sufficient for legacy/test fixtures that didn't pre-compute it.
+  // Sandbox and spawn workspace are prepared by the attempt owner.
   const sandbox = input.sandbox ?? undefined;
-  const spawnWorkspaceDir =
-    input.spawnWorkspaceDir ??
-    (workspaceDir
-      ? resolveAttemptSpawnWorkspaceDir({
-          sandbox,
-          resolvedWorkspace: workspaceDir,
-        })
-      : undefined);
 
   const model = a.model;
   const modelHasVision = Array.isArray(model?.input) && model.input.includes("image");
@@ -434,7 +415,7 @@ function buildOpenClawCodingToolsOptions(
     workspaceDir,
     cwd,
     sandbox,
-    spawnWorkspaceDir,
+    spawnWorkspaceDir: input.spawnWorkspaceDir,
     config: toolSurfaceRuntime?.config ?? a.config,
     abortSignal: input.abortSignal,
     modelProvider: input.modelProvider,


### PR DESCRIPTION
## What Problem This Solves

The Copilot tool bridge recomputes a spawn workspace when its caller omits one, even though every production attempt already prepares that decision from the original workspace. An obsolete private fixture kept the second calculation alive and expected the sandbox copy instead.

## Why This Change Was Made

Forward the attempt's prepared value directly and require the private input property as `string | undefined`. An explicit `undefined` remains the completed decision when no alternate spawn workspace is needed. Remove the old calculation and its obsolete fixture; the existing test helper supplies the explicit property. No runtime shim or new helper is introduced.

The complete change removes 9 production code lines and 11 test code lines, including the three lines of fixture setup needed for the explicit input.

## User Impact

No intended behavior change. Workspace selection stays with the existing attempt preparation owner. Read-only and no-access sandboxes retain the original workspace for subagent inheritance; absent and read-write sandboxes retain their normal wiring. Public SDK, configuration, and sandbox policy are unchanged.

## Evidence

- Baseline: 261 passing focused tests. Final: all 260 remaining tests pass; the only removed case asserts the obsolete private omitted-input fallback.
- Five synthetic cases pass before and after through actual attempt preparation/execution and the real bridge: no workspace, null sandbox, read-write, read-only, and no-access. They verify property presence, the original/effective/spawn values, terminal success, and the SDK request's working-directory value. The SDK is a fixture and final tool construction is captured; this is not live sandbox or Copilot service proof.
- All 25 selected check stages pass, including production/test types, lint, dead exports, and runtime import cycles.
- Fresh independent P2 review is scoped-clean. The refresh onto repaired main preserves both source files and the complete reviewed patch byte-for-byte.
