### PR TITLE
fix(test): keep denied Linux port probes in the safe pool

### DIFF
--- a/src/test-utils/ports.test.ts
+++ b/src/test-utils/ports.test.ts
@@ -185,17 +185,47 @@ describe("deterministic test port blocks", () => {
   });
 
   it.each(["EPERM", "EACCES"])(
-    "preserves the explicit permission fallback for %s",
+    "keeps permission-denied Linux blocks outside the client range for %s",
     async (code) => {
       host.range = "32768\t60999\n";
       host.rejectPort.mockReturnValue(code);
-      const { getFreePortBlockWithPermissionFallback, isPortFree } = await import("./ports.js");
-      await expect(isPortFree(41032)).resolves.toBe(false);
-      await expect(
-        getFreePortBlockWithPermissionFallback({ offsets: [0, 1, 2, 4], fallbackBase: 44000 }),
-      ).resolves.toBe(44000 + (process.pid % 10000));
+      const { getFreePortBlockWithPermissionFallback } = await import("./ports.js");
+      const offsets = [0, 1, 2, 4];
+      const port = await getFreePortBlockWithPermissionFallback({ offsets, fallbackBase: 44000 });
+      for (const offset of offsets) {
+        expect(port + offset >= 1024 && port + offset <= 65535).toBe(true);
+        expect(port + offset < 32768 || port + offset > 60999).toBe(true);
+      }
+      expect(host.rejectPort.mock.calls.map(([candidate]) => candidate)).toEqual(
+        offsets.map((offset) => port + offset),
+      );
     },
   );
+
+  it("skips HTTP-blocked derived ports before accepting a denied Linux block", async () => {
+    host.range = "1 1711";
+    host.rejectPort.mockReturnValue("EPERM");
+    const { getFreePortBlockWithPermissionFallback } = await import("./ports.js");
+    // Select the first safe shard so +7 first hits Fetch-blocked port 1719.
+    await withEnvAsync({ VITEST_WORKER_ID: String(64 - (process.pid % 64)) }, async () => {
+      const port = await getFreePortBlockWithPermissionFallback({
+        offsets: [0, 7],
+        fallbackBase: 44000,
+      });
+      expect(port).toBe(1728);
+      expect(host.rejectPort.mock.calls.map(([candidate]) => candidate)).toEqual([1728, 1735]);
+    });
+  });
+
+  it.each(["darwin", "win32"])("preserves the explicit %s permission fallback", async (os) => {
+    host.platform.mockReturnValue(os);
+    host.rejectPort.mockReturnValue("EACCES");
+    const { getFreePortBlockWithPermissionFallback } = await import("./ports.js");
+    await expect(
+      getFreePortBlockWithPermissionFallback({ offsets: [0, 1, 2, 4], fallbackBase: 44000 }),
+    ).resolves.toBe(44000 + (process.pid % 10000));
+    expect(host.reads).not.toHaveBeenCalled();
+  });
 
   it.each(["1024 65535", "invalid"])(
     "does not fall back to ephemeral ports for host range %s",

--- a/src/test-utils/ports.ts
+++ b/src/test-utils/ports.ts
@@ -114,7 +114,13 @@ let nextTestPortOffset = 0;
 export async function getDeterministicFreePortBlock(params?: {
   offsets?: number[];
 }): Promise<number> {
-  const offsets = params?.offsets ?? [0, 1, 2, 3, 4];
+  return allocateDeterministicPortBlock(params?.offsets ?? [0, 1, 2, 3, 4], false);
+}
+
+async function allocateDeterministicPortBlock(
+  offsets: number[],
+  allowPermissionFallback: boolean,
+): Promise<number> {
   if (
     offsets.length === 0 ||
     offsets.some((offset) => !Number.isInteger(offset) || offset < 0 || offset > 65535 - 1024)
@@ -135,6 +141,23 @@ export async function getDeterministicFreePortBlock(params?: {
       : processShard + Math.abs(threadId);
 
   const pool = getPortPool();
+  const canUseBlock = async (start: number): Promise<boolean> => {
+    try {
+      return await isPortBlockFree(start, offsets);
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (
+        allowPermissionFallback &&
+        pool.excludesEphemeral &&
+        (code === "EPERM" || code === "EACCES")
+      ) {
+        // Socket-denied callers still need the same safe pool and HTTP checks.
+        // Retain this candidate without attempting another denied probe.
+        return true;
+      }
+      throw err;
+    }
+  };
   const rangeSize = Math.max(1000, maxOffset + 1);
   const shards = pool.ranges.flatMap((range) => {
     const ranges: PortRange[] = [];
@@ -160,7 +183,7 @@ export async function getDeterministicFreePortBlock(params?: {
   // so probing every single offset is wasted work and slows large suites.
   for (let attempt = 0; attempt < usable; attempt += blockSize) {
     const start = primary.start + ((nextTestPortOffset + attempt) % usable);
-    const ok = await isPortBlockFree(start, offsets);
+    const ok = await canUseBlock(start);
     if (!ok) {
       continue;
     }
@@ -179,7 +202,7 @@ export async function getDeterministicFreePortBlock(params?: {
     const port = pool.excludesEphemeral
       ? alternative.start + ((nextTestPortOffset + attempt * blockSize) % available)
       : await getFreePort();
-    const ok = await isPortBlockFree(port, offsets);
+    const ok = await canUseBlock(port);
     if (ok) {
       return port;
     }
@@ -193,7 +216,7 @@ export async function getFreePortBlockWithPermissionFallback(params: {
   fallbackBase: number;
 }): Promise<number> {
   try {
-    return await getDeterministicFreePortBlock({ offsets: params.offsets });
+    return await allocateDeterministicPortBlock(params.offsets, true);
   } catch (err) {
     const code = (err as NodeJS.ErrnoException | undefined)?.code;
     if (code === "EPERM" || code === "EACCES") {


### PR DESCRIPTION
Related: #141627

## What Problem This Solves

Resolves a problem where Linux test fixtures could still select ports inside the kernel's ephemeral client range when socket probes were denied with EPERM or EACCES. This corrects a permission-fallback gap in #141627.

## Why This Change Was Made

Permission-tolerant allocation now retains the same complete, HTTP-valid, non-ephemeral candidate selected by the normal allocator, without trying additional denied socket probes. Strict allocation still reports permission errors. Non-Linux explicit fallback behavior and fail-closed handling of unreadable Linux kernel facts remain unchanged.

## User Impact

No runtime product behavior changes. Permission-constrained test fixtures retain the Linux listener-pool guarantees introduced by #141627.

## Evidence

Both Linux permission regressions fail on the previous implementation because the fallback is inside the client range. All 16 allocator cases pass with the repair, including blocked derived HTTP ports, Darwin/Windows fallback, and denied kernel facts. The unchanged real Gateway startup SecretRef owner-isolation suite passes 12/12. Full changed-file checks pass on the reviewed source; the main backport is identical in both changed files. Fresh independent P2 review found no actionable issues.

The original CI collision's actual occupant remains unknown; this follow-up addresses the independently identified permission-path gap.
