### PR TITLE
fix(doctor): show backup guidance for unreadable state during repair

### DIFF
--- a/src/commands/doctor-maintenance.ts
+++ b/src/commands/doctor-maintenance.ts
@@ -9,6 +9,7 @@ import {
   acquireGatewayLifecycleCoordinator,
   acquireStateDatabaseCoordinator,
 } from "../infra/state-database-coordinator.js";
+import { DoctorUnreadableStateDatabaseError } from "../infra/state-repair-message.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import type { DoctorOptions } from "./doctor-prompter.js";
@@ -159,12 +160,41 @@ export async function beginDoctorMaintenance(params: {
     // Gateway ownership lasts until that process stops, not for a short transaction.
     coordinators.push(acquireGatewayLifecycleCoordinator({ databasePath, busyTimeoutMs: 0 }));
     coordinators.push(acquireStateDatabaseCoordinator({ databasePath, busyTimeoutMs: 250 }));
-    const { assertNoOpenClawAgentDatabaseLeasesReadOnly } =
+    const { assertNoOpenClawAgentDatabaseLeasesReadOnly, OpenClawAgentDatabaseLeaseActiveError } =
       await import("../state/openclaw-agent-db-lease.js");
-    assertNoOpenClawAgentDatabaseLeasesReadOnly({ env });
+    try {
+      assertNoOpenClawAgentDatabaseLeasesReadOnly({ env });
+    } catch (error) {
+      if (error instanceof OpenClawAgentDatabaseLeaseActiveError) {
+        throw error;
+      }
+      // Classify unreadable state under the held owners without opening a writer.
+      const { preflightOpenClawDatabaseSchemas } =
+        await import("../state/openclaw-database-preflight.js");
+      const { OPENCLAW_STATE_SCHEMA_VERSION } =
+        await import("../state/openclaw-state-db-contract.js");
+      const { OPENCLAW_AGENT_SCHEMA_VERSION } =
+        await import("../state/openclaw-agent-db-contract.js");
+      const schemas = await preflightOpenClawDatabaseSchemas({
+        env,
+        scope: "state",
+        supportedVersions: {
+          state: OPENCLAW_STATE_SCHEMA_VERSION,
+          agent: OPENCLAW_AGENT_SCHEMA_VERSION,
+        },
+      });
+      const unreadable = schemas.indeterminate.find((database) => database.kind === "state");
+      if (unreadable) {
+        throw new DoctorUnreadableStateDatabaseError(unreadable.path, unreadable.reason);
+      }
+      throw error;
+    }
     repairStoresMayBeOpen = true;
   } catch (error) {
     await release();
+    if (error instanceof DoctorUnreadableStateDatabaseError) {
+      throw error;
+    }
     throw new Error(
       `Doctor could not enter maintenance. ${String(error)} Stop the Gateway service and other OpenClaw processes using this state, then run ${formatCliCommand("openclaw doctor --fix", env)} from an independent shell.`,
       { cause: error },

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -4,7 +4,7 @@ import { intro as clackIntro, outro as clackOutro } from "@clack/prompts";
 import { stylePromptTitle } from "../../packages/terminal-core/src/prompt-style.js";
 import type { DoctorOptions } from "../commands/doctor-prompter.js";
 import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
-import { formatDoctorStateRepairFailure } from "../infra/state-repair-message.js";
+import { DoctorUnreadableStateDatabaseError } from "../infra/state-repair-message.js";
 import {
   captureUpdateDoctorConfigWrites,
   UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE,
@@ -61,11 +61,9 @@ async function assertDoctorDatabaseSchemasCompatible(scope?: "state") {
     (database) => database.kind === "state",
   );
   if (unreadableStateDatabase) {
-    throw new Error(
-      formatDoctorStateRepairFailure(
-        `shared state database is unreadable at ${unreadableStateDatabase.path}: ${unreadableStateDatabase.reason}`,
-        "Stop OpenClaw processes, then restore this file from a verified backup; the unreadable database was left unchanged.",
-      ),
+    throw new DoctorUnreadableStateDatabaseError(
+      unreadableStateDatabase.path,
+      unreadableStateDatabase.reason,
     );
   }
   return databaseSchemas;

--- a/src/infra/state-repair-message.ts
+++ b/src/infra/state-repair-message.ts
@@ -1,3 +1,15 @@
 export function formatDoctorStateRepairFailure(problem: string, recovery: string): string {
   return `Doctor cannot repair this state: ${problem}. ${recovery}`;
 }
+
+export class DoctorUnreadableStateDatabaseError extends Error {
+  constructor(path: string, reason: string) {
+    super(
+      formatDoctorStateRepairFailure(
+        `shared state database is unreadable at ${path}: ${reason}`,
+        "Stop OpenClaw processes, then restore this file from a verified backup; the unreadable database was left unchanged.",
+      ),
+    );
+    this.name = "DoctorUnreadableStateDatabaseError";
+  }
+}


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users running `openclaw doctor --fix` against an unreadable shared state database received a generic maintenance error telling them to retry, without the database path or backup recovery guidance.

Related: #141412

## Why This Change Was Made

Keep lifecycle and database coordinator admission before lease inspection. If the read-only lease query fails unexpectedly, classify the shared database through the existing preserved-copy preflight while those owners remain held, then release them and return the same accurate recovery diagnostic as plain Doctor. Known active leases retain their existing immediate rejection.

## User Impact

Doctor identifies the affected file and advises restoring a verified backup while leaving the unreadable database unchanged. Existing service, writer and maintenance fences remain intact.

## Evidence

The existing unreadable-state E2E reproduced the failure before the repair: five cases passed and `doctor --fix` failed with the missing path. The repaired release source passed all 102 focused tests across the Doctor E2E, health flow and maintenance schema/plugin suites, plus the full changed gate and independent P2 review. The same focused source suites were rerun on the main backport; exact-head hosted checks will qualify landing.
