### PR TITLE
test(scripts): drop map-spread from plugin npm security scan fixtures

### DIFF
--- a/test/scripts/plugin-npm-security-scan.test.ts
+++ b/test/scripts/plugin-npm-security-scan.test.ts
@@ -284,13 +284,15 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
   });
 
   it("matches the recorded 2026.7.33 inert package scan inventory exactly", () => {
+    // syntheticResultsForFindings returns freshly built results that nothing else
+    // holds, so these are assigned in place rather than respread per element.
     const packageResults = syntheticResultsForFindings(frozen2026_7_33ReviewedFindings()).map(
-      (result) => ({
-        ...result,
-        expectedReviewedCriticalFindings: result.reviewedCriticalFindings.filter((finding) =>
-          finding.includes(".test.ts"),
-        ),
-      }),
+      (result) => {
+        result.expectedReviewedCriticalFindings = result.reviewedCriticalFindings.filter(
+          (finding) => finding.includes(".test.ts"),
+        );
+        return result;
+      },
     );
     const frozen = buildPluginNpmSecurityScanReport({
       candidateSha: CANDIDATE_SHA,
@@ -305,13 +307,16 @@ describe("scripts/lib/plugin-npm-security-scan.mts", () => {
       layout: "extended-stable-2026.7.33",
       status: "pass",
     });
-    const legacyPackageResults = packageResults.map((result) => ({
-      ...result,
-      expectedReviewedCriticalFindings:
-        result.packageName === "@openclaw/acpx"
-          ? result.expectedReviewedCriticalFindings.slice(0, 1)
-          : result.expectedReviewedCriticalFindings,
-    }));
+    // packageResults stays live for the assertion above, so this derives copies
+    // instead of mutating the elements in place.
+    const legacyPackageResults = packageResults.map((result) =>
+      Object.assign({}, result, {
+        expectedReviewedCriticalFindings:
+          result.packageName === "@openclaw/acpx"
+            ? result.expectedReviewedCriticalFindings.slice(0, 1)
+            : result.expectedReviewedCriticalFindings,
+      }),
+    );
     expect(
       buildPluginNpmSecurityScanReport({
         candidateSha: CANDIDATE_SHA,


### PR DESCRIPTION
## What Problem This Solves

`test/scripts/plugin-npm-security-scan.test.ts` has two `oxc(no-map-spread)` violations, at lines 287 and 308. The file sits outside the normal CI lint targets, so no lane surfaces them and they would keep rotting until that path is ever added to the lint scope.

Found while landing an unrelated batch of PRs; reported by a worker and reproduced on current `main`.

## Why This Change Was Made

The two callbacks are not equivalent, so they get different fixes rather than one mechanical rewrite:

- Line 287 maps over the array returned by `syntheticResultsForFindings`, which builds a fresh array of fresh object literals per call and is held by nothing else. Assigning the property in place is safe there.
- Line 308 derives `legacyPackageResults` from `packageResults`, which is still live for the assertion above it. Mutating in place would corrupt that array, so this one copies with `Object.assign` instead.

Both cases carry a short comment naming the ownership reason, since the asymmetry is the non-obvious part.

## User Impact

None. Test-only cleanup, no production code touched.

## Evidence

- `pnpm exec oxlint test/scripts/plugin-npm-security-scan.test.ts` reproduced both errors on current `main` and now exits 0.
- `node scripts/run-vitest.mjs test/scripts/plugin-npm-security-scan.test.ts`: 25 tests pass.
- `git diff --check` clean.
