### PR TITLE
test(release): require completed managed survivor evidence

### DIFF
--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -1,6 +1,6 @@
 import assertStrict from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 // Assertions for upgrade-survivor E2E scenarios.
 import fs from "node:fs";
 import path from "node:path";
@@ -677,7 +677,7 @@ function assertStateSurvived() {
     "legacy session file missing",
   );
   if (stage !== "baseline") {
-    assertSessionMetadataMigrated(stateDir);
+    assertSessionMetadataMigrated(stateDir, stage);
   }
   if (scenario === "meeting-transcripts-sqlite") {
     assertMeetingTranscriptsMigrated(stateDir, stage);
@@ -966,7 +966,100 @@ function assertMeetingTranscriptExport(stateDir) {
   );
 }
 
-function assertSessionMetadataMigrated(stateDir) {
+async function assertRestartServingTurn(file) {
+  assert(file, "assert-restart-serving-turn requires an output path");
+  const sessionKey = "agent:main:main";
+  const marker = `OPENCLAW_E2E_SURVIVOR_${randomUUID().replaceAll("-", "").toUpperCase()}`;
+  const token = requireEnv("GATEWAY_AUTH_TOKEN_REF");
+  const deadline = Date.now() + 120_000;
+  const call = (method, params) => {
+    const remainingMs = deadline - Date.now();
+    assert(remainingMs > 0, "managed serving turn exceeded its two-minute budget");
+    let output;
+    try {
+      output = execFileSync(
+        "openclaw",
+        [
+          "gateway",
+          "call",
+          method,
+          "--url",
+          "ws://127.0.0.1:18789",
+          "--token",
+          token,
+          "--timeout",
+          String(remainingMs),
+          "--json",
+          "--params",
+          JSON.stringify(params),
+        ],
+        { timeout: remainingMs, maxBuffer: 2 * 1024 * 1024, encoding: "utf8" },
+      );
+    } catch (error) {
+      // execFileSync errors include argv; never retain the authentication token.
+      // eslint-disable-next-line preserve-caught-error -- Never retain credential-bearing argv.
+      throw new Error(
+        `${method} managed serving probe failed (status ${error.status ?? "unknown"})`,
+      );
+    }
+    return JSON.parse(output);
+  };
+  const accepted = call("chat.send", {
+    sessionKey,
+    message: `Reply with exactly ${marker} and no other text. Do not use tools.`,
+    idempotencyKey: randomUUID(),
+    thinking: "off",
+    deliver: false,
+    timeoutMs: 90_000,
+  });
+  assert(
+    accepted?.status === "started" &&
+      typeof accepted.runId === "string" &&
+      accepted.runId.length > 0,
+    "managed serving turn did not start",
+  );
+  let completion;
+  do {
+    completion = call("agent.wait", { runId: accepted.runId, timeoutMs: 90_000 });
+    assert(completion?.runId === accepted.runId, "managed serving wait changed the run identity");
+    if (completion.status === "pending") {
+      await new Promise((resolve) => {
+        setTimeout(resolve, Math.min(500, Math.max(0, deadline - Date.now())));
+      });
+    }
+  } while (completion.status === "pending");
+  assert(
+    completion?.runId === accepted.runId &&
+      completion.status === "ok" &&
+      Number.isFinite(completion.endedAt) &&
+      !completion.error,
+    "managed serving turn did not complete successfully",
+  );
+  const history = call("chat.history", { sessionKey, limit: 100 });
+  assert(
+    history?.sessionId === LEGACY_SESSION_MAIN_ID,
+    "serving turn changed the migrated main session",
+  );
+  const reply = history.messages?.find(
+    (message) =>
+      message?.role === "assistant" &&
+      (typeof message.content === "string"
+        ? message.content === marker
+        : Array.isArray(message.content) &&
+          message.content.some((block) => block?.type === "text" && block.text === marker)),
+  );
+  assert(reply, "managed serving reply was not persisted in migrated main history");
+  writeJson(file, {
+    sessionKey,
+    sessionId: history.sessionId,
+    marker,
+    runId: accepted.runId,
+    completion,
+    reply,
+  });
+}
+
+function assertSessionMetadataMigrated(stateDir, stage) {
   const legacyStorePath = path.join(stateDir, "sessions", "sessions.json");
   const agentSessionsDir = path.join(stateDir, "agents", "main", "sessions");
   const targetStorePath = path.join(agentSessionsDir, "sessions.json");
@@ -1019,10 +1112,24 @@ function assertSessionMetadataMigrated(stateDir) {
       );
     }
   }
-  assert(
-    main.skillsSnapshot?.prompt === "legacy prompt survives as metadata",
-    "legacy session metadata prompt was not preserved",
-  );
+  // Migration preserves the legacy prompt. A completed serving turn rebuilds
+  // that cache; durable session identity and history must survive both stages.
+  if (stage === "post-inference") {
+    const snapshot = main.skillsSnapshot;
+    assert(
+      typeof snapshot?.prompt === "string" &&
+        snapshot.prompt !== "legacy prompt survives as metadata" &&
+        Array.isArray(snapshot.skills) &&
+        Number.isSafeInteger(snapshot.promptFormatVersion) &&
+        snapshot.promptFormatVersion > 0,
+      "serving turn did not persist a valid refreshed skills snapshot",
+    );
+  } else {
+    assert(
+      main.skillsSnapshot?.prompt === "legacy prompt survives as metadata",
+      "legacy session metadata prompt was not preserved",
+    );
+  }
   assert(
     main.skillsSnapshot?.resolvedSkills === undefined,
     "heavy resolvedSkills cache was persisted into migrated session metadata",
@@ -1800,6 +1907,8 @@ if (command === "list-scenarios") {
   seedUpgradeVolume(stateDir);
 } else if (command === "assert-config") {
   assertConfigSurvived();
+} else if (command === "assert-restart-serving-turn") {
+  await assertRestartServingTurn(process.argv[3]);
 } else if (command === "assert-state") {
   assertStateSurvived();
   assertConfiguredPluginInstalls();

--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -1022,12 +1022,12 @@ async function assertRestartServingTurn(file) {
   do {
     completion = call("agent.wait", { runId: accepted.runId, timeoutMs: 90_000 });
     assert(completion?.runId === accepted.runId, "managed serving wait changed the run identity");
-    if (completion.status === "pending") {
+    if (completion.status === "pending" || completion.status === "timeout") {
       await new Promise((resolve) => {
         setTimeout(resolve, Math.min(500, Math.max(0, deadline - Date.now())));
       });
     }
-  } while (completion.status === "pending");
+  } while (completion.status === "pending" || completion.status === "timeout");
   assert(
     completion?.runId === accepted.runId &&
       completion.status === "ok" &&

--- a/scripts/e2e/lib/upgrade-survivor/assertions.mjs
+++ b/scripts/e2e/lib/upgrade-survivor/assertions.mjs
@@ -1,5 +1,5 @@
 import assertStrict from "node:assert/strict";
-import { execFileSync } from "node:child_process";
+import { execFileSync, spawnSync } from "node:child_process";
 import { createHash, randomUUID } from "node:crypto";
 // Assertions for upgrade-survivor E2E scenarios.
 import fs from "node:fs";
@@ -975,34 +975,31 @@ async function assertRestartServingTurn(file) {
   const call = (method, params) => {
     const remainingMs = deadline - Date.now();
     assert(remainingMs > 0, "managed serving turn exceeded its two-minute budget");
-    let output;
-    try {
-      output = execFileSync(
-        "openclaw",
-        [
-          "gateway",
-          "call",
-          method,
-          "--url",
-          "ws://127.0.0.1:18789",
-          "--token",
-          token,
-          "--timeout",
-          String(remainingMs),
-          "--json",
-          "--params",
-          JSON.stringify(params),
-        ],
-        { timeout: remainingMs, maxBuffer: 2 * 1024 * 1024, encoding: "utf8" },
-      );
-    } catch (error) {
-      // execFileSync errors include argv; never retain the authentication token.
-      // eslint-disable-next-line preserve-caught-error -- Never retain credential-bearing argv.
+    const result = spawnSync(
+      "openclaw",
+      [
+        "gateway",
+        "call",
+        method,
+        "--url",
+        "ws://127.0.0.1:18789",
+        "--token",
+        token,
+        "--timeout",
+        String(remainingMs),
+        "--json",
+        "--params",
+        JSON.stringify(params),
+      ],
+      { timeout: remainingMs, maxBuffer: 2 * 1024 * 1024, encoding: "utf8" },
+    );
+    if (result.error || result.status !== 0) {
+      // Keep credential-bearing argv, stderr, and error objects out of failures.
       throw new Error(
-        `${method} managed serving probe failed (status ${error.status ?? "unknown"})`,
+        `${method} managed serving probe failed (status ${result.status ?? "unknown"})`,
       );
     }
-    return JSON.parse(output);
+    return JSON.parse(result.stdout);
   };
   const accepted = call("chat.send", {
     sessionKey,

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -110,6 +110,7 @@ restart_registry_pid=""
 restart_runtime_evidence=""
 restart_fixture_package=""
 restart_inference=""
+survival_assert_stage="survival"
 baseline_spec=""
 baseline_version=""
 baseline_version_expected="0"
@@ -990,7 +991,7 @@ assert.deepEqual(result.steps, [], "second update executed package mutations");
 assert(!result.nextAction, "second update requested repair");
 console.log("Second update: already-current, no package mutations or repair required.");
 NODE
-  assert_survival
+  assert_survival || return "$?"
   check_gateway_probes
 }
 
@@ -1225,11 +1226,11 @@ prepare_update_restart_probe() {
 
 assert_baseline_state() {
   OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE=baseline \
-    node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-exec-approvals
+    node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-exec-approvals || return "$?"
   OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE=baseline \
-    node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-config
+    node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-config || return "$?"
   OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE=baseline \
-    node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-state
+    node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-state || return "$?"
 }
 
 resolve_candidate_version() {
@@ -1537,7 +1538,7 @@ fs.writeFileSync(process.env.EVIDENCE_PATH, `${JSON.stringify(evidence, null, 2)
 });
 fs.chmodSync(process.env.EVIDENCE_PATH, 0o600);
 NODE
-  assert_survival
+  assert_survival || return "$?"
 }
 
 assert_root_managed_vps_cli_usable() {
@@ -1637,7 +1638,12 @@ repair_update_restart_auth() {
     phase recovery-update-restart update_candidate 1 "file:$restart_fixture_package" "$restart_fixture_version"
     local recovery_status=$?
     [ "$recovery_status" -eq 0 ] || return "$recovery_status"
-    assert_survival
+    if [ "$SCENARIO" != "watchos-direct-node" ] && [ "$SCENARIO" != "mobile-pairing-reconnect" ]; then
+      phase assert-restart-serving-turn node scripts/e2e/lib/upgrade-survivor/assertions.mjs \
+        assert-restart-serving-turn "$ARTIFACT_ROOT/restart-serving-turn.json" || return "$?"
+      survival_assert_stage="post-inference"
+    fi
+    assert_survival || return "$?"
     if [ "$update_repair_required" = "1" ]; then
       node scripts/e2e/lib/upgrade-survivor/assertions.mjs \
         assert-recovered-plugin-installs "$UPDATE_JSON" "$candidate_version" "$initial_update_observation_root" "$baseline_version"
@@ -1656,10 +1662,10 @@ repair_fixture_plugin_consent() {
       openclaw_e2e_print_log "$REPAIR_JSON" >&2
       return 1
     fi
-    node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-repair-json "$REPAIR_JSON"
+    node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-repair-json "$REPAIR_JSON" || return "$?"
     node scripts/e2e/lib/upgrade-survivor/assertions.mjs \
-      assert-recovered-plugin-installs "$UPDATE_JSON" "$candidate_version" "$initial_update_observation_root" "$baseline_version"
-    assert_survival
+      assert-recovered-plugin-installs "$UPDATE_JSON" "$candidate_version" "$initial_update_observation_root" "$baseline_version" || return "$?"
+    assert_survival || return "$?"
   fi
   repair_update_restart_auth || return "$?"
   if [ -n "${OPENCLAW_CLAWHUB_URL:-}" ]; then
@@ -1694,10 +1700,11 @@ validate_post_doctor_config() {
 }
 
 assert_survival() {
-  node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-exec-approvals
-  node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-config
-  node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-state
-  installed_version="$(read_installed_version)"
+  node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-exec-approvals || return "$?"
+  node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-config || return "$?"
+  OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE="$survival_assert_stage" \
+    node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-state || return "$?"
+  installed_version="$(read_installed_version)" || return "$?"
   if [ "$baseline_version" = "2026.9.2" ] && [ "$candidate_version" = "2026.9.3" ]; then
     node scripts/e2e/lib/external-package-transition.mjs schema 16 \
       >"$ARTIFACT_ROOT/schema-after-update.json" || return "$?"

--- a/scripts/e2e/lib/upgrade-survivor/run.sh
+++ b/scripts/e2e/lib/upgrade-survivor/run.sh
@@ -1688,7 +1688,8 @@ assert_volume_idempotence() {
     echo "SQLite volume idempotence exceeded budget: ${idempotence_seconds}s > ${budget}s" >&2
     return 1
   fi
-  node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-state
+  OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE="$survival_assert_stage" \
+    node scripts/e2e/lib/upgrade-survivor/assertions.mjs assert-state
 }
 
 validate_post_doctor_config() {

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -1874,6 +1874,73 @@ process.stdout.write(sessionDir + "\\n");
     ).not.toThrow();
   });
 
+  it.each([
+    "ok",
+    "queued",
+    "not-started",
+    "turn-failed",
+    "wrong-session",
+    "user-only",
+    "wrong-reply",
+  ])("requires a completed persisted managed serving reply (%s)", (outcome) => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-survivor-serving-turn-"));
+    try {
+      const bin = join(root, "bin");
+      mkdirSync(bin);
+      writeFileSync(
+        join(bin, "openclaw"),
+        `#!${process.execPath}
+const fs = require("node:fs");
+const method = process.argv[4];
+const params = JSON.parse(process.argv[process.argv.indexOf("--params") + 1]);
+const outcome = process.env.PROBE_OUTCOME;
+let result;
+if (method === "chat.send") {
+  fs.writeFileSync(process.env.PROBE_MARKER_FILE, params.message.match(/OPENCLAW_E2E_SURVIVOR_[A-F0-9]+/)[0]);
+  result = { status: outcome === "not-started" ? "error" : "started", runId: "serving-run" };
+} else if (method === "agent.wait") {
+  const pending = outcome === "queued" && !fs.existsSync(process.env.PROBE_MARKER_FILE + ".waited");
+  fs.writeFileSync(process.env.PROBE_MARKER_FILE + ".waited", "waited");
+  result = { runId: params.runId, status: pending ? "pending" : outcome === "turn-failed" ? "error" : "ok", endedAt: 1788820180863 };
+} else if (method === "chat.history") {
+  result = { sessionId: outcome === "wrong-session" ? "replacement" : "upgrade-main-session", messages: [{
+    role: outcome === "user-only" ? "user" : "assistant",
+    content: [{ type: "text", text: outcome === "wrong-reply" ? "other" : fs.readFileSync(process.env.PROBE_MARKER_FILE, "utf8") }],
+  }] };
+} else { process.exit(47); }
+process.stdout.write(JSON.stringify(result));
+`,
+        { mode: 0o755 },
+      );
+      const receipt = join(root, "receipt.json");
+      const result = spawnSync(
+        process.execPath,
+        [ASSERTIONS_PATH, "assert-restart-serving-turn", receipt],
+        {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            PATH: `${bin}${delimiter}${process.env.PATH}`,
+            GATEWAY_AUTH_TOKEN_REF: "synthetic-serving-token",
+            PROBE_OUTCOME: outcome,
+            PROBE_MARKER_FILE: join(root, "marker"),
+          },
+        },
+      );
+      const succeeded = outcome === "ok" || outcome === "queued";
+      expect(result.status, result.stderr).toBe(succeeded ? 0 : 1);
+      expect(existsSync(receipt)).toBe(succeeded);
+      if (succeeded) {
+        const proof = JSON.parse(readFileSync(receipt, "utf8"));
+        expect(proof.sessionId).toBe("upgrade-main-session");
+        expect(proof.reply.content[0].text).toBe(proof.marker);
+        expect(proof.completion.status).toBe("ok");
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it("accepts a SQLite-only migrated session store", () => {
     expect(() =>
       runSessionStateAssertion((stateDir) => {
@@ -1881,6 +1948,71 @@ process.stdout.write(sessionDir + "\\n");
       }),
     ).not.toThrow();
   });
+
+  it.each([
+    { stage: "survival", mutation: "none", error: /metadata prompt was not preserved/ },
+    { stage: "post-inference", mutation: "none", error: undefined },
+    { stage: "post-inference", mutation: "missing-marker", error: /refreshed skills snapshot/ },
+    { stage: "post-inference", mutation: "invalid-marker", error: /refreshed skills snapshot/ },
+    { stage: "post-inference", mutation: "stale-prompt", error: /refreshed skills snapshot/ },
+    { stage: "post-inference", mutation: "malformed-skills", error: /refreshed skills snapshot/ },
+    { stage: "post-inference", mutation: "heavy-cache", error: /heavy resolvedSkills cache/ },
+    {
+      stage: "post-inference",
+      mutation: "missing-session",
+      error: /main legacy session row missing/,
+    },
+    {
+      stage: "post-inference",
+      mutation: "missing-transcript",
+      error: /transcript was not imported/,
+    },
+  ])(
+    "checks migrated session state after inference ($stage, $mutation)",
+    ({ stage, mutation, error }) => {
+      const check = () =>
+        runSessionStateAssertion((stateDir) => {
+          writeMigratedSessionState(stateDir);
+          const db = new DatabaseSync(
+            join(stateDir, "agents", "main", "agent", "openclaw-agent.sqlite"),
+          );
+          try {
+            db.prepare("UPDATE session_nodes SET entry_json = ? WHERE session_key = ?").run(
+              JSON.stringify({
+                skillsSnapshot: {
+                  prompt:
+                    mutation === "stale-prompt"
+                      ? "legacy prompt survives as metadata"
+                      : "Current runtime skill instructions",
+                  skills: mutation === "malformed-skills" ? null : [{ name: "survivor-skill" }],
+                  ...(mutation === "missing-marker"
+                    ? {}
+                    : { promptFormatVersion: mutation === "invalid-marker" ? 0 : 4 }),
+                  ...(mutation === "heavy-cache" ? { resolvedSkills: [] } : {}),
+                },
+              }),
+              "agent:main:main",
+            );
+            if (mutation === "missing-session") {
+              db.prepare("DELETE FROM session_nodes WHERE session_key = ?").run("agent:main:main");
+            }
+            if (mutation === "missing-transcript") {
+              db.prepare("DELETE FROM transcript_events WHERE session_id = ?").run(
+                "upgrade-main-session",
+              );
+            }
+          } finally {
+            db.close();
+          }
+          return { OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE: stage };
+        });
+      if (error) {
+        expect(check).toThrow(error);
+      } else {
+        expect(check).not.toThrow();
+      }
+    },
+  );
 
   it("rejects retired sessionFile metadata in SQLite-backed session rows", () => {
     expect(() =>

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -1878,6 +1878,7 @@ process.stdout.write(sessionDir + "\\n");
     "ok",
     "queued",
     "wait-timeout",
+    "cli-failed",
     "not-started",
     "turn-failed",
     "wrong-session",
@@ -1895,6 +1896,10 @@ const fs = require("node:fs");
 const method = process.argv[4];
 const params = JSON.parse(process.argv[process.argv.indexOf("--params") + 1]);
 const outcome = process.env.PROBE_OUTCOME;
+if (outcome === "cli-failed") {
+  process.stderr.write(JSON.stringify(process.argv));
+  process.exit(47);
+}
 let result;
 if (method === "chat.send") {
   fs.writeFileSync(process.env.PROBE_MARKER_FILE, params.message.match(/OPENCLAW_E2E_SURVIVOR_[A-F0-9]+/)[0]);
@@ -1931,6 +1936,10 @@ process.stdout.write(JSON.stringify(result));
       const succeeded = outcome === "ok" || outcome === "queued" || outcome === "wait-timeout";
       expect(result.status, result.stderr).toBe(succeeded ? 0 : 1);
       expect(existsSync(receipt)).toBe(succeeded);
+      expect(result.stderr).not.toContain("synthetic-serving-token");
+      if (outcome === "cli-failed") {
+        expect(result.stderr).toContain("chat.send managed serving probe failed (status 47)");
+      }
       if (succeeded) {
         const proof = JSON.parse(readFileSync(receipt, "utf8"));
         expect(proof.sessionId).toBe("upgrade-main-session");

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -1877,6 +1877,7 @@ process.stdout.write(sessionDir + "\\n");
   it.each([
     "ok",
     "queued",
+    "wait-timeout",
     "not-started",
     "turn-failed",
     "wrong-session",
@@ -1899,9 +1900,9 @@ if (method === "chat.send") {
   fs.writeFileSync(process.env.PROBE_MARKER_FILE, params.message.match(/OPENCLAW_E2E_SURVIVOR_[A-F0-9]+/)[0]);
   result = { status: outcome === "not-started" ? "error" : "started", runId: "serving-run" };
 } else if (method === "agent.wait") {
-  const pending = outcome === "queued" && !fs.existsSync(process.env.PROBE_MARKER_FILE + ".waited");
+  const pending = ["queued", "wait-timeout"].includes(outcome) && !fs.existsSync(process.env.PROBE_MARKER_FILE + ".waited");
   fs.writeFileSync(process.env.PROBE_MARKER_FILE + ".waited", "waited");
-  result = { runId: params.runId, status: pending ? "pending" : outcome === "turn-failed" ? "error" : "ok", endedAt: 1788820180863 };
+  result = { runId: params.runId, status: pending ? (outcome === "wait-timeout" ? "timeout" : "pending") : outcome === "turn-failed" ? "error" : "ok", ...(pending ? {} : { endedAt: 1788820180863 }) };
 } else if (method === "chat.history") {
   result = { sessionId: outcome === "wrong-session" ? "replacement" : "upgrade-main-session", messages: [{
     role: outcome === "user-only" ? "user" : "assistant",
@@ -1927,7 +1928,7 @@ process.stdout.write(JSON.stringify(result));
           },
         },
       );
-      const succeeded = outcome === "ok" || outcome === "queued";
+      const succeeded = outcome === "ok" || outcome === "queued" || outcome === "wait-timeout";
       expect(result.status, result.stderr).toBe(succeeded ? 0 : 1);
       expect(existsSync(receipt)).toBe(succeeded);
       if (succeeded) {

--- a/test/scripts/upgrade-survivor-config-parking.test.ts
+++ b/test/scripts/upgrade-survivor-config-parking.test.ts
@@ -153,6 +153,13 @@ exit "$probe_status"
 
   it.each([
     { startStatus: 0, readyStatus: 0, activeStatus: 3, mutation: "none" },
+    {
+      startStatus: 0,
+      readyStatus: 0,
+      activeStatus: 3,
+      mutation: "none",
+      scenario: "sqlite-volume",
+    },
     { startStatus: 43, readyStatus: 0, activeStatus: 3, mutation: "none" },
     { startStatus: 0, readyStatus: 42, activeStatus: 3, mutation: "none" },
     { startStatus: 0, readyStatus: 0, activeStatus: 0, mutation: "none" },
@@ -161,7 +168,7 @@ exit "$probe_status"
     { startStatus: 0, readyStatus: 0, activeStatus: 3, mutation: "env" },
   ])(
     "requires prepared service readiness before the final updater (start=$startStatus, ready=$readyStatus, active=$activeStatus, mutation=$mutation)",
-    ({ startStatus, readyStatus, activeStatus, mutation }) => {
+    ({ startStatus, readyStatus, activeStatus, mutation, scenario = "base" }) => {
       const root = tempDirs.make("openclaw-repaired-service-start-");
       const bin = path.join(root, "bin");
       mkdirSync(bin);
@@ -223,6 +230,9 @@ update_candidate() {
 node() {
   if [ "$#" -eq 3 ] && [ "$1" = scripts/e2e/lib/upgrade-survivor/assertions.mjs ] && [ "$2" = assert-restart-serving-turn ]; then
     printf 'serving-turn\\n' >>"$PROBE_EVENTS"
+  elif [ "$#" -eq 2 ] && [ "$2" = assert-state ]; then
+    [ "\${OPENCLAW_UPGRADE_SURVIVOR_ASSERT_STAGE:-survival}" = post-inference ] || return 96
+    printf 'volume-state\\n' >>"$PROBE_EVENTS"
   else
     command node "$@"
   fi
@@ -233,6 +243,13 @@ assert_survival() {
 }
 probe_status=0
 repair_fixture_plugin_consent || probe_status=$?
+if [ "$SCENARIO" = sqlite-volume ] && [ "$probe_status" -eq 0 ]; then
+openclaw_e2e_maybe_timeout() {
+  [ "$#" -eq 5 ] && [ "$2" = openclaw ] && [ "$3" = doctor ] && [ "$4" = --fix ] && [ "$5" = --non-interactive ] || return 95
+  printf 'volume-doctor\\n' >>"$PROBE_EVENTS"
+}
+  assert_volume_idempotence || probe_status=$?
+fi
 exit "$probe_status"
 `,
         ],
@@ -245,6 +262,7 @@ exit "$probe_status"
             OPENCLAW_STATE_DIR: path.join(root, "state"),
             OPENCLAW_UPGRADE_SURVIVOR_BASELINE: "openclaw@2026.8.1",
             OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE: "auto-auth",
+            OPENCLAW_UPGRADE_SURVIVOR_SCENARIO: scenario,
             OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT: path.join(root, "runtime"),
             OPENCLAW_UPGRADE_SURVIVOR_SUMMARY_JSON: path.join(root, "artifacts", "summary.json"),
             OPENCLAW_CLAWHUB_URL: "",
@@ -278,6 +296,7 @@ exit "$probe_status"
                   "update",
                   "serving-turn",
                   "assert-survival",
+                  ...(scenario === "sqlite-volume" ? ["volume-doctor", "volume-state"] : []),
                 ],
       );
       if (activeStatus === 3) {

--- a/test/scripts/upgrade-survivor-config-parking.test.ts
+++ b/test/scripts/upgrade-survivor-config-parking.test.ts
@@ -220,7 +220,17 @@ update_candidate() {
   [ "$#" -eq 3 ] && [ "$1" = 1 ] && [ "$2" = "file:$RUNTIME_ROOT/future.tgz" ] && [ "$3" = 2100.1.0 ] || return 99
   printf 'update\\n' >>"$PROBE_EVENTS"
 }
-assert_survival() { printf 'assert-survival\\n' >>"$PROBE_EVENTS"; }
+node() {
+  if [ "$#" -eq 3 ] && [ "$1" = scripts/e2e/lib/upgrade-survivor/assertions.mjs ] && [ "$2" = assert-restart-serving-turn ]; then
+    printf 'serving-turn\\n' >>"$PROBE_EVENTS"
+  else
+    command node "$@"
+  fi
+}
+assert_survival() {
+  [ "$survival_assert_stage" = post-inference ] || return 96
+  printf 'assert-survival\\n' >>"$PROBE_EVENTS"
+}
 probe_status=0
 repair_fixture_plugin_consent || probe_status=$?
 exit "$probe_status"
@@ -266,6 +276,7 @@ exit "$probe_status"
                   "readiness",
                   "authenticated",
                   "update",
+                  "serving-turn",
                   "assert-survival",
                 ],
       );
@@ -297,6 +308,59 @@ exit "$probe_status"
       }
     },
   );
+
+  it.each([
+    "assert-restart-serving-turn",
+    "assert-exec-approvals",
+    "assert-config",
+    "assert-state",
+    "installed-version",
+  ])("propagates guarded restart survival failure at %s", (failure) => {
+    const root = tempDirs.make("openclaw-survivor-guarded-assertion-");
+    const source = readFileSync(PUBLISHED_RUNNER_PATH, "utf8");
+    const setup = source.slice(0, source.indexOf("phase storage-preflight"));
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        `${setup}
+trap - EXIT ERR INT TERM
+SCENARIO=base
+UPDATE_RESTART_MODE=auto-auth
+update_repair_required=0
+candidate_version=2026.9.3
+baseline_version=2026.9.2
+OPENCLAW_CLAWHUB_URL=fixture
+prepare_restart_inference() { :; }
+prepare_restart_fixture() { restart_fixture_package=/tmp/fixture.tgz; restart_fixture_version=2026.9.3; }
+install_update_restart_systemctl_shim() { :; }
+run_update_restart_probe_gateway() { :; }
+check_gateway_status() { :; }
+update_candidate() { :; }
+node() { if [ "$#" -ge 2 ] && [ "$2" = "$PROBE_FAILURE" ]; then return 47; fi; }
+read_installed_version() { [ "$PROBE_FAILURE" != installed-version ] || return 47; printf '2026.9.3'; }
+assert_prepublish_plugin_install() { touch "$PROBE_SIDE_EFFECT"; }
+probe_status=0
+repair_fixture_plugin_consent || probe_status=$?
+exit "$probe_status"
+`,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          HOME: root,
+          OPENCLAW_UPGRADE_SURVIVOR_BASELINE: "openclaw@2026.9.2",
+          OPENCLAW_UPGRADE_SURVIVOR_RUNTIME_ROOT: path.join(root, "runtime"),
+          OPENCLAW_UPGRADE_SURVIVOR_SUMMARY_JSON: path.join(root, "artifacts", "summary.json"),
+          PROBE_FAILURE: failure,
+          PROBE_SIDE_EFFECT: path.join(root, "continued"),
+        },
+      },
+    );
+    expect(result.status, result.stdout + result.stderr).toBe(47);
+    expect(existsSync(path.join(root, "continued"))).toBe(false);
+  });
 
   it.each([false, true])(
     "preserves phase failure without disabling normal errexit (conditional=%s)",

--- a/test/scripts/upgrade-survivor-cron-seed.test.ts
+++ b/test/scripts/upgrade-survivor-cron-seed.test.ts
@@ -74,6 +74,30 @@ if (args[0] === "config") {
   assert.deepEqual(args, ["config", "validate"]);
   assert.equal(config, original);
   assert.equal(fs.existsSync(path.join(state, "cron", "jobs.json")), false);
+} else if (args[0] === "gateway" && args[1] === "call") {
+  assert.equal(fs.existsSync(path.join(process.env.FIXTURE_ROOT, "restarted")), true,
+    "serving turn must follow the managed replacement");
+  assert.equal(args[args.indexOf("--token") + 1], "upgrade-survivor-token");
+  const params = JSON.parse(args[args.indexOf("--params") + 1]);
+  const markerFile = path.join(process.env.FIXTURE_ROOT, "serving-marker");
+  let result;
+  if (args[2] === "chat.send") {
+    assert.equal(params.sessionKey, "agent:main:main");
+    const marker = params.message.match(/OPENCLAW_E2E_SURVIVOR_[A-F0-9]+/)[0];
+    fs.writeFileSync(markerFile, marker);
+    result = { status: "started", runId: "fixture-serving-run" };
+  } else if (args[2] === "agent.wait") {
+    assert.equal(params.runId, "fixture-serving-run");
+    assert.equal(fs.existsSync(markerFile), true);
+    result = { runId: params.runId, status: "ok", endedAt: 1788820180863 };
+  } else {
+    assert.equal(args[2], "chat.history");
+    assert.equal(params.sessionKey, "agent:main:main");
+    result = { sessionId: "upgrade-main-session", messages: [{ role: "assistant",
+      content: [{ type: "text", text: fs.readFileSync(markerFile, "utf8") }] }] };
+    fs.writeFileSync(path.join(process.env.FIXTURE_ROOT, "served"), "complete");
+  }
+  process.stdout.write(JSON.stringify(result));
 } else if (args[0] === "gateway" && args[1] === "status") {
   assert.deepEqual(args, ["gateway", "status", "--url", "ws://127.0.0.1:18789", "--token",
     "upgrade-survivor-token", "--require-rpc", "--timeout", "30000", "--json"]);
@@ -218,6 +242,7 @@ repair_fixture_plugin_consent
   );
   expect(readFileSync(path.join(root, "updated"), "utf8")).toBe("complete");
   expect(existsSync(path.join(root, "restarted"))).toBe(mode === "auto-auth");
+  expect(existsSync(path.join(root, "served"))).toBe(mode === "auto-auth");
 });
 
 const baselineJobs = [


### PR DESCRIPTION
## What Problem This Solves

Resolves a false-green managed upgrade survivor result: a guarded Bash function could swallow a state assertion failure and continue reporting success. The post-startup check also expected legacy skills-cache bytes to remain unchanged after runtime turn preparation had legitimately refreshed that cache.

## Why This Change Was Made

Propagate assertion failures explicitly through the guarded shell calls. Preserve strict migration equality before startup, then require an authenticated installed-CLI serving turn to complete and its unique assistant reply to be persisted in the original migrated session before accepting a fresh versioned runtime skills snapshot.

The serving probe waits on the same run within a fixed two-minute deadline; it does not retry model turns. Result-based child execution retains timeout and output bounds while keeping credential-bearing stderr, argv, and error objects out of failures. Session IDs, imported transcripts, retired-field absence, and exclusion of heavy resolved-skills data remain checked. Companion watchOS and mobile scenarios retain their separate contracts.

## User Impact

Release verification can no longer report managed survivor success after these assertion failures, and it distinguishes preserved migration data from an intentionally refreshed runtime cache. Product behavior and storage formats are unchanged.

## Evidence

- All 371 survivor tests passed after updating the companion bootstrap fixture for the new authenticated serving calls. The final result-based child-process refinement passed 95 related assertion, bootstrap, and unchanged lint-inventory tests.
- The downstream SQLite-volume idempotence assertion now receives the current serving stage. Its managed-serving-to-idempotence regression fails before the fix and passes afterward; 110 focused tests and scoped checks pass, with independent P2 review clean.
- Scoped changed checks passed. Fresh integration review caught nonterminal agent.wait timeout handling; the regression failed before correction and passes afterward. Final P2 review is clean with the full deadline-enforcing helper context.
- Causal regressions cover swallowed failures, invalid cache acceptance, queued turns, nonterminal wait timeouts, and failed-CLI credential redaction. The redaction test fails against the prior throwing child-process call and passes with result-based execution, without adding a lint-inventory exception. Final component proof used private dependencies; invalid earlier borrowed-dependency results are not relied upon.
- The actual prepared-package managed Docker replay passed in157seconds with no hidden assertion errors. Its retained receipt proves successful completion and a matching assistant reply in the original migrated session; strict migration and post-inference checks passed. This used a synthetic local provider, not live credentials.

Full release qualification remains a separate campaign with explicitly selected Code and Tooling identities; no publication occurs in this PR.
