### PR TITLE
fix(docker): avoid hanging on resource-limit diagnostics

### DIFF
--- a/scripts/lib/docker-e2e-resource-diagnostics.sh
+++ b/scripts/lib/docker-e2e-resource-diagnostics.sh
@@ -121,7 +121,8 @@ docker_e2e_docker_run_with_resource_diagnostics() {
     return
   fi
 
-  "$tail_bin" -c 65536 <"$capture_fifo" >"$stderr_file" &
+  # Some tail implementations reopen named FIFOs passed through stdin and wait for a new writer.
+  "$tail_bin" -c 65536 "$capture_fifo" >"$stderr_file" &
   local tail_pid="$!"
   "$tee_bin" "$capture_fifo" <"$stderr_fifo" >&2 &
   local tee_pid="$!"

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -1429,7 +1429,8 @@ mktemp() {
 }
 
 tail() {
-  printf "%s\\n" "$*" >"$TMPDIR/tail-seen"
+  [[ "$#" = "3" && "$1" = "-c" && "$2" = "65536" && -p "$3" ]] || return 1
+  printf "%s %s\\n" "$1" "$2" >"$TMPDIR/tail-seen"
   /usr/bin/tail "$@"
 }
 
@@ -1446,15 +1447,15 @@ status="$?"
 set -e
 
 stderr="$(<"$TMPDIR/stderr")"
-[[ "$status" = "125" ]]
-[[ "$stderr" = before\\ Docker* ]]
-[[ "$stderr" = *"NanoCPUs can not be set"* ]]
-[[ "$stderr" = *"Docker E2E resource limits are incompatible with this Docker runtime"* ]]
-[[ "$stderr" = *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1"* ]]
-[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
-[[ "$(<"$TMPDIR/tail-seen")" = "-c 65536" ]]
-[[ "$(<"$TMPDIR/mktemp-seen")" = -d* ]]
-[[ ! -e "$(<"$TMPDIR/diagnostic-dir")" ]]
+[[ "$status" = "125" ]] || exit 1
+[[ "$stderr" = before\\ Docker* ]] || exit 1
+[[ "$stderr" = *"NanoCPUs can not be set"* ]] || exit 1
+[[ "$stderr" = *"Docker E2E resource limits are incompatible with this Docker runtime"* ]] || exit 1
+[[ "$stderr" = *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1"* ]] || exit 1
+[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]] || exit 1
+test "$(<"$TMPDIR/tail-seen")" = "-c 65536"
+[[ "$(<"$TMPDIR/mktemp-seen")" = -d* ]] || exit 1
+[[ ! -e "$(<"$TMPDIR/diagnostic-dir")" ]] || exit 1
 `,
     },
     {
@@ -1483,10 +1484,10 @@ status="$?"
 set -e
 
 stderr="$(<"$TMPDIR/stderr")"
-[[ "$status" = "125" ]]
-[[ "$stderr" = *"No such image: cgroup-helper"* ]]
-[[ "$stderr" != *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS"* ]]
-[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
+[[ "$status" = "125" ]] || exit 1
+[[ "$stderr" = *"No such image: cgroup-helper"* ]] || exit 1
+[[ "$stderr" != *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS"* ]] || exit 1
+[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]] || exit 1
 `,
     },
     {
@@ -1506,9 +1507,9 @@ OPENCLAW_DOCKER_E2E_PIDS_LIMIT=many docker_e2e_docker_cmd run demo 2>"$TMPDIR/st
 status="$?"
 set -e
 
-[[ "$status" = "2" ]]
-[[ "$(<"$TMPDIR/stderr")" = *"invalid OPENCLAW_DOCKER_E2E_PIDS_LIMIT: many"* ]]
-[[ ! -e "$TMPDIR/docker-seen" ]]
+[[ "$status" = "2" ]] || exit 1
+[[ "$(<"$TMPDIR/stderr")" = *"invalid OPENCLAW_DOCKER_E2E_PIDS_LIMIT: many"* ]] || exit 1
+[[ ! -e "$TMPDIR/docker-seen" ]] || exit 1
 `,
     },
     {
@@ -1532,9 +1533,9 @@ OPENCLAW_DOCKER_E2E_PIDS_LIMIT=many docker_e2e_docker_run_cmd run demo 2>"$TMPDI
 status="$?"
 set -e
 
-[[ "$status" = "2" ]]
-[[ "$(<"$TMPDIR/stderr")" = *"invalid OPENCLAW_DOCKER_E2E_PIDS_LIMIT: many"* ]]
-[[ ! -e "$TMPDIR/docker-seen" ]]
+[[ "$status" = "2" ]] || exit 1
+[[ "$(<"$TMPDIR/stderr")" = *"invalid OPENCLAW_DOCKER_E2E_PIDS_LIMIT: many"* ]] || exit 1
+[[ ! -e "$TMPDIR/docker-seen" ]] || exit 1
 `,
     },
     {
@@ -1567,11 +1568,11 @@ status="$?"
 set -e
 
 stderr="$(<"$TMPDIR/stderr")"
-[[ "$status" = "125" ]]
-[[ "$stderr" = *"controller pids is not available"* ]]
-[[ "$stderr" = *"Docker E2E resource limits are incompatible with this Docker runtime"* ]]
-[[ "$stderr" = *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1"* ]]
-[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]]
+[[ "$status" = "125" ]] || exit 1
+[[ "$stderr" = *"controller pids is not available"* ]] || exit 1
+[[ "$stderr" = *"Docker E2E resource limits are incompatible with this Docker runtime"* ]] || exit 1
+[[ "$stderr" = *"OPENCLAW_DOCKER_E2E_DISABLE_RESOURCE_LIMITS=1"* ]] || exit 1
+[[ "$(grep -c '^run ' "$TMPDIR/docker-seen")" = "1" ]] || exit 1
 `,
     },
     {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Fixes an issue where Docker E2E resource-limit diagnostics can hang on Linux systems using uutils coreutils 0.8.0. After Docker emits a short resource-limit error, tail can wait for another FIFO writer instead of completing the diagnostic.

## Why This Change Was Made

Pass the capture FIFO directly to tail instead of redirecting it through stdin. This avoids the implementation's pathname-resolution/reopen path while preserving the 65,536-byte tail limit, full stderr forwarding, Docker exit status, both child waits, and temporary-directory cleanup.

The existing short-error fixture verifies the limit and one real FIFO operand without assuming its pathname. Its assertions and 15 adjacent resource assertions now fail explicitly on Bash 3.2, where a failed standalone `[[ … ]]` can otherwise be masked despite `set -e`.

## User Impact

Resource-limit failures finish with their intended diagnostic and exit status on the affected Linux utility implementation. No dependency, timeout, resource-limit, or command-line option changes are introduced. This correctness repair adds one production line and one test line; it carries no aggregate runtime-improvement claim.

## Evidence

On the same Linux VM with uutils 0.8.0, the original targeted case hit the 120-second watchdog (121.4 seconds observed), with stable pre-signal samples showing Bash waiting for tail and tail waiting for a FIFO partner. The patched case passed, followed by all 276 tests selected by the frozen Docker test owner. The comparison driver still returned 1 because its inventory check incorrectly expected two files: that source revision routes the suppression sibling through the unit-fast owner. That wrapper failure is retained rather than reported as a passing comparison driver.

The suppression sibling then passed all four original cases with zero skips under its unit-fast owner. The native run exited 0 and joined its children; source/tree hashes remained unchanged from the patched comparison.

Locally, five resource/package cases passed, the old-helper/new-guard control failed as intended, and 16 synthetic shell controls demonstrated that four regressions masked by the original assertions are rejected by explicit exits. The full mapped changed gate, shell syntax, formatting, deslop, and fresh independent P2 review passed. Source and C44-derived patch/tree hashes are bound in the retained proof. No real Docker daemon was needed for the synthetic fixture cases.
