### PR TITLE
fix(health): report disabled channel accounts as off

### DIFF
--- a/docs/cli/health.md
+++ b/docs/cli/health.md
@@ -32,7 +32,8 @@ openclaw health --debug
 
 - Without `--verbose`, the Gateway can return a cached snapshot (fresh for up to 60 seconds and unchanged from live channel runtime state) and refresh it in the background for the next caller.
 - `--verbose` forces a live probe (per-channel account probes), prints Gateway connection details, and expands human-readable output across all configured accounts and agents instead of just the default agent.
-- An unconfigured preferred account does not hide probe results from other active accounts. Ordinary output still follows the default agent's account bindings; `--verbose` includes all accounts.
+- An unconfigured or disabled preferred account does not hide probe results from other active accounts. Ordinary output still follows the default agent's account bindings; `--verbose` includes all accounts.
+- When the displayed account is disabled, health text shows `disabled` and `status --deep` marks it `OFF`, even if the account remains configured.
 - Unhealthy channel lines include the recorded startup error when available, so a stopped channel reports its failure cause alongside its state.
 - `--json` always returns the full snapshot: channels, per-account probes, plugin load state, context-engine quarantine state, model-pricing cache state, event-loop health, delivery-queue warnings, and per-agent session stores.
 - Session ages in text and JSON use the Gateway's clock.

--- a/src/commands/health-format.test.ts
+++ b/src/commands/health-format.test.ts
@@ -186,6 +186,21 @@ describe("formatHealthChannelLines", () => {
       "auth stabilizing",
     ],
     [
+      "disabled account over configured metadata",
+      { enabled: false, stateReason: "disabled" },
+      "disabled",
+    ],
+    [
+      "disabled account over a stale successful probe",
+      { enabled: false, healthState: "healthy", probe: { ok: true, elapsedMs: 12 } },
+      "disabled",
+    ],
+    [
+      "disabled account over stale failure metadata",
+      { enabled: false, healthState: "blocked", probe: { ok: false, error: "old failure" } },
+      "disabled",
+    ],
+    [
       "disabled status over stale passive healthy state",
       { healthState: "healthy", statusState: "disabled" },
       "disabled",
@@ -226,6 +241,29 @@ describe("formatHealthChannelLines", () => {
 
     expect(formatHealthChannelLines(summary)).toStrictEqual([`Test: ${expected}`]);
   });
+
+  it.each(["default", "all"] as const)(
+    "renders a sole disabled configured account in %s health output",
+    (accountMode) => {
+      const account = {
+        accountId: "main",
+        enabled: false,
+        configured: true,
+        running: false,
+        stateReason: "disabled",
+        lastError: null,
+      };
+      const summary = createHealthSummary({
+        channels: { matrix: { ...account, accounts: { main: account } } },
+        channelOrder: ["matrix"],
+        channelLabels: { matrix: "Matrix" },
+      });
+
+      expect(formatHealthChannelLines(summary, { accountMode })).toStrictEqual([
+        "Matrix: disabled",
+      ]);
+    },
+  );
 
   it.each([
     ["blocked", { healthState: "blocked" }],
@@ -272,26 +310,31 @@ describe("formatHealthChannelLines", () => {
       expectedAll: "failed (unknown) - sync rejected",
     },
   ])(
-    "reports the $name active probe when the preferred account is unconfigured",
+    "reports the $name active probe when the preferred account is inactive",
     ({ probe, expected, expectedAll }) => {
-      const summary = createMultiAccountHealthSummary(
-        { healthState: "healthy", probe },
-        { configured: false, linked: undefined, healthState: undefined, probe: undefined },
-      );
-      const accountIdsByChannel = { matrix: ["main"] };
+      for (const [inactive, scopedState] of [
+        [{ configured: false }, "not configured"],
+        [{ enabled: false }, "disabled"],
+      ] as const) {
+        const summary = createMultiAccountHealthSummary(
+          { healthState: "healthy", probe },
+          { ...inactive, linked: undefined, healthState: undefined, probe: undefined },
+        );
+        const accountIdsByChannel = { matrix: ["main"] };
 
-      expect(formatHealthChannelLines(summary)).toStrictEqual([`Matrix: ${expected}`]);
-      expect(
-        formatHealthChannelLines(summary, { accountMode: "all", accountIdsByChannel }),
-      ).toStrictEqual([`Matrix: ${expectedAll}`]);
-      expect(
-        formatHealthChannelLines(summary, { accountMode: "default", accountIdsByChannel }),
-      ).toStrictEqual(["Matrix: not configured"]);
-      expect(
-        formatHealthChannelLines(summary, {
-          accountIdsByChannel: { matrix: ["alerts"] },
-        }),
-      ).toStrictEqual([`Matrix: ${expected}`]);
+        expect(formatHealthChannelLines(summary)).toStrictEqual([`Matrix: ${expected}`]);
+        expect(
+          formatHealthChannelLines(summary, { accountMode: "all", accountIdsByChannel }),
+        ).toStrictEqual([`Matrix: ${expectedAll}`]);
+        expect(
+          formatHealthChannelLines(summary, { accountMode: "default", accountIdsByChannel }),
+        ).toStrictEqual([`Matrix: ${scopedState}`]);
+        expect(
+          formatHealthChannelLines(summary, {
+            accountIdsByChannel: { matrix: ["alerts"] },
+          }),
+        ).toStrictEqual([`Matrix: ${expected}`]);
+      }
     },
   );
 

--- a/src/commands/health-format.ts
+++ b/src/commands/health-format.ts
@@ -186,15 +186,15 @@ export const formatHealthChannelLines = (
       typeof selectedSummary.healthState === "string" && selectedSummary.healthState
         ? selectedSummary.healthState
         : null;
-    const linked = typeof selectedSummary.linked === "boolean" ? selectedSummary.linked : null;
-    const configured =
-      typeof selectedSummary.configured === "boolean" ? selectedSummary.configured : null;
+    const { linked, configured } = selectedSummary;
     const inactiveState =
-      statusState === "disabled" || statusState === "unconfigured"
-        ? formatChannelStatusState(statusState)
-        : configured === false
-          ? "not configured"
-          : null;
+      selectedSummary.enabled === false
+        ? "disabled"
+        : statusState === "disabled" || statusState === "unconfigured"
+          ? formatChannelStatusState(statusState)
+          : configured === false
+            ? "not configured"
+            : null;
     // Explicit inactive/degraded facts outrank probes; passive success waits until after them.
     // Otherwise a live probe can be hidden behind stale "healthy", "linked", or "configured".
     const preProbeState = inactiveState

--- a/src/commands/status.command-sections.test.ts
+++ b/src/commands/status.command-sections.test.ts
@@ -319,6 +319,11 @@ describe("status.command-sections", () => {
       status: "muted(OFF)",
       detail: "not configured",
     },
+    {
+      account: { enabled: false, lastError: "previous start failed" },
+      status: "muted(OFF)",
+      detail: "disabled (previous start failed)",
+    },
   ])("classifies the real channel health detail $detail", ({ account, status, detail }) => {
     const health: HealthSummary = {
       ok: true,

--- a/src/commands/status.command-sections.ts
+++ b/src/commands/status.command-sections.ts
@@ -307,7 +307,7 @@ export function buildStatusHealthRows(params: {
     const status =
       normalized === "healthy" || normalized.startsWith("ok") || normalized.startsWith("configured")
         ? params.ok("OK")
-        : normalized.startsWith("not configured")
+        : normalized.startsWith("not configured") || normalized.startsWith("disabled")
           ? params.muted("OFF")
           : normalized.startsWith("linked")
             ? params.ok("LINKED")


### PR DESCRIPTION
Closes #141550

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators inspecting a configured but disabled channel account would see `configured` in health output and an `OK` chip in the deep Health table, despite the account JSON and Channels section correctly reporting it disabled.

## Why This Change Was Made

The shared health formatter now gives the existing `enabled: false` fact precedence over configured metadata, old probes, and retained health state. The deep Health table maps the resulting disabled text to its existing OFF style. Active sibling selection, explicit account scopes, recorded errors, JSON, and channel lifecycle behavior remain intact.

## User Impact

Ordinary health says `disabled`; `status --deep` shows `OFF / disabled`. Configuration, storage, provider calls, and public options are unchanged. Production LOC is +9/−9 (net zero); tests are net +48 and docs net +1.

## Evidence

- The tests-only baseline produced eight intended failures with 60 passing controls. The formatter-only repair reduced this to one OFF-chip failure; the complete repair passes all 68 tests.
- The full changed-file checks and independent P0–P2 review passed. Both normal builds passed.
- Real normal CLI and isolated Gateway runs reproduced the original displays and verified the corrected ones. Each phase ran config validation plus five normal reads; all commands exited zero. Canonical account facts matched across phases and remained unchanged after the reads.
- Both configured loopback API observers recorded zero accepted connections. Both Gateways and observers exited normally, and recorded identities/listeners were absent. This is disabled-account metadata proof; it does not claim real Bot API, model, or global network behavior.
- Before/after snapshots match for 39,319 tracked source files, 14,382 build artifacts, and 1,621 dependency manifest/input hashes in each checkout. Runtime proof used source `c20600ad` plus the exact candidate patch; commit `62014e69` preserves those source bytes.
- All four native screenshots were inspected and independently audited. The deep capture shows the live Health-section output while retaining complete raw CLI stdout separately.

Both phases also logged an unchanged `system-presence` permission rejection and the expected cron-disabled warning. First introduction is unverified; current main retains the affected code unchanged.

## Before and after

Before:

![Disabled account incorrectly shown as configured by health](https://github.com/user-attachments/assets/6c3fd1c1-2257-4592-b396-61bdab567e4f)

![Disabled account incorrectly shown as OK in the deep Health table](https://github.com/user-attachments/assets/878c1074-cdf9-459f-98f9-1be06ae18805)

After:

![Disabled account correctly shown as disabled by health](https://github.com/user-attachments/assets/d069aefc-9bad-408b-bd69-f3f2b3784d38)

![Disabled account correctly shown as OFF in the deep Health table](https://github.com/user-attachments/assets/7442b1f8-f67a-4bed-9023-dd8b614d5065)

## Review follow-through

The PR is ready for review. The September 7 ClawSweeper review found no actionable code defect and could not retrieve the linked screenshots because its retrieval returned cache misses. The maintainer reopened all four complete original captures and confirmed the visible baseline `configured` / `OK` and candidate `disabled` / `OFF` output; a separate artifact auditor also inspected all four frames and checked 58 artifact seals. That local visual verification resolves the evidence concern without claiming the bot inspected the images. The existing source, tests, and runtime proof remain unchanged.

## Current validation head

The branch was rebased to `c63b6d9ca93c1d66e842c5a76f8e6449f849d5fc` after the original CI merge encountered an unrelated stale QA scenario selector. Upstream #141555 had already repaired that selector on main. The complete health patch and all five changed files are byte-for-byte identical to the originally built and live-tested source; the local build/CLI proof remains bound to `c20600ad` plus that patch. Fresh exact-head CI: https://github.com/openclaw/openclaw/actions/runs/34162954541.

The refreshed CI completed successfully with 108 successful jobs and 16 skipped jobs. Fresh independent P0–P2 branch review completed with no actionable findings. The latest ClawSweeper review of the same head lists no before-merge items.
