### PR TITLE
fix(update): allow artifact updates with matching configured plugins

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -110,6 +110,8 @@ completion in a new shell profile remains an interactive choice.
 govern later foreground and automatic updates, even after a one-off beta
 install. Use `--channel` to change that policy.
 
+For explicit package artifacts, configured plugin availability is checked against the privately staged package version before rehearsal or activation. `--dry-run` does not stage the artifact and reports that this check remains pending.
+
 For source checkouts, `--dry-run` previews the update flow without fetching Git
 refs or checking working-tree changes. The real update checks for uncommitted
 changes before modifying the checkout. Use `openclaw update status` to inspect

--- a/docs/install/updating.md
+++ b/docs/install/updating.md
@@ -40,16 +40,18 @@ results. See
 [Validation and activation](/cli/update#validation-and-activation) for the checks.
 
 Package updates also check npm availability for enabled configured plugins before
-stopping the serving Gateway or replacing the installed core. The check uses the
-same plugin version rules as post-update synchronization, including release-cohort
+stopping the serving Gateway or replacing the installed core. Registry targets
+are checked early; explicit package artifacts are checked using the privately
+staged package version before rehearsal, live-state preparation, or activation.
+The check uses the same plugin version rules as post-update synchronization, including release-cohort
 tracking, beta selection, and extended-stable targets. A missing version or registry
-error refuses the update with `plugin-target-unavailable`; `--dry-run` reports the
-same refusal. Retry when the registry or mirror is ready, select an older available
+error refuses the update with `plugin-target-unavailable`; registry-target
+`--dry-run` reports the same refusal. For explicit artifacts, `--dry-run` does not
+stage the package and reports that plugin availability checking remains pending.
+Retry when the registry or mirror is ready, select an older available
 core with `openclaw update --tag <version>`, or disable the affected plugin before
 retrying. Extended-stable does not accept `--tag`; retry later or explicitly switch
 channels. Bundled and path-installed plugins do not require registry requests.
-When enabled npm plugins need admission, a package spec whose core version cannot
-be resolved before staging is also refused; select an exact registry version.
 This metadata check does not reserve downloads, so later download failures can
 still require recovery.
 

--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -5546,6 +5546,22 @@ describe("update-cli", () => {
     },
   );
 
+  it("previews explicit artifacts without claiming staged plugin admission", async () => {
+    mockPackageInstallStatus(createCaseDir("openclaw-local-preview"));
+    await updateCommand({ dryRun: true, json: true, tag: "/tmp/candidate.tgz" });
+    expect(lastWriteJsonCall()).toMatchObject({
+      dryRun: true,
+      targetVersion: null,
+      notes: expect.arrayContaining([
+        expect.stringContaining(
+          "Configured plugin availability will be checked against the staged package",
+        ),
+      ]),
+    });
+    expect(packageInstallCommandCall()?.[0]).toBeUndefined();
+    expect(cleanupStaleManagedServiceUpdateHandoffs).not.toHaveBeenCalled();
+  });
+
   it("previews the resolved package owner without probing for another manager", async () => {
     mockPackageInstallStatus(createCaseDir("openclaw-dry-run-owner"));
     resolveGlobalManager.mockResolvedValueOnce("npm").mockResolvedValue("bun");

--- a/src/cli/update-cli/update-command-execution.test.ts
+++ b/src/cli/update-cli/update-command-execution.test.ts
@@ -1,6 +1,9 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { UpdateRunResult } from "../../infra/update-runner.js";
+import { withTestDir } from "../../test-helpers/temp-dir.js";
 import type { captureTargetDatabaseSchemaContext } from "./schema-preflight.js";
 import type { PreManagedServiceStop } from "./update-command-service.js";
 
@@ -26,13 +29,18 @@ const mocks = vi.hoisted(() => ({
   runtimeError: vi.fn(),
   revalidateSchemaContext:
     vi.fn<typeof import("./update-command-managed-context.js").revalidateUpdateDatabaseContext>(),
+  validateCanary: vi.fn(),
   serviceStopped: false,
   shouldBlockServiceUpdate: vi.fn(),
   verifyPackageRecovery: vi.fn(),
 }));
 
-vi.mock("../../infra/update-global.js", () => ({
+vi.mock("../../infra/update-global.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../infra/update-global.js")>()),
   verifyPackageUpdateRecovery: mocks.verifyPackageRecovery,
+}));
+vi.mock("../../infra/update-candidate-canary.js", () => ({
+  validateUpdateCandidateCanary: mocks.validateCanary,
 }));
 
 vi.mock("./update-command-plugin-preflight.js", () => ({
@@ -64,7 +72,8 @@ vi.mock("./update-command-handoff.js", () => ({
   handoffUpdateFromGateway: vi.fn(),
 }));
 
-vi.mock("./update-command-managed-context.js", () => ({
+vi.mock("./update-command-managed-context.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./update-command-managed-context.js")>()),
   captureOwnedManagedUpdateContext: mocks.captureManagedContext,
   captureOwnedManagedUpdatePreflightContext: mocks.captureManagedPreflight,
   revalidateUpdateDatabaseContext: mocks.revalidateSchemaContext,
@@ -174,6 +183,13 @@ function inspectOrStopService(phase: "inspect" | "prepare" = "prepare"): PreMana
 beforeEach(() => {
   vi.clearAllMocks();
   mocks.serviceStopped = false;
+  mocks.validateCanary.mockResolvedValue({
+    status: "ok",
+    phase: "readiness",
+    steps: [],
+    durationMs: 1,
+    logTail: [],
+  });
   mocks.captureManagedContext.mockResolvedValue(undefined);
   mocks.captureManagedPreflight.mockResolvedValue(schemaContext("default"));
   mocks.captureSchemaContext.mockResolvedValue(schemaContext("invoker"));
@@ -195,6 +211,90 @@ beforeEach(() => {
 });
 
 describe("mutable update execution", () => {
+  it.each(["available", "unavailable", "changed-owner"] as const)(
+    "admits local artifacts from the staged version before rehearsal: %s",
+    async (outcome) => {
+      await withTestDir({ prefix: "openclaw-staged-plugin-admission-" }, async (stage) => {
+        await fs.writeFile(
+          path.join(stage, "package.json"),
+          JSON.stringify({ name: "openclaw", version: "1.0.7" }),
+        );
+        const events: string[] = [];
+        mocks.pluginPreflight.mockImplementation(async ({ targetVersion }) => {
+          events.push("preflight");
+          expect(targetVersion).toBe("1.0.7");
+          expect(mocks.serviceStopped).toBe(false);
+          if (outcome === "unavailable") {
+            throw new UpdatePreMutationError(
+              "plugin-target-unavailable",
+              "fixture plugin is unavailable",
+            );
+          }
+        });
+        mocks.revalidateSchemaContext.mockImplementation(async (context) => {
+          if (outcome === "changed-owner" && events.includes("preflight")) {
+            throw new UpdatePreMutationError("database-schema-preflight", "fixture owner changed");
+          }
+          return context;
+        });
+        mocks.validateCanary.mockImplementation(async () => {
+          events.push("rehearsal");
+          return { status: "ok", phase: "readiness", steps: [], durationMs: 1, logTail: [] };
+        });
+        mocks.runPackageUpdate.mockImplementation(async ({ validateCandidate }) => {
+          events.push("staged");
+          expect(mocks.prepareMutableUpdate).not.toHaveBeenCalled();
+          try {
+            await validateCandidate(stage);
+            return successfulUpdate;
+          } catch (error) {
+            if (!(error instanceof UpdatePreMutationError)) {
+              throw error;
+            }
+            return { ...successfulUpdate, status: "error", reason: "package-update-failed" };
+          }
+        });
+        const execution = await executeMutableUpdate({
+          ...executionParams("package"),
+          tag: "/tmp/candidate.tgz",
+          packageInstallSpec: "/tmp/candidate.tgz",
+          packageTargetVersion: undefined,
+        });
+        expect(events).toEqual(
+          outcome === "available" ? ["staged", "preflight", "rehearsal"] : ["staged", "preflight"],
+        );
+        expect(execution?.mutationStarted).toBe(false);
+        expect(mocks.serviceStopped).toBe(false);
+        expect(execution?.result.status).toBe(outcome === "available" ? "ok" : "error");
+        if (outcome !== "available") {
+          expect(mocks.validateCanary).not.toHaveBeenCalled();
+          expect(mocks.prepareMutableUpdate).not.toHaveBeenCalled();
+          expect(execution?.result.reason).toBe(
+            outcome === "unavailable" ? "plugin-target-unavailable" : "database-schema-preflight",
+          );
+        }
+      });
+    },
+  );
+
+  it("leaves a staged local same-version no-op free of plugin or mutable preparation", async () => {
+    mocks.runPackageUpdate.mockResolvedValue({
+      ...successfulUpdate,
+      status: "skipped",
+      reason: "already-current",
+    });
+    const execution = await executeMutableUpdate({
+      ...executionParams("package"),
+      tag: "/tmp/candidate.tgz",
+      packageInstallSpec: "/tmp/candidate.tgz",
+      packageTargetVersion: undefined,
+    });
+    expect(execution?.result.reason).toBe("already-current");
+    expect(mocks.prepareMutableUpdate).not.toHaveBeenCalled();
+    expect(mocks.pluginPreflight).not.toHaveBeenCalled();
+    expect(mocks.serviceStopped).toBe(false);
+  });
+
   it.each([
     "@openclaw/example@1.0.1: Package not found on npm",
     "@openclaw/example@1.0.1: npm view failed: ECONNRESET",

--- a/src/cli/update-cli/update-command-execution.ts
+++ b/src/cli/update-cli/update-command-execution.ts
@@ -15,6 +15,7 @@ import { readControlPlaneUpdateSentinelMeta } from "../../infra/update-control-p
 import type { DevUpdateTarget } from "../../infra/update-dev-target.js";
 import { readBuiltGatewayBuildId } from "../../infra/update-git-runtime.js";
 import {
+  canResolveRegistryVersionForPackageTarget,
   verifyPackageUpdateRecovery,
   type ResolvedGlobalInstallTarget,
 } from "../../infra/update-global.js";
@@ -124,6 +125,9 @@ export async function executeMutableUpdate(params: {
   prepareMutableUpdate: (env?: NodeJS.ProcessEnv) => Promise<void>;
   onActivation?: () => void;
 }): Promise<MutableUpdateExecutionResult | null> {
+  const stagedPluginAdmission =
+    params.updateInstallKind === "package" &&
+    !canResolveRegistryVersionForPackageTarget(params.packageInstallSpec ?? params.tag);
   let preManagedServiceStop: PreManagedServiceStop | undefined;
   let ownedManagedUpdateContext: OwnedManagedUpdateContext | undefined;
   let admission: Awaited<ReturnType<typeof inspectUpdateDatabaseContexts>> | undefined;
@@ -155,6 +159,20 @@ export async function executeMutableUpdate(params: {
       );
     }
     admittedTargetSchemaVersions = versions;
+  };
+  const preflightPlugins = async (targetVersion: string | null) => {
+    await recheckSchemas(params.packageTargetSchemaVersions);
+    const { preflightConfiguredNpmPluginTargets } =
+      await import("./update-command-plugin-preflight.js");
+    const context = admission!.contexts.at(-1)!;
+    await preflightConfiguredNpmPluginTargets({
+      config: context.configSnapshot.sourceConfig,
+      env: context.env,
+      targetVersion,
+      channel: params.channel,
+      timeoutMs: params.updateStepTimeoutMs,
+    });
+    await recheckSchemas(params.packageTargetSchemaVersions);
   };
   let recoveryEnv: NodeJS.ProcessEnv | undefined;
   let packageTransaction: PackageUpdateTransaction | undefined;
@@ -326,6 +344,25 @@ export async function executeMutableUpdate(params: {
       assertCurrent?: () => void,
     ) => {
       signal?.throwIfAborted();
+      if (stagedPluginAdmission) {
+        // Explicit artifacts acquire their version from the private staged package,
+        // before rehearsal or activation can mutate any serving state.
+        try {
+          await preflightPlugins(await readPackageVersion(root));
+          signal?.throwIfAborted();
+          assertCurrent?.();
+          await params.prepareMutableUpdate(
+            ownedManagedUpdateContext?.env ?? admission?.managedEnv,
+          );
+          signal?.throwIfAborted();
+          assertCurrent?.();
+        } catch (error) {
+          if (error instanceof UpdatePreMutationError) {
+            candidateFailureReason = error.reason;
+          }
+          throw error;
+        }
+      }
       const snapshot = rehearsal
         ? { config: rehearsal.sourceConfig, hash: rehearsal.sourceConfigHash }
         : (validatedConfigSnapshot ??
@@ -520,19 +557,10 @@ export async function executeMutableUpdate(params: {
       });
     }
     if (params.updateInstallKind === "package") {
-      await recheckSchemas(params.packageTargetSchemaVersions);
-      const { preflightConfiguredNpmPluginTargets } =
-        await import("./update-command-plugin-preflight.js");
-      const context = admission!.contexts.at(-1)!;
-      await preflightConfiguredNpmPluginTargets({
-        config: context.configSnapshot.sourceConfig,
-        env: context.env,
-        targetVersion: params.packageTargetVersion ?? null,
-        channel: params.channel,
-        timeoutMs: params.updateStepTimeoutMs,
-      });
-      await recheckSchemas(params.packageTargetSchemaVersions);
-      await params.prepareMutableUpdate(admission?.managedEnv);
+      if (!stagedPluginAdmission) {
+        await preflightPlugins(params.packageTargetVersion ?? null);
+        await params.prepareMutableUpdate(admission?.managedEnv);
+      }
       await stopManagedServiceBeforeMutableUpdate(undefined, "inspect");
       const packageUpdate: PackageInstallUpdateParams = {
         root: params.root,

--- a/src/cli/update-cli/update-command-schema.ts
+++ b/src/cli/update-cli/update-command-schema.ts
@@ -1,5 +1,6 @@
 import type { UpdateChannel } from "../../infra/update-channels.js";
 import type { DevUpdateTarget } from "../../infra/update-dev-target.js";
+import { canResolveRegistryVersionForPackageTarget } from "../../infra/update-global.js";
 import { recordUpdateRunPhase } from "../../infra/update-run-ledger.js";
 import type { OpenClawDatabaseSchemaPreflight } from "../../state/openclaw-database-preflight.js";
 import type { OpenClawSchemaVersions } from "../../state/openclaw-schema-versions.js";
@@ -29,6 +30,7 @@ export async function preflightUpdateCommandSchemas(params: {
   devTarget?: DevUpdateTarget;
   packageTargetSchemaVersions?: OpenClawSchemaVersions;
   packageTargetVersion?: string;
+  packageInstallSpec?: string | null;
   opts: Pick<UpdateCommandOptions, "dryRun" | "json" | "run">;
   refuseUpdate: (reason: string, message?: string) => Promise<void>;
 }): Promise<
@@ -89,16 +91,25 @@ export async function preflightUpdateCommandSchemas(params: {
         admission.contexts,
       );
       if (opts.dryRun && updateInstallKind === "package") {
-        const { preflightConfiguredNpmPluginTargets } =
-          await import("./update-command-plugin-preflight.js");
-        const context = admission.contexts.at(-1)!;
-        await preflightConfiguredNpmPluginTargets({
-          config: context.configSnapshot.sourceConfig,
-          env: context.env,
-          targetVersion: params.packageTargetVersion ?? null,
-          channel,
-          timeoutMs: updateStepTimeoutMs,
-        });
+        if (
+          params.packageInstallSpec &&
+          !canResolveRegistryVersionForPackageTarget(params.packageInstallSpec)
+        ) {
+          preflightNotes.push(
+            "Configured plugin availability will be checked against the staged package before rehearsal or activation; this preview does not stage the target.",
+          );
+        } else {
+          const { preflightConfiguredNpmPluginTargets } =
+            await import("./update-command-plugin-preflight.js");
+          const context = admission.contexts.at(-1)!;
+          await preflightConfiguredNpmPluginTargets({
+            config: context.configSnapshot.sourceConfig,
+            env: context.env,
+            targetVersion: params.packageTargetVersion ?? null,
+            channel,
+            timeoutMs: updateStepTimeoutMs,
+          });
+        }
       }
     } catch (error) {
       if (!opts.dryRun) {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -480,6 +480,7 @@ async function updateCommandInternal(
     devTarget,
     packageTargetSchemaVersions,
     packageTargetVersion: targetVersion ?? undefined,
+    packageInstallSpec,
     opts,
     refuseUpdate,
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators updating from an explicit package artifact could be refused before staging when enabled npm plugins required a matching core version. The updater could not resolve that version from registry metadata even though the artifact contained it.

## Why This Change Was Made

Explicit artifacts now provide their version from the private staged package. Configured plugin admission runs before rehearsal, live-state preparation, or activation, with service and database ownership revalidated around the metadata request. Registry targets keep their early admission. Same-version no-ops avoid mutable preparation, and artifact dry runs explain that plugin checking is pending because previews do not stage packages.

## User Impact

Operators can update from supported explicit artifacts when matching configured plugins are available. Missing plugins still refuse the update before serving state changes. Version pins, consent requirements, and ownership checks remain enforced. The CLI and installation guides describe both the registry and artifact paths.

## Evidence

- The two CLI/execution owner suites passed 433 tests on the original repair; the full changed gate passed and independent P0–P2 review reported no findings.
- A fresh packaged plugin-update Docker lane passed in 181 seconds using the original repair commit `77d12800edc4533ffbf70c54e0846f0c177838ae`: staged admission, rehearsal and activation; denied consent with healthy rollback; accepted fresh core; no future permission; missing payload cases.
- All five production/test files are byte-identical to that reviewed and packaged repair after applying it to main `635089846dcb`; only the docs merged surrounding main content.
- The same sealed repair package also passed corrupt-plugin recovery (75 seconds), plain upgrade survival (57 seconds), and managed restart/auth survival (157 seconds). The managed lane verified a completed serving turn and strict migrated-state checks using a synthetic local provider. These later runs used corrected test fixtures and failure propagation; earlier fixture/infrastructure failures were not counted as passing proof.
- On this main-based branch, the full changed gate passed and the two owner suites passed all 433 tests (76.72 seconds). Exact-head [CI passed](https://github.com/openclaw/openclaw/actions/runs/34165776149), and ClawSweeper reported no findings. These scoped results do not claim that the complete release validation campaign is green.
