### PR TITLE
perf(gateway): speed up suggestion delivery in large stores

### DIFF
--- a/src/gateway/session-sharing-store-cache.test.ts
+++ b/src/gateway/session-sharing-store-cache.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import * as sessionsConfig from "../config/sessions.js";
 import * as sessionAccessor from "../config/sessions/session-accessor.js";
 import { setCanonicalSqliteSessionMainKey } from "../config/sessions/session-canonical-key.js";
+import { addSessionMember, removeSessionMember } from "../config/sessions/session-sharing-store.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import {
   closeOpenClawAgentDatabasesForTest,
@@ -12,6 +13,8 @@ import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { GatewayClient } from "./server-methods/types.js";
 import {
   authorizeResolvedSessionMutation,
+  canReceiveSessionEvent,
+  invalidateSessionSharingSnapshot,
   resolveSessionMutationAuthorization,
 } from "./session-sharing.js";
 import { roleClient, rolePolicyConfig } from "./session-sharing.test-utils.js";
@@ -20,6 +23,7 @@ import { canAccessTaskRequesterSession } from "./task-session-access.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
+  invalidateSessionSharingSnapshot();
   closeOpenClawAgentDatabasesForTest();
 });
 
@@ -46,6 +50,81 @@ function identifiedClient(userId: string): GatewayClient {
     },
   };
 }
+
+describe("session event authorization store work", () => {
+  it.each([1, 2, 32])(
+    "bounds metadata work for %i event targets while refreshing membership",
+    async (targetCount) => {
+      await withOpenClawTestState({ scenario: "minimal" }, async () => {
+        const keys = Array.from(
+          { length: 64 },
+          (_, index) => `agent:main:event-${targetCount}-${index}`,
+        );
+        const sessionKeys = keys.slice(0, targetCount);
+        for (const sessionKey of keys) {
+          await sessionAccessor.upsertSessionEntryCore(
+            { agentId: "main", sessionKey },
+            {
+              sessionId: sessionKey,
+              updatedAt: 1,
+              visibility: "suggest",
+              createdActor: { type: "human", source: "profile", id: "owner" },
+            },
+          );
+        }
+        for (const sessionKey of sessionKeys) {
+          addSessionMember(
+            { agentId: "main", sessionKey },
+            { identityId: "member", addedBy: "owner" },
+          );
+        }
+        sessionAccessor.listSessionEntriesCore({
+          agentId: "main",
+          clone: false,
+          projection: "list",
+        });
+        const materializedKeys: string[] = [];
+        const listEntries = sessionAccessor.listSessionEntriesCore;
+        vi.spyOn(sessionAccessor, "listSessionEntriesCore").mockImplementation((scope) => {
+          const entries = listEntries(scope);
+          materializedKeys.push(...entries.map(({ sessionKey }) => sessionKey));
+          return entries;
+        });
+        const receive = (user: string, event = "session.suggestion") =>
+          canReceiveSessionEvent({
+            cfg: {},
+            client: identifiedClient(user),
+            sessionKeys,
+            event,
+            payload: { suggestion: { author: { id: "author" } } },
+          });
+        expect(receive("member", "session.message")).toBe(true);
+        materializedKeys.length = 0;
+        expect(receive("member", "session.message")).toBe(true);
+        expect(materializedKeys).toEqual([]);
+
+        const checkRecipient = (user: string, allowed: boolean) => {
+          materializedKeys.length = 0;
+          expect(receive(user)).toBe(allowed);
+          // Sparse events must not enumerate unrelated rows; dense checks share one store view.
+          expect(materializedKeys.length).toBeLessThanOrEqual(targetCount === 1 ? 0 : keys.length);
+        };
+        checkRecipient("member", true);
+        checkRecipient("owner", true);
+        checkRecipient("viewer", false);
+        checkRecipient("author", true);
+        const revokedKey = sessionKeys.at(-1)!;
+        removeSessionMember({ agentId: "main", sessionKey: revokedKey }, "member");
+        checkRecipient("member", false);
+        addSessionMember(
+          { agentId: "main", sessionKey: revokedKey },
+          { identityId: "member", addedBy: "owner" },
+        );
+        checkRecipient("member", true);
+      });
+    },
+  );
+});
 
 describe("session mutation authorization store caches", () => {
   it.each(["sessions.patch", "chat.send", "sessions.patchMany"])(

--- a/src/gateway/session-sharing.ts
+++ b/src/gateway/session-sharing.ts
@@ -508,6 +508,7 @@ export function canReceiveSessionEvent(params: {
   const lookup: Omit<Parameters<typeof resolveSessionSharingTarget>[0], "sessionKey"> = {
     cfg,
     agentId: params.agentId,
+    exactRead: sessionKeys.length === 1,
     storeCache: new Map(),
     targetDiscoveryCache: new Map(),
   };


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where delivering a suggestion gets slower as unrelated sessions accumulate and more operators are connected.

## Why This Change Was Made

A single-target event check now uses the existing exact metadata lookup. Multiple-target events retain their shared store view, and each recipient still gets fresh authorization checks with the existing lazy visibility, author, creator, alias and incognito behavior.

## User Impact

Suggestion delivery requires less metadata work in larger session stores. No configuration or API change is needed.

## Evidence

- Real-store RED/GREEN regression: unmodified main materialized 64 rows during a warm singleton suggestion check; the candidate avoids that whole-store work. Dense 2/32-target checks, snapshot laziness and membership revoke/restore remain covered. All 52 owner and policy/creator/snapshot sibling tests passed.
- Complete candidate changed-file gate passed on an independently installed Blacksmith Testbox, including core and core-test typechecks, lint and owner guards. Both revisions built successfully before timing.
- [Paired ordinary Gateway run](https://github.com/openclaw/openclaw/actions/runs/34163315778), baseline `0bec2710f6836388b58974c3a8310dfcbc21890e` versus candidate `e0daf0a1265d03c5e68c5cfd84b2c1aa8ab0e913`: fresh state per cell, alternating baseline/candidate order, 64/512/2,048 metadata rows, 1/8/32 explicit members plus five fixed profiles, three warm-ups and ten timed additions per cell, at least 100 ms pacing.
- At 2,048 rows and 37 connected profiles, completion median improved **39.671 → 8.801 ms (77.8%)**, p90 **40.501 → 9.109 ms**, and maximum **40.900 → 9.264 ms**. Larger adjacent cells also improved. Two 64-row medians increased by **1.035 ms** and **0.362 ms**; their tail increases stayed under 1 ms. This is a bounded synthetic comparison, not a p99 or universal-speedup claim.
- Both independent inspections reconciled all **1,408 request/response pairs**, **3,928 suggestion frames**, **384 list barriers**, **216 pacing intervals**, role/membership changes, closed copied SQLite state and all 18 Gateway/fixture shutdowns. No hold, unexpected recipient, duplicate delivery or state mismatch occurred.
