### PR TITLE
fix(ci): complete macOS CodeQL within hosted limits

### DIFF
--- a/.github/workflows/codeql-macos-critical-security.yml
+++ b/.github/workflows/codeql-macos-critical-security.yml
@@ -20,7 +20,7 @@ permissions:
 jobs:
   macos:
     name: Critical Security (macOS)
-    runs-on: macos-26
+    runs-on: macos-26-intel
     timeout-minutes: 45
     steps:
       - name: Checkout
@@ -57,7 +57,8 @@ jobs:
           config-file: ./.github/codeql/codeql-macos-critical-security.yml
 
       - name: Build macOS for CodeQL
-        run: swift build --package-path apps/macos --product OpenClaw
+        # Preserve ARM-only application paths in CodeQL coverage on the Intel host.
+        run: swift build --package-path apps/macos --product OpenClaw --arch arm64
 
       - name: Analyze
         id: analyze

--- a/.github/workflows/codeql-macos-critical-security.yml
+++ b/.github/workflows/codeql-macos-critical-security.yml
@@ -59,7 +59,8 @@ jobs:
       - name: Build macOS for CodeQL
         # Preserve ARM-only application paths in CodeQL coverage on the Intel host.
         # A positive backend thread count keeps SwiftPM's per-file object map linkable under WMO.
-        run: swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none -Xswiftc -whole-module-optimization -Xswiftc -num-threads -Xswiftc 1
+        # Combined module emission avoids a separate traced module-emission frontend.
+        run: swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none -Xswiftc -whole-module-optimization -Xswiftc -num-threads -Xswiftc 1 -Xswiftc -no-emit-module-separately-wmo
 
       - name: Analyze
         id: analyze

--- a/.github/workflows/codeql-macos-critical-security.yml
+++ b/.github/workflows/codeql-macos-critical-security.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Build macOS for CodeQL
         # Preserve ARM-only application paths in CodeQL coverage on the Intel host.
-        run: swift build --package-path apps/macos --product OpenClaw --arch arm64
+        run: swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none
 
       - name: Analyze
         id: analyze

--- a/.github/workflows/codeql-macos-critical-security.yml
+++ b/.github/workflows/codeql-macos-critical-security.yml
@@ -18,14 +18,65 @@ permissions:
   security-events: write
 
 jobs:
+  prepare-mermaid:
+    name: Prepare Mermaid assets
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    outputs:
+      artifact-id: ${{ steps.upload.outputs.artifact-id }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.sha }}
+          submodules: false
+
+      - name: Setup Node environment
+        uses: ./.github/actions/setup-node-env
+        with:
+          cache-mode: restore
+          install-bun: "false"
+          install-deps: "false"
+
+      - name: Install Mermaid renderer dependencies
+        env:
+          CI: "true"
+        run: >-
+          pnpm install --frozen-lockfile --prefer-offline --optional
+          --filter '@openclaw/mermaid-renderer...'
+          --config.ignore-scripts=false
+          --config.engine-strict=false
+          --config.enable-pre-post-scripts=true
+          --config.side-effects-cache=true
+
+      - name: Prepare Apple Mermaid assets
+        run: node scripts/prepare-apple-mermaid.mjs
+
+      - name: Upload Mermaid assets
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: codeql-macos-mermaid-${{ github.run_id }}-${{ github.run_attempt }}
+          path: apps/shared/OpenClawKit/Sources/OpenClawChatUI/Resources/Mermaid
+          if-no-files-found: error
+          retention-days: 1
+
   macos:
     name: Critical Security (macOS)
+    needs: prepare-mermaid
     runs-on: macos-26-intel
     timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
+          fetch-depth: 1
+          persist-credentials: false
+          ref: ${{ github.sha }}
           submodules: false
 
       - name: Select Xcode
@@ -40,14 +91,11 @@ jobs:
           fi
           swift --version
 
-      - name: Setup Node environment
-        uses: ./.github/actions/setup-node-env
+      - name: Download Mermaid assets
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          cache-mode: restore
-          install-bun: "false"
-
-      - name: Prepare Apple Mermaid assets
-        run: node scripts/prepare-apple-mermaid.mjs
+          artifact-ids: ${{ needs.prepare-mermaid.outputs.artifact-id }}
+          path: apps/shared/OpenClawKit/Sources/OpenClawChatUI/Resources/Mermaid
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
@@ -58,9 +106,7 @@ jobs:
 
       - name: Build macOS for CodeQL
         # Preserve ARM-only application paths in CodeQL coverage on the Intel host.
-        # A positive backend thread count keeps SwiftPM's per-file object map linkable under WMO.
-        # Combined module emission avoids a separate traced module-emission frontend.
-        run: swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none -Xswiftc -whole-module-optimization -Xswiftc -num-threads -Xswiftc 1 -Xswiftc -no-emit-module-separately-wmo
+        run: swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none
 
       - name: Analyze
         id: analyze

--- a/.github/workflows/codeql-macos-critical-security.yml
+++ b/.github/workflows/codeql-macos-critical-security.yml
@@ -58,7 +58,8 @@ jobs:
 
       - name: Build macOS for CodeQL
         # Preserve ARM-only application paths in CodeQL coverage on the Intel host.
-        run: swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none
+        # A positive backend thread count keeps SwiftPM's per-file object map linkable under WMO.
+        run: swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none -Xswiftc -whole-module-optimization -Xswiftc -num-threads -Xswiftc 1
 
       - name: Analyze
         id: analyze

--- a/.github/workflows/codeql-macos-critical-security.yml
+++ b/.github/workflows/codeql-macos-critical-security.yml
@@ -69,7 +69,7 @@ jobs:
     name: Critical Security (macOS)
     needs: prepare-mermaid
     runs-on: macos-26-intel
-    timeout-minutes: 45
+    timeout-minutes: 90
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/docs/ci/scheduled-workflows.md
+++ b/docs/ci/scheduled-workflows.md
@@ -149,7 +149,7 @@ The pull request guard stays light: it only starts for changes under `.github/ac
 ### Platform-specific security shards
 
 - `CodeQL Android Critical Security` — scheduled Android security shard. Builds the Android app manually for CodeQL on the smallest Blacksmith Linux runner accepted by workflow sanity. Uploads under `/codeql-critical-security/android`.
-- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Builds the macOS app manually for CodeQL on GitHub-hosted macOS, filters dependency build results out of uploaded SARIF, and uploads under `/codeql-critical-security/macos`. Kept outside daily defaults because macOS build dominates runtime even when clean.
+- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Builds the ARM64 macOS app manually for CodeQL on a GitHub-hosted Intel runner, filters dependency build results out of uploaded SARIF, and uploads under `/codeql-critical-security/macos`. Kept outside daily defaults because macOS build dominates runtime even when clean.
 
 ### Critical Quality categories
 

--- a/docs/ci/scheduled-workflows.md
+++ b/docs/ci/scheduled-workflows.md
@@ -149,7 +149,7 @@ The pull request guard stays light: it only starts for changes under `.github/ac
 ### Platform-specific security shards
 
 - `CodeQL Android Critical Security` — scheduled Android security shard. Builds the Android app manually for CodeQL on the smallest Blacksmith Linux runner accepted by workflow sanity. Uploads under `/codeql-critical-security/android`.
-- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Builds the ARM64 macOS app manually for CodeQL on a GitHub-hosted Intel runner, filters dependency build results out of uploaded SARIF, and uploads under `/codeql-critical-security/macos`. Kept outside daily defaults because macOS build dominates runtime even when clean.
+- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Builds the ARM64 macOS app manually for CodeQL on a GitHub-hosted Intel runner without generating unused index-store or debug-info artifacts, filters dependency build results out of uploaded SARIF, and uploads under `/codeql-critical-security/macos`. Kept outside daily defaults because macOS build dominates runtime even when clean.
 
 ### Critical Quality categories
 

--- a/docs/ci/scheduled-workflows.md
+++ b/docs/ci/scheduled-workflows.md
@@ -149,7 +149,7 @@ The pull request guard stays light: it only starts for changes under `.github/ac
 ### Platform-specific security shards
 
 - `CodeQL Android Critical Security` — scheduled Android security shard. Builds the Android app manually for CodeQL on the smallest Blacksmith Linux runner accepted by workflow sanity. Uploads under `/codeql-critical-security/android`.
-- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Builds the ARM64 macOS app manually for CodeQL on a GitHub-hosted Intel runner without generating unused index-store or debug-info artifacts, filters dependency build results out of uploaded SARIF, and uploads under `/codeql-critical-security/macos`. Kept outside daily defaults because macOS build dominates runtime even when clean.
+- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Builds the ARM64 macOS app manually for CodeQL on a GitHub-hosted Intel runner with whole-module compilation, one backend thread, and no unused index-store or debug-info artifacts; filters dependency build results out of uploaded SARIF; and uploads under `/codeql-critical-security/macos`. Kept outside daily defaults because macOS build dominates runtime even when clean.
 
 ### Critical Quality categories
 

--- a/docs/ci/scheduled-workflows.md
+++ b/docs/ci/scheduled-workflows.md
@@ -149,7 +149,7 @@ The pull request guard stays light: it only starts for changes under `.github/ac
 ### Platform-specific security shards
 
 - `CodeQL Android Critical Security` — scheduled Android security shard. Builds the Android app manually for CodeQL on the smallest Blacksmith Linux runner accepted by workflow sanity. Uploads under `/codeql-critical-security/android`.
-- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Builds the ARM64 macOS app manually for CodeQL on a GitHub-hosted Intel runner with whole-module compilation, combined module emission, one backend thread, and no unused index-store or debug-info artifacts; filters dependency build results out of uploaded SARIF; and uploads under `/codeql-critical-security/macos`. Kept outside daily defaults because macOS build dominates runtime even when clean.
+- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Prepares the generated Mermaid resources on GitHub-hosted Linux, then builds the ARM64 macOS app manually for CodeQL on a GitHub-hosted Intel runner without unused index-store or debug-info artifacts; filters dependency build results out of uploaded SARIF; and uploads under `/codeql-critical-security/macos`. Kept outside daily defaults because macOS build dominates runtime even when clean.
 
 ### Critical Quality categories
 

--- a/docs/ci/scheduled-workflows.md
+++ b/docs/ci/scheduled-workflows.md
@@ -149,7 +149,7 @@ The pull request guard stays light: it only starts for changes under `.github/ac
 ### Platform-specific security shards
 
 - `CodeQL Android Critical Security` — scheduled Android security shard. Builds the Android app manually for CodeQL on the smallest Blacksmith Linux runner accepted by workflow sanity. Uploads under `/codeql-critical-security/android`.
-- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Builds the ARM64 macOS app manually for CodeQL on a GitHub-hosted Intel runner with whole-module compilation, one backend thread, and no unused index-store or debug-info artifacts; filters dependency build results out of uploaded SARIF; and uploads under `/codeql-critical-security/macos`. Kept outside daily defaults because macOS build dominates runtime even when clean.
+- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Builds the ARM64 macOS app manually for CodeQL on a GitHub-hosted Intel runner with whole-module compilation, combined module emission, one backend thread, and no unused index-store or debug-info artifacts; filters dependency build results out of uploaded SARIF; and uploads under `/codeql-critical-security/macos`. Kept outside daily defaults because macOS build dominates runtime even when clean.
 
 ### Critical Quality categories
 

--- a/docs/ci/scheduled-workflows.md
+++ b/docs/ci/scheduled-workflows.md
@@ -149,7 +149,7 @@ The pull request guard stays light: it only starts for changes under `.github/ac
 ### Platform-specific security shards
 
 - `CodeQL Android Critical Security` — scheduled Android security shard. Builds the Android app manually for CodeQL on the smallest Blacksmith Linux runner accepted by workflow sanity. Uploads under `/codeql-critical-security/android`.
-- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Prepares the generated Mermaid resources on GitHub-hosted Linux, then builds the ARM64 macOS app manually for CodeQL on a GitHub-hosted Intel runner without unused index-store or debug-info artifacts; filters dependency build results out of uploaded SARIF; and uploads under `/codeql-critical-security/macos`. Kept outside daily defaults because macOS build dominates runtime even when clean.
+- `CodeQL macOS Critical Security` — weekly/manual macOS security shard. Prepares the generated Mermaid resources on GitHub-hosted Linux, then builds the ARM64 macOS app manually for CodeQL on a GitHub-hosted Intel runner without unused index-store or debug-info artifacts; filters dependency build results out of uploaded SARIF; and uploads under `/codeql-critical-security/macos`. Its macOS job has a 90-minute ceiling because the complete traced build and analysis exceed the previous 45-minute budget. Kept outside daily defaults because macOS build dominates runtime even when clean.
 
 ### Critical Quality categories
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4385,7 +4385,25 @@ NODE
       "CodeQL macOS Xcode selection",
     );
 
-    expect(codeqlJob["runs-on"]).toBe("macos-26");
+    const codeqlInitializeIndex = codeqlJob.steps.findIndex(
+      (step: WorkflowStep) => step.name === "Initialize CodeQL",
+    );
+    const codeqlBuildIndex = codeqlJob.steps.findIndex(
+      (step: WorkflowStep) => step.name === "Build macOS for CodeQL",
+    );
+    const codeqlAnalyzeIndex = codeqlJob.steps.findIndex(
+      (step: WorkflowStep) => step.name === "Analyze",
+    );
+    const codeqlBuild = expectDefined(codeqlJob.steps[codeqlBuildIndex], "CodeQL macOS build");
+
+    expect(codeqlJob["runs-on"]).toBe("macos-26-intel");
+    expect(codeqlJob["timeout-minutes"]).toBe(45);
+    expect(codeqlInitializeIndex).toBeGreaterThanOrEqual(0);
+    expect(codeqlInitializeIndex).toBeLessThan(codeqlBuildIndex);
+    expect(codeqlBuildIndex).toBeLessThan(codeqlAnalyzeIndex);
+    expect(codeqlBuild.run).toBe(
+      "swift build --package-path apps/macos --product OpenClaw --arch arm64",
+    );
     expect(codeqlSelect.run).toContain("/Applications/Xcode_26.6.app/Contents/Developer");
     expect(codeqlSelect.run).toContain('if [[ "$xcode_version" != 26.6* ]]; then');
 

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4395,14 +4395,111 @@ NODE
       (step: WorkflowStep) => step.name === "Analyze",
     );
     const codeqlBuild = expectDefined(codeqlJob.steps[codeqlBuildIndex], "CodeQL macOS build");
+    const codeqlPrepare = codeql.jobs["prepare-mermaid"];
+    const codeqlPrepareSteps = codeqlPrepare.steps as WorkflowStep[];
+    const codeqlPrepareCheckout = expectDefined(
+      codeqlPrepareSteps.find((step) => step.name === "Checkout"),
+      "CodeQL Mermaid checkout",
+    );
+    const codeqlPrepareSetup = expectDefined(
+      codeqlPrepareSteps.find((step) => step.name === "Setup Node environment"),
+      "CodeQL Mermaid Node setup",
+    );
+    const codeqlPrepareInstall = expectDefined(
+      codeqlPrepareSteps.find((step) => step.name === "Install Mermaid renderer dependencies"),
+      "CodeQL Mermaid dependency install",
+    );
+    const codeqlPrepareAssets = expectDefined(
+      codeqlPrepareSteps.find((step) => step.name === "Prepare Apple Mermaid assets"),
+      "CodeQL Mermaid asset preparation",
+    );
+    const codeqlUpload = expectDefined(
+      codeqlPrepareSteps.find((step) => step.name === "Upload Mermaid assets"),
+      "CodeQL Mermaid artifact upload",
+    );
+    const codeqlDownloadIndex = codeqlJob.steps.findIndex(
+      (step: WorkflowStep) => step.name === "Download Mermaid assets",
+    );
+    const codeqlDownload = expectDefined(
+      codeqlJob.steps[codeqlDownloadIndex],
+      "CodeQL Mermaid artifact download",
+    );
 
+    expect(codeqlPrepare["runs-on"]).toBe("ubuntu-24.04");
+    expect(codeqlPrepare["timeout-minutes"]).toBe(10);
+    expect(codeqlPrepare.permissions).toEqual({ contents: "read" });
+    expect(codeqlPrepare.outputs["artifact-id"]).toBe("${{ steps.upload.outputs.artifact-id }}");
+    expect(codeqlPrepareCheckout.with).toMatchObject({
+      "fetch-depth": 1,
+      "persist-credentials": false,
+      ref: "${{ github.sha }}",
+      submodules: false,
+    });
+    expect(codeqlPrepareSetup.with).toMatchObject({
+      "cache-mode": "restore",
+      "install-bun": "false",
+      "install-deps": "false",
+    });
+    expect(codeqlPrepareInstall.env).toEqual({ CI: "true" });
+    expect(codeqlPrepareInstall.run).toContain(
+      "pnpm install --frozen-lockfile --prefer-offline --optional",
+    );
+    expect(codeqlPrepareInstall.run).toContain("--filter '@openclaw/mermaid-renderer...'");
+    expect(codeqlPrepareInstall.run).toContain("--config.ignore-scripts=false");
+    expect(codeqlPrepareInstall.run).toContain("--config.engine-strict=false");
+    expect(codeqlPrepareInstall.run).toContain("--config.enable-pre-post-scripts=true");
+    expect(codeqlPrepareInstall.run).toContain("--config.side-effects-cache=true");
+    expect(codeqlPrepareAssets.run).toBe("node scripts/prepare-apple-mermaid.mjs");
+    expect(codeqlUpload).toMatchObject({
+      id: "upload",
+      uses: UPLOAD_ARTIFACT_V7,
+      with: {
+        name: "codeql-macos-mermaid-${{ github.run_id }}-${{ github.run_attempt }}",
+        path: "apps/shared/OpenClawKit/Sources/OpenClawChatUI/Resources/Mermaid",
+        "if-no-files-found": "error",
+        "retention-days": 1,
+      },
+    });
+    expect(codeqlPrepareSteps.indexOf(codeqlPrepareInstall)).toBeLessThan(
+      codeqlPrepareSteps.indexOf(codeqlPrepareAssets),
+    );
+    expect(codeqlPrepareSteps.indexOf(codeqlPrepareAssets)).toBeLessThan(
+      codeqlPrepareSteps.indexOf(codeqlUpload),
+    );
+    expect(codeqlJob.needs).toBe("prepare-mermaid");
     expect(codeqlJob["runs-on"]).toBe("macos-26-intel");
     expect(codeqlJob["timeout-minutes"]).toBe(45);
+    const codeqlCheckout = expectDefined(
+      codeqlJob.steps.find((step: WorkflowStep) => step.name === "Checkout"),
+      "CodeQL macOS checkout",
+    );
+    expect(codeqlCheckout.with).toMatchObject({
+      "fetch-depth": 1,
+      "persist-credentials": false,
+      ref: "${{ github.sha }}",
+      submodules: false,
+    });
+    expect(
+      codeqlJob.steps.some(
+        (step: WorkflowStep) => step.uses === "./.github/actions/setup-node-env",
+      ),
+    ).toBe(false);
+    expect(
+      codeqlJob.steps.some((step: WorkflowStep) => step.run?.includes("prepare-apple-mermaid.mjs")),
+    ).toBe(false);
+    expect(codeqlDownload).toMatchObject({
+      uses: DOWNLOAD_ARTIFACT_V8,
+      with: {
+        "artifact-ids": "${{ needs.prepare-mermaid.outputs.artifact-id }}",
+        path: "apps/shared/OpenClawKit/Sources/OpenClawChatUI/Resources/Mermaid",
+      },
+    });
+    expect(codeqlDownloadIndex).toBeLessThan(codeqlInitializeIndex);
     expect(codeqlInitializeIndex).toBeGreaterThanOrEqual(0);
     expect(codeqlInitializeIndex).toBeLessThan(codeqlBuildIndex);
     expect(codeqlBuildIndex).toBeLessThan(codeqlAnalyzeIndex);
     expect(codeqlBuild.run).toBe(
-      "swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none -Xswiftc -whole-module-optimization -Xswiftc -num-threads -Xswiftc 1 -Xswiftc -no-emit-module-separately-wmo",
+      "swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none",
     );
     expect(codeqlSelect.run).toContain("/Applications/Xcode_26.6.app/Contents/Developer");
     expect(codeqlSelect.run).toContain('if [[ "$xcode_version" != 26.6* ]]; then');
@@ -9830,7 +9927,6 @@ server.listen(0, "127.0.0.1", () => {
   it("prepares offline Apple assets before CI opens a macOS SwiftPM graph", () => {
     for (const [workflowPath, jobName] of [
       [".github/workflows/ci.yml", "macos-swift"],
-      [".github/workflows/codeql-macos-critical-security.yml", "macos"],
       [".github/workflows/macos-periphery.yml", "scan"],
       [".github/workflows/shared-openclawkit-periphery.yml", "scan-macos"],
     ] as const) {

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4402,7 +4402,7 @@ NODE
     expect(codeqlInitializeIndex).toBeLessThan(codeqlBuildIndex);
     expect(codeqlBuildIndex).toBeLessThan(codeqlAnalyzeIndex);
     expect(codeqlBuild.run).toBe(
-      "swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none -Xswiftc -whole-module-optimization -Xswiftc -num-threads -Xswiftc 1",
+      "swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none -Xswiftc -whole-module-optimization -Xswiftc -num-threads -Xswiftc 1 -Xswiftc -no-emit-module-separately-wmo",
     );
     expect(codeqlSelect.run).toContain("/Applications/Xcode_26.6.app/Contents/Developer");
     expect(codeqlSelect.run).toContain('if [[ "$xcode_version" != 26.6* ]]; then');

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4402,7 +4402,7 @@ NODE
     expect(codeqlInitializeIndex).toBeLessThan(codeqlBuildIndex);
     expect(codeqlBuildIndex).toBeLessThan(codeqlAnalyzeIndex);
     expect(codeqlBuild.run).toBe(
-      "swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none",
+      "swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none -Xswiftc -whole-module-optimization -Xswiftc -num-threads -Xswiftc 1",
     );
     expect(codeqlSelect.run).toContain("/Applications/Xcode_26.6.app/Contents/Developer");
     expect(codeqlSelect.run).toContain('if [[ "$xcode_version" != 26.6* ]]; then');

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4402,7 +4402,7 @@ NODE
     expect(codeqlInitializeIndex).toBeLessThan(codeqlBuildIndex);
     expect(codeqlBuildIndex).toBeLessThan(codeqlAnalyzeIndex);
     expect(codeqlBuild.run).toBe(
-      "swift build --package-path apps/macos --product OpenClaw --arch arm64",
+      "swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none",
     );
     expect(codeqlSelect.run).toContain("/Applications/Xcode_26.6.app/Contents/Developer");
     expect(codeqlSelect.run).toContain('if [[ "$xcode_version" != 26.6* ]]; then');

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -4468,7 +4468,7 @@ NODE
     );
     expect(codeqlJob.needs).toBe("prepare-mermaid");
     expect(codeqlJob["runs-on"]).toBe("macos-26-intel");
-    expect(codeqlJob["timeout-minutes"]).toBe(45);
+    expect(codeqlJob["timeout-minutes"]).toBe(90);
     const codeqlCheckout = expectDefined(
       codeqlJob.steps.find((step: WorkflowStep) => step.name === "Checkout"),
       "CodeQL macOS checkout",


### PR DESCRIPTION
Related: #141761

## What Problem This Solves

The weekly/manual macOS CodeQL scan reached the previous 45-minute job limit during the Swift build, before normal analysis, dependency-result filtering, filtered SARIF upload, and processing could finish.

## What Changed

The macOS job keeps the full ARM64 `OpenClaw` product build under CodeQL tracing on GitHub's Intel macOS runner:

```sh
swift build --package-path apps/macos --product OpenClaw --arch arm64 --disable-index-store -debug-info-format none
```

The generated Mermaid resource bundle is prepared in a separate GitHub-hosted Ubuntu job from the same immutable workflow SHA. That job uses the repository's canonical generator and frozen filtered dependency install, uploads the complete generated directory, and exposes the exact artifact ID. The macOS job downloads the artifact into the production resource path before CodeQL initialization.

This moves Node setup, dependency installation, and Mermaid generation outside the macOS job's budget. The production macOS job now has a 90-minute ceiling. It does not change the product, ARM64 target, CodeQL version, queries, permissions, concurrency, dependency-result filtering, or filtered SARIF upload.

The previous WMO experiments were removed because they did not complete the build and their hosted timings were too variable to establish a performance improvement.

## Asset Portability Proof

The one-off cross-platform diagnostic passed:

- https://github.com/openclaw/openclaw/actions/runs/34230384566
- Diagnostic head: `38eb15d07c74043732d8478a44f954a4481b3d5f`
- Production parent: `9fa47bb34f6d813de2b0a425fac722e778743039`
- Node `24.20.0`; pnpm `12.3.4`
- Artifact ID `10057536502`
- Clean cache-disabled installs materialized 1,044 packages on Linux and 1,046 on macOS across two workspace projects.
- The Ubuntu output, downloaded artifact in the production path, and fresh macOS generation had identical complete path, size, and SHA-256 inventories.
- All five expected non-empty root files matched byte-for-byte, including the transformed `native.js`.

This proves asset portability only.

## Production Qualification

The current production candidate is `7d9990482dfd46d7ceb8d478bfe458965be77aee`. It changes only the macOS job ceiling from 45 to 90 minutes, with matching workflow guard and documentation updates.

Its full 90-minute exact-head qualification passed:

- https://github.com/openclaw/openclaw/actions/runs/34284276789
- macOS job: 69m16s
- ARM64 Swift build: 60m47s
- CodeQL analysis: 5m22s
- Dependency-result filtering: 3s
- Filtered SARIF upload and processing: 8s
- Server processing completed at `23:18:14 UTC`

CodeQL accounted for all 339 Swift files expected in the selected `OpenClaw` product from the 351-file non-generated baseline. The remaining 12 are CLI-only sources outside that product. ARM64-specific source anchors compiled.

The preceding production head, `9fa47bb34f6d813de2b0a425fac722e778743039`, failed its full 45-minute hosted qualification:

- https://github.com/openclaw/openclaw/actions/runs/34230986570
- Swift build: `13:20:43-14:03:29 UTC` (42m46s)
- Last progress: `[903/1025] Compiling PeekabooAutomationKit DesktopObservationTraceRecorder.swift`

The job reached the unchanged limit before the `OpenClaw` main module or link completed. Normal CodeQL analysis, dependency-result filtering, filtered SARIF upload, and processing were skipped. That preceding 45-minute head remained unqualified.

The earlier Intel-host candidates also reached the same limit:

- https://github.com/openclaw/openclaw/actions/runs/34188090185
- https://github.com/openclaw/openclaw/actions/runs/34212967779
- https://github.com/openclaw/openclaw/actions/runs/34218461495
- https://github.com/openclaw/openclaw/actions/runs/34223566437

## 90-Minute Measurement

A never-merge diagnostic changed only the workflow name, removed its schedule, and raised the macOS job ceiling from 45 to 90 minutes. Its parent is the preceding production head, so the producer, artifact handoff, toolchain, build command, ARM64 product, CodeQL configuration and queries, filtering, permissions, and SARIF flow were unchanged:

- https://github.com/openclaw/openclaw/actions/runs/34255669217
- Diagnostic head: `881a454db46dce84bdcae46cffab98a800c2c7ae`
- Preceding production head: `9fa47bb34f6d813de2b0a425fac722e778743039`
- macOS job: 65m28s
- ARM64 Swift build: 58m35s
- CodeQL analysis: 3m52s
- Dependency-result filtering: 5s
- Filtered SARIF upload and processing: 7s
- Server processing completed at `18:19:11 UTC`

CodeQL scanned 339 of the 351 non-generated tracked Swift files. All 339 files expected in the selected `OpenClaw` product were present; the remaining 12 are CLI-only sources outside that product. ARM64-specific source anchors compiled.

This proves that the unchanged production workload can complete on the tested GitHub-hosted Intel runner when given more than 45 minutes.

## Capacity Decision

The owner accepted the timeout-only production repair. The production qualification used 69m16s, leaving 20m44s under the new 90-minute ceiling. That is observed headroom from one production run, not a statistical SLA or a claim that tracer overhead is fixed.

The production change now has exact-head proof through the complete build, analysis, filtering, normal filtered-SARIF upload, and processing.

A separate upstream report describes similar fixed macOS Swift tracer overhead on older CodeQL and Swift versions: https://github.com/github/codeql/issues/22275. It documents a relevant limitation but does not establish the entire cause or duration of OpenClaw's runs.

## Current Status

- Exact-head ordinary CI passed: https://github.com/openclaw/openclaw/actions/runs/34284265263
- Fresh exact-head autoreview and ClawSweeper review completed without an actionable code finding.
- The cross-platform asset handoff passed.
- The 90-minute diagnostic completed the full build, analysis, filtering, normal SARIF upload, and processing.
- The production 90-minute workflow completed the same full pipeline on the current head.

## User Impact

There is no runtime product change. The production qualification establishes a measured budget for completing the scheduled/manual macOS security scan on standard GitHub-hosted capacity without changing the selected Swift source set or security pipeline.

## Local Evidence

- The timeout guard failed against the 45-minute workflow, then passed after the production change: 1 test passed and 519 were skipped.
- Formatting, Actionlint, ShellCheck, Zizmor, structural security checks, and `git diff --check` passed.
- The production candidate diff is exactly the independently reviewed three-file change.
