### PR TITLE
fix(channels): backport workspace media access

### DIFF
--- a/extensions/matrix/src/actions.account-propagation.test.ts
+++ b/extensions/matrix/src/actions.account-propagation.test.ts
@@ -175,6 +175,10 @@ describe("matrixMessageActions account propagation", () => {
       createContext({
         action: "send",
         accountId: "ops",
+        mediaAccess: {
+          localRoots: ["/tmp/openclaw-matrix-test"],
+          workspaceDir: "/tmp/openclaw-matrix-test/workspace",
+        },
         mediaLocalRoots: ["/tmp/openclaw-matrix-test"],
         params: {
           to: "room:!room:example",
@@ -189,7 +193,13 @@ describe("matrixMessageActions account propagation", () => {
     expect(call.input.accountId).toBe("ops");
     expect(call.input.mediaUrl).toBe("file:///tmp/photo.png");
     expect(call.cfg).toBeTypeOf("object");
-    expect(call.options).toEqual({ mediaLocalRoots: ["/tmp/openclaw-matrix-test"] });
+    expect(call.options).toEqual({
+      mediaAccess: {
+        localRoots: ["/tmp/openclaw-matrix-test"],
+        workspaceDir: "/tmp/openclaw-matrix-test/workspace",
+      },
+      mediaLocalRoots: ["/tmp/openclaw-matrix-test"],
+    });
   });
 
   it("allows media-only sends without requiring a message body", async () => {

--- a/extensions/matrix/src/actions.ts
+++ b/extensions/matrix/src/actions.ts
@@ -152,7 +152,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
   },
   handleAction: async (ctx: ChannelMessageActionContext) => {
     const { handleMatrixAction } = await import("./tool-actions.runtime.js");
-    const { action, params, cfg, accountId, mediaLocalRoots } = ctx;
+    const { action, params, cfg, accountId, mediaAccess, mediaLocalRoots } = ctx;
     const dispatch = async (actionParams: Record<string, unknown>) =>
       await handleMatrixAction(
         {
@@ -160,7 +160,7 @@ export const matrixMessageActions: ChannelMessageActionAdapter = {
           ...(accountId ? { accountId } : {}),
         },
         cfg as CoreConfig,
-        { mediaLocalRoots },
+        { ...(mediaAccess ? { mediaAccess } : {}), mediaLocalRoots },
       );
     const resolveRoomId = () =>
       readStringParam(params, "roomId") ??

--- a/extensions/matrix/src/matrix/actions/messages.ts
+++ b/extensions/matrix/src/matrix/actions/messages.ts
@@ -31,6 +31,7 @@ export async function sendMatrixMessage(
   return await sendMessageMatrix(to, content, {
     cfg: opts.cfg,
     mediaUrl: opts.mediaUrl,
+    mediaAccess: opts.mediaAccess,
     mediaLocalRoots: opts.mediaLocalRoots,
     replyToId: opts.replyToId,
     threadId: opts.threadId,

--- a/extensions/matrix/src/matrix/actions/types.ts
+++ b/extensions/matrix/src/matrix/actions/types.ts
@@ -1,4 +1,5 @@
 // Matrix type declarations define plugin contracts.
+import type { OutboundMediaAccess } from "openclaw/plugin-sdk/media-runtime";
 import type { CoreConfig } from "../../types.js";
 import { MATRIX_REACTION_EVENT_TYPE } from "../reaction-common.js";
 import type { MatrixClient, MessageEventContent } from "../sdk.js";
@@ -31,6 +32,7 @@ export type MatrixActionClientOpts = {
   client?: MatrixClient;
   cfg?: CoreConfig;
   mediaLocalRoots?: readonly string[];
+  mediaAccess?: OutboundMediaAccess;
   timeoutMs?: number;
   accountId?: string | null;
   readiness?: "none" | "prepared" | "started";

--- a/extensions/matrix/src/tool-actions.test.ts
+++ b/extensions/matrix/src/tool-actions.test.ts
@@ -256,13 +256,23 @@ describe("handleMatrixAction pollVote", () => {
         threadId: "$thread",
       },
       cfg,
-      { mediaLocalRoots: ["/tmp/openclaw-matrix-test"] },
+      {
+        mediaAccess: {
+          localRoots: ["/tmp/openclaw-matrix-test"],
+          workspaceDir: "/tmp/openclaw-matrix-test/workspace",
+        },
+        mediaLocalRoots: ["/tmp/openclaw-matrix-test"],
+      },
     );
 
     expect(mocks.sendMatrixMessage).toHaveBeenCalledWith("room:!room:example", "hello", {
       cfg,
       accountId: "ops",
       mediaUrl: undefined,
+      mediaAccess: {
+        localRoots: ["/tmp/openclaw-matrix-test"],
+        workspaceDir: "/tmp/openclaw-matrix-test/workspace",
+      },
       mediaLocalRoots: ["/tmp/openclaw-matrix-test"],
       replyToId: undefined,
       threadId: "$thread",

--- a/extensions/matrix/src/tool-actions.ts
+++ b/extensions/matrix/src/tool-actions.ts
@@ -33,6 +33,7 @@ import {
   voteMatrixPoll,
   verifyMatrixRecoveryKey,
 } from "./matrix/actions.js";
+import type { MatrixActionClientOpts } from "./matrix/actions/types.js";
 import { reactMatrixMessage } from "./matrix/send.js";
 import { applyMatrixProfileUpdate } from "./profile-update.js";
 import {
@@ -147,7 +148,7 @@ function readPositiveIntegerArrayParam(params: Record<string, unknown>, key: str
 export async function handleMatrixAction(
   params: Record<string, unknown>,
   cfg: CoreConfig,
-  opts: { mediaLocalRoots?: readonly string[] } = {},
+  opts: Pick<MatrixActionClientOpts, "mediaAccess" | "mediaLocalRoots"> = {},
 ): Promise<AgentToolResult<unknown>> {
   const action = readStringParam(params, "action", { required: true });
   const accountId = readStringParam(params, "accountId") ?? undefined;
@@ -240,6 +241,7 @@ export async function handleMatrixAction(
               : undefined;
         const result = await sendMatrixMessage(to, content, {
           mediaUrl: mediaUrl ?? undefined,
+          ...(opts.mediaAccess ? { mediaAccess: opts.mediaAccess } : {}),
           mediaLocalRoots: opts.mediaLocalRoots,
           replyToId: replyToId ?? undefined,
           threadId: threadId ?? undefined,

--- a/extensions/telegram/src/action-runtime.test.ts
+++ b/extensions/telegram/src/action-runtime.test.ts
@@ -1562,7 +1562,12 @@ describe("handleTelegramAction", () => {
         content: "Hello with local media",
       },
       telegramConfig(),
-      { mediaLocalRoots: ["/tmp/agent-root"] },
+      {
+        mediaAccess: {
+          localRoots: ["/tmp/agent-root"],
+          workspaceDir: "/tmp/agent-root/workspace",
+        },
+      },
     );
     const call = mockCall(sendMessageTelegram, 0, "local media roots");
     expect(call[0]).toBe("@testchannel");
@@ -1570,6 +1575,15 @@ describe("handleTelegramAction", () => {
     expect(requireRecord(call[2], "local media roots options").mediaLocalRoots).toEqual([
       "/tmp/agent-root",
     ]);
+    expect(
+      requireRecord(
+        requireRecord(
+          mockCall(sendDurableMessageBatch, 0, "workspace media delivery")[0],
+          "workspace media delivery",
+        ).mediaAccess,
+        "workspace media access",
+      ).workspaceDir,
+    ).toBe("/tmp/agent-root/workspace");
   });
 
   it("forwards gateway client scopes into Telegram send target resolution", async () => {

--- a/extensions/telegram/src/action-runtime.ts
+++ b/extensions/telegram/src/action-runtime.ts
@@ -11,6 +11,7 @@ import {
   resolvePollMaxSelections,
   resolveReactionMessageId,
 } from "openclaw/plugin-sdk/channel-actions";
+import type { ChannelMessageActionContext } from "openclaw/plugin-sdk/channel-contract";
 import {
   buildOutboundSessionContext,
   sendDurableMessageBatch,
@@ -328,6 +329,7 @@ export async function handleTelegramAction(
   params: Record<string, unknown>,
   cfg: OpenClawConfig,
   options?: {
+    mediaAccess?: ChannelMessageActionContext["mediaAccess"];
     mediaLocalRoots?: readonly string[];
     mediaReadFile?: (filePath: string) => Promise<Buffer>;
     sessionKey?: string | null;
@@ -578,12 +580,13 @@ export async function handleTelegramAction(
         ? basePayload
         : { ...basePayload, replyToId: String(explicitReplyToMessageId) };
     const mediaAccess =
-      options?.mediaLocalRoots || options?.mediaReadFile
+      options?.mediaAccess ??
+      (options?.mediaLocalRoots || options?.mediaReadFile
         ? {
             ...(options.mediaLocalRoots ? { localRoots: options.mediaLocalRoots } : {}),
             ...(options.mediaReadFile ? { readFile: options.mediaReadFile } : {}),
           }
-        : undefined;
+        : undefined);
     const outboundSession = buildOutboundSessionContext({
       cfg,
       sessionKey: options?.sessionKey,

--- a/extensions/telegram/src/channel-actions.test.ts
+++ b/extensions/telegram/src/channel-actions.test.ts
@@ -52,6 +52,7 @@ describe("telegramMessageActions", () => {
       },
       cfg: {} as never,
       accountId: "default",
+      mediaAccess: { localRoots: [], workspaceDir: "/tmp/workspace" },
       mediaLocalRoots: [],
       sessionKey: "telegram-session",
     } as never);
@@ -72,6 +73,7 @@ describe("telegramMessageActions", () => {
       },
       {},
       {
+        mediaAccess: { localRoots: [], workspaceDir: "/tmp/workspace" },
         mediaLocalRoots: [],
         mediaReadFile: undefined,
         sessionKey: "telegram-session",

--- a/extensions/telegram/src/channel-actions.ts
+++ b/extensions/telegram/src/channel-actions.ts
@@ -205,6 +205,7 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
     params,
     cfg,
     accountId,
+    mediaAccess,
     mediaLocalRoots,
     mediaReadFile,
     sessionKey,
@@ -228,7 +229,14 @@ export const telegramMessageActions: ChannelMessageActionAdapter = {
           : {}),
       },
       cfg,
-      { mediaLocalRoots, mediaReadFile, sessionKey, inboundEventKind, gatewayClientScopes },
+      {
+        ...(mediaAccess !== undefined ? { mediaAccess } : {}),
+        mediaLocalRoots,
+        mediaReadFile,
+        sessionKey,
+        inboundEventKind,
+        gatewayClientScopes,
+      },
     );
   },
 };

--- a/extensions/telegram/src/outbound-adapter.test.ts
+++ b/extensions/telegram/src/outbound-adapter.test.ts
@@ -69,12 +69,17 @@ describe("telegramOutbound", () => {
 
   it("forwards mediaLocalRoots in direct media sends", async () => {
     sendMessageTelegramMock.mockResolvedValueOnce({ messageId: "tg-media" });
+    const mediaAccess = {
+      localRoots: ["/tmp/agent-root"],
+      workspaceDir: "/tmp/agent-root/workspace",
+    };
 
     const result = await telegramOutbound.sendMedia!({
       cfg: {} as never,
       to: "12345",
       text: "hello",
       mediaUrl: "/tmp/image.png",
+      mediaAccess,
       mediaLocalRoots: ["/tmp/agent-root"],
       accountId: "ops",
       replyToId: "900",
@@ -91,6 +96,7 @@ describe("telegramOutbound", () => {
       silent: undefined,
       gatewayClientScopes: undefined,
       mediaUrl: "/tmp/image.png",
+      mediaAccess,
       mediaLocalRoots: ["/tmp/agent-root"],
       mediaReadFile: undefined,
       forceDocument: false,

--- a/extensions/telegram/src/outbound-adapter.ts
+++ b/extensions/telegram/src/outbound-adapter.ts
@@ -332,6 +332,7 @@ export function createTelegramOutboundAdapter(
         return await send(outboundTo, params.text, {
           ...baseOpts,
           mediaUrl: params.mediaUrl,
+          ...(params.mediaAccess !== undefined ? { mediaAccess: params.mediaAccess } : {}),
           mediaLocalRoots: params.mediaLocalRoots,
           mediaReadFile: params.mediaReadFile,
           forceDocument: params.forceDocument ?? false,
@@ -351,6 +352,7 @@ export function createTelegramOutboundAdapter(
         payload: params.payload,
         baseOpts: {
           ...baseOpts,
+          ...(params.mediaAccess !== undefined ? { mediaAccess: params.mediaAccess } : {}),
           mediaLocalRoots: params.mediaLocalRoots,
           mediaReadFile: params.mediaReadFile,
           forceDocument: params.forceDocument ?? false,

--- a/extensions/telegram/src/send.test.ts
+++ b/extensions/telegram/src/send.test.ts
@@ -2766,6 +2766,10 @@ describe("sendMessageTelegram", () => {
 
   it("defaults outbound media uploads to 100MB", async () => {
     const chatId = "123";
+    const mediaAccess = {
+      localRoots: ["/tmp/agent-root"],
+      workspaceDir: "/tmp/agent-root/workspace",
+    };
     const sendPhoto = vi.fn().mockResolvedValue({
       message_id: 60,
       chat: { id: chatId },
@@ -2784,15 +2788,19 @@ describe("sendMessageTelegram", () => {
       cfg: TELEGRAM_TEST_CFG,
       token: "tok",
       api,
-      mediaUrl: "https://example.com/photo.jpg",
+      mediaUrl: "chart.png",
+      mediaAccess,
     });
 
     const [mediaUrl, options] = requireMockCall(
       firstMockCall(loadWebMedia, "loadWebMedia call"),
       "load web media call",
     );
-    expect(mediaUrl).toBe("https://example.com/photo.jpg");
-    expect(requireRecord(options, "load web media options").maxBytes).toBe(100 * 1024 * 1024);
+    expect(mediaUrl).toBe("chart.png");
+    const loadOptions = requireRecord(options, "load web media options");
+    expect(loadOptions.maxBytes).toBe(100 * 1024 * 1024);
+    expect(loadOptions.localRoots).toEqual(mediaAccess.localRoots);
+    expect(loadOptions.workspaceDir).toBe(mediaAccess.workspaceDir);
   });
 
   it("uses configured telegram mediaMaxMb for outbound uploads", async () => {

--- a/extensions/telegram/src/send.ts
+++ b/extensions/telegram/src/send.ts
@@ -7,6 +7,7 @@ import type { MarkdownTableMode, ReplyToMode } from "openclaw/plugin-sdk/config-
 import { isDiagnosticFlagEnabled } from "openclaw/plugin-sdk/diagnostic-runtime";
 import { formatUncaughtError } from "openclaw/plugin-sdk/error-runtime";
 import { redactSensitiveText } from "openclaw/plugin-sdk/logging-core";
+import type { OutboundMediaAccess } from "openclaw/plugin-sdk/media-runtime";
 import { parseStrictInteger } from "openclaw/plugin-sdk/number-runtime";
 import { resolveChunkMode, resolveTextChunkLimit } from "openclaw/plugin-sdk/reply-chunking";
 import { createTelegramRetryRunner, type RetryConfig } from "openclaw/plugin-sdk/retry-runtime";
@@ -101,6 +102,7 @@ type TelegramSendOpts = {
   accountId?: string;
   verbose?: boolean;
   mediaUrl?: string;
+  mediaAccess?: OutboundMediaAccess;
   mediaLocalRoots?: readonly string[];
   mediaReadFile?: (filePath: string) => Promise<Buffer>;
   gatewayClientScopes?: readonly string[];
@@ -1040,6 +1042,7 @@ export async function sendMessageTelegram(
       mediaUrl,
       buildOutboundMediaLoadOptions({
         maxBytes: mediaMaxBytes,
+        mediaAccess: opts.mediaAccess,
         mediaLocalRoots: opts.mediaLocalRoots,
         mediaReadFile: opts.mediaReadFile,
         optimizeImages: opts.forceDocument ? false : undefined,

--- a/src/gateway/server-methods/send.test.ts
+++ b/src/gateway/server-methods/send.test.ts
@@ -84,6 +84,7 @@ vi.mock("../../agents/agent-scope.js", () => ({
     agentId?: string;
   }) => resolveAgentIdFromSessionKeyForTests({ sessionKey }),
   resolveDefaultAgentId: () => "main",
+  resolveAgentConfig: () => undefined,
   resolveAgentWorkspaceDir: () => TEST_AGENT_WORKSPACE,
 }));
 
@@ -2579,8 +2580,8 @@ describe("gateway send mirroring", () => {
         isConfigured: () => true,
       },
       actions: {
-        describeMessageTool: () => ({ actions: ["sendAttachment"] }),
-        supportsAction: ({ action }) => action === "sendAttachment",
+        describeMessageTool: () => ({ actions: ["send"] }),
+        supportsAction: ({ action }) => action === "send",
         handleAction: async () => jsonResult({ ok: true }),
       },
     };
@@ -2593,7 +2594,7 @@ describe("gateway send mirroring", () => {
     const { respond } = await runMessageActionRequest(
       {
         channel: "telegram",
-        action: "sendAttachment",
+        action: "send",
         params: { chatId: "123", mediaUrl: `${TEST_AGENT_WORKSPACE}/render.png` },
         agentId: "work",
         idempotencyKey: "idem-message-action-media-roots",
@@ -2604,6 +2605,10 @@ describe("gateway send mirroring", () => {
     expect(firstRespondCall(respond)[0]).toBe(true);
     const actionCall = lastDispatchChannelMessageActionCall();
     expect(actionCall?.mediaLocalRoots).toContain(TEST_AGENT_WORKSPACE);
+    expect(actionCall?.mediaAccess).toMatchObject({
+      localRoots: expect.arrayContaining([TEST_AGENT_WORKSPACE]),
+      workspaceDir: TEST_AGENT_WORKSPACE,
+    });
     expect(actionCall?.gatewayClientScopes).toEqual(["operator.write"]);
   });
 

--- a/src/gateway/server-methods/send.ts
+++ b/src/gateway/server-methods/send.ts
@@ -43,6 +43,7 @@ import { mirrorDeliveredSourceReplyToTranscript } from "../../infra/outbound/sou
 import { maybeResolveIdLikeTarget } from "../../infra/outbound/target-resolver.js";
 import { resolveOutboundTarget } from "../../infra/outbound/targets.js";
 import { getAgentScopedMediaLocalRoots } from "../../media/local-roots.js";
+import { resolveAgentScopedOutboundMediaAccess } from "../../media/read-capability.js";
 import { extractToolPayload } from "../../plugin-sdk/tool-payload.js";
 import {
   getPluginRuntimeGatewayRequestScope,
@@ -548,6 +549,26 @@ export const sendHandlers: GatewayRequestHandlers = {
           normalizeOptionalString(request.agentId) ??
           (sessionKey ? resolveSessionAgentId({ sessionKey, config: cfg }) : undefined);
         const accountId = normalizeOptionalString(request.accountId) ?? undefined;
+        const resolvedMediaAccess =
+          request.action === "send"
+            ? resolveAgentScopedOutboundMediaAccess({
+                cfg,
+                agentId,
+                sessionKey,
+                messageProvider: sessionKey ? undefined : channel,
+                accountId,
+              })
+            : undefined;
+        // Gateway identities omit trusted sender aliases; expose roots/workspace
+        // only so a host reader cannot bypass alias-based group read policy.
+        const mediaAccess = resolvedMediaAccess
+          ? {
+              localRoots: resolvedMediaAccess.localRoots,
+              ...(resolvedMediaAccess.workspaceDir
+                ? { workspaceDir: resolvedMediaAccess.workspaceDir }
+                : {}),
+            }
+          : undefined;
         if (request.action === "send") {
           await hydrateAttachmentParamsForAction({
             cfg,
@@ -555,9 +576,11 @@ export const sendHandlers: GatewayRequestHandlers = {
             accountId,
             args: request.params,
             action: "send",
-            mediaPolicy: resolveAttachmentMediaPolicy({
-              mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, agentId),
-            }),
+            mediaPolicy: resolveAttachmentMediaPolicy(
+              mediaAccess
+                ? { mediaAccess, mediaLocalRoots: mediaAccess.localRoots }
+                : { mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, agentId) },
+            ),
           });
         }
         const gatewayClientScopes = client?.connect?.scopes ?? [];
@@ -599,7 +622,9 @@ export const sendHandlers: GatewayRequestHandlers = {
               sessionId: normalizeOptionalString(request.sessionId) ?? undefined,
               inboundEventKind: request.inboundTurnKind,
               agentId,
-              mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, agentId),
+              ...(mediaAccess
+                ? { mediaAccess, mediaLocalRoots: mediaAccess.localRoots }
+                : { mediaLocalRoots: getAgentScopedMediaLocalRoots(cfg, agentId) }),
               toolContext: request.toolContext,
               dryRun: false,
               gatewayClientScopes: dispatchGatewayClientScopes,


### PR DESCRIPTION
## Summary

- backport the gateway-owned agent-scoped outbound media policy
- pass the prepared media access contract through Telegram and Matrix action runtimes
- restore workspace-relative plugin message attachments without widening arbitrary local-file access

## Root cause

The 2026.6.35 candidate's Gateway resolved local media through account roots only. Plugin message actions therefore lost the authoritative agent workspace root before reaching Telegram/Matrix, while direct sends succeeded.

## Verification

- red before fix: Gateway plugin `send` action rejects a workspace-relative attachment as missing
- green after fix: affected Gateway, Telegram, and Matrix action tests (249 passed), then the final Telegram downstream regression suite (270/270)
- relevant sibling action suites, type-aware OXLint, Oxfmt, and `git diff --check`
- exact-head autoreview: correct (0.94), no actionable findings

## Scope

Production +56/-10; tests +64/-9. No config, schema, protocol, or dependency changes.
