### PR TITLE
fix(test): make TUI startup frame ordering deterministic

### DIFF
--- a/src/tui/tui-pty-harness-fixture-test-support.ts
+++ b/src/tui/tui-pty-harness-fixture-test-support.ts
@@ -31,10 +31,15 @@ export async function disposeActiveTuiFixtures(): Promise<void> {
   }
 }
 
-export async function startTuiFixture(opts: { env?: NodeJS.ProcessEnv; execPath?: string } = {}) {
+export async function startTuiFixture(
+  opts: { env?: NodeJS.ProcessEnv; execPath?: string; holdStartupHistory?: boolean } = {},
+) {
   const tempDir = await mkdtemp(path.join(tmpdir(), "openclaw-tui-pty-"));
   const scriptPath = await writeTuiPtyFixtureScript(tempDir);
   const logPath = path.join(tempDir, "fixture-log.jsonl");
+  const startupHistoryReleasePath = opts.holdStartupHistory
+    ? path.join(tempDir, "startup-history.release")
+    : undefined;
   const execPath = opts.execPath ?? process.execPath;
   const run = startPty(execPath, resolveRuntimeWorkerArgv(pathToFileURL(scriptPath), execPath), {
     activeRuns,
@@ -44,14 +49,35 @@ export async function startTuiFixture(opts: { env?: NodeJS.ProcessEnv; execPath?
       OPENCLAW_TUI_PTY_LOG_PATH: logPath,
       NO_COLOR: undefined,
       ...opts.env,
+      OPENCLAW_TUI_PTY_STARTUP_RELEASE_PATH: startupHistoryReleasePath,
     },
     exitTimeoutMs: EXIT_TIMEOUT_MS,
     outputTimeoutMs: OUTPUT_TIMEOUT_MS,
   });
 
+  let releaseStartupHistoryPromise: Promise<void> | undefined;
+  const releaseStartupHistory = () => {
+    releaseStartupHistoryPromise ??= startupHistoryReleasePath
+      ? writeFile(startupHistoryReleasePath, "")
+      : Promise.resolve();
+    return releaseStartupHistoryPromise;
+  };
+  if (startupHistoryReleasePath) {
+    const dispose = run.dispose;
+    // Suite cleanup must release held initialization even when its test never runs.
+    run.dispose = async () => {
+      try {
+        await releaseStartupHistory();
+      } finally {
+        await dispose();
+      }
+    };
+  }
+
   return {
     run,
     logPath,
+    releaseStartupHistory,
     waitForLogEntry: async (predicate: (entry: FixtureLogEntry) => boolean, timeoutMs?: number) =>
       await waitForFixtureLogEntry(logPath, predicate, timeoutMs ?? OUTPUT_TIMEOUT_MS, run.output),
     cleanup: async () => {
@@ -460,6 +486,7 @@ export async function writeTuiPtyFixtureScript(dir: string) {
               : null;
           const delayMs =
             rapidSwitchMarker === "A" ? 500 : rapidSwitchMarker === "B" ? 40 : startupDelayMs;
+          ${TUI_PTY_STARTUP_SESSION_FIXTURE.historyBarrier}
           if (delayMs > 0) {
             await new Promise((resolve) => setTimeout(resolve, delayMs));
           }

--- a/src/tui/tui-pty-harness.e2e.test.ts
+++ b/src/tui/tui-pty-harness.e2e.test.ts
@@ -22,6 +22,7 @@ import {
   streamingPrefixFrame,
   toolFrame,
 } from "./tui-pty-rendering-test-support.js";
+import { exerciseStartupHistoryRendering } from "./tui-pty-startup-session-fixture-test-support.js";
 const STARTUP_TIMEOUT_MS = 20_000;
 const TEST_TIMEOUT_MS = 5_000;
 const STARTUP_TEST_TIMEOUT_MS = 25_000;
@@ -71,7 +72,7 @@ describe("TUI PTY harness", { concurrent: false }, () => {
         },
       }),
       startTuiFixture({
-        env: { OPENCLAW_TUI_PTY_STARTUP_DELAY_MS: "400" },
+        holdStartupHistory: true,
       }),
     ]);
     const [mainBoot, compactBoot, thinkingOverrideBoot, slowBoot] = boots;
@@ -235,14 +236,7 @@ describe("TUI PTY harness", { concurrent: false }, () => {
   it(
     "shows startup activity while post-connect initialization is pending",
     async () => {
-      const output = await slowStartupFixture.run.waitForOutput(
-        "local ready | idle",
-        STARTUP_TIMEOUT_MS,
-      );
-      // PTY output is append-only, so first-occurrence order proves the startup
-      // activity frame rendered before the delayed post-connect init completed.
-      expect(output.indexOf("starting up")).toBeGreaterThanOrEqual(0);
-      expect(output.indexOf("starting up")).toBeLessThan(output.indexOf("local ready | idle"));
+      await exerciseStartupHistoryRendering(slowStartupFixture, STARTUP_TIMEOUT_MS);
     },
     STARTUP_TEST_TIMEOUT_MS,
   );

--- a/src/tui/tui-pty-startup-session-fixture-test-support.ts
+++ b/src/tui/tui-pty-startup-session-fixture-test-support.ts
@@ -1,3 +1,11 @@
+import { expect } from "vitest";
+import {
+  hasHistoricalSynchronizedFrameRow,
+  readFixtureLog,
+  waitForSynchronizedFrameRows,
+} from "./tui-pty-harness-assertion-test-support.js";
+import type { startTuiFixture } from "./tui-pty-harness-fixture-test-support.js";
+
 // Injects delayed session restore and history controls into the real-runTui PTY fixture.
 export const TUI_PTY_STARTUP_SESSION_FIXTURE = {
   variables: `
@@ -16,6 +24,14 @@ export const TUI_PTY_STARTUP_SESSION_FIXTURE = {
             await new Promise((resolve) => setTimeout(resolve, reconnectHistoryDelayMs));
           }
   `,
+  historyBarrier: `const startupReleasePath = process.env.OPENCLAW_TUI_PTY_STARTUP_RELEASE_PATH;
+          if (startupReleasePath) {
+            record("startupHistoryPending", { sessionKey });
+            while (!existsSync(startupReleasePath)) {
+              await new Promise((resolve) => setTimeout(resolve, 5));
+            }
+            record("startupHistoryReleased", { sessionKey });
+          }`,
   listSessionsSetup: `
           const isRestore = Boolean(opts?.search);
   `,
@@ -34,3 +50,37 @@ export const TUI_PTY_STARTUP_SESSION_FIXTURE = {
           }
   `,
 } as const;
+
+export async function exerciseStartupHistoryRendering(
+  fixture: Awaited<ReturnType<typeof startTuiFixture>>,
+  timeoutMs: number,
+) {
+  try {
+    await fixture.waitForLogEntry((entry) => entry.method === "startupHistoryPending", timeoutMs);
+    let startupOutput = "";
+    const startupRows = await waitForSynchronizedFrameRows(
+      {
+        ...fixture.run,
+        output: () => (startupOutput = fixture.run.output()),
+      },
+      (rows) => rows.some((row) => row.includes("starting up")),
+      timeoutMs,
+    );
+    expect(startupRows.join("\n")).not.toContain("local ready | idle");
+    expect(
+      hasHistoricalSynchronizedFrameRow(startupOutput, [], "local ready | idle", fixture.run),
+    ).toBe(false);
+    expect(await readFixtureLog(fixture.logPath)).not.toContainEqual(
+      expect.objectContaining({ method: "startupHistoryReleased" }),
+    );
+
+    await fixture.releaseStartupHistory();
+    await waitForSynchronizedFrameRows(
+      fixture.run,
+      (rows) => rows.some((row) => row.includes("local ready | idle")),
+      timeoutMs,
+    );
+  } finally {
+    await fixture.releaseStartupHistory();
+  }
+}

--- a/src/tui/tui-pty-startup-session-fixture-test-support.ts
+++ b/src/tui/tui-pty-startup-session-fixture-test-support.ts
@@ -2,9 +2,9 @@ import { expect } from "vitest";
 import {
   hasHistoricalSynchronizedFrameRow,
   readFixtureLog,
+  type StartTuiPtyFixture,
   waitForSynchronizedFrameRows,
 } from "./tui-pty-harness-assertion-test-support.js";
-import type { startTuiFixture } from "./tui-pty-harness-fixture-test-support.js";
 
 // Injects delayed session restore and history controls into the real-runTui PTY fixture.
 export const TUI_PTY_STARTUP_SESSION_FIXTURE = {
@@ -52,7 +52,9 @@ export const TUI_PTY_STARTUP_SESSION_FIXTURE = {
 } as const;
 
 export async function exerciseStartupHistoryRendering(
-  fixture: Awaited<ReturnType<typeof startTuiFixture>>,
+  fixture: Awaited<ReturnType<StartTuiPtyFixture>> & {
+    releaseStartupHistory: () => Promise<void>;
+  },
   timeoutMs: number,
 ) {
   try {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The PTY startup test could finish its artificial 400ms history delay without observing a startup frame, then fail while searching raw terminal output. Elapsed time alone does not establish that a frame was rendered while initialization remained pending.

## Why This Change Was Made

Hold fixture history initialization behind an owned release barrier. Require a completed startup frame, reject any earlier ready frame using the exact same captured snapshot, then release history and require a completed ready frame. The fixture's disposal also releases the barrier when the case is filtered out or setup fails.

The existing startup test-support owner holds the generated fixture fragment and assertions. Production rendering, the 20s/25s deadlines, and line limits remain unchanged.

## User Impact

More deterministic startup regression coverage; no product behavior change or overall runtime improvement claim. This adds 73 net test/support lines.

## Evidence

- The original case passed locally with complete PTY and phase captures. That pass does not establish full-load reliability or identify the exact mechanism of the earlier frozen-run failure.
- The full harness and session-identity sibling passed all 79 cases before the final historical-frame assertion was added. After that adjustment, the precise startup plus three existing frame-reader contracts passed (4 cases).
- Suppressing real startup rendering failed the completed-frame oracle. Emitting a real premature ready frame failed specifically at the new historical-frame assertion. Production was restored after both controls.
- Filtered-case and setup-failure controls verified barrier release during disposal and termination of all four fixture PTYs.
- Hosted architecture validation exposed a type-only dependency cycle; using the existing leaf fixture type removed it without changing emitted JavaScript. Madge, focused tests, mapped checks, and fresh review passed after the correction.
- The initial changed gate failed only file line limits. Moving the unchanged generated fragment and assertion exercise into the existing startup support file resolved this without weakening limits. Final mapped checks and fresh independent P2 review passed.

These are local Node 26 validation scopes, not a Linux full-suite or performance acceptance result.
