### PR TITLE
fix: preserve plugin test process limits with release flags

### DIFF
--- a/docs/ci/release-validation.md
+++ b/docs/ci/release-validation.md
@@ -426,6 +426,8 @@ The scheduled live/E2E workflow runs the full release-path Docker suite daily an
 
 ## Plugin Prerelease
 
+Plugin batch execution preserves existing process limits when the only forwarded options are numeric `--retry` and exact-file `--exclude` selections. Codex retains at most 12 files per sequential process, including release runs with those options. Watch mode, suite-wide bail or sharding, reports, broad exclusion patterns, and other options retain their single-process semantics.
+
 `Plugin Prerelease` is more expensive product/package coverage, so it is a separate workflow dispatched by `Full Release Validation` or by an explicit operator. Normal pull requests, `main` pushes, and standalone manual CI dispatches keep that suite off. It balances non-Telegram bundled plugin tests across eight generic extension workers; those jobs run up to two plugin config groups at a time with one Vitest worker per group and a larger Node heap. Telegram runs in dedicated shards of at most ten test files, preserving one-file Vitest processes while scheduling two processes concurrently. The combined extension matrix is capped at 12 concurrent jobs. The release-only Docker prerelease path (enabled by the `full_release_validation` input) batches targeted Docker lanes in groups of four to avoid reserving dozens of runners for one-to-three-minute jobs. The workflow also uploads an informational `plugin-inspector-advisory` artifact from `@openclaw/plugin-inspector`; inspector findings are triage input and do not change the blocking Plugin Prerelease gate.
 
 ## Related

--- a/scripts/lib/extension-test-plan.mts
+++ b/scripts/lib/extension-test-plan.mts
@@ -303,9 +303,25 @@ export function splitExtensionTestJobTargets(config: string, targets: string[]) 
 
 /** Whether a Vitest invocation can safely be split into independent one-shot processes. */
 export function shouldSplitExtensionTestProcesses(config: string, vitestArgs: string[] = []) {
-  // Passthrough options can carry suite-wide semantics such as bail thresholds,
-  // filtering, watch state, or shared artifacts. Only plain one-shot runs are splittable.
-  return EXTENSION_TEST_PROCESS_FILE_LIMITS.has(config) && vitestArgs.length === 0;
+  if (!EXTENSION_TEST_PROCESS_FILE_LIMITS.has(config)) {
+    return false;
+  }
+  // Per-test retries and exact file exclusions preserve independent process scopes.
+  // Other options may own suite-wide bail, watch, sharding, or report state.
+  for (let index = 0; index < vitestArgs.length; index++) {
+    const option = /^(--retry|--exclude)(?:=(.+))?$/u.exec(vitestArgs[index]!);
+    if (!option) {
+      return false;
+    }
+    const value = option[2] ?? vitestArgs[++index];
+    if (!value || value.startsWith("-")) {
+      return false;
+    }
+    if (option[1] === "--retry" ? !/^\d+$/u.test(value) : /[*!?[\]{}]/u.test(value)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 /** Resolve process targets for an extension config, expanding roots only when it is bounded. */

--- a/scripts/lib/extension-test-plan.mts
+++ b/scripts/lib/extension-test-plan.mts
@@ -317,7 +317,7 @@ export function shouldSplitExtensionTestProcesses(config: string, vitestArgs: st
     if (!value || value.startsWith("-")) {
       return false;
     }
-    if (option[1] === "--retry" ? !/^\d+$/u.test(value) : /[*!?[\]{}]/u.test(value)) {
+    if (option[1] === "--retry" ? !/^\d+$/u.test(value) : /[*!?[\]{}()]/u.test(value)) {
       return false;
     }
   }

--- a/test/scripts/test-extension.test.ts
+++ b/test/scripts/test-extension.test.ts
@@ -255,10 +255,14 @@ describe("scripts/test-extension.mts", () => {
     ["reporter", ["--reporter=json"]],
     ["output file", ["--outputFile=results.json"]],
     ["shard", ["--shard=1/2"]],
+    ["retry with shard", ["--retry=1", "--shard=1/2"]],
+    ["retry with report", ["--retry=1", "--reporter=json"]],
+    ["missing retry value", ["--retry"]],
+    ["invalid retry value", ["--retry=invalid"]],
+    ["missing exclude value", ["--exclude"]],
     ["bail", ["--bail=2"]],
     ["changed", ["--changed=origin/main"]],
     ["exclude", ["--exclude=extensions/matrix/src/**"]],
-    ["retry", ["--retry=1"]],
   ])("keeps Matrix %s runs in one process", (_name, vitestArgs) => {
     const root = bundledPluginRoot("matrix");
 
@@ -761,7 +765,7 @@ export default {root:${JSON.stringify(root)},cacheDir:${JSON.stringify(path.join
       const expectedHome = realHomeReplay ? JSON.stringify(home) : "path.join(tmpdir(), 'home')";
       writeFileSync(
         path.join(root, "selected.test.mjs"),
-        `import {homedir,tmpdir} from 'node:os';import path from 'node:path';import {test,expect} from 'vitest';test('selected native case',()=>{expect(process.env.HOME).toBe(${expectedHome});expect(homedir()).toBe(${expectedHome});});`,
+        `import {homedir,tmpdir} from 'node:os';import path from 'node:path';import {test,expect} from 'vitest';let attempts=0;test('selected native case',()=>{expect(++attempts).toBe(2);expect(process.env.HOME).toBe(${expectedHome});expect(homedir()).toBe(${expectedHome});});`,
       );
       for (const name of ["excluded", "unrelated"]) {
         writeFileSync(
@@ -774,6 +778,7 @@ export default {root:${JSON.stringify(root)},cacheDir:${JSON.stringify(path.join
         homeMode: realHomeReplay ? "live-aware" : undefined,
         args: [
           "--configLoader=native",
+          "--retry=1",
           "--reporter=verbose",
           "--reporter=json",
           `--outputFile=${report}`,
@@ -1001,6 +1006,34 @@ await new Promise(()=>{});export default {};`,
     expect(runParams.targets).toContain("codex/src/app-server/client.test.ts");
   });
 
+  it.each([
+    ["--retry=1", "--exclude", "extensions/codex/src/app-server/run-attempt.test.ts"],
+    ["--retry", "1", "--exclude=extensions/codex/src/app-server/run-attempt.test.ts"],
+  ])("preserves Codex process bounds with release options %j", async (...vitestArgs) => {
+    const runGroup = vi.fn<(params: RunGroupParams) => Promise<number>>().mockResolvedValue(0);
+    const excluded = "extensions/codex/src/app-server/run-attempt.test.ts";
+    const expectedFiles = listExtensionTestFilesForRoots([bundledPluginRoot("codex")])
+      .filter((file) => file !== excluded)
+      .map((file) => file.replace(/^extensions\//u, ""));
+
+    const result = await runExtensionBatchPlan(
+      resolveExtensionBatchPlan({ cwd: process.cwd(), extensionIds: ["codex"] }),
+      { runGroup, vitestArgs },
+    );
+
+    expect(result).toBe(0);
+    const calls = runGroup.mock.calls.map(([params]) => params);
+    expect(calls).toHaveLength(Math.ceil(expectedFiles.length / 12));
+    expect(calls.every((call) => call.targets.length <= 12)).toBe(true);
+    expect(calls.flatMap((call) => call.targets)).toEqual(expectedFiles);
+    for (const call of calls) {
+      expect(parseCLI(["vitest", "run", ...call.args]).options).toMatchObject({
+        retry: 1,
+        exclude: ["codex/src/app-server/run-attempt.test.ts"],
+      });
+    }
+  });
+
   it("runs Matrix extension batches in bounded sequential processes", async () => {
     const runGroup = vi.fn<(params: RunGroupParams) => Promise<number>>().mockResolvedValue(0);
     const expectedFiles = listExtensionTestFilesForRoots([bundledPluginRoot("matrix")]).map(
@@ -1042,7 +1075,6 @@ await new Promise(()=>{});export default {};`,
     ["--bail=2"],
     ["--changed=origin/main"],
     ["--exclude=extensions/matrix/src/**"],
-    ["--retry=1"],
   ])("keeps Matrix extension batch mode %s in one process", async (vitestArg) => {
     const runGroup = vi.fn<() => Promise<number>>().mockResolvedValue(0);
 

--- a/test/scripts/test-extension.test.ts
+++ b/test/scripts/test-extension.test.ts
@@ -263,6 +263,8 @@ describe("scripts/test-extension.mts", () => {
     ["bail", ["--bail=2"]],
     ["changed", ["--changed=origin/main"]],
     ["exclude", ["--exclude=extensions/matrix/src/**"]],
+    ["one-or-more extglob exclude", ["--exclude=extensions/matrix/src/+(a).test.ts"]],
+    ["exactly-one extglob exclude", ["--exclude=extensions/matrix/src/@(a).test.ts"]],
   ])("keeps Matrix %s runs in one process", (_name, vitestArgs) => {
     const root = bundledPluginRoot("matrix");
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Plugin Prerelease runs bypassed the existing plugin test process limits when forwarding retry and exact-file exclusion options. In [run 34159135860](https://github.com/openclaw/openclaw/actions/runs/34159135860/job/101857400767), the Codex batch put 232 files into one process and eventually exited 137.

## Why This Change Was Made

Preserve the existing sequential process limits for numeric per-test retry and exact-file exclusions. Codex keeps its 12-file limit. Unknown, malformed, watch, bail, report, shard, and broad-pattern options—including extglobs—keep their existing unsplit semantics. Heap sizes, runner classes, job parallelism and test inventory stay unchanged.

## User Impact

Release operators retain the established process boundaries when using the release command's retry and exclusion flags. The repair must be included in the selected release Code revision because Plugin Prerelease executes the planner from that checkout.

## Evidence

The exact release-command planning regression failed before the repair: one invocation instead of 20. After repair, all 232 selected files appear exactly once across 20 sequential invocations, each containing at most 12 files; the same retry and exclusion arguments reach Vitest.

- 179 owner tests pass, including installed Vitest fixtures that deliberately fail their first attempt, pass on retry, and preserve exclusions.
- Three sibling routing checks and the changed-file gate pass.
- Both extglob cases fail before the follow-up and pass afterward.
- Independent P2 reviews found no actionable findings.

The failed job retained no heap profile or RSS telemetry. This fixes the independently reproduced process-limit bypass; it does not claim proof of a specific application memory leak or a completed release rerun.
