### PR TITLE
refactor(web): share HTML tag scanning

### DIFF
--- a/src/agents/tools/web-fetch-html-tag.ts
+++ b/src/agents/tools/web-fetch-html-tag.ts
@@ -1,0 +1,248 @@
+// Rendering and visibility retain their malformed-input policies over one tag scanner.
+type HtmlTagMode = "render" | "visibility";
+export const RAW_TEXT_TAGS = new Set(["script", "style", "noscript"]);
+
+type HtmlTagToken = {
+  closing: boolean;
+  name: string;
+  raw: string;
+  attrs: string;
+  selfClosing: boolean;
+};
+
+type ReadTagResult = {
+  token: HtmlTagToken | null;
+  next: number;
+};
+
+type TagEndResult = {
+  end: number;
+  rawTextStart?: number;
+};
+
+export function isAsciiWhitespace(value: string): boolean {
+  return value === " " || value === "\n" || value === "\r" || value === "\t" || value === "\f";
+}
+
+export function isTagNameChar(value: string): boolean {
+  const code = value.charCodeAt(0);
+  return (
+    (code >= 48 && code <= 57) ||
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    value === "." ||
+    value === "-" ||
+    value === "_" ||
+    value === ":"
+  );
+}
+
+function isTagNameStartChar(value: string): boolean {
+  const code = value.charCodeAt(0);
+  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
+}
+
+function isTagBoundary(value: string | undefined): boolean {
+  return !value || isAsciiWhitespace(value) || value === ">" || value === "/";
+}
+
+function asciiLower(value: string): string {
+  const code = value.charCodeAt(0);
+  return code >= 65 && code <= 90 ? String.fromCharCode(code + 32) : value;
+}
+
+function startsWithClosingTag(html: string, start: number, tagName: string): boolean {
+  if (html[start] !== "<" || html[start + 1] !== "/") {
+    return false;
+  }
+  for (let offset = 0; offset < tagName.length; offset += 1) {
+    if (asciiLower(html[start + 2 + offset] ?? "") !== tagName[offset]) {
+      return false;
+    }
+  }
+  return isTagBoundary(html[start + 2 + tagName.length]);
+}
+
+export function readRawTextOpenTagName(html: string, start: number): string | undefined {
+  if (html[start] !== "<" || html[start + 1] === "/") {
+    return undefined;
+  }
+  for (const tagName of RAW_TEXT_TAGS) {
+    let matches = true;
+    for (let offset = 0; offset < tagName.length; offset += 1) {
+      if (asciiLower(html[start + 1 + offset] ?? "") !== tagName[offset]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches && isTagBoundary(html[start + 1 + tagName.length])) {
+      return tagName;
+    }
+  }
+  return undefined;
+}
+
+export function findRawTextOpenTagStart(html: string, start: number, end: number): number {
+  for (let i = html.indexOf("<", start); i !== -1 && i < end; i = html.indexOf("<", i + 1)) {
+    if (readRawTextOpenTagName(html, i)) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+export function startsLikeHtmlTag(html: string, start: number): boolean {
+  const next = html[start + 1];
+  return next === "!" || next === "?" || next === "/" || isTagNameStartChar(next ?? "");
+}
+
+function findTagEnd(html: string, start: number, mode: HtmlTagMode = "render"): TagEndResult {
+  const rendering = mode === "render";
+  let afterEquals = false;
+  let rawTextStartInQuote: number | undefined;
+  for (let i = start + 1; i < html.length; i += 1) {
+    const ch = html.charAt(i);
+    if (afterEquals && isAsciiWhitespace(ch)) {
+      continue;
+    }
+    if ((!rendering || afterEquals) && (ch === '"' || ch === "'")) {
+      const quoteEnd = html.indexOf(ch, i + 1);
+      if (rendering && rawTextStartInQuote === undefined) {
+        const rawTextStart = findRawTextOpenTagStart(
+          html,
+          i + 1,
+          quoteEnd === -1 ? html.length : quoteEnd,
+        );
+        if (rawTextStart !== -1) {
+          rawTextStartInQuote = rawTextStart;
+        }
+      }
+      if (quoteEnd === -1) {
+        return { end: -1, rawTextStart: rawTextStartInQuote };
+      }
+      i = quoteEnd;
+      afterEquals = false;
+      continue;
+    }
+    afterEquals = false;
+    if (rendering && readRawTextOpenTagName(html, i)) {
+      return { end: -1, rawTextStart: i };
+    }
+    if (ch === ">") {
+      return { end: i };
+    }
+    if (ch === "=") {
+      afterEquals = true;
+    }
+  }
+  return { end: -1, rawTextStart: rawTextStartInQuote };
+}
+
+function isSelfClosingTagRaw(raw: string): boolean {
+  const trimmed = raw.trimEnd();
+  if (!trimmed.endsWith("/")) {
+    return false;
+  }
+  const beforeSlash = trimmed.charAt(trimmed.length - 2);
+  const tagBody = trimmed.slice(0, -1);
+  let hasAttributeSeparator = false;
+  for (const ch of tagBody) {
+    if (isAsciiWhitespace(ch)) {
+      hasAttributeSeparator = true;
+      break;
+    }
+  }
+  return (
+    !beforeSlash ||
+    isAsciiWhitespace(beforeSlash) ||
+    beforeSlash === '"' ||
+    beforeSlash === "'" ||
+    !hasAttributeSeparator
+  );
+}
+
+export function readTagToken(
+  html: string,
+  start: number,
+  mode: HtmlTagMode = "render",
+): ReadTagResult | null {
+  const rendering = mode === "render";
+  if (rendering && html.startsWith("<!--", start)) {
+    if (html[start + 4] === ">") {
+      return { token: null, next: start + 5 };
+    }
+    if (html.startsWith("->", start + 4)) {
+      return { token: null, next: start + 6 };
+    }
+    const commentEnd = html.indexOf("-->", start + 4);
+    return { token: null, next: commentEnd === -1 ? html.length : commentEnd + 3 };
+  }
+
+  const tagEnd = findTagEnd(html, start, mode);
+  const end = tagEnd.end;
+  if (end === -1) {
+    return tagEnd.rawTextStart === undefined ? null : { token: null, next: tagEnd.rawTextStart };
+  }
+
+  const raw = html.slice(start + 1, end);
+  const body = rendering ? raw : raw.trim();
+  let pos = 0;
+  while (pos < body.length && isAsciiWhitespace(body.charAt(pos))) {
+    pos += 1;
+  }
+  const closing = body[pos] === "/";
+  if (closing) {
+    pos += 1;
+    while (
+      pos < body.length &&
+      (rendering ? isAsciiWhitespace(body.charAt(pos)) : /\s/.test(body.charAt(pos)))
+    ) {
+      pos += 1;
+    }
+  }
+  if (pos >= body.length || body[pos] === "!" || body[pos] === "?") {
+    return { token: null, next: end + 1 };
+  }
+
+  const nameStart = pos;
+  while (pos < body.length && isTagNameChar(body.charAt(pos))) {
+    if (!rendering && body[pos] === ".") {
+      break;
+    }
+    pos += 1;
+  }
+  if (pos === nameStart || (rendering && !isTagNameStartChar(body[nameStart] ?? ""))) {
+    const rawTextStart = rendering ? findRawTextOpenTagStart(html, start + 1, end + 1) : -1;
+    return { token: null, next: rawTextStart === -1 ? end + 1 : rawTextStart };
+  }
+
+  const attrs = closing ? "" : body.slice(pos);
+  return {
+    token: {
+      closing,
+      name: body.slice(nameStart, pos).toLowerCase(),
+      raw,
+      attrs,
+      selfClosing: rendering ? isSelfClosingTagRaw(raw) : !closing && attrs.trimEnd().endsWith("/"),
+    },
+    next: end + 1,
+  };
+}
+
+export function closeRawTextTagEnd(html: string, tagName: string, contentStart: number): number {
+  let closeStart = html.indexOf("</", contentStart);
+  while (closeStart !== -1) {
+    if (startsWithClosingTag(html, closeStart, tagName)) {
+      const closeEnd = findTagEnd(html, closeStart).end;
+      return closeEnd === -1 ? html.length : closeEnd + 1;
+    }
+    closeStart = html.indexOf("</", closeStart + 2);
+  }
+  return html.length;
+}
+
+export function skipRawTextElement(html: string, start: number, tagName: string): number {
+  const openerEnd = findTagEnd(html, start);
+  const contentStart = openerEnd.end === -1 ? start + tagName.length + 1 : openerEnd.end + 1;
+  return closeRawTextTagEnd(html, tagName, contentStart);
+}

--- a/src/agents/tools/web-fetch-html-tag.ts
+++ b/src/agents/tools/web-fetch-html-tag.ts
@@ -83,7 +83,9 @@ export function readRawTextOpenTagName(html: string, start: number): string | un
 }
 
 export function findRawTextOpenTagStart(html: string, start: number, end: number): number {
-  for (let i = html.indexOf("<", start); i !== -1 && i < end; i = html.indexOf("<", i + 1)) {
+  const span = html.slice(start, end);
+  for (let offset = span.indexOf("<"); offset !== -1; offset = span.indexOf("<", offset + 1)) {
+    const i = start + offset;
     if (readRawTextOpenTagName(html, i)) {
       return i;
     }

--- a/src/agents/tools/web-fetch-utils.test.ts
+++ b/src/agents/tools/web-fetch-utils.test.ts
@@ -1,5 +1,5 @@
 // web_fetch extraction utility tests cover HTML entity decoding.
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import {
   extractBasicHtmlContent,
   htmlToMarkdown,
@@ -89,6 +89,33 @@ describe("web-fetch-utils htmlToMarkdown entity decoding", () => {
     );
 
     expect(rendered.text).toBe("[Read](/real)After");
+  });
+
+  it("bounds raw-text searches for many short quoted attributes", () => {
+    const html = `<div${' a=""'.repeat(1_024)}>Visible</div>`;
+    // oxlint-disable-next-line typescript/unbound-method -- called below with the intercepted string receiver.
+    const originalIndexOf = String.prototype.indexOf;
+    let searchedSpanUnits = 0;
+    const indexOf = vi
+      .spyOn(String.prototype, "indexOf")
+      .mockImplementation(function (this: string, search, position) {
+        const found = originalIndexOf.call(this, search, position);
+        if (search === "<") {
+          const start = Math.min(this.length, Math.max(0, position ?? 0));
+          searchedSpanUnits += (found < 0 ? this.length : found + 1) - start;
+        }
+        return found;
+      });
+    let text = "";
+    try {
+      text = htmlToMarkdown(html).text;
+    } finally {
+      indexOf.mockRestore();
+    }
+
+    expect(text).toBe("Visible");
+    // Bound logical search spans without depending on machine timing or exact call counts.
+    expect(searchedSpanUnits).toBeLessThanOrEqual(html.length * 16);
   });
 
   it("re-enters raw-text parsing when an invalid tag span contains a raw-text opener", () => {

--- a/src/agents/tools/web-fetch-utils.ts
+++ b/src/agents/tools/web-fetch-utils.ts
@@ -6,12 +6,22 @@
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { stripInvisibleUnicode } from "../../infra/unicode-visibility.js";
 import { decodeHtmlEntities } from "../../shared/html-entities.js";
+import {
+  RAW_TEXT_TAGS,
+  isAsciiWhitespace,
+  isTagNameChar,
+  readRawTextOpenTagName,
+  findRawTextOpenTagStart,
+  startsLikeHtmlTag,
+  readTagToken,
+  closeRawTextTagEnd,
+  skipRawTextElement,
+} from "./web-fetch-html-tag.js";
 import { sanitizeHtml } from "./web-fetch-visibility.js";
 
 /** Output mode requested by web_fetch extraction. */
 export type ExtractMode = "markdown" | "text";
 
-const RAW_TEXT_TAGS = new Set(["script", "style", "noscript"]);
 const BLOCK_BREAK_TAGS = new Set([
   "p",
   "div",
@@ -35,245 +45,10 @@ type RenderContext =
   | { kind: "heading"; level: number; parts: string[] }
   | { kind: "list-item"; parts: string[] };
 
-type HtmlTagToken = {
-  closing: boolean;
-  name: string;
-  raw: string;
-  selfClosing: boolean;
-};
-
-type ReadTagResult = {
-  token: HtmlTagToken | null;
-  next: number;
-};
-
-type TagEndResult = {
-  end: number;
-  rawTextStart?: number;
-};
-
 function decodeEntities(value: string): string {
   // Display extraction historically accepted mixed-case &nbsp; and treats non-breaking spaces as
   // ordinary collapsible whitespace. Normalize it before the shared decoder to stay single-pass.
   return decodeHtmlEntities(value.replace(/&nbsp;/gi, "\u00a0")).replaceAll("\u00a0", " ");
-}
-
-function isAsciiWhitespace(value: string): boolean {
-  return value === " " || value === "\n" || value === "\r" || value === "\t" || value === "\f";
-}
-
-function isTagNameChar(value: string): boolean {
-  const code = value.charCodeAt(0);
-  return (
-    (code >= 48 && code <= 57) ||
-    (code >= 65 && code <= 90) ||
-    (code >= 97 && code <= 122) ||
-    value === "." ||
-    value === "-" ||
-    value === "_" ||
-    value === ":"
-  );
-}
-
-function isTagNameStartChar(value: string): boolean {
-  const code = value.charCodeAt(0);
-  return (code >= 65 && code <= 90) || (code >= 97 && code <= 122);
-}
-
-function isTagBoundary(value: string | undefined): boolean {
-  return !value || isAsciiWhitespace(value) || value === ">" || value === "/";
-}
-
-function asciiLower(value: string): string {
-  const code = value.charCodeAt(0);
-  return code >= 65 && code <= 90 ? String.fromCharCode(code + 32) : value;
-}
-
-function startsWithClosingTag(html: string, start: number, tagName: string): boolean {
-  if (html[start] !== "<" || html[start + 1] !== "/") {
-    return false;
-  }
-  for (let offset = 0; offset < tagName.length; offset += 1) {
-    if (asciiLower(html[start + 2 + offset] ?? "") !== tagName[offset]) {
-      return false;
-    }
-  }
-  return isTagBoundary(html[start + 2 + tagName.length]);
-}
-
-function readRawTextOpenTagName(html: string, start: number): string | undefined {
-  if (html[start] !== "<" || html[start + 1] === "/") {
-    return undefined;
-  }
-  for (const tagName of RAW_TEXT_TAGS) {
-    let matches = true;
-    for (let offset = 0; offset < tagName.length; offset += 1) {
-      if (asciiLower(html[start + 1 + offset] ?? "") !== tagName[offset]) {
-        matches = false;
-        break;
-      }
-    }
-    if (matches && isTagBoundary(html[start + 1 + tagName.length])) {
-      return tagName;
-    }
-  }
-  return undefined;
-}
-
-function findRawTextOpenTagStart(html: string, start: number, end: number): number {
-  for (let i = start; i < end; i += 1) {
-    if (readRawTextOpenTagName(html, i)) {
-      return i;
-    }
-  }
-  return -1;
-}
-
-function startsLikeHtmlTag(html: string, start: number): boolean {
-  const next = html[start + 1];
-  return next === "!" || next === "?" || next === "/" || isTagNameStartChar(next ?? "");
-}
-
-function findTagEnd(html: string, start: number): TagEndResult {
-  let quote: string | null = null;
-  let afterEquals = false;
-  let rawTextStartInQuote: number | undefined;
-  for (let i = start + 1; i < html.length; i += 1) {
-    const ch = html.charAt(i);
-    if (quote) {
-      if (rawTextStartInQuote === undefined && readRawTextOpenTagName(html, i)) {
-        rawTextStartInQuote = i;
-      }
-      if (ch === quote) {
-        quote = null;
-      }
-      continue;
-    }
-    if (afterEquals && isAsciiWhitespace(ch)) {
-      continue;
-    }
-    if (afterEquals && (ch === '"' || ch === "'")) {
-      quote = ch;
-      afterEquals = false;
-      continue;
-    }
-    afterEquals = false;
-    if (readRawTextOpenTagName(html, i)) {
-      return { end: -1, rawTextStart: i };
-    }
-    if (ch === ">") {
-      return { end: i };
-    }
-    if (ch === "=") {
-      afterEquals = true;
-    }
-  }
-  return { end: -1, rawTextStart: rawTextStartInQuote };
-}
-
-function isSelfClosingTagRaw(raw: string): boolean {
-  const trimmed = raw.trimEnd();
-  if (!trimmed.endsWith("/")) {
-    return false;
-  }
-  const beforeSlash = trimmed.charAt(trimmed.length - 2);
-  const tagBody = trimmed.slice(0, -1);
-  let hasAttributeSeparator = false;
-  for (const ch of tagBody) {
-    if (isAsciiWhitespace(ch)) {
-      hasAttributeSeparator = true;
-      break;
-    }
-  }
-  return (
-    !beforeSlash ||
-    isAsciiWhitespace(beforeSlash) ||
-    beforeSlash === '"' ||
-    beforeSlash === "'" ||
-    !hasAttributeSeparator
-  );
-}
-
-function readTagToken(html: string, start: number): ReadTagResult | null {
-  if (html.startsWith("<!--", start)) {
-    if (html[start + 4] === ">") {
-      return {
-        token: null,
-        next: start + 5,
-      };
-    }
-    if (html.startsWith("->", start + 4)) {
-      return {
-        token: null,
-        next: start + 6,
-      };
-    }
-    const commentEnd = html.indexOf("-->", start + 4);
-    return {
-      token: null,
-      next: commentEnd === -1 ? html.length : commentEnd + 3,
-    };
-  }
-
-  const tagEnd = findTagEnd(html, start);
-  const end = tagEnd.end;
-  if (end === -1) {
-    if (tagEnd.rawTextStart !== undefined) {
-      return {
-        token: null,
-        next: tagEnd.rawTextStart,
-      };
-    }
-    return null;
-  }
-
-  let pos = start + 1;
-  while (pos < end && isAsciiWhitespace(html.charAt(pos))) {
-    pos += 1;
-  }
-  const closing = html[pos] === "/";
-  if (closing) {
-    pos += 1;
-    while (pos < end && isAsciiWhitespace(html.charAt(pos))) {
-      pos += 1;
-    }
-  }
-
-  if (pos >= end || html[pos] === "!" || html[pos] === "?") {
-    return {
-      token: null,
-      next: end + 1,
-    };
-  }
-
-  const nameStart = pos;
-  while (pos < end && isTagNameChar(html.charAt(pos))) {
-    pos += 1;
-  }
-  if (pos === nameStart || !isTagNameStartChar(html[nameStart] ?? "")) {
-    const rawTextStart = findRawTextOpenTagStart(html, start + 1, end + 1);
-    if (rawTextStart !== -1) {
-      return {
-        token: null,
-        next: rawTextStart,
-      };
-    }
-    return {
-      token: null,
-      next: end + 1,
-    };
-  }
-
-  const raw = html.slice(start + 1, end);
-  return {
-    token: {
-      closing,
-      name: html.slice(nameStart, pos).toLowerCase(),
-      raw,
-      selfClosing: isSelfClosingTagRaw(raw),
-    },
-    next: end + 1,
-  };
 }
 
 function readAttributeValue(rawTag: string, name: string): string | undefined {
@@ -469,24 +244,6 @@ function closeOpenAnchorWithText(stack: RenderContext[], state: { title?: string
     }
   }
   return false;
-}
-
-function closeRawTextTagEnd(html: string, tagName: string, contentStart: number): number {
-  let closeStart = html.indexOf("</", contentStart);
-  while (closeStart !== -1) {
-    if (startsWithClosingTag(html, closeStart, tagName)) {
-      const closeEnd = findTagEnd(html, closeStart).end;
-      return closeEnd === -1 ? html.length : closeEnd + 1;
-    }
-    closeStart = html.indexOf("</", closeStart + 2);
-  }
-  return html.length;
-}
-
-function skipRawTextElement(html: string, start: number, tagName: string): number {
-  const openerEnd = findTagEnd(html, start);
-  const contentStart = openerEnd.end === -1 ? start + tagName.length + 1 : openerEnd.end + 1;
-  return closeRawTextTagEnd(html, tagName, contentStart);
 }
 
 function htmlFragmentToMarkdown(html: string): { text: string; title?: string } {

--- a/src/agents/tools/web-fetch-visibility.ts
+++ b/src/agents/tools/web-fetch-visibility.ts
@@ -7,6 +7,7 @@ import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalLowercaseString,
 } from "@openclaw/normalization-core/string-coerce";
+import { readTagToken } from "./web-fetch-html-tag.js";
 
 // Compile property matchers once: this list is checked for every styled element.
 const HIDDEN_STYLE_PATTERNS = (
@@ -168,84 +169,6 @@ function shouldRemoveElement(tagNameRaw: string, attrs: string): boolean {
   return false;
 }
 
-type HtmlTagToken = {
-  tagName: string;
-  attrs: string;
-  closing: boolean;
-  selfClosing: boolean;
-};
-
-function findTagEnd(html: string, start: number): number {
-  let quote: '"' | "'" | undefined;
-  for (let index = start + 1; index < html.length; index += 1) {
-    const char = html[index];
-    if (quote) {
-      if (char === quote) {
-        quote = undefined;
-      }
-      continue;
-    }
-    if (char === '"' || char === "'") {
-      quote = char;
-      continue;
-    }
-    if (char === ">") {
-      return index;
-    }
-  }
-  return -1;
-}
-
-function readTagName(source: string, start: number): { tagName: string; end: number } | null {
-  let end = start;
-  while (end < source.length) {
-    const code = source.charCodeAt(end);
-    const isNameChar =
-      (code >= 65 && code <= 90) ||
-      (code >= 97 && code <= 122) ||
-      (code >= 48 && code <= 57) ||
-      source[end] === "-" ||
-      source[end] === "_" ||
-      source[end] === ":";
-    if (!isNameChar) {
-      break;
-    }
-    end += 1;
-  }
-  if (end === start) {
-    return null;
-  }
-  return {
-    tagName: normalizeLowercaseStringOrEmpty(source.slice(start, end)),
-    end,
-  };
-}
-
-function parseHtmlTagToken(token: string): HtmlTagToken | null {
-  let inner = token.slice(1, -1).trim();
-  if (!inner || inner.startsWith("!") || inner.startsWith("?")) {
-    return null;
-  }
-
-  const closing = inner.startsWith("/");
-  if (closing) {
-    inner = inner.slice(1).trimStart();
-  }
-
-  const name = readTagName(inner, 0);
-  if (!name) {
-    return null;
-  }
-
-  const attrs = closing ? "" : inner.slice(name.end);
-  return {
-    tagName: name.tagName,
-    attrs,
-    closing,
-    selfClosing: !closing && attrs.trimEnd().endsWith("/"),
-  };
-}
-
 function popDroppedElement(dropStack: string[], tagName: string): void {
   const index = dropStack.lastIndexOf(tagName);
   if (index >= 0) {
@@ -277,44 +200,44 @@ function removeMarkedElements(html: string): string {
       continue;
     }
 
-    const tagEnd = findTagEnd(html, tagStart);
-    if (tagEnd < 0) {
+    const read = readTagToken(html, tagStart, "visibility");
+    if (!read) {
       if (dropStack.length === 0) {
         output += html.slice(tagStart);
       }
       break;
     }
 
-    const token = html.slice(tagStart, tagEnd + 1);
-    const parsed = parseHtmlTagToken(token);
+    const token = html.slice(tagStart, read.next);
+    const parsed = read.token;
     if (!parsed) {
       if (dropStack.length === 0) {
         output += token;
       }
-      cursor = tagEnd + 1;
+      cursor = read.next;
       continue;
     }
 
     if (dropStack.length > 0) {
       if (parsed.closing) {
-        popDroppedElement(dropStack, parsed.tagName);
-      } else if (!parsed.selfClosing && !HTML_VOID_ELEMENTS.has(parsed.tagName)) {
-        dropStack.push(parsed.tagName);
+        popDroppedElement(dropStack, parsed.name);
+      } else if (!parsed.selfClosing && !HTML_VOID_ELEMENTS.has(parsed.name)) {
+        dropStack.push(parsed.name);
       }
-      cursor = tagEnd + 1;
+      cursor = read.next;
       continue;
     }
 
     if (parsed.closing) {
       output += token;
-    } else if (shouldRemoveElement(parsed.tagName, parsed.attrs)) {
-      if (!parsed.selfClosing && !HTML_VOID_ELEMENTS.has(parsed.tagName)) {
-        dropStack.push(parsed.tagName);
+    } else if (shouldRemoveElement(parsed.name, parsed.attrs)) {
+      if (!parsed.selfClosing && !HTML_VOID_ELEMENTS.has(parsed.name)) {
+        dropStack.push(parsed.name);
       }
     } else {
       output += token;
     }
-    cursor = tagEnd + 1;
+    cursor = read.next;
   }
 
   return output;


### PR DESCRIPTION
Closes #141709

## What Problem This Solves

Maintaining `web_fetch` extraction currently requires updating two implementations of tag scanning. Visibility filtering and rendering repeat tag-end detection and name parsing, making it harder to preserve their different malformed-input behavior when either changes.

## Why This Change Was Made

Use one private tag reader with the two existing parsing policies. Remove the visibility module's separate scanner while keeping hidden-subtree handling, renderer contexts and attribute interpretation with their current owners. Quote scanning skips to the matching quote; raw-text searches operate on the supplied span before matches are translated back to original-string offsets.

The complete four-file change removes 63 production code lines and adds 23 test code lines: 40 maintained code lines / 43 physical lines removed net, including the new helper and regression guard. Readability's pre-DOM depth check and the public SDK are unchanged. This is the maintainer-requested consolidation tracked in #141709; it does not overlap #119467's depth-policy change.

## User Impact

No intended change to fetched text, titles, retained HTML, malformed-input recovery or output bounds.

## Evidence

- All 90 focused tests pass: the existing 89 HTML rendering/utilities, visibility/Unicode and real Readability cases, plus one resource-work regression.
- 115,892 exact output comparisons across 28,973 unique synthetic HTML inputs match the pinned baseline for sanitization, direct Markdown rendering and both basic extraction modes. The corpus includes the 33 composed edge cases identified during review.
- The new regression preserves exact rendered output and bounds logical search spans without a timing threshold. It fails the initial PR revision for repeated whole-suffix searches and passes the repaired implementation.
- Scaling checks through direct rendering and basic extraction cover up to 655,378 input units. At that largest synthetic input, direct rendering takes about 778 ms on the initial PR revision, 3.5 ms after the bounded-span repair, and 2.1 ms on original main; outputs match in all three. The repaired measurements grow approximately linearly across the tested sizes. The existing four-case offline `web_fetch` benchmark and large-attribute/malformed-tail measurements also completed; they are local measurements, not a live-network guarantee.
- Fresh P2 review and the complete selected checks pass for repaired commit `ddd5d16a6161145db883c2030f68a3400ff0b4b5`. Exact-head CI and ClawSweeper re-review are required before landing.
