### PR TITLE
perf(gateway): skip absent pin checks in session lists

### DIFF
--- a/src/gateway/session-list-order.ts
+++ b/src/gateway/session-list-order.ts
@@ -14,8 +14,10 @@ function compareSessionEntryPairs(
   sortBy: SessionsListParams["sortBy"] = "updatedAt",
 ): number {
   if (sortBy !== "lastInteractionAt") {
-    const aPinnedAt = isPinnableSessionEntry(a[0], a[1]) ? (a[1]?.pinnedAt ?? 0) : 0;
-    const bPinnedAt = isPinnableSessionEntry(b[0], b[1]) ? (b[1]?.pinnedAt ?? 0) : 0;
+    const aPinnedAt =
+      a[1]?.pinnedAt !== undefined && isPinnableSessionEntry(a[0], a[1]) ? (a[1].pinnedAt ?? 0) : 0;
+    const bPinnedAt =
+      b[1]?.pinnedAt !== undefined && isPinnableSessionEntry(b[0], b[1]) ? (b[1].pinnedAt ?? 0) : 0;
     if (aPinnedAt !== bPinnedAt) {
       return bPinnedAt - aPinnedAt;
     }

--- a/src/gateway/session-utils-row.ts
+++ b/src/gateway/session-utils-row.ts
@@ -194,7 +194,10 @@ export function buildGatewaySessionRow(params: {
         params.storeChildSessionsByKey.get(key),
       )
     : resolveChildSessionKeys(key, store, now, rowContext?.subagentRuns);
-  const pinnedAt = isPinnableSessionEntry(key, entry) ? entry?.pinnedAt : undefined;
+  const pinnedAt =
+    entry?.pinnedAt !== undefined && isPinnableSessionEntry(key, entry)
+      ? entry.pinnedAt
+      : undefined;
   const compactionCheckpoints = resolveProjectableCompactionCheckpoints(entry);
   const compactionCheckpointCount = Array.isArray(entry?.compactionCheckpoints)
     ? compactionCheckpoints.length

--- a/src/gateway/session-utils.single-row-cache.test.ts
+++ b/src/gateway/session-utils.single-row-cache.test.ts
@@ -348,12 +348,19 @@ describe("single gateway session row child projections", () => {
     await withSingleRowCacheStore(
       "openclaw-single-row-missing-store-",
       "/tmp/openclaw-single-row-missing-store",
-      async () => {
+      async ({ now }) => {
         const databasePath = resolveOpenClawAgentSqlitePath({ agentId: MAIN_AGENT_ID });
-        expect(loadSessionEntry("main", { clone: false }).entry).toBeUndefined();
+        const missing = loadSessionEntry("main", { clone: false });
+        expect(missing.entry).toBeUndefined();
         expect(existsSync(databasePath)).toBe(false);
         expect(loadSessionEntry("main").entry).toBeUndefined();
         expect(existsSync(databasePath)).toBe(true);
+        expect(
+          buildGatewaySessionInfo({ ...missing, key: missing.canonicalKey, now }),
+        ).toMatchObject({
+          pinned: false,
+          pinnedAt: undefined,
+        });
       },
     );
   });

--- a/src/gateway/session-utils.test.ts
+++ b/src/gateway/session-utils.test.ts
@@ -735,7 +735,7 @@ describe("gateway session utils", () => {
         "agent:main:dashboard:root": { sessionId: "root", updatedAt: 30 },
         [key]: { sessionId: "child", updatedAt: 10, pinnedAt: 40, ...lineage },
       };
-      for (const limit of [undefined, 2]) {
+      for (const limit of [2, 201]) {
         const listed = await listSessionFixture({ cfg, storePath: "", store, opts: { limit } });
         const child = listed.sessions.find((row) => row.key === key);
         expect.soft(child?.pinned).toBe(false);


### PR DESCRIPTION
Related: #140748

## What Problem This Solves

Large lists of unpinned sessions repeat child-session classification while sorting entries and preparing displayed rows. Those checks cannot affect an absent pin and add work to a frequent session-list request.

## Why This Change Was Made

Reuse the existing absent-pin guard at the two listing consumers. Entries with a pin still go through the unchanged root-only policy; mutation admission, sorting, filtering, paging and cache policy retain their current contracts.

## User Impact

Fresh metadata lists with 512–2,048 stored rows had 21–34% lower median response times in the paired test below, with the same results and pin behavior. The smallest 64-row/page-30 case was 0.44 ms slower; this is not a universal speedup claim.

## Evidence

A frozen common-base pair (`b1f07a0edeff` → `02a6ac142697`) ran on one fresh Linux Blacksmith Testbox. The published commit has the identical source tree to that measured candidate; only commit metadata differs. Both builds finished before timing; variant order alternated by state size. Each row below has ten fresh-list samples, timed to actual complete WebSocket response-frame receipt. No sample was removed.

| Stored rows | Page | Baseline median | Candidate median |
| ---: | ---: | ---: | ---: |
| 64 | 30 | 6.971 ms | 7.411 ms |
| 64 | 100 | 11.209 ms | 10.552 ms |
| 512 | 30 | 10.304 ms | 8.172 ms |
| 512 | 100 | 19.676 ms | 14.279 ms |
| 2048 | 30 | 20.366 ms | 15.262 ms |
| 2048 | 100 | 30.921 ms | 20.424 ms |

For the 2,048-row/page-100 shape, p90 decreased from 39.222 to 21.280 ms and maximum from 42.398 to 22.409 ms. The 64-row/page-30 candidate retained a 23.048 ms sample versus an 8.546 ms baseline maximum. These results cover sequential metadata requests, not concurrent turns or transcript-heavy sessions.

- Both revisions passed 446 tests across five focused files; candidate full changed-file checks and both full builds passed.
- All 460 request/response pairs, ordering/filter/paging/pin/error contracts, eight clean Gateway lifetimes and persisted state audits were independently verified. No admission holds occurred.
- Existing stale-child coverage now exercises limits 2 and 201, and the existing missing-store test verifies public projection of an undefined entry. No call-count test or new production test seam was added.
- P2 autoreview found no actionable issue; the later formatter-only correction was independently reviewed.
- Native Testbox command returned exit 0 ([hydration run](https://github.com/openclaw/openclaw/actions/runs/34178788952)). Complete raw artifacts were retained and hash-verified.

An earlier paired attempt stopped at formatting before any benchmark request; it remains recorded as failed. All reported timings come from the successful paired run.
