### PR TITLE
test(agents): compact code mode case matrices

### DIFF
--- a/src/agents/code-mode-runtime.test.ts
+++ b/src/agents/code-mode-runtime.test.ts
@@ -215,311 +215,233 @@ describe("Code Mode guest source validation", () => {
   });
 
   it.each([
-    {
-      name: "import-shaped template text",
-      code: "return `import('node:fs')`;",
-    },
-    {
-      name: "require-shaped template text",
-      code: "return `require('node:fs')`;",
-    },
-    {
-      name: "import.meta-shaped template text",
-      code: "return `import.meta.url`;",
-    },
-    {
-      name: "escaped template interpolation",
-      code: "return `\\${import('node:fs')}`;",
-    },
-    {
-      name: "escaped template delimiter",
-      code: "return `escaped \\` require('node:fs')`;",
-    },
-    {
-      name: "astral Unicode before harmless template text",
-      code: "const emoji = '😀'; return `import('node:fs') ${emoji}`;",
-    },
-    {
-      name: "nested harmless template text",
-      code: "return `outer ${`require('node:fs')`}`;",
-    },
-    {
-      name: "object braces inside a template expression",
-      code: "return `outer ${{ value: `import('node:fs')` }.value}`;",
-    },
-    {
-      name: "quoted module text inside a template expression",
-      code: "return `outer ${\"require('node:fs')\"}`;",
-    },
-    {
-      name: "line-commented module access",
-      code: "// require('node:fs')\nreturn 7;",
-    },
-    {
-      name: "block-commented module access",
-      code: "/* import('node:fs') */ return 7;",
-    },
-    {
-      name: "quoted import.meta text",
-      code: 'return "import.meta.url";',
-    },
-    {
-      name: "module-shaped regular expression",
-      code: 'return /import.meta/.test("import.meta");',
-    },
-    {
-      name: "module-shaped regular expression after an assignment",
-      code: 'const pattern = /import.meta/; return pattern.test("import.meta");',
-    },
-    {
-      name: "module-shaped regular expression in a template expression",
-      code: 'return `${/import.meta/.test("import.meta")}`;',
-    },
-    {
-      name: "module-shaped regular expression after division",
-      code: "return 10 / /import.meta/.source.length;",
-    },
-    {
-      name: "module-shaped regular expression after a control condition",
-      code: 'if (true) /import.meta/.test("import.meta"); return 7;',
-    },
-    {
-      name: "module-shaped regular expression after nested control parentheses",
-      code: 'if ((true)) /import.meta/.test("import.meta"); return 7;',
-    },
-    {
-      name: "regular-expression character class with a slash",
-      code: 'return /[a/]import.meta/.test("aimport.meta");',
-    },
-    {
-      name: "regular expression after postfix-increment division",
-      code: "let value = 10; return value++ / /import.meta/.source.length;",
-    },
-    {
-      name: "regular expression after postfix-decrement division",
-      code: "let value = 10; return value-- / /import.meta/.source.length;",
-    },
-    {
-      name: "regular expression after contextual member division",
-      code: "const value = { of: 10 }; return value.of / /import.meta/.source.length;",
-    },
-    {
-      name: "regular expression after a keyword-shaped control method",
-      code: "const value = { if() { return 10; } }; return value.if() / /import.meta/.source.length;",
-    },
-    {
-      name: "regular expression after an optional keyword-shaped control method",
-      code: "const value = { if() { return 10; } }; return value?.if() / /import.meta/.source.length;",
-    },
-    {
-      name: "regular expression after a nested contextual await identifier",
-      code: "function run() { const await = 10; return await / /import.meta/.source.length; } return run();",
-    },
-    {
-      name: "regular expression after a keyword-shaped private member",
-      code: "class Guest { #return = 10; run() { return this.#return / /import.meta/.source.length; } } return new Guest().run();",
-    },
-    {
-      name: "ordinary import method",
-      code: "const api = { import(value) { return value; } }; return api.import(42);",
-    },
-    {
-      name: "ordinary require method",
-      code: "const api = { require(value) { return value; } }; return api.require(42);",
-    },
-    {
-      name: "optional ordinary import method",
-      code: "const api = { import(value) { return value; } }; return api?.import?.(42);",
-    },
-    {
-      name: "computed ordinary require method",
-      code: 'const api = { require(value) { return value; } }; return api["require"](42);',
-    },
-    {
-      name: "ordinary import metadata property",
-      code: "const api = { import: { meta: 42 } }; return api.import.meta;",
-    },
-    {
-      name: "ordinary malformed JavaScript for guest syntax diagnostics",
-      code: "const answer = ;",
-    },
-  ])("preserves $name", async ({ code }) => {
+    ["import-shaped template text", "return `import('node:fs')`;"],
+    ["require-shaped template text", "return `require('node:fs')`;"],
+    ["import.meta-shaped template text", "return `import.meta.url`;"],
+    ["escaped template interpolation", "return `\\${import('node:fs')}`;"],
+    ["escaped template delimiter", "return `escaped \\` require('node:fs')`;"],
+    [
+      "astral Unicode before harmless template text",
+      "const emoji = '😀'; return `import('node:fs') ${emoji}`;",
+    ],
+    ["nested harmless template text", "return `outer ${`require('node:fs')`}`;"],
+    [
+      "object braces inside a template expression",
+      "return `outer ${{ value: `import('node:fs')` }.value}`;",
+    ],
+    [
+      "quoted module text inside a template expression",
+      "return `outer ${\"require('node:fs')\"}`;",
+    ],
+    ["line-commented module access", "// require('node:fs')\nreturn 7;"],
+    ["block-commented module access", "/* import('node:fs') */ return 7;"],
+    ["quoted import.meta text", 'return "import.meta.url";'],
+    ["module-shaped regular expression", 'return /import.meta/.test("import.meta");'],
+    [
+      "module-shaped regular expression after an assignment",
+      'const pattern = /import.meta/; return pattern.test("import.meta");',
+    ],
+    [
+      "module-shaped regular expression in a template expression",
+      'return `${/import.meta/.test("import.meta")}`;',
+    ],
+    ["module-shaped regular expression after division", "return 10 / /import.meta/.source.length;"],
+    [
+      "module-shaped regular expression after a control condition",
+      'if (true) /import.meta/.test("import.meta"); return 7;',
+    ],
+    [
+      "module-shaped regular expression after nested control parentheses",
+      'if ((true)) /import.meta/.test("import.meta"); return 7;',
+    ],
+    [
+      "regular-expression character class with a slash",
+      'return /[a/]import.meta/.test("aimport.meta");',
+    ],
+    [
+      "regular expression after postfix-increment division",
+      "let value = 10; return value++ / /import.meta/.source.length;",
+    ],
+    [
+      "regular expression after postfix-decrement division",
+      "let value = 10; return value-- / /import.meta/.source.length;",
+    ],
+    [
+      "regular expression after contextual member division",
+      "const value = { of: 10 }; return value.of / /import.meta/.source.length;",
+    ],
+    [
+      "regular expression after a keyword-shaped control method",
+      "const value = { if() { return 10; } }; return value.if() / /import.meta/.source.length;",
+    ],
+    [
+      "regular expression after an optional keyword-shaped control method",
+      "const value = { if() { return 10; } }; return value?.if() / /import.meta/.source.length;",
+    ],
+    [
+      "regular expression after a nested contextual await identifier",
+      "function run() { const await = 10; return await / /import.meta/.source.length; } return run();",
+    ],
+    [
+      "regular expression after a keyword-shaped private member",
+      "class Guest { #return = 10; run() { return this.#return / /import.meta/.source.length; } } return new Guest().run();",
+    ],
+    [
+      "ordinary import method",
+      "const api = { import(value) { return value; } }; return api.import(42);",
+    ],
+    [
+      "ordinary require method",
+      "const api = { require(value) { return value; } }; return api.require(42);",
+    ],
+    [
+      "optional ordinary import method",
+      "const api = { import(value) { return value; } }; return api?.import?.(42);",
+    ],
+    [
+      "computed ordinary require method",
+      'const api = { require(value) { return value; } }; return api["require"](42);',
+    ],
+    [
+      "ordinary import metadata property",
+      "const api = { import: { meta: 42 } }; return api.import.meta;",
+    ],
+    ["ordinary malformed JavaScript for guest syntax diagnostics", "const answer = ;"],
+  ])("preserves %s", async (_name, code) => {
     await expect(prepareSource({ code, config })).resolves.toBe(code);
   });
 
   it.each([
-    {
-      name: "direct require",
-      code: "return require('node:fs');",
-    },
-    {
-      name: "direct dynamic import",
-      code: "return import('node:fs');",
-    },
-    {
-      name: "direct import.meta",
-      code: "return import.meta.url;",
-    },
-    {
-      name: "comment-separated require",
-      code: "return require /* hidden */ ('node:fs');",
-    },
-    {
-      name: "Unicode-escaped direct require",
-      code: String.raw`return r\u0065quire('node:fs');`,
-    },
-    {
-      name: "optional direct require",
-      code: "return require?.('node:fs');",
-    },
-    {
-      name: "parenthesized direct require",
-      code: "return (require)('node:fs');",
-    },
-    {
-      name: "sequence-wrapped direct require",
-      code: "return (0, require)('node:fs');",
-    },
-    {
-      name: "comment-separated dynamic import",
-      code: "return import /* hidden */ ('node:fs');",
-    },
-    {
-      name: "dynamic import in template interpolation",
-      code: "return `${import('node:fs')}`;",
-    },
-    {
-      name: "require in template interpolation",
-      code: "return `${require('node:fs')}`;",
-    },
-    {
-      name: "dynamic import in nested template interpolation",
-      code: "return `${`nested ${import('node:fs')}`}`;",
-    },
-    {
-      name: "require in nested template interpolation",
-      code: "return `${`nested ${require('node:fs')}`}`;",
-    },
-    {
-      name: "dynamic import inside template-expression object braces",
-      code: "return `${({ value: import('node:fs') }).value}`;",
-    },
-    {
-      name: "require after a harmless template",
-      code: "const message = `import('node:fs')`; return require('node:fs');",
-    },
-    {
-      name: "dynamic import after a harmless regular expression",
-      code: "const pattern = /import.meta/; return import('node:fs');",
-    },
-    {
-      name: "dynamic import after division",
-      code: "return 10 / import('node:fs');",
-    },
-    {
-      name: "dynamic import after a regex and control condition",
-      code: "if (true) /import.meta/.test('x'); return import('node:fs');",
-    },
-    {
-      name: "dynamic import after postfix-increment division",
-      code: "let value = 1; return value++ / import('node:fs');",
-    },
-    {
-      name: "dynamic import after postfix-decrement division",
-      code: "let value = 1; return value-- / import('node:fs');",
-    },
-    {
-      name: "dynamic import after a contextual of property",
-      code: "const value = { of: 1 }; return value.of / import('node:fs');",
-    },
-    {
-      name: "dynamic import after a keyword-shaped return property",
-      code: "const value = { return: 1 }; return value.return / import('node:fs');",
-    },
-    {
-      name: "dynamic import after a keyword-shaped control method",
-      code: "const value = { if() { return 1; } }; return value.if() / import('node:fs');",
-    },
-    {
-      name: "dynamic import after an optional keyword-shaped return property",
-      code: "const value = { return: 1 }; return value?.return / import('node:fs') / 1;",
-    },
-    {
-      name: "require after an optional keyword-shaped return property",
-      code: "const value = { return: 1 }; return value?.return / require('node:fs') / 1;",
-    },
-    {
-      name: "dynamic import after an optional keyword-shaped control method",
-      code: "const value = { if() { return 1; } }; return value?.if() / import('node:fs');",
-    },
-    {
-      name: "dynamic import after a contextual of identifier",
-      code: "const of = 1; return of / import('node:fs');",
-    },
-    {
-      name: "dynamic import after a contextual yield identifier",
-      code: "const yield = 1; return yield / import('node:fs');",
-    },
-    {
-      name: "dynamic import after a nested contextual await identifier",
-      code: "function run() { const await = 1; return await / (globalThis.pending = import('node:fs')); } run(); return globalThis.pending;",
-    },
-    {
-      name: "dynamic import after a keyword-shaped private member",
-      code: "class Guest { #return = 1; run() { return this.#return / (globalThis.pending = import('node:fs')); } } new Guest().run(); return globalThis.pending;",
-    },
-    {
-      name: "require after a nested contextual await identifier",
-      code: "function run() { const await = 1; return await / require('node:fs'); } return run();",
-    },
-    {
-      name: "malformed input containing an executable module loader",
-      code: "const answer = ; return import('node:fs');",
-    },
-    {
-      name: "dynamic import after an astral-filled TypeScript string",
-      code: `const label: string = "${"😀".repeat(96)}"; return import('node:fs');`,
-    },
-    {
-      name: "require after an astral-filled TypeScript string",
-      code: `const label: string = "${"😀".repeat(96)}"; return require('node:fs');`,
-    },
-  ])("rejects $name", async ({ code }) => {
+    ["direct require", "return require('node:fs');"],
+    ["direct dynamic import", "return import('node:fs');"],
+    ["direct import.meta", "return import.meta.url;"],
+    ["comment-separated require", "return require /* hidden */ ('node:fs');"],
+    ["Unicode-escaped direct require", String.raw`return r\u0065quire('node:fs');`],
+    ["optional direct require", "return require?.('node:fs');"],
+    ["parenthesized direct require", "return (require)('node:fs');"],
+    ["sequence-wrapped direct require", "return (0, require)('node:fs');"],
+    ["comment-separated dynamic import", "return import /* hidden */ ('node:fs');"],
+    ["dynamic import in template interpolation", "return `${import('node:fs')}`;"],
+    ["require in template interpolation", "return `${require('node:fs')}`;"],
+    [
+      "dynamic import in nested template interpolation",
+      "return `${`nested ${import('node:fs')}`}`;",
+    ],
+    ["require in nested template interpolation", "return `${`nested ${require('node:fs')}`}`;"],
+    [
+      "dynamic import inside template-expression object braces",
+      "return `${({ value: import('node:fs') }).value}`;",
+    ],
+    [
+      "require after a harmless template",
+      "const message = `import('node:fs')`; return require('node:fs');",
+    ],
+    [
+      "dynamic import after a harmless regular expression",
+      "const pattern = /import.meta/; return import('node:fs');",
+    ],
+    ["dynamic import after division", "return 10 / import('node:fs');"],
+    [
+      "dynamic import after a regex and control condition",
+      "if (true) /import.meta/.test('x'); return import('node:fs');",
+    ],
+    [
+      "dynamic import after postfix-increment division",
+      "let value = 1; return value++ / import('node:fs');",
+    ],
+    [
+      "dynamic import after postfix-decrement division",
+      "let value = 1; return value-- / import('node:fs');",
+    ],
+    [
+      "dynamic import after a contextual of property",
+      "const value = { of: 1 }; return value.of / import('node:fs');",
+    ],
+    [
+      "dynamic import after a keyword-shaped return property",
+      "const value = { return: 1 }; return value.return / import('node:fs');",
+    ],
+    [
+      "dynamic import after a keyword-shaped control method",
+      "const value = { if() { return 1; } }; return value.if() / import('node:fs');",
+    ],
+    [
+      "dynamic import after an optional keyword-shaped return property",
+      "const value = { return: 1 }; return value?.return / import('node:fs') / 1;",
+    ],
+    [
+      "require after an optional keyword-shaped return property",
+      "const value = { return: 1 }; return value?.return / require('node:fs') / 1;",
+    ],
+    [
+      "dynamic import after an optional keyword-shaped control method",
+      "const value = { if() { return 1; } }; return value?.if() / import('node:fs');",
+    ],
+    [
+      "dynamic import after a contextual of identifier",
+      "const of = 1; return of / import('node:fs');",
+    ],
+    [
+      "dynamic import after a contextual yield identifier",
+      "const yield = 1; return yield / import('node:fs');",
+    ],
+    [
+      "dynamic import after a nested contextual await identifier",
+      "function run() { const await = 1; return await / (globalThis.pending = import('node:fs')); } run(); return globalThis.pending;",
+    ],
+    [
+      "dynamic import after a keyword-shaped private member",
+      "class Guest { #return = 1; run() { return this.#return / (globalThis.pending = import('node:fs')); } } new Guest().run(); return globalThis.pending;",
+    ],
+    [
+      "require after a nested contextual await identifier",
+      "function run() { const await = 1; return await / require('node:fs'); } return run();",
+    ],
+    [
+      "malformed input containing an executable module loader",
+      "const answer = ; return import('node:fs');",
+    ],
+    [
+      "dynamic import after an astral-filled TypeScript string",
+      `const label: string = "${"😀".repeat(96)}"; return import('node:fs');`,
+    ],
+    [
+      "require after an astral-filled TypeScript string",
+      `const label: string = "${"😀".repeat(96)}"; return require('node:fs');`,
+    ],
+  ])("rejects %s", async (_name, code) => {
     await expect(prepareSource({ code, config })).rejects.toThrow(
       "code mode module access is disabled",
     );
   });
 
   it.each([
-    {
-      name: "module-shaped regular expression after a type annotation",
-      code: 'const value: number = 1; return /import.meta/.test("import.meta");',
-    },
-    {
-      name: "module-shaped regular expression after astral Unicode",
-      code: `const value: number = 1; const padding = "${"😀".repeat(12)}"; return /import.meta/.test("import.meta");`,
-    },
-    {
-      name: "regular expression after an optional keyword-shaped property",
-      code: "const value: { return: number } = { return: 10 }; return value?.return / /import.meta/.source.length;",
-    },
-    {
-      name: "module-shaped nested template text",
-      code: "const value: number = 1; return `outer ${`import('node:fs')`}`;",
-    },
-    {
-      name: "module-shaped comment",
-      code: "const value: number = 1; /* import('node:fs') */ return value;",
-    },
-    {
-      name: "ordinary typed import method",
-      code: "const api: { import(value: number): number } = { import(value) { return value; } }; return api.import(42);",
-    },
-    {
-      name: "ordinary typed require method",
-      code: "const api: { require(value: number): number } = { require(value) { return value; } }; return api.require(42);",
-    },
-  ])("preserves TypeScript $name", async ({ code }) => {
+    [
+      "module-shaped regular expression after a type annotation",
+      'const value: number = 1; return /import.meta/.test("import.meta");',
+    ],
+    [
+      "module-shaped regular expression after astral Unicode",
+      `const value: number = 1; const padding = "${"😀".repeat(12)}"; return /import.meta/.test("import.meta");`,
+    ],
+    [
+      "regular expression after an optional keyword-shaped property",
+      "const value: { return: number } = { return: 10 }; return value?.return / /import.meta/.source.length;",
+    ],
+    [
+      "module-shaped nested template text",
+      "const value: number = 1; return `outer ${`import('node:fs')`}`;",
+    ],
+    ["module-shaped comment", "const value: number = 1; /* import('node:fs') */ return value;"],
+    [
+      "ordinary typed import method",
+      "const api: { import(value: number): number } = { import(value) { return value; } }; return api.import(42);",
+    ],
+    [
+      "ordinary typed require method",
+      "const api: { require(value: number): number } = { require(value) { return value; } }; return api.require(42);",
+    ],
+  ])("preserves TypeScript %s", async (_name, code) => {
     await expect(prepareSource({ code, language: "typescript", config })).resolves.toEqual(
       expect.any(String),
     );


### PR DESCRIPTION
## Summary

- compact Code Mode guest-source case objects into tuple matrices
- preserve all TypeScript, module-loader, regex, and Unicode-offset cases
- keep assertions and production behavior unchanged

Net: **-78 LOC**

## Testing

- `pnpm exec vitest run src/agents/code-mode-runtime.test.ts` (103 passed)
- `pnpm check:changed`
