### PR TITLE
refactor(e2e): use independent web-search fixtures

### DIFF
--- a/scripts/e2e/lib/openai-web-search-minimal/client.mjs
+++ b/scripts/e2e/lib/openai-web-search-minimal/client.mjs
@@ -177,9 +177,6 @@ if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
 }
 
 export const testing = {
-  DEFAULT_GATEWAY_SCHEMA_ERROR,
-  DEFAULT_RAW_SCHEMA_ERROR,
-  SUCCESS_MARKER,
   resolveGatewayPort,
   validateSuccessResult,
   validateRejectResult,

--- a/test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts
@@ -2,25 +2,29 @@
 import { describe, expect, it } from "vitest";
 import { testing } from "../../../../scripts/e2e/lib/openai-web-search-minimal/client.mjs";
 
+// Keep scenario defaults independent so changing the client cannot rewrite its expected inputs.
+const RAW_SCHEMA_ERROR =
+  "400 The following tools cannot be used with reasoning.effort 'minimal': web_search.";
+const GATEWAY_SCHEMA_ERROR = "provider rejected the request schema or tool payload";
+const SUCCESS_MARKER = "OPENCLAW_SCHEMA_E2E_OK";
+
 describe("scripts/e2e/lib/openai-web-search-minimal/client.mjs", () => {
   it("accepts only the expected raw schema rejection in reject mode", () => {
     expect(
       testing.validateRejectResult({
         ok: false,
-        error: new Error(`gateway failed: ${testing.DEFAULT_RAW_SCHEMA_ERROR}`),
+        error: new Error(`gateway failed: ${RAW_SCHEMA_ERROR}`),
       }),
-    ).toContain(testing.DEFAULT_RAW_SCHEMA_ERROR);
+    ).toContain(RAW_SCHEMA_ERROR);
   });
 
   it("accepts the gateway schema rejection wrapper in reject mode", () => {
     expect(
       testing.validateRejectResult({
         ok: false,
-        error: new Error(
-          `GatewayClientRequestError: FailoverError: ${testing.DEFAULT_GATEWAY_SCHEMA_ERROR}.`,
-        ),
+        error: new Error(`GatewayClientRequestError: FailoverError: ${GATEWAY_SCHEMA_ERROR}.`),
       }),
-    ).toContain(testing.DEFAULT_GATEWAY_SCHEMA_ERROR);
+    ).toContain(GATEWAY_SCHEMA_ERROR);
   });
 
   it("fails reject mode when the agent run unexpectedly succeeds", () => {
@@ -50,7 +54,7 @@ describe("scripts/e2e/lib/openai-web-search-minimal/client.mjs", () => {
       testing.validateSuccessResult({
         ok: true,
         value: {
-          meta: { finalAssistantVisibleText: `done: ${testing.SUCCESS_MARKER}` },
+          meta: { finalAssistantVisibleText: `done: ${SUCCESS_MARKER}` },
           status: "ok",
         },
       }),
@@ -62,7 +66,7 @@ describe("scripts/e2e/lib/openai-web-search-minimal/client.mjs", () => {
       testing.validateSuccessResult({
         ok: true,
         value: {
-          payloads: [{ text: testing.SUCCESS_MARKER }],
+          payloads: [{ text: SUCCESS_MARKER }],
           status: "ok",
         },
       }),
@@ -75,7 +79,7 @@ describe("scripts/e2e/lib/openai-web-search-minimal/client.mjs", () => {
         ok: true,
         value: {
           result: {
-            meta: { finalAssistantVisibleText: testing.SUCCESS_MARKER },
+            meta: { finalAssistantVisibleText: SUCCESS_MARKER },
             payloads: [{ text: "secondary reply" }],
           },
           status: "ok",
@@ -98,7 +102,7 @@ describe("scripts/e2e/lib/openai-web-search-minimal/client.mjs", () => {
       testing.validateSuccessResult({
         ok: true,
         value: {
-          payloads: [{ isError: true, text: testing.SUCCESS_MARKER }],
+          payloads: [{ isError: true, text: SUCCESS_MARKER }],
           status: "ok",
         },
       }),
@@ -110,7 +114,7 @@ describe("scripts/e2e/lib/openai-web-search-minimal/client.mjs", () => {
       testing.validateSuccessResult({
         ok: true,
         value: {
-          meta: { finalAssistantVisibleText: testing.SUCCESS_MARKER },
+          meta: { finalAssistantVisibleText: SUCCESS_MARKER },
           status: "blocked",
         },
       }),


### PR DESCRIPTION
## What Problem This Solves

The minimal web-search harness tests build expected errors and success replies from the client’s own constants. If a client default drifts away from the separate scenario/mock contract, the same change also rewrites the unit fixtures and can leave those tests green.

## Why This Change Was Made

Use independent fixtures for the scenario’s raw error and success marker and the Gateway’s schema-error wording, then remove those three constants from the test-only export object. Keep the validator functions, their optional inputs, and all existing scenarios and assertions.

Tooling: +0/-3 (net -3). Tests: +15/-11 (net +4), with all 11 cases retained.

## User Impact

No Gateway, provider, or harness runtime behavior changes. Maintainers get a default-drift check that cannot silently follow a changed client constant.

## Evidence

- Original suite: 11 passed, including with all three client defaults deliberately changed to unrelated nonempty strings.
- Updated fixtures under the same controlled drift: exactly five intended failures—the raw rejection, wrapped rejection, and three positive marker shapes. Six other cases still pass.
- Restored and formatted candidate: the same 11 cases pass. All temporary drift values are removed.
- Independent Codex review is clean through P2; formatting and diff checks pass.

The unchanged native test command performed its normal private QA runtime build before the baseline, then reused those prerequisites for subsequent runs. The validator checks did not invoke a Gateway, provider, mock server, or Docker scenario, so this is not a live OpenAI behavior claim.

```sh
node scripts/run-vitest.mjs test/e2e/qa-lab/runtime/openai-web-search-minimal.e2e.test.ts
```

All 17 normal changed-file checks passed on [Blacksmith Testbox](https://github.com/openclaw/openclaw/actions/runs/34181594233), including root-test TypeScript, scoped lint and structural guards. The one-shot lease, temporary source capsule and recorded processes are cleaned up, and the final source hashes are unchanged.
