### PR TITLE
fix(discord): preserve commentary and failed delivery progress

### DIFF
--- a/extensions/discord/src/monitor/message-handler.draft-preview.ts
+++ b/extensions/discord/src/monitor/message-handler.draft-preview.ts
@@ -368,13 +368,19 @@ export function createDiscordDraftPreviewController(params: {
       }
       await draftStream.flush();
     },
-    async cleanup() {
+    async cleanup({ finalDeliveryFailed = false }: { finalDeliveryFailed?: boolean } = {}) {
       try {
         progressDraft.cancel();
         if (finalReplyError !== false) {
           await draftStream?.discardPending();
         }
-        if (finalReplyError !== true && !finalizedViaPreviewMessage && draftStream?.messageId()) {
+        const keepFailedProgressDraft = discordStreamMode === "progress" && finalDeliveryFailed;
+        if (
+          !keepFailedProgressDraft &&
+          finalReplyError !== true &&
+          !finalizedViaPreviewMessage &&
+          draftStream?.messageId()
+        ) {
           await draftStream.clear();
         }
         await draftStream?.cleanupPendingMessages();

--- a/extensions/discord/src/monitor/message-handler.process.commentary.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.commentary.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import {
+  deliverDiscordReply,
+  dispatchInboundMessageForTest as dispatchInboundMessage,
+  registerDiscordProcessTestLifecycle,
+  runProcessDiscordMessage,
+} from "./message-handler.process.test-harness.js";
+import type { DispatchInboundParams } from "./message-handler.process.test-harness.js";
+import {
+  createAutomaticDraftContext,
+  createMockDraftStreamForTest,
+  expectFinalAnswerText,
+} from "./message-handler.process.test-helpers.js";
+
+registerDiscordProcessTestLifecycle();
+
+describe("Discord durable commentary delivery", () => {
+  it("delivers admitted commentary once without exposing ordinary progress blocks", async () => {
+    createMockDraftStreamForTest();
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      params?.replyOptions?.onVerboseProgressVisibility?.(() => true);
+      await params?.dispatcher.sendBlockReply({ text: "ordinary interim text" });
+      await params?.dispatcher.sendBlockReply({
+        text: "Checking the source before asking.",
+        isCommentary: true,
+      });
+      await params?.dispatcher.sendFinalReply({ text: "done" });
+      return { queuedFinal: true, counts: { final: 1, tool: 0, block: 1 } };
+    });
+    const ctx = await createAutomaticDraftContext({
+      discordConfig: {
+        streaming: {
+          mode: "progress",
+          progress: { toolProgress: false, commentary: true },
+        },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(2);
+    expect(deliverDiscordReply).toHaveBeenCalledWith(
+      expect.objectContaining({
+        replies: [{ text: "Checking the source before asking.", isCommentary: true }],
+      }),
+    );
+    expectFinalAnswerText("done");
+  });
+});

--- a/extensions/discord/src/monitor/message-handler.process.draft-recovery.test.ts
+++ b/extensions/discord/src/monitor/message-handler.process.draft-recovery.test.ts
@@ -126,6 +126,35 @@ describe("processDiscordMessage draft streaming recovery", () => {
     expect(draftStream.clear).toHaveBeenCalledTimes(1);
   });
 
+  it("keeps the visible progress draft when final delivery fails without recovery", async () => {
+    const elapseProgressDraftStartDelay = useProgressDraftStartDelay();
+    const draftStream = createMockDraftStreamForTest();
+    deliverDiscordReply.mockRejectedValueOnce(new Error("send failed"));
+    dispatchInboundMessage.mockImplementationOnce(async (params?: DispatchInboundParams) => {
+      await params?.replyOptions?.onToolStart?.({ name: "exec", phase: "start" });
+      await params?.replyOptions?.onItemEvent?.({ progressText: "checked the workspace" });
+      await elapseProgressDraftStartDelay();
+      await params?.dispatcher.sendFinalReply({ text: "complete answer" });
+      return {
+        queuedFinal: true,
+        counts: { final: 0, tool: 0, block: 0 },
+        failedCounts: { final: 1 },
+      };
+    });
+    const ctx = await createAutomaticDraftContext({
+      discordConfig: {
+        streaming: { mode: "progress", progress: { toolProgress: true } },
+      },
+    });
+
+    await runProcessDiscordMessage(ctx);
+
+    expect(draftStream.update).toHaveBeenCalled();
+    expect(deliverDiscordReply).toHaveBeenCalledTimes(1);
+    expect(draftStream.discardPending).toHaveBeenCalled();
+    expect(draftStream.clear).not.toHaveBeenCalled();
+  });
+
   it("uses root discord maxLinesPerMessage for fresh final delivery when runtime config omits it", async () => {
     const longReply = Array.from({ length: 20 }, (_value, index) => `Line ${index + 1}`).join("\n");
     const draftStream = await runFinalReplyScenario(

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -382,6 +382,7 @@ async function processDiscordMessageInner(
       draftStream &&
       draftPreview.isProgressMode &&
       info.kind === "block" &&
+      !deliverablePayload.isCommentary &&
       !options?.allowProgressBlock
     ) {
       const reply = resolveSendableOutboundReplyParts(deliverablePayload);

--- a/extensions/discord/src/monitor/message-handler.process.ts
+++ b/extensions/discord/src/monitor/message-handler.process.ts
@@ -713,7 +713,7 @@ async function processDiscordMessageInner(
   } finally {
     activeThreadRoute.end();
     endDeliveryCorrelation();
-    await draftPreview.cleanup();
+    await draftPreview.cleanup({ finalDeliveryFailed: userFacingFinalDeliveryFailed });
     dispatchError ||= readAgentRunTerminalOutcome(dispatchResult) === "failed";
     const finalReceipt = dispatchResult?.settledReceipt?.counts.final;
     const finalDeliveryFailed =


### PR DESCRIPTION
Related: #139217. Upstream commentary production remains a separate issue.

## What Problem This Solves

Discord progress mode can drop admitted commentary even though the final answer arrives. A failed final send can also erase the only visible progress message during cleanup.

## Why This Change Was Made

Preserve the existing commentary classification in the second progress-mode delivery filter. Use the sender's existing failure state to retain an acknowledged progress draft after a failed final send. Successful recovery still clears that failure state and removes the draft normally.

## User Impact

Admitted commentary appears once before the final answer. Ordinary intermediate text stays hidden. Progress remains visible if Discord rejects the final send. Existing commentary opt-in, verbose progress, media/error replies, and partial/block previews retain their behavior.

## Evidence

Real Discord guild mentions used leased driver and application bots, the normal Gateway, and a deterministic CLI provider loaded through the documented backend interface. Both source versions ran on the same isolated Testbox. Baseline main was pinned at `b09afb2f283248ac743a1db3e762a508c44822bf`.

| Scenario | Baseline | Repaired behavior |
| --- | --- | --- |
| Admitted commentary with an active progress draft | Commentary missing; final delivered | Commentary once before final; no duplicate in draft |
| Ordinary intermediate text | Hidden | Hidden |
| Successful final send | Draft deleted after final | Same behavior |
| Final send rejected with HTTP 403 | Only progress message deleted | Progress message retained; no false final or success |

The send-failure control rejects only the final-message request and permits deletion, so a broken delete route cannot fake retention. Commentary-disabled controls preserve the separate verbose preamble feature; disabling verbose as well leaves only the final after temporary draft cleanup.

- 101 focused Discord tests pass, including media/error replies, successful retry, partial/block previews, late-message cleanup, and the new terminal-failure case.
- Both regression tests fail on their original defects for the expected missing-delivery/deleted-progress reasons.
- Targeted formatting, syntax lint, line-count and assertion checks pass. Full type checks and CI run on GitHub.

The repair adds no product option or upstream commentary callback.
