### PR TITLE
fix(btw): report usage for direct-provider answers

### DIFF
--- a/docs/tools/btw.md
+++ b/docs/tools/btw.md
@@ -29,6 +29,10 @@ The two side-question contracts are deliberately separate. BTW is a one-shot que
 
 The main run, if one is active, is left untouched.
 
+When their runtime supplies usage, completed direct-provider and harness side
+questions report it through the configured [diagnostics pipeline](/gateway/opentelemetry).
+This does not add the exchange to session history or session-derived `/usage cost` totals.
+
 For Codex harness sessions, BTW forks the active Codex app-server thread into
 an ephemeral child thread instead of running a separate provider call. This
 keeps Codex OAuth and native tool/thread behavior intact, and the forked

--- a/src/agents/btw.test.ts
+++ b/src/agents/btw.test.ts
@@ -1265,14 +1265,37 @@ describe("runBtwSideQuestion", () => {
     );
   });
 
-  it.each([false, true])(
-    "exposes side-question usage with diagnostics enabled: %s",
-    async (enabled) => {
-      const usage = { input: 13, output: 9, cacheRead: 7, cacheWrite: 3, total: 32 };
-      const harness = registerCodexSideQuestionHarness();
-      harness.mockResolvedValue({ text: "Codex side answer.", usage });
-      const runId = `btw-usage-reply-${enabled}`;
-      const authorityRunId = `btw-usage-authority-${enabled}`;
+  it.each(
+    ["harness", "direct", "direct-block"].flatMap((mode) =>
+      [false, true, undefined].map((enabled) => ({ mode, enabled })),
+    ),
+  )(
+    "exposes $mode side-question usage with diagnostics enabled: $enabled",
+    async ({ mode, enabled }) => {
+      const tokens = { input: 13, output: 9, cacheRead: 7, cacheWrite: 3 };
+      const usage = { ...tokens, total: 41 };
+      const cost = { input: 0.1, output: 0.1, cacheRead: 0.03, cacheWrite: 0.02, total: 0.25 };
+      const text = "Side answer.";
+      const onBlockReply = vi.fn().mockResolvedValue(undefined);
+      if (mode === "harness") {
+        registerCodexSideQuestionHarness().mockResolvedValue({ text, usage: { ...usage, cost } });
+      } else {
+        const done = createDoneEvent(text);
+        done.message.usage = { ...tokens, totalTokens: 41, cost };
+        streamSimpleMock.mockReturnValue(
+          makeAsyncEvents([
+            ...(mode === "direct-block"
+              ? [
+                  { type: "text_delta", delta: text },
+                  { type: "text_end", content: text, contentIndex: 0 },
+                ]
+              : []),
+            done,
+          ]),
+        );
+      }
+      const runId = `btw-usage-reply-${mode}-${enabled}`;
+      const authorityRunId = `btw-usage-authority-${mode}-${enabled}`;
       const sessionEntry = createSessionEntry({ inputTokens: 200, cacheRead: 100 });
       const originalEntry = structuredClone(sessionEntry);
       const diagnostics: unknown[] = [];
@@ -1287,22 +1310,43 @@ describe("runBtwSideQuestion", () => {
             cfg: { diagnostics: { enabled } },
             sessionEntry,
             authorityRunId,
-            opts: { runId },
+            ...(mode === "direct-block"
+              ? {
+                  blockReplyChunking: {
+                    minChars: 1,
+                    maxChars: 200,
+                    breakPreference: "paragraph" as const,
+                  },
+                  resolvedBlockStreamingBreak: "text_end" as const,
+                }
+              : {}),
+            opts: { runId, onBlockReply },
           }),
-        ).resolves.toEqual({ text: "Codex side answer." });
-        expect(consumeReplyUsageState(runId)).toMatchObject({ usage, sessionId: "session-1" });
+        ).resolves.toEqual(mode === "direct-block" ? undefined : { text });
+        if (mode === "direct-block") {
+          expect(onBlockReply).toHaveBeenCalledExactlyOnceWith({
+            text,
+            btw: { question: DEFAULT_QUESTION },
+          });
+        }
+        expect.soft(consumeReplyUsageState(runId)).toMatchObject({
+          usage,
+          sessionId: "session-1",
+          turnUsd: 0.25,
+        });
         expect(consumeReplyUsageState(authorityRunId)).toBeUndefined();
         expect(sessionEntry).toEqual(originalEntry);
         await new Promise<void>((resolve) => {
           setImmediate(resolve);
         });
-        expect(diagnostics).toEqual(
-          enabled
+        expect.soft(diagnostics).toEqual(
+          enabled !== false
             ? [
                 expect.objectContaining({
                   type: "model.usage",
                   sessionId: "session-1",
                   usage: { ...usage, promptTokens: 23 },
+                  costUsd: 0.25,
                 }),
               ]
             : [],

--- a/src/agents/btw.ts
+++ b/src/agents/btw.ts
@@ -95,7 +95,12 @@ import { stripToolResultDetails } from "./session-transcript-repair.js";
 import { getModelRegistryRuntime } from "./sessions/model-registry-runtime.js";
 import { resolveAgentTimeoutMs } from "./timeout.js";
 import { sanitizeImageBlocks } from "./tool-images.js";
-import { hasBillableUsage } from "./usage.js";
+import {
+  hasBillableUsage,
+  normalizeUsage,
+  toDiagnosticUsage,
+  type NormalizedUsage,
+} from "./usage.js";
 
 function collectTextContent(content: Array<{ type?: string; text?: string }>): string {
   return content
@@ -843,6 +848,36 @@ export async function runBtwSideQuestion(
       }
       return runtimeSelection;
     };
+    const recordBtwUsage = (runtimeModel: Model, usage?: NormalizedUsage) => {
+      if (!hasBillableUsage(usage)) {
+        return;
+      }
+      const usageState = buildReplyUsageState({
+        config: params.cfg,
+        agentDir: params.agentDir,
+        agentId: sessionAgentId,
+        sessionId,
+        provider: runtimeModel.provider,
+        model: runtimeModel.id,
+        chatType: params.chatType,
+        usage,
+      });
+      // Delivery hooks use the reply correlation ID, not the side run's authority ID.
+      recordReplyUsageState(params.opts?.runId, usageState);
+      if (isDiagnosticsEnabled(params.cfg)) {
+        emitTrustedDiagnosticEvent({
+          type: "model.usage",
+          sessionKey: params.sessionKey,
+          sessionId,
+          channel: params.messageChannel,
+          agentId: sessionAgentId,
+          provider: runtimeModel.provider,
+          model: runtimeModel.id,
+          usage: toDiagnosticUsage(usage),
+          costUsd: usageState.turnUsd,
+        });
+      }
+    };
     type BtwHarnessSideQuestionDispatch =
       | { kind: "handled"; payload: ReplyPayload }
       | {
@@ -1073,42 +1108,7 @@ export async function runBtwSideQuestion(
         } finally {
           host.close();
         }
-        if (hasBillableUsage(result.usage)) {
-          const usageState = buildReplyUsageState({
-            config: params.cfg,
-            agentDir: params.agentDir,
-            agentId: sessionAgentId,
-            sessionId,
-            provider: runtimeModel.provider,
-            model: runtimeModel.id,
-            chatType: params.chatType,
-            usage: result.usage,
-          });
-          // Delivery hooks use the reply correlation ID, not the side run's authority ID.
-          recordReplyUsageState(params.opts?.runId, usageState);
-          if (isDiagnosticsEnabled(params.cfg)) {
-            const { input = 0, output = 0, cacheRead = 0, cacheWrite = 0 } = result.usage;
-            const promptTokens = input + cacheRead + cacheWrite;
-            emitTrustedDiagnosticEvent({
-              type: "model.usage",
-              sessionKey: params.sessionKey,
-              sessionId,
-              channel: params.messageChannel,
-              agentId: sessionAgentId,
-              provider: runtimeModel.provider,
-              model: runtimeModel.id,
-              usage: {
-                input,
-                output,
-                cacheRead,
-                cacheWrite,
-                promptTokens,
-                total: result.usage.total ?? promptTokens + output,
-              },
-              costUsd: usageState.turnUsd,
-            });
-          }
-        }
+        recordBtwUsage(runtimeModel, result.usage);
         return { kind: "handled", payload: { text: result.text } };
       } finally {
         preparedRunAdmission.close();
@@ -1450,6 +1450,8 @@ export async function runBtwSideQuestion(
     if (!answer) {
       throw new Error("No BTW response generated.");
     }
+
+    recordBtwUsage(runtimeModel, normalizeUsage(finalMessage?.usage));
 
     if (emittedBlocks > 0) {
       return undefined;

--- a/src/agents/command/ingress-diagnostics.ts
+++ b/src/agents/command/ingress-diagnostics.ts
@@ -1,7 +1,7 @@
 import { getRuntimeConfig } from "../../config/io.js";
 import { isDiagnosticsEnabled, emitTrustedDiagnosticEvent } from "../../infra/diagnostic-events.js";
 import { estimateAggregateUsageCost } from "../../utils/usage-format.js";
-import { hasBillableUsage, type NormalizedUsage } from "../usage.js";
+import { hasBillableUsage, toDiagnosticUsage, type NormalizedUsage } from "../usage.js";
 import type { AgentCommandIngressOpts } from "./types.js";
 
 type AgentCommandResult = {
@@ -43,12 +43,6 @@ export function emitIngressModelUsageDiagnostic(
 
   const providerUsed = agentMeta.provider ?? "";
   const modelUsed = agentMeta.model ?? "";
-  const input = usage.input ?? 0;
-  const output = usage.output ?? 0;
-  const cacheRead = usage.cacheRead ?? 0;
-  const cacheWrite = usage.cacheWrite ?? 0;
-  const usagePromptTokens = input + cacheRead + cacheWrite;
-  const totalTokens = usage.total ?? usagePromptTokens + output;
   const costUsd = estimateAggregateUsageCost({
     usage,
     provider: providerUsed,
@@ -65,14 +59,7 @@ export function emitIngressModelUsageDiagnostic(
     agentId: opts.agentId,
     provider: providerUsed,
     model: modelUsed,
-    usage: {
-      input,
-      output,
-      cacheRead,
-      cacheWrite,
-      promptTokens: usagePromptTokens,
-      total: totalTokens,
-    },
+    usage: toDiagnosticUsage(usage),
     lastCallUsage: agentMeta.lastCallUsage,
     context: {
       limit: agentMeta.contextTokens,

--- a/src/agents/usage.ts
+++ b/src/agents/usage.ts
@@ -300,6 +300,23 @@ export function normalizeUsage(raw?: UsageLike | null): NormalizedUsage | undefi
   };
 }
 
+/** Aggregate token counters for model.usage diagnostics, separate from context snapshots. */
+export function toDiagnosticUsage(usage: NormalizedUsage) {
+  const input = usage.input ?? 0;
+  const output = usage.output ?? 0;
+  const cacheRead = usage.cacheRead ?? 0;
+  const cacheWrite = usage.cacheWrite ?? 0;
+  const promptTokens = input + cacheRead + cacheWrite;
+  return {
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    promptTokens,
+    total: usage.total ?? promptTokens + output,
+  };
+}
+
 /**
  * Maps normalized usage to OpenAI Chat Completions `usage` fields.
  *

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -8,7 +8,11 @@ import {
   hasDeliberateSilentTerminalReply,
   hasIntentionalTerminalCompletion,
 } from "../../agents/embedded-agent-runner/result-fallback-classifier.js";
-import { deriveContextPromptTokens, hasBillableUsage } from "../../agents/usage.js";
+import {
+  deriveContextPromptTokens,
+  hasBillableUsage,
+  toDiagnosticUsage,
+} from "../../agents/usage.js";
 import { normalizeChatType } from "../../channels/chat-type.js";
 import { emitAgentEvent } from "../../infra/agent-events.js";
 import { emitTrustedDiagnosticEvent, isDiagnosticsEnabled } from "../../infra/diagnostic-events.js";
@@ -563,12 +567,6 @@ export async function prepareReplyAgentPayloads(state: {
 
   const diagnosticUsage = runResult.meta?.agentMeta?.diagnosticUsage ?? usage;
   if (isDiagnosticsEnabled(cfg) && hasBillableUsage(diagnosticUsage)) {
-    const input = diagnosticUsage.input ?? 0;
-    const output = diagnosticUsage.output ?? 0;
-    const cacheRead = diagnosticUsage.cacheRead ?? 0;
-    const cacheWrite = diagnosticUsage.cacheWrite ?? 0;
-    const usagePromptTokens = input + cacheRead + cacheWrite;
-    const totalTokens = diagnosticUsage.total ?? usagePromptTokens + output;
     const contextUsedTokens = deriveContextPromptTokens({
       lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
       promptTokens,
@@ -596,14 +594,7 @@ export async function prepareReplyAgentPayloads(state: {
       agentId: followupRun.run.agentId,
       provider: providerUsed,
       model: modelUsed,
-      usage: {
-        input,
-        output,
-        cacheRead,
-        cacheWrite,
-        promptTokens: usagePromptTokens,
-        total: totalTokens,
-      },
+      usage: toDiagnosticUsage(diagnosticUsage),
       lastCallUsage: runResult.meta?.agentMeta?.lastCallUsage,
       context: {
         limit: contextTokensUsed,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users received successful direct `/btw` answers but their usage was missing from configured model diagnostics and the optional reply-usage handoff. The harness side-question path already reported that usage.

## Why This Change Was Made

Direct and harness completions now share the existing BTW accounting owner. Direct completions normalize the returned usage once, and three identical diagnostic token projections use one pure helper. This preserves recorded cost, explicit totals, correlation IDs, diagnostics controls, and the ephemeral conversation contract.

## User Impact

Configured diagnostics include usage from successful direct side questions, including completed block streams. Questions and answers remain outside session history and session-derived `/usage cost` totals; blocks already delivered are not retroactively decorated.

## Evidence

- The same synthetic regression and sibling selection went from **20 passed / 6 failed** before the fix to **26 passed** afterward, with unchanged test bytes. The six failures covered direct final-text and block completion with diagnostics disabled, enabled, and at its default. Harness, ingress, and normal-reply controls passed throughout.
- Production **−3 lines**, existing tests **+44**, docs **+4**. No configuration, storage, audit/identity, protocol, or public SDK change.
- All **29 classified changed checks passed**, including core/test typechecks, focused lint, formatting, dead exports and architecture guards. Diff-scoped deslop review found no further change needed. Managed review is complete; its block-timing finding was rejected after source inspection confirmed the existing queued-delivery and best-effort handoff contract. Exact-head CI34170228202 passed108jobs with16skipped;the required gate is green.
- No live model/provider/exporter calls were made; proof uses existing synthetic stream events and isolated test state.

Reply hooks read the live snapshot when queued delivery starts, so queued blocks and later TTS replies can consume completion usage. Already-delivered blocks keep the documented best-effort limitation; this change adds no streaming delay.


CI recovery: the first run failed in an unrelated process-test adapter. That repair landed independently in #141634. This branch now includes it through a rebase; the complete introduced patch and all six changed file contents are byte-identical to the reviewed version. Final CI passed for the rebased head.
