### PR TITLE
fix(ui): explain setup codes pasted as Gateway secrets

### DIFF
--- a/docs/web/control-ui.md
+++ b/docs/web/control-ui.md
@@ -44,6 +44,8 @@ Auth is supplied during the WebSocket handshake via:
 
 Gateway auth runs before device pairing. A direct loopback connection does not bypass token or password auth. The login screen and **Settings → Gateway** use one **Gateway secret** field: paste the token or type the password. After a successful connection, the UI keeps the secret in session storage for the current browser tab and Gateway origin only when the Gateway reports token auth. Passwords stay in memory and are never persisted. After pairing, the browser can use its stored per-device token on later connections.
 
+If you paste a setup code from **Devices → Pair device → Copy setup code** into **Gateway secret**, the UI shows an inline hint before you connect. Paste that code into **Settings → Gateway** in the OpenClaw mobile app. For the Control UI, run `openclaw gateway auth-token --show` in an interactive terminal on the Gateway host and paste the shared token instead. If a connection with a setup code is rejected for a token or password mismatch, the login screen repeats this guidance.
+
 Onboarding usually configures a gateway token for shared-secret auth. If the Gateway starts in token mode without a configured token, it generates an ephemeral runtime token for that process instead. The runtime token is not written to config, so it cannot be recovered and a loopback browser without that token is rejected. Run `openclaw doctor --generate-gateway-token`, restart the Gateway, then run `openclaw gateway auth-token --show` in an interactive terminal and paste the output into Control UI settings. Password auth works instead when `gateway.auth.mode` is `"password"`.
 
 ## What each page covers

--- a/src/pairing/setup-code.control-ui.test.ts
+++ b/src/pairing/setup-code.control-ui.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { encodePairingSetupCode } from "../../../src/pairing/setup-code.js";
-import { classifyGatewaySecret } from "./gateway-secret-shape.ts";
+import { classifyGatewaySecret } from "../../ui/src/lib/gateway-secret-shape.ts";
+import { encodePairingSetupCode } from "./setup-code.js";
 
 const setupCode = encodePairingSetupCode({
   url: "wss://gateway.example/日本語",

--- a/ui/src/components/login-gate-feedback.ts
+++ b/ui/src/components/login-gate-feedback.ts
@@ -9,6 +9,7 @@ import {
   shouldShowInsecureContextHint,
 } from "../lib/connection-hints.ts";
 import { formatGatewayHost } from "../lib/gateway-host.ts";
+import { classifyGatewaySecret } from "../lib/gateway-secret-shape.ts";
 
 function isPasswordModeErrorCode(code: string | null): boolean {
   return (
@@ -74,6 +75,7 @@ export type LoginFailureFeedback = {
 
 export type LoginFailureFeedbackParams = Parameters<typeof resolveAuthHintKind>[0] & {
   gatewayUrl?: string;
+  secret?: string;
   reconnectPending?: boolean;
 };
 
@@ -318,7 +320,12 @@ export function resolveLoginFailureFeedback(
         : lastErrorCode === ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH
           ? "login.failure.authRequired.title"
           : "login.failure.authFailed.title",
-      summaryKey: "login.failure.authFailed.summary",
+      summaryKey:
+        (lastErrorCode === ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH ||
+          lastErrorCode === ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH) &&
+        classifyGatewaySecret(params.secret ?? "") === "setup-code"
+          ? "login.setupCodeHint"
+          : "login.failure.authFailed.summary",
       stepKeys: expectsPassword
         ? ["login.failure.authRequired.stepPassword", "login.failure.authRequired.stepConnect"]
         : [

--- a/ui/src/components/login-gate.test.ts
+++ b/ui/src/components/login-gate.test.ts
@@ -41,6 +41,57 @@ afterEach(() => {
 });
 
 describe("login gate failure recovery", () => {
+  const setupCode = btoa(
+    JSON.stringify({
+      url: "wss://gateway.example",
+      bootstrapToken: "synthetic-bootstrap-token",
+    }),
+  ).replace(/=+$/g, "");
+
+  it("explains a pasted setup code before connecting and clears the hint when replaced", async () => {
+    const element = await mountFailure("", null, setupCode);
+    const hint = element.querySelector("#login-gate-secret-hint");
+    expect(hint?.textContent).toContain("device setup code for the OpenClaw mobile app");
+    expect(hint?.textContent).toContain("openclaw gateway auth-token --show");
+    expect(element.querySelector("#login-gate-credential")?.getAttribute("aria-describedby")).toBe(
+      hint?.id,
+    );
+    expect(element.props.onConnect).not.toHaveBeenCalled();
+    element.props = { ...element.props, secret: "ordinary-secret" };
+    await element.updateComplete;
+    expect(element.querySelector("#login-gate-secret-hint")).toBeNull();
+    expect(element.querySelector("#login-gate-credential")?.hasAttribute("aria-describedby")).toBe(
+      false,
+    );
+  });
+
+  it.each([
+    ConnectErrorDetailCodes.AUTH_TOKEN_MISMATCH,
+    ConnectErrorDetailCodes.AUTH_PASSWORD_MISMATCH,
+  ])("explains setup codes instead of generic mismatch copy for %s", async (code) => {
+    const element = await mountFailure("unauthorized", code, setupCode);
+    expect(element.querySelector(".login-gate__failure-summary")?.textContent?.trim()).toBe(
+      element.querySelector("#login-gate-secret-hint")?.textContent?.trim(),
+    );
+    expect(element.querySelector(".login-gate__failure-summary")?.textContent).toContain(
+      "Paste it in the app's Gateway settings instead",
+    );
+  });
+
+  it("preserves unrelated failure summaries with a setup code entered", async () => {
+    const element = await mountFailure(
+      "rate limit",
+      ConnectErrorDetailCodes.AUTH_RATE_LIMITED,
+      setupCode,
+    );
+    expect(element.querySelector(".login-gate__failure")?.getAttribute("data-kind")).toBe(
+      "auth-rate-limited",
+    );
+    expect(element.querySelector(".login-gate__failure-summary")?.textContent).not.toContain(
+      "device setup code",
+    );
+  });
+
   it("explains how to reconnect with a verified user identity", async () => {
     const element = await mountFailure(
       "operator role policies require a verified user identity for this authentication method",

--- a/ui/src/components/login-gate.ts
+++ b/ui/src/components/login-gate.ts
@@ -9,6 +9,7 @@ import "../lib/toast.ts";
 import { registerLoginEnglish } from "../i18n/locales/en-login.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link.ts";
 import { formatGatewayHost } from "../lib/gateway-host.ts";
+import { classifyGatewaySecret } from "../lib/gateway-secret-shape.ts";
 import { OpenClawLightDomContentsElement } from "../lit/openclaw-element.ts";
 import { renderConnectCommand } from "./connect-command.ts";
 import { icons } from "./icons.ts";
@@ -144,6 +145,7 @@ function renderForm(params: {
   withSubmit: boolean;
 }) {
   const { props, feedback } = params;
+  const isSetupCode = classifyGatewaySecret(props.secret) === "setup-code";
   const invalidField = feedback?.placement === "form" ? feedback.field : undefined;
   const submitOnEnter = (e: KeyboardEvent) => {
     if (e.key === "Enter") {
@@ -182,6 +184,7 @@ function renderForm(params: {
             spellcheck="false"
             enterkeyhint="go"
             aria-invalid=${invalidField === "credential" ? "true" : nothing}
+            aria-describedby=${isSetupCode ? "login-gate-secret-hint" : nothing}
             .value=${props.secret}
             @input=${(e: Event) => {
               props.onSecretChange((e.target as HTMLInputElement).value);
@@ -195,6 +198,7 @@ function renderForm(params: {
             props.onToggleGatewaySecret,
           )}
         </span>
+        ${isSetupCode ? html`<p id="login-gate-secret-hint" class="muted" role="status">${t("login.setupCodeHint")}</p>` : nothing}
       </div>
       ${
         params.withSubmit

--- a/ui/src/i18n/locales/en-login.ts
+++ b/ui/src/i18n/locales/en-login.ts
@@ -8,6 +8,8 @@ const enLogin = {
     lede: "Enter the Gateway URL and secret, or open the one-time link that openclaw dashboard prints on the Gateway host.",
     gatewayUrl: "Gateway URL",
     secret: "Gateway secret",
+    setupCodeHint:
+      "This is a device setup code for the OpenClaw mobile app, not the Gateway secret. Paste it in the app's Gateway settings instead; the Gateway secret comes from openclaw gateway auth-token --show on the Gateway host.",
     secretPlaceholder: "Paste the token or type the password",
     runOnHost: "Run on the Gateway host",
     connection: {

--- a/ui/src/i18n/locales/en-settings.ts
+++ b/ui/src/i18n/locales/en-settings.ts
@@ -23,6 +23,8 @@ const enSettings = {
       gatewayUrlHint: "Use wss:// when the Gateway sits behind HTTPS or Tailscale Serve.",
       secret: "Gateway secret",
       secretPlaceholder: "Paste the token or type the password",
+      setupCodeHint:
+        "This is a device setup code for the OpenClaw mobile app, not the Gateway secret. Paste it in the app's Gateway settings instead; the Gateway secret comes from openclaw gateway auth-token --show on the Gateway host.",
       secretHint: "Tokens are saved for this tab after connecting. Passwords are never stored.",
       tokenHint: "This Gateway expects its token. Saved for this tab after connecting.",
       passwordHint: "This Gateway expects its password. Passwords are never stored.",

--- a/ui/src/lib/gateway-secret-shape.test.ts
+++ b/ui/src/lib/gateway-secret-shape.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { encodePairingSetupCode } from "../../../src/pairing/setup-code.js";
+import { classifyGatewaySecret } from "./gateway-secret-shape.ts";
+
+const setupCode = encodePairingSetupCode({
+  url: "wss://gateway.example/日本語",
+  bootstrapToken: "synthetic-bootstrap-token",
+  expiresAtMs: 1,
+});
+
+describe("classifyGatewaySecret", () => {
+  it.each([setupCode, `oc-pair://${setupCode}`, `  OC-PAIR://${setupCode}\n`])(
+    "recognizes encoded setup payloads even after expiry",
+    (value) => expect(classifyGatewaySecret(value)).toBe("setup-code"),
+  );
+
+  it.each([
+    "",
+    "   ",
+    "ordinary-gateway-token",
+    "a".repeat(43), // Device tokens cannot be distinguished from configured shared tokens.
+    Buffer.from("random bytes, not JSON").toString("base64url"),
+    "oc-pair://not-a-setup-code",
+    ...[
+      null,
+      [],
+      {},
+      { url: "wss://gateway.example" },
+      { bootstrapToken: "fake" },
+      { url: "wss://gateway.example", bootstrapToken: 1 },
+      { url: "", bootstrapToken: "fake" },
+      { url: "wss://gateway.example", bootstrapToken: " " },
+    ].map((value) => Buffer.from(JSON.stringify(value)).toString("base64url")),
+  ])("leaves unrelated or malformed values unknown", (value) => {
+    expect(classifyGatewaySecret(value)).toBe("unknown");
+  });
+});

--- a/ui/src/lib/gateway-secret-shape.ts
+++ b/ui/src/lib/gateway-secret-shape.ts
@@ -1,0 +1,26 @@
+/** Advisory only: device tokens have no prefix distinct from an arbitrary Gateway secret. */
+export function classifyGatewaySecret(value: string): "setup-code" | "unknown" {
+  const trimmed = value.trim();
+  const code = trimmed.toLowerCase().startsWith("oc-pair://") ? trimmed.slice(10) : trimmed;
+  if (!/^[A-Za-z0-9_-]+$/u.test(code)) {
+    return "unknown";
+  }
+  try {
+    const bytes = Uint8Array.from(atob(code.replace(/-/g, "+").replace(/_/g, "/")), (char) =>
+      char.charCodeAt(0),
+    );
+    const payload: unknown = JSON.parse(new TextDecoder().decode(bytes));
+    return payload !== null &&
+      typeof payload === "object" &&
+      "url" in payload &&
+      typeof payload.url === "string" &&
+      payload.url.trim() !== "" &&
+      "bootstrapToken" in payload &&
+      typeof payload.bootstrapToken === "string" &&
+      payload.bootstrapToken.trim() !== ""
+      ? "setup-code"
+      : "unknown";
+  } catch {
+    return "unknown";
+  }
+}

--- a/ui/src/pages/connection/view.render.test.ts
+++ b/ui/src/pages/connection/view.render.test.ts
@@ -64,6 +64,23 @@ function expectStatByLabel(container: Element, text: string): HTMLElement {
 }
 
 describe("connection view rendering", () => {
+  it("shows setup-code guidance beneath the secret before connecting", () => {
+    const container = document.createElement("div");
+    const secret = btoa(
+      JSON.stringify({ url: "wss://gateway.example", bootstrapToken: "synthetic-bootstrap-token" }),
+    ).replace(/=+$/g, "");
+    render(renderConnection(createConnectionProps({ secret })), container);
+    const control = container
+      .querySelector('input[aria-label="Gateway secret"]')
+      ?.closest(".settings-row__control");
+    expect(control?.querySelector('[role="status"]')?.textContent).toContain(
+      "device setup code for the OpenClaw mobile app",
+    );
+    expect(control?.textContent).toContain("openclaw gateway auth-token --show");
+    render(renderConnection(createConnectionProps()), container);
+    expect(control?.querySelector('[role="status"]')).toBeNull();
+  });
+
   it("names the live Gateway in the summary, not the edited draft", () => {
     const props = createConnectionProps({
       connected: true,

--- a/ui/src/pages/connection/view.ts
+++ b/ui/src/pages/connection/view.ts
@@ -13,6 +13,7 @@ import {
 import { t } from "../../i18n/index.ts";
 import { registerSettingsEnglish } from "../../i18n/locales/en-settings.ts";
 import { formatGatewayHost } from "../../lib/gateway-host.ts";
+import { classifyGatewaySecret } from "../../lib/gateway-secret-shape.ts";
 import { renderSystemSection } from "./system-section.ts";
 
 registerSettingsEnglish();
@@ -80,17 +81,26 @@ function renderSecretRow(props: ConnectionProps, authMode: GatewayAuthMode | und
   return renderSettingsRow({
     title: t("connection.access.secret"),
     description: t(hintKey),
-    control: renderSettingsSecretInput({
-      ariaLabel: t("connection.access.secret"),
-      value: props.secret,
-      placeholder: t("connection.access.secretPlaceholder"),
-      visible: props.showGatewaySecret,
-      showLabel: t("connection.access.showSecret"),
-      hideLabel: t("connection.access.hideSecret"),
-      toggleLabel: t("connection.access.toggleSecretVisibility"),
-      onInput: props.onSecretChange,
-      onToggle: props.onToggleGatewaySecretVisibility,
-    }),
+    control: html`<div class="settings-input-with-hint">
+      ${renderSettingsSecretInput({
+        ariaLabel: t("connection.access.secret"),
+        value: props.secret,
+        placeholder: t("connection.access.secretPlaceholder"),
+        visible: props.showGatewaySecret,
+        showLabel: t("connection.access.showSecret"),
+        hideLabel: t("connection.access.hideSecret"),
+        toggleLabel: t("connection.access.toggleSecretVisibility"),
+        onInput: props.onSecretChange,
+        onToggle: props.onToggleGatewaySecretVisibility,
+      })}
+      ${
+        classifyGatewaySecret(props.secret) === "setup-code"
+          ? html`<p class="settings-row__desc" role="status">
+              ${t("connection.access.setupCodeHint")}
+            </p>`
+          : nothing
+      }
+    </div>`,
     stackedOnNarrow: true,
   });
 }

--- a/ui/src/styles/settings.css
+++ b/ui/src/styles/settings.css
@@ -540,11 +540,13 @@ wa-switch.settings-toggle {
    shrinks via flex because .settings-input/.settings-secret set min-width: 0. */
 .settings-row:not(.settings-row--stacked) .settings-row__control > .settings-input,
 .settings-row:not(.settings-row--stacked) .settings-row__control > .settings-secret,
-.settings-row:not(.settings-row--stacked) .settings-row__control > .settings-phone-presentation {
+.settings-row:not(.settings-row--stacked) .settings-row__control > .settings-phone-presentation,
+.settings-row:not(.settings-row--stacked) .settings-row__control > .settings-input-with-hint {
   width: 340px;
 }
 
-.settings-phone-presentation {
+.settings-phone-presentation,
+.settings-input-with-hint {
   display: inline-flex;
   flex-direction: column;
   gap: 4px;
@@ -552,7 +554,8 @@ wa-switch.settings-toggle {
 }
 
 .settings-phone-presentation > .settings-input,
-.settings-phone-presentation > .settings-secret {
+.settings-phone-presentation > .settings-secret,
+.settings-input-with-hint > .settings-secret {
   width: 100%;
 }
 
@@ -959,6 +962,7 @@ textarea.settings-input {
         .settings-select,
         .settings-secret,
         .settings-phone-presentation,
+        .settings-input-with-hint,
         .settings-segmented
       ) {
       width: 100%;


### PR DESCRIPTION
Related: #141520
Related: #98486 (device-token recognition only; the macOS injection bug is separate and remains open)

## What Problem This Solves

Fixes an issue where users pasting **Devices → Pair device → Copy setup code** into the Control UI's **Gateway secret** field receive a generic token mismatch without knowing that the code belongs in the mobile app.

## Why This Change Was Made

A dependency-free browser helper recognizes base64url JSON carrying `url` and `bootstrapToken`, including the optional `oc-pair://` prefix and expired setup codes. The login gate and Settings → Gateway show immediate inline guidance. A token/password mismatch repeats that guidance in the login failure summary. Copy remains in the lazy English catalogs, and the Control UI guide documents recovery.

Device credentials are deliberately not guessed: `createDeviceAuthToken` uses 32 random bytes encoded as 43 unpadded base64url characters, serialized unchanged as `auth.deviceToken`, with no type prefix. Configured shared Gateway tokens can have exactly that shape. The native macOS injection behavior tracked in #98486 is outside this PR.

## User Impact

Users can recognize a misplaced setup code before connecting, paste it into the mobile app's Gateway settings, and obtain the actual shared token with `openclaw gateway auth-token --show` on the Gateway host. Ordinary secrets and unrelated connection failures retain their behavior. The helper neither logs nor persists pasted values; server authentication is unchanged.

## Review decisions

The requested setup-code wording is retained verbatim, including for token/password mismatch summaries. ClawSweeper correctly noted that `openclaw gateway auth-token --show` does not reveal a password: for password-mode Gateways, users must follow the existing password-specific recovery steps below the summary. Changing the prescribed wording is deferred; authentication behavior is unchanged.

The lead inspected the full synthetic before/after captures and the live rejection capture before publishing. The review service's inability to fetch attachment URLs does not leave the captures uninspected.

## Evidence

- Exact-head CI: [run 34175742740](https://github.com/openclaw/openclaw/actions/runs/34175742740) passed at `c543cc0f26a9fc3a678711d2a043435fed448fa1`; no failed or pending checks remained before preparation.
- Initial CI exposed a test-runner mismatch: importing the server encoder in the UI Vite project loaded a file-backed SQL schema through an HTTP module URL. The encoder-backed classifier tests now run in the core Node test suite; all assertions remain intact. Core tests and the CI UI configuration pass locally.
- Focused classifier, login-gate, and connection-view tests: **58 passed**. The four new UI hint/mismatch cases fail against the original components and pass with the fix.
- `pnpm ui:i18n:baseline` and `pnpm ui:i18n:verify`: passed; no generated translation files changed.
- `pnpm build`: passed (cold build, 18m 37s).
- `pnpm ui:build` and the Control UI performance report: passed. Startup JavaScript is **343,774 B gzip**, below the **350,953 B** enforcement limit, across 8 requests.
- `node scripts/check-changed.mjs`: passed (exit 0), including repository guards, formatting, core-test/UI typechecks, i18n, dead-export scans, and lint. The separate changed-file check for the added Settings CSS also passed. No nested-worktree declaration error occurred.
- Codex autoreview: **scoped-clean**, no actionable P0–P2 findings; patch is correct.
- Playwright Chromium against an isolated token-mode Gateway: the synthetic setup-code hint appears immediately, rejected Connect repeats that explanation, and the correct token reaches the app shell. The task Gateway was stopped and scratch state deleted; no operator state was used.
- Settings browser proof: desktop secret input remains 340px wide; input and hint fit a 390px mobile viewport.
- No existing copy or selector was renamed. Related copy/selectors were searched across `ui/src`, `extensions`, `apps`, `src`, and `docs`.

Before (synthetic setup code, masked):

![Before: setup code pasted with no guidance](https://github.com/user-attachments/assets/2f554b6f-040e-4542-80cb-54991799e9d6)

After (the same synthetic setup code, masked):

![After: setup-code guidance beneath the Gateway secret](https://github.com/user-attachments/assets/5036c62e-0511-42b2-8c1a-d5251efd6b5c)
