### PR TITLE
fix(cli): cross-reference `openclaw qr` from devices help

### DIFF
--- a/src/cli/devices-cli.test.ts
+++ b/src/cli/devices-cli.test.ts
@@ -1321,6 +1321,19 @@ describe("devices cli rename", () => {
   });
 });
 
+describe("devices cli help", () => {
+  it("cross-references `openclaw qr` for mobile app setup codes", () => {
+    const program = new Command();
+    registerDevicesCli(program);
+
+    const devices = program.commands.find((cmd) => cmd.name() === "devices");
+    const joinCode = devices?.commands.find((cmd) => cmd.name() === "join-code");
+
+    expect(devices?.description()).toContain("openclaw qr");
+    expect(joinCode?.description()).toContain("openclaw qr");
+  });
+});
+
 describe("devices cli join-code", () => {
   it("mints with admin scope and prints the pasteable command", async () => {
     const joinUrl = `https://gateway.example/j/${"a".repeat(22)}`;

--- a/src/cli/devices-cli.ts
+++ b/src/cli/devices-cli.ts
@@ -26,7 +26,11 @@ const devicesCallOpts = (cmd: Command, defaults?: { timeoutMs?: number }) =>
     .option("--json", "Output JSON", false);
 
 export function registerDevicesCli(program: Command) {
-  const devices = program.command("devices").description("Device pairing and auth tokens");
+  const devices = program
+    .command("devices")
+    .description(
+      "Device pairing and auth tokens (for mobile app setup codes, use `openclaw qr` instead)",
+    );
 
   devicesCallOpts(
     devices
@@ -41,7 +45,9 @@ export function registerDevicesCli(program: Command) {
   devicesCallOpts(
     devices
       .command("join-code")
-      .description("Mint a single-use node onboarding URL")
+      .description(
+        "Mint a single-use node onboarding URL (not a mobile app setup code; use `openclaw qr` for that)",
+      )
       .action(async (opts: DevicesRpcOpts) => {
         const { runDevicesJoinCodeCommand } = await loadDevicesRuntime();
         await runDevicesJoinCodeCommand(opts);

--- a/src/cli/program/subcli-descriptors.ts
+++ b/src/cli/program/subcli-descriptors.ts
@@ -84,7 +84,8 @@ const subCliCommandDescriptors = [
   },
   {
     name: "devices",
-    description: "Device pairing and auth tokens",
+    description:
+      "Device pairing and auth tokens (for mobile app setup codes, use `openclaw qr` instead)",
     hasSubcommands: true,
     machineOutput: ({ argv }) => isDevicesMachineOutput(argv),
     parentDefaultHelp: true,


### PR DESCRIPTION
Addresses the CLI-help portion of #141698. Related documentation work: #136277.

## What Problem This Solves

Fixes an issue where operators reading `devices --help` or `devices join-code --help` had no cross-reference to the command that generates mobile app setup codes.

## Why This Change Was Made

The descriptions now direct mobile setup-code users to the existing `openclaw qr` command. Join-code help also explains that its single-use node onboarding URL is not a mobile app setup code. The root command catalog uses the same devices description.

## User Impact

Operators can choose the correct existing command from devices help. Pairing actions, credentials, setup-code encoding, options and output modes retain their existing behavior.

Android already displays `openclaw qr`, as the reporter clarified. This PR covers CLI help only. The broader issue remains open for the separate guide, app-placeholder and join-URL redemption proposals; documentation PR #136277 remains separate.

## Evidence

The real packaged launcher was exercised on baseline `9bf06f7cc0f` and candidate `b5968c8b096` with isolated state. Baseline devices help had only “Device pairing and auth tokens”; nested help had only “Mint a single-use node onboarding URL.”

Candidate output at an actual 80-column terminal:

```text
Usage: openclaw devices [options] [command]

Device pairing and auth tokens (for mobile app setup codes, use `openclaw qr`
instead)
```

Candidate nested help at an actual 120-column terminal:

```text
Usage: openclaw devices join-code [options]

Mint a single-use node onboarding URL (not a mobile app setup code; use `openclaw qr` for that)
```

- Independent behavior acceptance passed all 20 candidate captures: 14 plain help commands and root/devices/join-code help at actual 80- and 120-column terminal widths. Full arguments, options, defaults and existing terminal behavior were compared with baseline.
- Packaged root help displays the matching devices guidance; `qr --help` exposes the existing mobile producer and `--setup-code-only` option.
- The added regression fails on baseline for the missing `openclaw qr` guidance. All 105 focused registration, parser, lazy-loading, timeout and root-description checks pass, along with formatting and scoped lint.
- Independent source review found no actionable defect. No setup code, token, QR payload or join URL was generated. Unchanged mobile, encoder, profile and single-use redemption behavior was reviewed in source, not claimed as a live pairing test.

AI-assisted.
