### PR TITLE
refactor(ui): type WebKit host bridge

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3712,12 +3712,10 @@ ui/src/app/config.ts	1
 ui/src/app/custom-theme.ts	2
 ui/src/app/native-bridge.ts	3
 ui/src/app/native-gateways.runtime.ts	4
-ui/src/app/native-link-routing.ts	3
-ui/src/app/native-nav-state.ts	1
-ui/src/app/native-notifications.ts	3
+ui/src/app/native-link-routing.ts	1
+ui/src/app/native-notifications.ts	2
 ui/src/app/native-route-memory.ts	1
 ui/src/app/native-web-chrome.ts	2
-ui/src/app/native-window-drag.ts	1
 ui/src/app/overlays.ts	1
 ui/src/app/question-prompt.ts	2
 ui/src/app/server-prefs-state.ts	14

--- a/ui/src/app/native-gateways.runtime.ts
+++ b/ui/src/app/native-gateways.runtime.ts
@@ -1,3 +1,5 @@
+import { webKitHostWindow } from "./native-webkit-bridge.ts";
+
 export type NativeGateway = {
   id: string;
   name: string;
@@ -8,14 +10,8 @@ export type NativeGateway = {
 };
 
 export type NativeGatewaysSnapshot = { gateways: NativeGateway[]; currentId: string };
-type NativeGatewaysMessage =
-  | { type: "select" | "open-window" | "set-primary"; id: string }
-  | { type: "open-settings" };
 type NativeGatewaysWindow = Window & {
   __OPENCLAW_NATIVE_GATEWAYS__?: unknown;
-  webkit?: {
-    messageHandlers?: { openclawGateways?: { postMessage(message: NativeGatewaysMessage): void } };
-  };
 };
 
 const NATIVE_GATEWAYS_CHANGED_EVENT = "openclaw:native-gateways-changed";
@@ -45,7 +41,7 @@ function createNativeGatewaysCapability(): NativeGatewaysCapability | null {
     return null;
   }
   const nativeWindow = window as NativeGatewaysWindow;
-  const handler = nativeWindow.webkit?.messageHandlers?.openclawGateways;
+  const handler = webKitHostWindow()?.webkit?.messageHandlers?.openclawGateways;
   if (!handler?.postMessage) {
     return null;
   }

--- a/ui/src/app/native-link-routing.ts
+++ b/ui/src/app/native-link-routing.ts
@@ -14,26 +14,10 @@ import {
   shouldHandleNavigationClick,
 } from "../lib/navigation-click.ts";
 import { hasNativeBrowserBridge } from "./native-browser-host.ts";
+import { webKitHostWindow, type WebKitHostMessages } from "./native-webkit-bridge.ts";
 
 type NativeLinkTarget = "external";
-
-type NativeLinkMessage = {
-  type: "open-link";
-  url: string;
-  target: NativeLinkTarget;
-};
-
-type WebKitMessageHandler = {
-  postMessage(message: NativeLinkMessage): void;
-};
-
-type NativeUpdateMessage = {
-  type: "start-update";
-};
-
-type WebKitUpdateMessageHandler = {
-  postMessage(message: NativeUpdateMessage): void;
-};
+type NativeLinkPoster = (message: WebKitHostMessages["openclawLink"]) => void;
 
 const NATIVE_UPDATE_DECLINED_EVENT = "openclaw:native-update-declined";
 export const NATIVE_UPDATE_AVAILABILITY_CHANGED_EVENT =
@@ -51,22 +35,14 @@ type NativeLinkRoutingOptions = {
   canPresentBrowserPanel?: () => boolean;
 };
 
-function getNativeLinkPoster(): WebKitMessageHandler["postMessage"] | undefined {
+function getNativeLinkPoster(): NativeLinkPoster | undefined {
   // Native hosts install this handler before navigation; its absence preserves browser behavior.
-  const handler = (
-    window as unknown as {
-      webkit?: { messageHandlers?: { openclawLink?: WebKitMessageHandler } };
-    }
-  ).webkit?.messageHandlers?.openclawLink;
+  const handler = webKitHostWindow()?.webkit?.messageHandlers?.openclawLink;
   return handler?.postMessage.bind(handler);
 }
 
-function getNativeUpdateHandler(): WebKitUpdateMessageHandler | undefined {
-  return (
-    window as unknown as {
-      webkit?: { messageHandlers?: { openclawUpdate?: WebKitUpdateMessageHandler } };
-    }
-  ).webkit?.messageHandlers?.openclawUpdate;
+function getNativeUpdateHandler() {
+  return webKitHostWindow()?.webkit?.messageHandlers?.openclawUpdate;
 }
 
 export function hasNativeUpdateBridge(): boolean {
@@ -120,7 +96,7 @@ function menuContainer(event: Event): HTMLElement {
 }
 
 function postNativeLink(
-  postMessage: WebKitMessageHandler["postMessage"],
+  postMessage: NativeLinkPoster,
   url: URL,
   target: NativeLinkTarget,
 ): boolean {
@@ -199,7 +175,7 @@ export function startNativeLinkRouting(options: NativeLinkRoutingOptions = {}): 
     menu = null;
   };
   const showMenu = async (
-    nativePostMessage: WebKitMessageHandler["postMessage"],
+    nativePostMessage: NativeLinkPoster,
     anchor: HTMLAnchorElement,
     url: URL,
     x: number,

--- a/ui/src/app/native-nav-state.ts
+++ b/ui/src/app/native-nav-state.ts
@@ -1,23 +1,10 @@
-export type NativeNavState = {
-  collapsed: boolean;
-  width: number;
-};
+import { webKitHostWindow, type WebKitHostMessages } from "./native-webkit-bridge.ts";
 
-type WebKitMessageHandler = {
-  postMessage(message: unknown): void;
-};
-
-type WebKitBridgeWindow = Window & {
-  webkit?: {
-    messageHandlers?: {
-      openclawNav?: WebKitMessageHandler;
-    };
-  };
-};
+export type NativeNavState = Omit<WebKitHostMessages["openclawNav"], "type">;
 
 export function postNativeNavState(state: NativeNavState): void {
   try {
-    (window as WebKitBridgeWindow).webkit?.messageHandlers?.openclawNav?.postMessage({
+    webKitHostWindow()?.webkit?.messageHandlers?.openclawNav?.postMessage({
       type: "nav-state",
       ...state,
     });

--- a/ui/src/app/native-notifications.ts
+++ b/ui/src/app/native-notifications.ts
@@ -1,3 +1,5 @@
+import { webKitHostWindow } from "./native-webkit-bridge.ts";
+
 export type NativeNotificationsPermission = "granted" | "denied" | "notDetermined";
 
 export type NativeNotificationTestOutcome =
@@ -10,29 +12,14 @@ type NativeNotificationsSnapshot = {
   test: NativeNotificationTestOutcome | null;
 };
 
-type NativeNotificationsMessage =
-  | { type: "status" }
-  | { type: "request-permission" }
-  | { type: "send-test" }
-  | ({ type: "background-session-completed" } & NativeBackgroundSessionCompletion);
-
 type NativeBackgroundSessionCompletion = {
   runId: string;
   path: string;
   search?: string;
 };
 
-type WebKitNotificationsMessageHandler = {
-  postMessage(message: NativeNotificationsMessage): void;
-};
-
 type NativeNotificationsWindow = Window & {
   __OPENCLAW_NATIVE_NOTIFICATIONS__?: unknown;
-  webkit?: {
-    messageHandlers?: {
-      openclawNotifications?: WebKitNotificationsMessageHandler;
-    };
-  };
 };
 
 // Wire contract with the Mac app's dashboard bridge (DashboardWindowController+Notifications.swift).
@@ -77,14 +64,8 @@ function snapshotFrom(value: unknown): NativeNotificationsSnapshot | null {
   return null;
 }
 
-function getNativeNotificationsPoster():
-  | WebKitNotificationsMessageHandler["postMessage"]
-  | undefined {
-  if (typeof window === "undefined") {
-    return undefined;
-  }
-  const handler = (window as NativeNotificationsWindow).webkit?.messageHandlers
-    ?.openclawNotifications;
+function getNativeNotificationsPoster() {
+  const handler = webKitHostWindow()?.webkit?.messageHandlers?.openclawNotifications;
   return handler?.postMessage.bind(handler);
 }
 

--- a/ui/src/app/native-webkit-bridge.ts
+++ b/ui/src/app/native-webkit-bridge.ts
@@ -1,0 +1,34 @@
+export type WebKitHostMessages = {
+  openclawLink: { type: "open-link"; url: string; target: "external" };
+  openclawUpdate: { type: "start-update" };
+  openclawNav: { type: "nav-state"; collapsed: boolean; width: number };
+  openclawWindowDrag: { type: "window-drag" };
+  openclawGateways:
+    | { type: "select" | "open-window" | "set-primary"; id: string }
+    | { type: "open-settings" };
+  openclawNotifications:
+    | { type: "status" | "request-permission" | "send-test" }
+    | {
+        type: "background-session-completed";
+        runId: string;
+        path: string;
+        search?: string;
+      };
+};
+
+type WebKitMessageHandler<Message> = {
+  postMessage(message: Message): void;
+};
+
+type WebKitHostWindow = Window & {
+  webkit?: {
+    messageHandlers?: {
+      [Name in keyof WebKitHostMessages]?: WebKitMessageHandler<WebKitHostMessages[Name]>;
+    };
+  };
+};
+
+export function webKitHostWindow(): WebKitHostWindow | undefined {
+  // SAFETY: WebKit owns this optional ambient bridge and the mapped contract narrows every handler.
+  return typeof window === "undefined" ? undefined : (window as WebKitHostWindow);
+}

--- a/ui/src/app/native-window-drag.ts
+++ b/ui/src/app/native-window-drag.ts
@@ -1,17 +1,9 @@
-type NativeWindowDragMessage = { type: "window-drag" };
+import { webKitHostWindow } from "./native-webkit-bridge.ts";
 
-type WebKitMessageHandler = {
-  postMessage(message: NativeWindowDragMessage): void;
-};
-
-function getNativeWindowDragPoster(): WebKitMessageHandler["postMessage"] | undefined {
+function getNativeWindowDragPoster() {
   // Native macOS hosts install this handler before navigation; its absence
   // (plain browsers, other hosts) keeps default mouse behavior.
-  const handler = (
-    window as unknown as {
-      webkit?: { messageHandlers?: { openclawWindowDrag?: WebKitMessageHandler } };
-    }
-  ).webkit?.messageHandlers?.openclawWindowDrag;
+  const handler = webKitHostWindow()?.webkit?.messageHandlers?.openclawWindowDrag;
   return handler?.postMessage.bind(handler);
 }
 


### PR DESCRIPTION
## What Problem This Solves

The Control UI repeated ad hoc `window.webkit.messageHandlers` shapes and chained assertions across native navigation, notifications, gateway selection, link routing, and window dragging. Those copies could drift from one another and weakened compile-time checking at the WebKit boundary.

## Why This Change Was Made

A single mapped `WebKitHostMessages` contract now types every host-owned handler. Existing native modules read that bridge directly, removing duplicated assertions while preserving optional/disappearing-handler behavior.

The link handler remains deliberately external-only. Inline presentation continues through the browser-panel path and is not part of the native `openclawLink` message contract.

## User Impact

No user-visible behavior change. Native Control UI behavior keeps the same lazy loading, Settings takeover, cleanup, and routing semantics with one checked host bridge.

## Evidence

- Prior exact-head `pnpm check:changed` passed before a clean rebase whose changed files were untouched upstream.
- Rebased exact head `1f727d4300a` passes 50 focused native bridge/link/navigation/notification tests, assertion ratchet, and formatting.
- Structured P0–P2 review identified one overly broad inline link target; it was narrowed to the actual external-only native contract and the focused suite reran green.
- Diff: 57 additions, 93 deletions; net −36 LOC.
