### PR TITLE
fix(test): preserve process snapshot selection

### DIFF
--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -367,8 +367,8 @@ process.stdin.on("end", () => process.exit(0));
       };
       const snapshotSpy = vi
         .spyOn(processSnapshot, "readCodexAppServerProcessSnapshot")
-        .mockImplementation((inspectionDeadline = Date.now() + 2_000, pids) =>
-          readSnapshot(inspectionDeadline, pids),
+        .mockImplementation((inspectionDeadline, pids) =>
+          readSnapshot(inspectionDeadline ?? Date.now() + 2_000, pids),
         );
       const processSpy = vi
         .spyOn(processSnapshot, "readCodexAppServerProcess")

--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -346,11 +346,14 @@ process.stdin.on("end", () => process.exit(0));
         }
         return signalled;
       });
-      const readSnapshot = async (inspectionDeadline: number): Promise<PosixProcess[]> => {
+      const readSnapshot = async (
+        inspectionDeadline: number,
+        pids?: readonly number[],
+      ): Promise<PosixProcess[]> => {
         // Identity faults exercise signalling; cleanup needs a separate OS
         // observation. A queued kill alone must not certify an uninterruptible child.
         if (descendantSignalled && mode !== "unconfirmed-termination") {
-          return await actualSnapshot(inspectionDeadline);
+          return await actualSnapshot(inspectionDeadline, pids);
         }
         const rows = snapshots[Math.min(inspection++, snapshots.length - 1)];
         if (rows === "deadline") {
@@ -364,8 +367,8 @@ process.stdin.on("end", () => process.exit(0));
       };
       const snapshotSpy = vi
         .spyOn(processSnapshot, "readCodexAppServerProcessSnapshot")
-        .mockImplementation((inspectionDeadline = Date.now() + 2_000) =>
-          readSnapshot(inspectionDeadline),
+        .mockImplementation((inspectionDeadline = Date.now() + 2_000, pids) =>
+          readSnapshot(inspectionDeadline, pids),
         );
       const processSpy = vi
         .spyOn(processSnapshot, "readCodexAppServerProcess")


### PR DESCRIPTION
Related: #141620

## What Problem This Solves

Resolves a test-adapter mismatch found while investigating unrelated CI failures blocking #141620. Cleanup requested a selected process snapshot, but the adapter dropped that argument and delegated a full-host snapshot instead.

## Why This Change Was Made

Forward the existing optional selector through the existing adapter to the real snapshot reader. All scenarios, expected cleanup results, exact assertions, deadlines, and fixture cleanup are preserved.

## User Impact

No product behavior changes. The fixture now exercises the same snapshot scope requested by its production caller.

## Evidence

The production caller supplies the selector, and the reader already accepts it. Reversing only the argument-forwarding edits reproduces the entire original test byte-for-byte. The canonical extension-test typecheck, targeted formatting, applicable Oxlint, and diff check pass; independent Codex P0–P2 review of the final staged patch found no actionable findings. The first CI run caught a default-parameter-order lint error in the new adapter signature; the follow-up keeps the same deadline default inside the call.

Runtime validation remains pending ordinary exact-head CI. No local process tests or probes were run. The earlier CI log does not identify the failed observation, so this fixes a verified adapter defect without claiming that the historical runtime cause has been conclusively reproduced.
