### PR TITLE
test: avoid idle connection stalls in webhook handoff probes

### DIFF
--- a/src/gateway/server-channels.test.ts
+++ b/src/gateway/server-channels.test.ts
@@ -2438,7 +2438,10 @@ describe("server-channels auto restart", () => {
       throw new Error("expected a TCP listener");
     }
     const read = async () => {
-      const response = await fetch(`http://127.0.0.1:${address.port}${route.path}`);
+      // Fake timers hold Undici's idle-socket validation; route handoff does not require reuse.
+      const response = await fetch(`http://127.0.0.1:${address.port}${route.path}`, {
+        headers: { Connection: "close" },
+      });
       return {
         status: response.status,
         retryAfter: response.headers.get("retry-after"),


### PR DESCRIPTION
## What Problem This Solves

The webhook handoff test can spend 12–24 seconds waiting for HTTP connections while exercising otherwise fast channel transitions.

## Why This Change Was Made

Its fake clock pauses Undici's zero-delay idle-socket validation. A queued fetch can then wait for the real server's six-second keep-alive timeout before reconnecting. Use `Connection: close`, following existing HTTP test fixtures, so each probe completes without waiting on idle reuse.

## User Impact

Faster test execution. Production behavior is unchanged. The same real Gateway HTTP handler, TCP requests, ten status/generation observations, channel lifecycle clock and cleanup assertions remain in place.

## Evidence

Both instrumented whole-file runs passed all 146 tests in their original order. Independent monotonic timing isolated two six-second waits between Undici request creation and connection setup; server close took 0.2ms. With the header, the target case fell from **12,032ms to 36ms**, and all ten accepted TCP connections were observed closed. Temporary diagnostics were removed. A separate normal run then passed all 146 tests: **36ms** for the target and **473ms** for the full file, versus **12,413ms** for the original instrumented file.

The preceding [main CI run](https://github.com/openclaw/openclaw/actions/runs/34178123801) reported **24,036ms** for this same case; adjacent completion timestamps independently confirm 24,035ms elapsed. These observations are from different environments; the exact-head CI result below provides additional corroboration.

The Node 24.19.0 bundled Undici and HTTP server implementations confirm the paused validation timer and 5s + 1s idle timeout. No dependencies, global dispatcher, production timeout, assertions or test inventory changed. Production LOC: zero; test diff: four additions and one deletion.

The required changed-file gate (gateway-root test types, targeted lint and guards) and independent P2 review passed.

Exact-head [CI passed in 5m46s](https://github.com/openclaw/openclaw/actions/runs/34181825725). All 146 case names and their order matched the prior main run. The target fell from **24,036ms to 44ms** and summed case time from **24,499ms to 383ms**. The changed-test runner detected two cores versus eight in the prior main job (both used two workers and Node 24.19.0); this is not a controlled whole-workflow comparison. Hosted lint controlled PR completion.

Post-merge [natural main CI passed in 7m38s](https://github.com/openclaw/openclaw/actions/runs/34182495898), with all 27 compact Node jobs green. On matching eight detected cores and two workers, all 146 names/order remained unchanged and the target took **33ms** versus **24,036ms** before. The critical Node job spent 310s testing, 35s building and 24s in setup; native-platform jobs were skipped. This confirms the fixture improvement without adding shards or changing coverage.
