### PR TITLE
fix: use scoped native login during model discovery

### DIFF
--- a/src/agents/embedded-agent-runner/model.generation-scope.test.ts
+++ b/src/agents/embedded-agent-runner/model.generation-scope.test.ts
@@ -1,3 +1,5 @@
+import fs from "node:fs/promises";
+import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -8,6 +10,10 @@ import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
+import {
+  ensureAuthProfileStore,
+  ensureAuthProfileStoreWithoutExternalProfiles,
+} from "../auth-profiles/store-runtime.js";
 import { AuthStorage, ModelRegistry } from "../sessions/index.js";
 import { resolveTieredModel } from "./model-resolution.js";
 import { guardModelFixtureAuth } from "./model.fixture.test-support.js";
@@ -21,7 +27,10 @@ import { resolveModelAsync } from "./model.js";
 let state: OpenClawTestState;
 let auth: ReturnType<typeof guardModelFixtureAuth>;
 beforeEach(async () => {
-  state = await createOpenClawTestState({ label: "model-generation" });
+  state = await createOpenClawTestState({
+    label: "model-generation",
+    env: { CODEX_HOME: undefined },
+  });
   auth = guardModelFixtureAuth(state.root);
 });
 afterEach(async () => {
@@ -55,6 +64,47 @@ async function resolveGeneration(
   );
 }
 
+async function createExternalCodexGeneration() {
+  const codexDir = path.join(state.home, ".codex");
+  const payload = Buffer.from(
+    JSON.stringify({ exp: Math.floor(Date.now() / 1_000) + 86_400 }),
+  ).toString("base64url");
+  await fs.mkdir(codexDir, { recursive: true, mode: 0o700 });
+  await fs.writeFile(
+    path.join(codexDir, "auth.json"),
+    JSON.stringify({
+      auth_mode: "chatgpt",
+      tokens: {
+        id_token: `synthetic.${payload}.signature`,
+        access_token: `synthetic.${payload}.signature`,
+        refresh_token: "synthetic-refresh-never-sent",
+        account_id: "synthetic-account",
+      },
+    }),
+    { mode: 0o600 },
+  );
+  vi.spyOn(globalThis, "fetch").mockImplementation(() => {
+    throw new Error("Model auth discovery must not contact a provider");
+  });
+  const generation = createModelGenerationFixture({
+    agentDir: state.agentDir(),
+    workspaceDir: state.workspaceDir,
+    provider: "openai",
+    requestProvider: "openai",
+    config: {},
+    label: "external-codex",
+  });
+  publishCurrentModelGeneration(generation);
+  await state.writeAuthProfiles({ version: 1, profiles: {} });
+  expect(
+    ensureAuthProfileStore(state.agentDir(), {
+      allowKeychainPrompt: false,
+      externalCliProviderIds: ["openai"],
+    }).profiles["openai:default"],
+  ).toMatchObject({ provider: "openai", type: "oauth" });
+  return generation;
+}
+
 describe("model runtime generation scope", () => {
   beforeEach(() => {
     clearPluginMetadataLifecycleCaches();
@@ -63,6 +113,50 @@ describe("model runtime generation scope", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     resetModelGenerationFixtureState();
+  });
+
+  it.each([
+    { selection: "explicit", profileId: "openai:default" },
+    { selection: "automatic", profileId: undefined },
+  ])(
+    "resolves $selection external Codex credentials without persisting them",
+    async ({ profileId }) => {
+      const generation = await createExternalCodexGeneration();
+
+      expect((await resolveGeneration(generation, profileId)).model?.id).toBe(generation.modelId);
+      expect(generation.resolveDynamicModel).toHaveBeenCalledWith(
+        expect.objectContaining({ authProfileId: "openai:default", authProfileMode: "oauth" }),
+      );
+      expect(
+        ensureAuthProfileStoreWithoutExternalProfiles(state.agentDir()).profiles["openai:default"],
+      ).toBeUndefined();
+      expect(globalThis.fetch).not.toHaveBeenCalled();
+    },
+  );
+
+  it("does not replace a missing managed profile with an external Codex account", async () => {
+    const generation = await createExternalCodexGeneration();
+    await state.writeAuthProfiles({
+      version: 1,
+      profiles: {
+        "openai:managed": {
+          provider: "openai",
+          type: "oauth",
+          access: "synthetic-managed-access",
+          refresh: "synthetic-managed-refresh",
+          expires: Date.now() + 86_400_000,
+          accountId: "managed-account",
+        },
+      },
+    });
+
+    await expect(resolveGeneration(generation, "openai:missing")).rejects.toMatchObject({
+      code: "selected_auth_profile_unavailable",
+      reason: "auth",
+      status: 401,
+    });
+    expect(generation.resolveDynamicModel).not.toHaveBeenCalled();
+    expect(globalThis.fetch).not.toHaveBeenCalled();
   });
 
   it("reports a removed selected credential before reusing dynamic model metadata", async () => {

--- a/src/agents/embedded-agent-runner/model.generation-scope.test.ts
+++ b/src/agents/embedded-agent-runner/model.generation-scope.test.ts
@@ -10,10 +10,7 @@ import {
   createOpenClawTestState,
   type OpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
-import {
-  ensureAuthProfileStore,
-  ensureAuthProfileStoreWithoutExternalProfiles,
-} from "../auth-profiles/store-runtime.js";
+import { ensureAuthProfileStoreWithoutExternalProfiles } from "../auth-profiles/store-runtime.js";
 import { AuthStorage, ModelRegistry } from "../sessions/index.js";
 import { resolveTieredModel } from "./model-resolution.js";
 import { guardModelFixtureAuth } from "./model.fixture.test-support.js";
@@ -96,12 +93,6 @@ async function createExternalCodexGeneration() {
   });
   publishCurrentModelGeneration(generation);
   await state.writeAuthProfiles({ version: 1, profiles: {} });
-  expect(
-    ensureAuthProfileStore(state.agentDir(), {
-      allowKeychainPrompt: false,
-      externalCliProviderIds: ["openai"],
-    }).profiles["openai:default"],
-  ).toMatchObject({ provider: "openai", type: "oauth" });
   return generation;
 }
 

--- a/src/agents/embedded-agent-runner/model.registry-resolution.ts
+++ b/src/agents/embedded-agent-runner/model.registry-resolution.ts
@@ -4,6 +4,7 @@ import type { Model } from "../../llm/types.js";
 import type { PluginMetadataSnapshotOwnerMaps } from "../../plugins/plugin-metadata-snapshot.types.js";
 import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
 import { ensureAuthProfileStore, resolveAuthProfileOrder } from "../auth-profiles.js";
+import { externalCliDiscoveryForProviderAuth } from "../auth-profiles/external-cli-discovery.js";
 import { createSelectedAuthProfileUnavailableError } from "../auth-profiles/selection-error.js";
 import type { AuthProfileCredential } from "../auth-profiles/types.js";
 import { resolveAgentHarnessPolicy } from "../harness/policy.js";
@@ -221,6 +222,13 @@ export function resolveDynamicModelAuthProfile(params: {
   const store = ensureAuthProfileStore(params.agentDir, {
     allowKeychainPrompt: false,
     profileId: explicitProfileId,
+    config: params.cfg,
+    externalCli: externalCliDiscoveryForProviderAuth({
+      cfg: params.cfg,
+      provider: params.provider,
+      profileId: explicitProfileId,
+      preferredProfile: params.preferredProfile,
+    }),
   });
   const profileId =
     explicitProfileId ??


### PR DESCRIPTION
Related: #140973

## What Problem This Solves

Model validation can reject an existing native Codex login as an unavailable `openai:default` profile when OpenClaw has no stored OAuth account. Automatic model discovery also loses the native login's OAuth mode.

## Why This Change Was Made

Pass the requested provider, explicit or preferred profile, and config to the existing scoped credential-discovery owner. The regression fixture now lets model resolution perform the first scoped lookup.

## User Impact

Eligible native logins work during model discovery without being imported into the managed auth store. Prepared selections, managed account ownership, missing-profile errors, and stored API keys retain their existing policy.

## Evidence

On pinned main `21ad735be2f44143bcd2f53ec2ffa8c128e5ede2`, this public command rejects the selected native profile; the candidate accepts it:

```sh
pnpm openclaw config set agents.defaults.model.primary '"openai/gpt-5.4@openai:default"' --strict-json --dry-run
```

The isolated fixture uses the OpenClaw model runtime, the OpenAI plugin, a synthetic future-dated native login, and real SQLite state. A configured external alias also validates. The candidate passes 36 focused tests; the cleaned regression suite fails on the original production owner for the two native-discovery cases.

Supplementary real-resolver checks observe default and alias OAuth selection and preserve prepared, managed, missing-managed, API-key, and non-OpenAI results. Shared auth rows and native-file hashes remain unchanged, with no agent-local credential copy. External networking is blocked. The network observer distinguishes loader Unix sockets from external requests.

This proves offline discovery and validation. It does not claim a real provider login, model turn, token refresh, browser login, or macOS Keychain execution. Prepared-mode and selected-auth-mode assertions are supplementary boundary proof because the public command does not expose those fields. Complete private raw captures are retained; published excerpts omit fixture paths and credential material.

Independent source-blind CLI checks cover native default, automatic selection, alias, managed refusals, stored keys, and invalid model input. Hidden auth-mode and implementation assertions remain separately reviewed source/boundary evidence.
