### PR TITLE
fix(agents): tell the settled-turn finalizer that tools are disabled

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -50,7 +50,7 @@ const QA_REASONING_ONLY_RETRY_INSTRUCTION =
 const QA_EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
 const QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
-  "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
+  "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch. Tools are unavailable in this step: it is a text-only pass, so reply with plain text and do not attempt any tool call.";
 const QA_COMPACTION_RETRY_CODE_MODE_WRITE_RESULT = {
   status: "completed",
   value: {

--- a/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.prompt-timeout-fallback.test-support.ts
@@ -147,7 +147,7 @@ describe("runEmbeddedAgent prompt timeout fallback handoff", () => {
       disableTools: true,
       skipPreparedUserTurnMessage: true,
       prompt:
-        "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.",
+        "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch. Tools are unavailable in this step: it is a text-only pass, so reply with plain text and do not attempt any tool call.",
     });
     expect(mockedGetApiKeyForModel).toHaveBeenCalledTimes(1);
   });

--- a/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
@@ -36,7 +36,7 @@ const REASONING_ONLY_RETRY_INSTRUCTION =
 const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
 const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
-  "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
+  "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch. Tools are unavailable in this step: it is a text-only pass, so reply with plain text and do not attempt any tool call.";
 
 export function shouldRetrySilentErrorAssistantTurn(params: {
   attempt: Pick<

--- a/src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-tool-evidence.test.ts
@@ -10,7 +10,7 @@ import { resolveReplayInvalidFlag, resolveRunLivenessState } from "./incomplete-
 import type { EmbeddedRunAttemptResult } from "./types.js";
 
 const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
-  "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
+  "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch. Tools are unavailable in this step: it is a text-only pass, so reply with plain text and do not attempt any tool call.";
 
 type LastAssistant = NonNullable<EmbeddedRunAttemptResult["lastAssistant"]>;
 
@@ -151,6 +151,21 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     );
 
     expect(instruction).toBe(SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION);
+  });
+
+  it("tells the finalizer that tools are unavailable", () => {
+    // The settled-turn finalization pass runs with disableTools: true. If the instruction
+    // does not say so, the model reaches for a tool, the denied call registers as capability
+    // activity, and projectSettledTurnFinalizationAttemptResult throws away the whole result
+    // -- including a perfectly good answer produced in the same completion.
+    const instruction = resolveSettledToolTerminalContinuationInstruction(
+      makeSettledContinuationParams(makeSettledIdleWriteAttempt(), {
+        timedOut: true,
+      }),
+    );
+
+    expect(instruction).toContain("Tools are unavailable in this step");
+    expect(instruction).toContain("do not attempt any tool call");
   });
 
   it("suppresses continuation for an exactly matched all-terminal current batch", () => {

--- a/src/agents/embedded-agent-runner/run/terminal-resolution.settled-request.test.ts
+++ b/src/agents/embedded-agent-runner/run/terminal-resolution.settled-request.test.ts
@@ -9,7 +9,7 @@ import { resolveEmbeddedRunAttemptTerminalState } from "./terminal-outcome.js";
 import { resolveSettledTurnFinalizationRequest } from "./terminal-resolution.js";
 
 const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
-  "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
+  "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch. Tools are unavailable in this step: it is a text-only pass, so reply with plain text and do not attempt any tool call.";
 
 describe("resolveSettledTurnFinalizationRequest", () => {
   it("requests isolated finalization only for a required settled-tool turn", () => {


### PR DESCRIPTION
## What Problem This Solves

The settled-turn finalization pass runs with `disableTools: true`, but the instruction it is handed never says so:

```ts
// src/agents/embedded-agent-runner/run/incomplete-turn-recovery.ts
const SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION =
  "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
```

"Do not repeat completed tool calls" reads as *don't redo work*, not *you have no tools*. So the model reaches for one, the call resolves against an empty tool list and returns `Tool <name> not found`, and that **denied** call registers as capability activity. `projectSettledTurnFinalizationAttemptResult` then throws `Settled-turn finalization attempt reported capability activity` and discards the whole result — **including a complete, correct answer written in the same completion**. The user receives only:

> The tool run finished, but no final summary was produced. I did not repeat any completed actions.

The work had already succeeded. Only the report is lost, which makes it look to the user like the task failed.

This is the discarded-answer half of #128368.

## Evidence

Running as a local patch on a live 2026.9.1 deployment since 2026-09-05 19:16 ET, measured from the gateway journal:

| window | finalizer triggered | `reported capability activity` | failed |
|---|---|---|---|
| before | 3 | **3** | 3 |
| after | **12** | **0** | 1 |

The guard fired on **every** finalization before the change and on **none of twelve** after.

```
# since the patch
$ journalctl -u openclaw-gateway --since "2026-09-05 19:16" | grep -c "reported capability activity"
0

# the only post-patch failure, a different error:
$ journalctl -u openclaw-gateway --since "2026-09-05 19:16" \
    | grep "settled-turn finalization failed" | sed -E 's/.*error=//' | sort | uniq -c
      1 Settled-turn finalization attempt did not complete successfully — using terminal fallback reply
```

That remaining failure is the earlier guard (terminal not ok / compaction / prompt timeout), not the tools guard, and it **discarded no answer** — the count of recoverable lost replies has not moved since the patch.

Before the change, the trace of a real occurrence (transcript event ids, one session):

```
[209] assistant  -> tool call
[210] toolResult "Tool automations not found"
[211] assistant  -> tool call
[212] toolResult "Tool exec not found"
[213] assistant  "<a complete, correct summary of the work>"   <- the real answer
[215] assistant  "The tool run finished, but no final summary was produced..."
[216] assistant  "The tool run finished, but no final summary was produced..."
```

Only `[216]` carried a delivery marker. `exec` is not a hallucinated tool name — it had 1458 successful calls in the same agent database; it "does not exist" only inside the finalization pass.

Full test suite not run locally (monorepo toolchain not installed here); CI covers that. I grepped the tree for every occurrence of the literal and updated each site that asserts equality — see below.

## Why this is safe

`resolveSettledToolTerminalContinuationInstruction` has exactly one caller, `resolveSettledTurnFinalizationRequest` (`terminal-resolution.ts`), whose only caller is `settled-turn-finalization.ts`, which always runs the attempt with `disableTools: true`. The added sentence is therefore true everywhere it is used and cannot mislead a tools-enabled retry.

**No security boundary changes.** Tools stay disabled, and the `toolMetas` guard in `agents/harness/settled-turn-finalization-result.ts` is untouched. This only stops the model walking into it.

That is deliberate. The review on #128368 blocked the tools-enabled-retry proposal as "changes a documented security boundary and needs maintainer direction", and I agree. I also floated excluding denied calls from `toolMetas` — on reading the guard, that understates it: the same denied call also lights `itemLifecycle.startedCount`, `itemLifecycle.completedCount` and `lastToolError`. That is a three-signal relaxation and still wants maintainer direction. This PR does not attempt it.

## Changes

- `incomplete-turn-recovery.ts` — the instruction gains one sentence.
- Four sites that assert the literal, updated to match: `settled-tool-evidence.test.ts`, `settled-turn-finalization.test.ts`, `run.prompt-timeout-fallback.test-support.ts`, `qa-lab/mock-openai/server.test.ts`.
- A new test asserting the *property* rather than the literal, so a future edit that drops the sentence fails with a reason rather than a string diff.

The qa-lab **needles** (`QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE`, `scenario-catalog.inference.test.ts`) contain only the unchanged opening sentence and still match, so they are intentionally left alone.

## CI note

`checks-node-compact-small-36` fails on `test/scripts/ci-git-owner.test.ts > accepts a newly proven relation when deepening only moves a boundary` (exit 125, `Release ancestry fetch completed without ancestry progress`, `warning: filtering not recognized by server`). That is release-ancestry git tooling and is unrelated to this diff, which touches only agent finalizer instruction strings and their assertions. The same shard passed 155/156, and the `Critical Quality (agent-runtime-boundary)` shard plus all six QA Smoke profiles are green. Happy to rebase if a re-run is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSQ1TiVbpzFfuU2p1LJX3p
