### PR TITLE
feat(discord): generate titles for forum posts

### DIFF
--- a/docs/channels/discord.md
+++ b/docs/channels/discord.md
@@ -632,6 +632,31 @@ This surprises people who add one channel to give it special settings and find t
 
 Channel entries override guild-level values, so a channel entry with `users: ["*"]` opens that one room to any sender even when the guild `users` list is narrow. Entries match by channel ID, name, or slug, and a thread falls back to its parent channel's entry.
 
+### Automatic thread titles
+
+Set `autoThreadName: "generated"` on a channel entry to replace the initial thread name with a concise model-generated title. OpenClaw uses the routed agent's utility model when configured and keeps the original name if title generation or the Discord rename fails.
+
+For normal text channels, use this with `autoThread: true`; OpenClaw creates the thread from the incoming message and renames it asynchronously. For Discord Forum and Media channels, configure `autoThreadName` on the parent channel entry. Discord creates the post thread, and OpenClaw renames it once from the starter message without requiring `autoThread`.
+
+```json5
+{
+  channels: {
+    discord: {
+      guilds: {
+        YOUR_SERVER_ID: {
+          channels: {
+            YOUR_FORUM_CHANNEL_ID: {
+              enabled: true,
+              autoThreadName: "generated",
+            },
+          },
+        },
+      },
+    },
+  },
+}
+```
+
 ### Role-based agent routing
 
 Use `bindings[].match.roles` to route Discord guild members to different agents by role ID. Role-based bindings accept role IDs only and are evaluated after peer or parent-peer bindings and before guild-only bindings. If a binding also sets other match fields (for example `peer` + `guildId` + `roles`), all configured fields must match.

--- a/extensions/discord/src/monitor/message-handler.context.ts
+++ b/extensions/discord/src/monitor/message-handler.context.ts
@@ -120,8 +120,9 @@ export async function buildDiscordMessageProcessContext(params: {
   const threadChannelId = threadChannel?.id;
   const threadParentInheritanceEnabled = discordConfig?.thread?.inheritParent ?? false;
   const isForumStarter =
-    Boolean(threadChannelId && isForumParent && forumParentSlug) && message.id === threadChannelId;
-  const forumContextLine = isForumStarter ? `[Forum parent: #${forumParentSlug}]` : null;
+    Boolean(threadChannelId && isForumParent) && message.id === threadChannelId;
+  const forumContextLine =
+    isForumStarter && forumParentSlug ? `[Forum parent: #${forumParentSlug}]` : null;
   const groupChannel = isGuildMessage && displayChannelSlug ? `#${displayChannelSlug}` : undefined;
   const senderName = sender.isPluralKit
     ? (sender.name ?? author.username)
@@ -318,6 +319,9 @@ export async function buildDiscordMessageProcessContext(params: {
     isGuildMessage,
     channelConfig: ctx.inboundEventKind === "room_event" ? null : channelConfig,
     threadChannel,
+    threadParentId,
+    threadParentName,
+    threadParentType,
     channelType: channelInfo?.type,
     channelName: channelInfo?.name,
     channelDescription: channelInfo?.topic,

--- a/extensions/discord/src/monitor/threading.auto-thread.test.ts
+++ b/extensions/discord/src/monitor/threading.auto-thread.test.ts
@@ -5,6 +5,8 @@ import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { ChannelType } from "../internal/discord.js";
 import { EMPTY_DISCORD_TEST_CONFIG } from "../test-support/config.js";
 type MaybeCreateDiscordAutoThreadFn = typeof import("./threading.js").maybeCreateDiscordAutoThread;
+type ResolveDiscordAutoThreadReplyPlanFn =
+  typeof import("./threading.js").resolveDiscordAutoThreadReplyPlan;
 
 const { generateThreadTitleMock } = vi.hoisted(() => ({
   generateThreadTitleMock: vi.fn(),
@@ -15,6 +17,7 @@ vi.mock("./thread-title.js", () => ({
 }));
 
 let maybeCreateDiscordAutoThread: MaybeCreateDiscordAutoThreadFn;
+let resolveDiscordAutoThreadReplyPlan: ResolveDiscordAutoThreadReplyPlanFn;
 
 const postMock = vi.fn();
 const getMock = vi.fn();
@@ -85,7 +88,8 @@ function expectGeneratedTitleField(field: string, expected: unknown) {
 }
 
 beforeAll(async () => {
-  ({ maybeCreateDiscordAutoThread } = await import("./threading.js"));
+  ({ maybeCreateDiscordAutoThread, resolveDiscordAutoThreadReplyPlan } =
+    await import("./threading.js"));
 });
 
 beforeEach(() => {
@@ -388,5 +392,75 @@ describe("maybeCreateDiscordAutoThread autoThreadName", () => {
     );
     expect(result).toBeUndefined();
     expect(postMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("resolveDiscordAutoThreadReplyPlan forum autoThreadName", () => {
+  it("renames a forum post from its starter message when generated mode is enabled", async () => {
+    patchMock.mockResolvedValueOnce({});
+    generateThreadTitleMock.mockResolvedValueOnce("Daily expense sync");
+
+    const cfg = { agents: { defaults: { model: "anthropic/claude-opus-4-6" } } } as OpenClawConfig;
+    const plan = await resolveDiscordAutoThreadReplyPlan({
+      client: mockClient,
+      message: createMockMessage({ id: "forum-thread-1", channelId: "forum-thread-1" }),
+      messageChannelId: "forum-thread-1",
+      channel: "discord",
+      isGuildMessage: true,
+      channelConfig: { allowed: true, autoThreadName: "generated" },
+      threadChannel: { id: "forum-thread-1", name: "m", parentId: "forum-1" },
+      threadParentId: "forum-1",
+      threadParentName: "finance",
+      threadParentType: ChannelType.GuildForum,
+      channelType: ChannelType.PublicThread,
+      channelName: "m",
+      baseText: "Reflect MoneyForward expenses into daily memory notes",
+      combinedBody: "Reflect MoneyForward expenses into daily memory notes",
+      replyToMode: "off",
+      agentId: "main",
+      cfg,
+      parentSessionKey: "agent:main:discord:channel:forum-thread-1",
+    });
+
+    expect(plan.createdThreadId).toBeUndefined();
+    await flushAsyncWork();
+    expectGeneratedTitleField("agentId", "main");
+    expectGeneratedTitleField(
+      "messageText",
+      "Reflect MoneyForward expenses into daily memory notes",
+    );
+    expectGeneratedTitleField("channelName", "finance");
+    expectRestBodyField(patchMock, "name", "Daily expense sync");
+  });
+
+  it("does not rename later replies in a forum post", async () => {
+    await resolveDiscordAutoThreadReplyPlan({
+      client: mockClient,
+      message: createMockMessage({ id: "reply-1", channelId: "forum-thread-1" }),
+      messageChannelId: "forum-thread-1",
+      channel: "discord",
+      isGuildMessage: true,
+      channelConfig: { allowed: true, autoThreadName: "generated" },
+      threadChannel: {
+        id: "forum-thread-1",
+        name: "Existing title",
+        parentId: "forum-1",
+      },
+      threadParentId: "forum-1",
+      threadParentName: "finance",
+      threadParentType: ChannelType.GuildForum,
+      channelType: ChannelType.PublicThread,
+      channelName: "Existing title",
+      baseText: "A later reply",
+      combinedBody: "A later reply",
+      replyToMode: "off",
+      agentId: "main",
+      cfg: EMPTY_DISCORD_TEST_CONFIG,
+      parentSessionKey: "agent:main:discord:channel:forum-thread-1",
+    });
+
+    await flushAsyncWork();
+    expect(generateThreadTitleMock).not.toHaveBeenCalled();
+    expect(patchMock).not.toHaveBeenCalled();
   });
 });

--- a/extensions/discord/src/monitor/threading.auto-thread.ts
+++ b/extensions/discord/src/monitor/threading.auto-thread.ts
@@ -24,6 +24,19 @@ import type {
   MaybeCreateDiscordAutoThreadParams,
 } from "./threading.types.js";
 
+type DiscordAutoThreadReplyPlanParams = MaybeCreateDiscordAutoThreadParams & {
+  replyToMode: ReplyToMode;
+  agentId: string;
+  channel: string;
+  cfg: OpenClawConfig;
+  parentSessionKey: string;
+  groupScope?: "main" | "per-group";
+  threadParentInheritanceEnabled?: boolean;
+  threadParentId?: string;
+  threadParentName?: string;
+  threadParentType?: ChannelType;
+};
+
 function resolveTrimmedDiscordMessageChannelId(params: {
   message: DiscordMessageEvent["message"];
   messageChannelId?: string;
@@ -77,19 +90,12 @@ export function resolveDiscordAutoThreadContext(params: {
 }
 
 export async function resolveDiscordAutoThreadReplyPlan(
-  params: MaybeCreateDiscordAutoThreadParams & {
-    replyToMode: ReplyToMode;
-    agentId: string;
-    channel: string;
-    cfg: OpenClawConfig;
-    parentSessionKey: string;
-    groupScope?: "main" | "per-group";
-    threadParentInheritanceEnabled?: boolean;
-  },
+  params: DiscordAutoThreadReplyPlanParams,
 ): Promise<DiscordAutoThreadReplyPlan> {
   const messageChannelId = resolveTrimmedDiscordMessageChannelId(params);
   const targetChannelId = params.threadChannel?.id ?? (messageChannelId || "unknown");
   const originalReplyTarget = `channel:${targetChannelId}`;
+  maybeRenameDiscordForumPost(params);
   const createdThreadId = await maybeCreateDiscordAutoThread({
     client: params.client,
     message: params.message,
@@ -124,6 +130,50 @@ export async function resolveDiscordAutoThreadReplyPlan(
       })
     : null;
   return { ...deliveryPlan, createdThreadId, autoThreadContext };
+}
+
+function maybeRenameDiscordForumPost(params: DiscordAutoThreadReplyPlanParams): void {
+  const isForumParent =
+    params.threadParentType === ChannelType.GuildForum ||
+    params.threadParentType === ChannelType.GuildMedia;
+  if (
+    !params.isGuildMessage ||
+    !isForumParent ||
+    params.channelConfig?.autoThreadName !== "generated" ||
+    !params.threadChannel ||
+    params.message.id !== params.threadChannel.id ||
+    !params.threadParentId ||
+    !params.channel ||
+    !params.agentId
+  ) {
+    return;
+  }
+
+  const sourceText = params.baseText || params.combinedBody;
+  if (!sourceText.trim()) {
+    return;
+  }
+  const threadId = params.threadChannel.id;
+  const currentName = normalizeOptionalString(params.threadChannel.name) ?? "";
+  const modelRef = resolveDiscordThreadTitleModelRef({
+    cfg: params.cfg,
+    channel: params.channel,
+    agentId: params.agentId,
+    threadId,
+    messageChannelId: params.threadParentId,
+    channelName: params.threadParentName,
+  });
+  void maybeRenameDiscordThread({
+    client: params.client,
+    threadId,
+    currentName,
+    fallbackId: params.message.id,
+    sourceText,
+    modelRef,
+    channelName: params.threadParentName,
+    cfg: params.cfg,
+    agentId: params.agentId,
+  });
 }
 
 export async function maybeCreateDiscordAutoThread(
@@ -206,7 +256,7 @@ export async function maybeCreateDiscordAutoThread(
         messageChannelId,
         channelName: params.channelName,
       });
-      void maybeRenameDiscordAutoThread({
+      void maybeRenameDiscordThread({
         client: params.client,
         threadId: createdId,
         currentName: threadName,
@@ -277,7 +327,7 @@ function resolveDiscordThreadTitleModelRef(params: {
   return channelOverride?.model;
 }
 
-async function maybeRenameDiscordAutoThread(params: {
+async function maybeRenameDiscordThread(params: {
   client: Client;
   threadId: string;
   currentName: string;
@@ -310,6 +360,8 @@ async function maybeRenameDiscordAutoThread(params: {
       body: { name: nextName },
     });
   } catch (err) {
-    logVerbose(`discord: autoThread rename failed for ${params.threadId}: ${String(err)}`);
+    logVerbose(
+      `discord: generated thread title rename failed for ${params.threadId}: ${String(err)}`,
+    );
   }
 }


### PR DESCRIPTION
## What Problem This Solves

Discord Forum and Media posts could not use the existing model-generated thread title behavior. Operators had to keep Discord's initial post title or maintain a separate custom hook, even when the parent channel was configured with `autoThreadName: "generated"`.

## Why This Change Was Made

Reuse the existing thread title generation, model routing, sanitization, and failure handling for Forum and Media starter messages. The rename runs asynchronously only for the starter message, while normal text-channel auto-thread behavior remains unchanged.

## User Impact

Operators can configure `autoThreadName: "generated"` on a Discord Forum or Media parent channel. OpenClaw will rename each new post once from its starter message and keep the current title if generation or the Discord rename fails.

## Evidence

- `node scripts/run-vitest.mjs run --config test/vitest/vitest.extension-discord.config.ts extensions/discord/src/monitor/threading.auto-thread.test.ts` — 22 tests passed
- `node scripts/check-changed.mjs` — passed
- `pnpm test:extension discord` — passed
- `git diff HEAD^ --check` — passed
