### PR TITLE
refactor(memory): simplify built-in runtime delegation

### DIFF
--- a/extensions/memory-core/index.ts
+++ b/extensions/memory-core/index.ts
@@ -196,11 +196,7 @@ function createLazyMemoryRuntime(host: MemoryCoreRuntimeHost): MemoryPluginRunti
     },
     async authorizeSearchHits(params) {
       const { createMemoryRuntime } = await loadRuntimeProviderModule();
-      const runtime = createMemoryRuntime(host);
-      if (!runtime.authorizeSearchHits) {
-        throw new Error("memory-core runtime search authorization is unavailable");
-      }
-      return await runtime.authorizeSearchHits(params);
+      return await createMemoryRuntime(host).authorizeSearchHits(params);
     },
     async classifyWorkspaceMemoryPaths(params) {
       const [{ classifyWorkspaceMemoryPaths }, dreamingState] = await Promise.all([
@@ -212,16 +208,14 @@ function createLazyMemoryRuntime(host: MemoryCoreRuntimeHost): MemoryPluginRunti
       }
       return await classifyWorkspaceMemoryPaths(params);
     },
-    resolveMemoryBackendConfig(params) {
-      return resolveMemoryBackendConfig(params);
-    },
+    resolveMemoryBackendConfig,
     async closeAllMemorySearchManagers() {
       const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
-      await runtime.closeAllMemorySearchManagers?.();
+      await runtime.closeAllMemorySearchManagers();
     },
     async closeMemorySearchManager(params) {
       const { memoryRuntime: runtime } = await loadRuntimeProviderModule();
-      await runtime.closeMemorySearchManager?.(params);
+      await runtime.closeMemorySearchManager(params);
     },
   };
 }

--- a/extensions/memory-core/src/memory/search-manager.ts
+++ b/extensions/memory-core/src/memory/search-manager.ts
@@ -6,8 +6,7 @@ import type { MemorySearchManager } from "openclaw/plugin-sdk/memory-core-host-e
 import { normalizeAgentId } from "openclaw/plugin-sdk/routing";
 import type { MemoryCoreAcquireLocalService } from "./embedding-local-service.js";
 
-const managerRuntimeLoader = createLazyRuntimeModule(() => import("../../manager-runtime.js"));
-const loadManagerRuntime = managerRuntimeLoader;
+const loadManagerRuntime = createLazyRuntimeModule(() => import("../../manager-runtime.js"));
 
 type MemorySearchManagerPurpose = "default" | "status" | "cli";
 type MemorySearchManagerParams = {
@@ -55,7 +54,7 @@ async function getBuiltinMemorySearchManager(
 }
 
 export async function closeAllMemorySearchManagers(): Promise<void> {
-  if (!managerRuntimeLoader.peek()) {
+  if (!loadManagerRuntime.peek()) {
     return;
   }
   const { closeAllMemoryIndexManagers } = await loadManagerRuntime();
@@ -66,7 +65,7 @@ export async function closeMemorySearchManager(params: {
   cfg: OpenClawConfig;
   agentId: string;
 }): Promise<void> {
-  if (!managerRuntimeLoader.peek()) {
+  if (!loadManagerRuntime.peek()) {
     return;
   }
   const { closeMemoryIndexManagersForAgent } = await loadManagerRuntime();

--- a/extensions/memory-core/src/runtime-provider.test.ts
+++ b/extensions/memory-core/src/runtime-provider.test.ts
@@ -123,10 +123,6 @@ describe("memoryRuntime", () => {
       },
     ];
     filterMemorySearchHitsBySessionVisibilityMock.mockResolvedValue([]);
-    if (!memoryRuntime.authorizeSearchHits) {
-      throw new Error("memory runtime search authorizer is unavailable");
-    }
-
     await expect(
       memoryRuntime.authorizeSearchHits({
         cfg,

--- a/extensions/memory-core/src/runtime-provider.ts
+++ b/extensions/memory-core/src/runtime-provider.ts
@@ -10,7 +10,7 @@ import {
 import type { MemoryCoreRuntimeHost } from "./memory/runtime-host.js";
 import { classifyWorkspaceMemoryPaths } from "./workspace-path-classifier.js";
 
-export function createMemoryRuntime(host: MemoryCoreRuntimeHost = {}): MemoryPluginRuntime {
+export function createMemoryRuntime(host: MemoryCoreRuntimeHost = {}) {
   if (host.openKeyedStore) {
     configureMemoryCoreDreamingState(host.openKeyedStore);
   }
@@ -27,22 +27,16 @@ export function createMemoryRuntime(host: MemoryCoreRuntimeHost = {}): MemoryPlu
         error,
       };
     },
-    resolveMemoryBackendConfig(params) {
-      return resolveMemoryBackendConfig(params);
-    },
+    resolveMemoryBackendConfig,
     async authorizeSearchHits(params) {
       const { filterMemorySearchHitsBySessionVisibility } =
         await import("./session-search-visibility.js");
       return await filterMemorySearchHitsBySessionVisibility(params);
     },
     classifyWorkspaceMemoryPaths,
-    async closeAllMemorySearchManagers() {
-      await closeAllMemorySearchManagers();
-    },
-    async closeMemorySearchManager(params) {
-      await closeMemorySearchManager(params);
-    },
-  };
+    closeAllMemorySearchManagers,
+    closeMemorySearchManager,
+  } satisfies MemoryPluginRuntime;
 }
 
 export const memoryRuntime = createMemoryRuntime();


### PR DESCRIPTION
## What Problem This Solves

Removes redundant delegation and impossible capability checks inside the built-in memory runtime. Its factory always provides authorization and cleanup, but widening the result to the optional plugin interface obscured that fact.

## Why This Change Was Made

Keep the factory's concrete type checked with `satisfies MemoryPluginRuntime`, expose the existing receiver-independent resolver and cleanup functions directly, and use one name for the lazy manager loader. The generic interface and host handling of optional third-party capabilities stay intact.

## User Impact

Memory behavior is preserved: host-scoped acquisition, lazy loading, authorization, result shape, and scoped/all-manager cleanup. Net reduction: **13 production lines and 4 test-guard lines**, with no new abstraction, dependency, configuration, or storage change.

## Evidence

- 38 existing tests passed across runtime registration, provider delegation, and manager acquisition/cleanup.
- Full changed-file checks passed, including plugin contracts, typechecks, lint, and unused-export scans. Canonical `ciArtifacts` build passed.
- Native source smoke used two synthetic agents and real SQLite FTS with `provider: none`: indexing, reading, searching, actual transcript-hit authorization, scoped cleanup preserving the other agent, persisted-index reopen, and all-manager cleanup passed. Cold cleanup loaded no manager runtime and created no state. The temporary sandbox was removed and source hashes stayed unchanged.
- Independent Codex review is clean at P0–P2. No new test or production test seam was added; the existing authorization test retains its assertions.
