### PR TITLE
refactor(sdk): reuse UTF-8 report truncation

### DIFF
--- a/src/plugin-sdk/api-diff.ts
+++ b/src/plugin-sdk/api-diff.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
+import { truncateUtf8Prefix } from "../utils/utf8-truncate.js";
 import type { PluginSdkApiDeclarationSection } from "./api-baseline-declaration-closure.js";
 import { renderPluginSdkApiBaseline, type PluginSdkApiExport } from "./api-baseline.js";
 
@@ -387,22 +388,6 @@ function appendText(lines: string[], label: "after" | "before", text: string | n
   }
 }
 
-function truncateUtf8(text: string, maxBytes: number): string {
-  const bytes = Buffer.from(text, "utf8");
-  if (bytes.length <= maxBytes) {
-    return text;
-  }
-  let end = maxBytes;
-  while (end > 0) {
-    const excludedByte = bytes[end];
-    if (excludedByte === undefined || (excludedByte & 0xc0) !== 0x80) {
-      break;
-    }
-    end -= 1;
-  }
-  return bytes.subarray(0, end).toString("utf8");
-}
-
 function appendExportChanges(
   lines: string[],
   title: string,
@@ -522,5 +507,5 @@ export function formatPluginSdkApiDiffReport(params: {
     return report;
   }
   const suffix = "\n\n… summary truncated; inspect the JSON artifact.\n";
-  return `${truncateUtf8(report, REPORT_BYTE_LIMIT - Buffer.byteLength(suffix, "utf8"))}${suffix}`;
+  return `${truncateUtf8Prefix(report, REPORT_BYTE_LIMIT - Buffer.byteLength(suffix, "utf8"))}${suffix}`;
 }


### PR DESCRIPTION
## What Problem This Solves

The internal Plugin SDK API-diff report duplicated the shared UTF-8 prefix truncator and encoded the entire oversized report before retaining its bounded prefix.

## Why This Change Was Made

Use the existing prefix helper and delete the private copy. The helper bounds the intermediate encoding work while retaining the report’s fixed 64 KiB limit and existing truncation suffix.

## User Impact

Report content and byte-boundary behavior remain unchanged. This removes 15 tooling lines without changing public SDK entrypoints, report ordering, acknowledgement digests, or the separately generated JSON artifact.

## Evidence

The same 19 existing tests pass before and after: the actual report multibyte-limit case and 18 shared UTF-8 cases. All 33 canonical changed checks pass, including the relevant type graphs and SDK boundary checks. Independent Codex P0–P2 review found no actionable findings. Surrogate and BOM behavior were checked against both implementations for the report’s fixed integer budget. No new tests, exports, or dependency changes were added; no performance benchmark is claimed.
