### PR TITLE
fix(agents): avoid retired relay connections during replacement

### DIFF
--- a/src/agents/harness/native-hook-relay-bridge.ts
+++ b/src/agents/harness/native-hook-relay-bridge.ts
@@ -169,7 +169,7 @@ export function renewNativeHookRelayBridgeRecord(
 export function unregisterNativeHookRelayBridge(
   relayId: string,
   options?: {
-    deferBridgeRecordRemovalMs?: number;
+    deferListenerCloseMs?: number;
     expectedBridge?: NativeHookRelayBridgeRegistration;
   },
 ): void {
@@ -180,27 +180,23 @@ export function unregisterNativeHookRelayBridge(
   if (relayBridges.get(relayId) === bridge) {
     relayBridges.delete(relayId);
   }
-  const removeRecord = () => {
-    bridge.server.close();
-    try {
-      deleteNativeHookRelayBridgeRecordIfOwned({ ...bridge, pid: process.pid });
-    } catch (error) {
-      log.debug("failed to remove native hook relay bridge record", { error, relayId });
-    }
-  };
-  const deferBridgeRecordRemovalMs = normalizePositiveInteger(
-    options?.deferBridgeRecordRemovalMs,
-    0,
-  );
-  if (deferBridgeRecordRemovalMs > 0) {
-    // Keep the retired listener with its locator during replacement: it rejects
-    // stale requests and reserves the port until the successor publishes. The
-    // token-scoped cleanup cannot delete that successor's record.
-    const timeout = setTimeout(removeRecord, deferBridgeRecordRemovalMs);
+  // Stop advertising the retired endpoint before its listener can close.
+  // Token-scoped removal cannot delete an already-published successor.
+  try {
+    deleteNativeHookRelayBridgeRecordIfOwned({ ...bridge, pid: process.pid });
+  } catch (error) {
+    log.debug("failed to remove native hook relay bridge record", { error, relayId });
+  }
+  const closeListener = () => bridge.server.close();
+  const deferListenerCloseMs = normalizePositiveInteger(options?.deferListenerCloseMs, 0);
+  if (deferListenerCloseMs > 0) {
+    // Readers that already captured the old locator still receive a stale-owner
+    // rejection. New lookups wait for the successor's listener publication.
+    const timeout = setTimeout(closeListener, deferListenerCloseMs);
     timeout.unref();
     return;
   }
-  removeRecord();
+  closeListener();
 }
 
 async function handleNativeHookRelayBridgeRequest(

--- a/src/agents/harness/native-hook-relay.test.ts
+++ b/src/agents/harness/native-hook-relay.test.ts
@@ -1,19 +1,23 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
-import { createServer, request as httpRequest } from "node:http";
+import { createServer, request as httpRequest, Server } from "node:http";
+import { Socket } from "node:net";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { PassThrough, Readable } from "node:stream";
 import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coercion";
 // Covers native hook relay registration, bridge invocation, and approval state.
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { runNativeHookRelayCliFromArgv } from "../../cli/native-hook-relay-cli.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import { replaceSessionEntry } from "../../config/sessions/session-accessor.js";
 import {
   createAgentRuntimeApprovalAuthorityValidator,
   mintAgentRuntimeIdentityToken,
 } from "../../gateway/agent-runtime-identity-token.js";
+import { nativeHookRelayHandlers } from "../../gateway/server-methods/native-hook-relay.js";
 import { validateAgentRunDelegatedAuthority } from "../../infra/agent-run-registry.js";
 import {
   initializeGlobalHookRunner,
@@ -24,6 +28,7 @@ import { patchPluginSessionExtension } from "../../plugins/host-hook-state.js";
 import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
 import { setActivePluginRegistry } from "../../plugins/runtime.js";
 import { resolveOpenClawStateSqlitePath } from "../../state/openclaw-state-db.paths.js";
+import { splitShellArgs } from "../../utils/shell-argv.js";
 import {
   closeAdmittedRunDelegatedAuthority,
   getAdmittedRunDelegatedAuthority,
@@ -1208,6 +1213,145 @@ describe("native hook relay registry", () => {
     ).resolves.toEqual({ stdout: "", stderr: "", exitCode: 0 });
     replacement.unregister();
   });
+
+  it("invokes the successor when retirement expires before its listener publishes", async () => {
+    const first = registerNativeHookRelay({
+      provider: "codex",
+      relayId: uniqueNativeHookRelayIdForTests("replacement-publication"),
+      sessionId: "session-1",
+      runId: "run-first",
+      allowedEvents: ["post_tool_use"],
+    });
+    await waitForNativeHookRelayBridgeRecord(first.relayId);
+    const connectionErrors: unknown[] = [];
+    // oxlint-disable-next-line typescript/unbound-method -- called below with the intercepted socket receiver.
+    const originalEmit = Socket.prototype.emit;
+    vi.spyOn(Socket.prototype, "emit").mockImplementation(function (this: Socket, event, ...args) {
+      if (event === "error") {
+        connectionErrors.push(args[0]);
+      }
+      return originalEmit.call(this, event, ...args);
+    });
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      const successor = registerNativeHookRelay({
+        provider: "codex",
+        relayId: first.relayId,
+        sessionId: "session-1",
+        runId: "run-successor",
+        allowedEvents: ["post_tool_use"],
+      });
+      const result = expect(
+        invokeNativeHookRelayBridge({
+          provider: "codex",
+          relayId: successor.relayId,
+          generation: successor.generation,
+          event: "post_tool_use",
+          timeoutMs: 2_000,
+          rawPayload: { hook_event_name: "PostToolUse", tool_name: "Bash", tool_response: {} },
+        }),
+      ).resolves.toMatchObject({ exitCode: 0 });
+      // Let retirement win before Node delivers listening/connect callbacks.
+      vi.advanceTimersByTime(250);
+      await vi.advanceTimersByTimeAsync(25);
+      await result;
+      expect(connectionErrors).toEqual([]);
+      expect(getOnlyNativeHookRelayInvocation()).toMatchObject({ runId: "run-successor" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it.each([
+    { event: "pre_tool_use", noop: false },
+    { event: "pre_tool_use", noop: true },
+    { event: "permission_request", noop: false },
+    { event: "post_tool_use", noop: false },
+  ] as const)(
+    "keeps stale CLI authority closed during delayed publication ($event, noop=$noop)",
+    async ({ event, noop }) => {
+      const first = registerNativeHookRelay({
+        provider: "codex",
+        relayId: uniqueNativeHookRelayIdForTests("replacement-cli"),
+        sessionId: "session-1",
+        runId: "run-first",
+        allowedEvents: [event],
+      });
+      await waitForNativeHookRelayBridgeRecord(first.relayId);
+      const command = buildNativeHookRelayCommand({
+        provider: "codex",
+        relayId: first.relayId,
+        generation: first.generation,
+        event,
+        ...(noop ? { preToolUseUnavailable: "noop" } : {}),
+        timeoutMs: 2_000,
+      });
+      const argv = splitShellArgs(command);
+      if (!argv) {
+        throw new Error("Expected generated relay command to parse");
+      }
+      // Hold successor startup, while keeping the retired listener and real
+      // read-only locator lookup intact across the CLI registration deadline.
+      const listen = vi
+        .spyOn(Server.prototype, "listen")
+        .mockImplementation(function (this: Server) {
+          return this;
+        });
+      try {
+        registerNativeHookRelay({
+          provider: "codex",
+          relayId: first.relayId,
+          sessionId: "session-1",
+          runId: "run-successor",
+          allowedEvents: [event],
+        });
+        const callGateway = vi.fn(async (opts: { params?: unknown }): Promise<never> => {
+          let failure = "Gateway unexpectedly accepted the retired generation";
+          await nativeHookRelayHandlers["nativeHook.invoke"]!({
+            req: { type: "req", id: "replacement-cli", method: "nativeHook.invoke" },
+            params: requireRecord(opts.params, "gateway relay parameters"),
+            client: null,
+            isWebchatConnect: () => false,
+            respond: (ok, _result, error) => {
+              expect(ok).toBe(false);
+              failure = error?.message ?? failure;
+            },
+            context: {} as never,
+          });
+          throw new Error(failure);
+        });
+        const stdout = new PassThrough();
+        const stderr = new PassThrough();
+        await expect(
+          runNativeHookRelayCliFromArgv(argv, {
+            stdin: Readable.from([
+              JSON.stringify({
+                hook_event_name: "PreToolUse",
+                tool_name: "Bash",
+                tool_input: { command: "echo fixture" },
+              }),
+            ]),
+            stdout,
+            stderr,
+            callGateway,
+          }),
+        ).resolves.toBe(0);
+        expect(callGateway).toHaveBeenCalledOnce();
+        expect(String(stderr.read())).toContain("native hook relay bridge stale registration");
+        const output = String(stdout.read() ?? "");
+        if (event === "pre_tool_use" && !noop) {
+          expect(JSON.parse(output).hookSpecificOutput.permissionDecision).toBe("deny");
+        } else if (event === "permission_request") {
+          expect(JSON.parse(output).hookSpecificOutput.decision.behavior).toBe("deny");
+        } else {
+          expect(output).toBe("");
+        }
+        expect(testing.getNativeHookRelayInvocationsForTests()).toEqual([]);
+      } finally {
+        listen.mockRestore();
+      }
+    },
+  );
 
   it("ignores stale exact-owner teardown after same-id replacement", async () => {
     const relayId = uniqueNativeHookRelayIdForTests("stale-owner-successor");

--- a/src/agents/harness/native-hook-relay.ts
+++ b/src/agents/harness/native-hook-relay.ts
@@ -181,7 +181,7 @@ function registerNativeHookRelayInternal(
   const allowedEvents = normalizeAllowedEvents(params.allowedEvents);
   const stateDbPath = resolveOpenClawStateSqlitePath();
   const deliverReplacedRegistrationUnregister = unregisterNativeHookRelay(relayId, undefined, {
-    deferBridgeRecordRemovalMs: NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS,
+    deferListenerCloseMs: NATIVE_HOOK_BRIDGE_REPLACEMENT_RECORD_GRACE_MS,
     deferOnUnregister: true,
   });
   let partialRegistration: ActiveNativeHookRelayRegistration | undefined;
@@ -300,7 +300,7 @@ function registerNativeHookRelayInternal(
 function unregisterNativeHookRelay(
   relayId: string,
   expectedRegistration?: ActiveNativeHookRelayRegistration,
-  options?: { deferBridgeRecordRemovalMs?: number; deferOnUnregister?: boolean },
+  options?: { deferListenerCloseMs?: number; deferOnUnregister?: boolean },
 ): (() => void) | undefined {
   if (expectedRegistration && relays.get(relayId) !== expectedRegistration) {
     return undefined;


### PR DESCRIPTION
Related: #141575

## What Problem This Solves

Fixes an issue where native hook callers can connect to a retired relay endpoint immediately after a same-ID replacement. A CI run exposed `connect ECONNRESET` in the duplicate-module relay test; a controlled macOS reproduction showed the caller selecting the retired port and receiving `ECONNREFUSED` before an existing retry recovered.

## Why This Change Was Made

Unpublish only the retired token-owned locator synchronously, before its listener can close. Keep the existing 250 ms listener grace for callers that already captured that endpoint. New callers use the existing missing-locator wait for the successor, and old cleanup cannot delete a successor's locator. Retry rules, deadlines, and generation checks are unchanged.

## User Impact

Relay replacement no longer advertises an endpoint scheduled for retirement. If successor publication is delayed, the CLI can reach its existing Gateway fallback after the 100 ms registration wait; that reachable routing difference is explicitly tested. For ordinary replacement, the Gateway rejects retired generations before invoking hooks; the existing explicitly configured bootstrap generation grace remains unchanged. Default pre-tool and permission responses deny, while only the explicitly configured pre-tool unavailable-noop path remains a noop. An explicit stale response from the direct bridge still suppresses Gateway fallback.

## Evidence

- The unmodified relay file passed 119 tests; the new real-socket scheduling regression failed on the retired-endpoint connection before the repair.
- All 195 relay, approval, store, import-boundary, CLI, and Gateway tests passed on the repair source, including the original full-file order. Five new cases also passed after test-only lint cleanup.
- Delayed-publication tests use generated CLI commands, the real argument parser and read-only bridge lookup, and the actual Gateway handler through a transport adapter. They verify retired generations cannot execute successor hooks across pre-tool, permission, explicit noop, and post-tool cases.
- All scoped-check components passed: production/test types, lint, formatting, ownership and schema guards, dead exports, import cycles, and remaining applicable checks. Initial test annotation and lint failures were corrected; assertions and deadlines were retained.
- Independent P2 review is clean. This main forward-port preserves the reviewed three-file patch exactly.
- Earlier CI hit an unchanged process-containment fixture. After #141634, old head `ec6ccb70e1a7` still failed its `late` and `extended` cases (`cleanup: uncertain` versus `closed`). The current rebase includes the independent #141681 repair; fresh results are recorded below.

The Linux `ECONNRESET` was not reproduced exactly on macOS; the controlled local proof exposes the same retired-endpoint selection with `ECONNREFUSED`. Gateway proof covers the actual handler boundary rather than an authenticated network connection. This PR does not claim full release qualification.

### Fresh main rebase and validation

Head `db83e7e16c23b0df967754477d520f50bb84799a` is rebased onto main `2634c04a64c4c6d40a364864808dc7908b61bb8a` and includes the independent containment fixture repair #141681 (`693485b36510`). **211 tests across ten complete files pass**: 198 relay/approval/store/CLI/Gateway cases and all 13 containment cases, including the previously failing `extended` case. Scoped oxlint passes 110 changed/large-main paths; formatting, static guards, the core graph boundary and diff checks pass. Fresh independent Codex P2 review is clean.

Local core typechecking refuses the shared dependency installation; [fresh exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/34177242043) passed, including the required aggregate gate. No unrelated flake fix, timeout, retry, assertion weakening or source rewrite was added to the relay patch. Gateway proof remains an actual-handler boundary test, and local socket/containment proof is on macOS.
