### PR TITLE
fix: keep containment test inspection scoped to requested processes

### DIFF
--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -346,11 +346,14 @@ process.stdin.on("end", () => process.exit(0));
         }
         return signalled;
       });
-      const readSnapshot = async (inspectionDeadline: number): Promise<PosixProcess[]> => {
+      const readSnapshot = async (
+        inspectionDeadline: number,
+        pids?: readonly number[],
+      ): Promise<PosixProcess[]> => {
         // Identity faults exercise signalling; cleanup needs a separate OS
         // observation. A queued kill alone must not certify an uninterruptible child.
         if (descendantSignalled && mode !== "unconfirmed-termination") {
-          return await actualSnapshot(inspectionDeadline);
+          return await actualSnapshot(inspectionDeadline, pids);
         }
         const rows = snapshots[Math.min(inspection++, snapshots.length - 1)];
         if (rows === "deadline") {
@@ -364,13 +367,13 @@ process.stdin.on("end", () => process.exit(0));
       };
       const snapshotSpy = vi
         .spyOn(processSnapshot, "readCodexAppServerProcessSnapshot")
-        .mockImplementation((inspectionDeadline = Date.now() + 2_000) =>
-          readSnapshot(inspectionDeadline),
+        .mockImplementation((inspectionDeadline, pids) =>
+          readSnapshot(inspectionDeadline ?? Date.now() + 2_000, pids),
         );
       const processSpy = vi
         .spyOn(processSnapshot, "readCodexAppServerProcess")
         .mockImplementation(async (pid, inspectionDeadline) =>
-          (await readSnapshot(inspectionDeadline))?.find((row) => row.pid === pid),
+          (await readSnapshot(inspectionDeadline, [pid]))?.find((row) => row.pid === pid),
         );
       restoreInspection = () => {
         snapshotSpy.mockRestore();


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Codex process-containment test fixture expanded selected process inspection into a whole-host scan during real cleanup observation. This introduced unrelated host inspection failures into a test that should inspect only the requested owners.

## Why This Change Was Made

Forward the requested PID list through the fixture's snapshot adapter, and preserve the single PID for scalar process reads. Production containment code, conservative `uncertain` results, survivor assertions, inspection deadlines and retry settings are unchanged. This is a one-file test repair.

## User Impact

CI containment tests now preserve the same inspection scope as their production caller. There is no production behavior change.

## Evidence

The original spontaneous failure in [run 34165662337](https://github.com/openclaw/openclaw/actions/runs/34165662337/job/101876183262) was not reproduced on a clean machine. Its precise historical OS cause remains unproven.

A controlled Linux test denied whole-host inspection during reparented termination while allowing selected owned-PID inspection. The original fixture reproduced the same `exited: true, cleanup: "uncertain"` assertion failure in 43 ms: 141 passed, one failed, 10 platform skips. Forwarding the PID scope passed all 142 applicable tests with the same 10 skips, retaining real child processes and OS survivor assertions.

The final uninstrumented 11-file Linux shard also passed 142 tests with 10 platform skips. Its verified source tree exactly matched the reviewed commit. Diagnostic fault injection was removed; only argument forwarding remains. Final lint/typechecking and independent P2 review passed. The fixture and production-owner preimages were unchanged when this patch was applied to current main.
