### PR TITLE
fix(e2e): preserve typed onboarding install diagnostics

### DIFF
--- a/scripts/lib/openclaw-e2e-instance.sh
+++ b/scripts/lib/openclaw-e2e-instance.sh
@@ -267,7 +267,7 @@ openclaw_e2e_install_package() {
     if [ -f "$log_file" ]; then
       openclaw_e2e_print_log "$log_file" >&2
     fi
-    exit 1
+    return "$install_status"
   fi
 }
 openclaw_e2e_find_dep_package() {

--- a/test/scripts/openclaw-e2e-instance.test.ts
+++ b/test/scripts/openclaw-e2e-instance.test.ts
@@ -524,11 +524,36 @@ describe("scripts/lib/openclaw-e2e-instance.sh", () => {
         OPENCLAW_TEST_TIMEOUT_ARGS: fixture.timeoutArgsPath,
       });
 
-      expect(result.status).toBe(1);
+      expect(result.status).toBe(42);
       expect(result.stderr).toContain("npm install failed for fixture package");
       expect(result.stderr).toContain("recent npm tail");
       expect(result.stderr).not.toContain("DO_NOT_PRINT_OLD_NPM_LOG");
       expect(fs.readFileSync(fixture.logPath, "utf8")).toContain("DO_NOT_PRINT_OLD_NPM_LOG");
+    });
+  });
+
+  it("returns install failures through the caller-owned ERR diagnostics", () => {
+    withTempDir("openclaw-e2e-instance-install-trap-", (tempDir) => {
+      const fixture = createPackageInstallFixture(tempDir);
+      const diagnosticPath = path.join(tempDir, "diagnostic.txt");
+      writeFakeTimeout(path.join(tempDir, "timeout"), true);
+      writeBashExecutable(path.join(tempDir, "npm"), ["exit 42"]);
+
+      const result = runBashWithHelper(
+        [
+          `trap 'status=$?; printf "%s" "$status" >${shellQuote(diagnosticPath)}; exit "$status"' ERR`,
+          `openclaw_e2e_install_package ${shellQuote(fixture.logPath)} ${shellQuote("fixture package")} ${shellQuote(fixture.prefixPath)}`,
+        ],
+        {
+          PATH: `${tempDir}${path.delimiter}${hostPath}`,
+          OPENCLAW_CURRENT_PACKAGE_TGZ: fixture.packagePath,
+          OPENCLAW_E2E_NPM_INSTALL_TIMEOUT: "42s",
+          OPENCLAW_TEST_TIMEOUT_ARGS: fixture.timeoutArgsPath,
+        },
+      );
+
+      expect(result.status).toBe(42);
+      expect(fs.readFileSync(diagnosticPath, "utf8")).toBe("42");
     });
   });
 


### PR DESCRIPTION
## Root cause

The shared package-install helper exits the scenario process itself when npm fails. That bypasses the caller-owned ERR trap, so scenario cleanup removes its temporary logs before the typed-onboarding diagnostics can publish.

## Fix

Return the original npm status from `openclaw_e2e_install_package`. The scenario remains fail-fast, but its existing ERR/EXIT lifecycle now owns diagnostics and cleanup in the intended order. No new helper, protocol, environment variable, or compatibility branch.

## Proof

- Pre-fix focused regression: status collapsed to 1 and caller diagnostics did not run.
- Post-fix: `test/scripts/openclaw-e2e-instance.test.ts` 40/40.
- Bash syntax, Oxfmt, OXLint, diff check pass.
- AutoReview P1 scoped-clean (0.97).

## LOC

- Production/tooling: +1/-1
- Tests: +26/-1

Rewrites the former +833-line diagnostic subsystem into the existing lifecycle owner.