### PR TITLE
fix(workboard): release stores from owned plugin inspections

### DIFF
--- a/extensions/workboard/index.lifecycle.test.ts
+++ b/extensions/workboard/index.lifecycle.test.ts
@@ -63,6 +63,11 @@ function registerGeneration(register: (api: OpenClawPluginApi) => void = plugin.
       await lifecycle.cleanup?.(context);
     }
   };
+  const dispose = async () => {
+    for (const lifecycle of captured.runtimeLifecycles) {
+      await lifecycle.dispose?.();
+    }
+  };
   const run = async (...args: string[]): Promise<unknown> => {
     const program = new Command().exitOverride();
     for (const registration of captured.cliRegistrars) {
@@ -95,17 +100,49 @@ function registerGeneration(register: (api: OpenClawPluginApi) => void = plugin.
     const [ok, payload, error] = respond.mock.calls[0] ?? [];
     return { ok, payload, error };
   };
-  return { cleanup, run, start, stop, warn, emit, call };
+  return { cleanup, dispose, run, start, stop, warn, emit, call };
 }
 
 describe("Workboard registration cleanup", () => {
-  it.each(["disable", "restart"] as const)(
+  it("registers store disposal before a later runtime dependency throws", async () => {
+    await withStateDirEnv("workboard-registration-failure-", async () => {
+      const store = WorkboardStore.openSqlite();
+      const opened = vi.spyOn(WorkboardStore, "openSqlite").mockReturnValueOnce(store);
+      const failure = new Error("synthetic Gateway runtime unavailable");
+      try {
+        const captured = capturePluginRegistration({
+          ...plugin,
+          register(api) {
+            const runtime = new Proxy(api.runtime, {
+              get(target, property) {
+                if (property === "gateway") {
+                  throw failure;
+                }
+                return Reflect.get(target, property, target);
+              },
+            });
+            expect(() => plugin.register({ ...api, runtime })).toThrow(failure);
+          },
+        });
+        expect(captured.runtimeLifecycles).toHaveLength(1);
+        await captured.runtimeLifecycles[0]!.dispose?.();
+        await expect(store.list()).rejects.toThrow("workboard store is closed.");
+      } finally {
+        opened.mockRestore();
+        await store.close();
+      }
+    });
+  });
+
+  it.each(["disable", "restart", "dispose"] as const)(
     "closes only the retired generation on %s",
-    async (reason) => {
+    async (action) => {
+      const reason = action === "dispose" ? "disable" : action;
       await withStateDirEnv("workboard-registration-lifecycle-", async () => {
         vi.useFakeTimers();
         const first = registerGeneration();
         const second = registerGeneration();
+        const retire = () => (action === "dispose" ? first.dispose() : first.cleanup({ reason }));
         try {
           await first.start();
           await first.run("create", "Retained card");
@@ -122,7 +159,7 @@ describe("Workboard registration cleanup", () => {
           }
 
           expect(vi.getTimerCount()).toBeGreaterThan(0);
-          await first.cleanup({ reason });
+          await retire();
           await expect(first.run("list")).rejects.toThrow("workboard store is closed.");
           await vi.advanceTimersByTimeAsync(60_000);
           expect(first.warn).not.toHaveBeenCalled();
@@ -137,7 +174,7 @@ describe("Workboard registration cleanup", () => {
               expect.objectContaining({ title: "Fresh card" }),
             ]),
           });
-          await first.cleanup({ reason });
+          await retire();
           second.emit.mockClear();
           await second.run("create", "After repeated retirement");
           expect(second.emit).toHaveBeenCalled();

--- a/extensions/workboard/index.ts
+++ b/extensions/workboard/index.ts
@@ -24,22 +24,26 @@ export default definePluginEntry({
   description: "Dashboard workboard for agent-owned issues and sessions.",
   register(api) {
     const store = WorkboardStore.openSqlite();
+    const resourceServices: Array<{ stop(): void }> = [];
+    registerWorkboardStoreLifecycle(api, store, () => {
+      for (const service of resourceServices) {
+        service.stop();
+      }
+    });
     const changeEvents = createWorkboardChangeEventService(store);
+    resourceServices.push(changeEvents);
     const automationNudge = createWorkboardAutomationNudgeService({
       store,
       gateway: api.runtime.gateway,
     });
+    resourceServices.push(automationNudge);
     const lifecycleSync = createWorkboardLifecycleService({
       store,
       worktrees: api.runtime.worktrees,
       readSessions: async (options) =>
         await readWorkboardLifecycleSessions(api.runtime.gateway, options),
     });
-    registerWorkboardStoreLifecycle(api, store, () => {
-      changeEvents.stop();
-      automationNudge.stop();
-      lifecycleSync.stop();
-    });
+    resourceServices.push(lifecycleSync);
     api.session.controls.registerControlUiDescriptor({
       surface: "tab",
       id: "workboard",

--- a/extensions/workboard/src/store-lifecycle.ts
+++ b/extensions/workboard/src/store-lifecycle.ts
@@ -6,8 +6,14 @@ export function registerWorkboardStoreLifecycle(
   store: WorkboardStore,
   stopServices?: () => void,
 ): void {
+  const dispose = () => {
+    // Stop producers before the store drains admitted work and closes its connection.
+    stopServices?.();
+    return store.close();
+  };
   api.lifecycle.registerRuntimeLifecycle({
     id: "workboard-sqlite-store",
+    dispose,
     cleanup: ({ reason, sessionKey, runId }) => {
       // Session cleanup shares this hook, but only registry retirement owns the whole store.
       if (
@@ -15,9 +21,7 @@ export function registerWorkboardStoreLifecycle(
         runId === undefined &&
         (reason === "disable" || reason === "restart")
       ) {
-        // Stop producers before the store drains admitted work and closes its connection.
-        stopServices?.();
-        return store.close();
+        return dispose();
       }
       return undefined;
     },


### PR DESCRIPTION
## What Problem This Solves

Fixes Workboard database connections remaining open after an owned plugin inspection. Registration could also fail after opening the store but before registering its cleanup.

## Why This Change Was Made

Register store cleanup immediately after acquisition and add a resource-only disposer using the existing close path. Track each successfully constructed service so disposal stops those producers before the existing store owner drains admitted work and closes its connection.

Related: #140674. This three-file slice uses the landed inspection owner and leaves general cached/prepared registry lifetimes unchanged.

## User Impact

Temporary inspections close their own Workboard connection while active registrations remain usable. Existing restart/disable and session/run cleanup rules are preserved, as are stored cards, schemas, queries, and transaction behavior.

## Evidence

Two intended regressions failed before production edits. All 82 entry/store/service tests, canonical changed checks, full build, and Codex review passed. Build time was 268.93 seconds.

An instrumented integration run used the actual compiled loader, bundled Workboard, and native SQLite with synthetic host context. It proved inspection release waits for admitted work, partial registration rollback joins cleanup, repeated release closes once, and the active sibling stays readable/writable with its change service intact. Each of three distinct Workboard connections closed once at its own retirement; three cards remained on reopen. This run took 2.267 seconds. The observer preserves native constructor argument arity; an earlier observer-only failure is retained separately.

A separate uninstrumented shipped `node openclaw.mjs workboard list --json` process read all three cards from that same final synthetic state in 3.218 seconds. That is compatibility and durable-data readback proof; deterministic disposal is established by the instrumented loader run, not by CLI process exit.

Source remained unchanged throughout validation. Production delta is +16/-8 lines; existing entry tests add the regression coverage. No new SDK export, configuration option, database schema, or persistence policy.
