### PR TITLE
fix(setup): New Agent fails with protected provider credentials

### DIFF
--- a/src/commands/triage-target.test.ts
+++ b/src/commands/triage-target.test.ts
@@ -182,6 +182,7 @@ describe.skipIf(process.platform === "win32")("embedded triage installation targ
             agentId: "diagnostic",
             agentDir: state.statePath("agents", "diagnostic", "agent"),
             runConfig: config,
+            sourceConfig: config,
           },
           modelFallbacks: ["fixture/blocked", "blocked-provider/model", "fixture/fallback"],
           prompt: "Check the installation.",
@@ -230,6 +231,7 @@ describe.skipIf(process.platform === "win32")("embedded triage installation targ
           agentId: "diagnostic",
           agentDir: state.statePath("agents", "diagnostic", "agent"),
           runConfig: config,
+          sourceConfig: config,
         },
         modelFallbacks: [],
       });

--- a/src/config/runtime-snapshot.test.ts
+++ b/src/config/runtime-snapshot.test.ts
@@ -200,6 +200,52 @@ describe("runtime snapshot state", () => {
     },
   );
 
+  it("matches independently loaded config with equivalent resolution facts", () => {
+    const source = createProviderConfigFixture();
+    const freshRead = structuredClone(source);
+    const facts = () =>
+      createConfigResolutionFacts(
+        [],
+        new Map([["models.providers.openai.apiKey", "PROVIDER_KEY"]]),
+      );
+    setConfigResolutionFacts(source, facts());
+    setConfigResolutionFacts(freshRead, facts());
+    const runtime = createProviderConfigFixture("synthetic-runtime-key");
+    setRuntimeConfigSnapshot(runtime, source);
+
+    expect(getConfigResolutionFacts(freshRead)).not.toBe(getConfigResolutionFacts(source));
+    expect(createRuntimeConfigReader(freshRead)()).toBe(runtime);
+  });
+
+  it.each(["absent", "empty", "different-ref", "different-provider", "resolved", "unresolved"])(
+    "does not reuse runtime for same-byte config with %s resolution facts",
+    (kind) => {
+      const source = createProviderConfigFixture();
+      const input = structuredClone(source);
+      const refs = new Map([["models.providers.openai.apiKey", "PROVIDER_KEY"]]);
+      setConfigResolutionFacts(source, createConfigResolutionFacts([], refs));
+      if (kind !== "absent") {
+        setConfigResolutionFacts(
+          input,
+          createConfigResolutionFacts(
+            kind === "unresolved"
+              ? [{ configPath: "models.providers.openai.apiKey", varName: "PROVIDER_KEY" }]
+              : [],
+            kind === "resolved" || kind === "empty"
+              ? new Map()
+              : kind === "different-ref"
+                ? new Map([["models.providers.openai.apiKey", "OTHER_KEY"]])
+                : refs,
+            kind === "different-provider" ? "other" : "default",
+            kind === "resolved" ? refs : new Map(),
+          ),
+        );
+      }
+      setRuntimeConfigSnapshot(createProviderConfigFixture("synthetic-runtime-key"), source);
+      expect(createRuntimeConfigReader(input)()).toBe(input);
+    },
+  );
+
   it("clears runtime source snapshot when runtime snapshot is cleared", () => {
     setRuntimeConfigSnapshot({ gateway: { port: 18789 } }, { gateway: { port: 18789 } });
     resetRuntimeConfigState();

--- a/src/config/runtime-snapshot.ts
+++ b/src/config/runtime-snapshot.ts
@@ -1,11 +1,16 @@
 // Produces redacted runtime config snapshots for diagnostics and UI surfaces.
+import { isDeepStrictEqual } from "node:util";
 import { sha256Base64Url } from "../infra/crypto-digest.js";
 import { clearExecutablePathCache } from "../infra/executable-path.js";
 import {
   resetPublishedConfigRuntimeEnv,
   type PreparedConfigRuntimeEnv,
 } from "./config-env-vars.js";
-import { copyConfigResolutionFacts, getConfigResolutionFacts } from "./resolution-facts.js";
+import {
+  copyConfigResolutionFacts,
+  getConfigResolutionFacts,
+  serializeConfigResolutionFacts,
+} from "./resolution-facts.js";
 import type { OpenClawConfig } from "./types.js";
 
 export type RuntimeConfigSnapshotRefreshOptions = {
@@ -140,8 +145,12 @@ function configSnapshotsMatch(left: OpenClawConfig, right: OpenClawConfig): bool
   if (left === right) {
     return true;
   }
-  // Authored SecretRefs live outside the JSON bytes. Projection must not replace their provenance.
-  if (getConfigResolutionFacts(left) !== getConfigResolutionFacts(right)) {
+  // Fresh reads allocate new facts. Compare their complete provenance, not object identity
+  // or just JSON config bytes: same-byte values can name different authored SecretRefs.
+  if (
+    getConfigResolutionFacts(left) !== getConfigResolutionFacts(right) &&
+    !isDeepStrictEqual(serializeConfigResolutionFacts(left), serializeConfigResolutionFacts(right))
+  ) {
     return false;
   }
   try {

--- a/src/infra/update-repair-inference.test.ts
+++ b/src/infra/update-repair-inference.test.ts
@@ -51,6 +51,7 @@ vi.mock("../system-agent/inference-route.js", () => ({
       model: split.model.slice(slash + 1),
       modelLabel: split.model,
       runConfig: config,
+      sourceConfig: config,
       agentId,
       agentDir: `/isolated/${agentId}`,
       ...(split.profile ? { authProfileId: split.profile } : {}),

--- a/src/system-agent/inference-fallback.test.ts
+++ b/src/system-agent/inference-fallback.test.ts
@@ -11,6 +11,7 @@ function route(agentId: string, provider: string): SystemAgentConfiguredRoute {
     runner: "embedded",
     agentHarnessRuntimeOverride: "openclaw",
     runConfig: {},
+    sourceConfig: {},
     modelLabel: `${provider}/model`,
     provider,
     model: "model",

--- a/src/system-agent/inference-fallback.ts
+++ b/src/system-agent/inference-fallback.ts
@@ -3,7 +3,7 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { resolveAmbientOwnerAgentId } from "../agents/agent-scope-config.js";
 import { listAgentIds } from "../agents/agent-scope.js";
 import { hasAvailableAuthForProvider } from "../agents/model-auth.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import type { RuntimeEnv } from "../runtime.js";
 import {
@@ -44,13 +44,9 @@ type InferenceFallbackDeps = {
   }) => Promise<BoundVerifySetupInferenceResult>;
 };
 
-async function readCurrentConfig(): Promise<OpenClawConfig> {
+async function readCurrentSnapshot(): Promise<ConfigFileSnapshot> {
   const { readConfigFileSnapshot } = await import("../config/config.js");
-  const snapshot = await readConfigFileSnapshot();
-  if (!snapshot.exists || !snapshot.valid) {
-    return {};
-  }
-  return snapshot.runtimeConfig ?? snapshot.config;
+  return await readConfigFileSnapshot();
 }
 
 type InferenceFallbackParams = {
@@ -82,13 +78,21 @@ export async function verifySystemAgentInferenceWithFallback(
 ): Promise<BoundVerifySetupInferenceResult | ConfiguredRouteResult> {
   const deps = params.deps ?? {};
   const routePolicy = params.routePolicy;
-  const config = await (deps.readConfig ?? readCurrentConfig)();
+  const snapshot = deps.readConfig ? undefined : await readCurrentSnapshot();
+  const config = deps.readConfig
+    ? await deps.readConfig()
+    : snapshot?.exists && snapshot.valid
+      ? (snapshot.runtimeConfig ?? snapshot.config)
+      : {};
   const requestedAgentId = resolveAmbientOwnerAgentId(config, params.requestingAgentId);
   const candidateAgentIds = new Set([
     requestedAgentId,
     ...listAgentIds(config).map((agentId) => normalizeAgentId(agentId)),
   ]);
-  const resolveRoute = deps.resolveRoute ?? resolveSystemAgentConfiguredRouteFromConfig;
+  const resolveRoute =
+    deps.resolveRoute ??
+    ((candidateConfig: OpenClawConfig, agentId: string) =>
+      resolveSystemAgentConfiguredRouteFromConfig(candidateConfig, agentId, {}, snapshot));
   const routes: Array<{ agentId: string; provider: string; route: SystemAgentConfiguredRoute }> =
     [];
   for (const agentId of candidateAgentIds) {
@@ -154,7 +158,7 @@ export async function verifySystemAgentInferenceWithFallback(
       candidate !== first &&
       !(await hasAuth({
         provider: candidate.provider,
-        cfg: config,
+        cfg: candidate.route.runConfig,
         preferredProfile: candidate.route.authProfileId,
         agentDir: candidate.route.agentDir,
         modelId: candidate.route.model,

--- a/src/system-agent/inference-route-runtime.test.ts
+++ b/src/system-agent/inference-route-runtime.test.ts
@@ -1,0 +1,394 @@
+import fs from "node:fs/promises";
+import path from "node:path";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { resolveAgentDir } from "../agents/agent-scope.js";
+import { upsertAuthProfile } from "../agents/auth-profiles/profiles.js";
+import { ensureAuthProfileStore } from "../agents/auth-profiles/store-runtime.js";
+import { fingerprintResolvedProviderAuth } from "../agents/execution-auth-binding.js";
+import { resolveManagedSecretRefRuntimeProviderAuth } from "../agents/model-auth-runtime-config.js";
+import { resolveApiKeyForProviderCore } from "../agents/model-auth.js";
+import { prepareAgentRuntimeAuth } from "../agents/runtime-plan/prepare-auth.js";
+import { readConfigFileSnapshot } from "../config/config.js";
+import { cloneConfigWithResolutionFacts } from "../config/resolution-facts.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import {
+  activateSecretsRuntimeSnapshotWithSource,
+  clearSecretsRuntimeSnapshot,
+  prepareSecretsRuntimeSnapshot,
+} from "../secrets/runtime.js";
+import { looksLikeSecretSentinel } from "../secrets/sentinel.js";
+import { writeSecretStoreEntry } from "../secrets/store/secret-store.js";
+import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js";
+import { verifySystemAgentInferenceWithFallback } from "./inference-fallback.js";
+import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
+import { activateSetupInference } from "./setup-inference-activate.js";
+import { completeSetupInference, verifySetupInference } from "./setup-inference-verify.js";
+import {
+  createSystemAgentVerifiedInferenceBinding,
+  resolveSystemAgentVerifiedInferenceRoute,
+} from "./verified-inference.js";
+
+const key = "synthetic-setup-test-key";
+const secretRef = { source: "store", provider: "default", id: "SETUP_TEST_KEY" } as const;
+const readSnapshot = () =>
+  readConfigFileSnapshot({ observe: false, pluginValidation: "core-only" });
+let temp: TempHomeEnv;
+let configPath: string;
+
+async function readRuntime() {
+  const snapshot = await readSnapshot();
+  expect(snapshot.valid, JSON.stringify(snapshot.issues)).toBe(true);
+  return snapshot.runtimeConfig ?? snapshot.config;
+}
+
+async function activate() {
+  const snapshot = await readSnapshot();
+  expect(snapshot.valid, JSON.stringify(snapshot.issues)).toBe(true);
+  activateSecretsRuntimeSnapshotWithSource(
+    await prepareSecretsRuntimeSnapshot({
+      config: snapshot.runtimeConfig,
+      env: process.env,
+      includeAuthStoreRefs: false,
+      manifestRegistry: { plugins: [] },
+      loadablePluginOrigins: new Map(),
+    }),
+    snapshot.sourceConfig,
+  );
+}
+
+function storeKey(value: string) {
+  writeSecretStoreEntry({
+    scope: { kind: "team" },
+    name: secretRef.id,
+    value,
+    kind: "secret",
+    allowedHosts: ["provider.example"],
+    updatedBy: "test",
+  });
+}
+
+beforeEach(async () => {
+  temp = await createTempHomeEnv("openclaw-setup-runtime-");
+  configPath = path.join(temp.home, ".openclaw", "openclaw.json");
+  vi.stubEnv("OPENCLAW_CONFIG_PATH", configPath);
+  vi.stubEnv("OPENCLAW_SECRET_SENTINELS", "1");
+  const config: OpenClawConfig = {
+    plugins: { enabled: false },
+    agents: {
+      defaults: { model: "fixture/test-model" },
+      entries: { main: { workspace: path.join(temp.home, "workspace") } },
+    },
+    models: {
+      providers: {
+        fixture: {
+          api: "openai-responses",
+          baseUrl: "https://provider.example/v1",
+          apiKey: secretRef,
+          models: [
+            {
+              id: "test-model",
+              name: "Fixture",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 32000,
+              maxTokens: 1000,
+            },
+          ],
+        },
+      },
+    },
+  };
+  await fs.writeFile(configPath, JSON.stringify(config));
+  storeKey(key);
+  await activate();
+});
+
+afterEach(async () => {
+  clearSecretsRuntimeSnapshot();
+  vi.unstubAllEnvs();
+  await temp?.restore();
+});
+
+it("keeps protected credentials through a fresh setup read and verified-route revalidation", async () => {
+  const snapshot = await readSnapshot();
+  const source = snapshot.runtimeConfig;
+  expect(source).not.toEqual(snapshot.sourceConfig);
+  const route = await resolveSystemAgentConfiguredRouteFromConfig(
+    source,
+    "main",
+    { pluginMetadataPlugins: [] },
+    snapshot,
+  );
+  expect(route).not.toBeNull();
+  expect(route!.runConfig.agents?.entries).toHaveProperty("openclaw");
+  expect(snapshot.sourceConfig.agents?.defaults?.maxConcurrent).toBeUndefined();
+  expect(route!.runConfig.agents?.defaults?.maxConcurrent).toBeGreaterThan(0);
+  expect(
+    resolveManagedSecretRefRuntimeProviderAuth({ cfg: route!.runConfig, provider: "fixture" })
+      ?.apiKey,
+  ).toBe(key);
+  const auth = await resolveApiKeyForProviderCore({
+    cfg: route!.runConfig,
+    provider: "fixture",
+    modelId: "test-model",
+    modelApi: "openai-responses",
+    agentDir: route!.agentDir,
+    store: { version: 1, profiles: {} },
+    allowAuthProfileFallback: false,
+    secretSentinels: true,
+  });
+  const binding = await createSystemAgentVerifiedInferenceBinding({
+    configuredRoute: route!,
+    executionRoute: route!,
+    auth: {
+      agentHarnessId: "openclaw",
+      modelId: "test-model",
+      modelApi: "openai-responses",
+      authFingerprint: fingerprintResolvedProviderAuth(auth),
+    },
+    deps: { pluginMetadataPlugins: [] },
+  });
+  const deps = { readConfigFileSnapshot: readSnapshot, pluginMetadataPlugins: [] };
+  expect(await resolveSystemAgentVerifiedInferenceRoute(binding, deps)).not.toBeNull();
+  // Neither the persisted input nor the configured-route fingerprint may contain the key.
+  expect(source.models?.providers?.fixture?.apiKey).toEqual(secretRef);
+  expect(JSON.stringify(binding.executionFingerprint)).not.toContain(key);
+  expect(await fs.readFile(configPath, "utf8")).not.toContain(key);
+
+  storeKey("synthetic-rotated-key");
+  await activate();
+  expect(await resolveSystemAgentVerifiedInferenceRoute(binding, deps)).toBeNull();
+});
+
+it.each([
+  {
+    label: "protected key",
+    entrypoint: "verify",
+    rotateBeforeBinding: false,
+    alternateProfile: false,
+  },
+  {
+    label: "key rotated during probe",
+    entrypoint: "verify",
+    rotateBeforeBinding: true,
+    alternateProfile: false,
+  },
+  {
+    label: "alternate profile available",
+    entrypoint: "verify",
+    rotateBeforeBinding: false,
+    alternateProfile: true,
+  },
+  {
+    label: "completion",
+    entrypoint: "complete",
+    rotateBeforeBinding: false,
+    alternateProfile: false,
+  },
+  {
+    label: "existing-model activation",
+    entrypoint: "activate",
+    rotateBeforeBinding: false,
+    alternateProfile: false,
+  },
+  {
+    label: "non-default fallback owner",
+    entrypoint: "fallback",
+    rotateBeforeBinding: false,
+    alternateProfile: false,
+  },
+])(
+  "verifies the actual setup entrypoint: $label",
+  async ({ entrypoint, rotateBeforeBinding, alternateProfile }) => {
+    if (entrypoint === "fallback") {
+      const config = (await readSnapshot()).sourceConfig;
+      config.agents!.ownership = "explicit";
+      config.agents!.defaults!.systemAgent = { agentId: "main" };
+      config.agents!.entries!.engineering = {
+        model: "fixture/test-model",
+        params: { temperature: 0.1 },
+      };
+      await fs.writeFile(configPath, JSON.stringify(config));
+      await activate();
+      expect((await readRuntime()).agents?.entries).toHaveProperty("engineering");
+    }
+    if (alternateProfile) {
+      upsertAuthProfile({
+        agentDir: resolveAgentDir(await readRuntime(), "main"),
+        profileId: "fixture:alternate",
+        credential: { type: "api_key", provider: "fixture", key: "synthetic-alternate-key" },
+      });
+    }
+    const runEmbeddedAgent = vi.fn<
+      NonNullable<
+        NonNullable<Parameters<typeof verifySetupInference>[0]["deps"]>["runEmbeddedAgent"]
+      >
+    >(async (params) => {
+      // Replace only the model turn; use the real planner and credential resolver.
+      const store = ensureAuthProfileStore(params.agentDir);
+      const prepared = prepareAgentRuntimeAuth({
+        config: params.config,
+        provider: "fixture",
+        modelId: "test-model",
+        modelApi: "openai-responses",
+        modelBaseUrl: "https://provider.example/v1",
+        agentDir: params.agentDir,
+        env: {},
+        metadataSnapshot: resolvePluginMetadataSnapshot({
+          config: params.config,
+          workspaceDir: params.workspaceDir,
+          env: process.env,
+        }),
+        authProfileStore: store,
+      });
+      const attempt = prepared.attempts[0];
+      if (attempt?.kind !== "direct") {
+        throw new Error("Expected the configured direct provider credential");
+      }
+      expect(attempt.allowAuthProfileFallback).toBe(false);
+      const auth = await resolveApiKeyForProviderCore({
+        cfg: params.config,
+        provider: "fixture",
+        modelId: "test-model",
+        modelApi: "openai-responses",
+        agentDir: params.agentDir,
+        store,
+        allowAuthProfileFallback: attempt.allowAuthProfileFallback,
+        secretSentinels: true,
+      });
+      expect(looksLikeSecretSentinel(auth.apiKey ?? "")).toBe(true);
+      params.onSuccessfulAuthBinding?.({
+        agentHarnessId: "openclaw",
+        modelId: "test-model",
+        modelApi: "openai-responses",
+        authFingerprint: fingerprintResolvedProviderAuth(auth),
+      });
+      if (rotateBeforeBinding) {
+        storeKey("synthetic-rotated-key");
+        await activate();
+      }
+      return {
+        meta: {
+          durationMs: 1,
+          finalAssistantVisibleText: "OK",
+          executionTrace: { winnerProvider: "fixture", winnerModel: "test-model" },
+        },
+      };
+    });
+    const runtime = {
+      log() {},
+      error() {},
+      exit() {
+        throw new Error("Unexpected exit");
+      },
+    };
+    const deps = {
+      readConfigFileSnapshot: readSnapshot,
+      createTempDir: () => fs.mkdtemp(path.join(temp.home, "probe-")),
+      runEmbeddedAgent,
+    };
+    const attemptedOwners: string[] = [];
+    const result =
+      entrypoint === "complete"
+        ? await completeSetupInference({ prompt: "Reply with OK", runtime, deps })
+        : entrypoint === "activate"
+          ? await activateSetupInference({
+              kind: "existing-model",
+              surface: "gateway",
+              runtime,
+              deps,
+            })
+          : entrypoint === "fallback"
+            ? await verifySystemAgentInferenceWithFallback({
+                runtime,
+                deps: {
+                  verify: async (params) => {
+                    attemptedOwners.push(params.agentId);
+                    return params.agentId === "main"
+                      ? { ok: false, status: "auth", error: "Primary owner unavailable" }
+                      : verifySetupInference({ ...params, deps });
+                  },
+                },
+              })
+            : await verifySetupInference({ agentId: "main", bindSession: true, runtime, deps });
+    expect(result.ok, result.ok ? undefined : result.error).toBe(!rotateBeforeBinding);
+    expect(runEmbeddedAgent).toHaveBeenCalledOnce();
+    if (result.ok && "binding" in result) {
+      expect(
+        await resolveSystemAgentVerifiedInferenceRoute(result.binding, {
+          readConfigFileSnapshot: readSnapshot,
+          pluginMetadataPlugins: [],
+        }),
+      ).not.toBeNull();
+      if (entrypoint === "fallback") {
+        expect(attemptedOwners).toEqual(["main", "engineering"]);
+        expect(result.binding.execution.agentId).toBe("engineering");
+        expect(result.binding.execution.runConfig.agents?.entries?.openclaw?.params).toEqual({
+          temperature: 0.1,
+        });
+      }
+    } else if (!result.ok) {
+      expect(result.error).toContain("owner changed");
+    }
+    expect((await readRuntime()).models?.providers?.fixture?.apiKey).toEqual(secretRef);
+  },
+);
+
+it.each([
+  { field: "destination", saved: false },
+  { field: "destination", saved: true },
+  { field: "reference", saved: false },
+  { field: "reference", saved: true },
+])(
+  "does not lend the active key after changing $field (saved: $saved)",
+  async ({ field, saved }) => {
+    let snapshot = await readSnapshot();
+    let candidate = cloneConfigWithResolutionFacts(snapshot.runtimeConfig);
+    const provider = candidate.models?.providers?.fixture;
+    if (!provider) {
+      throw new Error("Missing fixture provider");
+    }
+    const expectedRef = field === "reference" ? { ...secretRef, id: "OTHER_KEY" } : secretRef;
+    provider.apiKey = expectedRef;
+    if (field === "destination") {
+      provider.baseUrl = "https://other.example/v1";
+    }
+    if (saved) {
+      await fs.writeFile(configPath, JSON.stringify(candidate));
+      snapshot = await readSnapshot();
+      candidate = snapshot.runtimeConfig;
+    }
+    // A changed candidate with the old read, or a fresh read whose new source is
+    // not active yet: neither may reuse credentials prepared for the old owner.
+    const route = await resolveSystemAgentConfiguredRouteFromConfig(
+      candidate,
+      "main",
+      { pluginMetadataPlugins: [] },
+      snapshot,
+    );
+    expect(route).not.toBeNull();
+    expect(
+      resolveManagedSecretRefRuntimeProviderAuth({ cfg: route!.runConfig, provider: "fixture" }),
+    ).toBeUndefined();
+    expect(route!.runConfig.models?.providers?.fixture?.apiKey).toEqual(expectedRef);
+  },
+);
+
+it("retains the materialized view when no prepared runtime is active", async () => {
+  clearSecretsRuntimeSnapshot();
+  const snapshot = await readSnapshot();
+  const route = await resolveSystemAgentConfiguredRouteFromConfig(
+    snapshot.runtimeConfig,
+    "main",
+    { pluginMetadataPlugins: [] },
+    snapshot,
+  );
+  expect(route).not.toBeNull();
+  expect(route!.runConfig.agents?.defaults?.maxConcurrent).toBeGreaterThan(0);
+  expect(route!.runConfig.models?.providers?.fixture?.apiKey).toEqual(secretRef);
+  expect(
+    resolveManagedSecretRefRuntimeProviderAuth({ cfg: route!.runConfig, provider: "fixture" }),
+  ).toBeUndefined();
+});

--- a/src/system-agent/inference-route.ts
+++ b/src/system-agent/inference-route.ts
@@ -10,12 +10,16 @@ import {
   cliBackendAcceptsAuthProfileForwarding,
   resolveCliExecutionAuthProfileId,
 } from "../agents/cli-execution-auth.js";
-import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { copyConfigResolutionFacts } from "../config/resolution-facts.js";
+import { createRuntimeConfigReader } from "../config/runtime-snapshot.js";
+import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { SYSTEM_AGENT_ID } from "./agent-id.js";
 
 export type SystemAgentConfiguredRoute = {
+  /** Unprojected input, kept separate from prepared execution credentials. */
+  sourceConfig: OpenClawConfig;
   runConfig: OpenClawConfig;
   modelLabel: string;
   provider: string;
@@ -41,10 +45,16 @@ type SystemAgentRouteProjectionDeps = Pick<
   "loadAuthProfileStoreForRuntime" | "pluginMetadataPlugins"
 >;
 
+/** The canonical source and default-materialized view from one authoritative read. */
+export type SystemAgentConfigSnapshot = Pick<
+  ConfigFileSnapshot,
+  "sourceConfig" | "runtimeConfig" | "config"
+>;
+
 type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
 
 export type DefaultInferenceRouteProjection = {
-  route: DistributiveOmit<SystemAgentConfiguredRoute, "runConfig"> | null;
+  route: DistributiveOmit<SystemAgentConfiguredRoute, "runConfig" | "sourceConfig"> | null;
   defaultSelection: { explicitIds: string[]; fallbackId?: string };
   auth: unknown;
   models: unknown;
@@ -73,20 +83,33 @@ function projectSystemAgentExecutionConfig(
     },
   ];
   const { list: _legacyList, ...agentsConfig } = config.agents ?? {};
-  return {
+  const projected = {
     ...config,
     agents: {
       ...agentsConfig,
       entries: toAgentEntriesRecord(projectedAgents),
     },
   };
+  copyConfigResolutionFacts(config, projected);
+  return projected;
 }
 
 export async function resolveSystemAgentConfiguredRouteFromConfig(
   runConfig: OpenClawConfig,
   requestedAgentId?: string,
   deps: SystemAgentRouteProjectionDeps = {},
+  configSnapshot?: SystemAgentConfigSnapshot,
 ): Promise<SystemAgentConfiguredRoute | null> {
+  // Match before adding the reserved execution agent changes the source shape.
+  // Gateway publication owns the canonical source, not the default-materialized
+  // view. Only that exact view may use its paired source; a staged candidate must
+  // match on its own, even when its caller still holds the original snapshot.
+  const source =
+    configSnapshot && runConfig === (configSnapshot.runtimeConfig ?? configSnapshot.config)
+      ? configSnapshot.sourceConfig
+      : runConfig;
+  const prepared = createRuntimeConfigReader(source)();
+  const preparedConfig = prepared === source ? runConfig : prepared;
   const [agentScope, modelSelection, modelRuntimeAliases, simpleCompletion, harnessPolicy] =
     await Promise.all([
       import("../agents/agent-scope.js"),
@@ -147,8 +170,9 @@ export async function resolveSystemAgentConfiguredRouteFromConfig(
       })
     : undefined;
   const authProfileId = allowCliAuthProfileForwarding ? cliAuthProfileId : selection.profileId;
-  const executionConfig = projectSystemAgentExecutionConfig(runConfig, modelOwnerAgentId);
+  const executionConfig = projectSystemAgentExecutionConfig(preparedConfig, modelOwnerAgentId);
   const base = {
+    sourceConfig: runConfig,
     runConfig: executionConfig,
     modelLabel: `${selection.provider}/${selection.modelId}`,
     provider: executionProvider,
@@ -277,7 +301,7 @@ export async function projectInferenceRoute(
     Object.values(agentRouteOverrides).some((value) => value !== undefined);
   let projectedRoute: DefaultInferenceRouteProjection["route"] = null;
   if (route) {
-    const { runConfig: _runConfig, ...routeWithoutConfig } = route;
+    const { runConfig: _runConfig, sourceConfig: _sourceConfig, ...routeWithoutConfig } = route;
     projectedRoute = routeWithoutConfig;
   }
   return {

--- a/src/system-agent/revalidate-inference-owner.test.ts
+++ b/src/system-agent/revalidate-inference-owner.test.ts
@@ -36,6 +36,7 @@ function embeddedRoute(agentHarnessRuntimeOverride: string): SystemAgentConfigur
     agentId: "main",
     agentDir: "/tmp/openclaw-agent",
     agentHarnessRuntimeOverride,
+    sourceConfig: {},
     runConfig: {
       agents: {
         defaults: {

--- a/src/system-agent/setup-inference-activate.ts
+++ b/src/system-agent/setup-inference-activate.ts
@@ -181,6 +181,7 @@ async function activateSetupInferenceUnredacted(
       ...(params.apiKey !== undefined ? { apiKey: params.apiKey } : {}),
       cfg,
       sourceCfg,
+      configSnapshot: snapshot,
       workspaceDir: tempDir,
       pluginWorkspaceDir: workspace,
       agentDir: testAgentDir,
@@ -471,6 +472,7 @@ async function activateSetupInferenceUnredacted(
       testPlan.config,
       requestedAgentId,
       routeDeps,
+      snapshot,
     );
     if (
       !stagedRoute ||
@@ -627,6 +629,7 @@ async function activateSetupInferenceUnredacted(
             latestRuntime,
             requestedAgentId,
             routeDeps,
+            latestSnapshot,
           )
         : null;
       if (!latestResolvedRoute) {

--- a/src/system-agent/setup-inference-plan.ts
+++ b/src/system-agent/setup-inference-plan.ts
@@ -31,7 +31,10 @@ import type { ProviderAuthResult } from "../plugins/types.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { createPluginCapabilityConsentPrompter } from "../wizard/plugin-capability-consent.js";
 import type { WizardPrompter } from "../wizard/prompts.js";
-import { resolveSystemAgentConfiguredRouteFromConfig } from "./inference-route.js";
+import {
+  resolveSystemAgentConfiguredRouteFromConfig,
+  type SystemAgentConfigSnapshot,
+} from "./inference-route.js";
 import { createQuickstartNotePrompter } from "./setup-apply.js";
 import {
   supportsSetupManualSecret,
@@ -104,6 +107,7 @@ export async function buildTestPlan(params: {
   apiKey?: string;
   cfg: OpenClawConfig;
   sourceCfg: OpenClawConfig;
+  configSnapshot?: SystemAgentConfigSnapshot;
   workspaceDir: string;
   pluginWorkspaceDir: string;
   agentDir: string;
@@ -207,9 +211,12 @@ export async function buildTestPlan(params: {
     case "existing-model": {
       let route;
       try {
-        route = await resolveSystemAgentConfiguredRouteFromConfig(cfg, params.routeAgentId, {
-          loadAuthProfileStoreForRuntime: params.deps.loadAuthProfileStoreForRuntime,
-        });
+        route = await resolveSystemAgentConfiguredRouteFromConfig(
+          cfg,
+          params.routeAgentId,
+          { loadAuthProfileStoreForRuntime: params.deps.loadAuthProfileStoreForRuntime },
+          params.configSnapshot,
+        );
       } catch (error) {
         if (error instanceof CliExecutionAuthProfileError) {
           return { error: error.message, status: "auth" as const };

--- a/src/system-agent/setup-inference-verify.ts
+++ b/src/system-agent/setup-inference-verify.ts
@@ -14,6 +14,7 @@ import {
   projectInferenceRoute,
   resolveSystemAgentConfiguredRouteFromConfig,
   sameDefaultInferenceRoute,
+  type SystemAgentConfigSnapshot,
   type SystemAgentConfiguredRoute,
 } from "./inference-route.js";
 import {
@@ -87,6 +88,7 @@ export async function verifySetupInference(
   let verifiedBinding: SystemAgentVerifiedInferenceBinding | undefined;
   const verification = await verifySetupInferenceConfig({
     config: cfg,
+    configSnapshot: snapshot,
     runtime: params.runtime,
     requireExecutionOwner: params.bindSession === true,
     ...(params.agentId ? { agentId: params.agentId } : {}),
@@ -125,7 +127,12 @@ export async function verifySetupInference(
   if (!params.bindSession) {
     return verification;
   }
-  const configuredRoute = await resolveSystemAgentConfiguredRouteFromConfig(cfg, params.agentId);
+  const configuredRoute = await resolveSystemAgentConfiguredRouteFromConfig(
+    cfg,
+    params.agentId,
+    {},
+    snapshot,
+  );
   if (!configuredRoute || !verifiedBinding) {
     return {
       ok: false,
@@ -151,7 +158,7 @@ export type ResolvePersistentApplyInferenceDeps = SystemAgentVerifiedInferenceDe
 };
 
 function executionRouteIdentity(route: SystemAgentConfiguredRoute): unknown {
-  const { runConfig: _runConfig, ...identity } = route;
+  const { runConfig: _runConfig, sourceConfig: _sourceConfig, ...identity } = route;
   return identity;
 }
 
@@ -214,6 +221,8 @@ export async function resolvePersistentApplyInference(params: {
 /** Live-test a staged default-agent route before any caller persists it. */
 export async function verifySetupInferenceConfig(params: {
   config: OpenClawConfig;
+  /** Present only when config is the unchanged runtime view from this read. */
+  configSnapshot?: SystemAgentConfigSnapshot;
   /** Interactive candidate activation verifies managed tool-capable models before persistence. */
   verifyAgentTools?: boolean;
   /** Candidate profiles staged in the isolated probe store, never the real agent store. */
@@ -253,6 +262,7 @@ export async function verifySetupInferenceConfig(params: {
       kind: "existing-model",
       cfg,
       sourceCfg: cfg,
+      configSnapshot: params.configSnapshot,
       workspaceDir: tempDir,
       pluginWorkspaceDir: tempDir,
       agentDir: path.join(tempDir, "agent"),
@@ -348,7 +358,12 @@ export async function verifySetupInferenceConfig(params: {
     let stagedOwnerPluginArtifacts: SystemAgentOwnerPluginArtifactSnapshot | undefined;
     if (requiresExecutionOwner) {
       configuredRoute =
-        (await resolveSystemAgentConfiguredRouteFromConfig(cfg, routeAgentId)) ?? undefined;
+        (await resolveSystemAgentConfiguredRouteFromConfig(
+          cfg,
+          routeAgentId,
+          {},
+          params.configSnapshot,
+        )) ?? undefined;
       if (!configuredRoute) {
         return {
           ok: false,
@@ -483,6 +498,7 @@ export async function completeSetupInference(params: {
   }
   return await completeSetupInferenceConfig({
     config: snapshot.runtimeConfig ?? snapshot.config,
+    configSnapshot: snapshot,
     prompt: params.prompt,
     ...(params.agentId ? { agentId: params.agentId } : {}),
     runtime: params.runtime,
@@ -494,6 +510,7 @@ export async function completeSetupInference(params: {
 /** Config-injected variant used by setup clients and live provider tests. */
 export async function completeSetupInferenceConfig(params: {
   config: OpenClawConfig;
+  configSnapshot?: SystemAgentConfigSnapshot;
   prompt: string;
   agentId?: string;
   runtime: RuntimeEnv;
@@ -516,6 +533,7 @@ export async function completeSetupInferenceConfig(params: {
       kind: "existing-model",
       cfg: params.config,
       sourceCfg: params.config,
+      configSnapshot: params.configSnapshot,
       workspaceDir: tempDir,
       pluginWorkspaceDir: tempDir,
       agentDir: path.join(tempDir, "agent"),

--- a/src/system-agent/setup-inference.test.ts
+++ b/src/system-agent/setup-inference.test.ts
@@ -5889,6 +5889,7 @@ describe("resolvePersistentApplyInference", () => {
     const execution = {
       runner: "embedded" as const,
       runConfig: { agents: { defaults: { model: "openai/gpt-5.5" } } },
+      sourceConfig: { agents: { defaults: { model: "openai/gpt-5.5" } } },
       modelLabel: "openai/gpt-5.5",
       provider: "openai",
       model: "gpt-5.5",

--- a/src/system-agent/verified-inference.ts
+++ b/src/system-agent/verified-inference.ts
@@ -25,6 +25,7 @@ import { resolveAgentHarnessOwnerPluginIds } from "../agents/harness/runtime-plu
 import type { AgentHarnessAuthBindingFingerprintParams } from "../agents/harness/types.js";
 import type { ResolvedProviderAuth } from "../agents/model-auth-runtime-shared.js";
 import { resolveApiKeyForProviderCore } from "../agents/model-auth.js";
+import { cloneConfigWithResolutionFacts } from "../config/resolution-facts.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { normalizePluginsConfig } from "../plugins/config-state.js";
 import { passesManifestOwnerBasePolicy } from "../plugins/manifest-owner-policy.js";
@@ -48,7 +49,7 @@ import {
 type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
 type SystemAgentConfiguredRouteIdentity = DistributiveOmit<
   SystemAgentConfiguredRoute,
-  "runConfig" | "authProfileId"
+  "runConfig" | "sourceConfig" | "authProfileId"
 >;
 type SystemAgentVerifiedExecutionRoute =
   | Extract<SystemAgentConfiguredRoute, { runner: "cli" }>
@@ -219,7 +220,12 @@ async function resolveAgentHarnessAuthBindingFingerprint(params: {
 function systemAgentRouteIdentity(
   route: SystemAgentConfiguredRoute,
 ): SystemAgentConfiguredRouteIdentity {
-  const { runConfig: _runConfig, authProfileId: _authProfileId, ...identity } = route;
+  const {
+    runConfig: _runConfig,
+    sourceConfig: _sourceConfig,
+    authProfileId: _authProfileId,
+    ...identity
+  } = route;
   return identity;
 }
 
@@ -642,7 +648,7 @@ async function resolveCurrentAuthFingerprint(params: {
     ),
     ...(params.authProfileId
       ? { profileId: params.authProfileId, lockedProfile: true as const }
-      : {}),
+      : { allowAuthProfileFallback: false }),
     modelId: params.modelId,
     modelApi: params.modelApi,
     secretSentinels: true,
@@ -660,9 +666,10 @@ export async function createSystemAgentVerifiedInferenceBinding(params: {
   deps?: SystemAgentVerifiedInferenceDeps;
 }): Promise<SystemAgentVerifiedInferenceBinding> {
   const deps = params.deps ?? {};
-  const runConfig = structuredClone(params.executionRoute.runConfig);
+  const runConfig = cloneConfigWithResolutionFacts(params.executionRoute.runConfig);
   const configuredExecution = {
     ...params.executionRoute,
+    sourceConfig: cloneConfigWithResolutionFacts(params.executionRoute.sourceConfig),
     runConfig,
   } as SystemAgentConfiguredRoute;
   const authProfileId = params.auth.authProfileId ?? configuredExecution.authProfileId;
@@ -782,12 +789,12 @@ export async function createSystemAgentVerifiedInferenceBinding(params: {
   }
   if (
     pluginHarnessId &&
-    resolveRouteHarnessOwnerPluginIds(params.configuredRoute.runConfig, execution).length === 0
+    resolveRouteHarnessOwnerPluginIds(params.configuredRoute.sourceConfig, execution).length === 0
   ) {
     throw new Error("The successful inference harness has no trusted manifest owner.");
   }
   const ownerPluginArtifactSnapshot = captureSystemAgentOwnerPluginArtifacts({
-    config: params.configuredRoute.runConfig,
+    config: params.configuredRoute.sourceConfig,
     executionRoute: execution,
     deps,
   });
@@ -796,7 +803,7 @@ export async function createSystemAgentVerifiedInferenceBinding(params: {
     configuredRoute: systemAgentRouteIdentity(params.configuredRoute),
     execution,
     executionFingerprint: await projectVerifiedExecutionFingerprint(
-      params.configuredRoute.runConfig,
+      params.configuredRoute.sourceConfig,
       execution,
       ownerPluginIds,
       deps,
@@ -875,6 +882,7 @@ async function resolveSystemAgentVerifiedInferenceStateInternal(
     config,
     binding.execution.agentId,
     deps,
+    snapshot,
   );
   if (
     !currentRoute ||
@@ -886,6 +894,7 @@ async function resolveSystemAgentVerifiedInferenceStateInternal(
   // owner through current config so policy/backend changes cannot reuse proof.
   const currentExecution: SystemAgentVerifiedExecutionRoute = {
     ...binding.execution,
+    sourceConfig: currentRoute.sourceConfig,
     runConfig: currentRoute.runConfig,
   };
   let currentOwnerPluginIds: string[];

--- a/test/system-agent-managed-auth.e2e.test.ts
+++ b/test/system-agent-managed-auth.e2e.test.ts
@@ -1,0 +1,199 @@
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import { createServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { expect, it } from "vitest";
+import type { GatewayClient } from "../src/gateway/client.js";
+import { loadOrCreateDeviceIdentity } from "../src/infra/device-identity.js";
+import { writeSecretStoreEntry } from "../src/secrets/store/secret-store.js";
+import { GATEWAY_CLIENT_MODES, GATEWAY_CLIENT_NAMES } from "../src/utils/message-channel.js";
+import { acquireGatewayTestClient } from "./helpers/gateway-client.js";
+import { writeOpenAiResponsesText } from "./helpers/openai-responses-sse.js";
+import {
+  createOpenClawTestInstance,
+  type OpenClawTestInstance,
+} from "./helpers/openclaw-test-instance.js";
+import { runQaGatewayFixture } from "./helpers/qa-gateway-cleanup.js";
+
+it("opens New Agent through the real Gateway and runner using a protected provider key", async () => {
+  const key = "synthetic-new-agent-provider-key";
+  const rotatedKey = "synthetic-new-agent-rotated-key";
+  let acceptedKey = key;
+  const secretRef = { source: "store", provider: "default", id: "SETUP_TEST_KEY" };
+  const requests: { authorization: string | undefined; body: unknown }[] = [];
+  const provider = createServer((request, response) => {
+    if (request.method !== "POST" || request.url !== "/v1/responses") {
+      response.writeHead(404).end();
+      return;
+    }
+    const chunks: Buffer[] = [];
+    request.on("data", (chunk: Buffer) => chunks.push(chunk));
+    request.on("end", () => {
+      requests.push({
+        authorization: request.headers.authorization,
+        body: JSON.parse(Buffer.concat(chunks).toString("utf8")),
+      });
+      if (request.headers.authorization !== `Bearer ${acceptedKey}`) {
+        response.writeHead(401).end();
+        return;
+      }
+      writeOpenAiResponsesText(response, {
+        text: "OK",
+        messageId: "msg_setup_probe",
+        responseId: "resp_setup_probe",
+      });
+    });
+  });
+  let instance: OpenClawTestInstance | undefined;
+  let client: GatewayClient | undefined;
+  await runQaGatewayFixture(
+    async () => {
+      await new Promise<void>((resolve, reject) => {
+        provider.once("error", reject);
+        provider.listen(0, "127.0.0.1", resolve);
+      });
+      const port = (provider.address() as AddressInfo).port;
+      instance = await createOpenClawTestInstance({
+        name: "system-agent-managed-auth",
+        env: {
+          OPENCLAW_SKIP_PROVIDERS: undefined,
+          OPENCLAW_TEST_MINIMAL_GATEWAY: undefined,
+          OPENCLAW_TEST_FAST: "1",
+          OPENCLAW_SECRET_SENTINELS: "1",
+          OPENAI_API_KEY: undefined,
+          OPENAI_OAUTH_TOKEN: undefined,
+          ANTHROPIC_API_KEY: undefined,
+        },
+        config: {
+          plugins: { enabled: false },
+          agents: { defaults: { model: "fixture/test-model" } },
+          models: {
+            providers: {
+              fixture: {
+                api: "openai-responses",
+                baseUrl: `http://127.0.0.1:${port}/v1`,
+                apiKey: secretRef,
+                request: { allowPrivateNetwork: true },
+                models: [
+                  {
+                    id: "test-model",
+                    name: "Fixture",
+                    reasoning: false,
+                    input: ["text"],
+                    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                    contextWindow: 32000,
+                    maxTokens: 1000,
+                  },
+                ],
+              },
+            },
+          },
+        },
+      });
+      writeSecretStoreEntry({
+        scope: { kind: "team" },
+        name: secretRef.id,
+        value: key,
+        kind: "secret",
+        allowedHosts: ["127.0.0.1"],
+        updatedBy: "test",
+        database: { env: instance.env },
+      });
+      await instance.startGateway();
+      client = await acquireGatewayTestClient(
+        {
+          url: instance.url,
+          token: instance.gatewayToken,
+          clientName: GATEWAY_CLIENT_NAMES.TEST,
+          mode: GATEWAY_CLIENT_MODES.TEST,
+          role: "operator",
+          scopes: ["operator.admin", "operator.read", "operator.write"],
+          deviceIdentity: loadOrCreateDeviceIdentity({
+            path: instance.state.statePath("test-device.sqlite"),
+          }),
+        },
+        {
+          timeoutMs: 10_000,
+          timeoutMessage: "Setup client did not connect",
+          closeMessage: "Setup client closed before connecting",
+        },
+      );
+
+      // The UI's New Agent action starts this setup conversation. No runner,
+      // credential resolver, config reader, or Gateway handler is replaced.
+      const sessionId = randomUUID();
+      const result = await client.request(
+        "openclaw.chat",
+        { sessionId, welcomeVariant: "new-agent" },
+        { timeoutMs: 60_000 },
+      );
+      expect(result).toMatchObject({
+        sessionId,
+        action: "none",
+        reply: expect.stringContaining("Let's hatch a new agent"),
+      });
+      expect(requests).toEqual([
+        {
+          authorization: `Bearer ${key}`,
+          body: expect.objectContaining({ model: "test-model", stream: true }),
+        },
+      ]);
+
+      const reply = await client.request(
+        "openclaw.chat",
+        { sessionId, message: "Please reply with OK and make no changes." },
+        { timeoutMs: 60_000 },
+      );
+      expect(reply).toMatchObject({ sessionId, action: "none", reply: "OK" });
+      expect(requests).toHaveLength(2);
+      expect(requests[1]?.authorization).toBe(`Bearer ${key}`);
+
+      // Rotate through the real store/reload owner. A previously verified session
+      // must not silently switch credentials; a fresh session must verify the new key.
+      acceptedKey = rotatedKey;
+      const rotation = await client.request("secrets.store.set", {
+        name: secretRef.id,
+        value: rotatedKey,
+        kind: "secret",
+        allowedHosts: ["127.0.0.1"],
+      });
+      expect(rotation).toMatchObject({ ok: true, reloaded: true });
+      await expect(
+        client.request("openclaw.chat", { sessionId, message: "Reply with OK again." }),
+      ).rejects.toThrow("OpenClaw could not reach working inference");
+      expect(requests).toHaveLength(2);
+      const freshSessionId = randomUUID();
+      const fresh = await client.request("openclaw.chat", {
+        sessionId: freshSessionId,
+        welcomeVariant: "new-agent",
+      });
+      expect(fresh).toMatchObject({
+        sessionId: freshSessionId,
+        action: "none",
+        reply: expect.stringContaining("Let's hatch a new agent"),
+      });
+      expect(requests).toHaveLength(3);
+      expect(requests[2]?.authorization).toBe(`Bearer ${rotatedKey}`);
+
+      const configText = await fs.readFile(instance.configPath, "utf8");
+      expect(JSON.parse(configText).models.providers.fixture.apiKey).toEqual(secretRef);
+      const publicOutput = [
+        configText,
+        JSON.stringify([result, reply, rotation, fresh]),
+        instance.logs(),
+      ].join("\n");
+      expect(publicOutput).not.toContain(key);
+      expect(publicOutput).not.toContain(rotatedKey);
+    },
+    () => client?.stopAndWait(),
+    () => instance?.cleanup(),
+    async () => {
+      provider.closeAllConnections();
+      if (provider.listening) {
+        await new Promise<void>((resolve, reject) => {
+          provider.close((error) => (error ? reject(error) : resolve()));
+        });
+      }
+    },
+  );
+}, 180_000);


### PR DESCRIPTION
Related: #141191

<details>
<summary>Additional instructions</summary>

Allow edits from maintainers is enabled. The fork has no repository Actions
secrets or environments; maintainer branch edits are acceptable.

</details>

## What Problem This Solves

Fixes an issue where users opening **New Agent** or another fresh system-agent
setup conversation receive “No API key found” when their configured provider key
is held in the protected store, even though ordinary agent conversations can
use that same provider. This repairs the reproduced store-SecretRef probe failure
in #141191, not its separately unconfirmed custom-provider/profile interactions.

## Why This Change Was Made

Reuse the correctly scoped prepared runtime before setup projects its reserved
execution agent, carrying the paired canonical-source and default-materialized
configuration views from the authoritative read. Fresh reads compare complete
resolution-fact provenance structurally; ownership revalidation uses the
unprepared logical configuration and the same credential-selection policy as
the successful probe, while fallback-owner availability uses its prepared route.

This retains protected storage, sentinel/egress handling, candidate isolation,
and credential-rotation rejection. It does not copy keys into auth profiles,
change the env-only helper, add a plaintext fallback, or change a schema,
dependency, configuration option, or permission. This remains credential-sensitive
work for the inference/credential owners to review.

## User Impact

Operators can start setup conversations using their existing protected provider
key without moving it back into plaintext configuration. A changed provider
destination or SecretRef cannot borrow the active key, and a previously verified
session cannot silently switch credentials after rotation.

## Evidence

- **Before/after real Gateway proof:** on untouched `eb439c0d6e`, the authenticated
  New Agent RPC (`openclaw.chat`, `welcomeVariant: "new-agent"`) fails with
  `system_agent_inference_unavailable` / `No API key found for provider "fixture"`.
  The same acceptance gate passes with this repair. The fixture uses a protected
  SQLite-store key, the real embedded runner and Gateway handlers, and a local
  HTTP Responses provider that requires the correct synthetic bearer key; no
  runner, auth resolver, or Gateway handler is substituted.
- **Lifecycle proof:** the extended test verifies a successful follow-up turn,
  rotation through the real `secrets.store.set` RPC, rejection of the old session
  before another provider request, successful verification in a fresh session,
  and no key bytes in persisted config, public replies, or Gateway logs.
- **Local validation on `da3e876aaef5`:** 818 tests across 38 files passed, including repeated reads,
  alternate profiles, fallback owners, completion/activation, rotation during
  verification, staged versus saved-but-not-activated destination/reference
  changes, and absence of prepared runtime. Full build, changed-file checks, and
  the full aggregate check with `--include-test-types` passed on macOS with
  Node 24.19.0 and pinned pnpm 12.3.4. The patch-identical rebase onto
  `0bec2710f683` also preserves #140392 and passes its nine error-reporting tests.
- Repository autoreview completed. Its sole proposed canonical/logical-view
  change was checked independently and disproved by applying it to the existing
  revalidation test, which failed; restoring the intended view passed all 12
  boundary cases. No accepted actionable finding remains.

Focused reproduction:

```sh
node scripts/run-vitest.mjs run src/config/runtime-snapshot.test.ts src/system-agent/inference-route-runtime.test.ts
node scripts/run-vitest.mjs run test/system-agent-managed-auth.e2e.test.ts
node scripts/check-changed.mjs
node --import ./scripts/tsx.mjs scripts/check.mts --include-test-types
```

No external paid provider, rendered browser-click flow, Linux/Windows execution,
or Docker upgrade-survivor result is claimed by this local proof. The latter is
selected by CI because an existing update-repair test fixture must carry the new
route field. Hosted CI results belong to the exact PR head.

Worked on by:
- @IWhatsskill
