### PR TITLE
fix(state): distinguish slow database validation stages

### DIFF
--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -58,6 +58,28 @@ their structured file-log record, with cause and error-code details when
 available. Long summaries are truncated; the record retains its write timing
 and store fields.
 
+### Slow agent database opens
+
+A completed physical agent-database open taking at least one second emits
+`slow OpenClaw agent database open`. The record retains total elapsed time and
+the `open`, `validation`, `configuration`, `schema`, and `registration` phases.
+For a yielded integrity check, it also includes `integrityGateMs` and
+`integrityGateOutcome` (`healthy` or `failed`). The gate includes the check plus
+any driver waits, scheduling, and ownership revalidation. When admission uses a
+separate integrity Worker, its lifetime is included. This does not isolate
+native-check or CPU time.
+
+When canonical-index validation completes, `canonicalIndexMs` reports the
+subsequent synchronous inspection and any repair or rechecks, and
+`repairedIndexCount` counts indexes successfully repaired by that operation.
+A healthy initial integrity check can still require an index-definition repair;
+a failed initial check can be recovered by a successful repair. Fields are
+absent when their stage does not run, including the yielded-check fields for a
+fresh empty database. These details cover portions of `validation`, not extra
+time to add to it. The summary is emitted only at registration; earlier failures
+and live cache hits produce no summary. The details add no index names or
+database contents.
+
 ### Slow cron list pages
 
 A cron list page taking at least one second emits `cron: slow list page` through

--- a/src/infra/sqlite-index-schema.ts
+++ b/src/infra/sqlite-index-schema.ts
@@ -1,9 +1,12 @@
+import { performance } from "node:perf_hooks";
 import type { DatabaseSync } from "node:sqlite";
 import {
   assertSqliteIntegrity,
   assertSqliteTableIntegrity,
   isTerminalSqliteIntegrityError,
   runSqliteIntegrityOperationSync,
+  sqliteIntegrityCheckSteps,
+  type SqliteIntegrityDiagnostics,
   type SqliteIntegrityOperation,
 } from "./sqlite-integrity.js";
 import {
@@ -51,11 +54,14 @@ export function* verifyAndRepairCanonicalSqliteIndexSteps(
   db: DatabaseSync,
   databaseLabel: string,
   schemaSql: string,
-  options: Omit<RepairCanonicalSqliteIndexesOptions, "verifyPhysicalIntegrity"> = {},
+  options: Omit<RepairCanonicalSqliteIndexesOptions, "verifyPhysicalIntegrity"> & {
+    diagnostics?: SqliteIntegrityDiagnostics;
+  } = {},
 ): SqliteIntegrityOperation<string[]> {
+  const { diagnostics, ...repairOptions } = options;
   let integrityFailure: Error | undefined;
   try {
-    yield { database: db, databaseLabel };
+    yield* sqliteIntegrityCheckSteps(db, databaseLabel, diagnostics);
   } catch (error) {
     if (!(error instanceof Error) || !isTerminalSqliteIntegrityError(error)) {
       throw error;
@@ -63,14 +69,19 @@ export function* verifyAndRepairCanonicalSqliteIndexSteps(
     integrityFailure = error;
   }
 
+  const indexesStartedAt = performance.now();
   const repairedIndexes = repairCanonicalSqliteIndexes(db, databaseLabel, schemaSql, {
-    ...options,
+    ...repairOptions,
     verifyPhysicalIntegrity: integrityFailure !== undefined,
   });
   // A non-empty repair result already passed table and whole-file integrity
   // checks inside the repair savepoint, so it supersedes the initial failure.
   if (integrityFailure && repairedIndexes.length === 0) {
     throw integrityFailure;
+  }
+  if (diagnostics) {
+    diagnostics.canonicalIndexMs = Math.floor(performance.now() - indexesStartedAt);
+    diagnostics.repairedIndexCount = repairedIndexes.length;
   }
   return repairedIndexes;
 }

--- a/src/infra/sqlite-integrity.ts
+++ b/src/infra/sqlite-integrity.ts
@@ -1,3 +1,4 @@
+import { performance } from "node:perf_hooks";
 import type { DatabaseSync } from "node:sqlite";
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import { openNodeSqliteDatabase } from "./node-sqlite.js";
@@ -17,6 +18,37 @@ export type SqliteIntegrityOperation<T> = Generator<
   T,
   void
 >;
+
+export type SqliteIntegrityDiagnostics = {
+  integrityGateMs?: number;
+  integrityGateOutcome?: "healthy" | "failed";
+  canonicalIndexMs?: number;
+  repairedIndexCount?: number;
+};
+
+/** The gate includes the driver's check, awaited lifetime, and admission revalidation. */
+export function* sqliteIntegrityCheckSteps(
+  database: DatabaseSync,
+  databaseLabel: string,
+  diagnostics?: SqliteIntegrityDiagnostics,
+): SqliteIntegrityOperation<void> {
+  const startedAt = performance.now();
+  try {
+    yield { database, databaseLabel };
+    if (diagnostics) {
+      diagnostics.integrityGateOutcome = "healthy";
+    }
+  } catch (error) {
+    if (diagnostics) {
+      diagnostics.integrityGateOutcome = "failed";
+    }
+    throw error;
+  } finally {
+    if (diagnostics) {
+      diagnostics.integrityGateMs = Math.floor(performance.now() - startedAt);
+    }
+  }
+}
 
 /** Run the same admission steps synchronously when the caller cannot yield. */
 export function runSqliteIntegrityOperationSync<T>(operation: SqliteIntegrityOperation<T>): T {

--- a/src/state/openclaw-agent-db-lifecycle.ts
+++ b/src/state/openclaw-agent-db-lifecycle.ts
@@ -5,6 +5,7 @@ import { isMainThread, threadId } from "node:worker_threads";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { setSqliteBusyTimeout } from "../infra/sqlite-busy-timeout.js";
+import type { SqliteIntegrityDiagnostics } from "../infra/sqlite-integrity.js";
 import { createSqliteTerminalOpenLatch } from "../infra/sqlite-terminal-open-latch.js";
 import { registerSqliteCacheExitClose } from "../infra/sqlite-wal.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
@@ -74,6 +75,7 @@ export function startAgentDatabaseOpenTiming(
   agentId: string,
   pathname: string,
   admissionMode: "sync" | "async",
+  diagnostics: SqliteIntegrityDiagnostics,
 ) {
   const startedAt = performance.now();
   let elapsedMs = 0;
@@ -93,6 +95,7 @@ export function startAgentDatabaseOpenTiming(
         isMainThread,
         admissionMode,
         phaseDurationsMs,
+        ...diagnostics,
         thresholdMs: OPENCLAW_AGENT_DB_SLOW_OPEN_MS,
       });
     }

--- a/src/state/openclaw-agent-db-schema.ts
+++ b/src/state/openclaw-agent-db-schema.ts
@@ -18,6 +18,8 @@ import {
 import {
   assertSqliteIntegrity,
   runSqliteIntegrityOperationSync,
+  sqliteIntegrityCheckSteps,
+  type SqliteIntegrityDiagnostics,
   type SqliteIntegrityOperation,
 } from "../infra/sqlite-integrity.js";
 import { migrateSqliteSchemaToStrictInTransaction } from "../infra/sqlite-strict.js";
@@ -482,6 +484,7 @@ export function* agentDatabaseIntegrityBeforeMutationSteps(
   database: DatabaseSync,
   agentId: string,
   pathname: string,
+  diagnostics?: SqliteIntegrityDiagnostics,
 ): SqliteIntegrityOperation<boolean> {
   database.exec(`PRAGMA busy_timeout = ${OPENCLAW_SQLITE_BUSY_TIMEOUT_MS};`);
   const userVersion = readSqliteUserVersion(database);
@@ -512,6 +515,7 @@ export function* agentDatabaseIntegrityBeforeMutationSteps(
       allowMissingColumns: true,
       validateAfterRepair: () =>
         assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname }),
+      diagnostics,
     });
     assertOpenClawAgentCurrentRuntimeSchema(database, { agentId, pathname });
   } else if (
@@ -524,7 +528,7 @@ export function* agentDatabaseIntegrityBeforeMutationSteps(
     assertSqliteIntegrity(database, pathname);
   } else {
     // Every physical open proves the full file before schema mutation or exposure.
-    yield { database, databaseLabel: pathname };
+    yield* sqliteIntegrityCheckSteps(database, pathname, diagnostics);
   }
   return hasPendingCurrentVersionMigration;
 }

--- a/src/state/openclaw-agent-db.open-timing.test.ts
+++ b/src/state/openclaw-agent-db.open-timing.test.ts
@@ -41,7 +41,7 @@ afterEach(async () => {
   logger.warn.mockClear();
 });
 
-function createTimedOpen(validationMs: number) {
+function createTimedOpen(validationMs: number, indexRepairMs = 0) {
   const options = {
     agentId: "timing-test",
     env: { OPENCLAW_STATE_DIR: makeTempDir(tempDirs, "openclaw-agent-open-timing-") },
@@ -61,6 +61,13 @@ function createTimedOpen(validationMs: number) {
     const database = open(...args);
     if (args[0] === pathname) {
       advance(50);
+      const exec = database.exec.bind(database);
+      vi.spyOn(database, "exec").mockImplementation((sql) => {
+        exec(sql);
+        if (sql.startsWith("CREATE INDEX main.idx_agent_session_nodes_updated_at ")) {
+          advance(indexRepairMs);
+        }
+      });
     }
     return database;
   });
@@ -148,6 +155,10 @@ describe("agent database open timings", () => {
       isMainThread,
       admissionMode: "sync",
       thresholdMs: 1_000,
+      integrityGateMs: 0,
+      integrityGateOutcome: "healthy",
+      canonicalIndexMs: 0,
+      repairedIndexCount: 0,
       phaseDurationsMs: {
         open: 60,
         validation: 1_000,
@@ -157,6 +168,69 @@ describe("agent database open timings", () => {
       },
     });
   });
+
+  it.each(["definition", "physical"] as const)(
+    "reports actual repairs for %s index drift",
+    (drift) => {
+      const { options, pathname } = createTimedOpen(0, 1_000);
+      const database = openOpenClawAgentDatabase(options);
+      const canonicalIndex = database.db
+        .prepare("SELECT sql FROM sqlite_schema WHERE name = 'idx_agent_session_nodes_updated_at'")
+        .get();
+      const canonicalIndexCount = database.db
+        .prepare(
+          "SELECT name FROM sqlite_schema WHERE type = 'index' AND tbl_name = 'session_nodes' AND sql IS NOT NULL",
+        )
+        .all().length;
+      database.db.exec(`
+      INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at)
+      VALUES ('session-one', 'window-one', '{}', 1);
+      DROP INDEX idx_agent_session_nodes_updated_at;
+      CREATE INDEX idx_agent_session_nodes_updated_at ON session_nodes(session_key);
+    `);
+      if (drift === "physical") {
+        database.db.enableDefensive?.(false);
+        database.db.exec("PRAGMA writable_schema = ON;");
+        database.db
+          .prepare(
+            "UPDATE sqlite_schema SET sql = ? WHERE name = 'idx_agent_session_nodes_updated_at'",
+          )
+          .run(String(canonicalIndex?.sql));
+        database.db.exec("PRAGMA writable_schema = OFF;");
+      }
+      closeOpenClawAgentDatabaseByPath(pathname);
+      logger.warn.mockClear();
+
+      const reopened = openOpenClawAgentDatabase(options);
+      expect(
+        reopened.db
+          .prepare(
+            "SELECT session_key FROM session_nodes INDEXED BY idx_agent_session_nodes_updated_at",
+          )
+          .all(),
+      ).toEqual([{ session_key: "session-one" }]);
+      expect(reopened.db.prepare("PRAGMA integrity_check").get()).toEqual({
+        integrity_check: "ok",
+      });
+      expect(logger.warn).toHaveBeenCalledExactlyOnceWith(
+        "slow OpenClaw agent database open",
+        expect.objectContaining({
+          elapsedMs: 1_150,
+          integrityGateMs: 0,
+          integrityGateOutcome: drift === "physical" ? "failed" : "healthy",
+          canonicalIndexMs: 1_000,
+          repairedIndexCount: drift === "physical" ? canonicalIndexCount : 1,
+          phaseDurationsMs: {
+            open: 60,
+            validation: 1_000,
+            configuration: 80,
+            schema: 0,
+            registration: 10,
+          },
+        }),
+      );
+    },
+  );
 
   it("includes asynchronous admission waiting once for coalesced callers", async () => {
     const { options, pathname, advance } = createTimedOpen(0);
@@ -209,6 +283,10 @@ describe("agent database open timings", () => {
         isMainThread,
         admissionMode: "async",
         thresholdMs: 1_000,
+        integrityGateMs: 1_000,
+        integrityGateOutcome: "healthy",
+        canonicalIndexMs: 0,
+        repairedIndexCount: 0,
         phaseDurationsMs: {
           open: 60,
           validation: 1_000,

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -15,6 +15,7 @@ import {
   confirmSqliteFileIntegrity,
   isTerminalSqliteIntegrityError,
   runSqliteIntegrityOperationSync,
+  type SqliteIntegrityDiagnostics,
   type SqliteIntegrityOperation,
   type SqliteIntegrityConfirmation,
 } from "../infra/sqlite-integrity.js";
@@ -296,7 +297,13 @@ function* openOpenClawAgentDatabaseSteps(
         env: leaseEnvironment,
       });
   }
-  const finishPhase = startAgentDatabaseOpenTiming(agentId, pathname, pending ? "async" : "sync");
+  const diagnostics: SqliteIntegrityDiagnostics = {};
+  const finishPhase = startAgentDatabaseOpenTiming(
+    agentId,
+    pathname,
+    pending ? "async" : "sync",
+    diagnostics,
+  );
   let openedDb: DatabaseSync | undefined;
   let openedDatabase: OpenClawAgentDatabase | undefined;
   let openedWalMaintenance: SqliteWalMaintenance | undefined;
@@ -329,6 +336,7 @@ function* openOpenClawAgentDatabaseSteps(
           db,
           agentId,
           pathname,
+          diagnostics,
         );
         if (isValidatedReopen && (!existingSchema || requiresCurrentVersionConvergence)) {
           // New files and same-version divergence cannot inherit an earlier validation.


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where operators diagnosing a slow agent-database open could not distinguish the initial integrity check from subsequent canonical-index inspection or repair. The existing `validation` duration covered all of those operations, and a healthy initial check could still lead to an index-definition repair.

## Why This Change Was Made

The existing completed slow-open record now includes the yielded integrity gate's elapsed time and outcome, total subsequent canonical-index work, and the actual number of successfully repaired indexes. All fields come from their existing owners. Aggregate phases, the one-second threshold, emission point, SQL, error propagation, and admission/lease/Worker lifetime remain unchanged.

## User Impact

Operators can distinguish a slow integrity admission from synchronous index work without guessing whether a repair happened. The fields report elapsed time, including awaited work and revalidation, rather than CPU time. Work before the existing open timer, failures before registration, and live cache hits remain outside this summary. The diagnostic adds no index names or database contents.

## Evidence

- Pre-fix real-owner controls reproduced four missing-field failures after successful healthy, definition-drift, physical-drift, and coalesced async operations.
- Focused local integrity, index-repair, open-timing, and lease-owner tests: 41 passed across four files. Timing assertions use a controlled clock; SQLite checks and repairs are real.
- Independent autoreview: no actionable P0–P2 findings.
- `node scripts/check-changed.mjs` passed, including both core typechecks, lint, and owner guards; docs MDX and diff checks passed.
- Secretless AWS Crabbox on Linux/Node 24.19.0 verified all candidate file hashes, passed 41 focused tests, and exercised real file-log output for healthy opens, definition repairs, and physical-index repairs (reported repair counts: 0, 1, 9). The final documentation-only wording clarification does not change the verified runtime files.

The file-output proof uses synthetic databases and a deliberate 1.1-second delay after a real native check or index creation to exercise the existing threshold. It validates diagnostic attribution and preserved data, not production performance. This change does not reduce validation cost.
