### PR TITLE
docs: avoid a redundant release qualification pass

### DIFF
--- a/.agents/skills/openclaw-changelog-update/SKILL.md
+++ b/.agents/skills/openclaw-changelog-update/SKILL.md
@@ -6,7 +6,10 @@ description: Regenerate OpenClaw release changelog sections from git history bef
 # OpenClaw Changelog Update
 
 Use this for changelog rewrites and GitHub release-note source text. For regular
-beta/stable, run it after the Code SHA passes Full Release Validation. For
+beta/stable, prepare complete notes before final-source qualification when
+possible; Code SHA may then also be Release SHA. Editorial work may overlap
+Code validation. If notes change afterward, a genuine CHANGELOG-only descendant
+may use the existing product-evidence reuse policy. For
 extended-stable, run it before final exact-head validation and tagging. Do not
 rerun it for tooling retries, resumed publication, or promotion.
 Use it with `release-openclaw-maintainer`; this skill owns changelog content,
@@ -27,8 +30,11 @@ every human `Thanks @...` attribution.
   the target; a newer but divergent tag is not a valid history boundary. Use
   an explicit shipped/main-closeout SHA only when it is also reachable from the
   target.
-- Target ref: the exact green Code SHA. The changelog commit created from this
-  input becomes the Release SHA.
+- Target ref: the exact product-complete history being documented. Its
+  contribution-record target must be an ancestor of the final release target;
+  it need not name a not-yet-created changelog commit. Include any later fixes
+  before finalizing notes. Final notes may be committed before qualification,
+  or afterward as a CHANGELOG-only descendant of a green Code SHA.
 - Canonical main ref: current `origin/main`, fetched before verification. Release
   notes cite the original merged main PR when the same work is carried by a
   backport. A release-branch PR is used only while no forward-port exists on
@@ -36,12 +42,12 @@ every human `Thanks @...` attribution.
 
 ## Workflow
 
-1. Confirm the release branch is at the fully validated Code SHA:
+1. Confirm the release branch and exact history target:
    - `git fetch --tags origin`
    - confirm clean `git status -sb`
-   - record `git rev-parse HEAD` as the Code SHA
-   - record the successful Full Release Validation run id and attempt
-   - stop if any product/version/backport change is still pending
+   - record `git rev-parse HEAD` as the history target
+   - record the Full Release Validation run id and attempt when qualification already exists
+   - finish pending product/version/backport changes before freezing final source; refresh the inventory for actual changes
 2. Audit history, including direct commits:
    - `git log --topo-order --date=iso-strict --pretty=format:'%h%x09%ad%x09%s' <base-tag>..<target-ref>`
    - `git log --topo-order --grep='(#' --date=short --pretty=format:'%h%x09%ad%x09%s' <base-tag>..<target-ref>`
@@ -259,18 +265,20 @@ every human `Thanks @...` attribution.
   the immutable attached release evidence; never compact a fitting full
   contribution record just to preserve the optional tail
 - `pnpm release:candidate` performs this deterministic render check from the
-  exact tag before it dispatches Full Release Validation, including when local
+  exact target before it dispatches Full Release Validation, including when local
   generated checks are explicitly skipped
 - `git diff --check`
 - for docs/changelog-only changes, no broad tests are required
 - stage `CHANGELOG.md` and commit with `git commit -m "docs(changelog): refresh YYYY.M.PATCH notes"`
-- record the new commit as the Release SHA and require
-  `git diff --name-only <code-sha>..<release-sha>` to print only
-  `CHANGELOG.md`
 - push the release branch without rebasing it onto moving `main`
-- dispatch SHA-pinned Full Release Validation for the Release SHA with evidence
-  reuse enabled. It must select `changelog-only-release-v1`; any other changed
-  path returns the release to the Code SHA validation loop
+- when all fixes and final notes are committed before fresh full qualification,
+  record that commit as both Code SHA and Release SHA; use the same successful
+  full parent/attempt and its exact publication bytes for both roles
+- only when notes change after Code qualification, require
+  `git diff --name-only <code-sha>..<release-sha>` to print exactly
+  `CHANGELOG.md` before optionally using `changelog-only-release-v1`. That path
+  retains green Code proof and qualifies new Release SHA package bytes. Any
+  other changed path requires fresh product qualification
 
 ## Extended-Stable Variant
 

--- a/.agents/skills/release-openclaw-ci/SKILL.md
+++ b/.agents/skills/release-openclaw-ci/SKILL.md
@@ -114,10 +114,11 @@ Use this with `$release-openclaw-maintainer` and `$openclaw-testing` when a rele
 - Use one release operator, one transition-only watcher, and at most one
   investigator for the current failed surface. Do not build audit-review-plan
   trees around a single workflow transition.
-- For regular beta/stable releases, treat the product-complete pre-changelog
-  commit as the Code SHA. Full product validation and performance evidence bind
-  to that SHA. The later Release SHA may reuse those results only when it is a
-  descendant whose complete changed path set is exactly `CHANGELOG.md`.
+- For regular beta/stable releases, Code SHA may already contain final notes
+  and serve as Release SHA. One successful fresh full parent may qualify both
+  roles and their exact publication bytes. If notes change afterward, a later
+  Release SHA may reuse product evidence only when its complete delta from
+  Code SHA is exactly `CHANGELOG.md`; its changed bytes still need qualification.
 - Extended-stable validates one exact branch tip; it does not reuse the regular
   Code-SHA/Release-SHA evidence model.
 - In a sparse worktree or Testbox source sync, first confirm `package.json`,
@@ -148,7 +149,8 @@ Use this with `$release-openclaw-maintainer` and `$openclaw-testing` when a rele
 
 Record Validation SHA, Tooling SHA/ref, target context ref, parent run id,
 attempt, and phase before watching or recovering Full Release Validation. Keep
-Code SHA and Release SHA separately in the lifecycle ledger. Record the
+Code SHA and Release SHA as lifecycle roles in the ledger; they may name the
+same commit. Record the
 immutable Release Publish parent receipt separately from tag provenance.
 
 For the core and plugin npm mutations enforced by this foundation, re-read the
@@ -340,8 +342,13 @@ enabled after proving the workflow commit is still on trusted `main` lineage.
 Pass `-f reuse_evidence=false` only when the operator intentionally needs a
 fresh full run.
 
-After the Code SHA is green, commit only `CHANGELOG.md` and run the same helper
-against the Release SHA. The parent must report
+If final notes were already committed before fresh full qualification, retain
+that Code SHA as Release SHA and use the same successful parent/attempt and
+its exact prepared bytes for candidate and publication checks. Required gates,
+final channel-specific SDK review and acknowledgement still apply.
+
+Only if notes change after qualification, commit exactly `CHANGELOG.md` and
+optionally run the helper against the new Release SHA with reuse. That parent must report
 `policy=changelog-only-release-v1`, `evidenceSha=<code-sha>`, and
 `changedPaths=["CHANGELOG.md"]`; it should reuse the product matrix instead of
 dispatching child lanes. Npm preflight and package/install acceptance still run

--- a/.agents/skills/release-openclaw-maintainer/SKILL.md
+++ b/.agents/skills/release-openclaw-maintainer/SKILL.md
@@ -51,11 +51,14 @@ successful child artifacts, approved changes, phase and next action. Latest
 operator steering replaces superseded scope. Completed evidence stays complete
 until a named change invalidates it.
 
-For regular releases, freeze product-complete **Code SHA** before generating
-the changelog. Require its Full Release Validation decision, then create
-**Release SHA** with a complete delta of exactly `CHANGELOG.md`. The
-`changelog-only-release-v1` policy reuses product proof while qualifying fresh
-publication bytes. Any other source delta returns to the Code SHA loop.
+For regular releases, prepare complete notes before freezing **Code SHA** when
+possible. If those notes are final, **Code SHA and Release SHA are the same
+commit**: one successful fresh full qualification can supply both roles and
+their exact publication bytes. Do not create another commit or run solely to
+separate the labels. If notes change after qualification, a descendant whose
+complete delta is exactly `CHANGELOG.md` may use `changelog-only-release-v1`
+to reuse product proof while qualifying new publication bytes. Any other
+source delta returns to the Code SHA loop.
 Keep trusted **Tooling SHA** separate; tooling or infrastructure failures do
 not justify changing the candidate.
 

--- a/.agents/skills/release-openclaw-maintainer/references/preparation.md
+++ b/.agents/skills/release-openclaw-maintainer/references/preparation.md
@@ -71,23 +71,29 @@ For records whose `warningStarts` or `removeAfter` falls within seven days of
 release, include Upcoming deprecations with code, date, replacement and
 `docsPath` (or `/plugins/compatibility`).
 
-Freeze the product-complete tree, including approved versions and fixes but no
-new release changelog, as **Code SHA**. After this point admit only confirmed
+Freeze the product-complete tree, including approved versions, fixes and
+complete release notes, as **Code SHA**. If the notes are final, this is also
+**Release SHA**. After this point admit only confirmed
 product, package/provenance, security, or publication-blocking defects; defer
-adjacent improvements. Validate that Code SHA before changelog work.
+adjacent improvements. Validate that exact source and its publication bytes.
 
 ## Changelog and release notes
 
 Use `$openclaw-changelog-update` for source-history inventory, human credit,
-editorial grouping, renderer limits, and verification. Generate once after
-Code SHA passes; same-candidate retries reuse it. Beta notes use the stable-base
+editorial grouping, renderer limits, and verification. Generate the complete
+history manifest and notes during preparation; editorial work may overlap
+Code validation. Refresh them for actual source changes, not tooling retries.
+Beta notes use the stable-base
 `## YYYY.M.PATCH` section, with Highlights, Changes and Fixes. Canonical PR
 provenance follows current `origin/main`; retain a release-branch PR only while
 its change has not been forward-ported. Do not change root README as routine
 release prep or prefill a future changelog section.
 
-Commit only the release changelog to create **Release SHA**. Its complete diff
-from Code SHA must be exactly `CHANGELOG.md`; otherwise reenter product
-validation. Use the canonical release-note renderer and verifier before
+When final notes were already included in the qualified Code SHA, retain that
+same commit as Release SHA. If notes change afterward, commit only the release
+changelog and optionally reuse Code evidence: the complete Code-to-Release
+diff must be exactly `CHANGELOG.md`, with fresh qualification of the changed
+package bytes. Any other delta reenters product validation. Use the canonical
+release-note renderer and verifier before
 publication and closeout. The publish workflow owns GitHub page finalization
 only after postpublish evidence succeeds.

--- a/.agents/skills/release-openclaw-maintainer/references/regular-release.md
+++ b/.agents/skills/release-openclaw-maintainer/references/regular-release.md
@@ -3,7 +3,8 @@
 ## Freeze and validate code
 
 Read [preparation](preparation.md) before branch or version changes. Record the
-approved version, cut SHA, release branch and product-complete Code SHA. Use
+approved version, cut SHA, release branch and product-complete Code SHA,
+including final notes when ready. Code SHA may also be the Release SHA. Use
 [validation](validation.md) to select phase-specific gates and
 `$release-openclaw-ci` for dispatch/recovery.
 
@@ -30,13 +31,21 @@ proven infrastructure noise.
 
 ## Qualify publication bytes
 
-After Code SHA is green, run `$openclaw-changelog-update` once using current
-main for canonical PR provenance. Commit only `CHANGELOG.md` as Release SHA;
-verify the complete Code-to-Release delta is exactly that file.
+If Code SHA already contains fully final notes, use the same successful fresh
+Full Release Validation parent and attempt for Code and Release qualification.
+Its exact npm/OCI descriptors must belong to that SHA and satisfy the selected
+release profile's required gates. No second commit or validation run is needed
+solely to name a Release SHA.
 
-Dispatch Full Release Validation for Release SHA with evidence reuse. Require
-`changelog-only-release-v1`, green Code SHA product evidence, and fresh exact
-Release SHA npm qualification/Docker preparation. Final SDK reports cover both
+If notes change after Code qualification, use `$openclaw-changelog-update`
+with current main for canonical PR provenance and commit only `CHANGELOG.md`.
+The complete Code-to-Release delta must be exactly that file to optionally use
+`changelog-only-release-v1`. That path requires green Code product evidence
+and fresh Release SHA npm qualification/Docker preparation; it does not reuse
+the earlier package bytes. Any other source change requires fresh product
+qualification.
+
+For either path, final SDK reports cover both
 beta and latest; publication selects the appropriate one. Run release-note,
 package/install/update acceptance against these exact prepared bytes.
 

--- a/.agents/skills/release-openclaw-maintainer/references/validation.md
+++ b/.agents/skills/release-openclaw-maintainer/references/validation.md
@@ -22,9 +22,11 @@ pnpm test:install:smoke
 Use existing equivalent exact-SHA release evidence; do not repeat successful
 checks solely because this list mentions them. Required source CI includes
 `pnpm check` and `pnpm check:test-types`. Root Dockerfile/install-smoke and Linux
-cross-OS proof must pass on Code SHA before changelog or tagging. Release SHA
-reuses product evidence only through the exact changelog-only policy and still
-qualifies its changed package bytes.
+cross-OS proof must pass before tagging. Code SHA and Release SHA may be the
+same commit when it contains final notes; the same successful full parent
+qualifies that source and its exact publication bytes. Only a later
+CHANGELOG-only descendant may reuse earlier product evidence through the
+changelog-only policy, while qualifying its changed package bytes.
 
 `release:fast-pretag-check` protects package-root README, plugin-local runtime,
 and npm/ClawHub metadata contracts. Fix real packaging defects before tagging.

--- a/docs/reference/RELEASING.md
+++ b/docs/reference/RELEASING.md
@@ -230,11 +230,11 @@ For beta, stable, and full profiles, Linux (`ubuntu`) cross-OS lanes gate npm pu
 
 1. Start from current `main`: pull latest, confirm the target commit is pushed, and confirm `main` CI is green enough to branch from.
 2. Create `release/YYYY.M.PATCH` from that commit. Backports are optional; apply only the operator-selected set. Bump every required version location, run `pnpm release:prep`, finish release fixes and required forward-ports, and review `src/plugins/compat/registry.ts` plus `src/commands/doctor/shared/deprecation-compat.ts`.
-3. Freeze the product-complete pre-changelog commit and target context as the **Code SHA/ref**, and record the trusted **Tooling SHA/ref**. Run the deterministic source preflight, then use `node scripts/full-release-validation-at-sha.mjs --sha <code-sha> --target-ref release/YYYY.M.PATCH --workflow-sha <tooling-sha>`. Reuse those exact identities for later release validation; never refresh the tooling from moving `main`. Beta-publish uses `release_profile=beta` without soak; postpublish-confidence owns broad live, QA-live, mobile, and Parallels work.
+3. Prepare the complete history manifest and release notes, then freeze the product-complete commit and target context as the **Code SHA/ref**, and record the trusted **Tooling SHA/ref**. Run the deterministic source preflight, then use `node scripts/full-release-validation-at-sha.mjs --sha <code-sha> --target-ref release/YYYY.M.PATCH --workflow-sha <tooling-sha>`. Reuse those exact identities for later release validation; never refresh the tooling from moving `main`. Beta-publish uses `release_profile=beta` without soak; postpublish-confidence owns broad live, QA-live, mobile, and Parallels work.
 4. Classify failures before editing as product, harness/tooling/provenance, infrastructure/credential, or wrapper. Only confirmed product failure creates a new Code SHA. Use one diagnosis, one fix when needed, and one narrow retry, then reassess.
-5. Only after the Code SHA is green, generate the top `CHANGELOG.md` section from merged PRs and direct commits since the last reachable shipped tag. Keep entries user-facing and deduplicated. When a divergent shipped tag or later forward-port re-associates already-released PRs, pass it explicitly as `--shipped-ref`.
-6. Commit only `CHANGELOG.md`. This commit is the **Release SHA**. The complete diff from Code SHA to Release SHA must be exactly `CHANGELOG.md`; any other changed path returns the release to step 2.
-7. Run SHA-pinned Full Release Validation for the Release SHA with evidence reuse enabled. The parent must record `changelog-only-release-v1`, point at the green Code SHA, and dispatch no product child lanes. Its package and Docker preparation still run against the final Release SHA. This reuses product evidence; it does not reuse earlier package or image bytes. Regular final artifacts include SDK reports for both npm `beta` and `latest`, sharing the target snapshot; review the report and 8-character acknowledgement for the channel you will publish.
+5. Keep the top `CHANGELOG.md` section complete, user-facing and deduplicated, covering merged PRs and direct commits since the last reachable shipped tag. The full manifest and editorial pass may overlap Code validation. When a divergent shipped tag or later forward-port re-associates already-released PRs, pass it explicitly as `--shipped-ref`. A contribution-record target may be an ancestor of the final target; include later fixes honestly rather than inventing a self-referential SHA.
+6. If the qualified Code SHA already contains fully final notes, use that same commit as **Release SHA**. One successful fresh full qualification can supply both lifecycle roles and their exact publication bytes; do not create another commit or run solely to separate the labels. If notes change after qualification, commit only `CHANGELOG.md` as a new Release SHA. Any other changed path returns the release to step 2.
+7. When Code SHA equals Release SHA, retain its successful full validation parent and exact prepared npm/OCI descriptors. Only for a later genuine CHANGELOG-only descendant, optionally run SHA-pinned Full Release Validation with evidence reuse: the complete delta must be exactly `CHANGELOG.md`, and the parent must record `changelog-only-release-v1`, point at green Code evidence, and dispatch no product child lanes. That path still prepares and qualifies new Release SHA package/image bytes. Either path must satisfy every required profile gate. Regular final artifacts include SDK reports for both npm `beta` and `latest`; review the report and 8-character acknowledgement for the channel you will publish.
 8. Save that successful Full Release Validation run as both the validation run and `preflight_run_id`. Its read-only npm workflow builds and packs the root/core packages once, checks source in parallel, and qualifies the exact bytes with the final changelog. Docker images build in parallel and are preserved for later promotion. Review the **Plugin SDK API diff** summary. If it reports changes, inspect the readable diff (also uploaded as `plugin-sdk-api-release-diff-<run-id>-<run-attempt>`) and record the 8-character acknowledgement digest printed by the report; omit the acknowledgement when it reports no Plugin SDK API changes. Standalone `OpenClaw NPM Release` with `preflight_only=true` remains available for focused preflight and recovery.
 
    Prepared packing reuses the exact preflight build while retaining package smoke checks, inventory generation, docs and changelog preparation, and source restoration. Ordinary source packing still performs a clean package build.
@@ -415,7 +415,9 @@ tag-to-SHA mapping and exact parent run tuple authorize the npm mutations
 enforced by this foundation even if `main` has advanced. Other privileged
 writers remain blocked until their dependent enforcement changes land.
 
-After the Code SHA is green, commit only `CHANGELOG.md` and run the same helper with the Release SHA:
+If the fresh qualified commit already contains final notes, Code SHA and Release SHA are identical. Use that same successful parent/attempt and its exact prepared bytes for candidate and publication checks, including the final channel-specific SDK report and required acknowledgement. No second commit or FRV is required merely to name a Release SHA.
+
+If notes change afterward, commit only `CHANGELOG.md` and optionally run the same helper with the new Release SHA:
 
 ```bash
 TOOLING_SHA="<same-recorded-tooling-sha>"
@@ -425,7 +427,7 @@ pnpm ci:full-release \
   --workflow-sha "$TOOLING_SHA"
 ```
 
-The second parent reuses product evidence only when GitHub proves the Release SHA descends from the Code SHA and the complete changed path set is exactly `CHANGELOG.md`. It records `changelog-only-release-v1` and dispatches no product children. Npm preflight and package/install acceptance still run on the Release SHA because its tarball bytes changed.
+This optional second parent reuses product evidence only when GitHub proves the Release SHA descends from the Code SHA and the complete changed path set is exactly `CHANGELOG.md`. It records `changelog-only-release-v1` and dispatches no product children. Npm preflight and package/install acceptance still run on the Release SHA because its tarball bytes changed.
 
 For a fresh Code SHA, the workflow resolves the target, dispatches manual `CI`, then dispatches `OpenClaw Release Checks`. Beta-publish maps to `release_profile=beta` and `run_release_soak=false`. An `all` run for an actual beta package on its matching canonical release branch or beta tag records `coveragePolicy=npm-beta-v1`: Linux/macOS/Windows Node, Control UI, plugin, package, Linux cross-OS, and QA parity/runtime/restart/tool gates remain; Windows/macOS cross-OS outcomes are advisory; native apps, performance, and published-package Telegram confidence are deferred. Beta `all` without soak also defers broad live/E2E, QA-live, and Package Acceptance Telegram. Postpublish-confidence uses the exact published package with soak or explicit focused groups. Stable-publish maps to `release_profile=stable`. The final verifier summary includes slowest-job tables for each selected child run.
 
@@ -474,13 +476,13 @@ Use these variants depending on release stage:
 ```bash
 TOOLING_SHA="<recorded-full-main-ancestor-sha>"
 
-# Validate the product-complete Code SHA.
+# Validate the product-complete Code SHA; final notes let this also be Release SHA.
 pnpm ci:full-release \
   --sha <code-sha> \
   --target-ref release/YYYY.M.PATCH \
   --workflow-sha "$TOOLING_SHA"
 
-# Validate the changelog-only Release SHA by reusing Code SHA product evidence.
+# Optional: only after a later CHANGELOG-only edit, reuse the green Code proof.
 pnpm ci:full-release \
   --sha <release-sha> \
   --target-ref release/YYYY.M.PATCH \
@@ -503,7 +505,7 @@ Do not use the full umbrella as the first rerun after a focused fix. Classify th
 coverage policy, effective soak setting, and validation inputs match and either the target SHA
 is identical or the new target is a descendant whose complete changed path set
 is exactly `CHANGELOG.md`. Exact-target reuse records
-`exact-target-full-validation-v1`; the post-validation Release SHA records
+`exact-target-full-validation-v1`; an optional CHANGELOG-only descendant records
 `changelog-only-release-v1`. The latter reuses only product validation. Npm
 preflight, package bytes, release-note provenance, and install/update acceptance
 must still run against the Release SHA. Any version, source, generated,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where release instructions required a second changelog commit and qualification run even when the fully qualified source already contained final release notes.

## Why This Change Was Made

Align the release maintainer, CI, changelog skill, and release reference with the supported Code SHA == Release SHA path. A later genuine CHANGELOG-only edit may still reuse green product evidence while qualifying its new publication bytes.

## User Impact

Release maintainers can use one successful full parent/attempt and its exact prepared bytes when the notes were final before qualification. Required profile gates, source provenance, final channel-specific SDK review and acknowledgement, and publication authority remain unchanged. This does not promise every release will take one pass.

## Evidence

- Docs-only `check:changed`, docs inventory, formatting, and diff checks passed.
- Fresh independent P2 review: no actionable findings.
- Source audit: fresh evidence has no required reuse chain; candidate, npm, Docker, and publication validators bind the final target to its successful full parent and exact artifacts without requiring two distinct lifecycle SHAs.
- Documentation only; no runtime, workflow, release version, or artifact changes.

<details>
<summary>Additional instructions</summary>

The branch is in the repository, so maintainers retain normal repository edit access.

</details>
