### PR TITLE
refactor(test): simplify queued steering message fixtures

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.queue-message.test.ts
@@ -36,6 +36,14 @@ function registerDisplayRetirement(message: object) {
 type SteeringMessage = Parameters<typeof setSteeringMessageIdentity>[0];
 type CancelableAgent = NonNullable<EmbeddedAgentActiveSessionSteerTarget["agent"]>;
 
+function queuedTextMessage(text: string, timestamp: number) {
+  return {
+    role: "user",
+    content: [{ type: "text", text }],
+    timestamp,
+  } satisfies SteeringMessage;
+}
+
 function createCancelableAgent(messages: object[]): CancelableAgent {
   return {
     cancelSteeringMessage: (predicate: (message: SteeringMessage) => boolean) => {
@@ -224,11 +232,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
   });
 
   it("rejects only the exact drained steer when its transcript append fails", async () => {
-    const failedMessage = {
-      role: "user" as const,
-      content: [{ type: "text" as const, text: "same text" }],
-      timestamp: 1,
-    };
+    const failedMessage = queuedTextMessage("same text", 1);
     const survivingMessage = { ...failedMessage, timestamp: 2 };
     setSteeringMessageIdentity(failedMessage, "failed-turn");
     setSteeringMessageIdentity(survivingMessage, "surviving-turn");
@@ -284,11 +288,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
       content: [{ type: "text", text: "keep this rich payload" }, unrelatedImage],
       timestamp: 1,
     };
-    const targetMessage = {
-      role: "user",
-      content: [{ type: "text", text: "timed-out completion announce" }],
-      timestamp: 2,
-    };
+    const targetMessage = queuedTextMessage("timed-out completion announce", 2);
     const trailingMessage = {
       role: "custom",
       customType: "notice",
@@ -325,16 +325,8 @@ describe("embedded OpenClaw queued steering cancellation", () => {
   it("returns an unconsumed terminal steer for normal-turn promotion", async () => {
     vi.useFakeTimers();
     let emit!: (event: unknown) => void;
-    const targetMessage = {
-      role: "user",
-      content: [{ type: "text", text: "completion after parent stopped" }],
-      timestamp: 2,
-    };
-    const keepMessage = {
-      role: "user",
-      content: [{ type: "text", text: "keep unrelated queue entry" }],
-      timestamp: 3,
-    };
+    const targetMessage = queuedTextMessage("completion after parent stopped", 2);
+    const keepMessage = queuedTextMessage("keep unrelated queue entry", 3);
     const queueMessages = [targetMessage, keepMessage];
     const retireDisplay = registerDisplayRetirement(targetMessage);
     let unsubscribed = false;
@@ -433,11 +425,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
     const steerReturned = new Promise<void>((resolve) => {
       reportSteerReturned = resolve;
     });
-    const targetMessage = {
-      role: "user" as const,
-      content: [{ type: "text" as const, text: "queued before settlement" }],
-      timestamp: 1,
-    };
+    const targetMessage = queuedTextMessage("queued before settlement", 1);
     const queueMessages = [targetMessage];
     const retireDisplay = registerDisplayRetirement(targetMessage);
     const onQueueAccepted = vi.fn();
@@ -480,11 +468,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
 
   it("removes the runtime steer even when display retirement fails", async () => {
     let emit!: (event: unknown) => void;
-    const targetMessage = {
-      role: "user" as const,
-      content: [{ type: "text" as const, text: "runtime ownership wins" }],
-      timestamp: 1,
-    };
+    const targetMessage = queuedTextMessage("runtime ownership wins", 1);
     const queueMessages = [targetMessage];
     registerQueuedUserMessageRetirement(targetMessage, () => {
       throw new Error("display cleanup failed");
@@ -553,11 +537,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
 
   it("matches identical steering text by stable queue identity", async () => {
     let emit!: (event: unknown) => void;
-    const first = {
-      role: "user" as const,
-      content: [{ type: "text" as const, text: "same text" }],
-      timestamp: 1,
-    };
+    const first = queuedTextMessage("same text", 1);
     const second = { ...first, content: [...first.content], timestamp: 2 };
     setSteeringMessageIdentity(first, "steer-a");
     setSteeringMessageIdentity(second, "steer-b");
@@ -586,11 +566,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
   });
 
   it("cancels the exact accepted steer when its source aborts", async () => {
-    const first = {
-      role: "user" as const,
-      content: [{ type: "text" as const, text: "same text" }],
-      timestamp: 1,
-    };
+    const first = queuedTextMessage("same text", 1);
     const second = { ...first, content: [...first.content], timestamp: 2 };
     setSteeringMessageIdentity(first, "steer-a");
     setSteeringMessageIdentity(second, "steer-b");
@@ -616,11 +592,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
 
   it("cancels the exact expanded steer without leaving a duplicate UI entry", async () => {
     const expandedText = "expanded steering text";
-    const first = {
-      role: "user" as const,
-      content: [{ type: "text" as const, text: expandedText }],
-      timestamp: 1,
-    };
+    const first = queuedTextMessage(expandedText, 1);
     const second = { ...first, content: [...first.content], timestamp: 2 };
     setSteeringMessageIdentity(first, "keep-first");
     setSteeringMessageIdentity(second, "cancel-second");
@@ -744,11 +716,7 @@ describe("embedded OpenClaw queued steering cancellation", () => {
     vi.useFakeTimers();
     try {
       let emit!: (event: unknown) => void;
-      const targetMessage = {
-        role: "user",
-        content: [{ type: "text", text: "completion survives compaction" }],
-        timestamp: 2,
-      };
+      const targetMessage = queuedTextMessage("completion survives compaction", 2);
       const queueMessages = [targetMessage];
       const activeSession: EmbeddedAgentActiveSessionSteerTarget = {
         agent: createCancelableAgent(queueMessages),


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Queued steering tests repeat plain text-message setup, making their cancellation and transcript-commit scenarios harder to scan.

## Why This Change Was Made

Use one local constructor for ten plain text-user inputs. It preserves explicit text and timestamps, ordered properties, and fresh message, array, and text-block allocations. Existing spread-derived siblings retain their deliberate sharing. Multipart, incomplete, metadata-bearing, image-only, and expected-output fixtures remain unchanged.

## User Impact

No runtime behavior change. The same steering cancellation, persistence, and identity contracts remain covered with 32 fewer test lines.

## Evidence

- All 72 cases across the queued-steering suite and real-session correctness/next-turn siblings passed before and after, with identical case names.
- Expanding the ten constructor calls reproduces the complete original test AST and comments. Separate graph checks preserve ordered keys, property absence, fresh allocations, sibling sharing, and non-enumerable identity behavior.
- Mapped changed checks and fresh independent P2 review passed. No overall runtime improvement is claimed.
