### PR TITLE
fix(ci): bound frozen fs-safe contract resolution

### DIFF
--- a/scripts/resolve-fs-safe-native-contract.mjs
+++ b/scripts/resolve-fs-safe-native-contract.mjs
@@ -3,6 +3,9 @@ import { execFileSync } from "node:child_process";
 
 const [ref, workflowSha, allowFrozenSource] = process.argv.slice(2);
 const isSha = (value) => /^[0-9a-f]{40}$/u.test(value ?? "");
+const NATIVE_MARKER =
+  /\b(?:configureFsSafeNative|getFsSafeNativeConfig|getNativeBinding)\b|@openclaw\/fs-safe\/native/u;
+const LEGACY_PYTHON_ONLY_FS_SAFE_VERSION = "0.3.0";
 assert.ok(isSha(ref), "ref must be a full lowercase commit SHA");
 assert.ok(isSha(workflowSha), "workflow SHA must be a full lowercase commit SHA");
 
@@ -32,36 +35,25 @@ function isLegacyPythonOnlySource() {
     return false;
   }
   try {
-    const defaults = execFileSync("git", ["show", `${ref}:src/infra/fs-safe-defaults.ts`], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-    if (
-      !defaults.includes('import { configureFsSafePython } from "@openclaw/fs-safe/config";') ||
-      /\b(?:configureFsSafeNative|getFsSafeNativeConfig|getNativeBinding)\b|@openclaw\/fs-safe\/native/u.test(
-        defaults,
-      )
-    ) {
+    const readSource = (path) =>
+      execFileSync("git", ["show", `${ref}:${path}`], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      });
+    const packageJson = JSON.parse(readSource("package.json"));
+    if (packageJson.dependencies?.["@openclaw/fs-safe"] !== LEGACY_PYTHON_ONLY_FS_SAFE_VERSION) {
       return false;
     }
-    execFileSync(
-      "git",
-      [
-        "grep",
-        "-qE",
-        "\\b(configureFsSafeNative|getFsSafeNativeConfig|getNativeBinding)\\b|@openclaw/fs-safe/native",
-        ref,
-        "--",
-        "src",
-        "packages",
-        "extensions",
-      ],
-      { stdio: "ignore" },
+    const defaults = readSource("src/infra/fs-safe-defaults.ts");
+    // fs-safe 0.3.0's public config module exports Python/lock controls only;
+    // a built package on this exact dependency cannot consume native controls.
+    return (
+      defaults.includes('import { configureFsSafePython } from "@openclaw/fs-safe/config";') &&
+      !NATIVE_MARKER.test(defaults)
     );
+  } catch {
+    // Missing or unreadable ownership sources are unknown, therefore strict.
     return false;
-  } catch (error) {
-    // Only git grep's no-match status proves the complete product tree is pre-native.
-    return error && typeof error === "object" && "status" in error && error.status === 1;
   }
 }
 

--- a/test/scripts/resolve-fs-safe-native-contract.test.ts
+++ b/test/scripts/resolve-fs-safe-native-contract.test.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, writeFileSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -7,12 +7,7 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const SCRIPT = resolve("scripts/resolve-fs-safe-native-contract.mjs");
 const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
 
-function commitSource(
-  version: string,
-  defaults: string,
-  extraSource?: string,
-  remoteBranch?: string,
-) {
+function commitSource(version: string, defaults: string, remoteBranch?: string) {
   const root = tempDirectories.make("openclaw-fs-safe-contract-");
   execFileSync("git", ["init", "-q"], { cwd: root });
   execFileSync("git", ["config", "user.email", "test@openclaw.local"], { cwd: root });
@@ -24,11 +19,6 @@ function commitSource(
   const defaultsPath = join(root, "src/infra/fs-safe-defaults.ts");
   mkdirSync(dirname(defaultsPath), { recursive: true });
   writeFileSync(defaultsPath, defaults);
-  if (extraSource) {
-    const sourcePath = join(root, "packages/example/native.ts");
-    mkdirSync(dirname(sourcePath), { recursive: true });
-    writeFileSync(sourcePath, extraSource);
-  }
   execFileSync("git", ["add", "."], { cwd: root });
   execFileSync("git", ["commit", "-qm", "fixture"], { cwd: root });
   if (remoteBranch) {
@@ -58,12 +48,7 @@ const legacyDefaults = 'import { configureFsSafePython } from "@openclaw/fs-safe
 
 describe("resolve-fs-safe-native-contract", () => {
   it("reports the actual 0.3 selected-source contract as not applicable when authorized", () => {
-    const { root, ref } = commitSource(
-      "0.3.0",
-      legacyDefaults,
-      undefined,
-      "extended-stable/2026.6.33",
-    );
+    const { root, ref } = commitSource("0.3.0", legacyDefaults, "extended-stable/2026.6.33");
     expect(resolveContract(root, ref)).toBe("not-applicable");
   });
 
@@ -78,18 +63,44 @@ describe("resolve-fs-safe-native-contract", () => {
   it("keeps current, unapproved, unauthorized, or sibling-native source contracts strict", () => {
     const unapproved = commitSource("0.3.0", legacyDefaults);
     expect(resolveContract(unapproved.root, unapproved.ref)).toBe("required");
-    const currentRelease = commitSource("0.3.0", legacyDefaults, undefined, "release/2026.6.35");
+    const currentRelease = commitSource("0.3.0", legacyDefaults, "release/2026.6.35");
     expect(resolveContract(currentRelease.root, currentRelease.ref)).toBe("required");
     const unauthorized = commitSource("0.3.0", legacyDefaults);
     expect(resolveContract(unauthorized.root, unauthorized.ref, false)).toBe("required");
     expect(resolveContract(unauthorized.root, unauthorized.ref, true, unauthorized.ref)).toBe(
       "required",
     );
-    const sibling = commitSource(
-      "0.3.0",
-      legacyDefaults,
-      'import { getNativeBinding } from "@openclaw/fs-safe/native";\n',
+    const unknownDependency = commitSource("0.3.1", legacyDefaults, "extended-stable/2026.6.33");
+    expect(resolveContract(unknownDependency.root, unknownDependency.ref)).toBe("required");
+  });
+
+  it("uses only sparse-materialized fs-safe ownership sources for an authorized legacy target", () => {
+    const root = tempDirectories.make("openclaw-fs-safe-sparse-contract-");
+    const ref = "a".repeat(40);
+    const gitPath = join(root, "git");
+    writeFileSync(
+      gitPath,
+      `#!/usr/bin/env sh
+case "$1" in
+  for-each-ref) printf '%s\\n' 'origin/extended-stable/2026.6.33' ;;
+  show)
+    case "$2" in
+      ${ref}:package.json)
+        printf '%s\\n' '{"dependencies":{"@openclaw/fs-safe":"0.3.0"}}' ;;
+      ${ref}:src/infra/fs-safe-defaults.ts)
+        printf '%s\\n' 'import { configureFsSafePython } from "@openclaw/fs-safe/config";' ;;
+      *) echo "unmaterialized source: $2" >&2; exit 128 ;;
+    esac ;;
+  *) echo "unexpected git operation: $1" >&2; exit 128 ;;
+esac
+`,
     );
-    expect(resolveContract(sibling.root, sibling.ref)).toBe("required");
+    chmodSync(gitPath, 0o755);
+    const output = execFileSync(process.execPath, [SCRIPT, ref, "f".repeat(40), "1"], {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, PATH: `${root}:${process.env.PATH}` },
+    }).trim();
+    expect(output).toBe("not-applicable");
   });
 });


### PR DESCRIPTION
## Problem

The frozen-target fs-safe contract resolver runs a repository-wide `git grep` from a blobless sparse checkout. The focused frozen onboarding control stalled in selected-ref validation before any Docker lane could start.

## Fix

Resolve only the shipped capability boundary: the canonical frozen source must declare exact `@openclaw/fs-safe@0.3.0`, whose inspected public config exports only Python/lock controls, and retain the legacy Python default. Any other dependency version, native default, missing source, unreadable source, unapproved source, or current target remains `required`.

## Proof

- Red boundary: a sparse-source fixture exposes only package metadata and the legacy default; the previous resolver attempted broad `git grep` and returned `required`.
- Green: `node scripts/run-vitest.mjs test/scripts/resolve-fs-safe-native-contract.test.ts --run` (4 tests).
- `pnpm format:check --no-error-on-unmatched-pattern -- scripts/resolve-fs-safe-native-contract.mjs test/scripts/resolve-fs-safe-native-contract.test.ts` and `git diff --check`.
- Exact hung control: https://github.com/openclaw/openclaw/actions/runs/34163447194 (cancelled after 24m during `validate_selected_ref`, before any Docker lane).

## Scope

Tooling −17 production lines; tests +10 net. No tags, packages, npm state, or release candidate changed.