### PR TITLE
fix(tests): set explicit Doctor authority fixture permissions

### DIFF
--- a/src/commands/doctor-gateway-services.authority.test.ts
+++ b/src/commands/doctor-gateway-services.authority.test.ts
@@ -76,6 +76,7 @@ describe.skipIf(process.platform === "win32")("Doctor native repair authority or
   ) {
     state = await createOpenClawTestState({ prefix: "doctor-authority-" });
     const { root, home, stateDir, configPath } = state;
+    await fs.chmod(stateDir, 0o700);
     const installedStateDir = blockedTarget ? path.join(root, "installed-state") : stateDir;
     const unitPath = path.join(home, ".config/systemd/user/openclaw-gateway.service");
     const environmentPath = path.join(stateDir, "gateway.systemd.env");


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Doctor's service-authority regression suite fails under a group-writable umask before reaching its intended sealed-mount, inspection-failure and writable-repair scenarios. The shared fixture already creates the state directory, so the later recursive mkdir with mode 0700 does not change its existing permissions.

## Why This Change Was Made

Set the task-owned fixture state directory to 0700 immediately after creation. Keep the real authority checks, all deliberate unsafe-file permissions, and every assertion unchanged. This establishes the fixture's intended precondition without changing the shared helper or production policy.

## User Impact

No production behavior changes. The tests reliably exercise the intended service-repair authority paths across ambient umasks. This adds one test line; no runtime or aggregate coverage claim.

## Evidence

- Unchanged full suite under child-only umask 002 reproduced the same eight failing cases and five passing cases seen in the frozen baseline, including the state-directory unsafe-permissions refusal.
- Corrected suite: all 13 cases passed under each of 002, 022 and 000. Parent umask remained unchanged; the historical remote umask is unknown.
- Systemd mutation and directory-creation siblings: 86 cases passed under 002, retaining intentional unsafe-permission refusals.
- Full changed gate, formatting/diff checks and fresh P2 review passed. All test bytes other than the single fixture chmod remain unchanged.

Initial CI hit an unrelated max-lines failure in `update-command.ts`. This branch was refreshed identically onto the main repair; the Doctor patch and source hash are unchanged. Fresh CI validates the new head.
