### PR TITLE
refactor(doctor): share ACP legacy source identity check

### DIFF
--- a/src/infra/state-migrations.acp-replay.ts
+++ b/src/infra/state-migrations.acp-replay.ts
@@ -1,6 +1,6 @@
 // Doctor-only import for the retired ACP replay JSON ledger.
 import { createHash } from "node:crypto";
-import fsSync from "node:fs";
+import fsSync, { type Stats } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
@@ -17,6 +17,7 @@ import {
   executeSqliteQueryTakeFirstSync,
   getNodeSqliteKysely,
 } from "./kysely-sync.js";
+import { legacyMigrationSourceSnapshotsMatch as sourceIdentityMatches } from "./state-migrations.source-snapshot.js";
 import type { LegacyStateDetection, MigrationMessages } from "./state-migrations.types.js";
 
 const LEGACY_LEDGER_VERSION = 1;
@@ -50,14 +51,6 @@ type LegacyAcpReplaySession = {
   updatedAt: number;
   nextSeq: number;
   events: LegacyAcpReplayEvent[];
-};
-
-type LegacySourceIdentity = {
-  dev: number | bigint;
-  ino: number | bigint;
-  mtimeMs: number | bigint;
-  sha256: string;
-  size: number | bigint;
 };
 
 type AcpReplayMigrationDatabase = Pick<
@@ -174,10 +167,7 @@ function parseLegacyLedger(raw: string): LegacyAcpReplaySession[] {
   );
 }
 
-function sourceIdentity(
-  stat: Awaited<ReturnType<typeof fs.lstat>>,
-  raw: string,
-): LegacySourceIdentity {
+function sourceIdentity(stat: Stats, raw: string) {
   return {
     dev: stat.dev,
     ino: stat.ino,
@@ -185,16 +175,6 @@ function sourceIdentity(
     sha256: createHash("sha256").update(raw).digest("hex"),
     size: stat.size,
   };
-}
-
-function sourceIdentityMatches(left: LegacySourceIdentity, right: LegacySourceIdentity): boolean {
-  return (
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.mtimeMs === right.mtimeMs &&
-    left.sha256 === right.sha256 &&
-    left.size === right.size
-  );
 }
 
 function reconcileCanonicalSession(db: DatabaseSync, session: LegacyAcpReplaySession): boolean {


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested consolidation of legacy import validation: Doctor's retired ACP replay importer keeps a private copy of the existing shared source-identity comparison. Reusing the shared comparison keeps these import paths aligned during future maintenance; this is not a claim of a newly reproduced data-loss or recovery bug.

## Why This Change Was Made

Use the existing migration source-snapshot comparator under the ACP importer's existing call-site name, and type its unchanged identity producer with Node's `Stats`. Both `lstat` calls omit options and return ordinary `Stats`.

Comparison order and short-circuiting remain `dev`, `ino`, `mtimeMs`, `sha256`, then `size`. Decoded-string hashing, the call site, claim handling, transactions, recovery, cleanup, warnings, and locks are unchanged. No schema, configuration, SDK, or public API changes.

## User Impact

No externally visible behavior change is intended. The same source checks continue to protect the existing Doctor import workflow.

## Evidence

- The existing ACP replay and source-snapshot suites passed before and after: 16 tests across two suites. Vitest durations were 6.84s before and 6.19s after.
- The existing `routes explicit Doctor repair through the ACP replay SQLite importer` case passed separately before and after in `state-migrations.test.ts`; the other 124 cases were intentionally filtered out. Vitest durations were 10.98s before and 7.26s after. This covers migration routing, not the full Doctor CLI admission flow.
- Exact source-equivalence verification confirmed an identical comparator body and only the approved whole-file transformation: one file, +3/-23. No tests were added or changed.
- Targeted formatting, lint, and `git diff --check` passed.
- Fresh independent autoreview completed with no findings at its default P0 threshold.
- The changed-file gate passed 14 stages, including both ratchets and the core graph-boundary check, then stopped because compiler containment rejects the shared external `tsgo` symlink. Later gate stages did not run; no local typecheck pass or bypass is claimed.
- Exact-head [hosted CI](https://github.com/openclaw/openclaw/actions/runs/34181129626) completed successfully: 108 successful jobs, 17 skipped, no failed jobs. `check-prod-types`, `check-test-types`, `check-test-types-core-1`, `check-test-types-core-2`, and the required `openclaw/ci-gate` all passed. The Windows matrix was skipped, not passed.
- The completed [external review](https://github.com/openclaw/openclaw/pull/141784#issuecomment-5578382530) reported no actionable or security findings for the exact head. Its live-refresh limitation is supplemented by the maintainer's separate source-freshness checks.
- Before baseline testing, the task worktree received a package-level symlink to already-installed shared dependencies. No install or dependency reconciliation occurred. Existing worker-preparation warnings about `libphonenumber-js/min` resolution remain recorded.
- ACP claim-race, per-field getter, and post-commit cleanup-failure cases remain coverage gaps. This is behavior-preserving refactoring proof, not a new bug regression test. No live or credentialed remote proof was run.
- Native preparation uses the documented Testbox flag to verify hosted CI evidence; this is not a live or credentialed Crabbox run.
