### PR TITLE
fix(talk): await connection cleanup during shutdown

### DIFF
--- a/src/gateway/talk-client-gateway-control.test.ts
+++ b/src/gateway/talk-client-gateway-control.test.ts
@@ -1,6 +1,7 @@
 import { setImmediate as nextEventLoopTurn } from "node:timers/promises";
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
 import type { RealtimeVoiceBridge } from "../talk/provider-types.js";
 import {
   closeTalkClientGatewayControlSession,
@@ -552,27 +553,69 @@ describe("Talk client Gateway control owner", () => {
     }
   });
 
-  it("closes the provider and logical session when the owning client disconnects", async () => {
-    const closeProvider = vi.fn(async () => undefined);
-    const closeLogicalSession = vi.fn(async () => undefined);
-    const owner = createTalkClientGatewayControlOwner({
-      voiceSessionId: "voice-disconnect",
-      sessionTarget,
-      connId: "conn-disconnect",
-      context: controlContext(),
-      runAgentConsult: vi.fn(async () => ({ text: "done" })),
-      appendTranscript: vi.fn(async () => undefined),
-      flushTranscript: vi.fn(async () => undefined),
-      closeLogicalSession,
-    });
-    await owner.adoptProvider(closeProvider);
-    owner.activate();
+  it.each([false, true])(
+    "joins provider and logical cleanup when the owning client disconnects (provider rejects: %s)",
+    async (rejectProvider) => {
+      const providerStarted = createDeferred();
+      const finishProvider = createDeferred();
+      const failure = new Error("provider close failed");
+      const closeProvider = vi.fn(async () => {
+        providerStarted.resolve();
+        await finishProvider.promise;
+        if (rejectProvider) {
+          throw failure;
+        }
+      });
+      const closeLogicalSession = vi.fn(async () => undefined);
+      const ownerWarn = vi.fn();
+      const context = controlContext(ownerWarn);
+      const log = { warn: vi.fn() };
+      const owner = createTalkClientGatewayControlOwner({
+        voiceSessionId: "voice-disconnect",
+        sessionTarget,
+        connId: "conn-disconnect",
+        context,
+        runAgentConsult: vi.fn(async () => ({ text: "done" })),
+        appendTranscript: vi.fn(async () => undefined),
+        flushTranscript: vi.fn(async () => undefined),
+        closeLogicalSession,
+      });
+      await owner.adoptProvider(closeProvider);
+      owner.activate();
 
-    cleanupTalkConnection("conn-disconnect", { warn: vi.fn() });
-
-    await vi.waitFor(() => expect(closeLogicalSession).toHaveBeenCalledOnce());
-    expect(closeProvider).toHaveBeenCalledOnce();
-  });
+      cleanupTalkConnection("conn-disconnect", log);
+      await providerStarted.promise;
+      let drained = false;
+      const draining = drainGlobalSingletonLifecycleState("restart").then(() => {
+        drained = true;
+      });
+      try {
+        expect(() => owner.assertOpen()).toThrow("closed");
+        await nextEventLoopTurn();
+        expect(drained).toBe(false);
+        expect(closeLogicalSession).not.toHaveBeenCalled();
+        finishProvider.resolve();
+        await draining;
+        expect(closeLogicalSession).toHaveBeenCalledOnce();
+        expect(closeProvider).toHaveBeenCalledOnce();
+        if (rejectProvider) {
+          expect(ownerWarn).toHaveBeenCalledWith(
+            "talk disconnected Gateway control close failed: provider close failed",
+          );
+          await expect(owner.close()).rejects.toBe(failure);
+        } else {
+          expect(ownerWarn).not.toHaveBeenCalled();
+        }
+        expect(log.warn).not.toHaveBeenCalled();
+        cleanupTalkConnection("conn-disconnect", log);
+        await nextEventLoopTurn();
+        expect(closeProvider).toHaveBeenCalledOnce();
+      } finally {
+        finishProvider.resolve();
+        await Promise.allSettled([owner.close(), draining]);
+      }
+    },
+  );
 
   it("finishes logical cleanup when provider teardown fails", async () => {
     const closeLogicalSession = vi.fn(async () => undefined);

--- a/src/gateway/talk-client-gateway-control.ts
+++ b/src/gateway/talk-client-gateway-control.ts
@@ -621,14 +621,18 @@ export function createTalkClientGatewayControlOwner(params: {
   // startup succeeds, so a failed new transport cannot evict the current one.
   owner.assertOpen();
   pendingOwners.add(owner);
-  registerTalkConnectionCleanup(params.connId, "browser-control", () => {
+  registerTalkConnectionCleanup(params.connId, "browser-control", async () => {
+    const pendingCloses: Promise<void>[] = [];
     for (const current of [...pendingOwners, ...owners.values()]) {
       if (current.connId === params.connId) {
-        void current.close().catch((error: unknown) => {
-          warn(`talk disconnected Gateway control close failed: ${formatError(error)}`);
-        });
+        pendingCloses.push(
+          current.close().catch((error: unknown) => {
+            warn(`talk disconnected Gateway control close failed: ${formatError(error)}`);
+          }),
+        );
       }
     }
+    await Promise.all(pendingCloses);
   });
   return owner;
 }

--- a/src/gateway/talk-session-registry.test.ts
+++ b/src/gateway/talk-session-registry.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import { drainGlobalSingletonLifecycleState } from "../shared/global-singleton.js";
 import { cleanupTalkConnection, registerTalkConnectionCleanup } from "./talk-session-registry.js";
 
 describe("Talk connection cleanup registry", () => {
-  it("keeps one cleanup per relay kind and forgets the connection before running them", () => {
+  it("keeps one cleanup per relay kind and fences reentrant cleanup", () => {
     const replacedRealtimeCleanup = vi.fn();
     const transcriptionCleanup = vi.fn();
     const log = { warn: vi.fn() };
@@ -19,6 +21,7 @@ describe("Talk connection cleanup registry", () => {
 
     expect(replacedRealtimeCleanup).not.toHaveBeenCalled();
     expect(realtimeCleanup).toHaveBeenCalledOnce();
+    expect(realtimeCleanup.mock.contexts).toEqual([undefined]);
     expect(transcriptionCleanup).toHaveBeenCalledOnce();
     expect(log.warn).not.toHaveBeenCalled();
   });
@@ -28,9 +31,13 @@ describe("Talk connection cleanup registry", () => {
     const transcriptionCleanup = vi.fn();
     const log = { warn: vi.fn() };
 
-    registerTalkConnectionCleanup("conn-error", "realtime-relay", () => {
-      throw cleanupError;
-    });
+    registerTalkConnectionCleanup(
+      "conn-error",
+      "realtime-relay",
+      vi.fn().mockImplementationOnce(() => {
+        throw cleanupError;
+      }),
+    );
     registerTalkConnectionCleanup("conn-error", "transcription-relay", transcriptionCleanup);
 
     cleanupTalkConnection("conn-error", log);
@@ -39,5 +46,82 @@ describe("Talk connection cleanup registry", () => {
       "failed to run realtime-relay Talk cleanup after connection disconnect: realtime cleanup failed",
     );
     expect(transcriptionCleanup).toHaveBeenCalledOnce();
+    cleanupTalkConnection("conn-error", log);
+  });
+
+  it("retains failed async cleanup for shutdown retry without replacing its owner", async () => {
+    const first = createDeferred();
+    const finish = createDeferred();
+    const log = { warn: vi.fn() };
+    const queued = createDeferred();
+    const queuedStarted = createDeferred();
+    const replacement = vi.fn(() => {
+      queuedStarted.resolve();
+      return queued.promise;
+    });
+    const cleanup = vi
+      .fn()
+      .mockImplementationOnce(() => first.promise)
+      .mockImplementationOnce(() => finish.promise);
+    registerTalkConnectionCleanup("conn-async-retry", "browser-control", cleanup);
+    cleanupTalkConnection("conn-async-retry", log);
+    cleanupTalkConnection("conn-async-retry", log);
+    expect(cleanup).toHaveBeenCalledOnce();
+    const firstObserved = first.promise.catch(() => undefined);
+    first.reject(new Error("physical cleanup failed"));
+    await firstObserved;
+    await Promise.resolve();
+    registerTalkConnectionCleanup("conn-async-retry", "browser-control", replacement);
+    let drained = false;
+    const draining = drainGlobalSingletonLifecycleState("restart").then(() => {
+      drained = true;
+    });
+    let concurrentDrained = false;
+    const concurrentDrain = drainGlobalSingletonLifecycleState("restart").then(() => {
+      concurrentDrained = true;
+    });
+    try {
+      expect(cleanup).toHaveBeenCalledTimes(2);
+      expect(replacement).not.toHaveBeenCalled();
+      await Promise.resolve();
+      expect(drained).toBe(false);
+      finish.resolve();
+      await queuedStarted.promise;
+      expect(drained).toBe(false);
+      expect(concurrentDrained).toBe(false);
+      expect(replacement).toHaveBeenCalledOnce();
+      queued.resolve();
+      await Promise.all([draining, concurrentDrain]);
+      cleanupTalkConnection("conn-async-retry", log);
+      expect(cleanup).toHaveBeenCalledTimes(2);
+      expect(log.warn).toHaveBeenCalledWith(expect.stringContaining("physical cleanup failed"));
+    } finally {
+      finish.resolve();
+      queued.resolve();
+      await Promise.all([draining, concurrentDrain]);
+    }
+  });
+
+  it("joins a restart drain started before the cleanup callback returns", async () => {
+    const finish = createDeferred();
+    let drained = false;
+    let draining = Promise.resolve();
+    registerTalkConnectionCleanup("conn-reentrant-drain", "browser-control", () => {
+      draining = drainGlobalSingletonLifecycleState("restart").then(() => {
+        drained = true;
+      });
+      return finish.promise;
+    });
+    cleanupTalkConnection("conn-reentrant-drain", { warn: vi.fn() });
+    try {
+      await new Promise<void>((resolve) => {
+        setImmediate(resolve);
+      });
+      expect(drained).toBe(false);
+    } finally {
+      finish.resolve();
+      await draining;
+    }
+    expect(drained).toBe(true);
   });
 });

--- a/src/gateway/talk-session-registry.ts
+++ b/src/gateway/talk-session-registry.ts
@@ -2,6 +2,8 @@
  * Process-local registry that lets Talk protocol methods resolve opaque
  * `sessionId` values to the concrete relay or managed-room backend.
  */
+import { isPromiseLike } from "@openclaw/normalization-core/promise-like";
+import { createDeferredCore } from "../shared/deferred.js";
 import { resolveGlobalMap } from "../shared/global-singleton.js";
 import { formatError } from "./server-utils.js";
 import type { PreparedTalkSessionTarget } from "./talk-session-target.types.js";
@@ -31,27 +33,109 @@ const unifiedTalkSessions = resolveGlobalMap<string, UnifiedTalkSessionRecord>(
   Symbol.for("openclaw.unifiedTalkSessions"),
   "close-and-restart",
 );
-const talkConnectionCleanups = resolveGlobalMap<string, Map<TalkConnectionCleanupKind, () => void>>(
+type TalkConnectionCleanup = {
+  run: () => void | Promise<void>;
+  nextRun?: () => void | Promise<void>;
+  pending?: Promise<void>;
+  failed: boolean;
+};
+
+const talkConnectionCleanups = resolveGlobalMap<
+  string,
+  Map<TalkConnectionCleanupKind, TalkConnectionCleanup>
+>(
   Symbol.for("openclaw.talkConnectionCleanups"),
+  async (connections) => {
+    const results = await Promise.allSettled(
+      [...connections].flatMap(([connId, cleanups]) =>
+        [...cleanups].map(async ([kind, cleanup]) => {
+          await runTalkConnectionCleanup(connId, kind, cleanup);
+        }),
+      ),
+    );
+    const failures = results.flatMap((result) =>
+      result.status === "rejected" ? [result.reason] : [],
+    );
+    if (failures.length > 0) {
+      throw new AggregateError(failures, "Talk provider cleanup did not complete");
+    }
+  },
   "close-and-restart",
 );
 
-/**
- * Keeps one owner cleanup per relay kind until the connection closes.
- * Replacing by kind stays bounded while the owner cleanup scans all live sessions.
- */
+function runTalkConnectionCleanup(
+  connId: string,
+  kind: TalkConnectionCleanupKind,
+  cleanup: TalkConnectionCleanup,
+): void | Promise<void> {
+  if (cleanup.pending) {
+    return cleanup.pending;
+  }
+  if (talkConnectionCleanups.get(connId)?.get(kind) !== cleanup) {
+    return;
+  }
+  // A cleanup callback can reenter shutdown before returning its own promise.
+  const completion = createDeferredCore();
+  cleanup.pending = completion.promise;
+  const completed = (): void | Promise<void> => {
+    cleanup.pending = undefined;
+    cleanup.failed = false;
+    const cleanups = talkConnectionCleanups.get(connId);
+    if (cleanups?.get(kind) === cleanup) {
+      if (cleanup.nextRun) {
+        cleanup.run = cleanup.nextRun;
+        cleanup.nextRun = undefined;
+        return runTalkConnectionCleanup(connId, kind, cleanup);
+      }
+      cleanups.delete(kind);
+      if (cleanups.size === 0 && talkConnectionCleanups.get(connId) === cleanups) {
+        talkConnectionCleanups.delete(connId);
+      }
+    }
+  };
+  const failed = (error: unknown): never => {
+    cleanup.pending = undefined;
+    cleanup.failed = true;
+    throw error;
+  };
+  try {
+    const run = cleanup.run;
+    const result = run();
+    if (isPromiseLike(result)) {
+      completion.resolve(Promise.resolve(result).then(completed, failed));
+      return completion.promise;
+    }
+    const next = completed();
+    completion.resolve(next);
+    return next;
+  } catch (error) {
+    completion.reject(error);
+    // The caller observes the synchronous throw; a reentrant drain may also join this promise.
+    void completion.promise.catch(() => {});
+    return failed(error);
+  }
+}
+
+/** Keeps failed cleanup under its original owner until a successful retry. */
 export function registerTalkConnectionCleanup(
   connId: string,
   kind: TalkConnectionCleanupKind,
-  cleanup: () => void,
+  cleanup: () => void | Promise<void>,
 ): void {
   const cleanups =
-    talkConnectionCleanups.get(connId) ?? new Map<TalkConnectionCleanupKind, () => void>();
-  cleanups.set(kind, cleanup);
+    talkConnectionCleanups.get(connId) ??
+    new Map<TalkConnectionCleanupKind, TalkConnectionCleanup>();
+  const previous = cleanups.get(kind);
+  // Each kind scans its live sessions; retain a failed original before the latest replacement.
+  if (previous?.pending || previous?.failed) {
+    previous.nextRun = cleanup;
+  } else {
+    cleanups.set(kind, { run: cleanup, failed: false });
+  }
   talkConnectionCleanups.set(connId, cleanups);
 }
 
-/** Runs and forgets every Talk cleanup owned by a disconnected gateway connection. */
+/** Starts cleanup without blocking the socket callback and reports asynchronous failures. */
 export function cleanupTalkConnection(
   connId: string,
   log: { warn: (message: string) => void },
@@ -60,15 +144,24 @@ export function cleanupTalkConnection(
   if (!cleanups) {
     return;
   }
-  // Delete first so cleanup failures or re-entrancy cannot retain stale connection owners.
-  talkConnectionCleanups.delete(connId);
-  for (const [kind, cleanup] of cleanups) {
-    try {
-      cleanup();
-    } catch (error) {
+  // Snapshot owners because callbacks can remove or replace cleanup kinds.
+  const snapshot = [...cleanups];
+  for (const [kind, cleanup] of snapshot) {
+    if (cleanup.pending) {
+      continue;
+    }
+    const report = (error: unknown) => {
       log.warn(
         `failed to run ${kind} Talk cleanup after connection disconnect: ${formatError(error)}`,
       );
+    };
+    try {
+      const pending = runTalkConnectionCleanup(connId, kind, cleanup);
+      if (pending) {
+        void pending.catch(report);
+      }
+    } catch (error) {
+      report(error);
     }
   }
 }


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Talk connection cleanup deleted callback records before running them and ignored returned promises. Failures lost their cleanup owner, and shutdown could finish while browser provider cleanup was still pending.

## Why This Change Was Made

Retain one pending or failed cleanup owner per connection and relay kind. Join actual completion, run a queued replacement only after the original succeeds, and remove the record after successful cleanup. Browser disconnect now returns and joins its existing close-and-warn promises through the singleton shutdown drain.

## User Impact

Socket disconnect stays non-blocking while shutdown waits for returned cleanup work. Browser provider terminal errors, warnings, replacement, and late-adoption policy remain unchanged. This does not add physical browser-close retry or claim that relay callbacks which return no promise are fully drained.

## Evidence

- Both actual browser-owner variants failed before the callback change because shutdown resolved before provider close finished.
- 36 owner tests passed, including the complete browser-control suite.
- 11 native checks passed with all six SQLite instances closed by their actual owners and none left for manual fixture cleanup. The real browser-control owner was exercised through disconnect and singleton drain.
- Formatting, typed lint, and the full canonical changed gate passed; the gate took 399.95 seconds.
- Deslop and independent P0–P2 Codex review completed without actionable findings.
- Refreshed onto main to include its unrelated UI lint repair. Range comparison and all four source hashes are identical, runtime contracts and dependency lock are unchanged, and package changes are scripts only. Earlier local proof retains its original source/base attribution; exact-head hosted CI validates the refreshed branch.

No schema, data, configuration, dependency, or public protocol changes.

Hosted CI initially hit the existing 60-second child-process deadline in the unchanged update-cleanup refusal test. Its refusal path exits directly and does not await Talk drainage. Only that failed job was rerun; it and all required checks then passed on the same head, with no source, assertion, or timeout changes.
