### PR TITLE
refactor(infra): remove retired restart test overrides

### DIFF
--- a/src/infra/restart-stale-pids.ts
+++ b/src/infra/restart-stale-pids.ts
@@ -55,9 +55,6 @@ const POLL_SPAWN_TIMEOUT_MS = 400;
 const MAX_ANCESTOR_WALK_DEPTH = 32;
 
 const restartLog = createSubsystemLogger("restart");
-const sleepSyncOverride: ((ms: number) => void) | null = null;
-const dateNowOverride: (() => number) | null = null;
-const parentPidOverride: (() => number) | null = null;
 
 /** Terminate externally discovered stale gateway processes and allow cleanup to settle. */
 export async function terminateStaleGatewayPids(pids: number[]): Promise<number[]> {
@@ -73,17 +70,9 @@ export async function terminateStaleGatewayPids(pids: number[]): Promise<number[
   return targets;
 }
 
-function getTimeMs(): number {
-  return dateNowOverride ? dateNowOverride() : Date.now();
-}
-
 function sleepSync(ms: number): void {
   const timeoutMs = Math.max(0, Math.floor(ms));
   if (timeoutMs <= 0) {
-    return;
-  }
-  if (sleepSyncOverride) {
-    sleepSyncOverride(timeoutMs);
     return;
   }
   try {
@@ -95,10 +84,6 @@ function sleepSync(ms: number): void {
       // Best-effort fallback when Atomics.wait is unavailable.
     }
   }
-}
-
-function getParentPid(): number {
-  return parentPidOverride ? parentPidOverride() : process.ppid;
 }
 
 /**
@@ -178,7 +163,7 @@ export function getSelfAndAncestorPidsSync(
   spawnTimeoutMs = PROCESS_INSPECTION_TIMEOUT_MS,
 ): Set<number> {
   const pids = new Set<number>([process.pid]);
-  const immediateParent = getParentPid();
+  const immediateParent = process.ppid;
   if (!Number.isFinite(immediateParent) || immediateParent <= 0) {
     return pids;
   }
@@ -640,8 +625,8 @@ function isProcessAlive(pid: number): boolean {
  *   - Wall-clock deadline exceeded                               → log warning, proceed anyway
  */
 function waitForPortFreeSync(port: number): void {
-  const deadline = getTimeMs() + PORT_FREE_TIMEOUT_MS;
-  while (getTimeMs() < deadline) {
+  const deadline = Date.now() + PORT_FREE_TIMEOUT_MS;
+  while (Date.now() < deadline) {
     const result = pollPortOnce(port);
     if (result.free === true) {
       return;


### PR DESCRIPTION
## What Problem This Solves

The stale Gateway process helper retained three test overrides after #106019 removed their setters and migrated tests to the real built-in boundaries. Those module-local constants are permanently null, leaving unreachable branches and two wrappers with no remaining purpose.

## Why This Change Was Made

Delete the abandoned overrides and use `Date.now()` and `process.ppid` directly at the same decision points. Keep the synchronous sleep helper, its fallback, all timing constants, PID filtering, protected-process checks, signal ordering, port polling, and the separate asynchronous termination path unchanged.

Production: +3/-18, net -15. Tests and test support: unchanged. The existing cases already mock `Atomics.wait`, `Date.now`, and `process.ppid`; no replacement test seam or compatibility path is introduced.

## User Impact

Operator-visible restart behavior is unchanged. The implementation now matches the earlier test-seam retirement and is easier to follow.

## Evidence

- macOS before and after: 71 existing cases pass, with the same two Linux-only cases skipped.
- Linux candidate: all 73 cases pass with zero skips; the complete case inventory matches the original suite.
- Retained coverage includes ancestor exclusion, protected-PID refresh, signal failures and escalation, busy/free/inconclusive port polling, Windows helper behavior, and real diagnostic-child environment projection using synthetic inputs.
- Independent Codex review is clean through P2. The signed current-main composition preserves the exact reviewed source and all test files.
- No actual operator Gateway restart or native Windows service operation was performed. This deletes unreachable internal branches; it does not claim new process-control behavior or repair the documented restricted-ancestor lookup limitation.

Focused command:

```sh
node scripts/run-vitest.mjs src/infra/restart-stale-pids.test.ts src/infra/diagnostic-process-siblings.env.test.ts src/infra/gateway-processes.test.ts
```

The combined Linux proof and normal changed gate passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/34173609667), including production and core-test types, dead-code scans, scoped lint, and schema/storage guards. The one-shot lease stopped successfully; its exact isolated checkout and recorded local processes are gone.
