### PR TITLE
improve: avoid repeated snapshot compilation in handoff tests

### DIFF
--- a/src/infra/update-managed-service-handoff-repair.test-support.ts
+++ b/src/infra/update-managed-service-handoff-repair.test-support.ts
@@ -11,6 +11,7 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withServer } from "../plugin-sdk/test-helpers/http-test-server.js";
 import { runtimeProcessEntrypoints } from "./runtime-process-entrypoints.js";
+import { resolveRuntimeWorkerArgv } from "./runtime-worker-url.js";
 import type {
   ManagedRepairBoundary,
   ManagedServiceManagerBoundaryRunner,
@@ -83,9 +84,13 @@ export function managedRepairConfig(baseUrl: string): OpenClawConfig {
 }
 
 function managedRepairSpawnPreload(root: string): string {
+  const snapshotWorkerArgs = resolveRuntimeWorkerArgv(
+    new URL("./update-candidate-state.worker.ts", import.meta.url),
+  );
   return `const fs = require("node:fs");
     const childProcess = require("node:child_process");
     const spawn = childProcess.spawn;
+    const snapshotWorkerArgs = ${JSON.stringify(snapshotWorkerArgs)};
     childProcess.spawn = function(command, args, options) {
       // Rehearsal strips NODE_OPTIONS; carry the recorder only to its owned supervisor workers.
       if (command === process.execPath && Array.isArray(args) && args.length === 1 &&
@@ -93,8 +98,9 @@ function managedRepairSpawnPreload(root: string): string {
         args = ["--require", __filename, ...args];
       }
       // Source orchestration consumes the packaged SQLite worker from the completed build.
-      if (Array.isArray(args) && args.length === 3 && args[0] === "--import" && args[1] === "tsx" &&
-          args[2] === ${JSON.stringify(path.resolve("src/infra/update-candidate-state.worker.ts"))}) {
+      // Share the argv builder so its pinned source-loader URL cannot bypass this redirect.
+      if (Array.isArray(args) && args.length === snapshotWorkerArgs.length &&
+          args.every((arg, index) => arg === snapshotWorkerArgs[index])) {
         args = [${JSON.stringify(path.resolve("dist", runtimeProcessEntrypoints.updateCandidateState.distWorkerPath))}];
       }
       const script = Array.isArray(args) ? args.join(" ") : "";


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the managed-update lifecycle tests repeatedly compile the snapshot worker from source even though their fixture intends to use the already-built worker. The redirect still expected the bare `tsx` argument after the shared launcher began pinning it to an absolute file URL in #140458.

## Why This Change Was Made

Derive the exact source-worker argument vector with `resolveRuntimeWorkerArgv`, then match that vector in the existing fixture preload. The snapshot remains a fresh real process using the same built worker as packaged updates. Source admission and orchestration, candidate isolation, and the existing repair-effect checks remain intact.

## User Impact

Faster tests with no production behavior change. This changes one test-support file (+8/-2), with no added cache, dependency, shard, timeout, or test removal.

## Evidence

- A current-main baseline at `bd62b672` passed all four existing repair-effect cases. An observed child command still ran `src/infra/update-candidate-state.worker.ts` with an absolute TSX loader URL, confirming the stale match.
- Same four-case order on the candidate: all pass. Validating cases decreased from **55.634s / 29.806s** to **30.099s / 10.112s**. Verifying cases took **9.347s / 9.768s**, versus **12.470s / 8.574s** before. These sequential local samples show a useful improvement, not a portable CI ratio.
- Whole commands include the normal runtime prerequisite build: **211.56s before, 124.56s after**. Build/load variation is included in those totals, so it is not all attributed to the fix.
- A prior phase probe attributed **16.9–23.7s** to validating rehearsal and only **0.52–0.98s** to compiled repair-runtime import. Its separate Slack startup cost was already addressed by #141512, which is included in this baseline and is not part of this patch.
- All **173 tests** passed across the full lifecycle file and runtime-URL suite. Changed-file gates passed, including types, lint, and unused-export scans. Managed P2 review found no actionable issues.

A focused passing case with temporary launch logging recorded an actual child PID using `dist/infra/update-candidate-state.worker.js` with no TSX preload. The logger was removed by restoring the exact candidate bytes already tested and reviewed; recorded child and parent PIDs had exited. The earlier short process samplers missed that short-lived child and are not used as proof of the redirect.

Exact-head [CI run 34164332059](https://github.com/openclaw/openclaw/actions/runs/34164332059) passed in **7m30s**, including Docker seed tests and the required gate. The [Node job](https://github.com/openclaw/openclaw/actions/runs/34164332059/job/101872381444) passed all **164 lifecycle cases** in 182.95s Vitest time. The four target cases ran in their original order at **14.035s, 7.567s, 6.612s, and 6.552s**; compiler setup took 4.650s. Broad main CI still has runner-queue delays, so this PR run does not establish a consistent eight-minute result for the entire campaign.
