### PR TITLE
refactor: prepare model table formatting once

### DIFF
--- a/src/commands/models/list.format.ts
+++ b/src/commands/models/list.format.ts
@@ -28,10 +28,7 @@ export const padTerminalCell = (value: string, size: number) => {
 };
 
 /** Applies terminal color based on a model-list tag. */
-export const formatTag = (tag: string, rich: boolean) => {
-  if (!rich) {
-    return tag;
-  }
+export const formatTag = (tag: string) => {
   if (tag === "default") {
     return theme.success(tag);
   }
@@ -44,10 +41,7 @@ export const formatTag = (tag: string, rich: boolean) => {
   if (tag === "missing") {
     return theme.error(tag);
   }
-  if (tag.startsWith("fallback#")) {
-    return theme.warn(tag);
-  }
-  if (tag.startsWith("img-fallback#")) {
+  if (tag.startsWith("fallback#") || tag.startsWith("img-fallback#")) {
     return theme.warn(tag);
   }
   if (tag.startsWith("alias:")) {

--- a/src/commands/models/list.table.test.ts
+++ b/src/commands/models/list.table.test.ts
@@ -52,8 +52,16 @@ describe("printModelTable", () => {
     expect(runtime.log).not.toHaveBeenCalled();
   });
 
-  it("prints effective and native context values when a runtime cap differs", () => {
+  it("prints context caps with sanitized tags in their original order", () => {
     const runtime = { log: vi.fn(), error: vi.fn() };
+    const tags = [
+      "\u001b[31mdefault\u001b[0m",
+      "fallback#2",
+      "img-fallback#1",
+      "alias:a\tb",
+      "unknown",
+      "default",
+    ];
     const rows: ModelRow[] = [
       {
         key: "openai/gpt-5.5",
@@ -63,7 +71,7 @@ describe("printModelTable", () => {
         contextTokens: 272_000,
         local: false,
         available: true,
-        tags: [],
+        tags,
         missing: false,
       },
     ];
@@ -73,7 +81,17 @@ describe("printModelTable", () => {
     // Decimal windows render in decimal K: 272000 -> "272k", 400000 -> "400k".
     expect(runtime.log.mock.calls).toEqual([
       ["Model                                      Input      Ctx         Local Auth  Tags"],
-      ["openai/gpt-5.5                             text+image 272k/400k   no    yes   "],
+      [
+        "openai/gpt-5.5                             text+image 272k/400k   no    yes   default,fallback#2,img-fallback#1,alias:a\\tb,unknown,default",
+      ],
+    ]);
+    expect(rows[0]?.tags).toEqual([
+      "\u001b[31mdefault\u001b[0m",
+      "fallback#2",
+      "img-fallback#1",
+      "alias:a\tb",
+      "unknown",
+      "default",
     ]);
   });
 

--- a/src/commands/models/list.table.ts
+++ b/src/commands/models/list.table.ts
@@ -45,6 +45,9 @@ export function printModelTable(
   }
 
   const rich = isRich(opts);
+  const formatRowTag = rich
+    ? (tag: string) => formatTag(sanitizeTerminalText(tag))
+    : sanitizeTerminalText;
   const header = [
     padTerminalCell("Model", MODEL_PAD),
     padTerminalCell("Input", INPUT_PAD),
@@ -56,20 +59,14 @@ export function printModelTable(
   runtime.log(rich ? theme.heading(header) : header);
 
   for (const row of rows) {
-    const keyLabel = padTerminalCell(truncate(sanitizeTerminalText(row.key), MODEL_PAD), MODEL_PAD);
+    const keyLabel = padTerminalCell(truncate(row.key, MODEL_PAD), MODEL_PAD);
     const inputLabel = padTerminalCell(sanitizeTerminalText(row.input) || "-", INPUT_PAD);
     const ctxLabel = padTerminalCell(formatContextLabel(row), CTX_PAD);
     const localText = row.local === null ? "-" : row.local ? "yes" : "no";
     const localLabel = padTerminalCell(localText, LOCAL_PAD);
     const authText = row.available === null ? "-" : row.available ? "yes" : "no";
     const authLabel = padTerminalCell(authText, AUTH_PAD);
-    const tags = row.tags.map(sanitizeTerminalText);
-    const tagsLabel =
-      tags.length > 0
-        ? rich
-          ? tags.map((tag) => formatTag(tag, rich)).join(",")
-          : tags.join(",")
-        : "";
+    const tagsLabel = row.tags.map(formatRowTag).join(",");
 
     const coloredInput = colorize(
       rich,


### PR DESCRIPTION
## What Problem This Solves

The model-list table repeats formatting work for each row: model keys are sanitized twice, and colored tags are collected in one array before another mapping pass styles them.

## Why This Change Was Made

Choose the tag formatter once per table, sanitize and style tags in one pass, and let the existing width-aware truncation helper own key sanitation. Remove the private tag helper's unused non-rich branch and merge its identical warning-color branches. JSON/plain writer paths, terminal safety, tag order/duplicates, input ownership, column widths, and context labels remain unchanged.

Production: 7 added / 16 removed (net −9). Tests: 21 added / 3 removed (net +18), extending the existing context-cap case with ordered, duplicate, sanitized tags and input preservation. No new public option, dependency, cache, or compatibility path.

## User Impact

Less local formatting work for common model tables, with byte-identical captured output. For 512 rows with mixed tags, median formatting cost fell 3–11% in all four comparisons. Other cases regress; this does not establish faster catalog loading, terminal I/O, CLI startup, or Gateway turns.

## Evidence

- All 13 focused tests passed on baseline and candidate. All 29 changed-code checks passed; independent P2 review found no actionable issue.
- Fixed 22-case baseline/candidate/candidate/baseline cohorts separately under FORCE_COLOR 0 and 1: all 7,216 complete output records matched across variants.
- Independent audit decoded all 352 gzip/V8 graphs, checked every clock and journal position, retained input descriptors and callback order, and verified original-row aliases in 984 full JSON callbacks. Plain/fallback JSON and basic terminal rows also have independent literal oracles.
- Each case has one first call, eight warmups, and eight groups of four individually timed calls. Output sinks collect actual printer callbacks; snapshotting, compression, verification and journal writes occur outside each clock. Their overhead can still affect process/cache conditions and is not a product optimization.

Negative percentages below mean less time. Cells compare medians of eight four-call means, not population percentiles or independent statistical trials.

| Case | No color forward | No color reverse | Color forward | Color reverse |
| --- | ---: | ---: | ---: | ---: |
| table-empty | -51.50% | +43.11% | -28.38% | +23.41% |
| table-one-empty-tags | -15.25% | -36.71% | -8.57% | -23.71% |
| table-one-mixed-tags | -40.10% | +7.76% | -15.55% | +5.99% |
| table-32-empty-tags | -5.72% | -13.36% | -4.45% | -0.36% |
| table-32-mixed-tags | -3.35% | -15.74% | -6.38% | -2.35% |
| table-512-empty-tags | -10.04% | +14.28% | -14.45% | -3.01% |
| table-512-mixed-tags | -3.37% | -10.88% | -7.95% | -10.39% |
| table-32-dense-tags | +4.15% | +2.64% | -5.11% | -1.10% |
| table-512-dense-tags | -0.33% | +19.01% | -12.32% | +9.00% |
| table-32-unicode | -5.55% | -4.10% | -15.42% | -1.89% |
| table-32-long-keys | -5.24% | -10.59% | -8.85% | -1.17% |
| table-32-controls | -6.44% | +10.34% | -14.16% | -6.65% |
| table-32-context-limits | -4.27% | -2.72% | -8.93% | +0.13% |
| table-one-unknown-flags | -2.29% | +2.44% | +1.05% | -12.60% |
| plain-empty | -25.00% | +26.64% | -43.60% | -34.25% |
| plain-32-controls | +3.17% | +13.35% | -12.75% | -13.47% |
| plain-512 | +3.08% | -2.76% | -4.59% | +6.74% |
| json-empty | -1.85% | -14.86% | -22.13% | -7.97% |
| json-32-controls | -8.55% | -2.96% | -43.51% | -21.88% |
| json-512 | +6.52% | +41.69% | -4.43% | -8.20% |
| plain-fallback-writer | +5.38% | -4.14% | -16.43% | -0.22% |
| json-fallback-writer | -15.69% | -19.59% | -7.51% | -5.80% |

67/88 medians improved and 21 regressed. All adverse counts remain recorded: 1,064/2,816 paired sample calls; 258/704 group means; 105/352 summary metrics (21 medians, 30 means, 33 maxima, 21 minima); 40/88 first-call pairs; 291/704 warmup pairs; and 7/20 whole-child resources. These paired positions are descriptive, not independent trials.

Notable costs include uncolored 32-row dense tags (+4.15%/+2.64%), reverse 512-row dense tags (+19.01% uncolored/+9.00% colored), uncolored reverse 512 empty tags (+14.28%), and uncolored JSON-512 controls (+6.52%/+41.69%). Unchanged controls vary too; no result is discarded or explained away as proven noise.

Whole-child resources below include imports, fixture construction, snapshots, V8/gzip, equality checks, and evidence writes. They are not isolated printer or import measurements, and do not prove a general memory improvement.

| Phase | Wall seconds | User CPU seconds | System CPU seconds | Kernel max RSS MiB | Observed tree peak MiB |
| --- | ---: | ---: | ---: | ---: | ---: |
| B0-color-0 | 15.5602 | 18.4247 | 0.5231 | 818.61 | 835.08 |
| C0-color-0 | 14.9983 | 17.7314 | 0.5591 | 812.80 | 828.25 |
| C1-color-0 | 18.1141 | 19.5140 | 0.5455 | 824.14 | 833.67 |
| B1-color-0 | 17.3949 | 19.6591 | 0.6013 | 917.88 | 928.48 |
| B0-color-1 | 15.7523 | 18.7917 | 0.5466 | 833.50 | 835.12 |
| C0-color-1 | 14.9274 | 17.7023 | 0.5544 | 823.16 | 827.80 |
| C1-color-1 | 15.1319 | 17.9532 | 0.5368 | 832.17 | 852.33 |
| B1-color-1 | 15.0992 | 17.9025 | 0.5417 | 830.34 | 847.78 |

All eight native runners and outer processes closed successfully; the candidate was restored and source/dependency pins rechecked. Other host work was not globally stopped. Each phase has its own bound; no aggregate cohort deadline is claimed.

The initial review setup rejected absolute input paths before running a reviewer; the corrected repository-relative invocation passed. That failure is preserved. Before any benchmark data, exception bookkeeping was corrected to retain falsy thrown values; timings, corpus, counts and limits were unchanged. Neither event replaced a completed numerical capture.

Focused verification: `node scripts/run-vitest.mjs src/commands/models/list.table.test.ts src/commands/models/list.format.test.ts`, followed by the normal changed-code gate against `8efdc03f8c0bb19623adbff4dbef29f969e63a07`. The measured owner is the actual `printModelTable` export; campaign Gateway measurements remain separate.

CI refresh: the initial run found a stale QA credential-scenario selector inherited from main. Existing PR #141555 repaired that selector and its criteria. This branch was refreshed onto repaired main; the introduced patch is byte-identical and all three reviewed source blobs are unchanged. The original failed run and benchmark evidence remain preserved; fresh CI is required for the refreshed head.
