### PR TITLE
fix: keep Codex containment tests scoped to owned processes

### DIFF
--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -346,11 +346,14 @@ process.stdin.on("end", () => process.exit(0));
         }
         return signalled;
       });
-      const readSnapshot = async (inspectionDeadline: number): Promise<PosixProcess[]> => {
+      const readSnapshot = async (
+        inspectionDeadline: number,
+        pids?: readonly number[],
+      ): Promise<PosixProcess[]> => {
         // Identity faults exercise signalling; cleanup needs a separate OS
         // observation. A queued kill alone must not certify an uninterruptible child.
         if (descendantSignalled && mode !== "unconfirmed-termination") {
-          return await actualSnapshot(inspectionDeadline);
+          return await actualSnapshot(inspectionDeadline, pids);
         }
         const rows = snapshots[Math.min(inspection++, snapshots.length - 1)];
         if (rows === "deadline") {
@@ -364,13 +367,13 @@ process.stdin.on("end", () => process.exit(0));
       };
       const snapshotSpy = vi
         .spyOn(processSnapshot, "readCodexAppServerProcessSnapshot")
-        .mockImplementation((inspectionDeadline = Date.now() + 2_000) =>
-          readSnapshot(inspectionDeadline),
+        .mockImplementation((inspectionDeadline = Date.now() + 2_000, pids?: readonly number[]) =>
+          readSnapshot(inspectionDeadline, pids),
         );
       const processSpy = vi
         .spyOn(processSnapshot, "readCodexAppServerProcess")
         .mockImplementation(async (pid, inspectionDeadline) =>
-          (await readSnapshot(inspectionDeadline))?.find((row) => row.pid === pid),
+          (await readSnapshot(inspectionDeadline, [pid]))?.find((row) => row.pid === pid),
         );
       restoreInspection = () => {
         snapshotSpy.mockRestore();


### PR DESCRIPTION
Related: #141609

## What Problem This Solves

Resolves a problem where Codex process-containment tests can report uncertain cleanup because an unrelated process is unreadable, even when the production cleanup reader requests only the owned processes.

## Why This Change Was Made

The test adapter now preserves the snapshot reader's selected PIDs, including individual identity reads. It retains full enumeration when requested and preserves all cleanup assertions, signals, identity checks, and deadlines.

## User Impact

No runtime behavior changes. This makes the containment test exercise the production inspection scope accurately.

## Evidence

- Linux/Node 24 controlled proof preserved the original reparented execution order and added an unreadable unrelated procfs neighbor after the real descendant SIGKILL. The original adapter failed with `cleanup: uncertain`; the forwarding adapter passed with `cleanup: closed`. Both confirmed root exit 0, selected-owner read success, and full-scan refusal.
- Linux/Node 24 focused transport, process-snapshot and procfs registration tests: 70 passed, seven platform skips.
- The full changed gate passed on the isolated Linux Testbox; independent review found no actionable P0–P2 findings.
- The original failure investigated on #141609 remains causally unclassified; this separate controlled proof establishes the adapter defect.
