### PR TITLE
improve: reduce Doctor process test startup time

### DIFF
--- a/docs/reference/test.md
+++ b/docs/reference/test.md
@@ -339,6 +339,10 @@ inside one lazily created package fixture per test run, keeping real UI checks o
 fixture-owned assets and each scenario’s state separate. Standalone and watch runs
 use live source inside the same fixture.
 
+Isolated Doctor config scripts also share the prepared config-flow, health-writer,
+and install-index modules. Each case still starts a fresh process with separate
+state; standalone and watch runs resolve the original TypeScript entrypoints.
+
 The prepared model-catalog worker also uses this compiled generation. Separate
 prepared model generations still own separate worker threads, and their choice
 of source or built plugin artifacts stays independent of worker compilation.

--- a/scripts/lib/vitest-worker-artifacts.mts
+++ b/scripts/lib/vitest-worker-artifacts.mts
@@ -14,6 +14,8 @@ export const vitestWorkerDeclarationEntries = {
     "src/infra/update-managed-service-handoff-runtime-assets.ts",
   "infra/triage-runtime.test-support": "src/infra/triage-runtime.test-support.ts",
   "cli/cli-entrypoint.test-support": "src/cli/cli-entrypoint.test-support.ts",
+  "commands/doctor-config-runtime.test-support":
+    "src/commands/doctor-config-runtime.test-support.ts",
   "test-support/channel-ingress-gateway-restart-entrypoint":
     "test/fixtures/channel-ingress-gateway-restart-entrypoint.ts",
   "extensions/qa-lab/gateway-child-artifacts-runtime.test-support":

--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -9,6 +9,7 @@ import {
   cliRecoveryEntrypoints,
   gatewayDirectStopEntrypoints,
 } from "../../src/cli/cli-entrypoint.test-support.ts";
+import { doctorConfigRuntimeEntrypoints } from "../../src/commands/doctor-config-runtime.test-support.ts";
 import { cronOwnerHardeningEntrypoints } from "../../src/cron/owner-hardening-runtime.test-support.ts";
 import { sessionListCacheRetentionEntrypoint } from "../../src/gateway/server-methods/sessions-list-cache-retention-entrypoint.test-support.ts";
 import { sessionChildCacheRetentionEntrypoint } from "../../src/gateway/session-child-cache-retention-entrypoint.test-support.ts";
@@ -39,6 +40,7 @@ export const vitestWorkerBuildEntries = {
       ...cliCompactionBackendEntrypoints,
       ...Object.values(cliRecoveryEntrypoints),
       ...Object.values(gatewayDirectStopEntrypoints),
+      ...Object.values(doctorConfigRuntimeEntrypoints),
       ...Object.values(cronOwnerHardeningEntrypoints),
       ...Object.values(tuiPtyRuntimeEntrypoints),
       ...Object.values(sessionTitleRetentionEntrypoints),

--- a/src/commands/doctor-config-runtime.test-support.ts
+++ b/src/commands/doctor-config-runtime.test-support.ts
@@ -1,0 +1,18 @@
+// Fresh Doctor script processes share compiled config and install-index module identities.
+export const doctorConfigRuntimeEntrypoints = {
+  configFlow: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "doctor-config-flow",
+    distWorkerPath: "commands/doctor-config-flow.js",
+  },
+  configHealth: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "../flows/doctor-health-contribution-runners.config",
+    distWorkerPath: "flows/doctor-health-contribution-runners.config.js",
+  },
+  installRecords: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "../plugins/installed-plugin-index-records",
+    distWorkerPath: "plugins/installed-plugin-index-records.js",
+  },
+} as const;

--- a/src/commands/doctor-plugin-install-config.process.test.ts
+++ b/src/commands/doctor-plugin-install-config.process.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import {
   clearLoadInstalledPluginIndexInstallRecordsCache,
   readPersistedInstalledPluginIndexInstallRecords,
@@ -13,6 +14,7 @@ import {
   runBuiltRuntime,
   runIsolatedModuleScript,
 } from "./doctor-config-preflight.process.test-support.js";
+import { doctorConfigRuntimeEntrypoints } from "./doctor-config-runtime.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterAll);
 const doctorArgs = ["doctor", "--fix", "--non-interactive", "--no-workspace-suggestions"];
@@ -109,11 +111,8 @@ describe("Doctor retired plugin install config", () => {
     const legacy = { source: "path" as const, installPath: path.join(root, "missing-plugin") };
     const candidate = { ...config, plugins: { ...config.plugins, installs: { imported: legacy } } };
     fs.writeFileSync(configPath, JSON.stringify({ ...candidate, unknownKey: true }));
-    const writerUrl = new URL(
-      "../flows/doctor-health-contribution-runners.config.ts",
-      import.meta.url,
-    );
-    const configFlowUrl = new URL("./doctor-config-flow.ts", import.meta.url).href;
+    const writerUrl = resolveRuntimeWorkerUrl(doctorConfigRuntimeEntrypoints.configHealth);
+    const configFlowUrl = resolveRuntimeWorkerUrl(doctorConfigRuntimeEntrypoints.configFlow).href;
     const result = await runIsolatedModuleScript(
       env,
       `
@@ -170,13 +169,9 @@ describe("Doctor retired plugin install config", () => {
       configPath,
       JSON.stringify({ ...config, plugins: { ...config.plugins, installs: { retired: legacy } } }),
     );
-    const configFlowUrl = new URL("./doctor-config-flow.ts", import.meta.url).href;
-    const writerUrl = new URL(
-      "../flows/doctor-health-contribution-runners.config.ts",
-      import.meta.url,
-    ).href;
-    const recordsUrl = new URL("../plugins/installed-plugin-index-records.ts", import.meta.url)
-      .href;
+    const configFlowUrl = resolveRuntimeWorkerUrl(doctorConfigRuntimeEntrypoints.configFlow).href;
+    const writerUrl = resolveRuntimeWorkerUrl(doctorConfigRuntimeEntrypoints.configHealth).href;
+    const recordsUrl = resolveRuntimeWorkerUrl(doctorConfigRuntimeEntrypoints.installRecords).href;
     const result = await runIsolatedModuleScript(
       env,
       `


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Doctor process tests repeatedly load and transform the source config graph in fresh script processes. In the measured eight-case file, the consent and no-replay cases alone took 12.21s and 8.81s; their actual config checks need much less time.

## Why This Change Was Made

Register the config flow, health writer, and install-index entrypoints with the existing private Vitest worker compiler, then resolve those prepared modules through the existing runtime URL helper. The three entrypoints share the compiler's module graph. Standalone and watch execution continue to resolve the original TypeScript sources.

Each case still launches a fresh process with separate state. All eight cases, assertions, and 18 built-CLI calls are retained, including repair repetition and config validation. The shared script launcher, ordinary package build, production code, shard count, and timeouts are unchanged.

## User Impact

Faster developer and CI tests, with no runtime or configuration behavior change. This uses the existing test compiler and adds no cache or dependency.

## Evidence

- Same-machine, same-order eight-case baseline and final candidate: all eight pass. Consent falls from **12.21s to 2.06s**; no-replay falls from **8.81s to 1.63s**. Total case time falls from 66.70s to 43.52s. These are local observations, not a portable CI speedup guarantee.
- Whole commands, including the normal runtime prerequisite build, take 114.25s and 94.43s respectively. That build remains included rather than hiding setup costs.
- Direct source-mode execution passes both affected cases and resolves the source config-flow URL. Normal wrapper execution passes the same cases and resolves the private compiled generation's JavaScript URL. Temporary timing and URL instrumentation was removed before the final full-file run.
- Existing compiler owner/borrower probes: original 3.50s, candidate 3.33s; output grows by **2,298 bytes** and one input/output. The ordered pair shows no observed setup regression; it does not establish a compiler speedup.
- Existing runtime URL tests: **9 passed**. Full build and `node scripts/check-changed.mjs --base b7528507af5a4ea04b5165ac64d30f504e898f19` passed, including core-test/script types, lint, and unused-export scans. Managed P2 review: no actionable findings.

Production LOC delta: **0**. Test/support net +13, compiler registration +4, documentation +4.

Data-model compatibility review: the ClawSweeper request was triggered by the two compiler registration files. This patch changes no schema, stored representation, migration algorithm, or production build entry. It changes which equivalent source/prepared modules the tests import. The existing canonical-index preservation, repeated repair, malformed-source preservation, consent, and no-replay assertions all pass in the eight-case run; the two affected script cases also pass directly against source. No migration or upgrade behavior is changed.

Exact-head [CI run 34161088657](https://github.com/openclaw/openclaw/actions/runs/34161088657) passed, including the required gate. In [small1's actual Doctor group](https://github.com/openclaw/openclaw/actions/runs/34161088657/job/101863079447), all eight cases passed in the original order: consent **2.135s**, no-replay **1.595s**, whole-file case total **36.274s**, compiler **4.313s**. The earlier completed CI file totaled 51.208s, with the affected cases taking 11.034s and 6.596s. Small1 executed in 6m32s (Node setup 21s, runtime build 33s, tests 5m21s); total CI of 9m57s still includes runner waits and other tests. The broader eight-minute goal remains open.
