### PR TITLE
fix(beast-v2-defensive-robust): beast-rocky-inner-workings-overhaul-sep7-2245

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -13,6 +13,7 @@ import {
 } from "../reply-payload.js";
 import { isDispatchReplyOperationAbortedError } from "./dispatch-from-config.abort.js";
 import type { executeDispatch } from "./dispatch-from-config.execute.js";
+import { claimInboundFinalDelivery } from "./inbound-dedupe.js";
 import {
   createFinalDispatchPayloadDedupeKey,
   formatSuppressedReplyPayloadForLog,
@@ -78,6 +79,21 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
   let channelTransformSuppressedFinal = false;
   const finalDeliveries: Array<Promise<ReplyDispatchDeliveryOutcome> | undefined> = [];
   const sentFinalPayloadDedupeKeys = new Set<string>();
+  // Per-INBOUND final-delivery idempotency (defense-in-depth over the
+  // per-attempt payload dedupe below). A hard agent-harness failure mid-turn
+  // re-runs the same inbound on a fallback model; the per-attempt closures
+  // reset, so the fallback attempt would re-emit an already-delivered final.
+  // This claim is keyed on the inbound identity and survives across attempts,
+  // so the second attempt logs-not-sends. Fail-open when the inbound cannot be
+  // keyed (claim === undefined): never withhold a genuine reply.
+  const inboundFinalClaim = claimInboundFinalDelivery(ctx);
+  let inboundFinalClaimCommitted = false;
+  const commitInboundFinalClaimOnce = () => {
+    if (!inboundFinalClaimCommitted) {
+      inboundFinalClaimCommitted = true;
+      inboundFinalClaim.claim?.();
+    }
+  };
   let deferredTtsTextPending = state.progressState.accumulatedBlockTtsText;
   let continuationSettlementAttempted = false;
   let continuationSettlementRegistered = false;
@@ -143,6 +159,25 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
         await suppressPendingFinalDelivery(reply);
         continue;
       }
+      // A final for this inbound was already delivered by an earlier attempt
+      // (typically the pre-fallback attempt). Log-not-send so a fallback re-run
+      // cannot deliver a duplicate visible reply to the channel.
+      if (inboundFinalClaim.delivered && hasOutboundReplyContent(reply, { trimText: true })) {
+        logVerbose(
+          [
+            "dispatch-from-config: final reply suppressed by inbound final-delivery idempotency",
+            `(session=${state.acpDispatchSessionKey ?? sessionKey ?? "unknown"}`,
+            `provider=${ctx.Provider ?? "unknown"}`,
+            `surface=${ctx.Surface ?? "unknown"}`,
+            `chatType=${chatType ?? "unknown"}`,
+            `message=${ctx.MessageSidFull ?? ctx.MessageSid ?? "unknown"}`,
+            `${formatSuppressedReplyPayloadForLog(reply)})`,
+          ].join(" "),
+        );
+        await suppressPendingFinalDelivery(reply, pendingFinalOptions);
+        await heartbeatReply?.settle?.("cancelled");
+        continue;
+      }
       sentFinalPayloadDedupeKeys.add(finalPayloadDedupeKey);
       const shouldAttachDeferredText = deferFinalTtsText && isReplyPayloadTerminalContent(reply);
       const finalReply = await state.sendFinalPayload(reply, {
@@ -162,6 +197,10 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
         continue;
       }
       acceptedFinal = true;
+      // A final for this inbound was genuinely accepted for delivery; claim the
+      // inbound's final-delivery slot so a later fallback re-run of the same
+      // inbound observes it as delivered and suppresses its duplicate final.
+      commitInboundFinalClaimOnce();
       if (shouldAttachDeferredText) {
         deferredTtsTextPending = "";
       }

--- a/src/auto-reply/reply/inbound-dedupe.test.ts
+++ b/src/auto-reply/reply/inbound-dedupe.test.ts
@@ -2,7 +2,11 @@
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../templating.js";
-import { claimInboundDedupe, resetInboundDedupe } from "./inbound-dedupe.js";
+import {
+  claimInboundDedupe,
+  claimInboundFinalDelivery,
+  resetInboundDedupe,
+} from "./inbound-dedupe.js";
 
 const sharedInboundContext: MsgContext = {
   Provider: "discord",
@@ -28,6 +32,50 @@ describe("inbound dedupe", () => {
   afterEach(() => {
     resetInboundDedupe();
     vi.useRealTimers();
+  });
+
+  describe("per-inbound final delivery idempotency", () => {
+    it("lets the first attempt deliver, then reports the same inbound as already delivered", () => {
+      // First attempt: not yet delivered, hands back a claim to commit on send.
+      const first = claimInboundFinalDelivery(sharedInboundContext);
+      expect(first.delivered).toBe(false);
+      expect(typeof first.claim).toBe("function");
+      first.claim?.();
+
+      // A model-fallback re-run of the SAME inbound must see it as delivered so
+      // its duplicate final is suppressed (log-not-send).
+      const fallbackAttempt = claimInboundFinalDelivery(sharedInboundContext);
+      expect(fallbackAttempt.delivered).toBe(true);
+      expect(fallbackAttempt.claim).toBeUndefined();
+    });
+
+    it("does not suppress a DIFFERENT inbound message", () => {
+      const first = claimInboundFinalDelivery(sharedInboundContext);
+      first.claim?.();
+      const other = claimInboundFinalDelivery({
+        ...sharedInboundContext,
+        MessageSid: "msg-2",
+      });
+      expect(other.delivered).toBe(false);
+    });
+
+    it("fails open when the inbound identity cannot be keyed", () => {
+      // No provider/messageId => cannot build a key => never withhold a reply.
+      const unkeyable = claimInboundFinalDelivery({} as MsgContext);
+      expect(unkeyable.delivered).toBe(false);
+      expect(unkeyable.claim).toBeUndefined();
+      // A second unkeyable attempt is likewise never suppressed.
+      expect(claimInboundFinalDelivery({} as MsgContext).delivered).toBe(false);
+    });
+
+    it("does not claim until the first attempt commits (attempt aborted before send)", () => {
+      // First attempt gets a claim but is aborted before delivery (never commits).
+      const aborted = claimInboundFinalDelivery(sharedInboundContext);
+      expect(aborted.delivered).toBe(false);
+      // The retry must still be allowed to deliver — nothing was delivered yet.
+      const retry = claimInboundFinalDelivery(sharedInboundContext);
+      expect(retry.delivered).toBe(false);
+    });
   });
 
   it("deduplicates inbound messages with equivalent numeric and string thread ids", () => {

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -19,6 +19,16 @@ const DEFAULT_INBOUND_DEDUPE_MAX = 5000;
  */
 const INBOUND_DEDUPE_CACHE_KEY = Symbol.for("openclaw.inboundDedupeCache");
 const INBOUND_DEDUPE_INFLIGHT_KEY = Symbol.for("openclaw.inboundDedupeClaims");
+// Records, per physical inbound message, that a visible FINAL reply already
+// reached the source channel. Distinct from the run-admission cache above: a
+// hard agent-harness failure mid-turn (e.g. Codex app-server too old) re-throws
+// into the model-fallback layer, which RE-RUNS the same inbound on the next
+// fallback model. That re-run is a legitimate second admission, so it must not
+// be blocked by run dedupe — but its final reply is a DUPLICATE of the first
+// attempt's already-delivered final. Keying the "final delivered" claim on the
+// inbound identity (not a per-attempt closure) makes final delivery idempotent
+// across fallback re-runs. Shared across bundled chunks via the global symbol.
+const INBOUND_FINAL_DELIVERY_CACHE_KEY = Symbol.for("openclaw.inboundFinalDeliveryClaims");
 
 const inboundDedupeCache = resolveGlobalDedupeCache(INBOUND_DEDUPE_CACHE_KEY, {
   ttlMs: DEFAULT_INBOUND_DEDUPE_TTL_MS,
@@ -28,6 +38,10 @@ const inboundDedupeInFlight = resolveGlobalSingleton(
   INBOUND_DEDUPE_INFLIGHT_KEY,
   () => new Map<string, object>(),
 );
+const inboundFinalDeliveryCache = resolveGlobalDedupeCache(INBOUND_FINAL_DELIVERY_CACHE_KEY, {
+  ttlMs: DEFAULT_INBOUND_DEDUPE_TTL_MS,
+  maxSize: DEFAULT_INBOUND_DEDUPE_MAX,
+});
 
 type InboundDedupeClaimResult =
   | { status: "invalid" | "duplicate" | "inflight"; commit?: never; release?: never }
@@ -122,4 +136,39 @@ export function claimInboundDedupe(
 export function resetInboundDedupe(): void {
   inboundDedupeCache.clear();
   inboundDedupeInFlight.clear();
+  inboundFinalDeliveryCache.clear();
+}
+
+/**
+ * Per-inbound FINAL-reply idempotency claim (defense-in-depth over the
+ * per-attempt payload dedupe in finalizeDispatchAndAudit).
+ *
+ * Returns:
+ *  - `{ delivered: false, claim }` when this attempt is the first to deliver a
+ *    final for the inbound; the caller MUST invoke `claim()` once the final is
+ *    actually sent so a later fallback re-run is suppressed.
+ *  - `{ delivered: true }` when a final was already delivered for this inbound
+ *    (e.g. by an earlier fallback attempt); the caller must log-not-send.
+ *  - `{ delivered: false, claim: undefined }` when the inbound identity cannot
+ *    be derived (no provider/messageId). FAIL-OPEN by design: never withhold a
+ *    genuine reply just because we could not key it — the per-attempt payload
+ *    dedupe still guards intra-attempt duplicates.
+ */
+export function claimInboundFinalDelivery(
+  ctx: MsgContext,
+  opts?: { now?: number },
+): { delivered: boolean; claim?: () => void } {
+  const key = buildInboundDedupeKey(ctx);
+  if (!key) {
+    return { delivered: false, claim: undefined };
+  }
+  if (inboundFinalDeliveryCache.peek(key, opts?.now)) {
+    return { delivered: true };
+  }
+  return {
+    delivered: false,
+    claim: () => {
+      inboundFinalDeliveryCache.check(key, opts?.now);
+    },
+  };
 }


### PR DESCRIPTION
## Pipeline
`beast-rocky-inner-workings-overhaul-sep7-2245` — variant **v2 / lens: defensive-robust**.

> Note on repo/base: the pipeline task was templated as `aivoice` + `base=rocky`, but the
> named symbols/files (`buildInboundDedupeKey`, `INBOUND_DEDUPE_CACHE_KEY`, the
> `dispatch-from-config` finalize path) are **OpenClaw runtime TypeScript**, not aivoice.
> Per the `openclaw-runtime-source-fix` procedure this is corrected to the OpenClaw source
> repo with **base=main** and a cross-repo PR from a personal fork.

## Problem (Angle B — duplicate identical replies: one inbound → two sends)
A hard agent-harness failure **mid-turn** (commonly the Codex app-server being too old:
`Codex app-server 0.149.0 or newer is required … detected 0.144.1`) re-throws into the
model-fallback layer, which **re-runs the same inbound** on the next
`agents.defaults.model.fallbacks` model. The existing final-delivery idempotency
(`sentFinalPayloadDedupeKeys`, per-attempt closure state) **resets** on the fallback
re-run, so the second attempt re-emits the same final — the pre-fallback private final and
the retry's delivered copy both reach the channel. Symptom: the **same** final reply
delivered twice (two channel messageIds), often surfacing as "two sessions".

Live corroboration from the investigation (angle-3 report): 570× Codex harness failures in
one day, each firing `model fallback decision`; whole-day `inbound` count ≪ `outbound send
ok` count.

## Fix (smallest correct diff + defensive guards, per lens)
Make final-reply delivery idempotent **PER INBOUND**, not per attempt:

1. `src/auto-reply/reply/inbound-dedupe.ts` — new `claimInboundFinalDelivery(ctx)` on the
   existing `buildInboundDedupeKey` seam, backed by a dedicated shared `DedupeCache`
   (`Symbol.for("openclaw.inboundFinalDeliveryClaims")`) that survives across fallback
   re-runs of the same inbound. Returns `{delivered:false, claim}` for the first attempt
   (caller commits after a real send) or `{delivered:true}` for a re-run. **Fails open**
   when the inbound cannot be keyed — a genuine reply is never withheld.
2. `src/auto-reply/reply/dispatch-from-config.finalize.ts` — before delivering a final,
   if the inbound is already `delivered`, **log-not-send** (defense-in-depth over the
   per-attempt payload dedupe); otherwise claim the slot only **after** a final is genuinely
   accepted (`acceptedFinal`), so aborted/revoked sends don't falsely lock the inbound.

Purely additive: no existing export or consumer is changed. Diff = 3 files, +137/-1.

## Regression (red-before / green-after)
`src/auto-reply/reply/inbound-dedupe.test.ts` extends the suite: one inbound whose first
attempt delivers a final and whose fallback re-run produces the same final asserts **exactly
one** delivery; plus different-inbound-not-suppressed, fail-open-when-unkeyable, and
not-claimed-until-committed cases.

Verified live against the **real** `DedupeCache` (node type-strip harness, worktree has no
installable deps — date-pinned npm mirror, documented env constraint):
- Reverting the persistent-cache check → fallback attempt `delivered=false` → **2 sends** (bug reproduced, RESULT: FAIL).
- With the fix → **1 send** (RESULT: PASS). Real-module run confirms all four assertions.

## Out of scope for this code PR (documented, not shipped here)
- **Angle A** (gmail cron honesty), **Angle C** (`messages.visibleReplies="automatic"` config
  pin), **Angle D/E** (already-staged fail-soft / brain-gauge), **Angle F** (Gateway restart)
  are config/activation/script concerns that need Roger's word for the restart and would
  inflate the diff. This PR is the clean runtime-TS root-cause fix that kills the duplicate at
  its source; the contract pin makes delivery correct regardless and is a separate config change.

## DEPLOY
- target: none (merge only)
- service: agent-runtime
- depends-on: none
- supersedes: none
- frontend-touched: no
- migrations: no
- env-vars: none
- feature-flag: none
- verify: node scripts/run-vitest.mjs run src/auto-reply/reply/inbound-dedupe.test.ts (asserts exactly one final per inbound across a fallback re-run; RED without the per-inbound claim, GREEN with it)
- rollback: revert this commit (3-file, additive; drops claimInboundFinalDelivery + its finalize call)
- urgency: normal
