### PR TITLE
fix(telegram): keep successful album recovery quiet

### DIFF
--- a/extensions/telegram/src/bot/delivery.test.ts
+++ b/extensions/telegram/src/bot/delivery.test.ts
@@ -1346,6 +1346,7 @@ describe("deliverReplies", () => {
   });
 
   it("uses single-photo document recovery after a definite album photo-limit rejection", async () => {
+    const runtime = createRuntime();
     const mediaUrls = mockPhotoMedia();
     const failure = createChunkRejection("PHOTO_INVALID_DIMENSIONS");
     const sendMediaGroup = vi.fn().mockRejectedValue(failure);
@@ -1358,7 +1359,7 @@ describe("deliverReplies", () => {
     await expect(
       deliverWith({
         replies: [{ text: "Caption", mediaUrls }],
-        runtime: createRuntime(),
+        runtime,
         bot: createBot({ sendMediaGroup, sendPhoto, sendDocument }),
       }),
     ).resolves.toEqual({ delivered: true });
@@ -1375,9 +1376,11 @@ describe("deliverReplies", () => {
     );
     expect(mockCallArg(sendPhoto, 1, 1)).toMatchObject({ filename: "photo-1.jpg" });
     expect(recordSentMessage.mock.calls.map((call) => call[1])).toEqual([101, 102]);
+    expect(runtime.error).not.toHaveBeenCalled();
   });
 
   it("does not replay an album after an ambiguous upload failure", async () => {
+    const runtime = createRuntime();
     const mediaUrls = mockPhotoMedia();
     const failure = createPlainHttpError("sendMediaGroup");
     const sendMediaGroup = vi.fn().mockRejectedValue(failure);
@@ -1387,7 +1390,7 @@ describe("deliverReplies", () => {
     await expect(
       deliverWith({
         replies: [{ mediaUrls }],
-        runtime: createRuntime(),
+        runtime,
         bot: createBot({ sendMediaGroup, sendPhoto, sendDocument }),
       }),
     ).rejects.toBe(failure);
@@ -1395,6 +1398,7 @@ describe("deliverReplies", () => {
     expect(sendPhoto).not.toHaveBeenCalled();
     expect(sendDocument).not.toHaveBeenCalled();
     expect(recordSentMessage).not.toHaveBeenCalled();
+    expect(runtime.error).toHaveBeenCalledWith(expect.stringContaining("sendMediaGroup failed"));
   });
 
   it("stops a media follow-up when the provider returns the wrong topic", async () => {

--- a/extensions/telegram/src/send-prepared.ts
+++ b/extensions/telegram/src/send-prepared.ts
@@ -349,6 +349,7 @@ export function createTelegramPreparedSender(config: {
       operation: "sendMediaGroup",
       requestParams: params.requestParams,
       plainCaption: params.plainCaption,
+      shouldLog: (error) => !isTelegramPhotoLimitError(error),
       send: (requestParams, shouldLog) =>
         request(
           "sendMediaGroup",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Telegram logged an album upload as an error even after a photo-limit rejection was successfully recovered through the existing individual-photo/document path.

## Why This Change Was Made

Apply the existing single-photo logging policy to album uploads. Only the recognized photo-limit errors used by that recovery path are quieted; ambiguous upload failures remain logged and rethrown.

## User Impact

Successful album recovery no longer produces a misleading error. Delivery order, media bytes and message receipts keep their existing behavior.

## Evidence

The existing recovery case failed only on its unexpected error log before the change, then passed unchanged afterward. The ambiguous-failure control still logs and rethrows without replay. Both cases and 24 ordinary sibling cases passed; all 25 selected changed checks passed. Independent P0–P2 review found no actionable defect. No live Telegram messages were sent.
