### PR TITLE
fix(release): run frozen targets against shipped scenario contracts

### DIFF
--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -607,6 +607,7 @@ jobs:
           OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: ${{ inputs.allow_frozen_target_scenario_omissions && '1' || '0' }}
           OPENCLAW_GATEWAY_NETWORK_E2E_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_GATEWAY_NETWORK_E2E_SKIP_BUILD: "1"
+          OPENCLAW_DOCKER_E2E_REPO_ROOT: ${{ github.workspace }}
           OPENCLAW_SELECTED_SHA: ${{ needs.preflight.outputs.target_sha }}
           OPENCLAW_TOOLING_SHA: ${{ steps.workflow.outputs.sha }}
         run: bash .release-harness/scripts/e2e/gateway-network-docker.sh

--- a/.github/workflows/install-smoke-reusable.yml
+++ b/.github/workflows/install-smoke-reusable.yml
@@ -607,7 +607,6 @@ jobs:
           OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: ${{ inputs.allow_frozen_target_scenario_omissions && '1' || '0' }}
           OPENCLAW_GATEWAY_NETWORK_E2E_IMAGE: ${{ needs.root_dockerfile_image.outputs.image_ref }}
           OPENCLAW_GATEWAY_NETWORK_E2E_SKIP_BUILD: "1"
-          OPENCLAW_DOCKER_E2E_REPO_ROOT: ${{ github.workspace }}
           OPENCLAW_SELECTED_SHA: ${{ needs.preflight.outputs.target_sha }}
           OPENCLAW_TOOLING_SHA: ${{ steps.workflow.outputs.sha }}
         run: bash .release-harness/scripts/e2e/gateway-network-docker.sh

--- a/scripts/e2e/codex-on-demand-docker.sh
+++ b/scripts/e2e/codex-on-demand-docker.sh
@@ -7,6 +7,14 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
 source "$ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
+source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
+
+TARGET_ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" && pwd)"
+CODEX_ASSERTIONS="$ROOT_DIR/scripts/e2e/lib/codex-on-demand/assertions.mjs"
+if openclaw_prepare_frozen_target_context "$TARGET_ROOT_DIR" &&
+  openclaw_frozen_target_source_has_path "$TARGET_ROOT_DIR" scripts/e2e/lib/codex-on-demand/assertions.mjs; then
+  CODEX_ASSERTIONS="$TARGET_ROOT_DIR/scripts/e2e/lib/codex-on-demand/assertions.mjs"
+fi
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-codex-on-demand-e2e" OPENCLAW_CODEX_ON_DEMAND_E2E_IMAGE)"
 DOCKER_TARGET="${OPENCLAW_CODEX_ON_DEMAND_DOCKER_TARGET:-bare}"
@@ -69,6 +77,7 @@ OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 codex-on-deman
 echo "Running Codex on-demand Docker E2E..."
 if ! docker_e2e_run_with_harness \
   -v "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}/extensions/codex/package.json:/tmp/openclaw-candidate-codex-package.json:ro" \
+  -v "$CODEX_ASSERTIONS:/app/scripts/e2e/lib/codex-on-demand/assertions.mjs:ro" \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \

--- a/scripts/e2e/codex-on-demand-docker.sh
+++ b/scripts/e2e/codex-on-demand-docker.sh
@@ -10,11 +10,9 @@ source "$ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 
 TARGET_ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" && pwd)"
-CODEX_ASSERTIONS="$ROOT_DIR/scripts/e2e/lib/codex-on-demand/assertions.mjs"
-if openclaw_prepare_frozen_target_context "$TARGET_ROOT_DIR" &&
-  openclaw_frozen_target_source_has_path "$TARGET_ROOT_DIR" scripts/e2e/lib/codex-on-demand/assertions.mjs; then
-  CODEX_ASSERTIONS="$TARGET_ROOT_DIR/scripts/e2e/lib/codex-on-demand/assertions.mjs"
-fi
+CODEX_ASSERTIONS="$(openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR" \
+  scripts/e2e/lib/codex-on-demand/assertions.mjs \
+  "$ROOT_DIR/scripts/e2e/lib/codex-on-demand/assertions.mjs")"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-codex-on-demand-e2e" OPENCLAW_CODEX_ON_DEMAND_E2E_IMAGE)"
 DOCKER_TARGET="${OPENCLAW_CODEX_ON_DEMAND_DOCKER_TARGET:-bare}"

--- a/scripts/e2e/gateway-network-docker.sh
+++ b/scripts/e2e/gateway-network-docker.sh
@@ -5,10 +5,17 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 SOURCE_ROOT="${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}"
-openclaw_prepare_frozen_target_context "$SOURCE_ROOT" || {
+FROZEN_CONTEXT=0
+openclaw_prepare_frozen_target_context "$SOURCE_ROOT" && FROZEN_CONTEXT=1 || {
   context_status=$?
   [ "$context_status" -eq 1 ] || exit "$context_status"
 }
+LEGACY_GATEWAY_CLIENT=""
+if [[ "$FROZEN_CONTEXT" == "1" ]] &&
+  openclaw_frozen_target_source_has_path "$SOURCE_ROOT" scripts/e2e/lib/gateway-network/client.mjs &&
+  ! openclaw_frozen_target_source_has_path "$SOURCE_ROOT" scripts/e2e/lib/gateway-network/client.mts; then
+  LEGACY_GATEWAY_CLIENT="$SOURCE_ROOT/scripts/e2e/lib/gateway-network/client.mjs"
+fi
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-gateway-network-e2e" OPENCLAW_GATEWAY_NETWORK_E2E_IMAGE)"
 SKIP_BUILD="${OPENCLAW_GATEWAY_NETWORK_E2E_SKIP_BUILD:-0}"
 
@@ -70,6 +77,10 @@ docker_e2e_docker_cmd network create "$NET_NAME" >/dev/null
 
 echo "Starting gateway container..."
 docker_e2e_harness_mount_args
+gateway_setup='node "$entry" config set gateway.controlUi.enabled false >/dev/null'
+if [[ -z "$LEGACY_GATEWAY_CLIENT" ]]; then
+  gateway_setup+='; if [[ ! -f /tmp/gateway-network-configured ]]; then node "$entry" plugins enable admin-http-rpc >/dev/null; touch /tmp/gateway-network-configured; fi'
+fi
 docker_e2e_docker_cmd run -d \
   "${DOCKER_E2E_HARNESS_ARGS[@]}" \
   --name "$GW_NAME" \
@@ -80,7 +91,7 @@ docker_e2e_docker_cmd run -d \
   -e "OPENCLAW_SKIP_CRON=1" \
   -e "OPENCLAW_SKIP_CANVAS_HOST=1" \
   "$IMAGE_NAME" \
-  bash -lc "set -euo pipefail; source scripts/lib/openclaw-e2e-instance.sh; entry=\"\$(openclaw_e2e_resolve_entrypoint)\"; node \"\$entry\" config set gateway.controlUi.enabled false >/dev/null; if [[ ! -f /tmp/gateway-network-configured ]]; then node \"\$entry\" plugins enable admin-http-rpc >/dev/null; touch /tmp/gateway-network-configured; fi; openclaw_e2e_exec_gateway \"\$entry\" $PORT lan /tmp/gateway-net-e2e.log" >/dev/null
+  bash -lc "set -euo pipefail; source scripts/lib/openclaw-e2e-instance.sh; entry=\"\$(openclaw_e2e_resolve_entrypoint)\"; $gateway_setup; openclaw_e2e_exec_gateway \"\$entry\" $PORT lan /tmp/gateway-net-e2e.log" >/dev/null
 
 echo "Waiting for gateway to come up..."
 if ! docker_e2e_wait_container_bash "$GW_NAME" 180 0.5 "source scripts/lib/openclaw-e2e-instance.sh; openclaw_e2e_probe_tcp 127.0.0.1 $PORT"; then
@@ -90,6 +101,19 @@ if ! docker_e2e_wait_container_bash "$GW_NAME" 180 0.5 "source scripts/lib/openc
 fi
 
 echo "Running client container (connect + health)..."
+if [[ -n "$LEGACY_GATEWAY_CLIENT" ]]; then
+  DOCKER_COMMAND_TIMEOUT="$CLIENT_TIMEOUT" run_logged gateway-network-client docker_e2e_docker_run_cmd run --rm \
+    "${DOCKER_E2E_HARNESS_ARGS[@]}" \
+    --network "$NET_NAME" \
+    "${CLIENT_LIMIT_ENV_ARGS[@]}" \
+    -v "$LEGACY_GATEWAY_CLIENT:/tmp/openclaw-gateway-network-client.mjs:ro" \
+    -e "GW_URL=ws://$GW_NAME:$PORT" \
+    -e "GW_TOKEN=$TOKEN" \
+    "$IMAGE_NAME" \
+    node /tmp/openclaw-gateway-network-client.mjs
+  echo "OK"
+  exit 0
+fi
 CAPABILITIES_DIR="$(mktemp -d "${TMPDIR:-/tmp}/openclaw-gateway-network-capabilities.XXXXXX")"
 CAPABILITIES_PATH="$CAPABILITIES_DIR/capabilities.json"
 if [[ ! -O "$CAPABILITIES_DIR" ]]; then

--- a/scripts/e2e/kitchen-sink-plugin-docker.sh
+++ b/scripts/e2e/kitchen-sink-plugin-docker.sh
@@ -6,11 +6,9 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 
 TARGET_ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" && pwd)"
-KITCHEN_SINK_ASSERTIONS="$ROOT_DIR/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs"
-if openclaw_prepare_frozen_target_context "$TARGET_ROOT_DIR" &&
-  openclaw_frozen_target_source_has_path "$TARGET_ROOT_DIR" scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs; then
-  KITCHEN_SINK_ASSERTIONS="$TARGET_ROOT_DIR/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs"
-fi
+KITCHEN_SINK_ASSERTIONS="$(openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR" \
+  scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs \
+  "$ROOT_DIR/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs")"
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-kitchen-sink-plugin-e2e" OPENCLAW_KITCHEN_SINK_PLUGIN_E2E_IMAGE)"
 OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES="$(
   docker_e2e_read_positive_int_env OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES 65536

--- a/scripts/e2e/kitchen-sink-plugin-docker.sh
+++ b/scripts/e2e/kitchen-sink-plugin-docker.sh
@@ -4,6 +4,13 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
+
+TARGET_ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" && pwd)"
+KITCHEN_SINK_ASSERTIONS="$ROOT_DIR/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs"
+if openclaw_prepare_frozen_target_context "$TARGET_ROOT_DIR" &&
+  openclaw_frozen_target_source_has_path "$TARGET_ROOT_DIR" scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs; then
+  KITCHEN_SINK_ASSERTIONS="$TARGET_ROOT_DIR/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs"
+fi
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-kitchen-sink-plugin-e2e" OPENCLAW_KITCHEN_SINK_PLUGIN_E2E_IMAGE)"
 OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES="$(
   docker_e2e_read_positive_int_env OPENCLAW_DOCKER_E2E_LOG_PRINT_BYTES 65536
@@ -80,7 +87,7 @@ fi
 echo "Running kitchen-sink plugin Docker E2E..."
 docker_e2e_docker_cmd rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
 docker_e2e_harness_mount_args
-DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run --name "$CONTAINER_NAME" "${DOCKER_E2E_HARNESS_ARGS[@]}" "${DOCKER_ENV_ARGS[@]}" -i "$IMAGE_NAME" bash scripts/e2e/lib/kitchen-sink-plugin/sweep.sh \
+DOCKER_COMMAND_TIMEOUT="$DOCKER_RUN_TIMEOUT" docker_e2e_docker_run_cmd run --name "$CONTAINER_NAME" "${DOCKER_E2E_HARNESS_ARGS[@]}" "${DOCKER_ENV_ARGS[@]}" -v "$KITCHEN_SINK_ASSERTIONS:/app/scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs:ro" -i "$IMAGE_NAME" bash scripts/e2e/lib/kitchen-sink-plugin/sweep.sh \
   >"$RUN_LOG" 2>&1 &
 docker_pid="$!"
 

--- a/scripts/e2e/npm-onboard-channel-agent-docker.sh
+++ b/scripts/e2e/npm-onboard-channel-agent-docker.sh
@@ -10,11 +10,9 @@ source "$ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 
 TARGET_ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" && pwd)"
-ONBOARD_ASSERTIONS="$ROOT_DIR/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs"
-if openclaw_prepare_frozen_target_context "$TARGET_ROOT_DIR" &&
-  openclaw_frozen_target_source_has_path "$TARGET_ROOT_DIR" scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs; then
-  ONBOARD_ASSERTIONS="$TARGET_ROOT_DIR/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs"
-fi
+ONBOARD_ASSERTIONS="$(openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR" \
+  scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs \
+  "$ROOT_DIR/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs")"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-npm-onboard-channel-agent-e2e" OPENCLAW_NPM_ONBOARD_E2E_IMAGE)"
 DOCKER_TARGET="${OPENCLAW_NPM_ONBOARD_DOCKER_TARGET:-bare}"

--- a/scripts/e2e/npm-onboard-channel-agent-docker.sh
+++ b/scripts/e2e/npm-onboard-channel-agent-docker.sh
@@ -7,6 +7,14 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
 source "$ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
+source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
+
+TARGET_ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" && pwd)"
+ONBOARD_ASSERTIONS="$ROOT_DIR/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs"
+if openclaw_prepare_frozen_target_context "$TARGET_ROOT_DIR" &&
+  openclaw_frozen_target_source_has_path "$TARGET_ROOT_DIR" scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs; then
+  ONBOARD_ASSERTIONS="$TARGET_ROOT_DIR/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs"
+fi
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-npm-onboard-channel-agent-e2e" OPENCLAW_NPM_ONBOARD_E2E_IMAGE)"
 DOCKER_TARGET="${OPENCLAW_NPM_ONBOARD_DOCKER_TARGET:-bare}"
@@ -68,6 +76,7 @@ if ! docker_e2e_run_with_harness \
   -e "OPENCLAW_NPM_ONBOARD_JSON_ARTIFACT_MAX_BYTES=$JSON_ARTIFACT_MAX_BYTES" \
   -e "OPENCLAW_NPM_ONBOARD_STATUS_TEXT_MAX_BYTES=$STATUS_TEXT_MAX_BYTES" \
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64" \
+  -v "$ONBOARD_ASSERTIONS:/app/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs:ro" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   -i "$IMAGE_NAME" bash -s >"$run_log" 2>&1 <<'EOF'; then
 set -Eeuo pipefail

--- a/scripts/e2e/release-typed-onboarding-docker.sh
+++ b/scripts/e2e/release-typed-onboarding-docker.sh
@@ -11,12 +11,10 @@ source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 
 openclaw_resolve_frozen_core_harness_capabilities "$TARGET_ROOT_DIR"
 SCENARIO_PATH="$ROOT_DIR/scripts/e2e/lib/release-typed-onboarding/scenario.sh"
-if openclaw_prepare_frozen_target_context "$TARGET_ROOT_DIR" &&
-  openclaw_frozen_target_source_has_path "$TARGET_ROOT_DIR" scripts/e2e/lib/release-typed-onboarding/scenario.sh; then
-  # A frozen package is qualified by its own shipped onboarding journey. Do not
-  # overlay later companion-plugin setup onto the selected package's config.
-  SCENARIO_PATH="$TARGET_ROOT_DIR/scripts/e2e/lib/release-typed-onboarding/scenario.sh"
-fi
+# A frozen package is qualified by its own shipped onboarding journey. Do not
+# overlay later companion-plugin setup onto the selected package's config.
+SCENARIO_PATH="$(openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR" \
+  scripts/e2e/lib/release-typed-onboarding/scenario.sh "$SCENARIO_PATH")"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-release-typed-onboarding-e2e" OPENCLAW_RELEASE_TYPED_ONBOARDING_E2E_IMAGE)"
 SKIP_BUILD="${OPENCLAW_RELEASE_TYPED_ONBOARDING_E2E_SKIP_BUILD:-0}"

--- a/scripts/e2e/update-channel-switch-docker.sh
+++ b/scripts/e2e/update-channel-switch-docker.sh
@@ -198,7 +198,7 @@ set +e
 dirty_json="$(openclaw update "${dev_channel_args[@]}" --yes --json --no-restart)"
 dirty_status=$?
 set -e
-if [ "$dirty_status" -eq 0 ]; then
+if [ "$dirty_status" -eq 0 ] && [ "$OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT" != "1" ]; then
   echo "Git update unexpectedly admitted ordinary untracked user notes" >&2
   exit 1
 fi

--- a/scripts/e2e/update-corrupt-plugin-docker.sh
+++ b/scripts/e2e/update-corrupt-plugin-docker.sh
@@ -7,6 +7,14 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 source "$ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
+
+TARGET_ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" && pwd)"
+CORRUPT_UPDATE_SCENARIO="$ROOT_DIR/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh"
+if openclaw_prepare_frozen_target_context "$TARGET_ROOT_DIR" &&
+  openclaw_frozen_target_source_has_path "$TARGET_ROOT_DIR" scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh; then
+  CORRUPT_UPDATE_SCENARIO="$TARGET_ROOT_DIR/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh"
+fi
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-update-corrupt-plugin-e2e" OPENCLAW_UPDATE_CORRUPT_PLUGIN_E2E_IMAGE)"
 SKIP_BUILD="${OPENCLAW_UPDATE_CORRUPT_PLUGIN_E2E_SKIP_BUILD:-0}"
@@ -24,6 +32,7 @@ OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 update-corrupt
 
 echo "Running corrupt plugin update tolerance E2E..."
 docker_e2e_run_with_harness \
+  -v "$CORRUPT_UPDATE_SCENARIO:/app/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh:ro" \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e OPENCLAW_SKIP_CHANNELS=1 \
   -e OPENCLAW_SKIP_PROVIDERS=1 \

--- a/scripts/e2e/update-corrupt-plugin-docker.sh
+++ b/scripts/e2e/update-corrupt-plugin-docker.sh
@@ -10,11 +10,9 @@ source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
 source "$ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 
 TARGET_ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" && pwd)"
-CORRUPT_UPDATE_SCENARIO="$ROOT_DIR/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh"
-if openclaw_prepare_frozen_target_context "$TARGET_ROOT_DIR" &&
-  openclaw_frozen_target_source_has_path "$TARGET_ROOT_DIR" scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh; then
-  CORRUPT_UPDATE_SCENARIO="$TARGET_ROOT_DIR/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh"
-fi
+CORRUPT_UPDATE_SCENARIO="$(openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR" \
+  scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh \
+  "$ROOT_DIR/scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh")"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-update-corrupt-plugin-e2e" OPENCLAW_UPDATE_CORRUPT_PLUGIN_E2E_IMAGE)"
 SKIP_BUILD="${OPENCLAW_UPDATE_CORRUPT_PLUGIN_E2E_SKIP_BUILD:-0}"

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -46,7 +46,17 @@ source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-image.sh"
 source "$HARNESS_ROOT_DIR/scripts/lib/docker-e2e-package.sh"
 source "$HARNESS_ROOT_DIR/scripts/lib/upgrade-survivor-diagnostics.sh"
 source "$HARNESS_ROOT_DIR/scripts/lib/openclaw-e2e-instance.sh"
+source "$HARNESS_ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 source "$HARNESS_ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
+
+UPGRADE_ASSERTION_ARGS=()
+if openclaw_prepare_frozen_target_context "$ROOT_DIR" &&
+  openclaw_frozen_target_source_has_path "$ROOT_DIR" scripts/e2e/lib/upgrade-survivor/assertions.mjs; then
+  # Upgrade survival is defined by the selected release's shipped state contract.
+  UPGRADE_ASSERTION_ARGS+=(
+    -v "$ROOT_DIR/scripts/e2e/lib/upgrade-survivor/assertions.mjs:/app/scripts/e2e/lib/upgrade-survivor/assertions.mjs:ro"
+  )
+fi
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-upgrade-survivor-e2e" OPENCLAW_UPGRADE_SURVIVOR_E2E_IMAGE)"
 SKIP_BUILD="${OPENCLAW_UPGRADE_SURVIVOR_E2E_SKIP_BUILD:-0}"
@@ -286,6 +296,7 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/clawhub-fixture-server.cjs:/tmp/openclaw-clawhub-fixture-server.cjs:ro" \
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/config-parking.mjs:/tmp/openclaw-config-parking.mjs:ro" \
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh:/tmp/openclaw-upgrade-survivor-run.sh:ro" \
+    ${UPGRADE_ASSERTION_ARGS[@]+"${UPGRADE_ASSERTION_ARGS[@]}"} \
     ${DOCKER_E2E_PACKAGE_ARGS[@]+"${DOCKER_E2E_PACKAGE_ARGS[@]}"} \
     ${DOCKER_RUN_USER_ARGS[@]+"${DOCKER_RUN_USER_ARGS[@]}"} \
     "$IMAGE_NAME" \
@@ -335,6 +346,7 @@ docker_e2e_run_with_harness \
   -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
   -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/clawhub-fixture-server.cjs:/tmp/openclaw-clawhub-fixture-server.cjs:ro" \
   -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/config-parking.mjs:/tmp/openclaw-config-parking.mjs:ro" \
+  ${UPGRADE_ASSERTION_ARGS[@]+"${UPGRADE_ASSERTION_ARGS[@]}"} \
   ${DOCKER_E2E_PACKAGE_ARGS[@]+"${DOCKER_E2E_PACKAGE_ARGS[@]}"} \
   ${DOCKER_RUN_USER_ARGS[@]+"${DOCKER_RUN_USER_ARGS[@]}"} \
   "$IMAGE_NAME" \

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -50,11 +50,12 @@ source "$HARNESS_ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 source "$HARNESS_ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 
 UPGRADE_ASSERTION_ARGS=()
-if openclaw_prepare_frozen_target_context "$ROOT_DIR" &&
-  openclaw_frozen_target_source_has_path "$ROOT_DIR" scripts/e2e/lib/upgrade-survivor/assertions.mjs; then
+UPGRADE_ASSERTIONS="$(openclaw_resolve_frozen_target_file \
+  "$ROOT_DIR" scripts/e2e/lib/upgrade-survivor/assertions.mjs)"
+if [ -n "$UPGRADE_ASSERTIONS" ]; then
   # Upgrade survival is defined by the selected release's shipped state contract.
   UPGRADE_ASSERTION_ARGS+=(
-    -v "$ROOT_DIR/scripts/e2e/lib/upgrade-survivor/assertions.mjs:/app/scripts/e2e/lib/upgrade-survivor/assertions.mjs:ro"
+    -v "$UPGRADE_ASSERTIONS:/app/scripts/e2e/lib/upgrade-survivor/assertions.mjs:ro"
   )
 fi
 

--- a/scripts/lib/frozen-target-compat.sh
+++ b/scripts/lib/frozen-target-compat.sh
@@ -39,6 +39,25 @@ openclaw_prepare_frozen_target_context() {
   fi
 }
 
+openclaw_resolve_frozen_target_file() {
+  local source_root="${1:?missing selected source root}" \
+    relative_path="${2:?missing selected relative path}" \
+    fallback_path="${3:-}" context_status=0
+
+  openclaw_prepare_frozen_target_context "$source_root" || context_status=$?
+  case "$context_status" in
+    0)
+      if openclaw_frozen_target_source_has_path "$source_root" "$relative_path"; then
+        printf '%s\n' "$source_root/$relative_path"
+        return
+      fi
+      ;;
+    1) ;;
+    *) return "$context_status" ;;
+  esac
+  printf '%s\n' "$fallback_path"
+}
+
 openclaw_frozen_target_source_has_path() {
   local source_root="${1:?missing selected source root}" relative_path="${2:?missing relative path}"
   git -C "$source_root" cat-file -e "$OPENCLAW_SELECTED_SHA:$relative_path" 2>/dev/null

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3002,8 +3002,8 @@ docker_e2e_docker_run_cmd run demo
 
     expectTextToIncludeAll(runner, [
       'openclaw_resolve_frozen_core_harness_capabilities "$TARGET_ROOT_DIR"',
-      'openclaw_prepare_frozen_target_context "$TARGET_ROOT_DIR"',
-      'openclaw_frozen_target_source_has_path "$TARGET_ROOT_DIR" scripts/e2e/lib/release-typed-onboarding/scenario.sh',
+      'openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR"',
+      "scripts/e2e/lib/release-typed-onboarding/scenario.sh",
       '-v "$SCENARIO_PATH:/app/scripts/e2e/lib/release-typed-onboarding/scenario.sh:ro"',
     ]);
   });
@@ -5905,9 +5905,9 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
         "scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh",
       ],
       [KITCHEN_SINK_PLUGIN_DOCKER_E2E_PATH, "scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs"],
-    ]) {
+    ] as const) {
       const runner = readFileSync(runnerPath, "utf8");
-      expect(runner).toContain(`openclaw_frozen_target_source_has_path`);
+      expect(runner).toContain(`openclaw_resolve_frozen_target_file`);
       expect(runner).toContain(`${assertionPath}:ro`);
     }
   });

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -99,6 +99,7 @@ const PLUGINS_DOCKER_CLAWHUB_PATH = "scripts/e2e/lib/plugins/clawhub.sh";
 const PLUGINS_DOCKER_ASSERTIONS_PATH = "scripts/e2e/lib/plugins/assertions.mjs";
 const PLUGINS_DOCKER_NPM_REGISTRY_PATH = "scripts/e2e/lib/plugins/npm-registry-server.mjs";
 const PLUGIN_UPDATE_DOCKER_E2E_PATH = "scripts/e2e/plugin-update-unchanged-docker.sh";
+const PLUGIN_UPDATE_CORRUPT_DOCKER_E2E_PATH = "scripts/e2e/update-corrupt-plugin-docker.sh";
 const PLUGIN_UPDATE_SCENARIO_PATH = "scripts/e2e/lib/plugin-update/unchanged-scenario.sh";
 const PLUGIN_UPDATE_CORRUPT_SCENARIO_PATH =
   "scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh";
@@ -5899,6 +5900,10 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
         "scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs",
       ],
       [UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "scripts/e2e/lib/upgrade-survivor/assertions.mjs"],
+      [
+        PLUGIN_UPDATE_CORRUPT_DOCKER_E2E_PATH,
+        "scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh",
+      ],
     ]) {
       const runner = readFileSync(runnerPath, "utf8");
       expect(runner).toContain(`openclaw_frozen_target_source_has_path`);

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -56,7 +56,6 @@ const AGENTS_DELETE_SHARED_WORKSPACE_DOCKER_E2E_PATH =
 const OPENWEBUI_DOCKER_E2E_PATH = "scripts/e2e/openwebui-docker.sh";
 const ONBOARD_DOCKER_E2E_PATH = "scripts/e2e/onboard-docker.sh";
 const ONBOARD_SCENARIO_PATH = "scripts/e2e/lib/onboard/scenario.sh";
-const KITCHEN_SINK_PLUGIN_DOCKER_E2E_PATH = "scripts/e2e/kitchen-sink-plugin-docker.sh";
 const KITCHEN_SINK_RPC_DOCKER_E2E_PATH = "scripts/e2e/kitchen-sink-rpc-docker.sh";
 const CODEX_ON_DEMAND_DOCKER_E2E_PATH = "scripts/e2e/codex-on-demand-docker.sh";
 const MCP_CODE_MODE_GATEWAY_DOCKER_E2E_PATH = "scripts/e2e/mcp-code-mode-gateway-docker.sh";
@@ -93,6 +92,7 @@ const BUNDLED_PLUGIN_INSTALL_UNINSTALL_RUNTIME_SMOKE_PATH =
 const CLEANUP_SMOKE_DOCKERFILE_PATH = "scripts/docker/cleanup-smoke/Dockerfile";
 const CLEANUP_SMOKE_RUN_PATH = "scripts/docker/cleanup-smoke/run.sh";
 const PLUGINS_DOCKER_E2E_PATH = "scripts/e2e/plugins-docker.sh";
+const KITCHEN_SINK_PLUGIN_DOCKER_E2E_PATH = "scripts/e2e/kitchen-sink-plugin-docker.sh";
 const PLUGINS_DOCKER_SWEEP_PATH = "scripts/e2e/lib/plugins/sweep.sh";
 const PLUGINS_DOCKER_MARKETPLACE_PATH = "scripts/e2e/lib/plugins/marketplace.sh";
 const PLUGINS_DOCKER_CLAWHUB_PATH = "scripts/e2e/lib/plugins/clawhub.sh";
@@ -5904,6 +5904,7 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
         PLUGIN_UPDATE_CORRUPT_DOCKER_E2E_PATH,
         "scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh",
       ],
+      [KITCHEN_SINK_PLUGIN_DOCKER_E2E_PATH, "scripts/e2e/lib/kitchen-sink-plugin/assertions.mjs"],
     ]) {
       const runner = readFileSync(runnerPath, "utf8");
       expect(runner).toContain(`openclaw_frozen_target_source_has_path`);

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -5891,6 +5891,21 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
     );
   });
 
+  it("uses each authorized frozen release's shipped scenario assertions", () => {
+    for (const [runnerPath, assertionPath] of [
+      [CODEX_ON_DEMAND_DOCKER_E2E_PATH, "scripts/e2e/lib/codex-on-demand/assertions.mjs"],
+      [
+        NPM_ONBOARD_CHANNEL_AGENT_DOCKER_E2E_PATH,
+        "scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs",
+      ],
+      [UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "scripts/e2e/lib/upgrade-survivor/assertions.mjs"],
+    ]) {
+      const runner = readFileSync(runnerPath, "utf8");
+      expect(runner).toContain(`openclaw_frozen_target_source_has_path`);
+      expect(runner).toContain(`${assertionPath}:ro`);
+    }
+  });
+
   it("serves the version-matched Codex candidate during package onboarding", () => {
     const runner = readFileSync(CODEX_ON_DEMAND_DOCKER_E2E_PATH, "utf8");
     const registryHelper = readFileSync(PREPUBLISH_PLUGIN_REGISTRY_HELPER_PATH, "utf8");
@@ -6922,6 +6937,13 @@ process.exit(73);
     expect(runner).not.toContain(
       'run_logged gateway-network-client timeout "$CLIENT_TIMEOUT" docker run --rm',
     );
+  });
+
+  it("uses the selected release's legacy gateway client only after frozen authorization", () => {
+    const runner = readFileSync(GATEWAY_NETWORK_DOCKER_E2E_PATH, "utf8");
+    expect(runner).toContain('[[ "$FROZEN_CONTEXT" == "1" ]]');
+    expect(runner).toContain("scripts/e2e/lib/gateway-network/client.mjs");
+    expect(runner).toContain("node /tmp/openclaw-gateway-network-client.mjs");
   });
 
   it("proves gateway suspension across a same-container process restart", () => {

--- a/test/scripts/live-docker-stage.test.ts
+++ b/test/scripts/live-docker-stage.test.ts
@@ -353,6 +353,26 @@ export function parseRegistryNpmSpec(spec: string) {
     expect(malformed.stderr).toContain("invalid OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS");
   });
 
+  it("falls back without frozen context but fails malformed authorization", () => {
+    const command = [
+      "-c",
+      'set -euo pipefail; source "$1"; openclaw_resolve_frozen_target_file "$2" missing/path fallback',
+      "test",
+      stageScriptPath,
+      repoRoot,
+    ];
+    const run = (env: Record<string, string>) =>
+      spawnSync("bash", command, { encoding: "utf8", env: { ...process.env, ...env } });
+
+    const absent = run({});
+    expect(absent.status).toBe(0);
+    expect(absent.stdout).toBe("fallback\n");
+
+    const malformed = run({ OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "yes" });
+    expect(malformed.status).toBe(2);
+    expect(malformed.stderr).toContain("invalid OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS");
+  });
+
   it("keeps a matching frozen-source capability under pipefail", () => {
     const root = tempDirs.make("openclaw-frozen-target-capability-");
     const sourcePath = path.join(root, "scripts/e2e/lib/plugins/assertions.mjs");


### PR DESCRIPTION
## Summary

- qualify frozen upgrade, onboarding, and Codex package behavior with the selected release's shipped assertion modules
- run the selected release's legacy gateway client when the newer suspension client is absent
- preserve strict current-target behavior and require the existing frozen-target authorization/identity boundary
- let legacy update CLIs prove dirty-worktree rejection from their structured result even when they historically exited zero
- bind the root Docker install smoke to the selected source checkout

## Root cause

Full Release Validation used current-main scenario assertions and gateway setup against the immutable 2026.6.35 candidate. Those assertions require later SQLite exec-approval migration, current model defaults, plugin installation phases, and `admin-http-rpc`; the selected release shipped different valid contracts. This produced false failures after the package had completed its own behavior correctly.

The fix reuses target-owned, already-shipped scenario artifacts behind the canonical frozen-target authorization check. It does not add versions, SHA allowlists, public config, or a compatibility profile.

## Evidence

Failing full validation: https://github.com/openclaw/openclaw/actions/runs/34174003947

Local:
- `bash -n` on all changed runners
- focused Docker harness contracts: 2/2
- frozen target-file fallback/fail-closed regression: 1/1
- broader affected tooling suite before the final assertions: 770 passed, 2 skipped
- exact-head autoreview: scoped-clean (0.99), no actionable findings
- `git diff --check`

Production/workflow: +90/-10. Tests: +51/-3. Application runtime: 0. The six scenario selectors share one fail-closed target-file resolver; no per-scenario authorization logic remains.
