### PR TITLE
refactor(channels): expose catchall schema result type

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2186,7 +2186,7 @@ src/channels/plugins/bundled-setup-policy.ts	2
 src/channels/plugins/bundled.ts	4
 src/channels/plugins/chat-target-prefixes.ts	2
 src/channels/plugins/config-helpers.ts	7
-src/channels/plugins/config-schema.ts	14
+src/channels/plugins/config-schema.ts	12
 src/channels/plugins/config-write-policy-shared.ts	1
 src/channels/plugins/config-writes.ts	1
 src/channels/plugins/configured-binding-compiler.ts	1

--- a/src/channels/plugins/config-schema.ts
+++ b/src/channels/plugins/config-schema.ts
@@ -25,10 +25,6 @@ type ZodSchemaWithToJsonSchema = ZodTypeAny & {
   toJSONSchema?: (params?: Record<string, unknown>) => unknown;
 };
 
-type ExtendableZodObject = ZodTypeAny & {
-  extend: (shape: Record<string, ZodTypeAny>) => ZodTypeAny;
-};
-
 /** Shared allowlist entry shape for channel sender/user ids. */
 const AllowFromEntrySchema = z.union([z.string(), z.number()]);
 /** Optional allowlist array used by channel config schema builders. */
@@ -113,12 +109,12 @@ export function buildNestedDmConfigSchema(extraShape?: ZodRawShape) {
 }
 
 /** Add `accounts` catchall and `defaultAccount` fields to a channel account schema. */
-export function buildCatchallMultiAccountChannelSchema<T extends ExtendableZodObject>(
+export function buildCatchallMultiAccountChannelSchema<T extends z.ZodObject>(
   accountSchema: T,
-): T {
-  return buildMultiAccountChannelSchema(accountSchema as unknown as z.ZodObject, {
+): MultiAccountChannelSchema<T, T, false> {
+  return buildMultiAccountChannelSchema(accountSchema, {
     accountsMode: "catchall",
-  }) as unknown as T;
+  });
 }
 
 type MultiAccountSchemaBaseOptions<TAccount extends ZodTypeAny, TOptional extends boolean> = {


### PR DESCRIPTION
## What Problem This Solves

The catchall multi-account channel-schema helper returned its input schema type even though it actually returns an extended root schema containing `accounts` and `defaultAccount`. Preserving that false identity required two double casts and an ersatz extendable-object interface.

## Why This Change Was Made

The helper now accepts the concrete Zod object constraint and returns the precise `MultiAccountChannelSchema<T, T, false>` produced by `buildMultiAccountChannelSchema`. This preserves the account schema's input/output types and catchall optionality without compatibility assertions.

## User Impact

No runtime or emitted-import change. Plugin and channel callers receive a more accurate compile-time schema type.

## Evidence

- Prior exact-head `pnpm check:changed` passed before later baseline-only upstream updates.
- Rebased exact head `463874ba54f` passes 13/13 focused channel-schema tests, assertion ratchet, and formatting.
- Structured P0–P2 review found no actionable issue in generic inference, Zod transforms, optionality, Zod v3 compatibility, runtime shape, or emitted imports.
- Diff: 5 additions, 9 deletions; net −4 LOC.
