### PR TITLE
fix(ci): provision ripgrep for filesystem contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1665,18 +1665,18 @@ jobs:
                   // current isolated and Docker catalogs exclude the Go owner.
                   return (plan.shard_name ?? plan.shardName).startsWith("core-tooling");
                 }),
-                requires_ripgrep:
-                  shard.targets?.includes("src/agents/sessions/tools/index.test.ts") ||
-                  shard.includePatterns?.includes("src/agents/sessions/tools/index.test.ts") ||
-                  (shard.shardName === "agentic-agents-support" && !shard.includePatterns) ||
-                  shard.groups?.some(
-                    (group) =>
-                      group.includePatterns?.includes(
-                        "src/agents/sessions/tools/index.test.ts",
-                      ) ||
-                      (group.shard_name === "agentic-agents-support" &&
-                        !group.includePatterns),
-                   ),
+                requires_ripgrep: (shard.groups ?? [shard]).some((plan) => {
+                  const patterns = plan.targets ?? plan.includePatterns;
+                  if (patterns) {
+                    return patterns.some((pattern) => [
+                      "src/agents/sessions/tools/index.test.ts",
+                      "src/agents/filesystem-tools-output-contract.test.ts",
+                    ].some((test) => matchesGlob(test, pattern)));
+                  }
+                  return ["agentic-agents-support", "agentic-agents-core-runtime"].includes(
+                    plan.shard_name ?? plan.shardName,
+                  );
+                }),
               };
             });
           const nodeTestNonDistShards = nodeTestShards.filter((shard) => !shard.requires_dist);

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -14678,6 +14678,59 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     ).toEqual(row.groups);
   });
 
+  it("provisions ripgrep for real filesystem contract selections", () => {
+    const contract = "src/agents/filesystem-tools-output-contract.test.ts";
+    const nativeTools = "src/agents/sessions/tools/index.test.ts";
+    const unrelated = "src/agents/run-wait.test.ts";
+    const selections = [
+      { targets: [contract] },
+      { includePatterns: [contract] },
+      { includePatterns: ["src/agents/filesystem-*.test.ts"] },
+      { targets: [nativeTools] },
+      { includePatterns: [unrelated] },
+      { shardName: "agentic-agents-core-runtime" },
+      { shardName: "agentic-agents-support" },
+      { shardName: "agentic-agents-core-runtime", includePatterns: [unrelated] },
+      { groups: [{ shard_name: "agentic-agents-core-runtime", includePatterns: [contract] }] },
+      { groups: [{ shard_name: "agentic-agents-support", includePatterns: [nativeTools] }] },
+      { groups: [{ shard_name: "agentic-agents-core-runtime", includePatterns: [unrelated] }] },
+      { groups: [{ shard_name: "agentic-agents-core-runtime" }] },
+    ];
+    const result = runCiManifestFixture({
+      bundledPlanner: true,
+      nodeTestShards: selections.map((selection, index) =>
+        Object.assign(
+          {
+            checkName: `grep-${index}`,
+            configs: ["test/vitest/vitest.agents-core.config.ts"],
+            requiresDist: false,
+            runner: "ubuntu-24.04",
+            shardName: "compact-small-1",
+          },
+          selection,
+        ),
+      ),
+    });
+    expect(result.status, result.output).toBe(0);
+    const matrix = JSON.parse(
+      expectDefined(result.outputs.checks_node_core_nondist_matrix, "non-dist Node matrix"),
+    ) as { include: { requires_ripgrep?: boolean }[] };
+    expect(matrix.include.map((row) => Boolean(row.requires_ripgrep))).toEqual([
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+      true,
+      false,
+      true,
+    ]);
+  });
+
   it("fails and retries quiet Node test shard stalls quickly", () => {
     const workflow = readCiWorkflow();
     const preflightJob = workflow.jobs.preflight;


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Linux CI ran real filesystem output-contract grep tests without requesting the existing ripgrep installation step. Those tests could fail before search with “ripgrep (rg) is not available and could not be downloaded,” depending on the runner image or automatic download availability.

## Why This Change Was Made

The existing ripgrep prerequisite rule now recognizes both real grep test owners through exact selections, glob selections, grouped plans, and their unfiltered owning shards. Explicitly unrelated selections stay excluded. The installation step and all test assertions remain unchanged.

## User Impact

CI provisions the binary needed by the filesystem output-contract tests instead of relying on an ambient installation or a silent runtime download. No product runtime behavior changes.

## Evidence

The new test executes the workflow manifest and checks 12 routing cases. It fails against the previous rule and passes with this change; existing Go and ripgrep setup checks also pass. The observed CI failure contained four grep prerequisite errors while 3,475 sibling tests passed. Its silent resolver did not expose the actual download failure, so no particular external outage is claimed.

Full workflow-guard validation passes: 518 tests passed, two existing tests skipped. The full changed-file gate passes. Fresh independent P2 review found no actionable issues. A local Homebrew Bash heredoc stall was isolated and the unchanged workflow suite was rerun with system Bash; no workflow behavior or timeout was altered.
