### PR TITLE
improve(tests): make native Codex checks cancellation-safe

### DIFF
--- a/extensions/codex/src/node-exec-server.test.ts
+++ b/extensions/codex/src/node-exec-server.test.ts
@@ -1,5 +1,5 @@
 /** Protects node policy, real pinned Codex stdio framing, and child cleanup. */
-import { once } from "node:events";
+import { EventEmitter, once } from "node:events";
 import { access, readFile, realpath } from "node:fs/promises";
 import { createServer } from "node:http";
 import path from "node:path";
@@ -58,8 +58,10 @@ function createManagedWorkspaceInvocation(cwd: string) {
   return { placement, context, acquireManagedWorkspace, release };
 }
 
-function createNodeFrames() {
+function createNodeFrames(testSignal?: AbortSignal) {
   const controller = new AbortController();
+  const signal = testSignal ? AbortSignal.any([controller.signal, testSignal]) : controller.signal;
+  const messages = new EventEmitter();
   let receive: ((message: Uint8Array) => void | Promise<void>) | undefined;
   let signalReady = () => {};
   const ready = new Promise<void>((resolve) => {
@@ -67,12 +69,13 @@ function createNodeFrames() {
   });
   const outbound: JsonRpcRecord[] = [];
   const io: OpenClawPluginNodeHostCommandIo = {
-    signal: controller.signal,
+    signal,
     emitChunk: async () => undefined,
     onInput: () => undefined,
     frames: {
       send: async (message) => {
         outbound.push(JSON.parse(Buffer.from(message).toString("utf8")) as JsonRpcRecord);
+        messages.emit("frame");
       },
       onMessage: (listener) => {
         receive = listener;
@@ -90,6 +93,18 @@ function createNodeFrames() {
     io,
     outbound,
     ready,
+    waitForMessage: async (matches: (message: JsonRpcRecord) => boolean) => {
+      // Retain frames before waking readers: responses may precede the waiter.
+      // The test's cancellation owns the wait, not an arbitrary RPC poll deadline.
+      for (;;) {
+        signal.throwIfAborted();
+        const message = outbound.find(matches);
+        if (message) {
+          return message;
+        }
+        await once(messages, "frame", { signal });
+      }
+    },
     send: async (message: unknown) => {
       if (!receive) {
         throw new Error("Codex node command did not register a ready duplex receiver.");
@@ -109,10 +124,11 @@ async function readNodeResponse(
   frames: ReturnType<typeof createNodeFrames>,
   id: number,
 ): Promise<JsonRpcRecord> {
-  await vi.waitFor(() => expect(frames.outbound.some((message) => message.id === id)).toBe(true));
-  const response = frames.outbound.find((message) => message.id === id);
-  if (!response || response.error) {
-    throw new Error(`Codex exec-server request ${id} failed: ${JSON.stringify(response?.error)}`);
+  const response = await frames.waitForMessage(
+    (message) => message.id === id && ("result" in message || "error" in message),
+  );
+  if (response.error) {
+    throw new Error(`Codex exec-server request ${id} failed: ${JSON.stringify(response.error)}`);
   }
   return response.result as JsonRpcRecord;
 }
@@ -128,17 +144,30 @@ async function readNodeProcessNotifications(
         String(message.method).startsWith("process/") &&
         (message.params as { processId?: string }).processId === processId,
     );
-  await vi.waitFor(() => expect(matching()).toHaveLength(count));
+  // Codex records exit before asynchronously notifying; closed can arrive first.
+  // Wait for both facts, then reject extra notifications with the exact count.
+  await frames.waitForMessage(
+    (message) =>
+      message.method === "process/closed" &&
+      (message.params as { processId?: string }).processId === processId &&
+      matching().length >= count,
+  );
+  expect(matching()).toHaveLength(count);
   return matching().toSorted(
     (left, right) => (left.params as { seq: number }).seq - (right.params as { seq: number }).seq,
   );
 }
 
+let pendingNodeProof: Promise<void> | undefined;
 beforeEach(() => {
   setManagedCodexPluginRoot(fileURLToPath(new URL("../", import.meta.url)));
 });
 
-afterEach(() => {
+afterEach(async () => {
+  // A timed-out test aborts its signal; join native cleanup before restoring
+  // the shared environment or allowing the next test to start another child.
+  await pendingNodeProof?.catch(() => {});
+  pendingNodeProof = undefined;
   setManagedCodexPluginRoot(undefined);
   vi.unstubAllEnvs();
 });
@@ -452,7 +481,8 @@ describe("Codex node exec-server", () => {
     expect(workspace.release).toHaveBeenCalledOnce();
   });
 
-  it("relays the actual pinned Codex binary, isolates credentials, and removes its private home", async () => {
+  it("relays the actual pinned Codex binary, isolates credentials, and removes its private home", async (context) => {
+    const { signal } = context;
     vi.stubEnv("OPENAI_API_KEY", "node-provider-canary");
     vi.stubEnv("AWS_ACCESS_KEY_ID", "node-cloud-canary");
     vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", "/node-cloud-canary.json");
@@ -460,14 +490,14 @@ describe("Codex node exec-server", () => {
     vi.stubEnv("SSH_AUTH_SOCK", "/node-ssh-canary.sock");
     vi.stubEnv("NODE_OPTIONS", "--no-warnings");
 
-    await withTempWorkspace(
+    pendingNodeProof = withTempWorkspace(
       { rootDir: resolvePreferredOpenClawTmpDir(), prefix: "codex-node-exec-contract-" },
       async ({ dir }) => {
         const cwd = await realpath(dir);
         const workspaceUri = pathToFileURL(cwd).href;
         const probePath = path.join(cwd, "probe.txt");
         const probeUri = pathToFileURL(probePath).href;
-        const frames = createNodeFrames();
+        const frames = createNodeFrames(signal);
         const command = createCodexNodeExecServerCommand();
         const workspace = createManagedWorkspaceInvocation(cwd);
         const invocation = command.handle(
@@ -475,7 +505,10 @@ describe("Codex node exec-server", () => {
           frames.io,
           workspace.context,
         );
-        void invocation.catch(() => {});
+        void invocation.then(
+          () => frames.controller.abort(new Error("Codex exec-server invocation ended")),
+          (error: unknown) => frames.controller.abort(error),
+        );
         let isolatedHome: string | undefined;
 
         try {
@@ -737,16 +770,11 @@ describe("Codex node exec-server", () => {
               status: 200,
               bodyBase64: "",
             });
-            await vi.waitFor(() =>
-              expect(
-                frames.outbound.some(
-                  (message) =>
-                    message.method === "http/request/bodyDelta" &&
-                    (message.params as { requestId?: string; done?: boolean }).requestId ===
-                      "node-http-proof" &&
-                    (message.params as { done?: boolean }).done === true,
-                ),
-              ).toBe(true),
+            await frames.waitForMessage(
+              (message) =>
+                message.method === "http/request/bodyDelta" &&
+                (message.params as { requestId?: string }).requestId === "node-http-proof" &&
+                (message.params as { done?: boolean }).done === true,
             );
             const chunks = frames.outbound
               .filter(
@@ -813,12 +841,7 @@ describe("Codex node exec-server", () => {
             },
           });
           expect(await readNodeResponse(frames, 20)).toMatchObject({ processId: "node-policy" });
-          await vi.waitFor(() =>
-            expect(
-              frames.outbound.some((message) => message.method === "network/policyRequest"),
-            ).toBe(true),
-          );
-          const policyRequest = frames.outbound.find(
+          const policyRequest = await frames.waitForMessage(
             (message) => message.method === "network/policyRequest",
           );
           expect(policyRequest).toMatchObject({
@@ -829,17 +852,13 @@ describe("Codex node exec-server", () => {
             },
           });
           await frames.send({
-            id: policyRequest?.id,
+            id: policyRequest.id,
             result: { decision: { type: "deny", reason: "node-policy-proof" } },
           });
-          await vi.waitFor(() =>
-            expect(
-              frames.outbound.some(
-                (message) =>
-                  message.method === "process/closed" &&
-                  (message.params as { processId?: string }).processId === "node-policy",
-              ),
-            ).toBe(true),
+          await frames.waitForMessage(
+            (message) =>
+              message.method === "process/closed" &&
+              (message.params as { processId?: string }).processId === "node-policy",
           );
           expect(frames.outbound).toEqual(
             expect.arrayContaining([
@@ -853,9 +872,16 @@ describe("Codex node exec-server", () => {
               }),
             ]),
           );
+          const pendingResponse = readNodeResponse(frames, 21);
+          const closed = new Error("paired-device attempt completed");
+          frames.controller.abort(closed);
+          await expect(pendingResponse).rejects.toMatchObject({
+            name: "AbortError",
+            cause: closed,
+          });
         } finally {
           frames.controller.abort(new Error("paired-device attempt completed"));
-          await expect(invocation).rejects.toThrow("paired-device attempt completed");
+          await expect(invocation).rejects.toBe(frames.io.signal.reason);
           await command.onDisconnect?.();
           expect(workspace.release).toHaveBeenCalledOnce();
         }
@@ -864,5 +890,6 @@ describe("Codex node exec-server", () => {
         await expect(access(isolatedHome!)).rejects.toMatchObject({ code: "ENOENT" });
       },
     );
+    await pendingNodeProof;
   });
 });


### PR DESCRIPTION
Related: #132180 (split node-session completion and execution follow-ups). This is the pinned Codex test-lifetime slice only; the original remains open for other changes.

## What Problem This Solves

Resolves a problem where the native Codex integration test rejects valid delayed responses using a shorter polling deadline than the operation it is testing. A timed-out test can also leave its asynchronous proof running while shared environment and plugin-root state are restored.

## Why This Change Was Made

Use frame notifications and the existing test cancellation signal to own response waits, then join the native proof before restoring shared fixture state. Process notification checks require both the terminal frame and the expected received notifications before retaining the exact count and sequence assertions.

## User Impact

No product runtime or permission behavior changes. The real pinned-binary test now handles valid delayed responses, cancellation, and asynchronous notification delivery without increasing a timeout or weakening assertions. **Production delta: 0. One test file: +66/-39, net +27.** Existing cases and all deadlines remain unchanged.

## Evidence

The unchanged baseline passed all nine cases. Delaying only the loopback HTTP fixture's final response chunk by **1500 ms**, within its unchanged **3000 ms** request timeout, made the baseline fail at its one-second completion poll. The same actual pinned binary and delayed fixture passed with the candidate. The delay was removed.

A separate counterfactual reordered real received native frames so `process/exited` arrived after `process/closed`. The original proposal's closed-only wait failed the exact count assertion (two instead of three); the candidate's combined wait passed with exact count/order assertions preserved. No SDK outcome or native frame was fabricated, and the reordering control was removed. This does not claim a naturally reproduced production protocol defect.

A timeout control reached the existing **120000 ms** test deadline and produced the expected timeout failure. Its observations confirmed that the pending response was aborted through `TestContext.signal`, teardown waited while native cleanup was pending, and invocation/disconnect completion, workspace release, and private-home removal occurred before environment/plugin-root restoration. The control was removed.

On final candidate tree `8b4929d4d9d22b15ddb5f2ff309cfc8972f787f6`, the restored test and readiness/paired-device relay siblings passed **82 cases across three files in 24.031 seconds**. Required changed checks passed in **180.824 seconds**.

```bash
node scripts/run-vitest.mjs extensions/codex/src/node-exec-server.test.ts extensions/codex/src/node-exec-server.readiness.test.ts extensions/codex/src/app-server/sandbox-exec-server-node-relay.test.ts
```

```bash
node scripts/check-changed.mjs -- extensions/codex/src/node-exec-server.test.ts
```

Dependency behavior was personally checked against pinned Codex `rust-v0.153.4`, commit `3d2ee51ca2d5db578f328aa75e20aa22c0197c9a`: [stdio shutdown](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/exec-server/src/server/transport.rs#L131-L158), [process notification lifecycle](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/exec-server/src/local_process.rs#L930-L1149), and [notification enqueueing](https://github.com/openai/codex/blob/3d2ee51ca2d5db578f328aa75e20aa22c0197c9a/codex-rs/exec-server/src/rpc.rs#L116-L160). Exit state precedes asynchronous notification, and closed process records remain retained temporarily; the tests do not infer immediate handle removal from the README wording.

Proof used package-pinned Codex **0.153.4 on macOS arm64**, isolated homes, synthetic credential canaries, and loopback fixtures. No operator authentication, live-provider turn, desktop binary, native-app rollout, or cross-platform proof is claimed. Fresh isolated Codex review returned **scoped-clean at P0 across both partitions** in 34.047 seconds, with no findings; this is not an all-severity clean verdict. [Exact-head CI 34162919336](https://github.com/openclaw/openclaw/actions/runs/34162919336) passed on `801583eddf6862040f20c79bf48684b783730369`.
