### PR TITLE
fix(release): recognize frozen fs-safe capability

### DIFF
--- a/scripts/resolve-fs-safe-native-contract.mjs
+++ b/scripts/resolve-fs-safe-native-contract.mjs
@@ -5,7 +5,12 @@ const [ref, workflowSha, allowFrozenSource] = process.argv.slice(2);
 const isSha = (value) => /^[0-9a-f]{40}$/u.test(value ?? "");
 const NATIVE_MARKER =
   /\b(?:configureFsSafeNative|getFsSafeNativeConfig|getNativeBinding)\b|@openclaw\/fs-safe\/native/u;
-const LEGACY_PYTHON_ONLY_FS_SAFE_VERSION = "0.3.0";
+const LEGACY_PYTHON_ONLY_CONTRACTS = new Set([
+  // 2026.6.33 and earlier frozen lines selected the Python-only fs-safe 0.3 API.
+  "*:0.3.0",
+  // 2026.7.33 upgraded the package without adopting the native durability API.
+  "2026.7.33:0.4.1",
+]);
 assert.ok(isSha(ref), "ref must be a full lowercase commit SHA");
 assert.ok(isSha(workflowSha), "workflow SHA must be a full lowercase commit SHA");
 
@@ -41,7 +46,12 @@ function isLegacyPythonOnlySource() {
         stdio: ["ignore", "pipe", "ignore"],
       });
     const packageJson = JSON.parse(readSource("package.json"));
-    if (packageJson.dependencies?.["@openclaw/fs-safe"] !== LEGACY_PYTHON_ONLY_FS_SAFE_VERSION) {
+    const fsSafeVersion = packageJson.dependencies?.["@openclaw/fs-safe"];
+    const contractKey = `${packageJson.version ?? ""}:${fsSafeVersion ?? ""}`;
+    if (
+      !LEGACY_PYTHON_ONLY_CONTRACTS.has(`*:${fsSafeVersion ?? ""}`) &&
+      !LEGACY_PYTHON_ONLY_CONTRACTS.has(contractKey)
+    ) {
       return false;
     }
     const defaults = readSource("src/infra/fs-safe-defaults.ts");

--- a/test/scripts/resolve-fs-safe-native-contract.test.ts
+++ b/test/scripts/resolve-fs-safe-native-contract.test.ts
@@ -7,14 +7,19 @@ import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 const SCRIPT = resolve("scripts/resolve-fs-safe-native-contract.mjs");
 const tempDirectories = useAutoCleanupTempDirTracker(afterEach);
 
-function commitSource(version: string, defaults: string, remoteBranch?: string) {
+function commitSource(
+  fsSafeVersion: string,
+  defaults: string,
+  remoteBranch?: string,
+  productVersion = "2026.6.33",
+) {
   const root = tempDirectories.make("openclaw-fs-safe-contract-");
   execFileSync("git", ["init", "-q"], { cwd: root });
   execFileSync("git", ["config", "user.email", "test@openclaw.local"], { cwd: root });
   execFileSync("git", ["config", "user.name", "OpenClaw test"], { cwd: root });
   writeFileSync(
     join(root, "package.json"),
-    `${JSON.stringify({ dependencies: { "@openclaw/fs-safe": version } })}\n`,
+    `${JSON.stringify({ version: productVersion, dependencies: { "@openclaw/fs-safe": fsSafeVersion } })}\n`,
   );
   const defaultsPath = join(root, "src/infra/fs-safe-defaults.ts");
   mkdirSync(dirname(defaultsPath), { recursive: true });
@@ -52,6 +57,16 @@ describe("resolve-fs-safe-native-contract", () => {
     expect(resolveContract(root, ref)).toBe("not-applicable");
   });
 
+  it("reports the exact 2026.7.33 Python-only 0.4.1 contract as not applicable", () => {
+    const { root, ref } = commitSource(
+      "0.4.1",
+      legacyDefaults,
+      "extended-stable/2026.7.33",
+      "2026.7.33",
+    );
+    expect(resolveContract(root, ref)).toBe("not-applicable");
+  });
+
   it("keeps the current native consumer contract strict", () => {
     const { root, ref } = commitSource(
       "0.8.1",
@@ -72,6 +87,13 @@ describe("resolve-fs-safe-native-contract", () => {
     );
     const unknownDependency = commitSource("0.3.1", legacyDefaults, "extended-stable/2026.6.33");
     expect(resolveContract(unknownDependency.root, unknownDependency.ref)).toBe("required");
+    const unknownProduct = commitSource(
+      "0.4.1",
+      legacyDefaults,
+      "extended-stable/2026.8.33",
+      "2026.8.33",
+    );
+    expect(resolveContract(unknownProduct.root, unknownProduct.ref)).toBe("required");
   });
 
   it("uses only sparse-materialized fs-safe ownership sources for an authorized legacy target", () => {
@@ -86,7 +108,7 @@ case "$1" in
   show)
     case "$2" in
       ${ref}:package.json)
-        printf '%s\\n' '{"dependencies":{"@openclaw/fs-safe":"0.3.0"}}' ;;
+        printf '%s\\n' '{"version":"2026.6.33","dependencies":{"@openclaw/fs-safe":"0.3.0"}}' ;;
       ${ref}:src/infra/fs-safe-defaults.ts)
         printf '%s\\n' 'import { configureFsSafePython } from "@openclaw/fs-safe/config";' ;;
       *) echo "unmaterialized source: $2" >&2; exit 128 ;;


### PR DESCRIPTION
## Summary

- recognize the exact frozen `2026.7.33` + `@openclaw/fs-safe@0.4.1` Python-only contract
- keep native durability verification required for unknown and future package tuples
- preserve the existing canonical-branch, frozen-source, and source-marker authorization checks

## Why

The 2026.7.33 source upgraded `@openclaw/fs-safe` to 0.4.1 but still consumes only `configureFsSafePython`. Release Docker and Bun validation incorrectly require the later native durability export and fail with `ERR_PACKAGE_PATH_NOT_EXPORTED`.

## Validation

- `pnpm exec vitest run test/scripts/resolve-fs-safe-native-contract.test.ts` (5/5)
- exact frozen candidate `5e4f5599e478aab8638e6f172d37aa4ac7e75aa8` resolves to `not-applicable`
- unknown `2026.8.33` + 0.4.1 remains `required`
