### PR TITLE
fix: prevent published SDK compatibility verification timeouts

### DIFF
--- a/scripts/lib/vitest-worker-artifacts.mts
+++ b/scripts/lib/vitest-worker-artifacts.mts
@@ -20,6 +20,8 @@ export const vitestWorkerDeclarationEntries = {
     "test/fixtures/channel-ingress-gateway-restart-entrypoint.ts",
   "extensions/qa-lab/gateway-child-artifacts-runtime.test-support":
     "extensions/qa-lab/src/gateway-child-artifacts-runtime.test-support.ts",
+  "plugins/loader-sdk-bridge-artifacts.test-support":
+    "src/plugins/loader-sdk-bridge-artifacts.test-support.ts",
   "agents/code-mode-retention-entrypoint.test-support":
     "src/agents/code-mode-retention-entrypoint.test-support.ts",
   "agents/command/cli-compaction-runtime.test-support":

--- a/scripts/lib/vitest-worker-build-entries.mts
+++ b/scripts/lib/vitest-worker-build-entries.mts
@@ -19,6 +19,7 @@ import {
   triageMaintenanceRuntimeEntrypoints,
 } from "../../src/infra/triage-runtime.test-support.ts";
 import { nodeHostConfigRuntimeEntrypoint } from "../../src/node-host/config-runtime.test-support.ts";
+import { publishedSdkBridgeEntrypoints } from "../../src/plugins/loader-sdk-bridge-artifacts.test-support.ts";
 import { persistenceRuntimeEntrypoint } from "../../src/skills/library/persistence-runtime.test-support.ts";
 import {
   agentDatabaseHeldRuntimeEntrypoint,
@@ -38,6 +39,7 @@ export const vitestWorkerBuildEntries = {
       codeModeRetentionEntrypoint,
       codeModeDescriptionRetentionEntrypoint,
       ...cliCompactionBackendEntrypoints,
+      ...publishedSdkBridgeEntrypoints,
       ...Object.values(cliRecoveryEntrypoints),
       ...Object.values(gatewayDirectStopEntrypoints),
       ...Object.values(doctorConfigRuntimeEntrypoints),

--- a/src/plugins/loader-sdk-bridge-artifacts.test-support.ts
+++ b/src/plugins/loader-sdk-bridge-artifacts.test-support.ts
@@ -1,0 +1,19 @@
+// Published plugin compatibility uses the same compiled SDK graph as native execution.
+const currentModuleUrl = import.meta.url;
+export const publishedSdkBridgeEntrypoints = [
+  {
+    currentModuleUrl,
+    sourceWorkerName: "../plugin-sdk/runtime-doctor",
+    distWorkerPath: "plugin-sdk/runtime-doctor.js",
+  },
+  {
+    currentModuleUrl,
+    sourceWorkerName: "../plugin-sdk/channel-feedback",
+    distWorkerPath: "plugin-sdk/channel-feedback.js",
+  },
+  {
+    currentModuleUrl,
+    sourceWorkerName: "../plugin-sdk/channel-outbound",
+    distWorkerPath: "plugin-sdk/channel-outbound.js",
+  },
+] as const;

--- a/src/plugins/loader.native-module-loader.test.ts
+++ b/src/plugins/loader.native-module-loader.test.ts
@@ -1,8 +1,11 @@
 /** Verifies plugin loader behavior for native module loading and resolver hooks. */
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
+import { publishedSdkBridgeEntrypoints } from "./loader-sdk-bridge-artifacts.test-support.js";
 import { loadOpenClawPlugins } from "./loader.js";
 import { resetPluginCache } from "./plugin-cache.js";
 import { getPluginModuleLoaderStats } from "./plugin-module-loader-cache.js";
@@ -95,8 +98,8 @@ function writePreSplitSdkBridgeConsumerFixture() {
   // voice-call/matrix doctor contracts (runtime-doctor), whatsapp ack policy
   // (channel-feedback), slack progress-draft render (channel-outbound).
   // Covers both alias classes on purpose: runtime-doctor is private-local-only,
-  // the channel subpaths are public. A source checkout has no dist/, so every
-  // subpath listed here is evaluated through jiti — keep them light.
+  // the channel subpaths are public. The host fixture supplies real compiled
+  // SDK artifacts, matching the installed-package boundary.
   fs.writeFileSync(
     path.join(pluginRoot, "dist", "index.js"),
     [
@@ -195,10 +198,32 @@ describe("createPluginModuleLoader", () => {
 
   it("loads published pre-split SDK bridge imports (doctor repair, WhatsApp ack, Slack render)", () => {
     const pluginRoot = writePreSplitSdkBridgeConsumerFixture();
-    vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", tempDirs.make("openclaw-plugin-loader-"));
+    const [entrypoint] = publishedSdkBridgeEntrypoints;
+    const artifact = fileURLToPath(resolveRuntimeWorkerUrl(entrypoint));
+    const hasCompiledSdk = path.extname(artifact) === ".js";
+    if (hasCompiledSdk) {
+      const hostRoot = tempDirs.make("openclaw-sdk-bridge-host-");
+      fs.cpSync(path.dirname(path.dirname(artifact)), path.join(hostRoot, "dist"), {
+        recursive: true,
+      });
+      fs.copyFileSync(
+        path.resolve(import.meta.dirname, "../../package.json"),
+        path.join(hostRoot, "package.json"),
+      );
+      fs.mkdirSync(path.join(hostRoot, "src"));
+      fs.mkdirSync(path.join(hostRoot, "extensions"));
+      fs.symlinkSync(path.resolve("node_modules"), path.join(hostRoot, "node_modules"), "junction");
+      vi.stubEnv("OPENCLAW_DEV_SOURCE_ROOT", hostRoot);
+      vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", path.join(hostRoot, "extensions"));
+    } else {
+      // Standalone and watch-mode Vitest deliberately retain source declarations.
+      vi.stubEnv("OPENCLAW_BUNDLED_PLUGINS_DIR", tempDirs.make("openclaw-plugin-loader-"));
+    }
+    const before = getPluginModuleLoaderStats();
 
     const registry = loadOpenClawPlugins({
       cache: false,
+      pluginSdkResolution: hasCompiledSdk ? "dist" : "auto",
       onlyPluginIds: ["sdk-bridge-consumer"],
       config: {
         plugins: {
@@ -213,5 +238,10 @@ describe("createPluginModuleLoader", () => {
     const entry = registry.plugins.find((plugin) => plugin.id === "sdk-bridge-consumer");
     expect(entry?.error ?? null).toBeNull();
     expect(entry?.status).toBe("loaded");
+    if (hasCompiledSdk) {
+      const after = getPluginModuleLoaderStats();
+      expect(after.nativeHits).toBeGreaterThan(before.nativeHits);
+      expect(after.sourceTransformFallbacks).toBe(before.sourceTransformFallbacks);
+    }
   });
 });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release verification times out while checking published pre-split SDK bridge imports. The source-only fixture traverses the heavy SDK graph through Jiti; the [failed verification job](https://github.com/openclaw/openclaw/actions/runs/34159135860/job/101857400247) spent 131.7 seconds in a test with a 120-second limit.

## Why This Change Was Made

This maintainer-requested backport prepares the three real SDK bridge entries through the existing invocation-owned artifact builder and loads them with the native loader. It retains all nine export checks and successful registration checks, adds native-loading/no-fallback assertions, and preserves the original source path for standalone and watch runs. Production loading behavior and timeout limits are unchanged.

## User Impact

Maintainers get faster, reliable published-plugin compatibility verification. There is no application behavior change.

## Evidence

- Fresh main-based proof: 102 tests passed across the loader, alias, SDK bridge, module-cache, and artifact-owner suites; the bridge case took 2.9 seconds.
- The release fix also passed explicit standalone source-mode coverage with the unchanged timeout.
- Fresh independent P2 review found no actionable issues.
- Local changed-file checks and explicit pinned-base ratchets passed.
- [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34163258606).
