### PR TITLE
fix(doctor): release plugin resources after inspection

### DIFF
--- a/docs/plugins/sdk-overview.md
+++ b/docs/plugins/sdk-overview.md
@@ -498,6 +498,14 @@ plugins.
 | `api.session.controls.registerSessionAction(...)`                                    | Typed session actions clients can dispatch through the Gateway                                                                                             |
 | `api.registerBoardWidgetContentKind(...)`                                            | Sandboxed board widget source validation, renderer resources, and document composition                                                                     |
 
+Runtime lifecycle registrations can also supply `dispose()` for resources captured
+by that registration. Explicitly owned, uncached plugin inspections invoke it on
+rollback or release and await cleanup, including invalid asynchronous registration
+work. Doctor uses this ownership when loading a context engine for discovery; it
+still does not invoke a discovery-only engine factory. `dispose()` must not delete
+durable state or disable another registration. Existing raw loader and Gateway
+lifetimes do not gain automatic disposal: keep their `cleanup(ctx)` behavior.
+
 `registerBoardWidgetContentKind(...)` is for plugins that own a declarative
 widget source format. The registration supplies a globally unique lowercase
 `kind`, a short label, one capability-scoped plugin surface plus its renderer

--- a/src/commands/doctor/shared/context-engine-host-compat.test.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.test.ts
@@ -6,7 +6,7 @@ import {
   registerContextEngineForOwner,
 } from "../../../context-engine/registry.js";
 import type { ContextEngine, ContextEngineHostCapability } from "../../../context-engine/types.js";
-import { loadPluginRegistryHandle } from "../../../plugins/loader.js";
+import { acquirePluginRegistryForInspection } from "../../../plugins/loader.js";
 import { createEmptyPluginRegistry } from "../../../plugins/registry-empty.js";
 import {
   collectContextEngineHostCompatibilityWarnings,
@@ -36,7 +36,7 @@ vi.mock("../../../context-engine/init.js", () => ({
 }));
 
 vi.mock("../../../plugins/loader.js", () => ({
-  loadPluginRegistryHandle: vi.fn(),
+  acquirePluginRegistryForInspection: vi.fn(),
 }));
 
 let engineCounter = 0;
@@ -114,7 +114,10 @@ describe("doctor context-engine host compatibility", () => {
           lifecycle: "readOnlyDiscovery",
         });
       }
-      vi.mocked(loadPluginRegistryHandle).mockReturnValue(registry);
+      vi.mocked(acquirePluginRegistryForInspection).mockImplementation(async () => ({
+        registry,
+        release: async () => undefined,
+      }));
       const cfg = configWithEngine(id);
       const params = { cfg, doctorFixCommand: "openclaw doctor --fix" };
       const warnings = await collectContextEngineHostCompatibilityWarnings(params);

--- a/src/commands/doctor/shared/context-engine-host-compat.ts
+++ b/src/commands/doctor/shared/context-engine-host-compat.ts
@@ -25,7 +25,7 @@ import {
   resolveContextEngine,
 } from "../../../context-engine/registry.js";
 import type { ContextEngineInfo } from "../../../context-engine/types.js";
-import { loadPluginRegistryHandle } from "../../../plugins/loader.js";
+import { acquirePluginRegistryForInspection } from "../../../plugins/loader.js";
 import type { PluginRegistry } from "../../../plugins/registry-types.js";
 import { withPluginRuntimeRegistryScope } from "../../../plugins/runtime/gateway-request-scope.js";
 import { defaultSlotIdForKey } from "../../../plugins/slots.js";
@@ -252,54 +252,58 @@ async function resolveSelectedContextEngineInfo(params: {
 
   ensureContextEnginesInitialized();
   let pluginRegistry: PluginRegistry | undefined;
-  if (getContextEngineRegistration(engineId)?.lifecycle !== "runtime") {
-    try {
-      pluginRegistry = loadPluginRegistryHandle({
-        config: params.cfg,
-        env: params.env,
-        onlyPluginIds: [engineId],
-      });
-    } catch (error) {
-      if (pluginRegistry?.contextEngines.get(engineId)?.lifecycle !== "runtime") {
-        const message = error instanceof Error ? error.message : String(error);
-        return {
-          warnings: [
-            `- plugins.slots.contextEngine: could not inspect context engine "${engineId}" host requirements because its plugin failed to load: ${message}`,
-          ],
-        };
-      }
-    }
-    const registration = pluginRegistry?.contextEngines.get(engineId);
-    if (registration?.lifecycle === "readOnlyDiscovery") {
-      return {
-        warnings: [
-          `- plugins.slots.contextEngine: context engine "${engineId}" is registered for read-only discovery; offline host compatibility inspection is unavailable. This does not indicate a missing runtime registration in the Gateway.`,
-        ],
-      };
-    }
-    if (registration?.lifecycle !== "runtime") {
-      return {
-        warnings: [
-          `- plugins.slots.contextEngine: could not inspect context engine "${engineId}" host requirements because it is not registered.`,
-        ],
-      };
-    }
-  }
-
+  let inspection: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
   try {
-    const agentId = resolveAmbientOwnerAgentId(params.cfg, undefined, {
-      surface: "context-engine Doctor checks",
-      hint: "Set agents.defaults.systemAgent.agentId before running Doctor.",
-    });
-    const resolve = () =>
-      resolveContextEngine(params.cfg, {
-        agentDir: resolveAgentDir(params.cfg, agentId, params.env),
-        workspaceDir: params.cfg.agents?.defaults?.workspace
-          ? resolveUserPath(params.cfg.agents.defaults.workspace, params.env)
-          : undefined,
+    try {
+      if (getContextEngineRegistration(engineId)?.lifecycle !== "runtime") {
+        try {
+          inspection = await acquirePluginRegistryForInspection({
+            config: params.cfg,
+            env: params.env,
+            onlyPluginIds: [engineId],
+          });
+          pluginRegistry = inspection.registry;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          return {
+            warnings: [
+              `- plugins.slots.contextEngine: could not inspect context engine "${engineId}" host requirements because its plugin failed to load: ${message}`,
+            ],
+          };
+        }
+        const registration = pluginRegistry.contextEngines.get(engineId);
+        if (registration?.lifecycle === "readOnlyDiscovery") {
+          return {
+            warnings: [
+              `- plugins.slots.contextEngine: context engine "${engineId}" is registered for read-only discovery; offline host compatibility inspection is unavailable. This does not indicate a missing runtime registration in the Gateway.`,
+            ],
+          };
+        }
+        if (registration?.lifecycle !== "runtime") {
+          return {
+            warnings: [
+              `- plugins.slots.contextEngine: could not inspect context engine "${engineId}" host requirements because it is not registered.`,
+            ],
+          };
+        }
+      }
+
+      const agentId = resolveAmbientOwnerAgentId(params.cfg, undefined, {
+        surface: "context-engine Doctor checks",
+        hint: "Set agents.defaults.systemAgent.agentId before running Doctor.",
       });
-    const engine = await withPluginRuntimeRegistryScope(pluginRegistry, resolve);
-    return { info: engine.info, warnings: [] };
+      const resolve = () =>
+        resolveContextEngine(params.cfg, {
+          agentDir: resolveAgentDir(params.cfg, agentId, params.env),
+          workspaceDir: params.cfg.agents?.defaults?.workspace
+            ? resolveUserPath(params.cfg.agents.defaults.workspace, params.env)
+            : undefined,
+        });
+      const engine = await withPluginRuntimeRegistryScope(pluginRegistry, resolve);
+      return { info: engine.info, warnings: [] };
+    } finally {
+      await inspection?.release();
+    }
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return {

--- a/src/plugins/host-hooks.ts
+++ b/src/plugins/host-hooks.ts
@@ -155,6 +155,11 @@ export type PluginSessionActionRegistration = {
 export type PluginRuntimeLifecycleRegistration = {
   id: string;
   description?: string;
+  /**
+   * Releases this registration's resources after an explicitly owned inspection.
+   * Raw loaders do not invoke this callback. Host cleanup notifications stay separate.
+   */
+  dispose?: () => void | Promise<void>;
   cleanup?: (ctx: {
     reason: PluginHostCleanupReason;
     sessionKey?: string;

--- a/src/plugins/loader-module-runtime.ts
+++ b/src/plugins/loader-module-runtime.ts
@@ -8,6 +8,7 @@ import { getPluginCache, withPluginCache } from "./plugin-cache.js";
 import { withProfile } from "./plugin-load-profile.js";
 import { getCachedPluginModuleLoader } from "./plugin-module-loader-cache.js";
 import { installOpenClawPluginSdkNativeResolver } from "./plugin-sdk-native-resolver.js";
+import { getPluginRegistryInspectionResources } from "./registry-inspection-resources.js";
 import type { PluginRegistry } from "./registry-types.js";
 import { withPluginRegistrationContext } from "./runtime.js";
 import { createRuntimeBase } from "./runtime/runtime-base.js";
@@ -88,12 +89,15 @@ function createGuardedPluginRegistrationApi(api: OpenClawPluginApi): {
 function runPluginRegisterSync(
   register: NonNullable<OpenClawPluginDefinition["register"]>,
   api: Parameters<NonNullable<OpenClawPluginDefinition["register"]>>[0],
+  registry: PluginRegistry,
 ): void {
   const guarded = createGuardedPluginRegistrationApi(api);
   try {
     const result = register(guarded.api);
     if (isPromiseLike(result)) {
-      void Promise.resolve(result).catch(() => {});
+      const pending = Promise.resolve(result);
+      getPluginRegistryInspectionResources(registry)?.trackRegistration(pending);
+      void pending.catch(() => {});
       throw new Error("plugin register must be synchronous");
     }
   } finally {
@@ -107,9 +111,14 @@ export function runPluginRegisterSyncInRegistry(
   registry: PluginRegistry,
   pluginId: string,
 ): void {
-  withPluginRegistrationContext(registry, pluginId, () => runPluginRegisterSync(register, api), {
-    registerMemoryCapability: api.registerMemoryCapability,
-  });
+  withPluginRegistrationContext(
+    registry,
+    pluginId,
+    () => runPluginRegisterSync(register, api, registry),
+    {
+      registerMemoryCapability: api.registerMemoryCapability,
+    },
+  );
 }
 
 export function createPluginModuleLoader(options: {

--- a/src/plugins/loader-runtime-core.ts
+++ b/src/plugins/loader-runtime-core.ts
@@ -27,6 +27,7 @@ import {
 import type { PluginLoadOptions } from "./loader-types.js";
 import { createPluginIdScopeSet, normalizePluginIdScope } from "./plugin-scope.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
+import type { PluginRegistryInspectionResources } from "./registry-inspection-resources.js";
 import { pluginLoaderCacheState } from "./registry-lifecycle.js";
 import { getPluginRegistryRuntime } from "./registry-runtime-binding.js";
 import { createPluginRegistry, type PluginRegistry } from "./registry.js";
@@ -68,6 +69,7 @@ export function loadOpenClawPluginsCore(
   options: PluginLoadOptions,
   nativeBindings: NativePluginLoadBindings,
   overrides?: InternalPluginLoadOverrides,
+  inspectionResources?: PluginRegistryInspectionResources,
 ): PluginRegistry {
   const requestedOnlyPluginIds = normalizePluginIdScope(options.onlyPluginIds);
   const requestedOnlyPluginIdSet = createPluginIdScopeSet(requestedOnlyPluginIds);
@@ -163,6 +165,7 @@ export function loadOpenClawPluginsCore(
       activateGlobalSideEffects: context.shouldActivate,
     });
     const { registry } = registryBuilder;
+    inspectionResources?.attach(registry);
     const { manifestRegistry, orderedCandidates, manifestBySource, provenance } =
       resolvePluginLoadDiscovery({
         options,

--- a/src/plugins/loader-runtime-load.ts
+++ b/src/plugins/loader-runtime-load.ts
@@ -16,6 +16,7 @@ import { createProviderAuthAvailability } from "./provider-auth-availability-cor
 import { createProviderExternalAuthResolver } from "./provider-external-auth-core.js";
 import { createProviderHookRuntime } from "./provider-hook-runtime-core.js";
 import { createProviderRegistryResolver } from "./providers.runtime-core.js";
+import { PluginRegistryInspectionResources } from "./registry-inspection-resources.js";
 import type { PluginRegistry } from "./registry-types.js";
 import { createRuntimeModelAuth } from "./runtime/runtime-model-auth.js";
 import type { PluginRuntime } from "./runtime/types.js";
@@ -85,6 +86,33 @@ export function resolvePluginCapabilityCatalogContext() {
 }
 export function loadOpenClawPlugins(options: PluginLoadOptions = {}): PluginRegistry {
   return loadOpenClawPluginsCore(options, loaderBindings);
+}
+
+/** Acquires a fresh discovery registry; release waits for its registration resources. */
+export async function acquirePluginRegistryForInspection(
+  options: Omit<PluginLoadOptions, "activate" | "cache"> = {},
+): Promise<{ registry: PluginRegistry; release: () => Promise<void> }> {
+  const resources = new PluginRegistryInspectionResources();
+  try {
+    const registry = loadOpenClawPluginsCore(
+      { ...options, activate: false, cache: false },
+      loaderBindings,
+      undefined,
+      resources,
+    );
+    return { registry, release: () => resources.release() };
+  } catch (error) {
+    try {
+      await resources.release();
+    } catch (disposalError) {
+      throw new AggregateError(
+        [error, disposalError],
+        "Plugin inspection failed and its resources could not be disposed",
+        { cause: disposalError },
+      );
+    }
+    throw error;
+  }
 }
 
 export function loadOpenClawPluginsWithInternalOverrides(

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -8,7 +8,10 @@ export {
   resolvePluginRegistryLoadCacheKey,
 } from "./loader-cache.js";
 export { loadOpenClawPluginCliRegistry } from "./loader-cli-registry.js";
-export { resolveRuntimePluginRegistry } from "./loader-runtime-load.js";
+export {
+  resolveRuntimePluginRegistry,
+  acquirePluginRegistryForInspection,
+} from "./loader-runtime-load.js";
 
 /** Loads a caller-owned registry value without changing the process-wide active registry. */
 export function loadPluginRegistryHandle(options: PluginLoadOptions = {}) {

--- a/src/plugins/registry-inspection-resources.ts
+++ b/src/plugins/registry-inspection-resources.ts
@@ -1,0 +1,112 @@
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { markPluginRegistryRetired } from "./registry-lifecycle.js";
+import type { PluginRegistry } from "./registry-types.js";
+
+type RegistrationDisposer = { id: string; dispose: () => void | Promise<void> };
+type RegistrationResources = {
+  disposers: RegistrationDisposer[];
+  disposal?: Promise<Error[]>;
+};
+
+// Registrars and loaders can come from different source/built module copies.
+const inspections = resolveGlobalSingleton(
+  Symbol.for("openclaw.pluginRegistryInspectionResources"),
+  () => new WeakMap<PluginRegistry, PluginRegistryInspectionResources>(),
+);
+
+export function getPluginRegistryInspectionResources(registry: PluginRegistry) {
+  return inspections.get(registry);
+}
+
+/** Owns only an explicitly acquired, uncached inspection's registration resources. */
+export class PluginRegistryInspectionResources {
+  readonly #registrations = new Map<string, RegistrationResources>();
+  readonly #pending = new Set<Promise<void>>();
+  #registry?: PluginRegistry;
+  #release?: Promise<void>;
+
+  attach(registry: PluginRegistry): void {
+    this.#registry = registry;
+    inspections.set(registry, this);
+  }
+
+  #registration(pluginId: string): RegistrationResources {
+    let entry = this.#registrations.get(pluginId);
+    if (!entry) {
+      entry = { disposers: [] };
+      this.#registrations.set(pluginId, entry);
+    }
+    return entry;
+  }
+
+  register(pluginId: string, disposer: RegistrationDisposer): void {
+    this.#registration(pluginId).disposers.push(disposer);
+  }
+
+  trackRegistration(pending: Promise<unknown>): void {
+    const completion = pending.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.#pending.add(completion);
+    void completion.then(() => this.#pending.delete(completion));
+  }
+
+  rollback(pluginId: string): void {
+    const entry = this.#registrations.get(pluginId);
+    if (entry) {
+      void this.#dispose(pluginId, entry);
+    }
+  }
+
+  async #waitForRegistrations(): Promise<void> {
+    while (this.#pending.size > 0) {
+      await Promise.all(this.#pending);
+    }
+  }
+
+  #dispose(pluginId: string, entry: RegistrationResources): Promise<Error[]> {
+    return (entry.disposal ??= Promise.resolve().then(async () => {
+      // An invalid async registration can still use a sibling's resources in this inspection.
+      await this.#waitForRegistrations();
+      const failures: Error[] = [];
+      const disposers = entry.disposers.splice(0);
+      for (const { id, dispose } of disposers) {
+        try {
+          await dispose();
+        } catch (cause) {
+          failures.push(
+            new Error(`Plugin inspection disposal failed: ${pluginId}:${id}`, { cause }),
+          );
+        }
+      }
+      return failures;
+    }));
+  }
+
+  release(): Promise<void> {
+    if (!this.#release) {
+      // Revocation can call back into release through synchronous abort listeners.
+      this.#release = Promise.resolve()
+        .then(async () => {
+          await this.#waitForRegistrations();
+          return Promise.all(
+            [...this.#registrations].map(([pluginId, entry]) => this.#dispose(pluginId, entry)),
+          );
+        })
+        .then((results) => {
+          const failures = results.flat();
+          if (failures.length > 0) {
+            throw new AggregateError(
+              failures,
+              "Plugin inspection resources could not all be disposed",
+            );
+          }
+        });
+      if (this.#registry) {
+        markPluginRegistryRetired(this.#registry);
+      }
+    }
+    return this.#release;
+  }
+}

--- a/src/plugins/registry-lifecycle.test.ts
+++ b/src/plugins/registry-lifecycle.test.ts
@@ -1,5 +1,12 @@
-import { afterEach, describe, expect, it } from "vitest";
-import { loadPluginRegistryHandle } from "./loader.js";
+import type { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferredCore } from "../shared/deferred.js";
+import { acquirePluginRegistryForInspection, loadPluginRegistryHandle } from "./loader.js";
+import {
+  resetPluginLoaderTestStateForTest,
+  useNoBundledPlugins,
+  writePlugin,
+} from "./loader.test-fixtures.js";
 import { createEmptyPluginRegistry } from "./registry-empty.js";
 import {
   activatePluginRecordLifecycleEpoch,
@@ -17,6 +24,7 @@ import type { PluginRegistry } from "./registry-types.js";
 import {
   captureActivePluginRegistrySnapshot,
   commitStagedPluginRegistry,
+  getActivePluginRegistry,
   resetPluginRuntimeStateForTest,
   rollbackStagedPluginRegistry,
   setActivePluginRegistry,
@@ -37,6 +45,7 @@ function captureActivation(registry: PluginRegistry) {
 }
 
 afterEach(() => resetPluginRuntimeStateForTest());
+afterEach(resetPluginLoaderTestStateForTest);
 
 describe("plugin registry retirement notifications", () => {
   it.each(["retire", "activate"] as const)(
@@ -208,4 +217,284 @@ describe("plugin registry retirement notifications", () => {
       expect(current.signal).toBe(retained.signal);
     },
   );
+});
+
+type InspectionConnection = { database: DatabaseSync; disposals: number; cleanups: number };
+let inspectionFixtureId = 0;
+
+function createInspectionFixture(options?: {
+  registration?: "throw" | "async-resolve" | "async-reject";
+  pauseDisposal?: boolean;
+  disposalFailure?: boolean;
+  contextEngine?: boolean;
+}) {
+  useNoBundledPlugins();
+  const id = `owned-inspection-${inspectionFixtureId++}`;
+  const key = `__openclaw_${id}`;
+  const connections: InspectionConnection[] = [];
+  const resume = createDeferredCore();
+  const finishDisposal = createDeferredCore();
+  const disposalStarted = createDeferredCore();
+  const disposed = createDeferredCore();
+  const sibling: { read?: () => unknown; result?: unknown } = {};
+  const state = {
+    connections,
+    resume,
+    finishDisposal,
+    disposalStarted,
+    disposed,
+    sibling,
+    lateRead: 0,
+    factoryCalls: 0,
+  };
+  Object.defineProperty(globalThis, key, { value: state, configurable: true });
+  const plugin = writePlugin({
+    id,
+    body: `const { DatabaseSync } = require("node:sqlite");
+module.exports = {
+  id: ${JSON.stringify(id)},
+  register(api) {
+    const state = globalThis[${JSON.stringify(key)}];
+    const database = new DatabaseSync(":memory:");
+    const connection = { database, disposals: 0, cleanups: 0 };
+    state.connections.push(connection);
+    class NativeLifecycle {
+      id = " native-resource ";
+      #database = database;
+      async dispose() {
+        connection.disposals++;
+        state.disposalStarted.resolve();
+        if (${options?.pauseDisposal === true}) await state.finishDisposal.promise;
+        this.#database.close();
+        state.disposed.resolve();
+        if (${options?.disposalFailure === true}) throw new Error("fixture disposal failed");
+      }
+      cleanup = () => {
+        connection.cleanups++;
+        if (database.isOpen) database.close();
+      };
+    }
+    api.registerRuntimeLifecycle(new NativeLifecycle());
+    if (${options?.contextEngine === true}) {
+      api.registerContextEngine(${JSON.stringify(id)}, () => {
+        state.factoryCalls++;
+        throw new Error("Discovery must not invoke the context engine factory");
+      });
+    }
+    const mode = ${JSON.stringify(options?.registration)};
+    if (mode === "throw") throw new Error("fixture registration failed");
+    if (mode?.startsWith("async")) return (async () => {
+      await state.resume.promise;
+      state.lateRead = database.prepare("SELECT 42 AS value").get().value;
+      state.sibling.result = state.sibling.read?.();
+      if (mode === "async-reject") throw new Error("late registration failure");
+    })();
+  },
+};`,
+  });
+  const config = {
+    plugins: {
+      allow: [id],
+      load: { paths: [plugin.file] },
+      slots: { memory: "none", ...(options?.contextEngine ? { contextEngine: id } : {}) },
+    },
+  };
+  return {
+    plugin,
+    config,
+    state,
+    connection(index = 0) {
+      const connection = connections[index];
+      if (!connection) {
+        throw new Error(`Missing native inspection connection ${index}`);
+      }
+      return connection;
+    },
+    async cleanup(inspection?: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>>) {
+      resume.resolve();
+      finishDisposal.resolve();
+      await inspection?.release().catch(() => undefined);
+      for (const connection of connections) {
+        if (connection.database.isOpen) {
+          connection.database.close();
+        }
+      }
+      Reflect.deleteProperty(globalThis, key);
+    },
+  };
+}
+
+describe("owned plugin inspections", () => {
+  it("releases an uncached inspection without disposing or changing the raw loader value", async () => {
+    const fixture = createInspectionFixture({ pauseDisposal: true });
+    const active = createEmptyPluginRegistry();
+    setActivePluginRegistry(active);
+    let inspection: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
+    try {
+      const raw = loadPluginRegistryHandle({ config: fixture.config });
+      inspection = await acquirePluginRegistryForInspection({ config: fixture.config });
+      expect(raw.plugins[0]?.id).toBe(fixture.plugin.id);
+      expect(inspection.registry).not.toBe(raw);
+      expect(getActivePluginRegistry()).toBe(active);
+      expect(fixture.state.connections).toHaveLength(2);
+      const legacy = fixture.connection();
+      const owned = fixture.connection(1);
+      expect(owned.database.prepare("SELECT 42 AS value").get()).toEqual({ value: 42 });
+      const signal = capturePluginRegistryLifecycleSignal(inspection.registry, undefined, {
+        scopedRuntime: true,
+      });
+      let reentrantRelease: Promise<void> | undefined;
+      signal?.addEventListener("abort", () => {
+        reentrantRelease = inspection?.release();
+      });
+      const release = inspection.release();
+      expect(signal?.aborted).toBe(true);
+      expect(reentrantRelease).toBe(release);
+      expect(inspection.release()).toBe(release);
+      await fixture.state.disposalStarted.promise;
+      expect(owned.database.isOpen).toBe(true);
+      fixture.state.finishDisposal.resolve();
+      await release;
+      expect(owned.disposals).toBe(1);
+      expect(owned.database.isOpen).toBe(false);
+      expect(legacy.database.prepare("SELECT 42 AS value").get()).toEqual({ value: 42 });
+      expect(legacy.disposals).toBe(0);
+      expect(legacy.cleanups).toBe(0);
+      expect(loadPluginRegistryHandle({ config: fixture.config })).toBe(raw);
+      expect(getActivePluginRegistry()).toBe(active);
+    } finally {
+      await fixture.cleanup(inspection);
+    }
+  });
+
+  it("disposes a failed registration without closing a successful sibling", async () => {
+    const failed = createInspectionFixture({ registration: "throw", disposalFailure: true });
+    const successful = createInspectionFixture();
+    let inspection: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
+    try {
+      inspection = await acquirePluginRegistryForInspection({
+        config: {
+          plugins: {
+            allow: [failed.plugin.id, successful.plugin.id],
+            load: { paths: [failed.plugin.file, successful.plugin.file] },
+            slots: { memory: "none" },
+          },
+        },
+      });
+      expect(
+        inspection.registry.plugins.find((entry) => entry.id === failed.plugin.id),
+      ).toMatchObject({
+        status: "error",
+        failurePhase: "register",
+      });
+      expect(inspection.registry.runtimeLifecycles.map((entry) => entry.pluginId)).toEqual([
+        successful.plugin.id,
+      ]);
+      await failed.state.disposed.promise;
+      expect(failed.connection().database.isOpen).toBe(false);
+      expect(successful.connection().database.prepare("SELECT 42 AS value").get()).toEqual({
+        value: 42,
+      });
+      await expect(inspection.release()).rejects.toMatchObject({
+        errors: [
+          expect.objectContaining({
+            message: `Plugin inspection disposal failed: ${failed.plugin.id}:native-resource`,
+          }),
+        ],
+      });
+      expect(failed.connection().disposals).toBe(1);
+      expect(successful.connection().disposals).toBe(1);
+      expect(successful.connection().database.isOpen).toBe(false);
+    } finally {
+      await failed.cleanup(inspection);
+      await successful.cleanup();
+    }
+  });
+
+  it("finishes construction rollback before rejecting an inspection", async () => {
+    const fixture = createInspectionFixture({ registration: "throw" });
+    try {
+      await expect(
+        acquirePluginRegistryForInspection({ config: fixture.config, throwOnLoadError: true }),
+      ).rejects.toThrow();
+      expect(fixture.state.connections).toHaveLength(1);
+      expect(fixture.connection().database.isOpen).toBe(false);
+      expect(fixture.connection().disposals).toBe(1);
+    } finally {
+      await fixture.cleanup();
+    }
+  });
+
+  it.each(["async-resolve", "async-reject"] as const)(
+    "waits for actual invalid registration work before disposal (%s)",
+    async (registration) => {
+      const sibling = createInspectionFixture();
+      const fixture = createInspectionFixture({ registration });
+      fixture.state.sibling.read = () =>
+        sibling.connection().database.prepare("SELECT 42 AS value").get()?.value;
+      let inspection: Awaited<ReturnType<typeof acquirePluginRegistryForInspection>> | undefined;
+      try {
+        inspection = await acquirePluginRegistryForInspection({
+          config: {
+            plugins: {
+              allow: [sibling.plugin.id, fixture.plugin.id],
+              load: { paths: [sibling.plugin.file, fixture.plugin.file] },
+              slots: { memory: "none" },
+            },
+          },
+        });
+        expect(
+          inspection.registry.plugins.find((entry) => entry.id === fixture.plugin.id)?.error,
+        ).toContain("plugin register must be synchronous");
+        expect(inspection.registry.runtimeLifecycles).toHaveLength(1);
+        let released = false;
+        const release = inspection.release().then(() => {
+          released = true;
+        });
+        await Promise.resolve();
+        expect(released).toBe(false);
+        expect(fixture.connection().disposals).toBe(0);
+        fixture.state.resume.resolve();
+        await release;
+        expect(fixture.state.lateRead).toBe(42);
+        expect(fixture.state.sibling.result).toBe(42);
+        expect(sibling.connection().database.isOpen).toBe(false);
+        expect(fixture.connection().disposals).toBe(1);
+        expect(fixture.connection().database.isOpen).toBe(false);
+      } finally {
+        await fixture.cleanup(inspection);
+        await sibling.cleanup();
+      }
+    },
+  );
+
+  it("releases Doctor discovery resources without invoking the context engine factory", async () => {
+    const fixture = createInspectionFixture({ contextEngine: true, pauseDisposal: true });
+    const { collectContextEngineHostCompatibilityWarnings } =
+      await import("../commands/doctor/shared/context-engine-host-compat.js");
+    let warnings: Promise<string[]> | undefined;
+    try {
+      warnings = collectContextEngineHostCompatibilityWarnings({
+        cfg: fixture.config,
+        doctorFixCommand: "openclaw doctor --fix",
+      });
+      await vi.waitFor(() => expect(fixture.state.connections).toHaveLength(1));
+      let completed = false;
+      void warnings.then(() => {
+        completed = true;
+      });
+      await Promise.resolve();
+      expect(completed).toBe(false);
+      expect(fixture.state.factoryCalls).toBe(0);
+      fixture.state.finishDisposal.resolve();
+      expect((await warnings).join("\n")).toContain("registered for read-only discovery");
+      expect(fixture.connection().disposals).toBe(1);
+      expect(fixture.connection().database.isOpen).toBe(false);
+      expect(fixture.connection().cleanups).toBe(0);
+    } finally {
+      fixture.state.finishDisposal.resolve();
+      await warnings?.catch(() => undefined);
+      await fixture.cleanup();
+    }
+  });
 });

--- a/src/plugins/registry-registrars-host.ts
+++ b/src/plugins/registry-registrars-host.ts
@@ -17,6 +17,7 @@ import {
   type PluginTrustedToolPolicyRegistration,
 } from "./host-hooks.js";
 import { validateControlUiNativeRoutePlacement } from "./registry-control-ui-policy.js";
+import { getPluginRegistryInspectionResources } from "./registry-inspection-resources.js";
 import type { PluginRegistryState } from "./registry-state.js";
 import type {
   PluginRecord,
@@ -424,6 +425,16 @@ export function createHostRegistrars(state: PluginRegistryState) {
     if (lifecycle.cleanup !== undefined && typeof lifecycle.cleanup !== "function") {
       reportRegistrationError(record, `runtime lifecycle cleanup must be a function: ${id}`);
       return;
+    }
+    const inspection = getPluginRegistryInspectionResources(registry);
+    const dispose = inspection ? lifecycle.dispose : undefined;
+    if (dispose !== undefined && typeof dispose !== "function") {
+      reportRegistrationError(record, `runtime lifecycle dispose must be a function: ${id}`);
+      return;
+    }
+    if (inspection && dispose) {
+      // A disposer may be inherited and require the original registration as its receiver.
+      inspection.register(record.id, { id, dispose: () => dispose.call(lifecycle) });
     }
     registry.runtimeLifecycles.push({
       pluginId: record.id,

--- a/src/plugins/registry.ts
+++ b/src/plugins/registry.ts
@@ -1,6 +1,7 @@
 /** In-memory plugin registry builder and mutation API for plugin runtime registration. */
 import { cleanupPluginSessionSchedulerJobs } from "./host-hook-runtime.js";
 import { createPluginApiFactory } from "./registry-api.js";
+import { getPluginRegistryInspectionResources } from "./registry-inspection-resources.js";
 import { createPluginRegistrars } from "./registry-registrars.js";
 import { createPluginRuntimeResolver } from "./registry-runtime.js";
 import { createPluginRegistryState } from "./registry-state.js";
@@ -51,6 +52,7 @@ export function createPluginRegistry(registryParams: PluginRegistryParams) {
   const rollbackPluginGlobalSideEffects = (pluginId: string, record?: RegistryPluginRecord) => {
     deactivatePluginSideEffectGuards(pluginId);
     runtimeResolver.revokePluginRuntimeRecord(pluginId, record);
+    getPluginRegistryInspectionResources(state.registry)?.rollback(pluginId);
     const schedulerRecords = state.registry.sessionSchedulerJobs.filter(
       (r) => r.pluginId === pluginId,
     );


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Doctor can execute plugin registration while inspecting a configured context engine, but its existing raw loader result has no release boundary for resources captured during registration.

## Why This Change Was Made

Add an explicit uncached, non-activating inspection acquisition and release it when Doctor discovery finishes. Optional resource-only disposers remain owned through rollback and actual invalid asynchronous registration work; release waits for cleanup. Prototype methods retain their original receiver and normalized registration ID.

Existing raw loader returns, cache behavior, Gateway cleanup notifications, and active runtime engine handling stay unchanged. Discovery-only context engines still report offline inspection unavailable, and their factories are never invoked. This is the first bounded ownership slice from the aggregate PR.

## User Impact

Plugins can release registration-owned resources after an explicitly owned inspection by providing the documented optional disposer. Doctor waits for that cleanup. Disposal is separate from disabling a plugin or deleting durable state; older raw loader lifetimes still use their existing cleanup contract.

## Evidence

- 59 focused native, Doctor, raw-loader, and laziness cases passed. The final mechanical cleanup was rechecked with 23 native/Doctor cases and 13 format, type, lint, and guard phases.
- Initial canonical checks caught two missing-braces errors in test helpers. Those were fixed; the affected checks and previously unrun guard steps all passed. Production dead-export scans passed.
- Full build passed in 285.793 seconds with source and index unchanged.
- The original prototype-capture defect failed the native rollback regression before correction.
- A synthetic probe invoked the actual built Doctor owner with a prototype/private-field disposer and real SQLite file. Doctor stayed pending until disposal finished; the probe observed exactly one disposal, no cleanup notification or factory invocation, native closure, and successful read-only reopen with its row preserved. This covers the built owner entry, not a full CLI diagnostics run or real provider execution.
- Deslop and independent P0–P2 Codex review completed without actionable findings.

No schema, data representation, dependency, configuration option, protocol version, or host floor changes.

## Review Disposition

Retain the documented inspection-only callback contract. This is the accepted resource-only registration cleanup scope: disposers own resources captured by that registration and must not close resources belonging to a raw-loader or Gateway registration. The native isolation case keeps the cached raw registration usable while the separate inspection closes, and the existing cleanup notification remains untouched.

The automatic data-model flag is a path-classification false positive. The complete diff changes no schema, migration, stored value, query, retention, or repair logic; Doctor's existing configuration-repair function is unchanged. Its inspection path gains a finite resource lifetime. Native closure plus read-only reopen verifies preserved rows; there is no data conversion needing an upgrade migration.
