### PR TITLE
fix(npm): preserve comparison override selectors

### DIFF
--- a/scripts/generate-npm-package-lock.mts
+++ b/scripts/generate-npm-package-lock.mts
@@ -96,27 +96,25 @@ function normalizeOverrideValue(value: unknown): unknown {
 
 const NPM_PACKAGE_NAME_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u;
 
+function pnpmOverridePackageName(selector: string): string | null {
+  const versionSeparator = selector.startsWith("@")
+    ? selector.indexOf("@", selector.indexOf("/") + 1)
+    : selector.indexOf("@");
+  const packageName = versionSeparator === -1 ? selector : selector.slice(0, versionSeparator);
+  const version = versionSeparator === -1 ? null : selector.slice(versionSeparator + 1);
+  return NPM_PACKAGE_NAME_PATTERN.test(packageName) && (version === null || version.length > 0)
+    ? packageName
+    : null;
+}
+
 function pnpmScopedOverrideSeparator(key: string): number {
   for (let index = 1; index < key.length - 1; index += 1) {
     if (key[index] !== ">" || /\s/u.test(key[index - 1]!) || /\s/u.test(key[index + 1]!)) {
       continue;
     }
-    const dependencyName = key.slice(index + 1);
-    if (!NPM_PACKAGE_NAME_PATTERN.test(dependencyName)) {
-      continue;
-    }
     const parentSelector = key.slice(0, index);
-    const versionSeparator = parentSelector.startsWith("@")
-      ? parentSelector.indexOf("@", 1)
-      : parentSelector.indexOf("@");
-    const parentName =
-      versionSeparator === -1 ? parentSelector : parentSelector.slice(0, versionSeparator);
-    const parentVersion =
-      versionSeparator === -1 ? null : parentSelector.slice(versionSeparator + 1);
-    if (
-      NPM_PACKAGE_NAME_PATTERN.test(parentName) &&
-      (parentVersion === null || parentVersion.length > 0)
-    ) {
+    const childSelector = key.slice(index + 1);
+    if (pnpmOverridePackageName(parentSelector) && pnpmOverridePackageName(childSelector)) {
       return index;
     }
   }

--- a/scripts/generate-npm-package-lock.mts
+++ b/scripts/generate-npm-package-lock.mts
@@ -94,6 +94,35 @@ function normalizeOverrideValue(value: unknown): unknown {
   return value;
 }
 
+const NPM_PACKAGE_NAME_PATTERN = /^(?:@[a-z0-9][a-z0-9._-]*\/)?[a-z0-9][a-z0-9._-]*$/u;
+
+function pnpmScopedOverrideSeparator(key: string): number {
+  for (let index = 1; index < key.length - 1; index += 1) {
+    if (key[index] !== ">" || /\s/u.test(key[index - 1]!) || /\s/u.test(key[index + 1]!)) {
+      continue;
+    }
+    const dependencyName = key.slice(index + 1);
+    if (!NPM_PACKAGE_NAME_PATTERN.test(dependencyName)) {
+      continue;
+    }
+    const parentSelector = key.slice(0, index);
+    const versionSeparator = parentSelector.startsWith("@")
+      ? parentSelector.indexOf("@", 1)
+      : parentSelector.indexOf("@");
+    const parentName =
+      versionSeparator === -1 ? parentSelector : parentSelector.slice(0, versionSeparator);
+    const parentVersion =
+      versionSeparator === -1 ? null : parentSelector.slice(versionSeparator + 1);
+    if (
+      NPM_PACKAGE_NAME_PATTERN.test(parentName) &&
+      (parentVersion === null || parentVersion.length > 0)
+    ) {
+      return index;
+    }
+  }
+  return -1;
+}
+
 function normalizeOverrides(overrides: unknown): OverrideMap {
   if (!overrides || typeof overrides !== "object" || Array.isArray(overrides)) {
     return {};
@@ -105,7 +134,7 @@ function normalizeOverrides(overrides: unknown): OverrideMap {
     if (value === "-") {
       continue;
     }
-    const scopedSeparator = key.indexOf(">");
+    const scopedSeparator = pnpmScopedOverrideSeparator(key);
     if (scopedSeparator > 0) {
       const parentSelector = key.slice(0, scopedSeparator).trim();
       const dependencyName = key.slice(scopedSeparator + 1).trim();

--- a/test/scripts/generate-npm-package-lock.test.ts
+++ b/test/scripts/generate-npm-package-lock.test.ts
@@ -122,6 +122,19 @@ describe("generate-npm-package-lock", () => {
     });
   });
 
+  it("preserves version selectors on both sides of parent-child overrides", () => {
+    expect(
+      normalizeOverrides({
+        "bar>foo@1": "2",
+        "bar@>=1 <2>@scope/unused": "-",
+        "bar@>=1 <2>@scope/foo@>=3 <4": "4",
+      }),
+    ).toEqual({
+      bar: { "foo@1": "2" },
+      "bar@>=1 <2": { "@scope/foo@>=3 <4": "4" },
+    });
+  });
+
   it.each([false, true])(
     "retains parent and child overrides during normalization (childrenFirst=%s)",
     (childrenFirst) => {

--- a/test/scripts/generate-npm-package-lock.test.ts
+++ b/test/scripts/generate-npm-package-lock.test.ts
@@ -110,6 +110,18 @@ describe("generate-npm-package-lock", () => {
     });
   });
 
+  it("preserves range selectors containing comparison operators", () => {
+    expect(
+      normalizeOverrides({
+        "undici@>=7.0.0 <8.0.0": "7.29.1",
+        "undici@>=8.0.0 <8.9.0": "8.10.2",
+      }),
+    ).toEqual({
+      "undici@>=7.0.0 <8.0.0": "7.29.1",
+      "undici@>=8.0.0 <8.9.0": "8.10.2",
+    });
+  });
+
   it.each([false, true])(
     "retains parent and child overrides during normalization (childrenFirst=%s)",
     (childrenFirst) => {


### PR DESCRIPTION
## Summary
- distinguish pnpm parent-child override separators from semver comparison operators
- parse package selectors on both sides so version-qualified and scoped child overrides remain supported
- preserve selectors such as `undici@>=7.0.0 <8.0.0` when generating npm package-lock evidence

## Validation
- `test/scripts/generate-npm-package-lock.test.ts` — 48/48 passed
- exact 2026.7.33 candidate package-lock report — all 41 package graphs generated successfully
- covers bare, scoped, and version/range-qualified parent-child selectors
- `git diff --check`

## Release context
[npm preflight 34176496506](https://github.com/openclaw/openclaw/actions/runs/34176496506) failed because the normalizer split the `>` in `undici@>=7.0.0 <8.0.0`, producing npm’s `Override without name: =7.0.0 <8.0.0` error across every package graph. The vulnerability gate itself passed with zero hard blockers.
