### PR TITLE
fix(ui): load sidebar agent-menu avatars through authenticated blob loader

### DIFF
--- a/ui/src/components/app-sidebar-agent-menu.ts
+++ b/ui/src/components/app-sidebar-agent-menu.ts
@@ -9,6 +9,7 @@ import type { ApplicationNavigationOptions } from "../app/context.ts";
 import type { ThemeMode } from "../app/theme.ts";
 import { t } from "../i18n/index.ts";
 import { normalizeAgentLabel } from "../lib/agents/display.ts";
+import { resolveAgentAvatarUrl } from "../lib/avatar.ts";
 import { buildExternalLinkRel, EXTERNAL_LINK_TARGET } from "../lib/external-link.ts";
 import {
   formatKeyboardShortcutCombo,
@@ -23,6 +24,7 @@ import {
 } from "../pages/debug/debug-overlay-contract.ts";
 import { renderAgentSelectAvatar, renderAgentSelectCopy } from "./agent-select.ts";
 import { icons, type IconName } from "./icons.ts";
+import { identityAvatarImage } from "./identity-avatar-view.ts";
 import "./sidebar-build-chip.ts";
 import "./viewer-facepile.ts";
 import {
@@ -235,6 +237,7 @@ function renderAgentRow(agent: AgentMenuAgent, params: SidebarAgentMenuParams) {
   const active = agentId === params.activeId;
   const unread = active ? 0 : params.agentUnreadCount(agentId);
   const option = { value: agentId, label, agent };
+  const avatarUrl = resolveAgentAvatarUrl(agent, identity);
   return html`
     <wa-dropdown-item
       class="sidebar-customize-menu__item sidebar-agent-menu__agent-switch agent-select__option ${
@@ -248,7 +251,16 @@ function renderAgentRow(agent: AgentMenuAgent, params: SidebarAgentMenuParams) {
     >
       <span class="sidebar-agent-menu__agent-tile">
         <span class="sidebar-agent-menu__agent-avatar">
-          ${renderAgentSelectAvatar(option, identity)}
+          ${
+            avatarUrl
+              ? html`<img
+                  class="agent-select__avatar"
+                  src=${identityAvatarImage(avatarUrl, avatarUrl)}
+                  alt=""
+                  loading="lazy"
+                />`
+              : renderAgentSelectAvatar(option, identity)
+          }
         </span>
         ${renderAgentSelectCopy(option)}
         <span class="sidebar-agent-menu__agent-status">


### PR DESCRIPTION
## What Problem This Solves

After the sidebar agent-menu refactor, agent avatars in the agent-switcher grid (`sidebar-agent-menu__agent-grid`) fail to load when gateway token auth is active. Every `<img src="/avatar/<agentId>?v=...">` request returns **401** and renders as a broken/blank avatar.

Root cause: `renderAgentRow()` passes the raw local avatar URL straight to `<img src>`. The browser cannot attach the gateway `Authorization` header to an `<img>` request, while the `/avatar/*` route requires gateway authentication. Other surfaces (chat roster, agent-select dropdown, viewer avatars) already fetch the same URLs through the authenticated identity-avatar loader and render a CSP-safe blob URL. The pre-refactor implementation also resolved these avatars through the same authenticated path, so this is a regression.

## Change

Route agent-menu row avatars through the existing `identityAvatarImage` directive (the same authenticated fetch → blob-URL pipeline used by `identity-avatar-view.ts`):

- `ui/src/components/app-sidebar-agent-menu.ts`: resolve each agent's avatar URL with `resolveAgentAvatarUrl()` and render it via `identityAvatarImage(avatarUrl, avatarUrl)` instead of the unprotected plain fallback; keep the text/emoji fallback when no image URL exists.

## Evidence

- `pnpm lint:ui:no-raw-window-open` (CI gate): 0 warnings, 0 errors
- oxlint on the changed file: 0 errors
- Unit tests: `agent-select.test.ts` 23/23 pass; `app-sidebar.test.ts` + `sidebar-menus-controller.test.ts` 347/347 pass
- Manual browser verification against a token-authenticated gateway: avatars in the sidebar agent menu now render via blob URLs; before the fix all 8 grid images returned 401 (`resourceType: image`) and rendered blank
