### PR TITLE
fix: stop offering Fast when the selected request cannot use it

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -16537,6 +16537,7 @@ public struct ModelChoice: Codable, Sendable {
     public let thinkinglevels: [[String: AnyCodable]]?
     public let thinkingdefault: String?
     public let effectivefastmode: AnyCodable?
+    public let supportsfastmode: Bool?
     public let supportstools: Bool?
     public let agentruntime: [String: AnyCodable]?
     public let apikeysupported: Bool?
@@ -16558,6 +16559,7 @@ public struct ModelChoice: Codable, Sendable {
         thinkinglevels: [[String: AnyCodable]]? = nil,
         thinkingdefault: String? = nil,
         effectivefastmode: AnyCodable? = nil,
+        supportsfastmode: Bool? = nil,
         supportstools: Bool? = nil,
         agentruntime: [String: AnyCodable]? = nil,
         apikeysupported: Bool? = nil,
@@ -16578,6 +16580,7 @@ public struct ModelChoice: Codable, Sendable {
         self.thinkinglevels = thinkinglevels
         self.thinkingdefault = thinkingdefault
         self.effectivefastmode = effectivefastmode
+        self.supportsfastmode = supportsfastmode
         self.supportstools = supportstools
         self.agentruntime = agentruntime
         self.apikeysupported = apikeysupported
@@ -16600,6 +16603,7 @@ public struct ModelChoice: Codable, Sendable {
         case thinkinglevels = "thinkingLevels"
         case thinkingdefault = "thinkingDefault"
         case effectivefastmode = "effectiveFastMode"
+        case supportsfastmode = "supportsFastMode"
         case supportstools = "supportsTools"
         case agentruntime = "agentRuntime"
         case apikeysupported = "apiKeySupported"

--- a/docs/plugins/sdk-provider-plugins.md
+++ b/docs/plugins/sdk-provider-plugins.md
@@ -925,6 +925,16 @@ catalog, API-key auth, and dynamic model resolution.
       Explicit `tools.toolSearch` settings take precedence. This hook changes
       schema exposure, not tool permissions or availability.
 
+      `resolveFastModeSupport(ctx)` can be exported from the same policy artifact
+      and registered on the provider. Return `false` only for a confirmed no-op
+      Fast choice, `true` for an applicable local request mapping, or `undefined`
+      when facts are missing. `ProviderFastModePolicyContext` carries the selected
+      model, route, auth mode, runtime, request parameters and transport policy;
+      credentials are not included. Share the policy with request construction.
+      The host publishes only `supportsFastMode`, preserving unknown behavior
+      and clearing saved preferences. This describes local applicability, not
+      upstream entitlement or fulfillment, and does not reject `/fast` commands.
+
     </Accordion>
 
   </Step>

--- a/docs/providers/anthropic.md
+++ b/docs/providers/anthropic.md
@@ -656,6 +656,7 @@ OpenClaw supports Anthropic's prompt caching feature for API-key auth.
     - For other direct Anthropic models, `/fast` retains the existing Priority Tier mapping: on uses `service_tier: "auto"` and off uses `service_tier: "standard_only"`.
     - Explicit `serviceTier` or `service_tier` params override `/fast` when both are set.
     - Claude Sonnet 5 supports neither native fast mode nor Priority Tier, so OpenClaw omits both fields.
+    - The Control UI disables confirmed no-op Fast choices, including Sonnet 5 and requests governed by an explicit service tier. Saved Fast preferences remain clearable; unknown route or auth facts preserve existing controls.
 
     </Note>
 

--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -77,10 +77,11 @@ title: "Thinking levels"
 - `auto` keeps the session/config mode as auto but resolves each new model call independently. Calls that start before the auto cutoff have fast mode enabled; later retry, fallback, tool-result, or continuation calls start with fast mode disabled. The cutoff defaults to 60 seconds; set `agents.defaults.models["<provider>/<model>"].params.fastAutoOnSeconds` on the active model to change it.
 - For `openai/*`, fast mode maps to OpenAI API Fast mode (formerly Priority processing). OpenClaw currently sends `service_tier=priority` on supported Responses requests.
 - On Codex harness turns, the shared runtime control supersedes a configured native app-server tier: Fast on sends `priority`, Fast off sends `null` to clear the OpenClaw-owned tier, and auto decides for each model call. A configured Codex tier is used only when no shared Fast-mode run control is supplied. See [Codex harness](/plugins/codex-harness/commands#shared-fast-mode-and-codex-fast-mode).
-- For direct public `anthropic/*` requests, including OAuth-authenticated traffic sent to `api.anthropic.com`, fast mode maps to Anthropic service tiers: `/fast on` sets `service_tier=auto`, `/fast off` sets `service_tier=standard_only`.
+- For direct API-key `anthropic/*` requests, Opus 5 and Opus 4.8 use native `speed=fast`. Other supported models use Priority Tier: on sets `service_tier=auto`, off sets `service_tier=standard_only`. Sonnet 5 supports neither mapping; OAuth requests receive neither field.
 - For `minimax/*` on the Anthropic-compatible path, `/fast on` (or `params.fastMode: true`) rewrites `MiniMax-M2.7` to `MiniMax-M2.7-highspeed`.
 - Explicit Anthropic `serviceTier` / `service_tier` model params override the fast-mode default when both are set. OpenClaw still skips Anthropic service-tier injection for non-Anthropic proxy base URLs.
 - `/status` reports the resolved OpenClaw policy (`on`, `off`, or `auto`) and the selected runtime. It does not report the upstream service tier actually honored or returned for a completed request. See [OpenAI Fast mode](/providers/openai#advanced-configuration) for provider details.
+- The Control UI disables Fast choices confirmed to have no effect on the selected request. Existing saved preferences remain visible and clearable. When applicability is unknown, controls retain their existing behavior; availability does not promise vendor entitlement or faster responses.
 
 ## Verbose directives (/verbose or /v)
 

--- a/extensions/anthropic/fast-mode-policy.test.ts
+++ b/extensions/anthropic/fast-mode-policy.test.ts
@@ -1,0 +1,48 @@
+import type { ProviderFastModePolicyContext } from "openclaw/plugin-sdk/provider-model-types";
+import { describe, expect, it } from "vitest";
+import { resolveFastModeSupport } from "./fast-mode-policy.js";
+
+const opus: ProviderFastModePolicyContext = {
+  provider: "anthropic",
+  modelId: "claude-opus-5",
+  api: "anthropic-messages",
+  baseUrl: "https://api.anthropic.com",
+  authMode: "api_key",
+  requestCapabilities: { endpointClass: "anthropic-public", allowsAnthropicServiceTier: true },
+};
+
+describe("selected request Fast applicability", () => {
+  it.each([
+    { name: "Sonnet 5", context: { modelId: "claude-sonnet-5" }, expected: false },
+    { name: "Opus 5", context: {}, expected: true },
+    { name: "legacy Priority Tier", context: { modelId: "claude-sonnet-4-6" }, expected: true },
+    { name: "OAuth", context: { authMode: "oauth" }, expected: false },
+    { name: "unknown auth", context: { authMode: undefined }, expected: undefined },
+    { name: "unclassified token", context: { authMode: "token" }, expected: undefined },
+    { name: "unknown API", context: { api: undefined }, expected: undefined },
+    {
+      name: "native runtime",
+      context: { modelId: "claude-sonnet-5", runtimeId: "codex" },
+      expected: undefined,
+    },
+    {
+      name: "explicit tier",
+      context: { params: { serviceTier: "standard_only" } },
+      expected: false,
+    },
+    { name: "invalid tier", context: { params: { serviceTier: "invalid" } }, expected: true },
+    {
+      name: "proxy",
+      context: {
+        requestCapabilities: { endpointClass: "custom", allowsAnthropicServiceTier: false },
+      },
+      expected: false,
+    },
+  ] satisfies {
+    name: string;
+    context: Partial<ProviderFastModePolicyContext>;
+    expected: boolean | undefined;
+  }[])("preserves $name applicability", ({ context, expected }) => {
+    expect(resolveFastModeSupport({ ...opus, ...context })).toBe(expected);
+  });
+});

--- a/extensions/anthropic/fast-mode-policy.ts
+++ b/extensions/anthropic/fast-mode-policy.ts
@@ -1,0 +1,68 @@
+import {
+  resolveClaudeOpus5ModelIdentity,
+  resolveClaudeSonnet5ModelIdentity,
+  supportsClaudeFastMode,
+} from "openclaw/plugin-sdk/claude-model-runtime";
+import type { ProviderFastModePolicyContext } from "openclaw/plugin-sdk/provider-model-types";
+
+export type AnthropicServiceTier = "auto" | "standard_only";
+
+export function supportsAnthropicPriorityTier(model: {
+  id: string;
+  params?: Record<string, unknown>;
+}): boolean {
+  return !resolveClaudeOpus5ModelIdentity(model) && !resolveClaudeSonnet5ModelIdentity(model);
+}
+
+export function normalizeAnthropicServiceTier(value: unknown): AnthropicServiceTier | undefined {
+  const normalized = typeof value === "string" ? value.trim().toLowerCase() : undefined;
+  return normalized === "auto" || normalized === "standard_only" ? normalized : undefined;
+}
+
+/** The request wrapper and model controls share this plan; it does not claim vendor entitlement. */
+export function resolveAnthropicFastModePlan(
+  context: ProviderFastModePolicyContext,
+): "native" | "service-tier" | false | undefined {
+  if (
+    context.provider.trim().toLowerCase() !== "anthropic" ||
+    (context.runtimeId !== undefined &&
+      context.runtimeId !== "auto" &&
+      context.runtimeId !== "openclaw")
+  ) {
+    return undefined;
+  }
+  if (
+    normalizeAnthropicServiceTier(context.params?.serviceTier ?? context.params?.service_tier) ||
+    context.authMode === "oauth"
+  ) {
+    return false;
+  }
+  const model = { id: context.modelId, params: context.modelParams };
+  const native = supportsClaudeFastMode(model);
+  if (!native && !supportsAnthropicPriorityTier(model)) {
+    return false;
+  }
+  if (!context.api) {
+    return undefined;
+  }
+  const { endpointClass, allowsAnthropicServiceTier } = context.requestCapabilities;
+  if (
+    native
+      ? context.api.trim().toLowerCase() !== "anthropic-messages" ||
+        (endpointClass !== "default" && endpointClass !== "anthropic-public")
+      : !allowsAnthropicServiceTier
+  ) {
+    return false;
+  }
+  if (context.authMode !== "api_key") {
+    return undefined;
+  }
+  return native ? "native" : "service-tier";
+}
+
+export function resolveFastModeSupport(
+  context: ProviderFastModePolicyContext,
+): boolean | undefined {
+  const plan = resolveAnthropicFastModePlan(context);
+  return plan === undefined ? undefined : plan !== false;
+}

--- a/extensions/anthropic/provider-policy-api.ts
+++ b/extensions/anthropic/provider-policy-api.ts
@@ -14,6 +14,8 @@ import {
   normalizeAnthropicProviderConfigForProvider,
 } from "./config-defaults.js";
 
+export { resolveFastModeSupport } from "./fast-mode-policy.js";
+
 /** Profile ids that native Claude auth has retired from OpenClaw ownership. */
 export const deprecatedProfileIds = [CLAUDE_CLI_PROFILE_ID] as const;
 

--- a/extensions/anthropic/register.runtime.ts
+++ b/extensions/anthropic/register.runtime.ts
@@ -49,6 +49,7 @@ import {
   applyAnthropicConfigDefaults,
   normalizeAnthropicProviderConfigForProvider,
 } from "./config-defaults.js";
+import { resolveFastModeSupport } from "./fast-mode-policy.js";
 import { acceptsAnthropicLiveModelContract } from "./live-model-contract-gate.js";
 import { anthropicMediaUnderstandingProvider } from "./media-understanding-provider.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
@@ -873,6 +874,7 @@ export function buildAnthropicProvider(): ProviderPlugin {
           });
     },
     wrapStreamFn: wrapAnthropicProviderStream,
+    resolveFastModeSupport,
     resolveUsageAuth: resolveAnthropicUsageAuth,
     fetchUsageSnapshot: fetchAnthropicUsage,
     isCacheTtlEligible: () => true,

--- a/extensions/anthropic/stream-wrappers.ts
+++ b/extensions/anthropic/stream-wrappers.ts
@@ -7,10 +7,7 @@ import { streamSimple } from "openclaw/plugin-sdk/llm";
 import type { ProviderWrapStreamFnContext } from "openclaw/plugin-sdk/plugin-entry";
 import {
   resolveProviderEndpoint,
-  resolveClaudeOpus5ModelIdentity,
-  resolveClaudeSonnet5ModelIdentity,
   supportsClaude1MContext,
-  supportsClaudeFastMode,
 } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   applyAnthropicPayloadPolicyToParams,
@@ -27,6 +24,12 @@ import {
   normalizeLowercaseStringOrEmpty,
   readStringValue,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
+import {
+  normalizeAnthropicServiceTier,
+  resolveAnthropicFastModePlan,
+  supportsAnthropicPriorityTier,
+  type AnthropicServiceTier,
+} from "./fast-mode-policy.js";
 
 const log = createSubsystemLogger("anthropic-stream");
 
@@ -44,7 +47,6 @@ const OPENCLAW_OAUTH_ANTHROPIC_BETAS = [
   ...OPENCLAW_DEFAULT_ANTHROPIC_BETAS,
 ] as const;
 
-type AnthropicServiceTier = "auto" | "standard_only";
 type DynamicFastMode = boolean | (() => boolean | undefined);
 
 function isAnthropic1MModel(modelId: string): boolean {
@@ -82,17 +84,6 @@ function resolveAnthropicFastServiceTier(enabled: boolean): AnthropicServiceTier
   return enabled ? "auto" : "standard_only";
 }
 
-function isDirectAnthropicApiModel(model: Parameters<StreamFn>[0]): boolean {
-  if (
-    normalizeLowercaseStringOrEmpty(model.provider) !== "anthropic" ||
-    normalizeLowercaseStringOrEmpty(model.api) !== "anthropic-messages"
-  ) {
-    return false;
-  }
-  const endpointClass = resolveProviderEndpoint(model.baseUrl).endpointClass;
-  return endpointClass === "default" || endpointClass === "anthropic-public";
-}
-
 function applyAnthropicFastModePricing(model: Parameters<StreamFn>[0]): Parameters<StreamFn>[0] {
   const scaleRates = (rates: Parameters<StreamFn>[0]["cost"]) => ({
     input: rates.input * ANTHROPIC_FAST_MODE_COST_MULTIPLIER,
@@ -114,17 +105,6 @@ function applyAnthropicFastModePricing(model: Parameters<StreamFn>[0]): Paramete
         : {}),
     },
   };
-}
-
-function normalizeAnthropicServiceTier(value: unknown): AnthropicServiceTier | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-  const normalized = normalizeLowercaseStringOrEmpty(value);
-  if (normalized === "auto" || normalized === "standard_only") {
-    return normalized;
-  }
-  return undefined;
 }
 
 function hasConfiguredAnthropicBeta(extraParams: Record<string, unknown> | undefined): boolean {
@@ -191,6 +171,7 @@ export function createAnthropicBetaHeadersWrapper(
 export function createAnthropicFastModeWrapper(
   baseStreamFn: StreamFn | undefined,
   enabled: DynamicFastMode,
+  extraParams?: Record<string, unknown>,
 ): StreamFn {
   const underlying = baseStreamFn ?? streamSimple;
   const fastPayloadWrapper = createPayloadPatchStreamWrapper(underlying, ({ payload }) => {
@@ -202,12 +183,25 @@ export function createAnthropicFastModeWrapper(
     if (resolved === undefined) {
       return underlying(model, context, options);
     }
-    if (supportsClaudeFastMode(model)) {
-      if (
-        !resolved ||
-        isAnthropicOAuthApiKey(options?.apiKey) ||
-        !isDirectAnthropicApiModel(model)
-      ) {
+    const plan = resolveAnthropicFastModePlan({
+      provider: model.provider,
+      modelId: model.id,
+      api: model.api,
+      baseUrl: model.baseUrl,
+      modelParams: model.params,
+      params: extraParams,
+      authMode: isAnthropicOAuthApiKey(options?.apiKey) ? "oauth" : "api_key",
+      requestCapabilities: {
+        endpointClass: resolveProviderEndpoint(model.baseUrl).endpointClass,
+        allowsAnthropicServiceTier: resolveAnthropicPayloadPolicy({
+          provider: model.provider,
+          api: model.api,
+          baseUrl: model.baseUrl,
+        }).allowsServiceTier,
+      },
+    });
+    if (plan === "native") {
+      if (!resolved) {
         return underlying(model, context, options);
       }
       return fastPayloadWrapper(applyAnthropicFastModePricing(model), context, {
@@ -215,11 +209,13 @@ export function createAnthropicFastModeWrapper(
         headers: mergeAnthropicBetaHeader(options?.headers, [ANTHROPIC_FAST_MODE_BETA]),
       });
     }
-    return createAnthropicServiceTierWrapper(underlying, resolveAnthropicFastServiceTier(resolved))(
-      model,
-      context,
-      options,
-    );
+    return plan === "service-tier"
+      ? createAnthropicServiceTierWrapper(underlying, resolveAnthropicFastServiceTier(resolved))(
+          model,
+          context,
+          options,
+        )
+      : underlying(model, context, options);
   };
 }
 
@@ -263,11 +259,7 @@ export function createAnthropicServiceTierWrapper(
     {
       shouldPatch: ({ model, options }) => {
         // Opus 5 and Sonnet 5 do not support Priority Tier; omit service_tier entirely.
-        if (
-          isAnthropicOAuthApiKey(options?.apiKey) ||
-          resolveClaudeOpus5ModelIdentity(model) !== undefined ||
-          resolveClaudeSonnet5ModelIdentity(model) !== undefined
-        ) {
+        if (isAnthropicOAuthApiKey(options?.apiKey) || !supportsAnthropicPriorityTier(model)) {
           return false;
         }
         return resolveAnthropicPayloadPolicy({
@@ -336,9 +328,13 @@ export function wrapAnthropicProviderStream(
     serviceTier
       ? (streamFn) => createAnthropicServiceTierWrapper(streamFn, serviceTier)
       : undefined,
-    hasFastModeParam && serviceTier === undefined
+    hasFastModeParam
       ? (streamFn) =>
-          createAnthropicFastModeWrapper(streamFn, () => resolveAnthropicFastMode(ctx.extraParams))
+          createAnthropicFastModeWrapper(
+            streamFn,
+            () => resolveAnthropicFastMode(ctx.extraParams),
+            ctx.extraParams,
+          )
       : undefined,
     ctx.extraParams?.anthropicServerCompaction === true
       ? (streamFn) => createAnthropicCompactionWrapper(streamFn, ctx.extraParams)

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -78,6 +78,8 @@ export const ModelChoiceSchema = closedObject({
   thinkingLevels: Type.Optional(Type.Array(GatewayThinkingLevelOptionSchema)),
   thinkingDefault: Type.Optional(NonEmptyString),
   effectiveFastMode: Type.Optional(Type.Union([Type.Boolean(), Type.Literal("auto")])),
+  /** Local selected-request applicability, not preference or upstream fulfillment. */
+  supportsFastMode: Type.Optional(Type.Boolean()),
   supportsTools: Type.Optional(Type.Boolean()),
   agentRuntime: Type.Optional(GatewayAgentRuntimeSchema),
   apiKeySupported: Type.Optional(Type.Boolean()),

--- a/src/agents/model-fast-mode.test.ts
+++ b/src/agents/model-fast-mode.test.ts
@@ -1,0 +1,80 @@
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import type { ModelCatalogEntry } from "./model-catalog.types.js";
+import { createModelFastModeResolver } from "./model-fast-mode.js";
+
+const opus: ModelCatalogEntry = {
+  id: "claude-opus-5",
+  name: "Opus 5",
+  provider: "anthropic",
+  api: "anthropic-messages",
+  baseUrl: "https://api.anthropic.com",
+};
+function resolver(cfg: OpenClawConfig = {}) {
+  return createModelFastModeResolver({
+    cfg,
+    agentId: "main",
+    catalog: [opus],
+    metadataSnapshot: createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "anthropic",
+          providers: ["anthropic"],
+          rootDir: path.resolve(import.meta.dirname, "../../extensions/anthropic"),
+          providerEndpoints: [{ endpointClass: "anthropic-public", hosts: ["api.anthropic.com"] }],
+          providerRequest: { providers: { anthropic: { family: "anthropic" } } },
+        },
+      ],
+    }),
+  });
+}
+describe("private selected Fast metadata", () => {
+  it("loads the provider's light policy for the exact model and auth facts", () => {
+    const resolve = resolver();
+    expect(
+      resolve(
+        { ...opus, id: "claude-sonnet-5" },
+        { availability: true, routeResolution: null, selectedAuthMode: "api_key" },
+      ),
+    ).toBe(false);
+    expect(
+      resolve(opus, { availability: true, routeResolution: null, selectedAuthMode: "api_key" }),
+    ).toBe(true);
+    expect(resolve(opus, { availability: undefined, routeResolution: null })).toBeUndefined();
+    expect(
+      resolve(
+        { ...opus, id: "claude-sonnet-5" },
+        { availability: true, routeResolution: null },
+        "codex",
+      ),
+    ).toBeUndefined();
+  });
+  it("uses the same model/agent parameter order as request construction", () => {
+    const resolve = resolver({
+      agents: {
+        defaults: { params: { serviceTier: "auto" } },
+        entries: { main: { params: { serviceTier: "invalid" } } },
+      },
+    });
+    expect(
+      resolve(opus, { availability: true, routeResolution: null, selectedAuthMode: "api_key" }),
+    ).toBe(true);
+    const explicit = resolver({
+      agents: {
+        defaults: {
+          models: { "anthropic/claude-opus-5": { params: { serviceTier: "standard_only" } } },
+        },
+      },
+    });
+    expect(
+      explicit(opus, { availability: true, routeResolution: null, selectedAuthMode: "api_key" }),
+    ).toBe(false);
+  });
+  it("does not replace unresolved route ownership with catalog provenance", () => {
+    expect(
+      resolver()(opus, { availability: undefined, routeResolution: { kind: "indeterminate" } }),
+    ).toBeUndefined();
+  });
+});

--- a/src/agents/model-fast-mode.ts
+++ b/src/agents/model-fast-mode.ts
@@ -1,0 +1,73 @@
+import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getPluginMetadataSnapshotCache, withPluginCache } from "../plugins/plugin-cache.js";
+import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { resolveProviderPolicySurface } from "../plugins/provider-public-artifacts.js";
+import { matchesProviderPluginRef } from "../plugins/provider-registry-shared.js";
+import type { PluginRegistry } from "../plugins/registry.js";
+import type { ModelAuthAvailabilityEvaluation } from "./model-auth-availability.js";
+import type { ModelCatalogEntry } from "./model-catalog.types.js";
+import { resolveModelExtraParamSources } from "./model-extra-params.js";
+import { resolveProviderRequestCapabilities } from "./provider-attribution.js";
+
+/** Capture light policy with the private catalog owner; published row reads cannot load plugins. */
+export function createModelFastModeResolver(params: {
+  cfg: OpenClawConfig;
+  agentId: string;
+  catalog: readonly ModelCatalogEntry[];
+  metadataSnapshot: PluginMetadataSnapshot;
+  pluginRegistry?: PluginRegistry;
+}) {
+  const policies = withPluginCache(
+    getPluginMetadataSnapshotCache(params.metadataSnapshot),
+    () =>
+      new Map(
+        [...new Set(params.catalog.map((entry) => normalizeProviderId(entry.provider)))].map(
+          (provider) => [
+            provider,
+            params.pluginRegistry?.providers.find(({ provider: candidate }) =>
+              matchesProviderPluginRef(candidate, provider),
+            )?.provider.resolveFastModeSupport ??
+              resolveProviderPolicySurface(provider, {
+                manifestRegistry: params.metadataSnapshot.manifestRegistry,
+              })?.resolveFastModeSupport,
+          ],
+        ),
+      ),
+  );
+  return (
+    entry: ModelCatalogEntry,
+    evaluation: ModelAuthAvailabilityEvaluation,
+    runtimeId?: string,
+  ): boolean | undefined => {
+    const policy = policies.get(normalizeProviderId(entry.provider));
+    if (!policy || (evaluation.routeResolution !== null && !evaluation.selectedRoute)) {
+      return undefined;
+    }
+    const route = evaluation.selectedRoute ?? entry;
+    const { defaultParams, modelParams, agentModelParams, agentParams } =
+      resolveModelExtraParamSources({
+        config: params.cfg,
+        provider: entry.provider,
+        modelId: entry.id,
+        agentId: params.agentId,
+      });
+    return policy({
+      provider: entry.provider,
+      modelId: entry.id,
+      api: route.api,
+      baseUrl: route.baseUrl,
+      authMode: evaluation.selectedAuthMode,
+      runtimeId: runtimeId ?? entry.nativeRuntime,
+      modelParams: entry.params,
+      params: Object.assign({}, defaultParams, modelParams, agentModelParams, agentParams),
+      requestCapabilities: resolveProviderRequestCapabilities({
+        provider: entry.provider,
+        modelId: entry.id,
+        api: route.api,
+        baseUrl: route.baseUrl,
+        providerMetadataOwners: params.metadataSnapshot.owners,
+      }),
+    });
+  };
+}

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -18,6 +18,7 @@ import {
   prepareLogicalVisibleModelCatalog,
 } from "../../agents/model-catalog-visibility.js";
 import type { ModelCatalogSnapshot, ModelCatalogEntry } from "../../agents/model-catalog.types.js";
+import { createModelFastModeResolver } from "../../agents/model-fast-mode.js";
 import { modelKey } from "../../agents/model-ref-shared.js";
 import {
   dedupeModelCatalogEntries,
@@ -111,6 +112,7 @@ export function createGatewayAgentModelCatalogProjector(params: ModelsListAuthPr
 
 function createPublicModelsListProjector(params: {
   thinkingCatalog: ModelCatalogEntry[];
+  fastMode: ReturnType<typeof createModelFastModeResolver>;
   cfg: OpenClawConfig;
   agentId: string;
   configuredEntriesByKey: ReturnType<typeof resolveConfiguredModelEntries>["byKey"];
@@ -176,9 +178,11 @@ function createPublicModelsListProjector(params: {
     const projectedAvailability = params.preserveUnknownAvailability
       ? evaluation.availability
       : (evaluation.availability ?? false);
+    const supportsFastMode = params.fastMode(entry, evaluation, preparedEntry.agentRuntime?.id);
     return Object.assign(
       {},
       preparedEntry,
+      supportsFastMode === undefined ? {} : { supportsFastMode },
       projectedAvailability === undefined ? {} : { available: projectedAvailability },
       projectedAvailability === false && evaluation.unavailableReason
         ? {
@@ -469,6 +473,13 @@ export async function prepareModelsListResult(
     );
     const projectPublic = createPublicModelsListProjector({
       thinkingCatalog: catalog,
+      fastMode: createModelFastModeResolver({
+        cfg,
+        agentId,
+        catalog: inventory,
+        metadataSnapshot,
+        pluginRegistry: preparedPluginRegistry,
+      }),
       cfg,
       agentId,
       configuredEntriesByKey,
@@ -529,6 +540,13 @@ export async function prepareModelsListResult(
   });
   const projectPublic = createPublicModelsListProjector({
     thinkingCatalog: catalog,
+    fastMode: createModelFastModeResolver({
+      cfg,
+      agentId,
+      catalog,
+      metadataSnapshot,
+      pluginRegistry: preparedPluginRegistry,
+    }),
     cfg,
     agentId,
     configuredEntriesByKey,

--- a/src/plugin-sdk/claude-model-runtime.ts
+++ b/src/plugin-sdk/claude-model-runtime.ts
@@ -6,5 +6,6 @@ export {
   resolveClaudeMythos5ModelIdentity,
   resolveClaudeOpus5ModelIdentity,
   resolveClaudeSonnet5ModelIdentity,
+  supportsClaudeFastMode,
 } from "@openclaw/llm-core";
 export { resolveClaudeThinkingProfile } from "../plugins/provider-claude-thinking.js";

--- a/src/plugin-sdk/provider-model-types.ts
+++ b/src/plugin-sdk/provider-model-types.ts
@@ -1,7 +1,24 @@
+import type { ProviderRequestCapabilities } from "../agents/provider-attribution.js";
 /**
  * Public SDK type surface for model provider and model definition config.
  */
 import type { ModelApi } from "../config/types.models.js";
+
+/** Private selected-request facts; omission means the host cannot establish applicability. */
+export type ProviderFastModePolicyContext = {
+  provider: string;
+  modelId: string;
+  api?: string;
+  baseUrl?: string;
+  authMode?: string;
+  runtimeId?: string;
+  modelParams?: Record<string, unknown>;
+  params?: Record<string, unknown>;
+  requestCapabilities: Pick<
+    ProviderRequestCapabilities,
+    "endpointClass" | "allowsAnthropicServiceTier"
+  >;
+};
 
 export type {
   BedrockDiscoveryConfig,

--- a/src/plugin-sdk/provider-model-types.ts
+++ b/src/plugin-sdk/provider-model-types.ts
@@ -1,4 +1,3 @@
-import type { ProviderRequestCapabilities } from "../agents/provider-attribution.js";
 /**
  * Public SDK type surface for model provider and model definition config.
  */
@@ -14,10 +13,10 @@ export type ProviderFastModePolicyContext = {
   runtimeId?: string;
   modelParams?: Record<string, unknown>;
   params?: Record<string, unknown>;
-  requestCapabilities: Pick<
-    ProviderRequestCapabilities,
-    "endpointClass" | "allowsAnthropicServiceTier"
-  >;
+  requestCapabilities: {
+    endpointClass: string;
+    allowsAnthropicServiceTier: boolean;
+  };
 };
 
 export type {

--- a/src/plugins/provider-plugin.types.ts
+++ b/src/plugins/provider-plugin.types.ts
@@ -7,6 +7,7 @@ import type { AnyAgentTool } from "../agents/tools/common.js";
 import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ProviderUsageSnapshot } from "../infra/provider-usage.types.js";
+import type { ProviderFastModePolicyContext } from "../plugin-sdk/provider-model-types.js";
 import type {
   OAuthCredentials as SessionOAuthCredentials,
   OAuthLoginCallbacks,
@@ -479,6 +480,8 @@ export type ProviderPlugin = {
   resolveThinkingProfile?: (
     ctx: ProviderDefaultThinkingPolicyContext,
   ) => ProviderThinkingProfile | null | undefined;
+  /** Whether Fast can affect this selected request; undefined retains existing unknown behavior. */
+  resolveFastModeSupport?: (ctx: ProviderFastModePolicyContext) => boolean | undefined;
   /**
    * Provider-owned system-prompt contribution.
    *

--- a/src/plugins/provider-policy-surface.ts
+++ b/src/plugins/provider-policy-surface.ts
@@ -2,6 +2,7 @@
 import type { ModelProviderConfig } from "../config/types.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type {
+  ProviderFastModePolicyContext,
   ProviderModelRouteResolution,
   ProviderNormalizeModelCatalogIdContext,
   ProviderResponseModelEquivalenceContext,
@@ -65,6 +66,7 @@ export type InspectEmbeddingProviderSetup = (params: {
 
 /** Provider policy hooks supported by bundled and trusted official plugins. */
 export type ProviderPolicySurface = {
+  resolveFastModeSupport?: (ctx: ProviderFastModePolicyContext) => boolean | undefined;
   deprecatedProfileIds?: readonly string[];
   normalizeConfig?: (ctx: ProviderNormalizeConfigContext) => ModelProviderConfig | null | undefined;
   applyConfigDefaults?: (
@@ -99,6 +101,7 @@ export type BundledProviderPolicySurface = ProviderPolicySurface & {
 };
 
 const PROVIDER_POLICY_HOOK_KEYS = [
+  "resolveFastModeSupport",
   "normalizeConfig",
   "applyConfigDefaults",
   "resolveConfigApiKey",

--- a/ui/src/lib/chat/model-select-state.test.ts
+++ b/ui/src/lib/chat/model-select-state.test.ts
@@ -926,3 +926,68 @@ describe("chat-model-select-state", () => {
     ]);
   });
 });
+
+describe("selected Fast applicability", () => {
+  function state(
+    support: boolean | undefined,
+    fastMode?: boolean | "auto",
+    selected = "claude-sonnet-5",
+  ) {
+    const sessionsResult = createSessionsListResult({
+      model: "claude-sonnet-5",
+      modelProvider: "anthropic",
+    });
+    const session = expectDefined(sessionsResult.sessions[0], "Fast applicability session");
+    return resolveChatFastModeSelectState({
+      activeRunId: null,
+      connected: true,
+      gatewayAvailable: true,
+      loading: false,
+      sending: false,
+      stream: null,
+      currentModelOverride: `anthropic/${selected}`,
+      sessionsResult,
+      fastModeTarget: { ...session, ...(fastMode === undefined ? {} : { fastMode }) },
+      catalog: [
+        {
+          id: "claude-sonnet-5",
+          name: "Sonnet 5",
+          provider: "anthropic",
+          supportsFastMode: support,
+        },
+        { id: "claude-opus-5", name: "Opus 5", provider: "anthropic", supportsFastMode: true },
+      ],
+    });
+  }
+
+  it("disables a confirmed no-op offer", () => {
+    expect(state(false)).toMatchObject({ supported: false, disabled: true, nextValue: "" });
+  });
+  it("uses canonical spelling when matching the selected applicability", () => {
+    expect(state(false, undefined, "CLAUDE-SONNET-5")).toMatchObject({
+      supported: false,
+      disabled: true,
+      nextValue: "",
+    });
+  });
+  it.each([true, false, "auto"] as const)(
+    "keeps saved %s clearable on a no-op route",
+    (fastMode) => {
+      expect(state(false, fastMode)).toMatchObject({
+        supported: true,
+        disabled: false,
+        nextValue: "",
+      });
+    },
+  );
+  it("preserves the existing unknown behavior", () => {
+    expect(state(undefined)).toMatchObject({ supported: true, disabled: false, nextValue: "on" });
+  });
+  it("uses the selected model's support before the stale session model", () => {
+    expect(state(false, undefined, "claude-opus-5")).toMatchObject({
+      supported: true,
+      disabled: false,
+      nextValue: "on",
+    });
+  });
+});

--- a/ui/src/lib/chat/model-select-state.ts
+++ b/ui/src/lib/chat/model-select-state.ts
@@ -72,9 +72,7 @@ type ChatFastModeSelectStateInput = {
   stream: string | null;
 };
 
-// Providers with a runtime fast-mode mapping: Anthropic sets speed (or legacy
-// service_tier), OpenAI sets service_tier priority, MiniMax/xAI select fast variants.
-// Providers without a wire mapping must not offer the toggle.
+// Preserve existing controls only when the selected request's applicability is unknown.
 const FAST_MODE_PROVIDER_IDS = new Set(["anthropic", "minimax", "minimax-portal", "openai", "xai"]);
 
 export function isChatFastModeProviderSupported(provider: string | null | undefined): boolean {
@@ -375,8 +373,29 @@ export function resolveChatFastModeSelectState(
         ? "auto"
         : "off"
     : configuredOverride;
-  const providerSupported = isChatFastModeProviderSupported(effectiveProvider);
-  const supported = providerSupported || Boolean(configuredOverride);
+  const selectedValue = normalizeChatModelAvailabilityKey(
+    normalizeChatModelOverrideValue(
+      input.currentModelOverride ||
+        buildQualifiedChatModelValue(
+          activeRow?.model ?? input.sessionsResult?.defaults?.model ?? "",
+          effectiveProvider,
+        ),
+      input.catalog,
+    ),
+  );
+  const applicability = new Set(
+    input.catalog
+      .filter(
+        (entry) =>
+          normalizeChatModelAvailabilityKey(
+            buildQualifiedChatModelValue(entry.id, entry.provider),
+          ) === selectedValue,
+      )
+      .map((entry) => entry.supportsFastMode),
+  );
+  const selectedSupport = applicability.size === 1 ? [...applicability][0] : undefined;
+  const requestSupported = selectedSupport ?? isChatFastModeProviderSupported(effectiveProvider);
+  const supported = requestSupported || Boolean(configuredOverride);
   // The picker exposes speed as a two-state toggle: fast on, or back to the
   // provider baseline (explicit off for OpenAI's priority tier, inherited
   // default elsewhere). Auto and explicit standard overrides remain reachable
@@ -398,7 +417,7 @@ export function resolveChatFastModeSelectState(
   // inherited baseline is unknowable while an override exists, and clearing
   // could land on a fast default, turning the click into a visible no-op.
   // /fast default remains the way back to the inherited setting.
-  const nextValue: ChatFastModeSelectValue = !providerSupported ? "" : active ? "off" : "on";
+  const nextValue: ChatFastModeSelectValue = !requestSupported ? "" : active ? "off" : "on";
   return {
     active,
     currentOverride,


### PR DESCRIPTION
## What Problem This Solves

Control UI allowed Fast to be saved for requests where it had no effect.

## Why This Change Was Made

Request construction and provider policy now share an applicability plan. The selected route, authentication, and existing parameters supply an optional result to the UI, which disables confirmed no-op choices and preserves behavior when applicability is unknown.

## User Impact

Saved Fast preferences stay visible and clearable. Supported requests remain usable; applicability does not promise entitlement, fulfillment, or speed.

## Evidence

Real Gateway/browser checks reproduced the ineffective Fast choice and verified that the fix disables it, permits clearing a saved preference, retains supported Fast, and preserves unknown-applicability behavior. Public session readback confirmed selections. Provider/request, UI, metadata, and config checks passed. CI retained two unrelated failures with separate reproductions; it was not wholly green.

Consumers: Control UI Fast controls now honor confirmed request applicability.

Related: #136257.
