### PR TITLE
fix(lint): restore update command line budget

### DIFF
--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -76,7 +76,6 @@ import {
 import type { UpdateCommandRecoveryState } from "./update-command-service.js";
 import { withUpdateFailureTriage } from "./update-command-triage.js";
 
-const CLI_NAME = resolveCliName();
 const DEFAULT_UPDATE_STEP_TIMEOUT_MS = 30 * 60_000;
 
 export async function updateCommand(inputOpts: UpdateCommandOptions): Promise<void> {
@@ -308,7 +307,7 @@ async function updateCommandInternal(
         );
         defaultRuntime.log(
           theme.muted(
-            `After the update, make sure \`${CLI_NAME}\` on PATH resolves to the managed service root or reinstall the gateway service from the shell install you want to use.`,
+            `After the update, make sure \`${resolveCliName()}\` on PATH resolves to the managed service root or reinstall the gateway service from the shell install you want to use.`,
           ),
         );
         if (managedServiceNodeRunner) {


### PR DESCRIPTION
## Summary

- resolve the CLI display name at its single use site instead of retaining a module-level constant
- restore `update-command.ts` to the enforced 700 executable-line budget
- preserve the exact user-facing update guidance

## Why

#141610 added one required package-admission input and moved this file from 700 to 701 counted lines. The resulting `max-lines` failure reproduces on current `main` and blocks otherwise unrelated PR CI.

## Validation

- exact hosted core lint stripe `1/5` passes
- `src/cli/update-cli.test.ts` and `update-command-execution.test.ts`: 433 passed
- `oxfmt --check`
- `git diff --check`
