### PR TITLE
fix(worker): keep cloud bootstrap build closure self-contained

### DIFF
--- a/scripts/check-cli-bootstrap-imports.mts
+++ b/scripts/check-cli-bootstrap-imports.mts
@@ -12,6 +12,7 @@ import {
 } from "../src/shared/worker-bundle-hash.js";
 import { isDirectRunUrl } from "./lib/direct-run.mjs";
 import { readGatewayRunChunks } from "./lib/gateway-run-chunk-metadata.mts";
+import { isUnstagedWorkerDeployRuntimeArtifact } from "./lib/worker-deploy-build-plugin.mts";
 
 const DEFAULT_ENTRYPOINTS = ["dist/entry.js", "dist/cli/run-main.js"];
 const DEFAULT_NATIVE_HOOK_RELAY_ENTRYPOINT = "dist/native-hook-relay/entry.js";
@@ -483,7 +484,7 @@ export function collectWorkerDeployArtifactErrors(params: CliBootstrapCheckParam
         );
       } else if (entry.name === "node_modules") {
         errors.push("Worker deploy artifact must not contain materialized dependencies.");
-      } else if (/\.(?:mjs|node|wasm)$/u.test(entry.name)) {
+      } else if (isUnstagedWorkerDeployRuntimeArtifact(entry.name, artifactNames)) {
         errors.push(
           `Worker deploy artifact emits unstaged runtime asset ${path.relative(
             rootDir,

--- a/scripts/lib/worker-deploy-build-plugin.mts
+++ b/scripts/lib/worker-deploy-build-plugin.mts
@@ -40,6 +40,14 @@ export function resolveWorkerDeployGeneratorInputs(rootDir = process.cwd()) {
   ] as const;
 }
 
+/** The worker archive stages entry files only; emitted runtime auxiliaries have no owner. */
+export function isUnstagedWorkerDeployRuntimeArtifact(
+  fileName: string,
+  entrypoints: ReadonlySet<string>,
+): boolean {
+  return !entrypoints.has(fileName) && /\.(?:mjs|node|wasm)$/u.test(fileName);
+}
+
 /** Composes bundled-plugin runtime and removes dependency package reads from the worker build. */
 export function createWorkerDeployBuildPlugin(rootDir = process.cwd()) {
   const playwrightRoot = fs.realpathSync(path.resolve(rootDir, "node_modules/playwright-core"));
@@ -73,6 +81,22 @@ export function createWorkerDeployBuildPlugin(rootDir = process.cwd()) {
 
   return {
     name: WORKER_DEPLOY_BUILD_PLUGIN_NAME,
+    generateBundle(
+      this: { error(message: string): never },
+      _options: unknown,
+      bundle: Record<string, { type: string; fileName: string; isEntry?: boolean }>,
+    ) {
+      const files = Object.values(bundle);
+      const entrypoints = new Set(
+        files.filter((file) => file.type === "chunk" && file.isEntry).map((file) => file.fileName),
+      );
+      // Check the complete emitted graph: a root facade is outside the later worker-directory scan.
+      for (const file of files) {
+        if (isUnstagedWorkerDeployRuntimeArtifact(file.fileName, entrypoints)) {
+          this.error(`Worker deploy artifact emits unstaged runtime asset ${file.fileName}.`);
+        }
+      }
+    },
     load(id: string) {
       return id === WORKER_DEPLOY_OPTIONAL_NATIVE_MODULE_ID
         ? 'throw new Error("optional host-native dependency unavailable in portable worker runtime");'

--- a/src/infra/update-candidate-paths.ts
+++ b/src/infra/update-candidate-paths.ts
@@ -1,0 +1,39 @@
+import path from "node:path";
+import { sha256Hex } from "./crypto-digest.js";
+import { isPathInside } from "./path-guards.js";
+
+// Keep path projection independent of snapshot orchestration: the snapshot owner
+// dynamically loads plugin projection, so importing it back creates a worker build cycle.
+/** Shared with config projection so custom agent directories use their copied database. */
+export function resolveUpdateCandidateStatePath(
+  sourceRoot: string,
+  targetRoot: string,
+  source: string,
+): string {
+  // Registered link/../ locators can identify a different inode from their
+  // normalized spelling; flattening them would overwrite another copied database.
+  const relative =
+    path.normalize(source) === source && isPathInside(sourceRoot, source)
+      ? path.relative(sourceRoot, source)
+      : path.join("candidate-external", sha256Hex(source));
+  return path.join(targetRoot, relative);
+}
+
+/** Plugin locators cannot overwrite the separately snapshotted state databases. */
+export function resolveUpdateCandidatePluginPath(
+  sourceRoot: string,
+  targetRoot: string,
+  source: string,
+): string {
+  const managed = ["npm", "extensions"].some((directory) =>
+    isPathInside(path.join(sourceRoot, directory), source),
+  );
+  return managed
+    ? resolveUpdateCandidateStatePath(sourceRoot, targetRoot, source)
+    : path.join(
+        targetRoot,
+        "candidate-plugins",
+        sha256Hex(path.parse(source).root),
+        path.relative(path.parse(source).root, source),
+      );
+}

--- a/src/infra/update-candidate-plugins.ts
+++ b/src/infra/update-candidate-plugins.ts
@@ -17,8 +17,8 @@ import {
 } from "./kysely-sync.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
 import { hasNodeErrorCode, isPathInside } from "./path-guards.js";
+import { resolveUpdateCandidatePluginPath } from "./update-candidate-paths.js";
 import { copyUpdateCandidatePluginTrees } from "./update-candidate-plugin-tree.js";
-import { resolveUpdateCandidatePluginPath } from "./update-candidate-state.js";
 
 async function resolvePluginFilePackageRoot(file: string): Promise<string> {
   const directory = path.dirname(file);

--- a/src/infra/update-candidate-rehearsal.ts
+++ b/src/infra/update-candidate-rehearsal.ts
@@ -13,10 +13,8 @@ import { tryListenOnPort } from "./ports-probe.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
 import { SUPERVISOR_HINT_ENV_VARS } from "./supervisor-markers.js";
-import {
-  resolveUpdateCandidateStatePath,
-  UpdateCandidateStateSnapshotSchema,
-} from "./update-candidate-state.js";
+import { resolveUpdateCandidateStatePath } from "./update-candidate-paths.js";
+import { UpdateCandidateStateSnapshotSchema } from "./update-candidate-state.js";
 import {
   CONTROL_PLANE_UPDATE_SENTINEL_META_ENV,
   UPDATE_RUN_ID_ENV,

--- a/src/infra/update-candidate-state.ts
+++ b/src/infra/update-candidate-state.ts
@@ -10,15 +10,15 @@ import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
 import { readStateSchemaContentVersion } from "../state/openclaw-state-db-schema-version.js";
 import type { DB } from "../state/openclaw-state-db.generated.js";
 import { resolveOpenClawRegisteredAgentDatabasePath } from "../state/openclaw-state-db.paths.js";
-import { sha256Hex } from "./crypto-digest.js";
 import { resolveUserPath } from "./home-dir.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "./kysely-sync.js";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
-import { hasNodeErrorCode, isPathInside } from "./path-guards.js";
+import { hasNodeErrorCode } from "./path-guards.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "./runtime-worker-url.js";
 import { prepareSqliteReadOnlyLocationSyncInProcess } from "./sqlite-readonly-location.js";
 import { readSqliteUserVersion } from "./sqlite-user-version.js";
+import { resolveUpdateCandidateStatePath } from "./update-candidate-paths.js";
 
 const UpdateStateSchemaVersionsSchema = z.array(
   z.object({
@@ -236,40 +236,6 @@ export async function readUpdateStateSchemaVersions({
     );
   }
   return UpdateStateSchemaVersionsSchema.parse(JSON.parse(result.stdout.toString("utf8")));
-}
-
-/** Shared with config projection so custom agent directories use their copied database. */
-export function resolveUpdateCandidateStatePath(
-  sourceRoot: string,
-  targetRoot: string,
-  source: string,
-): string {
-  // Registered link/../ locators can identify a different inode from their
-  // normalized spelling; flattening them would overwrite another copied database.
-  const relative =
-    path.normalize(source) === source && isPathInside(sourceRoot, source)
-      ? path.relative(sourceRoot, source)
-      : path.join("candidate-external", sha256Hex(source));
-  return path.join(targetRoot, relative);
-}
-
-/** Plugin locators cannot overwrite the separately snapshotted state databases. */
-export function resolveUpdateCandidatePluginPath(
-  sourceRoot: string,
-  targetRoot: string,
-  source: string,
-): string {
-  const managed = ["npm", "extensions"].some((directory) =>
-    isPathInside(path.join(sourceRoot, directory), source),
-  );
-  return managed
-    ? resolveUpdateCandidateStatePath(sourceRoot, targetRoot, source)
-    : path.join(
-        targetRoot,
-        "candidate-plugins",
-        sha256Hex(path.parse(source).root),
-        path.relative(path.parse(source).root, source),
-      );
 }
 
 /** Keep snapshot dependencies out of schema inspection; rebind registry paths to private copies. */

--- a/test/scripts/worker-deploy-build-plugin.test.ts
+++ b/test/scripts/worker-deploy-build-plugin.test.ts
@@ -19,6 +19,63 @@ const fail = (message: string): never => {
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 describe("worker deploy build plugin", () => {
+  it.each(["escaped.mjs", "worker/extra.mjs", "worker/native.node", "worker/runtime.wasm"])(
+    "rejects an unstaged emitted %s before publishing the worker graph",
+    (fileName) => {
+      const plugin = createWorkerDeployBuildPlugin();
+      expect(() =>
+        plugin.generateBundle.call(
+          { error: fail },
+          {},
+          {
+            "worker/worker.mjs": { type: "chunk", fileName: "worker/worker.mjs", isEntry: true },
+            [fileName]: { type: fileName.endsWith(".mjs") ? "chunk" : "asset", fileName },
+          },
+        ),
+      ).toThrow(`Worker deploy artifact emits unstaged runtime asset ${fileName}.`);
+    },
+  );
+
+  it("keeps the complete deploy graph inside its single staged worker file", async () => {
+    const { build } = await import("tsdown");
+    const { default: configs } = await import("../../tsdown.config.ts");
+    const config = configs.find(
+      (candidate) =>
+        typeof candidate.entry === "object" &&
+        !Array.isArray(candidate.entry) &&
+        candidate.entry?.["worker/worker"] === "src/worker/worker-deploy-entry.ts",
+    );
+    if (!config) {
+      throw new Error("Worker deploy build config is missing");
+    }
+    const root = tempDirs.make("openclaw-worker-complete-graph-");
+    const bundles = await build({
+      ...config,
+      config: false,
+      outDir: path.join(root, "dist"),
+      dts: false,
+      logLevel: "silent",
+    });
+    try {
+      // A dynamic import cycle can leave an unstaged root facade even with code splitting off.
+      expect(bundles.flatMap((bundle) => bundle.chunks.map((chunk) => chunk.fileName))).toEqual([
+        "worker/worker.mjs",
+      ]);
+      const { collectWorkerDeployArtifactErrors } =
+        await import("../../scripts/check-cli-bootstrap-imports.mts");
+      expect(
+        collectWorkerDeployArtifactErrors({
+          rootDir: root,
+          workerDeployEntrypoints: ["dist/worker/worker.mjs"],
+        }),
+      ).toEqual([]);
+    } finally {
+      for (const bundle of bundles) {
+        await bundle[Symbol.asyncDispose]();
+      }
+    }
+  });
+
   it("preserves WebSocket transport and lazy transcription in relocated worker output", async () => {
     const { build } = await import("tsdown");
     const { default: buildConfigs } = await import("../../tsdown.config.ts");


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where creating a cloud session failed before allocating a machine after a successful fresh build. Node bootstrap rejected an incomplete import closure involving `dist/update-candidate-plugins-*.mjs` and the separately staged `dist/worker/worker.mjs`.

## Why This Change Was Made

Plugin projection imported pure path helpers from the snapshot owner that dynamically imports it. Moving the unchanged helpers into one dependency leaf removes that cycle and keeps the deploy worker in its single staged file. The existing unstaged-runtime rule now also checks the bundler's complete output before publication, so an escaped root chunk fails the build immediately.

## User Impact

Cloud sessions can package the slim node runtime from a fresh build again. Candidate state and plugin paths keep their existing semantics, and the worker's three public artifact paths and schema version 16 are preserved.

## Evidence

- Reproduced the exact failure on a clean full build of `7a1f677e3cb5d4882c0cff0d76dd4af196c27c58` using the canonical node-bootstrap artifact provider.
- Rechecked fresh main `0f22cb304de7760de58ecc4d277de6a19d4c3fac`, including the separate plugin-ownership repair in #141515: the actual worker build still emitted a root facade importing `worker/worker.mjs`. The fix preserves that plugin-ownership repair.
- The original actual worker build emitted an extra root facade. The real-build regression fails on that output; the repaired actual worker build emits only `worker/worker.mjs`.
- Started the candidate checkout with the original built output still present. A canonical full rebuild passed in 4m 49.3s, removed the stale facade through normal build cleanup, and passed node bootstrap packaging. Minimal node archive (no selected plugins): 23,185,354 bytes; SHA-256 `0c156b843ada6033006c448ff1008af3dd593ff8d50f01ae2d485c00efa82eda`.
- Canonical worker staging still contains exactly `worker.mjs`, `github-exec-launcher.mjs`, and `workspace-rsync-receiver.mjs`.
- 79 focused tests passed on the original proof; 88 worker/build-guard and updater/state/canary tests passed after integration onto current main, including workspace hoists and aliased state directories. Independent P2 review of the integrated patch is clean.
- Full seven-file changed gate passed on the integrated source: core and test type checks, script/root-test type checks, lint, dead exports, runtime import cycles, and architecture guards.
- Actual cloud flow passed on committed candidate `ac21783909a0674cca4c5f11aaf592f67e30f3cb`: dispatch completed in 261.855 s, a real tool turn completed in 57.378 s, and the session restored 13 files then wrote the 14th without a new Gateway checkout. State/agent schemas remained 16/19. Cleanup verified the lease released, environment destroyed, no attachments, all 33 original process identities absent, and the Gateway port closed.

Runtime source is +3 lines after moving the helpers; build tooling is +25 lines to enforce the existing artifact contract at publication; tests are +57 lines. No dependency or configuration option was added.


The final branch is mechanically integrated onto main `bd62b672d9ab8556b72fa1668392192bbc8dce6a`. It preserves #120340's schema-reader import relocation and new shared bootstrap checks, and takes the already-landed QA scenario repair from #141555 rather than retaining a duplicate metadata commit. Five of the seven repair files remain byte-identical to the cloud candidate; the state owner's non-import body is unchanged and the shared checker preserves all intervening main content. This is not a claim that the refreshed whole build is identical to the earlier cloud build.

The current-main premise was rechecked with the actual worker configuration: it still emits `worker/worker.mjs` plus an unstaged non-entry plugin facade. On the final branch, all 93 affected worker/build-guard and updater state/canary tests, the complete seven-file changed gate, and independent P2 review (0.98) pass. The selected real Chromium credential scenario and 20 catalog-owner tests also passed while diagnosing the upstream QA fix. A single final main smoke follows landing; no additional performance claim is made.
