### PR TITLE
refactor: keep live image probe matching private

### DIFF
--- a/src/agents/live-model-turn-probes.test.ts
+++ b/src/agents/live-model-turn-probes.test.ts
@@ -5,7 +5,6 @@ import {
   buildLiveModelFileProbeRetryContext,
   buildLiveModelImageProbeContext,
   fileProbeTextMatches,
-  imageProbeTextMatches,
   isLiveModelProbeEnabled,
   LIVE_MODEL_FILE_PROBE_TOKEN,
   modelSupportsImageInput,
@@ -178,9 +177,6 @@ describe("live model turn probes", () => {
   it("matches expected probe replies", () => {
     expect(fileProbeTextMatches(`The value is ${LIVE_MODEL_FILE_PROBE_TOKEN}.`)).toBe(true);
     expect(fileProbeTextMatches("amber")).toBe(false);
-    expect(imageProbeTextMatches("OK")).toBe(true);
-    expect(imageProbeTextMatches("blue")).toBe(false);
-    expect(imageProbeTextMatches('" or "Reply with exactly')).toBe(false);
   });
 
   it("retries one mismatched image reply and accepts only a matching retry", async () => {

--- a/src/agents/test-helpers/live-model-turn-probes.ts
+++ b/src/agents/test-helpers/live-model-turn-probes.ts
@@ -151,7 +151,7 @@ export function fileProbeTextMatches(text: string): boolean {
 }
 
 /** Returns whether image probe output contains an OK acknowledgement. */
-export function imageProbeTextMatches(text: string): boolean {
+function imageProbeTextMatches(text: string): boolean {
   return /\bok\b/i.test(text);
 }
 


### PR DESCRIPTION
## What Problem This Solves

The live image-probe suite exposes an internal reply matcher solely to repeat three assertions already covered by its retry flow. That couples the tests to a helper export without protecting additional behavior.

## Why This Change Was Made

Keep the matcher private and remove only the redundant direct assertions and import. The retry tests retain the same success and rejection inputs, exact attempt and callback checks, empty-response failures, provider-error handling, and diagnostic redaction. The matcher implementation and live caller remain unchanged.

## User Impact

No user-visible behavior change. All 17 test cases remain. Production code is unchanged; test support has a net-zero line change and the test file loses four lines.

## Evidence

- Complete focused suite before and after: 17 passed, zero skipped or failed, with identical case inventories.
- Targeted formatting and diff checks passed.
- Normal changed-file gate: all selected checks passed on the configured Linux Testbox, including core and core-test types, dead exports, scoped lint, and the structural guards ([run](https://github.com/openclaw/openclaw/actions/runs/34184209902)). The one-shot Testbox stopped after success.
- Independent Codex review: clean through P2; no actionable findings.

No live provider execution is claimed for this private-export and duplicate-assertion cleanup.
