### PR TITLE
fix(update): recover stale runs without stopping healthy gateways

### DIFF
--- a/config/knip.config.ts
+++ b/config/knip.config.ts
@@ -91,6 +91,8 @@ const repositoryScriptEntries = [
   // systemd-sealed-service-definition.sh executes these via Node stdin and a container path.
   "scripts/e2e/lib/systemd-sealed-service-definition/file-mount.mjs!",
   "scripts/e2e/lib/systemd-sealed-service-definition/paired-mounts.mjs!",
+  // abandoned-update.sh invokes the upgrade ledger assertions through Node.
+  "scripts/e2e/lib/upgrade-survivor/abandoned-update.mjs!",
   "scripts/e2e/lib/upgrade-survivor/config-parking.mjs!",
   // Capture runs in the container; sanitization runs only on the trusted host.
   "scripts/e2e/lib/upgrade-survivor/diagnostics.mjs!",

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -218,6 +218,30 @@ gets a separate `runId`.
 
 `openclaw update --json` includes `runId` and the `run` record. `openclaw update status --json`
 includes `activeRun` when a run is active and `lastRun` when history exists.
+When the active row has been inactive for more than 30 minutes and its recorded
+driver is verifiably dead, status also reports `abandonedRun` with its `runId`
+and reconciliation `rule`. Status remains read-only: the stored row stays in
+`activeRun` until the Gateway or explicit repair commits the outcome.
+Identityless rows are never reconciled automatically, even when their only
+step is `requested/in_progress`. For stale identityless rows, JSON includes
+`staleRun` with `runId` and `guidance`; human status and Doctor preflight report
+"no activity since &lt;time&gt;; if no update is running, run `openclaw update repair`
+or start a new `openclaw update`".
+
+An explicit new `openclaw update` (including `--dry-run`) supersedes the old row
+only when it is the sole active run, has no recorded driver identity, and has
+had no activity for more than 30 minutes. Admission atomically finishes that
+row as `failed` with reason `superseded` and a retained `reconcile:superseded`
+step, then creates the new run. Recent rows and rows with recorded identities
+are preserved. Inherited update continuations and automatic campaigns do not
+supersede legacy history. Configuration writes remain suspended until the
+active row is reconciled.
+
+OpenClaw 2026.9.2 can admit a new CLI update while an older row remains running;
+the stale row does not block updater admission. Upgrade normally, then run
+`openclaw update repair` from the updated installation if status still shows the
+old run. See [Updating](/install/updating#stale-update-history).
+
 Human output, chat completion notices, the Control UI update view, and the
 `openclaw status` update line use the same report, including on success. The report shows recorded facts; an absent verification fact
 means that check has not been observed.
@@ -244,6 +268,23 @@ Phases are `requested`, `staging`, `validating`, optional `repairing`, `activati
 automatic rollback cannot complete. Phase timings, repair attempts, and
 verification facts are included only when observed. Chat reports are limited to 1,500 characters;
 `update.runs.get` preserves the bounded record for detailed inspection.
+
+Current updaters record their process identities and refresh the ledger
+every 30 seconds during long build, install, and finalization phases. The Gateway checks for
+abandoned runs at startup and while following active updates. After more than
+30 minutes without step or heartbeat activity, verifiably dead recorded drivers
+allow the Gateway to finish the run as `failed` with reason `abandoned` and a
+`reconcile:abandoned` step naming the rule. A live, unreadable, or foreign-host
+driver prevents reconciliation. Each helper or finalization child records its
+own identity and retains earlier drivers, because detached children can outlive
+their parent.
+
+Historical rows without a driver identity require explicit `update repair` or
+a new operator-started `openclaw update`.
+An old `requested` row alone does not prove that its updater exited: the 2026.9.2
+updater can still be waiting on package-manager or registry preflight before it
+records its first staging step. Stop an unrecorded old updater before explicitly
+recovering its stale row. See [Database schemas](/reference/database-schemas#update-run-ledger).
 
 The run records `downtimeMs` from the service stop request until a Gateway is
 verified running. Staging, candidate validation, and pre-activation repair are excluded. Verification
@@ -292,7 +333,30 @@ openclaw update repair --accept-capabilities
 | `--accept-capabilities`                          | Accept each plugin's reviewed capability changes while repairing plugin state.                                                                                                                                                                                                                   |
 | `--no-restart`                                   | Accepted for parity; repair never restarts the Gateway.                                                                                                                                                                                                                                          |
 
-`update repair` runs `openclaw doctor --fix`, reloads the repaired config and
+`update repair` first inspects stale update history. When the installed Gateway
+generation is healthy and the only remaining problem is an inactive ledger row,
+repair records `failed` / `abandoned` and exits successfully without Doctor,
+maintenance, or a service stop. It also acknowledges a Gateway-reconciled row
+once within 30 minutes of reconciliation. Later repair invocations use full
+finalization, so historical recovery cannot suppress plugin convergence.
+Explicit recovery permits identityless historical rows only
+after more than 30 minutes of inactivity; a recorded live or uninspectable driver
+still blocks recovery. JSON output identifies reconciled run IDs in
+`reconciledRuns`, with `status: "ok"`, `mode: "repair"`, and `restart: false`.
+
+Explicit channel or capability changes and known incomplete post-core work use
+full finalization. Recorded activation, restart, verification, or finalization steps require
+that convergence even if the Gateway has already reconciled the run. If that
+work needs maintenance while the managed service is
+running, stop the service through its owner before retrying. Doctor cannot stop
+or restart the service on the update parent's behalf.
+Successful full finalization then reconciles the selected stale rows before
+reporting completion. Failed convergence leaves the selected rows intact. If any
+selected run resumes before reconciliation, the whole selection is preserved.
+Full finalization JSON includes `reconciledRuns` when stale rows were selected
+for recovery, listing the IDs reconciled by that invocation.
+
+For full finalization, `update repair` runs `openclaw doctor --fix`, reloads the repaired config and
 install records, syncs tracked plugins for the active update channel, updates
 managed npm plugin installs, repairs missing configured plugin payloads,
 refreshes the plugin registry, and writes converged install-record metadata.

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -277,7 +277,11 @@ allow the Gateway to finish the run as `failed` with reason `abandoned` and a
 `reconcile:abandoned` step naming the rule. A live, unreadable, or foreign-host
 driver prevents reconciliation. Each helper or finalization child records its
 own identity and retains earlier drivers, because detached children can outlive
-their parent.
+their parent. If process identity recording is unavailable, the update continues
+with one warning and the run requires explicit recovery. Known parent identities
+remain protected, and automatic reconciliation stays disabled for that run.
+Heartbeat write errors warn once per driver run and do not interrupt a running
+build, install, or finalization phase.
 
 Historical rows without a driver identity require explicit `update repair` or
 a new operator-started `openclaw update`.
@@ -346,7 +350,10 @@ still blocks recovery. JSON output identifies reconciled run IDs in
 
 Explicit channel or capability changes and known incomplete post-core work use
 full finalization. Recorded activation, restart, verification, or finalization steps require
-that convergence even if the Gateway has already reconciled the run. If that
+that convergence even if the Gateway has already reconciled the run. Repair
+checks newer abandoned history as well as active rows; an older stale row cannot
+hide unfinished work from a newer update. If the bounded history inspection is
+incomplete, repair also uses full finalization. If that
 work needs maintenance while the managed service is
 running, stop the service through its owner before retrying. Doctor cannot stop
 or restart the service on the update parent's behalf.

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -125,7 +125,8 @@ is deferred. The new Gateway runs on the migrated content during this interval.
 
 Publication waits until every affected update run has been terminal for at least
 five minutes. A running row that has not changed for more than 30 minutes counts
-as abandoned for this purpose. The Gateway watcher publishes after the deadline;
+as abandoned for publication purposes only; this does not terminalize an
+identityless update-history row. The Gateway watcher publishes after the deadline;
 a later database open can also publish it. See the precise timing and residual
 old-CLI limitation in [Database schemas](/reference/database-schemas#schema-bumps-and-older-updaters).
 
@@ -194,6 +195,30 @@ The sender must be in [`commands.ownerAllowFrom`](/tools/slash-commands#configur
 `/update` also requires `commands.restart` (enabled by default).
 Agents must never run `npm install -g openclaw` or stop the Gateway service
 from a chat shell; use the update action so restart and notification stay coordinated.
+
+## Stale update history
+
+If update status stays in progress while the Gateway is healthy, check that no
+update is still running. On the updated installation, run:
+
+```bash
+openclaw update repair
+openclaw update status
+```
+
+For an inactive legacy row older than 30 minutes, repair verifies that the
+running Gateway matches the installed version and build, then clears the stale
+run without maintenance or a service restart. A new explicit `openclaw update`
+can also supersede a single stale identityless row. Recent rows and recorded
+live drivers are protected. Identityless rows are never cleared automatically;
+the Control UI's configuration-write suspension clears after reconciliation.
+
+OpenClaw 2026.9.2 does not reject a new CLI update because an older running row
+exists: its [admission path](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command-run.ts#L77)
+creates a new run, and its [ledger](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/infra/update-run-ledger.ts#L250)
+checks only for a duplicate run ID. Upgrade normally, then use the updated
+`openclaw update repair` if the old history remains. A package-manager escape
+is not required for this ledger defect. See [Update run history](/cli/update#run-history-and-reports).
 
 ## Retire update recovery data
 

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -145,6 +145,66 @@ downtime. Each JSON column has a 16 KiB hard limit with deterministic truncation
 and redaction. The ledger stores bounded diagnostic summaries, not raw logs or
 credentials. There is no automatic history deletion.
 
+New drivers store optional `origin.driver` fields `host` (the hostname), `pid`,
+and `startIdentity` (the operating system's process-start identity as a decimal
+string) in the existing `origin_json` column. Each adopter becomes the current
+driver and retains distinct earlier identities in `origin.previousDrivers`.
+There are at most eight identities in total. Only positively dead identities
+are pruned; adoption is refused rather than dropping a live or uninspectable
+driver at capacity. Identity capture must succeed before a new driver starts.
+This is additive JSON metadata;
+there are no new columns, tables, or schema versions. The separate
+`verification.pid` still identifies the Gateway service, not the updater.
+Adoption records a retained `driver:adopted` step. Detached children can outlive
+their parent, so either lifetime can prevent reconciliation. Adopting a terminal
+run is refused. Long command and finalization phases renew `updated_at_ms`
+every 30 seconds; only current or retained identities may renew a row. Encoding
+reserves space for exact identity bytes before bounding and redacting other
+origin diagnostics.
+
+The ledger owns abandonment classification and terminalization. Automatic
+recovery requires more than 30 minutes since both `updated_at_ms` and the latest
+step timestamp, plus positive evidence that every recorded driver is dead on the
+same host: its PID is gone or its process-start identity differs. Unreadable and
+foreign-host identities are inconclusive. The Gateway performs reconciliation
+at startup and on active-run polls, rechecking the current row and process
+identity in the terminal write transaction. The shared 30-minute constant also
+owns the older-updater schema-publication bound below.
+
+Reconciliation writes status `failed`, reason `abandoned`, and a retained
+`reconcile:abandoned` step whose detail names `inactive-driver-dead` or
+`operator-reconciled-inactive-run`. All unfinished steps become terminal, and
+history is retained. Explicit `update repair` can reconcile inactive identityless
+rows when the current Gateway generation is healthy and no post-core repair is
+pending. It cannot override a live or inconclusive recorded driver. The
+[2026.9.2 updater](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command.ts#L465)
+does not record adoption: package-manager and registry preflight can
+leave a live updater at its single `requested/in_progress` step. Older writers
+may drop unknown driver JSON fields; identityless rows require explicit recovery.
+`update status` only reports classification and never commits reconciliation.
+
+Explicit new CLI update admission can supersede a legacy row only when it is
+the sole running row, has no current or previous driver identity, and exceeds
+the same inactivity bound. The transaction finishes it as `failed` with reason
+`superseded` and a retained `reconcile:superseded` step whose detail is
+`operator-started-update-supersedes-inactive-identityless-run`, then creates the
+new row. This includes dry-run admission, but excludes inherited continuations
+and campaigns. `abandoned` and `superseded` are additive values in the existing
+free-text reason contract. Neither recovery path deletes history.
+
+Successful ledger-only repair records a retained `reconcile:acknowledged` step.
+A terminal abandoned row can substitute for full repair only once, within
+30 minutes of its finish time; later repair invocations keep normal plugin
+convergence behavior.
+When full finalization is required, the selected inactive rows are rechecked
+and reconciled only after successful convergence, before success output.
+Explicit recovery validates and commits its selected rows in one transaction;
+renewed activity in any selected run preserves the entire selection. Ledger-only
+repair also refuses the write if another active run falls outside that selection.
+Finalization (`finalize:*`) and post-update verification markers survive step-count
+and diagnostic-byte eviction because repair relies on that history. If retained
+metadata alone exceeds a hard limit, the write fails without changing the row.
+
 The CLI and Gateway share WAL-backed transactions, including while the Gateway
 is stopped. The first terminal outcome wins; subsequent verification can enrich
 its observed facts without rewriting success, failure, skip, or rollback status.

--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -151,14 +151,21 @@ string) in the existing `origin_json` column. Each adopter becomes the current
 driver and retains distinct earlier identities in `origin.previousDrivers`.
 There are at most eight identities in total. Only positively dead identities
 are pruned; adoption is refused rather than dropping a live or uninspectable
-driver at capacity. Identity capture must succeed before a new driver starts.
+driver at capacity. If local process identity cannot be captured, adoption
+continues with one warning and a retained `driver:identity-unavailable` step.
+That marker permanently excludes the run from automatic reconciliation, even
+if known parents later exit; existing recorded identities remain protected.
+A fresh run without identity follows the legacy explicit repair/supersession
+rules below.
 This is additive JSON metadata;
 there are no new columns, tables, or schema versions. The separate
 `verification.pid` still identifies the Gateway service, not the updater.
 Adoption records a retained `driver:adopted` step. Detached children can outlive
 their parent, so either lifetime can prevent reconciliation. Adopting a terminal
 run is refused. Long command and finalization phases renew `updated_at_ms`
-every 30 seconds; only current or retained identities may renew a row. Encoding
+every 30 seconds; only current or retained identities may renew a row. Heartbeat
+write failures warn once per driver run and do not abort commands or finalization;
+step and outcome writes retain their existing failure behavior. Encoding
 reserves space for exact identity bytes before bounding and redacting other
 origin diagnostics.
 
@@ -196,6 +203,10 @@ Successful ledger-only repair records a retained `reconcile:acknowledged` step.
 A terminal abandoned row can substitute for full repair only once, within
 30 minutes of its finish time; later repair invocations keep normal plugin
 convergence behavior.
+Repair also inspects newer failed/abandoned history for unacknowledged post-core
+work, regardless of its age. An older active row cannot hide that work. If the
+bounded history prefix does not reach the selected recovery rows, repair uses
+full finalization rather than claiming that no post-core work remains.
 When full finalization is required, the selected inactive rows are rechecked
 and reconciled only after successful convergence, before success output.
 Explicit recovery validates and commits its selected rows in one transaction;

--- a/packages/gateway-protocol/src/schema/update-runs.ts
+++ b/packages/gateway-protocol/src/schema/update-runs.ts
@@ -1,5 +1,6 @@
 import { Type, type Static } from "typebox";
 import {
+  UPDATE_RUN_DRIVER_LIMIT,
   UPDATE_RUN_PHASES,
   UPDATE_RUN_STATUSES,
   UPDATE_RUN_STEP_STATUSES,
@@ -21,6 +22,11 @@ const version = closedObject({
   sha: Type.Optional(Type.Union([text, Type.Null()])),
   buildId: Type.Optional(Type.Union([text, Type.Null()])),
 });
+const driver = closedObject({
+  host: Type.String({ minLength: 1, maxLength: 255 }),
+  pid: Type.Integer({ minimum: 1, maximum: Number.MAX_SAFE_INTEGER }),
+  startIdentity: Type.String({ pattern: "^\\d+$", maxLength: 128 }),
+});
 
 /** Wire projection of the canonical update ledger record. */
 export const UpdateRunRecordSchema = closedObject({
@@ -32,6 +38,8 @@ export const UpdateRunRecordSchema = closedObject({
   status,
   reason: Type.Union([text, Type.Null()]),
   origin: closedObject({
+    driver: Type.Optional(driver),
+    previousDrivers: Type.Optional(Type.Array(driver, { maxItems: UPDATE_RUN_DRIVER_LIMIT - 1 })),
     requester: Type.Optional(
       closedObject({
         channel: Type.Optional(text),

--- a/packages/gateway-protocol/src/update-run-vocabulary.ts
+++ b/packages/gateway-protocol/src/update-run-vocabulary.ts
@@ -1,3 +1,5 @@
+export const UPDATE_RUN_DRIVER_LIMIT = 8;
+
 export const UPDATE_RUN_PHASES = [
   "requested",
   "staging",

--- a/packages/gateway-protocol/src/update-runs-validators.test.ts
+++ b/packages/gateway-protocol/src/update-runs-validators.test.ts
@@ -10,6 +10,7 @@ import {
   validateUpdateRunsListResult,
   validateUpdateStatusResult,
 } from "./index.js";
+import { UPDATE_RUN_DRIVER_LIMIT } from "./update-run-vocabulary.js";
 
 const run = LedgerRecordSchema.parse({
   runId: "27d967ef-0485-4f98-a93a-229d50c75111",
@@ -20,6 +21,8 @@ const run = LedgerRecordSchema.parse({
   status: "succeeded",
   reason: null,
   origin: {
+    driver: { host: "gateway.test", pid: 1234, startIdentity: "98765" },
+    previousDrivers: [{ host: "gateway.test", pid: 1200, startIdentity: "98700" }],
     requester: { channel: "telegram", accountId: "primary", senderId: "operator" },
     sessionKey: "agent:main:main",
     deliveryContext: { channel: "telegram", to: "chat", accountId: "default", threadId: "1" },
@@ -91,6 +94,22 @@ describe("update run wire contract", () => {
     ["oversized steps", { steps: Array.from({ length: 129 }, () => run.steps[0]) }],
     ["oversized repairs", { repair: Array.from({ length: 17 }, () => run.repair[0]) }],
     ["invalid service port", { verification: { port: 65536 } }],
+    [
+      "oversized driver host",
+      { origin: { driver: { ...run.origin.driver, host: "x".repeat(256) } } },
+    ],
+    [
+      "oversized driver start identity",
+      { origin: { driver: { ...run.origin.driver, startIdentity: "1".repeat(129) } } },
+    ],
+    [
+      "too many previous drivers",
+      {
+        origin: {
+          previousDrivers: Array.from({ length: UPDATE_RUN_DRIVER_LIMIT }, () => run.origin.driver),
+        },
+      },
+    ],
     [
       "oversized plugin errors",
       { verification: { pluginErrors: Array.from({ length: 33 }, () => "failed") } },

--- a/scripts/e2e/lib/upgrade-survivor/abandoned-update.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/abandoned-update.mjs
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+const runId = "f9bdb286-8f8a-4b72-a792-3ca83ad07605";
+const [command, first, second, third] = process.argv.slice(2);
+const readJson = (file) => JSON.parse(fs.readFileSync(file, "utf8"));
+const writeJson = (file, value) => fs.writeFileSync(file, `${JSON.stringify(value, null, 2)}\n`);
+
+function withDatabase(stateDir, write, callback) {
+  const databasePath = path.join(stateDir, "state", "openclaw.sqlite");
+  assert(fs.existsSync(databasePath), "the published Gateway must create its own state database");
+  const db = new DatabaseSync(databasePath, { readOnly: !write });
+  try {
+    return callback(db);
+  } finally {
+    db.close();
+  }
+}
+
+function readRun(db) {
+  const row = db.prepare("SELECT * FROM update_runs WHERE run_id = ?").get(runId);
+  assert(row, "the pre-upgrade ledger specimen disappeared");
+  return row;
+}
+
+function seed(stateDir, artifactRoot) {
+  withDatabase(stateDir, true, (db) => {
+    assert.equal(
+      db.prepare("SELECT count(*) AS total FROM update_runs WHERE status = 'running'").get().total,
+      0,
+      "the baseline preview must finish its ledger run before seeding",
+    );
+    // Deliberately older than the product's shared thirty-minute inactivity bound.
+    const lastActivity = Date.now() - 60 * 60_000;
+    const row = {
+      run_id: runId,
+      created_at_ms: lastActivity,
+      updated_at_ms: lastActivity,
+      trigger: "cli",
+      phase: "requested",
+      status: "running",
+      reason: null,
+      origin_json: "{}",
+      target_json: "{}",
+      before_json: JSON.stringify({ version: "2026.9.2" }),
+      after_json: "{}",
+      steps_json: JSON.stringify([
+        { step: "requested", status: "in_progress", startedAtMs: lastActivity },
+      ]),
+      verification_json: "{}",
+      repair_json: "[]",
+      confirmed_at_ms: null,
+      finished_at_ms: null,
+      downtime_ms: null,
+    };
+    db.prepare(
+      `INSERT INTO update_runs (${Object.keys(row).join(",")}) VALUES (${Object.keys(row)
+        .map(() => "?")
+        .join(",")})`,
+    ).run(...Object.values(row));
+    writeJson(path.join(artifactRoot, "abandoned-run-before.json"), readRun(db));
+  });
+}
+
+function preserved(stateDir, artifactRoot) {
+  withDatabase(stateDir, false, (db) => {
+    assert.deepEqual(
+      { ...readRun(db) },
+      readJson(path.join(artifactRoot, "abandoned-run-before.json")),
+      "upgrade and Gateway startup must preserve an identityless legacy run",
+    );
+    const active = db.prepare("SELECT run_id FROM update_runs WHERE status = 'running'").all();
+    assert.deepEqual(
+      active.map((row) => row.run_id),
+      [runId],
+      "the real updater must finish its own run",
+    );
+  });
+}
+
+function processIdentity(pid) {
+  assert(Number.isSafeInteger(pid) && pid > 1, "invalid service process ID");
+  const stat = fs.readFileSync(`/proc/${pid}/stat`, "utf8");
+  const fields = stat.slice(stat.lastIndexOf(") ") + 2).split(" ");
+  assert.notEqual(fields[0], "Z", "service process is a zombie");
+  assert(fields[19], "process start time is missing");
+  return { pid, startTime: fields[19] };
+}
+
+function gatewayListenerPid(supervisorPid) {
+  const listeningSockets = new Set(
+    ["tcp", "tcp6"].flatMap((name) =>
+      fs
+        .readFileSync(`/proc/net/${name}`, "utf8")
+        .trim()
+        .split("\n")
+        .slice(1)
+        .map((line) => line.trim().split(/\s+/u))
+        .filter(
+          (fields) => fields[3] === "0A" && Number.parseInt(fields[1].split(":")[1], 16) === 18789,
+        )
+        .map((fields) => `socket:[${fields[9]}]`),
+    ),
+  );
+  assert(listeningSockets.size > 0, "the Gateway port must have a listening socket");
+  const descendants = [supervisorPid];
+  const listeners = [];
+  for (const pid of descendants) {
+    const children = fs
+      .readFileSync(`/proc/${pid}/task/${pid}/children`, "utf8")
+      .trim()
+      .split(/\s+/u)
+      .filter(Boolean)
+      .map(Number);
+    descendants.push(...children);
+    const ownsListener = fs.readdirSync(`/proc/${pid}/fd`).some((fd) => {
+      try {
+        return listeningSockets.has(fs.readlinkSync(`/proc/${pid}/fd/${fd}`));
+      } catch (error) {
+        if (error.code === "ENOENT") {
+          return false;
+        }
+        throw error;
+      }
+    });
+    if (ownsListener) {
+      listeners.push(pid);
+    }
+  }
+  assert.equal(listeners.length, 1, "one supervised Gateway must own the listening port");
+  return listeners[0];
+}
+
+function service(pidFile, logFile, output) {
+  const supervisorPid = Number(fs.readFileSync(pidFile, "utf8").trim());
+  writeJson(output, {
+    supervisor: processIdentity(supervisorPid),
+    // The socket owner is authoritative even if a CLI respawn adds a wrapper.
+    gateway: processIdentity(gatewayListenerPid(supervisorPid)),
+    operations: fs.readFileSync(logFile, "utf8").trim().split("\n").filter(Boolean),
+  });
+}
+
+function packages(tarball, packageRoot, artifactRoot) {
+  const packedJson = (relative) =>
+    JSON.parse(execFileSync("tar", ["-xOf", tarball, `package/${relative}`], { encoding: "utf8" }));
+  const baseline = {
+    version: readJson(path.join(packageRoot, "package.json")).version,
+    build: readJson(path.join(packageRoot, "dist", "build-info.json")),
+  };
+  const candidate = {
+    version: packedJson("package.json").version,
+    build: packedJson("dist/build-info.json"),
+  };
+  assert(
+    baseline.build.buildId && candidate.build.buildId,
+    "both packages must identify their build",
+  );
+  assert.notEqual(
+    candidate.build.buildId,
+    baseline.build.buildId,
+    "candidate must be a distinct build, even when versions match",
+  );
+  writeJson(path.join(artifactRoot, "abandoned-update-packages.json"), { baseline, candidate });
+}
+
+function installed(packageRoot, artifactRoot) {
+  const expected = readJson(path.join(artifactRoot, "abandoned-update-packages.json")).candidate;
+  const actual = {
+    version: readJson(path.join(packageRoot, "package.json")).version,
+    build: readJson(path.join(packageRoot, "dist", "build-info.json")),
+  };
+  assert.deepEqual(actual, expected, "the updater must install the selected candidate build");
+}
+
+function recovered(stateDir, artifactRoot) {
+  const before = readJson(path.join(artifactRoot, "repair-service-before.json"));
+  const after = readJson(path.join(artifactRoot, "repair-service-after.json"));
+  const repairExit = Number(fs.readFileSync(path.join(artifactRoot, "repair.exit"), "utf8"));
+  const statusExit = Number(fs.readFileSync(path.join(artifactRoot, "update-status.exit"), "utf8"));
+  const repairOutput = fs.readFileSync(path.join(artifactRoot, "repair.json"), "utf8");
+  const repairError = fs.readFileSync(path.join(artifactRoot, "repair.err"), "utf8");
+  const row = withDatabase(stateDir, false, readRun);
+  const operations = after.operations.slice(before.operations.length);
+  writeJson(path.join(artifactRoot, "abandoned-update-evidence.json"), {
+    runId,
+    repairExit,
+    statusExit,
+    row,
+    serviceBefore: { supervisor: before.supervisor, gateway: before.gateway },
+    serviceAfter: { supervisor: after.supervisor, gateway: after.gateway },
+    operations,
+    repairOutput,
+    repairError,
+  });
+  assert.equal(repairExit, 0, `update repair failed: ${repairError || repairOutput}`);
+  assert.equal(statusExit, 0, "update status failed");
+  const repair = JSON.parse(repairOutput);
+  assert.equal(repair.status, "ok");
+  assert.equal(repair.mode, "repair", "ledger-only repair must not enter finalization/Doctor");
+  assert.equal(repair.restart, false);
+  assert.deepEqual(repair.reconciledRuns, [runId]);
+  assert.match(repair.message, /No maintenance or service restart was needed/u);
+  assert.equal(row.status, "failed");
+  assert.equal(row.phase, "finished");
+  assert.equal(row.reason, "abandoned");
+  assert(Number.isSafeInteger(row.finished_at_ms));
+  assert(
+    JSON.parse(row.steps_json).some(
+      (step) =>
+        step.step === "reconcile:abandoned" && step.detail === "operator-reconciled-inactive-run",
+    ),
+  );
+  const status = readJson(path.join(artifactRoot, "update-status.json"));
+  assert.equal(status.activeRun, undefined, "update status must have no active run");
+  assert.deepEqual(after.supervisor, before.supervisor, "repair replaced the service supervisor");
+  assert.deepEqual(after.gateway, before.gateway, "repair replaced the Gateway process");
+  assert(
+    !operations.some((operation) =>
+      /(?:^|\s)(?:stop|restart|start|enable|disable)(?:\s|$)/u.test(operation),
+    ),
+    `repair changed service activation: ${operations.join("; ")}`,
+  );
+  console.log(
+    JSON.stringify({
+      runId,
+      status: row.status,
+      reason: row.reason,
+      repairExit,
+      activeRun: null,
+      gatewayPid: after.gateway.pid,
+      serviceUnchanged: true,
+    }),
+  );
+}
+
+if (command === "seed") {
+  seed(first, second);
+} else if (command === "preserved") {
+  preserved(first, second);
+} else if (command === "service") {
+  service(first, second, third);
+} else if (command === "recovered") {
+  recovered(first, second);
+} else if (command === "packages") {
+  packages(first, second, third);
+} else if (command === "installed") {
+  installed(first, second);
+} else {
+  throw new Error(`Unknown abandoned-update fixture command: ${command}`);
+}

--- a/scripts/e2e/lib/upgrade-survivor/abandoned-update.sh
+++ b/scripts/e2e/lib/upgrade-survivor/abandoned-update.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+
+# Uses the published updater and the survivor's real Gateway/systemd fixture.
+run_abandoned_update_survivor() {
+  if [ "$baseline_version" != "2026.9.2" ] || [ "$UPDATE_RESTART_MODE" != "auto-auth" ]; then
+    echo "abandoned-update requires baseline openclaw@2026.9.2 and auto-auth service mode" >&2
+    return 1
+  fi
+  if [ "$CANDIDATE_KIND" != "tarball" ]; then
+    echo "abandoned-update requires a packed candidate tarball" >&2
+    return 1
+  fi
+  local helper="scripts/e2e/lib/upgrade-survivor/abandoned-update.mjs"
+  local gateway_config
+  gateway_config="$(cat scripts/e2e/lib/upgrade-survivor/config-recipe/gateway.json)"
+  phase configure-gateway openclaw config set gateway "$gateway_config" --strict-json
+  phase disable-fixture-plugins openclaw config set plugins.enabled false --strict-json
+  phase validate-baseline-config validate_baseline_config
+  phase resolve-candidate resolve_candidate_version
+  phase package-identities node "$helper" packages "$CANDIDATE_SPEC" "$(package_root)" "$ARTIFACT_ROOT"
+  phase prepare-update-restart-probe prepare_update_restart_probe
+  # The shipped ledger table is first-use-only, so let its own CLI create it.
+  openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw update --dry-run --yes --no-restart \
+    --tag "$(candidate_update_spec)" --json >"$ARTIFACT_ROOT/baseline-preview.json" 2>"$ARTIFACT_ROOT/baseline-preview.err"
+  phase seed-abandoned-run node "$helper" seed "$OPENCLAW_STATE_DIR" "$ARTIFACT_ROOT"
+  phase update-candidate update_candidate
+  phase assert-candidate-build node "$helper" installed "$(package_root)" "$ARTIFACT_ROOT"
+  if [ "$update_repair_required" != "0" ]; then
+    echo "ledger-only survivor unexpectedly needs post-core repair" >&2
+    return 1
+  fi
+  phase assert-preserved-run node "$helper" preserved "$OPENCLAW_STATE_DIR" "$ARTIFACT_ROOT"
+  # This setup occurs before the repair boundary. Only the candidate serves its new bytes.
+  phase start-candidate-service run_update_restart_probe_gateway install 18789 "$COMMAND_TIMEOUT"
+  phase gateway-probes check_gateway_probes
+  phase gateway-status check_gateway_status
+  phase assert-no-automatic-recovery node "$helper" preserved "$OPENCLAW_STATE_DIR" "$ARTIFACT_ROOT"
+  node "$helper" service "$SYSTEMCTL_SHIM_PID_FILE" "$SYSTEMCTL_SHIM_LOG" \
+    "$ARTIFACT_ROOT/repair-service-before.json"
+
+  local repair_status=0 status_status=0
+  openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw update repair --yes --json \
+    >"$REPAIR_JSON" 2>"$ARTIFACT_ROOT/repair.err" || repair_status=$?
+  printf '%s\n' "$repair_status" >"$ARTIFACT_ROOT/repair.exit"
+  openclaw_e2e_maybe_timeout "$COMMAND_TIMEOUT" openclaw update status --json \
+    >"$ARTIFACT_ROOT/update-status.json" 2>"$ARTIFACT_ROOT/update-status.err" || status_status=$?
+  printf '%s\n' "$status_status" >"$ARTIFACT_ROOT/update-status.exit"
+  node "$helper" service "$SYSTEMCTL_SHIM_PID_FILE" "$SYSTEMCTL_SHIM_LOG" \
+    "$ARTIFACT_ROOT/repair-service-after.json"
+  # Save both outcomes before assertions so the same fixture retains the origin/main refusal.
+  phase assert-ledger-recovery node "$helper" recovered "$OPENCLAW_STATE_DIR" "$ARTIFACT_ROOT"
+  phase repaired-gateway-probes check_gateway_probes
+  phase repaired-gateway-status check_gateway_status
+  echo "Published 2026.9.2 stale update run repaired without maintenance or a service stop."
+}

--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -23,6 +23,7 @@ const legacyOperator =
     : undefined;
 const SCENARIOS = new Set([
   "base",
+  "abandoned-update",
   "legacy-operator-state",
   "mobile-pairing-reconnect",
   "acpx-openclaw-tools-bridge",

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -1844,6 +1844,12 @@ phase validate-update-restart-mode validate_update_restart_mode
 phase reset-run-state reset_run_state
 phase install-baseline install_baseline
 phase initialize-state initialize_state
+if [ "$SCENARIO" = "abandoned-update" ]; then
+  source scripts/e2e/lib/upgrade-survivor/abandoned-update.sh
+  run_abandoned_update_survivor
+  run_completed="1"
+  exit 0
+fi
 phase apply-baseline-config-recipe apply_baseline_config_recipe
 if [ "$SCENARIO" = "watchos-direct-node" ]; then
   phase configure-watchos-tls configure_watchos_tls_fixture

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -54,6 +54,9 @@ DOCKER_RUN_TIMEOUT="${OPENCLAW_UPGRADE_SURVIVOR_DOCKER_RUN_TIMEOUT:-1200s}"
 BASELINE_SPEC="${OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC:-}"
 SCENARIO="${OPENCLAW_UPGRADE_SURVIVOR_SCENARIO:-base}"
 UPDATE_RESTART_MODE="${OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE:-manual}"
+if [ "$SCENARIO" = "abandoned-update" ] && [ -z "${OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE:-}" ]; then
+  UPDATE_RESTART_MODE="auto-auth"
+fi
 COMMAND_TIMEOUT="${OPENCLAW_UPGRADE_SURVIVOR_COMMAND_TIMEOUT:-900s}"
 START_BUDGET_SECONDS="$(openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_START_BUDGET_SECONDS 90)"
 STATUS_BUDGET_SECONDS="$(openclaw_e2e_read_positive_int_env OPENCLAW_UPGRADE_SURVIVOR_STATUS_BUDGET_SECONDS 30)"
@@ -109,6 +112,14 @@ if [ "$SCENARIO" = "recovery-cleanup" ] && { [ "$UPDATE_RESTART_MODE" != "manual
 fi
 if [ "$SCENARIO" = "mobile-pairing-reconnect" ] && { [ "$UPDATE_RESTART_MODE" != "manual" ] || [ "$ROOT_MANAGED_VPS" != "0" ] || [ "$LIVE_OPENAI" != "0" ]; }; then
   echo "mobile-pairing-reconnect requires the isolated manual-restart fixture without live provider credentials" >&2
+  exit 1
+fi
+
+if [ "$SCENARIO" = "abandoned-update" ] && {
+  [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" != "1" ] ||
+  [ "$UPDATE_RESTART_MODE" != "auto-auth" ] || [ "$ROOT_MANAGED_VPS" != "0" ] || [ "$LIVE_OPENAI" != "0" ];
+}; then
+  echo "abandoned-update requires the published baseline, auto-auth service fixture, and no live provider" >&2
   exit 1
 fi
 

--- a/scripts/lib/docker-e2e-plan.mts
+++ b/scripts/lib/docker-e2e-plan.mts
@@ -121,6 +121,10 @@ const UPGRADE_SURVIVOR_RUNTIME_COMPANION_PACKAGES = ["@openclaw/codex"];
 // closed instead of requiring a dependency or reimplementing a JavaScript parser.
 const LEGACY_UPGRADE_SURVIVOR_SCENARIO_CATALOGS = new Map([
   [
+    "6b80d370ff2cad1c122700264ddecdf392fb9957112a3b107dc5c9c9731b6646",
+    "base abandoned-update legacy-operator-state mobile-pairing-reconnect acpx-openclaw-tools-bridge feishu-channel bootstrap-persona channel-post-core-restore codex-allowlist-survival plugin-deps-cleanup configured-plugin-installs stale-source-plugin-shadow prerelease-plugin-registry tilde-log-path meeting-transcripts-sqlite versioned-runtime-deps cron-scheduled-authority sqlite-volume recovery-cleanup auth-profile-v2026-7-2-beta-5 watchos-direct-node",
+  ],
+  [
     "9c3b79d2fc1317a9b8033f59cb6ae350aebf8bd6ec9575d9704ed8d4b34b210d",
     "base legacy-operator-state mobile-pairing-reconnect acpx-openclaw-tools-bridge feishu-channel bootstrap-persona channel-post-core-restore codex-allowlist-survival plugin-deps-cleanup configured-plugin-installs stale-source-plugin-shadow prerelease-plugin-registry tilde-log-path meeting-transcripts-sqlite versioned-runtime-deps cron-scheduled-authority sqlite-volume recovery-cleanup auth-profile-v2026-7-2-beta-5 watchos-direct-node",
   ],

--- a/scripts/lib/docker-e2e-plan.mts
+++ b/scripts/lib/docker-e2e-plan.mts
@@ -595,7 +595,7 @@ export function requiredPrepublishPluginPackagesForLanes(poolLanes: DockerE2eLan
       requiredPackages.add(packageName);
     }
     const scenario = upgradeSurvivorScenarioForLane(poolLane);
-    if (!scenario) {
+    if (!scenario || scenario === "abandoned-update") {
       continue;
     }
     if (scenario === "legacy-operator-state") {

--- a/scripts/lib/upgrade-survivor-policy.mjs
+++ b/scripts/lib/upgrade-survivor-policy.mjs
@@ -1,5 +1,6 @@
 const UPGRADE_SURVIVOR_SCENARIOS = Object.freeze([
   "base",
+  "abandoned-update",
   "legacy-operator-state",
   "mobile-pairing-reconnect",
   "acpx-openclaw-tools-bridge",
@@ -25,7 +26,7 @@ export const OLDEST_SUPPORTED_UPGRADE_SURVIVOR_BASELINE = "2026.6.34";
 
 // These black-box scenarios are implemented entirely by the current trusted
 // release harness and treat the selected tree only as the package under test.
-const TRUSTED_HARNESS_OWNED_SCENARIOS = new Set(["mobile-pairing-reconnect"]);
+const TRUSTED_HARNESS_OWNED_SCENARIOS = new Set(["mobile-pairing-reconnect", "abandoned-update"]);
 
 export function isTrustedHarnessOwnedUpgradeSurvivorScenario(scenario) {
   return TRUSTED_HARNESS_OWNED_SCENARIOS.has(scenario);
@@ -37,6 +38,7 @@ export function isTrustedHarnessOwnedUpgradeSurvivorScenario(scenario) {
 // qualification until their runtime cost justifies aggregate release coverage.
 const aggregateScenarios = UPGRADE_SURVIVOR_SCENARIOS.filter(
   (scenario) =>
+    scenario !== "abandoned-update" &&
     scenario !== "mobile-pairing-reconnect" &&
     scenario !== "watchos-direct-node" &&
     scenario !== "prerelease-plugin-registry" &&
@@ -184,6 +186,7 @@ function supportsUpgradeSurvivorLegacyOperatorState(baselineSpec) {
 
 export function supportsUpgradeSurvivorScenarioAtBaseline(scenario, baselineSpec) {
   return (
+    (scenario !== "abandoned-update" || baselineSpec === "openclaw@2026.9.2") &&
     (scenario !== "legacy-operator-state" ||
       supportsUpgradeSurvivorLegacyOperatorState(baselineSpec)) &&
     (scenario !== "plugin-deps-cleanup" ||

--- a/src/cli/daemon-cli.ts
+++ b/src/cli/daemon-cli.ts
@@ -21,6 +21,7 @@ export {
 } from "./daemon-cli/lifecycle-context.js";
 // Handoff admission uses the serving runtime; terminal writes load the installed runtime afresh.
 export {
+  adoptUpdateRun,
   finishUpdateRun,
   getUpdateRun,
   recordUpdateRunStep,

--- a/src/cli/update-cli.option-collisions.test.ts
+++ b/src/cli/update-cli.option-collisions.test.ts
@@ -35,6 +35,10 @@ vi.mock("./update-cli/update-command-finalize.js", () => ({
   updateFinalizeCommand: (opts: unknown) => mocks.updateFinalizeCommand(opts),
 }));
 
+vi.mock("./update-cli/update-repair-command.js", () => ({
+  updateRepairCommand: (opts: unknown) => mocks.updateFinalizeCommand(opts),
+}));
+
 vi.mock("./update-cli/cleanup.js", () => ({ updateCleanupCommand: mocks.updateCleanupCommand }));
 
 vi.mock("./update-cli/status.js", () => ({

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -12028,28 +12028,37 @@ describe("update-cli", () => {
 
   it("updateFinalizeCommand capability env applies only to the hidden finalizer", async () => {
     pathExists.mockResolvedValue(false);
-    await withEnvAsync({ OPENCLAW_UPDATE_POST_CORE: "1" }, async () => {
-      const run = async (command: "repair" | "finalize") => {
-        vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValue(FRESH_POST_UPDATE_ENTRYPOINT);
-        vi.mocked(defaultRuntime.writeJson).mockClear();
-        const program = new Command();
-        program.name("openclaw");
-        program.exitOverride();
-        registerUpdateCli(program);
-        await program.parseAsync(["node", "openclaw", "update", command, "--json", "--yes"]);
-        const output = lastWriteJsonCall() as
-          | { phaseTimings?: Array<{ phase?: string; outcome?: string }> }
-          | undefined;
-        return output?.phaseTimings?.at(-1);
-      };
+    // Option wiring needs an idle installation; earlier workflow cases retain parent runs.
+    await withEnvAsync(
+      {
+        OPENCLAW_UPDATE_POST_CORE: "1",
+        OPENCLAW_STATE_DIR: tempDirs.make("openclaw-finalizer-options-"),
+      },
+      async () => {
+        const run = async (command: "repair" | "finalize") => {
+          vi.mocked(resolveGatewayInstallEntrypoint).mockResolvedValue(
+            FRESH_POST_UPDATE_ENTRYPOINT,
+          );
+          vi.mocked(defaultRuntime.writeJson).mockClear();
+          const program = new Command();
+          program.name("openclaw");
+          program.exitOverride();
+          registerUpdateCli(program);
+          await program.parseAsync(["node", "openclaw", "update", command, "--json", "--yes"]);
+          const output = lastWriteJsonCall() as
+            | { phaseTimings?: Array<{ phase?: string; outcome?: string }> }
+            | undefined;
+          return output?.phaseTimings?.at(-1);
+        };
 
-      expect(await run("repair")).toEqual(
-        expect.objectContaining({ phase: "completionCache", outcome: "skipped" }),
-      );
-      expect(await run("finalize")).toEqual(
-        expect.objectContaining({ phase: "completionCache", outcome: "deferred" }),
-      );
-    });
+        expect(await run("repair"), getErrorOutput()).toEqual(
+          expect.objectContaining({ phase: "completionCache", outcome: "skipped" }),
+        );
+        expect(await run("finalize")).toEqual(
+          expect.objectContaining({ phase: "completionCache", outcome: "deferred" }),
+        );
+      },
+    );
   });
 
   it.each(
@@ -12067,21 +12076,25 @@ describe("update-cli", () => {
       program.exitOverride();
       registerUpdateCli(program);
 
-      await program.parseAsync([
-        "node",
-        "openclaw",
-        "update",
-        ...(position === "before" ? ["--accept-capabilities"] : []),
-        leaf,
-        ...(position === "after" ? ["--accept-capabilities"] : []),
-        "--json",
-        "--yes",
-      ]);
+      await withEnvAsync(
+        { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-capability-options-") },
+        () =>
+          program.parseAsync([
+            "node",
+            "openclaw",
+            "update",
+            ...(position === "before" ? ["--accept-capabilities"] : []),
+            leaf,
+            ...(position === "after" ? ["--accept-capabilities"] : []),
+            "--json",
+            "--yes",
+          ]),
+      );
 
       const handler = syncPluginCall()?.onCapabilityConsent as
         | ((review: { reviewToken: string }) => Promise<{ reviewToken: string }>)
         | undefined;
-      expect(syncPluginsForUpdateChannel).toHaveBeenCalledOnce();
+      expect(syncPluginsForUpdateChannel, getErrorOutput()).toHaveBeenCalledOnce();
       expect(lastWriteJsonCall()).toMatchObject({ status: "ok", mode: "finalize" });
       if (position === "absent") {
         expect(handler).toBeUndefined();

--- a/src/cli/update-cli.ts
+++ b/src/cli/update-cli.ts
@@ -88,7 +88,7 @@ function createUpdateLeafAction(
 function registerUpdateFinalizationCommand(update: Command, name: string, hidden: boolean) {
   const command = update.command(name, { hidden });
   command
-    .description("Repair post-update doctor and plugin convergence")
+    .description("Reconcile abandoned updates or repair post-update doctor and plugin convergence")
     .option("--json", "Output result as JSON", false)
     .option("--channel <stable|extended-stable|beta|dev>", "Persist update channel before repair")
     .option("--timeout <seconds>", "Override per-phase repair deadlines in seconds")
@@ -99,7 +99,7 @@ function registerUpdateFinalizationCommand(update: Command, name: string, hidden
       "after",
       () =>
         `\n${theme.heading("Examples:")}\n${formatHelpExamples([
-          ["openclaw update repair", "Rerun post-update doctor and plugin convergence."],
+          ["openclaw update repair", "Reconcile abandoned runs or repair post-update state."],
           [
             "openclaw update repair --accept-capabilities",
             "Accept reviewed plugin capability changes during repair.",
@@ -107,15 +107,17 @@ function registerUpdateFinalizationCommand(update: Command, name: string, hidden
           ["openclaw update repair --channel beta", "Repair against the beta update channel."],
           ["openclaw update repair --json", "JSON output for automation."],
         ])}\n\n${theme.heading("Notes:")}\n${theme.muted(
-          "- Repairs post-update plugin state after the core package already changed",
+          "- Reconciles abandoned runs when the Gateway is healthy; otherwise repairs post-update state",
         )}\n${theme.muted("- Runs doctor repair and plugin convergence, but never restarts the Gateway")}\n\n${theme.muted(
           "Docs:",
         )} ${formatDocsLink("/cli/update", "docs.openclaw.ai/cli/update")}`,
     )
     .action(
       createUpdateLeafAction(async (opts, actionCommand) => {
-        const { updateFinalizeCommand } = await import("./update-cli/update-command-finalize.js");
-        await updateFinalizeCommand({
+        const repair = hidden
+          ? (await import("./update-cli/update-command-finalize.js")).updateFinalizeCommand
+          : (await import("./update-cli/update-repair-command.js")).updateRepairCommand;
+        await repair({
           json: Boolean(opts.json) || inheritedUpdateJson(actionCommand),
           channel:
             (opts.channel as string | undefined) ??

--- a/src/cli/update-cli/status.test.ts
+++ b/src/cli/update-cli/status.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { requireUpdateRunDriver } from "../../infra/update-run-driver.js";
+import {
+  createUpdateRun,
+  getUpdateRun,
+  recordUpdateRunPhase,
+} from "../../infra/update-run-ledger.js";
+import { ABANDONED_UPDATE_RUN_MS } from "../../infra/update-run-timeouts.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { updateStatusCommand } from "./status.js";
+
+const runtime = vi.hoisted(() => ({
+  log: vi.fn(),
+  error: vi.fn(),
+  writeJson: vi.fn(),
+  exit: vi.fn(),
+}));
+
+vi.mock("../../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../runtime.js")>()),
+  defaultRuntime: runtime,
+}));
+vi.mock("../../config/config.js", () => ({
+  readSourceConfigBestEffort: async () => ({}),
+}));
+vi.mock("../../infra/update-check.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/update-check.js")>()),
+  checkUpdateStatus: async () => ({
+    root: "/fixture/openclaw",
+    installKind: "package",
+    packageManager: "npm",
+    registry: { latestVersion: "2026.9.2" },
+  }),
+}));
+vi.mock("./shared.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./shared.js")>()),
+  resolveUpdateRoot: async () => "/fixture/openclaw",
+}));
+
+const tempDirs = createTempDirTracker();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("OPENCLAW_STATE_DIR", tempDirs.make("openclaw-update-status-"));
+});
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  tempDirs.cleanup();
+});
+
+describe("update status abandoned-run reporting", () => {
+  it.each([true, false])(
+    "gives explicit recovery guidance for stale identityless history (JSON: %s)",
+    async (json) => {
+      const now = Date.now();
+      const lastActivity = now - ABANDONED_UPDATE_RUN_MS - 10;
+      vi.spyOn(Date, "now").mockReturnValue(lastActivity);
+      const recorded = createUpdateRun({ trigger: "control-ui", before: { version: "2026.9.2" } });
+      vi.mocked(Date.now).mockReturnValue(now);
+
+      await updateStatusCommand({ json });
+
+      const guidance = `no activity since ${new Date(lastActivity).toISOString()}; if no update is running, run \`openclaw update repair\` or start a new \`openclaw update\``;
+      expect(getUpdateRun(recorded.runId)).toEqual(recorded);
+      if (json) {
+        expect(runtime.writeJson).toHaveBeenCalledWith(
+          expect.objectContaining({
+            activeRun: recorded,
+            staleRun: { runId: recorded.runId, guidance },
+          }),
+        );
+        expect(runtime.writeJson.mock.lastCall?.[0]).not.toHaveProperty("abandonedRun");
+      } else {
+        const output = runtime.log.mock.calls.map(([line]) => String(line)).join("\n");
+        expect(output).toContain(guidance);
+        expect(output).not.toContain("update in progress:");
+      }
+    },
+  );
+
+  it.each([true, false])("reports abandonment read-only (JSON: %s)", async (json) => {
+    const now = Date.now();
+    const driver = requireUpdateRunDriver();
+    vi.spyOn(Date, "now").mockReturnValue(now - ABANDONED_UPDATE_RUN_MS - 10);
+    const created = createUpdateRun({
+      trigger: "control-ui",
+      before: { version: "2026.9.2" },
+      // This live PID has a different start identity than the exited driver.
+      origin: { driver: { ...driver, startIdentity: String(Number(driver.startIdentity) + 1) } },
+    });
+    const recorded = recordUpdateRunPhase(created.runId, "staging");
+    vi.mocked(Date.now).mockReturnValue(now);
+
+    await updateStatusCommand({ json });
+
+    expect(getUpdateRun(created.runId)).toEqual(recorded);
+    if (json) {
+      expect(runtime.writeJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          activeRun: recorded,
+          lastRun: recorded,
+          abandonedRun: { runId: created.runId, rule: "inactive-driver-dead" },
+        }),
+      );
+    } else {
+      const output = runtime.log.mock.calls.map(([line]) => String(line)).join("\n");
+      expect(output).toContain("Abandoned update detected;");
+      expect(output).toContain("openclaw update repair");
+      expect(output).not.toContain("update in progress:");
+      expect(output).not.toContain("update failed:");
+    }
+  });
+});

--- a/src/cli/update-cli/status.test.ts
+++ b/src/cli/update-cli/status.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { requireUpdateRunDriver } from "../../infra/update-run-driver.js";
+import { readUpdateRunDriver } from "../../infra/update-run-driver.js";
 import {
   createUpdateRun,
   getUpdateRun,
@@ -84,7 +84,10 @@ describe("update status abandoned-run reporting", () => {
 
   it.each([true, false])("reports abandonment read-only (JSON: %s)", async (json) => {
     const now = Date.now();
-    const driver = requireUpdateRunDriver();
+    const driver = readUpdateRunDriver();
+    if (!driver) {
+      throw new Error("Test process identity is unavailable");
+    }
     vi.spyOn(Date, "now").mockReturnValue(now - ABANDONED_UPDATE_RUN_MS - 10);
     const created = createUpdateRun({
       trigger: "control-ui",

--- a/src/cli/update-cli/status.ts
+++ b/src/cli/update-cli/status.ts
@@ -13,6 +13,10 @@ import {
   resolveUpdateChannelDisplay,
 } from "../../infra/update-channels.js";
 import { checkUpdateStatus, formatGitInstallLabel } from "../../infra/update-check.js";
+import {
+  inspectUpdateRunAbandonment,
+  staleUpdateRunGuidance,
+} from "../../infra/update-run-activity.js";
 import { findActiveUpdateRun, listUpdateRuns } from "../../infra/update-run-ledger.js";
 import { renderUpdateRunReport } from "../../infra/update-run-report.js";
 import { defaultRuntime } from "../../runtime.js";
@@ -56,6 +60,8 @@ export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<vo
 
   const activeRun = findActiveUpdateRun();
   const lastRun = listUpdateRuns({ limit: 1 })[0];
+  const abandonment = activeRun ? inspectUpdateRunAbandonment(activeRun) : undefined;
+  const staleGuidance = activeRun ? staleUpdateRunGuidance(activeRun) : undefined;
 
   if (opts.json) {
     defaultRuntime.writeJson({
@@ -69,6 +75,12 @@ export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<vo
       availability: updateAvailability,
       ...(activeRun ? { activeRun } : {}),
       ...(lastRun ? { lastRun } : {}),
+      ...(staleGuidance && activeRun
+        ? { staleRun: { runId: activeRun.runId, guidance: staleGuidance } }
+        : {}),
+      ...(abandonment && activeRun
+        ? { abandonedRun: { runId: activeRun.runId, rule: abandonment } }
+        : {}),
     });
     return;
   }
@@ -109,8 +121,18 @@ export async function updateStatusCommand(opts: UpdateStatusOptions): Promise<vo
 
   const run = activeRun ?? lastRun;
   if (run) {
+    if (staleGuidance) {
+      defaultRuntime.log(`Update ${run.runId}: ${staleGuidance}`);
+    }
+    if (abandonment) {
+      defaultRuntime.log(
+        "Abandoned update detected; the Gateway will reconcile its recorded outcome. Run openclaw update repair to reconcile it now.",
+      );
+    }
     const report = renderUpdateRunReport(run);
-    defaultRuntime.log(report.headline);
+    if (!abandonment && !staleGuidance) {
+      defaultRuntime.log(report.headline);
+    }
     for (const line of report.lines) {
       defaultRuntime.log(line);
     }

--- a/src/cli/update-cli/update-command-finalize.ts
+++ b/src/cli/update-cli/update-command-finalize.ts
@@ -13,6 +13,11 @@ import {
 } from "../../infra/update-channels.js";
 import { resolveUpdateInstallKind } from "../../infra/update-check.js";
 import { POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV } from "../../infra/update-post-core-context.js";
+import {
+  acknowledgeAbandonedUpdateRun,
+  getUpdateRun,
+  reconcileAbandonedUpdateRuns,
+} from "../../infra/update-run-ledger.js";
 import { loadInstalledPluginIndexInstallRecords } from "../../plugins/installed-plugin-index-records.js";
 import { withPluginLifecycleLease } from "../../plugins/plugin-lifecycle-lease.js";
 import { withCommandProcessScope } from "../../process/exec-spawn.js";
@@ -49,7 +54,10 @@ import { resolveServiceRefreshEnv, withUpdateInProgressEnv } from "./update-comm
 import { withUpdateFailureTriage } from "./update-command-triage.js";
 import { UpdateFinalizationLifecycle } from "./update-finalization-lifecycle.js";
 
-export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promise<void> {
+export async function updateFinalizeCommand(
+  opts: UpdateFinalizeOptions,
+  recoveryRunIds: readonly string[] = [],
+): Promise<void> {
   const invocationCwd = tryResolveInvocationCwd();
   suppressDeprecations();
   const timeoutMs = parseTimeoutMsOrExit(opts.timeout);
@@ -89,7 +97,7 @@ export async function updateFinalizeCommand(opts: UpdateFinalizeOptions): Promis
             const prepared = await lifecycle.run("targetConfigValidation", () =>
               prepareUpdateFinalization(opts, root, requestedChannel),
             );
-            await updateFinalizeCommandInternal(opts, prepared, lifecycle);
+            await updateFinalizeCommandInternal(opts, prepared, lifecycle, recoveryRunIds);
           } catch (error) {
             if (error instanceof UpdateCommandFailure) {
               lifecycle.complete(error.exitCode);
@@ -175,6 +183,7 @@ async function updateFinalizeCommandInternal(
   opts: UpdateFinalizeOptions,
   prepared: Awaited<ReturnType<typeof prepareUpdateFinalization>>,
   lifecycle: UpdateFinalizationLifecycle,
+  recoveryRunIds: readonly string[],
 ): Promise<void> {
   const { root, preFinalizeConfig, requestedChannel, storedChannel, effectiveChannel, channel } =
     prepared;
@@ -261,6 +270,7 @@ async function updateFinalizeCommandInternal(
     (result) => result,
   );
 
+  const reconciledRuns: string[] = [];
   const result = {
     status:
       pluginUpdate.status === "error"
@@ -277,6 +287,7 @@ async function updateFinalizeCommandInternal(
         : null) ??
       channel,
     restart: false,
+    ...(recoveryRunIds.length ? { reconciledRuns } : {}),
     phaseTimings: lifecycle.phaseTimings,
     postUpdate: {
       doctor: {
@@ -285,6 +296,23 @@ async function updateFinalizeCommandInternal(
       plugins: pluginUpdate,
     },
   };
+  if (result.status !== "error" && recoveryRunIds.length) {
+    // Publish successful recovery only after convergence and the ledger's
+    // transactional inactivity/driver check both finish.
+    reconciledRuns.push(
+      ...reconcileAbandonedUpdateRuns({ explicit: true, runIds: recoveryRunIds }).map(
+        (run) => run.runId,
+      ),
+    );
+    if (recoveryRunIds.some((runId) => getUpdateRun(runId)?.status === "running")) {
+      throw new Error(
+        "An update resumed while repair was running; wait for that update before retrying repair.",
+      );
+    }
+    for (const runId of recoveryRunIds) {
+      acknowledgeAbandonedUpdateRun(runId);
+    }
+  }
   if (opts.json) {
     defaultRuntime.writeJson(result);
   } else if (result.status === "ok") {

--- a/src/cli/update-cli/update-command-lease.test.ts
+++ b/src/cli/update-cli/update-command-lease.test.ts
@@ -8,6 +8,15 @@ import { resolveFutureConfigActionBlock } from "../../config/future-version-guar
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import {
+  createUpdateRun,
+  getUpdateRun,
+  listUpdateRuns,
+  recordUpdateRunPhase,
+  recordUpdateRunStep,
+} from "../../infra/update-run-ledger.js";
+import type { UpdateRunRecord } from "../../infra/update-run-record.js";
+import { ABANDONED_UPDATE_RUN_MS } from "../../infra/update-run-timeouts.js";
+import {
   loadInstalledPluginIndexInstallRecords,
   writePersistedInstalledPluginIndexInstallRecords,
 } from "../../plugins/installed-plugin-index-records.js";
@@ -79,6 +88,7 @@ beforeEach(async () => {
       OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION: undefined,
       OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_SERVICE_REPAIR: undefined,
       OPENCLAW_UPDATE_PARENT_SUPPORTS_GATEWAY_RESTART: undefined,
+      OPENCLAW_UPDATE_RUN_ID: undefined,
     },
   });
   await state.writeConfig({ plugins: { enabled: false }, update: { channel: "stable" } });
@@ -114,7 +124,7 @@ async function writeScenario(
   await state.writeJson("scenario.json", { pluginUpdate: pluginResult, ...scenario, lane });
 }
 
-async function invoke(lane: Lane): Promise<void> {
+async function invoke(lane: Lane, recoveryRunIds: readonly string[] = []): Promise<void> {
   if (lane === "resume") {
     return resumePostCoreUpdate({
       root: state.root,
@@ -124,13 +134,16 @@ async function invoke(lane: Lane): Promise<void> {
     });
   }
   if (lane === "repair") {
-    return updateFinalizeCommand({
-      json: true,
-      yes: true,
-      restart: false,
-      timeout: "15",
-      deferCompletionCache: true,
-    });
+    return updateFinalizeCommand(
+      {
+        json: true,
+        yes: true,
+        restart: false,
+        timeout: "15",
+        deferCompletionCache: true,
+      },
+      recoveryRunIds,
+    );
   }
   await finishUpdate({
     mutationStarted: true,
@@ -160,8 +173,11 @@ async function invoke(lane: Lane): Promise<void> {
   });
 }
 
-async function invokeReportedFailure(lane: Lane): Promise<void> {
-  await expect(invoke(lane)).rejects.toMatchObject(
+async function invokeReportedFailure(
+  lane: Lane,
+  recoveryRunIds: readonly string[] = [],
+): Promise<void> {
+  await expect(invoke(lane, recoveryRunIds)).rejects.toMatchObject(
     lane === "repair"
       ? { name: "ExitError", code: 1 }
       : { name: "UpdateCommandFailure", exitCode: 1 },
@@ -206,10 +222,39 @@ function reportedResult(lane: Lane): unknown {
     : mocks.print.mock.lastCall?.[0];
 }
 
+function seedInterruptedPostCoreRun(): UpdateRunRecord {
+  const clock = vi.spyOn(Date, "now").mockReturnValue(Date.now() - 2 * ABANDONED_UPDATE_RUN_MS);
+  try {
+    const run = createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } });
+    return recordUpdateRunPhase(run.runId, "verifying", {
+      step: { step: "post-update verification", status: "in_progress" },
+    });
+  } finally {
+    clock.mockRestore();
+  }
+}
+
+function expectRecoveredRun(run: UpdateRunRecord | undefined): void {
+  expect(run).toMatchObject({
+    status: "failed",
+    reason: "abandoned",
+    steps: expect.arrayContaining([
+      expect.objectContaining({ step: "reconcile:acknowledged", status: "completed" }),
+    ]),
+  });
+}
+
 describe("update orchestration lifecycle ownership", () => {
   it.each(["fresh-process", "current-process", "repair"] as const)(
     "%s releases plugin ownership for fresh doctor without delegating Gateway activation",
     async (lane) => {
+      const recovery = lane === "repair" ? seedInterruptedPostCoreRun() : undefined;
+      let recoveredAtOutput: UpdateRunRecord | undefined;
+      if (recovery) {
+        vi.mocked(defaultRuntime.writeJson).mockImplementation(() => {
+          recoveredAtOutput = getUpdateRun(recovery.runId);
+        });
+      }
       await writeScenario(lane, {
         hostVersion: lane === "repair" ? undefined : "1.0.0",
       });
@@ -224,8 +269,15 @@ describe("update orchestration lifecycle ownership", () => {
         expect(result.stdout).toBe("excluded");
         return pluginResult;
       });
-      await invoke(lane);
+      await invoke(lane, recovery ? [recovery.runId] : []);
       expectSuccess(lane);
+      if (recovery) {
+        expectRecoveredRun(recoveredAtOutput);
+        expect(reportedResult(lane)).toMatchObject({ reconciledRuns: [recovery.runId] });
+        expectRecoveredRun(getUpdateRun(recovery.runId));
+        expect(listUpdateRuns({ active: true })).toEqual([]);
+        expect(listUpdateRuns({ limit: 1 })[0]?.origin.driver?.pid).toBe(process.pid);
+      }
       expect(process.env.OPENCLAW_UPDATE_PARENT_ALLOWS_GATEWAY_ACTIVATION).toBe(
         lane === "current-process" ? "1" : undefined,
       );
@@ -372,8 +424,12 @@ describe("update orchestration lifecycle ownership", () => {
   it.each(["fresh-process", "current-process", "repair"] as const)(
     "%s retains strict fresh validation after releasing the lease",
     async (lane) => {
+      const recovery = lane === "repair" ? seedInterruptedPostCoreRun() : undefined;
       await writeScenario(lane, { invalidConfig: true });
-      await invokeReportedFailure(lane);
+      await invokeReportedFailure(lane, recovery ? [recovery.runId] : []);
+      if (recovery) {
+        expect(getUpdateRun(recovery.runId)).toEqual(recovery);
+      }
       expect(reportedResult(lane)).toMatchObject({
         status: "error",
         postUpdate: { plugins: { reason: "post-plugin-doctor-invalid-config" } },
@@ -416,12 +472,56 @@ describe("update orchestration lifecycle ownership", () => {
   });
 
   it("repair propagates its pre-plugin doctor failure before mutation", async () => {
+    const recovery = seedInterruptedPostCoreRun();
     await writeScenario("repair", { failDoctor: "pre" });
-    await expect(invoke("repair")).rejects.toThrow("doctor fixture failure");
+    await expect(invoke("repair", [recovery.runId])).rejects.toThrow("doctor fixture failure");
+    expect(getUpdateRun(recovery.runId)).toEqual(recovery);
     expect(mocks.plugins).not.toHaveBeenCalled();
     expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
     expectDoctorDiagnostics();
     expect(await events()).toEqual(["pre-attempt", "pre-acquired"]);
+  });
+
+  it("repair reconciles captured runs before publishing successful convergence with warnings", async () => {
+    const recovery = seedInterruptedPostCoreRun();
+    const warning: PostCorePluginUpdateResult = {
+      ...pluginResult,
+      status: "warning",
+      changed: false,
+    };
+    await writeScenario("repair", { pluginUpdate: warning });
+    mocks.plugins.mockResolvedValueOnce(warning);
+    let recoveredAtOutput: UpdateRunRecord | undefined;
+    vi.mocked(defaultRuntime.writeJson).mockImplementation(() => {
+      recoveredAtOutput = getUpdateRun(recovery.runId);
+    });
+
+    await invoke("repair", [recovery.runId]);
+
+    expect(reportedResult("repair")).toMatchObject({
+      status: "warning",
+      reconciledRuns: [recovery.runId],
+    });
+    expectRecoveredRun(recoveredAtOutput);
+    expect(listUpdateRuns({ active: true })).toEqual([]);
+  });
+
+  it("repair withholds success when a captured updater advances during convergence", async () => {
+    const recovery = seedInterruptedPostCoreRun();
+    await writeScenario("repair", { pluginUpdate: { ...pluginResult, changed: false } });
+    mocks.plugins.mockImplementationOnce(async () => {
+      recordUpdateRunStep(recovery.runId, {
+        step: "build",
+        status: "in_progress",
+        startedAtMs: Date.now(),
+      });
+      return { ...pluginResult, changed: false };
+    });
+
+    await expect(invoke("repair", [recovery.runId])).rejects.toThrow("An update resumed");
+
+    expect(getUpdateRun(recovery.runId)).toMatchObject({ status: "running", reason: null });
+    expect(defaultRuntime.writeJson).not.toHaveBeenCalled();
   });
 
   it("resume reports a plugin exception after releasing its lease", async () => {

--- a/src/cli/update-cli/update-command-lifecycle.test.ts
+++ b/src/cli/update-cli/update-command-lifecycle.test.ts
@@ -46,6 +46,10 @@ vi.mock("../../config/config.js", async (importOriginal) => ({
 // This fixture proves lease ordering; process tests cover durable ledger writes.
 vi.mock("../../infra/update-run-ledger.js", () => ({
   createUpdateRun: vi.fn(() => ({ runId: "lease-order-fixture" })),
+  adoptUpdateRun: vi.fn(() => ({
+    origin: { driver: { host: "lease-order-fixture", pid: 1, startIdentity: "1" } },
+  })),
+  heartbeatUpdateRun: vi.fn(),
   recordUpdateRunStep: vi.fn(),
   finishUpdateRun: vi.fn(),
   recordUpdateRunDiagnostic: vi.fn(),

--- a/src/cli/update-cli/update-command-migrated.test.ts
+++ b/src/cli/update-cli/update-command-migrated.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterEach, expect, it, vi } from "vitest";
@@ -6,7 +7,11 @@ import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js"
 import { asResolvedSourceConfig, asRuntimeConfig } from "../../config/materialize.js";
 import { appendTranscriptEventsInTransaction } from "../../config/sessions/session-accessor.sqlite-transcript-store.js";
 import { readUpdateStateSchemaVersions } from "../../infra/update-candidate-state.js";
-import { createUpdateRun, recordUpdateRunStep } from "../../infra/update-run-ledger.js";
+import {
+  adoptUpdateRun,
+  createUpdateRun,
+  recordUpdateRunStep,
+} from "../../infra/update-run-ledger.js";
 import { defaultRuntime } from "../../runtime.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../../state/openclaw-agent-db-contract.js";
 import {
@@ -192,9 +197,12 @@ it.each([
   },
 );
 
-it.each([false, true])(
-  "finishes the same real ledger from the candidate after the old updater is fenced by migration (json=%s)",
-  async (json) => {
+it.each([
+  { json: false, parentOwns: false },
+  { json: true, parentOwns: true },
+])(
+  "finishes the same real ledger from the candidate after the old updater is fenced by migration (json=$json, parentOwns=$parentOwns)",
+  async ({ json, parentOwns }) => {
     const stateDir = await fs.realpath(dirs.make("migrated-update-"));
     const env = {
       ...process.env,
@@ -204,6 +212,9 @@ it.each([false, true])(
     };
     const root = process.cwd();
     const created = createUpdateRun({ trigger: "cli" }, { env });
+    const parentDriver = parentOwns
+      ? adoptUpdateRun(created.runId, { env }).origin.driver
+      : undefined;
     const run = { runId: created.runId, env };
     const log = vi.spyOn(defaultRuntime, "log").mockImplementation(() => {});
     vi.useFakeTimers();
@@ -328,12 +339,21 @@ it.each([false, true])(
     const inspected = new DatabaseSync(database.path, { readOnly: true });
     try {
       const row = inspected
-        .prepare("SELECT status, reason, steps_json FROM update_runs WHERE run_id = ?")
+        .prepare("SELECT status, reason, origin_json, steps_json FROM update_runs WHERE run_id = ?")
         .get(created.runId);
       expect(row).toMatchObject({ status: "failed", reason: "state-migrated-no-rollback" });
       expect(JSON.parse(String(row?.steps_json))).toEqual(
         expect.arrayContaining([progress.pendingSteps.at(-1)]),
       );
+      const origin = JSON.parse(String(row?.origin_json));
+      const driver = origin.driver;
+      expect(driver).toMatchObject({
+        host: os.hostname(),
+        pid: expect.any(Number),
+        startIdentity: expect.any(String),
+      });
+      expect(driver.pid).not.toBe(process.pid);
+      expect(origin.previousDrivers).toEqual(parentOwns ? [parentDriver] : undefined);
     } finally {
       inspected.close();
     }

--- a/src/cli/update-cli/update-command-run.ts
+++ b/src/cli/update-cli/update-command-run.ts
@@ -29,10 +29,13 @@ import {
   resolveManagedUpdateRequester,
 } from "../../infra/update-requester-authority.js";
 import { normalizeControlPlaneUpdateResult } from "../../infra/update-restart-sentinel-payload.js";
+import { requireUpdateRunDriver } from "../../infra/update-run-driver.js";
 import {
+  adoptUpdateRun,
   createUpdateRun,
   finishUpdateRun,
   getUpdateRun,
+  heartbeatUpdateRun,
   recordUpdateRunPhase,
   recordUpdateRunStep,
 } from "../../infra/update-run-ledger.js";
@@ -83,15 +86,20 @@ export async function admitUpdateCommandRun(params: {
     env,
     recoverOrphanedSidecars: false,
   });
-  const record = createUpdateRun(
+  const driver = requireUpdateRunDriver();
+  const created = createUpdateRun(
     {
       runId: env[UPDATE_RUN_ID_ENV]?.trim() || undefined,
       trigger: "cli",
+      origin: { driver },
+      supersedeStaleIdentityless:
+        !env[UPDATE_RUN_ID_ENV]?.trim() && env[POST_CORE_UPDATE_ENV] !== "1",
       target: { channel: params.opts.channel, tag: params.opts.tag },
       before: { version: VERSION },
     },
     { env },
   );
+  const record = adoptUpdateRun(created.runId, { env });
   const requester = resolveManagedUpdateRequester(record.origin.requester);
   const requesterAuthority = requester
     ? await createManagedUpdateRequesterAuthority(requester, env)
@@ -125,6 +133,7 @@ export function createUpdateRunProgress(
   pendingSteps: UpdateRunStep[];
 } {
   let deferred = false;
+  const driver = requireUpdateRunDriver();
   const pendingSteps: UpdateRunStep[] = [];
   const record = (step: UpdateRunStep) => {
     if (deferred) {
@@ -135,6 +144,11 @@ export function createUpdateRunProgress(
   };
   return {
     pendingSteps,
+    onHeartbeat() {
+      if (!deferred) {
+        heartbeatUpdateRun(run.runId, driver, { env: run.env });
+      }
+    },
     deferLedgerWrites() {
       // Candidate Doctor can advance SQLite beyond this process's reader. Hold
       // activation receipts until the supported runtime owns ledger writes.

--- a/src/cli/update-cli/update-command-run.ts
+++ b/src/cli/update-cli/update-command-run.ts
@@ -29,7 +29,7 @@ import {
   resolveManagedUpdateRequester,
 } from "../../infra/update-requester-authority.js";
 import { normalizeControlPlaneUpdateResult } from "../../infra/update-restart-sentinel-payload.js";
-import { requireUpdateRunDriver } from "../../infra/update-run-driver.js";
+import { readUpdateRunDriver } from "../../infra/update-run-driver.js";
 import {
   adoptUpdateRun,
   createUpdateRun,
@@ -86,7 +86,7 @@ export async function admitUpdateCommandRun(params: {
     env,
     recoverOrphanedSidecars: false,
   });
-  const driver = requireUpdateRunDriver();
+  const driver = readUpdateRunDriver();
   const created = createUpdateRun(
     {
       runId: env[UPDATE_RUN_ID_ENV]?.trim() || undefined,
@@ -133,7 +133,7 @@ export function createUpdateRunProgress(
   pendingSteps: UpdateRunStep[];
 } {
   let deferred = false;
-  const driver = requireUpdateRunDriver();
+  const driver = readUpdateRunDriver();
   const pendingSteps: UpdateRunStep[] = [];
   const record = (step: UpdateRunStep) => {
     if (deferred) {

--- a/src/cli/update-cli/update-finalization-lifecycle.test.ts
+++ b/src/cli/update-cli/update-finalization-lifecycle.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { UPDATE_RUN_ID_ENV } from "../../infra/update-control-plane-sentinel.js";
+import { getUpdateRun, listUpdateRuns } from "../../infra/update-run-ledger.js";
+import {
+  ABANDONED_UPDATE_RUN_MS,
+  UPDATE_RUN_HEARTBEAT_MS,
+} from "../../infra/update-run-timeouts.js";
+import { defaultRuntime } from "../../runtime.js";
+import { createDeferredCore } from "../../shared/deferred.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { UpdateFinalizationLifecycle } from "./update-finalization-lifecycle.js";
+
+const dirs = createTempDirTracker();
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.stubEnv("OPENCLAW_STATE_DIR", dirs.make("openclaw-finalize-heartbeat-"));
+  vi.stubEnv(UPDATE_RUN_ID_ENV, undefined);
+  vi.spyOn(defaultRuntime, "error").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  closeOpenClawStateDatabaseForTest();
+  vi.unstubAllEnvs();
+  dirs.cleanup();
+});
+
+it.each([false, true])(
+  "renews a long finalization phase and releases its heartbeat (failure=%s)",
+  async (fails) => {
+    const lifecycle = new UpdateFinalizationLifecycle(false, ABANDONED_UPDATE_RUN_MS * 2, () => {});
+    lifecycle.attachLedger();
+    const [initial] = listUpdateRuns();
+    if (!initial) {
+      throw new Error("Finalization did not create its update run.");
+    }
+    expect(initial.origin.driver?.pid).toBe(process.pid);
+    const phase = createDeferredCore();
+    const timerCount = vi.getTimerCount();
+    const running = lifecycle.run("plugins", () => phase.promise);
+    const settled = fails
+      ? expect(running).rejects.toThrow("plugin repair failed")
+      : expect(running).resolves.toBeUndefined();
+
+    await vi.advanceTimersByTimeAsync(ABANDONED_UPDATE_RUN_MS + UPDATE_RUN_HEARTBEAT_MS);
+    const observed = getUpdateRun(initial.runId);
+    expect(observed?.status).toBe("running");
+    expect(observed?.updatedAtMs).toBeGreaterThan(initial.updatedAtMs + ABANDONED_UPDATE_RUN_MS);
+    if (fails) {
+      phase.reject(new Error("plugin repair failed"));
+    } else {
+      phase.resolve();
+    }
+    await settled;
+    expect(vi.getTimerCount()).toBe(timerCount);
+    const finishedPhase = getUpdateRun(initial.runId);
+    await vi.advanceTimersByTimeAsync(UPDATE_RUN_HEARTBEAT_MS * 2);
+    expect(getUpdateRun(initial.runId)).toEqual(finishedPhase);
+    lifecycle.complete(fails ? 1 : 0);
+  },
+);

--- a/src/cli/update-cli/update-finalization-lifecycle.test.ts
+++ b/src/cli/update-cli/update-finalization-lifecycle.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import { UPDATE_RUN_ID_ENV } from "../../infra/update-control-plane-sentinel.js";
+import * as ledger from "../../infra/update-run-ledger.js";
 import { getUpdateRun, listUpdateRuns } from "../../infra/update-run-ledger.js";
 import {
   ABANDONED_UPDATE_RUN_MS,
@@ -62,3 +63,29 @@ it.each([false, true])(
     lifecycle.complete(fails ? 1 : 0);
   },
 );
+
+it("continues finalization after heartbeat errors and warns once for the run", async () => {
+  const stopChildren = vi.fn();
+  const lifecycle = new UpdateFinalizationLifecycle(
+    false,
+    ABANDONED_UPDATE_RUN_MS * 2,
+    stopChildren,
+  );
+  lifecycle.attachLedger();
+  const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+  vi.spyOn(ledger, "heartbeatUpdateRun").mockImplementation(() => {
+    throw new Error("SQLITE_BUSY: database is locked");
+  });
+  for (const phase of ["plugins", "targetConfigConvergence"] as const) {
+    const work = createDeferredCore();
+    const running = lifecycle.run(phase, () => work.promise);
+    await vi.advanceTimersByTimeAsync(UPDATE_RUN_HEARTBEAT_MS * 2);
+    expect(stopChildren).not.toHaveBeenCalled();
+    work.resolve();
+    await expect(running).resolves.toBeUndefined();
+  }
+  lifecycle.complete(0);
+  expect(listUpdateRuns()[0]?.status).toBe("succeeded");
+  expect(warning).toHaveBeenCalledTimes(1);
+  expect(warning).toHaveBeenCalledWith(expect.stringContaining("SQLITE_BUSY"));
+});

--- a/src/cli/update-cli/update-finalization-lifecycle.ts
+++ b/src/cli/update-cli/update-finalization-lifecycle.ts
@@ -1,11 +1,15 @@
 import { writeSync } from "node:fs";
 import { UPDATE_RUN_ID_ENV } from "../../infra/update-control-plane-sentinel.js";
+import { requireUpdateRunDriver, type UpdateRunDriver } from "../../infra/update-run-driver.js";
 import {
+  adoptUpdateRun,
   createUpdateRun,
   finishUpdateRun,
+  heartbeatUpdateRun,
   recordUpdateRunDiagnostic,
   recordUpdateRunStep,
 } from "../../infra/update-run-ledger.js";
+import { UPDATE_RUN_HEARTBEAT_MS } from "../../infra/update-run-timeouts.js";
 import { defaultRuntime } from "../../runtime.js";
 import { watchCliExitAfterOutput } from "../one-shot-exit.js";
 import { hasCliProcessScope } from "../runtime-cleanup-scope.js";
@@ -35,6 +39,7 @@ export class UpdateFinalizationLifecycle {
   }[] = [];
   root?: string;
   private runId?: string;
+  private driver?: UpdateRunDriver;
   private ledgerOptions?: { env: NodeJS.ProcessEnv };
   private ownsRun = false;
   private timer?: NodeJS.Timeout;
@@ -49,6 +54,7 @@ export class UpdateFinalizationLifecycle {
   ) {}
 
   attachLedger(): void {
+    requireUpdateRunDriver();
     const inherited = process.env[UPDATE_RUN_ID_ENV]?.trim();
     this.ledgerOptions = { env: { ...process.env } };
     this.runId = createUpdateRun(
@@ -56,6 +62,7 @@ export class UpdateFinalizationLifecycle {
       this.ledgerOptions,
     ).runId;
     this.ownsRun = !inherited;
+    this.driver = adoptUpdateRun(this.runId, this.ledgerOptions).origin.driver;
     if (this.active) {
       recordUpdateRunStep(
         this.runId,
@@ -96,6 +103,19 @@ export class UpdateFinalizationLifecycle {
     const active = { phase, step: `finalize:${phase}`, startedAtMs };
     this.active = active;
     this.record(active, "in_progress", startedAtMs);
+    let heartbeatFailure: { error: unknown } | undefined;
+    const heartbeat = setInterval(() => {
+      try {
+        if (this.runId) {
+          heartbeatUpdateRun(this.runId, this.driver, this.ledgerOptions);
+        }
+      } catch (error) {
+        // Join a still-mutating phase before reporting its failed heartbeat.
+        heartbeatFailure = { error };
+        clearInterval(heartbeat);
+      }
+    }, UPDATE_RUN_HEARTBEAT_MS);
+    heartbeat.unref();
     const end = (result: Outcome) => {
       this.phaseTimings.push({
         phase,
@@ -129,12 +149,16 @@ export class UpdateFinalizationLifecycle {
     }
     try {
       const result = await run();
+      if (heartbeatFailure) {
+        throw heartbeatFailure.error;
+      }
       end(outcome?.(result) ?? "completed");
       return result;
     } catch (error) {
       end("failed");
       throw error;
     } finally {
+      clearInterval(heartbeat);
       clearTimeout(this.timer);
       this.active = undefined;
     }

--- a/src/cli/update-cli/update-finalization-lifecycle.ts
+++ b/src/cli/update-cli/update-finalization-lifecycle.ts
@@ -1,6 +1,7 @@
 import { writeSync } from "node:fs";
+import { formatErrorMessage } from "../../infra/errors.js";
 import { UPDATE_RUN_ID_ENV } from "../../infra/update-control-plane-sentinel.js";
-import { requireUpdateRunDriver, type UpdateRunDriver } from "../../infra/update-run-driver.js";
+import { readUpdateRunDriver, type UpdateRunDriver } from "../../infra/update-run-driver.js";
 import {
   adoptUpdateRun,
   createUpdateRun,
@@ -42,6 +43,7 @@ export class UpdateFinalizationLifecycle {
   private driver?: UpdateRunDriver;
   private ledgerOptions?: { env: NodeJS.ProcessEnv };
   private ownsRun = false;
+  private warnedHeartbeat = false;
   private timer?: NodeJS.Timeout;
   private deferredExitWatch?: () => void;
   completed = false;
@@ -54,7 +56,7 @@ export class UpdateFinalizationLifecycle {
   ) {}
 
   attachLedger(): void {
-    requireUpdateRunDriver();
+    this.driver = readUpdateRunDriver();
     const inherited = process.env[UPDATE_RUN_ID_ENV]?.trim();
     this.ledgerOptions = { env: { ...process.env } };
     this.runId = createUpdateRun(
@@ -62,7 +64,7 @@ export class UpdateFinalizationLifecycle {
       this.ledgerOptions,
     ).runId;
     this.ownsRun = !inherited;
-    this.driver = adoptUpdateRun(this.runId, this.ledgerOptions).origin.driver;
+    adoptUpdateRun(this.runId, this.ledgerOptions);
     if (this.active) {
       recordUpdateRunStep(
         this.runId,
@@ -103,16 +105,18 @@ export class UpdateFinalizationLifecycle {
     const active = { phase, step: `finalize:${phase}`, startedAtMs };
     this.active = active;
     this.record(active, "in_progress", startedAtMs);
-    let heartbeatFailure: { error: unknown } | undefined;
     const heartbeat = setInterval(() => {
       try {
         if (this.runId) {
           heartbeatUpdateRun(this.runId, this.driver, this.ledgerOptions);
         }
       } catch (error) {
-        // Join a still-mutating phase before reporting its failed heartbeat.
-        heartbeatFailure = { error };
-        clearInterval(heartbeat);
+        if (!this.warnedHeartbeat) {
+          this.warnedHeartbeat = true;
+          console.warn(
+            `[update finalize] Could not refresh the update heartbeat; continuing: ${formatErrorMessage(error).slice(0, 500)}`,
+          );
+        }
       }
     }, UPDATE_RUN_HEARTBEAT_MS);
     heartbeat.unref();
@@ -149,9 +153,6 @@ export class UpdateFinalizationLifecycle {
     }
     try {
       const result = await run();
-      if (heartbeatFailure) {
-        throw heartbeatFailure.error;
-      }
       end(outcome?.(result) ?? "completed");
       return result;
     } catch (error) {

--- a/src/cli/update-cli/update-repair-command.test.ts
+++ b/src/cli/update-cli/update-repair-command.test.ts
@@ -1,0 +1,332 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { requireUpdateRunDriver } from "../../infra/update-run-driver.js";
+import {
+  createUpdateRun,
+  finishUpdateRun,
+  getUpdateRun,
+  listUpdateRuns,
+  recordUpdateRunPhase,
+  recordUpdateRunStep,
+} from "../../infra/update-run-ledger.js";
+import type { UpdateRunRecord } from "../../infra/update-run-record.js";
+import { ABANDONED_UPDATE_RUN_MS } from "../../infra/update-run-timeouts.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { runRegisteredCli } from "../../test-utils/command-runner.js";
+import { registerUpdateCli } from "../update-cli.js";
+import { updateRepairCommand } from "./update-repair-command.js";
+
+const mocks = vi.hoisted(() => ({
+  finalize: vi.fn(async (_opts: unknown, _recoveryRunIds?: readonly string[]) => {}),
+  readConfig: vi.fn(async () => ({ valid: true })),
+  configWriteAllowed: vi.fn(),
+  ownershipAllowed: vi.fn(async () => {}),
+  resolveRoot: vi.fn(async () => ""),
+  reachable: vi.fn(async () => ({
+    reachable: true,
+    gatewayVersion: "2026.9.3",
+    gatewayBuildId: "installed-build" as string | null,
+    activatedPluginErrors: [] as { id: string; error: string }[],
+    channelProbeErrors: [] as { id: string; error: string }[],
+  })),
+  readiness: vi.fn(async () => ({ healthz: 200, readyz: 200 })),
+  runtime: { log: vi.fn(), error: vi.fn(), writeJson: vi.fn(), exit: vi.fn() },
+}));
+
+vi.mock("../../config/config.js", () => ({
+  assertConfigWriteAllowedInCurrentMode: mocks.configWriteAllowed,
+  readConfigFileSnapshot: mocks.readConfig,
+}));
+vi.mock("../../state/openclaw-state-ownership.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../state/openclaw-state-ownership.js")>()),
+  assertOpenClawStateWriteAllowedAtPath: mocks.ownershipAllowed,
+}));
+vi.mock("../daemon-cli/restart-health-probe.js", () => ({
+  resolveGatewayRestartProbeContext: async () => ({ config: {}, auth: undefined }),
+  confirmGatewayReachable: mocks.reachable,
+  waitForGatewayHttpReadiness: mocks.readiness,
+}));
+vi.mock("./update-command-finalize.js", () => ({ updateFinalizeCommand: mocks.finalize }));
+vi.mock("./shared.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./shared.js")>()),
+  resolveUpdateRoot: mocks.resolveRoot,
+}));
+vi.mock("../../runtime.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../runtime.js")>()),
+  defaultRuntime: mocks.runtime,
+}));
+
+const tempDirs = createTempDirTracker();
+const now = Date.now();
+
+function seedRun(
+  params: { phase?: UpdateRunRecord["phase"]; liveDriver?: boolean; ageMs?: number } = {},
+) {
+  vi.mocked(Date.now).mockReturnValue(now - (params.ageMs ?? 3_600_000));
+  const driver = params.liveDriver ? requireUpdateRunDriver() : undefined;
+  const run = createUpdateRun({
+    trigger: "control-ui",
+    before: { version: "2026.9.2" },
+    ...(driver ? { origin: { driver } } : {}),
+  });
+  if (params.phase) {
+    recordUpdateRunPhase(run.runId, params.phase);
+  }
+  vi.mocked(Date.now).mockReturnValue(now);
+  return getUpdateRun(run.runId)!;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.spyOn(Date, "now").mockReturnValue(now);
+  vi.stubEnv("OPENCLAW_STATE_DIR", tempDirs.make("openclaw-update-repair-"));
+  const root = tempDirs.make("openclaw-update-repair-install-");
+  fs.mkdirSync(path.join(root, "dist"));
+  fs.writeFileSync(path.join(root, "package.json"), JSON.stringify({ version: "2026.9.3" }));
+  fs.writeFileSync(
+    path.join(root, "dist", "build-info.json"),
+    JSON.stringify({ buildId: "installed-build" }),
+  );
+  mocks.resolveRoot.mockResolvedValue(root);
+  mocks.readConfig.mockResolvedValue({ valid: true });
+  mocks.reachable.mockResolvedValue({
+    reachable: true,
+    gatewayVersion: "2026.9.3",
+    gatewayBuildId: "installed-build",
+    activatedPluginErrors: [],
+    channelProbeErrors: [],
+  });
+  mocks.readiness.mockResolvedValue({ healthz: 200, readyz: 200 });
+});
+
+afterEach(() => {
+  closeOpenClawStateDatabaseForTest();
+  vi.restoreAllMocks();
+  vi.unstubAllEnvs();
+  tempDirs.cleanup();
+});
+
+describe("update repair ledger recovery", () => {
+  it.each([undefined, "staging"] as const)(
+    "repairs an abandoned %s row through the public command without maintenance",
+    async (phase) => {
+      const run = seedRun({ phase });
+
+      await runRegisteredCli({ register: registerUpdateCli, argv: ["update", "repair", "--json"] });
+
+      expect(getUpdateRun(run.runId)).toMatchObject({ status: "failed", reason: "abandoned" });
+      expect(listUpdateRuns({ active: true })).toEqual([]);
+      expect(mocks.finalize).not.toHaveBeenCalled();
+      expect(mocks.runtime.writeJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status: "ok",
+          mode: "repair",
+          restart: false,
+          reconciledRuns: [run.runId],
+        }),
+      );
+      expect(mocks.runtime.exit).not.toHaveBeenCalledWith(1);
+    },
+  );
+
+  it("exits successfully when the Gateway already reconciled the abandoned row", async () => {
+    const run = seedRun();
+    finishUpdateRun(run.runId, { status: "failed", reason: "abandoned" });
+
+    await updateRepairCommand({});
+
+    expect(getUpdateRun(run.runId)).toMatchObject({
+      status: "failed",
+      reason: "abandoned",
+      steps: expect.arrayContaining([
+        expect.objectContaining({ step: "reconcile:acknowledged", status: "completed" }),
+      ]),
+    });
+    expect(mocks.finalize).not.toHaveBeenCalled();
+    expect(mocks.runtime.log).toHaveBeenCalledWith(expect.stringContaining("already reconciled"));
+  });
+
+  it.each(["repair", "gateway"] as const)(
+    "runs full repair on the next invocation after acknowledging %s reconciliation",
+    async (owner) => {
+      const run = seedRun();
+      if (owner === "gateway") {
+        finishUpdateRun(run.runId, { status: "failed", reason: "abandoned" });
+      }
+
+      await updateRepairCommand({});
+      expect(mocks.finalize).not.toHaveBeenCalled();
+      await updateRepairCommand({});
+
+      expect(mocks.finalize).toHaveBeenCalledExactlyOnceWith({}, []);
+      expect(getUpdateRun(run.runId)).toMatchObject({ status: "failed", reason: "abandoned" });
+    },
+  );
+
+  it("runs full repair when an abandoned outcome is older than the recovery window", async () => {
+    const run = seedRun();
+    vi.mocked(Date.now).mockReturnValue(now - ABANDONED_UPDATE_RUN_MS - 10);
+    finishUpdateRun(run.runId, { status: "failed", reason: "abandoned" });
+    vi.mocked(Date.now).mockReturnValue(now);
+    const recorded = getUpdateRun(run.runId);
+
+    await updateRepairCommand({});
+
+    expect(mocks.finalize).toHaveBeenCalledWith({}, []);
+    expect(getUpdateRun(run.runId)).toEqual(recorded);
+  });
+
+  it.each([
+    { label: "recent request", ageMs: 60_000 },
+    { label: "live driver", phase: "staging" as const, liveDriver: true },
+  ])("leaves a $label alone without entering maintenance", async (fixture) => {
+    const run = seedRun(fixture);
+
+    await expect(updateRepairCommand({})).rejects.toThrow("still in progress");
+
+    expect(getUpdateRun(run.runId)).toEqual(run);
+    expect(mocks.finalize).not.toHaveBeenCalled();
+  });
+
+  it("rechecks a driver that advances while Gateway health is being inspected", async () => {
+    const run = seedRun({ phase: "staging" });
+    mocks.readiness.mockImplementationOnce(async () => {
+      recordUpdateRunStep(run.runId, { step: "build", status: "in_progress", startedAtMs: now });
+      return { healthz: 200, readyz: 200 };
+    });
+
+    await expect(updateRepairCommand({})).rejects.toThrow("still in progress");
+
+    expect(getUpdateRun(run.runId)?.status).toBe("running");
+    expect(mocks.finalize).not.toHaveBeenCalled();
+  });
+
+  it.each([{ channel: "beta" }, { acceptCapabilities: true }])(
+    "retains full repair for explicit changes %j",
+    async (opts) => {
+      const run = seedRun();
+      mocks.finalize.mockRejectedValueOnce(new Error("Stop the service through its owner"));
+
+      await expect(updateRepairCommand(opts)).rejects.toThrow("Stop the service through its owner");
+
+      expect(getUpdateRun(run.runId)).toEqual(run);
+      expect(mocks.finalize).toHaveBeenCalledWith(opts, [run.runId]);
+    },
+  );
+
+  it.each(
+    (["activating", "restarting", "verifying", "repairing"] as const).flatMap((phase) =>
+      [false, true].map((reconciled) => ({ phase, reconciled })),
+    ),
+  )(
+    "retains post-core phases in full repair ($phase, reconciled=$reconciled)",
+    async ({ phase, reconciled }) => {
+      const run = seedRun({ phase: phase === "repairing" ? "verifying" : phase });
+      vi.mocked(Date.now).mockReturnValue(run.updatedAtMs);
+      if (phase === "repairing") {
+        recordUpdateRunPhase(run.runId, phase);
+      }
+      vi.mocked(Date.now).mockReturnValue(now);
+      if (reconciled) {
+        finishUpdateRun(run.runId, { status: "failed", reason: "abandoned" });
+      }
+      const recorded = getUpdateRun(run.runId);
+      mocks.finalize.mockRejectedValueOnce(new Error("Stop the service through its owner"));
+
+      await expect(updateRepairCommand({})).rejects.toThrow("Stop the service through its owner");
+
+      expect(getUpdateRun(run.runId)).toEqual(recorded);
+      expect(mocks.finalize).toHaveBeenCalledWith({}, [run.runId]);
+    },
+  );
+
+  it.each(["in_progress", "completed", "failed"] as const)(
+    "retains full repair after a %s finalization step",
+    async (status) => {
+      const run = seedRun();
+      vi.mocked(Date.now).mockReturnValue(run.updatedAtMs);
+      recordUpdateRunStep(run.runId, { step: "finalize:doctor", status });
+      vi.mocked(Date.now).mockReturnValue(now);
+      mocks.finalize.mockRejectedValueOnce(new Error("Stop the service through its owner"));
+
+      await expect(updateRepairCommand({})).rejects.toThrow("Stop the service through its owner");
+
+      expect(getUpdateRun(run.runId)?.status).toBe("running");
+      expect(mocks.finalize).toHaveBeenCalledWith({}, [run.runId]);
+    },
+  );
+
+  it.each([
+    "version mismatch",
+    "build mismatch",
+    "missing running build",
+    "missing installed build",
+    "missing installed version",
+  ])("retains full repair when the serving generation is unverified: %s", async (problem) => {
+    const run = seedRun();
+    const root = await mocks.resolveRoot();
+    if (problem === "missing installed build") {
+      fs.unlinkSync(path.join(root, "dist", "build-info.json"));
+    } else if (problem === "missing installed version") {
+      fs.writeFileSync(path.join(root, "package.json"), "{}");
+    }
+    mocks.reachable.mockResolvedValue({
+      reachable: true,
+      gatewayVersion: problem === "version mismatch" ? "2026.9.2" : "2026.9.3",
+      gatewayBuildId:
+        problem === "build mismatch"
+          ? "previous-build"
+          : problem === "missing running build"
+            ? null
+            : "installed-build",
+      activatedPluginErrors: [],
+      channelProbeErrors: [],
+    });
+    mocks.finalize.mockRejectedValueOnce(new Error("Stop the service through its owner"));
+
+    await expect(updateRepairCommand({})).rejects.toThrow("Stop the service through its owner");
+
+    expect(getUpdateRun(run.runId)).toEqual(run);
+    expect(mocks.finalize).toHaveBeenCalledWith({}, [run.runId]);
+    expect(mocks.runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("Reconciled"));
+  });
+
+  it.each(["config", "plugin", "channel", "readiness", "handshake"])(
+    "retains full repair when the Gateway has a %s problem",
+    async (problem) => {
+      const run = seedRun();
+      if (problem === "config") {
+        mocks.readConfig.mockResolvedValue({ valid: false });
+      } else if (problem === "readiness") {
+        mocks.readiness.mockResolvedValue({ healthz: 200, readyz: 503 });
+      } else {
+        mocks.reachable.mockResolvedValue({
+          reachable: true,
+          gatewayVersion: problem === "handshake" ? "" : "2026.9.3",
+          gatewayBuildId: "installed-build",
+          activatedPluginErrors: problem === "plugin" ? [{ id: "test", error: "failed" }] : [],
+          channelProbeErrors: problem === "channel" ? [{ id: "test", error: "failed" }] : [],
+        });
+      }
+      mocks.finalize.mockRejectedValueOnce(new Error("Stop the service through its owner"));
+
+      await expect(updateRepairCommand({})).rejects.toThrow("Stop the service through its owner");
+
+      expect(getUpdateRun(run.runId)).toEqual(run);
+      expect(mocks.finalize).toHaveBeenCalledWith({}, [run.runId]);
+    },
+  );
+
+  it("does not reconcile when write admission is refused", async () => {
+    const run = seedRun();
+    mocks.ownershipAllowed.mockRejectedValueOnce(new Error("externally supervised"));
+
+    await expect(updateRepairCommand({})).rejects.toThrow("externally supervised");
+
+    expect(getUpdateRun(run.runId)).toEqual(run);
+    expect(mocks.finalize).not.toHaveBeenCalled();
+    expect(mocks.reachable).not.toHaveBeenCalled();
+  });
+});

--- a/src/cli/update-cli/update-repair-command.test.ts
+++ b/src/cli/update-cli/update-repair-command.test.ts
@@ -2,8 +2,9 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
-import { requireUpdateRunDriver } from "../../infra/update-run-driver.js";
+import { readUpdateRunDriver } from "../../infra/update-run-driver.js";
 import {
+  acknowledgeAbandonedUpdateRun,
   createUpdateRun,
   finishUpdateRun,
   getUpdateRun,
@@ -65,7 +66,7 @@ function seedRun(
   params: { phase?: UpdateRunRecord["phase"]; liveDriver?: boolean; ageMs?: number } = {},
 ) {
   vi.mocked(Date.now).mockReturnValue(now - (params.ageMs ?? 3_600_000));
-  const driver = params.liveDriver ? requireUpdateRunDriver() : undefined;
+  const driver = params.liveDriver ? readUpdateRunDriver() : undefined;
   const run = createUpdateRun({
     trigger: "control-ui",
     before: { version: "2026.9.2" },
@@ -241,6 +242,70 @@ describe("update repair ledger recovery", () => {
       expect(mocks.finalize).toHaveBeenCalledWith({}, [run.runId]);
     },
   );
+
+  it.each(["activating", "finalize:plugins"])(
+    "does not let old active history hide newer abandoned %s work",
+    async (step) => {
+      const old = seedRun({ ageMs: ABANDONED_UPDATE_RUN_MS * 4 });
+      const newer = seedRun({ ageMs: ABANDONED_UPDATE_RUN_MS * 3 });
+      vi.mocked(Date.now).mockReturnValue(now - ABANDONED_UPDATE_RUN_MS * 2);
+      recordUpdateRunStep(newer.runId, { step, status: "completed" });
+      finishUpdateRun(newer.runId, { status: "failed", reason: "abandoned" });
+      vi.mocked(Date.now).mockReturnValue(now);
+      const recorded = listUpdateRuns();
+      mocks.finalize.mockRejectedValueOnce(new Error("Stop the service through its owner"));
+
+      await expect(updateRepairCommand({})).rejects.toThrow("Stop the service through its owner");
+
+      expect(mocks.finalize).toHaveBeenCalledWith({}, [old.runId, newer.runId]);
+      expect(mocks.reachable).not.toHaveBeenCalled();
+      expect(listUpdateRuns()).toEqual(recorded);
+    },
+  );
+
+  it("allows ledger-only repair after newer post-core abandonment was acknowledged", async () => {
+    const old = seedRun();
+    const newer = seedRun({ ageMs: 60_000, phase: "activating" });
+    finishUpdateRun(newer.runId, { status: "failed", reason: "abandoned" });
+    acknowledgeAbandonedUpdateRun(newer.runId);
+
+    await updateRepairCommand({});
+
+    expect(getUpdateRun(old.runId)).toMatchObject({ status: "failed", reason: "abandoned" });
+    expect(mocks.finalize).not.toHaveBeenCalled();
+  });
+
+  it("requires full repair when newer history exceeds the inspection bound", async () => {
+    const old = seedRun();
+    const abandoned = seedRun({ ageMs: 60_000, phase: "activating" });
+    finishUpdateRun(abandoned.runId, { status: "failed", reason: "abandoned" });
+    for (let index = 0; index < 100; index++) {
+      const newer = createUpdateRun({ trigger: "cli" });
+      finishUpdateRun(newer.runId, { status: "skipped", reason: "already-current" });
+    }
+    mocks.finalize.mockRejectedValueOnce(new Error("Stop the service through its owner"));
+
+    await expect(updateRepairCommand({})).rejects.toThrow("Stop the service through its owner");
+
+    expect(getUpdateRun(old.runId)).toEqual(old);
+    expect(mocks.reachable).not.toHaveBeenCalled();
+  });
+
+  it("rechecks newer abandoned post-core history after health probes", async () => {
+    const old = seedRun();
+    mocks.readiness.mockImplementationOnce(async () => {
+      const newer = seedRun({ ageMs: 60_000, phase: "activating" });
+      finishUpdateRun(newer.runId, { status: "failed", reason: "abandoned" });
+      return { healthz: 200, readyz: 200 };
+    });
+
+    await expect(updateRepairCommand({})).rejects.toThrow(
+      "Stop the Gateway service through its owner",
+    );
+
+    expect(getUpdateRun(old.runId)).toEqual(old);
+    expect(mocks.runtime.log).not.toHaveBeenCalledWith(expect.stringContaining("Reconciled"));
+  });
 
   it.each(["in_progress", "completed", "failed"] as const)(
     "retains full repair after a %s finalization step",

--- a/src/cli/update-cli/update-repair-command.ts
+++ b/src/cli/update-cli/update-repair-command.ts
@@ -1,0 +1,166 @@
+import {
+  assertConfigWriteAllowedInCurrentMode,
+  readConfigFileSnapshot,
+} from "../../config/config.js";
+import { resolveGatewayPort } from "../../config/paths.js";
+import { readPackageVersion } from "../../infra/package-json.js";
+import { readBuiltGatewayBuildId } from "../../infra/update-git-runtime.js";
+import {
+  inspectUpdateRunAbandonment,
+  isUnacknowledgedAbandonedUpdateRun,
+} from "../../infra/update-run-activity.js";
+import {
+  acknowledgeAbandonedUpdateRun,
+  listUpdateRuns,
+  reconcileAbandonedUpdateRuns,
+} from "../../infra/update-run-ledger.js";
+import type { UpdateRunRecord } from "../../infra/update-run-record.js";
+import { defaultRuntime } from "../../runtime.js";
+import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { assertOpenClawStateWriteAllowedAtPath } from "../../state/openclaw-state-ownership.js";
+import {
+  confirmGatewayReachable,
+  resolveGatewayRestartProbeContext,
+  waitForGatewayHttpReadiness,
+} from "../daemon-cli/restart-health-probe.js";
+import {
+  parseTimeoutMsOrExit,
+  resolveUpdateRoot,
+  tryResolveInvocationCwd,
+  type UpdateFinalizeOptions,
+} from "./shared.js";
+import { updateFinalizeCommand } from "./update-command-finalize.js";
+import { resolveServiceRefreshEnv } from "./update-command-service-env.js";
+
+const POST_CORE_PHASES = new Set(["activating", "restarting", "verifying"]);
+
+function needsPostCoreRepair(run: UpdateRunRecord): boolean {
+  // Reconciliation finishes phase steps but does not prove post-core convergence.
+  return (
+    POST_CORE_PHASES.has(run.phase) ||
+    run.steps.some(
+      (step) =>
+        POST_CORE_PHASES.has(step.step) ||
+        step.step === "post-update verification" ||
+        step.step.startsWith("finalize:"),
+    )
+  );
+}
+
+function assertNoActiveDriver(runs: UpdateRunRecord[]): void {
+  const active = runs.find((run) => !inspectUpdateRunAbandonment(run, { explicit: true }));
+  if (active) {
+    throw new Error(
+      `Update ${active.runId} is still in progress (${active.phase}); its driver is live or abandonment is not established. Wait for that update before running update repair.`,
+    );
+  }
+}
+
+/** Public repair can clear a stale ledger without entering post-core maintenance. */
+export async function updateRepairCommand(opts: UpdateFinalizeOptions): Promise<void> {
+  const timeoutMs = parseTimeoutMsOrExit(opts.timeout);
+  if (timeoutMs === null) {
+    return;
+  }
+  const env = resolveServiceRefreshEnv(process.env, tryResolveInvocationCwd());
+  const options = { env };
+  assertConfigWriteAllowedInCurrentMode({ env });
+  await assertOpenClawStateWriteAllowedAtPath({
+    databasePath: resolveOpenClawStateSqlitePath(env),
+    env,
+    recoverOrphanedSidecars: false,
+  });
+  const activeRuns = listUpdateRuns({ active: true, limit: 100 }, options);
+  assertNoActiveDriver(activeRuns);
+  const lastRun = listUpdateRuns({ limit: 1 }, options)[0];
+  const recoveryRuns = activeRuns.length
+    ? activeRuns
+    : lastRun && isUnacknowledgedAbandonedUpdateRun(lastRun)
+      ? [lastRun]
+      : [];
+  const recoveryRunIds = recoveryRuns.map((run) => run.runId);
+
+  if (
+    opts.channel !== undefined ||
+    opts.acceptCapabilities ||
+    recoveryRuns.length === 0 ||
+    recoveryRuns.some(needsPostCoreRepair)
+  ) {
+    await updateFinalizeCommand(opts, recoveryRunIds);
+    return;
+  }
+
+  const snapshot = await readConfigFileSnapshot({ skipPluginValidation: true });
+  if (!snapshot.valid) {
+    await updateFinalizeCommand(opts, recoveryRunIds);
+    return;
+  }
+  const context = await resolveGatewayRestartProbeContext(env);
+  const port = resolveGatewayPort(context.config, env);
+  const root = await resolveUpdateRoot();
+  const [gateway, http, expectedVersion, expectedBuildId] = await Promise.all([
+    confirmGatewayReachable({ port, ...context, env }),
+    waitForGatewayHttpReadiness({
+      config: context.config,
+      port,
+      attempts: 1,
+      deadlineAt: Date.now() + Math.min(timeoutMs ?? 3_000, 3_000),
+      delayMs: 0,
+    }),
+    readPackageVersion(root),
+    readBuiltGatewayBuildId(root),
+  ]);
+  // An old Gateway can remain healthy after the package changed on disk, before
+  // the interrupted updater recorded any post-core work.
+  if (
+    !gateway.reachable ||
+    !expectedVersion ||
+    !expectedBuildId ||
+    gateway.gatewayVersion !== expectedVersion ||
+    gateway.gatewayBuildId !== expectedBuildId ||
+    gateway.activatedPluginErrors.length ||
+    gateway.channelProbeErrors.length ||
+    http.healthz !== 200 ||
+    http.readyz !== 200
+  ) {
+    await updateFinalizeCommand(opts, recoveryRunIds);
+    return;
+  }
+
+  // Health probes await network I/O. Recheck current rows before the ledger's
+  // transaction revalidates each captured run's inactivity and driver identity.
+  assertConfigWriteAllowedInCurrentMode({ env });
+  const currentRuns = listUpdateRuns({ active: true, limit: 100 }, options);
+  assertNoActiveDriver(currentRuns);
+  if (currentRuns.some(needsPostCoreRepair)) {
+    throw new Error(
+      "Update repair needs post-core maintenance. Stop the Gateway service through its owner before retrying; repair will not stop or restart it.",
+    );
+  }
+  const reconciled = activeRuns.length
+    ? reconcileAbandonedUpdateRuns(
+        { explicit: true, runIds: activeRuns.map((run) => run.runId), requireAllActive: true },
+        options,
+      )
+    : [];
+  if (listUpdateRuns({ active: true, limit: 1 }, options).length) {
+    throw new Error("An update is still in progress; retry update repair after it finishes.");
+  }
+  for (const runId of new Set([...recoveryRuns, ...reconciled].map((run) => run.runId))) {
+    acknowledgeAbandonedUpdateRun(runId, options);
+  }
+  const message = reconciled.length
+    ? `Gateway is healthy. Reconciled ${reconciled.length} abandoned update run${reconciled.length === 1 ? "" : "s"}. No maintenance or service restart was needed.`
+    : "Gateway is healthy. Abandoned update runs are already reconciled. No maintenance or service restart was needed.";
+  if (opts.json) {
+    defaultRuntime.writeJson({
+      status: "ok",
+      mode: "repair",
+      restart: false,
+      reconciledRuns: reconciled.map((run) => run.runId),
+      message,
+    });
+  } else {
+    defaultRuntime.log(message);
+  }
+}

--- a/src/cli/update-cli/update-repair-command.ts
+++ b/src/cli/update-cli/update-repair-command.ts
@@ -47,6 +47,25 @@ function needsPostCoreRepair(run: UpdateRunRecord): boolean {
   );
 }
 
+function inspectNewerRecoveryHistory(recoveryRuns: UpdateRunRecord[], env: NodeJS.ProcessEnv) {
+  if (!recoveryRuns.length) {
+    return { postCoreRuns: [], incomplete: false };
+  }
+  const oldestRecovery = Math.min(...recoveryRuns.map((run) => run.createdAtMs));
+  const history = listUpdateRuns({ limit: 100 }, { env });
+  const postCoreRuns = history.filter(
+    (run) =>
+      run.createdAtMs >= oldestRecovery &&
+      run.status === "failed" &&
+      run.reason === "abandoned" &&
+      !run.steps.some((step) => step.step === "reconcile:acknowledged") &&
+      needsPostCoreRepair(run),
+  );
+  // A bounded prefix cannot prove absence of interrupted work beyond its tail.
+  const incomplete = history.length === 100 && (history.at(-1)?.createdAtMs ?? 0) >= oldestRecovery;
+  return { postCoreRuns, incomplete };
+}
+
 function assertNoActiveDriver(runs: UpdateRunRecord[]): void {
   const active = runs.find((run) => !inspectUpdateRunAbandonment(run, { explicit: true }));
   if (active) {
@@ -78,13 +97,18 @@ export async function updateRepairCommand(opts: UpdateFinalizeOptions): Promise<
     : lastRun && isUnacknowledgedAbandonedUpdateRun(lastRun)
       ? [lastRun]
       : [];
-  const recoveryRunIds = recoveryRuns.map((run) => run.runId);
+  const history = inspectNewerRecoveryHistory(recoveryRuns, env);
+  const recoveryRunIds = [
+    ...new Set([...recoveryRuns, ...history.postCoreRuns].map((run) => run.runId)),
+  ];
 
   if (
     opts.channel !== undefined ||
     opts.acceptCapabilities ||
     recoveryRuns.length === 0 ||
-    recoveryRuns.some(needsPostCoreRepair)
+    recoveryRuns.some(needsPostCoreRepair) ||
+    history.postCoreRuns.length > 0 ||
+    history.incomplete
   ) {
     await updateFinalizeCommand(opts, recoveryRunIds);
     return;
@@ -132,7 +156,12 @@ export async function updateRepairCommand(opts: UpdateFinalizeOptions): Promise<
   assertConfigWriteAllowedInCurrentMode({ env });
   const currentRuns = listUpdateRuns({ active: true, limit: 100 }, options);
   assertNoActiveDriver(currentRuns);
-  if (currentRuns.some(needsPostCoreRepair)) {
+  const currentHistory = inspectNewerRecoveryHistory(recoveryRuns, env);
+  if (
+    currentRuns.some(needsPostCoreRepair) ||
+    currentHistory.postCoreRuns.length > 0 ||
+    currentHistory.incomplete
+  ) {
     throw new Error(
       "Update repair needs post-core maintenance. Stop the Gateway service through its owner before retrying; repair will not stop or restart it.",
     );

--- a/src/commands/doctor-config-preflight.test.ts
+++ b/src/commands/doctor-config-preflight.test.ts
@@ -12,6 +12,8 @@ import {
   hasActiveStartupMigrationLease,
   readMigrationCheckpointStatus,
 } from "../infra/startup-migration-checkpoint.js";
+import { createUpdateRun, getUpdateRun } from "../infra/update-run-ledger.js";
+import { ABANDONED_UPDATE_RUN_MS } from "../infra/update-run-timeouts.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
 import { readConfigMachineState } from "../state/config-machine-state.js";
@@ -115,6 +117,23 @@ async function seedLastKnownGood(
 }
 
 describe("runDoctorConfigPreflight", () => {
+  it("reports stale legacy update recovery without modifying the run", async () => {
+    await withDoctorConfigPreflightHome(async (home) => {
+      await writeOpenClawConfig(home, { gateway: { mode: "local" } });
+      const now = Date.now();
+      const inactiveAt = now - ABANDONED_UPDATE_RUN_MS - 10;
+      const clock = vi.spyOn(Date, "now").mockReturnValue(inactiveAt);
+      const run = createUpdateRun({ trigger: "control-ui", before: { version: "2026.9.2" } });
+      clock.mockReturnValue(now);
+      await runDoctorConfigPreflight({ migrateState: false, migrateLegacyConfig: false });
+      expect(noteMock).toHaveBeenCalledWith(
+        `Update ${run.runId}: no activity since ${new Date(inactiveAt).toISOString()}; if no update is running, run \`openclaw update repair\` or start a new \`openclaw update\``,
+        "Update history",
+      );
+      expect(getUpdateRun(run.runId)).toEqual(run);
+    });
+  });
+
   afterEach(() => {
     closeOpenClawStateDatabaseForTest();
     resetLogger();

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -53,6 +53,7 @@ import {
   refuseStartupMigrationsForLiveGatewayOwner,
   throwStartupMigrationGuardRejected,
 } from "./doctor-startup-migration-refusal.js";
+import { noteStaleUpdateRuns } from "./doctor-update-run.js";
 import type { CronCodexRuntimePolicyTarget } from "./doctor/cron/store-migration.js";
 import {
   commitAutomaticConfigRepair,
@@ -119,6 +120,7 @@ export async function runDoctorConfigPreflight(
 ): Promise<DoctorConfigPreflightResult> {
   const stateMigrationsRequested = options.migrateState !== false;
   const gatewayStartupCheckpointRequired = options.requireStartupMigrationCheckpoint === true;
+  noteStaleUpdateRuns({ gatewayStartup: gatewayStartupCheckpointRequired });
   // Startup publishes one aggregate report; ordinary Doctor calls keep their per-stage output.
   const migrationLog = gatewayStartupCheckpointRequired ? { info() {}, warn() {} } : undefined;
   if (gatewayStartupCheckpointRequired) {
@@ -756,9 +758,7 @@ export async function runDoctorConfigPreflight(
       ...(postSessionPluginMigrationPlanBound ? { postSessionPluginMigrationPlanBound: true } : {}),
     };
   } finally {
-    if (startupMigrationHeartbeat) {
-      clearInterval(startupMigrationHeartbeat);
-    }
+    clearInterval(startupMigrationHeartbeat);
     startupMigrationLease?.release();
   }
 }

--- a/src/commands/doctor-config-preflight.ts
+++ b/src/commands/doctor-config-preflight.ts
@@ -120,7 +120,6 @@ export async function runDoctorConfigPreflight(
 ): Promise<DoctorConfigPreflightResult> {
   const stateMigrationsRequested = options.migrateState !== false;
   const gatewayStartupCheckpointRequired = options.requireStartupMigrationCheckpoint === true;
-  noteStaleUpdateRuns({ gatewayStartup: gatewayStartupCheckpointRequired });
   // Startup publishes one aggregate report; ordinary Doctor calls keep their per-stage output.
   const migrationLog = gatewayStartupCheckpointRequired ? { info() {}, warn() {} } : undefined;
   if (gatewayStartupCheckpointRequired) {
@@ -134,6 +133,7 @@ export async function runDoctorConfigPreflight(
       env: process.env,
     });
   }
+  noteStaleUpdateRuns(options);
   const measurePreflightStep = <T>(name: string, run: () => T | Promise<T>) =>
     measureDoctorConfigPreflightStep(name, run, options.measure);
   const migrationCheckpointRequired =

--- a/src/commands/doctor-update-run.ts
+++ b/src/commands/doctor-update-run.ts
@@ -1,0 +1,16 @@
+import { note } from "../../packages/terminal-core/src/note.js";
+import { staleUpdateRunGuidance } from "../infra/update-run-activity.js";
+import { listUpdateRuns } from "../infra/update-run-ledger.js";
+
+/** Doctor reports legacy history without granting startup automatic recovery authority. */
+export function noteStaleUpdateRuns(options: { gatewayStartup: boolean }): void {
+  if (options.gatewayStartup) {
+    return;
+  }
+  for (const run of listUpdateRuns({ active: true, limit: 100 })) {
+    const guidance = staleUpdateRunGuidance(run);
+    if (guidance) {
+      note(`Update ${run.runId}: ${guidance}`, "Update history");
+    }
+  }
+}

--- a/src/commands/doctor-update-run.ts
+++ b/src/commands/doctor-update-run.ts
@@ -2,9 +2,12 @@ import { note } from "../../packages/terminal-core/src/note.js";
 import { staleUpdateRunGuidance } from "../infra/update-run-activity.js";
 import { listUpdateRuns } from "../infra/update-run-ledger.js";
 
-/** Doctor reports legacy history without granting startup automatic recovery authority. */
-export function noteStaleUpdateRuns(options: { gatewayStartup: boolean }): void {
-  if (options.gatewayStartup) {
+/** Startup and proven-pristine preflights do not need a public ledger snapshot. */
+export function noteStaleUpdateRuns(options: {
+  requireStartupMigrationCheckpoint?: boolean;
+  skipPristineStartupStateMigrations?: boolean;
+}): void {
+  if (options.requireStartupMigrationCheckpoint || options.skipPristineStartupStateMigrations) {
     return;
   }
   for (const run of listUpdateRuns({ active: true, limit: 100 })) {

--- a/src/gateway/server-methods/update.ts
+++ b/src/gateway/server-methods/update.ts
@@ -51,9 +51,11 @@ import {
   type UpdateRestartSentinelMeta,
 } from "../../infra/update-restart-sentinel-payload.js";
 import {
+  adoptUpdateRun,
   createUpdateRun,
   finishUpdateRun,
   getUpdateRun,
+  heartbeatUpdateRun,
   recordUpdateRunPhase,
   recordUpdateRunStep,
   recordUpdateRunVerification,
@@ -502,10 +504,12 @@ export const updateHandlers: GatewayRequestHandlers = {
           }
           return;
         }
+        const driver = adoptUpdateRun(runId).origin.driver;
         recordUpdateRunPhase(runId, "staging");
         result = await runGatewayUpdate({
           runId,
           progress: {
+            onHeartbeat: () => heartbeatUpdateRun(runId, driver),
             onStepStart: (step) =>
               recordUpdateRunStep(runId, {
                 step: step.name,

--- a/src/gateway/update-run-watcher.test.ts
+++ b/src/gateway/update-run-watcher.test.ts
@@ -15,6 +15,7 @@ vi.mock("../state/openclaw-state-db.js", () => ({
 }));
 vi.mock("./update-run-notice.runtime.js", () => ({ notifyUpdateRunPhase: ledger.notice }));
 vi.mock("../infra/update-run-ledger.js", () => ({
+  reconcileAbandonedUpdateRuns: () => [],
   findActiveUpdateRun: () => {
     ledger.reads();
     return ledger.run?.status === "running" ? ledger.run : undefined;

--- a/src/gateway/update-run-watcher.ts
+++ b/src/gateway/update-run-watcher.ts
@@ -1,6 +1,10 @@
 import { formatErrorMessage } from "../infra/errors.js";
-import { findActiveUpdateRun, getUpdateRun } from "../infra/update-run-ledger.js";
-import type { UpdateRunPhase } from "../infra/update-run-record.js";
+import {
+  findActiveUpdateRun,
+  getUpdateRun,
+  reconcileAbandonedUpdateRuns,
+} from "../infra/update-run-ledger.js";
+import type { UpdateRunPhase, UpdateRunRecord } from "../infra/update-run-record.js";
 import { AsyncWorkScope } from "../shared/async-work-scope.js";
 import { reconcileOpenClawStateSchemaPublication } from "../state/openclaw-state-db.js";
 import { GATEWAY_EVENT_UPDATE_RUN_CHANGED } from "./events.js";
@@ -24,6 +28,7 @@ export function startUpdateRunWatcher(params: {
   let publicationTimer: ReturnType<typeof setTimeout> | undefined;
   let watched: { runId: string; revision?: number; phase?: UpdateRunPhase } | undefined;
   let notices = Promise.resolve();
+  const reconciled: UpdateRunRecord[] = [];
 
   const schedulePublication = () => {
     if (publicationTimer) {
@@ -54,8 +59,13 @@ export function startUpdateRunWatcher(params: {
     }
     timer = undefined;
     try {
+      reconciled.push(
+        ...reconcileAbandonedUpdateRuns().filter((run) => run.runId !== watched?.runId),
+      );
       schedulePublication();
-      const run = watched ? getUpdateRun(watched.runId) : findActiveUpdateRun();
+      const run = watched
+        ? getUpdateRun(watched.runId)
+        : (reconciled.shift() ?? findActiveUpdateRun());
       if (!run) {
         watched = undefined;
         return;

--- a/src/infra/update-managed-service-handoff-lifecycle.test.ts
+++ b/src/infra/update-managed-service-handoff-lifecycle.test.ts
@@ -227,13 +227,24 @@ describe("managed service update handoff", () => {
   );
 
   itUnix.each(["failed", "skipped"] as const)(
-    "leaves the serving generation untouched when validation finishes %s",
+    "finishes the update run without touching the serving generation when validation finishes %s",
     async (validationResult) => {
-      const { commands, parentSignal, log } = await runManagedServiceManagerBoundary("systemd", {
-        controlDisconnect: "transferred",
-        validationResult,
-        validationClockAdvanceMs: 10 * 60_000,
-        helperExitCode: validationResult === "failed" ? 1 : 0,
+      const { commands, parentSignal, log, run } = await runManagedServiceManagerBoundary(
+        "systemd",
+        {
+          controlDisconnect: "transferred",
+          ledger: true,
+          validationResult,
+          validationClockAdvanceMs: 10 * 60_000,
+          helperExitCode: validationResult === "failed" ? 1 : 0,
+        },
+      );
+      expect(run).toMatchObject({
+        status: validationResult,
+        phase: "finished",
+        reason:
+          validationResult === "failed" ? "managed-service-handoff-failed" : "already-current",
+        finishedAtMs: expect.any(Number),
       });
       expect(commands).toEqual([]);
       expect(parentSignal).toBeNull();

--- a/src/infra/update-managed-service-handoff-runtime.test-support.ts
+++ b/src/infra/update-managed-service-handoff-runtime.test-support.ts
@@ -43,7 +43,7 @@ export async function prepareManagedServiceRuntimeFixture(params: {
       recoveryModulePath,
       `
       ${ledgerRuntimeImport}
-      export const { getUpdateRun, recordUpdateRunStep, recordUpdateRunVerification } = ledger;
+      export const { adoptUpdateRun, getUpdateRun, recordUpdateRunStep, recordUpdateRunVerification } = ledger;
       ${options?.replaceLedgerWriter ? 'export function finishUpdateRun() { throw new Error("the previous runtime must not finalize the candidate"); }' : "export const { finishUpdateRun } = ledger;"}
     `,
     );

--- a/src/infra/update-managed-service-handoff.ts
+++ b/src/infra/update-managed-service-handoff.ts
@@ -1520,9 +1520,12 @@ let automaticRequested = false;
       // Admission and stop recording use the serving runtime. Terminal writes after
       // the updater starts must load the installed runtime in a fresh process.
       runLedger = await import(pathToFileURL(params.recoveryModulePath).href);
-      for (const name of ["finishUpdateRun", "getUpdateRun", "recordUpdateRunStep", "recordUpdateRunVerification"]) {
+      for (const name of ["adoptUpdateRun", "finishUpdateRun", "getUpdateRun", "recordUpdateRunStep", "recordUpdateRunVerification"]) {
         if (typeof runLedger[name] !== "function") throw new Error("managed update ledger writer is unavailable");
       }
+      if (!ownsManagedUpdateLease()) throw new Error("managed update lease no longer owns the helper");
+      // Retain prior drivers while recording this helper's independent lifetime.
+      runLedger.adoptUpdateRun(params.runId);
     }
     if (params.action === "triage") {
       await admitTriageScope();

--- a/src/infra/update-migrated-finalize.worker.ts
+++ b/src/infra/update-migrated-finalize.worker.ts
@@ -13,7 +13,7 @@ import { OPENCLAW_AGENT_SCHEMA_VERSION } from "../state/openclaw-agent-db-contra
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../state/openclaw-state-db-contract.js";
 import { closeOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { createManagedUpdateRequesterAuthority } from "./update-requester-authority.js";
-import { getUpdateRun, recordUpdateRunStep } from "./update-run-ledger.js";
+import { adoptUpdateRun, getUpdateRun, recordUpdateRunStep } from "./update-run-ledger.js";
 
 async function finalizeMigratedUpdate(): Promise<void> {
   // Validation imports this whole candidate graph before activation. The helper
@@ -46,6 +46,8 @@ async function finalizeMigratedUpdate(): Promise<void> {
     throw new Error("Candidate finalization requires its migrated update run.");
   }
   const { requesterAuthority: descriptor, ...runIdentity } = transferredRun;
+  // The candidate can outlive its parent; record both lifetimes before any awaits.
+  adoptUpdateRun(runIdentity.runId, { env: runIdentity.env });
   // Parent closures cannot cross JSON. Only the fresh installed runtime rebinds
   // the captured requester to the same current installation policy.
   const run: NonNullable<UpdateCommandOptions["run"]> = {

--- a/src/infra/update-run-abandonment.test.ts
+++ b/src/infra/update-run-abandonment.test.ts
@@ -1,0 +1,511 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { UPDATE_RUN_DRIVER_LIMIT } from "../../packages/gateway-protocol/src/update-run-vocabulary.js";
+import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createUpdateRunProgress } from "../cli/update-cli/update-command-run.js";
+import { createDeferredCore } from "../shared/deferred.js";
+import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { inspectUpdateRunAbandonment } from "./update-run-activity.js";
+import {
+  requireUpdateRunDriver as currentDriver,
+  type UpdateRunDriver,
+} from "./update-run-driver.js";
+import {
+  adoptUpdateRun,
+  createUpdateRun,
+  finishUpdateRun,
+  getUpdateRun,
+  heartbeatUpdateRun,
+  reconcileAbandonedUpdateRuns,
+  recordUpdateRunPhase,
+  recordUpdateRunStep,
+} from "./update-run-ledger.js";
+import { ABANDONED_UPDATE_RUN_MS, UPDATE_RUN_HEARTBEAT_MS } from "./update-run-timeouts.js";
+import { runStep } from "./update-runner-command.js";
+import type { CommandRunner } from "./update-runner-types.js";
+
+const tempDirs = createTempDirTracker();
+
+function isolatedOptions() {
+  return { env: { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-update-abandonment-") } };
+}
+
+function exitedDriver(): UpdateRunDriver {
+  const driver = currentDriver();
+  // The current PID belongs to a different generation than the recorded driver.
+  return { ...driver, startIdentity: String(Number(driver.startIdentity) + 1) };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.setSystemTime(new Date("2026-09-07T12:00:00Z"));
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  closeOpenClawStateDatabaseForTest();
+  tempDirs.cleanup();
+});
+
+describe("abandoned update runs", () => {
+  it("classifies without writing, then finishes an aged staging run whose driver exited", () => {
+    const options = isolatedOptions();
+    const created = createUpdateRun(
+      { trigger: "cli", origin: { driver: exitedDriver() } },
+      options,
+    );
+    const run = recordUpdateRunPhase(created.runId, "staging", {}, options);
+    vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 10);
+
+    expect(inspectUpdateRunAbandonment(run)).toBe("inactive-driver-dead");
+    expect(getUpdateRun(run.runId, options)).toEqual(run);
+    expect(reconcileAbandonedUpdateRuns({}, options)).toMatchObject([
+      {
+        runId: run.runId,
+        status: "failed",
+        phase: "finished",
+        reason: "abandoned",
+        finishedAtMs: Date.now(),
+        steps: expect.arrayContaining([
+          expect.objectContaining({
+            step: "reconcile:abandoned",
+            status: "failed",
+            detail: "inactive-driver-dead",
+          }),
+        ]),
+      },
+    ]);
+    expect(getUpdateRun(run.runId, options)?.reason).toBe("abandoned");
+    expect(reconcileAbandonedUpdateRuns({}, options)).toEqual([]);
+  });
+
+  it("preserves a recent run even when its driver exited", () => {
+    const options = isolatedOptions();
+    const run = createUpdateRun({ trigger: "cli", origin: { driver: exitedDriver() } }, options);
+    vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS - 1);
+
+    expect(inspectUpdateRunAbandonment(run, { explicit: true })).toBeUndefined();
+    expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toEqual([]);
+    expect(getUpdateRun(run.runId, options)).toEqual(run);
+  });
+
+  it.each([false, true])("preserves an aged live staging driver with explicit=%s", (explicit) => {
+    const options = isolatedOptions();
+    const created = createUpdateRun(
+      { trigger: "cli", origin: { driver: currentDriver() } },
+      options,
+    );
+    const run = recordUpdateRunPhase(created.runId, "staging", {}, options);
+    vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 10);
+
+    expect(inspectUpdateRunAbandonment(run, { explicit })).toBeUndefined();
+    expect(reconcileAbandonedUpdateRuns({ explicit }, options)).toEqual([]);
+    expect(getUpdateRun(run.runId, options)).toEqual(run);
+  });
+
+  it("preserves an aged driver whose host cannot be inspected, including explicit repair", () => {
+    const options = isolatedOptions();
+    const driver = { ...exitedDriver(), host: `${currentDriver().host}-other` };
+    const run = createUpdateRun({ trigger: "cli", origin: { driver } }, options);
+    vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 1);
+
+    expect(inspectUpdateRunAbandonment(run, { explicit: true })).toBeUndefined();
+    expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toEqual([]);
+    expect(getUpdateRun(run.runId, options)).toEqual(run);
+  });
+
+  it.each(["requested", "staging"] as const)(
+    "requires explicit recovery for an aged identityless %s run",
+    (phase) => {
+      const options = isolatedOptions();
+      const created = createUpdateRun({ trigger: "cli", before: { version: "2026.9.2" } }, options);
+      const run =
+        phase === "requested" ? created : recordUpdateRunPhase(created.runId, phase, {}, options);
+      vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 2);
+
+      expect(inspectUpdateRunAbandonment(run)).toBeUndefined();
+      expect(reconcileAbandonedUpdateRuns({}, options)).toEqual([]);
+      expect(getUpdateRun(run.runId, options)).toEqual(run);
+      expect(inspectUpdateRunAbandonment(run, { explicit: true })).toBe(
+        "operator-reconciled-inactive-run",
+      );
+      expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toMatchObject([
+        { runId: run.runId, status: "failed", phase: "finished", reason: "abandoned" },
+      ]);
+    },
+  );
+
+  it.each(["requested", "staging"] as const)(
+    "supersedes the single stale identityless %s run on explicit admission",
+    (phase) => {
+      const options = isolatedOptions();
+      const old = createUpdateRun(
+        { trigger: "control-ui", before: { version: "2026.9.2" } },
+        options,
+      );
+      recordUpdateRunPhase(old.runId, phase, {}, options);
+      vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 10);
+
+      const next = createUpdateRun(
+        { trigger: "cli", origin: { driver: currentDriver() }, supersedeStaleIdentityless: true },
+        options,
+      );
+
+      expect(next).toMatchObject({ status: "running", origin: { driver: currentDriver() } });
+      expect(getUpdateRun(old.runId, options)).toMatchObject({
+        status: "failed",
+        phase: "finished",
+        reason: "superseded",
+        steps: expect.arrayContaining([
+          expect.objectContaining({
+            step: "reconcile:superseded",
+            status: "failed",
+            detail: "operator-started-update-supersedes-inactive-identityless-run",
+          }),
+        ]),
+      });
+    },
+  );
+
+  it.each([
+    "recent",
+    "live",
+    "dead",
+    "previous-live",
+    "multiple",
+    "implicit",
+    "inherited",
+    "campaign",
+  ] as const)("does not supersede protected rows on %s admission", (kind) => {
+    const options = isolatedOptions();
+    const old = createUpdateRun(
+      {
+        trigger: "cli",
+        origin:
+          kind === "live"
+            ? { driver: currentDriver() }
+            : kind === "dead"
+              ? { driver: exitedDriver() }
+              : kind === "previous-live"
+                ? { previousDrivers: [currentDriver()] }
+                : {},
+      },
+      options,
+    );
+    if (kind !== "recent") {
+      vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 10);
+    }
+    if (kind === "multiple") {
+      createUpdateRun({ trigger: "cli" }, options);
+    }
+    createUpdateRun(
+      {
+        trigger: kind === "campaign" ? "campaign" : "cli",
+        runId: kind === "inherited" ? old.runId : undefined,
+        supersedeStaleIdentityless: kind !== "implicit",
+      },
+      options,
+    );
+    expect(getUpdateRun(old.runId, options)).toEqual(old);
+    if (kind === "recent") {
+      expect(
+        reconcileAbandonedUpdateRuns({ explicit: true, runIds: [old.runId] }, options),
+      ).toEqual([]);
+    }
+  });
+
+  it.each(["succeeded", "failed", "rolled-back", "skipped"] as const)(
+    "preserves an already %s run",
+    (status) => {
+      const options = isolatedOptions();
+      const created = createUpdateRun(
+        { trigger: "cli", origin: { driver: exitedDriver() } },
+        options,
+      );
+      const run = finishUpdateRun(created.runId, { status }, options);
+      vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 2);
+
+      expect(inspectUpdateRunAbandonment(run, { explicit: true })).toBeUndefined();
+      expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toEqual([]);
+      expect(getUpdateRun(run.runId, options)).toEqual(run);
+    },
+  );
+
+  it("rechecks current activity when a previously stale run advanced", () => {
+    const options = isolatedOptions();
+    const run = createUpdateRun({ trigger: "cli", origin: { driver: exitedDriver() } }, options);
+    vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 1);
+    expect(inspectUpdateRunAbandonment(run)).toBe("inactive-driver-dead");
+
+    const advanced = recordUpdateRunStep(
+      run.runId,
+      { step: "build", status: "completed", endedAtMs: Date.now() },
+      options,
+    );
+    expect(reconcileAbandonedUpdateRuns({ explicit: true, runIds: [run.runId] }, options)).toEqual(
+      [],
+    );
+    expect(getUpdateRun(run.runId, options)).toEqual(advanced);
+  });
+
+  it("preserves the whole explicit recovery selection when one driver resumes", () => {
+    const options = isolatedOptions();
+    const first = createUpdateRun({ trigger: "cli" }, options);
+    const second = createUpdateRun({ trigger: "cli" }, options);
+    vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 10);
+    const resumed = recordUpdateRunStep(
+      second.runId,
+      { step: "build", status: "in_progress", startedAtMs: Date.now() },
+      options,
+    );
+
+    expect(
+      reconcileAbandonedUpdateRuns(
+        { explicit: true, runIds: [first.runId, second.runId] },
+        options,
+      ),
+    ).toEqual([]);
+    expect(getUpdateRun(first.runId, options)).toEqual(first);
+    expect(getUpdateRun(second.runId, options)).toEqual(resumed);
+  });
+
+  it("commits every eligible row in the explicit recovery selection", () => {
+    const options = isolatedOptions();
+    const runs = [
+      createUpdateRun({ trigger: "cli" }, options),
+      createUpdateRun({ trigger: "cli" }, options),
+    ];
+    vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 10);
+    const reconciled = reconcileAbandonedUpdateRuns(
+      { explicit: true, runIds: runs.map((run) => run.runId), requireAllActive: true },
+      options,
+    );
+    expect(reconciled.map((run) => run.runId).toSorted()).toEqual(
+      runs.map((run) => run.runId).toSorted(),
+    );
+    for (const run of runs) {
+      expect(getUpdateRun(run.runId, options)).toMatchObject({
+        status: "failed",
+        reason: "abandoned",
+      });
+    }
+  });
+
+  it("automatically reconciles a dead driver while preserving other active rows", () => {
+    const options = isolatedOptions();
+    const dead = createUpdateRun({ trigger: "cli", origin: { driver: exitedDriver() } }, options);
+    const live = createUpdateRun({ trigger: "cli", origin: { driver: currentDriver() } }, options);
+    const legacy = createUpdateRun({ trigger: "cli" }, options);
+    vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 10);
+
+    expect(reconcileAbandonedUpdateRuns({}, options)).toMatchObject([
+      { runId: dead.runId, status: "failed", reason: "abandoned" },
+    ]);
+    expect(getUpdateRun(live.runId, options)).toEqual(live);
+    expect(getUpdateRun(legacy.runId, options)).toEqual(legacy);
+  });
+
+  it("preserves a captured recovery selection when another active run exists", () => {
+    const options = isolatedOptions();
+    const captured = createUpdateRun({ trigger: "cli" }, options);
+    vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 10);
+    const admitted = createUpdateRun({ trigger: "cli" }, options);
+
+    expect(
+      reconcileAbandonedUpdateRuns(
+        { explicit: true, runIds: [captured.runId], requireAllActive: true },
+        options,
+      ),
+    ).toEqual([]);
+    expect(getUpdateRun(captured.runId, options)).toEqual(captured);
+    expect(getUpdateRun(admitted.runId, options)).toEqual(admitted);
+  });
+
+  it("adopts an exited driver and rejects its old heartbeat without refreshing activity", () => {
+    const options = isolatedOptions();
+    const oldDriver = exitedDriver();
+    const created = createUpdateRun({ trigger: "cli", origin: { driver: oldDriver } }, options);
+    const adopted = adoptUpdateRun(created.runId, options);
+    expect(adopted.origin.driver).toEqual(currentDriver());
+    vi.advanceTimersByTime(UPDATE_RUN_HEARTBEAT_MS);
+
+    heartbeatUpdateRun(created.runId, oldDriver, options);
+    expect(getUpdateRun(created.runId, options)).toEqual(adopted);
+    expect(adoptUpdateRun(created.runId, options)).toEqual(adopted);
+    heartbeatUpdateRun(created.runId, adopted.origin.driver, options);
+    expect(getUpdateRun(created.runId, options)?.updatedAtMs).toBeGreaterThan(adopted.updatedAtMs);
+  });
+
+  it("rejects adoption after reconciliation instead of resuming a terminal run", () => {
+    const options = isolatedOptions();
+    const created = createUpdateRun(
+      { trigger: "cli", origin: { driver: exitedDriver() } },
+      options,
+    );
+    recordUpdateRunPhase(created.runId, "staging", {}, options);
+    vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 10);
+    const [reconciled] = reconcileAbandonedUpdateRuns({}, options);
+    expect(reconciled).toMatchObject({
+      runId: created.runId,
+      status: "failed",
+      reason: "abandoned",
+    });
+
+    expect(() => adoptUpdateRun(created.runId, options)).toThrow();
+    expect(getUpdateRun(created.runId, options)).toEqual(reconciled);
+  });
+
+  it("records the child while retaining and renewing its live controlling parent", () => {
+    const options = isolatedOptions();
+    const parentStart = getFileLockProcessStartTime(process.ppid);
+    if (parentStart === null) {
+      throw new Error("The test's controlling parent must have an observable start identity.");
+    }
+    const driver = { ...currentDriver(), pid: process.ppid, startIdentity: String(parentStart) };
+    const created = createUpdateRun({ trigger: "cli", origin: { driver } }, options);
+    const run = recordUpdateRunPhase(created.runId, "verifying", {}, options);
+    vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 10);
+
+    const adopted = adoptUpdateRun(run.runId, options);
+    expect(adopted.origin).toMatchObject({ driver: currentDriver(), previousDrivers: [driver] });
+    vi.advanceTimersByTime(UPDATE_RUN_HEARTBEAT_MS);
+    heartbeatUpdateRun(run.runId, driver, options);
+    expect(getUpdateRun(run.runId, options)?.updatedAtMs).toBeGreaterThan(adopted.updatedAtMs);
+    expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toEqual([]);
+  });
+
+  it.each(["alive", "unknown", "dead"] as const)(
+    "reconciles a dead current driver only when its previous driver is also dead (%s)",
+    (liveness) => {
+      const options = isolatedOptions();
+      const previous =
+        liveness === "alive"
+          ? currentDriver()
+          : liveness === "dead"
+            ? exitedDriver()
+            : { ...currentDriver(), host: "other-host.invalid" };
+      const run = createUpdateRun(
+        { trigger: "cli", origin: { driver: exitedDriver(), previousDrivers: [previous] } },
+        options,
+      );
+      vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 10);
+      const reconciled = reconcileAbandonedUpdateRuns({ explicit: true }, options);
+      expect(reconciled).toHaveLength(liveness === "dead" ? 1 : 0);
+      expect(getUpdateRun(run.runId, options)?.status).toBe(
+        liveness === "dead" ? "failed" : "running",
+      );
+    },
+  );
+
+  it("deduplicates retained drivers and removes only positively dead identities on adoption", () => {
+    const options = isolatedOptions();
+    const retained = { ...currentDriver(), host: "other-host.invalid" };
+    const run = createUpdateRun(
+      {
+        trigger: "cli",
+        origin: { driver: retained, previousDrivers: [retained, currentDriver(), exitedDriver()] },
+      },
+      options,
+    );
+    const adopted = adoptUpdateRun(run.runId, options);
+    expect(adopted.origin).toMatchObject({ driver: currentDriver(), previousDrivers: [retained] });
+    vi.advanceTimersByTime(100);
+    expect(adoptUpdateRun(run.runId, options)).toEqual(adopted);
+  });
+
+  it("refuses adoption without evicting an unobservable driver at capacity", () => {
+    const options = isolatedOptions();
+    const drivers = Array.from({ length: UPDATE_RUN_DRIVER_LIMIT }, (_, index) => ({
+      ...currentDriver(),
+      host: `other-host-${index}.invalid`,
+    }));
+    const run = createUpdateRun(
+      { trigger: "cli", origin: { driver: drivers[0], previousDrivers: drivers.slice(1) } },
+      options,
+    );
+    expect(() => adoptUpdateRun(run.runId, options)).toThrow(
+      "too many live or unobservable drivers",
+    );
+    expect(getUpdateRun(run.runId, options)).toEqual(run);
+  });
+
+  it("preserves exact current and previous identities while bounding and redacting large origin diagnostics", () => {
+    const options = isolatedOptions();
+    const drivers = Array.from({ length: UPDATE_RUN_DRIVER_LIMIT }, (_, index) => ({
+      host: `${"x".repeat(254)}${index}`,
+      pid: index + 1,
+      startIdentity: "9".repeat(128),
+    }));
+    const diagnostic = "😀".repeat(512);
+    const run = createUpdateRun(
+      {
+        trigger: "cli",
+        origin: {
+          driver: drivers[0],
+          previousDrivers: drivers.slice(1),
+          requester: { channel: diagnostic, accountId: diagnostic, senderId: diagnostic },
+          sessionKey: diagnostic,
+          deliveryContext: {
+            channel: diagnostic,
+            to: diagnostic,
+            accountId: diagnostic,
+            threadId: diagnostic,
+          },
+          campaignId: diagnostic,
+          doctorHint: diagnostic,
+          nextAction: diagnostic,
+        },
+      },
+      { ...options, redactPaths: drivers.map((driver) => driver.host) },
+    );
+    expect(run.origin.driver).toEqual(drivers[0]);
+    expect(run.origin.previousDrivers).toEqual(drivers.slice(1));
+    expect(Buffer.byteLength(JSON.stringify(run.origin))).toBeLessThanOrEqual(16 * 1024);
+    expect(run.origin.doctorHint?.length).toBeLessThan(diagnostic.length);
+    expect(getUpdateRun(run.runId, options)).toEqual(run);
+  });
+
+  it.each([false, true])(
+    "renews a slow step and stops heartbeats after failure=%s",
+    async (fails) => {
+      const options = isolatedOptions();
+      const created = createUpdateRun({ trigger: "cli" }, options);
+      const run = adoptUpdateRun(created.runId, options);
+      const progress = createUpdateRunProgress({ runId: run.runId, env: options.env }, {});
+      const command = createDeferredCore<Awaited<ReturnType<CommandRunner>>>();
+      const timersBefore = vi.getTimerCount();
+      const pending = runStep({
+        runCommand: () => command.promise,
+        name: "build",
+        argv: ["pnpm", "build"],
+        cwd: options.env.OPENCLAW_STATE_DIR,
+        timeoutMs: ABANDONED_UPDATE_RUN_MS * 2,
+        progress,
+        stepIndex: 0,
+        totalSteps: 1,
+      });
+      const settled = fails
+        ? expect(pending).rejects.toThrow("build interrupted")
+        : expect(pending).resolves.toMatchObject({ exitCode: 0 });
+      await vi.advanceTimersByTimeAsync(ABANDONED_UPDATE_RUN_MS + UPDATE_RUN_HEARTBEAT_MS);
+
+      const active = getUpdateRun(run.runId, options);
+      expect(active?.updatedAtMs).toBeGreaterThan(run.updatedAtMs + ABANDONED_UPDATE_RUN_MS);
+      expect(active?.steps).toContainEqual(
+        expect.objectContaining({ step: "build", status: "in_progress" }),
+      );
+      expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toEqual([]);
+
+      if (fails) {
+        command.reject(new Error("build interrupted"));
+      } else {
+        command.resolve({ stdout: "", stderr: "", code: 0 });
+      }
+      await settled;
+      expect(vi.getTimerCount()).toBe(timersBefore);
+      const finished = getUpdateRun(run.runId, options);
+      await vi.advanceTimersByTimeAsync(UPDATE_RUN_HEARTBEAT_MS * 2);
+      expect(getUpdateRun(run.runId, options)).toEqual(finished);
+    },
+  );
+});

--- a/src/infra/update-run-abandonment.test.ts
+++ b/src/infra/update-run-abandonment.test.ts
@@ -3,13 +3,11 @@ import { UPDATE_RUN_DRIVER_LIMIT } from "../../packages/gateway-protocol/src/upd
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { createUpdateRunProgress } from "../cli/update-cli/update-command-run.js";
 import { createDeferredCore } from "../shared/deferred.js";
+import * as pidAlive from "../shared/pid-alive.js";
 import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { inspectUpdateRunAbandonment } from "./update-run-activity.js";
-import {
-  requireUpdateRunDriver as currentDriver,
-  type UpdateRunDriver,
-} from "./update-run-driver.js";
+import { readUpdateRunDriver, type UpdateRunDriver } from "./update-run-driver.js";
 import {
   adoptUpdateRun,
   createUpdateRun,
@@ -30,6 +28,14 @@ function isolatedOptions() {
   return { env: { OPENCLAW_STATE_DIR: tempDirs.make("openclaw-update-abandonment-") } };
 }
 
+function currentDriver(): UpdateRunDriver {
+  const driver = readUpdateRunDriver();
+  if (!driver) {
+    throw new Error("Test process identity is unavailable");
+  }
+  return driver;
+}
+
 function exitedDriver(): UpdateRunDriver {
   const driver = currentDriver();
   // The current PID belongs to a different generation than the recorded driver.
@@ -43,11 +49,94 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.useRealTimers();
+  vi.restoreAllMocks();
   closeOpenClawStateDatabaseForTest();
   tempDirs.cleanup();
 });
 
 describe("abandoned update runs", () => {
+  it("adopts without identity when process inspection is unavailable", () => {
+    const options = isolatedOptions();
+    const created = createUpdateRun({ trigger: "cli" }, options);
+    vi.spyOn(pidAlive, "getFileLockProcessStartTime").mockReturnValue(null);
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const adopted = adoptUpdateRun(created.runId, options);
+    adoptUpdateRun(created.runId, options);
+
+    expect(adopted.origin.driver).toBeUndefined();
+    expect(warning).toHaveBeenCalledTimes(1);
+    expect(warning).toHaveBeenCalledWith(
+      expect.stringContaining("identity recording is unavailable"),
+    );
+    vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 10);
+    expect(reconcileAbandonedUpdateRuns({}, options)).toEqual([]);
+    expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toMatchObject([
+      { runId: created.runId, status: "failed", reason: "abandoned" },
+    ]);
+  });
+
+  it("preserves a known parent and the unobservable adopter across later driver death", () => {
+    const options = isolatedOptions();
+    const parent = currentDriver();
+    const created = createUpdateRun({ trigger: "cli", origin: { driver: parent } }, options);
+    const inspection = vi.spyOn(pidAlive, "getFileLockProcessStartTime").mockReturnValue(null);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    adoptUpdateRun(created.runId, options);
+    for (let index = 0; index < 150; index++) {
+      recordUpdateRunStep(
+        created.runId,
+        { step: `diagnostic:${index}`, status: "completed" },
+        options,
+      );
+    }
+    vi.advanceTimersByTime(ABANDONED_UPDATE_RUN_MS + 1_000);
+    inspection.mockReturnValue(Number(parent.startIdentity));
+    expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toEqual([]);
+    inspection.mockReturnValue(Number(parent.startIdentity) + 1);
+    expect(reconcileAbandonedUpdateRuns({}, options)).toEqual([]);
+    expect(reconcileAbandonedUpdateRuns({ explicit: true }, options)).toMatchObject([
+      { runId: created.runId, status: "failed", reason: "abandoned" },
+    ]);
+  });
+
+  it("keeps a command running after heartbeat errors and warns once across its steps", async () => {
+    const options = isolatedOptions();
+    const run = adoptUpdateRun(createUpdateRun({ trigger: "cli" }, options).runId, options);
+    const progress = createUpdateRunProgress({ runId: run.runId, env: options.env }, {});
+    progress.onHeartbeat = vi.fn(() => {
+      throw new Error("SQLITE_BUSY: database is locked");
+    });
+    const warning = vi.spyOn(console, "warn").mockImplementation(() => {});
+    for (const name of ["install", "build"]) {
+      const command = createDeferredCore<Awaited<ReturnType<CommandRunner>>>();
+      const aborted = vi.fn(() => command.reject(new Error("command aborted")));
+      const pending = runStep({
+        runCommand: (_argv, input) => {
+          input.signal?.addEventListener("abort", aborted);
+          return command.promise;
+        },
+        name,
+        argv: ["pnpm", name],
+        cwd: options.env.OPENCLAW_STATE_DIR,
+        timeoutMs: ABANDONED_UPDATE_RUN_MS,
+        progress,
+        stepIndex: 0,
+        totalSteps: 2,
+      });
+      const settled = pending.catch((error: unknown) => error);
+      await vi.advanceTimersByTimeAsync(UPDATE_RUN_HEARTBEAT_MS * 2);
+      expect(aborted).not.toHaveBeenCalled();
+      command.resolve({ stdout: "", stderr: "", code: 0 });
+      expect(await settled).toMatchObject({ exitCode: 0 });
+      expect(getUpdateRun(run.runId, options)?.steps).toContainEqual(
+        expect.objectContaining({ step: name, status: "completed" }),
+      );
+    }
+    expect(warning).toHaveBeenCalledTimes(1);
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("SQLITE_BUSY"));
+  });
+
   it("classifies without writing, then finishes an aged staging run whose driver exited", () => {
     const options = isolatedOptions();
     const created = createUpdateRun(

--- a/src/infra/update-run-activity.ts
+++ b/src/infra/update-run-activity.ts
@@ -1,0 +1,63 @@
+import { inspectUpdateRunDriver, type UpdateRunDriver } from "./update-run-driver.js";
+import type { UpdateRunRecord } from "./update-run-record.js";
+import { ABANDONED_UPDATE_RUN_MS } from "./update-run-timeouts.js";
+
+function updateRunLastActivity(record: UpdateRunRecord): number {
+  return Math.max(
+    record.updatedAtMs,
+    ...record.steps.flatMap((step) => [step.startedAtMs ?? 0, step.endedAtMs ?? 0]),
+  );
+}
+
+export function isStaleIdentitylessUpdateRun(record: UpdateRunRecord): boolean {
+  return (
+    record.status === "running" &&
+    !record.origin.driver &&
+    !record.origin.previousDrivers?.length &&
+    Date.now() - updateRunLastActivity(record) > ABANDONED_UPDATE_RUN_MS
+  );
+}
+
+export function recordedUpdateRunDrivers(record: UpdateRunRecord): UpdateRunDriver[] {
+  return [
+    ...(record.origin.driver ? [record.origin.driver] : []),
+    ...(record.origin.previousDrivers ?? []),
+  ];
+}
+
+/** Only a fresh, unacknowledged recovery may substitute for a full repair invocation. */
+export function isUnacknowledgedAbandonedUpdateRun(record: UpdateRunRecord): boolean {
+  return (
+    record.status === "failed" &&
+    record.reason === "abandoned" &&
+    record.finishedAtMs !== null &&
+    record.finishedAtMs <= Date.now() &&
+    Date.now() - record.finishedAtMs <= ABANDONED_UPDATE_RUN_MS &&
+    !record.steps.some((step) => step.step === "reconcile:acknowledged")
+  );
+}
+
+/** Read-only classification; an unobservable process is never presumed dead. */
+export function inspectUpdateRunAbandonment(
+  record: UpdateRunRecord,
+  input: { explicit?: boolean } = {},
+): string | undefined {
+  const lastActivity = updateRunLastActivity(record);
+  if (record.status !== "running" || Date.now() - lastActivity <= ABANDONED_UPDATE_RUN_MS) {
+    return undefined;
+  }
+  const drivers = recordedUpdateRunDrivers(record);
+  if (drivers.length) {
+    return drivers.every((driver) => inspectUpdateRunDriver(driver) === "dead")
+      ? "inactive-driver-dead"
+      : undefined;
+  }
+  return input.explicit ? "operator-reconciled-inactive-run" : undefined;
+}
+
+/** Legacy activity cannot prove death; reporting must leave recovery to the operator. */
+export function staleUpdateRunGuidance(record: UpdateRunRecord): string | undefined {
+  return isStaleIdentitylessUpdateRun(record)
+    ? `no activity since ${new Date(updateRunLastActivity(record)).toISOString()}; if no update is running, run \`openclaw update repair\` or start a new \`openclaw update\``
+    : undefined;
+}

--- a/src/infra/update-run-activity.ts
+++ b/src/infra/update-run-activity.ts
@@ -46,6 +46,9 @@ export function inspectUpdateRunAbandonment(
   if (record.status !== "running" || Date.now() - lastActivity <= ABANDONED_UPDATE_RUN_MS) {
     return undefined;
   }
+  if (!input.explicit && record.steps.some((step) => step.step === "driver:identity-unavailable")) {
+    return undefined;
+  }
   const drivers = recordedUpdateRunDrivers(record);
   if (drivers.length) {
     return drivers.every((driver) => inspectUpdateRunDriver(driver) === "dead")

--- a/src/infra/update-run-codec.ts
+++ b/src/infra/update-run-codec.ts
@@ -1,0 +1,199 @@
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import { UPDATE_RUN_PHASES } from "../../packages/gateway-protocol/src/update-run-vocabulary.js";
+import { resolveStateDir } from "../config/paths.js";
+import { redactSensitiveText } from "../logging/redact.js";
+import { escapeRegExp } from "../shared/regexp.js";
+import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
+import type { UpdateRuns } from "../state/openclaw-state-db.generated.js";
+import { resolveRequiredHomeDir } from "./home-dir.js";
+import type { UpdateRunRecord } from "./update-run-record.js";
+import { UpdateRunRecordSchema } from "./update-run-schema.js";
+
+const JSON_BYTES = 16 * 1024;
+const RETAINED_STEP_NAMES = [
+  ...UPDATE_RUN_PHASES,
+  "notice:ack",
+  "notice:activating",
+  "notice:verifying",
+  "previous generation restoration",
+  "post-update verification",
+  "driver:adopted",
+  "reconcile:abandoned",
+  "reconcile:superseded",
+  "reconcile:acknowledged",
+];
+const JSON_FIELDS = [
+  "origin",
+  "target",
+  "before",
+  "after",
+  "steps",
+  "verification",
+  "repair",
+] as const;
+export type UpdateRunLedgerOptions = OpenClawStateDatabaseOptions & {
+  redactPaths?: readonly string[];
+};
+
+function mapJsonText(value: unknown, transform: (text: string) => string): unknown {
+  if (typeof value === "string") {
+    return transform(value);
+  }
+  if (Array.isArray(value)) {
+    return value.map((entry) => mapJsonText(entry, transform));
+  }
+  if (isRecord(value)) {
+    return Object.fromEntries(
+      Object.keys(value)
+        .toSorted()
+        .map((key) => [key, mapJsonText(value[key], transform)]),
+    );
+  }
+  return value;
+}
+
+export function isRetainedStep(item: unknown): boolean {
+  return (
+    isRecord(item) &&
+    typeof item.step === "string" &&
+    (item.step.startsWith("finalize:") || RETAINED_STEP_NAMES.some((name) => name === item.step))
+  );
+}
+
+/** Phase history, notice custody, and restoration proof survive diagnostic eviction. */
+function boundedJson(input: unknown, maxBytes = JSON_BYTES): string {
+  let value = input;
+  let json = JSON.stringify(value);
+  while (Buffer.byteLength(json) > maxBytes) {
+    if (Array.isArray(value)) {
+      const disposable = value.findIndex((item) => !isRetainedStep(item));
+      if (disposable >= 0) {
+        value = value.toSpliced(disposable, 1);
+      } else {
+        // Reserved identities and timestamps fit; discard optional diagnostics
+        // before losing phase history, notice custody, or restoration proof.
+        const compacted = value.map((item) =>
+          isRecord(item) ? { ...item, detail: undefined } : item,
+        );
+        if (JSON.stringify(compacted) === json) {
+          throw new Error("Update run retained step metadata exceeds its byte limit");
+        }
+        value = compacted;
+      }
+    } else if (isRecord(value)) {
+      const object = value;
+      const key = Object.keys(object)
+        .toSorted()
+        .find((field) => Array.isArray(object[field]) && object[field].length > 0);
+      const array = key ? object[key] : undefined;
+      if (key && Array.isArray(array)) {
+        value = { ...object, [key]: array.slice(1) };
+      } else {
+        value = mapJsonText(value, (text) => truncateUtf16Safe(text, Math.floor(text.length / 2)));
+      }
+    } else {
+      throw new Error("Update run metadata exceeds its bounded schema");
+    }
+    json = JSON.stringify(value);
+  }
+  return json;
+}
+
+function boundedOriginJson(origin: UpdateRunRecord["origin"]): string {
+  const { driver, previousDrivers, ...diagnostics } = origin;
+  const identities = JSON.stringify({ driver, previousDrivers });
+  const boundedDiagnostics = boundedJson(diagnostics, JSON_BYTES - Buffer.byteLength(identities));
+  return `{${[identities.slice(1, -1), boundedDiagnostics.slice(1, -1)].filter(Boolean).join(",")}}`;
+}
+
+export function encodeRun(input: UpdateRunRecord, options: UpdateRunLedgerOptions): UpdateRuns {
+  const env = options.env ?? process.env;
+  // Home-relative selectors remain actionable in reports. Other captured roots
+  // are diagnostic only; model refs, slash commands, and URLs are not paths.
+  const roots: [string | undefined, string][] = [
+    [resolveRequiredHomeDir(env), "~"],
+    [env.HOME, "~"],
+    [env.USERPROFILE, "~"],
+    [resolveStateDir(env), "$OPENCLAW_STATE_DIR"],
+    [env.OPENCLAW_CONFIG_PATH, "[path]"],
+    ...(options.redactPaths ?? []).map((root): [string, string] => [root, "[path]"]),
+  ];
+  const redactPaths: [RegExp, string][] = roots.flatMap(([root, replacement]) => {
+    if (!root) {
+      return [];
+    }
+    const prefix = root
+      .replaceAll("\\", "/")
+      .replace(/\/+$/u, "")
+      .split("/")
+      .map(escapeRegExp)
+      .join("[\\\\/]");
+    const flags = /^(?:[A-Za-z]:|\\\\)/u.test(root) ? "giu" : "gu";
+    return prefix
+      ? [
+          [
+            new RegExp(
+              `(?<!https?:)(?:(?<![\\w/])|(?<=file:///?))${prefix}(?=$|[\\\\/\\s"'<>.,;:)])`,
+              flags,
+            ),
+            replacement,
+          ],
+        ]
+      : [];
+  });
+  // Process identities are exact observations, never redacted diagnostic strings.
+  const { driver, previousDrivers, ...originDiagnostics } = input.origin;
+  const record = UpdateRunRecordSchema.parse(
+    mapJsonText({ ...input, origin: originDiagnostics }, (value) => {
+      let text = redactSensitiveText(value, { mode: "tools" });
+      for (const [pattern, replacement] of redactPaths) {
+        text = text.replace(pattern, () => replacement);
+      }
+      return truncateUtf16Safe(text, 1024);
+    }),
+  );
+  record.origin = UpdateRunRecordSchema.shape.origin.parse({
+    ...record.origin,
+    driver,
+    previousDrivers,
+  });
+  return {
+    run_id: record.runId,
+    created_at_ms: record.createdAtMs,
+    updated_at_ms: record.updatedAtMs,
+    trigger: record.trigger,
+    phase: record.phase,
+    status: record.status,
+    reason: record.reason,
+    origin_json: boundedOriginJson(record.origin),
+    target_json: boundedJson(record.target),
+    before_json: boundedJson(record.before),
+    after_json: boundedJson(record.after),
+    steps_json: boundedJson(record.steps),
+    verification_json: boundedJson(record.verification),
+    repair_json: boundedJson(record.repair),
+    confirmed_at_ms: record.confirmedAtMs,
+    finished_at_ms: record.finishedAtMs,
+    downtime_ms: record.downtimeMs,
+  };
+}
+
+export function decodeRun(row: UpdateRuns): UpdateRunRecord {
+  const metadata = Object.fromEntries(
+    JSON_FIELDS.map((field) => [field, JSON.parse(row[`${field}_json`])]),
+  );
+  return UpdateRunRecordSchema.parse({
+    ...metadata,
+    runId: row.run_id,
+    createdAtMs: row.created_at_ms,
+    updatedAtMs: row.updated_at_ms,
+    trigger: row.trigger,
+    phase: row.phase,
+    status: row.status,
+    reason: row.reason,
+    confirmedAtMs: row.confirmed_at_ms,
+    finishedAtMs: row.finished_at_ms,
+    downtimeMs: row.downtime_ms,
+  });
+}

--- a/src/infra/update-run-codec.ts
+++ b/src/infra/update-run-codec.ts
@@ -19,6 +19,7 @@ const RETAINED_STEP_NAMES = [
   "previous generation restoration",
   "post-update verification",
   "driver:adopted",
+  "driver:identity-unavailable",
   "reconcile:abandoned",
   "reconcile:superseded",
   "reconcile:acknowledged",

--- a/src/infra/update-run-driver.test.ts
+++ b/src/infra/update-run-driver.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { inspectUpdateRunDriver, requireUpdateRunDriver } from "./update-run-driver.js";
+
+const probes = vi.hoisted(() => ({
+  hostname: vi.fn<() => string>(),
+  startedAt: vi.fn<(pid: number) => number | null>(),
+  definitelyDead: vi.fn<(pid: number) => boolean>(),
+}));
+
+vi.mock("node:os", () => ({ hostname: probes.hostname }));
+vi.mock("../shared/pid-alive.js", () => ({
+  getFileLockProcessStartTime: probes.startedAt,
+  isPidDefinitelyDead: probes.definitelyDead,
+}));
+
+beforeEach(() => {
+  probes.hostname.mockReturnValue("update-host");
+  probes.startedAt.mockReturnValue(123);
+  probes.definitelyDead.mockReturnValue(false);
+});
+
+describe("update run driver identity", () => {
+  it.each([0, 123])("captures the current driver with start identity %s", (startedAt) => {
+    probes.startedAt.mockReturnValue(startedAt);
+    expect(requireUpdateRunDriver()).toEqual({
+      host: "update-host",
+      pid: process.pid,
+      startIdentity: String(startedAt),
+    });
+  });
+
+  it.each([
+    { host: "", startedAt: 123 },
+    { host: "update-host", startedAt: null },
+    { host: "x".repeat(256), startedAt: 123 },
+  ])("does not invent a missing identity (%j)", ({ host, startedAt }) => {
+    probes.hostname.mockReturnValue(host);
+    probes.startedAt.mockReturnValue(startedAt);
+    expect(() => requireUpdateRunDriver()).toThrow("process identity is unavailable");
+  });
+
+  it.each([
+    { host: "update-host", dead: false, startedAt: 123, expected: "alive" },
+    { host: "update-host", dead: true, startedAt: null, expected: "dead" },
+    { host: "update-host", dead: false, startedAt: 456, expected: "dead" },
+    { host: "update-host", dead: false, startedAt: null, expected: "unknown" },
+    { host: "another-host", dead: true, startedAt: null, expected: "unknown" },
+    { host: "another-host", dead: false, startedAt: 456, expected: "unknown" },
+  ])("requires local positive evidence before declaring a driver dead (%j)", (test) => {
+    probes.definitelyDead.mockReturnValue(test.dead);
+    probes.startedAt.mockReturnValue(test.startedAt);
+    expect(inspectUpdateRunDriver({ host: test.host, pid: 42, startIdentity: "123" })).toBe(
+      test.expected,
+    );
+  });
+});

--- a/src/infra/update-run-driver.test.ts
+++ b/src/infra/update-run-driver.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { inspectUpdateRunDriver, requireUpdateRunDriver } from "./update-run-driver.js";
+import { inspectUpdateRunDriver, readUpdateRunDriver } from "./update-run-driver.js";
 
 const probes = vi.hoisted(() => ({
   hostname: vi.fn<() => string>(),
@@ -22,7 +22,7 @@ beforeEach(() => {
 describe("update run driver identity", () => {
   it.each([0, 123])("captures the current driver with start identity %s", (startedAt) => {
     probes.startedAt.mockReturnValue(startedAt);
-    expect(requireUpdateRunDriver()).toEqual({
+    expect(readUpdateRunDriver()).toEqual({
       host: "update-host",
       pid: process.pid,
       startIdentity: String(startedAt),
@@ -36,7 +36,7 @@ describe("update run driver identity", () => {
   ])("does not invent a missing identity (%j)", ({ host, startedAt }) => {
     probes.hostname.mockReturnValue(host);
     probes.startedAt.mockReturnValue(startedAt);
-    expect(() => requireUpdateRunDriver()).toThrow("process identity is unavailable");
+    expect(readUpdateRunDriver()).toBeUndefined();
   });
 
   it.each([

--- a/src/infra/update-run-driver.ts
+++ b/src/infra/update-run-driver.ts
@@ -1,0 +1,48 @@
+import { hostname } from "node:os";
+import { getFileLockProcessStartTime, isPidDefinitelyDead } from "../shared/pid-alive.js";
+
+export type UpdateRunDriver = {
+  host: string;
+  pid: number;
+  startIdentity: string;
+};
+
+export function sameUpdateRunDriver(left: UpdateRunDriver, right: UpdateRunDriver): boolean {
+  return (
+    left.host === right.host && left.pid === right.pid && left.startIdentity === right.startIdentity
+  );
+}
+
+export function requireUpdateRunDriver(): UpdateRunDriver {
+  const host = hostname();
+  const startedAt = getFileLockProcessStartTime(process.pid);
+  if (
+    !host ||
+    host.length > 255 ||
+    startedAt === null ||
+    !Number.isSafeInteger(startedAt) ||
+    startedAt < 0
+  ) {
+    throw new Error(
+      "Update driver process identity is unavailable; retry when local process inspection is available.",
+    );
+  }
+  return { host, pid: process.pid, startIdentity: String(startedAt) };
+}
+
+export function inspectUpdateRunDriver(driver: UpdateRunDriver): "alive" | "dead" | "unknown" {
+  // A PID on another host says nothing about this driver's lifetime.
+  if (driver.host !== hostname()) {
+    return "unknown";
+  }
+  if (isPidDefinitelyDead(driver.pid)) {
+    return "dead";
+  }
+  const startedAt = getFileLockProcessStartTime(driver.pid);
+  if (startedAt === null) {
+    return "unknown";
+  }
+  // A reused PID proves the recorded driver exited. An identical identity after
+  // a reboot remains conservatively live; identity coincidence never revokes it.
+  return String(startedAt) === driver.startIdentity ? "alive" : "dead";
+}

--- a/src/infra/update-run-driver.ts
+++ b/src/infra/update-run-driver.ts
@@ -13,7 +13,7 @@ export function sameUpdateRunDriver(left: UpdateRunDriver, right: UpdateRunDrive
   );
 }
 
-export function requireUpdateRunDriver(): UpdateRunDriver {
+export function readUpdateRunDriver(): UpdateRunDriver | undefined {
   const host = hostname();
   const startedAt = getFileLockProcessStartTime(process.pid);
   if (
@@ -23,9 +23,7 @@ export function requireUpdateRunDriver(): UpdateRunDriver {
     !Number.isSafeInteger(startedAt) ||
     startedAt < 0
   ) {
-    throw new Error(
-      "Update driver process identity is unavailable; retry when local process inspection is available.",
-    );
+    return undefined;
   }
   return { host, pid: process.pid, startIdentity: String(startedAt) };
 }

--- a/src/infra/update-run-ledger.test.ts
+++ b/src/infra/update-run-ledger.test.ts
@@ -434,7 +434,7 @@ describe("update run ledger", () => {
     { name: "diagnostic bytes", count: 30, detail: "diagnostic ".repeat(80) },
     { name: "retained phase bytes", count: 0, detail: "🦞".repeat(512) },
   ])(
-    "retains notice custody, restoration proof, and phases across the $name bound and database reopen",
+    "retains notice custody, restoration proof, and finalization history across the $name bound and database reopen",
     ({ count, detail }) => {
       const options = isolatedOptions();
       const run = createUpdateRun({ trigger: "chat" }, options);
@@ -443,6 +443,9 @@ describe("update run ledger", () => {
         "notice:activating",
         "notice:verifying",
         "previous generation restoration",
+        "finalize:doctor",
+        "finalize:future-phase",
+        "post-update verification",
       ];
       for (const step of [...UPDATE_RUN_PHASES, ...notices]) {
         recordUpdateRunStep(run.runId, { step, status: "completed", detail }, options);
@@ -462,6 +465,27 @@ describe("update run ledger", () => {
       expect(persisted.steps.every((step) => step.status === "completed")).toBe(true);
       expect(persisted.steps.length).toBeLessThanOrEqual(128);
       expect(Buffer.byteLength(JSON.stringify(persisted.steps))).toBeLessThanOrEqual(16 * 1024);
+    },
+  );
+
+  it.each(["bytes", "count"] as const)(
+    "rejects oversized retained step %s without changing the row",
+    (bound) => {
+      const options = isolatedOptions();
+      let saved = createUpdateRun({ trigger: "cli" }, options);
+      expect(() => {
+        for (let index = 0; index < 130; index++) {
+          saved = recordUpdateRunStep(
+            saved.runId,
+            {
+              step: `finalize:${index}${bound === "bytes" ? "界".repeat(330) : ""}`,
+              status: "completed",
+            },
+            options,
+          );
+        }
+      }).toThrow(/retained step.*limit/);
+      expect(getUpdateRun(saved.runId, options)).toEqual(saved);
     },
   );
 

--- a/src/infra/update-run-ledger.ts
+++ b/src/infra/update-run-ledger.ts
@@ -1,186 +1,44 @@
 import { randomUUID } from "node:crypto";
 import type { DatabaseSync } from "node:sqlite";
-import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
-import { UPDATE_RUN_PHASES } from "../../packages/gateway-protocol/src/update-run-vocabulary.js";
-import { resolveStateDir } from "../config/paths.js";
-import { redactSensitiveText } from "../logging/redact.js";
-import { escapeRegExp } from "../shared/regexp.js";
+import {
+  UPDATE_RUN_DRIVER_LIMIT,
+  UPDATE_RUN_PHASES,
+} from "../../packages/gateway-protocol/src/update-run-vocabulary.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
 import { withExistingOpenClawStateDatabaseArtifactPreservingReadOnly } from "../state/openclaw-state-db-readonly.js";
 import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
-import type { DB, UpdateRuns } from "../state/openclaw-state-db.generated.js";
+import type { DB } from "../state/openclaw-state-db.generated.js";
 import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { OPENCLAW_STATE_SCHEMA_SQL } from "../state/openclaw-state-schema.js";
-import { resolveRequiredHomeDir } from "./home-dir.js";
 import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import {
+  inspectUpdateRunAbandonment,
+  isStaleIdentitylessUpdateRun,
+  recordedUpdateRunDrivers,
+} from "./update-run-activity.js";
+import {
+  decodeRun,
+  encodeRun,
+  isRetainedStep,
+  type UpdateRunLedgerOptions as LedgerOptions,
+} from "./update-run-codec.js";
+import {
+  inspectUpdateRunDriver,
+  requireUpdateRunDriver,
+  sameUpdateRunDriver,
+  type UpdateRunDriver,
+} from "./update-run-driver.js";
 import type { UpdateRunRecord, UpdateRunPhase, UpdateRunStep } from "./update-run-record.js";
-import { UpdateRunRecordSchema } from "./update-run-schema.js";
+import { ABANDONED_UPDATE_RUN_MS } from "./update-run-timeouts.js";
 
-const JSON_BYTES = 16 * 1024;
-const RETAINED_STEP_NAMES = [
-  ...UPDATE_RUN_PHASES,
-  "notice:ack",
-  "notice:activating",
-  "notice:verifying",
-  "previous generation restoration",
-];
-const JSON_FIELDS = [
-  "origin",
-  "target",
-  "before",
-  "after",
-  "steps",
-  "verification",
-  "repair",
-] as const;
 type LedgerDatabase = Pick<DB, "update_runs">;
-type LedgerOptions = OpenClawStateDatabaseOptions & { redactPaths?: readonly string[] };
 type RunPatch = Partial<
   Pick<UpdateRunRecord, "origin" | "target" | "before" | "after" | "trigger">
 >;
-
-function mapJsonText(value: unknown, transform: (text: string) => string): unknown {
-  if (typeof value === "string") {
-    return transform(value);
-  }
-  if (Array.isArray(value)) {
-    return value.map((entry) => mapJsonText(entry, transform));
-  }
-  if (isRecord(value)) {
-    return Object.fromEntries(
-      Object.keys(value)
-        .toSorted()
-        .map((key) => [key, mapJsonText(value[key], transform)]),
-    );
-  }
-  return value;
-}
-
-function isRetainedStep(item: unknown): boolean {
-  return isRecord(item) && RETAINED_STEP_NAMES.some((name) => name === item.step);
-}
-
-/** Phase history, notice custody, and restoration proof survive diagnostic eviction. */
-function boundedJson(input: unknown): string {
-  let value = input;
-  let json = JSON.stringify(value);
-  while (Buffer.byteLength(json) > JSON_BYTES) {
-    if (Array.isArray(value)) {
-      const disposable = value.findIndex((item) => !isRetainedStep(item));
-      if (disposable >= 0) {
-        value = value.toSpliced(disposable, 1);
-      } else {
-        // Reserved identities and timestamps fit; discard optional diagnostics
-        // before losing phase history, notice custody, or restoration proof.
-        value = value.map((item) => (isRecord(item) ? { ...item, detail: undefined } : item));
-      }
-    } else if (isRecord(value)) {
-      const object = value;
-      const key = Object.keys(object)
-        .toSorted()
-        .find((field) => Array.isArray(object[field]) && object[field].length > 0);
-      const array = key ? object[key] : undefined;
-      if (key && Array.isArray(array)) {
-        value = { ...object, [key]: array.slice(1) };
-      } else {
-        value = mapJsonText(value, (text) => truncateUtf16Safe(text, Math.floor(text.length / 2)));
-      }
-    } else {
-      throw new Error("Update run metadata exceeds its bounded schema");
-    }
-    json = JSON.stringify(value);
-  }
-  return json;
-}
-
-function encodeRun(input: UpdateRunRecord, options: LedgerOptions): UpdateRuns {
-  const env = options.env ?? process.env;
-  // Home-relative selectors remain actionable in reports. Other captured roots
-  // are diagnostic only; model refs, slash commands, and URLs are not paths.
-  const roots: [string | undefined, string][] = [
-    [resolveRequiredHomeDir(env), "~"],
-    [env.HOME, "~"],
-    [env.USERPROFILE, "~"],
-    [resolveStateDir(env), "$OPENCLAW_STATE_DIR"],
-    [env.OPENCLAW_CONFIG_PATH, "[path]"],
-    ...(options.redactPaths ?? []).map((root): [string, string] => [root, "[path]"]),
-  ];
-  const redactPaths: [RegExp, string][] = roots.flatMap(([root, replacement]) => {
-    if (!root) {
-      return [];
-    }
-    const prefix = root
-      .replaceAll("\\", "/")
-      .replace(/\/+$/u, "")
-      .split("/")
-      .map(escapeRegExp)
-      .join("[\\\\/]");
-    const flags = /^(?:[A-Za-z]:|\\\\)/u.test(root) ? "giu" : "gu";
-    return prefix
-      ? [
-          [
-            new RegExp(
-              `(?<!https?:)(?:(?<![\\w/])|(?<=file:///?))${prefix}(?=$|[\\\\/\\s"'<>.,;:)])`,
-              flags,
-            ),
-            replacement,
-          ],
-        ]
-      : [];
-  });
-  const record = UpdateRunRecordSchema.parse(
-    mapJsonText(input, (value) => {
-      let text = redactSensitiveText(value, { mode: "tools" });
-      for (const [pattern, replacement] of redactPaths) {
-        text = text.replace(pattern, () => replacement);
-      }
-      return truncateUtf16Safe(text, 1024);
-    }),
-  );
-  return {
-    run_id: record.runId,
-    created_at_ms: record.createdAtMs,
-    updated_at_ms: record.updatedAtMs,
-    trigger: record.trigger,
-    phase: record.phase,
-    status: record.status,
-    reason: record.reason,
-    origin_json: boundedJson(record.origin),
-    target_json: boundedJson(record.target),
-    before_json: boundedJson(record.before),
-    after_json: boundedJson(record.after),
-    steps_json: boundedJson(record.steps),
-    verification_json: boundedJson(record.verification),
-    repair_json: boundedJson(record.repair),
-    confirmed_at_ms: record.confirmedAtMs,
-    finished_at_ms: record.finishedAtMs,
-    downtime_ms: record.downtimeMs,
-  };
-}
-
-function decodeRun(row: UpdateRuns): UpdateRunRecord {
-  const metadata = Object.fromEntries(
-    JSON_FIELDS.map((field) => [field, JSON.parse(row[`${field}_json`])]),
-  );
-  return UpdateRunRecordSchema.parse({
-    ...metadata,
-    runId: row.run_id,
-    createdAtMs: row.created_at_ms,
-    updatedAtMs: row.updated_at_ms,
-    trigger: row.trigger,
-    phase: row.phase,
-    status: row.status,
-    reason: row.reason,
-    confirmedAtMs: row.confirmed_at_ms,
-    finishedAtMs: row.finished_at_ms,
-    downtimeMs: row.downtime_ms,
-  });
-}
 
 const schemaStart = OPENCLAW_STATE_SCHEMA_SQL.indexOf("CREATE TABLE IF NOT EXISTS update_runs (");
 const schemaEndMarker = "ON update_runs(status, created_at_ms DESC, run_id);";
@@ -220,6 +78,23 @@ function writeRun<T>(operation: (db: DatabaseSync) => T, options: OpenClawStateD
   return result;
 }
 
+function persistRun(
+  db: DatabaseSync,
+  record: UpdateRunRecord,
+  options: LedgerOptions,
+): UpdateRunRecord {
+  record.updatedAtMs = Math.max(Date.now(), record.updatedAtMs + 1);
+  const row = encodeRun(record, options);
+  executeSqliteQuerySync(
+    db,
+    getNodeSqliteKysely<LedgerDatabase>(db)
+      .updateTable("update_runs")
+      .set(row)
+      .where("run_id", "=", record.runId),
+  );
+  return decodeRun(row);
+}
+
 function mutateRun(
   runId: string,
   update: (record: UpdateRunRecord) => void,
@@ -235,21 +110,16 @@ function mutateRun(
     if (before === JSON.stringify(record)) {
       return record;
     }
-    record.updatedAtMs = Math.max(Date.now(), record.updatedAtMs + 1);
-    const row = encodeRun(record, options);
-    executeSqliteQuerySync(
-      db,
-      getNodeSqliteKysely<LedgerDatabase>(db)
-        .updateTable("update_runs")
-        .set(row)
-        .where("run_id", "=", runId),
-    );
-    return decodeRun(row);
+    return persistRun(db, record, options);
   }, options);
 }
 
 export function createUpdateRun(
-  input: RunPatch & { runId?: string; trigger: UpdateRunRecord["trigger"] },
+  input: RunPatch & {
+    runId?: string;
+    trigger: UpdateRunRecord["trigger"];
+    supersedeStaleIdentityless?: boolean;
+  },
   options: LedgerOptions = {},
 ): UpdateRunRecord {
   const now = Date.now();
@@ -280,6 +150,29 @@ export function createUpdateRun(
     if (existing) {
       return existing;
     }
+    // Only an explicit new CLI invocation may supersede the single legacy run.
+    // Selection, activity recheck, terminalization, and admission share this transaction.
+    if (input.supersedeStaleIdentityless && !input.runId && input.trigger === "cli") {
+      const active = executeSqliteQuerySync(
+        db,
+        getNodeSqliteKysely<LedgerDatabase>(db)
+          .selectFrom("update_runs")
+          .selectAll()
+          .where("status", "=", "running")
+          .limit(2),
+      ).rows;
+      const previous = active.length === 1 && active[0] ? decodeRun(active[0]) : undefined;
+      if (previous && isStaleIdentitylessUpdateRun(previous)) {
+        upsertStep(previous, {
+          step: "reconcile:superseded",
+          status: "failed",
+          endedAtMs: now,
+          detail: "operator-started-update-supersedes-inactive-identityless-run",
+        });
+        finishRunRecord(previous, { status: "failed", reason: "superseded" });
+        persistRun(db, previous, options);
+      }
+    }
     executeSqliteQuerySync(
       db,
       getNodeSqliteKysely<LedgerDatabase>(db).insertInto("update_runs").values(row),
@@ -297,8 +190,173 @@ function upsertStep(record: UpdateRunRecord, step: UpdateRunStep): void {
   }
   while (record.steps.length > 128) {
     const disposable = record.steps.findIndex((entry) => !isRetainedStep(entry));
+    if (disposable < 0) {
+      throw new Error("Update run retained steps exceed the step limit");
+    }
     record.steps.splice(disposable, 1);
   }
+}
+
+/** Adoption is explicit: reading or reserving an existing run does not make this process its driver. */
+export function adoptUpdateRun(runId: string, options: LedgerOptions = {}): UpdateRunRecord {
+  const driver = requireUpdateRunDriver();
+  return mutateRun(
+    runId,
+    (record) => {
+      if (record.status !== "running") {
+        throw new Error(`Update run ${runId} is already ${record.status}; it cannot be adopted.`);
+      }
+      const previousDrivers: UpdateRunDriver[] = [];
+      for (const previous of recordedUpdateRunDrivers(record)) {
+        if (
+          !sameUpdateRunDriver(previous, driver) &&
+          !previousDrivers.some((retained) => sameUpdateRunDriver(retained, previous)) &&
+          inspectUpdateRunDriver(previous) !== "dead"
+        ) {
+          previousDrivers.push(previous);
+        }
+      }
+      if (previousDrivers.length >= UPDATE_RUN_DRIVER_LIMIT) {
+        throw new Error(
+          `Update run ${runId} has too many live or unobservable drivers; adoption refused.`,
+        );
+      }
+      const retained = record.origin.previousDrivers ?? [];
+      if (
+        record.origin.driver &&
+        sameUpdateRunDriver(record.origin.driver, driver) &&
+        record.steps.some((step) => step.step === "driver:adopted") &&
+        retained.length === previousDrivers.length &&
+        retained.every((previous, index) => {
+          const next = previousDrivers[index];
+          return next !== undefined && sameUpdateRunDriver(previous, next);
+        })
+      ) {
+        return;
+      }
+      record.origin.driver = driver;
+      record.origin.previousDrivers = previousDrivers.length ? previousDrivers : undefined;
+      upsertStep(record, { step: "driver:adopted", status: "completed", endedAtMs: Date.now() });
+    },
+    options,
+  );
+}
+
+/** Retained orchestrators can renew their children; pruned identities cannot. */
+export function heartbeatUpdateRun(
+  runId: string,
+  driver: UpdateRunDriver | undefined,
+  options: LedgerOptions = {},
+): void {
+  if (!driver) {
+    return;
+  }
+  mutateRun(
+    runId,
+    (record) => {
+      if (
+        record.status === "running" &&
+        recordedUpdateRunDrivers(record).some((current) => sameUpdateRunDriver(current, driver))
+      ) {
+        record.updatedAtMs = Math.max(Date.now(), record.updatedAtMs + 1);
+      }
+    },
+    options,
+  );
+}
+
+/** Record the operator's successful ledger-only repair without changing the failed outcome. */
+export function acknowledgeAbandonedUpdateRun(runId: string, options: LedgerOptions = {}): void {
+  mutateRun(
+    runId,
+    (record) => {
+      if (
+        record.status === "failed" &&
+        record.reason === "abandoned" &&
+        !record.steps.some((step) => step.step === "reconcile:acknowledged")
+      ) {
+        upsertStep(record, {
+          step: "reconcile:acknowledged",
+          status: "completed",
+          endedAtMs: Date.now(),
+        });
+      }
+    },
+    options,
+  );
+}
+
+/** The writer rechecks activity and process identity in the same transaction as terminalization. */
+export function reconcileAbandonedUpdateRuns(
+  input: { explicit?: boolean; runIds?: readonly string[]; requireAllActive?: boolean } = {},
+  options: LedgerOptions = {},
+): UpdateRunRecord[] {
+  if (input.runIds?.length === 0) {
+    return [];
+  }
+  const candidates =
+    withExistingOpenClawStateDatabaseArtifactPreservingReadOnly(({ db }) => {
+      if (!tableExists(db, "update_runs")) {
+        return [];
+      }
+      let query = getNodeSqliteKysely<LedgerDatabase>(db)
+        .selectFrom("update_runs")
+        .select("run_id")
+        .where("status", "=", "running");
+      if (!input.explicit) {
+        query = query.where("updated_at_ms", "<", Date.now() - ABANDONED_UPDATE_RUN_MS);
+      }
+      if (input.runIds) {
+        query = query.where("run_id", "in", [...input.runIds]);
+      }
+      return executeSqliteQuerySync(db, query.orderBy("run_id")).rows;
+    }, options) ?? [];
+  if (!candidates.length) {
+    return [];
+  }
+  return writeRun((db) => {
+    if (
+      input.requireAllActive &&
+      executeSqliteQueryTakeFirstSync(
+        db,
+        getNodeSqliteKysely<LedgerDatabase>(db)
+          .selectFrom("update_runs")
+          .select("run_id")
+          .where("status", "=", "running")
+          .where(
+            "run_id",
+            "not in",
+            candidates.map((candidate) => candidate.run_id),
+          )
+          .limit(1),
+      )
+    ) {
+      return [];
+    }
+    const selected = candidates.flatMap((candidate) => {
+      const record = readRun(db, candidate.run_id);
+      return record?.status === "running"
+        ? [{ record, rule: inspectUpdateRunAbandonment(record, input) }]
+        : [];
+    });
+    // Operator recovery is one selection: renewed activity preserves every selected row.
+    if (input.explicit && selected.some(({ rule }) => !rule)) {
+      return [];
+    }
+    return selected.flatMap(({ record, rule }) => {
+      if (!rule) {
+        return [];
+      }
+      upsertStep(record, {
+        step: "reconcile:abandoned",
+        status: "failed",
+        endedAtMs: Date.now(),
+        detail: rule,
+      });
+      finishRunRecord(record, { status: "failed", reason: "abandoned" });
+      return [persistRun(db, record, options)];
+    });
+  }, options);
 }
 
 export function recordUpdateRunPhase(
@@ -402,36 +460,37 @@ export function finishUpdateRun(
   },
   options: LedgerOptions = {},
 ): UpdateRunRecord {
-  return mutateRun(
-    runId,
-    (record) => {
-      // CLI and the new Gateway may finish together. The first durable terminal outcome wins.
-      if (record.status !== "running") {
-        return;
-      }
-      const now = Date.now();
-      // A thrown command or interrupted updater can miss its completion callback.
-      // Terminal runs cannot retain live steps after their lifecycle closes.
-      for (const step of record.steps) {
-        if (step.step === record.phase || step.status === "in_progress") {
-          step.status =
-            result.status === "failed"
-              ? "failed"
-              : result.status === "skipped"
-                ? "skipped"
-                : "completed";
-          step.endedAtMs = now;
-        }
-      }
-      record.status = result.status;
-      record.phase = "finished";
-      record.reason = result.reason ?? null;
-      record.finishedAtMs = now;
-      record.after = { ...record.after, ...result.after };
-      record.downtimeMs = result.downtimeMs ?? record.downtimeMs;
-    },
-    options,
-  );
+  return mutateRun(runId, (record) => finishRunRecord(record, result), options);
+}
+
+function finishRunRecord(
+  record: UpdateRunRecord,
+  result: Parameters<typeof finishUpdateRun>[1],
+): void {
+  // CLI and the new Gateway may finish together. The first durable terminal outcome wins.
+  if (record.status !== "running") {
+    return;
+  }
+  const now = Date.now();
+  // A thrown command or interrupted updater can miss its completion callback.
+  // Terminal runs cannot retain live steps after their lifecycle closes.
+  for (const step of record.steps) {
+    if (step.step === record.phase || step.status === "in_progress") {
+      step.status =
+        result.status === "failed"
+          ? "failed"
+          : result.status === "skipped"
+            ? "skipped"
+            : "completed";
+      step.endedAtMs = now;
+    }
+  }
+  record.status = result.status;
+  record.phase = "finished";
+  record.reason = result.reason ?? null;
+  record.finishedAtMs = now;
+  record.after = { ...record.after, ...result.after };
+  record.downtimeMs = result.downtimeMs ?? record.downtimeMs;
 }
 
 export function recordUpdateRunVerification(

--- a/src/infra/update-run-ledger.ts
+++ b/src/infra/update-run-ledger.ts
@@ -28,7 +28,7 @@ import {
 } from "./update-run-codec.js";
 import {
   inspectUpdateRunDriver,
-  requireUpdateRunDriver,
+  readUpdateRunDriver,
   sameUpdateRunDriver,
   type UpdateRunDriver,
 } from "./update-run-driver.js";
@@ -199,12 +199,25 @@ function upsertStep(record: UpdateRunRecord, step: UpdateRunStep): void {
 
 /** Adoption is explicit: reading or reserving an existing run does not make this process its driver. */
 export function adoptUpdateRun(runId: string, options: LedgerOptions = {}): UpdateRunRecord {
-  const driver = requireUpdateRunDriver();
-  return mutateRun(
+  const driver = readUpdateRunDriver();
+  let identityUnavailable = false;
+  const adopted = mutateRun(
     runId,
     (record) => {
       if (record.status !== "running") {
         throw new Error(`Update run ${runId} is already ${record.status}; it cannot be adopted.`);
+      }
+      if (!driver) {
+        if (!record.steps.some((step) => step.step === "driver:identity-unavailable")) {
+          // Retain known parents, but their death cannot prove this adopter exited.
+          upsertStep(record, {
+            step: "driver:identity-unavailable",
+            status: "completed",
+            endedAtMs: Date.now(),
+          });
+          identityUnavailable = true;
+        }
+        return;
       }
       const previousDrivers: UpdateRunDriver[] = [];
       for (const previous of recordedUpdateRunDrivers(record)) {
@@ -240,6 +253,12 @@ export function adoptUpdateRun(runId: string, options: LedgerOptions = {}): Upda
     },
     options,
   );
+  if (identityUnavailable) {
+    console.warn(
+      "[update] Driver identity recording is unavailable. The update will continue; this run requires explicit recovery if it stops reporting progress.",
+    );
+  }
+  return adopted;
 }
 
 /** Retained orchestrators can renew their children; pruned identities cannot. */

--- a/src/infra/update-run-schema.ts
+++ b/src/infra/update-run-schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import {
+  UPDATE_RUN_DRIVER_LIMIT,
   UPDATE_RUN_PHASES,
   UPDATE_RUN_STATUSES,
   UPDATE_RUN_STEP_STATUSES,
@@ -22,6 +23,12 @@ const UpdateRunStepSchema = z.object({
   detail: text.optional(),
 });
 
+const driver = z.object({
+  host: z.string().min(1).max(255),
+  pid: z.number().int().positive().max(Number.MAX_SAFE_INTEGER),
+  startIdentity: z.string().max(128).regex(/^\d+$/),
+});
+
 export const UpdateRunRecordSchema = z.object({
   runId: z.uuid(),
   createdAtMs: timestamp,
@@ -31,6 +38,11 @@ export const UpdateRunRecordSchema = z.object({
   status: z.enum(UPDATE_RUN_STATUSES),
   reason: text.nullable(),
   origin: z.object({
+    driver: driver.optional(),
+    previousDrivers: z
+      .array(driver)
+      .max(UPDATE_RUN_DRIVER_LIMIT - 1)
+      .optional(),
     requester: z
       .object({ channel: text.optional(), accountId: text.optional(), senderId: text.optional() })
       .optional(),

--- a/src/infra/update-run-timeouts.ts
+++ b/src/infra/update-run-timeouts.ts
@@ -1,0 +1,3 @@
+/** Shared legacy-reader grace and inactive update reconciliation threshold. */
+export const ABANDONED_UPDATE_RUN_MS = 30 * 60_000;
+export const UPDATE_RUN_HEARTBEAT_MS = 30_000;

--- a/src/infra/update-runner-command.ts
+++ b/src/infra/update-runner-command.ts
@@ -1,6 +1,7 @@
 import { runCommandWithTimeout } from "../process/exec.js";
 import { trimLogTail } from "./restart-sentinel.js";
 import { createGlobalInstallEnv } from "./update-global.js";
+import { UPDATE_RUN_HEARTBEAT_MS } from "./update-run-timeouts.js";
 import type {
   CommandRunner,
   RunStepOptions,
@@ -32,7 +33,29 @@ export async function runStep(opts: RunStepOptions): Promise<UpdateStepResult> {
   progress?.onStepStart?.(stepInfo);
 
   const started = Date.now();
-  const result = await runCommand(argv, { cwd, timeoutMs, env });
+  const controller = new AbortController();
+  const heartbeat = progress?.onHeartbeat
+    ? setInterval(() => {
+        try {
+          progress.onHeartbeat?.();
+        } catch (error) {
+          controller.abort(error);
+        }
+      }, UPDATE_RUN_HEARTBEAT_MS)
+    : undefined;
+  heartbeat?.unref();
+  let result: Awaited<ReturnType<CommandRunner>>;
+  try {
+    result = await runCommand(argv, {
+      cwd,
+      timeoutMs,
+      env,
+      ...(heartbeat ? { signal: controller.signal } : {}),
+    });
+    controller.signal.throwIfAborted();
+  } finally {
+    clearInterval(heartbeat);
+  }
   const durationMs = Date.now() - started;
   const stdoutTail = trimLogTail(result.stdout, MAX_LOG_CHARS);
   const stderrTail = trimLogTail(result.stderr, MAX_LOG_CHARS);

--- a/src/infra/update-runner-command.ts
+++ b/src/infra/update-runner-command.ts
@@ -1,4 +1,5 @@
 import { runCommandWithTimeout } from "../process/exec.js";
+import { formatErrorMessage } from "./errors.js";
 import { trimLogTail } from "./restart-sentinel.js";
 import { createGlobalInstallEnv } from "./update-global.js";
 import { UPDATE_RUN_HEARTBEAT_MS } from "./update-run-timeouts.js";
@@ -12,6 +13,9 @@ import type {
 
 export const UPDATE_RUNNER_TIMEOUT_MS = 20 * 60_000;
 export const MAX_LOG_CHARS = 8000;
+
+// A run shares its heartbeat callback across steps; weak keys do not retain completed runs.
+const warnedHeartbeats = new WeakSet<() => void>();
 
 function mergeCommandEnvironments(
   baseEnv: NodeJS.ProcessEnv | undefined,
@@ -33,13 +37,18 @@ export async function runStep(opts: RunStepOptions): Promise<UpdateStepResult> {
   progress?.onStepStart?.(stepInfo);
 
   const started = Date.now();
-  const controller = new AbortController();
-  const heartbeat = progress?.onHeartbeat
+  const onHeartbeat = progress?.onHeartbeat;
+  const heartbeat = onHeartbeat
     ? setInterval(() => {
         try {
-          progress.onHeartbeat?.();
+          onHeartbeat();
         } catch (error) {
-          controller.abort(error);
+          if (!warnedHeartbeats.has(onHeartbeat)) {
+            warnedHeartbeats.add(onHeartbeat);
+            console.warn(
+              `[update] Could not refresh the update heartbeat; continuing the command: ${trimLogTail(formatErrorMessage(error), 500)}`,
+            );
+          }
         }
       }, UPDATE_RUN_HEARTBEAT_MS)
     : undefined;
@@ -50,9 +59,7 @@ export async function runStep(opts: RunStepOptions): Promise<UpdateStepResult> {
       cwd,
       timeoutMs,
       env,
-      ...(heartbeat ? { signal: controller.signal } : {}),
     });
-    controller.signal.throwIfAborted();
   } finally {
     clearInterval(heartbeat);
   }

--- a/src/infra/update-runner-types.ts
+++ b/src/infra/update-runner-types.ts
@@ -98,6 +98,7 @@ export type UpdateStepInfo = {
 type UpdateStepCompletion = UpdateStepInfo & Omit<UpdateStepResult, "cwd">;
 
 export type UpdateStepProgress = {
+  onHeartbeat?: () => void;
   onStepStart?: (step: UpdateStepInfo) => void;
   onStepComplete?: (step: UpdateStepCompletion) => void;
 };

--- a/src/state/openclaw-state-ownership.test.ts
+++ b/src/state/openclaw-state-ownership.test.ts
@@ -252,7 +252,10 @@ describe("external shared-state ownership", () => {
     const fixture = claimFixture();
     const home = tempDirs.make("openclaw-state-ownership-doctor-");
     const snapshotStaging = vi.spyOn(sqliteReadonlyLocation, "prepareSqliteReadOnlyLocationSync");
-    const runPreflight = async (env: NodeJS.ProcessEnv) =>
+    const runPreflight = async (
+      env: NodeJS.ProcessEnv,
+      skipPristineStartupStateMigrations: boolean,
+    ) =>
       await withEnvAsync(
         {
           HOME: home,
@@ -267,12 +270,14 @@ describe("external shared-state ownership", () => {
             migrateLegacyConfig: false,
             migrateState: true,
             observe: false,
-            skipPristineStartupStateMigrations: true,
+            skipPristineStartupStateMigrations,
           }),
       );
     try {
-      await expect(runPreflight(fixture.unmarkedEnv)).rejects.toThrow(OpenClawStateOwnershipError);
-      await expect(runPreflight(fixture.externalEnv)).resolves.toBeDefined();
+      await expect(runPreflight(fixture.unmarkedEnv, false)).rejects.toThrow(
+        OpenClawStateOwnershipError,
+      );
+      await expect(runPreflight(fixture.externalEnv, true)).resolves.toBeDefined();
       expect(snapshotStaging).not.toHaveBeenCalled();
     } finally {
       snapshotStaging.mockRestore();

--- a/src/state/openclaw-state-schema-publication.ts
+++ b/src/state/openclaw-state-schema-publication.ts
@@ -3,13 +3,13 @@ import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { parse as parseSemver } from "semver";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { readSqliteUserVersion } from "../infra/sqlite-user-version.js";
+import { ABANDONED_UPDATE_RUN_MS } from "../infra/update-run-timeouts.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "./openclaw-state-db-contract.js";
 import { tableExists } from "./openclaw-state-db-schema-helpers.js";
 import { CONTENT_VERSION_KEY } from "./openclaw-state-db-schema-version.js";
 import type { DB } from "./openclaw-state-db.generated.js";
 
 const TERMINAL_GRACE_MS = 5 * 60_000;
-const ABANDONED_RUN_MS = 30 * 60_000;
 type PublicationDatabase = Pick<DB, "config_machine_state" | "update_runs">;
 
 export type StateSchemaPublicationBlocker = {
@@ -41,7 +41,7 @@ export function readStateSchemaPublicationBlocker(
         eb.or([
           eb.and([
             eb("status", "=", "running"),
-            eb("updated_at_ms", ">=", nowMs - ABANDONED_RUN_MS),
+            eb("updated_at_ms", ">=", nowMs - ABANDONED_UPDATE_RUN_MS),
           ]),
           eb.and([
             eb("status", "!=", "running"),
@@ -66,7 +66,7 @@ export function readStateSchemaPublicationBlocker(
     }
     const deadline =
       row.status === "running"
-        ? row.updated_at_ms + ABANDONED_RUN_MS + 1
+        ? row.updated_at_ms + ABANDONED_UPDATE_RUN_MS + 1
         : row.finished_at_ms === null
           ? null
           : row.finished_at_ms + TERMINAL_GRACE_MS;

--- a/test/gateway-external-state-ownership.e2e.test.ts
+++ b/test/gateway-external-state-ownership.e2e.test.ts
@@ -1,7 +1,9 @@
 import { backup, DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 import { withStateSchemaFence } from "../src/infra/state-database-coordinator.js";
-import { createUpdateRun } from "../src/infra/update-run-ledger.js";
+import { requireUpdateRunDriver, type UpdateRunDriver } from "../src/infra/update-run-driver.js";
+import { createUpdateRun, finishUpdateRun } from "../src/infra/update-run-ledger.js";
+import { ABANDONED_UPDATE_RUN_MS } from "../src/infra/update-run-timeouts.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../src/state/openclaw-state-db-contract.js";
 import {
   closeOpenClawStateDatabaseByPath,
@@ -62,6 +64,71 @@ function seedDeferredState(instance: OpenClawTestInstance, terminal: boolean) {
   }
 }
 
+function seedInactiveUpdateRun(
+  instance: OpenClawTestInstance,
+  input: { ageMs: number; phase?: "requested" | "staging"; driver?: UpdateRunDriver },
+) {
+  const options = { env: instance.env };
+  const { db, path: databasePath } = openOpenClawStateDatabase(options);
+  try {
+    const run = createUpdateRun(
+      {
+        trigger: "cli",
+        before: { version: "2026.9.2" },
+        origin: input.driver ? { driver: input.driver } : {},
+      },
+      options,
+    );
+    const phase = input.phase ?? "requested";
+    const lastActivity = Date.now() - input.ageMs;
+    const steps =
+      phase === "requested"
+        ? [{ step: "requested", status: "in_progress", startedAtMs: lastActivity }]
+        : [
+            {
+              step: "requested",
+              status: "completed",
+              startedAtMs: lastActivity,
+              endedAtMs: lastActivity,
+            },
+            { step: "staging", status: "in_progress", startedAtMs: lastActivity },
+          ];
+    db.prepare(`UPDATE update_runs SET created_at_ms = ?, updated_at_ms = ?,
+      phase = ?, steps_json = ? WHERE run_id = ?`).run(
+      lastActivity,
+      lastActivity,
+      phase,
+      JSON.stringify(steps),
+      run.runId,
+    );
+    return { databasePath, runId: run.runId, lastActivity };
+  } finally {
+    closeOpenClawStateDatabaseByPath(databasePath);
+  }
+}
+
+function readUpdateOutcome(db: DatabaseSync, runId: string) {
+  return db
+    .prepare("SELECT status, phase, reason, updated_at_ms FROM update_runs WHERE run_id = ?")
+    .get(runId);
+}
+
+async function expectGatewayStillServing(
+  instance: OpenClawTestInstance,
+  child: NonNullable<OpenClawTestInstance["child"]>,
+) {
+  expect(instance.child).toBe(child);
+  expect(child.exitCode).toBeNull();
+  expect(child.signalCode).toBeNull();
+  for (const pathname of ["/healthz", "/readyz"]) {
+    const response = await fetch(`http://127.0.0.1:${instance.port}${pathname}`, {
+      signal: AbortSignal.timeout(3_000),
+    });
+    await response.arrayBuffer();
+    expect(response.status, pathname).toBe(200);
+  }
+}
+
 function readSchemaVersions(db: DatabaseSync) {
   return {
     published: db.prepare("PRAGMA user_version").get()?.user_version,
@@ -87,6 +154,183 @@ function expectGatewayOwnsState(instance: OpenClawTestInstance, databasePath: st
 }
 
 describe("Gateway external shared-state ownership", () => {
+  it("reconciles a dead update driver at boot and repairs its ledger without restarting", async () => {
+    const instance = await createPublicationInstance("gateway-abandoned-update-driver");
+    let observer: DatabaseSync | undefined;
+    try {
+      const currentDriver = requireUpdateRunDriver();
+      const { databasePath, runId } = seedInactiveUpdateRun(instance, {
+        ageMs: ABANDONED_UPDATE_RUN_MS + 60_000,
+        // A live PID with a different start identity positively proves PID reuse.
+        driver: {
+          ...currentDriver,
+          startIdentity: currentDriver.startIdentity === "0" ? "1" : "0",
+        },
+      });
+      const database = new DatabaseSync(databasePath, { readOnly: true });
+      observer = database;
+      await instance.startGateway();
+      const child = instance.child;
+      if (!child) {
+        throw new Error("Gateway fixture started without an owned process.");
+      }
+      await expect
+        .poll(() => readUpdateOutcome(database, runId), { timeout: 10_000, interval: 100 })
+        .toMatchObject({ status: "failed", phase: "finished", reason: "abandoned" });
+      const row = database
+        .prepare("SELECT steps_json FROM update_runs WHERE run_id = ?")
+        .get(runId);
+      expect(JSON.parse(String(row?.steps_json))).toContainEqual(
+        expect.objectContaining({
+          step: "reconcile:abandoned",
+          status: "failed",
+          detail: "inactive-driver-dead",
+        }),
+      );
+      const status = await instance.cli(["update", "status", "--json", "--timeout", "1"]);
+      expect(status.code, `${status.stderr}\n${status.stdout}`).toBe(0);
+      expect(JSON.parse(status.stdout)).toMatchObject({
+        lastRun: { runId, status: "failed", reason: "abandoned" },
+      });
+      expect(JSON.parse(status.stdout)).not.toHaveProperty("activeRun");
+      const repair = await instance.cli(["update", "repair", "--json"]);
+      expect(repair.code, `${repair.stderr}\n${repair.stdout}`).toBe(0);
+      expect(JSON.parse(repair.stdout)).toMatchObject({
+        status: "ok",
+        mode: "repair",
+        restart: false,
+        reconciledRuns: [],
+      });
+      await expectGatewayStillServing(instance, child);
+      expectGatewayOwnsState(instance, databasePath);
+    } finally {
+      observer?.close();
+      await instance.cleanup();
+    }
+  }, 120_000);
+
+  it("preserves recent and live drivers and explicitly repairs an inactive identityless row", async () => {
+    const instance = await createPublicationInstance("gateway-inactive-update-repair");
+    let observer: DatabaseSync | undefined;
+    try {
+      const driver = requireUpdateRunDriver();
+      const inactive = seedInactiveUpdateRun(instance, {
+        ageMs: ABANDONED_UPDATE_RUN_MS + 60_000,
+        phase: "staging",
+      });
+      const live = seedInactiveUpdateRun(instance, {
+        ageMs: ABANDONED_UPDATE_RUN_MS + 60_000,
+        driver,
+      });
+      const recent = seedInactiveUpdateRun(instance, { ageMs: 60_000 });
+      observer = new DatabaseSync(inactive.databasePath, { readOnly: true });
+      await instance.startGateway();
+      const child = instance.child;
+      if (!child) {
+        throw new Error("Gateway fixture started without an owned process.");
+      }
+      const refused = await instance.cli(["update", "repair", "--json"]);
+      expect(refused.code).not.toBe(0);
+      expect(`${refused.stderr}\n${refused.stdout}`).toMatch(/still in progress/u);
+      for (const run of [inactive, live, recent]) {
+        expect(readUpdateOutcome(observer, run.runId)).toMatchObject({
+          status: "running",
+          reason: null,
+          updated_at_ms: run.lastActivity,
+        });
+      }
+      await expectGatewayStillServing(instance, child);
+
+      // These synthetic drivers complete their own work before operator repair.
+      for (const run of [live, recent]) {
+        finishUpdateRun(
+          run.runId,
+          { status: "skipped", reason: "fixture-complete" },
+          { env: instance.env },
+        );
+      }
+      closeOpenClawStateDatabaseByPath(inactive.databasePath);
+      const repair = await instance.cli(["update", "repair", "--json"]);
+      expect(repair.code, `${repair.stderr}\n${repair.stdout}`).toBe(0);
+      expect(JSON.parse(repair.stdout)).toMatchObject({
+        status: "ok",
+        mode: "repair",
+        restart: false,
+        reconciledRuns: [inactive.runId],
+      });
+      expect(readUpdateOutcome(observer, inactive.runId)).toMatchObject({
+        status: "failed",
+        phase: "finished",
+        reason: "abandoned",
+      });
+      const status = await instance.cli(["update", "status", "--json", "--timeout", "1"]);
+      expect(status.code, `${status.stderr}\n${status.stdout}`).toBe(0);
+      expect(JSON.parse(status.stdout)).not.toHaveProperty("activeRun");
+      await expectGatewayStillServing(instance, child);
+      expectGatewayOwnsState(instance, inactive.databasePath);
+    } finally {
+      observer?.close();
+      await instance.cleanup();
+    }
+  }, 120_000);
+
+  it.each(["repair", "update"] as const)(
+    "explicit %s clears legacy requested-only history without restarting",
+    async (action) => {
+      const instance = await createPublicationInstance(`gateway-legacy-update-${action}`);
+      let observer: DatabaseSync | undefined;
+      try {
+        const inactive = seedInactiveUpdateRun(instance, {
+          ageMs: ABANDONED_UPDATE_RUN_MS + 60_000,
+        });
+        observer = new DatabaseSync(inactive.databasePath, { readOnly: true });
+        await instance.startGateway();
+        const child = instance.child;
+        if (!child) {
+          throw new Error("Gateway fixture started without an owned process.");
+        }
+        const before = await instance.cli(["update", "status", "--json", "--timeout", "1"]);
+        expect(before.code, before.stderr).toBe(0);
+        expect(JSON.parse(before.stdout)).toMatchObject({
+          activeRun: { runId: inactive.runId },
+          staleRun: { runId: inactive.runId },
+        });
+        expect(readUpdateOutcome(observer, inactive.runId)).toMatchObject({
+          status: "running",
+          updated_at_ms: inactive.lastActivity,
+        });
+        const result = await instance.cli(
+          action === "repair"
+            ? ["update", "repair", "--json"]
+            : ["update", "--yes", "--json", "--dry-run"],
+          { timeoutMs: 60_000 },
+        );
+        expect(result.code, `${result.stderr}\n${result.stdout}`).toBe(0);
+        if (action === "repair") {
+          expect(JSON.parse(result.stdout)).toMatchObject({
+            status: "ok",
+            restart: false,
+            reconciledRuns: [inactive.runId],
+          });
+        }
+        expect(readUpdateOutcome(observer, inactive.runId)).toMatchObject({
+          status: "failed",
+          phase: "finished",
+          reason: action === "repair" ? "abandoned" : "superseded",
+        });
+        const after = await instance.cli(["update", "status", "--json", "--timeout", "1"]);
+        expect(after.code, after.stderr).toBe(0);
+        expect(JSON.parse(after.stdout)).not.toHaveProperty("activeRun");
+        await expectGatewayStillServing(instance, child);
+        expectGatewayOwnsState(instance, inactive.databasePath);
+      } finally {
+        observer?.close();
+        await instance.cleanup();
+      }
+    },
+    120_000,
+  );
+
   it("keeps CLI readers usable while the owning Gateway defers schema publication", async () => {
     const instance = await createPublicationInstance("gateway-deferred-schema-readers");
     let observer: DatabaseSync | undefined;

--- a/test/gateway-external-state-ownership.e2e.test.ts
+++ b/test/gateway-external-state-ownership.e2e.test.ts
@@ -1,7 +1,7 @@
 import { backup, DatabaseSync } from "node:sqlite";
 import { describe, expect, it } from "vitest";
 import { withStateSchemaFence } from "../src/infra/state-database-coordinator.js";
-import { requireUpdateRunDriver, type UpdateRunDriver } from "../src/infra/update-run-driver.js";
+import { readUpdateRunDriver, type UpdateRunDriver } from "../src/infra/update-run-driver.js";
 import { createUpdateRun, finishUpdateRun } from "../src/infra/update-run-ledger.js";
 import { ABANDONED_UPDATE_RUN_MS } from "../src/infra/update-run-timeouts.js";
 import { OPENCLAW_STATE_SCHEMA_VERSION } from "../src/state/openclaw-state-db-contract.js";
@@ -158,7 +158,10 @@ describe("Gateway external shared-state ownership", () => {
     const instance = await createPublicationInstance("gateway-abandoned-update-driver");
     let observer: DatabaseSync | undefined;
     try {
-      const currentDriver = requireUpdateRunDriver();
+      const currentDriver = readUpdateRunDriver();
+      if (!currentDriver) {
+        throw new Error("Test process identity is unavailable");
+      }
       const { databasePath, runId } = seedInactiveUpdateRun(instance, {
         ageMs: ABANDONED_UPDATE_RUN_MS + 60_000,
         // A live PID with a different start identity positively proves PID reuse.
@@ -213,7 +216,10 @@ describe("Gateway external shared-state ownership", () => {
     const instance = await createPublicationInstance("gateway-inactive-update-repair");
     let observer: DatabaseSync | undefined;
     try {
-      const driver = requireUpdateRunDriver();
+      const driver = readUpdateRunDriver();
+      if (!driver) {
+        throw new Error("Test process identity is unavailable");
+      }
       const inactive = seedInactiveUpdateRun(instance, {
         ageMs: ABANDONED_UPDATE_RUN_MS + 60_000,
         phase: "staging",

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -1086,6 +1086,7 @@ await import('./scripts/check-docker-e2e-boundaries.mts');`,
   it.each([
     { baseline: "2026.7.1", scenario: "mobile-pairing-reconnect" },
     { baseline: "2026.8.1", scenario: "watchos-direct-node" },
+    { baseline: "2026.9.2", scenario: "abandoned-update" },
     { baseline: "2026.7.1-2", scenario: "prerelease-plugin-registry" },
     { baseline: "2026.7.1-2", scenario: "auth-profile-v2026-7-2-beta-5" },
     { baseline: "2026.7.1-2", scenario: "recovery-cleanup" },
@@ -1100,6 +1101,9 @@ await import('./scripts/check-docker-e2e-boundaries.mts');`,
     expect(explicitPlan.lanes.map(summarizeLane)).toEqual([
       publishedUpgradeSurvivorLane(laneName, `openclaw@${baseline}`, scenario),
     ]);
+    if (scenario === "abandoned-update") {
+      expect(explicitPlan.requiredPrepublishPluginPackages).toEqual([]);
+    }
     if (scenario === "recovery-cleanup") {
       expect(explicitPlan.requiredPrepublishPluginPackages).toEqual([
         "@openclaw/codex",


### PR DESCRIPTION
Related: #141273, #139284.

## What Problem This Solves

Fixes an issue where a stranded update-history row leaves update status and the Control UI permanently in progress, suspends configuration writes, and makes `openclaw update repair` enter unnecessary maintenance and refuse a healthy managed Gateway.

## Why This Change Was Made

The ledger now owns conservative reconciliation. A run must exceed the shared 30-minute inactivity bound and every recorded driver must be verifiably dead on this host before the Gateway can finalize it automatically. Drivers record PID, host, and process-start identity in existing JSON metadata, retain earlier non-dead handoff identities, and heartbeat long commands/finalization every 30 seconds. No schema, tables, configuration options, environment names, or recovery command were added.

Legacy identityless rows are never auto-finalized. On a healthy Gateway matching the installed version/build, explicit `update repair` clears stale history as `failed/abandoned` without Doctor, maintenance, or service activation. Explicit recovery revalidates its selected rows together before committing any outcomes. A fresh operator-started `openclaw update`, including a dry run, atomically supersedes a single stale identityless active row as `failed/superseded` before admitting its new run. Recent rows and recorded live or unobservable identities remain protected. Status and Doctor/preflight report the last activity time and both recovery commands.

The old public repair route always entered finalization. Its Doctor child receives `allowGatewayActivation: false`; Doctor correctly refuses maintenance while the parent-owned managed service is online. The new inspection route avoids that unnecessary child. Recorded activation, restart, or verification history still requires full finalization and the service-owner stop rule, even if automatic reconciliation has already finalized the run. This does not duplicate the CLI initialization or legacy-continuation fixes associated with #139288 and #139608.

Design decision: automatic recovery requires aged inactivity plus recorded local driver death; identityless history requires explicit repair or fresh CLI admission, including dry-run supersession. If native process identity is unavailable, adoption continues with one warning and a retained marker that prevents automatic recovery. Known parent identities remain protected. Identifiable adoption still refuses to discard a live or uninspectable driver at capacity.

Review refinements:

- Missing self identity permits adoption and warns once. A retained `driver:identity-unavailable` step prevents later parent death from being mistaken for death of the unrecorded adopter.
- Heartbeat database errors warn once per driver run and leave build/install commands and finalization running; step and outcome writes keep their existing failure behavior.
- Repair inspects newer failed/abandoned post-core history, even when an older identityless row remains active, and repeats the inspection after health probes. Unacknowledged activation, restart, verification, or `finalize:*` work uses full finalization and its service-owner stop rule. An incomplete bounded history scan also uses full finalization.

## User Impact

Operators can recover stale update history without interrupting a healthy Gateway. Automatic recovery is limited to positive process-death evidence, preserving live slow builds and legacy identityless updates. Reconciled history is retained with an explicit reason and a rule-naming step; configuration-write suspension clears through the existing lifecycle.

Release-note context: 2026.9.2 can reach the fixed package through its normal updater. Its [admission](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command-run.ts#L77) directly creates a run, and its [ledger](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/infra/update-run-ledger.ts#L250) only deduplicates the exact run ID. It does not reject another running row. Upgrade normally, then run the updated `openclaw update repair` if the legacy row remains. A package-manager escape is not required for this ledger defect.

A requested-only row is not proof of a dead updater: [shipped admission](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command.ts#L90) precedes package-manager and registry waits, with the [first staging write](https://github.com/openclaw/openclaw/blob/v2026.9.2/src/cli/update-cli/update-command.ts#L465) occurring later. The existing schema-publication timeout from #141109 remains a compatibility timing rule, distinct from ledger terminalization.

## Evidence

Head: `d985f81a45a09dd7743f12b8ac149dd8be9ca26f`.

- `pnpm check:changed`: passed on the refined source. `git diff --check`: clean. Independent primary, CI-follow-up, and refinement reviews are clean through P2.
- Focused suites: 589 passed (80 ledger/identity, 41 CLI process/lifecycle, 468 CLI/repair/status). This includes dead+aged automatic recovery, live/unknown protection, recent-row protection, explicit legacy requested/staging recovery, admission supersession, terminal-row preservation, and both slow-step heartbeat outcomes.
- Seven real-Gateway process cases passed on this exact head in 114.43 seconds: dead-driver boot recovery; live/recent/identityless preservation; explicit requested-only repair; dry-run supersession; clean status and unchanged serving processes; schema-publication and ownership siblings.
- Both managed validation/no-op cases passed again on this head. The already-current fixture asserts terminal `skipped/already-current` history, no service commands, and no signal to the serving parent. This preserves the main no-restart behavior tracked by #136997.
- Canonical build, package inventory, and tarball integrity passed. Retention, post-core routing, and multi-row recovery races have failing-before/passing-after owner-boundary regressions. The new identity, heartbeat-error, and newer-abandoned-history regressions failed against the reviewed head and now pass. Counts from earlier overlapping runs are not added to the 589 above.

The published-upgrade survivor used official `openclaw@2026.9.2` and a pre-seeded one-hour-old identityless row: status `running`, phase `requested`, equal creation/update timestamps, `before.version = 2026.9.2`, and one `requested/in_progress` step. The baseline's actual updater installed the candidate successfully. Candidate boot preserved the legacy row, as required; candidate repair then cleared it:

```json
{"status":"failed","reason":"abandoned","repairExit":0,"activeRun":null,"gatewayPid":2160,"serviceUnchanged":true}
```

```text
Gateway is healthy. Reconciled 1 abandoned update run. No maintenance or service restart was needed.
```

Gateway PID/start identity `2160/3236121` and supervisor `2146/3236119` remained unchanged. Repair performed no service operation, Doctor, or maintenance; authenticated and HTTP probes passed afterward.

Candidate tarball SHA-256: `e9ac9cd05e11bd4b26fc91264b3ac1ff229d20e9b3c7977a68ecfb4a10649262`. Build ID: `2026.9.2-d985f81a45a0-2026-09-07T22-35-24.851Z`. The development package version remains 2026.9.2; the fixture verifies the distinct installed build identity.

Red comparison on pinned origin/main `0b13b5a1aca6c19f56584ce36569136500b6edda`: official 2026.9.2 upgraded successfully to that candidate, but candidate repair exited 1, the seeded row remained `running/requested`, and status still exposed it. The same fixture captured the exact refusal before failing its success assertion:

```text
Doctor could not enter maintenance. Error: The update parent owns Gateway activation. Stop the service through its owner before retrying the update; Doctor will not stop or restart it.
```

Docker uses the repository's systemctl supervisor fixture with real Gateway processes and synthetic provider-disabled configuration; it is not native systemd. The real process cases also ran locally on macOS. Test containers were cleaned up.

Reproduce with the canonical packed candidate:

```sh
OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE=1 \
OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=openclaw@2026.9.2 \
OPENCLAW_UPGRADE_SURVIVOR_CANDIDATE=/absolute/path/to/candidate.tgz \
OPENCLAW_UPGRADE_SURVIVOR_SCENARIO=abandoned-update \
OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE=auto-auth \
bash scripts/e2e/upgrade-survivor-docker.sh
```

## CI

Bounded exact-head CI is attached to [run 34167640864](https://github.com/openclaw/openclaw/actions/runs/34167640864) with:

```sh
node scripts/watch-pr-ci.mjs 141562 d985f81a45a09dd7743f12b8ac149dd8be9ca26f --repo openclaw/openclaw --attach-timeout 180 --timeout 900 --interval 30
```

The prior head's CI passed after scoped catalog/entrypoint, preflight-ordering, and test-isolation corrections. The 900-second watch ended with `TIMEOUT state=PENDING pending=1` (exit 16). Only `checks-windows-node-test-2` remained in progress; no failing check was reported. A fresh run-state read at 22:58 UTC confirmed that run 34167640864 was still `in_progress` on this exact head. CI is not yet fully green. No merge, issue closure, release publication, or lock recovery has been performed.
