### PR TITLE
refactor(approvals): infer lazy native runtimes

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -310,7 +310,6 @@ extensions/discord/src/activities/register.ts	1
 extensions/discord/src/activities/store.ts	1
 extensions/discord/src/api.ts	3
 extensions/discord/src/approval-handler.runtime.ts	4
-extensions/discord/src/approval-native.ts	1
 extensions/discord/src/audit-core.ts	2
 extensions/discord/src/channel-actions.ts	1
 extensions/discord/src/channel.ts	3
@@ -527,7 +526,6 @@ extensions/googlechat/src/accounts.ts	1
 extensions/googlechat/src/actions.ts	1
 extensions/googlechat/src/approval-card-actions.ts	1
 extensions/googlechat/src/approval-handler.runtime.ts	1
-extensions/googlechat/src/approval-native.ts	1
 extensions/googlechat/src/google-auth.runtime.ts	7
 extensions/googlechat/src/monitor-access.ts	1
 extensions/googlechat/src/monitor-event.ts	2
@@ -543,7 +541,6 @@ extensions/imessage/src/actions-contract.ts	1
 extensions/imessage/src/actions.runtime.ts	2
 extensions/imessage/src/actions.ts	1
 extensions/imessage/src/approval-handler.runtime.ts	2
-extensions/imessage/src/approval-native.ts	1
 extensions/imessage/src/approval-polls.ts	6
 extensions/imessage/src/approval-reaction-poller.ts	1
 extensions/imessage/src/approval-reactions.ts	2
@@ -620,7 +617,7 @@ extensions/logbook/src/store.ts	4
 extensions/matrix/src/actions.ts	3
 extensions/matrix/src/approval-auth.ts	1
 extensions/matrix/src/approval-handler.runtime.ts	8
-extensions/matrix/src/approval-native.ts	7
+extensions/matrix/src/approval-native.ts	6
 extensions/matrix/src/approval-reactions.ts	1
 extensions/matrix/src/auth-precedence.ts	1
 extensions/matrix/src/channel-account-paths.ts	1
@@ -1076,7 +1073,6 @@ extensions/searxng/src/config.ts	1
 extensions/searxng/src/searxng-client.ts	3
 extensions/signal/src/accounts.ts	3
 extensions/signal/src/approval-handler.runtime.ts	2
-extensions/signal/src/approval-native.ts	1
 extensions/signal/src/approval-reactions.ts	1
 extensions/signal/src/channel.ts	2
 extensions/signal/src/client-container.ts	34
@@ -1093,7 +1089,7 @@ extensions/slack/src/actions.ts	9
 extensions/slack/src/approval-actions.ts	1
 extensions/slack/src/approval-handler.runtime.ts	1
 extensions/slack/src/approval-native-gates.ts	1
-extensions/slack/src/approval-native.ts	2
+extensions/slack/src/approval-native.ts	1
 extensions/slack/src/blocks-fallback.ts	1
 extensions/slack/src/blocks-input.ts	2
 extensions/slack/src/blocks-render.ts	1
@@ -1180,7 +1176,6 @@ extensions/telegram/src/account-throttler.ts	4
 extensions/telegram/src/action-runtime.ts	6
 extensions/telegram/src/api-fetch.ts	1
 extensions/telegram/src/approval-handler.runtime.ts	2
-extensions/telegram/src/approval-native.ts	1
 extensions/telegram/src/audit-membership-runtime.ts	1
 extensions/telegram/src/audit.ts	1
 extensions/telegram/src/bot-core.ts	1
@@ -1323,7 +1318,6 @@ extensions/whatsapp/src/account-config.ts	1
 extensions/whatsapp/src/agent-tools-call.ts	1
 extensions/whatsapp/src/agent-tools-login.ts	6
 extensions/whatsapp/src/approval-handler.runtime.ts	1
-extensions/whatsapp/src/approval-native.ts	1
 extensions/whatsapp/src/auth-store.ts	3
 extensions/whatsapp/src/auto-reply/monitor.ts	2
 extensions/whatsapp/src/auto-reply/monitor/inbound-dispatch.ts	4

--- a/extensions/discord/src/approval-native.ts
+++ b/extensions/discord/src/approval-native.ts
@@ -1,6 +1,5 @@
 // Discord plugin module implements approval native behavior.
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import type { ChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { resolveApprovalRequestSessionConversation } from "openclaw/plugin-sdk/approval-native-runtime";
 import type { ChannelApprovalCapability } from "openclaw/plugin-sdk/channel-contract";
 import type { DiscordExecApprovalConfig } from "openclaw/plugin-sdk/config-contracts";
@@ -184,6 +183,7 @@ function createDiscordApprovalCapability(configOverride?: DiscordExecApprovalCon
     resolveApproverDmTargets: createDiscordApproverDmTargetResolver(configOverride),
     notifyOriginWhenDmOnly: true,
     nativeRuntime: createLazyChannelApprovalNativeRuntimeAdapter({
+      capabilityBoundary: true,
       eventKinds: ["exec", "plugin", "system-agent"],
       isConfigured: ({ cfg, accountId }) =>
         isDiscordExecApprovalClientEnabled({ cfg, accountId, configOverride }),
@@ -195,8 +195,7 @@ function createDiscordApprovalCapability(configOverride?: DiscordExecApprovalCon
           configOverride,
         }),
       load: async () =>
-        (await import("./approval-handler.runtime.js"))
-          .discordApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter,
+        (await import("./approval-handler.runtime.js")).discordApprovalNativeRuntime,
     }),
   });
 }

--- a/extensions/googlechat/src/approval-native.ts
+++ b/extensions/googlechat/src/approval-native.ts
@@ -1,9 +1,6 @@
 import { createApproverRestrictedNativeApprovalCapability } from "openclaw/plugin-sdk/approval-delivery-runtime";
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import type {
-  ChannelApprovalKind,
-  ChannelApprovalNativeRuntimeAdapter,
-} from "openclaw/plugin-sdk/approval-handler-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   createChannelApproverDmTargetResolver,
   createChannelNativeOriginTargetResolver,
@@ -236,13 +233,13 @@ export const googleChatApprovalCapability: ChannelApprovalCapability =
     resolveOriginTarget: resolveGoogleChatOriginTarget,
     resolveApproverDmTargets: resolveGoogleChatApproverDmTargets,
     nativeRuntime: createLazyChannelApprovalNativeRuntimeAdapter({
+      capabilityBoundary: true,
       eventKinds: ["exec", "plugin", "system-agent"],
       isConfigured: ({ cfg, accountId }) =>
         isGoogleChatNativeApprovalClientEnabled({ cfg, accountId }),
       shouldHandle: ({ cfg, accountId, approvalKind, request }) =>
         shouldHandleGoogleChatNativeApprovalRequest({ cfg, accountId, approvalKind, request }),
       load: async () =>
-        (await import("./approval-handler.runtime.js"))
-          .googleChatApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter,
+        (await import("./approval-handler.runtime.js")).googleChatApprovalNativeRuntime,
     }),
   });

--- a/extensions/imessage/src/approval-native.ts
+++ b/extensions/imessage/src/approval-native.ts
@@ -1,7 +1,6 @@
 // Imessage plugin module implements approval native behavior.
 import { createApproverRestrictedNativeApprovalCapabilityFromForwardingRoutes } from "openclaw/plugin-sdk/approval-delivery-runtime";
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import type { ChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { shouldSuppressLocalNativeExecApprovalPrompt } from "openclaw/plugin-sdk/approval-native-runtime";
 import { addApprovalReactionHintToText } from "openclaw/plugin-sdk/approval-reaction-runtime";
 import {
@@ -88,6 +87,7 @@ const imessageApproval = createApproverRestrictedNativeApprovalCapabilityFromFor
   },
   createNativeRuntime: (routing) =>
     createLazyChannelApprovalNativeRuntimeAdapter({
+      capabilityBoundary: true,
       eventKinds: ["exec", "plugin", "system-agent"],
       isConfigured: ({ cfg, accountId, context }) =>
         Boolean(context) &&
@@ -100,8 +100,7 @@ const imessageApproval = createApproverRestrictedNativeApprovalCapabilityFromFor
         Boolean(context) &&
         routing.shouldHandleApprovalRequest({ cfg, accountId, approvalKind, request }),
       load: async () =>
-        (await import("./approval-handler.runtime.js"))
-          .imessageApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter,
+        (await import("./approval-handler.runtime.js")).imessageApprovalNativeRuntime,
     }),
 });
 const imessageApprovalRouting = imessageApproval.routing;

--- a/extensions/matrix/src/approval-native.ts
+++ b/extensions/matrix/src/approval-native.ts
@@ -5,10 +5,7 @@ import {
   splitChannelApprovalCapability,
 } from "openclaw/plugin-sdk/approval-delivery-runtime";
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import type {
-  ChannelApprovalKind,
-  ChannelApprovalNativeRuntimeAdapter,
-} from "openclaw/plugin-sdk/approval-handler-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   createChannelNativeOriginTargetResolver,
   resolveApprovalRequestSessionConversation,
@@ -241,6 +238,7 @@ const matrixNativeApprovalCapability = createApproverRestrictedNativeApprovalCap
   resolveApproverDmTargets: resolveMatrixApproverDmTargets,
   notifyOriginWhenDmOnly: true,
   nativeRuntime: createLazyChannelApprovalNativeRuntimeAdapter({
+    capabilityBoundary: true,
     eventKinds: ["exec", "plugin", "system-agent"],
     isConfigured: ({ cfg, accountId }) =>
       isMatrixAnyApprovalClientEnabled({
@@ -254,9 +252,7 @@ const matrixNativeApprovalCapability = createApproverRestrictedNativeApprovalCap
         approvalKind,
         request,
       }),
-    load: async () =>
-      (await import("./approval-handler.runtime.js"))
-        .matrixApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter,
+    load: async () => (await import("./approval-handler.runtime.js")).matrixApprovalNativeRuntime,
   }),
 });
 

--- a/extensions/msteams/src/approval-native.ts
+++ b/extensions/msteams/src/approval-native.ts
@@ -1,10 +1,7 @@
 import { DEFAULT_ACCOUNT_ID, normalizeAccountId } from "openclaw/plugin-sdk/account-id";
 import { createApproverRestrictedNativeApprovalCapability } from "openclaw/plugin-sdk/approval-delivery-runtime";
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import type {
-  ChannelApprovalKind,
-  ChannelApprovalNativeRuntimeAdapter,
-} from "openclaw/plugin-sdk/approval-handler-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   createChannelApproverDmTargetResolver,
   createChannelNativeOriginTargetResolver,
@@ -119,14 +116,14 @@ const resolveMSTeamsOriginTarget = createChannelNativeOriginTargetResolver({
 });
 
 const msTeamsLazyApprovalNativeRuntime = createLazyChannelApprovalNativeRuntimeAdapter({
+  capabilityBoundary: true,
   eventKinds: ["exec", "plugin", "system-agent"],
   isConfigured: ({ cfg, accountId }) => isMSTeamsNativeApprovalClientEnabled({ cfg, accountId }),
   shouldHandle: ({ cfg, accountId, approvalKind, request }) =>
     shouldHandleMSTeamsNativeApprovalRequest({ cfg, accountId, approvalKind, request }),
   load: async () => {
     const { msTeamsApprovalNativeRuntime } = await import("./approval-handler.runtime.js");
-    // SAFETY: Core only returns payloads and entries produced by this same typed runtime.
-    return msTeamsApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter;
+    return msTeamsApprovalNativeRuntime;
   },
 });
 

--- a/extensions/signal/src/approval-native.ts
+++ b/extensions/signal/src/approval-native.ts
@@ -1,7 +1,6 @@
 // Signal plugin module implements approval native behavior.
 import { createApproverRestrictedNativeApprovalCapabilityFromForwardingRoutes } from "openclaw/plugin-sdk/approval-delivery-runtime";
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import type { ChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { shouldSuppressLocalNativeExecApprovalPrompt } from "openclaw/plugin-sdk/approval-native-runtime";
 import { buildApprovalReactionPendingContentForRequest } from "openclaw/plugin-sdk/approval-reaction-runtime";
 import type {
@@ -66,15 +65,14 @@ const signalApproval = createApproverRestrictedNativeApprovalCapabilityFromForwa
   },
   createNativeRuntime: (routing) =>
     createLazyChannelApprovalNativeRuntimeAdapter({
+      capabilityBoundary: true,
       eventKinds: ["exec", "plugin", "system-agent"],
       isConfigured: ({ cfg, accountId, context }) =>
         Boolean(context) && routing.isNativeApprovalHandlerConfigured({ cfg, accountId }),
       shouldHandle: ({ cfg, accountId, context, approvalKind, request }) =>
         Boolean(context) &&
         routing.shouldHandleApprovalRequest({ cfg, accountId, approvalKind, request }),
-      load: async () =>
-        (await import("./approval-handler.runtime.js"))
-          .signalApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter,
+      load: async () => (await import("./approval-handler.runtime.js")).signalApprovalNativeRuntime,
     }),
 });
 const signalApprovalRouting = signalApproval.routing;

--- a/extensions/slack/src/approval-native.ts
+++ b/extensions/slack/src/approval-native.ts
@@ -1,10 +1,7 @@
 // Slack plugin module implements approval native behavior.
 import { createApproverRestrictedNativeApprovalCapability } from "openclaw/plugin-sdk/approval-delivery-runtime";
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import type {
-  ChannelApprovalKind,
-  ChannelApprovalNativeRuntimeAdapter,
-} from "openclaw/plugin-sdk/approval-handler-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   createChannelNativeOriginTargetResolver,
   createNativeApprovalForwardingFallbackSuppressor,
@@ -170,6 +167,7 @@ const baseSlackApprovalCapability = createApproverRestrictedNativeApprovalCapabi
   resolveApproverDmTargets: resolveSlackApproverDmTargets,
   notifyOriginWhenDmOnly: true,
   nativeRuntime: createLazyChannelApprovalNativeRuntimeAdapter({
+    capabilityBoundary: true,
     eventKinds: ["exec", "plugin", "system-agent"],
     isConfigured: ({ cfg, accountId }) =>
       isSlackAnyNativeApprovalClientEnabled({
@@ -183,9 +181,7 @@ const baseSlackApprovalCapability = createApproverRestrictedNativeApprovalCapabi
         approvalKind,
         request,
       }),
-    load: async () =>
-      (await import("./approval-handler.runtime.js"))
-        .slackApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter,
+    load: async () => (await import("./approval-handler.runtime.js")).slackApprovalNativeRuntime,
   }),
 });
 

--- a/extensions/telegram/src/approval-native.ts
+++ b/extensions/telegram/src/approval-native.ts
@@ -1,7 +1,6 @@
 // Telegram plugin module implements approval native behavior.
 import { createApproverRestrictedNativeApprovalCapability } from "openclaw/plugin-sdk/approval-delivery-runtime";
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import type { ChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-runtime";
 import {
   createChannelApproverDmTargetResolver,
   createChannelNativeOriginTargetResolver,
@@ -119,6 +118,7 @@ const telegramNativeApprovalCapability = createApproverRestrictedNativeApprovalC
   resolveApproverDmTargets: resolveTelegramApproverDmTargets,
   notifyOriginWhenDmOnly: true,
   nativeRuntime: createLazyChannelApprovalNativeRuntimeAdapter({
+    capabilityBoundary: true,
     eventKinds: ["exec", "plugin", "system-agent"],
     isConfigured: ({ cfg, accountId }) =>
       isTelegramExecApprovalClientEnabled({
@@ -131,9 +131,7 @@ const telegramNativeApprovalCapability = createApproverRestrictedNativeApprovalC
         accountId,
         request,
       }),
-    load: async () =>
-      (await import("./approval-handler.runtime.js"))
-        .telegramApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter,
+    load: async () => (await import("./approval-handler.runtime.js")).telegramApprovalNativeRuntime,
   }),
 });
 

--- a/extensions/whatsapp/src/approval-native.ts
+++ b/extensions/whatsapp/src/approval-native.ts
@@ -1,10 +1,7 @@
 // Whatsapp plugin module implements approval native behavior.
 import { createApproverRestrictedNativeApprovalCapabilityFromForwardingRoutes } from "openclaw/plugin-sdk/approval-delivery-runtime";
 import { createLazyChannelApprovalNativeRuntimeAdapter } from "openclaw/plugin-sdk/approval-handler-adapter-runtime";
-import type {
-  ChannelApprovalKind,
-  ChannelApprovalNativeRuntimeAdapter,
-} from "openclaw/plugin-sdk/approval-handler-runtime";
+import type { ChannelApprovalKind } from "openclaw/plugin-sdk/approval-handler-runtime";
 import { buildApprovalReactionPromptPayloadForRequest } from "openclaw/plugin-sdk/approval-reaction-runtime";
 import { buildTypedApprovalPresentation } from "openclaw/plugin-sdk/approval-reply-runtime";
 import type {
@@ -63,6 +60,7 @@ const whatsappApproval = createApproverRestrictedNativeApprovalCapabilityFromFor
   },
   createNativeRuntime: (routing) =>
     createLazyChannelApprovalNativeRuntimeAdapter({
+      capabilityBoundary: true,
       eventKinds: ["exec", "plugin", "system-agent"],
       isConfigured: ({ cfg, accountId, context }) =>
         Boolean(context) &&
@@ -75,8 +73,7 @@ const whatsappApproval = createApproverRestrictedNativeApprovalCapabilityFromFor
         Boolean(context) &&
         routing.shouldHandleApprovalRequest({ cfg, accountId, approvalKind, request }),
       load: async () =>
-        (await import("./approval-handler.runtime.js"))
-          .whatsappApprovalNativeRuntime as unknown as ChannelApprovalNativeRuntimeAdapter,
+        (await import("./approval-handler.runtime.js")).whatsappApprovalNativeRuntime,
     }),
 });
 

--- a/src/infra/approval-handler-adapter-runtime.ts
+++ b/src/infra/approval-handler-adapter-runtime.ts
@@ -16,6 +16,7 @@ export function createLazyChannelApprovalNativeRuntimeAdapter<
   TPendingEntry = unknown,
   TBinding = unknown,
   TFinalPayload = unknown,
+  TCapabilityBoundary extends boolean = false,
 >(params: {
   load: () => Promise<
     ChannelApprovalNativeRuntimeAdapter<
@@ -29,15 +30,19 @@ export function createLazyChannelApprovalNativeRuntimeAdapter<
   isConfigured: ChannelApprovalNativeAvailabilityAdapter["isConfigured"];
   shouldHandle: ChannelApprovalNativeAvailabilityAdapter["shouldHandle"];
   eventKinds?: readonly ChannelApprovalKind[];
+  /** Erases payload types only when registering with the non-generic channel capability. */
+  capabilityBoundary?: TCapabilityBoundary;
   /** @deprecated Trusted compatibility override; omit to derive ownership from the payload. */
   resolveApprovalKind?: ChannelApprovalNativeRuntimeAdapter["resolveApprovalKind"];
-}): ChannelApprovalNativeRuntimeAdapter<
-  TPendingPayload,
-  TPreparedTarget,
-  TPendingEntry,
-  TBinding,
-  TFinalPayload
-> {
+}): TCapabilityBoundary extends true
+  ? ChannelApprovalNativeRuntimeAdapter
+  : ChannelApprovalNativeRuntimeAdapter<
+      TPendingPayload,
+      TPreparedTarget,
+      TPendingEntry,
+      TBinding,
+      TFinalPayload
+    > {
   const loadRuntime = createLazyRuntimeModule(params.load);
   let loadedRuntime: ChannelApprovalNativeRuntimeAdapter<
     TPendingPayload,
@@ -136,5 +141,14 @@ export function createLazyChannelApprovalNativeRuntimeAdapter<
         loadedRuntime?.observe?.onDuplicateSkipped?.(runtimeParams),
       onDelivered: (runtimeParams) => loadedRuntime?.observe?.onDelivered?.(runtimeParams),
     },
-  };
+    // `capabilityBoundary` opts into the non-generic registration contract;
+    // otherwise this object preserves every type inferred from `load`.
+    // SAFETY: the conditional return type selects exactly those two representations.
+  } satisfies ChannelApprovalNativeRuntimeAdapter<
+    TPendingPayload,
+    TPreparedTarget,
+    TPendingEntry,
+    TBinding,
+    TFinalPayload
+  > as never; // SAFETY: the conditional return selects typed or capability-boundary form.
 }

--- a/src/infra/approval-handler-runtime.test.ts
+++ b/src/infra/approval-handler-runtime.test.ts
@@ -1,6 +1,7 @@
 // Covers approval handler runtime adapter creation and lazy wiring.
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 import { createDeferred, withTestTimeout } from "../../test/helpers/promise.js";
+import type { ChannelApprovalNativeRuntimeAdapter } from "./approval-handler-runtime-types.js";
 import {
   createChannelApprovalNativeRuntimeAdapter,
   createChannelApprovalHandlerFromCapability,
@@ -390,22 +391,24 @@ describe("createLazyChannelApprovalNativeRuntimeAdapter", () => {
     const explicitIsConfigured = vi.fn().mockReturnValue(true);
     const explicitShouldHandle = vi.fn().mockReturnValue(false);
     const resolveApprovalKind = vi.fn().mockReturnValue("exec");
-    const buildPendingPayload = vi.fn().mockResolvedValue({ text: "pending" });
-    const load = vi.fn().mockResolvedValue({
-      availability: {
-        isConfigured: vi.fn(),
-        shouldHandle: vi.fn(),
-      },
-      presentation: {
-        buildPendingPayload,
-        buildResolvedResult: vi.fn(),
-        buildExpiredResult: vi.fn(),
-      },
-      transport: {
-        prepareTarget: vi.fn(),
-        deliverPending: vi.fn(),
-      },
-    });
+    const buildPendingPayload = vi.fn(async () => ({ text: "pending" }));
+    const load = vi.fn(
+      async (): Promise<ChannelApprovalNativeRuntimeAdapter<{ text: string }>> => ({
+        availability: {
+          isConfigured: vi.fn(),
+          shouldHandle: vi.fn(),
+        },
+        presentation: {
+          buildPendingPayload,
+          buildResolvedResult: vi.fn(),
+          buildExpiredResult: vi.fn(),
+        },
+        transport: {
+          prepareTarget: vi.fn(),
+          deliverPending: vi.fn(),
+        },
+      }),
+    );
     const adapter = createLazyChannelApprovalNativeRuntimeAdapter({
       eventKinds: ["exec"],
       resolveApprovalKind,
@@ -417,6 +420,9 @@ describe("createLazyChannelApprovalNativeRuntimeAdapter", () => {
     const request = { id: "exec:1" } as never;
     const view = {} as never;
 
+    expectTypeOf<
+      Awaited<ReturnType<typeof adapter.presentation.buildPendingPayload>>
+    >().toEqualTypeOf<{ text: string }>();
     expect(adapter.eventKinds).toEqual(["exec"]);
     expect(adapter.resolveApprovalKind?.(request)).toBe("exec");
     expect(resolveApprovalKind).toHaveBeenCalledWith(request);


### PR DESCRIPTION
## What Problem This Solves

Native approval adapters duplicated casts around lazily loaded channel runtimes. The shared adapter contract erased each loader's inferred payload type, forcing every channel to restate types that the loader already proves.

## Why This Change Was Made

The shared approval adapter now preserves all five loader-inferred generic types for ordinary SDK callers. Bundled channels opt into one explicit `capabilityBoundary` erasure only where their typed runtime enters the non-generic `ChannelApprovalCapability` contract.

This removes nine duplicated double casts without changing lazy loading, required/optional hook behavior, or startup imports. Observation remains intentionally limited to already-loaded runtimes.

## User Impact

No user-visible behavior change. Third-party typed SDK consumers retain the shipped generic return contract, while bundled native approval handling remains lazy and channel-owned.

## Evidence

- Exact-head `pnpm check:changed` passed at `e9fce8a2975`, including core and extension production/test typechecks, boundary guards, lint, dead-export scans, and cycle checks.
- All 14 focused approval runtime tests passed.
- A typed consumer assertion verifies that a loader returning `{ text: string }` preserves that payload type when `capabilityBoundary` is omitted.
- Fresh exact-head P0–P2 autoreview was scoped-clean with 0.93 correctness confidence.
- Diff: 70 additions, 79 deletions; net −9 LOC.
