### PR TITLE
refactor(comfy): remove unused cloud fixture input

### DIFF
--- a/extensions/comfy/image-generation-provider.test.ts
+++ b/extensions/comfy/image-generation-provider.test.ts
@@ -627,7 +627,6 @@ describe("comfy image-generation provider", () => {
       filename: "cloud.png",
       outputKind: "images",
       promptId: "strict-cloud-job-1",
-      redirectLocation: "https://cdn.example.com/cloud.png",
     });
 
     const provider = buildComfyImageGenerationProvider();
@@ -659,7 +658,6 @@ describe("comfy image-generation provider", () => {
       filename: "cloud.png",
       outputKind: "images",
       promptId: "private-cloud-job-1",
-      redirectLocation: "https://cdn.example.com/cloud.png",
     });
 
     const provider = buildComfyImageGenerationProvider();
@@ -1187,7 +1185,6 @@ describe("comfy image-generation provider", () => {
       filename: "cloud.png",
       outputKind: "images",
       promptId: "cloud-job-1",
-      redirectLocation: "https://cdn.example.com/cloud.png",
     });
 
     const provider = buildComfyImageGenerationProvider();
@@ -1247,7 +1244,6 @@ describe("comfy image-generation provider", () => {
       filename: "cloud.png",
       outputKind: "images",
       promptId: "cloud-secret-ref-1",
-      redirectLocation: "https://cdn.example.com/cloud.png",
     });
 
     const provider = buildComfyImageGenerationProvider();
@@ -1284,7 +1280,6 @@ describe("comfy image-generation provider", () => {
       filename: "cloud.png",
       outputKind: "images",
       promptId: "cloud-profile-1",
-      redirectLocation: "https://cdn.example.com/cloud.png",
     });
 
     const provider = buildComfyImageGenerationProvider();

--- a/extensions/comfy/test-helpers.ts
+++ b/extensions/comfy/test-helpers.ts
@@ -17,7 +17,6 @@ type ComfyCloudJobResponseOptions = {
   filename: string;
   outputKind: "gifs" | "images";
   promptId: string;
-  redirectLocation?: string;
 };
 
 export function buildComfyConfig(config: Record<string, unknown>): OpenClawConfig {

--- a/extensions/comfy/video-generation-provider.test.ts
+++ b/extensions/comfy/video-generation-provider.test.ts
@@ -443,7 +443,6 @@ describe("comfy video-generation provider", () => {
       filename: "cloud.mp4",
       outputKind: "gifs",
       promptId: "cloud-video-1",
-      redirectLocation: "https://cdn.example.com/cloud.mp4",
     });
 
     const provider = buildComfyVideoGenerationProvider();


### PR DESCRIPTION
## What Problem This Solves

Comfy cloud test fixtures still supply a redirect location even though their shared fixture stopped using it when redirect handling moved to the real request guard. The unused input makes the setup appear to exercise a redirect response that it no longer produces.

## Why This Change Was Made

Remove the unused private fixture option and its six caller values. The shared fixture still returns the same four responses. The separate helper used by real-guard redirect tests is unchanged, as are every test case and assertion.

## User Impact

No runtime, configuration, provider, authentication, or network-policy change. This removes seven test/test-support lines and no production code.

## Evidence

- Complete image/video suites before and after: 55 passed (41 image, 14 video), zero skipped or failed, with identical case inventories.
- Exact deletion comparison: every other byte in the three files is unchanged, including every assertion and the separate redirect fixtures.
- Scoped formatting, diff check, and independent Codex review through P2 passed.
- Normal changed-file gate passed on the configured Linux Testbox ([run](https://github.com/openclaw/openclaw/actions/runs/34186729034)), including extension types, doctor contracts, dead exports, scoped lint, and structural guards. The one-shot lease and temporary source capsule are cleaned up.

No live Comfy service invocation is claimed for this unused fixture-input cleanup.
