### PR TITLE
refactor(reef): type untrusted envelope versions

### DIFF
--- a/extensions/reef/protocol/envelope.ts
+++ b/extensions/reef/protocol/envelope.ts
@@ -122,7 +122,7 @@ export interface SealOptions {
 }
 
 export interface OpenOptions {
-  envelope: Envelope;
+  envelope: Omit<Envelope, "v"> & { v: number };
   self: string;
   recipientEncryptionSecretKey: string;
   senderSigningPublicKey?: string;
@@ -318,7 +318,7 @@ export function validateMessageBody(value: unknown): asserts value is MessageBod
   }
 }
 
-function validateEnvelope(value: unknown): Envelope {
+function validateEnvelope(value: unknown): OpenOptions["envelope"] {
   if (!isExactObject(value, ["v", "id", "from", "to", "ts", "epk", "n", "ct", "sig"])) {
     throw new MalformedError();
   }
@@ -363,7 +363,7 @@ function validateEnvelope(value: unknown): Envelope {
   if (canonicalBytes(value).length > MAX_ENVELOPE_BYTES) {
     throw new TooLargeError();
   }
-  return value as unknown as Envelope;
+  return value as OpenOptions["envelope"];
 }
 
 function isExactObject(value: unknown, keys: string[]): value is Record<string, unknown> {

--- a/extensions/reef/protocol/identity-envelope.test.ts
+++ b/extensions/reef/protocol/identity-envelope.test.ts
@@ -45,7 +45,7 @@ function fixture() {
 }
 
 async function openFixture(
-  envelope: Envelope,
+  envelope: Parameters<typeof open>[0]["envelope"],
   alice: ReturnType<typeof generateIdentity>,
   bob: ReturnType<typeof generateIdentity>,
   self = "bob#1",
@@ -175,8 +175,8 @@ describe("envelope", () => {
 
   it("verifies every signed field before acting on it", async () => {
     const { alice, bob, envelope } = fixture();
-    const mutations: Envelope[] = [
-      { ...envelope, v: 2 as 1 },
+    const mutations: Array<Parameters<typeof open>[0]["envelope"]> = [
+      { ...envelope, v: 2 },
       { ...envelope, id: `${envelope.id.slice(0, -1)}1` },
       { ...envelope, from: "mallory#1" },
       { ...envelope, to: "mallory#1" },


### PR DESCRIPTION
## What Problem This Solves

Reef's `open` boundary accepts untrusted envelopes, but its input type claimed the protocol version was already the literal `1`. Validation therefore needed a double assertion, and tests had to lie about a deliberately unsupported version.

## Why This Change Was Made

The untrusted `OpenOptions.envelope` shape now models `v` as a number until runtime validation completes. `validateEnvelope` returns that honest boundary type, and tests derive the same type directly from `open`.

Signature-before-semantics ordering is intentionally preserved: every signed field, including `v`, must pass Ed25519 verification before unsupported-version rejection. This keeps the existing anti-oracle behavior and its regression test intact.

## User Impact

No runtime behavior change. Unsupported or tampered versions are rejected exactly as before, while the TypeScript contract no longer requires a double cast.

## Evidence

- Exact-head `pnpm check:changed` passed at `ea128530aa2` after rebasing onto `59f57f3cc5f`.
- Structured P0–P2 review found no actionable issue after confirming that early `v === 1` validation would violate the existing signed-field verification invariant.
- Neither changed file moved during the later `main` advance; synthetic merge with current `origin/main` is clean.
- Diff: 6 additions, 6 deletions; zero net LOC and no emitted runtime change.
