### PR TITLE
fix(msteams): preserve every progress reply

### DIFF
--- a/extensions/msteams/src/__traces__/stream-failure-redeliver-full.trace.jsonl
+++ b/extensions/msteams/src/__traces__/stream-failure-redeliver-full.trace.jsonl
@@ -7,7 +7,6 @@
 {"seq":7,"at":600,"dir":"in","kind":"block-final","data":{"text":"Deploy status: build is green."}}
 {"seq":8,"at":600,"dir":"in","kind":"partial","data":{"text":"Rolling out to production now."}}
 {"seq":9,"at":900,"dir":"in","kind":"final","data":{"text":"Deploy status: build is green.\n\nRolling out to production now."}}
-{"seq":10,"at":900,"dir":"in","kind":"idle"}
-{"seq":11,"at":900,"dir":"out","kind":"context.sendActivity","data":{"payload":{"channelData":{"feedbackLoopEnabled":true},"entities":[{"@context":"https://schema.org","@id":"","@type":"Message","additionalType":["AIGeneratedContent"],"type":"https://schema.org/Message"}],"text":"Deploy status: build is green.","type":"message"},"result":{"id":"activity-2"},"target":"a:1dm-trace-conversation"}}
+{"seq":10,"at":900,"dir":"out","kind":"context.sendActivity","data":{"payload":{"channelData":{"feedbackLoopEnabled":true},"entities":[{"@context":"https://schema.org","@id":"","@type":"Message","additionalType":["AIGeneratedContent"],"type":"https://schema.org/Message"}],"text":"Deploy status: build is green.","type":"message"},"result":{"id":"activity-2"},"target":"a:1dm-trace-conversation"}}
+{"seq":11,"at":900,"dir":"in","kind":"idle"}
 {"seq":12,"at":900,"dir":"out","kind":"context.sendActivity","data":{"payload":{"channelData":{"feedbackLoopEnabled":true},"entities":[{"@context":"https://schema.org","@id":"","@type":"Message","additionalType":["AIGeneratedContent"],"type":"https://schema.org/Message"}],"text":"Deploy status: build is green.\n\nRolling out to production now.","type":"message"},"result":{"id":"activity-3"},"target":"a:1dm-trace-conversation"}}
-{"seq":13,"at":900,"dir":"out","kind":"stream.emit","data":{"payload":{"channelData":{"feedbackLoopEnabled":true},"entities":[{"@context":"https://schema.org","@id":"","@type":"Message","additionalType":["AIGeneratedContent"],"type":"https://schema.org/Message"}],"type":"message"},"result":{"error":"stream write failed"}}}

--- a/extensions/msteams/src/__traces__/streaming-happy-dm.trace.jsonl
+++ b/extensions/msteams/src/__traces__/streaming-happy-dm.trace.jsonl
@@ -7,7 +7,7 @@
 {"seq":7,"at":600,"dir":"in","kind":"block-final","data":{"text":"Deploy status: build is green."}}
 {"seq":8,"at":600,"dir":"in","kind":"partial","data":{"text":"Rolling out to production now."}}
 {"seq":9,"at":900,"dir":"in","kind":"final","data":{"text":"Deploy status: build is green.\n\nRolling out to production now."}}
-{"seq":10,"at":900,"dir":"in","kind":"idle"}
-{"seq":11,"at":900,"dir":"out","kind":"context.sendActivity","data":{"payload":{"channelData":{"feedbackLoopEnabled":true},"entities":[{"@context":"https://schema.org","@id":"","@type":"Message","additionalType":["AIGeneratedContent"],"type":"https://schema.org/Message"}],"text":"Deploy status: build is green.\n\nRolling out to production now.","type":"message"},"result":{"id":"activity-2"},"target":"a:1dm-trace-conversation"}}
-{"seq":12,"at":900,"dir":"out","kind":"stream.emit","data":{"payload":{"channelData":{"feedbackLoopEnabled":true},"entities":[{"@context":"https://schema.org","@id":"","@type":"Message","additionalType":["AIGeneratedContent"],"type":"https://schema.org/Message"}],"type":"message"}}}
-{"seq":13,"at":900,"dir":"out","kind":"stream.close","data":{"result":{"id":"stream-final"}}}
+{"seq":10,"at":900,"dir":"out","kind":"stream.emit","data":{"payload":{"channelData":{"feedbackLoopEnabled":true},"entities":[{"@context":"https://schema.org","@id":"","@type":"Message","additionalType":["AIGeneratedContent"],"type":"https://schema.org/Message"}],"type":"message"}}}
+{"seq":11,"at":900,"dir":"out","kind":"stream.close","data":{"result":{"id":"stream-final"}}}
+{"seq":12,"at":900,"dir":"in","kind":"idle"}
+{"seq":13,"at":900,"dir":"out","kind":"context.sendActivity","data":{"payload":{"channelData":{"feedbackLoopEnabled":true},"entities":[{"@context":"https://schema.org","@id":"","@type":"Message","additionalType":["AIGeneratedContent"],"type":"https://schema.org/Message"}],"text":"Deploy status: build is green.\n\nRolling out to production now.","type":"message"},"result":{"id":"activity-2"},"target":"a:1dm-trace-conversation"}}

--- a/extensions/msteams/src/delivery-trace.test.ts
+++ b/extensions/msteams/src/delivery-trace.test.ts
@@ -215,11 +215,9 @@ const MSTEAMS_TRACE_CASES: readonly MSTeamsTraceCase[] = [
     streamWriteFault: { atWrite: 2, kind: "cancelled" },
   },
   {
-    // Mid-stream non-cancel write failure latches streamFailed: the streamed
-    // prefix stays visible AND the full reply re-delivers as blocks. A later
-    // segment rewrites the stale stream buffer, then finalize attempts the
-    // closing metadata write after fallback delivery. The duplication is the
-    // contract (truncation is the worse outcome).
+    // This fixture has no provider acknowledgement, so the full first reply
+    // falls back before later blocks. A later partial cannot reopen the failed
+    // native segment or trigger another write to its retired stream.
     golden: "stream-failure-redeliver-full",
     scenario: "streaming-happy",
     conversationType: "personal",

--- a/extensions/msteams/src/reply-dispatcher.test.ts
+++ b/extensions/msteams/src/reply-dispatcher.test.ts
@@ -1,5 +1,7 @@
 // Msteams tests cover reply dispatcher plugin behavior.
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
+import { createReplyDispatcher } from "openclaw/plugin-sdk/reply-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ReplyPayload } from "../runtime-api.js";
 
@@ -7,7 +9,9 @@ const createChannelMessageReplyPipelineMock = vi.hoisted(() => vi.fn());
 const getMSTeamsRuntimeMock = vi.hoisted(() => vi.fn());
 const enqueueSystemEventMock = vi.hoisted(() => vi.fn());
 const getGlobalHookRunnerMock = vi.hoisted(() => vi.fn());
-const renderReplyPayloadsToMessagesMock = vi.hoisted(() => vi.fn(() => []));
+const renderReplyPayloadsToMessagesMock = vi.hoisted(() =>
+  vi.fn<(typeof import("./messenger.js"))["renderReplyPayloadsToMessages"]>(() => []),
+);
 const sendMSTeamsMessagesMock = vi.hoisted(() =>
   vi.fn<(typeof import("./messenger.js"))["sendMSTeamsMessages"]>(async () => []),
 );
@@ -47,7 +51,7 @@ type StreamMock = {
   update: ReturnType<typeof vi.fn>;
   emit: ReturnType<typeof vi.fn>;
   clearText: ReturnType<typeof vi.fn>;
-  close: ReturnType<typeof vi.fn>;
+  close: ReturnType<typeof vi.fn<() => Promise<{ id: string } | undefined>>>;
   canceled: boolean;
   events: {
     on: ReturnType<typeof vi.fn>;
@@ -948,6 +952,129 @@ describe("createMSTeamsReplyDispatcher", () => {
     });
   });
 
+  it("preserves both progress finals through real dispatcher settlement", async () => {
+    renderReplyPayloadsToMessagesMock.mockImplementation((payloads) =>
+      payloads.flatMap((payload) => (payload.text ? [{ text: payload.text }] : [])),
+    );
+    sendMSTeamsMessagesMock.mockResolvedValue(["block-result"]);
+    const teams = createDispatcher("personal", { streaming: { mode: "progress" } });
+    const deliveries: Array<Awaited<ReturnType<typeof teams.delivery.deliver>>> = [];
+    const events: string[] = [];
+    const producer = createReplyDispatcher({
+      deliver: async (payload, info) => {
+        events.push(`deliver:${payload.text}`);
+        const result = await teams.delivery.deliver(payload, info);
+        deliveries.push(result);
+        return result;
+      },
+      onIdle: async () => {
+        events.push("settle");
+        await teams.dispatcherOptions.onSettled?.();
+      },
+    });
+    producer.sendFinalReply({ text: "First distinct result." });
+    producer.sendFinalReply({ text: "# Second distinct result" });
+    producer.markComplete();
+    await producer.waitForIdle();
+    const results = await Promise.all(
+      deliveries.map((result) => Promise.resolve(result?.finalization ?? result)),
+    );
+    expect(events).toEqual([
+      "deliver:First distinct result.",
+      "deliver:# Second distinct result",
+      "settle",
+    ]);
+    for (const text of ["First distinct result.", "Second distinct result"]) {
+      expect(results).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            visibleReplySent: true,
+            content: expect.stringContaining(text),
+          }),
+        ]),
+      );
+    }
+  });
+
+  it.each(["close", "fallback"])("joins an active native %s before later blocks", async (phase) => {
+    const started = createDeferred<void>();
+    const release = createDeferred<void>();
+    const sent: string[] = [];
+    renderReplyPayloadsToMessagesMock.mockImplementation((payloads) =>
+      payloads.flatMap((payload) => (payload.text ? [{ text: payload.text }] : [])),
+    );
+    sendMSTeamsMessagesMock.mockImplementation(async ({ messages }) => {
+      const text = messages[0]?.text ?? "";
+      if (phase === "fallback" && text === "First result") {
+        started.resolve();
+        await release.promise;
+      }
+      sent.push(text);
+      return [`block-${text}`];
+    });
+    const teams = createDispatcher("personal", {
+      streaming: { mode: "progress", block: { enabled: true } },
+    });
+    getStreamMock().close.mockImplementation(async () => {
+      if (phase === "fallback") {
+        throw new Error("close failed");
+      }
+      started.resolve();
+      await release.promise;
+      sent.push("First result");
+      return { id: "stream-final" };
+    });
+    const first = await teams.delivery.deliver({ text: "First result" }, { kind: "final" });
+    const settling = teams.dispatcherOptions.onSettled?.();
+    await started.promise;
+    const later = teams.delivery.deliver({ text: "Second result" }, { kind: "final" });
+    release.resolve();
+    const second = await later;
+    await settling;
+    await teams.dispatcherOptions.onSettled?.();
+    const results = await Promise.all([first?.finalization, second?.finalization]);
+    expect(sent).toEqual(["First result", "Second result"]);
+    expect(results).toEqual([
+      expect.objectContaining({ visibleReplySent: true, content: "First result" }),
+      expect.objectContaining({ visibleReplySent: true, content: "Second result" }),
+    ]);
+  });
+
+  it.each(["partial", "progress"] as const)(
+    "honors late Stop before later %s text and media",
+    async (mode) => {
+      renderReplyPayloadsToMessagesMock.mockImplementation((payloads) =>
+        payloads.map(({ text, mediaUrl }) => ({ text, mediaUrl })),
+      );
+      sendMSTeamsMessagesMock.mockResolvedValue(["must-not-send"]);
+      const teams = createDispatcher("personal", { streaming: { mode } });
+      const stream = getStreamMock();
+      if (mode === "partial") {
+        teams.replyOptions.onPartialReply?.({ text: "First result" });
+      }
+      const first = await teams.delivery.deliver({ text: "First result" }, { kind: "final" });
+      stream.acknowledge("First result");
+      stream.close.mockImplementation(async () => {
+        stream.canceled = true;
+        return undefined;
+      });
+      const second = await teams.delivery.deliver(
+        { text: "Second result", mediaUrl: "https://example.test/later.png" },
+        { kind: "final" },
+      );
+      await teams.dispatcherOptions.onSettled?.();
+      await expect(first?.finalization).resolves.toMatchObject({
+        visibleReplySent: true,
+        content: "First result",
+      });
+      expect(second).toEqual({
+        visibleReplySent: false,
+        suppression: { reason: "no_visible_result" },
+      });
+      expect(sendMSTeamsMessagesMock).not.toHaveBeenCalled();
+    },
+  );
+
   it.each([
     {
       name: "attached media",
@@ -978,7 +1105,7 @@ describe("createMSTeamsReplyDispatcher", () => {
     ] as never);
     const dispatcher = createDispatcher("personal");
     const stream = getStreamMock();
-    stream.close.mockImplementation(() => {
+    stream.close.mockImplementation(async () => {
       stream.canceled = true;
       return undefined;
     });

--- a/extensions/msteams/src/reply-dispatcher.ts
+++ b/extensions/msteams/src/reply-dispatcher.ts
@@ -230,6 +230,11 @@ export function createMSTeamsReplyDispatcher(params: {
   };
 
   const pendingDeliveries: PendingDelivery[] = [];
+  // onIdle can overlap later deliveries. Join both close and fallback sends
+  // before another payload can mutate or overtake the native segment.
+  let pendingSettlement: Promise<void> | undefined;
+  const findPendingNativeDelivery = () =>
+    pendingDeliveries.find((candidate) => candidate.native && !candidate.nativeSettled);
 
   const joinAcceptedContents = (contents: readonly (string | undefined)[]): string =>
     contents.filter((content): content is string => Boolean(content)).join("\n");
@@ -439,9 +444,20 @@ export function createMSTeamsReplyDispatcher(params: {
   const delivery: ChannelInboundTurnPlan["delivery"] = {
     observeMessageSent: true,
     deliver: async (payload) => {
+      if (pendingSettlement) {
+        await pendingSettlement;
+      }
       const preparedPayload = streamController.preparePayload(payload);
       const native = streamController.claimNativeDelivery();
-      const messages = preparedPayload ? renderReplyPayload(preparedPayload) : [];
+      if (preparedPayload && !native && findPendingNativeDelivery()) {
+        // Close the earlier native segment before later blocks can overtake
+        // its final text or escape a Stop discovered by that closing request.
+        await settleDelivery();
+      }
+      const messages =
+        preparedPayload && !streamController.wasCanceled()
+          ? renderReplyPayload(preparedPayload)
+          : [];
       if (!native && messages.length === 0) {
         return {
           visibleReplySent: false,
@@ -478,67 +494,70 @@ export function createMSTeamsReplyDispatcher(params: {
     },
   };
 
-  const settleDelivery = async (): Promise<void> => {
-    await flushPendingMessages();
+  const settleDelivery = (): Promise<void> =>
+    (pendingSettlement ??= Promise.resolve()
+      .then(async () => {
+        await flushPendingMessages();
 
-    const nativeDelivery = pendingDeliveries.find(
-      (candidate) => candidate.native && !candidate.nativeSettled,
-    );
-    if (!nativeDelivery) {
-      await streamController.finalize();
-      return;
-    }
-    let nativeResult;
-    try {
-      nativeResult = await streamController.finalize();
-    } catch (error) {
-      nativeDelivery.errors.push(error);
-      nativeDelivery.nativeSettled = true;
-      settlePendingDelivery(nativeDelivery);
-      return;
-    }
+        const nativeDelivery = findPendingNativeDelivery();
+        if (!nativeDelivery) {
+          await streamController.finalize();
+          return;
+        }
+        let nativeResult;
+        try {
+          nativeResult = await streamController.finalize();
+        } catch (error) {
+          nativeDelivery.errors.push(error);
+          nativeDelivery.nativeSettled = true;
+          settlePendingDelivery(nativeDelivery);
+          return;
+        }
 
-    if (nativeResult.visibleReplySent) {
-      nativeDelivery.nativeResult = {
-        messageIds: nativeResult.messageId ? [nativeResult.messageId] : [],
-        ...(nativeResult.content !== undefined ? { content: nativeResult.content } : {}),
-      };
-    }
-    const hasPostNativePayloads = Boolean(nativeResult.postNativePayloads?.length);
-    if (nativeResult.logicalContent !== undefined) {
-      nativeDelivery.content = nativeResult.logicalContent;
-    } else if (
-      nativeResult.content !== undefined &&
-      ((!nativeResult.fallbackPayload && !hasPostNativePayloads) ||
-        nativeDelivery.content === undefined)
-    ) {
-      nativeDelivery.content = nativeResult.content;
-    }
-    const afterNativePayloads = [
-      ...(nativeResult.fallbackPayload ? [nativeResult.fallbackPayload] : []),
-      ...(nativeResult.postNativePayloads ?? []),
-    ];
-    if (afterNativePayloads.length > 0) {
-      nativeDelivery.messages.push(
-        ...afterNativePayloads.flatMap((payload) => renderReplyPayload(payload)),
-      );
-      nativeDelivery.blockSettled = nativeDelivery.messages.length === 0;
-    }
-    nativeDelivery.nativeSettled = true;
-    if (!nativeDelivery.blockSettled) {
-      await flushPendingMessages();
-    }
-    settlePendingDelivery(nativeDelivery);
-    if (nativeResult.messageId) {
-      try {
-        params.onSentMessageIds?.([nativeResult.messageId]);
-      } catch (error) {
-        params.log.warn?.("failed to record sent Teams message id", {
-          error: formatUnknownError(error),
-        });
-      }
-    }
-  };
+        if (nativeResult.visibleReplySent) {
+          nativeDelivery.nativeResult = {
+            messageIds: nativeResult.messageId ? [nativeResult.messageId] : [],
+            ...(nativeResult.content !== undefined ? { content: nativeResult.content } : {}),
+          };
+        }
+        const hasPostNativePayloads = Boolean(nativeResult.postNativePayloads?.length);
+        if (nativeResult.logicalContent !== undefined) {
+          nativeDelivery.content = nativeResult.logicalContent;
+        } else if (
+          nativeResult.content !== undefined &&
+          ((!nativeResult.fallbackPayload && !hasPostNativePayloads) ||
+            nativeDelivery.content === undefined)
+        ) {
+          nativeDelivery.content = nativeResult.content;
+        }
+        const afterNativePayloads = [
+          ...(nativeResult.fallbackPayload ? [nativeResult.fallbackPayload] : []),
+          ...(nativeResult.postNativePayloads ?? []),
+        ];
+        if (afterNativePayloads.length > 0) {
+          nativeDelivery.messages.push(
+            ...afterNativePayloads.flatMap((payload) => renderReplyPayload(payload)),
+          );
+          nativeDelivery.blockSettled = nativeDelivery.messages.length === 0;
+        }
+        nativeDelivery.nativeSettled = true;
+        if (!nativeDelivery.blockSettled) {
+          await flushPendingMessages();
+        }
+        settlePendingDelivery(nativeDelivery);
+        if (nativeResult.messageId) {
+          try {
+            params.onSentMessageIds?.([nativeResult.messageId]);
+          } catch (error) {
+            params.log.warn?.("failed to record sent Teams message id", {
+              error: formatUnknownError(error),
+            });
+          }
+        }
+      })
+      .finally(() => {
+        pendingSettlement = undefined;
+      }));
 
   // Pipe agent tool/plan/approval/command events into the stream controller's
   // progress-draft surface. In "progress" stream mode this lets the live

--- a/extensions/msteams/src/reply-stream-controller.sdk.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.sdk.test.ts
@@ -1,5 +1,6 @@
 import { createServer, request as requestHttp } from "node:http";
 import { HttpStream } from "@microsoft/teams.apps/dist/http/http-stream.js";
+import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { createTeamsReplyStreamController } from "./reply-stream-controller.js";
 
@@ -10,14 +11,6 @@ type TeamsLoopbackRequest = {
   status: number;
   entities?: unknown[];
 };
-
-function createOneShot() {
-  let resolve!: () => void;
-  const promise = new Promise<void>((settle) => {
-    resolve = settle;
-  });
-  return { promise, resolve };
-}
 
 const acknowledgedPrefix = "a".repeat(4_000);
 const completeReply = `${acknowledgedPrefix}${"b".repeat(200)}`;
@@ -136,8 +129,8 @@ function createLoopbackController(
     }
     return result.body;
   };
-  const firstAcknowledgement = createOneShot();
-  const firstFlushFailure = createOneShot();
+  const firstAcknowledgement = createDeferred<void>();
+  const firstFlushFailure = createDeferred<void>();
   const logger = {
     child: vi.fn(),
     debug: vi.fn(),
@@ -184,6 +177,7 @@ function createLoopbackController(
   return {
     acknowledgements,
     controller,
+    sendActivity: send,
     firstAcknowledgement: firstAcknowledgement.promise,
     firstFlushFailure: firstFlushFailure.promise,
     logger,
@@ -375,6 +369,34 @@ describe("Microsoft Teams SDK acknowledged stream fallback", () => {
 });
 
 describe("Teams native final text preparation", () => {
+  it("preserves all progress final payloads at the wire boundary", async () => {
+    const scenario = "progress-multiple-final";
+    const { controller, sendActivity } = createLoopbackController(scenario, {
+      streaming: { mode: "progress" },
+    });
+    const texts = ["First distinct result.\n\n", "# Second distinct result"];
+    const prepared = texts.map((text) => controller.preparePayload({ text }));
+    const result = await controller.finalize();
+    for (const payload of [
+      ...prepared,
+      result.fallbackPayload,
+      ...(result.postNativePayloads ?? []),
+    ]) {
+      if (payload?.text) {
+        await sendActivity({ type: "message", text: payload.text });
+      }
+    }
+    const wire = requests.filter(
+      (request) => request.scenario === scenario && request.type === "message",
+    );
+    const deliveredText = wire
+      .filter((request) => request.status >= 200 && request.status < 300)
+      .map((request) => request.text)
+      .join("\n");
+    expect(deliveredText.split("First distinct result.").length - 1).toBe(1);
+    expect(deliveredText.split("Second distinct result").length - 1).toBe(1);
+  });
+
   it("preserves required AI metadata when the SDK completes a timed-out stream by update", async () => {
     const { controller, firstAcknowledgement } = createLoopbackController("presentation-timeout");
     const text = "# Status";

--- a/extensions/msteams/src/reply-stream-controller.test.ts
+++ b/extensions/msteams/src/reply-stream-controller.test.ts
@@ -386,13 +386,18 @@ describe("createTeamsReplyStreamController", () => {
     });
   });
 
-  it("allows fallback delivery for second text segment after tool calls", () => {
+  it.each([false, true])("keeps later partial segments whole with settled=%s", async (settled) => {
     const stream = makeStream();
     const ctrl = makeController({ stream });
 
     ctrl.onPartialReply({ text: "First segment" });
     expect(ctrl.preparePayload({ text: "First segment" })).toBeUndefined();
+    expect(ctrl.claimNativeDelivery()).toBe(true);
+    if (settled) {
+      await ctrl.finalize();
+    }
 
+    ctrl.onPartialReply({ text: "Second segment after tools" });
     const result = ctrl.preparePayload({ text: "Second segment after tools" });
     expect(result).toEqual({ text: "Second segment after tools" });
   });
@@ -904,6 +909,7 @@ describe("createTeamsReplyStreamController", () => {
         fallbackPayload: { text: " world" },
       });
       expect(stream.events.off).toHaveBeenCalledWith(0);
+      expect(ctrl.preparePayload({ text: "hello again" })).toEqual({ text: "hello again" });
     });
 
     it("does not redeliver an acknowledged final when stream close produces no activity", async () => {

--- a/extensions/msteams/src/reply-stream-controller.ts
+++ b/extensions/msteams/src/reply-stream-controller.ts
@@ -263,9 +263,8 @@ export function createTeamsReplyStreamController(params: {
     },
 
     onPartialReply(payload: { text?: string }): void {
-      // Partial-token streaming only fires in "partial" mode. In "progress"
-      // mode, openclaw's pipeline doesn't deliver tokens — the model output
-      // arrives as a single payload at preparePayload time.
+      // Partial-token streaming only fires in "partial" mode. Progress-mode
+      // final payloads arrive at preparePayload instead.
       if (!stream || !payload.text || wasCanceled() || streamMode !== "partial") {
         return;
       }
@@ -276,7 +275,8 @@ export function createTeamsReplyStreamController(params: {
         pendingFinalPayload = { text: payload.text };
         return;
       }
-      if (streamFinalizationPending) {
+      // Closing the first segment does not grant another native delivery claim.
+      if (streamFinalizationPending || nativeDeliveryClaimed) {
         return;
       }
       // Convert cumulative-text from the pipeline into deltas for the SDK's
@@ -434,18 +434,6 @@ export function createTeamsReplyStreamController(params: {
           return undefined;
         }
       }
-      // Partial mode with tokens already streamed: stream carries the text;
-      // strip text from the payload (keep media if any) so block delivery
-      // doesn't duplicate. Exception: if a non-cancel stream failure was
-      // latched mid-flight, deliver only a provider-acknowledged remainder;
-      // preserve the full reply when delivery was not acknowledged.
-      if (tokensEmitted && !streamFailed) {
-        const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
-        pendingFinalPayload = fallbackPayloadForSuppressedFinal(payload);
-        streamFinalizationPending = true;
-        tokensEmitted = false;
-        return hasMedia ? { ...payload, text: undefined } : undefined;
-      }
       if (streamFailed) {
         // Trim the provider-acknowledged prefix only from the failed segment.
         // Retain its ID/text for final settlement while later tool rounds fall through whole.
@@ -456,20 +444,14 @@ export function createTeamsReplyStreamController(params: {
         pendingFinalPayload = undefined;
         return fallback;
       }
-      // Progress mode (or partial mode that received no tokens — e.g. a
-      // tool-only response): emit the final text into the stream so the
-      // preview card transitions in place to the final reply. The SDK's
-      // HttpStream accumulates the text and the next `finalize()` close()
-      // flushes it as the closing activity.
-      if (streamMode === "progress" && payload.text) {
+      // A native stream owns one final segment. Later progress payloads use
+      // block delivery, just like later partial-mode segments after tools.
+      if (streamMode === "progress" && payload.text && !nativeDispatchStarted) {
         try {
           stream.emit(payload.text);
           emittedText = payload.text;
           nativeDispatchStarted = true;
-          pendingFinalPayload = fallbackPayloadForSuppressedFinal(payload);
-          streamFinalizationPending = true;
-          const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
-          return hasMedia ? { ...payload, text: undefined } : undefined;
+          tokensEmitted = true;
         } catch (err) {
           if (isStreamCancelledError(err)) {
             canceledLocally = true;
@@ -479,6 +461,13 @@ export function createTeamsReplyStreamController(params: {
           // safety net so the user still sees the final reply.
           params.log?.debug?.(`progress-mode finalize failed: ${coerceErrorMessage(err)}`);
         }
+      }
+      if (tokensEmitted) {
+        const hasMedia = Boolean(payload.mediaUrl || payload.mediaUrls?.length);
+        pendingFinalPayload = fallbackPayloadForSuppressedFinal(payload);
+        streamFinalizationPending = true;
+        tokensEmitted = false;
+        return hasMedia ? { ...payload, text: undefined } : undefined;
       }
       return payload;
     },
@@ -630,6 +619,8 @@ export function createTeamsReplyStreamController(params: {
           ...(postNativePayloads.length > 0 ? { postNativePayloads } : {}),
         };
       } finally {
+        // This segment's acknowledged-prefix fallback has been consumed.
+        failedSegmentFallbackPrepared = true;
         queuedFinalActivity = undefined;
         replacementEmitFailed = false;
         replacementFinalPending = false;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Microsoft Teams users could lose earlier reply text when progress mode produced more than one final payload. Formatting the last payload replaced the accumulated stream text, even though delivery could be reported as successful.

## Why This Change Was Made

One native stream now owns its first final segment. Later replies use the existing block delivery path, and the dispatcher waits for the earlier stream close and any fallback send to settle before later output can overtake it. That shared settlement also prevents overlapping closes and preserves a Stop discovered during close.

The controller reuses the existing partial-mode suppression and segment fallback ownership. The dispatcher adds one in-flight settlement promise; production grows by 10 lines to cover that lifecycle.

## User Impact

Multi-part progress replies retain each part in order. Later partial replies remain whole after native finalization, and cancellation continues to suppress later text and attachments.

## Evidence

- Before the repair, the pinned Microsoft Teams SDK with a synthetic localhost transport lost the first of two final texts. A second regression through the real core dispatcher reproduced the incorrect delivery result. Both original cases pass after the repair.
- All 134 cases in the three affected owner suites passed. Eight affected settlement/cancellation cases passed again after test typing cleanup.
- All 25 selected changed checks passed across recorded resumes. Initial test TypeScript/lint errors were corrected before the final checks passed.
- Independent managed review completed with no actionable P0–P2 findings. The pinned Teams SDK source was included in that review context.
- CI exposed two trace expectations for the old ordering. Both were regenerated after source and independent review; all four exact-order trace scenarios and 24 additional selected checks passed. The follow-up changes only trace fixtures and their explanation.

The SDK test exercises the actual stream implementation and HTTP wire boundary; it does not send to a real Teams tenant.

The installed `@microsoft/teams.apps@2.0.15` HttpStream implementation was inspected directly. Its string emits accumulate text, while final formatting can replace that buffer. The one-segment owner and ordered settlement were checked against that implementation and exercised through the real SDK HTTP fixture.
