### PR TITLE
fix(opencode-go): backport stable session routing header

### DIFF
--- a/extensions/opencode-go/stream.session-header.test.ts
+++ b/extensions/opencode-go/stream.session-header.test.ts
@@ -1,0 +1,73 @@
+import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
+import { describe, expect, it, vi } from "vitest";
+import { createOpencodeGoSessionHeaderWrapper } from "./stream.js";
+
+type ProviderStreamFn = NonNullable<ProviderWrapStreamFnContext["streamFn"]>;
+
+function model(
+  api: "openai-completions" | "anthropic-messages",
+  baseUrl: string,
+  headers?: Record<string, string>,
+) {
+  return { provider: "opencode-go", id: "fixture", api, baseUrl, headers } as never;
+}
+
+describe("OpenCode Go session header wrapper", () => {
+  it.each([
+    ["openai-completions", "https://opencode.ai/zen/go/v1"],
+    ["anthropic-messages", "https://opencode.ai/zen/go"],
+  ] as const)("attaches stable conversation identity to %s requests", async (api, baseUrl) => {
+    const streamFn = vi.fn<ProviderStreamFn>(() => ({}) as never);
+    const wrapped = createOpencodeGoSessionHeaderWrapper(streamFn);
+
+    await wrapped?.(model(api, baseUrl), { messages: [] } as never, {
+      sessionId: "conversation-123",
+    });
+
+    expect(streamFn).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.objectContaining({ headers: { "x-opencode-session": "conversation-123" } }),
+    );
+  });
+
+  it("preserves explicit request identity case-insensitively", async () => {
+    const streamFn = vi.fn<ProviderStreamFn>(() => ({}) as never);
+    const wrapped = createOpencodeGoSessionHeaderWrapper(streamFn);
+
+    await wrapped?.(model("openai-completions", "https://opencode.ai/zen/go/v1"), {} as never, {
+      sessionId: "conversation-123",
+      headers: { "X-OpenCode-Session": "operator-route" },
+    });
+
+    expect(streamFn.mock.calls[0]?.[2]?.headers).toEqual({
+      "X-OpenCode-Session": "operator-route",
+    });
+  });
+
+  it("preserves explicit model identity case-insensitively", async () => {
+    const streamFn = vi.fn<ProviderStreamFn>(() => ({}) as never);
+    const wrapped = createOpencodeGoSessionHeaderWrapper(streamFn);
+
+    await wrapped?.(
+      model("anthropic-messages", "https://opencode.ai/zen/go", {
+        "X-OpenCode-Session": "model-route",
+      }),
+      {} as never,
+      { sessionId: "conversation-123" },
+    );
+
+    expect(streamFn.mock.calls[0]?.[2]?.headers).toBeUndefined();
+  });
+
+  it("does not attach identity to custom proxy routes", async () => {
+    const streamFn = vi.fn<ProviderStreamFn>(() => ({}) as never);
+    const wrapped = createOpencodeGoSessionHeaderWrapper(streamFn);
+
+    await wrapped?.(model("openai-completions", "https://proxy.example.com/v1"), {} as never, {
+      sessionId: "conversation-123",
+    });
+
+    expect(streamFn.mock.calls[0]?.[2]?.headers).toBeUndefined();
+  });
+});

--- a/extensions/opencode-go/stream.ts
+++ b/extensions/opencode-go/stream.ts
@@ -4,13 +4,46 @@ import {
   createDeepSeekV4OpenAICompatibleThinkingWrapper,
   streamWithPayloadPatch,
 } from "openclaw/plugin-sdk/provider-stream-shared";
-import { isOpencodeGoKimiNoReasoningModelId } from "./provider-catalog.js";
+import {
+  isOpencodeGoKimiNoReasoningModelId,
+  normalizeOpencodeGoBaseUrl,
+} from "./provider-catalog.js";
 import { stripOpencodeGoKimiReasoningPayload } from "./reasoning-sanitizer.js";
 import {
   createOpencodeGoStalledStreamWrapper,
   OPENCODE_GO_STREAM_FIRST_EVENT_TIMEOUT_MS_DEFAULT,
   OPENCODE_GO_STREAM_IDLE_TIMEOUT_MS_DEFAULT,
 } from "./stream-termination.js";
+
+const OPENCODE_SESSION_HEADER = "x-opencode-session";
+
+function hasOpencodeSessionHeader(headers: Record<string, string> | undefined): boolean {
+  return Object.keys(headers ?? {}).some((name) => name.toLowerCase() === OPENCODE_SESSION_HEADER);
+}
+
+export function createOpencodeGoSessionHeaderWrapper(
+  baseStreamFn: ProviderWrapStreamFnContext["streamFn"],
+): ProviderWrapStreamFnContext["streamFn"] {
+  if (!baseStreamFn) {
+    return undefined;
+  }
+  return (model, context, options) => {
+    const sessionId = options?.sessionId?.trim();
+    if (
+      model.provider !== "opencode-go" ||
+      !normalizeOpencodeGoBaseUrl({ api: model.api, baseUrl: model.baseUrl }) ||
+      !sessionId ||
+      hasOpencodeSessionHeader(model.headers) ||
+      hasOpencodeSessionHeader(options?.headers)
+    ) {
+      return baseStreamFn(model, context, options);
+    }
+    return baseStreamFn(model, context, {
+      ...options,
+      headers: { ...options?.headers, [OPENCODE_SESSION_HEADER]: sessionId },
+    });
+  };
+}
 
 function isOpencodeGoDeepSeekV4ModelId(modelId: unknown): boolean {
   return modelId === "deepseek-v4-flash" || modelId === "deepseek-v4-pro";
@@ -60,9 +93,10 @@ export function createOpencodeGoWrapper(
   // Outermost layer: provider-owned stalled SSE termination so the underlying
   // OpenAI SDK request is aborted at the raw opencode-go boundary instead of
   // waiting for the shared runtime stuck-session recovery.
-  return createOpencodeGoStalledStreamWrapper(deepSeekWrapped, {
+  const stalledWrapped = createOpencodeGoStalledStreamWrapper(deepSeekWrapped, {
     provider: "opencode-go",
     idleTimeoutMs: OPENCODE_GO_STREAM_IDLE_TIMEOUT_MS_DEFAULT,
     firstEventTimeoutMs: OPENCODE_GO_STREAM_FIRST_EVENT_TIMEOUT_MS_DEFAULT,
   });
+  return createOpencodeGoSessionHeaderWrapper(stalledWrapped);
 }


### PR DESCRIPTION
## Summary
- inject `x-opencode-session` through the provider's actual stream-wrapper boundary
- cover both OpenAI Chat Completions and Anthropic Messages routes used by OpenCode Go
- preserve explicit request identities case-insensitively and exclude custom proxy endpoints

## Why
The immutable 2026.7.33 OpenCode Go gate receives HTTP 400 without this required conversation-routing header. Current main already owns this behavior centrally; this PR is the minimal stable compatibility backport.

## Validation
- `node scripts/run-vitest.mjs run extensions/opencode-go/index.test.ts extensions/opencode-go/stream.session-header.test.ts extensions/opencode-go/stream-termination.test.ts` (30 passed)
- `oxfmt --check`
- `git diff --check`
