### PR TITLE
refactor(tasks): require atomic store writes

### DIFF
--- a/scripts/bench-agent-concurrency-worker.ts
+++ b/scripts/bench-agent-concurrency-worker.ts
@@ -228,20 +228,15 @@ async function configureSpawnRuntime(
     taskStore.configureTaskRegistryRuntime({
       store: {
         loadSnapshot: () => ({ tasks: new Map(), deliveryStates: new Map() }),
-        saveSnapshot: () => {},
         upsertTaskWithDeliveryState: () => {},
-        upsertTask: () => {},
         deleteTaskWithDeliveryState: () => {},
-        deleteTask: () => {},
         upsertDeliveryState: () => {},
-        deleteDeliveryState: () => {},
         close: () => {},
       },
     });
     flowStore.configureTaskFlowRegistryRuntime({
       store: {
         loadSnapshot: () => ({ flows: new Map() }),
-        saveSnapshot: () => {},
         upsertFlow: () => {},
         deleteFlow: () => {},
         close: () => {},

--- a/src/audit/execution-owner-lifecycle-binding-store.ts
+++ b/src/audit/execution-owner-lifecycle-binding-store.ts
@@ -18,7 +18,7 @@ type ExecutionOwnerLifecycleKind = "cron" | "task" | "flow";
 
 type ExecutionOwnerLifecycleDatabase = Pick<
   OpenClawStateDatabase,
-  "cron_run_receipts" | "execution_owner_lifecycle_bindings" | "flow_runs" | "task_runs"
+  "execution_owner_lifecycle_bindings"
 >;
 
 const SCHEMA_START = `CREATE TABLE IF NOT EXISTS ${EXECUTION_OWNER_LIFECYCLE_BINDING_TABLE} (`;
@@ -118,38 +118,4 @@ export function deleteExecutionOwnerLifecycleMetadata(params: {
       .where("owner_kind", "=", params.ownerKind)
       .where("owner_id", "in", params.ownerIds),
   );
-}
-
-/** Removes bindings whose canonical owner row was pruned in the same transaction. */
-export function pruneOrphanedExecutionOwnerLifecycleMetadata(
-  db: DatabaseSync,
-  ownerKind: ExecutionOwnerLifecycleKind,
-): void {
-  if (!tableExists(db, EXECUTION_OWNER_LIFECYCLE_BINDING_TABLE)) {
-    return;
-  }
-  const database = lifecycleDb(db);
-  const bindings = database
-    .deleteFrom(EXECUTION_OWNER_LIFECYCLE_BINDING_TABLE)
-    .where("owner_kind", "=", ownerKind);
-  if (ownerKind === "cron") {
-    executeSqliteQuerySync(
-      db,
-      bindings.where(
-        "owner_id",
-        "not in",
-        database.selectFrom("cron_run_receipts").select("receipt_id"),
-      ),
-    );
-  } else if (ownerKind === "task") {
-    executeSqliteQuerySync(
-      db,
-      bindings.where("owner_id", "not in", database.selectFrom("task_runs").select("task_id")),
-    );
-  } else {
-    executeSqliteQuerySync(
-      db,
-      bindings.where("owner_id", "not in", database.selectFrom("flow_runs").select("flow_id")),
-    );
-  }
 }

--- a/src/auto-reply/reply/commands-acp.test.ts
+++ b/src/auto-reply/reply/commands-acp.test.ts
@@ -164,13 +164,9 @@ function configureInMemoryTaskRegistryStoreForTests(): void {
         tasks: new Map(),
         deliveryStates: new Map(),
       }),
-      saveSnapshot: () => {},
       upsertTaskWithDeliveryState: () => {},
-      upsertTask: () => {},
       deleteTaskWithDeliveryState: () => {},
-      deleteTask: () => {},
       upsertDeliveryState: () => {},
-      deleteDeliveryState: () => {},
       close: () => {},
     },
   });

--- a/src/auto-reply/reply/commands.test-harness.ts
+++ b/src/auto-reply/reply/commands.test-harness.ts
@@ -66,13 +66,9 @@ export function configureInMemoryTaskRegistryStoreForTests(): void {
         tasks: new Map(),
         deliveryStates: new Map(),
       }),
-      saveSnapshot: () => {},
       upsertTaskWithDeliveryState: () => {},
-      upsertTask: () => {},
       deleteTaskWithDeliveryState: () => {},
-      deleteTask: () => {},
       upsertDeliveryState: () => {},
-      deleteDeliveryState: () => {},
       close: () => {},
     },
   });

--- a/src/commands/tasks-json.test.ts
+++ b/src/commands/tasks-json.test.ts
@@ -21,6 +21,7 @@ import type {
   TaskSystemAuditSeverity,
 } from "../tasks/task-system-audit.types.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createInMemoryTaskFlowRegistryStore } from "../test-utils/task-registry-store.js";
 import { tasksAuditJsonCommand, tasksListJsonCommand } from "./tasks-json.js";
 import { tasksListCommand, tasksShowCommand } from "./tasks.js";
 
@@ -385,8 +386,8 @@ describe("tasks JSON commands", () => {
       });
       configureTaskFlowRegistryRuntime({
         store: {
+          ...createInMemoryTaskFlowRegistryStore(),
           loadSnapshot,
-          saveSnapshot: () => {},
         },
       });
       const runtime = createRuntime();

--- a/src/commands/tasks.test.ts
+++ b/src/commands/tasks.test.ts
@@ -31,6 +31,7 @@ import type {
 } from "../tasks/task-system-audit.types.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createInMemoryTaskFlowRegistryStore } from "../test-utils/task-registry-store.js";
 import {
   tasksAuditCommand,
   tasksCancelCommand,
@@ -241,8 +242,8 @@ describe("tasks commands", () => {
       });
       configureTaskFlowRegistryRuntime({
         store: {
+          ...createInMemoryTaskFlowRegistryStore(),
           loadSnapshot,
-          saveSnapshot: () => {},
         },
       });
 
@@ -959,13 +960,11 @@ describe("tasks commands", () => {
         const loadSnapshot = vi.fn(() => {
           throw new Error("SQLITE_CORRUPT: task-flow maintenance restore failed");
         });
-        const saveSnapshot = vi.fn();
         const upsertFlow = vi.fn();
         const deleteFlow = vi.fn();
         configureTaskFlowRegistryRuntime({
           store: {
             loadSnapshot,
-            saveSnapshot,
             upsertFlow,
             deleteFlow,
           },
@@ -977,7 +976,6 @@ describe("tasks commands", () => {
         );
 
         expect(loadSnapshot).toHaveBeenCalledTimes(1);
-        expect(saveSnapshot).not.toHaveBeenCalled();
         expect(upsertFlow).not.toHaveBeenCalled();
         expect(deleteFlow).not.toHaveBeenCalled();
         expect(runtime.log).not.toHaveBeenCalled();

--- a/src/cron/task-run-history.test.ts
+++ b/src/cron/task-run-history.test.ts
@@ -2,10 +2,10 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
 import { FAILOVER_REASONS } from "../../packages/gateway-protocol/src/failover-reasons.js";
-import { saveTaskRegistryStateToSqlite } from "../tasks/task-registry.store.sqlite.js";
 import type { TaskRecord } from "../tasks/task-registry.types.js";
 import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { seedTaskRegistryRowsForTests } from "../test-utils/task-registry-sqlite.js";
 import type { CronRunLogEntry } from "./run-log-types.js";
 import { CronService } from "./service.js";
 import { createNoopLogger } from "./service.test-harness.js";
@@ -312,12 +312,11 @@ describe("cron task run history", () => {
             nextRunAtMs: 5_000,
           },
         ];
-        saveTaskRegistryStateToSqlite({
-          tasks: new Map(
+        seedTaskRegistryRowsForTests(
+          new Map(
             entries.map((entry, index) => [`task-${index}`, taskFromEntry(entry, index, storeKey)]),
-          ),
-          deliveryStates: new Map(),
-        });
+          ).values(),
+        );
         const ledger = readCronTaskRunHistoryPage({ storeKey, jobId: JOB_ID, limit: 50 });
         const expected = entries
           .map((entry, index) => cronTaskRecordToRunLogEntry(taskFromEntry(entry, index, storeKey)))
@@ -373,8 +372,8 @@ describe("cron task run history", () => {
             durationMs: 0,
           },
         ];
-        saveTaskRegistryStateToSqlite({
-          tasks: new Map([
+        seedTaskRegistryRowsForTests(
+          new Map([
             ...entries.map(
               (entry, index) => [`task-${index}`, taskFromEntry(entry, index, storeKey)] as const,
             ),
@@ -404,9 +403,8 @@ describe("cron task run history", () => {
                 detail: { kind: "cron-run", status: "ok" },
               },
             ] as const,
-          ]),
-          deliveryStates: new Map(),
-        });
+          ]).values(),
+        );
 
         expect(
           readCronTaskRunHistoryPage({ storeKey, jobId: JOB_ID, limit: 1, offset: 1 }),
@@ -451,13 +449,12 @@ describe("cron task run history", () => {
           status: "error",
           error: "store b",
         };
-        saveTaskRegistryStateToSqlite({
-          tasks: new Map([
+        seedTaskRegistryRowsForTests(
+          new Map([
             ["store-a", { ...taskFromEntry(entryA, 1, storeA), taskId: "store-a" }],
             ["store-b", { ...taskFromEntry(entryB, 2, storeB), taskId: "store-b" }],
-          ]),
-          deliveryStates: new Map(),
-        });
+          ]).values(),
+        );
 
         expect(readCronTaskRunHistoryPage({ storeKey: storeA, jobId: JOB_ID })).toMatchObject({
           entries: [expect.objectContaining({ summary: "store a" })],

--- a/src/gateway/server-methods/cron.runs.test.ts
+++ b/src/gateway/server-methods/cron.runs.test.ts
@@ -9,9 +9,9 @@ import {
   cronRunLogEntryToTaskDetail,
   cronRunStatusToTaskStatus,
 } from "../../cron/task-run-detail.js";
-import { saveTaskRegistryStateToSqlite } from "../../tasks/task-registry.store.sqlite.js";
 import type { TaskRecord } from "../../tasks/task-registry.types.js";
 import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { seedTaskRegistryRowsForTests } from "../../test-utils/task-registry-sqlite.js";
 import { createDirectChatContext } from "../server-chat.agent-events.test-helpers.js";
 import { roleClient, rolePolicyConfig } from "../session-sharing.test-utils.js";
 import { cronHandlers } from "./cron.js";
@@ -120,10 +120,7 @@ async function withCronHistory(
           detail: cronRunLogEntryToTaskDetail(entry, { storeKey: cronStoreKey(storePath) }),
         };
       });
-      saveTaskRegistryStateToSqlite({
-        tasks: new Map(tasks.map((task) => [task.taskId, task])),
-        deliveryStates: new Map(),
-      });
+      seedTaskRegistryRowsForTests(new Map(tasks.map((task) => [task.taskId, task])).values());
       const context = createDirectChatContext({
         cron,
         cronStorePath: storePath,

--- a/src/gateway/server-methods/tasks.access.test.ts
+++ b/src/gateway/server-methods/tasks.access.test.ts
@@ -10,9 +10,9 @@ import {
 import { ensureProfileForEmail } from "../../state/user-profiles.js";
 import { deleteTaskRecordById } from "../../tasks/runtime-internal.js";
 import { reloadTaskRegistryFromStore } from "../../tasks/task-registry.js";
-import { saveTaskRegistryStateToSqlite } from "../../tasks/task-registry.store.sqlite.js";
 import { resetTaskRegistryForTests } from "../../tasks/task-runtime.test-helpers.js";
 import { createOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { seedTaskRegistryRowsForTests } from "../../test-utils/task-registry-sqlite.js";
 import { readGatewayAccessRevision } from "../gateway-access-revision.js";
 import { rolePolicyConfig } from "../session-sharing.test-utils.js";
 import { sessionSharingHandlers } from "./sessions-sharing.js";
@@ -75,10 +75,7 @@ describe("task page access snapshots", () => {
           lastEventAt: 2_000 + index,
         }),
       );
-      saveTaskRegistryStateToSqlite({
-        tasks: new Map(tasks.map((task) => [task.taskId, task])),
-        deliveryStates: new Map(),
-      });
+      seedTaskRegistryRowsForTests(tasks);
       reloadTaskRegistryFromStore();
       if (!warm) {
         closeOpenClawAgentDatabasesForTest();
@@ -182,10 +179,7 @@ describe("task page access snapshots", () => {
         lastEventAt: index === changingIndex ? 10_000 : 2_000 + index,
       }),
     );
-    saveTaskRegistryStateToSqlite({
-      tasks: new Map(tasks.map((task) => [task.taskId, task])),
-      deliveryStates: new Map(),
-    });
+    seedTaskRegistryRowsForTests(tasks);
     reloadTaskRegistryFromStore();
     const context = {
       getRuntimeConfig: () => config,

--- a/src/gateway/server-methods/tasks.test.ts
+++ b/src/gateway/server-methods/tasks.test.ts
@@ -26,7 +26,6 @@ import {
   recordTaskProgressByRunId,
 } from "../../tasks/runtime-internal.js";
 import { reloadTaskRegistryFromStore } from "../../tasks/task-registry.js";
-import { saveTaskRegistryStateToSqlite } from "../../tasks/task-registry.store.sqlite.js";
 import type { TaskRecord } from "../../tasks/task-registry.types.js";
 import {
   resetTaskRegistryControlRuntimeForTests,
@@ -34,6 +33,7 @@ import {
   setTaskRegistryControlRuntimeForTests,
 } from "../../tasks/task-runtime.test-helpers.js";
 import { captureEnv, setTestEnvValue } from "../../test-utils/env.js";
+import { seedTaskRegistryRowsForTests } from "../../test-utils/task-registry-sqlite.js";
 import {
   createContext,
   createSnapshotTask,
@@ -228,13 +228,7 @@ describe("tasks gateway handlers", () => {
       lastEventAt: base - 2_000,
       endedAt: base - 3_000,
     });
-    saveTaskRegistryStateToSqlite({
-      tasks: new Map([
-        [justFinished.taskId, justFinished],
-        [finishedEarlier.taskId, finishedEarlier],
-      ]),
-      deliveryStates: new Map(),
-    });
+    seedTaskRegistryRowsForTests([justFinished, finishedEarlier]);
     reloadTaskRegistryFromStore();
 
     const { payload } = await runTaskHandler("tasks.list", {});
@@ -267,13 +261,7 @@ describe("tasks gateway handlers", () => {
       lastEventAt: base - 4_000,
       endedAt: base - 500,
     });
-    saveTaskRegistryStateToSqlite({
-      tasks: new Map([
-        [laterActivity.taskId, laterActivity],
-        [laterCompletion.taskId, laterCompletion],
-      ]),
-      deliveryStates: new Map(),
-    });
+    seedTaskRegistryRowsForTests([laterActivity, laterCompletion]);
     reloadTaskRegistryFromStore();
 
     const { payload } = await runTaskHandler("tasks.list", {});
@@ -403,13 +391,7 @@ describe("tasks gateway handlers", () => {
       runId: "run-a",
       lastEventAt: sharedActivityAt,
     });
-    saveTaskRegistryStateToSqlite({
-      tasks: new Map([
-        [laterId.taskId, laterId],
-        [earlierId.taskId, earlierId],
-      ]),
-      deliveryStates: new Map(),
-    });
+    seedTaskRegistryRowsForTests([laterId, earlierId]);
     reloadTaskRegistryFromStore();
 
     const { payload } = await runTaskHandler("tasks.list", {});
@@ -944,13 +926,7 @@ describe("tasks gateway handlers", () => {
       startedAt: 1_011,
       lastEventAt: 1_011,
     });
-    saveTaskRegistryStateToSqlite({
-      tasks: new Map([
-        [task.taskId, task],
-        [siblingTask.taskId, siblingTask],
-      ]),
-      deliveryStates: new Map(),
-    });
+    seedTaskRegistryRowsForTests([task, siblingTask]);
     reloadTaskRegistryFromStore();
     cancelSessionMock.mockResolvedValue(undefined);
 

--- a/src/gateway/server.tasks-list-performance.test.ts
+++ b/src/gateway/server.tasks-list-performance.test.ts
@@ -11,6 +11,7 @@ import {
 } from "../tasks/runtime-internal.js";
 import { configureTaskRegistryRuntime } from "../tasks/task-registry.store.js";
 import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
+import { createInMemoryTaskRegistryStore } from "../test-utils/task-registry-store.js";
 import { installGatewayTestHooks } from "./server.auth.test-helpers.js";
 import {
   createTaskSnapshot,
@@ -48,11 +49,11 @@ describe("tasks.list Gateway performance", () => {
       resetTaskRegistryForTests({ persist: false });
       configureTaskRegistryRuntime({
         store: {
+          ...createInMemoryTaskRegistryStore(),
           loadSnapshot: () => {
             onSnapshotLoad?.();
             return { tasks, deliveryStates: new Map() };
           },
-          saveSnapshot: () => {},
         },
       });
     };
@@ -236,6 +237,7 @@ describe("tasks.list Gateway performance", () => {
         };
         configureTaskRegistryRuntime({
           store: {
+            ...createInMemoryTaskRegistryStore(),
             loadSnapshot: () => {
               if (!convergingChurnStarted) {
                 convergingChurnStarted = true;
@@ -243,7 +245,6 @@ describe("tasks.list Gateway performance", () => {
               }
               return { tasks: convergingTasks, deliveryStates: new Map() };
             },
-            saveSnapshot: () => {},
           },
         });
         const convergedRegistry = await sendRpc<TasksListResult>(
@@ -279,6 +280,7 @@ describe("tasks.list Gateway performance", () => {
         };
         configureTaskRegistryRuntime({
           store: {
+            ...createInMemoryTaskRegistryStore(),
             loadSnapshot: () => {
               if (!taskChurnStarted) {
                 taskChurnStarted = true;
@@ -286,7 +288,6 @@ describe("tasks.list Gateway performance", () => {
               }
               return { tasks: churnTasks, deliveryStates: new Map() };
             },
-            saveSnapshot: () => {},
           },
         });
         const unstableRegistry = await sendRpc<Record<string, unknown>>(
@@ -330,11 +331,11 @@ describe("tasks.list Gateway performance", () => {
         resetTaskRegistryForTests({ persist: false });
         configureTaskRegistryRuntime({
           store: {
+            ...createInMemoryTaskRegistryStore(),
             loadSnapshot: () => {
               scopedChurn = setImmediate(mutateUnrelatedTask);
               return { tasks: scopedTasks, deliveryStates: new Map() };
             },
-            saveSnapshot: () => {},
           },
         });
         try {
@@ -354,8 +355,8 @@ describe("tasks.list Gateway performance", () => {
         resetTaskRegistryForTests({ persist: false });
         configureTaskRegistryRuntime({
           store: {
+            ...createInMemoryTaskRegistryStore(),
             loadSnapshot: () => ({ tasks: accessTasks, deliveryStates: new Map() }),
-            saveSnapshot: () => {},
           },
         });
         let accessChurnActive = true;

--- a/src/gateway/server.tasks-profile-merge.test.ts
+++ b/src/gateway/server.tasks-profile-merge.test.ts
@@ -11,6 +11,7 @@ import { ensureProfileForEmail, setUserProfileRole } from "../state/user-profile
 import { configureTaskRegistryRuntime } from "../tasks/task-registry.store.js";
 import type { TaskRecord } from "../tasks/task-registry.types.js";
 import { resetTaskRegistryForTests } from "../tasks/task-runtime.test-helpers.js";
+import { createInMemoryTaskRegistryStore } from "../test-utils/task-registry-store.js";
 import { invalidateOperatorRolePolicy } from "./operator-role-policy.js";
 import {
   connectReq,
@@ -100,8 +101,8 @@ test("expires task cursors when a profile merge changes the same caller's sessio
       resetTaskRegistryForTests({ persist: false });
       configureTaskRegistryRuntime({
         store: {
+          ...createInMemoryTaskRegistryStore(),
           loadSnapshot: () => ({ tasks, deliveryStates: new Map() }),
-          saveSnapshot: () => {},
         },
       });
       const stateDir = process.env.OPENCLAW_STATE_DIR;

--- a/src/gateway/server/__tests__/server.tasks-list-metadata.test.ts
+++ b/src/gateway/server/__tests__/server.tasks-list-metadata.test.ts
@@ -5,6 +5,7 @@ import { listTaskRecordsUnsorted } from "../../../tasks/runtime-internal.js";
 import { configureTaskRegistryRuntime } from "../../../tasks/task-registry.store.js";
 import type { TaskRecord } from "../../../tasks/task-registry.types.js";
 import { resetTaskRegistryForTests } from "../../../tasks/task-runtime.test-helpers.js";
+import { createInMemoryTaskRegistryStore } from "../../../test-utils/task-registry-store.js";
 import { installGatewayTestHooks } from "../../server.auth.test-helpers.js";
 import {
   createTaskSnapshot,
@@ -28,11 +29,11 @@ test("preserves task pagination during metadata patches but invalidates new requ
     resetTaskRegistryForTests({ persist: false });
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => ({
           tasks: new Map([...createTaskSnapshot()].slice(0, 256)),
           deliveryStates: new Map(),
         }),
-        saveSnapshot: () => {},
       },
     });
   };
@@ -136,11 +137,11 @@ test("preserves task pagination during metadata patches but invalidates new requ
     resetTaskRegistryForTests({ persist: false });
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => ({
           tasks: new Map([...metadataTasks, missingSessionTask].map((task) => [task.taskId, task])),
           deliveryStates: new Map(),
         }),
-        saveSnapshot: () => {},
       },
     });
     const beforeCreation = await sendRpc<TasksListResult>(

--- a/src/tasks/task-executor.test.ts
+++ b/src/tasks/task-executor.test.ts
@@ -4,6 +4,7 @@ import { emitAgentEvent, resetAgentEventsForTest } from "../infra/agent-events.j
 import { resetSystemEventsForTest } from "../infra/system-events.js";
 import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
 import { captureEnv } from "../test-utils/env.js";
+import { createInMemoryTaskFlowRegistryStore } from "../test-utils/task-registry-store.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "./detached-task-runtime-contract.js";
 import { getDetachedTaskLifecycleRuntime } from "./detached-task-runtime.js";
 import { createSubagentTaskBackingDetail } from "./task-backing-authority.js";
@@ -394,8 +395,8 @@ describe("task-executor", () => {
       });
       configureTaskFlowRegistryRuntime({
         store: {
+          ...createInMemoryTaskFlowRegistryStore(),
           loadSnapshot,
-          saveSnapshot: () => {},
         },
       });
 
@@ -934,10 +935,10 @@ describe("task-executor", () => {
       resetTaskFlowRegistryForTests({ persist: false });
       configureTaskFlowRegistryRuntime({
         store: {
+          ...createInMemoryTaskFlowRegistryStore(),
           loadSnapshot: () => {
             throw new Error("SQLITE_IOERR: cancellation flow restore failed");
           },
-          saveSnapshot: () => {},
         },
       });
 
@@ -1106,10 +1107,10 @@ describe("task-executor", () => {
       resetTaskFlowRegistryForTests({ persist: false });
       configureTaskFlowRegistryRuntime({
         store: {
+          ...createInMemoryTaskFlowRegistryStore(),
           loadSnapshot: () => {
             throw new Error("SQLITE_IOERR: provisional cancellation restore failed");
           },
-          saveSnapshot: () => {},
         },
       });
 

--- a/src/tasks/task-flow-owner-access.test.ts
+++ b/src/tasks/task-flow-owner-access.test.ts
@@ -28,7 +28,6 @@ beforeEach(() => {
   configureTaskFlowRegistryRuntime({
     store: {
       loadSnapshot: () => ({ flows: new Map() }),
-      saveSnapshot: () => {},
       upsertFlow: () => {},
       deleteFlow: () => {},
     },

--- a/src/tasks/task-flow-registry.audit.test.ts
+++ b/src/tasks/task-flow-registry.audit.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { captureEnv } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createInMemoryTaskFlowRegistryStore } from "../test-utils/task-registry-store.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "./detached-task-runtime-contract.js";
 import {
   createRunningTaskRunCore as createRunningTaskRunOrNull,
@@ -95,8 +96,8 @@ describe("task-flow-registry audit", () => {
     });
     configureTaskFlowRegistryRuntime({
       store: {
+        ...createInMemoryTaskFlowRegistryStore(),
         loadSnapshot,
-        saveSnapshot: () => {},
       },
     });
 
@@ -113,10 +114,10 @@ describe("task-flow-registry audit", () => {
   it("clears restore-failed findings after a clean reset and restore", () => {
     configureTaskFlowRegistryRuntime({
       store: {
+        ...createInMemoryTaskFlowRegistryStore(),
         loadSnapshot: () => {
           throw new Error("boom");
         },
-        saveSnapshot: () => {},
       },
     });
 
@@ -127,10 +128,10 @@ describe("task-flow-registry audit", () => {
     resetTaskFlowRegistryForTests({ persist: false });
     configureTaskFlowRegistryRuntime({
       store: {
+        ...createInMemoryTaskFlowRegistryStore(),
         loadSnapshot: () => ({
           flows: new Map(),
         }),
-        saveSnapshot: () => {},
       },
     });
 

--- a/src/tasks/task-flow-registry.store.sqlite.ts
+++ b/src/tasks/task-flow-registry.store.sqlite.ts
@@ -9,7 +9,6 @@ import {
 import {
   bindExecutionOwnerLifecycleMetadata,
   deleteExecutionOwnerLifecycleMetadata,
-  pruneOrphanedExecutionOwnerLifecycleMetadata,
 } from "../audit/execution-owner-lifecycle-binding-store.js";
 import {
   executeSqliteQuerySync,
@@ -150,24 +149,6 @@ function getFlowRegistryKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<FlowRegistryStoreDatabase>(db);
 }
 
-function pruneFlowsNotInSnapshot(params: { db: DatabaseSync; ids: readonly string[] }) {
-  const tempTableName = "openclaw_live_flow_ids";
-  params.db.exec(`CREATE TEMP TABLE IF NOT EXISTS ${tempTableName} (id TEXT PRIMARY KEY)`);
-  params.db.exec(`DELETE FROM ${tempTableName}`);
-  const insert = params.db.prepare(`INSERT OR IGNORE INTO ${tempTableName} (id) VALUES (?)`);
-  for (const id of params.ids) {
-    insert.run(id);
-  }
-  params.db.exec(`
-    DELETE FROM flow_runs
-    WHERE NOT EXISTS (
-      SELECT 1 FROM ${tempTableName}
-      WHERE ${tempTableName}.id = flow_runs.flow_id
-    )
-  `);
-  params.db.exec(`DELETE FROM ${tempTableName}`);
-}
-
 function readTaskFlowRegistrySnapshot(db: DatabaseSync): TaskFlowRegistryStoreSnapshot {
   const query = getFlowRegistryKysely(db)
     .selectFrom("flow_runs")
@@ -274,23 +255,6 @@ export function loadTaskFlowRegistryStateFromSqliteReadOnly(): TaskFlowRegistryS
       flows: new Map(),
     }
   );
-}
-
-export function saveTaskFlowRegistryStateToSqlite(snapshot: TaskFlowRegistryStoreSnapshot) {
-  withWriteTransaction(({ db }) => {
-    const kysely = getFlowRegistryKysely(db);
-    const flowIds = [...snapshot.flows.keys()];
-    if (flowIds.length === 0) {
-      executeSqliteQuerySync(db, kysely.deleteFrom("flow_runs"));
-      pruneOrphanedExecutionOwnerLifecycleMetadata(db, "flow");
-      return;
-    }
-    pruneFlowsNotInSnapshot({ db, ids: flowIds });
-    for (const flow of snapshot.flows.values()) {
-      upsertTaskFlowRowInDatabase(db, bindTaskFlowRecord(flow));
-    }
-    pruneOrphanedExecutionOwnerLifecycleMetadata(db, "flow");
-  });
 }
 
 export function upsertTaskFlowRegistryRecordToSqlite(flow: TaskFlowRecord) {

--- a/src/tasks/task-flow-registry.store.test-support.ts
+++ b/src/tasks/task-flow-registry.store.test-support.ts
@@ -1,15 +1,10 @@
-import type { TaskFlowRegistryObserverEvent } from "./task-flow-registry.store.js";
-import type { TaskFlowRegistryStoreSnapshot } from "./task-flow-registry.store.types.js";
+import type {
+  getTaskFlowRegistryStore,
+  TaskFlowRegistryObserverEvent,
+} from "./task-flow-registry.store.js";
 import "./task-flow-registry.store.js";
-import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 
-type TaskFlowRegistryStore = {
-  loadSnapshot: () => TaskFlowRegistryStoreSnapshot;
-  saveSnapshot: (snapshot: TaskFlowRegistryStoreSnapshot) => void;
-  upsertFlow?: (flow: TaskFlowRecord) => void;
-  deleteFlow?: (flowId: string) => void;
-  close?: () => void;
-};
+type TaskFlowRegistryStore = ReturnType<typeof getTaskFlowRegistryStore>;
 
 type TaskFlowRegistryStoreTestApi = {
   configureTaskFlowRegistryRuntime(params: {

--- a/src/tasks/task-flow-registry.store.test.ts
+++ b/src/tasks/task-flow-registry.store.test.ts
@@ -10,6 +10,7 @@ import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-
 import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createInMemoryTaskFlowRegistryStore } from "../test-utils/task-registry-store.js";
 import {
   createManagedTaskFlow as createManagedTaskFlowOrNull,
   getTaskFlowById,
@@ -20,7 +21,8 @@ import {
   bindTaskFlowExecution,
   loadTaskFlowRegistryStateFromSqlite,
   loadTaskFlowRegistryStateFromSqliteReadOnly,
-  saveTaskFlowRegistryStateToSqlite,
+  deleteTaskFlowRegistryRecordFromSqlite,
+  upsertTaskFlowRegistryRecordToSqlite,
 } from "./task-flow-registry.store.sqlite.js";
 import {
   parseOptionalTaskFlowSyncMode,
@@ -122,18 +124,14 @@ describe("task-flow-registry store runtime", () => {
     );
   });
 
-  it("uses the configured flow store for restore and save", () => {
+  it("uses the configured flow store for restore and writes", () => {
     const storedFlow = createStoredFlow();
-    const loadSnapshot = vi.fn(() => ({
+    const store = createInMemoryTaskFlowRegistryStore({
       flows: new Map([[storedFlow.flowId, storedFlow]]),
-    }));
-    const saveSnapshot = vi.fn();
-    configureTaskFlowRegistryRuntime({
-      store: {
-        loadSnapshot,
-        saveSnapshot,
-      },
     });
+    const loadSnapshot = vi.fn(store.loadSnapshot);
+    const upsertFlow = vi.fn(store.upsertFlow);
+    configureTaskFlowRegistryRuntime({ store: { ...store, loadSnapshot, upsertFlow } });
 
     const restored = getTaskFlowById("flow-restored");
     expect(restored?.flowId).toBe("flow-restored");
@@ -153,14 +151,8 @@ describe("task-flow-registry store runtime", () => {
       currentStep: "wait_for",
     });
 
-    expect(saveSnapshot).toHaveBeenCalled();
-    const latestCall = saveSnapshot.mock.calls[saveSnapshot.mock.calls.length - 1];
-    if (!latestCall) {
-      throw new Error("Expected task flow snapshot save call");
-    }
-    const latestSnapshot = latestCall[0] as {
-      flows: ReadonlyMap<string, TaskFlowRecord>;
-    };
+    expect(upsertFlow).toHaveBeenCalledTimes(1);
+    const latestSnapshot = store.loadSnapshot();
     expect(latestSnapshot.flows.size).toBe(2);
     const restoredFlow = latestSnapshot.flows.get("flow-restored");
     if (!restoredFlow) {
@@ -296,54 +288,6 @@ describe("task-flow-registry store runtime", () => {
     });
   });
 
-  it("prunes large sqlite snapshots without binding every flow id at once", async () => {
-    await withFlowRegistryTempDir(async () => {
-      const flows = new Map<string, TaskFlowRecord>();
-      for (let index = 0; index < 1_200; index++) {
-        const flow: TaskFlowRecord = {
-          ...createStoredFlow(),
-          flowId: `flow-large-${index}`,
-          controllerId: `tests/large-flow-${index}`,
-          status: "running",
-          createdAt: index,
-          updatedAt: index,
-          cancelRequestedAt: undefined,
-          endedAt: undefined,
-        };
-        flows.set(flow.flowId, flow);
-      }
-
-      saveTaskFlowRegistryStateToSqlite({ flows });
-      const admitted: AdmittedRunContext = {
-        operationalRunInstance: { instanceId: "instance-flow-prune", runId: "run-flow-prune" },
-        executionIdentityToken: createExecutionIdentityAdmissionToken("run-flow-prune", {
-          contextId: "context-flow-prune",
-          executionId: "execution-flow-prune",
-        }),
-      };
-      expect(bindTaskFlowExecution({ admitted, flowId: "flow-large-0" })).toBe("bound");
-      expect(bindTaskFlowExecution({ admitted, flowId: "flow-large-1199" })).toBe("bound");
-      const retainedFlows = new Map([...flows].slice(100));
-      saveTaskFlowRegistryStateToSqlite({ flows: retainedFlows });
-
-      const restored = loadTaskFlowRegistryStateFromSqlite();
-      expect(restored.flows.size).toBe(1_100);
-      expect(restored.flows.has("flow-large-0")).toBe(false);
-      expect(restored.flows.has("flow-large-1199")).toBe(true);
-      expect(loadTaskFlowRegistryStateFromSqliteReadOnly()).toEqual(restored);
-      expect(
-        openOpenClawStateDatabase()
-          .db.prepare(
-            `SELECT owner_id
-             FROM execution_owner_lifecycle_bindings
-             WHERE owner_kind = 'flow'
-             ORDER BY owner_id`,
-          )
-          .all(),
-      ).toEqual([{ owner_id: "flow-large-1199" }]);
-    });
-  });
-
   it("binds only source-live flow owners across managed and mirrored lifecycles", async () => {
     await withFlowRegistryTempDir(async () => {
       const managed: TaskFlowRecord = {
@@ -380,14 +324,15 @@ describe("task-flow-registry store runtime", () => {
         status: "running",
         cancelRequestedAt: 199,
       };
-      saveTaskFlowRegistryStateToSqlite({
-        flows: new Map(
-          [managed, mirrored, managedTerminal, mirroredTerminal, managedCancelling].map((flow) => [
-            flow.flowId,
-            flow,
-          ]),
-        ),
-      });
+      for (const flow of [
+        managed,
+        mirrored,
+        managedTerminal,
+        mirroredTerminal,
+        managedCancelling,
+      ]) {
+        upsertTaskFlowRegistryRecordToSqlite(flow);
+      }
       const admitted: AdmittedRunContext = {
         operationalRunInstance: { instanceId: "instance-flow-owner", runId: "run-flow-owner" },
         executionIdentityToken: createExecutionIdentityAdmissionToken("run-flow-owner", {
@@ -408,15 +353,8 @@ describe("task-flow-registry store runtime", () => {
       expect(bindTaskFlowExecution({ admitted, flowId: managed.flowId })).toBe("bound");
       expect(bindTaskFlowExecution({ admitted, flowId: mirrored.flowId })).toBe("bound");
 
-      saveTaskFlowRegistryStateToSqlite({
-        flows: new Map([
-          [managed.flowId, { ...managed, status: "succeeded", endedAt: 210 }],
-          [mirrored.flowId, { ...mirrored, status: "blocked", endedAt: 211 }],
-          [managedTerminal.flowId, managedTerminal],
-          [mirroredTerminal.flowId, mirroredTerminal],
-          [managedCancelling.flowId, managedCancelling],
-        ]),
-      });
+      upsertTaskFlowRegistryRecordToSqlite({ ...managed, status: "succeeded", endedAt: 210 });
+      upsertTaskFlowRegistryRecordToSqlite({ ...mirrored, status: "blocked", endedAt: 211 });
       expect(bindTaskFlowExecution({ admitted, flowId: managed.flowId })).toBe("missing");
       expect(bindTaskFlowExecution({ admitted, flowId: mirrored.flowId })).toBe("missing");
       expect(
@@ -429,6 +367,25 @@ describe("task-flow-registry store runtime", () => {
           )
           .all(),
       ).toEqual([{ owner_id: managed.flowId }, { owner_id: mirrored.flowId }]);
+
+      deleteTaskFlowRegistryRecordFromSqlite(managed.flowId);
+      const restored = loadTaskFlowRegistryStateFromSqlite();
+      expect([...restored.flows.keys()].toSorted()).toEqual(
+        [
+          mirrored.flowId,
+          managedTerminal.flowId,
+          mirroredTerminal.flowId,
+          managedCancelling.flowId,
+        ].toSorted(),
+      );
+      expect(loadTaskFlowRegistryStateFromSqliteReadOnly()).toEqual(restored);
+      expect(
+        openOpenClawStateDatabase()
+          .db.prepare(
+            "SELECT owner_id FROM execution_owner_lifecycle_bindings WHERE owner_kind = 'flow'",
+          )
+          .all(),
+      ).toEqual([{ owner_id: mirrored.flowId }]);
     });
   });
 

--- a/src/tasks/task-flow-registry.store.ts
+++ b/src/tasks/task-flow-registry.store.ts
@@ -3,7 +3,6 @@ import {
   closeTaskFlowRegistryDatabase,
   deleteTaskFlowRegistryRecordFromSqlite,
   loadTaskFlowRegistryStateFromSqlite,
-  saveTaskFlowRegistryStateToSqlite,
   upsertTaskFlowRegistryRecordToSqlite,
 } from "./task-flow-registry.store.sqlite.js";
 import type { TaskFlowRegistryStoreSnapshot } from "./task-flow-registry.store.types.js";
@@ -11,9 +10,8 @@ import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 
 type TaskFlowRegistryStore = {
   loadSnapshot: () => TaskFlowRegistryStoreSnapshot;
-  saveSnapshot: (snapshot: TaskFlowRegistryStoreSnapshot) => void;
-  upsertFlow?: (flow: TaskFlowRecord) => void;
-  deleteFlow?: (flowId: string) => void;
+  upsertFlow: (flow: TaskFlowRecord) => void;
+  deleteFlow: (flowId: string) => void;
   close?: () => void;
 };
 
@@ -34,13 +32,12 @@ export type TaskFlowRegistryObserverEvent =
     };
 
 type TaskFlowRegistryObservers = {
-  // Observers are incremental/best-effort only. Snapshot persistence belongs to TaskFlowRegistryStore.
+  // Observers are incremental/best-effort only. Persistence belongs to TaskFlowRegistryStore.
   onEvent?: (event: TaskFlowRegistryObserverEvent) => void;
 };
 
 const defaultFlowRegistryStore: TaskFlowRegistryStore = {
   loadSnapshot: loadTaskFlowRegistryStateFromSqlite,
-  saveSnapshot: saveTaskFlowRegistryStateToSqlite,
   upsertFlow: upsertTaskFlowRegistryRecordToSqlite,
   deleteFlow: deleteTaskFlowRegistryRecordFromSqlite,
   close: closeTaskFlowRegistryDatabase,

--- a/src/tasks/task-flow-registry.test-support.ts
+++ b/src/tasks/task-flow-registry.test-support.ts
@@ -1,3 +1,4 @@
+import { clearTaskRegistrySqliteForTests } from "../test-utils/task-registry-sqlite.js";
 import type {
   JsonValue,
   TaskFlowRecord,
@@ -29,7 +30,7 @@ type CreateFlowRecordParams = {
 
 type TaskFlowRegistryTestApi = {
   createFlowRecord(params: CreateFlowRecordParams): TaskFlowRecord | null;
-  resetTaskFlowRegistryForTests(opts?: { persist?: boolean }): void;
+  resetTaskFlowRegistryForTests(): void;
 };
 
 function getTestApi(): TaskFlowRegistryTestApi {
@@ -47,5 +48,8 @@ export function createFlowRecord(params: CreateFlowRecordParams): TaskFlowRecord
 }
 
 export function resetTaskFlowRegistryForTests(opts?: { persist?: boolean }): void {
-  getTestApi().resetTaskFlowRegistryForTests(opts);
+  getTestApi().resetTaskFlowRegistryForTests();
+  if (opts?.persist !== false) {
+    clearTaskRegistrySqliteForTests("flow");
+  }
 }

--- a/src/tasks/task-flow-registry.test.ts
+++ b/src/tasks/task-flow-registry.test.ts
@@ -1,6 +1,7 @@
 // Covers managed task-flow creation, lookup, ownership, and state transitions.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createInMemoryTaskFlowRegistryStore } from "../test-utils/task-registry-store.js";
 import {
   createTaskFlowForTask as createTaskFlowForTaskOrNull,
   createManagedTaskFlow as createManagedTaskFlowOrNull,
@@ -221,10 +222,10 @@ describe("task-flow-registry", () => {
     const onEvent = vi.fn();
     configureTaskFlowRegistryRuntime({
       store: {
+        ...createInMemoryTaskFlowRegistryStore(),
         loadSnapshot: () => ({
           flows: new Map(),
         }),
-        saveSnapshot: () => {},
       },
       observers: {
         onEvent,
@@ -276,7 +277,6 @@ describe("task-flow-registry", () => {
     configureTaskFlowRegistryRuntime({
       store: {
         loadSnapshot,
-        saveSnapshot: () => {},
         upsertFlow,
         deleteFlow,
       },
@@ -328,10 +328,10 @@ describe("task-flow-registry", () => {
     });
     configureTaskFlowRegistryRuntime({
       store: {
+        ...createInMemoryTaskFlowRegistryStore(),
         loadSnapshot: () => ({
           flows: new Map(),
         }),
-        saveSnapshot: () => {},
         upsertFlow,
       },
     });
@@ -357,10 +357,10 @@ describe("task-flow-registry", () => {
     });
     configureTaskFlowRegistryRuntime({
       store: {
+        ...createInMemoryTaskFlowRegistryStore(),
         loadSnapshot: () => ({
           flows: new Map(),
         }),
-        saveSnapshot: () => {},
         upsertFlow,
       },
     });
@@ -401,7 +401,6 @@ describe("task-flow-registry", () => {
         loadSnapshot: () => ({
           flows: new Map(),
         }),
-        saveSnapshot: () => {},
         upsertFlow: () => {},
         deleteFlow,
       },
@@ -421,6 +420,7 @@ describe("task-flow-registry", () => {
   it("normalizes restored managed flows without a controller id", () => {
     configureTaskFlowRegistryRuntime({
       store: {
+        ...createInMemoryTaskFlowRegistryStore(),
         loadSnapshot: () => ({
           flows: new Map([
             [
@@ -439,7 +439,6 @@ describe("task-flow-registry", () => {
             ],
           ]),
         }),
-        saveSnapshot: () => {},
       },
     });
 

--- a/src/tasks/task-flow-registry.ts
+++ b/src/tasks/task-flow-registry.ts
@@ -318,43 +318,9 @@ export function reloadTaskFlowRegistryFromStore(): void {
   ensureTaskFlowRegistryReady();
 }
 
-function createFlowSnapshotWith(next?: TaskFlowRecord, deletedFlowId?: string) {
-  const snapshot = new Map(snapshotFlowRecords(flows).map((flow) => [flow.flowId, flow]));
-  if (deletedFlowId) {
-    snapshot.delete(deletedFlowId);
-  }
-  if (next) {
-    snapshot.set(next.flowId, cloneFlowRecord(next));
-  }
-  return snapshot;
-}
-
-function persistFlowRegistry(): boolean {
-  try {
-    getTaskFlowRegistryStore().saveSnapshot({
-      flows: createFlowSnapshotWith(),
-    });
-    return true;
-  } catch (error) {
-    log.warn("Failed to persist task-flow registry snapshot", { error });
-    return false;
-  }
-}
-
-function persistFlowUpsert(flow: TaskFlowRecord) {
-  const store = getTaskFlowRegistryStore();
-  if (store.upsertFlow) {
-    store.upsertFlow(cloneFlowRecord(flow));
-    return;
-  }
-  store.saveSnapshot({
-    flows: createFlowSnapshotWith(flow),
-  });
-}
-
 function tryPersistFlowUpsert(flow: TaskFlowRecord, operation: string): boolean {
   try {
-    persistFlowUpsert(flow);
+    getTaskFlowRegistryStore().upsertFlow(cloneFlowRecord(flow));
     return true;
   } catch (error) {
     log.warn("Failed to persist task-flow registry upsert", {
@@ -366,20 +332,9 @@ function tryPersistFlowUpsert(flow: TaskFlowRecord, operation: string): boolean 
   }
 }
 
-function persistFlowDelete(flowId: string) {
-  const store = getTaskFlowRegistryStore();
-  if (store.deleteFlow) {
-    store.deleteFlow(flowId);
-    return;
-  }
-  store.saveSnapshot({
-    flows: createFlowSnapshotWith(undefined, flowId),
-  });
-}
-
 function tryPersistFlowDelete(flowId: string): boolean {
   try {
-    persistFlowDelete(flowId);
+    getTaskFlowRegistryStore().deleteFlow(flowId);
     return true;
   } catch (error) {
     log.warn("Failed to persist task-flow registry delete", {
@@ -850,13 +805,10 @@ export function deleteTaskFlowRecordById(flowId: string): boolean {
   return true;
 }
 
-function resetTaskFlowRegistryForTests(opts?: { persist?: boolean }) {
+function resetTaskFlowRegistryForTests() {
   flows = new Map();
   taskFlowRegistryRestoreState = { status: "uninitialized" };
   resetTaskFlowRegistryRuntimeForTests();
-  if (opts?.persist !== false) {
-    persistFlowRegistry();
-  }
   getTaskFlowRegistryStore().close?.();
 }
 

--- a/src/tasks/task-registry-query.test.ts
+++ b/src/tasks/task-registry-query.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createInMemoryTaskRegistryStore } from "../test-utils/task-registry-store.js";
 import {
   getTaskById,
   listTaskRecordPage,
@@ -10,15 +11,15 @@ import { configureTaskRegistryRuntime } from "./task-registry.store.js";
 import type { TaskRecord } from "./task-registry.types.js";
 
 afterEach(() => {
-  resetTaskRegistryForTests({ persist: false });
+  resetTaskRegistryForTests();
 });
 
 function configureTaskSnapshot(tasks: Iterable<TaskRecord>): void {
   const snapshotTasks = new Map([...tasks].map((task) => [task.taskId, task]));
   configureTaskRegistryRuntime({
     store: {
+      ...createInMemoryTaskRegistryStore(),
       loadSnapshot: () => ({ tasks: snapshotTasks, deliveryStates: new Map() }),
-      saveSnapshot: () => {},
     },
   });
 }

--- a/src/tasks/task-registry-query.ts
+++ b/src/tasks/task-registry-query.ts
@@ -21,7 +21,6 @@ import {
   ensureTaskRegistryReady,
   getTasksByRunId,
   taskRegistryLog,
-  persistTaskRegistry,
   pickPreferredRunIdTask,
   readTaskRegistryRevision,
   rebuildRunIdIndex,
@@ -456,7 +455,7 @@ export function deleteTaskRecordById(taskId: string): boolean {
   return true;
 }
 
-export function resetTaskRegistryForTests(opts?: { persist?: boolean }) {
+export function resetTaskRegistryForTests() {
   getTaskRegistryProcessState().runOwners.clear();
   clearTaskRegistryMemory();
   resetTaskRegistryRestoreState();
@@ -464,11 +463,7 @@ export function resetTaskRegistryForTests(opts?: { persist?: boolean }) {
   resetTaskRegistryListenerState();
   deliveryRuntimeLoader.clear();
   controlRuntimeLoader.clear();
-  if (opts?.persist !== false) {
-    persistTaskRegistry();
-  }
-  // Always close the sqlite handle so Windows temp-dir cleanup can remove the
-  // state directory even when a test intentionally skips persisting the reset.
+  // Close the default SQLite handle too, even when a custom store was configured.
   getTaskRegistryStore().close?.();
 }
 

--- a/src/tasks/task-registry-session-index.test.ts
+++ b/src/tasks/task-registry-session-index.test.ts
@@ -14,7 +14,7 @@ import {
 import { createTaskRecord, linkTaskToFlowById } from "./task-registry-record-api.js";
 import { reloadTaskRegistryFromStore } from "./task-registry-state.js";
 import { configureTaskRegistryRuntime, getTaskRegistryStore } from "./task-registry.store.js";
-import { upsertTaskRegistryRecordToSqlite } from "./task-registry.store.sqlite.js";
+import { upsertTaskWithDeliveryStateToSqlite } from "./task-registry.store.sqlite.js";
 import {
   resetTaskFlowRegistryForTests,
   resetTaskRegistryForTests,
@@ -92,7 +92,11 @@ it("publishes requester membership through create, update, restore, atomic publi
   ]);
 
   const published = { ...task, requesterSessionKey: "agent:main:published" };
-  upsertTaskRegistryRecordToSqlite(published);
+  const deliveryState = store.loadSnapshot().deliveryStates.get(task.taskId);
+  upsertTaskWithDeliveryStateToSqlite({
+    task: published,
+    ...(deliveryState ? { deliveryState } : {}),
+  });
   publishTaskRecordAfterAtomicStore(published);
   expect(await taskIds({ sessionKey: published.requesterSessionKey })).toEqual([task.taskId]);
   expect(await taskIds({ sessionKey: task.ownerKey })).toEqual([task.taskId]);

--- a/src/tasks/task-registry-state.ts
+++ b/src/tasks/task-registry-state.ts
@@ -5,11 +5,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { createLazyPromiseLoader } from "../shared/lazy-runtime.js";
 import type { TaskRegistryControlRuntime } from "./task-registry-control.types.js";
-import {
-  cloneTaskDeliveryState,
-  cloneTaskRecord,
-  normalizeTaskTimestamps,
-} from "./task-registry-records.js";
+import { cloneTaskRecord, normalizeTaskTimestamps } from "./task-registry-records.js";
 import { getTaskRegistryProcessState } from "./task-registry.process-state.js";
 import {
   getTaskRegistryObservers,
@@ -144,51 +140,17 @@ export function emitTaskRegistryObserverEvent(createEvent: () => TaskRegistryObs
   }
 }
 
-export function persistTaskRegistry(): boolean {
-  try {
-    getTaskRegistryStore().saveSnapshot({
-      tasks,
-      deliveryStates: taskDeliveryStates,
-    });
-    return true;
-  } catch (error) {
-    taskRegistryLog.warn("Failed to persist task registry snapshot", { error });
-    return false;
-  }
-}
-
-function persistTaskUpsert(task: TaskRecord, pendingDeliveryState?: TaskDeliveryState): void {
-  const store = getTaskRegistryStore();
-  const deliveryState = pendingDeliveryState ?? taskDeliveryStates.get(task.taskId);
-  if (store.upsertTaskWithDeliveryState) {
-    store.upsertTaskWithDeliveryState({
-      task,
-      ...(deliveryState ? { deliveryState } : {}),
-    });
-    return;
-  }
-  if (!deliveryState && store.upsertTask) {
-    store.upsertTask(task);
-    return;
-  }
-  // Snapshot fallback: project the pending upsert so the snapshot is correct
-  // even though we persist before mutating memory. Delivery state must stay in
-  // the same write as its task; split upserts can leave a durable half-create.
-  store.saveSnapshot({
-    tasks: new Map(tasks).set(task.taskId, task),
-    deliveryStates: deliveryState
-      ? new Map(taskDeliveryStates).set(task.taskId, deliveryState)
-      : taskDeliveryStates,
-  });
-}
-
 export function tryPersistTaskUpsert(
   task: TaskRecord,
   operation: string,
   pendingDeliveryState?: TaskDeliveryState,
 ): boolean {
   try {
-    persistTaskUpsert(task, pendingDeliveryState);
+    const deliveryState = pendingDeliveryState ?? taskDeliveryStates.get(task.taskId);
+    getTaskRegistryStore().upsertTaskWithDeliveryState({
+      task,
+      ...(deliveryState ? { deliveryState } : {}),
+    });
     return true;
   } catch (error) {
     taskRegistryLog.warn("Failed to persist task registry upsert", {
@@ -201,36 +163,9 @@ export function tryPersistTaskUpsert(
   }
 }
 
-function persistTaskDelete(taskId: string) {
-  const store = getTaskRegistryStore();
-  if (store.deleteTaskWithDeliveryState) {
-    // Composite delete removes the task row and its delivery state in a single
-    // transaction. This is the only atomic "remove both records" store
-    // primitive, and the one the default sqlite store uses.
-    store.deleteTaskWithDeliveryState(taskId);
-    return;
-  }
-  // No atomic composite delete is available: persist the removal of BOTH the
-  // task and its delivery state in one projected snapshot. saveSnapshot is a
-  // required store method and writes atomically. Using the separate deleteTask
-  // / deleteDeliveryState methods instead would either leave the delivery-state
-  // row behind (a task-only delete) or, if both were called, reintroduce a
-  // two-write divergence window when the second delete threw before the
-  // in-memory mutation. Projecting both deletions into a single snapshot keeps
-  // the persisted store consistent under the persist-before-in-memory ordering.
-  const projectedTasks = new Map(tasks);
-  projectedTasks.delete(taskId);
-  const projectedDeliveryStates = new Map(taskDeliveryStates);
-  projectedDeliveryStates.delete(taskId);
-  store.saveSnapshot({
-    tasks: projectedTasks,
-    deliveryStates: projectedDeliveryStates,
-  });
-}
-
 export function tryPersistTaskDelete(taskId: string): boolean {
   try {
-    persistTaskDelete(taskId);
+    getTaskRegistryStore().deleteTaskWithDeliveryState(taskId);
     return true;
   } catch (error) {
     taskRegistryLog.warn("Failed to persist task registry delete", {
@@ -241,23 +176,9 @@ export function tryPersistTaskDelete(taskId: string): boolean {
   }
 }
 
-function persistTaskDeliveryStateUpsert(state: TaskDeliveryState) {
-  const store = getTaskRegistryStore();
-  if (store.upsertDeliveryState) {
-    store.upsertDeliveryState(state);
-    return;
-  }
-  const projectedDeliveryStates = new Map(taskDeliveryStates);
-  projectedDeliveryStates.set(state.taskId, cloneTaskDeliveryState(state));
-  store.saveSnapshot({
-    tasks,
-    deliveryStates: projectedDeliveryStates,
-  });
-}
-
 export function tryPersistTaskDeliveryStateUpsert(state: TaskDeliveryState): boolean {
   try {
-    persistTaskDeliveryStateUpsert(state);
+    getTaskRegistryStore().upsertDeliveryState(state);
     return true;
   } catch (error) {
     taskRegistryLog.warn("Failed to persist task delivery state", {

--- a/src/tasks/task-registry.process-state.test.ts
+++ b/src/tasks/task-registry.process-state.test.ts
@@ -1,6 +1,7 @@
 // Verifies process-state persistence across fresh task registry module loads.
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it, vi } from "vitest";
+import { createInMemoryTaskRegistryStore } from "../test-utils/task-registry-store.js";
 
 describe("task registry process state", () => {
   it("shares state across duplicate module instances", async () => {
@@ -44,8 +45,8 @@ describe("task registry process state", () => {
     const events = await import("../infra/agent-events.js");
     const firstStore = await import("./task-registry.store.js");
     const store = {
+      ...createInMemoryTaskRegistryStore(),
       loadSnapshot: () => ({ tasks: new Map(), deliveryStates: new Map() }),
-      saveSnapshot: () => {},
     };
     firstStore.configureTaskRegistryRuntime({ store });
     const firstRegistry = await import("./task-registry.js");

--- a/src/tasks/task-registry.store.sqlite.ts
+++ b/src/tasks/task-registry.store.sqlite.ts
@@ -9,7 +9,6 @@ import {
 import {
   bindExecutionOwnerLifecycleMetadata,
   deleteExecutionOwnerLifecycleMetadata,
-  pruneOrphanedExecutionOwnerLifecycleMetadata,
 } from "../audit/execution-owner-lifecycle-binding-store.js";
 import {
   executeSqliteQuerySync,
@@ -226,29 +225,6 @@ function getTaskRegistryKysely(db: DatabaseSync) {
   return getNodeSqliteKysely<TaskRegistryStoreDatabase>(db);
 }
 
-function pruneRowsNotInSnapshot(params: {
-  db: DatabaseSync;
-  tableName: "task_delivery_state" | "task_runs";
-  columnName: "task_id";
-  tempTableName: string;
-  ids: readonly string[];
-}) {
-  params.db.exec(`CREATE TEMP TABLE IF NOT EXISTS ${params.tempTableName} (id TEXT PRIMARY KEY)`);
-  params.db.exec(`DELETE FROM ${params.tempTableName}`);
-  const insert = params.db.prepare(`INSERT OR IGNORE INTO ${params.tempTableName} (id) VALUES (?)`);
-  for (const id of params.ids) {
-    insert.run(id);
-  }
-  params.db.exec(`
-    DELETE FROM ${params.tableName}
-    WHERE NOT EXISTS (
-      SELECT 1 FROM ${params.tempTableName}
-      WHERE ${params.tempTableName}.id = ${params.tableName}.${params.columnName}
-    )
-  `);
-  params.db.exec(`DELETE FROM ${params.tempTableName}`);
-}
-
 function selectTaskRows(db: DatabaseSync): TaskRegistryRow[] {
   const query = getTaskRegistryKysely(db)
     .selectFrom("task_runs")
@@ -456,52 +432,6 @@ export function listTaskRegistryRecordsByRuntimeSourceIdFromSqlite(params: {
   );
 }
 
-export function saveTaskRegistryStateToSqlite(snapshot: TaskRegistryStoreSnapshot) {
-  withWriteTransaction((database) => {
-    const { db } = database;
-    const kysely = getTaskRegistryKysely(db);
-    const taskIds = [...snapshot.tasks.keys()];
-    if (taskIds.length === 0) {
-      executeSqliteQuerySync(db, kysely.deleteFrom("task_delivery_state"));
-      executeSqliteQuerySync(db, kysely.deleteFrom("task_runs"));
-      pruneOrphanedExecutionOwnerLifecycleMetadata(db, "task");
-      return;
-    }
-    pruneRowsNotInSnapshot({
-      db,
-      tableName: "task_runs",
-      columnName: "task_id",
-      tempTableName: "openclaw_live_task_run_ids",
-      ids: taskIds,
-    });
-    const deliveryTaskIds = [...snapshot.deliveryStates.keys()];
-    if (deliveryTaskIds.length === 0) {
-      executeSqliteQuerySync(db, kysely.deleteFrom("task_delivery_state"));
-    } else {
-      pruneRowsNotInSnapshot({
-        db,
-        tableName: "task_delivery_state",
-        columnName: "task_id",
-        tempTableName: "openclaw_live_task_delivery_ids",
-        ids: deliveryTaskIds,
-      });
-    }
-    for (const task of snapshot.tasks.values()) {
-      upsertTaskRunRowInDatabase(database, bindTaskRecord(task));
-    }
-    for (const state of snapshot.deliveryStates.values()) {
-      replaceTaskDeliveryStateRow(db, bindTaskDeliveryState(state));
-    }
-    pruneOrphanedExecutionOwnerLifecycleMetadata(db, "task");
-  });
-}
-
-export function upsertTaskRegistryRecordToSqlite(task: TaskRecord) {
-  withWriteTransaction((database) => {
-    upsertTaskRunRowInDatabase(database, bindTaskRecord(task));
-  });
-}
-
 /** Binds only the exact task row selected before admission; runId is never a join key. */
 export function bindTaskRunExecution(params: {
   admitted: AdmittedRunContext;
@@ -558,12 +488,6 @@ export function upsertTaskWithDeliveryStateToSqlite(params: {
   });
 }
 
-export function deleteTaskRegistryRecordFromSqlite(taskId: string) {
-  withWriteTransaction(({ db }) => {
-    deleteTaskRowsWithDeliveryState(db, taskId);
-  });
-}
-
 export function deleteTaskAndDeliveryStateFromSqlite(taskId: string) {
   withWriteTransaction(({ db }) => {
     deleteTaskRowsWithDeliveryState(db, taskId);
@@ -573,15 +497,6 @@ export function deleteTaskAndDeliveryStateFromSqlite(taskId: string) {
 export function upsertTaskDeliveryStateToSqlite(state: TaskDeliveryState) {
   withWriteTransaction(({ db }) => {
     replaceTaskDeliveryStateRow(db, bindTaskDeliveryState(state));
-  });
-}
-
-export function deleteTaskDeliveryStateFromSqlite(taskId: string) {
-  withWriteTransaction(({ db }) => {
-    executeSqliteQuerySync(
-      db,
-      getTaskRegistryKysely(db).deleteFrom("task_delivery_state").where("task_id", "=", taskId),
-    );
   });
 }
 

--- a/src/tasks/task-registry.store.test.ts
+++ b/src/tasks/task-registry.store.test.ts
@@ -1,10 +1,11 @@
 // Covers task registry store persistence, in-memory behavior, and observer notifications.
-import { statSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import type { AdmittedRunContext } from "../agents/admitted-run-context.js";
 import { createExecutionIdentityAdmissionToken } from "../audit/execution-identity-admission.js";
+import { bindExecutionOwnerLifecycleMetadata } from "../audit/execution-owner-lifecycle-binding-store.js";
 import { emitAgentEvent } from "../infra/agent-events.js";
 import {
   executeSqliteQuerySync,
@@ -28,11 +29,15 @@ import {
   type OpenClawTestState,
   withOpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
+import { createInMemoryTaskRegistryStore } from "../test-utils/task-registry-store.js";
 import {
   collectCronHistoryOverflowTaskIds,
   CRON_HISTORY_KEEP_PER_JOB,
 } from "./cron-history-retention.js";
-import { createManagedTaskFlow as createManagedTaskFlowOrNull } from "./task-flow-registry.js";
+import {
+  createManagedTaskFlow as createManagedTaskFlowOrNull,
+  getTaskFlowById,
+} from "./task-flow-registry.js";
 import type { TaskFlowRecord } from "./task-flow-registry.types.js";
 import { getTaskRegistryMaintenanceSnapshot } from "./task-registry-maintenance-snapshot.js";
 import {
@@ -61,7 +66,8 @@ import {
   loadTaskRegistryStateFromSqlite,
   loadTaskRegistryStateFromSqliteReadOnly,
   loadTaskRegistryStateFromSqliteReadOnlyResult,
-  saveTaskRegistryStateToSqlite,
+  deleteTaskAndDeliveryStateFromSqlite,
+  upsertTaskWithDeliveryStateToSqlite,
 } from "./task-registry.store.sqlite.js";
 import type { TaskDeliveryState, TaskNotifyPolicy, TaskRecord } from "./task-registry.types.js";
 import {
@@ -226,18 +232,16 @@ describe("task-registry store runtime", () => {
     resetLogger();
   });
 
-  it("uses the configured task store for restore and save", () => {
+  it("uses the configured task store for restore and writes", () => {
     const storedTask = createStoredTask();
-    const loadSnapshot = vi.fn(() => ({
+    const store = createInMemoryTaskRegistryStore({
       tasks: new Map([[storedTask.taskId, storedTask]]),
       deliveryStates: new Map(),
-    }));
-    const saveSnapshot = vi.fn();
+    });
+    const loadSnapshot = vi.fn(store.loadSnapshot);
+    const upsertTaskWithDeliveryState = vi.fn(store.upsertTaskWithDeliveryState);
     configureTaskRegistryRuntime({
-      store: {
-        loadSnapshot,
-        saveSnapshot,
-      },
+      store: { ...store, loadSnapshot, upsertTaskWithDeliveryState },
     });
 
     expect(findTaskByRunId("run-restored")).toMatchObject({
@@ -257,10 +261,8 @@ describe("task-registry store runtime", () => {
       deliveryStatus: "pending",
     });
 
-    expect(saveSnapshot).toHaveBeenCalled();
-    const latestSnapshot = saveSnapshot.mock.calls[saveSnapshot.mock.calls.length - 1]?.[0] as {
-      tasks: ReadonlyMap<string, TaskRecord>;
-    };
+    expect(upsertTaskWithDeliveryState).toHaveBeenCalledOnce();
+    const latestSnapshot = store.loadSnapshot();
     expect(latestSnapshot.tasks.size).toBe(2);
     expect(latestSnapshot.tasks.get("task-restored")?.task).toBe("Restored task");
   });
@@ -274,8 +276,8 @@ describe("task-registry store runtime", () => {
     try {
       configureTaskRegistryRuntime({
         store: {
+          ...createInMemoryTaskRegistryStore(),
           loadSnapshot,
-          saveSnapshot: () => {},
         },
       });
 
@@ -304,12 +306,12 @@ describe("task-registry store runtime", () => {
     };
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => {
           throw new Error(
             `Invalid persisted task delivery status: ${JSON.stringify(invalidValue)}`,
           );
         },
-        saveSnapshot: () => {},
       },
     });
 
@@ -337,8 +339,8 @@ describe("task-registry store runtime", () => {
     const upsertTaskWithDeliveryState = vi.fn();
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot,
-        saveSnapshot: () => {},
         upsertTaskWithDeliveryState,
       },
     });
@@ -373,8 +375,8 @@ describe("task-registry store runtime", () => {
     });
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: failedLoad,
-        saveSnapshot: () => {},
       },
     });
 
@@ -389,8 +391,8 @@ describe("task-registry store runtime", () => {
     }));
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: cleanLoad,
-        saveSnapshot: () => {},
       },
     });
 
@@ -408,8 +410,8 @@ describe("task-registry store runtime", () => {
     const listTasksForOwnerKey = vi.fn(() => [storedTask]);
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot,
-        saveSnapshot: () => {},
         listTasksForOwnerKey,
       },
     });
@@ -440,14 +442,17 @@ describe("task-registry store runtime", () => {
       { ...active, taskId: "running-ended", endedAt: now, detail: nonBlockerDetail },
       { ...active, taskId: "tie-last" },
     ];
-    const saveSnapshot = vi.fn();
+    const writeStore = vi.fn();
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => ({
           tasks: new Map(storedTasks.map((task) => [task.taskId, task])),
           deliveryStates: new Map(),
         }),
-        saveSnapshot,
+        upsertTaskWithDeliveryState: writeStore,
+        deleteTaskWithDeliveryState: writeStore,
+        upsertDeliveryState: writeStore,
       },
     });
     // Restore before measuring: the hot query, not startup hydration, owns this assertion.
@@ -459,7 +464,7 @@ describe("task-registry store runtime", () => {
       expect(clone).not.toHaveBeenCalledWith(nonBlockerDetail);
       blockers[0]!.title = "caller mutation";
       expect(getInspectableActiveTaskRestartBlockers()[0]?.title).toBe(active.task);
-      expect(saveSnapshot).not.toHaveBeenCalled();
+      expect(writeStore).not.toHaveBeenCalled();
     } finally {
       clone.mockRestore();
     }
@@ -493,14 +498,17 @@ describe("task-registry store runtime", () => {
       { ...base, taskId: "child-only", childSessionKey: sessionKey, detail: unrelatedDetail },
       { ...base, taskId: "padded-owner", ownerKey: ` ${sessionKey} `, detail: unrelatedDetail },
     ];
-    const saveSnapshot = vi.fn();
+    const writeStore = vi.fn();
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => ({
           tasks: new Map(storedTasks.map((task) => [task.taskId, task])),
           deliveryStates: new Map(),
         }),
-        saveSnapshot,
+        upsertTaskWithDeliveryState: writeStore,
+        deleteTaskWithDeliveryState: writeStore,
+        upsertDeliveryState: writeStore,
       },
     });
     expect(getTaskById("owner-only")?.taskId).toBe("owner-only");
@@ -519,7 +527,7 @@ describe("task-registry store runtime", () => {
       }
       detail[0].push("caller mutation");
       expect(getTaskById("requester-only")?.detail).toEqual([["selected detail"]]);
-      expect(saveSnapshot).not.toHaveBeenCalled();
+      expect(writeStore).not.toHaveBeenCalled();
     } finally {
       clone.mockRestore();
     }
@@ -539,14 +547,17 @@ describe("task-registry store runtime", () => {
       cleanupAfter: now + 24 * 60 * 60_000,
       detail,
     }));
-    const saveSnapshot = vi.fn();
+    const writeStore = vi.fn();
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => ({
           tasks: new Map(storedTasks.map((task) => [task.taskId, task])),
           deliveryStates: new Map(),
         }),
-        saveSnapshot,
+        upsertTaskWithDeliveryState: writeStore,
+        deleteTaskWithDeliveryState: writeStore,
+        upsertDeliveryState: writeStore,
       },
       observers: null,
     });
@@ -562,7 +573,7 @@ describe("task-registry store runtime", () => {
       expect(clone.mock.calls.filter(([value]) => value === detail).length).toBeLessThanOrEqual(
         storedTasks.length,
       );
-      expect(saveSnapshot).not.toHaveBeenCalled();
+      expect(writeStore).not.toHaveBeenCalled();
     } finally {
       clone.mockRestore();
     }
@@ -616,11 +627,11 @@ describe("task-registry store runtime", () => {
     ];
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => ({
           tasks: new Map(storedTasks.map((task) => [task.taskId, task])),
           deliveryStates: new Map(),
         }),
-        saveSnapshot: vi.fn(),
       },
       observers: null,
     });
@@ -848,10 +859,7 @@ describe("task-registry store runtime", () => {
             usage: { input_tokens: 3, cached: false },
           },
         };
-        saveTaskRegistryStateToSqlite({
-          tasks: new Map([[task.taskId, task]]),
-          deliveryStates: new Map(),
-        });
+        upsertTaskWithDeliveryStateToSqlite({ task });
 
         expect(loadTaskRegistryStateFromSqlite().tasks.get(task.taskId)?.detail).toEqual(
           task.detail,
@@ -868,10 +876,7 @@ describe("task-registry store runtime", () => {
           ...createStoredTask(),
           detail: null,
         };
-        saveTaskRegistryStateToSqlite({
-          tasks: new Map([[task.taskId, task]]),
-          deliveryStates: new Map(),
-        });
+        upsertTaskWithDeliveryStateToSqlite({ task });
 
         const restored = loadTaskRegistryStateFromSqlite().tasks.get(task.taskId);
         expect(restored).toHaveProperty("detail", null);
@@ -1000,11 +1005,11 @@ describe("task-registry store runtime", () => {
     const events: TaskRegistryObserverEvent[] = [];
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => ({
           tasks: new Map([[createStoredTask().taskId, createStoredTask()]]),
           deliveryStates: new Map(),
         }),
-        saveSnapshot: () => {},
       },
       observers: {
         onEvent: (event) => {
@@ -1045,16 +1050,16 @@ describe("task-registry store runtime", () => {
     });
   });
 
-  it("uses atomic task-plus-delivery store methods when available", async () => {
+  it("uses atomic task-plus-delivery store methods", async () => {
     const upsertTaskWithDeliveryState = vi.fn();
     const deleteTaskWithDeliveryState = vi.fn();
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => ({
           tasks: new Map(),
           deliveryStates: new Map(),
         }),
-        saveSnapshot: vi.fn(),
         upsertTaskWithDeliveryState,
         deleteTaskWithDeliveryState,
       },
@@ -1092,148 +1097,6 @@ describe("task-registry store runtime", () => {
       }),
     ).toBe(true);
     expect(deleteTaskWithDeliveryState).toHaveBeenCalledWith(created.taskId);
-  });
-
-  it("persists create requester origin with one projected snapshot when only separate upserts exist", () => {
-    const upsertTask = vi.fn();
-    const upsertDeliveryState = vi.fn();
-    const saveSnapshot = vi.fn();
-    configureTaskRegistryRuntime({
-      store: {
-        loadSnapshot: () => ({
-          tasks: new Map(),
-          deliveryStates: new Map(),
-        }),
-        saveSnapshot,
-        upsertTask,
-        upsertDeliveryState,
-      },
-    });
-
-    const created = createTaskRecord({
-      runtime: "acp",
-      ownerKey: "agent:main:main",
-      scopeKind: "session",
-      childSessionKey: "agent:codex:acp:new",
-      runId: "run-separate-store-origin",
-      task: "Separate store task",
-      status: "running",
-      deliveryStatus: "pending",
-      requesterOrigin: {
-        channel: "test-channel",
-        to: "C1234567890",
-      },
-    });
-
-    expect(upsertTask).not.toHaveBeenCalled();
-    expect(upsertDeliveryState).not.toHaveBeenCalled();
-    expect(saveSnapshot).toHaveBeenCalledOnce();
-    const snapshot = saveSnapshot.mock.calls[0]?.[0] as {
-      tasks: ReadonlyMap<string, TaskRecord>;
-      deliveryStates: ReadonlyMap<string, TaskDeliveryState>;
-    };
-    expect(snapshot.tasks.get(created.taskId)?.task).toBe("Separate store task");
-    expect(snapshot.deliveryStates.get(created.taskId)?.requesterOrigin).toEqual({
-      channel: "test-channel",
-      to: "C1234567890",
-    });
-  });
-
-  it("falls back to full snapshots when custom stores cannot upsert delivery state", () => {
-    const saveSnapshot = vi.fn();
-    const upsertTask = vi.fn();
-    configureTaskRegistryRuntime({
-      store: {
-        loadSnapshot: () => ({
-          tasks: new Map(),
-          deliveryStates: new Map(),
-        }),
-        saveSnapshot,
-        upsertTask,
-      },
-    });
-
-    const created = createTaskRecord({
-      runtime: "acp",
-      ownerKey: "agent:main:main",
-      scopeKind: "session",
-      childSessionKey: "agent:codex:acp:snapshot-fallback",
-      runId: "run-snapshot-fallback-origin",
-      task: "Snapshot fallback task",
-      status: "running",
-      deliveryStatus: "pending",
-      requesterOrigin: {
-        channel: "test-channel",
-        to: "C1234567890",
-      },
-    });
-
-    expect(upsertTask).not.toHaveBeenCalled();
-    expect(saveSnapshot).toHaveBeenCalledOnce();
-    const snapshot = saveSnapshot.mock.calls[0]?.[0] as {
-      deliveryStates: ReadonlyMap<string, TaskDeliveryState>;
-    };
-    expect(snapshot.deliveryStates.get(created.taskId)?.requesterOrigin).toEqual({
-      channel: "test-channel",
-      to: "C1234567890",
-    });
-  });
-
-  it("projects updated tasks into snapshots when custom stores cannot upsert delivery state", () => {
-    const storedTask = createStoredTask();
-    const requesterOrigin = {
-      channel: "test-channel",
-      to: "C1234567890",
-    };
-    const snapshots: Array<{
-      tasks: ReadonlyMap<string, TaskRecord>;
-      deliveryStates: ReadonlyMap<string, TaskDeliveryState>;
-    }> = [];
-    const saveSnapshot = vi.fn(
-      (snapshot: {
-        tasks: ReadonlyMap<string, TaskRecord>;
-        deliveryStates: ReadonlyMap<string, TaskDeliveryState>;
-      }) => {
-        snapshots.push({
-          tasks: new Map(snapshot.tasks),
-          deliveryStates: new Map(snapshot.deliveryStates),
-        });
-      },
-    );
-    const upsertTask = vi.fn();
-    configureTaskRegistryRuntime({
-      store: {
-        loadSnapshot: () => ({
-          tasks: new Map([[storedTask.taskId, storedTask]]),
-          deliveryStates: new Map([
-            [
-              storedTask.taskId,
-              {
-                taskId: storedTask.taskId,
-                requesterOrigin,
-              },
-            ],
-          ]),
-        }),
-        saveSnapshot,
-        upsertTask,
-      },
-    });
-
-    expect(findTaskByRunId("run-restored")?.taskId).toBe(storedTask.taskId);
-    expect(
-      updateTaskNotifyPolicyById({
-        taskId: storedTask.taskId,
-        notifyPolicy: "state_changes",
-      })?.notifyPolicy,
-    ).toBe("state_changes");
-
-    expect(upsertTask).not.toHaveBeenCalled();
-    const latestSnapshot = snapshots.at(-1);
-    expect(latestSnapshot?.tasks.get(storedTask.taskId)?.notifyPolicy).toBe("state_changes");
-    expect(latestSnapshot?.deliveryStates.get(storedTask.taskId)?.requesterOrigin).toEqual(
-      requesterOrigin,
-    );
   });
 
   it("restores persisted tasks from the default sqlite store", () => {
@@ -1474,7 +1337,95 @@ describe("task-registry store runtime", () => {
     });
   });
 
-  it("prunes stale sqlite delivery state while retaining current rows", async () => {
+  it("keeps nonpersistent resets storage-free and normal resets metadata-free", async () => {
+    await withOpenClawTestState({ layout: "state-only" }, async () => {
+      const databasePath = resolveOpenClawStateSqlitePath(process.env);
+      expect(existsSync(databasePath)).toBe(false);
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      expect(existsSync(databasePath)).toBe(false);
+
+      resetTaskRegistryForTests();
+      resetTaskFlowRegistryForTests();
+      expect(
+        tableExists(openOpenClawStateDatabase().db, "execution_owner_lifecycle_bindings"),
+      ).toBe(false);
+    });
+  });
+
+  it("clears only the reset family's rows and orphan bindings", async () => {
+    await withOpenClawTestState({ layout: "state-only" }, async () => {
+      resetTaskRegistryForTests({ persist: false });
+      resetTaskFlowRegistryForTests({ persist: false });
+      const task = createStoredTask();
+      upsertTaskWithDeliveryStateToSqlite({ task, deliveryState: { taskId: task.taskId } });
+      const flow = createManagedTaskFlow({
+        ownerKey: task.ownerKey,
+        controllerId: "tests/reset-flow",
+        goal: "Retained flow",
+      });
+      const { db } = openOpenClawStateDatabase();
+      for (const [ownerKind, ownerId] of [
+        ["task", task.taskId],
+        ["task", "orphan-task"],
+        ["flow", flow.flowId],
+        ["flow", "orphan-flow"],
+        ["cron", "retained-cron"],
+      ] as const) {
+        bindExecutionOwnerLifecycleMetadata({
+          db,
+          ownerKind,
+          ownerId,
+          binding: { contextId: "reset-context", executionId: "reset-execution" },
+        });
+      }
+      // Reset must not parse malformed fixture payloads before deleting them.
+      executeSqliteQuerySync(
+        db,
+        getNodeSqliteKysely<TaskRegistryTestDatabase>(db)
+          .updateTable("task_runs")
+          .set({ detail_json: "{" }),
+      );
+      const readBindings = () =>
+        openOpenClawStateDatabase()
+          .db.prepare(
+            "SELECT owner_kind, owner_id FROM execution_owner_lifecycle_bindings ORDER BY owner_kind, owner_id",
+          )
+          .all();
+
+      resetTaskRegistryForTests();
+      expect(db.isOpen).toBe(false);
+      expect(loadTaskRegistryStateFromSqlite()).toEqual({
+        tasks: new Map(),
+        deliveryStates: new Map(),
+      });
+      expect(readBindings()).toEqual([
+        { owner_kind: "cron", owner_id: "retained-cron" },
+        ...[flow.flowId, "orphan-flow"]
+          .toSorted()
+          .map((owner_id) => ({ owner_kind: "flow", owner_id })),
+      ]);
+      upsertTaskWithDeliveryStateToSqlite({ task });
+      bindExecutionOwnerLifecycleMetadata({
+        db: openOpenClawStateDatabase().db,
+        ownerKind: "task",
+        ownerId: task.taskId,
+        binding: { contextId: "reset-context", executionId: "reset-execution" },
+      });
+      resetTaskFlowRegistryForTests({ persist: false });
+      expect(getTaskFlowById(flow.flowId)).toEqual(flow);
+
+      resetTaskFlowRegistryForTests();
+      expect(getTaskFlowById(flow.flowId)).toBeUndefined();
+      expect(loadTaskRegistryStateFromSqlite().tasks.get(task.taskId)).toEqual(task);
+      expect(readBindings()).toEqual([
+        { owner_kind: "cron", owner_id: "retained-cron" },
+        { owner_kind: "task", owner_id: task.taskId },
+      ]);
+    });
+  });
+
+  it("removes omitted delivery state without changing other task rows", async () => {
     await withOpenClawTestState(
       { layout: "state-only", prefix: "openclaw-task-delivery-prune-" },
       async () => {
@@ -1493,85 +1444,19 @@ describe("task-registry store runtime", () => {
           lastNotifiedEventAt: 200,
         };
 
-        saveTaskRegistryStateToSqlite({
-          tasks: new Map([
-            [taskA.taskId, taskA],
-            [taskB.taskId, taskB],
-          ]),
-          deliveryStates: new Map([
-            [deliveryA.taskId, deliveryA],
-            [deliveryB.taskId, deliveryB],
-          ]),
-        });
-
-        saveTaskRegistryStateToSqlite({
-          tasks: new Map([
-            [taskA.taskId, taskA],
-            [taskB.taskId, taskB],
-          ]),
-          deliveryStates: new Map([[deliveryB.taskId, deliveryB]]),
-        });
+        upsertTaskWithDeliveryStateToSqlite({ task: taskA, deliveryState: deliveryA });
+        upsertTaskWithDeliveryStateToSqlite({ task: taskB, deliveryState: deliveryB });
+        upsertTaskWithDeliveryStateToSqlite({ task: taskA });
 
         const restored = loadTaskRegistryStateFromSqlite();
+        expect(restored.tasks).toEqual(
+          new Map([
+            [taskA.taskId, taskA],
+            [taskB.taskId, taskB],
+          ]),
+        );
         expect(restored.deliveryStates.has(taskA.taskId)).toBe(false);
         expect(restored.deliveryStates.get(taskB.taskId)).toEqual(deliveryB);
-      },
-    );
-  });
-
-  it("prunes large sqlite snapshots without binding every task id at once", async () => {
-    await withOpenClawTestState(
-      { layout: "state-only", prefix: "openclaw-task-large-prune-" },
-      async () => {
-        const tasks = new Map<string, TaskRecord>();
-        const deliveryStates = new Map<string, TaskDeliveryState>();
-        for (let index = 0; index < 1_200; index++) {
-          const task: TaskRecord = {
-            ...createStoredTask(),
-            taskId: `task-large-${index}`,
-            runId: `run-large-${index}`,
-            createdAt: index,
-            lastEventAt: index,
-          };
-          tasks.set(task.taskId, task);
-          deliveryStates.set(task.taskId, {
-            taskId: task.taskId,
-            lastNotifiedEventAt: index,
-          });
-        }
-
-        saveTaskRegistryStateToSqlite({ tasks, deliveryStates });
-        const admitted: AdmittedRunContext = {
-          operationalRunInstance: { instanceId: "instance-task-prune", runId: "run-task-prune" },
-          executionIdentityToken: createExecutionIdentityAdmissionToken("run-task-prune", {
-            contextId: "context-task-prune",
-            executionId: "execution-task-prune",
-          }),
-        };
-        expect(bindTaskRunExecution({ admitted, taskId: "task-large-0" })).toBe("bound");
-        expect(bindTaskRunExecution({ admitted, taskId: "task-large-1199" })).toBe("bound");
-        const retainedTasks = new Map([...tasks].slice(100));
-        const retainedDeliveryStates = new Map([...deliveryStates].slice(100));
-        saveTaskRegistryStateToSqlite({
-          tasks: retainedTasks,
-          deliveryStates: retainedDeliveryStates,
-        });
-
-        const restored = loadTaskRegistryStateFromSqlite();
-        expect(restored.tasks.size).toBe(1_100);
-        expect(restored.deliveryStates.size).toBe(1_100);
-        expect(restored.tasks.has("task-large-0")).toBe(false);
-        expect(restored.tasks.has("task-large-1199")).toBe(true);
-        expect(
-          openOpenClawStateDatabase()
-            .db.prepare(
-              `SELECT owner_id
-               FROM execution_owner_lifecycle_bindings
-               WHERE owner_kind = 'task'
-               ORDER BY owner_id`,
-            )
-            .all(),
-        ).toEqual([{ owner_id: "task-large-1199" }]);
       },
     );
   });
@@ -1581,6 +1466,7 @@ describe("task-registry store runtime", () => {
       { layout: "state-only", prefix: "openclaw-task-binding-owner-" },
       async () => {
         const active = { ...createStoredTask(), taskId: "task-binding-active" };
+        const retained = { ...createStoredTask(), taskId: "task-binding-retained" };
         const terminal: TaskRecord = {
           ...createStoredTask(),
           taskId: "task-binding-terminal",
@@ -1592,14 +1478,9 @@ describe("task-registry store runtime", () => {
           taskId: "task-binding-stale",
           endedAt: 199,
         };
-        saveTaskRegistryStateToSqlite({
-          tasks: new Map([
-            [active.taskId, active],
-            [terminal.taskId, terminal],
-            [stale.taskId, stale],
-          ]),
-          deliveryStates: new Map(),
-        });
+        for (const task of [active, retained, terminal, stale]) {
+          upsertTaskWithDeliveryStateToSqlite({ task });
+        }
         const admitted: AdmittedRunContext = {
           operationalRunInstance: { instanceId: "instance-task-owner", runId: "run-task-owner" },
           executionIdentityToken: createExecutionIdentityAdmissionToken("run-task-owner", {
@@ -1617,26 +1498,33 @@ describe("task-registry store runtime", () => {
           tableExists(openOpenClawStateDatabase().db, "execution_owner_lifecycle_bindings"),
         ).toBe(false);
         expect(bindTaskRunExecution({ admitted, taskId: active.taskId })).toBe("bound");
+        expect(bindTaskRunExecution({ admitted, taskId: retained.taskId })).toBe("bound");
 
         const finished = { ...active, status: "succeeded" as const, endedAt: 210 };
-        saveTaskRegistryStateToSqlite({
-          tasks: new Map([
-            [finished.taskId, finished],
-            [terminal.taskId, terminal],
-            [stale.taskId, stale],
-          ]),
-          deliveryStates: new Map(),
-        });
+        upsertTaskWithDeliveryStateToSqlite({ task: finished });
         expect(bindTaskRunExecution({ admitted, taskId: finished.taskId })).toBe("missing");
         expect(
           openOpenClawStateDatabase()
             .db.prepare(
               `SELECT owner_id
                FROM execution_owner_lifecycle_bindings
-               WHERE owner_kind = 'task'`,
+               WHERE owner_kind = 'task' ORDER BY owner_id`,
             )
             .all(),
-        ).toEqual([{ owner_id: active.taskId }]);
+        ).toEqual([{ owner_id: active.taskId }, { owner_id: retained.taskId }]);
+
+        deleteTaskAndDeliveryStateFromSqlite(active.taskId);
+        const restored = loadTaskRegistryStateFromSqlite();
+        expect([...restored.tasks.keys()].toSorted()).toEqual(
+          [retained.taskId, terminal.taskId, stale.taskId].toSorted(),
+        );
+        expect(
+          openOpenClawStateDatabase()
+            .db.prepare(
+              "SELECT owner_id FROM execution_owner_lifecycle_bindings WHERE owner_kind = 'task'",
+            )
+            .all(),
+        ).toEqual([{ owner_id: retained.taskId }]);
       },
     );
   });
@@ -1646,10 +1534,7 @@ describe("task-registry store runtime", () => {
       { layout: "state-only", prefix: "openclaw-task-store-" },
       async () => {
         const task = createStoredTask();
-        saveTaskRegistryStateToSqlite({
-          tasks: new Map([[task.taskId, task]]),
-          deliveryStates: new Map(),
-        });
+        upsertTaskWithDeliveryStateToSqlite({ task });
 
         closeOpenClawStateDatabase();
 
@@ -1721,11 +1606,11 @@ describe("task-registry store runtime", () => {
 
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => ({
           tasks: new Map(sqliteState),
           deliveryStates: new Map(),
         }),
-        saveSnapshot: () => {},
         upsertTaskWithDeliveryState,
         deleteTaskWithDeliveryState,
         listTasksForOwnerKey,
@@ -1771,11 +1656,11 @@ describe("task-registry store runtime", () => {
     );
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => ({
           tasks: new Map(),
           deliveryStates: new Map(),
         }),
-        saveSnapshot: () => {},
         upsertTaskWithDeliveryState,
       },
     });
@@ -1815,11 +1700,11 @@ describe("task-registry store runtime", () => {
     );
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => ({
           tasks: new Map([[first.taskId, first]]),
           deliveryStates: new Map(),
         }),
-        saveSnapshot: () => {},
         upsertTaskWithDeliveryState,
       },
     });
@@ -1852,11 +1737,11 @@ describe("task-registry store runtime", () => {
     });
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => ({
           tasks: new Map(sqliteState),
           deliveryStates: new Map(),
         }),
-        saveSnapshot: () => {},
         upsertTaskWithDeliveryState: vi.fn(),
         deleteTaskWithDeliveryState,
       },
@@ -1869,19 +1754,17 @@ describe("task-registry store runtime", () => {
     expect(getTaskById(sqliteRow.taskId)?.status).toBe("running");
   });
 
-  it("deletes through a single atomic store call without a redundant delivery-state delete", () => {
+  it("deletes through a single atomic store call", () => {
     const deleteTaskWithDeliveryState = vi.fn();
-    const deleteDeliveryState = vi.fn();
     configureTaskRegistryRuntime({
       store: {
+        ...createInMemoryTaskRegistryStore(),
         loadSnapshot: () => ({
           tasks: new Map(),
           deliveryStates: new Map(),
         }),
-        saveSnapshot: () => {},
         upsertTaskWithDeliveryState: vi.fn(),
         deleteTaskWithDeliveryState,
-        deleteDeliveryState,
       },
     });
 
@@ -1898,105 +1781,109 @@ describe("task-registry store runtime", () => {
 
     expect(deleteTaskRecordById(created.taskId)).toBe(true);
 
-    // The composite delete already removes the task and its delivery state in a
-    // single transaction. A second, non-transactional delivery-state delete
-    // before the in-memory mutation would re-open the divergence window (sqlite
-    // deleted / memory retained) if it threw, so it must not be issued.
     expect(deleteTaskWithDeliveryState).toHaveBeenCalledTimes(1);
     expect(deleteTaskWithDeliveryState).toHaveBeenCalledWith(created.taskId);
-    expect(deleteDeliveryState).not.toHaveBeenCalled();
+    expect(getTaskById(created.taskId)).toBeUndefined();
   });
 
-  it("persists snapshot-only deletes without resurrecting the task", () => {
-    const persistedTaskIds: string[][] = [];
-    const persistedDeliveryIds: string[][] = [];
-    const saveSnapshot = vi.fn(
-      (snapshot: {
-        tasks: ReadonlyMap<string, TaskRecord>;
-        deliveryStates: ReadonlyMap<string, TaskDeliveryState>;
-      }) => {
-        // Capture the keys at call time. A real store serializes the snapshot
-        // immediately; holding the live map reference would let the in-memory
-        // delete (which runs after persistence) mask a resurrected row.
-        persistedTaskIds.push([...snapshot.tasks.keys()]);
-        persistedDeliveryIds.push([...snapshot.deliveryStates.keys()]);
-      },
-    );
-    configureTaskRegistryRuntime({
-      store: {
-        loadSnapshot: () => ({
-          tasks: new Map([[createStoredTask().taskId, createStoredTask()]]),
-          deliveryStates: new Map<string, TaskDeliveryState>([
-            ["task-restored", { taskId: "task-restored", lastNotifiedEventAt: 100 }],
-          ]),
-        }),
-        saveSnapshot,
-      },
-    });
+  it.each(["create", "update", "delete"] as const)(
+    "keeps SQLite and published task state atomic when %s persistence fails",
+    async (operation) => {
+      await withOpenClawTestState(
+        { layout: "state-only", prefix: `openclaw-task-atomic-${operation}-` },
+        async () => {
+          resetTaskRegistryForTests({ persist: false });
+          const params = {
+            runtime: "cli" as const,
+            ownerKey: "agent:main:main",
+            scopeKind: "session" as const,
+            runId: `atomic-${operation}`,
+            task: "Preserve task and delivery state together",
+            status: "running" as const,
+            deliveryStatus: "pending" as const,
+            notifyPolicy: "silent" as const,
+            requesterOrigin: { channel: "test-channel", to: "C1234567890" },
+          };
+          const existing = operation === "create" ? undefined : createTaskRecord(params);
+          const visibleBefore = listTaskRecords();
+          const storedBefore = loadTaskRegistryStateFromSqlite();
+          const observed: Array<{
+            kind: TaskRegistryObserverEvent["kind"];
+            stored: ReturnType<typeof loadTaskRegistryStateFromSqlite>;
+            visible: TaskRecord[];
+          }> = [];
+          configureTaskRegistryRuntime({
+            observers: {
+              onEvent: (event) => {
+                observed.push({
+                  kind: event.kind,
+                  stored: loadTaskRegistryStateFromSqliteReadOnly(),
+                  visible: listTaskRecords(),
+                });
+              },
+            },
+          });
+          const mutate = () => {
+            if (operation === "create") {
+              return createTaskRecordOrNull(params);
+            }
+            if (!existing) {
+              throw new Error("expected the existing task fixture");
+            }
+            return operation === "update"
+              ? updateTaskNotifyPolicyById({
+                  taskId: existing.taskId,
+                  notifyPolicy: "state_changes",
+                })
+              : deleteTaskRecordById(existing.taskId);
+          };
+          const { db } = openOpenClawStateDatabase();
+          const failingStatement =
+            operation === "delete" ? "DELETE ON task_runs" : "INSERT ON task_delivery_state";
+          // Fail the second statement: a missing transaction would leave the first row change behind.
+          db.exec(`
+            CREATE TEMP TRIGGER reject_task_write BEFORE ${failingStatement}
+            BEGIN SELECT RAISE(ABORT, 'synthetic task write failure'); END;
+          `);
+          try {
+            expect(mutate()).toBe(operation === "delete" ? false : null);
+            expect(loadTaskRegistryStateFromSqlite()).toEqual(storedBefore);
+            expect(listTaskRecords()).toEqual(visibleBefore);
+            expect(findTaskByRunId(params.runId)).toEqual(existing);
+            expect(observed).toEqual([]);
+          } finally {
+            db.exec("DROP TRIGGER reject_task_write");
+          }
 
-    // Trigger restore so the task and its delivery state are loaded into memory.
-    expect(findTaskByRunId("run-restored")?.taskId).toBe("task-restored");
-
-    expect(deleteTaskRecordById("task-restored")).toBe(true);
-
-    // A snapshot-only store persists the delete by saving a projected snapshot.
-    // The final persisted snapshot must exclude both the task and its delivery
-    // state; saving the task and delivery deletions as two separate snapshots
-    // would let the second save (built from the un-projected in-memory maps)
-    // resurrect the row the first save removed.
-    expect(saveSnapshot).toHaveBeenCalled();
-    expect(persistedTaskIds.at(-1)).not.toContain("task-restored");
-    expect(persistedDeliveryIds.at(-1)).not.toContain("task-restored");
-  });
-
-  it("persists deletes atomically for non-composite stores with separate delete methods", () => {
-    const backing = {
-      tasks: new Map<string, TaskRecord>(),
-      deliveryStates: new Map<string, TaskDeliveryState>(),
-    };
-    const deleteTask = vi.fn((taskId: string) => {
-      backing.tasks.delete(taskId);
-    });
-    const deleteDeliveryState = vi.fn((taskId: string) => {
-      backing.deliveryStates.delete(taskId);
-    });
-    const saveSnapshot = vi.fn(
-      (snapshot: {
-        tasks: ReadonlyMap<string, TaskRecord>;
-        deliveryStates: ReadonlyMap<string, TaskDeliveryState>;
-      }) => {
-        backing.tasks = new Map(snapshot.tasks);
-        backing.deliveryStates = new Map(snapshot.deliveryStates);
-      },
-    );
-    configureTaskRegistryRuntime({
-      store: {
-        loadSnapshot: () => ({
-          tasks: new Map([[createStoredTask().taskId, createStoredTask()]]),
-          deliveryStates: new Map<string, TaskDeliveryState>([
-            ["task-restored", { taskId: "task-restored", lastNotifiedEventAt: 100 }],
-          ]),
-        }),
-        saveSnapshot,
-        // Non-composite store: separate task / delivery-state deletes, no
-        // deleteTaskWithDeliveryState.
-        deleteTask,
-        deleteDeliveryState,
-      },
-    });
-
-    // Trigger restore so the task and its delivery state are loaded into memory.
-    expect(findTaskByRunId("run-restored")?.taskId).toBe("task-restored");
-
-    expect(deleteTaskRecordById("task-restored")).toBe(true);
-
-    // Without a composite delete, the removal of both the task and its delivery
-    // state is persisted atomically through one projected snapshot, so neither a
-    // leftover delivery-state row nor a two-write divergence window remains.
-    expect(backing.tasks.has("task-restored")).toBe(false);
-    expect(backing.deliveryStates.has("task-restored")).toBe(false);
-    expect(deleteTask).not.toHaveBeenCalled();
-    expect(deleteDeliveryState).not.toHaveBeenCalled();
-  });
+          const result = mutate();
+          expect(result).not.toBeNull();
+          expect(result).not.toBe(false);
+          const storedAfter = loadTaskRegistryStateFromSqlite();
+          if (operation === "delete") {
+            expect(storedAfter.tasks.size).toBe(0);
+            expect(storedAfter.deliveryStates.size).toBe(0);
+            expect(findTaskByRunId(params.runId)).toBeUndefined();
+          } else {
+            const current = findTaskByRunId(params.runId);
+            expect(current).toMatchObject({
+              notifyPolicy: operation === "update" ? "state_changes" : "silent",
+            });
+            expect(storedAfter.tasks.get(current?.taskId ?? "")).toMatchObject({
+              task: params.task,
+              notifyPolicy: operation === "update" ? "state_changes" : "silent",
+            });
+            expect(storedAfter.deliveryStates.get(current?.taskId ?? "")?.requesterOrigin).toEqual(
+              params.requesterOrigin,
+            );
+          }
+          expect(observed.map((event) => event.kind)).toEqual([
+            operation === "delete" ? "deleted" : "upserted",
+          ]);
+          expect(observed[0]?.stored).toEqual(storedAfter);
+          expect(observed[0]?.visible).toEqual(listTaskRecords());
+        },
+      );
+    },
+  );
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/tasks/task-registry.store.ts
+++ b/src/tasks/task-registry.store.ts
@@ -2,14 +2,10 @@
 import {
   closeTaskRegistryDatabase,
   deleteTaskAndDeliveryStateFromSqlite,
-  deleteTaskDeliveryStateFromSqlite,
-  deleteTaskRegistryRecordFromSqlite,
   loadTaskRegistryStateFromSqlite,
   listTaskRegistryRecordsByOwnerKeyFromSqlite,
-  saveTaskRegistryStateToSqlite,
   upsertTaskWithDeliveryStateToSqlite,
   upsertTaskDeliveryStateToSqlite,
-  upsertTaskRegistryRecordToSqlite,
 } from "./task-registry.store.sqlite.js";
 import type { TaskRegistryStoreSnapshot } from "./task-registry.store.types.js";
 import type { TaskDeliveryState, TaskRecord } from "./task-registry.types.js";
@@ -18,17 +14,13 @@ export type { TaskRegistryStoreSnapshot } from "./task-registry.store.types.js";
 
 export type TaskRegistryStore = {
   loadSnapshot: () => TaskRegistryStoreSnapshot;
-  saveSnapshot: (snapshot: TaskRegistryStoreSnapshot) => void;
   listTasksForOwnerKey?: (ownerKey: string) => TaskRecord[];
-  upsertTaskWithDeliveryState?: (params: {
+  upsertTaskWithDeliveryState: (params: {
     task: TaskRecord;
     deliveryState?: TaskDeliveryState;
   }) => void;
-  upsertTask?: (task: TaskRecord) => void;
-  deleteTaskWithDeliveryState?: (taskId: string) => void;
-  deleteTask?: (taskId: string) => void;
-  upsertDeliveryState?: (state: TaskDeliveryState) => void;
-  deleteDeliveryState?: (taskId: string) => void;
+  deleteTaskWithDeliveryState: (taskId: string) => void;
+  upsertDeliveryState: (state: TaskDeliveryState) => void;
   close?: () => void;
 };
 
@@ -49,20 +41,16 @@ export type TaskRegistryObserverEvent =
     };
 
 type TaskRegistryObservers = {
-  // Observers are incremental/best-effort only. Snapshot persistence belongs to TaskRegistryStore.
+  // Observers are incremental/best-effort only. Persistence belongs to TaskRegistryStore.
   onEvent?: (event: TaskRegistryObserverEvent) => void;
 };
 
 const defaultTaskRegistryStore: TaskRegistryStore = {
   loadSnapshot: loadTaskRegistryStateFromSqlite,
-  saveSnapshot: saveTaskRegistryStateToSqlite,
   listTasksForOwnerKey: listTaskRegistryRecordsByOwnerKeyFromSqlite,
   upsertTaskWithDeliveryState: upsertTaskWithDeliveryStateToSqlite,
-  upsertTask: upsertTaskRegistryRecordToSqlite,
   deleteTaskWithDeliveryState: deleteTaskAndDeliveryStateFromSqlite,
-  deleteTask: deleteTaskRegistryRecordFromSqlite,
   upsertDeliveryState: upsertTaskDeliveryStateToSqlite,
-  deleteDeliveryState: deleteTaskDeliveryStateFromSqlite,
   close: closeTaskRegistryDatabase,
 };
 

--- a/src/tasks/task-registry.test-support.ts
+++ b/src/tasks/task-registry.test-support.ts
@@ -1,3 +1,4 @@
+import { clearTaskRegistrySqliteForTests } from "../test-utils/task-registry-sqlite.js";
 import type { TaskRegistryControlRuntime } from "./task-registry-control.types.js";
 import type { TaskRegistryDeliveryRuntime } from "./task-registry-state.js";
 import { createTaskRecord as createTaskRecordOrNull } from "./task-registry.js";
@@ -42,7 +43,7 @@ type TaskRegistryTestApi = {
     taskId: string,
     latestEvent?: TaskEventRecord,
   ): Promise<TaskRecord | null>;
-  resetTaskRegistryForTests(opts?: { persist?: boolean }): void;
+  resetTaskRegistryForTests(): void;
   resetTaskRegistryDeliveryRuntimeForTests(): void;
   setTaskRegistryDeliveryRuntimeForTests(runtime: TaskRegistryDeliveryRuntime): void;
   resetTaskRegistryControlRuntimeForTests(): void;
@@ -67,7 +68,10 @@ export async function maybeDeliverTaskStateChangeUpdate(
 }
 
 export function resetTaskRegistryForTests(opts?: { persist?: boolean }): void {
-  getTestApi().resetTaskRegistryForTests(opts);
+  getTestApi().resetTaskRegistryForTests();
+  if (opts?.persist !== false) {
+    clearTaskRegistrySqliteForTests("task");
+  }
 }
 
 export function resetTaskRegistryDeliveryRuntimeForTests(): void {

--- a/src/tasks/task-registry.test.ts
+++ b/src/tasks/task-registry.test.ts
@@ -45,6 +45,10 @@ import type { DB as OpenClawStateKyselyDatabase } from "../state/openclaw-state-
 import { openOpenClawStateDatabase } from "../state/openclaw-state-db.js";
 import { withTestDir } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import {
+  createInMemoryTaskRegistryStore,
+  createInMemoryTaskFlowRegistryStore,
+} from "../test-utils/task-registry-store.js";
 import { collectCronHistoryOverflowTaskIds } from "./cron-history-retention.js";
 import { CRON_TASK_KIND } from "./cron-task-contract.js";
 import { SUBAGENT_KILL_TASK_ERROR } from "./detached-task-runtime-contract.js";
@@ -403,81 +407,6 @@ function finalizeSubagentTask(
   params: Omit<Parameters<typeof finalizeTaskRecordByRunId>[0], "runId" | "runtime">,
 ) {
   return finalizeTaskRecordByRunId({ runId: task.runId!, runtime: "subagent", ...params });
-}
-
-function createInMemoryTaskRegistryStore() {
-  const tasks = new Map<string, TaskRecord>();
-  const deliveryStates = new Map<string, TaskDeliveryState>();
-  return {
-    loadSnapshot: () => ({
-      tasks: new Map(tasks),
-      deliveryStates: new Map(deliveryStates),
-    }),
-    saveSnapshot: (snapshot: {
-      tasks: Map<string, TaskRecord>;
-      deliveryStates: Map<string, TaskDeliveryState>;
-    }) => {
-      tasks.clear();
-      deliveryStates.clear();
-      for (const [taskId, task] of snapshot.tasks.entries()) {
-        tasks.set(taskId, task);
-      }
-      for (const [taskId, state] of snapshot.deliveryStates.entries()) {
-        deliveryStates.set(taskId, state);
-      }
-    },
-    upsertTaskWithDeliveryState: (params: {
-      task: TaskRecord;
-      deliveryState?: TaskDeliveryState;
-    }) => {
-      tasks.set(params.task.taskId, params.task);
-      if (params.deliveryState) {
-        deliveryStates.set(params.deliveryState.taskId, params.deliveryState);
-      } else {
-        deliveryStates.delete(params.task.taskId);
-      }
-    },
-    upsertTask: (task: TaskRecord) => {
-      tasks.set(task.taskId, task);
-    },
-    deleteTaskWithDeliveryState: (taskId: string) => {
-      tasks.delete(taskId);
-      deliveryStates.delete(taskId);
-    },
-    deleteTask: (taskId: string) => {
-      tasks.delete(taskId);
-      deliveryStates.delete(taskId);
-    },
-    upsertDeliveryState: (state: TaskDeliveryState) => {
-      deliveryStates.set(state.taskId, state);
-    },
-    deleteDeliveryState: (taskId: string) => {
-      deliveryStates.delete(taskId);
-    },
-    close: () => {},
-  };
-}
-
-function createInMemoryTaskFlowRegistryStore() {
-  const flows = new Map<string, TaskFlowRecord>();
-  return {
-    loadSnapshot: () => ({
-      flows: new Map(flows),
-    }),
-    saveSnapshot: (snapshot: { flows: Map<string, TaskFlowRecord> }) => {
-      flows.clear();
-      for (const [flowId, flow] of snapshot.flows.entries()) {
-        flows.set(flowId, flow);
-      }
-    },
-    upsertFlow: (flow: TaskFlowRecord) => {
-      flows.set(flow.flowId, flow);
-    },
-    deleteFlow: (flowId: string) => {
-      flows.delete(flowId);
-    },
-    close: () => {},
-  };
 }
 
 function configureInMemoryTaskStoresForTests() {
@@ -1797,8 +1726,8 @@ describe("task-registry", () => {
       });
       configureTaskFlowRegistryRuntime({
         store: {
+          ...createInMemoryTaskFlowRegistryStore(),
           loadSnapshot,
-          saveSnapshot: () => {},
         },
       });
 
@@ -1852,16 +1781,16 @@ describe("task-registry", () => {
       }));
       configureTaskRegistryRuntime({
         store: {
+          ...createInMemoryTaskRegistryStore(),
           loadSnapshot: loadTaskSnapshot,
-          saveSnapshot: () => {},
         },
       });
       configureTaskFlowRegistryRuntime({
         store: {
+          ...createInMemoryTaskFlowRegistryStore(),
           loadSnapshot: () => {
             throw new Error("SQLITE_CORRUPT: task-flow startup restore failed");
           },
-          saveSnapshot: () => {},
         },
       });
 
@@ -1880,10 +1809,10 @@ describe("task-registry", () => {
       });
       configureTaskRegistryRuntime({
         store: {
+          ...createInMemoryTaskRegistryStore(),
           loadSnapshot: () => {
             throw new Error("SQLITE_IOERR: task startup restore failed");
           },
-          saveSnapshot: () => {},
         },
       });
 
@@ -1925,10 +1854,10 @@ describe("task-registry", () => {
       });
       configureTaskFlowRegistryRuntime({
         store: {
+          ...createInMemoryTaskFlowRegistryStore(),
           loadSnapshot: () => ({
             flows: new Map(),
           }),
-          saveSnapshot: () => {},
           upsertFlow,
         },
       });
@@ -1994,10 +1923,10 @@ describe("task-registry", () => {
       let failUpsert = true;
       configureTaskFlowRegistryRuntime({
         store: {
+          ...createInMemoryTaskFlowRegistryStore(),
           loadSnapshot: () => ({
             flows: new Map(),
           }),
-          saveSnapshot: () => {},
           upsertFlow: () => {
             if (failUpsert) {
               throw new Error("SQLITE_BUSY: database is locked");
@@ -3789,6 +3718,7 @@ describe("task-registry", () => {
       const now = Date.now();
       configureTaskRegistryRuntime({
         store: {
+          ...createInMemoryTaskRegistryStore(),
           loadSnapshot: () => ({
             tasks: new Map([
               [
@@ -3812,7 +3742,6 @@ describe("task-registry", () => {
             ]),
             deliveryStates: new Map(),
           }),
-          saveSnapshot: () => {},
         },
       });
 
@@ -4204,6 +4133,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       configureTaskRegistryRuntime({
         store: {
+          ...createInMemoryTaskRegistryStore(),
           loadSnapshot: () => ({
             tasks: new Map([
               [
@@ -4227,7 +4157,6 @@ describe("task-registry", () => {
             ]),
             deliveryStates: new Map(),
           }),
-          saveSnapshot: () => {},
         },
       });
 
@@ -4243,6 +4172,7 @@ describe("task-registry", () => {
     await withTaskRegistryTempDir(async () => {
       configureTaskRegistryRuntime({
         store: {
+          ...createInMemoryTaskRegistryStore(),
           loadSnapshot: () => ({
             tasks: new Map([
               [
@@ -4265,7 +4195,6 @@ describe("task-registry", () => {
             ]),
             deliveryStates: new Map(),
           }),
-          saveSnapshot: () => {},
         },
       });
 
@@ -4282,12 +4211,11 @@ describe("task-registry", () => {
       let durableTasks = new Map<string, ReturnType<typeof createTaskFixture>>();
       configureTaskRegistryRuntime({
         store: {
+          ...createInMemoryTaskRegistryStore(),
           loadSnapshot: () => ({
             tasks: durableTasks,
             deliveryStates: new Map(),
           }),
-          saveSnapshot: () => {},
-          upsertTask: () => {},
           upsertTaskWithDeliveryState: () => {},
         },
       });
@@ -4357,6 +4285,7 @@ describe("task-registry", () => {
       let restoreShouldFail = true;
       configureTaskRegistryRuntime({
         store: {
+          ...createInMemoryTaskRegistryStore(),
           loadSnapshot: () => {
             if (restoreShouldFail) {
               throw new Error("SQLITE_IOERR: initial task restore failed");
@@ -4366,7 +4295,6 @@ describe("task-registry", () => {
               deliveryStates: new Map(),
             };
           },
-          saveSnapshot: () => {},
         },
       });
 
@@ -4412,6 +4340,7 @@ describe("task-registry", () => {
       let restoreError: Error | null = null;
       configureTaskRegistryRuntime({
         store: {
+          ...createInMemoryTaskRegistryStore(),
           loadSnapshot: () => {
             if (restoreError) {
               throw restoreError;
@@ -4421,7 +4350,6 @@ describe("task-registry", () => {
               deliveryStates: new Map(),
             };
           },
-          saveSnapshot: () => {},
         },
       });
       expect(getTaskById(storedTask.taskId)?.taskId).toBe(storedTask.taskId);
@@ -4447,6 +4375,7 @@ describe("task-registry", () => {
       const now = Date.now();
       configureTaskRegistryRuntime({
         store: {
+          ...createInMemoryTaskRegistryStore(),
           loadSnapshot: () => ({
             tasks: new Map([
               [
@@ -4470,7 +4399,6 @@ describe("task-registry", () => {
             ]),
             deliveryStates: new Map(),
           }),
-          saveSnapshot: () => {},
         },
       });
 

--- a/src/test-utils/task-registry-runtime.ts
+++ b/src/test-utils/task-registry-runtime.ts
@@ -1,71 +1,10 @@
 // Test runtime helpers for task registry state and deterministic cleanup.
-import {
-  configureTaskRegistryRuntime,
-  type TaskRegistryStore,
-  type TaskRegistryStoreSnapshot,
-} from "../tasks/task-registry.store.js";
-import type { TaskDeliveryState, TaskRecord } from "../tasks/task-registry.types.js";
-
-// Clone snapshots across load/save so tests catch accidental shared mutation.
-function cloneTask(task: TaskRecord): TaskRecord {
-  return { ...task };
-}
-
-function cloneDeliveryState(state: TaskDeliveryState): TaskDeliveryState {
-  return {
-    ...state,
-    ...(state.requesterOrigin ? { requesterOrigin: { ...state.requesterOrigin } } : {}),
-  };
-}
+import { configureTaskRegistryRuntime } from "../tasks/task-registry.store.js";
+import { createInMemoryTaskRegistryStore } from "./task-registry-store.js";
 
 /** Installs an in-memory task registry store for tests that avoid disk state. */
-export function installInMemoryTaskRegistryRuntime(): {
-  taskStore: TaskRegistryStore;
-} {
-  let taskSnapshot: TaskRegistryStoreSnapshot = {
-    tasks: new Map<string, TaskRecord>(),
-    deliveryStates: new Map<string, TaskDeliveryState>(),
-  };
-
-  const taskStore: TaskRegistryStore = {
-    loadSnapshot: () => ({
-      tasks: new Map(
-        [...taskSnapshot.tasks.entries()].map(([taskId, task]) => [taskId, cloneTask(task)]),
-      ),
-      deliveryStates: new Map(
-        [...taskSnapshot.deliveryStates.entries()].map(([taskId, state]) => [
-          taskId,
-          cloneDeliveryState(state),
-        ]),
-      ),
-    }),
-    saveSnapshot: (snapshot) => {
-      taskSnapshot = {
-        tasks: new Map(
-          [...snapshot.tasks.entries()].map(([taskId, task]) => [taskId, cloneTask(task)]),
-        ),
-        deliveryStates: new Map(
-          [...snapshot.deliveryStates.entries()].map(([taskId, state]) => [
-            taskId,
-            cloneDeliveryState(state),
-          ]),
-        ),
-      };
-    },
-    upsertTask: (task) => {
-      taskSnapshot.tasks.set(task.taskId, cloneTask(task));
-    },
-    deleteTask: (taskId) => {
-      taskSnapshot.tasks.delete(taskId);
-    },
-    upsertDeliveryState: (state) => {
-      taskSnapshot.deliveryStates.set(state.taskId, cloneDeliveryState(state));
-    },
-    deleteDeliveryState: (taskId) => {
-      taskSnapshot.deliveryStates.delete(taskId);
-    },
-  };
-
+export function installInMemoryTaskRegistryRuntime() {
+  const taskStore = createInMemoryTaskRegistryStore();
   configureTaskRegistryRuntime({ store: taskStore });
   return { taskStore };
 }

--- a/src/test-utils/task-registry-sqlite.ts
+++ b/src/test-utils/task-registry-sqlite.ts
@@ -1,0 +1,48 @@
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
+import { tableExists } from "../state/openclaw-state-db-schema-helpers.js";
+import type { DB as OpenClawStateDatabase } from "../state/openclaw-state-db.generated.js";
+import {
+  closeOpenClawStateDatabase,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+import { upsertTaskWithDeliveryStateToSqlite } from "../tasks/task-registry.store.sqlite.js";
+import type { TaskRecord } from "../tasks/task-registry.types.js";
+
+export function clearTaskRegistrySqliteForTests(ownerKind: "task" | "flow"): void {
+  try {
+    runOpenClawStateWriteTransaction(({ db }) => {
+      const kysely = getNodeSqliteKysely<OpenClawStateDatabase>(db);
+      if (ownerKind === "task") {
+        executeSqliteQuerySync(db, kysely.deleteFrom("task_delivery_state"));
+        executeSqliteQuerySync(db, kysely.deleteFrom("task_runs"));
+      } else {
+        executeSqliteQuerySync(db, kysely.deleteFrom("flow_runs"));
+      }
+      // Reset selected-family orphans without enabling optional lifecycle metadata.
+      if (tableExists(db, "execution_owner_lifecycle_bindings")) {
+        executeSqliteQuerySync(
+          db,
+          kysely
+            .deleteFrom("execution_owner_lifecycle_bindings")
+            .where("owner_kind", "=", ownerKind),
+        );
+      }
+    });
+  } catch (error) {
+    const subsystem = ownerKind === "task" ? "tasks/registry" : "tasks/task-flow-registry";
+    createSubsystemLogger(subsystem).warn(`Failed to reset ${ownerKind} registry storage`, {
+      error,
+    });
+  } finally {
+    closeOpenClawStateDatabase();
+  }
+}
+
+export function seedTaskRegistryRowsForTests(tasks: Iterable<TaskRecord>): void {
+  runOpenClawStateWriteTransaction(() => {
+    for (const task of tasks) {
+      upsertTaskWithDeliveryStateToSqlite({ task });
+    }
+  });
+}

--- a/src/test-utils/task-registry-store.ts
+++ b/src/test-utils/task-registry-store.ts
@@ -1,0 +1,46 @@
+import type { getTaskFlowRegistryStore } from "../tasks/task-flow-registry.store.js";
+import type { TaskFlowRegistryStoreSnapshot } from "../tasks/task-flow-registry.store.types.js";
+import type { TaskRegistryStore, TaskRegistryStoreSnapshot } from "../tasks/task-registry.store.js";
+
+type TaskFlowRegistryStore = ReturnType<typeof getTaskFlowRegistryStore>;
+
+export function createInMemoryTaskRegistryStore(
+  snapshot: TaskRegistryStoreSnapshot = { tasks: new Map(), deliveryStates: new Map() },
+): TaskRegistryStore {
+  const state = structuredClone(snapshot);
+  return {
+    loadSnapshot: () => structuredClone(state),
+    upsertTaskWithDeliveryState: ({ task, deliveryState }) => {
+      const nextTask = structuredClone(task);
+      const nextDeliveryState = deliveryState ? structuredClone(deliveryState) : undefined;
+      state.tasks.set(task.taskId, nextTask);
+      if (nextDeliveryState) {
+        state.deliveryStates.set(task.taskId, nextDeliveryState);
+      } else {
+        state.deliveryStates.delete(task.taskId);
+      }
+    },
+    deleteTaskWithDeliveryState: (taskId) => {
+      state.tasks.delete(taskId);
+      state.deliveryStates.delete(taskId);
+    },
+    upsertDeliveryState: (deliveryState) => {
+      state.deliveryStates.set(deliveryState.taskId, structuredClone(deliveryState));
+    },
+  };
+}
+
+export function createInMemoryTaskFlowRegistryStore(
+  snapshot: TaskFlowRegistryStoreSnapshot = { flows: new Map() },
+): TaskFlowRegistryStore {
+  const state = structuredClone(snapshot);
+  return {
+    loadSnapshot: () => structuredClone(state),
+    upsertFlow: (flow) => {
+      state.flows.set(flow.flowId, structuredClone(flow));
+    },
+    deleteFlow: (flowId) => {
+      state.flows.delete(flowId);
+    },
+  };
+}

--- a/test/helpers/acp-manager-task-state.ts
+++ b/test/helpers/acp-manager-task-state.ts
@@ -31,7 +31,6 @@ export async function withAcpManagerTaskStateDir(
         loadSnapshot: () => ({
           flows: new Map(),
         }),
-        saveSnapshot: () => {},
         upsertFlow: () => {},
         deleteFlow: () => {},
         close: () => {},


### PR DESCRIPTION
Closes #141661

## What Problem This Solves

Maintaining task persistence required two write strategies even though the shipped stores already support atomic row operations. Partial test adapters kept full-snapshot fallbacks, temporary-table reconciliation and orphan-pruning code in production, while some storage-failure tests only threw SQLite-shaped errors from memory stores.

## Why This Change Was Made

Require atomic task-plus-delivery writes and flow row writes, then remove the unused snapshot writers and their pruning helpers. Shared complete memory fixtures preserve fast tests; narrow test-owned reset and seeding helpers replace the former production setup API. Canonical snapshot readers, SQLite transactions, lifecycle binding and exact-owner deletion remain with their existing owners.

## User Impact

No public API, configuration, schema or task behavior changes. Gateway observers, optional owner reads and the benchmark's no-op persistence mode remain supported. The maintenance surface is smaller, and the retained persistence contract is tested against real SQLite failures.

## Evidence

589 distinct cases pass across 25 owner and consumer files. Three create/update/delete cases fail the second SQLite statement, verify durable and in-memory state remain unchanged with no observer event, then verify successful publication sees committed rows through the read-only loader. A temporary transaction bypass makes all three fail for the intended partial-write differences; original transaction code was restored.

Existing two-connection read-snapshot proof is unchanged. Scoped reset tests preserve other-family metadata and leave optional tables absent; lifecycle tests retain exact deletion, surviving bindings and read-only parity. All 41 selected check stages pass. The synthetic size-four benchmark passes in memory and durable modes: no SQLite state in memory mode, four persisted task/subagent rows in durable mode, and clean teardown in both.

The complete patch removes 270 production code lines, 196 test/support lines and five tooling lines: 471 maintained code lines / 536 physical lines, including both new test helpers. Fresh independent review through P2 is scoped-clean with no actionable findings. Hosted CI will run on the published head before landing. No live provider or remote-platform result is claimed.
