### PR TITLE
refactor(tests): simplify dispatch policy fixtures

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
+++ b/src/auto-reply/reply/dispatch-from-config.hooks-and-send-policy.test-utils.ts
@@ -42,6 +42,14 @@ import { createReplyDispatcher } from "./reply-dispatcher.js";
 import { resolveReplyOperationRunState } from "./reply-operation-run-state.js";
 import { buildTestCtx } from "./test-ctx.js";
 
+function sendPolicySessionEntry(sendPolicy: "allow" | "deny") {
+  return { sessionId: "s1", updatedAt: 0, sendPolicy };
+}
+
+function groupSilenceConfig(group: "allow" | "disallow"): OpenClawConfig {
+  return { agents: { defaults: { silentReply: { group } } } };
+}
+
 beforeAll(globalBeforeAll0);
 
 describe("before_dispatch hook", () => {
@@ -272,11 +280,7 @@ describe("before_dispatch hook", () => {
 
   it("suppresses before_dispatch handled reply when sendPolicy is deny", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "deny",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("deny");
     hookMocks.runner.runBeforeDispatch.mockResolvedValue({ handled: true, text: "Blocked" });
     const dispatcher = createDispatcher();
     const result = await dispatchReplyFromConfig({
@@ -311,11 +315,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("still calls the replyResolver when sendPolicy is deny", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "deny",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("deny");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
       expect(opts?.suppressTyping).toBe(true);
@@ -338,11 +338,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     setNoAbort();
     diagnosticMocks.logMessageDispatchStarted.mockClear();
     diagnosticMocks.logMessageDispatchCompleted.mockClear();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "deny",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("deny");
     hookMocks.runner.runReplyDispatch.mockImplementation(async (event: unknown) => {
       const candidate = event as { isTailDispatch?: boolean };
       if (candidate.isTailDispatch) {
@@ -397,11 +393,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("suppresses final reply delivery when sendPolicy is deny", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "deny",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("deny");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
     const ctx = buildTestCtx({ SessionKey: "test:session" });
@@ -422,11 +414,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
   it("keeps the suppressed reply log preview UTF-16 safe", async () => {
     setNoAbort();
     globalMocks.logVerbose.mockClear();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "deny",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("deny");
     const dispatcher = createDispatcher();
     const text = `${"y".repeat(159)}🚀`;
 
@@ -486,15 +474,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
         SessionKey: "agent:main:feishu:group:oc_group",
         WasMentioned: true,
       }),
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
     },
   ])("records explicit NO_REPLY without a generic fallback in $name", async ({ ctx, cfg }) => {
     setNoAbort();
@@ -628,15 +608,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -668,15 +640,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -732,15 +696,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -770,15 +726,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -853,15 +801,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "allow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("allow"),
       dispatcher,
       replyResolver,
     });
@@ -877,11 +817,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("does not deliver no-visible fallback when sendPolicy is deny", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "deny",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("deny");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => undefined);
     const ctx = buildTestCtx({
@@ -894,15 +830,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -916,11 +844,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("does not deliver no-visible fallback under message_tool_only source delivery", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => undefined);
     const ctx = buildTestCtx({
@@ -965,15 +889,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
       replyOptions: {
@@ -1010,15 +926,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -1052,15 +960,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -1088,15 +988,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -1130,15 +1022,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -1172,15 +1056,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -1208,9 +1084,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: { defaults: { silentReply: { group: "disallow" } } },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver: vi.fn(async () => ({ text: "Legacy final answer." })),
     });
@@ -1239,15 +1113,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -1273,15 +1139,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -1318,15 +1176,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -1365,15 +1215,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -1406,15 +1248,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -1445,15 +1279,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
     const result = await dispatchReplyFromConfig({
       ctx,
-      cfg: {
-        agents: {
-          defaults: {
-            silentReply: {
-              group: "disallow",
-            },
-          },
-        },
-      } as OpenClawConfig,
+      cfg: groupSilenceConfig("disallow"),
       dispatcher,
       replyResolver,
     });
@@ -1467,11 +1293,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("suppresses tool result delivery when sendPolicy is deny", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "deny",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("deny");
     const dispatcher = createDispatcher();
     let capturedOnToolResult: ((payload: ReplyPayload) => Promise<void>) | undefined;
     const replyResolver = vi.fn(
@@ -1498,11 +1320,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("suppresses block reply delivery when sendPolicy is deny", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "deny",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("deny");
     const dispatcher = createDispatcher();
     let capturedOnBlockReply:
       | ((payload: ReplyPayload, context?: unknown) => Promise<void>)
@@ -1531,11 +1349,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("delivers replies normally when sendPolicy is allow", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
     const ctx = buildTestCtx({ SessionKey: "test:session" });
@@ -1553,11 +1367,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("delivers provider conversation-state runner payloads as outbound channel replies", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const exactProviderError = "Custom tool call output is missing for call id: call_live_123.";
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async (receivedCtx: MsgContext) => {
@@ -1619,11 +1429,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       handled: true,
       aborted: true,
     });
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "deny",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("deny");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "should not run" }) satisfies ReplyPayload);
     const ctx = buildTestCtx({
@@ -1649,11 +1455,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
       handled: true,
       aborted: true,
     });
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "hi" }) satisfies ReplyPayload);
     const ctx = buildTestCtx({
@@ -2266,11 +2068,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
         pluginRoot: "/tmp/plugin",
       },
     } satisfies SessionBindingRecord);
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "deny",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("deny");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
     const ctx = buildTestCtx({
@@ -2420,11 +2218,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
           pluginRoot: "/tmp/plugin",
         },
       } satisfies SessionBindingRecord);
-      sessionStoreMocks.currentEntry = {
-        sessionId: "s1",
-        updatedAt: 0,
-        sendPolicy: "allow",
-      };
+      sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
       const dispatcher = createDispatcher();
       const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
 
@@ -2495,11 +2289,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
         pluginRoot: "/tmp/plugin",
       },
     } satisfies SessionBindingRecord);
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
     const ctx = buildTestCtx({
@@ -2590,11 +2380,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
         pluginRoot: "/tmp/plugin",
       },
     } satisfies SessionBindingRecord);
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "agent reply" }) satisfies ReplyPayload);
     const ctx = buildTestCtx({
@@ -2673,11 +2459,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
         pluginRoot: "/tmp/plugin",
       },
     } satisfies SessionBindingRecord);
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const cfg = { messages: { visibleReplies: "message_tool" } } as OpenClawConfig;
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "reset ack" }) satisfies ReplyPayload);
@@ -2742,11 +2524,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
         pluginRoot: "/tmp/plugin",
       },
     } satisfies SessionBindingRecord);
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "core reply" }) satisfies ReplyPayload);
     const ctx = buildTestCtx({
@@ -2818,11 +2596,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
         pluginRoot: "/tmp/plugin",
       },
     } satisfies SessionBindingRecord);
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async () => ({ text: "core reply" }) satisfies ReplyPayload);
     const ctx = buildTestCtx({
@@ -2873,11 +2647,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("keeps message-tool-only source delivery private while still processing the turn", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const callbacks = {
       partial: vi.fn(),
@@ -2961,11 +2731,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("treats message-tool-only observed delivery as visible for fallback eligibility", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const observedReplyDelivery = vi.fn();
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
@@ -2999,11 +2765,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("preserves hook-blocked metadata when source delivery is message-tool-only", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const blockedReply = setReplyPayloadMetadata(
       { text: "Your message could not be sent: blocked by policy-plugin", isError: true },
@@ -3034,11 +2796,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("suppresses fast auto progress in message-tool-only mode without verbose progress", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
       await opts?.onToolResult?.({
@@ -3154,11 +2912,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("suppresses fast auto progress when sendPolicy is deny", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "deny",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("deny");
     const dispatcher = createDispatcher();
     const onToolResult = vi.fn();
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
@@ -3192,11 +2946,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("suppresses fast auto progress callbacks when verbose progress is off", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const onToolResult = vi.fn();
     const payload = {
@@ -3231,11 +2981,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("forwards hidden fast auto progress only to lifecycle callbacks", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const onToolResult = vi.fn(() => false);
     const payload = {
@@ -3434,11 +3180,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("lets the channel own forced tool progress at verbosity off", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const onToolResult = vi.fn(() => false);
     const payload = { text: "🧠 Memory Search: release notes" } satisfies ReplyPayload;
@@ -3515,11 +3257,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
     "keeps forced $label durable when channel progress is available",
     async ({ payload }) => {
       setNoAbort();
-      sessionStoreMocks.currentEntry = {
-        sessionId: "s1",
-        updatedAt: 0,
-        sendPolicy: "allow",
-      };
+      sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
       const dispatcher = createDispatcher();
       const onToolResult = vi.fn(() => false);
       const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
@@ -3550,11 +3288,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("delivers forced tool progress in message-tool-only mode without verbose progress", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const replyResolver = vi.fn(async (_ctx: MsgContext, opts?: GetReplyOptions) => {
       await opts?.onToolResult?.({ text: "🛠️ Exec: ruby sleep proof" });
@@ -3621,11 +3355,7 @@ describe("sendPolicy deny — suppress delivery, not processing (#53328)", () =>
 
   it("delivers marked runtime failure notices in message-tool-only mode", async () => {
     setNoAbort();
-    sessionStoreMocks.currentEntry = {
-      sessionId: "s1",
-      updatedAt: 0,
-      sendPolicy: "allow",
-    };
+    sessionStoreMocks.currentEntry = sendPolicySessionEntry("allow");
     const dispatcher = createDispatcher();
     const failureNotice = setReplyPayloadMetadata(
       { text: "⚠️ You've reached your Codex subscription usage limit." },


### PR DESCRIPTION
## What Problem This Solves

Dispatch policy tests repeatedly spell out the same session records and nested group-silence configuration, obscuring the policy choice each scenario exercises.

## Why This Change Was Made

Use two local constructors for 51 exact input fixtures. Each call keeps its explicit policy value and original allocation site, including the collection-time table input. Records and nested configuration objects remain fresh, with the same ordered fields. Specialized metadata, unset policies, callbacks, assertions, and all scenarios remain unchanged.

## User Impact

No runtime behavior change. Removes 270 net test lines while keeping the existing dispatch, delivery, and lifecycle regression coverage.

## Evidence

- The same 366 named cases passed before and after across the full delivery and lifecycle suites.
- Whole-file expansion proof matches the original emitted code, including assertions and callbacks; all 51 original inputs independently match ordered property descriptors and fresh object graphs.
- Full mapped changed-file checks and P2 review passed with no actionable findings.

No test runtime or aggregate coverage improvement is claimed.
