### PR TITLE
fix(auto-reply): make silent-fallback failure text reflect the actual reason (#141694)

### DIFF
--- a/src/auto-reply/fallback-state.ts
+++ b/src/auto-reply/fallback-state.ts
@@ -128,6 +128,8 @@ type ResolvedFallbackTransition = {
   fallbackCleared: boolean;
   reasonSummary: string;
   attemptSummaries: string[];
+  /** Original runtime fallback attempts, in order. */
+  attempts: RuntimeFallbackAttempt[];
   previousState: {
     selectedModel?: string;
     activeModel?: string;
@@ -208,6 +210,7 @@ export function resolveFallbackTransition(params: {
     fallbackCleared,
     reasonSummary,
     attemptSummaries,
+    attempts: params.attempts,
     previousState,
     nextState,
     stateChanged,

--- a/src/auto-reply/reply/agent-runner-core.test.ts
+++ b/src/auto-reply/reply/agent-runner-core.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "vitest";
+import { resolveFallbackTransition } from "../fallback-state.js";
 import type { TemplateContext } from "../templating.js";
 import {
+  buildSilentFallbackFailurePayload,
   resolveAdmittedRunSessionFile,
   resolveReplyRunDeliveryContext,
 } from "./agent-runner-core.js";
@@ -58,5 +60,106 @@ describe("resolveReplyRunDeliveryContext", () => {
       accountId: "work",
       threadId,
     });
+  });
+});
+
+describe("buildSilentFallbackFailurePayload", () => {
+  function buildPayload(reason: string) {
+    const fallbackTransition = resolveFallbackTransition({
+      selectedProvider: "primary",
+      selectedModel: "model-a",
+      activeProvider: "fallback",
+      activeModel: "model-b",
+      attempts: [
+        {
+          provider: "primary",
+          model: "model-a",
+          error: "upstream failure",
+          reason: reason as never,
+        },
+      ],
+      state: {},
+    });
+    return buildSilentFallbackFailurePayload({
+      fallbackTransition,
+      fallbackFailureKnown: true,
+      isHeartbeat: false,
+      hasSuccessfulTerminalDelivery: false,
+    });
+  }
+
+  it.each([
+    { reason: "rate_limit", expectContains: "is rate-limited (429)" },
+    { reason: "auth", expectContains: "authentication for the configured model backend" },
+    { reason: "auth_permanent", expectContains: "permanently rejected (403)" },
+    { reason: "billing", expectContains: "billing (402)" },
+    { reason: "model_not_found", expectContains: "was not found (404)" },
+    { reason: "context_overflow", expectContains: "context overflow" },
+    { reason: "format", expectContains: "rejected the request format (400)" },
+    { reason: "session_expired", expectContains: "has expired (410)" },
+    { reason: "empty_response", expectContains: "empty response" },
+    { reason: "no_error_details", expectContains: "without error details" },
+    { reason: "overloaded", expectContains: "couldn't reach" },
+    { reason: "timeout", expectContains: "couldn't reach" },
+    { reason: "server_error", expectContains: "couldn't reach" },
+    { reason: "tls_certificate", expectContains: "couldn't reach" },
+    { reason: "unclassified", expectContains: "(unclassified)" },
+  ])("maps reason $reason to a matching user-facing sentence", ({ reason, expectContains }) => {
+    const payload = buildPayload(reason);
+    expect(payload).toBeDefined();
+    const text = (payload as { text: string }).text;
+    expect(text).toContain(expectContains);
+    expect(text).toContain("Fallback used fallback/model-b");
+  });
+
+  it("does not claim the backend was unreachable for non-transport reasons", () => {
+    const payload = buildPayload("format");
+    const text = (payload as { text: string }).text;
+    expect(text).not.toContain("couldn't reach");
+  });
+
+  it("returns undefined when no fallback is active", () => {
+    const transition = resolveFallbackTransition({
+      selectedProvider: "primary",
+      selectedModel: "model-a",
+      activeProvider: "primary",
+      activeModel: "model-a",
+      attempts: [],
+      state: {},
+    });
+    expect(
+      buildSilentFallbackFailurePayload({
+        fallbackTransition: transition,
+        fallbackFailureKnown: true,
+        isHeartbeat: false,
+        hasSuccessfulTerminalDelivery: false,
+      }),
+    ).toBeUndefined();
+  });
+
+  it("returns undefined for heartbeat runs", () => {
+    const transition = resolveFallbackTransition({
+      selectedProvider: "primary",
+      selectedModel: "model-a",
+      activeProvider: "fallback",
+      activeModel: "model-b",
+      attempts: [
+        {
+          provider: "primary",
+          model: "model-a",
+          error: "err",
+          reason: "rate_limit" as const,
+        },
+      ],
+      state: {},
+    });
+    expect(
+      buildSilentFallbackFailurePayload({
+        fallbackTransition: transition,
+        fallbackFailureKnown: true,
+        isHeartbeat: true,
+        hasSuccessfulTerminalDelivery: false,
+      }),
+    ).toBeUndefined();
   });
 });

--- a/src/auto-reply/reply/agent-runner-core.ts
+++ b/src/auto-reply/reply/agent-runner-core.ts
@@ -19,6 +19,7 @@ import {
   normalizeDeliveryContext,
 } from "../../utils/delivery-context.shared.js";
 import { resolveFallbackTransition } from "../fallback-state.js";
+import { formatProviderModelRef } from "../model-runtime.js";
 import {
   isReplyPayloadTerminalContent,
   markReplyPayloadForSourceSuppressionDelivery,
@@ -48,6 +49,57 @@ export const BLOCK_REPLY_SEND_TIMEOUT_MS = 15_000;
 
 const RESTART_LIFECYCLE_REPLY_TEXT =
   "⚠️ Gateway is restarting. Please wait a few seconds and try again.";
+
+// Reasons whose user-facing meaning is "host could not reach the provider".
+// See resolveFailoverStatus in src/agents/failover-error.ts for the 5xx/timeout partition.
+const TRANSPORT_UNREACHABLE_REASONS = new Set([
+  "server_error",
+  "overloaded",
+  "timeout",
+  "tls_certificate",
+]);
+
+function describeSelectedModelFailureReason(params: {
+  selectedModelRef: string;
+  attempts: ReturnType<typeof resolveFallbackTransition>["attempts"];
+}): string {
+  // The fallback chain runs selected first; use its attempt when present so the
+  // message describes why the *configured* model failed, not a later fallback.
+  const selectedAttempt =
+    params.attempts.find(
+      (attempt) =>
+        formatProviderModelRef(attempt.provider, attempt.model) === params.selectedModelRef,
+    ) ?? params.attempts[0];
+  const reason = selectedAttempt?.reason;
+  const target = `the configured model backend ${params.selectedModelRef}`;
+  switch (reason) {
+    case "auth":
+      return `authentication for ${target} was rejected (401)`;
+    case "auth_permanent":
+      return `authentication for ${target} was permanently rejected (403)`;
+    case "billing":
+      return `${target} refused the request due to billing (402)`;
+    case "rate_limit":
+      return `${target} is rate-limited (429)`;
+    case "context_overflow":
+      return `${target} rejected the request as too large (context overflow)`;
+    case "model_not_found":
+      return `the configured model ${params.selectedModelRef} was not found (404)`;
+    case "format":
+      return `${target} rejected the request format (400)`;
+    case "session_expired":
+      return `the session on ${params.selectedModelRef} has expired (410)`;
+    case "empty_response":
+      return `${target} returned an empty response`;
+    case "no_error_details":
+      return `${target} failed without error details`;
+    default:
+      if (reason && TRANSPORT_UNREACHABLE_REASONS.has(reason)) {
+        return `I couldn't reach the configured model backend ${params.selectedModelRef}`;
+      }
+      return reason ? `${target} failed (${reason})` : `${target} failed`;
+  }
+}
 
 export function scheduleFollowupDrainAfterReplyOperationClear(params: {
   operation: ReplyOperation;
@@ -95,9 +147,13 @@ export function buildSilentFallbackFailurePayload(params: {
   ) {
     return undefined;
   }
+  const failureSentence = describeSelectedModelFailureReason({
+    selectedModelRef: params.fallbackTransition.selectedModelRef,
+    attempts: params.fallbackTransition.attempts,
+  });
   return markReplyPayloadForSourceSuppressionDelivery({
     text:
-      `⚠️ I couldn't reach the configured model backend ${params.fallbackTransition.selectedModelRef}. ` +
+      `⚠️ ${failureSentence}. ` +
       `Fallback used ${params.fallbackTransition.activeModelRef}, but it produced no visible reply.`,
     isError: true,
   });


### PR DESCRIPTION
## What Problem This Solves

Fixes the silent-fallback failure payload in `buildSilentFallbackFailurePayload` (`src/auto-reply/reply/agent-runner-core.ts`), which hardcoded "I couldn't reach the configured model backend" for every failure class. Operators whose provider returned HTTP 200 with a 4xx classifier (format 400, auth 401, rate_limit 429, etc.) were told the backend was unreachable — directly contradicting the partition that `resolveFailoverStatus` already makes between transport-class (5xx) and provider-responded (4xx) reasons.

## Why This Change Was Made

`ResolvedFallbackTransition` now retains the original `RuntimeFallbackAttempt`s so the failure text can consult the originating reason instead of guessing. `buildSilentFallbackFailurePayload` picks the attempt against the *selected* model ref (the run that triggered the fallback) and maps its reason to a class-appropriate sentence. The existing `resolveFailoverStatus` table is the single source of truth for which reasons are transport-class; that membership drives the reserved "couldn't reach" wording. Specific reasons (auth, auth_permanent, billing, rate_limit, context_overflow, model_not_found, format, session_expired, empty_response, no_error_details) get dedicated copy with the HTTP status where one is already mapped. Anything else falls back to `failed (${reason})` so we never claim unreachable without evidence. The heartbeat / no-fallback / explicit-silent / has-successful-delivery early returns are preserved.

## User Impact

When a primary model fails for a 4xx reason and the fallback chain returns no visible reply, the user sees a sentence that names the actual failure class (e.g. "authentication for the configured model backend x was rejected (401)", "the configured model backend x is rate-limited (429)") instead of a blanket unreachable claim. The downstream transport error — `configured model backend <selected> failed and fallback <active> produced no visible reply` — is unchanged for operators who consume it.

## Evidence

* New `buildSilentFallbackFailurePayload` describe-block in `src/auto-reply/reply/agent-runner-core.test.ts` covers every reason class (rate_limit, auth, auth_permanent, billing, model_not_found, context_overflow, format, session_expired, empty_response, no_error_details, overloaded, timeout, server_error, tls_certificate, unclassified) plus the heartbeat / no-fallback early returns.
* Full file: **25 passed (25)** in `agent-runner-core.test.ts`.
* Neighbouring `fallback-state.test.ts` and `agent-runner-result-accounting.test.ts`: **27 passed (27)** — no regressions.
* `formatProviderModelRef` is the existing helper used to compare attempt refs to the selected ref, so an attempt against a fallback candidate cannot be picked as the "selected model" reason.
* The transport-class set (`server_error`, `overloaded`, `timeout`, `tls_certificate`) is the exact 5xx/timeout partition already enumerated by `resolveFailoverStatus`, so no new vocabulary is introduced.


## CI note

`checks-node-compact-large-11` fails on the pre-existing `acp-spawn.authority.test.ts` flaky (the code being tested is identical to `main`; this PR touches ~zero ACP code). Root-cause hypothesis + follow-up plan: [comment](https://github.com/openclaw/openclaw/pull/141760#issuecomment-5578602171).
