### PR TITLE
refactor(tests): remove duplicate memory resolver cases

### DIFF
--- a/src/plugins/memory-embedding-provider-runtime.test.ts
+++ b/src/plugins/memory-embedding-provider-runtime.test.ts
@@ -44,22 +44,6 @@ afterEach(() => {
 });
 
 describe("memory embedding provider runtime resolution", () => {
-  it("merges registered and declared capability fallback adapters", () => {
-    registerEmbeddingProvider({
-      id: "registered",
-      create: async () => ({ provider: null }),
-    });
-    mocks.resolvePluginCapabilityProviders.mockReturnValue([createCapabilityAdapter("capability")]);
-
-    expect(runtimeModule.listMemoryEmbeddingProviders().map((adapter) => adapter.id)).toEqual([
-      "openai-compatible",
-      "registered",
-      "capability",
-    ]);
-    expect(runtimeModule.getMemoryEmbeddingProvider("registered")?.id).toBe("registered");
-    expect(mocks.resolvePluginCapabilityProviders).toHaveBeenCalledTimes(1);
-  });
-
   it("falls back to declared capability adapters when the registry is cold", () => {
     mocks.resolvePluginCapabilityProviders.mockReturnValue([createCapabilityAdapter("ollama")]);
     mocks.resolvePluginCapabilityProvider.mockReturnValue(createCapabilityAdapter("ollama"));
@@ -133,24 +117,6 @@ describe("memory embedding provider runtime resolution", () => {
       providerId: "ollama-gpu1",
       cfg: config,
     });
-  });
-
-  it("prefers registered adapters over declared capability fallback adapters with the same id", () => {
-    const registered = {
-      id: "openai",
-      create: async () => ({ provider: null }),
-    } satisfies EmbeddingProviderAdapter;
-    registerEmbeddingProvider({
-      ...registered,
-    });
-    mocks.resolvePluginCapabilityProviders.mockReturnValue([createCapabilityAdapter("openai")]);
-
-    expect(runtimeModule.getMemoryEmbeddingProvider("openai")?.id).toBe(registered.id);
-    expect(runtimeModule.listMemoryEmbeddingProviders().map((adapter) => adapter.id)).toEqual([
-      "openai-compatible",
-      "openai",
-    ]);
-    expect(mocks.resolvePluginCapabilityProviders).toHaveBeenCalledTimes(1);
   });
 
   it("returns generic provider, runtime, and identity objects unchanged", async () => {


### PR DESCRIPTION
Related: #130506

## What Problem This Solves

Memory embedding tests still repeat two generic resolver scenarios after the embedding contract unification made the memory facade delegate directly to the canonical resolver.

## Why This Change Was Made

Remove the duplicate registered/capability merge and same-ID precedence cases from the memory facade suite. Both remain in the canonical resolver suite, whose precedence assertion checks the complete adapter rather than only its ID. This removes 34 test lines without changing production code.

## User Impact

No user-visible change. The five retained memory facade tests still cover cold capability fallback, configured API aliases, registered adapters, provider/runtime identity and private memory metadata.

## Evidence

- The memory resolver, canonical resolver and registry suites passed before (19 tests) and after (17 tests), with no failures or skips. Exactly the two approved duplicate names disappeared; all remaining identities, order and results match.
- The rest of the changed file is byte-identical; canonical tests and production owner hashes are unchanged. Compared removed bodies with their retained canonical counterparts.
- `node scripts/check-changed.mjs -- src/plugins/memory-embedding-provider-runtime.test.ts` passed.
- Deslop and independent P2 review found no actionable issues.

No runtime-speed improvement is claimed.
