### PR TITLE
fix(android): show expanded catalog refresh failures

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/NodeRuntime.kt
@@ -5945,26 +5945,20 @@ class NodeRuntime private constructor(
           loadedPageDepthsByHost = previousPageDepths,
           isCurrent = { sessionCatalogRefreshSeq.get() == requestSeq },
         ) { catalogId, hostId, cursor ->
-          try {
-            val pageResponse =
-              requestGatewayData(
-                gatewayScope,
-                "sessions.catalog.list",
-                sessionCatalogPageParams(
-                  normalizedAgentId,
-                  catalogId,
-                  mapOf(hostId to cursor),
-                ),
-              )
-            parseSessionCatalogs(pageResponse, normalizedAgentId, json)
-              .firstOrNull { it.id == catalogId }
-              ?.hosts
-              ?.firstOrNull { it.hostId == hostId }
-          } catch (err: CancellationException) {
-            throw err
-          } catch (_: Throwable) {
-            null
-          }
+          val pageResponse =
+            requestGatewayData(
+              gatewayScope,
+              "sessions.catalog.list",
+              sessionCatalogPageParams(
+                normalizedAgentId,
+                catalogId,
+                mapOf(hostId to cursor),
+              ),
+            )
+          parseSessionCatalogs(pageResponse, normalizedAgentId, json)
+            .firstOrNull { it.id == catalogId }
+            ?.hosts
+            ?.firstOrNull { it.hostId == hostId }
         }
       publishGatewayData(gatewayScope) {
         if (sessionCatalogRefreshSeq.get() == requestSeq) {

--- a/apps/android/app/src/test/java/ai/openclaw/app/SessionCatalogRuntimeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/SessionCatalogRuntimeTest.kt
@@ -149,6 +149,7 @@ class SessionCatalogRuntimeTest {
       val refreshStarted = CompletableDeferred<Unit>()
       val releaseRefresh = CompletableDeferred<Unit>()
       val loadMoreStarted = CompletableDeferred<Unit>()
+      var failExpandedRefresh = false
       try {
         ReflectionHelpers.setField(runtime, "connectedEndpoint", GatewayEndpoint.manual("127.0.0.1", 18789))
         ReflectionHelpers.setField(runtime, "operatorConnected", true)
@@ -181,6 +182,7 @@ class SessionCatalogRuntimeTest {
           val request = Json.parseToJsonElement(requireNotNull(params)).jsonObject
           if ("cursors" in request) {
             loadMoreStarted.complete(Unit)
+            if (failExpandedRefresh) error("Synthetic catalog page failure")
             """{"catalogs":[{"id":"codex","label":"Codex","hosts":[{"hostId":"desktop","label":"Desktop","kind":"node","connected":true,"sessions":[{"threadId":"page-2","status":"idle","canContinue":true}]}]}]}"""
           } else {
             refreshStarted.complete(Unit)
@@ -226,6 +228,15 @@ class SessionCatalogRuntimeTest {
             .map(SessionCatalogEntry::threadId),
         )
         assertEquals(1, state.loadedPageDepthsByHost[sessionCatalogHostKey("codex", "desktop")])
+
+        failExpandedRefresh = true
+        withTimeout(2_000) { invokeRefreshSessionCatalogFromGateway(runtime, "main") }
+
+        val failedRefresh = runtime.sessionCatalogState.value
+        assertFalse(failedRefresh.loading)
+        assertEquals(state.catalogs, failedRefresh.catalogs)
+        assertEquals(state.loadedPageDepthsByHost, failedRefresh.loadedPageDepthsByHost)
+        assertTrue("A failed expanded-page refresh must remain visible", !failedRefresh.errorText.isNullOrBlank())
       } finally {
         releaseRefresh.complete(Unit)
         closeNodeRuntimeTestFixture(runtime)


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android could hide a session-catalog refresh failure after the user had loaded more pages. Previously loaded rows stayed visible, making the failed refresh look successful.

## Why This Change Was Made

Remove the inner catch that converted a failed page request into a successful missing-host result. The existing refresh error handler now handles that failure, preserving loaded rows and page depths while clearing loading and publishing the existing error message. Successful missing-host responses retain their existing behavior.

## User Impact

An expanded catalog reports a failed refresh while keeping its previous contents available.

## Evidence

The existing paging test first proves successful refresh/load-more, then fails a later-page request. On unchanged production, only the visible-error assertion failed among 11 selected cases. The identical regression and all existing catalog siblings passed after repair: 15 tests, zero skips.

All 14 canonical changed checks passed, including Gradle ktlint. Independent P0–P2 review found no actionable defect. Proof ran as hermetic Robolectric/JVM tests on a disposable Linux worker; raw JUnit results were inspected and the worker was stopped. Device rendering and a live Gateway were not exercised.


CI recovery: the original run failed in an unrelated Voice Wake save-notice test. Its synchronization fix landed separately in #141635. This branch includes that prerequisite through a rebase; both changed file contents and the complete introduced patch remain byte-identical to the reviewed version. Exact-head CI34174157023 passed8jobs with26skipped;the required gate is green.
