### PR TITLE
fix(agents): prevent lost replies after compaction and yield

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-prompt-submit.ts
@@ -254,7 +254,7 @@ function hasNonEmptyContent(content: unknown): boolean {
 }
 
 /** Classifies prompt failures and performs yield or mid-turn recovery. */
-type PromptErrorAttempt = Pick<EmbeddedRunAttemptParams, "runId" | "sessionId">;
+type PromptErrorAttempt = Pick<EmbeddedRunAttemptParams, "runId" | "sessionId" | "abortSignal">;
 type WithOwnedTranscriptWrite = <T>(operation: () => Promise<T> | T) => Promise<T>;
 
 type EmbeddedAttemptPromptErrorOutcome = {
@@ -287,9 +287,17 @@ export async function handleEmbeddedAttemptPromptError(input: {
       sessionId: input.attempt.sessionId,
     });
     await input.withOwnedTranscriptWrite(async () => {
-      stripSessionsYieldArtifacts(input.activeSession);
+      const transcriptRewritten = stripSessionsYieldArtifacts(input.activeSession);
       if (input.yieldMessage) {
         await persistSessionsYieldContextMessage(input.activeSession, input.yieldMessage);
+      }
+      const target = transcriptRewritten && input.activeSession.sessionManager.getSessionTarget();
+      if (target) {
+        // Yield cleanup owns this rewrite; settle its projection before handing off the lane.
+        // The caller signal stays live during a deliberate sessions_yield provider abort.
+        const { waitForSessionTranscriptProjection } =
+          await import("../../../config/sessions/session-transcript-reconcile.js");
+        await waitForSessionTranscriptProjection(target, input.attempt.abortSignal);
       }
     });
     return {};

--- a/src/agents/embedded-agent-runner/run/attempt-sessions-yield.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-sessions-yield.ts
@@ -120,7 +120,7 @@ export function stripSessionsYieldArtifacts(activeSession: {
   messages: AgentMessage[];
   agent: { state: { messages: AgentMessage[] } };
   sessionManager: Pick<SessionManager, "removeTrailingEntries">;
-}) {
+}): boolean {
   const strippedMessages = activeSession.messages.slice();
 
   // The tool-calling assistant turn and synthetic abort artifacts form one
@@ -138,7 +138,7 @@ export function stripSessionsYieldArtifacts(activeSession: {
 
   const removedMessages = activeSession.messages.slice(strippedMessages.length);
   if (removedMessages.length === 0) {
-    return;
+    return false;
   }
 
   // The interrupt marker can settle independently in live and persisted state.
@@ -146,7 +146,7 @@ export function stripSessionsYieldArtifacts(activeSession: {
   let remainingAssistantCount = removedMessages.filter(
     (message) => message.role === "assistant",
   ).length;
-  activeSession.sessionManager.removeTrailingEntries(
+  const removedEntries = activeSession.sessionManager.removeTrailingEntries(
     (entry) => {
       if (
         entry.type === "custom_message" &&
@@ -173,4 +173,5 @@ export function stripSessionsYieldArtifacts(activeSession: {
     },
   );
   activeSession.agent.state.messages = strippedMessages;
+  return removedEntries > 0;
 }

--- a/src/agents/embedded-agent-runner/run/attempt-yield-handoff.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-yield-handoff.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { upsertSessionEntryCore } from "../../../config/sessions/session-accessor.js";
+import { withOpenClawTestState } from "../../../test-utils/openclaw-test-state.js";
+import type { AgentMessage } from "../../runtime/index.js";
+import {
+  createAssistant,
+  createTestSession,
+  registerAgentSessionLoopTestLifecycle,
+  testModel,
+} from "../../sessions/agent-session-loop-correctness.test-support.js";
+import { SessionManager } from "../../sessions/session-manager.js";
+import { handleEmbeddedAttemptPromptError } from "./attempt-prompt-submit.js";
+import { SESSIONS_YIELD_ABORT_REASON } from "./attempt-sessions-yield.js";
+
+registerAgentSessionLoopTestLifecycle();
+
+describe("sessions_yield transcript handoff", () => {
+  it.each([null, "Continue after the child completes"])(
+    "leaves yielded history ready for the next queued turn (context=%s)",
+    async (yieldMessage) => {
+      await withOpenClawTestState({ label: "yield-projection-handoff" }, async (state) => {
+        const target = {
+          agentId: "main",
+          sessionId: "yielded-session",
+          sessionKey: "agent:main:yielded-session",
+          storePath: state.statePath("sessions.json"),
+        };
+        await upsertSessionEntryCore(target, { sessionId: target.sessionId, updatedAt: 1 });
+        const manager = SessionManager.open(target, state.workspaceDir);
+        const { session } = await createTestSession({ sessionManager: manager });
+        // Large histories rebuild asynchronously after yield cleanup replaces them.
+        for (let index = 0; index < 4_001; index += 1) {
+          manager.appendCustomEntry("fixture-history", { index });
+        }
+        const user: AgentMessage = { role: "user", content: "Continue the task", timestamp: 1 };
+        const toolResult: AgentMessage = {
+          role: "toolResult",
+          toolCallId: "yield-call",
+          toolName: "sessions_yield",
+          content: [{ type: "text", text: "yielded" }],
+          isError: false,
+          timestamp: 2,
+        };
+        const aborted = createAssistant(testModel, [], "aborted");
+        manager.appendMessage(user);
+        manager.appendMessage(toolResult);
+        manager.appendMessage(aborted);
+        // A live yield still has the synthetic abort that normal history loading omits.
+        session.agent.state.messages = [user, toolResult, aborted];
+        try {
+          await handleEmbeddedAttemptPromptError({
+            activeSession: session,
+            attempt: { runId: "yielding-run", sessionId: target.sessionId },
+            error: new Error("aborted", { cause: SESSIONS_YIELD_ABORT_REASON }),
+            handleMidTurnPrecheckRequest: vi.fn(),
+            markYieldAborted: vi.fn(),
+            releaseLeasedSteering: vi.fn(),
+            withOwnedTranscriptWrite: async (operation) => await operation(),
+            yieldAbortSettled: null,
+            yieldDetected: true,
+            yieldMessage,
+          });
+          // Reopen exactly as the next queued attempt does, with no unrelated await.
+          const reopened = SessionManager.open(target, state.workspaceDir, {
+            maxBytes: 4096,
+            maxEvents: 20,
+          });
+          const messages = reopened.buildSessionContext().messages;
+          expect(messages.map((message) => message.role)).toEqual(
+            yieldMessage ? ["user", "toolResult", "custom"] : ["user", "toolResult"],
+          );
+          expect(messages[0]).toMatchObject({ content: "Continue the task" });
+        } finally {
+          session.dispose();
+        }
+      });
+    },
+  );
+});

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -3947,6 +3947,68 @@ describe("runMemoryFlushIfNeeded", () => {
     },
   );
 
+  it.each(["tokens", "transcript_bytes"] as const)(
+    "records %s compaction before a queued continuation claims the session",
+    async (trigger) => {
+      const sessionKey = "agent:main:main";
+      const storePath = path.join(rootDir, "preflight-handoff.json");
+      const scope = { agentId: "main", sessionId: "session", sessionKey, storePath };
+      await upsertSessionEntryCore(scope, {
+        sessionId: "session",
+        updatedAt: 1,
+        totalTokens: 95_000,
+        totalTokensFresh: true,
+        totalTokensVersion: 1,
+        compactionCount: 0,
+        activeWriterRunId: "preflight",
+      });
+      const manager = SessionManager.open(scope, rootDir);
+      manager.appendMessage({
+        role: "user",
+        content: "Earlier discussion. ".repeat(100),
+        timestamp: 1,
+      });
+      const entry = loadSessionEntry(scope)!;
+      incrementCompactionCountMock.mockImplementation(incrementCompactionCount);
+      compactEmbeddedAgentSessionMock.mockImplementationOnce(async (_params, host) => {
+        await host?.onHostCompactionCommitted?.({
+          entry,
+          tokensAfter: 42,
+          compactionKind: "context-engine",
+        });
+        // The backend releases its lane before its caller's await resumes.
+        await upsertSessionEntryCore(scope, { activeWriterRunId: "queued-continuation" });
+        return {
+          ok: true,
+          compacted: true,
+          compactionKind: "context-engine",
+          result: { tokensAfter: 42 },
+        };
+      });
+
+      await expect(
+        runDefaultPreflight(entry, {
+          sessionKey,
+          storePath,
+          cfg: {
+            agents: {
+              defaults: {
+                compaction: {
+                  maxActiveTranscriptBytes: trigger === "transcript_bytes" ? "10b" : "100mb",
+                },
+              },
+            },
+          },
+        }),
+      ).resolves.toMatchObject({ compactionCount: 1 });
+      expect(loadSessionEntry(scope)).toMatchObject({
+        activeWriterRunId: "queued-continuation",
+        compactionCount: 1,
+      });
+      expect(incrementCompactionCountMock).toHaveBeenCalledOnce();
+    },
+  );
+
   it("persists Codex byte accounting before the accepted compactor returns", async () => {
     const storePath = path.join(rootDir, "sqlite-codex-held-accounting.json");
     const sessionKey = "agent:main:main";

--- a/src/auto-reply/reply/agent-runner-memory.ts
+++ b/src/auto-reply/reply/agent-runner-memory.ts
@@ -1123,20 +1123,21 @@ export async function runSessionCompactionIfNeeded(params: {
                     },
                   }
                 : {}),
-              onHostCompactionCommitted: async (commit) => {
-                await recordCompactionAccounting(
-                  commit.entry,
-                  commit.tokensAfter,
-                  commit.compactionKind,
-                  hostAccountingCommitted ? 0 : 1,
-                );
-                hostAccountingCommitted = true;
-              },
               onHostCompactionTranscriptSettled: async (commit) => {
                 await recordCompactionAccounting(commit.entry, undefined, undefined, 0);
               },
             }
           : {}),
+        // Record every host compaction while its session lane still excludes the next writer.
+        onHostCompactionCommitted: async (commit) => {
+          await recordCompactionAccounting(
+            commit.entry,
+            commit.tokensAfter,
+            commit.compactionKind,
+            hostAccountingCommitted ? 0 : 1,
+          );
+          hostAccountingCommitted = true;
+        },
         onCommitted: (accepted) => {
           expectedSession = accepted.entry;
           entry = accepted.entry;


### PR DESCRIPTION
## Summary

### High Level TLDR

Keep session handoffs from dropping queued chat replies after compaction or `sessions_yield`. Complete compaction bookkeeping while the compactor owns the session lane, and settle a yield cleanup's deferred history projection before handing that lane to the next turn.

Related: #138984 (already merged; both regressions reproduce on main with that change present).

## What Problem This Solves

Fixes an issue where users following up in an active, long-running conversation could receive no model reply when compaction or a background child continuation handed the session to another turn. An observed foreground reply failed after compaction; its retry and the next message then failed during a history rebuild.

## Why This Change Was Made

### Root Cause

Two missing handoff steps combine in the observed sequence:

1. `runSessionCompactionIfNeeded` registered its existing in-lane accounting callback only for native-harness byte preflight. Ordinary token/byte compaction instead updated accounting after the compactor released the session lane. A waiting continuation could claim the session first, causing the correct writer guard to reject the late update with `Session changed before compaction maintenance could be recorded`.
2. `sessions_yield` cleanup removes synthetic abort entries by replacing the persisted transcript. Large replacements defer their projection rebuild, but the yield handler returned without settling that owned work. The next queued attempt's bounded history read then failed with `Session transcript projection is rebuilding` before model execution. Small-history tests missed the deferred path.

Reuse the existing host callback for all host compactions. Have yield cleanup report whether it actually rewrote the transcript, and await the existing projection owner only for that durable rewrite, using the caller's cancellation signal. Ownership checks, normal fail-fast readers, and storage semantics remain intact.

## User Impact

Queued replies can proceed after compaction and large-history yield cleanup. Compaction is counted once before the next writer takes over, and yield handoff exposes readable history without replaying completed tools.

## Evidence

### Real behavior proof

Regression fixtures use isolated SQLite stores and current-main source. The compaction cases simulate the actual ordering: backend commit, in-lane host callback, next-writer claim, caller continuation. The yield cases use the real session manager and prompt-error handler, remove a synthetic aborted suffix from a history with more than 4,000 entries, and immediately reopen with the same bounded reader used by the next attempt.

Before the production changes:

- Both token/byte compaction cases fail with `Session changed before compaction maintenance could be recorded`.
- Both yield cases, with and without a handoff message, fail with `Session transcript projection is rebuilding`.

After the production changes, all four cases pass while preserving the next writer and the retained user/tool history.

Attribution check: the same four cases also fail on `ca10e17c129eda1548de070010bc82d731d3dcc4`, the immediate parent of #138984's merge commit. Both token/byte cases produce the maintenance error, and both yield cases produce the projection error. The isolated parent checkout contains only the added regression tests; its production source is unchanged. These defects therefore predate #138984.


## Verification

On Linux with Node 24.19.0 and isolated SQLite state:

```sh
node scripts/run-vitest.mjs \
  src/auto-reply/reply/agent-runner-memory.test.ts \
  src/auto-reply/reply/session-updates.test.ts \
  src/agents/embedded-agent-runner/compact.queued-successor.test.ts \
  src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts \
  src/agents/embedded-agent-runner/run/attempt-prompt-error.test.ts \
  src/agents/embedded-agent-runner/run/attempt.sessions-yield.test.ts \
  src/agents/embedded-agent-runner/run/attempt-prompt-phase.test.ts
```

Result: **213 tests passed**. The two new yield regressions initially lived in `attempt-prompt-submit.test.ts`; they were then moved to `attempt-yield-handoff.test.ts` to satisfy the existing file-length limit. The final two-file rerun passed **27 tests**:

```sh
node scripts/run-vitest.mjs \
  src/agents/embedded-agent-runner/run/attempt-yield-handoff.test.ts \
  src/agents/embedded-agent-runner/run/attempt-prompt-submit.test.ts
node scripts/check-changed.mjs
```

Changed-file checks: **passed**, including production/test typechecking, formatting, lint, dead exports, import cycles, and repository guards. `git diff --check` also passed.

Before/after handoff timing used the same real yield fixture on main and the final production patch, without a context message, with 0 or 4,001 preceding custom entries. Measure `performance.now()` around `handleEmbeddedAttemptPromptError`, then immediately try the bounded `SessionManager.open`; exclude fixture setup. Run one warmup plus three measured samples per size/version.

| Preceding entries | Main median | Patched median | Readable immediately, main → patched |
| --- | ---: | ---: | --- |
| 0 | 2.16 ms | 1.88 ms | 3/3 → 3/3 |
| 4,001 | 86.43 ms | 408.81 ms | 0/3 → 3/3 |

The large-history handoff now waits for its existing rebuild to finish. These fixture timings demonstrate the added wait, not a production latency guarantee.

### What was not tested

No live Gateway deployment or new Telegram round trip. No external provider calls were needed for these failures, which occur at session handoff and before reply inference. The full repository test suite was not run.

