### PR TITLE
fix(status): report missing skill requirements

### DIFF
--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -42,6 +42,16 @@ security audit, plugin compatibility, and memory-vector probes are left to
 `openclaw status --all`, `openclaw status --deep`, `openclaw security audit`,
 and `openclaw memory status --deep`.
 
+## Skills diagnosis
+
+`status --all` reports eligible skills and skills with missing prerequisites for
+the workspace shown in the Skills row. Missing prerequisites use the same category as
+`openclaw skills check`: intentionally disabled skills and skills blocked by the
+bundled allowlist are excluded; agent allowlist exclusions remain independent.
+Unmet OS requirements are included in this count, although Doctor does not disable
+skills for OS incompatibility.
+Use `openclaw skills check --agent <id>` to inspect the missing requirements.
+
 ## Session and model resolution
 
 - Session status output separates `Execution:` from `Runtime:`. `Execution`

--- a/src/cli/skills-cli.format.ts
+++ b/src/cli/skills-cli.format.ts
@@ -7,6 +7,7 @@ import {
 import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
 import { theme } from "../../packages/terminal-core/src/theme.js";
 import {
+  hasMissingSkillRequirements,
   resolveSkillStatusEntry,
   type SkillStatusEntry,
   type SkillStatusReport,
@@ -306,9 +307,7 @@ export function formatSkillsCheck(report: SkillStatusReport, opts: SkillsCheckOp
   const promptHidden = report.skills.filter(
     (s) => s.eligible && !s.blockedByAgentFilter && !s.modelVisible,
   );
-  const missingReqs = report.skills.filter(
-    (s) => !s.eligible && !s.disabled && !s.blockedByAllowlist,
-  );
+  const missingReqs = report.skills.filter(hasMissingSkillRequirements);
   const agentId = report.agentId ?? opts.agent;
 
   if (opts.json) {

--- a/src/commands/status-all/diagnosis.test.ts
+++ b/src/commands/status-all/diagnosis.test.ts
@@ -1,6 +1,10 @@
 // Status-all diagnosis tests cover port checks, restart logs, config issues, and safe diagnostic output.
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import type { ProgressReporter } from "../../cli/progress.js";
+import { buildWorkspaceSkillStatus } from "../../skills/discovery/status.js";
+import { createCanonicalFixtureSkill } from "../../skills/test-support/test-helpers.js";
 
 type GatewayLogPaths = {
   logDir: string;
@@ -41,6 +45,7 @@ vi.mock("./gateway.js", () => ({
 import { appendStatusAllDiagnosis } from "./diagnosis.js";
 
 type DiagnosisParams = Parameters<typeof appendStatusAllDiagnosis>[0];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function createProgressReporter(): ProgressReporter {
   return {
@@ -148,6 +153,60 @@ describe("status-all diagnosis port checks", () => {
       "  … +2 more",
     ]);
     expect(params.snap).toEqual(original);
+  });
+
+  it.each([
+    { state: "ready", eligible: 1, missing: 0 },
+    { state: "missing", eligible: 0, missing: 1 },
+    { state: "disabled", eligible: 0, missing: 0 },
+    { state: "blocked", eligible: 0, missing: 0 },
+    { state: "agent-excluded", eligible: 0, missing: 1 },
+    { state: "always", eligible: 1, missing: 0 },
+    { state: "unsupported-os", eligible: 0, missing: 1 },
+  ] as const)("reports skill readiness for $state", async ({ state, eligible, missing }) => {
+    const workspaceDir = tempDirs.make("openclaw-status-skills-");
+    const baseDir = path.join(workspaceDir, "skills", "fixture");
+    const params = createBaseParams([]);
+    params.skillStatus = buildWorkspaceSkillStatus(workspaceDir, {
+      managedSkillsDir: path.join(workspaceDir, "managed"),
+      agentId: "qa",
+      config: {
+        plugins: { enabled: false },
+        agents: { entries: { qa: { skills: state === "agent-excluded" ? [] : ["fixture"] } } },
+        skills: {
+          allowBundled: ["other-fixture"],
+          entries: { fixture: { enabled: state !== "disabled" } },
+        },
+      },
+      entries: [
+        {
+          skill: createCanonicalFixtureSkill({
+            name: "fixture",
+            description: "Synthetic status readiness fixture",
+            filePath: path.join(baseDir, "SKILL.md"),
+            baseDir,
+            source: state === "blocked" ? "openclaw-bundled" : "openclaw-workspace",
+          }),
+          frontmatter: {},
+          metadata: {
+            always: state === "always",
+            requires: {
+              bins:
+                state === "ready" || state === "unsupported-os"
+                  ? []
+                  : ["openclaw-qa-readiness-absent-binary"],
+            },
+            ...(state === "unsupported-os" ? { os: ["openclaw-qa-unsupported-os"] } : {}),
+          },
+        },
+      ],
+    });
+
+    await appendStatusAllDiagnosis(params);
+
+    expect(params.lines.find((line) => line.includes("Skills:"))).toBe(
+      `${missing > 0 ? "!" : "✓"} Skills: ${eligible} eligible · ${missing} missing · ${workspaceDir}`,
+    );
   });
 
   it("retains queue warnings from a successful gateway health snapshot", async () => {

--- a/src/commands/status-all/diagnosis.ts
+++ b/src/commands/status-all/diagnosis.ts
@@ -27,6 +27,10 @@ import {
   type PluginCompatibilityNotice,
 } from "../../plugins/status.js";
 import { dedupeByKey } from "../../shared/dedupe-by-key.js";
+import {
+  hasMissingSkillRequirements,
+  type SkillStatusReport,
+} from "../../skills/discovery/status.js";
 import { formatDeliveryQueueHealthLine } from "../health-format.js";
 import type {
   resolveStatusGatewayHealthSafe,
@@ -57,11 +61,6 @@ type TailscaleStatusLike = {
   dnsName: string | null;
   ips: string[];
   error: string | null;
-};
-
-type SkillStatusLike = {
-  workspaceDir: string;
-  skills: Array<{ eligible: boolean; missing: Record<string, unknown[]> }>;
 };
 
 type ChannelIssueLike = {
@@ -161,7 +160,7 @@ export async function appendStatusAllDiagnosis(params: {
   tailscaleMode: string;
   tailscale: TailscaleStatusLike;
   tailscaleHttpsUrl: string | null;
-  skillStatus: SkillStatusLike | null;
+  skillStatus: SkillStatusReport | null;
   pluginCompatibility: PluginCompatibilityNotice[];
   channelsStatus: unknown;
   channelIssues: ChannelIssueLike[];
@@ -316,9 +315,7 @@ export async function appendStatusAllDiagnosis(params: {
 
   if (params.skillStatus) {
     const eligible = params.skillStatus.skills.filter((s) => s.eligible).length;
-    const missing = params.skillStatus.skills.filter(
-      (s) => s.eligible && Object.values(s.missing).some((arr) => arr.length),
-    ).length;
+    const missing = params.skillStatus.skills.filter(hasMissingSkillRequirements).length;
     emitCheck(
       `Skills: ${eligible} eligible · ${missing} missing · ${params.skillStatus.workspaceDir}`,
       missing === 0 ? "ok" : "warn",

--- a/src/skills/discovery/status.ts
+++ b/src/skills/discovery/status.ts
@@ -37,6 +37,11 @@ import {
 import type { SkillInstallOption, SkillStatusEntry, SkillStatusReport } from "./status.types.js";
 export type { SkillStatusEntry, SkillStatusReport } from "./status.types.js";
 
+/** Missing prerequisites exclude intentional disablement and are independent of agent exposure. */
+export function hasMissingSkillRequirements(skill: SkillStatusEntry): boolean {
+  return !skill.eligible && !skill.disabled && !skill.blockedByAllowlist;
+}
+
 const skillsLogger = createSubsystemLogger("skills");
 let hasWarnedMissingBundledDir = false;
 


### PR DESCRIPTION
Closes #141606

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators running `status --all` would see a success mark and zero missing skill requirements even when the same workspace's `skills check` reported a missing prerequisite.

## Why This Change Was Made

The status diagnosis counted missing requirements only among eligible skills, an impossible intersection for canonical discovery data. Both CLI displays now share the existing inventory classifier. Disabled and bundled-blocked skills remain excluded, agent selection remains independent, and Doctor retains its narrower repair policy.

## User Impact

The full diagnostic report now warns and reports the actual missing count. A healthy inventory remains green. Unmet OS requirements count as missing for inspection; Doctor does not disable skills for OS incompatibility. No eligibility, configuration, storage, provider, permission, or protocol behavior changes.

Production LOC is +13/−12 (net +1): the shared classifier replaces duplicate policy and a copied report shape. Tests are net +59; docs net +10.

## Evidence

- Tests-only baseline: three intended failures with 26 passing controls. The repaired owner and sibling suites pass all 72 tests across four routed Vitest shards.
- Complete changed-file checks passed. The subsequent two-line OS/Doctor documentation clarification was separately format-checked and MDX-validated; production and tests stayed byte-identical. Fresh independent P0–P2 review found no actionable findings.
- Both ordinary full builds passed. Real normal CLI runs used fresh synthetic homes, workspaces, skill files and configuration. Each phase ran configuration validation plus four status/skills reads; all ten commands exited zero with empty stderr.

| Real CLI fixture | Baseline `status --all` | Candidate `status --all` | `skills check` in both |
| --- | --- | --- | --- |
| One missing binary | `✓ Skills: 1 eligible · 0 missing` | `! Skills: 1 eligible · 1 missing` | 1 missing requirement |
| Ready + intentionally disabled + bundled-blocked | `✓ Skills: 1 eligible · 0 missing` | Same | 0 missing requirements |

Canonical category lists and summary counts match across phases, and all four configuration files remain unchanged. Post-run verification matched 39,391 inventoried source entries, 15,384 artifact entries, 2,094 dependency manifest records and six selected native binaries per checkout. These are bounded source/artifact/input inventories, not every dependency implementation byte.

Runtime proof used baseline production source `9a4114bc` (with a retained tests-only overlay) and that source plus the exact candidate patch `0e89baa349856b12479f3a1326eef3bb4dbbe088a7eef88cbb1783f7cc01b9d8`. The ordinary package launcher executed the built product; no replacement formatter or injected inventory was used. The offline fixture denies network access and `launchctl` execution, so unrelated unavailable-Gateway/service diagnosis is outside the Skills assertion. No real provider or Gateway service operation is claimed.

Before/after native screenshots were attempted but could not be captured: the macOS GUI session was at `loginwindow`, and the task-owned terminal had no window in both observations. No native CLI pipeline or image was observed. That instance was gracefully closed with its exact process identity, and the tracked launcher exited zero. Full ordinary CLI stdout/stderr and proof receipts are retained locally; no synthetic screenshot or replay is presented as UI evidence.

Commit `df3282638d8254d1f03c4ddde38e6059281c738c` preserves that exact tested, built and live-proven patch. Independent artifact review verified 76 retained evidence seals with no blocker for the bounded count/marker claim. First introduction remains unverified. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34166273496) completed with 108 successful jobs and 16 skipped jobs. ClawSweeper found no blocking findings and accepted the normal CLI output as proof for this count/marker change.
