### PR TITLE
fix: repair Workshop review targeting and release checks

### DIFF
--- a/extensions/exa/src/exa-web-search-provider.test.ts
+++ b/extensions/exa/src/exa-web-search-provider.test.ts
@@ -49,42 +49,51 @@ describe("exa web search provider", () => {
     }
   });
 
-  it("aborts the guarded Exa request without losing the caller's reason", async () => {
+  it("aborts the guarded Exa request without losing the caller's reason", async ({
+    onTestFinished,
+  }) => {
+    const tool = requireExaTool({ apiKey: "exa-test-key" });
+    const controller = new AbortController();
+    const reason = new Error("Exa request canceled in flight");
     const fetchMock = vi.spyOn(globalThis, "fetch").mockImplementation(
       async (_url, init) =>
         await new Promise<Response>((_resolve, reject) => {
-          if (!init?.signal) {
+          const signal = init?.signal;
+          if (!signal) {
             reject(new Error("Exa request lost caller cancellation"));
             return;
           }
-          init.signal.addEventListener("abort", () => reject(init.signal?.reason as Error), {
-            once: true,
-          });
+          const rejectAbort = () => {
+            const abortReason: unknown = signal.reason;
+            reject(
+              abortReason instanceof Error
+                ? abortReason
+                : new Error("Exa request lost caller cancellation reason"),
+            );
+          };
+          if (signal.aborted) {
+            rejectAbort();
+            return;
+          }
+          signal.addEventListener("abort", rejectAbort, { once: true });
+          // Cancel at transport entry, after cold runtime loading has completed.
+          controller.abort(reason);
+          expect(signal.aborted).toBe(true);
         }),
     );
-    const tool = createExaWebSearchProvider().createTool({
-      config: {
-        plugins: { entries: { exa: { config: { webSearch: { apiKey: "exa-test-key" } } } } },
-      },
-      searchConfig: {},
-    });
-    if (!tool) {
-      throw new Error("Expected tool definition");
-    }
-    const controller = new AbortController();
     const result = tool.execute(
       { query: "exa in-flight cancellation" },
       { signal: controller.signal },
     );
-
-    try {
-      await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledOnce());
-      controller.abort(new Error("Exa request canceled in flight"));
-      await expect(result).rejects.toThrow("Exa request canceled in flight");
-      expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
-    } finally {
+    onTestFinished(async () => {
+      controller.abort(reason);
+      await result.catch(() => {});
       fetchMock.mockRestore();
-    }
+    });
+
+    await expect(result).rejects.toBe(reason);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock.mock.calls[0]?.[1]?.signal?.aborted).toBe(true);
   });
 
   it("exposes the expected metadata and selection wiring", () => {

--- a/scripts/lib/official-external-plugin-catalog.json
+++ b/scripts/lib/official-external-plugin-catalog.json
@@ -711,6 +711,24 @@
       }
     },
     {
+      "name": "@openclaw/team-reports",
+      "description": "OpenClaw team activity reports plugin (GitHub org + Discord activity with model summaries)",
+      "source": "official",
+      "kind": "plugin",
+      "openclaw": {
+        "plugin": {
+          "id": "team-reports",
+          "label": "Team Reports"
+        },
+        "install": {
+          "clawhubSpec": "clawhub:@openclaw/team-reports",
+          "npmSpec": "@openclaw/team-reports",
+          "defaultChoice": "npm",
+          "minHostVersion": ">=2026.9.2"
+        }
+      }
+    },
+    {
       "name": "@openclaw/teams-meetings",
       "description": "OpenClaw Microsoft Teams browser meeting participant plugin.",
       "source": "official",

--- a/src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts
+++ b/src/commands/doctor/shared/legacy-config-migrate.e2e.test.ts
@@ -17,6 +17,10 @@ describe("legacy config migration end to end", () => {
     });
     expect(duplicate.next).toEqual({
       agents: {
+        defaults: {
+          systemAgent: { agentId: "main" },
+          heartbeat: { agentId: "main" },
+        },
         entries: {
           main: { name: "first", workspace: resolveDefaultAgentWorkspaceDir() },
           "main-2": { name: "second" },

--- a/src/plugins/installed-plugin-index-store.install-record-map.test.ts
+++ b/src/plugins/installed-plugin-index-store.install-record-map.test.ts
@@ -91,8 +91,8 @@ describe("installed plugin index install-record persistence", () => {
               { env: { ...process.env, OPENCLAW_STATE_DIR: stateDir } },
             );
           }
-          const { DatabaseSync } = requireNodeSqlite();
-          const prepare = vi.spyOn(DatabaseSync.prototype, "prepare");
+          const { StatementSync } = requireNodeSqlite();
+          const iterate = vi.spyOn(StatementSync.prototype, "iterate");
           const readRecords = () =>
             expect(readPersistedInstalledPluginIndexInstallRecordsSync({ stateDir })).toEqual(
               records,
@@ -113,11 +113,16 @@ describe("installed plugin index install-record persistence", () => {
           }
 
           expect(
-            prepare.mock.calls.filter(([sql]) =>
-              /SELECT\s+"?value_json"?\s+FROM\s+"?config_machine_state"?\s+WHERE\s+"?state_key"?\s*=/i.test(
-                sql,
-              ),
-            ),
+            iterate.mock.calls.filter((params, index) => {
+              const statement = iterate.mock.contexts[index];
+              return (
+                statement instanceof StatementSync &&
+                params.includes("plugins.installedIndex") &&
+                /SELECT\s+"?value_json"?\s+FROM\s+"?config_machine_state"?\s+WHERE\s+"?state_key"?\s*=/i.test(
+                  statement.sourceSQL,
+                )
+              );
+            }),
           ).toHaveLength(1);
         },
       );

--- a/src/skills/workshop/experience-review-prompt.ts
+++ b/src/skills/workshop/experience-review-prompt.ts
@@ -113,7 +113,7 @@ export function buildSkillExperienceReviewPrompt(
           SKILL_WORKSHOP_MAINTENANCE_PROMPT,
         ]
       : [
-          "Only skill_workshop executes in this draft-only review. Choose the smallest useful change: inspect pending proposals and revise the best match; otherwise read and patch the governing Workshop skill, preferring one actually used. Create a class-level skill only when none covers the procedure. Follow the tool's read and prepare_patch contracts; use a full-body update only for restructuring. Keep reusable scripts, templates and references in support_files linked from the procedure.",
+          "Only skill_workshop executes in this draft-only review. Choose the smallest useful change: inspect pending proposals and revise the best match; otherwise, if an existing Workshop-generated skill governs the procedure, read and patch it, preferring one actually used. Read or prepare_patch only a Workshop-generated skill identified in the inventory, used-skill receipt, or tool results; do not guess a skill name from the tool name. Create a class-level skill only when none covers the procedure. Follow the tool's read and prepare_patch contracts; use a full-body update only for restructuring. Keep reusable scripts, templates and references in support_files linked from the procedure.",
           "Finish with at most one create, patch, update or revise, after any needed preparation calls; otherwise answer NO_REPLY. The mutation stages a pending proposal, not a direct publication.",
         ]),
     ...(candidate.turnAborted === true


### PR DESCRIPTION
## What Problem This Solves

Fixes Workshop draft reviews targeting a skill name that does not exist and restores Team Reports to the official external-plugin catalog. It also repairs three validation assumptions exposed by [Full Release Validation](https://github.com/openclaw/openclaw/actions/runs/34159062849): cancellation before Exa's lazy transport starts, counting SQLite statement preparation instead of cached row execution, and expecting Doctor output without its existing ownership defaults.

## Why This Change Was Made

Workshop reads and patches now require a generated skill identified by the inventory, used-skill receipt, or tool results. The catalog entry uses Team Reports' declared package metadata. The existing tests observe the actual transport and SQLite execution boundaries and retain Doctor's complete normalized-output assertion.

This is the maintainer-requested main forward-port of four separately diagnosed release-verification repairs. The touched main files matched their reviewed pre-fix sources exactly; no runtime migration, timeout, retry, skip, or baseline exception was introduced.

## User Impact

Workshop reviews have explicit guidance for selecting existing generated skills, and Team Reports is available through the official fallback catalog. Cancellation, cache reuse, and Doctor ownership contracts receive accurate validation without changing their runtime behavior.

## Evidence

- Fresh head `8b146c32f083fa9d1b940a9ad392a4269f25248a` is rebased onto main `3245d91761f58cef3a93a55661302204d33d43f7` and includes the separately landed retired-relay fix #141608.
- Reproduced the existing catalog-completeness test failing on main solely for the missing `team-reports` entry. The candidate passes that case and its complete catalog suite. Package metadata and existing docs already declare the official external plugin; this is an omitted-record repair.
- **222 test cases across eight files pass**: Workshop preparation/decision contracts, Exa, official catalog, installed-index projection/store, and Doctor migration/system-agent controls. The source-only Doctor fixture used the wrapper's supported `OPENCLAW_E2E_SKIP_BUILD=1` mode after automatic build setup encountered this checkout's shared dependency layout. No assertions or timeouts were weakened, and no local full build is claimed.
- The five changed paths pass oxlint, and changed-file formatting/static guards/core graph boundary plus `git diff --check` pass. Local typechecking refuses the nested shared install. The expanded large-main-file lint preflight also found two unchanged `oxc(no-map-spread)` errors in `test/scripts/plugin-npm-security-scan.test.ts`, outside normal lint shard targets; that unrelated file was left untouched.
- Fresh independent Codex P2 review is clean. [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/34178887446) passed, including the required aggregate gate; the earlier relay failure did not recur.
- Earlier live Workshop positive, negative and interrupted-recovery controls passed both baseline and clarified prompt. They remain prior-candidate evidence: no fresh live-provider result or measured reduction in intermittent failures is claimed. The strict zero-tool-error contract is unchanged. The earlier relay-failing CI run also passed on its unchanged-head rerun; this rebase now includes the independent source repair.
