### PR TITLE
fix(deps): backport Undici security update for 2026.6.35

### DIFF
--- a/docs/tools/web-fetch.md
+++ b/docs/tools/web-fetch.md
@@ -174,7 +174,8 @@ outbound policy after DNS resolution.
 <Note>
   If no HTTP(S) proxy env var is configured, or the target host is excluded by
   `NO_PROXY`, `web_fetch` falls back to the normal strict path with local DNS
-  pinning.
+  pinning. Hostname matching ignores case and a single trailing DNS dot in
+  either the URL or the `NO_PROXY` entry.
 </Note>
 
 ## Limits and safety

--- a/extensions/browser/package.json
+++ b/extensions/browser/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*",
-    "undici": "8.9.0"
+    "undici": "8.10.2"
   },
   "openclaw": {
     "extensions": [

--- a/extensions/discord/npm-shrinkwrap.json
+++ b/extensions/discord/npm-shrinkwrap.json
@@ -12,7 +12,7 @@
         "discord-api-types": "0.38.48",
         "libopus-wasm": "0.2.0",
         "typebox": "1.1.39",
-        "undici": "8.9.0",
+        "undici": "8.10.2",
         "ws": "8.21.0"
       },
       "peerDependencies": {
@@ -399,9 +399,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
-      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/extensions/discord/package.json
+++ b/extensions/discord/package.json
@@ -12,7 +12,7 @@
     "discord-api-types": "0.38.48",
     "libopus-wasm": "0.2.0",
     "typebox": "1.1.39",
-    "undici": "8.9.0",
+    "undici": "8.10.2",
     "ws": "8.21.0"
   },
   "devDependencies": {

--- a/extensions/qa-matrix/package.json
+++ b/extensions/qa-matrix/package.json
@@ -5,7 +5,7 @@
   "description": "OpenClaw Matrix QA runner plugin",
   "type": "module",
   "dependencies": {
-    "undici": "8.9.0"
+    "undici": "8.10.2"
   },
   "devDependencies": {
     "@openclaw/matrix": "workspace:*",

--- a/extensions/telegram/package.json
+++ b/extensions/telegram/package.json
@@ -9,7 +9,7 @@
     "@grammyjs/transformer-throttler": "1.2.1",
     "grammy": "1.43.0",
     "typebox": "1.1.39",
-    "undici": "8.9.0"
+    "undici": "8.10.2"
   },
   "devDependencies": {
     "@openclaw/plugin-sdk": "workspace:*"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -58,7 +58,7 @@
         "tslog": "4.10.2",
         "typebox": "1.1.39",
         "typescript": "6.0.3",
-        "undici": "8.9.0",
+        "undici": "8.10.2",
         "web-push": "3.6.7",
         "web-tree-sitter": "0.26.9",
         "ws": "8.21.0",
@@ -3331,9 +3331,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.9.0.tgz",
-      "integrity": "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==",
+      "version": "8.10.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.2.tgz",
+      "integrity": "sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==",
       "license": "MIT",
       "engines": {
         "node": ">=22.19.0"

--- a/package.json
+++ b/package.json
@@ -1999,7 +1999,7 @@
     "tslog": "4.10.2",
     "typebox": "1.1.39",
     "typescript": "6.0.3",
-    "undici": "8.9.0",
+    "undici": "8.10.2",
     "web-push": "3.6.7",
     "web-tree-sitter": "0.26.9",
     "ws": "8.21.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,7 +89,7 @@ importers:
         version: 0.3.0
       '@openclaw/proxyline':
         specifier: 0.3.3
-        version: 0.3.3(undici@8.9.0)
+        version: 0.3.3(undici@8.10.2)
       chalk:
         specifier: 5.6.2
         version: 5.6.2
@@ -190,8 +190,8 @@ importers:
         specifier: 6.0.3
         version: 6.0.3
       undici:
-        specifier: 8.9.0
-        version: 8.9.0
+        specifier: 8.10.2
+        version: 8.10.2
       web-push:
         specifier: 3.6.7
         version: 3.6.7
@@ -444,8 +444,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/plugin-sdk
       undici:
-        specifier: 8.9.0
-        version: 8.9.0
+        specifier: 8.10.2
+        version: 8.10.2
 
   extensions/byteplus:
     devDependencies:
@@ -691,8 +691,8 @@ importers:
         specifier: 1.1.39
         version: 1.1.39
       undici:
-        specifier: 8.9.0
-        version: 8.9.0
+        specifier: 8.10.2
+        version: 8.10.2
       ws:
         specifier: 8.21.0
         version: 8.21.0
@@ -1369,8 +1369,8 @@ importers:
   extensions/qa-matrix:
     dependencies:
       undici:
-        specifier: 8.9.0
-        version: 8.9.0
+        specifier: 8.10.2
+        version: 8.10.2
     devDependencies:
       '@openclaw/matrix':
         specifier: workspace:*
@@ -1554,8 +1554,8 @@ importers:
         specifier: 1.1.39
         version: 1.1.39
       undici:
-        specifier: 8.9.0
-        version: 8.9.0
+        specifier: 8.10.2
+        version: 8.10.2
     devDependencies:
       '@openclaw/plugin-sdk':
         specifier: workspace:*
@@ -7502,8 +7502,8 @@ packages:
     resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
     engines: {node: '>=20.18.1'}
 
-  undici@8.9.0:
-    resolution: {integrity: sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA==}
+  undici@8.10.2:
+    resolution: {integrity: sha512-/y4/bH9YNU5hi9NIrpOuvGXFcxrj3CMrV+/AYpowAYTpHn8gX/XPFjNy766FPoYY0miQhdW977JFWKGNhBdwyQ==}
     engines: {node: '>=22.19.0'}
 
   unhomoglyph@1.0.6:
@@ -9232,9 +9232,9 @@ snapshots:
       jszip: 3.10.1
       tar: 7.5.22
 
-  '@openclaw/proxyline@0.3.3(undici@8.9.0)':
+  '@openclaw/proxyline@0.3.3(undici@8.10.2)':
     dependencies:
-      undici: 8.9.0
+      undici: 8.10.2
 
   '@opentelemetry/api-logs@0.220.0':
     dependencies:
@@ -14020,7 +14020,7 @@ snapshots:
 
   undici@7.29.0: {}
 
-  undici@8.9.0: {}
+  undici@8.10.2: {}
 
   unhomoglyph@1.0.6: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7498,8 +7498,8 @@ packages:
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
-  undici@7.29.0:
-    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+  undici@7.29.1:
+    resolution: {integrity: sha512-RYONW2MeafgYlkVOKYKkA/Ag7BmXqgIWCa8t1m0JcxrQg9pI9lEqRhAOruOBCbAohOa/gkCF+iPi9hrgvTzu6Q==}
     engines: {node: '>=20.18.1'}
 
   undici@8.10.2:
@@ -12002,7 +12002,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 4.1.3
-      undici: 7.29.0
+      undici: 7.29.1
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -14018,7 +14018,7 @@ snapshots:
 
   undici-types@7.24.6: {}
 
-  undici@7.29.0: {}
+  undici@7.29.1: {}
 
   undici@8.10.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,7 @@ minimumReleaseAge: 2880
 minimumReleaseAgeExclude:
   # GHSA-vp8m-p9jh-q5pm / GHSA-w293-vg96-wgc3 security fix; remove after 2026-09-12.
   - "undici@8.10.2"
+  - "undici@7.29.1"
   # Current fast-uri security baseline; remove after 2026-09-09.
   - "fast-uri@4.1.4"
   - "@openclaw/crabline@0.1.6"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,6 +7,8 @@ packages:
 minimumReleaseAge: 2880
 
 minimumReleaseAgeExclude:
+  # GHSA-vp8m-p9jh-q5pm / GHSA-w293-vg96-wgc3 security fix; remove after 2026-09-12.
+  - "undici@8.10.2"
   # Current fast-uri security baseline; remove after 2026-09-09.
   - "fast-uri@4.1.4"
   - "@openclaw/crabline@0.1.6"

--- a/src/infra/net/proxy-env.test.ts
+++ b/src/infra/net/proxy-env.test.ts
@@ -344,6 +344,23 @@ describe("matchesNoProxy", () => {
 
 describe("shouldUseEnvHttpProxyForUrl", () => {
   it.each([
+    ["https://api.example./v1", "example", false],
+    ["https://api.example/v1", "example.", false],
+    ["https://api.example.:8443/v1", "*.example.:8443", false],
+    ["https://api.example.:8443/v1", "*.example.:443", true],
+    ["https://notexample./v1", "example.", true],
+    ["https://api.example../v1", "example", true],
+    ["https://api.example./v1", ".", true],
+  ])("keeps NO_PROXY DNS-dot routing aligned for %s and %s", (url, noProxy, expected) => {
+    expect(
+      shouldUseEnvHttpProxyForUrl(url, {
+        HTTPS_PROXY: "http://proxy.test:8080",
+        NO_PROXY: noProxy,
+      }),
+    ).toBe(expected);
+  });
+
+  it.each([
     {
       name: "uses HTTPS_PROXY for https URLs",
       url: "https://api.example.com/v1",

--- a/src/infra/net/proxy-env.test.ts
+++ b/src/infra/net/proxy-env.test.ts
@@ -351,11 +351,11 @@ describe("shouldUseEnvHttpProxyForUrl", () => {
     ["https://notexample./v1", "example.", true],
     ["https://api.example../v1", "example", true],
     ["https://api.example./v1", ".", true],
-  ])("keeps NO_PROXY DNS-dot routing aligned for %s and %s", (url, noProxy, expected) => {
+  ])("keeps proxy-bypass DNS-dot routing aligned for %s and %s", (url, noProxy, expected) => {
     expect(
       shouldUseEnvHttpProxyForUrl(url, {
-        HTTPS_PROXY: "http://proxy.test:8080",
-        NO_PROXY: noProxy,
+        https_proxy: "http://proxy.test:8080",
+        no_proxy: noProxy,
       }),
     ).toBe(expected);
   });

--- a/src/infra/net/proxy-env.ts
+++ b/src/infra/net/proxy-env.ts
@@ -129,6 +129,7 @@ export function shouldUseEnvHttpProxyForUrl(
  * (`undici/lib/dispatcher/env-http-proxy-agent.js`):
  * - Entries separated by commas OR whitespace (undici splits on `/[,\s]/`)
  * - Case-insensitive
+ * - A single trailing DNS dot is ignored in both hosts and entries
  * - Empty or missing → no bypass
  * - Bare `*` value → bypass everything
  * - Exact hostname match
@@ -162,7 +163,11 @@ export function matchesNoProxy(targetUrl: string, env: NodeJS.ProcessEnv = proce
     return false;
   }
 
-  const targetHost = parsed.hostname.toLowerCase().replace(/^\[|\]$/g, "");
+  // Keep the eligibility gate aligned with Undici so direct bypasses retain DNS pinning.
+  const targetHost = parsed.hostname
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "")
+    .replace(/^(.+)\.$/, "$1");
   if (!targetHost) {
     return false;
   }
@@ -219,7 +224,7 @@ export function matchesNoProxy(targetUrl: string, env: NodeJS.ProcessEnv = proce
     // Mirror undici: strip optional leading `*` followed by `.` so both
     // `.example.com` and `*.example.com` normalize to `example.com`. That also
     // means apex hosts still match those entries after normalization.
-    const normalizedEntry = entryHost.replace(/^\*\./, "").replace(/^\./, "");
+    const normalizedEntry = entryHost.replace(/^\*?\./, "").replace(/^(.+)\.$/, "$1");
     if (!normalizedEntry || normalizedEntry === "*") {
       continue;
     }


### PR DESCRIPTION
## Summary

- backport main's reviewed Undici security repair from #139056 to the 2026.6.35 candidate
- move every candidate-owned Undici 8.x importer from 8.9.0 to patched 8.10.2 and its remaining jsdom edge from 7.29.0 to 7.29.1
- retain strict local DNS pinning for `NO_PROXY` hosts after Undici's trailing-dot matcher change

## Root cause

Full Release Validation run 34159146303 resolves the candidate at `01b26bf77af0d133bda9962b418cc8e755767068`. Its npm artifact dependency gate fails on GHSA-w293-vg96-wgc3 because the candidate still resolves production Undici 8.9.0:

- https://github.com/openclaw/openclaw/actions/runs/34159173339/job/101857249218

The upstream advisory marks 8.0.0 through 8.10.1 vulnerable and 8.10.2 patched. Undici's 8.10.2 `BalancedPool` constructor preserves function-valued `connect` and `tls` options outside its JSON clone instead of silently dropping custom TLS verification.

Direct dependency sources inspected:

- advisory: https://github.com/nodejs/undici/security/advisories/GHSA-w293-vg96-wgc3
- exact patched source: https://github.com/nodejs/undici/blob/v8.10.2/lib/dispatcher/balanced-pool.js#L51-L63

Main fixed this in #139056. This backport carries only the candidate's existing Undici 8.x importers, its transitive jsdom 7.x edge, exact lock refresh, temporary security-cooldown exceptions, and the proxy/DNS contract needed by the newer dispatcher. Main-only release-tool and plugin manifests are absent from this candidate and are intentionally not recreated.

## Verification

- `pnpm test src/infra/net/proxy-env.test.ts` — 62 passed
- `GH_TOKEN=... pnpm deps:vuln:gate -- --root "$PWD" --json /tmp/openclaw-undici-vuln.json --markdown /tmp/openclaw-undici-vuln.md` — 1 hard blocker before in hosted validation; 0 hard blockers / 1,355 resolved versions after
- `pnpm install --lockfile-only` — lockfile supply-chain policy passed
- `pnpm install --frozen-lockfile` — exact 1,355-entry lock passed supply-chain policy
- `pnpm deps:shrinkwrap:check` — root and all plugin shrinkwraps current
- `pnpm deps:changes:report -- --base-ref origin/extended-stable/2026.6.33 ...` — one package family changed: Undici 7.29.0/8.9.0 to 7.29.1/8.10.2; no package additions/removals
- `pnpm docs:list`
- `git diff --check`

Exact-head CI note: the network-runtime detector intentionally escalates the `NO_PROXY` test additions to full CodeQL, which is green. The separate compact-large failure is in untouched session-lock test scheduling (1 failure / 1,568 tests); its failed job was rerun without weakening or changing this backport.

## Scope

- production TypeScript: +5 net lines, preserving Undici `NO_PROXY` semantics
- tests: +17 lines
- remaining changes: exact dependency manifests/lock/shrinkwraps, cooldown policy, and two documentation lines
- no release publication, tag, or npm mutation

Backport of #139056 for the canonical `extended-stable/2026.6.33` candidate.
