### PR TITLE
fix(sqlite): report observed integrity timeout phases

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -795,7 +795,19 @@ Background verification errors retain the original name and message and append b
 
 Agent database maintenance fences other writers with a 60-second lease in the shared state database. A dedicated worker renews that lease during synchronous integrity scans and migration phases. Maintenance still checks the exact persisted owner before mutations and commit, and stops if the heartbeat fails or ownership expires or changes. Finishing or cancelling maintenance stops renewal before releasing the lease; process death leaves at most the remaining lease duration.
 
-Maintenance schema admission runs its initial full-file integrity check in a read-only child process when that check is outside a write transaction. The scan has a 30-second execution limit; the connection and maintenance lease remain held until the child process closes, including on cancellation or timeout. Schema changes, index repairs, and compaction retain their synchronous phases.
+Asynchronous agent-database admission and maintenance run their initial full-file integrity check in a read-only child process when that check is outside a write transaction. The child has a 30-second lifetime limit, including startup and shutdown. The connection and owning scope remain held until the child closes, including on cancellation or timeout. Schema changes, index repairs, and compaction retain their synchronous phases.
+
+Integrity-child timeout and incomplete-exit errors include `lastObservedPhase`:
+
+| Value             | Last observation                                                                          |
+| ----------------- | ----------------------------------------------------------------------------------------- |
+| `starting`        | The parent has not received a child phase.                                                |
+| `opening`         | The child announced file-identity checks and opening a read-only connection.              |
+| `checking`        | The connection opened, and the child announced the full integrity and foreign-key checks. |
+| `closing`         | The child announced connection cleanup after checking or an error.                        |
+| `result-received` | The parent received a final result and is waiting for child closure.                      |
+
+These phases describe messages the parent received, not the child's exact current location or native CPU time. `checking` does not distinguish the integrity check from the foreign-key check. A final result can report failure; phase messages never establish successful validation or release ownership.
 
 Startup errors containing `state lease heartbeat did not become ready` include `phase=startup`, the settlement trigger (`timeout` or `message`), and the status observed before the parent marks failure. `status=starting` distinguishes readiness still pending from `status=lost`, where loss was already recorded. `elapsedMs` measures monotonic time since heartbeat startup began; `timeoutMs` is the startup wait budget, capped at five seconds or the remaining initial lease lifetime. These fields do not establish why startup stalled or ownership was lost.
 

--- a/src/infra/sqlite-integrity-worker.ts
+++ b/src/infra/sqlite-integrity-worker.ts
@@ -28,6 +28,12 @@ export type SqliteIntegrityWorkerResult =
       };
     };
 
+export type SqliteIntegrityWorkerPhase = "opening" | "checking" | "closing";
+
+export type SqliteIntegrityWorkerMessage =
+  | SqliteIntegrityWorkerResult
+  | { type: "phase"; phase: SqliteIntegrityWorkerPhase };
+
 export function readSqliteIntegrityFileIdentity(
   pathname: string,
   expected?: FileIdentityStat,
@@ -61,8 +67,21 @@ export function assertSqliteIntegrityInWorker(
   return new Promise((resolve, reject) => {
     let result: SqliteIntegrityWorkerResult | undefined;
     let failure: Error | undefined;
-    worker.on("message", (message: SqliteIntegrityWorkerResult) => {
-      result = message;
+    let lastObservedPhase: SqliteIntegrityWorkerPhase | "starting" | "result-received" = "starting";
+    worker.on("message", (message: SqliteIntegrityWorkerMessage) => {
+      if ("type" in message && message.type === "phase") {
+        if (
+          !result &&
+          (message.phase === "opening" ||
+            message.phase === "checking" ||
+            message.phase === "closing")
+        ) {
+          lastObservedPhase = message.phase;
+        }
+      } else if ("ok" in message) {
+        result = message;
+        lastObservedPhase = "result-received";
+      }
     });
     worker.on("error", (error) => {
       failure = toStringifiedError(error);
@@ -75,10 +94,14 @@ export function assertSqliteIntegrityInWorker(
           throw failure;
         }
         if (worker.killed && closeSignal === "SIGKILL") {
-          throw sqliteInspectionTimeoutError("integrity check", pathname);
+          const error = sqliteInspectionTimeoutError("integrity check", pathname);
+          error.message += ` (lastObservedPhase=${lastObservedPhase})`;
+          throw error;
         }
         if (code !== 0 || !result) {
-          throw new Error(`SQLite integrity worker exited ${code} without a completed check`);
+          throw new Error(
+            `SQLite integrity worker exited ${code} without a completed check (lastObservedPhase=${lastObservedPhase})`,
+          );
         }
         readSqliteIntegrityFileIdentity(pathname, identity);
         if (!result.ok) {

--- a/src/infra/sqlite-integrity.test.ts
+++ b/src/infra/sqlite-integrity.test.ts
@@ -245,7 +245,7 @@ describe("SQLite integrity child", () => {
     const worker = path.join(root, "blocked.mjs");
     fs.writeFileSync(
       worker,
-      `process.on('message', () => {}); process.on('SIGTERM', () => {}); setTimeout(() => process.exit(0), 35000);`,
+      `process.on('message', () => process.send({ type: 'phase', phase: 'checking' })); process.on('SIGTERM', () => {}); setTimeout(() => process.exit(0), 35000);`,
     );
     vi.spyOn(processUrls, "resolveRuntimeProcessEntrypointUrl").mockReturnValue(
       pathToFileURL(worker),
@@ -253,23 +253,101 @@ describe("SQLite integrity child", () => {
     const started = performance.now();
     await expect(
       assertSqliteIntegrityInWorker(source, 250, new AbortController().signal),
-    ).rejects.toThrow(/integrity check timed out after 30 seconds.*Stop the Gateway service/);
+    ).rejects.toThrow(
+      /integrity check timed out after 30 seconds.*Stop the Gateway service.*lastObservedPhase=checking/,
+    );
     expect(performance.now() - started).toBeLessThan(33_000);
     expect(fs.readFileSync(source, "utf8")).toBe("retained source");
   }, 40_000);
 
-  it("preserves native integrity errors across the process boundary", async () => {
-    const source = path.join(tempDirs.make("openclaw-integrity-native-"), "source.sqlite");
-    const db = new (requireNodeSqlite().DatabaseSync)(source);
-    db.exec(
-      "PRAGMA foreign_keys = OFF; CREATE TABLE parent(id INTEGER PRIMARY KEY); CREATE TABLE child(parent_id INTEGER REFERENCES parent(id)); INSERT INTO child VALUES (42);",
-    );
-    db.close();
-    await expect(
-      assertSqliteIntegrityInWorker(source, 250, new AbortController().signal),
-    ).rejects.toMatchObject({
-      name: "SqliteIntegrityError",
-      message: expect.stringContaining("foreign_key_check failed"),
-    });
-  });
+  it.each([
+    { messages: [{ type: "phase", phase: "checking" }], completes: false },
+    { messages: [{ type: "phase", phase: "checking" }, { ok: true }], completes: true },
+    { messages: [{ ok: true }, { type: "phase", phase: "closing" }], completes: true },
+  ])(
+    "requires a final result independently of progress: $messages",
+    async ({ messages, completes }) => {
+      const root = tempDirs.make("openclaw-integrity-protocol-");
+      const source = path.join(root, "source.sqlite");
+      fs.writeFileSync(source, "retained source");
+      const worker = path.join(root, "messages.mjs");
+      fs.writeFileSync(
+        worker,
+        `process.once('message', async () => {
+        for (const message of ${JSON.stringify(messages)}) {
+          await new Promise((resolve, reject) => process.send(message, error => error ? reject(error) : resolve()));
+        }
+        process.disconnect();
+      });`,
+      );
+      vi.spyOn(processUrls, "resolveRuntimeProcessEntrypointUrl").mockReturnValue(
+        pathToFileURL(worker),
+      );
+      const check = assertSqliteIntegrityInWorker(source, 250, new AbortController().signal);
+      if (completes) {
+        await expect(check).resolves.toBeUndefined();
+      } else {
+        await expect(check).rejects.toThrow(
+          /without a completed check.*lastObservedPhase=checking/,
+        );
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "preserves native errors and closes the database when closing diagnostics fail=%s",
+    async (failClosingPhase) => {
+      const root = tempDirs.make("openclaw-integrity-native-");
+      const source = path.join(root, "source.sqlite");
+      const db = new (requireNodeSqlite().DatabaseSync)(source);
+      db.exec(
+        "PRAGMA foreign_keys = OFF; CREATE TABLE parent(id INTEGER PRIMARY KEY); CREATE TABLE child(parent_id INTEGER REFERENCES parent(id)); INSERT INTO child VALUES (42);",
+      );
+      db.close();
+      const entry = processUrls.resolveRuntimeProcessEntrypointUrl("sqliteIntegrity");
+      const phases = path.join(root, "phases.jsonl");
+      const closed = path.join(root, "closed.json");
+      const worker = path.join(root, "observed-worker.mts");
+      fs.writeFileSync(
+        worker,
+        `import fs from 'node:fs';
+        import { createRequire } from 'node:module';
+        const sqlite = createRequire(import.meta.url)('node:sqlite');
+        const close = sqlite.DatabaseSync.prototype.close;
+        sqlite.DatabaseSync.prototype.close = function (...args) {
+          const location = this.prepare('PRAGMA database_list').all().find(row => row.name === 'main').file;
+          const result = Reflect.apply(close, this, args);
+          if (location === ${JSON.stringify(source)}) fs.writeFileSync(${JSON.stringify(closed)}, JSON.stringify({ isOpen: this.isOpen }));
+          return result;
+        };
+        const send = process.send.bind(process);
+        process.send = (message, ...args) => {
+          if (message.type === 'phase') {
+            fs.appendFileSync(${JSON.stringify(phases)}, JSON.stringify(message.phase) + '\\n');
+            if (${failClosingPhase} && message.phase === 'closing') throw new Error('synthetic diagnostic send failure');
+          }
+          return send(message, ...args);
+        };
+        await import(${JSON.stringify(entry.href)});`,
+      );
+      vi.spyOn(processUrls, "resolveRuntimeProcessEntrypointUrl").mockReturnValue(
+        pathToFileURL(worker),
+      );
+      await expect(
+        assertSqliteIntegrityInWorker(source, 250, new AbortController().signal),
+      ).rejects.toMatchObject({
+        name: "SqliteIntegrityError",
+        message: expect.stringContaining("foreign_key_check failed"),
+      });
+      expect(fs.existsSync(phases)).toBe(true);
+      expect(
+        fs
+          .readFileSync(phases, "utf8")
+          .trim()
+          .split("\n")
+          .map((line) => JSON.parse(line)),
+      ).toEqual(["opening", "checking", "closing"]);
+      expect(JSON.parse(fs.readFileSync(closed, "utf8"))).toEqual({ isOpen: false });
+    },
+  );
 });

--- a/src/infra/sqlite-integrity.worker.ts
+++ b/src/infra/sqlite-integrity.worker.ts
@@ -5,6 +5,8 @@ import { setSqliteBusyTimeout } from "./sqlite-busy-timeout.js";
 import {
   readSqliteIntegrityFileIdentity,
   type SqliteIntegrityWorkerInput,
+  type SqliteIntegrityWorkerMessage,
+  type SqliteIntegrityWorkerPhase,
   type SqliteIntegrityWorkerResult,
 } from "./sqlite-integrity-worker.js";
 import { assertSqliteIntegrity } from "./sqlite-integrity.js";
@@ -18,22 +20,45 @@ function nativeErrorDetails(error: Error) {
 if (!process.send || !process.disconnect) {
   throw new Error("SQLite integrity child requires parent IPC.");
 }
-const sendResult = process.send.bind(process);
+const sendMessage = process.send.bind(process);
 const disconnect = process.disconnect.bind(process);
+
+function sendPhase(phase: SqliteIntegrityWorkerPhase): Promise<void> {
+  return new Promise((resolve, reject) => {
+    // Flush each phase before native work can block this child's event loop.
+    sendMessage({ type: "phase", phase } satisfies SqliteIntegrityWorkerMessage, (error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
 
 // SAFETY: Only assertSqliteIntegrityInWorker sends this private IPC input.
 const [input] = (await once(process, "message")) as [SqliteIntegrityWorkerInput];
 let database: import("node:sqlite").DatabaseSync | undefined;
 let failure: Error | undefined;
 try {
+  await sendPhase("opening");
   readSqliteIntegrityFileIdentity(input.pathname, input.identity);
   database = openNodeSqliteDatabase(input.pathname, { readOnly: true });
   setSqliteBusyTimeout(database, input.busyTimeoutMs);
   readSqliteIntegrityFileIdentity(input.pathname, input.identity);
+  await sendPhase("checking");
   assertSqliteIntegrity(database, input.pathname);
 } catch (error) {
   failure = toStringifiedError(error);
 } finally {
+  if (database) {
+    try {
+      await sendPhase("closing");
+    } catch (error) {
+      // Reporting failure cannot replace a native failure or skip native close.
+      failure ??= toStringifiedError(error);
+    }
+  }
   try {
     database?.close();
   } catch (error) {
@@ -51,4 +76,4 @@ if (failure) {
     },
   };
 }
-sendResult(result, disconnect);
+sendMessage(result, disconnect);

--- a/src/state/openclaw-agent-admission-order.diagnostic.test.ts
+++ b/src/state/openclaw-agent-admission-order.diagnostic.test.ts
@@ -257,7 +257,7 @@ describe("asynchronous canonical admission", () => {
           "message",
           (message: integrityWorker.SqliteIntegrityWorkerResult | { phase: string }) => {
             if ("phase" in message) {
-              committed = message.phase === "external-commit";
+              committed ||= message.phase === "external-commit";
             } else {
               result = message;
             }


### PR DESCRIPTION
Related: #141412.

## What Problem This Solves

Fixes an issue where operators diagnosing a database integrity timeout during startup or maintenance could not tell whether the child had opened the database, reached validation, or begun closing. The existing 30-second timeout covers the child's whole lifetime.

## Why This Change Was Made

The child reports three bounded phases through its existing private IPC channel: `opening`, `checking`, and `closing`. The parent retains the last observed phase, including `starting` and `result-received`, and appends it to timeout and incomplete-exit errors. Messages are flushed before blocking work; progress cannot count as a final result or overwrite one.

The existing deadline, SIGKILL cancellation, full integrity and foreign-key checks, file-identity checks, native error envelope, and ownership until child closure are preserved. Failed closing diagnostics still close the native database and retain an existing integrity failure. No SQLite schema, stored representation, SQL, retention, configuration, or execution-policy change is included.

## User Impact

Timeout errors now include a field such as `lastObservedPhase=checking`. This records the last message the parent received; it does not identify the child's exact current location, distinguish integrity from foreign-key work, establish CPU use, or explain the underlying stall. The reference documentation defines each value.

## Evidence

Verified candidate: `d32cb57583a774a4a55c829e0342c756799a8398`.

- All **68 focused tests pass**: 15 integrity/protocol cases, 38 database-admission cases, and 15 maintenance cases, including real cancellation and child-closure fencing.
- Pre-fix protocol checks failed for missing timeout phase detail, missing-completion diagnostics, and a final result overwritten by a later phase. Real FK cases preserved their native failure but lacked the expected phases. The candidate passes those checks, including a failed closing-phase send with native close independently observed.
- The existing WAL-commit observer initially failed because an unrelated closing phase erased its confirmed commit flag. It now latches that actual observation; the same foreign-key and ownership assertions pass.
- Full changed checks passed, including production/test types, lint, unused exports, storage guards, and zero runtime import cycles. Independent review through P2 found no actionable findings.
- [Dedicated Linux built-runtime proof](https://github.com/openclaw/openclaw/actions/runs/34170804432) passed normal `pnpm build`, all 68 focused tests, and actual emitted parent-to-child flows on healthy and FK-invalid synthetic databases. Both flows observed three phases followed by one final result, unchanged `30000`/`SIGKILL` launch options, child closure before settlement, and preserved caller connections and rows. The immutable proof capsule has the same complete tree as original head `bc3dd85a`. The refresh onto main for #141671 preserves the identical patch, all five changed file blobs, and seven unchanged integrity/admission/maintenance contract files; the existing Linux proof applies to that unchanged implementation. This verifies built runtime behavior, not an installed-tarball upgrade or production stall cause.
- Initial CI failed on an unrelated update-command line limit in the merge parent. The separate main fix #141671 is included by the refresh, and the targeted lint now passes. [Fresh exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34172823465) passed; the earlier failure is retained.

Production: **+54/−6 lines** (net +48). Tests: **+95/−17** (net +78). Docs: **+13/−1** (net +12).


Final landing validation: head `714897d6e0e28f017129db71c68ed49dddcae014` is a patch-identical rebase; all five changed files and seven relevant contract files are unchanged. All 68 focused tests, fresh P2 review, documentation formatting, and pre-push lint over the PR paths plus 14 large main-changed files passed. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34174294390) and native hosted-gate preparation passed. The local changed-file check stopped before typechecking because the supplied shared dependency installation violates the nested-checkout declaration guard; that guard was preserved.
