### PR TITLE
fix: avoid Linux Gateway test port collisions

### DIFF
--- a/src/test-utils/ports.test.ts
+++ b/src/test-utils/ports.test.ts
@@ -1,0 +1,220 @@
+import { createServer as createRealServer } from "node:net";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { withEnvAsync } from "./env.js";
+
+const host = vi.hoisted(() => ({
+  platform: vi.fn(() => "linux"),
+  range: "32768\t60999\n",
+  reads: vi.fn(),
+  cacheKey: Symbol("test port host"),
+  rejectPort: vi.fn<(...args: [number]) => string | undefined>(() => undefined),
+}));
+
+vi.mock("node:net", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:net")>();
+  return {
+    ...actual,
+    createServer: (...args: Parameters<typeof actual.createServer>) => {
+      const server = actual.createServer(...args);
+      const listen = server.listen.bind(server);
+      vi.spyOn(server, "listen").mockImplementation((...listenArgs) => {
+        const port = listenArgs[0];
+        const code = typeof port === "number" ? host.rejectPort(port) : undefined;
+        if (code) {
+          queueMicrotask(() => server.emit("error", Object.assign(new Error(code), { code })));
+          return server;
+        }
+        return listen(...listenArgs);
+      });
+      return server;
+    },
+  };
+});
+
+vi.mock("node:os", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("node:os")>()),
+  platform: host.platform,
+}));
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    readFileSync: (...args: Parameters<typeof actual.readFileSync>) => {
+      if (args[0] === "/proc/sys/net/ipv4/ip_local_port_range") {
+        host.reads();
+        return host.range;
+      }
+      return actual.readFileSync(...args);
+    },
+  };
+});
+vi.mock("../shared/global-singleton.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../shared/global-singleton.js")>();
+  return {
+    ...actual,
+    resolveGlobalSingleton: (...args: Parameters<typeof actual.resolveGlobalSingleton>) => {
+      if (args[0] === Symbol.for("openclaw.testPortPool")) {
+        args[0] = host.cacheKey;
+      }
+      return actual.resolveGlobalSingleton(...args);
+    },
+  };
+});
+
+const listeners: ReturnType<typeof createRealServer>[] = [];
+
+beforeEach(() => {
+  vi.resetModules();
+  host.platform.mockReturnValue("linux");
+  host.reads.mockClear();
+  host.rejectPort.mockReset();
+  host.cacheKey = Symbol("test port host");
+});
+
+afterEach(async () => {
+  Reflect.deleteProperty(globalThis, host.cacheKey);
+  await Promise.all(
+    listeners.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    ),
+  );
+});
+
+describe("deterministic test port blocks", () => {
+  it.each([
+    [32768, 60999],
+    [20000, 65000],
+  ])(
+    "excludes the kernel client range %i–%i from every worker's listener block",
+    async (low, high) => {
+      host.range = `${low}\t${high}\n`;
+      const { getDeterministicFreePortBlock } = await import("./ports.js");
+      const offsets = [0, 1, 2, 3, 4];
+      for (let worker = 0; worker < 64; worker += 1) {
+        const port = await withEnvAsync({ VITEST_WORKER_ID: String(worker) }, () =>
+          getDeterministicFreePortBlock({ offsets }),
+        );
+        for (const offset of offsets) {
+          expect(port + offset).toBeGreaterThanOrEqual(1024);
+          expect(port + offset).toBeLessThanOrEqual(65535);
+          expect(port + offset < low || port + offset > high).toBe(true);
+        }
+      }
+      expect(host.reads).toHaveBeenCalledTimes(1);
+    },
+  );
+
+  it("keeps returned adjacent blocks bindable and separate from live listeners", async () => {
+    host.range = "32768\t60999\n";
+    const { getDeterministicFreePortBlock } = await import("./ports.js");
+    const bound = new Set<number>();
+    for (let block = 0; block < 2; block += 1) {
+      const port = await getDeterministicFreePortBlock();
+      for (const offset of [0, 1, 2, 3, 4]) {
+        expect(bound.has(port + offset)).toBe(false);
+        const server = createRealServer();
+        listeners.push(server);
+        await new Promise<void>((resolve, reject) => {
+          server.once("error", reject);
+          server.listen(port + offset, "127.0.0.1", resolve);
+        });
+        bound.add(port + offset);
+      }
+    }
+  });
+
+  it.each([
+    { first: 1720, last: 1720, offsets: [0] },
+    { first: 1712, last: 1719, offsets: [0, 7] },
+  ])(
+    "does not return an HTTP-blocked base or derived port ($first–$last)",
+    async ({ first, last, offsets }) => {
+      host.range = "2024 65535";
+      host.rejectPort.mockImplementation((port) =>
+        (port >= first && port <= last) || (port >= 1800 && port <= 1807)
+          ? undefined
+          : "EADDRINUSE",
+      );
+      const { getDeterministicFreePortBlock, isPortFree } = await import("./ports.js");
+      await expect(isPortFree(last)).resolves.toBe(true);
+      await expect(fetch(`http://127.0.0.1:${last}/`)).rejects.toMatchObject({
+        cause: { message: "bad port" },
+      });
+      const port = await getDeterministicFreePortBlock({ offsets });
+      for (const offset of offsets) {
+        expect(port + offset).toBeGreaterThanOrEqual(1800);
+        expect(port + offset).toBeLessThanOrEqual(1807);
+      }
+    },
+  );
+
+  it.each(["darwin", "win32"])(
+    "preserves the existing %s pool without Linux host reads",
+    async (os) => {
+      host.platform.mockReturnValue(os);
+      const { getDeterministicFreePortBlock } = await import("./ports.js");
+      const port = await getDeterministicFreePortBlock();
+      expect(port).toBeGreaterThanOrEqual(30000);
+      expect(port + 4).toBeLessThanOrEqual(64999);
+      expect(host.reads).not.toHaveBeenCalled();
+    },
+  );
+
+  it("falls back outside both an occupied worker shard and the kernel client range", async () => {
+    host.range = "32768\t60999\n";
+    let occupiedStart: number | undefined;
+    host.rejectPort.mockImplementation((port) => {
+      occupiedStart ??= port;
+      return port === 0 || (port >= occupiedStart && port < occupiedStart + 1000)
+        ? "EADDRINUSE"
+        : undefined;
+    });
+    const { getDeterministicFreePortBlock } = await import("./ports.js");
+    const port = await getDeterministicFreePortBlock();
+    expect(occupiedStart).toBeDefined();
+    for (const offset of [0, 1, 2, 3, 4]) {
+      const candidate = port + offset;
+      expect(candidate < occupiedStart! || candidate >= occupiedStart! + 1000).toBe(true);
+      expect(candidate < 32768 || candidate > 60999).toBe(true);
+      expect(host.rejectPort).toHaveBeenCalledWith(candidate);
+    }
+    expect(host.rejectPort).not.toHaveBeenCalledWith(0);
+  });
+
+  it.each(["EPERM", "EACCES"])(
+    "preserves the explicit permission fallback for %s",
+    async (code) => {
+      host.range = "32768\t60999\n";
+      host.rejectPort.mockReturnValue(code);
+      const { getFreePortBlockWithPermissionFallback, isPortFree } = await import("./ports.js");
+      await expect(isPortFree(41032)).resolves.toBe(false);
+      await expect(
+        getFreePortBlockWithPermissionFallback({ offsets: [0, 1, 2, 4], fallbackBase: 44000 }),
+      ).resolves.toBe(44000 + (process.pid % 10000));
+    },
+  );
+
+  it.each(["1024 65535", "invalid"])(
+    "does not fall back to ephemeral ports for host range %s",
+    async (range) => {
+      host.range = range;
+      const { getDeterministicFreePortBlock } = await import("./ports.js");
+      await expect(getDeterministicFreePortBlock()).rejects.toThrow(/ephemeral TCP (port )?range/);
+      expect(host.rejectPort).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not mistake denied host facts for permission to use an unchecked fallback", async () => {
+    host.reads.mockImplementationOnce(() => {
+      throw Object.assign(new Error("proc access denied"), { code: "EACCES" });
+    });
+    const { getFreePortBlockWithPermissionFallback } = await import("./ports.js");
+    await expect(
+      getFreePortBlockWithPermissionFallback({ offsets: [0, 1, 2, 4], fallbackBase: 44000 }),
+    ).rejects.toThrow("failed to read Linux ephemeral TCP port range");
+    expect(host.rejectPort).not.toHaveBeenCalled();
+  });
+});

--- a/src/test-utils/ports.ts
+++ b/src/test-utils/ports.ts
@@ -1,18 +1,88 @@
 // Allocates available local ports for tests that start servers.
+import { readFileSync } from "node:fs";
 import { createServer } from "node:net";
+import { platform } from "node:os";
 import { isMainThread, threadId } from "node:worker_threads";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 
-export async function isPortFree(port: number): Promise<boolean> {
+type PortProbe = { free: boolean; error?: NodeJS.ErrnoException };
+type PortRange = { start: number; end: number };
+type PortPool = { ranges: PortRange[]; excludesEphemeral: boolean };
+
+// Nonprivileged ports blocked by Fetch; Gateway callers use HTTP and WebSockets.
+// https://fetch.spec.whatwg.org/#port-blocking
+const httpBlockedPorts = new Set([
+  1719, 1720, 1723, 2049, 3659, 4045, 4190, 5060, 5061, 6000, 6566, 6665, 6666, 6667, 6668, 6669,
+  6679, 6697, 10080,
+]);
+
+const hostPortPool = resolveGlobalSingleton<{ value?: PortPool }>(
+  Symbol.for("openclaw.testPortPool"),
+  () => ({}),
+);
+
+function getPortPool(): PortPool {
+  if (hostPortPool.value) {
+    return hostPortPool.value;
+  }
+  if (platform() !== "linux") {
+    return (hostPortPool.value = {
+      ranges: [{ start: 30_000, end: 64_999 }],
+      excludesEphemeral: false,
+    });
+  }
+  let raw: string;
+  try {
+    raw = readFileSync("/proc/sys/net/ipv4/ip_local_port_range", "utf8");
+  } catch (cause) {
+    throw new Error("failed to read Linux ephemeral TCP port range", { cause });
+  }
+  const match = /^\s*(\d+)\s+(\d+)\s*$/u.exec(raw);
+  const low = Number(match?.[1]);
+  const high = Number(match?.[2]);
+  if (!match || low < 1 || high > 65535 || low > high) {
+    throw new Error("invalid Linux ephemeral TCP port range");
+  }
+  // A probe is not a lease: startup's outbound sockets can claim its port and
+  // leave TIME_WAIT behind before the listener binds. Keep test listeners out
+  // of the kernel's client-port pool, including derived ports and fallback.
+  return (hostPortPool.value = {
+    ranges: [
+      { start: 1024, end: low - 1 },
+      { start: Math.max(1024, high + 1), end: 65535 },
+    ].filter((range) => range.start <= range.end),
+    excludesEphemeral: true,
+  });
+}
+
+async function probePort(port: number): Promise<PortProbe> {
   if (!Number.isFinite(port) || port <= 0 || port > 65535) {
-    return false;
+    return { free: false };
   }
   return await new Promise((resolve) => {
     const server = createServer();
-    server.once("error", () => resolve(false));
+    server.once("error", (error: NodeJS.ErrnoException) => resolve({ free: false, error }));
     server.listen(port, "127.0.0.1", () => {
-      server.close(() => resolve(true));
+      server.close(() => resolve({ free: true }));
     });
   });
+}
+
+export async function isPortFree(port: number): Promise<boolean> {
+  return (await probePort(port)).free;
+}
+
+async function isPortBlockFree(start: number, offsets: number[]): Promise<boolean> {
+  if (offsets.some((offset) => httpBlockedPorts.has(start + offset))) {
+    return false;
+  }
+  const probes = await Promise.all(offsets.map((offset) => probePort(start + offset)));
+  for (const probe of probes) {
+    if (probe.error?.code === "EPERM" || probe.error?.code === "EACCES") {
+      throw probe.error;
+    }
+  }
+  return probes.every((probe) => probe.free);
 }
 
 export async function getFreePort(host = "127.0.0.1"): Promise<number> {
@@ -45,6 +115,14 @@ export async function getDeterministicFreePortBlock(params?: {
   offsets?: number[];
 }): Promise<number> {
   const offsets = params?.offsets ?? [0, 1, 2, 3, 4];
+  if (
+    offsets.length === 0 ||
+    offsets.some((offset) => !Number.isInteger(offset) || offset < 0 || offset > 65535 - 1024)
+  ) {
+    throw new Error(
+      "test port offsets must be nonnegative integers within nonprivileged TCP bounds",
+    );
+  }
   const maxOffset = Math.max(...offsets);
 
   const workerIdRaw = process.env.VITEST_WORKER_ID ?? process.env.VITEST_POOL_ID ?? "";
@@ -56,10 +134,24 @@ export async function getDeterministicFreePortBlock(params?: {
       ? processShard
       : processShard + Math.abs(threadId);
 
-  const rangeSize = 1000;
-  const shardCount = 35;
-  const base = 30_000 + (Math.abs(shard) % shardCount) * rangeSize; // <= 59_999
-  const usable = rangeSize - maxOffset;
+  const pool = getPortPool();
+  const rangeSize = Math.max(1000, maxOffset + 1);
+  const shards = pool.ranges.flatMap((range) => {
+    const ranges: PortRange[] = [];
+    for (let start = range.start; start <= range.end; start += rangeSize) {
+      const end = Math.min(start + rangeSize - 1, range.end);
+      if (end - start >= maxOffset) {
+        ranges.push({ start, end });
+      }
+    }
+    return ranges;
+  });
+  const shardIndex = Math.abs(shard) % shards.length;
+  const primary = shards[shardIndex];
+  if (!primary) {
+    throw new Error("no nonprivileged test port block fits outside the ephemeral TCP range");
+  }
+  const usable = primary.end - primary.start + 1 - maxOffset;
 
   // Allocate in blocks to avoid derived-port overlaps (e.g. port+3).
   const blockSize = Math.max(maxOffset + 1, 8);
@@ -67,10 +159,8 @@ export async function getDeterministicFreePortBlock(params?: {
   // Scan in block-size steps. Tests consume neighboring derived ports (+1/+2/...),
   // so probing every single offset is wasted work and slows large suites.
   for (let attempt = 0; attempt < usable; attempt += blockSize) {
-    const start = base + ((nextTestPortOffset + attempt) % usable);
-    const ok = (await Promise.all(offsets.map((offset) => isPortFree(start + offset)))).every(
-      Boolean,
-    );
+    const start = primary.start + ((nextTestPortOffset + attempt) % usable);
+    const ok = await isPortBlockFree(start, offsets);
     if (!ok) {
       continue;
     }
@@ -78,12 +168,18 @@ export async function getDeterministicFreePortBlock(params?: {
     return start;
   }
 
-  // Fallback: let the OS pick a port block (best effort).
+  // Try other safe worker shards on Linux. Asking its kernel for port zero
+  // would put the fallback straight back into the excluded ephemeral range.
   for (let attempt = 0; attempt < 25; attempt += 1) {
-    const port = await getFreePort();
-    const ok = (await Promise.all(offsets.map((offset) => isPortFree(port + offset)))).every(
-      Boolean,
-    );
+    const alternative = shards[(shardIndex + attempt + 1) % shards.length];
+    if (!alternative) {
+      break;
+    }
+    const available = alternative.end - alternative.start + 1 - maxOffset;
+    const port = pool.excludesEphemeral
+      ? alternative.start + ((nextTestPortOffset + attempt * blockSize) % available)
+      : await getFreePort();
+    const ok = await isPortBlockFree(port, offsets);
     if (ok) {
       return port;
     }


### PR DESCRIPTION
Related: #141575

## What Problem This Solves

Resolves a problem where Linux Gateway tests intermittently fail to bind even though their selected port passed an availability probe. An outbound startup connection can claim that port and leave it unavailable in `TIME_WAIT`.

## Why This Change Was Made

Cache the actual Linux kernel ephemeral range and select complete nonprivileged listener blocks outside it, including fallback and derived ports. Preserve the existing non-Linux pool and explicit bind-permission handling. Exclude Fetch-blocked ports so the lower Linux pool remains usable by HTTP and WebSocket clients.

## User Impact

More reliable Gateway verification. This changes test tooling, with no end-user configuration change. Availability probing remains best-effort; it is not an exclusive port lease.

## Evidence

- A controlled Linux socket experiment reproduced `EADDRINUSE` for an established outbound client and its subsequent `TIME_WAIT` state. The original CI occupant could not be identified retrospectively.
- On the actual kernel range, the original allocator selected an unsafe port; the repair allocated 64 complete blocks and served 320 real HTTP requests successfully.
- All 13 allocator regressions and 12 unchanged Gateway startup owner tests pass locally and on Linux. The range and HTTP-compatibility regressions fail for their intended reasons before the corresponding fixes.
- Full changed checks and independent P2 review pass on the identical reviewed patch. Both files and their direct owners are unchanged by this main backport.

[Final Linux proof](https://github.com/openclaw/openclaw/actions/runs/34166422702)
