### PR TITLE
refactor(slack): share reply segment projection

### DIFF
--- a/extensions/slack/src/monitor/replies.test.ts
+++ b/extensions/slack/src/monitor/replies.test.ts
@@ -83,7 +83,7 @@ function baseParams(overrides?: Record<string, unknown>) {
   return { ...params, replies: params.replies.map(prepareSlackReply) };
 }
 
-function largePortableTablePresentation() {
+function largePortableTablePresentation(rowLength = 110) {
   return {
     blocks: [
       {
@@ -91,7 +91,7 @@ function largePortableTablePresentation() {
         caption: "Large pipeline",
         headers: ["Account"],
         rows: Array.from({ length: 100 }, (_entry, index) => [
-          index === 0 ? "<@U123>" : `account-${String(index)} ${"x".repeat(110)}`,
+          index === 0 ? "<@U123>" : `account-${String(index)} ${"x".repeat(rowLength)}`,
         ]),
       },
     ],
@@ -106,7 +106,7 @@ function requireSendCall(index = 0) {
   return call;
 }
 
-function acceptedSlackSendResult(messageId: string, kind: "media" | "text" = "media") {
+function acceptedSlackSendResult(messageId: string, kind: "media" | "text" | "card" = "media") {
   return {
     messageId,
     channelId: "C123",
@@ -206,45 +206,57 @@ describe("deliverReplies identity passthrough", () => {
     expect(options.identity).toBe(identity);
   });
 
-  it("routes non-native portable tables through complete Slack-safe text delivery", async () => {
-    sendMock.mockResolvedValue({ messageId: "table-ts", channelId: "C123" });
+  it.each([
+    { rowLength: 110, textCalls: 1 },
+    { rowLength: 450, textCalls: 2 },
+  ])(
+    "delivers complete literal table text within the hard limit ($rowLength)",
+    async ({ rowLength, textCalls }) => {
+      sendMock.mockResolvedValue({ messageId: "table-ts", channelId: "C123" });
 
-    await deliverReplies(
-      baseParams({
-        textLimit: 8000,
-        replies: [
-          {
-            presentation: largePortableTablePresentation(),
-            interactive: {
-              blocks: [
-                {
-                  type: "buttons",
-                  buttons: [{ label: "Refresh", value: "refresh" }],
-                },
-              ],
+      await deliverReplies(
+        baseParams({
+          textLimit: 8000,
+          replies: [
+            {
+              presentation: largePortableTablePresentation(rowLength),
+              interactive: {
+                blocks: [
+                  {
+                    type: "buttons",
+                    buttons: [{ label: "Refresh", value: "refresh" }],
+                  },
+                ],
+              },
             },
-          },
-        ],
-      }),
-    );
+          ],
+        }),
+      );
 
-    expect(sendMock).toHaveBeenCalledTimes(2);
-    const [_textTarget, text, textOptions] = requireSendCall(0);
-    expect(text).toContain("- Account: <@U123>");
-    expect(text).toContain("- Account: account-99");
-    expect(text.length).toBeGreaterThan(8000);
-    expect(textOptions.textIsSlackPlainText).toBe(true);
-    expect(textOptions.blocks).toBeUndefined();
+      expect(sendMock).toHaveBeenCalledTimes(textCalls + 1);
+      const textSends = Array.from({ length: textCalls }, (_entry, index) =>
+        requireSendCall(index),
+      );
+      const text = textSends.map((call) => call[1]).join("");
+      expect(text).toContain("- Account: <@U123>");
+      expect(text).toContain("- Account: account-99");
+      expect(text.length).toBeGreaterThan(8000);
+      for (const [_target, chunk, options] of textSends) {
+        expect(chunk.length).toBeLessThanOrEqual(40_000);
+        expect(options.textIsSlackPlainText).toBe(true);
+        expect(options.blocks).toBeUndefined();
+      }
 
-    const [_blockTarget, blockText, blockOptions] = requireSendCall(1);
-    expect(blockText).toBe("");
-    expect(blockOptions.blocks).toEqual([
-      expect.objectContaining({
-        type: "actions",
-        elements: [expect.objectContaining({ type: "button", value: "refresh" })],
-      }),
-    ]);
-  });
+      const [_blockTarget, blockText, blockOptions] = requireSendCall(textCalls);
+      expect(blockText).toBe("");
+      expect(blockOptions.blocks).toEqual([
+        expect.objectContaining({
+          type: "actions",
+          elements: [expect.objectContaining({ type: "button", value: "refresh" })],
+        }),
+      ]);
+    },
+  );
 
   it("delivers media before native chart blocks with the same reply context", async () => {
     messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
@@ -1453,6 +1465,63 @@ describe("deliverReplies message_sent hook", () => {
     });
     expect((error as Error).cause).toBe(failure);
     expect(sendMock).toHaveBeenCalledOnce();
+  });
+
+  it("preserves accepted media and blocks when a later block projection fails", async () => {
+    messageHookRunner.hasHooks.mockImplementation((name: string) => name === "message_sent");
+    const failure = new Error("later block projection failed");
+    const params = baseParams({
+      replies: [
+        {
+          text: "Caption",
+          mediaUrl: "https://example.com/report.png",
+          channelData: {
+            slack: { blocks: Array.from({ length: 50 }, () => ({ type: "divider" })) },
+          },
+          presentation: { title: "Later block", blocks: [] },
+        },
+      ],
+    });
+    const lastSegment = params.replies[0]?.resolveDelivery().segments.at(-1);
+    expect(lastSegment?.kind).toBe("blocks");
+    if (lastSegment?.kind !== "blocks" || !lastSegment.blocks[0]) {
+      throw new Error("expected the later block segment");
+    }
+    Object.defineProperty(lastSegment.blocks[0], "text", {
+      get() {
+        throw failure;
+      },
+    });
+    for (const accepted of [
+      acceptedSlackSendResult("media-1"),
+      acceptedSlackSendResult("card-1", "card"),
+    ]) {
+      sendMock.mockImplementationOnce(async (_target, _text, options) => {
+        await options.onDeliveryResult?.(accepted);
+        return accepted;
+      });
+    }
+
+    const error = await deliverReplies(params).catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      code: "CHANNEL_PARTIAL_DELIVERY",
+      cause: failure,
+      deliveryResult: {
+        messageIds: ["media-1", "card-1"],
+        receipt: { platformMessageIds: ["media-1", "card-1"] },
+        visibleReplySent: true,
+      },
+    });
+    expect(sendMock).toHaveBeenCalledTimes(2);
+    expect(messageHookRunner.runMessageSent).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({
+        content: "Caption\n\nShared a Block Kit message",
+        success: false,
+        error: failure.message,
+      }),
+      expect.anything(),
+    );
   });
 
   it("preserves an undispatched first-send failure without a partial wrapper", async () => {

--- a/extensions/slack/src/monitor/replies.ts
+++ b/extensions/slack/src/monitor/replies.ts
@@ -38,6 +38,7 @@ import {
 } from "../native-data-fallback.js";
 import {
   hasSlackReplyStructuredContent,
+  iterateSlackReplyDeliveryMessages,
   resolveSlackReplyBlockResolution,
   resolveSlackReplyBlocks,
   type PreparedSlackReply,
@@ -280,44 +281,25 @@ export async function deliverReplies(params: {
         delivered ||= mediaDelivery !== "empty";
       }
 
-      for (const segment of segments) {
-        if (segment.kind === "text") {
-          const text = [outsideText, segment.text].filter(Boolean).join("\n\n");
-          outsideText = "";
-          if (!text) {
-            continue;
-          }
-          hookParts.push(text);
-          for (const chunk of chunkSlackTextAtHardLimit(text)) {
+      for (const message of iterateSlackReplyDeliveryMessages({
+        authoredTextPlacement,
+        segments,
+        text: outsideText,
+      })) {
+        hookParts.push(message.text);
+        if (message.textIsSlackPlainText) {
+          for (const chunk of chunkSlackTextAtHardLimit(message.text)) {
             lastResult = await sendReply({ text: chunk, threadTs, textIsSlackPlainText: true });
             delivered = true;
           }
           continue;
         }
-        const baseText = outsideText;
-        outsideText = "";
-        const accessibilityText =
-          buildSlackNativeDataAccessibilityText(baseText, segment.blocks) ||
-          buildSlackBlocksFallbackText(segment.blocks);
-        hookParts.push(accessibilityText);
-        const segmentPlacement = baseText
-          ? "outside-blocks"
-          : authoredTextPlacement === "blocks"
-            ? "blocks"
-            : "none";
         lastResult = await sendReply({
-          text: baseText,
+          ...(message.blocks
+            ? { ...message, text: message.nativeDataFallbackBaseText ?? "" }
+            : { text: message.text }),
           threadTs,
-          blocks: segment.blocks,
-          authoredTextPlacement: segmentPlacement,
-          ...(baseText ? { nativeDataFallbackBaseText: baseText } : {}),
         });
-        delivered = true;
-      }
-
-      if (outsideText && !reply.hasMedia) {
-        hookParts.push(outsideText);
-        lastResult = await sendReply({ text: outsideText, threadTs });
         delivered = true;
       }
     } catch (error) {

--- a/extensions/slack/src/reply-blocks.ts
+++ b/extensions/slack/src/reply-blocks.ts
@@ -86,13 +86,12 @@ export type SlackReplyDeliveryMessage = {
   textIsSlackPlainText?: true;
 };
 
-/** Convert compiled segments into ordered sender calls without re-inferring text placement. */
-export function resolveSlackReplyDeliveryMessages(params: {
+/** Project each segment only when the caller is ready to deliver it. */
+export function* iterateSlackReplyDeliveryMessages(params: {
   authoredTextPlacement: SlackAuthoredTextPlacement;
   segments: readonly SlackReplyBlockSegment[];
   text?: string;
-}): SlackReplyDeliveryMessage[] {
-  const messages: SlackReplyDeliveryMessage[] = [];
+}): Iterable<SlackReplyDeliveryMessage> {
   let outsideText =
     params.authoredTextPlacement === "outside-blocks" ? (params.text?.trim() ?? "") : "";
   for (const segment of params.segments) {
@@ -100,7 +99,7 @@ export function resolveSlackReplyDeliveryMessages(params: {
       const text = [outsideText, segment.text].filter(Boolean).join("\n\n");
       outsideText = "";
       if (text) {
-        messages.push({ text, textIsSlackPlainText: true });
+        yield { text, textIsSlackPlainText: true };
       }
       continue;
     }
@@ -114,17 +113,22 @@ export function resolveSlackReplyDeliveryMessages(params: {
       : params.authoredTextPlacement === "blocks"
         ? "blocks"
         : "none";
-    messages.push({
+    yield {
       text,
       blocks: segment.blocks,
       authoredTextPlacement,
       ...(baseText ? { nativeDataFallbackBaseText: baseText } : {}),
-    });
+    };
   }
   if (outsideText) {
-    messages.push({ text: outsideText, authoredTextPlacement: "outside-blocks" });
+    yield { text: outsideText, authoredTextPlacement: "outside-blocks" };
   }
-  return messages;
+}
+
+export function resolveSlackReplyDeliveryMessages(
+  params: Parameters<typeof iterateSlackReplyDeliveryMessages>[0],
+): SlackReplyDeliveryMessage[] {
+  return Array.from(iterateSlackReplyDeliveryMessages(params));
 }
 
 function resolveSlackReplyText(payload: ReplyPayload, text = payload.text): string {


### PR DESCRIPTION
Closes #141732
Related: #133136

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

This maintainer-requested cleanup removes duplicated segment projection rules from Slack structured reply delivery. Keeping the monitor and other delivery callers aligned currently requires parallel changes to caption placement, accessibility text, and fallback handling.

## Why This Change Was Made

One synchronous iterator now owns segment projection. The existing eager array API collects it for its current callers; the monitor advances it inside its existing error boundary, after media delivery, and sends each message before projecting the next. This preserves accepted receipts if a later projection fails, while keeping accessibility hook text separate from block sender base text and applying outer 40,000-character chunking only to literal fallback text.

The private extraction does not change configuration, defaults, schemas, persistent stores, migrations, public SDK contracts, Gateway handlers, or documented behavior. It retains the rendering and delivery ownership already on main; broader authored-text changes in #133136 are outside this PR.

## User Impact

No intended user-visible change. Slack reply maintainers have one projection implementation to update. Production code shrinks by 14 lines; preservation coverage grows by 69 lines. There is no claimed memory or latency improvement.

## Evidence

- All 59 baseline monitor tests passed before production changed, including later-projection partial receipts and literal tables above the hard limit.
- All 489 final tests across eight monitor, rendering, outbound, action, and preview suites passed.
- The complete selected changed gate and independent P2 review passed; the final review reported no findings.
- The added cases exercise the real prepared-reply owner with mocked transport boundaries. No live Slack send was run.

Required hosted CI remains tied to the published head.
