### PR TITLE
refactor(agents): derive conversation capability profile

### DIFF
--- a/src/agents/conversation-capability-profile.ts
+++ b/src/agents/conversation-capability-profile.ts
@@ -4,7 +4,6 @@
  * new public access-profile config surface.
  */
 import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
-import type { ChatType } from "../channels/chat-type.js";
 import { normalizeChatType } from "../channels/chat-type.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { GroupToolPolicyConfig } from "../config/types.tools.js";
@@ -19,10 +18,7 @@ import {
   resolveTrustedGroupId,
   sessionKeyNamesGroupConversation,
 } from "./agent-tools.policy.js";
-import {
-  resolveRequesterToolPolicies,
-  type RequesterToolPolicySource,
-} from "./requester-tool-policy.js";
+import { resolveRequesterToolPolicies } from "./requester-tool-policy.js";
 import { pickSandboxToolPolicy } from "./sandbox-tool-policy.js";
 import type { SandboxToolPolicy } from "./sandbox/types.js";
 import type { ScheduledToolPolicyContext } from "./scheduled-tool-policy.js";
@@ -34,7 +30,6 @@ import {
   collectExplicitDenylist,
   mergeAlsoAllowPolicy,
   resolveToolProfilePolicy,
-  type ToolPolicyLike,
 } from "./tool-policy.js";
 import { resolveWorkspaceRoot } from "./workspace-dir.js";
 
@@ -112,107 +107,7 @@ export type ConversationCapabilityProfileParams = {
   scheduledToolPolicy?: ScheduledToolPolicyContext;
 };
 
-export type ResolvedConversationCapabilityProfile = {
-  agentId?: string;
-  serviceIdentity: {
-    agentId?: string;
-    agentDir?: string;
-    accountId?: string | null;
-    runId?: string;
-    sessionId?: string;
-  };
-  model: {
-    provider?: string;
-    id?: string;
-    api?: string;
-    contextWindowTokens?: number;
-    hasVision?: boolean;
-  };
-  conversation: {
-    scope: ConversationCapabilityScope;
-    chatType?: ChatType;
-    sessionKey?: string;
-    policySessionKey?: string;
-    runSessionKey?: string;
-    sessionId?: string;
-    messageProvider?: string | null;
-    messageChannel?: string | null;
-    messageTo?: string | null;
-    messageThreadId?: string | number | null;
-    currentChannelId?: string | null;
-    currentMessagingTarget?: string | null;
-    currentThreadTs?: string | null;
-    currentMessageId?: string | number | null;
-    groupId?: string | null;
-    groupChannel?: string | null;
-    groupSpace?: string | null;
-    memberRoleIds?: readonly string[];
-    spawnedBy?: string | null;
-  };
-  sender: {
-    id?: string | null;
-    name?: string | null;
-    username?: string | null;
-    e164?: string | null;
-    isOwner?: boolean;
-  };
-  workspace: {
-    workspaceDir?: string;
-    cwd?: string;
-    spawnWorkspaceDir?: string;
-    workspaceRoot: string;
-    runtimeRoot: string;
-    spawnWorkspaceRoot?: string;
-    instructionRoot?: string;
-    isCanonicalWorkspace?: boolean;
-  };
-  instructions: {
-    agentDir?: string;
-    workspaceDir?: string;
-    promptMode?: PromptMode;
-    isCanonicalWorkspace?: boolean;
-  };
-  skills: {
-    snapshot?: SkillSnapshot;
-  };
-  policy: {
-    agentId?: string;
-    sessionKey?: string;
-    subagentSessionKey?: string;
-    trustedGroup: {
-      groupId: string | null | undefined;
-      dropped: boolean;
-    };
-    profile?: string;
-    providerProfile?: string;
-    profilePolicy?: ToolPolicyLike;
-    providerProfilePolicy?: ToolPolicyLike;
-    profileAlsoAllow?: string[];
-    providerProfileAlsoAllow?: string[];
-    globalPolicy?: SandboxToolPolicy;
-    globalProviderPolicy?: SandboxToolPolicy;
-    agentPolicy?: SandboxToolPolicy;
-    agentProviderPolicy?: SandboxToolPolicy;
-    groupPolicy?: SandboxToolPolicy;
-    senderPolicy?: SandboxToolPolicy;
-    sandboxPolicy?: SandboxToolPolicy;
-    subagentPolicy?: SandboxToolPolicy;
-    inheritedToolPolicy?: SandboxToolPolicy;
-    delegated: boolean;
-    requesterPolicySource: RequesterToolPolicySource;
-    runtimeToolPolicyForInheritance?: ToolPolicyLike;
-    inheritancePolicies: Array<ToolPolicyLike | undefined>;
-    explicitToolAllowlist: string[];
-    /** Explicit config/runtime grants only; excludes built-in profile expansion. */
-    explicitToolOverrideAllowlist: string[];
-    explicitToolDenylist: string[];
-    runtimePluginToolGrant?: RuntimePluginToolGrant;
-  };
-};
-
-export function resolveConversationCapabilityProfile(
-  params: ConversationCapabilityProfileParams,
-): ResolvedConversationCapabilityProfile {
+export function resolveConversationCapabilityProfile(params: ConversationCapabilityProfileParams) {
   const messageProvider = params.messageProvider;
   const effective = resolveEffectiveToolPolicy({
     config: params.config,
@@ -415,6 +310,10 @@ export function resolveConversationCapabilityProfile(
     },
   };
 }
+
+export type ResolvedConversationCapabilityProfile = ReturnType<
+  typeof resolveConversationCapabilityProfile
+>;
 
 function resolveConversationScope(params: {
   chatType?: string;

--- a/src/agents/requester-tool-policy.ts
+++ b/src/agents/requester-tool-policy.ts
@@ -27,10 +27,7 @@ import {
 
 const MAX_DELEGATION_LINEAGE_DEPTH = 32;
 
-export type RequesterToolPolicySource =
-  | "current-request"
-  | "persisted-child"
-  | "completion-handoff";
+type RequesterToolPolicySource = "current-request" | "persisted-child" | "completion-handoff";
 
 type RequesterToolPolicyResolution = {
   delegated: boolean;


### PR DESCRIPTION
## What Problem This Solves

Conversation capability resolution maintained a 97-line result interface separately from the function that constructs every returned field, allowing the two to drift.

## Why This Change Was Made

Make the resolver the contract owner and derive its exported result type from the producer. The cleanup also makes its now-internal requester-policy source type private.

## User Impact

No runtime behavior change. Capability additions and removals can no longer silently diverge from a hand-maintained parallel result model.

## Evidence

- Full `pnpm check:changed` passed
- P0–P2 autoreview scoped-clean
- Production diff: +7/−111 (net −104)