### PR TITLE
refactor(agents): separate prepared runtime retention

### DIFF
--- a/src/agents/prepared-model-runtime-auth-publication.ts
+++ b/src/agents/prepared-model-runtime-auth-publication.ts
@@ -293,3 +293,35 @@ export class PreparedModelRuntimeAuthPublicationOwner {
     return rejected;
   }
 }
+
+export function invalidatePreparedModelRuntimeOwnersForAuthMutation(
+  owners: Map<string, PreparedModelRuntimeOwner>,
+  normalizedEvent: PreparedModelRuntimeAuthMutation,
+): {
+  invalidatedOwners: PreparedModelRuntimeOwner[];
+  invalidatedConfiguredAgentIds: Set<string>;
+} {
+  const staleError = new Error("prepared model runtime owner is stale after auth mutation");
+  const invalidatedOwners: PreparedModelRuntimeOwner[] = [];
+  const invalidatedConfiguredAgentIds = new Set<string>();
+  for (const owner of owners.values()) {
+    if (
+      !normalizedEvent.affectsInheritedStores &&
+      owner.input.agentDir !== normalizedEvent.agentDir &&
+      owner.input.inheritedAuthDir !== normalizedEvent.agentDir
+    ) {
+      continue;
+    }
+    invalidatedOwners.push(owner);
+    owner.generation += 1;
+    owner.needsRefresh = true;
+    owner.refreshError = staleError;
+    if (normalizedEvent.profileSetChanged) {
+      owner.catalogStale = true;
+    }
+    if (owner.provenance === "configured" && owner.input.agentId) {
+      invalidatedConfiguredAgentIds.add(owner.input.agentId);
+    }
+  }
+  return { invalidatedOwners, invalidatedConfiguredAgentIds };
+}

--- a/src/agents/prepared-model-runtime-lease.ts
+++ b/src/agents/prepared-model-runtime-lease.ts
@@ -12,13 +12,11 @@ import {
   preparedModelRuntimeConfigsMatch,
   publishModelRuntimeSnapshot,
   rebindInputToCommittedConfiguredOwner,
-  retirePreparedModelRuntimeOwnerIfUnused,
   resolveConfiguredOwner,
   resolveConfiguredOwnerPublication,
   type PreparedModelRuntimeInput,
   type PreparedModelRuntimeLease,
   type PreparedModelRuntimeOwner,
-  type PreparedModelRuntimeOwnerRetention,
   type PreparedModelRuntimeReplacement,
   type PreparedModelRuntimeSnapshot,
 } from "./prepared-model-runtime.owner.js";
@@ -26,6 +24,10 @@ import {
   preparedPluginGenerationReusesBase,
   preparedPluginGenerationSupportsSelections,
 } from "./prepared-model-runtime.plugin-generation.js";
+import {
+  retirePreparedModelRuntimeOwnerIfUnused,
+  type PreparedModelRuntimeOwnerRetention,
+} from "./prepared-model-runtime.retention.js";
 import type { PreparedModelRuntimeLeaseOptions } from "./prepared-model-runtime.types.js";
 
 type PreparedModelRuntimeLeaseContext = {

--- a/src/agents/prepared-model-runtime.owner.ts
+++ b/src/agents/prepared-model-runtime.owner.ts
@@ -32,6 +32,7 @@ import {
   PreparedModelRuntimeOwnerNotPublishedError,
   PreparedModelRuntimePublicationSupersededError,
 } from "./prepared-model-runtime.errors.js";
+import { retirePreparedModelRuntimeOwnerIfUnused } from "./prepared-model-runtime.retention.js";
 import type {
   PreparedModelRuntimeBuildStats,
   PreparedModelRuntimeCatalogMode,
@@ -90,61 +91,6 @@ export function prepareModelRuntimeOwner(
     catalogMode,
     provenance,
   });
-}
-
-export function retirePreparedModelRuntimeOwnerIfUnused(
-  owners: Map<string, PreparedModelRuntimeOwner>,
-  key: string,
-  owner: PreparedModelRuntimeOwner,
-  retained = false,
-): void {
-  if (
-    (owner.provenance === "run" || owner.provenance === "ephemeral") &&
-    (owner.admissionCount ?? 0) === 0 &&
-    (owner.leaseCount ?? 0) === 0 &&
-    !retained &&
-    owners.get(key) === owner
-  ) {
-    owners.delete(key);
-  }
-}
-
-export class PreparedModelRuntimeOwnerRetention {
-  readonly #retained = new Map<string, PreparedModelRuntimeOwner>();
-  constructor(private readonly maxSize: number) {}
-
-  clear(owners: Map<string, PreparedModelRuntimeOwner>): void {
-    // Released run owners retire here; active leases retire on release.
-    for (const [key, owner] of this.#retained) {
-      retirePreparedModelRuntimeOwnerIfUnused(owners, key, owner);
-    }
-    this.#retained.clear();
-  }
-
-  has(key: string, owner: PreparedModelRuntimeOwner): boolean {
-    return this.#retained.get(key) === owner;
-  }
-
-  retain(
-    key: string,
-    owner: PreparedModelRuntimeOwner,
-    owners: Map<string, PreparedModelRuntimeOwner>,
-  ): void {
-    if (owner.provenance !== "run") {
-      return;
-    }
-    this.#retained.delete(key);
-    this.#retained.set(key, owner);
-    while (this.#retained.size > this.maxSize) {
-      const oldest = this.#retained.entries().next().value;
-      if (!oldest) {
-        return;
-      }
-      const [oldestKey, oldestOwner] = oldest;
-      this.#retained.delete(oldestKey);
-      retirePreparedModelRuntimeOwnerIfUnused(owners, oldestKey, oldestOwner);
-    }
-  }
 }
 
 export {

--- a/src/agents/prepared-model-runtime.retention.ts
+++ b/src/agents/prepared-model-runtime.retention.ts
@@ -1,0 +1,56 @@
+import type { PreparedModelRuntimeOwner } from "./prepared-model-runtime.types.js";
+
+export function retirePreparedModelRuntimeOwnerIfUnused(
+  owners: Map<string, PreparedModelRuntimeOwner>,
+  key: string,
+  owner: PreparedModelRuntimeOwner,
+  retained = false,
+): void {
+  if (
+    (owner.provenance === "run" || owner.provenance === "ephemeral") &&
+    (owner.admissionCount ?? 0) === 0 &&
+    (owner.leaseCount ?? 0) === 0 &&
+    !retained &&
+    owners.get(key) === owner
+  ) {
+    owners.delete(key);
+  }
+}
+
+export class PreparedModelRuntimeOwnerRetention {
+  readonly #retained = new Map<string, PreparedModelRuntimeOwner>();
+  constructor(private readonly maxSize: number) {}
+
+  clear(owners: Map<string, PreparedModelRuntimeOwner>): void {
+    // Released run owners retire here; active leases retire on release.
+    for (const [key, owner] of this.#retained) {
+      retirePreparedModelRuntimeOwnerIfUnused(owners, key, owner);
+    }
+    this.#retained.clear();
+  }
+
+  has(key: string, owner: PreparedModelRuntimeOwner): boolean {
+    return this.#retained.get(key) === owner;
+  }
+
+  retain(
+    key: string,
+    owner: PreparedModelRuntimeOwner,
+    owners: Map<string, PreparedModelRuntimeOwner>,
+  ): void {
+    if (owner.provenance !== "run") {
+      return;
+    }
+    this.#retained.delete(key);
+    this.#retained.set(key, owner);
+    while (this.#retained.size > this.maxSize) {
+      const oldest = this.#retained.entries().next().value;
+      if (!oldest) {
+        return;
+      }
+      const [oldestKey, oldestOwner] = oldest;
+      this.#retained.delete(oldestKey);
+      retirePreparedModelRuntimeOwnerIfUnused(owners, oldestKey, oldestOwner);
+    }
+  }
+}

--- a/src/agents/prepared-model-runtime.ts
+++ b/src/agents/prepared-model-runtime.ts
@@ -6,6 +6,7 @@ import { registerRuntimeAuthProfileStoreMutationListener } from "./auth-profiles
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import {
   PreparedModelRuntimeAuthPublicationOwner,
+  invalidatePreparedModelRuntimeOwnersForAuthMutation,
   type PreparedModelRuntimeAuthMutation,
 } from "./prepared-model-runtime-auth-publication.js";
 import { acquirePreparedModelRuntimeLeaseFromOwners } from "./prepared-model-runtime-lease.js";
@@ -22,7 +23,6 @@ import {
 } from "./prepared-model-runtime.lifecycle.js";
 import {
   PreparedModelRuntimeOwnerNotPublishedError,
-  PreparedModelRuntimeOwnerRetention,
   PreparedModelRuntimePublicationSupersededError,
   advancePreparedModelRuntimeOwnerConfig,
   prepareModelRuntimeOwner,
@@ -58,6 +58,7 @@ import {
   resolveSafeRefreshAgentIds,
   updateOwnersForScopedRefresh,
 } from "./prepared-model-runtime.refresh-scope.js";
+import { PreparedModelRuntimeOwnerRetention } from "./prepared-model-runtime.retention.js";
 import type {
   PreparedModelRuntimeCatalogMode,
   PreparedModelRuntimeLeaseOptions,
@@ -669,28 +670,8 @@ function invalidateForAuthMutation(event: PreparedModelRuntimeAuthMutation): voi
     ...event,
     agentDir: normalizeOptionalDir(event.agentDir),
   };
-  const staleError = new Error("prepared model runtime owner is stale after auth mutation");
-  const invalidatedOwners: PreparedModelRuntimeOwner[] = [];
-  const invalidatedConfiguredAgentIds = new Set<string>();
-  for (const owner of owners.values()) {
-    if (
-      !normalizedEvent.affectsInheritedStores &&
-      owner.input.agentDir !== normalizedEvent.agentDir &&
-      owner.input.inheritedAuthDir !== normalizedEvent.agentDir
-    ) {
-      continue;
-    }
-    invalidatedOwners.push(owner);
-    owner.generation += 1;
-    owner.needsRefresh = true;
-    owner.refreshError = staleError;
-    if (normalizedEvent.profileSetChanged) {
-      owner.catalogStale = true;
-    }
-    if (owner.provenance === "configured" && owner.input.agentId) {
-      invalidatedConfiguredAgentIds.add(owner.input.agentId);
-    }
-  }
+  const { invalidatedOwners, invalidatedConfiguredAgentIds } =
+    invalidatePreparedModelRuntimeOwnersForAuthMutation(owners, normalizedEvent);
   if (invalidatedOwners.length === 0) {
     // A first owner reads the already-published auth snapshot while it builds. Replaying an earlier
     // mutation would immediately stale that initial generation even though no prior owner existed.


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Prepared-runtime retention and auth invalidation currently sit among publication and lease orchestration. This separates their existing mechanisms so the later resource-ownership change can be reviewed without unrelated code movement.

## Why This Change Was Made

Move the existing retirement predicate and bounded retention class into a small internal module. Move the existing synchronous auth-invalidation block beside auth publication and update its caller. Admission and lease guards, owner identity checks, cache bounds, generation updates, and refresh dispatch ordering remain unchanged.

## User Impact

No user-visible behavior change. This is in-memory prepared-runtime retention, with no SQLite retention, schema, stored-data, configuration, or resource-disposal changes.

## Evidence

- Exact comparison confirms the retirement declarations and auth mutation block are unchanged; all other non-import declarations are unchanged except the synchronous helper call.
- 60 existing owner-selection, reload/auth, and cancelled-admission tests passed in 26.777 seconds.
- Canonical changed checks passed in 537.267 seconds, including production/test types, lint, dead exports, and zero runtime import cycles.
- The new retention module has no runtime imports; auth publication adds no import or initialization dependency. No new full build or performance improvement is claimed.
- Deslop and independent P0–P2 Codex review completed without actionable findings.
