### PR TITLE
test(doctor): compact plugin repair cases

### DIFF
--- a/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
+++ b/src/commands/doctor/shared/missing-configured-plugin-install.test.ts
@@ -3503,85 +3503,30 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     },
   );
 
-  it.each([
-    {
-      name: "stale beta follows newer latest",
-      installedVersion: "2026.9.1-beta.1",
-      betaVersion: "2026.9.1-beta.1",
-      latestVersion: "2026.9.2",
-      selectedVersion: "2026.9.2",
-      refresh: true,
-    },
-    {
-      name: "same-base beta follows newer latest",
-      installedVersion: "2026.9.2-beta.1",
-      betaVersion: "2026.9.2-beta.1",
-      latestVersion: "2026.9.2",
-      selectedVersion: "2026.9.2",
-      refresh: true,
-    },
-    {
-      name: "newer beta stays ahead of latest",
-      installedVersion: "2026.9.1-beta.1",
-      betaVersion: "2026.9.3-beta.1",
-      latestVersion: "2026.9.2",
-      selectedVersion: "2026.9.3-beta.1",
-      refresh: true,
-    },
-    {
-      name: "already-current beta older than the host is a no-op",
-      installedVersion: "2026.9.1-beta.1",
-      betaVersion: "2026.9.1-beta.1",
-      latestVersion: "2026.8.31",
-      selectedVersion: "2026.9.1-beta.1",
-      refresh: false,
-    },
-    {
-      name: "already-current same-base beta is a no-op",
-      installedVersion: "2026.9.2-beta.4",
-      betaVersion: "2026.9.2-beta.4",
-      latestVersion: "2026.9.1",
-      selectedVersion: "2026.9.2-beta.4",
-      refresh: false,
-    },
-    {
-      name: "registry tags behind the installed beta are a no-op",
-      installedVersion: "2026.9.1-beta.2",
-      betaVersion: "2026.9.1-beta.1",
-      latestVersion: "2026.8.31",
-      selectedVersion: "2026.9.1-beta.1",
-      refresh: false,
-    },
-    {
-      name: "registry outage retains a healthy installed beta",
-      installedVersion: "2026.9.1-beta.1",
-      betaVersion: "2026.9.1-beta.1",
-      latestVersion: "2026.9.2",
-      selectedVersion: "2026.9.2",
-      refresh: false,
-      registryUnavailable: true,
-    },
-    {
-      name: "registry outage cannot hide broken package diagnostics",
-      installedVersion: "2026.9.1-beta.1",
-      betaVersion: "2026.9.1-beta.1",
-      latestVersion: "2026.9.2",
-      selectedVersion: "2026.9.2",
-      refresh: false,
-      registryUnavailable: true,
-      brokenPayload: true,
-    },
-  ])(
-    "converges managed Codex startup: $name",
-    async ({
+  it.each(
+    // prettier-ignore
+    [
+    ["stale beta follows newer latest", "2026.9.1-beta.1", "2026.9.1-beta.1", "2026.9.2", "2026.9.2", true, undefined, undefined],
+    ["same-base beta follows newer latest", "2026.9.2-beta.1", "2026.9.2-beta.1", "2026.9.2", "2026.9.2", true, undefined, undefined],
+    ["newer beta stays ahead of latest", "2026.9.1-beta.1", "2026.9.3-beta.1", "2026.9.2", "2026.9.3-beta.1", true, undefined, undefined],
+    ["already-current beta older than the host is a no-op", "2026.9.1-beta.1", "2026.9.1-beta.1", "2026.8.31", "2026.9.1-beta.1", false, undefined, undefined],
+    ["already-current same-base beta is a no-op", "2026.9.2-beta.4", "2026.9.2-beta.4", "2026.9.1", "2026.9.2-beta.4", false, undefined, undefined],
+    ["registry tags behind the installed beta are a no-op", "2026.9.1-beta.2", "2026.9.1-beta.1", "2026.8.31", "2026.9.1-beta.1", false, undefined, undefined],
+    ["registry outage retains a healthy installed beta", "2026.9.1-beta.1", "2026.9.1-beta.1", "2026.9.2", "2026.9.2", false, true, undefined],
+    ["registry outage cannot hide broken package diagnostics", "2026.9.1-beta.1", "2026.9.1-beta.1", "2026.9.2", "2026.9.2", false, true, true],
+  ] as const,
+  )(
+    "converges managed Codex startup: %s",
+    async (
+      _name,
       installedVersion,
       betaVersion,
       latestVersion,
       selectedVersion,
       refresh,
-      registryUnavailable = false,
-      brokenPayload = false,
-    }) => {
+      registryUnavailable: boolean | undefined = false,
+      brokenPayload: boolean | undefined = false,
+    ) => {
       mockNpmRegistryTags({ beta: betaVersion, latest: latestVersion });
       if (registryUnavailable) {
         mocks.resolveNpmSpecMetadata.mockResolvedValue({
@@ -4970,13 +4915,10 @@ describe("repairMissingConfiguredPluginInstalls", () => {
     );
   });
 
-  it.each([
-    {
-      name: "installs missing configured non-channel plugins from the official external catalog",
-      pluginId: "diagnostics-otel",
-      npmSpec: "@openclaw/diagnostics-otel",
-      version: "2026.5.2",
-      entry: {
+  it.each(
+    // prettier-ignore
+    [
+    ["installs missing configured non-channel plugins from the official external catalog", "diagnostics-otel", "@openclaw/diagnostics-otel", "2026.5.2", {
         id: "diagnostics-otel",
         label: "Diagnostics OpenTelemetry",
         install: {
@@ -4984,16 +4926,8 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           npmSpec: "@openclaw/diagnostics-otel",
           defaultChoice: "npm" as const,
         },
-      },
-      cfg: { plugins: { entries: { "diagnostics-otel": { enabled: true } } } },
-      useManifestResolvers: false,
-    },
-    {
-      name: "installs the official llama.cpp plugin for configured local memory embeddings",
-      pluginId: "llama-cpp",
-      npmSpec: "@openclaw/llama-cpp-provider",
-      version: "2026.6.2",
-      entry: {
+      }, { plugins: { entries: { "diagnostics-otel": { enabled: true } } } }, false],
+    ["installs the official llama.cpp plugin for configured local memory embeddings", "llama-cpp", "@openclaw/llama-cpp-provider", "2026.6.2", {
         id: "llama-cpp",
         label: "llama.cpp Provider",
         openclaw: {
@@ -5008,29 +4942,13 @@ describe("repairMissingConfiguredPluginInstalls", () => {
           npmSpec: "@openclaw/llama-cpp-provider",
           defaultChoice: "npm" as const,
         },
-      },
-      cfg: { memory: { search: { provider: "local" } }, agents: { defaults: {} } },
-      useManifestResolvers: false,
-    },
-    {
-      name: "does not let runtime fallback metadata override official catalog install specs",
-      pluginId: "acpx",
-      npmSpec: "@openclaw/acpx",
-      version: "2026.5.2-beta.2",
-      entry: {
+      }, { memory: { search: { provider: "local" } }, agents: { defaults: {} } }, false],
+    ["does not let runtime fallback metadata override official catalog install specs", "acpx", "@openclaw/acpx", "2026.5.2-beta.2", {
         id: "acpx",
         label: "ACPX Runtime",
         install: { npmSpec: "@openclaw/acpx", defaultChoice: "npm" as const },
-      },
-      cfg: { acp: { backend: "acpx" } },
-      useManifestResolvers: false,
-    },
-    {
-      name: "installs a configured external web search plugin from provider-only config",
-      pluginId: "brave",
-      npmSpec: "@openclaw/brave-plugin",
-      version: "2026.5.2",
-      entry: officialWebSearchPluginEntry({
+      }, { acp: { backend: "acpx" } }, false],
+    ["installs a configured external web search plugin from provider-only config", "brave", "@openclaw/brave-plugin", "2026.5.2", officialWebSearchPluginEntry({
         id: "brave",
         npmSpec: "@openclaw/brave-plugin",
         envVar: "BRAVE_API_KEY",
@@ -5038,36 +4956,21 @@ describe("repairMissingConfiguredPluginInstalls", () => {
         providerLabel: "Brave Search",
         credentialPath: "plugins.entries.brave.config.webSearch.apiKey",
         includeManifestInstall: true,
-      }),
-      cfg: { tools: { web: { search: { provider: "brave" } } } },
-      useManifestResolvers: true,
-    },
-    {
-      name: "installs a configured external model provider without an auth choice",
-      pluginId: "groq",
-      npmSpec: "@openclaw/groq-provider",
-      entry: officialPluginEntry({
+      }), { tools: { web: { search: { provider: "brave" } } } }, true],
+    ["installs a configured external model provider without an auth choice", "groq", "@openclaw/groq-provider", undefined, officialPluginEntry({
         id: "groq",
         npmSpec: "@openclaw/groq-provider",
         label: "Groq",
         manifest: { providers: [{ id: "groq" }] },
-      }),
-      cfg: {
+      }), {
         agents: { defaults: { model: "groq/llama-3.3-70b-versatile" } },
-      } satisfies OpenClawConfig,
-      useManifestResolvers: false,
-    },
-    {
-      name: "installs an external media-understanding provider selected only by media config",
-      pluginId: "groq",
-      npmSpec: "@openclaw/groq-provider",
-      entry: officialPluginEntry({
+      } satisfies OpenClawConfig, false],
+    ["installs an external media-understanding provider selected only by media config", "groq", "@openclaw/groq-provider", undefined, officialPluginEntry({
         id: "groq",
         npmSpec: "@openclaw/groq-provider",
         label: "Groq",
         manifest: { contracts: { mediaUnderstandingProviders: ["groq"] } },
-      }),
-      cfg: {
+      }), {
         tools: {
           media: {
             models: [
@@ -5079,25 +4982,17 @@ describe("repairMissingConfiguredPluginInstalls", () => {
             ],
           },
         },
-      } satisfies OpenClawConfig,
-      useManifestResolvers: false,
-    },
-    {
-      name: "installs an external speech provider selected only by voiceModel",
-      pluginId: "gradium",
-      npmSpec: "@openclaw/gradium-speech",
-      entry: officialPluginEntry({
+      } satisfies OpenClawConfig, false],
+    ["installs an external speech provider selected only by voiceModel", "gradium", "@openclaw/gradium-speech", undefined, officialPluginEntry({
         id: "gradium",
         npmSpec: "@openclaw/gradium-speech",
         label: "Gradium",
         manifest: { contracts: { speechProviders: ["gradium"] } },
-      }),
-      cfg: {
+      }), {
         agents: { defaults: { voiceModel: { primary: "gradium/tts-default" } } },
-      } satisfies OpenClawConfig,
-      useManifestResolvers: false,
-    },
-  ])("$name", async ({ pluginId, npmSpec, version, entry, cfg, useManifestResolvers }) => {
+      } satisfies OpenClawConfig, false],
+  ] as const,
+  )("%s", async (_name, pluginId, npmSpec, version, entry, cfg, useManifestResolvers) => {
     mocks.listOfficialExternalPluginCatalogEntries.mockReturnValue([entry]);
     if (useManifestResolvers) {
       useManifestCatalogResolvers();


### PR DESCRIPTION
Compacts the managed Codex beta convergence and official external-plugin repair matrices into positional tuples while preserving defaults and install assertions.\n\nNet: 105 LOC removed.\n\nValidation:\n- 132 focused tests passed\n- pnpm check:changed\n- exact-commit Codex review: no findings