### PR TITLE
fix(plugins): keep published runtimes out of root bundle

### DIFF
--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -70,6 +70,7 @@
       "pluginApi": ">=2026.6.35"
     },
     "build": {
+      "bundledDist": false,
       "openclawVersion": "2026.6.35"
     },
     "release": {

--- a/extensions/msteams/package.json
+++ b/extensions/msteams/package.json
@@ -59,6 +59,7 @@
       "pluginApi": ">=2026.6.35"
     },
     "build": {
+      "bundledDist": false,
       "openclawVersion": "2026.6.35"
     },
     "release": {

--- a/test/scripts/bundled-plugin-build-entries.test.ts
+++ b/test/scripts/bundled-plugin-build-entries.test.ts
@@ -191,6 +191,16 @@ describe("bundled plugin build entries", () => {
     }
   });
 
+  it("keeps separately published Discord and Microsoft Teams runtimes out of the root bundle", () => {
+    const entries = listBundledPluginBuildEntries();
+    const artifacts = listBundledPluginPackArtifacts();
+
+    for (const pluginId of ["discord", "msteams"]) {
+      expectNoPrefixMatches(Object.keys(entries), `extensions/${pluginId}/`);
+      expectNoPrefixMatches(artifacts, `dist/extensions/${pluginId}/`);
+    }
+  });
+
   it("keeps Cohere bundled through the externalization transition", () => {
     const artifacts = listBundledPluginPackArtifacts();
 


### PR DESCRIPTION
Fixes the npm preflight package-contents failure for the 2026.6.35 candidate.

The root npm artifact was compiling Discord and Microsoft Teams into root `dist` chunks while `package.json` excludes their plugin directories. Their runtime dependencies therefore cannot be installed from the root manifest. Both are separately published plugin packages and already declare their dependencies locally.

Canonical repair: mark the two packages `openclaw.build.bundledDist: false`. The existing bundled-entry owner consequently excludes them from the root build, while the existing package-local runtime builder still compiles and verifies each plugin with its declared dependencies. This preserves plugin dependency ownership; it does not add plugin-only dependencies to the core package or weaken the installed-artifact verifier.

Proof:
- Red: added real planner regression fails on candidate because `extensions/discord/**` and `extensions/msteams/**` enter root entries.
- Green: `node scripts/run-vitest.mjs test/scripts/bundled-plugin-build-entries.test.ts` (18/18).
- Green: `node scripts/check-plugin-npm-runtime-builds.mjs --package extensions/discord --package extensions/msteams` (both package-local runtimes built).
- Green: `node scripts/check-package-dist-imports.mjs`.
- Local `pnpm pack` is still completing its prepack build; I will attach the installed-artifact result separately.

Production metadata: +2/-0. Tests: +10/-0. No tag, publish, or npm selector change.