### PR TITLE
fix(openshell): backport bounded sandbox names

### DIFF
--- a/extensions/openshell/src/backend.test.ts
+++ b/extensions/openshell/src/backend.test.ts
@@ -30,12 +30,14 @@ describe("openshell backend env", () => {
 });
 
 describe("openshell sandbox names", () => {
-  it("generates Kubernetes-safe names from OpenClaw session scope keys", () => {
-    const name = buildOpenShellSandboxName("agent:somalley_alice:dashboard-8");
+  it("generates deterministic OpenShell-compatible names from session scope keys", () => {
+    const scopeKey = "agent:somalley_alice:dashboard-8";
+    const name = buildOpenShellSandboxName(scopeKey);
 
-    expect(name).toMatch(/^[a-z0-9]([-a-z0-9]*[a-z0-9])?$/);
-    expect(name).toContain("somalley-alice");
-    expect(name).not.toContain("_");
-    expect(name.length).toBeLessThanOrEqual(63);
+    expect(name).toMatch(/^oc-[a-f0-9]{16}$/u);
+    expect(name).toHaveLength(19);
+    expect(buildOpenShellSandboxName(scopeKey)).toBe(name);
+    expect(buildOpenShellSandboxName("agent:other")).not.toBe(name);
+    expect(buildOpenShellSandboxName("   ")).toBe(buildOpenShellSandboxName("session"));
   });
 });

--- a/extensions/openshell/src/backend.ts
+++ b/extensions/openshell/src/backend.ts
@@ -1,4 +1,5 @@
 // Openshell plugin module implements backend behavior.
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type {
@@ -18,7 +19,6 @@ import {
   sanitizeEnvVars,
   withTempWorkspace,
 } from "openclaw/plugin-sdk/sandbox";
-import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import type { OpenShellSandboxBackend } from "./backend.types.js";
 import {
   buildValidatedExecRemoteCommand,
@@ -895,15 +895,10 @@ function resolveOpenShellPluginConfigFromConfig(
 
 export function buildOpenShellSandboxName(scopeKey: string): string {
   const trimmed = scopeKey.trim() || "session";
-  const safe = normalizeLowercaseStringOrEmpty(trimmed)
-    .replace(/[^a-z0-9-]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 32);
-  const hash = Array.from(trimmed).reduce(
-    (acc, char) => ((acc * 33) ^ char.charCodeAt(0)) >>> 0,
-    5381,
-  );
-  return `openclaw-${safe || "session"}-${hash.toString(16).slice(0, 8)}`;
+  // OpenShell reserves 19 characters so workspace--sandbox--service remains
+  // a valid DNS label. Keep 64 hash bits to make opaque scope names collision-resistant.
+  const hash = createHash("sha256").update(trimmed).digest("hex").slice(0, 16);
+  return `oc-${hash}`;
 }
 
 function resolveRemoteMaterializedSkillsWorkspaceDir(remoteWorkspaceDir: string): string {

--- a/extensions/openshell/src/openshell-core.test.ts
+++ b/extensions/openshell/src/openshell-core.test.ts
@@ -342,6 +342,24 @@ describe("openshell backend manager", () => {
     });
   });
 
+  it("passes an OpenShell-compatible name through the backend factory", async () => {
+    const factory = createOpenShellSandboxBackendFactory({
+      pluginConfig: resolveOpenShellPluginConfig({ command: "openshell" }),
+    });
+
+    const backend = await factory({
+      sessionKey: "agent:somalley_alice:dashboard-8:turn",
+      scopeKey: "agent:somalley_alice:dashboard-8",
+      workspaceDir: "/tmp/workspace",
+      agentWorkspaceDir: "/tmp/workspace",
+      cfg: createOpenShellBackendSandboxConfig(),
+    });
+
+    expect(backend.runtimeId).toMatch(/^oc-[a-f0-9]{16}$/u);
+    expect(backend.runtimeId).toHaveLength(19);
+    expect(backend.runtimeLabel).toBe(backend.runtimeId);
+  });
+
   it("rejects malformed exec commands before opening an OpenShell SSH session", async () => {
     const factory = createOpenShellSandboxBackendFactory({
       pluginConfig: resolveOpenShellPluginConfig({


### PR DESCRIPTION
## Summary

- generate deterministic 19-character OpenShell sandbox names for the 2026.7.33 candidate
- retain 64 hash bits so opaque session scopes remain collision-resistant
- replace the older 63-character Kubernetes-name assertion with the actual OpenShell contract

## Root cause

Full Validation run 34176498513 reached the OpenShell E2E after gateway discovery succeeded, then OpenShell rejected the generated sandbox name with `name exceeds maximum length (50 > 19)`.

Current `main` already uses the `oc-<16 hex characters>` naming contract. This is the minimal stable backport; it intentionally excludes main's later runtime-registry and lifecycle architecture because 2026.7.33 has not shipped with the old name format.

## Validation

- `node scripts/run-vitest.mjs run extensions/openshell/src/backend.test.ts extensions/openshell/src/openshell-core.test.ts` (45 passed, including the backend-factory identity path)
- `pnpm exec oxfmt --check extensions/openshell/src/backend.ts extensions/openshell/src/backend.test.ts`
- `git diff --check`

## Evidence

- failing leaf job: https://github.com/openclaw/openclaw/actions/runs/34176498513/job/101907320338
- current-main owning fix: #115058
