### PR TITLE
fix: preserve native CLI auth status in model lists

### DIFF
--- a/src/agents/model-auth-availability.ts
+++ b/src/agents/model-auth-availability.ts
@@ -112,6 +112,8 @@ export type ModelAuthAvailabilityRef = {
 };
 export type ModelAuthAvailabilityEvaluation = {
   availability: ModelAuthAvailability;
+  /** A runtime-owned result must not fall back to provider-only registry auth. */
+  availabilityAuthoritative?: true;
   unavailableReason?: "missing-auth" | "auth-failed" | "cooldown";
   /** Earliest known retry time, in milliseconds since the Unix epoch. */
   unavailableUntil?: number;
@@ -139,15 +141,15 @@ export type ModelAuthAvailabilityResolver = {
   hasSyntheticAuth(provider: string): boolean;
 };
 
-function applyCliRuntimeModelAuthAvailability(
+function evaluateCliRuntimeModelAuthAvailability(
   params: CreateModelAuthAvailabilityResolverParams,
   provider: string,
   ref: ModelAuthAvailabilityRef,
   evaluation: ModelAuthAvailabilityEvaluation,
   evaluateProviderAuth: ModelAuthAvailabilityResolver["evaluateModelAuth"],
-): ModelAuthAvailabilityEvaluation {
+): ModelAuthAvailabilityEvaluation | undefined {
   if (evaluation.routeResolution !== null || normalizeProviderId(provider) === "openai") {
-    return evaluation;
+    return undefined;
   }
   const selectedProfileId = ref.pinnedProfileId?.trim() || ref.preferredProfileId?.trim();
   // Direct CLI refs have no alias, but still own plugin and selected-account checks.
@@ -197,7 +199,7 @@ function applyCliRuntimeModelAuthAvailability(
       : evaluation;
   }
   if (normalizeProviderId(runtimeProvider) === normalizeProviderId(provider)) {
-    return evaluation;
+    return runtimeOwners?.length ? evaluation : undefined;
   }
   const runtimeAuthMode =
     params.preparedRuntimeAuthModes?.[normalizeProviderIdForAuth(runtimeProvider)];
@@ -1395,13 +1397,16 @@ export function createModelAuthAvailabilityResolver(
       if (ref.requiredProfileId?.trim()) {
         return evaluation;
       }
-      return applyCliRuntimeModelAuthAvailability(
+      const runtimeEvaluation = evaluateCliRuntimeModelAuthAvailability(
         params,
         provider,
         ref,
         evaluation,
         evaluateModelAuth,
       );
+      return runtimeEvaluation
+        ? { ...runtimeEvaluation, availabilityAuthoritative: true }
+        : evaluation;
     },
     resolveProviderAuthAvailability,
     hasSyntheticAuth: (provider) =>

--- a/src/commands/models/list.list-command.forward-compat.test.ts
+++ b/src/commands/models/list.list-command.forward-compat.test.ts
@@ -1191,16 +1191,27 @@ describe("modelsListCommand forward-compat", () => {
       {
         authModes: { "claude-cli": "api_key" as const },
         providerApiKey: false,
+        registryAvailableKeys: new Set<string>(),
         available: true,
       },
-      { authModes: {}, providerApiKey: false, available: null },
-      { authModes: {}, providerApiKey: true, available: null },
+      {
+        authModes: {},
+        providerApiKey: false,
+        registryAvailableKeys: new Set<string>(),
+        available: null,
+      },
+      {
+        authModes: {},
+        providerApiKey: true,
+        registryAvailableKeys: new Set(["anthropic/claude-opus-5"]),
+        available: null,
+      },
     ])(
       "uses the prepared CLI runtime auth result ($available) with provider key=$providerApiKey",
-      async ({ authModes, providerApiKey, available }) => {
+      async ({ authModes, providerApiKey, registryAvailableKeys, available }) => {
         vi.stubEnv("ANTHROPIC_API_KEY", providerApiKey ? "test-key" : "");
         const config = configureClaudeRuntime();
-        primeModelRegistry([ANTHROPIC_CLI_MODEL]);
+        primeModelRegistry([ANTHROPIC_CLI_MODEL], registryAvailableKeys);
         mocks.prepareScopedReadOnlyModelAuthModes.mockResolvedValueOnce(authModes);
 
         await modelsListCommand({ provider: "anthropic", json: true }, createRuntime() as never);
@@ -1233,7 +1244,7 @@ describe("modelsListCommand forward-compat", () => {
       mocks.prepareScopedReadOnlyModelAuthModes.mockResolvedValueOnce({
         "claude-cli": "api_key",
       });
-      primeModelRegistry([ANTHROPIC_CLI_MODEL]);
+      primeModelRegistry([ANTHROPIC_CLI_MODEL], new Set(["anthropic/claude-opus-5"]));
 
       await modelsListCommand({ provider: "anthropic", json: true }, createRuntime() as never);
 

--- a/src/commands/models/list.rows.ts
+++ b/src/commands/models/list.rows.ts
@@ -182,6 +182,7 @@ function buildRow(params: {
     authAvailability: params.authEvaluation.availability,
     authAvailabilityAuthoritative:
       params.allowAuthAvailabilityOverride === true ||
+      params.authEvaluation.availabilityAuthoritative === true ||
       normalizeProviderIdForAuth(params.model.provider) === "openai" ||
       params.authEvaluation.routeResolution !== null,
   });


### PR DESCRIPTION
## What Problem This Solves

Native-runtime model lists could report availability from an unrelated provider key when native authentication was unknown, or hide authentication reported by the native program.

## Why This Change Was Made

The shared native-auth evaluator now carries its authority into list rows so provider-registry hints cannot overwrite it. Ordinary registry precedence remains.

## User Impact

Model lists preserve the selected native runtime’s available, unavailable, or unknown state while staying lazy. Listing still does not establish execution readiness.

## Evidence

Matched CLI runs used the installed native program and real auth-status output in isolated state. A provider key no longer turned unknown native auth into available; native configured auth remained available without a provider key. All four listing commands succeeded and preserved metadata. Ten focused native, registry, route, and mode checks passed. Artificial credentials tested local configuration only, without real login or inference.
