### PR TITLE
refactor(ui): reuse Gateway wire result types

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -1,5 +1,6 @@
 import type { FastMode } from "@openclaw/normalization-core/string-coerce";
 import type {
+  ArtifactSummary as ProtocolArtifactSummary,
   CronJob as ProtocolCronJob,
   CronListParams,
   CronRunLogEntry as ProtocolCronRunLogEntry,
@@ -29,7 +30,6 @@ import type {
   SessionContextBudgetStatus,
   SessionGoal,
 } from "../../../src/config/sessions/types.js";
-import type { ConfigUiHints } from "../../../src/shared/config-ui-hints-types.js";
 import type { FastModeSource } from "../../../src/shared/fast-mode.js";
 import type {
   GatewayAgentRuntime,
@@ -40,6 +40,10 @@ import type {
   SessionsPatchResultBase,
 } from "../../../src/shared/session-types.js";
 export type {
+  AgentIdentityResult,
+  ArtifactsDownloadResult as ArtifactDownloadResult,
+  ConfigSchemaResponse,
+  ModelsListResult as ModelCatalogResult,
   AgentsFileEntry as AgentFileEntry,
   AgentsFilesListResult,
   AgentsFilesGetResult,
@@ -207,13 +211,6 @@ export type ConfigSnapshot = {
   issues?: ConfigSnapshotIssue[] | null;
 };
 
-export type ConfigSchemaResponse = {
-  schema: unknown;
-  uiHints: ConfigUiHints;
-  version: string;
-  generatedAt: string;
-};
-
 export type PresenceEntry = ProtocolPresenceEntry;
 
 export type GatewaySessionsDefaults = {
@@ -235,40 +232,11 @@ export type { GatewayContextWindowOption, GatewayThinkingLevelOption };
 
 export type AgentsListResult = ProtocolAgentsListResult;
 
-export type AgentIdentityResult = {
-  agentId: string;
-  name: string;
-  nameSource?: "config" | "agent" | "workspace" | "default";
-  avatar: string;
-  avatarSource?: string | null;
-  avatarStatus?: "none" | "local" | "remote" | "data" | null;
-  avatarReason?: string | null;
-  emoji?: string;
-};
-
-type SessionWorkspaceArtifactEntry = {
-  id: string;
-  type: string;
-  title: string;
-  mimeType?: string;
-  sizeBytes?: number;
-  source?: string;
-  download: {
-    mode: "bytes" | "url" | "unsupported";
-  };
-};
+type SessionWorkspaceArtifactEntry = ProtocolArtifactSummary;
 
 // The workspace view joins file results with separately fetched artifacts.
 export type SessionWorkspaceListResult = ProtocolSessionsFilesListResult & {
   artifacts?: SessionWorkspaceArtifactEntry[];
-};
-
-export type ArtifactDownloadResult = {
-  artifact: SessionWorkspaceArtifactEntry;
-  encoding?: "base64";
-  data?: string;
-  url?: string;
-  expiresAt?: string;
 };
 
 type SubagentRunState = "active" | "interrupted" | "historical";
@@ -466,16 +434,10 @@ export type StatusSummary = Record<string, unknown>;
 export type HealthSnapshot = Record<string, unknown>;
 
 /** A model entry returned by the gateway model-catalog endpoint. */
-export type ModelCatalogEntry = Omit<ProtocolModelChoice, "input"> & {
-  input?: Array<"text" | "image" | "document">;
-};
+export type ModelCatalogEntry = ProtocolModelChoice;
 
 export type ModelCatalogProviderOutcome =
   import("../../../packages/gateway-protocol/src/schema/agents-models-skills.js").ModelCatalogProviderOutcome;
-export type ModelCatalogResult = {
-  models: ModelCatalogEntry[];
-  providerOutcomes?: ModelCatalogProviderOutcome[];
-};
 
 export type ToolCatalogProfile =
   import("../../../packages/gateway-protocol/src/schema.js").ToolCatalogProfile;

--- a/ui/src/lib/assistant-identity.ts
+++ b/ui/src/lib/assistant-identity.ts
@@ -1,6 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 // Control UI module implements assistant identity behavior.
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
+import type { AgentIdentityResult } from "../../../packages/gateway-protocol/src/schema/agent.js";
 import { isRenderableAvatarImageDataUrl } from "../../../src/shared/avatar-limits.js";
 
 // Short text/emoji avatars (e.g. "A", "PS", "🦞"). Anything longer that is not
@@ -55,7 +56,7 @@ function normalizeAssistantAvatar(value: string | null | undefined): string | nu
 }
 
 export function normalizeAssistantIdentity(
-  input?: Partial<AssistantIdentity> | null,
+  input?: Partial<AssistantIdentity> | AgentIdentityResult | null,
 ): Required<AssistantIdentity> {
   const name = normalizeAssistantValue("name", input?.name) ?? DEFAULT_ASSISTANT_NAME;
   const avatar = normalizeAssistantAvatar(input?.avatar);


### PR DESCRIPTION
## What Problem This Solves

The Control UI maintained private copies of Gateway identity, artifact, configuration-schema and model-catalog result types. Several copies described narrower or more required fields than the actual wire contracts, creating a second definition to maintain.

## Why This Change Was Made

Reuse the existing Gateway protocol types while retaining the UI's existing exported names. The identity normalizer accepts its two existing input sources—the protocol response and partial local identity overrides—and keeps the same validated, narrow output type and runtime implementation.

These are private browser-build declarations; no public plugin SDK export or protocol schema changes.

## User Impact

No rendered or runtime behavior changes. UI consumers now track the existing serialized Gateway contracts directly, and both edited modules emit byte-identical JavaScript.

## Evidence

All four native UI production/test type graphs passed before and after. The 123 existing assistant-identity, identity-cache and chat-state tests pass, the complete selected changed-file gate passes, and independent review through P2 found no actionable issue. Both complete changed modules emit byte-identical JavaScript; the normalizer body and narrow output declaration are unchanged.

The full change removes 34 production code lines / 37 physical lines, including the normalizer's type-import cost. No tests, fixture payloads, assertions, protocol schemas, dependencies or public SDK exports change. No live Gateway or visual change is claimed.
