### PR TITLE
fix(directives): preserve indented code in markdown containers

### DIFF
--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -149,6 +149,27 @@ describe("parseInlineDirectives", () => {
     expect(result.text).toBe("    keep this indent\n        and this one");
   });
 
+  test.each([
+    ["quoted four-space", '> Example\n>\n>     print("a  b")'],
+    ["quoted tab", '> Example\n>\n> \tprint("a  b")'],
+    ["nested quote", '> > Example\n> >\n> >     print("a  b")'],
+  ])("preserves %s code bytes after recording reply intent", (_name, code) => {
+    const result = parseInlineDirectives(`[[reply_to_current]]\n${code}`);
+
+    expect(result.hasReplyTag).toBe(true);
+    expect(result.replyToCurrent).toBe(true);
+    expect(result.text).toBe(code);
+  });
+
+  test("preserves quoted directive examples beside an active audio directive", () => {
+    const code = "> Example\n>\n>     [[reply_to:literal-example]]";
+    const result = parseInlineDirectives(`[[audio_as_voice]]\n${code}`);
+
+    expect(result.audioAsVoice).toBe(true);
+    expect(result.hasReplyTag).toBe(false);
+    expect(result.text).toBe(code);
+  });
+
   test("preserves fenced code block indentation after stripping a reply tag", () => {
     const input = [
       "[[reply_to_current]]",

--- a/src/utils/directive-tags.test.ts
+++ b/src/utils/directive-tags.test.ts
@@ -151,7 +151,7 @@ describe("parseInlineDirectives", () => {
 
   test.each([
     ["quoted four-space", '> Example\n>\n>     print("a  b")'],
-    ["quoted tab", '> Example\n>\n> \tprint("a  b")'],
+    ["quoted tab", '> Example\n>\n> \t\tprint("a  b")'],
     ["nested quote", '> > Example\n> >\n> >     print("a  b")'],
   ])("preserves %s code bytes after recording reply intent", (_name, code) => {
     const result = parseInlineDirectives(`[[reply_to_current]]\n${code}`);
@@ -159,6 +159,14 @@ describe("parseInlineDirectives", () => {
     expect(result.hasReplyTag).toBe(true);
     expect(result.replyToCurrent).toBe(true);
     expect(result.text).toBe(code);
+  });
+
+  test("normalizes a single tab after a quote marker as prose", () => {
+    const result = parseInlineDirectives('[[reply_to_current]]\n> \tprint("a  b")');
+
+    expect(result.hasReplyTag).toBe(true);
+    expect(result.replyToCurrent).toBe(true);
+    expect(result.text).toBe('> print("a b")');
   });
 
   test("preserves quoted directive examples beside an active audio directive", () => {

--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -69,13 +69,12 @@ export function replaceOutsideCodeRegions(
 }
 
 function normalizeDirectiveWhitespace(text: string): string {
-  // Extract → normalize prose → restore:
-  // Stash every code block (fenced ``` / ~~~ and indent-code 4-space/tab)
-  // under a sentinel-delimited placeholder so the prose regexes never touch them.
+  // Stash canonical code regions before normalizing prose. Indented code also
+  // occurs inside Markdown containers without any backtick or tilde delimiter.
   const blockSentinel = createBlockSentinel(text);
   const blockPlaceholderRe = new RegExp(`${blockSentinel}(\\d+)${blockSentinel}`, "g");
   const blocks: string[] = [];
-  const codeRegions = text.includes("`") || text.includes("~~~") ? findCodeRegions(text) : [];
+  const codeRegions = findCodeRegions(text);
   let masked = "";
   let cursor = 0;
   // The canonical scanner keeps false closers, indented closers, and open fences intact.
@@ -84,10 +83,7 @@ function normalizeDirectiveWhitespace(text: string): string {
     masked += `${text.slice(cursor, span.start)}${blockSentinel}${blocks.length - 1}${blockSentinel}`;
     cursor = span.end;
   }
-  masked = `${masked}${text.slice(cursor)}`.replace(/(?:(?:^|\n)(?:    |\t)[^\n]*)+/gm, (block) => {
-    blocks.push(block);
-    return `${blockSentinel}${blocks.length - 1}${blockSentinel}`;
-  });
+  masked += text.slice(cursor);
 
   const normalized = masked
     .replace(/\r\n/g, "\n")


### PR DESCRIPTION
## What Problem This Solves

Assistant replies with a reply or audio directive can lose whitespace inside quoted indented-code examples. A valid block quote containing `print("a  b")` can become ordinary quoted prose containing `print("a b")` while the directive is removed.

## Why This Change Was Made

Use the existing CommonMark-aware code-region scanner for every code region before normalizing prose. Remove the competing top-level indentation fallback. This keeps one owner for fenced, inline, standalone indented, quoted, and nested-container code.

## User Impact

Quoted code retains its source bytes and native Telegram code formatting. Reply and audio intent stay separate from visible text. Ordinary prose normalization and explicit reply-ID precedence remain intact.

## Evidence

- Exact candidate: `0a34ee8a2c5d5a90e5e7785fbe8ab30843d2889a`; baseline pin: `e05374f88389c1c226c2dbfd1ebd14fd73e7e686`.
- Real Telegram Test Server proof used one native Testbox, one fresh credential lease, one DM recorder, and the same deterministic provider across baseline and candidate Gateway starts. Baseline collapsed the string spaces and lost native code formatting. The candidate preserved `print("a  b")` with a native code entity and replied once to the correct originating user message.
- Public history and distinct-process SQLite readback preserved the exact stripped Markdown source and `replyToCurrent: true`. Earlier baseline history remained unchanged. Telegram renders Markdown syntax, so stored source bytes and native displayed code were checked separately.
- Fifteen parser/producer/persistence controls per runtime cover quoted spaces and tabs, nested quotes, literal directives, audio intent, fenced/inline/list/table code, prose, CRLF, no-directive text, and explicit reply precedence. A fresh independent validator repeated the real Telegram pair and all controls with new inputs: 15 observable clauses passed; source-only ownership and build identity were reviewed separately.
- 421 focused and sibling tests passed, with changed-file lint and line/assertion ratchets. The new regressions failed on the actual baseline: four quoted-code failures and 35 passing controls. Fresh source review found no actionable P0–P2 defect.
- [Exact-head hosted CI](https://github.com/openclaw/openclaw/actions/runs/34179128079) remains red because [MCP runtime cleanup](https://github.com/openclaw/openclaw/actions/runs/34179128079/job/101914651112) fails during a Codex thread-setup test. Its acquisition/disposal, logging and assertion paths do not call the changed normalizer, and the added directive tests are outside that worker's selector. The precise lower-level close failure is unlogged. This failure and the aggregate gate are retained for the guarded unrelated-failure route; no green CI result is claimed.

The selected Telegram proof uses existing non-streaming, `replyToMode: first`, and `richMessages: false` settings. Audio controls verify parsing and metadata, not a voice upload. No schema, configuration option, parser, protocol, retry, provider branch, or authorization change is added. Production is +4/-8; tests are +29/-0. No external model credentials or production Telegram account were used.
