### PR TITLE
fix(gateway): stale startup logs after plugin reload

### DIFF
--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -23,6 +23,8 @@ agent model: openai/gpt-5.6-sol (thinking=medium, fast=on)
 
 `thinking` comes from the default agent, model params, or the global agent default; when unset it shows `medium`. `fast` comes from the default agent or the model's `fastMode` params.
 
+If a plugin reload supersedes startup plugin loading, the model line, loaded-plugin summary, and channel warnings use the replacement configuration and plugin metadata.
+
 ## File-based logger
 
 - Default rolling log files are under `/tmp/openclaw/` (one file per day), dated by the gateway host's local timezone. The default profile uses `openclaw-YYYY-MM-DD.log`; named profiles use `openclaw-<profile>-YYYY-MM-DD.log` (for example, `openclaw-dev-YYYY-MM-DD.log`). If that directory is unsafe or unwritable (wrong owner, world-writable, a symlink), OpenClaw falls back to a user-scoped `os.tmpdir()/openclaw-<uid>` path instead; on Windows it always uses that OS-tmpdir fallback.

--- a/src/gateway/server-startup-finish.ts
+++ b/src/gateway/server-startup-finish.ts
@@ -261,6 +261,7 @@ export async function finishGatewayStartup(params: {
           pluginRuntimeClaim: startupPluginRuntimeClaim,
           getCurrentPluginRegistry: () => pluginRuntime.registry,
           getCurrentPluginMetadataSnapshot: getPluginMetadataSnapshot,
+          getCurrentActivationSourceConfig: getRuntimeConfigSourceSnapshot,
           ambientEnvTriggers,
           pluginRegistry: pluginRuntime.registry,
           defaultWorkspaceDir,

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -11,6 +11,7 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { writeRestartSentinel } from "../infra/restart-sentinel.js";
 import type { PluginHookGatewayContext, PluginHookHandlerMap } from "../plugins/hook-types.js";
 import { registerPluginHttpRoute } from "../plugins/http-registry.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import type { PluginServicesHandle } from "../plugins/services.js";
@@ -1753,6 +1754,21 @@ describe("startGatewayPostAttachRuntime", () => {
   });
 
   it("adopts a winning plugin generation without publishing stale deferred startup state", async () => {
+    const { logGatewayStartup } =
+      await vi.importActual<typeof import("./server-startup-log.js")>("./server-startup-log.js");
+    const log = { info: vi.fn(), warn: vi.fn() };
+    const startupConfig: OpenClawConfig = {
+      agents: { defaults: { model: "fixture/stale", thinkingDefault: "off" } },
+      channels: { "diagnostic-chat": { enabled: true } },
+    };
+    const winningConfig: OpenClawConfig = {
+      ...startupConfig,
+      agents: { defaults: { model: "fixture/current", thinkingDefault: "high" } },
+      plugins: { entries: { replacement: { enabled: true } } },
+    };
+    const winningMetadata = createPluginMetadataSnapshotFixture({
+      plugins: [{ id: "replacement", channels: ["diagnostic-chat"], origin: "global" }],
+    });
     const startupRegistry = {
       plugins: [{ id: "startup", status: "loaded" }],
       typedHooks: [],
@@ -1800,8 +1816,17 @@ describe("startGatewayPostAttachRuntime", () => {
         unlockStartupMethods,
         pluginRuntimeClaim,
         getCurrentPluginRegistry: () => winningRegistry,
+        getCurrentPluginMetadataSnapshot: () => winningMetadata,
+        getCurrentActivationSourceConfig: () => winningConfig,
+        cfgAtStart: startupConfig,
+        activationSourceConfig: startupConfig,
+        getConfig: () => winningConfig,
+        log,
       }),
-      createPostAttachRuntimeDeps({ startGatewaySidecars: startGatewaySidecarsCandidate }),
+      createPostAttachRuntimeDeps({
+        startGatewaySidecars: startGatewaySidecarsCandidate,
+        logGatewayStartup,
+      }),
     );
     await waitForGatewayTestState(() => expect(loadStartupPlugins).toHaveBeenCalledOnce());
     startupClaimCurrent = false;
@@ -1813,6 +1838,14 @@ describe("startGatewayPostAttachRuntime", () => {
     expect(onPluginServices).not.toHaveBeenCalled();
     expect(unlockStartupMethods).toHaveBeenCalledOnce();
     expect(onSidecarsReady).toHaveBeenCalledOnce();
+    expect
+      .soft(log.info)
+      .toHaveBeenCalledWith(
+        "agent model: fixture/current (thinking=high, fast=off)",
+        expect.any(Object),
+      );
+    expect(log.info).toHaveBeenCalledWith("http server listening (1 plugin: replacement)");
+    expect(log.warn).not.toHaveBeenCalled();
   });
 
   it("waits for sidecars by default before returning", async () => {

--- a/src/gateway/server-startup-post-attach.ts
+++ b/src/gateway/server-startup-post-attach.ts
@@ -1250,6 +1250,7 @@ export async function startGatewayPostAttachRuntime(
     pluginRuntimeClaim?: GatewayPluginRuntimeClaim;
     getCurrentPluginRegistry?: () => PluginRegistry;
     getCurrentPluginMetadataSnapshot?: () => PluginMetadataSnapshot | undefined;
+    getCurrentActivationSourceConfig?: () => OpenClawConfig | null;
     getCronService?: () => PluginServiceCronHost | null | undefined;
     onChannelsStarted?: () => Awaitable<void>;
     onPluginServices?: (pluginServices: PluginServicesHandle | null) => void;
@@ -1303,45 +1304,30 @@ export async function startGatewayPostAttachRuntime(
   }
 
   let pluginRegistry = params.pluginRegistry;
-  let startupPluginsLoaded = false;
-  let startupPluginsLoadPromise: Promise<{
-    pluginRegistry: PluginRegistry;
-    gatewayMethods: string[];
-    retireGatewayRuntimeBindings?: () => void;
-  }> | null = null;
   const loadStartupPluginsIfNeeded = async () => {
     if (params.minimalTestGateway || !params.loadStartupPlugins) {
-      return { pluginRegistry, gatewayMethods: [] };
+      return;
     }
-    if (startupPluginsLoaded) {
-      return { pluginRegistry, gatewayMethods: [] };
+    params.onStartupPluginsLoading?.();
+    const loaded = await measureStartup(params.startupTrace, "plugins.runtime-post-bind", () =>
+      params.loadStartupPlugins!(),
+    );
+    await params.pluginRuntimeClaim?.waitForUnblocked();
+    if (params.isClosing?.() || params.pluginRuntimeClaim?.isCurrent() === false) {
+      // Shutdown only owns attached bindings; retire unadopted results here.
+      loaded.retireGatewayRuntimeBindings?.();
+      pluginRegistry = params.getCurrentPluginRegistry?.() ?? pluginRegistry;
+      return;
     }
-    startupPluginsLoadPromise ??= (async () => {
-      params.onStartupPluginsLoading?.();
-      const loaded = await measureStartup(params.startupTrace, "plugins.runtime-post-bind", () =>
-        params.loadStartupPlugins!(),
-      );
-      await params.pluginRuntimeClaim?.waitForUnblocked();
-      if (params.isClosing?.() || params.pluginRuntimeClaim?.isCurrent() === false) {
-        // Shutdown only owns attached bindings; retire unadopted results here.
-        loaded.retireGatewayRuntimeBindings?.();
-        pluginRegistry = params.getCurrentPluginRegistry?.() ?? pluginRegistry;
-        startupPluginsLoaded = true;
-        return { pluginRegistry, gatewayMethods: [] };
-      }
-      pluginRegistry = loaded.pluginRegistry;
-      startupPluginsLoaded = true;
-      params.startupTrace?.detail("plugins.runtime-post-bind", [
-        [
-          "loadedPluginCount",
-          pluginRegistry.plugins.filter((plugin) => plugin.status === "loaded").length,
-        ],
-        ["gatewayMethodCount", loaded.gatewayMethods.length],
-      ]);
-      await params.onStartupPluginsLoaded?.(loaded);
-      return loaded;
-    })();
-    return await startupPluginsLoadPromise;
+    pluginRegistry = loaded.pluginRegistry;
+    params.startupTrace?.detail("plugins.runtime-post-bind", [
+      [
+        "loadedPluginCount",
+        pluginRegistry.plugins.filter((plugin) => plugin.status === "loaded").length,
+      ],
+      ["gatewayMethodCount", loaded.gatewayMethods.length],
+    ]);
+    await params.onStartupPluginsLoaded?.(loaded);
   };
   let startupLogPromise: Promise<void> | undefined;
   const startupLogSettled = createDeferredCore();
@@ -1360,27 +1346,37 @@ export async function startGatewayPostAttachRuntime(
       return startupLogPromise;
     }
     // Sidecar failure can settle public readiness before this producer finishes.
-    startupLogPromise = params.trackStartupWork(() =>
-      measureStartup(params.startupTrace, "post-attach.log", () =>
+    startupLogPromise = params.trackStartupWork(() => {
+      // A replacement can win while plugins load or startup logging is queued.
+      // Keep model, trust warnings, and loaded ids on that same runtime generation.
+      const startupRuntimeCurrent = params.pluginRuntimeClaim?.isCurrent() !== false;
+      const startupPluginRegistry = startupRuntimeCurrent
+        ? pluginRegistry
+        : (params.getCurrentPluginRegistry?.() ?? pluginRegistry);
+      return measureStartup(params.startupTrace, "post-attach.log", () =>
         runtimeDeps.logGatewayStartup({
-          cfg: params.cfgAtStart,
-          activationSourceConfig: params.activationSourceConfig,
+          cfg: startupRuntimeCurrent ? params.cfgAtStart : params.getConfig(),
+          activationSourceConfig: startupRuntimeCurrent
+            ? params.activationSourceConfig
+            : (params.getCurrentActivationSourceConfig?.() ?? undefined),
           env: process.env,
-          manifestRecords: params.pluginManifestRecords,
+          manifestRecords: startupRuntimeCurrent
+            ? params.pluginManifestRecords
+            : (params.getCurrentPluginMetadataSnapshot?.()?.plugins ?? []),
           ...(params.ambientEnvTriggers ? { ambientEnvTriggers: params.ambientEnvTriggers } : {}),
           bindHost: params.bindHost,
           bindHosts: params.bindHosts,
           port: params.port,
           tlsEnabled: params.tlsEnabled,
-          loadedPluginIds: pluginRegistry.plugins
+          loadedPluginIds: startupPluginRegistry.plugins
             .filter((plugin) => plugin.status === "loaded")
             .map((plugin) => plugin.id),
           log: params.log,
           isNixMode: params.isNixMode,
           startupStartedAt: params.startupStartedAt,
         }),
-      ),
-    );
+      );
+    });
     void startupLogPromise.catch(() => {});
     assignStartupLogOwner(startupLogPromise);
     return startupLogPromise;


### PR DESCRIPTION
Related: #130706, #133633

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Fixes an issue where operators starting the Gateway would see an old model and misleading channel-plugin warnings when a plugin reload superseded startup loading. The listening banner could already name the replacement plugin, making the diagnostics contradict one another.

## Why This Change Was Made

Select the runtime configuration, authored activation source, plugin metadata, and loaded-plugin IDs together when the queued startup logger begins. Remove the single-use loader's unused cached state and return values while preserving its awaited loading and attachment order. The resulting production change removes three lines overall.

## User Impact

Startup model details, the loaded-plugin summary, and channel warnings agree with the replacement plugin runtime when a reload wins during startup.

## Evidence

- The existing deferred-startup supersession test now calls the real `logGatewayStartup`. Before the fix it printed `agent model: fixture/stale (thinking=off, fast=off)` beside `http server listening (1 plugin: replacement)` and incorrectly warned that `diagnostic-chat` had `no-channel-owner`. After the fix it prints `agent model: fixture/current (thinking=high, fast=off)`, retains the replacement-plugin summary, and emits no channel warning.
- On the reviewed candidate based on `59f57f3cc5fa4beaba0d2f08bcc7e5ed3d947b3e`, all **162 tests** passed across `server-startup-post-attach.test.ts`, `server-startup-log.test.ts`, and `server-startup-plugins.test.ts`. The full changed-file gate passed, and fresh P2 review reported no actionable findings after the loader cleanup. Validation used Node 24.20.0 and pnpm 12.3.4.
- This cut applies the identical four-file patch to freshly fetched main `31a823079ed837c43ac0cd85a0c46d9dcbc6750c`. All four preimages and postimages match the reviewed candidate, and the complete patch is byte-identical. Relevant source-getter, post-bind loader, diagnostic-producer, and once-only tracker operations remain unchanged; the two related upstream file changes were inspected outside those operations. Formatting and `git diff --check` passed on this cut.

- [Blacksmith Testbox runtime proof](https://github.com/openclaw/openclaw/actions/runs/34180686943) built exact published head `b063fafaffd2dd0ad816f2421691f3591f585daf` and exercised the compiled CLI/Gateway through eight phases: config validation and plugin indexing, first boot, captured plugin RPC, applied config change, plugin disablement, clean stop, second boot, and final stop. Both boots reported the expected model and plugin count without channel warnings. All nine RPC receipts passed, both Gateway processes stopped gracefully, and all 14 owned process groups/output readers joined without escalation. Source and build manifests remained unchanged; all 139 exported files were hash-verified.

The 162-test and P2 results above remain carried source-bound evidence. The new running-Gateway proof uses isolated synthetic config and a fixture plugin; it verifies ordinary startup, config replacement, disablement and relaunch. The exact supersession race is covered by the real-logger regression, not claimed as reproduced live. Exact published-head CI and native landing remain pending.

