### PR TITLE
fix(agents): honor account selectors in agent summaries

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -40,6 +40,12 @@ Options: `--json`, `--bindings` (include full routing rules, not only per-agent 
 Provider-status labels include optional account display names beside account IDs.
 Routing rules continue to identify accounts by channel and account ID.
 
+Provider rows summarize local account status for the displayed binding scopes.
+A wildcard includes each locally known account once; message routing still applies
+peer and account precedence. Stored bindings with an omitted or blank account id
+refer to the literal `default` account key, independently of a channel's preferred
+account for commands. Use `--json --bindings` to include provider rows in JSON.
+
 Identity fields saved in config take precedence. Fields that are not configured
 fall back to `IDENTITY.md` in the agent's workspace. Unsupported avatar values
 and unreadable local images also fall back to the workspace avatar.
@@ -120,7 +126,7 @@ If you omit `--agent` for `bind` or `unbind`, OpenClaw targets the current defau
 
 ### Binding scope behavior
 
-- A stored binding without `accountId` matches the channel default account only.
+- A stored binding without `accountId` matches the literal `default` account key only.
 - `accountId: "*"` is the channel-wide fallback (all accounts) and is less specific than an explicit account binding.
 - If the same agent already has a matching channel binding without `accountId`, and you later bind with an explicit or resolved `accountId`, OpenClaw upgrades that existing binding in place instead of adding a duplicate.
 

--- a/src/commands/agents.providers.test.ts
+++ b/src/commands/agents.providers.test.ts
@@ -1,7 +1,14 @@
 // Agents provider tests cover provider status index construction for configured agents.
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ChannelPlugin } from "../channels/plugins/types.plugin.js";
+import type { ChannelAccountSnapshot } from "../channels/plugins/types.public.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createAccountListHelpers } from "../plugin-sdk/account-helpers.js";
+import { createScopedChannelConfigAdapter } from "../plugin-sdk/channel-config-helpers.js";
 import type { OfficialExternalPluginRepairHint } from "../plugins/official-external-plugin-repair-hints.js";
+import { normalizeAccountId } from "../routing/account-id.js";
+import { resolveAccountEntry } from "../routing/account-lookup.js";
+import { resolveAgentRoute } from "../routing/resolve-route.js";
 import {
   buildProviderStatusIndex,
   buildProviderSummaryMetadataIndex,
@@ -56,6 +63,79 @@ vi.mock("../plugins/official-external-plugin-repair-hints.js", () => ({
   resolveMissingOfficialExternalChannelPluginRepairHints:
     mocks.resolveMissingOfficialExternalChannelPluginRepairHints,
 }));
+
+function createAccountSelectionFixture(): ChannelPlugin<ChannelAccountSnapshot> {
+  const accounts = new Map<string, ChannelAccountSnapshot>([
+    ["default", { accountId: "default", name: "Default", configured: false, enabled: true }],
+    ["alpha", { accountId: "alpha", name: "Alpha", configured: false, enabled: true }],
+    ["beta", { accountId: "beta", name: "Beta", configured: false, enabled: false }],
+  ]);
+  const resolveAccount = (_cfg: OpenClawConfig, accountId?: string | null) => {
+    const account = accounts.get(accountId ?? "alpha");
+    if (!account) {
+      throw new Error("Unexpected fixture account");
+    }
+    return account;
+  };
+  return {
+    id: "telegram",
+    meta: {
+      id: "telegram",
+      label: "Telegram",
+      selectionLabel: "Telegram",
+      docsPath: "/channels/telegram",
+      blurb: "Fixture channel",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      listAccountIds: () => [...accounts.keys()],
+      defaultAccountId: () => "alpha",
+      resolveAccount,
+      inspectAccount: resolveAccount,
+      describeAccount: (account) => account,
+    },
+  };
+}
+
+function createRawListedAccountFixture() {
+  const helpers = createAccountListHelpers("imessage");
+  const calls: Array<string | null | undefined> = [];
+  const resolveAccount = (cfg: OpenClawConfig, requestedId?: string | null) => {
+    calls.push(requestedId);
+    const accountId = normalizeAccountId(requestedId);
+    const account = resolveAccountEntry(cfg.channels?.imessage?.accounts, accountId);
+    return {
+      accountId,
+      name: account?.name,
+      enabled: account?.enabled !== false,
+      configured: true,
+    };
+  };
+  const plugin: ChannelPlugin<ReturnType<typeof resolveAccount>> = {
+    id: "imessage",
+    meta: {
+      id: "imessage",
+      label: "iMessage",
+      selectionLabel: "iMessage",
+      docsPath: "/channels/imessage",
+      blurb: "Fixture channel",
+    },
+    capabilities: { chatTypes: ["direct"] },
+    config: {
+      ...createScopedChannelConfigAdapter({
+        sectionKey: "imessage",
+        listAccountIds: helpers.listAccountIds,
+        defaultAccountId: helpers.resolveDefaultAccountId,
+        resolveAccount,
+        clearBaseFields: [],
+        resolveAllowFrom: () => [],
+        formatAllowFrom: (values) => values.map(String),
+      }),
+      describeAccount: (account) => account,
+    },
+  };
+  return { plugin, calls };
+}
 
 describe("buildProviderStatusIndex", () => {
   beforeEach(() => {
@@ -394,6 +474,290 @@ describe("buildProviderStatusIndex", () => {
       config: { channels: { feishu: { appId: "cli_xxx" } } },
       channelIds: [],
     });
+  });
+
+  it.each([
+    { selector: undefined, ids: ["default"], route: "default" },
+    { selector: "", ids: ["default"], route: "default" },
+    { selector: " \t ", ids: ["default"], route: "default" },
+    { selector: "default", ids: ["default"], route: "default" },
+    { selector: "alpha", ids: ["alpha"], route: "alpha" },
+    { selector: " ALPHA ", ids: ["alpha"], route: "alpha" },
+    { selector: "*", ids: ["default", "alpha", "beta"], route: "*" },
+    { selector: " * ", ids: ["default", "alpha", "beta"], route: "*" },
+    { selector: "absent", ids: ["absent"], route: "absent" },
+  ])("renders canonical account selector $selector", async ({ selector, ids, route }) => {
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([createAccountSelectionFixture()]);
+    const cfg: OpenClawConfig = {};
+    const providerStatus = await buildProviderStatusIndex(cfg);
+    const providerMetadata = new Map([
+      [
+        "telegram",
+        { label: "Telegram", defaultAccountId: "alpha", visibleInConfiguredLists: true },
+      ],
+    ]);
+    const bindings = [{ agentId: "proof", match: { channel: "telegram", accountId: selector } }];
+    const lines = new Map([
+      ["default", "Telegram default (Default): not configured"],
+      ["alpha", "Telegram alpha (Alpha): not configured"],
+      ["beta", "Telegram beta (Beta): disabled"],
+      ["absent", "Telegram absent: unknown"],
+    ]);
+    expect(
+      listProvidersForAgent({
+        summaryIsDefault: false,
+        cfg,
+        bindings,
+        providerStatus,
+        providerMetadata,
+      }),
+    ).toEqual(ids.map((id) => lines.get(id)));
+    expect(summarizeBindings(cfg, bindings, providerMetadata)).toEqual(["Telegram " + route]);
+  });
+
+  it("keeps configured-scope inventory separate from mixed-owner route precedence", async () => {
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([createAccountSelectionFixture()]);
+    const cfg: OpenClawConfig = {
+      agents: {
+        ownership: "explicit",
+        entries: { fallback: {}, specific: {}, defaultscope: {}, idle: {} },
+      },
+      bindings: [
+        { agentId: "fallback", match: { channel: "telegram", accountId: " * " } },
+        { agentId: "specific", match: { channel: "telegram", accountId: " ALPHA " } },
+        { agentId: "defaultscope", match: { channel: "telegram", accountId: " " } },
+        {
+          agentId: "fallback",
+          match: { channel: "telegram", accountId: "*", peer: { kind: "direct", id: "vip" } },
+        },
+      ],
+    };
+    const providerStatus = await buildProviderStatusIndex(cfg);
+    const providerMetadata = new Map([
+      [
+        "telegram",
+        { label: "Telegram", defaultAccountId: "alpha", visibleInConfiguredLists: true },
+      ],
+    ]);
+    for (const [accountId, peerId, agentId, matchedBy] of [
+      [undefined, "ordinary", "defaultscope", "binding.account"],
+      [" ", "ordinary", "defaultscope", "binding.account"],
+      ["default", "ordinary", "defaultscope", "binding.account"],
+      ["alpha", "ordinary", "specific", "binding.account"],
+      ["beta", "ordinary", "fallback", "binding.channel"],
+      ["alpha", "vip", "fallback", "binding.peer"],
+    ] as const) {
+      expect(
+        resolveAgentRoute({
+          cfg,
+          channel: "telegram",
+          accountId,
+          peer: { kind: "direct", id: peerId },
+        }),
+      ).toMatchObject({ agentId, matchedBy });
+    }
+    expect(
+      resolveAgentRoute({
+        cfg,
+        channel: "discord",
+        accountId: "alpha",
+        defaultAgentId: "fallback",
+        peer: { kind: "direct", id: "ordinary" },
+      }),
+    ).toMatchObject({ agentId: "fallback", matchedBy: "default" });
+    expect(() =>
+      resolveAgentRoute({
+        cfg,
+        channel: "discord",
+        accountId: "alpha",
+        peer: { kind: "direct", id: "ordinary" },
+      }),
+    ).toThrow("Multiple agents are configured");
+    const rows = (agentId: string) =>
+      listProvidersForAgent({
+        summaryIsDefault: false,
+        cfg,
+        bindings: cfg.bindings!.filter((binding) => binding.agentId === agentId),
+        providerStatus,
+        providerMetadata,
+      });
+    expect(rows("fallback")).toEqual([
+      "Telegram default (Default): not configured",
+      "Telegram alpha (Alpha): not configured",
+      "Telegram beta (Beta): disabled",
+    ]);
+    expect(rows("specific")).toEqual(["Telegram alpha (Alpha): not configured"]);
+    expect(rows("defaultscope")).toEqual(["Telegram default (Default): not configured"]);
+    expect(rows("idle")).toEqual([]);
+  });
+
+  it.each([false, true])("preserves unbound default=%s filtering", async (summaryIsDefault) => {
+    const plugin = createAccountSelectionFixture();
+    plugin.config.isConfigured = (account) => account.accountId === "alpha";
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([plugin]);
+    expect(
+      listProvidersForAgent({
+        summaryIsDefault,
+        cfg: {},
+        bindings: [],
+        providerStatus: await buildProviderStatusIndex({}),
+        providerMetadata: new Map(),
+      }),
+    ).toEqual(summaryIsDefault ? ["Telegram alpha (Alpha): configured"] : []);
+  });
+
+  it.each([
+    { repairHint: undefined, expected: "Telegram *: unknown" },
+    { repairHint: "Install Telegram.", expected: "Telegram *: missing plugin - Install Telegram." },
+  ])("preserves empty wildcard diagnostic $expected", async ({ repairHint, expected }) => {
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([]);
+    expect(
+      listProvidersForAgent({
+        summaryIsDefault: false,
+        cfg: {},
+        bindings: [{ agentId: "proof", match: { channel: "telegram", accountId: " * " } }],
+        providerStatus: await buildProviderStatusIndex({}),
+        providerMetadata: new Map([
+          [
+            "telegram",
+            {
+              label: "Telegram",
+              defaultAccountId: "alpha",
+              visibleInConfiguredLists: true,
+              repairHint,
+            },
+          ],
+        ]),
+      }),
+    ).toEqual([expected]);
+  });
+
+  it.each(
+    [
+      ["alpha"],
+      ["Alpha"],
+      [" ALPHA "],
+      ["*", "Alpha"],
+      ["Alpha", "*"],
+      ["*", "alpha", "Alpha"],
+    ].map((selectors) => ({ selectors })),
+  )("joins raw listed Alpha through canonical selectors $selectors", async ({ selectors }) => {
+    const cfg: OpenClawConfig = {
+      channels: { imessage: { accounts: { Alpha: { name: "Work", enabled: true } } } },
+    };
+    const { plugin, calls } = createRawListedAccountFixture();
+    expect(plugin.config.listAccountIds(cfg)).toEqual(["Alpha"]);
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([plugin]);
+    const providerStatus = await buildProviderStatusIndex(cfg);
+    expect(calls).toEqual(["Alpha"]);
+    expect(
+      listProvidersForAgent({
+        summaryIsDefault: false,
+        cfg,
+        bindings: selectors.map((accountId) => ({
+          agentId: "proof",
+          match: { channel: "imessage", accountId },
+        })),
+        providerStatus,
+        providerMetadata: new Map([
+          [
+            "imessage",
+            { label: "iMessage", defaultAccountId: "default", visibleInConfiguredLists: true },
+          ],
+        ]),
+      }),
+    ).toEqual(["iMessage Alpha (Work): configured"]);
+  });
+
+  it("canonicalizes raw listed ids for unavailable account status records", async () => {
+    const cfg: OpenClawConfig = {
+      channels: { imessage: { accounts: { Alpha: { enabled: true } } } },
+    };
+    const { plugin, calls } = createRawListedAccountFixture();
+    plugin.config.resolveAccount = (_cfg, requestedId) => {
+      calls.push(requestedId);
+      throw new Error("unresolved SecretRef: synthetic fixture");
+    };
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([plugin]);
+    const providerStatus = await buildProviderStatusIndex(cfg);
+    expect(calls).toEqual(["Alpha"]);
+    expect(
+      listProvidersForAgent({
+        summaryIsDefault: false,
+        cfg,
+        bindings: [{ agentId: "proof", match: { channel: "imessage", accountId: "alpha" } }],
+        providerStatus,
+        providerMetadata: new Map([
+          [
+            "imessage",
+            { label: "iMessage", defaultAccountId: "default", visibleInConfiguredLists: true },
+          ],
+        ]),
+      }),
+    ).toEqual(["iMessage Alpha: configured unavailable"]);
+  });
+
+  it("prefers the exact canonical record when listed account aliases collide", async () => {
+    const cfg: OpenClawConfig = {
+      channels: {
+        imessage: {
+          accounts: {
+            Alpha: { name: "Alias", enabled: true },
+            alpha: { name: "Exact", enabled: true },
+          },
+        },
+      },
+    };
+    const { plugin, calls } = createRawListedAccountFixture();
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([plugin]);
+    const providerStatus = await buildProviderStatusIndex(cfg);
+    expect(calls).toEqual(plugin.config.listAccountIds(cfg));
+    expect(
+      listProvidersForAgent({
+        summaryIsDefault: false,
+        cfg,
+        bindings: ["*", "Alpha", "alpha"].map((accountId) => ({
+          agentId: "proof",
+          match: { channel: "imessage", accountId },
+        })),
+        providerStatus,
+        providerMetadata: new Map([
+          [
+            "imessage",
+            { label: "iMessage", defaultAccountId: "default", visibleInConfiguredLists: true },
+          ],
+        ]),
+      }),
+    ).toEqual(["iMessage alpha (Exact): configured"]);
+    expect(cfg.channels?.imessage?.accounts?.Alpha?.name).toBe("Alias");
+  });
+
+  it("keeps wildcard scope diagnostics distinct from the concrete default key", async () => {
+    mocks.listReadOnlyChannelPluginsForConfig.mockReturnValue([]);
+    const cfg: OpenClawConfig = {};
+    const bindings = ["*", "default"].map((accountId) => ({
+      agentId: "proof",
+      match: { channel: "imessage", accountId },
+    }));
+    const providerMetadata = new Map([
+      [
+        "imessage",
+        { label: "iMessage", defaultAccountId: "default", visibleInConfiguredLists: true },
+      ],
+    ]);
+    expect(summarizeBindings(cfg, bindings, providerMetadata)).toEqual([
+      "iMessage *",
+      "iMessage default",
+    ]);
+    expect(
+      listProvidersForAgent({
+        summaryIsDefault: false,
+        cfg,
+        bindings,
+        providerMetadata,
+        providerStatus: await buildProviderStatusIndex(cfg),
+      }),
+    ).toEqual(["iMessage *: unknown", "iMessage default: unknown"]);
   });
 
   it("uses repair hints instead of unknown for bound missing external channels", () => {

--- a/src/commands/agents.providers.ts
+++ b/src/commands/agents.providers.ts
@@ -16,7 +16,7 @@ import type { AgentBinding } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { listExplicitConfiguredChannelIdsForConfig } from "../plugins/channel-plugin-ids.js";
 import { resolveMissingOfficialExternalChannelPluginRepairHints } from "../plugins/official-external-plugin-repair-hints.js";
-import { DEFAULT_ACCOUNT_ID } from "../routing/session-key.js";
+import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "../routing/session-key.js";
 
 type ProviderAccountStatus = {
   provider: ChannelId;
@@ -43,8 +43,20 @@ type ProviderSummaryMetadata = {
   repairHint?: string;
 };
 
+// Concrete account keys normalize aliases; scope keys must keep "*" distinct from "default".
 function providerAccountKey(provider: ChannelId, accountId?: string) {
-  return `${provider}:${accountId ?? DEFAULT_ACCOUNT_ID}`;
+  return `${provider}:${normalizeAccountId(accountId)}`;
+}
+
+function recordProviderAccountStatus(
+  index: Map<string, ProviderAccountStatus>,
+  entry: ProviderAccountStatus,
+) {
+  const key = providerAccountKey(entry.provider, entry.accountId);
+  // Exact canonical spelling wins; otherwise keep the first listed alias.
+  if (!index.has(key) || entry.accountId === normalizeAccountId(entry.accountId)) {
+    index.set(key, entry);
+  }
 }
 
 function resolveProviderChannelId(params: {
@@ -158,7 +170,7 @@ export async function buildProviderStatusIndex(
         if (!isUnresolvedSecretRefResolutionError(error)) {
           throw error;
         }
-        map.set(providerAccountKey(plugin.id, accountId), {
+        recordProviderAccountStatus(map, {
           provider: plugin.id,
           providerLabel: plugin.meta.label,
           accountId,
@@ -216,7 +228,7 @@ export async function buildProviderStatusIndex(
             fallbackState,
           );
       const name = snapshot?.name ?? (account as { name?: string }).name;
-      map.set(providerAccountKey(plugin.id, accountId), {
+      recordProviderAccountStatus(map, {
         provider: plugin.id,
         providerLabel: plugin.meta.label,
         accountId,
@@ -232,11 +244,9 @@ export async function buildProviderStatusIndex(
   return map;
 }
 
-function resolveDefaultAccountId(
-  provider: ChannelId,
-  metadataByProvider: ReadonlyMap<ChannelId, ProviderSummaryMetadata>,
-): string {
-  return metadataByProvider.get(provider)?.defaultAccountId ?? DEFAULT_ACCOUNT_ID;
+function resolveBindingAccountId(binding: AgentBinding): string {
+  const accountId = binding.match.accountId?.trim();
+  return accountId === "*" ? accountId : normalizeAccountId(accountId);
 }
 
 function shouldShowProviderEntry(params: {
@@ -298,9 +308,8 @@ export function summarizeBindings(
     if (!channel) {
       continue;
     }
-    const accountId =
-      binding.match.accountId ?? resolveDefaultAccountId(channel, metadataByProvider);
-    const key = providerAccountKey(channel, accountId);
+    const accountId = resolveBindingAccountId(binding);
+    const key = `${channel}:${accountId}`;
     if (!seen.has(key)) {
       const label = formatChannelAccountLabel({
         provider: channel,
@@ -322,11 +331,11 @@ export function listProvidersForAgent(params: {
   providerMetadata?: ReadonlyMap<ChannelId, ProviderSummaryMetadata>;
 }): string[] {
   const allProviderEntries = [...params.providerStatus.values()];
-  const providerLines: string[] = [];
   const metadataByProvider =
     params.providerMetadata ?? buildProviderSummaryMetadataIndex(params.cfg);
   if (params.bindings.length > 0) {
-    const seen = new Set<string>();
+    // Keep first-seen account order; empty wildcard scopes retain the existing diagnostic.
+    const linesByAccount = new Map<string, string>();
     for (const binding of params.bindings) {
       const channel = resolveProviderChannelId({
         rawChannelId: binding.match.channel,
@@ -335,29 +344,28 @@ export function listProvidersForAgent(params: {
       if (!channel) {
         continue;
       }
-      const accountId =
-        binding.match.accountId ?? resolveDefaultAccountId(channel, metadataByProvider);
-      const key = providerAccountKey(channel, accountId);
-      if (seen.has(key)) {
-        continue;
-      }
-      seen.add(key);
-      const status = params.providerStatus.get(key);
-      if (status) {
-        providerLines.push(formatProviderEntry(status));
-      } else {
-        providerLines.push(
-          formatMissingProviderEntry({
-            provider: channel,
-            accountId,
-            metadata: metadataByProvider.get(channel),
-          }),
+      const accountId = resolveBindingAccountId(binding);
+      const statuses =
+        accountId === "*"
+          ? allProviderEntries.filter((entry) => entry.provider === channel)
+          : [params.providerStatus.get(providerAccountKey(channel, accountId))];
+      for (const status of statuses.length > 0 ? statuses : [undefined]) {
+        linesByAccount.set(
+          status ? providerAccountKey(channel, status.accountId) : `${channel}:${accountId}`,
+          status
+            ? formatProviderEntry(status)
+            : formatMissingProviderEntry({
+                provider: channel,
+                accountId,
+                metadata: metadataByProvider.get(channel),
+              }),
         );
       }
     }
-    return providerLines;
+    return [...linesByAccount.values()];
   }
 
+  const providerLines: string[] = [];
   if (params.summaryIsDefault) {
     const seenProviders = new Set<ChannelId>();
     for (const entry of allProviderEntries) {


### PR DESCRIPTION
Closes #141710

## What Problem This Solves

Fixes an issue where operators inspecting wildcard account bindings with `agents list` see an unknown account instead of their configured channel accounts. The same summary path substitutes a channel's preferred command account for an omitted stored selector and fails to join case/padded aliases to known accounts.

## Why This Change Was Made

Interpret stored account selectors consistently with the existing router: preserve wildcard scope, normalize concrete selectors, and treat omitted/blank selectors as literal `default`. Build the status index with canonical keys while retaining raw plugin inspection arguments and preferring an exact canonical record when aliases collide. Both route labels and account rows use that interpretation; overlapping scopes show each account once.

This repairs the summary owner without changing message routing, plugin arguments, configuration, credentials, permissions, schemas or persistence. Stored binding counts/details remain intact. The default-account metadata still serves its existing command and missing-plugin purposes. The earlier account-name producer repair is preserved.

Production is +40/−32 (net +8): the canonical status recorder and wildcard expansion replace duplicated preferred-account substitution and literal lookup. Tests add 364 lines after repository formatting; docs are +7/−1. Introduction provenance is unverified in retained shallow history.

## User Impact

A wildcard now shows its known local account inventory:

```text
Before:
  Routing: Telegram *
  Providers:
    - Telegram *: unknown

After:
  Routing: Telegram *
  Providers:
    - Telegram alpha (Canonical): configured
    - Telegram beta (Disabled): disabled
    - Telegram default (Literal default): configured
```

An omitted/blank stored selector now describes literal `default`, while concrete aliases resolve to the canonical account. Wildcard inventory includes accounts even when a more specific binding gives another agent precedence for particular incoming messages; listing declared scopes does not execute a routing decision. Plain JSON and tree output retain their existing shape.

## Evidence

- Tests-only baseline: 16 intended selector failures and 22 passing controls. Candidate owner tests: 38/38. Siblings: 125 pass across the real routing function, list command and public account helpers; one existing Windows-only home-casing test is skipped on macOS.
- Full changed-file gate passed in 865.79 seconds with the source unchanged. One managed P0–P2 review passed with no findings. Normal full candidate build passed in 9m45s, including unchanged source/dependency and semantic-index checks and natural process cleanup.
- Paired normal compiled CLI proof: 17 commands per phase, all 34 exit 0 with empty stderr. The initial concrete inventory verifies the actual `Alpha`/`alpha` collision and account-name fixture before the selector cases. Nine baseline defect cases are corrected; four healthy cases remain correct. Both ordinary text modes show the wildcard's three account rows exactly once. Plain JSON is identical after substituting only the actual isolated profile path; tree output is byte-identical. Config bytes and stored binding details stay unchanged.
- Proof identities are explicit: retained normal baseline production source `9a4114bc4691bdb1293fd48ef1ed1b1790485d12`; candidate `4d81411ef967f9b892a3953f67c849dff3e6ba18` plus patch `c69d9dc7f4641bc96a3837e2c1a2e64ba24280a791aa1ad3d3c73debb440ad59`. Relevant owners/contracts were compared across these sources; the changed config validator preserves this read-only path. The baseline is not relabeled as a current-main build.
- Baseline pre/post verification matched 39,391 source files, 15,384 artifacts, 2,094 dependency manifests, six native binaries and three toolchain binaries. Candidate post-run verification matched 39,432 source files, 15,385 artifacts and the corresponding dependency/toolchain records. These inventories do not claim to hash every transitive dependency implementation byte.

The normal CLI proof reads synthetic local config and manifest metadata. `configured` is the CLI's local status, not evidence of usable credentials or a healthy live channel. No channel sends, login, Gateway, model or GUI run is claimed. The loaded raw-ID plugin seam and actual routing precedence are covered by their owner/public-helper tests; they are not inferred from CLI output.

An independent artifact audit verified all 26 case projections, eight nonempty mode outputs, 34 empty stderr captures, unchanged config pairs, and 239 fixed proof inputs. Commit `0d660ed5a9f9e2056e21d7d85299161382268d42` preserves the exact reviewed/built patch and all three built source files. All 27 selected contracts remain unchanged on inspected main `823ff3ed9ad61e03aecd0bec0421a5463d80eccf`.
