### PR TITLE
fix(ui): show the number of displayed Usage sessions

### DIFF
--- a/docs/web/control-ui/feature-reference.md
+++ b/docs/web/control-ui/feature-reference.md
@@ -82,6 +82,7 @@ Control UI capabilities grouped by area, each with the Gateway RPC methods behin
   </Accordion>
   <Accordion title="Usage">
     - Session-derived token and estimated-cost analysis stays separate from provider billing.
+    - The Sessions card counts the rows currently shown: up to 50 in **All**, or matching sessions selected on this Usage page in **Recently viewed**. The total is the loaded session count for the agent scope; the separate selected-session comparison does not increase the shown count.
     - Filter sessions with the provider, model, channel, or tool menus, or type case-insensitive `key:value` terms. Values within one category match as alternatives. Toggling a menu option preserves the other filters and their quoted text.
     - Selecting days narrows token and cost totals to those days within the active session filters. Daily charts and exports retain that session scope. Provider/model/tool queries select matching sessions, including all usage within each matched session; hour filters select sessions active in those hours.
     - Drag the handles in a session’s usage timeline to inspect an interval. Tool-call counts use assistant invocations in the loaded conversation, including repeated calls to the same tool; tool results do not add calls.

--- a/ui/src/pages/usage/view-overview.test.ts
+++ b/ui/src/pages/usage/view-overview.test.ts
@@ -570,6 +570,7 @@ describe("renderSessionsCard", () => {
       recent?: string[];
       tab?: Parameters<typeof renderSessionsCard>[7];
       onSelect?: Parameters<typeof renderSessionsCard>[8];
+      totalSessions?: number;
     } = {},
   ) => {
     const container = document.createElement("div");
@@ -588,13 +589,131 @@ describe("renderSessionsCard", () => {
         noop,
         noop,
         [],
-        sessions.length,
+        options.totalSessions ?? sessions.length,
         noop,
       ),
       container,
     );
     return container;
   };
+
+  const shownCountCases: Array<{
+    name: string;
+    sessionCount: number;
+    options?: Parameters<typeof renderCard>[1];
+    shown: number;
+    header: string;
+    empty?: string;
+    more?: string;
+    primaryLabels?: string[];
+    selectedLabel?: string;
+  }> = [
+    {
+      name: "empty All list",
+      sessionCount: 0,
+      shown: 0,
+      header: "0 shown",
+      empty: "No sessions in range",
+    },
+    {
+      name: "All list below the display cap",
+      sessionCount: 3,
+      shown: 3,
+      header: "3 shown",
+    },
+    {
+      name: "All list above the display cap",
+      sessionCount: 51,
+      shown: 50,
+      header: "50 shown · 51 total",
+      more: "+1 more",
+    },
+    {
+      name: "empty Recently viewed list",
+      sessionCount: 3,
+      options: { tab: "recent" },
+      shown: 0,
+      header: "0 shown · 3 total",
+      empty: "No recent sessions",
+    },
+    {
+      name: "Recently viewed list with a separate selected comparison",
+      sessionCount: 3,
+      options: {
+        tab: "recent",
+        recent: ["session-2", "missing", "session-0"],
+        selected: ["session-0", "session-1"],
+      },
+      shown: 2,
+      header: "2 shown · 3 total",
+      primaryLabels: ["Session 2", "Session 0"],
+      selectedLabel: "Selected (2)",
+    },
+    {
+      name: "Recently viewed list whose keys no longer match",
+      sessionCount: 3,
+      options: { tab: "recent", recent: ["missing"] },
+      shown: 0,
+      header: "0 shown · 3 total",
+      empty: "No recent sessions",
+    },
+    {
+      name: "filtered All list with its original total",
+      sessionCount: 3,
+      options: { totalSessions: 7 },
+      shown: 3,
+      header: "3 shown · 7 total",
+    },
+    {
+      name: "filtered Recently viewed list with its original total",
+      sessionCount: 3,
+      options: { tab: "recent", recent: ["session-1", "missing"], totalSessions: 7 },
+      shown: 1,
+      header: "1 shown · 7 total",
+      primaryLabels: ["Session 1"],
+    },
+  ];
+
+  it.each(shownCountCases)("reports the rows shown in the $name", (scenario) => {
+    const sessions: UsageSessionEntry[] = Array.from(
+      { length: scenario.sessionCount },
+      (_, index) => ({
+        key: `session-${index}`,
+        label: `Session ${index}`,
+        usage: {
+          ...totals,
+          input: 100 - index,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens: 100 - index,
+        },
+      }),
+    );
+    const container = renderCard(sessions, scenario.options);
+    const primaryList = container.querySelector(".sessions-card > .session-bars");
+    expect(primaryList?.querySelectorAll(".session-bar-row").length ?? 0).toBe(scenario.shown);
+    expect(
+      container
+        .querySelector(".sessions-card-header .sessions-card-count")
+        ?.textContent?.replace(/\s+/g, " ")
+        .trim(),
+    ).toBe(scenario.header);
+    expect(container.querySelector(".usage-empty-block")?.textContent?.trim()).toBe(scenario.empty);
+    expect(container.querySelector(".usage-more-sessions")?.textContent?.trim()).toBe(
+      scenario.more,
+    );
+    expect(
+      container.querySelector(".sessions-selected-group .sessions-card-count")?.textContent?.trim(),
+    ).toBe(scenario.selectedLabel);
+    if (scenario.primaryLabels) {
+      expect(
+        [...(primaryList?.querySelectorAll(".session-bar-title") ?? [])].map((label) =>
+          label.textContent?.trim(),
+        ),
+      ).toEqual(scenario.primaryLabels);
+    }
+  });
 
   it.each([
     { copied: true, feedback: "Copied!" },

--- a/ui/src/pages/usage/view-overview.ts
+++ b/ui/src/pages/usage/view-overview.ts
@@ -945,6 +945,7 @@ function renderSessionsCard(
   const recentEntries = recentSessions
     .map((key) => sessionMap.get(key))
     .filter((entry) => entry !== undefined);
+  const displayedEntries = sessionsTab === "recent" ? recentEntries : sortedWithDir.slice(0, 50);
   const renderSessionBarRows = (entries: typeof sortedSessions) => {
     // Selection follows this rendered group, before a click reorders recently viewed sessions.
     const orderedKeys = entries.map((entry) => entry.session.key);
@@ -959,9 +960,9 @@ function renderSessionsCard(
       <div class="usage-panel sessions-card">
         <div class="sessions-card-header">
           <div class="sessions-card-count">
-            ${t("usage.sessions.shown", { count: String(sessions.length) })}
+            ${t("usage.sessions.shown", { count: String(displayedEntries.length) })}
             ${
-              totalSessions !== sessions.length
+              totalSessions !== displayedEntries.length
                 ? ` · ${t("usage.sessions.total", { count: String(totalSessions) })}`
                 : ""
             }
@@ -1042,23 +1043,25 @@ function renderSessionsCard(
         </div>
         ${
           sessionsTab === "recent"
-            ? recentEntries.length === 0
+            ? displayedEntries.length === 0
               ? html` <div class="usage-empty-block">${t("usage.sessions.noRecent")}</div> `
               : html`
                   <div class="session-bars session-bars--recent">
-                    ${renderSessionBarRows(recentEntries)}
+                    ${renderSessionBarRows(displayedEntries)}
                   </div>
                 `
-            : sessions.length === 0
+            : displayedEntries.length === 0
               ? html` <div class="usage-empty-block">${t("usage.sessions.noneInRange")}</div> `
               : html`
                   <div class="session-bars">
-                    ${renderSessionBarRows(sortedWithDir.slice(0, 50))}
+                    ${renderSessionBarRows(displayedEntries)}
                     ${
-                      sessions.length > 50
+                      sessions.length > displayedEntries.length
                         ? html`
                             <div class="usage-more-sessions">
-                              ${t("usage.sessions.more", { count: String(sessions.length - 50) })}
+                              ${t("usage.sessions.more", {
+                                count: String(sessions.length - displayedEntries.length),
+                              })}
                             </div>
                           `
                         : nothing


### PR DESCRIPTION
Closes #141748

## What Problem This Solves

Fixes an issue where users viewing Usage see an incorrect “shown” count when All exceeds its 50-row display cap or Recently viewed contains fewer sessions than the current filters match. An empty Recently viewed list could say “51 shown.”

## Why This Change Was Made

The Sessions card now derives its caption, rows and remaining-row cue from one `displayedEntries` array. Loaded totals, matching-session averages/errors, sort order and the separate selected-session comparison retain their existing behavior. The feature reference explains those distinctions.

Production is +11/−8 (net +3): the shared displayed-array binding replaces independent row/count calculations, and the remaining-row translation spans three lines. Tests are +120/−1; docs add one line. No configuration, schema, persistence, routing or dependency contract changes. Introduction provenance is unknown in the retained shallow history.

## User Impact

All shows “50 shown · 51 total” for 51 loaded sessions. An empty Recently viewed list shows “0 shown · 51 total”; selecting two matching sessions shows “2 shown · 51 total.” Filtering and selecting sessions continue to work as before.

## Evidence

- Tests-only baseline: five intended header failures, with row assertions already passing, and 31 controls. The repaired owner and caller suites pass all 63 tests.
- Paired normal standalone mock-dev browser flow: 15 states per phase, correcting all 10 observed caption mismatches and preserving five healthy controls. An independent audit verified 18 other DOM fields, selection traces and matching Usage request multisets, including the 50-row cap, exact-50/no-overflow case, ascending sort, query/hour intersections and separate Shift-selection comparison.
- All 18 before/after screenshots were inspected. Served module source maps match the exact baseline and candidate owner bytes; the preview's synthetic build ID is not used as source identity. The first driver attempt is retained as a failed setup assertion: the fresh page correctly requested `agentScope: all`, while that driver expected `agentId: main`. The corrected driver checks the actual all-agent request contract; all 51 synthetic rows belong to main.
- Full changed-file checks passed, including type checks, lint, formatting and i18n. Normal `pnpm ui:build` passed with 832 finalized sidecars verified and 1,969 output files hashed; the three changed source files remained unchanged.

The browser proof uses the real running Control UI with synthetic Gateway responses, not a live Gateway or provider. Both phases have two expected 404s for the same missing synthetic Riley avatar and no page errors. Production-bundle verification is separate from the source-dev browser captures.

One managed P0–P2 review completed scoped-clean with zero findings. Commit `16bb14625a237934e7a7742ed83e22732fea49b6` preserves the exact reviewed and built patch `b4006770d4daf176733c49387c58a6e5d4bbaf3d28e417ec20061eb14df70c74`. The relevant Usage owner/caller/selection files remain unchanged on inspected main `2a6b2ed89f0ef27d0dabc436ed4f429f58db7f98`.

![Before: All says 51 shown while displaying 50 rows](https://github.com/user-attachments/assets/3d019123-fa56-4e1e-a87c-2815524b274c)

![After: All shows 50 shown and 51 total](https://github.com/user-attachments/assets/031360a5-a14e-445a-b689-2410114f29f8)

![Before: empty Recently viewed says 51 shown](https://github.com/user-attachments/assets/c5a9fcb1-9900-419a-b73c-7c9476046f0c)

![After: empty Recently viewed says 0 shown](https://github.com/user-attachments/assets/c82a9289-63ae-42c6-90d5-9d57e3864fab)


### ClawSweeper before-merge item: attachment inspection resolved

The only item in the 01:53 UTC review was that its attachment fetches failed. On September 8 at 02:01 UTC, all four published attachment URLs returned HTTP 200 with PNG bytes identical to the retained captures. A separate reviewer then personally inspected every full frame: All changes from “51 shown” to “50 shown · 51 total”; empty Recently viewed changes from “51 shown” to “0 shown · 51 total,” with the active tab and “No recent sessions” visible together. The frames contain only verified synthetic fixture content.

This resolves the attachment-access and independent pixel-inspection concern. The 50-row cardinality and overflow assertions remain supported by the separately audited DOM evidence; the All screenshots show the beginning of that list.

| Capture | Published PNG SHA-256 |
| --- | --- |
| Before All | `2194e714ece55886575f54cd7ba927843351042a2f437b2edf2566a75683329f` |
| After All | `56f89a050477b02a26c5f7bcb661e2bb30a7827f15b13fbd5ec8cfc09b580985` |
| Before empty Recent | `db03382a16c1015772b9201345835e1255c61e5d702a86cb18b813db8005e6c0` |
| After empty Recent | `0d6accd197ae44ced63f338facbc19ee967d5ffad101081539452f05222d9d6c` |

Exact-head CI [34177785779](https://github.com/openclaw/openclaw/actions/runs/34177785779) passed 90 jobs with 12 expected skips on signed commit `16bb14625a237934e7a7742ed83e22732fea49b6`.
