### PR TITLE
fix(windows): stop Gateway task descendants and log child failures

### DIFF
--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -137,6 +137,12 @@ through a generated `gateway.vbs` WScript wrapper, so the background Gateway
 does not open a visible console window. If task creation is denied, OpenClaw
 falls back to a per-user Startup-folder login item.
 
+The hidden launcher owns the supervised Gateway process tree. Ending the task
+with `schtasks /end /tn "OpenClaw Gateway"`, `Stop-ScheduledTask`, or Task
+Scheduler's **End** action terminates the Gateway and its descendants. After
+updating an older installation, run `openclaw gateway install --force` to
+regenerate the launcher if the update did not refresh it.
+
 Gateway status and Doctor read the Scheduled Task's numeric current state, independently of the Windows display language or console code page. A previous task exit result does not prove whether it is running now. Queued or unknown tasks do not count as safely stopped for Doctor maintenance. Stop a queued task through its service owner; if inspection is inaccessible, restore Task Scheduler inspection permissions before retrying.
 
 Gateway startup creates private SQLite staging directories through Windows APIs,

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -275,6 +275,15 @@ Notes:
 
 ## Troubleshooting
 
+### The Scheduled Task stops before the Gateway is ready
+
+Run `openclaw gateway status --json`, then inspect the local [Gateway log](/gateway/logging).
+Entries from `gateway/task-supervisor` record the child exit code, signal, and
+the last 8,192 characters of stderr, including failures before Gateway logging
+starts. Child stdout is discarded. A failed child or supervisor exits nonzero
+so Task Scheduler can apply its failure policy; an intentional clean stop still
+exits zero. A successful task result alone does not prove the Gateway is healthy.
+
 ### The tray icon does not appear
 
 Check Task Manager for `OpenClaw.Tray.WinUI.exe`. If it is running, open the

--- a/docs/platforms/windows.md
+++ b/docs/platforms/windows.md
@@ -286,9 +286,14 @@ Notes:
 Run `openclaw gateway status --json`, then inspect the local [Gateway log](/gateway/logging).
 Entries from `gateway/task-supervisor` record the child exit code, signal, and
 the last 8,192 characters of stderr, including failures before Gateway logging
-starts. Child stdout is discarded. A failed child or supervisor exits nonzero
-so Task Scheduler can apply its failure policy; an intentional clean stop still
-exits zero. A successful task result alone does not prove the Gateway is healthy.
+starts. Child stdout is discarded. A failed child or supervisor exits nonzero;
+an intentional clean stop still exits zero. A successful task result alone does
+not prove the Gateway is healthy.
+
+Task Scheduler's [`RestartOnFailure` policy](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsch/2ff4aa5a-7bc4-449f-bbb1-27475645867f)
+retries failed start conditions or action launches. Do not rely on it to restart
+a Gateway that launches successfully and then exits with an error, such as an
+occupied port. Fix the logged cause, then run `openclaw gateway start`.
 
 ### The tray icon does not appear
 

--- a/src/cli/gateway-cli/task-supervisor.test.ts
+++ b/src/cli/gateway-cli/task-supervisor.test.ts
@@ -1,10 +1,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { SpawnInput } from "../../process/supervisor/types.js";
 
-const { spawn, log, flushLogger } = vi.hoisted(() => ({
+const { spawn, log, flushLogger, bindWindowsTaskLauncher } = vi.hoisted(() => ({
   spawn: vi.fn(),
   log: { info: vi.fn(), error: vi.fn() },
   flushLogger: vi.fn(async () => {}),
+  bindWindowsTaskLauncher: vi.fn(),
+}));
+
+vi.mock("koffi", () => ({ default: {} }));
+vi.mock("../../process/supervisor/service-child-windows-task-launcher.js", () => ({
+  bindWindowsTaskLauncher,
 }));
 
 vi.mock("../../logging/subsystem.js", () => ({
@@ -21,6 +27,7 @@ describe("Windows Gateway task supervisor", () => {
   const argv = [...process.argv];
   const execArgv = [...process.execArgv];
   const exitCode = process.exitCode;
+  const launcherMarker = process.env.OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER;
 
   beforeEach(() => {
     process.argv = [
@@ -31,6 +38,7 @@ describe("Windows Gateway task supervisor", () => {
     ];
     process.execArgv = ["--import", "tsx"];
     process.exitCode = undefined;
+    delete process.env.OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER;
     vi.spyOn(process, "platform", "get").mockReturnValue("win32");
   });
 
@@ -38,12 +46,54 @@ describe("Windows Gateway task supervisor", () => {
     process.argv = [...argv];
     process.execArgv = [...execArgv];
     process.exitCode = exitCode;
+    if (launcherMarker === undefined) {
+      delete process.env.OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER;
+    } else {
+      process.env.OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER = launcherMarker;
+    }
     vi.restoreAllMocks();
     vi.clearAllMocks();
     spawn.mockReset();
+    bindWindowsTaskLauncher.mockReset();
+  });
+
+  it("binds launcher ownership before admitting a child and consumes the launcher marker", async () => {
+    process.env.OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER = "wscript";
+    bindWindowsTaskLauncher.mockImplementation(() => {
+      expect(spawn).not.toHaveBeenCalled();
+      expect(process.env.OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER).toBeUndefined();
+    });
+    spawn.mockImplementation(async () => {
+      expect(bindWindowsTaskLauncher).toHaveBeenCalledOnce();
+      expect(process.env.OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER).toBeUndefined();
+      return { cancel: vi.fn(), wait: async () => ({ exitCode: 0, exitSignal: null }) };
+    });
+    const { runWindowsGatewayTaskSupervisor } = await import("./task-supervisor.js");
+    await runWindowsGatewayTaskSupervisor();
+    expect(spawn).toHaveBeenCalledOnce();
+    expect(bindWindowsTaskLauncher).toHaveBeenCalledOnce();
+  });
+
+  it("does not admit a Gateway after its task launcher has exited", async () => {
+    process.env.OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER = "wscript";
+    spawn.mockResolvedValue({
+      cancel: vi.fn(),
+      wait: async () => ({ exitCode: 0, exitSignal: null }),
+    });
+    bindWindowsTaskLauncher.mockImplementation(() => {
+      throw new Error("Windows task WScript launcher is no longer live");
+    });
+    const { runWindowsGatewayTaskSupervisor } = await import("./task-supervisor.js");
+    await runWindowsGatewayTaskSupervisor();
+    expect(spawn).not.toHaveBeenCalled();
+    expect(process.exitCode).toBe(1);
+    expect(JSON.stringify(log.error.mock.calls)).toContain("WScript launcher is no longer live");
+    expect(process.env.OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER).toBeUndefined();
   });
 
   it("runs the Gateway child through the anchored Job Object and waits for its tree", async () => {
+    // A direct Startup fallback inherits the install preference, without a live WScript owner.
+    process.env.OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER = "1";
     const waitForExtinction = vi.fn(async () => {});
     spawn.mockResolvedValue({
       cancel: vi.fn(),
@@ -53,6 +103,7 @@ describe("Windows Gateway task supervisor", () => {
     const { runWindowsGatewayTaskSupervisor } = await import("./task-supervisor.js");
     await runWindowsGatewayTaskSupervisor();
 
+    expect(bindWindowsTaskLauncher).not.toHaveBeenCalled();
     expect(spawn).toHaveBeenCalledWith(
       expect.objectContaining({
         mode: "anchored-shell",

--- a/src/cli/gateway-cli/task-supervisor.test.ts
+++ b/src/cli/gateway-cli/task-supervisor.test.ts
@@ -1,6 +1,17 @@
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SpawnInput } from "../../process/supervisor/types.js";
 
-const spawn = vi.hoisted(() => vi.fn());
+const { spawn, log, flushLogger } = vi.hoisted(() => ({
+  spawn: vi.fn(),
+  log: { info: vi.fn(), error: vi.fn() },
+  flushLogger: vi.fn(async () => {}),
+}));
+
+vi.mock("../../logging/subsystem.js", () => ({
+  createSubsystemLogger: () => log,
+}));
+
+vi.mock("../../logging/logger.js", () => ({ flushLogger }));
 
 vi.mock("../../process/supervisor/index.js", () => ({
   getProcessSupervisor: () => ({ spawn }),
@@ -9,11 +20,26 @@ vi.mock("../../process/supervisor/index.js", () => ({
 describe("Windows Gateway task supervisor", () => {
   const argv = [...process.argv];
   const execArgv = [...process.execArgv];
+  const exitCode = process.exitCode;
+
+  beforeEach(() => {
+    process.argv = [
+      process.execPath,
+      "C:\\OpenClaw\\dist\\entry.js",
+      "gateway",
+      "--task-supervisor",
+    ];
+    process.execArgv = ["--import", "tsx"];
+    process.exitCode = undefined;
+    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
+  });
 
   afterEach(() => {
     process.argv = [...argv];
     process.execArgv = [...execArgv];
+    process.exitCode = exitCode;
     vi.restoreAllMocks();
+    vi.clearAllMocks();
     spawn.mockReset();
   });
 
@@ -24,15 +50,6 @@ describe("Windows Gateway task supervisor", () => {
       wait: async () => ({ exitCode: 0, exitSignal: null }),
       waitForExtinction,
     });
-    process.argv = [
-      process.execPath,
-      "C:\\OpenClaw\\dist\\entry.js",
-      "gateway",
-      "--task-supervisor",
-    ];
-    process.execArgv = ["--import", "tsx"];
-    vi.spyOn(process, "platform", "get").mockReturnValue("win32");
-
     const { runWindowsGatewayTaskSupervisor } = await import("./task-supervisor.js");
     await runWindowsGatewayTaskSupervisor();
 
@@ -48,5 +65,101 @@ describe("Windows Gateway task supervisor", () => {
     expect(spawn.mock.calls[0]?.[0].command).toContain("--import");
     expect(spawn.mock.calls[0]?.[0].command).toContain("tsx");
     expect(waitForExtinction).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    { exitCode: 23, exitSignal: null, reason: "exit", expectedCode: 23 },
+    { exitCode: null, exitSignal: "SIGTERM", reason: "signal", expectedCode: 1 },
+    { exitCode: 0, exitSignal: null, reason: "exit", expectedCode: 0 },
+  ])("records child result $exitCode/$exitSignal and preserves its task result", async (result) => {
+    const stderr = "Gateway failed to bind its configured port\n";
+    spawn.mockImplementation(async (input: SpawnInput) => {
+      input.onStderr?.(stderr);
+      return {
+        cancel: vi.fn(),
+        wait: async () => result,
+        waitForExtinction: async () => {},
+      };
+    });
+
+    const { runWindowsGatewayTaskSupervisor } = await import("./task-supervisor.js");
+    await runWindowsGatewayTaskSupervisor();
+
+    expect(process.exitCode ?? 0).toBe(result.expectedCode);
+    const diagnostic = result.exitCode === 0 ? log.info : log.error;
+    expect(diagnostic).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        exitCode: result.exitCode,
+        exitSignal: result.exitSignal,
+        reason: result.reason,
+        stderr,
+      }),
+    );
+    expect(flushLogger).toHaveBeenCalledOnce();
+  });
+
+  it("retains only a bounded stderr tail and discards stdout", async () => {
+    const lastReason = "final startup failure";
+    spawn.mockImplementation(async (input: SpawnInput) => {
+      expect(input.captureOutput).toBe(false);
+      input.onStdout?.("unretained stdout");
+      input.onStderr?.("old stderr diagnostic\n");
+      input.onStderr?.("x".repeat(8192));
+      input.onStderr?.(lastReason);
+      return {
+        cancel: vi.fn(),
+        wait: async () => ({ exitCode: 1, exitSignal: null, reason: "exit" }),
+        waitForExtinction: async () => {},
+      };
+    });
+
+    const { runWindowsGatewayTaskSupervisor } = await import("./task-supervisor.js");
+    await runWindowsGatewayTaskSupervisor();
+
+    expect(log.error).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ stderr: expect.stringContaining(lastReason) }),
+    );
+    const stderr: string = log.error.mock.calls[0]?.[1].stderr;
+    expect(stderr.length).toBeLessThanOrEqual(8192);
+    expect(stderr).not.toContain("old stderr diagnostic");
+    expect(JSON.stringify(log.error.mock.calls)).not.toContain("unretained stdout");
+  });
+
+  it("records a spawn failure and fails the task", async () => {
+    spawn.mockRejectedValue(new Error("synthetic Job Object spawn failure"));
+
+    const { runWindowsGatewayTaskSupervisor } = await import("./task-supervisor.js");
+    await runWindowsGatewayTaskSupervisor();
+
+    expect(process.exitCode).toBe(1);
+    expect(JSON.stringify(log.error.mock.calls)).toContain("synthetic Job Object spawn failure");
+    expect(flushLogger).toHaveBeenCalledOnce();
+  });
+
+  it("preserves the child diagnostic when its tree cleanup fails", async () => {
+    const stderr = "synthetic child startup failure";
+    spawn.mockImplementation(async (input: SpawnInput) => {
+      input.onStderr?.(stderr);
+      return {
+        cancel: vi.fn(),
+        wait: async () => ({ exitCode: 23, exitSignal: null, reason: "exit" }),
+        waitForExtinction: async () => {
+          expect(log.error).toHaveBeenCalledWith(
+            expect.any(String),
+            expect.objectContaining({ exitCode: 23, stderr }),
+          );
+          throw new Error("synthetic Job Object cleanup failure");
+        },
+      };
+    });
+
+    const { runWindowsGatewayTaskSupervisor } = await import("./task-supervisor.js");
+    await runWindowsGatewayTaskSupervisor();
+
+    expect(process.exitCode).toBe(1);
+    expect(JSON.stringify(log.error.mock.calls)).toContain("synthetic Job Object cleanup failure");
+    expect(flushLogger).toHaveBeenCalledOnce();
   });
 });

--- a/src/cli/gateway-cli/task-supervisor.ts
+++ b/src/cli/gateway-cli/task-supervisor.ts
@@ -1,6 +1,10 @@
 // Windows Task Scheduler bridge: retain the Job Object owner until the Gateway exits.
 import { quoteCmdScriptArg } from "../../daemon/cmd-argv.js";
-import { WINDOWS_TASK_SUPERVISOR_FLAG } from "../../daemon/windows-task-supervisor-contract.js";
+import {
+  WINDOWS_TASK_LAUNCHER_ACTIVE,
+  WINDOWS_TASK_LAUNCHER_ENV,
+  WINDOWS_TASK_SUPERVISOR_FLAG,
+} from "../../daemon/windows-task-supervisor-contract.js";
 import { flushLogger } from "../../logging/logger.js";
 import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getProcessSupervisor } from "../../process/supervisor/index.js";
@@ -20,8 +24,8 @@ function renderGatewayTaskCommand(): string {
 
 /**
  * Runs the real Gateway inside the Windows Job Object owned by ProcessSupervisor.
- * The Task Scheduler action waits on this process; parent loss closes the Job and
- * its entire child tree, so a detached launcher cannot leave a stale Gateway behind.
+ * The hidden task launcher owns an outer Job containing this supervisor. The
+ * command anchor owns the inner Job used for cancellation and extinction joins.
  */
 export async function runWindowsGatewayTaskSupervisor(): Promise<void> {
   if (process.platform !== "win32") {
@@ -29,6 +33,15 @@ export async function runWindowsGatewayTaskSupervisor(): Promise<void> {
   }
   let stderr = "";
   try {
+    const launcher = process.env[WINDOWS_TASK_LAUNCHER_ENV];
+    delete process.env[WINDOWS_TASK_LAUNCHER_ENV];
+    if (launcher === WINDOWS_TASK_LAUNCHER_ACTIVE) {
+      const [{ default: koffi }, { bindWindowsTaskLauncher }] = await Promise.all([
+        import("koffi"),
+        import("../../process/supervisor/service-child-windows-task-launcher.js"),
+      ]);
+      bindWindowsTaskLauncher(koffi);
+    }
     const managed = await getProcessSupervisor().spawn({
       mode: "anchored-shell",
       command: renderGatewayTaskCommand(),

--- a/src/cli/gateway-cli/task-supervisor.ts
+++ b/src/cli/gateway-cli/task-supervisor.ts
@@ -1,7 +1,12 @@
 // Windows Task Scheduler bridge: retain the Job Object owner until the Gateway exits.
 import { quoteCmdScriptArg } from "../../daemon/cmd-argv.js";
 import { WINDOWS_TASK_SUPERVISOR_FLAG } from "../../daemon/windows-task-supervisor-contract.js";
+import { flushLogger } from "../../logging/logger.js";
+import { createSubsystemLogger } from "../../logging/subsystem.js";
 import { getProcessSupervisor } from "../../process/supervisor/index.js";
+
+const log = createSubsystemLogger("gateway/task-supervisor");
+const STDERR_TAIL_CHARS = 8192;
 
 function renderGatewayTaskCommand(): string {
   const childArgs = [...process.execArgv, ...process.argv.slice(1)].filter(
@@ -22,23 +27,44 @@ export async function runWindowsGatewayTaskSupervisor(): Promise<void> {
   if (process.platform !== "win32") {
     throw new Error("--task-supervisor is only available to the Windows Gateway service");
   }
-  const managed = await getProcessSupervisor().spawn({
-    mode: "anchored-shell",
-    command: renderGatewayTaskCommand(),
-    scopeKey: `gateway-task-supervisor:${process.pid}`,
-    captureOutput: false,
-  });
-  const cancel = () => managed.cancel("signal");
-  process.once("SIGINT", cancel);
-  process.once("SIGTERM", cancel);
+  let stderr = "";
   try {
-    const result = await managed.wait();
-    await managed.waitForExtinction?.();
-    if (result.exitCode !== 0) {
-      process.exitCode = result.exitCode ?? 1;
+    const managed = await getProcessSupervisor().spawn({
+      mode: "anchored-shell",
+      command: renderGatewayTaskCommand(),
+      scopeKey: `gateway-task-supervisor:${process.pid}`,
+      captureOutput: false,
+      onStderr: (chunk) => {
+        stderr = (stderr + chunk).slice(-STDERR_TAIL_CHARS);
+      },
+    });
+    const cancel = () => managed.cancel("signal");
+    process.once("SIGINT", cancel);
+    process.once("SIGTERM", cancel);
+    try {
+      const result = await managed.wait();
+      // Persist the child failure before joining cleanup, which can fail independently.
+      const diagnostic = {
+        exitCode: result.exitCode,
+        exitSignal: result.exitSignal,
+        reason: result.reason,
+        stderr,
+      };
+      if (result.exitCode === 0) {
+        log.info("Gateway child exited", diagnostic);
+      } else {
+        process.exitCode = result.exitCode ?? 1;
+        log.error("Gateway child failed", diagnostic);
+      }
+      await managed.waitForExtinction?.();
+    } finally {
+      process.removeListener("SIGINT", cancel);
+      process.removeListener("SIGTERM", cancel);
     }
+  } catch (error) {
+    process.exitCode = 1;
+    log.error(`Gateway task supervisor failed: ${String(error)}`, { stderr });
   } finally {
-    process.removeListener("SIGINT", cancel);
-    process.removeListener("SIGTERM", cancel);
+    await flushLogger();
   }
 }

--- a/src/daemon/schtasks-install.ts
+++ b/src/daemon/schtasks-install.ts
@@ -139,7 +139,11 @@ async function writeScheduledTaskScript({
   });
   await fs.writeFile(scriptPath, encodeWindowsLauncherScript({ format: "cmd", content: script }));
   if (taskLaunchPath !== scriptPath) {
-    const launcher = buildHiddenLauncherScript({ description: taskDescription, scriptPath });
+    const launcher = buildHiddenLauncherScript({
+      description: taskDescription,
+      scriptPath,
+      taskSupervisor: environment?.OPENCLAW_SERVICE_KIND === "gateway",
+    });
     await fs.writeFile(
       taskLaunchPath,
       encodeWindowsLauncherScript({ format: "vbs", content: launcher }),
@@ -252,7 +256,11 @@ async function activateScheduledTask(params: {
       await fs.mkdir(path.dirname(startupEntryPath), { recursive: true });
       const useHiddenLauncher = shouldUseHiddenWindowsTaskLauncher(params.env);
       const launcher = useHiddenLauncher
-        ? buildHiddenLauncherScript({ description: taskDescription, scriptPath: params.scriptPath })
+        ? buildHiddenLauncherScript({
+            description: taskDescription,
+            scriptPath: params.scriptPath,
+            taskSupervisor: params.env.OPENCLAW_SERVICE_KIND === "gateway",
+          })
         : buildStartupLauncherScript({
             description: taskDescription,
             scriptPath: params.scriptPath,

--- a/src/daemon/schtasks-layout.ts
+++ b/src/daemon/schtasks-layout.ts
@@ -20,7 +20,11 @@ import type {
   GatewayServiceReadOptions,
   GatewayServiceRenderArgs,
 } from "./service-types.js";
-import { WINDOWS_TASK_SUPERVISOR_FLAG } from "./windows-task-supervisor-contract.js";
+import {
+  WINDOWS_TASK_LAUNCHER_ACTIVE,
+  WINDOWS_TASK_LAUNCHER_ENV,
+  WINDOWS_TASK_SUPERVISOR_FLAG,
+} from "./windows-task-supervisor-contract.js";
 
 export function resolveTaskName(env: GatewayServiceEnv): string {
   const override = env.OPENCLAW_WINDOWS_TASK_NAME?.trim();
@@ -339,7 +343,10 @@ export function buildTaskScript({
       if (
         value === undefined ||
         (!value && key.toUpperCase() !== "NODE_OPTIONS") ||
-        key.toUpperCase() === "PATH"
+        key.toUpperCase() === "PATH" ||
+        // This preference chooses the launcher at install time. Persisting it
+        // would overwrite the live WScript marker inherited by the supervisor.
+        key.toUpperCase() === WINDOWS_TASK_LAUNCHER_ENV
       ) {
         continue;
       }
@@ -391,6 +398,7 @@ function quoteVbsRunCommand(scriptPath: string): string {
 export function buildHiddenLauncherScript(params: {
   description?: string;
   scriptPath: string;
+  taskSupervisor?: boolean;
 }): string {
   const lines = [];
   const trimmedDescription = params.description?.trim();
@@ -398,9 +406,13 @@ export function buildHiddenLauncherScript(params: {
     assertNoCmdLineBreak(trimmedDescription, "Hidden launcher description");
     lines.push(`' ${trimmedDescription}`);
   }
-  lines.push(
-    `WScript.Quit CreateObject("WScript.Shell").Run(${quoteVbsRunCommand(params.scriptPath)}, 0, True)`,
-  );
+  lines.push('Set shell = CreateObject("WScript.Shell")');
+  if (params.taskSupervisor) {
+    lines.push(
+      `shell.Environment("Process")("${WINDOWS_TASK_LAUNCHER_ENV}") = "${WINDOWS_TASK_LAUNCHER_ACTIVE}"`,
+    );
+  }
+  lines.push(`WScript.Quit shell.Run(${quoteVbsRunCommand(params.scriptPath)}, 0, True)`);
   return `${lines.join("\r\n")}\r\n`;
 }
 

--- a/src/daemon/schtasks.install.test.ts
+++ b/src/daemon/schtasks.install.test.ts
@@ -365,9 +365,7 @@ describe("installScheduledTask", () => {
       const xml = xmlPayloadCaptures.find((entry) => entry.index === xmlIndex)?.xml;
       expect(xml).toContain("<UserId>WORKSTATION\\alice</UserId>");
       expect(xml).toContain("<LogonType>InteractiveToken</LogonType>");
-      expect(launcher).toContain(
-        `WScript.Quit CreateObject("WScript.Shell").Run("""${scriptPath}""", 0, True)`,
-      );
+      expect(launcher).toContain(`WScript.Quit shell.Run("""${scriptPath}""", 0, True)`);
       expectTaskRunCall(xmlIndex + 1);
     });
   });
@@ -389,7 +387,7 @@ describe("installScheduledTask", () => {
       expect(scriptPath).toContain("苗振");
       expect(rawLauncher.subarray(0, 2)).toEqual(Buffer.from([0xff, 0xfe]));
       expect(rawLauncher.subarray(2).toString("utf16le")).toContain(
-        `WScript.Quit CreateObject("WScript.Shell").Run("""${scriptPath}""", 0, True)`,
+        `WScript.Quit shell.Run("""${scriptPath}""", 0, True)`,
       );
     });
   });
@@ -459,10 +457,12 @@ describe("installScheduledTask", () => {
       expect(captured?.xml).toContain("<UserId>WORKSTATION\\alice</UserId>");
       expect(captured?.xml).toContain("<LogonType>InteractiveToken</LogonType>");
       expect(script).toContain('set "OPENCLAW_WINDOWS_TASK_NAME=OpenClaw Custom Gateway"');
-      expect(launcher).toContain("WScript.Shell");
+      expect(script).not.toContain('set "OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER=');
       expect(launcher).toContain(
-        `WScript.Quit CreateObject("WScript.Shell").Run("""${scriptPath}""", 0, True)`,
+        'shell.Environment("Process")("OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER") = "wscript"',
       );
+      expect(launcher).toContain("WScript.Shell");
+      expect(launcher).toContain(`WScript.Quit shell.Run("""${scriptPath}""", 0, True)`);
       expectTaskRunCall(2, "OpenClaw Custom Gateway");
     });
   });

--- a/src/daemon/schtasks.integration-observation.test-support.ts
+++ b/src/daemon/schtasks.integration-observation.test-support.ts
@@ -139,6 +139,28 @@ export function readRelatedProcessDiagnostics(needles: string[]): {
     const commandLine = (entry.CommandLine ?? "").replaceAll("/", "\\").toLowerCase();
     return normalizedNeedles.some((needle) => commandLine.includes(needle));
   });
+  const matchingPids = new Set(
+    matching
+      .map((entry) => entry.ProcessId)
+      .filter((pid): pid is number => typeof pid === "number"),
+  );
+  // Anchors and console hosts need not carry fixture paths in argv. Expand only
+  // descendants of matching processes; context parents must not admit unrelated siblings.
+  let descendantsAdded: boolean;
+  do {
+    descendantsAdded = false;
+    for (const entry of entries) {
+      if (
+        typeof entry.ProcessId === "number" &&
+        typeof entry.ParentProcessId === "number" &&
+        matchingPids.has(entry.ParentProcessId) &&
+        !matchingPids.has(entry.ProcessId)
+      ) {
+        matchingPids.add(entry.ProcessId);
+        descendantsAdded = true;
+      }
+    }
+  } while (descendantsAdded);
   const parentPids = new Set(
     matching
       .map((entry) => entry.ParentProcessId)
@@ -147,7 +169,8 @@ export function readRelatedProcessDiagnostics(needles: string[]): {
   const processes = entries.filter(
     (entry) =>
       matching.includes(entry) ||
-      (typeof entry.ProcessId === "number" && parentPids.has(entry.ProcessId)),
+      (typeof entry.ProcessId === "number" &&
+        (matchingPids.has(entry.ProcessId) || parentPids.has(entry.ProcessId))),
   );
   return {
     error: null,

--- a/src/daemon/schtasks.integration.e2e.test.ts
+++ b/src/daemon/schtasks.integration.e2e.test.ts
@@ -36,6 +36,7 @@ import {
   expectGatewayTaskSupervisorProcessAlive,
   expectScheduledTaskProbeOrigin,
   isProcessAlive,
+  stopGatewayTaskWithPowerShell,
   waitForGatewayTaskSupervisorExit,
   waitForGatewayTaskSupervisorProcesses,
   waitForProcessExit,
@@ -570,7 +571,7 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
 
     let testFailed = false;
     let testError: unknown;
-    let lifecyclePids: number[] = [];
+    const lifecyclePids: number[] = [];
     let installedPrincipal: ScheduledTaskPrincipal | null = null;
     let pendingProof: { path: string; content: string } | undefined;
     const programArguments = buildGatewayTaskSupervisorProgramArguments({
@@ -652,33 +653,79 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
         const recoveredProcesses = await waitForGatewayTaskSupervisorProcesses({ probe });
         expect(recoveredPid).not.toBe(failedProcesses.childPid);
         expect(recoveredProcesses.supervisorPid).not.toBe(failedProcesses.supervisorPid);
-        expectProbeProcessAlive(recoveredPid);
-        expectProbeProcessAlive(recoveredProcesses.childPid);
-        expectGatewayTaskSupervisorProcessAlive(recoveredProcesses.supervisorPid, probe.probePath);
-        expectScheduledTaskProbeOrigin({
-          eventsPath,
-          probePath: probe.probePath,
-          run: recoveredRun,
-          scriptPath,
-          readRelatedProcessDiagnostics,
-        });
-        expect(await canBindLoopbackPort(gatewayPort)).toBe(false);
-        await waitForRuntimeStatus(readRuntime, "running", recoveredPid);
-        expect(readTaskPrincipal(taskName).taskState).toBe(TASK_STATE_RUNNING);
-
-        const stopMutations: string[] = [];
-        await service.stop({
-          env,
-          stdout,
-          onMutation: (mutation) => stopMutations.push(mutation.mode),
-        });
-        expect(stopMutations).toEqual(["schtasks-stop"]);
-        await waitForProcessExit(recoveredPid);
-        await waitForGatewayTaskSupervisorExit(recoveredProcesses);
-        await clearActivePid(activePidPath, recoveredPid);
-        await waitForLoopbackPortRelease(gatewayPort);
-        await waitForRuntimeStatus(readRuntime, "stopped");
-        expect((await execSchtasks(["/Query", "/TN", taskName])).code).toBe(0);
+        lifecyclePids.push(recoveredPid);
+        const externalStops = [];
+        let externalRun = recoveredRun;
+        let externalProcesses = recoveredProcesses;
+        for (const [stopIndex, method] of ["schtasks /End", "Stop-ScheduledTask"].entries()) {
+          if (stopIndex > 0) {
+            await service.start({ env, stdout });
+            const nextRun = await proof.waitForExactProbeRun(eventsPath, 2);
+            const nextProcesses = await waitForGatewayTaskSupervisorProcesses({ probe });
+            expect(nextRun.pid).not.toBe(externalRun.pid);
+            expect(nextProcesses.supervisorPid).not.toBe(externalProcesses.supervisorPid);
+            externalRun = nextRun;
+            externalProcesses = nextProcesses;
+            lifecyclePids.push(nextRun.pid);
+          }
+          expectProbeProcessAlive(externalRun.pid);
+          expectProbeProcessAlive(externalProcesses.childPid);
+          expectGatewayTaskSupervisorProcessAlive(externalProcesses.supervisorPid, probe.probePath);
+          expectScheduledTaskProbeOrigin({
+            eventsPath,
+            probePath: probe.probePath,
+            run: externalRun,
+            scriptPath,
+            readRelatedProcessDiagnostics,
+          });
+          expect(await canBindLoopbackPort(gatewayPort)).toBe(false);
+          await waitForRuntimeStatus(readRuntime, "running", externalRun.pid);
+          expect(readTaskPrincipal(taskName).taskState).toBe(TASK_STATE_RUNNING);
+          const processCapture = readRelatedProcessDiagnostics([
+            probe.probePath,
+            eventsPath,
+            scriptPath,
+          ]);
+          expect(processCapture.ok).toBe(true);
+          expect(processCapture.truncated).toBe(false);
+          expect(processCapture.processes.map((entry) => entry.ProcessId)).toEqual(
+            expect.arrayContaining([externalRun.pid, externalProcesses.supervisorPid]),
+          );
+          const ownedPids = Array.from(
+            new Set([
+              externalRun.pid,
+              externalProcesses.childPid,
+              externalProcesses.supervisorPid,
+              ...processCapture.processes.flatMap((entry) =>
+                entry.ProcessId === undefined ? [] : [entry.ProcessId],
+              ),
+            ]),
+          );
+          // External Scheduler stop must own extinction; service.stop() also kills
+          // listeners and would conceal a surviving hidden launcher process tree.
+          if (method === "schtasks /End") {
+            const stopped = await execSchtasks(["/End", "/TN", taskName]);
+            expect(stopped.code, stopped.stderr || stopped.stdout).toBe(0);
+          } else {
+            stopGatewayTaskWithPowerShell(taskName);
+          }
+          await Promise.all(ownedPids.map((pid) => waitForProcessExit(pid)));
+          await waitForLoopbackPortRelease(gatewayPort);
+          await waitForRuntimeStatus(readRuntime, "stopped");
+          const stoppedTask = readTaskPrincipal(taskName);
+          expect(stoppedTask.taskState).toBe(TASK_STATE_READY);
+          await clearActivePid(activePidPath, externalRun.pid);
+          expect((await execSchtasks(["/Query", "/TN", taskName])).code).toBe(0);
+          externalStops.push({
+            method,
+            gatewayPid: externalRun.pid,
+            ...externalProcesses,
+            pids: ownedPids,
+            taskState: stoppedTask.taskState,
+            lastTaskResult: stoppedTask.lastTaskResult,
+            portReleaseRebind: true,
+          });
+        }
 
         const startMutations: string[] = [];
         await service.start({
@@ -687,10 +734,10 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
           onMutation: (mutation) => startMutations.push(mutation.mode),
         });
         expect(startMutations).toEqual(["schtasks-start"]);
-        const startedRun = await proof.waitForExactProbeRun(eventsPath, 2);
+        const startedRun = await proof.waitForExactProbeRun(eventsPath, 3);
         const startedPid = startedRun.pid;
         const startedProcesses = await waitForGatewayTaskSupervisorProcesses({ probe });
-        expect(startedPid).not.toBe(recoveredPid);
+        expect(lifecyclePids).not.toContain(startedPid);
         expectProbeProcessAlive(startedPid);
         expectProbeProcessAlive(startedProcesses.childPid);
         expectGatewayTaskSupervisorProcessAlive(startedProcesses.supervisorPid, probe.probePath);
@@ -705,7 +752,7 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
         await waitForRuntimeStatus(readRuntime, "running", startedPid);
         expect(readTaskPrincipal(taskName).taskState).toBe(TASK_STATE_RUNNING);
         await service.start({ env, stdout });
-        await proof.waitForExactProbeRun(eventsPath, 2);
+        await proof.waitForExactProbeRun(eventsPath, 3);
 
         const restartMutations: string[] = [];
         const restartResult = await service.restart({
@@ -715,10 +762,10 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
         });
         expect(restartResult).toEqual({ outcome: "completed" });
         expect(restartMutations).toEqual(["schtasks-end", "schtasks-restart"]);
-        const restartedRun = await proof.waitForExactProbeRun(eventsPath, 3);
+        const restartedRun = await proof.waitForExactProbeRun(eventsPath, 4);
         const restartedPid = restartedRun.pid;
         const restartedProcesses = await waitForGatewayTaskSupervisorProcesses({ probe });
-        lifecyclePids = [recoveredPid, startedPid, restartedPid];
+        lifecyclePids.push(startedPid, restartedPid);
         expect(new Set(lifecyclePids).size).toBe(lifecyclePids.length);
         expectProbeProcessAlive(restartedPid);
         expectProbeProcessAlive(restartedProcesses.childPid);
@@ -875,7 +922,9 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
                   "install",
                   "failed-run",
                   "recovery-start",
-                  "stop",
+                  "schtasks-end",
+                  "external-stop-recovery-start",
+                  "powershell-stop-scheduled-task",
                   "start",
                   "restart",
                   "hosted-stop",
@@ -887,6 +936,7 @@ describe.runIf(nativeIntegrationEnabled)("schtasks Windows integration", () => {
                   ...failedProcesses,
                 },
                 pids: lifecyclePids,
+                externalStops,
                 gatewayPort,
                 portReleaseRebind: true,
                 startupFallback: false,

--- a/src/daemon/schtasks.startup-fallback.test.ts
+++ b/src/daemon/schtasks.startup-fallback.test.ts
@@ -705,7 +705,7 @@ describe("Windows startup fallback", () => {
       expect(startupScript).toContain("WScript.Shell");
       expect(startupScript).toContain("gateway.cmd");
       expect(startupScript).toContain(
-        `WScript.Quit CreateObject("WScript.Shell").Run("""${result.scriptPath}""", 0, True)`,
+        `WScript.Quit shell.Run("""${result.scriptPath}""", 0, True)`,
       );
       expectStartupFallbackSpawn();
     });

--- a/src/daemon/schtasks.task-supervisor.native-test-support.ts
+++ b/src/daemon/schtasks.task-supervisor.native-test-support.ts
@@ -1,8 +1,10 @@
+import { spawnSync } from "node:child_process";
 import fs from "node:fs/promises";
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { expect } from "vitest";
+import { getWindowsPowerShellExePath } from "../infra/windows-install-roots.js";
 import { readWindowsProcessSnapshot } from "./schtasks-process.js";
 
 const WAIT_INTERVAL_MS = 200;
@@ -61,6 +63,33 @@ export async function waitForProcessExit(pid: number): Promise<void> {
   throw new Error(`Timed out waiting for Scheduled Task process ${pid} to exit`);
 }
 
+export function stopGatewayTaskWithPowerShell(taskName: string): void {
+  const encodedTaskName = Buffer.from(taskName, "utf8").toString("base64");
+  const script = [
+    "$ErrorActionPreference='Stop'",
+    `$taskName=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${encodedTaskName}'))`,
+    "Stop-ScheduledTask -TaskName $taskName -TaskPath '\\' -ErrorAction Stop",
+  ].join("; ");
+  const result = spawnSync(
+    getWindowsPowerShellExePath(),
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-EncodedCommand",
+      Buffer.from(script, "utf16le").toString("base64"),
+    ],
+    { encoding: "utf8", timeout: 5_000, windowsHide: true },
+  );
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `Stop-ScheduledTask failed for ${taskName}: ${result.stderr.trim() || `PowerShell exited ${result.status ?? "without status"}`}`,
+    );
+  }
+}
+
 export function createGatewayTaskSupervisorProbe(rootDir: string): GatewayTaskSupervisorProbe {
   return {
     childPidPath: path.join(rootDir, "child-pid.txt"),
@@ -93,6 +122,7 @@ export async function writeGatewayTaskSupervisorProbe(params: {
       '  "USERPROFILE", "HOME", "APPDATA", "LOCALAPPDATA", "PROGRAMDATA",',
       '  "OPENCLAW_PROFILE", "OPENCLAW_STATE_DIR", "OPENCLAW_CONFIG_PATH",',
       '  "OPENCLAW_GATEWAY_PORT", "OPENCLAW_SERVICE_KIND", "OPENCLAW_SERVICE_MARKER",',
+      '  "OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER",',
       '  "TSX_TSCONFIG_PATH",',
       "]);",
       "for (const key of Object.keys(process.env)) if (!allowedEnv.has(key.toUpperCase())) delete process.env[key];",

--- a/src/daemon/windows-task-supervisor-contract.ts
+++ b/src/daemon/windows-task-supervisor-contract.ts
@@ -1,2 +1,6 @@
 /** Internal argument used by generated Windows Gateway service launchers. */
 export const WINDOWS_TASK_SUPERVISOR_FLAG = "--task-supervisor";
+
+/** The install preference becomes a consumed runtime marker only inside the hidden launcher. */
+export const WINDOWS_TASK_LAUNCHER_ENV = "OPENCLAW_WINDOWS_TASK_HIDDEN_LAUNCHER";
+export const WINDOWS_TASK_LAUNCHER_ACTIVE = "wscript";

--- a/src/process/supervisor/service-child-windows-job-native.ts
+++ b/src/process/supervisor/service-child-windows-job-native.ts
@@ -35,6 +35,34 @@ export function retainWindowsProcessJobUntilExit(koffi: typeof import("koffi").d
   retainedProcessJob = job;
 }
 
+/** The caller supplies a pinned live launcher process, which becomes the last Job handle owner. */
+export function bindWindowsProcessJobToOwner(
+  bindings: ReturnType<typeof createWindowsJobBindings>,
+  owner: NativeHandle,
+): void {
+  const job = bindings.requireHandle(bindings.CreateJobObjectW(null, null), "CreateJobObjectW");
+  try {
+    if (!bindings.SetExtendedLimits(job, 9, bindings.extendedLimits, bindings.extendedLimitsSize)) {
+      throw bindings.lastError("SetInformationJobObject(KILL_ON_JOB_CLOSE)");
+    }
+    const transferred: Array<NativeHandle | null> = [null];
+    if (!bindings.DuplicateHandle(bindings.GetCurrentProcess(), job, owner, transferred, 0, 0, 2)) {
+      throw bindings.lastError("DuplicateHandle(Job to task launcher)");
+    }
+    bindings.requireHandle(transferred[0], "DuplicateHandle(task launcher Job)");
+    if (!bindings.AssignProcessToJobObject(job, bindings.GetCurrentProcess())) {
+      throw bindings.lastError("AssignProcessToJobObject(task supervisor)");
+    }
+  } catch (error) {
+    bindings.CloseHandle(job);
+    throw error;
+  }
+  // No supervisor/child copy may keep this Job alive after Task Scheduler ends its launcher.
+  if (!bindings.CloseHandle(job)) {
+    throw bindings.lastError("CloseHandle(local task Job)");
+  }
+}
+
 export function createWindowsJobBindings(koffi: typeof import("koffi").default) {
   if (process.arch !== "x64" && process.arch !== "arm64") {
     throw new Error(`Windows Job command ownership requires x64 or arm64, got ${process.arch}`);
@@ -121,6 +149,15 @@ export function createWindowsJobBindings(koffi: typeof import("koffi").default) 
     "str16",
   ]);
   const GetCurrentProcess = kernel32.func("__stdcall", "GetCurrentProcess", HANDLE, []);
+  const DuplicateHandle = kernel32.func("__stdcall", "DuplicateHandle", "int32_t", [
+    HANDLE,
+    HANDLE,
+    HANDLE,
+    koffi.out(koffi.pointer(HANDLE)),
+    "uint32_t",
+    "int32_t",
+    "uint32_t",
+  ]);
   const AssignProcessToJobObject = kernel32.func(
     "__stdcall",
     "AssignProcessToJobObject",
@@ -370,6 +407,7 @@ export function createWindowsJobBindings(koffi: typeof import("koffi").default) 
   return {
     CreateJobObjectW,
     GetCurrentProcess,
+    DuplicateHandle,
     AssignProcessToJobObject,
     SetExtendedLimits,
     CreateProcessW,

--- a/src/process/supervisor/service-child-windows-task-launcher.ts
+++ b/src/process/supervisor/service-child-windows-task-launcher.ts
@@ -1,0 +1,125 @@
+import path from "node:path";
+import {
+  bindWindowsProcessJobToOwner,
+  createWindowsJobBindings,
+} from "./service-child-windows-job-native.js";
+
+type NativeHandle = bigint;
+const PROCESS_QUERY_INFORMATION = 0x0400;
+const PROCESS_QUERY_LIMITED_INFORMATION = 0x1000;
+const PROCESS_DUP_HANDLE = 0x0040;
+const SYNCHRONIZE = 0x0010_0000;
+const WAIT_TIMEOUT = 258;
+
+/** Bind a generated WScript -> CMD -> supervisor launch to its actual, still-live WScript owner. */
+export function bindWindowsTaskLauncher(koffi: typeof import("koffi").default): void {
+  const bindings = createWindowsJobBindings(koffi);
+  bindings.assertLayouts();
+  const kernel32 = koffi.load("kernel32.dll");
+  const ntdll = koffi.load("ntdll.dll");
+  const outDword = koffi.out(koffi.pointer("uint32_t"));
+  const inoutDword = koffi.inout(koffi.pointer("uint32_t"));
+  const OpenProcess = kernel32.func("__stdcall", "OpenProcess", "void *", [
+    "uint32_t",
+    "int32_t",
+    "uint32_t",
+  ]);
+  const GetProcessTimes = kernel32.func("__stdcall", "GetProcessTimes", "int32_t", [
+    "void *",
+    "void *",
+    "void *",
+    "void *",
+    "void *",
+  ]);
+  const QueryImage = kernel32.func("__stdcall", "QueryFullProcessImageNameW", "int32_t", [
+    "void *",
+    "uint32_t",
+    "void *",
+    inoutDword,
+  ]);
+  const QueryBasic = ntdll.func("__stdcall", "NtQueryInformationProcess", "int32_t", [
+    "void *",
+    "uint32_t",
+    "void *",
+    "uint32_t",
+    outDword,
+  ]);
+  const requireLive = (handle: NativeHandle, role: string) => {
+    if (bindings.WaitForSingleObject(handle, 0) !== WAIT_TIMEOUT) {
+      throw new Error(`Windows task ${role} is no longer live`);
+    }
+  };
+  const identity = (handle: NativeHandle, expectedPid: number, role: string) => {
+    // Win64 PROCESS_BASIC_INFORMATION: PID and inherited parent PID follow four pointer-sized slots.
+    const basic = Buffer.alloc(48);
+    const returned = [0];
+    const result = QueryBasic(handle, 0, basic, basic.length, returned);
+    if (result < 0) {
+      throw new Error(`NtQueryInformationProcess(${role}) failed (NTSTATUS ${result})`);
+    }
+    if (returned[0] !== basic.length || basic.readBigUInt64LE(32) !== BigInt(expectedPid)) {
+      throw new Error(`Windows task ${role} process identity changed`);
+    }
+    const parentPid = Number(basic.readBigUInt64LE(40));
+    if (!Number.isSafeInteger(parentPid) || parentPid <= 0 || parentPid > 0xffff_ffff) {
+      throw new Error(`Windows task ${role} has an invalid parent process`);
+    }
+    const imageBuffer = Buffer.alloc(32768 * 2);
+    const imageChars: [number] = [32768];
+    if (!QueryImage(handle, 0, imageBuffer, imageChars)) {
+      throw bindings.lastError(`QueryFullProcessImageNameW(${role})`);
+    }
+    if (imageChars[0] < 1 || imageChars[0] > 32768) {
+      throw new Error(`Windows task ${role} has an invalid image path`);
+    }
+    const creationTime = Buffer.alloc(8);
+    if (!GetProcessTimes(handle, creationTime, Buffer.alloc(8), Buffer.alloc(8), Buffer.alloc(8))) {
+      throw bindings.lastError(`GetProcessTimes(${role})`);
+    }
+    const created = creationTime.readBigUInt64LE();
+    if (created === 0n) {
+      throw new Error(`Windows task ${role} has no process creation time`);
+    }
+    return {
+      parentPid,
+      image: path.win32
+        .basename(imageBuffer.toString("utf16le", 0, imageChars[0] * 2))
+        .toLowerCase(),
+      created,
+    };
+  };
+
+  const supervisor = identity(bindings.GetCurrentProcess(), process.pid, "supervisor");
+  const parentAccess = PROCESS_QUERY_INFORMATION | PROCESS_QUERY_LIMITED_INFORMATION | SYNCHRONIZE;
+  let cmd: NativeHandle | undefined;
+  let launcher: NativeHandle | undefined;
+  try {
+    cmd = bindings.requireHandle(
+      OpenProcess(parentAccess, 0, supervisor.parentPid),
+      "OpenProcess(CMD)",
+    );
+    const command = identity(cmd, supervisor.parentPid, "CMD");
+    if (command.image !== "cmd.exe" || command.created > supervisor.created) {
+      throw new Error("Windows task supervisor lost its original CMD launcher");
+    }
+    launcher = bindings.requireHandle(
+      OpenProcess(parentAccess | PROCESS_DUP_HANDLE, 0, command.parentPid),
+      "OpenProcess(WScript)",
+    );
+    const host = identity(launcher, command.parentPid, "WScript");
+    if (host.image !== "wscript.exe" || host.created > command.created) {
+      throw new Error("Windows task supervisor lost its original WScript launcher");
+    }
+    // Handles pin kernel identities; creation ordering rejects recycled parent PIDs.
+    requireLive(cmd, "CMD launcher");
+    requireLive(launcher, "WScript launcher");
+    bindWindowsProcessJobToOwner(bindings, launcher);
+  } finally {
+    if (launcher !== undefined) {
+      bindings.CloseHandle(launcher);
+    }
+    if (cmd !== undefined) {
+      bindings.CloseHandle(cmd);
+    }
+  }
+}


### PR DESCRIPTION
Related: #137813 and #136980.

## What Problem This Solves

Fixes two Windows Scheduled Task failures: a supervised Gateway can fail without recording its child exit result or stderr, and ending the task can leave the Gateway alive and owning its state directory. The 2026.9.1 premature-host-exit fix from #136980 is already in 2026.9.2; this PR adds the missing diagnostics and repairs task teardown.

## Why This Change Was Made

The supervisor records the child exit code, signal, reason, and the last 8,192 stderr characters in the existing redacted Gateway log. It preserves failure results and intentional zero exits, flushes logging, and continues to discard stdout.

Native inspection found that the Gateway already belonged to a kill-on-close Job, but the surviving anchor process held its handle. Task Scheduler ended WScript, leaving the Node supervisor and anchor alive. The supervisor now validates and pins its original CMD/WScript ancestry, transfers the last non-inheritable handle of an outer kill-on-close Job to WScript, assigns itself, and closes its local copy before admitting a child. Ending WScript therefore takes down the supervisor and its descendants. The existing inner Job still owns cancellation and extinction joins.

The generated VBS uses the existing hidden-launcher setting as a consumed runtime marker. The generated CMD does not overwrite it with the install preference. Direct Startup launches retain their existing behavior. This changes the generated launcher contract; it adds no dependency, configuration option or log store. This PR makes no config-schema or SQLite/storage-format change. Existing installations receive the new launcher through service refresh or `openclaw gateway install --force`.

## User Impact

Operators can diagnose early child failures and end the Scheduled Task without leaving a Gateway behind. Both `schtasks /end` and `Stop-ScheduledTask` are covered directly, before any CLI cleanup, and a subsequent task start must create a new healthy process.

The Windows docs also clarify a platform limit: Task Scheduler's `RestartOnFailure` policy covers failed start conditions or action launches. A nonzero exit from an already launched Gateway does not guarantee automatic recovery; fix the logged cause and start it again.

## Evidence

Validation is native Windows Server 2022 x64 with Node 24.20.0, isolated task-owned accounts/state and loopback ports. Windows 11 and ARM64 were not directly exercised.

- Released 2026.9.2 and earlier candidate `9386638`: both raw stop methods kill the real Scheduler WScript action while leaving the Node supervisor, anchor and Gateway alive. Event 129 and EnginePID establish Scheduler origin. Specific `IsProcessInJob` queries prove Gateway membership in the anchor-held Job with `KILL_ON_JOB_CLOSE=0x2000`; the diagnostic inspector closes its duplicates before stopping the task.
- Exact final head `19e1f718aabb3807f4dd7d753b64c552bb683591`: the native integration suite passed all 5 tests. Raw `/End` extinguished all 10 recorded processes; `Stop-ScheduledTask` extinguished all 9 recorded processes. Each freed the port and allowed a fresh start. Restart, intentional zero-exit shutdown, and the 65-second no-restart observation passed. Generic direct and batch Startup fallback probes survived their launcher's exit (these native probes do not launch a real Gateway), and the default task definition remained unchanged. The Gateway-specific unit case also verifies that the install preference `1` does not require a WScript owner.
- The installed final tarball (SHA256 `165b20e8dd709ae04783f1775e6df53da90846a95b73156ffc5eb887238178de`) also passed both stop and fresh-start checks. Raw `/End`: WScript 2192 held non-inheritable Job handle 1516 with flags `0x2000`; Gateway 6156 was a confirmed member. All descendants disappeared, and the next `/Run` started Gateway 2624 with HTTP 200. `Stop-ScheduledTask`: WScript 4520 held handle 944 with the same flags; Gateway 6688 disappeared and the next `/Run` started Gateway 6484 with HTTP 200. Both left no listener or recorded survivor. The probe's aggregate status was nonzero because short-lived PowerShell/conhost startup helpers exited before handle enumeration (Win32 error 87); inspection of the WScript/supervisor/anchor/Gateway and the stop/restart assertions succeeded. These were normal generated launchers, without the diagnostic preload.
- Occupied-port retry comparison: the registered policy was `PT1M`, count 3. Demand-start, actual timer-triggered start, and explicit `wscript.exe` action each produced result `1` and the logged child failure, but no automatic second execution over 270.8–271.5 seconds after failure. This agrees with the [Task Scheduler protocol specification](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-tsch/2ff4aa5a-7bc4-449f-bbb1-27475645867f). The timer experiment restored the original definition exactly. The final installed package independently returned task result `1` and logged `Gateway child failed` with child exit code `1` and an `EADDRINUSE` stderr tail; after 270.58 seconds it still had exactly one Scheduler-created action instance and no automatic retry.
- Positive retry control on the installed final package: changing only the Exec working directory to a nonexistent path caused Scheduler Event 203 / `ERROR_DIRECTORY` (`0x8007010B`) before WScript launched. Creating that directory triggered a new Scheduler-created WScript (PID 2180) automatically after 60.997 seconds, without a second user start; Gateway 5256 returned HTTP 200. The probe completed its 271.64-second window with exit `0`, stopped the task, and restored the original task XML exactly. This proves that the configured retry policy is active for an action-launch failure, while the occupied-port comparison proves that application exit `1` does not trigger it on this host. The initial live evidence-copy attempt encountered a Windows file-sharing conflict; the control was repeated without live output-file reads. The successful native probe outlived a Crabbox heartbeat failure; its completed JSON and cleanup receipt were retrieved afterward.
- Focused local tests: 183 passed, 1 platform-specific skip. The two new admission cases were first demonstrated failing against the original owner. `pnpm check:changed`, `git diff --check`, package build and tarball integrity passed. Independent P0–P2 review found no actionable code issue; the retry documentation correction also passed independent review.
- Exact-head CI is [green](https://github.com/openclaw/openclaw/actions/runs/34181787590).

Earlier issue proof remains relevant: 2026.9.1 reproduced silent task result `0`, no listener, and no added log lines. Shell `openclaw update --tag 2026.9.2 --yes` installed 9.2 but the old updater's restart step failed loading a removed dist module; a fresh CLI start recovered. The previous candidate's shell update completed and reached HTTP 200. No manual lock removal or stale-lock recovery was used. Issue #137813 remains open for maintainer review.

Thanks to @akagifreeez, @Devin-Linux, and @unknowbug for the native diagnosis in #137813.
