### PR TITLE
fix(auto-reply): pick silent-fallback wording by failure reason class

### DIFF
--- a/src/auto-reply/reply/agent-runner-core.test.ts
+++ b/src/auto-reply/reply/agent-runner-core.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from "vitest";
 import type { TemplateContext } from "../templating.js";
 import {
+  buildSilentFallbackFailurePayload,
   resolveAdmittedRunSessionFile,
   resolveReplyRunDeliveryContext,
 } from "./agent-runner-core.js";
+import type { RuntimeFallbackAttempt } from "./agent-runner-execution.types.js";
 
 describe("resolveAdmittedRunSessionFile", () => {
   it("uses the scoped session key when one is available", () => {
@@ -58,5 +60,98 @@ describe("resolveReplyRunDeliveryContext", () => {
       accountId: "work",
       threadId,
     });
+  });
+});
+
+const silentFallbackParams = {
+  fallbackFailureKnown: true,
+  isHeartbeat: false,
+  hasSuccessfulTerminalDelivery: false,
+} as const;
+
+function silentFallbackTransition() {
+  return {
+    selectedModelRef: "openai/gpt-5.6-luna",
+    activeModelRef: "anthropic/claude-sonnet-5",
+    fallbackActive: true,
+    fallbackTransitioned: true,
+    fallbackCleared: false,
+    reasonSummary: "",
+    attemptSummaries: [],
+    previousState: {},
+    nextState: {},
+    stateChanged: true,
+  };
+}
+
+function fallbackAttempt(reason: RuntimeFallbackAttempt["reason"]): RuntimeFallbackAttempt {
+  return { provider: "openai", model: "gpt-5.6-luna", error: "failed", reason };
+}
+
+describe("buildSilentFallbackFailurePayload", () => {
+  it("keeps the unreachable wording when every attempt failed before the backend answered", () => {
+    const payload = buildSilentFallbackFailurePayload({
+      ...silentFallbackParams,
+      fallbackTransition: silentFallbackTransition(),
+      fallbackAttempts: [fallbackAttempt("server_error"), fallbackAttempt("timeout")],
+    });
+    expect(payload?.text).toContain("I couldn't reach the configured model backend");
+  });
+
+  it("keeps the historical wording when no attempt records exist", () => {
+    const payload = buildSilentFallbackFailurePayload({
+      ...silentFallbackParams,
+      fallbackTransition: silentFallbackTransition(),
+      fallbackAttempts: [],
+    });
+    expect(payload?.text).toContain("I couldn't reach the configured model backend");
+  });
+
+  it.each([
+    "format",
+    "auth",
+    "billing",
+    "rate_limit",
+    "context_overflow",
+    "session_expired",
+  ] as const)("reports a responded backend instead of unreachability for %s", (reason) => {
+    const payload = buildSilentFallbackFailurePayload({
+      ...silentFallbackParams,
+      fallbackTransition: silentFallbackTransition(),
+      fallbackAttempts: [fallbackAttempt(reason)],
+    });
+    expect(payload?.text).toContain("responded without a usable reply");
+    expect(payload?.text).not.toContain("couldn't reach");
+  });
+
+  it("reports a responded backend when any attempt reached it, even beside transport failures", () => {
+    const payload = buildSilentFallbackFailurePayload({
+      ...silentFallbackParams,
+      fallbackTransition: silentFallbackTransition(),
+      fallbackAttempts: [fallbackAttempt("server_error"), fallbackAttempt("format")],
+    });
+    expect(payload?.text).toContain("responded without a usable reply");
+  });
+
+  it("still suppresses the payload for heartbeat runs", () => {
+    expect(
+      buildSilentFallbackFailurePayload({
+        ...silentFallbackParams,
+        isHeartbeat: true,
+        fallbackTransition: silentFallbackTransition(),
+        fallbackAttempts: [fallbackAttempt("format")],
+      }),
+    ).toBeUndefined();
+  });
+
+  it("still suppresses the payload when no fallback failure is known", () => {
+    expect(
+      buildSilentFallbackFailurePayload({
+        ...silentFallbackParams,
+        fallbackFailureKnown: false,
+        fallbackTransition: silentFallbackTransition(),
+        fallbackAttempts: [fallbackAttempt("format")],
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/agent-runner-core.test.ts
+++ b/src/auto-reply/reply/agent-runner-core.test.ts
@@ -84,8 +84,12 @@ function silentFallbackTransition() {
   };
 }
 
-function fallbackAttempt(reason: RuntimeFallbackAttempt["reason"]): RuntimeFallbackAttempt {
-  return { provider: "openai", model: "gpt-5.6-luna", error: "failed", reason };
+function fallbackAttempt(
+  reason: RuntimeFallbackAttempt["reason"],
+  provider = "openai",
+  model = "gpt-5.6-luna",
+): RuntimeFallbackAttempt {
+  return { provider, model, error: "failed", reason };
 }
 
 describe("buildSilentFallbackFailurePayload", () => {
@@ -107,31 +111,53 @@ describe("buildSilentFallbackFailurePayload", () => {
     expect(payload?.text).toContain("I couldn't reach the configured model backend");
   });
 
-  it.each([
-    "format",
-    "auth",
-    "billing",
-    "rate_limit",
-    "context_overflow",
-    "session_expired",
-  ] as const)("reports a responded backend instead of unreachability for %s", (reason) => {
+  it.each(["format", "billing", "rate_limit", "context_overflow", "session_expired"] as const)(
+    "uses neutral wording for %s failures, claiming neither reachability nor a response",
+    (reason) => {
+      const payload = buildSilentFallbackFailurePayload({
+        ...silentFallbackParams,
+        fallbackTransition: silentFallbackTransition(),
+        fallbackAttempts: [fallbackAttempt(reason)],
+      });
+      expect(payload?.text).toContain("did not produce a usable reply");
+      expect(payload?.text).not.toContain("couldn't reach");
+      expect(payload?.text).not.toContain("responded");
+    },
+  );
+
+  it("uses neutral wording for auth-skipped candidates that never sent a request", () => {
+    // The fallback runner records an auth-class failure for skipped candidates
+    // and continues without executing them, so no backend answered and no
+    // response claim is supportable.
     const payload = buildSilentFallbackFailurePayload({
       ...silentFallbackParams,
       fallbackTransition: silentFallbackTransition(),
-      fallbackAttempts: [fallbackAttempt(reason)],
+      fallbackAttempts: [fallbackAttempt("auth")],
     });
-    expect(payload?.text).toContain("responded without a usable reply");
+    expect(payload?.text).toContain("did not produce a usable reply");
     expect(payload?.text).not.toContain("couldn't reach");
+    expect(payload?.text).not.toContain("responded");
   });
 
-  it("reports a responded backend when any attempt reached it, even beside transport failures", () => {
-    const payload = buildSilentFallbackFailurePayload({
-      ...silentFallbackParams,
-      fallbackTransition: silentFallbackTransition(),
-      fallbackAttempts: [fallbackAttempt("server_error"), fallbackAttempt("format")],
-    });
-    expect(payload?.text).toContain("responded without a usable reply");
-  });
+  it.each([
+    { primary: "timeout", secondary: "format" },
+    { primary: "server_error", secondary: "format" },
+  ] as const)(
+    "uses neutral wording when a $primary transport failure mixes with a $secondary response-side failure",
+    ({ primary, secondary }) => {
+      const payload = buildSilentFallbackFailurePayload({
+        ...silentFallbackParams,
+        fallbackTransition: silentFallbackTransition(),
+        fallbackAttempts: [
+          fallbackAttempt(primary, "openai", "gpt-5.6-luna"),
+          fallbackAttempt(secondary, "anthropic", "claude-sonnet-5"),
+        ],
+      });
+      expect(payload?.text).toContain("did not produce a usable reply");
+      expect(payload?.text).not.toContain("couldn't reach");
+      expect(payload?.text).not.toContain("responded");
+    },
+  );
 
   it("still suppresses the payload for heartbeat runs", () => {
     expect(

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -1,6 +1,7 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { hasSessionAutoModelFallbackProvenance } from "../../agents/agent-scope.js";
 import { hasVisibleCommittedMessagingToolDeliveryEvidence } from "../../agents/embedded-agent-runner/delivery-evidence.js";
+import { resolveFailoverStatus } from "../../agents/failover-error.js";
 import type { ModelRef } from "../../agents/model-ref-shared.js";
 import type { OpenClawConfig } from "../../config/config.js";
 import {
@@ -28,6 +29,7 @@ import type { TemplateContext } from "../templating.js";
 import type { VerboseLevel } from "../thinking.js";
 import { SILENT_REPLY_TOKEN } from "../tokens.js";
 import type { GetReplyOptions, ReplyPayload } from "../types.js";
+import type { RuntimeFallbackAttempt } from "./agent-runner-execution.types.js";
 import {
   buildKnownAgentRunFailureReplyPayload,
   buildTerminalAgentRunFailureReplyPayload,
@@ -75,9 +77,28 @@ export function markBeforeAgentRunBlockedPayloads(payloads: ReplyPayload[]): Rep
   );
 }
 
+// "Couldn't reach" is only true when an attempt failed before the backend could
+// answer: 5xx classes plus request timeout. A 4xx-mapped reason (format, auth,
+// billing, ...) or an unmapped one (empty response, unknown) reached the
+// backend, and reporting unreachability sends operators auditing connectivity
+// for a provider that answered.
+const UNREACHABLE_FAILOVER_STATUSES = new Set([408, 500, 502, 503]);
+
+function everyFallbackAttemptUnreachable(attempts: readonly RuntimeFallbackAttempt[]): boolean {
+  if (attempts.length === 0) {
+    // No recorded attempt carries no reason evidence; keep the historical wording.
+    return true;
+  }
+  return attempts.every((attempt) => {
+    const status = resolveFailoverStatus(attempt.reason);
+    return status !== undefined && UNREACHABLE_FAILOVER_STATUSES.has(status);
+  });
+}
+
 export function buildSilentFallbackFailurePayload(params: {
   fallbackTransition: ReturnType<typeof resolveFallbackTransition>;
   fallbackFailureKnown: boolean;
+  fallbackAttempts: readonly RuntimeFallbackAttempt[];
   isHeartbeat: boolean;
   hasSuccessfulTerminalDelivery: boolean;
   allowEmptyAssistantReplyAsSilent?: boolean;
@@ -95,10 +116,13 @@ export function buildSilentFallbackFailurePayload(params: {
   ) {
     return undefined;
   }
+  const backendUnreachable = everyFallbackAttemptUnreachable(params.fallbackAttempts);
   return markReplyPayloadForSourceSuppressionDelivery({
-    text:
-      `⚠️ I couldn't reach the configured model backend ${params.fallbackTransition.selectedModelRef}. ` +
-      `Fallback used ${params.fallbackTransition.activeModelRef}, but it produced no visible reply.`,
+    text: backendUnreachable
+      ? `⚠️ I couldn't reach the configured model backend ${params.fallbackTransition.selectedModelRef}. ` +
+        `Fallback used ${params.fallbackTransition.activeModelRef}, but it produced no visible reply.`
+      : `⚠️ The configured model backend ${params.fallbackTransition.selectedModelRef} responded without a usable reply. ` +
+        `Fallback used ${params.fallbackTransition.activeModelRef}, but it produced no visible reply.`,
     isError: true,
   });
 }

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -78,10 +78,10 @@ export function markBeforeAgentRunBlockedPayloads(payloads: ReplyPayload[]): Rep
 }
 
 // "Couldn't reach" is only true when an attempt failed before the backend could
-// answer: 5xx classes plus request timeout. A 4xx-mapped reason (format, auth,
-// billing, ...) or an unmapped one (empty response, unknown) reached the
-// backend, and reporting unreachability sends operators auditing connectivity
-// for a provider that answered.
+// answer: 5xx classes plus request timeout. Any other record — a 4xx-mapped
+// reason (format, auth, billing, ...), an unmapped one (empty response,
+// unknown), or a candidate skipped without sending a request — establishes
+// neither reachability nor a response, so the wording must claim neither.
 const UNREACHABLE_FAILOVER_STATUSES = new Set([408, 500, 502, 503]);
 
 function everyFallbackAttemptUnreachable(attempts: readonly RuntimeFallbackAttempt[]): boolean {
@@ -121,7 +121,7 @@ export function buildSilentFallbackFailurePayload(params: {
     text: backendUnreachable
       ? `⚠️ I couldn't reach the configured model backend ${params.fallbackTransition.selectedModelRef}. ` +
         `Fallback used ${params.fallbackTransition.activeModelRef}, but it produced no visible reply.`
-      : `⚠️ The configured model backend ${params.fallbackTransition.selectedModelRef} responded without a usable reply. ` +
+      : `⚠️ The configured model backend ${params.fallbackTransition.selectedModelRef} did not produce a usable reply. ` +
         `Fallback used ${params.fallbackTransition.activeModelRef}, but it produced no visible reply.`,
     isError: true,
   });

--- a/src/auto-reply/reply/agent-runner-result-payloads.ts
+++ b/src/auto-reply/reply/agent-runner-result-payloads.ts
@@ -308,6 +308,7 @@ export async function prepareReplyAgentPayloads(state: {
     const silentFallbackFailurePayload = buildSilentFallbackFailurePayload({
       fallbackTransition,
       fallbackFailureKnown,
+      fallbackAttempts,
       isHeartbeat,
       hasSuccessfulTerminalDelivery: successfulTerminalDelivery,
       allowEmptyAssistantReplyAsSilent: followupRun.run.allowEmptyAssistantReplyAsSilent,


### PR DESCRIPTION
## What Problem This Solves

Fixes #141694. When a fallback model ran and the final reply was empty, `buildSilentFallbackFailurePayload` always told the user "I couldn't reach the configured model backend <ref>", no matter why the attempts failed. A provider that answered HTTP 200 to every request in the window was named to the operator as unreachable — the message confidently asserted a cause it never checked, sending operators to audit credentials, credit balance and connectivity for a provider with no fault.

## Why This Change Was Made

The payload builder received `fallbackTransition` and a boolean `fallbackFailureKnown`, but never the failure reasons. The reason data existed one frame away in `fallbackAttempts` and was discarded before the message was built, while sibling aggregate copy in the same module (`resolveReplyFailureSummary` in `agent-runner-failure-reply.ts`) already branches on `attempt.reason`.

The fix threads `fallbackAttempts` into the builder and selects between exactly two supported claims:

- **Unreachable wording (unchanged sentence):** every recorded attempt failed before the backend could answer — reasons mapping to 5xx classes plus request timeout (`server_error` 500, `overloaded` 503, `tls_certificate` 502, `timeout` 408).
- **Neutral wording (this revision):** any other record — 4xx-mapped reasons (`format`, `auth`, `billing`, `rate_limit`, `context_overflow`, `session_expired`, ...), unmapped ones (`empty_response`, `unknown`), or a candidate skipped without sending a request — yields "The configured model backend <ref> did not produce a usable reply", which claims neither reachability nor a response.

**Revision addressing the P2 review finding:** the previous revision's second branch asserted "responded" whenever any candidate carried a non-transport reason. That inference is unsupported by these records: missing local credentials classify as `auth` and `model-fallback-runner.ts` records auth-skipped candidates without ever sending them, and a primary `timeout` beside another provider's `format` failure named the primary as having responded when no record ties a response to the named candidate. The neutral sentence drops the unsupported claim while keeping the actionable content (which chain ran, fallback engaged, no visible reply).

The parallel `replyOperation.fail(...)` diagnostic string is untouched — "failed" there is factual.

## User Impact

An operator whose primary failed with `candidate_failed reason=format` (provider answering 200) now sees:

```text
⚠️ The configured model backend openai/gpt-5.6-luna did not produce a usable reply. Fallback used anthropic/claude-sonnet-5, but it produced no visible reply.
```

instead of being told the backend was unreachable. An auth-skipped candidate (credentials missing locally, request never sent) and a mixed chain (primary timeout beside another provider's format failure) now also produce this neutral sentence instead of the previous revision's unsupported "responded" claim or main's "couldn't reach" claim. Genuine transport failures (timeouts, 5xx, TLS) keep the existing unreachable sentence verbatim. No config, schema or SDK surface changes.

## Evidence

**Unit coverage (new, `agent-runner-core.test.ts`):** 19 tests in the file, all passing. The neutral partition is covered by a table over `format`/`billing`/`rate_limit`/`context_overflow`/`session_expired`, a dedicated `auth`-skipped case (request never sent), two mixed-provider chains (`timeout`+`format`, `server_error`+`format`), the all-transport-failures unreachable path, the empty-attempts historical path, and the heartbeat / unknown-failure suppression guards.

**Pre-fix reproduction:** with the test file at this revision and only `agent-runner-core.ts` reverted to the previous head (`b18a01e53f9`), the 8 new wording tests fail — the neutral cases emit the old "responded without a usable reply" sentence, failing the `not.toContain("responded")` assertion for exactly the auth-skipped and mixed-chain scenarios the P2 finding describes:

```sh
# src reverted to b18a01e53f9, tests at this revision
Test Files  1 failed (1) | Tests  8 failed | 11 passed (19)
```

**Type checks:** `pnpm tsgo:core` exit 0; `node scripts/run-tsgo-core-test-shards.mjs src` exit 0.

**Adjacent suites:** `agent-runner-auto-fallback.test.ts` and `agent-runner-failure-reply.test.ts` pass unchanged (8 tests).

**Behavior before fix:** main's emitting path had no reason-dependent branch — `buildSilentFallbackFailurePayload` built the sentence from `fallbackTransition` alone, so every reason class produced the unreachable claim (issue #141694 records the observed run: 112 of 112 requests answered 200, message named the healthy provider).

Production LOC: **+5/-5** in `agent-runner-core.ts`; tests **+46/-14**.

## Remaining review ask

The after-fix runtime capture of the warning reaching a chat (review checklist item 1) is still open and will be delivered in a follow-up push on this branch.
