### PR TITLE
refactor(plugins): share root-relative MCP assembly

### DIFF
--- a/src/plugins/bundle-mcp.ts
+++ b/src/plugins/bundle-mcp.ts
@@ -452,29 +452,7 @@ function loadBundleFileBackedMcpConfig(params: {
   };
 }
 
-function loadBundleInlineMcpConfig(params: {
-  raw: Record<string, unknown>;
-  baseDir: string;
-}): BundleMcpRuntimeConfig {
-  if (!isRecord(params.raw.mcpServers)) {
-    return { mcpServers: {}, prepareDataDirsByServer: {} };
-  }
-  const baseDir = normalizeBundlePath(params.baseDir);
-  const servers = extractMcpServerMap(params.raw.mcpServers);
-  return {
-    mcpServers: Object.fromEntries(
-      Object.entries(servers).map(([serverName, server]) => [
-        serverName,
-        absolutizeBundleMcpServer({ rootDir: baseDir, baseDir, server }),
-      ]),
-    ),
-    prepareDataDirsByServer: Object.fromEntries(
-      Object.keys(servers).map((serverName) => [serverName, null]),
-    ),
-  };
-}
-
-function loadNativePluginMcpConfig(params: {
+function loadRootRelativeMcpConfig(params: {
   rootDir: string;
   mcpServers: Record<string, BundleMcpServerConfig>;
 }): { config: BundleMcpRuntimeConfig; diagnostics: string[] } {
@@ -539,10 +517,10 @@ function loadBundleMcpConfig(params: {
   if (params.bundleFormat !== "agent") {
     merged = applyMergePatch(
       merged,
-      loadBundleInlineMcpConfig({
-        raw: manifestLoaded.raw,
-        baseDir: params.rootDir,
-      }),
+      loadRootRelativeMcpConfig({
+        rootDir: params.rootDir,
+        mcpServers: extractMcpServerMap(manifestLoaded.raw.mcpServers),
+      }).config,
     ) as BundleMcpRuntimeConfig;
   }
 
@@ -561,7 +539,7 @@ export function inspectNativePluginMcpRuntimeSupport(params: {
   rootDir: string;
   mcpServers: Record<string, BundleMcpServerConfig>;
 }): BundleMcpRuntimeSupport {
-  return inspectMcpServerRuntimeSupport(loadNativePluginMcpConfig(params));
+  return inspectMcpServerRuntimeSupport(loadRootRelativeMcpConfig(params));
 }
 
 function inspectMcpServerRuntimeSupport(loaded: {
@@ -609,7 +587,7 @@ export function loadEnabledBundleMcpConfig(params: {
     loadBundleConfig: loadBundleMcpConfig,
     loadNativePluginConfig: ({ record }) =>
       record.mcpServers
-        ? loadNativePluginMcpConfig({
+        ? loadRootRelativeMcpConfig({
             rootDir: record.rootDir,
             mcpServers: record.mcpServers,
           })


### PR DESCRIPTION
## What Problem This Solves

Inline bundle MCP declarations and native plugin declarations duplicated the same root-relative server assembly. Each copy normalized the plugin root, resolved server paths and created preparation metadata, leaving two places to maintain the same behavior.

## Why This Change Was Made

Reuse the existing builder under the private name `loadRootRelativeMcpConfig` and remove the inline copy. Inline declarations retain their existing map extraction and merge position. File-backed and Agent-format configuration continue through their existing owners.

## User Impact

Existing plugin MCP configurations retain the same path resolution, merge ordering and diagnostics. This removes 22 production lines from one module without changing the public configuration or SDK surface.

## Evidence

The same 19 existing packaging and consumer cases passed before and after the refactor; five unrelated cases were explicitly filtered. No tests or snapshots changed. All 28 selected changed checks passed, including core and core-test type checking. Independent managed P0–P2 review found no actionable defect.
