### PR TITLE
fix: keep update refusal exits within the lint limit

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -197,8 +197,7 @@ async function updateCommandInternal(
     });
 
   if (requestedChannel === "extended-stable" && installKind === "git") {
-    await refuseUpdate("unsupported_git_channel");
-    return;
+    return await refuseUpdate("unsupported_git_channel");
   }
 
   const preparedConfig = await createConfigIO({
@@ -219,11 +218,10 @@ async function updateCommandInternal(
 
   if (opts.channel && !configSnapshot.valid) {
     const issues = formatConfigIssueLines(configSnapshot.issues, "-");
-    await refuseUpdate(
+    return await refuseUpdate(
       "invalid-config",
       ["Config is invalid; cannot set update channel.", ...issues].join("\n"),
     );
-    return;
   }
 
   const channel =
@@ -236,8 +234,7 @@ async function updateCommandInternal(
           installKind,
         }).channel);
   if (channel === "extended-stable" && installKind === "git") {
-    await refuseUpdate("unsupported_git_channel");
-    return;
+    return await refuseUpdate("unsupported_git_channel");
   }
   // An effective dev channel (stored or explicit) selects the git flow — the
   // documented dev contract is a git checkout. Exception: --tag is a one-run
@@ -263,13 +260,12 @@ async function updateCommandInternal(
 
   const unsupportedMainTag = updateInstallKind === "package" && explicitTag === "main";
   if ((channel === "extended-stable" && explicitTag) || unsupportedMainTag) {
-    await refuseUpdate(
+    return await refuseUpdate(
       unsupportedMainTag ? "unsupported-package-target" : EXTENDED_STABLE_TAG_UNSUPPORTED_REASON,
       unsupportedMainTag
         ? "`--tag main` cannot update a package install. Run `openclaw update --channel dev` to switch to the supported Git checkout and build flow."
         : undefined,
     );
-    return;
   }
   let tag = explicitTag ?? channelToNpmTag(channel);
   let currentVersion: string | null = null;
@@ -354,8 +350,7 @@ async function updateCommandInternal(
       });
       const npmLifecycleGate = resolveNpmLifecyclePolicyGate(packageInstallTarget);
       if (npmLifecycleGate.error) {
-        await refuseUpdate("npm lifecycle policy preflight", npmLifecycleGate.error);
-        return;
+        return await refuseUpdate("npm lifecycle policy preflight", npmLifecycleGate.error);
       }
     }
     const npmMetadataCommand =
@@ -368,8 +363,7 @@ async function updateCommandInternal(
         packageName: installedPackageName,
       });
       if (extendedStable.status === "failed") {
-        await refuseUpdate(extendedStable.reason);
-        return;
+        return await refuseUpdate(extendedStable.reason);
       }
       targetVersion = extendedStable.version;
       tag = extendedStable.version;
@@ -431,11 +425,10 @@ async function updateCommandInternal(
         env: packageInstallEnv,
       });
       if (targetMetadata.error || targetMetadata.version !== targetVersion) {
-        await refuseUpdate(
+        return await refuseUpdate(
           "target-metadata-preflight",
           `Update refused: could not inspect exact package target openclaw@${targetVersion}: ${targetMetadata.error ?? `registry returned version ${targetMetadata.version ?? "unknown"}`}.`,
         );
-        return;
       }
       packageTargetSchemaVersions = targetMetadata.schemaVersions;
       // Runtime and schema checks must use the same exact package that will be
@@ -593,8 +586,7 @@ async function updateCommandInternal(
       fallbackNodeRunner: canRefreshManagedServiceNode ? resolveNodeRunner() : undefined,
     });
     if (!runtimePreflight.ok) {
-      await refuseUpdate("node-runtime-preflight", runtimePreflight.error);
-      return;
+      return await refuseUpdate("node-runtime-preflight", runtimePreflight.error);
     }
     const runtimeSelection = runtimePreflight.value;
     packageUpdateNodeRunner = runtimeSelection.nodeRunner;


### PR DESCRIPTION
## What Problem This Solves

Main CI fails because the update command reached 701 counted lines after the staged-target admission change, exceeding the existing 700-line lint limit. [Failing run](https://github.com/openclaw/openclaw/actions/runs/34170545757).

## Why This Change Was Made

Combine eight `await refuseUpdate(...); return;` exits into `return await refuseUpdate(...)`. The failure owner returns `Promise<never>` and always throws after its existing reporting and recovery work. Every refusal condition, argument, await, and failure remains; the explicit return preserves TypeScript narrowing. No lint suppression or packed formatting.

## User Impact

Restores CI without changing update admission, error reporting, schema checks, configuration, or service behavior. Production is eight lines smaller; no test changes.

## Evidence

- Reproduced the exact 701-line lint failure on the original file; the same targeted lint passes after the cleanup.
- Four existing refusal cases pass: exact target metadata, explicit and stored extended-stable resolution, and extended-stable Git rejection. Their error and no-mutation assertions are retained.
- Formatting and diff checks pass. Managed P2 review found no actionable issues; the reviewed update-command file is byte-identical to this patch.
