### PR TITLE
refactor(gateway): keep cached turn replay with dedupe

### DIFF
--- a/src/gateway/agent-turn/agent-dedupe.ts
+++ b/src/gateway/agent-turn/agent-dedupe.ts
@@ -1,6 +1,9 @@
+import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { GatewayRequestContext } from "../server-methods/types.js";
 import { setGatewayDedupeEntry } from "./agent-job.js";
+import type { AgentTurnIo } from "./types.js";
 
 export function resolveAgentDedupeKeys(params: {
   idempotencyKey: string;
@@ -141,4 +144,44 @@ export function setAbortedAgentDedupeEntries(params: {
       },
     },
   });
+}
+
+export function replayAgentTurnIfCached(params: {
+  preflight: { agentDedupeKeys: readonly string[]; runId: string };
+  context: GatewayRequestContext;
+  io: AgentTurnIo;
+}): boolean {
+  const { agentDedupeKeys, runId } = params.preflight;
+  const cached = readGatewayDedupeEntry({
+    dedupe: params.context.dedupe,
+    keys: agentDedupeKeys,
+  });
+  if (!cached) {
+    return false;
+  }
+  if (cached.ok && isAcceptedAgentDedupePayload(cached.payload)) {
+    const cachedRunId = normalizeOptionalString(cached.payload.runId) ?? runId;
+    const cachedSessionKey = normalizeOptionalString(cached.payload.sessionKey);
+    const cachedAgentId = normalizeOptionalString(cached.payload.agentId);
+    const cachedRuntime = asOptionalRecord(cached.payload.runtime);
+    const admissionPending = typeof cached.payload.reservationId === "string";
+    params.io.emitAcceptance(
+      [
+        true,
+        {
+          runId: cachedRunId,
+          status: "in_flight" as const,
+          ...(cachedSessionKey ? { sessionKey: cachedSessionKey } : {}),
+          ...(cachedAgentId ? { agentId: cachedAgentId } : {}),
+          ...(cachedRuntime ? { runtime: cachedRuntime } : {}),
+          ...(admissionPending ? { admissionPending: true } : {}),
+        },
+        undefined,
+      ],
+      { cached: true, runId: cachedRunId },
+    );
+  } else {
+    params.io.emitAcceptance([cached.ok, cached.payload, cached.error], { cached: true });
+  }
+  return true;
 }

--- a/src/gateway/agent-turn/agent-turn-service.ts
+++ b/src/gateway/agent-turn/agent-turn-service.ts
@@ -1,4 +1,3 @@
-import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { ErrorCodes, type AgentWaitParams } from "../../../packages/gateway-protocol/src/index.js";
 import { MAIN_SESSION_RECOVERY_WORK_ADMISSION_OWNER } from "../../agents/main-session-recovery/main-session-recovery-admission.js";
@@ -25,7 +24,7 @@ import { prepareSkillLibrarySessionCreation } from "../skill-library-session.js"
 import { createAgentAdmissionController } from "./agent-admission-controller.js";
 import { prepareAgentContentPhase } from "./agent-content-phase.js";
 import { createAgentDedupeLifecycle } from "./agent-dedupe-lifecycle.js";
-import { isAcceptedAgentDedupePayload, readGatewayDedupeEntry } from "./agent-dedupe.js";
+import { replayAgentTurnIfCached } from "./agent-dedupe.js";
 import { resolveAgentDeliveryPhase } from "./agent-delivery-phase.js";
 import type { RestoredCronContinuation } from "./agent-handler-helpers.js";
 import { waitForAgentJob } from "./agent-job.js";
@@ -43,46 +42,6 @@ type AgentTurnStartRequest = {
   io: AgentTurnIo;
   onRunObserved?: (runId: string) => void;
 };
-
-function replayAgentTurnIfCached(params: {
-  preflight: AgentRequestPreflight;
-  context: GatewayRequestHandlerOptions["context"];
-  io: AgentTurnIo;
-}): boolean {
-  const { agentDedupeKeys, runId } = params.preflight;
-  const cached = readGatewayDedupeEntry({
-    dedupe: params.context.dedupe,
-    keys: agentDedupeKeys,
-  });
-  if (!cached) {
-    return false;
-  }
-  if (cached.ok && isAcceptedAgentDedupePayload(cached.payload)) {
-    const cachedRunId = normalizeOptionalString(cached.payload.runId) ?? runId;
-    const cachedSessionKey = normalizeOptionalString(cached.payload.sessionKey);
-    const cachedAgentId = normalizeOptionalString(cached.payload.agentId);
-    const cachedRuntime = asOptionalRecord(cached.payload.runtime);
-    const admissionPending = typeof cached.payload.reservationId === "string";
-    params.io.emitAcceptance(
-      [
-        true,
-        {
-          runId: cachedRunId,
-          status: "in_flight" as const,
-          ...(cachedSessionKey ? { sessionKey: cachedSessionKey } : {}),
-          ...(cachedAgentId ? { agentId: cachedAgentId } : {}),
-          ...(cachedRuntime ? { runtime: cachedRuntime } : {}),
-          ...(admissionPending ? { admissionPending: true } : {}),
-        },
-        undefined,
-      ],
-      { cached: true, runId: cachedRunId },
-    );
-  } else {
-    params.io.emitAcceptance([cached.ok, cached.payload, cached.error], { cached: true });
-  }
-  return true;
-}
 
 export function createAgentTurnService(
   { context, isWebchatConnect }: Pick<GatewayRequestHandlerOptions, "context" | "isWebchatConnect">,


### PR DESCRIPTION
## What Problem This Solves

Cached agent-turn replay lives in the turn orchestration module, separate from its existing dedupe reader and payload classifier. Moving it to that owner makes the later lifetime changes in #140674 easier to review independently.

## Why This Change Was Made

Move the unchanged replay helper into the existing dedupe module and import it directly from the turn service. Its parameters describe the two preflight fields it reads and use the existing Gateway context type. The call remains before lifecycle generation, reservations, and awaited preparation.

## User Impact

No user-visible behavior change. Accepted, completed, and failed cached responses keep their payload and metadata. Cache misses continue normal admission. No cache policy, resource lifetime, schema, protocol, or SDK change.

## Evidence

The complete helper body is byte-identical to the original, and all other statements remain unchanged. The new type import is erased; both normalization helpers already belong to the module's runtime dependency graph. No lazy or bundled-plugin import boundary changes.

All 22 existing preflight tests passed before and after the move. Wall times were 35.39 and 14.48 seconds; the second run used warmed caches, so these are validation timings, not a speedup claim. Two existing isolated Gateway WebSocket cases passed in 29.03 seconds, covering completed-response dedupe and replay after reconnect. No tests were changed or added.

Canonical changed checks passed in 405.53 seconds, including core and test types, lint, and zero runtime import cycles. Independent Codex review found no actionable findings. The diff touches two production files (+44/-42 lines), with no compatibility alias or duplicated helper left behind.
