### PR TITLE
test: reuse provider registries in catalog auth fixtures

### DIFF
--- a/test/openai-model-discovery-auth-order.test.ts
+++ b/test/openai-model-discovery-auth-order.test.ts
@@ -19,6 +19,8 @@ import { createTestPluginApi } from "../src/plugin-sdk/plugin-test-api.js";
 import type { ProviderCatalogOutcome } from "../src/plugins/provider-catalog.types.js";
 import * as providerDiscovery from "../src/plugins/provider-discovery.js";
 import * as providerRuntime from "../src/plugins/provider-runtime.runtime.js";
+import { createEmptyPluginRegistry } from "../src/plugins/registry-empty.js";
+import { withPluginRuntimeRegistryScope } from "../src/plugins/runtime/gateway-request-scope.js";
 import type { ProviderPlugin } from "../src/plugins/types.js";
 import { createDeferredCore } from "../src/shared/deferred.js";
 import {
@@ -34,6 +36,17 @@ vi.mock("../src/plugins/provider-discovery.runtime.js", () => ({
   resolvePluginDiscoveryProvidersRuntime: () => discovery.providers,
 }));
 
+function withCatalogProviders<T>(run: () => T): T {
+  const registry = createEmptyPluginRegistry();
+  registry.providers = discovery.providers.map((provider) => ({
+    pluginId: provider.id,
+    provider,
+    source: "test",
+  }));
+  // Exhausted auth must consult the same providers as discovery, without loading a second runtime.
+  return withPluginRuntimeRegistryScope(registry, run);
+}
+
 describe("Provider model discovery auth preparation", () => {
   let state: OpenClawTestState;
   let agentDir: string;
@@ -42,10 +55,6 @@ describe("Provider model discovery auth preparation", () => {
     state = await createOpenClawTestState({ prefix: "catalog-auth-order-", agentEnv: "main" });
     agentDir = state.agentDir();
     discovery.providers = [buildOpenAIProvider()];
-    vi.spyOn(providerRuntime, "formatProviderAuthProfileApiKeyWithPlugin").mockImplementation(
-      async ({ provider, context }) =>
-        discovery.providers.find((candidate) => candidate.id === provider)?.formatApiKey?.(context),
-    );
   });
 
   afterEach(async () => {
@@ -66,22 +75,24 @@ describe("Provider model discovery auth preparation", () => {
       env?: NodeJS.ProcessEnv;
     } = {},
   ) {
-    return planOpenClawModelsJson({
-      context: {
-        cfg: config,
-        discoveryAuthConfig: config,
-        sourceConfigForSecrets: config,
-        agentDir,
-        env: options.env ?? {},
-        envFingerprint: {},
-        providerDiscoveryProviderIds: [options.providerId ?? "openai"],
-        providerDiscoveryTimeoutMs: options.timeoutMs,
-        onProviderCatalogOutcome: (outcome) => options.outcomes?.push(outcome),
-      },
-      authStore: store,
-      existingRaw: "",
-      existingParsed: null,
-    });
+    return withCatalogProviders(() =>
+      planOpenClawModelsJson({
+        context: {
+          cfg: config,
+          discoveryAuthConfig: config,
+          sourceConfigForSecrets: config,
+          agentDir,
+          env: options.env ?? {},
+          envFingerprint: {},
+          providerDiscoveryProviderIds: [options.providerId ?? "openai"],
+          providerDiscoveryTimeoutMs: options.timeoutMs,
+          onProviderCatalogOutcome: (outcome) => options.outcomes?.push(outcome),
+        },
+        authStore: store,
+        existingRaw: "",
+        existingParsed: null,
+      }),
+    );
   }
 
   async function createChutesCatalogFixture() {
@@ -831,14 +842,16 @@ describe("provider catalog late-result finalization", () => {
       ];
       const outcomes: ProviderCatalogOutcome[] = [];
       const discover = (timeoutMs?: number) =>
-        resolveImplicitProviders({
-          config: { auth: { order: { [providerId]: [profileId] } } },
-          agentDir: state.agentDir(),
-          authStore: store,
-          env: {},
-          providerDiscoveryTimeoutMs: timeoutMs,
-          onProviderCatalogOutcome: (outcome) => outcomes.push(outcome),
-        });
+        withCatalogProviders(() =>
+          resolveImplicitProviders({
+            config: { auth: { order: { [providerId]: [profileId] } } },
+            agentDir: state.agentDir(),
+            authStore: store,
+            env: {},
+            providerDiscoveryTimeoutMs: timeoutMs,
+            onProviderCatalogOutcome: (outcome) => outcomes.push(outcome),
+          }),
+        );
       vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
       const pending = discover(timedOut ? 25 : undefined);
       try {


### PR DESCRIPTION
## What Problem This Solves

The catalog auth fixture registers OpenAI, Chutes, and Xai provider objects for discovery, but exhausted-auth lookup can load a separate provider runtime. The first Chutes retention case took 47.5 seconds in CI and 61.3 seconds in the local baseline. A transparent probe attributed 75.7 seconds to its cold runtime lookup; catalog publication and normalization were sub-millisecond or tens of milliseconds.

## Why This Change Was Made

Run catalog planning and late-result discovery in the existing runtime registry scope, populated from the same provider descriptors used by discovery. Real auth lookup and provider hooks now use that fixture-owned registry. Remove the redundant formatter mock so the registered provider's actual hook runs.

The registry is local to each planning invocation and its asynchronous work. Existing storage, credential rotation, account retention, failure handling, timeout ownership, and late-result assertions remain intact. No new mocks or production changes.

## User Impact

Faster CI and local tests with the same coverage. No shard, cache, dependency, deadline, or product behavior changes.

## Evidence

All **24 existing cases passed in the same order**, including native credential persistence and late-result handling:

- First exhausted Chutes case: **61.294s → 0.195s**.
- First configured literal OAuth case: **9.077s → 0.206s**.
- Whole command: **89.18s → 16.95s**; case totals: **75.476s → 5.606s**.

These are sequential local fresh-process observations with host/cache variation; the instrumented call path independently establishes the unnecessary runtime load. Profiling changes were hash-restored before the candidate run.

The changed-file gate passed, including core and test types, formatting, lint, unused exports, and runtime import cycles. Managed P2 review found no actionable issues. The final fixture is byte-identical to the reviewed and tested version.

Production LOC: **0**. Test LOC: **+13 net**, primarily the scoped registry helper; all assertions remain.

Final exact-head [CI passed in 8m24s](https://github.com/openclaw/openclaw/actions/runs/34172437744). All 24 cases retained the same names/order; summed case time fell from **58.125s to 3.361s**, with the first Chutes case **47.495s to 115ms** and literal OAuth **7.217s to 127ms**. The critical job test step improved **388s to 343s**; its queue grew **8s to 78s**, explaining the unchanged workflow total.
