### PR TITLE
refactor(qa): remove unused script test accessors

### DIFF
--- a/scripts/qa-e2e.ts
+++ b/scripts/qa-e2e.ts
@@ -27,11 +27,7 @@ export function enablePrivateQaScriptEnv(env: NodeJS.ProcessEnv = process.env) {
   env.OPENCLAW_DISABLE_BUNDLED_PLUGINS = "0";
 }
 
-export function resolveQaE2eOutputPath(argv: readonly string[] = process.argv.slice(2)) {
-  return parseQaE2eArgs(argv).outputPath;
-}
-
-export function usage(): string {
+function usage(): string {
   return `Usage: pnpm qa:e2e [--output <path>]
 
 Options:

--- a/scripts/qa-lab-up.ts
+++ b/scripts/qa-lab-up.ts
@@ -42,9 +42,7 @@ function parseQaLabUpArgs(argv: readonly string[]) {
 }
 
 export const qaLabUpTesting = {
-  parseQaLabUpArgs,
   runQaLabUp,
-  usage,
 };
 
 type QaLabRuntime = typeof import("../extensions/qa-lab/src/cli.runtime.ts");

--- a/test/scripts/qa-e2e.test.ts
+++ b/test/scripts/qa-e2e.test.ts
@@ -1,12 +1,7 @@
 // Qa E2E tests cover qa e2e script behavior.
 import { describe, expect, it, vi } from "vitest";
 import type { QaSelfCheckResult } from "../../extensions/qa-lab/api.js";
-import {
-  enablePrivateQaScriptEnv,
-  main,
-  parseQaE2eArgs,
-  resolveQaE2eOutputPath,
-} from "../../scripts/qa-e2e.js";
+import { enablePrivateQaScriptEnv, main, parseQaE2eArgs } from "../../scripts/qa-e2e.js";
 
 function makeSelfCheckResult(status: "pass" | "fail"): QaSelfCheckResult {
   return {
@@ -47,12 +42,12 @@ describe("qa-e2e script", () => {
   });
 
   it("resolves the default self-check report path", () => {
-    expect(resolveQaE2eOutputPath([])).toBeUndefined();
-    expect(resolveQaE2eOutputPath([".artifacts/custom.md"])).toBe(".artifacts/custom.md");
-    expect(resolveQaE2eOutputPath(["--output", ".artifacts/custom.md"])).toBe(
+    expect(parseQaE2eArgs([]).outputPath).toBeUndefined();
+    expect(parseQaE2eArgs([".artifacts/custom.md"]).outputPath).toBe(".artifacts/custom.md");
+    expect(parseQaE2eArgs(["--output", ".artifacts/custom.md"]).outputPath).toBe(
       ".artifacts/custom.md",
     );
-    expect(resolveQaE2eOutputPath(["--", ".artifacts/custom.md"])).toBe(".artifacts/custom.md");
+    expect(parseQaE2eArgs(["--", ".artifacts/custom.md"]).outputPath).toBe(".artifacts/custom.md");
   });
 
   it("prints help before enabling private QA or loading QA Lab", async () => {


### PR DESCRIPTION
## What Problem This Solves

The QA script tests retain accessors that the commands no longer use. In particular, output-path assertions exercise a wrapper around the real parser, while QA Lab still exports two test members whose consumers were removed in an earlier cleanup.

## Why This Change Was Made

Remove the unused parser/help members and help export, and make the existing four output-path assertions call the same parser as the command. Keep the run boundary, lazy loading, default report ownership, environment handling, and every existing test case.

This is maintainer-requested test-seam cleanup. Tooling: +1/-7 (net -6). Tests: +5/-10 (net -5). No parser policy or QA runtime behavior changes.

## User Impact

No user-facing behavior change. The source commands retain their flags, help, errors, exit codes, and report destinations; maintainers have fewer test-only entry points to preserve.

## Evidence

All 30 existing QA E2E, QA Lab, and sibling report CLI cases pass before and after, with the same case inventory. Twelve additional real source CLI invocations preserve exact arguments, exit codes, standard output, and standard error. These cover help and invalid-input paths and do not start Docker or a private QA runtime.

```sh
node scripts/run-vitest.mjs test/scripts/qa-e2e.test.ts test/scripts/qa-lab-up.test.ts test/scripts/qa-report-cli.test.ts
```

Scoped formatting and diff checks pass. Independent Codex review is clean through P2. The normal changed-file gate passed all 19 checks, including script and root-test TypeScript graphs and scoped lint, on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/34177677381). The one-shot lease and temporary checkout were cleaned up, and the source remained unchanged.

The first gate attempt stopped before any checks because its runner used unsupported Node 25. The successful retry used the current installed Crabbox and the configured Testbox runner; no source, assertion, or runtime requirement was weakened.
