### PR TITLE
fix(setup): retain consent choices through roster reconciliation

### DIFF
--- a/src/wizard/setup.default-agent.test.ts
+++ b/src/wizard/setup.default-agent.test.ts
@@ -108,7 +108,10 @@ vi.mock("../commands/onboard-helpers.js", () => ({
 }));
 
 vi.mock("../commands/onboard-skills.js", () => ({ setupSkills: mocks.setupSkills }));
-vi.mock("../config/config.js", () => ({ resolveGatewayPort: () => 18789 }));
+vi.mock("../config/config.js", () => ({
+  resolveGatewayPort: () => 18789,
+  readConfigFileSnapshot: mocks.readSnapshot,
+}));
 vi.mock("../config/logging.js", () => ({ logConfigUpdated: vi.fn() }));
 vi.mock("../plugins/status.js", () => ({
   buildPluginCompatibilitySnapshotNotices: vi.fn(() => []),
@@ -170,6 +173,103 @@ describe("runSetupWizard default-agent ownership", () => {
       async ({ config: nextConfig }: { config: OpenClawConfig }) => nextConfig,
     );
     mocks.finalizeSetup.mockResolvedValue({ launchedTui: false });
+  });
+
+  it.each([false, true])(
+    "retains the telemetry choice %s when reconciling an authored main roster",
+    async (enabled) => {
+      const config = {
+        gateway: { mode: "local", port: 18789 },
+        agents: { entries: { main: {} } },
+      } satisfies OpenClawConfig;
+      mocks.readSnapshot.mockResolvedValue({
+        exists: true,
+        valid: true,
+        config,
+        sourceConfig: config,
+        sourceConfigBeforeMigrations: config,
+        issues: [],
+      });
+      vi.mocked(prompter.select).mockResolvedValue(enabled);
+      let persisted: OpenClawConfig | undefined;
+      mocks.writeConfig.mockImplementation(async (nextConfig: OpenClawConfig) => {
+        persisted = nextConfig;
+        return nextConfig;
+      });
+
+      await runSetupWizard(
+        {
+          acceptRisk: true,
+          flow: "quickstart",
+          mode: "local",
+          authChoice: "skip",
+          skipChannels: true,
+          skipSkills: true,
+          skipSearch: true,
+          skipHealth: true,
+          skipHooks: true,
+          skipUi: true,
+          installDaemon: false,
+        },
+        runtime,
+        prompter,
+      );
+
+      expect(persisted?.telemetry).toEqual({ enabled, consentedAt: expect.any(String) });
+      expect(persisted?.agents?.entries).toEqual({ main: {} });
+    },
+  );
+
+  it("keeps concurrent gateway settings while carrying the telemetry choice", async () => {
+    const config = {
+      gateway: { mode: "local", port: 18789 },
+      agents: { entries: { main: {} } },
+    } satisfies OpenClawConfig;
+    const current = { ...config, gateway: { ...config.gateway, port: 24444 } };
+    mocks.readSnapshot
+      .mockResolvedValueOnce({
+        exists: true,
+        valid: true,
+        config,
+        sourceConfig: config,
+        sourceConfigBeforeMigrations: config,
+        issues: [],
+      })
+      .mockResolvedValue({
+        exists: true,
+        valid: true,
+        config: current,
+        sourceConfig: current,
+        sourceConfigBeforeMigrations: current,
+        issues: [],
+      });
+    vi.mocked(prompter.select).mockResolvedValue(false);
+    let persisted: OpenClawConfig | undefined;
+    mocks.writeConfig.mockImplementation(async (nextConfig: OpenClawConfig) => {
+      persisted = nextConfig;
+      return nextConfig;
+    });
+
+    await runSetupWizard(
+      {
+        acceptRisk: true,
+        flow: "quickstart",
+        mode: "local",
+        authChoice: "skip",
+        skipChannels: true,
+        skipSkills: true,
+        skipSearch: true,
+        skipHealth: true,
+        skipHooks: true,
+        skipUi: true,
+        installDaemon: false,
+      },
+      runtime,
+      prompter,
+    );
+
+    expect(persisted?.telemetry).toEqual({ enabled: false, consentedAt: expect.any(String) });
+    expect(persisted?.gateway?.port).toBe(24444);
   });
 
   it("uses the keyed default-agent workspace for all classic agent-owned effects", async () => {

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -550,7 +550,8 @@ async function runSetupWizardOnce(
     config: gateway.nextConfig,
     workspace: workspaceDir,
     preserveCandidateRoster: usedImportFlow && hasAuthoredRoster,
-    baseConfig,
+    // Pending setup choices must remain changes relative to the saved snapshot.
+    baseConfig: currentSetupSnapshot.runtimeConfig ?? currentSetupSnapshot.config,
     ...(firstAgent ? { firstAgent } : {}),
   });
   nextConfig = onboardingAgent.config;


### PR DESCRIPTION
Classic setup could discard an answered telemetry preference when reconciling an existing bare `main` agent roster. The merge compared the candidate against a baseline that already contained the new choice, so the preference was missing from saved configuration even though onboarding completed.

Use the retained configuration snapshot as the roster-merge baseline. This preserves pending choices while keeping concurrent saved settings and existing agent ownership.

Validation:
- The current-main owner regression failed because the saved telemetry choice was absent.
- Four targeted checks pass: decline, accept, concurrent Gateway settings, and existing default-agent ownership.
- One isolated source-mode onboarding run saved the declined preference and its timestamp while preserving authored model rows, aliases, primary/fallback and the synthetic auth profile. No inference or repeated-prompt claim.
- Focused formatting, lint, boundary guards, ratchets and `git diff --check` pass. Local build and typecheck were not run.
