### PR TITLE
fix: preserve optional tool arguments in Copilot Responses

### DIFF
--- a/src/agents/openai-strict-tool-setting.test.ts
+++ b/src/agents/openai-strict-tool-setting.test.ts
@@ -1,0 +1,142 @@
+import { streamOpenAIResponses } from "@openclaw/ai/internal/openai";
+import type { Context } from "@openclaw/ai/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { resolveOpenAIStrictToolSetting } from "./openai-strict-tool-setting.js";
+import {
+  buildOpenAIResponsesParams,
+  makeResponsesModel,
+} from "./openai-transport-stream.test-harness.js";
+
+const unexpectedFetch = vi.fn(() => {
+  throw new Error("Unexpected network request");
+});
+
+beforeEach(() => {
+  unexpectedFetch.mockClear();
+  vi.stubGlobal("fetch", unexpectedFetch);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("Copilot Responses optional tool fields", () => {
+  it.each(
+    (["provider", "transport"] as const).flatMap((entrypoint) =>
+      [undefined, false, true].map((supportsStrictMode) => ({ entrypoint, supportsStrictMode })),
+    ),
+  )(
+    "preserves optional UUIDs in $entrypoint requests with supportsStrictMode=$supportsStrictMode",
+    async ({ entrypoint, supportsStrictMode }) => {
+      const model = makeResponsesModel({
+        provider: "github-copilot",
+        baseUrl: "https://api.individual.githubcopilot.com",
+        reasoning: false,
+        ...(supportsStrictMode === undefined ? {} : { compat: { supportsStrictMode } }),
+      });
+      const parameters = {
+        type: "object",
+        properties: {
+          title: { type: "string" },
+          folder_id: { type: "string", format: "uuid" },
+        },
+        required: ["title"],
+        additionalProperties: false,
+      };
+      const originalParameters = structuredClone(parameters);
+      const context: Context = {
+        messages: [{ role: "user", content: "Create an item without a folder", timestamp: 1 }],
+        tools: [{ name: "create_item", description: "Create an item", parameters }],
+      };
+      let payload: unknown;
+      if (entrypoint === "transport") {
+        payload = buildOpenAIResponsesParams(model, context, undefined);
+      } else {
+        // Exercise the provider's real builder, but stop before any API request.
+        const stream = streamOpenAIResponses(model, context, {
+          apiKey: "synthetic-key",
+          onPayload: (request) => {
+            payload = request;
+            throw new Error("Request captured before dispatch");
+          },
+        });
+        const result = await stream.result();
+        expect(result.stopReason).toBe("error");
+        expect(result.errorMessage).toContain("Request captured before dispatch");
+      }
+      expect(unexpectedFetch).not.toHaveBeenCalled();
+      // Check serialized request bytes as well as the caller's original schema:
+      // the UUID stays optional and string-only, without nullable substitutes.
+      const serializedPayload = JSON.stringify(payload);
+      expect(JSON.parse(serializedPayload)).toHaveProperty("tools", [
+        {
+          type: "function",
+          name: "create_item",
+          description: "Create an item",
+          strict: false,
+          parameters: originalParameters,
+        },
+      ]);
+      expect(parameters).toEqual(originalParameters);
+    },
+  );
+});
+
+describe("resolveOpenAIStrictToolSetting sibling routes", () => {
+  it.each([
+    {
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://api.openai.com/v1",
+      expected: true,
+    },
+    {
+      provider: "openai",
+      api: "openai-completions",
+      baseUrl: "https://api.openai.com/v1",
+      expected: true,
+    },
+    {
+      provider: "azure-openai",
+      api: "openai-responses",
+      baseUrl: "https://example.openai.azure.com",
+      expected: true,
+    },
+    {
+      provider: "azure-openai-responses",
+      api: "azure-openai-responses",
+      baseUrl: "https://example.openai.azure.com/openai/responses",
+      expected: true,
+    },
+    {
+      provider: "openai",
+      api: "openai-responses",
+      baseUrl: "https://proxy.example.com/v1",
+      expected: undefined,
+    },
+    {
+      provider: "custom-provider",
+      api: "openai-responses",
+      baseUrl: "https://proxy.example.com/v1",
+      expected: undefined,
+    },
+    {
+      provider: "github-copilot",
+      api: "openai-completions",
+      baseUrl: "https://api.individual.githubcopilot.com",
+      expected: undefined,
+    },
+    {
+      provider: "github-copilot",
+      api: "anthropic-messages",
+      baseUrl: "https://api.individual.githubcopilot.com",
+      expected: undefined,
+    },
+  ])("keeps $provider / $api at $baseUrl unchanged", ({ expected, ...model }) => {
+    expect(resolveOpenAIStrictToolSetting(model)).toBe(expected);
+    expect(resolveOpenAIStrictToolSetting(model, { supportsStrictMode: false })).toBe(expected);
+    expect(resolveOpenAIStrictToolSetting(model, { supportsStrictMode: true })).toBe(
+      expected ?? false,
+    );
+  });
+});

--- a/src/agents/openai-strict-tool-setting.ts
+++ b/src/agents/openai-strict-tool-setting.ts
@@ -53,6 +53,11 @@ export function resolveOpenAIStrictToolSetting(
   if (resolvesToNativeOpenAIStrictTools(model, options?.transport ?? "stream")) {
     return true;
   }
+  // Responses can normalize an omitted strict flag into strict mode. Explicitly
+  // opt Copilot out so optional tool fields stay optional, rather than nullable.
+  if (model.provider === "github-copilot" && model.api === "openai-responses") {
+    return false;
+  }
   if (options?.supportsStrictMode) {
     return false;
   }


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**Allow edits from maintainers** is enabled for this fork PR.

</details>

## What Problem This Solves

Resolves a problem where users calling tools through GitHub Copilot's Responses route can be asked to supply optional fields, including optional UUID references, instead of leaving them absent. This affects workflows such as MCP tools with an optional association ID: supplying `null` or an invented ID is not equivalent to omitting the field and may fail validation or change the requested association.

This is a candidate fix for the request-serialization boundary. The provider's downstream behavior has not yet been verified with a live before/after test.

## Why This Change Was Made

Explicitly send `strict: false` for `github-copilot` models using `openai-responses`, retaining the caller's original schema rather than making optional fields required or nullable. The change runs after native OpenAI/Azure strict-mode resolution and leaves other provider/API routes unchanged; it does not change MCP schemas, tool permissions, or stored records.

## User Impact

Copilot Responses tool calls should be able to omit genuinely optional arguments without substituting nulls or fabricated values. Native OpenAI/Azure strict handling is preserved, and no configuration or data migration is required.

## Evidence

### Source regression proof — September 7, 2026

Verified against unchanged PR head `f70801939e42501a46bdb2ac8519360f15cf5127` on Windows x64, Node 24.18.0, Vitest 5.0.0.

```powershell
node scripts/run-vitest.mjs src/agents/openai-strict-tool-setting.test.ts src/agents/schema-normalization-runtime-contract.test.ts packages/ai/src/providers/openai-responses-tools.integration.test.ts --maxWorkers=1 --reporter=verbose
```

Runs were serialized with a task-specific `OPENCLAW_VITEST_FS_MODULE_CACHE_PATH` to avoid sharing a module-cache path with other commands. No test or runner timeout settings were changed.

Sanitized terminal result:

```text
schema-normalization-runtime-contract.test.ts: 4 passed (4)
openai-responses-tools.integration.test.ts:    7 passed (7)
openai-strict-tool-setting.test.ts:           14 passed (14)
[test] passed 3 Vitest shards in 307.55s
Exit: 0
```

**Negative control:** temporarily substituted only the original production resolver from parent `9fb6b2b5ec3b2cf1889912c5d6f030ffe31d2573`, leaving the new tests unchanged. All six Copilot provider/transport cases failed specifically because the serialized tool lacked `strict: false`; all eight sibling-route cases passed. The production file was restored byte-for-byte before the successful final run above.

```text
Original resolver: 6 failed / 8 passed; exit 1
Expected tool: ... "strict": false ...
Received tool: strict property absent
Restored candidate: 14 passed / 0 failed
```

The 14-case core suite uses the real production host policy and both Responses request builders. It covers compatibility settings absent/false/true, optional string-only UUID properties, unchanged caller schemas, and sibling provider/API routes. Its provider requests are captured before network dispatch. The seven-case package suite uses actual SDK HTTP serialization through a task-owned loopback server with an injected policy; that is **not** live Copilot proof.

No source/test changes, weakened assertions, additional mocks, skipped tests, or timeout increases were needed. Cold transformation was substantial (170.83s in the adjacent schema suite); this run does not establish the root cause of the earlier watchdog failures. Checkout remained clean at the reviewed head.

Focused formatting and installed oxlint passed (230 rules, zero warnings/errors), as did `git diff --check`. The lint-wrapper attempt timed out; its result is not counted as passing. Full build, whole-project typecheck, and the full test suite remain unverified.

### Review follow-up and remaining live-proof blocker

ClawSweeper's [review](https://github.com/openclaw/openclaw/pull/141755#issuecomment-5578009202) found no actionable introduced correctness or security defect. Its source-test completion request is now addressed by the results above. Local autoreview previously stopped at its required scanner preflight; no clean local autoreview verdict is claimed and the gate was not bypassed.

**Live Copilot validation remains outstanding.** Offline serialization and loopback results do not prove that Copilot accepts this setting or returns a tool call omitting the optional UUID. The available test environment has no supported isolated credential route for the candidate checkout. The running Gateway's authenticated session was not exported, and the live installation was not patched or restarted to obtain proof.

The remaining proof needs an authorized isolated Copilot test environment: submit the same synthetic tool/prompt before and after the change, capture sanitized tool-schema/request and generated-argument output, and verify that the after-fix arguments omit `folder_id` entirely rather than supplying `null` or an invented value. No CRM tool needs to execute. If the baseline already omits the field, report that honestly rather than claiming an end-to-end reproduction.

This remains a draft pending real provider-contract validation and required maintainer checks. No live installation, configuration, database, or user-record changes were made. No UI changes; screenshots are not applicable.
