### PR TITLE
improve(tests): cover Gateway fixture edits without duplicate setup

### DIFF
--- a/src/gateway/test-helpers.server-env.test.ts
+++ b/src/gateway/test-helpers.server-env.test.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
 import { listAgentIds } from "../agents/agent-scope.js";
-import { type AgentsConfig, resetConfigRuntimeState } from "../config/config.js";
+import { type AgentsConfig, getRuntimeConfig, resetConfigRuntimeState } from "../config/config.js";
 import { drainSystemEvents, enqueueSystemEvent } from "../infra/system-events.js";
 import { deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { GatewayClient, GatewayClientRequestError } from "./client.js";
@@ -15,9 +15,7 @@ import {
 } from "./test-helpers.e2e.js";
 import { testState } from "./test-helpers.runtime-state.js";
 import {
-  connectWebchatClient,
   installGatewayTestHooks,
-  rpcReq,
   waitForSystemEvent,
   withGatewayServer,
   writeSessionStore,
@@ -130,39 +128,29 @@ describe("Gateway test environment lifecycle", () => {
     },
   );
 
-  it("keeps the fixture roster visible to real runtime readers while an RPC is pending", async () => {
-    const actual = await vi.importActual<typeof import("../config/io.js")>("../config/io.js");
-    await withGatewayServer(async ({ port }) => {
-      const ws = await connectWebchatClient({ port, scopes: ["operator.admin"] });
-      try {
-        for (const agentId of ["first", "second"]) {
-          const workspace = path.join(process.env.OPENCLAW_STATE_DIR!, agentId);
-          testState.agentsConfig = { ownership: "explicit", entries: { [agentId]: { workspace } } };
-          const request = rpcReq(ws, "health");
-          try {
-            // A retained real-IO reader can run before the request is dispatched.
-            // It must see this case's roster, not pin the suite's on-disk default.
-            expect(actual.getRuntimeConfig().agents?.entries).toEqual({ [agentId]: { workspace } });
-            expect((await request).ok).toBe(true);
-          } finally {
-            await request;
-          }
-        }
-      } finally {
-        ws.close();
-      }
-    });
-  });
-
-  it.each(["session store", "config mock"])(
-    "keeps config readable while the %s fixture publishes an update",
-    async (fixture) => {
+  it.each([
+    { fixture: "session store", roster: "entries" },
+    { fixture: "config mock", roster: "entries" },
+    { fixture: "session store", roster: "list" },
+  ])(
+    "keeps authored config readable while the $fixture publishes canonical $roster overrides",
+    async ({ fixture, roster }) => {
       const actual = await vi.importActual<typeof import("../config/io.js")>("../config/io.js");
       const { writeConfigFile } = createGatewayConfigOverrides(actual);
-      const agents: AgentsConfig = { ownership: "explicit", entries: { main: {}, authored: {} } };
-      await writeConfigFile({ agents, session: { reset: { idleMinutes: 30 } } });
-      testState.agentsConfig = { ownership: "explicit", entries: { main: {}, fixture: {} } };
       const configPath = process.env.OPENCLAW_CONFIG_PATH!;
+      const workspace = path.dirname(configPath);
+      const agents = {
+        ownership: "explicit",
+        entries: { main: {}, authored: {} },
+        defaults: { userTimezone: "UTC", timeoutSeconds: 90 },
+      } satisfies AgentsConfig;
+      await writeConfigFile({ agents, session: { reset: { idleMinutes: 30 } } });
+      const fixtureEntries = { main: {}, fixture: { workspace } };
+      testState.agentsConfig =
+        roster === "list"
+          ? { list: [{ id: "main" }, { id: "fixture", workspace }] }
+          : { ownership: "explicit", entries: fixtureEntries };
+      testState.agentConfig = { workspace, timeoutSeconds: 45 };
       const readAuthoredConfig = () =>
         actual.loadConfig({ pin: false, skipPluginValidation: true, skipShellEnvFallback: true });
       const readIdleMinutes = () => readAuthoredConfig().session?.reset?.idleMinutes;
@@ -189,8 +177,20 @@ describe("Gateway test environment lifecycle", () => {
           await writeConfigFile({ agents, session: { reset: { idleMinutes: 60 } } });
         }
         expect(readIdleMinutes()).toBe(60);
-        expect(listAgentIds(actual.getRuntimeConfig())).toEqual(["main", "fixture"]);
-        expect(listAgentIds(readAuthoredConfig())).toEqual(["main", "authored"]);
+        const realConfig = actual.getRuntimeConfig();
+        expect(realConfig.agents?.entries).toEqual(fixtureEntries);
+        expect(realConfig.agents?.list).toBeUndefined();
+        expect(realConfig.agents?.defaults).toMatchObject({
+          userTimezone: "UTC",
+          workspace,
+          timeoutSeconds: 45,
+        });
+        expect(realConfig.session?.store).toBe(testState.sessionStorePath);
+        expect(getRuntimeConfig()).toEqual(realConfig);
+        const authoredConfig = readAuthoredConfig();
+        expect(listAgentIds(authoredConfig)).toEqual(["main", "authored"]);
+        expect(authoredConfig.agents?.defaults).toMatchObject(agents.defaults);
+        expect(JSON.parse(await fs.readFile(configPath, "utf8")).agents).toEqual(agents);
       } finally {
         writeSpy.mockRestore();
       }

--- a/src/gateway/test-helpers.server-rpc.test.ts
+++ b/src/gateway/test-helpers.server-rpc.test.ts
@@ -5,12 +5,14 @@ import { describe, expect, test, vi } from "vitest";
 import type { WebSocket } from "ws";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { listAgentIds } from "../agents/agent-scope.js";
+import { type AgentsConfig, getRuntimeConfig as getMockedRuntimeConfig } from "../config/config.js";
 import { loadSessionEntry, updateSessionEntry } from "../config/sessions/session-accessor.js";
 import { SQLITE_SESSION_WRITER_QUEUES } from "../config/sessions/store-writer-state.js";
 import {
   disposeOpenClawAgentDatabaseByPath,
   listOpenClawAgentDatabasesForTest,
 } from "../state/openclaw-agent-db.js";
+import { createGatewayConfigOverrides } from "./test-helpers.config-runtime.js";
 import {
   installGatewayTestHooks,
   onceMessage,
@@ -117,4 +119,75 @@ describe("Gateway fixture config publication", () => {
       }
     },
   );
+
+  test("publishes agent-only edits and removals without overwriting authored config", async () => {
+    const actual = await vi.importActual<typeof import("../config/io.js")>("../config/io.js");
+    const { writeConfigFile } = createGatewayConfigOverrides(actual);
+    const configPath = process.env.OPENCLAW_CONFIG_PATH!;
+    const store = path.join(path.dirname(configPath), "agents", "{agentId}", "sessions.json");
+    const authoredConfig = {
+      agents: {
+        ownership: "explicit",
+        entries: { main: { name: "Authored main" } },
+        defaults: { userTimezone: "UTC", timeoutSeconds: 90 },
+      } satisfies AgentsConfig,
+      session: { store },
+    };
+    await writeConfigFile(authoredConfig);
+    const workspace = path.join(path.dirname(configPath), "fixture-workspace");
+    const secondary = { name: "Fixture secondary", workspace };
+    // Publication must not inject main, even after deletion leaves a sole fixture agent.
+    const entries: NonNullable<AgentsConfig["entries"]> = { primary: { workspace }, secondary };
+    testState.agentsConfig = { ownership: "explicit", entries };
+    testState.agentConfig = { timeoutSeconds: 45 };
+
+    const expectPublished = async (
+      expectedEntries: NonNullable<AgentsConfig["entries"]>,
+      timeoutSeconds: number,
+    ) => {
+      const request = rpcReq<{ agents: Array<{ id: string; name?: string }> }>(
+        ws,
+        "agents.list",
+        {},
+      );
+      try {
+        const realConfig = actual.getRuntimeConfig();
+        expect(realConfig.agents?.entries).toEqual(expectedEntries);
+        expect(realConfig.agents?.defaults).toMatchObject({ userTimezone: "UTC", timeoutSeconds });
+        expect(realConfig.session?.store).toBe(store);
+        expect(getMockedRuntimeConfig()).toEqual(realConfig);
+        const response = await request;
+        expect(response.ok, JSON.stringify(response)).toBe(true);
+        expect(response.payload?.agents.map(({ id, name }) => ({ id, name }))).toEqual(
+          Object.entries(expectedEntries).map(([id, { name }]) => ({ id, name })),
+        );
+        expect(JSON.parse(await fs.readFile(configPath, "utf8"))).toEqual(authoredConfig);
+      } finally {
+        await request;
+      }
+    };
+
+    await expectPublished(
+      { primary: { workspace }, secondary: { name: "Fixture secondary", workspace } },
+      45,
+    );
+    // Entries can alias the published snapshot; the copied default must also refresh.
+    secondary.name = "Updated fixture";
+    testState.agentConfig.timeoutSeconds = 60;
+    await expectPublished(
+      { primary: { workspace }, secondary: { name: "Updated fixture", workspace } },
+      60,
+    );
+    delete entries.secondary;
+    delete testState.agentConfig.timeoutSeconds;
+    await expectPublished({ primary: { workspace } }, 90);
+    testState.agentsConfig = undefined;
+    testState.agentConfig = undefined;
+    await expectPublished({ main: { name: "Authored main" } }, 90);
+
+    authoredConfig.agents.entries.main.name = "Updated file intent";
+    await fs.writeFile(configPath, JSON.stringify(authoredConfig));
+    testState.agentConfig = { timeoutSeconds: 30 };
+    await expectPublished({ main: { name: "Updated file intent" } }, 30);
+  });
 });


### PR DESCRIPTION
Related: #132180 (split node-session completion and execution follow-ups). This is the Gateway test-fixture coverage slice only; the original remains open for the other changes.

## What Problem This Solves

Gateway integration tests must expose one current runtime configuration to both mocked and real readers, without overwriting authored configuration. Existing coverage checks publication across RPC, reply preparation, and session writes, but does not distinguish several default-precedence, in-place edit, removal, and external-file-refresh regressions.

## Why This Change Was Made

Extend the existing atomic-writer cases and one connected RPC sequence rather than duplicating a pending-request matrix. The connected sequence now subsumes the standalone health-request fixture, including immediate real-reader visibility, exact workspace entries, and an explicit roster without an injected main agent.

## User Impact

No product behavior changes. Developers get stronger fixture-isolation regression coverage with less duplication than the original proposal. Runtime-only overrides stay runtime-only, deleted overrides reveal authored values, and actual `agents.list` responses reflect the published roster.

**Production/test-support delta: 0. Tests: +108/-35, net +73**, compared with the original slice's net +129. No product configuration keys, defaults, storage APIs, schemas, migrations, or dependencies change; all configuration and state are synthetic test fixtures.

## Evidence

On candidate tree `00525c5fe0beb8066033e4f7101586d5f8b95f52`, all **16 tests across both files passed in 17.878 seconds**, followed by the complete staged changed-scope gate in **171.067 seconds**.

```bash
node scripts/run-vitest.mjs src/gateway/test-helpers.server-env.test.ts src/gateway/test-helpers.server-rpc.test.ts
```

```bash
node scripts/check-changed.mjs --staged
```

Nine temporary fault controls failed at the intended assertions: authored-roster shadowing, reversed default precedence, persisted runtime overrides, identity-only caching, sticky deleted defaults, sticky removed rosters, stale authored-file reads, delayed publication, and dropped workspace fields. The last two specifically validated the consolidated replacement before the final healthy run. All controls are removed.

The connected test uses the existing suite-owned Gateway and checks real configuration immediately after RPC admission starts, then verifies the actual `agents.list` result and unchanged authored file. Existing queued-session-write and three-boundary publication coverage remains intact. This is isolated Gateway fixture proof, not a live-provider or production rollout claim.

Fresh isolated Codex review returned **scoped-clean at P0 across both partitions** in 34.869 seconds, with no findings; this is not an all-severity clean verdict. [Exact-head CI 34163083655](https://github.com/openclaw/openclaw/actions/runs/34163083655) passed on `1565e7052b0b81feb915acee9a784be9b197fbe7`.
