### PR TITLE
refactor(tests): share caller-mode snapshot inputs

### DIFF
--- a/src/infra/state-migrations.caller-mode.execution.test.ts
+++ b/src/infra/state-migrations.caller-mode.execution.test.ts
@@ -14,6 +14,7 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
+  createCallerModeSnapshot,
   expectBlockedTailInPlanOrder,
   expectPlanReceiptDescriptorsToMatch,
   writeLegacyStateSchemaV1,
@@ -162,11 +163,7 @@ describe("legacy state migration caller execution", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: { root: fixture.root, version: "test" },
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -520,11 +517,7 @@ describe("legacy state migration caller execution", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: { root: fixture.root, version: "test" },
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -568,11 +561,7 @@ describe("legacy state migration caller execution", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: { root: fixture.root, version: "test" },
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
     const legacySessionSurfaces: PreparedLegacySessionSurfaces = Object.defineProperty(
@@ -637,11 +626,7 @@ describe("legacy state migration caller execution", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: { root: fixture.root, version: "test" },
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
     const pluginLoader = vi.fn(() => {
@@ -717,11 +702,7 @@ describe("legacy state migration caller execution", () => {
     const healthyPlan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: { root: healthyFixture.root, version: "test" },
-      snapshot: {
-        homeDir: healthyFixture.homeDir,
-        configPath: healthyFixture.configPath,
-        stateDir: healthyFixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(healthyFixture),
       env: healthyFixture.env,
     });
     const fixture = await makeFixture();
@@ -760,11 +741,7 @@ describe("legacy state migration caller execution", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: { root: fixture.root, version: "test" },
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -809,11 +786,7 @@ describe("legacy state migration caller execution", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: { root: fixture.root, version: "test" },
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -868,11 +841,7 @@ describe("legacy state migration caller execution", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: { root: fixture.root, version: "test" },
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 

--- a/src/infra/state-migrations.caller-mode.refusal.test.ts
+++ b/src/infra/state-migrations.caller-mode.refusal.test.ts
@@ -15,6 +15,7 @@ import {
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
+  createCallerModeSnapshot,
   expectBlockedTailInPlanOrder,
   expectPlanReceiptDescriptorsToMatch,
   snapshotFiles,
@@ -115,11 +116,7 @@ describe("legacy state migration read-only refusals", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: assertedCandidate,
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -141,11 +138,7 @@ describe("legacy state migration read-only refusals", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
       legacySessionSurfaces: { surfaces: [], failures: ["session surface unavailable"] },
     });
@@ -189,11 +182,7 @@ describe("legacy state migration read-only refusals", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
       legacySessionSurfaces,
     });
@@ -218,11 +207,7 @@ describe("legacy state migration read-only refusals", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: { ...fixture.env, OPENCLAW_OAUTH_DIR: externalOAuthDir },
     });
 
@@ -263,11 +248,7 @@ describe("legacy state migration read-only refusals", () => {
       const plan = await planLegacyStateMigrationsReadOnly({
         mode: "doctor",
         candidate: candidateAt(fixture.root),
-        snapshot: {
-          homeDir: fixture.homeDir,
-          configPath: fixture.configPath,
-          stateDir: fixture.stateDir,
-        },
+        snapshot: createCallerModeSnapshot(fixture),
         env: {
           ...fixture.env,
           OPENCLAW_AGENT_DIR: pathStyle === "tilde" ? "~/relocated-auth" : authDir,
@@ -306,11 +287,7 @@ describe("legacy state migration read-only refusals", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: { ...fixture.env, OPENCLAW_OAUTH_DIR: oauthDir },
     });
 
@@ -345,11 +322,7 @@ describe("legacy state migration read-only refusals", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -411,11 +384,7 @@ describe("legacy state migration read-only refusals", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "automatic",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
     const plannedWorkshopIndex = plan.steps.findIndex((step) => step.refusal !== undefined);
@@ -495,11 +464,7 @@ module.exports = { stateMigrations: [{
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "automatic",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -558,11 +523,7 @@ module.exports = { stateMigrations: [{
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -591,11 +552,7 @@ module.exports = { stateMigrations: [{
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -647,11 +604,7 @@ module.exports = { stateMigrations: [{
       const authorizedPlan = await planLegacyStateMigrationsReadOnly({
         mode: "doctor",
         candidate: candidateAt(fixture.root),
-        snapshot: {
-          homeDir: fixture.homeDir,
-          configPath: fixture.configPath,
-          stateDir: fixture.stateDir,
-        },
+        snapshot: createCallerModeSnapshot(fixture),
         env: fixture.env,
       });
       expect(authorizedPlan.steps.find((step) => step.id === "migration-detection")).toBeDefined();
@@ -731,11 +684,7 @@ module.exports = { stateMigrations: [{
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -763,11 +712,7 @@ module.exports = { stateMigrations: [{
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -798,11 +743,7 @@ module.exports = { stateMigrations: [{
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -847,11 +788,7 @@ module.exports = { stateMigrations: [{
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
     const pluginDoctorConfig = Object.defineProperty({}, "meta", {
@@ -915,11 +852,7 @@ module.exports = { stateMigrations: [{
       const plan = await planLegacyStateMigrationsReadOnly({
         mode: "automatic",
         candidate: candidateAt(fixture.root),
-        snapshot: {
-          homeDir: fixture.homeDir,
-          configPath: fixture.configPath,
-          stateDir: fixture.stateDir,
-        },
+        snapshot: createCallerModeSnapshot(fixture),
         env: fixture.env,
       });
       const failure = new Error(`synthetic automatic ${blockerId} failure`);
@@ -962,11 +895,7 @@ module.exports = { stateMigrations: [{
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
     const lastTouchedAt = "2026-09-02T00:00:00.000Z";
@@ -1019,11 +948,7 @@ module.exports = { stateMigrations: [{
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
     const params = Object.defineProperty(

--- a/src/infra/state-migrations.caller-mode.test-helpers.ts
+++ b/src/infra/state-migrations.caller-mode.test-helpers.ts
@@ -106,3 +106,13 @@ export function expectPlanReceiptDescriptorsToMatch(params: {
     params.plan.steps.map(stableStepDescriptor),
   );
 }
+
+export function createCallerModeSnapshot(
+  fixture: Pick<LegacyStateMigrationPlan["snapshot"], "homeDir" | "configPath" | "stateDir">,
+): LegacyStateMigrationPlan["snapshot"] {
+  return {
+    homeDir: fixture.homeDir,
+    configPath: fixture.configPath,
+    stateDir: fixture.stateDir,
+  };
+}

--- a/src/infra/state-migrations.caller-mode.test.ts
+++ b/src/infra/state-migrations.caller-mode.test.ts
@@ -11,6 +11,7 @@ import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js
 import { resolveOpenClawStateSqlitePath } from "../state/openclaw-state-db.paths.js";
 import { createTrackedTempDirs } from "../test-utils/tracked-temp-dirs.js";
 import {
+  createCallerModeSnapshot,
   expectBlockedTailInPlanOrder,
   expectPlanReceiptDescriptorsToMatch,
   snapshotFiles,
@@ -156,11 +157,7 @@ describe("legacy state migration caller mode", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(candidateRoot),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -190,11 +187,7 @@ describe("legacy state migration caller mode", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(path.join(fixture.root, "candidate"), "2026.9.2-candidate"),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -269,11 +262,7 @@ describe("legacy state migration caller mode", () => {
     const first = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
     expect(first.warnings).toEqual([]);
@@ -283,11 +272,7 @@ describe("legacy state migration caller mode", () => {
     const second = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
     expect(second.snapshot.stateDigest).not.toBe(first.snapshot.stateDigest);
@@ -307,11 +292,7 @@ describe("legacy state migration caller mode", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -341,11 +322,7 @@ describe("legacy state migration caller mode", () => {
       const plan = await planLegacyStateMigrationsReadOnly({
         mode: "doctor",
         candidate: candidateAt(fixture.root),
-        snapshot: {
-          homeDir: fixture.homeDir,
-          configPath: fixture.configPath,
-          stateDir: fixture.stateDir,
-        },
+        snapshot: createCallerModeSnapshot(fixture),
         env: fixture.env,
       });
 
@@ -363,11 +340,7 @@ describe("legacy state migration caller mode", () => {
       const updatedPlan = await planLegacyStateMigrationsReadOnly({
         mode: "doctor",
         candidate: candidateAt(fixture.root),
-        snapshot: {
-          homeDir: fixture.homeDir,
-          configPath: fixture.configPath,
-          stateDir: fixture.stateDir,
-        },
+        snapshot: createCallerModeSnapshot(fixture),
         env: fixture.env,
       });
       expect(updatedPlan.snapshot.stateDigest).not.toBe(plan.snapshot.stateDigest);
@@ -386,11 +359,7 @@ describe("legacy state migration caller mode", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -416,11 +385,7 @@ describe("legacy state migration caller mode", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -448,11 +413,7 @@ describe("legacy state migration caller mode", () => {
     const first = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
     expect(first.warnings).toEqual([]);
@@ -513,11 +474,7 @@ describe("legacy state migration caller mode", () => {
     const second = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
     const secondAgentStep = second.steps.find((step) => step.id === "acp-session-metadata");
@@ -576,11 +533,7 @@ describe("legacy state migration caller mode", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "automatic",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env: fixture.env,
     });
 
@@ -684,11 +637,7 @@ describe("legacy state migration caller mode", () => {
       const plan = await planLegacyStateMigrationsReadOnly({
         mode: "doctor",
         candidate: candidateAt(fixture.root),
-        snapshot: {
-          homeDir: fixture.homeDir,
-          configPath: fixture.configPath,
-          stateDir: fixture.stateDir,
-        },
+        snapshot: createCallerModeSnapshot(fixture),
         env,
       });
       for (const suffix of ["", "-wal", "-shm"]) {
@@ -700,11 +649,7 @@ describe("legacy state migration caller mode", () => {
       const repeatedPlan = await planLegacyStateMigrationsReadOnly({
         mode: "doctor",
         candidate: candidateAt(fixture.root),
-        snapshot: {
-          homeDir: fixture.homeDir,
-          configPath: fixture.configPath,
-          stateDir: fixture.stateDir,
-        },
+        snapshot: createCallerModeSnapshot(fixture),
         env,
       });
 
@@ -840,11 +785,7 @@ describe("legacy state migration caller mode", () => {
       const plan = await planLegacyStateMigrationsReadOnly({
         mode: "doctor",
         candidate: candidateAt(fixture.root),
-        snapshot: {
-          homeDir: fixture.homeDir,
-          configPath: fixture.configPath,
-          stateDir: fixture.stateDir,
-        },
+        snapshot: createCallerModeSnapshot(fixture),
         env: fixture.env,
       });
       expect(snapshotExternalArtifacts()).toEqual(externalArtifactsBeforePlan);
@@ -872,11 +813,7 @@ describe("legacy state migration caller mode", () => {
       const repeatedPlan = await planLegacyStateMigrationsReadOnly({
         mode: "doctor",
         candidate: candidateAt(fixture.root),
-        snapshot: {
-          homeDir: fixture.homeDir,
-          configPath: fixture.configPath,
-          stateDir: fixture.stateDir,
-        },
+        snapshot: createCallerModeSnapshot(fixture),
         env: fixture.env,
       });
       expect(repeatedPlan.planDigest).toBe(plan.planDigest);
@@ -920,11 +857,7 @@ describe("legacy state migration caller mode", () => {
     const plan = await planLegacyStateMigrationsReadOnly({
       mode: "doctor",
       candidate: candidateAt(fixture.root),
-      snapshot: {
-        homeDir: fixture.homeDir,
-        configPath: fixture.configPath,
-        stateDir: fixture.stateDir,
-      },
+      snapshot: createCallerModeSnapshot(fixture),
       env,
     });
 


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Caller-mode migration tests repeat the same three-field copied-snapshot input 44 times, adding setup noise around the authority and refusal scenarios those tests protect.

## Why This Change Was Made

Use a pure `createCallerModeSnapshot` factory in the existing test helper. Each original call still creates a fresh object and reads `homeDir`, `configPath` and `stateDir` once in the same order. Digest fields remain absent. Migration calls, modes, candidates, richer or alternate-path inputs, fixtures and assertions are unchanged.

## User Impact

No production or migration behavior changes. All scenarios remain while test/support code shrinks by 163 net lines. No runtime savings or aggregate coverage claim.

## Evidence

- Full three-suite baseline and final runs: all 51 cases passed with identical names and per-file order (13 caller-mode, 25 refusal, 13 execution).
- All 44 expansions preserve values, ordered property reads and keys, missing digests and fresh allocation, including the distinct healthy fixture. Expanding the helper calls reconstructs the complete original test ASTs.
- Existing helper contents, SQLite/fixture lifetimes and all independent assertions remain unchanged.
- Formatting, diff checks, deslop and fresh P2 review passed. Full changed gate passed.
