### PR TITLE
fix(release): bind source admission and retain first-hop coverage

### DIFF
--- a/.github/actions/git-owner/release-ancestry.py
+++ b/.github/actions/git-owner/release-ancestry.py
@@ -192,6 +192,9 @@ def establish_ancestry():
         return result
 
     previous_count = reachable_commit_count(source_sha, target_sha)
+    # Seed the separate destination: Git may only create a new ref on the first
+    # deepen, leaving existing shallow edges unchanged until the next fetch.
+    run_git(workspace, "update-ref", target_hydration_local_ref, target_sha, timeout=operation_timeout())
     chunk_index = 0
     while True:
         chunk = deepen_chunks[min(chunk_index, len(deepen_chunks) - 1)]

--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -489,6 +489,15 @@ jobs:
       - *trusted_workflow_subdir_checkout_step
       - *trusted_workflow_subdir_identity_step
 
+      - name: Checkout selected source for gateway network provenance
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          repository: openclaw/openclaw
+          ref: ${{ needs.preflight.outputs.target_sha }}
+          path: .release-source
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Validate root Dockerfile image artifact binding
         env:
           ARCHIVE_SHA256: ${{ needs.root_dockerfile_image.outputs.archive_sha256 }}
@@ -586,6 +595,7 @@ jobs:
 
       - name: Run Docker gateway network e2e
         env:
+          OPENCLAW_DOCKER_E2E_REPO_ROOT: ${{ github.workspace }}/.release-source
           OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: ${{ inputs.allow_frozen_target_scenario_omissions && '1' || '0' }}
           OPENCLAW_GATEWAY_NETWORK_E2E_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_GATEWAY_NETWORK_E2E_SKIP_BUILD: "1"

--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -489,14 +489,22 @@ jobs:
       - *trusted_workflow_subdir_checkout_step
       - *trusted_workflow_subdir_identity_step
 
+      - name: Prepare trusted selected-source Git owner
+        uses: ./.release-harness/.github/actions/git-owner
+
       - name: Checkout selected source for gateway network provenance
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          repository: openclaw/openclaw
-          ref: ${{ needs.preflight.outputs.target_sha }}
-          path: .release-source
-          fetch-depth: 1
-          persist-credentials: false
+        env:
+          CHECKOUT_KIND: preflight
+          CHECKOUT_REPO: openclaw/openclaw
+          CHECKOUT_REF: ${{ needs.preflight.outputs.target_sha }}
+          CHECKOUT_FALLBACK_REF: ${{ needs.preflight.outputs.target_sha }}
+          CHECKOUT_TOKEN: ""
+          SELECTED_SOURCE_DIR: ${{ github.workspace }}/.release-source
+          WORKFLOW_SHA: ${{ steps.workflow.outputs.sha }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$SELECTED_SOURCE_DIR"
+          GITHUB_WORKSPACE="$SELECTED_SOURCE_DIR" python3 -I -S "$CI_GIT_OWNER"
 
       - name: Validate root Dockerfile image artifact binding
         env:

--- a/scripts/lib/docker-e2e-plan.mts
+++ b/scripts/lib/docker-e2e-plan.mts
@@ -57,7 +57,12 @@ export const RELEASE_PATH_PROFILE = "release-path";
 type LiveMode = "all" | "only" | "skip";
 type DockerProfile = typeof DEFAULT_PROFILE | typeof RELEASE_PATH_PROFILE;
 type UpgradeSurvivorExpansion = { lanes: DockerE2eLane[]; omittedLaneNames: string[] };
-const UPDATE_FIRST_HOP_COMPAT_OUTPUTS = ["shared-DTaQo6Hi.js", "shared-Y6bNiw2w.js"];
+// Inert postbuild declarations: shipped 9.1/9.2 literal outputs and the mapped
+// catalog that followed. Selection must not execute a frozen target's build code.
+const UPDATE_FIRST_HOP_COMPAT_CATALOGS = new Set([
+  "3a07518cac2a3f92c0ecb73e177ced4ae3350872be59c8c9a1871c2f0e3c0773",
+  "edf5302a5bb101f2a2efaf9735cd0ae90081bd1b693e0c77a1f8e56ada865096",
+]);
 const IOS_WATCH_RELAY_COMMANDS = ['"watch.status"', '"watch.notify"'];
 type DockerE2ePlanOptions = {
   allowFrozenTargetScenarioOmissions?: boolean;
@@ -304,7 +309,17 @@ function supportsUpdateFirstHopCompatForTarget(targetRoot: string | undefined): 
     return false;
   }
   const source = readFileSync(runtimePostbuild, "utf8");
-  return UPDATE_FIRST_HOP_COMPAT_OUTPUTS.every((name) => source.includes(`dest: "dist/${name}"`));
+  const startMarker = "const LEGACY_CLI_EXIT_COMPAT_CHUNKS = [";
+  const start = source.indexOf(startMarker);
+  if (start < 0 || source.lastIndexOf(startMarker) !== start) {
+    return false;
+  }
+  const end = source.indexOf("\n];", start + startMarker.length);
+  if (end < 0) {
+    return false;
+  }
+  const block = source.slice(start, end + 3);
+  return UPDATE_FIRST_HOP_COMPAT_CATALOGS.has(createHash("sha256").update(block).digest("hex"));
 }
 
 function supportsMobilePairingReconnectForTarget(targetRoot: string | undefined): boolean {

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -138,6 +138,82 @@ function bundledPluginSweepLane(index: number): ReturnType<typeof summarizeLane>
 }
 
 describe("scripts/lib/docker-e2e-plan", () => {
+  const literalFirstHopPostbuild = String.raw`const LEGACY_CLI_EXIT_COMPAT_CHUNKS = [
+  // v2026.8.2 and the exact d413210 build load these after replacing dist/.
+  // Remove only after both source artifacts fall outside the supported upgrade window.
+  {
+    dest: "dist/shared-Y6bNiw2w.js",
+    contents: LEGACY_UPDATE_NODE_RUNNER_COMPAT_CHUNK,
+  },
+  {
+    dest: "dist/shared-DTaQo6Hi.js",
+    contents: LEGACY_UPDATE_NODE_RUNNER_COMPAT_CHUNK,
+  },
+  {
+    dest: "dist/memory-state-CcqRgDZU.js",
+    contents: "export function hasMemoryRuntime() {\n  return false;\n}\n",
+  },
+  {
+    dest: "dist/memory-state-DwGdReW4.js",
+    contents: "export function hasMemoryRuntime() {\n  return false;\n}\n",
+  },
+];`;
+
+  it.each(["literal", "mapped"])(
+    "retains first-hop coverage for supported %s postbuild output declarations without executing target code",
+    (shape) => {
+      const targetRoot = tempDirs.make("openclaw-first-hop-target-");
+      mkdirSync(join(targetRoot, "scripts"));
+      const source =
+        shape === "literal"
+          ? literalFirstHopPostbuild
+          : readFileSync("scripts/runtime-postbuild.mts", "utf8");
+      writeFileSync(
+        join(targetRoot, "scripts/runtime-postbuild.mts"),
+        `throw new Error("must not execute target");\n${source}`,
+      );
+      const plan = planFor({
+        selectedLaneNames: ["update-first-hop-compat"],
+        upgradeSurvivorTargetRoot: targetRoot,
+      });
+      expect(plan.lanes.map((lane) => lane.name)).toEqual(["update-first-hop-compat"]);
+      expect(plan.omittedUnsupportedLanes).toEqual([]);
+    },
+  );
+
+  it.each([
+    ["literal", "shared-Y6bNiw2w.js"],
+    ["literal", "shared-DTaQo6Hi.js"],
+    ["mapped", "shared-Y6bNiw2w.js"],
+    ["mapped", "shared-DTaQo6Hi.js"],
+    ["unrelated", ""],
+    ["absent", ""],
+  ])(
+    "does not infer first-hop support from %s with missing or unrelated outputs %s",
+    (shape, missing) => {
+      const targetRoot = tempDirs.make("openclaw-missing-first-hop-target-");
+      mkdirSync(join(targetRoot, "scripts"));
+      if (shape !== "absent") {
+        const source =
+          shape === "mapped"
+            ? readFileSync("scripts/runtime-postbuild.mts", "utf8")
+            : literalFirstHopPostbuild;
+        writeFileSync(
+          join(targetRoot, "scripts/runtime-postbuild.mts"),
+          shape === "unrelated"
+            ? source.replace("const LEGACY_CLI_EXIT_COMPAT_CHUNKS", "const UNRELATED_OUTPUTS")
+            : source.replaceAll(missing, "missing.js"),
+        );
+      }
+      const plan = planFor({
+        selectedLaneNames: ["update-first-hop-compat"],
+        upgradeSurvivorTargetRoot: targetRoot,
+      });
+      expect(plan.lanes).toEqual([]);
+      expect(plan.omittedUnsupportedLanes).toEqual(["update-first-hop-compat"]);
+    },
+  );
+
   it.each([
     ["catalog", "docker-package-install", {}, 0, ""],
     ["missing package", "docker-package-install", { needsPackage: false }, 1, "package Docker"],

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -1,7 +1,11 @@
-import { spawnSync } from "node:child_process";
-import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
+import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 const INSTALL_SMOKE = ".github/workflows/install-smoke.yml";
 const INSTALL_SMOKE_REUSABLE = ".github/workflows/install-smoke-reusable.yml";
@@ -46,8 +50,8 @@ type Workflow = {
   permissions?: Record<string, unknown>;
 };
 
-function readWorkflow(path: string): Workflow {
-  return parse(readFileSync(path, "utf8")) as Workflow;
+function readWorkflow(workflowPath: string): Workflow {
+  return parse(readFileSync(workflowPath, "utf8")) as Workflow;
 }
 
 function job(workflow: Workflow, name: string): WorkflowJob {
@@ -390,8 +394,20 @@ describe("install smoke no-push root image transport", () => {
       expect(requireLocal.if, jobName).toBeUndefined();
       expect(requireLocal.run, jobName).toBe('docker image inspect "$IMAGE_REF" >/dev/null');
 
+      const selectedCheckout = step(
+        consumer,
+        "Checkout selected source for gateway network provenance",
+      );
+      expect(selectedCheckout.with).toMatchObject({
+        repository: "openclaw/openclaw",
+        ref: "${{ needs.preflight.outputs.target_sha }}",
+        path: ".release-source",
+        "fetch-depth": 1,
+        "persist-credentials": false,
+      });
       const gatewayNetwork = step(consumer, "Run Docker gateway network e2e");
       expect(gatewayNetwork.env, jobName).toMatchObject({
+        OPENCLAW_DOCKER_E2E_REPO_ROOT: "${{ github.workspace }}/.release-source",
         OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS:
           "${{ inputs.allow_frozen_target_scenario_omissions && '1' || '0' }}",
         OPENCLAW_SELECTED_SHA: "${{ needs.preflight.outputs.target_sha }}",
@@ -403,6 +419,83 @@ describe("install smoke no-push root image transport", () => {
     expect(text.match(/verify-upload "Root image"/g)).toHaveLength(1);
     expect(text).not.toContain("gh api");
   });
+
+  it.each(["selected", "tooling", "missing"])(
+    "checks selected network source provenance before Docker: %s",
+    (source) => {
+      const workspace = tempDirs.make("install-smoke-source-binding-");
+      const selected = path.join(workspace, ".release-source");
+      const tooling = process.cwd();
+      mkdirSync(selected);
+      execFileSync("git", ["init", "--quiet", selected]);
+      execFileSync("git", [
+        "-C",
+        selected,
+        "-c",
+        "user.name=Fixture",
+        "-c",
+        "user.email=fixture@example.invalid",
+        "commit",
+        "--quiet",
+        "--allow-empty",
+        "-m",
+        "selected source",
+      ]);
+      const selectedSha = execFileSync("git", ["-C", selected, "rev-parse", "HEAD"], {
+        encoding: "utf8",
+      }).trim();
+      const toolingSha = execFileSync("git", ["-C", tooling, "rev-parse", "HEAD"], {
+        encoding: "utf8",
+      }).trim();
+      symlinkSync(tooling, path.join(workspace, ".release-harness"), "dir");
+      const bin = path.join(workspace, "bin");
+      mkdirSync(bin);
+      const dockerCalls = path.join(workspace, "docker-calls");
+      writeFileSync(
+        path.join(bin, "docker"),
+        '#!/bin/sh\nprintf "%s\n" "$*" >>"$DOCKER_CALLS"\nexit 47\n',
+        { mode: 0o755 },
+      );
+      const consumer = job(readWorkflow(INSTALL_SMOKE_REUSABLE), "root_dockerfile_smokes");
+      const network = step(consumer, "Run Docker gateway network e2e");
+      const configuredRoot = network.env?.OPENCLAW_DOCKER_E2E_REPO_ROOT?.replace(
+        "${{ github.workspace }}",
+        workspace,
+      );
+      const repoRoot =
+        source === "selected"
+          ? configuredRoot
+          : source === "tooling"
+            ? tooling
+            : path.join(workspace, "absent");
+      const result = spawnSync("bash", ["-c", network.run!], {
+        cwd: workspace,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${bin}${path.delimiter}${process.env.PATH}`,
+          DOCKER_CALLS: dockerCalls,
+          OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1",
+          OPENCLAW_SELECTED_SHA: selectedSha,
+          OPENCLAW_TOOLING_SHA: toolingSha,
+          OPENCLAW_GATEWAY_NETWORK_E2E_SKIP_BUILD: "1",
+          OPENCLAW_DOCKER_E2E_REQUIRE_LOCAL_IMAGE: "1",
+          OPENCLAW_DOCKER_E2E_REPO_ROOT: repoRoot ?? "",
+        },
+      });
+      if (source === "selected") {
+        expect(result.stderr).not.toContain("selected source checkout does not match");
+        expect(existsSync(dockerCalls), result.stderr).toBe(true);
+        expect(readFileSync(dockerCalls, "utf8")).toContain("image inspect");
+      } else {
+        expect(result.status).toBe(2);
+        expect(result.stderr).toContain(
+          "selected source checkout does not match OPENCLAW_SELECTED_SHA",
+        );
+        expect(existsSync(dockerCalls)).toBe(false);
+      }
+    },
+  );
 
   it("forwards frozen-target omission authority from the release coordinator", () => {
     const workflow = readWorkflow(RELEASE_CHECKS);

--- a/test/scripts/install-smoke-no-push-workflow.test.ts
+++ b/test/scripts/install-smoke-no-push-workflow.test.ts
@@ -1,6 +1,7 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readFileSync, symlinkSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
@@ -398,12 +399,17 @@ describe("install smoke no-push root image transport", () => {
         consumer,
         "Checkout selected source for gateway network provenance",
       );
-      expect(selectedCheckout.with).toMatchObject({
-        repository: "openclaw/openclaw",
-        ref: "${{ needs.preflight.outputs.target_sha }}",
-        path: ".release-source",
-        "fetch-depth": 1,
-        "persist-credentials": false,
+      expect(step(consumer, "Prepare trusted selected-source Git owner").uses).toBe(
+        "./.release-harness/.github/actions/git-owner",
+      );
+      expect(selectedCheckout.env).toMatchObject({
+        CHECKOUT_KIND: "preflight",
+        CHECKOUT_REPO: "openclaw/openclaw",
+        CHECKOUT_REF: "${{ needs.preflight.outputs.target_sha }}",
+        CHECKOUT_FALLBACK_REF: "${{ needs.preflight.outputs.target_sha }}",
+        CHECKOUT_TOKEN: "",
+        SELECTED_SOURCE_DIR: "${{ github.workspace }}/.release-source",
+        WORKFLOW_SHA: "${{ steps.workflow.outputs.sha }}",
       });
       const gatewayNetwork = step(consumer, "Run Docker gateway network e2e");
       expect(gatewayNetwork.env, jobName).toMatchObject({
@@ -426,11 +432,12 @@ describe("install smoke no-push root image transport", () => {
       const workspace = tempDirs.make("install-smoke-source-binding-");
       const selected = path.join(workspace, ".release-source");
       const tooling = process.cwd();
-      mkdirSync(selected);
-      execFileSync("git", ["init", "--quiet", selected]);
+      const origin = path.join(workspace, "source-origin");
+      mkdirSync(origin);
+      execFileSync("git", ["init", "--quiet", origin]);
       execFileSync("git", [
         "-C",
-        selected,
+        origin,
         "-c",
         "user.name=Fixture",
         "-c",
@@ -441,7 +448,7 @@ describe("install smoke no-push root image transport", () => {
         "-m",
         "selected source",
       ]);
-      const selectedSha = execFileSync("git", ["-C", selected, "rev-parse", "HEAD"], {
+      const selectedSha = execFileSync("git", ["-C", origin, "rev-parse", "HEAD"], {
         encoding: "utf8",
       }).trim();
       const toolingSha = execFileSync("git", ["-C", tooling, "rev-parse", "HEAD"], {
@@ -457,6 +464,38 @@ describe("install smoke no-push root image transport", () => {
         { mode: 0o755 },
       );
       const consumer = job(readWorkflow(INSTALL_SMOKE_REUSABLE), "root_dockerfile_smokes");
+      const checkout = step(consumer, "Checkout selected source for gateway network provenance");
+      const checkoutEnv = Object.fromEntries(
+        Object.entries(checkout.env ?? {}).map(([key, value]) => [
+          key,
+          value
+            .replace("${{ github.workspace }}", workspace)
+            .replace("${{ needs.preflight.outputs.target_sha }}", selectedSha)
+            .replace("${{ steps.workflow.outputs.sha }}", toolingSha),
+        ]),
+      );
+      const fetched = spawnSync("bash", ["-c", checkout.run!], {
+        cwd: workspace,
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          ...checkoutEnv,
+          CI_GIT_OWNER: path.join(tooling, ".github/actions/git-owner/owner.py"),
+          GITHUB_EVENT_NAME: "workflow_dispatch",
+          GIT_CONFIG_NOSYSTEM: "1",
+          GIT_CONFIG_GLOBAL: "/dev/null",
+          GIT_CONFIG_COUNT: "1",
+          GIT_CONFIG_KEY_0: `url.${pathToFileURL(origin).href}.insteadOf`,
+          GIT_CONFIG_VALUE_0: "https://github.com/openclaw/openclaw.git",
+        },
+      });
+      expect(fetched.status, fetched.stdout + fetched.stderr).toBe(0);
+      expect(
+        execFileSync("git", ["-C", selected, "rev-parse", "HEAD"], { encoding: "utf8" }).trim(),
+      ).toBe(selectedSha);
+      expect(
+        execFileSync("git", ["-C", selected, "config", "--local", "--list"], { encoding: "utf8" }),
+      ).not.toMatch(/extraheader|AUTHORIZATION/i);
       const network = step(consumer, "Run Docker gateway network e2e");
       const configuredRoot = network.env?.OPENCLAW_DOCKER_E2E_REPO_ROOT?.replace(
         "${{ github.workspace }}",


### PR DESCRIPTION
## What Problem This Solves

Resolves three deterministic release-verification admission failures: the root-image network consumer validated the selected Code SHA against its Tooling checkout; ancestry deepening could create a hydration ref without advancing a shallow boundary; and the first-hop planner misclassified a supported mapped build declaration as unsupported.

## Why This Change Was Made

Use the existing trusted Git owner to check out the exact preflight-selected SHA without a token in a separate `.release-source` directory, then pass that directory through the network script's existing repository-root input. Executable tooling remains in the trusted harness; the network provenance and image-binding guards remain unchanged.

Seed the separate ancestry hydration ref at the already pinned target before deepening. Recognize the verified literal and mapped first-hop declaration blocks inertly, following the planner's existing content-addressed contract convention. Target build code is never executed during selection; missing or modified declarations remain unsupported, and zero-runnable execution still fails.

## User Impact

Release validation can use distinct selected Code and trusted Tooling revisions and retain required first-hop coverage without bypassing provenance, capability, or execution gates. No runtime or publication behavior changes.

## Evidence

- 159 combined workflow, planner, and postbuild tests pass, plus 12 selected real-Git ancestry tests and the scheduler's zero-runnable refusal regression.
- Actual workflow checkout uses the real Git owner against local Git transport, verifies exact HEAD and no persisted authentication, then runs the real network script. Correct source binding reaches a deliberate Docker inspection boundary; wrong or missing roots fail before Docker.
- Frozen candidate build metadata reproduces the original false first-hop omission; the corrected plan contains the required lane with no omissions. The postbuild writer and compatibility ABI tests remain green.
- Scoped type/lint/format/guard checks and workflow validation pass. Fresh combined P2 review is clean.

The entrypoint proof deliberately stops at a stubbed Docker inspection. Complete network and first-hop behavior against the exact release artifacts remains part of the release consumer runs; this PR does not claim full release verification is green.
