### PR TITLE
refactor(tests): reuse Discord allowlist fixtures

### DIFF
--- a/extensions/discord/src/actions/runtime.test.ts
+++ b/extensions/discord/src/actions/runtime.test.ts
@@ -651,21 +651,13 @@ describe("handleDiscordMessagingAction", () => {
   });
 
   it("rejects Discord reaction reads for non-allowlisted target channels", async () => {
-    const cfg = {
-      channels: {
-        discord: {
-          token: "token",
-          groupPolicy: "allowlist",
-          guilds: {
-            "111": {
-              channels: {
-                "222": { enabled: true },
-              },
-            },
-          },
+    const cfg = discordAllowlistCfg({
+      "111": {
+        channels: {
+          "222": { enabled: true },
         },
       },
-    } as OpenClawConfig;
+    });
 
     await expect(
       handleMessagingAction(
@@ -1205,21 +1197,13 @@ describe("handleDiscordMessagingAction", () => {
   });
 
   it("rejects Discord permission reads for non-allowlisted target channels", async () => {
-    const cfg = {
-      channels: {
-        discord: {
-          token: "token",
-          groupPolicy: "allowlist",
-          guilds: {
-            "111": {
-              channels: {
-                "222": { enabled: true },
-              },
-            },
-          },
+    const cfg = discordAllowlistCfg({
+      "111": {
+        channels: {
+          "222": { enabled: true },
         },
       },
-    } as OpenClawConfig;
+    });
 
     await expect(
       handleMessagingAction("permissions", { channelId: "444" }, enableAllActions, cfg),
@@ -1293,21 +1277,13 @@ describe("handleDiscordMessagingAction", () => {
       guild_id: "111",
       type: ChannelType.GuildText,
     });
-    const cfg = {
-      channels: {
-        discord: {
-          token: "token",
-          groupPolicy: "allowlist",
-          guilds: {
-            "111": {
-              channels: {
-                "222": { enabled: true },
-              },
-            },
-          },
+    const cfg = discordAllowlistCfg({
+      "111": {
+        channels: {
+          "222": { enabled: true },
         },
       },
-    } as OpenClawConfig;
+    });
 
     await handleMessagingAction("readMessages", { channelId: "222" }, enableAllActions, cfg);
 
@@ -1505,21 +1481,13 @@ describe("handleDiscordMessagingAction", () => {
       id: "111",
       name: "Friends of OpenClaw",
     });
-    const cfg = {
-      channels: {
-        discord: {
-          token: "token",
-          groupPolicy: "allowlist",
-          guilds: {
-            "friends-of-openclaw": {
-              channels: {
-                "222": { enabled: true },
-              },
-            },
-          },
+    const cfg = discordAllowlistCfg({
+      "friends-of-openclaw": {
+        channels: {
+          "222": { enabled: true },
         },
       },
-    } as OpenClawConfig;
+    });
 
     await handleMessagingAction("readMessages", { channelId: "222" }, enableAllActions, cfg);
 
@@ -1532,21 +1500,13 @@ describe("handleDiscordMessagingAction", () => {
   });
 
   it("rejects Discord reads for non-allowlisted target channels", async () => {
-    const cfg = {
-      channels: {
-        discord: {
-          token: "token",
-          groupPolicy: "allowlist",
-          guilds: {
-            "111": {
-              channels: {
-                "222": { enabled: true },
-              },
-            },
-          },
+    const cfg = discordAllowlistCfg({
+      "111": {
+        channels: {
+          "222": { enabled: true },
         },
       },
-    } as OpenClawConfig;
+    });
 
     await expect(
       handleMessagingAction("readMessages", { channelId: "333" }, enableAllActions, cfg),
@@ -1618,21 +1578,13 @@ describe("handleDiscordMessagingAction", () => {
       id: "111",
       name: "Friends of OpenClaw",
     });
-    const cfg = {
-      channels: {
-        discord: {
-          token: "token",
-          groupPolicy: "allowlist",
-          guilds: {
-            "friends-of-openclaw": {
-              channels: {
-                "222": { enabled: true },
-              },
-            },
-          },
+    const cfg = discordAllowlistCfg({
+      "friends-of-openclaw": {
+        channels: {
+          "222": { enabled: true },
         },
       },
-    } as OpenClawConfig;
+    });
 
     await handleMessagingAction(
       "fetchMessage",
@@ -1646,21 +1598,13 @@ describe("handleDiscordMessagingAction", () => {
   });
 
   it("rejects Discord message links for non-allowlisted target channels", async () => {
-    const cfg = {
-      channels: {
-        discord: {
-          token: "token",
-          groupPolicy: "allowlist",
-          guilds: {
-            "111": {
-              channels: {
-                "222": { enabled: true },
-              },
-            },
-          },
+    const cfg = discordAllowlistCfg({
+      "111": {
+        channels: {
+          "222": { enabled: true },
         },
       },
-    } as OpenClawConfig;
+    });
 
     await expect(
       handleMessagingAction(
@@ -1694,21 +1638,13 @@ describe("handleDiscordMessagingAction", () => {
       }
       return { id: channelId, guild_id: "111", type: ChannelType.GuildText };
     });
-    const cfg = {
-      channels: {
-        discord: {
-          token: "token",
-          groupPolicy: "allowlist",
-          guilds: {
-            "111": {
-              channels: {
-                "222": { enabled: true },
-              },
-            },
-          },
+    const cfg = discordAllowlistCfg({
+      "111": {
+        channels: {
+          "222": { enabled: true },
         },
       },
-    } as OpenClawConfig;
+    });
 
     await handleMessagingAction(
       "fetchMessage",
@@ -1727,21 +1663,13 @@ describe("handleDiscordMessagingAction", () => {
       name: "allowed-channel",
       type: 0,
     }));
-    const cfg = {
-      channels: {
-        discord: {
-          token: "token",
-          groupPolicy: "allowlist",
-          guilds: {
-            "111": {
-              channels: {
-                "allowed-channel": { enabled: true },
-              },
-            },
-          },
+    const cfg = discordAllowlistCfg({
+      "111": {
+        channels: {
+          "allowed-channel": { enabled: true },
         },
       },
-    } as OpenClawConfig;
+    });
 
     await expect(
       handleMessagingAction(
@@ -1766,21 +1694,13 @@ describe("handleDiscordMessagingAction", () => {
         name: "allowed-channel",
         type: 0,
       }));
-      const cfg = {
-        channels: {
-          discord: {
-            token: "token",
-            groupPolicy: "allowlist",
-            guilds: {
-              "111": {
-                channels: {
-                  "allowed-channel": { enabled: true },
-                },
-              },
-            },
+      const cfg = discordAllowlistCfg({
+        "111": {
+          channels: {
+            "allowed-channel": { enabled: true },
           },
         },
-      } as OpenClawConfig;
+      });
 
       await expect(
         handleMessagingAction(action, { channelId: "333" }, enableAllActions, cfg),
@@ -1804,21 +1724,13 @@ describe("handleDiscordMessagingAction", () => {
   });
 
   it("rejects Discord pin reads for non-allowlisted target channels", async () => {
-    const cfg = {
-      channels: {
-        discord: {
-          token: "token",
-          groupPolicy: "allowlist",
-          guilds: {
-            "111": {
-              channels: {
-                "222": { enabled: true },
-              },
-            },
-          },
+    const cfg = discordAllowlistCfg({
+      "111": {
+        channels: {
+          "222": { enabled: true },
         },
       },
-    } as OpenClawConfig;
+    });
 
     await expect(
       handleMessagingAction("listPins", { channelId: "444" }, enableAllActions, cfg),
@@ -1849,21 +1761,13 @@ describe("handleDiscordMessagingAction", () => {
   });
 
   it("rejects Discord searches for non-allowlisted target channels", async () => {
-    const cfg = {
-      channels: {
-        discord: {
-          token: "token",
-          groupPolicy: "allowlist",
-          guilds: {
-            "111": {
-              channels: {
-                "222": { enabled: true },
-              },
-            },
-          },
+    const cfg = discordAllowlistCfg({
+      "111": {
+        channels: {
+          "222": { enabled: true },
         },
       },
-    } as OpenClawConfig;
+    });
 
     await expect(
       handleMessagingAction(
@@ -1877,21 +1781,13 @@ describe("handleDiscordMessagingAction", () => {
   });
 
   it("requires explicit Discord search targets when channels are allowlisted", async () => {
-    const cfg = {
-      channels: {
-        discord: {
-          token: "token",
-          groupPolicy: "allowlist",
-          guilds: {
-            "111": {
-              channels: {
-                "222": { enabled: true },
-              },
-            },
-          },
+    const cfg = discordAllowlistCfg({
+      "111": {
+        channels: {
+          "222": { enabled: true },
         },
       },
-    } as OpenClawConfig;
+    });
 
     await expect(
       handleMessagingAction(
@@ -1944,21 +1840,13 @@ describe("handleDiscordMessagingAction", () => {
   });
 
   it("allows guild-wide Discord searches when the guild has a wildcard channel allowlist", async () => {
-    const cfg = {
-      channels: {
-        discord: {
-          token: "token",
-          groupPolicy: "allowlist",
-          guilds: {
-            "111": {
-              channels: {
-                "*": { enabled: true },
-              },
-            },
-          },
+    const cfg = discordAllowlistCfg({
+      "111": {
+        channels: {
+          "*": { enabled: true },
         },
       },
-    } as OpenClawConfig;
+    });
 
     await handleMessagingAction(
       "searchMessages",


### PR DESCRIPTION
## What Problem This Solves

Discord action tests repeat the same configuration wrapper around fourteen explicit guild/channel allowlists, even though this suite already has a helper for that setup. This adds maintenance noise around useful authorization regressions.

## Why This Change Was Made

Reuse the existing local `discordAllowlistCfg` helper at those fourteen positions. Keep every guild/channel rule, assertion, test name, callback, mock and allocation point explicit and unchanged. This removes 112 net test lines without adding support code or changing production behavior.

## User Impact

No user-visible change. Discord read-target authorization, guild matching, thread-parent handling and wildcard search behavior retain their existing tests.

## Evidence

- Full `runtime.test.ts` and `handle-action.test.ts` suites passed before and after: 201 tests, no failures or skips; identical test names, order and results.
- Expanding the fourteen calls using the unchanged helper reproduces the original full-file AST. Fixture checks preserve ordered properties, absent fields and fresh nested objects across repeated construction.
- `node scripts/check-changed.mjs -- extensions/discord/src/actions/runtime.test.ts` passed.
- Deslop and independent P2 review found no actionable issues.

No suite-runtime improvement is claimed for this fixture cleanup.
