### PR TITLE
fix(release): preserve candidate channel and config ownership in QA

### DIFF
--- a/.github/workflows/openclaw-release-telegram-qa.yml
+++ b/.github/workflows/openclaw-release-telegram-qa.yml
@@ -1626,6 +1626,48 @@ jobs:
             chmod -R a+rX,go-w "$OPENCLAW_BUNDLED_PLUGINS_DIR"
           fi
 
+          if [[ "$requested_config_path" == "$config_path" ]]; then
+            # Doctor owns a writable runtime copy; the scenario's source stays immutable.
+            # Keep generation receipts outside SUT state so a canonical mutation always
+            # refreshes the copy, while an unchanged source preserves Doctor repairs.
+            projection_dir="${OPENCLAW_STATE_DIR}/qa-runtime-config"
+            generation_dir="${RUNTIME_ROOT}/config-generations"
+            install -d -o root -g root -m 0700 "$generation_dir"
+            generation_key="$(printf %s "$config_path" | sha256sum | cut -d ' ' -f1)"
+            generation_path="${generation_dir}/${generation_key}"
+            config_generation="$(sha256sum "$config_path" | cut -d ' ' -f1)"
+            previous_generation=""
+            if [[ -e "$generation_path" ]]; then
+              [[ "$(stat -c '%F:%a:%u:%g' "$generation_path")" == "regular file:600:0:0" ]]
+              previous_generation="$(<"$generation_path")"
+            fi
+            if [[ "$previous_generation" != "$config_generation" || ! -e "$projection_dir/openclaw.json" ]]; then
+              # Only the unprivileged SUT writes below its private state root.
+              /usr/bin/setpriv --reuid="$SUT_UID" --regid="$SUT_GID" \
+                --clear-groups --no-new-privs --inh-caps=-all --ambient-caps=-all --bounding-set=-all \
+                /usr/bin/env -i PATH=/usr/bin:/bin /bin/bash -ceu '
+                  umask 077
+                  source_config="$1"
+                  projection_dir="$2"
+                  expected_generation="$3"
+                  mkdir -p "$projection_dir"
+                  [[ -d "$projection_dir" && ! -L "$projection_dir" &&
+                        "$(realpath -e "$projection_dir")" == "$projection_dir" ]]
+                  projection_tmp="$(mktemp "$projection_dir/.seed.XXXXXX")"
+                  trap '\''rm -f "$projection_tmp"'\'' EXIT
+                  cat "$source_config" >"$projection_tmp"
+                  [[ "$(sha256sum "$projection_tmp" | cut -d " " -f1)" == "$expected_generation" ]]
+                  mv -T "$projection_tmp" "$projection_dir/openclaw.json"
+                ' openclaw-config-projection "$config_path" "$projection_dir" "$config_generation"
+              [[ "$(sha256sum "$config_path" | cut -d ' ' -f1)" == "$config_generation" ]]
+              generation_tmp="$(mktemp "$generation_dir/.generation.XXXXXX")"
+              printf %s "$config_generation" >"$generation_tmp"
+              chmod 0600 "$generation_tmp"
+              mv -T "$generation_tmp" "$generation_path"
+            fi
+            export OPENCLAW_CONFIG_PATH="$projection_dir/openclaw.json"
+          fi
+
           boundary_mode=false
           for key in "${control_keys[@]}"; do
             if declare -p "$key" >/dev/null 2>&1; then
@@ -1851,8 +1893,14 @@ jobs:
                           -r "${CANONICAL_CONFIG_PATH:?}" &&
                           ! -w "$CANONICAL_CONFIG_PATH" ]]
                     if [[ "$OPENCLAW_CONFIG_PATH" != "$CANONICAL_CONFIG_PATH" ]]; then
-                      [[ "${1:-}" == "models" && "${2:-}" == "auth" &&
-                            -r "$OPENCLAW_CONFIG_PATH" && -w "$OPENCLAW_CONFIG_PATH" ]]
+                      [[ -r "$OPENCLAW_CONFIG_PATH" && -w "$OPENCLAW_CONFIG_PATH" &&
+                            ! -L "$OPENCLAW_CONFIG_PATH" ]]
+                      case "$OPENCLAW_CONFIG_PATH" in
+                        "${OPENCLAW_STATE_DIR}/qa-runtime-config/openclaw.json") ;;
+                        "${OPENCLAW_STATE_DIR}/qa-auth-bootstrap/openclaw.json")
+                          [[ "${1:-}" == "models" && "${2:-}" == "auth" ]] ;;
+                        *) exit 1 ;;
+                      esac
                     fi
                     [[ -d "${CANDIDATE_ARTIFACTS_DIR:?}" && -r "$CANDIDATE_ARTIFACTS_DIR" && -x "$CANDIDATE_ARTIFACTS_DIR" && ! -w "$CANDIDATE_ARTIFACTS_DIR" ]]
                     for writable_path in \

--- a/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
+++ b/scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh
@@ -12,7 +12,8 @@ fi
 export CI=true
 export OPENCLAW_NO_ONBOARD=1
 export OPENCLAW_NO_PROMPT=1
-export OPENCLAW_SKIP_PROVIDERS=1
+# The target manager must start channels; suppression belongs only to the old process.
+unset OPENCLAW_SKIP_PROVIDERS OPENCLAW_SKIP_CHANNELS
 export OPENCLAW_DISABLE_BONJOUR=1
 export npm_config_audit=false
 export npm_config_fund=false
@@ -387,6 +388,7 @@ cp "$SYSTEMCTL_SHIM_LOG" "$SYSTEMCTL_SHIM_SETUP_LOG"
 : >"$SYSTEMCTL_SHIM_LOG"
 
 env \
+  OPENCLAW_SKIP_PROVIDERS=1 \
   OPENCLAW_SYSTEMD_UNIT=openclaw-gateway.service \
   openclaw gateway --port "$PORT" --bind loopback --allow-unconfigured \
   >"$GATEWAY_LOG" 2>&1 &
@@ -679,9 +681,7 @@ source_gateway_pid="$gateway_pid"
   fi
   echo "source Gateway exited through supervised update handoff"
   echo "starting installed service without provider suppression"
-  env \
-    -u OPENCLAW_SKIP_PROVIDERS \
-    systemctl --user start openclaw-gateway.service
+  systemctl --user start openclaw-gateway.service
   service_pid="$(cat "$SYSTEMCTL_SHIM_PID_FILE" 2>/dev/null || true)"
   [[ "$service_pid" =~ ^[0-9]+$ ]] || exit 1
   echo "service Gateway started pid=$service_pid"

--- a/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
+++ b/test/e2e/qa-lab/runtime/update-run-package-self-upgrade.test.ts
@@ -36,7 +36,6 @@ describe("update.run package self-upgrade producer", () => {
     );
 
     expect(script).toContain("source scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh");
-    expect(script).toContain("-u OPENCLAW_SKIP_PROVIDERS");
     expect(script).toContain("systemctl --user start openclaw-gateway.service");
     expect(script).toContain("OPENCLAW_SYSTEMD_UNIT=openclaw-gateway.service");
     expect(script).toContain("restart mode: update process respawn (supervisor restart)");

--- a/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
+++ b/test/scripts/openclaw-release-telegram-qa-workflow.test.ts
@@ -951,6 +951,12 @@ describe("release Telegram QA workflow", () => {
     expect(createSut).toContain(
       '"$(stat -c \'%F:%a:%u:%g\' "$requested_config_path")" == "regular file:600:${SUT_UID}:${SUT_GID}"',
     );
+    expect(createSut).toContain('generation_dir="${RUNTIME_ROOT}/config-generations"');
+    expect(createSut).toContain('install -d -o root -g root -m 0700 "$generation_dir"');
+    expect(createSut).toContain('"regular file:600:0:0"');
+    expect(createSut).toContain('/usr/bin/setpriv --reuid="$SUT_UID" --regid="$SUT_GID"');
+    expect(createSut).toContain('export OPENCLAW_CONFIG_PATH="$projection_dir/openclaw.json"');
+    expect(createSut).toContain('"${OPENCLAW_STATE_DIR}/qa-runtime-config/openclaw.json") ;;');
   });
 
   it("does not defer Bash startup cleanup to the privileged launcher", () => {

--- a/test/scripts/upgrade-survivor-systemd.test.ts
+++ b/test/scripts/upgrade-survivor-systemd.test.ts
@@ -14,7 +14,7 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 const owner = resolve("scripts/e2e/lib/upgrade-survivor/update-restart-auth.sh");
 
-function fixture(customPaths = true, registry?: string) {
+function fixture(customPaths = true, registry?: string, managerSetup = "") {
   const home = tempDirs.make("survivor-manager-");
   const artifacts = join(home, customPaths ? "artifacts ' \" $ `" : "bin");
   mkdirSync(artifacts, { recursive: true });
@@ -45,7 +45,7 @@ function fixture(customPaths = true, registry?: string) {
         timeout: 40_000,
       },
     );
-  const installed = shell("install_update_restart_systemctl_shim");
+  const installed = shell(`${managerSetup}\ninstall_update_restart_systemctl_shim`);
   expect(installed.status, installed.stderr).toBe(0);
   const systemctl = (...args: string[]) =>
     spawnSync(join(home, "bin/systemctl"), ["--user", ...args], {
@@ -59,6 +59,36 @@ function fixture(customPaths = true, registry?: string) {
 }
 
 describe.skipIf(process.platform === "win32")("survivor manager fixture", () => {
+  it("keeps self-upgrade target channels enabled despite historical source suppression", async () => {
+    const lane = readFileSync(
+      resolve("scripts/e2e/lib/upgrade-survivor/update-run-package-self-upgrade.sh"),
+      "utf8",
+    );
+    const setup = lane.slice(lane.indexOf("export CI=true"), lane.indexOf("SOURCE_VERSION="));
+    const { home, systemctl, unit } = fixture(true, undefined, setup);
+    const record = join(home, "target-env.json");
+    const program = join(home, "target.mjs");
+    writeFileSync(
+      program,
+      `import fs from "node:fs";
+fs.writeFileSync(${JSON.stringify(record)}, JSON.stringify({providers:process.env.OPENCLAW_SKIP_PROVIDERS ?? null, channels:process.env.OPENCLAW_SKIP_CHANNELS ?? null}));
+process.on("SIGTERM", () => process.exit(0));
+setInterval(() => {}, 1000);
+`,
+    );
+    writeFileSync(
+      unit,
+      buildSystemdUnit({ programArguments: [process.execPath, program], workingDirectory: home }),
+    );
+    try {
+      expect(systemctl("start", "openclaw-gateway.service").status).toBe(0);
+      await expect.poll(() => existsSync(record)).toBe(true);
+      expect(JSON.parse(readFileSync(record, "utf8"))).toEqual({ providers: null, channels: null });
+    } finally {
+      expect(systemctl("stop", "openclaw-gateway.service").status).toBe(0);
+    }
+  });
+
   it("distinguishes confirmed absence from unsupported inspection and reads the generated service", async () => {
     const { home, env, systemctl, unit } = fixture();
     // First install must reach the same effective reader used by the guarded writer.


### PR DESCRIPTION
## What Problem This Solves

Resolves two release-verification failures caused by harness ownership: a restarted self-upgrade candidate inherits provider suppression and never starts its QA channel, while the isolated Telegram candidate's Doctor cannot update a configuration in the trusted runner's directory.

## Why This Change Was Made

Clear provider/channel suppression before the fixture manager captures its environment, and apply suppression only to the historical Gateway process. The candidate service can then start channels under the existing strict readiness checks.

Keep Telegram's canonical scenario configuration immutable and seed a private runtime copy as the unprivileged system-under-test user. Root-owned generation receipts outside runtime state preserve Doctor repairs when canonical bytes are unchanged and refresh the copy after scenario mutations. Config digest checks, UID/capability dropping, trusted artifact protections, and runtime isolation remain enforced.

## User Impact

Release qualification can exercise the intended candidate channel and Doctor flows without changing product permissions, generic manager behavior, or weakening readiness assertions.

## Evidence

- Combined focused tests: 85 passed; two existing Linux-only diagnostics tests skipped on macOS.
- Scoped changed checks passed, including workflow validation, script/root-test typing, lint, formatting, and Docker boundary guards.
- Fresh combined independent P2 review passed. CI exposed one obsolete source-text assertion for transient systemctl environment clearing; removed it in favor of the real managed-child proof. All 13 affected producer/manager tests, scoped checks, and narrow P2 review pass.
- The actual manager-child regression reproduces captured suppression before the fix and verifies both flags absent afterward; 64 survivor assertion tests remain green.
- With the exact prepared candidate package and synthetic Linux UIDs, canonical config reproduces Doctor's permission failure; the projected copy passes Doctor, update repair, and Gateway health. The lifecycle proof verifies unchanged-source preservation, changed-source reseeding, and protected canonical config/generation receipts.

The complete hosted Telegram and sealed self-upgrade consumer reruns remain assigned to Full Release Verification. This PR does not claim those complete lanes are green or publish a release.
