### PR TITLE
test: avoid duplicate waits in Kova auth fixtures

### DIFF
--- a/test/scripts/ci-git-owner-auth.test.ts
+++ b/test/scripts/ci-git-owner-auth.test.ts
@@ -89,12 +89,12 @@ it.skipIf(process.platform === "win32").each([
 );
 
 it.skipIf(process.platform === "win32").each([
-  { mode: "kova", failures: 0, succeeds: true },
-  { mode: "kova-retry", failures: 2, succeeds: true },
-  { mode: "kova-exhausted", failures: 3, succeeds: false },
+  { mode: "kova", failures: 0, succeeds: true, backoffs: [] },
+  { mode: "kova-retry", failures: 2, succeeds: true, backoffs: [5, 5] },
+  { mode: "kova-exhausted", failures: 3, succeeds: false, backoffs: [5, 5] },
 ])(
   "Kova authenticates source fetch and checkout with bounded retries ($mode)",
-  async ({ mode, failures, succeeds }) => {
+  async ({ mode, failures, succeeds, backoffs }) => {
     const report = await runAuthFixture(
       mode,
       workflowScript("openclaw-performance.yml", "kova", "Install OCM and Kova"),
@@ -104,6 +104,7 @@ it.skipIf(process.platform === "win32").each([
       checkoutComplete: succeeds,
       sessions: failures + (succeeds ? 2 : 0),
       transientFailures: failures,
+      backoffs,
       filteredFetch: succeeds,
       shallowCheckout: succeeds,
       credentialPersisted: false,

--- a/test/scripts/fixtures/ci-checkout-auth.py
+++ b/test/scripts/fixtures/ci-checkout-auth.py
@@ -166,8 +166,8 @@ with tempfile.TemporaryDirectory(prefix="checkout-auth-") as directory:
         remote = f"http://127.0.0.1:{server.server_port}/{bare.name}"
         workspace = root / "workspace"
         if kova:
-            # Keep the whole workflow body intact. Only unrelated OCM/npm tools
-            # are stubbed; Git talks to the real server for every object it needs.
+            # Keep the workflow statements intact. Git talks to the real server;
+            # only unrelated OCM/npm tools and retry waiting are stubbed.
             workspace = root / "kova-src"
             (root / "ocm-install").mkdir()
             (root / "ocm-install/ocm").write_text("#!/bin/sh\nexit 0\n")
@@ -178,6 +178,23 @@ npm() { test -s "$KOVA_SRC/payload.txt"; }
 node() { :; }
 ''' + sys.argv[3].replace('"https://github.com/${KOVA_REPOSITORY}.git"', json.dumps(remote)).replace(
                 'f"https://github.com/{os.environ[\'KOVA_REPOSITORY\']}.git"', repr(remote))
+            backoffs_path = root / "backoffs.json"
+            policy_start = "<<'PYTHON'\n"
+            assert script.count(policy_start) == 1, "Expected one Kova Python policy boundary"
+            # Observe retry policy on the existing owner, leaving Git deadlines
+            # and process draining real. Lifecycle tests cover elapsed backoff/cancellation.
+            script = script.replace(policy_start, policy_start + f'''import ci_git_owner as fixture_owner
+import json as fixture_json
+from pathlib import Path as FixturePath
+fixture_backoffs = []
+fixture_backoffs_path = FixturePath({str(backoffs_path)!r})
+fixture_backoffs_path.write_text(fixture_json.dumps(fixture_backoffs))
+def fixture_backoff(seconds):
+    fixture_owner.check_cancelled()
+    fixture_backoffs.append(seconds)
+    fixture_backoffs_path.write_text(fixture_json.dumps(fixture_backoffs))
+fixture_owner.backoff = fixture_backoff
+''', 1)
             result = command("bash", "-e", "-o", "pipefail", "-c", script, extra={
                 "CI_GIT_OWNER": owner, "GH_TOKEN": token,
                 "RUNNER_TEMP": str(root), "KOVA_HOME": str(home / "kova"),
@@ -195,6 +212,7 @@ node() { :; }
             print(json.dumps({"mode": mode, "exitCode": result.returncode, "stderr": result.stderr,
                               "checkoutComplete": complete, "sessions": kova_methods.count("GET"),
                               "transientFailures": transient_failures, "filteredFetch": filtered_fetch,
+                              "backoffs": json.loads(backoffs_path.read_text()),
                               "shallowCheckout": complete and checked(git, "rev-parse", "--is-shallow-repository", cwd=workspace) == "true",
                               "credentialPersisted": "extraheader" in local_config.lower(), "requests": requests}))
             raise SystemExit(0)


### PR DESCRIPTION
## What Problem This Solves

The Git-auth fixture spends two real five-second backoffs in both Kova retry cases. Those waits duplicate existing real-clock and cancellation coverage, adding about twenty seconds to the auth tests.

## Why This Change Was Made

At the fixture's existing trusted Python policy boundary, observe the original Git owner's requested backoffs instead of waiting through them. Assert no delay for immediate success and exactly `[5, 5]` for successful retry and exhaustion. The observer checks cancellation and records each received delay; a missing report fails the fixture.

Real Git fetches, smart-HTTP authentication, transient HTTP failures, shallow/blobless checkout, credential scoping, process deadlines, and cleanup are unchanged. The production owner and workflow remain byte-identical. Separate tests retain real five-second elapsed backoff and cancellation proof.

## User Impact

Faster CI and local auth tests with the same real Git/HTTP coverage. No runtime flags, production changes, global clock changes, or additional sharding.

## Evidence

All **15 existing cases passed in the same order**:

- Retry case: **11.498s to 1.607s**.
- Exhaustion case: **11.383s to 1.393s**.
- Whole command: **47.02s to 28.42s**, saving **18.60s** in this local comparison.

A controlled change of the owner's requested delay from five to four seconds failed the new assertion with `[4, 4]` versus `[5, 5]`, while checkout succeeded. The owner was then hash-restored; the final fixture matches the full passing candidate run. The changed-file gate and managed P2 review passed.

The initial unchanged baseline encountered intermittent QA subprocess-cleanup failures; its unchanged repeat and the candidate both passed all 15 cases. The first negative-control attempt also hit cleanup failure before the exact control repeat demonstrated the intended assertion failure. Those logs are retained; this change does not claim to repair the separate cleanup flake.

Production LOC: **0**. Tests/support: **+19 net** (25 added, 6 removed). Existing assertions are preserved, with requested-delay assertions added.

Final exact-head [CI passed in 7m30s](https://github.com/openclaw/openclaw/actions/runs/34173454579). All 15 auth cases kept their names and order; total case time fell **31.917s to 11.655s**, with retry **840ms** and exhaustion **779ms**. Those two cases saved **20.076s** in CI. The auth job no longer sets completion time; the remaining critical job spent 301s testing and 392s executing, with a 2s queue.
