### PR TITLE
fix(ci): restore macOS CodeQL runner availability

### DIFF
--- a/.github/workflows/codeql-macos-critical-security.yml
+++ b/.github/workflows/codeql-macos-critical-security.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   macos:
     name: Critical Security (macOS)
-    runs-on: blacksmith-12vcpu-macos-26
+    runs-on: macos-26
     timeout-minutes: 45
     steps:
       - name: Checkout

--- a/docs/ci/scheduled-workflows.md
+++ b/docs/ci/scheduled-workflows.md
@@ -149,7 +149,7 @@ The pull request guard stays light: it only starts for changes under `.github/ac
 ### Platform-specific security shards
 
 - `CodeQL Android Critical Security` — scheduled Android security shard. Builds the Android app manually for CodeQL on the smallest Blacksmith Linux runner accepted by workflow sanity. Uploads under `/codeql-critical-security/android`.
-- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Builds the macOS app manually for CodeQL on Blacksmith macOS, filters dependency build results out of uploaded SARIF, and uploads under `/codeql-critical-security/macos`. Kept outside daily defaults because macOS build dominates runtime even when clean.
+- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Builds the macOS app manually for CodeQL on GitHub-hosted macOS, filters dependency build results out of uploaded SARIF, and uploads under `/codeql-critical-security/macos`. Kept outside daily defaults because macOS build dominates runtime even when clean.
 
 ### Critical Quality categories
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4385,7 +4385,7 @@ NODE
       "CodeQL macOS Xcode selection",
     );
 
-    expect(codeqlJob["runs-on"]).toBe("blacksmith-12vcpu-macos-26");
+    expect(codeqlJob["runs-on"]).toBe("macos-26");
     expect(codeqlSelect.run).toContain("/Applications/Xcode_26.6.app/Contents/Developer");
     expect(codeqlSelect.run).toContain('if [[ "$xcode_version" != 26.6* ]]; then');
 


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the CodeQL macOS Critical Security workflow remains queued without an assigned runner. The scheduled [run 34098602000](https://github.com/openclaw/openclaw/actions/runs/34098602000/job/101667670705) was waiting for `blacksmith-12vcpu-macos-26` for more than 17 hours when investigated.

## Why This Change Was Made

Route this workflow to GitHub-hosted `macos-26`, which provides the existing Xcode 26.6 toolchain. Update the existing Xcode-capable runner assertion to match.

The 45-minute timeout, manual Swift build, pinned actions, query configuration, permissions, dependency-result filtering, SARIF category, and upload processing remain unchanged. Other workflows and provider capacity are unchanged.

## User Impact

Maintainers can run the macOS security analysis without waiting for this Blacksmith runner label. There is no application runtime change.

## Evidence

- The focused Xcode runner guard passes with the new routing. It rejected the original Blacksmith routing with the updated assertion.
- Targeted formatting and `git diff --check` pass.
- Actionlint at the repository-pinned revision and the cached pinned Zizmor 1.29.0 pass for the changed workflow. Composite-action interpolation, generated CI Git-owner, and conflict-marker checks pass.
- Full exact-branch CodeQL qualification is pending. Merge is held until the existing asset preparation, initialization, Swift build/extraction, analysis, filtering, and SARIF processing complete successfully within the unchanged timeout.
- Branch analysis does not replace default-branch analysis; a post-merge main run is required.
