### PR TITLE
fix(message): render Matrix reaction labels as plain text

### DIFF
--- a/docs/cli/message.md
+++ b/docs/cli/message.md
@@ -89,6 +89,9 @@ unresolved SecretRef on the selected channel/account fails the action closed.
 | `search`        | Discord                                                                                                         | `--guild-id`, `--query`                                        | `--channel-id`, `--channel-ids` (repeat), `--author-id`, `--author-ids` (repeat), `--limit`.                                                                                                                                                                                                           |
 | `member info`   | Discord, Matrix, Microsoft Teams, Slack                                                                         | `--user-id`                                                    | `--guild-id` (Discord).                                                                                                                                                                                                                                                                                |
 
+Reaction listings show labels, counts, and available users as plain terminal text.
+Use `--json` for the complete channel result.
+
 The legacy `message read --include-thread` spelling remains accepted for existing
 scripts but has no effect.
 

--- a/src/commands/message-format.test.ts
+++ b/src/commands/message-format.test.ts
@@ -163,6 +163,72 @@ describe("formatMessageCliText displayLimit", () => {
   });
 });
 
+describe("formatMessageCliText reaction labels", () => {
+  it.each(["raw", "name", "emoji", "key"] as const)(
+    "renders untrusted %s reaction cells as plain terminal text",
+    (field) => {
+      const label = "\u001b[2Jreaction\nline";
+      const reaction = field === "raw" ? { emoji: { raw: label } } : { [field]: label };
+      const result = {
+        kind: "action",
+        channel: "matrix",
+        action: "reactions",
+        handledBy: "plugin",
+        payload: {
+          reactions: [{ ...reaction, count: 2, users: ["\u001b[31malice\u001b[0m", "bob\tother"] }],
+        },
+        dryRun: false,
+      } satisfies MessageActionResult;
+      const payload = structuredClone(result.payload);
+
+      const output = textJoined(formatMessageCliText(result));
+
+      expect(result.payload).toEqual(payload);
+      expect(output).not.toContain("\u001b[2J");
+      expect(output).toContain("reaction\\nline");
+      expect(output).toContain("alice");
+      expect(output).toContain("bob\\tother");
+      expect(output.replaceAll("\n", "")).not.toMatch(/\p{Cc}/u);
+    },
+  );
+
+  it.each([
+    ["matrix", { key: "👍" }, "👍"],
+    ["matrix", { key: ":party_parrot:" }, ":party_parrot:"],
+    ["discord", { emoji: { id: "123", name: "party", raw: "party:123" } }, "party:123"],
+    ["slack", { name: "thumbsup" }, "thumbsup"],
+    ["msteams", { name: "like", emoji: "👍" }, "like"],
+    [
+      "directchat",
+      { emoji: { raw: "raw-priority" }, name: "unused-name", key: "unused-key" },
+      "raw-priority",
+    ],
+    [
+      "directchat",
+      { name: "name-priority", emoji: "unused-emoji", key: "unused-key" },
+      "name-priority",
+    ],
+    ["directchat", { emoji: "🦞", key: "unused-key" }, "🦞"],
+  ] as const)("renders %s reaction labels from their result shape", (channel, reaction, label) => {
+    const result = {
+      kind: "action",
+      channel,
+      action: "reactions",
+      handledBy: "plugin",
+      payload: {
+        reactions: [{ ...reaction, count: 2, users: ["@alice:qa.test", "@bob:qa.test"] }],
+      },
+      dryRun: false,
+    } satisfies MessageActionResult;
+
+    const output = textJoined(formatMessageCliText(result));
+
+    expect(output).toContain(label);
+    expect(output).toContain("@alice:qa.test");
+    expect(output).toContain("@bob:qa.test");
+  });
+});
+
 describe("renderPaginationHint", () => {
   it("emits hint when payload has hasMore: true", () => {
     const messages = [msg("id-1", "2026-01-01T00:00:00.000Z", "alice", "hello")];

--- a/src/commands/message-format.ts
+++ b/src/commands/message-format.ts
@@ -1,6 +1,10 @@
 /** Human-readable formatter for `openclaw message` action results. */
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
-import { getTerminalTableWidth, renderTable } from "../../packages/terminal-core/src/table.js";
+import {
+  getTerminalTableWidth,
+  renderTable,
+  renderTerminalSafeTable,
+} from "../../packages/terminal-core/src/table.js";
 import { isRich, theme } from "../../packages/terminal-core/src/theme.js";
 import { getLoadedChannelPlugin } from "../channels/plugins/index.js";
 import type { ChannelId } from "../channels/plugins/types.public.js";
@@ -148,7 +152,7 @@ function renderReactions(payload: unknown, opts: FormatOpts): string | null {
     const entry = r as Record<string, unknown>;
     const emojiObj = entry.emoji as Record<string, unknown> | undefined;
     const emoji =
-      firstNonemptyString(emojiObj, "raw") || firstNonemptyString(entry, "name", "emoji");
+      firstNonemptyString(emojiObj, "raw") || firstNonemptyString(entry, "name", "emoji", "key");
     const count = typeof entry.count === "number" ? String(entry.count) : "";
     const userList = Array.isArray(entry.users)
       ? (entry.users as unknown[])
@@ -176,7 +180,8 @@ function renderReactions(payload: unknown, opts: FormatOpts): string | null {
     return theme.muted("No reactions.");
   }
 
-  return renderTable({
+  // Escape remote labels and users only for display; raw keys remain identities in JSON.
+  return renderTerminalSafeTable({
     width: opts.width,
     columns: [
       { key: "Emoji", header: "Emoji", minWidth: 8 },


### PR DESCRIPTION
Closes #141802

## What Problem This Solves

Fixes an issue where operators listing Matrix reactions see counts and users with a blank Emoji column. The native result stores its label in `key`, which the human formatter did not recognize.

## Why This Change Was Made

The shared reaction formatter recognizes `key` after the existing `emoji.raw`, `name`, and scalar `emoji` fields. Reaction cells use the existing renderer for plain terminal text, so remote labels and users remain data when displayed. Raw provider results, aggregation keys, JSON, account selection and request limits are preserved.

Production is +8/−3 (net +5), including the canonical renderer import and one boundary comment; tests add 66 lines and docs add three. The extra production lines keep the newly displayed data out of the renderer that preserves ANSI styling without adding a sanitizer, option, alias payload or provider-specific branch. Other table and direct-message formatting paths are outside this change. No configuration, schema, persistence, authentication, SDK or protocol contract changes.

## User Impact

Reaction listings now show `👍` with its two users and `:party_parrot:` with its one user. Literal annotation keys remain literal keys; this does not add an emote-pack feature. Line controls display as printable escapes, and terminal escape sequences in cell data are removed. `--json` retains the complete original values.

## Evidence

- Two intended baseline label failures and 38 controls; four additional renderer regressions exposed terminal-control passthrough before the safe-table correction. The final owner and message-command suites pass all 68 tests, including label precedence, raw payload preservation, limits and sibling shapes.
- The final changed-file gate and normal full `pnpm build` passed. The build took 4m25s, with 11,325 distribution files hashed and the tested source unchanged. An initial gate rejected a control-range regex in the new test; the equivalent Unicode-control predicate passes without disabling the lint rule.
- Paired real Tuwunel v1.8.3 proof: nine ordinary compiled CLI commands per build, all 18 exit zero with empty stderr. Full, limited, empty and control-key JSON outputs are byte-identical across builds. Independently seeded keys, counts and users match the results. Explicit and default account selection, result limits and empty listings remain correct.
- A separate message's control-character annotation key was accepted by the real API. Both JSON results preserve its exact value; the final human output contains the printable `reaction\nline` label and no raw control bytes with colour disabled. Output was captured through pipes; no physical-terminal side effect is claimed.
- Every CLI command has a recorded successful annotation-relations GET. The existing runner settled all children, the harness stopped, the owned container was absent and both ports could be rebound. Private fixtures and all earlier proof remain retained.

Proof identities are explicit: baseline normal build `031e7702ad81c933e7930f632ed2c25b439f8174` plus unrelated node-label patch `1153d21b20594b42433cc4e22a3fcc3b486a1ece421bc56182ed1dd6b3b48baa`; final candidate `2a6b2ed89f0ef27d0dabc436ed4f429f58db7f98` plus patch `364a12c52e3b7e9620c5725b9179f227b86107fb07c7f63d5783daf6de368a41`. The retained baseline's 39,401 source and 15,387 artifact entries were reverified before the first live run. Selected build/SDK bindings are checked around each run; the installed Matrix SDK is 42.2.0, and its inspected source/type bytes match across builds.

The live baseline omits Matrix keys. The intermediate unsafe display was demonstrated separately by the renderer's failing tests; the final live run establishes API acceptance, raw JSON preservation and safe final display. This is local Matrix service proof with synthetic accounts, not a production Gateway, real-user channel or model test. Introduction provenance remains unknown in shallow history.

The independent artifact audit verified all 18 outputs, 82 recorded exchanges, every final build asset, all four byte-identical JSON modes, the accepted control key and cleanup evidence. All seven benign candidate outputs also match the retained intermediate build byte for byte. One final managed P0–P2 review completed scoped-clean with zero findings. Commit `e963cf10bf67b020b58c726dfd9f896b0cacdac2` preserves the exact built/reviewed patch. Relevant owners, tests and Matrix producers remain unchanged on inspected main `add7dee816462c556c729369033044404e9944cb`.
