### PR TITLE
fix(clawrouter): report usage failures promptly during capture

### DIFF
--- a/extensions/clawrouter/usage.test.ts
+++ b/extensions/clawrouter/usage.test.ts
@@ -302,6 +302,36 @@ describe("ClawRouter usage", () => {
     expect(cancelled).toBe(true);
   });
 
+  it("releases a rejected response while a capture clone retains its body", async () => {
+    const cancel = vi.fn();
+    const response = new Response(new ReadableStream({ cancel }), { status: 503 });
+    const capture = response.clone();
+    const release = vi.fn(async () => {
+      await capture.body?.cancel();
+    });
+    const fetchGuard = mockFetchGuard(response);
+    fetchGuard.mockResolvedValue({
+      response,
+      finalUrl: "https://clawrouter.example/v1/usage",
+      release,
+    });
+    const outcome = fetchClawRouterUsage({
+      token: "proxy-key",
+      timeoutMs: 5000,
+      fetchGuard,
+    }).catch((error: unknown) => error);
+
+    try {
+      await vi.waitFor(() => expect(release).toHaveBeenCalledOnce());
+      expect(await outcome).toEqual(new Error("ClawRouter usage request failed (HTTP 503)"));
+      expect(cancel).toHaveBeenCalledOnce();
+    } finally {
+      // Settle both native tee branches even when the release-order assertion fails.
+      await capture.body?.cancel();
+      await outcome;
+    }
+  });
+
   it("observes peer closure when a real loopback server returns non-OK", async () => {
     let responseClosed = false;
     const { baseUrl, requests } = await startUsageServer((_req, res) => {

--- a/extensions/clawrouter/usage.ts
+++ b/extensions/clawrouter/usage.ts
@@ -115,7 +115,9 @@ export async function fetchClawRouterUsage(params: {
   );
   try {
     if (!response.ok) {
-      await response.body?.cancel().catch(() => undefined);
+      // A capture clone can keep cancellation pending. Let finally release the
+      // owned request before waiting on that diagnostic reader.
+      void response.body?.cancel().catch(() => undefined);
       throw new Error(`ClawRouter usage request failed (HTTP ${response.status})`);
     }
     const payload = await readClawRouterUsagePayload(response, params.timeoutMs);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where ClawRouter usage checks wait for a rejected HTTP response body to finish when diagnostic capture retains a response clone. The HTTP error is already known, but status callers can wait several seconds before the request is released.

## Why This Change Was Made

Request body cancellation without awaiting the retained clone, then let the existing guarded-request release run in `finally`. That owner aborts the request and closes its transport. Successful usage parsing, deadlines, proxy checks, and server errors remain unchanged.

## User Impact

ClawRouter usage checks finish promptly after a rejected response, even with diagnostic capture enabled. `status --usage` and Gateway `usage.status` retain the existing HTTP error. Text-mode `models status` also finishes promptly and keeps its existing behavior of hiding failed usage summaries.

## Evidence

Ran the real compiled CLI and Gateway on one isolated Linux Testbox with a controlled HTTP/CONNECT fixture, supported `openclaw proxy run` capture, and the actual capture database. Final scenarios used a loopback-only network namespace and synthetic credentials.

The fixture held a 503 response body for 3000 ms. Times below measure response headers to public command completion:

| Public surface | Current main | Candidate |
| --- | ---: | ---: |
| Gateway `usage.status` | 3026 ms | 33 ms |
| `status --usage --json --agent main` | 3166 ms | 207 ms |
| Text-mode `models status` with token profile | 3076 ms | 99 ms |

Each case sent exactly one usage request. The candidate closed the response before the held body completed, left no fixture socket open after settlement, and wrote exactly one correlated aborted HTTP capture terminal. Capture-off Gateway controls returned the same 503 error in 29 ms before and 25 ms after.

```text
ClawRouter usage request failed (HTTP 503)
```

- Managed monthly budget and unmetered spend values remain exact.
- Matching baseline/candidate controls preserve immediate EOF, malformed JSON, invalid UTF-8, oversized-body, stalled-body, stream-failure, proxy-route, and private-redirect behavior.
- Synthetic tokens are absent from command output, captured headers, and decoded captured payloads.
- All 14 ClawRouter tests, 13 usage-loader/plugin tests, and 10 real guarded-release tests passed. The new retained-clone regression fails on main because release is never reached; 13 other ClawRouter controls pass.
- The shared release suite confirms an abandoned captured request does not cancel its live pooled sibling.
- Changed-file formatting and lint passed.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34184245719) passed.

Baseline: `1029e3870f23315812565cc02d0504a208173697`. Candidate: `52e33c2956ca8a52c03f4e771641b7d91514b66f`. These are controlled fixture timings, not general performance benchmarks.

Independent source-blind validation passed 14 runtime scenarios with varied delays, plus a separate two-scenario host-policy follow-up. A configured local base remains usable, and a redirect to another private address is blocked. Seven additional shared host-policy tests passed, for 44 focused tests total. The original proof gap and its source-audited correction remain recorded; no new provider host restriction was added.
