### PR TITLE
fix(sessions): keep yielded running main sessions reusable during sibling completion

### DIFF
--- a/src/agents/command/session.yielded-parent-reuse.test.ts
+++ b/src/agents/command/session.yielded-parent-reuse.test.ts
@@ -1,0 +1,104 @@
+// Covers command-session resolution for a yielded parent whose children complete
+// after its transcript was admitted: the parent generation must survive.
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../../config/config.js";
+import {
+  appendTranscriptEvent,
+  loadSessionEntry,
+  upsertSessionEntryCore,
+} from "../../config/sessions/session-accessor.js";
+import { deriveGatewaySessionLifecycleSnapshot } from "../../gateway/session-lifecycle-state.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  resolveOpenClawAgentSqlitePath,
+} from "../../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
+import { resolveSession } from "./session.js";
+
+describe("resolveSession with a yielded running parent", () => {
+  let stateDir: string;
+  let storePath: string;
+
+  beforeEach(() => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-yielded-parent-"));
+    storePath = path.join(stateDir, "agents", "main", "sessions", "sessions.json");
+  });
+
+  afterEach(() => {
+    closeOpenClawAgentDatabasesForTest();
+    closeOpenClawStateDatabaseForTest();
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it("keeps the parent session generation across sibling completions", async () => {
+    const agentId = "main";
+    const sessionKey = "agent:main:main";
+    const parentSessionId = "parent-session-0001";
+    const cfg = { session: { store: storePath } } as OpenClawConfig;
+    const startedAt = Date.now() - 60_000;
+    const yieldedAt = startedAt + 20_000;
+
+    // The parent run starts, then yields; the Gateway projection keeps it running
+    // while recording the settled run's endedAt.
+    const running = deriveGatewaySessionLifecycleSnapshot({
+      session: { updatedAt: startedAt },
+      event: {
+        ts: startedAt,
+        sessionId: parentSessionId,
+        runId: "parent-run",
+        data: { phase: "start", startedAt },
+      },
+    });
+    const yielded = deriveGatewaySessionLifecycleSnapshot({
+      session: running,
+      event: {
+        ts: yieldedAt,
+        sessionId: parentSessionId,
+        runId: "parent-run",
+        data: {
+          phase: "end",
+          endedAt: yieldedAt,
+          yielded: true,
+          livenessState: "paused",
+          stopReason: "end_turn",
+        },
+      },
+    });
+    expect(yielded).toMatchObject({ status: "running", endedAt: yieldedAt });
+    await upsertSessionEntryCore(
+      { agentId, sessionKey, storePath },
+      {
+        sessionId: parentSessionId,
+        sessionFile: `sqlite:main:${parentSessionId}:${resolveOpenClawAgentSqlitePath({
+          agentId,
+          env: { OPENCLAW_STATE_DIR: stateDir },
+        })}`,
+        updatedAt: yieldedAt,
+        startedAt,
+        status: yielded.status,
+        endedAt: yielded.endedAt,
+      },
+    );
+
+    const first = resolveSession({ cfg, sessionKey, agentId });
+    expect(first.sessionId).toBe(parentSessionId);
+
+    // The first completion's prompt admission lands after the registry row.
+    await appendTranscriptEvent(
+      { agentId, sessionId: parentSessionId, sessionKey, storePath },
+      { type: "custom", timestamp: new Date().toISOString() },
+    );
+    expect(loadSessionEntry({ agentId, sessionKey, storePath })).toMatchObject({
+      status: "running",
+      endedAt: yieldedAt,
+    });
+
+    const second = resolveSession({ cfg, sessionKey, agentId });
+    expect(second.sessionId).toBe(parentSessionId);
+    expect(second.isNewSession).toBe(false);
+    expect(second.previousSessionId).toBeUndefined();
+  });
+});

--- a/src/config/sessions/lifecycle.test.ts
+++ b/src/config/sessions/lifecycle.test.ts
@@ -126,6 +126,19 @@ describe("terminal main session transcript freshness", () => {
     expect(check(entry, sessionKey)).toBe(true);
   });
 
+  it("keeps a yielded running main session reusable after a child transcript admission", async () => {
+    // A yielded parent is persisted as status "running" plus the settled run's
+    // endedAt; a later child transcript write must not rotate it.
+    const { entry, sessionKey } = await createEntry({
+      status: "running",
+      endedAt: Date.now() - 20_000,
+      updatedAt: Date.now() - 10_000,
+    });
+
+    expect(entry.endedAt).toBeDefined();
+    expect(check(entry, sessionKey)).toBe(false);
+  });
+
   it("uses SQLite freshness for entries that still contain legacy transcript paths", async () => {
     const { entry, sessionKey } = await createEntry({
       sessionFile: path.join(stateDir, "legacy-session.jsonl"),

--- a/src/config/sessions/lifecycle.ts
+++ b/src/config/sessions/lifecycle.ts
@@ -238,6 +238,13 @@ function resolveTerminalMainSessionTranscriptRegistryCheck(
   if (candidateSessionKey !== configuredMainSessionKey) {
     return undefined;
   }
+  if (params.entry.status === "running") {
+    // A yielded parent keeps status "running" next to the settled run's endedAt
+    // (see deriveGatewaySessionLifecycleSnapshot). That timestamp records run
+    // timing, not a terminal session: sibling completions must keep reusing the
+    // same session generation instead of rotating the parent mid-preparation.
+    return undefined;
+  }
   const hasTerminalLifecycle =
     isTerminalSessionStatus(params.entry.status) ||
     resolvePositiveTimestamp(params.entry.endedAt) !== undefined;


### PR DESCRIPTION
Closes #141242.

## What Problem This Solves

A yielded main session is intentionally stored with `status: "running"` together with the settled run's `endedAt`. The terminal-transcript freshness predicate in `src/config/sessions/lifecycle.ts` treated any positive `endedAt` as a terminal lifecycle marker, so a later child transcript admission made it report the parent as stale. The next sibling completion then resolved a new session ID and the earlier completion's captured generation authority failed with `AgentHarnessSessionSupersededError`.

## Why This Change Was Made

`endedAt` on a running row records run timing, not a terminal session. The Gateway lifecycle projection already asserts this shape for yielded parents (`keeps an explicitly yielded parent pending until continuation starts` in `src/gateway/session-lifecycle-state.test.ts`). The predicate now returns early for an explicit `running` status before the `endedAt` fallback, which remains in place for legacy rows that carry `endedAt` without any status. The existing `done` and `failed` reuse branches are unchanged. Both consumers of the predicate, the agent command session resolver and the Gateway session patch path, pick up the repair without modification.

## User Impact

Sibling child completions targeting a yielded parent keep the same session generation instead of rotating the parent mid-preparation, so the first completion no longer fails as superseded and the parent's transcript continuity is preserved.

## Evidence

Base: `662080ac830ea15d147a498d72a1abf884e48b37`. Head: `3a30cf8c7cfc263c258c8997821362579fd47c59`.

Regression tests, both failing on the base commit for the reported reason and passing with the fix:

- Predicate boundary: `keeps a yielded running main session reusable after a child transcript admission` in `src/config/sessions/lifecycle.test.ts` (base: `expected true to be false`).
- Consumer boundary: `keeps the parent session generation across sibling completions` in `src/agents/command/session.yielded-parent-reuse.test.ts`. It drives the production `resolveSession` against a real SQLite store: the parent row is projected by `deriveGatewaySessionLifecycleSnapshot` from a `sessions_yield` end event, the first completion resolves the parent, its prompt admission is written with `appendTranscriptEvent`, and the second completion resolves the canonical main key with no explicit session id (base: `expected '4c4b839e-…' to be 'parent-session-0001'`).

Suites: `src/config/sessions/lifecycle.test.ts` (9 passed), `src/gateway/session-lifecycle-state.test.ts` (42 passed), `src/gateway/server-methods/agent-session-patch.test.ts` (16 passed), the five `src/agents/command/session*.test.ts` files (135 passed).

Real Gateway run: `pnpm openclaw qa suite --provider-mode mock-openai --scenario subagent-fanout-synthesis --scenario subagent-handoff` on this head, isolated QA Gateway child, 2 passed, 0 failed, 19.7 s. The fan-out scenario spawns two children sequentially with the parent waiting on each completion, then folds both results into one parent reply (`subagent-1: ok` / `subagent-2: ok`); the handoff scenario reports the child result folded back into the main thread exactly once. No supersession error appears in the evidence bundle.

`$autoreview` (Codex `gpt-5.6-sol`, high reasoning, `--mode branch --base origin/main --max-priority P2`): scoped-clean, no accepted or actionable findings. Reviewer summary: the early return treats an explicitly running main session as non-terminal even when `endedAt` is populated by a yielded run, preserves parent-session reuse during sibling continuation, and leaves terminal statuses and legacy `endedAt`-only rows on the existing path.

`node scripts/check-changed.mjs --base origin/main --head HEAD`: passed on `3a30cf8c7cf` (deprecated-API guard, Knip dead-export scans, core lint, tsgo core and core-test typecheck, schema version guard, database-first legacy-store guard, import-cycle check, and the remaining repository guards).

## After-fix behavior trace

### Overlapping sibling completions through the Gateway agent handler

Two `task_completion` internal events for the same canonical main key are sent through the real Gateway `agent` handler (`agentHandlers.agent` in `src/gateway/server-methods/agent.ts`), backed by a real SQLite session store in an isolated `OPENCLAW_STATE_DIR`. The parent row is projected by `deriveGatewaySessionLifecycleSnapshot` from a `sessions_yield` end event. The run executor behind the handler is replaced by a stub that records the session id it is dispatched with and holds the run open, so completion #2 is admitted and prepared while completion #1 is still live. Between the two, completion #1's prompt admission is written to the parent transcript with `appendTranscriptEvent`.

With this PR (head `3a30cf8c7cf`):

```text
parent row after sessions_yield: {"status":"running","endedAt":1788821185216}
gateway accepted completion #1: {"ok":true,"status":"accepted","err":null}
completion #1 dispatched with: {"runId":"idem-alpha","sessionId":"parent-session-0001","sessionKey":"agent:main:main"}
parent row seen by completion #2: {"sessionId":"parent-session-0001","status":"running","endedAt":1788821185216}
gateway accepted completion #2: {"ok":true,"status":"accepted","err":null}
completion #2 dispatched with: {"runId":"idem-beta","sessionId":"parent-session-0001","sessionKey":"agent:main:main"}
RESULT: both completions dispatched on parent-session-0001; parent generation preserved
```

Same exercise with the base predicate (`662080ac830`):

```text
parent row after sessions_yield: {"status":"running","endedAt":1788821228326}
gateway accepted completion #1: {"ok":true,"status":"accepted","err":null}
completion #1 dispatched with: {"runId":"idem-alpha","sessionId":"parent-session-0001","sessionKey":"agent:main:main"}
parent row seen by completion #2: {"sessionId":"parent-session-0001","status":"running","endedAt":1788821228326}
gateway accepted completion #2: {"ok":true,"status":"accepted","err":null}
completion #2 dispatched with: {"runId":"idem-beta","sessionId":"d79ce8f8-88c4-46f7-ad27-51dc8edf27e7","sessionKey":"agent:main:main"}
RESULT: completion #2 dispatched on d79ce8f8-88c4-46f7-ad27-51dc8edf27e7 while completion #1 runs on parent-session-0001; parent ROTATED
```

On the base commit the Gateway hands the second sibling a fresh session id while the first sibling is still executing on the parent id. That divergence is the session-generation change behind `AgentHarnessSessionSupersededError`. With the fix both siblings are dispatched on the parent id.

### Agent command resolver

The same flow driven through `resolveSession` in `src/agents/command/session.ts` (the other consumer of the predicate), no mocks. With this PR:

```text
completion #1 resolved: {"sessionId":"parent-session-0001","isNewSession":false}
registry row before completion #2: {"status":"running","endedAt":1788819516839,"updatedAt":1788819557388}
completion #2 resolved: {"sessionId":"parent-session-0001","isNewSession":false}
```

Base predicate:

```text
completion #2 resolved: {"sessionId":"40a846e3-664f-43ea-b288-abb404cbe772","isNewSession":true,"previousSessionId":"parent-session-0001"}
```

Known gap: in the Gateway exercise the run executor behind the handler is a stub, so the model turn itself does not execute; the session admission, preparation, reuse decision, and dispatch are the real Gateway code paths. A live-provider run with two concurrently executing Codex children was not reproduced, since that race depends on provider timing.
