### PR TITLE
fix(ui): respect empty thinking choices

### DIFF
--- a/src/gateway/session-utils-model.thinking-default.test.ts
+++ b/src/gateway/session-utils-model.thinking-default.test.ts
@@ -2,6 +2,38 @@ import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { resolveGatewayModelThinkingProfile } from "./session-utils-model.js";
 
+describe("Gateway all-null thinking map", () => {
+  it("preserves off as the default without selectable levels", () => {
+    const profile = resolveGatewayModelThinkingProfile({
+      cfg: {},
+      agentId: "main",
+      provider: "metadata-fixture",
+      model: "no-effort",
+      agentRuntime: "openclaw",
+      modelCatalog: [
+        {
+          provider: "metadata-fixture",
+          id: "no-effort",
+          name: "No selectable effort",
+          api: "openai-completions",
+          reasoning: true,
+          thinkingLevelMap: {
+            off: null,
+            minimal: null,
+            low: null,
+            medium: null,
+            high: null,
+            xhigh: null,
+            max: null,
+          },
+        },
+      ],
+    });
+
+    expect(profile).toEqual({ thinkingLevels: [], thinkingDefault: "off" });
+  });
+});
+
 describe.each([
   { agentRuntime: "openclaw", api: "openai-responses" as const },
   { agentRuntime: "codex", api: "openai-chatgpt-responses" as const },

--- a/ui/src/e2e/chat-model-controls.e2e.test.ts
+++ b/ui/src/e2e/chat-model-controls.e2e.test.ts
@@ -457,13 +457,26 @@ suite.define(() => {
       });
     },
   );
-  it.each(["openai", "example"])(
-    "keeps %s non-reasoning capabilities reachable without a model-menu bridge",
-    async (provider) => {
+  it.each([
+    { provider: "openai", reasoning: false, capability: "non-reasoning" },
+    { provider: "example", reasoning: false, capability: "non-reasoning" },
+    { provider: "metadata-fixture", reasoning: true, capability: "no-effort" },
+  ])(
+    "keeps $provider $capability capabilities reachable without a model-menu bridge",
+    async ({ provider, reasoning }) => {
       await suite.withPage({ viewport: { width: 320, height: 852 } }, async ({ page }) => {
         const gateway = await installMockGateway(page, {
           agentModel: `${provider}/basic`,
-          models: [{ id: "basic", provider, name: "Basic", reasoning: false, thinkingLevels: [] }],
+          models: [
+            {
+              id: "basic",
+              provider,
+              name: "Basic",
+              reasoning,
+              thinkingLevels: [],
+              thinkingDefault: "off",
+            },
+          ],
           methodResponses: {
             "sessions.list": {
               count: 1,
@@ -473,6 +486,7 @@ suite.define(() => {
                 model: "basic",
                 modelProvider: provider,
                 thinkingLevels: [],
+                thinkingDefault: "off",
                 contextTokens: 200_000,
               },
               sessions: [
@@ -482,6 +496,7 @@ suite.define(() => {
                   model: "basic",
                   modelProvider: provider,
                   thinkingLevels: [],
+                  thinkingDefault: "off",
                   contextTokens: 200_000,
                   totalTokens: 46_000,
                   totalTokensFresh: true,
@@ -496,8 +511,13 @@ suite.define(() => {
         const model = composer.locator('[data-chat-model-select="true"]');
         await expect.poll(() => model.getAttribute("aria-busy")).toBe("false");
         const effort = composer.locator('[data-chat-thinking-select="true"]');
-        if (provider === "example") {
+        if (provider !== "openai") {
           await expect.poll(() => effort.count()).toBe(0);
+          expect(
+            (await gateway.getRequests("sessions.patch")).some(
+              ({ params }) => params && Object.hasOwn(params, "thinkingLevel"),
+            ),
+          ).toBe(false);
           return;
         }
         await expect.poll(() => effort.getAttribute("aria-label")).toBe("Fast mode: Standard");

--- a/ui/src/lib/chat/thinking.test.ts
+++ b/ui/src/lib/chat/thinking.test.ts
@@ -1,8 +1,128 @@
 import { describe, expect, it } from "vitest";
 import type { ModelCatalogEntry } from "../../api/types.ts";
-import { resolveChatThinkingSelectState, resolveThinkingLevelInput } from "./thinking.ts";
+import {
+  formatThinkingCommandOptionsForSession,
+  isThinkingLevelOptionForSession,
+  resolveChatThinkingSelectState,
+  resolveThinkingCommandArgOptionsForSession,
+  resolveThinkingLevelInput,
+} from "./thinking.ts";
 
 describe("chat thinking helpers", () => {
+  it("keeps a ready empty thinking profile empty for the selected model", () => {
+    const model: ModelCatalogEntry = {
+      provider: "metadata-fixture",
+      id: "no-effort",
+      name: "No selectable effort",
+      reasoning: true,
+      agentRuntime: { id: "openclaw", source: "model" },
+      thinkingLevels: [],
+      thinkingDefault: "off",
+    };
+    const session = {
+      modelProvider: model.provider,
+      model: model.id,
+      agentRuntime: model.agentRuntime,
+      thinkingLevels: model.thinkingLevels,
+      thinkingOptions: [],
+      thinkingDefault: model.thinkingDefault,
+    };
+    const state = resolveChatThinkingSelectState({
+      catalog: [model],
+      session,
+      sessionKey: "agent:main:main",
+      sessionsResult: null,
+    });
+
+    expect({
+      options: state.options.map((option) => option.value),
+      acceptsHigh: isThinkingLevelOptionForSession(session, undefined, "high", [model]),
+      inherited: state.inherited.value,
+    }).toEqual({ options: [], acceptsHigh: false, inherited: "off" });
+    expect(formatThinkingCommandOptionsForSession(session, undefined, [model])).toBe("default");
+    expect(resolveThinkingCommandArgOptionsForSession(session, undefined, [model])).toEqual([]);
+  });
+
+  it.each(["catalog", "defaults", "session labels", "default labels"] as const)(
+    "preserves explicitly empty %s metadata",
+    (source) => {
+      const model: ModelCatalogEntry = {
+        provider: "metadata-fixture",
+        id: "no-effort",
+        name: "No selectable effort",
+        reasoning: true,
+        agentRuntime: { id: "openclaw", source: "model" },
+        thinkingDefault: "off",
+        ...(source === "catalog" ? { thinkingLevels: [] } : {}),
+      };
+      const session = {
+        modelProvider: model.provider,
+        model: model.id,
+        agentRuntime: model.agentRuntime,
+        thinkingDefault: model.thinkingDefault,
+        ...(source === "session labels" ? { thinkingOptions: [] } : {}),
+      };
+      const defaults = {
+        modelProvider: model.provider,
+        model: model.id,
+        agentRuntime: model.agentRuntime,
+        contextTokens: null,
+        thinkingDefault: model.thinkingDefault,
+        ...(source === "defaults" ? { thinkingLevels: [] } : {}),
+        ...(source === "default labels" ? { thinkingOptions: [] } : {}),
+      };
+      const state = resolveChatThinkingSelectState({
+        catalog: [model],
+        defaults,
+        session,
+        sessionKey: "agent:main:main",
+        sessionsResult: null,
+      });
+
+      expect(state.options).toEqual([]);
+      expect(isThinkingLevelOptionForSession(session, defaults, "high", [model])).toBe(false);
+    },
+  );
+
+  it("retains generic choices while thinking metadata is missing", () => {
+    const state = resolveChatThinkingSelectState({
+      catalog: [],
+      session: { modelProvider: "metadata-fixture", model: "loading" },
+      sessionKey: "agent:main:main",
+      sessionsResult: null,
+    });
+
+    expect(state.options.map((option) => option.value)).toEqual([
+      "off",
+      "minimal",
+      "low",
+      "medium",
+      "high",
+    ]);
+  });
+
+  it("keeps non-reasoning Off-only metadata distinct from an empty profile", () => {
+    const model: ModelCatalogEntry = {
+      provider: "metadata-fixture",
+      id: "plain",
+      name: "Plain model",
+      reasoning: false,
+      thinkingLevels: [{ id: "off", label: "off" }],
+      thinkingDefault: "off",
+    };
+    const session = { modelProvider: model.provider, model: model.id };
+    const state = resolveChatThinkingSelectState({
+      catalog: [model],
+      session,
+      sessionKey: "agent:main:main",
+      sessionsResult: null,
+    });
+
+    expect(state.options).toEqual([]);
+    expect(isThinkingLevelOptionForSession(session, undefined, "off", [model])).toBe(true);
+    expect(isThinkingLevelOptionForSession(session, undefined, "high", [model])).toBe(false);
+  });
+
   const lunaModel: ModelCatalogEntry = {
     id: "gpt-5.6-luna",
     name: "GPT-5.6 Luna",

--- a/ui/src/lib/chat/thinking.ts
+++ b/ui/src/lib/chat/thinking.ts
@@ -73,10 +73,10 @@ export function formatThinkingCommandOptionsForSession(
   defaults?: SessionsListResult["defaults"],
   catalog: readonly ModelCatalogEntry[] = [],
 ): string {
-  const options = resolveThinkingLevelOptionsForSession(session, defaults, catalog)
-    .map((level) => level.label)
-    .join(", ");
-  return options.split(", ").includes("default") ? options : `default, ${options}`;
+  const options = resolveThinkingLevelOptionsForSession(session, defaults, catalog).map(
+    (level) => level.label,
+  );
+  return (options.includes("default") ? options : ["default", ...options]).join(", ");
 }
 
 export function resolveThinkingLevelInput(
@@ -205,13 +205,9 @@ function resolveThinkingLevelOptions(params: {
   const { catalogEntry } = params;
   const modelMatchesDefaults = sessionModelMatchesDefaults(params.session, params.defaults);
   const explicitLevels =
-    (params.session?.thinkingLevels?.length ? params.session.thinkingLevels : null) ??
-    (params.session?.model && catalogEntry?.thinkingLevels?.length
-      ? catalogEntry.thinkingLevels
-      : null) ??
-    (modelMatchesDefaults && params.defaults?.thinkingLevels?.length
-      ? params.defaults.thinkingLevels
-      : null);
+    params.session?.thinkingLevels ??
+    (params.session?.model ? catalogEntry?.thinkingLevels : undefined) ??
+    (modelMatchesDefaults ? params.defaults?.thinkingLevels : undefined);
   if (explicitLevels) {
     if (
       params.hideUnsupportedOffOnly &&
@@ -223,10 +219,8 @@ function resolveThinkingLevelOptions(params: {
     return explicitLevels;
   }
   const explicitLabels =
-    (params.session?.thinkingOptions?.length ? params.session.thinkingOptions : null) ??
-    (modelMatchesDefaults && params.defaults?.thinkingOptions?.length
-      ? params.defaults.thinkingOptions
-      : null);
+    params.session?.thinkingOptions ??
+    (modelMatchesDefaults ? params.defaults?.thinkingOptions : undefined);
   if (params.hideUnsupportedOffOnly && catalogEntry?.reasoning === false) {
     if (!explicitLabels || explicitLabels.every(isOffThinkingOption)) {
       return [];


### PR DESCRIPTION
## What Problem This Solves

Control UI treated an explicitly empty thinking profile as missing metadata and offered generic efforts that the Gateway did not permit.

## Why This Change Was Made

Keep explicit empty session, catalog, and default lists empty while retaining the existing fallback when metadata is absent.

## User Impact

Unavailable thinking controls stay hidden, and unsupported commands are rejected locally. Supported thinking levels and the Fast toggle remain usable. Server validation, protocol, and stored config do not change.

## Evidence

The original client regression offered five invalid choices. Fourteen focused tests and nine neighboring controls passed after repair. Browser tests verified no effort control or thinking update for an empty profile and a working Fast-only neighbor. Real Gateway/chat checks confirmed local refusal plus persisted supported thinking and Fast changes. UI, build, and performance checks passed; one CI job was cancelled before execution.

Consumers: Control UI thinking controls preserve the Gateway’s explicit empty profile.
