### PR TITLE
fix(onboard): scope recommendations by agent

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -46,6 +46,8 @@ openclaw onboard --flow import
 openclaw onboard --import-from hermes --import-source ~/.hermes
 openclaw onboard --skip-bootstrap
 openclaw onboard recommendations --json
+openclaw onboard recommendations --agent writer --json
+openclaw onboard recommendations --agent writer acknowledge
 openclaw onboard recommendations acknowledge
 openclaw onboard recommendations acknowledge --retry "<failed-id>"
 openclaw onboard recommendations refresh
@@ -61,6 +63,13 @@ labels. After the recommendation offer has been answered, the command returns
 an empty list and future onboarding runs skip the step entirely.
 `openclaw onboard recommendations refresh` clears the stored offer so the next
 onboarding run rescans installed apps and creates a new offer.
+
+Pass `--agent <id>` after `recommendations` to select a configured agent for
+reads, `acknowledge`, `acknowledge --retry`, or `refresh`. These operations use
+only that agent's workspace recommendations. Without the selector, the command
+keeps its existing default-agent behavior and asks you to select an agent when
+the owner is ambiguous. Blank or unknown agent IDs fail without changing the
+stored recommendations; use `openclaw agents list` to find configured IDs.
 
 Fresh workspaces defer the recommendation choice to the bootstrap conversation.
 After that conversation handles the user's choices,

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -91,25 +91,25 @@ describe("registerOnboardCommand", () => {
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 
-  it("routes an explicit agent to the recommendations commands", async () => {
-    await runCli(["onboard", "recommendations", "--agent", "writer", "--json"]);
-    expect(mocks.onboardRecommendationsCommand).toHaveBeenCalledWith(
-      { agent: "writer", json: true },
-      runtime,
-    );
+  it.each(["writer", "", "   ", "writer!"])(
+    "preserves explicit agent '%s' for command validation",
+    async (agent) => {
+      await runCli(["onboard", "recommendations", "--agent", agent, "--json"]);
+      expect(mocks.onboardRecommendationsCommand).toHaveBeenCalledWith(
+        { agent, json: true },
+        runtime,
+      );
 
-    await runCli(["onboard", "recommendations", "--agent", "writer", "acknowledge"]);
-    expect(mocks.acknowledgeOnboardRecommendationsCommand).toHaveBeenCalledWith(
-      { agent: "writer", retry: undefined },
-      runtime,
-    );
+      await runCli(["onboard", "recommendations", "--agent", agent, "acknowledge"]);
+      expect(mocks.acknowledgeOnboardRecommendationsCommand).toHaveBeenCalledWith(
+        { agent, retry: undefined },
+        runtime,
+      );
 
-    await runCli(["onboard", "recommendations", "--agent", "writer", "refresh"]);
-    expect(mocks.refreshOnboardRecommendationsCommand).toHaveBeenCalledWith(
-      { agent: "writer" },
-      runtime,
-    );
-  });
+      await runCli(["onboard", "recommendations", "--agent", agent, "refresh"]);
+      expect(mocks.refreshOnboardRecommendationsCommand).toHaveBeenCalledWith({ agent }, runtime);
+    },
+  );
 
   it("routes the recommendations acknowledgement subcommand", async () => {
     await runCli(["onboard", "recommendations", "acknowledge"]);

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -91,6 +91,26 @@ describe("registerOnboardCommand", () => {
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 
+  it("routes an explicit agent to the recommendations commands", async () => {
+    await runCli(["onboard", "recommendations", "--agent", "writer", "--json"]);
+    expect(mocks.onboardRecommendationsCommand).toHaveBeenCalledWith(
+      { agent: "writer", json: true },
+      runtime,
+    );
+
+    await runCli(["onboard", "recommendations", "--agent", "writer", "acknowledge"]);
+    expect(mocks.acknowledgeOnboardRecommendationsCommand).toHaveBeenCalledWith(
+      { agent: "writer", retry: undefined },
+      runtime,
+    );
+
+    await runCli(["onboard", "recommendations", "--agent", "writer", "refresh"]);
+    expect(mocks.refreshOnboardRecommendationsCommand).toHaveBeenCalledWith(
+      { agent: "writer" },
+      runtime,
+    );
+  });
+
   it("routes the recommendations acknowledgement subcommand", async () => {
     await runCli(["onboard", "recommendations", "acknowledge"]);
 
@@ -121,7 +141,7 @@ describe("registerOnboardCommand", () => {
   it("routes the recommendations refresh subcommand", async () => {
     await runCli(["onboard", "recommendations", "refresh"]);
 
-    expect(mocks.refreshOnboardRecommendationsCommand).toHaveBeenCalledWith(runtime);
+    expect(mocks.refreshOnboardRecommendationsCommand).toHaveBeenCalledWith({}, runtime);
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
 

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -65,7 +65,7 @@ async function validateRecommendationParentOptions(
 
 const AUTH_CHOICE_HELP = formatAuthChoiceChoicesForCli({ includeSkip: true });
 const RECOMMENDATION_READ_PARENT_OPTIONS = new Set(["json"]);
-const NO_RECOMMENDATION_PARENT_OPTIONS = new Set<string>();
+const NO_RECOMMENDATION_PARENT_OPTIONS = new Set(["agent"]);
 
 type OnboardAuthFlag = {
   readonly cliOption: string;
@@ -316,6 +316,7 @@ export function registerOnboardCommand(program: Command): void {
   const recommendations = command
     .command("recommendations")
     .description("Read the app recommendations stored during onboarding")
+    .option("--agent <id>", "Agent whose onboarding recommendations should be used")
     .option("--json", "Output stored recommendation matches as JSON", false)
     .action(async (opts, recommendationsCommand: Command) => {
       const { defaultRuntime } = await import("../../runtime.js");
@@ -326,7 +327,8 @@ export function registerOnboardCommand(program: Command): void {
         }
         const { onboardRecommendationsCommand } =
           await import("../../commands/onboard-recommendations.js");
-        onboardRecommendationsCommand({ json }, defaultRuntime);
+        const agent = readStringValue(opts.agent);
+        onboardRecommendationsCommand({ json, ...(agent ? { agent } : {}) }, defaultRuntime);
       });
     });
 
@@ -345,7 +347,11 @@ export function registerOnboardCommand(program: Command): void {
         }
         const { acknowledgeOnboardRecommendationsCommand } =
           await import("../../commands/onboard-recommendations.js");
-        acknowledgeOnboardRecommendationsCommand({ retry: opts.retry }, defaultRuntime);
+        const agent = readStringValue(recommendations.opts().agent);
+        acknowledgeOnboardRecommendationsCommand(
+          { retry: opts.retry, ...(agent ? { agent } : {}) },
+          defaultRuntime,
+        );
       });
     });
 
@@ -363,7 +369,8 @@ export function registerOnboardCommand(program: Command): void {
         }
         const { refreshOnboardRecommendationsCommand } =
           await import("../../commands/onboard-recommendations.js");
-        refreshOnboardRecommendationsCommand(defaultRuntime);
+        const agent = readStringValue(recommendations.opts().agent);
+        refreshOnboardRecommendationsCommand(agent ? { agent } : {}, defaultRuntime);
       });
     });
 

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -50,7 +50,7 @@ async function validateRecommendationParentOptions(
 ): Promise<boolean> {
   const unsupported = listExplicitOptionFlagsExcept(
     command,
-    json ? RECOMMENDATION_READ_PARENT_OPTIONS : NO_RECOMMENDATION_PARENT_OPTIONS,
+    json ? RECOMMENDATION_READ_PARENT_OPTIONS : RECOMMENDATION_MUTATION_PARENT_OPTIONS,
   );
   if (unsupported.length === 0) {
     return true;
@@ -65,7 +65,7 @@ async function validateRecommendationParentOptions(
 
 const AUTH_CHOICE_HELP = formatAuthChoiceChoicesForCli({ includeSkip: true });
 const RECOMMENDATION_READ_PARENT_OPTIONS = new Set(["json"]);
-const NO_RECOMMENDATION_PARENT_OPTIONS = new Set(["agent"]);
+const RECOMMENDATION_MUTATION_PARENT_OPTIONS = new Set(["agent"]);
 
 type OnboardAuthFlag = {
   readonly cliOption: string;
@@ -328,7 +328,10 @@ export function registerOnboardCommand(program: Command): void {
         const { onboardRecommendationsCommand } =
           await import("../../commands/onboard-recommendations.js");
         const agent = readStringValue(opts.agent);
-        onboardRecommendationsCommand({ json, ...(agent ? { agent } : {}) }, defaultRuntime);
+        onboardRecommendationsCommand(
+          { json, ...(agent !== undefined ? { agent } : {}) },
+          defaultRuntime,
+        );
       });
     });
 
@@ -349,7 +352,7 @@ export function registerOnboardCommand(program: Command): void {
           await import("../../commands/onboard-recommendations.js");
         const agent = readStringValue(recommendations.opts().agent);
         acknowledgeOnboardRecommendationsCommand(
-          { retry: opts.retry, ...(agent ? { agent } : {}) },
+          { retry: opts.retry, ...(agent !== undefined ? { agent } : {}) },
           defaultRuntime,
         );
       });
@@ -370,7 +373,7 @@ export function registerOnboardCommand(program: Command): void {
         const { refreshOnboardRecommendationsCommand } =
           await import("../../commands/onboard-recommendations.js");
         const agent = readStringValue(recommendations.opts().agent);
-        refreshOnboardRecommendationsCommand(agent ? { agent } : {}, defaultRuntime);
+        refreshOnboardRecommendationsCommand(agent !== undefined ? { agent } : {}, defaultRuntime);
       });
     });
 

--- a/src/commands/onboard-recommendations.test.ts
+++ b/src/commands/onboard-recommendations.test.ts
@@ -260,7 +260,7 @@ describe("onboard recommendations command", () => {
     const runtime = makeRuntime();
     const clear = vi.fn(() => true);
 
-    refreshOnboardRecommendationsCommand(runtime, { clear });
+    refreshOnboardRecommendationsCommand({}, runtime, { clear });
 
     expect(clear).toHaveBeenCalledOnce();
     expect(runtime.log).toHaveBeenCalledWith(

--- a/src/commands/onboard-recommendations.test.ts
+++ b/src/commands/onboard-recommendations.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { RuntimeEnv } from "../runtime.js";
+import { createOnboardingRecommendationsStore } from "../state/onboarding-recommendations.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import {
   acknowledgeOnboardRecommendationsCommand,
   onboardRecommendationsCommand,
@@ -13,6 +15,62 @@ function makeRuntime(): RuntimeEnv {
     exit: vi.fn(),
   };
 }
+
+describe.each([
+  {
+    operation: "read",
+    run: (agent: string, runtime: RuntimeEnv) =>
+      onboardRecommendationsCommand({ agent, json: true }, runtime),
+  },
+  {
+    operation: "acknowledge",
+    run: (agent: string, runtime: RuntimeEnv) =>
+      acknowledgeOnboardRecommendationsCommand({ agent }, runtime),
+  },
+  {
+    operation: "refresh",
+    run: (agent: string, runtime: RuntimeEnv) =>
+      refreshOnboardRecommendationsCommand({ agent }, runtime),
+  },
+])("onboard recommendations $operation selection", ({ run }) => {
+  it.each([
+    { agent: "", error: "--agent must not be blank" },
+    { agent: "   ", error: "--agent must not be blank" },
+    { agent: "writer!", error: 'Unknown agent id "writer!"' },
+  ])(
+    "rejects invalid selector '$agent' without changing the default offer",
+    async ({ agent, error }) => {
+      await withOpenClawTestState({ label: "recommendation-agent-selection" }, async (state) => {
+        await state.writeConfig({
+          agents: { entries: { writer: { workspace: state.workspaceDir } } },
+        });
+        const store = createOnboardingRecommendationsStore({ workspaceDir: state.workspaceDir });
+        const offer = store.writeOffer({
+          inventory: [{ label: "Legacy app" }],
+          matches: [
+            {
+              appLabel: "Legacy app",
+              candidateId: "legacy-app",
+              tier: "recommended",
+              reason: "Legacy offer",
+              candidate: {
+                id: "legacy-app",
+                displayName: "Legacy app",
+                summary: "Legacy offer",
+                source: "clawhub-skill",
+              },
+            },
+          ],
+          answered: false,
+          nowMs: 1,
+        });
+
+        expect(() => run(agent, makeRuntime())).toThrow(error);
+        expect(store.read()).toEqual(offer);
+      });
+    },
+  );
+});
 
 describe("onboard recommendations command", () => {
   it("returns stored matches as JSON without rescanning", () => {

--- a/src/commands/onboard-recommendations.ts
+++ b/src/commands/onboard-recommendations.ts
@@ -4,7 +4,6 @@ import {
   resolveDefaultAgentId,
 } from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/config.js";
-import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import {
   createOnboardingRecommendationsStore,
@@ -45,10 +44,12 @@ type BootstrapRecommendation = {
 function createDefaultOnboardingRecommendationsStore(
   requestedAgentId?: string,
 ): OnboardingRecommendationsStore {
+  const requested = requestedAgentId?.trim();
+  if (requestedAgentId !== undefined && !requested) {
+    throw new Error("--agent must not be blank");
+  }
   const cfg = getRuntimeConfig();
-  const agentId = requestedAgentId
-    ? resolveConfiguredAgentId(cfg, normalizeAgentId(requestedAgentId))
-    : resolveDefaultAgentId(cfg);
+  const agentId = requested ? resolveConfiguredAgentId(cfg, requested) : resolveDefaultAgentId(cfg);
   const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   return createOnboardingRecommendationsStore({ workspaceDir });
 }

--- a/src/commands/onboard-recommendations.ts
+++ b/src/commands/onboard-recommendations.ts
@@ -1,5 +1,10 @@
-import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../agents/agent-scope.js";
+import {
+  resolveAgentWorkspaceDir,
+  resolveConfiguredAgentId,
+  resolveDefaultAgentId,
+} from "../agents/agent-scope.js";
 import { getRuntimeConfig } from "../config/config.js";
+import { normalizeAgentId } from "../routing/session-key.js";
 import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import {
   createOnboardingRecommendationsStore,
@@ -16,7 +21,17 @@ type OnboardRecommendationsDeps = {
 };
 
 type AcknowledgeOnboardRecommendationsOptions = {
+  agent?: string;
   retry?: readonly string[];
+};
+
+type OnboardRecommendationsOptions = {
+  agent?: string;
+  json?: boolean;
+};
+
+type RefreshOnboardRecommendationsOptions = {
+  agent?: string;
 };
 
 const SAFE_INSTALL_ID_RE = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/iu;
@@ -27,15 +42,20 @@ type BootstrapRecommendation = {
   tier: "recommended" | "optional";
 };
 
-function createDefaultOnboardingRecommendationsStore(): OnboardingRecommendationsStore {
+function createDefaultOnboardingRecommendationsStore(
+  requestedAgentId?: string,
+): OnboardingRecommendationsStore {
   const cfg = getRuntimeConfig();
-  const workspaceDir = resolveAgentWorkspaceDir(cfg, resolveDefaultAgentId(cfg));
+  const agentId = requestedAgentId
+    ? resolveConfiguredAgentId(cfg, normalizeAgentId(requestedAgentId))
+    : resolveDefaultAgentId(cfg);
+  const workspaceDir = resolveAgentWorkspaceDir(cfg, agentId);
   return createOnboardingRecommendationsStore({ workspaceDir });
 }
 
-function createDefaultStoreAccessor(): () => OnboardingRecommendationsStore {
+function createDefaultStoreAccessor(agentId?: string): () => OnboardingRecommendationsStore {
   let store: OnboardingRecommendationsStore | undefined;
-  return () => (store ??= createDefaultOnboardingRecommendationsStore());
+  return () => (store ??= createDefaultOnboardingRecommendationsStore(agentId));
 }
 
 function isLegacyBareClawHubId(match: OnboardingRecommendationsRecord["matches"][number]): boolean {
@@ -72,11 +92,11 @@ function bootstrapRecommendations(
 }
 
 export function onboardRecommendationsCommand(
-  opts: { json?: boolean },
+  opts: OnboardRecommendationsOptions,
   runtime: RuntimeEnv,
   deps: OnboardRecommendationsDeps = {},
 ): void {
-  const defaultStore = createDefaultStoreAccessor();
+  const defaultStore = createDefaultStoreAccessor(opts.agent);
   const stored = (deps.read ?? defaultStore().read)();
   const hasLegacyClawHubId = stored?.matches.some(isLegacyBareClawHubId);
   if (hasLegacyClawHubId && stored && stored.acceptedAt == null) {
@@ -116,7 +136,7 @@ export function acknowledgeOnboardRecommendationsCommand(
   runtime: RuntimeEnv,
   deps: OnboardRecommendationsDeps = {},
 ): void {
-  const defaultStore = createDefaultStoreAccessor();
+  const defaultStore = createDefaultStoreAccessor(opts.agent);
   const retryIds = [...new Set(opts.retry ?? [])];
   if (retryIds.length > 0) {
     const record = (deps.read ?? defaultStore().read)();
@@ -153,10 +173,11 @@ export function acknowledgeOnboardRecommendationsCommand(
 }
 
 export function refreshOnboardRecommendationsCommand(
+  opts: RefreshOnboardRecommendationsOptions,
   runtime: RuntimeEnv,
   deps: OnboardRecommendationsDeps = {},
 ): void {
-  const defaultStore = createDefaultStoreAccessor();
+  const defaultStore = createDefaultStoreAccessor(opts.agent);
   const cleared = (deps.clear ?? defaultStore().clear)();
   runtime.log(
     cleared

--- a/src/wizard/setup.app-recommendations.test.ts
+++ b/src/wizard/setup.app-recommendations.test.ts
@@ -203,7 +203,7 @@ describe("setupAppRecommendations", () => {
     const log = vi.fn();
     const prompter = createPrompter();
 
-    refreshOnboardRecommendationsCommand(runtime, { clear });
+    refreshOnboardRecommendationsCommand({}, runtime, { clear });
     await setupAppRecommendations({
       config: {},
       prompter,


### PR DESCRIPTION
## What Problem This Solves

Onboarding recommendation commands told operators to pass `--agent <id>` when workspace selection was ambiguous, but did not accept that option. Add the shared selector and resolve its configured workspace before reading, acknowledging, retrying, or clearing the existing recommendation record.

Preserve explicit input through command registration. Reject blank and unknown IDs before store access, so an empty selector cannot fall through to the default workspace and a malformed ID cannot be rewritten into another configured agent. Omitted selection keeps the existing default behavior. The store schema, workspace keys, filtering, and concurrent-update checks stay with their existing owners.

## Evidence

Real CLI proof used two isolated configured agents, `writer` and `analyst`, with distinct workspaces and seeded records in the canonical store. Main was pinned at `f310ecc64128e33b3ace61e5a66f20ad8414be1f`.

Before:

```text
$ openclaw onboard recommendations --agent writer --json
OpenClaw does not recognize option "--agent".
Try: openclaw onboard recommendations --help
```

After:

```text
$ openclaw onboard recommendations --agent writer --json
[
  {
    "id": "writer-plugin",
    "source": "official-plugin",
    "tier": "recommended"
  },
  {
    "id": "@fixture/writer-skill",
    "source": "clawhub-skill",
    "tier": "optional"
  }
]
```

- Read, acknowledge, retry, and refresh select the requested workspace. Follow-up reads without reseeding confirm that mutations persist.
- The unselected workspace's exact record bytes and timestamps remain unchanged. These are workspace-keyed rows in a shared database, not separate per-agent recommendation files.
- Empty and whitespace-only IDs return `--agent must not be blank`; unknown IDs retain the `openclaw agents list` guidance. Invalid selectors cannot trigger legacy read-side cleanup or delete an offer.
- Safe install-ID filtering, selected legacy cleanup, parent-option rejection, structured JSON errors, ambiguous omission, and the unambiguous default remain covered.
- All 116 focused tests passed. Nine real-store invalid-selector cases and the empty-selector registration case fail on the original candidate for the intended reasons.
- Fresh independent CLI validation retained 47 complete captures: 12 observable clauses passed, none failed; source, concurrency, baseline identity, and final cleanup remain separately verified roles. Cumulative P0–P2 code review is clean.

The native tested tree is `5cbbae065668cd655417be42f770edcf7225f614`. The build retains its pre-commit `02a1750` stamp; the signed revision has the same tested tree. Full hosted CI and the final exact-head review are landing gates. The initial fixture ownership error and original candidate failures remain in the private evidence history.

