### PR TITLE
fix: resolve environment references in channel setup checks

### DIFF
--- a/docs/plugins/sdk-setup.md
+++ b/docs/plugins/sdk-setup.md
@@ -166,6 +166,8 @@ For a boolean `useEnv` field, set `envVars` to the static environment variable n
 
 The released `setup`/`ChannelSetupInput` adapter stays available for existing external plugins. New plugins should expose `setupContract`; OpenClaw always prefers it when both are present.
 
+Use `afterAccountConfigWritten` (or a wizard's `afterConfigWritten`) for connection checks and other work that requires saved configuration. OpenClaw runs these callbacks after the write succeeds and passes a runtime `cfg` reread from the exact committed file, with environment references and plugin defaults resolved. The saved file can retain `${VAR}` references. Missing or invalid saved configuration prevents callback execution; callback failures are reported as post-setup warnings without undoing the saved configuration.
+
 | Field                                  | Type       | What it means                                                                 |
 | -------------------------------------- | ---------- | ----------------------------------------------------------------------------- |
 | `id`                                   | `string`   | Canonical channel id.                                                         |

--- a/src/agents/agent-create.integration.test.ts
+++ b/src/agents/agent-create.integration.test.ts
@@ -372,7 +372,11 @@ describe("agent roster persistence", () => {
     try {
       await state.writeConfig(config);
       const result = await createAgent({ name: "Worker", workspace: state.path("worker") });
-      expect(result).toMatchObject({ status: "created", agentId: "worker" });
+      expect(result).toMatchObject({
+        status: "created",
+        agentId: "worker",
+        configPath: state.configPath,
+      });
       return JSON.parse(await fs.readFile(state.configPath, "utf8")) as OpenClawConfig;
     } finally {
       closeOpenClawStateDatabaseForTest();

--- a/src/agents/agent-create.test.ts
+++ b/src/agents/agent-create.test.ts
@@ -132,7 +132,11 @@ describe("createAgent", () => {
         };
         mocks.persisted = transformed.nextConfig;
         mocks.config = transformed.nextConfig;
-        return { result: transformed.result, nextConfig: transformed.nextConfig };
+        return {
+          path: "/tmp/created-config.json",
+          result: transformed.result,
+          nextConfig: transformed.nextConfig,
+        };
       },
     );
   });

--- a/src/agents/agent-create.ts
+++ b/src/agents/agent-create.ts
@@ -64,7 +64,9 @@ type CreateError = {
   message: string;
 };
 
-type CreateAgentResult = (CreateAgentSuccess & { config: OpenClawConfig }) | CreateError;
+type CreateAgentResult =
+  | (CreateAgentSuccess & { config: OpenClawConfig; configPath: string })
+  | CreateError;
 type AgentEntryConfig = NonNullable<NonNullable<OpenClawConfig["agents"]>["entries"]>[string];
 type CreateAgentEntry = AgentEntryConfig & { id: string };
 type ConfigCommitRollback = () => void | Promise<void>;
@@ -502,6 +504,7 @@ export async function createAgent(params: CreateAgentParams): Promise<CreateAgen
       return {
         ...result,
         config: committed.nextConfig,
+        configPath: committed.path,
         ...(typeof committed.persistedHash === "string"
           ? { configHash: committed.persistedHash }
           : {}),

--- a/src/cli/plugins-cli-test-helpers.ts
+++ b/src/cli/plugins-cli-test-helpers.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import type { Mock } from "vitest";
 import { vi } from "vitest";
+import { createTestConfigSnapshot } from "../commands/test-runtime-config-helpers.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { ConfigWriteOptions } from "../config/io.types.js";
 import type { ConfigReplaceInput } from "../config/mutate.js";
@@ -1004,7 +1005,15 @@ export function resetPluginsCliTestState() {
     await configWriteMock(nextConfig);
     const configPath = params.writeOptions?.ownedConfigPathForWrite ?? "/tmp/openclaw-config.json5";
     mockPersistedConfigs.set(configPath, structuredClone(nextConfig));
-    return { path: configPath, nextConfig };
+    return {
+      path: configPath,
+      previousHash: null,
+      snapshot: createTestConfigSnapshot(nextConfig, nextConfig, configPath),
+      nextConfig,
+      persistedHash: "mock",
+      afterWrite: { mode: "auto" },
+      followUp: { mode: "auto", requiresRestart: false },
+    };
   }) as (...args: unknown[]) => Promise<unknown>);
   resolveStateDir.mockReturnValue("/tmp/openclaw-state");
   resolveMarketplaceInstallShortcutMock.mockResolvedValue(null);

--- a/src/commands/agents.add.test-fixtures.ts
+++ b/src/commands/agents.add.test-fixtures.ts
@@ -1,0 +1,47 @@
+import type { createAgent } from "../agents/agent-create.js";
+import { committedConfigFiles } from "./committed-config.test-support.js";
+
+export async function createAgentForAddCommandTest(params: {
+  name?: string;
+  workspace?: string;
+  entry?: { id: string; name?: string; workspace?: string; agentDir?: string };
+  bindingSpecs?: string[];
+  stagedConfig?: Parameters<typeof createAgent>[0]["stagedConfig"];
+  prepareConfigCommit?: () => Promise<(() => void | Promise<void>) | void>;
+}) {
+  const name = params.name ?? params.entry?.name ?? params.entry?.id ?? "";
+  const agentId = (params.entry?.id ?? name).toLowerCase();
+  if (agentId === "openclaw" || agentId === "crestodian") {
+    return { status: "error", reason: "reserved-id", agentId };
+  }
+  const binding = params.bindingSpecs?.[0]
+    ? {
+        type: "route",
+        agentId,
+        match: { channel: params.bindingSpecs[0].split(":")[0] },
+      }
+    : undefined;
+  await params.prepareConfigCommit?.();
+  const committed = committedConfigFiles.write(params.stagedConfig?.config ?? {});
+  return {
+    status: "created" as const,
+    agentId,
+    name,
+    workspace: params.workspace ?? params.entry?.workspace ?? `/tmp/workspace-${agentId}`,
+    agentDir: params.entry?.agentDir ?? `/tmp/agent-${agentId}`,
+    bootstrapPending: true,
+    config: committed.nextConfig,
+    configPath: committed.path,
+    ...(binding
+      ? {
+          bindingResult: {
+            config: {},
+            added: [],
+            updated: [],
+            skipped: [],
+            conflicts: [{ binding, existingAgentId: "other-agent" }],
+          },
+        }
+      : {}),
+  };
+}

--- a/src/commands/agents.add.test.ts
+++ b/src/commands/agents.add.test.ts
@@ -16,6 +16,8 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import { createSuiteTempRootTracker } from "../test-helpers/temp-dir.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { createQueuedWizardPrompter } from "../test-utils/plugin-setup-wizard.js";
+import { createAgentForAddCommandTest } from "./agents.add.test-fixtures.js";
+import { committedConfigFiles as configFiles } from "./committed-config.test-support.js";
 import { baseConfigSnapshot, createTestRuntime } from "./test-runtime-config-helpers.js";
 
 type SetupChannels = typeof import("./onboard-channels.js").setupChannels;
@@ -32,7 +34,7 @@ const checkAgentCreationGateMock = vi.hoisted(() => vi.fn());
 const commitConfigWithPendingPluginInstallsMock = vi.hoisted(() =>
   vi.fn(async (params: { sourceConfig: Record<string, unknown> }) => {
     await writeConfigFileMock(params.sourceConfig);
-    return { config: params.sourceConfig };
+    return configFiles.write(params.sourceConfig);
   }),
 );
 const transformConfigWithPendingPluginInstallsMock = vi.hoisted(() =>
@@ -203,6 +205,7 @@ describe("agents add command", () => {
   });
 
   beforeEach(() => {
+    configFiles.clear();
     readConfigFileSnapshotMock.mockClear();
     writeConfigFileMock.mockClear();
     replaceConfigFileMock.mockClear();
@@ -210,50 +213,7 @@ describe("agents add command", () => {
     transformConfigWithPendingPluginInstallsMock.mockClear();
     checkAgentCreationGateMock.mockReset().mockResolvedValue(undefined);
     createAgentMock.mockReset();
-    createAgentMock.mockImplementation(
-      async (params: {
-        name?: string;
-        workspace?: string;
-        entry?: { id: string; name?: string; workspace?: string; agentDir?: string };
-        bindingSpecs?: string[];
-        stagedConfig?: { config: Record<string, unknown> };
-        prepareConfigCommit?: () => Promise<(() => void | Promise<void>) | void>;
-      }) => {
-        const name = params.name ?? params.entry?.name ?? params.entry?.id ?? "";
-        const agentId = (params.entry?.id ?? name).toLowerCase();
-        if (agentId === "openclaw" || agentId === "crestodian") {
-          return { status: "error", reason: "reserved-id", agentId };
-        }
-        const binding = params.bindingSpecs?.[0]
-          ? {
-              type: "route",
-              agentId,
-              match: { channel: params.bindingSpecs[0].split(":")[0] },
-            }
-          : undefined;
-        await params.prepareConfigCommit?.();
-        return {
-          status: "created" as const,
-          agentId,
-          name,
-          workspace: params.workspace ?? params.entry?.workspace ?? `/tmp/workspace-${agentId}`,
-          agentDir: params.entry?.agentDir ?? `/tmp/agent-${agentId}`,
-          bootstrapPending: true,
-          config: params.stagedConfig?.config ?? {},
-          ...(binding
-            ? {
-                bindingResult: {
-                  config: {},
-                  added: [],
-                  updated: [],
-                  skipped: [],
-                  conflicts: [{ binding, existingAgentId: "other-agent" }],
-                },
-              }
-            : {}),
-        };
-      },
-    );
+    createAgentMock.mockImplementation(createAgentForAddCommandTest);
     wizardMocks.createClackPrompter.mockClear();
     pluginLifecycleMocks.withPluginLifecycleLease.mockClear();
     pluginLifecycleMocks.state.active = false;
@@ -945,6 +905,7 @@ describe("agents add command", () => {
       agentDir: "/tmp/agent-work",
       bootstrapPending: true,
       config: persistedConfig,
+      configPath: configFiles.write(persistedConfig).path,
     });
 
     await agentsAddCommand({}, runtime);

--- a/src/commands/agents.commands.add.ts
+++ b/src/commands/agents.commands.add.ts
@@ -30,7 +30,7 @@ import { formatCliCommand } from "../cli/command-format.js";
 import { ExpectedCliError } from "../cli/failure-output.js";
 import { isTerminalInteractive } from "../cli/terminal-interactivity.js";
 import { logConfigUpdated } from "../config/logging.js";
-import { createChannelSetupTransaction } from "../flows/channel-setup.js";
+import { createChannelSetupHooks } from "../flows/channel-setup.js";
 import {
   commitConfigWithPendingPluginInstalls,
   transformConfigWithPendingPluginInstalls,
@@ -423,7 +423,7 @@ export async function agentsAddCommand(
       validateCatalog: false,
     });
 
-    const channelSetup = createChannelSetupTransaction({ runtime: wizardRuntime });
+    const channelSetup = createChannelSetupHooks({ runtime: wizardRuntime });
     let selection: ChannelChoice[] = [];
     const channelAccountIds: Partial<Record<ChannelChoice, string>> = {};
     nextConfig = await setupChannels(nextConfig, wizardRuntime, prompter, {
@@ -504,14 +504,13 @@ export async function agentsAddCommand(
         ? await persistProviderAuthProfileBatch(stagedAuthBatch)
         : undefined;
       try {
-        nextConfig = await channelSetup.commit(nextConfig, async (configToCommit) => {
-          const committed = await commitConfigWithPendingPluginInstalls({
-            sourceConfig: configToCommit,
-            writeOptions: writeSnapshot.writeOptions,
-            baseHash: writeSnapshot.snapshot.hash,
-          });
-          return committed.config;
+        const committed = await commitConfigWithPendingPluginInstalls({
+          sourceConfig: nextConfig,
+          writeOptions: writeSnapshot.writeOptions,
+          baseHash: writeSnapshot.snapshot.hash,
         });
+        await channelSetup.runPostWriteHooks(committed.path);
+        nextConfig = committed.nextConfig;
       } catch (error) {
         authPersistence?.rollback();
         throw error;
@@ -550,7 +549,7 @@ export async function agentsAddCommand(
         workspace: created.workspace,
         agentDir: created.agentDir,
       };
-      await channelSetup.runPostWriteHooks(nextConfig);
+      await channelSetup.runPostWriteHooks(created.configPath);
     }
     await reportPortableAuthCopy?.();
     if (!opts.json) {

--- a/src/commands/channels.add.test.ts
+++ b/src/commands/channels.add.test.ts
@@ -22,6 +22,7 @@ import {
   createExternalChatCatalogEntry,
   createExternalChatSetupPlugin,
 } from "./channels.plugin-install.test-helpers.js";
+import { committedConfigFiles as configFiles } from "./committed-config.test-support.js";
 import {
   baseConfigSnapshot,
   createTestConfigSnapshot,
@@ -475,6 +476,7 @@ describe("channelsAddCommand", () => {
 
   beforeEach(async () => {
     resetPluginRuntimeStateForTest();
+    configFiles.clear();
     configMocks.readConfigFileSnapshot.mockClear();
     configMocks.readConfigFileSnapshotForWrite.mockClear();
     configMocks.writeConfigFile.mockClear();
@@ -485,10 +487,10 @@ describe("channelsAddCommand", () => {
       });
     pluginInstallRecordCommitMocks.commitConfigWithPendingPluginInstalls.mockReset();
     pluginInstallRecordCommitMocks.commitConfigWithPendingPluginInstalls.mockImplementation(
-      async (params: { sourceConfig: unknown }) => {
+      async (params: { sourceConfig: OpenClawConfig }) => {
         await configMocks.writeConfigFile(params.sourceConfig);
         return {
-          config: params.sourceConfig,
+          ...configFiles.write(params.sourceConfig),
           installRecords: {},
           movedInstallRecords: false,
         };
@@ -740,6 +742,39 @@ describe("channelsAddCommand", () => {
     expect(setupOptions()).not.toHaveProperty("finishAfterInitialSelection");
     expect(setupOptions().deferDeviceLinkToClient).toBe(true);
   });
+
+  it.each(["authority", "write"] as const)(
+    "does not run guided hooks after %s rejection",
+    async (failure) => {
+      const hook = vi.fn(async () => {});
+      const beforePersistentEffect = vi.fn(async () => {
+        if (failure === "authority") {
+          throw new Error("owner revoked");
+        }
+      });
+      channelWizardMocks.setupChannels.mockImplementationOnce(async (...args: unknown[]) => {
+        const options = args[3] as SetupChannelsOptions;
+        options.onPostWriteHook?.({ channel: "matrix", accountId: "ops", run: hook });
+        return { ...(args[0] as OpenClawConfig), messages: { responsePrefix: "configured" } };
+      });
+      if (failure === "write") {
+        pluginInstallRecordCommitMocks.commitConfigWithPendingPluginInstalls.mockRejectedValueOnce(
+          new Error("write failed"),
+        );
+      }
+
+      await expect(
+        channelsAddCommand({}, runtime, { hasFlags: false, beforePersistentEffect }),
+      ).rejects.toThrow(failure === "authority" ? "owner revoked" : "write failed");
+
+      expect(hook).not.toHaveBeenCalled();
+      expect(beforePersistentEffect).toHaveBeenCalledOnce();
+      expect(configMocks.writeConfigFile).not.toHaveBeenCalled();
+      expect(
+        pluginInstallRecordCommitMocks.commitConfigWithPendingPluginInstalls,
+      ).toHaveBeenCalledTimes(failure === "authority" ? 0 : 1);
+    },
+  );
 
   it.each(["external-chat", "ext"])(
     "preselects a hosted catalog channel from the %s selector",
@@ -1903,7 +1938,7 @@ describe("channelsAddCommand", () => {
         const writtenConfigLocal = { ...params.sourceConfig, plugins };
         await configMocks.writeConfigFile(writtenConfigLocal);
         return {
-          config: writtenConfigLocal,
+          ...configFiles.write(writtenConfigLocal),
           installRecords,
           movedInstallRecords: true,
         };

--- a/src/commands/channels/add-wizard.ts
+++ b/src/commands/channels/add-wizard.ts
@@ -90,7 +90,7 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
     import("../agents.config.js"),
     import("../onboard-channels.js"),
   ]);
-  const channelSetup = onboardChannels.createChannelSetupTransaction({
+  const channelSetup = onboardChannels.createChannelSetupHooks({
     runtime,
     ...(params.beforePersistentEffect
       ? { beforePersistentEffect: params.beforePersistentEffect }
@@ -126,21 +126,21 @@ export async function runChannelsAddWizardFlow(params: ChannelsAddWizardFlowPara
     },
   });
   const commitWizardConfig = async (config: OpenClawConfig) => {
-    return await channelSetup.commit(config, async (configToCommit) => {
-      const committed = await commitConfigWithPendingPluginInstalls({
-        sourceConfig: configToCommit,
-        writeOptions: writeSnapshot.writeOptions,
-        ...(baseHash !== undefined ? { baseHash } : {}),
-      });
-      if (committed.movedInstallRecords) {
-        await refreshPluginRegistryAfterConfigMutation({
-          reason: "source-changed",
-          installRecords: committed.installRecords,
-          logger: { warn: (message) => runtime.log(message) },
-        });
-      }
-      return committed.config;
+    await params.beforePersistentEffect?.();
+    const committed = await commitConfigWithPendingPluginInstalls({
+      sourceConfig: config,
+      writeOptions: writeSnapshot.writeOptions,
+      ...(baseHash !== undefined ? { baseHash } : {}),
     });
+    if (committed.movedInstallRecords) {
+      await refreshPluginRegistryAfterConfigMutation({
+        reason: "source-changed",
+        installRecords: committed.installRecords,
+        logger: { warn: (message) => runtime.log(message) },
+      });
+    }
+    await channelSetup.runPostWriteHooks(committed.path);
+    return committed.nextConfig;
   };
   if (selection.length === 0) {
     if (nextConfig !== cfg) {

--- a/src/commands/channels/add.ts
+++ b/src/commands/channels/add.ts
@@ -306,7 +306,6 @@ async function channelsAddCommandImpl(
     writeOptions: writeSnapshot.writeOptions,
     baseHash: writeSnapshot.snapshot.hash,
   });
-  const writtenConfig = committed.config;
   if (committed.movedInstallRecords || pluginRegistrySourceChanged) {
     await refreshPluginRegistryAfterConfigMutation({
       reason: "source-changed",
@@ -335,7 +334,7 @@ async function channelsAddCommandImpl(
             }),
         },
       ],
-      cfg: writtenConfig,
+      configPath: committed.path,
       runtime,
       ...(params?.beforePersistentEffect
         ? { beforePersistentEffect: params.beforePersistentEffect }

--- a/src/commands/committed-config.test-support.ts
+++ b/src/commands/committed-config.test-support.ts
@@ -1,0 +1,22 @@
+import { vi } from "vitest";
+import { createTestConfigFileStore } from "./test-runtime-config-helpers.js";
+
+export const committedConfigFiles = createTestConfigFileStore();
+
+vi.mock("../config/io.factory.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../config/io.factory.js")>();
+  return {
+    ...actual,
+    createConfigIO: (options: Parameters<typeof actual.createConfigIO>[0]) => {
+      const io = actual.createConfigIO(options);
+      const configPath = options?.configPath;
+      return configPath
+        ? {
+            ...io,
+            readConfigFileSnapshotWithPluginMetadata: async () =>
+              committedConfigFiles.read(configPath),
+          }
+        : io;
+    },
+  };
+});

--- a/src/commands/configure.wizard.default-agent.test.ts
+++ b/src/commands/configure.wizard.default-agent.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { retainLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { committedConfigFiles as configFiles } from "./committed-config.test-support.js";
 
 type SetupChannels = typeof import("./onboard-channels.js").setupChannels;
 
@@ -45,7 +46,7 @@ vi.mock("../plugins/install-record-commit.js", () => ({
     };
     const nextConfig = params.transform(snapshot.sourceConfig ?? snapshot.config).nextConfig;
     const committed = await mocks.commitConfig({ nextConfig, writeOptions: params.writeOptions });
-    return { nextConfig: committed.config };
+    return committed;
   },
 }));
 
@@ -102,6 +103,7 @@ const runtime = {
 describe("runConfigureWizard default-agent ownership", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    configFiles.clear();
     mocks.select.mockReset();
     mocks.text.mockReset();
     const baseConfig = {
@@ -130,8 +132,8 @@ describe("runConfigureWizard default-agent ownership", () => {
       async ({ config }: { config: OpenClawConfig }) => config,
     );
     mocks.setupSkills.mockImplementation(async (config: OpenClawConfig) => config);
-    mocks.commitConfig.mockImplementation(
-      async ({ nextConfig }: { nextConfig: OpenClawConfig }) => ({ config: nextConfig }),
+    mocks.commitConfig.mockImplementation(async ({ nextConfig }: { nextConfig: OpenClawConfig }) =>
+      configFiles.write(nextConfig),
     );
   });
 

--- a/src/commands/configure.wizard.persistence.test.ts
+++ b/src/commands/configure.wizard.persistence.test.ts
@@ -123,7 +123,7 @@ describe("configure wizard persistence before local side effects", () => {
     mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => {
       events.push("commit");
       writes.push(config);
-      return config;
+      return { path: "/tmp/openclaw.json", nextConfig: config };
     });
     if (section === "health") {
       mocks.waitForGatewayReachable.mockImplementationOnce(async () => {

--- a/src/commands/configure.wizard.test-support.ts
+++ b/src/commands/configure.wizard.test-support.ts
@@ -1,6 +1,7 @@
 import { vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { committedConfigFiles } from "./committed-config.test-support.js";
 
 const wizardTestMocks = vi.hoisted(() => {
   const writeConfigFile = vi.fn();
@@ -24,6 +25,7 @@ const wizardTestMocks = vi.hoisted(() => {
       }) => {
         params.writeOptions?.assertConfigPathForWrite?.();
         await writeConfigFile(params.nextConfig);
+        return committedConfigFiles.write(params.nextConfig as OpenClawConfig);
       },
     ),
     resolveGatewayPort: vi.fn(),
@@ -107,7 +109,11 @@ vi.mock("../config/config.js", () => ({
           writeOptions: params.writeOptions,
           afterWrite: { mode: "auto" },
         });
-        return { nextConfig: committed.config };
+        return {
+          ...committedConfigFiles.write(committed.config),
+          result: transformed.result,
+          attempts: attempt + 1,
+        };
       } catch (error) {
         if (
           !(error instanceof Error) ||
@@ -211,6 +217,7 @@ const { runConfigureWizard } = await import("./configure.wizard.js");
 export { runConfigureWizard, wizardTestMocks };
 
 export function setupWizardTestDefaults() {
+  committedConfigFiles.clear();
   wizardTestMocks.assertConfigPathForWrite.mockImplementation(() => {});
   wizardTestMocks.resolvePluginContributionOwners.mockReturnValue(["firecrawl"]);
   wizardTestMocks.resolveSearchProviderOptions.mockReturnValue([

--- a/src/commands/configure.wizard.test.ts
+++ b/src/commands/configure.wizard.test.ts
@@ -3,6 +3,7 @@ import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { ConfigMutationConflictError } from "../config/mutate.js";
+import { committedConfigFiles } from "./committed-config.test-support.js";
 import {
   createEnabledWebSearchConfig,
   createWizardTestRuntime as createRuntime,
@@ -410,6 +411,7 @@ describe("runConfigureWizard", () => {
         // Second call: succeeds with refreshed hash
         expect(params.baseHash).toBe(newHashAfterMutation);
         await mocks.writeConfigFile(params.nextConfig);
+        return committedConfigFiles.write(params.nextConfig as OpenClawConfig);
       },
     );
 
@@ -499,6 +501,7 @@ describe("runConfigureWizard", () => {
       }) => {
         params.writeOptions?.assertConfigPathForWrite?.();
         await mocks.writeConfigFile(params.nextConfig);
+        return committedConfigFiles.write(params.nextConfig as OpenClawConfig);
       },
     );
 

--- a/src/commands/configure.wizard.ts
+++ b/src/commands/configure.wizard.ts
@@ -16,7 +16,7 @@ import { readConfigFileSnapshotForWrite, resolveGatewayPort } from "../config/co
 import { inheritLegacyDefaultAgentId } from "../config/legacy.default-agent-owner.js";
 import { logConfigUpdated } from "../config/logging.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
-import { createChannelSetupTransaction } from "../flows/channel-setup.js";
+import { createChannelSetupHooks } from "../flows/channel-setup.js";
 import { resolveGatewayProbeAuthSafeWithSecretInputs } from "../gateway/probe-auth.js";
 import { formatWindowsGatewayFirewallGuidance } from "../infra/windows-gateway-firewall-diagnostics.js";
 import { resolvePluginContributionOwners } from "../plugins/plugin-registry.js";
@@ -566,11 +566,12 @@ export async function runConfigureWizard(
         command: opts.command,
         mode: metadataMode,
       });
-      remoteConfig = await writeWizardConfigFile(remoteConfig, {
+      const committed = await writeWizardConfigFile(remoteConfig, {
         mergeBase: baseConfig,
         ...(currentBaseHash !== undefined ? { baseHash: currentBaseHash } : {}),
         writeOptions: configWriteOwnership,
       });
+      remoteConfig = committed.nextConfig;
       logConfigUpdated(runtime);
       if (selectedSections?.includes("health")) {
         const healthCheckOutcome = await runGatewayHealthCheck({
@@ -630,7 +631,7 @@ export async function runConfigureWizard(
     let didPersistConfig = false;
     let daemonSetupOutcome: DaemonSetupOutcome | undefined;
     let healthCheckOutcome: GatewayHealthCheckOutcome | undefined;
-    const channelSetup = createChannelSetupTransaction({ runtime });
+    const channelSetup = createChannelSetupHooks({ runtime });
 
     const persistPendingConfig = async () => {
       if (!hasPendingConfig) {
@@ -641,14 +642,13 @@ export async function runConfigureWizard(
         mode: metadataMode,
       });
 
-      nextConfig = await channelSetup.commit(nextConfig, async (configToCommit) => {
-        const committedConfig = await writeWizardConfigFile(configToCommit, {
-          mergeBase: mergeBaseConfig,
-          writeOptions: configWriteOwnership,
-        });
-        mergeBaseConfig = structuredClone(committedConfig);
-        return committedConfig;
+      const committed = await writeWizardConfigFile(nextConfig, {
+        mergeBase: mergeBaseConfig,
+        writeOptions: configWriteOwnership,
       });
+      mergeBaseConfig = structuredClone(committed.nextConfig);
+      await channelSetup.runPostWriteHooks(committed.path);
+      nextConfig = committed.nextConfig;
       hasPendingConfig = false;
       didPersistConfig = true;
       logConfigUpdated(runtime);

--- a/src/commands/onboard-channels.post-write.test.ts
+++ b/src/commands/onboard-channels.post-write.test.ts
@@ -1,82 +1,125 @@
-// Onboard channel post-write tests cover plugin post-write hooks after channel setup.
+import fs from "node:fs/promises";
 import { describe, expect, it, vi } from "vitest";
 import { createExitThrowingRuntime } from "../../test/helpers/auth-wizard.js";
-import type { OpenClawConfig } from "../config/config.js";
+import { readConfigFileSnapshot } from "../config/config.js";
+import { commitConfigWithPendingPluginInstalls } from "../plugins/install-record-commit.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { writeWizardConfigFile } from "../wizard/setup.shared.js";
 import {
   createChannelOnboardingPostWriteHook,
-  createChannelSetupTransaction,
+  createChannelSetupHooks,
 } from "./onboard-channels.js";
 
 describe("setupChannels post-write hooks", () => {
-  it("collects onboarding post-write hooks and runs them against the final config", async () => {
-    const afterConfigWritten = vi.fn(async () => {});
-    const previousCfg = {} as OpenClawConfig;
-    const cfg = {
-      channels: {
-        telegram: { botToken: "new-token" },
+  it.each(["plugin", "wizard"] as const)(
+    "resolves the exact %s commit after config selection changes",
+    async (writer) => {
+      await withOpenClawTestState(
+        {
+          label: "post-write-config",
+          layout: "split",
+          env: { SETUP_REPLY_PREFIX: "resolved prefix" },
+        },
+        async (state) => {
+          await state.writeConfig({ messages: { responsePrefix: "${SETUP_REPLY_PREFIX}" } });
+          const before = await readConfigFileSnapshot();
+          const next = { ...before.sourceConfig, gateway: { port: 19001 } };
+          const runtime = createExitThrowingRuntime();
+          const afterConfigWritten = vi.fn(async () => {});
+          const hooks = createChannelSetupHooks({ runtime });
+          hooks.onPostWriteHook(
+            createChannelOnboardingPostWriteHook({
+              channel: "matrix",
+              accountId: "ops",
+              previousCfg: before.sourceConfig,
+              adapter: { afterConfigWritten },
+            })!,
+          );
+          const committed =
+            writer === "plugin"
+              ? await commitConfigWithPendingPluginInstalls({
+                  sourceConfig: next,
+                  baseHash: before.hash,
+                })
+              : await writeWizardConfigFile(next, { baseHash: before.hash });
+          expect(afterConfigWritten).not.toHaveBeenCalled();
+          expect(committed.nextConfig.messages?.responsePrefix).toBe("${SETUP_REPLY_PREFIX}");
+          const decoy = state.path("decoy.json");
+          await fs.writeFile(decoy, JSON.stringify({ messages: { responsePrefix: "wrong file" } }));
+          process.env.OPENCLAW_CONFIG_PATH = decoy;
+
+          await hooks.runPostWriteHooks(committed.path);
+
+          expect(afterConfigWritten).toHaveBeenCalledWith(
+            expect.objectContaining({
+              cfg: expect.objectContaining({
+                messages: expect.objectContaining({ responsePrefix: "resolved prefix" }),
+                gateway: expect.objectContaining({ port: 19001 }),
+              }),
+              previousCfg: before.sourceConfig,
+              accountId: "ops",
+            }),
+          );
+          expect(runtime.error).not.toHaveBeenCalled();
+        },
+      );
+    },
+  );
+
+  it("deduplicates accounts, continues after a hook warning, and clears completed hooks", async () => {
+    await withOpenClawTestState(
+      { label: "post-write-hook-lifecycle", scenario: "minimal" },
+      async (state) => {
+        const runtime = createExitThrowingRuntime();
+        const hooks = createChannelSetupHooks({ runtime });
+        const replaced = vi.fn();
+        const failing = vi.fn(async () => {
+          throw new Error("hook failed");
+        });
+        const succeeding = vi.fn();
+        hooks.onPostWriteHook({ channel: "matrix", accountId: "ops", run: replaced });
+        hooks.onPostWriteHook({ channel: "matrix", accountId: "ops", run: failing });
+        hooks.onPostWriteHook({ channel: "telegram", accountId: "ops", run: succeeding });
+
+        await hooks.runPostWriteHooks(state.configPath);
+        await hooks.runPostWriteHooks(state.path("missing-after-completion.json"));
+
+        expect(replaced).not.toHaveBeenCalled();
+        expect(failing).toHaveBeenCalledOnce();
+        expect(succeeding).toHaveBeenCalledOnce();
+        expect(runtime.error).toHaveBeenCalledExactlyOnceWith(
+          'Channel matrix post-setup warning for "ops": hook failed',
+        );
       },
-    } as OpenClawConfig;
-    const adapter = {
-      afterConfigWritten,
-    };
-    const runtime = createExitThrowingRuntime();
-    const transaction = createChannelSetupTransaction({ runtime });
-    const hook = createChannelOnboardingPostWriteHook({
-      accountId: "acct-1",
-      adapter,
-      channel: "telegram",
-      previousCfg,
-    });
-
-    if (!hook) {
-      throw new Error("expected post-write hook");
-    }
-    transaction.onPostWriteHook(hook);
-
-    expect(afterConfigWritten).not.toHaveBeenCalled();
-
-    const committed = await transaction.commit(cfg, async () => cfg);
-
-    expect(committed).toBe(cfg);
-    expect(afterConfigWritten).toHaveBeenCalledWith({
-      previousCfg,
-      cfg,
-      accountId: "acct-1",
-      runtime,
-    });
-  });
-
-  it("logs onboarding post-write hook failures without aborting", async () => {
-    const runtime = createExitThrowingRuntime();
-    const transaction = createChannelSetupTransaction({ runtime });
-    transaction.onPostWriteHook({
-      channel: "telegram",
-      accountId: "acct-1",
-      run: async () => {
-        throw new Error("hook failed");
-      },
-    });
-
-    await transaction.commit({} as OpenClawConfig, async (config) => config);
-
-    expect(runtime.error).toHaveBeenCalledWith(
-      'Channel telegram post-setup warning for "acct-1": hook failed',
     );
-    expect(runtime.exit).not.toHaveBeenCalled();
   });
 
-  it("does not run hooks when config persistence fails", async () => {
-    const runtime = createExitThrowingRuntime();
-    const hook = vi.fn();
-    const transaction = createChannelSetupTransaction({ runtime });
-    transaction.onPostWriteHook({ channel: "matrix", accountId: "ops", run: hook });
+  it("rechecks authority after the awaited read and retains rejected hooks", async () => {
+    await withOpenClawTestState(
+      { label: "post-write-authority", scenario: "minimal" },
+      async (state) => {
+        let active = true;
+        const hook = vi.fn();
+        const runtime = createExitThrowingRuntime();
+        const hooks = createChannelSetupHooks({
+          runtime,
+          beforePersistentEffect: async () => {
+            if (!active) {
+              throw new Error("owner revoked");
+            }
+          },
+        });
+        hooks.onPostWriteHook({ channel: "matrix", accountId: "ops", run: hook });
+        const pending = hooks.runPostWriteHooks(state.configPath);
+        active = false;
 
-    await expect(
-      transaction.commit({} as OpenClawConfig, async () => {
-        throw new Error("write failed");
-      }),
-    ).rejects.toThrow("write failed");
-
-    expect(hook).not.toHaveBeenCalled();
+        await expect(pending).rejects.toThrow("owner revoked");
+        expect(hook).not.toHaveBeenCalled();
+        expect(runtime.error).not.toHaveBeenCalled();
+        active = true;
+        await hooks.runPostWriteHooks(state.configPath);
+        expect(hook).toHaveBeenCalledOnce();
+      },
+    );
   });
 });

--- a/src/commands/onboard-channels.ts
+++ b/src/commands/onboard-channels.ts
@@ -1,7 +1,7 @@
 /** Re-export seam for channel onboarding flow helpers. */
 export {
   createChannelOnboardingPostWriteHook,
-  createChannelSetupTransaction,
+  createChannelSetupHooks,
   runCollectedChannelOnboardingPostWriteHooks,
   setupChannels,
 } from "../flows/channel-setup.js";

--- a/src/commands/onboard-guided.ts
+++ b/src/commands/onboard-guided.ts
@@ -592,10 +592,12 @@ async function runGuidedOnboardingFlow(
     const recommendedConfig = recommendationOutcome.config;
     if (recommendedConfig !== persistedConfig) {
       const { writeWizardConfigFile } = await import("../wizard/setup.shared.js");
-      persistedConfig = await writeWizardConfigFile(recommendedConfig, {
-        allowConfigSizeDrop: false,
-        mergeBase: persistedConfig,
-      });
+      persistedConfig = (
+        await writeWizardConfigFile(recommendedConfig, {
+          allowConfigSizeDrop: false,
+          mergeBase: persistedConfig,
+        })
+      ).nextConfig;
     }
     recommendationOutcome.commitResult();
   }

--- a/src/commands/onboard-non-interactive.gateway.test-mocks.ts
+++ b/src/commands/onboard-non-interactive.gateway.test-mocks.ts
@@ -1,7 +1,7 @@
 // Shared mocks and harness for the non-interactive gateway onboarding suites.
 // vi.mock calls live here so sibling suites share one config-write/daemon/health surface.
 import path from "node:path";
-import { vi } from "vitest";
+import { afterEach, vi } from "vitest";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import {
   createOnboardTestConfigStore,
@@ -10,9 +10,12 @@ import {
 } from "./onboard-non-interactive.test-helpers.js";
 import type { WaitForGatewayReachableMock } from "./onboard-non-interactive.test-helpers.js";
 import type { installGatewayDaemonNonInteractive } from "./onboard-non-interactive/local/daemon-install.js";
+import { createTestConfigFileStore } from "./test-runtime-config-helpers.js";
 
 export const ensureWorkspaceAndSessionsMock = vi.fn(async (..._args: unknown[]) => {});
 const onboardTestConfigStore = createOnboardTestConfigStore();
+const committedConfigFiles = createTestConfigFileStore();
+afterEach(() => committedConfigFiles.clear());
 export const {
   configStore: testConfigStore,
   resolveConfigPath: resolveTestConfigPath,
@@ -101,6 +104,7 @@ vi.mock("../config/config.js", async (importActual) => {
         ...(writeOptions ? { writeOptions } : {}),
       });
       testConfigStore.set(resolveTestConfigPath(), nextConfig);
+      return committedConfigFiles.write(nextConfig, resolveTestConfigPath());
     },
     resolveConfigWriteAfterWrite: actual.resolveConfigWriteAfterWrite,
     resolveGatewayPort: (cfg: OpenClawConfig) => cfg.gateway?.port ?? 18789,
@@ -121,7 +125,7 @@ vi.mock("../config/config.js", async (importActual) => {
         writeOptions: params.writeOptions,
         afterWrite: { mode: "auto" },
       });
-      return { nextConfig: committed.config };
+      return committedConfigFiles.write(committed.config, snapshot.path);
     },
   };
 });

--- a/src/commands/onboard-non-interactive/config-write.test.ts
+++ b/src/commands/onboard-non-interactive/config-write.test.ts
@@ -10,7 +10,10 @@ import { commitNonInteractiveOnboardConfig } from "./config-write.js";
 describe("commitNonInteractiveOnboardConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => config);
+    writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => ({
+      path: "/tmp/openclaw.json",
+      nextConfig: config,
+    }));
   });
 
   it("keeps the verified config hash on the canonical writer", async () => {

--- a/src/commands/onboard-non-interactive/config-write.ts
+++ b/src/commands/onboard-non-interactive/config-write.ts
@@ -10,9 +10,11 @@ export async function commitNonInteractiveOnboardConfig(params: {
   const { writeWizardConfigFile } = await import("../../wizard/setup.shared.js");
   // Ordinary onboard reruns must preserve existing agents.list / bindings.
   // Only explicit --reset may allow a config size drop; see openclaw#84692.
-  return await writeWizardConfigFile(params.nextConfig, {
-    mergeBase: params.baseConfig,
-    allowConfigSizeDrop: params.reset === true,
-    ...(params.baseHash !== undefined ? { baseHash: params.baseHash } : {}),
-  });
+  return (
+    await writeWizardConfigFile(params.nextConfig, {
+      mergeBase: params.baseConfig,
+      allowConfigSizeDrop: params.reset === true,
+      ...(params.baseHash !== undefined ? { baseHash: params.baseHash } : {}),
+    })
+  ).nextConfig;
 }

--- a/src/commands/onboard-non-interactive/local/auth-choice.test.ts
+++ b/src/commands/onboard-non-interactive/local/auth-choice.test.ts
@@ -6,7 +6,9 @@ import * as apiProviderAuthChoices from "../../auth-choice.apply.api-providers.j
 import { commitNonInteractiveOnboardConfig } from "../config-write.js";
 import { applyNonInteractiveAuthChoice } from "./auth-choice.js";
 
-const writeWizardConfigFile = vi.hoisted(() => vi.fn(async (config: OpenClawConfig) => config));
+const writeWizardConfigFile = vi.hoisted(() =>
+  vi.fn(async (config: OpenClawConfig) => ({ path: "/tmp/openclaw.json", nextConfig: config })),
+);
 vi.mock("../../../wizard/setup.shared.js", () => ({ writeWizardConfigFile }));
 
 const formatAuthChoiceChoicesForCli = vi.hoisted(() =>

--- a/src/commands/test-runtime-config-helpers.ts
+++ b/src/commands/test-runtime-config-helpers.ts
@@ -2,6 +2,7 @@
 // Kept under commands because many command tests need the same mock runtime shapes.
 
 import { vi } from "vitest";
+import type { ConfigMutationResult } from "../config/mutate.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import type { RuntimeEnv } from "../runtime.js";
 import type { MockFn } from "../test-utils/vitest-mock-fn.js";
@@ -21,13 +22,14 @@ export const baseConfigSnapshot = {
 export function createTestConfigSnapshot(
   sourceConfig: OpenClawConfig,
   runtimeConfig: OpenClawConfig = sourceConfig,
+  configPath = "/tmp/openclaw.json",
 ): ConfigFileSnapshot {
   // SAFETY: Snapshot source branding preserves the exact caller-owned authored config object.
   const resolvedSourceConfig = sourceConfig as ConfigFileSnapshot["sourceConfig"];
   // SAFETY: Snapshot runtime branding preserves the distinct caller-owned runtime config object.
   const resolvedRuntimeConfig = runtimeConfig as ConfigFileSnapshot["runtimeConfig"];
   return {
-    path: "/tmp/openclaw.json",
+    path: configPath,
     exists: true,
     raw: "{}",
     parsed: {},
@@ -39,6 +41,39 @@ export function createTestConfigSnapshot(
     issues: [],
     warnings: [],
     legacyIssues: [],
+  };
+}
+
+/** Virtual file ownership for command tests that keep the real post-write hook dispatcher. */
+export function createTestConfigFileStore() {
+  const snapshots = new Map<string, ConfigFileSnapshot>();
+  return {
+    write(next: OpenClawConfig, configPath = "/tmp/openclaw.json"): ConfigMutationResult<void> {
+      const nextConfig = structuredClone(next);
+      const snapshot = createTestConfigSnapshot(nextConfig, nextConfig, configPath);
+      snapshots.set(configPath, snapshot);
+      return {
+        path: configPath,
+        result: undefined,
+        attempts: 1,
+        previousHash: null,
+        persistedHash: "test-config-hash",
+        snapshot,
+        nextConfig,
+        afterWrite: { mode: "auto" },
+        followUp: { mode: "auto", requiresRestart: false },
+      };
+    },
+    read(configPath: string) {
+      const snapshot = snapshots.get(configPath);
+      if (!snapshot) {
+        throw new Error(`No test config was committed to ${configPath}`);
+      }
+      return { snapshot: structuredClone(snapshot) };
+    },
+    clear() {
+      snapshots.clear();
+    },
   };
 }
 

--- a/src/flows/channel-setup.ts
+++ b/src/flows/channel-setup.ts
@@ -26,6 +26,9 @@ import {
 } from "../commands/channel-setup/trusted-catalog.js";
 import type { ChannelChoice } from "../commands/onboard-types.js";
 import { isChannelConfigured } from "../config/channel-configured.js";
+import { createConfigIO } from "../config/io.factory.js";
+import { createManagedRuntimeEnvBase } from "../config/io.read-helpers.js";
+import { formatConfigIssueSummary } from "../config/issue-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage } from "../infra/errors.js";
 import { resolveBundledPluginSources } from "../plugins/bundled-sources.js";
@@ -57,49 +60,57 @@ import {
   resolveQuickstartDefault,
 } from "./channel-setup.status.js";
 
-export function createChannelSetupTransaction(params: {
+export function createChannelSetupHooks(params: {
   runtime: RuntimeEnv;
   beforePersistentEffect?: () => Promise<void>;
 }) {
   const hooks = new Map<string, ChannelOnboardingPostWriteHook>();
-  const runPostWriteHooks = async (cfg: OpenClawConfig) => {
-    await runCollectedChannelOnboardingPostWriteHooks({
-      hooks: [...hooks.values()],
-      cfg,
-      runtime: params.runtime,
-      ...(params.beforePersistentEffect
-        ? { beforePersistentEffect: params.beforePersistentEffect }
-        : {}),
-    });
-    hooks.clear();
-  };
   return {
     onPostWriteHook: (hook: ChannelOnboardingPostWriteHook) => {
       hooks.set(`${hook.channel}:${hook.accountId}`, hook);
     },
-    async commit(
-      nextConfig: OpenClawConfig,
-      write: (config: OpenClawConfig) => Promise<OpenClawConfig>,
-    ): Promise<OpenClawConfig> {
-      await params.beforePersistentEffect?.();
-      const committedConfig = await write(nextConfig);
-      await runPostWriteHooks(committedConfig);
-      return committedConfig;
+    async runPostWriteHooks(configPath: string) {
+      await runCollectedChannelOnboardingPostWriteHooks({
+        hooks: [...hooks.values()],
+        configPath,
+        runtime: params.runtime,
+        ...(params.beforePersistentEffect
+          ? { beforePersistentEffect: params.beforePersistentEffect }
+          : {}),
+      });
+      hooks.clear();
     },
-    runPostWriteHooks,
   };
 }
 
 export async function runCollectedChannelOnboardingPostWriteHooks(params: {
   hooks: ChannelOnboardingPostWriteHook[];
-  cfg: OpenClawConfig;
+  configPath: string;
   runtime: RuntimeEnv;
   beforePersistentEffect?: () => Promise<void>;
 }): Promise<void> {
+  if (params.hooks.length === 0) {
+    return;
+  }
+  // Writer receipts bind the file even if config selection changes after commit.
+  // Hooks execute against fresh runtime values; persisted config may contain env refs.
+  const { snapshot } = await createConfigIO({
+    configPath: params.configPath,
+    env: createManagedRuntimeEnvBase(),
+    observe: false,
+  }).readConfigFileSnapshotWithPluginMetadata({ allowCurrentPluginMetadata: false });
   for (const hook of params.hooks) {
     await params.beforePersistentEffect?.();
     try {
-      await hook.run({ cfg: params.cfg, runtime: params.runtime });
+      if (!snapshot.exists || !snapshot.valid) {
+        const reason = snapshot.exists
+          ? formatConfigIssueSummary(snapshot.issues)
+          : "file not found";
+        throw new Error(
+          `Saved config is unavailable: ${reason}. Run openclaw doctor --fix, then retry setup.`,
+        );
+      }
+      await hook.run({ cfg: snapshot.runtimeConfig, runtime: params.runtime });
     } catch (err) {
       const message = formatErrorMessage(err);
       params.runtime.error(

--- a/src/plugins/install-record-commit.persisted-result.test.ts
+++ b/src/plugins/install-record-commit.persisted-result.test.ts
@@ -24,10 +24,11 @@ describe("committed plugin configuration", () => {
         const result = await commitConfigWithPendingPluginInstalls({ nextConfig });
         const persisted = JSON.parse(await fs.readFile(state.configPath, "utf8"));
 
-        expect(result.config).toEqual(persisted);
-        expect(result.config.meta?.lastTouchedVersion).toEqual(expect.any(String));
+        expect(result.path).toBe(state.configPath);
+        expect(result.nextConfig).toEqual(persisted);
+        expect(result.nextConfig.meta?.lastTouchedVersion).toEqual(expect.any(String));
         expect(result.movedInstallRecords).toBe(pending);
-        expect(result.config.plugins?.installs).toBeUndefined();
+        expect(result.nextConfig.plugins?.installs).toBeUndefined();
       });
     },
   );

--- a/src/plugins/install-record-commit.sqlite.test.ts
+++ b/src/plugins/install-record-commit.sqlite.test.ts
@@ -5,6 +5,7 @@ import { setTimeout as delay } from "node:timers/promises";
 import { pathToFileURL } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it } from "vitest";
+import { replaceConfigFile, type OpenClawConfig } from "../config/config.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
@@ -144,8 +145,9 @@ describe("plugin install record commit rollback", () => {
                   },
                 },
               },
-              commit: async () => {
+              commit: async (nextConfig) => {
                 commits += 1;
+                return await replaceConfigFile({ sourceConfig: nextConfig });
               },
             });
             expect(commits).toBe(1);
@@ -162,8 +164,9 @@ describe("plugin install record commit rollback", () => {
             );
           });
           let commits = 0;
-          const commit = async () => {
+          const commit = async (nextConfig: OpenClawConfig) => {
             commits += 1;
+            return await replaceConfigFile({ sourceConfig: nextConfig });
           };
           await expect(
             commitConfigWriteWithPendingPluginInstalls({

--- a/src/plugins/install-record-commit.test.ts
+++ b/src/plugins/install-record-commit.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { createTestConfigFileStore } from "../commands/test-runtime-config-helpers.js";
 import type { ConfigWriteOptions } from "../config/io.js";
 import {
   createPluginInstallRecordMap,
@@ -26,6 +27,8 @@ import {
   resolveRetainedManagedNpmInstallMarkerPath,
 } from "./managed-npm-retention.js";
 import { writeManagedNpmPlugin } from "./test-helpers/managed-npm-plugin.js";
+
+const configFiles = createTestConfigFileStore();
 
 const retentionTempDirs = useAutoCleanupTempDirTracker(afterEach);
 
@@ -118,15 +121,10 @@ describe("commitConfigWithPendingPluginInstalls", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue({});
-    mocks.replaceConfigFile.mockImplementation(async (params: { nextConfig: OpenClawConfig }) => ({
-      path: "/tmp/openclaw.json",
-      previousHash: null,
-      snapshot: {} as never,
-      nextConfig: params.nextConfig,
-      persistedHash: "test-config-hash",
-      afterWrite: { mode: "auto" },
-      followUp: { mode: "auto", requiresRestart: false },
-    }));
+    configFiles.clear();
+    mocks.replaceConfigFile.mockImplementation(async (params: { nextConfig: OpenClawConfig }) =>
+      configFiles.write(params.nextConfig),
+    );
     mocks.restorePersistedInstalledPluginIndexIfCurrent.mockResolvedValue(true);
     mocks.writePersistedInstalledPluginIndexInstallRecordsWithLease.mockResolvedValue({
       previous: null,
@@ -198,8 +196,9 @@ describe("commitConfigWithPendingPluginInstalls", () => {
         unsetPaths: [["plugins", "installs"]],
       },
     });
-    expect(result).toEqual({
-      config: {
+    expect(result).toMatchObject({
+      path: "/tmp/openclaw.json",
+      nextConfig: {
         plugins: {
           entries: {
             demo: { enabled: true },
@@ -272,7 +271,7 @@ describe("commitConfigWithPendingPluginInstalls", () => {
         },
       },
     };
-    const commit = vi.fn(async () => undefined);
+    const commit = vi.fn(async (candidate: OpenClawConfig) => configFiles.write(candidate));
     mocks.loadInstalledPluginIndexInstallRecords.mockResolvedValue(existingRecords);
 
     const result = await commitConfigWriteWithPendingPluginInstalls({
@@ -1025,33 +1024,12 @@ describe("commitConfigWithPendingPluginInstalls", () => {
     expect(mocks.replaceConfigFile).toHaveBeenCalledWith({
       nextConfig,
     });
-    expect(result).toEqual({
-      config: nextConfig,
+    expect(result).toMatchObject({
+      path: "/tmp/openclaw.json",
+      nextConfig,
       installRecords: {},
       movedInstallRecords: false,
       persistedHash: "test-config-hash",
-    });
-  });
-
-  it("supports non-replace config writers without adding an undefined write options argument", async () => {
-    const writeConfigFile = vi.fn(async () => undefined);
-    const nextConfig: OpenClawConfig = {
-      gateway: {
-        mode: "local",
-      },
-    };
-
-    const result = await commitConfigWriteWithPendingPluginInstalls({
-      nextConfig,
-      commit: writeConfigFile,
-    });
-
-    expect(writeConfigFile).toHaveBeenCalledWith(nextConfig);
-    expect(result).toEqual({
-      config: nextConfig,
-      installRecords: {},
-      movedInstallRecords: false,
-      persistedHash: null,
     });
   });
 });

--- a/src/plugins/install-record-commit.ts
+++ b/src/plugins/install-record-commit.ts
@@ -120,10 +120,10 @@ export function stripPendingPluginInstallRecords(
   };
 }
 
-type ConfigCommit = (
+type ConfigCommit<T = ConfigReplaceResult | void> = (
   config: OpenClawConfig,
   writeOptions?: ConfigWriteOptions,
-) => Promise<ConfigReplaceResult | void>;
+) => Promise<T>;
 const PLUGIN_SOURCE_CHANGED_RESTART_REASON = "plugin source changed";
 
 function mergeAfterWrite(
@@ -436,7 +436,7 @@ async function assertPluginConfigActivationConsent(params: {
   }
 }
 
-async function commitPluginInstallRecordsWithWriter(params: {
+async function commitPluginInstallRecordsWithWriter<T extends ConfigReplaceResult | void>(params: {
   prepareInstallRecords: (storeOptions: InstalledPluginIndexRecordStoreOptions) => Promise<{
     previousInstallRecords: Record<string, PluginInstallRecord>;
     nextInstallRecords: Record<string, PluginInstallRecord>;
@@ -445,9 +445,9 @@ async function commitPluginInstallRecordsWithWriter(params: {
   recheckStagedActivation?: boolean;
   beforePersistentEffect?: () => void | Promise<void>;
   writeOptions?: ConfigWriteOptions;
-  commit: ConfigCommit;
+  commit: ConfigCommit<T>;
 }): Promise<{
-  committed: ConfigReplaceResult | void;
+  committed: T;
   nextInstallRecords: Record<string, PluginInstallRecord>;
   indexWrite: InstalledPluginIndexWriteReceipt;
 }> {
@@ -608,19 +608,19 @@ export async function commitPluginInstallRecordsOnly(params: {
   return result.indexWrite;
 }
 
+type PluginConfigCommit = ConfigReplaceResult & {
+  installRecords: Record<string, PluginInstallRecord>;
+  movedInstallRecords: boolean;
+};
+
 /** Commit config while migrating any pending install records into the install index. */
 export async function commitConfigWriteWithPendingPluginInstalls(params: {
   nextConfig: OpenClawConfig;
   /** Source snapshot whose transient records migrate below the canonical index. */
   sourceConfig?: OpenClawConfig;
   writeOptions?: ConfigWriteOptions;
-  commit: ConfigCommit;
-}): Promise<{
-  config: OpenClawConfig;
-  installRecords: Record<string, PluginInstallRecord>;
-  movedInstallRecords: boolean;
-  persistedHash: string | null;
-}> {
+  commit: ConfigCommit<ConfigReplaceResult>;
+}): Promise<PluginConfigCommit> {
   const sourceInstallRecords = params.sourceConfig?.plugins?.installs ?? {};
   const nextPendingConfig = params.sourceConfig
     ? stripPendingPluginInstallRecords(
@@ -642,10 +642,9 @@ export async function commitConfigWriteWithPendingPluginInstalls(params: {
         : await params.commit(params.nextConfig);
     });
     return {
-      config: committed ? committed.nextConfig : params.nextConfig,
+      ...committed,
       installRecords: {},
       movedInstallRecords: false,
-      persistedHash: committed?.persistedHash ?? null,
     };
   }
 
@@ -671,10 +670,9 @@ export async function commitConfigWriteWithPendingPluginInstalls(params: {
     commit: params.commit,
   });
   return {
-    config: result.committed ? result.committed.nextConfig : strippedConfig,
+    ...result.committed,
     installRecords: result.nextInstallRecords,
     movedInstallRecords: true,
-    persistedHash: result.committed?.persistedHash ?? null,
   };
 }
 
@@ -684,12 +682,7 @@ export async function commitConfigWithPendingPluginInstalls(
     baseHash?: string;
     writeOptions?: ConfigWriteOptions;
   },
-): Promise<{
-  config: OpenClawConfig;
-  installRecords: Record<string, PluginInstallRecord>;
-  movedInstallRecords: boolean;
-  persistedHash: string | null;
-}> {
+): Promise<PluginConfigCommit> {
   return await commitConfigWriteWithPendingPluginInstalls({
     nextConfig: params.sourceConfig ?? params.nextConfig,
     ...(params.writeOptions ? { writeOptions: params.writeOptions } : {}),
@@ -729,7 +722,7 @@ export async function transformConfigWithPendingPluginInstalls<T = void>(
           : undefined),
     );
     return {
-      config: committed.config,
+      config: committed.nextConfig,
       persistedHash: committed.persistedHash,
       afterWrite,
     };

--- a/src/system-agent/chat-engine.test-support.ts
+++ b/src/system-agent/chat-engine.test-support.ts
@@ -8,6 +8,7 @@ import {
   fingerprintOpaqueRuntimeOwner,
   fingerprintResolvedProviderAuth,
 } from "../agents/execution-auth-binding.js";
+import { committedConfigFiles as hostedConfigFiles } from "../commands/committed-config.test-support.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import type { runSetupMemoryImportStep } from "../wizard/setup.memory-import.js";
 import { runSystemAgentTurnWithDeps as runSystemAgentTurnWithDepsImpl } from "./agent-turn.test-support.js";
@@ -47,7 +48,6 @@ const mocks = vi.hoisted(() => ({
   runSearchSetupFlow: vi.fn(),
   runSetupMemoryImportStep: vi.fn(),
   writeWizardConfigFile: vi.fn(),
-  runCollectedChannelOnboardingPostWriteHooks: vi.fn(async () => {}),
   sharedVerifiedInference: undefined as SystemAgentVerifiedInferenceBinding | undefined,
 }));
 
@@ -67,7 +67,6 @@ vi.mock("../wizard/setup.shared.js", async (importOriginal) => ({
 vi.mock("../commands/onboard-channels.js", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../commands/onboard-channels.js")>()),
   setupChannels: mocks.setupChannels,
-  runCollectedChannelOnboardingPostWriteHooks: mocks.runCollectedChannelOnboardingPostWriteHooks,
 }));
 
 vi.mock("../commands/onboard-skills.js", async (importOriginal) => ({
@@ -410,6 +409,7 @@ beforeAll(async () => {
 });
 
 afterEach(() => {
+  hostedConfigFiles.clear();
   vi.unstubAllEnvs();
   vi.clearAllMocks();
   mocks.readConfigFileSnapshot.mockResolvedValue(
@@ -421,7 +421,6 @@ afterEach(() => {
   mocks.runSearchSetupFlow.mockReset();
   mocks.runSetupMemoryImportStep.mockReset();
   mocks.writeWizardConfigFile.mockReset();
-  mocks.runCollectedChannelOnboardingPostWriteHooks.mockReset();
   for (const dir of tempDirs.splice(0)) {
     fs.rmSync(dir, { recursive: true, force: true });
   }

--- a/src/system-agent/chat-turn-router.approval.test.ts
+++ b/src/system-agent/chat-turn-router.approval.test.ts
@@ -211,6 +211,7 @@ describe("SystemAgentChatEngine approval", () => {
         agentDir: "/tmp/agent-researcher",
         bootstrapPending: true,
         config: {},
+        configPath: "/tmp/openclaw.json",
       }));
       const engine = new SystemAgentChatEngine({
         runAgentTurn: async () => ({ text: "noted" }),

--- a/src/system-agent/hosted-setup.runtime.test.ts
+++ b/src/system-agent/hosted-setup.runtime.test.ts
@@ -1,5 +1,6 @@
 import "./chat-engine.mocks.test-support.js";
 import { describe, expect, it, vi } from "vitest";
+import { committedConfigFiles as hostedConfigFiles } from "../commands/committed-config.test-support.js";
 import {
   fakeOverviewLoader,
   sharedVerifiedInferenceConfig,
@@ -87,7 +88,9 @@ describe("SystemAgentChatEngine runtime", () => {
         return { ...config, skills: { install: { nodeManager: "npm" } } };
       },
     );
-    mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => config);
+    mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) =>
+      hostedConfigFiles.write(config),
+    );
     const engine = new SystemAgentChatEngine({
       surface: "gateway",
       runAgentTurn: async () => null,
@@ -154,7 +157,9 @@ describe("SystemAgentChatEngine runtime", () => {
         };
       },
     );
-    mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => config);
+    mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) =>
+      hostedConfigFiles.write(config),
+    );
     const engine = new SystemAgentChatEngine({
       surface: "gateway",
       runAgentTurn: async () => null,
@@ -200,7 +205,9 @@ describe("SystemAgentChatEngine runtime", () => {
       config: baseConfig,
       sourceConfig: baseConfig,
     });
-    mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => config);
+    mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) =>
+      hostedConfigFiles.write(config),
+    );
     const engine = new SystemAgentChatEngine({
       surface: "gateway",
       runAgentTurn: async () => null,
@@ -274,7 +281,9 @@ describe("SystemAgentChatEngine runtime", () => {
       config: baseConfig,
       sourceConfig: baseConfig,
     });
-    mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => config);
+    mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) =>
+      hostedConfigFiles.write(config),
+    );
     const changedConfig: OpenClawConfig = {
       agents: { defaults: { model: "anthropic/claude-opus-4-8" } },
       models: {
@@ -493,7 +502,7 @@ describe("SystemAgentChatEngine runtime", () => {
         }
         currentConfig = structuredClone(nextConfig);
         currentHash = "committed-hash";
-        return nextConfig;
+        return hostedConfigFiles.write(nextConfig);
       },
     );
     const engine = new SystemAgentChatEngine({
@@ -569,7 +578,9 @@ describe("SystemAgentChatEngine runtime", () => {
         };
       },
     );
-    mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => config);
+    mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) =>
+      hostedConfigFiles.write(config),
+    );
     const engine = new SystemAgentChatEngine({
       surface: "gateway",
       verifiedInference,
@@ -586,7 +597,6 @@ describe("SystemAgentChatEngine runtime", () => {
 
     expect(stopped.text).toContain("Telegram setup stopped");
     expect(mocks.writeWizardConfigFile).not.toHaveBeenCalled();
-    expect(mocks.runCollectedChannelOnboardingPostWriteHooks).not.toHaveBeenCalled();
   });
 
   it("rechecks inference authority before hosted channel post-write hooks", async () => {
@@ -637,13 +647,8 @@ describe("SystemAgentChatEngine runtime", () => {
     );
     mocks.writeWizardConfigFile.mockImplementation(async (config: OpenClawConfig) => {
       currentConfig = structuredClone(changedConfig);
-      return config;
+      return hostedConfigFiles.write(config);
     });
-    mocks.runCollectedChannelOnboardingPostWriteHooks.mockImplementationOnce(
-      async (params?: { beforePersistentEffect?: () => Promise<void> }) => {
-        await params?.beforePersistentEffect?.();
-      },
-    );
     const engine = new SystemAgentChatEngine({
       surface: "gateway",
       verifiedInference,
@@ -686,7 +691,7 @@ describe("hosted channel post-write hooks", () => {
       },
     );
     const committed = { channels: { matrix: { enabled: true, committed: true } } };
-    mocks.writeWizardConfigFile.mockResolvedValue(committed);
+    mocks.writeWizardConfigFile.mockResolvedValue(hostedConfigFiles.write(committed));
     const engine = new SystemAgentChatEngine({
       surface: "gateway",
       runAgentTurn: async () => null,

--- a/src/system-agent/hosted-setup.runtime.ts
+++ b/src/system-agent/hosted-setup.runtime.ts
@@ -52,7 +52,7 @@ export async function runHostedSetup(params: {
   run: (context: { baseConfig: OpenClawConfig; runtime: RuntimeEnv }) => Promise<
     | {
         nextConfig: OpenClawConfig;
-        afterWrite?: (committedConfig: OpenClawConfig) => Promise<void>;
+        afterWrite?: (configPath: string) => Promise<void>;
       }
     | { keptCurrent: true }
   >;
@@ -71,12 +71,12 @@ export async function runHostedSetup(params: {
     return "kept-current";
   }
   await params.beforePersistentApply(runtime);
-  const committedConfig = await writeWizardConfigFile(result.nextConfig, {
+  const committed = await writeWizardConfigFile(result.nextConfig, {
     allowConfigSizeDrop: false,
     baseHash: snapshot.hash,
     ...(params.afterWrite ? { afterWrite: params.afterWrite } : {}),
   });
-  await result.afterWrite?.(committedConfig);
+  await result.afterWrite?.(committed.path);
   return "applied";
 }
 
@@ -86,15 +86,15 @@ export async function runHostedChannelSetup(
   beforePersistentApply: (runtime: RuntimeEnv) => Promise<void>,
   runtime?: RuntimeEnv,
 ): Promise<HostedSetupCompletion> {
-  const { createChannelSetupTransaction, setupChannels } =
+  const { createChannelSetupHooks, setupChannels } =
     await import("../commands/onboard-channels.js");
-  let channelSetup: ReturnType<typeof createChannelSetupTransaction>;
+  let channelSetup: ReturnType<typeof createChannelSetupHooks>;
   return await runHostedSetup({
     label: "Channel setup",
     runtime,
     beforePersistentApply,
     run: async ({ baseConfig, runtime: setupRuntime }) => {
-      channelSetup = createChannelSetupTransaction({
+      channelSetup = createChannelSetupHooks({
         runtime: setupRuntime,
         beforePersistentEffect: async () => await beforePersistentApply(setupRuntime),
       });
@@ -111,8 +111,8 @@ export async function runHostedChannelSetup(
           beforePersistentEffect: async () => await beforePersistentApply(setupRuntime),
           onPostWriteHook: (hook) => channelSetup.onPostWriteHook(hook),
         }),
-        afterWrite: async (committedConfig) => {
-          await channelSetup.runPostWriteHooks(committedConfig);
+        afterWrite: async (configPath) => {
+          await channelSetup.runPostWriteHooks(configPath);
         },
       };
     },

--- a/src/system-agent/rescue-message.test.ts
+++ b/src/system-agent/rescue-message.test.ts
@@ -669,6 +669,7 @@ describe("OpenClaw rescue message", () => {
           agentDir: "/tmp/agent-work",
           bootstrapPending: true,
           config: cfg,
+          configPath: "/tmp/openclaw.json",
         })),
       };
 

--- a/src/wizard/setup.default-agent.test.ts
+++ b/src/wizard/setup.default-agent.test.ts
@@ -161,7 +161,10 @@ describe("runSetupWizard default-agent ownership", () => {
       sourceConfigBeforeMigrations: config,
       issues: [],
     });
-    mocks.writeConfig.mockImplementation(async (nextConfig: OpenClawConfig) => nextConfig);
+    mocks.writeConfig.mockImplementation(async (nextConfig: OpenClawConfig) => ({
+      path: "/tmp/openclaw.json",
+      nextConfig,
+    }));
     mocks.setupSkills.mockImplementation(async (nextConfig: OpenClawConfig) => nextConfig);
     mocks.setupOfficialPlugins.mockImplementation(
       async ({ config: nextConfig }: { config: OpenClawConfig }) => nextConfig,
@@ -194,7 +197,7 @@ describe("runSetupWizard default-agent ownership", () => {
       let persisted: OpenClawConfig | undefined;
       mocks.writeConfig.mockImplementation(async (nextConfig: OpenClawConfig) => {
         persisted = nextConfig;
-        return nextConfig;
+        return { path: "/tmp/openclaw.json", nextConfig };
       });
 
       await runSetupWizard(
@@ -247,7 +250,7 @@ describe("runSetupWizard default-agent ownership", () => {
     let persisted: OpenClawConfig | undefined;
     mocks.writeConfig.mockImplementation(async (nextConfig: OpenClawConfig) => {
       persisted = nextConfig;
-      return nextConfig;
+      return { path: "/tmp/openclaw.json", nextConfig };
     });
 
     await runSetupWizard(

--- a/src/wizard/setup.shared.test.ts
+++ b/src/wizard/setup.shared.test.ts
@@ -1,7 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createWizardPrompter } from "../../test/helpers/wizard-prompter.js";
+import { createTestConfigFileStore } from "../commands/test-runtime-config-helpers.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.openclaw.js";
 import type { WizardPrompter } from "./prompts.js";
+
+const configFiles = createTestConfigFileStore();
 
 const mocks = vi.hoisted(() => ({
   currentConfig: {} as OpenClawConfig,
@@ -173,9 +176,8 @@ describe("writeWizardConfigFile", () => {
     vi.clearAllMocks();
     mocks.currentConfig = {};
     mocks.transformConfigWithPendingPluginInstalls.mockImplementation(
-      async (params: {
-        transform: (current: OpenClawConfig) => { nextConfig: OpenClawConfig };
-      }) => ({ nextConfig: params.transform(mocks.currentConfig).nextConfig }),
+      async (params: { transform: (current: OpenClawConfig) => { nextConfig: OpenClawConfig } }) =>
+        configFiles.write(params.transform(mocks.currentConfig).nextConfig),
     );
   });
 
@@ -206,7 +208,10 @@ describe("writeWizardConfigFile", () => {
     };
     mocks.currentConfig = { gateway: { port: 19001 } };
 
-    await expect(writeWizardConfigFile(config)).resolves.toEqual(config);
+    await expect(writeWizardConfigFile(config)).resolves.toMatchObject({
+      nextConfig: config,
+      path: "/tmp/openclaw.json",
+    });
   });
 
   it("applies only the wizard delta to a fresh concurrent config", async () => {
@@ -224,10 +229,13 @@ describe("writeWizardConfigFile", () => {
       plugins: { entries: { demo: { enabled: true } } },
     };
 
-    await expect(writeWizardConfigFile(next, { mergeBase: base })).resolves.toEqual({
-      agents: { defaults: { workspace: "/concurrent" } },
-      gateway: { port: 19001 },
-      plugins: { entries: { demo: { enabled: true } } },
+    await expect(writeWizardConfigFile(next, { mergeBase: base })).resolves.toMatchObject({
+      path: "/tmp/openclaw.json",
+      nextConfig: {
+        agents: { defaults: { workspace: "/concurrent" } },
+        gateway: { port: 19001 },
+        plugins: { entries: { demo: { enabled: true } } },
+      },
     });
   });
 });

--- a/src/wizard/setup.shared.ts
+++ b/src/wizard/setup.shared.ts
@@ -95,8 +95,8 @@ export async function writeWizardConfigFile(
     /** Runtime follow-up intent for the Gateway config watcher. */
     afterWrite?: ConfigWriteAfterWrite;
   } = {},
-): Promise<OpenClawConfig> {
-  const committed = await transformConfigWithPendingPluginInstalls({
+) {
+  return await transformConfigWithPendingPluginInstalls({
     ...(opts.baseHash !== undefined ? { baseHash: opts.baseHash } : {}),
     // Caller-owned snapshots are one-shot CAS preconditions, not retry baselines.
     ...(opts.baseHash !== undefined || opts.baseSnapshot ? { maxAttempts: 1 } : {}),
@@ -114,7 +114,6 @@ export async function writeWizardConfigFile(
         : config,
     }),
   });
-  return committed.nextConfig;
 }
 
 export async function readSetupConfigFileSnapshot() {

--- a/src/wizard/setup.test.ts
+++ b/src/wizard/setup.test.ts
@@ -12,6 +12,7 @@ import {
 } from "../agents/auth-profiles/oauth-test-utils.js";
 import { upsertAuthProfileWithLock } from "../agents/auth-profiles/profiles.js";
 import { DEFAULT_BOOTSTRAP_FILENAME } from "../agents/workspace.js";
+import { committedConfigFiles } from "../commands/committed-config.test-support.js";
 import { ConfigMutationConflictError } from "../config/config.js";
 import { createConfigIO as createRealConfigIO } from "../config/io.factory.js";
 import { coerceConfig } from "../config/io.read-helpers.js";
@@ -448,7 +449,7 @@ vi.mock("../config/config.js", async (importActual) => {
             writeOptions: params.writeOptions,
             afterWrite: { mode: "auto" },
           });
-          return { nextConfig: committed.config };
+          return committedConfigFiles.write(committed.config, snapshot.path);
         } catch (error) {
           if (
             !(error instanceof actual.ConfigMutationConflictError) ||
@@ -614,6 +615,7 @@ describe("runSetupWizard", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    committedConfigFiles.clear();
     promptAuthChoiceGrouped.mockReset();
     promptAuthChoiceGrouped.mockResolvedValue("skip");
     applyAuthChoice.mockReset();

--- a/src/wizard/setup.ts
+++ b/src/wizard/setup.ts
@@ -87,7 +87,7 @@ async function runSetupWizardOnce(
   // Ordinary onboard reruns must preserve existing agents.list / bindings. Only
   // explicit reset or import flows are allowed to shrink the config — see issue
   // openclaw#84692.
-  const writeSetupConfigFile = async (
+  const commitSetupConfigFile = async (
     config: OpenClawConfig,
     optsLocal: { allowConfigSizeDrop?: boolean } = {},
   ) => {
@@ -95,7 +95,7 @@ async function runSetupWizardOnce(
       ...optsLocal,
       mergeBase: setupConfigMergeBase,
     });
-    setupConfigMergeBase = structuredClone(committed);
+    setupConfigMergeBase = structuredClone(committed.nextConfig);
     return committed;
   };
 
@@ -248,11 +248,13 @@ async function runSetupWizardOnce(
           if (!isDeepStrictEqual(latestConfig, expectedConfig)) {
             throw new ConfigMutationConflictError("config changed during migration promotion");
           }
-          return await writeWizardConfigFile(cfg, {
-            allowConfigSizeDrop: true,
-            baseSnapshot: latest,
-            ...(latest.hash !== undefined ? { baseHash: latest.hash } : {}),
-          });
+          return (
+            await writeWizardConfigFile(cfg, {
+              allowConfigSizeDrop: true,
+              baseSnapshot: latest,
+              ...(latest.hash !== undefined ? { baseHash: latest.hash } : {}),
+            })
+          ).nextConfig;
         },
         allowProviderBack: flowFromPrompt,
         continueOnboarding: true,
@@ -467,7 +469,7 @@ async function runSetupWizardOnce(
     nextConfig = opts.skipBootstrap ? applySkipBootstrapConfig(nextConfig) : nextConfig;
     nextConfig = onboardHelpers.applyWizardMetadata(nextConfig, { command: "onboard", mode });
     prompter.disableBackNavigation?.();
-    await writeSetupConfigFile(nextConfig, {
+    await commitSetupConfigFile(nextConfig, {
       allowConfigSizeDrop: false,
     });
     logConfigUpdated(runtime);
@@ -585,7 +587,7 @@ async function runSetupWizardOnce(
       runtime,
       workspaceDir: verificationTarget.workspaceDir,
       writeConfig: async (config) =>
-        await writeSetupConfigFile(config, { allowConfigSizeDrop: false }),
+        (await commitSetupConfigFile(config, { allowConfigSizeDrop: false })).nextConfig,
       required: usedImportFlow && keepExistingModelConfig,
     });
     nextConfig = verification.config;
@@ -610,9 +612,10 @@ async function runSetupWizardOnce(
 
   if (!setupConfigPersisted) {
     // Persist gateway/roster decisions only after the interactive verification boundary.
-    nextConfig = await writeSetupConfigFile(nextConfig, {
+    const committed = await commitSetupConfigFile(nextConfig, {
       allowConfigSizeDrop: false,
     });
+    nextConfig = committed.nextConfig;
   }
 
   prompter.disableBackNavigation?.();
@@ -620,9 +623,9 @@ async function runSetupWizardOnce(
     await prompter.note(t("wizard.setup.skipChannels"), t("wizard.setup.channelsTitle"));
   } else {
     const { listChannelPlugins } = await import("../channels/plugins/index.js");
-    const { createChannelSetupTransaction, setupChannels } =
+    const { createChannelSetupHooks, setupChannels } =
       await import("../commands/onboard-channels.js");
-    const channelSetup = createChannelSetupTransaction({ runtime });
+    const channelSetup = createChannelSetupHooks({ runtime });
     const quickstartAllowFromChannels =
       flow === "quickstart"
         ? listChannelPlugins()
@@ -640,16 +643,16 @@ async function runSetupWizardOnce(
       secretInputMode: opts.secretInputMode,
       onPostWriteHook: (hook) => channelSetup.onPostWriteHook(hook),
     });
-    nextConfig = await channelSetup.commit(
-      nextConfig,
-      async (config) => await writeSetupConfigFile(config, { allowConfigSizeDrop: false }),
-    );
+    const committed = await commitSetupConfigFile(nextConfig, { allowConfigSizeDrop: false });
+    await channelSetup.runPostWriteHooks(committed.path);
+    nextConfig = committed.nextConfig;
   }
 
   if (opts.skipChannels) {
-    nextConfig = await writeSetupConfigFile(nextConfig, {
+    const committed = await commitSetupConfigFile(nextConfig, {
       allowConfigSizeDrop: false,
     });
+    nextConfig = committed.nextConfig;
   }
   let onboardingTarget = resolveOnboardingSetupTarget(nextConfig);
   const { logConfigUpdated } = await loadConfigLoggingModule();
@@ -718,9 +721,10 @@ async function runSetupWizardOnce(
   }
 
   nextConfig = onboardHelpers.applyWizardMetadata(nextConfig, { command: "onboard", mode });
-  nextConfig = await writeSetupConfigFile(nextConfig, {
+  const committed = await commitSetupConfigFile(nextConfig, {
     allowConfigSizeDrop: false,
   });
+  nextConfig = committed.nextConfig;
   onboardingTarget = resolveOnboardingSetupTarget(nextConfig);
   commitAppRecommendationResult?.();
 


### PR DESCRIPTION
Related: #130706

## What Problem This Solves

Fixes an issue where channel setup saves configuration successfully but its connection check receives unresolved `${VAR}` values. A channel configured with an environment-backed service URL can therefore report a setup failure even though the saved configuration is correct.

## Why This Change Was Made

Carry the native write receipt through agent creation, pending plugin installs, and setup wizards. Post-write callbacks reread runtime values from that receipt's exact committed file; subsequent writes continue using the authored config and existing merge-base and conflict checks. The hook collector now only collects and runs callbacks.

## User Impact

Channel setup checks receive resolved environment values and plugin defaults after the save succeeds. A later config-path selection cannot redirect the check. Callback failures remain warnings without undoing the saved configuration, and revoked authority or a failed write prevents callback execution. The protected source and credential behavior from #141586 is preserved.

## Evidence

On current main `48d1551a3327a154ebba5caab03486ae82bf7479`, 61 tests passed across five focused files:

```sh
node scripts/run-vitest.mjs src/agents/agent-create.integration.test.ts src/wizard/setup.inference-verification.test.ts src/system-agent/inference-route-runtime.test.ts src/config/runtime-snapshot.test.ts src/commands/onboard-channels.post-write.test.ts
```

These cover committed-path propagation, both real-file post-write writer paths, classic setup persistence, prepared credential isolation, rotation, and runtime snapshot provenance. Protected credentials use a synthetic store and substituted model turns; this is source-level contract proof.

The initial 38-file cut was reconciled with current main; the CI follow-up adds two test-fixture files. Its only overlap preserves main's newer agent-creation test fixture; all 13 production postimages remain byte-identical to the reviewed hook commit. The owner-scoped changed gate passed, including the agent test type graph, formatting, lint, and its normal repository guards:

```sh
node scripts/check-changed.mjs --base 48d1551a3327a154ebba5caab03486ae82bf7479 -- src/agents/agent-create.integration.test.ts
```

[Blacksmith Testbox runtime proof](https://github.com/openclaw/openclaw/actions/runs/34181019832) built exact published head `604fa25e6f32d5269d99c6097ce6bf3b2da30b90` and passed all three compiled flows: pending-install persistence, wizard persistence, and the real `channels add` CLI with the ClickClack setup callback. The synthetic loopback service received exactly `GET /api/me` and `GET /api/workspaces`. Checks used resolved environment values from the committed path even after selecting a decoy config; authored references and unrelated config remained intact. Existing warning, invalid-file, deduplication and authority checks also passed. All servers and process groups closed without escalation, source/build manifests stayed unchanged, and all 76 exported files were hash-verified.

CI on `604fa25e` found two older fixture owners still returning bare config or no write result. The tests-only follow-up `bf905373c87216aa7dda98804e14b68fce5c5289` makes them return native receipts and expose the committed snapshot. All 11 failures were reproduced first; both complete failed files then passed (116 tests), and the final sibling cohort passed 154 tests across seven files. The changed gate and fresh P2 review passed with every behavior assertion retained. Runtime source and build configuration remain byte-identical to the compiled proof above.

This is compiled application proof with an isolated synthetic service, not an npm installation or an external ClickClack service test. [Exact follow-up CI](https://github.com/openclaw/openclaw/actions/runs/34188170829) is green; native landing remains pending.

