### PR TITLE
fix(matrix): avoid false readiness failures after unrelated config updates

### DIFF
--- a/docs/gateway/configuration.md
+++ b/docs/gateway/configuration.md
@@ -810,7 +810,11 @@ openclaw gateway call config.patch --params '{
 ```
 
 `config.patch` records explicitly supplied values in the config file even when
-they equal the current runtime defaults. Unchanged runtime defaults stay omitted.
+they equal the current runtime defaults. Unchanged runtime defaults stay omitted. Its
+successful response includes `changedPaths`, the effective runtime paths changed
+after validation and secret restoration, or `[]` for a no-op. These paths contain
+no configuration values; clients can use them to distinguish a channel change
+from an unrelated write even when secret values are redacted.
 
 Both `config.apply` and `config.patch` accept `raw`, `baseHash`, `sessionKey`,
 `note`, and `restartDelayMs`. `baseHash` is required for both methods once a

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.observation.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.observation.test.ts
@@ -51,7 +51,7 @@ describe("matrix scenario observation", () => {
           };
         }
         if (method === "config.patch") {
-          return { hash: "config-hash", noop: true, ok: true };
+          return { hash: "config-hash", changedPaths: [], noop: true, ok: true };
         }
         if (method === "channels.status") {
           return {

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.test.ts
@@ -210,7 +210,7 @@ describe("matrix scenario environment", () => {
           }
           if (method === "config.patch") {
             patchCount += 1;
-            return { hash: `patched-${patchCount}`, ok: true };
+            return { hash: `patched-${patchCount}`, changedPaths: ["channels.matrix"], ok: true };
           }
           if (method === "channels.status") {
             statusCount += 1;
@@ -394,6 +394,7 @@ describe("matrix scenario environment", () => {
           if (method === "config.patch") {
             return {
               hash: "patched-config-hash",
+              changedPaths: ["channels.matrix"],
               ok: true,
             };
           }
@@ -537,7 +538,7 @@ describe("matrix scenario environment", () => {
             if (patchCount === 1) {
               throw new Error("config changed since last load");
             }
-            return { hash: "patched-config-hash", ok: true };
+            return { hash: "patched-config-hash", changedPaths: ["channels.matrix"], ok: true };
           }
           if (method === "channels.status") {
             statusCount += 1;
@@ -621,6 +622,7 @@ describe("matrix scenario environment", () => {
         if (method === "config.patch") {
           return {
             noop: true,
+            changedPaths: [],
             ok: true,
           };
         }
@@ -687,108 +689,127 @@ describe("matrix scenario environment", () => {
     expect(waitForConfigRestartSettle).not.toHaveBeenCalled();
   });
 
-  it("fails preparation when fresh account readiness exhausts the shared deadline", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    let configReadCount = 0;
-    let statusReadCount = 0;
-    const statusTimeouts: number[] = [];
-    const gateway = {
-      baseUrl: "http://127.0.0.1:12345",
-      runtimeEnv: {},
-      tempRoot: "/tmp/matrix-qa",
-      workspaceDir: "/tmp/matrix-qa/workspace",
-      call: vi.fn(
-        async (
-          method: string,
-          params?: unknown,
-          opts?: { deadlineMs?: number; timeoutMs?: number },
-        ) => {
-          if (method === "config.get") {
-            configReadCount += 1;
-            if (configReadCount === 1) {
-              return { config: {} };
+  it.each([
+    { changedPaths: ["channels.matrix.accounts.sut.accessToken"], requiresRestart: true },
+    { changedPaths: ["models.providers.openai.models"], requiresRestart: false },
+    { changedPaths: [], requiresRestart: false },
+  ])(
+    "requires a fresh account only for effective Matrix changes: $changedPaths",
+    async ({ changedPaths, requiresRestart }) => {
+      vi.useFakeTimers();
+      vi.setSystemTime(0);
+      let configReadCount = 0;
+      let statusReadCount = 0;
+      const statusTimeouts: number[] = [];
+      const gateway = {
+        baseUrl: "http://127.0.0.1:12345",
+        runtimeEnv: {},
+        tempRoot: "/tmp/matrix-qa",
+        workspaceDir: "/tmp/matrix-qa/workspace",
+        call: vi.fn(
+          async (
+            method: string,
+            params?: unknown,
+            opts?: { deadlineMs?: number; timeoutMs?: number },
+          ) => {
+            if (method === "config.get") {
+              configReadCount += 1;
+              if (configReadCount === 1) {
+                return { config: {} };
+              }
+              if (configReadCount === 2) {
+                return { hash: "config-hash" };
+              }
+              vi.setSystemTime(59_900);
+              return {
+                appliedConfigHash: "patched-config-hash",
+                configRevisionHash: "patched-config-hash",
+                hash: changedPaths.length === 0 ? "config-hash" : "patched-config-hash",
+              };
             }
-            if (configReadCount === 2) {
-              return { hash: "config-hash" };
+            if (method === "config.patch") {
+              return {
+                hash: "patched-config-hash",
+                changedPaths,
+                noop: changedPaths.length === 0,
+                ok: true,
+              };
             }
-            vi.setSystemTime(59_900);
-            return {
-              appliedConfigHash: "patched-config-hash",
-              configRevisionHash: "patched-config-hash",
-              hash: "patched-config-hash",
-            };
-          }
-          if (method === "config.patch") {
-            return { hash: "patched-config-hash", ok: true };
-          }
-          if (method === "channels.status") {
-            statusReadCount += 1;
-            statusTimeouts.push(opts?.timeoutMs ?? -1);
-            if (statusReadCount === 2) {
-              expect((params as { timeoutMs?: number } | undefined)?.timeoutMs).toBe(100);
-              vi.setSystemTime(60_000);
+            if (method === "channels.status") {
+              statusReadCount += 1;
+              statusTimeouts.push(opts?.timeoutMs ?? -1);
+              if (statusReadCount === 2) {
+                expect((params as { timeoutMs?: number } | undefined)?.timeoutMs).toBe(100);
+                if (requiresRestart) {
+                  vi.setSystemTime(60_000);
+                }
+              }
+              if (statusReadCount === 3) {
+                vi.setSystemTime(60_000);
+              }
+              return {
+                channelAccounts: {
+                  matrix: [
+                    {
+                      accountId: "sut",
+                      connected: true,
+                      healthState: "healthy",
+                      lastStartAt: 100,
+                      restartPending: false,
+                      running: true,
+                    },
+                  ],
+                },
+              };
             }
-            return {
-              channelAccounts: {
-                matrix: [
-                  {
-                    accountId: "sut",
-                    connected: true,
-                    healthState: "healthy",
-                    lastStartAt: 100,
-                    restartPending: false,
-                    running: true,
-                  },
-                ],
-              },
-            };
-          }
-          throw new Error(`unexpected gateway method ${method}`);
-        },
-      ),
-    };
-    const environment = createMatrixQaScenarioEnvironment({
-      accountId: "sut",
-      harness: { baseUrl: "http://127.0.0.1:8008", recording: {} } as never,
-      observedEvents: [],
-      provisioning: {
-        observationAccounts: {
-          driver: { accessToken: "driver-room-observation" },
-          observer: { accessToken: "observer-room-observation" },
-        },
-        driver: { accessToken: "fixture", userId: "@driver:test" },
-        observer: { accessToken: "fixture", userId: "@observer:test" },
-        roomId: "!room:test",
-        sut: { accessToken: "fixture", userId: "@sut:test" },
-        topology: { rooms: [] },
-      } as never,
-    });
-    const waitForConfigRestartSettle = vi.fn();
-    const preparing = environment.prepareFlow({
-      config: {},
-      gateway,
-      outputDir: "/tmp/matrix-qa/output",
-      scenarioId: "matrix-deadline",
-      scenarioTitle: "Matrix deadline",
-      timeoutMs: 8_000,
-      waitForConfigRestartSettle,
-    });
-    const rejection = expect(preparing).rejects.toThrow(
-      'matrix account "sut" did not become ready',
-    );
+            throw new Error(`unexpected gateway method ${method}`);
+          },
+        ),
+      };
+      const environment = createMatrixQaScenarioEnvironment({
+        accountId: "sut",
+        harness: { baseUrl: "http://127.0.0.1:8008", recording: {} } as never,
+        observedEvents: [],
+        provisioning: {
+          observationAccounts: {
+            driver: { accessToken: "driver-room-observation" },
+            observer: { accessToken: "observer-room-observation" },
+          },
+          driver: { accessToken: "fixture", userId: "@driver:test" },
+          observer: { accessToken: "fixture", userId: "@observer:test" },
+          roomId: "!room:test",
+          sut: { accessToken: "fixture", userId: "@sut:test" },
+          topology: { rooms: [] },
+        } as never,
+      });
+      const waitForConfigRestartSettle = vi.fn();
+      const preparing = environment.prepareFlow({
+        config: {},
+        gateway,
+        outputDir: "/tmp/matrix-qa/output",
+        scenarioId: "matrix-deadline",
+        scenarioTitle: "Matrix deadline",
+        timeoutMs: 8_000,
+        waitForConfigRestartSettle,
+      });
+      const outcome = requiresRestart
+        ? expect(preparing).rejects.toThrow('matrix account "sut" did not become ready')
+        : expect(preparing).resolves.toBeDefined();
 
-    await vi.runAllTimersAsync();
-    await rejection;
+      await vi.runAllTimersAsync();
+      await outcome;
 
-    expect(Date.now()).toBe(60_000);
-    expect(statusTimeouts).toEqual([5_000, 100]);
-    expect(
-      gateway.call.mock.calls.map((call) => (call[2] as { deadlineMs?: number }).deadlineMs),
-    ).toEqual(Array.from({ length: gateway.call.mock.calls.length }, () => 60_000));
-    expect(waitForConfigRestartSettle).not.toHaveBeenCalled();
-    expect(gateway.call.mock.calls.filter(([method]) => method === "config.patch")).toHaveLength(1);
-  });
+      expect(Date.now()).toBe(requiresRestart ? 60_000 : 59_900);
+      expect(statusTimeouts).toEqual([5_000, 100]);
+      expect(
+        gateway.call.mock.calls.map((call) => (call[2] as { deadlineMs?: number }).deadlineMs),
+      ).toEqual(Array.from({ length: gateway.call.mock.calls.length }, () => 60_000));
+      expect(waitForConfigRestartSettle).not.toHaveBeenCalled();
+      expect(gateway.call.mock.calls.filter(([method]) => method === "config.patch")).toHaveLength(
+        1,
+      );
+    },
+  );
 
   it("rejects a stale account start after a delayed failed pre-restart status read", async () => {
     vi.useFakeTimers();
@@ -834,7 +855,7 @@ describe("matrix scenario environment", () => {
           };
         }
         if (method === "config.patch") {
-          return { hash: "config-hash", noop: true, ok: true };
+          return { hash: "config-hash", changedPaths: [], noop: true, ok: true };
         }
         if (method === "channels.status") {
           statusReadCount += 1;

--- a/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
+++ b/extensions/qa-lab/src/live-transports/matrix/scenarios/scenario-environment.ts
@@ -33,6 +33,7 @@ type MatrixQaScenarioEnvironmentParams = {
 };
 
 type MatrixQaConfigPatchResult = {
+  changedPaths: string[];
   hash?: string;
   noop?: boolean;
   sentinel?: {
@@ -331,10 +332,6 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
       gatewayConfig,
       params.accountId,
     );
-    const matrixConfigChanged = !isDeepStrictEqual(
-      configSnapshot.config.channels?.matrix,
-      gatewayConfig.channels?.matrix,
-    );
     const patchStartedAt = Date.now();
     const accountStartAtBeforePatch = (
       await readMatrixAccountStatuses(input.gateway, 5_000, preparationDeadline).catch(() => [])
@@ -345,6 +342,9 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
       patch: gatewayPatch.patch,
       replacePaths: gatewayPatch.replacePaths,
     });
+    const matrixConfigChanged = patchResult.changedPaths.some(
+      (path) => path === "channels.matrix" || path.startsWith("channels.matrix."),
+    );
     if (!patchResult.hash) {
       throw new Error("Matrix QA config patch returned no persisted hash");
     }
@@ -356,9 +356,9 @@ export function createMatrixQaScenarioEnvironment(params: MatrixQaScenarioEnviro
       gateway: input.gateway,
     });
     await waitForMatrixAccountReady({
-      // Config writes acknowledge persisted state before a deferred channel
-      // reload completes. Require the changed Matrix account to actually restart
-      // so a later config patch cannot supersede this scenario's live runtime.
+      // Use the owner's effective paths: desired tokens differ from redacted
+      // snapshots even when unchanged, while real token rotations redact alike.
+      // Actual Matrix changes must still advance the channel generation.
       afterStartAt:
         matrixConfigChanged && patchResult.noop !== true
           ? (accountStartAtBeforePatch ?? patchStartedAt - 1)

--- a/src/gateway/server-methods/config.test.ts
+++ b/src/gateway/server-methods/config.test.ts
@@ -204,6 +204,32 @@ afterEach(() => {
   vi.clearAllMocks();
 });
 
+describe("config.patch effective change receipt", () => {
+  it.each([
+    { nextToken: "synthetic-old-token", expectedPaths: [] },
+    {
+      nextToken: "synthetic-new-token",
+      expectedPaths: ["channels.matrix.accounts.sut.accessToken"],
+    },
+  ])(
+    "reports persisted secret changes without values: $expectedPaths",
+    async ({ nextToken, expectedPaths }) => {
+      storedConfig = {
+        channels: { matrix: { accounts: { sut: { accessToken: "synthetic-old-token" } } } },
+      };
+      const { respond } = await invokeConfigPatch({
+        raw: { channels: { matrix: { accounts: { sut: { accessToken: nextToken } } } } },
+        baseHash: "base-hash",
+      });
+      expect(respond).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ changedPaths: expectedPaths }),
+        undefined,
+      );
+    },
+  );
+});
+
 describe("config application settlement", () => {
   it.each(
     (["config.patch", "config.apply"] as const).flatMap((method) =>

--- a/src/gateway/server-methods/config.ts
+++ b/src/gateway/server-methods/config.ts
@@ -707,6 +707,7 @@ async function respondWithConfigRestartWrite(params: {
         ? { hash: params.context.configRevisionProjector.projectRawHash(params.writeResult.hash) }
         : {}),
       config: redactConfigObject(params.writeResult.config, params.uiHints),
+      ...(params.mode === "config.patch" ? { changedPaths: params.changedPaths } : {}),
       ...preparedSecretDegradationPayload(params.preparedSecretsSnapshot),
       restart,
       sentinel: {
@@ -751,6 +752,7 @@ function respondConfigPatchNoop(params: {
     {
       ok: true,
       noop: true,
+      changedPaths: [],
       path: resolveGatewayConfigPath(params.snapshot),
       config: redactConfigObject(params.config, params.uiHints),
     },


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Matrix release verification rejects an already healthy, connected account after a configuration update that changes only provider model metadata. The release run had 81 passing scenarios and 12 failures at the same preparation gate; seven other scenarios needed a retry.

## Why This Change Was Made

The QA runner compared a redacted configuration snapshot with provisioned credentials and incorrectly inferred that Matrix must restart. `config.patch` now returns its canonical effective `changedPaths` (names only, including an empty list for a no-op), and Matrix preparation uses that receipt. Real Matrix credential changes still require a new account generation, alongside the existing applied-revision, health, connection, and deadline checks.

## User Impact

Matrix verification can proceed after unrelated configuration changes. Configuration API clients also receive authoritative change paths without exposing secret values. There are no configuration, protocol-version, or storage changes.

## Evidence

- Original Matrix failure artifacts: https://github.com/openclaw/openclaw/actions/runs/34175777625/artifacts/10037667475. Both representative failures show healthy accounts and Gateway writes changing only provider model arrays.
- Regression proof fails before the repair for the unrelated-write readiness timeout and missing effective token/no-op receipts, then passes with the repair.
- The five-file producer/consumer patch passed 104 owner/sibling tests (one existing skip), the full changed-file gate including all four type graphs, and independent P2 review. It applies byte-identically to current main with unchanged owner files. PR CI exposed one additional observation fixture missing the new no-op receipt; that fixture now matches production, and the observation plus environment suite passes all nine tests.
- A full Matrix transport run will qualify the integrated release candidate; the local proof covers the configuration and readiness boundaries.
