### PR TITLE
perf(cli): avoid diagnostic imports in successful respawns

### DIFF
--- a/src/entry.compile-cache.ts
+++ b/src/entry.compile-cache.ts
@@ -105,7 +105,7 @@ type OpenClawCompileCacheRespawnPlan = {
 };
 
 type OpenClawCompileCacheRespawnRuntime = RespawnChildRuntime & {
-  writeError: (message: string) => void;
+  writeError: (message: string) => void | Promise<void>;
 };
 
 function buildOpenClawCompileCacheRespawnPlan(params: {
@@ -145,7 +145,7 @@ function buildOpenClawCompileCacheRespawnPlan(params: {
 export async function respawnWithoutOpenClawCompileCacheIfNeeded(params: {
   currentFile: string;
   installRoot: string;
-  prepareWriteError?: () => Promise<(message: string) => void>;
+  prepareWriteError?: () => Promise<(message: string) => void | Promise<void>>;
 }): Promise<boolean> {
   const plan = buildOpenClawCompileCacheRespawnPlan({
     currentFile: params.currentFile,
@@ -176,7 +176,9 @@ function runOpenClawCompileCacheRespawnPlan(
     spawn,
     attachChildProcessBridge,
     exit: process.exit.bind(process) as (code?: number) => never,
-    writeError: (message: string) => process.stderr.write(message),
+    writeError: (message: string) => {
+      process.stderr.write(message);
+    },
   },
 ): ChildProcess {
   return runRespawnChildWithSignalBridge({
@@ -186,7 +188,7 @@ function runOpenClawCompileCacheRespawnPlan(
     detachForProcessTree: plan.detachForProcessTree,
     runtime,
     onError: (error) => {
-      runtime.writeError(
+      return runtime.writeError(
         `[openclaw] Failed to respawn CLI without compile cache: ${
           error instanceof Error ? (error.stack ?? error.message) : String(error)
         }\n`,

--- a/src/entry.respawn-diagnostics.test.ts
+++ b/src/entry.respawn-diagnostics.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+const boundary = vi.hoisted(() => ({
+  mode: "flags" as "flags" | "compile-cache",
+  trace: false,
+  events: [] as string[],
+  writer: undefined as ((message: string, error?: unknown) => void | Promise<void>) | undefined,
+}));
+
+vi.mock("./infra/is-main.js", () => ({ isMainModule: () => true }));
+vi.mock("./infra/openclaw-exec-env.js", () => ({ ensureOpenClawExecMarkerOnProcess: vi.fn() }));
+vi.mock("./infra/warning-filter.js", () => ({ installProcessWarningFilter: vi.fn() }));
+vi.mock("./cli/dotenv.js", () => ({
+  loadCliDotEnv: () => boundary.events.push("dotenv"),
+}));
+vi.mock("./cli/startup-trace.js", () => ({
+  createGatewayDispatchStartupTrace: () => ({ enabled: boundary.trace, mark: vi.fn() }),
+  configureGatewayStartupTraceConsoleFormatting: async () => {
+    boundary.events.push("trace formatting");
+  },
+}));
+vi.mock("./entry.compile-cache.js", () => ({
+  resolveEntryInstallRoot: () => "/fixture/openclaw",
+  enableOpenClawCompileCache: vi.fn(),
+  respawnWithoutOpenClawCompileCacheIfNeeded: async (params: {
+    prepareWriteError: () => Promise<NonNullable<typeof boundary.writer>>;
+  }) => {
+    if (boundary.mode !== "compile-cache") {
+      return false;
+    }
+    boundary.writer = await params.prepareWriteError();
+    boundary.events.push("spawn");
+    return true;
+  },
+}));
+vi.mock("./entry.respawn.js", () => ({
+  buildCliRespawnPlan: () => ({ command: "node", argv: [], env: {} }),
+  runCliRespawnPlan: (_plan: unknown, _runtime: unknown, writer: typeof boundary.writer) => {
+    boundary.writer = writer;
+    boundary.events.push("spawn");
+  },
+}));
+
+const originalArgv = process.argv;
+const originalTitle = process.title;
+
+beforeEach(() => {
+  vi.resetModules();
+  boundary.events = [];
+  boundary.writer = undefined;
+  process.argv = [
+    process.execPath,
+    "/fixture/openclaw/dist/entry.js",
+    "plugins",
+    "enable",
+    "fixture",
+  ];
+});
+afterEach(() => {
+  process.argv = originalArgv;
+  process.title = originalTitle;
+  vi.restoreAllMocks();
+});
+
+it.each([
+  { mode: "flags", trace: false },
+  { mode: "flags", trace: true },
+  { mode: "compile-cache", trace: false },
+  { mode: "compile-cache", trace: true },
+] as const)(
+  "prepares $mode diagnostics only when needed (trace: $trace)",
+  async ({ mode, trace }) => {
+    boundary.mode = mode;
+    boundary.trace = trace;
+    const stderr = vi.spyOn(process.stderr, "write").mockImplementation(() => {
+      boundary.events.push("diagnostic");
+      return true;
+    });
+
+    await import("./entry.js");
+
+    expect(boundary.events).toEqual(trace ? ["dotenv", "trace formatting", "spawn"] : ["spawn"]);
+    expect(stderr).not.toHaveBeenCalled();
+    expect(boundary.writer).toBeTypeOf("function");
+    await boundary.writer?.("startup failed");
+    expect(boundary.events).toEqual(
+      trace
+        ? ["dotenv", "trace formatting", "spawn", "diagnostic"]
+        : ["spawn", "dotenv", "trace formatting", "diagnostic"],
+    );
+    expect(stderr).toHaveBeenCalledWith(expect.stringContaining("startup failed"));
+  },
+);

--- a/src/entry.respawn.ts
+++ b/src/entry.respawn.ts
@@ -29,7 +29,7 @@ type CliRespawnPlan = {
 };
 
 type CliRespawnRuntime = RespawnChildRuntime & {
-  writeError: (message: string, error?: unknown) => void;
+  writeError: (message: string, error?: unknown) => void | Promise<void>;
 };
 
 function pathModuleForPlatform(platform: NodeJS.Platform): typeof path.posix {
@@ -180,7 +180,7 @@ export function runCliRespawnPlan(
     detachForProcessTree: plan.detachForProcessTree,
     runtime: resolvedRuntime,
     onError: (error) => {
-      resolvedRuntime.writeError(
+      return resolvedRuntime.writeError(
         "[openclaw] Failed to respawn CLI:",
         error instanceof Error ? (error.stack ?? error.message) : error,
       );

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -59,30 +59,28 @@ async function writeCapturedCliArgumentError(message: string): Promise<void> {
   console.error(`[openclaw] ${message}`);
 }
 
-async function writeCliDiagnosticBlock(message: string): Promise<void> {
-  const { loadCliDotEnv } = await import("./cli/dotenv.js");
-  loadCliDotEnv({ quiet: true });
-  await configureGatewayStartupTraceConsoleFormatting(gatewayEntryStartupTrace);
-  const { formatConsoleDiagnosticBlock } = await import("./logging/json-console-line.js");
-  process.stderr.write(formatConsoleDiagnosticBlock({ level: "error", message: `${message}\n` }));
-}
-
 async function prepareCliDiagnosticBlockWriter(): Promise<
-  (message: string, error?: unknown) => void
+  (message: string, error?: unknown) => void | Promise<void>
 > {
-  const { loadCliDotEnv } = await import("./cli/dotenv.js");
-  loadCliDotEnv({ quiet: true });
-  await configureGatewayStartupTraceConsoleFormatting(gatewayEntryStartupTrace);
-  const { formatConsoleDiagnosticBlock } = await import("./logging/json-console-line.js");
-  return (message, error) => {
-    const formatted = error === undefined ? message : format(message, error);
-    process.stderr.write(
-      formatConsoleDiagnosticBlock({
-        level: "error",
-        message: formatted.endsWith("\n") ? formatted : `${formatted}\n`,
-      }),
-    );
+  const loadWriter = async (): Promise<(message: string, error?: unknown) => void> => {
+    const { loadCliDotEnv } = await import("./cli/dotenv.js");
+    loadCliDotEnv({ quiet: true });
+    await configureGatewayStartupTraceConsoleFormatting(gatewayEntryStartupTrace);
+    const { formatConsoleDiagnosticBlock } = await import("./logging/json-console-line.js");
+    return (message, error) => {
+      const formatted = error === undefined ? message : format(message, error);
+      process.stderr.write(
+        formatConsoleDiagnosticBlock({
+          level: "error",
+          message: formatted.endsWith("\n") ? formatted : `${formatted}\n`,
+        }),
+      );
+    };
   };
+  // Explicit traces flush before spawn; successful untraced parents need no diagnostics.
+  return gatewayEntryStartupTrace.enabled
+    ? loadWriter()
+    : async (message, error) => (await loadWriter())(message, error);
 }
 
 async function flushEntryStartupTraceForEarlyReturn(argv: string[]): Promise<void> {
@@ -238,7 +236,8 @@ export async function tryHandleRootHelpFastPath(
     deps.onError ??
     (async (error: unknown) => {
       const detail = error instanceof Error ? (error.stack ?? error.message) : String(error);
-      await writeCliDiagnosticBlock(`[openclaw] Failed to display help: ${detail}`);
+      const writeError = await prepareCliDiagnosticBlockWriter();
+      await writeError(`[openclaw] Failed to display help: ${detail}\n`);
       process.exit(1);
     });
   try {

--- a/src/process/respawn-child-runner.test.ts
+++ b/src/process/respawn-child-runner.test.ts
@@ -2,6 +2,7 @@
 import type { ChildProcess, spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../shared/deferred.js";
 
 const signalProcessTreeMock = vi.hoisted(() => vi.fn());
 
@@ -231,6 +232,65 @@ describe("runRespawnChildWithSignalBridge", () => {
 
     expect(onError).toHaveBeenCalledWith(error);
     expect(exit).toHaveBeenCalledWith(1);
+  });
+
+  it.each(["resolve", "reject"] as const)(
+    "waits for asynchronous spawn diagnostics to %s before exiting",
+    async (settlement) => {
+      const { child } = createChild();
+      const reporting = createDeferredCore();
+      const onError = vi.fn(() => reporting.promise);
+      const exit = vi.fn<RespawnChildRuntime["exit"]>();
+      runRespawnChildWithSignalBridge({
+        command: "missing-command",
+        args: [],
+        env: {},
+        runtime: {
+          spawn: vi.fn(() => child) as unknown as typeof spawn,
+          attachChildProcessBridge: vi.fn(),
+          exit,
+        },
+        onError,
+      });
+
+      const error = new Error("spawn failed");
+      try {
+        child.emit("error", error);
+        expect(onError).toHaveBeenCalledExactlyOnceWith(error);
+        expect(exit).not.toHaveBeenCalled();
+      } finally {
+        if (settlement === "resolve") {
+          reporting.resolve();
+        } else {
+          reporting.reject(new Error("formatter unavailable"));
+        }
+        await reporting.promise.catch(() => undefined);
+      }
+      await vi.waitFor(() => expect(exit).toHaveBeenCalledExactlyOnceWith(1));
+    },
+  );
+
+  it("preserves synchronous spawn exceptions without starting diagnostics", () => {
+    const error = new Error("invalid spawn options");
+    const onError = vi.fn();
+    const exit = vi.fn<RespawnChildRuntime["exit"]>();
+    expect(() =>
+      runRespawnChildWithSignalBridge({
+        command: "node",
+        args: [],
+        env: {},
+        runtime: {
+          spawn: vi.fn(() => {
+            throw error;
+          }) as unknown as typeof spawn,
+          attachChildProcessBridge: vi.fn(),
+          exit,
+        },
+        onError,
+      }),
+    ).toThrow(error);
+    expect(onError).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
   });
 
   it("keeps escalation active across repeated operational errors", () => {

--- a/src/process/respawn-child-runner.ts
+++ b/src/process/respawn-child-runner.ts
@@ -20,7 +20,7 @@ export function runRespawnChildWithSignalBridge(params: {
   detachForProcessTree?: boolean;
   stdioIsTerminal?: boolean;
   runtime: RespawnChildRuntime;
-  onError: (error: unknown) => void;
+  onError: (error: unknown) => void | Promise<void>;
 }): ChildProcess {
   const { command, args, env, runtime, onError } = params;
   const stdioIsTerminal = params.stdioIsTerminal ?? (process.stdin.isTTY || process.stdout.isTTY);
@@ -125,8 +125,14 @@ export function runRespawnChildWithSignalBridge(params: {
       return;
     }
     clearSignalTimers();
-    onError(error);
-    runtime.exit(1);
+    const reporting = onError(error);
+    const exit = () => runtime.exit(1);
+    // A failed spawn retains async diagnostics until settled, including formatter failure.
+    if (reporting) {
+      void reporting.then(exit, exit);
+    } else {
+      exit();
+    }
   });
 
   return child;


### PR DESCRIPTION
## What Problem This Solves

Successful CLI respawns prepared an error writer after the child environment was already snapshotted. That unnecessarily loaded dotenv, provider/plugin metadata, and diagnostic modules in the parent before starting the child, which then loaded most of the same modules again.

## Why This Change Was Made

Defer that preparation until a spawn failure needs it. Explicit startup tracing keeps its existing eager dotenv and formatting order before spawn. The shared respawn owner waits for asynchronous diagnostics before exit 1, including a rejected formatter, while synchronous reporting, synchronous spawn exceptions, and signal/TTY behavior retain their existing semantics. Root-help failures now use the same diagnostic writer instead of duplicating its setup.

No new config, environment controls, CLI flags, dependencies, schema, or persistence behavior. Production delta is +7 lines: the existing process owner now retains asynchronous error reporting through settlement.

## User Impact

Successful untraced respawns avoid loading diagnostic dependencies in the parent. Failed starts retain formatted, redacted error output before exit; explicitly enabled startup tracing keeps its existing order.

## Evidence

- Regressions failed on unchanged main for both untraced entry paths and for premature exit before asynchronous diagnostics settled. All 103 focused tests passed, including existing signal/escalation and synchronous error cases; final targeted retests passed.
- Core and core-test types, formatting, dead exports, lint, and the complete remaining changed-check guard sequence passed. Schema remains v16.
- Untouched baseline and candidate full builds share base `3fbd8f5739ba6d0622c8bbecad83ad54b90d5030`. Real packaged CLI enablement and canonical readback passed on both; observed processes exited and were verified absent.
- Parent module loads fell from 635 to 169; the child still loaded 2,150. Most removed parent imports are also needed by the child, so this is not a claim of 466 fewer unique cloud file reads.
- A fixed local comparison used one recorded warmup each and four balanced AB/BA pairs, fresh process/state/compile cache per run, and no profiler/import hook. Median wall time was 3.818 s before and 3.568 s after; recorded child CPU medians were 4.067 s and 3.818 s. All samples are retained. Host load/OS cache was uncontrolled, and this is not cloud/EBS proof.
- Real local failed-spawn probes recorded ENOENT with no child PID. Packaged and source compile-cache paths preserve empty stdout, JSON error output, dotenv-backed custom redaction, and parent trace-before-error ordering. A subsequent diagnostic import rejection exits 1 without raw fallback output or an unhandled rejection.
- Managed P0–P2 review was clean (0.94). The only later edit omitted a redundant default `void` type argument in a test; production bytes match the reviewed and built input, and final test/type/lint checks passed.

The failed-spawn probes use synthetic local executables and temporary state created by the normal config CLI. No live cloud state or credentials were involved. The changed CLI flow was live-tested locally. Candidate cloud latency remains unmeasured and no cloud speedup is claimed; the broader latest-main cloud flow is separate follow-up work.
