### PR TITLE
refactor(transcripts): separate summary persistence from capture

### DIFF
--- a/src/agents/tools/transcripts-tool.ts
+++ b/src/agents/tools/transcripts-tool.ts
@@ -14,13 +14,15 @@ import {
   stopTranscriptCapture,
 } from "../../transcripts/capture-operations.js";
 import {
+  persistTranscriptSummary,
+  readTranscriptSummary,
+} from "../../transcripts/capture-summary.js";
+import {
   activeSessions,
   authorizeTranscriptSource,
   createTranscriptSessionId,
   isTranscriptSelectionCurrent,
-  persistTranscriptSummary,
   readTranscriptStringParam,
-  readTranscriptSummary,
   resolveTranscriptSourceOwnership,
   resolveSourceProvider,
   sourceFromParams,

--- a/src/transcripts/capture-operations.ts
+++ b/src/transcripts/capture-operations.ts
@@ -1,10 +1,10 @@
 import path from "node:path";
+import { persistTranscriptSummary } from "./capture-summary.js";
 import {
   activeSessions,
   finalizeTranscriptCapture,
   isTranscriptSelectionCurrent,
   isTranscriptSessionStarting,
-  persistTranscriptSummary,
   revokeTranscriptStartRetries,
   stopTranscriptProviderCapture,
   type TranscriptCaptureSelection,

--- a/src/transcripts/capture-summary.ts
+++ b/src/transcripts/capture-summary.ts
@@ -1,0 +1,52 @@
+import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { resolveTranscriptsConfig } from "./config.js";
+import type { TranscriptSessionDescriptor } from "./provider-types.js";
+import { TranscriptsSummaryChangedError, type TranscriptsStore } from "./store.js";
+import { summarizeTranscriptsWithModel } from "./summary-model.js";
+import { summarizeTranscripts } from "./summary.js";
+
+export async function readTranscriptSummary(params: {
+  config: ReturnType<typeof resolveTranscriptsConfig>;
+  cfg?: OpenClawConfig;
+  store: TranscriptsStore;
+  session: TranscriptSessionDescriptor;
+}) {
+  const utterances = await params.store.readUtterancesForSession(params.session, {
+    maxUtterances: params.config.maxUtterances,
+  });
+  const agentId = params.session.metadata?.agentId;
+  try {
+    if (params.cfg) {
+      const modeled = await summarizeTranscriptsWithModel({
+        cfg: params.cfg,
+        agentId:
+          typeof agentId === "string" && agentId.trim()
+            ? agentId
+            : resolveDefaultAgentId(params.cfg),
+        session: params.session,
+        utterances,
+      });
+      if (modeled) {
+        return modeled;
+      }
+    }
+  } catch {
+    // Historical captures may have no resolvable agent; they still get notes.
+  }
+  // Heuristic notes are the deterministic base; model inference is an enhancement
+  // so an unavailable model never loses the captured meeting notes.
+  return summarizeTranscripts({ session: params.session, utterances });
+}
+
+export async function persistTranscriptSummary(
+  params: Parameters<typeof readTranscriptSummary>[0],
+) {
+  const revision = params.store.readSummaryInputRevision(params.session);
+  if (revision === undefined) {
+    throw new TranscriptsSummaryChangedError();
+  }
+  const summary = await readTranscriptSummary(params);
+  const intendedSummaryPath = await params.store.writeSummary(summary, params.session, revision);
+  return { summary, intendedSummaryPath };
+}

--- a/src/transcripts/capture.ts
+++ b/src/transcripts/capture.ts
@@ -1,8 +1,8 @@
 import { randomUUID } from "node:crypto";
-import { resolveDefaultAgentId } from "../agents/agent-scope-config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveAgentRoute } from "../routing/resolve-route.js";
 import { truncateUtf16Safe } from "../utils.js";
+import { persistTranscriptSummary } from "./capture-summary.js";
 import { resolveTranscriptsConfig } from "./config.js";
 import { manualTranscriptSourceProvider } from "./manual-source.js";
 import { getTranscriptSourceProvider } from "./provider-registry.js";
@@ -15,9 +15,7 @@ import type {
   TranscriptsStartResult,
 } from "./provider-types.js";
 import { sanitizeTranscriptSourceLocator } from "./source-locator.js";
-import { TranscriptsSummaryChangedError, type TranscriptsStore } from "./store.js";
-import { summarizeTranscriptsWithModel } from "./summary-model.js";
-import { summarizeTranscripts } from "./summary.js";
+import type { TranscriptsStore } from "./store.js";
 
 const ACCOUNT_ID_OUTPUT_MAX_CHARS = 64;
 
@@ -162,51 +160,6 @@ export function revokeTranscriptStartRetries(
       pendingStartRetries.delete(owner);
     }
   }
-}
-
-export async function readTranscriptSummary(params: {
-  config: ReturnType<typeof resolveTranscriptsConfig>;
-  cfg?: OpenClawConfig;
-  store: TranscriptsStore;
-  session: TranscriptSessionDescriptor;
-}) {
-  const utterances = await params.store.readUtterancesForSession(params.session, {
-    maxUtterances: params.config.maxUtterances,
-  });
-  const agentId = params.session.metadata?.agentId;
-  try {
-    if (params.cfg) {
-      const modeled = await summarizeTranscriptsWithModel({
-        cfg: params.cfg,
-        agentId:
-          typeof agentId === "string" && agentId.trim()
-            ? agentId
-            : resolveDefaultAgentId(params.cfg),
-        session: params.session,
-        utterances,
-      });
-      if (modeled) {
-        return modeled;
-      }
-    }
-  } catch {
-    // Historical captures may have no resolvable agent; they still get notes.
-  }
-  // Heuristic notes are the deterministic base; model inference is an enhancement
-  // so an unavailable model never loses the captured meeting notes.
-  return summarizeTranscripts({ session: params.session, utterances });
-}
-
-export async function persistTranscriptSummary(
-  params: Parameters<typeof readTranscriptSummary>[0],
-) {
-  const revision = params.store.readSummaryInputRevision(params.session);
-  if (revision === undefined) {
-    throw new TranscriptsSummaryChangedError();
-  }
-  const summary = await readTranscriptSummary(params);
-  const intendedSummaryPath = await params.store.writeSummary(summary, params.session, revision);
-  return { summary, intendedSummaryPath };
 }
 
 // Retain the exact owner on failure so stop can retry persistence without touching


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Transcript summary generation and persistence currently share the live capture module. Moving them separately makes the upcoming capture-resource change smaller and keeps the summary write boundary easy to inspect.

## Why This Change Was Made

Move the existing read/persist functions into `capture-summary.ts` and update their capture, stop, import, and summarize callers. Both complete function declarations remain byte-identical. The revision check, heuristic fallback, lazy model inference, and export behavior are unchanged; no compatibility forwarding path remains.

## User Impact

No user-visible behavior change. This four-file refactor separates code movement from the later lifetime repair.

## Evidence

- Exact source comparison confirms both moved declarations and all remaining function bodies are unchanged.
- 84 existing tests passed in 36.951 seconds, including temporary SQLite capture cleanup, import, summary revision races, and model-summary behavior.
- Canonical changed checks passed in 388.703 seconds, including types, import cycles, dead exports, and persistence guards.
- Deslop completed without further edits. No schema, query, model deadline, or stored representation changes.
