### PR TITLE
fix(agents): tolerate redundant offsets in anchored session history

### DIFF
--- a/src/agents/tool-description-presets.test.ts
+++ b/src/agents/tool-description-presets.test.ts
@@ -52,7 +52,7 @@ const SESSION_DESCRIPTIONS = [
     tool: "sessions_history",
     describe: describeSessionsHistoryTool,
     original:
-      "Read sanitized visible-session history. Before reply/debug/resume. Supports limit, offset, search-result sessionId/messageId anchors, and tool messages. pendingInputs are accepted inputs outside model history; page with pendingBefore=nextBefore. Cancelled/interrupted inputs never replay automatically. Lower limit for richer pending previews.",
+      "Read sanitized visible-session history. Before reply/debug/resume. Use exactly one pagination mode: plain (limit, optional offset) or anchored (messageId, optionally sessionId) — never both; offset is ignored when messageId is set. Include tool messages with includeTools. pendingInputs are accepted inputs outside model history; page with pendingBefore=nextBefore. Cancelled/interrupted inputs never replay automatically. Lower limit for richer pending previews.",
   },
   {
     tool: "sessions_search",

--- a/src/agents/tool-description-presets.test.ts
+++ b/src/agents/tool-description-presets.test.ts
@@ -52,7 +52,7 @@ const SESSION_DESCRIPTIONS = [
     tool: "sessions_history",
     describe: describeSessionsHistoryTool,
     original:
-      "Read sanitized visible-session history. Before reply/debug/resume. Use exactly one pagination mode: plain (limit, optional offset) or anchored (messageId, optionally sessionId) — never both; offset is ignored when messageId is set. Include tool messages with includeTools. pendingInputs are accepted inputs outside model history; page with pendingBefore=nextBefore. Cancelled/interrupted inputs never replay automatically. Lower limit for richer pending previews.",
+      "Read sanitized visible-session history. Before reply/debug/resume. Use messageId (optionally sessionId) for anchored history; offset is ignored when messageId is set. Without messageId, use offset for plain pagination. limit bounds either mode. Include tool messages with includeTools. pendingInputs are accepted inputs outside model history; page with pendingBefore=nextBefore. Cancelled/interrupted inputs never replay automatically. Lower limit for richer pending previews.",
   },
   {
     tool: "sessions_search",

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -81,7 +81,7 @@ export function describeSessionsListTool(options?: SessionLinkDescriptionOptions
 export function describeSessionsHistoryTool(options?: SessionLinkDescriptionOptions): string {
   return [
     "Read sanitized visible-session history.",
-    "Before reply/debug/resume. Supports limit, offset, search-result sessionId/messageId anchors, and tool messages.",
+    "Before reply/debug/resume. Use exactly one pagination mode: plain (limit, optional offset) or anchored (messageId, optionally sessionId) — never both; offset is ignored when messageId is set. Include tool messages with includeTools.",
     "pendingInputs are accepted inputs outside model history; page with pendingBefore=nextBefore. Cancelled/interrupted inputs never replay automatically. Lower limit for richer pending previews.",
     ...(options?.sessionLinkBase ? [describeSessionLinkRule(options.sessionLinkBase)] : []),
   ].join(" ");

--- a/src/agents/tool-description-presets.ts
+++ b/src/agents/tool-description-presets.ts
@@ -81,7 +81,7 @@ export function describeSessionsListTool(options?: SessionLinkDescriptionOptions
 export function describeSessionsHistoryTool(options?: SessionLinkDescriptionOptions): string {
   return [
     "Read sanitized visible-session history.",
-    "Before reply/debug/resume. Use exactly one pagination mode: plain (limit, optional offset) or anchored (messageId, optionally sessionId) — never both; offset is ignored when messageId is set. Include tool messages with includeTools.",
+    "Before reply/debug/resume. Use messageId (optionally sessionId) for anchored history; offset is ignored when messageId is set. Without messageId, use offset for plain pagination. limit bounds either mode. Include tool messages with includeTools.",
     "pendingInputs are accepted inputs outside model history; page with pendingBefore=nextBefore. Cancelled/interrupted inputs never replay automatically. Lower limit for richer pending previews.",
     ...(options?.sessionLinkBase ? [describeSessionLinkRule(options.sessionLinkBase)] : []),
   ].join(" ");

--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -319,12 +319,48 @@ describe("sessions_history redaction", () => {
     expect(requests).toEqual([]);
   });
 
-  it("rejects offset and messageId together", async () => {
-    const tool = createHistoryToolWithMessage("hello");
+  it("ignores offset when an anchored read is requested", async () => {
+    const requests: CallGatewayRequest[] = [];
+    const tool = createSessionsHistoryTool({
+      config: {},
+      callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
+        requests.push(request);
+        return { messages: [{ role: "assistant", content: "latest" }] } as T;
+      },
+    });
 
-    await expect(
-      tool.execute("call-1", { sessionKey: "main", offset: 0, messageId: "message-1" }),
-    ).rejects.toThrow("offset and messageId cannot be used together");
+    const result = await tool.execute("call-1", {
+      sessionKey: "main",
+      offset: 0,
+      messageId: "message-1",
+    });
+    const request = requireGatewayRequest(requests, "chat.history");
+
+    expect(request.params).toMatchObject({ sessionKey: "main", messageId: "message-1" });
+    expect((request.params as Record<string, unknown>).offset).toBeUndefined();
+    expect((result.details as Record<string, unknown>).offset).toBeUndefined();
+  });
+
+  it("ignores a non-zero offset when an anchored read is requested", async () => {
+    const requests: CallGatewayRequest[] = [];
+    const tool = createSessionsHistoryTool({
+      config: {},
+      callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
+        requests.push(request);
+        return { messages: [{ role: "assistant", content: "latest" }] } as T;
+      },
+    });
+
+    const result = await tool.execute("call-1", {
+      sessionKey: "main",
+      offset: 4,
+      messageId: "message-1",
+    });
+    const request = requireGatewayRequest(requests, "chat.history");
+
+    expect(request.params).toMatchObject({ sessionKey: "main", messageId: "message-1" });
+    expect((request.params as Record<string, unknown>).offset).toBeUndefined();
+    expect((result.details as Record<string, unknown>).offset).toBeUndefined();
   });
 
   it("rejects sessionId without messageId", async () => {

--- a/src/agents/tools/sessions-history-tool.test.ts
+++ b/src/agents/tools/sessions-history-tool.test.ts
@@ -319,7 +319,7 @@ describe("sessions_history redaction", () => {
     expect(requests).toEqual([]);
   });
 
-  it("ignores offset when an anchored read is requested", async () => {
+  it.each([0, 4])("ignores offset %i when an anchored read is requested", async (offset) => {
     const requests: CallGatewayRequest[] = [];
     const tool = createSessionsHistoryTool({
       config: {},
@@ -328,39 +328,14 @@ describe("sessions_history redaction", () => {
         return { messages: [{ role: "assistant", content: "latest" }] } as T;
       },
     });
-
-    const result = await tool.execute("call-1", {
-      sessionKey: "main",
-      offset: 0,
-      messageId: "message-1",
-    });
+    const args = { sessionKey: "main", offset, messageId: "message-1" };
+    const result = await tool.execute("call-1", args);
     const request = requireGatewayRequest(requests, "chat.history");
 
     expect(request.params).toMatchObject({ sessionKey: "main", messageId: "message-1" });
-    expect((request.params as Record<string, unknown>).offset).toBeUndefined();
-    expect((result.details as Record<string, unknown>).offset).toBeUndefined();
-  });
-
-  it("ignores a non-zero offset when an anchored read is requested", async () => {
-    const requests: CallGatewayRequest[] = [];
-    const tool = createSessionsHistoryTool({
-      config: {},
-      callGateway: async <T = Record<string, unknown>>(request: CallGatewayRequest): Promise<T> => {
-        requests.push(request);
-        return { messages: [{ role: "assistant", content: "latest" }] } as T;
-      },
-    });
-
-    const result = await tool.execute("call-1", {
-      sessionKey: "main",
-      offset: 4,
-      messageId: "message-1",
-    });
-    const request = requireGatewayRequest(requests, "chat.history");
-
-    expect(request.params).toMatchObject({ sessionKey: "main", messageId: "message-1" });
-    expect((request.params as Record<string, unknown>).offset).toBeUndefined();
-    expect((result.details as Record<string, unknown>).offset).toBeUndefined();
+    expect(request.params).not.toHaveProperty("offset");
+    expect(result.details).not.toHaveProperty("offset");
+    expect(args).toEqual({ sessionKey: "main", offset, messageId: "message-1" });
   });
 
   it("rejects sessionId without messageId", async () => {

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -51,10 +51,27 @@ import {
 const SessionsHistoryToolSchema = Type.Object({
   sessionKey: Type.String(),
   limit: optionalPositiveIntegerSchema(),
-  offset: Type.Optional(Type.Integer({ minimum: 0 })),
+  offset: Type.Optional(
+    Type.Integer({
+      minimum: 0,
+      description:
+        "Plain-pagination offset. Ignored when messageId is set (anchored reads window history around messageId instead).",
+    }),
+  ),
   pendingBefore: optionalPositiveIntegerSchema(),
-  messageId: Type.Optional(Type.String({ minLength: 1 })),
-  sessionId: Type.Optional(Type.String({ minLength: 1 })),
+  messageId: Type.Optional(
+    Type.String({
+      minLength: 1,
+      description:
+        "Anchored read: return history around this message id. Mutually exclusive with offset.",
+    }),
+  ),
+  sessionId: Type.Optional(
+    Type.String({
+      minLength: 1,
+      description: "Transcript session id that owns messageId. Requires messageId.",
+    }),
+  ),
   includeTools: Type.Optional(Type.Boolean()),
 });
 
@@ -451,12 +468,14 @@ export function createSessionsHistoryTool(opts?: {
       const pendingBefore = readPositiveIntegerParam(params, "pendingBefore");
       const messageId = readToolStringParam(params, "messageId");
       const sessionId = readToolStringParam(params, "sessionId");
-      if (offset !== undefined && messageId) {
-        throw new ToolInputError("offset and messageId cannot be used together");
-      }
       if (sessionId && !messageId) {
         throw new ToolInputError("sessionId requires messageId");
       }
+      // Anchored reads window history around messageId, so a caller-passed
+      // offset is redundant. Models frequently emit `offset: 0` next to an
+      // anchor because the two pagination modes are easy to conflate; treat
+      // the offset as absent instead of failing the entire call.
+      const paginationOffset = messageId ? undefined : offset;
       const includeTools = Boolean(params.includeTools);
       const {
         cfg,
@@ -585,7 +604,7 @@ export function createSessionsHistoryTool(opts?: {
               sessionKey: resolvedKey,
               agentId: targetAgentId,
               limit,
-              ...(offset !== undefined ? { offset } : {}),
+              ...(paginationOffset !== undefined ? { offset: paginationOffset } : {}),
               ...(pendingBefore !== undefined ? { pendingBefore } : {}),
               ...(messageId ? { messageId } : {}),
               ...(sessionId ? { sessionId } : {}),

--- a/src/agents/tools/sessions-history-tool.ts
+++ b/src/agents/tools/sessions-history-tool.ts
@@ -63,7 +63,7 @@ const SessionsHistoryToolSchema = Type.Object({
     Type.String({
       minLength: 1,
       description:
-        "Anchored read: return history around this message id. Mutually exclusive with offset.",
+        "Return history around this message id. Ignores offset; limit still bounds the window.",
     }),
   ),
   sessionId: Type.Optional(
@@ -471,10 +471,7 @@ export function createSessionsHistoryTool(opts?: {
       if (sessionId && !messageId) {
         throw new ToolInputError("sessionId requires messageId");
       }
-      // Anchored reads window history around messageId, so a caller-passed
-      // offset is redundant. Models frequently emit `offset: 0` next to an
-      // anchor because the two pagination modes are easy to conflate; treat
-      // the offset as absent instead of failing the entire call.
+      // Keep redundant model arguments out of the strict Gateway pagination contract.
       const paginationOffset = messageId ? undefined : offset;
       const includeTools = Boolean(params.includeTools);
       const {

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1080,7 +1080,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Read sanitized visible-session history. Before reply/debug/resume. Supports limit, offset, search-result sessionId/messageId anchors, and tool messages. pendingInputs are accepted inputs outside model history; page with pendingBefore=nextBefore. Cancelled/interrupted inputs never replay automatically. Lower limit for richer pending previews.",
+        "description": "Read sanitized visible-session history. Before reply/debug/resume. Use exactly one pagination mode: plain (limit, optional offset) or anchored (messageId, optionally sessionId) — never both; offset is ignored when messageId is set. Include tool messages with includeTools. pendingInputs are accepted inputs outside model history; page with pendingBefore=nextBefore. Cancelled/interrupted inputs never replay automatically. Lower limit for richer pending previews.",
         "inputSchema": {
           "properties": {
             "includeTools": {
@@ -1091,10 +1091,12 @@
               "type": "integer"
             },
             "messageId": {
+              "description": "Anchored read: return history around this message id. Mutually exclusive with offset.",
               "minLength": 1,
               "type": "string"
             },
             "offset": {
+              "description": "Plain-pagination offset. Ignored when messageId is set (anchored reads window history around messageId instead).",
               "minimum": 0,
               "type": "integer"
             },
@@ -1103,6 +1105,7 @@
               "type": "integer"
             },
             "sessionId": {
+              "description": "Transcript session id that owns messageId. Requires messageId.",
               "minLength": 1,
               "type": "string"
             },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/codex-dynamic-tools.telegram-direct.json
@@ -1080,7 +1080,7 @@
       },
       {
         "deferLoading": true,
-        "description": "Read sanitized visible-session history. Before reply/debug/resume. Use exactly one pagination mode: plain (limit, optional offset) or anchored (messageId, optionally sessionId) — never both; offset is ignored when messageId is set. Include tool messages with includeTools. pendingInputs are accepted inputs outside model history; page with pendingBefore=nextBefore. Cancelled/interrupted inputs never replay automatically. Lower limit for richer pending previews.",
+        "description": "Read sanitized visible-session history. Before reply/debug/resume. Use messageId (optionally sessionId) for anchored history; offset is ignored when messageId is set. Without messageId, use offset for plain pagination. limit bounds either mode. Include tool messages with includeTools. pendingInputs are accepted inputs outside model history; page with pendingBefore=nextBefore. Cancelled/interrupted inputs never replay automatically. Lower limit for richer pending previews.",
         "inputSchema": {
           "properties": {
             "includeTools": {
@@ -1091,7 +1091,7 @@
               "type": "integer"
             },
             "messageId": {
-              "description": "Anchored read: return history around this message id. Mutually exclusive with offset.",
+              "description": "Return history around this message id. Ignores offset; limit still bounds the window.",
               "minLength": 1,
               "type": "string"
             },

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=1f0e5aa6d2bd912cd45d8e604558bb4f4d82124496c23526c62d00e7e3cf8237
-+++ discord-group-codex-message-tool.md	sha256=63d926a4f2a0f55a67faace9939eb9e283a550c794b3da6f9bf60f9b375da41f
+--- telegram-direct-codex-message-tool.md	sha256=435d3023f4fef923b08eac06933f61d5f279fe1473b94e625ad9bfbd29dc2d7b
++++ discord-group-codex-message-tool.md	sha256=ac6771fc3d68ccb7fb1ddd3cb3380fb42a8ce62edc3558ef15e9952d58fc3d5a
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -32,10 +32,10 @@
 -    "chars": 882,
 +    "chars": 881,
 @@ -254,2 +254,2 @@
--    "chars": 57821,
--    "roughTokens": 14456
-+    "chars": 58377,
-+    "roughTokens": 14595
+-    "chars": 58299,
+-    "roughTokens": 14575
++    "chars": 58855,
++    "roughTokens": 14714
 @@ -258,2 +258,2 @@
 -    "chars": 3672,
 -    "roughTokens": 918
@@ -47,10 +47,10 @@
 +    "chars": 29820,
 +    "roughTokens": 7455
 @@ -266,2 +266,2 @@
--    "chars": 86325,
--    "roughTokens": 21582
-+    "chars": 88199,
-+    "roughTokens": 22050
+-    "chars": 86803,
+-    "roughTokens": 21701
++    "chars": 88677,
++    "roughTokens": 22170
 @@ -270,2 +270,2 @@
 -    "chars": 863,
 -    "roughTokens": 216

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/discord-group-codex-message-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=435d3023f4fef923b08eac06933f61d5f279fe1473b94e625ad9bfbd29dc2d7b
-+++ discord-group-codex-message-tool.md	sha256=ac6771fc3d68ccb7fb1ddd3cb3380fb42a8ce62edc3558ef15e9952d58fc3d5a
+--- telegram-direct-codex-message-tool.md	sha256=236af16edef5d2edfffd5a648737e2cb496374a7c95cd255422236db5292e371
++++ discord-group-codex-message-tool.md	sha256=834d9f07f597bf8a7f0010f649fb03d43d1e7ab5df21c6cd4481895541736780
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Discord Group Codex Message Tool Turn
@@ -32,10 +32,10 @@
 -    "chars": 882,
 +    "chars": 881,
 @@ -254,2 +254,2 @@
--    "chars": 58299,
--    "roughTokens": 14575
-+    "chars": 58855,
-+    "roughTokens": 14714
+-    "chars": 58312,
+-    "roughTokens": 14578
++    "chars": 58868,
++    "roughTokens": 14717
 @@ -258,2 +258,2 @@
 -    "chars": 3672,
 -    "roughTokens": 918
@@ -47,10 +47,10 @@
 +    "chars": 29820,
 +    "roughTokens": 7455
 @@ -266,2 +266,2 @@
--    "chars": 86803,
--    "roughTokens": 21701
-+    "chars": 88677,
-+    "roughTokens": 22170
+-    "chars": 86816,
+-    "roughTokens": 21704
++    "chars": 88690,
++    "roughTokens": 22173
 @@ -270,2 +270,2 @@
 -    "chars": 863,
 -    "roughTokens": 216

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -251,8 +251,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 57821,
-    "roughTokens": 14456
+    "chars": 58299,
+    "roughTokens": 14575
   },
   "openClawDeveloperInstructions": {
     "chars": 3672,
@@ -263,8 +263,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7126
   },
   "totalWithDynamicToolsJson": {
-    "chars": 86325,
-    "roughTokens": 21582
+    "chars": 86803,
+    "roughTokens": 21701
   },
   "userInputText": {
     "chars": 863,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-direct-codex-message-tool.md
@@ -251,8 +251,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 0
   },
   "dynamicToolsJson": {
-    "chars": 58299,
-    "roughTokens": 14575
+    "chars": 58312,
+    "roughTokens": 14578
   },
   "openClawDeveloperInstructions": {
     "chars": 3672,
@@ -263,8 +263,8 @@ This is the deterministic model-bound layer stack OpenClaw can snapshot for the 
     "roughTokens": 7126
   },
   "totalWithDynamicToolsJson": {
-    "chars": 86803,
-    "roughTokens": 21701
+    "chars": 86816,
+    "roughTokens": 21704
   },
   "userInputText": {
     "chars": 863,

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=1f0e5aa6d2bd912cd45d8e604558bb4f4d82124496c23526c62d00e7e3cf8237
-+++ telegram-heartbeat-codex-tool.md	sha256=7e5abdc146ad20d5f942987155452b38e0792332b8a78acc190c59d2ba0eb5d6
+--- telegram-direct-codex-message-tool.md	sha256=435d3023f4fef923b08eac06933f61d5f279fe1473b94e625ad9bfbd29dc2d7b
++++ telegram-heartbeat-codex-tool.md	sha256=6a8f4dd3082cc2d56bc9f2567b6dfc7be2c9f5c15bd4e65809f6a55a2bf159a8
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -35,20 +35,20 @@
 +    "chars": 752,
 +    "roughTokens": 188
 @@ -254,2 +251,2 @@
--    "chars": 57821,
--    "roughTokens": 14456
-+    "chars": 59314,
-+    "roughTokens": 14829
+-    "chars": 58299,
+-    "roughTokens": 14575
++    "chars": 59792,
++    "roughTokens": 14948
 @@ -262,2 +259,2 @@
 -    "chars": 28502,
 -    "roughTokens": 7126
 +    "chars": 28714,
 +    "roughTokens": 7179
 @@ -266,2 +263,2 @@
--    "chars": 86325,
--    "roughTokens": 21582
-+    "chars": 88030,
-+    "roughTokens": 22008
+-    "chars": 86803,
+-    "roughTokens": 21701
++    "chars": 88508,
++    "roughTokens": 22127
 @@ -270,2 +267,2 @@
 -    "chars": 863,
 -    "roughTokens": 216

--- a/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
+++ b/test/fixtures/agents/prompt-snapshots/codex-runtime-happy-path/telegram-heartbeat-codex-tool.md.diff
@@ -1,5 +1,5 @@
---- telegram-direct-codex-message-tool.md	sha256=435d3023f4fef923b08eac06933f61d5f279fe1473b94e625ad9bfbd29dc2d7b
-+++ telegram-heartbeat-codex-tool.md	sha256=6a8f4dd3082cc2d56bc9f2567b6dfc7be2c9f5c15bd4e65809f6a55a2bf159a8
+--- telegram-direct-codex-message-tool.md	sha256=236af16edef5d2edfffd5a648737e2cb496374a7c95cd255422236db5292e371
++++ telegram-heartbeat-codex-tool.md	sha256=23607eecd0d996f0123674dc768f67040bcc54e5ba3602f9e96209db738af4c8
 @@ -1,1 +1,1 @@
 -# Telegram Direct Codex Message Tool Turn
 +# Telegram Direct Codex Heartbeat Tool Turn
@@ -35,20 +35,20 @@
 +    "chars": 752,
 +    "roughTokens": 188
 @@ -254,2 +251,2 @@
--    "chars": 58299,
--    "roughTokens": 14575
-+    "chars": 59792,
-+    "roughTokens": 14948
+-    "chars": 58312,
+-    "roughTokens": 14578
++    "chars": 59805,
++    "roughTokens": 14952
 @@ -262,2 +259,2 @@
 -    "chars": 28502,
 -    "roughTokens": 7126
 +    "chars": 28714,
 +    "roughTokens": 7179
 @@ -266,2 +263,2 @@
--    "chars": 86803,
--    "roughTokens": 21701
-+    "chars": 88508,
-+    "roughTokens": 22127
+-    "chars": 86816,
+-    "roughTokens": 21704
++    "chars": 88521,
++    "roughTokens": 22131
 @@ -270,2 +267,2 @@
 -    "chars": 863,
 -    "roughTokens": 216


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where agents cannot read history around a message when they also provide `offset: 0` or another numeric offset. The complete read fails with `offset and messageId cannot be used together`.

The contributor reported 189 mixed anchor/offset calls out of 195 calls on one installation and 124 out of 212 on another, both running 2026.9.2. Their production observation also showed a patched anchored read returning two surrounding entries (5,796 bytes) and a successful plain-read control. These are contributor observations; the independent synthetic proof below exercises the actual Gateway and agent tool.

## Why This Change Was Made

`messageId` now selects anchored history, and the tool omits a redundant offset before calling `chat.history`. Direct Gateway requests retain strict mixed-pagination validation. The description and parameter schema explain that `limit` bounds either mode and `offset` applies only without an anchor.

## User Impact

Agents can complete anchored history reads when they include a redundant offset. Original tool-call arguments remain available in the transcript. Existing pagination, session ownership, access policy, sanitization, and pending-input behavior remain intact.

## Evidence

- Same native Testbox, pinned main `44b52287ff38`, real seeded sessions, a loopback provider, and actual agent turns: main rejects offsets 0 and 4 alongside an anchor; the candidate returns the same three-message window as the anchor-only control.
- Read-only runtime capture confirms the original offset remains in tool-call arguments and is absent from the downstream Gateway request and anchored result cursor. Direct external mixed-pagination calls still fail.
- Public controls cover ordinary pagination, invalid offsets, mismatched transcript IDs, missing anchors, current/main aliases, cross-agent policy, self/agent/tree visibility, owned-child restrictions, actual tool-result filtering, redaction, and text/byte limits.
- Real held turns and queued inputs cover same-owner cancellation, interruption after an isolated Gateway restart, pending-page cursors, and anchored pending reads. No production transcript or provider credential was used.
- Independent source-blind acceptance found no behavior defects across 41 real tool calls, using fresh seed text and a different anchor. Source-only contract checks were reviewed separately.
- 39 focused tests pass. Both new offset regressions fail on the original code for the intended reason. Focused lint, line/assertion checks, regenerated prompt snapshots, and source review pass.

Retained reset anchors are also checked on the candidate combined with the pinned main tree, which already contains the separate reset-history fix #141437. The PR branch was not rebased for that proof. The existing native tool-result size cap remains in effect; smaller history limits return complete results.

Related: #129054. Contributor commits and credit are retained.
