### PR TITLE
fix(release): preserve frozen gateway package resolution

### DIFF
--- a/scripts/e2e/gateway-network-docker.sh
+++ b/scripts/e2e/gateway-network-docker.sh
@@ -106,11 +106,11 @@ if [[ -n "$LEGACY_GATEWAY_LIB" ]]; then
     "${DOCKER_E2E_HARNESS_ARGS[@]}" \
     --network "$NET_NAME" \
     "${CLIENT_LIMIT_ENV_ARGS[@]}" \
-    -v "$LEGACY_GATEWAY_LIB:/tmp/openclaw-selected-e2e-lib:ro" \
+    -v "$LEGACY_GATEWAY_LIB:/app/scripts/e2e/lib:ro" \
     -e "GW_URL=ws://$GW_NAME:$PORT" \
     -e "GW_TOKEN=$TOKEN" \
     "$IMAGE_NAME" \
-    node /tmp/openclaw-selected-e2e-lib/gateway-network/client.mjs
+    node /app/scripts/e2e/lib/gateway-network/client.mjs
   echo "OK"
   exit 0
 fi

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -6949,8 +6949,9 @@ process.exit(73);
     const runner = readFileSync(GATEWAY_NETWORK_DOCKER_E2E_PATH, "utf8");
     expect(runner).toContain('[[ "$FROZEN_CONTEXT" == "1" ]]');
     expect(runner).toContain("scripts/e2e/lib/gateway-network/client.mjs");
-    expect(runner).toContain('-v "$LEGACY_GATEWAY_LIB:/tmp/openclaw-selected-e2e-lib:ro"');
-    expect(runner).toContain("node /tmp/openclaw-selected-e2e-lib/gateway-network/client.mjs");
+    expect(runner).toContain('-v "$LEGACY_GATEWAY_LIB:/app/scripts/e2e/lib:ro"');
+    expect(runner).toContain("node /app/scripts/e2e/lib/gateway-network/client.mjs");
+    expect(runner).not.toContain("/tmp/openclaw-selected-e2e-lib");
     expect(runner).not.toContain("/tmp/openclaw-gateway-network-client.mjs");
   });
 


### PR DESCRIPTION
## Summary

- mount the authorized selected-release gateway client at its canonical `/app/scripts/e2e/lib` path
- preserve both relative ESM imports and bare package resolution through `/app/node_modules`
- leave the strict current-harness path unchanged

## Root cause

Full validation job https://github.com/openclaw/openclaw/actions/runs/34184637525/job/101931606884 failed because the selected client was copied under `/tmp`. Its relative imports resolved there, but the bare `ws` import could not walk to `/app/node_modules`. The later, client-only bind now shadows the broad harness bind at the original package root.

## Validation

- red before fix: focused Docker contract expected the canonical mount and failed on the `/tmp` path
- green after fix: focused Docker contract 1/1
- `bash -n scripts/e2e/gateway-network-docker.sh`
- Oxfmt, OXLint, diff check
- changed-file gate
- AutoReview: correct, no P0/P1 findings (0.94)

## LOC

- release tooling: +2/-2
- tests: +3/-2
- application runtime: 0
