### PR TITLE
refactor(tests): consolidate WebSocket ping fixtures

### DIFF
--- a/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
+++ b/apps/shared/OpenClawKit/Tests/OpenClawKitTests/GatewayNodeSessionTests.swift
@@ -36,13 +36,17 @@ private actor StringCapture {
     }
 }
 
-/// Delivers a pong asynchronously, well before the deadline, so a cancelled deadline
-/// task racing the gate would surface as a spurious timeout.
-private final class DelayedPongWebSocketTask: WebSocketTasking, @unchecked Sendable {
-    private let delay: Duration
+private final class PingWebSocketTask: WebSocketTasking, @unchecked Sendable {
+    enum Behavior {
+        case delayed(Duration)
+        case omitted
+        case callbacks([Error?])
+    }
 
-    init(delay: Duration) {
-        self.delay = delay
+    private let behavior: Behavior
+
+    init(_ behavior: Behavior) {
+        self.behavior = behavior
     }
 
     var state: URLSessionTask.State {
@@ -60,80 +64,18 @@ private final class DelayedPongWebSocketTask: WebSocketTasking, @unchecked Senda
     }
 
     func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void) {
-        let delay = self.delay
-        Task {
-            try? await Task.sleep(for: delay)
-            pongReceiveHandler(nil)
-        }
-    }
-
-    func receive() async throws -> URLSessionWebSocketTask.Message {
-        throw URLError(.badServerResponse)
-    }
-
-    func receive(
-        completionHandler: @escaping @Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)
-    {
-        completionHandler(.failure(URLError(.badServerResponse)))
-    }
-}
-
-/// Mirrors URLSession dropping a pong handler outright when the task is cancelled or
-/// closed mid-flight: the ping is accepted and no callback ever arrives.
-private final class SilentPingWebSocketTask: WebSocketTasking, @unchecked Sendable {
-    var state: URLSessionTask.State {
-        .running
-    }
-
-    func resume() {}
-
-    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
-        _ = (closeCode, reason)
-    }
-
-    func send(_ message: URLSessionWebSocketTask.Message) async throws {
-        _ = message
-    }
-
-    func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void) {
-        _ = pongReceiveHandler
-    }
-
-    func receive() async throws -> URLSessionWebSocketTask.Message {
-        throw URLError(.badServerResponse)
-    }
-
-    func receive(
-        completionHandler: @escaping @Sendable (Result<URLSessionWebSocketTask.Message, Error>) -> Void)
-    {
-        completionHandler(.failure(URLError(.badServerResponse)))
-    }
-}
-
-private final class DoubleCallbackPingWebSocketTask: WebSocketTasking, @unchecked Sendable {
-    private let callbacks: [Error?]
-
-    init(callbacks: [Error?]) {
-        self.callbacks = callbacks
-    }
-
-    var state: URLSessionTask.State {
-        .running
-    }
-
-    func resume() {}
-
-    func cancel(with closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
-        _ = (closeCode, reason)
-    }
-
-    func send(_ message: URLSessionWebSocketTask.Message) async throws {
-        _ = message
-    }
-
-    func sendPing(pongReceiveHandler: @escaping @Sendable (Error?) -> Void) {
-        for callback in self.callbacks {
-            pongReceiveHandler(callback)
+        switch self.behavior {
+        case let .delayed(delay):
+            Task {
+                try? await Task.sleep(for: delay)
+                pongReceiveHandler(nil)
+            }
+        case .omitted:
+            _ = pongReceiveHandler
+        case let .callbacks(callbacks):
+            for callback in callbacks {
+                pongReceiveHandler(callback)
+            }
         }
     }
 
@@ -1241,7 +1183,7 @@ struct GatewayNodeSessionTests {
     func `websocket ping times out when no pong callback ever arrives`() async throws {
         // Without the deadline this await never returns: the checked continuation is
         // orphaned, Swift logs CONTINUATION MISUSE, and the keepalive loop wedges forever.
-        let task = SilentPingWebSocketTask()
+        let task = PingWebSocketTask(.omitted)
 
         do {
             try await WebSocketTaskBox(task: task).sendPing(timeout: .milliseconds(50))
@@ -1256,7 +1198,7 @@ struct GatewayNodeSessionTests {
         // Cancelling the deadline makes Task.sleep throw; if that cancellation were
         // swallowed the deadline task would fall through and race the pong callback,
         // reporting a healthy ping as timed out.
-        let task = DelayedPongWebSocketTask(delay: .milliseconds(20))
+        let task = PingWebSocketTask(.delayed(.milliseconds(20)))
 
         for _ in 0..<20 {
             try await WebSocketTaskBox(task: task).sendPing(timeout: .seconds(5))
@@ -1265,14 +1207,14 @@ struct GatewayNodeSessionTests {
 
     @Test
     func `websocket ping ignores duplicate success callbacks`() async throws {
-        let task = DoubleCallbackPingWebSocketTask(callbacks: [nil, nil])
+        let task = PingWebSocketTask(.callbacks([nil, nil]))
         try await WebSocketTaskBox(task: task).sendPing()
     }
 
     @Test
     func `websocket ping ignores duplicate callbacks after first error`() async throws {
         let firstError = URLError(.networkConnectionLost)
-        let task = DoubleCallbackPingWebSocketTask(callbacks: [firstError, nil])
+        let task = PingWebSocketTask(.callbacks([firstError, nil]))
 
         do {
             try await WebSocketTaskBox(task: task).sendPing()


### PR DESCRIPTION
## What Problem This Solves

Four WebSocket ping regressions use three private fake tasks that repeat every protocol member except pong delivery. The repeated transport scaffolding makes their actual timing and callback differences harder to see.

## Why This Change Was Made

Use one private fake with an immutable, explicit delayed/omitted/callback-list behavior. Preserve asynchronous delayed pongs, discarded omitted handlers, synchronous callback order, fresh task instances, and all four existing test bodies. Removes 58 net test lines with no production changes.

## User Impact

No user-visible behavior change. Missing-pong timeout, healthy delayed pong, duplicate success, and first-error handling remain independently covered. The healthy-pong case retains its 20 repetitions and every deadline stays unchanged.

## Evidence

- Static comparison verifies all six shared protocol members, all three behavior branches, and the complete remaining file/four test bodies after constructor normalization.
- SwiftFormat passed without changes. The normal mapped changed gate passed, including 1,132 Node/Vitest macOS script-fixture tests; these are not Swift runtime proof.
- Direct SwiftLint reports the same six existing findings before and after, shifted by the removed lines: file/type size, for-where, and three multiline argument findings. No new violation or suppression was introduced.
- Fresh P2 review passed. Exact-head macOS CI compiled the target in fresh scratch and ran the unfiltered OpenClawKit suite: 1,668 tests across 128 suites passed, including GatewayNodeSessionTests. The raw log records three ping passes but omits the missing-pong case and ten other test names; all four unconditional test registrations and bodies remain unchanged. Full-suite execution plus static equivalence supplies the native proof; no fourth individual console receipt is claimed.
- No native app, Swift test, signing, or credential operation ran on the operator desktop. No runtime improvement is claimed.
