### PR TITLE
test: skip browser assets in config RPC fixtures

### DIFF
--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -94,7 +94,8 @@ async function startConfigRpcGateway() {
   const port = await getFreePort();
   server = await startGatewayServerCore(port, {
     auth: { mode: "token", token: GATEWAY_TOKEN },
-    controlUiEnabled: true,
+    // These config RPCs do not exercise browser asset serving or preparation.
+    controlUiEnabled: false,
     hotReloadRecovery,
   });
   const connected = createDeferredCore();


### PR DESCRIPTION
## What Problem This Solves

The config RPC fixture starts browser UI asset serving even though every request uses WebSocket config methods. On a clean checkout, the first full run generated 1,973 browser asset files during the test window, adding unrelated frontend preparation.

## Why This Change Was Made

Disable browser serving through the existing server option in this fixture. Keep the full Gateway, fresh per-write config/secrets owners, authenticated clients, startup settlement, and teardown. No assertions, timers, mocks, or production code change.

## User Impact

Faster local and CI config tests without requiring browser assets. Browser serving and non-loopback origin/security policy remain covered by their separate tests.

## Evidence

All 52 existing config cases passed in the same order in four runs:

| Fixture | Vitest duration | First case |
| --- | ---: | ---: |
| Original, clean checkout/UI assets built during run | 76.57s | 15.274s |
| Candidate, existing UI assets | 52.61s | 6.189s |
| Original repeated, existing UI assets | 56.99s | 8.512s |
| Candidate, UI assets absent | 51.66s | 4.723s |

The last candidate run passed with the baseline-generated UI tree temporarily set aside and left it absent. Its 1,973 files were hash-verified and restored afterward. This confirms the fixture no longer needs or generates them.

These are sequential local observations with host/cache variation. Later per-case totals were slower in the candidate even though overall Vitest duration improved; do not equate individual case sums with suite wall time. The first command also included a separate 50.3s runtime prerequisite build, which is excluded from the table and is not claimed as a saving.

The 44 existing browser-root and runtime-security tests passed, including non-loopback origin checks. The changed-file gate and independent P2 review passed. Production LOC is zero; the test adds one explanatory line net.

Final exact-head [CI passed in 5m44s](https://github.com/openclaw/openclaw/actions/runs/34177053838). Its changed-test job ran all 52 cases in the same order: 42.28s Vitest duration, 10.570s first case, and 28.992s summed case time. The changed-scope runner carried an 8-vCPU label versus a 4-vCPU label on main; both logs detected two cores and used two workers. This is additional behavior/performance evidence, not an exclusive whole-main speedup claim. Hosted lint controlled completion.

Subsequent [natural-main CI passed in 7m30s](https://github.com/openclaw/openclaw/actions/runs/34178123801) with all 27 compact Node jobs green. On matching 4-vCPU runner labels with two detected cores, Node24.19.0 and the same dependency-cache key, all 52 config cases retained their names/order: first case **17.817s to 11.155s**, case totals **37.355s to 27.713s**, file Vitest **56.13s to 41.93s**. Setup stayed 21s; other source changes and runner variance prevent exclusive attribution of the full workflow improvement.
