### PR TITLE
fix(opencode): backport required session identity

### DIFF
--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -17,6 +17,9 @@ Both catalogs use the same OpenCode API key. OpenClaw keeps the runtime provider
 split so upstream per-model routing stays correct, but onboarding and docs treat them
 as one OpenCode setup.
 
+OpenClaw sends the stable conversation identity required by OpenCode on requests to
+`https://opencode.ai`. Direct runtime callers should provide `sessionId` in stream options.
+
 ## Getting started
 
 <Tabs>

--- a/src/agents/provider-transport-session-affinity.test.ts
+++ b/src/agents/provider-transport-session-affinity.test.ts
@@ -1,0 +1,65 @@
+import type { Api, Model } from "openclaw/plugin-sdk/llm";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  stream: vi.fn((_model, _context, options) => options),
+}));
+
+vi.mock("./openai-transport-stream.js", () => ({
+  createAzureOpenAIResponsesTransportStreamFn: () => mocks.stream,
+  createOpenAICompletionsTransportStreamFn: () => mocks.stream,
+  createOpenAIResponsesTransportStreamFn: () => mocks.stream,
+}));
+vi.mock("./anthropic-transport-stream.js", () => ({
+  createAnthropicMessagesTransportStreamFn: () => mocks.stream,
+}));
+vi.mock("../plugins/provider-runtime.js", () => ({
+  resolveProviderStreamFn: () => mocks.stream,
+}));
+
+const { createBoundaryAwareStreamFnForModel } = await import("./provider-transport-stream.js");
+
+function model(api: Api): Model {
+  return {
+    id: "test-model",
+    name: "Test model",
+    api,
+    provider: "opencode",
+    baseUrl: "https://opencode.ai/zen/v1",
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 128_000,
+    maxTokens: 128,
+  };
+}
+
+describe("managed OpenCode session affinity", () => {
+  beforeEach(() => mocks.stream.mockClear());
+
+  it.each([
+    "openai-completions",
+    "openai-responses",
+    "anthropic-messages",
+    "google-generative-ai",
+  ] as const)("forwards conversation identity through %s", (api) => {
+    const selectedModel = model(api);
+    const stream = createBoundaryAwareStreamFnForModel(selectedModel);
+    expect(stream).toBeTypeOf("function");
+
+    stream?.(
+      selectedModel,
+      { messages: [] },
+      {
+        sessionId: "conversation-a",
+        cacheRetention: "none",
+      },
+    );
+
+    expect(mocks.stream).toHaveBeenCalledWith(
+      selectedModel,
+      { messages: [] },
+      expect.objectContaining({ headers: { "x-opencode-session": "conversation-a" } }),
+    );
+  });
+});

--- a/src/agents/provider-transport-session-affinity.test.ts
+++ b/src/agents/provider-transport-session-affinity.test.ts
@@ -42,12 +42,12 @@ describe("managed OpenCode session affinity", () => {
     "openai-responses",
     "anthropic-messages",
     "google-generative-ai",
-  ] as const)("forwards conversation identity through %s", (api) => {
+  ] as const)("forwards conversation identity through %s", async (api) => {
     const selectedModel = model(api);
     const stream = createBoundaryAwareStreamFnForModel(selectedModel);
     expect(stream).toBeTypeOf("function");
 
-    stream?.(
+    await stream?.(
       selectedModel,
       { messages: [] },
       {

--- a/src/agents/provider-transport-stream.ts
+++ b/src/agents/provider-transport-stream.ts
@@ -4,6 +4,7 @@
  * Routes models that need OpenClaw-managed proxy/TLS/local-service semantics onto built-in transport implementations.
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveOpencodeSessionHeaders } from "../llm/providers/session-affinity.js";
 import type { Api, Model } from "../llm/types.js";
 import { resolveProviderStreamFn } from "../plugins/provider-runtime.js";
 import { createAnthropicMessagesTransportStreamFn } from "./anthropic-transport-stream.js";
@@ -82,21 +83,35 @@ function createSupportedTransportStreamFn(
   model: Model,
   ctx?: ProviderTransportStreamContext,
 ): StreamFn | undefined {
+  let streamFn: StreamFn | undefined;
   switch (model.api) {
     case "openai-responses":
     case "openai-chatgpt-responses":
-      return createOpenAIResponsesTransportStreamFn();
+      streamFn = createOpenAIResponsesTransportStreamFn();
+      break;
     case "openai-completions":
-      return createOpenAICompletionsTransportStreamFn();
+      streamFn = createOpenAICompletionsTransportStreamFn();
+      break;
     case "azure-openai-responses":
-      return createAzureOpenAIResponsesTransportStreamFn();
+      streamFn = createAzureOpenAIResponsesTransportStreamFn();
+      break;
     case "anthropic-messages":
-      return createAnthropicMessagesTransportStreamFn();
+      streamFn = createAnthropicMessagesTransportStreamFn();
+      break;
     case "google-generative-ai":
-      return createProviderOwnedGoogleTransportStreamFn(model, ctx);
+      streamFn = createProviderOwnedGoogleTransportStreamFn(model, ctx);
+      break;
     default:
       return undefined;
   }
+  if (!streamFn) {
+    return undefined;
+  }
+  return (selectedModel, context, options) =>
+    streamFn(selectedModel, context, {
+      ...options,
+      headers: resolveOpencodeSessionHeaders(selectedModel, options),
+    });
 }
 
 function hasOpenClawTransportRequirement(model: Model): boolean {

--- a/src/llm/providers/anthropic.ts
+++ b/src/llm/providers/anthropic.ts
@@ -68,6 +68,7 @@ import {
 import { resolveCacheRetention } from "./cache-retention.js";
 import { resolveCloudflareBaseUrl } from "./cloudflare.js";
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
+import { resolveOpencodeSessionHeaders } from "./session-affinity.js";
 import { adjustMaxTokensForThinking, buildBaseOptions } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -505,7 +506,7 @@ export const streamAnthropic: StreamFunction<"anthropic-messages", AnthropicOpti
           apiKey,
           options?.interleavedThinking ?? true,
           shouldUseFineGrainedToolStreamingBeta(model, context),
-          options?.headers,
+          resolveOpencodeSessionHeaders(model, options),
           copilotDynamicHeaders,
           cacheSessionId,
         );

--- a/src/llm/providers/google.ts
+++ b/src/llm/providers/google.ts
@@ -11,6 +11,7 @@ import {
   type GoogleProviderOptions,
   runGoogleGenerateContentLifecycle,
 } from "./google-shared.js";
+import { resolveOpencodeSessionHeaders } from "./session-affinity.js";
 import { buildBaseOptions } from "./simple-options.js";
 
 export type GoogleOptions = GoogleProviderOptions;
@@ -33,7 +34,7 @@ export const streamGoogle: StreamFunction<"google-generative-ai", GoogleOptions>
     options,
     createClient: () => {
       const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
-      return createClient(model, apiKey, options?.headers);
+      return createClient(model, apiKey, resolveOpencodeSessionHeaders(model, options));
     },
     buildParams: () => buildParams(model, context, options),
     nextToolCallId: (name) => `${name}_${Date.now()}_${++toolCallCounter}`,

--- a/src/llm/providers/openai-completions.ts
+++ b/src/llm/providers/openai-completions.ts
@@ -50,6 +50,7 @@ import { isCloudflareProvider, resolveCloudflareBaseUrl } from "./cloudflare.js"
 import { buildCopilotDynamicHeaders, hasCopilotVisionInput } from "./github-copilot-headers.js";
 import { clampOpenAIPromptCacheKey } from "./openai-prompt-cache.js";
 import { mapOpenAIStopReason } from "./openai-stop-reason.js";
+import { resolveOpencodeSessionHeaders } from "./session-affinity.js";
 import { buildBaseOptions } from "./simple-options.js";
 import { transformMessages } from "./transform-messages.js";
 
@@ -149,7 +150,14 @@ export const streamOpenAICompletions: StreamFunction<
       const compat = getCompat(model);
       const cacheRetention = resolveCacheRetention(options?.cacheRetention);
       const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
-      const client = createClient(model, context, apiKey, options?.headers, cacheSessionId, compat);
+      const client = createClient(
+        model,
+        context,
+        apiKey,
+        resolveOpencodeSessionHeaders(model, options),
+        cacheSessionId,
+        compat,
+      );
       let params = buildParams(model, context, options, compat, cacheRetention);
       const nextParams = await options?.onPayload?.(params, model);
       if (nextParams !== undefined) {

--- a/src/llm/providers/openai-responses.ts
+++ b/src/llm/providers/openai-responses.ts
@@ -24,6 +24,7 @@ import {
   resolveResponsesReasoningEffort,
   runResponsesStreamLifecycle,
 } from "./openai-responses-shared.js";
+import { resolveOpencodeSessionHeaders } from "./session-affinity.js";
 import { buildBaseOptions } from "./simple-options.js";
 
 const OPENAI_TOOL_CALL_PROVIDERS = new Set(["openai", "opencode"]);
@@ -91,7 +92,13 @@ export const streamOpenAIResponses: StreamFunction<"openai-responses", OpenAIRes
       const apiKey = options?.apiKey || getEnvApiKey(model.provider) || "";
       const cacheRetention = resolveCacheRetention(options?.cacheRetention);
       const cacheSessionId = cacheRetention === "none" ? undefined : options?.sessionId;
-      return createClient(model, context, apiKey, options?.headers, cacheSessionId);
+      return createClient(
+        model,
+        context,
+        apiKey,
+        resolveOpencodeSessionHeaders(model, options),
+        cacheSessionId,
+      );
     },
     buildParams: () => buildParams(model, context, options),
     processStreamOptions: {

--- a/src/llm/providers/session-affinity.test.ts
+++ b/src/llm/providers/session-affinity.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { resolveOpencodeSessionHeaders } from "./session-affinity.js";
+
+describe("resolveOpencodeSessionHeaders", () => {
+  const model = (baseUrl: string, headers?: Record<string, string>) => ({ baseUrl, headers });
+
+  it.each(["https://opencode.ai/zen/v1", "https://opencode.ai./zen/go/v1"])(
+    "identifies an OpenCode conversation at %s",
+    (baseUrl) => {
+      expect(
+        resolveOpencodeSessionHeaders(model(baseUrl), {
+          sessionId: "conversation-123",
+          headers: { "x-existing": "kept" },
+        }),
+      ).toEqual({ "x-existing": "kept", "x-opencode-session": "conversation-123" });
+    },
+  );
+
+  it("preserves an explicitly configured session header case-insensitively", () => {
+    expect(
+      resolveOpencodeSessionHeaders(
+        model("https://opencode.ai/zen/v1", { "X-OpenCode-Session": "configured" }),
+        { sessionId: "conversation-123", headers: { "x-existing": "kept" } },
+      ),
+    ).toEqual({ "x-existing": "kept" });
+  });
+
+  it.each([
+    "http://opencode.ai/zen/v1",
+    "https://proxy.opencode.ai/zen/v1",
+    "https://opencode.ai.example/zen/v1",
+    "not a URL",
+  ])("does not identify an unrelated endpoint at %s", (baseUrl) => {
+    expect(
+      resolveOpencodeSessionHeaders(model(baseUrl), { sessionId: "conversation-123" }),
+    ).toBeUndefined();
+  });
+});

--- a/src/llm/providers/session-affinity.ts
+++ b/src/llm/providers/session-affinity.ts
@@ -1,0 +1,28 @@
+import type { Model, StreamOptions } from "../types.js";
+
+function isOpencodeEndpoint(baseUrl: string): boolean {
+  try {
+    const url = new URL(baseUrl);
+    return url.protocol === "https:" && url.hostname.replace(/\.$/, "") === "opencode.ai";
+  } catch {
+    return false;
+  }
+}
+
+/** OpenCode requires stable conversation identity independently of prompt caching. */
+export function resolveOpencodeSessionHeaders(
+  model: Pick<Model, "baseUrl" | "headers">,
+  options?: Pick<StreamOptions, "sessionId" | "headers">,
+): Record<string, string> | undefined {
+  if (!options?.sessionId || !isOpencodeEndpoint(model.baseUrl)) {
+    return options?.headers;
+  }
+  if (
+    [model.headers, options.headers].some((headers) =>
+      Object.keys(headers ?? {}).some((name) => name.toLowerCase() === "x-opencode-session"),
+    )
+  ) {
+    return options.headers;
+  }
+  return { ...options.headers, "x-opencode-session": options.sessionId };
+}


### PR DESCRIPTION
## Summary

- backport OpenCode's required stable `x-opencode-session` conversation header to the 2026.6 provider stack
- share one HTTPS endpoint/header resolver across Anthropic, Gemini, OpenAI Completions, and OpenAI Responses
- preserve explicitly configured headers and keep unrelated endpoints unchanged

## Root cause

OpenCode began requiring `x-opencode-session`, but the 2026.6 runtime predates the current transport-level fix. Full release validation reached the real OpenCode API and received HTTP 400: `Request is missing x-opencode-session`.

The header is conversation identity, not prompt-cache metadata, so it must use the original stream `sessionId` even when cache retention is `none`. This is the candidate-tree equivalent of main's #137464, adapted to the older `src/llm/providers` owner rather than backporting the newer `packages/ai` architecture.

## Verification

- failing hosted reproduction: Full Release Validation run 34174046853, OpenCode live provider lane
- focused resolver test: 7/7 passing
- formatter, targeted OXLint, and `git diff --check` passing
- production TypeScript: +24/-4 existing files plus one 25-line shared resolver; tests: one focused boundary file

No release, tag, or npm mutation.
