### PR TITLE
fix(models): report hosted catalogs pending a Gateway restart

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -330,6 +330,11 @@ only for providers declared by installed plugin manifests. It cannot supply API
 base URLs or request headers, and a catalog older than the installed release's
 build stamp is ignored.
 
+The Gateway reports when a checked catalog needs a restart to become active,
+including a bundle downloaded by another process. Repeated checks of the same
+source and generation do not repeat the notice. Checking for an update does not
+activate the downloaded rows or prices.
+
 The hosted file is published from the public
 [`openclaw/catalog`](https://github.com/openclaw/catalog) GitHub repository.
 At publish time, it also hydrates model ids and metadata from models.dev for

--- a/src/infra/update-startup.test.ts
+++ b/src/infra/update-startup.test.ts
@@ -5,6 +5,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { getRemoteModelCatalogProviderOverlay } from "../model-catalog/remote-overlay.js";
+import { setRemoteModelCatalogOverlaySourcesForTest } from "../model-catalog/remote-overlay.test-support.js";
 import { writeConfigMachineState } from "../state/config-machine-state-write.js";
 import { readConfigMachineState } from "../state/config-machine-state.js";
 import {
@@ -3006,6 +3008,201 @@ describe("update-startup", () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(refreshRemoteModelCatalogMock).toHaveBeenCalledTimes(2);
     await stop();
+  });
+
+  it.each(["updated", "fresh", "unchanged"] as const)(
+    "announces a pending catalog from another process after a %s check only once",
+    async (status) => {
+      const sourceUrl = "https://catalog.example.test/catalog.json";
+      const cfg: OpenClawConfig = {
+        update: { channel: "extended-stable", checkOnStart: false },
+        models: { catalogRefresh: { url: sourceUrl } },
+      };
+      const bundle = (generatedAt: number, id: string) => ({
+        schemaVersion: 1,
+        sourceCommit: "synthetic-catalog",
+        generatedAt,
+        providers: { anthropic: { models: [{ id }] } },
+      });
+      const stored = {
+        id: 1,
+        bundle_json: JSON.stringify(bundle(200, "startup-model")),
+        generated_at: 200,
+        min_version: null,
+        source_url: sourceUrl,
+        etag: null,
+        last_modified: null,
+        checked_at: Date.now(),
+      };
+      setRemoteModelCatalogOverlaySourcesForTest({
+        bundledGeneratedAt: () => 100,
+        readStoredCatalog: () => stored,
+      });
+      const info = vi.fn();
+      const check = createTestUpdateCheck({ cfg, log: { info }, isNixMode: false });
+      try {
+        expect(getRemoteModelCatalogProviderOverlay(cfg, "anthropic")?.models).toEqual([
+          { id: "startup-model" },
+        ]);
+        stored.bundle_json = JSON.stringify(bundle(300, "downloaded-model"));
+        stored.generated_at = 300;
+        const counts = { providers: 1, models: 1, generatedAt: 300 };
+        refreshRemoteModelCatalogMock.mockResolvedValue(
+          status === "fresh" ? { status, ...counts, nextCheckInMs: 1_000 } : { status, ...counts },
+        );
+        check.start();
+        await vi.advanceTimersByTimeAsync(0);
+        expect(info).toHaveBeenCalledWith(
+          "remote model catalog downloaded; restart the Gateway to apply it",
+          { providers: 1, models: 1, generatedAt: 300 },
+        );
+        await vi.advanceTimersByTimeAsync(status === "fresh" ? 1_000 : 6 * 60 * 60_000);
+        expect(
+          info.mock.calls.filter(([message]) => message.includes("restart the Gateway")),
+        ).toHaveLength(1);
+        expect(getRemoteModelCatalogProviderOverlay(cfg, "anthropic")?.models).toEqual([
+          { id: "startup-model" },
+        ]);
+      } finally {
+        await check.stop();
+        refreshRemoteModelCatalogMock.mockReset().mockResolvedValue({
+          status: "unchanged",
+          providers: 1,
+          models: 1,
+          generatedAt: 1_753_500_000_000,
+        });
+        setRemoteModelCatalogOverlaySourcesForTest();
+      }
+    },
+  );
+
+  it("discards a pending notice when the selected source changes during refresh", async () => {
+    const sourceUrl = "https://catalog.example.test/catalog.json";
+    const cfg: OpenClawConfig = {
+      update: { channel: "extended-stable", checkOnStart: false },
+      models: { catalogRefresh: { url: sourceUrl } },
+    };
+    let stored: ReturnType<
+      typeof import("../model-catalog/remote-store.js").readRemoteModelCatalog
+    > = undefined;
+    setRemoteModelCatalogOverlaySourcesForTest({
+      bundledGeneratedAt: () => 100,
+      readStoredCatalog: () => stored,
+    });
+    expect(getRemoteModelCatalogProviderOverlay(cfg, "anthropic")).toBeUndefined();
+    stored = {
+      id: 1,
+      generated_at: 300,
+      min_version: null,
+      source_url: sourceUrl,
+      etag: null,
+      last_modified: null,
+      checked_at: Date.now(),
+      bundle_json: JSON.stringify({
+        schemaVersion: 1,
+        generatedAt: 300,
+        sourceCommit: "synthetic-catalog",
+        providers: { anthropic: { models: [{ id: "downloaded-model" }] } },
+      }),
+    };
+    const finished = createDeferred<Awaited<ReturnType<typeof refreshRemoteModelCatalogMock>>>();
+    refreshRemoteModelCatalogMock.mockImplementationOnce(() => finished.promise);
+    const info = vi.fn();
+    let currentConfig = cfg;
+    const check = createGatewayUpdateCheck({
+      getConfig: () => currentConfig,
+      log: { info },
+      isNixMode: false,
+    });
+    try {
+      check.start();
+      await vi.advanceTimersByTimeAsync(0);
+      currentConfig = {
+        ...cfg,
+        models: { catalogRefresh: { url: "https://mirror.example.test/catalog.json" } },
+      };
+      finished.resolve({
+        status: "fresh",
+        generatedAt: 300,
+        providers: 1,
+        models: 1,
+        nextCheckInMs: 1_000,
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(info).toHaveBeenCalledWith(
+        "remote model catalog check superseded; deferred to the next check",
+      );
+      expect(info.mock.calls.some(([message]) => message.includes("restart the Gateway"))).toBe(
+        false,
+      );
+    } finally {
+      finished.resolve({ status: "disabled", providers: 0, models: 0 });
+      await check.stop();
+      setRemoteModelCatalogOverlaySourcesForTest();
+    }
+  });
+
+  it("retries failed notice inspection at the remaining fresh-cache interval", async () => {
+    const sourceUrl = "https://catalog.example.test/catalog.json";
+    const cfg: OpenClawConfig = {
+      update: { channel: "extended-stable", checkOnStart: false },
+      models: { catalogRefresh: { url: sourceUrl } },
+    };
+    let stored: ReturnType<
+      typeof import("../model-catalog/remote-store.js").readRemoteModelCatalog
+    > = undefined;
+    setRemoteModelCatalogOverlaySourcesForTest({
+      bundledGeneratedAt: () => 100,
+      readStoredCatalog: () => stored,
+    });
+    expect(getRemoteModelCatalogProviderOverlay(cfg, "anthropic")).toBeUndefined();
+    stored = {
+      id: 1,
+      bundle_json: "{",
+      generated_at: 300,
+      min_version: null,
+      source_url: sourceUrl,
+      etag: null,
+      last_modified: null,
+      checked_at: Date.now(),
+    };
+    refreshRemoteModelCatalogMock.mockResolvedValue({
+      status: "fresh",
+      generatedAt: 300,
+      providers: 1,
+      models: 1,
+      nextCheckInMs: 1_000,
+    });
+    const info = vi.fn();
+    const check = createTestUpdateCheck({ cfg, log: { info }, isNixMode: false });
+    try {
+      check.start();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(info).toHaveBeenCalledWith("remote model catalog check failed", {
+        error: expect.stringContaining("SyntaxError"),
+      });
+      stored.bundle_json = JSON.stringify({
+        schemaVersion: 1,
+        generatedAt: 300,
+        sourceCommit: "synthetic-catalog",
+        providers: { anthropic: { models: [{ id: "downloaded-model" }] } },
+      });
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(info).toHaveBeenCalledWith(
+        "remote model catalog downloaded; restart the Gateway to apply it",
+        { providers: 1, models: 1, generatedAt: 300 },
+      );
+      expect(getRemoteModelCatalogProviderOverlay(cfg, "anthropic")).toBeUndefined();
+    } finally {
+      await check.stop();
+      refreshRemoteModelCatalogMock.mockReset().mockResolvedValue({
+        status: "unchanged",
+        providers: 1,
+        models: 1,
+        generatedAt: 1_753_500_000_000,
+      });
+      setRemoteModelCatalogOverlaySourcesForTest();
+    }
   });
 });
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/src/infra/update-startup.ts
+++ b/src/infra/update-startup.ts
@@ -13,6 +13,8 @@ import type {
 import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
 import { formatCliCommand } from "../cli/command-format.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { resolveRemoteCatalogUrl } from "../model-catalog/remote-config.js";
+import { checkRemoteModelCatalogUpdate } from "../model-catalog/remote-overlay.js";
 import {
   refreshRemoteModelCatalog,
   REMOTE_MODEL_CATALOG_TTL_MS,
@@ -1483,6 +1485,7 @@ export function createGatewayUpdateCheck(params: {
   const lifecycle = createUpdateCheckLifecycle();
   updateCheckLifecycle = lifecycle;
   let started = false;
+  let observedCatalog: { sourceUrl: string; generatedAt: number } | undefined;
   return {
     initialize: lifecycle.initialize,
     stop: lifecycle.stop,
@@ -1500,30 +1503,47 @@ export function createGatewayUpdateCheck(params: {
         return resolveCheckIntervalMs(params.getConfig(), updateScheduleCache?.install?.kind);
       });
       lifecycle.schedule(async () => {
+        let nextCheckInMs = REMOTE_MODEL_CATALOG_TTL_MS;
         try {
+          const config = params.getConfig();
+          const sourceUrl = resolveRemoteCatalogUrl(config);
           const result = await refreshRemoteModelCatalog({
-            config: params.getConfig(),
+            config,
             signal: lifecycle.signal,
           });
           if (lifecycle.signal.aborted) {
             return REMOTE_MODEL_CATALOG_TTL_MS;
           }
+          nextCheckInMs =
+            result.status === "fresh" ? result.nextCheckInMs : REMOTE_MODEL_CATALOG_TTL_MS;
           if (result.status === "error") {
             params.log.info("remote model catalog refresh failed", { error: result.error });
-          } else if (result.status === "updated") {
-            params.log.info("remote model catalog downloaded; restart the Gateway to apply it", {
-              providers: result.providers,
-              models: result.models,
-              generatedAt: result.generatedAt,
-            });
+          } else if (
+            result.status !== "disabled" &&
+            (observedCatalog?.sourceUrl !== sourceUrl ||
+              observedCatalog.generatedAt !== result.generatedAt)
+          ) {
+            const expected = { sourceUrl, generatedAt: result.generatedAt };
+            const state = checkRemoteModelCatalogUpdate(params.getConfig(), expected);
+            if (state !== "superseded") {
+              observedCatalog = expected;
+            }
+            if (state === "restart-required") {
+              params.log.info("remote model catalog downloaded; restart the Gateway to apply it", {
+                providers: result.providers,
+                models: result.models,
+                generatedAt: result.generatedAt,
+              });
+            } else if (state === "superseded") {
+              params.log.info("remote model catalog check superseded; deferred to the next check");
+            }
           }
-          return result.status === "fresh" ? result.nextCheckInMs : REMOTE_MODEL_CATALOG_TTL_MS;
         } catch (error) {
           if (!lifecycle.signal.aborted) {
-            params.log.info("remote model catalog refresh failed", { error: String(error) });
+            params.log.info("remote model catalog check failed", { error: String(error) });
           }
-          return REMOTE_MODEL_CATALOG_TTL_MS;
         }
+        return nextCheckInMs;
       }, true);
     },
   };

--- a/src/model-catalog/remote-overlay.test.ts
+++ b/src/model-catalog/remote-overlay.test.ts
@@ -1,6 +1,8 @@
 import { Worker } from "node:worker_threads";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  captureRemoteModelCatalogStartupSnapshot,
+  checkRemoteModelCatalogUpdate,
   getRemoteModelCatalogPricing,
   getRemoteModelCatalogProviderOverlay,
 } from "./remote-overlay.js";
@@ -37,6 +39,83 @@ afterEach(() => {
 });
 
 describe("remote model catalog overlay", () => {
+  it("inspects pending generations without replacing the startup snapshot, rows, or prices", () => {
+    const sourceUrl = "https://catalog.openclaw.ai/models/v1/catalog.json";
+    const snapshot = captureRemoteModelCatalogStartupSnapshot();
+    const overlay = getRemoteModelCatalogProviderOverlay({}, "anthropic");
+    const pricing = getRemoteModelCatalogPricing({});
+    expect(checkRemoteModelCatalogUpdate({}, { sourceUrl, generatedAt: 200 })).toBe("unchanged");
+    expect(mocks.read).toHaveBeenCalledOnce();
+
+    mocks.read.mockReturnValue({
+      source_url: sourceUrl,
+      bundle_json: JSON.stringify({
+        ...bundle,
+        generatedAt: 300,
+        providers: { anthropic: { models: [{ id: "downloaded" }] } },
+        pricing: { "openai/gpt-external": { input: 5, output: 20 } },
+      }),
+    });
+    expect(checkRemoteModelCatalogUpdate({}, { sourceUrl, generatedAt: 300 })).toBe(
+      "restart-required",
+    );
+    expect(captureRemoteModelCatalogStartupSnapshot()).toBe(snapshot);
+    expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toBe(overlay);
+    expect(getRemoteModelCatalogPricing({})).toBe(pricing);
+  });
+
+  it.each([{ enabled: false }, { url: "https://mirror.example.test/catalog.json" }])(
+    "rejects a check superseded by config %j without reading stored data",
+    (catalogRefresh) => {
+      expect(
+        checkRemoteModelCatalogUpdate(
+          { models: { catalogRefresh } },
+          { sourceUrl: "https://catalog.openclaw.ai/models/v1/catalog.json", generatedAt: 300 },
+        ),
+      ).toBe("superseded");
+      expect(mocks.read).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each([
+    { sourceUrl: "https://mirror.example.test/catalog.json", generatedAt: 300 },
+    { sourceUrl: "https://catalog.openclaw.ai/models/v1/catalog.json", generatedAt: 400 },
+  ])("rejects a stored check superseded by %j", ({ sourceUrl, generatedAt }) => {
+    const snapshot = captureRemoteModelCatalogStartupSnapshot();
+    mocks.read.mockReturnValue({
+      source_url: sourceUrl,
+      bundle_json: JSON.stringify({ ...bundle, generatedAt }),
+    });
+    expect(
+      checkRemoteModelCatalogUpdate(
+        {},
+        {
+          sourceUrl: "https://catalog.openclaw.ai/models/v1/catalog.json",
+          generatedAt: 300,
+        },
+      ),
+    ).toBe("superseded");
+    expect(captureRemoteModelCatalogStartupSnapshot()).toBe(snapshot);
+  });
+
+  it("reports failed inspection without replacing a valid startup snapshot", () => {
+    const snapshot = captureRemoteModelCatalogStartupSnapshot();
+    mocks.read.mockReturnValue({
+      source_url: "https://catalog.openclaw.ai/models/v1/catalog.json",
+      bundle_json: "{",
+    });
+    expect(() =>
+      checkRemoteModelCatalogUpdate(
+        {},
+        {
+          sourceUrl: "https://catalog.openclaw.ai/models/v1/catalog.json",
+          generatedAt: 300,
+        },
+      ),
+    ).toThrow(SyntaxError);
+    expect(captureRemoteModelCatalogStartupSnapshot()).toBe(snapshot);
+  });
+
   it("loads a newer compatible bundle once", () => {
     expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toHaveProperty("models");
     expect(getRemoteModelCatalogProviderOverlay({}, "anthropic")).toHaveProperty("models");

--- a/src/model-catalog/remote-overlay.ts
+++ b/src/model-catalog/remote-overlay.ts
@@ -16,6 +16,7 @@ import { readRemoteModelCatalog } from "./remote-store.js";
 type RemoteModelCatalogOverlay = Readonly<Record<string, ModelCatalogProvider>>;
 type ActiveRemoteModelCatalog = {
   sourceUrl: string;
+  generatedAt: number;
   providers: RemoteModelCatalogOverlay;
   pricing?: Readonly<Record<string, RemoteModelCatalogPricing>>;
 };
@@ -32,28 +33,25 @@ function isCompatible(bundle: RemoteModelCatalogBundle): boolean {
   return comparison !== null && comparison >= 0;
 }
 
-function readStartupSnapshot(): ActiveRemoteModelCatalog | null {
-  try {
-    const bundledGeneratedAt = readBundledGeneratedAt();
-    if (bundledGeneratedAt === undefined) {
-      return null;
-    }
-    const stored = readStoredCatalog();
-    if (!stored) {
-      return null;
-    }
-    const bundle = validateAndSanitizeRemoteModelCatalogBundle(JSON.parse(stored.bundle_json));
-    if (bundle.generatedAt <= bundledGeneratedAt || !isCompatible(bundle)) {
-      return null;
-    }
-    return {
-      sourceUrl: stored.source_url,
-      providers: bundle.providers,
-      ...(bundle.pricing ? { pricing: bundle.pricing } : {}),
-    };
-  } catch {
+function readCompatibleRemoteModelCatalog(): ActiveRemoteModelCatalog | null {
+  const bundledGeneratedAt = readBundledGeneratedAt();
+  if (bundledGeneratedAt === undefined) {
     return null;
   }
+  const stored = readStoredCatalog();
+  if (!stored) {
+    return null;
+  }
+  const bundle = validateAndSanitizeRemoteModelCatalogBundle(JSON.parse(stored.bundle_json));
+  if (bundle.generatedAt <= bundledGeneratedAt || !isCompatible(bundle)) {
+    return null;
+  }
+  return {
+    sourceUrl: stored.source_url,
+    generatedAt: bundle.generatedAt,
+    providers: bundle.providers,
+    ...(bundle.pricing ? { pricing: bundle.pricing } : {}),
+  };
 }
 
 export function captureRemoteModelCatalogStartupSnapshot(): ActiveRemoteModelCatalog | null {
@@ -65,7 +63,12 @@ export function captureRemoteModelCatalogStartupSnapshot(): ActiveRemoteModelCat
     return inherited.catalog;
   }
   // New workers inherit the startup pair, including absence, rather than later downloads.
-  const snapshot = readStartupSnapshot();
+  let snapshot: ActiveRemoteModelCatalog | null;
+  try {
+    snapshot = readCompatibleRemoteModelCatalog();
+  } catch {
+    snapshot = null;
+  }
   setEnvironmentData(STARTUP_SNAPSHOT_KEY, { catalog: snapshot });
   return snapshot;
 }
@@ -76,6 +79,29 @@ function getActiveRemoteModelCatalog(config: OpenClawConfig): ActiveRemoteModelC
   }
   const snapshot = captureRemoteModelCatalogStartupSnapshot();
   return snapshot?.sourceUrl === resolveRemoteCatalogUrl(config) ? snapshot : undefined;
+}
+
+/** Inspects a completed check without activating its download or replacing the startup pair. */
+export function checkRemoteModelCatalogUpdate(
+  config: OpenClawConfig,
+  expected: { sourceUrl: string; generatedAt: number },
+): "restart-required" | "unchanged" | "superseded" {
+  if (
+    !isRemoteModelCatalogRefreshEnabled(config) ||
+    resolveRemoteCatalogUrl(config) !== expected.sourceUrl
+  ) {
+    return "superseded";
+  }
+  if (getActiveRemoteModelCatalog(config)?.generatedAt === expected.generatedAt) {
+    return "unchanged";
+  }
+  const stored = readCompatibleRemoteModelCatalog();
+  if (!stored) {
+    return "unchanged";
+  }
+  return stored.sourceUrl === expected.sourceUrl && stored.generatedAt === expected.generatedAt
+    ? "restart-required"
+    : "superseded";
 }
 
 export function getRemoteModelCatalogProviderOverlay(


### PR DESCRIPTION
## What Problem This Solves

A running Gateway could miss restart guidance when another process downloaded a newer catalog and the next scheduled refresh reported fresh or unchanged.

## Why This Change Was Made

The startup snapshot retains its generation. A read-only check compares completed refresh data with the active snapshot and stored eligible bundle, reporting one notice per source/generation and rejecting superseded results. Failed inspection retains the remaining refresh interval.

## User Impact

Operators receive restart guidance for externally downloaded catalogs without repeated notices. Inspection does not activate new rows or prices; no configuration or persistent state is added.

## Evidence

Matched Gateway and CLI sequences reproduced the missing notice and produced one after the fix while both Gateways stayed healthy. Focused overlay and scheduling tests covered fresh/unchanged results, source races, cancellation, and inspection-error delay. Required CI passed all final controls. These source executions do not establish a newly compiled package or provider inference.
