### PR TITLE
fix(android): stabilize wake-word save tests

### DIFF
--- a/apps/android/app/src/test/java/ai/openclaw/app/VoiceWakeRuntimeTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/VoiceWakeRuntimeTest.kt
@@ -58,7 +58,7 @@ class VoiceWakeRuntimeTest {
 
       runtime.setVoiceWakeWords(listOf("local draft"))
       withTimeout(5_000) {
-        while (runtime.voiceWakeWordsSaving.value) delay(10)
+        while (runtime.voiceWakeWordsSaving.value || runtime.voiceWakeWordsNoticeText.value == null) delay(10)
       }
 
       assertEquals(listOf("gateway claw"), runtime.voiceWakeWords.value)
@@ -74,7 +74,7 @@ class VoiceWakeRuntimeTest {
 
       runtime.setVoiceWakeWords(listOf("local draft"))
       withTimeout(5_000) {
-        while (runtime.voiceWakeWordsSaving.value) delay(10)
+        while (runtime.voiceWakeWordsSaving.value || runtime.voiceWakeWordsNoticeText.value == null) delay(10)
       }
 
       assertEquals(listOf("openclaw", "claude", "computer"), runtime.voiceWakeWords.value)


### PR DESCRIPTION
Related: #141603

## What Problem This Solves

Resolves a race where Android save tests read a null notice immediately after saving became false. This unrelated failure blocked validation of the catalog refresh fix in #141603.

## Why This Change Was Made

The existing success and failure tests now wait for both facts they assert: saving has finished and a notice has been published. Their five-second deadline, ten-millisecond polling interval, exact word/message assertions, and cleanup remain unchanged.

## User Impact

No product behavior changes. The tests consistently wait for the observable result while retaining checks for missing or incorrect notices.

## Evidence

The retained third-party CI failure showed canonical saved words followed by a null success notice. The source publishes saving and notice as separate flow updates in that order.

Both affected methods pass in the hermetic third-party Robolectric task with zero failures or skips. All 13 canonical changed checks pass, including Android lint. Independent Codex P0–P2 review found no actionable findings. This is a two-line test-only repair; no new tests, production changes, timeout increases, or assertion changes.
