### PR TITLE
refactor(doctor): reuse path containment predicate

### DIFF
--- a/src/commands/doctor-state-integrity.ts
+++ b/src/commands/doctor-state-integrity.ts
@@ -324,16 +324,7 @@ function countJsonlLines(filePath: string): number {
 }
 
 function isPathUnderRoot(targetPath: string, rootPath: string): boolean {
-  const normalizedTarget = path.resolve(targetPath);
-  const normalizedRoot = path.resolve(rootPath);
-  const rootToken = path.parse(normalizedRoot).root;
-  if (normalizedRoot === rootToken) {
-    return normalizedTarget.startsWith(rootToken);
-  }
-  return (
-    normalizedTarget === normalizedRoot ||
-    normalizedTarget.startsWith(`${normalizedRoot}${path.sep}`)
-  );
+  return isPathUnderRootWithPathOps(targetPath, rootPath, path);
 }
 
 const tryResolveRealPath = safeRealpathSync;


### PR DESCRIPTION
## What Problem This Solves

Maintainer-requested consolidation of Doctor's state-directory containment check. The native-path wrapper repeats the same comparison already used by the path-operations helper, leaving two implementations of one rule to maintain. This is not a fix for an observed user-visible regression.

## Why This Change Was Made

Delegate the private native-path wrapper to the existing same-file helper with the unchanged `path` object. Keep its declaration, callers, imports, Linux `path.posix` routing, and ancestor/symlink resolution unchanged.

## User Impact

No intended user-visible behavior change. Root handling, short-circuiting, property evaluation order, and lazy separator lookup are preserved. Delegation adds one stack frame.

## Evidence

- Existing four Doctor suites: 49 tests passed before and after (20.49s / 16.25s).
- Exact missing-state Doctor command case: one passed before and after (29.22s / 22.75s); 26 unrelated cases filtered out each time. Used the runner's `OPENCLAW_E2E_SKIP_BUILD=1` fixture-owned mode: the test imports real Doctor/state-integrity source with mocked service/Gateway operations and temporary state.
- Initial default E2E preparation failed before collecting any tests because diffs-plugin asset dependencies were unavailable in the linked checkout. No full CLI/dist-build or live credentialed proof is claimed.
- Exact-file comparison confirms only the wrapper body changed: one file, +1/-10. The canonical helper is unchanged; its AST body matches the removed body after substituting `pathOps` with `path`.
- Targeted formatting, lint, and `git diff --check` passed. The actual changed gate passed 14 stages, then stopped at the shared-compiler containment guard. No local type pass or bypass; later gate stages were not reached.
- Fresh independent autoreview: scoped-clean at the owning skill's default P0 threshold, no findings. Completed ClawSweeper review on the same head found no actionable defect.
- Exact-head hosted CI for `7b85c8f86d4adefdddb54163dacc1b7d53bf7973`: 109 jobs succeeded, 16 skipped, none failed. `check-prod-types`, `check-test-types`, `check-test-types-core-1`, `check-test-types-core-2`, and required `openclaw/ci-gate` all passed: https://github.com/openclaw/openclaw/actions/runs/34186277484
- The Windows matrix was skipped, not passed. Hosted CI supplies real type evidence; it is not credentialed live Crabbox proof and does not turn the failed local build/type attempts into passes.

No tests or baselines changed. Direct getter/error-order, case/UNC, and sibling-prefix matrices remain separate coverage gaps. The filtered command case proves wiring, not the full cloud-warning output.
