### PR TITLE
refactor(cli): share local onboarding decision

### DIFF
--- a/src/cli/fresh-install-config.ts
+++ b/src/cli/fresh-install-config.ts
@@ -1,3 +1,5 @@
+import type { ConfigFileSnapshot } from "../config/types.openclaw.js";
+
 const UNCONFIGURED_CONFIG_IGNORED_KEYS = new Set(["$schema", "meta"]);
 
 function isIncompleteWizardConfig(value: unknown): boolean {
@@ -14,5 +16,25 @@ export function isUnconfiguredConfigSource(sourceConfig: Record<string, unknown>
     ([key, value]) =>
       UNCONFIGURED_CONFIG_IGNORED_KEYS.has(key) ||
       (key === "wizard" && isIncompleteWizardConfig(value)),
+  );
+}
+
+export async function shouldStartLocalOnboarding(
+  snapshot: Pick<ConfigFileSnapshot, "exists" | "valid" | "sourceConfig" | "path">,
+): Promise<boolean> {
+  if (!snapshot.exists) {
+    return true;
+  }
+  if (!snapshot.valid || snapshot.sourceConfig.gateway?.mode === "remote") {
+    return false;
+  }
+  if (isUnconfiguredConfigSource(snapshot.sourceConfig)) {
+    return true;
+  }
+  // Inference persists before setup finishes; only its owning receipt can
+  // distinguish interrupted local onboarding from an authored model-only config.
+  const { readLocalOnboardingStateForConfig } = await import("../state/local-onboarding-state.js");
+  return (
+    readLocalOnboardingStateForConfig(snapshot.path, snapshot.sourceConfig)?.status === "pending"
   );
 }

--- a/src/cli/program/register.setup.ts
+++ b/src/cli/program/register.setup.ts
@@ -6,7 +6,7 @@ import { theme } from "../../../packages/terminal-core/src/theme.js";
 import type { RuntimeEnv } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { hasExplicitOptions, listExplicitOptionFlagsExcept } from "../command-options.js";
-import { isUnconfiguredConfigSource } from "../fresh-install-config.js";
+import { shouldStartLocalOnboarding } from "../fresh-install-config.js";
 import {
   registerOnboardAuthOptions,
   registerOnboardGatewayOptions,
@@ -44,27 +44,6 @@ function hasExplicitOnboardingOption(command: Command): boolean {
     const name = option.attributeName();
     return !SYSTEM_AGENT_OPTION_NAMES.has(name) && command.getOptionValueSource(name) === "cli";
   });
-}
-
-async function isConfiguredInstance(): Promise<boolean> {
-  const { readConfigFileSnapshot } = await import("../../config/config.js");
-  const snapshot = await readConfigFileSnapshot();
-  if (!snapshot.exists) {
-    return false;
-  }
-  if (!snapshot.valid || snapshot.sourceConfig.gateway?.mode === "remote") {
-    return true;
-  }
-  if (isUnconfiguredConfigSource(snapshot.sourceConfig)) {
-    return false;
-  }
-  // Inference commits before installation finishes; pending local setup must
-  // resume onboarding instead of opening a chat against an unfinished Gateway.
-  const { readLocalOnboardingStateForConfig } =
-    await import("../../state/local-onboarding-state.js");
-  return (
-    readLocalOnboardingStateForConfig(snapshot.path, snapshot.sourceConfig)?.status !== "pending"
-  );
 }
 
 async function runSystemAgentEntry(
@@ -173,8 +152,11 @@ export function registerSetupCommand(program: Command): void {
       const options = rawOptions as Record<string, unknown>;
       const hasOnboardingFlag = hasExplicitOnboardingOption(commandRuntime);
       const hasSystemAgentRequest = hasExplicitOptions(commandRuntime, ["message", "yes"]);
-      const configured =
-        hasOnboardingFlag || hasSystemAgentRequest ? false : await isConfiguredInstance();
+      let configured = false;
+      if (!hasOnboardingFlag && !hasSystemAgentRequest) {
+        const { readConfigFileSnapshot } = await import("../../config/config.js");
+        configured = !(await shouldStartLocalOnboarding(await readConfigFileSnapshot()));
+      }
       const route = resolveSetupCommandRoute({
         hasOnboardingFlag,
         hasSystemAgentRequest,

--- a/src/cli/run-main.ts
+++ b/src/cli/run-main.ts
@@ -35,7 +35,7 @@ import {
 } from "./command-registration-policy.js";
 import { resolveCliStartupPolicy as resolveCliStartupPolicyForArgv } from "./command-startup-policy.js";
 import { maybeRunCliInContainer, parseCliContainerArgs } from "./container-target.js";
-import { isUnconfiguredConfigSource } from "./fresh-install-config.js";
+import { shouldStartLocalOnboarding } from "./fresh-install-config.js";
 import {
   consumeGatewayFastPathRootOptionToken,
   consumeGatewayRunOptionToken,
@@ -264,35 +264,6 @@ async function tryRunGatewayRunFastPath(
     process.exitCode = error.exitCode;
   }
   return true;
-}
-
-function isUnconfiguredConfigSnapshot(
-  snapshot: Pick<ConfigFileSnapshot, "exists" | "valid" | "sourceConfig">,
-): boolean {
-  if (!snapshot.exists) {
-    return true;
-  }
-  if (!snapshot.valid) {
-    return false;
-  }
-  return isUnconfiguredConfigSource(snapshot.sourceConfig);
-}
-
-async function shouldStartLocalOnboarding(
-  snapshot: Pick<ConfigFileSnapshot, "exists" | "valid" | "sourceConfig" | "path">,
-): Promise<boolean> {
-  if (isUnconfiguredConfigSnapshot(snapshot)) {
-    return true;
-  }
-  if (!snapshot.valid || snapshot.sourceConfig.gateway?.mode === "remote") {
-    return false;
-  }
-  // Inference persists before setup finishes; only its owning receipt can
-  // distinguish interrupted local onboarding from an authored model-only config.
-  const { readLocalOnboardingStateForConfig } = await import("../state/local-onboarding-state.js");
-  return (
-    readLocalOnboardingStateForConfig(snapshot.path, snapshot.sourceConfig)?.status === "pending"
-  );
 }
 
 export async function shouldStartOnboardingForFreshInstall(argv: string[]): Promise<boolean> {


### PR DESCRIPTION
Closes #141734

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

The bare-root CLI and `openclaw setup` duplicate the decision about whether local onboarding is incomplete. Keeping their missing-config, config-shape and pending-receipt checks aligned requires maintaining the same policy in two places. This is a maintainer-requested cleanup of that shared decision, with no intended user-visible behavior change.

## Why This Change Was Made

Both entry points now use one helper over the already captured config snapshot. The raw config-shape helper remains pure for guided setup, and the existing state owner still validates whether a pending receipt belongs to that configuration; its module stays lazily loaded.

Explicit onboarding options and `--message`/`--yes` continue to bypass config reads. Invalid and remote snapshots retain their caller-specific routing, and `--json` alone keeps the existing configured/fresh decision. No schema, default, store, receipt or migration behavior changes.

## User Impact

Fresh and interrupted local setup, configured-system entry, explicit setup options and remote/invalid-config handling keep their current behavior. The change removes 25 production lines across three files, without adding tests, compatibility wrappers or configuration options.

## Evidence

- 304 existing owner/caller/state tests passed across three files and two Vitest projects. Coverage includes missing, empty, metadata-only and wizard-only config; pending, completed and replaced receipts; remote/invalid config; explicit options; and startup routing.
- The complete selected changed-file gate, full `pnpm build`, and final independent P2 review passed on the accepted source.
- Two actual normal-launcher checks used isolated config/state with no provider credentials. Fresh `pnpm openclaw` under a noninteractive terminal exited 1 with the expected interactive-onboarding guidance; `pnpm openclaw setup --help` exited 0 with the normal setup options. Observed owned descendants drained and temporary state was removed.
- All three candidate source hashes remained stable through proof. Their baseline files match captured main `02fe272b105525469adadae586bd56cf7abcb074`; the existing receipt owner is unchanged.

The CLI checks cover routing and help, not completion of interactive onboarding or a live provider flow. No latency or memory improvement is claimed. Release-note context: consolidate the local onboarding decision while preserving existing setup and recovery behavior.
