### PR TITLE
refactor(update): simplify constant downgrade confirmation text

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -548,10 +548,7 @@ async function updateCommandInternal(
         { env: run.env },
       );
       defaultRuntime.error(
-        [
-          "Downgrade confirmation required.",
-          "Downgrading can break configuration. Re-run in a TTY to confirm.",
-        ].join("\n"),
+        "Downgrade confirmation required.\nDowngrading can break configuration. Re-run in a TTY to confirm.",
       );
       defaultRuntime.exit(1);
       return;


### PR DESCRIPTION
Related: #141663

## What Problem This Solves

Resolves a problem where main-based CI fails the update CLI's existing 700-line limit, blocking unrelated changes such as #141663.

## Why This Change Was Made

Replace a constant two-element array joined with a newline with its identical string literal. This removes unnecessary allocation and three counted lines without changing the confirmation message or the lint rule.

## User Impact

No user-visible behavior change. The downgrade warning has exactly the same bytes.

## Evidence

- Original core lint failure: https://github.com/openclaw/openclaw/actions/runs/34170481334/job/101889773104
- Focused core lint and formatting passed.
- Compared the original joined strings with the replacement literal: exact byte equality.
- Independent P2 review found no actionable issues.
- Full scoped changed check passed, including core/test typechecks and repository guards.
- Exact-head CI is required before merge.
