### PR TITLE
fix(ci): bind root Docker smoke to frozen source

### DIFF
--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -489,6 +489,25 @@ jobs:
       - *trusted_workflow_subdir_checkout_step
       - *trusted_workflow_subdir_identity_step
 
+      - name: Prepare selected root Docker source identity
+        env:
+          SOURCE_IDENTITY_DIR: ${{ runner.temp }}/root-dockerfile-candidate.git
+          TARGET_REPOSITORY: ${{ github.repository }}
+          TARGET_SHA: ${{ needs.preflight.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$TARGET_SHA" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "Selected root Docker source SHA is invalid." >&2
+            exit 1
+          }
+          rm -rf "$SOURCE_IDENTITY_DIR"
+          git init --bare "$SOURCE_IDENTITY_DIR"
+          timeout --kill-after=30s 5m git -C "$SOURCE_IDENTITY_DIR" fetch \
+            --no-tags --depth=1 "https://github.com/${TARGET_REPOSITORY}.git" \
+            "$TARGET_SHA:refs/heads/selected"
+          git -C "$SOURCE_IDENTITY_DIR" symbolic-ref HEAD refs/heads/selected
+          test "$(git -C "$SOURCE_IDENTITY_DIR" rev-parse HEAD)" = "$TARGET_SHA"
+
       - name: Validate root Dockerfile image artifact binding
         env:
           ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
@@ -587,6 +606,7 @@ jobs:
       - name: Run Docker gateway network e2e
         env:
           OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: ${{ inputs.allow_frozen_target_scenario_omissions && '1' || '0' }}
+          OPENCLAW_DOCKER_E2E_REPO_ROOT: ${{ runner.temp }}/root-dockerfile-candidate.git
           OPENCLAW_GATEWAY_NETWORK_E2E_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_GATEWAY_NETWORK_E2E_SKIP_BUILD: "1"
           OPENCLAW_SELECTED_SHA: ${{ needs.preflight.outputs.target_sha }}

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -11811,6 +11811,24 @@ wait_for_run plugin-clawhub-new.yml 123 "${expectedSha}" || status=$?
     expect(installSmoke.jobs?.root_dockerfile_image_ready?.["timeout-minutes"]).toBe(5);
     expect(installSmoke.jobs?.qr_package_install_smoke?.["timeout-minutes"]).toBe(30);
     expect(installSmoke.jobs?.root_dockerfile_smokes?.["timeout-minutes"]).toBe(90);
+    const sourceIdentityStep = workflowStep(
+      workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "root_dockerfile_smokes"),
+      "Prepare selected root Docker source identity",
+    );
+    expect(sourceIdentityStep.env).toMatchObject({
+      SOURCE_IDENTITY_DIR: "${{ runner.temp }}/root-dockerfile-candidate.git",
+      TARGET_REPOSITORY: "${{ github.repository }}",
+      TARGET_SHA: "${{ needs.preflight.outputs.target_sha }}",
+    });
+    expect(sourceIdentityStep.run).toContain('git init --bare "$SOURCE_IDENTITY_DIR"');
+    expect(sourceIdentityStep.run).toContain('"$TARGET_SHA:refs/heads/selected"');
+    expect(sourceIdentityStep.run).toContain("symbolic-ref HEAD refs/heads/selected");
+    expect(
+      workflowStep(
+        workflowJob(INSTALL_SMOKE_REUSABLE_WORKFLOW, "root_dockerfile_smokes"),
+        "Run Docker gateway network e2e",
+      ).env?.OPENCLAW_DOCKER_E2E_REPO_ROOT,
+    ).toBe("${{ runner.temp }}/root-dockerfile-candidate.git");
     expect(installSmoke.jobs?.installer_smoke_update_image?.["timeout-minutes"]).toBe(45);
     expect(installSmoke.jobs?.installer_smoke_nonroot_image?.["timeout-minutes"]).toBe(45);
     expect(installSmoke.jobs?.installer_smoke_update?.["timeout-minutes"]).toBe(120);


### PR DESCRIPTION
## Summary
- fetch the selected root Docker source into a bare, non-executable Git object store at the resolved immutable target SHA
- run the trusted root Docker gateway-network harness against that exact repository identity without materializing candidate files
- guard the bounded fetch, exact SHA binding, and smoke input in package-acceptance tests

## Validation
- `node scripts/run-vitest.mjs run test/scripts/package-acceptance-workflow.test.ts` — 414 passed
- `oxfmt --check test/scripts/package-acceptance-workflow.test.ts`
- `git diff --check`

## Release context
2026.7.33 Full Validation built the correct candidate image but ran the gateway network helper with the trusted tooling checkout as its default repository root. The frozen-source identity check therefore compared tooling SHA `f3076010...` with candidate SHA `f9e17bac...` and rejected the smoke before exercising the image.

The workflow now performs a bounded, credential-free exact-SHA fetch into a bare repository under `runner.temp`, verifies its `HEAD`, and passes that repository identity to the trusted smoke harness. Candidate-controlled files are never checked out or executed in the privileged job.
