### PR TITLE
refactor(ui): unify profile identity save lifecycle

### DIFF
--- a/ui/src/pages/profile/profile-page.test.ts
+++ b/ui/src/pages/profile/profile-page.test.ts
@@ -89,7 +89,7 @@ function createContext(
   } as unknown as ApplicationContext<RouteId>;
 }
 
-function stubProfileAvatarProcessing() {
+function stubProfileAvatarProcessing(decode = vi.fn<() => Promise<void>>(async () => undefined)) {
   class StubUrl extends URL {
     static override createObjectURL = vi.fn(() => "blob:avatar");
     static override revokeObjectURL = vi.fn();
@@ -99,7 +99,7 @@ function stubProfileAvatarProcessing() {
     src = "";
     naturalWidth = 512;
     naturalHeight = 256;
-    decode = vi.fn(async () => undefined);
+    decode = decode;
   }
   vi.stubGlobal("URL", StubUrl);
   vi.stubGlobal("Image", StubImage);
@@ -682,6 +682,91 @@ it("replaces an in-flight identity request after a same-client reconnect", async
     "Fresh identity",
   );
   expect(selfCalls()).toHaveLength(2);
+});
+
+it.each([
+  { stage: "preprocessing", outcome: "success" },
+  { stage: "preprocessing", outcome: "failure" },
+  { stage: "mutation", outcome: "success" },
+  { stage: "mutation", outcome: "failure" },
+])("retires avatar $stage $outcome without disturbing a newer save", async ({ stage, outcome }) => {
+  let profile = { ...modelAccountProfile };
+  const staleDecode = createDeferred();
+  const staleMutation = createDeferred<{ profile: UserProfile; avatarRevision: string }>();
+  const currentMutation = createDeferred<{ profile: UserProfile; avatarRevision: string }>();
+  const decode = vi.fn<() => Promise<void>>(async () => undefined);
+  if (stage === "preprocessing") {
+    decode.mockImplementationOnce(() => staleDecode.promise);
+  }
+  stubProfileAvatarProcessing(decode);
+  let avatarRequests = 0;
+  const request = vi.fn(async (method: string) => {
+    if (method === "users.self") {
+      return { profile };
+    }
+    if (method === "users.listModelAccounts") {
+      return { profileId: profile.id, accounts: [], links: [] };
+    }
+    if (method === "users.setAvatar") {
+      avatarRequests += 1;
+      return stage === "mutation" && avatarRequests === 1
+        ? staleMutation.promise
+        : currentMutation.promise;
+    }
+    throw new Error(`unexpected method: ${method}`);
+  });
+  const avatarBefore = "/api/users/profile-1/avatar?v=before";
+  const harness = createConnectedContext(request as GatewayBrowserClient["request"], {
+    id: profile.id,
+    name: profile.displayName ?? undefined,
+    avatarUrl: avatarBefore,
+  });
+  const page = mountProfilePage(harness.context);
+  const nameInput = () => page.querySelector<HTMLInputElement>(".identity-name-control input");
+  await waitForFast(() => expect(nameInput()?.disabled).toBe(false));
+  selectProfileAvatar(page);
+  await waitForFast(() =>
+    expect(stage === "preprocessing" ? decode.mock.calls.length : avatarRequests).toBe(1),
+  );
+
+  harness.emitConnected(false);
+  harness.emitConnected(true);
+  await waitForFast(() => expect(nameInput()?.disabled).toBe(false));
+  nameInput()!.value = "Current draft";
+  nameInput()!.dispatchEvent(new Event("input", { bubbles: true }));
+  selectProfileAvatar(page);
+  const expectedAvatarRequests = stage === "preprocessing" ? 1 : 2;
+  await waitForFast(() => expect(avatarRequests).toBe(expectedAvatarRequests));
+
+  if (outcome === "failure") {
+    (stage === "preprocessing" ? staleDecode : staleMutation).reject(new Error("Retired save"));
+  } else if (stage === "preprocessing") {
+    staleDecode.resolve();
+  } else {
+    staleMutation.resolve({
+      profile: { ...profile, displayName: "Retired identity" },
+      avatarRevision: "retired",
+    });
+  }
+  // Settle the retired promise chain while the replacement RPC remains pending.
+  await new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+  await page.updateComplete;
+
+  expect(avatarRequests).toBe(expectedAvatarRequests);
+  expect(nameInput()?.disabled).toBe(true);
+  expect(nameInput()?.value).toBe("Current draft");
+  expect(page.querySelector('[role="alert"]')).toBeNull();
+  expect(harness.context.gateway.snapshot.selfUser?.avatarUrl).toBe(avatarBefore);
+  expect(request.mock.calls.filter(([method]) => method === "users.self")).toHaveLength(2);
+
+  profile = { ...profile, hasAvatar: true, avatarMime: "image/png", updatedAt: 3 };
+  currentMutation.resolve({ profile, avatarRevision: "current" });
+  await waitForFast(() => expect(nameInput()?.disabled).toBe(false));
+  expect(nameInput()?.value).toBe("Current draft");
+  expect(harness.context.gateway.snapshot.selfUser?.avatarUrl).toContain("?v=current");
+  expect(request.mock.calls.filter(([method]) => method === "users.self")).toHaveLength(3);
 });
 
 it("bootstraps and refreshes the connected user's profile through users.self", async () => {

--- a/ui/src/pages/profile/profile-page.ts
+++ b/ui/src/pages/profile/profile-page.ts
@@ -51,6 +51,11 @@ registerModelAccountsEnglish();
 
 const PROFILE_DOCS_URL = "https://docs.openclaw.ai/concepts/user-model";
 
+type IdentityChange =
+  | { kind: "display-name" }
+  | { kind: "avatar"; file: File }
+  | { kind: "git-coauthor"; enabled: boolean };
+
 function toIdentityErrorMessage(error: unknown): string {
   return formatUiError(error, t("profilePage.identity.profileUnavailable"));
 }
@@ -64,7 +69,7 @@ export class ProfilePage extends OpenClawLightDomElement {
   @state() private displayName = "";
   @state() private gitCoauthorEnabled = true;
   @state() private identityLoading = false;
-  @state() private identityBusy: "display-name" | "avatar" | "git-coauthor" | null = null;
+  @state() private identityBusy: IdentityChange["kind"] | null = null;
   @state() private identityError: string | null = null;
   @state() private failedHeroAvatarUrl: string | null = null;
 
@@ -184,94 +189,91 @@ export class ProfilePage extends OpenClawLightDomElement {
     }
   }
 
-  private applyOwnProfile(profile: UserProfile) {
-    this.ownProfile = profile;
-    this.displayName = profile.displayName ?? "";
-  }
-
-  private async saveDisplayName() {
+  private async saveIdentity(change: IdentityChange) {
     const client = this.client;
     const profile = this.ownProfile;
-    if (!client || !profile || !this.canWrite || this.identityBusy || this.identityLoading) {
+    if (
+      !client ||
+      !profile ||
+      !this.canWrite ||
+      this.identityBusy ||
+      this.identityLoading ||
+      (change.kind === "git-coauthor" && !profile.githubIdentity)
+    ) {
       return;
     }
-    this.identityBusy = "display-name";
+    this.identityBusy = change.kind;
     this.identityError = null;
     const identityRequestId = this.identityRequestId;
-    let shouldRefresh = false;
+    const isCurrent = () => client === this.client && identityRequestId === this.identityRequestId;
     try {
-      const displayName = this.displayName.trim() || null;
-      const result = await client.request<UsersSetDisplayNameResult>("users.setDisplayName", {
-        profileId: profile.id,
-        displayName,
-      });
-      if (client !== this.client || identityRequestId !== this.identityRequestId) {
-        return;
+      switch (change.kind) {
+        case "display-name": {
+          const result = await client.request<UsersSetDisplayNameResult>("users.setDisplayName", {
+            profileId: profile.id,
+            displayName: this.displayName.trim() || null,
+          });
+          if (!isCurrent()) {
+            return;
+          }
+          this.ownProfile = result.profile;
+          this.displayName = result.profile.displayName ?? "";
+          this.context.gateway.updateSelfUser?.({ name: result.profile.displayName ?? undefined });
+          break;
+        }
+        case "avatar": {
+          const displayNameDraft = this.displayName;
+          const hasUnsavedDisplayName = displayNameDraft.trim() !== (profile.displayName ?? "");
+          const selfAvatarUrlBefore =
+            this.selfUser?.id === profile.id ? this.selfUser.avatarUrl : undefined;
+          const avatar = await processProfileAvatar(change.file);
+          if (!isCurrent()) {
+            return;
+          }
+          const result = await client.request<UsersSetAvatarResult>("users.setAvatar", {
+            profileId: profile.id,
+            mime: avatar.mime,
+            avatarBase64: avatar.avatarBase64,
+          });
+          if (!isCurrent()) {
+            return;
+          }
+          this.ownProfile = result.profile;
+          this.displayName = hasUnsavedDisplayName
+            ? displayNameDraft
+            : (result.profile.displayName ?? "");
+          const avatarUrl = userProfileAvatarUrl(
+            this.context.gateway.connection.gatewayUrl,
+            result.profile.id,
+            result.avatarRevision,
+            this.context.resourceBasePath,
+          );
+          const presenceAvatarChanged =
+            this.selfUser?.id === result.profile.id &&
+            this.selfUser.avatarUrl !== selfAvatarUrlBefore;
+          if (avatarUrl && !presenceAvatarChanged) {
+            this.context.gateway.updateSelfUser?.({ avatarUrl });
+          }
+          break;
+        }
+        case "git-coauthor": {
+          const result = await client.request<UsersPrefsSetResult>("users.prefs.set", {
+            entries: { [GIT_COAUTHOR_PREFERENCE_KEY]: change.enabled },
+          });
+          if (!isCurrent()) {
+            return;
+          }
+          if (result.status !== "ok") {
+            throw new Error(t("profilePage.identity.profileUnavailable"));
+          }
+          this.gitCoauthorEnabled = change.enabled;
+          return;
+        }
       }
-      this.applyOwnProfile(result.profile);
-      this.context.gateway.updateSelfUser?.({ name: result.profile.displayName ?? undefined });
-      shouldRefresh = true;
     } catch (error) {
-      if (client === this.client && identityRequestId === this.identityRequestId) {
-        this.identityError = toIdentityErrorMessage(error);
-      }
-    } finally {
-      if (identityRequestId === this.identityRequestId && this.identityBusy === "display-name") {
-        this.identityBusy = null;
-      }
-    }
-    if (shouldRefresh && client === this.client && identityRequestId === this.identityRequestId) {
-      void this.loadIdentity();
-    }
-  }
-
-  private async saveAvatar(file: File) {
-    const client = this.client;
-    const profile = this.ownProfile;
-    if (!client || !profile || !this.canWrite || this.identityBusy || this.identityLoading) {
-      return;
-    }
-    this.identityBusy = "avatar";
-    this.identityError = null;
-    const identityRequestId = this.identityRequestId;
-    const displayNameDraft = this.displayName;
-    const hasUnsavedDisplayName = displayNameDraft.trim() !== (profile.displayName ?? "");
-    const selfAvatarUrlBefore =
-      this.selfUser?.id === profile.id ? this.selfUser.avatarUrl : undefined;
-    let shouldRefresh = false;
-    try {
-      const avatar = await processProfileAvatar(file);
-      if (client !== this.client || identityRequestId !== this.identityRequestId) {
-        return;
-      }
-      const result = await client.request<UsersSetAvatarResult>("users.setAvatar", {
-        profileId: profile.id,
-        mime: avatar.mime,
-        avatarBase64: avatar.avatarBase64,
-      });
-      if (client !== this.client || identityRequestId !== this.identityRequestId) {
-        return;
-      }
-      this.ownProfile = result.profile;
-      this.displayName = hasUnsavedDisplayName
-        ? displayNameDraft
-        : (result.profile.displayName ?? "");
-      const avatarUrl = userProfileAvatarUrl(
-        this.context.gateway.connection.gatewayUrl,
-        result.profile.id,
-        result.avatarRevision,
-        this.context.resourceBasePath,
-      );
-      const presenceAvatarChanged =
-        this.selfUser?.id === result.profile.id && this.selfUser.avatarUrl !== selfAvatarUrlBefore;
-      if (avatarUrl && !presenceAvatarChanged) {
-        this.context.gateway.updateSelfUser?.({ avatarUrl });
-      }
-      shouldRefresh = true;
-    } catch (error) {
-      if (client === this.client && identityRequestId === this.identityRequestId) {
+      if (isCurrent()) {
         this.identityError =
-          error instanceof ProfileAvatarError
+          change.kind === "avatar" && error instanceof ProfileAvatarError
             ? t(
                 error.code === "too-large"
                   ? "profilePage.identity.avatarErrors.tooLarge"
@@ -281,50 +283,14 @@ export class ProfilePage extends OpenClawLightDomElement {
               )
             : toIdentityErrorMessage(error);
       }
-    } finally {
-      if (identityRequestId === this.identityRequestId && this.identityBusy === "avatar") {
-        this.identityBusy = null;
-      }
-    }
-    if (shouldRefresh && client === this.client && identityRequestId === this.identityRequestId) {
-      void this.loadIdentity();
-    }
-  }
-
-  private async saveGitCoauthorPreference(enabled: boolean) {
-    const client = this.client;
-    const profile = this.ownProfile;
-    if (
-      !client ||
-      !profile?.githubIdentity ||
-      !this.canWrite ||
-      this.identityBusy ||
-      this.identityLoading
-    ) {
       return;
-    }
-    this.identityBusy = "git-coauthor";
-    this.identityError = null;
-    const identityRequestId = this.identityRequestId;
-    try {
-      const result = await client.request<UsersPrefsSetResult>("users.prefs.set", {
-        entries: { [GIT_COAUTHOR_PREFERENCE_KEY]: enabled },
-      });
-      if (client !== this.client || identityRequestId !== this.identityRequestId) {
-        return;
-      }
-      if (result.status !== "ok") {
-        throw new Error(t("profilePage.identity.profileUnavailable"));
-      }
-      this.gitCoauthorEnabled = enabled;
-    } catch (error) {
-      if (client === this.client && identityRequestId === this.identityRequestId) {
-        this.identityError = toIdentityErrorMessage(error);
-      }
     } finally {
-      if (identityRequestId === this.identityRequestId && this.identityBusy === "git-coauthor") {
+      if (isCurrent() && this.identityBusy === change.kind) {
         this.identityBusy = null;
       }
+    }
+    if (isCurrent()) {
+      void this.loadIdentity();
     }
   }
 
@@ -378,9 +344,9 @@ export class ProfilePage extends OpenClawLightDomElement {
       onDisplayNameInput: (value) => {
         this.displayName = value;
       },
-      onSaveDisplayName: () => void this.saveDisplayName(),
-      onAvatarSelect: (file) => void this.saveAvatar(file),
-      onGitCoauthorChange: (enabled) => void this.saveGitCoauthorPreference(enabled),
+      onSaveDisplayName: () => void this.saveIdentity({ kind: "display-name" }),
+      onAvatarSelect: (file) => void this.saveIdentity({ kind: "avatar", file }),
+      onGitCoauthorChange: (enabled) => void this.saveIdentity({ kind: "git-coauthor", enabled }),
     });
   }
 


### PR DESCRIPTION
Closes #141729

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

Related: #140225

## What Problem This Solves

Settings → Profile → Identity has separate save routines for display names, avatars and Git coauthor credit. They repeat admission, request-generation checks, busy/error cleanup and refresh handling, making the same lifecycle contract harder to maintain consistently. This maintainer-requested refactor gives those steps one private owner.

## Why This Change Was Made

A discriminated `saveIdentity` routine shares the lifecycle while keeping each operation's RPC and state updates explicit. The three old save methods and the single-use profile-application wrapper are removed, reducing production code by 34 lines.

Avatar processing still checks that the request is current before dispatch and after the RPC. Name drafts, newer presence-avatar revisions, GitHub eligibility and coauthor status validation retain their existing behavior. Successful name/avatar saves refresh after clearing busy state; failed, stale and coauthor saves do not refresh.

## User Impact

No intended change to Profile behavior or appearance. Reconnection, identity changes and loss of write access continue to retire old work without allowing it to disturb a newer save. No schema, defaults, storage semantics, migrations, Gateway handlers or RPC contracts change.

## Evidence

- Four new DOM-driven cases cover stale avatar preprocessing and RPC success/failure after reconnecting with the same client while a newer upload remains pending. All four passed on the original implementation; these are preservation tests, not a newly reproduced bug fix. The original owner suite passed 22 tests.
- Final focused owner and sibling suites passed all 34 tests. The final changed-code gate, formatting/whitespace checks and independent P0–P2 review passed. An initial test-only Promise-executor lint error was corrected before the final unit, gate and review runs.
- All nine existing Profile browser scenarios passed on the candidate using a mocked Gateway. The selected avatar-revision scenario also passed before the refactor. This is Control UI browser-boundary proof with synthetic responses, not a live Gateway or provider run.
- The inspected synthetic before/after avatar-processing captures are byte-identical and show the preserved disabled-upload state. No real account data appears in them.

Tests grow by 85 lines; no production test seam or compatibility path is added.

![Before: preserved disabled avatar processing state (synthetic mocked Gateway)](https://github.com/user-attachments/assets/99070cd9-03e0-4f9b-bd0c-ad7e9c54e238)

![After: preserved disabled avatar processing state (synthetic mocked Gateway)](https://github.com/user-attachments/assets/2630cab1-98dd-4b4c-93c1-acabc35adda3)

Maintainer review disposition: this is a maintainer-authored and reviewed private UI lifecycle consolidation. The completed review finds no introduced correctness or security defect; its two remaining boxes repeat a contributor real-setup request. The 34 focused tests and nine mocked-Gateway browser flows cover the changed lifecycle, with inspected synthetic captures documenting preserved controls. RPC parameters, Gateway handlers, authorization, stored data, defaults, and migration behavior are unchanged. A live Gateway recording is not part of this proof; the accepted scope is the Control UI browser boundary. Required CI and native completed-review gates remain in force.
