### PR TITLE
fix(ui): refresh selected usage details

### DIFF
--- a/docs/web/control-ui/feature-reference.md
+++ b/docs/web/control-ui/feature-reference.md
@@ -89,6 +89,7 @@ Control UI capabilities grouped by area, each with the Gateway RPC methods behin
     - Provider cards call `usage.status` and show live plan names, quota windows, balances, spend, and budgets reported by configured provider plugins.
     - A provider usage failure does not block the session/cost dashboard; unavailable provider cards show their own error state.
     - Incomplete session/cost totals stay readable while the visible, focused page checks for updates. Automatic checks are bounded; if they pause, select **Refresh** to check again.
+    - **Refresh** also reloads the selected session's timeline, conversation, and system-prompt breakdown.
     - The overview loads session summaries first. Full system-prompt breakdowns load when you select a session; the `has:context` filter still works before opening details.
     - JSON exports keep the displayed usage snapshot and load prompt details for the same session instance. If that session has been replaced, refresh Usage and export again.
 

--- a/ui/src/e2e/usage-tool-count.e2e.test.ts
+++ b/ui/src/e2e/usage-tool-count.e2e.test.ts
@@ -1,13 +1,14 @@
+import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
-const suite = createControlUiE2eSuite({ name: "Usage selected-range tool calls" });
+const suite = createControlUiE2eSuite({ name: "Usage selected-session details" });
 
 suite.define(() => {
-  it("counts each assistant invocation once after dragging the timeline range", async () => {
+  it("counts assistant invocations and refreshes selected usage details", async () => {
     const date = "2026-08-20";
     const start = Date.parse(`${date}T12:00:00Z`);
     const totals = {
@@ -57,7 +58,7 @@ suite.define(() => {
       },
       async ({ page }) => {
         await page.clock.setFixedTime(new Date(start + 5000));
-        const gateway = await installMockGateway(page, {
+        const scenario = {
           methodResponses: {
             "sessions.usage": {
               updatedAt: start + 5000,
@@ -114,7 +115,8 @@ suite.define(() => {
               ],
             },
           },
-        });
+        };
+        const gateway = await installMockGateway(page, scenario);
         await page.goto(`${suite.server.baseUrl}usage`);
         await page.getByRole("button", { name: "Review two files", exact: true }).click();
         await gateway.waitForRequest("sessions.usage.timeseries");
@@ -152,6 +154,79 @@ suite.define(() => {
         await panel.getByRole("button", { name: "Reset", exact: true }).click();
         await expect.poll(() => panel.locator(".session-detail-indicator").count()).toBe(0);
         await expect.poll(() => panel.locator(".session-log-entry").count()).toBe(5);
+
+        const refreshedTotals = { ...totals, input: 400, output: 80, totalTokens: 480 };
+        const usage = scenario.methodResponses["sessions.usage"];
+        const session = usage.sessions[0]!;
+        const latestReply = "The newly completed reply is included after Refresh.";
+        await page.clock.setFixedTime(new Date(start + 7000));
+        await gateway.setMethodResponse("sessions.usage", {
+          ...usage,
+          updatedAt: start + 7000,
+          sessions: [
+            {
+              ...session,
+              updatedAt: start + 7000,
+              usage: {
+                ...session.usage,
+                ...refreshedTotals,
+                messageCounts: { ...messages, total: 4, assistant: 4 },
+              },
+            },
+          ],
+          totals: refreshedTotals,
+        });
+        await gateway.setMethodResponse("usage.cost", {
+          ...scenario.methodResponses["usage.cost"],
+          updatedAt: start + 7000,
+          daily: [{ date, ...refreshedTotals }],
+          totals: refreshedTotals,
+        });
+        await gateway.setMethodResponse("sessions.usage.timeseries", {
+          points: [...points, { ...points[2]!, timestamp: start + 6000, cumulativeTokens: 480 }],
+        });
+        await gateway.setMethodResponse("sessions.usage.logs", {
+          logs: [
+            ...scenario.methodResponses["sessions.usage.logs"].logs,
+            { timestamp: start + 6000, role: "assistant", content: latestReply },
+          ],
+        });
+        await page.getByRole("button", { name: "Refresh", exact: true }).click();
+        await expect
+          .poll(() => panel.locator(".session-detail-stats").textContent())
+          .toContain("480");
+        const readDetails = async () => ({
+          timeline: await panel.locator(".timeseries-summary").textContent(),
+          conversation: await panel.locator(".session-log-content").allTextContents(),
+        });
+        try {
+          await expect.poll(readDetails).toMatchObject({
+            timeline: expect.stringContaining("480"),
+            conversation: expect.arrayContaining([latestReply]),
+          });
+          for (const method of ["sessions.usage.timeseries", "sessions.usage.logs"]) {
+            expect(await gateway.getRequests(method)).toHaveLength(2);
+          }
+        } finally {
+          if (proofDir) {
+            await panel.locator(".timeseries-summary").scrollIntoViewIfNeeded();
+            await page.screenshot({ path: path.join(proofDir, "manual-refresh.png") });
+            await panel.locator(".session-log-entry").last().scrollIntoViewIfNeeded();
+            await page.screenshot({ path: path.join(proofDir, "manual-conversation.png") });
+            await fs.writeFile(
+              path.join(proofDir, "manual-refresh.json"),
+              JSON.stringify(
+                {
+                  ...(await readDetails()),
+                  timelineRequests: await gateway.getRequests("sessions.usage.timeseries"),
+                  conversationRequests: await gateway.getRequests("sessions.usage.logs"),
+                },
+                null,
+                2,
+              ),
+            );
+          }
+        }
       },
     );
   });

--- a/ui/src/pages/usage/refresh-policy.ts
+++ b/ui/src/pages/usage/refresh-policy.ts
@@ -38,7 +38,7 @@ function decideUsageRefresh(params: {
 
 type UsageRefreshPolicyOptions = {
   isLoading: () => boolean;
-  reload: () => void | Promise<void>;
+  reload: (reason: UsageRefreshReason) => void | Promise<void>;
   onIncompleteUsageExhausted?: () => void;
 };
 
@@ -107,11 +107,6 @@ export class UsageRefreshPolicy {
     this.reloadPending = false;
   }
 
-  private async reloadAndWait(): Promise<void> {
-    this.pendingAutomaticRefresh = false;
-    await this.options.reload();
-  }
-
   request(reason: UsageRefreshReason): void {
     void this.requestAndWait(reason);
   }
@@ -133,7 +128,7 @@ export class UsageRefreshPolicy {
       if (reason !== "poll") {
         this.incompleteUsageRetry.startCycle();
       }
-      await this.reloadAndWait();
+      await this.options.reload(reason);
     }
   }
 

--- a/ui/src/pages/usage/usage-page-details.test.ts
+++ b/ui/src/pages/usage/usage-page-details.test.ts
@@ -433,27 +433,55 @@ describe("UsagePage detail requests", () => {
     );
   });
 
-  it("refreshes the selected context and clears it when its report disappears", async () => {
+  it("refreshes selected details and clears context when its report disappears", async () => {
     const snapshot = cacheSnapshot("sessions", "fresh");
+    const timestamp = new Date().setHours(12, 0, 0, 0);
+    let turns = 2;
     let available = true;
     let report = "original-context";
     const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      const totals = {
+        ...snapshot.result.totals,
+        input: turns * 100,
+        totalTokens: turns * 100,
+        totalCost: turns * 0.1,
+        inputCost: turns * 0.1,
+      };
       if (method === "sessions.usage") {
         const session = {
           key: "agent:main:context",
           label: "Context session",
           agentId: "main",
           hasContextWeight: available,
-          usage: snapshot.result.totals,
+          usage: totals,
         };
         return {
           ...snapshot.result,
+          totals,
           sessions: [params?.key ? { ...session, contextWeight: contextWeight(report) } : session],
         };
       }
-      return method === "usage.cost"
-        ? snapshot.costSummary
-        : { providers: [], logs: [], points: [] };
+      if (method === "sessions.usage.timeseries") {
+        return {
+          points: Array.from({ length: turns }, (_, index) => ({
+            timestamp: timestamp + index * 1_000,
+            input: 100,
+            output: 0,
+            cacheRead: 0,
+            cacheWrite: 0,
+            totalTokens: 100,
+            cost: 0.1,
+            cumulativeTokens: (index + 1) * 100,
+            cumulativeCost: (index + 1) * 0.1,
+          })),
+        };
+      }
+      if (method === "sessions.usage.logs") {
+        return {
+          logs: [{ timestamp, role: "assistant", content: `${turns} completed turns` }],
+        };
+      }
+      return method === "usage.cost" ? { ...snapshot.costSummary, totals } : { providers: [] };
     });
     const page = await createPage({ request } as unknown as GatewayBrowserClient, true);
     await preloadUsage(page);
@@ -461,12 +489,18 @@ describe("UsagePage detail requests", () => {
     await vi.waitFor(() =>
       expect(page.querySelector(".context-details-panel")?.textContent).toContain(report),
     );
+    expect(page.querySelector(".timeseries-summary")?.textContent).toContain("200");
+    expect(page.querySelector(".session-log-content")?.textContent).toBe("2 completed turns");
 
+    turns = 3;
     report = "refreshed-context";
     refreshButton(page).click();
     await vi.waitFor(() =>
       expect(page.querySelector(".context-details-panel")?.textContent).toContain(report),
     );
+    expect(page.querySelector(".session-detail-stats")?.textContent).toContain("300");
+    expect.soft(page.querySelector(".timeseries-summary")?.textContent).toContain("300");
+    expect.soft(page.querySelector(".session-log-content")?.textContent).toBe("3 completed turns");
     const contextRequests = request.mock.calls.filter(
       ([method, params]) => method === "sessions.usage" && params?.key,
     ).length;

--- a/ui/src/pages/usage/usage-page.test.ts
+++ b/ui/src/pages/usage/usage-page.test.ts
@@ -173,15 +173,26 @@ describe("UsagePage cache convergence", () => {
       focusDocument();
       let snapshot = cacheSnapshot(source, status);
       const provider = { updatedAt: 1, providers: [] };
-      const request = vi.fn(async (method: string) =>
-        method === "usage.status"
+      const request = vi.fn(async (method: string) => {
+        if (method === "sessions.usage.timeseries") {
+          return { points: [] };
+        }
+        if (method === "sessions.usage.logs") {
+          return { logs: [] };
+        }
+        return method === "usage.status"
           ? provider
           : method === "usage.cost"
             ? snapshot.costSummary
-            : snapshot.result,
-      );
+            : {
+                ...snapshot.result,
+                sessions: [{ key: "agent:main:poll", usage: snapshot.result.totals }],
+              };
+      });
       const page = await createPage({ request } as unknown as GatewayBrowserClient, true);
       await preloadUsage(page);
+      page.querySelector<HTMLButtonElement>(".session-bar-selection")!.click();
+      await vi.advanceTimersByTimeAsync(0);
       expect(page.querySelector(".usage-cache-warning")?.textContent).toContain(
         "Checking for updated totals",
       );
@@ -190,6 +201,9 @@ describe("UsagePage cache convergence", () => {
       await vi.advanceTimersByTimeAsync(20_000);
       await page.updateComplete;
       expect(request.mock.calls.filter(([method]) => method === "sessions.usage")).toHaveLength(4);
+      for (const method of ["sessions.usage.timeseries", "sessions.usage.logs"]) {
+        expect(request.mock.calls.filter(([called]) => called === method)).toHaveLength(1);
+      }
       expect(page.querySelector(".usage-cache-warning")?.textContent).toContain(
         "Automatic checks paused; select Refresh",
       );
@@ -220,6 +234,51 @@ describe("UsagePage cache convergence", () => {
       expect(request).toHaveBeenCalledTimes(callsBeforeRemoval);
     },
   );
+
+  it("does not transfer a manual detail refresh to a replacement selection", async () => {
+    const snapshot = cacheSnapshot("sessions", "fresh");
+    const keys = ["agent:main:a", "agent:main:b"];
+    const result = {
+      ...snapshot.result,
+      sessions: keys.map((key) => ({ key, usage: snapshot.result.totals })),
+    };
+    const manual = deferred<typeof result>();
+    let refreshing = false;
+    const request = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === "sessions.usage") {
+        return refreshing ? manual.promise : result;
+      }
+      if (method === "sessions.usage.timeseries") {
+        return { points: [] };
+      }
+      if (method === "sessions.usage.logs") {
+        return { logs: [{ timestamp: Date.now(), role: "user", content: String(params?.key) }] };
+      }
+      return method === "usage.cost" ? snapshot.costSummary : { providers: [] };
+    });
+    const page = await createPage({ request } as unknown as GatewayBrowserClient, true);
+    await preloadUsage(page);
+    page.querySelectorAll<HTMLButtonElement>(".session-bar-selection")[0]!.click();
+    await vi.waitFor(() =>
+      expect(page.querySelector(".session-log-content")?.textContent).toBe(keys[0]),
+    );
+
+    refreshing = true;
+    refreshButton(page).click();
+    page.querySelectorAll<HTMLButtonElement>(".session-bar-selection")[1]!.click();
+    await vi.waitFor(() =>
+      expect(page.querySelector(".session-log-content")?.textContent).toBe(keys[1]),
+    );
+    manual.resolve(result);
+    await vi.waitFor(() => expect(refreshButton(page).disabled).toBe(false));
+
+    expect(page.querySelector(".session-log-content")?.textContent).toBe(keys[1]);
+    for (const method of ["sessions.usage.timeseries", "sessions.usage.logs"]) {
+      expect(
+        request.mock.calls.filter(([called]) => called === method).map(([, params]) => params?.key),
+      ).toEqual(keys);
+    }
+  });
 
   it.each(["pending", "settled"] as const)(
     "keeps cache convergence after an aggregate failure with %s provider usage",

--- a/ui/src/pages/usage/usage-page.ts
+++ b/ui/src/pages/usage/usage-page.ts
@@ -97,9 +97,13 @@ class UsagePage extends OpenClawLightDomElement {
   private routeDataEnabled = true;
   private readonly refreshPolicy = new UsageRefreshPolicy({
     isLoading: () => this.usageLoading,
-    reload: () => {
+    reload: (reason) => {
       this.clearDateDebounce();
-      return this.loadUsage();
+      const sessionKey =
+        reason === "manual" && this.usageSelectedSessions.length === 1
+          ? this.usageSelectedSessions[0]
+          : undefined;
+      return this.loadUsage(sessionKey);
     },
     onIncompleteUsageExhausted: () => this.requestUpdate(),
   });
@@ -129,11 +133,15 @@ class UsagePage extends OpenClawLightDomElement {
   });
 
   private readonly usageRequest = createUsageRequest(this, {
-    task: async (client: GatewayBrowserClient, { signal }) => {
+    task: async (
+      [client, refreshSessionKey]: readonly [GatewayBrowserClient, string | undefined],
+      { signal },
+    ) => {
       this.refreshPolicy.beginLoad();
       const epoch = this.connectionEpoch;
       return {
         epoch,
+        refreshSessionKey,
         snapshot: await requestUsageSnapshot(
           client,
           {
@@ -156,7 +164,12 @@ class UsagePage extends OpenClawLightDomElement {
         const sessionKey =
           this.usageSelectedSessions.length === 1 ? this.usageSelectedSessions[0] : undefined;
         if (sessionKey) {
-          void this.details.contextWeight.load(sessionKey);
+          // Manual intent belongs to this request's selection, never a later poll or selection.
+          if (value.refreshSessionKey === sessionKey) {
+            this.details.load(sessionKey);
+          } else {
+            void this.details.contextWeight.load(sessionKey);
+          }
         }
       } else {
         this.applyUsageError(snapshot.error.cause);
@@ -339,7 +352,7 @@ class UsagePage extends OpenClawLightDomElement {
     return !this.routeDataInitialized || this.usageRequest.pending;
   }
 
-  private loadUsage(): Promise<void> {
+  private loadUsage(refreshSessionKey?: string): Promise<void> {
     const client = this.gateway.client;
     if (!client || !this.gateway.connected) {
       this.refreshPolicy.markLoadDeferred();
@@ -351,7 +364,7 @@ class UsagePage extends OpenClawLightDomElement {
     this.usageLoadStartDate = this.usageStartDate;
     this.usageLoadEndDate = this.usageEndDate;
     this.usageError = null;
-    return this.usageRequest.run(client);
+    return this.usageRequest.run([client, refreshSessionKey]);
   }
 
   private clearSelections() {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users selecting Refresh in Usage saw updated totals while the selected session’s timeline and conversation stayed stale.

## Why This Change Was Made

Carry the selected session key with the accepted manual refresh request and reload its details through the existing detail owner. Automatic refreshes retain their current behavior, and a late response cannot transfer manual refresh intent to a different selection. This also removes a redundant private reload wrapper.

## User Impact

Refresh updates the selected timeline, conversation, and system-prompt breakdown alongside the overview. The existing query controls, refresh errors, and bounded automatic retry policy remain intact.

## Evidence

The existing mounted regression fails on the original code with stale timeline and conversation values, then passes unchanged after the fix. All 42 related mounted cases and 20 canonical changed checks pass, including automatic polling and replacement-selection controls. Independent Codex P0–P2 review found no actionable findings.

The same bundled Chromium scenario with a synthetic Gateway shows overview480/timeline360/five conversation entries before, then overview480/timeline480/six entries after; each detail request count changes from one to two. Existing tool-count, drag-selection, and Reset checks are retained. The inspected screenshots below use synthetic data. This validates the client request/render flow; it does not claim an atomic server snapshot or live provider billing freshness.

![Before Refresh leaves the selected timeline and conversation count stale](https://github.com/user-attachments/assets/3aff290e-1857-4997-b6b0-899e462045ee)

![After Refresh updates the selected timeline and conversation count](https://github.com/user-attachments/assets/633eeb55-a645-4561-b231-495a7eddf86a)

![Before the newly completed reply is missing](https://github.com/user-attachments/assets/2503f818-29c0-43e6-a4a3-68e951fbceb1)

![After the newly completed reply appears](https://github.com/user-attachments/assets/e261d6a2-d526-4ad9-87f3-62ff4840a2a3)