### PR TITLE
refactor(scripts): test default HTML response cap

### DIFF
--- a/scripts/firecrawl-compare.ts
+++ b/scripts/firecrawl-compare.ts
@@ -24,11 +24,6 @@ const userAgent =
 const timeoutMs = 30_000;
 const FETCH_HTML_MAX_BYTES = 5 * 1024 * 1024;
 
-type FetchHtmlOptions = {
-  fetchImpl?: typeof fetch;
-  maxBytes?: number;
-};
-
 function truncate(value: string, max = 180): string {
   if (!value) {
     return "";
@@ -38,7 +33,7 @@ function truncate(value: string, max = 180): string {
 
 async function fetchHtml(
   url: string,
-  options: FetchHtmlOptions = {},
+  fetchImpl: typeof fetch = fetch,
 ): Promise<{
   ok: boolean;
   status: number;
@@ -48,7 +43,6 @@ async function fetchHtml(
 }> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
-  const fetchImpl = options.fetchImpl ?? fetch;
   try {
     const res = await fetchImpl(url, {
       method: "GET",
@@ -56,12 +50,9 @@ async function fetchHtml(
       signal: controller.signal,
     });
     const contentType = res.headers.get("content-type") ?? "application/octet-stream";
-    const body = await readBoundedResponseText(
-      res,
-      "local HTML fetch",
-      options.maxBytes ?? FETCH_HTML_MAX_BYTES,
-      { signal: controller.signal },
-    );
+    const body = await readBoundedResponseText(res, "local HTML fetch", FETCH_HTML_MAX_BYTES, {
+      signal: controller.signal,
+    });
     return {
       ok: res.ok,
       status: res.status,

--- a/test/scripts/firecrawl-compare.test.ts
+++ b/test/scripts/firecrawl-compare.test.ts
@@ -2,22 +2,22 @@
 import { describe, expect, it } from "vitest";
 import { testing as firecrawlCompareTesting } from "../../scripts/firecrawl-compare.ts";
 
+const HTML_MAX_BYTES = 5 * 1024 * 1024;
+
 describe("firecrawl-compare", () => {
   it("does not split surrogate pairs when truncating output", () => {
     expect(firecrawlCompareTesting.truncate(`ab🤖cd`, 3)).toBe("ab…");
   });
 
-  it("fetches local HTML under the byte cap", async () => {
-    const result = await firecrawlCompareTesting.fetchHtml("https://example.test/page", {
-      fetchImpl: (() =>
-        Promise.resolve(
-          new Response("<html><body>ok</body></html>", {
-            headers: { "content-type": "text/html" },
-            status: 200,
-          }),
-        )) as typeof fetch,
-      maxBytes: 1024,
-    });
+  it("fetches local HTML under the default byte cap", async () => {
+    const result = await firecrawlCompareTesting.fetchHtml(
+      "https://example.test/page",
+      async () =>
+        new Response("<html><body>ok</body></html>", {
+          headers: { "content-type": "text/html" },
+          status: 200,
+        }),
+    );
 
     expect(result).toMatchObject({
       body: "<html><body>ok</body></html>",
@@ -27,25 +27,26 @@ describe("firecrawl-compare", () => {
     });
   });
 
-  it("rejects local HTML bodies that exceed declared content-length", async () => {
+  it("rejects declared local HTML sizes above the default byte cap", async () => {
     await expect(
-      firecrawlCompareTesting.fetchHtml("https://example.test/huge", {
-        fetchImpl: (() =>
-          Promise.resolve(
-            new Response("<html></html>", {
-              headers: { "content-length": "1025", "content-type": "text/html" },
-            }),
-          )) as typeof fetch,
-        maxBytes: 1024,
-      }),
-    ).rejects.toThrow("local HTML fetch response body exceeded 1024 bytes");
+      firecrawlCompareTesting.fetchHtml(
+        "https://example.test/huge",
+        async () =>
+          new Response("<html></html>", {
+            headers: {
+              "content-length": String(HTML_MAX_BYTES + 1),
+              "content-type": "text/html",
+            },
+          }),
+      ),
+    ).rejects.toThrow(`local HTML fetch response body exceeded ${HTML_MAX_BYTES} bytes`);
   });
 
-  it("rejects local HTML bodies that exceed the stream byte cap", async () => {
+  it("rejects streamed local HTML above the default byte cap", async () => {
     const response = new Response(
       new ReadableStream({
         start(controller) {
-          controller.enqueue(new Uint8Array(1025));
+          controller.enqueue(new Uint8Array(HTML_MAX_BYTES + 1));
           controller.close();
         },
       }),
@@ -53,10 +54,7 @@ describe("firecrawl-compare", () => {
     );
 
     await expect(
-      firecrawlCompareTesting.fetchHtml("https://example.test/stream", {
-        fetchImpl: (() => Promise.resolve(response)) as typeof fetch,
-        maxBytes: 1024,
-      }),
-    ).rejects.toThrow("local HTML fetch response body exceeded 1024 bytes");
+      firecrawlCompareTesting.fetchHtml("https://example.test/stream", async () => response),
+    ).rejects.toThrow(`local HTML fetch response body exceeded ${HTML_MAX_BYTES} bytes`);
   });
 });


### PR DESCRIPTION
## What Problem This Solves

The HTML comparison script's tests supplied a private 1 KiB override, so they did not exercise its real 5 MiB response limit. Changing that default could leave every test green.

## Why This Change Was Made

Remove the test-only byte-limit override and its options bag. Tests inject fetch directly and check the fixed default using an independent 5 MiB expectation. The shared bounded reader, abort timer, CLI URL arguments, vendor comparison path, and UTF-16 output handling remain unchanged.

## User Impact

The operational default remains 5 MiB. The tests now detect drift in that default. All four script cases remain, with three titles clarified, alongside the unchanged shared reader coverage. Tooling shrinks by nine lines and tests by two.

## Evidence

- Baseline script and shared-reader suites: 15 passed.
- Change only the production default to 6 MiB: old tests still pass all four cases; new tests fail exactly the declared-size and streamed-overflow cases, while two other cases pass.
- Restore the correct candidate: all 15 cases pass. The subsequent formatter change only reflows one reader call; that whitespace-only equivalence was verified separately.
- Independent Codex review through P2 is clean, and scoped formatting/diff checks passed.
- All 19 normal changed-file checks passed on the final formatted source, including script/root-test types and scoped lint ([Linux Testbox run](https://github.com/openclaw/openclaw/actions/runs/34189307023)). The one-shot lease and temporary capsule are cleaned up.

All HTML responses in this proof are injected. No live vendor requests were made, and no temporary control change remains.
