### PR TITLE
fix(gateway): classify effective bind/Tailscale conflicts as non-retryable

### DIFF
--- a/src/cli/gateway-cli/run.supervised-lock.test.ts
+++ b/src/cli/gateway-cli/run.supervised-lock.test.ts
@@ -1,6 +1,7 @@
 // Gateway supervised lock tests cover single-runner locking for supervised gateway starts.
 import { createServer } from "node:http";
 import { describe, expect, it, vi } from "vitest";
+import { GatewayEffectiveConfigConflictError } from "../../gateway/server-runtime-config.js";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
 import { TailscaleRouteOwnershipConflictError } from "../../infra/tailscale-route-ownership-error.js";
 import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "../../state/openclaw-agent-db-migration-required.js";
@@ -25,6 +26,16 @@ describe("supervised gateway lock recovery", () => {
   it("uses exit 78 for an ambiguous persistent Tailscale route", () => {
     expect(
       testing.resolveGatewayStartupFailureExitCode(new TailscaleRouteOwnershipConflictError()),
+    ).toBe(78);
+  });
+
+  it("uses exit 78 for an effective bind/Tailscale config conflict", () => {
+    expect(
+      testing.resolveGatewayStartupFailureExitCode(
+        new GatewayEffectiveConfigConflictError(
+          "tailscale serve/funnel requires gateway bind=loopback (127.0.0.1)",
+        ),
+      ),
     ).toBe(78);
   });
 

--- a/src/cli/gateway-cli/run.supervised-lock.test.ts
+++ b/src/cli/gateway-cli/run.supervised-lock.test.ts
@@ -1,7 +1,7 @@
 // Gateway supervised lock tests cover single-runner locking for supervised gateway starts.
 import { createServer } from "node:http";
 import { describe, expect, it, vi } from "vitest";
-import { GatewayEffectiveConfigConflictError } from "../../gateway/server-runtime-config.js";
+import { resolveGatewayRuntimeConfig } from "../../gateway/server-runtime-config.js";
 import { GatewayLockError } from "../../infra/gateway-lock.js";
 import { TailscaleRouteOwnershipConflictError } from "../../infra/tailscale-route-ownership-error.js";
 import { OpenClawAgentDatabaseMediaMigrationRequiredError } from "../../state/openclaw-agent-db-migration-required.js";
@@ -29,14 +29,27 @@ describe("supervised gateway lock recovery", () => {
     ).toBe(78);
   });
 
-  it("uses exit 78 for an effective bind/Tailscale config conflict", () => {
-    expect(
-      testing.resolveGatewayStartupFailureExitCode(
-        new GatewayEffectiveConfigConflictError(
-          "tailscale serve/funnel requires gateway bind=loopback (127.0.0.1)",
-        ),
-      ),
-    ).toBe(78);
+  it("uses exit 78 for an effective bind/Tailscale config conflict", async () => {
+    // Reproduces the reported crash-loop trigger: a persisted gateway.bind=lan
+    // combined with a service-level tailscale serve override is only invalid
+    // once the two are merged, so only runtime resolution (not static config
+    // validation) can detect it.
+    const conflict = await resolveGatewayRuntimeConfig({
+      cfg: {
+        gateway: {
+          bind: "lan",
+          auth: { mode: "token", token: "test-token-123" },
+          tailscale: { mode: "serve" },
+        },
+      },
+      port: 18789,
+    }).catch((err: unknown) => err);
+
+    expect(conflict).toBeInstanceOf(Error);
+    expect((conflict as Error).message).toBe(
+      "tailscale serve/funnel requires gateway bind=loopback (127.0.0.1)",
+    );
+    expect(testing.resolveGatewayStartupFailureExitCode(conflict)).toBe(78);
   });
 
   it("uses exit 78 for offline agent database migration requirements", () => {

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -34,6 +34,7 @@ import {
   isLoopbackHost,
   resolveGatewayBindHost,
 } from "../../gateway/net.js";
+import { isGatewayEffectiveConfigConflictError } from "../../gateway/server-runtime-config.js";
 import { GatewayStartupCleanupError } from "../../gateway/server-shutdown.js";
 import type { GatewayWsLogStyle } from "../../gateway/ws-logging.js";
 import { setGatewayWsLogStyle } from "../../gateway/ws-logging.js";
@@ -428,6 +429,7 @@ function resolveGatewayLockErrorExitCode(err: unknown): number {
 function resolveGatewayStartupFailureExitCode(err: unknown): number {
   return isInvalidConfigError(err) ||
     isTailscaleRouteOwnershipConflictError(err) ||
+    isGatewayEffectiveConfigConflictError(err) ||
     resolveGatewayStartupMaintenanceReason(err)
     ? EXIT_CONFIG_ERROR
     : 1;
@@ -1011,6 +1013,7 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
       isGatewayLockError(error) ||
       isInvalidConfigError(error) ||
       isTailscaleRouteOwnershipConflictError(error) ||
+      isGatewayEffectiveConfigConflictError(error) ||
       collectNestedErrorCandidates(error).some(
         (candidate) => candidate instanceof GatewayStartupCleanupError,
       ) ||

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -38,6 +38,32 @@ type GatewayRuntimeConfig = {
   hooksConfig: ReturnType<typeof resolveHooksConfig>;
 };
 
+const GATEWAY_EFFECTIVE_CONFIG_CONFLICT_CODE = "GATEWAY_EFFECTIVE_CONFIG_CONFLICT";
+
+/**
+ * The effective bind/auth/Tailscale combination (after CLI and service overrides are
+ * applied) is invalid. A supervisor restart cannot fix this without operator action, so
+ * callers must classify it the same as a persisted-config validation failure rather than
+ * a transient startup error eligible for restart.
+ */
+export class GatewayEffectiveConfigConflictError extends Error {
+  readonly code = GATEWAY_EFFECTIVE_CONFIG_CONFLICT_CODE;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "GatewayEffectiveConfigConflictError";
+  }
+}
+
+export function isGatewayEffectiveConfigConflictError(error: unknown): boolean {
+  return (
+    error instanceof GatewayEffectiveConfigConflictError ||
+    (Boolean(error) &&
+      typeof error === "object" &&
+      (error as { code?: unknown }).code === GATEWAY_EFFECTIVE_CONFIG_CONFLICT_CODE)
+  );
+}
+
 /** Startup and reload validate the same security policy against the serving listener. */
 export function assertGatewayRuntimeSecurityConfig(
   params: Pick<
@@ -61,18 +87,22 @@ export function assertGatewayRuntimeSecurityConfig(
 
   assertGatewayAuthConfigured(resolvedAuth, cfg.gateway?.auth);
   if (tailscaleMode === "funnel" && authMode !== "password") {
-    throw new Error(
+    throw new GatewayEffectiveConfigConflictError(
       "tailscale funnel requires gateway auth mode=password (set gateway.auth.password or OPENCLAW_GATEWAY_PASSWORD)",
     );
   }
   if (isUnsafeGatewayTailscaleNoAuth({ authMode, tailscaleMode })) {
-    throw new Error(formatUnsafeGatewayTailscaleNoAuthMessage(tailscaleMode));
+    throw new GatewayEffectiveConfigConflictError(
+      formatUnsafeGatewayTailscaleNoAuthMessage(tailscaleMode),
+    );
   }
   if (tailscaleMode !== "off" && !isLoopbackHost(bindHost)) {
-    throw new Error("tailscale serve/funnel requires gateway bind=loopback (127.0.0.1)");
+    throw new GatewayEffectiveConfigConflictError(
+      "tailscale serve/funnel requires gateway bind=loopback (127.0.0.1)",
+    );
   }
   if (!isLoopbackHost(bindHost) && !hasSharedSecret && authMode !== "trusted-proxy") {
-    throw new Error(
+    throw new GatewayEffectiveConfigConflictError(
       `refusing to bind gateway to ${bindHost}:${params.port} without auth (set gateway.auth.token/password, or set OPENCLAW_GATEWAY_TOKEN/OPENCLAW_GATEWAY_PASSWORD; legacy CLAWDBOT_* and MOLTBOT_* environment variables are ignored)`,
     );
   }
@@ -84,12 +114,12 @@ export function assertGatewayRuntimeSecurityConfig(
   ) {
     // Remote Control UI must use explicit origins unless the operator deliberately accepts
     // Host-header fallback; otherwise any reachable host name can become a browser origin.
-    throw new Error(
+    throw new GatewayEffectiveConfigConflictError(
       "non-loopback Control UI requires gateway.controlUi.allowedOrigins (set explicit origins), or set gateway.controlUi.dangerouslyAllowHostHeaderOriginFallback=true to use Host-header origin fallback mode",
     );
   }
   if (authMode === "trusted-proxy" && !cfg.gateway?.trustedProxies?.length) {
-    throw new Error(
+    throw new GatewayEffectiveConfigConflictError(
       "gateway auth mode=trusted-proxy requires gateway.trustedProxies to be configured with at least one proxy IP",
     );
   }

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -46,7 +46,7 @@ const GATEWAY_EFFECTIVE_CONFIG_CONFLICT_CODE = "GATEWAY_EFFECTIVE_CONFIG_CONFLIC
  * callers must classify it the same as a persisted-config validation failure rather than
  * a transient startup error eligible for restart.
  */
-export class GatewayEffectiveConfigConflictError extends Error {
+class GatewayEffectiveConfigConflictError extends Error {
   readonly code = GATEWAY_EFFECTIVE_CONFIG_CONFLICT_CODE;
 
   constructor(message: string) {

--- a/src/gateway/server-runtime-config.ts
+++ b/src/gateway/server-runtime-config.ts
@@ -58,9 +58,10 @@ class GatewayEffectiveConfigConflictError extends Error {
 export function isGatewayEffectiveConfigConflictError(error: unknown): boolean {
   return (
     error instanceof GatewayEffectiveConfigConflictError ||
-    (Boolean(error) &&
+    (error !== null &&
       typeof error === "object" &&
-      (error as { code?: unknown }).code === GATEWAY_EFFECTIVE_CONFIG_CONFLICT_CODE)
+      "code" in error &&
+      error.code === GATEWAY_EFFECTIVE_CONFIG_CONFLICT_CODE)
   );
 }
 


### PR DESCRIPTION
Closes #141701

## What Problem This Solves

Fixes an issue where the Gateway crash-loops under systemd instead of failing
closed when the *effective* bind/Tailscale/auth combination is invalid but
only becomes invalid after CLI or service-level overrides are applied — for
example, changing `gateway.bind` from `loopback` to `lan` in the persisted
config while a `--tailscale serve` service flag is still active. The
persisted config alone is valid (its own `tailscale.mode` is unset/off), so
the static config-file validator never sees the conflict; it is only
detected at runtime by `assertGatewayRuntimeSecurityConfig` after the
override is merged in.

That function threw a plain `Error`, which `resolveGatewayStartupFailureExitCode`
in `src/cli/gateway-cli/run.ts` does not recognize as a non-retryable
configuration error, so the process exited with code 1. The generated systemd
unit only stops restarting on exit code 78 (`RestartPreventExitStatus=78`,
`src/daemon/systemd-unit.ts:84`), so exit 1 causes an endless supervised
restart loop, printing "Gateway failed to start: tailscale serve/funnel
requires gateway bind=loopback (127.0.0.1)" on every cycle — exactly the
crash-loop reported in the issue.

## Why This Change Was Made

`assertGatewayRuntimeSecurityConfig` (src/gateway/server-runtime-config.ts)
now throws a classified `GatewayEffectiveConfigConflictError` for every
bind/auth/Tailscale conflict it detects (funnel-without-password, unsafe
no-auth exposure, non-loopback Tailscale bind, non-loopback bind without
auth, non-loopback Control UI without allowed origins, trusted-proxy without
configured proxies). `src/cli/gateway-cli/run.ts` treats this new error class
the same way it already treats `InvalidConfigError` and
`TailscaleRouteOwnershipConflictError`: it maps to exit code 78 in
`resolveGatewayStartupFailureExitCode`, and it is excluded from crash-loop
triage in `runGatewayCommandOnce`, since a supervisor restart cannot fix an
invalid effective configuration without operator action.

This does not change any exit code for already-classified errors, and it
does not add new configuration or change any schema — it only classifies an
existing validation error correctly so the CLI's existing exit-code and
triage logic (used for `InvalidConfigError` and
`TailscaleRouteOwnershipConflictError`) also applies here.

The issue's other two suggestions (escalating to SIGKILL for a stuck
state-lock owner, and reporting whether the owning pid is still alive) are
separate lifecycle/diagnostics changes and are left for a follow-up; this PR
only addresses the crash-loop/exit-code classification gap, which is the
part ClawSweeper's review identified as the bounded, reproducible repair.

## Evidence

Added a regression test proving the fix, and confirmed it fails without it:

```
$ git stash push -- src/gateway/server-runtime-config.ts src/cli/gateway-cli/run.ts
$ node scripts/run-vitest.mjs src/cli/gateway-cli/run.supervised-lock.test.ts
 ✓ ... uses exit 78 for an ambiguous persistent Tailscale route
 × ... uses exit 78 for an effective bind/Tailscale config conflict
   → GatewayEffectiveConfigConflictError is not a constructor
 ...
 Test Files  1 failed (1)
      Tests  1 failed | 14 passed (15)

$ git stash pop
$ node scripts/run-vitest.mjs src/cli/gateway-cli/run.supervised-lock.test.ts src/gateway/server-runtime-config.test.ts
 ✓ ... uses exit 78 for an ambiguous persistent Tailscale route
 ✓ ... uses exit 78 for an effective bind/Tailscale config conflict
 ✓ ... uses exit 78 for offline agent database migration requirements
 ...
 Test Files  2 passed (2)
      Tests  15 passed (15)   [run.supervised-lock.test.ts]
      Tests  27 passed (27)   [server-runtime-config.test.ts]
```

Also ran the directly related existing suites to confirm no regressions:

```
$ node scripts/run-vitest.mjs src/config/config.gateway-tailscale-bind.test.ts \
    src/gateway/server-reload-handlers.test.ts src/gateway/config-reload.test.ts \
    src/daemon/systemd-unit.test.ts
 Test Files  4 passed (4)
      Tests  742 + 8 + 25 passed
```

Typecheck and lint on the changed files:

```
$ pnpm tsgo:core
(clean, no output)

$ node scripts/run-oxlint.mjs --tsconfig tsconfig.core.json \
    src/gateway/server-runtime-config.ts src/cli/gateway-cli/run.ts \
    src/cli/gateway-cli/run.supervised-lock.test.ts
(clean, exit 0)
```

`pnpm check:changed`'s `max-lines suppression ratchet` check fails on this
branch, but it fails identically on unmodified `work-base` against
`origin/main` (confirmed by stashing this change and re-running the same
check), so it is unrelated to this diff.

AI-assisted: yes, this PR was authored end-to-end by an autonomous agent
(root-caused via source reading, patched, and tested as shown above).


## Real-behavior proof (added in response to review)

Ran the actual production entrypoint (`node openclaw.mjs gateway ...`, which
loads the built `dist/entry.js`, not the unit-test harness) against an
isolated `OPENCLAW_STATE_DIR`/`OPENCLAW_HOME`, reproducing the issue's exact
scenario: persisted config `gateway.bind=lan` (valid on its own) plus a
service-level `--tailscale serve` override.

Built `dist/` from this branch's head and ran it directly:

```
$ node ./openclaw.mjs gateway --port 57823 --tailscale serve
...
Gateway failed to start: tailscale serve/funnel requires gateway bind=loopback (127.0.0.1). Run openclaw gateway status --deep for diagnostics.
$ echo $?
78
```

Rebuilt `dist/` from the parent commit (`a3f19d3ea3b~1`, pre-fix) with the
same isolated config and override to confirm the baseline behavior the issue
reports:

```
$ node ./openclaw.mjs gateway --port 57823 --tailscale serve
...
Gateway failed to start: tailscale serve/funnel requires gateway bind=loopback (127.0.0.1). Run openclaw gateway status --deep for diagnostics.
$ echo $?
1
```

Same error message, exit 78 after the fix vs. exit 1 before it.

Then proved the systemd side by installing a real user-scope systemd unit
(`systemctl --user`) with the exact `[Service]` block
`buildSystemdUnit()` generates (`Restart=always`, `RestartSec=5`,
`RestartPreventExitStatus=78`), `ExecStart` pointing at the same
conflicting invocation, isolated `OPENCLAW_STATE_DIR`/`OPENCLAW_HOME`, and
watched `journalctl --user -u openclaw-proof-gateway.service`:

Pre-fix build, real systemd unit, exit 1 — systemd loops as the issue
describes:

```
Main process exited, code=exited, status=1/FAILURE
openclaw-proof-gateway.service: Failed with result 'exit-code'.
openclaw-proof-gateway.service: Scheduled restart job, restart counter is at 1.
Started openclaw-proof-gateway.service ...
Main process exited, code=exited, status=1/FAILURE
openclaw-proof-gateway.service: Scheduled restart job, restart counter is at 2.
Started openclaw-proof-gateway.service ...
Main process exited, code=exited, status=1/FAILURE
openclaw-proof-gateway.service: Scheduled restart job, restart counter is at 3.
Started openclaw-proof-gateway.service ...
Main process exited, code=exited, status=1/FAILURE
openclaw-proof-gateway.service: Scheduled restart job, restart counter is at 4.
```

Fixed build, same real systemd unit, exit 78 — systemd stops, no restart is
scheduled (confirmed by waiting past `RestartSec=5` and re-checking):

```
$ systemctl --user status openclaw-proof-gateway.service
× openclaw-proof-gateway.service - OpenClaw Gateway Proof (effective config conflict)
     Active: failed (Result: exit-code) since ...
    Process: 20773 ExecStart=... gateway --port 57823 --tailscale serve (code=exited, status=78)
   Main PID: 20773 (code=exited, status=78)

Main process exited, code=exited, status=78/CONFIG
openclaw-proof-gateway.service: Failed with result 'exit-code'.
(no further "Scheduled restart job" line after 20s+, i.e. past RestartSec=5)
```

The test unit and isolated state/config directories were removed afterward
(`systemctl --user stop/disable`, unit file deleted, `daemon-reload`); no
persistent host state or real gateway instance was touched.

<!-- maintainer-exact-head-proof-141771 -->
## Exact-head maintainer verification

Verified `f5572017ba0165d886dc0b80d8ba7b5d4e733714` in [sanitized AWS Crabbox run run_7a73e6be420d](https://crabbox.openclaw.ai/portal/runs/run_7a73e6be420d), lease `cbx_e31bdd0197b4`.

The trusted main bootstrap checked the exact head and absence of an instance role, then restored frozen dependencies in an isolated home. No Tailscale connection, credential hydration, or local contributor-code execution was used. The full build passed.

The built production CLI used isolated state with saved `gateway.bind=lan` and the `--tailscale serve` override. A real systemd service ran as the same unprivileged user that owned the temporary files, with `Restart=always` and `RestartPreventExitStatus=78`. After 25 seconds:

```text
node ./openclaw.mjs gateway --port 57823 --tailscale serve
CLI_EXIT=78
ExecMainStatus=78
NRestarts=0
REAL_BEHAVIOR_PROOF=PASS cli_exit=78 systemd_exit=78 restarts=0
OWNED_CLEANUP=PASS state_absent=true unit_inactive=true
Crabbox run exitCode=0; runStatus=succeeded
```

The CLI reported the expected bind/Tailscale conflict and did not enter automatic triage. The service was stopped and temporary state removed.

An earlier exact-head run passed 42 focused tests and these behavior assertions, but exited 1 while deleting root-owned temporary state. That was a proof-harness cleanup failure; it is not counted as a clean run. The recovery above fixes ownership in the proof harness without changing PR code.

Independent P0/P1 autoreview found no actionable defects. Native review validation and `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 141771` passed for this exact head. Preparation detected the unchanged remote head and skipped the push. Final merge remains a separate maintainer action.
