### PR TITLE
fix(qa): restore Gateway credential scenario selection

### DIFF
--- a/qa/scenarios/ui/control-ui-token-password-auth.yaml
+++ b/qa/scenarios/ui/control-ui-token-password-auth.yaml
@@ -1,4 +1,4 @@
-title: Control UI token and password credential submission
+title: Control UI Gateway secret submission
 
 scenario:
   id: control-ui-token-password-auth
@@ -8,13 +8,13 @@ scenario:
     primary:
       - control-ui.token-password-auth
   objective: >-
-    Prove the Control UI submits operator-entered token and password
-    credentials in browser connect requests and renders deterministic accepted,
-    rejected, and recovered outcomes.
+    Prove the Control UI submits one operator-entered Gateway secret for token
+    and password authentication and renders deterministic accepted, rejected,
+    and recovered outcomes.
   successCriteria:
     - Real Chromium renders the login gate after the mocked Gateway requests credentials.
-    - Token submission appears only in the connect token field and visibly reaches the connected shell.
-    - Password submission appears only in the connect password field.
+    - The Gateway secret appears in both connect authentication fields and visibly reaches the connected shell when accepted as a token.
+    - Password submission uses the same Gateway secret field and appears in both connect authentication fields.
     - A rejected password renders visible recovery guidance and the mismatch reason without mounting the shell.
     - A replacement password visibly reconnects, with screenshots, video, and a credential-free behavior summary retained as artifacts.
   docsRefs:
@@ -26,7 +26,7 @@ scenario:
   execution:
     kind: playwright
     path: ui/src/e2e/control-ui-credentials.e2e.test.ts
-    testNamePattern: submits token and password credentials with visible acceptance and rejection recovery
+    testNamePattern: submits one secret for both authentication modes with visible acceptance and rejection recovery
     summary: >-
-      Real Chromium coverage for Control UI credential selection, connect-frame
-      consumption, and visible authentication recovery at the browser boundary.
+      Real Chromium coverage for the single Gateway secret field, both connect
+      authentication fields, and visible authentication recovery at the browser boundary.


### PR DESCRIPTION
Closes #141545
Related: #141514

## What Problem This Solves

Fixes an issue where the QA Lab credential scenario no longer selects its executable browser test after the Control UI changed to one Gateway secret field. The scenario also describes the previous separate-field wire behavior.

## Why This Change Was Made

Update the selector and criteria to match the maintained executable flow: one entered secret is sent in both connect authentication fields, with token acceptance, password rejection, and recovery checked visibly. Scenario and coverage IDs, assertions, and authentication behavior remain unchanged.

## User Impact

QA operators can run the existing credential scenario again and receive criteria that describe the current Control UI flow. This also repairs the deterministic scenario-discovery failure inherited by other PRs from main.

## Evidence

- Existing discovery guard fails before because the configured test-name pattern matches no executable test.
- Existing native scenario runner and catalog suites: 78 passed after.
- Existing real Chromium/mock-Gateway credential flow, selected through the corrected pattern: 1 passed in 9.85 seconds. Synthetic credentials only.
- Formatting and whitespace checks pass. Independent local source review found no actionable issues.
- No test, assertion, schema, or authentication-code changes.
