### PR TITLE
perf(talk): skip unused trailing wake-name distance

### DIFF
--- a/src/talk/activation-name.ts
+++ b/src/talk/activation-name.ts
@@ -306,13 +306,13 @@ function isFuzzyActivationNameMatch(
   if (heardCompact[0] !== activationCompact[0]) {
     return false;
   }
-  const distance = levenshteinDistance(heardCompact, activationCompact);
   if (candidate.edge === "trailing") {
     return (
       heardCompact.length === activationCompact.length &&
       hasOnlyPhoneticSubstitutions(heardCompact, activationCompact)
     );
   }
+  const distance = levenshteinDistance(heardCompact, activationCompact);
   if (distance <= 1) {
     return true;
   }


### PR DESCRIPTION
## What Problem This Solves

Realtime voice wake-name matching calculates an edit distance for trailing names even though the trailing-name policy never uses it. This adds avoidable work when processing a transcript.

## Why This Change Was Made

Move the distance calculation below the unconditional trailing-edge return. Trailing names continue to require the same boundary, first letter, equal length and phonetic substitutions. Leading names retain the existing edit-distance thresholds. The shared distance helper and all callers are unchanged; no cache, setting or public contract is added.

Production LOC is neutral: one line moved. Existing matching and transcript stripping behavior is preserved.

## User Impact

Less work in trailing wake-name matching, with no intended recognition or output change. This is a component optimization, not a measured end-to-end speech or Gateway speedup.

## Evidence

- All 77 existing tests passed: activation-name, distance and session-policy suites (30), plus the complete Discord realtime-turns suite (47). This is channel-boundary harness proof, not live speech recognition.
- All 28 normal changed-file checks passed. Independent managed review found no P0–P2 issues.
- A fixed baseline/candidate/candidate/baseline experiment plus two correctness phases verified 10,032 calls. Independent decoding confirmed complete input/output graph parity, property order/descriptors, no throws and no input mutation across 672 captured batches/controls.
- Timing uses 16-call batches, with two warm batches and 16 measured batches per case. The table reports per-call medians in microseconds; these are descriptive samples, not significance or tail estimates.

| Case | Forward baseline → candidate, µs | Reverse baseline → candidate, µs |
|---|---:|---:|
| Trailing vowel substitution | 2.790 → 2.675 (-4.15%) | 3.333 → 2.700 (-18.99%) |
| Trailing length mismatch | 2.967 → 2.401 (-19.09%) | 2.993 → 2.374 (-20.70%) |
| Trailing exact | 2.796 → 2.397 (-14.25%) | 2.982 → 2.395 (-19.69%) |
| Leading exact | 1.975 → 1.918 (-2.90%) | 2.237 → 1.801 (-19.50%) |
| Leading fuzzy | 2.250 → 2.431 (+8.04%) | 2.737 → 2.385 (-12.84%) |
| Ambient rejected | 2.273 → 2.576 (+13.29%) | 2.969 → 2.562 (-13.68%) |
| Trailing consonant rejected | 2.510 → 2.506 (-0.16%) | 2.958 → 2.474 (-16.37%) |
| Multiple names | 2.710 → 2.667 (-1.59%) | 3.242 → 2.727 (-15.90%) |

The measured eight-case mixture total was 10.85% lower forward and 16.35% lower reverse. Retained adverse results: 2/16 measured medians, 37/146 aggregate metrics, 102/304 indexed timing comparisons and 3/12 whole-child resource/import comparisons. Whole-child wall time was 3.11% higher forward and 1.13% lower reverse; import and system CPU were also higher forward. Whole-child metrics include capture, filesystem writes and verification.

Two disk-floor refusals occurred before the first candidate process launched. Cache cleanup and an intervening main pull interrupted continuity after the first baseline; the forward comparison is confounded. Both refusals and all original samples are retained; no acquired sample was rerun. Unchanged leading/control cases also moved, demonstrating noise. The source-level removal of unused computation is the reason for this patch; the experiment does not establish a universal speedup.
