### PR TITLE
refactor(chat): share model provider grouping

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModelPickerStore.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawChatUI/ChatModelPickerStore.swift
@@ -75,13 +75,7 @@ public final class ChatModelPickerStore {
         }
         let remaining = choices.filter { included.insert($0.selectionID).inserted }
         let normalizedDefaultProvider = self.normalizedProviderIfPresent(defaultProvider)
-        let grouped = Dictionary(grouping: remaining) { choice in
-            let metadataProvider = self.normalizedProvider(choice.provider)
-            if metadataProvider != "other" {
-                return metadataProvider
-            }
-            return self.providerFromQualifiedModelID(choice.modelID) ?? metadataProvider
-        }
+        let grouped = Dictionary(grouping: remaining) { self.effectiveProvider($0) }
         let providers = grouped.map { provider, models in
             ChatModelProviderSection(
                 id: provider,


### PR DESCRIPTION
## What Problem This Solves

Model grouping repeated the provider-resolution logic already used to identify default models, leaving two copies of the same normalization and fallback rules.

## Why This Change Was Made

Use the existing private `effectiveProvider` helper in the grouping closure. This removes six production lines and keeps provider resolution in one place.

## User Impact

Model groups, ordering, defaults, favorites and recents retain their existing behavior.

## Evidence

The same six existing pure grouping/default tests passed before and after in a small Swift target containing the exact static owner and model declarations. No test source changed. This is extracted logic proof, not a full OpenClawKit build or an app/preferences run.

Scoped SwiftFormat, SwiftLint, complete-file parsing and all 14 canonical changed-check stages passed. Independent P0–P2 review found no actionable defect. Full OpenClawKit compilation has not been run locally; final integration is still subject to required CI.
