### PR TITLE
fix(gateway): classify background exec task blockers

### DIFF
--- a/docs/gateway/external-apps.md
+++ b/docs/gateway/external-apps.md
@@ -270,9 +270,13 @@ transports, or control the hosting platform. The host must fence its ingress
 before preparation and remains responsible for wake, snapshot/freeze, and
 stop. `activeCount` is the aggregate tracked-work count, while `blockers`
 contains the non-zero category counts and bounded task details. This is not a
-general process-quiescence barrier. A `background-exec` blocker is aggregate
-only: command text, process IDs, output, and session or scope identifiers never
-cross the protocol. Channel health, maintenance, cache refresh, established
+general process-quiescence barrier. The process registry's `background-exec` entry
+is aggregate only. Durable background exec tasks also use `background-exec`
+and retain their bounded `task` metadata; other task kinds remain `task`.
+A process can contribute to both counts. This classification does not change
+`activeCount` or readiness, and adds no command text, output, operating system
+process IDs, or session or scope identifiers. Channel health, maintenance,
+cache refresh, established
 plugin WebSocket sessions, and unregistered plugin-owned background work can
 remain active.
 The hosting platform must freeze or snapshot the full process tree and its

--- a/src/infra/gateway-active-work.test.ts
+++ b/src/infra/gateway-active-work.test.ts
@@ -1,5 +1,7 @@
 // Canonical Gateway active-work waiting must report the owners that block shutdown.
+import { Value } from "typebox/value";
 import { afterEach, describe, expect, it } from "vitest";
+import { GatewaySuspendPrepareResultSchema } from "../../packages/gateway-protocol/src/index.js";
 import type { EmbeddedAgentQueueHandle } from "../agents/embedded-agent-runner/run-state.js";
 import {
   clearActiveEmbeddedRun,
@@ -25,6 +27,90 @@ afterEach(() => {
 });
 
 describe("waitForGatewayActiveWork", () => {
+  it.each([
+    { runtime: "cli", taskKind: "exec", kind: "background-exec" },
+    { runtime: "cli", taskKind: undefined, kind: "task" },
+    { runtime: "cli", taskKind: "media", kind: "task" },
+    { runtime: "subagent", taskKind: "exec", kind: "task" },
+  ] as const)(
+    "reports $runtime/$taskKind task ownership without changing counts",
+    ({ runtime, taskKind, kind }) => {
+      const task = {
+        taskId: "task-owned",
+        runId: "exec:owned-process",
+        status: "running" as const,
+        runtime,
+        taskKind,
+        label: "CLI command",
+        title: "Background CLI command",
+      };
+      const snapshot = createGatewayActiveWorkSnapshot({
+        getQueueSize: () => 0,
+        getPendingReplies: () => 0,
+        getEmbeddedRuns: () => 0,
+        getBackgroundExecSessions: () => 1,
+        getCronRuns: () => 0,
+        getActiveTasks: () => 1,
+        getTaskBlockers: () => [task],
+        getRootRequests: () => 0,
+        getSessionAdmissions: () => 0,
+        getSessionMutations: () => 0,
+        getChatRuns: () => 0,
+        getQueuedTurns: () => 0,
+        getTerminalPersistence: () => 0,
+        getTerminalSessions: () => 0,
+      });
+
+      expect(snapshot.idle).toBe(false);
+      expect(snapshot.counts).toMatchObject({
+        backgroundExecSessions: 1,
+        activeTasks: 1,
+        totalActive: 2,
+      });
+      expect(snapshot.blockers.map((blocker) => blocker.kind)).toEqual(["background-exec", kind]);
+      expect(snapshot.blockers[1]?.task).toEqual({
+        taskId: "task-owned",
+        runId: "exec:owned-process",
+        status: "running",
+        runtime,
+        label: "CLI command",
+        title: "Background CLI command",
+      });
+      expect(
+        Value.Check(GatewaySuspendPrepareResultSchema, {
+          status: "draining",
+          suspensionId: "held-owner",
+          expiresAtMs: 120_000,
+          retryAfterMs: 20_000,
+          activeCount: snapshot.counts.totalActive,
+          blockers: snapshot.blockers,
+        }),
+      ).toBe(true);
+    },
+  );
+
+  it("keeps omitted process-task details as conservative task blockers", () => {
+    const tasks = Array.from({ length: 9 }, (_, index) => ({
+      taskId: `task-${index}`,
+      runtime: "cli" as const,
+      taskKind: "exec",
+      status: "running" as const,
+    }));
+    const snapshot = createGatewayActiveWorkSnapshot({
+      getActiveTasks: () => 9,
+      getTaskBlockers: () => tasks,
+    });
+
+    expect(snapshot.idle).toBe(false);
+    expect(snapshot.counts.activeTasks).toBe(9);
+    expect(snapshot.blockers.filter((blocker) => blocker.task)).toHaveLength(8);
+    expect(snapshot.blockers.at(-1)).toEqual({
+      kind: "task",
+      count: 1,
+      message: "1 additional active background task run(s)",
+    });
+  });
+
   it("returns the final canonical blockers when its deadline expires", async () => {
     const sessionId = "probe-gateway-active-work-timeout";
     const handle: EmbeddedAgentQueueHandle = {

--- a/src/infra/gateway-active-work.ts
+++ b/src/infra/gateway-active-work.ts
@@ -13,6 +13,7 @@ import {
   getActiveSessionLifecycleMutationCount,
   getActiveSessionWorkAdmissionCount,
 } from "../sessions/session-lifecycle-admission.js";
+import { isBackgroundExecTask } from "../tasks/background-exec-task-contract.js";
 import { getInspectableActiveTaskRestartBlockers } from "../tasks/task-registry.maintenance.js";
 import {
   type ActiveTaskRestartBlocker,
@@ -54,7 +55,7 @@ export type GatewayActiveWorkBlocker = {
     | "terminal-session";
   count: number;
   message: string;
-  task?: ActiveTaskRestartBlocker;
+  task?: Omit<ActiveTaskRestartBlocker, "taskKind">;
 };
 
 export type GatewayActiveWorkSnapshot = {
@@ -202,9 +203,11 @@ export function createGatewayActiveWorkSnapshot(
       });
     } else {
       const shownTaskBlockers = taskBlockers.slice(0, 8);
-      for (const task of shownTaskBlockers) {
+      for (const { taskKind, ...task } of shownTaskBlockers) {
         blockers.push({
-          kind: "task",
+          kind: isBackgroundExecTask({ runtime: task.runtime, taskKind })
+            ? "background-exec"
+            : "task",
           count: 1,
           message: formatActiveTaskRestartBlocker(task),
           task,

--- a/src/tasks/task-registry.maintenance.issue-60299.test.ts
+++ b/src/tasks/task-registry.maintenance.issue-60299.test.ts
@@ -390,6 +390,7 @@ describe("task-registry maintenance issue #60299", () => {
     const activeRunning = makeStaleTask({
       taskId: "task-running-live",
       runtime: "cli",
+      taskKind: "exec",
       status: "running",
       createdAt: now,
       startedAt: now,
@@ -418,6 +419,7 @@ describe("task-registry maintenance issue #60299", () => {
     expect(blockers[0]?.taskId).toBe("task-running-live");
     expect(blockers[0]?.status).toBe("running");
     expect(blockers[0]?.runtime).toBe("cli");
+    expect(blockers[0]?.taskKind).toBe("exec");
     expect(blockers[0]?.runId).toBe("run-running-live");
   });
 

--- a/src/tasks/task-registry.maintenance.ts
+++ b/src/tasks/task-registry.maintenance.ts
@@ -887,6 +887,9 @@ export function getInspectableActiveTaskRestartBlockers(): ActiveTaskRestartBloc
       status: task.status,
       runtime: task.runtime,
     };
+    if (task.taskKind) {
+      blocker.taskKind = task.taskKind;
+    }
     if (task.runId) {
       blocker.runId = task.runId;
     }

--- a/src/tasks/task-restart-blocker.ts
+++ b/src/tasks/task-restart-blocker.ts
@@ -6,6 +6,8 @@ export type ActiveTaskRestartBlocker = {
   taskId: string;
   status: Extract<TaskStatus, "running">;
   runtime: TaskRecord["runtime"];
+  /** Internal classification; omitted from suspension task metadata. */
+  taskKind?: TaskRecord["taskKind"];
   runId?: string;
   label?: string;
   title?: string;


### PR DESCRIPTION
Related to #141417.

## What Problem This Solves

Gateway suspension reports a running background command once as `background-exec` and again as a generic `task`. The task projection discards its canonical exec classification, so a controller preserving existing processes cannot distinguish that task record from active model work. A follow-up `tasks.get` is unavailable while suspension holds admission closed.

## Why This Change Was Made

Carry the canonical task kind through the internal restart-blocker projection, classify CLI exec tasks with the existing `isBackgroundExecTask` helper, and emit the existing `background-exec` wire category. Preserve the bounded task metadata while removing the internal classification field before serialization.

## User Impact

Suspension diagnostics identify durable background exec records as processes. Existing activity counts, readiness, suspension admission, the eight-detail bound, and conservative omitted-task summaries retain their behavior. Generic CLI, media, and subagent tasks remain task blockers.

## Evidence

- The producer regression fails on the original source because `taskKind` is lost. The snapshot regressions cover canonical exec, generic CLI, media, and subagent cases and validate the existing closed wire schema.
- All 91 focused tests passed across active-work, task maintenance, restart coordination, suspension coordination, and Gateway suspension schema suites.
- `node scripts/check-changed.mjs` passed, including both core typecheck lanes, lint, and repository guards.
- Fresh independent P0–P2 review is scoped-clean.
- Packaged Linux Gateway qualification passed all ten native completion/fault cases across both builds: descendant work drains before verification, a background HTTP service remains responsive for 140 seconds, the same suspension owner renews beyond its initial lease, and deadline/cancel/fault paths remain enforced. Six additional native/Pi process-lifecycle cases preserved the original CPU/memory limits and verifier usability. These are synthetic lifecycle checks, not scored benchmark results.
- The repair is identical in both native builds for the separate matched Code Mode benchmark; no benchmark gain is claimed here.
- [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34163498279).

The external-apps documentation explains the classification and overlapping counts. No protocol version or dependency change is required.
