### PR TITLE
fix(ci): use frozen-compatible Node runtime tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3351,7 +3351,7 @@ jobs:
           node openclaw.mjs --help
           node openclaw.mjs status --json --timeout 1
           pnpm test:build:singleton
-          pnpm test src/config/sessions/session-suggestion-store.test.ts src/config/sessions/session-sharing-store.test.ts src/config/sessions/session-accessor.creation-snapshot.test.ts
+          pnpm test src/config/sessions/session-accessor.test.ts src/config/sessions/store-writer.test.ts src/config/sessions/sessions.test.ts
 
   checks-node-core-test-nondist-shard:
     permissions:

--- a/.github/workflows/node-runtime-compat.yml
+++ b/.github/workflows/node-runtime-compat.yml
@@ -108,7 +108,7 @@ jobs:
           node openclaw.mjs --help
           node openclaw.mjs status --json --timeout 1
           pnpm test:build:singleton
-          pnpm test src/config/sessions/session-suggestion-store.test.ts src/config/sessions/session-sharing-store.test.ts src/config/sessions/session-accessor.creation-snapshot.test.ts
+          pnpm test src/config/sessions/session-accessor.test.ts src/config/sessions/store-writer.test.ts src/config/sessions/sessions.test.ts
 
       - name: Publish trusted declaration cache artifact
         if: success() && github.repository == 'openclaw/openclaw' && github.ref == 'refs/heads/main'

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -15224,6 +15224,13 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     expect(fullReleaseDispatch.env.CHILD_WORKFLOW_KIND).toBe("ci");
     expect(fullReleaseDispatch.run).toContain('dispatch_child ci.yml "$dispatch_run_name"');
     expect(fullReleaseDispatch.run).toContain('-f target_ref="$TARGET_SHA"');
+    expect(compatibilityJob.steps.at(-1)?.run).toContain(
+      "src/config/sessions/session-accessor.test.ts",
+    );
+    expect(compatibilityJob.steps.at(-1)?.run).toContain(
+      "src/config/sessions/store-writer.test.ts",
+    );
+    expect(compatibilityJob.steps.at(-1)?.run).toContain("src/config/sessions/sessions.test.ts");
   });
 
   it.skipIf(process.platform === "win32")("ci-gate rejects an unexpected selected skip", () => {


### PR DESCRIPTION
## Summary
- replace newly added session-store test paths in Node 24/26 compatibility jobs with long-lived session tests present in frozen releases
- guard the selected compatibility paths in workflow tests

## Why
The 2026.7.33 Full Validation CI child failed before testing Node compatibility because all three explicit targets exist only on current main. Historical dispatches must select tests present in the frozen checkout.

## Validation
- `node --import ./scripts/tsx.mjs scripts/test-projects.mts test/scripts/ci-workflow-guards.test.ts`