### PR TITLE
fix(agents): preserve shared history and deletion retries

### DIFF
--- a/docs/cli/agents.md
+++ b/docs/cli/agents.md
@@ -76,9 +76,12 @@ Options: `--force`, `--json`.
 - The only configured agent cannot be deleted.
 - Without `--force`, interactive confirmation is required (fails in a non-TTY session; re-run with `--force`).
 - Workspace, agent state, and session transcript directories move to Trash, not hard-deleted. If Trash is unavailable, agent config deletion still succeeds and reports paths requiring manual cleanup; `--json` exposes path outcomes in `removed` and `failed` arrays.
+- If session-store cleanup fails, the agent is removed from config but its files and pending cleanup are retained. Resolve the reported storage error, then retry the same deletion command; `--json` reports `purgeFailed: true` until the purge succeeds.
 - On installations that have not migrated shared auth yet, the legacy owner cannot be deleted. Run `openclaw doctor --fix`; after relocation into shared state SQLite, `main` follows the same deletion rules as any other agent.
+- An agent that owns a session database still used by another configured agent cannot be deleted, even when retaining files. Keep that owner configured; moving shared history to another owner requires a supported migration, which is not currently available.
 - When the Gateway is reachable, deletion routes through the Gateway so config and session-store cleanup share the same writer as runtime traffic. If the Gateway is unreachable, the CLI falls back to the offline local path and removes the agent's scheduled jobs transactionally. If Gateway credentials are unavailable before the CLI can test reachability, deletion still falls back locally but warns that cron cleanup was skipped because a live scheduler may own the store.
 - If another agent's workspace is the same path, inside this workspace, or contains this workspace, the workspace is retained, and `--json` reports `workspaceRetained`, `workspaceRetainedReason`, and `workspaceSharedWith`.
+- Cleanup also retains directories containing another agent's registered database, so deleting a parent directory cannot discard the survivor's history.
 
 ## Routing bindings
 

--- a/src/agents/agent-create.integration.test.ts
+++ b/src/agents/agent-create.integration.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it, vi } from "vitest";
@@ -20,21 +21,27 @@ import {
   releaseAgentRunDelegatedAuthority,
   validateAgentRunDelegatedAuthority,
 } from "../infra/agent-run-registry.js";
-import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
+import {
+  beginAgentDeletionJournal,
+  completeAgentDeletionJournalInDatabase,
+  readAgentDeletionJournal,
+} from "../state/agent-deletion-journal.js";
 import { readAgentProvenance } from "../state/agent-provenance.js";
 import { writeConfigMachineState } from "../state/config-machine-state-write.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { executeSystemAgentOperation } from "../system-agent/operations-execute.js";
 import { createSystemAgentTestRuntime } from "../system-agent/system-agent.runtime.test-support.js";
 import { nodeFilePath } from "../test-utils/node-file-path.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { createAgent } from "./agent-create.js";
-import { beginAgentDeletion } from "./agent-lifecycle-registry.js";
 import { resolveSharedAuthStorePath } from "./auth-profiles/path-resolve.js";
 import { resolveAuthProfileDatabasePath } from "./auth-profiles/sqlite.js";
 import { readWorkspaceStateSnapshot } from "./workspace-state-store.js";
@@ -208,14 +215,17 @@ it("finishes creation bookkeeping when delegated authority closes after successf
     runId: "published",
   });
   const workspace = state.path("published-workspace");
-  const deletion = beginAgentDeletion({
+  const deletion = beginAgentDeletionJournal({
     agentId: "published",
+    operationId: randomUUID(),
     agentDir: state.agentDir("published"),
     workspaceDir: workspace,
     sessionsDir: state.sessionsDir("published"),
     deleteFiles: false,
   });
-  deletion.finish();
+  runOpenClawStateWriteTransaction((database) =>
+    completeAgentDeletionJournalInDatabase(database, deletion.agentId, deletion.operationId),
+  );
   const rollback = vi.fn();
   try {
     const created = await createAgent({
@@ -242,7 +252,6 @@ it("finishes creation bookkeeping when delegated authority closes after successf
     expect(readAgentProvenance("published")).toMatchObject({ createdVia: "operator" });
     expect(rollback).not.toHaveBeenCalled();
   } finally {
-    deletion.rollback();
     releaseAgentRunDelegatedAuthority(authority);
     closeOpenClawStateDatabaseForTest();
     await state.cleanup();

--- a/src/agents/agent-delete-databases.ts
+++ b/src/agents/agent-delete-databases.ts
@@ -1,4 +1,7 @@
 import path from "node:path";
+import { resolveSessionStoreCompatibilityAgentId } from "../config/legacy.default-agent-owner.js";
+import { resolveSessionStorePathCore } from "../config/sessions/paths.js";
+import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isPathInside } from "../infra/path-guards.js";
 import { resolveSqliteDatabaseFilePaths } from "../infra/sqlite-files.js";
@@ -7,7 +10,9 @@ import { assertNoOpenClawAgentDatabaseLeases } from "../state/openclaw-agent-db-
 import { invalidateRegisteredAgentDatabasesMemo } from "../state/openclaw-agent-db-registry-listing.js";
 import {
   closeOpenClawAgentDatabaseByPath,
+  inspectOpenClawAgentDatabaseOwner,
   listOpenClawRegisteredAgentDatabases,
+  resolveIncognitoOpenClawAgentSqlitePath,
   resolveOpenClawAgentSqlitePath,
 } from "../state/openclaw-agent-db.js";
 import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
@@ -16,6 +21,7 @@ import {
   isPathOwnedByAnotherRegisteredAgent,
   normalizeAgentDirRegistryPath,
 } from "./agent-dir-registry.js";
+import { listAgentIds } from "./agent-scope.js";
 
 export type AgentDeleteDatabasePlan = {
   registrationPaths: string[];
@@ -30,6 +36,43 @@ export function readAgentDeleteDatabaseRegistry(options: OpenClawStateDatabaseOp
     ...options,
     includeIncompatibleSchemaVersions: true,
   });
+}
+
+export class AgentSharedStoreOwnerError extends Error {}
+
+/** Check before journaling: retaining the file alone would still fence its shared owner. */
+export function assertAgentSessionStoreDeletionSafe(
+  cfg: OpenClawConfig,
+  agentId: string,
+  options: OpenClawStateDatabaseOptions = {},
+): void {
+  if (!cfg.session?.store?.trim()) {
+    return;
+  }
+  const id = normalizeAgentId(agentId);
+  const defaultAgentId = resolveSessionStoreCompatibilityAgentId(cfg);
+  const registeredDatabases = readAgentDeleteDatabaseRegistry(options);
+  for (const survivorId of listAgentIds(cfg)) {
+    if (normalizeAgentId(survivorId) === id) {
+      continue;
+    }
+    const storePath = resolveSessionStorePathCore(cfg.session.store, {
+      agentId: survivorId,
+      env: options.env,
+    });
+    const target = resolveSqliteTargetFromSessionStorePath(storePath, {
+      agentId: survivorId,
+      defaultAgentId,
+      env: options.env,
+      registeredDatabases,
+    });
+    const owner = inspectOpenClawAgentDatabaseOwner(target.path);
+    if (owner.status === "owned" && owner.agentId === id) {
+      throw new AgentSharedStoreOwnerError(
+        `Agent "${id}" owns the session database still used by agent "${survivorId}" and cannot be deleted. Keep this owner configured until shared history can be moved with a supported migration; no such migration is currently available.`,
+      );
+    }
+  }
 }
 
 export function resolveSurvivingDatabaseFilePaths(
@@ -94,6 +137,11 @@ export function prepareAgentDeleteDatabases(
   for (const databasePath of registeredDatabasePaths) {
     closeOpenClawAgentDatabaseByPath(databasePath, agentId);
   }
+  // Incognito has no registry row or files, but retained statements must also be retired.
+  closeOpenClawAgentDatabaseByPath(
+    resolveIncognitoOpenClawAgentSqlitePath({ agentId, env: options.env }),
+    agentId,
+  );
   const databasePaths = [...registeredDatabasePaths].filter((pathname) =>
     resolveSqliteDatabaseFilePaths(pathname).every(
       (filePath) =>

--- a/src/agents/agent-delete-safety.test.ts
+++ b/src/agents/agent-delete-safety.test.ts
@@ -3,7 +3,37 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
+import { withStateDirEnv } from "../test-helpers/state-dir-env.js";
+import { assertAgentSessionStoreDeletionSafe } from "./agent-delete-databases.js";
 import { findOverlappingWorkspaceAgentIds, isSharedAuthStoreOwner } from "./agent-delete-safety.js";
+
+describe("shared session store deletion safety", () => {
+  it.each(["absent", "survivor-owned", "per-agent"])(
+    "allows deletion with an %s session store",
+    async (kind) => {
+      await withStateDirEnv("openclaw-agent-delete-session-owner-", async ({ stateDir }) => {
+        const sharedPath = path.join(stateDir, "shared.sqlite");
+        const cfg: OpenClawConfig = {
+          agents: { ownership: "explicit", entries: { alpha: {}, ops: {} } },
+          session: {
+            store:
+              kind === "per-agent"
+                ? path.join(stateDir, "agents", "{agentId}", "agent", "openclaw-agent.sqlite")
+                : sharedPath,
+          },
+        };
+        if (kind === "survivor-owned") {
+          openOpenClawAgentDatabase({ agentId: "ops", path: sharedPath });
+        } else if (kind === "per-agent") {
+          openOpenClawAgentDatabase({ agentId: "alpha" });
+        }
+
+        expect(() => assertAgentSessionStoreDeletionSafe(cfg, "alpha")).not.toThrow();
+      });
+    },
+  );
+});
 
 describe("shared auth store deletion safety", () => {
   const sharedAuthDbPath = path.join(os.tmpdir(), "shared-auth", "openclaw-agent.sqlite");

--- a/src/agents/agent-lifecycle-registry.test.ts
+++ b/src/agents/agent-lifecycle-registry.test.ts
@@ -7,13 +7,16 @@ import {
   readAgentDeletionJournal,
 } from "../state/agent-deletion-journal.js";
 import { readAgentProvenance, recordAgentProvenance } from "../state/agent-provenance.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import {
-  beginAgentDeletion,
+  closeOpenClawStateDatabaseForTest,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
+import {
   captureAgentLifecycleBinding,
   claimCompletedAgentDeletion,
   isAgentDeletionBlocked,
   matchesAgentLifecycleBinding,
+  withAgentDeletion,
 } from "./agent-lifecycle-registry.js";
 
 const tempDirs: string[] = [];
@@ -65,65 +68,85 @@ describe("agent lifecycle registry", () => {
     });
   });
 
-  it("refuses capture and matching while deletion owns the agent id", () => {
+  it("refuses capture and matching until deletion rolls back before roster commit", async () => {
     const options = createOptions();
     const config = { agents: { entries: { main: {} } } };
     recordAgentProvenance("main", { createdVia: "operator" }, options);
     const binding = captureAgentLifecycleBinding(config, "main", options);
-    const deletion = beginAgentDeletion(createEntry("main"), options);
-
-    expect(captureAgentLifecycleBinding(config, "main", options)).toBeUndefined();
-    expect(binding && matchesAgentLifecycleBinding(config, binding, options)).toBe(false);
-    deletion.rollback();
-    expect(binding && matchesAgentLifecycleBinding(config, binding, options)).toBe(true);
+    await withAgentDeletion(
+      "main",
+      async (begin) => {
+        const deletion = begin(createEntry("main"));
+        expect(captureAgentLifecycleBinding(config, "main", options)).toBeUndefined();
+        expect(binding && matchesAgentLifecycleBinding(config, binding, options)).toBe(false);
+        deletion.rollback();
+        expect(readAgentDeletionJournal("main", options)).toBeUndefined();
+        expect(binding && matchesAgentLifecycleBinding(config, binding, options)).toBe(true);
+      },
+      options,
+    );
   });
 
-  it("removes only the completing operation's provenance and keeps partial cleanup fenced", () => {
+  it("removes only the completing operation's provenance and keeps partial cleanup fenced", async () => {
     const options = createOptions();
     const config = { agents: { entries: { main: {}, kept: {} } } };
     recordAgentProvenance("main", { createdVia: "claw" }, { ...options, nowMs: 1 });
     recordAgentProvenance("kept", { createdVia: "operator" }, options);
     const before = readAgentProvenance("main", options);
     const binding = captureAgentLifecycleBinding(config, "main", options);
-    const first = beginAgentDeletion(createEntry("main"), options);
+    const first = await withAgentDeletion(
+      "main",
+      async (begin) => begin(createEntry("main")),
+      options,
+    );
 
     expect(readAgentProvenance("main", options)).toEqual(before);
     expect(isAgentDeletionBlocked("main", options)).toBe(true);
     expect(binding && matchesAgentLifecycleBinding(config, binding, options)).toBe(false);
     expect(captureAgentLifecycleBinding(config, "main", options)).toBeUndefined();
 
-    const recovery = beginAgentDeletion(createEntry("main"), options);
-    first.finish();
-    expect(readAgentProvenance("main", options)).toEqual(before);
-    recovery.finish();
+    const recovery = await withAgentDeletion(
+      "main",
+      async (begin) => {
+        const deletion = begin(createEntry("main"));
+        expect(() => first.finish()).toThrow("no longer owns");
+        expect(readAgentProvenance("main", options)).toEqual(before);
+        runOpenClawStateWriteTransaction(deletion.completeInTransaction, options);
+        return deletion;
+      },
+      options,
+    );
     expect(readAgentProvenance("main", options)).toBeUndefined();
     expect(readAgentProvenance("kept", options)?.createdVia).toBe("operator");
 
     expect(claimCompletedAgentDeletion("main", recovery.entry.operationId, options)).toBe(true);
     recordAgentProvenance("main", { createdVia: "operator" }, { ...options, nowMs: 2 });
-    first.finish();
-    recovery.finish();
+    expect(() => first.finish()).toThrow("no longer owns");
+    expect(() => recovery.finish()).toThrow("no longer owns");
     expect(readAgentProvenance("main", options)?.createdAtMs).toBe(2);
     expect(binding && matchesAgentLifecycleBinding(config, binding, options)).toBe(false);
   });
 
-  it("keeps a completed deletion fenced until recreation claims cleanup", () => {
+  it("keeps a completed deletion fenced until recreation claims cleanup", async () => {
     const options = createOptions();
-    const deletion = beginAgentDeletion(createEntry("Recreated-Agent"), options);
-
-    expect(isAgentDeletionBlocked("recreated-agent", options)).toBe(true);
-    expect(readAgentDeletionJournal("RECREATED-AGENT", options)).toMatchObject({
-      agentId: "recreated-agent",
-      agentDir: "/agents/Recreated-Agent",
-    });
-    expect(isAgentDeletionBlocked("RECREATED-AGENT", options)).toBe(true);
-
-    deletion.finish();
+    const deletion = await withAgentDeletion(
+      "Recreated-Agent",
+      async (begin) => {
+        const operation = begin(createEntry("Recreated-Agent"));
+        expect(isAgentDeletionBlocked("recreated-agent", options)).toBe(true);
+        expect(readAgentDeletionJournal("RECREATED-AGENT", options)).toMatchObject({
+          agentId: "recreated-agent",
+          agentDir: "/agents/Recreated-Agent",
+        });
+        operation.finish();
+        return operation;
+      },
+      options,
+    );
     expect(readAgentDeletionJournal("recreated-agent", options)).toMatchObject({
       cleanupCompleted: true,
     });
     expect(isAgentDeletionBlocked("recreated-agent", options)).toBe(true);
-
     expect(
       claimCompletedAgentDeletion("recreated-agent", deletion.entry.operationId, options),
     ).toBe(true);
@@ -131,18 +154,8 @@ describe("agent lifecycle registry", () => {
     expect(isAgentDeletionBlocked("recreated-agent", options)).toBe(false);
   });
 
-  it("releases the durable fence when deletion rolls back before roster commit", () => {
+  it("retains pre-resolved cleanup targets when recovery claims the journal", async () => {
     const options = createOptions();
-    const deletion = beginAgentDeletion(createEntry("rollback-agent"), options);
-    deletion.rollback();
-
-    expect(readAgentDeletionJournal("rollback-agent", options)).toBeUndefined();
-    expect(isAgentDeletionBlocked("rollback-agent", options)).toBe(false);
-  });
-
-  it("retains pre-resolved cleanup targets when recovery claims the journal", () => {
-    const options = createOptions();
-    const first = beginAgentDeletion(createEntry("cleanup-recovery-agent"), options);
     const cleanupPaths = [
       {
         path: "/real/workspace",
@@ -167,59 +180,90 @@ describe("agent lifecycle registry", () => {
         done: false,
       },
     ];
-    first.fenceCleanupPaths(cleanupPaths);
-
-    const recovery = beginAgentDeletion(createEntry("cleanup-recovery-agent"), options);
-
-    expect(recovery.entry.cleanupPaths).toEqual(cleanupPaths);
-    expect(readAgentDeletionJournal("cleanup-recovery-agent", options)?.cleanupPaths).toEqual(
-      cleanupPaths,
+    await withAgentDeletion(
+      "cleanup-recovery-agent",
+      async (begin) => {
+        begin(createEntry("cleanup-recovery-agent")).fenceCleanupPaths(cleanupPaths);
+      },
+      options,
     );
-    recovery.rollback();
+    await withAgentDeletion(
+      "cleanup-recovery-agent",
+      async (begin) => {
+        const recovery = begin(createEntry("cleanup-recovery-agent"));
+        expect(recovery.entry.cleanupPaths).toEqual(cleanupPaths);
+        expect(readAgentDeletionJournal("cleanup-recovery-agent", options)?.cleanupPaths).toEqual(
+          cleanupPaths,
+        );
+        recovery.rollback();
+      },
+      options,
+    );
   });
 
-  it("does not let a stale operation clear a journal claimed by recovery", () => {
-    const options = createOptions();
-    const first = beginAgentDeletion(createEntry("claimed-agent"), options);
-    const recovery = beginAgentDeletion(createEntry("claimed-agent"), options);
-
-    first.finish();
-    expect(readAgentDeletionJournal("claimed-agent", options)?.operationId).toBe(
-      recovery.entry.operationId,
-    );
-    expect(isAgentDeletionBlocked("claimed-agent", options)).toBe(true);
-
-    recovery.finish();
-    expect(isAgentDeletionBlocked("claimed-agent", options)).toBe(true);
-    expect(claimCompletedAgentDeletion("claimed-agent", recovery.entry.operationId, options)).toBe(
-      true,
-    );
-    expect(isAgentDeletionBlocked("claimed-agent", options)).toBe(false);
-  });
-
-  it("lets recovery roll back after a stale operation also tries to roll back", () => {
-    const options = createOptions();
-    const first = beginAgentDeletion(createEntry("rollback-claimed-agent"), options);
-    const recovery = beginAgentDeletion(createEntry("rollback-claimed-agent"), options);
-
-    first.rollback();
-    expect(isAgentDeletionBlocked("rollback-claimed-agent", options)).toBe(true);
-    recovery.rollback();
-    expect(isAgentDeletionBlocked("rollback-claimed-agent", options)).toBe(false);
-  });
-
-  it("observes a tombstone claimed outside the lifecycle wrapper", () => {
-    const options = createOptions();
-    const deletion = beginAgentDeletion(createEntry("cross-process-agent"), options);
-    deletion.finish();
-
-    expect(
-      claimCompletedAgentDeletionJournal(
-        "cross-process-agent",
-        deletion.entry.operationId,
+  it.each(["finish", "rollback"] as const)(
+    "rejects stale %s after recovery claims the journal",
+    async (action) => {
+      const options = createOptions();
+      const first = await withAgentDeletion(
+        "claimed-agent",
+        async (begin) => begin(createEntry("claimed-agent")),
         options,
-      ),
-    ).toBe(true);
-    expect(isAgentDeletionBlocked("cross-process-agent", options)).toBe(false);
+      );
+      await withAgentDeletion(
+        "claimed-agent",
+        async (begin) => {
+          const recovery = begin(createEntry("claimed-agent"));
+          expect(() => first[action]()).toThrow("no longer owns");
+          expect(readAgentDeletionJournal("claimed-agent", options)?.operationId).toBe(
+            recovery.entry.operationId,
+          );
+          expect(isAgentDeletionBlocked("claimed-agent", options)).toBe(true);
+          recovery[action]();
+          if (action === "finish") {
+            expect(
+              claimCompletedAgentDeletion("claimed-agent", recovery.entry.operationId, options),
+            ).toBe(true);
+          }
+          expect(isAgentDeletionBlocked("claimed-agent", options)).toBe(false);
+        },
+        options,
+      );
+    },
+  );
+
+  it("allows refusal without a journal and revokes retained admission after settlement", async () => {
+    const options = createOptions();
+    const retained = await withAgentDeletion("main", async (begin) => begin, options);
+    expect(readAgentDeletionJournal("main", options)).toBeUndefined();
+    expect(() => retained(createEntry("main"))).toThrow("already began or has a different target");
+    await withAgentDeletion(
+      "main",
+      async (begin) => {
+        const deletion = begin(createEntry("main"));
+        expect(() => begin(createEntry("main"))).toThrow("already began or has a different target");
+        deletion.rollback();
+      },
+      options,
+    );
+  });
+  it("observes a tombstone claimed outside the lifecycle wrapper", async () => {
+    const options = createOptions();
+    await withAgentDeletion(
+      "cross-process-agent",
+      async (begin) => {
+        const deletion = begin(createEntry("cross-process-agent"));
+        deletion.finish();
+        expect(
+          claimCompletedAgentDeletionJournal(
+            "cross-process-agent",
+            deletion.entry.operationId,
+            options,
+          ),
+        ).toBe(true);
+        expect(isAgentDeletionBlocked("cross-process-agent", options)).toBe(false);
+      },
+      options,
+    );
   });
 });

--- a/src/agents/agent-lifecycle-registry.ts
+++ b/src/agents/agent-lifecycle-registry.ts
@@ -2,13 +2,15 @@ import crypto from "node:crypto";
 import path from "node:path";
 import { isDeepStrictEqual } from "node:util";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAgentId } from "../routing/session-key.js";
 import { createAgentDeletionDatabaseCleanup } from "../state/agent-deletion-cleanup.js";
 import {
   beginAgentDeletionJournal,
   claimCompletedAgentDeletionJournal,
-  completeAgentDeletionJournal,
+  completeAgentDeletionJournalInDatabase,
   readAgentDeletionJournal,
+  readAgentDeletionJournalInDatabase,
   removeAgentDeletionJournal,
   updateAgentDeletionJournalDatabasePaths,
   updateAgentDeletionJournalCleanupPaths,
@@ -17,8 +19,13 @@ import {
 } from "../state/agent-deletion-journal.js";
 import { readAgentProvenance, type AgentProvenance } from "../state/agent-provenance.js";
 import { assertNoOpenClawAgentDatabaseLeases } from "../state/openclaw-agent-db-lease.js";
-import type { OpenClawStateDatabaseOptions } from "../state/openclaw-state-db-contract.js";
+import type {
+  OpenClawStateDatabase,
+  OpenClawStateDatabaseOptions,
+} from "../state/openclaw-state-db-contract.js";
+import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
+import { withOpenClawStateLease } from "../state/openclaw-state-lease.js";
 import { resolveAgentConfig } from "./agent-scope-config.js";
 
 export class AgentDeletionAuthorityRollbackError extends AggregateError {}
@@ -34,98 +41,187 @@ export type AgentLifecycleBinding = Readonly<{
   provenance: AgentProvenance | null;
 }>;
 
-/** Fence authority producers while an agent deletion is pending or committed. */
-export function beginAgentDeletion(
-  entry: Omit<
-    AgentDeletionJournalEntry,
-    | "createdAt"
-    | "operationId"
-    | "cleanupCompleted"
-    | "databasePaths"
-    | "cleanupPaths"
-    | "deleteFiles"
-  > & {
-    databasePaths?: string[];
-    cleanupPaths?: AgentDeletionJournalCleanupPath[];
-    deleteFiles?: boolean;
-  },
-  options: OpenClawStateDatabaseOptions = {},
-): {
+type AgentDeletionInput = Omit<
+  AgentDeletionJournalEntry,
+  | "createdAt"
+  | "operationId"
+  | "cleanupCompleted"
+  | "databasePaths"
+  | "cleanupPaths"
+  | "deleteFiles"
+> & {
+  databasePaths?: string[];
+  cleanupPaths?: AgentDeletionJournalCleanupPath[];
+  deleteFiles?: boolean;
+};
+
+export type AgentDeletionOperation = {
   entry: AgentDeletionJournalEntry;
+  assertCurrent: (database?: OpenClawStateDatabase) => void;
+  runDatabaseCleanup: ReturnType<typeof createAgentDeletionDatabaseCleanup>;
   fenceDatabasePaths: (paths: readonly string[]) => void;
   fenceCleanupPaths: (paths: readonly AgentDeletionJournalCleanupPath[]) => void;
   finish: () => void;
+  completeInTransaction: (database: OpenClawStateDatabase) => void;
   rollback: () => void;
-  runDatabaseCleanup: ReturnType<typeof createAgentDeletionDatabaseCleanup>;
-} {
-  const id = normalizeAgentId(entry.agentId);
+};
+
+const log = createSubsystemLogger("agents/lifecycle");
+
+/** Acquire before the config lock and retain ownership through cleanup and recovery. */
+export function withAgentDeletion<T>(
+  agentId: string,
+  run: (begin: (entry: AgentDeletionInput) => AgentDeletionOperation) => Promise<T>,
+  options: OpenClawStateDatabaseOptions = {},
+): Promise<T> {
+  const id = normalizeAgentId(agentId);
   const statePath = path.resolve(
     options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env),
   );
-  const stateOptions = { ...options, path: statePath, env: options.env && { ...options.env } };
-  const operationId = crypto.randomUUID();
-  const journal = beginAgentDeletionJournal(
-    { ...entry, agentId: id, operationId, deleteFiles: entry.deleteFiles !== false },
-    stateOptions,
+  const stateOptions = { ...options, path: statePath, env: { ...(options.env ?? process.env) } };
+  return withOpenClawStateLease(
+    {
+      scope: "core:agent-deletion",
+      key: id,
+      database: { scope: "shared", options: stateOptions },
+      leaseMs: 60_000,
+      waitMs: 5_000,
+      // SQLite cleanup can block the event loop beyond the lease duration.
+      heartbeat: "worker",
+      leaseLabel: "agent deletion",
+      operationLabel: "agent.deletion.lease",
+    },
+    async (lease) => {
+      let begun = false;
+      let closed = false;
+      try {
+        return await run((entry) => {
+          if (closed || begun || normalizeAgentId(entry.agentId) !== id) {
+            throw new Error(`Agent ${id} deletion already began or has a different target.`);
+          }
+          begun = true;
+          const operationId = crypto.randomUUID();
+          const journal = runOpenClawStateWriteTransaction((database) => {
+            lease.assertOwnedInTransaction(database.db);
+            return beginAgentDeletionJournal(
+              { ...entry, agentId: id, operationId, deleteFiles: entry.deleteFiles !== false },
+              stateOptions,
+            );
+          }, stateOptions);
+          const assertJournal = (
+            currentStatePath: string,
+            entries: readonly Pick<
+              AgentDeletionJournalEntry,
+              "agentId" | "operationId" | "cleanupCompleted"
+            >[],
+            database?: OpenClawStateDatabase,
+          ) => {
+            if (
+              closed ||
+              path.resolve(currentStatePath) !== statePath ||
+              !entries.some(
+                (current) =>
+                  current.agentId === id &&
+                  current.operationId === operationId &&
+                  !current.cleanupCompleted,
+              )
+            ) {
+              throw new Error(`Agent ${id} deletion no longer owns database cleanup.`);
+            }
+            if (database) {
+              lease.assertOwnedInTransaction(database.db);
+            } else {
+              lease.assertOwned();
+            }
+            return id;
+          };
+          const assertCurrent = (database?: OpenClawStateDatabase) => {
+            const current = closed
+              ? undefined
+              : database
+                ? readAgentDeletionJournalInDatabase(database, id)
+                : readAgentDeletionJournal(id, stateOptions);
+            assertJournal(database?.path ?? statePath, current ? [current] : [], database);
+          };
+          const mutateJournal = <Result>(mutate: () => Result): Result =>
+            runOpenClawStateWriteTransaction((database) => {
+              assertCurrent(database);
+              return mutate();
+            }, stateOptions);
+          const completeInTransaction = (database: OpenClawStateDatabase) => {
+            assertCurrent(database);
+            if (!completeAgentDeletionJournalInDatabase(database, id, operationId)) {
+              throw new Error(`Failed to complete deletion journal for agent ${id}.`);
+            }
+            closed = true;
+          };
+          return {
+            entry: journal,
+            assertCurrent,
+            runDatabaseCleanup: createAgentDeletionDatabaseCleanup({
+              statePath,
+              assertAdmission: () => assertNoOpenClawAgentDatabaseLeases(id, stateOptions),
+              assertCurrent,
+              assertJournal,
+              withCommit: (commit) => {
+                let committed = false;
+                try {
+                  // Agent writers already acquire agent -> shared. Hold that order through
+                  // COMMIT so an expired deletion cannot race a replacement owner.
+                  mutateJournal(() => {
+                    commit();
+                    committed = true;
+                  });
+                } catch (error) {
+                  if (!committed) {
+                    throw error;
+                  }
+                  // Guard release cannot roll back durable agent rows or restore native bindings.
+                  try {
+                    log.warn("Agent deletion committed, but releasing its state guard failed", {
+                      agentId: id,
+                      error,
+                    });
+                  } catch {
+                    // Diagnostics are also postcommit and cannot change the durable outcome.
+                  }
+                }
+              },
+            }),
+            fenceDatabasePaths: (paths) =>
+              mutateJournal(() => {
+                if (
+                  !updateAgentDeletionJournalDatabasePaths(id, operationId, paths, stateOptions)
+                ) {
+                  throw new Error(`Failed to fence database cleanup paths for agent ${id}.`);
+                }
+                journal.databasePaths = [
+                  ...new Set(paths.map((entryPath) => path.resolve(entryPath))),
+                ];
+              }),
+            fenceCleanupPaths: (paths) =>
+              mutateJournal(() => {
+                if (!updateAgentDeletionJournalCleanupPaths(id, operationId, paths, stateOptions)) {
+                  throw new Error(`Failed to fence cleanup paths for agent ${id}.`);
+                }
+                journal.cleanupPaths = [...paths];
+              }),
+            completeInTransaction,
+            finish: () => runOpenClawStateWriteTransaction(completeInTransaction, stateOptions),
+            rollback: () =>
+              mutateJournal(() => {
+                if (!removeAgentDeletionJournal(id, operationId, stateOptions)) {
+                  throw new Error(`Failed to roll back deletion journal for agent ${id}.`);
+                }
+                closed = true;
+              }),
+          };
+        });
+      } finally {
+        closed = true;
+      }
+    },
   );
-  let active = true;
-  const assertJournal: Parameters<typeof createAgentDeletionDatabaseCleanup>[0]["assertJournal"] = (
-    currentStatePath,
-    entries,
-  ) => {
-    if (
-      !active ||
-      path.resolve(currentStatePath) !== statePath ||
-      !entries.some(
-        (current) =>
-          current.agentId === id &&
-          current.operationId === operationId &&
-          !current.cleanupCompleted,
-      )
-    ) {
-      throw new Error(`Agent ${id} deletion no longer owns database cleanup.`);
-    }
-    return id;
-  };
-  const runDatabaseCleanup = createAgentDeletionDatabaseCleanup({
-    statePath,
-    assertAdmission: () => assertNoOpenClawAgentDatabaseLeases(id, stateOptions),
-    assertJournal,
-    assertCurrent: () => {
-      const current = readAgentDeletionJournal(id, stateOptions);
-      assertJournal(statePath, current ? [current] : []);
-    },
-  });
-  return {
-    entry: journal,
-    runDatabaseCleanup,
-    fenceDatabasePaths: (paths) => {
-      if (!updateAgentDeletionJournalDatabasePaths(id, operationId, paths, stateOptions)) {
-        throw new Error(`Failed to fence database cleanup paths for agent ${id}.`);
-      }
-      journal.databasePaths = [...new Set(paths.map((entryPath) => path.resolve(entryPath)))];
-    },
-    fenceCleanupPaths: (paths) => {
-      if (!updateAgentDeletionJournalCleanupPaths(id, operationId, paths, stateOptions)) {
-        throw new Error(`Failed to fence cleanup paths for agent ${id}.`);
-      }
-      journal.cleanupPaths = [...paths];
-    },
-    finish: () => {
-      try {
-        completeAgentDeletionJournal(id, operationId, stateOptions);
-      } finally {
-        active = false;
-      }
-    },
-    rollback: () => {
-      try {
-        removeAgentDeletionJournal(id, operationId, stateOptions);
-      } finally {
-        active = false;
-      }
-    },
-  };
 }
 
 /** Atomically claim a completed deletion tombstone for a newly created identity. */

--- a/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
+++ b/src/agents/main-session-recovery/main-session-restart-recovery.test.ts
@@ -1,4 +1,5 @@
 // Verifies restart recovery marks and resumes interrupted main-agent sessions.
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -63,6 +64,10 @@ import {
   runExclusiveSessionLifecycleMutation,
 } from "../../sessions/session-lifecycle-admission.js";
 import {
+  beginAgentDeletionJournal,
+  removeAgentDeletionJournal,
+} from "../../state/agent-deletion-journal.js";
+import {
   closeOpenClawAgentDatabasesForTest,
   openOpenClawAgentDatabase,
 } from "../../state/openclaw-agent-db.js";
@@ -70,7 +75,6 @@ import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db
 import { createOutboundTestPlugin, createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { buildCurrentRunRestartRecoveryClaim } from "../agent-command-restart-recovery.js";
-import { beginAgentDeletion } from "../agent-lifecycle-registry.js";
 import { deliverAgentCommandResult } from "../command/delivery.js";
 import { setActiveEmbeddedRunLifecycleGeneration } from "../embedded-agent-runner/run-state.js";
 import {
@@ -729,8 +733,9 @@ describe("main-session-restart-recovery", () => {
         sessionKey: "agent:retired-probe:main",
       });
       closeOpenClawAgentDatabasesForTest();
-      const deletion = beginAgentDeletion({
+      const deletion = beginAgentDeletionJournal({
         agentId: "retired-probe",
+        operationId: randomUUID(),
         agentDir: path.join(tmpDir, "agents", "retired-probe", "agent"),
         workspaceDir: path.join(tmpDir, "workspace-retired-probe"),
         sessionsDir: staleSessionsDir,
@@ -765,7 +770,7 @@ describe("main-session-restart-recovery", () => {
         });
       } finally {
         admission?.release();
-        deletion.rollback();
+        removeAgentDeletionJournal(deletion.agentId, deletion.operationId);
         closeOpenClawAgentDatabasesForTest();
         closeOpenClawStateDatabaseForTest();
       }

--- a/src/agents/mcp-lifecycle-lease.ts
+++ b/src/agents/mcp-lifecycle-lease.ts
@@ -13,7 +13,7 @@ type McpLifecycleLeaseOptions = Pick<OpenClawStateDatabaseOptions, "env" | "path
 export async function withMcpLifecycleLease<T>(
   name: string,
   options: McpLifecycleLeaseOptions,
-  run: () => Promise<T>,
+  run: (assertOwned: () => void) => Promise<T>,
 ): Promise<T> {
   return await withOpenClawStateLease(
     {
@@ -35,7 +35,7 @@ export async function withMcpLifecycleLease<T>(
     },
     async (lease) => {
       lease.assertOwned();
-      const result = await run();
+      const result = await run(() => lease.assertOwned());
       lease.assertOwned();
       return result;
     },

--- a/src/agents/workspace-legacy-state.test.ts
+++ b/src/agents/workspace-legacy-state.test.ts
@@ -40,6 +40,28 @@ describe("legacy workspace reset cleanup", () => {
     });
   }
 
+  it("retains retired state when ownership expires during asynchronous validation", async () => {
+    const context = setup();
+    await fs.mkdir(context.workspaceDir, { recursive: true });
+    const marker = `${LEGACY_WORKSPACE_ATTESTATION_HEADER}\n`;
+    const siblingPath = `${context.workspaceDir}.attested`;
+    await fs.writeFile(siblingPath, marker);
+    let owned = true;
+    const cleanup = removeLegacyWorkspaceStateForReset(prepare(context), {
+      assertCurrent: () => {
+        if (!owned) {
+          throw new Error("cleanup ownership expired");
+        }
+      },
+    });
+    owned = false;
+
+    const result = await cleanup;
+    expect(result.removedPaths).toEqual([]);
+    expect(result.warnings).toEqual([expect.stringContaining("cleanup ownership expired")]);
+    expect(await fs.readFile(siblingPath, "utf8")).toBe(marker);
+  });
+
   it("removes retired setup files, claims, and owned attestations", async () => {
     const context = setup();
     await fs.mkdir(context.workspaceDir, { recursive: true });

--- a/src/agents/workspace-legacy-state.ts
+++ b/src/agents/workspace-legacy-state.ts
@@ -266,7 +266,7 @@ export function prepareLegacyWorkspaceStateReset(
 /** Discard retired workspace files from a pre-removal reset plan. */
 export async function removeLegacyWorkspaceStateForReset(
   plan: LegacyWorkspaceResetPlan,
-  options?: { dryRun?: boolean },
+  options?: { dryRun?: boolean; assertCurrent?: () => void },
 ): Promise<LegacyWorkspaceResetCleanup> {
   const removedPaths: string[] = [];
   const warnings: string[] = [];
@@ -299,6 +299,7 @@ export async function removeLegacyWorkspaceStateForReset(
         }
       }
       if (!options?.dryRun) {
+        options?.assertCurrent?.();
         await sourceRoot.remove(relativePath);
       }
       removedPaths.push(sourcePath);

--- a/src/claws/lifecycle-bootstrap-removal.ts
+++ b/src/claws/lifecycle-bootstrap-removal.ts
@@ -39,6 +39,7 @@ export function planClawBootstrapRemoval(
 
 export async function removeClawBootstrap(
   record: ClawStatusRecord,
+  assertCurrent: () => void,
 ): Promise<RemovedWorkspaceFile | undefined> {
   if (!record.install.bootstrap) {
     return undefined;
@@ -51,6 +52,7 @@ export async function removeClawBootstrap(
         contentDigest: record.install.bootstrap.contentDigest,
         state: "unchanged",
       },
+      assertCurrent,
       MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES,
     );
   }

--- a/src/claws/lifecycle-config-removal.ts
+++ b/src/claws/lifecycle-config-removal.ts
@@ -1,8 +1,14 @@
 import { createHash } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { stableStringify } from "@openclaw/normalization-core";
-import { prepareAgentDeleteDatabases } from "../agents/agent-delete-databases.js";
-import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
+import {
+  assertAgentSessionStoreDeletionSafe,
+  prepareAgentDeleteDatabases,
+} from "../agents/agent-delete-databases.js";
+import {
+  withAgentDeletion,
+  type AgentDeletionOperation,
+} from "../agents/agent-lifecycle-registry.js";
 import { listAgentEntries } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -12,10 +18,7 @@ import {
 } from "../gateway/server-methods/agents-config-mutations.js";
 import { withAgentExecApprovalsRemoved } from "../infra/exec-approvals.js";
 import { normalizeAgentId } from "../routing/session-key.js";
-import {
-  completeAgentDeletionJournalInDatabase,
-  readAgentDeletionJournal,
-} from "../state/agent-deletion-journal.js";
+import { readAgentDeletionJournalInDatabase } from "../state/agent-deletion-journal.js";
 import type {
   OpenClawStateDatabase,
   OpenClawStateDatabaseOptions,
@@ -76,11 +79,13 @@ async function commitClawAgentConfigRemoval(
   try {
     const committed = await deleteAgentConfigEntry({
       agentId: params.agentId,
+      assertCurrent,
       allowConfigSizeDrop: true,
       allowMissing: params.expectedState === "missing",
       fallbackWorkspace: params.fallbackWorkspace,
       validateConfig: (config) => {
         assertCurrent();
+        assertAgentSessionStoreDeletionSafe(config, params.agentId, params.stateDatabase);
         if (
           digestClawAgentRemovalSurface(config, params.agentId) !==
           params.expectedRemovalSurfaceDigest
@@ -144,139 +149,125 @@ type CommittedClawAgentRemoval = ClawAgentConfigRemovalResult & {
   assertCurrent: (database?: OpenClawStateDatabase) => void;
   drainMonitors: () => Promise<void>;
   completeDeletion: (database: OpenClawStateDatabase) => void;
-  runDatabaseCleanup: ReturnType<typeof beginAgentDeletion>["runDatabaseCleanup"];
+  runDatabaseCleanup: AgentDeletionOperation["runDatabaseCleanup"];
 };
 
 export async function withClawAgentConfigRemoval<T>(
   params: ClawAgentConfigRemovalParams,
-  apply: (commitRemoval: () => Promise<CommittedClawAgentRemoval>) => Promise<T>,
+  apply: (
+    commitRemoval: () => Promise<CommittedClawAgentRemoval>,
+    assertCurrent: () => void,
+  ) => Promise<T>,
 ): Promise<T> {
-  const config = params.config ?? getRuntimeConfig();
+  const expectedInstall = structuredClone(params.expectedInstall);
   const stateOptions = {
     ...params.stateDatabase,
     path: openOpenClawStateDatabase(params.stateDatabase).path,
   };
-  const effects = deletionEffects(
-    config,
+  return await withAgentDeletion(
     params.agentId,
-    params.fallbackWorkspace,
-    stateOptions.env,
-  );
-  const expectedInstall = structuredClone(params.expectedInstall);
-  const matchesInstall = (database: OpenClawStateDatabase) =>
-    expectedInstall === undefined ||
-    isDeepStrictEqual(
-      readClawInstallRecordFromDatabase(database.db, params.agentId) ?? null,
-      expectedInstall,
-    );
-  // Validate and claim together: a stale install snapshot must never fence a replacement.
-  const { existingJournal, deletion } = runOpenClawStateWriteTransaction((database) => {
-    if (!matchesInstall(database)) {
-      throw params.onModified();
-    }
-    const transactionOptions = { ...stateOptions, database };
-    const previousJournal = readAgentDeletionJournal(params.agentId, transactionOptions);
-    const claimedDeletion = beginAgentDeletion(
-      {
-        agentId: params.agentId,
-        workspaceDir: effects.workspace,
-        agentDir: effects.agentDir,
-        sessionsDir: effects.sessionsDir,
-        // Selective cleanup may retain modified or untracked workspace entries.
-        deleteFiles: previousJournal?.deleteFiles ?? false,
-      },
-      transactionOptions,
-    );
-    return { existingJournal: previousJournal, deletion: claimedDeletion };
-  }, stateOptions);
-  let committed = false;
-  let monitorEffectsStarted = false;
-  const ownsRemoval = (database: OpenClawStateDatabase) => {
-    if (database.path !== stateOptions.path) {
-      return false;
-    }
-    const current = readAgentDeletionJournal(params.agentId, {
-      ...stateOptions,
-      path: database.path,
-      database,
-    });
-    return (
-      current?.operationId === deletion.entry.operationId &&
-      !current.cleanupCompleted &&
-      matchesInstall(database)
-    );
-  };
-  const assertCurrent = (database?: OpenClawStateDatabase) => {
-    const check = (current: OpenClawStateDatabase) => {
-      if (!ownsRemoval(current)) {
-        throw new Error(`Claw removal no longer owns agent ${params.agentId}.`);
-      }
-    };
-    if (database) {
-      check(database);
-    } else {
-      runOpenClawStateWriteTransaction(check, stateOptions);
-    }
-  };
-  try {
-    // Fence new claims and drain existing owners before any external or local removal effect.
-    if (params.quiesceMonitors) {
-      // A lost RPC response can hide accepted cancellation. Keep the durable fence
-      // until a retry has observed the serving owner and completed cleanup.
-      monitorEffectsStarted = true;
-      await params.quiesceMonitors(deletion.entry.operationId);
-    }
-    assertCurrent();
-    prepareAgentDeleteDatabases(config, params.agentId, effects.agentDir, stateOptions);
-    return await apply(async () => {
-      assertCurrent();
-      const result = await withAgentExecApprovalsRemoved(
+    async (begin) => {
+      const config = params.config ?? getRuntimeConfig();
+      assertAgentSessionStoreDeletionSafe(config, params.agentId, stateOptions);
+      const effects = deletionEffects(
+        config,
         params.agentId,
-        async () =>
-          commitClawAgentConfigRemoval(
-            { ...params, config, stateDatabase: stateOptions },
-            assertCurrent,
-          ),
-        stateOptions,
+        params.fallbackWorkspace,
+        stateOptions.env,
       );
-      committed = true;
-      assertCurrent();
-      return {
-        ...result,
-        assertCurrent,
-        drainMonitors: async () => {
-          await params.drainMonitors?.(deletion.entry.operationId);
-        },
-        runDatabaseCleanup: deletion.runDatabaseCleanup,
-        completeDeletion: (database: OpenClawStateDatabase) => {
-          if (
-            !completeAgentDeletionJournalInDatabase(
-              database,
-              params.agentId,
-              deletion.entry.operationId,
-            )
-          ) {
-            throw new Error(`Failed to complete deletion journal for agent ${params.agentId}.`);
-          }
-        },
-      };
-    });
-  } finally {
-    // Pre-config partial results release only this attempt's fence; committed cleanup retains it.
-    if (!committed && !monitorEffectsStarted && !existingJournal) {
-      deletion.rollback();
-    }
-    if (expectedInstall) {
-      // Result construction is pure; only the live operation may publish retry status.
-      runOpenClawStateWriteTransaction((database) => {
-        if (ownsRemoval(database)) {
-          updateClawInstallRecordStatus(params.agentId, "partial", {
-            ...stateOptions,
-            path: database.path,
-            database,
-          });
+      const matchesInstall = (database: OpenClawStateDatabase) =>
+        expectedInstall === undefined ||
+        isDeepStrictEqual(
+          readClawInstallRecordFromDatabase(database.db, params.agentId) ?? null,
+          expectedInstall,
+        );
+      // Validate and claim together: a stale install snapshot must never fence a replacement.
+      const { existingJournal, deletion } = runOpenClawStateWriteTransaction((database) => {
+        if (!matchesInstall(database)) {
+          throw params.onModified();
         }
+        const previousJournal = readAgentDeletionJournalInDatabase(database, params.agentId);
+        const claimedDeletion = begin({
+          agentId: params.agentId,
+          workspaceDir: effects.workspace,
+          agentDir: effects.agentDir,
+          sessionsDir: effects.sessionsDir,
+          // Selective cleanup may retain modified or untracked workspace entries.
+          deleteFiles: previousJournal?.deleteFiles ?? false,
+        });
+        return { existingJournal: previousJournal, deletion: claimedDeletion };
       }, stateOptions);
-    }
-  }
+      let committed = false;
+      let monitorEffectsStarted = false;
+      const assertCurrent = (database?: OpenClawStateDatabase) => {
+        const check = (current: OpenClawStateDatabase) => {
+          deletion.assertCurrent(current);
+          if (!matchesInstall(current)) {
+            throw new Error(`Claw removal no longer owns agent ${params.agentId}.`);
+          }
+        };
+        if (database) {
+          check(database);
+        } else {
+          runOpenClawStateWriteTransaction(check, stateOptions);
+        }
+      };
+      try {
+        // Fence new claims and drain existing owners before any external or local removal effect.
+        if (params.quiesceMonitors) {
+          // A lost RPC response can hide accepted cancellation. Keep the durable fence
+          // until a retry has observed the serving owner and completed cleanup.
+          monitorEffectsStarted = true;
+          await params.quiesceMonitors(deletion.entry.operationId);
+        }
+        assertCurrent();
+        prepareAgentDeleteDatabases(config, params.agentId, effects.agentDir, stateOptions);
+        return await apply(async () => {
+          assertCurrent();
+          const result = await withAgentExecApprovalsRemoved(
+            params.agentId,
+            async () =>
+              commitClawAgentConfigRemoval(
+                { ...params, config, stateDatabase: stateOptions },
+                assertCurrent,
+              ),
+            stateOptions,
+          );
+          committed = true;
+          assertCurrent();
+          return {
+            ...result,
+            assertCurrent,
+            drainMonitors: async () => {
+              assertCurrent();
+              await params.drainMonitors?.(deletion.entry.operationId);
+              assertCurrent();
+            },
+            runDatabaseCleanup: deletion.runDatabaseCleanup,
+            completeDeletion: deletion.completeInTransaction,
+          };
+        }, assertCurrent);
+      } finally {
+        // Pre-config partial results release only this attempt's fence; committed cleanup retains it.
+        if (!committed && !monitorEffectsStarted && !existingJournal) {
+          deletion.rollback();
+        }
+        if (expectedInstall) {
+          // Result construction is pure; only the live operation may publish retry status.
+          runOpenClawStateWriteTransaction((database) => {
+            try {
+              assertCurrent(database);
+            } catch {
+              return;
+            }
+            updateClawInstallRecordStatus(params.agentId, "partial", {
+              ...stateOptions,
+              database,
+            });
+          }, stateOptions);
+        }
+      }
+    },
+    stateOptions,
+  );
 }

--- a/src/claws/lifecycle-delete-support.ts
+++ b/src/claws/lifecycle-delete-support.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { coerceErrorMessage } from "@openclaw/normalization-core/error-coercion";
+import { err, ok, type Result } from "@openclaw/normalization-core/result";
 import {
   isPathOwnedBySurvivingAgent,
   readAgentDeleteDatabaseRegistry,
@@ -254,9 +255,15 @@ export async function cleanupClawAgentFilesystem(params: {
   trashPath?: ClawTrashPath;
   retainWorkspace?: boolean;
   stateDatabase?: OpenClawStateDatabaseOptions;
+  assertCurrent: () => void;
 }): Promise<string[]> {
   const errors: string[] = [];
-  const trashPath = params.trashPath ?? moveToTrash;
+  const trashPath: ClawTrashPath = (pathname, runtime) => {
+    params.assertCurrent();
+    return params.trashPath
+      ? params.trashPath(pathname, runtime)
+      : moveToTrash(pathname, runtime, params.assertCurrent);
+  };
   const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
     readAgentDeleteDatabaseRegistry(params.stateDatabase),
     params.agentId,
@@ -280,10 +287,13 @@ export async function cleanupClawAgentFilesystem(params: {
     const workspaceRemoved = await trashPath(params.targets.workspaceDir, params.runtime);
     if (workspaceRemoved) {
       try {
-        const legacyCleanup = await removeLegacyWorkspaceStateForReset(legacyPlan);
+        const legacyCleanup = await removeLegacyWorkspaceStateForReset(legacyPlan, {
+          assertCurrent: params.assertCurrent,
+        });
         for (const warning of legacyCleanup.warnings) {
           params.runtime.log(warning);
         }
+        params.assertCurrent();
         deleteWorkspaceState(statePlan);
       } catch (error) {
         errors.push(coerceErrorMessage(error));
@@ -441,6 +451,7 @@ export async function inspectClawBootstrap(
 
 export async function removeClawWorkspaceFile(
   record: ClawRemovableWorkspaceFile,
+  assertCurrent: () => void,
   maxBytes = 1024 * 1024,
 ): Promise<RemovedWorkspaceFile> {
   if (record.state === "missing") {
@@ -459,15 +470,35 @@ export async function removeClawWorkspaceFile(
       return { path: record.path, action: "missing" };
     }
     const stagedPath = `${record.path}.openclaw-claw-remove-${randomUUID()}`;
+    assertCurrent();
     await workspace.move(record.path, stagedPath, { overwrite: false });
-    const content = await workspace.readBytes(stagedPath, { maxBytes });
-    const digest = `sha256:${createHash("sha256").update(content).digest("hex")}`;
-    if (digest !== record.contentDigest) {
-      await workspace.move(stagedPath, record.path, { overwrite: false });
-      return { path: record.path, action: "retainedModified" };
+    let outcome: Result<void, unknown>;
+    try {
+      const content = await workspace.readBytes(stagedPath, { maxBytes });
+      assertCurrent();
+      const digest = `sha256:${createHash("sha256").update(content).digest("hex")}`;
+      if (digest === record.contentDigest) {
+        await workspace.remove(stagedPath);
+        return { path: record.path, action: "deleted" };
+      }
+      outcome = ok(undefined);
+    } catch (error) {
+      outcome = err(error);
     }
-    await workspace.remove(stagedPath);
-    return { path: record.path, action: "deleted" };
+    // Undo this attempt's staging even after ownership loss; never replace new content.
+    try {
+      await workspace.move(stagedPath, record.path, { overwrite: false });
+    } catch (error) {
+      throw new AggregateError(
+        [...(outcome.ok ? [] : [outcome.error]), error],
+        `Could not restore ${record.path} from ${stagedPath}: ${String(error)}`,
+        { cause: error },
+      );
+    }
+    if (!outcome.ok) {
+      throw outcome.error;
+    }
+    return { path: record.path, action: "retainedModified" };
   } catch (error) {
     return {
       path: record.path,

--- a/src/claws/lifecycle-mcp-removal.ts
+++ b/src/claws/lifecycle-mcp-removal.ts
@@ -28,6 +28,7 @@ export async function removeClawMcpServers(params: {
   agentId: string;
   servers: ClawStatusRecord["mcpServers"];
   options: RemoveMcpServerOptions;
+  assertCurrent: () => void;
 }): Promise<{ mcpServers: RemovedMcpServer[]; error?: string }> {
   const listed = params.options.sourceMcpServers
     ? undefined
@@ -36,6 +37,7 @@ export async function removeClawMcpServers(params: {
       : params.options.config
         ? undefined
         : await listConfiguredMcpServers();
+  params.assertCurrent();
   if (listed && !listed.ok) {
     throw new ClawRemoveError("mcp_config_unavailable", listed.error);
   }
@@ -48,7 +50,13 @@ export async function removeClawMcpServers(params: {
   const mcpServers: RemovedMcpServer[] = [];
   for (const server of params.servers) {
     let removalError: string | undefined;
-    await withClawMcpLifecycleLease(server.name, params.options, async () => {
+    params.assertCurrent();
+    await withClawMcpLifecycleLease(server.name, params.options, async (assertMcpCurrent) => {
+      const assertCurrent = () => {
+        params.assertCurrent();
+        assertMcpCurrent();
+      };
+      assertCurrent();
       const currentRef = readClawMcpServerRefsByName(server.name, params.options).find(
         (candidate) => candidate.agentId === params.agentId,
       );
@@ -60,6 +68,7 @@ export async function removeClawMcpServers(params: {
       }
       const ownerAction = planClawMcpServerRemoval(currentRef, params.options).action;
       if (ownerAction === "release") {
+        assertCurrent();
         deleteClawMcpServerRef(params.agentId, server.name, params.options);
         mcpServers.push({
           name: server.name,
@@ -75,6 +84,7 @@ export async function removeClawMcpServers(params: {
             `MCP server ${JSON.stringify(server.name)} disappeared during removal.`,
           );
         }
+        assertCurrent();
         deleteClawMcpServerRef(params.agentId, server.name, params.options);
         mcpServers.push({ name: server.name, action: "missing" });
         return;
@@ -90,10 +100,12 @@ export async function removeClawMcpServers(params: {
           name: server.name,
           expectedServer,
           recordIndependentOwner: false,
+          assertCurrent,
         });
         if (!result.ok) {
           throw new Error(result.error);
         }
+        assertCurrent();
         deleteClawMcpServerRef(params.agentId, server.name, params.options);
         mcpServers.push({ name: server.name, action: result.removed ? "removed" : "missing" });
       } catch (cause) {
@@ -102,6 +114,7 @@ export async function removeClawMcpServers(params: {
         removalError = message;
       }
     });
+    params.assertCurrent();
     if (removalError) {
       return { mcpServers, error: removalError };
     }

--- a/src/claws/lifecycle-remove-approvals.test.ts
+++ b/src/claws/lifecycle-remove-approvals.test.ts
@@ -7,7 +7,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { stopChildProcess } from "../../test/helpers/stop-child-process.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { createAgent } from "../agents/agent-create.js";
-import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
+import { withAgentDeletion } from "../agents/agent-lifecycle-registry.js";
 import { listAgentEntries } from "../agents/agent-scope.js";
 import {
   appendTranscriptMessage,
@@ -19,7 +19,10 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { loadExecApprovals, saveExecApprovals } from "../infra/exec-approvals.js";
 import { resolveRuntimeWorkerArgv, resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import { onSessionIdentityMutation } from "../sessions/session-lifecycle-events.js";
-import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
+import {
+  beginAgentDeletionJournal,
+  readAgentDeletionJournal,
+} from "../state/agent-deletion-journal.js";
 import { readAgentProvenance } from "../state/agent-provenance.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
 import { registerOpenClawAgentDatabase } from "../state/openclaw-agent-db-registry.js";
@@ -313,27 +316,29 @@ describe("Claw exec approvals removal", () => {
         expect(readClawMcpServerRefs("worker")).toHaveLength(1);
         expect(readAgentDeletionJournal("worker")).toMatchObject({ cleanupCompleted: false });
         const agentDir = join(home, ".openclaw", "agents", "worker", "agent");
-        const deletion = beginAgentDeletion({
-          agentId: "worker",
-          agentDir,
-          workspaceDir: join(home, "workspace-worker"),
-          sessionsDir: join(home, ".openclaw", "agents", "worker", "sessions"),
+        await withAgentDeletion("worker", async (begin) => {
+          const deletion = begin({
+            agentId: "worker",
+            agentDir,
+            workspaceDir: join(home, "workspace-worker"),
+            sessionsDir: join(home, ".openclaw", "agents", "worker", "sessions"),
+          });
+          const cleanup = vi.fn(async () => undefined);
+          try {
+            await expect(
+              deletion.runDatabaseCleanup(
+                {
+                  agentId: "worker",
+                  path: join(agentDir, "openclaw-agent.sqlite"),
+                },
+                cleanup,
+              ),
+            ).rejects.toThrow("database is still open in another process");
+            expect(cleanup).not.toHaveBeenCalled();
+          } finally {
+            deletion.rollback();
+          }
         });
-        const cleanup = vi.fn(async () => undefined);
-        try {
-          await expect(
-            deletion.runDatabaseCleanup(
-              {
-                agentId: "worker",
-                path: join(agentDir, "openclaw-agent.sqlite"),
-              },
-              cleanup,
-            ),
-          ).rejects.toThrow("database is still open in another process");
-          expect(cleanup).not.toHaveBeenCalled();
-        } finally {
-          deletion.rollback();
-        }
         await child.close();
         const retry = await buildClawRemovePlan("worker", { config });
         await expect(
@@ -360,21 +365,23 @@ describe("Claw exec approvals removal", () => {
       const child = startHeldDatabase(target.agentId, target.path);
       try {
         await child.ready;
-        const deletion = beginAgentDeletion({
-          agentId: "worker",
-          agentDir,
-          workspaceDir: join(home, "workspace-worker"),
-          sessionsDir: join(home, ".openclaw", "agents", "worker", "sessions"),
+        await withAgentDeletion("worker", async (begin) => {
+          const deletion = begin({
+            agentId: "worker",
+            agentDir,
+            workspaceDir: join(home, "workspace-worker"),
+            sessionsDir: join(home, ".openclaw", "agents", "worker", "sessions"),
+          });
+          const cleanup = vi.fn(async () => openOpenClawAgentDatabase(target));
+          await expect(deletion.runDatabaseCleanup(target, cleanup)).rejects.toThrow(
+            "agent worker deletion owns",
+          );
+          expect(cleanup).not.toHaveBeenCalled();
+          await child.close();
+          const database = await deletion.runDatabaseCleanup(target, cleanup);
+          expect(database.db.isOpen).toBe(false);
+          deletion.rollback();
         });
-        const cleanup = vi.fn(async () => openOpenClawAgentDatabase(target));
-        await expect(deletion.runDatabaseCleanup(target, cleanup)).rejects.toThrow(
-          "agent worker deletion owns",
-        );
-        expect(cleanup).not.toHaveBeenCalled();
-        await child.close();
-        const database = await deletion.runDatabaseCleanup(target, cleanup);
-        expect(database.db.isOpen).toBe(false);
-        deletion.rollback();
       } finally {
         await child.dispose();
       }
@@ -661,8 +668,49 @@ describe("Claw exec approvals removal", () => {
     });
   });
 
-  // beginAgentDeletion takes over an existing journal row, so a failed Claw removal must not roll
-  // back a deletion another path started.
+  it("rechecks shared session ownership after resource cleanup changes config", async () => {
+    const root = tempDirs.make("claw-remove-shared-topology-");
+    const env = { OPENCLAW_STATE_DIR: join(root, "state") };
+    const workspace = join(root, "workspace-worker");
+    const sharedPath = join(root, "shared.sqlite");
+    const database = openOpenClawAgentDatabase({ agentId: "worker", path: sharedPath, env });
+    closeOpenClawAgentDatabaseByPath(database.path);
+    const initialConfig: OpenClawConfig = {
+      agents: { ownership: "explicit", entries: { worker: { workspace }, kept: {} } },
+    };
+    const configPath = join(root, "openclaw.json");
+    setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
+    setTestEnvValue("OPENCLAW_STATE_DIR", env.OPENCLAW_STATE_DIR);
+    await writeFile(configPath, JSON.stringify(initialConfig));
+
+    await expect(
+      withClawAgentConfigRemoval(
+        {
+          agentId: "worker",
+          expectedDigest: digestClawAgentConfig({ id: "worker", workspace }),
+          expectedRemovalSurfaceDigest: digestClawAgentRemovalSurface(initialConfig, "worker"),
+          expectedState: "present",
+          fallbackWorkspace: workspace,
+          config: initialConfig,
+          stateDatabase: { env },
+          onModified: () => new Error("agent changed"),
+        },
+        async (commitRemoval) => {
+          await writeFile(
+            configPath,
+            JSON.stringify({ ...initialConfig, session: { store: sharedPath } }),
+          );
+          return await commitRemoval();
+        },
+      ),
+    ).rejects.toThrow('still used by agent "kept"');
+    const persistedConfig = JSON.parse(await readFile(configPath, "utf8")) as OpenClawConfig;
+    expect(listAgentEntries(persistedConfig).map((entry) => entry.id)).toEqual(["worker", "kept"]);
+    expect(persistedConfig.session?.store).toBe(sharedPath);
+    expect(readAgentDeletionJournal("worker", { env })).toBeUndefined();
+  });
+
+  // A failed retry must retain the journal left by the original deletion.
   it.each([
     { label: "keeps a pre-existing journal", seedJournal: true },
     { label: "rolls back the journal it opened", seedJournal: false },
@@ -676,8 +724,10 @@ describe("Claw exec approvals removal", () => {
     setTestEnvValue("OPENCLAW_CONFIG_PATH", configPath);
     await writeFile(configPath, JSON.stringify(config));
     if (seedJournal) {
-      beginAgentDeletion({
+      beginAgentDeletionJournal({
         agentId: "worker",
+        operationId: "prior-deletion",
+        deleteFiles: false,
         agentDir: join(root, "agent"),
         workspaceDir: join(root, "workspace"),
         sessionsDir: join(root, "sessions"),

--- a/src/claws/lifecycle-remove-ownership.test.ts
+++ b/src/claws/lifecycle-remove-ownership.test.ts
@@ -3,12 +3,15 @@ import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { readSourceConfigBestEffort, resetConfigRuntimeState } from "../config/config.js";
+import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
 import { listOpenClawRegisteredAgentDatabases } from "../state/openclaw-agent-db-registry.js";
 import {
   closeOpenClawAgentDatabases,
   openOpenClawAgentDatabase,
 } from "../state/openclaw-agent-db.js";
+import type { DB } from "../state/openclaw-state-db.generated.js";
+import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import { applyClawAddPlan } from "./add.js";
 import type { ClawRemoveApplyOptions, ClawRemoveResult } from "./lifecycle-remove-contract.js";
@@ -66,6 +69,20 @@ async function fixture(withFile = false) {
   return { state, workspace, install, remove, trashPath };
 }
 
+function expireDeletionLease(): void {
+  // A live deletion serializes successors; expiry models the recovery boundary.
+  runOpenClawStateWriteTransaction(({ db }) => {
+    executeSqliteQuerySync(
+      db,
+      getNodeSqliteKysely<Pick<DB, "state_leases">>(db)
+        .updateTable("state_leases")
+        .set({ expires_at: 0 })
+        .where("scope", "=", "core:agent-deletion")
+        .where("lease_key", "=", "worker"),
+    );
+  });
+}
+
 describe("Claw removal operation ownership", () => {
   it.each([
     { successor: "removing", reject: false },
@@ -95,6 +112,7 @@ describe("Claw removal operation ownership", () => {
     });
     try {
       const originalOperation = await entered.promise;
+      expireDeletionLease();
       next = current.remove({
         monitorGateway: {
           ...quiescentClawMonitorGateway,
@@ -120,8 +138,11 @@ describe("Claw removal operation ownership", () => {
       expect(await stale).toMatchObject({
         status: "partial",
         error: {
-          message: expect.stringContaining(
-            test.reject ? "original quiescence failure" : "no longer owns",
+          code: "monitor_cleanup_failed",
+          message: expect.stringMatching(
+            test.reject
+              ? /original quiescence failure|agent deletion core:agent-deletion\/worker was lost/
+              : /no longer owns|agent deletion core:agent-deletion\/worker was lost/,
           ),
         },
       });
@@ -152,6 +173,7 @@ describe("Claw removal operation ownership", () => {
     });
     try {
       await entered.promise;
+      expireDeletionLease();
       next = current.remove({
         monitorGateway: {
           ...quiescentClawMonitorGateway,
@@ -167,9 +189,12 @@ describe("Claw removal operation ownership", () => {
       release.resolve();
       expect(await stale).toMatchObject({
         status: "partial",
+        agentRemoved: true,
         error: {
-          code: "session_cleanup_failed",
-          message: expect.stringContaining("Session cleanup failed"),
+          code: "monitor_cleanup_failed",
+          message: expect.stringMatching(
+            /no longer owns|agent deletion core:agent-deletion\/worker was lost/,
+          ),
         },
       });
       expect(readClawInstallRecord("worker")).toEqual(before);
@@ -211,6 +236,7 @@ describe("Claw removal operation ownership", () => {
       });
       try {
         await entered.promise;
+        expireDeletionLease();
         next = current.remove({
           monitorGateway: {
             ...quiescentClawMonitorGateway,
@@ -228,14 +254,16 @@ describe("Claw removal operation ownership", () => {
         expect(registry.some((entry) => entry.agentId === "worker")).toBe(true);
         expect(files).toHaveLength(1);
         release.resolve();
-        const outcome = await stale;
-        expect(outcome.status).toBe("partial");
-        if (!complete) {
-          expect(outcome.error).toMatchObject({
-            code: "workspace_cleanup_failed",
-            message: expect.stringContaining("Could not trash session transcripts"),
-          });
-        }
+        expect(await stale).toMatchObject({
+          status: "partial",
+          agentRemoved: true,
+          error: {
+            code: "monitor_cleanup_failed",
+            message: expect.stringMatching(
+              /no longer owns|agent deletion core:agent-deletion\/worker was lost/,
+            ),
+          },
+        });
         expect(listOpenClawRegisteredAgentDatabases()).toEqual(registry);
         expect(readClawWorkspaceFiles("worker")).toEqual(files);
         expect(readClawInstallRecord("worker")).toEqual(install);

--- a/src/claws/lifecycle-remove.test-support.ts
+++ b/src/claws/lifecycle-remove.test-support.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { hasActiveCronJobsForAgent } from "../cron/active-jobs.js";
@@ -32,12 +33,16 @@ export async function buildClawRemovalFixture(
     id?: string;
     name?: string;
     withFile?: boolean;
+    withBootstrap?: boolean;
     withCron?: boolean;
     withMcp?: boolean;
   } = {},
 ) {
   if (params.withFile) {
     await writeFile(join(root, "SOUL.md"), "managed\n", "utf8");
+  }
+  if (params.withBootstrap) {
+    await writeFile(join(root, "BOOTSTRAP.md"), "managed\n", "utf8");
   }
   const parsed = parseClawManifest({
     schemaVersion: 1,
@@ -78,6 +83,16 @@ export async function buildClawRemovalFixture(
   };
   const plan = await buildClawAddPlan({
     manifest: parsed.manifest,
+    ...(params.withBootstrap
+      ? {
+          packageBootstrap: {
+            sourcePath: "BOOTSTRAP.md",
+            realPath: join(root, "BOOTSTRAP.md"),
+            byteLength: Buffer.byteLength("managed\n"),
+            digest: `sha256:${createHash("sha256").update("managed\n").digest("hex")}`,
+          },
+        }
+      : {}),
     source,
     context: { workspace: join(root, `workspace-${params.id ?? "worker"}`) },
   });

--- a/src/claws/lifecycle-state-mcp.test.ts
+++ b/src/claws/lifecycle-state-mcp.test.ts
@@ -2,21 +2,34 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { readSourceConfigSnapshot } from "../config/io.js";
+import * as configMutate from "../config/mutate.js";
 import { withTempHomeConfig } from "../config/test-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import {
+  beginAgentDeletionJournal,
+  readAgentDeletionJournal,
+} from "../state/agent-deletion-journal.js";
 import { markClawMcpServerIndependentlyOwned } from "../state/claw-mcp-adoption.js";
+import {
+  closeOpenClawAgentDatabasesForTest,
+  openOpenClawAgentDatabase,
+} from "../state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { setTestEnvValue } from "../test-utils/env.js";
 import { applyClawAddPlan } from "./add.js";
 import { quiescentClawMonitorGateway } from "./lifecycle-remove.test-support.js";
 import { applyClawRemovePlan, buildClawRemovePlan } from "./lifecycle-state.js";
 import { buildClawAddPlan } from "./lifecycle.js";
-import { installClawMcpServers } from "./mcp.js";
+import { installClawMcpServers, readClawMcpServerRefsByName } from "./mcp.js";
 import { parseClawManifest } from "./schema.js";
 import type { ClawSourceIdentity } from "./types.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
-afterEach(() => closeOpenClawStateDatabaseForTest());
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+});
 
 const sourceServer = {
   command: "uvx",
@@ -87,6 +100,133 @@ async function recordManagedMcp(current: Awaited<ReturnType<typeof addMcpFixture
 }
 
 describe("Claw MCP removal", () => {
+  it.each(["config publication", "unset settlement"] as const)(
+    "preserves MCP state after deletion takeover during %s",
+    async (boundary) => {
+      const current = await addMcpFixture();
+      await recordManagedMcp(current);
+      const config = structuredClone(current.getConfig());
+      config.agents = { ...config.agents, ownership: "explicit" };
+      for (const entry of Object.values(config.agents.entries ?? {})) {
+        delete entry.default;
+      }
+      config.mcp = { servers: { docs: sourceServer } };
+      await withTempHomeConfig(config, async ({ configPath }) => {
+        const snapshot = await readSourceConfigSnapshot();
+        expect(snapshot.valid, JSON.stringify(snapshot.issues)).toBe(true);
+        const refs = readClawMcpServerRefsByName("docs", { env: current.env });
+        const plan = await buildClawRemovePlan("worker", {
+          env: current.env,
+          config,
+          sourceMcpServers: { docs: sourceServer },
+        });
+        let replaced = false;
+        const replaceOwner = () => {
+          const entry = readAgentDeletionJournal("worker", { env: current.env });
+          expect(entry).toBeDefined();
+          if (!entry) {
+            throw new Error("expected active deletion journal");
+          }
+          beginAgentDeletionJournal({ ...entry, operationId: "replacement" }, { env: current.env });
+          replaced = true;
+        };
+        const replace = configMutate.replaceConfigFile;
+        const writeSpy = vi
+          .spyOn(configMutate, "replaceConfigFile")
+          .mockImplementation(async (params) => {
+            replaceOwner();
+            return await replace(params);
+          });
+        try {
+          await expect(
+            applyClawRemovePlan(plan, {
+              env: current.env,
+              config,
+              sourceMcpServers: { docs: sourceServer },
+              consentPlanIntegrity: plan.planIntegrity,
+              monitorGateway: quiescentClawMonitorGateway,
+              ...(boundary === "unset settlement"
+                ? {
+                    unsetMcpServer: async () => {
+                      replaceOwner();
+                      return {
+                        ok: true as const,
+                        path: configPath,
+                        config,
+                        mcpServers: {},
+                        removed: true,
+                      };
+                    },
+                  }
+                : {}),
+            }),
+          ).resolves.toMatchObject({
+            status: "partial",
+            agentRemoved: false,
+            error: { message: expect.stringContaining("no longer owns") },
+          });
+          expect(replaced).toBe(true);
+          expect(JSON.parse(await readFile(configPath, "utf8")).mcp?.servers?.docs).toEqual(
+            sourceServer,
+          );
+          expect(
+            JSON.parse(await readFile(configPath, "utf8")).agents.entries.worker,
+          ).toBeDefined();
+          expect(readClawMcpServerRefsByName("docs", { env: current.env })).toEqual(refs);
+          expect(readAgentDeletionJournal("worker", { env: current.env })?.operationId).toBe(
+            "replacement",
+          );
+        } finally {
+          writeSpy.mockRestore();
+        }
+      });
+    },
+  );
+
+  it("preserves managed MCP resources when the agent owns a shared session store", async () => {
+    const current = await addMcpFixture();
+    await recordManagedMcp(current);
+    const installedConfig = current.getConfig();
+    const storePath = join(current.env.OPENCLAW_STATE_DIR, "shared.sqlite");
+    const config: OpenClawConfig = {
+      ...installedConfig,
+      agents: {
+        ...installedConfig.agents,
+        entries: { ...installedConfig.agents?.entries, ops: {} },
+      },
+      session: { store: storePath },
+    };
+    openOpenClawAgentDatabase({ agentId: "worker", path: storePath, env: current.env });
+    const plan = await buildClawRemovePlan("worker", {
+      env: current.env,
+      config,
+      sourceMcpServers: { docs: sourceServer },
+    });
+    const refs = readClawMcpServerRefsByName("docs", { env: current.env });
+    const unsetMcpServer = vi
+      .fn()
+      .mockResolvedValue({ ok: true, path: "config", config: {}, mcpServers: {}, removed: true });
+
+    await expect(
+      applyClawRemovePlan(plan, {
+        consentPlanIntegrity: plan.planIntegrity,
+        env: current.env,
+        config,
+        sourceMcpServers: { docs: sourceServer },
+        unsetMcpServer,
+        monitorGateway: quiescentClawMonitorGateway,
+      }),
+    ).rejects.toThrow();
+
+    expect(unsetMcpServer).not.toHaveBeenCalled();
+    expect(readClawMcpServerRefsByName("docs", { env: current.env })).toEqual(refs);
+    expect(readAgentDeletionJournal("worker", { env: current.env })).toBeUndefined();
+    expect(plan.blockers).toContainEqual({
+      code: "shared_session_store_owner",
+      message: expect.stringContaining("session database still used by agent"),
+    });
+  });
+
   it("releases an exact pre-existing MCP server without deleting it", async () => {
     const current = await addMcpFixture();
     await installClawMcpServers(current.plan, {
@@ -168,6 +308,7 @@ describe("Claw MCP removal", () => {
       name: "docs",
       expectedServer: sourceServer,
       recordIndependentOwner: false,
+      assertCurrent: expect.any(Function),
     });
     expect(result).toMatchObject({
       status: "complete",
@@ -274,6 +415,7 @@ describe("Claw MCP removal", () => {
         name: "docs",
         expectedServer: sourceServer,
         recordIndependentOwner: false,
+        assertCurrent: expect.any(Function),
       });
       expect(result).toMatchObject({
         status: "complete",

--- a/src/claws/lifecycle-state-takeover.test.ts
+++ b/src/claws/lifecycle-state-takeover.test.ts
@@ -1,0 +1,115 @@
+import { readFile, readdir, writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import * as fsSafe from "../infra/fs-safe.js";
+import {
+  beginAgentDeletionJournal,
+  readAgentDeletionJournal,
+} from "../state/agent-deletion-journal.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import { quiescentClawMonitorGateway } from "./lifecycle-remove.test-support.js";
+import { applyClawRemovePlan, buildClawRemovePlan } from "./lifecycle-state.js";
+import { createClawRemoveTestFixtures } from "./lifecycle-state.test-helpers.js";
+
+let state: OpenClawTestState;
+beforeEach(async () => {
+  state = await createOpenClawTestState({ prefix: "claw-takeover-config-" });
+  await state.writeConfig({});
+});
+afterEach(async () => {
+  closeOpenClawStateDatabaseForTest();
+  await state.cleanup();
+});
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const { addFixture } = createClawRemoveTestFixtures(tempDirs, () => state);
+
+describe("Claw workspace deletion ownership", () => {
+  it.each([
+    ["SOUL.md", "discovery"],
+    ["SOUL.md", "staged read"],
+    ["SOUL.md", "staged replacement"],
+    ["BOOTSTRAP.md", "discovery"],
+    ["BOOTSTRAP.md", "staged read"],
+  ] as const)("preserves %s after deletion takeover during %s", async (filename, boundary) => {
+    const current = await addFixture({
+      withFile: filename === "SOUL.md",
+      withBootstrap: filename === "BOOTSTRAP.md",
+    });
+    const config = current.getConfig();
+    const plan = await buildClawRemovePlan("worker", { env: current.env, config });
+    const originalRoot = fsSafe.root;
+    let replaced = false;
+    const replaceOwner = () => {
+      const entry = readAgentDeletionJournal("worker", { env: current.env });
+      if (!entry || replaced) {
+        return;
+      }
+      beginAgentDeletionJournal({ ...entry, operationId: "replacement" }, { env: current.env });
+      replaced = true;
+    };
+    const rootSpy = vi.spyOn(fsSafe, "root").mockImplementation(async (...args) => {
+      const workspace = await originalRoot(...args);
+      if (args[0] === current.plan.agent.workspace) {
+        const exists = workspace.exists.bind(workspace);
+        workspace.exists = async (path) => {
+          const found = await exists(path);
+          if (boundary === "discovery" && path === filename) {
+            replaceOwner();
+          }
+          return found;
+        };
+        const readBytes = workspace.readBytes.bind(workspace);
+        workspace.readBytes = async (path, options) => {
+          const bytes = await readBytes(path, options);
+          if (boundary !== "discovery" && path.startsWith(`${filename}.openclaw-claw-remove-`)) {
+            if (boundary === "staged replacement") {
+              await writeFile(join(current.plan.agent.workspace, filename), "replacement\n");
+            }
+            replaceOwner();
+          }
+          return bytes;
+        };
+      }
+      return workspace;
+    });
+    try {
+      await expect(
+        applyClawRemovePlan(plan, {
+          env: current.env,
+          config,
+          consentPlanIntegrity: plan.planIntegrity,
+          monitorGateway: quiescentClawMonitorGateway,
+        }),
+      ).resolves.toMatchObject({
+        status: "partial",
+        agentRemoved: true,
+        error: { message: expect.stringContaining("no longer owns") },
+      });
+      expect(replaced).toBe(true);
+      await expect(readFile(join(current.plan.agent.workspace, filename), "utf8")).resolves.toBe(
+        boundary === "staged replacement" ? "replacement\n" : "managed\n",
+      );
+      const staged = (await readdir(current.plan.agent.workspace)).filter((name) =>
+        name.includes(".openclaw-claw-remove-"),
+      );
+      if (boundary === "staged replacement") {
+        expect(staged).toHaveLength(1);
+        await expect(
+          readFile(join(current.plan.agent.workspace, staged[0]!), "utf8"),
+        ).resolves.toBe("managed\n");
+      } else {
+        expect(staged).toEqual([]);
+      }
+      expect(readAgentDeletionJournal("worker", { env: current.env })?.operationId).toBe(
+        "replacement",
+      );
+    } finally {
+      rootSpy.mockRestore();
+    }
+  });
+});

--- a/src/claws/lifecycle-state.test-helpers.ts
+++ b/src/claws/lifecycle-state.test-helpers.ts
@@ -1,0 +1,33 @@
+import { loadConfig } from "../config/config.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { applyClawAddPlan } from "./add.js";
+import { buildClawRemovalFixture } from "./lifecycle-remove.test-support.js";
+
+export function createClawRemoveTestFixtures(
+  tempDirs: { make: (prefix: string) => string },
+  getState: () => OpenClawTestState,
+) {
+  async function fixture(params: Parameters<typeof buildClawRemovalFixture>[1] = {}) {
+    const current = await buildClawRemovalFixture(tempDirs.make("openclaw-claw-remove-"), params);
+    return { ...current, env: { OPENCLAW_STATE_DIR: getState().stateDir } };
+  }
+
+  async function addFixture(params: Parameters<typeof fixture>[0] = {}) {
+    const current = await fixture(params);
+    let config: OpenClawConfig = {};
+    await applyClawAddPlan(current.plan, {
+      consentPlanIntegrity: current.plan.planIntegrity,
+      env: current.env,
+      commitConfig: async (transform) => {
+        config = transform(config);
+        await getState().writeConfig(config);
+      },
+      cronGateway: { add: async () => ({ id: "scheduler-daily" }) },
+      ...(params.withMcp ? { installMcpServers: async () => [] } : {}),
+    });
+    return { ...current, getConfig: loadConfig };
+  }
+
+  return { fixture, addFixture };
+}

--- a/src/claws/lifecycle-state.test.ts
+++ b/src/claws/lifecycle-state.test.ts
@@ -21,14 +21,11 @@ import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../test-utils/openclaw-test-state.js";
-import { applyClawAddPlan } from "./add.js";
 import { clawCronGatewayInput, markClawCronRefRemoved, readClawCronRefs } from "./cron.js";
 import { withClawAgentConfigRemoval } from "./lifecycle-config-removal.js";
-import {
-  buildClawRemovalFixture,
-  quiescentClawMonitorGateway,
-} from "./lifecycle-remove.test-support.js";
+import { quiescentClawMonitorGateway } from "./lifecycle-remove.test-support.js";
 import { applyClawRemovePlan, buildClawRemovePlan, readClawStatus } from "./lifecycle-state.js";
+import { createClawRemoveTestFixtures } from "./lifecycle-state.test-helpers.js";
 import {
   persistClawInstallRecord,
   persistClawPackageRef,
@@ -45,6 +42,7 @@ afterEach(async () => {
   await state.cleanup();
 });
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+const { fixture, addFixture } = createClawRemoveTestFixtures(tempDirs, () => state);
 
 const packageIntegrity = "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
 
@@ -84,32 +82,6 @@ function seedAttachedCronJob(
     },
     0,
   );
-}
-
-async function fixture(params: Parameters<typeof buildClawRemovalFixture>[1] = {}) {
-  const current = await buildClawRemovalFixture(tempDirs.make("openclaw-claw-remove-"), params);
-  return { ...current, env: { OPENCLAW_STATE_DIR: state.stateDir } };
-}
-
-async function addFixture(
-  params: { withFile?: boolean; withCron?: boolean; withMcp?: boolean } = {},
-) {
-  const current = await fixture(params);
-  let config: OpenClawConfig = {};
-  await applyClawAddPlan(current.plan, {
-    consentPlanIntegrity: current.plan.planIntegrity,
-    env: current.env,
-    commitConfig: async (transform) => {
-      config = transform(config);
-      await state.writeConfig(config);
-    },
-    cronGateway: { add: async () => ({ id: "scheduler-daily" }) },
-    ...(params.withMcp ? { installMcpServers: async () => [] } : {}),
-  });
-  return {
-    ...current,
-    getConfig: loadConfig,
-  };
 }
 
 describe("Claw status and remove", () => {

--- a/src/claws/lifecycle-state.ts
+++ b/src/claws/lifecycle-state.ts
@@ -2,6 +2,8 @@ import { createHash } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { coerceErrorMessage, stableStringify } from "@openclaw/normalization-core";
 import {
+  AgentSharedStoreOwnerError,
+  assertAgentSessionStoreDeletionSafe,
   isPathOwnedBySurvivingAgent,
   readAgentDeleteDatabaseRegistry,
   resolveSurvivingDatabaseFilePaths,
@@ -40,7 +42,7 @@ import {
 import { readClawStatus } from "./lifecycle-status.js";
 import { clawMcpRemovalSelector, planClawMcpServerRemoval } from "./mcp.js";
 import { clawMonitorSnapshotSchema } from "./monitor-cleanup-contract.js";
-import { projectClawPackageRemovePlan } from "./package-remove-plan.js";
+import { filterReferencedCleanup, projectClawPackageRemovePlan } from "./package-remove-plan.js";
 import { applyClawPackageRemovals, planClawPackageRemovals } from "./package-remove.js";
 import { CLAW_OUTPUT_STABILITY } from "./types.js";
 
@@ -107,19 +109,8 @@ export async function buildClawRemovePlan(
   }
   const actions: ClawRemovePlanAction[] = [];
   if (record) {
-    const selectedResources = options.referencedCleanup?.selected ?? [];
-    const packageCleanup = options.referencedCleanup
-      ? {
-          ...options.referencedCleanup,
-          selected: selectedResources.filter((selector) => !selector.startsWith("mcp:")),
-        }
-      : undefined;
-    const mcpCleanup = options.referencedCleanup
-      ? {
-          ...options.referencedCleanup,
-          selected: selectedResources.filter((selector) => selector.startsWith("mcp:")),
-        }
-      : undefined;
+    const packageCleanup = filterReferencedCleanup(options.referencedCleanup, "package");
+    const mcpCleanup = filterReferencedCleanup(options.referencedCleanup, "mcp");
     const packageDecisions = await planClawPackageRemovals(record.install, record.packages, {
       ...options,
       deps: options.packageDeps,
@@ -132,6 +123,14 @@ export async function buildClawRemovePlan(
     });
     blockers.push(...packagePlan.blockers);
     const config = options.config ?? getRuntimeConfig();
+    try {
+      assertAgentSessionStoreDeletionSafe(config, record.install.agentId, options);
+    } catch (error) {
+      if (!(error instanceof AgentSharedStoreOwnerError)) {
+        throw error;
+      }
+      blockers.push({ code: "shared_session_store_owner", message: error.message });
+    }
     const effects = deletionEffects(
       config,
       record.install.agentId,
@@ -465,14 +464,7 @@ export async function applyClawRemovePlan(
   const packageDecisions = await planClawPackageRemovals(record.install, record.packages, {
     ...options,
     deps: options.packageDeps,
-    referencedCleanup: options.referencedCleanup
-      ? {
-          ...options.referencedCleanup,
-          selected: (options.referencedCleanup.selected ?? []).filter(
-            (selector) => !selector.startsWith("mcp:"),
-          ),
-        }
-      : undefined,
+    referencedCleanup: filterReferencedCleanup(options.referencedCleanup, "package"),
   });
   const plannedPackages = plan.actions
     .filter((action) => action.kind === "packageRef")
@@ -532,12 +524,15 @@ export async function applyClawRemovePlan(
       quiesceMonitors: (operationId) => monitorGateway.quiesce(agentId, operationId, monitors),
       drainMonitors: async (operationId) => await monitorGateway.drain(agentId, operationId),
     },
-    async (commitRemoval) => {
+    async (commitRemoval, assertCurrent) => {
+      assertCurrent();
       const mcpRemoval = await removeClawMcpServers({
         agentId,
         servers: record.mcpServers,
         options,
+        assertCurrent,
       });
+      assertCurrent();
       result.mcpServers = mcpRemoval.mcpServers;
       if (mcpRemoval.error) {
         return partial("mcp_cleanup_failed", mcpRemoval.error);
@@ -567,6 +562,7 @@ export async function applyClawRemovePlan(
                 `Cron declaration ${JSON.stringify(cron.manifestId)} changed after planning.`,
               );
             }
+            assertCurrent();
             if (live != null) {
               try {
                 await options.cronGateway!.remove(cron.schedulerJobId!);
@@ -578,6 +574,7 @@ export async function applyClawRemovePlan(
                 }
               }
             }
+            assertCurrent();
             markClawCronRefRemoved(agentId, cron.manifestId, options);
           }
           deleteClawCronRef(agentId, cron.manifestId, options);
@@ -613,6 +610,7 @@ export async function applyClawRemovePlan(
         env: options.env,
         runDatabaseCleanup: configRemoval.runDatabaseCleanup,
       });
+      assertCurrent();
       if (purgeFailed) {
         return partial(
           "session_cleanup_failed",
@@ -628,19 +626,21 @@ export async function applyClawRemovePlan(
         {
           ...options,
           deps: options.packageDeps,
+          assertCurrent,
         },
       );
+      assertCurrent();
       const packageErrors = result.packages.filter((pkg) => pkg.action === "error");
       if (packageErrors.length > 0) {
         return partial("package_cleanup_failed", packageErrors.map((pkg) => pkg.reason).join("; "));
       }
       const workspaceFiles = result.workspaceFiles;
       for (const file of record.workspaceFiles) {
-        configRemoval.assertCurrent();
-        workspaceFiles.push(await removeClawWorkspaceFile(file));
+        assertCurrent();
+        workspaceFiles.push(await removeClawWorkspaceFile(file, assertCurrent));
       }
-      configRemoval.assertCurrent();
-      const bootstrap = await removeClawBootstrap(record);
+      assertCurrent();
+      const bootstrap = await removeClawBootstrap(record, assertCurrent);
       const cleanupErrors = workspaceFiles
         .filter((file) => file.action === "error")
         .map((file) => file.message ?? `Could not remove ${file.path}.`);
@@ -661,6 +661,7 @@ export async function applyClawRemovePlan(
             runtime: clawRemoveQuietRuntime,
             trashPath: options.trashPath,
             stateDatabase: options,
+            assertCurrent,
             retainWorkspace:
               workspaceHasRemainingEntries ||
               bootstrap?.action === "retainedModified" ||

--- a/src/claws/package-remove-plan.ts
+++ b/src/claws/package-remove-plan.ts
@@ -17,6 +17,20 @@ type PackageRemoveAction = {
 
 type PackageRemoveBlocker = { code: string; message: string };
 
+export function filterReferencedCleanup(
+  cleanup: ClawReferencedCleanup | undefined,
+  kind: "package" | "mcp",
+): ClawReferencedCleanup | undefined {
+  return cleanup
+    ? {
+        ...cleanup,
+        selected: (cleanup.selected ?? []).filter(
+          (selector) => selector.startsWith("mcp:") === (kind === "mcp"),
+        ),
+      }
+    : undefined;
+}
+
 export function projectClawPackageRemovePlan(params: {
   decisions: ClawPackageRemovalDecision[];
   inspections: ClawPackageInspection[];

--- a/src/claws/package-remove.test.ts
+++ b/src/claws/package-remove.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { digestClawHubSkillTree } from "../skills/lifecycle/skill-tree-digest.js";
 import { applyClawPackageRemovals, planClawPackageRemovals } from "./package-remove.js";
@@ -228,6 +229,78 @@ describe("Claw package removal", () => {
       expect.anything(),
     );
   });
+
+  it.each(["discovery", "uninstall"])(
+    "refuses package mutations when parent deletion ends during %s",
+    async (stage) => {
+      const ref = packageRef();
+      const store = packageRefStore(ref);
+      const started = createDeferred();
+      const resume = createDeferred();
+      let active = true;
+      const uninstall = vi.fn();
+      const options = {
+        assertCurrent: () => {
+          if (!active) {
+            throw new Error("Parent deletion ended.");
+          }
+        },
+        deps: {
+          ...store,
+          resolvePlugin: vi.fn(async () => {
+            if (stage === "discovery") {
+              started.resolve();
+              await resume.promise;
+            }
+            return {
+              status: "found" as const,
+              pluginId: "audit",
+              record: {
+                source: "clawhub" as const,
+                integrity: "sha256:audit",
+                installedAt: "1970-01-01T00:00:00.001Z",
+              },
+              installedVersion: "1.0.0",
+            };
+          }),
+          uninstallPlugin: vi.fn(
+            async (_id: string, apply?: { beforePersistentApply?: () => void }) => {
+              if (stage === "uninstall") {
+                started.resolve();
+                await resume.promise;
+              }
+              apply?.beforePersistentApply?.();
+              uninstall();
+            },
+          ),
+        },
+      };
+      const removing = applyClawPackageRemovals(
+        [
+          {
+            packageRef: ref,
+            workspace: install.workspace,
+            action: "uninstall",
+            affectedClawAgentIds: [],
+            pluginId: "audit",
+          },
+        ],
+        options,
+      );
+      try {
+        await started.promise;
+        active = false;
+      } finally {
+        resume.resolve();
+      }
+
+      await expect(removing).resolves.toMatchObject([
+        { action: "error", reason: "Parent deletion ended." },
+      ]);
+      expect(uninstall).not.toHaveBeenCalled();
+      expect(store.readPackageRefs()).toEqual([{ ...ref, status: "pending" }]);
+    },
+  );
 
   it("leaves failed provenance when an error occurs after uninstall starts", async () => {
     const ref = packageRef();

--- a/src/claws/package-remove.ts
+++ b/src/claws/package-remove.ts
@@ -378,6 +378,7 @@ export async function planClawPackageRemovals(
 
 type ApplyClawPackageRemovalOptions = OpenClawStateDatabaseOptions & {
   deps?: PackageRemovalDeps;
+  assertCurrent?: () => void;
 };
 
 export async function applyClawPackageRemovals(
@@ -402,6 +403,13 @@ async function applyClawPackageRemovalsUnlocked(
   options: ApplyClawPackageRemovalOptions,
 ): Promise<ClawPackageRemovalResult[]> {
   const deps = options.deps ?? {};
+  const claimPackageRef = (
+    ref: PersistedClawPackageRef,
+    status: PersistedClawPackageRef["status"],
+  ) => {
+    options.assertCurrent?.();
+    return (deps.claimPackageRef ?? updateClawPackageRefStatus)(ref, status, options);
+  };
   const results: ClawPackageRemovalResult[] = [];
   for (const decision of decisions) {
     const base = {
@@ -413,6 +421,7 @@ async function applyClawPackageRemovalsUnlocked(
     let claimed = false;
     let externalMutationStarted = false;
     try {
+      options.assertCurrent?.();
       const leaseArtifact =
         decision.packageRef.kind === "skill"
           ? {
@@ -456,7 +465,7 @@ async function applyClawPackageRemovalsUnlocked(
           );
         }
         if (currentRef.status === "complete") {
-          (deps.claimPackageRef ?? updateClawPackageRefStatus)(currentRef, "pending", options);
+          claimPackageRef(currentRef, "pending");
           claimed = true;
         }
         if (decision.reason === "Another Claw still references this package.") {
@@ -499,7 +508,7 @@ async function applyClawPackageRemovalsUnlocked(
           `Package ${decision.packageRef.ref}@${decision.packageRef.version} ownership changed after removal planning.`,
         );
       }
-      (deps.claimPackageRef ?? updateClawPackageRefStatus)(currentRef, "pending", options);
+      claimPackageRef(currentRef, "pending");
       claimed = true;
       const postClaimRefs = (deps.readPackageRefs ?? readClawPackageRefs)(options);
       const postClaimInstalls =
@@ -549,39 +558,35 @@ async function applyClawPackageRemovalsUnlocked(
             `Plugin ${decision.packageRef.ref}@${decision.packageRef.version} changed after removal planning.`,
           );
         }
+        options.assertCurrent?.();
         externalMutationStarted = true;
         await (deps.uninstallPlugin ?? runPluginUninstallCommand)(decision.pluginId, {
           force: true,
           invalidateRuntimeCache: false,
           clawManaged: true,
+          ...(options.assertCurrent ? { beforePersistentApply: options.assertCurrent } : {}),
         });
       } else {
         if (!decision.skillPlan) {
           throw new Error("Skill removal plan is missing canonical uninstall state.");
         }
+        options.assertCurrent?.();
         externalMutationStarted = true;
         const removed = await (deps.uninstallSkill ?? applyClawHubSkillUninstall)(
           decision.skillPlan,
+          { beforePersistentApply: options.assertCurrent },
         );
         if (!removed.ok) {
           throw new Error(removed.error);
         }
       }
       packageLease.assertCurrent();
-      (deps.claimPackageRef ?? updateClawPackageRefStatus)(
-        decision.packageRef,
-        "complete",
-        options,
-      );
+      claimPackageRef(decision.packageRef, "complete");
       results.push({ ...base, action: "uninstalled" });
     } catch (error) {
       if (claimed) {
         try {
-          (deps.claimPackageRef ?? updateClawPackageRefStatus)(
-            decision.packageRef,
-            externalMutationStarted ? "failed" : "complete",
-            options,
-          );
+          claimPackageRef(decision.packageRef, externalMutationStarted ? "failed" : "complete");
         } catch {
           // Preserve the original cleanup failure as the actionable result.
         }

--- a/src/commands/agents.commands.delete.ts
+++ b/src/commands/agents.commands.delete.ts
@@ -1,6 +1,8 @@
 // Implements agent deletion with gateway delegation and local cleanup fallback.
 import type { AgentsDeleteResult } from "../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import {
+  AgentSharedStoreOwnerError,
+  assertAgentSessionStoreDeletionSafe,
   isPathOwnedBySurvivingAgent,
   prepareAgentDeleteDatabases,
   readAgentDeleteDatabaseRegistry,
@@ -14,7 +16,7 @@ import {
 } from "../agents/agent-delete-safety.js";
 import { normalizeAgentDirRegistryPath } from "../agents/agent-dir-registry.js";
 import {
-  beginAgentDeletion,
+  withAgentDeletion,
   claimCompletedAgentDeletion,
 } from "../agents/agent-lifecycle-registry.js";
 import {
@@ -96,7 +98,7 @@ function logClearedOwnerRefs(runtime: RuntimeEnv, clearedOwnerRefs: readonly str
 function logSessionPurgeWarning(runtime: RuntimeEnv, agentId: string, purgeFailed: boolean): void {
   if (purgeFailed) {
     runtime.error(
-      `Warning: session-store purge failed for deleted agent "${agentId}"; stale shared-store rows may remain.`,
+      `Warning: session-store purge failed for deleted agent "${agentId}"; source data was retained. Retry deletion after resolving the storage error.`,
     );
   }
 }
@@ -177,6 +179,15 @@ export async function agentsDeleteCommand(
   if (!safetyAgentDir) {
     throw new Error(`Agent "${agentId}" deletion has no state directory.`);
   }
+  try {
+    assertAgentSessionStoreDeletionSafe(cfg, agentId);
+  } catch (error) {
+    if (!(error instanceof AgentSharedStoreOwnerError)) {
+      throw error;
+    }
+    failAgentsDelete(opts, runtime, error.message);
+    return;
+  }
   const sharedAuthOwnership = resolveSharedAuthStoreOwnership();
   if (
     isSharedAuthStoreOwner({
@@ -209,9 +220,6 @@ export async function agentsDeleteCommand(
   if (configured) {
     existingJournal = readAgentDeletionJournal(agentId);
     if (existingJournal?.cleanupCompleted) {
-      if (!claimCompletedAgentDeletion(agentId, existingJournal.operationId)) {
-        throw new Error(`Agent "${agentId}" deletion tombstone changed before fresh deletion.`);
-      }
       existingJournal = undefined;
     }
   }
@@ -280,148 +288,173 @@ export async function agentsDeleteCommand(
     return;
   }
 
-  const workspaceSharedWith = findOverlappingWorkspaceAgentIds(cfg, agentId, workspaceDir);
+  return await withAgentDeletion(agentId, async (begin) => {
+    existingJournal = readAgentDeletionJournal(agentId);
+    if (configured && existingJournal?.cleanupCompleted) {
+      if (!claimCompletedAgentDeletion(agentId, existingJournal.operationId)) {
+        throw new Error(`Agent "${agentId}" deletion tombstone changed before fresh deletion.`);
+      }
+      existingJournal = undefined;
+    }
+    if (!configured && (!existingJournal || existingJournal.cleanupCompleted)) {
+      throw new Error(`Agent "${agentId}" deletion already completed.`);
+    }
+    assertAgentSessionStoreDeletionSafe(cfg, agentId);
+    const workspaceSharedWith = findOverlappingWorkspaceAgentIds(cfg, agentId, workspaceDir);
 
-  const deleteFiles = existingJournal?.deleteFiles ?? true;
-  const deletion = beginAgentDeletion(
-    existingJournal ?? { agentId, agentDir, workspaceDir, sessionsDir, deleteFiles },
-  );
-  try {
-    prepareAgentDeleteDatabases(cfg, agentId, agentDir);
-    const commitRoster = async () =>
-      await withAgentExecApprovalsRemoved(agentId, async () => {
-        if (configured) {
-          await replaceConfigFile({
-            ...writeSnapshot,
-            sourceConfig: result.config,
-            writeOptions: {
-              ...writeSnapshot.writeOptions,
-              allowedAgentRosterRemovals: [agentId],
-              ...(opts.json ? { skipOutputLogs: true } : {}),
-            },
-          });
-          if (!opts.json) {
-            logConfigUpdated(runtime);
+    const deleteFiles = existingJournal?.deleteFiles ?? true;
+    const deletion = begin(
+      existingJournal ?? { agentId, agentDir, workspaceDir, sessionsDir, deleteFiles },
+    );
+    try {
+      prepareAgentDeleteDatabases(cfg, agentId, agentDir);
+      const commitRoster = async () =>
+        await withAgentExecApprovalsRemoved(agentId, async () => {
+          deletion.assertCurrent();
+          if (configured) {
+            await replaceConfigFile({
+              ...writeSnapshot,
+              sourceConfig: result.config,
+              writeOptions: {
+                ...writeSnapshot.writeOptions,
+                allowedAgentRosterRemovals: [agentId],
+                assertConfigPathForWrite: () => {
+                  writeSnapshot.writeOptions.assertConfigPathForWrite?.();
+                  deletion.assertCurrent();
+                },
+                ...(opts.json ? { skipOutputLogs: true } : {}),
+              },
+            });
+            if (!opts.json) {
+              logConfigUpdated(runtime);
+            }
           }
-        }
-      });
-    if (gatewayAttempt.kind === "fallback-unreachable") {
-      await withLocalAgentCronJobsRemoved(agentId, () => cfg, commitRoster);
-    } else {
-      // Credential resolution fails before transport, so a live scheduler may still own the store.
-      await commitRoster();
-    }
-  } catch (error) {
-    if (!existingJournal) {
-      deletion.rollback();
-    }
-    throw error;
-  }
-
-  // Purge session store entries for this agent so orphaned sessions cannot be targeted (#65524).
-  const purgeFailed = await purgeAgentSessionStoreEntries(cfg, agentId, {
-    runDatabaseCleanup: deletion.runDatabaseCleanup,
-  });
-  // Directory ownership is process-local; resolve survivors before the destructive recheck.
-  for (const survivingAgentId of listAgentIds(result.config)) {
-    resolveAgentDir(result.config, survivingAgentId);
-  }
-  const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
-    readAgentDeleteDatabaseRegistry(),
-    agentId,
-  );
-  const sharedWithSurvivor = (pathname: string) =>
-    isPathOwnedBySurvivingAgent(result.config, agentId, pathname, survivingDatabaseFilePaths);
-  const workspaceRetained = sharedWithSurvivor(workspaceDir);
-
-  const quietRuntime = opts.json ? createQuietRuntime(runtime) : runtime;
-  // Only trash the workspace if no other agent can depend on that path (#70890).
-  let workspaceCleanupError: Error | undefined;
-  const removed: AgentDeleteRemovedPath[] = [];
-  const failed: AgentDeleteFailedPath[] = [];
-  const removePath = async (pathname: string) => {
-    const outcome = await moveToTrashResult(pathname, quietRuntime);
-    if ("removed" in outcome) {
-      removed.push(outcome.removed);
-    } else {
-      failed.push(outcome.failed);
-    }
-    return outcome;
-  };
-  if (deleteFiles && !purgeFailed && workspaceRetained) {
-    quietRuntime.log(
-      `Skipped workspace removal (shared with other agents${workspaceSharedWith.length ? `: ${workspaceSharedWith.join(", ")}` : ""}): ${workspaceDir}`,
-    );
-  } else if (deleteFiles && !purgeFailed) {
-    const legacyPlan = prepareLegacyWorkspaceStateReset(workspaceDir);
-    const statePlan = prepareWorkspaceStateDeletion(workspaceDir);
-    const workspaceResult = await removePath(workspaceDir);
-    if ("removed" in workspaceResult) {
-      try {
-        const legacyCleanup = await removeLegacyWorkspaceStateForReset(legacyPlan);
-        for (const warning of legacyCleanup.warnings) {
-          quietRuntime.log(warning);
-        }
-        deleteWorkspaceState(statePlan);
-      } catch (error) {
-        workspaceCleanupError = error instanceof Error ? error : new Error(String(error));
+        });
+      if (gatewayAttempt.kind === "fallback-unreachable") {
+        await withLocalAgentCronJobsRemoved(agentId, () => cfg, commitRoster);
+      } else {
+        // Credential resolution fails before transport, so a live scheduler may still own the store.
+        await commitRoster();
       }
+      deletion.assertCurrent();
+    } catch (error) {
+      if (!existingJournal) {
+        deletion.rollback();
+      }
+      throw error;
     }
-  }
-  if (deleteFiles && !purgeFailed) {
-    const canonicalAgentDir = normalizeAgentDirRegistryPath(agentDir);
-    const databasePaths = deletion.entry.databasePaths.filter((pathname) => {
-      const canonicalPath = normalizeAgentDirRegistryPath(pathname);
-      return !isPathInside(canonicalAgentDir, canonicalPath) && !sharedWithSurvivor(pathname);
+
+    // Purge session store entries for this agent so orphaned sessions cannot be targeted (#65524).
+    const purgeFailed = await purgeAgentSessionStoreEntries(cfg, agentId, {
+      runDatabaseCleanup: deletion.runDatabaseCleanup,
     });
-    for (const directory of [agentDir, sessionsDir]) {
-      if (!sharedWithSurvivor(directory)) {
-        await removePath(directory);
-      }
+    deletion.assertCurrent();
+    // Directory ownership is process-local; resolve survivors before the destructive recheck.
+    for (const survivingAgentId of listAgentIds(result.config)) {
+      resolveAgentDir(result.config, survivingAgentId);
     }
-    for (const databasePath of databasePaths) {
-      await removePath(databasePath);
-    }
-  }
-  if (workspaceCleanupError) {
-    throw workspaceCleanupError;
-  }
-  if (failed.length === 0 && !purgeFailed) {
-    if (deleteFiles) {
-      // Keep registry ownership until every cleanup target is terminal. A crash before journal
-      // completion leaves this idempotent deregistration reachable on the next delete attempt.
-      unregisterOpenClawAgentDatabases({ agentId });
-    }
-    deletion.finish();
-  }
-
-  if (opts.json) {
-    writeRuntimeJson(runtime, {
+    const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
+      readAgentDeleteDatabaseRegistry(),
       agentId,
-      workspace: workspaceDir,
-      workspaceRetained: workspaceRetained || undefined,
-      workspaceRetainedReason: workspaceRetained ? "shared" : undefined,
-      workspaceSharedWith: workspaceRetained ? workspaceSharedWith : undefined,
-      agentDir,
-      sessionsDir,
-      removedBindings: result.removedBindings,
-      removedAllow: result.removedAllow,
-      clearedOwnerRefs: result.clearedOwnerRefs.length > 0 ? result.clearedOwnerRefs : undefined,
-      removed,
-      failed,
-      ...(purgeFailed ? { purgeFailed: true } : {}),
-      ...(gatewayAttempt.kind === "fallback-credentials-required"
-        ? { cronCleanupSkipped: true }
-        : {}),
-    });
-  } else {
-    runtime.log(`Deleted agent: ${agentId}`);
-    logClearedOwnerRefs(runtime, result.clearedOwnerRefs);
-    logSessionPurgeWarning(runtime, agentId, purgeFailed);
-  }
-  if (gatewayAttempt.kind === "fallback-credentials-required") {
-    runtime.error(
-      `Warning: cron cleanup was skipped for deleted agent "${agentId}" because the Gateway could not be authenticated; scheduled jobs may remain.`,
     );
-  }
+    const sharedWithSurvivor = (pathname: string) =>
+      isPathOwnedBySurvivingAgent(result.config, agentId, pathname, survivingDatabaseFilePaths);
+    const workspaceRetained = sharedWithSurvivor(workspaceDir);
+
+    const quietRuntime = opts.json ? createQuietRuntime(runtime) : runtime;
+    // Only trash the workspace if no other agent can depend on that path (#70890).
+    let workspaceCleanupError: Error | undefined;
+    const removed: AgentDeleteRemovedPath[] = [];
+    const failed: AgentDeleteFailedPath[] = [];
+    const removePath = async (pathname: string) => {
+      const outcome = await moveToTrashResult(pathname, quietRuntime, deletion.assertCurrent);
+      deletion.assertCurrent();
+      if ("removed" in outcome) {
+        removed.push(outcome.removed);
+      } else {
+        failed.push(outcome.failed);
+      }
+      return outcome;
+    };
+    if (deleteFiles && !purgeFailed && workspaceRetained) {
+      quietRuntime.log(
+        `Skipped workspace removal (shared with other agents${workspaceSharedWith.length ? `: ${workspaceSharedWith.join(", ")}` : ""}): ${workspaceDir}`,
+      );
+    } else if (deleteFiles && !purgeFailed) {
+      const legacyPlan = prepareLegacyWorkspaceStateReset(workspaceDir);
+      const statePlan = prepareWorkspaceStateDeletion(workspaceDir);
+      const workspaceResult = await removePath(workspaceDir);
+      if ("removed" in workspaceResult) {
+        try {
+          const legacyCleanup = await removeLegacyWorkspaceStateForReset(legacyPlan, {
+            assertCurrent: deletion.assertCurrent,
+          });
+          for (const warning of legacyCleanup.warnings) {
+            quietRuntime.log(warning);
+          }
+          deletion.assertCurrent();
+          deleteWorkspaceState(statePlan);
+        } catch (error) {
+          workspaceCleanupError = error instanceof Error ? error : new Error(String(error));
+        }
+      }
+    }
+    if (deleteFiles && !purgeFailed) {
+      const canonicalAgentDir = normalizeAgentDirRegistryPath(agentDir);
+      const databasePaths = deletion.entry.databasePaths.filter((pathname) => {
+        const canonicalPath = normalizeAgentDirRegistryPath(pathname);
+        return !isPathInside(canonicalAgentDir, canonicalPath) && !sharedWithSurvivor(pathname);
+      });
+      for (const directory of [agentDir, sessionsDir]) {
+        if (!sharedWithSurvivor(directory)) {
+          await removePath(directory);
+        }
+      }
+      for (const databasePath of databasePaths) {
+        await removePath(databasePath);
+      }
+    }
+    if (workspaceCleanupError) {
+      throw workspaceCleanupError;
+    }
+    deletion.assertCurrent();
+    if (failed.length === 0 && !purgeFailed) {
+      if (deleteFiles) {
+        // Keep registry ownership until every cleanup target is terminal. A crash before journal
+        // completion leaves this idempotent deregistration reachable on the next delete attempt.
+        unregisterOpenClawAgentDatabases({ agentId });
+      }
+      deletion.finish();
+    }
+
+    if (opts.json) {
+      writeRuntimeJson(runtime, {
+        agentId,
+        workspace: workspaceDir,
+        workspaceRetained: workspaceRetained || undefined,
+        workspaceRetainedReason: workspaceRetained ? "shared" : undefined,
+        workspaceSharedWith: workspaceRetained ? workspaceSharedWith : undefined,
+        agentDir,
+        sessionsDir,
+        removedBindings: result.removedBindings,
+        removedAllow: result.removedAllow,
+        clearedOwnerRefs: result.clearedOwnerRefs.length > 0 ? result.clearedOwnerRefs : undefined,
+        removed,
+        failed,
+        ...(purgeFailed ? { purgeFailed: true } : {}),
+        ...(gatewayAttempt.kind === "fallback-credentials-required"
+          ? { cronCleanupSkipped: true }
+          : {}),
+      });
+    } else {
+      runtime.log(`Deleted agent: ${agentId}`);
+      logClearedOwnerRefs(runtime, result.clearedOwnerRefs);
+      logSessionPurgeWarning(runtime, agentId, purgeFailed);
+    }
+    if (gatewayAttempt.kind === "fallback-credentials-required") {
+      runtime.error(
+        `Warning: cron cleanup was skipped for deleted agent "${agentId}" because the Gateway could not be authenticated; scheduled jobs may remain.`,
+      );
+    }
+  });
 }

--- a/src/commands/agents.delete.test.ts
+++ b/src/commands/agents.delete.test.ts
@@ -248,6 +248,52 @@ describe("agents delete command", () => {
     });
   });
 
+  it.each(["relocated", "agent directory"])(
+    "refuses deleting a shared session database owner at a %s locator before any mutation",
+    async (location) => {
+      await withStateDirEnv("openclaw-agents-delete-shared-owner-", async ({ stateDir }) => {
+        const storePath =
+          location === "relocated"
+            ? path.join(stateDir, "shared.sqlite")
+            : path.join(stateDir, "agents", "alpha", "agent", "openclaw-agent.sqlite");
+        const cfg: OpenClawConfig = {
+          agents: {
+            ownership: "explicit",
+            entries: { alpha: {}, ops: {} },
+          },
+          session: { store: storePath },
+        };
+        openOpenClawAgentDatabase({ agentId: "alpha", path: storePath });
+        const sessions = {
+          "agent:alpha:main": { sessionId: "alpha-session", updatedAt: 1 },
+          ...(location === "relocated"
+            ? { "agent:ops:main": { sessionId: "ops-session", updatedAt: 2 } }
+            : {}),
+        };
+        await arrangeAgentsDeleteTest({ stateDir, cfg, deletedAgentId: "alpha", sessions });
+        saveExecApprovals({ version: 1, agents: { alpha: { security: "deny" } } });
+        const approvals = readExecApprovalsSnapshot();
+
+        await agentsDeleteCommand({ id: "alpha", force: true, json: true }, runtime);
+
+        expect(readJsonLogs()).toEqual([
+          expect.objectContaining({
+            ok: false,
+            error: expect.objectContaining({
+              message: expect.stringContaining('still used by agent "ops"'),
+            }),
+          }),
+        ]);
+        expect(configMocks.replaceConfigFile).not.toHaveBeenCalled();
+        expect(gatewayMocks.callGateway).not.toHaveBeenCalled();
+        expect(fsSafeMocks.movePathToTrash).not.toHaveBeenCalled();
+        expect(readAgentDeletionJournal("alpha")).toBeUndefined();
+        expect(readExecApprovalsSnapshot()).toEqual(approvals);
+        expectSessionStore(cfg, sessions, "alpha");
+      });
+    },
+  );
+
   it("deletes main normally after shared auth ownership moves to state SQLite", async () => {
     await withStateDirEnv("openclaw-agents-delete-relocated-auth-", async ({ stateDir }) => {
       const cfg: OpenClawConfig = {
@@ -399,7 +445,7 @@ describe("agents delete command", () => {
         `Warning: path could not be moved to Trash: trash unavailable; remove it manually at ${workspace}`,
       );
       expect(runtime.error).toHaveBeenCalledWith(
-        'Warning: session-store purge failed for deleted agent "ops"; stale shared-store rows may remain.',
+        'Warning: session-store purge failed for deleted agent "ops"; source data was retained. Retry deletion after resolving the storage error.',
       );
       expect(runtime.exit).not.toHaveBeenCalled();
     });

--- a/src/commands/cleanup-utils.test.ts
+++ b/src/commands/cleanup-utils.test.ts
@@ -14,6 +14,7 @@ import { resolveGatewayLockDir } from "../config/paths.js";
 import { acquireGatewayLock, GatewayLockError } from "../infra/gateway-lock.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
+import { createTestRuntime } from "./test-runtime-config-helpers.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -113,6 +114,22 @@ function expectedTrashSourcePath(targetPath: string): string {
 }
 
 describe("moveToTrash", () => {
+  it("retains the target when ownership expires during asynchronous preparation", async () => {
+    const targetPath = path.join(tempDirs.make("openclaw-trash-expired-"), "target");
+    await fs.writeFile(targetPath, "retain me");
+    let owned = true;
+    const removal = moveToTrash(targetPath, createTestRuntime(), () => {
+      if (!owned) {
+        throw new Error("cleanup ownership expired");
+      }
+    });
+    owned = false;
+
+    await expect(removal).resolves.toBe(false);
+    expect(fsSafeMocks.movePathToTrash).not.toHaveBeenCalled();
+    expect(await fs.readFile(targetPath, "utf8")).toBe("retain me");
+  });
+
   it("uses fs-safe trash instead of resolving a PATH trash command", async () => {
     const testRoot = fsSync.mkdtempSync(path.join(os.tmpdir(), "openclaw-trash-helper-"));
     const targetPath = path.join(testRoot, "target");

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -61,6 +61,7 @@ function trashFailure(pathname: string, error: unknown, runtime: RuntimeEnv): Mo
 export async function moveToTrashResult(
   pathname: string,
   runtime: RuntimeEnv,
+  assertCurrent?: () => void,
 ): Promise<MoveToTrashResult> {
   if (!pathname) {
     return { failed: { path: pathname, reason: "path is empty" } };
@@ -75,9 +76,10 @@ export async function moveToTrashResult(
   try {
     const targetPath = path.resolve(pathname);
     const sourcePath = await resolveMoveToTrashSourcePath(targetPath);
-    await movePathToTrash(sourcePath, {
-      allowedRoots: await resolveMoveToTrashAllowedRoots(sourcePath),
-    });
+    const allowedRoots = await resolveMoveToTrashAllowedRoots(sourcePath);
+    // Preparation can outlive its owner; revalidate immediately before Trash dispatch.
+    assertCurrent?.();
+    await movePathToTrash(sourcePath, { allowedRoots });
     runtime.log(`Moved to Trash: ${shortenHomePath(pathname)}`);
     return { removed: { path: pathname, method: "trash" } };
   } catch (error) {
@@ -86,8 +88,12 @@ export async function moveToTrashResult(
 }
 
 /** Moves a path to Trash when it exists, logging a manual-delete fallback on failure. */
-export async function moveToTrash(pathname: string, runtime: RuntimeEnv): Promise<boolean> {
-  return "removed" in (await moveToTrashResult(pathname, runtime));
+export async function moveToTrash(
+  pathname: string,
+  runtime: RuntimeEnv,
+  assertCurrent?: () => void,
+): Promise<boolean> {
+  return "removed" in (await moveToTrashResult(pathname, runtime, assertCurrent));
 }
 
 async function resolveMoveToTrashSourcePath(targetPath: string): Promise<string> {

--- a/src/commands/onboard-agent.persistence.test.ts
+++ b/src/commands/onboard-agent.persistence.test.ts
@@ -19,7 +19,7 @@ import { runSessionStartupMigration } from "../config/sessions/startup-migration
 import { resetAgentRunRegistryForTest } from "../infra/agent-run-registry.js";
 import {
   beginAgentDeletionJournal,
-  completeAgentDeletionJournal,
+  completeAgentDeletionJournalInDatabase,
   readAgentDeletionJournal,
 } from "../state/agent-deletion-journal.js";
 import { readAgentProvenance } from "../state/agent-provenance.js";
@@ -29,7 +29,10 @@ import {
   runOpenClawAgentWriteTransaction,
 } from "../state/openclaw-agent-db.js";
 import { withExistingOpenClawStateDatabaseReadOnly } from "../state/openclaw-state-db-readonly.js";
-import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import {
+  closeOpenClawStateDatabaseForTest,
+  runOpenClawStateWriteTransaction,
+} from "../state/openclaw-state-db.js";
 import { captureEnv, deleteTestEnvValue, setTestEnvValue } from "../test-utils/env.js";
 import { ensureOnboardingAgent } from "./onboard-agent.js";
 
@@ -288,7 +291,9 @@ describe("onboarding authored config persistence", () => {
             sessionsDir: path.join(stateDir, "agents", "robby", "sessions"),
             workspaceDir: path.join(stateDir, "workspace"),
           });
-          completeAgentDeletionJournal("robby", "previous-robby");
+          runOpenClawStateWriteTransaction((sharedStateDatabase) =>
+            completeAgentDeletionJournalInDatabase(sharedStateDatabase, "robby", "previous-robby"),
+          );
           migrationWindow.afterPublication = () => {
             beforePersistentApply();
             admission.close();

--- a/src/commands/tasks-session-registry-maintenance.test.ts
+++ b/src/commands/tasks-session-registry-maintenance.test.ts
@@ -1,14 +1,19 @@
 // Covers session-registry sweep isolation: unreadable cron facts fail the whole
 // sweep closed, while completed agent deletions are reported as per-store skips.
+import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { loadSessionEntry, replaceSessionEntry } from "../config/sessions/session-accessor.js";
 import { resolveSqliteTargetFromSessionStorePath } from "../config/sessions/session-sqlite-target.js";
 import type { RuntimeEnv } from "../runtime.js";
+import {
+  beginAgentDeletionJournal,
+  completeAgentDeletionJournalInDatabase,
+} from "../state/agent-deletion-journal.js";
 import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { runOpenClawStateWriteTransaction } from "../state/openclaw-state-db.js";
 import * as taskRegistryMaintenance from "../tasks/task-registry.maintenance.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { OpenClawTestState } from "../test-utils/openclaw-test-state.js";
@@ -38,15 +43,18 @@ function writeAgentDeletion(
   agentId: string,
   cleanupCompleted: boolean,
 ): void {
-  const deletion = beginAgentDeletion({
+  const deletion = beginAgentDeletionJournal({
     agentId,
+    operationId: randomUUID(),
     agentDir: state.agentDir(agentId),
     workspaceDir: state.path(`workspace-${agentId}`),
     sessionsDir: state.sessionsDir(agentId),
     deleteFiles: false,
   });
   if (cleanupCompleted) {
-    deletion.finish();
+    runOpenClawStateWriteTransaction((database) =>
+      completeAgentDeletionJournalInDatabase(database, deletion.agentId, deletion.operationId),
+    );
   }
 }
 

--- a/src/config/mcp-config.ts
+++ b/src/config/mcp-config.ts
@@ -128,6 +128,7 @@ async function commitConfiguredMcpServers(params: {
   errorLabel: string;
   success?: { removed?: boolean; updated?: boolean };
   independentlyOwnedName?: string;
+  assertCurrent?: () => void;
   mutation?: { name: string; onCommitted?: McpConfigMutationHook };
 }): Promise<ConfigMcpWriteResult> {
   const next = structuredClone(params.loaded.config);
@@ -153,7 +154,13 @@ async function commitConfiguredMcpServers(params: {
   const committed = await replaceConfigFile({
     sourceConfig: next,
     baseHash: params.loaded.baseHash,
-    writeOptions: params.writeOptions,
+    writeOptions: {
+      ...params.writeOptions,
+      assertConfigPathForWrite: () => {
+        params.writeOptions.assertConfigPathForWrite?.();
+        params.assertCurrent?.();
+      },
+    },
   });
   if (params.mutation?.onCommitted) {
     const previous = params.loaded.mcpServers[params.mutation.name];
@@ -357,6 +364,7 @@ async function unsetConfiguredMcpServer(
   params: {
     name: string;
     expectedServer?: Record<string, unknown>;
+    assertCurrent?: () => void;
   },
   onCommitted?: McpConfigMutationHook,
 ): Promise<ConfigMcpWriteResult> {
@@ -396,6 +404,7 @@ async function unsetConfiguredMcpServer(
     servers,
     errorLabel: "unset",
     success: { removed: true },
+    assertCurrent: params.assertCurrent,
     mutation: { name, onCommitted },
   });
 }

--- a/src/config/sessions/startup-migration.registry-recovery.test.ts
+++ b/src/config/sessions/startup-migration.registry-recovery.test.ts
@@ -1,9 +1,14 @@
+import { randomUUID } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
 import * as sessionDirs from "../../agents/session-dirs.js";
 import * as nodeSqlite from "../../infra/node-sqlite.js";
+import {
+  beginAgentDeletionJournal,
+  completeAgentDeletionJournalInDatabase,
+} from "../../state/agent-deletion-journal.js";
 import { invalidateRegisteredAgentDatabasesMemo } from "../../state/openclaw-agent-db-registry-listing.js";
 import { unregisterOpenClawAgentDatabase } from "../../state/openclaw-agent-db-registry.js";
 import {
@@ -12,10 +17,12 @@ import {
   isOpenClawAgentDatabaseOpen,
   listOpenClawRegisteredAgentDatabases,
   openOpenClawAgentDatabase,
+  type OpenClawAgentDatabaseOptions,
 } from "../../state/openclaw-agent-db.js";
 import {
   closeOpenClawStateDatabaseForTest,
   repairOpenClawStateDatabaseSchemaIfNeeded,
+  runOpenClawStateWriteTransaction,
 } from "../../state/openclaw-state-db.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import type { OpenClawConfig } from "../types.openclaw.js";
@@ -26,7 +33,9 @@ import {
   setCanonicalSqliteSessionMainKey,
 } from "./session-canonical-key.js";
 import { resolveSqliteTargetFromSessionStorePath } from "./session-sqlite-target.js";
+import { reconcileSessionTranscriptIndexes } from "./session-transcript-reconcile.js";
 import { runSessionStartupMigration } from "./startup-migration.js";
+import { resolveAllAgentSessionStoreTargetsSync } from "./targets.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -99,6 +108,68 @@ it("does not create a missing configured agent database during startup maintenan
   expect(fs.existsSync(sqlitePath)).toBe(false);
   expect(migrateManagedWorktreeCanonicalWorkspaces).not.toHaveBeenCalled();
 });
+
+it.each([false, true])(
+  "reconciles surviving stores while retained deleted stores stay fenced (cleanup completed: %s)",
+  async (cleanupCompleted) => {
+    const stateDir = fs.realpathSync.native(tempDirs.make("openclaw-startup-deleted-agent-"));
+    const env = { ...process.env, OPENCLAW_STATE_DIR: stateDir };
+    const sharedPath = path.join(stateDir, "shared.sqlite");
+    const cfg: OpenClawConfig = {
+      agents: { ownership: "explicit", entries: { alpha: {} } },
+      session: { store: sharedPath },
+    };
+    const survivorOptions = { agentId: "alpha", env, path: sharedPath };
+    const survivor = openOpenClawAgentDatabase(survivorOptions);
+    const deletedOptions = { agentId: "ops", env };
+    const deleted = openOpenClawAgentDatabase(deletedOptions);
+    for (const agentId of ["alpha", "ops"]) {
+      await replaceSessionEntry(
+        { agentId, env, storePath: sharedPath, sessionKey: `agent:${agentId}:shared` },
+        { sessionId: `${agentId}-shared`, updatedAt: 1 },
+      );
+    }
+    setCanonicalSqliteSessionMainKey(survivor, "previous");
+    setCanonicalSqliteSessionMainKey(deleted, "previous");
+    closeOpenClawAgentDatabasesForTest();
+    const deletion = beginAgentDeletionJournal(
+      {
+        agentId: "ops",
+        operationId: randomUUID(),
+        agentDir: path.dirname(deleted.path),
+        sessionsDir: path.join(stateDir, "agents", "ops", "sessions"),
+        workspaceDir: path.join(stateDir, "workspace-ops"),
+        deleteFiles: false,
+      },
+      { env },
+    );
+    if (cleanupCompleted) {
+      runOpenClawStateWriteTransaction(
+        (database) => completeAgentDeletionJournalInDatabase(database, "ops", deletion.operationId),
+        { env },
+      );
+    }
+    expect(resolveAllAgentSessionStoreTargetsSync(cfg, { env })).toContainEqual(
+      expect.objectContaining({ agentId: "ops" }),
+    );
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const handoffDatabase = vi.fn(async (options: OpenClawAgentDatabaseOptions) => {
+      await reconcileSessionTranscriptIndexes(options);
+    });
+
+    await runSessionStartupMigration({ cfg, env, log, handoffDatabase });
+
+    expect(handoffDatabase).toHaveBeenCalledExactlyOnceWith(survivorOptions);
+    expect(isCanonicalSqliteSessionMainKeyCurrent(survivorOptions, undefined)).toBe(true);
+    expect(isCanonicalSqliteSessionMainKeyCurrent(deletedOptions, "previous")).toBe(true);
+    expect(isOpenClawAgentDatabaseOpen(deleted.path)).toBe(false);
+    expect(() => openOpenClawAgentDatabase(deletedOptions)).toThrow("agent ops is deleted");
+    expect(log.warn).not.toHaveBeenCalled();
+    expect(log.info).toHaveBeenCalledWith(
+      expect.stringContaining(cleanupCompleted ? "cleanup complete" : "cleanup pending"),
+    );
+  },
+);
 
 it("re-registers durable lineage children before configured-only runtime reads", async () => {
   const root = fs.realpathSync.native(tempDirs.make("openclaw-startup-registry-recovery-"));

--- a/src/config/sessions/startup-migration.ts
+++ b/src/config/sessions/startup-migration.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { formatCliCommand } from "../../cli/command-format.js";
 import { formatDoctorStateRepairFailure } from "../../infra/state-repair-message.js";
+import { readAgentDeletionJournal } from "../../state/agent-deletion-journal.js";
 import { listOpenClawRegisteredAgentDatabases } from "../../state/openclaw-agent-db-registry.js";
 import {
   closeOpenClawAgentDatabaseByPath,
@@ -100,6 +101,15 @@ export async function runSessionStartupMigration(params: {
       continue;
     }
     databases.add(databasePath);
+    // Retained stores remain discoverable, but only deletion cleanup may write them.
+    // Check the physical owner so surviving shared stores still reach their runtime.
+    const deletion = readAgentDeletionJournal(options.agentId, { env });
+    if (deletion) {
+      params.log.info(
+        `session: skipping deleted agent database for ${options.agentId} (${deletion.cleanupCompleted ? "cleanup complete" : "cleanup pending; retry agent deletion"})`,
+      );
+      continue;
+    }
     const alreadyOpen = isOpenClawAgentDatabaseOpen(databasePath);
     let handedOff = false;
     try {

--- a/src/gateway/github-oauth-lifecycle.test.ts
+++ b/src/gateway/github-oauth-lifecycle.test.ts
@@ -1,8 +1,8 @@
+import { randomUUID } from "node:crypto";
 import { isDeepStrictEqual } from "node:util";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ToolsGitHubStatusResult } from "../../packages/gateway-protocol/src/index.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
-import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
 import {
   inspectGitHubOAuthRecord,
   listGitHubDeviceAuthorizationRecords,
@@ -21,6 +21,10 @@ import {
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { GitHubToolIdentityConfig } from "../config/types.tools.js";
 import { writeHiddenGitHubSecretRecord } from "../secrets/store/secret-store.js";
+import {
+  beginAgentDeletionJournal,
+  removeAgentDeletionJournal,
+} from "../state/agent-deletion-journal.js";
 import { recordAgentProvenance } from "../state/agent-provenance.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 
@@ -715,21 +719,26 @@ describe("GitHub OAuth authorization lifecycle", () => {
     currentConfig = configForScope("agent");
     const lifecycle = createLifecycle();
     const started = await startAuthorization(lifecycle, "agent");
-    const deletion = beginAgentDeletion({
+    const deletion = beginAgentDeletionJournal({
       agentId: "main",
+      operationId: randomUUID(),
       agentDir: "/agents/main",
       workspaceDir: "/workspaces/main",
       sessionsDir: "/sessions/main",
+      deleteFiles: true,
     });
-    await advanceToPoll(started.requestId);
+    try {
+      await advanceToPoll(started.requestId);
 
-    await expect(lifecycle.pollAuthorization(started.requestId)).resolves.toEqual({
-      status: "failed",
-      reason: "identity_changed",
-    });
-    expect(mocks.pollDeviceToken).not.toHaveBeenCalled();
-    expect(mocks.installProfile).not.toHaveBeenCalled();
-    deletion.rollback();
+      await expect(lifecycle.pollAuthorization(started.requestId)).resolves.toEqual({
+        status: "failed",
+        reason: "identity_changed",
+      });
+      expect(mocks.pollDeviceToken).not.toHaveBeenCalled();
+      expect(mocks.installProfile).not.toHaveBeenCalled();
+    } finally {
+      removeAgentDeletionJournal(deletion.agentId, deletion.operationId);
+    }
   });
 
   it("rejects an agent authorization after same-id recreation gets fresh provenance", async () => {

--- a/src/gateway/server-claws-monitors.test.ts
+++ b/src/gateway/server-claws-monitors.test.ts
@@ -4,7 +4,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
-import { beginAgentDeletion, isAgentDeletionBlocked } from "../agents/agent-lifecycle-registry.js";
+import {
+  withAgentDeletion,
+  isAgentDeletionBlocked,
+  type AgentDeletionOperation,
+} from "../agents/agent-lifecycle-registry.js";
 import { listAgentEntries } from "../agents/agent-scope.js";
 import { applyClawAddPlan } from "../claws/add.js";
 import type { ClawRemoveApplyOptions } from "../claws/lifecycle-remove-contract.js";
@@ -36,7 +40,10 @@ import {
   releaseLocalCronRunReceiptOwnership,
 } from "../cron/store/run-receipt-store.js";
 import { getFileLockProcessStartTime } from "../shared/pid-alive.js";
-import { readAgentDeletionJournal } from "../state/agent-deletion-journal.js";
+import {
+  beginAgentDeletionJournal,
+  readAgentDeletionJournal,
+} from "../state/agent-deletion-journal.js";
 import { openOpenClawAgentDatabase } from "../state/openclaw-agent-db.js";
 import {
   closeOpenClawStateDatabaseForTest,
@@ -243,6 +250,18 @@ async function fixture(
       });
     },
     getConfig: () => config,
+    withDeletion: <T>(run: (deletion: AgentDeletionOperation) => Promise<T>) =>
+      withAgentDeletion("worker", async (begin) =>
+        run(
+          begin({
+            agentId: "worker",
+            agentDir: state.agentDir("worker"),
+            workspaceDir,
+            sessionsDir: state.sessionsDir("worker"),
+            deleteFiles: false,
+          }),
+        ),
+      ),
     setReloadSettled: (value: boolean) => {
       reloadSettled = value;
     },
@@ -254,28 +273,25 @@ describe("Claw serving monitor cleanup", () => {
     "retains a configured agent without a Claw install during %s",
     async (phase) => {
       const current = await fixture(false);
-      const deletion = beginAgentDeletion({
-        agentId: "worker",
-        agentDir: current.state.agentDir("worker"),
-        workspaceDir: current.workspaceDir,
-        sessionsDir: current.state.sessionsDir("worker"),
-        deleteFiles: false,
+      await current.withDeletion(async (deletion) => {
+        openOpenClawStateDatabase()
+          .db.prepare("DELETE FROM claw_installs WHERE agent_id = ?")
+          .run("worker");
+        await expect(
+          current.invoke({
+            phase,
+            agentId: "worker",
+            operationId: deletion.entry.operationId,
+            ...(phase === "quiesce" ? { monitors: await current.gateway.inspect("worker") } : {}),
+          }),
+        ).rejects.toThrow("configuration changed");
+        expect(listAgentEntries(current.getConfig()).some((agent) => agent.id === "worker")).toBe(
+          true,
+        );
+        await expect(
+          fs.access(path.join(current.workspaceDir, "SOUL.md")),
+        ).resolves.toBeUndefined();
       });
-      openOpenClawStateDatabase()
-        .db.prepare("DELETE FROM claw_installs WHERE agent_id = ?")
-        .run("worker");
-      await expect(
-        current.invoke({
-          phase,
-          agentId: "worker",
-          operationId: deletion.entry.operationId,
-          ...(phase === "quiesce" ? { monitors: await current.gateway.inspect("worker") } : {}),
-        }),
-      ).rejects.toThrow("configuration changed");
-      expect(listAgentEntries(current.getConfig()).some((agent) => agent.id === "worker")).toBe(
-        true,
-      );
-      await expect(fs.access(path.join(current.workspaceDir, "SOUL.md"))).resolves.toBeUndefined();
     },
   );
 
@@ -374,35 +390,29 @@ describe("Claw serving monitor cleanup", () => {
       const current = await fixture(false);
       const database = openOpenClawAgentDatabase({ agentId: "worker" });
       const monitors = await current.gateway.inspect("worker");
-      const target = {
-        agentId: "worker",
-        agentDir: current.state.agentDir("worker"),
-        workspaceDir: current.workspaceDir,
-        sessionsDir: current.state.sessionsDir("worker"),
-        deleteFiles: false,
-      };
-      const deletion = beginAgentDeletion(target);
-      const originalList = current.cron.list.bind(current.cron);
-      const list = vi.spyOn(current.cron, "list").mockImplementationOnce(async (opts) => {
-        const jobs = await originalList(opts);
-        if (changedOwner === "operation") {
-          beginAgentDeletion(target);
-        } else {
-          current.replaceCron();
+      await current.withDeletion(async (deletion) => {
+        const originalList = current.cron.list.bind(current.cron);
+        const list = vi.spyOn(current.cron, "list").mockImplementationOnce(async (opts) => {
+          const jobs = await originalList(opts);
+          if (changedOwner === "operation") {
+            beginAgentDeletionJournal({ ...deletion.entry, operationId: "replacement" });
+          } else {
+            current.replaceCron();
+          }
+          return jobs;
+        });
+        try {
+          await expect(
+            current.gateway.quiesce("worker", deletion.entry.operationId, monitors),
+          ).rejects.toThrow(changedOwner === "operation" ? "deletion fence" : "changing");
+          expect(database.db.prepare("SELECT 1 AS alive").get()).toEqual({ alive: 1 });
+          await expect(
+            fs.access(path.join(current.workspaceDir, "SOUL.md")),
+          ).resolves.toBeUndefined();
+        } finally {
+          list.mockRestore();
         }
-        return jobs;
       });
-      try {
-        await expect(
-          current.gateway.quiesce("worker", deletion.entry.operationId, monitors),
-        ).rejects.toThrow(changedOwner === "operation" ? "deletion fence" : "changing");
-        expect(database.db.prepare("SELECT 1 AS alive").get()).toEqual({ alive: 1 });
-        await expect(
-          fs.access(path.join(current.workspaceDir, "SOUL.md")),
-        ).resolves.toBeUndefined();
-      } finally {
-        list.mockRestore();
-      }
     },
   );
 
@@ -479,30 +489,25 @@ describe("Claw serving monitor cleanup", () => {
     const current = await fixture(false);
     const database = openOpenClawAgentDatabase({ agentId: "worker" });
     const monitors = await current.gateway.inspect("worker");
-    const deletion = beginAgentDeletion({
-      agentId: "worker",
-      agentDir: current.state.agentDir("worker"),
-      workspaceDir: current.workspaceDir,
-      sessionsDir: current.state.sessionsDir("worker"),
-      deleteFiles: false,
+    await current.withDeletion(async (deletion) => {
+      await current.gateway.quiesce("worker", deletion.entry.operationId, monitors);
+      expect(() => database.db.prepare("SELECT 1")).toThrow();
+      const config = current.getConfig();
+      config.agents = { ...config.agents, entries: undefined, list: listAgentEntries(config) };
+      for (const monitor of monitors) {
+        await current.cron.remove(monitor.id, { systemOwned: true });
+      }
+      expect(
+        (await current.cron.list({ includeDisabled: true })).filter(
+          (job) => job.agentId === "worker",
+        ),
+      ).toEqual([]);
+      expect(listAgentEntries(current.getConfig()).map((agent) => agent.id)).toContain("worker");
+      await expect(current.gateway.drain("worker", deletion.entry.operationId)).rejects.toThrow(
+        "config convergence is incomplete",
+      );
+      await expect(fs.access(path.join(current.workspaceDir, "SOUL.md"))).resolves.toBeUndefined();
     });
-    await current.gateway.quiesce("worker", deletion.entry.operationId, monitors);
-    expect(() => database.db.prepare("SELECT 1")).toThrow();
-    const config = current.getConfig();
-    config.agents = { ...config.agents, entries: undefined, list: listAgentEntries(config) };
-    for (const monitor of monitors) {
-      await current.cron.remove(monitor.id, { systemOwned: true });
-    }
-    expect(
-      (await current.cron.list({ includeDisabled: true })).filter(
-        (job) => job.agentId === "worker",
-      ),
-    ).toEqual([]);
-    expect(listAgentEntries(current.getConfig()).map((agent) => agent.id)).toContain("worker");
-    await expect(current.gateway.drain("worker", deletion.entry.operationId)).rejects.toThrow(
-      "config convergence is incomplete",
-    );
-    await expect(fs.access(path.join(current.workspaceDir, "SOUL.md"))).resolves.toBeUndefined();
     expect(await current.apply(await current.plan())).toMatchObject({ status: "complete" });
   });
 

--- a/src/gateway/server-methods/agents-config-mutations.ts
+++ b/src/gateway/server-methods/agents-config-mutations.ts
@@ -59,6 +59,7 @@ export async function deleteAgentConfigEntry(params: {
   agentId: string;
   validate?: (agent: AgentConfig) => void;
   validateConfig?: (config: OpenClawConfig) => void;
+  assertCurrent?: () => void;
   allowMissing?: boolean;
   allowConfigSizeDrop?: boolean;
   fallbackWorkspace?: string;
@@ -70,6 +71,7 @@ export async function deleteAgentConfigEntry(params: {
     afterWrite: { mode: "auto" },
     writeOptions: {
       allowedAgentRosterRemovals: [params.agentId],
+      assertConfigPathForWrite: params.assertCurrent,
       ...(params.allowConfigSizeDrop ? { allowConfigSizeDrop: true } : {}),
     },
     mutate: (draft) => {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -39,6 +39,7 @@ const mocks = vi.hoisted(() => ({
   withAgentExecApprovalsRemoved: vi.fn(
     async (_agentId: string, commit: () => Promise<unknown>) => await commit(),
   ),
+  assertAgentDeletionCurrent: vi.fn(),
   beginAgentDeletionRollback: vi.fn(),
   beginAgentDeletionFinish: vi.fn(),
   runAgentDatabaseCleanup: vi.fn(
@@ -233,21 +234,26 @@ vi.mock("../../agents/agent-lifecycle-registry.js", () => ({
       super(cause instanceof Error ? cause.message : String(cause));
     }
   },
-  beginAgentDeletion: (entry: Record<string, unknown>) => ({
-    entry: Object.assign(entry, {
-      databasePaths: entry.databasePaths ?? [],
-      cleanupPaths: entry.cleanupPaths ?? [],
-    }),
-    fenceDatabasePaths: (paths: string[]) => {
-      entry.databasePaths = [...new Set(paths)];
-    },
-    fenceCleanupPaths: (paths: unknown[]) => {
-      entry.cleanupPaths = [...paths];
-    },
-    finish: mocks.beginAgentDeletionFinish,
-    rollback: mocks.beginAgentDeletionRollback,
-    runDatabaseCleanup: mocks.runAgentDatabaseCleanup,
-  }),
+  withAgentDeletion: async (
+    _agentId: string,
+    run: (begin: (entry: Record<string, unknown>) => unknown) => Promise<unknown>,
+  ) =>
+    run((entry) => ({
+      entry: Object.assign(entry, {
+        databasePaths: entry.databasePaths ?? [],
+        cleanupPaths: entry.cleanupPaths ?? [],
+      }),
+      assertCurrent: mocks.assertAgentDeletionCurrent,
+      fenceDatabasePaths: (paths: string[]) => {
+        entry.databasePaths = [...new Set(paths)];
+      },
+      fenceCleanupPaths: (paths: unknown[]) => {
+        entry.cleanupPaths = [...paths];
+      },
+      finish: mocks.beginAgentDeletionFinish,
+      rollback: mocks.beginAgentDeletionRollback,
+      runDatabaseCleanup: mocks.runAgentDatabaseCleanup,
+    })),
   claimCompletedAgentDeletion: mocks.claimCompletedAgentDeletion,
   isAgentDeletionBlocked: () => false,
 }));
@@ -260,6 +266,8 @@ vi.mock("../../state/openclaw-agent-db.js", () => ({
   closeOpenClawAgentDatabaseByPath: mocks.closeOpenClawAgentDatabaseByPath,
   listOpenClawRegisteredAgentDatabases: mocks.listOpenClawRegisteredAgentDatabases,
   resolveOpenClawAgentSqlitePath: mocks.resolveOpenClawAgentSqlitePath,
+  resolveIncognitoOpenClawAgentSqlitePath: () =>
+    "/agents/test-agent/incognito-openclaw-agent.sqlite",
 }));
 
 vi.mock("../../state/agent-deletion-journal.js", () => ({
@@ -391,6 +399,7 @@ beforeEach(() => {
   mocks.withAgentExecApprovalsRemoved
     .mockReset()
     .mockImplementation(async (_agentId: string, commit: () => Promise<unknown>) => await commit());
+  mocks.assertAgentDeletionCurrent.mockReset();
   mocks.beginAgentDeletionRollback.mockReset();
   mocks.beginAgentDeletionFinish.mockReset();
   mocks.readAgentDeletionJournal.mockReset().mockReturnValue(undefined);
@@ -1436,7 +1445,7 @@ describe("agents.delete", () => {
       agentId: "test-agent",
       agentDir: "/agents/test-agent",
     });
-    expect(events).toEqual(["database", "cron", "approvals", "config", "directory"]);
+    expect(events).toEqual(["database", "database", "cron", "approvals", "config", "directory"]);
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
@@ -1468,7 +1477,7 @@ describe("agents.delete", () => {
     ]);
     expect(mocks.beginAgentDeletionRollback).toHaveBeenCalledOnce();
     expect(mocks.writeConfigFile).not.toHaveBeenCalled();
-    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledOnce();
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledTimes(2);
     expect(mocks.movePathToTrash).not.toHaveBeenCalled();
   });
 
@@ -1533,7 +1542,7 @@ describe("agents.delete", () => {
     const { promise } = makeCall("agents.delete", { agentId: "test-agent" });
 
     await expect(promise).rejects.toThrow("config mutation did not return its target");
-    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledOnce();
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledTimes(2);
     expect(mocks.movePathToTrash).not.toHaveBeenCalled();
     expect(mocks.unregisterOpenClawAgentDatabase).not.toHaveBeenCalled();
     expect(mocks.beginAgentDeletionRollback).toHaveBeenCalledOnce();
@@ -2484,7 +2493,7 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, { ok: true });
-    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledTimes(2);
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledTimes(3);
     expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/relocated/deleted.sqlite",
       "test-agent",
@@ -2551,7 +2560,7 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, { ok: true });
-    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledTimes(2);
+    expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledTimes(3);
     expect(mocks.closeOpenClawAgentDatabaseByPath).toHaveBeenCalledWith(
       "/agents/test-agent/openclaw-agent.sqlite",
       "test-agent",
@@ -2848,6 +2857,7 @@ describe("agents.delete", () => {
     );
     expect(mocks.writeConfigFile).toHaveBeenCalled();
     expect(mocks.writeConfigFile).toHaveBeenCalledWith(expect.anything(), {
+      assertConfigPathForWrite: mocks.assertAgentDeletionCurrent,
       allowedAgentRosterRemovals: ["test-agent"],
     });
     expect(mocks.movePathToTrash).toHaveBeenCalled();

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -22,6 +22,8 @@ import {
 import type { AgentsDeleteResult } from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import { createAgent } from "../../agents/agent-create.js";
 import {
+  AgentSharedStoreOwnerError,
+  assertAgentSessionStoreDeletionSafe,
   isPathOwnedBySurvivingAgent,
   prepareAgentDeleteDatabases,
   readAgentDeleteDatabaseRegistry,
@@ -42,7 +44,7 @@ import {
 import {
   AgentDeletionAuthorityRollbackError,
   AgentDeletionCommitUncertainError,
-  beginAgentDeletion,
+  withAgentDeletion,
   claimCompletedAgentDeletion,
 } from "../../agents/agent-lifecycle-registry.js";
 import {
@@ -392,6 +394,7 @@ async function statAgentCleanupPath(cleanupPath: AgentDeleteCleanupPath) {
 
 async function removeAgentPath(
   cleanupPath: AgentDeleteCleanupPath,
+  assertCurrent: () => void,
 ): Promise<AgentDeletePathOutcome> {
   const pathname = cleanupPath.path;
   const trashPath = cleanupPath.trashPath;
@@ -408,6 +411,7 @@ async function removeAgentPath(
   try {
     // fs-safe pins traversal and identity for validation; Trash has no fd-relative move API, so
     // replacement after this check and before its rename is the accepted residual race bound.
+    assertCurrent();
     await movePathToTrash(trashPath);
     return { removed: { path: pathname, method: "trash" } };
   } catch (error) {
@@ -993,435 +997,460 @@ export const agentsHandlers: GatewayRequestHandlers = {
     const requestedDeleteFiles =
       typeof params.deleteFiles === "boolean" ? params.deleteFiles : true;
     try {
-      const result = await withConfigMutationExclusive(async (lockedConfig) => {
-        let lockedJournal = readAgentDeletionJournal(agentId);
-        const configured = isConfiguredAgent(lockedConfig, agentId);
-        if (agentOwnsSharedAuthStore(lockedConfig, agentId)) {
-          throw new AgentSharedAuthStoreOwnerError(formatSharedAuthStoreOwnerDeleteError(agentId));
-        }
-        if (!configured && (!lockedJournal || lockedJournal.cleanupCompleted)) {
-          throw new AgentConfigPreconditionError(`agent "${agentId}" not found`);
-        }
-        if (agentId === tryResolveSoleAgentId(lockedConfig)) {
-          throw new AgentConfigPreconditionError(`agent "${agentId}" is the only configured agent`);
-        }
-        if (isInheritedAuthStoreOwner(lockedConfig, agentId)) {
-          throw new AgentConfigPreconditionError(
-            `agent "${agentId}" owns agents.defaults.authInheritance.agentId; relocate credentials and re-point it first`,
-          );
-        }
-        if (configured && lockedJournal?.cleanupCompleted) {
-          const claimed = claimCompletedAgentDeletion(agentId, lockedJournal.operationId);
-          const remainingJournal = readAgentDeletionJournal(agentId);
-          if (!claimed && remainingJournal) {
-            throw new Error(`agent "${agentId}" deletion tombstone changed before fresh deletion`);
-          }
-          lockedJournal = undefined;
-        }
-        const deleteFiles = lockedJournal?.deleteFiles ?? requestedDeleteFiles;
-        const deletion = beginAgentDeletion(
-          lockedJournal ?? {
-            agentId,
-            agentDir: resolveAgentDir(lockedConfig, agentId),
-            workspaceDir: resolveAgentWorkspaceDir(lockedConfig, agentId),
-            sessionsDir: resolveSessionTranscriptsDirForAgent(agentId),
-            deleteFiles,
-          },
-        );
-        const journal = deletion.entry;
-        let rosterCommitted = !configured;
-        let committed: Awaited<ReturnType<typeof deleteAgentConfigEntry>> | undefined;
-        let databasePlan: AgentDeleteDatabasePlan | undefined;
-        try {
-          prepareJournaledAgentDirOwnership(lockedConfig, agentId, journal.agentDir);
-          databasePlan = prepareAgentDeleteDatabases(lockedConfig, agentId, journal.agentDir);
-          deletion.fenceDatabasePaths([
-            ...journal.databasePaths,
-            ...databasePlan.fileGroups.flat(),
-          ]);
-          if (deleteFiles) {
-            const fencedSourcePaths = new Set(
-              journal.cleanupPaths.flatMap((cleanupPath) =>
-                cleanupPath.sourcePaths.map((sourcePath) => path.resolve(sourcePath)),
-              ),
+      const result = await withAgentDeletion(agentId, async (begin) =>
+        withConfigMutationExclusive(async (lockedConfig) => {
+          assertAgentSessionStoreDeletionSafe(lockedConfig, agentId);
+          let lockedJournal = readAgentDeletionJournal(agentId);
+          const configured = isConfiguredAgent(lockedConfig, agentId);
+          if (agentOwnsSharedAuthStore(lockedConfig, agentId)) {
+            throw new AgentSharedAuthStoreOwnerError(
+              formatSharedAuthStoreOwnerDeleteError(agentId),
             );
-            const unfencedSourcePaths = [
-              journal.workspaceDir,
-              journal.agentDir,
-              journal.sessionsDir,
+          }
+          if (!configured && (!lockedJournal || lockedJournal.cleanupCompleted)) {
+            throw new AgentConfigPreconditionError(`agent "${agentId}" not found`);
+          }
+          if (agentId === tryResolveSoleAgentId(lockedConfig)) {
+            throw new AgentConfigPreconditionError(
+              `agent "${agentId}" is the only configured agent`,
+            );
+          }
+          if (isInheritedAuthStoreOwner(lockedConfig, agentId)) {
+            throw new AgentConfigPreconditionError(
+              `agent "${agentId}" owns agents.defaults.authInheritance.agentId; relocate credentials and re-point it first`,
+            );
+          }
+          if (configured && lockedJournal?.cleanupCompleted) {
+            const claimed = claimCompletedAgentDeletion(agentId, lockedJournal.operationId);
+            const remainingJournal = readAgentDeletionJournal(agentId);
+            if (!claimed && remainingJournal) {
+              throw new Error(
+                `agent "${agentId}" deletion tombstone changed before fresh deletion`,
+              );
+            }
+            lockedJournal = undefined;
+          }
+          const deleteFiles = lockedJournal?.deleteFiles ?? requestedDeleteFiles;
+          const deletion = begin(
+            lockedJournal ?? {
+              agentId,
+              agentDir: resolveAgentDir(lockedConfig, agentId),
+              workspaceDir: resolveAgentWorkspaceDir(lockedConfig, agentId),
+              sessionsDir: resolveSessionTranscriptsDirForAgent(agentId),
+              deleteFiles,
+            },
+          );
+          const journal = deletion.entry;
+          let rosterCommitted = !configured;
+          let committed: Awaited<ReturnType<typeof deleteAgentConfigEntry>> | undefined;
+          let databasePlan: AgentDeleteDatabasePlan | undefined;
+          try {
+            prepareJournaledAgentDirOwnership(lockedConfig, agentId, journal.agentDir);
+            databasePlan = prepareAgentDeleteDatabases(lockedConfig, agentId, journal.agentDir);
+            deletion.fenceDatabasePaths([
               ...journal.databasePaths,
-            ].filter((sourcePath) => !fencedSourcePaths.has(path.resolve(sourcePath)));
-            if (unfencedSourcePaths.length > 0) {
-              const unfencedSourcePathSet = new Set(
-                unfencedSourcePaths.map((sourcePath) => path.resolve(sourcePath)),
-              );
-              const cleanupPlan = await prepareAgentDeleteCleanupPaths(
-                unfencedSourcePaths,
-                journal.cleanupPaths,
-              );
-              const unresolvedPath = cleanupPlan.find(
-                (cleanupPath) =>
-                  cleanupPath.preparationError !== undefined &&
-                  cleanupPath.sourcePaths.some((sourcePath) =>
-                    unfencedSourcePathSet.has(path.resolve(sourcePath)),
-                  ),
-              );
-              if (unresolvedPath) {
-                throw unresolvedPath.preparationError;
-              }
-              deletion.fenceCleanupPaths(
-                cleanupPlan.map(
-                  ({
-                    path: cleanupPath,
-                    trashPath,
-                    parentPath,
-                    kind,
-                    preparedIdentity,
-                    trashCoversDescendants,
-                    done,
-                    note,
-                    sourcePaths,
-                  }) => {
-                    const journalPath: AgentDeletionJournalCleanupPath = {
-                      path: cleanupPath,
-                      canonicalPath: trashPath,
-                      parentPath,
-                      kind,
-                      sourcePaths,
-                      dev: preparedIdentity?.dev ?? null,
-                      ino: preparedIdentity?.ino ?? null,
-                      coversDescendants: trashCoversDescendants,
-                      done,
-                    };
-                    if (note) {
-                      journalPath.note = note;
-                    }
-                    return journalPath;
-                  },
+              ...databasePlan.fileGroups.flat(),
+            ]);
+            if (deleteFiles) {
+              const fencedSourcePaths = new Set(
+                journal.cleanupPaths.flatMap((cleanupPath) =>
+                  cleanupPath.sourcePaths.map((sourcePath) => path.resolve(sourcePath)),
                 ),
               );
+              const unfencedSourcePaths = [
+                journal.workspaceDir,
+                journal.agentDir,
+                journal.sessionsDir,
+                ...journal.databasePaths,
+              ].filter((sourcePath) => !fencedSourcePaths.has(path.resolve(sourcePath)));
+              if (unfencedSourcePaths.length > 0) {
+                const unfencedSourcePathSet = new Set(
+                  unfencedSourcePaths.map((sourcePath) => path.resolve(sourcePath)),
+                );
+                const cleanupPlan = await prepareAgentDeleteCleanupPaths(
+                  unfencedSourcePaths,
+                  journal.cleanupPaths,
+                );
+                const unresolvedPath = cleanupPlan.find(
+                  (cleanupPath) =>
+                    cleanupPath.preparationError !== undefined &&
+                    cleanupPath.sourcePaths.some((sourcePath) =>
+                      unfencedSourcePathSet.has(path.resolve(sourcePath)),
+                    ),
+                );
+                if (unresolvedPath) {
+                  throw unresolvedPath.preparationError;
+                }
+                deletion.fenceCleanupPaths(
+                  cleanupPlan.map(
+                    ({
+                      path: cleanupPath,
+                      trashPath,
+                      parentPath,
+                      kind,
+                      preparedIdentity,
+                      trashCoversDescendants,
+                      done,
+                      note,
+                      sourcePaths,
+                    }) => {
+                      const journalPath: AgentDeletionJournalCleanupPath = {
+                        path: cleanupPath,
+                        canonicalPath: trashPath,
+                        parentPath,
+                        kind,
+                        sourcePaths,
+                        dev: preparedIdentity?.dev ?? null,
+                        ino: preparedIdentity?.ino ?? null,
+                        coversDescendants: trashCoversDescendants,
+                        done,
+                      };
+                      if (note) {
+                        journalPath.note = note;
+                      }
+                      return journalPath;
+                    },
+                  ),
+                );
+              }
             }
-          }
-          await context.cron.removeAgentJobsTransactional(
-            agentId,
-            async () =>
-              await withAgentExecApprovalsRemoved(agentId, async () => {
-                if (!rosterCommitted) {
-                  try {
-                    committed = await deleteAgentConfigEntry({ agentId });
-                  } catch (error) {
+            await context.cron.removeAgentJobsTransactional(
+              agentId,
+              async () =>
+                await withAgentExecApprovalsRemoved(agentId, async () => {
+                  deletion.assertCurrent();
+                  if (!rosterCommitted) {
                     try {
-                      const persisted = await readConfigFileSnapshotForWrite();
-                      if (!isConfiguredAgent(persisted.snapshot.sourceConfig, agentId)) {
-                        rosterCommitted = true;
+                      committed = await deleteAgentConfigEntry({
+                        agentId,
+                        assertCurrent: deletion.assertCurrent,
+                      });
+                    } catch (error) {
+                      try {
+                        const persisted = await readConfigFileSnapshotForWrite();
+                        if (!isConfiguredAgent(persisted.snapshot.sourceConfig, agentId)) {
+                          rosterCommitted = true;
+                          throw new AgentDeletionCommitUncertainError(error);
+                        }
+                      } catch (readError) {
+                        if (readError instanceof AgentDeletionCommitUncertainError) {
+                          throw readError;
+                        }
                         throw new AgentDeletionCommitUncertainError(error);
                       }
-                    } catch (readError) {
-                      if (readError instanceof AgentDeletionCommitUncertainError) {
-                        throw readError;
+                      throw error;
+                    }
+                    if (!committed.result) {
+                      rosterCommitted = !isConfiguredAgent(committed.nextConfig, agentId);
+                      const missingResultError = new Error(
+                        "agent delete config mutation did not return its target",
+                      );
+                      if (rosterCommitted) {
+                        throw new AgentDeletionCommitUncertainError(missingResultError);
                       }
-                      throw new AgentDeletionCommitUncertainError(error);
+                      throw missingResultError;
                     }
-                    throw error;
+                    rosterCommitted = true;
                   }
-                  if (!committed.result) {
-                    rosterCommitted = !isConfiguredAgent(committed.nextConfig, agentId);
-                    const missingResultError = new Error(
-                      "agent delete config mutation did not return its target",
-                    );
-                    if (rosterCommitted) {
-                      throw new AgentDeletionCommitUncertainError(missingResultError);
-                    }
-                    throw missingResultError;
-                  }
-                  rosterCommitted = true;
-                }
-              }),
-          );
-        } catch (error) {
-          let canReleaseFence =
-            !rosterCommitted &&
-            !lockedJournal &&
-            !(error instanceof AgentDeletionAuthorityRollbackError) &&
-            !(error instanceof AgentDeletionCommitUncertainError);
-          if (canReleaseFence) {
-            try {
-              const persisted = await readConfigFileSnapshotForWrite();
-              canReleaseFence = isConfiguredAgent(persisted.snapshot.sourceConfig, agentId);
-            } catch {
-              canReleaseFence = false;
+                }),
+            );
+            deletion.assertCurrent();
+          } catch (error) {
+            let canReleaseFence =
+              !rosterCommitted &&
+              !lockedJournal &&
+              !(error instanceof AgentDeletionAuthorityRollbackError) &&
+              !(error instanceof AgentDeletionCommitUncertainError);
+            if (canReleaseFence) {
+              try {
+                const persisted = await readConfigFileSnapshotForWrite();
+                canReleaseFence = isConfiguredAgent(persisted.snapshot.sourceConfig, agentId);
+              } catch {
+                canReleaseFence = false;
+              }
             }
+            if (canReleaseFence) {
+              deletion.rollback();
+            }
+            throw error;
           }
-          if (canReleaseFence) {
-            deletion.rollback();
-          }
-          throw error;
-        }
 
-        const deleteResult = committed?.result ?? {
-          agentDir: journal.agentDir,
-          workspaceDir: journal.workspaceDir,
-          sessionsDir: journal.sessionsDir,
-          removedBindings: 0,
-        };
-        const nextConfig = committed?.nextConfig ?? lockedConfig;
+          const deleteResult = committed?.result ?? {
+            agentDir: journal.agentDir,
+            workspaceDir: journal.workspaceDir,
+            sessionsDir: journal.sessionsDir,
+            removedBindings: 0,
+          };
+          const nextConfig = committed?.nextConfig ?? lockedConfig;
 
-        // A journaled path is trash-eligible only while registry ownership still points at the
-        // deleted agent; recovery must not consume a path claimed by a surviving agent.
-        const agentDirRegistryPath = normalizeAgentDirRegistryPath(deleteResult.agentDir);
-        const purgeFailed = await purgeAgentSessionStoreEntries(lockedConfig, agentId, {
-          runDatabaseCleanup: deletion.runDatabaseCleanup,
-        });
+          // A journaled path is trash-eligible only while registry ownership still points at the
+          // deleted agent; recovery must not consume a path claimed by a surviving agent.
+          const agentDirRegistryPath = normalizeAgentDirRegistryPath(deleteResult.agentDir);
+          const purgeFailed = await purgeAgentSessionStoreEntries(lockedConfig, agentId, {
+            runDatabaseCleanup: deletion.runDatabaseCleanup,
+          });
+          deletion.assertCurrent();
 
-        const removed: AgentDeleteRemovedPath[] = [];
-        const failed: AgentDeleteFailedPath[] = [];
+          const removed: AgentDeleteRemovedPath[] = [];
+          const failed: AgentDeleteFailedPath[] = [];
 
-        if (deleteFiles && !purgeFailed) {
-          const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
-            readAgentDeleteDatabaseRegistry(),
-            agentId,
-          );
-          const workspaceTrashEligible = !isPathOwnedBySurvivingAgent(
-            nextConfig,
-            agentId,
-            deleteResult.workspaceDir,
-            survivingDatabaseFilePaths,
-          );
-          // The config mutation lock and durable journal fence block new roster and database
-          // claims across this final ownership recheck and the filesystem cleanup below.
-          const agentDirTrashEligible =
-            resolveRegisteredAgentIdForDir(deleteResult.agentDir) === agentId &&
-            !isPathOwnedBySurvivingAgent(
+          if (deleteFiles && !purgeFailed) {
+            const survivingDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
+              readAgentDeleteDatabaseRegistry(),
+              agentId,
+            );
+            const workspaceTrashEligible = !isPathOwnedBySurvivingAgent(
               nextConfig,
               agentId,
-              deleteResult.agentDir,
+              deleteResult.workspaceDir,
               survivingDatabaseFilePaths,
             );
-          const sessionsDirTrashEligible = !isPathOwnedBySurvivingAgent(
-            nextConfig,
-            agentId,
-            deleteResult.sessionsDir,
-            survivingDatabaseFilePaths,
-          );
-          const databaseFilePaths = [
-            ...(agentDirTrashEligible
-              ? (databasePlan?.relocatedFileGroups ?? [])
-              : (databasePlan?.fileGroups ?? [])
-            ).flat(),
-            ...journal.databasePaths,
-          ].filter(
-            (pathname) =>
+            // The config mutation lock and durable journal fence block new roster and database
+            // claims across this final ownership recheck and the filesystem cleanup below.
+            const agentDirTrashEligible =
+              resolveRegisteredAgentIdForDir(deleteResult.agentDir) === agentId &&
               !isPathOwnedBySurvivingAgent(
                 nextConfig,
                 agentId,
-                pathname,
+                deleteResult.agentDir,
                 survivingDatabaseFilePaths,
-              ),
-          );
-          const eligibleSourcePaths = new Set(
-            [
-              ...(workspaceTrashEligible ? [deleteResult.workspaceDir] : []),
-              ...(agentDirTrashEligible ? [deleteResult.agentDir] : []),
-              ...(sessionsDirTrashEligible ? [deleteResult.sessionsDir] : []),
-              ...databaseFilePaths,
-            ].map((sourcePath) => path.resolve(sourcePath)),
-          );
-          const cleanupPaths = (
-            await prepareAgentDeleteCleanupPaths([], journal.cleanupPaths)
-          ).filter(
-            (cleanupPath) =>
-              cleanupPath.sourcePaths.some((sourcePath) => eligibleSourcePaths.has(sourcePath)) &&
-              (agentDirTrashEligible ||
-                !cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath)),
-          );
-          const workspaceCanonicalPath = normalizeAgentDirRegistryPath(deleteResult.workspaceDir);
-          const workspaceCleanupPaths = cleanupPaths.filter((cleanupPath) =>
-            cleanupPathCovers(cleanupPath, deleteResult.workspaceDir, workspaceCanonicalPath),
-          );
-          const legacyPlan =
-            workspaceCleanupPaths.length > 0
-              ? prepareLegacyWorkspaceStateReset(deleteResult.workspaceDir)
-              : undefined;
-          const statePlan =
-            workspaceCleanupPaths.length > 0
-              ? prepareWorkspaceStateDeletion(deleteResult.workspaceDir)
-              : undefined;
-          const outcomes: Array<{
-            cleanupPath: AgentDeleteCleanupPath;
-            outcome: AgentDeletePathOutcome;
-          }> = [];
-          const completedCleanupPaths = new Set(
-            cleanupPaths.filter((cleanupPath) => cleanupPath.done),
-          );
-          const markCleanupPathDone = (cleanupPath: AgentDeleteCleanupPath, note?: string) => {
-            const canonicalPath = path.resolve(cleanupPath.trashPath);
-            deletion.fenceCleanupPaths(
-              journal.cleanupPaths.map((entry) => {
-                if (
-                  path.resolve(entry.canonicalPath) !== canonicalPath ||
-                  entry.kind !== cleanupPath.kind
-                ) {
-                  return entry;
-                }
-                const updated = Object.assign({}, entry, { done: true });
-                if (note) {
-                  updated.note = note;
-                }
-                return updated;
-              }),
+              );
+            const sessionsDirTrashEligible = !isPathOwnedBySurvivingAgent(
+              nextConfig,
+              agentId,
+              deleteResult.sessionsDir,
+              survivingDatabaseFilePaths,
             );
-            cleanupPath.done = true;
-            cleanupPath.note = note;
-            completedCleanupPaths.add(cleanupPath);
-          };
-          const protectedCleanupPaths: Array<{
-            cleanupPath: AgentDeleteCleanupPath;
-            protectAliases: boolean;
-            terminal: boolean;
-            note?: string;
-          }> = [];
-          for (const cleanupPath of cleanupPaths) {
-            if (cleanupPath.done) {
-              let replacementPresent = true;
-              let note =
-                cleanupPath.note ?? "completed cleanup path is occupied; replacement preserved";
-              try {
-                await statAgentCleanupPath(cleanupPath);
-              } catch (error) {
-                if (isMissingPathError(error)) {
-                  replacementPresent = false;
-                } else if (!(error instanceof AgentCleanupIdentityMismatchError)) {
-                  note = "completed cleanup path could not be verified; replacement preserved";
+            const databaseFilePaths = [
+              ...(agentDirTrashEligible
+                ? (databasePlan?.relocatedFileGroups ?? [])
+                : (databasePlan?.fileGroups ?? [])
+              ).flat(),
+              ...journal.databasePaths,
+            ].filter(
+              (pathname) =>
+                !isPathOwnedBySurvivingAgent(
+                  nextConfig,
+                  agentId,
+                  pathname,
+                  survivingDatabaseFilePaths,
+                ),
+            );
+            const eligibleSourcePaths = new Set(
+              [
+                ...(workspaceTrashEligible ? [deleteResult.workspaceDir] : []),
+                ...(agentDirTrashEligible ? [deleteResult.agentDir] : []),
+                ...(sessionsDirTrashEligible ? [deleteResult.sessionsDir] : []),
+                ...databaseFilePaths,
+              ].map((sourcePath) => path.resolve(sourcePath)),
+            );
+            const cleanupPaths = (
+              await prepareAgentDeleteCleanupPaths([], journal.cleanupPaths)
+            ).filter(
+              (cleanupPath) =>
+                cleanupPath.sourcePaths.some((sourcePath) => eligibleSourcePaths.has(sourcePath)) &&
+                (agentDirTrashEligible ||
+                  !cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath)),
+            );
+            const workspaceCanonicalPath = normalizeAgentDirRegistryPath(deleteResult.workspaceDir);
+            const workspaceCleanupPaths = cleanupPaths.filter((cleanupPath) =>
+              cleanupPathCovers(cleanupPath, deleteResult.workspaceDir, workspaceCanonicalPath),
+            );
+            const legacyPlan =
+              workspaceCleanupPaths.length > 0
+                ? prepareLegacyWorkspaceStateReset(deleteResult.workspaceDir)
+                : undefined;
+            const statePlan =
+              workspaceCleanupPaths.length > 0
+                ? prepareWorkspaceStateDeletion(deleteResult.workspaceDir)
+                : undefined;
+            const outcomes: Array<{
+              cleanupPath: AgentDeleteCleanupPath;
+              outcome: AgentDeletePathOutcome;
+            }> = [];
+            const completedCleanupPaths = new Set(
+              cleanupPaths.filter((cleanupPath) => cleanupPath.done),
+            );
+            const markCleanupPathDone = (cleanupPath: AgentDeleteCleanupPath, note?: string) => {
+              const canonicalPath = path.resolve(cleanupPath.trashPath);
+              deletion.fenceCleanupPaths(
+                journal.cleanupPaths.map((entry) => {
+                  if (
+                    path.resolve(entry.canonicalPath) !== canonicalPath ||
+                    entry.kind !== cleanupPath.kind
+                  ) {
+                    return entry;
+                  }
+                  const updated = Object.assign({}, entry, { done: true });
+                  if (note) {
+                    updated.note = note;
+                  }
+                  return updated;
+                }),
+              );
+              cleanupPath.done = true;
+              cleanupPath.note = note;
+              completedCleanupPaths.add(cleanupPath);
+            };
+            const protectedCleanupPaths: Array<{
+              cleanupPath: AgentDeleteCleanupPath;
+              protectAliases: boolean;
+              terminal: boolean;
+              note?: string;
+            }> = [];
+            for (const cleanupPath of cleanupPaths) {
+              deletion.assertCurrent();
+              if (cleanupPath.done) {
+                let replacementPresent = true;
+                let note =
+                  cleanupPath.note ?? "completed cleanup path is occupied; replacement preserved";
+                try {
+                  await statAgentCleanupPath(cleanupPath);
+                } catch (error) {
+                  if (isMissingPathError(error)) {
+                    replacementPresent = false;
+                  } else if (!(error instanceof AgentCleanupIdentityMismatchError)) {
+                    note = "completed cleanup path could not be verified; replacement preserved";
+                  }
                 }
+                if (replacementPresent) {
+                  markCleanupPathDone(cleanupPath, note);
+                  protectedCleanupPaths.push({
+                    cleanupPath,
+                    protectAliases: true,
+                    terminal: true,
+                    note,
+                  });
+                }
+                continue;
               }
-              if (replacementPresent) {
-                markCleanupPathDone(cleanupPath, note);
+              const refreshedDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
+                readAgentDeleteDatabaseRegistry(),
+                agentId,
+              );
+              const blockingProtection = protectedCleanupPaths.find(
+                ({ cleanupPath: protectedPath, protectAliases }) =>
+                  ((cleanupPath.kind !== "symlink" || protectAliases) &&
+                    (protectedPath.canonicalPath === cleanupPath.canonicalPath ||
+                      isPathInside(cleanupPath.canonicalPath, protectedPath.canonicalPath))) ||
+                  [
+                    protectedPath.trashPath,
+                    ...(protectAliases ? protectedPath.sourcePaths : []),
+                  ].some(
+                    (protectedSourcePath) =>
+                      protectedSourcePath === cleanupPath.trashPath ||
+                      isPathInside(cleanupPath.trashPath, protectedSourcePath),
+                  ),
+              );
+              const ownedBySurvivor =
+                isPathOwnedBySurvivingAgent(
+                  nextConfig,
+                  agentId,
+                  cleanupPath.path,
+                  refreshedDatabaseFilePaths,
+                ) ||
+                (cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath) &&
+                  resolveRegisteredAgentIdForDir(deleteResult.agentDir) !== agentId);
+              if (blockingProtection || ownedBySurvivor) {
+                const terminal = ownedBySurvivor || blockingProtection?.terminal === true;
+                const note = ownedBySurvivor
+                  ? "replacement owned by a surviving agent"
+                  : blockingProtection?.note;
+                if (terminal) {
+                  markCleanupPathDone(cleanupPath, note ?? "protected replacement preserved");
+                }
+                protectedCleanupPaths.push({
+                  cleanupPath,
+                  protectAliases: blockingProtection?.protectAliases ?? false,
+                  terminal,
+                  note,
+                });
+                continue;
+              }
+              const outcome = cleanupPath.preparationError
+                ? cleanupFailure(cleanupPath.path, cleanupPath.preparationError)
+                : await removeAgentPath(cleanupPath, deletion.assertCurrent);
+              outcomes.push({
+                cleanupPath,
+                outcome,
+              });
+              if ("removed" in outcome) {
+                markCleanupPathDone(cleanupPath);
+              } else if ("skipped" in outcome) {
+                markCleanupPathDone(cleanupPath, outcome.skipped.reason);
                 protectedCleanupPaths.push({
                   cleanupPath,
                   protectAliases: true,
                   terminal: true,
-                  note,
+                  note: outcome.skipped.reason,
+                });
+              } else {
+                protectedCleanupPaths.push({
+                  cleanupPath,
+                  protectAliases: true,
+                  terminal: false,
                 });
               }
-              continue;
             }
-            const refreshedDatabaseFilePaths = resolveSurvivingDatabaseFilePaths(
-              readAgentDeleteDatabaseRegistry(),
-              agentId,
-            );
-            const blockingProtection = protectedCleanupPaths.find(
-              ({ cleanupPath: protectedPath, protectAliases }) =>
-                ((cleanupPath.kind !== "symlink" || protectAliases) &&
-                  (protectedPath.canonicalPath === cleanupPath.canonicalPath ||
-                    isPathInside(cleanupPath.canonicalPath, protectedPath.canonicalPath))) ||
-                [
-                  protectedPath.trashPath,
-                  ...(protectAliases ? protectedPath.sourcePaths : []),
-                ].some(
-                  (protectedSourcePath) =>
-                    protectedSourcePath === cleanupPath.trashPath ||
-                    isPathInside(cleanupPath.trashPath, protectedSourcePath),
-                ),
-            );
-            const ownedBySurvivor =
-              isPathOwnedBySurvivingAgent(
-                nextConfig,
-                agentId,
-                cleanupPath.path,
-                refreshedDatabaseFilePaths,
-              ) ||
-              (cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath) &&
-                resolveRegisteredAgentIdForDir(deleteResult.agentDir) !== agentId);
-            if (blockingProtection || ownedBySurvivor) {
-              const terminal = ownedBySurvivor || blockingProtection?.terminal === true;
-              const note = ownedBySurvivor
-                ? "replacement owned by a surviving agent"
-                : blockingProtection?.note;
-              if (terminal) {
-                markCleanupPathDone(cleanupPath, note ?? "protected replacement preserved");
+            for (const { outcome } of outcomes) {
+              if ("removed" in outcome) {
+                removed.push(outcome.removed);
+              } else if ("failed" in outcome) {
+                failed.push(outcome.failed);
               }
-              protectedCleanupPaths.push({
-                cleanupPath,
-                protectAliases: blockingProtection?.protectAliases ?? false,
-                terminal,
-                note,
-              });
-              continue;
             }
-            const outcome = cleanupPath.preparationError
-              ? cleanupFailure(cleanupPath.path, cleanupPath.preparationError)
-              : await removeAgentPath(cleanupPath);
-            outcomes.push({
-              cleanupPath,
-              outcome,
-            });
-            if ("removed" in outcome) {
-              markCleanupPathDone(cleanupPath);
-            } else if ("skipped" in outcome) {
-              markCleanupPathDone(cleanupPath, outcome.skipped.reason);
-              protectedCleanupPaths.push({
-                cleanupPath,
-                protectAliases: true,
-                terminal: true,
-                note: outcome.skipped.reason,
-              });
-            } else {
-              protectedCleanupPaths.push({
-                cleanupPath,
-                protectAliases: true,
-                terminal: false,
-              });
+            if (
+              workspaceCleanupPaths.length > 0 &&
+              workspaceCleanupPaths.every((cleanupPath) =>
+                completedCleanupPaths.has(cleanupPath),
+              ) &&
+              legacyPlan &&
+              statePlan
+            ) {
+              try {
+                await removeLegacyWorkspaceStateForReset(legacyPlan, {
+                  assertCurrent: deletion.assertCurrent,
+                });
+                deletion.assertCurrent();
+                deleteWorkspaceState(statePlan);
+              } catch {
+                // Best-effort cleanup. A later explicit reset can remove stale rows.
+              }
+            }
+            const agentDirCleanupPaths = cleanupPaths.filter((cleanupPath) =>
+              cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath),
+            );
+            if (
+              agentDirCleanupPaths.length > 0 &&
+              agentDirCleanupPaths.every((cleanupPath) => completedCleanupPaths.has(cleanupPath))
+            ) {
+              unregisterResolvedAgentDir({ agentId, agentDir: agentDirRegistryPath });
             }
           }
-          for (const { outcome } of outcomes) {
-            if ("removed" in outcome) {
-              removed.push(outcome.removed);
-            } else if ("failed" in outcome) {
-              failed.push(outcome.failed);
-            }
-          }
-          if (
-            workspaceCleanupPaths.length > 0 &&
-            workspaceCleanupPaths.every((cleanupPath) => completedCleanupPaths.has(cleanupPath)) &&
-            legacyPlan &&
-            statePlan
-          ) {
-            try {
-              await removeLegacyWorkspaceStateForReset(legacyPlan);
-              deleteWorkspaceState(statePlan);
-            } catch {
-              // Best-effort cleanup. A later explicit reset can remove stale rows.
-            }
-          }
-          const agentDirCleanupPaths = cleanupPaths.filter((cleanupPath) =>
-            cleanupPathCovers(cleanupPath, deleteResult.agentDir, agentDirRegistryPath),
-          );
-          if (
-            agentDirCleanupPaths.length > 0 &&
-            agentDirCleanupPaths.every((cleanupPath) => completedCleanupPaths.has(cleanupPath))
-          ) {
+          deletion.assertCurrent();
+          if (failed.length === 0 && !purgeFailed) {
             unregisterResolvedAgentDir({ agentId, agentDir: agentDirRegistryPath });
+            if (deleteFiles) {
+              unregisterAgentDeleteDatabases(agentId, databasePlan?.registrationPaths ?? []);
+            }
+            deletion.finish();
           }
-        }
-        if (failed.length === 0 && !purgeFailed) {
-          unregisterResolvedAgentDir({ agentId, agentDir: agentDirRegistryPath });
-          if (deleteFiles) {
-            unregisterAgentDeleteDatabases(agentId, databasePlan?.registrationPaths ?? []);
-          }
-          deletion.finish();
-        }
-        return {
-          ok: true,
-          agentId,
-          removedBindings: deleteResult.removedBindings,
-          removed,
-          failed,
-          ...(purgeFailed ? { purgeFailed: true as const } : {}),
-        };
-      });
+          return {
+            ok: true,
+            agentId,
+            removedBindings: deleteResult.removedBindings,
+            removed,
+            failed,
+            ...(purgeFailed ? { purgeFailed: true as const } : {}),
+          };
+        }),
+      );
       respond(true, result, undefined);
     } catch (error) {
-      if (error instanceof AgentSharedAuthStoreOwnerError) {
+      if (
+        error instanceof AgentSharedAuthStoreOwnerError ||
+        error instanceof AgentSharedStoreOwnerError
+      ) {
         respond(false, undefined, errorShape(ErrorCodes.INVALID_REQUEST, error.message));
         return;
       }

--- a/src/infra/sqlite-transaction.ts
+++ b/src/infra/sqlite-transaction.ts
@@ -107,6 +107,8 @@ export type SqliteTransactionOptions = {
   logger?: Pick<SubsystemLogger, "warn">;
   operationLabel?: string;
   slowTransactionHoldMs?: number;
+  /** Enclose the physical commit in an owner's synchronous authority guard. */
+  withCommit?: (commit: () => void) => void;
 };
 
 type SqliteTransactionStep = "begin" | "commit";
@@ -344,7 +346,13 @@ function runSqliteTransactionSync<T>(
       elapsedMs: Date.now() - transactionStartedAt,
       options,
     });
-    commitImmediateTransaction(db, options);
+    if (options?.withCommit) {
+      assertSyncTransactionResult(
+        options.withCommit(() => commitImmediateTransaction(db, options)),
+      );
+    } else {
+      commitImmediateTransaction(db, options);
+    }
     return result;
   } catch (error) {
     abortImmediateTransaction(db, error);

--- a/src/skills/lifecycle/clawhub-store.ts
+++ b/src/skills/lifecycle/clawhub-store.ts
@@ -423,6 +423,7 @@ export async function readTrackedClawHubSkillSlugs(workspaceDir: string): Promis
 export async function untrackClawHubSkill(
   workspaceDir: string,
   slug: string,
+  beforePersistentApply?: () => void,
 ): Promise<() => Promise<void>> {
   const trackedSlug = normalizeTrackedSkillSlug(slug);
   const lock = await readClawHubSkillsLockfile(workspaceDir);
@@ -431,6 +432,7 @@ export async function untrackClawHubSkill(
     return async () => undefined;
   }
   delete lock.skills[trackedSlug];
+  beforePersistentApply?.();
   await writeClawHubSkillsLockfile(workspaceDir, lock);
   return async () => {
     const current = await readClawHubSkillsLockfile(workspaceDir);

--- a/src/skills/lifecycle/clawhub-uninstall.test.ts
+++ b/src/skills/lifecycle/clawhub-uninstall.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
@@ -213,6 +213,40 @@ describe("ClawHub skill uninstall lifecycle", () => {
         expectedVersion: "1.0.0",
       }),
     ).resolves.toMatchObject({ ok: false, code: "modified" });
+  });
+
+  it("restores the staged skill when parent deletion ends before untracking", async () => {
+    const current = await fixture();
+    const beforeLock = await readFile(current.lockPath, "utf8");
+    const planned = await planClawHubSkillUninstall({
+      workspaceDir: current.workspaceDir,
+      slug: current.slug,
+      expectedVersion: "1.0.0",
+    });
+    if (!planned.ok) {
+      throw new Error(planned.error);
+    }
+    let active = true;
+    const deps = {
+      beforePersistentApply: () => {
+        if (!active) {
+          throw new Error("Parent deletion ended.");
+        }
+      },
+      rename: async (...args: Parameters<typeof rename>) => {
+        await rename(...args);
+        active = false;
+      },
+    };
+
+    await expect(applyClawHubSkillUninstall(planned.plan, deps)).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining("Parent deletion ended."),
+    });
+    await expect(readFile(join(current.skillDir, "SKILL.md"), "utf8")).resolves.toContain(
+      "name: triage",
+    );
+    await expect(readFile(current.lockPath, "utf8")).resolves.toBe(beforeLock);
   });
 
   it("restores the staged skill when lockfile untracking fails", async () => {

--- a/src/skills/lifecycle/clawhub-uninstall.ts
+++ b/src/skills/lifecycle/clawhub-uninstall.ts
@@ -190,6 +190,7 @@ export async function applyClawHubSkillUninstall(
     removeDir?: typeof fs.rm;
     rename?: typeof fs.rename;
     untrack?: typeof untrackClawHubSkill;
+    beforePersistentApply?: () => void;
   } = {},
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const current = await planClawHubSkillUninstall({
@@ -214,6 +215,7 @@ export async function applyClawHubSkillUninstall(
   let restoreTracking: (() => Promise<void>) | undefined;
   const rename = deps.rename ?? fs.rename;
   try {
+    deps.beforePersistentApply?.();
     await rename(plan.targetDir, stagedDir);
     staged = true;
     const stagedPlan = await checkClawHubSkillPlanAtPath(
@@ -225,7 +227,13 @@ export async function applyClawHubSkillUninstall(
       await rename(stagedDir, plan.targetDir);
       return { ok: false, error: `Skill ${JSON.stringify(plan.slug)} changed during removal.` };
     }
-    restoreTracking = await (deps.untrack ?? untrackClawHubSkill)(plan.workspaceDir, plan.slug);
+    deps.beforePersistentApply?.();
+    restoreTracking = await (deps.untrack ?? untrackClawHubSkill)(
+      plan.workspaceDir,
+      plan.slug,
+      deps.beforePersistentApply,
+    );
+    deps.beforePersistentApply?.();
     await (deps.removeDir ?? fs.rm)(stagedDir, { recursive: true, force: false });
     if (shouldDispatchChange) {
       await dispatchCommittedSkillChangeBestEffort({

--- a/src/state/agent-deletion-cleanup.test.ts
+++ b/src/state/agent-deletion-cleanup.test.ts
@@ -3,12 +3,17 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
-import { beginAgentDeletion } from "../agents/agent-lifecycle-registry.js";
+import { prepareAgentDeleteDatabases } from "../agents/agent-delete-databases.js";
+import {
+  withAgentDeletion,
+  type AgentDeletionOperation,
+} from "../agents/agent-lifecycle-registry.js";
 import { purgeAgentSessionStoreEntries } from "../config/sessions/cleanup-service.js";
 import { loadSessionEntryReadOnly } from "../config/sessions/session-accessor.js";
 import { replaceSessionEntrySync } from "../config/sessions/session-accessor.sqlite-entry.js";
 import { openNodeSqliteDatabase } from "../infra/node-sqlite.js";
 import * as integrityWorker from "../infra/sqlite-integrity-worker.js";
+import { beginAgentDeletionJournal, removeAgentDeletionJournal } from "./agent-deletion-journal.js";
 import { assertNoOpenClawAgentDatabaseLeases } from "./openclaw-agent-db-lease.js";
 import {
   closeOpenClawAgentDatabaseByPath,
@@ -16,6 +21,7 @@ import {
   closeOpenClawAgentDatabasesAsync,
   getOpenClawAgentDatabaseIfOpen,
   openOpenClawAgentDatabase,
+  runOpenClawAgentWriteTransaction,
   withOpenClawAgentDatabaseAsync,
 } from "./openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "./openclaw-state-db.js";
@@ -53,7 +59,8 @@ function fixture() {
     entry,
     write,
     read: () => loadSessionEntryReadOnly(scope)?.sessionId,
-    begin: () => beginAgentDeletion(entry, { env: options.env }),
+    withDeletion: <T>(run: (deletion: AgentDeletionOperation) => Promise<T>) =>
+      withAgentDeletion(options.agentId, async (begin) => run(begin(entry)), { env: options.env }),
   };
 }
 
@@ -68,44 +75,50 @@ describe("agent deletion database cleanup authority", () => {
       } finally {
         writer.close();
       }
-      const deletion = f.begin();
-      const checked = createDeferred();
-      const resume = createDeferred();
-      const check = integrityWorker.assertSqliteIntegrityInWorker;
-      vi.spyOn(integrityWorker, "assertSqliteIntegrityInWorker").mockImplementation(
-        async (...args) => {
-          await check(...args);
-          checked.resolve();
-          await resume.promise;
-        },
-      );
-      let rejected: Promise<unknown> | undefined;
       let operationCalled = false;
-      const running = deletion.runDatabaseCleanup(f.target, async () => {
-        rejected = expect(
-          withOpenClawAgentDatabaseAsync(f.options, () => {
-            operationCalled = true;
-          }),
-        ).rejects.toThrow(/no longer/);
-        // A retained admission must not outlive a callback that did not await it.
-        if (retire !== "settle") {
+      await f.withDeletion(async (deletion) => {
+        const checked = createDeferred();
+        const resume = createDeferred();
+        const check = integrityWorker.assertSqliteIntegrityInWorker;
+        vi.spyOn(integrityWorker, "assertSqliteIntegrityInWorker").mockImplementation(
+          async (...args) => {
+            await check(...args);
+            checked.resolve();
+            await resume.promise;
+          },
+        );
+        let rejected: Promise<unknown> | undefined;
+        const running = deletion.runDatabaseCleanup(f.target, async () => {
+          rejected = expect(
+            withOpenClawAgentDatabaseAsync(f.options, () => {
+              operationCalled = true;
+            }),
+          ).rejects.toThrow(/no longer/);
+          // A retained admission must not outlive a callback that did not await it.
+          if (retire !== "settle") {
+            await rejected;
+          }
+        });
+        const settled =
+          retire === "settle" ? running : expect(running).rejects.toThrow(/no longer/);
+        try {
+          await checked.promise;
+          if (retire === "settle") {
+            await running;
+          } else if (retire === "replace") {
+            beginAgentDeletionJournal(
+              { ...f.entry, operationId: "replacement", deleteFiles: true },
+              { env: f.options.env },
+            );
+          } else {
+            deletion[retire]();
+          }
+        } finally {
+          resume.resolve();
+          await settled;
           await rejected;
         }
       });
-      try {
-        await checked.promise;
-        if (retire === "settle") {
-          await running;
-        } else if (retire === "replace") {
-          f.begin();
-        } else {
-          deletion[retire]();
-        }
-      } finally {
-        resume.resolve();
-        await running;
-        await rejected;
-      }
       const reader = openNodeSqliteDatabase(f.target.path, { readOnly: true });
       try {
         expect(
@@ -125,41 +138,42 @@ describe("agent deletion database cleanup authority", () => {
 
   it("does not expose cleanup admission to a coalesced operation outside its scope", async () => {
     const f = fixture();
-    const deletion = f.begin();
-    const checked = createDeferred();
-    const resume = createDeferred();
-    const releaseOwner = createDeferred();
-    const check = integrityWorker.assertSqliteIntegrityInWorker;
-    vi.spyOn(integrityWorker, "assertSqliteIntegrityInWorker").mockImplementation(
-      async (...args) => {
-        await check(...args);
-        checked.resolve();
-        await resume.promise;
-      },
-    );
-    const running = deletion.runDatabaseCleanup(f.target, () =>
-      withOpenClawAgentDatabaseAsync(f.options, async () => {
-        await releaseOwner.promise;
-        f.write("owned");
-      }),
-    );
-    try {
-      await checked.promise;
-      let outsideCalled = false;
-      const rejected = expect(
-        withOpenClawAgentDatabaseAsync(f.options, (database) => {
-          outsideCalled = true;
-          return database.db.isOpen;
+    await f.withDeletion(async (deletion) => {
+      const checked = createDeferred();
+      const resume = createDeferred();
+      const releaseOwner = createDeferred();
+      const check = integrityWorker.assertSqliteIntegrityInWorker;
+      vi.spyOn(integrityWorker, "assertSqliteIntegrityInWorker").mockImplementation(
+        async (...args) => {
+          await check(...args);
+          checked.resolve();
+          await resume.promise;
+        },
+      );
+      const running = deletion.runDatabaseCleanup(f.target, () =>
+        withOpenClawAgentDatabaseAsync(f.options, async () => {
+          await releaseOwner.promise;
+          f.write("owned");
         }),
-      ).rejects.toThrow("active deletion cleanup");
-      resume.resolve();
-      await rejected;
-      expect(outsideCalled).toBe(false);
-    } finally {
-      resume.resolve();
-      releaseOwner.resolve();
-      await running;
-    }
+      );
+      try {
+        await checked.promise;
+        let outsideCalled = false;
+        const rejected = expect(
+          withOpenClawAgentDatabaseAsync(f.options, (database) => {
+            outsideCalled = true;
+            return database.db.isOpen;
+          }),
+        ).rejects.toThrow("active deletion cleanup");
+        resume.resolve();
+        await rejected;
+        expect(outsideCalled).toBe(false);
+      } finally {
+        resume.resolve();
+        releaseOwner.resolve();
+        await running;
+      }
+    });
     expect(f.read()).toBe("owned");
   });
 
@@ -167,170 +181,294 @@ describe("agent deletion database cleanup authority", () => {
     const f = fixture();
     const options = { ...f.options, agentId: "kept", path: path.join(f.root, "shared.sqlite") };
     const kept = openOpenClawAgentDatabase(options);
-    const deletion = f.begin();
     let operationCalled = false;
-    let rejected: Promise<unknown> | undefined;
-    await deletion.runDatabaseCleanup({ agentId: "kept", path: kept.path }, async () => {
-      rejected = expect(
-        withOpenClawAgentDatabaseAsync(options, () => {
-          operationCalled = true;
-        }),
-      ).rejects.toThrow("no longer active");
+    await f.withDeletion(async (deletion) => {
+      let rejected: Promise<unknown> | undefined;
+      await deletion.runDatabaseCleanup({ agentId: "kept", path: kept.path }, async () => {
+        rejected = expect(
+          withOpenClawAgentDatabaseAsync(options, () => {
+            operationCalled = true;
+          }),
+        ).rejects.toThrow("no longer active");
+      });
+      await rejected;
     });
-    await rejected;
     expect(operationCalled).toBe(false);
     expect(kept.db.isOpen).toBe(true);
     expect(openOpenClawAgentDatabase(options)).toBe(kept);
   });
 
+  it("retries a settled shared-store close before admitting a fresh deletion cleanup", async () => {
+    const f = fixture();
+    const storePath = path.join(f.root, "shared.sqlite");
+    const sharedOptions = { ...f.options, agentId: "kept", path: storePath };
+    const cfg = {
+      agents: { entries: { worker: {}, kept: {} } },
+      session: { store: storePath },
+    };
+    openOpenClawAgentDatabase(sharedOptions);
+    const workerScope = { ...f.options, storePath, sessionKey: "agent:worker:shared" };
+    const keptScope = { ...workerScope, agentId: "kept", sessionKey: "agent:kept:shared" };
+    replaceSessionEntrySync(workerScope, { sessionId: "remove", updatedAt: Date.now() });
+    replaceSessionEntrySync(keptScope, { sessionId: "keep", updatedAt: Date.now() });
+    closeOpenClawAgentDatabaseByPath(storePath, "kept");
+    let retained: ReturnType<typeof openOpenClawAgentDatabase> | undefined;
+    let closeCalls = 0;
+    const runAttempt = (deletion: AgentDeletionOperation, injectFailure: boolean) => {
+      prepareAgentDeleteDatabases(cfg, "worker", f.entry.agentDir, { env: f.options.env });
+      return purgeAgentSessionStoreEntries(cfg, "worker", {
+        env: f.options.env,
+        runDatabaseCleanup: (target, run) =>
+          deletion.runDatabaseCleanup(target, async () => {
+            if (injectFailure && target.path === storePath) {
+              retained = openOpenClawAgentDatabase(sharedOptions);
+              const close = retained.db.close.bind(retained.db);
+              vi.spyOn(retained.db, "close").mockImplementation(() => {
+                closeCalls += 1;
+                if (closeCalls === 1) {
+                  throw new Error("one-time native close failure");
+                }
+                close();
+              });
+            }
+            return await run();
+          }),
+      });
+    };
+
+    await expect(f.withDeletion((deletion) => runAttempt(deletion, true))).resolves.toBe(true);
+    expect(closeCalls).toBe(1);
+    expect(retained?.db.isOpen).toBe(true);
+    expect(() => openOpenClawAgentDatabase(sharedOptions)).toThrow("active deletion cleanup");
+    await expect(f.withDeletion((deletion) => runAttempt(deletion, false))).resolves.toBe(false);
+    expect(closeCalls).toBe(2);
+    expect(retained?.db.isOpen).toBe(false);
+    expect(loadSessionEntryReadOnly(workerScope)).toBeUndefined();
+    expect(loadSessionEntryReadOnly(keptScope)?.sessionId).toBe("keep");
+    expect(openOpenClawAgentDatabase(sharedOptions).db.isOpen).toBe(true);
+  });
+
+  it("rejects cleanup settlement after awaited journal takeover", async () => {
+    const f = fixture();
+    await f.withDeletion(async (deletion) => {
+      const opened = createDeferred();
+      const release = createDeferred();
+      const running = deletion.runDatabaseCleanup(f.target, async () => {
+        openOpenClawAgentDatabase(f.options);
+        opened.resolve();
+        await release.promise;
+      });
+      const rejected = expect(running).rejects.toThrow("no longer owns");
+      try {
+        await opened.promise;
+        beginAgentDeletionJournal(
+          { ...f.entry, operationId: "replacement", deleteFiles: true },
+          { env: f.options.env },
+        );
+      } finally {
+        release.resolve();
+      }
+      await rejected;
+      expect(f.read()).toBe("before");
+      expect(getOpenClawAgentDatabaseIfOpen(f.options)).toBeUndefined();
+    });
+  });
+
+  it.each([false, true])(
+    "rolls back writes after precommit journal takeover (warm survivor: %s)",
+    async (warmSurvivor) => {
+      const f = fixture();
+      const options = {
+        ...f.options,
+        agentId: warmSurvivor ? "kept" : f.options.agentId,
+        path: warmSurvivor ? path.join(f.root, "shared.sqlite") : f.target.path,
+      };
+      const scope = { ...f.options, storePath: options.path, sessionKey: "agent:worker:main" };
+      const write = (sessionId: string) =>
+        replaceSessionEntrySync(scope, { sessionId, updatedAt: 1 });
+      if (warmSurvivor) {
+        openOpenClawAgentDatabase(options);
+        write("before");
+      }
+      await f.withDeletion(async (deletion) => {
+        await expect(
+          deletion.runDatabaseCleanup(options, async () => {
+            runOpenClawAgentWriteTransaction(() => {
+              write("stale");
+              beginAgentDeletionJournal(
+                { ...f.entry, operationId: "replacement", deleteFiles: true },
+                { env: f.options.env },
+              );
+            }, options);
+          }),
+        ).rejects.toThrow("no longer owns");
+        expect(loadSessionEntryReadOnly(scope)?.sessionId).toBe("before");
+      });
+    },
+  );
+
   it("keeps a cold cleanup handle private through awaits and closes it before settlement", async () => {
     const f = fixture();
-    const deletion = f.begin();
-    const opened = createDeferred();
-    const release = createDeferred();
-    const late = createDeferred();
-    let lateWrite: Promise<unknown> | undefined;
-    const running = deletion.runDatabaseCleanup(f.target, async () => {
-      const database = openOpenClawAgentDatabase(f.options);
-      lateWrite = (async () => {
-        await late.promise;
-        expect(() => f.write("late")).toThrow("no longer active");
-      })();
-      opened.resolve();
-      await release.promise;
-      f.write("owned");
-      return database;
-    });
-    try {
-      await opened.promise;
-      expect(() => openOpenClawAgentDatabase(f.options)).toThrow("active deletion cleanup");
-      expect(() => getOpenClawAgentDatabaseIfOpen(f.options)).toThrow("active deletion cleanup");
-      expect(() => f.write("ordinary")).toThrow("active deletion cleanup");
-      const alias = path.join(f.root, "alias");
-      fs.symlinkSync(
-        path.dirname(f.target.path),
-        alias,
-        process.platform === "win32" ? "junction" : "dir",
-      );
-      expect(() =>
-        openOpenClawAgentDatabase({
-          ...f.options,
-          path: path.join(alias, path.basename(f.target.path)),
-        }),
-      ).toThrow("active deletion cleanup");
-      expect(f.read()).toBe("before");
-    } finally {
-      release.resolve();
+    await f.withDeletion(async (deletion) => {
+      const opened = createDeferred();
+      const release = createDeferred();
+      const late = createDeferred();
+      let lateWrite: Promise<unknown> | undefined;
+      const running = deletion.runDatabaseCleanup(f.target, async () => {
+        const database = openOpenClawAgentDatabase(f.options);
+        lateWrite = (async () => {
+          await late.promise;
+          expect(() => f.write("late")).toThrow("no longer active");
+        })();
+        opened.resolve();
+        await release.promise;
+        f.write("owned");
+        return database;
+      });
       try {
-        expect((await running).db.isOpen).toBe(false);
+        await opened.promise;
+        expect(() => openOpenClawAgentDatabase(f.options)).toThrow("active deletion cleanup");
+        expect(() => getOpenClawAgentDatabaseIfOpen(f.options)).toThrow("active deletion cleanup");
+        expect(() => f.write("ordinary")).toThrow("active deletion cleanup");
+        const alias = path.join(f.root, "alias");
+        fs.symlinkSync(
+          path.dirname(f.target.path),
+          alias,
+          process.platform === "win32" ? "junction" : "dir",
+        );
+        expect(() =>
+          openOpenClawAgentDatabase({
+            ...f.options,
+            path: path.join(alias, path.basename(f.target.path)),
+          }),
+        ).toThrow("active deletion cleanup");
+        expect(f.read()).toBe("before");
       } finally {
-        late.resolve();
-        await lateWrite;
+        release.resolve();
+        try {
+          expect((await running).db.isOpen).toBe(false);
+        } finally {
+          late.resolve();
+          await lateWrite;
+        }
       }
-    }
-    expect(f.read()).toBe("owned");
-    expect(() =>
-      assertNoOpenClawAgentDatabaseLeases("worker", { env: f.options.env }),
-    ).not.toThrow();
+      expect(f.read()).toBe("owned");
+      expect(() =>
+        assertNoOpenClawAgentDatabaseLeases("worker", { env: f.options.env }),
+      ).not.toThrow();
+    });
   });
 
   it.each(["replace", "rollback", "finish"] as const)(
     "rejects cleanup writes after its journal owner is retired by %s",
     async (retire) => {
       const f = fixture();
-      const deletion = f.begin();
-      const opened = createDeferred();
-      const release = createDeferred();
-      const running = deletion.runDatabaseCleanup(f.target, async () => {
-        const database = openOpenClawAgentDatabase(f.options);
-        opened.resolve();
-        await release.promise;
-        expect(() => f.write("stale")).toThrow("no longer owns database cleanup");
-        return database;
-      });
-      try {
-        await opened.promise;
-        if (retire === "replace") {
-          f.begin();
-        } else {
-          deletion[retire]();
+      await f.withDeletion(async (deletion) => {
+        const opened = createDeferred();
+        const release = createDeferred();
+        let database: ReturnType<typeof openOpenClawAgentDatabase> | undefined;
+        const running = deletion.runDatabaseCleanup(f.target, async () => {
+          database = openOpenClawAgentDatabase(f.options);
+          opened.resolve();
+          await release.promise;
+          expect(() => f.write("stale")).toThrow("no longer owns database cleanup");
+          return database;
+        });
+        const rejected = expect(running).rejects.toThrow("no longer owns");
+        try {
+          await opened.promise;
+          if (retire === "replace") {
+            beginAgentDeletionJournal(
+              { ...f.entry, operationId: "replacement", deleteFiles: true },
+              { env: f.options.env },
+            );
+          } else {
+            deletion[retire]();
+          }
+        } finally {
+          release.resolve();
+          await rejected;
+          expect(database?.db.isOpen).toBe(false);
         }
-      } finally {
-        release.resolve();
-        expect((await running).db.isOpen).toBe(false);
-      }
-      expect(f.read()).toBe("before");
+        expect(f.read()).toBe("before");
+      });
     },
   );
 
   it("binds the cleanup target to its state database, identity, and physical locator", async () => {
     const f = fixture();
     const other = fixture();
-    const deletion = f.begin();
-    await deletion.runDatabaseCleanup(f.target, async () => {
-      const database = openOpenClawAgentDatabase(f.options);
-      expect(() =>
-        openOpenClawAgentDatabase({ ...f.options, env: other.options.env, path: f.target.path }),
-      ).toThrow("another state database");
-      expect(() =>
-        openOpenClawAgentDatabase({ ...f.options, agentId: "kept", path: f.target.path }),
-      ).toThrow("already open for agent worker");
-      expect(() =>
-        openOpenClawAgentDatabase({ ...f.options, path: path.join(f.root, "unowned.sqlite") }),
-      ).toThrow("unavailable while agent worker is deleted");
-      expect(database.db.isOpen).toBe(true);
+    await f.withDeletion(async (deletion) => {
+      await deletion.runDatabaseCleanup(f.target, async () => {
+        const database = openOpenClawAgentDatabase(f.options);
+        expect(() =>
+          openOpenClawAgentDatabase({ ...f.options, env: other.options.env, path: f.target.path }),
+        ).toThrow("another state database");
+        expect(() =>
+          openOpenClawAgentDatabase({ ...f.options, agentId: "kept", path: f.target.path }),
+        ).toThrow("already open for agent worker");
+        expect(() =>
+          openOpenClawAgentDatabase({ ...f.options, path: path.join(f.root, "unowned.sqlite") }),
+        ).toThrow("unavailable while agent worker is deleted");
+        expect(database.db.isOpen).toBe(true);
+      });
+      expect(f.read()).toBe("before");
+      expect(other.read()).toBe("before");
     });
-    expect(f.read()).toBe("before");
-    expect(other.read()).toBe("before");
   });
 
   it.each([false, true])(
     "retains failed cleanup close ownership (operation also failed: %s)",
     async (failRun) => {
       const f = fixture();
-      const deletion = f.begin();
-      let retained: ReturnType<typeof openOpenClawAgentDatabase> | undefined;
-      const closeError = new Error("held native close");
-      const runError = new Error("cleanup operation failed");
-      const running = deletion.runDatabaseCleanup(f.target, async () => {
-        retained = openOpenClawAgentDatabase(f.options);
-        vi.spyOn(retained.db, "close").mockImplementationOnce(() => {
-          throw closeError;
+      await f.withDeletion(async (deletion) => {
+        let retained: ReturnType<typeof openOpenClawAgentDatabase> | undefined;
+        const closeError = new Error("held native close");
+        const runError = new Error("cleanup operation failed");
+        const running = deletion.runDatabaseCleanup(f.target, async () => {
+          retained = openOpenClawAgentDatabase(f.options);
+          vi.spyOn(retained.db, "close").mockImplementationOnce(() => {
+            throw closeError;
+          });
+          if (failRun) {
+            throw runError;
+          }
         });
         if (failRun) {
-          throw runError;
+          await expect(running).rejects.toMatchObject({ errors: [runError, closeError] });
+        } else {
+          await expect(running).rejects.toBe(closeError);
         }
+        expect(retained?.db.isOpen).toBe(true);
+        expect(() => openOpenClawAgentDatabase(f.options)).toThrow("active deletion cleanup");
+        expect(() => assertNoOpenClawAgentDatabaseLeases("worker", { env: f.options.env })).toThrow(
+          "database is still open",
+        );
+        expect(closeOpenClawAgentDatabaseByPath(f.target.path, "worker")).toBe(true);
+        await deletion.runDatabaseCleanup(f.target, async () => f.write("retried"));
+        expect(f.read()).toBe("retried");
+        expect(() =>
+          assertNoOpenClawAgentDatabaseLeases("worker", { env: f.options.env }),
+        ).not.toThrow();
       });
-      if (failRun) {
-        await expect(running).rejects.toMatchObject({ errors: [runError, closeError] });
-      } else {
-        await expect(running).rejects.toBe(closeError);
-      }
-      expect(retained?.db.isOpen).toBe(true);
-      expect(() => openOpenClawAgentDatabase(f.options)).toThrow("active deletion cleanup");
-      expect(() => assertNoOpenClawAgentDatabaseLeases("worker", { env: f.options.env })).toThrow(
-        "database is still open",
-      );
-      expect(closeOpenClawAgentDatabaseByPath(f.target.path, "worker")).toBe(true);
-      await deletion.runDatabaseCleanup(f.target, async () => f.write("retried"));
-      expect(f.read()).toBe("retried");
-      expect(() =>
-        assertNoOpenClawAgentDatabaseLeases("worker", { env: f.options.env }),
-      ).not.toThrow();
     },
   );
 
   it("never exempts a foreign deletion journal's overlapping path", async () => {
     const f = fixture();
-    const foreign = beginAgentDeletion({ ...f.entry, agentId: "kept" }, { env: f.options.env });
-    const deletion = f.begin();
-    await expect(
-      deletion.runDatabaseCleanup(f.target, async () => f.write("blocked")),
-    ).rejects.toThrow("agent kept deletion owns");
-    expect(f.read()).toBe("before");
-    foreign.rollback();
-    await deletion.runDatabaseCleanup(f.target, async () => f.write("retried"));
-    expect(f.read()).toBe("retried");
+    const foreign = beginAgentDeletionJournal(
+      { ...f.entry, agentId: "kept", operationId: "foreign", deleteFiles: true },
+      { env: f.options.env },
+    );
+    await f.withDeletion(async (deletion) => {
+      await expect(
+        deletion.runDatabaseCleanup(f.target, async () => f.write("blocked")),
+      ).rejects.toThrow("agent kept deletion owns");
+      expect(f.read()).toBe("before");
+      removeAgentDeletionJournal("kept", foreign.operationId, { env: f.options.env });
+      await deletion.runDatabaseCleanup(f.target, async () => f.write("retried"));
+      expect(f.read()).toBe("retried");
+    });
   });
 
   it.each([false, true])(
@@ -347,20 +485,21 @@ describe("agent deletion database cleanup authority", () => {
       if (cold) {
         closeOpenClawAgentDatabaseByPath(storePath);
       }
-      const deletion = f.begin();
-      await expect(
-        purgeAgentSessionStoreEntries(
-          { agents: { entries: { worker: {}, kept: {} } }, session: { store: storePath } },
-          "worker",
-          { env: f.options.env, runDatabaseCleanup: deletion.runDatabaseCleanup },
-        ),
-      ).resolves.toBe(false);
-      expect(loadSessionEntryReadOnly(workerScope)).toBeUndefined();
-      expect(loadSessionEntryReadOnly(keptScope)?.sessionId).toBe("keep");
-      expect(shared.db.isOpen).toBe(!cold);
-      if (cold) {
-        expect(getOpenClawAgentDatabaseIfOpen(sharedOptions)).toBeUndefined();
-      }
+      await f.withDeletion(async (deletion) => {
+        await expect(
+          purgeAgentSessionStoreEntries(
+            { agents: { entries: { worker: {}, kept: {} } }, session: { store: storePath } },
+            "worker",
+            { env: f.options.env, runDatabaseCleanup: deletion.runDatabaseCleanup },
+          ),
+        ).resolves.toBe(false);
+        expect(loadSessionEntryReadOnly(workerScope)).toBeUndefined();
+        expect(loadSessionEntryReadOnly(keptScope)?.sessionId).toBe("keep");
+        expect(shared.db.isOpen).toBe(!cold);
+        if (cold) {
+          expect(getOpenClawAgentDatabaseIfOpen(sharedOptions)).toBeUndefined();
+        }
+      });
     },
   );
 });

--- a/src/state/agent-deletion-cleanup.ts
+++ b/src/state/agent-deletion-cleanup.ts
@@ -23,6 +23,8 @@ type AgentDeletionDatabaseCleanupScope = {
   assertCurrent: () => void;
   assertJournal: (statePath: string, entries: readonly AgentDeletionCleanupRow[]) => string;
   registerClose: (close: () => void) => void;
+  retryClose: () => void;
+  withCommit: (commit: () => void) => void;
 };
 
 const databaseCleanup = resolveGlobalSingleton(
@@ -38,6 +40,7 @@ const cleanupHandles = resolveGlobalSingleton(
 export function createAgentDeletionDatabaseCleanup(owner: {
   statePath: string;
   assertAdmission: () => void;
+  withCommit: (commit: () => void) => void;
   assertCurrent: () => void;
   assertJournal: (statePath: string, entries: readonly AgentDeletionCleanupRow[]) => string;
 }) {
@@ -46,7 +49,19 @@ export function createAgentDeletionDatabaseCleanup(owner: {
     run: () => Promise<T>,
   ): Promise<T> => {
     let active = true;
-    const closers: Array<() => void> = [];
+    const closers = new Set<() => void>();
+    const closeHandles = () => {
+      const errors: unknown[] = [];
+      for (const close of [...closers].toReversed()) {
+        try {
+          close();
+          closers.delete(close);
+        } catch (error) {
+          errors.push(error);
+        }
+      }
+      return errors;
+    };
     const assertActive = () => {
       if (!active) {
         throw new Error("Agent deletion database cleanup is no longer active.");
@@ -66,7 +81,20 @@ export function createAgentDeletionDatabaseCleanup(owner: {
       },
       registerClose: (close) => {
         assertActive();
-        closers.push(close);
+        closers.add(close);
+      },
+      retryClose: () => {
+        if (active) {
+          throw new Error("Agent database belongs to an active deletion cleanup.");
+        }
+        const errors = closeHandles();
+        if (errors.length > 0) {
+          throw new AggregateError(errors, "Agent deletion database close retry failed.");
+        }
+      },
+      withCommit: (commit) => {
+        assertActive();
+        owner.withCommit(commit);
       },
     };
     return await databaseCleanup.run(scope, async () => {
@@ -74,22 +102,28 @@ export function createAgentDeletionDatabaseCleanup(owner: {
       const closeErrors: unknown[] = [];
       try {
         scope.assertCurrent();
+        // A failed cold close keeps its tag and native lease. A fresh exact owner
+        // retries only that settled close; it never adopts the expired write scope.
+        for (const previous of new Set(cleanupHandles.values())) {
+          if (
+            previous.statePath === scope.statePath &&
+            previous.agentId === scope.agentId &&
+            previous.path === scope.path
+          ) {
+            previous.retryClose();
+          }
+        }
         owner.assertAdmission();
-        outcome = ok(await run());
+        const value = await run();
+        scope.assertCurrent();
+        outcome = ok(value);
       } catch (error) {
         outcome = err(error);
       } finally {
-        for (const close of closers.toReversed()) {
-          try {
-            close();
-          } catch (error) {
-            closeErrors.push(error);
-          }
-        }
+        closeErrors.push(...closeHandles());
         // Retained async callbacks keep this same object and must fail after settlement.
         // A failed native close remains tagged and leased for the existing close retry.
         active = false;
-        closers.length = 0;
       }
       if (!outcome.ok) {
         throw closeErrors.length > 0

--- a/src/state/agent-deletion-journal.ts
+++ b/src/state/agent-deletion-journal.ts
@@ -350,28 +350,37 @@ function parseCleanupPaths(value: string): AgentDeletionJournalCleanupPath[] {
   return parsed;
 }
 
+/** Read the journal through an already validated shared-state connection. */
+export function readAgentDeletionJournalInDatabase(
+  database: OpenClawStateDatabase,
+  agentId: string,
+): AgentDeletionJournalEntry | undefined {
+  ensureAgentDeletionJournalSchema(database.db);
+  const db = getNodeSqliteKysely<AgentDeletionDatabase>(database.db);
+  const row = executeSqliteQueryTakeFirstSync(
+    database.db,
+    db
+      .selectFrom("agent_deletion_journal")
+      .selectAll()
+      .where("agent_id", "=", normalizeAgentId(agentId)),
+  );
+  return row ? fromRow(row) : undefined;
+}
+
 export function readAgentDeletionJournal(
   agentId: string,
   options: OpenClawStateDatabaseOptions = {},
 ): AgentDeletionJournalEntry | undefined {
-  const id = normalizeAgentId(agentId);
   const databasePath = path.resolve(
     options.path ?? resolveOpenClawStateSqlitePath(options.env ?? process.env),
   );
   if (!existsSync(databasePath)) {
     return undefined;
   }
-  let entry: AgentDeletionJournalEntry | undefined;
-  runOpenClawStateWriteTransaction((database) => {
-    ensureAgentDeletionJournalSchema(database.db);
-    const db = getNodeSqliteKysely<AgentDeletionDatabase>(database.db);
-    const row = executeSqliteQueryTakeFirstSync(
-      database.db,
-      db.selectFrom("agent_deletion_journal").selectAll().where("agent_id", "=", id),
-    );
-    entry = row ? fromRow(row) : undefined;
-  }, options);
-  return entry;
+  return runOpenClawStateWriteTransaction(
+    (database) => readAgentDeletionJournalInDatabase(database, agentId),
+    options,
+  );
 }
 
 export function beginAgentDeletionJournal(
@@ -519,17 +528,6 @@ export function updateAgentDeletionJournalDatabasePaths(
     updated = Number(result.numAffectedRows ?? 0) > 0;
   }, options);
   return updated;
-}
-
-export function completeAgentDeletionJournal(
-  agentId: string,
-  operationId: string,
-  options: OpenClawStateDatabaseOptions = {},
-): boolean {
-  return runOpenClawStateWriteTransaction(
-    (database) => completeAgentDeletionJournalInDatabase(database, agentId, operationId),
-    options,
-  );
 }
 
 /** Complete a deletion journal inside a caller-owned shared-state transaction. */

--- a/src/state/openclaw-agent-db.incognito.test.ts
+++ b/src/state/openclaw-agent-db.incognito.test.ts
@@ -2,6 +2,8 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
+import { prepareAgentDeleteDatabases } from "../agents/agent-delete-databases.js";
+import { beginAgentDeletionJournal } from "./agent-deletion-journal.js";
 import { OPENCLAW_AGENT_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
 import { withOpenClawAgentDatabaseReadOnly } from "./openclaw-agent-db-readonly.js";
 import {
@@ -14,18 +16,67 @@ import {
   openOpenClawAgentDatabase,
   readOpenIncognitoAgentDatabaseGeneration,
   resolveIncognitoOpenClawAgentSqlitePath,
+  runOpenClawAgentWriteTransaction,
 } from "./openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "./openclaw-state-db.js";
 
 const tempDirs: string[] = [];
 
 afterEach(() => {
   closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
   for (const tempDir of tempDirs.splice(0)) {
     fs.rmSync(tempDir, { force: true, recursive: true });
   }
 });
 
 describe("incognito agent database", () => {
+  it.each([false, true])(
+    "rejects deletion-fenced opens and writes and retires prepared statements (held: %s)",
+    (held) => {
+      const stateDir = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "incognito-delete-")));
+      tempDirs.push(stateDir);
+      const env = { OPENCLAW_STATE_DIR: stateDir };
+      const sentinel = resolveIncognitoOpenClawAgentSqlitePath({ agentId: "worker", env });
+      const options = { agentId: "worker", env, path: sentinel };
+      const database = held ? openOpenClawAgentDatabase(options) : undefined;
+      const writeSql =
+        "UPDATE schema_meta SET updated_at = updated_at + 1 WHERE meta_key = 'primary'";
+      const retained = database?.db.prepare(writeSql);
+      beginAgentDeletionJournal(
+        {
+          agentId: "worker",
+          operationId: "delete-worker",
+          agentDir: path.dirname(sentinel),
+          workspaceDir: path.join(stateDir, "workspace-worker"),
+          sessionsDir: path.join(stateDir, "agents", "worker", "sessions"),
+          deleteFiles: true,
+        },
+        { env },
+      );
+
+      expect.soft(() => openOpenClawAgentDatabase(options)).toThrow("is deleted");
+      expect
+        .soft(() =>
+          runOpenClawAgentWriteTransaction(({ db }) => db.prepare(writeSql).run(), options),
+        )
+        .toThrow("is deleted");
+      const plan = prepareAgentDeleteDatabases(
+        { agents: { entries: { worker: {}, kept: {} } } },
+        "worker",
+        path.dirname(sentinel),
+        { env },
+      );
+      if (database && retained) {
+        expect.soft(database.db.isOpen).toBe(false);
+        expect.soft(() => retained.run()).toThrow();
+      }
+      expect(plan.registrationPaths).not.toContain(sentinel);
+      expect(plan.fileGroups.flat()).not.toContain(sentinel);
+      expect(fs.existsSync(sentinel)).toBe(false);
+    },
+  );
+
   it("does not allocate an in-memory database for a read-only miss", () => {
     const stateDir = fs.realpathSync(
       fs.mkdtempSync(path.join(fs.realpathSync(os.tmpdir()), "openclaw-incognito-read-miss-")),
@@ -93,6 +144,7 @@ describe("incognito agent database", () => {
     expect(openedGeneration).toBeGreaterThan(beforeGeneration);
     expect(readOpenIncognitoAgentDatabaseGeneration()).toBe(openedGeneration);
     expect(reopened).toBe(first);
+    expect(fs.readdirSync(stateDir)).toEqual([]);
     expect(listOpenIncognitoAgentDatabases()).toEqual([{ agentId: "main", storePath: sentinel }]);
     expect(listOpenClawRegisteredAgentDatabases({ env })).toEqual([]);
     expect(

--- a/src/state/openclaw-agent-db.test.ts
+++ b/src/state/openclaw-agent-db.test.ts
@@ -7,10 +7,6 @@ import type { DatabaseSync } from "node:sqlite";
 import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
 import { cleanupTempDirs, makeTempDir } from "../../test/helpers/temp-dir.js";
 import {
-  beginAgentDeletion,
-  claimCompletedAgentDeletion,
-} from "../agents/agent-lifecycle-registry.js";
-import {
   executeSqliteQuerySync,
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
@@ -23,7 +19,13 @@ import { runSqliteImmediateTransactionSync } from "../infra/sqlite-transaction.j
 import { VERSION } from "../version.js";
 import {
   assertAgentDeletionPathFence,
+  beginAgentDeletionJournal,
+  claimCompletedAgentDeletionJournal,
+  completeAgentDeletionJournalInDatabase,
   prepareAgentDeletionPathFence,
+  removeAgentDeletionJournal,
+  updateAgentDeletionJournalDatabasePaths,
+  updateAgentDeletionJournalCleanupPaths,
 } from "./agent-deletion-journal.js";
 import { AGENT_MEDIA_SCHEMA_VERSION } from "./openclaw-agent-db-contract.js";
 import {
@@ -894,7 +896,10 @@ describe("openclaw agent database", () => {
       workspaceDir: path.join(stateDir, "workspace-deleted"),
       sessionsDir: path.join(stateDir, "sessions-deleted"),
     };
-    const deletion = beginAgentDeletion(entry, { env });
+    const deletion = beginAgentDeletionJournal(
+      { ...entry, operationId: "deletion", deleteFiles: true },
+      { env },
+    );
     const databasePaths = [path.join(entry.agentDir, "openclaw-agent.sqlite")];
     const cleanupPaths = [
       {
@@ -909,13 +914,20 @@ describe("openclaw agent database", () => {
         done: false,
       },
     ];
-    deletion.fenceDatabasePaths(databasePaths);
-    deletion.fenceCleanupPaths(cleanupPaths);
+    updateAgentDeletionJournalDatabasePaths(deletion.agentId, deletion.operationId, databasePaths, {
+      env,
+    });
+    updateAgentDeletionJournalCleanupPaths(deletion.agentId, deletion.operationId, cleanupPaths, {
+      env,
+    });
 
-    const recovery = beginAgentDeletion(entry, { env });
-    expect(recovery.entry.databasePaths).toEqual(databasePaths);
-    expect(recovery.entry.cleanupPaths).toEqual(cleanupPaths);
-    recovery.rollback();
+    const recovery = beginAgentDeletionJournal(
+      { ...entry, operationId: "recovery", deleteFiles: true },
+      { env },
+    );
+    expect(recovery.databasePaths).toEqual(databasePaths);
+    expect(recovery.cleanupPaths).toEqual(cleanupPaths);
+    removeAgentDeletionJournal(recovery.agentId, recovery.operationId, { env });
   });
 
   it("fences registration and lease claims beneath another agent's pending deletion", () => {
@@ -935,8 +947,10 @@ describe("openclaw agent database", () => {
       env,
     });
     registerOpenClawAgentDatabase({ agentId: "deleted", path: registeredSidecarPath, env });
-    const deletion = beginAgentDeletion(
+    const deletion = beginAgentDeletionJournal(
       {
+        operationId: "deletion",
+        deleteFiles: true,
         agentId: "deleted",
         agentDir: linkedAgentDir,
         workspaceDir: path.join(stateDir, "workspace-deleted"),
@@ -958,7 +972,7 @@ describe("openclaw agent database", () => {
         ).toThrow("deletion owns");
       }
     } finally {
-      deletion.rollback();
+      removeAgentDeletionJournal(deletion.agentId, deletion.operationId, { env });
     }
 
     expect(() =>
@@ -983,8 +997,10 @@ describe("openclaw agent database", () => {
       path: foreignDatabasePath,
       env,
     });
-    const deletion = beginAgentDeletion(
+    const deletion = beginAgentDeletionJournal(
       {
+        operationId: "deletion",
+        deleteFiles: true,
         agentId: "deleted",
         agentDir: path.join(stateDir, "agents", "deleted", "agent"),
         workspaceDir,
@@ -996,7 +1012,7 @@ describe("openclaw agent database", () => {
     expect(() => assertNoOpenClawAgentDatabaseLeases("deleted", { env })).toThrow("deletion owns");
     releaseOpenClawAgentDatabaseLease(leaseId, { env });
     expect(() => assertNoOpenClawAgentDatabaseLeases("deleted", { env })).not.toThrow();
-    deletion.rollback();
+    removeAgentDeletionJournal(deletion.agentId, deletion.operationId, { env });
   });
 
   it("rejects a database claim prepared before deletion cleanup completes", () => {
@@ -1004,8 +1020,10 @@ describe("openclaw agent database", () => {
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentDir = path.join(stateDir, "agents", "deleted", "agent");
     const databasePath = path.join(agentDir, "survivor.sqlite");
-    const deletion = beginAgentDeletion(
+    const deletion = beginAgentDeletionJournal(
       {
+        operationId: "deletion",
+        deleteFiles: true,
         agentId: "deleted",
         agentDir,
         workspaceDir: path.join(stateDir, "workspace-deleted"),
@@ -1018,7 +1036,15 @@ describe("openclaw agent database", () => {
       { env },
     );
 
-    deletion.finish();
+    runOpenClawStateWriteTransaction(
+      (sharedStateDatabase) =>
+        completeAgentDeletionJournalInDatabase(
+          sharedStateDatabase,
+          deletion.agentId,
+          deletion.operationId,
+        ),
+      { env },
+    );
 
     expect(() =>
       runOpenClawStateWriteTransaction(
@@ -3177,8 +3203,10 @@ describe("openclaw agent database", () => {
     const original = openOpenClawAgentDatabase({ agentId: "worker-1", env });
     const originalInode = fs.statSync(original.path).ino;
     const archivedDir = path.join(stateDir, "trash", "worker-1-agent");
-    const deletion = beginAgentDeletion(
+    const deletion = beginAgentDeletionJournal(
       {
+        operationId: "deletion",
+        deleteFiles: true,
         agentId: "worker-1",
         agentDir: path.dirname(original.path),
         workspaceDir: path.join(stateDir, "workspace-worker-1"),
@@ -3196,8 +3224,16 @@ describe("openclaw agent database", () => {
         "agent worker-1 is deleted",
       );
 
-      deletion.finish();
-      expect(claimCompletedAgentDeletion("worker-1", deletion.entry.operationId, { env })).toBe(
+      runOpenClawStateWriteTransaction(
+        (sharedStateDatabase) =>
+          completeAgentDeletionJournalInDatabase(
+            sharedStateDatabase,
+            deletion.agentId,
+            deletion.operationId,
+          ),
+        { env },
+      );
+      expect(claimCompletedAgentDeletionJournal("worker-1", deletion.operationId, { env })).toBe(
         true,
       );
       const recreated = openOpenClawAgentDatabase({ agentId: "worker-1", env });
@@ -3208,7 +3244,15 @@ describe("openclaw agent database", () => {
         expect.objectContaining({ agentId: "worker-1", path: recreated.path }),
       ]);
     } finally {
-      deletion.finish();
+      runOpenClawStateWriteTransaction(
+        (sharedStateDatabase) =>
+          completeAgentDeletionJournalInDatabase(
+            sharedStateDatabase,
+            deletion.agentId,
+            deletion.operationId,
+          ),
+        { env },
+      );
     }
   });
 
@@ -3217,8 +3261,10 @@ describe("openclaw agent database", () => {
     const env = { OPENCLAW_STATE_DIR: stateDir };
     const agentDir = path.join(stateDir, "agents", "worker-1", "agent");
     const databasePath = path.join(agentDir, "openclaw-agent.sqlite");
-    const deletion = beginAgentDeletion(
+    const deletion = beginAgentDeletionJournal(
       {
+        operationId: "deletion",
+        deleteFiles: true,
         agentId: "worker-1",
         agentDir,
         workspaceDir: path.join(stateDir, "workspace-worker-1"),
@@ -3226,7 +3272,15 @@ describe("openclaw agent database", () => {
       },
       { env },
     );
-    deletion.finish();
+    runOpenClawStateWriteTransaction(
+      (sharedStateDatabase) =>
+        completeAgentDeletionJournalInDatabase(
+          sharedStateDatabase,
+          deletion.agentId,
+          deletion.operationId,
+        ),
+      { env },
+    );
 
     expect(() =>
       registerOpenClawAgentDatabase({ agentId: "worker-1", path: databasePath, env }),
@@ -3236,7 +3290,9 @@ describe("openclaw agent database", () => {
     ).not.toThrow();
     unregisterOpenClawAgentDatabase({ agentId: "worker-2", path: databasePath, env });
 
-    expect(claimCompletedAgentDeletion("worker-1", deletion.entry.operationId, { env })).toBe(true);
+    expect(claimCompletedAgentDeletionJournal("worker-1", deletion.operationId, { env })).toBe(
+      true,
+    );
     expect(() =>
       registerOpenClawAgentDatabase({ agentId: "worker-1", path: databasePath, env }),
     ).not.toThrow();
@@ -3252,8 +3308,10 @@ describe("openclaw agent database", () => {
       path: databasePath,
       env,
     });
-    const deletion = beginAgentDeletion(
+    const deletion = beginAgentDeletionJournal(
       {
+        operationId: "deletion",
+        deleteFiles: true,
         agentId: "worker-1",
         agentDir: path.dirname(databasePath),
         workspaceDir: path.join(stateDir, "workspace-worker-1"),
@@ -3272,7 +3330,7 @@ describe("openclaw agent database", () => {
       expect(() => assertNoOpenClawAgentDatabaseLeases("worker-1", { env })).not.toThrow();
     } finally {
       releaseOpenClawAgentDatabaseLease(leaseId, { env });
-      deletion.rollback();
+      removeAgentDeletionJournal(deletion.agentId, deletion.operationId, { env });
     }
   });
 

--- a/src/state/openclaw-agent-db.ts
+++ b/src/state/openclaw-agent-db.ts
@@ -41,6 +41,7 @@ import {
   getAgentDeletionDatabaseCleanup,
   registerAgentDeletionDatabaseCleanup,
 } from "./agent-deletion-cleanup.js";
+import { readAgentDeletionJournal } from "./agent-deletion-journal.js";
 import { createOpenClawAgentDatabaseAdmissionOwner } from "./openclaw-agent-db-admission.js";
 import type {
   OpenClawAgentDatabase,
@@ -505,6 +506,7 @@ export function runOpenClawAgentWriteTransaction<T>(
         databaseLabel: database.path,
         ...transactionOptions,
         operationLabel: transactionOptions.operationLabel ?? "agent.write",
+        withCommit: getAgentDeletionDatabaseCleanup(options)?.withCommit,
       },
     ),
   );
@@ -530,6 +532,13 @@ export function getOpenClawAgentDatabaseIfOpen(
 ): OpenClawAgentDatabase | undefined {
   const agentId = normalizeAgentId(options.agentId);
   const pathname = resolveOpenClawAgentSqlitePath({ ...options, agentId });
+  // Incognito skips durable database leases, but still follows the agent deletion fence.
+  if (
+    isIncognitoOpenClawAgentSqlitePath(pathname, options) &&
+    readAgentDeletionJournal(agentId, { env: options.env })
+  ) {
+    throw new Error(`OpenClaw agent database is unavailable while agent ${agentId} is deleted.`);
+  }
   const database = cache.databases.get(pathname);
   if (!database?.db.isOpen) {
     assertAgentDeletionCleanupAliases(options, isSameOpenClawAgentDatabasePath);


### PR DESCRIPTION
Fixes #138676. Builds on #138693.

## What Problem This Solves

Fixes an issue where users deleting an agent could lose access to another agent's shared history, or be unable to restart the Gateway to retry failed cleanup. Superseded Claw removals could continue deleting files, MCP configuration and packages.

## Why This Change Was Made

The deletion journal records recovery state but did not provide a live owner spanning asynchronous cleanup and the physical database commit. This change gives CLI, Gateway and Claw deletion one callback-scoped owner using the existing state lease, journal and cleanup handles. The existing worker heartbeat keeps that lease alive during synchronous SQLite work.

Shared-store ownership is checked before effects and again against Claw's actual commit configuration. Failed native closes can be retried by the next cleanup; incognito handles retire with their agent; startup leaves deleted physical owners fenced so recovery can run. The change preserves current main's async database admission, source-config persistence, monitor quiescence and install-identity checks. It replaces the begin-only API and removes the test-only journal completion wrapper. The material lifecycle repair was discussed and accepted in #138676; schemas, versions and retention policy are unchanged.

## User Impact

Deleting a physical database owner still used by another configured agent now refuses before changing configuration or resources, even when retaining files. Failed purges remain retriable across restart, survivors remain usable after a close retry, and superseded cleanup preserves current files and references. Failed staged-file removal restores its content without overwriting a replacement.

## Evidence

- Reproduced shared-history loss, failed-retry startup, incognito admission and stranded cleanup handles before the corresponding repairs. Regression cases also cover stale continuations and cold/warm physical-commit ownership.
- Current-main integration: 809 focused and sibling tests passed across 27 files; four existing gated cases skipped. Coverage includes CLI/Gateway/Claw/MCP, package/skill removal, async database admission, transaction failure, repository-workspace cleanup and serving monitor quiescence. Adapted takeover tests explicitly expire the old lease and retain exact successor-state checks.
- Canonical build and native proof passed before the final pure selector deduplication: eleven CLI/Gateway cases, two database probes, a 65-second synchronous SQLite transaction with live worker renewal, and real Claw add/remove. Shared histories and archived transcript bytes were preserved; all owned leases, roots and ports were cleaned. The selector extraction passed 58 rerun Claw/MCP/package tests; its rebuilt Claw E2E also passed on the pushed commit (one selected case, eight filtered out), with the complete source/index unchanged and cleanup verified.
- Two managed Codex reviews are clean at P0–P2: the full lifecycle change and the final selector extraction. Typechecks, all changed-file lint and the required guards passed. The first changed gate stopped on the Claw module line cap; deduplicating three selectors fixed it without changing checks or guard placement.
- Net LOC against the integrated base: production +350, tests/support +992, docs +3. Growth establishes the live owner and commit boundary across the three callers and their nested cleanup paths, reusing existing persistence and lease machinery. The earlier lifecycle-map/no-op cleanup is already on main.

Known boundaries: this fences OpenClaw dispatch and safely restores owned staging; it does not add atomic revocation inside filesystem dependency calls. Standalone Claw package-lease pre-dispatch validation and cancellation of late archive-export publication remain named follow-ups. Existing transcript archives remain preserved. Introducing-commit attribution is unknown; historical reproduction and current-source repair evidence are recorded separately.
