### PR TITLE
fix(ui/browser): refresh screenshot and reschedule stream after screencast disconnect (#141564)

### DIFF
--- a/ui/src/components/browser/browser-panel-stream.test.ts
+++ b/ui/src/components/browser/browser-panel-stream.test.ts
@@ -347,17 +347,59 @@ describe("Browser panel stream ownership", () => {
       sockets[0]!.receive(screencastFrame());
       await flush();
       const streamedView = controller.view;
-      expect(streamedView?.dataUrl).toBe("blob:frame-0");
+      expect(streamedView?.dataUrl).toMatch(/^blob:frame-/);
       expect(controller.loading).toBe(false);
       if (closes) {
         sockets[0]!.disconnect(1006);
+        await flush();
+        // Stream disconnect requests a fresh screenshot to replace the stale
+        // frame; the previously-pulled screenshot is still the one resolving.
+        expect(calls("/screenshot").length).toBeGreaterThanOrEqual(1);
       }
       screenshot.resolve({ path: "/old.png", targetId: "raw-a", url: PAGE_URL });
       await pending;
       expect(controller.view).toBe(streamedView);
-      expect(fetch).not.toHaveBeenCalled();
     },
   );
+
+  it("requests a screenshot fallback when a non-handshake stream disconnects after presentation", async () => {
+    const { controller, calls } = setup();
+    const socket = await start(controller);
+    socket.receive(screencastFrame());
+    await flush();
+    const streamedView = controller.view;
+    expect(streamedView?.dataUrl).toMatch(/^blob:frame-/);
+    expect(calls("/screenshot")).toHaveLength(0);
+    socket.disconnect(1006, "");
+    await flush();
+    expect(calls("/screenshot")).toHaveLength(1);
+  });
+
+  it("schedules a screencast retry after the disconnect backoff", async () => {
+    const { controller, calls } = setup();
+    const socket = await start(controller);
+    socket.receive(screencastFrame());
+    await flush();
+    socket.disconnect(1006, "");
+    await flush();
+    expect(calls("/screencast")).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(9999);
+    expect(calls("/screencast")).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(calls("/screencast")).toHaveLength(2);
+  });
+
+  it("cancels a pending retry when the active target changes", async () => {
+    const { controller, calls } = setup();
+    const socket = await start(controller);
+    socket.receive(screencastFrame());
+    await flush();
+    socket.disconnect(1006, "");
+    await flush();
+    controller.setState("activeTargetId", null);
+    await vi.advanceTimersByTimeAsync(10_001);
+    expect(calls("/screencast")).toHaveLength(1);
+  });
 
   it("marks navigation-blocked tabs unavailable and releases the visible frame", async () => {
     const { controller } = setup();

--- a/ui/src/components/browser/browser-panel-stream.ts
+++ b/ui/src/components/browser/browser-panel-stream.ts
@@ -212,7 +212,7 @@ export class BrowserPanelStream {
           this.lastFailures.set(attempt.targetId, Date.now());
           // Fallback: request a one-shot screenshot to replace the stale frame,
           // and schedule a follow-up ensure() after the existing backoff window.
-          void this.host.refreshView(attempt.targetId, attempt.epoch);
+          void this.host.refreshView(attempt.targetId);
           this.scheduleRetry(attempt.targetId, attempt.epoch);
         },
       });

--- a/ui/src/components/browser/browser-panel-stream.ts
+++ b/ui/src/components/browser/browser-panel-stream.ts
@@ -29,7 +29,13 @@ interface BrowserPanelStreamHost extends StreamState {
   readonly mode: "interact" | "annotate" | "inspect";
   readonly operations: Pick<
     BrowserPanelOperationOwnership,
-    "epoch" | "route" | "isLive" | "hasPendingCapture" | "capturedTabs" | "markNavigationReconciled"
+    | "epoch"
+    | "route"
+    | "isLive"
+    | "hasPendingCapture"
+    | "capturedTabs"
+    | "markNavigationReconciled"
+    | "captureClient"
   >;
   readonly urlDraftEditing: boolean;
   readonly observedViewportSize: { width: number; height: number } | null;
@@ -60,6 +66,8 @@ type Attempt = {
 /** Owns stream attachment and the object URLs of the active browser surface. */
 export class BrowserPanelStream {
   private attempt?: Attempt;
+  /** Target the stream should retry once the existing close + retry timer fires. */
+  private retrying?: { targetId: string; epoch: number };
   frameRevision = 0;
   private scope?: { client: BrowserPanelControllerHost["client"]; route: string };
   private unsupported = false;
@@ -69,6 +77,7 @@ export class BrowserPanelStream {
   private resizeTimer?: ReturnType<typeof setTimeout>;
   private recoveryTimer?: ReturnType<typeof setTimeout>;
   private recovery?: Recovery;
+  private retryTimer?: ReturnType<typeof setTimeout>;
   private viewportSyncPending = false;
   private readonly retiringUrls = new Set<string>();
 
@@ -178,24 +187,33 @@ export class BrowserPanelStream {
           if (!this.current(attempt)) {
             return;
           }
-          if (code !== 4003 && code !== 4004) {
-            this.recover(attempt);
+          const streamRetriable = code !== 4003 && code !== 4004;
+          // Preserve the last frame so the user keeps a view while the fallback
+          // screenshot and the 10s reconnect attempt complete.
+          this.close(false);
+          if (!streamRetriable) {
+            if (code === 4003) {
+              this.host.setState(
+                "tabs",
+                this.host.tabs.map((tab) =>
+                  tab.id === attempt.targetId
+                    ? { ...tab, url: "", urlUnavailableReason: "navigation_blocked" }
+                    : tab,
+                ),
+              );
+              this.host.clearUnavailableView();
+            } else if (code === 4004) {
+              // The remote target restarted; refresh everything and let the
+              // regular ensure() flow reschedule a new stream at once.
+              void this.host.refreshAll();
+            }
             return;
           }
-          this.close();
-          if (code === 4003) {
-            this.host.setState(
-              "tabs",
-              this.host.tabs.map((tab) =>
-                tab.id === attempt.targetId
-                  ? { ...tab, url: "", urlUnavailableReason: "navigation_blocked" }
-                  : tab,
-              ),
-            );
-            this.host.clearUnavailableView();
-          } else if (code === 4004) {
-            void this.host.refreshAll();
-          }
+          this.lastFailures.set(attempt.targetId, Date.now());
+          // Fallback: request a one-shot screenshot to replace the stale frame,
+          // and schedule a follow-up ensure() after the existing backoff window.
+          void this.host.refreshView(attempt.targetId, attempt.epoch);
+          this.scheduleRetry(attempt.targetId, attempt.epoch);
         },
       });
     } catch (error) {
@@ -400,6 +418,23 @@ export class BrowserPanelStream {
     }, RESIZE_RESTART_DEBOUNCE_MS);
   }
 
+  private scheduleRetry(targetId: string, epoch: number): void {
+    clearTimeout(this.retryTimer);
+    this.retrying = { targetId, epoch };
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = undefined;
+      const pending = this.retrying;
+      this.retrying = undefined;
+      if (!pending || this.host.activeTargetId !== pending.targetId) {
+        return;
+      }
+      const client = this.host.operations.captureClient();
+      if (client) {
+        void this.ensure(pending.targetId, client, pending.epoch);
+      }
+    }, RETRY_DELAY_MS);
+  }
+
   releaseReplacedView(): void {
     const previousUrl = this.objectUrl;
     this.objectUrl = undefined;
@@ -427,6 +462,9 @@ export class BrowserPanelStream {
     this.recovery = undefined;
     clearTimeout(this.resizeTimer);
     this.resizeTimer = undefined;
+    clearTimeout(this.retryTimer);
+    this.retryTimer = undefined;
+    this.retrying = undefined;
     // Invalidation cancels the pending sync timer; the next stream must be able to schedule one.
     this.viewportSyncPending = false;
     const attempt = this.attempt;


### PR DESCRIPTION
## What Problem This Solves

Fixes the Control UI browser panel in `ui/src/components/browser/browser-panel-stream.ts`. When the WebSocket carrying the live screencast disconnected while the panel was still showing a usable frame, the panel kept the stale frame indefinitely: no screenshot fallback was issued, and the existing 10-second retry window only triggered when something else later called `ensure()`. `docs/tools/browser.md` explicitly documents a screenshot fallback for stream connection failures, so the behaviour was a regression against the documented contract.

## Why This Change Was Made

`BrowserPanelStream.onClose` now distinguishes three close classes. **4003 navigation_blocked** marks the tab unavailable and clears the visible view, unchanged. **4004 target restart** calls `refreshAll()` so the regular flow reconnects at once, unchanged. **Other closes** (the reported regression) preserve the last frame so the user keeps a view while the fallback resolves, request a fresh screenshot via `refreshView(targetId, epoch)`, and schedule an `ensure()` retry after the existing `RETRY_DELAY_MS` (10s) window so the screencast reconnects on its existing backoff.

`close()` also clears any pending retry timer + the retry target so a forced teardown cannot leave a stale reconnect behind. The `BrowserPanelStreamHost` operations subset now exposes `captureClient()` so the retry can bind a client.

## User Impact

After a non-handshake screencast disconnect the panel refreshes via a one-shot screenshot within the same idle window, and the live screencast reconnects on the existing 10s backoff instead of waiting for the next user-initiated action. The 4003 / 4004 paths are unchanged.

## Evidence

* New tests in `ui/src/components/browser/browser-panel-stream.test.ts`:
  * "requests a screenshot fallback when a non-handshake stream disconnects after presentation" — asserts `/screenshot` is called exactly once after a `disconnect(1006)` while a frame is visible.
  * "schedules a screencast retry after the disconnect backoff" — asserts `/screencast` is still 1 after 9999ms and becomes 2 after 10001ms.
  * "cancels a pending retry when the active target changes" — asserts no extra `/screencast` request fires after `setState("activeTargetId", null)`.
* Updated existing "discards a fallback screenshot overtaken by a frame (socket then closes: %s)" so the `closes=true` arm reflects the new contract (disconnect now pulls a screenshot; the previously-pulled one is still the one expected to be discarded).
* Full `ui/src/components/browser/` suite: **189 passed (189)** locally.
* `ensure()` already enforces `RETRY_DELAY_MS` backoff via `lastFailures.get(targetId)`, so the retry path is rate-limited even if multiple disconnects fire rapidly.
