### PR TITLE
fix: prevent stale provider hooks and incorrect model alias selection

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -1887,7 +1887,6 @@ src/agents/provider-attribution.ts	14
 src/agents/provider-auth-aliases.ts	1
 src/agents/provider-http-errors.ts	1
 src/agents/provider-local-service.ts	4
-src/agents/provider-model-normalization.runtime.ts	1
 src/agents/provider-model-route.ts	1
 src/agents/provider-request-config.ts	6
 src/agents/provider-secret-egress.ts	3

--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -37,6 +37,8 @@ For `models status`, `OPENCLAW_AGENT_DIR` overrides the inspected auth directory
 
 `models set` and `models set-image` require the provider to be declared by an installed plugin or configured under `models.providers`. An unknown provider exits nonzero without changing config. If the provider is known but the model is absent from the local catalog, the command saves the selection and prints a warning because newly released and self-hosted models may not be cataloged yet. `openclaw doctor --json` reports configured unknown providers; add `--severity-min info` to also see active models that the local catalog cannot confirm.
 
+Default-model, alias, and fallback changes resolve provider-owned model aliases using the current plugin configuration. When stored entries resolve to the selected model, their settings move to its canonical key; existing canonical settings take precedence. Adding an alias replaces the model's previous alias. If config changes during that preparation, the command rejects the write; rerun it against the updated config.
+
 ### Status
 
 Bare `openclaw models` is equivalent to `openclaw models status`.

--- a/docs/plugins/architecture-internals.md
+++ b/docs/plugins/architecture-internals.md
@@ -135,6 +135,48 @@ once per immutable index. Mutable management indexes remain uncached. Lookup
 methods and install-record results remain caller-owned; enablement and trust are
 evaluated from the current operation's policy rather than stored in these facts.
 
+Outside a retained generation, reusing a loaded plugin requires the
+selected ID, origin, root, entry point, and artifact-selection inputs to agree.
+The loader records source/build selection and any executed setup entry on the loaded owner. Explicit manifest
+and discovery source selections, including admitted sidecars, also participate in the loader cache key. Raw
+discovery additionally needs matching load identity before active reuse because
+its manifest winners have not been established. Retained generations remain
+authoritative, including empty selections. Source/build views may share an owner
+only when the loader resolves them to the same execution root and entry under
+the retained preference. Path names or matching
+entry stems alone do not establish ownership. Runtime reuse and loading share
+the existing lifecycle-owned artifact facts and final execution step, including
+executed setup entries. Discovery and artifact identity retain their selected paths.
+
+Bounded loaded-owner lookups retain the owner's artifact policy when no preference
+is specified. An explicit preference is checked; exact loader requests apply the
+full cache identity and cold-load defaults.
+
+Provider lookup uses an explicit caller workspace first, then the workspace
+recorded by its metadata snapshot, including an explicitly shared-root scope.
+Only narrowed metadata views without a workspace field inherit the active
+workspace. The registry's existing load context retains its workspace so a request or active
+registry from another workspace cannot replace a prepared selection.
+
+Provider hooks share the canonical provider registry selection. Declared providers
+reserve their names, while provider-triggered helpers still activate beside them.
+Required load owners and eligible hook receivers are captured separately in that
+selection. Declared provider owners need matching physical records and provider
+registrations before reuse; activation-only helpers may have no provider rows,
+but need a successfully completed runtime registration pass. A setup-only pass
+cannot prove their runtime contributions are complete. References without a
+static owner select only their matching runtime aliases within the requested scope.
+Loaded aliases can identify owners to reload, but only the selected registry's
+current registrations determine alias receivers.
+Loaded-only failover inspection never discovers or activates plugins. When it uses
+registry-owned metadata, the caller's discovery and policy inputs must match the
+recorded fingerprint. The loader captures normalized registration inputs, including
+paired source config, once; later metadata updates preserve that record. Ordinary
+lookups reuse callbacks only when those inputs match; retained generations stay
+authoritative. Model-reference parsing reads the same declared-owner facts
+from the registry or retained request scope, so a failed declared provider cannot
+be replaced by another provider's hook alias.
+
 Provider auth aliases are normalized and indexed with the snapshot. Lookups
 select among those prepared candidates using the current workspace trust config;
 they do not cache trust decisions or credentials. Callers supplying a partial
@@ -337,9 +379,16 @@ releases its lease without classifying the healthy process as a startup failure.
 
 Normalization dispatch is hook-specific:
 
-- `normalizeModelId` uses the matched provider hook's non-empty result. If none
-  is returned, OpenClaw applies manifest-declared model-ID normalization; it does
-  not try other providers' normalization hooks.
+- Model references apply manifest-declared model-ID normalization once before
+  `normalizeModelId` dispatch. The matched provider hook can refine that prepared
+  model ID; an empty result keeps it unchanged. OpenClaw does not try other
+  providers' normalization hooks or reapply manifest rules afterward.
+  Reference parsing reads the selected runtime registry without activating
+  plugins. Executable normalization requires a prepared runtime owner; reads
+  without one use static manifest policies only.
+  A directly registered provider owns its ID; compatibility aliases match only
+  when no literal provider exists, preserving alias-only routes and explicit
+  API-owner eligibility.
 - `normalizeTransport` tries the matched provider first. Only if that does not
   change `api` or `baseUrl` and the provider has no `models.providers.<id>` entry
   does it try other transport hooks, stopping at the first change.

--- a/src/agents/embedded-agent-runner/compact.hooks.harness.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.harness.ts
@@ -436,6 +436,7 @@ const emptyPluginMetadataSnapshot: PluginMetadataSnapshot = {
   diagnostics: [],
   byPluginId: new Map(),
   normalizePluginId: (pluginId: string) => pluginId,
+  declaredProviderOwners: new Map(),
   owners: {
     channels: new Map(),
     channelConfigs: new Map(),

--- a/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
+++ b/src/agents/embedded-agent-runner/compaction-runtime-context.test.ts
@@ -290,7 +290,7 @@ describe("buildEmbeddedCompactionRuntimeContext", () => {
     "resolves literal compaction overrides without discovering provider plugins $name",
     ({ models }) => {
       const manifestNormalization = vi
-        .spyOn(manifestModelIdNormalization, "normalizeProviderModelIdWithManifest")
+        .spyOn(manifestModelIdNormalization, "resolveManifestModelIdNormalizationPolicies")
         .mockImplementation(() => {
           throw new Error("literal compaction overrides must not discover plugin manifests");
         });

--- a/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
+++ b/src/agents/embedded-agent-runner/model-resolution-consistency.test.ts
@@ -282,7 +282,6 @@ describe("embedded model resolution consistency", () => {
     ]);
     expect(normalizeProviderModelIdWithRuntimeMock).toHaveBeenCalledWith({
       provider: "custom-provider",
-      plugins: manifestPlugins,
       context: {
         provider: "custom-provider",
         modelId: "modern-model",

--- a/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.harness.ts
@@ -97,6 +97,7 @@ const emptyPluginMetadataSnapshot: PluginMetadataSnapshot = {
   diagnostics: [],
   byPluginId: new Map(),
   normalizePluginId: (pluginId: string) => pluginId,
+  declaredProviderOwners: new Map(),
   owners: {
     channels: new Map(),
     channelConfigs: new Map(),

--- a/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-spawn-workspace.test-support.ts
@@ -367,6 +367,7 @@ const emptyPluginMetadataSnapshot: PluginMetadataSnapshot = {
   diagnostics: [],
   byPluginId: new Map(),
   normalizePluginId: (pluginId: string) => pluginId,
+  declaredProviderOwners: new Map(),
   owners: {
     channels: new Map(),
     channelConfigs: new Map(),

--- a/src/agents/harness/types.ts
+++ b/src/agents/harness/types.ts
@@ -1,3 +1,5 @@
+// Harness contracts depend on the model-ref data shape, not its runtime normalization.
+import type { ProviderModelRef as ModelRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import type { SessionToolOverrides } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 /**
@@ -9,7 +11,6 @@ import type {
   ProviderRouteOverridePresence,
 } from "../../plugin-sdk/provider-model-types.js";
 import type { McpToolCatalog } from "../agent-bundle-mcp-types.js";
-import type { ModelRef } from "../model-ref-shared.js";
 import type { AgentHarnessHostCapabilities } from "./host-capability-types.js";
 import type { AgentHarnessRuntimeArtifactBinding } from "./runtime-artifact.types.js";
 
@@ -540,7 +541,7 @@ export type AgentHarnessModelCatalogParams = {
   agentId: string;
   agentDir: string;
   workspaceDir: string;
-  configuredModelRefs?: readonly import("../model-ref-shared.js").ModelRef[];
+  configuredModelRefs?: readonly ModelRef[];
 };
 
 type AgentHarnessModelCatalogCapability = {

--- a/src/agents/mcp-auth-profile.integration.test-support.ts
+++ b/src/agents/mcp-auth-profile.integration.test-support.ts
@@ -541,11 +541,17 @@ async function runScopeScenario(root: string): Promise<void> {
     assert.equal(second.generation.pluginRegistry.providers.length, 1);
     assert.equal(disabled.generation.pluginRegistry.providers.length, 0);
     const checkScope = (owner: ScopedOwner, context?: HookContext) => {
-      assert.deepEqual(getPluginRuntimeGatewayRequestScope(), {
-        ...owner.request,
-        pluginRegistry: owner.generation.pluginRegistry,
-      });
-      assert.equal(getPluginRuntimeGenerationRegistry(), owner.generation.pluginRegistry);
+      const scope = getPluginRuntimeGatewayRequestScope();
+      assert(scope, "request scope must survive deferred auth");
+      assert.equal(scope.pluginId, owner.request.pluginId);
+      assert.equal(scope.isWebchatConnect === owner.request.isWebchatConnect, true);
+      assert.equal(scope.resolveGatewayContext === owner.request.resolveGatewayContext, true);
+      assert.equal(scope.pluginRegistry === owner.generation.pluginRegistry, true);
+      assert.equal(
+        scope.declaredProviderOwners === owner.generation.metadataSnapshot.declaredProviderOwners,
+        true,
+      );
+      assert.equal(getPluginRuntimeGenerationRegistry() === owner.generation.pluginRegistry, true);
       if (context) {
         assert.equal(context.config, owner.fixture.config);
         assert.equal(context.agentDir, owner.fixture.agentDir);
@@ -600,7 +606,10 @@ async function runScopeScenario(root: string): Promise<void> {
     assert(!providerEvents.some((event) => event.owner === "disabled"));
     assert.equal(getPluginRuntimeGatewayRequestScope(), undefined);
     assert.equal(getPluginRuntimeGenerationRegistry(), undefined);
-    assert.equal(getPluginRegistryState()?.activeRegistry, second.generation.pluginRegistry);
+    assert.equal(
+      getPluginRegistryState()?.activeRegistry === second.generation.pluginRegistry,
+      true,
+    );
   } finally {
     inspectHook = undefined;
     await endpoint.close();

--- a/src/agents/model-ref-shared.test.ts
+++ b/src/agents/model-ref-shared.test.ts
@@ -1,18 +1,33 @@
-// Documents provider/model id normalization from built-ins and plugin manifests.
+// Checks model reference normalization across manifests and runtime owners.
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { promisify } from "node:util";
+import { build } from "esbuild";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata.test-support.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../plugins/runtime.js";
+import { withPluginRuntimeRegistryScope } from "../plugins/runtime/gateway-request-scope.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
+import type { ProviderPlugin } from "../plugins/types.js";
+import { withTempDir } from "../test-utils/temp-dir.js";
 import {
   normalizeConfiguredProviderCatalogModelId,
   normalizeStaticProviderModelId,
 } from "./model-ref-shared.js";
+import { normalizeProviderModelIdWithRuntime } from "./provider-model-normalization.runtime.js";
 
 beforeEach(() => {
+  resetPluginRuntimeStateForTest();
   clearPluginMetadataLifecycleCaches();
 });
 
 afterEach(() => {
+  resetPluginRuntimeStateForTest();
   clearPluginMetadataLifecycleCaches();
 });
 
@@ -147,5 +162,178 @@ describe("normalizeConfiguredProviderCatalogModelId", () => {
     expect(
       normalizeConfiguredProviderCatalogModelId("kilocode", "kilocode/google/gemini-3-pro-preview"),
     ).toBe("kilocode/google/gemini-3.1-pro-preview");
+  });
+});
+
+const execFileAsync = promisify(execFile);
+
+function createModelNormalizerGeneration() {
+  const pluginRegistry = createEmptyPluginRegistry();
+  pluginRegistry.providers.push({
+    pluginId: "foreign-owner",
+    source: "foreign-owner.ts",
+    provider: {
+      id: "foreign",
+      hookAliases: ["fixture"],
+      label: "Foreign alias",
+      auth: [],
+      normalizeModelId: () => "foreign-model",
+    },
+  });
+  pluginRegistry.providers.push({
+    pluginId: "fixture-owner",
+    source: "fixture-owner.ts",
+    provider: {
+      id: "fixture",
+      hookAliases: ["fixture-alias"],
+      label: "Fixture",
+      auth: [],
+      normalizeModelId(this: ProviderPlugin, { modelId }) {
+        return `${this.pluginId}-${modelId}`;
+      },
+    },
+  });
+  const metadataSnapshot = createPluginMetadataSnapshotFixture({
+    plugins: [
+      { id: "foreign-owner", providers: ["foreign"] },
+      { id: "fixture-owner", providers: ["fixture"] },
+    ],
+  });
+  return { metadataSnapshot, pluginRegistry };
+}
+
+describe("provider model normalization bridge", () => {
+  it.each(
+    ["fixture", "fixture-alias"].flatMap((provider) =>
+      ["generation", "request", "active"].map((scope) => ({ provider, scope })),
+    ),
+  )("invokes $provider with its registry owner from $scope", ({ provider, scope }) => {
+    const generation = createModelNormalizerGeneration();
+    const normalize = () =>
+      normalizeProviderModelIdWithRuntime({
+        provider,
+        context: { provider, modelId: "model" },
+      });
+    if (scope === "active") {
+      setActivePluginRegistry(generation.pluginRegistry, "normalizer-fixture");
+    }
+    const result =
+      scope === "generation"
+        ? withPluginRuntimeGenerationScope(generation, normalize)
+        : scope === "request"
+          ? withPluginRuntimeRegistryScope(generation.pluginRegistry, normalize)
+          : normalize();
+    expect(result).toBe("fixture-owner-model");
+  });
+
+  it("keeps an empty generation authoritative over ambient request hooks", () => {
+    const generation = createModelNormalizerGeneration();
+    expect(
+      withPluginRuntimeRegistryScope(generation.pluginRegistry, () =>
+        withPluginRuntimeGenerationScope(
+          { ...generation, pluginRegistry: createEmptyPluginRegistry() },
+          () =>
+            normalizeProviderModelIdWithRuntime({
+              provider: "fixture",
+              context: { provider: "fixture", modelId: "model" },
+            }),
+        ),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("does not borrow an active provider on a request registry miss", () => {
+    const generation = createModelNormalizerGeneration();
+    setActivePluginRegistry(generation.pluginRegistry, "another-gateway");
+    const normalize = () =>
+      normalizeProviderModelIdWithRuntime({
+        provider: "fixture",
+        context: { provider: "fixture", modelId: "model" },
+      });
+    expect(normalize()).toBe("fixture-owner-model");
+    expect(withPluginRuntimeRegistryScope(createEmptyPluginRegistry(), normalize)).toBeUndefined();
+  });
+
+  it("invokes the retained normalizer from the packaged runtime layout", async () => {
+    await withTempDir("openclaw-model-normalizer-", async (root) => {
+      const dist = path.join(root, "dist");
+      await fs.mkdir(dist, { recursive: true });
+      await fs.writeFile(path.join(root, "package.json"), '{"type":"module"}');
+      const bridgePath = path.join(dist, "model-reference.js");
+      // The bundler places this bridge at the dist root, unlike its source directory.
+      await build({
+        entryPoints: [path.resolve("src/agents/provider-model-normalization.runtime.ts")],
+        outfile: bridgePath,
+        bundle: true,
+        platform: "node",
+        format: "esm",
+        tsconfig: path.resolve("tsconfig.json"),
+      });
+      // SAFETY: This test emits the actual typed bridge into a standalone package.
+      const bridge = createRequire(import.meta.url)(
+        bridgePath,
+      ) as typeof import("./provider-model-normalization.runtime.js");
+
+      expect(
+        withPluginRuntimeGenerationScope(createModelNormalizerGeneration(), () =>
+          bridge.normalizeProviderModelIdWithRuntime({
+            provider: "fixture",
+            context: { provider: "fixture", modelId: "model" },
+          }),
+        ),
+      ).toBe("fixture-owner-model");
+    });
+  });
+
+  it("applies source manifest normalization once without an executable hook", async () => {
+    await withTempDir("openclaw-model-normalizer-source-", async (root) => {
+      // Native source execution protects the same contract before runtime preparation.
+      const script = `
+        const { pathToFileURL } = await import("node:url");
+        const load = (file) => import(pathToFileURL(${JSON.stringify(process.cwd())} + "/" + file).href);
+        const { normalizeModelRef } = await load("src/agents/model-ref-shared.ts");
+        const { createPluginMetadataSnapshotFixture } = await load("src/plugins/plugin-metadata.test-support.ts");
+        const { createEmptyPluginRegistry } = await load("src/plugins/registry-empty.ts");
+        const { withPluginRuntimeGenerationScope } = await load("src/plugins/runtime/generation-scope.ts");
+        const { withPluginRuntimeRegistryScope } = await load("src/plugins/runtime/gateway-request-scope.ts");
+        const { withPluginMetadataSnapshotScope } = await load("src/plugins/current-plugin-metadata-snapshot.ts");
+        const metadataSnapshot = createPluginMetadataSnapshotFixture({ plugins: [{
+          id: "fixture", providers: ["fixture"],
+          modelIdNormalization: { providers: { fixture: { stripPrefixes: ["compat/"] } } },
+        }] });
+        const empty = withPluginRuntimeGenerationScope(
+          { metadataSnapshot, pluginRegistry: createEmptyPluginRegistry() },
+          () => normalizeModelRef("fixture", "compat/compat/model"),
+        );
+        const registry = createEmptyPluginRegistry();
+        registry.providers.push({ pluginId: "fixture", provider: { id: "fixture", label: "Fixture", auth: [] } });
+        const request = withPluginMetadataSnapshotScope(metadataSnapshot,
+          () => withPluginRuntimeRegistryScope(registry,
+            () => normalizeModelRef("fixture", "compat/compat/model")),
+          { trustConfigIdentity: true });
+        const unprepared = withPluginMetadataSnapshotScope(metadataSnapshot,
+          () => normalizeModelRef("fixture", "compat/compat/model"),
+          { trustConfigIdentity: true });
+        process.stdout.write(JSON.stringify({ empty, request, unprepared }));
+      `;
+      const { stdout } = await execFileAsync(
+        process.execPath,
+        ["--import", path.resolve("scripts/tsx.mjs"), "--input-type=module", "--eval", script],
+        {
+          env: {
+            ...process.env,
+            OPENCLAW_HOME: root,
+            OPENCLAW_STATE_DIR: path.join(root, "state"),
+            OPENCLAW_CONFIG_PATH: path.join(root, "openclaw.json"),
+            OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+          },
+        },
+      );
+      expect(JSON.parse(stdout)).toEqual({
+        empty: { provider: "fixture", model: "compat/model" },
+        request: { provider: "fixture", model: "compat/model" },
+        unprepared: { provider: "fixture", model: "compat/model" },
+      });
+    });
   });
 });

--- a/src/agents/model-ref-shared.ts
+++ b/src/agents/model-ref-shared.ts
@@ -3,6 +3,7 @@
  * allowlists, and display paths. Manifest policies are optional so tests can
  * isolate built-in normalization behavior.
  */
+import type { ProviderModelRef as ModelRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 import {
   findNormalizedProviderKey as findNormalizedProviderKeyCore,
   normalizeProviderId as normalizeProviderIdCore,
@@ -23,10 +24,7 @@ import { modelKey } from "../shared/model-key.js";
 import { normalizeProviderModelIdWithRuntime } from "./provider-model-normalization.runtime.js";
 export { modelKey } from "../shared/model-key.js";
 
-export type ModelRef = {
-  provider: string;
-  model: string;
-};
+export type { ProviderModelRef as ModelRef } from "@openclaw/model-catalog-core/model-catalog-refs";
 
 export type ModelManifestNormalizationContext = {
   manifestPlugins?: ManifestModelIdNormalizationSource;
@@ -133,7 +131,6 @@ function normalizeProviderModelId(
   return (
     normalizeProviderModelIdWithRuntime({
       provider,
-      ...(options?.manifestPlugins ? { plugins: options.manifestPlugins } : {}),
       context: {
         provider,
         modelId: staticModelId,

--- a/src/agents/model-selection.plugin-runtime.test.ts
+++ b/src/agents/model-selection.plugin-runtime.test.ts
@@ -336,10 +336,7 @@ describe("model-selection plugin runtime normalization", () => {
       ["stored-legacy", "stored-modern"],
       ["fallback-legacy", "fallback-modern"],
     ]);
-    normalizeProviderModelIdWithPluginMock.mockImplementation(({ context, plugins }) => {
-      if (plugins) {
-        expect(plugins.length).toBeGreaterThan(0);
-      }
+    normalizeProviderModelIdWithPluginMock.mockImplementation(({ context }) => {
       const modelId = (context as { modelId?: string }).modelId ?? "";
       return aliases.get(modelId);
     });
@@ -398,37 +395,5 @@ describe("model-selection plugin runtime normalization", () => {
         ([call]) => (call as { context?: { modelId?: string } }).context?.modelId,
       ),
     ).toEqual(expect.arrayContaining(["configured-legacy", "stored-legacy", "fallback-legacy"]));
-  });
-
-  it("forwards manifestPlugins to the runtime normalization call so it can skip the slot-or-load disk walk", async () => {
-    normalizeProviderModelIdWithPluginMock.mockReturnValue(undefined);
-    const preparedPlugins = [
-      {
-        modelIdNormalization: {
-          providers: {
-            custom: { prefixWhenBare: "prepared" },
-          },
-        },
-      },
-    ];
-    const { normalizeModelRef } = await import("./model-ref-shared.js");
-    normalizeModelRef("custom", "my-model", { manifestPlugins: preparedPlugins });
-    expect(normalizeProviderModelIdWithPluginMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        provider: "custom",
-        plugins: preparedPlugins,
-      }),
-    );
-  });
-
-  it("omits plugins from the runtime call when no manifestPlugins are prepared (preserves current behavior)", async () => {
-    normalizeProviderModelIdWithPluginMock.mockReturnValue(undefined);
-    const { normalizeModelRef } = await import("./model-ref-shared.js");
-    normalizeModelRef("custom", "my-model");
-    const callArgs = normalizeProviderModelIdWithPluginMock.mock.calls[0]?.[0] as
-      | { plugins?: unknown }
-      | undefined;
-    expect(callArgs).toBeDefined();
-    expect(callArgs?.plugins).toBeUndefined();
   });
 });

--- a/src/agents/models-config.write-serialization.test.ts
+++ b/src/agents/models-config.write-serialization.test.ts
@@ -86,6 +86,7 @@ function createPluginMetadataSnapshot(workspaceDir: string): PluginMetadataSnaps
     diagnostics: [],
     byPluginId: new Map(),
     normalizePluginId: (pluginId) => pluginId,
+    declaredProviderOwners: new Map(),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/agents/prepared-model-runtime.inbound-registry.ts
+++ b/src/agents/prepared-model-runtime.inbound-registry.ts
@@ -1,7 +1,7 @@
 import { hashRuntimeConfigValue } from "../config/runtime-snapshot.js";
 import {
   listRuntimePluginIdsFromRegistry,
-  registryMatchesManifestPluginIds,
+  createRuntimePluginManifestLookup,
 } from "../plugins/active-runtime-registry.js";
 import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
@@ -76,10 +76,8 @@ export function loadPreparedInboundPluginRegistry(
       workspaceDir: metadataSnapshot.workspaceDir,
       allowWorkspaceScopedSnapshot: true,
     }) === metadataSnapshot &&
-    registryMatchesManifestPluginIds(
-      activeRegistry,
-      metadataSnapshot.manifestRegistry.plugins,
-      listRuntimePluginIdsFromRegistry(activeRegistry),
+    listRuntimePluginIdsFromRegistry(activeRegistry).every(
+      createRuntimePluginManifestLookup(activeRegistry, metadataSnapshot.manifestRegistry.plugins),
     )
       ? activeRegistry
       : undefined;

--- a/src/agents/prepared-model-runtime.startup-static.test.ts
+++ b/src/agents/prepared-model-runtime.startup-static.test.ts
@@ -15,6 +15,7 @@ const mocks = vi.hoisted(() => {
     pluginIds: [],
     index: { plugins: [{ pluginId: "openai", enabled: true }] },
     manifestRegistry: { plugins: [], diagnostics: [] },
+    declaredProviderOwners: new Map(),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/agents/prepared-model-runtime.test-harness.ts
+++ b/src/agents/prepared-model-runtime.test-harness.ts
@@ -22,6 +22,7 @@ const preparedModelRuntimeMocks = vi.hoisted(() => ({
     pluginIds: [],
     index: { plugins: [] },
     manifestRegistry: { plugins: [], diagnostics: [] },
+    declaredProviderOwners: new Map(),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/agents/provider-auth-aliases.test.ts
+++ b/src/agents/provider-auth-aliases.test.ts
@@ -3,6 +3,7 @@
  * Verifies plugin metadata aliases, origin priority, trust, and cache behavior.
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { buildDeclaredProviderOwnerIndex } from "../plugins/provider-owner-index.js";
 
 const pluginRegistryMocks = vi.hoisted(() => {
   const loadManifestRegistry = vi.fn();
@@ -123,6 +124,7 @@ function createPluginMetadataSnapshot(params: {
     diagnostics: [],
     byPluginId: new Map(params.plugins.map((plugin) => [plugin.id, plugin])),
     normalizePluginId: (pluginId) => pluginId,
+    declaredProviderOwners: buildDeclaredProviderOwnerIndex(params.plugins),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/agents/provider-model-normalization.runtime.ts
+++ b/src/agents/provider-model-normalization.runtime.ts
@@ -1,54 +1,24 @@
-/**
- * Runtime bridge for provider-owned model id normalization hooks. Source and
- * built artifacts can resolve different extensions, so this module probes both
- * once and caches the result.
- */
-import { createRequire } from "node:module";
-import type { ManifestModelIdNormalizationSource } from "../plugins/manifest-model-id-normalization.js";
+/** Reads prepared provider hooks without activating plugins during model-reference parsing. */
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
+import { findProviderRuntimePluginInRegistry } from "../plugins/provider-registry-selection.js";
+import type { ProviderNormalizeModelIdContext } from "../plugins/provider-runtime.types.js";
+import { getPluginRegistryForContext } from "../plugins/runtime/gateway-request-scope.js";
+import { getPluginRuntimeGenerationRegistry } from "../plugins/runtime/generation-state.js";
 
-type ProviderRuntimeModule = Pick<
-  typeof import("../plugins/provider-runtime.js"),
-  "normalizeProviderModelIdWithPlugin"
->;
-
-const require = createRequire(import.meta.url);
-// Built code loads .js while source/test paths may still resolve .ts. Try both
-// once, then cache the absence to avoid repeated require work on hot paths.
-const PROVIDER_RUNTIME_CANDIDATES = [
-  "../plugins/provider-runtime.js",
-  "../plugins/provider-runtime.ts",
-] as const;
-
-let providerRuntimeModule: ProviderRuntimeModule | undefined;
-let providerRuntimeLoadAttempted = false;
-
-function loadProviderRuntime(): ProviderRuntimeModule | null {
-  if (providerRuntimeModule) {
-    return providerRuntimeModule;
-  }
-  if (providerRuntimeLoadAttempted) {
-    return null;
-  }
-  providerRuntimeLoadAttempted = true;
-  for (const candidate of PROVIDER_RUNTIME_CANDIDATES) {
-    try {
-      providerRuntimeModule = require(candidate) as ProviderRuntimeModule;
-      return providerRuntimeModule;
-    } catch {
-      // Try source/runtime candidates in order.
-    }
-  }
-  return null;
-}
-
-/** Normalizes provider model ids through plugin runtime hooks when available. */
+/** Refines an already statically normalized model id through its provider hook. */
 export function normalizeProviderModelIdWithRuntime(params: {
   provider: string;
-  plugins?: ManifestModelIdNormalizationSource;
-  context: {
-    provider: string;
-    modelId: string;
-  };
+  context: ProviderNormalizeModelIdContext;
 }): string | undefined {
-  return loadProviderRuntime()?.normalizeProviderModelIdWithPlugin(params);
+  // An exact generation, including an empty one, cannot borrow ambient hooks.
+  const registry = getPluginRuntimeGenerationRegistry() ?? getPluginRegistryForContext();
+  if (!registry) {
+    return undefined;
+  }
+  const plugin = findProviderRuntimePluginInRegistry({
+    registry,
+    provider: params.provider,
+    ownerRefs: [],
+  });
+  return normalizeOptionalString(plugin?.normalizeModelId?.(params.context));
 }

--- a/src/agents/runtime-plugins.test.ts
+++ b/src/agents/runtime-plugins.test.ts
@@ -55,6 +55,10 @@ import {
   makeRegistry,
 } from "../config/plugin-auto-enable.test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  bindPluginRuntimeArtifactSelection,
+  resolvePluginRuntimeArtifactSelection,
+} from "../plugins/plugin-runtime-artifact-selection.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import {
   getPluginRuntimeGatewayRequestScope,
@@ -233,28 +237,34 @@ describe("agent runtime plugin registries", () => {
   it("reuses the current Gateway generation and loads only the imported-plugin delta", () => {
     const config = {} as never;
     const workspaceDir = "/tmp/default-workspace";
-    const activeRegistry = {
-      plugins: [
-        { id: "gateway-owned", origin: "bundled", status: "loaded" },
-        {
-          id: "deferred",
-          origin: "bundled",
-          status: "loaded",
-          format: "openclaw",
-          imported: false,
-        },
-      ],
-    };
-    const metadataSnapshot = {
-      ...createMetadataSnapshot(workspaceDir, undefined),
-      manifestRegistry: {
-        diagnostics: [],
-        plugins: [
-          { id: "gateway-owned", origin: "bundled" },
-          { id: "deferred", origin: "bundled" },
-        ],
-      },
-    };
+    const metadataSnapshot = createPluginMetadataSnapshot({
+      config,
+      workspaceDir,
+      manifestRegistry: makeRegistry([
+        { id: "gateway-owned", origin: "bundled", channels: [] },
+        { id: "deferred", origin: "bundled", channels: [] },
+      ]),
+    });
+    const activeRegistry = createEmptyPluginRegistry();
+    activeRegistry.plugins = metadataSnapshot.plugins.map((manifest) => {
+      const record = createPluginRecord({
+        id: manifest.id,
+        rootDir: manifest.rootDir,
+        source: manifest.source,
+        origin: manifest.origin,
+        format: "openclaw",
+        imported: manifest.id !== "deferred",
+      });
+      bindPluginRuntimeArtifactSelection(record, {
+        preferBuiltPluginArtifacts: false,
+        runtimeEntry: resolvePluginRuntimeArtifactSelection({
+          ...manifest,
+          entryKind: "runtime",
+          preferBuiltPluginArtifacts: false,
+        }),
+      });
+      return record;
+    });
     const selectedRegistry = { plugins: [...activeRegistry.plugins, { id: "selected-provider" }] };
     hoisted.getActivePluginRegistry.mockReturnValue(activeRegistry);
     hoisted.getActivePluginRegistryWorkspaceDir.mockReturnValue(workspaceDir);
@@ -279,18 +289,15 @@ describe("agent runtime plugin registries", () => {
       true,
     );
 
-    expect(prepared.inboundPluginRegistry).toBe(activeRegistry);
-    expect(prepared.runtimePluginRegistry).toBe(selectedRegistry);
-    expect(hoisted.resolveAgentRuntimePluginLoadPlan).toHaveBeenCalledWith(
-      expect.objectContaining({ basePluginIds: ["gateway-owned"] }),
-    );
+    expect(prepared.inboundPluginRegistry === activeRegistry).toBe(true);
+    expect(prepared.runtimePluginRegistry === selectedRegistry).toBe(true);
+    expect(hoisted.resolveAgentRuntimePluginLoadPlan.mock.calls[0]?.[0].basePluginIds).toEqual([
+      "gateway-owned",
+    ]);
     expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledOnce();
-    expect(hoisted.loadPluginRegistryHandle).toHaveBeenCalledWith(
-      expect.objectContaining({
-        onlyPluginIds: ["gateway-owned", "selected-provider"],
-        preferBuiltPluginArtifacts: true,
-      }),
-    );
+    const loadedOptions = hoisted.loadPluginRegistryHandle.mock.calls[0]?.[0];
+    expect(loadedOptions?.onlyPluginIds).toEqual(["gateway-owned", "selected-provider"]);
+    expect(loadedOptions?.preferBuiltPluginArtifacts).toBe(true);
   });
 
   it.each([

--- a/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
+++ b/src/agents/test-helpers/embedded-agent-runner-e2e-mocks.ts
@@ -53,6 +53,7 @@ export function createEmptyPluginMetadataSnapshot(workspaceDir?: string): Plugin
     diagnostics: [],
     byPluginId: new Map(),
     normalizePluginId: (pluginId) => pluginId,
+    declaredProviderOwners: new Map(),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/agents/tools-effective-inventory.cold-provider.test.ts
+++ b/src/agents/tools-effective-inventory.cold-provider.test.ts
@@ -336,9 +336,7 @@ describe("cold dynamic-model effective inventory", () => {
         },
       });
       await withPluginRuntimeRegistryScope(registry, async () => {
-        expect(resolveProviderRuntimePlugin({ provider, config })).toMatchObject({
-          prepareDynamicModel: ambientHook,
-        });
+        expect(resolveProviderRuntimePlugin({ provider, config })).toBeUndefined();
         await expect(
           resolveEffectiveToolInventoryRuntimeModelContextAsync({
             ...fixture.inventoryParams,

--- a/src/agents/tools/video-generate-tool.test.ts
+++ b/src/agents/tools/video-generate-tool.test.ts
@@ -14,6 +14,7 @@ import { resolveInstalledPluginIndexPolicyHash } from "../../plugins/installed-p
 import type { PluginManifestRecord } from "../../plugins/manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { buildDeclaredProviderOwnerIndex } from "../../plugins/provider-owner-index.js";
 import * as videoGenerationRuntime from "../../video-generation/runtime.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
 import { formatAgentInternalEventsForPrompt } from "../internal-events.js";
@@ -233,6 +234,7 @@ function createVideoProviderSnapshot(params: {
     diagnostics: [],
     byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
     normalizePluginId: (pluginId) => pluginId,
+    declaredProviderOwners: buildDeclaredProviderOwnerIndex(plugins),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/cli/plugin-registry.test.ts
+++ b/src/cli/plugin-registry.test.ts
@@ -119,7 +119,7 @@ vi.mock("../plugins/runtime/load-context.resolve.js", () => ({
 }));
 
 vi.mock("../plugins/runtime/load-context.js", () => ({
-  buildPluginRuntimeLoadOptionsFromValues: (
+  buildPluginRuntimeLoadOptions: (
     values: {
       config: unknown;
       activationSourceConfig: unknown;
@@ -136,25 +136,6 @@ vi.mock("../plugins/runtime/load-context.js", () => ({
     workspaceDir: values.workspaceDir,
     env: values.env,
     logger: values.logger,
-    ...overrides,
-  }),
-  buildPluginRuntimeLoadOptions: (
-    context: {
-      config: unknown;
-      activationSourceConfig: unknown;
-      autoEnabledReasons: Readonly<Record<string, string[]>>;
-      workspaceDir: string | undefined;
-      env: NodeJS.ProcessEnv;
-      logger: typeof logger;
-    },
-    overrides?: Record<string, unknown>,
-  ) => ({
-    config: context.config,
-    activationSourceConfig: context.activationSourceConfig,
-    autoEnabledReasons: context.autoEnabledReasons,
-    workspaceDir: context.workspaceDir,
-    env: context.env,
-    logger: context.logger,
     ...overrides,
   }),
 }));

--- a/src/commands/doctor/repair-sequencing.test.ts
+++ b/src/commands/doctor/repair-sequencing.test.ts
@@ -764,6 +764,7 @@ describe("doctor repair sequencing", () => {
     const researchPlugin = {
       id: "research-channel",
       source: "/srv/research/.openclaw/extensions/research-channel/openclaw.plugin.json",
+      providers: [],
     };
     const manifestRegistry = { plugins: [researchPlugin], diagnostics: [] };
     mocks.resolveConfigWidePluginManifestRegistry.mockReturnValue(manifestRegistry);

--- a/src/commands/models/aliases.test.ts
+++ b/src/commands/models/aliases.test.ts
@@ -22,6 +22,7 @@ vi.mock("../../config/config.js", () => ({
     const loaded = await mocks.readConfigFileSnapshot();
     const writeSnapshot = {
       path: "/tmp/openclaw.json",
+      parsed: loaded.sourceConfig ?? loaded.config,
       runtimeConfig: loaded.config,
       ...loaded,
     };
@@ -37,6 +38,11 @@ vi.mock("../../config/config.js", () => ({
 
 vi.mock("./load-config.js", () => ({
   loadModelsConfig: (...args: unknown[]) => mocks.loadModelsConfig(...args),
+}));
+
+// Real provider activation is covered by model-selection.runtime.test.ts.
+vi.mock("./model-selection.runtime.js", () => ({
+  withModelCommandProviderRuntime: (_params: unknown, run: () => unknown) => run(),
 }));
 
 function makeRuntime(): RuntimeEnv & { logs: string[] } {

--- a/src/commands/models/aliases.ts
+++ b/src/commands/models/aliases.ts
@@ -6,7 +6,12 @@ import { normalizeAgentModelMapForConfig } from "../../config/model-input.js";
 import { type RuntimeEnv, writeRuntimeJson, writeRuntimeStdout } from "../../runtime.js";
 import { normalizeAlias } from "./alias-name.js";
 import { loadModelsConfig } from "./load-config.js";
-import { ensureFlagCompatibility, resolveModelTarget, updateConfig } from "./shared.js";
+import {
+  ensureFlagCompatibility,
+  resolveModelTarget,
+  upsertCanonicalModelConfigEntry,
+  updateConfig,
+} from "./shared.js";
 
 /** Lists configured model aliases as JSON, plain pairs, or human-readable rows. */
 export async function modelsAliasesListCommand(
@@ -56,32 +61,34 @@ export async function modelsAliasesAddCommand(
   const alias = normalizeAlias(aliasRaw);
   const normalizedAlias = alias.toLowerCase();
   let target = modelRaw;
-  await updateConfig((cfgLocal, context) => {
-    // Alias resolution must share the snapshot whose hash fences this write.
-    const resolved = resolveModelTarget({ raw: modelRaw, cfg: context.runtimeConfig });
-    const modelKey = `${resolved.provider}/${resolved.model}`;
-    target = modelKey;
-    const nextModels = { ...cfgLocal.agents?.defaults?.models };
-    // Model selection folds alias case, so case variants must not collide.
-    for (const [key, entry] of Object.entries(nextModels)) {
-      const existing = entry?.alias?.trim();
-      if (existing && existing.toLowerCase() === normalizedAlias && key !== modelKey) {
-        throw new Error(`Alias ${alias} already points to ${key}.`);
+  await updateConfig(
+    (cfgLocal, context) => {
+      // Alias resolution must share the snapshot whose hash fences this write.
+      const resolved = resolveModelTarget({ raw: modelRaw, cfg: context.runtimeConfig });
+      const nextModels = { ...cfgLocal.agents?.defaults?.models };
+      const modelKey = upsertCanonicalModelConfigEntry(nextModels, resolved, context);
+      target = modelKey;
+      // Model selection folds alias case, so case variants must not collide.
+      for (const [key, entry] of Object.entries(nextModels)) {
+        const existing = entry?.alias?.trim();
+        if (existing && existing.toLowerCase() === normalizedAlias && key !== modelKey) {
+          throw new Error(`Alias ${alias} already points to ${key}.`);
+        }
       }
-    }
-    const existing = nextModels[modelKey] ?? {};
-    nextModels[modelKey] = { ...existing, alias };
-    return {
-      ...cfgLocal,
-      agents: {
-        ...cfgLocal.agents,
-        defaults: {
-          ...cfgLocal.agents?.defaults,
-          models: nextModels,
+      nextModels[modelKey] = { ...nextModels[modelKey], alias };
+      return {
+        ...cfgLocal,
+        agents: {
+          ...cfgLocal.agents,
+          defaults: {
+            ...cfgLocal.agents?.defaults,
+            models: nextModels,
+          },
         },
-      },
-    };
-  });
+      };
+    },
+    (_cfg, context) => [resolveModelTarget({ raw: modelRaw, cfg: context.runtimeConfig })],
+  );
 
   logConfigUpdated(runtime);
   runtime.log(`Alias ${alias} -> ${target}`);

--- a/src/commands/models/fallbacks-shared.ts
+++ b/src/commands/models/fallbacks-shared.ts
@@ -12,6 +12,7 @@ import {
   modelKey,
   resolveModelTarget,
   resolveModelKeysFromEntries,
+  resolveModelRefsFromEntries,
   upsertCanonicalModelConfigEntry,
   updateConfig,
 } from "./shared.js";
@@ -87,24 +88,33 @@ export async function addFallbackCommand(
   modelRaw: string,
   runtime: RuntimeEnv,
 ) {
-  const updated = await updateConfig((cfg) => {
-    const resolved = resolveModelTarget({ raw: modelRaw, cfg });
-    const nextModels = {
-      ...cfg.agents?.defaults?.models,
-    } as Record<string, AgentModelEntryConfig>;
-    const targetKey = upsertCanonicalModelConfigEntry(nextModels, resolved);
-    const existing = getFallbacks(cfg, params.key);
-    const existingKeys = resolveModelKeysFromEntries({ cfg, entries: existing });
-    if (existingKeys.includes(targetKey)) {
-      return cfg;
-    }
-
-    return patchDefaultsFallbacks(cfg, {
-      key: params.key,
-      fallbacks: [...existing, targetKey],
-      models: nextModels,
-    });
-  });
+  const updated = await updateConfig(
+    (cfg, context) => {
+      const { runtimeConfig } = context;
+      const resolved = resolveModelTarget({ raw: modelRaw, cfg: runtimeConfig });
+      const nextModels = {
+        ...cfg.agents?.defaults?.models,
+      } as Record<string, AgentModelEntryConfig>;
+      const targetKey = upsertCanonicalModelConfigEntry(nextModels, resolved, context);
+      const existing = getFallbacks(cfg, params.key);
+      const existingKeys = resolveModelKeysFromEntries({
+        cfg: runtimeConfig,
+        entries: getFallbacks(runtimeConfig, params.key),
+      });
+      return patchDefaultsFallbacks(cfg, {
+        key: params.key,
+        fallbacks: existingKeys.includes(targetKey) ? existing : [...existing, targetKey],
+        models: nextModels,
+      });
+    },
+    (_, { runtimeConfig }) => [
+      resolveModelTarget({ raw: modelRaw, cfg: runtimeConfig }),
+      ...resolveModelRefsFromEntries({
+        cfg: runtimeConfig,
+        entries: getFallbacks(runtimeConfig, params.key),
+      }),
+    ],
+  );
 
   logConfigUpdated(runtime);
   runtime.log(`${params.label}: ${getFallbacks(updated, params.key).join(", ")}`);
@@ -120,23 +130,35 @@ export async function removeFallbackCommand(
   modelRaw: string,
   runtime: RuntimeEnv,
 ) {
-  const updated = await updateConfig((cfg) => {
-    const resolved = resolveModelTarget({ raw: modelRaw, cfg });
-    const targetKey = modelKey(resolved.provider, resolved.model);
-    const existing = getFallbacks(cfg, params.key);
-    const existingKeys = resolveModelKeysFromEntries({ cfg, entries: existing });
-    // Fallback entries may be aliases or provider/model refs. Resolve each entry
-    // before comparison so removing an alias removes the canonical target.
-    const filtered = existing.filter((_, index) => existingKeys[index] !== targetKey);
+  const updated = await updateConfig(
+    (cfg, { runtimeConfig }) => {
+      const resolved = resolveModelTarget({ raw: modelRaw, cfg: runtimeConfig });
+      const targetKey = modelKey(resolved.provider, resolved.model);
+      const existing = getFallbacks(cfg, params.key);
+      const existingKeys = resolveModelKeysFromEntries({
+        cfg: runtimeConfig,
+        entries: getFallbacks(runtimeConfig, params.key),
+      });
+      // Compare effective refs, but filter their source positions so unrelated
+      // placeholders and source-authored values survive the config write.
+      const filtered = existing.filter((_, index) => existingKeys[index] !== targetKey);
 
-    if (filtered.length === existing.length) {
-      throw new Error(
-        `${params.notFoundLabel} not found: ${targetKey}. Run ${formatCliCommand(`openclaw ${listCommandForFallbackKey(params.key)}`)} to see configured fallbacks.`,
-      );
-    }
+      if (filtered.length === existing.length) {
+        throw new Error(
+          `${params.notFoundLabel} not found: ${targetKey}. Run ${formatCliCommand(`openclaw ${listCommandForFallbackKey(params.key)}`)} to see configured fallbacks.`,
+        );
+      }
 
-    return patchDefaultsFallbacks(cfg, { key: params.key, fallbacks: filtered });
-  });
+      return patchDefaultsFallbacks(cfg, { key: params.key, fallbacks: filtered });
+    },
+    (_, { runtimeConfig }) => [
+      resolveModelTarget({ raw: modelRaw, cfg: runtimeConfig }),
+      ...resolveModelRefsFromEntries({
+        cfg: runtimeConfig,
+        entries: getFallbacks(runtimeConfig, params.key),
+      }),
+    ],
+  );
 
   logConfigUpdated(runtime);
   runtime.log(`${params.label}: ${getFallbacks(updated, params.key).join(", ")}`);

--- a/src/commands/models/model-selection.runtime.test.ts
+++ b/src/commands/models/model-selection.runtime.test.ts
@@ -1,0 +1,577 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveModelExtraParamSources } from "../../agents/model-extra-params.js";
+import {
+  readConfigFileSnapshot,
+  resetConfigRuntimeState,
+  type OpenClawConfig,
+} from "../../config/config.js";
+import { DEFAULT_MODEL_ALIASES } from "../../config/defaults.js";
+import { ConfigMutationConflictError } from "../../config/mutation-conflict.js";
+import {
+  loadOpenClawPlugins,
+  resetPluginLoaderTestStateForTest,
+} from "../../plugins/loader.test-fixtures.js";
+import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
+import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
+import { resolvePluginProviderRegistryCore } from "../../plugins/providers.runtime.js";
+import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
+import type { RuntimeEnv } from "../../runtime.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { cleanupSessionStateForTest } from "../../test-utils/session-state-cleanup.js";
+import { modelsAliasesAddCommand } from "./aliases.js";
+import { addFallbackCommand, removeFallbackCommand } from "./fallbacks-shared.js";
+import { modelsSetImageCommand } from "./set-image.js";
+import { modelsSetCommand } from "./set.js";
+
+describe("model command provider preparation", () => {
+  let root: string;
+  let configPath: string;
+  let config: OpenClawConfig;
+  let runtime: RuntimeEnv;
+
+  beforeEach(() => {
+    root = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-model-command-"));
+    configPath = path.join(root, "openclaw.json");
+    const pluginDir = path.join(root, "provider");
+    fs.mkdirSync(pluginDir);
+    fs.writeFileSync(
+      path.join(pluginDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "alias-fixture",
+        providers: ["fixture", "custom"],
+        configSchema: { type: "object", additionalProperties: false, properties: {} },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(pluginDir, "index.cjs"),
+      `module.exports = {
+        id: "alias-fixture",
+        register(api) {
+          api.registerProvider({
+            id: "fixture", label: "Fixture", hookAliases: ["custom"], auth: [],
+            normalizeModelId: ({ modelId }) => modelId === "legacy" ? "current" : undefined,
+          });
+        },
+      };`,
+    );
+    config = {
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "probe" } },
+        entries: { probe: {} },
+      },
+      plugins: { allow: ["alias-fixture"], load: { paths: [pluginDir] } },
+    };
+    runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+  });
+
+  afterEach(async () => {
+    resetConfigRuntimeState();
+    resetPluginLoaderTestStateForTest();
+    clearPluginMetadataLifecycleCaches();
+    await cleanupSessionStateForTest({ stateDir: root });
+    fs.rmSync(root, { recursive: true, force: true });
+  });
+
+  async function isolated(run: () => Promise<void>) {
+    fs.writeFileSync(configPath, JSON.stringify(config));
+    await withEnvAsync(
+      {
+        OPENCLAW_STATE_DIR: root,
+        OPENCLAW_CONFIG_PATH: configPath,
+        OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+        OPENCLAW_BUNDLED_PLUGINS_DIR: undefined,
+      },
+      run,
+    );
+  }
+
+  function readConfig(): OpenClawConfig {
+    return JSON.parse(fs.readFileSync(configPath, "utf8"));
+  }
+
+  it.each([
+    { raw: "fixture/legacy", expected: "fixture/current" },
+    { raw: "fixture/LEGACY", expected: "fixture/LEGACY" },
+    { raw: "friendly", expected: "fixture/current" },
+  ])("saves $raw using its cold provider's exact alias rules", async ({ raw, expected }) => {
+    config.agents!.defaults!.models = { "fixture/legacy": { alias: "friendly" } };
+    await isolated(() => modelsSetCommand(raw, runtime));
+    expect(readConfig().agents?.defaults?.model).toEqual({ primary: expected });
+    expect(runtime.log).toHaveBeenCalledWith(`Default model: ${expected}`);
+  });
+
+  it.each([
+    { provider: "fixture", api: "openai-completions" },
+    { provider: "custom", api: "openai-completions" },
+  ] as const)("keeps the $provider/$api owner's model literal", async ({ provider, api }) => {
+    config.models = {
+      providers: {
+        [provider]: {
+          api,
+          baseUrl: "https://custom.example.invalid/v1",
+          models: [
+            {
+              id: "legacy",
+              name: "Literal model",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              maxTokens: 1024,
+            },
+          ],
+        },
+      },
+    };
+    config.agents!.defaults!.models = {
+      [`${provider}/legacy`]: { alias: "friendly", params: { temperature: 0.2 } },
+    };
+    await isolated(async () => {
+      await modelsSetCommand(`${provider}/legacy`, runtime);
+      await modelsAliasesAddCommand("Friendly", `${provider}/legacy`, runtime);
+      await modelsAliasesAddCommand("Friendly", `${provider}/legacy`, runtime);
+      await expect(
+        modelsAliasesAddCommand("friendly", `${provider}/current`, runtime),
+      ).rejects.toThrow(`Alias friendly already points to ${provider}/legacy.`);
+    });
+    expect(readConfig().agents?.defaults?.model).toEqual({ primary: `${provider}/legacy` });
+    expect(readConfig().agents?.defaults?.models).toEqual({
+      [`${provider}/legacy`]: { alias: "Friendly", params: { temperature: 0.2 } },
+    });
+  });
+
+  it.each(
+    [false, true].flatMap((hasCanonicalEntry) =>
+      [false, true].flatMap((included) =>
+        ["same", "different", "missing"].map((priorAlias) => ({
+          hasCanonicalEntry,
+          included,
+          priorAlias,
+        })),
+      ),
+    ),
+  )(
+    "preserves alias source settings across canonical moves (existing: $hasCanonicalEntry, include: $included, alias: $priorAlias)",
+    async ({ hasCanonicalEntry, included, priorAlias }) => {
+      config.agents!.defaults!.models = {
+        "fixture/legacy": {
+          ...(priorAlias === "missing"
+            ? {}
+            : { alias: priorAlias === "same" ? "${MODEL_ALIAS}" : "old" }),
+          params: {
+            temperature: 0.2,
+            maxTokens: 128,
+            cacheRetention: "${ALIAS_CACHE_RETENTION}",
+            credential: { source: "env", provider: "default", id: "MODEL_SECRET" },
+          },
+          streaming: false,
+        },
+        ...(hasCanonicalEntry
+          ? { "fixture/current": { params: { temperature: 0.7 }, codeMode: false } }
+          : {}),
+        "unrelated/legacy": {
+          alias: "other",
+          params: { temperature: 0.9, cacheRetention: "long" },
+        },
+      };
+      await withEnvAsync({ MODEL_ALIAS: "friendly", ALIAS_CACHE_RETENTION: "long" }, () =>
+        isolated(async () => {
+          const agentsPath = path.join(root, "agents.json");
+          if (included) {
+            fs.writeFileSync(agentsPath, JSON.stringify(config.agents));
+            fs.writeFileSync(
+              configPath,
+              JSON.stringify({ ...config, agents: { $include: "agents.json" } }),
+            );
+          }
+          const readAgents = (): OpenClawConfig["agents"] =>
+            included ? JSON.parse(fs.readFileSync(agentsPath, "utf8")) : readConfig().agents;
+          await modelsAliasesAddCommand("friendly", "fixture/legacy", runtime);
+          const expectedModels = {
+            "fixture/current": {
+              alias: "friendly",
+              params: {
+                temperature: hasCanonicalEntry ? 0.7 : 0.2,
+                maxTokens: 128,
+                cacheRetention: "${ALIAS_CACHE_RETENTION}",
+                credential: { source: "env", provider: "default", id: "MODEL_SECRET" },
+              },
+              streaming: false,
+              ...(hasCanonicalEntry ? { codeMode: false } : {}),
+            },
+            "unrelated/legacy": {
+              alias: "other",
+              params: { temperature: 0.9, cacheRetention: "long" },
+            },
+          };
+          expect(readAgents()?.defaults?.models).toEqual(expectedModels);
+          await modelsAliasesAddCommand("friendly", "fixture/legacy", runtime);
+          expect(readAgents()?.defaults?.models).toEqual(expectedModels);
+          await expect(
+            modelsAliasesAddCommand("FRIENDLY", "fixture/different", runtime),
+          ).rejects.toThrow("Alias FRIENDLY already points to fixture/current.");
+          expect(readAgents()?.defaults?.models).toEqual(expectedModels);
+          await addFallbackCommand({ label: "Fallbacks", key: "model" }, "friendly", runtime);
+          expect((await readConfigFileSnapshot()).sourceConfig.agents?.defaults?.model).toEqual({
+            fallbacks: ["fixture/current"],
+          });
+          await removeFallbackCommand(
+            { label: "Fallbacks", key: "model", notFoundLabel: "Fallback" },
+            "fixture/legacy",
+            runtime,
+          );
+          expect((await readConfigFileSnapshot()).sourceConfig.agents?.defaults?.model).toEqual({
+            fallbacks: [],
+          });
+          if (included) {
+            expect(readConfig().agents).toMatchObject({ $include: "agents.json" });
+          }
+        }),
+      );
+    },
+  );
+
+  it.each(
+    ["set", "set-image", "fallback", "image-fallback"].flatMap((command) => [
+      {
+        command,
+        provider: "openrouter",
+        sourceKey: "openrouter/openrouter/hunter-alpha",
+        input: "openrouter/hunter-alpha",
+        modelId: "hunter-alpha",
+      },
+      {
+        command,
+        provider: "fixture",
+        sourceKey: "fixture/legacy",
+        input: "fixture/legacy",
+        modelId: "current",
+      },
+    ]),
+  )(
+    "preserves source and request settings when $command canonicalizes $sourceKey",
+    async ({ command, provider, sourceKey, input, modelId }) => {
+      if (provider === "openrouter") {
+        const pluginDir = path.join(root, "provider");
+        fs.writeFileSync(
+          path.join(pluginDir, "openclaw.plugin.json"),
+          JSON.stringify({
+            id: "alias-fixture",
+            providers: [provider],
+            configSchema: { type: "object", additionalProperties: false, properties: {} },
+          }),
+        );
+        const pluginFile = path.join(pluginDir, "index.cjs");
+        fs.writeFileSync(
+          pluginFile,
+          fs
+            .readFileSync(pluginFile, "utf8")
+            .replace('id: "fixture", label:', 'id: "openrouter", label:'),
+        );
+      }
+      const entry = {
+        params: {
+          cacheRetention: "${ALIAS_CACHE_RETENTION}",
+          credential: { source: "env", provider: "default", id: "MODEL_SECRET" },
+        },
+        streaming: false,
+      };
+      config.agents!.defaults!.models = { [sourceKey]: entry };
+      await withEnvAsync({ ALIAS_CACHE_RETENTION: "long" }, () =>
+        isolated(async () => {
+          const key = command.includes("image") ? "imageModel" : "model";
+          if (command === "set") {
+            await modelsSetCommand(input, runtime);
+          } else if (command === "set-image") {
+            await modelsSetImageCommand(input, runtime);
+          } else {
+            await addFallbackCommand({ label: "Fallbacks", key }, input, runtime);
+          }
+          const canonicalKey = `${provider}/${modelId}`;
+          expect(readConfig().agents?.defaults?.models).toEqual({
+            [canonicalKey]: entry,
+          });
+          const snapshot = await readConfigFileSnapshot();
+          expect(snapshot.sourceConfig.agents?.defaults?.[key]).toEqual(
+            command.startsWith("set") ? { primary: canonicalKey } : { fallbacks: [canonicalKey] },
+          );
+          expect(
+            resolveModelExtraParamSources({ config: snapshot.runtimeConfig, provider, modelId })
+              .modelParams,
+          ).toEqual({ ...entry.params, cacheRetention: "long" });
+        }),
+      );
+    },
+  );
+
+  it.each([false, true])(
+    "preserves nested include ownership with sibling overrides=%s",
+    async (siblingOverrides) => {
+      const models = {
+        "fixture/legacy": {
+          alias: "friendly",
+          params: { cacheRetention: "${ALIAS_CACHE_RETENTION}" },
+        },
+      };
+      config.agents!.defaults!.models = models;
+      await withEnvAsync({ ALIAS_CACHE_RETENTION: "long" }, () =>
+        isolated(async () => {
+          const modelsPath = path.join(root, "models.json");
+          const modelsRaw = JSON.stringify(models);
+          const rootRaw = JSON.stringify({
+            ...config,
+            agents: {
+              ...config.agents,
+              defaults: {
+                ...config.agents?.defaults,
+                models: {
+                  $include: "models.json",
+                  ...(siblingOverrides ? { "fixture/other": { alias: "other" } } : {}),
+                },
+              },
+            },
+          });
+          fs.writeFileSync(modelsPath, modelsRaw);
+          fs.writeFileSync(configPath, rootRaw);
+          if (siblingOverrides) {
+            await expect(
+              modelsAliasesAddCommand("friendly", "fixture/legacy", runtime),
+            ).rejects.toThrow("$include");
+            expect(fs.readFileSync(modelsPath, "utf8")).toBe(modelsRaw);
+          } else {
+            await modelsAliasesAddCommand("friendly", "fixture/legacy", runtime);
+            expect(JSON.parse(fs.readFileSync(modelsPath, "utf8"))).toEqual({
+              "fixture/current": models["fixture/legacy"],
+            });
+          }
+          expect(fs.readFileSync(configPath, "utf8")).toBe(rootRaw);
+        }),
+      );
+    },
+  );
+
+  it("excludes unrelated hooks when reusing an already-loaded registry", async () => {
+    const foreignDir = path.join(root, "aaa-foreign");
+    fs.mkdirSync(foreignDir);
+    fs.writeFileSync(
+      path.join(foreignDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "aaa-foreign",
+        providers: ["foreign"],
+        configSchema: { type: "object", additionalProperties: false, properties: {} },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(foreignDir, "index.cjs"),
+      `module.exports = { id: "aaa-foreign", register(api) {
+        api.registerProvider({ id: "foreign", label: "Foreign", auth: [],
+          hookAliases: ["fixture"], normalizeModelId: () => "wrong-owner" });
+      }};`,
+    );
+    config.plugins!.allow!.unshift("aaa-foreign");
+    config.plugins!.load!.paths!.unshift(foreignDir);
+    config.agents!.entries!.probe = { workspace: root };
+    await isolated(async () => {
+      const registry = loadOpenClawPlugins({ config, workspaceDir: root, env: process.env });
+      expect(registry.providers.map((entry) => entry.pluginId)).toEqual([
+        "aaa-foreign",
+        "alias-fixture",
+      ]);
+      await modelsSetCommand("fixture/legacy", runtime);
+      expect(readConfig().agents?.defaults?.model).toEqual({ primary: "fixture/current" });
+    });
+  });
+
+  it.each(["exact", "retained", "empty"] as const)(
+    "prepares runtime-only aliases with %s ownership while preserving source refs",
+    async (scope) => {
+      const marker = path.join(root, "registrations");
+      const pluginFile = path.join(root, "provider", "index.cjs");
+      fs.writeFileSync(
+        pluginFile,
+        fs
+          .readFileSync(pluginFile, "utf8")
+          .replace(
+            "register(api) {",
+            `register(api) {
+              const fs = require("node:fs");
+              const model = fs.existsSync(${JSON.stringify(marker)}) ? "current" : "stale";
+              fs.appendFileSync(${JSON.stringify(marker)}, "registered\\n");`,
+          )
+          .replace('hookAliases: ["custom"]', 'hookAliases: ["compat"]')
+          .replace('? "current" : undefined', "? model : undefined"),
+      );
+      const entry = { params: { cacheRetention: "${ALIAS_CACHE_RETENTION}" }, streaming: false };
+      config.agents!.defaults!.models = { "compat/legacy": entry };
+      config.agents!.entries!.probe = { workspace: root };
+      await withEnvAsync({ ALIAS_CACHE_RETENTION: "long" }, () =>
+        isolated(async () => {
+          const metadataSnapshot = loadManifestMetadataSnapshot({
+            config,
+            env: process.env,
+            workspaceDir: root,
+          });
+          const registry = loadOpenClawPlugins({ config, env: process.env, workspaceDir: root });
+          expect(
+            resolvePluginProviderRegistryCore({
+              config,
+              workspaceDir: root,
+              providerRefs: ["compat"],
+            })?.registry,
+          ).toBe(registry);
+          expect(fs.readFileSync(marker, "utf8")).toBe("registered\n");
+          const run = () => modelsAliasesAddCommand("friendly", "compat/legacy", runtime);
+          if (scope === "exact") {
+            await run();
+          } else {
+            await withPluginRuntimeGenerationScope(
+              { metadataSnapshot, ...(scope === "retained" ? { pluginRegistry: registry } : {}) },
+              run,
+            );
+          }
+          const model = scope === "exact" ? "current" : scope === "retained" ? "stale" : "legacy";
+          expect(readConfig().agents?.defaults?.models).toEqual({
+            [`compat/${model}`]: { ...entry, alias: "friendly" },
+          });
+          expect(runtime.log).toHaveBeenCalledWith(`Alias friendly -> compat/${model}`);
+          expect(fs.readFileSync(marker, "utf8")).toBe(
+            "registered\n".repeat(scope === "exact" ? 2 : 1),
+          );
+        }),
+      );
+    },
+  );
+
+  it("does not activate an unused provider for a runtime-only alias", async () => {
+    const canonical = DEFAULT_MODEL_ALIASES.sonnet;
+    if (!canonical) {
+      throw new Error("Expected the built-in sonnet alias");
+    }
+    config.agents!.defaults!.models = { [canonical]: {} };
+    const providerDir = path.join(root, "provider");
+    fs.writeFileSync(
+      path.join(providerDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "alias-fixture",
+        providers: ["anthropic"],
+        configSchema: { type: "object", additionalProperties: false, properties: {} },
+      }),
+    );
+    const providerFile = path.join(providerDir, "index.cjs");
+    fs.writeFileSync(
+      providerFile,
+      fs
+        .readFileSync(providerFile, "utf8")
+        .replace('id: "fixture", label:', 'id: "anthropic", label:'),
+    );
+    const unusedDir = path.join(root, "unused");
+    const marker = path.join(root, "unused-imported");
+    fs.mkdirSync(unusedDir);
+    fs.writeFileSync(
+      path.join(unusedDir, "openclaw.plugin.json"),
+      JSON.stringify({
+        id: "unused-provider",
+        providers: ["openai"],
+        configSchema: { type: "object", additionalProperties: false, properties: {} },
+      }),
+    );
+    fs.writeFileSync(
+      path.join(unusedDir, "index.cjs"),
+      `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "imported");
+      module.exports = { id: "unused-provider", register(api) {
+        api.registerProvider({ id: "openai", label: "Unused", auth: [] });
+      }};`,
+    );
+    config.plugins!.allow!.push("unused-provider");
+    config.plugins!.load!.paths!.push(unusedDir);
+
+    await isolated(async () => {
+      await modelsSetCommand("sonnet", runtime);
+      expect(readConfig().agents?.defaults?.model).toEqual({ primary: canonical });
+      await addFallbackCommand({ label: "Fallbacks", key: "model" }, "sonnet", runtime);
+      expect(readConfig().agents?.defaults?.model).toEqual({
+        primary: canonical,
+        fallbacks: [canonical],
+      });
+      await removeFallbackCommand(
+        { label: "Fallbacks", key: "model", notFoundLabel: "Fallback" },
+        "sonnet",
+        runtime,
+      );
+      expect(readConfig().agents?.defaults?.model).toEqual({ primary: canonical, fallbacks: [] });
+      await modelsAliasesAddCommand("friendly", "sonnet", runtime);
+      await modelsAliasesAddCommand("friendly", canonical, runtime);
+      expect(readConfig().agents?.defaults?.models?.[canonical]?.alias).toBe("friendly");
+    });
+    expect(fs.existsSync(marker)).toBe(false);
+  });
+
+  it.each(["model", "imageModel"] as const)(
+    "repairs %s entry settings while preserving an existing fallback placeholder",
+    async (key) => {
+      config.agents!.defaults![key] = { fallbacks: ["${FALLBACK_REF}"] };
+      const entry = { params: { temperature: 0.2 }, streaming: false };
+      config.agents!.defaults!.models = { "fixture/legacy": entry };
+      await withEnvAsync({ FALLBACK_REF: "fixture/legacy" }, () =>
+        isolated(async () => {
+          await addFallbackCommand({ label: "Fallbacks", key }, "fixture/current", runtime);
+          expect(readConfig().agents?.defaults?.[key]).toEqual({ fallbacks: ["${FALLBACK_REF}"] });
+          expect(readConfig().agents?.defaults?.models).toEqual({ "fixture/current": entry });
+          await removeFallbackCommand(
+            { label: "Fallbacks", key, notFoundLabel: "Fallback" },
+            "fixture/current",
+            runtime,
+          );
+          expect(readConfig().agents?.defaults?.[key]).toEqual({ fallbacks: [] });
+        }),
+      );
+    },
+  );
+
+  it("rejects config replacement during provider preparation", async () => {
+    const pluginFile = path.join(root, "provider", "index.cjs");
+    fs.writeFileSync(
+      pluginFile,
+      fs.readFileSync(pluginFile, "utf8").replace(
+        "register(api) {",
+        `register(api) {
+          const fs = require("node:fs");
+          const file = ${JSON.stringify(configPath)};
+          const newer = JSON.parse(fs.readFileSync(file, "utf8"));
+          newer.update = { channel: "beta" };
+          fs.writeFileSync(file, JSON.stringify(newer));`,
+      ),
+    );
+    await isolated(async () => {
+      await expect(modelsSetCommand("fixture/legacy", runtime)).rejects.toBeInstanceOf(
+        ConfigMutationConflictError,
+      );
+    });
+    expect(readConfig().update?.channel).toBe("beta");
+    expect(readConfig().agents?.defaults?.model).toBeUndefined();
+  });
+
+  it("rejects an invalid fallback target before activating existing providers", async () => {
+    config.agents!.defaults!.model = { fallbacks: ["fixture/legacy"] };
+    const marker = path.join(root, "provider-imported");
+    const pluginFile = path.join(root, "provider", "index.cjs");
+    fs.writeFileSync(
+      pluginFile,
+      `require("node:fs").writeFileSync(${JSON.stringify(marker)}, "imported");\n` +
+        fs.readFileSync(pluginFile, "utf8"),
+    );
+    await isolated(async () => {
+      await expect(
+        removeFallbackCommand(
+          { label: "Fallbacks", key: "model", notFoundLabel: "Fallback" },
+          "/invalid",
+          runtime,
+        ),
+      ).rejects.toThrow("Invalid model reference: /invalid");
+    });
+    expect(fs.existsSync(marker)).toBe(false);
+  });
+});

--- a/src/commands/models/model-selection.runtime.ts
+++ b/src/commands/models/model-selection.runtime.ts
@@ -1,0 +1,47 @@
+/** Prepares only the provider owners needed by a model config mutation. */
+import { tryResolveConfiguredAgentWorkspaceDir } from "../../agents/agent-scope-config.js";
+import { modelKey, type ModelRef } from "../../agents/model-ref-shared.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { loadManifestMetadataSnapshot } from "../../plugins/manifest-contract-eligibility.js";
+import { resolvePluginProviderRegistryCore } from "../../plugins/providers.runtime.js";
+import { withPluginRuntimeGenerationScope } from "../../plugins/runtime/generation-scope.js";
+
+export function withModelCommandProviderRuntime<T>(
+  params: {
+    runtimeConfig: OpenClawConfig;
+    selectModelRefs: () => readonly (ModelRef | undefined)[];
+  },
+  run: () => T,
+): T {
+  const config = params.runtimeConfig;
+  const env = process.env;
+  const workspaceDir = tryResolveConfiguredAgentWorkspaceDir(config, env);
+  const metadataSnapshot = loadManifestMetadataSnapshot({ config, env, workspaceDir });
+  const providerRefs = new Set<string>();
+  const modelRefs = new Set<string>();
+  // Reuse the operation's selection policy with hooks fenced off. Combining
+  // alternate source/runtime interpretations would activate unused providers.
+  const selections = withPluginRuntimeGenerationScope({ metadataSnapshot }, params.selectModelRefs);
+  for (const ref of selections) {
+    if (ref) {
+      providerRefs.add(ref.provider);
+      modelRefs.add(modelKey(ref.provider, ref.model));
+    }
+  }
+  const selected = providerRefs.size
+    ? resolvePluginProviderRegistryCore({
+        config,
+        env,
+        workspaceDir,
+        pluginMetadataSnapshot: metadataSnapshot,
+        providerRefs: [...providerRefs],
+        modelRefs: [...modelRefs],
+        registryScope: "exact",
+        activate: false,
+      })
+    : undefined;
+  return withPluginRuntimeGenerationScope(
+    { metadataSnapshot, pluginRegistry: selected?.registry },
+    run,
+  );
+}

--- a/src/commands/models/set.test.ts
+++ b/src/commands/models/set.test.ts
@@ -18,6 +18,7 @@ vi.mock("../../config/config.js", () => ({
     const loaded = await mocks.readConfigFileSnapshot();
     const snapshot = {
       path: "/tmp/openclaw.json",
+      parsed: loaded.sourceConfig ?? loaded.config,
       runtimeConfig: loaded.config,
       ...loaded,
     };
@@ -33,6 +34,11 @@ vi.mock("../../config/config.js", () => ({
 
 vi.mock("../../config/logging.js", () => ({
   logConfigUpdated: (...args: unknown[]) => mocks.logConfigUpdated(...args),
+}));
+
+// Real provider activation is covered by model-selection.runtime.test.ts.
+vi.mock("./model-selection.runtime.js", () => ({
+  withModelCommandProviderRuntime: (_params: unknown, run: () => unknown) => run(),
 }));
 
 vi.mock("../codex-runtime-plugin-install.js", () => ({

--- a/src/commands/models/shared.test.ts
+++ b/src/commands/models/shared.test.ts
@@ -14,6 +14,7 @@ vi.mock("../../config/config.js", () => ({
     const loaded = await mocks.readConfigFileSnapshot();
     const snapshot = {
       path: "/tmp/openclaw.json",
+      parsed: loaded.sourceConfig ?? loaded.config,
       runtimeConfig: loaded.config,
       ...loaded,
     };

--- a/src/commands/models/shared.ts
+++ b/src/commands/models/shared.ts
@@ -1,6 +1,7 @@
 /** Shared helpers for model commands that read or mutate model config. */
 
 import { expectDefined } from "@openclaw/normalization-core";
+import { asNonArrayRecord } from "@openclaw/normalization-core/record-coerce";
 import { resolveAmbientOwnerAgentId } from "../../agents/agent-scope-config.js";
 import { listAgentIds, resolveAgentDir, resolveSoleAgentId } from "../../agents/agent-scope.js";
 import { DEFAULT_MODEL, DEFAULT_PROVIDER } from "../../agents/defaults.js";
@@ -9,6 +10,7 @@ import {
   legacyModelKey,
   modelKey,
   resolveModelRefFromString,
+  type ModelRef,
 } from "../../agents/model-selection.js";
 import { formatCliCommand } from "../../cli/command-format.js";
 import {
@@ -16,8 +18,15 @@ import {
   readConfigFileSnapshot,
   transformConfigFile,
 } from "../../config/config.js";
+import { restoreEnvVarRefs } from "../../config/env-preserve.js";
+import { resolveConfigIncludes } from "../../config/includes.js";
 import { formatConfigIssueLines } from "../../config/issue-format.js";
-import { normalizeAgentModelRefForConfig, toAgentModelListLike } from "../../config/model-input.js";
+import {
+  mergeAgentModelEntryForConfig,
+  normalizeAgentModelRefForConfig,
+  toAgentModelListLike,
+} from "../../config/model-input.js";
+import { resolveIncludeRoots } from "../../config/paths.js";
 import type { AgentModelEntryConfig } from "../../config/types.agent-defaults.js";
 import type { AgentModelConfig } from "../../config/types.agents-shared.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
@@ -57,7 +66,17 @@ export async function loadValidConfigOrThrow(): Promise<OpenClawConfig> {
 /** Runtime config snapshot supplied to model config mutators. */
 type UpdateConfigContext = {
   runtimeConfig: OpenClawConfig;
+  canonicalModelKeys?: ReadonlyMap<string, string | undefined>;
+  restoreSourceEntry: (
+    from: string,
+    to: string,
+    entry: AgentModelEntryConfig,
+  ) => AgentModelEntryConfig;
 };
+
+type ModelEntryMergeOptions = Partial<
+  Pick<UpdateConfigContext, "canonicalModelKeys" | "restoreSourceEntry">
+>;
 
 /** Reads source config, applies a mutator, and writes only the source-form config. */
 export async function updateConfig(
@@ -65,16 +84,73 @@ export async function updateConfig(
     cfg: OpenClawConfig,
     context: UpdateConfigContext,
   ) => OpenClawConfig | Promise<OpenClawConfig>,
+  selectModelRefs?: (
+    cfg: OpenClawConfig,
+    context: UpdateConfigContext,
+  ) => readonly (ModelRef | undefined)[],
 ): Promise<OpenClawConfig> {
+  const explicitSetPaths: string[][] = [];
   const result = await transformConfigFile({
-    transform: async (currentConfig, { snapshot }) => {
+    base: "source",
+    writeOptions: { explicitSetPaths },
+    transform: async (currentConfig, { snapshot }, { envSnapshotForRestore }) => {
       if (!snapshot.valid) {
         const issues = formatConfigIssueLines(snapshot.issues, "-").join("\n");
         throw new Error(`Invalid config at ${snapshot.path}\n${issues}`);
       }
-      const nextConfig = await mutator(structuredClone(currentConfig), {
-        runtimeConfig: structuredClone(snapshot.runtimeConfig),
-      });
+      const sourceConfig = structuredClone(currentConfig);
+      let authoredModels: Record<string, unknown> | undefined;
+      const context: UpdateConfigContext = {
+        runtimeConfig: snapshot.runtimeConfig,
+        restoreSourceEntry: (from, to, entry) => {
+          // Equal runtime values can still move an authored key; record that write intent.
+          explicitSetPaths.push(["agents", "defaults", "models", to]);
+          if (!authoredModels) {
+            const authored = asNonArrayRecord(
+              resolveConfigIncludes(snapshot.parsed, snapshot.path, undefined, {
+                allowedRoots: resolveIncludeRoots(envSnapshotForRestore),
+              }),
+            );
+            const defaults = asNonArrayRecord(asNonArrayRecord(authored.agents).defaults);
+            authoredModels = asNonArrayRecord(defaults.models);
+          }
+          // Source snapshots expand env values; restore while the authored key is known.
+          const restored = restoreEnvVarRefs(entry, authoredModels[from], envSnapshotForRestore);
+          // SAFETY: Only string leaves change; the validated entry shape remains intact.
+          return restored as AgentModelEntryConfig;
+        },
+      };
+      const mutate = () => {
+        if (selectModelRefs) {
+          const cfg = context.runtimeConfig;
+          const canonicalizer = createModelCatalogProviderAliasCanonicalizer({ cfg });
+          context.canonicalModelKeys = new Map(
+            Object.keys(sourceConfig.agents?.defaults?.models ?? {}).map((key) => {
+              // Stored keys are refs, not user-facing aliases. Resolve them only
+              // after the command's provider generation has been prepared.
+              const resolved = resolveModelRefFromString({
+                cfg,
+                raw: key,
+                defaultProvider: DEFAULT_PROVIDER,
+              });
+              const ref = resolved && canonicalizer.ref(resolved.ref);
+              return [key, ref ? modelKey(ref.provider, ref.model) : undefined];
+            }),
+          );
+        }
+        return mutator(sourceConfig, context);
+      };
+      const nextConfig = selectModelRefs
+        ? await (
+            await import("./model-selection.runtime.js")
+          ).withModelCommandProviderRuntime(
+            {
+              runtimeConfig: context.runtimeConfig,
+              selectModelRefs: () => selectModelRefs(sourceConfig, context),
+            },
+            mutate,
+          )
+        : await mutate();
       // The public SDK returns the mutator's value; persisted readback may restore env refs.
       return { nextConfig, result: nextConfig };
     },
@@ -82,20 +158,25 @@ export async function updateConfig(
   return expectDefined(result.result, "model config mutation result");
 }
 
+function resolveModelInput(params: { raw: string; cfg: OpenClawConfig }) {
+  const aliasIndex = buildModelAliasIndex({
+    cfg: params.cfg,
+    defaultProvider: DEFAULT_PROVIDER,
+  });
+  return resolveModelRefFromString({
+    cfg: params.cfg,
+    raw: params.raw,
+    defaultProvider: DEFAULT_PROVIDER,
+    aliasIndex,
+  });
+}
+
 /** Resolves a CLI model reference through aliases and catalog provider aliases. */
 export function resolveModelTarget(params: { raw: string; cfg: OpenClawConfig }): {
   provider: string;
   model: string;
 } {
-  const aliasIndex = buildModelAliasIndex({
-    cfg: params.cfg,
-    defaultProvider: DEFAULT_PROVIDER,
-  });
-  const resolved = resolveModelRefFromString({
-    raw: params.raw,
-    defaultProvider: DEFAULT_PROVIDER,
-    aliasIndex,
-  });
+  const resolved = resolveModelInput(params);
   if (!resolved) {
     throw new Error(`Invalid model reference: ${params.raw}`);
   }
@@ -106,23 +187,15 @@ function resolveAuthoredModelAliasTarget(params: {
   raw: string;
   cfg: OpenClawConfig;
 }): { provider: string; model: string } | undefined {
-  const aliasIndex = buildModelAliasIndex({
-    cfg: params.cfg,
-    defaultProvider: DEFAULT_PROVIDER,
-  });
-  const resolved = resolveModelRefFromString({
-    raw: params.raw,
-    defaultProvider: DEFAULT_PROVIDER,
-    aliasIndex,
-  });
+  const resolved = resolveModelInput(params);
   return resolved?.alias ? resolved.ref : undefined;
 }
 
-/** Resolves model reference strings to index-aligned canonical provider/model keys. */
-export function resolveModelKeysFromEntries(params: {
+/** Resolves model reference strings to index-aligned canonical refs. */
+export function resolveModelRefsFromEntries(params: {
   cfg: OpenClawConfig;
   entries: readonly string[];
-}): Array<string | undefined> {
+}): Array<ModelRef | undefined> {
   const aliasIndex = buildModelAliasIndex({
     cfg: params.cfg,
     defaultProvider: DEFAULT_PROVIDER,
@@ -130,13 +203,22 @@ export function resolveModelKeysFromEntries(params: {
   const canonicalizer = createModelCatalogProviderAliasCanonicalizer({ cfg: params.cfg });
   return params.entries.map((entry) => {
     const resolved = resolveModelRefFromString({
+      cfg: params.cfg,
       raw: entry,
       defaultProvider: DEFAULT_PROVIDER,
       aliasIndex,
     });
-    const ref = resolved ? canonicalizer.ref(resolved.ref) : undefined;
-    return ref ? modelKey(ref.provider, ref.model) : undefined;
+    return resolved ? canonicalizer.ref(resolved.ref) : undefined;
   });
+}
+
+/** Projects canonical model refs into index-aligned keys for config comparisons. */
+export function resolveModelKeysFromEntries(
+  params: Parameters<typeof resolveModelRefsFromEntries>[0],
+): Array<string | undefined> {
+  return resolveModelRefsFromEntries(params).map((ref) =>
+    ref ? modelKey(ref.provider, ref.model) : undefined,
+  );
 }
 
 function resolveKnownAgentId(cfg: OpenClawConfig, rawAgentId: string): string {
@@ -186,14 +268,19 @@ type PrimaryFallbackConfig = { primary?: string; fallbacks?: string[] };
 export function upsertCanonicalModelConfigEntry(
   models: Record<string, AgentModelEntryConfig>,
   params: { provider: string; model: string },
+  options: ModelEntryMergeOptions = {},
 ) {
   const key = modelKey(params.provider, params.model);
-  const legacyKeys = [
-    legacyModelKey(params.provider, params.model),
-    `${params.provider}/${key}`,
-  ].filter(
-    (legacyKey): legacyKey is string =>
-      typeof legacyKey === "string" && legacyKey.length > 0 && legacyKey !== key,
+  const { canonicalModelKeys } = options;
+  // Prepared ownership facts replace legacy guesses, including an empty selection.
+  const sourceKeys = canonicalModelKeys
+    ? Object.keys(models).filter((sourceKey) => canonicalModelKeys.get(sourceKey) === key)
+    : [legacyModelKey(params.provider, params.model), `${params.provider}/${key}`];
+  const legacyKeys = new Set(
+    sourceKeys.filter(
+      (legacyKey): legacyKey is string =>
+        typeof legacyKey === "string" && legacyKey.length > 0 && legacyKey !== key,
+    ),
   );
   let legacyEntry: AgentModelEntryConfig | undefined;
   for (const legacyKey of legacyKeys) {
@@ -201,26 +288,14 @@ export function upsertCanonicalModelConfigEntry(
     if (!entry) {
       continue;
     }
-    Object.assign((legacyEntry ??= {}), entry);
-    legacyEntry.params = {
-      ...legacyEntry.params,
-      ...entry.params,
-    };
+    legacyEntry = mergeAgentModelEntryForConfig(
+      legacyEntry,
+      options.restoreSourceEntry ? options.restoreSourceEntry(legacyKey, key, entry) : entry,
+    );
   }
 
-  if (legacyEntry) {
-    // Preserve legacy per-model params while moving the entry to provider/model.
-    models[key] = {
-      ...legacyEntry,
-      ...models[key],
-      params: {
-        ...legacyEntry.params,
-        ...models[key]?.params,
-      },
-    };
-  } else if (!models[key]) {
-    models[key] = {};
-  }
+  // Canonical values override migrated fields while omitted settings survive.
+  models[key] = mergeAgentModelEntryForConfig(legacyEntry, models[key] ?? {});
   for (const legacyKey of legacyKeys) {
     delete models[legacyKey];
   }
@@ -252,12 +327,13 @@ export function applyDefaultModelPrimaryUpdate(params: {
   modelRaw: string;
   field: "model" | "imageModel";
   resolvedTarget?: { provider: string; model: string };
+  modelEntryMerge?: ModelEntryMergeOptions;
 }): OpenClawConfig {
   const resolved = params.resolvedTarget ?? resolveDefaultModelPrimaryTarget(params);
   const nextModels = {
     ...params.cfg.agents?.defaults?.models,
   } as Record<string, AgentModelEntryConfig>;
-  const key = upsertCanonicalModelConfigEntry(nextModels, resolved);
+  const key = upsertCanonicalModelConfigEntry(nextModels, resolved, params.modelEntryMerge);
 
   const defaults = params.cfg.agents?.defaults ?? {};
   const existing = toAgentModelListLike(
@@ -294,29 +370,39 @@ export async function updateDefaultModelPrimaryConfig(params: {
   field: "model" | "imageModel";
 }): Promise<{ updated: OpenClawConfig; warning?: string }> {
   let warning: string | undefined;
-  const updated = await updateConfig((cfg, context) => {
-    const resolvedTarget = resolveDefaultModelPrimaryTarget({
-      cfg,
-      resolveCfg: context.runtimeConfig,
-      modelRaw: params.modelRaw,
-    });
-    const inspection = inspectModelReference({ cfg: context.runtimeConfig, ref: resolvedTarget });
-    if (inspection.status === "unknown-provider") {
-      throw new Error(
-        `Unknown model provider "${inspection.provider}". Install a plugin that declares it or configure it under models.providers before selecting "${inspection.ref}". Config was not changed.`,
-      );
-    }
-    if (inspection.status === "unknown-model") {
-      warning = `Warning: Model "${inspection.ref}" is not in the local model catalog for provider "${inspection.provider}". The provider is installed or configured, so the selection was saved; verify the model ID if it is not a newly released or self-hosted model.`;
-    }
-    return applyDefaultModelPrimaryUpdate({
-      cfg,
-      resolveCfg: context.runtimeConfig,
-      modelRaw: params.modelRaw,
-      field: params.field,
-      resolvedTarget,
-    });
-  });
+  const updated = await updateConfig(
+    (cfg, context) => {
+      const resolvedTarget = resolveDefaultModelPrimaryTarget({
+        cfg,
+        resolveCfg: context.runtimeConfig,
+        modelRaw: params.modelRaw,
+      });
+      const inspection = inspectModelReference({ cfg: context.runtimeConfig, ref: resolvedTarget });
+      if (inspection.status === "unknown-provider") {
+        throw new Error(
+          `Unknown model provider "${inspection.provider}". Install a plugin that declares it or configure it under models.providers before selecting "${inspection.ref}". Config was not changed.`,
+        );
+      }
+      if (inspection.status === "unknown-model") {
+        warning = `Warning: Model "${inspection.ref}" is not in the local model catalog for provider "${inspection.provider}". The provider is installed or configured, so the selection was saved; verify the model ID if it is not a newly released or self-hosted model.`;
+      }
+      return applyDefaultModelPrimaryUpdate({
+        cfg,
+        resolveCfg: context.runtimeConfig,
+        modelEntryMerge: context,
+        modelRaw: params.modelRaw,
+        field: params.field,
+        resolvedTarget,
+      });
+    },
+    (cfg, context) => [
+      resolveDefaultModelPrimaryTarget({
+        cfg,
+        resolveCfg: context.runtimeConfig,
+        modelRaw: params.modelRaw,
+      }),
+    ],
+  );
   return { updated, ...(warning ? { warning } : {}) };
 }
 

--- a/src/commands/status.summary.runtime.normalization.test.ts
+++ b/src/commands/status.summary.runtime.normalization.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const normalizeProviderModelIdWithManifestMock = vi.hoisted(() => vi.fn());
+const resolveManifestModelIdNormalizationPoliciesMock = vi.hoisted(() => vi.fn());
 const normalizeProviderModelIdWithRuntimeMock = vi.hoisted(() => vi.fn());
 
 vi.mock("../plugins/manifest-model-id-normalization.js", () => ({
-  normalizeProviderModelIdWithManifest: normalizeProviderModelIdWithManifestMock,
+  resolveManifestModelIdNormalizationPolicies: resolveManifestModelIdNormalizationPoliciesMock,
 }));
 
 vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
@@ -14,7 +14,7 @@ vi.mock("../agents/provider-model-normalization.runtime.js", () => ({
 describe("statusSummaryRuntime configured model normalization", () => {
   beforeEach(() => {
     vi.resetModules();
-    normalizeProviderModelIdWithManifestMock.mockReset();
+    resolveManifestModelIdNormalizationPoliciesMock.mockReset();
     normalizeProviderModelIdWithRuntimeMock.mockReset();
   });
 
@@ -58,7 +58,7 @@ describe("statusSummaryRuntime configured model normalization", () => {
       model: "gpt-5.5",
     });
 
-    expect(normalizeProviderModelIdWithManifestMock).not.toHaveBeenCalled();
+    expect(resolveManifestModelIdNormalizationPoliciesMock).not.toHaveBeenCalled();
     expect(normalizeProviderModelIdWithRuntimeMock).not.toHaveBeenCalled();
   });
 
@@ -72,7 +72,6 @@ describe("statusSummaryRuntime configured model normalization", () => {
       },
     } as never;
 
-    normalizeProviderModelIdWithManifestMock.mockReturnValue("claude-opus-4-6");
     normalizeProviderModelIdWithRuntimeMock.mockReturnValue("runtime-normalized-opus");
 
     expect(
@@ -112,7 +111,7 @@ describe("statusSummaryRuntime configured model normalization", () => {
       model: "claude-opus-4-6",
     });
 
-    expect(normalizeProviderModelIdWithManifestMock).not.toHaveBeenCalled();
+    expect(resolveManifestModelIdNormalizationPoliciesMock).not.toHaveBeenCalled();
     expect(normalizeProviderModelIdWithRuntimeMock).not.toHaveBeenCalled();
   });
 });

--- a/src/config/io.context.plugin-metadata.test.ts
+++ b/src/config/io.context.plugin-metadata.test.ts
@@ -7,6 +7,7 @@ import type { InstalledPluginIndex } from "../plugins/installed-plugin-index-typ
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import { restorePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
+import { buildDeclaredProviderOwnerIndex } from "../plugins/provider-owner-index.js";
 
 const mocks = vi.hoisted(() => ({
   resolvePluginMetadataSnapshot: vi.fn(),
@@ -89,6 +90,7 @@ function workspaceSnapshot(
     plugins,
     diagnostics: [],
     byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
+    declaredProviderOwners: buildDeclaredProviderOwnerIndex(plugins),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/config/plugin-auto-enable.test-helpers.ts
+++ b/src/config/plugin-auto-enable.test-helpers.ts
@@ -5,6 +5,7 @@ import type { PluginManifestRegistry } from "../plugins/manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginOrigin } from "../plugins/plugin-origin.types.js";
+import { buildDeclaredProviderOwnerIndex } from "../plugins/provider-owner-index.js";
 import { cleanupTrackedTempDirs, makeTrackedTempDir } from "../plugins/test-helpers/fs-fixtures.js";
 import type { OpenClawConfig } from "./types.openclaw.js";
 
@@ -106,6 +107,7 @@ export function createPluginMetadataSnapshot(params: {
     diagnostics: params.manifestRegistry.diagnostics,
     byPluginId: new Map(params.manifestRegistry.plugins.map((plugin) => [plugin.id, plugin])),
     normalizePluginId: (pluginId) => pluginId,
+    declaredProviderOwners: buildDeclaredProviderOwnerIndex(params.manifestRegistry.plugins),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/gateway/server-methods/models.test.ts
+++ b/src/gateway/server-methods/models.test.ts
@@ -37,7 +37,8 @@ const OPENCLAW_DEVICE_PLACEMENT: NonNullable<GatewayAgentRuntime["devicePlacemen
   consumesWorkerSlot: true,
 };
 
-const modelPluginMetadataSnapshot = vi.hoisted(() => {
+const modelPluginMetadataSnapshot = await vi.hoisted(async () => {
+  const { buildDeclaredProviderOwnerIndex } = await import("../../plugins/provider-owner-index.js");
   const plugins = [
     {
       id: "anthropic",
@@ -126,6 +127,7 @@ const modelPluginMetadataSnapshot = vi.hoisted(() => {
     diagnostics: [],
     byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
     normalizePluginId: (pluginId: string) => pluginId,
+    declaredProviderOwners: buildDeclaredProviderOwnerIndex(plugins),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/gateway/server-plugins.test.ts
+++ b/src/gateway/server-plugins.test.ts
@@ -15,6 +15,7 @@ import {
 import { createPluginRecord } from "../plugins/loader-records.js";
 import type { PluginDiagnostic } from "../plugins/manifest-types.js";
 import type { PluginLookUpTable } from "../plugins/plugin-lookup-table.js";
+import { buildDeclaredProviderOwnerIndex } from "../plugins/provider-owner-index.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import type { PluginRegistry } from "../plugins/registry.js";
 import { setActiveDegradedPlugins } from "../plugins/runtime-degraded-state.js";
@@ -219,6 +220,7 @@ function createLookUpTableForTest(params: {
     diagnostics: [],
     byPluginId: new Map(),
     normalizePluginId: (pluginId) => pluginId,
+    declaredProviderOwners: buildDeclaredProviderOwnerIndex(params.manifestRegistry?.plugins ?? []),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/gateway/server-startup-config.recovery.test.ts
+++ b/src/gateway/server-startup-config.recovery.test.ts
@@ -57,6 +57,7 @@ const pluginMetadataSnapshot = vi.hoisted((): PluginMetadataSnapshot => {
     diagnostics: [],
     byPluginId: new Map(),
     normalizePluginId: (pluginId) => pluginId,
+    declaredProviderOwners: new Map(),
     owners: emptyOwners,
     metrics: zeroMetrics,
   };

--- a/src/gateway/server-startup-plugins.test.ts
+++ b/src/gateway/server-startup-plugins.test.ts
@@ -65,6 +65,7 @@ const pluginMetadataSnapshot = vi.hoisted((): PluginMetadataSnapshot => {
     diagnostics: [],
     byPluginId: new Map(),
     normalizePluginId: (pluginId) => pluginId,
+    declaredProviderOwners: new Map(),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -215,6 +215,7 @@ function createGatewayPluginMetadataSnapshot(config: OpenClawConfig): PluginMeta
     diagnostics: [],
     byPluginId: new Map(),
     normalizePluginId: (pluginId) => pluginId,
+    declaredProviderOwners: new Map(),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/infra/dotenv-workspace-blocklist.test.ts
+++ b/src/infra/dotenv-workspace-blocklist.test.ts
@@ -8,6 +8,7 @@ import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plug
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { buildDeclaredProviderOwnerIndex } from "../plugins/provider-owner-index.js";
 import { listKnownProviderAuthEnvVarNames } from "../secrets/provider-env-vars.js";
 import { captureFullEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { loadDotEnv, loadWorkspaceDotEnvFile } from "./dotenv.js";
@@ -88,6 +89,7 @@ function createManifestBackedProviderSnapshot(
     diagnostics: [],
     byPluginId: new Map([[plugin.id, plugin]]),
     normalizePluginId: (pluginId: string) => pluginId,
+    declaredProviderOwners: buildDeclaredProviderOwnerIndex([plugin]),
     owners: emptyOwnerMaps(),
     metrics: {
       registrySnapshotMs: 0,

--- a/src/model-catalog/pricing.test.ts
+++ b/src/model-catalog/pricing.test.ts
@@ -593,7 +593,7 @@ describe("hosted model pricing", () => {
         const discoverySpies = allowPluginNormalization
           ? []
           : [
-              vi.spyOn(manifestNormalization, "normalizeProviderModelIdWithManifest"),
+              vi.spyOn(manifestNormalization, "resolveManifestModelIdNormalizationPolicies"),
               vi.spyOn(runtimeNormalization, "normalizeProviderModelIdWithRuntime"),
               vi.spyOn(pluginMetadata, "resolvePluginMetadataSnapshot"),
             ];

--- a/src/plugin-sdk/agent-runtime-model-catalog-contract.test.ts
+++ b/src/plugin-sdk/agent-runtime-model-catalog-contract.test.ts
@@ -65,7 +65,10 @@ describe("agent-runtime model catalog compatibility", () => {
   });
 
   it("accepts legacy options without overriding lifecycle metadata", async () => {
-    type LegacyMetadataSnapshot = Omit<PluginMetadataSnapshot, "owners"> & {
+    type LegacyMetadataSnapshot = Omit<
+      PluginMetadataSnapshot,
+      "owners" | "declaredProviderOwners"
+    > & {
       owners: Omit<PluginMetadataSnapshot["owners"], "modelIdNormalizationPolicies">;
     };
     type AcceptedMetadataSnapshot = NonNullable<

--- a/src/plugin-sdk/agent-runtime.ts
+++ b/src/plugin-sdk/agent-runtime.ts
@@ -42,8 +42,9 @@ type LoadModelCatalogCompatibilityParams = LoadPreparedModelCatalogParams & {
   /** @deprecated Use getPreparedModelCatalogSnapshot for new nonblocking readers. */
   cacheOnly?: boolean;
   /** @deprecated Plugin metadata belongs to the published lifecycle generation. */
-  metadataSnapshot?: Omit<PluginMetadataSnapshot, "owners"> & {
-    // Shipped callers may supply owner maps from before normalization policies were prepared.
+  metadataSnapshot?: Omit<PluginMetadataSnapshot, "owners" | "declaredProviderOwners"> & {
+    // Shipped snapshots may predate prepared provider ownership and normalization policies.
+    declaredProviderOwners?: PluginMetadataSnapshot["declaredProviderOwners"];
     owners: Omit<PluginMetadataSnapshot["owners"], "modelIdNormalizationPolicies"> &
       Partial<Pick<PluginMetadataSnapshot["owners"], "modelIdNormalizationPolicies">>;
   };

--- a/src/plugin-sdk/facade-runtime.test.ts
+++ b/src/plugin-sdk/facade-runtime.test.ts
@@ -9,6 +9,7 @@ import { setCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-meta
 import { resolveInstalledPluginIndexPolicyHash } from "../plugins/installed-plugin-index-policy.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugins/plugin-metadata-lifecycle.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { buildDeclaredProviderOwnerIndex } from "../plugins/provider-owner-index.js";
 import * as facadeActivationRuntime from "./facade-activation-check.runtime.js";
 import {
   evaluateBundledPluginPublicSurfaceAccess,
@@ -861,6 +862,7 @@ describe("plugin-sdk facade runtime", () => {
         diagnostics: [],
         byPluginId: new Map(),
         normalizePluginId: (pluginId) => pluginId,
+        declaredProviderOwners: buildDeclaredProviderOwnerIndex(params.plugins ?? []),
         owners: {
           channels: new Map(),
           channelConfigs: new Map(),

--- a/src/plugins/active-runtime-registry.test.ts
+++ b/src/plugins/active-runtime-registry.test.ts
@@ -1,13 +1,23 @@
 // Covers active runtime plugin registry state and reset behavior.
-import { afterEach, describe, expect, it } from "vitest";
+import { mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
 import {
   getLoadedRuntimePluginRegistry,
   listLoadedRuntimePluginIds,
   listRuntimePluginIdsFromRegistry,
-  registryMatchesManifestPluginIds,
+  createRuntimePluginManifestLookup,
 } from "./active-runtime-registry.js";
 import { resolvePluginLoadCacheContext } from "./loader-load-context.js";
-import { clearPluginLoaderCache } from "./loader.test-fixtures.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  clearPluginLoaderCache,
+  EMPTY_PLUGIN_SCHEMA,
+  loadOpenClawPlugins,
+  makePluginLoaderTempDir,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+import { createPluginMetadataSnapshotFixture } from "./plugin-metadata.test-support.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginRegistry } from "./registry-types.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
@@ -16,6 +26,8 @@ afterEach(() => {
   clearPluginLoaderCache();
   resetPluginRuntimeStateForTest();
 });
+
+afterAll(cleanupPluginLoaderFixturesForTest);
 
 function createRegistryWithPlugin(pluginId: string): PluginRegistry {
   const registry = createEmptyPluginRegistry();
@@ -216,41 +228,251 @@ describe("getLoadedRuntimePluginRegistry", () => {
     ).toBeUndefined();
   });
 
-  it("reuses built bundled runtimes for the matching source manifest owner", () => {
-    const registry = createOwnedRegistryWithPlugin("demo", "/dist/extensions/demo");
-
-    expect(
-      registryMatchesManifestPluginIds(
-        registry,
-        [
-          {
-            id: "demo",
-            origin: "bundled",
-            rootDir: "/extensions/demo",
-            source: "/extensions/demo/index.ts",
-          } as never,
-        ],
-        ["demo"],
-      ),
-    ).toBe(true);
-  });
-
   it("rejects a request registry when a workspace selects another physical owner", () => {
     const registry = createOwnedRegistryWithPlugin("demo", "/plugins/demo");
 
     expect(
-      registryMatchesManifestPluginIds(
-        registry,
-        [
-          {
-            id: "demo",
-            origin: "workspace",
-            rootDir: "/tmp/session-workspace/.openclaw/extensions/demo",
-            source: "/tmp/session-workspace/.openclaw/extensions/demo/index.js",
-          } as never,
-        ],
-        ["demo"],
-      ),
-    ).toBe(false);
+      createRuntimePluginManifestLookup(registry, [
+        {
+          id: "demo",
+          origin: "workspace",
+          rootDir: "/tmp/session-workspace/.openclaw/extensions/demo",
+          source: "/tmp/session-workspace/.openclaw/extensions/demo/index.js",
+        } as never,
+      ])("demo"),
+    ).toBeUndefined();
   });
+});
+
+it.each(["setup", "full"] as const)(
+  "matches the executable setup source selected by a %s load",
+  (channelPluginLoadIntent) => {
+    const runtime = writePlugin({
+      id: "setup-fixture",
+      filename: "index.cjs",
+      body: 'module.exports = { id: "setup-fixture", register() {} };',
+    });
+    for (const label of ["old", "new"]) {
+      writeFileSync(
+        path.join(runtime.dir, `${label}.cjs`),
+        `module.exports = { plugin: {
+        id: "setup-channel", meta: { id: "setup-channel", label: ${JSON.stringify(label)},
+          selectionLabel: "Fixture", docsPath: "/synthetic", blurb: "Synthetic fixture" },
+        capabilities: { chatTypes: ["direct"] },
+        config: { listAccountIds: () => [], resolveAccount: () => ({}) },
+      }};`,
+      );
+    }
+    const options = (label: string) => ({
+      config: { plugins: { allow: [runtime.id], entries: { [runtime.id]: { enabled: true } } } },
+      env: {},
+      installRecords: {},
+      onlyPluginIds: [runtime.id],
+      activate: false,
+      channelPluginLoadIntent,
+      manifestRegistry: createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: runtime.id,
+            origin: "global",
+            rootDir: runtime.dir,
+            source: runtime.file,
+            channels: ["setup-channel"],
+            configSchema: EMPTY_PLUGIN_SCHEMA,
+            setupSource: path.join(runtime.dir, `${label}.cjs`),
+            providerDiscoverySource: path.join(runtime.dir, `${label}.cjs`),
+            capabilityCatalogSource: path.join(runtime.dir, `${label}.cjs`),
+          },
+        ],
+      }).manifestRegistry,
+    });
+    const old = loadOpenClawPlugins(options("old"));
+    const next = loadOpenClawPlugins(options("new"));
+    expect(old.plugins[0]?.status).toBe("loaded");
+    setActivePluginRegistry(old, "old");
+    const reused = getLoadedRuntimePluginRegistry({ loadOptions: options("new") });
+    if (channelPluginLoadIntent === "setup") {
+      expect([old.channels[0]?.plugin.meta.label, next.channels[0]?.plugin.meta.label]).toEqual([
+        "old",
+        "new",
+      ]);
+      expect(reused === undefined).toBe(true);
+    } else {
+      expect(old.channels).toEqual([]);
+      expect(reused === old).toBe(true);
+    }
+  },
+);
+
+it.each([
+  { sourceFormat: "cts", builtFormat: "cjs", preferBuiltPluginArtifacts: false },
+  { sourceFormat: "cts", builtFormat: "cjs", preferBuiltPluginArtifacts: true },
+  { sourceFormat: "mts", builtFormat: "mjs", preferBuiltPluginArtifacts: false },
+  { sourceFormat: "mts", builtFormat: "mjs", preferBuiltPluginArtifacts: true },
+])(
+  "reuses selected bundled setup $sourceFormat/$builtFormat artifacts with built=$preferBuiltPluginArtifacts",
+  ({ sourceFormat, builtFormat, preferBuiltPluginArtifacts }) => {
+    const schema = EMPTY_PLUGIN_SCHEMA;
+    const packageRoot = makePluginLoaderTempDir();
+    const options = [
+      { format: sourceFormat, tree: "extensions" },
+      { format: builtFormat, tree: "dist/extensions" },
+      { format: builtFormat, tree: "dist-runtime/extensions" },
+    ].map(({ format, tree }) => {
+      const rootDir = path.join(packageRoot, tree, "bundled-setup");
+      mkdirSync(rootDir, { recursive: true });
+      const source = path.join(rootDir, `index.${format}`);
+      const setupSource = path.join(rootDir, `setup.${format}`);
+      const label = tree === "extensions" ? "source" : "built";
+      const exported = ["mts", "mjs"].includes(format) ? "export default" : "module.exports =";
+      writeFileSync(source, `${exported} { id: "bundled-setup", register() {} };`);
+      writeFileSync(
+        setupSource,
+        `${exported} { plugin: {
+      id: "bundled-setup", meta: { id: "bundled-setup", label: ${JSON.stringify(label)}, selectionLabel: "Fixture", docsPath: "/synthetic", blurb: "Synthetic fixture" },
+      capabilities: { chatTypes: ["direct"] }, config: { listAccountIds: () => [], resolveAccount: () => ({}) },
+    }};`,
+      );
+      writeFileSync(
+        path.join(rootDir, "package.json"),
+        JSON.stringify({
+          openclaw: { extensions: [`./index.${format}`], setupEntry: `./setup.${format}` },
+        }),
+      );
+      writeFileSync(
+        path.join(rootDir, "openclaw.plugin.json"),
+        JSON.stringify({ id: "bundled-setup", channels: ["bundled-setup"], configSchema: schema }),
+      );
+      return {
+        config: {
+          plugins: { allow: ["bundled-setup"], entries: { "bundled-setup": { enabled: true } } },
+        },
+        env: {},
+        installRecords: {},
+        onlyPluginIds: ["bundled-setup"],
+        activate: false,
+        preferBuiltPluginArtifacts,
+        channelPluginLoadIntent: "setup" as const,
+        manifestRegistry: createPluginMetadataSnapshotFixture({
+          plugins: [
+            {
+              id: "bundled-setup",
+              origin: "bundled",
+              rootDir,
+              source,
+              setupSource,
+              channels: ["bundled-setup"],
+              configSchema: schema,
+            },
+          ],
+        }).manifestRegistry,
+      };
+    });
+    const expectedLabel = (index: number) =>
+      preferBuiltPluginArtifacts || index !== 0 ? "built" : "source";
+    for (const [loadedIndex, loadedOptions] of options.entries()) {
+      const loaded = loadOpenClawPlugins(loadedOptions);
+      expect(loaded.channels[0]?.plugin.meta.label).toBe(expectedLabel(loadedIndex));
+      setActivePluginRegistry(loaded, "canonical-view");
+      for (const [requestedIndex, requestedOptions] of options.entries()) {
+        expect(getLoadedRuntimePluginRegistry({ loadOptions: requestedOptions }) === loaded).toBe(
+          expectedLabel(loadedIndex) === expectedLabel(requestedIndex),
+        );
+      }
+    }
+  },
+);
+
+it("does not reuse a different explicitly selected bundled entry", () => {
+  const runtime = writePlugin({
+    id: "entry-fixture",
+    filename: "index.cjs",
+    body: `module.exports = { id: "entry-fixture", register(api) {
+      api.registerProvider({ id: "entry-provider", label: "Old", auth: [] });
+    }};`,
+  });
+  const selectedSource = path.join(runtime.dir, "selected.cjs");
+  writeFileSync(
+    selectedSource,
+    `module.exports = { id: "entry-fixture", register(api) {
+    api.registerProvider({ id: "entry-provider", label: "Selected", auth: [] });
+  }};`,
+  );
+  const options = (source: string) => ({
+    config: { plugins: { allow: [runtime.id], entries: { [runtime.id]: { enabled: true } } } },
+    env: {},
+    installRecords: {},
+    onlyPluginIds: [runtime.id],
+    activate: false,
+    manifestRegistry: createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: runtime.id,
+          origin: "bundled",
+          rootDir: runtime.dir,
+          source,
+          sourcePreferred: true,
+          providers: ["entry-provider"],
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+        },
+      ],
+    }).manifestRegistry,
+  });
+  const old = loadOpenClawPlugins(options(runtime.file));
+  expect(old.providers[0]?.provider.label).toBe("Old");
+  setActivePluginRegistry(old, "old-entry");
+  expect(
+    getLoadedRuntimePluginRegistry({ loadOptions: options(selectedSource) }) === undefined,
+  ).toBe(true);
+  expect(loadOpenClawPlugins(options(selectedSource)).providers[0]?.provider.label).toBe(
+    "Selected",
+  );
+});
+
+it("compares the executed artifact after the loader's final staging pass", () => {
+  const packageRoot = makePluginLoaderTempDir();
+  let source = path.join(
+    packageRoot,
+    "dist-runtime/extensions/a/dist-runtime/extensions/b/dist-runtime/extensions/c/index.cjs",
+  );
+  const selectedSource = source;
+  for (let stage = 0; stage <= 3; stage += 1) {
+    mkdirSync(path.dirname(source), { recursive: true });
+    writeFileSync(
+      source,
+      `module.exports = { id: "staged-fixture", register(api) {
+        api.registerProvider({ id: "staged-provider", label: "stage-${stage}", auth: [] });
+      }};`,
+    );
+    source = source.replace(
+      `${path.sep}dist-runtime${path.sep}extensions${path.sep}`,
+      `${path.sep}dist${path.sep}extensions${path.sep}`,
+    );
+  }
+  const options = {
+    config: {
+      plugins: { allow: ["staged-fixture"], entries: { "staged-fixture": { enabled: true } } },
+    },
+    env: {},
+    installRecords: {},
+    onlyPluginIds: ["staged-fixture"],
+    activate: false,
+    preferBuiltPluginArtifacts: false,
+    manifestRegistry: createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "staged-fixture",
+          origin: "bundled",
+          rootDir: path.dirname(selectedSource),
+          source: selectedSource,
+          providers: ["staged-provider"],
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+        },
+      ],
+    }).manifestRegistry,
+  };
+  const loaded = loadOpenClawPlugins(options);
+  expect(loaded.providers[0]?.provider.label).toBe("stage-3");
+  setActivePluginRegistry(loaded, "executed-stage");
+  expect(getLoadedRuntimePluginRegistry({ loadOptions: options }) === loaded).toBe(true);
 });

--- a/src/plugins/active-runtime-registry.ts
+++ b/src/plugins/active-runtime-registry.ts
@@ -3,6 +3,7 @@ import { normalizeSortedUniqueStringEntries } from "@openclaw/normalization-core
 import { resolvePluginLoadCacheContext } from "./loader-load-context.js";
 import type { PluginLoadOptions } from "./loader-types.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
+import { matchesPluginRuntimeArtifactSelection } from "./plugin-runtime-artifact-selection.js";
 import type { PluginRecord, PluginRegistry } from "./registry-types.js";
 import {
   getActivePluginRegistry,
@@ -100,27 +101,27 @@ export function registryContainsRuntimePluginIds(
   return pluginIds.length === 0;
 }
 
-export function registryMatchesManifestPluginIds(
+/** Indexes selected owners; omitted artifact preference retains the loaded owner's policy. */
+export function createRuntimePluginManifestLookup(
   registry: PluginRegistry,
-  manifestPlugins: readonly PluginManifestRecord[] | undefined,
-  pluginIds: readonly string[],
-): boolean {
-  if (!manifestPlugins) {
-    return false;
-  }
-  const records = new Map(registry.plugins.map((plugin) => [plugin.id, plugin]));
-  const manifests = new Map(manifestPlugins.map((plugin) => [plugin.id, plugin]));
-  return pluginIds.every((pluginId) => {
+  manifestPlugins: readonly PluginManifestRecord[],
+  preferBuiltPluginArtifacts?: boolean,
+): (pluginId: string) => PluginRecord | undefined {
+  // Loader order chooses the owner; later disabled duplicates are diagnostics only.
+  const records = new Map(
+    registry.plugins.filter(isRuntimePluginRecordLoaded).map((plugin) => [plugin.id, plugin]),
+  );
+  const manifests = new Map(manifestPlugins.toReversed().map((plugin) => [plugin.id, plugin]));
+  return (pluginId) => {
     const record = records.get(pluginId);
     const manifest = manifests.get(pluginId);
-    return Boolean(
-      record &&
+    return record &&
       manifest &&
       record.origin === manifest.origin &&
-      (record.origin === "bundled" ||
-        (record.rootDir === manifest.rootDir && record.source === manifest.source)),
-    );
-  });
+      matchesPluginRuntimeArtifactSelection(record, manifest, preferBuiltPluginArtifacts)
+      ? record
+      : undefined;
+  };
 }
 
 export function getLoadedRuntimePluginRegistry(
@@ -135,22 +136,43 @@ export function getLoadedRuntimePluginRegistry(
     params.requiredPluginIds ?? params.loadOptions?.onlyPluginIds,
   );
   if (params.loadOptions && requiredPluginIds === undefined) {
-    // Explicit scopes below are bounded by workspace and loaded owners. Only
-    // unscoped requests need the full load identity to prove compatible reuse.
+    // Unscoped requests need the full load identity. Bounded manifest scopes
+    // can compare their prepared ownership facts below.
     return resolveCompatibleRuntimePluginRegistry(params.loadOptions);
   }
 
   const activeWorkspaceDir = getActivePluginRegistryWorkspaceDir();
   const requestedWorkspaceDir = params.workspaceDir ?? params.loadOptions?.workspaceDir;
-  if (requestedWorkspaceDir !== undefined && activeWorkspaceDir !== requestedWorkspaceDir) {
+  if (
+    (Object.hasOwn(params, "workspaceDir") ||
+      params.loadOptions ||
+      requestedWorkspaceDir !== undefined) &&
+    activeWorkspaceDir !== requestedWorkspaceDir
+  ) {
     return undefined;
   }
   const registry = getActivePluginRegistry();
   if (!registry) {
     return undefined;
   }
-  if (!registryContainsRuntimePluginIds(registry, requiredPluginIds)) {
+  if (
+    !registryContainsRuntimePluginIds(registry, requiredPluginIds) ||
+    (params.loadOptions?.manifestRegistry &&
+      requiredPluginIds !== undefined &&
+      !requiredPluginIds.every(
+        createRuntimePluginManifestLookup(
+          registry,
+          params.loadOptions.manifestRegistry.plugins,
+          params.loadOptions.preferBuiltPluginArtifacts,
+        ),
+      ))
+  ) {
     return undefined;
+  }
+  // Raw discovery has not established manifest winners, so ID containment alone
+  // cannot prove which candidate would load. Prepared manifests keep the fast path.
+  if (params.loadOptions?.discovery && !params.loadOptions.manifestRegistry) {
+    return resolveCompatibleRuntimePluginRegistry(params.loadOptions);
   }
   return registry;
 }

--- a/src/plugins/current-plugin-metadata-snapshot.test.ts
+++ b/src/plugins/current-plugin-metadata-snapshot.test.ts
@@ -29,6 +29,7 @@ import {
 import { createPluginMetadataSnapshotFixture } from "./plugin-metadata.test-support.js";
 import { classifyProviderFailoverSignalWithPlugin } from "./provider-failover.js";
 import { resolveProviderRuntimePlugin } from "./provider-hook-runtime.js";
+import { buildDeclaredProviderOwnerIndex } from "./provider-owner-index.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
 import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
@@ -90,6 +91,7 @@ function createSnapshot(
     diagnostics: [],
     byPluginId: new Map(),
     normalizePluginId: (pluginId) => pluginId,
+    declaredProviderOwners: buildDeclaredProviderOwnerIndex(plugins),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/plugins/legacy-session-surfaces.ts
+++ b/src/plugins/legacy-session-surfaces.ts
@@ -19,10 +19,8 @@ import {
 } from "./manifest-owner-policy.js";
 import { unwrapDefaultModuleExport } from "./module-export.js";
 import { getCachedPluginModuleLoader } from "./plugin-module-loader-cache.js";
-import {
-  resolveCanonicalDistRuntimeSource,
-  resolvePluginRuntimeArtifact,
-} from "./plugin-runtime-artifact-resolution.js";
+import { resolvePluginRuntimeArtifact } from "./plugin-runtime-artifact-resolution.js";
+import { resolvePluginRuntimeExecutionArtifact } from "./plugin-runtime-artifact-selection.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import type { PluginRuntimeLoadContext } from "./runtime/load-context.js";
 import { resolvePluginRuntimeLoadContext } from "./runtime/load-context.resolve.js";
@@ -107,18 +105,18 @@ function loadLegacySessionSurface(params: {
   env: NodeJS.ProcessEnv;
   artifactRegistry: ReturnType<typeof createEmptyPluginRegistry>;
 }): BundledChannelLegacySessionSurface {
-  const setupEntry = resolvePluginRuntimeArtifact({
-    pluginId: params.record.id,
-    entryKind: "setup",
-    source: params.record.setupSource,
-    rootDir: params.record.rootDir,
-    origin: params.record.origin,
-    preferBuiltPluginArtifacts: false,
-    packageManifest: params.record.packageManifest,
-    registry: params.artifactRegistry,
-  });
-  const moduleSource = resolveCanonicalDistRuntimeSource(setupEntry.source);
-  const moduleRoot = resolveCanonicalDistRuntimeSource(setupEntry.rootDir);
+  const { source: moduleSource, rootDir: moduleRoot } = resolvePluginRuntimeExecutionArtifact(
+    resolvePluginRuntimeArtifact({
+      pluginId: params.record.id,
+      entryKind: "setup",
+      source: params.record.setupSource,
+      rootDir: params.record.rootDir,
+      origin: params.record.origin,
+      preferBuiltPluginArtifacts: false,
+      packageManifest: params.record.packageManifest,
+      registry: params.artifactRegistry,
+    }),
+  );
   const opened = openRootFileSync({
     absolutePath: moduleSource,
     rootPath: moduleRoot,

--- a/src/plugins/loader-channel-runtime.ts
+++ b/src/plugins/loader-channel-runtime.ts
@@ -15,7 +15,7 @@ import { recordPluginError } from "./loader-records.js";
 import type { PluginRegistrationPlan } from "./loader-registration-plan.js";
 import type { PluginManifestRecord } from "./manifest-registry.js";
 import { withProfile } from "./plugin-load-profile.js";
-import { resolveCanonicalDistRuntimeSource } from "./plugin-runtime-artifact-resolution.js";
+import { resolvePluginRuntimeExecutionArtifact } from "./plugin-runtime-artifact-selection.js";
 import type { createPluginRegistry, PluginRecord } from "./registry.js";
 import type { OpenClawPluginModule, PluginLogger } from "./types.js";
 
@@ -88,13 +88,12 @@ export function loadSetupRuntimeChannelCandidate(params: {
   });
   let mergedSetupRegistration = setupRegistration;
   let runtimeSetterApplied = false;
-  if (
-    registrationPlan.loadSetupRuntimeEntry &&
-    setupRegistration.usesBundledSetupContract &&
-    resolveCanonicalDistRuntimeSource(runtimeCandidateEntry.source) !== params.safeSource
-  ) {
-    const runtimeModuleSource = resolveCanonicalDistRuntimeSource(runtimeCandidateEntry.source);
-    const runtimeModuleRoot = resolveCanonicalDistRuntimeSource(runtimeCandidateEntry.rootDir);
+  const runtimeEntry =
+    registrationPlan.loadSetupRuntimeEntry && setupRegistration.usesBundledSetupContract
+      ? resolvePluginRuntimeExecutionArtifact(runtimeCandidateEntry)
+      : undefined;
+  if (runtimeEntry && runtimeEntry.source !== params.safeSource) {
+    const { source: runtimeModuleSource, rootDir: runtimeModuleRoot } = runtimeEntry;
     const runtimeOpened = openRootFileSync({
       absolutePath: runtimeModuleSource,
       rootPath: runtimeModuleRoot,

--- a/src/plugins/loader-load-context.ts
+++ b/src/plugins/loader-load-context.ts
@@ -18,6 +18,7 @@ import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snap
 import { resolveOpenClawDevSourceRoot } from "./dev-source-root.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "./installed-plugin-index-install-records.js";
 import { loadInstalledPluginIndexInstallRecordsSync } from "./installed-plugin-index-records.js";
+import { resolvePluginRegistrationConfigKey } from "./loader-registration-config.js";
 import type {
   ChannelPluginLoadIntent,
   PluginLoadOptions,
@@ -149,10 +150,9 @@ function buildActivationMetadataHash(params: {
       return typeof enabled === "boolean" ? [[channelId, enabled] as const] : [];
     })
     .toSorted(([left], [right]) => left.localeCompare(right));
-  // Source config selects validation and defaults even when resolved values match.
-  // Object fields keep an absent config distinct from an explicit null source.
+  // Registration inputs are keyed separately; source enablement still steers activation.
   const pluginEntryInputs = Object.entries(params.activationSource.plugins.entries)
-    .map(([pluginId, { enabled, config }]) => [pluginId, { enabled, config }] as const)
+    .map(([pluginId, { enabled }]) => [pluginId, enabled] as const)
     .toSorted(([left], [right]) => left.localeCompare(right));
   const autoEnableReasonEntries = Object.entries(params.autoEnabledReasons)
     .map(([pluginId, reasons]) => [pluginId, [...reasons]] as const)
@@ -176,8 +176,11 @@ function buildActivationMetadataHash(params: {
 function buildCacheKey(params: {
   workspaceDir?: string;
   plugins: NormalizedPluginsConfig;
+  registrationConfigKey: string;
   activationMetadataKey?: string;
   installs?: Record<string, PluginInstallRecord>;
+  manifestRegistry?: PluginLoadOptions["manifestRegistry"];
+  discovery?: PluginLoadOptions["discovery"];
   env: NodeJS.ProcessEnv;
   devSourceRoot?: string | null;
   onlyPluginIds?: string[];
@@ -233,8 +236,33 @@ function buildCacheKey(params: {
       devSourceRoot: params.devSourceRoot ?? "",
       discoveryFingerprint: fingerprintPluginDiscoveryContext(discoveryContext),
       ...params.plugins,
+      entries: Object.entries(params.plugins.entries).map(([id, entry]) => [id, entry.enabled]),
+      registrationConfigKey: params.registrationConfigKey,
       installs,
       loadPaths,
+      // Supplied candidates own physical source selection even when ids/config match.
+      // Keep the selection facts in the loader key instead of a second hook cache.
+      manifestSources: params.manifestRegistry?.plugins.map((plugin) => [
+        plugin.id,
+        plugin.origin,
+        plugin.rootDir,
+        plugin.source,
+        plugin.setupSource,
+        plugin.providerDiscoverySource,
+        plugin.capabilityCatalogSource,
+        plugin.sourcePreferred,
+        plugin.packageManifest?.build?.bundledDist,
+      ]),
+      discoverySources: params.discovery?.candidates.map((candidate) => [
+        candidate.effectivePluginId ?? candidate.idHint,
+        candidate.origin,
+        candidate.rootDir,
+        candidate.source,
+        candidate.setupSource,
+        candidate.sourcePreferred,
+        candidate.configSelected,
+        candidate.packageManifest?.build?.bundledDist,
+      ]),
       activationMetadataKey: params.activationMetadataKey ?? "",
       capabilityCatalogIdentity: params.capabilityCatalogIdentity,
       allowProcessHomeSessionCatalogs: params.allowProcessHomeSessionCatalogs !== false,
@@ -370,14 +398,23 @@ export function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
     ...cfg.plugins?.installs,
   };
   const devSourceRoot = resolveOpenClawDevSourceRoot(env);
+  const registrationConfigKey = resolvePluginRegistrationConfigKey({
+    config: cfg,
+    activationSourceConfig,
+  });
   const cacheKey = buildCacheKey({
     workspaceDir: options.workspaceDir,
     plugins: trustNormalized,
+    registrationConfigKey,
     activationMetadataKey: buildActivationMetadataHash({
       activationSource,
       autoEnabledReasons: options.autoEnabledReasons ?? {},
     }),
     installs: installRecords,
+    manifestRegistry:
+      options.manifestRegistry ??
+      (options.discovery === undefined ? currentMetadataSnapshot?.manifestRegistry : undefined),
+    discovery: options.manifestRegistry ? undefined : options.discovery,
     env,
     devSourceRoot,
     onlyPluginIds,
@@ -406,6 +443,7 @@ export function resolvePluginLoadCacheContext(options: PluginLoadOptions = {}) {
   return {
     env,
     cfg,
+    registrationConfigKey,
     metadataSnapshot: currentMetadataSnapshot,
     normalized: trustNormalized,
     activationSourceConfig,

--- a/src/plugins/loader-registration-config.ts
+++ b/src/plugins/loader-registration-config.ts
@@ -1,0 +1,23 @@
+import { createHash } from "node:crypto";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { normalizePluginsConfig } from "./config-state.js";
+
+/** Configuration consumed during registration, independent of activation and load scope. */
+export function resolvePluginRegistrationConfigKey(params: {
+  config?: OpenClawConfig;
+  activationSourceConfig?: OpenClawConfig;
+}): string {
+  const runtimeEntries = normalizePluginsConfig(params.config?.plugins).entries;
+  const sourceEntries = normalizePluginsConfig(params.activationSourceConfig?.plugins).entries;
+  const pluginIds = new Set([...Object.keys(runtimeEntries), ...Object.keys(sourceEntries)]);
+  const inputs = [...pluginIds].toSorted().flatMap((pluginId) => {
+    const { enabled: _enabled, ...runtime } = runtimeEntries[pluginId] ?? {};
+    const sourceConfig = sourceEntries[pluginId]?.config;
+    const registration = { ...runtime, sourceConfig };
+    // Auto-enable may add an otherwise empty entry; it does not change callback inputs.
+    return Object.values(registration).some((value) => value !== undefined)
+      ? [[pluginId, registration]]
+      : [];
+  });
+  return createHash("sha256").update(JSON.stringify(inputs)).digest("hex");
+}

--- a/src/plugins/loader-runtime-candidate.ts
+++ b/src/plugins/loader-runtime-candidate.ts
@@ -42,11 +42,12 @@ import type { PluginManifestRecord } from "./manifest-registry.js";
 import { resolveExternalPluginRuntimeDependencyRepairHint } from "./official-external-plugin-repair-hints.js";
 import { withProfile } from "./plugin-load-profile.js";
 import { preparePluginModule } from "./plugin-module-loader-cache.js";
+import { resolvePluginRuntimeArtifact } from "./plugin-runtime-artifact-resolution.js";
 import {
-  resolveCanonicalDistRuntimeSource,
-  resolvePluginRuntimeArtifact,
-} from "./plugin-runtime-artifact-resolution.js";
-import { prefersBuiltPluginArtifacts } from "./plugin-runtime-artifact-selection.js";
+  bindPluginRuntimeArtifactSelection,
+  resolvePluginRuntimeExecutionArtifact,
+  prefersBuiltPluginArtifacts,
+} from "./plugin-runtime-artifact-selection.js";
 import type { createPluginRegistry, PluginRecord } from "./registry.js";
 import {
   clearActiveDegradedPlugin,
@@ -163,28 +164,25 @@ export function loadRuntimePluginCandidate(params: {
     context.artifactPreference,
     candidate.origin,
   );
-  const runtimeCandidateEntry = resolvePluginRuntimeArtifact({
+  const artifactParams = {
     pluginId,
-    entryKind: "runtime",
-    source: candidate.source,
     rootDir: pluginRoot,
     origin: candidate.origin,
     preferBuiltPluginArtifacts,
     sourcePreferred: manifestRecord.sourcePreferred,
     packageManifest: candidate.packageManifest,
     registry,
+  };
+  const runtimeCandidateEntry = resolvePluginRuntimeArtifact({
+    ...artifactParams,
+    entryKind: "runtime",
+    source: candidate.source,
   });
   const runtimeSetupEntry = manifestRecord.setupSource
     ? resolvePluginRuntimeArtifact({
-        pluginId,
+        ...artifactParams,
         entryKind: "setup",
         source: manifestRecord.setupSource,
-        rootDir: pluginRoot,
-        origin: candidate.origin,
-        preferBuiltPluginArtifacts,
-        sourcePreferred: manifestRecord.sourcePreferred,
-        packageManifest: candidate.packageManifest,
-        registry,
       })
     : undefined;
   const scopedSetupOnlyChannelPluginRequested =
@@ -308,15 +306,9 @@ export function loadRuntimePluginCandidate(params: {
         throw new Error("entry must resolve inside the selected plugin root");
       }
       const artifact = resolvePluginRuntimeArtifact({
-        pluginId,
+        ...artifactParams,
         entryKind: "capability-catalog",
         source: manifestRecord.capabilityCatalogSource,
-        rootDir: pluginRoot,
-        origin: candidate.origin,
-        preferBuiltPluginArtifacts,
-        sourcePreferred: manifestRecord.sourcePreferred,
-        packageManifest: candidate.packageManifest,
-        registry,
       });
       const { source, modulePath } = preparePluginModule({
         modulePath: artifact.source,
@@ -381,12 +373,20 @@ export function loadRuntimePluginCandidate(params: {
     // Shipped register()-only plugins and families omitted by a catalog keep runtime discovery.
   }
 
-  const loadEntry =
+  const loadEntry = resolvePluginRuntimeExecutionArtifact(
     registrationPlan.loadSetupEntry && runtimeSetupEntry
       ? runtimeSetupEntry
-      : runtimeCandidateEntry;
-  const moduleLoadSource = resolveCanonicalDistRuntimeSource(loadEntry.source);
-  const moduleRoot = resolveCanonicalDistRuntimeSource(loadEntry.rootDir);
+      : runtimeCandidateEntry,
+  );
+  // Setup runtime can register a channel without importing the main entry.
+  // Retain the setup source that actually ran, rather than unused declarations.
+  const artifactSelection = bindPluginRuntimeArtifactSelection(record, {
+    ...artifactParams,
+    runtimeEntry: resolvePluginRuntimeExecutionArtifact(runtimeCandidateEntry),
+    setupEntry: registrationPlan.loadSetupEntry ? loadEntry : undefined,
+  });
+  const moduleLoadSource = loadEntry.source;
+  const moduleRoot = loadEntry.rootDir;
   const rejectHardlinks = shouldRejectHardlinkedPluginFiles({
     origin: candidate.origin,
     rootDir: candidate.rootDir,
@@ -567,6 +567,8 @@ export function loadRuntimePluginCandidate(params: {
     // Non-activating snapshots are private until cached activation; rollback restores both.
     if (registrationPlan.runRuntimeCapabilityPolicy) {
       registerPluginDashboardCapabilities({ record, registry });
+      // Publish completion only after the capability-enabled register pass succeeds.
+      artifactSelection.runtimeRegistrationComplete = true;
     }
     registry.plugins.push(record);
     state.seenIds.set(pluginId, candidate.origin);

--- a/src/plugins/loader-runtime-core.ts
+++ b/src/plugins/loader-runtime-core.ts
@@ -31,6 +31,7 @@ import { pluginLoaderCacheState } from "./registry-lifecycle.js";
 import { getPluginRegistryRuntime } from "./registry-runtime-binding.js";
 import { createPluginRegistry, type PluginRegistry } from "./registry.js";
 import { getActivePluginRegistry } from "./runtime.js";
+import { setPluginRuntimeLoadContext } from "./runtime/load-context.js";
 import type { PluginRuntime } from "./runtime/types.js";
 
 type PluginModuleLoaderOverrides = Pick<
@@ -173,6 +174,23 @@ export function loadOpenClawPluginsCore(
         emitWarning: context.shouldActivate,
         warningCacheKey: context.cacheKey,
       });
+    // Raw and prepared loads share one owner; absent workspace means shared-root scope.
+    setPluginRuntimeLoadContext(
+      registry,
+      {
+        rawConfig: options.config ?? {},
+        config: context.cfg,
+        activationSourceConfig: context.activationSourceConfig,
+        autoEnabledReasons: context.autoEnabledReasons,
+        workspaceDir: options.workspaceDir,
+        env: context.env,
+        logger,
+        manifestRegistry,
+        installRecords: context.installRecords,
+        preferBuiltPluginArtifacts: options.preferBuiltPluginArtifacts,
+      },
+      context.registrationConfigKey,
+    );
     const selectedMiddlewareOwnerManifests = new Map<
       string,
       (typeof manifestRegistry.plugins)[number]

--- a/src/plugins/manifest-model-id-normalization.test.ts
+++ b/src/plugins/manifest-model-id-normalization.test.ts
@@ -4,12 +4,12 @@ import path from "node:path";
 import { normalizeConfiguredProviderCatalogModelId } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { normalizeStaticProviderModelId } from "../agents/model-ref-shared.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { withPluginMetadataSnapshotScope } from "./current-plugin-metadata-snapshot.js";
 import { setCurrentPluginMetadataSnapshot } from "./current-plugin-metadata.test-support.js";
 import { writePersistedInstalledPluginIndexSync } from "./installed-plugin-index-store-write.js";
 import { listOpenClawPluginManifestMetadata } from "./manifest-metadata-scan.js";
-import { normalizeProviderModelIdWithManifest } from "./manifest-model-id-normalization.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 // Registers the snapshot resolver in the runtime bridge slot. Production and
 // jiti load it via the bridge's require fallback; vitest workers lack a CJS TS
@@ -89,11 +89,8 @@ function writeNormalizerManifest(params: { pluginDir: string; prefix: string }):
   );
 }
 
-function normalizeDemoModel(modelId = "demo-model"): string | undefined {
-  return normalizeProviderModelIdWithManifest({
-    provider: "demo",
-    context: { provider: "demo", modelId },
-  });
+function normalizeDemoModel(modelId = "demo-model"): string {
+  return normalizeStaticProviderModelId("demo", modelId);
 }
 
 describe("manifest model id normalization", () => {
@@ -128,7 +125,7 @@ describe("manifest model id normalization", () => {
       });
 
     expect(normalize(snapshot)).toBe("scoped/demo-model");
-    expect(normalize(narrowed)).toBeUndefined();
+    expect(normalize(narrowed)).toBe("demo-model");
     expect(normalizeConfiguredProviderCatalogModelId("demo", "demo-model")).toBe(
       "scoped/demo-model",
     );

--- a/src/plugins/manifest-model-id-normalization.ts
+++ b/src/plugins/manifest-model-id-normalization.ts
@@ -1,7 +1,6 @@
 /** Applies manifest-declared model-id normalization policies to provider model refs. */
 import {
   collectManifestModelIdNormalizationPolicies,
-  normalizeProviderModelIdWithPolicies,
   type ManifestModelIdNormalizationProvider,
 } from "@openclaw/model-catalog-core/provider-model-id-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -57,23 +56,4 @@ export function resolveManifestModelIdNormalizationPolicies(
     allowWorkspaceScopedCurrent: true,
   });
   return snapshot ? snapshot.owners.modelIdNormalizationPolicies : new Map();
-}
-
-/** Normalizes a provider model id using plugin manifest-declared model-id policies. */
-export function normalizeProviderModelIdWithManifest(params: {
-  provider: string;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  plugins?: ManifestModelIdNormalizationSource;
-  context: {
-    provider: string;
-    modelId: string;
-  };
-}): string | undefined {
-  return normalizeProviderModelIdWithPolicies({
-    provider: params.provider,
-    policies: resolveManifestModelIdNormalizationPolicies(params),
-    context: params.context,
-  });
 }

--- a/src/plugins/plugin-metadata-snapshot.test.ts
+++ b/src/plugins/plugin-metadata-snapshot.test.ts
@@ -1,6 +1,7 @@
 // Verifies lifecycle snapshot loading, ownership facts, and immutable boundaries.
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { makeTempDir } from "../../test/helpers/temp-dir.js";
+import { normalizeStaticProviderModelId } from "../agents/model-ref-shared.js";
 import { resolveDefaultModelForAgent } from "../agents/model-selection-config.js";
 import { buildConfiguredModelCatalog } from "../agents/model-selection-shared.js";
 import {
@@ -26,7 +27,6 @@ import {
 } from "./current-plugin-metadata.test-support.js";
 import type { PluginDiscoveryResult } from "./discovery.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
-import { normalizeProviderModelIdWithManifest } from "./manifest-model-id-normalization.js";
 import { loadPluginManifestRegistryCore } from "./manifest-registry.js";
 import {
   createPluginCache,
@@ -38,6 +38,7 @@ import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.
 import {
   completePluginMetadataSnapshot,
   loadPluginMetadataSnapshot,
+  projectPluginMetadataSnapshot,
   resolvePluginMetadataSnapshot,
   restorePluginMetadataSnapshot,
 } from "./plugin-metadata-snapshot.js";
@@ -95,6 +96,34 @@ function mockSchemaSnapshotSource(
 }
 
 describe("plugin metadata snapshot", () => {
+  it("keeps strict declared ownership separate from public aliases and last-winner views", () => {
+    const snapshot = restorePluginMetadataSnapshot(
+      createPluginMetadataSnapshotFixture({
+        plugins: [
+          { id: "literal-owner", providers: ["literal"] },
+          { id: "alias-owner", providers: ["other"], providerAuthAliases: { literal: "other" } },
+          { id: "literal-owner", providers: ["ignored-later-declaration"] },
+          { id: "setup-owner", setup: { providers: [{ id: "literal" }, { id: "setup-only" }] } },
+        ],
+      }),
+    );
+    expect([...(snapshot.declaredProviderOwners.get("literal") ?? [])]).toEqual(["literal-owner"]);
+    expect(snapshot.declaredProviderOwners.has("ignored-later-declaration")).toBe(false);
+    expect(snapshot.owners.providers.get("literal")).toEqual(["literal-owner", "alias-owner"]);
+    expect(snapshot.byPluginId.get("literal-owner")?.providers).toEqual([
+      "ignored-later-declaration",
+    ]);
+    const projected = projectPluginMetadataSnapshot(snapshot, ["setup-owner"]);
+    expect([...(projected.declaredProviderOwners.get("literal") ?? [])]).toEqual(["setup-owner"]);
+    expect(projectPluginMetadataSnapshot(snapshot, []).declaredProviderOwners.size).toBe(0);
+    expect(() => (snapshot.declaredProviderOwners as Map<string, Set<string>>).clear()).toThrow(
+      "Plugin metadata snapshots are immutable",
+    );
+    expect(() =>
+      (snapshot.declaredProviderOwners.get("literal") as Set<string>).add("foreign"),
+    ).toThrow("Plugin metadata snapshots are immutable");
+  });
+
   beforeEach(() => {
     loadPluginRegistrySnapshotWithMetadata.mockReset();
     loadPluginManifestRegistryForInstalledIndex.mockReset();
@@ -762,18 +791,8 @@ describe("plugin metadata snapshot", () => {
       snapshot,
       () => {
         for (let repeat = 0; repeat < 4; repeat += 1) {
-          expect(
-            normalizeProviderModelIdWithManifest({
-              provider: " DEMO ",
-              context: { provider: "demo", modelId: "latest" },
-            }),
-          ).toBe("middle-model");
-          expect(
-            normalizeProviderModelIdWithManifest({
-              provider: "missing",
-              context: { provider: "missing", modelId: "latest" },
-            }),
-          ).toBeUndefined();
+          expect(normalizeStaticProviderModelId(" DEMO ", "latest")).toBe("middle-model");
+          expect(normalizeStaticProviderModelId("missing", "latest")).toBe("latest");
           expect(resolveDefaultModelForAgent({ cfg })).toEqual({
             provider: "demo",
             model: "final-model",
@@ -782,13 +801,12 @@ describe("plugin metadata snapshot", () => {
             { provider: "demo", id: "middle-model" },
           ]);
         }
-        const context = { provider: "demo", modelId: "latest" };
-        expect(
-          normalizeProviderModelIdWithManifest({ provider: "demo", context, plugins: [] }),
-        ).toBeUndefined();
+        expect(normalizeStaticProviderModelId("demo", "latest", { manifestPlugins: [] })).toBe(
+          "latest",
+        );
         const providers = { demo: { aliases: { latest: "explicit-model" } } };
         const plugins = [{ modelIdNormalization: { providers } }];
-        expect(normalizeProviderModelIdWithManifest({ provider: "demo", context, plugins })).toBe(
+        expect(normalizeStaticProviderModelId("demo", "latest", { manifestPlugins: plugins })).toBe(
           "explicit-model",
         );
         plugins.splice(0, 1, {
@@ -796,7 +814,7 @@ describe("plugin metadata snapshot", () => {
             providers: { demo: { aliases: { latest: "changed-explicit-model" } } },
           },
         });
-        expect(normalizeProviderModelIdWithManifest({ provider: "demo", context, plugins })).toBe(
+        expect(normalizeStaticProviderModelId("demo", "latest", { manifestPlugins: plugins })).toBe(
           "changed-explicit-model",
         );
       },

--- a/src/plugins/plugin-metadata-snapshot.ts
+++ b/src/plugins/plugin-metadata-snapshot.ts
@@ -48,6 +48,7 @@ import type {
 import { createPluginRegistryIdNormalizer } from "./plugin-registry-id-normalizer.js";
 import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry-snapshot.js";
 import { normalizePluginIdScope, serializePluginIdScope } from "./plugin-scope.js";
+import { buildDeclaredProviderOwnerIndex } from "./provider-owner-index.js";
 
 const MAX_PLUGIN_METADATA_PROJECTIONS = 64;
 export type {
@@ -230,6 +231,18 @@ function buildPluginMetadataOwnerMaps(
   return { ...owners, ...buildPluginMetadataProviderFacts(plugins) };
 }
 
+function buildPluginMetadataManifestFacts(manifestRegistry: PluginManifestRegistry) {
+  const plugins = manifestRegistry.plugins;
+  return {
+    manifestRegistry,
+    plugins,
+    diagnostics: manifestRegistry.diagnostics,
+    byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
+    owners: buildPluginMetadataOwnerMaps(plugins),
+    declaredProviderOwners: buildDeclaredProviderOwnerIndex(plugins),
+  };
+}
+
 export function listPluginOriginsFromMetadataSnapshot(
   snapshot: Pick<PluginMetadataSnapshot, "plugins">,
 ): ReadonlyMap<string, PluginManifestRecord["origin"]> {
@@ -240,23 +253,23 @@ export function listPluginOriginsFromMetadataSnapshot(
 export function rebasePluginMetadataSnapshotManifestRegistry(
   snapshot: Omit<
     PluginMetadataSnapshot,
-    "manifestRegistry" | "plugins" | "diagnostics" | "byPluginId" | "owners"
+    | "manifestRegistry"
+    | "plugins"
+    | "diagnostics"
+    | "byPluginId"
+    | "owners"
+    | "declaredProviderOwners"
   >,
   manifestRegistry: PluginManifestRegistry,
 ): PluginMetadataSnapshot {
-  const plugins = manifestRegistry.plugins;
   const rebased = {
     ...snapshot,
-    manifestRegistry,
-    plugins,
-    diagnostics: manifestRegistry.diagnostics,
-    byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
+    ...buildPluginMetadataManifestFacts(manifestRegistry),
     normalizePluginId: snapshot.index
       ? createPluginRegistryIdNormalizer(snapshot.index, { manifestRegistry })
       : snapshot.normalizePluginId,
-    owners: buildPluginMetadataOwnerMaps(plugins),
     ...(snapshot.metrics
-      ? { metrics: { ...snapshot.metrics, manifestPluginCount: plugins.length } }
+      ? { metrics: { ...snapshot.metrics, manifestPluginCount: manifestRegistry.plugins.length } }
       : {}),
   };
   // Rebuilt views retain the original generation even when consumed in another scope.
@@ -562,9 +575,8 @@ function loadPluginMetadataSnapshotImpl(
     includeDisabled: true,
   });
   const manifestRegistryMs = performance.now() - manifestStartedAt;
-  const byPluginId = new Map(manifestRegistry.plugins.map((plugin) => [plugin.id, plugin]));
   const ownerMapsStartedAt = performance.now();
-  const owners = buildPluginMetadataOwnerMaps(manifestRegistry.plugins);
+  const manifestFacts = buildPluginMetadataManifestFacts(manifestRegistry);
   const ownerMapsMs = performance.now() - ownerMapsStartedAt;
   const totalMs = performance.now() - totalStartedAt;
 
@@ -578,15 +590,11 @@ function loadPluginMetadataSnapshotImpl(
       policyHash: index.policyHash,
       workspaceDir: params.workspaceDir,
     }),
-    ...(params.workspaceDir ? { workspaceDir: params.workspaceDir } : {}),
+    workspaceDir: params.workspaceDir,
     index,
     registryIndex: index,
     registryDiagnostics: registryResult.diagnostics,
-    manifestRegistry,
-    plugins: manifestRegistry.plugins,
-    diagnostics: manifestRegistry.diagnostics,
-    byPluginId,
-    owners,
+    ...manifestFacts,
     metrics: {
       registrySnapshotMs,
       manifestRegistryMs,

--- a/src/plugins/plugin-metadata-snapshot.types.ts
+++ b/src/plugins/plugin-metadata-snapshot.types.ts
@@ -12,6 +12,7 @@ import type {
   PluginRegistrySnapshotDiagnostic,
   PluginRegistrySnapshotSource,
 } from "./plugin-registry-snapshot.types.js";
+import type { DeclaredProviderOwnerIndex } from "./provider-owner-index.js";
 
 export type PluginMetadataSnapshotPluginIdScope = {
   resolve: (params: { index: InstalledPluginIndex }) => readonly string[] | undefined;
@@ -67,14 +68,17 @@ export type PluginMetadataSnapshot = {
   byPluginId: ReadonlyMap<string, PluginManifestRecord>;
   normalizePluginId: (pluginId: string) => string;
   owners: PluginMetadataSnapshotOwnerMaps;
+  /** Strict first-winner literal/setup ownership, separate from public alias maps. */
+  declaredProviderOwners: DeclaredProviderOwnerIndex;
   metrics: PluginMetadataSnapshotMetrics;
   discovery?: PluginDiscoveryResult;
 };
 
 export type PluginMetadataRegistryView = Pick<
   PluginMetadataSnapshot,
-  "index" | "manifestRegistry" | "discovery"
->;
+  "index" | "manifestRegistry" | "discovery" | "workspaceDir"
+> &
+  Partial<Pick<PluginMetadataSnapshot, "declaredProviderOwners">>;
 
 export type PluginMetadataManifestView = Pick<PluginMetadataSnapshot, "index" | "plugins">;
 

--- a/src/plugins/plugin-registry-contributions.current-snapshot.test.ts
+++ b/src/plugins/plugin-registry-contributions.current-snapshot.test.ts
@@ -15,6 +15,7 @@ import {
   resolveManifestContractPluginIds,
 } from "./plugin-registry-contributions.js";
 import { loadPluginRegistrySnapshotWithMetadata } from "./plugin-registry-snapshot.js";
+import { buildDeclaredProviderOwnerIndex } from "./provider-owner-index.js";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -80,6 +81,7 @@ function createSnapshot(params: {
     diagnostics: [],
     byPluginId: new Map(plugins.map((plugin) => [plugin.id, plugin])),
     normalizePluginId: (pluginId: string) => pluginId,
+    declaredProviderOwners: buildDeclaredProviderOwnerIndex(plugins),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/plugins/plugin-runtime-artifact-resolution.ts
+++ b/src/plugins/plugin-runtime-artifact-resolution.ts
@@ -1,46 +1,25 @@
 /** Resolves the exact root and entry selected by the plugin runtime loader. */
 import path from "node:path";
-import type { OpenClawPackageManifest } from "./manifest.js";
-import { pluginCacheExistsSync, pluginCacheRealpathSync } from "./plugin-cache-files.js";
-import { getPluginCacheRoot } from "./plugin-cache.js";
-import type { PluginOrigin } from "./plugin-origin.types.js";
-import { resolvePreferredBuiltRuntimeArtifact } from "./plugin-runtime-artifact-selection.js";
+import { pluginCacheRealpathSync } from "./plugin-cache-files.js";
+import {
+  resolveCanonicalDistRuntimeSource,
+  resolvePluginRuntimeArtifactSelection,
+  type PluginRuntimeArtifactSelectionParams,
+} from "./plugin-runtime-artifact-selection.js";
 import type { PluginRegistry } from "./registry-types.js";
 import { getActivePluginRegistry, requireActivePluginRegistry } from "./runtime.js";
-
-type PluginRuntimeArtifactEntryKind =
-  | "runtime"
-  | "setup"
-  | "provider-discovery"
-  | "capability-catalog";
 
 export function clearPluginRuntimeArtifactResolutionMemo(): void {
   getActivePluginRegistry()?.pluginRuntimeArtifacts.clear();
 }
 
-/** Canonical packaged runtime replaces staging-only dist-runtime artifacts. */
-export function resolveCanonicalDistRuntimeSource(source: string): string {
-  const marker = `${path.sep}dist-runtime${path.sep}extensions${path.sep}`;
-  const index = source.indexOf(marker);
-  if (index === -1) {
-    return source;
-  }
-  const candidate = `${source.slice(0, index)}${path.sep}dist${path.sep}extensions${path.sep}${source.slice(index + marker.length)}`;
-  return pluginCacheExistsSync(candidate) ? candidate : source;
-}
-
 /** Applies both loader selection phases in their runtime order. */
-export function resolvePluginRuntimeArtifact(params: {
-  pluginId: string;
-  entryKind: PluginRuntimeArtifactEntryKind;
-  source: string;
-  rootDir: string;
-  origin: PluginOrigin;
-  preferBuiltPluginArtifacts: boolean;
-  sourcePreferred?: boolean;
-  packageManifest?: OpenClawPackageManifest;
-  registry?: PluginRegistry;
-}): { source: string; rootDir: string } {
+export function resolvePluginRuntimeArtifact(
+  params: PluginRuntimeArtifactSelectionParams & {
+    pluginId: string;
+    registry?: PluginRegistry;
+  },
+): { source: string; rootDir: string } {
   const rootDir = resolveCanonicalDistRuntimeSource(
     pluginCacheRealpathSync(params.rootDir) ?? path.resolve(params.rootDir),
   );
@@ -50,27 +29,7 @@ export function resolvePluginRuntimeArtifact(params: {
   if (cached) {
     return { ...cached };
   }
-  const artifacts = getPluginCacheRoot(rootDir).runtimeArtifacts;
-  const selectionKey = JSON.stringify([
-    params.source,
-    params.entryKind,
-    params.origin,
-    params.preferBuiltPluginArtifacts,
-    params.sourcePreferred,
-    params.packageManifest?.build?.bundledDist,
-  ]);
-  let resolved = artifacts.get(selectionKey);
-  if (!resolved) {
-    const source = resolveCanonicalDistRuntimeSource(
-      pluginCacheRealpathSync(params.source) ?? path.resolve(params.source),
-    );
-    const preferred = resolvePreferredBuiltRuntimeArtifact({ ...params, source, rootDir });
-    resolved = {
-      source: resolveCanonicalDistRuntimeSource(preferred.source),
-      rootDir: resolveCanonicalDistRuntimeSource(preferred.rootDir),
-    };
-    artifacts.set(selectionKey, resolved);
-  }
+  const resolved = resolvePluginRuntimeArtifactSelection(params);
   // A registry binds hooks and tools to one entry even when callers disagree on
   // source/build preference. Only filesystem selection facts belong to the cache.
   targetRegistry.pluginRuntimeArtifacts.set(memoKey, resolved);

--- a/src/plugins/plugin-runtime-artifact-selection.ts
+++ b/src/plugins/plugin-runtime-artifact-selection.ts
@@ -15,8 +15,167 @@ import {
 } from "./plugin-cache-files.js";
 import { getPluginCacheRoot } from "./plugin-cache.js";
 import type { PluginOrigin } from "./plugin-origin.types.js";
+import type { PluginRecord } from "./registry-types.js";
 
 export type PluginRuntimeArtifactPreference = "source" | "bundled" | "all";
+type PluginRuntimeArtifact = { source: string; rootDir: string };
+export type PluginRuntimeArtifactSelectionParams = PluginRuntimeArtifact & {
+  entryKind: "runtime" | "setup" | "provider-discovery" | "capability-catalog";
+  origin: PluginOrigin;
+  preferBuiltPluginArtifacts: boolean;
+  sourcePreferred?: boolean;
+  packageManifest?: OpenClawPackageManifest;
+};
+
+const RUNTIME_ARTIFACT_SELECTION = Symbol.for("openclaw.pluginRuntimeArtifactSelection");
+type RuntimeArtifactSelection = {
+  sourcePreferred: boolean;
+  sourceExternal: boolean;
+  runtimeEntry: PluginRuntimeArtifact;
+  setupEntry?: PluginRuntimeArtifact;
+  preferBuiltPluginArtifacts?: boolean;
+  runtimeRegistrationComplete: boolean;
+};
+type ArtifactBoundRecord = PluginRecord & {
+  [RUNTIME_ARTIFACT_SELECTION]?: RuntimeArtifactSelection;
+};
+
+type RuntimeArtifactSelectionInput = {
+  sourcePreferred?: boolean;
+  setupSource?: string;
+  packageManifest?: OpenClawPackageManifest;
+  preferBuiltPluginArtifacts?: boolean;
+};
+
+/** Preserve selection inputs on the loaded owner, outside status/protocol serialization. */
+export function bindPluginRuntimeArtifactSelection(
+  record: PluginRecord,
+  params: RuntimeArtifactSelectionInput & {
+    runtimeEntry: PluginRuntimeArtifact;
+    setupEntry?: PluginRuntimeArtifact;
+  },
+): RuntimeArtifactSelection {
+  const selection = {
+    sourcePreferred: params.sourcePreferred === true,
+    sourceExternal: params.packageManifest?.build?.bundledDist === false,
+    runtimeEntry: params.runtimeEntry,
+    setupEntry: params.setupEntry,
+    preferBuiltPluginArtifacts: params.preferBuiltPluginArtifacts,
+    runtimeRegistrationComplete: false,
+  };
+  Object.defineProperty(record, RUNTIME_ARTIFACT_SELECTION, { value: selection });
+  return selection;
+}
+
+export function hasCompletedPluginRuntimeRegistration(record: ArtifactBoundRecord): boolean {
+  return (
+    record.status === "loaded" &&
+    record[RUNTIME_ARTIFACT_SELECTION]?.runtimeRegistrationComplete === true
+  );
+}
+
+export function matchesPluginRuntimeArtifactSelection(
+  record: ArtifactBoundRecord,
+  params: RuntimeArtifactSelectionInput & { rootDir: string; source: string },
+  preferBuiltPluginArtifacts?: boolean,
+): boolean {
+  const loaded = record[RUNTIME_ARTIFACT_SELECTION];
+  if (
+    (loaded?.sourcePreferred === true) !== (params.sourcePreferred === true) ||
+    (loaded?.sourceExternal === true) !== (params.packageManifest?.build?.bundledDist === false) ||
+    // Bounded reuse keeps an unspecified policy; exact loads compare the full loader key.
+    (preferBuiltPluginArtifacts !== undefined &&
+      loaded?.preferBuiltPluginArtifacts !== preferBuiltPluginArtifacts)
+  ) {
+    return false;
+  }
+  if (!loaded) {
+    // Bundle-format records are metadata-only and never select executable artifacts.
+    return (
+      record.format === "bundle" &&
+      record.rootDir === params.rootDir &&
+      record.source === params.source
+    );
+  }
+  // Source/build names alone do not prove shared execution. Compare the loader's
+  // selected artifacts while retaining the policy that produced this owner.
+  const matchesEntry = (
+    entry: PluginRuntimeArtifact,
+    source: string,
+    entryKind: "runtime" | "setup",
+  ): boolean => {
+    const selected = resolvePluginRuntimeExecutionArtifact(
+      resolvePluginRuntimeArtifactSelection({
+        ...params,
+        source,
+        entryKind,
+        origin: record.origin,
+        preferBuiltPluginArtifacts: loaded.preferBuiltPluginArtifacts === true,
+      }),
+    );
+    return entry.rootDir === selected.rootDir && entry.source === selected.source;
+  };
+  return (
+    matchesEntry(loaded.runtimeEntry, params.source, "runtime") &&
+    (!loaded.setupEntry ||
+      (params.setupSource !== undefined &&
+        matchesEntry(loaded.setupEntry, params.setupSource, "setup")))
+  );
+}
+
+/** Canonical packaged runtime replaces staging-only dist-runtime artifacts. */
+export function resolveCanonicalDistRuntimeSource(source: string): string {
+  const marker = `${path.sep}dist-runtime${path.sep}extensions${path.sep}`;
+  const index = source.indexOf(marker);
+  if (index === -1) {
+    return source;
+  }
+  const candidate = `${source.slice(0, index)}${path.sep}dist${path.sep}extensions${path.sep}${source.slice(index + marker.length)}`;
+  return pluginCacheExistsSync(candidate) ? candidate : source;
+}
+
+/** Finalize once at execution; discovery and identity retain the selected artifact. */
+export function resolvePluginRuntimeExecutionArtifact(
+  selected: PluginRuntimeArtifact,
+): PluginRuntimeArtifact {
+  // This is the loader's existing final pass, not recursive normalization:
+  // nested staging paths can make another pass select a different file.
+  return {
+    source: resolveCanonicalDistRuntimeSource(selected.source),
+    rootDir: resolveCanonicalDistRuntimeSource(selected.rootDir),
+  };
+}
+
+/** Selects from lifecycle-owned package facts without pinning a runtime registry. */
+export function resolvePluginRuntimeArtifactSelection(
+  params: PluginRuntimeArtifactSelectionParams,
+): PluginRuntimeArtifact {
+  const rootDir = resolveCanonicalDistRuntimeSource(
+    pluginCacheRealpathSync(params.rootDir) ?? path.resolve(params.rootDir),
+  );
+  const artifacts = getPluginCacheRoot(rootDir).runtimeArtifacts;
+  const key = JSON.stringify([
+    params.source,
+    params.entryKind,
+    params.origin,
+    params.preferBuiltPluginArtifacts,
+    params.sourcePreferred,
+    params.packageManifest?.build?.bundledDist,
+  ]);
+  let resolved = artifacts.get(key);
+  if (!resolved) {
+    const source = resolveCanonicalDistRuntimeSource(
+      pluginCacheRealpathSync(params.source) ?? path.resolve(params.source),
+    );
+    const preferred = resolvePreferredBuiltRuntimeArtifact({ ...params, source, rootDir });
+    resolved = {
+      source: resolveCanonicalDistRuntimeSource(preferred.source),
+      rootDir: resolveCanonicalDistRuntimeSource(preferred.rootDir),
+    };
+    artifacts.set(key, resolved);
+  }
+  return resolved;
+}
 
 /** Built hosts default only checkout plugins to compiled execution, not installed packages. */
 export function resolvePluginRuntimeArtifactPreference(
@@ -170,7 +329,7 @@ export function resolvePreferredBundledRootArtifact(params: {
 }
 
 /** Applies source, package-local, and root-build preference without runtime memo state. */
-export function resolvePreferredBuiltRuntimeArtifact(params: {
+function resolvePreferredBuiltRuntimeArtifact(params: {
   source: string;
   rootDir: string;
   origin: PluginOrigin;

--- a/src/plugins/provider-hook-runtime-core.ts
+++ b/src/plugins/provider-hook-runtime-core.ts
@@ -1,25 +1,15 @@
 import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
-import {
-  normalizeLowercaseStringOrEmpty,
-  normalizeOptionalString,
-} from "@openclaw/normalization-core/string-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { attachModelProviderLocalServiceReconciler } from "../agents/provider-local-service-reconcile.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import {
-  getLoadedRuntimePluginRegistry,
-  registryContainsRuntimePluginIds,
-} from "./active-runtime-registry.js";
 import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
 import {
   resolveModelCatalogScope,
   resolveProviderConfigApiOwnerHint,
 } from "./provider-config-owner.js";
+import { findProviderRuntimePluginInRegistry } from "./provider-registry-selection.js";
 import { matchesProviderPluginRef } from "./provider-registry-shared.js";
 import type { createProviderRegistryResolver } from "./providers.runtime-core.js";
-import type { PluginRegistry } from "./registry-types.js";
-import { getActivePluginRegistryWorkspaceDirFromState } from "./runtime-state.js";
-import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
-import { getPluginRuntimeGenerationRegistry } from "./runtime/generation-scope.js";
 import type {
   ProviderPlugin,
   ProviderResolveAuthProfileIdContext,
@@ -67,8 +57,7 @@ type ProviderHookParams<TContext> = {
 export function createProviderHookRuntime(
   providers: ReturnType<typeof createProviderRegistryResolver>,
 ) {
-  const { isPluginProvidersLoadInFlight, resolvePluginProvidersCore } = providers;
-
+  const { resolvePluginProviderRegistryCore, resolvePluginProvidersCore } = providers;
   /** Carries one attempt's prepared provider plugin through the model transport boundary. */
   function attachModelProviderRuntimePluginHandle<TModel extends object>(
     model: TModel,
@@ -93,45 +82,12 @@ export function createProviderHookRuntime(
       : undefined;
   }
 
-  function matchesProviderLiteralId(provider: ProviderPlugin, providerId: string): boolean {
-    const normalized = normalizeLowercaseStringOrEmpty(providerId);
-    return Boolean(normalized) && normalizeLowercaseStringOrEmpty(provider.id) === normalized;
-  }
-
   function resolveProviderRuntimeLookupModelId(
     params: ProviderRuntimePluginLookupParams & { context?: { modelId?: unknown } },
   ): string | undefined {
     return normalizeOptionalString(
       params.modelId ??
         (typeof params.context?.modelId === "string" ? params.context.modelId : undefined),
-    );
-  }
-
-  function findProviderRuntimePluginInLoadedRegistries(params: {
-    lookup: ProviderRuntimePluginLookupParams;
-    ownerRefs: readonly string[];
-  }): ProviderPlugin | undefined {
-    const find = (registry: PluginRegistry | undefined): ProviderPlugin | undefined => {
-      const entry = registry?.providers.find(({ provider: plugin }) =>
-        params.ownerRefs.length > 0
-          ? matchesProviderLiteralId(plugin, params.lookup.provider) ||
-            params.ownerRefs.some((ownerRef) => matchesProviderPluginRef(plugin, ownerRef))
-          : matchesProviderPluginRef(plugin, params.lookup.provider),
-      );
-      return entry ? Object.assign({}, entry.provider, { pluginId: entry.pluginId }) : undefined;
-    };
-    const generationRegistry = getPluginRuntimeGenerationRegistry();
-    if (generationRegistry) {
-      return find(generationRegistry);
-    }
-    return (
-      find(getPluginRuntimeGatewayRequestScope()?.pluginRegistry) ??
-      find(
-        getLoadedRuntimePluginRegistry({
-          env: params.lookup.env,
-          workspaceDir: params.lookup.workspaceDir,
-        }),
-      )
     );
   }
 
@@ -154,104 +110,45 @@ export function createProviderHookRuntime(
     applyAutoEnable?: boolean;
     pluginMetadataSnapshot?: PluginMetadataRegistryView;
   }): ProviderPlugin[] | undefined {
-    const onlyPluginIds = params.onlyPluginIds ? new Set(params.onlyPluginIds) : undefined;
-    const filterRegistryPlugins = (registry: PluginRegistry) =>
-      registry.providers
-        .filter(
-          ({ pluginId, provider }) =>
-            (!onlyPluginIds || onlyPluginIds.has(pluginId)) &&
-            (!params.providerRefs?.length ||
-              params.providerRefs.some((providerRef) =>
-                matchesProviderPluginRef(provider, providerRef),
-              )),
-        )
-        .map(({ pluginId, provider }) => Object.assign({}, provider, { pluginId }));
-    const generationRegistry = getPluginRuntimeGenerationRegistry();
-    if (generationRegistry) {
-      return filterRegistryPlugins(generationRegistry);
-    }
-    // An empty generation is authoritative. Outside a generation, only a loaded
-    // hit proves the registry serves this query; preparation may discover on a miss.
-    const readLoadedRegistry = (registry: PluginRegistry | undefined) => {
-      if (registry && registryContainsRuntimePluginIds(registry, params.onlyPluginIds)) {
-        const plugins = filterRegistryPlugins(registry);
-        return plugins.length > 0 ? plugins : undefined;
-      }
+    const resolved = resolvePluginProviderRegistryCore({ ...params, registryScope: "loaded" });
+    if (!resolved) {
       return undefined;
-    };
-    return (
-      readLoadedRegistry(getPluginRuntimeGatewayRequestScope()?.pluginRegistry) ??
-      readLoadedRegistry(
-        getLoadedRuntimePluginRegistry({
-          env: params.env ?? process.env,
-          workspaceDir: params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState(),
-          requiredPluginIds: params.onlyPluginIds,
-        }),
+    }
+    return resolved.registry.providers
+      .filter(
+        ({ pluginId, provider }) =>
+          (!resolved.onlyPluginIds || resolved.onlyPluginIds.includes(pluginId)) &&
+          (!params.providerRefs?.length ||
+            params.providerRefs.some((ref) => matchesProviderPluginRef(provider, ref))),
       )
-    );
+      .map(({ pluginId, provider }) => Object.assign({}, provider, { pluginId }));
   }
 
   function resolveProviderPluginsForHooks(
     params: Parameters<typeof resolveLoadedProviderPluginsForHooks>[0],
   ): ProviderPlugin[] {
-    const loaded = resolveLoadedProviderPluginsForHooks(params);
-    if (loaded) {
-      return loaded;
-    }
     return resolvePluginProvidersCore({
       ...params,
-      workspaceDir: params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState(),
-      env: params.env ?? process.env,
       activate: false,
       applyAutoEnable: params.applyAutoEnable,
       skipIfLoadInFlight: true,
     });
   }
 
-  function resolveProviderRuntimePlugin(
+  function resolveProviderRuntimePluginLookup(
     params: ProviderRuntimePluginLookupParams,
-  ): ProviderPlugin | undefined {
-    const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState();
-    const env = params.env ?? process.env;
-    const lookup = { ...params, workspaceDir, env };
-    const apiOwnerHint = resolveProviderConfigApiOwnerHint({
-      provider: params.provider,
-      config: params.config,
-    });
+    registryScope?: "loaded",
+  ): ProviderRuntimePluginHandle {
+    const apiOwnerHint = resolveProviderConfigApiOwnerHint(params);
     const ownerRefs = [
       ...new Set(
         [params.providerOwner, apiOwnerHint].filter((owner): owner is string => Boolean(owner)),
       ),
     ];
-    const providerRefs = [params.provider, ...ownerRefs];
-    const loadedPlugin = findProviderRuntimePluginInLoadedRegistries({
-      lookup,
-      ownerRefs,
-    });
-    if (loadedPlugin) {
-      return loadedPlugin;
-    }
-    if (getPluginRuntimeGenerationRegistry()) {
-      return undefined;
-    }
-    if (
-      isPluginProvidersLoadInFlight({
-        ...params,
-        workspaceDir,
-        env,
-        providerRefs,
-        activate: false,
-        applyAutoEnable: params.applyAutoEnable,
-      })
-    ) {
-      return undefined;
-    }
     const modelId = resolveProviderRuntimeLookupModelId(params);
-    return resolveProviderPluginsForHooks({
-      config: params.config,
-      workspaceDir,
-      env,
-      providerRefs,
+    const selection = resolvePluginProviderRegistryCore({
+      ...params,
+      providerRefs: [params.provider, ...ownerRefs],
       modelRefs: modelId
         ? resolveModelCatalogScope({
             cfg: params.config,
@@ -259,35 +156,34 @@ export function createProviderHookRuntime(
             model: modelId,
           }).modelRefs
         : undefined,
-      applyAutoEnable: params.applyAutoEnable,
-      pluginMetadataSnapshot: params.pluginMetadataSnapshot,
-    }).find((plugin) => {
-      if (ownerRefs.length > 0) {
-        return (
-          matchesProviderLiteralId(plugin, params.provider) ||
-          ownerRefs.some((ownerRef) => matchesProviderPluginRef(plugin, ownerRef))
-        );
-      }
-      return matchesProviderPluginRef(plugin, params.provider);
+      registryScope,
+      activate: false,
+      skipIfLoadInFlight: true,
     });
+    return {
+      ...params,
+      ...(selection ? { workspaceDir: selection.workspaceDir } : {}),
+      plugin: selection
+        ? findProviderRuntimePluginInRegistry({
+            registry: selection.registry,
+            provider: params.provider,
+            ownerRefs,
+            isOwnerEligible: (id) => selection.isProviderOwnerEligible(id, params.provider),
+          })
+        : undefined,
+    };
+  }
+
+  function resolveProviderRuntimePlugin(
+    params: ProviderRuntimePluginLookupParams,
+  ): ProviderPlugin | undefined {
+    return resolveProviderRuntimePluginLookup(params).plugin;
   }
 
   function resolveLoadedProviderRuntimePlugin(
     params: ProviderRuntimePluginLookupParams,
   ): ProviderPlugin | undefined {
-    const apiOwnerHint = resolveProviderConfigApiOwnerHint({
-      provider: params.provider,
-      config: params.config,
-    });
-    const ownerRefs = [
-      ...new Set(
-        [params.providerOwner, apiOwnerHint].filter((owner): owner is string => Boolean(owner)),
-      ),
-    ];
-    return findProviderRuntimePluginInLoadedRegistries({
-      lookup: params,
-      ownerRefs,
-    });
+    return resolveProviderRuntimePluginLookup(params, "loaded").plugin;
   }
 
   function resolveProviderHookPlugin(params: {
@@ -304,22 +200,27 @@ export function createProviderHookRuntime(
     if (hasConfiguredModelProvider(params)) {
       return undefined;
     }
-    return resolveProviderPluginsForHooks({
+    const selection = resolvePluginProviderRegistryCore({
       config: params.config,
       workspaceDir: params.workspaceDir,
       env: params.env,
-    }).find((candidate) => matchesProviderPluginRef(candidate, params.provider));
+      activate: false,
+      skipIfLoadInFlight: true,
+    });
+    return selection
+      ? findProviderRuntimePluginInRegistry({
+          registry: selection.registry,
+          provider: params.provider,
+          ownerRefs: [],
+          isOwnerEligible: (id) => selection.isProviderOwnerEligible(id, params.provider),
+        })
+      : undefined;
   }
 
   function resolveProviderRuntimePluginHandle(
     params: ProviderRuntimePluginLookupParams,
   ): ProviderRuntimePluginHandle {
-    const lookup = {
-      ...params,
-      workspaceDir: params.workspaceDir ?? getActivePluginRegistryWorkspaceDirFromState(),
-      env: params.env,
-    };
-    return { ...lookup, plugin: resolveProviderRuntimePlugin(lookup) };
+    return resolveProviderRuntimePluginLookup(params);
   }
 
   function ensureProviderRuntimePluginHandle(

--- a/src/plugins/provider-hook-runtime.provenance.test.ts
+++ b/src/plugins/provider-hook-runtime.provenance.test.ts
@@ -1,0 +1,992 @@
+import assert from "node:assert/strict";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import {
+  clearRuntimeConfigSnapshot,
+  setRuntimeConfigSnapshot,
+} from "../config/runtime-snapshot.js";
+import { withEnv } from "../test-utils/env.js";
+import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
+import { resolvePluginLoadCacheContext } from "./loader-load-context.js";
+import { createPluginCandidatesFromManifestRegistry } from "./loader-shared.js";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  clearPluginLoaderCache,
+  EMPTY_PLUGIN_SCHEMA,
+  loadOpenClawPlugins,
+  makePluginLoaderTempDir,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
+import { createPluginMetadataSnapshotFixture } from "./plugin-metadata.test-support.js";
+import {
+  resolveLoadedProviderPluginsForHooks,
+  resolveLoadedProviderRuntimePlugin,
+  resolveProviderPluginsForHooks,
+  resolveProviderRuntimePlugin,
+  resolveProviderRuntimePluginHandle,
+} from "./provider-hook-runtime.js";
+import { resolvePluginProvidersCore } from "./providers.runtime.js";
+import { createEmptyPluginRegistry } from "./registry-empty.js";
+import { setActivePluginRegistry } from "./runtime.js";
+import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.js";
+import { withPluginRuntimeGenerationScope } from "./runtime/generation-scope.js";
+import {
+  getPluginRuntimeLoadContext,
+  setPluginRuntimeLoadContext,
+} from "./runtime/load-context.js";
+
+const config = { plugins: { allow: ["same-id"], entries: { "same-id": { enabled: true } } } };
+
+function metadata(
+  rootDir: string,
+  source = `${rootDir}/index.cjs`,
+  origin: "global" | "bundled" = "global",
+) {
+  return createPluginMetadataSnapshotFixture({
+    plugins: [
+      {
+        id: "same-id",
+        origin,
+        rootDir,
+        source,
+        providers: ["same-provider"],
+        configSchema: EMPTY_PLUGIN_SCHEMA,
+      },
+    ],
+  });
+}
+
+function registry(snapshot: ReturnType<typeof metadata>, workspaceDir?: string) {
+  return loadOpenClawPlugins({
+    config,
+    env: {},
+    workspaceDir,
+    installRecords: {},
+    onlyPluginIds: ["same-id"],
+    manifestRegistry: snapshot.manifestRegistry,
+    activate: false,
+  });
+}
+
+function loadFixture(label: string, dir?: string, hookAliases?: readonly string[]) {
+  const plugin = writePlugin({
+    id: "same-id",
+    dir,
+    filename: `${label}.cjs`,
+    body: `let registrations = 0;
+    module.exports = { id: "same-id", register(api) {
+      const registration = ++registrations;
+      api.registerProvider({ id: "same-provider", label: ${JSON.stringify(label)}, auth: [],
+        ${hookAliases ? `hookAliases: ${JSON.stringify(hookAliases)},` : ""}
+        normalizeModelId: () => String(registration) });
+    }};`,
+  });
+  writeFileSync(
+    path.join(plugin.dir, "openclaw.plugin.json"),
+    JSON.stringify({
+      id: "same-id",
+      providers: ["same-provider"],
+      configSchema: EMPTY_PLUGIN_SCHEMA,
+    }),
+  );
+  return metadata(plugin.dir, plugin.file);
+}
+
+afterEach(clearPluginLoaderCache);
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe("provider runtime physical ownership", () => {
+  it.each([undefined, "exact"] as const)(
+    "projects a cold explicitly scoped runtime alias with registryScope=%s",
+    (registryScope) => {
+      const snapshot = loadFixture("cold-alias", undefined, ["runtime-alias"]);
+      setActivePluginRegistry(createEmptyPluginRegistry());
+      const requested = {
+        config,
+        env: {},
+        pluginMetadataSnapshot: snapshot,
+        onlyPluginIds: ["same-id"],
+        providerRefs: ["runtime-alias"],
+        registryScope,
+      };
+      for (let attempt = 0; attempt < 2; attempt += 1) {
+        const providers = resolvePluginProvidersCore(requested);
+        expect(providers.map((provider) => provider.label)).toEqual(["cold-alias"]);
+        expect(
+          providers[0]?.normalizeModelId?.({ provider: "runtime-alias", modelId: "probe" }),
+        ).toBe("1");
+      }
+    },
+  );
+
+  it.each([false, true])(
+    "preserves paired source defaults during config reuse with snapshot=%s",
+    (snapshotPresent) => {
+      const plugin = writePlugin({
+        id: "same-id",
+        filename: "index.cjs",
+        body: `let registrations = 0;
+        module.exports = { id: "same-id", register(api) {
+          if (api.pluginConfig.credential !== "resolved-fixture-key") throw new Error("unhydrated fixture");
+          api.registerProvider({ id: "same-provider", label: api.pluginConfig.revision + "/" + (++registrations), auth: [] });
+        }};`,
+      });
+      writeFileSync(
+        path.join(plugin.dir, "openclaw.plugin.json"),
+        JSON.stringify({
+          id: "same-id",
+          providers: ["same-provider"],
+          configContracts: {
+            secretInputs: { paths: [{ path: "credential", expected: "string" }] },
+          },
+          configSchema: {
+            type: "object",
+            properties: {
+              credential: {
+                type: "object",
+                properties: {
+                  source: { const: "store" },
+                  provider: { type: "string" },
+                  id: { type: "string" },
+                },
+                required: ["source", "provider", "id"],
+              },
+              revision: { type: "string" },
+            },
+            required: ["credential"],
+            if: { properties: { credential: { properties: { id: { const: "KEY" } } } } },
+            // oxlint-disable-next-line unicorn/no-thenable -- JSON Schema branch data.
+            then: { properties: { revision: { default: "A" } } },
+            else: { properties: { revision: { default: "B" } } },
+            additionalProperties: false,
+          },
+        }),
+      );
+      const runtimeConfig = {
+        plugins: {
+          allow: ["same-id"],
+          load: { paths: [plugin.file] },
+          entries: { "same-id": { enabled: true, config: { credential: "resolved-fixture-key" } } },
+        },
+      };
+      const sourceFor = (id: string) => ({
+        ...runtimeConfig,
+        plugins: {
+          ...runtimeConfig.plugins,
+          entries: {
+            "same-id": {
+              enabled: true,
+              config: { credential: { source: "store", provider: "default", id } },
+            },
+          },
+        },
+      });
+      const sourceConfig = sourceFor("KEY");
+      const env = { OPENCLAW_STATE_DIR: makePluginLoaderTempDir() };
+      try {
+        setRuntimeConfigSnapshot(runtimeConfig, sourceConfig);
+        const firstSnapshot = loadPluginMetadataSnapshot({ config: runtimeConfig, env });
+        const loadOptions = {
+          config: runtimeConfig,
+          activationSourceConfig: sourceConfig,
+          env,
+          installRecords: {},
+          manifestRegistry: firstSnapshot.manifestRegistry,
+          onlyPluginIds: ["same-id"],
+          activate: false,
+        };
+        const loadedRegistry = loadOpenClawPlugins(loadOptions);
+        setActivePluginRegistry(
+          loadedRegistry,
+          resolvePluginLoadCacheContext(loadOptions).cacheKey,
+        );
+        const lookup = {
+          provider: "same-provider",
+          config: runtimeConfig,
+          env,
+          ...(snapshotPresent ? { pluginMetadataSnapshot: firstSnapshot } : {}),
+        };
+        expect(resolveLoadedProviderRuntimePlugin(lookup)?.label).toBe("A/1");
+        expect(resolveProviderRuntimePlugin(lookup)?.label).toBe("A/1");
+        setRuntimeConfigSnapshot(runtimeConfig, sourceFor("OTHER"));
+        expect(resolveLoadedProviderRuntimePlugin(lookup)).toBeUndefined();
+        expect(resolveProviderRuntimePlugin(lookup)?.label).toBe("B/2");
+        expect(
+          withPluginRuntimeGenerationScope(
+            { pluginRegistry: loadedRegistry, metadataSnapshot: firstSnapshot },
+            () => resolveProviderRuntimePlugin(lookup)?.label,
+          ),
+        ).toBe("A/1");
+        const setupProviders = resolvePluginProvidersCore({
+          ...lookup,
+          providerRefs: ["same-provider"],
+          mode: "setup",
+        });
+        expect(setupProviders).toHaveLength(1);
+        expect(setupProviders[0]?.label).toMatch(/^B\//);
+        expect(resolveProviderRuntimePlugin(lookup)?.label).toBe("B/2");
+      } finally {
+        clearRuntimeConfigSnapshot();
+      }
+    },
+  );
+
+  it.each(
+    (
+      [
+        { change: "replace", receiver: "declared" },
+        { change: "mutate", receiver: "declared" },
+        { change: "rebind", receiver: "declared" },
+        { change: "replace", receiver: "alias" },
+        { change: "replace", receiver: "removed-alias" },
+      ] as const
+    ).flatMap((variant) =>
+      [false, true].map((snapshotPresent) => ({
+        change: variant.change,
+        receiver: variant.receiver,
+        snapshotPresent,
+      })),
+    ),
+  )(
+    "keeps registration config current with snapshot=$snapshotPresent, change=$change, receiver=$receiver",
+    ({ snapshotPresent, change, receiver }) => {
+      const registrationMarker = path.join(makePluginLoaderTempDir(), "registered");
+      const plugin = writePlugin({
+        id: "same-id",
+        filename: "index.cjs",
+        body: `let registrations = 0;
+        module.exports = { id: "same-id", register(api) {
+          const captured = api.pluginConfig.revision + "/" + (++registrations);
+          require("node:fs").writeFileSync(${JSON.stringify(registrationMarker)}, captured);
+          api.registerProvider({ id: "same-provider", label: captured, auth: [],
+            hookAliases: ${receiver === "removed-alias" ? 'api.pluginConfig.revision === "A" ? ["runtime-alias"] : ["new-alias"]' : '["runtime-alias"]'},
+            normalizeModelId: () => captured });
+        }};`,
+      });
+      writeFileSync(
+        path.join(plugin.dir, "openclaw.plugin.json"),
+        JSON.stringify({
+          id: "same-id",
+          providers: ["same-provider"],
+          configSchema: {
+            type: "object",
+            properties: { revision: { type: "string" } },
+            additionalProperties: false,
+          },
+        }),
+      );
+      const configFor = (revision: string) => ({
+        plugins: {
+          allow: ["same-id"],
+          load: { paths: [plugin.file] },
+          entries: { "same-id": { enabled: true, config: { revision } } },
+        },
+      });
+      const firstConfig = configFor("A");
+      const env = { OPENCLAW_STATE_DIR: makePluginLoaderTempDir() };
+      const firstSnapshot = loadPluginMetadataSnapshot({ config: firstConfig, env });
+      const loadOptions = {
+        config: firstConfig,
+        env,
+        installRecords: {},
+        onlyPluginIds: ["same-id"],
+        manifestRegistry: firstSnapshot.manifestRegistry,
+        activate: false,
+      };
+      const loadedRegistry = loadOpenClawPlugins(loadOptions);
+      setActivePluginRegistry(loadedRegistry, resolvePluginLoadCacheContext(loadOptions).cacheKey);
+      const lookup = { provider: receiver === "declared" ? "same-provider" : "runtime-alias", env };
+      const modelOnlyConfig = { ...firstConfig, agents: { defaults: { model: "other/model" } } };
+      expect(
+        resolveLoadedProviderRuntimePlugin({ ...lookup, config: modelOnlyConfig })?.label,
+      ).toBe("A/1");
+      const nextConfig = change === "mutate" ? firstConfig : configFor("B");
+      nextConfig.plugins.entries["same-id"].config.revision = "B";
+      const nextSnapshot = loadPluginMetadataSnapshot({ config: nextConfig, env });
+      if (change === "rebind") {
+        const capturedContext = getPluginRuntimeLoadContext(loadedRegistry);
+        assert.ok(capturedContext);
+        setPluginRuntimeLoadContext(loadedRegistry, {
+          ...capturedContext,
+          rawConfig: nextConfig,
+          config: nextConfig,
+          activationSourceConfig: nextConfig,
+          metadataSnapshot: nextSnapshot,
+        });
+      }
+      const requested = {
+        ...lookup,
+        config: nextConfig,
+        ...(snapshotPresent ? { pluginMetadataSnapshot: nextSnapshot } : {}),
+      };
+      expect(
+        withPluginRuntimeGenerationScope(
+          { pluginRegistry: loadedRegistry, metadataSnapshot: firstSnapshot },
+          () => resolveProviderRuntimePlugin(requested)?.label,
+        ),
+      ).toBe("A/1");
+      expect(resolveLoadedProviderRuntimePlugin(requested)).toBeUndefined();
+      expect(readFileSync(registrationMarker, "utf8")).toBe("A/1");
+      expect(
+        resolvePluginProvidersCore({ ...requested, providerRefs: [requested.provider] }).map(
+          (provider) => provider.label,
+        ),
+      ).toEqual(receiver === "removed-alias" ? [] : ["B/2"]);
+      expect(readFileSync(registrationMarker, "utf8")).toBe("B/2");
+      expect(resolveProviderRuntimePlugin(requested)?.label).toBe(
+        receiver === "removed-alias" ? undefined : "B/2",
+      );
+    },
+  );
+
+  it("checks changed discovery selectors before borrowing registry-owned manifests", () => {
+    const old = loadFixture("old");
+    const next = loadFixture("next");
+    const stateDir = makePluginLoaderTempDir();
+    const env = { OPENCLAW_STATE_DIR: stateDir };
+    const configFor = (snapshot: typeof old) => ({
+      ...config,
+      plugins: {
+        ...config.plugins,
+        load: { paths: snapshot.plugins.map((plugin) => plugin.source) },
+      },
+    });
+    const originalConfig = configFor(old);
+    const originalSnapshot = loadPluginMetadataSnapshot({ config: originalConfig, env });
+    const loaded = loadOpenClawPlugins({
+      config: originalConfig,
+      env,
+      installRecords: {},
+      onlyPluginIds: ["same-id"],
+      manifestRegistry: originalSnapshot.manifestRegistry,
+      activate: false,
+    });
+    setActivePluginRegistry(loaded, "original-selectors");
+    const lookup = { provider: "same-provider", env };
+    const derivedConfig = {
+      ...originalConfig,
+      agents: { defaults: { workspace: "/synthetic/derived" } },
+    };
+    expect(resolveLoadedProviderRuntimePlugin({ ...lookup, config: derivedConfig })?.label).toBe(
+      "old",
+    );
+    const changed = { ...lookup, config: configFor(next) };
+    expect(resolveLoadedProviderRuntimePlugin(changed) === undefined).toBe(true);
+    originalConfig.plugins.load.paths = changed.config.plugins.load.paths;
+    expect(
+      resolveLoadedProviderRuntimePlugin({ ...lookup, config: originalConfig }) === undefined,
+    ).toBe(true);
+    expect(resolveProviderRuntimePlugin(changed)?.label).toBe("next");
+  });
+
+  it.each(["replaced", "absent", "setup-only"] as const)(
+    "reserves a %s literal owner before considering another loaded hook alias",
+    (state) => {
+      const old = loadFixture("old");
+      let selected = loadFixture("selected");
+      if (state === "setup-only") {
+        selected = createPluginMetadataSnapshotFixture({
+          plugins: selected.plugins.map((plugin) => ({
+            ...plugin,
+            channels: ["setup-channel"],
+            setupSource: path.join(plugin.rootDir, "setup.cjs"),
+          })),
+        });
+        const plugin = selected.plugins[0];
+        assert.ok(plugin?.setupSource);
+        writeFileSync(
+          plugin.setupSource,
+          `module.exports={plugin:{id:"setup-channel",meta:{id:"setup-channel",label:"Setup",selectionLabel:"Setup",docsPath:"/synthetic",blurb:"Synthetic"},capabilities:{chatTypes:["direct"]},config:{listAccountIds:()=>[],resolveAccount:()=>({})}}};`,
+        );
+      }
+      const alias = writePlugin({
+        id: "alias-owner",
+        filename: "index.cjs",
+        body: `module.exports = { id: "alias-owner", register(api) {
+          api.registerProvider({ id: "other-provider", label: "alias", auth: [],
+            hookAliases: ["same-provider", "runtime-only"] });
+        }};`,
+      });
+      writeFileSync(
+        path.join(alias.dir, "openclaw.plugin.json"),
+        JSON.stringify({
+          id: "alias-owner",
+          providers: ["other-provider"],
+          configSchema: EMPTY_PLUGIN_SCHEMA,
+        }),
+      );
+      const aliasMetadata = createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "alias-owner",
+            origin: "global",
+            rootDir: alias.dir,
+            source: alias.file,
+            providers: ["other-provider"],
+            providerAuthAliases: { "same-provider": "other-provider" },
+            activation: { onProviders: ["same-provider"] },
+            configSchema: EMPTY_PLUGIN_SCHEMA,
+          },
+        ],
+      });
+      const pluginConfig = {
+        plugins: {
+          allow: ["same-id", "alias-owner"],
+          entries: {
+            "same-id": { enabled: true },
+            "alias-owner": { enabled: true },
+          },
+        },
+      };
+      const snapshot = createPluginMetadataSnapshotFixture({
+        plugins: [...selected.plugins, ...aliasMetadata.plugins],
+      });
+      const loaded = loadOpenClawPlugins({
+        config: pluginConfig,
+        env: {},
+        installRecords: {},
+        activate: false,
+        channelPluginLoadIntent: state === "setup-only" ? "setup" : undefined,
+        manifestRegistry: {
+          plugins: [
+            ...(state === "absent" ? [] : state === "replaced" ? old.plugins : selected.plugins),
+            ...aliasMetadata.plugins,
+          ],
+          diagnostics: [],
+        },
+      });
+      setActivePluginRegistry(loaded, state);
+      const lookup = { config: pluginConfig, env: {}, pluginMetadataSnapshot: snapshot };
+      expect(
+        resolveLoadedProviderRuntimePlugin({ ...lookup, provider: "same-provider" }) === undefined,
+      ).toBe(true);
+      expect(
+        resolveLoadedProviderPluginsForHooks({
+          ...lookup,
+          providerRefs: ["same-provider", "other-provider"],
+          onlyPluginIds: ["same-id", "alias-owner"],
+        }) === undefined,
+      ).toBe(true);
+      expect(resolveProviderRuntimePlugin({ ...lookup, provider: "same-provider" })?.label).toBe(
+        "selected",
+      );
+      expect(
+        resolvePluginProvidersCore({ ...lookup, providerRefs: ["same-provider"] }).map(
+          (provider) => provider.label,
+        ),
+      ).toEqual(["selected"]);
+      expect(
+        resolveProviderPluginsForHooks({
+          ...lookup,
+          providerRefs: ["same-provider", "other-provider"],
+          onlyPluginIds: ["same-id", "alias-owner"],
+        })
+          .map((provider) => provider.label)
+          .toSorted(),
+      ).toEqual(["alias", "selected"]);
+      expect(
+        resolveLoadedProviderRuntimePlugin({
+          ...lookup,
+          pluginMetadataSnapshot: aliasMetadata,
+          provider: "same-provider",
+        })?.label,
+      ).toBe("alias");
+      const complete = loadOpenClawPlugins({
+        config: pluginConfig,
+        env: {},
+        installRecords: {},
+        manifestRegistry: snapshot.manifestRegistry,
+        activate: false,
+      });
+      if (state === "setup-only") {
+        expect(complete.providers.map((entry) => entry.provider.label).toSorted()).toEqual([
+          "alias",
+          "selected",
+        ]);
+        withPluginRuntimeGenerationScope(
+          { metadataSnapshot: snapshot, pluginRegistry: loaded },
+          () => {
+            expect(
+              resolveProviderPluginsForHooks({
+                ...lookup,
+                providerRefs: ["same-provider", "other-provider"],
+              }).map((provider) => provider.label),
+            ).toEqual(["alias"]);
+            expect(
+              resolveProviderRuntimePlugin({ ...lookup, provider: "same-provider" }) === undefined,
+            ).toBe(true);
+          },
+        );
+      }
+      const verifyAliasProjection = () => {
+        const aliases = { ...lookup, providerRefs: ["runtime-only"] };
+        expect(
+          resolveLoadedProviderPluginsForHooks(aliases)?.map((provider) => provider.label),
+        ).toEqual(["alias"]);
+        expect(resolveProviderPluginsForHooks(aliases).map((provider) => provider.label)).toEqual([
+          "alias",
+        ]);
+        expect(
+          resolveProviderPluginsForHooks({
+            ...lookup,
+            providerRefs: ["same-provider", "runtime-only"],
+          })
+            .map((provider) => provider.label)
+            .toSorted(),
+        ).toEqual(["alias", "selected"]);
+      };
+      withPluginRuntimeRegistryScope(complete, verifyAliasProjection);
+      withPluginRuntimeGenerationScope(
+        { metadataSnapshot: snapshot, pluginRegistry: complete },
+        () => {
+          verifyAliasProjection();
+          expect(resolveProviderPluginsForHooks({ ...lookup, providerRefs: ["unknown"] })).toEqual(
+            [],
+          );
+        },
+      );
+    },
+  );
+
+  // Compare opaque handles as scalars: failure formatting must not inspect lazy runtime proxies.
+  it.each(
+    (["request", "active"] as const).flatMap((scope) =>
+      (["global", "bundled"] as const).flatMap((origin) =>
+        ["unrelated", "nested-layout"].map((layout) => ({ scope, origin, layout })),
+      ),
+    ),
+  )("rejects another $origin $layout source in a $scope registry", ({ scope, origin, layout }) => {
+    const packageRoot = makePluginLoaderTempDir();
+    const oldRoot = path.join(
+      packageRoot,
+      "extensions",
+      layout === "nested-layout" ? "task/dist/extensions" : "old",
+      "same-id",
+    );
+    const oldPlugin = loadFixture("old", oldRoot).plugins[0];
+    assert.ok(oldPlugin);
+    const old = registry(metadata(oldPlugin.rootDir, oldPlugin.source, origin));
+    const newRoot = path.join(
+      packageRoot,
+      "extensions",
+      layout === "nested-layout" ? "task/extensions" : "new",
+      "same-id",
+    );
+    const lookup = {
+      provider: "same-provider",
+      pluginMetadataSnapshot: metadata(
+        newRoot,
+        path.join(newRoot, path.basename(oldPlugin.source)),
+        origin,
+      ),
+    };
+    const check = () => {
+      expect(resolveLoadedProviderRuntimePlugin(lookup) === undefined).toBe(true);
+      expect(
+        resolveLoadedProviderPluginsForHooks({
+          providerRefs: [lookup.provider],
+          pluginMetadataSnapshot: lookup.pluginMetadataSnapshot,
+        }) === undefined,
+      ).toBe(true);
+    };
+    if (scope === "request") {
+      withPluginRuntimeRegistryScope(old, check);
+    } else {
+      setActivePluginRegistry(old, "old");
+      check();
+    }
+  });
+
+  it("matches physical manifests before reusing a bounded active registry", () => {
+    const snapshot = loadFixture("old");
+    const old = registry(snapshot);
+    setActivePluginRegistry(old, "old");
+    const resolve = (selected: typeof snapshot) =>
+      getLoadedRuntimePluginRegistry({
+        requiredPluginIds: ["same-id"],
+        loadOptions: {
+          onlyPluginIds: ["same-id"],
+          manifestRegistry: selected.manifestRegistry,
+        },
+      });
+    expect(resolve(snapshot) === old).toBe(true);
+    expect(resolve(metadata("/synthetic/new")) === undefined).toBe(true);
+  });
+
+  it("does not reuse an active registry for another raw discovery selection", () => {
+    const snapshot = loadFixture("old");
+    const old = registry(snapshot);
+    const options = (selected: typeof snapshot) => ({
+      config,
+      env: {},
+      installRecords: {},
+      onlyPluginIds: ["same-id"],
+      discovery: {
+        candidates: createPluginCandidatesFromManifestRegistry(selected.manifestRegistry),
+        diagnostics: [],
+      },
+    });
+    const oldOptions = options(snapshot);
+    setActivePluginRegistry(old, resolvePluginLoadCacheContext(oldOptions).cacheKey);
+    expect(
+      getLoadedRuntimePluginRegistry({
+        loadOptions: oldOptions,
+        requiredPluginIds: ["same-id"],
+      }) === old,
+    ).toBe(true);
+    expect(
+      getLoadedRuntimePluginRegistry({
+        loadOptions: options(metadata("/synthetic/new")),
+        requiredPluginIds: ["same-id"],
+      }) === undefined,
+    ).toBe(true);
+  });
+
+  it("uses the loaded owner rather than a later disabled duplicate record", () => {
+    const old = loadFixture("old");
+    const next = loadFixture("new");
+    const loaded = loadOpenClawPlugins({
+      config,
+      env: {},
+      installRecords: {},
+      onlyPluginIds: ["same-id"],
+      activate: false,
+      manifestRegistry: { plugins: [...old.plugins, ...next.plugins], diagnostics: [] },
+    });
+    expect(loaded.plugins.map((plugin) => plugin.status)).toEqual(["loaded", "disabled"]);
+    withPluginRuntimeRegistryScope(loaded, () => {
+      const combined = createPluginMetadataSnapshotFixture({
+        plugins: [...old.plugins, ...next.plugins],
+      });
+      expect(
+        resolveLoadedProviderRuntimePlugin({
+          provider: "same-provider",
+          pluginMetadataSnapshot: combined,
+        })?.label,
+      ).toBe("old");
+      expect(
+        resolveLoadedProviderRuntimePlugin({
+          provider: "same-provider",
+          pluginMetadataSnapshot: old,
+        })?.label,
+      ).toBe("old");
+      expect(
+        resolveLoadedProviderRuntimePlugin({
+          provider: "same-provider",
+          pluginMetadataSnapshot: next,
+        }) === undefined,
+      ).toBe(true);
+    });
+  });
+
+  it.each(["source preference", "explicit load preference", "omitted load preference"] as const)(
+    "honors %s when matching a loaded artifact",
+    (selection) => {
+      const source = loadFixture("source");
+      const sourcePlugin = source.plugins[0];
+      assert.ok(sourcePlugin);
+      const built = loadFixture("built", sourcePlugin.rootDir);
+      const builtPlugin = built.plugins[0];
+      assert.ok(builtPlugin);
+      const rootDir = sourcePlugin.rootDir;
+      mkdirSync(path.join(rootDir, "dist"));
+      const sourcePath = path.join(rootDir, "index.cts");
+      writeFileSync(
+        sourcePath,
+        `module.exports = require(${JSON.stringify(sourcePlugin.source)});`,
+      );
+      writeFileSync(
+        path.join(rootDir, "dist/index.cjs"),
+        `module.exports = require(${JSON.stringify(builtPlugin.source)});`,
+      );
+      const original = metadata(rootDir, sourcePath);
+      const selected = createPluginMetadataSnapshotFixture({
+        plugins: original.plugins.map((plugin) => ({
+          ...plugin,
+          ...(selection === "source preference" ? { sourcePreferred: true as const } : {}),
+        })),
+      });
+      const options = {
+        config,
+        env: {},
+        installRecords: {},
+        onlyPluginIds: ["same-id"],
+        activate: false,
+        preferBuiltPluginArtifacts: true,
+      };
+      const loaded = loadOpenClawPlugins({
+        ...options,
+        manifestRegistry: original.manifestRegistry,
+      });
+      const selectedOptions = {
+        ...options,
+        preferBuiltPluginArtifacts:
+          selection === "omitted load preference" ? undefined : selection === "source preference",
+        manifestRegistry: selected.manifestRegistry,
+      };
+      expect(loaded.providers[0]?.provider.label).toBe("built");
+      setActivePluginRegistry(loaded, "built");
+      expect(
+        getLoadedRuntimePluginRegistry({ loadOptions: selectedOptions }) ===
+          (selection === "omitted load preference" ? loaded : undefined),
+      ).toBe(true);
+      expect(loadOpenClawPlugins(selectedOptions).providers[0]?.provider.label).toBe("source");
+      if (selection === "source preference") {
+        withPluginRuntimeRegistryScope(loaded, () => {
+          expect(
+            resolveLoadedProviderRuntimePlugin({
+              provider: "same-provider",
+              pluginMetadataSnapshot: selected,
+            }) === undefined,
+          ).toBe(true);
+        });
+      }
+    },
+  );
+
+  it("keeps an admitted dreaming sidecar in the scoped loader source identity", () => {
+    const memoryPlugin = (id: string, label: string) => {
+      const plugin = writePlugin({
+        id,
+        filename: "index.cjs",
+        body: `module.exports = { id: ${JSON.stringify(id)}, kind: "memory", register(api) {
+          api.registerProvider({ id: ${JSON.stringify(id)}, label: ${JSON.stringify(label)}, auth: [] });
+        }};`,
+      });
+      return {
+        id,
+        kind: "memory" as const,
+        origin: "global" as const,
+        rootDir: plugin.dir,
+        source: plugin.file,
+        configSchema: { type: "object", additionalProperties: true },
+      };
+    };
+    const selected = memoryPlugin("selected-memory", "selected");
+    const old = memoryPlugin("memory-core", "old");
+    const next = memoryPlugin("memory-core", "new");
+    const load = (sidecar: ReturnType<typeof memoryPlugin>) =>
+      loadOpenClawPlugins({
+        config: {
+          plugins: {
+            allow: ["selected-memory", "memory-core"],
+            slots: { memory: "selected-memory" },
+            entries: {
+              "selected-memory": { enabled: true, config: { dreaming: { enabled: true } } },
+              "memory-core": { enabled: true },
+            },
+          },
+        },
+        env: {},
+        installRecords: {},
+        onlyPluginIds: ["selected-memory"],
+        activate: false,
+        manifestRegistry: createPluginMetadataSnapshotFixture({ plugins: [selected, sidecar] })
+          .manifestRegistry,
+      }).providers.find((entry) => entry.pluginId === "memory-core")?.provider.label;
+    expect([load(old), load(next), load(old)]).toEqual(["old", "new", "old"]);
+  });
+
+  it("retains an exact runtime generation despite newer supplied metadata", () => {
+    const selected = loadFixture("old");
+    const old = registry(selected);
+    const newer = createPluginMetadataSnapshotFixture();
+    const lookup = { provider: "same-provider", config, pluginMetadataSnapshot: newer };
+    withPluginRuntimeGenerationScope({ metadataSnapshot: selected, pluginRegistry: old }, () => {
+      expect(resolveLoadedProviderRuntimePlugin(lookup)?.label).toBe("old");
+      expect(
+        resolvePluginProvidersCore({
+          config,
+          providerRefs: [lookup.provider],
+          pluginMetadataSnapshot: newer,
+        }).map((provider) => provider.label),
+      ).toEqual(["old"]);
+      withPluginRuntimeGenerationScope({ metadataSnapshot: selected }, () => {
+        expect(resolveLoadedProviderRuntimePlugin(lookup) === undefined).toBe(true);
+        expect(resolveLoadedProviderPluginsForHooks({ providerRefs: [lookup.provider] })).toEqual(
+          [],
+        );
+      });
+    });
+  });
+
+  it.each([undefined, "/synthetic/retained"])(
+    "carries retained workspace %s into handles without explicit metadata",
+    (workspaceDir) => {
+      const selected = { ...loadFixture("retained"), workspaceDir };
+      const retained = registry(selected, workspaceDir);
+      const ambient = registry(loadFixture("ambient"), "/synthetic/ambient");
+      setActivePluginRegistry(ambient, "ambient", "default", "/synthetic/ambient");
+      const lookup = { provider: "same-provider", config };
+      withPluginRuntimeGenerationScope(
+        { metadataSnapshot: selected, pluginRegistry: retained },
+        () => {
+          const handle = resolveProviderRuntimePluginHandle(lookup);
+          expect(handle.plugin?.label).toBe("retained");
+          expect(handle.workspaceDir).toBe(workspaceDir);
+          const explicit = resolveProviderRuntimePluginHandle({
+            ...lookup,
+            workspaceDir: "/synthetic/explicit",
+          });
+          expect(explicit.plugin?.label).toBe("retained");
+          expect(explicit.workspaceDir).toBe("/synthetic/explicit");
+        },
+      );
+      withPluginRuntimeGenerationScope({ metadataSnapshot: selected }, () => {
+        const empty = resolveProviderRuntimePluginHandle(lookup);
+        expect(empty.plugin).toBeUndefined();
+        expect(empty.workspaceDir).toBe(workspaceDir);
+      });
+    },
+  );
+
+  it.each(["empty active", "loaded active", "request"] as const)(
+    "retains a full shared-root snapshot across another %s workspace",
+    (scope) => {
+      const fixture = loadFixture("shared");
+      const stateDir = makePluginLoaderTempDir();
+      withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+        const snapshot = loadPluginMetadataSnapshot({
+          config,
+          env: process.env,
+          index: fixture.index,
+        });
+        const lookup = {
+          provider: "same-provider",
+          config,
+          env: process.env,
+          pluginMetadataSnapshot: snapshot,
+        };
+        const registration = (handle: ReturnType<typeof resolveProviderRuntimePluginHandle>) =>
+          handle.plugin?.normalizeModelId?.({ provider: lookup.provider, modelId: "probe" });
+        expect(registration(resolveProviderRuntimePluginHandle(lookup))).toBe("1");
+        const otherWorkspace = path.join(stateDir, "other-workspace");
+        const other =
+          scope === "empty active"
+            ? createEmptyPluginRegistry()
+            : loadOpenClawPlugins({
+                config,
+                env: process.env,
+                installRecords: {},
+                workspaceDir: otherWorkspace,
+                onlyPluginIds: ["same-id"],
+                manifestRegistry: snapshot.manifestRegistry,
+                activate: false,
+              });
+        setActivePluginRegistry(other, "other-workspace", "default", otherWorkspace);
+        const verify = () => {
+          const retained = resolveProviderRuntimePluginHandle(lookup);
+          expect(retained.workspaceDir).toBeUndefined();
+          expect(registration(retained)).toBe("1");
+          if (scope !== "empty active") {
+            expect(
+              registration(
+                resolveProviderRuntimePluginHandle({ ...lookup, workspaceDir: otherWorkspace }),
+              ),
+            ).toBe("2");
+            const narrowed = { index: snapshot.index, manifestRegistry: snapshot.manifestRegistry };
+            expect(
+              registration(
+                resolveProviderRuntimePluginHandle({ ...lookup, pluginMetadataSnapshot: narrowed }),
+              ),
+            ).toBe("2");
+          }
+        };
+        if (scope === "request") {
+          withPluginRuntimeRegistryScope(other, verify);
+        } else {
+          verify();
+        }
+      });
+    },
+  );
+
+  it.each(["explicit", "narrowed"] as const)(
+    "uses the resolved %s workspace instead of another request registry",
+    (selection) => {
+      const snapshot = loadFixture("shared");
+      const load = (workspaceDir: string) =>
+        loadOpenClawPlugins({
+          config,
+          env: {},
+          installRecords: {},
+          workspaceDir,
+          onlyPluginIds: ["same-id"],
+          manifestRegistry: snapshot.manifestRegistry,
+          activate: false,
+        });
+      const request = load("/synthetic/request");
+      const active = load("/synthetic/active");
+      setActivePluginRegistry(active, "active", "default", "/synthetic/active");
+      withPluginRuntimeRegistryScope(request, () => {
+        const params =
+          selection === "explicit"
+            ? { workspaceDir: "/synthetic/active" }
+            : {
+                pluginMetadataSnapshot: {
+                  index: snapshot.index,
+                  manifestRegistry: snapshot.manifestRegistry,
+                },
+              };
+        const context = { provider: "same-provider", modelId: "probe" };
+        expect(
+          resolveLoadedProviderRuntimePlugin({
+            provider: context.provider,
+            ...params,
+          })?.normalizeModelId?.(context),
+        ).toBe("2");
+        expect(
+          resolveLoadedProviderPluginsForHooks({
+            providerRefs: [context.provider],
+            ...params,
+          })?.[0]?.normalizeModelId?.(context),
+        ).toBe("2");
+      });
+    },
+  );
+
+  it.each(
+    ["loader", "provider", "discovery"].flatMap((surface) =>
+      ["root", "entry"].map((changed) => ({ surface, changed })),
+    ),
+  )("keeps warm $surface entries bound to a changed $changed", ({ surface, changed }) => {
+    const sharedRoot = changed === "entry" ? makePluginLoaderTempDir() : undefined;
+    const old = loadFixture("old", sharedRoot);
+    const next = loadFixture("new", sharedRoot);
+    const stateDir = makePluginLoaderTempDir();
+    const load = (snapshot: typeof old) =>
+      surface !== "provider"
+        ? loadOpenClawPlugins({
+            config,
+            env: process.env,
+            installRecords: {},
+            onlyPluginIds: ["same-id"],
+            ...(surface === "discovery"
+              ? {
+                  discovery: {
+                    candidates: createPluginCandidatesFromManifestRegistry(
+                      snapshot.manifestRegistry,
+                    ),
+                    diagnostics: [],
+                  },
+                }
+              : { manifestRegistry: snapshot.manifestRegistry }),
+            activate: false,
+          }).providers[0]?.provider
+        : resolveProviderRuntimePlugin({
+            provider: "same-provider",
+            config,
+            env: process.env,
+            pluginMetadataSnapshot: snapshot,
+          });
+    withEnv({ OPENCLAW_STATE_DIR: stateDir }, () => {
+      expect(load(old)?.label).toBe("old");
+      expect(load(next)?.label).toBe("new");
+      const reused = load(old);
+      expect(reused?.label).toBe("old");
+      expect(reused?.normalizeModelId?.({ provider: "same-provider", modelId: "probe" })).toBe("1");
+    });
+  });
+});

--- a/src/plugins/provider-owner-index.ts
+++ b/src/plugins/provider-owner-index.ts
@@ -1,0 +1,49 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+
+export type DeclaredProviderOwnerIndex = ReadonlyMap<string, ReadonlySet<string>>;
+
+type ProviderOwnerManifest = {
+  id: string;
+  providers: readonly string[];
+  setup?: { providers?: readonly { id: string }[] };
+};
+
+/** Captures declared receivers independently from plugins triggered by a provider. */
+export function buildDeclaredProviderOwnerIndex(
+  manifests: readonly ProviderOwnerManifest[],
+): DeclaredProviderOwnerIndex {
+  const winners = new Map<string, ProviderOwnerManifest>();
+  for (const plugin of manifests) {
+    if (!winners.has(plugin.id)) {
+      winners.set(plugin.id, plugin);
+    }
+  }
+  const owners = new Map<string, Set<string>>();
+  for (const phase of ["runtime", "setup"] as const) {
+    const runtimeRefs = new Set(owners.keys());
+    for (const plugin of winners.values()) {
+      const refs =
+        phase === "runtime"
+          ? plugin.providers
+          : (plugin.setup?.providers?.map((entry) => entry.id) ?? []);
+      for (const ref of refs) {
+        const normalized = normalizeProviderId(ref);
+        if (phase === "setup" && runtimeRefs.has(normalized)) {
+          continue;
+        }
+        const ids = owners.get(normalized) ?? new Set<string>();
+        ids.add(plugin.id);
+        owners.set(normalized, ids);
+      }
+    }
+  }
+  return owners;
+}
+
+export function matchesDeclaredProviderOwner(
+  owners: DeclaredProviderOwnerIndex | undefined,
+  provider: string,
+  pluginId: string,
+): boolean {
+  return owners?.get(normalizeProviderId(provider))?.has(pluginId) ?? true;
+}

--- a/src/plugins/provider-plugin.types.ts
+++ b/src/plugins/provider-plugin.types.ts
@@ -652,3 +652,12 @@ export type ProviderPlugin = {
   ) => boolean | undefined;
   onModelSelected?: (ctx: ProviderModelSelectedContext) => Promise<void>;
 };
+
+/** Provider runtime registered with its owning plugin and source. */
+export type PluginProviderRegistration = {
+  pluginId: string;
+  pluginName?: string;
+  provider: ProviderPlugin;
+  source: string;
+  rootDir?: string;
+};

--- a/src/plugins/provider-registry-selection.ts
+++ b/src/plugins/provider-registry-selection.ts
@@ -1,0 +1,38 @@
+import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
+import { matchesDeclaredProviderOwner } from "./provider-owner-index.js";
+import type { PluginProviderRegistration, ProviderPlugin } from "./provider-plugin.types.js";
+import { matchesProviderRuntimePlugin } from "./provider-registry-shared.js";
+import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
+import { getPluginRuntimeLoadContextState } from "./runtime/load-context-state.js";
+
+/** Resolves the hook receiver with its authoritative registry-owned plugin id. */
+export function findProviderRuntimePluginInRegistry(params: {
+  registry: { providers: readonly PluginProviderRegistration[] };
+  provider: string;
+  ownerRefs: readonly string[];
+  isOwnerEligible?: (pluginId: string) => boolean;
+}): ProviderPlugin | undefined {
+  const scope = getPluginRuntimeGatewayRequestScope();
+  const owners =
+    (scope?.pluginRegistry === params.registry ? scope.declaredProviderOwners : undefined) ??
+    getPluginRuntimeLoadContextState(params.registry)?.declaredProviderOwners;
+  const isOwnerEligible =
+    params.isOwnerEligible ??
+    ((id: string) => matchesDeclaredProviderOwner(owners, params.provider, id));
+  const literalId = normalizeLowercaseStringOrEmpty(params.provider);
+  // A registered provider owns its name; another provider's compatibility
+  // alias must not replace its executable hooks in a shared generation.
+  const entry =
+    params.registry.providers.find(
+      ({ pluginId, provider }) =>
+        literalId &&
+        normalizeLowercaseStringOrEmpty(provider.id) === literalId &&
+        isOwnerEligible(pluginId),
+    ) ??
+    params.registry.providers.find(
+      ({ pluginId, provider }) =>
+        matchesProviderRuntimePlugin(provider, params.provider, params.ownerRefs) &&
+        isOwnerEligible(pluginId),
+    );
+  return entry ? Object.assign({}, entry.provider, { pluginId: entry.pluginId }) : undefined;
+}

--- a/src/plugins/provider-registry-shared.ts
+++ b/src/plugins/provider-registry-shared.ts
@@ -1,7 +1,25 @@
 // Shares provider registry normalization helpers across plugin paths.
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
+import {
+  normalizeLowercaseStringOrEmpty,
+  normalizeOptionalLowercaseString,
+} from "@openclaw/normalization-core/string-coerce";
 import { isBlockedObjectKey } from "../infra/prototype-keys.js";
+import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
+import type { ProviderPlugin } from "./provider-plugin.types.js";
+
+/** A full snapshot retains shared-root scope; narrowed views may still use the ambient workspace. */
+export function resolveProviderRuntimeWorkspaceDir(
+  params: { workspaceDir?: string; pluginMetadataSnapshot?: PluginMetadataRegistryView },
+  ambientWorkspaceDir: string | undefined,
+): string | undefined {
+  return (
+    params.workspaceDir ??
+    (params.pluginMetadataSnapshot && Object.hasOwn(params.pluginMetadataSnapshot, "workspaceDir")
+      ? params.pluginMetadataSnapshot.workspaceDir
+      : ambientWorkspaceDir)
+  );
+}
 
 /** Normalizes provider ids used by capability-provider registries. */
 export function normalizeCapabilityProviderId(providerId: string | undefined): string | undefined {
@@ -20,6 +38,22 @@ export function matchesProviderPluginRef(
       [...(provider.aliases ?? []), ...(provider.hookAliases ?? [])].some(
         (alias) => normalizeProviderId(alias) === normalized,
       )),
+  );
+}
+
+/** Explicit API owners keep foreign aliases from taking over a configured provider route. */
+export function matchesProviderRuntimePlugin(
+  plugin: ProviderPlugin,
+  provider: string,
+  ownerRefs: readonly string[],
+): boolean {
+  if (ownerRefs.length === 0) {
+    return matchesProviderPluginRef(plugin, provider);
+  }
+  const literalId = normalizeLowercaseStringOrEmpty(provider);
+  return (
+    (Boolean(literalId) && normalizeLowercaseStringOrEmpty(plugin.id) === literalId) ||
+    ownerRefs.some((ownerRef) => matchesProviderPluginRef(plugin, ownerRef))
   );
 }
 

--- a/src/plugins/provider-runtime.test.ts
+++ b/src/plugins/provider-runtime.test.ts
@@ -6,6 +6,7 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createPluginMetadataSnapshot } from "../config/plugin-auto-enable.test-helpers.js";
 import type { ModelProviderConfig, OpenClawConfig } from "../config/types.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
+import { createPluginMetadataSnapshotFixture } from "./plugin-metadata.test-support.js";
 import type { ProviderExternalAuthProfile } from "./provider-external-auth.types.js";
 import type { ProviderRuntimeModel } from "./provider-runtime-model.types.js";
 import {
@@ -14,6 +15,7 @@ import {
 } from "./provider-runtime.test-support.js";
 import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.js";
 import { withPluginRuntimeGenerationScope } from "./runtime/generation-scope.js";
+import { setPluginRuntimeLoadContext } from "./runtime/load-context.js";
 import type {
   AnyAgentTool,
   ProviderNormalizeToolSchemasContext,
@@ -71,7 +73,6 @@ let formatProviderAuthProfileApiKeyWithPlugin: typeof import("./provider-runtime
 let loginProviderOAuthWithPlugin: typeof import("./provider-runtime.js").loginProviderOAuthWithPlugin;
 let classifyProviderFailoverSignalWithPlugin: typeof import("./provider-runtime.js").classifyProviderFailoverSignalWithPlugin;
 let normalizeProviderConfigWithPlugin: typeof import("./provider-runtime.js").normalizeProviderConfigWithPlugin;
-let normalizeProviderModelIdWithPlugin: typeof import("./provider-runtime.js").normalizeProviderModelIdWithPlugin;
 let applyProviderResolvedTransportWithPlugin: typeof import("./provider-runtime.js").applyProviderResolvedTransportWithPlugin;
 let normalizeProviderTransportWithPlugin: typeof import("./provider-runtime.js").normalizeProviderTransportWithPlugin;
 let resolvePreparedExtraParams: typeof import("../agents/embedded-agent-runner/extra-params.js").resolvePreparedExtraParams;
@@ -283,7 +284,8 @@ describe("provider-runtime", () => {
       resolveProviderPolicySurface: (...args: Parameters<ResolveProviderPolicySurface>) =>
         resolveProviderPolicySurfaceMock(...args),
     }));
-    vi.doMock("./providers.js", () => ({
+    vi.doMock("./providers.js", async (importOriginal) => ({
+      ...(await importOriginal<typeof import("./providers.js")>()),
       resolveCatalogHookProviderPluginIds: (params: unknown) =>
         resolveCatalogHookProviderPluginIdsMock(params as never),
       resolveUsageHookProviderPluginContracts: (params: unknown) =>
@@ -299,11 +301,50 @@ describe("provider-runtime", () => {
         return pluginIds?.length ? { status: "owned", pluginIds } : { status: "unowned" };
       },
     }));
-    vi.doMock("./providers.runtime.js", () => ({
-      resolvePluginProvidersCore: (params: unknown) => resolvePluginProvidersMock(params as never),
-      isPluginProvidersLoadInFlight: (params: unknown) =>
-        isPluginProvidersLoadInFlightMock(params as never),
-    }));
+    vi.doMock("./providers.runtime.js", async (importOriginal) => {
+      const actual = await importOriginal<typeof import("./providers.runtime.js")>();
+      const resolveRegistry = (params: Parameters<ResolvePluginProviders>[0]) => {
+        const loaded = actual.resolvePluginProviderRegistryCore({
+          ...params,
+          registryScope: "loaded",
+        });
+        if (loaded || params.registryScope === "loaded") {
+          return loaded;
+        }
+        if (params.skipIfLoadInFlight && isPluginProvidersLoadInFlightMock(params)) {
+          return undefined;
+        }
+        const providers = resolvePluginProvidersMock(params);
+        if (providers.length === 0) {
+          return undefined;
+        }
+        const registry = createEmptyPluginRegistry();
+        registry.providers = providers.map((provider) => ({
+          pluginId: provider.pluginId ?? provider.id,
+          provider,
+          source: "synthetic-provider",
+        }));
+        return { registry, onlyPluginIds: undefined, isProviderOwnerEligible: () => true };
+      };
+      return {
+        ...actual,
+        resolvePluginProviderRegistryCore: resolveRegistry,
+        resolvePluginProvidersCore: (params: Parameters<ResolvePluginProviders>[0]) => {
+          const selection = resolveRegistry(params);
+          if (!selection) {
+            return [];
+          }
+          return selection.registry.providers
+            .filter(
+              (entry) =>
+                !selection.onlyPluginIds || selection.onlyPluginIds.includes(entry.pluginId),
+            )
+            .map((entry) => Object.assign({}, entry.provider, { pluginId: entry.pluginId }));
+        },
+        isPluginProvidersLoadInFlight: (params: Parameters<IsPluginProvidersLoadInFlight>[0]) =>
+          isPluginProvidersLoadInFlightMock(params),
+      };
+    });
     vi.doMock("./provider-hook-runtime.js", async () => {
       const { createProviderHookRuntime } = await import("./provider-hook-runtime-core.js");
       const providers = await import("./providers.runtime.js");
@@ -333,7 +374,6 @@ describe("provider-runtime", () => {
       formatProviderAuthProfileApiKeyWithPlugin,
       loginProviderOAuthWithPlugin,
       normalizeProviderConfigWithPlugin,
-      normalizeProviderModelIdWithPlugin,
       normalizeProviderTransportWithPlugin,
       resolveProviderAuthProfileId,
       resolveProviderConfigApiKeyWithPlugin,
@@ -705,6 +745,15 @@ describe("provider-runtime", () => {
       provider,
       source: "test",
     });
+    setPluginRuntimeLoadContext(registry, {
+      rawConfig: {},
+      config: {},
+      activationSourceConfig: {},
+      autoEnabledReasons: {},
+      workspaceDir: "/tmp/prepared-workspace",
+      env: process.env,
+      logger: { info() {}, warn() {}, error() {}, debug() {} },
+    });
 
     const resolved = withPluginRuntimeRegistryScope(registry, () =>
       resolveProviderRuntimePlugin({
@@ -1007,12 +1056,12 @@ describe("provider-runtime", () => {
       },
     } as OpenClawConfig;
 
-    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID, config: firstConfig })).toBe(
-      provider,
-    );
-    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID, config: secondConfig })).toBe(
-      provider,
-    );
+    expect(
+      resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID, config: firstConfig }),
+    ).toMatchObject(provider);
+    expect(
+      resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID, config: secondConfig }),
+    ).toMatchObject(provider);
 
     expect(resolvePluginProvidersMock).toHaveBeenCalledTimes(2);
   });
@@ -1042,12 +1091,12 @@ describe("provider-runtime", () => {
       },
     } as OpenClawConfig;
 
-    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID, config: firstConfig })).toBe(
-      provider,
-    );
-    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID, config: secondConfig })).toBe(
-      provider,
-    );
+    expect(
+      resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID, config: firstConfig }),
+    ).toMatchObject(provider);
+    expect(
+      resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID, config: secondConfig }),
+    ).toMatchObject(provider);
 
     expect(resolvePluginProvidersMock).toHaveBeenCalledTimes(2);
   });
@@ -1152,13 +1201,13 @@ describe("provider-runtime", () => {
       setTestEnvValue("HOME", "/home/one");
       deleteTestEnvValue("OPENCLAW_HOME");
       resolvePluginProvidersMock.mockReturnValueOnce([firstProvider]);
-      expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID, config })).toBe(
+      expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID, config })).toMatchObject(
         firstProvider,
       );
 
       setTestEnvValue("HOME", "/home/two");
       resolvePluginProvidersMock.mockReturnValueOnce([secondProvider]);
-      expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID, config })).toBe(
+      expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID, config })).toMatchObject(
         secondProvider,
       );
     } finally {
@@ -1182,11 +1231,15 @@ describe("provider-runtime", () => {
 
     setActivePluginRegistry(createEmptyPluginRegistry(), "workspace-one", "default", "/tmp/one");
     resolvePluginProvidersMock.mockReturnValueOnce([firstProvider]);
-    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toBe(firstProvider);
+    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toMatchObject(
+      firstProvider,
+    );
 
     setActivePluginRegistry(createEmptyPluginRegistry(), "workspace-two", "default", "/tmp/two");
     resolvePluginProvidersMock.mockReturnValueOnce([secondProvider]);
-    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toBe(secondProvider);
+    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toMatchObject(
+      secondProvider,
+    );
 
     expect(resolvePluginProvidersMock).toHaveBeenCalledTimes(2);
   });
@@ -1200,7 +1253,7 @@ describe("provider-runtime", () => {
 
     setActivePluginRegistry(createEmptyPluginRegistry(), "workspace-one", "default", "/tmp/work");
     resolvePluginProvidersMock.mockReturnValueOnce([provider]);
-    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toBe(provider);
+    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toMatchObject(provider);
 
     setActivePluginRegistry(createEmptyPluginRegistry(), "workspace-two", "default", "/tmp/work");
     resolvePluginProvidersMock.mockReturnValueOnce([]);
@@ -1237,9 +1290,15 @@ describe("provider-runtime", () => {
     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
   });
 
-  it.each(["matching", "filtered", "missing-owner"] as const)(
-    "uses the correct hook owner with a %s request registry",
-    (scope) => {
+  it.each([
+    { scope: "matching", providerRefs: ["demo"] },
+    { scope: "filtered", providerRefs: ["demo"] },
+    { scope: "missing-owner", providerRefs: ["demo"] },
+    { scope: "matching", providerRefs: ["unregistered", "demo"] },
+    { scope: "matching", providerRefs: ["demo-alias"] },
+  ])(
+    "uses the correct hook owner with a $scope request registry for $providerRefs",
+    ({ scope, providerRefs }) => {
       const active = createEmptyPluginRegistry();
       const scoped = createEmptyPluginRegistry();
       for (const [registry, label] of [
@@ -1255,16 +1314,26 @@ describe("provider-runtime", () => {
           source: "demo/index.js",
           provider: {
             id: scope === "filtered" && registry === scoped ? "other" : "demo",
+            aliases: ["demo-alias"],
             label,
             auth: [],
           },
         });
       }
+      setPluginRuntimeLoadContext(scoped, {
+        rawConfig: {},
+        config: {},
+        activationSourceConfig: {},
+        autoEnabledReasons: {},
+        workspaceDir: "/tmp/work",
+        env: process.env,
+        logger: { info() {}, warn() {}, error() {}, debug() {} },
+      });
       setActivePluginRegistry(active, "active", "default", "/tmp/work");
       const plugins = withPluginRuntimeRegistryScope(scoped, () =>
         resolveProviderPluginsForHooks({
           onlyPluginIds: ["demo-plugin"],
-          providerRefs: ["demo"],
+          providerRefs,
         }),
       );
       expect(plugins.map((plugin) => plugin.label)).toEqual([
@@ -1301,7 +1370,7 @@ describe("provider-runtime", () => {
     expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toBeUndefined();
 
     resolvePluginProvidersMock.mockReturnValueOnce([provider]);
-    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toBe(provider);
+    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toMatchObject(provider);
 
     expect(resolvePluginProvidersMock).toHaveBeenCalledTimes(2);
   });
@@ -1327,7 +1396,7 @@ describe("provider-runtime", () => {
     expect(resolvePluginProvidersMock).not.toHaveBeenCalled();
 
     providerScopedLoadInFlight = false;
-    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toBe(provider);
+    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toMatchObject(provider);
     expect(resolvePluginProvidersMock).toHaveBeenCalledTimes(1);
   });
 
@@ -1346,7 +1415,9 @@ describe("provider-runtime", () => {
       params.applyAutoEnable === false ? [] : [runtimeProvider],
     );
 
-    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toBe(runtimeProvider);
+    expect(resolveProviderRuntimePlugin({ provider: DEMO_PROVIDER_ID })).toMatchObject(
+      runtimeProvider,
+    );
 
     expect(
       resolveProviderSyntheticAuthWithPlugin({
@@ -1436,10 +1507,9 @@ describe("provider-runtime", () => {
       agents: { defaults: { model: "anthropic/claude-sonnet-4-5" } },
     } as OpenClawConfig;
     const metadataSnapshot = {
-      index: {},
-      manifestRegistry: {},
+      ...createPluginMetadataSnapshotFixture(),
       workspaceDir: "/tmp/snapshot-workspace",
-    } as never;
+    };
 
     expect(
       await augmentModelCatalogWithProviderPlugins({
@@ -1835,29 +1905,6 @@ describe("provider-runtime", () => {
     ).toBeUndefined();
   });
 
-  it("can normalize model ids through provider aliases without changing ownership", () => {
-    resolvePluginProvidersMock.mockReturnValue([
-      {
-        id: "google",
-        label: "Google",
-        hookAliases: ["google-vertex"],
-        auth: [],
-        normalizeModelId: ({ modelId }) => modelId.replace("flash-lite-preview", "flash-lite"),
-      },
-    ]);
-
-    expect(
-      normalizeProviderModelIdWithPlugin({
-        provider: "google-vertex",
-        context: {
-          provider: "google-vertex",
-          modelId: "gemini-3.1-flash-lite-preview",
-        },
-      }),
-    ).toBe("gemini-3.1-flash-lite");
-    expect(resolvePluginProvidersMock).toHaveBeenCalledTimes(1);
-  });
-
   it("resolves config hooks through hook-only aliases without changing provider surfaces", () => {
     resolvePluginProvidersMock.mockReturnValue([
       {
@@ -2143,7 +2190,7 @@ describe("provider-runtime", () => {
         providerOwner: "openrouter",
         modelId: "anthropic/claude-sonnet-4",
       }),
-    ).toBe(openrouterPlugin);
+    ).toMatchObject(openrouterPlugin);
   });
 
   it("does not broad-scan failover hooks for unresolved providers with structured descriptors", () => {
@@ -2482,7 +2529,6 @@ describe("provider-runtime", () => {
             api,
             baseUrl: baseUrl ? `${baseUrl}/normalized` : undefined,
           }),
-          normalizeModelId: ({ modelId }) => modelId.replace("-legacy", ""),
           resolveDynamicModel: () => MODEL,
           prepareDynamicModel,
           sanitizeReplayHistory,
@@ -2555,16 +2601,6 @@ describe("provider-runtime", () => {
         }),
       }),
     ).toEqual(MODEL);
-
-    expect(
-      normalizeProviderModelIdWithPlugin({
-        provider: DEMO_PROVIDER_ID,
-        context: {
-          provider: DEMO_PROVIDER_ID,
-          modelId: "demo-model-legacy",
-        },
-      }),
-    ).toBe("demo-model");
 
     expect(
       normalizeProviderTransportWithPlugin({
@@ -2939,7 +2975,7 @@ describe("provider-runtime", () => {
       } as never,
     });
 
-    expect(plugin).toBe(ollamaPlugin);
+    expect(plugin).toMatchObject(ollamaPlugin);
     expect(getLastResolvePluginProvidersParams().providerRefs).toEqual(["ollama-spark", "ollama"]);
   });
 

--- a/src/plugins/provider-runtime.ts
+++ b/src/plugins/provider-runtime.ts
@@ -21,10 +21,6 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { providerUsageLabel } from "../infra/provider-usage.shared.js";
 import type { UsageProviderId } from "../infra/provider-usage.types.js";
 import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
-import {
-  normalizeProviderModelIdWithManifest,
-  type ManifestModelIdNormalizationSource,
-} from "./manifest-model-id-normalization.js";
 import type { PluginManifestRegistry } from "./manifest-registry.js";
 import type {
   PluginMetadataRegistryView,
@@ -76,7 +72,6 @@ import type {
   ProviderFetchUsageSnapshotContext,
   ProviderNormalizeToolSchemasContext,
   ProviderNormalizeConfigContext,
-  ProviderNormalizeModelIdContext,
   ProviderReasoningOutputMode,
   ProviderReasoningOutputModeContext,
   ProviderNormalizeResolvedModelContext,
@@ -384,21 +379,6 @@ export function applyProviderResolvedTransportWithPlugin(params: {
     api: nextApi as ProviderRuntimeModel["api"],
     baseUrl: nextBaseUrl,
   };
-}
-
-export function normalizeProviderModelIdWithPlugin(params: {
-  provider: string;
-  config?: OpenClawConfig;
-  workspaceDir?: string;
-  env?: NodeJS.ProcessEnv;
-  plugins?: ManifestModelIdNormalizationSource;
-  context: ProviderNormalizeModelIdContext;
-}): string | undefined {
-  const plugin = resolveProviderHookPlugin(params);
-  return (
-    normalizeOptionalString(plugin?.normalizeModelId?.(params.context)) ??
-    normalizeProviderModelIdWithManifest(params)
-  );
 }
 
 export function normalizeProviderTransportWithPlugin(params: {

--- a/src/plugins/providers.runtime-core.ts
+++ b/src/plugins/providers.runtime-core.ts
@@ -1,17 +1,36 @@
 // Runtime boundary for resolving provider plugins from metadata and config.
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import { sortUniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import {
   resolveBundledCompatActivationInputs,
   withActivatedPluginIds,
 } from "./activation-context.js";
 import { resolveManifestActivationPluginIds } from "./activation-planner.js";
-import { getLoadedRuntimePluginRegistry } from "./active-runtime-registry.js";
+import { resolvePluginActivationSourceConfig } from "./activation-source-config.js";
+import {
+  createRuntimePluginManifestLookup,
+  getLoadedRuntimePluginRegistry,
+  registryContainsRuntimePluginIds,
+} from "./active-runtime-registry.js";
+import { getCurrentPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
 import { extractPluginInstallRecordsFromInstalledPluginIndex } from "./installed-plugin-index-install-records.js";
+import { resolvePluginRegistrationConfigKey } from "./loader-registration-config.js";
 import type { PluginLoadOptions } from "./loader-types.js";
+import { resolvePluginControlPlaneFingerprint } from "./plugin-control-plane-context.js";
 import { resolvePluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
 import type { PluginMetadataRegistryView } from "./plugin-metadata-snapshot.types.js";
+import { hasCompletedPluginRuntimeRegistration } from "./plugin-runtime-artifact-selection.js";
 import { hasExplicitPluginIdScope } from "./plugin-scope.js";
 import { resolveProviderConfigApiOwnerHint } from "./provider-config-owner.js";
+import {
+  buildDeclaredProviderOwnerIndex,
+  matchesDeclaredProviderOwner,
+  type DeclaredProviderOwnerIndex,
+} from "./provider-owner-index.js";
+import {
+  matchesProviderPluginRef,
+  resolveProviderRuntimeWorkspaceDir,
+} from "./provider-registry-shared.js";
 import {
   resolveActivatableProviderOwnerPluginIds,
   resolveBundledProviderCompatPluginIds,
@@ -23,10 +42,12 @@ import {
 } from "./providers.js";
 import type { PluginRegistry } from "./registry-types.js";
 import { getActivePluginRegistryWorkspaceDir } from "./runtime.js";
-import { getPluginRuntimeGenerationRegistry } from "./runtime/generation-scope.js";
+import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
+import { getPluginRuntimeGenerationRegistry } from "./runtime/generation-state.js";
 import {
-  buildPluginRuntimeLoadOptionsFromValues,
+  buildPluginRuntimeLoadOptions,
   createPluginRuntimeLoaderLogger,
+  getPluginRuntimeLoadContext,
 } from "./runtime/load-context.js";
 import type { ProviderPlugin } from "./types.js";
 
@@ -37,259 +58,256 @@ export function createProviderRegistryResolver(dependencies: {
 }) {
   const { loadOpenClawPlugins, resolveRuntimePluginRegistry, isPluginRegistryLoadInFlight } =
     dependencies;
+  type ProviderResolutionInputs = Parameters<typeof resolvePluginProviderRegistryCore>[0] & {
+    env: NodeJS.ProcessEnv;
+  };
 
-  function resolveExplicitProviderOwnerPluginIds(
+  function resolveProviderOwnerSelection(
     params: {
-      providerRefs: readonly string[];
+      provider: string;
       config?: PluginLoadOptions["config"];
       workspaceDir?: string;
       env?: PluginLoadOptions["env"];
     },
-    snapshot: PluginMetadataRegistryView,
-  ): string[] {
-    return sortUniqueStrings(
-      params.providerRefs.flatMap((provider) => {
-        const plannedPluginIds = resolveManifestActivationPluginIds({
-          trigger: {
-            kind: "provider",
-            provider,
-          },
-          config: params.config,
-          workspaceDir: params.workspaceDir,
-          env: params.env,
-          manifestRecords: snapshot.manifestRegistry.plugins,
-        });
-        if (plannedPluginIds.length > 0) {
-          return plannedPluginIds;
-        }
-        const apiOwnerHint = resolveProviderConfigApiOwnerHint({
-          provider,
-          config: params.config,
-        });
-        if (apiOwnerHint) {
-          const apiOwnerPluginIds = resolveManifestActivationPluginIds({
-            trigger: {
-              kind: "provider",
-              provider: apiOwnerHint,
-            },
-            config: params.config,
-            workspaceDir: params.workspaceDir,
-            env: params.env,
-            manifestRecords: snapshot.manifestRegistry.plugins,
-          });
-          if (apiOwnerPluginIds.length > 0) {
-            return apiOwnerPluginIds;
-          }
-        }
-        return (
-          resolveOwningPluginIdsForProviderRef({
-            provider,
-            config: params.config,
-            workspaceDir: params.workspaceDir,
-            env: params.env,
-            manifestRegistry: snapshot.manifestRegistry,
-          }) ?? []
-        );
-      }),
-    );
-  }
-
-  function mergeExplicitOwnerPluginIds(
-    providerPluginIds: readonly string[],
-    explicitOwnerPluginIds: readonly string[],
-  ): string[] {
-    if (explicitOwnerPluginIds.length === 0) {
-      return [...providerPluginIds];
-    }
-    return sortUniqueStrings([...providerPluginIds, ...explicitOwnerPluginIds]);
-  }
-
-  function resolvePluginProviderLoadBase(
-    params: {
-      config?: PluginLoadOptions["config"];
-      workspaceDir?: string;
-      env?: PluginLoadOptions["env"];
-      onlyPluginIds?: string[];
-      providerRefs?: readonly string[];
-      modelRefs?: readonly string[];
-    },
-    snapshot: PluginMetadataRegistryView,
+    manifestRegistry: NonNullable<PluginLoadOptions["manifestRegistry"]>,
+    declaredOwners: DeclaredProviderOwnerIndex,
   ) {
-    const env = params.env ?? process.env;
-    const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDir();
-    const providerOwnedPluginIds = params.providerRefs?.length
-      ? resolveExplicitProviderOwnerPluginIds(
-          {
-            providerRefs: params.providerRefs,
-            config: params.config,
-            workspaceDir,
-            env,
-          },
-          snapshot,
-        )
-      : [];
-    const modelOwnedPluginIds = params.modelRefs?.length
-      ? resolveOwningPluginIdsForModelRefs({
-          models: params.modelRefs,
-          config: params.config,
-          workspaceDir,
-          env,
-          manifestRegistry: snapshot.manifestRegistry,
-        })
-      : [];
-    const requestedPluginIds =
-      hasExplicitPluginIdScope(params.onlyPluginIds) ||
-      params.providerRefs?.length ||
-      params.modelRefs?.length ||
-      providerOwnedPluginIds.length > 0 ||
-      modelOwnedPluginIds.length > 0
-        ? sortUniqueStrings([
-            ...(params.onlyPluginIds ?? []),
-            ...providerOwnedPluginIds,
-            ...modelOwnedPluginIds,
-          ])
-        : undefined;
-    const explicitOwnerPluginIds = sortUniqueStrings([
-      ...providerOwnedPluginIds,
-      ...modelOwnedPluginIds,
-    ]);
+    const apiOwnerHint = resolveProviderConfigApiOwnerHint(params);
+    const ownerRef = declaredOwners.has(normalizeProviderId(params.provider))
+      ? params.provider
+      : (apiOwnerHint ?? params.provider);
+    const declaredIds = declaredOwners.get(normalizeProviderId(ownerRef));
+    const ownerIds = declaredIds
+      ? [...declaredIds]
+      : (resolveOwningPluginIdsForProviderRef({
+          ...params,
+          provider: ownerRef,
+          manifestRegistry,
+        }) ?? []);
+    // Activation helpers still run beside a declared receiver. Their triggers do
+    // not confer ownership of another provider's executable hooks.
+    const runtimePluginIds = sortUniqueStrings(
+      [params.provider, ...(apiOwnerHint ? [apiOwnerHint] : [])].flatMap((provider) =>
+        resolveManifestActivationPluginIds({
+          ...params,
+          trigger: { kind: "provider", provider },
+          manifestRecords: manifestRegistry.plugins,
+        }),
+      ),
+    );
     return {
-      env,
-      workspaceDir,
-      requestedPluginIds,
-      explicitOwnerPluginIds,
-      rawConfig: params.config,
+      provider: params.provider,
+      ownerPluginIds: ownerIds,
+      providerPluginIds: ownerIds.length > 0 ? ownerIds : runtimePluginIds,
+      runtimePluginIds,
     };
   }
 
-  function resolveProviderMetadataLookup(params: {
-    config?: PluginLoadOptions["config"];
-    workspaceDir?: string;
-    env?: PluginLoadOptions["env"];
-    pluginMetadataSnapshot?: PluginMetadataRegistryView;
-  }) {
-    const env = params.env ?? process.env;
-    const workspaceDir = params.workspaceDir ?? getActivePluginRegistryWorkspaceDir();
-    const snapshot =
-      params.pluginMetadataSnapshot ??
-      resolvePluginMetadataSnapshot({
-        config: params.config ?? {},
-        workspaceDir,
-        env,
-      });
-    return { env, workspaceDir, snapshot };
+  function prepareProviderSelection(
+    params: ProviderResolutionInputs,
+    manifestRegistry?: PluginLoadOptions["manifestRegistry"],
+    declaredProviderOwners = buildDeclaredProviderOwnerIndex(manifestRegistry?.plugins ?? []),
+  ) {
+    const providerOwners = manifestRegistry
+      ? (params.providerRefs ?? []).map((provider) =>
+          resolveProviderOwnerSelection(
+            {
+              provider,
+              config: params.config,
+              workspaceDir: params.workspaceDir,
+              env: params.env,
+            },
+            manifestRegistry,
+            declaredProviderOwners,
+          ),
+        )
+      : [];
+    const modelOwnedPluginIds =
+      manifestRegistry && params.modelRefs?.length
+        ? resolveOwningPluginIdsForModelRefs({
+            models: params.modelRefs,
+            config: params.config,
+            workspaceDir: params.workspaceDir,
+            env: params.env,
+            manifestRegistry,
+          })
+        : [];
+    const explicitOwnerPluginIds = sortUniqueStrings([
+      ...providerOwners.flatMap((owner) => [...owner.ownerPluginIds, ...owner.runtimePluginIds]),
+      ...modelOwnedPluginIds,
+    ]);
+    const pluginIds = !manifestRegistry
+      ? params.onlyPluginIds
+      : hasExplicitPluginIdScope(params.onlyPluginIds) ||
+          params.providerRefs?.length ||
+          params.modelRefs?.length
+        ? sortUniqueStrings([...(params.onlyPluginIds ?? []), ...explicitOwnerPluginIds])
+        : undefined;
+    return {
+      pluginIds,
+      workspaceDir: params.workspaceDir,
+      manifestRegistry,
+      onlyPluginIds: params.onlyPluginIds,
+      providerRefs: params.providerRefs,
+      projectedPluginIds:
+        manifestRegistry && (params.providerRefs?.length || params.modelRefs?.length)
+          ? sortUniqueStrings([
+              ...providerOwners.flatMap((owner) => owner.providerPluginIds),
+              ...modelOwnedPluginIds,
+            ])
+          : undefined,
+      declaredProviderOwners,
+      providerRegistrationPluginIds: new Set(
+        (manifestRegistry?.plugins ?? [])
+          .filter(
+            (plugin) => plugin.providers.length > 0 || (plugin.setup?.providers?.length ?? 0) > 0,
+          )
+          .map((plugin) => plugin.id),
+      ),
+      runtimeRegistrationPluginIds: new Set(
+        providerOwners.flatMap((owner) => owner.runtimePluginIds),
+      ),
+      unownedProviderRefs: manifestRegistry
+        ? providerOwners
+            .filter((owner) => owner.ownerPluginIds.length === 0)
+            .map((owner) => owner.provider)
+        : (params.providerRefs ?? []),
+      explicitOwnerPluginIds,
+    };
   }
 
-  function resolveSetupProviderPluginLoadOptions(
-    params: Parameters<typeof resolvePluginProvidersCore>[0],
-    base: ReturnType<typeof resolvePluginProviderLoadBase>,
-    snapshot: PluginMetadataRegistryView,
+  function prepareProviderLookup(
+    params: Parameters<typeof resolvePluginProviderRegistryCore>[0],
+    retained = false,
   ) {
-    const providerPluginIds = resolveDiscoveredProviderPluginIds({
+    const env = params.env ?? process.env;
+    const sourceParams = retained
+      ? {
+          ...params,
+          pluginMetadataSnapshot: getCurrentPluginMetadataSnapshot({ config: params.config, env }),
+        }
+      : params;
+    // Retained metadata owns even an undefined shared-root workspace; only an
+    // explicit caller workspace overrides it, never the process-active registry.
+    const workspaceDir = resolveProviderRuntimeWorkspaceDir(
+      sourceParams,
+      retained ? undefined : getActivePluginRegistryWorkspaceDir(),
+    );
+    const snapshot =
+      sourceParams.pluginMetadataSnapshot ??
+      (retained || params.registryScope === "loaded"
+        ? getCurrentPluginMetadataSnapshot({
+            config: params.config,
+            env,
+            workspaceDir,
+            allowWorkspaceScopedSnapshot: true,
+          })
+        : resolvePluginMetadataSnapshot({ config: params.config ?? {}, env, workspaceDir }));
+    const inputs = { ...sourceParams, env, workspaceDir };
+    const selection = snapshot
+      ? prepareProviderSelection(inputs, snapshot.manifestRegistry, snapshot.declaredProviderOwners)
+      : undefined;
+    const loadOptions =
+      snapshot && selection && !retained
+        ? resolveProviderLoadOptions(inputs, selection, snapshot)
+        : undefined;
+    return { inputs, snapshot, selection, loadOptions };
+  }
+
+  function resolveProviderLoadOptions(
+    params: ProviderResolutionInputs,
+    selection: ReturnType<typeof prepareProviderSelection>,
+    snapshot: PluginMetadataRegistryView,
+  ): PluginLoadOptions | undefined {
+    const sourceConfig = resolvePluginActivationSourceConfig(params);
+    const ownerLookup = {
       config: params.config,
-      workspaceDir: base.workspaceDir,
-      env: base.env,
-      onlyPluginIds: base.requestedPluginIds,
+      workspaceDir: params.workspaceDir,
+      env: params.env,
       includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
       registry: snapshot.index,
       manifestRegistry: snapshot.manifestRegistry,
-    });
-    const explicitOwnerPluginIds = resolveDiscoverableProviderOwnerPluginIds({
-      pluginIds: base.explicitOwnerPluginIds,
-      config: params.config,
-      workspaceDir: base.workspaceDir,
-      env: base.env,
-      includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
-      registry: snapshot.index,
-      manifestRegistry: snapshot.manifestRegistry,
-    });
-    const setupPluginIds = mergeExplicitOwnerPluginIds(providerPluginIds, explicitOwnerPluginIds);
-    if (setupPluginIds.length === 0) {
-      return undefined;
-    }
-    const setupConfig = withActivatedPluginIds({
-      config: base.rawConfig,
-      pluginIds: setupPluginIds,
-    });
-    return buildPluginRuntimeLoadOptionsFromValues(
-      {
+    };
+    const setup = params.mode === "setup";
+    const explicitOwnerPluginIds = (
+      setup ? resolveDiscoverableProviderOwnerPluginIds : resolveActivatableProviderOwnerPluginIds
+    )({ ...ownerLookup, pluginIds: selection.explicitOwnerPluginIds });
+    let activation: Pick<
+      PluginLoadOptions,
+      "config" | "activationSourceConfig" | "autoEnabledReasons"
+    >;
+    if (setup) {
+      selection.pluginIds = sortUniqueStrings([
+        ...resolveDiscoveredProviderPluginIds({
+          ...ownerLookup,
+          onlyPluginIds: selection.pluginIds,
+        }),
+        ...explicitOwnerPluginIds,
+      ]);
+      if (selection.pluginIds.length === 0) {
+        return undefined;
+      }
+      const setupConfig = withActivatedPluginIds({
+        config: params.config,
+        pluginIds: selection.pluginIds,
+      });
+      activation = {
         config: setupConfig,
         activationSourceConfig: setupConfig,
         autoEnabledReasons: {},
-        workspaceDir: base.workspaceDir,
-        env: base.env,
+      };
+    } else {
+      const onlyPluginIds =
+        selection.pluginIds !== undefined
+          ? sortUniqueStrings([...(params.onlyPluginIds ?? []), ...explicitOwnerPluginIds])
+          : undefined;
+      activation = resolveBundledCompatActivationInputs({
+        rawConfig: withActivatedPluginIds({
+          config: params.config,
+          pluginIds: explicitOwnerPluginIds,
+        }),
+        env: params.env,
+        workspaceDir: params.workspaceDir,
+        applyAutoEnable: params.applyAutoEnable ?? true,
+        discovery: snapshot.discovery,
+        manifestRegistry: snapshot.manifestRegistry,
+        onlyPluginIds,
+        resolveBundledPluginIds: resolveBundledProviderCompatPluginIds,
+        activation: "defaults",
+      });
+      const eligiblePluginIds = sortUniqueStrings([
+        ...resolveEnabledProviderPluginIds({
+          ...ownerLookup,
+          config: activation.config,
+          onlyPluginIds,
+        }),
+        ...explicitOwnerPluginIds,
+      ]);
+      selection.pluginIds = eligiblePluginIds;
+      selection.projectedPluginIds = selection.projectedPluginIds?.filter((pluginId) =>
+        eligiblePluginIds.includes(pluginId),
+      );
+    }
+    if (params.config !== undefined && sourceConfig !== params.config) {
+      // Activation copies runtime config; source validation still owns the original paired inputs.
+      activation.activationSourceConfig = withActivatedPluginIds({
+        config: sourceConfig,
+        pluginIds: setup ? selection.pluginIds : explicitOwnerPluginIds,
+      });
+    }
+    return buildPluginRuntimeLoadOptions(
+      {
+        ...activation,
+        workspaceDir: params.workspaceDir,
+        env: params.env,
         logger: createPluginRuntimeLoaderLogger(),
         manifestRegistry: snapshot.manifestRegistry,
         installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(snapshot.index),
       },
       {
-        onlyPluginIds: setupPluginIds,
+        onlyPluginIds: selection.pluginIds,
         pluginSdkResolution: params.pluginSdkResolution,
-        cache: params.cache ?? false,
-        activate: params.activate ?? false,
-      },
-    );
-  }
-
-  function resolveRuntimeProviderPluginLoadOptions(
-    params: Parameters<typeof resolvePluginProvidersCore>[0],
-    base: ReturnType<typeof resolvePluginProviderLoadBase>,
-    snapshot: PluginMetadataRegistryView,
-  ) {
-    const explicitOwnerPluginIds = resolveActivatableProviderOwnerPluginIds({
-      pluginIds: base.explicitOwnerPluginIds,
-      config: base.rawConfig,
-      workspaceDir: base.workspaceDir,
-      env: base.env,
-      includeUntrustedWorkspacePlugins: params.includeUntrustedWorkspacePlugins,
-      registry: snapshot.index,
-      manifestRegistry: snapshot.manifestRegistry,
-    });
-    const runtimeRequestedPluginIds =
-      base.requestedPluginIds !== undefined
-        ? sortUniqueStrings([...(params.onlyPluginIds ?? []), ...explicitOwnerPluginIds])
-        : undefined;
-    const requestConfig = withActivatedPluginIds({
-      config: base.rawConfig,
-      pluginIds: explicitOwnerPluginIds,
-    });
-    const activation = resolveBundledCompatActivationInputs({
-      rawConfig: requestConfig,
-      env: base.env,
-      workspaceDir: base.workspaceDir,
-      applyAutoEnable: params.applyAutoEnable ?? true,
-      discovery: snapshot.discovery,
-      manifestRegistry: snapshot.manifestRegistry,
-      onlyPluginIds: runtimeRequestedPluginIds,
-      resolveBundledPluginIds: resolveBundledProviderCompatPluginIds,
-      activation: "defaults",
-    });
-    const providerPluginIds = mergeExplicitOwnerPluginIds(
-      resolveEnabledProviderPluginIds({
-        config: activation.config,
-        workspaceDir: base.workspaceDir,
-        env: base.env,
-        onlyPluginIds: runtimeRequestedPluginIds,
-        registry: snapshot.index,
-        manifestRegistry: snapshot.manifestRegistry,
-      }),
-      explicitOwnerPluginIds,
-    );
-    return buildPluginRuntimeLoadOptionsFromValues(
-      {
-        config: activation.config,
-        activationSourceConfig: activation.activationSourceConfig,
-        autoEnabledReasons: activation.autoEnabledReasons,
-        workspaceDir: base.workspaceDir,
-        env: base.env,
-        logger: createPluginRuntimeLoaderLogger(),
-        manifestRegistry: snapshot.manifestRegistry,
-        installRecords: extractPluginInstallRecordsFromInstalledPluginIndex(snapshot.index),
-      },
-      {
-        onlyPluginIds: providerPluginIds,
-        pluginSdkResolution: params.pluginSdkResolution,
-        cache: params.cache ?? true,
+        cache: params.cache ?? !setup,
         activate: params.activate ?? false,
       },
     );
@@ -298,19 +316,77 @@ export function createProviderRegistryResolver(dependencies: {
   function isPluginProvidersLoadInFlight(
     params: Parameters<typeof resolvePluginProvidersCore>[0],
   ): boolean {
-    const { env, workspaceDir, snapshot } = resolveProviderMetadataLookup(params);
-    const base = resolvePluginProviderLoadBase({ ...params, workspaceDir, env }, snapshot);
-    const loadOptions =
-      params.mode === "setup"
-        ? resolveSetupProviderPluginLoadOptions(params, base, snapshot)
-        : resolveRuntimeProviderPluginLoadOptions(params, base, snapshot);
-    if (!loadOptions) {
-      return false;
-    }
-    return isPluginRegistryLoadInFlight(loadOptions);
+    const { loadOptions } = prepareProviderLookup({ ...params, registryScope: undefined });
+    return loadOptions !== undefined && isPluginRegistryLoadInFlight(loadOptions);
   }
 
-  function resolvePluginProvidersCore(params: {
+  function captureProviderRegistrySelection(
+    registry: PluginRegistry,
+    base: ReturnType<typeof prepareProviderSelection>,
+    onlyPluginIds?: readonly string[],
+  ) {
+    return {
+      registry,
+      workspaceDir: base.workspaceDir,
+      onlyPluginIds,
+      isProviderOwnerEligible: (pluginId: string, provider: string) =>
+        (!onlyPluginIds || onlyPluginIds.includes(pluginId)) &&
+        matchesDeclaredProviderOwner(base.declaredProviderOwners, provider, pluginId),
+    };
+  }
+
+  function resolveProviderRegistryCandidate(
+    registry: PluginRegistry,
+    selection: ReturnType<typeof prepareProviderSelection>,
+    retained: boolean,
+    aliasOwners: readonly string[],
+    lookup: ReturnType<typeof createRuntimePluginManifestLookup> | undefined,
+  ): ReturnType<typeof captureProviderRegistrySelection> | undefined {
+    let onlyPluginIds = selection.pluginIds;
+    let projectedPluginIds = selection.projectedPluginIds ?? onlyPluginIds;
+    if (selection.unownedProviderRefs.length > 0) {
+      onlyPluginIds = sortUniqueStrings([...(onlyPluginIds ?? []), ...aliasOwners]);
+      projectedPluginIds = sortUniqueStrings([...(projectedPluginIds ?? []), ...aliasOwners]);
+    }
+    if (retained) {
+      return captureProviderRegistrySelection(registry, selection, projectedPluginIds);
+    }
+    if (!registryContainsRuntimePluginIds(registry, onlyPluginIds)) {
+      return undefined;
+    }
+    if (lookup) {
+      const providerOwners = new Set(registry.providers.map((entry) => entry.pluginId));
+      // Manifest-preseeded record.providerIds cannot prove registration. Rows do;
+      // activation-only helpers instead need a successful capability-enabled pass.
+      for (const id of onlyPluginIds ?? []) {
+        const record = lookup(id);
+        if (
+          !record ||
+          (selection.providerRegistrationPluginIds.has(id)
+            ? !providerOwners.has(id)
+            : selection.runtimeRegistrationPluginIds.has(id) &&
+              !hasCompletedPluginRuntimeRegistration(record))
+        ) {
+          return undefined;
+        }
+      }
+      onlyPluginIds ??= sortUniqueStrings(
+        registry.providers.map((entry) => entry.pluginId).filter(lookup),
+      );
+    }
+    // Query refs are alternative names or API-owner hints. Owner completeness
+    // above remains mandatory; reuse also needs a provider matching the query.
+    return registry.providers.some(
+      ({ pluginId, provider }) =>
+        (!onlyPluginIds || onlyPluginIds.includes(pluginId)) &&
+        (!selection.providerRefs?.length ||
+          selection.providerRefs.some((ref) => matchesProviderPluginRef(provider, ref))),
+    )
+      ? captureProviderRegistrySelection(registry, selection, projectedPluginIds ?? onlyPluginIds)
+      : undefined;
+  }
+
+  function resolvePluginProviderRegistryCore(params: {
     config?: PluginLoadOptions["config"];
     workspaceDir?: string;
     /** Use an explicit env when plugin roots should resolve independently from process.env. */
@@ -328,52 +404,188 @@ export function createProviderRegistryResolver(dependencies: {
     includeUntrustedWorkspacePlugins?: boolean;
     pluginMetadataSnapshot?: PluginMetadataRegistryView;
     skipIfLoadInFlight?: boolean;
-  }): ProviderPlugin[] {
-    const { env, workspaceDir, snapshot } = resolveProviderMetadataLookup(params);
-    const base = resolvePluginProviderLoadBase({ ...params, workspaceDir, env }, snapshot);
-    if (params.mode === "setup") {
-      const loadOptions = resolveSetupProviderPluginLoadOptions(params, base, snapshot);
-      if (!loadOptions) {
-        return [];
-      }
-      if (params.skipIfLoadInFlight && isPluginRegistryLoadInFlight(loadOptions)) {
-        return [];
-      }
-      const registry = loadOpenClawPlugins(loadOptions);
-      return registry.providers.map((entry) =>
-        Object.assign({}, entry.provider, { pluginId: entry.pluginId }),
-      );
+    /** Exact preparation or loaded-only inspection without discovery/activation. */
+    registryScope?: "exact" | "loaded";
+  }): ReturnType<typeof captureProviderRegistrySelection> | undefined {
+    if (params.mode === "setup" && params.registryScope === "loaded") {
+      return undefined;
     }
-    const loadOptions = resolveRuntimeProviderPluginLoadOptions(params, base, snapshot);
-    const generationRegistry = getPluginRuntimeGenerationRegistry();
+    const generationRegistry =
+      params.mode === "setup" ? undefined : getPluginRuntimeGenerationRegistry();
+    const prepared = prepareProviderLookup(params, Boolean(generationRegistry));
+    const { inputs, snapshot } = prepared;
+    let { loadOptions } = prepared;
+    const { env, workspaceDir } = inputs;
+    const registrationConfigKey =
+      !generationRegistry && params.config !== undefined
+        ? resolvePluginRegistrationConfigKey(
+            loadOptions ?? {
+              config: params.config,
+              activationSourceConfig: resolvePluginActivationSourceConfig(params),
+            },
+          )
+        : undefined;
+    if (params.skipIfLoadInFlight && loadOptions && isPluginRegistryLoadInFlight(loadOptions)) {
+      return undefined;
+    }
+    const prepareRegistry = (
+      registry: PluginRegistry,
+      selection: ReturnType<typeof prepareProviderSelection>,
+    ) => {
+      const lookup =
+        !generationRegistry && selection.manifestRegistry
+          ? createRuntimePluginManifestLookup(registry, selection.manifestRegistry.plugins)
+          : undefined;
+      const aliasOwners =
+        selection.unownedProviderRefs.length > 0
+          ? registry.providers
+              .filter(
+                ({ pluginId, provider }) =>
+                  (!selection.onlyPluginIds || selection.onlyPluginIds.includes(pluginId)) &&
+                  selection.unownedProviderRefs.some((ref) =>
+                    matchesProviderPluginRef(provider, ref),
+                  ) &&
+                  (!lookup || Boolean(lookup(pluginId))),
+              )
+              .map((entry) => entry.pluginId)
+          : [];
+      return {
+        lookup,
+        aliasOwners:
+          !generationRegistry && snapshot && aliasOwners.length > 0
+            ? resolveActivatableProviderOwnerPluginIds({
+                ...inputs,
+                pluginIds: aliasOwners,
+                registry: snapshot.index,
+                manifestRegistry: snapshot.manifestRegistry,
+              })
+            : aliasOwners,
+      };
+    };
+    if (generationRegistry || params.mode !== "setup") {
+      const request = getPluginRuntimeGatewayRequestScope()?.pluginRegistry;
+      const requestContext = getPluginRuntimeLoadContext(request);
+      const candidates = generationRegistry
+        ? [generationRegistry]
+        : [
+            requestContext && requestContext.workspaceDir === workspaceDir ? request : undefined,
+            getLoadedRuntimePluginRegistry({ env, workspaceDir }),
+          ];
+      for (const registry of candidates) {
+        if (!registry) {
+          continue;
+        }
+        const context = getPluginRuntimeLoadContext(registry);
+        // Without requested metadata, a loaded-only lookup may use the captured
+        // owner only after its discovery/policy scope agrees with the caller.
+        if (
+          !snapshot &&
+          !generationRegistry &&
+          context &&
+          resolvePluginControlPlaneFingerprint({
+            config: params.config ?? context.rawConfig,
+            env: params.env ?? context.env,
+            workspaceDir,
+          }) !== context.controlPlaneFingerprint
+        ) {
+          continue;
+        }
+        const selection =
+          prepared.selection ??
+          prepareProviderSelection(
+            inputs,
+            context?.manifestRegistry,
+            context?.declaredProviderOwners,
+          );
+        const { lookup, aliasOwners } = prepareRegistry(registry, selection);
+        if (
+          !generationRegistry &&
+          snapshot &&
+          aliasOwners.some((id) => !selection.explicitOwnerPluginIds.includes(id))
+        ) {
+          // Old eligible aliases supply reload hints. Keep the static receiver projection
+          // unchanged: refreshed registrations decide which aliases still exist.
+          selection.explicitOwnerPluginIds = sortUniqueStrings([
+            ...selection.explicitOwnerPluginIds,
+            ...aliasOwners,
+          ]);
+          loadOptions = resolveProviderLoadOptions(inputs, selection, snapshot);
+          if (
+            params.skipIfLoadInFlight &&
+            loadOptions &&
+            isPluginRegistryLoadInFlight(loadOptions)
+          ) {
+            return undefined;
+          }
+        }
+        // Exact preparation may learn aliases here, but its owner load must still run.
+        if (
+          (!generationRegistry && params.registryScope === "exact") ||
+          (context &&
+            registrationConfigKey !== undefined &&
+            registrationConfigKey !== context.registrationConfigKey)
+        ) {
+          continue;
+        }
+        const selected = resolveProviderRegistryCandidate(
+          registry,
+          selection,
+          Boolean(generationRegistry),
+          aliasOwners,
+          lookup,
+        );
+        if (selected) {
+          return selected;
+        }
+      }
+    }
     if (
-      !generationRegistry &&
-      params.skipIfLoadInFlight &&
-      isPluginRegistryLoadInFlight(loadOptions)
+      generationRegistry ||
+      params.registryScope === "loaded" ||
+      !loadOptions ||
+      !prepared.selection ||
+      loadOptions.onlyPluginIds?.length === 0
     ) {
-      return [];
+      return undefined;
     }
-    const onlyPluginIds = loadOptions.onlyPluginIds;
-    // Prepared discovery must retain its exact runtime artifacts, including an empty selection.
     const registry =
-      onlyPluginIds?.length === 0
-        ? undefined
-        : (generationRegistry ??
-          getLoadedRuntimePluginRegistry({
-            env: base.env,
-            loadOptions,
-            workspaceDir: base.workspaceDir,
-            requiredPluginIds: onlyPluginIds,
-          }) ??
-          resolveRuntimePluginRegistry(loadOptions));
+      params.mode === "setup" || params.registryScope === "exact"
+        ? loadOpenClawPlugins(loadOptions)
+        : resolveRuntimePluginRegistry(loadOptions);
     if (!registry) {
+      return undefined;
+    }
+    const projectedPluginIds = prepared.selection.projectedPluginIds ?? loadOptions.onlyPluginIds;
+    return captureProviderRegistrySelection(
+      registry,
+      prepared.selection,
+      params.mode !== "setup" && projectedPluginIds
+        ? sortUniqueStrings([
+            ...projectedPluginIds,
+            ...(prepared.selection.unownedProviderRefs.length > 0
+              ? prepareRegistry(registry, prepared.selection).aliasOwners
+              : []),
+          ])
+        : undefined,
+    );
+  }
+
+  function resolvePluginProvidersCore(
+    params: Parameters<typeof resolvePluginProviderRegistryCore>[0],
+  ): ProviderPlugin[] {
+    const resolved = resolvePluginProviderRegistryCore(params);
+    if (!resolved) {
       return [];
     }
-
+    const { registry, onlyPluginIds } = resolved;
     return registry.providers
       .filter((entry) => !onlyPluginIds || onlyPluginIds.includes(entry.pluginId))
       .map((entry) => Object.assign({}, entry.provider, { pluginId: entry.pluginId }));
   }
 
-  return { isPluginProvidersLoadInFlight, resolvePluginProvidersCore };
+  return {
+    isPluginProvidersLoadInFlight,
+    resolvePluginProviderRegistryCore,
+    resolvePluginProvidersCore,
+  };
 }

--- a/src/plugins/providers.runtime.consult-current-snapshot.test.ts
+++ b/src/plugins/providers.runtime.consult-current-snapshot.test.ts
@@ -7,9 +7,14 @@ import {
   setCurrentPluginMetadataSnapshot,
 } from "./current-plugin-metadata.test-support.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
+import { createPluginRecord } from "./loader-records.js";
 import type { PluginManifestRegistry } from "./manifest-registry.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
+import {
+  bindPluginRuntimeArtifactSelection,
+  resolvePluginRuntimeArtifactSelection,
+} from "./plugin-runtime-artifact-selection.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "./runtime.js";
 import { withPluginRuntimeGenerationScope } from "./runtime/generation-scope.js";
@@ -157,6 +162,18 @@ describe("provider runtime consults the current plugin metadata snapshot", () =>
         source: `/plugins/${pluginId}/index.js`,
       }));
       const activeRegistry = createEmptyPluginRegistry();
+      activeRegistry.plugins = metadataSnapshot.plugins.map((plugin) => {
+        const record = createPluginRecord({ ...plugin, enabled: true, configSchema: true });
+        bindPluginRuntimeArtifactSelection(record, {
+          preferBuiltPluginArtifacts: false,
+          runtimeEntry: resolvePluginRuntimeArtifactSelection({
+            ...plugin,
+            entryKind: "runtime",
+            preferBuiltPluginArtifacts: false,
+          }),
+        });
+        return record;
+      });
       activeRegistry.providers = [
         { ...pluginRegistry.providers[0]!, provider: { id: "demo", label: "active", auth: [] } },
       ];

--- a/src/plugins/providers.runtime.owner-completeness.test.ts
+++ b/src/plugins/providers.runtime.owner-completeness.test.ts
@@ -1,0 +1,367 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterAll, afterEach, describe, expect, it } from "vitest";
+import {
+  cleanupPluginLoaderFixturesForTest,
+  clearPluginLoaderCache,
+  EMPTY_PLUGIN_SCHEMA,
+  loadOpenClawPlugins,
+  makePluginLoaderTempDir,
+  writePlugin,
+} from "./loader.test-fixtures.js";
+import { createPluginMetadataSnapshotFixture } from "./plugin-metadata.test-support.js";
+import {
+  resolveLoadedProviderPluginsForHooks,
+  resolveProviderPluginsForHooks,
+  resolveProviderRuntimePluginHandle,
+} from "./provider-hook-runtime.js";
+import { findProviderRuntimePluginInRegistry } from "./provider-registry-selection.js";
+import { resolvePluginProvidersCore } from "./providers.runtime.js";
+import { setActivePluginRegistry } from "./runtime.js";
+import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.js";
+import { withPluginRuntimeGenerationScope } from "./runtime/generation-scope.js";
+
+function fixture(
+  declaration: "setup" | "activation" | "cli",
+  registersProvider = true,
+  triggerProvider = "helper-provider",
+) {
+  const root = makePluginLoaderTempDir();
+  const marker = path.join(root, "registrations.log");
+  const helper = writePlugin({
+    id: "helper-owner",
+    dir: root,
+    filename: "index.cjs",
+    body: `module.exports={id:"helper-owner",register(api){
+      require("node:fs").appendFileSync(${JSON.stringify(marker)},"registered");
+      ${registersProvider ? 'api.registerProvider({id:"helper-provider",label:"Helper",auth:[]});' : ""}
+    }};`,
+  });
+  const other = writePlugin({
+    id: "other-owner",
+    filename: "index.cjs",
+    body: 'module.exports={id:"other-owner",register(api){api.registerProvider({id:"other-provider",label:"Other",auth:[]});}};',
+  });
+  const setupSource = path.join(root, "setup.cjs");
+  writeFileSync(
+    setupSource,
+    'module.exports={plugin:{id:"setup-channel",meta:{id:"setup-channel",label:"Setup",selectionLabel:"Setup",docsPath:"/synthetic",blurb:"Synthetic"},capabilities:{chatTypes:["direct"]},config:{listAccountIds:()=>[],resolveAccount:()=>({})}}};',
+  );
+  const helperManifest = {
+    id: "helper-owner",
+    origin: "global" as const,
+    rootDir: root,
+    source: helper.file,
+    setupSource,
+    channels: ["setup-channel"],
+    providers: [],
+    configSchema: EMPTY_PLUGIN_SCHEMA,
+    ...(declaration === "setup"
+      ? { setup: { providers: [{ id: "helper-provider" }] } }
+      : declaration === "activation"
+        ? { activation: { onProviders: [triggerProvider] } }
+        : { cliBackends: ["helper-cli"] }),
+  };
+  const otherManifest = {
+    id: "other-owner",
+    origin: "global" as const,
+    rootDir: other.dir,
+    source: other.file,
+    providers: ["other-provider"],
+    configSchema: EMPTY_PLUGIN_SCHEMA,
+  };
+  for (const manifest of [helperManifest, otherManifest]) {
+    writeFileSync(path.join(manifest.rootDir, "openclaw.plugin.json"), JSON.stringify(manifest));
+  }
+  const snapshot = createPluginMetadataSnapshotFixture({
+    plugins: [helperManifest, otherManifest],
+  });
+  const config = {
+    plugins: {
+      allow: ["helper-owner", "other-owner"],
+      entries: { "helper-owner": { enabled: true }, "other-owner": { enabled: true } },
+    },
+  };
+  const query = {
+    config,
+    env: {},
+    pluginMetadataSnapshot: snapshot,
+    providerRefs: [declaration === "cli" ? "helper-cli" : "helper-provider", "other-provider"],
+    onlyPluginIds: ["helper-owner", "other-owner"],
+  };
+  return {
+    query,
+    snapshot,
+    helperSource: helper.file,
+    otherSource: other.file,
+    registrations: () => (existsSync(marker) ? readFileSync(marker, "utf8") : ""),
+    load: (channelPluginLoadIntent: "setup" | "full", onlyPluginIds = query.onlyPluginIds) =>
+      loadOpenClawPlugins({
+        config,
+        env: {},
+        installRecords: {},
+        onlyPluginIds,
+        manifestRegistry: snapshot.manifestRegistry,
+        channelPluginLoadIntent,
+        activate: false,
+      }),
+  };
+}
+
+afterEach(clearPluginLoaderCache);
+afterAll(cleanupPluginLoaderFixturesForTest);
+
+describe("provider selection registration coverage", () => {
+  it.each(["active", "request", "retained"] as const)(
+    "keeps current policy separate from a mixed %s receiver projection",
+    (scope) => {
+      const proof = fixture("setup");
+      const loaded = proof.load("full");
+      const all = ["Helper", "Other"];
+      expect(loaded.providers.map(({ provider }) => provider.label)).toEqual(all);
+      const query = {
+        ...proof.query,
+        config: {
+          plugins: {
+            ...proof.query.config.plugins,
+            entries: {
+              ...proof.query.config.plugins.entries,
+              "helper-owner": { enabled: false },
+            },
+          },
+        },
+      };
+      const verify = () => {
+        const expected = scope === "retained" ? all : ["Other"];
+        expect(
+          resolveLoadedProviderPluginsForHooks(query)?.map((provider) => provider.label),
+        ).toEqual(expected);
+        expect(resolveProviderPluginsForHooks(query).map((provider) => provider.label)).toEqual(
+          expected,
+        );
+        expect(loaded.providers.map(({ provider }) => provider.label)).toEqual(all);
+        expect(proof.registrations()).toBe("registered");
+        expect(
+          resolveProviderPluginsForHooks(proof.query).map((provider) => provider.label),
+        ).toEqual(all);
+        expect(
+          resolveProviderPluginsForHooks({ ...query, providerRefs: ["other-provider"] }).map(
+            (provider) => provider.label,
+          ),
+        ).toEqual(["Other"]);
+        expect(
+          resolveProviderPluginsForHooks({ ...query, providerRefs: ["helper-provider"] }).map(
+            (provider) => provider.label,
+          ),
+        ).toEqual(scope === "retained" ? ["Helper"] : []);
+        expect(
+          resolvePluginProvidersCore({ ...query, registryScope: "exact" }).map(
+            (provider) => provider.label,
+          ),
+        ).toEqual(expected);
+      };
+      if (scope === "retained") {
+        withPluginRuntimeGenerationScope(
+          { metadataSnapshot: proof.snapshot, pluginRegistry: loaded },
+          verify,
+        );
+      } else if (scope === "request") {
+        withPluginRuntimeRegistryScope(loaded, verify);
+      } else {
+        setActivePluginRegistry(loaded, "mixed-current-policy");
+        verify();
+      }
+    },
+  );
+
+  it("runs an activation helper beside the declared provider without projecting it as the receiver", () => {
+    const proof = fixture("activation", false, "other-provider");
+    expect(
+      resolveProviderPluginsForHooks({ ...proof.query, providerRefs: ["other-provider"] }).map(
+        (provider) => provider.label,
+      ),
+    ).toEqual(["Other"]);
+    expect(proof.registrations()).toBe("registered");
+  });
+
+  it.each([
+    "active",
+    "request",
+    "retained",
+    "missing helper",
+    "disabled alias owner",
+    "replaced alias owner",
+    "retained disabled owner",
+  ] as const)("resolves runtime aliases beside activation helpers in the %s registry", (scope) => {
+    const proof = fixture("activation", false);
+    const aliasCalls = path.join(path.dirname(proof.otherSource), "alias-calls");
+    writeFileSync(
+      proof.otherSource,
+      `module.exports={id:"other-owner",register(api){api.registerProvider({id:"other-provider",label:"Other",auth:[],hookAliases:["helper-provider"],normalizeModelId(){require("node:fs").appendFileSync(${JSON.stringify(aliasCalls)}, "called");return "alias-current";}});}};`,
+    );
+    const blockedAlias = scope === "disabled alias owner" || scope === "replaced alias owner";
+    const missingHelper = scope === "missing helper" || scope === "replaced alias owner";
+    const loaded = proof.load("full", missingHelper ? ["other-owner"] : undefined);
+    expect(proof.registrations()).toBe(missingHelper ? "" : "registered");
+    const unexpectedImport = path.join(path.dirname(proof.otherSource), "replacement-imported");
+    const replacementSource = path.join(path.dirname(proof.otherSource), "replacement.cjs");
+    if (scope === "replaced alias owner") {
+      writeFileSync(
+        replacementSource,
+        `require("node:fs").writeFileSync(${JSON.stringify(unexpectedImport)}, "imported");
+          module.exports={id:"other-owner",register(api){api.registerProvider({id:"other-provider",label:"Replacement",auth:[],hookAliases:["helper-provider"]});}};`,
+      );
+    }
+    const query = {
+      ...proof.query,
+      ...(scope === "disabled alias owner" || scope === "retained disabled owner"
+        ? {
+            config: {
+              plugins: {
+                ...proof.query.config.plugins,
+                entries: {
+                  ...proof.query.config.plugins.entries,
+                  "other-owner": { enabled: false },
+                },
+              },
+            },
+          }
+        : {}),
+      ...(scope === "replaced alias owner"
+        ? {
+            pluginMetadataSnapshot: createPluginMetadataSnapshotFixture({
+              plugins: proof.snapshot.plugins.map((plugin) =>
+                plugin.id === "other-owner" ? { ...plugin, source: replacementSource } : plugin,
+              ),
+            }),
+          }
+        : {}),
+      providerRefs: ["helper-provider"],
+      onlyPluginIds: missingHelper ? undefined : proof.query.onlyPluginIds,
+    };
+    const verify = () => {
+      expect(
+        resolveLoadedProviderPluginsForHooks(query)?.map((provider) => provider.label),
+      ).toEqual(missingHelper || blockedAlias ? undefined : ["Other"]);
+      expect(proof.registrations()).toBe(missingHelper ? "" : "registered");
+      expect(resolveProviderPluginsForHooks(query).map((provider) => provider.label)).toEqual(
+        blockedAlias ? [] : ["Other"],
+      );
+      // Disabling A creates a new policy/scope key; the helper completes once in
+      // that new registry, in addition to its original warm registration.
+      const expectedRegistrations =
+        scope === "disabled alias owner" ? "registeredregistered" : "registered";
+      expect(proof.registrations()).toBe(expectedRegistrations);
+      const handle = resolveProviderRuntimePluginHandle({ ...query, provider: "helper-provider" });
+      expect(handle.plugin?.id).toBe(blockedAlias ? undefined : "other-provider");
+      expect(
+        handle.plugin?.normalizeModelId?.({ provider: "helper-provider", modelId: "legacy" }),
+      ).toBe(blockedAlias ? undefined : "alias-current");
+      expect(existsSync(aliasCalls) ? readFileSync(aliasCalls, "utf8") : "").toBe(
+        blockedAlias ? "" : "called",
+      );
+      expect(proof.registrations()).toBe(expectedRegistrations);
+      expect(existsSync(unexpectedImport)).toBe(false);
+      expect(resolveProviderPluginsForHooks({ ...query, onlyPluginIds: ["helper-owner"] })).toEqual(
+        [],
+      );
+    };
+    if (scope === "retained" || scope === "retained disabled owner") {
+      withPluginRuntimeGenerationScope(
+        { metadataSnapshot: proof.snapshot, pluginRegistry: loaded },
+        verify,
+      );
+    } else if (scope === "request") {
+      withPluginRuntimeRegistryScope(loaded, verify);
+    } else {
+      setActivePluginRegistry(loaded, "active-alias");
+      verify();
+    }
+  });
+
+  it("keeps a failed declared receiver reserved for raw parser and hook lookups", () => {
+    const proof = fixture("setup");
+    writeFileSync(
+      proof.helperSource,
+      'module.exports={id:"helper-owner",register(){throw new Error("synthetic registration failure");}};',
+    );
+    writeFileSync(
+      proof.otherSource,
+      'module.exports={id:"other-owner",register(api){api.registerProvider({id:"other-provider",label:"Other",auth:[],hookAliases:["helper-provider"],normalizeModelId:()=>"wrong-owner"});}};',
+    );
+    const registry = proof.load("full");
+    setActivePluginRegistry(registry, "failed-receiver");
+    const lookup = () =>
+      findProviderRuntimePluginInRegistry({ registry, provider: "helper-provider", ownerRefs: [] });
+    expect(lookup() === undefined).toBe(true);
+    withPluginRuntimeGenerationScope(
+      { metadataSnapshot: proof.snapshot, pluginRegistry: registry },
+      () => {
+        expect(lookup() === undefined).toBe(true);
+        expect(
+          resolveProviderPluginsForHooks({ ...proof.query, providerRefs: ["helper-provider"] }),
+        ).toEqual([]);
+      },
+    );
+    expect(
+      resolveProviderPluginsForHooks({ ...proof.query, providerRefs: ["helper-provider"] }),
+    ).toEqual([]);
+  });
+
+  it.each(["setup", "activation"] as const)(
+    "completes a provider selected through %s metadata",
+    (declaration) => {
+      const proof = fixture(declaration);
+      const partial = proof.load("setup");
+      setActivePluginRegistry(partial, "partial");
+      expect(partial.providers.map((entry) => entry.provider.label)).toEqual(["Other"]);
+      expect(resolveLoadedProviderPluginsForHooks(proof.query) === undefined).toBe(true);
+      expect(resolveProviderPluginsForHooks(proof.query).map((provider) => provider.label)).toEqual(
+        ["Helper", "Other"],
+      );
+      expect(proof.load("full").providers.map((entry) => entry.provider.label)).toEqual([
+        "Helper",
+        "Other",
+      ]);
+    },
+  );
+
+  it.each(["setup", "full"] as const)(
+    "keeps a non-provider activation helper's %s registration pass distinct",
+    (intent) => {
+      const proof = fixture("activation", false);
+      const registry = proof.load(intent);
+      setActivePluginRegistry(registry, intent);
+      const before = intent === "full" ? "registered" : "";
+      expect(proof.registrations()).toBe(before);
+      withPluginRuntimeGenerationScope(
+        { metadataSnapshot: proof.snapshot, pluginRegistry: registry },
+        () => {
+          expect(
+            resolveProviderPluginsForHooks(proof.query).map((provider) => provider.label),
+          ).toEqual(["Other"]);
+          expect(proof.registrations()).toBe(before);
+        },
+      );
+      expect(
+        resolveLoadedProviderPluginsForHooks(proof.query)?.map((provider) => provider.label),
+      ).toEqual(intent === "full" ? ["Other"] : undefined);
+      expect(resolveProviderPluginsForHooks(proof.query).map((provider) => provider.label)).toEqual(
+        ["Other"],
+      );
+      expect(proof.registrations()).toBe("registered");
+    },
+  );
+
+  it("does not require provider registration from a CLI-backend-only owner", () => {
+    const proof = fixture("cli", false);
+    setActivePluginRegistry(proof.load("setup"), "cli-only");
+    expect(
+      resolveLoadedProviderPluginsForHooks(proof.query)?.map((provider) => provider.label),
+    ).toEqual(["Other"]);
+    expect(resolveProviderPluginsForHooks(proof.query).map((provider) => provider.label)).toEqual([
+      "Other",
+    ]);
+    expect(proof.registrations()).toBe("");
+  });
+});

--- a/src/plugins/providers.runtime.ts
+++ b/src/plugins/providers.runtime.ts
@@ -1,3 +1,6 @@
 import { nativePluginBindings } from "./loader-runtime-load.js";
-export const { isPluginProvidersLoadInFlight, resolvePluginProvidersCore } =
-  nativePluginBindings.providerRegistry;
+export const {
+  isPluginProvidersLoadInFlight,
+  resolvePluginProviderRegistryCore,
+  resolvePluginProvidersCore,
+} = nativePluginBindings.providerRegistry;

--- a/src/plugins/registry-types.ts
+++ b/src/plugins/registry-types.ts
@@ -43,6 +43,7 @@ import type {
   PluginManifestMcpServer,
 } from "./manifest.js";
 import type { PluginKind } from "./plugin-kind.types.js";
+import type { PluginProviderRegistration } from "./provider-plugin.types.js";
 import type {
   ContextEngineRegistration,
   MemoryCorpusSupplementRegistration,
@@ -91,7 +92,6 @@ type PluginLogger = import("./types.js").PluginLogger;
 type PluginOrigin = import("./types.js").PluginOrigin;
 type PluginTextTransformRegistration = import("./types.js").PluginTextTransformRegistration;
 type MigrationProviderPlugin = import("./types.js").MigrationProviderPlugin;
-type ProviderPlugin = import("./types.js").ProviderPlugin;
 type RealtimeTranscriptionProviderPlugin = import("./types.js").RealtimeTranscriptionProviderPlugin;
 type RealtimeVoiceProviderPlugin = import("./types.js").RealtimeVoiceProviderPlugin;
 type SpeechProviderPlugin = import("./types.js").SpeechProviderPlugin;
@@ -172,14 +172,6 @@ type PluginChannelSetupRegistration = {
   origin?: PluginOrigin;
   source: string;
   enabled: boolean;
-  rootDir?: string;
-};
-
-type PluginProviderRegistration = {
-  pluginId: string;
-  pluginName?: string;
-  provider: ProviderPlugin;
-  source: string;
   rootDir?: string;
 };
 

--- a/src/plugins/runtime.ts
+++ b/src/plugins/runtime.ts
@@ -19,7 +19,9 @@ import { markPluginRegistryActive, markPluginRegistryRetired } from "./registry-
 import type { PluginRegistry } from "./registry-types.js";
 import { getActivePluginChannelRegistrySnapshotFromState } from "./runtime-channel-state.js";
 import { PLUGIN_REGISTRY_STATE, type RegistryState } from "./runtime-state.js";
-import { getPluginRuntimeGatewayRequestScope } from "./runtime/gateway-request-scope.js";
+import { getPluginRegistryForContext } from "./runtime/gateway-request-scope.js";
+
+export { getPluginRegistryForContext };
 
 const log = createSubsystemLogger("plugins/runtime");
 
@@ -262,15 +264,6 @@ export function getActivePluginRegistry(): PluginRegistry | null {
 
 export function getActivePluginRegistryWorkspaceDir(): string | undefined {
   return state.workspaceDir ?? undefined;
-}
-
-/** Reads registration/request/active registry precedence without initializing a cold runtime. */
-export function getPluginRegistryForContext(): PluginRegistry | null {
-  return (
-    state.registrationContext?.registry ??
-    getPluginRuntimeGatewayRequestScope()?.pluginRegistry ??
-    getActivePluginRegistry()
-  );
 }
 
 export function requireActivePluginRegistry(): PluginRegistry {

--- a/src/plugins/runtime/gateway-request-scope.ts
+++ b/src/plugins/runtime/gateway-request-scope.ts
@@ -7,8 +7,11 @@ import type {
 } from "../../gateway/server-methods/types.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import type { PluginOrigin } from "../plugin-origin.types.js";
+import type { DeclaredProviderOwnerIndex } from "../provider-owner-index.js";
 import type { PluginRegistry } from "../registry-types.js";
+import { getPluginRegistryState } from "../runtime-state.js";
 import type { OpenClawPluginNodeWorkspace } from "../types.node-host.js";
+import { getPluginRuntimeLoadContextState } from "./load-context-state.js";
 
 type PluginRuntimeGatewayRequestScope = {
   /** Exact placement owner captured before the local harness begins. */
@@ -51,6 +54,7 @@ type PluginRuntimeGatewayRequestScope = {
   pluginTrustedOfficialInstall?: boolean;
   gatewayMethodDispatchAllowed?: boolean;
   pluginRegistry?: PluginRegistry;
+  declaredProviderOwners?: DeclaredProviderOwnerIndex;
 };
 
 type PluginRuntimePluginScope = {
@@ -176,13 +180,21 @@ export function withPluginRuntimeGatewayContextResolver<T>(
 export function withPluginRuntimeRegistryScope<T>(
   registry: PluginRegistry | undefined,
   run: () => T,
+  declaredProviderOwners?: DeclaredProviderOwnerIndex,
 ): T {
   if (!registry) {
     return run();
   }
   const current = pluginRuntimeGatewayRequestScope.getStore();
   return pluginRuntimeGatewayRequestScope.run(
-    { isWebchatConnect: () => false, ...current, pluginRegistry: registry },
+    {
+      isWebchatConnect: () => false,
+      ...current,
+      pluginRegistry: registry,
+      declaredProviderOwners:
+        declaredProviderOwners ??
+        getPluginRuntimeLoadContextState(registry)?.declaredProviderOwners,
+    },
     run,
   );
 }
@@ -230,4 +242,15 @@ export function getPluginRuntimeGatewayRequestScope():
   | PluginRuntimeGatewayRequestScope
   | undefined {
   return pluginRuntimeGatewayRequestScope.getStore();
+}
+
+/** Reads registration/request/active registry precedence without initializing a cold runtime. */
+export function getPluginRegistryForContext(): PluginRegistry | null {
+  const state = getPluginRegistryState();
+  return (
+    state?.registrationContext?.registry ??
+    getPluginRuntimeGatewayRequestScope()?.pluginRegistry ??
+    state?.activeRegistry ??
+    null
+  );
 }

--- a/src/plugins/runtime/generation-scope.ts
+++ b/src/plugins/runtime/generation-scope.ts
@@ -1,18 +1,11 @@
-import { AsyncLocalStorage } from "node:async_hooks";
-import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { withPluginMetadataSnapshotScope } from "../current-plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugin-metadata-snapshot.types.js";
 import { createEmptyPluginRegistry } from "../registry-empty.js";
 import type { PluginRegistry } from "../registry-types.js";
 import { withPluginRuntimeRegistryScope } from "./gateway-request-scope.js";
+import { withPluginRuntimeGenerationRegistryScope } from "./generation-state.js";
 
-const PLUGIN_RUNTIME_GENERATION_REGISTRY_SCOPE_KEY: unique symbol = Symbol.for(
-  "openclaw.pluginRuntimeGenerationRegistryScope",
-);
-
-const pluginRuntimeGenerationRegistryScope = resolveGlobalSingleton<
-  AsyncLocalStorage<PluginRegistry>
->(PLUGIN_RUNTIME_GENERATION_REGISTRY_SCOPE_KEY, () => new AsyncLocalStorage<PluginRegistry>());
+export { getPluginRuntimeGenerationRegistry } from "./generation-state.js";
 
 /** Carries one prepared plugin generation through all nested runtime lookups. */
 export function withPluginRuntimeGenerationScope<T>(
@@ -26,15 +19,14 @@ export function withPluginRuntimeGenerationScope<T>(
   return withPluginMetadataSnapshotScope(
     generation.metadataSnapshot,
     () =>
-      pluginRuntimeGenerationRegistryScope.run(pluginRegistry, () =>
-        withPluginRuntimeRegistryScope(pluginRegistry, run),
+      withPluginRuntimeGenerationRegistryScope(pluginRegistry, () =>
+        withPluginRuntimeRegistryScope(
+          pluginRegistry,
+          run,
+          generation.metadataSnapshot.declaredProviderOwners,
+        ),
       ),
     // The prepared generation already owns discovery and policy compatibility.
     { trustConfigIdentity: true },
   );
-}
-
-/** Exact registry owned by the prepared generation, when one is active. */
-export function getPluginRuntimeGenerationRegistry(): PluginRegistry | undefined {
-  return pluginRuntimeGenerationRegistryScope.getStore();
 }

--- a/src/plugins/runtime/generation-state.ts
+++ b/src/plugins/runtime/generation-state.ts
@@ -1,0 +1,21 @@
+// Keep retained registry reads independent of metadata discovery and plugin loading.
+import { AsyncLocalStorage } from "node:async_hooks";
+import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
+import type { PluginRegistry } from "../registry-types.js";
+
+const registryScope = resolveGlobalSingleton<AsyncLocalStorage<PluginRegistry>>(
+  Symbol.for("openclaw.pluginRuntimeGenerationRegistryScope"),
+  () => new AsyncLocalStorage<PluginRegistry>(),
+);
+
+export function withPluginRuntimeGenerationRegistryScope<T>(
+  registry: PluginRegistry,
+  run: () => T,
+): T {
+  return registryScope.run(registry, run);
+}
+
+/** Exact registry owned by the prepared generation, including empty selections. */
+export function getPluginRuntimeGenerationRegistry(): PluginRegistry | undefined {
+  return registryScope.getStore();
+}

--- a/src/plugins/runtime/load-context-state.ts
+++ b/src/plugins/runtime/load-context-state.ts
@@ -1,0 +1,31 @@
+import type { DeclaredProviderOwnerIndex } from "../provider-owner-index.js";
+
+export type PluginRuntimeLoadContextState = {
+  controlPlaneFingerprint: string;
+  registrationConfigKey: string;
+  declaredProviderOwners: DeclaredProviderOwnerIndex;
+};
+
+// Keep private config/env out of diagnostic traversal while registry spreads
+// preserve the exact owning context across source and built readers.
+const pluginRuntimeLoadContext = Symbol.for("openclaw.pluginRuntimeLoadContext");
+type ContextCarrier = { [pluginRuntimeLoadContext]?: () => PluginRuntimeLoadContextState };
+
+export function bindPluginRuntimeLoadContextState(
+  registry: object,
+  context: PluginRuntimeLoadContextState,
+): void {
+  Object.defineProperty(registry, pluginRuntimeLoadContext, {
+    value: () => context,
+    configurable: true,
+    writable: true,
+    enumerable: true,
+  });
+}
+
+export function getPluginRuntimeLoadContextState(
+  registry: object | undefined,
+): PluginRuntimeLoadContextState | undefined {
+  // SAFETY: Only the owning setter writes this private registry slot.
+  return (registry as ContextCarrier | undefined)?.[pluginRuntimeLoadContext]?.();
+}

--- a/src/plugins/runtime/load-context.current-snapshot.test.ts
+++ b/src/plugins/runtime/load-context.current-snapshot.test.ts
@@ -44,6 +44,7 @@ function createSnapshot(params: {
     diagnostics: [],
     byPluginId: new Map(),
     normalizePluginId: (pluginId) => pluginId,
+    declaredProviderOwners: new Map(),
     owners: {
       channels: new Map(),
       channelConfigs: new Map(),

--- a/src/plugins/runtime/load-context.resolve.ts
+++ b/src/plugins/runtime/load-context.resolve.ts
@@ -39,32 +39,23 @@ export function resolvePluginRuntimeLoadContext(
     env,
     workspaceDir: options?.workspaceDir,
   }).workspaceDir;
-  const resolveMetadataSnapshot = (params: {
-    config: OpenClawConfig;
-    index?: PluginMetadataSnapshot["index"];
-  }): PluginMetadataSnapshot => {
-    if (options?.workspaceDir === undefined) {
-      return projectPluginMetadataSnapshot(
-        resolveConfigWidePluginMetadataSnapshot({ config: params.config, env }),
-        options?.onlyPluginIds,
-      );
-    }
-    const snapshot = resolvePluginMetadataSnapshot({
-      config: params.config,
-      env,
-      workspaceDir: rawWorkspaceDir,
-      allowWorkspaceScopedCurrent: true,
-      ...(params.index ? { index: params.index } : {}),
-      ...(options?.onlyPluginIds !== undefined ? { pluginIds: options.onlyPluginIds } : {}),
-    });
-    return snapshot;
-  };
-  const initialMetadataSnapshot =
+  const metadataSnapshot =
     options?.metadataSnapshot ??
-    (options?.manifestRegistry === undefined
-      ? resolveMetadataSnapshot({ config: rawConfig })
-      : undefined);
-  const manifestRegistry = options?.manifestRegistry ?? initialMetadataSnapshot?.manifestRegistry;
+    (options?.manifestRegistry !== undefined
+      ? undefined
+      : options?.workspaceDir === undefined
+        ? projectPluginMetadataSnapshot(
+            resolveConfigWidePluginMetadataSnapshot({ config: rawConfig, env }),
+            options?.onlyPluginIds,
+          )
+        : resolvePluginMetadataSnapshot({
+            config: rawConfig,
+            env,
+            workspaceDir: rawWorkspaceDir,
+            allowWorkspaceScopedCurrent: true,
+            ...(options?.onlyPluginIds !== undefined ? { pluginIds: options.onlyPluginIds } : {}),
+          }));
+  const manifestRegistry = options?.manifestRegistry ?? metadataSnapshot?.manifestRegistry;
   const activationSourceConfig = resolvePluginActivationSourceConfig({
     config: rawConfig,
     activationSourceConfig: options?.activationSourceConfig,
@@ -73,7 +64,7 @@ export function resolvePluginRuntimeLoadContext(
     config: rawConfig,
     env,
     manifestRegistry,
-    discovery: initialMetadataSnapshot?.discovery,
+    discovery: metadataSnapshot?.discovery,
   });
   const config = autoEnabled.config;
   const workspaceDir = resolvePluginControlPlaneWorkspace({
@@ -81,8 +72,6 @@ export function resolvePluginRuntimeLoadContext(
     env,
     workspaceDir: options?.workspaceDir,
   }).workspaceDir;
-  const metadataSnapshot = initialMetadataSnapshot;
-  const finalManifestRegistry = options?.manifestRegistry ?? metadataSnapshot?.manifestRegistry;
   const installRecords = metadataSnapshot
     ? extractPluginInstallRecordsFromInstalledPluginIndex(metadataSnapshot.index)
     : undefined;
@@ -94,7 +83,7 @@ export function resolvePluginRuntimeLoadContext(
     workspaceDir,
     env,
     logger: options?.logger ?? createPluginRuntimeLoaderLogger(),
-    ...(finalManifestRegistry ? { manifestRegistry: finalManifestRegistry } : {}),
+    ...(manifestRegistry ? { manifestRegistry } : {}),
     ...(metadataSnapshot ? { metadataSnapshot } : {}),
     installRecords,
     preferBuiltPluginArtifacts: options?.preferBuiltPluginArtifacts,

--- a/src/plugins/runtime/load-context.test.ts
+++ b/src/plugins/runtime/load-context.test.ts
@@ -1,8 +1,10 @@
 // Load context tests cover agent and workspace context resolution for plugin runtimes.
+import { inspect } from "node:util";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { createPluginCache, withPluginCache } from "../plugin-cache.js";
 import type { PluginMetadataSnapshot } from "../plugin-metadata-snapshot.types.js";
+import { createEmptyPluginRegistry } from "../registry-empty.js";
 
 const loadConfigMock = vi.fn<typeof import("../../config/config.js").loadConfig>();
 const applyPluginAutoEnableMock =
@@ -35,6 +37,7 @@ const metadataSnapshot: PluginMetadataSnapshot = {
   plugins: [],
   byPluginId: new Map(),
   normalizePluginId: (id) => id,
+  declaredProviderOwners: new Map(),
   owners: {
     channels: new Map(),
     channelConfigs: new Map(),
@@ -62,6 +65,8 @@ const resolveConfigWidePluginMetadataSnapshotMock = vi.fn(() => metadataSnapshot
 
 let resolvePluginRuntimeLoadContext: typeof import("./load-context.resolve.js").resolvePluginRuntimeLoadContext;
 let buildPluginRuntimeLoadOptions: typeof import("./load-context.js").buildPluginRuntimeLoadOptions;
+let setPluginRuntimeLoadContext: typeof import("./load-context.js").setPluginRuntimeLoadContext;
+let getPluginRuntimeLoadContext: typeof import("./load-context.js").getPluginRuntimeLoadContext;
 let clearRuntimeConfigSnapshot: typeof import("../../config/runtime-snapshot.js").clearRuntimeConfigSnapshot;
 let setRuntimeConfigSnapshot: typeof import("../../config/runtime-snapshot.js").setRuntimeConfigSnapshot;
 let clearPluginMetadataLifecycleCaches: typeof import("../plugin-metadata-lifecycle.js").clearPluginMetadataLifecycleCaches;
@@ -94,7 +99,8 @@ describe("resolvePluginRuntimeLoadContext", () => {
       await import("../../config/runtime-snapshot.js"));
     ({ clearPluginMetadataLifecycleCaches } = await import("../plugin-metadata-lifecycle.js"));
     ({ resolvePluginRuntimeLoadContext } = await import("./load-context.resolve.js"));
-    ({ buildPluginRuntimeLoadOptions } = await import("./load-context.js"));
+    ({ buildPluginRuntimeLoadOptions, setPluginRuntimeLoadContext, getPluginRuntimeLoadContext } =
+      await import("./load-context.js"));
   });
 
   beforeEach(() => {
@@ -311,6 +317,45 @@ describe("resolvePluginRuntimeLoadContext", () => {
       env,
     });
     expect(resolvePluginMetadataSnapshotMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps private load facts out of diagnostics while preserving registry copies", () => {
+    const configSentinel = "synthetic-private-config-sentinel";
+    const envSentinel = "synthetic-private-env-sentinel";
+    const config: OpenClawConfig = {
+      plugins: { entries: { demo: { config: { sentinel: configSentinel } } } },
+    };
+    const env = { HOME: "/tmp/openclaw-home", PRIVATE_CONTEXT_TEST: envSentinel };
+    const context = resolvePluginRuntimeLoadContext({ config, env });
+    const registry = createEmptyPluginRegistry();
+    setPluginRuntimeLoadContext(registry, context, "original-registration");
+    const bound = getPluginRuntimeLoadContext(registry);
+    expect(bound).toMatchObject(context);
+    expect(bound?.config).toBe(config);
+    expect(bound?.env).toBe(env);
+
+    const copy = { ...registry };
+    expect(getPluginRuntimeLoadContext(copy)).toBe(bound);
+    const reboundContext = {
+      ...context,
+      workspaceDir: "/rebound-workspace",
+      env: { ...env, PRIVATE_CONTEXT_TEST: `${envSentinel}-rebound` },
+    };
+    setPluginRuntimeLoadContext(copy, reboundContext, "replacement-registration");
+    expect(getPluginRuntimeLoadContext(copy)).toMatchObject({
+      ...reboundContext,
+      registrationConfigKey: "original-registration",
+    });
+    expect(getPluginRuntimeLoadContext(copy)?.env).toBe(reboundContext.env);
+    expect(getPluginRuntimeLoadContext(registry)).toBe(bound);
+
+    for (const carrier of [registry, copy]) {
+      for (const showHidden of [false, true]) {
+        const diagnostic = inspect(carrier, { depth: null, showHidden });
+        expect(diagnostic).not.toContain(configSentinel);
+        expect(diagnostic).not.toContain(envSentinel);
+      }
+    }
   });
 
   it("builds plugin load options from the shared runtime context", () => {

--- a/src/plugins/runtime/load-context.ts
+++ b/src/plugins/runtime/load-context.ts
@@ -2,11 +2,19 @@
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type { PluginInstallRecord } from "../../config/types.plugins.js";
 import { createSubsystemLogger } from "../../logging.js";
+import { resolvePluginRegistrationConfigKey } from "../loader-registration-config.js";
 import type { PluginLoadOptions } from "../loader-types.js";
 import type { PluginManifestRegistry } from "../manifest-registry.js";
+import { resolvePluginControlPlaneFingerprint } from "../plugin-control-plane-context.js";
 import type { PluginMetadataSnapshot } from "../plugin-metadata-snapshot.types.js";
+import { buildDeclaredProviderOwnerIndex } from "../provider-owner-index.js";
 import type { PluginRegistry } from "../registry-types.js";
 import type { PluginLogger } from "../types.js";
+import {
+  bindPluginRuntimeLoadContextState,
+  getPluginRuntimeLoadContextState,
+  type PluginRuntimeLoadContextState,
+} from "./load-context-state.js";
 
 const log = createSubsystemLogger("plugins");
 
@@ -25,26 +33,42 @@ export type PluginRuntimeLoadContext = {
   preferBuiltPluginArtifacts?: boolean;
 };
 
-// Source and built consumers must read the same facts from the owning registry.
-const pluginRuntimeLoadContext = Symbol.for("openclaw.pluginRuntimeLoadContext");
-type RuntimeContextRegistry = PluginRegistry & {
-  [pluginRuntimeLoadContext]?: PluginRuntimeLoadContext;
-};
-
 export function setPluginRuntimeLoadContext(
   registry: PluginRegistry,
   context: PluginRuntimeLoadContext,
+  registrationConfigKey?: string,
 ): void {
-  // SAFETY: Internal registries are extensible; this module owns the optional symbol slot.
-  (registry as RuntimeContextRegistry)[pluginRuntimeLoadContext] = context;
+  const previous = getPluginRuntimeLoadContextState(registry);
+  const bound = {
+    ...context,
+    // Host preparation may rebind metadata, but it cannot change already-registered closures.
+    registrationConfigKey:
+      previous?.registrationConfigKey ??
+      registrationConfigKey ??
+      resolvePluginRegistrationConfigKey(context),
+    declaredProviderOwners:
+      context.metadataSnapshot &&
+      context.metadataSnapshot.manifestRegistry === context.manifestRegistry
+        ? context.metadataSnapshot.declaredProviderOwners
+        : buildDeclaredProviderOwnerIndex(context.manifestRegistry?.plugins ?? []),
+    // Capture selection before caller-owned config or environment objects can change.
+    controlPlaneFingerprint: resolvePluginControlPlaneFingerprint({
+      config: context.rawConfig,
+      env: context.env,
+      workspaceDir: context.workspaceDir,
+    }),
+  };
+  bindPluginRuntimeLoadContextState(registry, bound);
 }
 
 /** Reads load facts carried by an exact lifecycle-owned registry. */
 export const getPluginRuntimeLoadContext = (
-  registry: PluginRegistry | undefined,
-): PluginRuntimeLoadContext | undefined =>
-  // SAFETY: Only the setter above writes this optional registry-owned symbol slot.
-  (registry as RuntimeContextRegistry | undefined)?.[pluginRuntimeLoadContext];
+  registry: object | undefined,
+): (PluginRuntimeLoadContext & PluginRuntimeLoadContextState) | undefined =>
+  // SAFETY: setPluginRuntimeLoadContext is the sole writer and supplies all load facts.
+  getPluginRuntimeLoadContextState(registry) as
+    | (PluginRuntimeLoadContext & PluginRuntimeLoadContextState)
+    | undefined;
 
 /** Runtime load option values that can be passed directly to plugin loading. */
 type PluginRuntimeResolvedLoadValues = Pick<
@@ -70,16 +94,8 @@ export function createPluginRuntimeLoaderLogger(): PluginLogger {
   };
 }
 
-/** Builds plugin load options from a resolved runtime load context. */
+/** Projects explicit runtime load fields from prepared contexts or resolved values. */
 export function buildPluginRuntimeLoadOptions(
-  context: PluginRuntimeLoadContext,
-  overrides?: Partial<PluginLoadOptions>,
-): PluginLoadOptions {
-  return buildPluginRuntimeLoadOptionsFromValues(context, overrides);
-}
-
-/** Builds plugin load options from explicit runtime load values. */
-export function buildPluginRuntimeLoadOptionsFromValues(
   values: PluginRuntimeResolvedLoadValues,
   overrides?: Partial<PluginLoadOptions>,
 ): PluginLoadOptions {

--- a/src/plugins/runtime/runtime-registry-loader.ts
+++ b/src/plugins/runtime/runtime-registry-loader.ts
@@ -12,7 +12,7 @@ import { collectConfiguredMemoryEmbeddingProviderIds } from "../gateway-startup-
 import { createInstalledPluginIndexScopeLookup } from "../installed-plugin-index-scope-lookup.js";
 import { loadOpenClawPlugins } from "../loader.js";
 import { hasNonEmptyPluginIdScope } from "../plugin-scope.js";
-import { buildPluginRuntimeLoadOptionsFromValues } from "./load-context.js";
+import { buildPluginRuntimeLoadOptions } from "./load-context.js";
 import { resolvePluginRuntimeLoadContext } from "./load-context.resolve.js";
 
 export type PluginRegistryScope =
@@ -140,7 +140,7 @@ export function ensurePluginRegistryLoaded(options?: {
       }) ?? context.activationSourceConfig)
     : context.activationSourceConfig;
   loadOpenClawPlugins(
-    buildPluginRuntimeLoadOptionsFromValues(
+    buildPluginRuntimeLoadOptions(
       { ...context, config, activationSourceConfig },
       {
         throwOnLoadError: true,

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -1,4 +1,5 @@
 // Verifies optional plugin tool registration and absence handling.
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { normalizeToolParameters } from "../agents/agent-tools.schema.js";
@@ -10,7 +11,12 @@ import { createDedupeCache } from "../infra/dedupe.js";
 import { resetLogger, setLoggerOverride } from "../logging/logger.js";
 import { loggingState } from "../logging/state.js";
 import { resolveInstalledPluginIndexPolicyHash } from "./installed-plugin-index-policy.js";
+import { createPluginRecord } from "./loader-records.js";
 import type { PluginLoadOptions } from "./loader-types.js";
+import {
+  bindPluginRuntimeArtifactSelection,
+  resolvePluginRuntimeArtifactSelection,
+} from "./plugin-runtime-artifact-selection.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import { appendRuntimePluginToolGrant } from "./tool-grant-allowlist.js";
 
@@ -200,12 +206,9 @@ function createResolveToolsParams(params?: {
 function createToolRegistry(entries: MockRegistryToolEntry[]) {
   return {
     ...createEmptyPluginRegistry(),
-    plugins: entries.map((entry) => ({
-      id: entry.pluginId,
-      origin: entry.origin ?? "bundled",
-      status: "loaded",
-      enabled: true,
-    })),
+    plugins: entries.map((entry) =>
+      createToolRuntimeRecord(entry.pluginId, entry.source, entry.origin),
+    ),
     tools: entries,
     diagnostics: [] as Array<{
       level: string;
@@ -214,6 +217,25 @@ function createToolRegistry(entries: MockRegistryToolEntry[]) {
       message: string;
     }>,
   };
+}
+
+function createToolRuntimeRecord(
+  id: string,
+  source = `/tmp/${id}.js`,
+  origin: MockRegistryToolEntry["origin"] = "bundled",
+) {
+  const artifact = {
+    source,
+    rootDir: path.dirname(source),
+    origin,
+    preferBuiltPluginArtifacts: false,
+  };
+  const record = createPluginRecord({ id, ...artifact, enabled: true, configSchema: true });
+  bindPluginRuntimeArtifactSelection(record, {
+    preferBuiltPluginArtifacts: false,
+    runtimeEntry: resolvePluginRuntimeArtifactSelection({ ...artifact, entryKind: "runtime" }),
+  });
+  return record;
 }
 
 function setRegistry(
@@ -228,6 +250,8 @@ function setRegistry(
     plugins: entries
       .map((entry) => ({
         id: entry.pluginId,
+        source: entry.source,
+        rootDir: path.dirname(entry.source),
         origin: entry.origin ?? "bundled",
         enabledByDefault: true,
         channels: [],
@@ -372,11 +396,7 @@ function createOptionalDemoActiveRegistry() {
     config: createContext().config,
     plugin: createToolManifest("optional-demo", ["optional_tool"]),
   });
-  const registry = {
-    plugins: [{ id: "optional-demo", status: "loaded" }],
-    tools: [createOptionalDemoEntry()],
-    diagnostics: [],
-  };
+  const registry = createToolRegistry([createOptionalDemoEntry()]);
   setActivePluginRegistry?.(registry as never, "test-tool-registry", "gateway-bindable", "/tmp");
   return registry;
 }
@@ -401,7 +421,11 @@ function installToolManifestSnapshots(params: {
   env?: NodeJS.ProcessEnv;
   plugins: Record<string, unknown>[];
 }) {
-  const plugins = params.plugins;
+  const plugins = params.plugins.map((plugin): Record<string, unknown> => ({
+    rootDir: "/tmp",
+    source: `/tmp/${String(plugin.id)}.js`,
+    ...plugin,
+  }));
   const snapshot = {
     policyHash: resolveInstalledPluginIndexPolicyHash(params.config),
     workspaceDir: "/tmp",
@@ -1176,12 +1200,7 @@ describe("resolvePluginTools optional tools", () => {
       ],
     });
     const partialRegistry = createToolRegistry([multiEntry]);
-    partialRegistry.plugins.push({
-      id: "optional-demo",
-      origin: "bundled",
-      status: "loaded",
-      enabled: true,
-    });
+    partialRegistry.plugins.push(createToolRuntimeRecord("optional-demo"));
     const fullRegistry = createToolRegistry([multiEntry, optionalEntry]);
     setActivePluginRegistry?.(
       partialRegistry as never,
@@ -1265,12 +1284,7 @@ describe("resolvePluginTools optional tools", () => {
       ],
     });
     const staleRegistry = createToolRegistry([multiEntry]);
-    staleRegistry.plugins.push({
-      id: "optional-demo",
-      origin: "bundled",
-      status: "loaded",
-      enabled: true,
-    });
+    staleRegistry.plugins.push(createToolRuntimeRecord("optional-demo"));
     const freshRegistry = createToolRegistry([multiEntry, optionalEntry]);
     setActivePluginRegistry?.(
       staleRegistry as never,
@@ -1305,7 +1319,7 @@ describe("resolvePluginTools optional tools", () => {
     const factory = vi.fn(() => makeTool("x_search"));
     setActivePluginRegistry(
       {
-        plugins: [{ id: "xai", status: "loaded" }],
+        plugins: [createToolRuntimeRecord("xai")],
         tools: [
           {
             pluginId: "xai",
@@ -1388,7 +1402,7 @@ describe("resolvePluginTools optional tools", () => {
     const factory = vi.fn(() => makeTool("x_search"));
     setActivePluginRegistry(
       {
-        plugins: [{ id: "xai", status: "loaded" }],
+        plugins: [createToolRuntimeRecord("xai")],
         tools: [
           {
             pluginId: "xai",
@@ -3094,12 +3108,7 @@ describe("resolvePluginTools optional tools", () => {
       factory: () => makeTool("unrelated_live_tool"),
     };
     const replacementRegistry = createToolRegistry([unrelatedEntry]);
-    replacementRegistry.plugins.push({
-      id: "cache-lifecycle-test",
-      origin: "bundled",
-      status: "loaded",
-      enabled: true,
-    });
+    replacementRegistry.plugins.push(createToolRuntimeRecord("cache-lifecycle-test"));
     setActivePluginRegistry?.(replacementRegistry as never, "provider-runtime", "default", "/tmp");
     loadOpenClawPluginsMock.mockReset();
 
@@ -3366,10 +3375,7 @@ describe("resolvePluginTools optional tools", () => {
     });
     const heavyFactory = vi.fn(() => makeTool("heavy_tool"));
     const activeRegistry = {
-      plugins: [
-        { id: "optional-demo", status: "loaded" },
-        { id: "heavy-startup", status: "loaded" },
-      ],
+      plugins: [createToolRuntimeRecord("optional-demo"), createToolRuntimeRecord("heavy-startup")],
       tools: [
         createOptionalDemoEntry(),
         {
@@ -3426,8 +3432,8 @@ describe("resolvePluginTools optional tools", () => {
     const memorySearchFactory = vi.fn(() => [makeTool("memory_search"), makeTool("memory_get")]);
     const activeRegistry = {
       plugins: [
-        { id: "memory-core", status: "loaded" },
-        { id: "memory-lancedb", status: "disabled" },
+        createToolRuntimeRecord("memory-core"),
+        { id: "memory-lancedb", origin: "bundled", status: "disabled" },
       ],
       tools: [
         {
@@ -3491,7 +3497,7 @@ describe("resolvePluginTools optional tools", () => {
       });
     });
     const loadedRegistry = {
-      plugins: [{ id: "memory-core", status: "loaded", enabled: true }],
+      plugins: [createToolRuntimeRecord("memory-core")],
       tools: [
         {
           pluginId: "memory-core",
@@ -3506,7 +3512,7 @@ describe("resolvePluginTools optional tools", () => {
     };
     setActivePluginRegistry(
       {
-        plugins: [{ id: "memory-core", status: "loaded", enabled: true }],
+        plugins: [createToolRuntimeRecord("memory-core")],
         tools: [],
         diagnostics: [],
       } as never,

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -10,7 +10,7 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import {
   getLoadedRuntimePluginRegistry,
-  registryMatchesManifestPluginIds,
+  createRuntimePluginManifestLookup,
 } from "./active-runtime-registry.js";
 import {
   isBundledConversationReadToolRegistration,
@@ -639,15 +639,16 @@ function registryHasScopedPluginTools(
   if (pluginIds === undefined) {
     return (registry.tools?.length ?? 0) > 0;
   }
-  const scopedPluginIds = new Set(pluginIds);
-  if (scopedPluginIds.size === 0) {
+  if (pluginIds.length === 0) {
     return true;
   }
   const registryPluginIds = new Set(registry.tools.map((entry) => entry.pluginId));
-  return (
-    Array.from(scopedPluginIds).every((pluginId) => registryPluginIds.has(pluginId)) &&
-    (manifestPlugins === undefined ||
-      registryMatchesManifestPluginIds(registry, manifestPlugins, pluginIds))
+  const isOwnerEligible = manifestPlugins
+    ? createRuntimePluginManifestLookup(registry, manifestPlugins)
+    : undefined;
+  return pluginIds.every(
+    (pluginId) =>
+      registryPluginIds.has(pluginId) && (!isOwnerEligible || Boolean(isOwnerEligible(pluginId))),
   );
 }
 

--- a/src/plugins/web-provider-runtime-shared.test.ts
+++ b/src/plugins/web-provider-runtime-shared.test.ts
@@ -12,11 +12,9 @@ const mocks = vi.hoisted(() => ({
   resolveRuntimePluginRegistry: vi.fn(),
   getActivePluginRegistry: vi.fn<() => Record<string, unknown> | null>(() => null),
   getActivePluginRegistryWorkspaceDir: vi.fn(() => undefined),
-  buildPluginRuntimeLoadOptionsFromValues: vi.fn(
-    (_values: unknown, overrides?: Record<string, unknown>) => ({
-      ...overrides,
-    }),
-  ),
+  buildPluginRuntimeLoadOptions: vi.fn((_values: unknown, overrides?: Record<string, unknown>) => ({
+    ...overrides,
+  })),
   createPluginRuntimeLoaderLogger: vi.fn(() => ({
     info: vi.fn(),
     warn: vi.fn(),
@@ -43,7 +41,7 @@ vi.mock("./runtime.js", () => ({
 }));
 
 vi.mock("./runtime/load-context.js", () => ({
-  buildPluginRuntimeLoadOptionsFromValues: mocks.buildPluginRuntimeLoadOptionsFromValues,
+  buildPluginRuntimeLoadOptions: mocks.buildPluginRuntimeLoadOptions,
   createPluginRuntimeLoaderLogger: mocks.createPluginRuntimeLoaderLogger,
 }));
 
@@ -76,8 +74,8 @@ describe("web-provider-runtime-shared", () => {
     mocks.getActivePluginRegistry.mockReturnValue(null);
     mocks.getActivePluginRegistryWorkspaceDir.mockReset();
     mocks.getActivePluginRegistryWorkspaceDir.mockReturnValue(undefined);
-    mocks.buildPluginRuntimeLoadOptionsFromValues.mockReset();
-    mocks.buildPluginRuntimeLoadOptionsFromValues.mockImplementation(
+    mocks.buildPluginRuntimeLoadOptions.mockReset();
+    mocks.buildPluginRuntimeLoadOptions.mockImplementation(
       (_values: unknown, overrides?: Record<string, unknown>) => ({
         ...overrides,
       }),
@@ -182,7 +180,7 @@ describe("web-provider-runtime-shared", () => {
       registry: activeRegistry,
       onlyPluginIds: ["brave"],
     });
-    expect(mockArg(mocks.buildPluginRuntimeLoadOptionsFromValues).manifestRegistry).toEqual({
+    expect(mockArg(mocks.buildPluginRuntimeLoadOptions).manifestRegistry).toEqual({
       plugins: manifestRecords,
       diagnostics: [],
     });

--- a/src/plugins/web-provider-runtime-shared.ts
+++ b/src/plugins/web-provider-runtime-shared.ts
@@ -9,7 +9,7 @@ import { hasExplicitPluginIdScope, normalizePluginIdScope } from "./plugin-scope
 import type { PluginRegistry } from "./registry.js";
 import { getActivePluginRegistryWorkspaceDir } from "./runtime.js";
 import {
-  buildPluginRuntimeLoadOptionsFromValues,
+  buildPluginRuntimeLoadOptions,
   createPluginRuntimeLoaderLogger,
 } from "./runtime/load-context.js";
 
@@ -137,7 +137,7 @@ function resolveWebProviderLoadOptions(
   context: WebProviderRuntimeContext,
   params: ResolvePluginWebProvidersParams,
 ) {
-  return buildPluginRuntimeLoadOptionsFromValues(
+  return buildPluginRuntimeLoadOptions(
     {
       env: context.env,
       config: context.config,
@@ -193,7 +193,7 @@ export function resolvePluginWebProviders<TEntry>(
       }
     }
     const registry = loadOpenClawPlugins(
-      buildPluginRuntimeLoadOptionsFromValues(
+      buildPluginRuntimeLoadOptions(
         {
           config: withActivatedPluginIds({
             config: params.config,

--- a/src/skills/loading/workspace-skill-loader.test.ts
+++ b/src/skills/loading/workspace-skill-loader.test.ts
@@ -13,6 +13,7 @@ import type {
   PluginManifestRegistry,
 } from "../../plugins/manifest-registry.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.js";
+import { buildDeclaredProviderOwnerIndex } from "../../plugins/provider-owner-index.js";
 import { bumpSkillsSnapshotVersion } from "../runtime/refresh-state.js";
 import { writeSkill, writeWorkspaceSkills } from "../test-support/e2e-test-helpers.js";
 import {
@@ -140,6 +141,7 @@ function createWorkspacePluginMetadataSnapshot(params: {
     diagnostics: params.manifestRegistry.diagnostics,
     byPluginId: new Map(params.manifestRegistry.plugins.map((plugin) => [plugin.id, plugin])),
     normalizePluginId: (pluginId) => pluginId,
+    declaredProviderOwners: buildDeclaredProviderOwnerIndex(params.manifestRegistry.plugins),
     owners: ownerMaps,
     metrics: {
       registrySnapshotMs: 0,

--- a/src/utils/usage-format.test.ts
+++ b/src/utils/usage-format.test.ts
@@ -401,7 +401,7 @@ describe("usage-format", () => {
   it("skips manifest model normalization for raw cost lookup", () => {
     const manifestSpy = vi.spyOn(
       manifestModelIdNormalization,
-      "normalizeProviderModelIdWithManifest",
+      "resolveManifestModelIdNormalizationPolicies",
     );
     const config = {
       models: {

--- a/test/canonical-descendant.integration.test.ts
+++ b/test/canonical-descendant.integration.test.ts
@@ -1,14 +1,13 @@
 import http from "node:http";
-import { fileURLToPath } from "node:url";
+import { pathToFileURL } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
+import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   createPluginRuntimeMock,
   createPluginRegistry,
 } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import codexPlugin from "../extensions/codex/index.js";
 import { createCanonicalForkFixtureForTest } from "../extensions/codex/test-api.js";
-import openaiPlugin from "../extensions/openai/index.js";
 import {
   prepareAgentRunAdmission,
   createOperationalRunInstanceRef,
@@ -41,8 +40,14 @@ import {
   createPluginStateSyncKeyedStore,
   type OpenKeyedStoreOptions,
 } from "../src/plugin-state/plugin-state-store.js";
+import { createRuntimePluginManifestLookup } from "../src/plugins/active-runtime-registry.js";
 import { resolvePluginCapabilityCatalogContext } from "../src/plugins/loader-runtime-load.js";
 import { resolvePluginMetadataSnapshot } from "../src/plugins/plugin-metadata-snapshot.js";
+import {
+  bindPluginRuntimeArtifactSelection,
+  resolvePluginRuntimeArtifactSelection,
+  resolvePluginRuntimeExecutionArtifact,
+} from "../src/plugins/plugin-runtime-artifact-selection.js";
 import {
   markPluginRegistryActive,
   markPluginRegistryRetired,
@@ -52,7 +57,10 @@ import { setPluginRuntimeLoadContext } from "../src/plugins/runtime/load-context
 import { resolvePluginRuntimeLoadContext } from "../src/plugins/runtime/load-context.resolve.js";
 import { createRuntimeAgent } from "../src/plugins/runtime/runtime-agent.js";
 import { createPluginRecord } from "../src/plugins/status.test-helpers.js";
-import type { OpenClawPluginMcpServerConnectionResolver } from "../src/plugins/types.js";
+import type {
+  OpenClawPluginDefinition,
+  OpenClawPluginMcpServerConnectionResolver,
+} from "../src/plugins/types.js";
 import {
   listSessionStateEventsSince,
   registerSessionStateWatch,
@@ -327,21 +335,43 @@ async function withFixture(
           workspaceDir: state.workspaceDir,
           preferPersisted: false,
         });
-        for (const plugin of [codexPlugin, openaiPlugin]) {
-          const rootDir = fileURLToPath(new URL(`../extensions/${plugin.id}/`, import.meta.url));
+        for (const pluginId of ["codex", "openai"]) {
+          const manifest = expectDefined(
+            metadataSnapshot.byPluginId.get(pluginId),
+            "plugin manifest",
+          );
+          const artifact = resolvePluginRuntimeExecutionArtifact(
+            resolvePluginRuntimeArtifactSelection({
+              ...manifest,
+              entryKind: "runtime",
+              preferBuiltPluginArtifacts: false,
+            }),
+          );
+          const plugin: OpenClawPluginDefinition = (
+            await import(pathToFileURL(artifact.source).href)
+          ).default;
+          expect(plugin.id).toBe(pluginId);
           const record = createPluginRecord({
-            id: plugin.id,
-            contracts: expectDefined(metadataSnapshot.byPluginId.get(plugin.id), "plugin manifest")
-              .contracts,
-            origin: "bundled",
-            rootDir,
-            source: `${rootDir}index.ts`,
+            id: manifest.id,
+            contracts: manifest.contracts,
+            origin: manifest.origin,
+            ...artifact,
+          });
+          // Register the selected artifact itself so retained tool ownership agrees
+          // with both source-only and built metadata discovery.
+          bindPluginRuntimeArtifactSelection(record, {
+            ...manifest,
+            preferBuiltPluginArtifacts: false,
+            runtimeEntry: artifact,
           });
           registry.plugins.push(record);
-          plugin.register(
+          expectDefined(
+            plugin.register,
+            "fixture plugin registration",
+          )(
             createApi(record, {
               config,
-              pluginConfig: config.plugins.entries?.[plugin.id]?.config,
+              pluginConfig: config.plugins.entries?.[pluginId]?.config,
             }),
           );
         }
@@ -351,6 +381,12 @@ async function withFixture(
           createApi(record, { config }).registerMcpServerConnectionResolver(options.mcpResolver);
         }
         expect(registry.diagnostics.filter((entry) => entry.level === "error")).toEqual([]);
+        const fixtureOwners = createRuntimePluginManifestLookup(registry, metadataSnapshot.plugins);
+        expect(
+          registry.plugins
+            .filter((record) => record.id === "codex" || record.id === "openai")
+            .map((record) => fixtureOwners(record.id) === record),
+        ).toEqual([true, true]);
         markPluginRegistryActive(registry);
         setPluginRuntimeLoadContext(
           registry,
@@ -1119,6 +1155,20 @@ describe("canonical descendant lifecycle through real owners", () => {
             "canonical native thread",
           );
           const currentBefore = structuredClone(current);
+          if (!Array.isArray(current.dynamicTools)) {
+            throw new Error("Expected the canonical native dynamic tool catalog");
+          }
+          expect(
+            current.dynamicTools.flatMap((spec) =>
+              isRecord(spec) && spec.type === "namespace" && Array.isArray(spec.tools)
+                ? spec.tools
+                : [spec],
+            ),
+          ).toEqual(
+            expect.arrayContaining([
+              expect.objectContaining({ type: "function", name: "codex_threads" }),
+            ]),
+          );
           const entries = await fixture.readEntries(source.sessionKey);
           const users = entries.filter((entry) => entry.role === "user");
           expect(users).toHaveLength(4);

--- a/test/plugins/openrouter-error-classification.integration.test.ts
+++ b/test/plugins/openrouter-error-classification.integration.test.ts
@@ -2,19 +2,17 @@ import { createServer } from "node:http";
 import type { AddressInfo } from "node:net";
 import type { AssistantMessage, Context, Model } from "@openclaw/ai";
 import { streamOpenAICompletions } from "@openclaw/ai/internal/openai";
-import { aroundEach, beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 import { classifyAssistantFailoverReason } from "../../src/agents/embedded-agent-helpers/assistant-message-failures.js";
 import { formatAssistantErrorText } from "../../src/agents/embedded-agent-helpers/error-text.js";
 import {
   resolveFailoverStatus,
   resolveModelFallbackError,
 } from "../../src/agents/failover-error.js";
-import { createEmptyPluginRegistry } from "../../src/plugins/registry-empty.js";
-import { withPluginRuntimeRegistryScope } from "../../src/plugins/runtime/gateway-request-scope.js";
 import { loadBundledPluginFacade } from "../../src/test-utils/bundled-plugin-public-surface.js";
 import { registerSingleProviderPlugin } from "../../src/test-utils/plugin-registration.js";
 
-const pluginRegistry = createEmptyPluginRegistry();
+let providerOwner: Awaited<ReturnType<typeof registerSingleProviderPlugin>>;
 
 beforeAll(async () => {
   const { default: openrouterPlugin } = await loadBundledPluginFacade<{
@@ -23,17 +21,8 @@ beforeAll(async () => {
     pluginId: "openrouter",
     artifactBasename: "index.js",
   });
-  const provider = await registerSingleProviderPlugin(openrouterPlugin);
-  pluginRegistry.providers.push({
-    pluginId: provider.id,
-    source: "test",
-    provider,
-  });
+  providerOwner = await registerSingleProviderPlugin(openrouterPlugin);
 });
-
-// Keep the real provider hooks in an owned scope, without cold discovery or
-// publishing a registry that can leak into another shared-worker test.
-aroundEach((runTest) => withPluginRuntimeRegistryScope(pluginRegistry, runTest));
 
 const model = {
   id: "example/model",
@@ -79,7 +68,7 @@ async function runAgainstOpenRouterError(params: {
     ).result();
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain(params.message);
-    return { reason: classifyAssistantFailoverReason(result), requestBody };
+    return { reason: classifyAssistantFailoverReason(result, { providerOwner }), requestBody };
   } finally {
     await new Promise<void>((resolve, reject) => {
       server.close((error) => (error ? reject(error) : resolve()));
@@ -130,7 +119,7 @@ function expectFallbackBoundary(
   result: AssistantMessage,
   expected: { reason: "server_error" | "timeout"; status: number },
 ): void {
-  const reason = classifyAssistantFailoverReason(result);
+  const reason = classifyAssistantFailoverReason(result, { providerOwner });
   expect(reason).toBe(expected.reason);
   if (!reason) {
     throw new Error("expected streamed provider error to be classified");
@@ -191,7 +180,7 @@ describe("OpenRouter runtime error classification", () => {
 
     expect(result.stopReason).toBe("error");
     expect(result.errorMessage).toContain("Rate limit exceeded");
-    const reason = classifyAssistantFailoverReason(result);
+    const reason = classifyAssistantFailoverReason(result, { providerOwner });
     expect(reason).toBe("rate_limit");
     if (!reason) {
       throw new Error("expected structured rate-limit error to be classified");

--- a/test/scripts/vitest-worker-artifacts.test.ts
+++ b/test/scripts/vitest-worker-artifacts.test.ts
@@ -283,11 +283,16 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
       const file=name=>path.join(directory,name);
       fs.writeFileSync(file('input'),'compiler input');
       const spawn=cp.spawn;
-      let compiler, closed=false, ready=false, finished=false, readyClosed, leafPid;
+      let compiler, compilerClose, closed=false, ready=false, finished=false, readyJoined, leafPid;
+      // Node marks streams closed before delivering their deferred close events.
+      const compilerJoined=()=>Boolean(compiler &&
+        (compiler.exitCode!==null || compiler.signalCode!==null) &&
+        [compiler.stdout,compiler.stderr].every(pipe=>!pipe || pipe.closed) &&
+        inspectManagedProcessGroup(compiler,{errorPolicy:'indeterminate'})==='dead');
       cp.spawn=(bin,args,options)=>{
         if(args[0]!==${JSON.stringify(path.join(root, compilerEntry))}) return spawn(bin,args,options);
         compiler=spawn(bin,[...${JSON.stringify(fixturePreloadArgs(preload))},...args],options);
-        compiler.once('close',()=>{closed=true;});
+        compilerClose=new Promise(resolve=>compiler.once('close',()=>{closed=true;resolve();}));
         return compiler;
       };
       syncFixtureBuiltinExports();
@@ -296,7 +301,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
       const owner=createVitestWorkerRun(), generation=owner.descriptor.directory;
       const child=spawn(process.execPath,['--input-type=module','--eval',${JSON.stringify(preparationClient.replace("await requestVitestWorkerArtifacts();", 'await requestVitestWorkerArtifacts();process.send("borrower-ready");'))}],{detached:true,stdio:['ignore','ignore','pipe','ipc']});
       child.stderr.resume();
-      child.on('message',message=>{if(message==='borrower-ready'){ready=true;readyClosed=closed;}});
+      child.on('message',message=>{if(message==='borrower-ready'){ready=true;readyJoined=compilerJoined();}});
       const completion=owner.borrow(child,createVitestProcessCompletion({child,detached:true}));
       void completion.then(()=>{finished=true;},()=>{finished=true;});
       const observe=async name=>{
@@ -316,10 +321,10 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
           } else fs.writeFileSync(file('release'),'release');
         }
         const result=await completion;
-        assert.equal(closed,true,'ready must wait for actual compiler close');
+        assert.equal(compilerJoined(),true,'ready must wait for compiler termination and output closure');
         assert.equal(inspectManagedProcessGroup(compiler,{errorPolicy:'indeterminate'}),'dead');
         if(mode==='close before ready') {
-          assert.equal(result.code,0);assert.equal(readyClosed,true);await owner.dispose();
+          assert.equal(result.code,0);assert.equal(readyJoined,true);await owner.dispose();
         } else {
           assert.notEqual(result.code,0);
           const error=await (disposal??owner.dispose()).then(()=>{throw new Error('expected compiler failure');},error=>error);
@@ -341,12 +346,14 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
           }
         }
         assert.equal(fs.existsSync(generation),mode==='uncertain output');
+        await compilerClose;
         console.log(JSON.stringify({mode,compilerPid:compiler.pid,compilerClosed:closed,compilerGroup:'dead',borrowerCode:result.code,retained:fs.existsSync(generation),leafPid}));
       } finally {
         fs.writeFileSync(file('release'),'release');
         child.kill('SIGTERM');
         await completion.catch(()=>{});
         await owner.dispose().catch(()=>{});
+        await compilerClose;
         assert.equal(inspectManagedProcessGroup(child,{errorPolicy:'indeterminate'}),'dead');
         if(compiler) {
           assert.equal(closed,true);
@@ -638,7 +645,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
               assistantTexts:[],sessionKey:'agent:main:fixture-hook',provider:'fixture-provider',
               lastAssistant:{role:'assistant',content:[],stopReason:'error',provider:'fixture-provider',model:'fixture-model',errorMessage},
             });
-            const registry = createEmptyPluginRegistry();
+            let registry = createEmptyPluginRegistry();
             let scopedCalls = 0;
             registry.providers.push({pluginId:'fixture-hook',provider:{id:'fixture-provider',label:'Fixture',auth:[],
               classifyFailoverReason(context) {
@@ -649,6 +656,18 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
             const unprepared = buildEmbeddedRunPayloads(input('403 fixture refusal'));
             assert.deepEqual(unprepared,[{text:'⚠️ fixture-provider/fixture-model request failed (authentication failed, HTTP 403). Re-authenticate the provider and try again.',isError:true}], 'an unprepared error must retain safe provider, model and status facts');
             assert.deepEqual(observed(),[], 'error formatting must not materialize the provider');
+            let scopedPreparationRecordCount = 0;
+            if (${scope === "scoped"}) {
+              const {loadOpenClawPlugins} = await import(${JSON.stringify(pathToFileURL(path.join(root, "src/plugins/loader.ts")).href)});
+              const scopedHook = registry.providers[0].provider.classifyFailoverReason;
+              registry = loadOpenClawPlugins({config:{plugins:{allow:['fixture-hook'],entries:{'fixture-hook':{enabled:true}}}},onlyPluginIds:['fixture-hook'],activate:false});
+              const loadedOwner = registry.providers.find(entry=>entry.pluginId==='fixture-hook');
+              assert(loadedOwner, 'the real loader must establish the scoped provider owner');
+              loadedOwner.provider.classifyFailoverReason = scopedHook;
+              const preparationRecords = observed();
+              assert.deepEqual(preparationRecords.map(record=>record.event),['import','register']);
+              scopedPreparationRecordCount = preparationRecords.length;
+            }
             const providerOwner = ${scope === "prepared" ? "resolveProviderRuntimePluginHandle({provider:'fixture-provider'}).plugin" : "undefined"};
             if (${scope === "prepared"}) {
               assert.equal(providerOwner?.id,'fixture-provider');
@@ -667,7 +686,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
             };
             const payloads = withPluginRuntimeRegistryScope(registry,call);
             const callMs = performance.now()-callStarted;
-            const records = observed();
+            const records = observed().slice(scopedPreparationRecordCount);
             if (${scope === "scoped"}) {
               assert.ok(scopedCalls > 0, 'payload errors must reach the scoped provider hook');
               assert.deepEqual(records,[]);
@@ -680,8 +699,12 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
             assert.ok(payloads.some(payload=>payload.isError && payload.text.includes('temporarily overloaded')));
             assert.equal(getPluginRegistryState()?.activeRegistry ?? null,null,'preparation and error handling must not install a global registry');
             if (${scope === "scoped"}) {
-              const config = {};
-              const metadataSnapshot = createPluginMetadataSnapshot({config,manifestRegistry:{plugins:[],diagnostics:[]}});
+              const {getPluginRuntimeLoadContext} = await import(${JSON.stringify(pathToFileURL(path.join(root, "src/plugins/runtime/load-context.ts")).href)});
+              const loadContext = getPluginRuntimeLoadContext(registry);
+              const config = loadContext?.rawConfig;
+              const manifestRegistry = loadContext?.manifestRegistry;
+              assert(manifestRegistry, 'the loaded registry must retain its manifest owner');
+              const metadataSnapshot = createPluginMetadataSnapshot({config,manifestRegistry});
               setActivePluginRegistry(registry,'fixture-active');
               try {
                 assert.deepEqual(call(),payloads,'preparation must select the active loaded provider');
@@ -700,7 +723,7 @@ describe.concurrent("fresh compiled subprocess invocation", () => {
                 });
               } finally {await clearActivePluginRegistry();}
               assert.deepEqual(render(),unprepared,'presentation outside the scope still needs an explicit owner');
-              assert.deepEqual(observed(),[],'loaded lookups must not import the fixture plugin');
+              assert.deepEqual(observed().slice(scopedPreparationRecordCount),[],'loaded lookups must not reimport the fixture plugin');
             }
             console.log(JSON.stringify({pid:process.pid,mode:${JSON.stringify(mode)},scope:${JSON.stringify(scope)},importMs:imported-started,callMs,scopedCalls,records,payloads,rss:process.memoryUsage().rss}));
           `,


### PR DESCRIPTION
Related: #130706.

## What Problem This Solves

Fixes an issue where users changing model defaults, aliases, or fallbacks from a fresh CLI could save a provider's legacy model ID instead of its canonical ID. Reusing a warm registry could also select hooks from another plugin copy or workspace, keep a disabled provider in a mixed selection, or let another provider's runtime alias take over after a declared provider failed to load.

## Why This Change Was Made

Provider parsing and hooks now share one registry selection with separate required load owners and eligible receivers. Declared providers reserve their names even when registration fails; activation helpers can still run beside them, and a setup-only registration does not satisfy a runtime registration requirement. Retained generations keep their captured selection, including an explicitly empty selection.

The loader owns the physical source, artifact-selection, workspace, and registration-input facts used for reuse. Ordinary lookups validate the selected origin, root, entry, source/build choice, and paired runtime/source configuration against those records. Current enablement independently narrows eligible receivers before warm reuse, so disabling one provider cannot leave its hooks in an otherwise valid mixed selection. The shared selection replaces duplicate provider-hook caches and normalization paths.

Model mutations prepare the selected providers and required helpers through the canonical loader, then resolve aliases under that registry and metadata scope. Runtime-only aliases can identify an eligible owner to load, while exact command preparation still follows the normal loader policy. The original config snapshot/hash fences the write against concurrent replacement. The legacy public SDK `loadModelCatalog` metadata input remains source-compatible when callers omit the new internal owner index; internally built snapshots still provide complete owner facts.

## User Impact

Default-model, image-model, alias, and fallback commands agree on the canonical provider model. Existing model-entry settings move to the canonical key, with existing canonical settings taking precedence; adding an alias replaces the model's previous alias. Unrelated authored values, including environment references, remain in source form. A failed declared provider cannot silently hand normalization to another provider's alias, and ordinary lookups no longer reuse a disabled or physically unrelated provider's callbacks.

## Evidence

- Fresh rebased head: `d0b317508a6d76e754c931269280ba15a1f4af6b`, based on main `53ff0867149e1fd753cbfc9f67f79a28e6318f58`. The stale-base lint failure is absent: all 95 changed paths, 24 large files changed by main, and explicit update-command/markdown lint controls pass `pnpm exec oxlint`.
- **156 focused tests passed across seven files**: provider physical provenance, complete owner/receiver selection, active and retained registries, model-reference parsing, model selection, all 36 cold model-command/config-preservation cases, and four public SDK runtime compatibility cases. These use real synthetic plugin loading and config writes, including environment references, nested includes, canonical-key precedence and concurrent replacement.
- Fresh independent Codex P2 review is clean. The rebase required no source repair or weakened assertions. Formatting, static guards, core graph-boundary validation and `git diff --check` passed.
- Local `check-changed` stopped at the declaration boundary because its compiler resolves into a shared ancestor installation. A local full-build attempt likewise stopped at an external shared-dependency declaration guard after asset compilation. Neither is claimed as a passing full typecheck/build. [Fresh exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34174641418) passed, including build artifacts, test-type gates, both Windows jobs, and the aggregate CI gate.
- The preceding integration's 281 tests and complete changed gate remain prior-candidate evidence. The earlier downloaded-artifact Gateway attempt failed at a stale shared workspace dependency export and remains failed. The fresh compiled proof below is separate evidence.


Post-merge Linux proof on `ccd3a4414e5f941665679172d5e9f83a8a3ae14f` passed a fresh Node 24.19.0 build in 225.637 seconds. The exact built image passed the alias checkpoint, all 85 compiled local cases (32 owner, three nested SDK, 14 alias, 32 command and four cold CLI cases), three exact-alias cases, and all three active/request/retained mixed-selection cases.

A separately named Gateway continuation passed all 32 owner controls and one real Gateway subagent round trip against a loopback provider. It sent exactly one request using the startup provider/model and produced the expected visible reply. The preceding full run remains failed: its synthetic shared-root registry had omitted the workspace field, causing the lookup to inherit the Gateway workspace. The continuation corrected that one fixture declaration, retained every assertion, and reused the same verified source, runtime and build. All 803 original evidence files and helper inputs stayed unchanged; all 18 continuation files were recovered and verified. Independent review confirmed the results, complete process/container cleanup and retained failure records. The [owned Testbox lease](https://github.com/openclaw/openclaw/actions/runs/34221572621) was stopped after proof. This is built Gateway/CLI proof with synthetic plugins and a local provider, not authenticated external-provider inference or a reproduction of the broader CPU report.

Production changes are +1,519/-896 lines (net +623); tests/support are net +2,533. The additional in-memory metadata records physical ownership, completed registration and receiver eligibility. Cold CLI preparation loads the selected plugins, and duplicate hook caches and normalization paths are removed. No operator configuration option, persistent-store schema or protocol version changes.
