### PR TITLE
fix(gateway): update model availability after expiry or cooldown

### DIFF
--- a/src/gateway/server-methods/chat-metadata-runtime.auth-deadline.test.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.auth-deadline.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test, vi } from "vitest";
+import type { AuthProfileStore } from "../../agents/auth-profiles.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import {
+  createChatMetadataHarness,
+  createChatMetadataOwner,
+} from "./chat-metadata-runtime.test-support.js";
+
+describe("gateway chat metadata auth deadlines", () => {
+  test.each([
+    { at: 19_999, available: true },
+    { at: 20_000, available: false },
+  ])("reads a cached static token at $at without publication", async ({ at, available }) => {
+    const clock = vi.spyOn(Date, "now").mockReturnValue(10_000);
+    const config: OpenClawConfig = {
+      auth: { order: { acme: ["acme:primary"] } },
+      agents: {
+        defaults: { model: { primary: "acme/model" }, models: { "acme/model": {} } },
+        list: [{ id: "main", default: true }],
+      },
+    };
+    const owner = createChatMetadataOwner(
+      config,
+      "model",
+      { acme: { type: "api_key", key: "synthetic-token" } },
+      "acme",
+    );
+    const authStore: AuthProfileStore = {
+      version: 1,
+      profiles: {
+        "acme:primary": {
+          type: "token",
+          provider: "acme",
+          token: "synthetic-token",
+          expires: 20_000,
+        },
+      },
+    };
+    const cached = createChatMetadataHarness(config, { useDefaultProjection: true });
+    const fresh = createChatMetadataHarness(config, { useDefaultProjection: true });
+    for (const harness of [cached, fresh]) {
+      harness.setOwner(owner);
+      harness.setAuthStore(authStore);
+    }
+    try {
+      await cached.runtime.refresh();
+      await expect(cached.runtime.read({ agentId: "main" })).resolves.toMatchObject({
+        models: [{ id: "model", provider: "acme", available: true }],
+      });
+      clock.mockReturnValue(at);
+      await fresh.runtime.refresh();
+      const expected = await fresh.runtime.read({ agentId: "main" });
+      expect(expected).toMatchObject({
+        models: [{ id: "model", provider: "acme", available }],
+      });
+      expect(await cached.runtime.read({ agentId: "main" })).toEqual(expected);
+    } finally {
+      await Promise.all([cached.runtime.stop(), fresh.runtime.stop()]);
+      clock.mockRestore();
+    }
+  });
+
+  test.each([
+    { name: "cooldown end", cooldownUntil: 20_000, at: 20_000, before: false, after: true },
+    { name: "before cooldown end", cooldownUntil: 20_000, at: 19_999, before: false, after: false },
+    { name: "nonexpiring key", cooldownUntil: undefined, at: 20_000, before: true, after: true },
+  ])(
+    "keeps cached metadata current at $name without publication",
+    async ({ cooldownUntil, at, before, after }) => {
+      const clock = vi.spyOn(Date, "now").mockReturnValue(10_000);
+      const config: OpenClawConfig = {
+        auth: { order: { acme: ["acme:primary"] } },
+        agents: {
+          defaults: { model: { primary: "acme/model" }, models: { "acme/model": {} } },
+          list: [{ id: "main", default: true }],
+        },
+      };
+      const owner = createChatMetadataOwner(
+        config,
+        "model",
+        { acme: { type: "api_key", key: "synthetic-key" } },
+        "acme",
+      );
+      const authStore: AuthProfileStore = {
+        version: 1,
+        profiles: { "acme:primary": { type: "api_key", provider: "acme", key: "synthetic-key" } },
+        usageStats: { "acme:primary": { cooldownUntil } },
+      };
+      const cached = createChatMetadataHarness(config, { useDefaultProjection: true });
+      const fresh = createChatMetadataHarness(config, { useDefaultProjection: true });
+      for (const harness of [cached, fresh]) {
+        harness.setOwner(owner);
+        harness.setAuthStore(authStore);
+      }
+      try {
+        await cached.runtime.refresh();
+        await expect(cached.runtime.read({ agentId: "main" })).resolves.toMatchObject({
+          models: [{ id: "model", provider: "acme", available: before }],
+        });
+        cached.getPreparedAuthStore.mockClear();
+        clock.mockReturnValue(at);
+        await fresh.runtime.refresh();
+        const expected = await fresh.runtime.read({ agentId: "main" });
+        expect(expected).toMatchObject({
+          models: [{ id: "model", provider: "acme", available: after }],
+        });
+        expect(await cached.runtime.read({ agentId: "main" })).toEqual(expected);
+        expect(cached.getPreparedAuthStore).not.toHaveBeenCalled();
+        expect(cached.buildCommands).toHaveBeenCalledOnce();
+      } finally {
+        await Promise.all([cached.runtime.stop(), fresh.runtime.stop()]);
+        clock.mockRestore();
+      }
+    },
+  );
+});

--- a/src/gateway/server-methods/models-list-auth-resolver.ts
+++ b/src/gateway/server-methods/models-list-auth-resolver.ts
@@ -227,6 +227,21 @@ export function createModelsListAuthProjection(params: ModelsListAuthProjectionP
     preferredProfilesByProvider.has(normalizeProviderId(entry.provider))
       ? host
       : nativeEvaluator(entry, host);
+  // Store revisions do not advance when a token or failure window expires.
+  // Retire the captured host evaluation so its caller prepares fresh facts.
+  const preparedAt = Date.now();
+  const authValidUntil = Math.min(
+    ...[
+      ...Object.values(authStore.profiles).map((profile) =>
+        profile.type === "token" ? profile.expires : undefined,
+      ),
+      ...Object.values(authStore.usageStats ?? {}).flatMap((stats) => [
+        stats.blockedUntil,
+        stats.cooldownUntil,
+        stats.disabledUntil,
+      ]),
+    ].filter((deadline): deadline is number => deadline !== undefined && deadline > preparedAt),
+  );
   const authResolver = createModelsListAuthResolver({
     cfg: params.cfg,
     agentId: params.agentId,
@@ -267,7 +282,9 @@ export function createModelsListAuthProjection(params: ModelsListAuthProjectionP
     authModes: params.preparedRuntimeAuthModes,
     authMaterializations: params.preparedRuntimeAuthMaterializations,
     pluginRegistry: params.pluginRegistry,
-    isCurrent: params.isCurrent ?? (() => params.observationConfig === undefined),
+    isCurrent: () =>
+      Date.now() < authValidUntil &&
+      (params.isCurrent?.() ?? params.observationConfig === undefined),
     observationConfig: params.observationConfig,
   };
 }

--- a/src/gateway/server-methods/models-list-result.plugin-runtime.test.ts
+++ b/src/gateway/server-methods/models-list-result.plugin-runtime.test.ts
@@ -14,6 +14,7 @@ import { registerGatewayModelCatalogPrivateAccess } from "../server-model-catalo
 import {
   buildModelsListResult,
   createGatewayAgentModelCatalogProjector,
+  prepareModelsListResult,
 } from "./models-list-result.js";
 import { modelsHandlers } from "./models.js";
 import type { GatewayRequestContext } from "./types.js";
@@ -95,12 +96,13 @@ describe("models.list plugin metadata handoff", () => {
         });
         await projector.projectCatalog();
 
+        let currentConfig = cfg;
         const context = {
-          getRuntimeConfig: () => cfg,
+          getRuntimeConfig: () => currentConfig,
           loadGatewayModelCatalogSnapshot: vi.fn(),
           logGateway: { debug: vi.fn() },
         } as unknown as GatewayRequestContext;
-        await buildModelsListResult({
+        const prepared = await prepareModelsListResult({
           context,
           agentId: "main",
           params: { view: "configured" },
@@ -108,9 +110,13 @@ describe("models.list plugin metadata handoff", () => {
           preloadedOnly: true,
           catalogProjector: projector,
         });
+        prepared.read();
         expect(mocks.prepareHarnessCatalog).toHaveBeenCalledWith(
           expect.objectContaining({ allowHarnessDiscovery: false }),
         );
+        expect(prepared.isCurrent()).toBe(true);
+        currentConfig = { ...cfg };
+        expect(prepared.isCurrent()).toBe(false);
       },
     );
   });

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -520,7 +520,7 @@ export async function prepareModelsListResult(
       ...(capableProviders ? { apiKeyCapabilities: capableProviders } : {}),
     });
     return {
-      isCurrent,
+      isCurrent: () => isCurrent() && inventoryProjector.isCurrent(),
       read: () => ({
         models: entries.map(({ entry, host }) => projectPublic(entry, evaluateNative(entry, host))),
         ...outcomeProjection,
@@ -578,7 +578,7 @@ export async function prepareModelsListResult(
     ...(capableProviders ? { apiKeyCapabilities: capableProviders } : {}),
   });
   return {
-    isCurrent,
+    isCurrent: () => isCurrent() && projector.isCurrent(),
     read: () => ({
       models: readCatalog().map((entry) => {
         const evaluation = evaluations.get(evaluationKey(entry));


### PR DESCRIPTION
## What Problem This Solves

Chat model metadata could show stale availability after a token expired or a credential cooldown ended.

## Why This Change Was Made

Bind cached authentication projections to their token and failure-window deadlines so the existing reader rebuilds expired state. Existing config and prepared-state ownership checks remain.

## User Impact

The next metadata read reflects expiry or recovery without another login, credential edit, or restart. No timer or public field is added.

## Evidence

Matched real CLI/Gateway runs with actual clock deadlines reproduced available-after-expiry and unavailable-after-recovery states. The fix matched fresh model-list controls in both cases, and all four instances stopped cleanly. Focused deadline and config checks, formatting, and lint passed. Tests used synthetic credentials and did not cover inference or graphical presentation.
