### PR TITLE
refactor: remove duplicate collapsed chat activity test

### DIFF
--- a/ui/src/pages/chat/components/chat-message.test.ts
+++ b/ui/src/pages/chat/components/chat-message.test.ts
@@ -3206,6 +3206,7 @@ describe("grouped chat rendering", () => {
     expect(activitySummary.getAttribute("aria-expanded")).toBe("false");
     expect(activitySummary.textContent).not.toContain("failed");
     expect(activitySummary.querySelector(".chat-activity-group__badge")).toBeNull();
+    expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
     selectText(expectElement(activitySummary, ".chat-activity-group__label", HTMLElement));
     pointerClick(activitySummary);
     expect(onToggleToolMessageExpanded).not.toHaveBeenCalled();
@@ -3215,34 +3216,6 @@ describe("grouped chat rendering", () => {
 
     expect(onToggleToolMessageExpanded).toHaveBeenCalledWith("activity:tool-group", false);
     container.remove();
-  });
-
-  it("keeps recovered grouped activity collapsed without a failure summary", () => {
-    const container = document.createElement("div");
-    const group = createToolGroup("tool-group", [
-      createMessageEntry(
-        "tool-message-1",
-        createToolResultMessage("call-1", "web_search", JSON.stringify({ error: "No matches" }), {
-          isError: true,
-          timestamp: 1000,
-        }),
-      ),
-      createMessageEntry(
-        "tool-message-2",
-        createToolResultMessage("call-2", "read_file", "Fallback context", {
-          timestamp: 1001,
-        }),
-      ),
-    ]);
-
-    renderMessageGroups(container, [group]);
-
-    expect(container.querySelector(".chat-activity-group.is-open")).toBeNull();
-    expect(container.querySelector(".chat-activity-group__summary--error")).toBeNull();
-    expect(container.querySelector(".chat-activity-group__label")?.textContent).not.toContain(
-      "failed",
-    );
-    expect(container.querySelector(".chat-tool-msg-body")).toBeNull();
   });
 
   it("keeps recovered coalesced tool failures neutral in the activity list", () => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Two grouped-chat tests now cover the same collapsed, neutral presentation of a failed tool result followed by a successful result. The recovered-activity case lost its distinguishing success flag when #122681 moved failure state to individual calls.

## Why This Change Was Made

Remove that duplicate case and carry its tool-body absence assertion into the stronger retained test, which also covers selection-safe clicks, disclosure callbacks, and accessibility attributes. Keep the separate coalesced-tool case and all production code unchanged.

## User Impact

No product behavior changes. This maintainer-requested cleanup removes one redundant case and 27 net test lines while preserving its assertions at the retained rendering boundary.

## Evidence

- Full chat-message suite: 234 baseline cases passed; all 233 retained cases passed after the change and again after the negative control was restored.
- Exact inventory and source comparison show one removed case and one carried assertion; all other test text is unchanged.
- A controlled leak of real expanded child bodies beneath a collapsed activity row fails the carried assertion. Production restored byte-for-byte before final validation.
- Formatting, deslop, the full UI changed-file gate, and fresh P2 review passed.
- The passing baseline logged a late MCP App import teardown diagnostic; it is preserved in the evidence and was not suppressed or changed by this patch. No runtime improvement is claimed.
