### PR TITLE
fix(memory): keep workspace state updates responsive

### DIFF
--- a/extensions/memory-core/src/dreaming-state.test.ts
+++ b/extensions/memory-core/src/dreaming-state.test.ts
@@ -1,0 +1,150 @@
+import path from "node:path";
+import { setImmediate } from "node:timers";
+import type { OpenKeyedStoreOptions } from "openclaw/plugin-sdk/plugin-state-runtime";
+import {
+  createPluginStateKeyedStoreForTests,
+  openOpenClawStateDatabase,
+  resetPluginStateStoreForTests,
+} from "openclaw/plugin-sdk/plugin-state-test-runtime";
+import { useAutoCleanupTempDirTracker } from "openclaw/plugin-sdk/test-env";
+import { afterEach, expect, test } from "vitest";
+import {
+  clearMemoryCoreWorkspaceNamespace,
+  configureMemoryCoreDreamingState,
+  readMemoryCoreWorkspaceEntries,
+  writeMemoryCoreWorkspaceEntries,
+  writeMemoryCoreWorkspaceEntry,
+} from "./dreaming-state.js";
+
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) =>
+  afterEach(() => {
+    configureMemoryCoreDreamingState(() => {
+      throw new Error("memory workspace test store is closed");
+    });
+    resetPluginStateStoreForTests();
+    cleanup();
+  }),
+);
+
+function createFixture() {
+  const root = tempDirs.make("memory-workspace-state-");
+  const env = { OPENCLAW_STATE_DIR: root };
+  configureMemoryCoreDreamingState(<T>(options: OpenKeyedStoreOptions) =>
+    createPluginStateKeyedStoreForTests<T>("memory-core", { ...options, env }),
+  );
+  const scope = { namespace: "workspace-progress", workspaceDir: path.join(root, "workspace") };
+  return {
+    scope,
+    foreignWorkspace: { ...scope, workspaceDir: path.join(root, "foreign-workspace") },
+    foreignNamespace: { ...scope, namespace: "workspace-other" },
+    database: openOpenClawStateDatabase({ env }),
+  };
+}
+
+async function readValues(scope: ReturnType<typeof createFixture>["scope"]) {
+  return Object.fromEntries(
+    (await readMemoryCoreWorkspaceEntries(scope)).map(({ key, value }) => [key, value]),
+  );
+}
+
+test.each(["replacement", "cleanup", "clear"] as const)(
+  "workspace %s lets queued event-loop work observe committed progress",
+  async (phase) => {
+    const { scope, foreignWorkspace, foreignNamespace, database } = createFixture();
+    const originals = Array.from({ length: 64 }, (_, index) => ({
+      key: `entry-${index}`,
+      value: "old",
+    }));
+    const initial =
+      phase === "replacement" ? [...originals, { key: "stale", value: "old" }] : originals;
+    await writeMemoryCoreWorkspaceEntries({ ...scope, entries: initial });
+    await writeMemoryCoreWorkspaceEntry({ ...foreignWorkspace, key: "entry-0", value: "foreign" });
+    await writeMemoryCoreWorkspaceEntry({ ...foreignNamespace, key: "stale", value: "other" });
+    const entries =
+      phase === "clear"
+        ? []
+        : phase === "replacement"
+          ? originals.map(({ key }) => ({ key, value: "new" }))
+          : [{ key: "retained", value: "new" }];
+    let completed = false;
+    const observation = new Promise<{
+      completed: boolean;
+      transactionOpen: boolean;
+      entries: Array<{ key: string; value: string }>;
+    }>((resolve, reject) => {
+      setImmediate(() => {
+        const completedAtCallback = completed;
+        const transactionOpen = database.db.isTransaction;
+        void readMemoryCoreWorkspaceEntries<string>(scope).then(
+          (current) =>
+            resolve({ completed: completedAtCallback, transactionOpen, entries: current }),
+          reject,
+        );
+      });
+    });
+    const operation = (
+      phase === "clear"
+        ? clearMemoryCoreWorkspaceNamespace(scope)
+        : writeMemoryCoreWorkspaceEntries({ ...scope, entries })
+    ).then(() => {
+      completed = true;
+    });
+    try {
+      const [, observed] = await Promise.all([operation, observation]);
+      expect(await readValues(scope)).toEqual(
+        Object.fromEntries(entries.map(({ key, value }) => [key, value])),
+      );
+      expect(await readValues(foreignWorkspace)).toEqual({ "entry-0": "foreign" });
+      expect(await readValues(foreignNamespace)).toEqual({ stale: "other" });
+
+      expect(observed).toMatchObject({ completed: false, transactionOpen: false });
+      if (phase === "replacement") {
+        const updated = observed.entries.filter((entry) => entry.value === "new");
+        expect(updated.length).toBeGreaterThan(0);
+        expect(updated.length).toBeLessThan(entries.length);
+        // Obsolete rows cannot disappear before every replacement write commits.
+        expect(observed.entries).toContainEqual({ key: "stale", value: "old" });
+      } else {
+        const remaining = observed.entries.filter((entry) => entry.value === "old");
+        expect(remaining.length).toBeGreaterThan(0);
+        expect(remaining.length).toBeLessThan(originals.length);
+        if (phase === "cleanup") {
+          expect(observed.entries).toContainEqual({ key: "retained", value: "new" });
+        }
+      }
+    } finally {
+      await Promise.allSettled([operation, observation]);
+    }
+  },
+);
+
+test("a rejected replacement preserves its committed prefix and skips cleanup", async () => {
+  const { scope, foreignWorkspace, foreignNamespace } = createFixture();
+  await writeMemoryCoreWorkspaceEntries({
+    ...scope,
+    entries: [
+      { key: "first", value: "old" },
+      { key: "tail", value: "old" },
+      { key: "stale", value: "old" },
+    ],
+  });
+  await writeMemoryCoreWorkspaceEntry({ ...foreignWorkspace, key: "first", value: "foreign" });
+  await writeMemoryCoreWorkspaceEntry({ ...foreignNamespace, key: "stale", value: "other" });
+
+  await expect(
+    writeMemoryCoreWorkspaceEntries<unknown>({
+      ...scope,
+      entries: [
+        { key: "first", value: "new" },
+        { key: "invalid", value: 1n },
+        { key: "tail", value: "unreached" },
+      ],
+    }),
+  ).rejects.toMatchObject({ code: "PLUGIN_STATE_INVALID_INPUT", operation: "register" });
+  expect(await readValues(scope)).toEqual({ first: "new", tail: "old", stale: "old" });
+  expect(await readValues(foreignWorkspace)).toEqual({ first: "foreign" });
+  expect(await readValues(foreignNamespace)).toEqual({ stale: "other" });
+
+  await writeMemoryCoreWorkspaceEntry({ ...scope, key: "tail", value: "scalar" });
+  expect(await readValues(scope)).toEqual({ first: "new", tail: "scalar", stale: "old" });
+});

--- a/extensions/memory-core/src/dreaming-state.ts
+++ b/extensions/memory-core/src/dreaming-state.ts
@@ -1,6 +1,7 @@
 // Memory Core dreaming state lives in SQLite-backed plugin state.
 import { createHash } from "node:crypto";
 import path from "node:path";
+import { setImmediate as yieldToEventLoop } from "node:timers/promises";
 import type {
   OpenKeyedStoreOptions,
   PluginStateKeyedStore,
@@ -18,6 +19,7 @@ export const SHORT_TERM_META_NAMESPACE = "short-term-meta";
 export const SHORT_TERM_LOCK_NAMESPACE = "short-term-locks";
 
 const DREAMING_WORKSPACE_STATE_MAX_ENTRIES = 50_000;
+const WORKSPACE_STATE_YIELD_EVERY = 10;
 export const SHORT_TERM_LOCK_MAX_ENTRIES = 4_096;
 export const SESSION_SEEN_HASHES_PER_CHUNK = 512;
 
@@ -114,6 +116,8 @@ export async function writeMemoryCoreWorkspaceEntries(
   const workspaceKey = memoryCoreWorkspaceStateKey(params.workspaceDir);
   const prefix = `${workspaceKey}:`;
   const replacementKeys = new Set<string>();
+  // Scalar store calls can finish synchronously; await alone does not service I/O.
+  let completed = 0;
   for (const entry of params.entries) {
     const stateKey = memoryCoreWorkspaceEntryKey(params.workspaceDir, entry.key);
     replacementKeys.add(stateKey);
@@ -124,10 +128,16 @@ export async function writeMemoryCoreWorkspaceEntries(
       key: entry.key,
       value: entry.value,
     });
+    if (++completed % WORKSPACE_STATE_YIELD_EVERY === 0) {
+      await yieldToEventLoop();
+    }
   }
   for (const entry of await store.entries()) {
     if (entry.key.startsWith(prefix) && !replacementKeys.has(entry.key)) {
       await store.delete(entry.key);
+      if (++completed % WORKSPACE_STATE_YIELD_EVERY === 0) {
+        await yieldToEventLoop();
+      }
     }
   }
 }
@@ -159,9 +169,13 @@ export async function clearMemoryCoreWorkspaceNamespace(params: {
   const store = openWorkspaceStore(params.namespace);
   const workspaceKey = memoryCoreWorkspaceStateKey(params.workspaceDir);
   const prefix = `${workspaceKey}:`;
+  let completed = 0;
   for (const entry of await store.entries()) {
     if (entry.key.startsWith(prefix)) {
       await store.delete(entry.key);
+      if (++completed % WORKSPACE_STATE_YIELD_EVERY === 0) {
+        await yieldToEventLoop();
+      }
     }
   }
 }


### PR DESCRIPTION
Related: #111376, #111392, #121823.

## What Problem This Solves

Fixes an issue where users could see delayed Gateway I/O while background memory workspace state was replaced or cleared. Large loops await keyed-store methods that finish their SQLite work synchronously, so those awaits can keep running through microtasks without servicing other event-loop work.

## Why This Change Was Made

Workspace replacement and clearing now yield to the event loop after every ten completed scalar store operations, following the existing memory source-sync convention. Registrations still finish before obsolete-row cleanup; each operation keeps its existing transaction, retention, error and workspace/namespace boundaries. The separate scalar writer is unchanged.

This is complementary to #111392, which proposes reducing unchanged writes and selecting a different retention policy. This change preserves every existing scalar write and SQL count and does not claim to close the broader write-amplification or Dreaming-stall issues.

Storage compatibility is unchanged: workspace records retain the same `version: 1` value shape, hashed keys, namespaces, encoding and readers. The keyed-store API, SQLite backend, schema, indexes, SQL, per-operation transactions, TTLs, limits and retention policy are untouched. Existing records remain readable and writable without migration; the only new state is a function-local completed-operation counter. The real-store regressions verify replacement and clearing against existing records, correct final contents, foreign workspace/namespace isolation, and unchanged committed-prefix behavior after rejection. The generic `unknown-data-model-change` review flag therefore does not identify a persistent-model change in this patch.

## User Impact

Queued work can run before a large memory-state operation finishes. This improves scheduling responsiveness; total duration can be slightly longer, and an individual expensive native operation still runs to completion before yielding.

## Evidence

Verified candidate: `47f790b3005f8f2fdf7c84efbd273b896c311a3a`.

- [Exact-head required CI](https://github.com/openclaw/openclaw/actions/runs/34165996815) passed, including `openclaw/ci-gate`.
- Four real-store regression cases pass. Replacement and cleanup progress failed on unchanged main; the equivalent clear case failed before its matching fix. Each progress test observes partial committed work outside a SQLite transaction, preserves foreign workspace/namespace rows, and checks final state. Rejected registration retains its committed prefix and skips cleanup; scalar recovery remains intact.
- All 164 tests in six existing ingestion, promotion, consolidation, repair, forget and workspace-lock suites passed without test or fake-timer changes.
- Full changed checks passed, including production/test types, lint, exports, storage/runtime guards and zero runtime import cycles. Managed independent review through P2 found no accepted/actionable findings; the ownership and test review also found no issue.
- [Blacksmith Testbox proof](https://github.com/openclaw/openclaw/actions/runs/34165089145) completed normal `pnpm build`, all four regressions and 36 ordinary real-owner measurements with payload exit 0. The source was verified, and the one-shot Testbox is independently confirmed completed. Its external portal sync timed out afterward; that warning is retained separately. The delegated workflow may show cancellation during teardown and is not represented as green PR CI.

The Linux probe used Node 24.19.0 / SQLite 3.53.3, 64 overwrites with 1 KiB payloads, and three alternating baseline/candidate pairs per shape. Sparse namespaces contain 64 rows; dense namespaces contain all listed plugin rows. A timer and immediate callback are queued before each replacement, and a 5 ms heartbeat records the largest observed service gap. All candidate immediate callbacks ran before completion with a partial write count and no active transaction; baseline callbacks ran after completion. Final contents and row counts were verified.

| Plugin rows / namespace | Median first timer, before → after | Worst heartbeat gap, before → after | Median total, before → after |
| --- | --- | --- | --- |
| 512 / sparse | 14.5 → 2.4 ms | 19.2 → 6.8 ms | 14.4 → 15.8 ms |
| 512 / dense | 15.7 → 2.4 ms | 17.3 → 7.0 ms | 15.7 → 15.6 ms |
| 2,048 / sparse | 33.9 → 4.6 ms | 35.2 → 9.2 ms | 33.9 → 29.0 ms |
| 2,048 / dense | 72.0 → 10.7 ms | 73.7 → 13.0 ms | 71.9 → 72.7 ms |
| 8,192 / sparse | 91.2 → 14.3 ms | 96.7 → 14.6 ms | 91.1 → 87.0 ms |
| 8,192 / dense | 259.6 → 37.9 ms | 261.6 → 42.0 ms | 259.5 → 256.4 ms |

A separate counter pass verified identical query executions: 64 plugin counts, 64 namespace counts, 64 point reads/upserts/expiry sweeps and one final listing. Each COUNT returned one aggregate row; this is a scheduling fix, not a row-materialization optimization. The final namespace listing still materializes its rows.

Retained macOS pairs of the same replacement implementation had a slower dense median total (685.5 → 728.9 ms), while the worst heartbeat gap improved from 715.4 → 227.8 ms. Those measurements preceded the equivalent clear-sibling addition; the final-head Linux proof above includes it. All samples and qualifications are retained. These small synthetic samples establish progress, not a universal latency bound, reduced SQL work, or sustained production acceptance.

Production: **+14 lines**. Tests: **+150 lines**. No schema, index, configuration, dependency, row-limit, TTL, retention or batch-atomicity change is included.
