### PR TITLE
fix(test): preserve Doctor config across SecretRef scenarios

### DIFF
--- a/test/e2e/qa-lab/runtime/doctor-auth-secretref-checks.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/doctor-auth-secretref-checks.e2e.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { stripAnsiSequences } from "../../../../packages/terminal-core/src/ansi.js";
+import { createConfigIO } from "../../../../src/config/io.js";
 import type { OpenClawConfig } from "../../../../src/config/types.openclaw.js";
 import { withSecureTestNodeCommand } from "../../../../src/secrets/test-node-command.test-support.js";
 import {
@@ -32,7 +33,17 @@ function normalizedOutputOf(result: { stderr: string; stdout: string }): string 
 }
 
 async function writeConfig(config: OpenClawConfig): Promise<void> {
-  await instance?.state.writeConfig(config);
+  const activeInstance = instance;
+  if (!activeInstance) {
+    throw new Error("Doctor test instance is not initialized");
+  }
+  const io = createConfigIO({
+    env: activeInstance.env,
+    configPath: activeInstance.configPath,
+    homedir: () => activeInstance.homeDir,
+  });
+  // Keep Doctor-authored fields so the next scenario is not a config-clobber recovery.
+  await io.writeConfigFile({ ...(await io.readSourceConfigBestEffort()), ...config });
 }
 
 function localGatewayConfig(token?: GatewayToken): OpenClawConfig {


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the Doctor SecretRef release-verification scenario fails with a missing execution marker after an earlier repair. Reproduced on current main: the next scenario silently exercises the earlier unresolved environment reference instead of its configured exec reference.

## Why This Change Was Made

The fixture replaced the entire configuration through raw file writes, discarding Doctor-authored metadata and defaults. Existing config-clobber recovery then restored the earlier configuration. Update the isolated fixture through canonical config IO and preserve the existing root fields while replacing each scenario's gateway and secrets configuration.

## User Impact

No runtime behavior changes. Release verification can exercise SecretRef ownership, resolution, fallback rejection, exec gating, and token generation without accidentally testing config-clobber recovery. All assertions and deadlines remain unchanged.

## Evidence

The unchanged six-CLI scenario fails with the same missing marker on main `48d1551a3327a154ebba5caab03486ae82bf7479`; captured before/after config proves recovery restores the earlier reference. The same bounded repair has passed the complete scenario on the release cut. Current-main repaired scenario passes (1/1, all six CLI steps); `check-changed` passes including test-root typecheck and targeted lint; fresh P2 review has no actionable findings. This maintainer-directed test repair is part of release preparation.
