### PR TITLE
fix(googlechat): render Markdown in conversational replies

### DIFF
--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -146,9 +146,9 @@ export async function deliverGoogleChatReply(params: {
       deliveryThreadName = sent?.threadName?.trim() || deliveryThreadName;
     }
   };
-  const chunks = core.channel.text
-    .chunkMarkdownTextWithMode(reply.text, chunkLimit, chunkMode)
-    .flatMap((chunk) => formatGoogleChatTextChunks(chunk, chunkLimit));
+  const chunks = formatGoogleChatTextChunks(reply.text, chunkLimit).flatMap((chunk) =>
+    core.channel.text.chunkMarkdownTextWithMode(chunk, chunkLimit, chunkMode),
+  );
   if (reply.hasText && !chunks.some((chunk) => chunk)) {
     try {
       if (typingMessage) {

--- a/extensions/googlechat/src/monitor-reply-delivery.ts
+++ b/extensions/googlechat/src/monitor-reply-delivery.ts
@@ -10,6 +10,7 @@ import {
   sendGoogleChatMessage,
   updateGoogleChatMessage,
 } from "./api.js";
+import { formatGoogleChatTextChunks } from "./format.js";
 import type { GoogleChatCoreRuntime, GoogleChatRuntimeEnv } from "./monitor-types.js";
 
 export type GoogleChatTypingMessage =
@@ -145,7 +146,22 @@ export async function deliverGoogleChatReply(params: {
       deliveryThreadName = sent?.threadName?.trim() || deliveryThreadName;
     }
   };
-  const chunks = core.channel.text.chunkMarkdownTextWithMode(reply.text, chunkLimit, chunkMode);
+  const chunks = core.channel.text
+    .chunkMarkdownTextWithMode(reply.text, chunkLimit, chunkMode)
+    .flatMap((chunk) => formatGoogleChatTextChunks(chunk, chunkLimit));
+  if (reply.hasText && !chunks.some((chunk) => chunk)) {
+    try {
+      if (typingMessage) {
+        await deleteGoogleChatMessage({ account, messageName: typingMessage.name });
+      }
+    } catch (err) {
+      runtime.error?.(`Google Chat typing cleanup failed: ${String(err)}`);
+    }
+    throw new PlatformMessageNotDispatchedError(
+      "Google Chat reply has no visible text after formatting.",
+      { cause: undefined, retryable: false },
+    );
+  }
   for (const chunk of chunks) {
     if (!chunk) {
       continue;

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -69,6 +69,64 @@ afterAll(() => {
 });
 
 describe("Google Chat reply delivery", () => {
+  it("formats Markdown for typing updates and subsequent sends", async () => {
+    const core = createCore({ chunks: ["**first**", "**second**"] });
+
+    await deliverGoogleChatReply({
+      payload: { text: "**first**\n\n**second**", replyToId: "spaces/AAA/threads/root" },
+      account,
+      spaceId: "spaces/AAA",
+      runtime: createRuntime(),
+      core,
+      config,
+      typingMessage: createGoogleChatTypingMessage({
+        messageName: "spaces/AAA/messages/typing",
+        requestedThreadName: "spaces/AAA/threads/root",
+        deliveredThreadName: "spaces/AAA/threads/root",
+      }),
+    });
+
+    expect(mocks.updateGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      messageName: "spaces/AAA/messages/typing",
+      text: "*first*",
+    });
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      space: "spaces/AAA",
+      text: "*second*",
+      thread: "spaces/AAA/threads/root",
+    });
+  });
+
+  it("cleans up typing and rejects text removed by formatting", async () => {
+    await expect(
+      deliverGoogleChatReply({
+        payload: { text: "<div></div>" },
+        account,
+        spaceId: "spaces/AAA",
+        runtime: createRuntime(),
+        core: createCore(),
+        config,
+        typingMessage: createGoogleChatTypingMessage({
+          messageName: "spaces/AAA/messages/typing",
+        }),
+      }),
+    ).rejects.toSatisfy(
+      (error: unknown) =>
+        error instanceof PlatformMessageNotDispatchedError &&
+        !error.retryable &&
+        error.message === "Google Chat reply has no visible text after formatting.",
+    );
+
+    expect(mocks.deleteGoogleChatMessage).toHaveBeenCalledWith({
+      account,
+      messageName: "spaces/AAA/messages/typing",
+    });
+    expect(mocks.updateGoogleChatMessage).not.toHaveBeenCalled();
+    expect(mocks.sendGoogleChatMessage).not.toHaveBeenCalled();
+  });
+
   it("does not resend the first chunk when the typing update result is ambiguous", async () => {
     const core = createCore({ chunks: ["first chunk", "second chunk"] });
     const runtime = createRuntime();

--- a/extensions/googlechat/src/monitor.reply-delivery.test.ts
+++ b/extensions/googlechat/src/monitor.reply-delivery.test.ts
@@ -1,5 +1,6 @@
 // Googlechat tests cover monitor.reply delivery plugin behavior.
 import { PlatformMessageNotDispatchedError } from "openclaw/plugin-sdk/error-runtime";
+import { chunkMarkdownTextWithMode } from "openclaw/plugin-sdk/reply-chunking";
 import { afterAll, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../runtime-api.js";
 import type { ResolvedGoogleChatAccount } from "./accounts.js";
@@ -36,7 +37,10 @@ function createCore(params?: {
     channel: {
       text: {
         resolveChunkMode: vi.fn(() => "markdown"),
-        chunkMarkdownTextWithMode: vi.fn((text: string) => params?.chunks ?? [text]),
+        chunkMarkdownTextWithMode: vi.fn(
+          (text: string, limit: number, mode: "length" | "newline") =>
+            params?.chunks ?? chunkMarkdownTextWithMode(text, limit, mode),
+        ),
       },
       media: {
         readRemoteMediaBuffer: vi.fn(async () => params?.media ?? { buffer: Buffer.from("image") }),
@@ -70,14 +74,19 @@ afterAll(() => {
 
 describe("Google Chat reply delivery", () => {
   it("formats Markdown for typing updates and subsequent sends", async () => {
-    const core = createCore({ chunks: ["**first**", "**second**"] });
+    const first = "a".repeat(55);
+    const second = "b".repeat(55);
+    const limitedAccount = {
+      ...account,
+      config: { ...account.config, textChunkLimit: 64 },
+    } as ResolvedGoogleChatAccount;
 
     await deliverGoogleChatReply({
-      payload: { text: "**first**\n\n**second**", replyToId: "spaces/AAA/threads/root" },
-      account,
+      payload: { text: `**${first}**\n\n**${second}**`, replyToId: "spaces/AAA/threads/root" },
+      account: limitedAccount,
       spaceId: "spaces/AAA",
       runtime: createRuntime(),
-      core,
+      core: createCore(),
       config,
       typingMessage: createGoogleChatTypingMessage({
         messageName: "spaces/AAA/messages/typing",
@@ -86,17 +95,42 @@ describe("Google Chat reply delivery", () => {
       }),
     });
 
-    expect(mocks.updateGoogleChatMessage).toHaveBeenCalledWith({
-      account,
+    expect(mocks.updateGoogleChatMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.updateGoogleChatMessage.mock.calls[0]?.[0]).toMatchObject({
+      account: limitedAccount,
       messageName: "spaces/AAA/messages/typing",
-      text: "*first*",
     });
-    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledWith({
-      account,
+    expect(mocks.updateGoogleChatMessage.mock.calls[0]?.[0]?.text.trim()).toBe(`*${first}*`);
+    expect(mocks.sendGoogleChatMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.sendGoogleChatMessage.mock.calls[0]?.[0]).toMatchObject({
+      account: limitedAccount,
       space: "spaces/AAA",
-      text: "*second*",
       thread: "spaces/AAA/threads/root",
     });
+    expect(mocks.sendGoogleChatMessage.mock.calls[0]?.[0]?.text.trim()).toBe(`*${second}*`);
+  });
+
+  it("preserves reference links across configured source chunk boundaries", async () => {
+    const replyText = `${"A".repeat(45)} [docs][ref]\n\n[ref]: https://example.com`;
+    const limitedAccount = {
+      ...account,
+      config: { ...account.config, textChunkLimit: 64 },
+    } as ResolvedGoogleChatAccount;
+
+    await deliverGoogleChatReply({
+      payload: { text: replyText },
+      account: limitedAccount,
+      spaceId: "spaces/AAA",
+      runtime: createRuntime(),
+      core: createCore(),
+      config,
+    });
+
+    const deliveredText = mocks.sendGoogleChatMessage.mock.calls
+      .map((call) => call[0]?.text)
+      .join("");
+    expect(deliveredText).toContain("<https://example.com|docs>");
+    expect(deliveredText).not.toContain("[ref]");
   });
 
   it("cleans up typing and rejects text removed by formatting", async () => {


### PR DESCRIPTION
Closes #141625

## What Problem This Solves

Google Chat conversational replies bypass the plugin's existing Markdown renderer. CommonMark such as `**bold**` therefore reaches both typing-message updates and ordinary sends as raw syntax instead of Google Chat's native markup.

## Why This Change Was Made

The local reply-delivery owner now renders the complete Markdown document with `formatGoogleChatTextChunks` before applying the configured source chunk mode. This preserves document-level constructs such as reference links across chunk boundaries while keeping typing updates, direct sends, and missing-placeholder fallback sends on the same plugin-owned formatting path.

If formatting removes all visible content from an otherwise non-empty reply, delivery now removes an existing typing placeholder and returns a non-retryable not-dispatched error instead of silently completing with stale UI.

Non-goals: this does not change Google Chat formatting semantics, thread routing, low-level API serialization, configuration, or shared channel behavior.

## User Impact

Google Chat conversational replies render supported Markdown natively instead of exposing raw CommonMark delimiters. Existing chunk-mode selection, thread continuity, attachment fallback, and partial-delivery behavior remain unchanged. Reference-link destinations remain intact even when the configured message limit places their definitions beyond a source chunk boundary.

## Evidence

- Pre-fix at `1d5cb72a13ce70af9cf7e6afa2cf63cd33e93fcf`: the delivery-boundary regression failed because the typing update received `**first**` instead of `*first*`.
- Post-fix at `432735ae2d1ccb81fe73a4ae9c1bb9a567b25369`: the same regression, the review-supplied 64-character reference-link boundary case, and sibling suites passed.
- `node scripts/run-vitest.mjs extensions/googlechat/src/monitor.reply-delivery.test.ts extensions/googlechat/src/monitor.reply-delivery-failure.test.ts extensions/googlechat/src/monitor.test.ts extensions/googlechat/src/format.test.ts` — 4 files, 91 tests passed.
- `node scripts/check-changed.mjs --base 1d5cb72a13ce70af9cf7e6afa2cf63cd33e93fcf` — passed for the extension and extension-test lanes.
- `git diff --check` — passed.
- Autoreview found no actionable P0/P1 findings after the chunk-order correction.
- Production LOC: +17/-1. Tests: +93/-1.

The local tests above use the isolated Google Chat delivery boundary with mocked transport calls; the PR author did not send a live Google Chat message. The test delegates to the real source chunker for the reported cross-boundary case.

### Reporter-provided live Google Chat verification

On September 8, 2026 at 23:30 UTC, original reporter @pbreault supplied [live verification and a screenshot](https://github.com/openclaw/openclaw/pull/141752#issuecomment-5593339079) from their Google Chat environment.

- The reporter manually applied the equivalent of commit `432735ae2d1ccb81fe73a4ae9c1bb9a567b25369` to the compiled plugin installed on their gateway, wiring `formatGoogleChatTextChunks` into `deliverGoogleChatReply` before chunking, and restarted the gateway.
- They prompted the agent through a real conversation to produce bold, italic, strikethrough, inline code, headings, nested bullets, a numbered list, a blockquote, a fenced code block, and a labeled link.
- They report native Google Chat rendering, including both the typing-placeholder update and the final delivered message, with no literal Markdown delimiters, gateway log errors, or dropped/empty replies. The linked screenshot shows the rendered result.

Evidence boundaries: this is independent reporter-provided live validation of a manually applied equivalent patch, not an exact-checkout run performed by the PR author. The report does not explicitly demonstrate a long reply split into multiple subsequent messages or the cross-chunk reference-link case; those remain covered by the local regression tests above, not claimed as live-tested. The screenshot shows the result, not a recording of the placeholder-update lifecycle. This evidence is submitted for review; no proof-acceptance verdict is claimed.

### Co-author credit

Thanks @pbreault (Philippe Breault) for the original diagnosis, source-level reproduction, and live Google Chat validation. Philippe has [confirmed consent and the attribution details](https://github.com/openclaw/openclaw/pull/141752#issuecomment-5594639465).

Please preserve the following co-author trailer in the final merge/squash commit message (separated from the preceding text by a blank line):

```text
Co-authored-by: Philippe Breault <279299+pbreault@users.noreply.github.com>
```

The co-author trailer is now included in commit `897d83a856a98979114fb3e51914cb641cb7f0b9`. This is an attribution-only amendment of `432735ae2d1ccb81fe73a4ae9c1bb9a567b25369`: the Git trees are identical, with no source or test changes. The earlier validation remains recorded against the original SHA; tests were not rerun for this commit-message-only amendment. Please retain the trailer when squashing.
