### PR TITLE
refactor(agents): separate catalog source preparation

### DIFF
--- a/src/agents/prepared-model-catalog-worker.secrets.test.ts
+++ b/src/agents/prepared-model-catalog-worker.secrets.test.ts
@@ -24,10 +24,8 @@ import { resolveUsableCustomProviderApiKey } from "./model-auth-provider-config.
 import * as modelsConfig from "./models-config.js";
 import { createPreparedModelCatalogWorkerInput } from "./prepared-model-catalog-worker.js";
 import { runPreparedModelCatalogWorkerRequest } from "./prepared-model-catalog.worker.js";
-import {
-  prepareAgentCatalogSource,
-  prepareWorkspaceBuildGroup,
-} from "./prepared-model-runtime.facts.js";
+import { prepareWorkspaceBuildGroup } from "./prepared-model-runtime.facts.js";
+import { prepareAgentCatalogSource } from "./prepared-model-runtime.scoped-catalog.js";
 
 // Run the real worker entrypoint without attaching it to Vitest's own worker port.
 vi.mock("node:worker_threads", async (importOriginal) => ({

--- a/src/agents/prepared-model-catalog.worker.ts
+++ b/src/agents/prepared-model-catalog.worker.ts
@@ -214,7 +214,8 @@ export async function runPreparedModelCatalogWorkerRequest(
         }),
       };
     }
-    const { prepareAgentCatalogSource } = await import("./prepared-model-runtime.facts.js");
+    const { prepareAgentCatalogSource } =
+      await import("./prepared-model-runtime.scoped-catalog.js");
     const { prepareFullCatalogFacts } = await import("./prepared-model-runtime.full-catalog.js");
     // Full discovery is one point-in-time operation: refresh first, then let every provider hook
     // and the returned availability projection consume the same exact store.

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -36,7 +36,6 @@ import {
 import {
   fingerprintPreparedRuntimeFacts,
   preparedModelInventoryKey,
-  prepareAgentCatalogSource,
   prepareConfiguredRuntimeFactsBatch,
   prepareWorkspaceBuildGroup,
 } from "./prepared-model-runtime.facts.js";
@@ -54,6 +53,7 @@ import {
   preparedModelRuntimeWorkspaceFactsKey,
 } from "./prepared-model-runtime.inbound-registry.js";
 import { createCatalogAttemptReporter } from "./prepared-model-runtime.publication-events.js";
+import { prepareAgentCatalogSource } from "./prepared-model-runtime.scoped-catalog.js";
 import type {
   PreparedModelRuntimeBuildStats,
   PreparedModelRuntimeCatalogMode,

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -11,7 +11,6 @@ import {
   getPreparedMessageToolCatalog,
   getPreparedMessageToolCatalogForRegistry,
 } from "../plugins/prepared-message-tool-catalog.js";
-import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import { resolveRuntimeSyntheticAuthProviderRefs } from "../plugins/synthetic-auth.runtime.js";
@@ -26,19 +25,16 @@ import {
   getPreparedRuntimeAuthProfileStoreSnapshotCore,
   getRuntimeAuthProfileStoreCredentialsRevision,
 } from "./auth-profiles/runtime-snapshots.js";
-import type { AuthProfileStore } from "./auth-profiles/types.js";
 import { buildInlineProviderModels } from "./embedded-agent-runner/model.inline-provider.js";
 import {
   createBundledStaticCatalogModelResolver,
   loadBundledProviderStaticCatalogContextModels,
 } from "./embedded-agent-runner/model.static-catalog.js";
 import { createStaticModelIdMatcher } from "./embedded-agent-runner/model.static-id.js";
-import { createPreparedModelCatalogProviderNormalizer } from "./model-catalog-provider-normalizer.js";
 import {
   buildConfiguredModelCatalog,
   parseConfiguredModelVisibilityEntries,
 } from "./model-selection-shared.js";
-import { ensureOpenClawModelsJson, planOpenClawModelsJsonSource } from "./models-config.js";
 import { prepareImplicitProviderStaticCatalog } from "./models-config.providers.implicit.js";
 import { resolveModelCatalogIdentityKey } from "./openai-model-routes.js";
 import {
@@ -51,7 +47,6 @@ import type {
   PreparedModelRuntimeAgentBaseFacts,
   PreparedModelRuntimeAgentFacts,
   PreparedModelRuntimeCatalogFacts,
-  PreparedModelRuntimeCatalogSource,
 } from "./prepared-model-runtime.catalog-contract.js";
 import { prepareConfiguredRuntimeFacts } from "./prepared-model-runtime.configured-catalog.js";
 import { completeConfiguredRuntimeModels } from "./prepared-model-runtime.configured-completion.js";
@@ -82,7 +77,6 @@ import type {
 } from "./prepared-model-runtime.types.js";
 import { AuthStorage } from "./sessions/auth-storage.js";
 
-const MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS = 5_000;
 type PreparedConfiguredRegistryGroup = {
   agentFacts: PreparedModelRuntimeAgentFacts[];
   modelsJsonContents: string | null;
@@ -486,7 +480,7 @@ export async function prepareWorkspaceBuildGroup(
   );
 }
 
-function captureModelsJsonContents(agentDir: string): string | null {
+export function captureModelsJsonContents(agentDir: string): string | null {
   try {
     return fs.readFileSync(path.join(agentDir, "models.json"), "utf8");
   } catch (error) {
@@ -623,83 +617,4 @@ export function prepareConfiguredRuntimeFactsBatch(params: {
     }
   }
   return { catalogs, registryCount };
-}
-
-export async function prepareAgentCatalogSource(
-  agentFacts: PreparedModelRuntimeAgentFacts,
-  pluginGeneration: PreparedModelRuntimePluginGeneration,
-  catalogMode: PreparedModelRuntimeCatalogMode,
-  persist = true,
-  sourceOptions: {
-    authStore?: AuthProfileStore;
-    providerDiscoveryProviderIds?: readonly string[];
-  } = {},
-): Promise<PreparedModelRuntimeCatalogSource> {
-  const { env, input, providerIds } = agentFacts;
-  const normalizeProvider = createPreparedModelCatalogProviderNormalizer(
-    pluginGeneration.pluginMetadataSnapshot,
-    input.config,
-    env,
-  );
-  const providerOutcomes = new Map<string, ProviderCatalogOutcome>();
-  const recordProviderOutcome = (outcome: ProviderCatalogOutcome) => {
-    const provider = normalizeProvider(outcome.provider);
-    if (provider) {
-      providerOutcomes.set(`${provider}\0${outcome.profileId ?? ""}`, { ...outcome, provider });
-    }
-  };
-  const resultOutcomes = () =>
-    [...providerOutcomes.values()].toSorted(
-      (left, right) =>
-        left.provider.localeCompare(right.provider) ||
-        (left.profileId ?? "").localeCompare(right.profileId ?? ""),
-    );
-  const options = {
-    pluginMetadataSnapshot: pluginGeneration.pluginMetadataSnapshot,
-    providerDiscoveryProviderIds: sourceOptions.providerDiscoveryProviderIds ?? providerIds,
-    ...(pluginGeneration.preparedStaticProviderCatalog
-      ? { preparedStaticProviderCatalog: pluginGeneration.preparedStaticProviderCatalog }
-      : {}),
-    ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
-    ...(input.env ? { env } : {}),
-    ...(catalogMode === "static"
-      ? {
-          providerDiscoveryEntriesOnly: true as const,
-        }
-      : {
-          providerDiscoveryTimeoutMs: MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS,
-        }),
-  };
-  const prepareSource = async () => {
-    if (!persist) {
-      const source = await planOpenClawModelsJsonSource(input.config, input.agentDir, {
-        ...options,
-        ...(sourceOptions.authStore ? { authStore: sourceOptions.authStore } : {}),
-        ...(catalogMode === "live" ? { onProviderCatalogOutcome: recordProviderOutcome } : {}),
-      });
-      return {
-        modelsJsonContents: source.modelsJsonContents,
-        pluginCatalogs: source.pluginCatalogs,
-        providerOutcomes: resultOutcomes(),
-      };
-    }
-    if (!input.readOnly) {
-      await ensureOpenClawModelsJson(input.config, input.agentDir, {
-        ...options,
-        ...(catalogMode === "live" ? { onProviderCatalogOutcome: recordProviderOutcome } : {}),
-      });
-    }
-    // Capture immediately after the serialized write. Another owner may share this directory and
-    // publish a different workspace generation before full-catalog parsing begins.
-    return {
-      modelsJsonContents: captureModelsJsonContents(input.agentDir),
-      pluginCatalogs: loadPersistedPluginModelCatalogsReadOnly(input.agentDir),
-      providerOutcomes: resultOutcomes(),
-    };
-  };
-  const { pluginMetadataSnapshot: metadataSnapshot, pluginRegistry } = pluginGeneration;
-  // Read-only inventories can request live discovery without preparing a runtime registry.
-  return pluginRegistry
-    ? withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, prepareSource)
-    : prepareSource();
 }

--- a/src/agents/prepared-model-runtime.scoped-catalog.ts
+++ b/src/agents/prepared-model-runtime.scoped-catalog.ts
@@ -1,12 +1,22 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.js";
+import { withPluginRuntimeGenerationScope } from "../plugins/runtime/generation-scope.js";
 import type { PreparedAgentCredentialModes } from "./agent-auth-credential-modes.js";
 import { resolveUsableAgentCredentialModes } from "./agent-auth-credentials.js";
 import { prepareAmbientAgentCredentialsForDiscovery } from "./agent-auth-discovery.js";
+import type { AuthProfileStore } from "./auth-profiles/types.js";
+import { createPreparedModelCatalogProviderNormalizer } from "./model-catalog-provider-normalizer.js";
 import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
+import { ensureOpenClawModelsJson, planOpenClawModelsJsonSource } from "./models-config.js";
 import { prepareImplicitProviderStaticCatalog } from "./models-config.providers.implicit.js";
+import { loadPersistedPluginModelCatalogsReadOnly } from "./plugin-model-catalog.js";
+import type {
+  PreparedModelRuntimeAgentFacts,
+  PreparedModelRuntimeCatalogSource,
+} from "./prepared-model-runtime.catalog-contract.js";
 import {
-  prepareAgentCatalogSource,
+  captureModelsJsonContents,
   prepareWorkspaceBuildGroup,
 } from "./prepared-model-runtime.facts.js";
 import {
@@ -20,7 +30,10 @@ import {
 import type {
   PreparedModelRuntimeCatalogMode,
   PreparedModelRuntimeInput,
+  PreparedModelRuntimePluginGeneration,
 } from "./prepared-model-runtime.types.js";
+
+const MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS = 5_000;
 
 type ScopedReadOnlyModelAuthInput = Pick<
   PreparedModelRuntimeInput,
@@ -114,4 +127,83 @@ export function prepareScopedReadOnlyLiveModelCatalog(
   providerDiscoveryProviderIds: readonly string[],
 ): Promise<ModelCatalogSnapshot> {
   return prepareScopedReadOnlyModelCatalogWithMode(input, providerDiscoveryProviderIds, "live");
+}
+
+export async function prepareAgentCatalogSource(
+  agentFacts: PreparedModelRuntimeAgentFacts,
+  pluginGeneration: PreparedModelRuntimePluginGeneration,
+  catalogMode: PreparedModelRuntimeCatalogMode,
+  persist = true,
+  sourceOptions: {
+    authStore?: AuthProfileStore;
+    providerDiscoveryProviderIds?: readonly string[];
+  } = {},
+): Promise<PreparedModelRuntimeCatalogSource> {
+  const { env, input, providerIds } = agentFacts;
+  const normalizeProvider = createPreparedModelCatalogProviderNormalizer(
+    pluginGeneration.pluginMetadataSnapshot,
+    input.config,
+    env,
+  );
+  const providerOutcomes = new Map<string, ProviderCatalogOutcome>();
+  const recordProviderOutcome = (outcome: ProviderCatalogOutcome) => {
+    const provider = normalizeProvider(outcome.provider);
+    if (provider) {
+      providerOutcomes.set(`${provider}\0${outcome.profileId ?? ""}`, { ...outcome, provider });
+    }
+  };
+  const resultOutcomes = () =>
+    [...providerOutcomes.values()].toSorted(
+      (left, right) =>
+        left.provider.localeCompare(right.provider) ||
+        (left.profileId ?? "").localeCompare(right.profileId ?? ""),
+    );
+  const options = {
+    pluginMetadataSnapshot: pluginGeneration.pluginMetadataSnapshot,
+    providerDiscoveryProviderIds: sourceOptions.providerDiscoveryProviderIds ?? providerIds,
+    ...(pluginGeneration.preparedStaticProviderCatalog
+      ? { preparedStaticProviderCatalog: pluginGeneration.preparedStaticProviderCatalog }
+      : {}),
+    ...(input.workspaceDir ? { workspaceDir: input.workspaceDir } : {}),
+    ...(input.env ? { env } : {}),
+    ...(catalogMode === "static"
+      ? {
+          providerDiscoveryEntriesOnly: true as const,
+        }
+      : {
+          providerDiscoveryTimeoutMs: MODEL_RUNTIME_PROVIDER_DISCOVERY_TIMEOUT_MS,
+        }),
+  };
+  const prepareSource = async () => {
+    if (!persist) {
+      const source = await planOpenClawModelsJsonSource(input.config, input.agentDir, {
+        ...options,
+        ...(sourceOptions.authStore ? { authStore: sourceOptions.authStore } : {}),
+        ...(catalogMode === "live" ? { onProviderCatalogOutcome: recordProviderOutcome } : {}),
+      });
+      return {
+        modelsJsonContents: source.modelsJsonContents,
+        pluginCatalogs: source.pluginCatalogs,
+        providerOutcomes: resultOutcomes(),
+      };
+    }
+    if (!input.readOnly) {
+      await ensureOpenClawModelsJson(input.config, input.agentDir, {
+        ...options,
+        ...(catalogMode === "live" ? { onProviderCatalogOutcome: recordProviderOutcome } : {}),
+      });
+    }
+    // Capture immediately after the serialized write. Another owner may share this directory and
+    // publish a different workspace generation before full-catalog parsing begins.
+    return {
+      modelsJsonContents: captureModelsJsonContents(input.agentDir),
+      pluginCatalogs: loadPersistedPluginModelCatalogsReadOnly(input.agentDir),
+      providerOutcomes: resultOutcomes(),
+    };
+  };
+  const { pluginMetadataSnapshot: metadataSnapshot, pluginRegistry } = pluginGeneration;
+  // Read-only inventories can request live discovery without preparing a runtime registry.
+  return pluginRegistry
+    ? withPluginRuntimeGenerationScope({ metadataSnapshot, pluginRegistry }, prepareSource)
+    : prepareSource();
 }


### PR DESCRIPTION
Related: #140674

## What Problem This Solves

Catalog-source preparation is mixed into workspace fact collection. Separating the existing function makes the later prepared-generation resource change easier to review independently.

## Why This Change Was Made

Move the unchanged catalog-source preparer into the scoped-catalog module and update build, worker, and test imports. The worker keeps its existing lazy await boundary and order. The existing model-file capture helper gains an internal export for its new caller; its body and call ordering remain unchanged.

## User Impact

No user-visible behavior change. Static/live discovery, read-only planning, persistence, provider outcome ordering, timeouts, and generation scope remain unchanged.

## Evidence

- Exact comparison confirms the complete moved declaration and existing capture helper are unchanged apart from the export.
- 111 existing tests passed in 55.580 seconds, covering runtime/build, owner selection, static/read-only startup, worker secrets, and actual worker integration.
- Canonical changed checks passed in 381.266 seconds, including production/test types, lint, dead exports, and zero runtime import cycles.
- Import-closure inspection confirms the worker's existing facts/full-catalog imports already include the new scoped-catalog dependencies. The full `pnpm build` then passed on the reviewed head in 244.757 seconds, including the compiled worker/import surfaces. All 39,491 tracked entries, index, and HEAD stayed unchanged. No live-provider claim is made.
- Deslop and independent P0–P2 Codex review completed without actionable findings.

Four production files change through code movement and imports; the fifth file has only the required test import port. No schema, configuration, dependency, or resource-lifetime change.

The latest ClawSweeper review found no code defect and requested compiled-build validation for the worker import relocation. The successful full build above completes that request and its corresponding Rank-up move.
