### PR TITLE
fix(history): preserve message ID code examples

### DIFF
--- a/src/auto-reply/reply/display-text-sanitize.ts
+++ b/src/auto-reply/reply/display-text-sanitize.ts
@@ -1,14 +1,9 @@
 // Removes internal runtime context from text shown back to users.
+// Keep this leaf free of Markdown parsing: terminal and transformed SDK paths import it.
 import { stripInternalRuntimeContext } from "../../agents/internal-runtime-context.js";
-import { stripEnvelope, stripMessageIdHints } from "../../shared/chat-envelope.js";
 import { stripInboundMetadata } from "./strip-inbound-meta.js";
 
 /** Removes internal runtime metadata before showing text to users. */
 export function stripInternalMetadataForDisplay(text: string): string {
   return stripInboundMetadata(stripInternalRuntimeContext(text));
-}
-
-/** Removes user-envelope and message-id hints from display text. */
-export function stripUserEnvelopeForDisplay(text: string): string {
-  return stripMessageIdHints(stripEnvelope(stripInternalMetadataForDisplay(text)));
 }

--- a/src/auto-reply/reply/user-envelope-display.ts
+++ b/src/auto-reply/reply/user-envelope-display.ts
@@ -1,0 +1,8 @@
+import { stripEnvelope } from "../../shared/chat-envelope.js";
+import { stripMessageIdHints } from "../../shared/text/message-id-hints.js";
+import { stripInternalMetadataForDisplay } from "./display-text-sanitize.js";
+
+/** Removes user-envelope and message-id hints from display text. */
+export function stripUserEnvelopeForDisplay(text: string): string {
+  return stripMessageIdHints(stripEnvelope(stripInternalMetadataForDisplay(text)));
+}

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -1,10 +1,8 @@
 // Gateway chat display sanitizer.
 // Removes OpenClaw-only envelopes before messages are shown in UI/RPC results.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
-import {
-  stripInternalMetadataForDisplay,
-  stripUserEnvelopeForDisplay,
-} from "../auto-reply/reply/display-text-sanitize.js";
+import { stripInternalMetadataForDisplay } from "../auto-reply/reply/display-text-sanitize.js";
+import { stripUserEnvelopeForDisplay } from "../auto-reply/reply/user-envelope-display.js";
 import { extractInboundSenderLabel } from "../auto-reply/reply/strip-inbound-meta.js";
 import { stripEnvelope } from "../shared/chat-envelope.js";
 

--- a/src/gateway/chat-sanitize.ts
+++ b/src/gateway/chat-sanitize.ts
@@ -2,8 +2,8 @@
 // Removes OpenClaw-only envelopes before messages are shown in UI/RPC results.
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { stripInternalMetadataForDisplay } from "../auto-reply/reply/display-text-sanitize.js";
-import { stripUserEnvelopeForDisplay } from "../auto-reply/reply/user-envelope-display.js";
 import { extractInboundSenderLabel } from "../auto-reply/reply/strip-inbound-meta.js";
+import { stripUserEnvelopeForDisplay } from "../auto-reply/reply/user-envelope-display.js";
 import { stripEnvelope } from "../shared/chat-envelope.js";
 
 // Gateway chat history display strips internal/user envelopes while preserving

--- a/src/gateway/control-ui-public-session-render.ts
+++ b/src/gateway/control-ui-public-session-render.ts
@@ -2,10 +2,8 @@ import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import MarkdownIt from "markdown-it";
 import { isHeartbeatOkResponse, isHeartbeatUserMessage } from "../auto-reply/heartbeat-filter.js";
 import { HEARTBEAT_PROMPT } from "../auto-reply/heartbeat.js";
-import {
-  stripInternalMetadataForDisplay,
-  stripUserEnvelopeForDisplay,
-} from "../auto-reply/reply/display-text-sanitize.js";
+import { stripInternalMetadataForDisplay } from "../auto-reply/reply/display-text-sanitize.js";
+import { stripUserEnvelopeForDisplay } from "../auto-reply/reply/user-envelope-display.js";
 import { redactToolPayloadText } from "../logging/redact.js";
 import { splitMediaFromOutput } from "../media/parse.js";
 import { INTER_SESSION_PROMPT_PREFIX_BASE } from "../sessions/input-provenance.js";

--- a/src/infra/session-cost-usage-reporting.ts
+++ b/src/infra/session-cost-usage-reporting.ts
@@ -3,12 +3,11 @@ import path from "node:path";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 import { stripInboundMetadata } from "../auto-reply/reply/strip-inbound-meta.js";
+import { stripUserEnvelopeForDisplay } from "../auto-reply/reply/user-envelope-display.js";
 import { isPrimarySessionTranscriptFileName } from "../config/sessions/artifacts.js";
 import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { stripEnvelope } from "../shared/chat-envelope.js";
-import { stripMessageIdHints } from "../shared/text/message-id-hints.js";
 import {
   isUsageCostRollupFresh,
   readUsageCostRollups,
@@ -389,14 +388,11 @@ export async function loadSessionLogs(params: {
         }
       }
 
-      let content = contentParts.join("\n").trim();
-      if (!content) {
-        continue;
-      }
-      content = stripInboundMetadata(content);
-      if (role === "user") {
-        content = stripMessageIdHints(stripEnvelope(content)).trim();
-      }
+      const rawText = contentParts.join("\n");
+      let content =
+        role === "user"
+          ? stripUserEnvelopeForDisplay(rawText).trim()
+          : stripInboundMetadata(rawText.trim());
       if (!content) {
         continue;
       }

--- a/src/infra/session-cost-usage-reporting.ts
+++ b/src/infra/session-cost-usage-reporting.ts
@@ -7,7 +7,8 @@ import { isPrimarySessionTranscriptFileName } from "../config/sessions/artifacts
 import { parseSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import type { SessionEntry } from "../config/sessions/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { stripEnvelope, stripMessageIdHints } from "../shared/chat-envelope.js";
+import { stripEnvelope } from "../shared/chat-envelope.js";
+import { stripMessageIdHints } from "../shared/text/message-id-hints.js";
 import {
   isUsageCostRollupFresh,
   readUsageCostRollups,

--- a/src/infra/session-cost-usage.test.ts
+++ b/src/infra/session-cost-usage.test.ts
@@ -2743,6 +2743,42 @@ describe("session cost usage", () => {
     expect(logs?.[0]?.content).toBe("hello there");
   });
 
+  it.each([
+    {
+      name: "indented message-ID code",
+      content: "    [message_id: literal]",
+      expected: "[message_id: literal]",
+    },
+    {
+      name: "fenced code after a generated hint",
+      content: "[message_id: generated]\n```text\n[message_id: literal]\n```",
+      expected: "```text\n[message_id: literal]\n```",
+    },
+    {
+      name: "visible text after internal context",
+      content:
+        "<<<BEGIN_OPENCLAW_INTERNAL_CONTEXT>>>\nprivate runtime context\n<<<END_OPENCLAW_INTERNAL_CONTEXT>>>\nvisible user text",
+      expected: "visible user text",
+    },
+  ])("preserves $name in user usage logs", async ({ content, expected }) => {
+    const root = await makeSessionCostRoot("logs-user-display");
+    const sessionFile = path.join(root, "session.jsonl");
+    await fs.writeFile(
+      sessionFile,
+      JSON.stringify({
+        type: "message",
+        timestamp: "2026-02-21T17:47:00.000Z",
+        message: { role: "user", content },
+      }),
+      "utf-8",
+    );
+    await withStateDir(root, async () => {
+      const logs = await loadSessionLogs({ sessionFile });
+      expect(logs).toHaveLength(1);
+      expect(logs?.[0]?.content).toBe(expected);
+    });
+  });
+
   it("does not split surrogate pairs when truncating session log content", async () => {
     const root = await makeSessionCostRoot("logs-utf16");
     const sessionFile = path.join(root, "session.jsonl");

--- a/src/shared/chat-envelope.test.ts
+++ b/src/shared/chat-envelope.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { stripEnvelope, stripMessageIdHints } from "./chat-envelope.js";
+import { stripEnvelope } from "./chat-envelope.js";
 
 describe("shared/chat-envelope", () => {
   it("strips recognized channel and timestamp envelope prefixes only", () => {
@@ -15,44 +15,5 @@ describe("shared/chat-envelope", () => {
     expect(stripEnvelope("[note] hello")).toBe("[note] hello");
     expect(stripEnvelope("[2026/01/24 13:36] hello")).toBe("[2026/01/24 13:36] hello");
     expect(stripEnvelope("[Teams] hello")).toBe("[Teams] hello");
-  });
-
-  it("removes standalone message id hint lines but keeps inline mentions", () => {
-    expect(stripMessageIdHints("hello\n[message_id: abc123]")).toBe("hello");
-    expect(stripMessageIdHints("hello\n [message_id: abc123] \nworld")).toBe("hello\nworld");
-    expect(stripMessageIdHints("[message_id: abc123]\nhello")).toBe("hello");
-    expect(stripMessageIdHints("[message_id: abc123]")).toBe("");
-    expect(stripMessageIdHints("hello\r\n[MESSAGE_ID: abc123]\r\nworld")).toBe("hello\nworld");
-    expect(stripMessageIdHints("I typed [message_id: abc123] inline")).toBe(
-      "I typed [message_id: abc123] inline",
-    );
-  });
-
-  it("preserves message id examples in code", () => {
-    expect(stripMessageIdHints("```text\n[message_id: abc123]\n```")).toBe(
-      "```text\n[message_id: abc123]\n```",
-    );
-    expect(stripMessageIdHints("    [message_id: abc123]")).toBe("    [message_id: abc123]");
-    expect(stripMessageIdHints("> ```text\n> [message_id: abc123]\n> ```")).toBe(
-      "> ```text\n> [message_id: abc123]\n> ```",
-    );
-  });
-
-  it("removes generated hints surrounding code examples", () => {
-    expect(
-      stripMessageIdHints("[message_id: generated]\n```text\n[message_id: literal]\n```"),
-    ).toBe("```text\n[message_id: literal]\n```");
-    expect(
-      stripMessageIdHints("```text\n[message_id: literal]\n```\n[message_id: generated]"),
-    ).toBe("```text\n[message_id: literal]\n```");
-    expect(
-      stripMessageIdHints("[message_id: generated]\r\n```text\r\n[message_id: literal]\r\n```"),
-    ).toBe("```text\n[message_id: literal]\n```");
-  });
-
-  it("preserves CRLF code when no generated hint is removed", () => {
-    expect(stripMessageIdHints("```text\r\n[message_id: literal]\r\n```")).toBe(
-      "```text\r\n[message_id: literal]\r\n```",
-    );
   });
 });

--- a/src/shared/chat-envelope.test.ts
+++ b/src/shared/chat-envelope.test.ts
@@ -27,4 +27,32 @@ describe("shared/chat-envelope", () => {
       "I typed [message_id: abc123] inline",
     );
   });
+
+  it("preserves message id examples in code", () => {
+    expect(stripMessageIdHints("```text\n[message_id: abc123]\n```")).toBe(
+      "```text\n[message_id: abc123]\n```",
+    );
+    expect(stripMessageIdHints("    [message_id: abc123]")).toBe("    [message_id: abc123]");
+    expect(stripMessageIdHints("> ```text\n> [message_id: abc123]\n> ```")).toBe(
+      "> ```text\n> [message_id: abc123]\n> ```",
+    );
+  });
+
+  it("removes generated hints surrounding code examples", () => {
+    expect(
+      stripMessageIdHints("[message_id: generated]\n```text\n[message_id: literal]\n```"),
+    ).toBe("```text\n[message_id: literal]\n```");
+    expect(
+      stripMessageIdHints("```text\n[message_id: literal]\n```\n[message_id: generated]"),
+    ).toBe("```text\n[message_id: literal]\n```");
+    expect(
+      stripMessageIdHints("[message_id: generated]\r\n```text\r\n[message_id: literal]\r\n```"),
+    ).toBe("```text\n[message_id: literal]\n```");
+  });
+
+  it("preserves CRLF code when no generated hint is removed", () => {
+    expect(stripMessageIdHints("```text\r\n[message_id: literal]\r\n```")).toBe(
+      "```text\r\n[message_id: literal]\r\n```",
+    );
+  });
 });

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -1,3 +1,5 @@
+import { findCodeRegions, isInsideCode, type CodeRegion } from "./text/code-regions.js";
+
 const ENVELOPE_PREFIX = /^\[([^\]]+)\]\s*/;
 const ENVELOPE_CHANNELS = [
   "WebChat",
@@ -44,7 +46,20 @@ export function stripMessageIdHints(text: string): string {
   if (!/\[message_id:/i.test(text)) {
     return text;
   }
-  const lines = text.split(/\r?\n/);
-  const filtered = lines.filter((line) => !MESSAGE_ID_LINE.test(line));
+  // Match parser offsets against the same LF-normalized lines used for removal.
+  // Return the original bytes when no generated hint is removed.
+  const normalized = text.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
+  let offset = 0;
+  let regions: CodeRegion[] | undefined;
+  const filtered = lines.filter((line) => {
+    const markerOffset = line.search(/\[message_id:/i);
+    const shouldRemove =
+      markerOffset >= 0 &&
+      MESSAGE_ID_LINE.test(line) &&
+      !isInsideCode(offset + markerOffset, (regions ??= findCodeRegions(normalized)));
+    offset += line.length + 1;
+    return !shouldRemove;
+  });
   return filtered.length === lines.length ? text : filtered.join("\n");
 }

--- a/src/shared/chat-envelope.ts
+++ b/src/shared/chat-envelope.ts
@@ -1,5 +1,3 @@
-import { findCodeRegions, isInsideCode, type CodeRegion } from "./text/code-regions.js";
-
 const ENVELOPE_PREFIX = /^\[([^\]]+)\]\s*/;
 const ENVELOPE_CHANNELS = [
   "WebChat",
@@ -16,7 +14,6 @@ const ENVELOPE_CHANNELS = [
   "Zalo Personal",
 ];
 
-const MESSAGE_ID_LINE = /^\s*\[message_id:\s*[^\]]+\]\s*$/i;
 function looksLikeEnvelopeHeader(header: string): boolean {
   if (/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}Z\b/.test(header)) {
     return true;
@@ -39,27 +36,4 @@ export function stripEnvelope(text: string): string {
     return text;
   }
   return text.slice(match[0].length);
-}
-
-/** Removes standalone message-id hint lines without touching inline user mentions. */
-export function stripMessageIdHints(text: string): string {
-  if (!/\[message_id:/i.test(text)) {
-    return text;
-  }
-  // Match parser offsets against the same LF-normalized lines used for removal.
-  // Return the original bytes when no generated hint is removed.
-  const normalized = text.replace(/\r\n/g, "\n");
-  const lines = normalized.split("\n");
-  let offset = 0;
-  let regions: CodeRegion[] | undefined;
-  const filtered = lines.filter((line) => {
-    const markerOffset = line.search(/\[message_id:/i);
-    const shouldRemove =
-      markerOffset >= 0 &&
-      MESSAGE_ID_LINE.test(line) &&
-      !isInsideCode(offset + markerOffset, (regions ??= findCodeRegions(normalized)));
-    offset += line.length + 1;
-    return !shouldRemove;
-  });
-  return filtered.length === lines.length ? text : filtered.join("\n");
 }

--- a/src/shared/text/message-id-hints.test.ts
+++ b/src/shared/text/message-id-hints.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { stripMessageIdHints } from "./message-id-hints.js";
+
+describe("shared/text/message-id-hints", () => {
+  it("removes standalone message id hint lines but keeps inline mentions", () => {
+    expect(stripMessageIdHints("hello\n[message_id: abc123]")).toBe("hello");
+    expect(stripMessageIdHints("hello\n [message_id: abc123] \nworld")).toBe("hello\nworld");
+    expect(stripMessageIdHints("[message_id: abc123]\nhello")).toBe("hello");
+    expect(stripMessageIdHints("[message_id: abc123]")).toBe("");
+    expect(stripMessageIdHints("hello\r\n[MESSAGE_ID: abc123]\r\nworld")).toBe("hello\nworld");
+    expect(stripMessageIdHints("I typed [message_id: abc123] inline")).toBe(
+      "I typed [message_id: abc123] inline",
+    );
+  });
+
+  it("preserves message id examples in code", () => {
+    expect(stripMessageIdHints("```text\n[message_id: abc123]\n```")).toBe(
+      "```text\n[message_id: abc123]\n```",
+    );
+    expect(stripMessageIdHints("    [message_id: abc123]")).toBe("    [message_id: abc123]");
+    expect(stripMessageIdHints("> ```text\n> [message_id: abc123]\n> ```")).toBe(
+      "> ```text\n> [message_id: abc123]\n> ```",
+    );
+  });
+
+  it("removes generated hints surrounding code examples", () => {
+    expect(
+      stripMessageIdHints("[message_id: generated]\n```text\n[message_id: literal]\n```"),
+    ).toBe("```text\n[message_id: literal]\n```");
+    expect(
+      stripMessageIdHints("```text\n[message_id: literal]\n```\n[message_id: generated]"),
+    ).toBe("```text\n[message_id: literal]\n```");
+    expect(
+      stripMessageIdHints("[message_id: generated]\r\n```text\r\n[message_id: literal]\r\n```"),
+    ).toBe("```text\n[message_id: literal]\n```");
+  });
+
+  it("preserves CRLF code when no generated hint is removed", () => {
+    expect(stripMessageIdHints("```text\r\n[message_id: literal]\r\n```")).toBe(
+      "```text\r\n[message_id: literal]\r\n```",
+    );
+  });
+});

--- a/src/shared/text/message-id-hints.ts
+++ b/src/shared/text/message-id-hints.ts
@@ -1,0 +1,26 @@
+import { findCodeRegions, isInsideCode, type CodeRegion } from "./code-regions.js";
+
+const MESSAGE_ID_LINE = /^\s*\[message_id:\s*[^\]]+\]\s*$/i;
+
+/** Removes standalone message-id hint lines without touching inline user mentions. */
+export function stripMessageIdHints(text: string): string {
+  if (!/\[message_id:/i.test(text)) {
+    return text;
+  }
+  // Match parser offsets against the same LF-normalized lines used for removal.
+  // Return the original bytes when no generated hint is removed.
+  const normalized = text.replace(/\r\n/g, "\n");
+  const lines = normalized.split("\n");
+  let offset = 0;
+  let regions: CodeRegion[] | undefined;
+  const filtered = lines.filter((line) => {
+    const markerOffset = line.search(/\[message_id:/i);
+    const shouldRemove =
+      markerOffset >= 0 &&
+      MESSAGE_ID_LINE.test(line) &&
+      !isInsideCode(offset + markerOffset, (regions ??= findCodeRegions(normalized)));
+    offset += line.length + 1;
+    return !shouldRemove;
+  });
+  return filtered.length === lines.length ? text : filtered.join("\n");
+}


### PR DESCRIPTION
> **AI-assisted: yes**

## What Problem This Solves

Displayed chat history and usage logs removed literal `[message_id: ...]` lines from Markdown code examples, even though the stored transcript retained them.

## Why This Change Was Made

Message-ID cleanup now uses the existing Markdown code-region parser. Gateway history, public conversation pages, and user usage logs share the same display owner. Usage logs sanitize before trimming, preserving leading indented examples and removing internal runtime context.

The Markdown-aware owner stays separate from lightweight internal-metadata cleanup, so terminal and transformed plugin paths do not gain the parser dependency. Unchanged hint-free history text retains its original bytes and line endings; actual hint removal retains existing LF normalization.

## User Impact

Literal code examples remain visible. Generated standalone hints remain hidden. Assistant handling, public redaction, and existing usage/HTML formatting are preserved. Canonical transcript data is not rewritten.

## Evidence

- Real isolated Gateway reads reproduced the defect on main at `42fa00e04e78f7ada936590b5d1fa95cd3004371`.
- Matching final build `a2ac92164dca547849bf20799f8b26dc355db31a` passes 19 seeded cases through `chat.history`, `sessions.usage.logs`, and local public-session HTTP. Exact ordered SQLite transcript strings, sequence values, and timestamps remain unchanged around every display read.
- Cases cover fenced, indented, quoted, inline, mixed generated/literal, malformed, assistant, sender/envelope, internal-context, CRLF, and public tool/media redaction behavior.
- 113 focused tests pass, with one existing platform-specific skip. The new usage cases fail on the contributor candidate for the intended reasons and pass after repair. Formatting, lint, and source guard checks pass.
- Terminal/metadata import graphs contain no Markdown parser modules. The transformed SDK module and plugin resolver controls also pass.
- Independent source-blind acceptance passes all observable clauses: 120 unchanged before/after transcript snapshot pairs and 40 successful public-page reads. Code-aware review covers shared ownership and dependency isolation. Required CI and final landing review gate the merge.
