### PR TITLE
fix(tests): report worker failures and verify immediate quota failover

### DIFF
--- a/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.auth-profile-rotation.e2e.test.ts
@@ -921,9 +921,8 @@ describe("runEmbeddedAgent auth profile rotation", () => {
     }
   });
 
-  it("rotates auto-pinned profiles on long-window rate limits after transient retries", async () => {
+  it("rotates auto-pinned profiles immediately on long-window rate limits", async () => {
     await runAutoPinnedRotationCase({
-      exhaustTransientRetries: true,
       errorMessage: "429 Too Many Requests: subscription usage limit reached",
       sessionKey: "agent:test:auto",
       runId: "run:auto",

--- a/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/node-worker-launch-wire.e2e.test.ts
@@ -482,6 +482,7 @@ describe("node worker launch wire", () => {
                 return loadRunId;
               }),
             );
+            const waveGateway = gateway;
             const waits = Promise.all(
               loadRunIds.map(async (loadRunId) => {
                 const completedLoad = await operator!.request<{ status?: string }>(
@@ -489,10 +490,19 @@ describe("node worker launch wire", () => {
                   { runId: loadRunId, timeoutMs: PROOF_TIMEOUT_MS },
                   { timeoutMs: PROOF_TIMEOUT_MS + 5_000 },
                 );
-                expect(completedLoad.status).toBe("ok");
+                expect(
+                  completedLoad,
+                  `load run ${loadRunId} failed\n${waveGateway.logs().slice(-12_000)}`,
+                ).toMatchObject({ status: "ok" });
               }),
             );
-            await waveFinalizationStarted;
+            // Failed turns may never upload; observe their failure while waiting for finalization.
+            await Promise.race([
+              waveFinalizationStarted,
+              waits.then(() => {
+                throw new Error("load wave completed without workspace finalization");
+              }),
+            ]);
             const freshConnectionStartedAt = performance.now();
             const freshClient = await connectWireClient({
               gateway,


### PR DESCRIPTION
## What Problem This Solves

Resolves two release-verification failures: the exhausted-subscription auth fixture supplied more failures after the runtime had correctly rotated profiles, and the node worker load proof could hide a terminal failure behind a workspace-finalization timeout and leak its rejection into the following test.

## Why This Change Was Made

Use the existing immediate-rotation fixture for long-window quota exhaustion, preserving exact profile order, zero sleeps, usage updates, and neighboring transient-retry coverage. Observe load completion while waiting for workspace upload and retain the returned error details. The worker workload and all timing gates remain unchanged.

## User Impact

No production behavior changes. Maintainers get accurate auth failover coverage and attributable worker-load failures. This is an explicitly requested maintainer backport from release verification.

## Evidence

Auth fixture: original full file had 30 passes/1 failure; repaired file 31/31 and retry-controller 28/28 pass. Node wire: unchanged full scenario passes locally; repaired full scenario also passes with all 12 sessions, 3 waves, latency limits, and existing deadlines. A source-extracted controlled-error probe reproduces the original pending wait/unhandled rejection and verifies immediate diagnostic failure after this change.

Both repairs passed scoped checks and independent P2 review on the release source. The original files are byte-identical on this main base. The combined main backport also passes the full changed-file gate and a fresh independent P2 review. Exact-head CI and native landing checks follow. The underlying hosted node-worker error was not reproduced locally; this change ensures its full response is visible if it recurs.

<details>
<summary>Additional instructions</summary>
This same-repository branch is editable by repository maintainers; GitHub reserves the fork-collaboration toggle for cross-repository PRs. No changelog change is needed for these test-only repairs.
</details>
