### PR TITLE
refactor(tests): simplify Discord recording phase branches

### DIFF
--- a/extensions/discord/src/voice/transcripts-recording.test.ts
+++ b/extensions/discord/src/voice/transcripts-recording.test.ts
@@ -51,7 +51,7 @@ defineDiscordVoiceTests((harness) => {
       try {
         if (phase === "fresh") {
           await f.manager.leave({ guildId: "g1" });
-        } else if (phase === "replacement") {
+        } else {
           expect(
             await discordVoiceTranscriptsSourceProvider.start!({
               cfg: config,
@@ -80,11 +80,7 @@ defineDiscordVoiceTests((harness) => {
           expectConnectedStatus(f.manager, "1001");
           await f.audio("100000000000000001", 1);
           expect(realtimeSessionMock.sendAudio).not.toHaveBeenCalled();
-          if (phase === "replacement") {
-            expect(f.sink).toHaveBeenCalledOnce();
-          } else {
-            expect(transcribeAudioFileMock).not.toHaveBeenCalled();
-          }
+          expect(f.sink).toHaveBeenCalledOnce();
         }
       } finally {
         await discordVoiceTranscriptsSourceProvider.stop!({ sessionId: "first", source });


### PR DESCRIPTION
Related: #139658

## What Problem This Solves

The Discord recording test for disabled batch audio contains redundant phase checks and an unreachable assertion. Its explicit table has only `fresh` and `replacement`, so the branch after `fresh` always covers `replacement`.

## Why This Change Was Made

Replace the redundant `else if` with `else`, and keep the existing sink assertion directly in the later replacement branch. Remove only the unreachable alternative. Both cases, fixtures, executed assertions and cleanup remain unchanged; four net test lines are removed.

## User Impact

No production behavior change. Both fresh-capture rejection and preservation of an existing recording remain tested.

## Evidence

- Full recording suite passed before and after: 43 tests, no failures or skips, identical ordered names and results.
- Static selection for both literal phases produces identical executed case structure; only the two intended source edits are present.
- Classified changed gate passed, including extension-test typechecks and lint.
- Deslop and independent P2 review found no actionable issues.

No runtime-speed improvement is claimed.
