### PR TITLE
fix(ci): hydrate release source ancestry through branch

### DIFF
--- a/.github/actions/git-owner/release-ancestry.py
+++ b/.github/actions/git-owner/release-ancestry.py
@@ -56,7 +56,7 @@ def resolve_commit(ref):
     return value
 
 
-def fetch_history(source_sha, target, depth_argument):
+def fetch_history(source, target, depth_argument):
     for attempt in range(1, max_fetch_attempts + 1):
         try:
             run_git(
@@ -71,7 +71,7 @@ def fetch_history(source_sha, target, depth_argument):
                 "--refmap=",
                 depth_argument,
                 "origin",
-                f"+{source_sha}:{source_local_ref}",
+                f"+{source}:{source_local_ref}",
                 target,
                 timeout=operation_timeout(max_fetch_seconds),
                 reclaim_locks=True,
@@ -173,6 +173,7 @@ def relation_result(mode, source_sha, target_sha):
 
 def establish_ancestry():
     mode = os.environ.get("RELEASE_ANCESTRY_MODE", "")
+    source_ref = os.environ.get("RELEASE_ANCESTRY_SOURCE_REF", "")
     target_ref = os.environ.get("RELEASE_ANCESTRY_TARGET_REF", "")
     if mode not in ("merge-base", "ancestor"):
         print("::error::Release ancestry mode must be merge-base or ancestor.", flush=True)
@@ -180,9 +181,15 @@ def establish_ancestry():
     if not target_ref.startswith("refs/heads/") or not git_test("check-ref-format", target_ref):
         print("::error::Release ancestry target must be a valid branch ref.", flush=True)
         return 2
+    if source_ref and (
+        not source_ref.startswith("refs/heads/") or not git_test("check-ref-format", source_ref)
+    ):
+        print("::error::Release ancestry source must be a valid branch ref.", flush=True)
+        return 2
     target_local_ref = f"refs/remotes/origin/{target_ref[len('refs/heads/') :]}"
     source_sha = resolve_commit("HEAD")
-    fetch_history(source_sha, f"+{target_ref}:{target_local_ref}", "--depth=64")
+    source = source_ref or source_sha
+    fetch_history(source, f"+{target_ref}:{target_local_ref}", "--depth=64")
     # Freeze the branch after the first fetch. Later requests hydrate the live
     # branch into a separate ref: Git may not deepen a detached SHA want, while
     # every ancestry decision below remains bound to this immutable target.
@@ -199,7 +206,7 @@ def establish_ancestry():
     while True:
         chunk = deepen_chunks[min(chunk_index, len(deepen_chunks) - 1)]
         fetch_history(
-            source_sha,
+            source,
             f"+{target_ref}:{target_hydration_local_ref}",
             f"--deepen={chunk}",
         )

--- a/.github/workflows/openclaw-npm-preflight.yml
+++ b/.github/workflows/openclaw-npm-preflight.yml
@@ -177,6 +177,7 @@ jobs:
       - name: Establish source ancestry with main
         env:
           RELEASE_ANCESTRY_MODE: merge-base
+          RELEASE_ANCESTRY_SOURCE_REF: ${{ inputs.release_candidate_branch != '' && format('refs/heads/{0}', inputs.release_candidate_branch) || '' }}
           RELEASE_ANCESTRY_TARGET_REF: refs/heads/main
         run: |
           exec python3 -I -S .release-harness/.github/actions/git-owner/owner.py \

--- a/test/scripts/ci-git-owner.test.ts
+++ b/test/scripts/ci-git-owner.test.ts
@@ -390,6 +390,35 @@ exec "$REAL_GIT" "$@"`,
   },
 );
 
+releasePolicyIt("hydrates a divergent release source through its canonical branch", () => {
+  const fixture = createAncestryFixture({
+    sourceDistance: 220,
+    targetDistance: 8,
+    related: true,
+  });
+  const proxy = writeGitProxy(
+    fixture,
+    "detached-source-no-deepen-git",
+    `if [[ " $* " == *" fetch "* && " $* " == *" --deepen=128 "* && " $* " == *" +${fixture.source}:refs/remotes/origin/release-ancestry-source "* ]]; then
+  exit 0
+fi
+exec "$REAL_GIT" "$@"`,
+  );
+  try {
+    const checkout = cloneAncestrySource(fixture, "checkout");
+    expectPolicySuccess(
+      runReleaseAncestry(checkout, "merge-base", {
+        PATH: `${proxy.binDir}:${process.env.PATH ?? ""}`,
+        REAL_GIT: proxy.realGit,
+        RELEASE_ANCESTRY_SOURCE_REF: "refs/heads/release-source",
+      }),
+      "merge-base",
+    );
+  } finally {
+    rmSync(fixture.root, { force: true, recursive: true });
+  }
+});
+
 releasePolicyIt("rejects fully hydrated disconnected release histories", () => {
   const fixture = createAncestryFixture({
     sourceDistance: 8,

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -164,6 +164,8 @@ describe("minimal npm extended-stable workflow", () => {
     expect(sourceAncestry).toMatchObject({
       env: {
         RELEASE_ANCESTRY_MODE: "merge-base",
+        RELEASE_ANCESTRY_SOURCE_REF:
+          "${{ inputs.release_candidate_branch != '' && format('refs/heads/{0}', inputs.release_candidate_branch) || '' }}",
         RELEASE_ANCESTRY_TARGET_REF: "refs/heads/main",
       },
     });


### PR DESCRIPTION
## Summary

- hydrate long-lived release-source history through its canonical branch instead of repeatedly deepening a detached SHA want
- keep every ancestry verdict bound to the immutable checked-out candidate SHA
- validate and wire the optional source branch only for canonical extended-stable preflight callers

## Root cause

NPM preflight run 34184589031 fetched the frozen candidate as a detached SHA. Git reported a successful deepen while leaving the source shallow boundary unchanged, so the trusted ancestry policy correctly failed with exit 125 (`Release ancestry fetch completed without ancestry progress`). Target-side branch hydration already existed; the source side lacked the equivalent transport.

## Proof

- red before fix: real-Git divergent-source fixture exits 125 when detached-source deepen is a no-op
- green after fix: the same fixture establishes the exact merge-base through `refs/heads/release-source`
- full `test/scripts/ci-git-owner.test.ts` passed
- `test/scripts/openclaw-npm-extended-stable-workflow.test.ts`: 17/17
- actionlint, Oxfmt, direct OXLint, diff check passed
- structured AutoReview: scoped-clean, no P0/P1 findings (0.90)

## Size

Production/tooling: +12/-4. Tests: +31/-0. Application runtime: 0.

No publish, tag, package, product, or release-candidate behavior changes.