### PR TITLE
fix(baseten): keep generated models out of ordinary setup config

### DIFF
--- a/docs/providers/baseten.md
+++ b/docs/providers/baseten.md
@@ -51,6 +51,8 @@ export BASETEN_API_KEY=...
 
     </CodeGroup>
 
+    Onboarding saves the connection settings without copying the generated catalog into your config. Existing model rows stay unchanged. If you use `models.mode: "replace"`, onboarding also adds the bundled catalog because that mode disables implicit discovery.
+
   </Step>
   <Step title="Verify the live catalog">
     ```bash

--- a/extensions/baseten/index.test.ts
+++ b/extensions/baseten/index.test.ts
@@ -140,6 +140,7 @@ describe("Baseten provider registration", () => {
       });
       const noninteractive = await method.runNonInteractive({
         authChoice: "baseten-api-key",
+        opts: {},
         config,
         baseConfig: config,
         runtime: createRuntimeEnv(),
@@ -203,6 +204,7 @@ describe("Baseten provider registration", () => {
       const authenticate = (config: OpenClawConfig) =>
         run({
           authChoice: "baseten-api-key",
+          opts: {},
           config,
           baseConfig: config,
           runtime: createRuntimeEnv(),

--- a/extensions/baseten/index.test.ts
+++ b/extensions/baseten/index.test.ts
@@ -2,15 +2,22 @@ import type { Model } from "openclaw/plugin-sdk/llm";
 import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import {
+  createRuntimeEnv,
+  createTestWizardPrompter,
   registerSingleProviderPlugin,
   resolveProviderPluginChoice,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
-import { resolveAgentModelPrimaryValue } from "openclaw/plugin-sdk/provider-onboard";
+import {
+  resolveAgentModelFallbackValues,
+  resolveAgentModelPrimaryValue,
+  type ModelDefinitionConfig,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
 import { buildOpenAICompletionsParams } from "openclaw/plugin-sdk/provider-transport-runtime";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { runSingleProviderCatalog } from "../test-support/provider-model-test-helpers.js";
+import { applyBasetenConfig } from "./api.js";
 import basetenPlugin from "./index.js";
-import { applyBasetenConfig } from "./onboard.js";
 import { createBasetenThinkingWrapper } from "./stream.js";
 
 type OpenAICompletionsModel = Model<"openai-completions">;
@@ -108,6 +115,125 @@ function captureDeepSeekReplayPayload(thinkingLevel: "off" | "high" | undefined)
 }
 
 describe("Baseten provider registration", () => {
+  it.each([undefined, "merge", "replace"] as const)(
+    "keeps registered %s setup separate from the public catalog preset",
+    async (mode) => {
+      const provider = await registerSingleProviderPlugin(basetenPlugin);
+      const method = resolveProviderPluginChoice({
+        providers: [provider],
+        choice: "baseten-api-key",
+      })?.method;
+      if (!method?.runNonInteractive) {
+        throw new Error("expected Baseten noninteractive auth method");
+      }
+      const config: OpenClawConfig = { models: { mode } };
+      const interactive = await method.run({
+        config,
+        env: {},
+        opts: { basetenApiKey: TEST_VALUE },
+        runtime: createRuntimeEnv(),
+        prompter: createTestWizardPrompter(),
+        secretInputMode: "plaintext",
+        isRemote: false,
+        openUrl: vi.fn(),
+        oauth: { createVpsAwareHandlers: vi.fn() },
+      });
+      const noninteractive = await method.runNonInteractive({
+        authChoice: "baseten-api-key",
+        config,
+        baseConfig: config,
+        runtime: createRuntimeEnv(),
+        resolveApiKey: async () => ({ key: TEST_VALUE, source: "profile" }),
+        toApiKeyCredential: () => null,
+      });
+
+      for (const output of [interactive.configPatch, noninteractive]) {
+        expect(output?.models?.providers?.baseten).toMatchObject({
+          baseUrl: "https://inference.baseten.co/v1",
+          api: "openai-completions",
+        });
+        expect(output?.models?.providers?.baseten?.models).toHaveLength(mode === "replace" ? 9 : 0);
+        expect(output?.agents?.defaults?.models).toEqual({
+          "baseten/thinkingmachines/inkling": { alias: "Inkling" },
+        });
+      }
+      expect(applyBasetenConfig(config).models?.providers?.baseten?.models).toHaveLength(9);
+    },
+  );
+
+  it.each(["merge", "replace"] as const)(
+    "preserves authored rows and aliases when repeating registered %s setup",
+    async (mode) => {
+      const provider = await registerSingleProviderPlugin(basetenPlugin);
+      const run = resolveProviderPluginChoice({
+        providers: [provider],
+        choice: "baseten-api-key",
+      })?.method.runNonInteractive;
+      if (!run) {
+        throw new Error("expected Baseten noninteractive auth method");
+      }
+      const authoredDefault: ModelDefinitionConfig = {
+        id: "thinkingmachines/inkling",
+        name: "Authored default",
+        reasoning: false,
+        input: ["text"],
+        contextWindow: 8192,
+        maxTokens: 1024,
+        cost: { input: 7, output: 9, cacheRead: 1, cacheWrite: 2 },
+      };
+      const authoredModels = [
+        authoredDefault,
+        { ...authoredDefault, id: "operator-only", name: "Authored selection" },
+      ];
+      const input: OpenClawConfig = {
+        models: {
+          mode,
+          providers: {
+            baseten: { baseUrl: "https://operator.invalid/v1", models: authoredModels },
+          },
+        },
+        agents: {
+          defaults: {
+            model: { primary: "fixture/primary", fallbacks: ["fixture/fallback"] },
+            models: { "baseten/thinkingmachines/inkling": { alias: "Saved alias" } },
+          },
+        },
+      };
+      const original = structuredClone(input);
+      const authenticate = (config: OpenClawConfig) =>
+        run({
+          authChoice: "baseten-api-key",
+          config,
+          baseConfig: config,
+          runtime: createRuntimeEnv(),
+          resolveApiKey: async () => ({ key: TEST_VALUE, source: "profile" }),
+          toApiKeyCredential: () => null,
+        });
+      const first = await authenticate(input);
+      if (!first) {
+        throw new Error("expected configured Baseten provider");
+      }
+      const second = await authenticate(first);
+
+      for (const output of [first, second]) {
+        expect(output?.models?.providers?.baseten?.models).toEqual(
+          expect.arrayContaining(authoredModels),
+        );
+        expect(output?.models?.providers?.baseten?.models).toHaveLength(
+          mode === "replace" ? 10 : 2,
+        );
+        expect(output?.agents?.defaults?.models).toEqual(original.agents?.defaults?.models);
+        expect(resolveAgentModelPrimaryValue(output?.agents?.defaults?.model)).toBe(
+          "baseten/thinkingmachines/inkling",
+        );
+        expect(resolveAgentModelFallbackValues(output?.agents?.defaults?.model)).toEqual([
+          "fixture/fallback",
+        ]);
+      }
+      expect(input).toEqual(original);
+    },
+  );
+
   it("registers authenticated live and network-free static catalogs", async () => {
     const provider = await registerSingleProviderPlugin(basetenPlugin);
     const choice = resolveProviderPluginChoice({

--- a/extensions/baseten/index.ts
+++ b/extensions/baseten/index.ts
@@ -4,7 +4,7 @@ import type { ProviderCatalogContext } from "openclaw/plugin-sdk/provider-catalo
 import { defineSingleProviderPluginEntry } from "openclaw/plugin-sdk/provider-entry";
 import { buildProviderReplayFamilyHooks } from "openclaw/plugin-sdk/provider-model-shared";
 import { projectBasetenLiveModels, resolveBasetenDynamicModel } from "./models.js";
-import { applyBasetenConfig } from "./onboard.js";
+import { applyBasetenSetupConfig } from "./onboard.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 import { buildStaticBasetenProvider } from "./provider-catalog.js";
 import { createBasetenThinkingWrapper } from "./stream.js";
@@ -21,7 +21,7 @@ export default defineSingleProviderPluginEntry({
     label: "Baseten",
     docsPath: "/providers/baseten",
     manifestAuth: {
-      applyConfig: applyBasetenConfig,
+      applyConfig: applyBasetenSetupConfig,
       noteTitle: "Baseten",
       noteMessage: [
         "Baseten hosts Thinking Machines Lab's Inkling and other frontier models behind one OpenAI-compatible API.",

--- a/extensions/baseten/onboard.ts
+++ b/extensions/baseten/onboard.ts
@@ -1,15 +1,25 @@
 /** Baseten onboarding config helpers. */
-import { createModelCatalogPresetAppliers } from "openclaw/plugin-sdk/provider-onboard";
+import {
+  createModelCatalogPresetAppliers,
+  type ModelDefinitionConfig,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
 import { BASETEN_BASE_URL, BASETEN_DEFAULT_MODEL_REF, buildStaticBasetenModels } from "./models.js";
 
-/** Applies Baseten's provider catalog, Inkling alias, and default model. */
-export const { applyConfig: applyBasetenConfig } = createModelCatalogPresetAppliers<[]>({
+const { applyConfig } = createModelCatalogPresetAppliers<[ModelDefinitionConfig[]]>({
   primaryModelRef: BASETEN_DEFAULT_MODEL_REF,
-  resolveParams: () => ({
+  resolveParams: (_cfg, catalogModels) => ({
     providerId: "baseten",
     api: "openai-completions",
     baseUrl: BASETEN_BASE_URL,
-    catalogModels: buildStaticBasetenModels(),
+    catalogModels,
     aliases: [{ modelRef: BASETEN_DEFAULT_MODEL_REF, alias: "Inkling" }],
   }),
 });
+
+/** Applies Baseten's provider catalog, Inkling alias, and default model. */
+export const applyBasetenConfig = (cfg: OpenClawConfig) =>
+  applyConfig(cfg, buildStaticBasetenModels());
+
+export const applyBasetenSetupConfig = (cfg: OpenClawConfig) =>
+  applyConfig(cfg, cfg.models?.mode === "replace" ? buildStaticBasetenModels() : []);


### PR DESCRIPTION
Related: #141531.

## What Problem This Solves

Fixes an issue where ordinary provider onboarding copied bundled catalog models into saved configuration, making generated inventory indistinguishable from authored settings.

## Why This Change Was Made

Registered setup uses a private callback that adds no catalog rows in ordinary mode. Keep the shared configuration applier, authored rows, aliases and caller-specific defaults. Explicit replace mode and the public configuration helper still seed the catalog.

## User Impact

Ordinary onboarding preserves authored configuration without saving generated inventory. Explicit replacement and public-helper behavior remain available.

Consumers: registered provider setup becomes passive about catalog rows; explicit replacement retains seeding.

## Evidence

The public onboarding regression saved nine unwanted rows before the fix. Sixteen candidate tests and a plugin build passed. Source-mode setup and public-helper checks covered authored, repeated and replace modes. Real Gateway checks covered failure, empty results, recovery and authored-row retention without external inference.
