### PR TITLE
feat(models): report nonfatal catalog attempt failures

### DIFF
--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -53,7 +53,7 @@ import {
   createPreparedInboundRegistryLoader,
   preparedModelRuntimeWorkspaceFactsKey,
 } from "./prepared-model-runtime.inbound-registry.js";
-import { notifyPreparedModelRuntimePublication } from "./prepared-model-runtime.publication-events.js";
+import { createCatalogAttemptReporter } from "./prepared-model-runtime.publication-events.js";
 import type {
   PreparedModelRuntimeBuildStats,
   PreparedModelRuntimeCatalogMode,
@@ -78,7 +78,7 @@ type PreparedModelRuntimeCatalogAccess = Readonly<{
 export type PreparedModelRuntimeBuildCandidate = Readonly<{
   input: PreparedModelRuntimeInput;
   catalogOwner: PreparedModelRuntimeSnapshot["catalogOwner"];
-  inventoryOwner?: Pick<PreparedModelRuntimeOwner, "catalogInventory">;
+  inventoryOwner?: Pick<PreparedModelRuntimeOwner, "catalogInventory" | "catalogAttemptError">;
   pluginGeneration?: PreparedModelRuntimePluginGeneration;
   prepareInboundPluginRegistry?: boolean;
   isGenerationCurrent?: () => boolean;
@@ -165,7 +165,7 @@ function createFullModelCatalogAccess(params: {
   pluginGeneration: PreparedModelRuntimePluginGeneration;
   agentBuildCompletions: Map<string, Promise<void>>;
   isCurrent: () => boolean;
-  inventoryOwner: Pick<PreparedModelRuntimeOwner, "catalogInventory">;
+  inventoryOwner: Pick<PreparedModelRuntimeOwner, "catalogInventory" | "catalogAttemptError">;
 }): PreparedModelRuntimeCatalogAccess {
   // Retain discovery, not the retired worker or its runtime capability projection.
   const project = (
@@ -216,6 +216,7 @@ function createFullModelCatalogAccess(params: {
     params.agentFacts.env,
   );
   const previousInventory = params.inventoryOwner.catalogInventory;
+  const attempt = createCatalogAttemptReporter(params.inventoryOwner, params.isCurrent);
   const pluginFingerprint = resolveInstalledManifestRegistryIndexFingerprint(
     params.pluginGeneration.pluginMetadataSnapshot.index,
   );
@@ -359,9 +360,10 @@ function createFullModelCatalogAccess(params: {
             };
             params.inventoryOwner.catalogInventory = inventory;
             fullCatalog = catalog;
-            notifyPreparedModelRuntimePublication({ phase: "catalog-published" });
+            attempt.published();
             return fullCatalog;
           })
+          .catch(attempt.failed)
           .finally(() => {
             pending = undefined;
           });

--- a/src/agents/prepared-model-runtime.publication-events.ts
+++ b/src/agents/prepared-model-runtime.publication-events.ts
@@ -1,12 +1,36 @@
+import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import { PreparedModelRuntimePublicationSupersededError } from "./prepared-model-runtime.errors.js";
+import type { PreparedModelRuntimeOwner } from "./prepared-model-runtime.types.js";
 
 const log = createSubsystemLogger("agents/prepared-model-runtime");
 
 type PreparedModelRuntimePublicationEvent =
   | { phase: "catalog-published" | "invalidated" | "published" }
-  | { phase: "failed"; error: Error };
+  | { phase: "catalog-failed" | "failed"; error: Error };
 
 const publicationListeners = new Set<(event: PreparedModelRuntimePublicationEvent) => void>();
+
+/** Completes catalog attempts without withdrawing their prepared turn runtime. */
+export function createCatalogAttemptReporter(
+  owner: Pick<PreparedModelRuntimeOwner, "catalogAttemptError">,
+  isCurrent: () => boolean,
+): { published: () => void; failed: (error: unknown) => never } {
+  return {
+    published: () => {
+      delete owner.catalogAttemptError;
+      notifyPreparedModelRuntimePublication({ phase: "catalog-published" });
+    },
+    failed: (error) => {
+      if (isCurrent() && !(error instanceof PreparedModelRuntimePublicationSupersededError)) {
+        const attemptError = toStringifiedError(error);
+        owner.catalogAttemptError = attemptError;
+        notifyPreparedModelRuntimePublication({ phase: "catalog-failed", error: attemptError });
+      }
+      throw error;
+    },
+  };
+}
 
 /** Observes committed prepared model/auth generations without starting discovery. */
 export function registerPreparedModelRuntimePublicationListener(

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -12,6 +12,7 @@ import {
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
 import { loadPreparedModelCatalogOwnerSnapshot } from "./prepared-model-catalog.js";
+import { withPreparedModelRuntimePluginGenerationScope } from "./prepared-model-runtime-generation-scope.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   advancePreparedModelRuntimeConfig,
@@ -30,6 +31,179 @@ describe("prepared model runtime reload auth adoption", () => {
   beforeEach(async () => {
     state = await createOpenClawTestState({ label: "prepared-model-runtime" });
     await resetPreparedModelRuntimeHarness(state);
+  });
+
+  it("records failed catalog attempts without withdrawing published runtime", async () => {
+    mocks.configuredAgentIds = ["default"];
+    await refreshPreparedModelRuntimeSnapshots({}, { gatewayLifecycle: true });
+    const input = {
+      agentId: "default",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
+      config: {},
+    };
+    const snapshot = await prepareModelRuntimeSnapshot(input);
+    if (!snapshot.loadFullModelCatalog || !snapshot.readFullModelCatalog) {
+      throw new Error("catalog attempt test requires the published full-catalog accessors");
+    }
+    const original = await snapshot.loadFullModelCatalog();
+    const { resolvePreparedModelRuntimeOwnerBySnapshot } =
+      await import("./prepared-model-runtime.owner.js");
+    const owner = resolvePreparedModelRuntimeOwnerBySnapshot(snapshot);
+    if (!owner?.catalogInventory) {
+      throw new Error("catalog attempt test requires the completed internal inventory owner");
+    }
+    const dispatch = await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" });
+    if (!dispatch) {
+      throw new Error("expected a published reply dispatch runtime");
+    }
+    const events: Array<{ phase: string; error?: Error }> = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) =>
+      events.push(event),
+    );
+    const failure = new Error("catalog attempt failed");
+    try {
+      mocks.runPreparedModelCatalogWorker.mockRejectedValueOnce(failure);
+      await expect(snapshot.loadFullModelCatalog({ refresh: true })).rejects.toThrow(
+        failure.message,
+      );
+      expect.soft(snapshot.readFullModelCatalog()).toBe(original);
+      expect.soft(snapshot.isCurrent()).toBe(true);
+      expect.soft(owner.needsRefresh).toBe(false);
+      expect.soft(owner.refreshError).toBeUndefined();
+      expect.soft(await prepareModelRuntimeSnapshot(input)).toBe(snapshot);
+      expect
+        .soft(await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }))
+        .toBe(dispatch);
+      expect.soft(owner.catalogAttemptError).toBe(failure);
+      expect.soft(events).toContainEqual({ phase: "catalog-failed", error: failure });
+      expect.soft(events.map((event) => event.phase)).not.toContain("failed");
+      const runInput = {
+        config: dispatch.config,
+        agentId: dispatch.agentId,
+        agentDir: dispatch.agentDir,
+        workspaceDir: dispatch.workspaceDir,
+        runtimePluginSelections: [{ provider: "custom", modelId: "model", runtime: "openclaw" }],
+      };
+      const lease = await acquireAgentRunPreparedModelRuntime(runInput, {
+        pluginGeneration: dispatch.pluginGeneration,
+      });
+      let active = true;
+      try {
+        await withPreparedModelRuntimePluginGenerationScope(
+          lease.pluginGeneration,
+          async () => {
+            const nested = await acquireAgentRunPreparedModelRuntime(runInput, {
+              pluginGeneration: lease.pluginGeneration,
+            });
+            try {
+              expect(nested.snapshot).toBe(lease.snapshot);
+            } finally {
+              nested.release();
+            }
+          },
+          () => (active ? lease.snapshot : undefined),
+        );
+        expect(await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" })).toBe(
+          dispatch,
+        );
+      } finally {
+        active = false;
+        lease.release();
+      }
+      await snapshot.loadFullModelCatalog({ refresh: true });
+      if (!owner.catalogInventory) {
+        throw new Error("catalog attempt test lost its internal inventory after recovery");
+      }
+      expect.soft(owner.catalogAttemptError).toBeUndefined();
+    } finally {
+      unregister();
+    }
+  });
+
+  it("records a failed first catalog attempt without inventing completed inventory", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    const snapshot = await prepareModelRuntimeSnapshot({
+      agentId: "default",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
+      config,
+    });
+    const { resolvePreparedModelRuntimeOwnerBySnapshot } =
+      await import("./prepared-model-runtime.owner.js");
+    const owner = resolvePreparedModelRuntimeOwnerBySnapshot(snapshot);
+    if (!owner || !snapshot.loadFullModelCatalog || !snapshot.readFullModelCatalog) {
+      throw new Error("expected the published catalog owner");
+    }
+    expect(owner.catalogInventory).toBeUndefined();
+    const failure = new Error("first catalog attempt failed");
+    mocks.runPreparedModelCatalogWorker.mockRejectedValueOnce(failure);
+    await expect(snapshot.loadFullModelCatalog()).rejects.toBe(failure);
+    expect(owner.catalogAttemptError).toBe(failure);
+    expect(owner.catalogInventory).toBeUndefined();
+    expect(snapshot.readFullModelCatalog()).toBeUndefined();
+    expect(snapshot.isCurrent()).toBe(true);
+    await snapshot.loadFullModelCatalog();
+    expect(owner.catalogAttemptError).toBeUndefined();
+    expect(snapshot.readFullModelCatalog()).toBeDefined();
+  });
+
+  it("does not record an obsolete catalog attempt after its owner is superseded", async () => {
+    mocks.configuredAgentIds = ["default"];
+    const config = {};
+    await refreshPreparedModelRuntimeSnapshots(config, {
+      gatewayLifecycle: true,
+      catalogMode: "static",
+    });
+    const snapshot = await prepareModelRuntimeSnapshot({
+      agentId: "default",
+      agentDir: state.agentDir("default"),
+      inheritedAuthDir: state.agentDir("default"),
+      config,
+    });
+    const { resolvePreparedModelRuntimeOwnerBySnapshot } =
+      await import("./prepared-model-runtime.owner.js");
+    const owner = resolvePreparedModelRuntimeOwnerBySnapshot(snapshot);
+    if (!owner || !snapshot.loadFullModelCatalog) {
+      throw new Error("expected the published catalog owner");
+    }
+    const started = createDeferred();
+    const result = createDeferred<{ entries: []; routeVariants: [] }>();
+    mocks.runPreparedModelCatalogWorker.mockImplementationOnce(() => {
+      started.resolve();
+      return result.promise;
+    });
+    const failure = new Error("obsolete catalog attempt failed");
+    const events: string[] = [];
+    const unregister = registerPreparedModelRuntimePublicationListener((event) =>
+      events.push(event.phase),
+    );
+    const load = snapshot.loadFullModelCatalog();
+    const rejected = expect(load).rejects.toBe(failure);
+    let replacement: ReturnType<typeof refreshPreparedModelRuntimeSnapshots> | undefined;
+    try {
+      await started.promise;
+      replacement = refreshPreparedModelRuntimeSnapshots(
+        { logging: { level: "debug" } },
+        { gatewayLifecycle: true, catalogMode: "static" },
+      );
+      await Promise.resolve();
+      expect(snapshot.isCurrent()).toBe(false);
+      result.reject(failure);
+      await rejected;
+      await replacement;
+      expect(owner.catalogAttemptError).toBeUndefined();
+      expect(events).not.toContain("catalog-failed");
+    } finally {
+      result.reject(failure);
+      await Promise.allSettled([load, replacement]);
+      unregister();
+    }
   });
 
   it("refreshes stale catalog content only when an explicit read requests it", async () => {

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -734,7 +734,11 @@ describe("prepared model runtime Gateway catalog mode", () => {
     await expect(snapshot?.loadFullModelCatalog?.({ refresh: true })).rejects.toThrow(
       "refresh failed",
     );
-    expect(catalogPublicationEvents).toEqual(["catalog-published", "catalog-published"]);
+    expect(catalogPublicationEvents).toEqual([
+      "catalog-published",
+      "catalog-published",
+      "catalog-failed",
+    ]);
     unregisterCatalogPublication();
     expect(snapshot?.readFullModelCatalog?.()).toEqual(fullCatalog);
     expect(mocks.runPreparedModelCatalogWorker).toHaveBeenCalledTimes(3);

--- a/src/agents/prepared-model-runtime.types.ts
+++ b/src/agents/prepared-model-runtime.types.ts
@@ -185,6 +185,8 @@ export type PreparedModelRuntimeOwner = {
   catalogStale: boolean;
   /** Completed discovery facts; runtime capability projection belongs to each generation. */
   catalogInventory?: PreparedModelCatalogInventory;
+  /** Last failed catalog attempt; it does not withdraw the published turn runtime. */
+  catalogAttemptError?: Error;
   refreshError?: Error;
   snapshot?: PreparedModelRuntimeSnapshot;
   pluginGeneration?: PreparedModelRuntimePluginGeneration;

--- a/src/gateway/server-chat-metadata-lifecycle.test.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.test.ts
@@ -165,6 +165,8 @@ async function createRealMetadataLifecycle(
       skills: () => mocks.registerSkillsListener.mock.calls[0]![0](),
       auth: () => authEvent(),
       catalog: () => modelEvent({ phase: "catalog-published" }),
+      catalogFailure: () =>
+        modelEvent({ phase: "catalog-failed", error: new Error("catalog failed") }),
       owner: () => modelEvent({ phase: "invalidated" }),
     },
     async stop() {
@@ -214,7 +216,7 @@ describe("gateway chat metadata lifecycle", () => {
     },
   );
 
-  it.each(["skills", "auth", "catalog", "owner"] as const)(
+  it.each(["skills", "auth", "catalog", "catalogFailure", "owner"] as const)(
     "retains a terminal metadata failure through a later %s invalidation",
     async (event) => {
       const harness = await createRealMetadataLifecycle();
@@ -625,6 +627,7 @@ describe("gateway chat metadata lifecycle", () => {
 
     modelListener({ phase: "invalidated" });
     modelListener({ phase: "catalog-published" });
+    modelListener({ phase: "catalog-failed", error: new Error("obsolete catalog failed") });
     authListener();
     skillsListener();
 
@@ -649,6 +652,20 @@ describe("gateway chat metadata lifecycle", () => {
     await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(2));
     skillsListener();
     await vi.waitFor(() => expect(mocks.refresh).toHaveBeenCalledTimes(3));
+  });
+
+  it("keeps real metadata reads available after a nonfatal catalog attempt failure", async () => {
+    const harness = await createRealMetadataLifecycle();
+    try {
+      const before = await harness.lifecycle.read({ agentId: "main" });
+      harness.modelEvent({ phase: "catalog-failed", error: new Error("catalog attempt failed") });
+      const after = await harness.lifecycle.read({ agentId: "main" });
+      expect(after).toEqual(before);
+      expect(harness.warn).not.toHaveBeenCalled();
+      expect(mocks.fail).not.toHaveBeenCalled();
+    } finally {
+      await harness.stop();
+    }
   });
 
   it("refreshes after the prepared owner publishes a completed full catalog", async () => {

--- a/src/gateway/server-chat-metadata-lifecycle.ts
+++ b/src/gateway/server-chat-metadata-lifecycle.ts
@@ -83,7 +83,7 @@ export async function createGatewayChatMetadataLifecycle(params: {
     ]);
     const unregisterPreparedModelRuntimePublication =
       registerPreparedModelRuntimePublicationListener((event) => {
-        if (event.phase === "catalog-published") {
+        if (event.phase === "catalog-published" || event.phase === "catalog-failed") {
           invalidateForSubordinateChange();
           return;
         }


### PR DESCRIPTION
A failed lazy catalog task already rejects to its caller and retains the last completed inventory. This change adds the missing internal attempt outcome: record `catalogAttemptError`, emit `catalog-failed`, and clear the error after successful catalog publication. Superseded attempts cannot record a current failure.

The Gateway treats this notification as a subordinate catalog change. Published turn facts, nested leases and reply dispatch remain available; fatal prepared-runtime failures keep their existing behavior. No public protocol/config fields, credential policy, provider-retention rules or worker restart policy change.

Validation:

- The prepared owner case failed on current main only because the state and notification were absent. The expanded case also preserved same-generation nested leases.
- Three focused owner cases pass: retained inventory/dispatch with nested leases, first-attempt failure and recovery, and obsolete-attempt suppression.
- Gateway controls pass for nonfatal readable metadata, replacement waits and preserved fatal failure. An initial test-call error was corrected; the successful controls were retained.
- Pinned formatting and focused syntax lint pass. Local builds and typechecks were not used as proof; CI supplies the required checks.

This is an internal runtime observability addition from #136257, following the inventory work in #139357. Tests use the existing owner harness and one-shot worker-task rejection; they do not claim provider HTTP or worker-crash recovery proof.

AI-assisted.
