### PR TITLE
feat(cron): show readable timer wake timestamps

### DIFF
--- a/src/cron/service.armtimer-tight-loop.test.ts
+++ b/src/cron/service.armtimer-tight-loop.test.ts
@@ -169,6 +169,19 @@ describe("CronService - armTimer tight loop prevention", () => {
       expect(lengthReads).toBe(2);
       expect(state.timer).toBe(latestTimeoutHandle(timeoutSpy));
       expect(extractTimeoutDelays(timeoutSpy)).toContain(10_000);
+      expect(noopLogger.debug).toHaveBeenLastCalledWith(
+        {
+          nextAt: now + 10_000,
+          nextAtIso: expect.stringMatching(
+            /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-]\d{2}:\d{2}$/,
+          ),
+          delayMs: 10_000,
+          clamped: false,
+        },
+        "cron: timer armed",
+      );
+      const timerLog = noopLogger.debug.mock.lastCall?.[0] as { nextAtIso: string };
+      expect(Date.parse(timerLog.nextAtIso)).toBe(now + 10_000);
     } finally {
       timeoutSpy.mockRestore();
     }

--- a/src/cron/service/timer-scheduler.ts
+++ b/src/cron/service/timer-scheduler.ts
@@ -1,5 +1,6 @@
 import pMap, { pMapSkip } from "p-map";
 import { formatErrorMessage } from "../../infra/errors.js";
+import { formatTimestamp } from "../../logging/timestamps.js";
 import {
   beginGatewayRootWorkAdmissionWhenOpen,
   GatewayDrainingError,
@@ -97,7 +98,12 @@ export function armTimer(state: CronServiceState) {
   // tests that simulate long-running jobs. Runtime behavior is unchanged.
   setCronTimer(state, clampedDelay);
   state.deps.log.debug(
-    { nextAt, delayMs: clampedDelay, clamped: delay > MAX_CRON_TIMER_DELAY_MS },
+    {
+      nextAt,
+      nextAtIso: formatTimestamp(new Date(nextAt), { style: "long" }),
+      delayMs: clampedDelay,
+      clamped: delay > MAX_CRON_TIMER_DELAY_MS,
+    },
     "cron: timer armed",
   );
 }


### PR DESCRIPTION
Closes #58574

## What Problem This Solves

Operators inspecting cron debug logs currently have to convert the numeric `nextAt` timestamp by hand to see when the next scheduled wake is due. This adds a readable timestamp alongside it in the `cron: timer armed` record.

AI-assisted; the implementation, source contracts, and recorded before/after results were reviewed.

## Why This Change Was Made

The timer log now includes `nextAtIso`, using the same full date, milliseconds, and explicit timezone-offset formatter as existing log timestamps. The canonical schedule summary already admits only positive, Date-valid timestamps, so the log can format the selected wake directly.

This is a diagnostic projection at the scheduler's existing logging boundary. Numeric `nextAt`, `delayMs`, and `clamped` remain intact; scheduling, job storage, events, configuration, and log level are unchanged. Reusing the existing formatter avoids a second timestamp convention or an additional dependency.

## User Impact

With debug logging enabled, operators can read the next wake time directly and compare it with other timestamps in the same log. Existing consumers can continue using the numeric timestamp. For example, the recorded UTC product run emitted `nextAt: 1788829989723` with `nextAtIso: "2026-09-08T01:13:09.723+00:00"`.

## Evidence

Exact product head: `f8bb7522bc3a2196f26869bfabd7d69bfa7c4e7f`; parent: `59f57f3cc5fa4beaba0d2f08bcc7e5ed3d947b3e`. Both workflows independently fetched and archived their selected source SHA, verified it against `HEADS.txt`, and installed the frozen dependencies without lifecycle hooks. Proof controls live on separate fork branches, outside the product diff. Both runs used GitHub-hosted Linux and supported Node 24.16.0 with read-only workflow permissions, no persisted checkout credentials, and no injected repository/environment secrets.

- **Before:** [parent run 34174490467](https://github.com/Alix-007/openclaw/actions/runs/34174490467), [artifact 10036794902](https://github.com/Alix-007/openclaw/actions/runs/34174490467/artifacts/10036794902). Actual `cron: timer armed` records had numeric `nextAt` but no readable companion in both UTC and Asia/Shanghai. The workflow passed because it confirmed this expected baseline gap and all normal controls; it does not claim feature acceptance on the parent.
- **After:** [product run 34175267591](https://github.com/Alix-007/openclaw/actions/runs/34175267591), [artifact 10037045096](https://github.com/Alix-007/openclaw/actions/runs/34175267591/artifacts/10037045096). `HEADS.txt` and `SUMMARY.txt` identify the exact product SHA above. All four real timer records—near/far future in UTC/Asia-Shanghai—contained a readable timestamp whose parsed instant equaled numeric `nextAt`. UTC used `+00:00`; Shanghai used `+08:00`. Near timers remained unclamped; far timers retained their 60-second recheck clamp.

The behavior proof calls the real `CronService.start/add/remove` entry points with an isolated state directory, routes logs through the production child logger and file transport, flushes the transport, and reads the emitted JSONL file. A separate service instance reads each persisted job. Controls verify that an empty scheduler produces no next-wake record, no future job executes during observation, and the readable projection does not appear in persisted jobs or lifecycle events. This is real service/file-transport proof, not a mocked logger assertion; it does not exercise a packaged CLI or a running Gateway process.

Exact behavior command (same control script for both heads; `EXPECTATION_MODE` selects the expected observation):

```sh
EXPECTATION_MODE=product bash .github/pr-proof/run-cron-timestamp-parent-red.sh "$RUNNER_TEMP/product" f8bb7522bc3a2196f26869bfabd7d69bfa7c4e7f "$RUNNER_TEMP/cron-timestamp"
```

Readback artifacts: `UTC/OBSERVATIONS.json`, `Asia-Shanghai/OBSERVATIONS.json`, and each zone's `runtime.log`. The control removes its future jobs and stops both service instances; the runner discards its isolated state after the job. No live channels, accounts, or operator data were used. No protocol, schema, security, or upgrade behavior changes.

The product run also passed **18 focused tests across three files** (two Vitest shards):

```sh
node scripts/run-vitest.mjs run src/cron/service.armtimer-tight-loop.test.ts src/cron/service.timer-maintenance.test.ts src/logging/timestamps.test.ts
```

The extended timer test checks the existing numeric fields, offset-bearing timestamp shape, and instant equality. Existing maintenance-record assertions remain unchanged. `git diff --check` passed. Fresh structured autoreview of this exact two-file patch used **gpt-5.6-sol, low reasoning, P0–P3 coverage** and returned no findings; its TruffleHog scan was clean. Broader repository checks and upstream PR CI are not claimed by this focused proof.

Scope/competition check: the issue's five linked attempts (#59248, #58703, #58908, #58907, #58906) are closed, and current all-state searches found no open implementation of this timer-log projection. No human product rejection was found. The bot's historical reference to an unnamed external-fork proposal could not be corroborated; this is not a claim that every external fork was exhaustively searched. The change stays within the issue's additive, log-only request.

LOC: production **+7/−1, net +6**; tests **+13/−0**. Production growth is the requested readable diagnostic field and import, including expanded object formatting. No new helper, runtime state, or compatibility path is introduced.
