### PR TITLE
fix(openshell): backport structured gateway discovery

### DIFF
--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -21,7 +21,6 @@ const OPENCLAW_OPENSHELL_COMMAND =
 const OPENCLAW_OPENSHELL_CONFIG_HOME =
   process.env.OPENCLAW_E2E_OPENSHELL_CONFIG_HOME?.trim() || null;
 const OPENCLAW_OPENSHELL_HOST_IP = process.env.OPENCLAW_E2E_OPENSHELL_HOST_IP?.trim() || null;
-const ANSI_ESCAPE_RE = new RegExp(`${String.fromCharCode(0x1b)}\\[[0-?]*[ -/]*[@-~]`, "gu");
 
 const CUSTOM_IMAGE_DOCKERFILE = `FROM python:3.13-slim
 
@@ -128,6 +127,35 @@ async function commandAvailable(command: string): Promise<boolean> {
   }
 }
 
+function parseActiveLocalOpenShellGateway(stdout: string): string | null {
+  let gateways: unknown;
+  try {
+    gateways = JSON.parse(stdout);
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(gateways)) {
+    return null;
+  }
+  for (const gateway of gateways) {
+    if (
+      typeof gateway !== "object" ||
+      gateway === null ||
+      gateway.active !== true ||
+      typeof gateway.name !== "string" ||
+      typeof gateway.endpoint !== "string"
+    ) {
+      continue;
+    }
+    if (
+      /^(?:https?:\/\/)?(?:127\.0\.0\.1|localhost|\[::1\])(?::\d+)?(?:\/|$)/u.test(gateway.endpoint)
+    ) {
+      return gateway.name;
+    }
+  }
+  return null;
+}
+
 async function activeOpenShellGateway(
   command: string,
   env: NodeJS.ProcessEnv = process.env,
@@ -135,7 +163,7 @@ async function activeOpenShellGateway(
   try {
     const result = await runCommand({
       command,
-      args: ["gateway", "list"],
+      args: ["gateway", "list", "--output", "json"],
       env,
       allowFailure: true,
       timeoutMs: 20_000,
@@ -143,38 +171,18 @@ async function activeOpenShellGateway(
     if (result.code !== 0) {
       return null;
     }
-    const output = `${result.stdout}\n${result.stderr}`.replace(ANSI_ESCAPE_RE, "");
-    for (const line of output.split(/\r?\n/u)) {
-      const match = line.match(/\*\s+(\S+)/u);
-      if (match) {
-        const info = await runCommand({
-          command,
-          args: ["gateway", "info", "--gateway", match[1]],
-          env,
-          allowFailure: true,
-          timeoutMs: 20_000,
-        });
-        const endpoint = `${info.stdout}\n${info.stderr}`
-          .replace(ANSI_ESCAPE_RE, "")
-          .match(/Gateway endpoint:\s+(\S+)/u)?.[1];
-        if (
-          info.code === 0 &&
-          endpoint &&
-          /^(?:https?:\/\/)?(?:127\.0\.0\.1|localhost)(?::\d+)?(?:\/|$)/u.test(endpoint)
-        ) {
-          const status = await runCommand({
-            command,
-            args: ["--gateway", match[1], "sandbox", "list"],
-            env,
-            allowFailure: true,
-            timeoutMs: 20_000,
-          });
-          return status.code === 0 ? match[1] : null;
-        }
-        return null;
-      }
+    const gateway = parseActiveLocalOpenShellGateway(result.stdout);
+    if (!gateway) {
+      return null;
     }
-    return null;
+    const status = await runCommand({
+      command,
+      args: ["--gateway", gateway, "sandbox", "list"],
+      env,
+      allowFailure: true,
+      timeoutMs: 20_000,
+    });
+    return status.code === 0 ? gateway : null;
   } catch {
     return null;
   }
@@ -427,6 +435,29 @@ async function runBackendExec(params: {
     });
   }
 }
+
+describe("OpenShell gateway discovery", () => {
+  it("selects the active local gateway from structured output", () => {
+    expect(
+      parseActiveLocalOpenShellGateway(
+        JSON.stringify([
+          { name: "remote", endpoint: "https://gateway.example.com", active: false },
+          { name: "openshell", endpoint: "https://127.0.0.1:17670", active: true },
+        ]),
+      ),
+    ).toBe("openshell");
+  });
+
+  it.each([
+    ["malformed output", "not json"],
+    [
+      "active remote gateway",
+      JSON.stringify([{ name: "remote", endpoint: "https://gateway.example.com", active: true }]),
+    ],
+  ])("rejects %s", (_name, output) => {
+    expect(parseActiveLocalOpenShellGateway(output)).toBeNull();
+  });
+});
 
 describe("openshell sandbox backend e2e", () => {
   it.runIf(process.platform !== "win32" && OPENCLAW_OPENSHELL_E2E)(


### PR DESCRIPTION
## Summary
- discover the active OpenShell gateway from `gateway list --output json`
- require an active loopback endpoint and prove it with `sandbox list`
- retain fail-closed behavior for malformed or remote-only gateway output

## Validation
- `node scripts/run-vitest.mjs run extensions/openshell/src/backend.e2e.test.ts` (3 passed, 1 E2E skipped)
- `oxfmt --check`
- `git diff --check`

## Release context
2026.7.33 Full Validation installed OpenShell 0.0.109 and started the local gateway successfully, but the candidate E2E still parsed the removed table/info CLI shape. Current main already uses the structured JSON contract; this is the minimal stable backport.
