### PR TITLE
refactor: reduce duplicate queue work in error handling

### DIFF
--- a/packages/normalization-core/src/error-coercion.ts
+++ b/packages/normalization-core/src/error-coercion.ts
@@ -297,25 +297,22 @@ export function collectErrorGraphCandidates(
   err: unknown,
   resolveNested?: (current: Record<string, unknown>) => Iterable<unknown>,
 ): unknown[] {
-  const queue: unknown[] = [err];
-  const seen = new Set<unknown>();
-  const candidates: unknown[] = [];
+  if (err == null) {
+    return [];
+  }
+  const candidates: unknown[] = [err];
+  const seen = new Set<unknown>().add(err);
 
-  while (queue.length > 0) {
-    const current = queue.shift();
-    if (current == null || seen.has(current)) {
-      continue;
-    }
-    seen.add(current);
-    candidates.push(current);
-
+  // First discovery fixes breadth-first order; the returned array is also the worklist.
+  for (const current of candidates) {
     if (!current || typeof current !== "object" || !resolveNested) {
       continue;
     }
     // SAFETY: Non-object nodes were excluded before the callback reads optional graph links.
     for (const nested of resolveNested(current as Record<string, unknown>)) {
       if (nested != null && !seen.has(nested)) {
-        queue.push(nested);
+        seen.add(nested);
+        candidates.push(nested);
       }
     }
   }

--- a/src/infra/errors.test.ts
+++ b/src/infra/errors.test.ts
@@ -96,6 +96,15 @@ describe("error helpers", () => {
       },
     };
     expect(() => readErrorCause(error)).toThrow(failure);
+    let caught: unknown;
+    try {
+      collectErrorGraphCandidates(error, function* (current) {
+        yield readErrorCause(current);
+      });
+    } catch (caughtError) {
+      caught = caughtError;
+    }
+    expect(caught).toBe(failure);
   });
 
   it("walks nested error graphs once in breadth-first order", () => {
@@ -108,13 +117,33 @@ describe("error helpers", () => {
     const root = { name: "root", cause: child, errors: [leaf, child] };
     child.cause = root;
 
-    expect(
-      collectErrorGraphCandidates(root, (current) => [
-        current.cause,
-        ...((current as { errors?: unknown[] }).errors ?? []),
-      ]),
-    ).toEqual([root, child, leaf]);
+    const events: string[] = [];
+    const candidates = collectErrorGraphCandidates(root, function* (current) {
+      events.push(`${String(current.name)}:start`);
+      yield current.cause;
+      yield* (current as { errors?: unknown[] }).errors ?? [];
+      events.push(`${String(current.name)}:end`);
+    });
+    expect(candidates).toEqual([root, child, leaf]);
+    expect(events).toEqual([
+      "root:start",
+      "root:end",
+      "child:start",
+      "child:end",
+      "leaf:start",
+      "leaf:end",
+    ]);
     expect(collectErrorGraphCandidates(null)).toStrictEqual([]);
+    expect(collectErrorGraphCandidates(undefined)).toStrictEqual([]);
+  });
+
+  it.each([-0, 0])("retains the first signed zero at the root and through links: %#", (first) => {
+    const root = {};
+    const candidates = collectErrorGraphCandidates(root, () => [first, -first]);
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0]).toBe(root);
+    expect(Object.is(candidates[1], first)).toBe(true);
+    expect(Object.is(collectErrorGraphCandidates(first)[0], first)).toBe(true);
   });
 
   it("walks every canonical wrapper edge once despite duplicates and cycles", () => {


### PR DESCRIPTION
## What Problem This Solves

Formatting and classifying errors with repeated or cyclic causes does unnecessary queue work. Shared nodes can enter the pending queue repeatedly, only to be discarded when visited.

## Why This Change Was Made

Use the returned candidates array as the breadth-first worklist and mark nodes when first discovered. This removes the separate queue and its front removals while retaining first-discovery order, original references, complete resolver iteration, exception propagation, and the first signed-zero representation. The already non-nullish root initializes the Set directly.

The shared normalization owner changes; formatter/redaction policy, network retry policy, and delivery no-send decisions do not. Production delta: 9 added / 12 removed (net −3). Test delta: 35 added / 6 removed (net +29), extending existing behavior coverage without a new production seam.

## User Impact

Less local error-processing work for shared graphs, with unchanged diagnostic text and classification decisions. Small cases are mixed; this does not establish an overall Gateway latency or memory improvement.

## Evidence

- 40 baseline preservation tests retained; fresh candidate run passed all 134 focused tests across four files, including normalization, diagnostics, process-level handling, and delivery policy.
- Formatting unchanged; all 29 changed-code checks passed. Fresh independent P2 review found no actionable findings.
- Fixed 24-case baseline/candidate/candidate/baseline measurement on Node 26.8.1: all 3,744 complete returned strings/booleans matched literal expectations. This includes 288 untimed first/warm calls and 3,456 timed calls in 864 four-call intervals. Timed intervals include the call loop/result assignment; verification and output journaling occur afterward.
- Actual production exports measured: the redacting formatter, transient-network classifier, and delivery no-send classifier. No mocked replacement helper, network delivery, or model turn is used in this component benchmark.

All paired median changes are below; negative means less elapsed time. These are median four-call interval costs normalized per call, not isolated individual-call latency percentiles.

| Case | B0 → C0 | B1 → C1 |
| --- | ---: | ---: |
| undefined/format | +2.30% | -3.81% |
| undefined/transient | +0.00% | +9.83% |
| undefined/not-sent | -29.38% | -24.92% |
| single/format | -2.88% | +1.25% |
| single/transient | +2.05% | +5.25% |
| single/not-sent | -6.19% | -38.93% |
| chain3/format | -0.20% | -10.72% |
| chain3/transient | +12.75% | -37.26% |
| chain3/not-sent | +4.49% | +4.65% |
| shared8/format | +5.47% | -4.57% |
| shared8/transient | -9.18% | -12.49% |
| shared8/not-sent | +20.51% | -18.69% |
| shared64/format | -17.41% | -13.63% |
| shared64/transient | -38.87% | -37.29% |
| shared64/not-sent | -34.40% | -20.98% |
| cyclic-diamond/format | -11.28% | -5.82% |
| cyclic-diamond/transient | -1.48% | -9.36% |
| cyclic-diamond/not-sent | -10.02% | +23.93% |
| unknown-branch/format | -8.31% | +13.32% |
| unknown-branch/transient | -14.17% | +1.20% |
| unknown-branch/not-sent | -4.50% | -5.38% |
| terminal-veto/format | -7.17% | +1.95% |
| terminal-veto/transient | -8.95% | -10.46% |
| terminal-veto/not-sent | -5.49% | -2.37% |

Of 48 median comparisons, 33 improved, 14 regressed, and one was unchanged. Across median/mean/minimum/maximum, 45 of 192 aggregate comparisons were adverse. The largest retained outlier was the forward unknown-branch formatter: mean +443.70%, maximum +2661.34%, despite its lower median. Shared-8 delivery and several small/reverse-order rows also regressed; no samples were discarded.

Whole-child resources include module loading and all workload/verification/journaling work. They do not isolate queue cost:

| Resource | B0 | C0 | B1 | C1 |
| --- | ---: | ---: | ---: | ---: |
| Wall (s) | 0.4986 | 0.3581 | 0.3762 | 0.3500 |
| User CPU (s) | 0.4001 | 0.3806 | 0.3777 | 0.3747 |
| System CPU (s) | 0.1000 | 0.0890 | 0.0931 | 0.0878 |
| Kernel child max RSS (MiB) | 136.4844 | 137.5469 | 139.0625 | 138.3438 |
| Observed process-tree peak RSS (MiB) | 134.4062 | 124.1250 | 123.4062 | 126.4219 |

Owned test/review/measurement processes closed and the candidate was restored. Other host work was not globally stopped, so whole-child wall/RSS differences are not attributed solely to the patch. The campaign's real-provider Gateway baseline is separate and is not evidence of an end-to-end gain from this change.

The earlier iterable-seeded variant remains recorded separately (21/48 median comparisons adverse); this is a distinct direct-seeded candidate, not a pooled or selectively repeated run. Its mixed result does not establish an initialization-specific cause. An initial test-only lint failure was corrected by renaming a shadowed catch binding; that failed run remains retained.

Independent data audit verified all 3,744 returns, 864 intervals, 192 reduced metrics, source/dependency bindings and process closure. Two of ten resource comparisons were adverse: forward kernel maximum RSS +0.78% and reverse observed process-tree peak RSS +2.44%. No data-integrity finding remains.

Focused verification: `pnpm test packages/normalization-core/src/error-coercion.test.ts src/infra/errors.test.ts src/infra/outbound/delivery-queue.policy.test.ts src/infra/unhandled-rejections.test.ts`, followed by the normal changed-code gate against `8efdc03f8c0bb19623adbff4dbef29f969e63a07`.
