### PR TITLE
refactor(clawhub): own skill wire models in protocol

### DIFF
--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -540,6 +540,7 @@ export const SkillsDetailResultSchema = closedObject({
       slug: NonEmptyString,
       displayName: NonEmptyString,
       summary: Type.Optional(Type.String()),
+      icon: Type.Optional(Type.Union([Type.String(), Type.Null()])),
       tags: Type.Optional(Type.Record(NonEmptyString, Type.String())),
       channel: Type.Optional(Type.Union([Type.String(), Type.Null()])),
       isOfficial: Type.Optional(Type.Union([Type.Boolean(), Type.Null()])),

--- a/src/infra/clawhub-skills.ts
+++ b/src/infra/clawhub-skills.ts
@@ -1,3 +1,4 @@
+import type { SkillsDetailResult } from "@openclaw/gateway-protocol";
 // ClawHub skill metadata, trust, install resolution, cards, and telemetry.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -64,36 +65,7 @@ type ClawHubSkillSearchWireEntry = Omit<
   install?: { kind?: string | null; reference?: string | null } | null;
 };
 
-export type ClawHubSkillDetail = {
-  skill: {
-    slug: string;
-    displayName: string;
-    summary?: string;
-    icon?: string | null;
-    tags?: Record<string, string>;
-    channel?: string | null;
-    isOfficial?: boolean | null;
-    createdAt: number;
-    updatedAt: number;
-  } | null;
-  latestVersion?: {
-    version: string;
-    createdAt: number;
-    changelog?: string;
-  } | null;
-  metadata?: {
-    os?: string[] | null;
-    systems?: string[] | null;
-  } | null;
-  owner?: {
-    handle?: string | null;
-    displayName?: string | null;
-    image?: string | null;
-    official?: boolean | null;
-    channel?: string | null;
-    isOfficial?: boolean | null;
-  } | null;
-};
+export type ClawHubSkillDetail = SkillsDetailResult;
 
 export type ClawHubSkillInstallResolutionResponse =
   | {

--- a/ui/src/lib/skills/index.ts
+++ b/ui/src/lib/skills/index.ts
@@ -1,3 +1,4 @@
+import type { SkillsDetailResult, SkillsSecurityVerdictsResult } from "@openclaw/gateway-protocol";
 import { readClawHubTrustErrorDetails } from "../../../../packages/gateway-protocol/src/clawhub-trust-error-details.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
@@ -16,61 +17,8 @@ import {
 } from "./config-mutations.ts";
 import { loadSkillStatusReport } from "./status-report.ts";
 
-export type ClawHubSkillDetail = {
-  skill: {
-    slug: string;
-    displayName: string;
-    summary?: string;
-    icon?: string | null;
-    tags?: Record<string, string>;
-    channel?: string | null;
-    isOfficial?: boolean | null;
-    createdAt: number;
-    updatedAt: number;
-  } | null;
-  latestVersion?: {
-    version: string;
-    createdAt: number;
-    changelog?: string;
-  } | null;
-  metadata?: {
-    os?: string[] | null;
-    systems?: string[] | null;
-  } | null;
-  owner?: {
-    handle?: string | null;
-    displayName?: string | null;
-    image?: string | null;
-    official?: boolean | null;
-    channel?: string | null;
-    isOfficial?: boolean | null;
-  } | null;
-};
-
-export type ClawHubSkillSecurityVerdict = {
-  registry: string;
-  ok: boolean;
-  decision: string;
-  reasons: string[];
-  requestedSlug: string;
-  requestedOwnerHandle?: string;
-  requestedVersion: string;
-  slug?: string | null;
-  version?: string | null;
-  displayName?: string | null;
-  publisherHandle?: string | null;
-  publisherDisplayName?: string | null;
-  createdAt?: number | null;
-  checkedAt?: number | null;
-  skillUrl?: string | null;
-  securityAuditUrl?: string | null;
-  securityStatus?: string | null;
-  securityPassed?: boolean | null;
-  error?: {
-    code?: string;
-    message?: string;
-  };
-};
+export type ClawHubSkillDetail = SkillsDetailResult;
+export type ClawHubSkillSecurityVerdict = SkillsSecurityVerdictsResult["items"][number];
 
 type SkillsState = {
   client: GatewayBrowserClient | null;


### PR DESCRIPTION
## What Problem This Solves

ClawHub skill responses were modeled independently in protocol, runtime, and UI code, allowing their contracts to drift.

## Why This Change Was Made

Use the gateway protocol schemas as the single owner of ClawHub skill wire models and derive runtime and UI consumers from those types. The shared detail schema also models the optional nullable icon field already carried by the runtime.

## User Impact

No behavior change. Maintainers get one authoritative ClawHub wire contract instead of three duplicated model sets.

## Evidence

- 68 focused protocol/runtime/UI tests passed
- Full `pnpm check:changed` passed
- P0–P2 autoreview scoped-clean
- Production diff: +6/−85 (net −79)