### PR TITLE
fix(sqlite): reduce temporary space for database snapshots

### DIFF
--- a/src/infra/sqlite-readonly-location.copy.test.ts
+++ b/src/infra/sqlite-readonly-location.copy.test.ts
@@ -1,0 +1,316 @@
+import fs from "node:fs";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { requireNodeSqlite } from "./node-sqlite.js";
+import { prepareSqliteReadOnlyLocationSyncInProcess } from "./sqlite-readonly-location.js";
+
+const MIB = 1024 * 1024;
+const tempDirs = useAutoCleanupTempDirTracker((cleanup) => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+});
+
+function createFixture(bytes: Buffer) {
+  const sourceRoot = tempDirs.make("openclaw-readonly-copy-source-");
+  const sourcePath = path.join(sourceRoot, "source.sqlite");
+  const stagingRoot = tempDirs.make("openclaw-readonly-copy-staging-");
+  fs.writeFileSync(sourcePath, bytes, { mode: 0o600 });
+  return { sourcePath, sourceRoot, stagingRoot };
+}
+
+function patternedBytes(size: number): Buffer {
+  const bytes = Buffer.allocUnsafe(size);
+  for (let index = 0; index < size; index += 1) {
+    bytes[index] = index % 251;
+  }
+  return bytes;
+}
+
+function expectSnapshot(
+  fixture: ReturnType<typeof createFixture>,
+  expected: Buffer,
+  inspect?: (location: string) => void,
+): void {
+  let prepared: ReturnType<typeof prepareSqliteReadOnlyLocationSyncInProcess> | undefined;
+  try {
+    prepared = prepareSqliteReadOnlyLocationSyncInProcess(fixture.sourcePath, fixture.stagingRoot);
+    expect(fs.readFileSync(prepared.location).equals(expected)).toBe(true);
+    if (process.platform !== "win32") {
+      expect(fs.statSync(prepared.location).mode & 0o777).toBe(0o600);
+      expect(fs.statSync(path.dirname(prepared.location)).mode & 0o777).toBe(0o700);
+    }
+    inspect?.(prepared.location);
+  } finally {
+    if (prepared) {
+      expect(prepared.cleanup()).toBe(true);
+    }
+    expect(fs.readdirSync(fixture.stagingRoot)).toEqual([]);
+    expect(fs.readFileSync(fixture.sourcePath).equals(expected)).toBe(true);
+  }
+}
+
+function afterFirstCopy(operation: () => void): () => boolean {
+  const fsync = fs.fsyncSync.bind(fs);
+  let injected = false;
+  vi.spyOn(fs, "fsyncSync").mockImplementation((descriptor) => {
+    fsync(descriptor);
+    if (!injected) {
+      injected = true;
+      operation();
+    }
+  });
+  return () => injected;
+}
+
+function interceptSourceReads(
+  sourcePath: string,
+  operation: (
+    descriptor: number,
+    buffer: NodeJS.ArrayBufferView,
+    options: fs.ReadOptions,
+  ) => number,
+): void {
+  const source = fs.statSync(sourcePath, { bigint: true });
+  const read = fs.readSync.bind(fs);
+  vi.spyOn(fs, "readSync").mockImplementation(
+    (
+      descriptor: number,
+      buffer: NodeJS.ArrayBufferView,
+      offsetOrOptions: number | fs.ReadOptions = {},
+      length?: number,
+      position?: fs.ReadPosition | null,
+    ) => {
+      const options =
+        typeof offsetOrOptions === "number"
+          ? { offset: offsetOrOptions, length, position }
+          : offsetOrOptions;
+      const opened = fs.fstatSync(descriptor, { bigint: true });
+      return opened.dev === source.dev && opened.ino === source.ino
+        ? operation(descriptor, buffer, options)
+        : read(descriptor, buffer, options);
+    },
+  );
+}
+
+describe("stable read-only snapshot copies", () => {
+  it.each([
+    { label: "empty", size: 0 },
+    { label: "partial chunk", size: 4099 },
+    { label: "exact chunk", size: MIB },
+    { label: "multiple chunks and a tail", size: 2 * MIB + 37 },
+  ])("preserves every byte of an equal $label source", ({ size }) => {
+    const bytes = patternedBytes(size);
+    const fixture = createFixture(bytes);
+    expectSnapshot(fixture, bytes);
+    expect(fs.readdirSync(fixture.sourceRoot)).toEqual(["source.sqlite"]);
+  });
+
+  it("continues after positive short source reads", () => {
+    const bytes = patternedBytes(MIB + 37);
+    const fixture = createFixture(bytes);
+    const read = fs.readSync.bind(fs);
+    let shortened = 0;
+    interceptSourceReads(fixture.sourcePath, (descriptor, buffer, options) => {
+      const length = options.length ?? buffer.byteLength - (options.offset ?? 0);
+      if (length > 4093) {
+        shortened += 1;
+      }
+      return read(descriptor, buffer, { ...options, length: Math.min(length, 4093) });
+    });
+
+    expectSnapshot(fixture, bytes);
+    expect(shortened).toBeGreaterThan(0);
+  });
+
+  it.each(["overwrite", "append", "truncate"] as const)(
+    "retries a source that stabilizes after an intervening %s",
+    (mutation) => {
+      const before = patternedBytes(MIB);
+      const fixture = createFixture(before);
+      const after =
+        mutation === "append"
+          ? Buffer.concat([before, Buffer.from([251])])
+          : mutation === "truncate"
+            ? before.subarray(0, -1)
+            : Buffer.from(before);
+      if (mutation === "overwrite") {
+        after.writeUInt8(after.readUInt8(after.length - 1) ^ 0xff, after.length - 1);
+      }
+      const injected = afterFirstCopy(() => fs.writeFileSync(fixture.sourcePath, after));
+
+      expectSnapshot(fixture, after);
+      expect(injected()).toBe(true);
+      expect(fs.readdirSync(fixture.sourceRoot)).toEqual(["source.sqlite"]);
+    },
+  );
+
+  it.runIf(process.platform !== "win32")(
+    "retries pathname replacement while the second pass still reads the original inode",
+    () => {
+      const before = patternedBytes(MIB + 37);
+      const after = Buffer.from(before);
+      after.writeUInt8(after.readUInt8(0) ^ 0xff, 0);
+      const fixture = createFixture(before);
+      const replacementPath = path.join(fixture.sourceRoot, "replacement.sqlite");
+      const displacedPath = path.join(fixture.sourceRoot, "displaced.sqlite");
+      fs.writeFileSync(replacementPath, after, { mode: 0o600 });
+      const firstCopied = afterFirstCopy(() => {});
+      const read = fs.readSync.bind(fs);
+      let replaced = false;
+      interceptSourceReads(fixture.sourcePath, (descriptor, buffer, options) => {
+        const bytesRead = read(descriptor, buffer, options);
+        const requested = options.length ?? buffer.byteLength - (options.offset ?? 0);
+        // A later header probe cannot substitute for the complete second pass.
+        if (firstCopied() && !replaced && bytesRead > 0 && requested > 20) {
+          replaced = true;
+          fs.renameSync(fixture.sourcePath, displacedPath);
+          fs.renameSync(replacementPath, fixture.sourcePath);
+        }
+        return bytesRead;
+      });
+
+      expectSnapshot(fixture, after);
+      expect(replaced).toBe(true);
+      expect(fs.readFileSync(displacedPath)).toEqual(before);
+      expect(fs.readdirSync(fixture.sourceRoot).toSorted()).toEqual([
+        "displaced.sqlite",
+        "source.sqlite",
+      ]);
+    },
+  );
+
+  it("releases pinned source handles when closing the private comparison handle fails", () => {
+    const bytes = patternedBytes(4099);
+    const fixture = createFixture(bytes);
+    const closeError = Object.assign(new Error("private comparison close failed"), { code: "EIO" });
+    const owned = new Map<number, { source: boolean; privateRead: boolean }>();
+    const open = fs.openSync.bind(fs);
+    const close = fs.closeSync.bind(fs);
+    let injected = false;
+    let sourcesAtFailure: number[] = [];
+    const openSpy = vi.spyOn(fs, "openSync").mockImplementation((pathname, flags, mode) => {
+      const descriptor = open(pathname, flags, mode);
+      const resolved = path.resolve(String(pathname));
+      const source = resolved === fixture.sourcePath;
+      const staged = resolved.startsWith(`${fixture.stagingRoot}${path.sep}`);
+      if (source || staged) {
+        owned.set(descriptor, { source, privateRead: staged && flags === "r" });
+      }
+      return descriptor;
+    });
+    const closeSpy = vi.spyOn(fs, "closeSync").mockImplementation((descriptor) => {
+      const privateRead = owned.get(descriptor)?.privateRead;
+      if (privateRead && !injected) {
+        sourcesAtFailure = [...owned].filter(([, owner]) => owner.source).map(([fd]) => fd);
+        injected = true;
+        // A native close can release its descriptor before reporting an I/O error.
+        close(descriptor);
+        owned.delete(descriptor);
+        throw closeError;
+      }
+      close(descriptor);
+      owned.delete(descriptor);
+    });
+
+    try {
+      expect(() =>
+        prepareSqliteReadOnlyLocationSyncInProcess(fixture.sourcePath, fixture.stagingRoot),
+      ).toThrow(closeError);
+      expect(injected).toBe(true);
+      for (const descriptor of sourcesAtFailure) {
+        expect(() => fs.fstatSync(descriptor)).toThrowError(
+          expect.objectContaining({ code: "EBADF" }),
+        );
+      }
+    } finally {
+      openSpy.mockRestore();
+      closeSpy.mockRestore();
+      for (const descriptor of owned.keys()) {
+        close(descriptor);
+      }
+      expect(fs.readFileSync(fixture.sourcePath).equals(bytes)).toBe(true);
+      expect(fs.readdirSync(fixture.sourceRoot)).toEqual(["source.sqlite"]);
+      expect(fs.readdirSync(fixture.stagingRoot)).toEqual([]);
+    }
+  });
+
+  it("snapshots a fixed 16 MiB database when staging can write one complete copy", () => {
+    const fixture = createFixture(Buffer.alloc(0));
+    const sqlite = requireNodeSqlite();
+    const database = new sqlite.DatabaseSync(fixture.sourcePath);
+    try {
+      database.exec(`
+        PRAGMA journal_mode = DELETE;
+        CREATE TABLE probe (payload BLOB NOT NULL);
+        INSERT INTO probe VALUES (zeroblob(${16 * MIB}));
+      `);
+    } finally {
+      database.close();
+    }
+    const bytes = fs.readFileSync(fixture.sourcePath);
+    const descriptors = new Set<number>();
+    const open = fs.openSync.bind(fs);
+    const close = fs.closeSync.bind(fs);
+    const write = fs.writeSync.bind(fs);
+    let written = 0;
+    vi.spyOn(fs, "openSync").mockImplementation((pathname, flags, mode) => {
+      const descriptor = open(pathname, flags, mode);
+      if (path.resolve(String(pathname)).startsWith(`${fixture.stagingRoot}${path.sep}`)) {
+        descriptors.add(descriptor);
+      }
+      return descriptor;
+    });
+    vi.spyOn(fs, "closeSync").mockImplementation((descriptor) => {
+      close(descriptor);
+      descriptors.delete(descriptor);
+    });
+    vi.spyOn(fs, "writeSync").mockImplementation(
+      (
+        descriptor: number,
+        content: string | NodeJS.ArrayBufferView,
+        offset?: number | null,
+        lengthOrEncoding?: number | BufferEncoding | null,
+        position?: number | null,
+      ) => {
+        const encoding = typeof lengthOrEncoding === "string" ? lengthOrEncoding : undefined;
+        const length =
+          typeof content === "string"
+            ? Buffer.byteLength(content, encoding)
+            : typeof lengthOrEncoding === "number"
+              ? lengthOrEncoding
+              : content.byteLength - (offset ?? 0);
+        const staged = descriptors.has(descriptor);
+        if (staged && written + length > bytes.length) {
+          throw Object.assign(new Error("synthetic staging capacity exhausted"), {
+            code: "ENOSPC",
+          });
+        }
+        const count =
+          typeof content === "string"
+            ? write(descriptor, content, offset, encoding)
+            : write(descriptor, content, offset, length, position);
+        if (staged) {
+          written += count;
+        }
+        return count;
+      },
+    );
+
+    expectSnapshot(fixture, bytes, (location) => {
+      const snapshot = new sqlite.DatabaseSync(location, { readOnly: true });
+      try {
+        expect(snapshot.prepare("SELECT length(payload) AS bytes FROM probe").get()).toEqual({
+          bytes: 16 * MIB,
+        });
+      } finally {
+        snapshot.close();
+      }
+    });
+    expect(written).toBeLessThanOrEqual(bytes.length);
+    expect(descriptors.size).toBe(0);
+    expect(fs.readdirSync(fixture.sourceRoot)).toEqual(["source.sqlite"]);
+  });
+});

--- a/src/infra/sqlite-readonly-location.ts
+++ b/src/infra/sqlite-readonly-location.ts
@@ -198,35 +198,50 @@ function copySourceFile(sourcePath: string, targetPath: string): void {
   }
 }
 
-function filesEqual(leftPath: string, rightPath: string): boolean {
-  const leftStat = fs.statSync(leftPath, { bigint: true });
-  const rightStat = fs.statSync(rightPath, { bigint: true });
-  if (!leftStat.isFile() || !rightStat.isFile() || leftStat.size !== rightStat.size) {
-    return false;
-  }
-  const left = fs.openSync(leftPath, "r");
-  const right = fs.openSync(rightPath, "r");
+function sourceMatchesCopy(sourcePath: string, copyPath: string): boolean {
+  const source = openPinnedFile(sourcePath);
+  let copy: number | undefined;
   try {
-    const leftBuffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
-    const rightBuffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
-    let offset = 0;
-    while (BigInt(offset) < leftStat.size) {
-      const length = Math.min(COPY_BUFFER_BYTES, Number(leftStat.size - BigInt(offset)));
-      const leftBytes = fs.readSync(left, leftBuffer, 0, length, offset);
-      const rightBytes = fs.readSync(right, rightBuffer, 0, length, offset);
-      if (
-        leftBytes !== rightBytes ||
-        leftBytes !== length ||
-        !leftBuffer.subarray(0, leftBytes).equals(rightBuffer.subarray(0, rightBytes))
-      ) {
-        return false;
-      }
-      offset += leftBytes;
+    copy = fs.openSync(copyPath, "r");
+    if (!fs.fstatSync(copy).isFile()) {
+      return false;
     }
-    return true;
+    const sourceBuffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
+    const copyBuffer = Buffer.allocUnsafe(COPY_BUFFER_BYTES);
+    let offset = 0;
+    let equal = true;
+    while (true) {
+      const sourceBytes = fs.readSync(
+        source.descriptor,
+        sourceBuffer,
+        0,
+        sourceBuffer.length,
+        offset,
+      );
+      // Compare every source read, including positive short reads, and prove both EOFs.
+      const copyBytes = fs.readSync(copy, copyBuffer, 0, Math.max(1, sourceBytes), offset);
+      if (
+        sourceBytes !== copyBytes ||
+        !sourceBuffer.subarray(0, sourceBytes).equals(copyBuffer.subarray(0, copyBytes))
+      ) {
+        equal = false;
+        break;
+      }
+      if (sourceBytes === 0) {
+        break;
+      }
+      offset += sourceBytes;
+    }
+    assertPinnedIdentityUnchanged(source);
+    return equal;
   } finally {
-    fs.closeSync(right);
-    fs.closeSync(left);
+    try {
+      if (copy !== undefined) {
+        fs.closeSync(copy);
+      }
+    } finally {
+      fs.closeSync(source.descriptor);
+    }
   }
 }
 
@@ -360,7 +375,6 @@ function createStableReadOnlyCopyInTempDirectory(
     tempDir ??= createPrivateSqliteTempDirectorySync(stagingRoot, SQLITE_SNAPSHOT_STAGING_PREFIX);
     const snapshotPath = path.join(tempDir, "database.sqlite");
     const firstPath = path.join(tempDir, "first");
-    const secondPath = path.join(tempDir, "second");
     if (process.platform !== "win32") {
       fs.chmodSync(tempDir, 0o700);
     }
@@ -375,30 +389,29 @@ function createStableReadOnlyCopyInTempDirectory(
     if (sidecarSuffix) {
       copySourceFile(`${pathname}${sidecarSuffix}`, firstPath);
       copySourceFile(pathname, snapshotPath);
-      copySourceFile(`${pathname}${sidecarSuffix}`, secondPath);
+      const sidecarUnchanged = sourceMatchesCopy(`${pathname}${sidecarSuffix}`, firstPath);
       assertExpectedSidecars(pathname, sidecars);
-      if (!filesEqual(firstPath, secondPath)) {
+      if (!sidecarUnchanged) {
         const label = sidecarSuffix === "-wal" ? "WAL" : "rollback journal";
         throw new SqliteSourceChangedError(`SQLite ${label} changed while copying: ${pathname}`);
       }
-      replaceFile(secondPath, `${snapshotPath}${sidecarSuffix}`);
+      replaceFile(firstPath, `${snapshotPath}${sidecarSuffix}`);
     } else {
       copySourceFile(pathname, firstPath);
       assertExpectedSidecars(pathname, sidecars);
-      copySourceFile(pathname, secondPath);
+      const mainUnchanged = sourceMatchesCopy(pathname, firstPath);
       assertExpectedSidecars(pathname, sidecars);
-      if (!filesEqual(firstPath, secondPath)) {
+      if (!mainUnchanged) {
         throw new SqliteSourceChangedError(
           `SQLite main database changed while copying: ${pathname}`,
         );
       }
-      replaceFile(secondPath, snapshotPath);
+      replaceFile(firstPath, snapshotPath);
     }
 
     if (readSourceJournalMode(pathname) !== journalMode) {
       throw new SqliteSourceChangedError(`SQLite journal mode changed while copying: ${pathname}`);
     }
-    fs.rmSync(firstPath, { force: true });
     if (sidecars.journal) {
       // Recover only the private pair. The source journal remains untouched so
       // a later writable open can perform SQLite's normal crash recovery.


### PR DESCRIPTION
Related #122105 for snapshot write volume; verification scheduling is a separate issue.

## What Problem This Solves

Fixes an issue where database inspection can exhaust temporary disk space even when one complete snapshot fits. Artifact-preserving snapshots retained two copies of a stable database before inspecting it.

## Why This Change Was Made

Keep the first fsynced private copy and compare a complete second pinned source read directly against it. Both streams must reach the same EOF, and the source descriptor and pathname identity are revalidated before promotion. Sidecar ordering, private rollback recovery, retries, cleanup, and the native worker deadline remain unchanged.

## User Impact

A stable database without sidecars needs one complete staging copy instead of two, removing one full scratch write and one scratch read. WAL and rollback-journal snapshots likewise avoid the duplicate sidecar copy.

## Evidence

- A real SQLite fixture with a 16 MiB payload is exercised under an injected synthetic per-staging-descriptor `writeSync` budget of one complete copy (not an OS quota): the original producer throws injected ENOSPC and the candidate succeeds. Byte preservation, short reads, mutation/replacement races, private permissions, and descriptor cleanup are covered.
- Focused readonly, worker, cancellation, rollback-recovery, and preflight-artifact suites: 144 passed, 2 platform skips. The final copy suite passed 11/11; the full changed gate and independent review passed.
- Both normal Linux builds passed. All 8 built snapshot/schema-preflight cases completed, with all 12 native children closing before API settlement and source families/cleanup preserved. [Testbox hosting run](https://github.com/openclaw/openclaw/actions/runs/34177418845); the successful command receipt is distinct from hosting-job cleanup state.
- On the same 9,368,645,632-byte synthetic database, one ordered warm-cache pair measured snapshot invocation at 23.612 → 12.085 seconds and schema preflight at 19.270 → 11.277 seconds. Observed large-file logical staging peak was 18,737,291,264 → 9,368,645,632 bytes for both operations.

The paired source was 9fb6b2b5ec3b2cf1889912c5d6f030ffe31d2573 plus this patch. Current main retains the same snapshot producer and native worker. Sampling provides lower bounds, and this single synthetic pair does not establish cold-cache performance, complete Gateway startup, or production latency. Full-file verification and the 30-second worker deadline were preserved.
