### PR TITLE
fix: prevent multi-select tests leaking their resize observer

### DIFF
--- a/ui/src/components/multi-select.test.ts
+++ b/ui/src/components/multi-select.test.ts
@@ -1,5 +1,5 @@
 /* @vitest-environment jsdom */
-import { afterEach, beforeAll, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, expect, it, vi } from "vitest";
 import { MultiSelect, type MultiSelectOption } from "./multi-select.ts";
 
 const MULTI_SELECT_TEST_TAG = `test-openclaw-multi-select-${crypto.randomUUID()}`;
@@ -30,16 +30,19 @@ const options: MultiSelectOption[] = [
 beforeAll(() => {
   // Web Awesome's popup observes its anchor; jsdom has no ResizeObserver.
   if (!("ResizeObserver" in globalThis)) {
-    Object.assign(globalThis, {
-      ResizeObserver: class {
+    vi.stubGlobal(
+      "ResizeObserver",
+      class {
         observe() {}
         unobserve() {}
         disconnect() {}
       },
-    });
+    );
   }
   customElements.define(MULTI_SELECT_TEST_TAG, class extends MultiSelect {});
 });
+
+afterAll(() => vi.unstubAllGlobals());
 
 afterEach(() => {
   document.body.replaceChildren();


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves a problem where the shared UI test run fails the marquee resize case after the multi-select suite runs.

## Why This Change Was Made

The multi-select fixture assigned a synthetic `ResizeObserver` directly to the global object and never restored it. The marquee suite then cached that observer before its resize case could install its own callback. Track the fixture with `vi.stubGlobal` and restore globals after the suite.

## User Impact

No product behavior changes. All 13 multi-select cases and seven marquee cases remain, with unchanged production code and assertions.

## Evidence

- The complete suites, forced into multi-select → marquee order in one non-isolated worker with the repository UI configuration, reproduce the original missing-callback failure: 19 passed, one failed.
- The same ordered run passes all 20 cases after the repair; marquee alone passes all seven.
- Changed-file gate and fresh P2 review pass.

The initial CI run failed on an inherited `update-command.ts` maximum-line violation. After #141671 repaired that baseline, this branch was refreshed onto the fixed main with an identical patch; new exact-head CI supplies the landing check.
