### PR TITLE
fix: synchronize containment fixtures with real process stops

### DIFF
--- a/extensions/codex/src/app-server/transport.process.test.ts
+++ b/extensions/codex/src/app-server/transport.process.test.ts
@@ -338,6 +338,8 @@ process.stdin.on("end", () => process.exit(0));
       let inspection = 0;
       let descendantSignalled = false;
       const actualSnapshot = processSnapshot.readCodexAppServerProcessSnapshot;
+      const actualProcess = processSnapshot.readCodexAppServerProcess;
+      let rootStopObserved = false;
       const actualKill = process.kill.bind(process);
       const killSpy = vi.spyOn(process, "kill").mockImplementation((pid, signal) => {
         const signalled = actualKill(pid, signal);
@@ -362,6 +364,18 @@ process.stdin.on("end", () => process.exit(0));
         }
         if (!rows) {
           throw new processSnapshot.ProcessInspectionError("unavailable");
+        }
+        if (
+          !rootStopObserved &&
+          rows.some((row) => row.pid === rootIdentity.pid && row.state === "T")
+        ) {
+          // Do not let synthetic stopped rows outrun delivery of the real SIGSTOP.
+          while (
+            !(await actualProcess(rootIdentity.pid, inspectionDeadline))?.state.startsWith("T")
+          ) {
+            await delay(1);
+          }
+          rootStopObserved = true;
         }
         return rows;
       };


### PR DESCRIPTION
## What Problem This Solves

Resolves a race where the Codex containment fixture supplies synthetic stopped-root snapshots before Linux has delivered the real `SIGSTOP`. The later OS snapshot then sees a running root and production correctly reports `uncertain`, failing the fixture's expected successful cleanup.

This follows the earlier PID-scope correction in #141634. The remaining race was observed during investigation of the recurring containment-family failures in [run 34170158684](https://github.com/openclaw/openclaw/actions/runs/34170158684/job/101888883820).

## Why This Change Was Made

Before exposing the first synthetic stopped-root row, acknowledge that the retained real root has reached state `T` through the original, unmocked scalar process reader. Reuse the existing inspection deadline; read and deadline errors still propagate. Later synthetic resume/identity-fault sequences remain unchanged.

The patch adds 14 lines to one test file. It does not change production containment, conservative `uncertain` results, deadlines, retry settings, cleanup expectations or survivor assertions. Diagnostic instrumentation is removed.

## User Impact

Containment tests synchronize their injected process state with actual OS signal delivery. There is no production behavior change.

## Evidence

Five fixed Linux rounds of the original 11-file shard reproduced two failing rounds before the repair. Both observed the real root still running immediately after the fixture had claimed it was stopped, with the full inspection budget remaining:

```json
{
  "queuedSignals": ["root:SIGSTOP", "sentinel:SIGSTOP", "sentinel:SIGKILL"],
  "firstTerminalObservations": [
    {"rootState": "Rl", "sentinelState": "Rl", "remainingMs": 2000},
    {"rootState": "Rl", "sentinelState": "Zl", "remainingMs": 2000}
  ],
  "result": {"exited": true, "cleanup": "uncertain"}
}
```

After repair, five matching uninstrumented Linux rounds each passed all 142 applicable tests with the same 10 platform skips: 710 passes total. A focused Linux check with CI's worker override and the macOS containment check each passed 13/13. Both Linux source capsules matched the reviewed commit's exact tree. Testbox proof: [run 34171078353](https://github.com/openclaw/openclaw/actions/runs/34171078353); the task-owned lease was stopped afterward.

The changed-file gate passed, and independent P2 review found no actionable issues. The fixture and production-owner preimages were unchanged when this patch was applied to current main.
