### PR TITLE
feat(cron): explain slow automation list requests

### DIFF
--- a/docs/gateway/logging.md
+++ b/docs/gateway/logging.md
@@ -97,6 +97,35 @@ trace context is retained when present. Emitter identity identifies the logging 
 awaited by the callback. The diagnostic adds no job identifiers,
 job contents, or request parameters.
 
+### Slow cron list requests
+
+With `diagnostics.enabled` active, a `cron.list` handler taking at least one
+second emits `cron: slow list request` through the Gateway logger. The record
+uses the existing request trace/span and reports `elapsedMs` plus fixed
+`phaseDurationsMs` for `setup`, `listing`, `projection`, optional `previews`,
+`response`, and `handlerExit`. Unentered phases are absent.
+
+`sourcePageMs` and `sourcePageCount` aggregate source-page calls, including
+failed calls. `returnedCount` appears once a page is selected.
+`scopeAttemptCount` is zero for direct lists; scoped lists allow
+three total attempts. For scoped lists, `scopeProcessingMs` is listing time
+minus source-page time: it includes visibility filtering, snapshot processing
+and scheduling between page calls. These components are already included in
+the listing phase and must not be added to it again.
+
+The bounded branch fields are `compact`, `previewsRequested`, and `scopeApplied`.
+`previewsRequested` describes the selected response mode, not whether execution
+reached that phase. `handlerOutcome` is `returned` or `threw`; `responseOutcome`
+is `none`, `ok`, `error`, or `threw` for the handler's response callback. Its
+`response` phase measures that synchronous callback, and `handlerExit` ends at
+the handler's own cleanup boundary. Neither proves socket delivery or client
+receipt; outer RPC diagnostics retain those separate outcomes.
+
+All durations are wall time, including awaits and scheduling, not CPU time.
+Fast requests and requests with diagnostics disabled emit no summary. The
+record adds no job identifiers, content, query strings, targets or error text,
+and does not change individual slow-page warnings or response payloads.
+
 ## Console capture
 
 The CLI captures `console.log/info/warn/error/debug/trace`, writes them to file logs, and still prints to stdout/stderr.

--- a/src/gateway/server-methods/cron-list-caller-scope.ts
+++ b/src/gateway/server-methods/cron-list-caller-scope.ts
@@ -4,6 +4,7 @@ import type {
   CronListPageResult,
 } from "../../cron/service/list-page-types.js";
 import type { CronJob } from "../../cron/types.js";
+import type { CronListDiagnostics } from "./cron-list-diagnostics.js";
 
 type CronListCallerScopeContext = {
   cron: {
@@ -17,24 +18,33 @@ export async function listCronPageWithVisibility({
   matchesJob,
   context,
   options,
+  diagnostics,
 }: {
   matchesJob: (job: CronJob) => boolean;
   context: CronListCallerScopeContext;
   options: CronListPageOptions;
+  diagnostics?: Pick<CronListDiagnostics, "startScopeAttempt" | "startSourcePage">;
 }): Promise<CronListPageResult> {
   let stableScopedJobs: CronJob[] | undefined;
   for (let attempt = 0; attempt < CRON_LIST_SCOPED_SNAPSHOT_MAX_ATTEMPTS; attempt += 1) {
+    diagnostics?.startScopeAttempt();
     const scopedJobs: CronJob[] = [];
     let offset = 0;
     let snapshotRevision: string | undefined;
     let snapshotChanged = false;
 
     for (;;) {
-      const sourcePage = await context.cron.listPage({
-        ...options,
-        limit: 200,
-        offset,
-      });
+      const finishPage = diagnostics?.startSourcePage();
+      let sourcePage: CronListPageResult;
+      try {
+        sourcePage = await context.cron.listPage({
+          ...options,
+          limit: 200,
+          offset,
+        });
+      } finally {
+        finishPage?.();
+      }
       if (snapshotRevision && sourcePage.snapshotRevision !== snapshotRevision) {
         snapshotChanged = true;
         break;

--- a/src/gateway/server-methods/cron-list-diagnostics.test.ts
+++ b/src/gateway/server-methods/cron-list-diagnostics.test.ts
@@ -1,0 +1,112 @@
+import { performance } from "node:perf_hooks";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import {
+  areDiagnosticsEnabledForProcess,
+  setDiagnosticsEnabledForProcess,
+} from "../../infra/diagnostic-events.js";
+import {
+  createDiagnosticTraceContext,
+  getActiveDiagnosticTraceContext,
+  runWithDiagnosticTraceContext,
+  type DiagnosticTraceContext,
+} from "../../infra/diagnostic-trace-context.js";
+import { startCronListDiagnostics } from "./cron-list-diagnostics.js";
+
+let previousDiagnostics: boolean;
+beforeEach(() => {
+  previousDiagnostics = areDiagnosticsEnabledForProcess();
+});
+afterEach(() => {
+  setDiagnosticsEnabledForProcess(previousDiagnostics);
+  vi.restoreAllMocks();
+});
+
+test("disabled cron list diagnostics do not start clocks", () => {
+  setDiagnosticsEnabledForProcess(false);
+  const now = vi.spyOn(performance, "now");
+  const warn = vi.fn();
+  expect(startCronListDiagnostics({ warn }, vi.fn())).toBeUndefined();
+  expect(now).not.toHaveBeenCalled();
+  expect(warn).not.toHaveBeenCalled();
+});
+
+test.each([999.9, 1_000])("cron list warning threshold uses raw elapsed time: %s", (elapsed) => {
+  setDiagnosticsEnabledForProcess(true);
+  let clock = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => clock);
+  const warn = vi.fn();
+  const diagnostics = expectDefined(
+    startCronListDiagnostics({ warn }, vi.fn()),
+    "enabled cron list diagnostics",
+  );
+  clock = elapsed;
+  diagnostics.finish("returned");
+  expect(warn).toHaveBeenCalledTimes(elapsed >= 1_000 ? 1 : 0);
+});
+
+test("cron list diagnostics close unfinished work once and retire later marks", () => {
+  setDiagnosticsEnabledForProcess(true);
+  let clock = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => clock);
+  const warn = vi.fn();
+  const diagnostics = expectDefined(
+    startCronListDiagnostics({ warn }, vi.fn()),
+    "enabled cron list diagnostics",
+  );
+  clock = 100;
+  diagnostics.mark("listing");
+  clock = 1_100;
+  diagnostics.finish("threw");
+  clock = 9_000;
+  diagnostics.mark("previews");
+  diagnostics.finish("returned");
+  expect(warn).toHaveBeenCalledExactlyOnceWith("cron: slow list request", {
+    operation: "cron.list",
+    elapsedMs: 1_100,
+    phaseDurationsMs: { setup: 100, listing: 1_000 },
+    sourcePageMs: 0,
+    sourcePageCount: 0,
+    scopeAttemptCount: 0,
+    handlerOutcome: "threw",
+    responseOutcome: "none",
+  });
+});
+
+test("disabling diagnostics during a cron request cannot publish its summary later", () => {
+  setDiagnosticsEnabledForProcess(true);
+  let clock = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => clock);
+  const warn = vi.fn();
+  const diagnostics = expectDefined(
+    startCronListDiagnostics({ warn }, vi.fn()),
+    "enabled cron list diagnostics",
+  );
+  clock = 2_000;
+  setDiagnosticsEnabledForProcess(false);
+  diagnostics.finish("returned");
+  setDiagnosticsEnabledForProcess(true);
+  diagnostics.finish("returned");
+  expect(warn).not.toHaveBeenCalled();
+});
+
+test.each([true, false])("cron diagnostics preserve captured trace presence: %s", (bound) => {
+  setDiagnosticsEnabledForProcess(true);
+  let clock = 0;
+  vi.spyOn(performance, "now").mockImplementation(() => clock);
+  const original = bound ? createDiagnosticTraceContext() : undefined;
+  let loggedTrace: DiagnosticTraceContext | undefined;
+  const warn = vi.fn(() => {
+    loggedTrace = getActiveDiagnosticTraceContext();
+  });
+  const diagnostics = expectDefined(
+    runWithDiagnosticTraceContext(original, () => startCronListDiagnostics({ warn }, vi.fn())),
+    "enabled request-scoped cron diagnostics",
+  );
+  clock = 1_500;
+  runWithDiagnosticTraceContext(createDiagnosticTraceContext(), () =>
+    diagnostics.finish("returned"),
+  );
+  expect(warn).toHaveBeenCalledOnce();
+  expect(loggedTrace).toEqual(original);
+});

--- a/src/gateway/server-methods/cron-list-diagnostics.ts
+++ b/src/gateway/server-methods/cron-list-diagnostics.ts
@@ -1,0 +1,113 @@
+import { performance } from "node:perf_hooks";
+import { areDiagnosticsEnabledForProcess } from "../../infra/diagnostic-events.js";
+import {
+  getActiveDiagnosticTraceContext,
+  runWithDiagnosticTraceContext,
+} from "../../infra/diagnostic-trace-context.js";
+import { createStageTimingTracker } from "../../shared/stage-timing.js";
+import type { GatewayRequestContext, RespondFn } from "./types.js";
+
+type Phase = "setup" | "listing" | "projection" | "previews" | "response" | "handlerExit";
+type RequestMode = { compact: boolean; previewsRequested: boolean; scopeApplied: boolean };
+export type CronListDiagnostics = NonNullable<ReturnType<typeof startCronListDiagnostics>>;
+
+export function startCronListDiagnostics(
+  log: Pick<GatewayRequestContext["logGateway"], "warn">,
+  respond: RespondFn,
+) {
+  if (!areDiagnosticsEnabledForProcess()) {
+    return undefined;
+  }
+  let checkpoint = performance.now();
+  const startedAt = checkpoint;
+  // Share each raw checkpoint with the tracker before its display-only rounding.
+  const timing = createStageTimingTracker(() => checkpoint);
+  const trace = getActiveDiagnosticTraceContext();
+  let phase: Phase = "setup";
+  let phaseStartedAt = checkpoint;
+  let listingMs = 0;
+  let sourcePageMs = 0;
+  let sourcePageCount = 0;
+  let scopeAttemptCount = 0;
+  let returnedCount: number | undefined;
+  let requestMode: RequestMode | undefined;
+  let responseOutcome: "none" | "ok" | "error" | "threw" = "none";
+  let finished = false;
+  const mark = (nextPhase: Phase) => {
+    if (finished) {
+      return;
+    }
+    checkpoint = performance.now();
+    timing.mark(phase);
+    if (phase === "listing") {
+      listingMs = checkpoint - phaseStartedAt;
+    }
+    phase = nextPhase;
+    phaseStartedAt = checkpoint;
+  };
+  return {
+    mark,
+    setRequestMode(mode: RequestMode) {
+      requestMode = mode;
+    },
+    setReturnedCount(count: number) {
+      returnedCount = count;
+    },
+    startScopeAttempt() {
+      scopeAttemptCount++;
+    },
+    startSourcePage() {
+      sourcePageCount++;
+      const pageStartedAt = performance.now();
+      return () => {
+        sourcePageMs += performance.now() - pageStartedAt;
+      };
+    },
+    respond: ((...args) => {
+      mark("response");
+      responseOutcome = args[0] ? "ok" : "error";
+      try {
+        return respond(...args);
+      } catch (error) {
+        responseOutcome = "threw";
+        throw error;
+      } finally {
+        mark("handlerExit");
+      }
+    }) satisfies RespondFn,
+    finish(handlerOutcome: "returned" | "threw") {
+      if (finished) {
+        return;
+      }
+      mark("handlerExit");
+      finished = true;
+      const elapsedMs = checkpoint - startedAt;
+      if (elapsedMs < 1_000 || !areDiagnosticsEnabledForProcess()) {
+        return;
+      }
+      try {
+        runWithDiagnosticTraceContext(trace, () =>
+          log.warn("cron: slow list request", {
+            operation: "cron.list",
+            elapsedMs: Math.round(elapsedMs),
+            phaseDurationsMs: Object.fromEntries(
+              timing.snapshot().stages.map((stage) => [stage.name, stage.durationMs]),
+            ),
+            sourcePageMs: Math.round(sourcePageMs),
+            sourcePageCount,
+            scopeAttemptCount,
+            ...(returnedCount === undefined ? {} : { returnedCount }),
+            ...(requestMode?.scopeApplied
+              ? { scopeProcessingMs: Math.round(listingMs - sourcePageMs) }
+              : {}),
+            ...requestMode,
+            handlerOutcome,
+            responseOutcome,
+          }),
+        );
+      } catch {
+        // Diagnostic failures cannot replace the handler's response or original error.
+      }
+    },
+  };
+}

--- a/src/gateway/server-methods/cron.ts
+++ b/src/gateway/server-methods/cron.ts
@@ -39,6 +39,7 @@ import type { CronRuntimeAuthority } from "../../cron/runtime-authority.js";
 import { CRON_JOB_SCRATCH_MAX_BYTES } from "../../cron/scratch-contract.js";
 import { resolveFailureAlert } from "../../cron/service/failure-alerts.js";
 import { applyJobPatch } from "../../cron/service/jobs.js";
+import type { CronListPageResult } from "../../cron/service/list-page-types.js";
 import {
   isInvalidCronSessionTargetIdError,
   resolveCronSessionTargetSessionKey,
@@ -89,6 +90,7 @@ import {
 } from "./cron-caller-scope.js";
 import { isCronInvalidRequestError } from "./cron-error-classification.js";
 import { listCronPageWithVisibility } from "./cron-list-caller-scope.js";
+import { startCronListDiagnostics } from "./cron-list-diagnostics.js";
 import { cronRunLogPageFilters, filterCronRunLogJobsByAgent } from "./cron-run-log-filters.js";
 import { resolveOperatorSessionCreation } from "./session-creation-provenance.js";
 import type {
@@ -580,69 +582,96 @@ export const cronHandlers: GatewayRequestHandlers = {
     });
     respond(true, result, undefined);
   },
-  "cron.list": async ({ params, respond, context, client }) => {
-    if (!assertValidParams(params, validateCronListParams, "cron.list", respond)) {
-      return;
+  "cron.list": async ({ params, respond: originalRespond, context, client }) => {
+    const diagnostics = startCronListDiagnostics(context.logGateway, originalRespond);
+    const respond = diagnostics?.respond ?? originalRespond;
+    let handlerOutcome: "returned" | "threw" = "returned";
+    try {
+      if (!assertValidParams(params, validateCronListParams, "cron.list", respond)) {
+        return;
+      }
+      const p = params as CronListParams;
+      const admittedScope = readCronCallerScope(client);
+      const callerScope = admittedScope?.manageAll ? undefined : admittedScope;
+      const requestedAgentId = p.agentId ? normalizeAgentId(p.agentId) : undefined;
+      if (callerScope && requestedAgentId && requestedAgentId !== callerScope.agentId) {
+        respondInvalidCronParams(respond, "cron.list", "agentId outside caller scope");
+        return;
+      }
+      const listOptions = {
+        includeDisabled: p.includeDisabled,
+        limit: p.limit,
+        offset: p.offset,
+        query: p.query,
+        enabled: p.enabled,
+        scheduleKind: p.scheduleKind,
+        lastRunStatus: p.lastRunStatus,
+        trigger: p.trigger,
+        sortBy: p.sortBy,
+        sortDir: p.sortDir,
+        // Owners retain visibility when execution is retargeted to another agent.
+        agentId: callerScope ? undefined : p.agentId,
+      };
+      const cronVisibility = resolveCronSessionVisibility(client, context.getRuntimeConfig());
+      const defaultAgentId = context.cron.getDefaultAgentId();
+      diagnostics?.setRequestMode({
+        compact: p.compact === true,
+        previewsRequested: p.compact !== true && p.includeDeliveryPreviews !== false,
+        scopeApplied: Boolean(callerScope || cronVisibility),
+      });
+      diagnostics?.mark("listing");
+      let page: CronListPageResult;
+      if (callerScope || cronVisibility) {
+        page = await listCronPageWithVisibility({
+          context,
+          options: listOptions,
+          diagnostics,
+          matchesJob: (job) =>
+            cronJobMatchesCallerScope({
+              job,
+              callerScope,
+              defaultAgentId,
+              allowCurrentJob: true,
+            }) && cronJobIsVisible(job, cronVisibility, defaultAgentId),
+        });
+      } else {
+        const finishPage = diagnostics?.startSourcePage();
+        try {
+          page = await context.cron.listPage(listOptions);
+        } finally {
+          finishPage?.();
+        }
+      }
+      diagnostics?.setReturnedCount(page.jobs.length);
+      diagnostics?.mark("projection");
+      const jobs = page.jobs.map((job) => ({
+        ...(p.compact === true ? compactCronListJob(job) : cronJobReadView(job)),
+        effectiveAgentId: tryResolveCronJobEffectiveAgentId(job, defaultAgentId) ?? null,
+      }));
+      if (p.compact === true) {
+        respond(true, { ...page, jobs }, undefined);
+        return;
+      }
+      if (p.includeDeliveryPreviews === false) {
+        // Full job rows are the default because editors need their payloads. Delivery
+        // previews are independently suppressible so list-only callers avoid per-job I/O
+        // without weakening the shipped full-response default.
+        respond(true, { ...page, jobs }, undefined);
+        return;
+      }
+      diagnostics?.mark("previews");
+      const deliveryPreviews = await resolveCronDeliveryPreviews({
+        cfg: context.getRuntimeConfig(),
+        defaultAgentId: context.cron.getDefaultAgentId(),
+        jobs: page.jobs,
+      });
+      respond(true, { ...page, jobs, deliveryPreviews }, undefined);
+    } catch (error) {
+      handlerOutcome = "threw";
+      throw error;
+    } finally {
+      diagnostics?.finish(handlerOutcome);
     }
-    const p = params as CronListParams;
-    const admittedScope = readCronCallerScope(client);
-    const callerScope = admittedScope?.manageAll ? undefined : admittedScope;
-    const requestedAgentId = p.agentId ? normalizeAgentId(p.agentId) : undefined;
-    if (callerScope && requestedAgentId && requestedAgentId !== callerScope.agentId) {
-      respondInvalidCronParams(respond, "cron.list", "agentId outside caller scope");
-      return;
-    }
-    const listOptions = {
-      includeDisabled: p.includeDisabled,
-      limit: p.limit,
-      offset: p.offset,
-      query: p.query,
-      enabled: p.enabled,
-      scheduleKind: p.scheduleKind,
-      lastRunStatus: p.lastRunStatus,
-      trigger: p.trigger,
-      sortBy: p.sortBy,
-      sortDir: p.sortDir,
-      // Owners retain visibility when execution is retargeted to another agent.
-      agentId: callerScope ? undefined : p.agentId,
-    };
-    const cronVisibility = resolveCronSessionVisibility(client, context.getRuntimeConfig());
-    const defaultAgentId = context.cron.getDefaultAgentId();
-    const page =
-      callerScope || cronVisibility
-        ? await listCronPageWithVisibility({
-            context,
-            options: listOptions,
-            matchesJob: (job) =>
-              cronJobMatchesCallerScope({
-                job,
-                callerScope,
-                defaultAgentId,
-                allowCurrentJob: true,
-              }) && cronJobIsVisible(job, cronVisibility, defaultAgentId),
-          })
-        : await context.cron.listPage(listOptions);
-    const jobs = page.jobs.map((job) => ({
-      ...(p.compact === true ? compactCronListJob(job) : cronJobReadView(job)),
-      effectiveAgentId: tryResolveCronJobEffectiveAgentId(job, defaultAgentId) ?? null,
-    }));
-    if (p.compact === true) {
-      respond(true, { ...page, jobs }, undefined);
-      return;
-    }
-    if (p.includeDeliveryPreviews === false) {
-      // Full job rows are the default because editors need their payloads. Delivery
-      // previews are independently suppressible so list-only callers avoid per-job I/O
-      // without weakening the shipped full-response default.
-      respond(true, { ...page, jobs }, undefined);
-      return;
-    }
-    const deliveryPreviews = await resolveCronDeliveryPreviews({
-      cfg: context.getRuntimeConfig(),
-      defaultAgentId: context.cron.getDefaultAgentId(),
-      jobs: page.jobs,
-    });
-    respond(true, { ...page, jobs, deliveryPreviews }, undefined);
   },
   "cron.status": async ({ params, respond, context }) => {
     if (!assertValidParams(params, validateCronStatusParams, "cron.status", respond)) {

--- a/src/gateway/server-methods/cron.validation.test.ts
+++ b/src/gateway/server-methods/cron.validation.test.ts
@@ -1,6 +1,7 @@
 // Cron validation tests cover channel target validation against plugin
 // prefixes/aliases and runtime config for cron delivery destinations.
 
+import { performance } from "node:perf_hooks";
 import { expectDefined } from "@openclaw/normalization-core";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -17,6 +18,10 @@ import {
   claimAgentRunDelegatedAuthority,
   releaseAgentRunDelegatedAuthority,
 } from "../../infra/agent-run-registry.js";
+import {
+  areDiagnosticsEnabledForProcess,
+  setDiagnosticsEnabledForProcess,
+} from "../../infra/diagnostic-events.js";
 import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
 import {
   createChannelTestPluginBase,
@@ -29,6 +34,7 @@ import {
 } from "../cron-creator-authority-grant.js";
 import type { CronCreatorAuthorityGrant } from "../cron-creator-authority-grant.types.js";
 import { getGatewayProcessInstanceId } from "../process-instance.js";
+import * as cronCallerScope from "./cron-caller-scope.js";
 import type { GatewayClient, GatewayRequestContext } from "./types.js";
 
 const cronLogger = createNoopLogger();
@@ -286,6 +292,7 @@ function createCronContext(currentJobs?: CronJob | CronJob[]) {
     },
     logGateway: {
       info: vi.fn(),
+      warn: vi.fn(),
     },
     cronStorePath: "cron-validation-test.json",
     getRuntimeConfig: () => getRuntimeConfig(),
@@ -304,10 +311,11 @@ async function invokeCron(
     currentJob?: CronJob;
     context?: ReturnType<typeof createCronContext>;
     client?: GatewayClient;
+    respond?: ReturnType<typeof vi.fn>;
   } = {},
 ) {
   const context = options.context ?? createCronContext(options.currentJob);
-  const respond = vi.fn();
+  const respond = options.respond ?? vi.fn();
   await expectDefined(
     cronHandlers[method],
     "cronHandlers[method] test invariant",
@@ -945,6 +953,172 @@ describe("cron method validation", () => {
     const error = respond.mock.calls.at(-1)?.[2];
     expect(String(error?.message)).toContain("cron job not found: missing");
     expect(String(error?.message)).not.toContain("automation not found");
+  });
+
+  describe("cron.list request diagnostics", () => {
+    let clock = 0;
+    let previousDiagnostics: boolean;
+    beforeEach(() => {
+      previousDiagnostics = areDiagnosticsEnabledForProcess();
+      setDiagnosticsEnabledForProcess(true);
+      clock = 0;
+      vi.spyOn(performance, "now").mockImplementation(() => clock);
+    });
+    afterEach(() => {
+      setDiagnosticsEnabledForProcess(previousDiagnostics);
+      vi.restoreAllMocks();
+    });
+
+    it.each([false, true])(
+      "attributes scoped inventory attempts without leaking hidden job data (unstable: %s)",
+      async (unstable) => {
+        const jobs = Array.from({ length: 201 }, (_, index) =>
+          createCronJob({ id: `private-job-${index}`, agentId: index === 200 ? "ops" : "other" }),
+        );
+        const context = createCronContext(jobs);
+        const listPage = context.cron.listPage.getMockImplementation()!;
+        context.cron.listPage.mockImplementation(async (opts) => {
+          clock += 600;
+          const page = await listPage(opts);
+          return unstable && opts?.offset === 200
+            ? { ...page, snapshotRevision: "changed-before-second-page" }
+            : page;
+        });
+        const matches = cronCallerScope.cronJobMatchesCallerScope;
+        vi.spyOn(cronCallerScope, "cronJobMatchesCallerScope").mockImplementation((params) => {
+          clock += 1;
+          return matches(params);
+        });
+        const respond = vi.fn();
+        const invocation = invokeCron(
+          "cron.list",
+          { compact: true, limit: 1 },
+          { context, client: callerClient("ops"), respond },
+        );
+        if (unstable) {
+          await expect(invocation).rejects.toThrow(
+            new Error("cron.list changed repeatedly while applying caller scope"),
+          );
+          expect(respond).not.toHaveBeenCalled();
+        } else {
+          await invocation;
+          expect(respond).toHaveBeenCalledExactlyOnceWith(
+            true,
+            expect.objectContaining({
+              jobs: [expect.objectContaining({ id: "private-job-200" })],
+              total: 1,
+              hasMore: false,
+            }),
+            undefined,
+          );
+        }
+        expect(context.cron.listPage.mock.calls.map(([opts]) => opts?.offset)).toEqual(
+          unstable ? [0, 200, 0, 200, 0, 200] : [0, 200],
+        );
+        expect(context.logGateway.warn).toHaveBeenCalledExactlyOnceWith("cron: slow list request", {
+          operation: "cron.list",
+          elapsedMs: unstable ? 4200 : 1401,
+          phaseDurationsMs: unstable
+            ? { setup: 0, listing: 4200 }
+            : { setup: 0, listing: 1401, projection: 0, response: 0, handlerExit: 0 },
+          sourcePageMs: unstable ? 3600 : 1200,
+          sourcePageCount: unstable ? 6 : 2,
+          scopeAttemptCount: unstable ? 3 : 1,
+          handlerOutcome: unstable ? "threw" : "returned",
+          responseOutcome: unstable ? "none" : "ok",
+          compact: true,
+          previewsRequested: false,
+          scopeApplied: true,
+          ...(!unstable ? { returnedCount: 1 } : {}),
+          scopeProcessingMs: unstable ? 600 : 201,
+        });
+      },
+    );
+
+    it.each([
+      [{}, true],
+      [{ compact: true }, false],
+      [{ includeDeliveryPreviews: false }, false],
+    ] as const)(
+      "attributes previews without making bypassed reads eager: %j",
+      async (params, previewsRequested) => {
+        const context = createCronContext(createCronJob());
+        const listPage = context.cron.listPage.getMockImplementation()!;
+        context.cron.listPage.mockImplementation(async (opts) => {
+          clock += 1100;
+          return await listPage(opts);
+        });
+        const previews = { "cron-1": { label: "private-preview", detail: "private-destination" } };
+        resolveCronDeliveryPreviews.mockImplementation(async () => {
+          clock += 400;
+          return previews;
+        });
+        const { respond } = await invokeCron("cron.list", params, { context });
+        expect(respond).toHaveBeenCalledTimes(1);
+        expect(respond.mock.calls[0]).toEqual([true, expect.any(Object), undefined]);
+        const payload = requireRecord(respond.mock.calls[0]?.[1], "cron list response");
+        expect(resolveCronDeliveryPreviews).toHaveBeenCalledTimes(previewsRequested ? 1 : 0);
+        if (previewsRequested) {
+          expect(payload.deliveryPreviews).toBe(previews);
+        } else {
+          expect(payload).not.toHaveProperty("deliveryPreviews");
+        }
+        expect(context.logGateway.warn).toHaveBeenCalledExactlyOnceWith("cron: slow list request", {
+          operation: "cron.list",
+          elapsedMs: previewsRequested ? 1500 : 1100,
+          phaseDurationsMs: {
+            setup: 0,
+            listing: 1100,
+            projection: 0,
+            ...(previewsRequested ? { previews: 400 } : {}),
+            response: 0,
+            handlerExit: 0,
+          },
+          sourcePageMs: 1100,
+          sourcePageCount: 1,
+          scopeAttemptCount: 0,
+          handlerOutcome: "returned",
+          responseOutcome: "ok",
+          compact: "compact" in params,
+          previewsRequested,
+          scopeApplied: false,
+          returnedCount: 1,
+        });
+      },
+    );
+
+    it.each(["page", "response"] as const)(
+      "preserves a %s error when the diagnostic sink throws",
+      async (source) => {
+        const context = createCronContext(createCronJob());
+        const failure = new Error("original failure");
+        const listPage = context.cron.listPage.getMockImplementation()!;
+        context.cron.listPage.mockImplementation(async (opts) => {
+          clock = 1100;
+          if (source === "page") {
+            throw failure;
+          }
+          return await listPage(opts);
+        });
+        const respond = vi.fn(() => {
+          throw failure;
+        });
+        context.logGateway.warn.mockImplementation(() => {
+          throw new Error("diagnostic failure");
+        });
+        await expect(invokeCron("cron.list", { compact: true }, { context, respond })).rejects.toBe(
+          failure,
+        );
+        expect(respond).toHaveBeenCalledTimes(source === "response" ? 1 : 0);
+        expect(context.logGateway.warn).toHaveBeenCalledExactlyOnceWith(
+          "cron: slow list request",
+          expect.objectContaining({
+            handlerOutcome: "threw",
+            responseOutcome: source === "page" ? "none" : "threw",
+          }),
+        );
+      },
+    );
   });
 
   it.each([


### PR DESCRIPTION
Related: #140994

## What Problem This Solves

Resolves a problem where operators investigating slow automation lists can see individual source-page timings but cannot locate delays in the rest of the request. A scoped listing can exceed one second across several individually fast pages, and job projection or delivery previews can add further time.

## Why This Change Was Made

Adds one request-owned summary for `cron.list` handlers taking at least one second, using the existing diagnostics policy, Gateway logger and trace context. Fixed outer phases and scalar page/attempt totals cover listing, scope processing, projection, previews and the response callback without retaining per-job or per-page diagnostic records.

## User Impact

Operators can distinguish these elapsed-time boundaries while existing request parameters, response payloads, pagination, authorization and preview defaults retain their behavior. The summary contains no job identifiers, content, targets, query strings or error text. Timings include awaits and scheduling; callback completion does not establish client receipt.

## Evidence

- Regression cases fail on unchanged main solely because the whole-request warning is absent; response, preview-laziness and original-error assertions still pass.
- Focused cron handler, diagnostics-owner and existing source-page suites: 262 tests passed. Final assertion-label correction: all seven diagnostics-owner tests passed.
- Complete changed-source gate passed: production/core-test types, formatting, lint, all dead-export scans, import cycles and applicable owner guards.
- [Blacksmith Testbox RPC proof](https://github.com/openclaw/openclaw/actions/runs/34181383881): six authenticated synthetic operator requests compare complete payloads with diagnostics off/on, verify preview bypasses, and correlate the real structured warning with native RPC trace/span. The two full-preview requests use a fixed awaited 1,100-ms delay after a pure webhook preview result; this proves diagnostic attribution, not production latency, CPU cost or a live upstream contract.
- The remote test and wrapper exited 0, artifacts were verified, and the owned Testbox stopped. The backing Actions job can show cancellation after delegated cleanup; a later portal-sync warning is retained separately from successful command/export/stop.
- Independent autoreview found no actionable P0–P2 issue; the RPC artifacts also passed independent verification.
