### PR TITLE
improve: reduce session recovery import overhead

### DIFF
--- a/src/agents/main-session-recovery/main-session-recovery-state.ts
+++ b/src/agents/main-session-recovery/main-session-recovery-state.ts
@@ -1,7 +1,7 @@
 import {
   PENDING_FINAL_DELIVERY_CLEAR_PATCH,
   sanitizePendingFinalDeliveryText,
-} from "../../auto-reply/reply/pending-final-delivery.js";
+} from "../../auto-reply/reply/pending-final-delivery-state.js";
 import type {
   InternalSessionEntry as SessionEntry,
   MainRestartRecoveryState,

--- a/src/agents/main-session-recovery/main-session-restart-dispatch.ts
+++ b/src/agents/main-session-recovery/main-session-restart-dispatch.ts
@@ -2,7 +2,7 @@ import { randomUUID } from "node:crypto";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { GatewayClientRequestError } from "../../../packages/gateway-client/src/index.js";
 import { isExecutionIdentityCollectionEnabled } from "../../audit/audit-config.js";
-import { sanitizePendingFinalDeliveryText } from "../../auto-reply/reply/pending-final-delivery.js";
+import { sanitizePendingFinalDeliveryText } from "../../auto-reply/reply/pending-final-delivery-state.js";
 import type { SessionEntry } from "../../config/sessions.js";
 import {
   buildRestartRecoveryClaimCleanupPatch,

--- a/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
+++ b/src/agents/subagents/announce/subagent-announce-completion-delivery.ts
@@ -1,7 +1,7 @@
 /**
  * Direct completion fallback and source-delivery evidence for subagent announcements.
  */
-import { sanitizePendingFinalDeliveryText } from "../../../auto-reply/reply/pending-final-delivery.js";
+import { sanitizePendingFinalDeliveryText } from "../../../auto-reply/reply/pending-final-delivery-state.js";
 import type { OpenClawConfig } from "../../../config/types.openclaw.js";
 import { sourceDeliveryTargetsMatch } from "../../../infra/outbound/source-delivery-plan.js";
 import { deriveSessionChatTypeFromKey } from "../../../sessions/session-chat-type-shared.js";

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -36,7 +36,7 @@ import type { BlockReplyPipeline } from "./block-reply-pipeline.js";
 import { resolveEffectiveReplyRoute } from "./effective-reply-route.js";
 import type { InternalGetReplyOptions } from "./get-reply.types.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
-import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery.js";
+import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery-state.js";
 import { type FollowupRun, type QueueSettings, scheduleFollowupDrain } from "./queue.js";
 import { normalizeReplyPayloadDirectives } from "./reply-delivery.js";
 import { isReplyOperationSuperseded } from "./reply-operation-abort.js";

--- a/src/auto-reply/reply/get-reply.ts
+++ b/src/auto-reply/reply/get-reply.ts
@@ -76,7 +76,7 @@ import { resolveOriginMessageProvider } from "./origin-routing.js";
 import {
   PENDING_FINAL_DELIVERY_CLEAR_PATCH,
   sanitizePendingFinalDeliveryText,
-} from "./pending-final-delivery.js";
+} from "./pending-final-delivery-state.js";
 import { getPreparedReplyDispatchRuntime } from "./prepared-reply-dispatch-context.js";
 import { attachProgressNarratorToReplyOptions } from "./progress-narrator.js";
 import { prepareReplyConversation } from "./prompt-session-context.js";

--- a/src/auto-reply/reply/pending-final-delivery-state.ts
+++ b/src/auto-reply/reply/pending-final-delivery-state.ts
@@ -1,0 +1,42 @@
+// Recovery admission must not load outbound normalization or provider runtime to inspect text.
+import type { SessionEntry } from "../../config/sessions/types.js";
+import {
+  isSilentReplyPayloadText,
+  isSilentReplyText,
+  SILENT_REPLY_TOKEN,
+  startsWithSilentToken,
+  stripLeadingSilentToken,
+  stripSilentToken,
+} from "../tokens.js";
+import { stripInternalMetadataForDisplay } from "./display-text-sanitize.js";
+
+// A delivered or discarded final must lose the whole record. Keeping this list
+// centralized prevents new ownership fields from leaving a phantom pending delivery.
+export const PENDING_FINAL_DELIVERY_CLEAR_PATCH = {
+  pendingFinalDelivery: undefined,
+} as const satisfies Partial<SessionEntry>;
+
+/** Sanitizes pending final delivery text before channel-visible output. */
+export function sanitizePendingFinalDeliveryText(text: string): string {
+  let stripped = stripInternalMetadataForDisplay(text).trim();
+  if (isSilentReplyPayloadText(stripped, SILENT_REPLY_TOKEN)) {
+    return "";
+  }
+  if (stripped && !isSilentReplyText(stripped, SILENT_REPLY_TOKEN)) {
+    const hasLeadingSilentToken = startsWithSilentToken(stripped, SILENT_REPLY_TOKEN);
+    if (hasLeadingSilentToken) {
+      stripped = stripLeadingSilentToken(stripped, SILENT_REPLY_TOKEN);
+    }
+    // Remove stray silent tokens only after confirming the payload is not entirely silent.
+    if (
+      hasLeadingSilentToken ||
+      stripped.toLowerCase().includes(SILENT_REPLY_TOKEN.toLowerCase())
+    ) {
+      stripped = stripSilentToken(stripped, SILENT_REPLY_TOKEN);
+    }
+  }
+  if (!stripped.trim()) {
+    return "";
+  }
+  return isSilentReplyPayloadText(stripped, SILENT_REPLY_TOKEN) ? "" : stripped.trim();
+}

--- a/src/auto-reply/reply/pending-final-delivery.test.ts
+++ b/src/auto-reply/reply/pending-final-delivery.test.ts
@@ -6,12 +6,12 @@ import {
 } from "../../agents/internal-runtime-context.js";
 import { setReplyPayloadMetadata } from "../reply-payload.js";
 import { markInboundContextLabel } from "./inbound-context-marker.js";
+import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery-state.js";
 import {
   buildRecoverablePendingFinalDeliveryText,
   normalizePendingFinalDeliveryPayloads,
   normalizePendingFinalRecoveryPayloads,
   resolvePendingFinalDeliveryCompletion,
-  sanitizePendingFinalDeliveryText,
 } from "./pending-final-delivery.js";
 
 describe("resolvePendingFinalDeliveryCompletion", () => {

--- a/src/auto-reply/reply/pending-final-delivery.ts
+++ b/src/auto-reply/reply/pending-final-delivery.ts
@@ -1,17 +1,8 @@
-import type { SessionEntry } from "../../config/sessions/types.js";
 import type { DurableDeliveryCompletion } from "../../infra/outbound/delivery-completion.js";
 import { normalizeReplyPayloadsForDelivery } from "../../infra/outbound/payloads.js";
 import { getReplyPayloadMetadata, type ReplyPayload } from "../reply-payload.js";
-import {
-  isSilentReplyPayloadText,
-  isSilentReplyText,
-  SILENT_REPLY_TOKEN,
-  startsWithSilentToken,
-  stripLeadingSilentToken,
-  stripSilentToken,
-} from "../tokens.js";
-import { stripInternalMetadataForDisplay } from "./display-text-sanitize.js";
 import { normalizeReplyPayload } from "./normalize-reply.js";
+import { sanitizePendingFinalDeliveryText } from "./pending-final-delivery-state.js";
 
 /** Normalize raw final payloads into the channel-agnostic sendable set recovery can mark. */
 export function normalizePendingFinalDeliveryPayloads(
@@ -92,12 +83,6 @@ function buildPendingFinalDeliveryText(payloads: ReplyPayload[]): string {
   return sanitizePendingFinalDeliveryText(text);
 }
 
-// A delivered or discarded final must lose the whole record. Keeping this list
-// centralized prevents new ownership fields from leaving a phantom pending delivery.
-export const PENDING_FINAL_DELIVERY_CLEAR_PATCH = {
-  pendingFinalDelivery: undefined,
-} as const satisfies Partial<SessionEntry>;
-
 export function resolvePendingFinalDeliveryCompletion(
   payloads: readonly ReplyPayload[] | undefined,
 ): Extract<DurableDeliveryCompletion, { kind: "pending-final" }> | undefined {
@@ -171,29 +156,4 @@ function hasUnrecoverableNormalizedDeliveryShape(payload: ReplyPayload): boolean
     payload.audioAsVoice === true ||
     payload.videoAsNote === true
   );
-}
-
-/** Sanitizes pending final delivery text before channel-visible output. */
-export function sanitizePendingFinalDeliveryText(text: string): string {
-  let stripped = stripInternalMetadataForDisplay(text).trim();
-  if (isSilentReplyPayloadText(stripped, SILENT_REPLY_TOKEN)) {
-    return "";
-  }
-  if (stripped && !isSilentReplyText(stripped, SILENT_REPLY_TOKEN)) {
-    const hasLeadingSilentToken = startsWithSilentToken(stripped, SILENT_REPLY_TOKEN);
-    if (hasLeadingSilentToken) {
-      stripped = stripLeadingSilentToken(stripped, SILENT_REPLY_TOKEN);
-    }
-    // Remove stray silent tokens only after confirming the payload is not entirely silent.
-    if (
-      hasLeadingSilentToken ||
-      stripped.toLowerCase().includes(SILENT_REPLY_TOKEN.toLowerCase())
-    ) {
-      stripped = stripSilentToken(stripped, SILENT_REPLY_TOKEN);
-    }
-  }
-  if (!stripped.trim()) {
-    return "";
-  }
-  return isSilentReplyPayloadText(stripped, SILENT_REPLY_TOKEN) ? "" : stripped.trim();
 }


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where session recovery and admission load outbound payload normalization and provider runtime just to sanitize or clear stored reply text. The module-identity regression test exposed this unnecessary work during cold SDK transformation.

## Why This Change Was Made

Move the existing sanitizer and clear patch into a small text-only state module and redirect all five lightweight consumers to it. Payload normalization keeps its existing owner and imports the same sanitizer when it actually needs it. The old internal exports are removed; no public SDK or package export changes.

The helper implementations are byte-identical. Recovery decisions, persisted record shape, replay ordering, silence handling, media handling, and ownership checks are unchanged.

## User Impact

Less cold-import work when admitting or recovering sessions, with the same reply and recovery behavior. No cache, dependency, configuration option, timeout, or shard change.

## Evidence

- Rebuilt admission graph: **666 → 520 statically reachable chunks**, **9.16 MB → 7.02 MB**. The provider-loader path is no longer reachable through recovery state. This removes about **2.14 MB** from the evaluated graph; total emitted bundle size is nearly unchanged because actual delivery still owns that code.
- The unchanged module-identity test passes with native graph equality, transformed graph inequality, and all three real storage/admission scenarios retained. Local case time: **17.028s → 8.989s**; whole command: **24.87s → 10.33s**. These are sequential local observations with host/cache variation, not a portable speedup ratio.
- **92 existing tests passed**: the identity case, 90 sanitizer/builder/recovery/core/heartbeat cases, and the named real resume-prompt sanitation case. No assertions or test deadlines were weakened.
- Original helper bodies and the identity test were independently checked byte-for-byte. Temporary profiling/inventory instrumentation was removed. Managed P2 review found no actionable issues. The full build and changed-file gate passed, including core/test types, lint, unused-export scans, and runtime import-cycle checks.

Production LOC delta is **+2**, entirely module-boundary/import/comment overhead; implementation is moved. Test LOC is net zero, with one import updated.

Additional sibling cross-check: the exact patch also passed all **38 migration caller-mode/refusal cases** on the same baseline, preserving their observed order. This brings local coverage to **130 existing tests**. These later timing samples are not used to claim a separate migration speedup.

Final exact-head [CI passed in 8m24s](https://github.com/openclaw/openclaw/actions/runs/34169571333), with the unchanged module-identity case at **10.175s**. The current-head ClawSweeper review has no actionable findings.

Two earlier CI runs exposed separate process-containment fixture failures (`reparented` and `root-resumed`). [PR #141634](https://github.com/openclaw/openclaw/pull/141634) independently landed the proven PID-selection forwarding repair. This branch was refreshed onto that canonical fix; its eight authored file blobs remain byte-identical to the reviewed refactor, with no containment changes in this PR. The second failure occurred despite forwarding, so the remaining OS/fixture race is being investigated separately with Linux process-state diagnostics; the final green run is not claimed as proof that the flake is resolved.
