### PR TITLE
fix(release): declare 7.33 Telegram evidence contract

### DIFF
--- a/qa/contracts/telegram-execution-evidence.json
+++ b/qa/contracts/telegram-execution-evidence.json
@@ -1,0 +1,6 @@
+{
+  "version": 1,
+  "kind": "openclaw-release-telegram-execution-evidence",
+  "mode": "legacy-direct-runner-v1",
+  "candidateVersion": "2026.7.33"
+}


### PR DESCRIPTION
## Summary
- declare the reviewed 2026.7.33 Telegram execution-evidence mode
- let trusted current tooling finalize the already-successful live lane with the candidate's legacy direct-runner evidence shape

## Validation
- exact schema/key/mode/version check with `jq -e`
- `git diff --check`

## Release context
All 13 Telegram live scenarios passed for the immutable 2026.7.33 candidate. Evidence finalization failed because this historical candidate predates runtime-boundary evidence and did not carry the target-owned legacy contract consumed by the trusted harness.
