### PR TITLE
fix(daemon): preserve service inspection identity and deadlines

### DIFF
--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -91,6 +91,8 @@ and `openclaw memory status --deep`.
 
 - Overview includes Gateway + node host service install/runtime status when
   available, plus compact Gateway process uptime and host system uptime.
+- On Linux, a readable installed node service remains listed when the service
+  manager is unavailable; its runtime status stays unknown.
 - Overview includes update channel + git SHA (for source checkouts).
 - Update info surfaces in the Overview; if an update is available, status
   prints a hint to run `openclaw update` (see [Updating](/install/updating)).

--- a/src/cli/update-cli/update-command-service-maintenance.test.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.test.ts
@@ -72,6 +72,7 @@ type NativeOfflineCase = {
   loaded: boolean;
   offline: boolean;
   enabled?: boolean;
+  phase?: "inspect" | "prepare";
   state?: number | string;
 };
 
@@ -110,6 +111,15 @@ const nativeOfflineCases: NativeOfflineCase[] = [
   },
   {
     platform: "darwin",
+    label: "loaded disabled preparation",
+    runtime: "stopped",
+    loaded: true,
+    enabled: false,
+    offline: true,
+    phase: "prepare",
+  },
+  {
+    platform: "darwin",
     label: "enabled unknown",
     runtime: "stopped",
     loaded: true,
@@ -139,6 +149,12 @@ it.each(nativeOfflineCases)(
     withServiceHome(async (home) => {
       mockProcessPlatform(scenario.platform);
       mocks.taskState = scenario.state ?? 3;
+      const isEnabled = vi.fn<NonNullable<GatewayService["isEnabled"]>>(async () => {
+        if (scenario.enabled === undefined) {
+          throw new Error("enabled state unavailable");
+        }
+        return scenario.enabled;
+      });
       const service = createMockGatewayService({
         readCommand: async () => ({
           programArguments: [process.execPath, path.join(process.cwd(), "openclaw.mjs"), "gateway"],
@@ -149,25 +165,24 @@ it.each(nativeOfflineCases)(
             ? readScheduledTaskRuntime
             : async () => ({ status: scenario.runtime }),
         isLoaded: async () => scenario.loaded,
-        isEnabled: async () => {
-          if (scenario.enabled === undefined) {
-            throw new Error("enabled state unavailable");
-          }
-          return scenario.enabled;
-        },
+        isEnabled,
       });
       mocks.service.mockReturnValue(service);
       const inspected = await maybeStopManagedServiceBeforeMutableUpdate({
         root: process.cwd(),
         updateInstallKind: "package",
         shouldRestart: true,
-        phase: "inspect",
+        phase: scenario.phase ?? "inspect",
         jsonMode: true,
+        timeoutMs: 200,
       });
       expect(inspected.serviceUpdateVerdict?.kind).toBe(
         scenario.runtime === "unknown" ? "unavailable" : "owned",
       );
       expect(inspected.offline).toBe(scenario.offline);
+      for (const [args] of isEnabled.mock.calls) {
+        expect(args.timeoutMs).toBe(200);
+      }
       expect(service.stop).not.toHaveBeenCalled();
       expect(service.start).not.toHaveBeenCalled();
       expect(service.restart).not.toHaveBeenCalled();

--- a/src/cli/update-cli/update-command-service-maintenance.ts
+++ b/src/cli/update-cli/update-command-service-maintenance.ts
@@ -458,7 +458,7 @@ export async function maybeStopManagedServiceBeforeMutableUpdate(params: {
     params.shouldRestart &&
     serviceState.loadState.status === "loaded" &&
     (process.platform === "darwin"
-      ? (await service.isEnabled?.({ env: serviceState.env })) === true
+      ? (await service.isEnabled?.({ env: serviceState.env, timeoutMs: params.timeoutMs })) === true
       : process.env.OPENCLAW_UPDATE_RUN_HANDOFF === "1");
   if (!params.shouldRestart || (!serviceState.running && !supervisorMayRespawn)) {
     if (!params.shouldRestart && !params.jsonMode && serviceState.running) {

--- a/src/daemon/launchd-runtime.ts
+++ b/src/daemon/launchd-runtime.ts
@@ -219,7 +219,7 @@ export function parseLaunchAgentEnabled(output: string, label: string): boolean 
 export async function isLaunchAgentEnabled(args: GatewayServiceEnvArgs): Promise<boolean> {
   const domain = resolveLaunchAgentGuiDomain();
   const label = resolveLaunchAgentLabel(args.env);
-  const res = await execLaunchctl(["print-disabled", domain]);
+  const res = await execLaunchctl(["print-disabled", domain], args.timeoutMs);
   if (res.code !== 0) {
     throw new Error(`launchctl print-disabled failed: ${formatLaunchctlResultDetail(res)}`);
   }

--- a/src/daemon/launchd.test.ts
+++ b/src/daemon/launchd.test.ts
@@ -987,20 +987,28 @@ describe("launchd runtime parsing", () => {
 });
 
 describe("launchd runtime state", () => {
-  it.runIf(process.platform === "darwin")(
-    "fails soft within the supplied deadline when launchctl blocks",
-    async () => {
+  it.runIf(process.platform === "darwin").each(["runtime", "enabled"] as const)(
+    "bounds the %s read by the supplied deadline when launchctl blocks",
+    async (read) => {
       const realFs = await vi.importActual<typeof import("node:fs/promises")>("node:fs/promises");
       const tempDir = await realFs.mkdtemp(`${process.env.TMPDIR ?? "/tmp"}/openclaw-launchd-`);
-      await realFs.writeFile(`${tempDir}/launchctl`, "#!/bin/sh\nsleep 2\n", { mode: 0o755 });
+      await realFs.writeFile(`${tempDir}/launchctl`, "#!/bin/sh\nexec /bin/sleep 2\n", {
+        mode: 0o755,
+      });
       state.realExecFile = true;
 
       try {
         await withEnvAsync({ PATH: `${tempDir}:${process.env.PATH ?? ""}` }, async () => {
           const startedAt = Date.now();
-          const runtime = await readLaunchAgentRuntime({ HOME: tempDir }, { timeoutMs: 100 });
+          if (read === "enabled") {
+            await expect(
+              isLaunchAgentEnabled({ env: { HOME: tempDir }, timeoutMs: 100 }),
+            ).rejects.toThrow("launchctl print-disabled failed");
+          } else {
+            const runtime = await readLaunchAgentRuntime({ HOME: tempDir }, { timeoutMs: 100 });
+            expect(runtime.status).toBe("unknown");
+          }
           expect(Date.now() - startedAt).toBeLessThan(1_000);
-          expect(runtime.status).toBe("unknown");
         });
       } finally {
         state.realExecFile = false;

--- a/src/daemon/node-service.ts
+++ b/src/daemon/node-service.ts
@@ -26,7 +26,7 @@ function withNodeInstallEnv(args: GatewayServiceInstallArgs): GatewayServiceInst
 /** Returns a service controller bound to node-host labels across all platforms. */
 export function resolveNodeService(): GatewayService {
   const base = resolveGatewayService();
-  const hasInstalledDefinition = base.hasInstalledDefinition;
+  const { hasInstalledDefinition, isAbsent } = base;
   return {
     ...base,
     stage: (args) => base.stage(withNodeInstallEnv(args)),
@@ -42,6 +42,9 @@ export function resolveNodeService(): GatewayService {
     },
     hasInstalledDefinition: hasInstalledDefinition
       ? (args) => hasInstalledDefinition({ ...args, env: withNodeServiceEnv(args.env ?? {}) })
+      : undefined,
+    isAbsent: isAbsent
+      ? (args) => isAbsent({ ...args, env: withNodeServiceEnv(args.env ?? {}) })
       : undefined,
     readCommand: (env, opts) => base.readCommand(withNodeServiceEnv(env), opts),
     readRuntime: (env, opts) => base.readRuntime(withNodeServiceEnv(env), opts),

--- a/src/daemon/service.test.ts
+++ b/src/daemon/service.test.ts
@@ -7,6 +7,7 @@ import { clearConfigCache, clearRuntimeConfigSnapshot } from "../config/config.j
 import { makeTempWorkspace } from "../test-helpers/workspace.js";
 import { captureEnv } from "../test-utils/env.js";
 import { mockProcessPlatform } from "../test-utils/vitest-spies.js";
+import { resolveNodeService } from "./node-service.js";
 import type { GatewayService } from "./service.js";
 import {
   describeGatewayServiceRestart,
@@ -54,6 +55,8 @@ const managerlessPreflightCases = [
     })),
   ),
   { updateInstallKind: "package" as const, shouldRestart: true, condition: "installed" },
+  { updateInstallKind: "package" as const, shouldRestart: true, condition: "node absent" },
+  { updateInstallKind: "package" as const, shouldRestart: true, condition: "node installed" },
   { updateInstallKind: "package" as const, shouldRestart: true, condition: "global definition" },
   { updateInstallKind: "package" as const, shouldRestart: true, condition: "unreadable" },
   { updateInstallKind: "package" as const, shouldRestart: true, condition: "manager" },
@@ -187,7 +190,7 @@ describe("resolveGatewayService", () => {
 
 describe("readGatewayServiceState", () => {
   it.each(managerlessPreflightCases)(
-    "handles managerless Linux preflight for $updateInstallKind restart=$shouldRestart ($condition)",
+    "handles managerless Linux inspection for $updateInstallKind restart=$shouldRestart ($condition)",
     async ({ updateInstallKind, shouldRestart, condition, portUsage, portSource }) => {
       const { maybeStopManagedServiceBeforeMutableUpdate } =
         await import("../cli/update-cli/update-command-service.js");
@@ -235,14 +238,42 @@ describe("readGatewayServiceState", () => {
         if (portUsage) {
           probePortUsage.mockResolvedValue(portUsage);
         }
-        const unit = path.join(home, ".config/systemd/user/openclaw-gateway.service");
-        if (condition === "installed") {
+        const node = condition.startsWith("node ");
+        const unit = path.join(
+          home,
+          `.config/systemd/user/openclaw-${node ? "node" : "gateway"}.service`,
+        );
+        if (condition === "installed" || condition === "node installed") {
           await fs.mkdir(path.dirname(unit), { recursive: true });
-          await fs.writeFile(unit, "[Service]\nExecStart=/missing/openclaw gateway\n");
+          await fs.writeFile(
+            unit,
+            `[Service]\nExecStart=/missing/openclaw ${node ? "node run" : "gateway"}\n`,
+          );
+        }
+        if (node) {
+          // Only the fixture HOME contains definitions; no native manager is contacted.
+          vi.spyOn(await import("./exec-file.js"), "execFileUtf8").mockResolvedValue({
+            stdout: "",
+            stderr: "service manager unavailable",
+            code: 1,
+            termination: "error",
+            errorCode: "ENOENT",
+          });
+          const access = fs.access;
+          vi.spyOn(fs, "access").mockImplementation(async (target, mode) => {
+            if (!String(target).startsWith(`${home}${path.sep}`)) {
+              throw Object.assign(new Error("missing"), { code: "ENOENT" });
+            }
+            return access(target, mode);
+          });
+          vi.spyOn(fs, "readdir").mockResolvedValue([]);
         }
         const lstat = fs.lstat;
         vi.spyOn(fs, "lstat").mockImplementation(async (target, options) => {
           const name = String(target);
+          if (node && !name.startsWith(`${home}${path.sep}`)) {
+            throw Object.assign(new Error("missing"), { code: "ENOENT" });
+          }
           if (
             (condition === "manager" && name === "/run/systemd") ||
             (condition === "global definition" &&
@@ -259,6 +290,22 @@ describe("readGatewayServiceState", () => {
           }
           return lstat(target, options);
         });
+        if (node) {
+          const result = await readGatewayServiceState(resolveNodeService(), {
+            env: process.env,
+            timeoutMs: 2_000,
+          });
+          expect(result.installed).toBe(condition === "node installed");
+          if (condition === "node installed") {
+            expect(result.command?.sourcePath).toBe(unit);
+            expect(result.loadState.status).toBe("unknown");
+            expect(result.runtime?.status).toBe("unknown");
+          } else {
+            expect(result.command).toBeNull();
+            expect(result.runtime?.missingUnit).toBe(true);
+          }
+          return;
+        }
         const result = await maybeStopManagedServiceBeforeMutableUpdate({
           root: home,
           updateInstallKind,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Linux status could report an installed node service as absent when the service manager was unavailable. Also fixes LaunchAgent enabled-state inspection exceeding its requested deadline, including the second inspection during update preparation.

## Why This Change Was Made

The node adapter now supplies its existing node-specific service identity to the inherited absence check. The LaunchAgent read and update preparation forward the existing timeout through their missing call sites. The repair keeps inspection context with its current owner and adds three production lines overall.

## User Impact

A readable installed node service stays visible even when its runtime cannot be queried. macOS enabled-state inspection respects the supplied deadline instead of delaying status or update preparation indefinitely.

## Evidence

Three regressions failed on unchanged production: the enabled-state read ignored its 100 ms deadline, node inspection returned installed=false for a node-only fixture, and update preparation dropped its 200 ms timeout. The same regression source passed after repair, along with two existing controls.

All 323 owner/sibling cases across six files passed, as did all 29 selected changed checks and the docs checks. Independent managed P0–P2 review found no actionable defect. Tests use an owned fake launchctl command and isolated service definitions; no live services were stopped or modified.
