### PR TITLE
fix(update): restore the core lint gate

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -557,8 +557,7 @@ async function updateCommandInternal(
       return;
     }
 
-    const targetLabel = targetVersion ?? `${tag} (unknown)`;
-    const message = `Downgrading from ${currentVersion} to ${targetLabel} can break configuration. Continue?`;
+    const message = `Downgrading from ${currentVersion} to ${targetVersion ?? `${tag} (unknown)`} can break configuration. Continue?`;
     const ok = await confirm({
       message: stylePromptMessage(message),
       initialValue: false,


### PR DESCRIPTION
Superseded by #141671, merged while this PR was being validated. Current main passes the unchanged lint rule; this additional cleanup is not needed.

Related: #141610, #141669.

## What Problem This Solves

Resolves a problem where main and PR validation fail the core lint gate because the update command has 701 counted lines against the existing 700-line limit. The package-install preflight argument added in #141610 crossed that limit; the unrelated SQLite diagnostics PR exposed it in CI.

## Why This Change Was Made

Inline the one-use downgrade target label into its existing confirmation message. The same nullish fallback and message are preserved, and the package artifact preflight argument remains intact. The lint rule and its limit are unchanged.

## User Impact

No CLI behavior or output changes. Core lint can validate this source again.

## Evidence

- [Original exact CI job](https://github.com/openclaw/openclaw/actions/runs/34171147777/job/101891631711) failed only this rule in the core lint stripe.
- Reproduced on current main `29464d4ff7d6e7ac37e87a0e29064c930ea19439` with pinned oxlint 1.80.0 and the unchanged repository configuration: 701 counted lines, exit 1. The candidate passes at 700, exit 0.
- Pinned oxfmt 0.65.0 check and `git diff --check` pass.
- Independent P0–P2 review found no actionable findings.
- Production diff: +1/-2 lines. No new tests were added for this equivalent expression; no local build, typecheck or runtime test was run. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34171957839) passed, including the previously failing core lint stripe.

Supersession verified on main `59f57f3cc5fa4beaba0d2f08bcc7e5ed3d947b3e`: it contains merge `4140743e31f8c3500ef9ab972105d5f273107b4e`, preserves `packageInstallSpec`, and passes pinned oxlint with the unchanged configuration.
