### PR TITLE
fix(devices): use operator labels in node approval notices

### DIFF
--- a/docs/cli/devices.md
+++ b/docs/cli/devices.md
@@ -35,7 +35,7 @@ openclaw devices list --json
 
 For a pending request on an already-paired device, the output shows requested access next to the device's current approved access, so scope/role upgrades are visible instead of looking like a lost pairing.
 
-Paired device display names use this precedence: operator label (`operatorLabel` from `devices rename`), then client `displayName`, then `clientId`, then `deviceId`.
+Paired device display names use this precedence: operator label (`operatorLabel` from `devices rename`), then client `displayName`, then `clientId`, then `deviceId`. Node approval notices printed by `devices` commands use the operator label when one is set.
 
 ### `openclaw devices approve [requestId] [--latest]`
 

--- a/src/cli/devices-cli.runtime.ts
+++ b/src/cli/devices-cli.runtime.ts
@@ -123,6 +123,7 @@ function buildPendingNodeApprovalNotice(
   return {
     action: device.nodeSurface ? "reapproval" : "approval",
     label:
+      normalizeOptionalString(device.operatorLabel) ??
       normalizeOptionalString(pending.displayName) ??
       normalizeOptionalString(device.nodeSurface?.displayName) ??
       normalizeOptionalString(device.displayName) ??

--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -183,6 +183,22 @@ const approvalCommandContexts = [
   ["container", "work", "demo", "openclaw --container demo"],
 ] as const;
 
+const nodeApprovalLabelCases = [
+  { labelKind: "operator label", operatorLabel: "Kitchen Mac", expectedName: "Kitchen Mac" },
+  { labelKind: "blank operator label", operatorLabel: "   ", expectedName: "Colin's S25" },
+  { labelKind: "missing operator label", operatorLabel: undefined, expectedName: "Colin's S25" },
+] as const;
+
+const nodeApprovalErrorCases = [
+  ...nodeApprovalLabelCases.map((labelCase) => ({ ...labelCase, json: false })),
+  {
+    labelKind: "operator label with JSON output",
+    operatorLabel: "Kitchen Mac",
+    expectedName: "Kitchen Mac",
+    json: true,
+  },
+];
+
 function expectRecordFields(record: Record<string, unknown>, fields: Record<string, unknown>) {
   for (const [key, value] of Object.entries(fields)) {
     expect(record[key]).toEqual(value);
@@ -537,56 +553,62 @@ describe("devices cli approve", () => {
     expect(hasGatewayMethod("device.pair.approve")).toBe(false);
   });
 
-  it("suggests pending node approval when a device IP is approved at the wrong layer", async () => {
-    callGateway
-      .mockResolvedValueOnce({
-        pending: [],
-        paired: [
-          pairedDevice({
-            deviceId: "android-node",
-            displayName: "Colin's S25",
-            remoteIp: "192.168.0.202",
-            roles: ["node"],
-            nodeSurface: {
+  it.each(nodeApprovalErrorCases)(
+    "suggests pending node approval when a device IP is approved at the wrong layer: $labelKind",
+    async ({ operatorLabel, expectedName, json }) => {
+      callGateway
+        .mockResolvedValueOnce({
+          pending: [],
+          paired: [
+            pairedDevice({
+              deviceId: "android-node",
               displayName: "Colin's S25",
-              createdAtMs: 1,
-              approvedAtMs: 1,
-            },
-            pendingNodeSurface: {
-              requestId: "node-req-1",
-              revision: "revision-1",
-              displayName: "Colin's S25",
+              operatorLabel,
               remoteIp: "192.168.0.202",
-              ts: 2,
-            },
-          }),
-        ],
-      })
-      .mockRejectedValueOnce(new Error("device pairing approval denied"))
-      .mockRejectedValueOnce({ message: "unknown requestId", gatewayCode: "INVALID_REQUEST" });
+              roles: ["node"],
+              nodeSurface: {
+                displayName: "Colin's S25",
+                createdAtMs: 1,
+                approvedAtMs: 1,
+              },
+              pendingNodeSurface: {
+                requestId: "node-req-1",
+                revision: "revision-1",
+                displayName: "Colin's S25",
+                remoteIp: "192.168.0.202",
+                ts: 2,
+              },
+            }),
+          ],
+        })
+        .mockRejectedValueOnce(new Error("device pairing approval denied"))
+        .mockRejectedValueOnce({ message: "unknown requestId", gatewayCode: "INVALID_REQUEST" });
 
-    await runDevicesApprove([
-      "192.168.0.202",
-      "--url",
-      "ws://gateway-user:url-secret@gateway.example:18789/openclaw?cluster=qa",
-      "--token",
-      "secret-token",
-    ]);
+      await runDevicesApprove([
+        "192.168.0.202",
+        "--url",
+        "ws://gateway-user:url-secret@gateway.example:18789/openclaw?cluster=qa",
+        "--token",
+        "secret-token",
+        ...(json ? ["--json"] : []),
+      ]);
 
-    expect(callGateway).toHaveBeenCalledTimes(3);
-    const errorOutput = readRuntimeErrorOutput();
-    expect(errorOutput).toContain("No pending device request matches");
-    expect(errorOutput).toContain("Node reapproval pending for Colin's S25");
-    expect(errorOutput).toContain("openclaw nodes approve node-req-1");
-    expect(errorOutput).toContain(
-      "Reuse the same connection options when rerunning: --url, --token.",
-    );
-    expect(errorOutput).not.toContain("gateway-user");
-    expect(errorOutput).not.toContain("url-secret");
-    expect(errorOutput).not.toContain("gateway.example");
-    expect(errorOutput).not.toContain("secret-token");
-    expect(runtime.exit).toHaveBeenCalledWith(1);
-  });
+      expect(callGateway).toHaveBeenCalledTimes(3);
+      const errorOutput = readRuntimeErrorOutput();
+      expect(errorOutput).toContain("No pending device request matches");
+      expect(errorOutput).toContain(`Node reapproval pending for ${expectedName}. Run`);
+      expect(errorOutput).toContain("openclaw nodes approve node-req-1");
+      expect(errorOutput).toContain(
+        "Reuse the same connection options when rerunning: --url, --token.",
+      );
+      expect(errorOutput).not.toContain("gateway-user");
+      expect(errorOutput).not.toContain("url-secret");
+      expect(errorOutput).not.toContain("gateway.example");
+      expect(errorOutput).not.toContain("secret-token");
+      expect(runtime.writeJson).not.toHaveBeenCalled();
+      expect(runtime.exit).toHaveBeenCalledWith(1);
+    },
+  );
 
   it("does not suggest node approval for a wrong-layer device IP when only display names match", async () => {
     callGateway
@@ -640,6 +662,34 @@ describe("devices cli approve", () => {
     expect(errorOutput).toContain("No pending device request matches");
     expect(errorOutput).not.toContain("node-req-display-name");
     expect(errorOutput).not.toContain("openclaw nodes approve");
+  });
+
+  it("does not suggest node approval when a JSON-mode query only matches an operator label", async () => {
+    primeGatewayPairing(
+      [],
+      [
+        pairedDevice({
+          deviceId: "paired-node",
+          operatorLabel: "Kitchen Mac",
+          displayName: "Client Phone",
+          roles: ["node"],
+          pendingNodeSurface: {
+            requestId: "node-req-alias",
+            displayName: "Declared Phone",
+          },
+        }),
+      ],
+    ).mockRejectedValueOnce({ message: "unknown requestId", gatewayCode: "INVALID_REQUEST" });
+
+    await runDevicesApprove(["Kitchen Mac", "--json"]);
+
+    expect(callGateway).toHaveBeenCalledTimes(2);
+    const errorOutput = readRuntimeErrorOutput();
+    expect(errorOutput).toContain("No pending device request matches Kitchen Mac");
+    expect(errorOutput).not.toContain("node-req-alias");
+    expect(errorOutput).not.toContain("openclaw nodes approve");
+    expect(runtime.writeJson).not.toHaveBeenCalled();
+    expect(runtime.exit).toHaveBeenCalledWith(1);
   });
 });
 
@@ -1045,51 +1095,58 @@ describe("devices cli list", () => {
     expect(output).toContain("operator.read");
   });
 
-  it("shows pending node approval commands for paired node devices", async () => {
-    vi.stubEnv("OPENCLAW_PROFILE", "work");
-    callGateway.mockResolvedValueOnce({
-      pending: [],
-      paired: [
-        pairedDevice({
-          deviceId: "android-node",
-          displayName: "Colin's S25",
-          remoteIp: "192.168.0.202",
-          role: "node",
-          roles: [],
-          nodeSurface: {
+  it.each(nodeApprovalLabelCases)(
+    "shows pending node approval commands for paired node devices: $labelKind",
+    async ({ operatorLabel, expectedName }) => {
+      vi.stubEnv("OPENCLAW_PROFILE", "work");
+      callGateway.mockResolvedValueOnce({
+        pending: [],
+        paired: [
+          pairedDevice({
+            deviceId: "android-node",
             displayName: "Colin's S25",
-            createdAtMs: 1,
-            approvedAtMs: 1,
-          },
-          pendingNodeSurface: {
-            requestId: "node-req-1",
-            revision: "revision-1",
-            displayName: "Colin's S25",
+            operatorLabel,
             remoteIp: "192.168.0.202",
-            ts: 2,
-          },
-        }),
-      ],
-    });
+            role: "node",
+            roles: [],
+            nodeSurface: {
+              displayName: "Colin's S25",
+              createdAtMs: 1,
+              approvedAtMs: 1,
+            },
+            pendingNodeSurface: {
+              requestId: "node-req-1",
+              revision: "revision-1",
+              displayName: "Colin's S25",
+              remoteIp: "192.168.0.202",
+              ts: 2,
+            },
+          }),
+        ],
+      });
 
-    await runDevicesCommand([
-      "list",
-      "--url",
-      "ws://gateway-user:url-secret@gateway.example:18789/openclaw?cluster=qa",
-      "--token",
-      "secret-token",
-    ]);
+      await runDevicesCommand([
+        "list",
+        "--url",
+        "ws://gateway-user:url-secret@gateway.example:18789/openclaw?cluster=qa",
+        "--token",
+        "secret-token",
+      ]);
 
-    expect(callGateway).toHaveBeenCalledOnce();
-    const output = readRuntimeOutput();
-    expect(output).toContain("Node reapproval pending for Colin's S25");
-    expect(output).toContain("openclaw --profile work nodes approve node-req-1");
-    expect(output).toContain("Reuse the same connection options when rerunning: --url, --token.");
-    expect(output).not.toContain("gateway-user");
-    expect(output).not.toContain("url-secret");
-    expect(output).not.toContain("gateway.example");
-    expect(output).not.toContain("secret-token");
-  });
+      expect(callGateway).toHaveBeenCalledOnce();
+      const output = readRuntimeOutput();
+      expect(output).toContain(`Node reapproval pending for ${expectedName}. Run`);
+      if (operatorLabel?.trim()) {
+        expect(output.split("\n")).toContain(`  android-node  ${expectedName}`);
+      }
+      expect(output).toContain("openclaw --profile work nodes approve node-req-1");
+      expect(output).toContain("Reuse the same connection options when rerunning: --url, --token.");
+      expect(output).not.toContain("gateway-user");
+      expect(output).not.toContain("url-secret");
+      expect(output).not.toContain("gateway.example");
+      expect(output).not.toContain("secret-token");
+    },
+  );
 
   it("does not show node approval commands for paired node devices when only display names match", async () => {
     callGateway.mockResolvedValueOnce({


### PR DESCRIPTION
Closes #141644

## What Problem This Solves

Fixes an issue where operators who rename a paired device see the old client name in its pending node-approval notice. `devices list` already shows the operator label in the paired-device table, but its notice and the guidance from a wrong-layer `devices approve` command identify the same device differently.

## Why This Change Was Made

The shared `buildPendingNodeApprovalNotice` renderer omitted the existing `operatorLabel`. Prefer its normalized value before the existing pending-surface, approved-surface, client-name and device-ID fallbacks. Both notice callers use this owner, so one precedence correction repairs list output and approval-error guidance together.

This is a display repair. Request IDs, approval selectors, permissions, configuration, protocol, schemas and stored representations are unchanged. Labels alone still cannot select an approval. Successful JSON rendering is unchanged; human error text on stderr also receives the corrected name when `--json` is requested. Production delta is +1 line for the missing existing-field precedence; tests net +57, docs net zero. Introduction provenance remains unknown in the retained shallow history.

## User Impact

After renaming the synthetic node from `Fixture Phone` to `Kitchen Mac`, the paired table and approval notice agree:

```text
Before: Node approval pending for Fixture Phone. Run openclaw nodes approve <request ID>
After:  Node approval pending for Kitchen Mac. Run openclaw nodes approve <same request ID>
```

Empty or absent operator labels retain the existing name fallback. The suggested command preserves the exact pending request ID and connection guidance.

## Evidence

- Tests-only baseline: three intended alias regressions fail while 65 controls pass. Candidate: all 68 device CLI tests pass, covering list notices, wrong-layer errors, reapproval/fallback names, JSON output and alias-only no-match behavior.
- Complete changed-file gate passed in 405 seconds; fresh independent P0–P2 review found no actionable findings. Normal full candidate build passed in 5m21s. The committed patch is byte-identical to the reviewed, built and live-tested patch (`1153d21b20594b42433cc4e22a3fcc3b486a1ece421bc56182ed1dd6b3b48baa`).
- Real isolated loopback Gateway, fresh test node and ordinary built CLI commands: 22 one-shot commands produced the expected exits (18 successful, four intentional invalid-approval probes). Before rename, both CLI builds display `Fixture Phone`. After rename, the baseline retains that name only in notices; the candidate uses `Kitchen Mac` consistently. Invalid `--json` approvals exit 1 with human guidance on stderr and empty stdout. Alias-only approval remains the same generic no-match without a node suggestion.
- The selected paired-node record remains exactly its initial value plus the one explicit operator label. Node description authority, capabilities and request fields are unchanged; only the response timestamp differs. No capability was approved or invoked. Server evidence records 13 successful device-list responses, one rename and eight denied approval responses from the existing scope-negotiation flow.
- Honest build scope: Gateway/node/baseline CLI use the retained normal build at `9a4114bc4691bdb1293fd48ef1ed1b1790485d12`. Candidate CLI uses `031e7702ad81c933e7930f632ed2c25b439f8174` plus the exact committed patch. Scoped baseline reuse was checked against 34 source contracts and 28 critical artifacts; this is not an exact-031 whole-product baseline. Source, artifact and dependency inventories remained unchanged after live execution. The three repair files and producer contracts remain unchanged on inspected main `f3076010caa4f247bb4f64ca154148b433240f6e`.
- Cleanup: deliberate Ctrl-C gives node exit 130 (no graceful node-protocol shutdown claim), Gateway exit 0 and a recorded clean shutdown in 34ms. Gateway PID and listener are absent, the port can be rebound, and no open handles under the node fixture were observed. Both private configuration hashes remain unchanged. An independent audit checked 79 sealed evidence artifacts.

Runtime limitations are retained: the unchanged baseline node logged 97 inventory-publication denials explicitly awaiting capability approval and eight node-event denials saying pairing changed while invocation was active. The latter diagnostic's cause is unestablished; no pristine-log or successful node-invocation claim is made.

Native screenshots are infeasible because a fresh desktop observation showed the macOS login window active. The evidence above is real headless CLI output; no screenshot or GUI execution is claimed. Private fixture state and raw evidence are retained locally, without publishing credentials or device data.
