### PR TITLE
fix(tests): isolate plugin artifact loader fixtures

### DIFF
--- a/src/cli/plugins-feature-artifact.test.ts
+++ b/src/cli/plugins-feature-artifact.test.ts
@@ -254,22 +254,36 @@ export default Object.assign(defineToolPlugin({ id: ${JSON.stringify(id)}, name:
         tools: [{ name: "artifact_echo", optional: true }],
       });
       if (setup) {
-        const setupPath = resolvePackageSetupSource(resolution);
+        // Keep native module caches out of the independent source-loader graph.
+        const sourceExtracted = path.join(parent, "source-extracted");
+        await fs.mkdir(sourceExtracted);
+        await extract({ file: archive, cwd: sourceExtracted, strict: true });
+        const sourcePackageDir = path.join(sourceExtracted, "package");
+        const sourceResolution = {
+          ...resolution,
+          packageDir: sourcePackageDir,
+          sourceLabel: sourcePackageDir,
+        };
+        const [sourceEntryPath] = resolvePackageRuntimeExtensionSources({
+          ...sourceResolution,
+          extensions: manifest.openclaw.extensions,
+        });
+        const setupPath = resolvePackageSetupSource(sourceResolution);
         expect(setupPath).toBeTruthy();
         withPluginCache(createPluginCache(), () => {
           const load = getCachedPluginSourceModuleLoader({
-            modulePath: entryPath!,
-            rootDir: packageDir,
+            modulePath: sourceEntryPath!,
+            rootDir: sourcePackageDir,
             importerUrl: import.meta.url,
             aliasMap: buildPluginLoaderAliasMap(
-              entryPath!,
+              sourceEntryPath!,
               process.argv[1],
               import.meta.url,
               "src",
             ),
             transformOpenClawDependencies: true,
           });
-          expect(load(entryPath!)).toMatchObject({ default: { shared: { ready: true } } });
+          expect(load(sourceEntryPath!)).toMatchObject({ default: { shared: { ready: true } } });
           expect(load(setupPath!)).toMatchObject({
             default: {
               artifactMarker: runtime ? "setup-runtime" : "setup-source",


### PR DESCRIPTION
## What Problem This Solves

Fixes two plugin artifact tests that fail on Linux when setup modules observe uninitialized shared state after the artifact entry has already passed its native-loading checks.

## Why This Change Was Made

Extract the same archive into a separate directory for forced-source loading, following the isolation pattern already used by the neighboring test. Native module caches can otherwise supply the entry while the source loader evaluates setup against a different shared-module instance. Entry and setup still use one source loader and extraction together.

## User Impact

Test-only repair; no plugin runtime behavior changes. Native loading, source entry/setup initialization, metadata and shared-chunk assertions remain intact. The fixture adds 14 net test lines.

## Evidence

- On Linux x64 with Node 24.19.0, the unchanged full suite reproduced 14 passing tests and the same two failures. The isolated patched copy passed all 16 tests with no skips and the same ordered case inventory.
- Local Node 24.20.0: all 16 tests passed after the change.
- Full mapped changed-file checks and independent P2 review passed.

The Linux control and comparison source trees were preserved. No runtime performance claim is made.
