### PR TITLE
fix(cli): honor the selected agent when inspecting models

### DIFF
--- a/src/cli/capability-cli.test.ts
+++ b/src/cli/capability-cli.test.ts
@@ -104,7 +104,9 @@ const mocks = vi.hoisted(() => ({
   resolveMemorySearchConfig: vi.fn<
     typeof import("../agents/memory-search.js").resolveMemorySearchConfig
   >(() => null),
-  loadModelCatalog: vi.fn(async () => []),
+  loadModelCatalog: vi.fn<
+    typeof import("../agents/prepared-model-catalog.js").loadPreparedModelCatalog
+  >(async () => []),
   prepareSimpleCompletionModelForAgent: vi.fn(async () => ({
     selection: {
       provider: "openai",
@@ -914,6 +916,84 @@ describe("capability cli", () => {
 
     await runCapability("model", "list");
     expect(mocks.runtime.log).toHaveBeenCalledWith("No results found.");
+  });
+
+  it.each([
+    ["list", []],
+    ["inspect", ["--model", "catalog-fixture/work-model"]],
+  ] as const)("shows the requested agent's model in infer model %s", async (command, args) => {
+    mocks.loadConfig.mockReturnValue({
+      agents: {
+        ownership: "explicit",
+        defaults: { systemAgent: { agentId: "main" } },
+        entries: { main: {}, work: {} },
+      },
+    });
+    const workModel = { provider: "catalog-fixture", id: "work-model", name: "Work model" };
+    mocks.loadModelCatalog.mockImplementation(async (params) =>
+      params?.agentId === "work"
+        ? [workModel]
+        : [{ provider: "catalog-fixture", id: "main-model", name: "Main model" }],
+    );
+
+    await runCap("infer", "model", "--agent", "work", command, ...args, "--json");
+
+    expect(mocks.runtime.writeJson).toHaveBeenCalledWith(
+      command === "list" ? [workModel] : workModel,
+    );
+  });
+
+  it.each(["list", "inspect"])(
+    "rejects an unknown agent before infer model %s returns another agent's model",
+    async (command) => {
+      mocks.loadConfig.mockReturnValue({
+        agents: { ownership: "explicit", entries: { main: {}, work: {} } },
+      });
+
+      await expect(
+        runCap(
+          "infer",
+          "model",
+          "--agent",
+          "retired",
+          command,
+          ...(command === "inspect" ? ["--model", "openai/gpt-5.4"] : []),
+          "--json",
+        ),
+      ).rejects.toThrow("exit 1");
+
+      expectRuntimeErrorContains('Unknown agent id "retired"');
+      expect(mocks.runtime.writeJson).not.toHaveBeenCalled();
+    },
+  );
+
+  it("canonicalizes an infer model run override using the requested agent's catalog", async () => {
+    mocks.loadConfig.mockReturnValue({
+      agents: { ownership: "explicit", entries: { main: {}, work: {} } },
+    });
+    mocks.loadModelCatalog.mockImplementation(async (params) =>
+      params?.agentId === "work"
+        ? [{ provider: "catalog-fixture", id: "Work-Model", name: "Work model" }]
+        : [],
+    );
+
+    await runCap(
+      "infer",
+      "model",
+      "--agent",
+      "work",
+      "run",
+      "--model",
+      "catalog-fixture/WORK-MODEL",
+      "--prompt",
+      "hello",
+      "--json",
+    );
+
+    expect(firstPreparedModelParams()).toMatchObject({
+      agentId: "work",
+      modelRef: "catalog-fixture/Work-Model",
+    });
   });
 
   it("reports model providers configured through their environment key", async () => {

--- a/src/cli/capability-cli/model.ts
+++ b/src/cli/capability-cli/model.ts
@@ -58,7 +58,9 @@ const HEIC_MODEL_RUN_MIMES = new Set([
   "image/heif-sequence",
 ]);
 
-async function loadModelCatalogForInspection(cfg: OpenClawConfig, agentId?: string) {
+async function loadModelCatalogForInspection(cfg: OpenClawConfig, rawAgentId?: string) {
+  const agentId =
+    rawAgentId === undefined ? undefined : resolveCapabilityProviderAgentId(cfg, rawAgentId);
   const prepared = await loadPreparedModelCatalog({ config: cfg, agentId, readOnly: true });
   const metadataSnapshot = loadManifestMetadataSnapshot({ config: cfg, env: process.env });
   const manifest = planEffectiveModelCatalogRows({
@@ -80,13 +82,15 @@ async function loadModelCatalogForInspection(cfg: OpenClawConfig, agentId?: stri
 async function canonicalizeModelRunRef(params: {
   raw: string | undefined;
   cfg: OpenClawConfig;
+  agentId: string;
   preserveAuthProfile: boolean;
 }): Promise<string | undefined> {
   return await canonicalizeCaseOnlyCatalogModelRef({
     cfg: params.cfg,
     raw: params.raw,
     defaultProvider: DEFAULT_PROVIDER,
-    loadCatalog: () => loadPreparedModelCatalog({ config: params.cfg, readOnly: true }),
+    loadCatalog: () =>
+      loadPreparedModelCatalog({ config: params.cfg, agentId: params.agentId, readOnly: true }),
     preserveAuthProfile: params.preserveAuthProfile,
   });
 }
@@ -186,6 +190,7 @@ async function runModelRun(params: {
   const modelRef = await canonicalizeModelRunRef({
     raw: params.model,
     cfg,
+    agentId,
     preserveAuthProfile: params.transport === "local",
   });
   const hasExplicitProviderModelOverride = Boolean(explicitModelOverride);
@@ -492,9 +497,12 @@ export function registerModelCapabilityCommands(capability: Command): void {
     .command("list")
     .description("List known models")
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
+    .action(async (opts, command) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
-        const result = await loadModelCatalogForInspection(getRuntimeConfig());
+        const result = await loadModelCatalogForInspection(
+          getRuntimeConfig(),
+          resolveCapabilityAgentOption(command, opts.agent),
+        );
         emitJsonOrText(defaultRuntime, Boolean(opts.json), result, providerSummaryText);
       });
     });
@@ -504,10 +512,13 @@ export function registerModelCapabilityCommands(capability: Command): void {
     .description("Inspect one model catalog entry")
     .requiredOption("--model <provider/model>", "Model id")
     .option("--json", "Output JSON", false)
-    .action(async (opts) => {
+    .action(async (opts, command) => {
       await runCommandWithRuntime(defaultRuntime, async () => {
         const target = normalizeStringifiedOptionalString(opts.model) ?? "";
-        const catalog = await loadModelCatalogForInspection(getRuntimeConfig());
+        const catalog = await loadModelCatalogForInspection(
+          getRuntimeConfig(),
+          resolveCapabilityAgentOption(command, opts.agent),
+        );
         const entry =
           catalog.find((candidate) => `${candidate.provider}/${candidate.id}` === target) ??
           catalog.find((candidate) => candidate.id === target);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw infer model --agent work list --json` tells operators that no agent was selected in a multi-agent configuration. Model inspection and case-only model-name normalization also lose the selected agent when reading the catalog.

## Why This Change Was Made

Pass the inherited agent option through the existing catalog reader and validate explicit agent IDs with the existing CLI owner resolver. Model runs keep their already-resolved agent during catalog normalization. Read-only acquisition, omitted-agent behavior and aggregate inventory remain unchanged.

## User Impact

Operators can list and inspect models for a selected agent without configuring a separate system agent. An unknown agent is rejected instead of reading another agent's catalog.

## Evidence

- Real CLI baseline: `infer model --agent work list --json` exits 1 with “this operation has no explicit owner” despite the supplied selector.
- With this change, the same command exits 0. `infer model --agent work inspect --model catalog-fixture/work-model --json` returns the expected model with a 32768-token context window and text input. An unknown `retired` agent exits 1 with the correct diagnostic.
- Five added regression cases fail before the fix. All 14 selected regression and neighboring checks pass after it, including local/Gateway case normalization and auth-profile preservation. These dispatch checks use the existing test doubles; no live inference is claimed.
- Pinned formatting and `git diff --check` pass. Public command checks use isolated synthetic state, no credentials and no external network.
