### PR TITLE
fix(release): verify current package scan and installer outcomes

### DIFF
--- a/scripts/docker/install-sh-smoke/run.sh
+++ b/scripts/docker/install-sh-smoke/run.sh
@@ -407,7 +407,7 @@ run_update_smoke() {
 
   assert_update_smoke_offline
   # The idle container owns no Gateway service; exercise the baseline updater
-  # before checking the candidate's default restart policy independently.
+  # before checking the candidate's already-current idle behavior independently.
   run_update_candidate "$UPDATE_BASELINE_VERSION" applied --no-restart
   echo "==> Verify candidate already-current no-op without a Gateway service"
   run_update_candidate "$UPDATE_EXPECT_VERSION" already-current

--- a/scripts/docker/install-sh-smoke/run.sh
+++ b/scripts/docker/install-sh-smoke/run.sh
@@ -408,9 +408,10 @@ run_update_smoke() {
   assert_update_smoke_offline
   # The idle container owns no Gateway service; exercise the baseline updater
   # before checking the candidate's default restart policy independently.
-  run_update_candidate "$UPDATE_BASELINE_VERSION" --no-restart
-  echo "==> Verify candidate default update without a Gateway service"
-  run_update_candidate "$UPDATE_EXPECT_VERSION"
+  run_update_candidate "$UPDATE_BASELINE_VERSION" applied --no-restart
+  echo "==> Verify candidate already-current no-op without a Gateway service"
+  run_update_candidate "$UPDATE_EXPECT_VERSION" already-current
+  assert_update_smoke_offline
   verify_candidate_ai_runtime
   echo "OK"
 }
@@ -418,7 +419,8 @@ run_update_smoke() {
 
 run_update_candidate() {
   local UPDATE_BASELINE_VERSION="$1"
-  shift
+  local expected_outcome="$2"
+  shift 2
   echo "==> Run openclaw update from host-served tgz (from $UPDATE_BASELINE_VERSION)"
   local update_status
   local update_stderr_file
@@ -465,6 +467,7 @@ run_update_candidate() {
   UPDATE_JSON="$UPDATE_JSON" \
     UPDATE_EXPECT_VERSION="$UPDATE_EXPECT_VERSION" \
     UPDATE_BASELINE_VERSION="$UPDATE_BASELINE_VERSION" \
+    UPDATE_EXPECT_OUTCOME="$expected_outcome" \
     UPDATE_TAG_URL="$UPDATE_TAG_URL" \
     node - <<'NODE'
 function parseFirstJsonObject(raw) {
@@ -505,8 +508,14 @@ const payload = parseFirstJsonObject(process.env.UPDATE_JSON || "{}");
 const expectedVersion = String(process.env.UPDATE_EXPECT_VERSION || "");
 const baselineVersion = String(process.env.UPDATE_BASELINE_VERSION || "");
 const expectedUrl = String(process.env.UPDATE_TAG_URL || "");
-if (payload.status !== "ok") {
-  throw new Error(`expected update status ok, got ${JSON.stringify(payload.status)}`);
+const expectedOutcome = process.env.UPDATE_EXPECT_OUTCOME || "applied";
+if (!["applied", "already-current"].includes(expectedOutcome)) {
+  throw new Error(`unknown expected update outcome ${expectedOutcome}`);
+}
+const noOp = expectedOutcome === "already-current";
+const expectedStatus = noOp ? "skipped" : "ok";
+if (payload.status !== expectedStatus) {
+  throw new Error(`expected update status ${expectedStatus}, got ${JSON.stringify(payload.status)}`);
 }
 if ((payload.before?.version ?? null) !== baselineVersion) {
   throw new Error(
@@ -518,8 +527,8 @@ if ((payload.after?.version ?? null) !== expectedVersion) {
     `expected after.version ${expectedVersion}, got ${JSON.stringify(payload.after?.version)}`,
   );
 }
-if (payload.reason != null) {
-  throw new Error(`expected no failure reason, got ${JSON.stringify(payload.reason)}`);
+if (noOp ? payload.reason !== "already-current" : payload.reason != null) {
+  throw new Error(`unexpected update reason ${JSON.stringify(payload.reason)}`);
 }
 const steps = Array.isArray(payload.steps) ? payload.steps : [];
 const updateStep = steps.find((step) => step?.name === "global update");
@@ -531,6 +540,17 @@ if (Number(updateStep.exitCode ?? 1) !== 0) {
 }
 if (typeof updateStep.command !== "string" || !updateStep.command.includes(expectedUrl)) {
   throw new Error(`global update step missing expected tgz URL: ${JSON.stringify(updateStep)}`);
+}
+if (noOp) {
+  if (baselineVersion !== expectedVersion || typeof payload.before?.buildId !== "string" ||
+      !payload.before.buildId || payload.after?.buildId !== payload.before.buildId) {
+    throw new Error("already-current update changed or omitted installed build identity");
+  }
+  if (steps.length !== 1) {
+    throw new Error("already-current update performed unexpected activation or maintenance steps");
+  }
+  console.log("Verified already-current no-op: package staged, installed build unchanged, no activation");
+  process.exit(0);
 }
 const doctorStep = steps.find((step) => step?.name === "openclaw doctor");
 // Every baseline that passes verify_installed_cli implements this contract;

--- a/scripts/lib/plugin-npm-security-scan.mts
+++ b/scripts/lib/plugin-npm-security-scan.mts
@@ -110,10 +110,18 @@ const RELEASE_2026_9_1_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS = new Map<string,
   ["@openclaw/voice-call:dangerous-exec:src/tunnel.ts", 1],
 ]);
 
-const CURRENT_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS = new Map<string, number>([
+const RELEASE_2026_9_2_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS = new Map<string, number>([
   ...RELEASE_2026_9_1_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS,
   ["@openclaw/llama-cpp-provider:dangerous-exec:src/hardware.ts", 1],
 ]);
+
+// The bounded async Codex version probe no longer produces this syntactic finding.
+// Keep shipped inventories intact; a new direct call must be reviewed again.
+const CURRENT_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS = new Map(
+  [...RELEASE_2026_9_2_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS].filter(
+    ([key]) => key !== "@openclaw/codex:dangerous-exec:src/doctor.ts",
+  ),
+);
 
 type ReviewedReleaseLayout = {
   id: string;
@@ -212,7 +220,13 @@ const FROZEN_RELEASE_SECURITY_INVENTORY_POLICIES = new Map<string, PluginSecurit
       requiredSourceFindingCounts: RELEASE_2026_9_1_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS,
     },
   ],
-  ["release/2026.9.2", CURRENT_SECURITY_INVENTORY_POLICY],
+  [
+    "release/2026.9.2",
+    {
+      ...CURRENT_SECURITY_INVENTORY_POLICY,
+      requiredSourceFindingCounts: RELEASE_2026_9_2_REQUIRED_REVIEWED_SOURCE_FINDING_COUNTS,
+    },
+  ],
   ["release/2026.9.3", CURRENT_SECURITY_INVENTORY_POLICY],
   [
     "extended-stable/2026.6.33",

--- a/test/scripts/plugin-npm-security-scan.test.ts
+++ b/test/scripts/plugin-npm-security-scan.test.ts
@@ -261,6 +261,51 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
     ).toMatchObject({ layout: null, status: "fail" });
   });
 
+  it.each([0, 1, 2])(
+    "preserves frozen doctor counts while shrinking current policy: %s",
+    async (count) => {
+      const packageName = "@openclaw/codex";
+      const probe = 'import { spawn } from "node:child_process";\nspawn(process.execPath, []);\n';
+      const artifact = writePluginArtifact({
+        extensionId: "codex",
+        packageName,
+        files: {
+          "src/app-server/transport-stdio.ts": probe,
+          "src/app-server/sandbox-exec-server/sandbox-child.ts": probe,
+          "src/app-server/transport-process-snapshot.ts": probe,
+          "src/doctor.ts":
+            'import { spawn } from "node:child_process";\n' +
+            "spawn(process.execPath, []);\n".repeat(count),
+          "src/unreviewed.ts": probe,
+        },
+      });
+      for (const context of ["", "release/2026.9.1", "release/2026.9.2", "release/2026.9.3"]) {
+        const frozen = context === "release/2026.9.1" || context === "release/2026.9.2";
+        const scanned = await scanPublishablePluginPackages([artifact.artifact], context);
+        expect(scanned.scanErrors).toEqual([]);
+        const result = scanned.packageResults[0]!;
+        expect(result.unexpectedCriticalFindings.map((finding) => finding.path).toSorted()).toEqual(
+          [
+            ...Array.from({ length: frozen ? 0 : count }, () => "src/doctor.ts"),
+            "src/unreviewed.ts",
+          ],
+        );
+        const report = buildPluginNpmSecurityScanReport({
+          candidateSha: CANDIDATE_SHA,
+          packageResults: scanned.packageResults,
+          targetContextRef: context,
+          toolingSha: TOOLING_SHA,
+        });
+        expect(report.status).toBe("fail"); // The unknown finding is never admitted.
+        expect(
+          report.errors.filter((error) =>
+            error.startsWith(`${packageName}: reviewed critical inventory mismatch`),
+          ),
+        ).toHaveLength(frozen && count !== 1 ? 1 : 0);
+      }
+    },
+  );
+
   it.each([null, 0, 2, 3, 4])(
     "requires exactly three reviewed one-shot fixture spawns when packed: %s",
     async (count) => {
@@ -274,7 +319,6 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
         packageName,
         files: {
           "src/app-server/transport-stdio.ts": spawnProbe,
-          "src/doctor.ts": spawnProbe,
           "src/app-server/sandbox-exec-server/sandbox-child.ts": spawnProbe,
           "src/app-server/transport-process-snapshot.ts": spawnProbe,
           ...(count === null

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -1780,10 +1780,12 @@ if (args[0] === "--version") {
   if (before === "2026.9.1" && (args.includes("--no-restart") || process.env.FAKE_SCENARIO === "candidate refusal")) process.exit(21);
   fs.writeFileSync(process.env.FAKE_VERSION_FILE, "2026.9.1");
   console.log(JSON.stringify({
-    status: "ok", before: { version: before }, after: { version: "2026.9.1" },
+    status: before === "2026.9.1" ? "skipped" : "ok",
+    ...(before === "2026.9.1" ? { reason: "already-current" } : {}),
+    before: { version: before, buildId: "candidate-build" }, after: { version: "2026.9.1", buildId: "candidate-build" },
     steps: [
       { name: "global update", exitCode: 0, command: "npm install " + args[args.indexOf("--tag") + 1] },
-      { name: "openclaw doctor", exitCode: 0 },
+      ...(before === "2026.9.1" ? [] : [{ name: "openclaw doctor", exitCode: 0 }]),
     ],
   }));
 }
@@ -1959,10 +1961,10 @@ run_update_smoke
       );
       expect(result.status, result.stderr).toBe(failure);
       expect(result.stdout).toContain("idle\n");
-      expect(result.stdout).toContain(`self-update:${baseline}:${baseline} --no-restart\n`);
+      expect(result.stdout).toContain(`self-update:${baseline}:${baseline} applied --no-restart\n`);
       expect(result.stdout).not.toContain("external\n");
       if (failure === 0) {
-        expect(result.stdout).toContain(`self-update:${candidate}:${candidate}\n`);
+        expect(result.stdout).toContain(`self-update:${candidate}:${candidate} already-current\n`);
         expect(result.stdout).toContain("verified\n");
       } else {
         expect(result.stdout).not.toContain(`self-update:${candidate}:`);
@@ -1994,6 +1996,52 @@ run_update_smoke
     expect(script).toContain("unterminated update JSON object");
     expect(script).toContain("verify_candidate_ai_runtime");
     expect(script).toContain("openclaw infer image providers --json");
+  });
+
+  it.each([
+    ["verified same-build no-op", {}, "already-current", 0],
+    ["unrelated skip", { reason: "dirty" }, "already-current", 1],
+    ["changed build", { after: { version: "2026.9.3", buildId: "other" } }, "already-current", 1],
+    ["missing build identity", { before: { version: "2026.9.3" } }, "already-current", 1],
+    [
+      "unexpected activation",
+      {
+        steps: [
+          {
+            name: "global update",
+            exitCode: 0,
+            command: "npm install http://candidate.invalid/openclaw.tgz",
+          },
+          { name: "global install swap", exitCode: 0 },
+        ],
+      },
+      "already-current",
+      1,
+    ],
+    ["skipped first upgrade", {}, "applied", 1],
+  ])("validates explicit installer outcome: %s", (_label, overrides, outcome, expectedExit) => {
+    const url = "http://candidate.invalid/openclaw.tgz";
+    const payload = {
+      status: "skipped",
+      reason: "already-current",
+      before: { version: "2026.9.3", buildId: "candidate-build" },
+      after: { version: "2026.9.3", buildId: "candidate-build" },
+      steps: [{ name: "global update", exitCode: 0, command: `npm install ${url}` }],
+      ...overrides,
+    };
+    const result = spawnSync(process.execPath, ["-"], {
+      encoding: "utf8",
+      input: extractInstallSmokeUpdateJsonParser(),
+      env: {
+        ...process.env,
+        UPDATE_JSON: JSON.stringify(payload),
+        UPDATE_EXPECT_VERSION: "2026.9.3",
+        UPDATE_BASELINE_VERSION: "2026.9.3",
+        UPDATE_TAG_URL: url,
+        UPDATE_EXPECT_OUTCOME: outcome,
+      },
+    });
+    expect(result.status, result.stderr).toBe(expectedExit);
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Resolves two false failures in Full Release Verification: the plugin scan still required a finding removed by the bounded async Codex version probe, and installer smoke treated a successful already-current result as a failed second upgrade.

## Why This Change Was Made

Freeze the shipped 2026.9.2 security inventory before removing exactly one current required finding; 2026.9.1 and 2026.9.2 retain their existing counts. Scanner rules and rejection of new findings remain unchanged.

Give each installer invocation an explicit outcome contract. The first historical upgrade still requires a successful applied update and Doctor result. The second identical candidate invocation requires `skipped/already-current`, an unchanged nonempty build identity, successful staging of the selected archive, and no activation or maintenance. The idle process/service checks and installed CLI/AI runtime proof remain intact.

## User Impact

Release verification follows the supported runtime outcomes without relaxing package security or mistaking a skipped update for an applied upgrade. No product runtime behavior changes.

## Evidence

- 143 focused scanner and installer tests pass together on the current-main integration.
- Scoped changed checks pass, including script/root-test typechecking, lint, formatting, and Docker boundary guards.
- Independent combined P2 review passed.
- Scanner regressions reproduce the original mismatch and preserve zero/exact/duplicate frozen counts plus unknown-finding rejection. The exact candidate source inertly scans with one fewer finding; the failed CI multiset has no additions.
- Installer regressions reproduce the original rejection and accept the retained actual already-current result only under the explicit no-op contract. Wrong reasons, changed or missing build identities, extra activation, and a skipped first upgrade remain failures.

The full sealed-candidate Docker replay remains owned by the next Full Release Verification run; these focused checks do not claim that complete release run is green.
