### PR TITLE
fix(docker): resolve fs-safe manifest through public export

### DIFF
--- a/scripts/docker/verify-fs-safe-native.mjs
+++ b/scripts/docker/verify-fs-safe-native.mjs
@@ -42,7 +42,7 @@ const requireFromPackage = createRequire(path.join(packageRoot, "package.json"))
 // `package.json` is not a public fs-safe export. Its public root entry is,
 // and the manifest beside that resolved entry declares platform packages.
 const fsSafeEntryPath = requireFromPackage.resolve("@openclaw/fs-safe");
-const fsSafeManifestPath = path.resolve(fsSafeEntryPath, "..", "package.json");
+const fsSafeManifestPath = path.resolve(fsSafeEntryPath, "..", "..", "package.json");
 const fsSafeManifest = JSON.parse(await fsPromises.readFile(fsSafeManifestPath, "utf8"));
 const requireFromFsSafe = createRequire(fsSafeManifestPath);
 const platformPackageNames = Object.keys(fsSafeManifest.optionalDependencies ?? {}).filter((name) =>

--- a/scripts/docker/verify-fs-safe-native.mjs
+++ b/scripts/docker/verify-fs-safe-native.mjs
@@ -39,7 +39,10 @@ if (fsSafeNativeContract === "not-applicable") {
 
 const { mode, packageRoot } = parseArgs(process.argv.slice(2));
 const requireFromPackage = createRequire(path.join(packageRoot, "package.json"));
-const fsSafeManifestPath = requireFromPackage.resolve("@openclaw/fs-safe/package.json");
+// `package.json` is not a public fs-safe export. Its public root entry is,
+// and the manifest beside that resolved entry declares platform packages.
+const fsSafeEntryPath = requireFromPackage.resolve("@openclaw/fs-safe");
+const fsSafeManifestPath = path.resolve(fsSafeEntryPath, "..", "package.json");
 const fsSafeManifest = JSON.parse(await fsPromises.readFile(fsSafeManifestPath, "utf8"));
 const requireFromFsSafe = createRequire(fsSafeManifestPath);
 const platformPackageNames = Object.keys(fsSafeManifest.optionalDependencies ?? {}).filter((name) =>

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6197,7 +6197,7 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
     writeFileSync(join(physicalRoot, "package.json"), '{"name":"openclaw"}');
     writeFileSync(
       join(physicalRoot, "cli.cjs"),
-      'process.stdout.write(require.resolve("@openclaw/fs-safe/package.json"));',
+      'process.stdout.write(require.resolve("@openclaw/fs-safe"));',
     );
     writeFileSync(
       join(fsSafe, "package.json"),
@@ -6205,12 +6205,13 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
         name: "@openclaw/fs-safe",
         type: "module",
         exports: {
-          "./package.json": "./package.json",
+          ".": "./index.js",
           "./config": "./config.js",
           "./durability": "./durability.js",
         },
       }),
     );
+    writeFileSync(join(fsSafe, "index.js"), "export {};\n");
     writeFileSync(
       join(fsSafe, "config.js"),
       'export function configureFsSafeNative({ mode }) { if (mode !== "off") throw new Error("fixture requires fallback mode"); }',
@@ -6228,7 +6229,7 @@ export async function sha256File(file) {
     symlinkSync(physicalRoot, logicalRoot, process.platform === "win32" ? "junction" : "dir");
     expect(
       execFileSync(process.execPath, [join(logicalRoot, "cli.cjs")], { encoding: "utf8" }),
-    ).toBe(join(fsSafe, "package.json"));
+    ).toBe(join(fsSafe, "index.js"));
     for (const packageRoot of [physicalRoot, logicalRoot]) {
       const result = spawnSync(
         process.execPath,

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6205,13 +6205,14 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-logs.sh"
         name: "@openclaw/fs-safe",
         type: "module",
         exports: {
-          ".": "./index.js",
+          ".": "./dist/index.js",
           "./config": "./config.js",
           "./durability": "./durability.js",
         },
       }),
     );
-    writeFileSync(join(fsSafe, "index.js"), "export {};\n");
+    mkdirSync(join(fsSafe, "dist"), { recursive: true });
+    writeFileSync(join(fsSafe, "dist/index.js"), "export {};\n");
     writeFileSync(
       join(fsSafe, "config.js"),
       'export function configureFsSafeNative({ mode }) { if (mode !== "off") throw new Error("fixture requires fallback mode"); }',
@@ -6229,7 +6230,7 @@ export async function sha256File(file) {
     symlinkSync(physicalRoot, logicalRoot, process.platform === "win32" ? "junction" : "dir");
     expect(
       execFileSync(process.execPath, [join(logicalRoot, "cli.cjs")], { encoding: "utf8" }),
-    ).toBe(join(fsSafe, "index.js"));
+    ).toBe(join(fsSafe, "dist/index.js"));
     for (const packageRoot of [physicalRoot, logicalRoot]) {
       const result = spawnSync(
         process.execPath,


### PR DESCRIPTION
## Summary

The packaged fs-safe verifier used `@openclaw/fs-safe/package.json`, an unexported subpath in the 0.8.5 artifact used by the frozen composite. Resolve the public package root instead, then read the adjacent manifest solely for declared optional platform packages. Native verification remains strict.

## Proof

- Red: a pnpm-style package fixture that exposes `.`, `./config`, and `./durability` but not `./package.json` fails before this change with `ERR_PACKAGE_PATH_NOT_EXPORTED`.
- Green: the same fixture succeeds through physical and symlinked package roots.
- Focused tooling Docker test: 3 passed.
- `pnpm exec oxfmt --check`, focused oxlint, and `git diff --check` pass.
- npm registry metadata for `@openclaw/fs-safe@0.8.5` confirms the public root/config/durability exports and optional platform dependency contract.

Production delta: +4/-1. Test delta: +4/-3.

This repairs the image-build blocker from frozen composite run https://github.com/openclaw/openclaw/actions/runs/34156874863/job/101850550299. No release tag, package, or npm state changed.