### PR TITLE
fix(memory): recover searches after manager replacement

### DIFF
--- a/extensions/memory-core/src/memory-search-tool-query.ts
+++ b/extensions/memory-core/src/memory-search-tool-query.ts
@@ -63,7 +63,7 @@ function isClosedMemoryStoreError(error: unknown): boolean {
     message.includes("database is not open") ||
     message.includes("database connection is not open") ||
     message.includes("database handle is closed") ||
-    message.includes("memory search manager is closed")
+    message.includes("memory index manager is closed")
   );
 }
 
@@ -93,6 +93,7 @@ export async function executeMemorySearchToolQuery(params: {
           ? query.indexedSources
           : query.defaultSources
         : undefined);
+  const queryContext = { query, visibility, searchSources, startedAt };
 
   const searchOnce = async () => {
     const allowedSources = searchSources ? new Set(searchSources) : undefined;
@@ -132,11 +133,8 @@ export async function executeMemorySearchToolQuery(params: {
             void finalizeMemorySearchToolQuery({
               active,
               searched: { candidates: memoryCandidates, searchWindow },
-              query,
-              visibility,
-              searchSources,
+              ...queryContext,
               runtimeDebug: [...runtimeDebug],
-              startedAt,
               effectiveMode: "keyword-only",
             }).then(
               (result) => {
@@ -150,7 +148,7 @@ export async function executeMemorySearchToolQuery(params: {
         : undefined,
       ...(searchSources ? { sources: searchSources } : {}),
     });
-    return { candidates, searchWindow };
+    return { searched: { candidates, searchWindow }, status: active.manager.status() };
   };
 
   let searched: Awaited<ReturnType<typeof searchOnce>>;
@@ -174,17 +172,15 @@ export async function executeMemorySearchToolQuery(params: {
 
   return await finalizeMemorySearchToolQuery({
     active,
-    searched,
-    query,
-    visibility,
-    searchSources,
+    ...searched,
+    ...queryContext,
     runtimeDebug,
-    startedAt,
   });
 }
 
 async function finalizeMemorySearchToolQuery(params: {
   active: ManagerState;
+  status?: MemoryProviderStatus;
   searched: { candidates: MemorySearchResult[]; searchWindow: number };
   query: MemorySearchToolQuery;
   visibility: MemorySearchToolVisibility;
@@ -194,7 +190,7 @@ async function finalizeMemorySearchToolQuery(params: {
   effectiveMode?: string;
 }) {
   const { active, searched, query, visibility, searchSources, runtimeDebug, startedAt } = params;
-  const status = active.manager.status();
+  const status = params.status ?? active.manager.status();
   const pausedIndexIdentity = resolveMemoryIndexIdentityDiagnostic(status);
   if (pausedIndexIdentity) {
     return {
@@ -225,7 +221,6 @@ async function finalizeMemorySearchToolQuery(params: {
     filtered = filtered.filter((hit) => hit.source === "memory");
   }
 
-  const postFilterHits = filtered.length;
   const rawResults = filtered.slice(0, query.resultLimit);
   const latestDebug = runtimeDebug.at(-1);
   return {
@@ -245,7 +240,7 @@ async function finalizeMemorySearchToolQuery(params: {
         ?.embeddingBootstrap,
       hits: rawResults.length,
       candidateHits: searched.candidates.length,
-      withheldHits: Math.max(0, searched.candidates.length - postFilterHits),
+      withheldHits: Math.max(0, searched.candidates.length - filtered.length),
       searchWindow: searched.searchWindow,
     },
   };

--- a/extensions/memory-core/src/memory/manager.ts
+++ b/extensions/memory-core/src/memory/manager.ts
@@ -499,6 +499,9 @@ export class MemoryIndexManager extends MemorySearchOrchestration implements Mem
   }
 
   status(): MemoryProviderStatus {
+    if (this.closing || this.closed) {
+      throw new Error("Memory index manager is closed");
+    }
     return this.withPublishedDatabase(() => this.publishedStatus());
   }
 

--- a/extensions/memory-core/src/tools.real-manager.test.ts
+++ b/extensions/memory-core/src/tools.real-manager.test.ts
@@ -178,6 +178,56 @@ describe("memory_search real manager", () => {
     }
   });
 
+  it.each(["before", "after"] as const)(
+    "recovers when the memory manager closes %s retrieval without rebuilding its index",
+    async (closeAt) => {
+      const cfg = fixture.createConfig({ vectorEnabled: false, minScore: 0 });
+      const manager = await fixture.getFreshManager(cfg);
+      await manager.sync({ reason: "cli", force: true });
+      const db = openOpenClawAgentDatabase({ agentId: "main" }).db;
+      const embeddingCalls = fixture.provider.embedBatchCalls;
+      const search = manager.search.bind(manager);
+      const close = async () => {
+        await manager.close();
+        expect(db.isOpen).toBe(true);
+        expect(db.prepare("SELECT 1 FROM memory_index_chunks LIMIT 1").get()).toBeDefined();
+      };
+      const searchSpy = vi.spyOn(manager, "search").mockImplementationOnce(async (...args) => {
+        if (closeAt === "before") {
+          await close();
+        }
+        const results = await search(...args);
+        if (closeAt === "after") {
+          await close();
+        }
+        return results;
+      });
+      const getSpy = vi.spyOn(MemoryIndexManager, "get");
+      try {
+        const tool = createMemorySearchTool({ config: cfg, agentId: "main" });
+        if (!tool) {
+          throw new Error("memory_search tool missing");
+        }
+        const result = await tool.execute("closed-memory-manager", {
+          query: "alpha",
+          corpus: "memory",
+        });
+        expect(result.details).not.toHaveProperty("error");
+        expect(result.details).toMatchObject({
+          results: [expect.objectContaining({ path: "memory/2026-01-12.md" })],
+        });
+        expect(result.details).not.toHaveProperty("unavailable");
+        expect(fixture.provider.embedBatchCalls).toBe(embeddingCalls);
+        expect(
+          getSpy.mock.calls.filter(([params]) => (params.purpose ?? "default") === "default"),
+        ).toHaveLength(2);
+      } finally {
+        getSpy.mockRestore();
+        searchSpy.mockRestore();
+      }
+    },
+  );
+
   it("attributes a persisted provenance mismatch to OpenClaw", async () => {
     const cfg = fixture.createConfig({
       provider: "none",
@@ -249,6 +299,7 @@ describe("memory_search real manager", () => {
       expect(primary.details).toMatchObject({
         disabled: true,
         unavailable: true,
+        error: "index was built for model old-embed, expected new-embed",
         action,
       });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users searching memories receive “Memory Search failed” and misleading index-rebuild guidance when the memory manager closes or is replaced during retrieval. A valid semantic index could be reported as incompatible with keyword-only search.

## Why This Change Was Made

A retired memory manager can still read its shared SQLite connection after its embedding provider has closed. Status now rejects retired managers, and the tool captures post-search status inside its existing single-reacquisition boundary before finalizing results. The recovery matcher now recognizes the manager's actual closed error. Shared query context and removal of a redundant intermediate value keep the production diff at **−2 lines**.

## User Impact

Memory searches recover from manager replacement without rebuilding a healthy index. Genuine embedding-model mismatches still return their diagnostic and repair guidance. The existing public search API and visibility filtering are preserved.

## Evidence

- Before the fix, both real-manager regression cases failed: closing before retrieval returned “Memory index manager is closed”; closing after retrieval returned “index was built for model mock-embed, expected fts-only”. Both use real manager teardown while confirming shared SQLite remains readable.
- After the fix, all **67 tests** passed across the tool, real-manager integration, and provider-lifecycle suites. Recovery reacquires once and makes no indexing-embedding calls; the genuine model-change control still fails correctly.
- Independent autoreview through P2: scoped-clean, no actionable findings.
- Live tool proof passed on Linux/Node 24.19.0 with real OpenAI `text-embedding-3-small`: one synthetic file/chunk and a complete 1536-dimensional vector index; real search followed by real manager teardown; the tool reacquired and returned the match while shared SQLite stayed open. A SHA-256 comparison of every chunk row plus index metadata was unchanged. A true change to `text-embedding-3-large` remained unavailable without changing the index. [Blacksmith Testbox run](https://github.com/openclaw/openclaw/actions/runs/34189812188).
- `check:changed` passed on Blacksmith Testbox (Linux/Node 24.19.0), including production/test typechecks, lint, formatting, plugin boundaries, and runtime import-cycle checks: [run](https://github.com/openclaw/openclaw/actions/runs/34189874690). Delegated command exit codes were zero; stopped Testbox workflows may display cancelled after lease cleanup.
