### PR TITLE
refactor(cron): return activation state atomically

### DIFF
--- a/src/cron/service/run-admission.ts
+++ b/src/cron/service/run-admission.ts
@@ -383,54 +383,51 @@ export async function activateQueuedCronRun(params: {
   if (!reservation || reservation.identity !== reservationIdentity || !runReceipt) {
     return { kind: "fenced" };
   }
-  let previousLastError: string | undefined;
-  let activatedJob: CronJob | undefined;
-  let activatedReceipt: CronRunReceiptHandle | undefined;
-  try {
-    activatedJob = commitCronRuntimeRows({
-      state,
-      jobIds: [job.id],
-      operationLabel: "cron.run-activation",
-      mutate: ({ database, jobs }) => {
-        const current = jobs.get(job.id);
-        const markerAtMs = state.queuedRunReservationsByJobId.get(job.id)?.markerAtMs;
-        if (!current || markerAtMs === undefined || current.state.queuedAtMs !== markerAtMs) {
-          return { value: undefined, runHooks: false };
-        }
-        previousLastError = current.state.lastError;
-        activatedReceipt = activateServiceCronRunReceiptInDatabase(
-          state,
-          database,
-          runReceipt,
-          startedAt,
-        );
-        delete current.state.queuedAtMs;
-        current.state.runningAtMs = startedAt;
-        current.state.lastError = undefined;
-        return { value: current, upsertJobIds: [current.id] };
-      },
-    });
-  } catch (error) {
-    if (error instanceof CronRunReceiptConflictError) {
-      enrollForeignReceipt(state, error.candidate);
-      return { kind: "fenced" };
+  const activation = (() => {
+    try {
+      return commitCronRuntimeRows({
+        state,
+        jobIds: [job.id],
+        operationLabel: "cron.run-activation",
+        mutate: ({ database, jobs }) => {
+          const current = jobs.get(job.id);
+          const markerAtMs = state.queuedRunReservationsByJobId.get(job.id)?.markerAtMs;
+          if (!current || markerAtMs === undefined || current.state.queuedAtMs !== markerAtMs) {
+            return { value: undefined, runHooks: false };
+          }
+          const previousLastError = current.state.lastError;
+          const value = [
+            current,
+            activateServiceCronRunReceiptInDatabase(state, database, runReceipt, startedAt),
+            previousLastError,
+          ] as const;
+          delete current.state.queuedAtMs;
+          current.state.runningAtMs = startedAt;
+          current.state.lastError = undefined;
+          return { value, upsertJobIds: [current.id] };
+        },
+      });
+    } catch (error) {
+      if (error instanceof CronRunReceiptConflictError) {
+        enrollForeignReceipt(state, error.candidate);
+      } else if (!(error instanceof CronRunReceiptRevisionError)) {
+        throw error;
+      }
+      return undefined;
     }
-    if (error instanceof CronRunReceiptRevisionError) {
-      return { kind: "fenced" };
-    }
-    throw error;
-  }
-  if (!activatedJob) {
+  })();
+  if (!activation) {
     return { kind: "fenced" };
   }
+  const [activatedJob, activatedReceipt, previousLastError] = activation;
   applyCronRuntimeRowsToState(state, [activatedJob]);
   if (reservation?.identity === reservationIdentity) {
     reservation.markerAtMs = startedAt;
-    reservation.runReceipt = activatedReceipt!;
+    reservation.runReceipt = activatedReceipt;
     reservation.activationPreviousLastError = { value: previousLastError };
   }
   if (!state.stopped && reservation.lifecycleGeneration === state.lifecycleGeneration) {
-    return { kind: "activated", job: activatedJob, startedAt, runReceipt: activatedReceipt! };
+    return { kind: "activated", job: activatedJob, startedAt, runReceipt: activatedReceipt };
   }
 
   params.onUnavailable?.();
@@ -441,7 +438,7 @@ export async function activateQueuedCronRun(params: {
       operationLabel: "cron.run-activation-unavailable",
       transactionHooks: cronRunReceiptPersistHooks({
         state,
-        handle: activatedReceipt!,
+        handle: activatedReceipt,
         terminal: {
           status: "skipped",
           finishedAtMs: state.deps.nowMs(),
@@ -465,7 +462,7 @@ export async function activateQueuedCronRun(params: {
     await params.onUnavailableRollbackError?.();
     throw error;
   } finally {
-    releaseLocalCronRunReceiptOwnership(activatedReceipt!);
+    releaseLocalCronRunReceiptOwnership(activatedReceipt);
   }
   releaseQueuedCronRun(state, job.id, reservationIdentity);
   return { kind: "unavailable", reason: "stopped" };


### PR DESCRIPTION
## What Problem This Solves

Cron run activation assembled the activated job, receipt handle, and previous error through separately assigned optional variables. That forced downstream non-null assertions even though a successful transaction produces all three values atomically.

## Why This Change Was Made

The transaction now returns the complete activation tuple as its value. Conflict and revision fencing still return the same fenced result, while unexpected errors continue to propagate. Callers consume the proven tuple directly, removing four unsafe receipt assertions without changing persistence or ownership behavior.

## User Impact

No user-visible behavior change. Cron activation retains its transaction, rollback, fencing, and receipt-release semantics with a tighter static contract.

## Evidence

- Exact-head `pnpm check:changed` passed at `9be7b60e4f0`, including core typechecks, lint, formatting, assertion ratchets, dead-export scans, and boundary guards.
- 59 focused cron admission tests and core typechecking passed.
- Structured P0–P2 review found no actionable issue, including evaluation order, transaction rollback, receipt ownership/release, conflict/revision fencing, and `previousLastError` preservation.
- `main` advances after the proof did not touch `src/cron/service/run-admission.ts`; a synthetic merge with current `origin/main` is clean.
- Diff: 38 additions, 41 deletions; net −3 production LOC.
