### PR TITLE
fix(opencode-go): send stable session routing header

### DIFF
--- a/extensions/opencode-go/index.test.ts
+++ b/extensions/opencode-go/index.test.ts
@@ -610,6 +610,44 @@ describe("opencode-go provider plugin", () => {
     expect(provider.wrapStreamFn?.({ streamFn: undefined } as never)).toBeUndefined();
   });
 
+  it("attaches a stable conversation id only to native OpenCode Go requests", async () => {
+    const provider = await registerSingleProviderPlugin(plugin);
+    const resolveTurnState = provider.resolveTransportTurnState;
+
+    expect(
+      resolveTurnState?.({
+        provider: "opencode-go",
+        modelId: "glm-5",
+        model: {
+          provider: "opencode-go",
+          id: "glm-5",
+          api: "openai-completions",
+          baseUrl: "https://opencode.ai/zen/go/v1",
+        },
+        sessionId: "conversation-123",
+        turnId: "turn-1",
+        attempt: 1,
+        transport: "stream",
+      } as never),
+    ).toEqual({ headers: { "x-opencode-session": "conversation-123" } });
+    expect(
+      resolveTurnState?.({
+        provider: "opencode-go",
+        modelId: "glm-5",
+        model: {
+          provider: "opencode-go",
+          id: "glm-5",
+          api: "openai-completions",
+          baseUrl: "https://proxy.example.com/v1",
+        },
+        sessionId: "conversation-123",
+        turnId: "turn-1",
+        attempt: 1,
+        transport: "stream",
+      } as never),
+    ).toBeUndefined();
+  });
+
   it("identifies native Anthropic stream and simple requests without tagging proxies", async () => {
     const provider = await registerSingleProviderPlugin(plugin);
     for (const testCase of [

--- a/extensions/opencode-go/index.ts
+++ b/extensions/opencode-go/index.ts
@@ -115,6 +115,13 @@ export default defineSingleProviderPluginEntry({
     augmentModelCatalog: () => listOpencodeGoModelCatalogEntries(),
     ...buildProviderReplayFamilyHooks({ family: "passthrough-gemini" }),
     resolveThinkingProfile,
+    resolveTransportTurnState: (ctx) => {
+      if (!normalizeOpencodeGoBaseUrl({ api: ctx.model?.api, baseUrl: ctx.model?.baseUrl })) {
+        return undefined;
+      }
+      const sessionId = ctx.sessionId?.trim() || ctx.turnId.trim();
+      return sessionId ? { headers: { "x-opencode-session": sessionId } } : undefined;
+    },
     wrapStreamFn: (ctx) => createOpencodeGoWrapper(ctx.streamFn, ctx.thinkingLevel),
     wrapSimpleCompletionStreamFn: (ctx) =>
       createOpencodeGoAttributionWrapper(ctx.streamFn, ctx.sourceApi),


### PR DESCRIPTION
## Summary
- attach a stable `x-opencode-session` header to native OpenCode Go requests
- derive it from the conversation session id, falling back to the turn id
- leave custom proxy transports untouched

## Why
The 2026.7.33 live provider gate now receives HTTP 400 because OpenCode Go requires this routing header.

## Validation
- `node scripts/run-vitest.mjs run extensions/opencode-go/index.test.ts` (39 passed)