### PR TITLE
feat(sqlite): select an extension-capable SQLite library for Bun on macOS

### DIFF
--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -28,15 +28,16 @@ The variables below are the supported environment contract for operators. Undocu
 
 ### Paths and instances
 
-| Variable                 | Purpose                                                           |
-| ------------------------ | ----------------------------------------------------------------- |
-| `OPENCLAW_HOME`          | Override the home directory used for OpenClaw path defaults.      |
-| `OPENCLAW_STATE_DIR`     | Override the mutable state directory.                             |
-| `OPENCLAW_CONFIG_PATH`   | Override the active config file path.                             |
-| `OPENCLAW_WORKSPACE_DIR` | Override the default agent workspace.                             |
-| `OPENCLAW_PROFILE`       | Select a named profile and its isolated defaults.                 |
-| `OPENCLAW_GIT_DIR`       | Override the source checkout used by development-channel updates. |
-| `OPENCLAW_INCLUDE_ROOTS` | Allow `$include` to resolve from additional roots.                |
+| Variable                  | Purpose                                                               |
+| ------------------------- | --------------------------------------------------------------------- |
+| `OPENCLAW_HOME`           | Override the home directory used for OpenClaw path defaults.          |
+| `OPENCLAW_STATE_DIR`      | Override the mutable state directory.                                 |
+| `OPENCLAW_CONFIG_PATH`    | Override the active config file path.                                 |
+| `OPENCLAW_WORKSPACE_DIR`  | Override the default agent workspace.                                 |
+| `OPENCLAW_PROFILE`        | Select a named profile and its isolated defaults.                     |
+| `OPENCLAW_GIT_DIR`        | Override the source checkout used by development-channel updates.     |
+| `OPENCLAW_INCLUDE_ROOTS`  | Allow `$include` to resolve from additional roots.                    |
+| `OPENCLAW_SQLITE_LIBRARY` | Override the SQLite library for [Bun on macOS](/install/bun#caveats). |
 
 ### Gateway and authentication
 

--- a/docs/install/bun.md
+++ b/docs/install/bun.md
@@ -95,6 +95,13 @@ floor and supports extension loading. An invalid override fails with an error
 explaining how to fix or unset it. Node and Bun on platforms other than macOS
 ignore this override; Gateway startup logs a warning when it is ignored.
 
+If you previously used a Bun preload script that calls `Database.setCustomSQLite()`,
+remove that preload and set `OPENCLAW_SQLITE_LIBRARY` to the same library path
+instead. Bun permits that hook only once per process; keeping the preload causes
+startup to fail with `SQLite already loaded`, even when both selections name the
+same library. The environment override lets OpenClaw select the library before
+opening databases and forward the path to the memory KNN child.
+
 Without a suitable library on macOS, Bun keeps Apple's system SQLite, which omits
 native extension loading. OpenClaw can open ordinary agent databases when that
 library meets the WAL safety floor. Memory search falls back to a batched

--- a/docs/install/bun.md
+++ b/docs/install/bun.md
@@ -70,18 +70,36 @@ be released promptly after closing. This is a temporary runtime workaround while
 the [upstream close fix](https://github.com/oven-sh/bun/pull/40005) is pending;
 OpenClaw cannot finalize these handles through Bun's public `node:sqlite` API.
 
-On macOS, Bun uses Apple's system SQLite, which omits native extension loading.
-OpenClaw can open ordinary agent databases without extension loading when that
-library meets the WAL safety floor. For native `sqlite-vec` KNN memory queries on
-macOS, use Node. When the KNN child's SQLite cannot load extensions, memory search
-uses a batched embedding scan with the same provider and source filters and
-cancellation checks between batches. This can be slower on large indexes.
+On macOS, install Homebrew SQLite to enable native `sqlite-vec` KNN memory queries:
 
-Bun's [custom SQLite setup](https://bun.sh/docs/runtime/sqlite#loadextension) can
-enable extensions in the parent process when configured before opening any
-database. That selection does not reach the KNN child, whose environment
-intentionally omits Node and Bun preload options. OpenClaw does not select a
-different SQLite library automatically.
+```sh
+brew install sqlite
+```
+
+OpenClaw automatically selects a WAL-reset-safe, extension-capable SQLite library
+from Homebrew or MacPorts before opening a database, and uses the same library in
+the memory KNN child process. Discovery checks `$HOMEBREW_PREFIX/opt/sqlite/lib/libsqlite3.dylib`
+first, then the standard Homebrew paths under `/opt/homebrew` and `/usr/local`,
+then `/opt/local/lib/libsqlite3.dylib` for MacPorts. Linux and Windows Bun already
+support extension loading and need no additional SQLite installation.
+
+To override discovery, set `OPENCLAW_SQLITE_LIBRARY` in the process environment
+before starting OpenClaw:
+
+```sh
+OPENCLAW_SQLITE_LIBRARY=/path/to/libsqlite3.dylib bun openclaw.mjs gateway
+```
+
+The override must point to a loadable SQLite library that meets the WAL safety
+floor and supports extension loading. An invalid override fails with an error
+explaining how to fix or unset it. Node and Bun on platforms other than macOS
+ignore this override; Gateway startup logs a warning when it is ignored.
+
+Without a suitable library on macOS, Bun keeps Apple's system SQLite, which omits
+native extension loading. OpenClaw can open ordinary agent databases when that
+library meets the WAL safety floor. Memory search falls back to a batched
+embedding scan with the same provider and source filters and cancellation checks
+between batches. This can be slower on large indexes.
 
 Some package scripts hardcode `pnpm` internally (for example `check:docs`, `ui:*`, `protocol:check`). Running them via `bun run` still shells out to `pnpm`, so just run those via `pnpm` directly.
 

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -595,6 +595,8 @@ default `all`:
 | `store.vector.enabled`       | `boolean` | `true`  | Use sqlite-vec for vector queries |
 | `store.vector.extensionPath` | `string`  | bundled | Override sqlite-vec path          |
 
+For Bun on macOS, install Homebrew SQLite to enable extension loading; see [Bun SQLite setup](/install/bun#caveats) for automatic discovery and the `OPENCLAW_SQLITE_LIBRARY` library override.
+
 When sqlite-vec is unavailable, OpenClaw falls back to in-process cosine similarity automatically.
 
 ---

--- a/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 import { ensureSqliteLibrarySelected } from "openclaw/plugin-sdk/memory-core-host-engine-knn";
 import { loadSqliteVecExtension } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, type MockInstance, vi } from "vitest";
 import { runVectorKnnInSubprocess } from "./manager-search-knn-subprocess.js";
 import type { VectorKnnRequest } from "./manager-search-knn.js";
 import { searchVector } from "./manager-search.js";
@@ -23,7 +23,8 @@ vi.mock("node:child_process", async (importOriginal) => {
 });
 
 vi.mock("openclaw/plugin-sdk/memory-core-host-engine-knn", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/memory-core-host-engine-knn")>();
+  const actual =
+    await importOriginal<typeof import("openclaw/plugin-sdk/memory-core-host-engine-knn")>();
   return { ...actual, ensureSqliteLibrarySelected: vi.fn(actual.ensureSqliteLibrarySelected) };
 });
 
@@ -34,6 +35,8 @@ beforeEach(() => {
 
 function useFixtureChild() {
   const children: childProcess.ChildProcessWithoutNullStreams[] = [];
+  const stdinEndSpies: MockInstance<childProcess.ChildProcessWithoutNullStreams["stdin"]["end"]>[] =
+    [];
   const ready: Promise<unknown[]>[] = [];
   vi.mocked(childProcess.spawn).mockImplementation((_command, _args, options) => {
     const child = spawn(process.execPath, [fileURLToPath(fixtureChildUrl)], {
@@ -41,11 +44,11 @@ function useFixtureChild() {
       stdio: ["pipe", "pipe", "pipe"],
     });
     children.push(child);
-    vi.spyOn(child.stdin, "end");
+    stdinEndSpies.push(vi.spyOn(child.stdin, "end"));
     ready.push(once(child.stderr, "data"));
     return child;
   });
-  return { children, ready };
+  return { children, ready, stdinEndSpies };
 }
 
 function request(limit: number): VectorKnnRequest {
@@ -146,7 +149,7 @@ describe("memory vector KNN subprocess boundary", () => {
       );
       const fixture = useFixtureChild();
       await runVectorKnnInSubprocess({ databasePath: "fixture:ok", request: request(1) });
-      const input = JSON.parse(String(vi.mocked(fixture.children[0]!.stdin.end).mock.calls[0]![0]));
+      const input = JSON.parse(String(fixture.stdinEndSpies[0]!.mock.calls[0]![0]));
       if (source === "runtime") {
         expect(input).not.toHaveProperty("sqliteLibraryPath");
       } else {

--- a/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn-subprocess.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import type { DatabaseSync } from "node:sqlite";
 import { fileURLToPath } from "node:url";
+import { ensureSqliteLibrarySelected } from "openclaw/plugin-sdk/memory-core-host-engine-knn";
 import { loadSqliteVecExtension } from "openclaw/plugin-sdk/memory-core-host-engine-storage";
 import { openNodeSqliteDatabase } from "openclaw/plugin-sdk/sqlite-runtime";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -21,6 +22,11 @@ vi.mock("node:child_process", async (importOriginal) => {
   return { ...actual, spawn: vi.fn(actual.spawn) };
 });
 
+vi.mock("openclaw/plugin-sdk/memory-core-host-engine-knn", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("openclaw/plugin-sdk/memory-core-host-engine-knn")>();
+  return { ...actual, ensureSqliteLibrarySelected: vi.fn(actual.ensureSqliteLibrarySelected) };
+});
+
 const { spawn } = await vi.importActual<typeof import("node:child_process")>("node:child_process");
 beforeEach(() => {
   vi.mocked(childProcess.spawn).mockReset().mockImplementation(spawn);
@@ -35,6 +41,7 @@ function useFixtureChild() {
       stdio: ["pipe", "pipe", "pipe"],
     });
     children.push(child);
+    vi.spyOn(child.stdin, "end");
     ready.push(once(child.stderr, "data"));
     return child;
   });
@@ -123,9 +130,34 @@ async function createFileBackedVectorDatabase(): Promise<{
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 describe("memory vector KNN subprocess boundary", () => {
+  it.each(["runtime", "env", "discovered"] as const)(
+    "forwards the selected SQLite library through stdin for %s selection",
+    async (source) => {
+      const sqliteLibraryPath = "/synthetic/sqlite/libsqlite3.dylib";
+      vi.stubEnv("OPENCLAW_SQLITE_LIBRARY", sqliteLibraryPath);
+      vi.mocked(ensureSqliteLibrarySelected).mockReturnValueOnce(
+        source === "runtime"
+          ? { source }
+          : { source, path: sqliteLibraryPath, version: "3.53.4", extensionLoadingSupported: true },
+      );
+      const fixture = useFixtureChild();
+      await runVectorKnnInSubprocess({ databasePath: "fixture:ok", request: request(1) });
+      const input = JSON.parse(String(vi.mocked(fixture.children[0]!.stdin.end).mock.calls[0]![0]));
+      if (source === "runtime") {
+        expect(input).not.toHaveProperty("sqliteLibraryPath");
+      } else {
+        expect(input).toHaveProperty("sqliteLibraryPath", sqliteLibraryPath);
+      }
+      expect(vi.mocked(childProcess.spawn).mock.calls[0]![2]?.env).not.toHaveProperty(
+        "OPENCLAW_SQLITE_LIBRARY",
+      );
+    },
+  );
+
   it("keeps the parent event loop responsive during synchronous child work", async () => {
     const fixture = useFixtureChild();
     let childFinished = false;
@@ -241,6 +273,7 @@ describe("memory vector KNN subprocess boundary", () => {
         },
       });
       expect(memoryResult.rows.map((row) => row.id)).toEqual(["committed"]);
+      expect(memoryResult.fallbackScanRequired).toBe(false);
 
       const beforeCommit = await runVectorKnnInSubprocess({
         databasePath: fixture.databasePath,

--- a/extensions/memory-core/src/memory/manager-search-knn-subprocess.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn-subprocess.ts
@@ -1,5 +1,6 @@
 // Parent-side subprocess boundary for synchronous sqlite-vec KNN work.
 import { spawn } from "node:child_process";
+import { ensureSqliteLibrarySelected } from "openclaw/plugin-sdk/memory-core-host-engine-knn";
 import {
   resolveRuntimeWorkerArgv,
   resolveRuntimeWorkerUrl,
@@ -160,9 +161,11 @@ export async function runVectorKnnInSubprocess(
   if (params.signal?.aborted) {
     throw toAbortError(params.signal);
   }
+  const sqliteLibrary = ensureSqliteLibrarySelected();
   const input: VectorKnnChildInput = {
     databasePath: params.databasePath,
     extensionPath: params.extensionPath,
+    ...(sqliteLibrary.source !== "runtime" ? { sqliteLibraryPath: sqliteLibrary.path } : {}),
     request: params.request,
   };
   const inputPayload = Buffer.from(JSON.stringify(input), "utf8");

--- a/extensions/memory-core/src/memory/manager-search-knn.child.ts
+++ b/extensions/memory-core/src/memory/manager-search-knn.child.ts
@@ -1,5 +1,6 @@
 // Child-process entrypoint for one hard-cancellable sqlite-vec KNN query.
 import {
+  ensureSqliteLibrarySelected,
   loadSqliteVecExtension,
   openNodeSqliteDatabase,
   supportsNodeSqliteExtensionLoading,
@@ -17,6 +18,7 @@ const MAX_STDOUT_BYTES = 2 * 1024 * 1024;
 export type VectorKnnChildInput = {
   databasePath: string;
   extensionPath?: string;
+  sqliteLibraryPath?: string;
   request: VectorKnnRequest;
 };
 
@@ -33,6 +35,8 @@ function isChildInput(value: unknown): value is VectorKnnChildInput {
   return (
     typeof input.databasePath === "string" &&
     input.databasePath.length > 0 &&
+    (input.sqliteLibraryPath === undefined ||
+      (typeof input.sqliteLibraryPath === "string" && input.sqliteLibraryPath.trim().length > 0)) &&
     Boolean(input.request) &&
     typeof input.request === "object"
   );
@@ -43,6 +47,7 @@ async function run(input: unknown): Promise<VectorKnnChildResult> {
     return { status: "failed", error: "invalid memory vector KNN child input" };
   }
   validateVectorKnnRequest(input.request);
+  ensureSqliteLibrarySelected({ explicitPath: input.sqliteLibraryPath });
   const extensionLoadingSupported = supportsNodeSqliteExtensionLoading();
   const db = openNodeSqliteDatabase(input.databasePath, {
     allowExtension: extensionLoadingSupported,

--- a/src/agents/cli-runner/execute.ts
+++ b/src/agents/cli-runner/execute.ts
@@ -61,11 +61,7 @@ import {
   resolveSessionIdToSend,
   resolveSystemPromptUsage,
 } from "./helpers.js";
-import {
-  cliBackendLog,
-  CLI_BACKEND_LOG_OUTPUT_ENV,
-  LEGACY_CLAUDE_CLI_LOG_OUTPUT_ENV,
-} from "./log.js";
+import { cliBackendLog, CLI_BACKEND_LOG_OUTPUT_ENV } from "./log.js";
 import { createClaudeCliModelCallDiagnostics } from "./model-call-diagnostics.js";
 import { composeCliPromptContext } from "./prompt-context.js";
 import type { PreparedCliRunContext } from "./types.js";
@@ -415,9 +411,7 @@ export async function executePreparedCliRun(
           hasHistoryPrompt: Boolean(context.openClawHistoryPrompt),
         }),
       );
-      const logOutputText =
-        isTruthyEnvValue(process.env[CLI_BACKEND_LOG_OUTPUT_ENV]) ||
-        isTruthyEnvValue(process.env[LEGACY_CLAUDE_CLI_LOG_OUTPUT_ENV]);
+      const logOutputText = isTruthyEnvValue(process.env[CLI_BACKEND_LOG_OUTPUT_ENV]);
       const outputMode = useResume ? (backend.resumeOutput ?? backend.output) : backend.output;
       const initialGatewayCaptureKey =
         nodePlacement || !context.mcpDeliveryCapture ? undefined : crypto.randomUUID();

--- a/src/agents/cli-runner/log.ts
+++ b/src/agents/cli-runner/log.ts
@@ -8,8 +8,6 @@ import { createSubsystemLogger } from "../../logging/subsystem.js";
 export const cliBackendLog = createSubsystemLogger("agent/cli-backend");
 /** Env var that enables CLI backend output logging. */
 export const CLI_BACKEND_LOG_OUTPUT_ENV = "OPENCLAW_CLI_BACKEND_LOG_OUTPUT";
-/** Legacy env var accepted for Claude CLI output logging. */
-export const LEGACY_CLAUDE_CLI_LOG_OUTPUT_ENV = "OPENCLAW_CLAUDE_CLI_LOG_OUTPUT";
 
 /** Return a compact byte/hash summary for CLI backend output. */
 export function formatCliBackendOutputDigest(text: string): string {

--- a/src/commands/doctor-gateway-daemon-flow.ts
+++ b/src/commands/doctor-gateway-daemon-flow.ts
@@ -25,6 +25,7 @@ import {
 import { renderSystemdUnavailableHints } from "../daemon/systemd-hints.js";
 import { classifySystemdUnavailableDetail } from "../daemon/systemd-unavailable.js";
 import { resolveGatewayBindHost, resolveGatewayRequiredListenHosts } from "../gateway/net.js";
+import { ensureSqliteLibrarySelected } from "../infra/bun-sqlite-library.js";
 import { NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON } from "../infra/gateway-supervision.js";
 import { formatPortDiagnostics, isExpectedGatewayListeners } from "../infra/ports-format.js";
 import { inspectPortConnections, inspectPortUsage } from "../infra/ports-inspect.js";
@@ -70,6 +71,14 @@ function noteGatewayRuntime(
   const summary = formatGatewayRuntimeSummary(serviceRuntime);
   const hints = buildGatewayRuntimeHints(serviceRuntime, { platform: process.platform, env });
   const lines = summary ? [`Runtime: ${summary}`, ...hints] : hints;
+  const sqliteLibrary = ensureSqliteLibrarySelected();
+  if (sqliteLibrary.source !== "runtime") {
+    lines.push(
+      `SQLite (doctor process): ${sqliteLibrary.path} (${sqliteLibrary.version}, extension loading enabled)`,
+    );
+  } else if (sqliteLibrary.ignoredOverride) {
+    lines.push(`SQLite (doctor process): ${sqliteLibrary.ignoredOverride}; override ignored`);
+  }
   if (lines.length > 0) {
     note(lines.join("\n"), "Gateway");
   }

--- a/src/gateway/server-startup-log.ts
+++ b/src/gateway/server-startup-log.ts
@@ -15,6 +15,7 @@ import {
 import { resolveThinkingDefault } from "../agents/model-thinking-default.js";
 import type { AmbientEnvTriggerPolicy } from "../channels/config-presence.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { ensureSqliteLibrarySelected } from "../infra/bun-sqlite-library.js";
 import { getResolvedLoggerSettings } from "../logging.js";
 import type { PluginManifestRecord } from "../plugins/manifest-registry.js";
 import { collectEnabledInsecureOrDangerousFlagsFromCurrentSnapshot } from "../security/dangerous-config-flags-current.js";
@@ -67,6 +68,14 @@ export async function logGatewayStartup(params: {
     `http server listening (${formatReadyDetails(params.loadedPluginIds, startupDurationLabel)})`,
   );
   params.log.info(`log file: ${getResolvedLoggerSettings().file}`);
+  const sqliteLibrary = ensureSqliteLibrarySelected();
+  if (sqliteLibrary.source !== "runtime") {
+    params.log.info(
+      `SQLite: using ${sanitizeForLog(sqliteLibrary.path)} (${sqliteLibrary.version}, extension loading enabled)`,
+    );
+  } else if (sqliteLibrary.ignoredOverride) {
+    params.log.warn(`SQLite: ${sqliteLibrary.ignoredOverride}; override ignored`);
+  }
   if (params.isNixMode) {
     params.log.info("gateway: running in Nix mode (config managed externally)");
   }

--- a/src/infra/bun-sqlite-library.ts
+++ b/src/infra/bun-sqlite-library.ts
@@ -1,0 +1,171 @@
+import { existsSync } from "node:fs";
+import { createRequire } from "node:module";
+import { posix } from "node:path";
+import { resolveGlobalSingleton } from "../shared/global-singleton.js";
+import { isSqliteWalResetSafeVersion } from "./sqlite-runtime-version.js";
+
+export type SqliteLibrarySelection =
+  | { source: "runtime"; ignoredOverride?: string }
+  | {
+      source: "env" | "discovered";
+      path: string;
+      version: string;
+      extensionLoadingSupported: true;
+    };
+
+type SelectionOptions = { explicitPath?: string };
+type LibraryProbe = { version: string; extensionLoadingSupported: boolean };
+type SelectionDependencies = {
+  isBun: boolean;
+  platform: string;
+  env: NodeJS.ProcessEnv;
+  exists: (path: string) => boolean;
+  probe: (path: string) => LibraryProbe;
+  select: (path: string) => void;
+};
+
+// Bun is optional: describe only the FFI symbols used at this native boundary.
+type BunFfi = {
+  FFIType: { cstring: number; i32: number };
+  dlopen: (
+    path: string,
+    symbols: Record<string, { args: number[]; returns: number }>,
+  ) => {
+    symbols: {
+      sqlite3_libversion: () => { toString(): string };
+      sqlite3_compileoption_used: (option: Buffer) => number;
+    };
+    close: () => void;
+  };
+};
+
+function probeLibrary(path: string): LibraryProbe {
+  const require = createRequire(import.meta.url);
+  // SAFETY: Called only on Bun; this models its FFI module and the two requested SQLite symbols.
+  const { dlopen, FFIType } = require("bun:ffi") as BunFfi;
+  const library = dlopen(path, {
+    sqlite3_libversion: { args: [], returns: FFIType.cstring },
+    sqlite3_compileoption_used: { args: [FFIType.cstring], returns: FFIType.i32 },
+  });
+  try {
+    return {
+      version: String(library.symbols.sqlite3_libversion()),
+      extensionLoadingSupported:
+        library.symbols.sqlite3_compileoption_used(Buffer.from("OMIT_LOAD_EXTENSION\0")) === 0,
+    };
+  } finally {
+    library.close();
+  }
+}
+
+function selectLibrary(path: string): void {
+  const require = createRequire(import.meta.url);
+  // SAFETY: Called only on macOS Bun, whose Database exposes the process-wide library selector.
+  const { Database } = require("bun:sqlite") as {
+    Database: { setCustomSQLite: (path: string) => void };
+  };
+  Database.setCustomSQLite(path);
+}
+
+function createSelector(deps: SelectionDependencies) {
+  let selection: SqliteLibrarySelection | undefined;
+  let failure: Error | undefined;
+  return (options: SelectionOptions = {}): SqliteLibrarySelection => {
+    if (failure) {
+      throw failure;
+    }
+    if (selection) {
+      return selection;
+    }
+    const override =
+      options.explicitPath ?? (deps.env.OPENCLAW_SQLITE_LIBRARY?.trim() || undefined);
+    if (!deps.isBun || deps.platform !== "darwin") {
+      selection = override
+        ? { source: "runtime", ignoredOverride: "OPENCLAW_SQLITE_LIBRARY requires Bun on macOS" }
+        : { source: "runtime" };
+      return selection;
+    }
+    const prefix = deps.env.HOMEBREW_PREFIX?.trim();
+    const candidates =
+      override !== undefined
+        ? [override]
+        : [
+            ...new Set([
+              ...(prefix ? [posix.join(prefix, "opt/sqlite/lib/libsqlite3.dylib")] : []),
+              "/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib",
+              "/usr/local/opt/sqlite/lib/libsqlite3.dylib",
+              "/opt/local/lib/libsqlite3.dylib",
+            ]),
+          ];
+    for (const path of candidates) {
+      let probe: LibraryProbe;
+      try {
+        if (!deps.exists(path)) {
+          throw new Error("missing file");
+        }
+        probe = deps.probe(path);
+        if (!isSqliteWalResetSafeVersion(probe.version)) {
+          throw new Error(`SQLite version ${probe.version} below the WAL safety floor`);
+        }
+        if (!probe.extensionLoadingSupported) {
+          throw new Error("built with SQLITE_OMIT_LOAD_EXTENSION");
+        }
+      } catch (error) {
+        if (override === undefined) {
+          continue;
+        }
+        failure = selectionError(path, error);
+        throw failure;
+      }
+      try {
+        // Never try another candidate after committing: Bun's hook is one-shot, even on failure.
+        // Discovery trusts the user-writable prefix like the Homebrew Bun binary itself;
+        // an override is operator-specified code, like memory.search.store.vector.extensionPath.
+        deps.select(path);
+      } catch (error) {
+        failure = selectionError(path, error);
+        throw failure;
+      }
+      selection = {
+        source: override === undefined ? "discovered" : "env",
+        path,
+        version: probe.version,
+        extensionLoadingSupported: true,
+      };
+      return selection;
+    }
+    selection = { source: "runtime" };
+    return selection;
+  };
+}
+
+function selectionError(path: string, error: unknown): Error {
+  return new Error(
+    `Cannot use SQLite library ${path}: ${error instanceof Error ? error.message : String(error)}. ` +
+      "Fix or unset OPENCLAW_SQLITE_LIBRARY; install a supported library with brew install sqlite.",
+    { cause: error },
+  );
+}
+
+/** Select once, before any SQLite open; shared across CLI and bundled SDK module graphs. */
+export function ensureSqliteLibrarySelected(
+  options?: SelectionOptions & {
+    /** @internal Isolated native dependencies and memoization for boundary tests. */
+    internals?: SelectionDependencies & { selector?: ReturnType<typeof createSelector> };
+  },
+): SqliteLibrarySelection {
+  const dependencies = options?.internals;
+  const select = dependencies
+    ? (dependencies.selector ??= createSelector(dependencies))
+    : resolveGlobalSingleton(Symbol.for("openclaw.bunSqliteLibrarySelection"), () =>
+        createSelector({
+          isBun: Boolean(process.versions.bun),
+          platform: process.platform,
+          env: process.env,
+          exists: existsSync,
+          probe: probeLibrary,
+          select: selectLibrary,
+        }),
+      );
+  return select(options);
+}

--- a/src/infra/node-sqlite.test.ts
+++ b/src/infra/node-sqlite.test.ts
@@ -2,6 +2,7 @@
 import path from "node:path";
 import { DatabaseSync, type StatementSync } from "node:sqlite";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ensureSqliteLibrarySelected } from "./bun-sqlite-library.js";
 import {
   openNodeSqliteDatabase,
   resolveImmutableSqliteFileUri,
@@ -210,5 +211,166 @@ describe("node SQLite safety", () => {
     return import("./node-sqlite.js").then(({ requireNodeSqlite }) => {
       expect(() => requireNodeSqlite()).not.toThrow();
     });
+  });
+});
+
+const homebrew = "/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib";
+const intelHomebrew = "/usr/local/opt/sqlite/lib/libsqlite3.dylib";
+const safeProbe = { version: "3.53.4", extensionLoadingSupported: true };
+
+function fixture(
+  overrides: Partial<
+    NonNullable<NonNullable<Parameters<typeof ensureSqliteLibrarySelected>[0]>["internals"]>
+  > = {},
+) {
+  const deps = {
+    isBun: true,
+    platform: "darwin",
+    env: {},
+    exists: vi.fn(() => true),
+    probe: vi.fn(() => safeProbe),
+    select: vi.fn(),
+    ...overrides,
+  };
+  return {
+    ...deps,
+    ensure: (options?: { explicitPath?: string }) =>
+      ensureSqliteLibrarySelected({ ...options, internals: deps }),
+  };
+}
+
+describe("Bun SQLite library selection", () => {
+  it.each([
+    { explicitPath: undefined, expected: "/env/sqlite.dylib" },
+    { explicitPath: "/parent/sqlite.dylib", expected: "/parent/sqlite.dylib" },
+  ])("honors explicit then environment priority ($expected)", ({ explicitPath, expected }) => {
+    const f = fixture({ env: { OPENCLAW_SQLITE_LIBRARY: "  /env/sqlite.dylib  " } });
+    expect(f.ensure({ explicitPath })).toEqual({ source: "env", path: expected, ...safeProbe });
+    expect(f.probe).toHaveBeenCalledExactlyOnceWith(expected);
+    expect(f.select).toHaveBeenCalledExactlyOnceWith(expected);
+  });
+
+  it.each(["explicit", "env"])(
+    "rejects an invalid %s override without selecting a library",
+    (source) => {
+      const libraryPath = "/missing/sqlite.dylib";
+      const f = fixture({
+        exists: vi.fn(() => false),
+        env: source === "env" ? { OPENCLAW_SQLITE_LIBRARY: libraryPath } : {},
+      });
+      expect(() => f.ensure(source === "explicit" ? { explicitPath: libraryPath } : {})).toThrow(
+        `Cannot use SQLite library ${libraryPath}: missing file. Fix or unset OPENCLAW_SQLITE_LIBRARY; install a supported library with brew install sqlite.`,
+      );
+      expect(f.probe).not.toHaveBeenCalled();
+      expect(f.select).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    {
+      probe: () => {
+        throw new Error("dlopen: incompatible architecture");
+      },
+      reason: "dlopen: incompatible architecture",
+    },
+    {
+      probe: () => ({ ...safeProbe, version: "3.51.2" }),
+      reason: "SQLite version 3.51.2 below the WAL safety floor",
+    },
+    {
+      probe: () => ({ ...safeProbe, extensionLoadingSupported: false }),
+      reason: "built with SQLITE_OMIT_LOAD_EXTENSION",
+    },
+  ])("reports override validation failure: $reason", ({ probe, reason }) => {
+    const f = fixture({ env: { OPENCLAW_SQLITE_LIBRARY: "/custom/sqlite.dylib" }, probe });
+    expect(() => f.ensure()).toThrow(`Cannot use SQLite library /custom/sqlite.dylib: ${reason}`);
+    expect(f.select).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { ...safeProbe, version: "3.51.2" },
+    { ...safeProbe, extensionLoadingSupported: false },
+  ])("skips unusable discovered libraries (%j)", (firstProbe) => {
+    const f = fixture({
+      probe: vi.fn().mockReturnValueOnce(firstProbe).mockReturnValue(safeProbe),
+    });
+    expect(f.ensure()).toEqual({ source: "discovered", path: intelHomebrew, ...safeProbe });
+    expect(f.select).toHaveBeenCalledExactlyOnceWith(intelHomebrew);
+  });
+
+  it("skips missing and unloadable candidates and reaches MacPorts", () => {
+    const f = fixture({
+      env: { HOMEBREW_PREFIX: "/custom-brew" },
+      exists: vi.fn(
+        (libraryPath) => libraryPath !== "/custom-brew/opt/sqlite/lib/libsqlite3.dylib",
+      ),
+      probe: vi.fn((libraryPath) => {
+        if (libraryPath !== "/opt/local/lib/libsqlite3.dylib") {
+          throw new Error("dlopen failed");
+        }
+        return safeProbe;
+      }),
+    });
+    expect(f.ensure()).toEqual({
+      source: "discovered",
+      path: "/opt/local/lib/libsqlite3.dylib",
+      ...safeProbe,
+    });
+    expect(f.select).toHaveBeenCalledTimes(1);
+  });
+
+  it("prefers HOMEBREW_PREFIX and memoizes the selection without probing again", () => {
+    const f = fixture({ env: { HOMEBREW_PREFIX: "/custom-brew" } });
+    const selected = f.ensure();
+    expect(selected).toEqual({
+      source: "discovered",
+      path: "/custom-brew/opt/sqlite/lib/libsqlite3.dylib",
+      ...safeProbe,
+    });
+    expect(f.ensure({ explicitPath: "/different.dylib" })).toBe(selected);
+    expect(f.probe).toHaveBeenCalledTimes(1);
+    expect(f.select).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the runtime default when no library exists, including a blank override", () => {
+    const f = fixture({ exists: vi.fn(() => false), env: { OPENCLAW_SQLITE_LIBRARY: "  " } });
+    const selection = f.ensure();
+    expect(selection).toEqual({ source: "runtime" });
+    expect(f.ensure()).toBe(selection);
+    expect(f.exists).toHaveBeenCalledTimes(3);
+    expect(f.probe).not.toHaveBeenCalled();
+    expect(f.select).not.toHaveBeenCalled();
+  });
+
+  it("never retries the one-shot hook after a selection failure", () => {
+    const f = fixture({
+      select: vi.fn(() => {
+        throw new Error("SQLite already loaded");
+      }),
+    });
+    expect(() => f.ensure()).toThrow(
+      `Cannot use SQLite library ${homebrew}: SQLite already loaded`,
+    );
+    expect(() => f.ensure()).toThrow("SQLite already loaded");
+    expect(f.probe).toHaveBeenCalledTimes(1);
+    expect(f.select).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    { isBun: false, platform: "darwin" },
+    { isBun: true, platform: "linux" },
+    { isBun: true, platform: "win32" },
+  ])("leaves unsupported runtimes untouched (%j)", (runtime) => {
+    for (const env of [{}, { OPENCLAW_SQLITE_LIBRARY: "/custom/sqlite.dylib" }]) {
+      const f = fixture({ ...runtime, env });
+      expect(f.ensure()).toEqual(
+        env.OPENCLAW_SQLITE_LIBRARY
+          ? { source: "runtime", ignoredOverride: "OPENCLAW_SQLITE_LIBRARY requires Bun on macOS" }
+          : { source: "runtime" },
+      );
+      expect(f.exists).not.toHaveBeenCalled();
+      expect(f.probe).not.toHaveBeenCalled();
+      expect(f.select).not.toHaveBeenCalled();
+    }
   });
 });

--- a/src/infra/node-sqlite.ts
+++ b/src/infra/node-sqlite.ts
@@ -2,6 +2,7 @@
 import { createRequire } from "node:module";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { ensureSqliteLibrarySelected } from "./bun-sqlite-library.js";
 import { formatErrorMessage } from "./errors.js";
 import { isSqliteWalResetSafeVersion } from "./sqlite-runtime-version.js";
 import { installProcessWarningFilter } from "./warning-filter.js";
@@ -92,6 +93,7 @@ function assertSafeSqliteRuntime(sqlite: typeof import("node:sqlite")): void {
 export function requireNodeSqlite(): typeof import("node:sqlite") {
   installProcessWarningFilter();
   try {
+    ensureSqliteLibrarySelected();
     // Bun follow-up: Revalidate close/dispose file release after oven-sh/bun#40005 ships.
     // Bun 1.4.2 retains native statements after close; node:sqlite exposes no finalizer.
     const sqlite = require("node:sqlite") as typeof import("node:sqlite");

--- a/src/infra/runtime-guard.test.ts
+++ b/src/infra/runtime-guard.test.ts
@@ -163,6 +163,27 @@ describe("runtime-guard", () => {
     expect(runtime.error).not.toHaveBeenCalled();
   });
 
+  it("reports a SQLite selection failure through the runtime diagnostic sink", () => {
+    const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+    const sqliteSelectionError =
+      "Cannot use SQLite library /nonexistent.dylib: missing file. " +
+      "Fix or unset OPENCLAW_SQLITE_LIBRARY; install a supported library with brew install sqlite.";
+    assertSupportedRuntime(runtime, {
+      kind: "bun",
+      version: "1.4.2",
+      execPath: "/usr/bin/bun",
+      pathEnv: "/usr/bin",
+      hasNodeSqlite: true,
+      sqliteVersion: "3.53.4",
+      sqliteSelectionError,
+    });
+    expect(runtime.error).toHaveBeenCalledExactlyOnceWith(
+      `${sqliteSelectionError}\nDetected: bun 1.4.2 (exec: /usr/bin/bun).`,
+    );
+    expect(runtime.exit).toHaveBeenCalledExactlyOnceWith(1);
+    expect(runtime.log).not.toHaveBeenCalled();
+  });
+
   it("rejects Bun when it does not provide node:sqlite", () => {
     const runtime = {
       log: vi.fn(),

--- a/src/infra/runtime-guard.ts
+++ b/src/infra/runtime-guard.ts
@@ -9,6 +9,7 @@ import {
 } from "../../node-version.mjs";
 import { formatConsoleDiagnosticBlock } from "../logging/json-console-line.js";
 import type { RuntimeEnv } from "../runtime.js";
+import { ensureSqliteLibrarySelected } from "./bun-sqlite-library.js";
 import {
   detectCurrentRuntimeSqliteVersion,
   isSqliteWalResetSafeVersion,
@@ -48,6 +49,7 @@ type RuntimeDetails = {
   pathEnv: string;
   hasNodeSqlite: boolean;
   sqliteVersion: string | null;
+  sqliteSelectionError?: string;
 };
 
 const SEMVER_RE = /(\d+)\.(\d+)\.(\d+)/;
@@ -88,7 +90,7 @@ function detectRuntime(): RuntimeDetails {
   const bunVersion = process.versions?.bun;
   const kind: RuntimeKind = bunVersion ? "bun" : process.versions?.node ? "node" : "unknown";
   const version = bunVersion ?? process.versions?.node ?? null;
-  const sqlite =
+  const sqlite: ReturnType<typeof detectCurrentRuntimeSqlite> =
     kind === "bun" ? detectCurrentRuntimeSqlite() : { available: false, version: null };
 
   return {
@@ -98,10 +100,24 @@ function detectRuntime(): RuntimeDetails {
     pathEnv: process.env.PATH ?? "(not set)",
     hasNodeSqlite: sqlite.available,
     sqliteVersion: sqlite.version,
+    sqliteSelectionError: sqlite.selectionError,
   };
 }
 
-function detectCurrentRuntimeSqlite(): { available: boolean; version: string | null } {
+function detectCurrentRuntimeSqlite(): {
+  available: boolean;
+  version: string | null;
+  selectionError?: string;
+} {
+  try {
+    ensureSqliteLibrarySelected();
+  } catch (error) {
+    return {
+      available: false,
+      version: null,
+      selectionError: error instanceof Error ? error.message : String(error),
+    };
+  }
   try {
     const version = detectCurrentRuntimeSqliteVersion();
     return { available: version !== null, version };
@@ -112,6 +128,9 @@ function detectCurrentRuntimeSqlite(): { available: boolean; version: string | n
 
 /** Returns whether a detected runtime meets OpenClaw's minimum runtime contract. */
 function runtimeSatisfies(details: RuntimeDetails): boolean {
+  if (details.sqliteSelectionError) {
+    return false;
+  }
   if (details.kind === "node") {
     return isSupportedNodeVersion(details.version);
   }
@@ -206,6 +225,13 @@ export function assertSupportedRuntime(
   const runtimeLabel =
     details.kind === "unknown" ? "unknown runtime" : `${details.kind} ${versionLabel}`;
   const execLabel = details.execPath ?? "unknown";
+  if (details.sqliteSelectionError) {
+    runtime.error(
+      `${details.sqliteSelectionError}\nDetected: ${runtimeLabel} (exec: ${execLabel}).`,
+    );
+    runtime.exit(1);
+    return;
+  }
   const requirement =
     details.kind === "bun"
       ? "openclaw requires Bun 1.4 or newer with WAL-reset-safe node:sqlite (SQLite 3.51.3+ or a patched 3.50.x/3.44.x release)."

--- a/src/plugin-sdk/memory-core-host-engine-knn.ts
+++ b/src/plugin-sdk/memory-core-host-engine-knn.ts
@@ -2,6 +2,7 @@
 // schema migrations, or agent configuration exported by the broader host barrels.
 export { truncateUtf16Safe } from "@openclaw/normalization-core/utf16-slice";
 export { loadSqliteVecExtension } from "../../packages/memory-host-sdk/src/host/sqlite-vec.js";
+export { ensureSqliteLibrarySelected } from "../infra/bun-sqlite-library.js";
 export {
   openNodeSqliteDatabase,
   supportsNodeSqliteExtensionLoading,


### PR DESCRIPTION
## What Problem This Solves

Under Bun on macOS, `sqlite-vec` never loaded, so memory search silently ran the batched embedding scan (after #141104) or failed outright (before it). Bun dlopens Apple's system SQLite so exactly one SQLite library lives in the process, and Apple's build omits extension loading. Our docs told operators to preload a custom SQLite themselves, which nobody does, and even a parent-process preload never reached the KNN child.

## Why This Change Was Made

Bun's only hook is `bun:sqlite` `Database.setCustomSQLite(path)`. It is one-shot, must run before the first database open, and a bad path breaks every later open in the process. This change turns that fragile hook into safe automatic behavior owned by the SQLite runtime boundary.

- New `src/infra/bun-sqlite-library.ts` validates each candidate through `bun:ffi` (`sqlite3_libversion` passes the WAL-reset safety floor, `OMIT_LOAD_EXTENSION` absent) before committing, then memoizes process-wide. Resolution order: explicit path, then `OPENCLAW_SQLITE_LIBRARY`, then discovery under `$HOMEBREW_PREFIX`, `/opt/homebrew`, `/usr/local`, and MacPorts. A capable candidate wins on capability, not raw version: Homebrew 3.53.4 beats Apple 3.54.0 because Apple's cannot load extensions.
- Selection runs at both first-open owners: the startup runtime guard probe and `requireNodeSqlite()`. An unusable override is reported as one clean runtime-guard diagnostic with exit 1.
- The memory KNN child receives the selected library through its typed stdin input and selects before opening. `buildChildEnv` stays stripped. The #141104 scan fallback remains the path when no capable library exists.
- Gateway startup logs the selected library; doctor reports it for the doctor process.
- Node, and Bun on Linux and Windows, are intentional no-ops. Bun statically links its own SQLite 3.53.2 with upstream defaults there, so extension loading already works; `setCustomSQLite` is a documented no-op on those platforms.
- The undocumented legacy alias `OPENCLAW_CLAUDE_CLI_LOG_OUTPUT` (superseded by `OPENCLAW_CLI_BACKEND_LOG_OUTPUT` in the March 2026 CLI-backend rename, present in no docs) is retired so the `OPENCLAW_*` name budget stays at 493. `docs/help/environment.md` states undocumented names are internal and may disappear.

No configuration option, schema, persistent-store, WAL floor, or child-environment change. `src/daemon/runtime-paths.ts`'s raw runtime probe is unchanged: it checks the runtime default's WAL floor, which selection never lowers.

## User Impact

On macOS Bun, `brew install sqlite` is now all that is needed for native `sqlite-vec` KNN memory search; OpenClaw picks the library up automatically in the Gateway and in the KNN child. Operators can pin a library with `OPENCLAW_SQLITE_LIBRARY`; an invalid value fails loudly with the fix. Without a capable library, behavior is unchanged from #141104.

Existing custom SQLite preload scripts must be removed and replaced with `OPENCLAW_SQLITE_LIBRARY` pointing to the same library. The Bun install guide documents this migration because Bun allows the selector hook only once per process.

## Evidence

- The KNN barrel export follows main's narrow child import boundary; the parent and subprocess mock use the same selector import. SDK registration and surface checks pass.

- Live on macOS with Bun 1.4.2 and Homebrew SQLite 3.53.4: discovery selects the Homebrew library, `sqlite-vec` v0.1.9 loads, and a real `runVectorKnnInSubprocess` round trip returns both synthetic rows with `fallbackScanRequired: false`.
- Built CLI: `bun openclaw.mjs --version` unchanged (metadata fast path); `OPENCLAW_SQLITE_LIBRARY=/nonexistent.dylib bun openclaw.mjs status` prints one diagnostic block (`Cannot use SQLite library /nonexistent.dylib: missing file. Fix or unset OPENCLAW_SQLITE_LIBRARY; install a supported library with brew install sqlite.` plus the Detected line) and exits 1; the same override under Node is ignored and `--version` succeeds.
- Linux verified on a Blacksmith Testbox lease (`tbx_01m1yd3xnasmcm5h2qq3rec2kg`, x64, fresh Bun 1.4.2): `node:sqlite` reports SQLite 3.53.2, `OMIT_LOAD_EXTENSION` = 0, `enableLoadExtension(true)` works, and `setCustomSQLite` is a no-op. Windows shares Bun's static build path.
- Tests: selector resolution, validation, memoization, one-shot failure, and platform no-op cases in `src/infra/node-sqlite.test.ts` (consolidated to respect the 720-root infra shard limit); runtime-guard diagnostic path; KNN subprocess forwarding for runtime/env/discovered selections with the stripped child env asserted; 83 infra + 10 subprocess + 26 orchestration tests pass on the rebased head.
- `pnpm build` passes; the bundled chunk keeps `bun:ffi` and `bun:sqlite` as runtime `createRequire` calls with no inlining. Import cycles 0. `OPENCLAW_*` count 493/493. `git diff --check` clean. Independent review reported no actionable findings.
- `check:changed` passed every gate up to the known nested-worktree extension declaration lint boundary; the changed core files pass the core lint configuration directly. CI is authoritative for that lane.

- Preload migration verified on Bun 1.4.2: a legacy `--preload` script calling `Database.setCustomSQLite()` conflicts with automatic selection (`SQLite already loaded`), even for the same Homebrew path. Removing that preload and setting `OPENCLAW_SQLITE_LIBRARY` to the same path makes the built CLI `memory status --json` exit 0 in an isolated state directory; the real parent/child KNN round trip returns both synthetic rows with `fallbackScanRequired: false`.
- Initial hosted CI found test formatting and an unbound `stdin.end` method reference. A test-only follow-up retains the spy handle directly; all 10 subprocess tests, formatting, and fresh independent review pass.

- Review resolution: the supported upgrade path for custom SQLite preload users is the documented and live-verified preload-to-environment transition. The data-model heuristic does not identify a persisted-format change: `sqliteLibraryPath` exists only in the bounded per-query stdin message, and the doctor addition reports the selected runtime library. Database paths, schemas, stored vectors, and existing fallback search remain unchanged, so no database migration or backfill is required.
