### PR TITLE
refactor(hooks): derive canonical inbound projection

### DIFF
--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -120,6 +120,27 @@ describe("message hook mappers", () => {
     );
   });
 
+  it("preserves producer enrichment and minimal mapper input compatibility", () => {
+    const derived = deriveInboundMessageHookContext(makeInboundCtx());
+    derived.runId = "run-1";
+    derived.trace = {
+      traceId: "11111111111111111111111111111111",
+      spanId: "2222222222222222",
+    };
+    derived.callDepth = 2;
+    derived.mediaStagingPending = true;
+    derived.originalMedia = [];
+
+    expect(
+      toPluginMessageContext({
+        from: "sender",
+        content: "hello",
+        channelId: "demo-chat",
+        isGroup: false,
+      }),
+    ).toMatchObject({ channelId: "demo-chat" });
+  });
+
   it("derives canonical inbound context with body precedence and group metadata", () => {
     const canonical = deriveInboundMessageHookContext(makeInboundCtx());
 

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -14,6 +14,7 @@ import { normalizeMediaFacts } from "../media/media-facts.js";
 import type {
   PluginHookInboundClaimContext,
   PluginHookInboundClaimEvent,
+  PluginHookInboundMessageMetadata,
   PluginHookMessageContext,
   PluginHookMessageReceivedEvent,
   PluginHookMessageSentEvent,
@@ -27,65 +28,6 @@ import type {
   MessageTranscribedHookContext,
 } from "./internal-hooks.js";
 import { projectMessageHookMediaFacts, type MessageHookMediaFact } from "./message-hook-media.js";
-
-type CanonicalInboundMessageHookContext = {
-  from: string;
-  to?: string;
-  content: string;
-  body?: string;
-  bodyForAgent?: string;
-  transcript?: string;
-  timestamp?: number;
-  channelId: string;
-  accountId?: string;
-  conversationId?: string;
-  sessionKey?: string;
-  agentId?: string;
-  runId?: string;
-  messageId?: string;
-  senderId?: string;
-  senderName?: string;
-  senderUsername?: string;
-  senderE164?: string;
-  replyToId?: string;
-  replyToIdFull?: string;
-  replyToBody?: string;
-  replyToSender?: string;
-  replyToIsQuote?: boolean;
-  provider?: string;
-  surface?: string;
-  threadId?: string | number;
-  threadParentId?: string | number;
-  media?: MessageHookMediaFact[];
-  originalMedia?: MessageHookMediaFact[];
-  // `mediaPath(s)` are files OpenClaw has already staged locally. `mediaUrl(s)`
-  // are provider/media-server references that may not exist on this host.
-  mediaPath?: string;
-  mediaUrl?: string;
-  mediaType?: string;
-  mediaPaths?: string[];
-  mediaUrls?: string[];
-  mediaTypes?: string[];
-  mediaRemoteHost?: string;
-  mediaStagingPending?: boolean;
-  originalMediaPath?: string;
-  originalMediaUrl?: string;
-  originalMediaType?: string;
-  originalMediaPaths?: string[];
-  originalMediaUrls?: string[];
-  originalMediaTypes?: string[];
-  originatingChannel?: string;
-  originatingTo?: string;
-  guildId?: string;
-  channelName?: string;
-  isGroup: boolean;
-  groupId?: string;
-  topicName?: string;
-  location?: PluginHookInboundClaimEvent["location"];
-  providerUpdate?: PluginHookInboundClaimEvent["providerUpdate"];
-  trace?: DiagnosticTraceContext;
-  callDepth?: number;
-};
 
 type CanonicalSentMessageHookContext = {
   to: string;
@@ -138,13 +80,13 @@ function projectHookMediaState(canonical: CanonicalInboundMessageHookContext) {
   };
 }
 
-export function deriveInboundMessageHookContext(
+function deriveInboundMessageHookContextBase(
   ctx: FinalizedMsgContext,
   overrides?: {
     content?: string;
     messageId?: string;
   },
-): CanonicalInboundMessageHookContext {
+) {
   const content =
     overrides?.content ??
     readNonBlankString(ctx.BodyForCommands) ??
@@ -175,7 +117,7 @@ export function deriveInboundMessageHookContext(
     Number.isFinite(ctx.LocationLat) &&
     typeof ctx.LocationLon === "number" &&
     Number.isFinite(ctx.LocationLon);
-  const locationSource =
+  const locationSource: NonNullable<PluginHookInboundClaimEvent["location"]>["source"] =
     ctx.LocationSource === "pin" || ctx.LocationSource === "place" || ctx.LocationSource === "live"
       ? ctx.LocationSource
       : undefined;
@@ -268,6 +210,28 @@ export function deriveInboundMessageHookContext(
         }
       : {}),
   };
+}
+
+type DerivedInboundMessageHookContext = ReturnType<typeof deriveInboundMessageHookContextBase>;
+type CanonicalInboundMessageHookContext = Pick<
+  DerivedInboundMessageHookContext,
+  "from" | "content" | "channelId" | "isGroup"
+> &
+  Partial<DerivedInboundMessageHookContext> &
+  Partial<Pick<PluginHookMessageContext, "runId" | "trace" | "callDepth">> &
+  Partial<PluginHookInboundMessageMetadata> & {
+    originalMedia?: MessageHookMediaFact[];
+    mediaRemoteHost?: string;
+  };
+
+export function deriveInboundMessageHookContext(
+  ctx: FinalizedMsgContext,
+  overrides?: {
+    content?: string;
+    messageId?: string;
+  },
+): CanonicalInboundMessageHookContext {
+  return deriveInboundMessageHookContextBase(ctx, overrides);
 }
 
 export function buildCanonicalSentMessageHookContext(params: {


### PR DESCRIPTION
## What Problem This Solves

Inbound hook projection maintained a 60-line canonical base model separately from the producer and the public hook contracts that own its enrichment fields.

## Why This Change Was Made

Derive the base context from `deriveInboundMessageHookContext` and compose staged-media and trace enrichment from the existing public hook contracts. This preserves the intentional post-derivation enrichment surface without duplicating the producer model.

## User Impact

No runtime behavior change. Inbound hook context evolution now follows its producer and public enrichment owners instead of a third hand-maintained mirror.

## Evidence

- 28 focused hook projection tests passed
- Full `pnpm check:changed` passed
- P0–P2 autoreview scoped-clean
- Production diff: +10/−61 (net −51)