### PR TITLE
docs: explain Control UI browser setup in Docker

### DIFF
--- a/docs/install/docker.md
+++ b/docs/install/docker.md
@@ -44,7 +44,7 @@ Hosting multiple users? See [Multi-tenant hosting](/gateway/multi-tenant-hosting
     ./scripts/docker/setup.sh
     ```
 
-    Use `ghcr.io/openclaw/openclaw` or `openclaw/openclaw` and avoid unofficial mirrors, which don't share OpenClaw's release timing or retention policy. Version-specific tags include releases such as `2026.9.3` and prereleases such as `2026.9.1-beta.1`. Stable releases move `latest` and `main`; trailing-month Gateway releases move only `extended-stable`. Variants include `slim`, `main-slim`, `extended-stable-slim`, `latest-browser`, `main-browser`, and `extended-stable-browser`. The default images bundle the `codex` and `diagnostics-otel` plugins. A `-browser` variant also ships with Chromium baked in, useful for the [sandboxed browser](/gateway/sandboxing#sandboxed-browser) tool without a first-run Playwright install.
+    Use `ghcr.io/openclaw/openclaw` or `openclaw/openclaw` and avoid unofficial mirrors, which don't share OpenClaw's release timing or retention policy. Version-specific tags include releases such as `2026.9.3` and prereleases such as `2026.9.1-beta.1`. Stable releases move `latest` and `main`; trailing-month Gateway releases move only `extended-stable`. Variants include `slim`, `main-slim`, `extended-stable-slim`, `latest-browser`, `main-browser`, and `extended-stable-browser`. The default images bundle the `codex` and `diagnostics-otel` plugins. A `-browser` variant also ships with Chromium baked in for the [Gateway-controlled browser](/install/docker#using-the-control-ui-browser). The agent sandbox browser uses a separate image.
 
   </Step>
 
@@ -104,6 +104,70 @@ Hosting multiple users? See [Multi-tenant hosting](/gateway/multi-tenant-hosting
 
   </Step>
 </Steps>
+
+### Using the Control UI browser
+
+The [Control UI Browser panel](/web/control-ui/panels#browser-panel) displays a
+browser controlled by the Gateway. It is separate from the browser on your laptop
+or phone that opens the dashboard. For a local managed browser with a Docker
+Gateway, Chromium must be available **inside the Gateway container**.
+
+For a new installation, use the official browser-equipped image with the normal
+Compose setup; no custom Dockerfile is needed:
+
+```bash
+export OPENCLAW_IMAGE="ghcr.io/openclaw/openclaw:latest-browser"
+./scripts/docker/setup.sh
+```
+
+For a pinned deployment, choose a release's `-browser` tag instead of the moving
+`latest-browser` tag. For an existing Compose installation, change `OPENCLAW_IMAGE`
+in its `.env` to the browser variant, then pull and recreate the Gateway using
+the same Compose files and overlays as your current deployment:
+
+```bash
+docker compose pull openclaw-gateway openclaw-cli
+docker compose up -d openclaw-gateway
+```
+
+Keep your existing volumes, ports, and other settings. Do not rerun setup with an
+empty shell environment to change only the image: setup rewrites `.env` from the
+current shell and defaults.
+
+An existing home volume or bind mount covering `/home/node/.cache/ms-playwright`
+can hide the image's bundled Chromium. If browser discovery still fails after the
+image switch, check those mounts. Preserve the data, then either provision
+Chromium in the mounted home or adjust the mounts to leave the image's browser
+cache visible; recreating the container does not refresh a populated home volume.
+
+For a new installation from a local source build, bake Chromium into the image:
+
+```bash
+OPENCLAW_IMAGE=openclaw:local OPENCLAW_INSTALL_BROWSER=1 ./scripts/docker/setup.sh
+```
+
+This build-time option installs Chromium and Xvfb; setting it on
+an already-built container does not install a browser.
+
+The image supplies Chromium, not a replacement for your browser configuration:
+
+- Keep browser control enabled (`browser.enabled`). Use a local managed profile
+  such as `openclaw` for the container's Chromium, not an extension, attach-only,
+  or remote-CDP profile intended for another browser.
+- OpenClaw auto-detects the image's Playwright-managed Chromium on Linux. An
+  explicit `browser.executablePath` or profile executable path must point to a
+  binary inside the container; a path from your laptop will not work there.
+- A headless container needs headless browser operation. Check explicit
+  `browser.headless`, profile headless settings, and `OPENCLAW_BROWSER_HEADLESS`
+  overrides if startup reports a missing display. See [Browser configuration](/tools/browser-control).
+- Connect with `operator.admin` access to a Gateway advertising `browser.request`.
+  Open **+ → Browser** in the Chat side panel, navigate to a page, and confirm that
+  its snapshot loads and navigation works. Loading the dashboard alone does not
+  verify that Chromium can start.
+
+This is not the separate [sandboxed browser](/gateway/sandboxing#sandboxed-browser)
+container used by sandboxed agent sessions. Selecting a Gateway `-browser` image
+does not build or configure that sandbox image.
 
 ### Headless bootstrap
 

--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -61,6 +61,8 @@ Local onboarding generates a Gateway secret in token mode by default, without a 
 - [Security model](/web/control-ui/security-model) — content security policy, media route auth, and approval links.
 - [Build and develop](/web/control-ui/development) — build the UI and run the dev server against a Gateway.
 
+Running the Gateway in Docker? See [Using the Control UI browser](/install/docker#using-the-control-ui-browser) for the browser-equipped image and setup requirements.
+
 ## Where each section moved
 
 Every section heading from the previous single-page version keeps its anchor here, so an existing link such as `/web/control-ui#chat-behavior` still resolves. Each entry points at the page that now holds the content.


### PR DESCRIPTION
## What Problem This Solves

Resolves a documentation gap where Docker users looking for the Control UI Browser panel setup are directed toward the separate sandbox browser. The Docker guide lists the official browser image but does not connect it to that panel or explain where Chromium needs to run.

## Why This Change Was Made

Adds one setup section using the official GHCR browser image and existing Compose workflow, with a cross-link from the Control UI overview. Distinguishes the dashboard client, Gateway-controlled Chromium, and agent sandbox browser; preserves existing deployment settings and explains configuration overrides. No runtime, default, dependency, or security-setting changes.

## User Impact

Users can find the prebuilt image or source-build option without inventing a custom Dockerfile, and check the browser profile, executable path, headless settings, and operator permissions before testing the panel.

## Evidence

- Verified the instructions against the current Dockerfile, Compose file, setup script, browser config/executable discovery, and Browser panel documentation.
- `node_modules/.bin/oxfmt --check docs/install/docker.md docs/web/control-ui.md`: passed.
- `node scripts/check-docs-mdx.mjs docs/install/docker.md docs/web/control-ui.md`: passed (2 files).
- Markdownlint 0.41.1 API with the repository config: both changed files passed (no findings).
- `git diff --check`: passed.
- Independent native Codex review completed; fixed its persistent-home-volume cache-masking finding and obtained a clean follow-up. The standalone autoreview helper failed before returning a verdict, so it is not counted as coverage.
- `node scripts/docs-link-audit.mjs --anchors`: checked 9,410 links; no failures in the changed pages. Its 37 failures are missing external ClawHub routes, documented by `docs/AGENTS.md` as requiring the separate ClawHub checkout.
- Documentation-only validation: no fresh Docker deployment or live panel test was performed; these checks do not establish container runtime proof.

Scope: two documentation pages, about 60 added lines. Rollback is a docs-only revert. AI-assisted.
