### PR TITLE
refactor: simplify provider HTTP error normalization

### DIFF
--- a/src/agents/provider-http-errors.test.ts
+++ b/src/agents/provider-http-errors.test.ts
@@ -6,6 +6,7 @@ import {
   createProviderHttpError,
   extractProviderErrorDetail,
   extractProviderRequestId,
+  formatProviderErrorPayload,
   ProviderHttpError,
   readProviderBinaryResponse,
   readProviderJsonResponse,
@@ -91,6 +92,134 @@ function createStreamingTextResponse(params: { chunkCount: number; chunkSize: nu
 }
 
 describe("provider error utils", () => {
+  it.each([
+    ["undefined", undefined, undefined],
+    ["null", null, undefined],
+    ["string", "provider failure", undefined],
+    ["number", 429, undefined],
+    ["boolean", false, undefined],
+    ["function", () => "provider failure", undefined],
+    ["array", [{ message: "ignored" }], undefined],
+    ["empty object", {}, undefined],
+    ["blank fields", { message: " ", detail: "\n", type: " ", code: " " }, undefined],
+    [
+      "nested error before detail and root",
+      {
+        error: { message: " nested ", type: " invalid ", code: " bad " },
+        detail: { message: "ignored detail" },
+        message: "ignored root",
+      },
+      "nested [type=invalid, code=bad]",
+    ],
+    [
+      "array error before object detail",
+      { error: [{ message: "ignored" }], detail: { message: " detail ", status: " retry " } },
+      "detail [code=retry]",
+    ],
+    ["array detail before root", { detail: ["ignored"], message: " root " }, "root"],
+    [
+      "blank nested message before root fallback",
+      { error: { message: " ", detail: 7 }, detail: { message: "ignored" }, message: " root " },
+      "root",
+    ],
+    [
+      "nested detail before OAuth description",
+      { error: { message: " ", detail: " nested detail ", error_description: "ignored" } },
+      "nested detail",
+    ],
+    ["root detail before flat error", { detail: " detail ", error: "ignored" }, "detail"],
+    [
+      "OAuth description and raw error code",
+      { error: " invalid_request ", error_description: " Needs configuration " },
+      "Needs configuration [code=invalid_request]",
+    ],
+    ["flat error without OAuth description", { error: " invalid_request " }, "invalid_request"],
+    [
+      "blank OAuth description without inferred code",
+      { error: " invalid_request ", error_description: " " },
+      "invalid_request",
+    ],
+    [
+      "explicit code before status and OAuth code",
+      {
+        message: "retry",
+        code: " limited ",
+        status: "ignored",
+        error: "ignored",
+        error_description: "ignored",
+      },
+      "retry [code=limited]",
+    ],
+    ["non-string code before status", { code: 3, status: " bad " }, "[code=bad]"],
+    ["type-only metadata", { type: " rate ", code: " " }, "[type=rate]"],
+    ["raw public text", { message: "api_key=not-a-real-key" }, "api_key=not-a-real-key"],
+  ] as const)("formats the public %s payload", (_name, payload, expected) => {
+    expect(formatProviderErrorPayload(payload)).toBe(expected);
+  });
+
+  it("preserves changing public getters and skips lower-priority fields", () => {
+    const reads: string[] = [];
+    let messageReads = 0;
+    const subject = {
+      get error_description() {
+        reads.push("subject.error_description");
+        return undefined;
+      },
+      get message() {
+        reads.push("subject.message");
+        return ++messageReads === 1 ? " first " : " second ";
+      },
+      get detail() {
+        throw new Error("lower-priority subject detail must stay unread");
+      },
+      get type() {
+        reads.push("subject.type");
+        return " rate ";
+      },
+      get code() {
+        reads.push("subject.code");
+        return " limited ";
+      },
+      get status() {
+        throw new Error("lower-priority status must stay unread");
+      },
+    };
+    const payload = {
+      get detail() {
+        reads.push("root.detail");
+        return { message: "ignored detail" };
+      },
+      get error() {
+        reads.push("root.error");
+        return subject;
+      },
+      get error_description() {
+        reads.push("root.error_description");
+        return undefined;
+      },
+      get message() {
+        throw new Error("lower-priority root message must stay unread");
+      },
+    };
+
+    for (const expected of [
+      "first [type=rate, code=limited]",
+      "second [type=rate, code=limited]",
+    ]) {
+      reads.length = 0;
+      expect(formatProviderErrorPayload(payload)).toBe(expected);
+      expect(reads).toEqual([
+        "root.detail",
+        "root.error",
+        "subject.error_description",
+        "root.error_description",
+        "subject.message",
+        "subject.type",
+        "subject.code",
+      ]);
+    }
+  });
+
   it("formats nested provider error details with request ids", async () => {
     const response = new Response(
       JSON.stringify({

--- a/src/agents/provider-http-errors.ts
+++ b/src/agents/provider-http-errors.ts
@@ -174,13 +174,18 @@ export async function readProviderTextResponse(
   return new TextDecoder().decode(bytes);
 }
 
-/** Formats common provider JSON error payload shapes into one readable detail string. */
-export function formatProviderErrorPayload(payload: unknown): string | undefined {
+type ProviderErrorPayloadMetadata = {
+  detail?: string;
+  code?: string;
+  type?: string;
+};
+
+function resolveProviderErrorPayloadMetadata(payload: unknown): ProviderErrorPayloadMetadata {
   const root = asOptionalRecord(payload);
   const detailObject = asOptionalRecord(root?.detail);
   const subject = asOptionalRecord(root?.error) ?? detailObject ?? root;
   if (!subject) {
-    return undefined;
+    return { detail: undefined };
   }
   const errorDescription =
     trimToUndefined(subject.error_description) ?? trimToUndefined(root?.error_description);
@@ -197,50 +202,21 @@ export function formatProviderErrorPayload(payload: unknown): string | undefined
   const metadata = [type ? `type=${type}` : undefined, code ? `code=${code}` : undefined]
     .filter((value): value is string => Boolean(value))
     .join(", ");
-  if (message && metadata) {
-    return `${truncateErrorDetail(message)} [${metadata}]`;
-  }
-  if (message) {
-    return truncateErrorDetail(message);
-  }
-  if (metadata) {
-    return `[${metadata}]`;
-  }
-  return undefined;
+  const detail = message
+    ? `${truncateErrorDetail(message)}${metadata ? ` [${metadata}]` : ""}`
+    : metadata
+      ? `[${metadata}]`
+      : undefined;
+  return { detail, code, type };
 }
 
-type ProviderErrorPayloadMetadata = {
-  detail?: string;
-  code?: string;
-  type?: string;
-};
-
-function extractProviderErrorPayloadMetadata(payload: unknown): ProviderErrorPayloadMetadata {
-  const root = asOptionalRecord(payload);
-  const detailObject = asOptionalRecord(root?.detail);
-  const subject = asOptionalRecord(root?.error) ?? detailObject ?? root;
-  if (!subject) {
-    return {};
-  }
-
-  const detail = formatProviderErrorPayload(payload);
-  const type = trimToUndefined(subject.type);
-  const errorDescription =
-    trimToUndefined(subject.error_description) ?? trimToUndefined(root?.error_description);
-  const oauthCode = errorDescription ? trimToUndefined(root?.error) : undefined;
-  const code = trimToUndefined(subject.code) ?? trimToUndefined(subject.status) ?? oauthCode;
-  return {
-    ...(detail ? { detail: redactSensitiveText(detail) } : {}),
-    ...(code ? { code } : {}),
-    ...(type ? { type } : {}),
-  };
+/** Formats common provider JSON error payload shapes into one readable detail string. */
+export function formatProviderErrorPayload(payload: unknown): string | undefined {
+  return resolveProviderErrorPayloadMetadata(payload).detail;
 }
 
 /** Metadata extracted from a non-2xx provider response body and headers. */
-type ProviderHttpErrorInfo = {
-  detail?: string;
-  code?: string;
-  type?: string;
+type ProviderHttpErrorInfo = ProviderErrorPayloadMetadata & {
   body?: string;
   requestId?: string;
 };
@@ -287,7 +263,7 @@ async function extractProviderErrorInfo(
       : rawRequestId;
   const rawBody = trimToUndefined(prefix?.text);
   if (!rawBody) {
-    return requestId ? { requestId } : {};
+    return { requestId };
   }
   // Redact before metadata extraction or preview truncation can split a credential.
   const safeBody = options?.requestHeaders
@@ -297,19 +273,20 @@ async function extractProviderErrorInfo(
     : rawBody;
   const body = redactProviderErrorBody(safeBody);
   try {
-    const metadata = extractProviderErrorPayloadMetadata(JSON.parse(safeBody));
+    const metadata = resolveProviderErrorPayloadMetadata(JSON.parse(safeBody));
     return {
-      ...(metadata.detail ? { detail: metadata.detail } : { detail: body }),
-      ...(metadata.code ? { code: metadata.code } : {}),
-      ...(metadata.type ? { type: metadata.type } : {}),
+      // Public formatting stays raw; HTTP details are redacted before choosing the fallback.
+      detail: (metadata.detail && redactSensitiveText(metadata.detail)) || body,
+      code: metadata.code,
+      type: metadata.type,
       body,
-      ...(requestId ? { requestId } : {}),
+      requestId,
     };
   } catch {
     return {
       detail: body,
       body,
-      ...(requestId ? { requestId } : {}),
+      requestId,
     };
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Provider HTTP failures normalized the same parsed payload twice: once to format its detail and again to recover code/type metadata. Keeping those copies aligned added work and made precedence rules harder to maintain.

## Why This Change Was Made

One private normalization result now supplies both the existing raw public formatter and the HTTP error owner. HTTP details are still redacted before selecting the existing body fallback. The redundant metadata extractor and optional-property spreads are removed; the final error constructor retains its existing public properties.

Production is **26 added / 49 removed (−23)**. Tests add 129 lines covering public payload precedence and observable getter order. No public signature, config, storage, transport, timeout, cancellation, or credential-redaction behavior changes.

## User Impact

Error text and metadata remain unchanged. This is primarily a canonical parsing cleanup, with specific HTTP-path improvements and mixed performance elsewhere. It is **not** a general Gateway or provider-latency speedup.

## Evidence

Fresh final-source validation passed: 51 owner tests, 63 header-redaction/media sibling tests, and all 29 changed-scope checks (285.55 s). The identical 51-test baseline and unchanged dependency installation were reused. Existing coverage includes real TCP body-stall behavior. Independent managed P0–P2 review was scoped-clean with no findings.

A fixed B0/C0/C1/B1 cohort exercised the actual public formatter, fresh Response → HTTP error, and detail-only exports: **5,772 calls**, including 4,992 individually timed samples. Every complete output was retained before literal/value/class/reader-lock checks; 1,924 Error stack observations remain available. Non-stack descriptors/values match throughout. Stack text is retained but excluded from equivalence because source locations differ. Factory setup and output recording are outside individual clocks; startup and recording remain in process resources.

HTTP detail cases improved **6.38% / 11.33%** (3.37 / 6.32 µs); OAuth HTTP cases improved **3.62% / 11.76%** (2.27 / 7.06 µs). Regressions are retained: **45/78 medians**, **320/546 aggregate metrics**, **340/624 sample-group comparisons**, **1,249/2,496 individual sample comparisons**, **187/312 warmup comparisons**, **37/78 first calls**, and **4/10 process-resource comparisons** were adverse. The reverse Unicode HTTP row increased 40.12% (42.78 µs); reverse nested detail increased 35.91% (19.30 µs). Direct public OAuth formatting increased 0.240 / 0.328 µs. No internal production call to the raw public formatter remains, but external SDK consumers still retain that contract and those costs matter.

These short, sequential synthetic cohorts do not establish statistical significance, tail latency, or a whole-Gateway improvement. The original data-only reducer had a missing function terminator; it and an unsuccessful syntax-only correction are preserved. A separate corrected reducer audited the original data; no measured calls were rerun.

<details>
<summary>All paired sample-group medians (microseconds; positive change is slower)</summary>

| Case | B0 → C0 µs | Change | B1 → C1 µs | Change |
|---|---:|---:|---:|---:|
| direct/undefined | 0.323 → 2.297 | +611.42% | 0.333 → 1.068 | +220.28% |
| direct/null | 0.620 → 0.594 | -4.22% | 0.339 → 0.531 | +56.83% |
| direct/string | 0.312 → 0.359 | +15.04% | 0.291 → 0.354 | +21.48% |
| direct/number | 0.307 → 0.349 | +13.54% | 0.286 → 0.344 | +20.03% |
| direct/boolean | 0.234 → 0.354 | +51.09% | 0.234 → 0.239 | +2.13% |
| direct/function | 0.224 → 0.234 | +4.63% | 0.172 → 0.469 | +172.65% |
| direct/array | 0.328 → 0.354 | +7.92% | 0.349 → 0.334 | -4.48% |
| direct/empty object | 1.604 → 0.922 | -42.53% | 0.906 → 0.667 | -26.43% |
| direct/blank fields | 0.735 → 0.724 | -1.43% | 0.667 → 0.599 | -10.14% |
| direct/nested error before detail and root | 1.286 → 1.146 | -10.95% | 0.990 → 0.911 | -7.89% |
| direct/array error before object detail | 0.760 → 0.786 | +3.42% | 0.760 → 0.719 | -5.47% |
| direct/array detail before root | 0.531 → 0.646 | +21.55% | 0.542 → 0.537 | -0.97% |
| direct/blank nested message before root fallback | 0.578 → 0.740 | +27.98% | 0.714 → 0.911 | +27.72% |
| direct/nested detail before OAuth description | 0.547 → 0.688 | +25.76% | 0.557 → 0.599 | +7.44% |
| direct/root detail before flat error | 0.521 → 0.516 | -0.96% | 0.464 → 0.760 | +64.02% |
| direct/OAuth description and raw error code | 0.630 → 0.870 | +37.99% | 0.568 → 0.896 | +57.81% |
| direct/flat error without OAuth description | 0.427 → 0.380 | -11.03% | 0.386 → 0.406 | +5.42% |
| direct/blank OAuth description without inferred code | 0.432 → 0.427 | -1.19% | 0.386 → 0.411 | +6.65% |
| direct/explicit code before status and OAuth code | 0.510 → 0.479 | -6.12% | 0.464 → 0.547 | +18.01% |
| direct/non-string code before status | 0.459 → 0.469 | +2.26% | 0.505 → 1.167 | +131.01% |
| direct/type-only metadata | 0.479 → 0.505 | +5.43% | 0.463 → 0.510 | +10.17% |
| direct/raw public text | 0.370 → 0.365 | -1.42% | 0.359 → 0.510 | +41.98% |
| response/empty | 12.359 → 14.396 | +16.48% | 12.193 → 16.765 | +37.50% |
| response/plain | 25.432 → 20.193 | -20.60% | 21.807 → 21.151 | -3.01% |
| response/nested | 54.062 → 54.266 | +0.38% | 56.708 → 59.151 | +4.31% |
| response/detail | 52.812 → 49.443 | -6.38% | 55.833 → 49.510 | -11.33% |
| response/oauth | 62.739 → 60.469 | -3.62% | 60.005 → 52.948 | -11.76% |
| response/metadata | 58.547 → 58.526 | -0.04% | 55.864 → 57.688 | +3.26% |
| response/object | 21.177 → 17.583 | -16.97% | 17.542 → 13.073 | -25.48% |
| response/array | 15.766 → 12.291 | -22.04% | 14.604 → 18.417 | +26.11% |
| response/null | 15.193 → 15.380 | +1.24% | 11.797 → 12.484 | +5.83% |
| response/malformed | 14.766 → 16.662 | +12.84% | 19.859 → 15.318 | -22.87% |
| response/fallback | 18.838 → 19.365 | +2.79% | 17.016 → 16.057 | -5.63% |
| response/unicode | 122.328 → 105.692 | -13.60% | 106.630 → 149.406 | +40.12% |
| response/long-plain | 99.641 → 92.193 | -7.47% | 98.802 → 100.031 | +1.24% |
| detail/plain | 16.089 → 17.531 | +8.97% | 16.959 → 22.297 | +31.48% |
| detail/nested | 55.406 → 54.516 | -1.61% | 53.755 → 73.058 | +35.91% |
| detail/oauth | 48.354 → 43.849 | -9.32% | 43.656 → 45.422 | +4.04% |
| detail/malformed | 12.213 → 11.568 | -5.29% | 13.010 → 11.021 | -15.29% |

</details>

Whole-process wall time changed −8.08% / +10.32%; kernel peak RSS +0.81% / −15.26%; sampled tree peak RSS −7.16% / −3.46%. These include imports and proof recording and are not isolated application-memory claims. All raw calls, both orders, first/warm samples, output graphs and failures remain retained in the campaign evidence.
