### PR TITLE
fix(browser): recover stale panel after stream disconnects

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -165,6 +165,10 @@ screenshots for node-routed browsers, Chrome MCP existing-session profiles,
 missing Playwright, or stream connection failures. Navigation rules apply to
 the stream: navigating to a blocked address stops it and clears the view.
 
+After an established stream disconnects, the panel refreshes its screenshot
+and retries the stream automatically after a short delay. Annotation and
+inspection keep their captured image until you return to interaction mode.
+
 Preview cards are interactive only when OpenClaw can identify the browser's
 route. Sandbox browser results remain available to the agent but do not open a
 host-browser preview.

--- a/ui/src/components/browser/browser-panel-snapshot-controller.ts
+++ b/ui/src/components/browser/browser-panel-snapshot-controller.ts
@@ -24,6 +24,7 @@ interface BrowserPanelSnapshotHost extends BrowserPanelSnapshotState {
     "ownsView" | "ensure" | "frameRevision" | "releaseReplacedView"
   >;
   readonly activeTargetId: string | null;
+  readonly mode: "interact" | "annotate" | "inspect";
   readonly operations: Pick<
     BrowserPanelOperationOwnership,
     | "epoch"
@@ -56,7 +57,8 @@ export class BrowserPanelSnapshotController {
       this.controller.native.activeTab ||
       !client ||
       !this.controller.operations.isLive(epoch, client) ||
-      this.controller.activeTargetId !== targetId
+      this.controller.activeTargetId !== targetId ||
+      this.controller.mode !== "interact"
     ) {
       return;
     }
@@ -76,7 +78,10 @@ export class BrowserPanelSnapshotController {
     const stream = this.controller.stream;
     let captureRevision = stream.frameRevision;
     const captureCurrent = () =>
-      current() && captureRevision === stream.frameRevision && !stream.ownsView(targetId);
+      current() &&
+      this.controller.mode === "interact" &&
+      captureRevision === stream.frameRevision &&
+      !stream.ownsView(targetId);
     try {
       if (
         (await stream.ensure(targetId, client, epoch)) ||

--- a/ui/src/components/browser/browser-panel-stream.test.ts
+++ b/ui/src/components/browser/browser-panel-stream.test.ts
@@ -144,6 +144,61 @@ describe("Browser panel stream ownership", () => {
     },
   );
 
+  it("reconnects while a fallback screenshot is still pending", async () => {
+    const screenshot = createDeferred<unknown>();
+    const { controller, calls } = setup(async (envelope) =>
+      envelope.path === "/screenshot" ? screenshot.promise : undefined,
+    );
+    const socket = await start(controller);
+    socket.disconnect(1006);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls("/screenshot")).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(calls("/screencast")).toHaveLength(2);
+    sockets[1]!.receive(screencastFrame(NEXT_URL));
+    await flush();
+    const recovered = controller.view;
+    expect(recovered?.url).toBe(NEXT_URL);
+    screenshot.resolve({ path: "/old.png", targetId: "raw-a", url: PAGE_URL });
+    await flush();
+    expect(controller.view).toBe(recovered);
+  });
+
+  it("recaptures when a late first frame closes before decoding", async () => {
+    const screenshot = createDeferred<unknown>();
+    let captures = 0;
+    const { controller, calls } = setup(async (envelope) =>
+      envelope.path === "/screenshot" && captures++ === 0 ? screenshot.promise : undefined,
+    );
+    const initial = controller.refreshAll();
+    await flush();
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(calls("/screenshot")).toHaveLength(1);
+    const images: EventTarget[] = [];
+    vi.stubGlobal(
+      "Image",
+      class extends EventTarget {
+        constructor() {
+          super();
+          images.push(this);
+        }
+        src = "";
+      },
+    );
+    sockets[0]!.receive(screencastFrame());
+    sockets[0]!.disconnect(1006);
+    screenshot.resolve({ path: "/old.png", targetId: "raw-a", url: PAGE_URL });
+    await initial;
+    stubScreenshotMedia();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls("/screenshot")).toHaveLength(2);
+    const fallback = controller.view;
+    expect(fallback?.dataUrl).toMatch(/^data:/);
+    images[0]!.dispatchEvent(new Event("load"));
+    await flush();
+    expect(controller.view).toBe(fallback);
+  });
+
   it("keeps annotation context on the displayed frame when navigation metadata arrives first", async () => {
     const { controller } = setup();
     const socket = await start(controller);
@@ -309,23 +364,107 @@ describe("Browser panel stream ownership", () => {
     ).toBe(true);
   });
 
-  it("keeps the displayed frame on socket failure, falls back, and rate-limits retries", async () => {
+  it("automatically falls back after socket failure and rate-limits reconnects", async () => {
     const { controller, calls } = setup();
     const socket = await start(controller);
     socket.disconnect(1006);
     expect(controller.view?.dataUrl).toBe("blob:frame-0");
     expect(revokedUrls).toEqual([]);
-    await controller.refreshAll();
+    await vi.advanceTimersByTimeAsync(0);
     expect(controller.view?.dataUrl).toMatch(/^data:/);
     expect(revokedUrls).toEqual(["blob:frame-0"]);
     expect(calls("/screencast")).toHaveLength(1);
     await vi.advanceTimersByTimeAsync(10_000);
-    const retry = controller.refreshAll();
     await flush();
     expect(calls("/screencast")).toHaveLength(2);
     sockets[1]!.disconnect(1006);
-    await retry;
+    await flush();
+    expect(calls("/screenshot")).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(9999);
+    expect(calls("/screencast")).toHaveLength(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(calls("/screencast")).toHaveLength(3);
+    sockets[2]!.receive(screencastFrame(NEXT_URL));
+    await flush();
+    expect(controller.view?.url).toBe(NEXT_URL);
+    await vi.advanceTimersByTimeAsync(20_000);
+    expect(calls("/screencast")).toHaveLength(3);
   });
+
+  it.each(["annotate", "inspect"] as const)(
+    "defers socket recovery until %s ends",
+    async (mode) => {
+      const { controller, calls } = setup();
+      const socket = await start(controller);
+      controller.setMode(mode);
+      controller.setState("strokes", [{ points: [{ x: 0.1, y: 0.2 }] }]);
+      controller.setState("inspected", createInspectedNode("Pinned button"));
+      const pinned = controller.view;
+      socket.disconnect(1006);
+      await vi.advanceTimersByTimeAsync(20_000);
+      expect(controller.view).toBe(pinned);
+      expect(controller.strokes).toHaveLength(1);
+      expect(controller.inspected?.name).toBe("Pinned button");
+      expect(calls("/screenshot")).toHaveLength(0);
+      expect(calls("/screencast")).toHaveLength(1);
+
+      controller.exitCaptureModes();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(calls("/screencast")).toHaveLength(2);
+      sockets[1]!.receive(screencastFrame(NEXT_URL));
+      await flush();
+      expect(controller.view?.url).toBe(NEXT_URL);
+    },
+  );
+
+  it("does not replace a capture entered while the recovery screenshot is pending", async () => {
+    const screenshot = createDeferred<unknown>();
+    const { controller, calls } = setup(async (envelope) =>
+      envelope.path === "/screenshot" ? screenshot.promise : undefined,
+    );
+    const socket = await start(controller);
+    socket.disconnect(1006);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls("/screenshot")).toHaveLength(1);
+    controller.setMode("annotate");
+    const pinned = controller.view;
+    screenshot.resolve({ path: "/fresh.png", targetId: "raw-a", url: PAGE_URL });
+    await flush();
+    expect(controller.view).toBe(pinned);
+    expect(revokedUrls).toEqual([]);
+    controller.exitCaptureModes();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(controller.view?.dataUrl).toMatch(/^data:/);
+  });
+
+  it.each(["disconnect", "reset", "tab", "client", "route", "hidden", "unavailable"])(
+    "does not recover a stream after %s invalidates its owner",
+    async (kind) => {
+      const { controller, host, calls } = setup();
+      const socket = await start(controller);
+      socket.disconnect(1006);
+      await vi.advanceTimersByTimeAsync(0);
+      const screenshots = calls("/screenshot").length;
+      if (kind === "disconnect") {
+        controller.hostDisconnected();
+      } else if (kind === "reset") {
+        controller.resetBrowserState();
+      } else if (kind === "tab") {
+        controller.setState("activeTargetId", "tab-b");
+      } else if (kind === "client") {
+        host.client = null;
+      } else if (kind === "route") {
+        controller.operations.resetRoute({ target: "host", profile: "other" });
+      } else if (kind === "hidden") {
+        host.open = false;
+      } else {
+        host.available = false;
+      }
+      await vi.advanceTimersByTimeAsync(20_000);
+      expect(calls("/screencast")).toHaveLength(1);
+      expect(calls("/screenshot")).toHaveLength(screenshots);
+    },
+  );
 
   it("falls back and backs off malformed mint responses without opening a socket", async () => {
     const { controller, calls } = setup(async (envelope) =>
@@ -345,26 +484,33 @@ describe("Browser panel stream ownership", () => {
     expect(sockets).toHaveLength(0);
   });
 
-  it("restarts streaming immediately after a URL-bar navigation on the same tab", async () => {
-    const { controller, calls } = setup(async (envelope) =>
-      envelope.path === "/navigate" ? { targetId: "raw-a", url: NEXT_URL } : undefined,
-    );
-    await start(controller);
-    expect(calls("/screencast")).toHaveLength(1);
-    const navigation = controller.openUrl(NEXT_URL, { newTab: false });
-    await flush();
-    expect(calls("/screencast")).toHaveLength(2);
-    const socket = sockets.at(-1)!;
-    socket.receive(
-      JSON.stringify({ type: "ready", targetId: "raw-a", url: NEXT_URL, title: "Next" }),
-    );
-    socket.receive(screencastFrame(NEXT_URL));
-    await navigation;
-    await flush();
-    expect(controller.view?.dataUrl).toBe("blob:frame-1");
-    expect(controller.view?.url).toBe(NEXT_URL);
-    expect(calls("/screenshot")).toHaveLength(0);
-  });
+  it.each([false, true])(
+    "restarts streaming after navigation (previous stream failed: %s)",
+    async (failed) => {
+      const { controller, calls } = setup(async (envelope) =>
+        envelope.path === "/navigate" ? { targetId: "raw-a", url: NEXT_URL } : undefined,
+      );
+      const initialSocket = await start(controller);
+      if (failed) {
+        initialSocket.disconnect(1006);
+        await vi.advanceTimersByTimeAsync(0);
+      }
+      expect(calls("/screencast")).toHaveLength(1);
+      const navigation = controller.openUrl(NEXT_URL, { newTab: false });
+      await flush();
+      expect(calls("/screencast")).toHaveLength(2);
+      const socket = sockets.at(-1)!;
+      socket.receive(
+        JSON.stringify({ type: "ready", targetId: "raw-a", url: NEXT_URL, title: "Next" }),
+      );
+      socket.receive(screencastFrame(NEXT_URL));
+      await navigation;
+      await flush();
+      expect(controller.view?.dataUrl).toBe("blob:frame-1");
+      expect(controller.view?.url).toBe(NEXT_URL);
+      expect(calls("/screenshot")).toHaveLength(failed ? 1 : 0);
+    },
+  );
 
   it.each(["disconnect", "reset", "tab"])("closes and revokes on %s teardown", async (kind) => {
     const { controller } = setup();

--- a/ui/src/components/browser/browser-panel-stream.test.ts
+++ b/ui/src/components/browser/browser-panel-stream.test.ts
@@ -164,6 +164,61 @@ describe("Browser panel stream ownership", () => {
     expect(controller.view).toBe(recovered);
   });
 
+  it("keeps a pending fallback screenshot when the reconnect fails", async () => {
+    const screenshot = createDeferred<unknown>();
+    const { controller, calls } = setup(async (envelope) =>
+      envelope.path === "/screenshot" ? screenshot.promise : undefined,
+    );
+    const socket = await start(controller);
+    socket.disconnect(1006);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(calls("/screenshot")).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(calls("/screencast")).toHaveLength(2);
+    sockets[1]!.disconnect(1006);
+    await flush();
+    expect(calls("/screenshot")).toHaveLength(1);
+    screenshot.resolve({ path: "/fresh.png", targetId: "raw-a", url: PAGE_URL });
+    await flush();
+    expect(controller.view?.dataUrl).toMatch(/^data:/);
+    expect(controller.loading).toBe(false);
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(calls("/screencast")).toHaveLength(3);
+    sockets[2]!.disconnect(1006);
+    await flush();
+    expect(calls("/screenshot")).toHaveLength(2);
+  });
+
+  it.each(["annotate", "inspect"] as const)(
+    "defers a resize restart until %s ends",
+    async (mode) => {
+      const { controller, host, calls } = setup();
+      let width = 500;
+      const stage = host.renderRoot.querySelector<HTMLElement>(".bp-stage")!;
+      Object.defineProperty(stage, "clientWidth", { get: () => width });
+      controller.handleViewportResize(width, 300);
+      const socket = await start(controller);
+      controller.setMode(mode);
+      const pinned = controller.view;
+      width = 800;
+      controller.handleViewportResize(width, 300);
+      await vi.advanceTimersByTimeAsync(10_000);
+      expect(socket.close).not.toHaveBeenCalled();
+      expect(calls("/screencast")).toHaveLength(1);
+      expect(controller.view).toBe(pinned);
+
+      controller.exitCaptureModes();
+      await vi.advanceTimersByTimeAsync(500);
+      expect(socket.close).toHaveBeenCalledOnce();
+      expect(calls("/screencast")).toHaveLength(2);
+      expect(calls("/screencast")[1]?.[1]).toMatchObject({ body: { maxWidth: 800 } });
+      sockets[1]!.receive(screencastFrame(PAGE_URL, 800, 300));
+      await flush();
+      expect(controller.view?.dataUrl).toBe("blob:frame-1");
+      expect(calls("/screenshot")).toHaveLength(0);
+    },
+  );
+
   it("recaptures when a late first frame closes before decoding", async () => {
     const screenshot = createDeferred<unknown>();
     let captures = 0;

--- a/ui/src/components/browser/browser-panel-stream.ts
+++ b/ui/src/components/browser/browser-panel-stream.ts
@@ -65,6 +65,8 @@ export class BrowserPanelStream {
   private objectUrl?: string;
   private decodingUrl?: string;
   private resizeTimer?: ReturnType<typeof setTimeout>;
+  private recoveryTimer?: ReturnType<typeof setTimeout>;
+  private recovery?: Pick<Attempt, "targetId" | "epoch" | "client">;
   private viewportSyncPending = false;
   private readonly retiringUrls = new Set<string>();
 
@@ -104,12 +106,10 @@ export class BrowserPanelStream {
       this.close();
       this.scope = { client: this.host.host.client, route };
       this.unsupported = false;
-      this.lastFailures.clear();
     }
     if (this.attempt && this.current(this.attempt) && this.attempt.targetId === targetId) {
       return this.attempt.live || (await this.attempt.firstFrame);
     }
-    this.close(false);
     // Only failed attempts back off; navigation and resize close streams on purpose and restart at once.
     if (
       this.unsupported ||
@@ -117,6 +117,7 @@ export class BrowserPanelStream {
     ) {
       return false;
     }
+    this.close(false);
     const dimensions = this.dimensions();
     let settle!: Attempt["settle"];
     const firstFrame = new Promise<boolean>((resolve) => {
@@ -176,9 +177,10 @@ export class BrowserPanelStream {
             return;
           }
           if (code !== 4003 && code !== 4004) {
-            this.lastFailures.set(attempt.targetId, Date.now());
+            this.recover(attempt);
+            return;
           }
-          this.close(code === 4003 || code === 4004);
+          this.close();
           if (code === 4003) {
             this.host.setState(
               "tabs",
@@ -197,12 +199,46 @@ export class BrowserPanelStream {
     } catch (error) {
       if (this.current(attempt)) {
         this.unsupported = isBrowserScreencastUnsupportedError(error);
-        if (!this.unsupported) {
-          this.lastFailures.set(attempt.targetId, Date.now());
+        if (this.unsupported) {
+          this.close(false);
+        } else {
+          this.recover(attempt);
         }
-        this.close(false);
       }
     }
+  }
+
+  private recover(attempt: Attempt): void {
+    this.lastFailures.set(attempt.targetId, Date.now());
+    this.close(false);
+    this.recovery = { targetId: attempt.targetId, epoch: attempt.epoch, client: attempt.client };
+    // A received frame invalidates older screenshots even if decoding has not finished.
+    this.scheduleRecovery(attempt.live ? 0 : RETRY_DELAY_MS);
+  }
+
+  private scheduleRecovery(delay: number): void {
+    const recovery = this.recovery;
+    if (!recovery) {
+      return;
+    }
+    clearTimeout(this.recoveryTimer);
+    this.recoveryTimer = setTimeout(() => {
+      this.recoveryTimer = undefined;
+      if (
+        this.host.activeTargetId !== recovery.targetId ||
+        !this.host.operations.isLive(recovery.epoch, recovery.client)
+      ) {
+        this.recovery = undefined;
+        return;
+      }
+      // Capture modes pin their image; flushPendingFrame resumes recovery on exit.
+      if (this.host.mode !== "interact") {
+        return;
+      }
+      // A stalled screenshot must not hold the reconnect deadline.
+      this.scheduleRecovery(RETRY_DELAY_MS);
+      void this.host.refreshView(recovery.targetId);
+    }, delay);
   }
 
   private updateMetadata(attempt: Attempt, metadata: BrowserScreencastMeta): void {
@@ -224,6 +260,7 @@ export class BrowserPanelStream {
   }
 
   flushPendingFrame(): void {
+    this.scheduleRecovery(0);
     const attempt = this.attempt;
     if (attempt && this.current(attempt) && !attempt.decoding) {
       void this.decodeFrames(attempt);
@@ -309,7 +346,7 @@ export class BrowserPanelStream {
       }
     } catch {
       if (this.current(attempt)) {
-        this.close(false);
+        this.recover(attempt);
       }
     } finally {
       attempt.decoding = false;
@@ -360,6 +397,13 @@ export class BrowserPanelStream {
   }
 
   close(releaseView = true): void {
+    if (releaseView) {
+      // Intentional teardown starts a new owner; it must not inherit an orphaned backoff.
+      this.lastFailures.clear();
+    }
+    clearTimeout(this.recoveryTimer);
+    this.recoveryTimer = undefined;
+    this.recovery = undefined;
     clearTimeout(this.resizeTimer);
     this.resizeTimer = undefined;
     // Invalidation cancels the pending sync timer; the next stream must be able to schedule one.

--- a/ui/src/components/browser/browser-panel-stream.ts
+++ b/ui/src/components/browser/browser-panel-stream.ts
@@ -29,7 +29,7 @@ interface BrowserPanelStreamHost extends StreamState {
   readonly mode: "interact" | "annotate" | "inspect";
   readonly operations: Pick<
     BrowserPanelOperationOwnership,
-    "epoch" | "route" | "isLive" | "capturedTabs" | "markNavigationReconciled"
+    "epoch" | "route" | "isLive" | "hasPendingCapture" | "capturedTabs" | "markNavigationReconciled"
   >;
   readonly urlDraftEditing: boolean;
   readonly observedViewportSize: { width: number; height: number } | null;
@@ -39,6 +39,8 @@ interface BrowserPanelStreamHost extends StreamState {
   refreshView(targetId: string): Promise<void>;
   refreshAll(): Promise<void>;
 }
+
+type Recovery = Pick<Attempt, "targetId" | "epoch" | "client">;
 
 type Attempt = {
   targetId: string;
@@ -66,7 +68,7 @@ export class BrowserPanelStream {
   private decodingUrl?: string;
   private resizeTimer?: ReturnType<typeof setTimeout>;
   private recoveryTimer?: ReturnType<typeof setTimeout>;
-  private recovery?: Pick<Attempt, "targetId" | "epoch" | "client">;
+  private recovery?: Recovery;
   private viewportSyncPending = false;
   private readonly retiringUrls = new Set<string>();
 
@@ -237,8 +239,22 @@ export class BrowserPanelStream {
       }
       // A stalled screenshot must not hold the reconnect deadline.
       this.scheduleRecovery(RETRY_DELAY_MS);
-      void this.host.refreshView(recovery.targetId);
+      void this.resume(recovery);
     }, delay);
+  }
+
+  private async resume(recovery: Recovery): Promise<void> {
+    if (await this.ensure(recovery.targetId, recovery.client, recovery.epoch)) {
+      return;
+    }
+    // A failed reconnect must not discard a fallback screenshot that is still in flight.
+    if (
+      this.host.activeTargetId === recovery.targetId &&
+      this.host.operations.isLive(recovery.epoch, recovery.client) &&
+      !this.host.operations.hasPendingCapture
+    ) {
+      void this.host.refreshView(recovery.targetId);
+    }
   }
 
   private updateMetadata(attempt: Attempt, metadata: BrowserScreencastMeta): void {
@@ -265,6 +281,7 @@ export class BrowserPanelStream {
     if (attempt && this.current(attempt) && !attempt.decoding) {
       void this.decodeFrames(attempt);
     }
+    this.restartAfterResize();
   }
 
   private async decodeFrames(attempt: Attempt): Promise<void> {
@@ -356,22 +373,26 @@ export class BrowserPanelStream {
   resize(): void {
     // The debounced viewport sync just ran; later mismatched frames may schedule again.
     this.viewportSyncPending = false;
+    this.restartAfterResize();
+  }
+
+  private resized(attempt: Attempt): boolean {
+    return Math.abs(this.dimensions().width - attempt.width) / attempt.width > 0.3;
+  }
+
+  private restartAfterResize(): void {
     const attempt = this.attempt;
-    if (
-      !attempt ||
-      !this.current(attempt) ||
-      Math.abs(this.dimensions().width - attempt.width) / attempt.width <= 0.3
-    ) {
+    if (!attempt || !this.current(attempt) || !this.resized(attempt)) {
       return;
     }
     // Coalesce a burst of layout changes into one restart.
     this.resizeTimer ??= setTimeout(() => {
       this.resizeTimer = undefined;
-      if (
-        this.attempt !== attempt ||
-        !this.current(attempt) ||
-        Math.abs(this.dimensions().width - attempt.width) / attempt.width <= 0.3
-      ) {
+      if (this.attempt !== attempt || !this.current(attempt) || !this.resized(attempt)) {
+        return;
+      }
+      // Capture modes pin their image; flushPendingFrame restarts the stream on exit.
+      if (this.host.mode !== "interact") {
         return;
       }
       this.close(false);


### PR DESCRIPTION
Closes #141564

## What Problem This Solves

Fixes an issue where the Browser panel would keep displaying a stale image after an established screencast connection failed. The Gateway client could remain available while the panel requested neither a screenshot nor a replacement stream.

## Why This Change Was Made

The stream owner now requests screenshot fallback and retries streaming through its existing ten-second backoff. Recovery cancels when ownership changes. The screenshot controller preserves captured annotation and inspection images.

Review follow-up in `68e57c98`:

- A retry reconnects the stream directly and requests a new screenshot only when no screenshot is still in flight. A failed reconnect no longer discards a pending fallback screenshot.
- A large width change during annotation or inspection no longer closes the stream. The restart waits until interaction mode resumes.

## User Impact

The panel recovers without a refresh, resize, or navigation action. Users can finish annotating or inspecting their captured image and return to interaction mode to resume streaming, including after resizing the panel.

## Evidence

- All 202 tests pass across the 14 browser panel test files. The 36 stream tests include three new regressions for the review findings; all three failed on `d05d51d6` before the fix.
- Formatting, lint, UI typecheck, and `git diff --check` pass. `check:madge-import-cycles` reports zero cycles.
- An independent reviewer checked the follow-up commit. It found no defect in either fix and confirmed that the three regressions fail on the previous head for the traced reasons. Its one remaining note concerns the open-socket case below.

The Chromium fixture loads the production Browser panel and terminates a real disposable WebSocket connection. Gateway request responses are synthetic; this does not test a real Gateway backend.

| Observation | Baseline `63126736` | PR head `68e57c98` |
| --- | --- | --- |
| Screenshot after disconnect | None within 12 seconds | Requested after 4 ms |
| Replacement stream | None within 12 seconds | Connected after 10.004 seconds |
| Display | Original image remains | Fallback screenshot, then a new streamed frame |
| Gateway client | Available throughout | Available throughout |

The timing values describe one fixture run. No manual refresh occurs.

A socket that stays open without sending its first frame remains outside this fix. The independent review of the follow-up commit flagged the same case; it behaves as it did on the previous head and on `main`.

The `checks-ui-e2e (7/13)` failure on `d05d51d6` was `chat-flow.image-handoff.e2e.test.ts`, which this change does not touch.

AI-assisted implementation and review.
