### PR TITLE
fix(android): keep Thinking controls clear of folds

### DIFF
--- a/apps/android/README.md
+++ b/apps/android/README.md
@@ -66,14 +66,14 @@ menu, it closes without choosing an action. Reopen it explicitly when space
 permits; it does not reopen automatically when the layout recovers. Dismissing
 the menu does not reset Chat's draft, editor, or reader state.
 
-Chat's Model picker and its Permissions page initially use the largest safe
-region with usable sheet space, not the trigger's region. They keep that region
-while it remains usable. Valid geometry changes retain the same sheet and local
-state. An invalid opening closes without selecting an option and stays closed
-until explicitly reopened.
+Chat's Model picker, its Permissions page, and Thinking effort sheet initially
+use the largest safe region with usable sheet space, not the trigger's region.
+They keep that region while it remains usable. Valid geometry changes retain
+the same sheet and local state. An invalid opening closes without selecting an
+option and stays closed until explicitly reopened.
 
-The Thinking effort sheet, background-task and branch-switching sheets, and
-other dialogs, sheets, and popup menus are not fold-adapted yet.
+Background-task and branch-switching sheets and other dialogs, sheets, and
+popup menus are not fold-adapted yet.
 
 ## Wear OS companion
 

--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/chat/ChatScreen.kt
@@ -471,6 +471,44 @@ internal fun ChatScreen(
   val sendInFlight = composerOwner in sendStates
   val pickerActivity = LocalActivity.current
   val pickerView = LocalView.current
+
+  // Admission reads current settings, not the last composed enabled state.
+  fun currentEffortSession() =
+    viewModel.chatSessions.value.firstOrNull {
+      isActiveSessionChoice(it.key, viewModel.chatSessionKey.value, viewModel.mainSessionKey.value)
+    }
+
+  fun currentFastModeProviderSupported() =
+    fastModeProviderSupportedForSelection(
+      selectedModelRef = viewModel.chatSelectedModelRef.value,
+      sessionModelProvider = currentEffortSession()?.modelProvider,
+      catalog = viewModel.chatModelCatalog.value,
+    )
+
+  fun canChangeThinking() =
+    operatorScopesAllowAdmin(viewModel.operatorScopes.value) &&
+      chatThinkingSupported(
+        selection = viewModel.chatThinkingLevelSelection.value,
+        fallbackSupported = thinkingSupportedForSelection(viewModel.chatSelectedModelRef.value, viewModel.chatModelCatalog.value),
+      )
+
+  fun canChangeFastMode(expected: ChatComposerOwner) =
+    chatFastModeControlEnabled(
+      supported =
+        fastModeSupportedForSelection(
+          providerSupported = currentFastModeProviderSupported(),
+          hasConfiguredFastModeOverride = currentEffortSession()?.fastMode != null,
+        ),
+      adminAuthorized = operatorScopesAllowAdmin(viewModel.operatorScopes.value),
+      connected = viewModel.gatewayConnectionDisplay.value.isConnected,
+      gatewayAvailable = viewModel.chatHealthOk.value,
+      loading = viewModel.chatHistoryLoading.value || viewModel.chatSessionCreating.value,
+      sending = expected in composerState.sendStates.value,
+      activeRun = viewModel.pendingRunCount.value > 0,
+      streaming = viewModel.chatStreamingAssistantText.value != null,
+      settingsMutationPending = viewModel.chatSessionKey.value in viewModel.chatPendingSessionSettingsKeys.value,
+    )
+
   val modelPicker =
     remember(viewModel, pickerActivity, pickerView, lifecycleOwner) {
       ChatModelPickerSessionOwner(pickerActivity, pickerView, lifecycleOwner.lifecycle) { expected ->
@@ -479,9 +517,26 @@ internal fun ChatScreen(
           operatorScopesAllowWrite(viewModel.operatorScopes.value)
       }
     }
-  rememberWindowDisplayFeatureState(modelPicker::publishFeatures)
-  SideEffect { modelPicker.refreshTarget() }
-  DisposableEffect(modelPicker) { onDispose { modelPicker.dispose() } }
+  val effortPicker =
+    remember(viewModel, pickerActivity, pickerView, lifecycleOwner) {
+      ChatModelPickerSessionOwner(pickerActivity, pickerView, lifecycleOwner.lifecycle) { expected ->
+        viewModel.isCurrentChatComposerOwner(expected) && (canChangeThinking() || canChangeFastMode(expected))
+      }
+    }
+  rememberWindowDisplayFeatureState { publication ->
+    modelPicker.publishFeatures(publication)
+    effortPicker.publishFeatures(publication)
+  }
+  SideEffect {
+    modelPicker.refreshTarget()
+    effortPicker.refreshTarget()
+  }
+  DisposableEffect(modelPicker, effortPicker) {
+    onDispose {
+      modelPicker.dispose()
+      effortPicker.dispose()
+    }
+  }
   var showBackgroundTasks by rememberSaveable { mutableStateOf(false) }
   var showBranchSwitcher by rememberSaveable { mutableStateOf(false) }
   var detailsExpanded by rememberSaveable { mutableStateOf(false) }
@@ -945,14 +1000,7 @@ internal fun ChatScreen(
         composerState.clearAttachmentOmission(composerOwner)
       },
       commands = chatCommands,
-      onThinkingLevelChange = viewModel::setChatThinkingLevel,
-      onFastModeChange = { enabled ->
-        viewModel.setChatSessionFastMode(
-          sessionKey = sessionKey,
-          enabled = enabled,
-          clearOverride = !fastModeProviderSupported,
-        )
-      },
+      onOpenEffortPicker = { effortPicker.open(composerOwner, sessionKey) },
       onOpenModelPicker = { modelPicker.open(composerOwner, sessionKey) },
       onPickImages = {
         if (!viewModel.isCurrentChatComposerOwner(composerOwner)) return@ChatComposer
@@ -1068,6 +1116,35 @@ internal fun ChatScreen(
         sendCheckpointFull = result == ChatComposerSendStartResult.CheckpointFull
       },
     )
+  }
+
+  effortPicker.visible?.let { opening ->
+    key(opening) {
+      ChatEffortSheet(
+        opening = opening,
+        options = thinkingLevelSelection.options,
+        selectedId = thinkingLevel,
+        thinkingSupported = thinkingSupported,
+        thinkingLevelEnabled = canAdminSessionSettings,
+        fastMode = fastMode,
+        fastModeEnabled = canChangeFastMode(opening.composerOwner),
+        onSelect = { level ->
+          if (effortPicker.admit(opening) && canChangeThinking()) {
+            viewModel.setChatThinkingLevel(level)
+          }
+        },
+        onFastModeChange = { enabled ->
+          if (effortPicker.admit(opening) && canChangeFastMode(opening.composerOwner)) {
+            viewModel.setChatSessionFastMode(
+              sessionKey = opening.sessionKey,
+              enabled = enabled,
+              clearOverride = !currentFastModeProviderSupported(),
+            )
+          }
+        },
+        onDismiss = { if (effortPicker.admit(opening)) effortPicker.retire(opening) },
+      )
+    }
   }
 
   modelPicker.visible?.let { opening ->
@@ -2586,8 +2663,7 @@ private fun ChatComposer(
   modelUnavailableMessage: NativeText?,
   onDismissShareImportNotice: () -> Unit,
   commands: List<ChatCommandEntry>,
-  onThinkingLevelChange: (String) -> Unit,
-  onFastModeChange: (Boolean) -> Unit,
+  onOpenEffortPicker: () -> Unit,
   onOpenModelPicker: () -> Unit,
   onPickImages: () -> Unit,
   onPickAudioOrDocument: () -> Unit,
@@ -2762,8 +2838,7 @@ private fun ChatComposer(
             thinkingLevelEnabled = thinkingLevelEnabled,
             fastMode = fastMode,
             fastModeEnabled = fastModeEnabled,
-            onFastModeChange = onFastModeChange,
-            onThinkingLevelChange = onThinkingLevelChange,
+            onOpenEffortPicker = onOpenEffortPicker,
             contextUsage = contextUsage,
             modifier = Modifier.weight(1f),
           )
@@ -2848,21 +2923,16 @@ private fun ChatThinkingLevelPicker(
   thinkingLevelEnabled: Boolean,
   fastMode: Boolean,
   fastModeEnabled: Boolean,
-  onSelect: (String) -> Unit,
-  onFastModeChange: (Boolean) -> Unit,
+  onOpen: () -> Unit,
 ) {
-  var expanded by rememberSaveable { mutableStateOf(false) }
   val enabled = (thinkingSupported && thinkingLevelEnabled) || fastModeEnabled
-  LaunchedEffect(enabled) {
-    if (!enabled) expanded = false
-  }
   val languageTag = currentAppLanguage().languageTag
   val position = resolveChatEffortPosition(selectedId, options)
   val description = nativeString("Thinking")
   val dialColor = if (enabled) ClawTheme.colors.textMuted else ClawTheme.colors.textSubtle
   val needleColor = if (enabled) ClawTheme.colors.text else ClawTheme.colors.textSubtle
   Surface(
-    onClick = { expanded = true },
+    onClick = onOpen,
     enabled = enabled,
     modifier =
       Modifier.size(ClawTheme.spacing.touchTarget).semantics {
@@ -2910,19 +2980,6 @@ private fun ChatThinkingLevelPicker(
         }
       }
     }
-  }
-  if (expanded) {
-    ChatEffortSheet(
-      options = options,
-      selectedId = selectedId,
-      thinkingSupported = thinkingSupported,
-      thinkingLevelEnabled = thinkingLevelEnabled,
-      fastMode = fastMode,
-      fastModeEnabled = fastModeEnabled,
-      onSelect = onSelect,
-      onFastModeChange = onFastModeChange,
-      onDismiss = { expanded = false },
-    )
   }
 }
 
@@ -3068,6 +3125,7 @@ private fun ChatEffortSliderTrack(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun ChatEffortSheet(
+  opening: ChatModelPickerSession,
   options: List<ChatThinkingLevelOption>,
   selectedId: String,
   thinkingSupported: Boolean,
@@ -3080,6 +3138,7 @@ private fun ChatEffortSheet(
 ) {
   val thinkingOptions = if (thinkingSupported) options else emptyList()
   ModalBottomSheet(
+    modifier = Modifier.foldAwareSheet(opening.geometry),
     onDismissRequest = onDismiss,
     sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
     containerColor = ClawTheme.colors.surface,
@@ -3653,8 +3712,7 @@ private fun ChatInputPill(
   thinkingLevelEnabled: Boolean,
   fastMode: Boolean,
   fastModeEnabled: Boolean,
-  onFastModeChange: (Boolean) -> Unit,
-  onThinkingLevelChange: (String) -> Unit,
+  onOpenEffortPicker: () -> Unit,
   contextUsage: ChatContextUsage,
   modifier: Modifier = Modifier,
 ) {
@@ -3755,8 +3813,7 @@ private fun ChatInputPill(
               thinkingLevelEnabled = thinkingLevelEnabled,
               fastMode = fastMode,
               fastModeEnabled = fastModeEnabled,
-              onSelect = onThinkingLevelChange,
-              onFastModeChange = onFastModeChange,
+              onOpen = onOpenEffortPicker,
             )
           }
         }

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/chat/ChatComposerLayoutTest.kt
@@ -31,6 +31,8 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
+import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.graphics.Rect
 import android.os.SystemClock
 import android.provider.Settings
@@ -193,6 +195,7 @@ class ChatComposerLayoutTest {
   private val viewModelStore = ViewModelStore()
   private var originalAnimatorScale: String? = null
   private var renderedCanvasColor = Color.Unspecified
+  private var renderedSheetColor = Color.Unspecified
   private lateinit var chatActivity: Activity
   private lateinit var insetView: View
   private var observedBottomInsets: Pair<Int, Int>? = null
@@ -1421,6 +1424,363 @@ class ChatComposerLayoutTest {
     val caretTop = with(composeRule.density) { caret.top.toDp() }
     val caretBottom = with(composeRule.density) { caret.bottom.toDp() }
     assertTrue("The whole caret must be visible inside the editor: $caret within $bounds", caretTop >= bounds.top && caretBottom <= bounds.bottom)
+  }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun effortSheetSurfaceStaysInsideTheActivityFoldPane() {
+    showChat(viewportWidth = 720.dp, viewportHeight = { 720.dp })
+    composeRule.onNodeWithContentDescription(nativeString("Thinking")).performClick()
+    composeRule.waitForIdle()
+    val dialog = checkNotNull(ShadowDialog.getLatestDialog()) as ComponentDialog
+    assertNotSame(chatActivity.window, dialog.window)
+    assertTrue(dialog.isShowing)
+    val cases =
+      listOf(
+        emptyList<DisplayFeature>() to Rect(0, 0, 800, 800),
+        listOf(testFold(Rect(390, 0, 410, 800))) to Rect(0, 0, 390, 800),
+        listOf(testFold(Rect(0, 390, 800, 410))) to Rect(0, 0, 800, 390),
+      )
+    for ((features, pane) in cases) {
+      composeRule.runOnIdle { runBlocking { sheetFeatures.publish(features) } }
+      composeRule.waitForIdle()
+      val surface = effortSheetSurfaceBounds(dialog)
+      assertTrue("The rendered Thinking Surface $surface must fit Activity pane $pane", pane.contains(surface))
+      assertTrue("A benign remap retains the actual native opening", dialog === ShadowDialog.getLatestDialog())
+      composeRule.onNodeWithText(nativeString("Fast mode")).performScrollTo().assertIsDisplayed()
+    }
+    composeRule.runOnIdle { dialog.onBackPressedDispatcher.onBackPressed() }
+    composeRule.onNode(isDialog()).assertDoesNotExist()
+  }
+
+  private fun effortSheetSurfaceBounds(dialog: ComponentDialog): Rect =
+    composeRule.runOnIdle {
+      val root = checkNotNull(dialog.window).decorView
+      val bitmap = Bitmap.createBitmap(root.width, root.height, Bitmap.Config.ARGB_8888)
+      try {
+        root.draw(Canvas(bitmap))
+        var left = bitmap.width
+        var top = bitmap.height
+        var right = 0
+        var bottom = 0
+        for (y in 0 until bitmap.height) {
+          for (x in 0 until bitmap.width) {
+            if (bitmap.getPixel(x, y) == renderedSheetColor.toArgb()) {
+              left = minOf(left, x)
+              top = minOf(top, y)
+              right = maxOf(right, x + 1)
+              bottom = maxOf(bottom, y + 1)
+            }
+          }
+        }
+        assertTrue("The actual Thinking Surface must render", right > left && bottom > top)
+        val activityOrigin = IntArray(2).also(chatActivity.window.decorView::getLocationOnScreen)
+        val dialogOrigin = IntArray(2).also(root::getLocationOnScreen)
+        Rect(left, top, right, bottom).apply {
+          offset(dialogOrigin[0] - activityOrigin[0], dialogOrigin[1] - activityOrigin[1])
+        }
+      } finally {
+        bitmap.recycle()
+      }
+    }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun effortOpeningRejectsHeldSliderReleaseAfterUnsafeRecovery() =
+    withEffortRequests { model, requests, release ->
+      val editor = composeRule.onNode(hasSetTextAction())
+      editor.performTextReplacement("retained effort draft")
+      editor.performSemanticsAction(SemanticsActions.SetSelection) { assertTrue(it(3, 8, false)) }
+      val editorId = editor.fetchSemanticsNode().id
+      val old = openEffortSheet()
+      val (x, y, time) = startEffortDrag(old)
+      assertEquals("Preview must not dispatch a request", 0, requests.size)
+      composeRule.mainClock.autoAdvance = false
+      composeRule.runOnUiThread {
+        val deliveries = sheetFeatures.deliveries
+        runBlocking {
+          sheetFeatures.publish(listOf(testFold(Rect(0, 0, 800, 800))))
+          sheetFeatures.publish(emptyList())
+        }
+        assertEquals(deliveries + 2, sheetFeatures.deliveries)
+        assertTrue("Original UP must reach the still-attached A window", old.isShowing)
+        sheetTouch(old, MotionEvent.ACTION_UP, x, y, time, time + 80)
+      }
+      composeRule.mainClock.autoAdvance = true
+      composeRule.waitForIdle()
+      assertEquals("A's recognized drag cannot commit after unsafe-to-safe recovery", 0, requests.size)
+      composeRule.onNode(isDialog()).assertDoesNotExist()
+      editor.assertTextEquals("retained effort draft")
+      assertEquals(editorId, editor.fetchSemanticsNode().id)
+      assertEquals(TextRange(3, 8), editor.fetchSemanticsNode().config[SemanticsProperties.TextSelectionRange])
+
+      val fresh = openEffortSheet()
+      assertNotSame(old.window, fresh.window)
+      composeRule.runOnIdle { runBlocking { sheetFeatures.publish(listOf(testFold(Rect(0, 390, 800, 410)))) } }
+      composeRule.waitForIdle()
+      assertTrue(Rect(0, 0, 800, 390).contains(effortSheetSurfaceBounds(fresh)))
+      val (freshX, freshY, freshTime) = startEffortDrag(fresh)
+      composeRule.runOnUiThread { sheetTouch(fresh, MotionEvent.ACTION_UP, freshX, freshY, freshTime, freshTime + 80) }
+      composeRule.waitUntil { requests.size == 1 }
+      assertEquals(JsonPrimitive("high"), requests.single().second["thinkingLevel"])
+      composeRule.runOnIdle { release.complete(Unit) }
+      composeRule.waitUntil { model.chatThinkingLevel.value == "high" }
+      assertTrue("A valid remap and a fresh full gesture retain the opening", fresh.isShowing)
+    }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun effortOpeningBRejectsSavedASelectionAndDismissal() =
+    withEffortRequests { _, requests, _ ->
+      val open =
+        checkNotNull(
+          composeRule
+            .onNodeWithContentDescription(nativeString("Thinking"))
+            .fetchSemanticsNode()
+            .config[SemanticsActions.OnClick]
+            .action,
+        )
+      val old = openEffortSheet()
+      val select = checkNotNull(effortSlider().fetchSemanticsNode().config[SemanticsActions.SetProgress].action)
+      val fast =
+        checkNotNull(
+          composeRule
+            .onNodeWithContentDescription(nativeString("Fast mode"))
+            .fetchSemanticsNode()
+            .config[SemanticsActions.OnClick]
+            .action,
+        )
+      val dismiss =
+        checkNotNull(
+          composeRule
+            .onNode(SemanticsMatcher.keyIsDefined(SemanticsActions.Dismiss))
+            .fetchSemanticsNode()
+            .config[SemanticsActions.Dismiss]
+            .action,
+        )
+      composeRule.mainClock.autoAdvance = false
+      composeRule.runOnUiThread {
+        runBlocking {
+          sheetFeatures.publish(listOf(testFold(Rect(0, 0, 800, 800))))
+          sheetFeatures.publish(emptyList())
+        }
+        assertTrue("B opens before deferred removal of the still-attached A", old.isShowing)
+        assertTrue(open())
+        // Material's saved actions still belong to attached A, never to logical opening B.
+        select(2f)
+        fast()
+        dismiss()
+        old.onBackPressedDispatcher.onBackPressed()
+      }
+      composeRule.mainClock.autoAdvance = true
+      composeRule.waitForIdle()
+      val fresh = checkNotNull(ShadowDialog.getLatestDialog()) as ComponentDialog
+      assertNotSame(old.window, fresh.window)
+      assertEquals(0, requests.size)
+      assertTrue("A's late dismissal cannot close B", fresh.isShowing)
+      assertTrue(fresh === ShadowDialog.getLatestDialog())
+      effortSlider().assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, nativeString("Low")))
+      composeRule.onNodeWithContentDescription(nativeString("Fast mode")).assertIsEnabled().performClick()
+      composeRule.waitUntil { requests.size == 1 }
+      assertEquals(JsonPrimitive(true), requests.single().second["fastMode"])
+    }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun effortOpeningRejectsCommandsAfterComposerOwnerChanges() =
+    withEffortRequests { model, requests, _ ->
+      val owner = model.captureChatShareOwner()
+      openEffortSheet()
+      val select = checkNotNull(effortSlider().fetchSemanticsNode().config[SemanticsActions.SetProgress].action)
+      val fast =
+        checkNotNull(
+          composeRule
+            .onNodeWithContentDescription(nativeString("Fast mode"))
+            .fetchSemanticsNode()
+            .config[SemanticsActions.OnClick]
+            .action,
+        )
+      val other = model.chatSessions.value.first { it.key != controller.sessionKey.value }
+      composeRule.runOnIdle { model.switchChatSession(other.key, other.ownerAgentId) }
+      composeRule.waitUntil { !model.isCurrentChatComposerOwner(owner) }
+      composeRule.runOnUiThread {
+        select(2f)
+        fast()
+      }
+      composeRule.waitForIdle()
+      assertEquals("Old effort actions cannot target either session", 0, requests.size)
+      composeRule.onNode(isDialog()).assertDoesNotExist()
+    }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun effortCommandsRecheckAdminAndFastRunEligibility() =
+    withEffortRequests { model, requests, _ ->
+      openEffortSheet()
+      val select = checkNotNull(effortSlider().fetchSemanticsNode().config[SemanticsActions.SetProgress].action)
+      val fast =
+        checkNotNull(
+          composeRule
+            .onNodeWithContentDescription(nativeString("Fast mode"))
+            .fetchSemanticsNode()
+            .config[SemanticsActions.OnClick]
+            .action,
+        )
+      composeRule.runOnIdle {
+        @Suppress("UNCHECKED_CAST")
+        val pending =
+          ChatController::class.java
+            .getDeclaredField("_pendingRunCount")
+            .apply { isAccessible = true }
+            .get(controller) as MutableStateFlow<Int>
+        pending.value = 1
+      }
+      composeRule.waitUntil { model.pendingRunCount.value > 0 }
+      composeRule.runOnUiThread { fast() }
+      composeRule.waitForIdle()
+      assertEquals("A saved Switch callback must respect a newly active run", 0, requests.size)
+      composeRule.runOnIdle {
+        @Suppress("UNCHECKED_CAST")
+        val scopes =
+          NodeRuntime::class.java
+            .getDeclaredField("_operatorScopes")
+            .apply { isAccessible = true }
+            .get(runtime) as MutableStateFlow<List<String>>
+        scopes.value = listOf("operator.read", "operator.write")
+      }
+      composeRule.waitUntil { "operator.admin" !in model.operatorScopes.value }
+      composeRule.runOnUiThread { select(2f) }
+      composeRule.waitForIdle()
+      assertEquals("Thinking must recheck admin instead of using the old enabled value", 0, requests.size)
+    }
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun effortOpeningPreservesAlreadyAdmittedThinkingEffect() = assertAdmittedEffortEffect(fast = false)
+
+  @Test
+  @Config(qualifiers = "w800dp-h800dp-mdpi")
+  fun effortOpeningPreservesAlreadyAdmittedFastEffect() = assertAdmittedEffortEffect(fast = true)
+
+  private fun assertAdmittedEffortEffect(fast: Boolean) =
+    withEffortRequests { model, requests, release ->
+      val owner = model.captureChatShareOwner()
+      val session = controller.sessionKey.value
+      val old = openEffortSheet()
+      if (fast) {
+        composeRule.onNodeWithContentDescription(nativeString("Fast mode")).assertIsEnabled().performClick()
+      } else {
+        effortSlider().performSemanticsAction(SemanticsActions.SetProgress) { assertTrue(it(2f)) }
+      }
+      composeRule.waitUntil { requests.size == 1 }
+      assertFalse(release.isCompleted)
+      composeRule.runOnUiThread {
+        runBlocking {
+          sheetFeatures.publish(listOf(testFold(Rect(0, 0, 800, 800))))
+          sheetFeatures.publish(emptyList())
+        }
+      }
+      composeRule.waitForIdle()
+      composeRule.onNode(isDialog()).assertDoesNotExist()
+      val fresh = openEffortSheet()
+      assertNotSame(old.window, fresh.window)
+      composeRule.runOnIdle { release.complete(Unit) }
+      composeRule.waitUntil { composeRule.runOnIdle { session !in model.chatPendingSessionSettingsKeys.value } }
+      val (gateway, payload) = requests.single()
+      assertEquals(owner.gatewayStableId, gateway)
+      assertEquals(JsonPrimitive(session), payload["key"])
+      assertEquals(JsonPrimitive(owner.agentId), payload["agentId"])
+      if (fast) {
+        assertEquals(JsonPrimitive(true), payload["fastMode"])
+        assertTrue(
+          model.chatSessions.value
+            .first { it.key == session }
+            .fastMode
+            ?.isEnabled == true,
+        )
+      } else {
+        assertEquals(JsonPrimitive("high"), payload["thinkingLevel"])
+        assertEquals("high", model.chatThinkingLevel.value)
+      }
+      assertTrue("An admitted A request completes without closing or retargeting B", fresh.isShowing)
+    }
+
+  private fun effortSlider() = composeRule.onNode(SemanticsMatcher.keyIsDefined(SemanticsProperties.ProgressBarRangeInfo))
+
+  private fun openEffortSheet(): ComponentDialog {
+    composeRule.onNodeWithContentDescription(nativeString("Thinking")).performClick()
+    composeRule.waitForIdle()
+    composeRule.onNodeWithText(nativeString("Effort")).assertIsDisplayed()
+    return checkNotNull(ShadowDialog.getLatestDialog()) as ComponentDialog
+  }
+
+  private fun startEffortDrag(dialog: ComponentDialog): Triple<Float, Float, Long> {
+    val slider = effortSlider().assertIsEnabled().assertIsDisplayed()
+    val bounds = slider.getUnclippedBoundsInRoot()
+    val x = bounds.right.value - 8f
+    val y = (bounds.top.value + bounds.bottom.value) / 2f
+    val time = SystemClock.uptimeMillis()
+    composeRule.runOnUiThread {
+      assertTrue("The real slider must receive DOWN", sheetTouch(dialog, MotionEvent.ACTION_DOWN, (bounds.left.value + bounds.right.value) / 2f, y, time, time))
+      sheetTouch(dialog, MotionEvent.ACTION_MOVE, x, y, time, time + 32)
+      sheetTouch(dialog, MotionEvent.ACTION_MOVE, x, y, time, time + 48)
+    }
+    composeRule.waitForIdle()
+    slider.assert(SemanticsMatcher.expectValue(SemanticsProperties.StateDescription, nativeString("High")))
+    return Triple(x, y, time)
+  }
+
+  private fun withEffortRequests(
+    assertions: (MainViewModel, ConcurrentLinkedQueue<Pair<String, JsonObject>>, CompletableDeferred<Unit>) -> Unit,
+  ) {
+    prefs.gatewayRegistry.upsert(
+      GatewayRegistryEntry(stableId = AndroidScreenshotFixture.gatewayId, kind = GatewayRegistryEntryKind.MANUAL, name = "Test gateway"),
+    )
+    prefs.gatewayRegistry.setActive(AndroidScreenshotFixture.gatewayId)
+    val model = showChat(viewportWidth = 720.dp, viewportHeight = { 720.dp })
+    composeRule.runOnIdle {
+      controller.handleGatewayEvent(
+        "agent",
+        """{"sessionKey":"${controller.sessionKey.value}","runId":"android-screenshot-active-run","seq":1,"stream":"lifecycle","data":{"phase":"end"}}""",
+      )
+      controller.handleGatewayEvent(
+        "sessions.changed",
+        """{"session":{"key":"${controller.sessionKey.value}","thinkingLevel":"low","thinkingLevels":[{"id":"off","label":"off"},{"id":"low","label":"low"},{"id":"high","label":"high"}],"fastMode":false}}""",
+      )
+    }
+    composeRule.waitUntil { model.pendingRunCount.value == 0 && model.chatThinkingLevelSelection.value.options.size == 3 }
+    val requests = ConcurrentLinkedQueue<Pair<String, JsonObject>>()
+    val release = CompletableDeferred<Unit>()
+    val field = ChatController::class.java.getDeclaredField("captureRequestLease").apply { isAccessible = true }
+
+    @Suppress("UNCHECKED_CAST")
+    val original = field.get(controller) as (ChatCacheScope?) -> GatewaySession.RequestLease?
+    val capture: (ChatCacheScope?) -> GatewaySession.RequestLease? = { scope ->
+      original(scope)?.let { lease ->
+        GatewaySession.RequestLease(
+          endpointStableId = lease.endpointStableId,
+          isCurrentImpl = lease::isCurrent,
+          commitIfCurrentImpl = lease::commitIfCurrent,
+        ) { method, params, timeout, withEnqueue ->
+          if (method == "sessions.patch") {
+            val payload = Json.parseToJsonElement(checkNotNull(params)).jsonObject
+            withEnqueue { requests.add(lease.endpointStableId to payload) }
+            release.await()
+            buildJsonObject { put("entry", payload) }.toString()
+          } else {
+            lease.request(method, params, timeout, withEnqueue)
+          }
+        }
+      }
+    }
+    try {
+      field.set(controller, capture)
+      assertions(model, requests, release)
+    } finally {
+      composeRule.mainClock.autoAdvance = true
+      release.complete(Unit)
+      field.set(controller, original)
+    }
   }
 
   @Test
@@ -2958,6 +3318,7 @@ class ChatComposerLayoutTest {
         CompositionLocalProvider(LocalLayoutDirection provides layoutDirection()) {
           ClawDesignTheme {
             renderedCanvasColor = ClawTheme.colors.canvas
+            renderedSheetColor = ClawTheme.colors.surface
             renderedDensity = LocalDensity.current
             Box(if (displayFeatures != null) Modifier.fillMaxSize() else Modifier, contentAlignment = AbsoluteAlignment.TopLeft) {
               // The default viewport models a portrait phone after its IME opens.


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/issues/140708

## What Problem This Solves

Fixes an issue where users adjusting Thinking or Fast mode see the sheet cross
a fold separator. Input that began before the sheet became unsafe could also
commit after the layout recovered or the originating conversation changed.

## Why This Change Was Made

Reuse the existing native sheet geometry and immutable opening owner for the
Thinking sheet. Valid geometry changes retain the opening; unsafe geometry or
a changed conversation retires it until the user explicitly reopens it.

Thinking and Fast mode recheck their own current eligibility immediately before
dispatch. A retired opening cannot write settings or dismiss its replacement,
while a request admitted before retirement still completes under the controller's
existing ownership. Material continues to own slider, Switch, keyboard, and
accessibility interaction.

## User Impact

Thinking controls stay in a usable fold pane without resetting the underlying
draft. Late input cannot modify a replacement conversation. This extends the
existing Model/Permissions sheet adaptation; Background Tasks and branch
switching remain separate work.

## Evidence

- Original-code failures reproduce painted sheet bounds crossing the safe pane,
  a recognized held slider release writing after unsafe-to-safe recovery, and
  stale opening callbacks.
- 81 focused composer, model-picker, and sheet tests pass, including successful
  reopened actions and already-admitted Thinking/Fast requests.
- Android `lintPlayDebug`, the actual scoped `check:changed`, and the debug APK
  build pass. The archived APK is bound to the reviewed source.
- Independent P0-P2 review found no actionable issues.
- Native fold-emulator before/after captures show the original sheet crossing
  the book separator and the candidate staying within the book and tabletop
  panes. Runtime receipts retain the same modal and Activity across rotation.
- Native Back returns to Gboard and the retained draft; appending without
  retapping changes `Thinking draft retained` to
  `Thinking draft retained resumed`, with the caret moving from 23 to 31.

## Native Examples

All transcript and status content below is synthetic fixture data. The baseline
matches the affected Thinking and geometry owners, not the entire app tree.
Book uses rotation 0; tabletop uses rotation 3. The platform fold resource
supplies the separator coordinate, not a captured app `WindowLayoutInfo` event.

**Before: Thinking crosses the book separator.**

![Original Thinking sheet crosses the book fold](https://github.com/user-attachments/assets/caef111d-e15c-401a-a993-2b95f8d1857c)

**After: Thinking stays within the left book pane.**

![Thinking sheet contained in the left book pane](https://github.com/user-attachments/assets/94bdd06c-12bc-4039-89cf-32e8328180d6)

**After rotation: the same opening stays above the tabletop separator.**

![Thinking sheet contained above the tabletop fold](https://github.com/user-attachments/assets/7966e335-2aae-4fcc-9959-6275e701b6da)

**After native Back: retained draft, end caret, and Gboard.**

![Retained draft after Back and continued typing](https://github.com/user-attachments/assets/27d21d67-20eb-4169-b599-a0d12bcb7ea8)

## Limits

The native screenshot fixture does not implement `sessions.patch`. Native
successful settings writes and held-input effects are not certified by unchanged
fixture values; those effects are covered by the controlled JVM/Material tests.
Native selected-range continuity and unsafe invalidation are also not claimed.
Same-modal identity and no-retap insertion are backed by runtime receipts, not
screenshots alone. Emulator examples are not physical-device certification.
