### PR TITLE
fix(update): identify blocked finalizer child processes

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -419,7 +419,8 @@ Both stall diagnostics also include `childProcesses`: up to eight descendant
 processes with `pid`, `parentPid`, and an executable name (`command`). Arguments,
 environment values, and executable paths are omitted. `childProcessesTruncated`
 indicates omitted entries; `childProcessInspection: "unavailable"` means the
-process list could not be read. Inspection runs only after a stall and adds at
+process list could not be read. A null `command` means that process's executable
+name was unavailable. Inspection runs only after a stall and adds at
 most one second to the exit bound. Phase-failure JSON includes the same fields.
 Preserve these diagnostics and the phase receipts when reporting a blocked child.
 Human repair can still wait for a recovery choice or repair agent; its exit grace

--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -415,6 +415,13 @@ remains alive ten seconds after its terminal JSON, stderr and the ledger
 record active resource types and unsettled disposer names, then the process
 exits with its recorded outcome. A retained handle cannot withhold the
 supervisor's result indefinitely.
+Both stall diagnostics also include `childProcesses`: up to eight descendant
+processes with `pid`, `parentPid`, and an executable name (`command`). Arguments,
+environment values, and executable paths are omitted. `childProcessesTruncated`
+indicates omitted entries; `childProcessInspection: "unavailable"` means the
+process list could not be read. Inspection runs only after a stall and adds at
+most one second to the exit bound. Phase-failure JSON includes the same fields.
+Preserve these diagnostics and the phase receipts when reporting a blocked child.
 Human repair can still wait for a recovery choice or repair agent; its exit grace
 starts after recovery finishes. Completion-cache refresh remains best effort
 when its child can be stopped within the phase budget. A phase that exceeds its

--- a/src/cli/update-cli/update-finalization-lifecycle.ts
+++ b/src/cli/update-cli/update-finalization-lifecycle.ts
@@ -15,6 +15,7 @@ import { defaultRuntime } from "../../runtime.js";
 import { watchCliExitAfterOutput } from "../one-shot-exit.js";
 import { hasCliProcessScope } from "../runtime-cleanup-scope.js";
 import { getPendingCliDisposers } from "../runtime-cleanup.js";
+import { inspectUpdateFinalizationChildren } from "./update-finalization-processes.js";
 
 // Local metadata/backup/completion work gets 30s; Doctor gets 2m for migrations,
 // registry installs get 10m, and convergence gets 3m for Doctor + validation.
@@ -135,15 +136,27 @@ export class UpdateFinalizationLifecycle {
         // Do not race and unwind a still-mutating phase. Kill owned subprocesses and
         // exit without yielding, so late awaits cannot write into an OCM rollback.
         try {
-          this.stopChildren();
+          let diagnostics: ReturnType<typeof inspectUpdateFinalizationChildren>;
+          try {
+            // The parent still owns the update; capture names before killing them.
+            // No result or rollback handoff can occur during this bounded synchronous read.
+            diagnostics = inspectUpdateFinalizationChildren();
+          } finally {
+            this.stopChildren();
+          }
           end("failed");
           const error = `Update finalization timed out in ${phase} after ${budgetMs}ms`;
           this.finishLedger(1, error);
           writeSync(2, `${error}\n`);
+          writeSync(
+            2,
+            `[update finalize] Stalled phase children: ${JSON.stringify(diagnostics)}\n`,
+          );
+          this.recordDiagnostic(JSON.stringify(diagnostics));
           if (this.json) {
             writeSync(
               1,
-              `${JSON.stringify({ status: "failed", mode: "finalize", root: this.root, restart: false, stuckPhase: phase, elapsedMs: Math.round(performance.now() - this.startedAt), error, phaseTimings: this.phaseTimings })}\n`,
+              `${JSON.stringify({ status: "failed", mode: "finalize", root: this.root, restart: false, stuckPhase: phase, elapsedMs: Math.round(performance.now() - this.startedAt), error, phaseTimings: this.phaseTimings, ...diagnostics })}\n`,
             );
           }
         } finally {
@@ -179,6 +192,16 @@ export class UpdateFinalizationLifecycle {
     }
   }
 
+  private recordDiagnostic(diagnostic: string): void {
+    if (this.runId) {
+      try {
+        recordUpdateRunDiagnostic(this.runId, diagnostic, this.ledgerOptions);
+      } catch {
+        /* stderr still carries the diagnostic. */
+      }
+    }
+  }
+
   fail(): void {
     clearTimeout(this.timer);
     this.finishLedger(1);
@@ -207,18 +230,13 @@ export class UpdateFinalizationLifecycle {
         const diagnostic = JSON.stringify({
           activeResources: [...new Set(process.getActiveResourcesInfo())].toSorted(),
           unsettledDisposers: getPendingCliDisposers(),
+          ...inspectUpdateFinalizationChildren(),
         });
         writeSync(
           2,
           `[update finalize] Process still alive after terminal output: ${diagnostic}\n`,
         );
-        if (this.runId) {
-          try {
-            recordUpdateRunDiagnostic(this.runId, diagnostic, this.ledgerOptions);
-          } catch {
-            /* stderr still carries the diagnostic. */
-          }
-        }
+        this.recordDiagnostic(diagnostic);
         this.stopChildren();
       });
     // Human repair may still await a recovery choice or agent after reporting failure.

--- a/src/cli/update-cli/update-finalization-processes.test.ts
+++ b/src/cli/update-cli/update-finalization-processes.test.ts
@@ -1,0 +1,66 @@
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { inspectUpdateFinalizationChildren } from "./update-finalization-processes.js";
+
+const mocks = vi.hoisted(() => ({ spawnSync: vi.fn() }));
+vi.mock("node:child_process", () => ({ spawnSync: mocks.spawnSync }));
+
+beforeEach(() => mocks.spawnSync.mockReset());
+afterEach(() => vi.restoreAllMocks());
+
+it("reports nested children without unrelated processes, paths, or the diagnostic subprocess", () => {
+  mocks.spawnSync.mockReturnValue({
+    pid: 900,
+    status: 0,
+    stdout: [
+      "103 102 /private/workspace/blocked-child",
+      `101 ${process.pid} /private/runtime/node`,
+      "102 101 /usr/bin/security",
+      `900 ${process.pid} /bin/ps`,
+      "901 900 /private/query-helper",
+      "800 1 /private/unrelated-process",
+    ].join("\n"),
+  });
+  expect(inspectUpdateFinalizationChildren()).toEqual({
+    childProcessInspection: "complete",
+    childProcessesTruncated: false,
+    childProcesses: [
+      { pid: 101, parentPid: process.pid, command: "node" },
+      { pid: 102, parentPid: 101, command: "security" },
+      { pid: 103, parentPid: 102, command: "blocked-child" },
+    ],
+  });
+  expect(mocks.spawnSync).toHaveBeenCalledWith(expect.any(String), expect.any(Array), {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 1_000,
+    killSignal: "SIGKILL",
+    maxBuffer: 1024 * 1024,
+    windowsHide: true,
+  });
+});
+
+it("bounds child count and command names and reports truncation", () => {
+  mocks.spawnSync.mockReturnValue({
+    pid: 900,
+    status: 0,
+    stdout: Array.from(
+      { length: 10 },
+      (_, index) => `${100 + index} ${process.pid} /private/${"n".repeat(100)}`,
+    ).join("\n"),
+  });
+  const result = inspectUpdateFinalizationChildren();
+  expect(result.childProcessesTruncated).toBe(true);
+  expect(result.childProcesses.map(({ pid }) => pid)).toEqual([
+    100, 101, 102, 103, 104, 105, 106, 107,
+  ]);
+  expect(result.childProcesses.every(({ command }) => command.length === 64)).toBe(true);
+});
+
+it("reports an unavailable process snapshot instead of claiming there are no children", () => {
+  mocks.spawnSync.mockReturnValue({ status: null, error: new Error("timeout") });
+  expect(inspectUpdateFinalizationChildren()).toEqual({
+    childProcessInspection: "unavailable",
+    childProcessesTruncated: false,
+    childProcesses: [],
+  });
+});

--- a/src/cli/update-cli/update-finalization-processes.test.ts
+++ b/src/cli/update-cli/update-finalization-processes.test.ts
@@ -1,13 +1,27 @@
 import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { inspectUpdateFinalizationChildren } from "./update-finalization-processes.js";
 
-const mocks = vi.hoisted(() => ({ spawnSync: vi.fn() }));
+const mocks = vi.hoisted(() => ({ spawnSync: vi.fn(), readlinkSync: vi.fn() }));
 vi.mock("node:child_process", () => ({ spawnSync: mocks.spawnSync }));
+vi.mock("node:fs", () => ({ readlinkSync: mocks.readlinkSync }));
 
-beforeEach(() => mocks.spawnSync.mockReset());
-afterEach(() => vi.restoreAllMocks());
+const originalPlatform = process.platform;
+beforeEach(() => {
+  mocks.spawnSync.mockReset();
+  mocks.readlinkSync.mockReset();
+});
+afterEach(() => {
+  Object.defineProperty(process, "platform", { value: originalPlatform });
+  vi.restoreAllMocks();
+});
 
 it("reports nested children without unrelated processes, paths, or the diagnostic subprocess", () => {
+  const executables = new Map([
+    ["/proc/101/exe", "/private/runtime/node"],
+    ["/proc/102/exe", "/usr/bin/security"],
+    ["/proc/103/exe", "/private/workspace/blocked-child"],
+  ]);
+  mocks.readlinkSync.mockImplementation((file: string) => executables.get(file));
   mocks.spawnSync.mockReturnValue({
     pid: 900,
     status: 0,
@@ -40,6 +54,7 @@ it("reports nested children without unrelated processes, paths, or the diagnosti
 });
 
 it("bounds child count and command names and reports truncation", () => {
+  mocks.readlinkSync.mockReturnValue(`/private/${"n".repeat(100)}`);
   mocks.spawnSync.mockReturnValue({
     pid: 900,
     status: 0,
@@ -53,8 +68,29 @@ it("bounds child count and command names and reports truncation", () => {
   expect(result.childProcesses.map(({ pid }) => pid)).toEqual([
     100, 101, 102, 103, 104, 105, 106, 107,
   ]);
-  expect(result.childProcesses.every(({ command }) => command.length === 64)).toBe(true);
+  expect(result.childProcesses.every(({ command }) => command?.length === 64)).toBe(true);
+  if (process.platform === "linux") {
+    expect(mocks.readlinkSync).toHaveBeenCalledTimes(8);
+  }
 });
+
+it.each([false, true])(
+  "uses Linux executable identity, never a mutable title (unreadable=%s)",
+  (unreadable) => {
+    Object.defineProperty(process, "platform", { value: "linux" });
+    mocks.spawnSync.mockReturnValue({ pid: 900, status: 0, stdout: `101 ${process.pid}\n` });
+    mocks.readlinkSync.mockImplementation(() => {
+      if (unreadable) {
+        throw new Error("process executable unavailable");
+      }
+      return "/private/runtime/node";
+    });
+    expect(inspectUpdateFinalizationChildren().childProcesses).toEqual([
+      { pid: 101, parentPid: process.pid, command: unreadable ? null : "node" },
+    ]);
+    expect(mocks.spawnSync.mock.calls[0]?.[1]).toEqual(["-axo", "pid=,ppid="]);
+  },
+);
 
 it("reports an unavailable process snapshot instead of claiming there are no children", () => {
   mocks.spawnSync.mockReturnValue({ status: null, error: new Error("timeout") });

--- a/src/cli/update-cli/update-finalization-processes.ts
+++ b/src/cli/update-cli/update-finalization-processes.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import { readlinkSync } from "node:fs";
 import path from "node:path";
 
 const MAX_CHILD_PROCESSES = 8;
@@ -6,7 +7,7 @@ const MAX_COMMAND_LENGTH = 64;
 
 /** Inspect names, never argv or environment, only when finalization is already stalled. */
 export function inspectUpdateFinalizationChildren(): {
-  childProcesses: { pid: number; parentPid: number; command: string }[];
+  childProcesses: { pid: number; parentPid: number; command: string | null }[];
   childProcessInspection: "complete" | "unavailable";
   childProcessesTruncated: boolean;
 } {
@@ -28,7 +29,7 @@ export function inspectUpdateFinalizationChildren(): {
         'Get-CimInstance Win32_Process | ForEach-Object { "{0} {1} {2}" -f $_.ProcessId,$_.ParentProcessId,$_.Name }',
       ]
     : // Darwin's comm can include argv copied into a mutable process title.
-      ["-axo", "pid=,ppid=,ucomm="];
+      ["-axo", process.platform === "linux" ? "pid=,ppid=" : "pid=,ppid=,ucomm="];
   const result = spawnSync(inspector, args, {
     encoding: "utf8",
     stdio: ["ignore", "pipe", "ignore"],
@@ -45,12 +46,12 @@ export function inspectUpdateFinalizationChildren(): {
     };
   }
   const processes = result.stdout.split("\n").flatMap((line) => {
-    const match = /^\s*(\d+)\s+(\d+)\s+(.+?)\s*$/u.exec(line);
+    const match = /^\s*(\d+)\s+(\d+)(?:\s+(.+?))?\s*$/u.exec(line);
     if (!match) {
       return [];
     }
-    const [, pid, parentPid, command] = match;
-    if (!pid || !parentPid || !command) {
+    const [, pid, parentPid, command = ""] = match;
+    if (!pid || !parentPid || (process.platform !== "linux" && !command)) {
       return [];
     }
     return [{ pid: Number(pid), parentPid: Number(parentPid), command }];
@@ -72,16 +73,31 @@ export function inspectUpdateFinalizationChildren(): {
       }
       parents.add(child.pid);
       pending.push(child.pid);
-      childProcesses.push({
-        ...child,
-        command: (windows ? path.win32 : path.posix)
-          .basename(child.command)
-          .slice(0, MAX_COMMAND_LENGTH),
-      });
+      childProcesses.push(child);
     }
   }
   return {
-    childProcesses: childProcesses.toSorted((a, b) => a.pid - b.pid).slice(0, MAX_CHILD_PROCESSES),
+    childProcesses: childProcesses
+      .toSorted((a, b) => a.pid - b.pid)
+      .slice(0, MAX_CHILD_PROCESSES)
+      .map((child) => {
+        let executable = child.command;
+        if (process.platform === "linux") {
+          // Linux accounting names are mutable too; query only the bounded selected set.
+          try {
+            executable = readlinkSync(`/proc/${child.pid}/exe`);
+          } catch {
+            return { pid: child.pid, parentPid: child.parentPid, command: null };
+          }
+        }
+        return {
+          pid: child.pid,
+          parentPid: child.parentPid,
+          command: (windows ? path.win32 : path.posix)
+            .basename(executable)
+            .slice(0, MAX_COMMAND_LENGTH),
+        };
+      }),
     childProcessInspection: "complete",
     childProcessesTruncated: childProcesses.length > MAX_CHILD_PROCESSES,
   };

--- a/src/cli/update-cli/update-finalization-processes.ts
+++ b/src/cli/update-cli/update-finalization-processes.ts
@@ -1,0 +1,88 @@
+import { spawnSync } from "node:child_process";
+import path from "node:path";
+
+const MAX_CHILD_PROCESSES = 8;
+const MAX_COMMAND_LENGTH = 64;
+
+/** Inspect names, never argv or environment, only when finalization is already stalled. */
+export function inspectUpdateFinalizationChildren(): {
+  childProcesses: { pid: number; parentPid: number; command: string }[];
+  childProcessInspection: "complete" | "unavailable";
+  childProcessesTruncated: boolean;
+} {
+  const windows = process.platform === "win32";
+  const inspector = windows
+    ? path.win32.join(
+        process.env.SystemRoot ?? "C:\\Windows",
+        "System32",
+        "WindowsPowerShell",
+        "v1.0",
+        "powershell.exe",
+      )
+    : "/bin/ps";
+  const args = windows
+    ? [
+        "-NoProfile",
+        "-NonInteractive",
+        "-Command",
+        'Get-CimInstance Win32_Process | ForEach-Object { "{0} {1} {2}" -f $_.ProcessId,$_.ParentProcessId,$_.Name }',
+      ]
+    : // Darwin's comm can include argv copied into a mutable process title.
+      ["-axo", "pid=,ppid=,ucomm="];
+  const result = spawnSync(inspector, args, {
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "ignore"],
+    timeout: 1_000,
+    killSignal: "SIGKILL",
+    maxBuffer: 1024 * 1024,
+    windowsHide: true,
+  });
+  if (result.error || result.status !== 0 || !result.stdout) {
+    return {
+      childProcesses: [],
+      childProcessInspection: "unavailable",
+      childProcessesTruncated: false,
+    };
+  }
+  const processes = result.stdout.split("\n").flatMap((line) => {
+    const match = /^\s*(\d+)\s+(\d+)\s+(.+?)\s*$/u.exec(line);
+    if (!match) {
+      return [];
+    }
+    const [, pid, parentPid, command] = match;
+    if (!pid || !parentPid || !command) {
+      return [];
+    }
+    return [{ pid: Number(pid), parentPid: Number(parentPid), command }];
+  });
+  const childrenByParent = new Map<number, typeof processes>();
+  for (const child of processes) {
+    const children = childrenByParent.get(child.parentPid) ?? [];
+    children.push(child);
+    childrenByParent.set(child.parentPid, children);
+  }
+  const parents = new Set([process.pid]);
+  const pending = [process.pid];
+  const childProcesses: { pid: number; parentPid: number; command: string }[] = [];
+  // Follow ancestry, including native grandchildren that are outside the command runner.
+  for (const parentPid of pending) {
+    for (const child of childrenByParent.get(parentPid) ?? []) {
+      if (parents.has(child.pid) || child.pid === result.pid) {
+        continue;
+      }
+      parents.add(child.pid);
+      pending.push(child.pid);
+      childProcesses.push({
+        ...child,
+        command: (windows ? path.win32 : path.posix)
+          .basename(child.command)
+          .slice(0, MAX_COMMAND_LENGTH),
+      });
+    }
+  }
+  return {
+    childProcesses: childProcesses.toSorted((a, b) => a.pid - b.pid).slice(0, MAX_CHILD_PROCESSES),
+    childProcessInspection: "complete",
+    childProcessesTruncated: childProcesses.length > MAX_CHILD_PROCESSES,
+  };
+}

--- a/src/cli/update-finalization-output.process.test.ts
+++ b/src/cli/update-finalization-output.process.test.ts
@@ -175,6 +175,14 @@ describe.each(["repair", "finalize"])("update %s process output", (command) => {
         });
         if (scenario === "phase-hang") {
           expect(output.stuckPhase).toBe(blockedPhase);
+          const pid = Number(await fs.readFile(path.join(root, "blocked-child.pid"), "utf8"));
+          expect(output.childProcesses, failure).toContainEqual({
+            pid,
+            parentPid: expect.any(Number),
+            command: expect.stringMatching(/^node(?:\.exe)?$/u),
+          });
+          expect(output.childProcessInspection, failure).toBe("complete");
+          expect(result.stdout + result.stderr, failure).not.toContain("fixture-private-argument");
           const prerequisite = output.phaseTimings.find(
             (entry: { phase: string }) => entry.phase === "targetConfigValidation",
           );
@@ -210,6 +218,19 @@ describe.each(["repair", "finalize"])("update %s process output", (command) => {
       if (scenario === "handle-hang") {
         expect(result.stderr).toContain("activeResources");
         expect(result.stderr).toContain("unsettledDisposers");
+        const pid = Number(await fs.readFile(path.join(root, "blocked-child.pid"), "utf8"));
+        const diagnostic = result.stderr
+          .split("\n")
+          .find((line) => line.includes("Process still alive after terminal output:"));
+        expect(diagnostic, failure).toBeDefined();
+        const payload = JSON.parse(diagnostic!.slice(diagnostic!.indexOf("{")));
+        expect(payload.childProcesses, failure).toContainEqual({
+          pid,
+          parentPid: expect.any(Number),
+          command: expect.stringMatching(/^node(?:\.exe)?$/u),
+        });
+        expect(payload.unsettledDisposers, failure).toContain("fixture-stdin-child");
+        expect(result.stdout + result.stderr, failure).not.toContain("fixture-private-argument");
         expect(readRun()).toMatchObject({
           status: "succeeded",
           steps: expect.arrayContaining([

--- a/src/cli/update-finalization-output.test-support.ts
+++ b/src/cli/update-finalization-output.test-support.ts
@@ -11,6 +11,13 @@ const root = process.env.HOME!;
 await fs.writeFile(path.join(root, "package.json"), JSON.stringify({ name: "openclaw" }));
 const [runtimeProcessEntrypointsJson, scenario, ...args] = process.argv.slice(2);
 const borrowed = scenario?.startsWith("borrowed-");
+const blockedChildSource = `
+const fs = require('node:fs');
+process.title = 'node fixture-private-argument';
+fs.writeFileSync(${JSON.stringify(path.join(root, "blocked-child.pid"))}, String(process.pid));
+process.stdin.resume();
+process.stdin.on('end', () => process.exit(0));
+`;
 if (scenario === "completion-hang") {
   await fs.writeFile(
     path.join(root, "openclaw.mjs"),
@@ -107,7 +114,12 @@ const stubs = new Map<string, string>([
   [
     sourceUrl("./update-cli/update-command-config-snapshot.ts"),
     scenario === "phase-hang"
-      ? 'export const createUpdateConfigSnapshot = async () => { console.error("fixture configSnapshot entered"); setInterval(() => {}, 1000); await new Promise(() => {}); };'
+      ? `import { spawnCommand } from ${JSON.stringify(sourceUrl("../process/exec-spawn.ts"))};
+export const createUpdateConfigSnapshot = async () => {
+  const child = spawnCommand([process.execPath, '-e', ${JSON.stringify(blockedChildSource)}, '--', 'fixture-private-argument'], {stdin:'pipe', stdout:'ignore', stderr:'ignore'});
+  console.error('fixture configSnapshot entered');
+  await child;
+};`
       : scenario === "borrowed-phase"
         ? "export const createUpdateConfigSnapshot = async () => { await new Promise(resolve => setTimeout(resolve, 1_200)); };"
         : "export const createUpdateConfigSnapshot = async () => {};",
@@ -203,7 +215,22 @@ const run = () =>
       registerUpdateCli(program);
       await program.parseAsync(process.argv);
       if (scenario === "handle-hang") {
-        setInterval(() => {}, 1000);
+        const { spawn } = await import("node:child_process");
+        const { runCliDisposer } = await import("./runtime-cleanup.js");
+        const child = spawn(
+          process.execPath,
+          ["-e", blockedChildSource, "--", "fixture-private-argument"],
+          {
+            stdio: ["pipe", "ignore", "ignore"],
+          },
+        );
+        await runCliDisposer(
+          "fixture-stdin-child",
+          () =>
+            new Promise<void>((resolve) => {
+              child.once("exit", () => resolve());
+            }),
+        );
       }
       if (borrowed) {
         if (scenario === "borrowed-output") {


### PR DESCRIPTION
Related: #139485
Follow-up to #140648. This does not close #139485.

## What Problem This Solves

Fixes an issue where operators investigating a stalled update finalizer receive a phase or resource-type diagnostic without the identities of its blocked child processes. A pending Doctor child and its native subprocess can therefore be indistinguishable from completed work retaining a pipe. Reported by @hannesrudolph.

## Why This Change Was Made

Stalled phases and the post-output watchdog now include up to eight live descendant PIDs, parent PIDs, and executable basenames. The snapshot excludes argv, environment values, paths, unrelated processes, and the diagnostic subprocess itself. macOS uses its stable accounting name; Linux queries only PIDs and resolves at most eight `/proc/<pid>/exe` links; unavailable executable names are null. Windows uses bounded noninteractive CIM names. Output indicates truncation or unavailable inspection.

Inspection runs only after a stall, with a one-second SIGKILL deadline and a 1 MiB capture cap. The phase callback remains synchronous and retains update ownership while inspecting; its finally block stops owned children before any terminal result or exit permits supervisor recovery. This preserves the existing fencing/handoff contract while allowing the snapshot to observe children before they disappear. Post-output cleanup retains the already-recorded exit outcome.

## User Impact

Operators can identify the live child or grandchild to inspect when the next release reports a blocked finalizer. Phase-failure JSON, stderr, and the existing diagnostic ledger carry the child identities. Healthy commands perform no extra process inspection. No configuration, dependency, protocol, or schema change is involved.

The original affected-host trigger remains unconfirmed. Controlled fault injection did demonstrate that the released Codex native-version probe can remain pending after its SIGTERM timeout; that probe can execute inside Doctor repair, not only OCM's separate candidate check. Its SIGKILL repair already landed in #140648. This PR supplies the missing process identities rather than claiming a second causal repair.

## Evidence

- Before-fix process regressions reached both real timeout/cleanup outcomes, then failed because child identities were absent. The repaired phase and cleanup regressions passed and verify that a synthetic private argv value is excluded.
- The full focused run passed 20 tests across finalization process output, lifecycle, and bounded process diagnostics; final targeted validation and packed proof are recorded below.
- Official 9.2 and the preceding main candidate both returned terminal results with an EOF-reading fresh Doctor stand-in. Without a controlling terminal, a `/dev/tty` reader failed with ENXIO and both finalizers exited 1.
- Prior isolated runs passed OCM 0.2.36, 0.2.38, and 0.2.41 upgrade variants, Node 24/26 direct-contract variants, post-core marker controls, and external-supervision silent/502 listeners. These are negative controls, not proof of the reporter's macOS 26 environment.

Commit `4a5962d35975a1b0e951c9c4c67b53434d6c9f25` passed `pnpm check:changed`, `git diff --check`, and independent P0–P2 review. The final targeted rerun passed nine cases, including both real-process diagnostics regressions, the bounds/privacy cases, and the existing SIGTERM-resistant Codex probe regression (5,109 ms). The full preceding focused matrix passed 20 tests. Packed macOS proof on `4a5962d35975` identified both a blocked child and grandchild in the phase JSON (exit 1 in 7.12 s), identified a retained cleanup child after success (exit 0), and identified two retained cleanup children after an error (exit 1). Both post-output diagnostics fired about ten seconds after terminal JSON. The matching built Codex owner also terminated the forced SIGTERM-resistant version probe and finalized successfully.

CI run [34177207221](https://github.com/openclaw/openclaw/actions/runs/34177207221) caught a Linux-specific mutable accounting name in the unchanged privacy regressions. Follow-up head `6a1ef1340ba1e3a47a89e055569e8b2923172b3c` corrects the producer by reading executable links, preserves those native regressions, and passes five focused helper tests, `pnpm check:changed`, and independent review. The exact `6a1ef1340ba1` package built and passed tarball integrity checks; its installed build metadata matches the head. Final packed proof repeated the child/grandchild timeout (exit 1 in 7.24 s; `stuckPhase: doctor`, `elapsedMs: 5636`), post-success cleanup diagnostic (exit 0 in 17.98 s), and post-error cleanup diagnostic naming both children/disposers (exit 1 in 17.15 s).

[CI run 34178261495](https://github.com/openclaw/openclaw/actions/runs/34178261495) is green on this exact head (79 successful jobs, 15 intentional skips), including the [formerly failing native Linux shard](https://github.com/openclaw/openclaw/actions/runs/34178261495/job/101912029318). The bounded watcher ended while jobs were pending; the final exact-run snapshot was completed/success. No merge was performed. No merge is requested.
