### PR TITLE
refactor(tests): share unreachable Gateway probe fixtures

### DIFF
--- a/src/commands/gateway-status.test.ts
+++ b/src/commands/gateway-status.test.ts
@@ -8,7 +8,10 @@ import type { inspectGatewayTlsCertificate as InspectGatewayTlsCertificate } fro
 import type { RuntimeEnv } from "../runtime.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { gatewayStatusCommand } from "./gateway-status.js";
-import { createSecretRefGatewayConfig } from "./gateway-status/test-support.js";
+import {
+  createUnreachableGatewayProbe,
+  createSecretRefGatewayConfig,
+} from "./gateway-status/test-support.js";
 
 const mocks = vi.hoisted(() => {
   const sshStop = vi.fn(async () => {});
@@ -600,22 +603,9 @@ describe("gateway-status command", () => {
     const { runtime, runtimeLogs, runtimeErrors } = createRuntimeCapture();
     const defaultProbeGateway = probeGateway.getMockImplementation();
     try {
-      probeGateway.mockImplementation(async (opts: { url: string }) => ({
-        ok: false,
-        url: opts.url,
-        connectLatencyMs: null,
-        error: "connection refused",
-        close: null,
-        auth: {
-          role: null,
-          scopes: [],
-          capability: "unknown",
-        },
-        health: null,
-        status: null,
-        presence: null,
-        configSnapshot: null,
-      }));
+      probeGateway.mockImplementation(async (opts: { url: string }) =>
+        createUnreachableGatewayProbe(opts.url, "connection refused"),
+      );
 
       await expect(runGatewayStatus(runtime, { timeout: "1000", json: true })).rejects.toThrow(
         "__exit__:1",
@@ -760,22 +750,7 @@ describe("gateway-status command", () => {
           mockLocalTokenEnvRefConfig();
           probeGateway.mockImplementation(async (opts: { url: string }) => {
             const { url } = opts;
-            return {
-              ok: false,
-              url,
-              connectLatencyMs: null,
-              error: "connection refused",
-              close: null,
-              auth: {
-                role: null,
-                scopes: [],
-                capability: "unknown",
-              },
-              health: null,
-              status: null,
-              presence: null,
-              configSnapshot: null,
-            };
+            return createUnreachableGatewayProbe(url, "connection refused");
           });
           await expect(runGatewayStatus(runtime, { timeout: "1000", json: true })).rejects.toThrow(
             "__exit__:1",

--- a/src/commands/gateway-status/helpers.test.ts
+++ b/src/commands/gateway-status/helpers.test.ts
@@ -13,7 +13,7 @@ import {
   resolveTargets,
   sanitizeSshTarget,
 } from "./helpers.js";
-import { createSecretRefGatewayConfig } from "./test-support.js";
+import { createUnreachableGatewayProbe, createSecretRefGatewayConfig } from "./test-support.js";
 
 describe("extractConfigSummary", () => {
   it("marks SecretRef-backed gateway auth credentials as configured", () => {
@@ -313,22 +313,7 @@ describe("probe reachability classification", () => {
   });
 
   it("keeps failed-before-connect probes unreachable", () => {
-    const probe = {
-      ok: false,
-      url: "ws://127.0.0.1:18789",
-      connectLatencyMs: null,
-      error: "timeout",
-      close: null,
-      auth: {
-        role: null,
-        scopes: [],
-        capability: "unknown" as const,
-      },
-      health: null,
-      status: null,
-      presence: null,
-      configSnapshot: null,
-    };
+    const probe = createUnreachableGatewayProbe("ws://127.0.0.1:18789", "timeout");
 
     expect(isPostConnectProbeFailure(probe)).toBe(false);
     expect(isProbeReachable(probe)).toBe(false);

--- a/src/commands/gateway-status/test-support.ts
+++ b/src/commands/gateway-status/test-support.ts
@@ -1,4 +1,5 @@
-// Test-only config helpers for gateway status SecretRef scenarios.
+import type { GatewayProbeResult } from "../../gateway/probe.js";
+
 /** Builds gateway config where local and remote auth values use environment SecretRefs. */
 export function createSecretRefGatewayConfig(params?: { gatewayMode?: "local" | "remote" }) {
   return {
@@ -20,5 +21,24 @@ export function createSecretRefGatewayConfig(params?: { gatewayMode?: "local" | 
         password: { source: "env", provider: "default", id: "REMOTE_GATEWAY_PASSWORD" },
       },
     },
+  };
+}
+
+export function createUnreachableGatewayProbe(url: string, error: string): GatewayProbeResult {
+  return {
+    ok: false,
+    url,
+    connectLatencyMs: null,
+    error,
+    close: null,
+    auth: {
+      role: null,
+      scopes: [],
+      capability: "unknown",
+    },
+    health: null,
+    status: null,
+    presence: null,
+    configSnapshot: null,
   };
 }

--- a/src/commands/status.scan.shared.test.ts
+++ b/src/commands/status.scan.shared.test.ts
@@ -14,6 +14,7 @@ import {
   sendMinimalGatewayConnectChallenge,
   sendMinimalGatewayResponse,
 } from "../gateway/minimal-gateway.test-helpers.js";
+import { createUnreachableGatewayProbe } from "./gateway-status/test-support.js";
 import {
   buildTailscaleHttpsUrl,
   resolveGatewayProbeSnapshot as resolveGatewayProbeSnapshotOwner,
@@ -267,22 +268,9 @@ describe("resolveGatewayProbeSnapshot", () => {
       gatewayMode: "local",
       remoteUrlMissing: false,
     });
-    mocks.probeGateway.mockResolvedValue({
-      ok: false,
-      url: "ws://127.0.0.1:18789",
-      connectLatencyMs: null,
-      error: "timeout",
-      close: null,
-      auth: {
-        role: null,
-        scopes: [],
-        capability: "unknown",
-      },
-      health: null,
-      status: null,
-      presence: null,
-      configSnapshot: null,
-    });
+    mocks.probeGateway.mockResolvedValue(
+      createUnreachableGatewayProbe("ws://127.0.0.1:18789", "timeout"),
+    );
     mocks.callGateway.mockResolvedValue({ sessions: 1 });
 
     const result = await resolveGatewayProbeSnapshot({
@@ -320,22 +308,9 @@ describe("resolveGatewayProbeSnapshot", () => {
       gatewayMode: "local",
       remoteUrlMissing: false,
     });
-    mocks.probeGateway.mockResolvedValue({
-      ok: false,
-      url: "ws://localhost.:18789",
-      connectLatencyMs: null,
-      error: "timeout",
-      close: null,
-      auth: {
-        role: null,
-        scopes: [],
-        capability: "unknown",
-      },
-      health: null,
-      status: null,
-      presence: null,
-      configSnapshot: null,
-    });
+    mocks.probeGateway.mockResolvedValue(
+      createUnreachableGatewayProbe("ws://localhost.:18789", "timeout"),
+    );
 
     const result = await resolveGatewayProbeSnapshot({
       cfg: {},
@@ -352,22 +327,9 @@ describe("resolveGatewayProbeSnapshot", () => {
       gatewayMode: "local",
       remoteUrlMissing: false,
     });
-    mocks.probeGateway.mockResolvedValue({
-      ok: false,
-      url: "ws://127.0.0.1:18789",
-      connectLatencyMs: null,
-      error: "timeout",
-      close: null,
-      auth: {
-        role: null,
-        scopes: [],
-        capability: "unknown",
-      },
-      health: null,
-      status: null,
-      presence: null,
-      configSnapshot: null,
-    });
+    mocks.probeGateway.mockResolvedValue(
+      createUnreachableGatewayProbe("ws://127.0.0.1:18789", "timeout"),
+    );
     mocks.callGateway.mockResolvedValue({ sessions: 1 });
 
     await resolveGatewayProbeSnapshot({
@@ -391,22 +353,9 @@ describe("resolveGatewayProbeSnapshot", () => {
         gatewayMode: "local",
         remoteUrlMissing: false,
       });
-      mocks.probeGateway.mockResolvedValue({
-        ok: false,
-        url: "ws://127.0.0.1:18789",
-        connectLatencyMs: null,
-        error: "timeout",
-        close: null,
-        auth: {
-          role: null,
-          scopes: [],
-          capability: "unknown",
-        },
-        health: null,
-        status: null,
-        presence: null,
-        configSnapshot: null,
-      });
+      mocks.probeGateway.mockResolvedValue(
+        createUnreachableGatewayProbe("ws://127.0.0.1:18789", "timeout"),
+      );
       mocks.callGateway.mockResolvedValue({ sessions: 1 });
 
       await resolveGatewayProbeSnapshot({
@@ -547,22 +496,9 @@ describe("resolveGatewayProbeSnapshot", () => {
       gatewayMode: "remote",
       remoteUrlMissing: false,
     });
-    mocks.probeGateway.mockResolvedValue({
-      ok: false,
-      url: "wss://gateway.example/ws",
-      connectLatencyMs: null,
-      error: "timeout",
-      close: null,
-      auth: {
-        role: null,
-        scopes: [],
-        capability: "unknown",
-      },
-      health: null,
-      status: null,
-      presence: null,
-      configSnapshot: null,
-    });
+    mocks.probeGateway.mockResolvedValue(
+      createUnreachableGatewayProbe("wss://gateway.example/ws", "timeout"),
+    );
 
     const result = await resolveGatewayProbeSnapshot({
       cfg: { gateway: { mode: "remote", remote: { url: "wss://gateway.example/ws" } } },


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Gateway status tests repeatedly construct the same unreachable-probe result, obscuring the URL and error that each scenario actually varies. Those fixtures also need fresh nested objects because status processing can append diagnostic warnings to a result.

## Why This Change Was Made

Add a narrow `createUnreachableGatewayProbe(url, error)` factory to the existing test support owner and replace eight matching input objects. Preserve all ten ordered properties, absent connection/server/detail fields, and fresh outer/auth/scopes allocations. Successful, scope-limited, post-connect and missing-auth fixtures remain explicit.

## User Impact

No production behavior changes. The test suite retains every scenario and assertion while removing 84 net lines: 83 from fixture consolidation and one generic comment removed. No runtime savings claim.

## Evidence

- All 86 cases passed before and after across the three affected test files, with identical per-file names and ordering.
- Eight runtime equivalence checks prove values, ordered keys, absent optional properties, fresh nested allocations and unchanged URL read counts. Expanding the calls reconstructs each complete original test AST.
- The original SecretRef factory remains unchanged; the added import is type-only and adds no runtime probe loading.
- Formatting, diff checks and fresh P2 review passed. Full changed gate passed.
