### PR TITLE
test(release): preserve unavailable and corrupt plugin update coverage

### DIFF
--- a/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh
+++ b/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh
@@ -41,7 +41,7 @@ node scripts/e2e/lib/update-first-hop-package-fixtures.mjs   future-tarball "$ca
 cat /tmp/openclaw-corrupt-plugin-update-method.json
 pack_fixture_plugin "$npm_pack_dir" /tmp/demo-corrupt-plugin.tgz demo-corrupt-plugin 0.0.1 demo.corrupt "Demo Corrupt Plugin"
 (
-  # Restore the candidate registry and stop serving the synthetic plugin before update.
+  # Restore the candidate registry to prove unavailable-target refusal first.
   # The parent retains the pack directory needed for post-core result evidence.
   trap - EXIT
   start_npm_fixture_registry "@openclaw/demo-corrupt-plugin" "0.0.1" /tmp/demo-corrupt-plugin.tgz "$npm_registry_dir"
@@ -76,20 +76,58 @@ if [ -f "$plugin_dir/package.json" ]; then
   exit 1
 fi
 
-echo "Updating OpenClaw with corrupt plugin present..."
-set +e
-openclaw_e2e_maybe_timeout "${update_timeout_seconds}s" \
-  node "$entry" update \
-  --channel beta \
-  --tag "$future_package" \
-  --yes \
-  --no-restart \
-  --timeout "$update_step_timeout_seconds" \
-  --json \
-  >/tmp/openclaw-update-corrupt-plugin.json \
-  2>/tmp/openclaw-update-corrupt-plugin.err
-update_status=$?
-set -e
+capture_corrupt_state() {
+  node --input-type=module - "$OPENCLAW_CONFIG_PATH" "$plugin_dir" <<'NODE'
+import fs from "node:fs";
+import path from "node:path";
+import { readPluginInstallRecords } from "./scripts/e2e/lib/plugin-index-sqlite.mjs";
+const [configPath, pluginDir] = process.argv.slice(2);
+process.stdout.write(JSON.stringify({
+  config: fs.readFileSync(configPath, "utf8"),
+  records: readPluginInstallRecords(),
+  packageJsonExists: fs.existsSync(path.join(pluginDir, "package.json")),
+  entry: fs.readFileSync(path.join(pluginDir, "index.js"), "utf8"),
+  manifest: fs.readFileSync(path.join(pluginDir, "openclaw.plugin.json"), "utf8"),
+}));
+NODE
+}
+
+run_corrupt_update() {
+  local output_prefix="$1"
+  openclaw_e2e_maybe_timeout "${update_timeout_seconds}s" \
+    node "$entry" update \
+    --channel beta \
+    --tag "$future_package" \
+    --yes \
+    --no-restart \
+    --timeout "$update_step_timeout_seconds" \
+    --json \
+    >"$output_prefix.json" 2>"$output_prefix.err"
+}
+
+echo "Checking unavailable corrupt-plugin target preserves the installation..."
+state_before_refusal="$(capture_corrupt_state)"
+if run_corrupt_update /tmp/openclaw-corrupt-plugin-unavailable; then
+  echo "Expected the unavailable plugin target to refuse the core update." >&2
+  exit 1
+fi
+node scripts/e2e/lib/plugin-update/probe.mjs assert-corrupt-unavailable /tmp/openclaw-corrupt-plugin-unavailable.json demo-corrupt-plugin
+if [ "$(capture_corrupt_state)" != "$state_before_refusal" ]; then
+  echo "Unavailable plugin admission changed config, install records, or corrupt payload." >&2
+  exit 1
+fi
+source_version="$(node -p 'JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")).sourceVersion' /tmp/openclaw-corrupt-plugin-update-method.json)"
+node scripts/e2e/lib/release-scenarios/assertions.mjs assert-package-version "$package_root" "$source_version" unavailable-plugin-refusal
+
+# The recovery case has a real registry package to reinstall; admission must not be bypassed.
+mkdir "$npm_registry_dir/recovery"
+start_npm_fixture_registry "@openclaw/demo-corrupt-plugin" "0.0.1" /tmp/demo-corrupt-plugin.tgz "$npm_registry_dir/recovery"
+echo "Updating OpenClaw with a recoverable corrupt plugin present..."
+if run_corrupt_update /tmp/openclaw-update-corrupt-plugin; then
+  update_status=0
+else
+  update_status=$?
+fi
 if [ "$update_status" -ne 0 ]; then
   echo "openclaw update failed or timed out after ${update_timeout_seconds}s with corrupt plugin present" >&2
   openclaw_e2e_print_log /tmp/openclaw-update-corrupt-plugin.err >&2

--- a/scripts/e2e/lib/plugin-update/probe.mjs
+++ b/scripts/e2e/lib/plugin-update/probe.mjs
@@ -207,6 +207,23 @@ async function assertOutput(logPath) {
   }
 }
 
+function assertCorruptTargetUnavailable(updateJsonPath, pluginId) {
+  const result = readJson(updateJsonPath);
+  const details = (result.steps ?? []).map((step) => step.stderrTail ?? "").join("\n");
+  if (
+    result.status !== "error" ||
+    result.reason !== "plugin-target-unavailable" ||
+    result.recovery?.serviceRestartSafe !== true ||
+    !details.includes(`requires @openclaw/${pluginId}@0.0.1 for core `) ||
+    !details.includes(`Package not found on npm: @openclaw/${pluginId}@0.0.1`) ||
+    (result.steps ?? []).some((step) => step.name === "global install swap")
+  ) {
+    throw new Error(
+      `expected unavailable-target refusal before activation: ${JSON.stringify(result)}`,
+    );
+  }
+}
+
 function assertCorruptUpdate(updateJsonPath, pluginId) {
   const payload = readJson(updateJsonPath);
   if (payload.status !== "ok") {
@@ -353,6 +370,7 @@ const commands = {
   snapshot: () => process.stdout.write(JSON.stringify(pluginRecordSnapshot(), null, 2)),
   "assert-snapshot": () => assertSnapshot(arg),
   "assert-output": () => assertOutput(arg),
+  "assert-corrupt-unavailable": () => assertCorruptTargetUnavailable(arg, arg2),
   "assert-corrupt-update": () => assertCorruptUpdate(arg, arg2),
   "assert-corrupt-plugin-result": () => assertCorruptPluginResult(arg, arg2),
   "assert-corrupt-policy-preserved": () => assertCorruptPluginPolicyPreserved(arg, arg2),

--- a/test/scripts/plugin-update-unchanged-docker.test.ts
+++ b/test/scripts/plugin-update-unchanged-docker.test.ts
@@ -408,6 +408,31 @@ describe("plugin update unchanged Docker E2E", () => {
     expect(result.stderr).toContain(expectedError);
   });
 
+  it.each(["unavailable", "unknown-version", "activated", "unsafe-recovery"] as const)(
+    "accepts only a pre-activation unavailable-target refusal: %s",
+    (outcome) => {
+      const result = runProbeStatus("assert-corrupt-unavailable", {
+        status: "error",
+        reason: "plugin-target-unavailable",
+        recovery: { serviceRestartSafe: outcome !== "unsafe-recovery" },
+        steps: [
+          {
+            name: outcome === "activated" ? "global install swap" : "package update",
+            exitCode: 1,
+            stderrTail:
+              outcome === "unknown-version"
+                ? "cannot determine the required version because the target core version is unknown"
+                : "Plugin demo-corrupt-plugin requires @openclaw/demo-corrupt-plugin@0.0.1 for core 2026.9.99-first-hop.0: Package not found on npm: @openclaw/demo-corrupt-plugin@0.0.1",
+          },
+        ],
+      });
+      expect(result.status).toBe(outcome === "unavailable" ? 0 : 1);
+      if (outcome !== "unavailable") {
+        expect(result.stderr).toContain("expected unavailable-target refusal before activation");
+      }
+    },
+  );
+
   it("accepts disabled or quarantined corrupt plugin warnings and rejects neither", () => {
     const disabledAfterFailure = {
       status: "ok",


### PR DESCRIPTION
## What Problem This Solves

Resolves a release-QA mismatch where the corrupt-plugin recovery scenario stopped serving the plugin archive, then expected the core update to succeed despite the documented plugin-availability admission check.

## Why This Change Was Made

Exercise both contracts explicitly. First, an unavailable plugin target must refuse before activation and preserve the installed core, config bytes, install records, and corrupt plugin payload. Then start the owned fixture registry with the original plugin archive and retain the existing successful core-update, corrupt-plugin recovery, and policy-preservation checks.

## User Impact

Release verification covers refusal and recovery independently without bypassing availability admission or changing product behavior.

## Evidence

Local main integration:303 tests passed across the plugin-update owner and Docker wrappers, with two existing platform skips. Scoped changed checks passed; independent P2 review is clean. The refusal probe rejects unknown target metadata, activation, and unsafe recovery. Sibling source-text assertions were searched before testing.

Actual Docker replay of the unchanged prepared candidate with the exact reviewed harness patch passed the corrupt-plugin lane in75seconds. This uses retained package bytes, with no duplicate build or full release-green claim.
