### PR TITLE
fix(plugins): release doctor inspection resources before output

### DIFF
--- a/docs/cli/plugins.md
+++ b/docs/cli/plugins.md
@@ -602,6 +602,11 @@ openclaw plugins doctor --json
 With `--json`, the same discovery, compatibility, and configuration diagnostics
 are returned as one machine-readable object.
 
+Doctor waits for its inspection registration resources to be released before
+printing the report and setting the diagnostic exit status. Cleanup failures
+produce a command error instead of a successful report. Running Gateway
+registrations are not disposed by this inspection.
+
 If a configured plugin is present on disk but blocked by the loader's path-safety checks, config validation keeps the plugin entry and reports it as `present but blocked`. Fix the preceding blocked-plugin diagnostic, such as path ownership or world-writable permissions, instead of removing the `plugins.entries.<id>` or `plugins.allow` config.
 
 For module-shape failures such as missing `register`/`activate` exports, rerun with `OPENCLAW_PLUGIN_LOAD_DEBUG=1` to include a compact export-shape summary in the diagnostic output.

--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -5,11 +5,14 @@ import type {
   ConfigValidationIssue,
   OpenClawConfig,
 } from "../config/types.openclaw.js";
+import { createEmptyPluginRegistry } from "../plugins/registry-empty.js";
+import type { PluginStatusReport } from "../plugins/status.js";
 import { createCompatibilityNotice, createPluginRecord } from "../plugins/status.test-fixtures.js";
+import { createDeferredCore } from "../shared/deferred.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import {
   buildPluginCompatibilityNoticesMock,
-  buildPluginDiagnosticsReportMock,
+  withPluginDiagnosticsReportForInspectionMock,
   buildPluginRegistrySnapshotReportMock,
   inspectPluginRegistryMock,
   pluginCliConfigMock,
@@ -26,6 +29,12 @@ const cleanDoctorMessage =
   "Plugin discovery, module loading, compatibility, and configuration checks passed. " +
   'Run "openclaw health" to check the running Gateway, including runtime quarantines and fallbacks.';
 const originalExitCode = process.exitCode;
+
+function mockDoctorReport(report: Pick<PluginStatusReport, "plugins" | "diagnostics">) {
+  withPluginDiagnosticsReportForInspectionMock.mockImplementation(async (_params, formatReport) =>
+    formatReport({ ...createEmptyPluginRegistry(), workspaceScope: "omitted", ...report }),
+  );
+}
 
 async function mockPluginDoctorValidationWarnings(warnings: ConfigValidationIssue[]) {
   const config: OpenClawConfig = {
@@ -52,7 +61,7 @@ async function mockPluginDoctorValidationWarnings(warnings: ConfigValidationIssu
     })),
     diagnostics: [],
   });
-  buildPluginDiagnosticsReportMock.mockReturnValue({
+  mockDoctorReport({
     plugins: [createPluginRecord({ id: "google", enabled: false, status: "disabled" })],
     diagnostics: [],
   });
@@ -222,18 +231,69 @@ describe("plugins cli list", () => {
     expect(output.diagnostics).toEqual(diagnostics);
   });
 
+  it.each([false, true])(
+    "publishes Doctor output and exit status only after cleanup (json: %s)",
+    async (json) => {
+      const entered = createDeferredCore();
+      const finish = createDeferredCore();
+      process.exitCode = 7;
+      withPluginDiagnosticsReportForInspectionMock.mockImplementation(
+        async (_params, formatReport) => {
+          const text = formatReport({ ...createEmptyPluginRegistry(), workspaceScope: "omitted" });
+          entered.resolve();
+          await finish.promise;
+          return text;
+        },
+      );
+      const command = runPluginsCommand(["plugins", "doctor", ...(json ? ["--json"] : [])]);
+      try {
+        await entered.promise;
+        expect(pluginsCliRuntimeLogs).toEqual([]);
+        expect(process.exitCode).toBe(7);
+      } finally {
+        finish.resolve();
+        await command;
+      }
+      expect(process.exitCode).toBe(0);
+      expect(pluginsCliRuntimeLogs).toHaveLength(1);
+    },
+  );
+
+  it.each(["format", "dispose"])("does not publish success when Doctor %s fails", async (phase) => {
+    process.exitCode = 7;
+    const failure = new Error(`Doctor ${phase} failed`);
+    if (phase === "format") {
+      buildPluginCompatibilityNoticesMock.mockImplementation(() => {
+        throw failure;
+      });
+    } else {
+      withPluginDiagnosticsReportForInspectionMock.mockImplementation(
+        async (_params, formatReport) => {
+          formatReport({ ...createEmptyPluginRegistry(), workspaceScope: "omitted" });
+          throw failure;
+        },
+      );
+    }
+    await expect(runPluginsCommand(["plugins", "doctor", "--json"])).rejects.toBe(failure);
+    expect(pluginsCliRuntimeLogs).toEqual([]);
+    expect(process.exitCode).toBe(7);
+  });
+
   it("keeps doctor on a module-loading snapshot", async () => {
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [],
       diagnostics: [],
     });
 
     await runPluginsCommand(["plugins", "doctor"]);
 
-    expect(buildPluginDiagnosticsReportMock).toHaveBeenCalledWith({
-      config: {},
-      effectiveOnly: true,
-    });
+    expect(withPluginDiagnosticsReportForInspectionMock).toHaveBeenCalledWith(
+      {
+        config: {},
+        effectiveOnly: true,
+      },
+      expect.any(Function),
+    );
     expect(pluginsCliRuntimeLogs).toContain(cleanDoctorMessage);
   });
 
@@ -256,7 +316,7 @@ describe("plugins cli list", () => {
     "keeps $severity compatibility notices visible while reporting healthy=$healthy ($args)",
     async ({ code, healthy, args }) => {
       const notice = createCompatibilityNotice({ pluginId: "compatible-plugin", code });
-      buildPluginDiagnosticsReportMock.mockReturnValue({
+      mockDoctorReport({
         plugins: [createPluginRecord({ id: "compatible-plugin" })],
         diagnostics: [],
       });
@@ -289,7 +349,7 @@ describe("plugins cli list", () => {
   );
 
   it("updates the doctor exit status as health changes in one process", async () => {
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [createPluginRecord({ id: "compatible-plugin" })],
       diagnostics: [],
     });
@@ -415,7 +475,7 @@ describe("plugins cli list", () => {
 
   it("emits one sanitized JSON doctor report without human decoration", async () => {
     const homeDir = "/tmp/openclaw-plugin-doctor-home";
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [
         createPluginRecord({
           id: "broken",
@@ -512,7 +572,7 @@ describe("plugins cli list", () => {
   ])(
     "reports actionable discovery warnings when $description",
     async ({ diagnostic, expected }) => {
-      buildPluginDiagnosticsReportMock.mockReturnValue({ plugins: [], diagnostics: [diagnostic] });
+      mockDoctorReport({ plugins: [], diagnostics: [diagnostic] });
 
       await runPluginsCommand(["plugins", "doctor"]);
 
@@ -524,7 +584,7 @@ describe("plugins cli list", () => {
   );
 
   it("keeps actionable discovery warnings alongside existing errors", async () => {
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [],
       diagnostics: [
         { level: "error", pluginId: "broken", message: "plugin manifest invalid" },
@@ -568,7 +628,7 @@ describe("plugins cli list", () => {
       warnings: [],
       legacyIssues: [],
     });
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [],
       diagnostics: [],
     });
@@ -620,7 +680,7 @@ describe("plugins cli list", () => {
       warnings: [],
       legacyIssues: [],
     });
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [],
       diagnostics: [],
     });
@@ -645,7 +705,7 @@ describe("plugins cli list", () => {
       },
     };
     pluginCliConfigMock.mockReturnValue(sourceConfig);
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [],
       diagnostics: [],
     });
@@ -672,7 +732,7 @@ describe("plugins cli list", () => {
       },
     };
     pluginCliConfigMock.mockReturnValue(sourceConfig);
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [],
       diagnostics: [],
     });
@@ -695,7 +755,7 @@ describe("plugins cli list", () => {
       },
     };
     pluginCliConfigMock.mockReturnValue(sourceConfig);
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [createPluginRecord({ id: "acpx", enabled: false, status: "disabled" })],
       diagnostics: [],
     });
@@ -720,7 +780,7 @@ describe("plugins cli list", () => {
       },
     };
     pluginCliConfigMock.mockReturnValue(sourceConfig);
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [],
       diagnostics: [],
     });
@@ -745,7 +805,7 @@ describe("plugins cli list", () => {
       },
     };
     pluginCliConfigMock.mockReturnValue(sourceConfig);
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [createPluginRecord({ id: "codex" })],
       diagnostics: [],
     });
@@ -768,7 +828,7 @@ describe("plugins cli list", () => {
       },
     };
     pluginCliConfigMock.mockReturnValue(sourceConfig);
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [createPluginRecord({ id: "codex", enabled: false, status: "disabled" })],
       diagnostics: [],
     });
@@ -799,7 +859,7 @@ describe("plugins cli list", () => {
       },
     };
     pluginCliConfigMock.mockReturnValue(sourceConfig);
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [],
       diagnostics: [],
     });
@@ -833,7 +893,7 @@ describe("plugins cli list", () => {
       },
     };
     pluginCliConfigMock.mockReturnValue(sourceConfig);
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [],
       diagnostics: [],
     });
@@ -850,7 +910,7 @@ describe("plugins cli list", () => {
   });
 
   it("reports config-selected plugin source shadowing in doctor output", async () => {
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [
         createPluginRecord({
           id: "discord",
@@ -884,7 +944,7 @@ describe("plugins cli list", () => {
   });
 
   it("does not report healthy config-selected plugin source shadowing as doctor issue", async () => {
-    buildPluginDiagnosticsReportMock.mockReturnValue({
+    mockDoctorReport({
       plugins: [
         createPluginRecord({
           id: "discord",

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -343,7 +343,7 @@ export async function runPluginsRegistryCommand(opts: PluginRegistryOptions): Pr
 export async function runPluginsDoctorCommand(opts: PluginDoctorOptions = {}): Promise<void> {
   const {
     buildPluginCompatibilityNotices,
-    buildPluginDiagnosticsReport,
+    withPluginDiagnosticsReportForInspection,
     formatPluginCompatibilityNotice,
   } = await loadPluginsStatus();
   const {
@@ -354,157 +354,170 @@ export async function runPluginsDoctorCommand(opts: PluginDoctorOptions = {}): P
   const cfg = getRuntimeConfig();
   const configSnapshot = await readConfigFileSnapshot().catch(() => null);
   const sourceCfg = configSnapshot?.sourceConfig ?? configSnapshot?.config ?? cfg;
-  const report = buildPluginDiagnosticsReport({ config: cfg, effectiveOnly: true });
-  const errors = report.plugins.filter((p) => p.status === "error");
-  const diags = report.diagnostics.filter((entry) => !isConfigSelectedShadowDiagnostic(entry));
-  const shadowed = report.diagnostics.filter((entry) =>
-    isErroredConfigSelectedShadowDiagnostic({ entry, plugins: report.plugins }),
-  );
-  const compatibility = buildPluginCompatibilityNotices({ report });
-  const pluginConfigWarnings = new Set([
-    ...formatConfigIssueLines(
-      (configSnapshot?.warnings ?? []).filter(
-        ({ path }) => path === "plugins" || path.startsWith("plugins."),
-      ),
-    ),
-    ...collectStalePluginConfigWarnings({
-      hits: scanStalePluginConfig(sourceCfg, process.env),
-      doctorFixCommand: "openclaw doctor --fix",
-      autoRepairBlocked: isStalePluginAutoRepairBlocked(sourceCfg, process.env),
-    }),
-    ...collectConfiguredRuntimePluginWarnings({ cfg: sourceCfg, plugins: report.plugins }),
-  ]);
-  const hasInstallTreeIssues =
-    [errors, diags, shadowed].some(({ length }) => length > 0) ||
-    compatibility.some(({ severity }) => severity === "warn");
-  const doctorOk = !hasInstallTreeIssues && pluginConfigWarnings.size === 0;
-  process.exitCode = doctorOk ? 0 : 1;
+  let exitCode = 1;
+  const output = await withPluginDiagnosticsReportForInspection(
+    { config: cfg, effectiveOnly: true },
+    (report) => {
+      const errors = report.plugins.filter((p) => p.status === "error");
+      const diags = report.diagnostics.filter((entry) => !isConfigSelectedShadowDiagnostic(entry));
+      const shadowed = report.diagnostics.filter((entry) =>
+        isErroredConfigSelectedShadowDiagnostic({ entry, plugins: report.plugins }),
+      );
+      const compatibility = buildPluginCompatibilityNotices({ report });
+      const pluginConfigWarnings = new Set([
+        ...formatConfigIssueLines(
+          (configSnapshot?.warnings ?? []).filter(
+            ({ path }) => path === "plugins" || path.startsWith("plugins."),
+          ),
+        ),
+        ...collectStalePluginConfigWarnings({
+          hits: scanStalePluginConfig(sourceCfg, process.env),
+          doctorFixCommand: "openclaw doctor --fix",
+          autoRepairBlocked: isStalePluginAutoRepairBlocked(sourceCfg, process.env),
+        }),
+        ...collectConfiguredRuntimePluginWarnings({ cfg: sourceCfg, plugins: report.plugins }),
+      ]);
+      const hasInstallTreeIssues =
+        [errors, diags, shadowed].some(({ length }) => length > 0) ||
+        compatibility.some(({ severity }) => severity === "warn");
+      const doctorOk = !hasInstallTreeIssues && pluginConfigWarnings.size === 0;
+      exitCode = doctorOk ? 0 : 1;
 
-  if (opts.json) {
-    defaultRuntime.writeJson({
-      ok: doctorOk,
-      pluginErrors: errors.map((entry) => ({
-        id: entry.id,
-        ...(entry.failurePhase ? { failurePhase: entry.failurePhase } : {}),
-        error: shortenHomeInString(entry.error ?? "failed to load"),
-        source: shortenHomeInString(entry.source),
-      })),
-      diagnostics: diags.map((entry) => ({
-        level: entry.level,
-        ...(entry.pluginId ? { pluginId: entry.pluginId } : {}),
-        message: shortenHomeInString(entry.message),
-        ...(entry.source ? { source: shortenHomeInString(entry.source) } : {}),
-      })),
-      sourceShadowing: shadowed.map((entry) => {
-        const active = report.plugins.find((plugin) => plugin.id === entry.pluginId);
-        return {
-          ...(entry.pluginId ? { pluginId: entry.pluginId } : {}),
-          message: shortenHomeInString(entry.message),
-          ...(active
-            ? {
-                active: {
-                  source: shortenHomeInString(active.source),
-                  origin: active.origin,
-                  status: active.status,
-                  ...(active.error ? { error: shortenHomeInString(active.error) } : {}),
-                },
-              }
-            : {}),
-          ...(entry.source ? { shadowedSource: shortenHomeInString(entry.source) } : {}),
-          repair: [
-            `openclaw plugins inspect ${entry.pluginId ?? "<plugin-id>"}`,
-            "edit or remove the config-selected plugin source",
-            "openclaw plugins registry --refresh",
-            "openclaw gateway restart --force",
-          ],
-        };
-      }),
-      compatibility: compatibility.map((notice) => ({
-        ...notice,
-        message: shortenHomeInString(notice.message),
-      })),
-      configurationWarnings: Array.from(pluginConfigWarnings, shortenHomeInString),
-    });
-    return;
-  }
+      if (opts.json) {
+        return JSON.stringify(
+          {
+            ok: doctorOk,
+            pluginErrors: errors.map((entry) => ({
+              id: entry.id,
+              ...(entry.failurePhase ? { failurePhase: entry.failurePhase } : {}),
+              error: shortenHomeInString(entry.error ?? "failed to load"),
+              source: shortenHomeInString(entry.source),
+            })),
+            diagnostics: diags.map((entry) => ({
+              level: entry.level,
+              ...(entry.pluginId ? { pluginId: entry.pluginId } : {}),
+              message: shortenHomeInString(entry.message),
+              ...(entry.source ? { source: shortenHomeInString(entry.source) } : {}),
+            })),
+            sourceShadowing: shadowed.map((entry) => {
+              const active = report.plugins.find((plugin) => plugin.id === entry.pluginId);
+              return {
+                ...(entry.pluginId ? { pluginId: entry.pluginId } : {}),
+                message: shortenHomeInString(entry.message),
+                ...(active
+                  ? {
+                      active: {
+                        source: shortenHomeInString(active.source),
+                        origin: active.origin,
+                        status: active.status,
+                        ...(active.error ? { error: shortenHomeInString(active.error) } : {}),
+                      },
+                    }
+                  : {}),
+                ...(entry.source ? { shadowedSource: shortenHomeInString(entry.source) } : {}),
+                repair: [
+                  `openclaw plugins inspect ${entry.pluginId ?? "<plugin-id>"}`,
+                  "edit or remove the config-selected plugin source",
+                  "openclaw plugins registry --refresh",
+                  "openclaw gateway restart --force",
+                ],
+              };
+            }),
+            compatibility: compatibility.map((notice) => ({
+              ...notice,
+              message: shortenHomeInString(notice.message),
+            })),
+            configurationWarnings: Array.from(pluginConfigWarnings, shortenHomeInString),
+          },
+          null,
+          2,
+        );
+      }
 
-  const healthyMessage =
-    "Plugin discovery, module loading, compatibility, and configuration checks passed. " +
-    'Run "openclaw health" to check the running Gateway, including runtime quarantines and fallbacks.';
-  if (!hasInstallTreeIssues && pluginConfigWarnings.size === 0 && compatibility.length === 0) {
-    defaultRuntime.log(healthyMessage);
-    return;
-  }
+      const healthyMessage =
+        "Plugin discovery, module loading, compatibility, and configuration checks passed. " +
+        'Run "openclaw health" to check the running Gateway, including runtime quarantines and fallbacks.';
+      if (!hasInstallTreeIssues && pluginConfigWarnings.size === 0 && compatibility.length === 0) {
+        return healthyMessage;
+      }
 
-  const lines: string[] = [];
-  if (errors.length > 0) {
-    lines.push(theme.error("Plugin errors:"));
-    for (const entry of errors) {
-      const phase = entry.failurePhase ? ` [${entry.failurePhase}]` : "";
-      lines.push(`- ${entry.id}${phase}: ${entry.error ?? "failed to load"} (${entry.source})`);
-    }
-  }
-  if (diags.length > 0) {
-    if (lines.length > 0) {
-      lines.push("");
-    }
-    lines.push(theme.warn("Diagnostics:"));
-    for (const diag of diags) {
-      const target = diag.pluginId ? `${diag.pluginId}: ` : "";
-      lines.push(`- ${target}${diag.message}`);
-    }
-  }
-  if (shadowed.length > 0) {
-    if (lines.length > 0) {
-      lines.push("");
-    }
-    lines.push(theme.warn("Plugin source shadowing:"));
-    for (const diag of shadowed) {
-      const active = report.plugins.find((plugin) => plugin.id === diag.pluginId);
-      const target = diag.pluginId ? `${diag.pluginId}: ` : "";
-      lines.push(`- ${target}${diag.message}`);
-      if (active) {
-        lines.push(`  active: ${shortenHomeInString(active.source)} (${active.origin})`);
-        if (active.status === "error") {
-          lines.push(`  active status: error${active.error ? `: ${active.error}` : ""}`);
+      const lines: string[] = [];
+      if (errors.length > 0) {
+        lines.push(theme.error("Plugin errors:"));
+        for (const entry of errors) {
+          const phase = entry.failurePhase ? ` [${entry.failurePhase}]` : "";
+          lines.push(`- ${entry.id}${phase}: ${entry.error ?? "failed to load"} (${entry.source})`);
         }
       }
-      if (diag.source) {
-        lines.push(`  shadowed: ${shortenHomeInString(diag.source)}`);
+      if (diags.length > 0) {
+        if (lines.length > 0) {
+          lines.push("");
+        }
+        lines.push(theme.warn("Diagnostics:"));
+        for (const diag of diags) {
+          const target = diag.pluginId ? `${diag.pluginId}: ` : "";
+          lines.push(`- ${target}${diag.message}`);
+        }
       }
-      lines.push("  repair:");
-      lines.push("    openclaw plugins inspect " + (diag.pluginId ?? "<plugin-id>"));
-      lines.push("    edit or remove the config-selected plugin source");
-      lines.push("    openclaw plugins registry --refresh");
-      lines.push("    openclaw gateway restart --force");
-    }
-  }
-  if (compatibility.length > 0) {
-    if (lines.length > 0) {
+      if (shadowed.length > 0) {
+        if (lines.length > 0) {
+          lines.push("");
+        }
+        lines.push(theme.warn("Plugin source shadowing:"));
+        for (const diag of shadowed) {
+          const active = report.plugins.find((plugin) => plugin.id === diag.pluginId);
+          const target = diag.pluginId ? `${diag.pluginId}: ` : "";
+          lines.push(`- ${target}${diag.message}`);
+          if (active) {
+            lines.push(`  active: ${shortenHomeInString(active.source)} (${active.origin})`);
+            if (active.status === "error") {
+              lines.push(`  active status: error${active.error ? `: ${active.error}` : ""}`);
+            }
+          }
+          if (diag.source) {
+            lines.push(`  shadowed: ${shortenHomeInString(diag.source)}`);
+          }
+          lines.push("  repair:");
+          lines.push("    openclaw plugins inspect " + (diag.pluginId ?? "<plugin-id>"));
+          lines.push("    edit or remove the config-selected plugin source");
+          lines.push("    openclaw plugins registry --refresh");
+          lines.push("    openclaw gateway restart --force");
+        }
+      }
+      if (compatibility.length > 0) {
+        if (lines.length > 0) {
+          lines.push("");
+        }
+        lines.push(theme.warn("Compatibility:"));
+        for (const notice of compatibility) {
+          const marker = notice.severity === "warn" ? theme.warn("warn") : theme.muted("info");
+          lines.push(`- ${formatPluginCompatibilityNotice(notice)} [${marker}]`);
+        }
+      }
+      if (pluginConfigWarnings.size > 0) {
+        if (lines.length > 0) {
+          lines.push("");
+        }
+        lines.push(theme.warn("Plugin configuration:"), ...pluginConfigWarnings);
+      }
+      if (!hasInstallTreeIssues) {
+        const summary = pluginConfigWarnings.size
+          ? "No plugin install-tree issues detected; configuration warnings remain."
+          : healthyMessage;
+        lines.push("", summary);
+      }
+      const docs = formatDocsLink("/plugin", "docs.openclaw.ai/plugin");
       lines.push("");
-    }
-    lines.push(theme.warn("Compatibility:"));
-    for (const notice of compatibility) {
-      const marker = notice.severity === "warn" ? theme.warn("warn") : theme.muted("info");
-      lines.push(`- ${formatPluginCompatibilityNotice(notice)} [${marker}]`);
-    }
+      lines.push(`${theme.muted("Docs:")} ${docs}`);
+      return lines.join("\n");
+    },
+  );
+  process.exitCode = exitCode;
+  if (opts.json) {
+    defaultRuntime.writeStdout(output);
+  } else {
+    defaultRuntime.log(output);
   }
-  if (pluginConfigWarnings.size > 0) {
-    if (lines.length > 0) {
-      lines.push("");
-    }
-    lines.push(theme.warn("Plugin configuration:"), ...pluginConfigWarnings);
-  }
-  if (!hasInstallTreeIssues) {
-    const summary = pluginConfigWarnings.size
-      ? "No plugin install-tree issues detected; configuration warnings remain."
-      : healthyMessage;
-    lines.push("", summary);
-  }
-  const docs = formatDocsLink("/plugin", "docs.openclaw.ai/plugin");
-  lines.push("");
-  lines.push(`${theme.muted("Docs:")} ${docs}`);
-  defaultRuntime.log(lines.join("\n"));
 }
 
 type MarketplaceRefreshPayload = {

--- a/src/plugins/status.runtime-inspection.test.ts
+++ b/src/plugins/status.runtime-inspection.test.ts
@@ -4,6 +4,7 @@ import { DatabaseSync } from "node:sqlite";
 import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { handlePluginsCommand } from "../auto-reply/reply/commands-plugins.js";
 import { buildPluginsCommandParams } from "../auto-reply/reply/commands.test-harness.js";
+import { runPluginsDoctorCommand } from "../cli/plugins-cli.runtime.js";
 import { runPluginsInspectCommand } from "../cli/plugins-inspect-command.js";
 import { readConfigFileSnapshotForWrite, writeConfigFile } from "../config/config.js";
 import { defaultRuntime } from "../runtime.js";
@@ -52,10 +53,26 @@ describe("plugin runtime inspection", () => {
     cleanupPluginLoaderFixturesForTest();
   });
 
-  it.each(["inspect", "inspect native-chat-inspection", "inspect all", "inspect missing"])(
-    "releases chat inspection while the active native registration stays usable: %s",
+  it.each([
+    "inspect",
+    "inspect native-chat-inspection",
+    "inspect all",
+    "inspect missing",
+    "doctor",
+    "doctor-json",
+  ])(
+    "releases inspection while the active native registration stays usable: %s",
     async (selection) => {
       const stateDir = makePluginLoaderTempDir();
+      const doctor = selection.startsWith("doctor");
+      const previousExitCode = process.exitCode;
+      const output: string[] = [];
+      const log = vi.spyOn(defaultRuntime, "log").mockImplementation((value) => {
+        output.push(String(value));
+      });
+      const writeStdout = vi.spyOn(defaultRuntime, "writeStdout").mockImplementation((value) => {
+        output.push(value);
+      });
       const key = `__openclaw_chat_inspection_${selection}`;
       const started = createDeferredCore();
       const finish = createDeferredCore();
@@ -105,12 +122,24 @@ module.exports = { id: "native-chat-inspection", register(api) {
             useNoBundledPlugins();
             const config = {
               commands: { text: true, plugins: true },
+              ...(doctor
+                ? {
+                    agents: {
+                      defaults: { systemAgent: { agentId: "main" } },
+                      entries: { main: { workspace: stateDir } },
+                    },
+                  }
+                : {}),
               plugins: {
                 allow: [plugin.id],
                 load: { paths: [plugin.file] },
                 slots: { memory: "none" },
               },
             };
+            if (doctor) {
+              // Existing configs preserve omitted catalog preferences; fresh installs initialize stock catalogs.
+              fs.writeFileSync(path.join(stateDir, "openclaw.json"), "{}");
+            }
             await writeConfigFile(config);
             const active = loadAndActivateRootPluginRegistry({
               config,
@@ -127,15 +156,20 @@ module.exports = { id: "native-chat-inspection", register(api) {
               activeConnection?.database.prepare("SELECT value FROM owned").get();
             expect(readActive()).toEqual({ value: 42 });
             let replied = false;
+            if (doctor) {
+              process.exitCode = 7;
+            }
             command = withPluginRuntimeRegistryScope(active, () =>
-              handlePluginsCommand(
-                buildPluginsCommandParams({
-                  commandBodyNormalized: `/plugins ${selection}`,
-                  cfg: config,
-                  workspaceDir: stateDir,
-                }),
-                true,
-              ),
+              doctor
+                ? runPluginsDoctorCommand({ json: selection === "doctor-json" }).then(() => null)
+                : handlePluginsCommand(
+                    buildPluginsCommandParams({
+                      commandBodyNormalized: `/plugins ${selection}`,
+                      cfg: config,
+                      workspaceDir: stateDir,
+                    }),
+                    true,
+                  ),
             ).then((result) => {
               replied = true;
               return result;
@@ -147,20 +181,41 @@ module.exports = { id: "native-chat-inspection", register(api) {
             expect(inspection?.disposals).toBe(1);
             expect(inspection?.database.isOpen).toBe(true);
             expect(replied).toBe(false);
+            if (doctor) {
+              expect(output).toEqual([]);
+              expect(process.exitCode).toBe(7);
+            }
             expect(readActive()).toEqual({ value: 42 });
             expect(getActivePluginRegistry()).toBe(active);
             expect(capturePluginRegistryLifecycleEpoch(active)).toBe(epoch);
             expect(signal?.aborted).toBe(false);
             finish.resolve();
             const result = await command;
-            expect(result?.shouldContinue).toBe(false);
-            expect(result?.reply?.text).toContain(
-              selection === "inspect missing"
-                ? 'No plugin named "missing" found.'
-                : selection === "inspect"
-                  ? "Plugins ("
-                  : "```json",
-            );
+            if (doctor) {
+              expect(output).toHaveLength(1);
+              expect(process.exitCode, output.join("\n")).toBe(0);
+              if (selection === "doctor-json") {
+                expect(JSON.parse(output[0] ?? "")).toMatchObject({
+                  ok: true,
+                  pluginErrors: [],
+                  diagnostics: [],
+                  configurationWarnings: [],
+                });
+              } else {
+                expect(output[0]).toContain(
+                  "Plugin discovery, module loading, compatibility, and configuration checks passed.",
+                );
+              }
+            } else {
+              expect(result?.shouldContinue).toBe(false);
+              expect(result?.reply?.text).toContain(
+                selection === "inspect missing"
+                  ? 'No plugin named "missing" found.'
+                  : selection === "inspect"
+                    ? "Plugins ("
+                    : "```json",
+              );
+            }
             expect(inspection?.database.isOpen).toBe(false);
             expect(inspection?.disposals).toBe(1);
             expect(activeConnection?.disposals).toBe(0);
@@ -182,6 +237,9 @@ module.exports = { id: "native-chat-inspection", register(api) {
             }
           }
           Reflect.deleteProperty(globalThis, key);
+          log.mockRestore();
+          writeStdout.mockRestore();
+          process.exitCode = previousExitCode;
         }
       }
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `plugins doctor` could leave resources acquired during plugin registration open after rendering its diagnostics report.

## Why This Change Was Made

Doctor now uses the existing inspection owner through warning calculation and serialization, awaits disposal, and then publishes its output and diagnostic exit status. A cleanup failure reaches the existing command-error boundary without a preceding successful report.

Related: #140674. This four-file slice is independent of general cached-registry and prepared-generation disposal.

## User Impact

Effective-only discovery, configuration fallback, warning and compatibility rules, human output, JSON fields, and healthy/unhealthy exit transitions remain consistent. Inspection closes its separate registration resources while active Gateway registrations remain available.

## Evidence

A native regression reproduced the original missing disposal. All 71 focused tests and the full canonical changed checks passed, followed by a full build in 247.8 seconds. Codex review found no actionable findings.

Four runs through the compiled Doctor owner passed in 4.149 seconds. They covered delayed cleanup, healthy→unhealthy→healthy exit transitions, and disposal rejection while a separate active SQLite registration remained queryable with unchanged identity, epoch, and signal.

Four fresh processes using the shipped `node openclaw.mjs plugins doctor` launcher passed: healthy human and JSON output (exit 0), registration failure with cleanup (exit 1), and exactly one JSON command error on disposal failure (exit 1). Individual timings were 1.335, 1.178, 1.188, and 1.153 seconds. Each synthetic plugin connection closed once; source and all 13,704 build artifacts remained unchanged during proof.

The native fixture represents an existing configured installation. Initial failures exposed retired agent markers and first-install provider-preference initialization in its setup; correcting that synthetic setup preserved the health assertions and production warning policy. No real provider credentials, network service, or running Gateway coverage is claimed.

Production changes are confined to the existing Doctor owner (+157/-144 lines, primarily callback indentation). Existing tests gain cleanup and active-registration controls; docs explain completion and failure behavior. No database schema, configuration surface, dependency, or public API changes.

## Review Disposition

The automatic data-model compatibility item does not apply to this diff. The sole production change is in `runPluginsDoctorCommand`; the existing configuration-warning reads, report fields, and health calculations are preserved. No schema, schema version, migration/backfill implementation, stored representation, retention rule, or persistent write changes. The native and shipped CLI cases verify resource closure while retaining the synthetic database row; active-registration queries remain valid. This is the already accepted registration-resource cleanup scope, with no data migration to validate.
