### PR TITLE
fix(plugins): release chat inspection resources before replying

### DIFF
--- a/docs/tools/slash-commands.md
+++ b/docs/tools/slash-commands.md
@@ -519,7 +519,7 @@ the source and permits replacement of an existing install; it does not bypass
 are printed informationally; blocked releases remain non-installable.
 Marketplace, linked, and pinned installs remain shell-only.
 
-`/plugins inspect <child>` (also `show` or `get`) and `/plugins inspect all` include the shared package install metadata for multi-entry plugins. Inspection returns `install: null` when package ownership is missing or ambiguous, and preserves its runtime capability report.
+`/plugins inspect <child>` (also `show` or `get`) and `/plugins inspect all` include the shared package install metadata for multi-entry plugins. Inspection returns `install: null` when package ownership is missing or ambiguous, and preserves its runtime capability report. It releases its inspection registration resources before returning a reply, while the running Gateway's active registrations remain available. Cleanup failures propagate as command failures.
 
 When `/plugins install` or `/plugins enable` requires capability consent, it
 returns the plugin's declared capabilities and an exact retry command. Review

--- a/src/auto-reply/reply/commands-plugins.test.ts
+++ b/src/auto-reply/reply/commands-plugins.test.ts
@@ -5,7 +5,12 @@ import type { OpenClawConfig } from "../../config/config.js";
 import type { PluginCapabilityConsentReview } from "../../plugins/capability-summary.js";
 import { recordInstalledPluginIndexInstallOwner } from "../../plugins/installed-plugin-index-install-owner.js";
 import { ManagedPluginLifecycleError } from "../../plugins/management-lifecycle-error.js";
-import { createInstalledPluginIndexSnapshot } from "../../plugins/status.test-fixtures.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import {
+  createInstalledPluginIndexSnapshot,
+  createPluginRecord,
+} from "../../plugins/status.test-fixtures.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { handlePluginsCommand } from "./commands-plugins.js";
 import { buildPluginsCommandParams, type ConfigSnapshotMock } from "./commands.test-harness.js";
 
@@ -14,7 +19,9 @@ const loadPluginMetadataSnapshotMock = vi.hoisted(() => vi.fn());
 const validateConfigObjectWithPluginsMock = vi.hoisted(() => vi.fn());
 const replaceConfigFileMock = vi.hoisted(() => vi.fn(async (_params: unknown) => undefined));
 const buildPluginRegistrySnapshotReportMock = vi.hoisted(() => vi.fn());
-const buildPluginDiagnosticsReportMock = vi.hoisted(() => vi.fn());
+const withPluginDiagnosticsReportForInspectionMock = vi.hoisted(() =>
+  vi.fn<typeof import("../../plugins/status.js").withPluginDiagnosticsReportForInspection>(),
+);
 const buildPluginInspectReportMock = vi.hoisted(() => vi.fn());
 const buildAllPluginInspectReportsMock = vi.hoisted(() => vi.fn());
 const formatPluginCompatibilityNoticeMock = vi.hoisted(() => vi.fn(() => "ok"));
@@ -117,7 +124,7 @@ vi.mock("../../plugins/plugin-metadata-snapshot.js", async (importOriginal) => (
 
 vi.mock("../../plugins/status.js", () => ({
   buildAllPluginInspectReports: buildAllPluginInspectReportsMock,
-  buildPluginDiagnosticsReport: buildPluginDiagnosticsReportMock,
+  withPluginDiagnosticsReportForInspection: withPluginDiagnosticsReportForInspectionMock,
   buildPluginInspectReport: buildPluginInspectReportMock,
   buildPluginRegistrySnapshotReport: buildPluginRegistrySnapshotReportMock,
   formatPluginCompatibilityNotice: formatPluginCompatibilityNoticeMock,
@@ -238,18 +245,24 @@ describe("handlePluginsCommand", () => {
         },
       ],
     });
-    buildPluginDiagnosticsReportMock.mockReturnValue({
-      workspaceDir: "/tmp/plugins-workspace",
-      plugins: [
-        {
-          id: "superpowers",
-          name: "superpowers",
-          status: "disabled",
-          format: "openclaw",
-          bundleFormat: "claude",
-        },
-      ],
-    });
+    withPluginDiagnosticsReportForInspectionMock
+      .mockReset()
+      .mockImplementation(async (_params, formatReport) =>
+        formatReport({
+          ...createEmptyPluginRegistry(),
+          workspaceScope: "selected",
+          workspaceDir: "/tmp/plugins-workspace",
+          plugins: [
+            createPluginRecord({
+              id: "superpowers",
+              name: "superpowers",
+              status: "disabled",
+              format: "openclaw",
+              bundleFormat: "claude",
+            }),
+          ],
+        }),
+      );
     buildPluginInspectReportMock.mockReturnValue({
       plugin: {
         id: "superpowers",
@@ -265,6 +278,72 @@ describe("handlePluginsCommand", () => {
       },
     ]);
   });
+
+  it.each(["inspect", "inspect superpowers", "inspect all", "inspect missing"])(
+    "waits for inspection cleanup before returning the %s reply",
+    async (action) => {
+      const entered = createDeferredCore();
+      const finish = createDeferredCore();
+      if (action === "inspect missing") {
+        buildPluginInspectReportMock.mockReturnValue(null);
+      }
+      withPluginDiagnosticsReportForInspectionMock.mockImplementation(
+        async (_params, formatReport) => {
+          const text = formatReport({
+            ...createEmptyPluginRegistry(),
+            workspaceScope: "selected",
+            workspaceDir: "/tmp/plugins-workspace",
+          });
+          entered.resolve();
+          await finish.promise;
+          return text;
+        },
+      );
+      let returned = false;
+      const command = handlePluginsCommand(
+        buildPluginsParams(`/plugins ${action}`, buildCfg()),
+        true,
+      ).then((result) => {
+        returned = true;
+        return result;
+      });
+      try {
+        await entered.promise;
+        expect(returned).toBe(false);
+        expect(replaceConfigFileMock).not.toHaveBeenCalled();
+        expect(refreshPluginRegistryAfterConfigMutationMock).not.toHaveBeenCalled();
+      } finally {
+        finish.resolve();
+        await command;
+      }
+      expect(withPluginDiagnosticsReportForInspectionMock).toHaveBeenCalledTimes(1);
+      expect((await command)?.shouldContinue).toBe(false);
+      expect(withPluginDiagnosticsReportForInspectionMock.mock.calls[0]?.[0]).toEqual({
+        config: buildCfg(),
+        workspaceDir: "/tmp/plugins-workspace",
+        metadataSnapshot: { index: createInstalledPluginIndexSnapshot([]) },
+      });
+    },
+  );
+
+  it.each(["load", "format", "dispose"])(
+    "propagates %s failure without a successful reply",
+    async (phase) => {
+      const failure = new Error(`inspection ${phase} failed`);
+      if (phase === "format") {
+        buildPluginInspectReportMock.mockImplementation(() => {
+          throw failure;
+        });
+      } else {
+        withPluginDiagnosticsReportForInspectionMock.mockRejectedValue(failure);
+      }
+      await expect(
+        handlePluginsCommand(buildPluginsParams("/plugins inspect superpowers", buildCfg()), true),
+      ).rejects.toBe(failure);
+      expect(replaceConfigFileMock).not.toHaveBeenCalled();
+      expect(refreshPluginRegistryAfterConfigMutationMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("lists discovered plugins and inspects plugin details", async () => {
     const listResult = await handlePluginsCommand(
@@ -344,7 +423,7 @@ describe("handlePluginsCommand", () => {
         reports.map((inspect) => ({ inspect, compatibilityWarnings: [], install })),
       );
     }
-    expect(buildPluginDiagnosticsReportMock).toHaveBeenCalled();
+    expect(withPluginDiagnosticsReportForInspectionMock).toHaveBeenCalled();
     expect(buildPluginRegistrySnapshotReportMock).not.toHaveBeenCalled();
   });
 
@@ -354,7 +433,7 @@ describe("handlePluginsCommand", () => {
       true,
     );
     expect(result?.reply?.text).toContain("superpowers");
-    expect(buildPluginDiagnosticsReportMock).toHaveBeenCalledTimes(1);
+    expect(withPluginDiagnosticsReportForInspectionMock).toHaveBeenCalledTimes(1);
     expect(buildPluginRegistrySnapshotReportMock).not.toHaveBeenCalled();
   });
 
@@ -369,7 +448,7 @@ describe("handlePluginsCommand", () => {
         true,
       );
       expect(result?.reply?.text).toBe("⚠️ Config file is invalid; fix it before using /plugins.");
-      expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
+      expect(withPluginDiagnosticsReportForInspectionMock).not.toHaveBeenCalled();
       expect(buildPluginRegistrySnapshotReportMock).not.toHaveBeenCalled();
       expect(replaceConfigFileMock).not.toHaveBeenCalled();
     },
@@ -607,7 +686,7 @@ describe("handlePluginsCommand", () => {
     const result = await handlePluginsCommand(params, true);
     expect(result?.reply?.text).toContain('Plugin "superpowers" enabled');
     expect(buildPluginRegistrySnapshotReportMock).toHaveBeenCalledTimes(1);
-    expect(buildPluginDiagnosticsReportMock).not.toHaveBeenCalled();
+    expect(withPluginDiagnosticsReportForInspectionMock).not.toHaveBeenCalled();
   });
 
   it("returns an explicit unauthorized reply for native /plugins list", async () => {

--- a/src/auto-reply/reply/commands-plugins.ts
+++ b/src/auto-reply/reply/commands-plugins.ts
@@ -16,7 +16,7 @@ import { refreshPluginRegistryAfterConfigMutation } from "../../plugins/registry
 import type { PluginRecord } from "../../plugins/registry.js";
 import {
   buildAllPluginInspectReports,
-  buildPluginDiagnosticsReport,
+  withPluginDiagnosticsReportForInspection,
   buildPluginInspectReport,
   buildPluginRegistrySnapshotReport,
   formatPluginCompatibilityNotice,
@@ -224,36 +224,41 @@ export const handlePluginsCommand: CommandHandler = defineAuthorizedTextCommand(
 
       if (pluginsCommand.action === "inspect") {
         const metadataSnapshot = loadPluginMetadataSnapshot(reportParams);
-        const report = buildPluginDiagnosticsReport({ ...reportParams, metadataSnapshot });
-        if (!pluginsCommand.name) {
-          return commandReply(formatPluginsList(report));
-        }
-        if (normalizeOptionalLowercaseString(pluginsCommand.name) === "all") {
-          const ownershipResolver = createInstalledPluginOwnershipResolver(metadataSnapshot.index);
-          const reports = buildAllPluginInspectReports({ config, report }).map((inspect) =>
-            buildPluginInspectJson(inspect, ownershipResolver),
-          );
-          return commandReply(renderJsonBlock("🔌 Plugins", reports));
-        }
-        const inspect = buildPluginInspectReport({
-          id: pluginsCommand.name,
-          config,
-          report,
-        });
-        if (!inspect) {
-          return commandReply(`🔌 No plugin named "${pluginsCommand.name}" found.`);
-        }
-        const payload = buildPluginInspectJson(
-          inspect,
-          createInstalledPluginOwnershipResolver(metadataSnapshot.index),
+        const text = await withPluginDiagnosticsReportForInspection(
+          { ...reportParams, metadataSnapshot },
+          (report) => {
+            if (!pluginsCommand.name) {
+              return formatPluginsList(report);
+            }
+            if (normalizeOptionalLowercaseString(pluginsCommand.name) === "all") {
+              const ownershipResolver = createInstalledPluginOwnershipResolver(
+                metadataSnapshot.index,
+              );
+              const reports = buildAllPluginInspectReports({ config, report }).map((inspect) =>
+                buildPluginInspectJson(inspect, ownershipResolver),
+              );
+              return renderJsonBlock("🔌 Plugins", reports);
+            }
+            const inspect = buildPluginInspectReport({
+              id: pluginsCommand.name,
+              config,
+              report,
+            });
+            if (!inspect) {
+              return `🔌 No plugin named "${pluginsCommand.name}" found.`;
+            }
+            const payload = buildPluginInspectJson(
+              inspect,
+              createInstalledPluginOwnershipResolver(metadataSnapshot.index),
+            );
+            return renderJsonBlock(`🔌 Plugin "${inspect.plugin.id}"`, {
+              ...inspect,
+              compatibilityWarnings: payload.compatibilityWarnings,
+              install: payload.install,
+            });
+          },
         );
-        return commandReply(
-          renderJsonBlock(`🔌 Plugin "${inspect.plugin.id}"`, {
-            ...inspect,
-            compatibilityWarnings: payload.compatibilityWarnings,
-            install: payload.install,
-          }),
-        );
+        return commandReply(text);
       }
 
       const report = buildPluginRegistrySnapshotReport(reportParams);

--- a/src/plugins/status.runtime-inspection.test.ts
+++ b/src/plugins/status.runtime-inspection.test.ts
@@ -2,9 +2,12 @@ import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { handlePluginsCommand } from "../auto-reply/reply/commands-plugins.js";
+import { buildPluginsCommandParams } from "../auto-reply/reply/commands.test-harness.js";
 import { runPluginsInspectCommand } from "../cli/plugins-inspect-command.js";
 import { readConfigFileSnapshotForWrite, writeConfigFile } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
 import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import { setGatewayPluginMetadataSnapshot } from "./current-plugin-metadata-snapshot.js";
@@ -13,6 +16,7 @@ import { selectInstallMutationWriteOptions } from "./install-config-mutation.js"
 import { persistPluginInstall } from "./install-persistence.js";
 import { readPersistedInstalledPluginIndexInstallRecords } from "./installed-plugin-index-records.js";
 import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
+import { loadAndActivateRootPluginRegistry } from "./loader.js";
 import {
   cleanupPluginLoaderFixturesForTest,
   makePluginLoaderTempDir,
@@ -24,7 +28,12 @@ import { mutateManagedPluginEnabled } from "./management-mutations.js";
 import { withPluginLifecycleLease } from "./plugin-lifecycle-lease.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import { loadPluginMetadataSnapshot } from "./plugin-metadata-snapshot.js";
+import {
+  capturePluginRegistryLifecycleEpoch,
+  capturePluginRegistryLifecycleSignal,
+} from "./registry-lifecycle.js";
 import { getActivePluginRegistry } from "./runtime.js";
+import { withPluginRuntimeRegistryScope } from "./runtime/gateway-request-scope.js";
 import { applySlotSelectionForPlugin } from "./slot-selection.js";
 import * as statusSnapshot from "./status-snapshot.js";
 import {
@@ -42,6 +51,141 @@ describe("plugin runtime inspection", () => {
   afterAll(() => {
     cleanupPluginLoaderFixturesForTest();
   });
+
+  it.each(["inspect", "inspect native-chat-inspection", "inspect all", "inspect missing"])(
+    "releases chat inspection while the active native registration stays usable: %s",
+    async (selection) => {
+      const stateDir = makePluginLoaderTempDir();
+      const key = `__openclaw_chat_inspection_${selection}`;
+      const started = createDeferredCore();
+      const finish = createDeferredCore();
+      const connections: Array<{
+        database: DatabaseSync;
+        mode: string;
+        disposals: number;
+        cleanups: number;
+      }> = [];
+      Object.defineProperty(globalThis, key, {
+        value: { connections, started, finish },
+        configurable: true,
+      });
+      const plugin = writePlugin({
+        id: "native-chat-inspection",
+        body: `
+const { DatabaseSync } = require("node:sqlite");
+module.exports = { id: "native-chat-inspection", register(api) {
+  const state = globalThis[${JSON.stringify(key)}];
+  const database = new DatabaseSync(${JSON.stringify(path.join(stateDir, "connection-"))} + state.connections.length + ".sqlite");
+  database.exec("CREATE TABLE owned (value INTEGER); INSERT INTO owned VALUES (42)");
+  const connection = { database, mode: api.registrationMode, disposals: 0, cleanups: 0 };
+  state.connections.push(connection);
+  class NativeLifecycle {
+    id = "native-chat-resource";
+    #database = database;
+    async dispose() {
+      connection.disposals++;
+      state.started.resolve();
+      await state.finish.promise;
+      this.#database.close();
+    }
+    cleanup = () => { connection.cleanups++; };
+  }
+  api.registerRuntimeLifecycle(new NativeLifecycle());
+} };`,
+      });
+      let command: ReturnType<typeof handlePluginsCommand> | undefined;
+      try {
+        await withEnvAsync(
+          {
+            OPENCLAW_HOME: stateDir,
+            OPENCLAW_STATE_DIR: stateDir,
+            OPENCLAW_CONFIG_PATH: path.join(stateDir, "openclaw.json"),
+          },
+          async () => {
+            useNoBundledPlugins();
+            const config = {
+              commands: { text: true, plugins: true },
+              plugins: {
+                allow: [plugin.id],
+                load: { paths: [plugin.file] },
+                slots: { memory: "none" },
+              },
+            };
+            await writeConfigFile(config);
+            const active = loadAndActivateRootPluginRegistry({
+              config,
+              workspaceDir: stateDir,
+              cache: false,
+            });
+            const epoch = capturePluginRegistryLifecycleEpoch(active);
+            const signal = capturePluginRegistryLifecycleSignal(active, epoch);
+            expect(epoch).toBeDefined();
+            expect(signal?.aborted).toBe(false);
+            const activeConnection = connections[0];
+            expect(activeConnection?.mode).toBe("full");
+            const readActive = () =>
+              activeConnection?.database.prepare("SELECT value FROM owned").get();
+            expect(readActive()).toEqual({ value: 42 });
+            let replied = false;
+            command = withPluginRuntimeRegistryScope(active, () =>
+              handlePluginsCommand(
+                buildPluginsCommandParams({
+                  commandBodyNormalized: `/plugins ${selection}`,
+                  cfg: config,
+                  workspaceDir: stateDir,
+                }),
+                true,
+              ),
+            ).then((result) => {
+              replied = true;
+              return result;
+            });
+            await Promise.race([started.promise, command]);
+            expect(connections).toHaveLength(2);
+            const inspection = connections[1];
+            expect(inspection?.mode).toBe("discovery");
+            expect(inspection?.disposals).toBe(1);
+            expect(inspection?.database.isOpen).toBe(true);
+            expect(replied).toBe(false);
+            expect(readActive()).toEqual({ value: 42 });
+            expect(getActivePluginRegistry()).toBe(active);
+            expect(capturePluginRegistryLifecycleEpoch(active)).toBe(epoch);
+            expect(signal?.aborted).toBe(false);
+            finish.resolve();
+            const result = await command;
+            expect(result?.shouldContinue).toBe(false);
+            expect(result?.reply?.text).toContain(
+              selection === "inspect missing"
+                ? 'No plugin named "missing" found.'
+                : selection === "inspect"
+                  ? "Plugins ("
+                  : "```json",
+            );
+            expect(inspection?.database.isOpen).toBe(false);
+            expect(inspection?.disposals).toBe(1);
+            expect(activeConnection?.disposals).toBe(0);
+            expect(connections.map((connection) => connection.cleanups)).toEqual([0, 0]);
+            expect(readActive()).toEqual({ value: 42 });
+            expect(getActivePluginRegistry()).toBe(active);
+            expect(capturePluginRegistryLifecycleEpoch(active)).toBe(epoch);
+            expect(signal?.aborted).toBe(false);
+          },
+        );
+      } finally {
+        finish.resolve();
+        try {
+          await command;
+        } finally {
+          for (const { database } of connections) {
+            if (database.isOpen) {
+              database.close();
+            }
+          }
+          Reflect.deleteProperty(globalThis, key);
+        }
+      }
+    },
+  );
 
   it.each([
     "single",


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `/plugins inspect` left registration resources open after returning a report. Repeated chat inspections could accumulate native database connections and other resources created by plugin registration.

## Why This Change Was Made

The inspect command now uses the existing inspection owner to render its reply while resources are available, await their disposal, and then return the text. Each inspection owns separate registration instances, so cleanup leaves the active Gateway registration usable.

Related: #140674. This is a four-file replacement slice; the aggregate remains a draft reference.

## User Impact

Bare, named, all, and missing-plugin inspection keep their discovery mode and report scope. The `show`/`get` aliases, package provenance, authorization, configuration validation, and other plugin commands retain their behavior. Cleanup failures propagate as command failures.

## Evidence

The native regression failed before the repair. All 54 focused tests and the canonical changed checks passed, followed by a successful full build (301.91 seconds). Codex review found no actionable findings.

Seven runs through the built command dispatcher covered bare/named/all/missing inspection, aliases, and disposal rejection in 5.187 seconds. Synthetic authenticated command contexts and file-backed native SQLite demonstrated that each inspection connection closes once while the active registration remains queryable before, during, and after cleanup, with unchanged registry identity, epoch, and signal. Source and build artifacts stayed unchanged during proof.

This is built command-dispatcher and native-resource proof; no Gateway server, channel, network, or provider coverage is claimed. Production changes are limited to the inspect branch and its import (+35/-30 lines); existing test files add the ownership regression coverage. No schema or persistence semantics change.
