### PR TITLE
fix(cli): reject blank directory --limit

### DIFF
--- a/docs/cli/directory.md
+++ b/docs/cli/directory.md
@@ -17,6 +17,10 @@ Results are meant to be pasted into other commands, especially `openclaw message
 - `--channel <name>`: channel id/alias (required when multiple channels are configured; auto-selected when only one is configured)
 - `--account <id>`: account id (default: channel default)
 - `--json`: output JSON
+- `--limit <n>`: positive integer cap for peers/groups/members listings
+
+`--limit` requires a positive integer. Omit `--limit` for an unbounded listing; explicitly empty
+values are rejected.
 
 Default output renders IDs and names in a table. Empty list results name the channel and account
 that were queried; JSON list output uses an empty array (`[]`). Failures exit nonzero and use the

--- a/docs/cli/directory.md
+++ b/docs/cli/directory.md
@@ -19,8 +19,8 @@ Results are meant to be pasted into other commands, especially `openclaw message
 - `--json`: output JSON
 - `--limit <n>`: positive integer cap for peers/groups/members listings
 
-`--limit` requires a positive integer. Omit `--limit` for an unbounded listing; explicitly empty
-values are rejected.
+`--limit` requires a positive integer. Omit `--limit` to use the selected channel plugin's default.
+Explicitly empty and whitespace-only values are rejected.
 
 Default output renders IDs and names in a table. Empty list results name the channel and account
 that were queried; JSON list output uses an empty array (`[]`). Failures exit nonzero and use the

--- a/src/cli/directory-cli.test.ts
+++ b/src/cli/directory-cli.test.ts
@@ -749,10 +749,14 @@ describe("registerDirectoryCli", () => {
   });
 
   it.each([
-    ["peers list", ["directory", "peers", "list", "--channel", "slack", "--limit", "5x"]],
-    ["groups list", ["directory", "groups", "list", "--channel", "slack", "--limit", "5x"]],
+    ["peers list", "5x", ["directory", "peers", "list", "--channel", "slack", "--limit", "5x"]],
+    ["peers list", "", ["directory", "peers", "list", "--channel", "slack", "--limit", ""]],
+    ["peers list", "   ", ["directory", "peers", "list", "--channel", "slack", "--limit", "   "]],
+    ["groups list", "5x", ["directory", "groups", "list", "--channel", "slack", "--limit", "5x"]],
+    ["groups list", "", ["directory", "groups", "list", "--channel", "slack", "--limit", ""]],
     [
       "group members",
+      "5x",
       [
         "directory",
         "groups",
@@ -765,7 +769,22 @@ describe("registerDirectoryCli", () => {
         "5x",
       ],
     ],
-  ])("rejects partial directory limit for %s", async (_label, args) => {
+    [
+      "group members",
+      "",
+      [
+        "directory",
+        "groups",
+        "members",
+        "--channel",
+        "slack",
+        "--group-id",
+        "group-1",
+        "--limit",
+        "",
+      ],
+    ],
+  ])("rejects invalid directory limit %s %j", async (_label, _limit, args) => {
     mocks.resolveInstallableChannelPlugin.mockResolvedValue({
       cfg: { channels: { slack: {} } },
       channelId: "slack",

--- a/src/cli/directory-cli.ts
+++ b/src/cli/directory-cli.ts
@@ -28,7 +28,7 @@ import { getScopedChannelsCommandSecretTargets } from "./command-secret-targets.
 import { formatHelpExamples } from "./help-format.js";
 
 function parseLimit(value: unknown): number | null {
-  if (value === undefined || value === null || value === "") {
+  if (value === undefined || value === null) {
     return null;
   }
   const parsed = parseStrictPositiveInteger(value);


### PR DESCRIPTION
## What Problem This Solves

An explicit empty `--limit ""` on directory peer, group, or group-member listings was treated as omission. The command could perform a directory lookup using the plugin's default instead of rejecting the invalid input.

## Why This Change Was Made

Remove the empty-string exemption and reuse the existing strict positive-integer parser. Omission still passes `null` to the selected channel plugin, which owns its default limit. The documentation now describes that behavior without promising an unbounded result.

## User Impact

Explicit empty and whitespace-only limits receive `--limit must be a positive integer.` before directory-owned channel selection, installation, configuration changes, secret resolution, and requests. Normal CLI startup is preserved. Scripts that want the plugin default must omit the option.

## Evidence

Real source-CLI processes preserved actual empty and whitespace argv values. Baseline calls reached a trusted synthetic directory plugin with `null` and used its finite default. The candidate rejected those limits in all three commands.

- 31 focused directory tests passed.
- 119 candidate process observations cover human/JSON errors, strict malformed inputs, repeated scalar flags, omitted/positive limits, account/query/group-ID forwarding, table/JSON/empty output, sanitization, and unsupported operations.
- Invalid cases made no directory callbacks or directory-owned configuration changes; full filesystem/network traces and config records are retained privately.
- Omission kept the plugin's finite default, and valid positive values were forwarded unchanged.
- Pinned formatting, scoped lint, source ratchets, docs checks, and fresh independent source review passed.

Fresh independent behavior acceptance exercised 29 additional CLI processes and found no repair defect. Internal source obligations and exact-head CI remain part of the final landing gate. No external channel or production credential was used.

Original implementation by @hugenshen. AI-assisted verification and documentation correction.
