### PR TITLE
fix(ci): hydrate frozen release ancestry through branch ref

### DIFF
--- a/.github/actions/git-owner/release-ancestry.py
+++ b/.github/actions/git-owner/release-ancestry.py
@@ -8,6 +8,7 @@ from ci_git_owner import FetchTimeout, GitFailure, backoff, cleanup_seconds, git
 
 
 source_local_ref = "refs/remotes/origin/release-ancestry-source"
+target_hydration_local_ref = "refs/remotes/origin/release-ancestry-target-hydration"
 deepen_chunks = (128, 256, 512, 1024, 2048)
 max_total_seconds = 120
 max_fetch_seconds = 30
@@ -181,7 +182,9 @@ def establish_ancestry():
     target_local_ref = f"refs/remotes/origin/{target_ref[len('refs/heads/') :]}"
     source_sha = resolve_commit("HEAD")
     fetch_history(source_sha, f"+{target_ref}:{target_local_ref}", "--depth=64")
-    # Freeze the branch after the first fetch; every deepen hydrates this exact target.
+    # Freeze the branch after the first fetch. Later requests hydrate the live
+    # branch into a separate ref: Git may not deepen a detached SHA want, while
+    # every ancestry decision below remains bound to this immutable target.
     target_sha = resolve_commit(target_local_ref)
     result, previous_boundaries = relation_result(mode, source_sha, target_sha)
     if result is not None:
@@ -191,7 +194,11 @@ def establish_ancestry():
     chunk_index = 0
     while True:
         chunk = deepen_chunks[min(chunk_index, len(deepen_chunks) - 1)]
-        fetch_history(source_sha, f"+{target_sha}:{target_local_ref}", f"--deepen={chunk}")
+        fetch_history(
+            source_sha,
+            f"+{target_ref}:{target_hydration_local_ref}",
+            f"--deepen={chunk}",
+        )
         result, current_boundaries = relation_result(mode, source_sha, target_sha)
         if result is not None:
             return result

--- a/.github/actions/git-owner/release-ancestry.py
+++ b/.github/actions/git-owner/release-ancestry.py
@@ -68,6 +68,7 @@ def fetch_history(source_sha, target, depth_argument):
                 "--no-tags",
                 "--no-recurse-submodules",
                 "--filter=blob:none",
+                "--refmap=",
                 depth_argument,
                 "origin",
                 f"+{source_sha}:{source_local_ref}",

--- a/test/scripts/ci-git-owner.test.ts
+++ b/test/scripts/ci-git-owner.test.ts
@@ -352,6 +352,38 @@ exit "$status"`,
   }
 });
 
+releasePolicyIt(
+  "hydrates a frozen target through its branch when detached wants cannot deepen",
+  () => {
+    const fixture = createAncestryFixture({
+      sourceDistance: 8,
+      targetDistance: 220,
+      related: true,
+    });
+    const proxy = writeGitProxy(
+      fixture,
+      "detached-target-no-deepen-git",
+      `if [[ " $* " == *" fetch "* && " $* " == *" --deepen=128 "* && " $* " == *" +${fixture.target}:refs/remotes/origin/main "* ]]; then
+  exit 0
+fi
+exec "$REAL_GIT" "$@"`,
+    );
+    try {
+      const checkout = cloneAncestrySource(fixture, "checkout");
+      expectPolicySuccess(
+        runReleaseAncestry(checkout, "merge-base", {
+          PATH: `${proxy.binDir}:${process.env.PATH ?? ""}`,
+          REAL_GIT: proxy.realGit,
+        }),
+        "merge-base",
+      );
+      expect(fixtureGit(checkout, ["rev-parse", "refs/remotes/origin/main"])).toBe(fixture.target);
+    } finally {
+      rmSync(fixture.root, { force: true, recursive: true });
+    }
+  },
+);
+
 releasePolicyIt("rejects fully hydrated disconnected release histories", () => {
   const fixture = createAncestryFixture({
     sourceDistance: 8,

--- a/test/scripts/ci-git-owner.test.ts
+++ b/test/scripts/ci-git-owner.test.ts
@@ -333,6 +333,12 @@ exit "$status"`,
   );
   try {
     const checkout = cloneAncestrySource(fixture, "checkout");
+    fixtureGit(checkout, [
+      "config",
+      "--add",
+      "remote.origin.fetch",
+      "+refs/heads/*:refs/remotes/origin/*",
+    ]);
     expectPolicySuccess(
       runReleaseAncestry(checkout, "merge-base", {
         MOVE_MARKER: marker,


### PR DESCRIPTION
## Summary

Fixes npm preflight source qualification for an immutable release target when Git accepts the initial detached-SHA fetch but makes no progress while deepening that detached want. The policy freezes the first `main` SHA for the verdict, then hydrates the live branch into a separate tracking ref; the frozen SHA remains the only decision input.

## Proof

- Red: the real-Git topology regression exits 125 under a remote that accepts the first fetch but does not deepen the detached target want.
- Green: `node scripts/run-vitest.mjs test/scripts/ci-git-owner.test.ts` (including frozen target, disconnected-history, and no-progress siblings).
- Exact release symptom: [npm preflight source check](https://github.com/openclaw/openclaw/actions/runs/34159144215/job/101857126943) exits 125, `Release ancestry fetch completed without ancestry progress.`

## Scope

Production/tooling: +10/-2. Tests: +29/-0. The separate hydration ref is required to preserve the frozen verdict while allowing Git to deepen an advertised branch ref; no release candidate, tag, or npm state is modified.