### PR TITLE
fix(e2e): keep frozen onboarding fixtures aligned

### DIFF
--- a/scripts/e2e/codex-on-demand-docker.sh
+++ b/scripts/e2e/codex-on-demand-docker.sh
@@ -13,6 +13,10 @@ TARGET_ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" && pwd)"
 CODEX_ASSERTIONS="$(openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR" \
   scripts/e2e/lib/codex-on-demand/assertions.mjs \
   "$ROOT_DIR/scripts/e2e/lib/codex-on-demand/assertions.mjs")"
+CODEX_DOCTOR_CHECKS="$(openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR" \
+  scripts/e2e/lib/codex-on-demand/doctor-checks.mjs \
+  "$ROOT_DIR/scripts/e2e/lib/codex-on-demand/doctor-checks.mjs" \
+  "")"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-codex-on-demand-e2e" OPENCLAW_CODEX_ON_DEMAND_E2E_IMAGE)"
 DOCKER_TARGET="${OPENCLAW_CODEX_ON_DEMAND_DOCKER_TARGET:-bare}"
@@ -71,11 +75,19 @@ fi
 docker_e2e_package_mount_args "$PACKAGE_TGZ"
 run_log="$(docker_e2e_run_log codex-on-demand)"
 OPENCLAW_TEST_STATE_SCRIPT_B64="$(docker_e2e_test_state_shell_b64 codex-on-demand empty)"
+CODEX_CONTRACT_MOUNT_ARGS=(
+  -v "$CODEX_ASSERTIONS:/app/scripts/e2e/lib/codex-on-demand/assertions.mjs:ro"
+)
+if [ -n "$CODEX_DOCTOR_CHECKS" ]; then
+  CODEX_CONTRACT_MOUNT_ARGS+=(
+    -v "$CODEX_DOCTOR_CHECKS:/app/scripts/e2e/lib/codex-on-demand/doctor-checks.mjs:ro"
+  )
+fi
 
 echo "Running Codex on-demand Docker E2E..."
 if ! docker_e2e_run_with_harness \
   -v "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}/extensions/codex/package.json:/tmp/openclaw-candidate-codex-package.json:ro" \
-  -v "$CODEX_ASSERTIONS:/app/scripts/e2e/lib/codex-on-demand/assertions.mjs:ro" \
+  "${CODEX_CONTRACT_MOUNT_ARGS[@]}" \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
@@ -154,7 +166,9 @@ openclaw onboard --non-interactive --accept-risk \
 openclaw plugins list --json >/tmp/openclaw-plugins-list.json
 openclaw plugins inspect codex --runtime --json >/tmp/openclaw-codex-inspect.json
 node scripts/e2e/lib/codex-on-demand/assertions.mjs
-node scripts/e2e/lib/codex-on-demand/doctor-checks.mjs
+if [ -f scripts/e2e/lib/codex-on-demand/doctor-checks.mjs ]; then
+  node scripts/e2e/lib/codex-on-demand/doctor-checks.mjs
+fi
 
 echo "Codex on-demand Docker E2E passed"
 EOF

--- a/scripts/e2e/codex-on-demand-docker.sh
+++ b/scripts/e2e/codex-on-demand-docker.sh
@@ -17,6 +17,10 @@ CODEX_DOCTOR_CHECKS="$(openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR" \
   scripts/e2e/lib/codex-on-demand/doctor-checks.mjs \
   "$ROOT_DIR/scripts/e2e/lib/codex-on-demand/doctor-checks.mjs" \
   "")"
+CODEX_DOCTOR_CHECKS_ENABLED=0
+if [ -n "$CODEX_DOCTOR_CHECKS" ]; then
+  CODEX_DOCTOR_CHECKS_ENABLED=1
+fi
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-codex-on-demand-e2e" OPENCLAW_CODEX_ON_DEMAND_E2E_IMAGE)"
 DOCKER_TARGET="${OPENCLAW_CODEX_ON_DEMAND_DOCKER_TARGET:-bare}"
@@ -89,6 +93,7 @@ if ! docker_e2e_run_with_harness \
   -v "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}/extensions/codex/package.json:/tmp/openclaw-candidate-codex-package.json:ro" \
   "${CODEX_CONTRACT_MOUNT_ARGS[@]}" \
   -e COREPACK_ENABLE_DOWNLOAD_PROMPT=0 \
+  -e "OPENCLAW_CODEX_DOCTOR_CHECKS_ENABLED=$CODEX_DOCTOR_CHECKS_ENABLED" \
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   -i "$IMAGE_NAME" bash -s >"$run_log" 2>&1 <<'EOF'; then
@@ -166,7 +171,7 @@ openclaw onboard --non-interactive --accept-risk \
 openclaw plugins list --json >/tmp/openclaw-plugins-list.json
 openclaw plugins inspect codex --runtime --json >/tmp/openclaw-codex-inspect.json
 node scripts/e2e/lib/codex-on-demand/assertions.mjs
-if [ -f scripts/e2e/lib/codex-on-demand/doctor-checks.mjs ]; then
+if [ "$OPENCLAW_CODEX_DOCTOR_CHECKS_ENABLED" = "1" ]; then
   node scripts/e2e/lib/codex-on-demand/doctor-checks.mjs
 fi
 

--- a/scripts/e2e/npm-onboard-channel-agent-docker.sh
+++ b/scripts/e2e/npm-onboard-channel-agent-docker.sh
@@ -13,6 +13,11 @@ TARGET_ROOT_DIR="$(cd "${OPENCLAW_DOCKER_E2E_REPO_ROOT:-$ROOT_DIR}" && pwd)"
 ONBOARD_ASSERTIONS="$(openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR" \
   scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs \
   "$ROOT_DIR/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs")"
+# The assertion and its config producer are one target-owned contract; mixing
+# generations can make a valid frozen package appear to change its default model.
+ONBOARD_MOCK_OPENAI_CONFIG="$(openclaw_resolve_frozen_target_file "$TARGET_ROOT_DIR" \
+  scripts/e2e/lib/fixtures/mock-openai-config.mjs \
+  "$ROOT_DIR/scripts/e2e/lib/fixtures/mock-openai-config.mjs")"
 
 IMAGE_NAME="$(docker_e2e_resolve_image "openclaw-npm-onboard-channel-agent-e2e" OPENCLAW_NPM_ONBOARD_E2E_IMAGE)"
 DOCKER_TARGET="${OPENCLAW_NPM_ONBOARD_DOCKER_TARGET:-bare}"
@@ -75,6 +80,7 @@ if ! docker_e2e_run_with_harness \
   -e "OPENCLAW_NPM_ONBOARD_STATUS_TEXT_MAX_BYTES=$STATUS_TEXT_MAX_BYTES" \
   -e "OPENCLAW_TEST_STATE_SCRIPT_B64=$OPENCLAW_TEST_STATE_SCRIPT_B64" \
   -v "$ONBOARD_ASSERTIONS:/app/scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs:ro" \
+  -v "$ONBOARD_MOCK_OPENAI_CONFIG:/app/scripts/e2e/lib/fixtures/mock-openai-config.mjs:ro" \
   "${DOCKER_E2E_PACKAGE_ARGS[@]}" \
   -i "$IMAGE_NAME" bash -s >"$run_log" 2>&1 <<'EOF'; then
 set -Eeuo pipefail

--- a/scripts/e2e/update-channel-switch-docker.sh
+++ b/scripts/e2e/update-channel-switch-docker.sh
@@ -196,10 +196,16 @@ echo "==> ordinary untracked files still block Git admission"
 printf "retain user notes\n" >"$git_root/operator-update-notes.tmp"
 set +e
 dirty_json="$(openclaw update "${dev_channel_args[@]}" --yes --json --no-restart)"
+dirty_status=$?
 set -e
 # Historical update CLIs can report a blocked structured result with exit zero.
 # The assertion proves the update was rejected and no checkout state changed.
-UPDATE_JSON="$dirty_json" node scripts/e2e/lib/update-channel-switch/assertions.mjs   assert-dirty-update "$git_root" "$fixture_sha"
+if [ "$OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT" != "1" ] && [ "$dirty_status" -ne 1 ]; then
+  echo "expected current dirty-worktree update to exit 1, got $dirty_status" >&2
+  exit 1
+fi
+UPDATE_JSON="$dirty_json" node scripts/e2e/lib/update-channel-switch/assertions.mjs \
+  assert-dirty-update "$git_root" "$fixture_sha"
 node -e "require(\"node:fs\").unlinkSync(process.argv[1])" "$git_root/operator-update-notes.tmp"
 
 echo "==> package -> git dev channel"

--- a/scripts/e2e/update-channel-switch-docker.sh
+++ b/scripts/e2e/update-channel-switch-docker.sh
@@ -196,12 +196,9 @@ echo "==> ordinary untracked files still block Git admission"
 printf "retain user notes\n" >"$git_root/operator-update-notes.tmp"
 set +e
 dirty_json="$(openclaw update "${dev_channel_args[@]}" --yes --json --no-restart)"
-dirty_status=$?
 set -e
-if [ "$dirty_status" -eq 0 ] && [ "$OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT" != "1" ]; then
-  echo "Git update unexpectedly admitted ordinary untracked user notes" >&2
-  exit 1
-fi
+# Historical update CLIs can report a blocked structured result with exit zero.
+# The assertion proves the update was rejected and no checkout state changed.
 UPDATE_JSON="$dirty_json" node scripts/e2e/lib/update-channel-switch/assertions.mjs   assert-dirty-update "$git_root" "$fixture_sha"
 node -e "require(\"node:fs\").unlinkSync(process.argv[1])" "$git_root/operator-update-notes.tmp"
 

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -49,13 +49,15 @@ source "$HARNESS_ROOT_DIR/scripts/lib/openclaw-e2e-instance.sh"
 source "$HARNESS_ROOT_DIR/scripts/lib/frozen-target-compat.sh"
 source "$HARNESS_ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 
-UPGRADE_ASSERTION_ARGS=()
-UPGRADE_ASSERTIONS="$(openclaw_resolve_frozen_target_file \
-  "$ROOT_DIR" scripts/e2e/lib/upgrade-survivor/assertions.mjs)"
-if [ -n "$UPGRADE_ASSERTIONS" ]; then
-  # Upgrade survival is defined by the selected release's shipped state contract.
-  UPGRADE_ASSERTION_ARGS+=(
-    -v "$UPGRADE_ASSERTIONS:/app/scripts/e2e/lib/upgrade-survivor/assertions.mjs:ro"
+UPGRADE_SCENARIO_ARGS=()
+UPGRADE_RUNNER="$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh"
+UPGRADE_SCENARIO_DIR="$(openclaw_resolve_frozen_target_file \
+  "$ROOT_DIR" scripts/e2e/lib/upgrade-survivor)"
+if [ -n "$UPGRADE_SCENARIO_DIR" ]; then
+  # The runner, assertions, and fixtures form one shipped scenario contract.
+  UPGRADE_RUNNER="$UPGRADE_SCENARIO_DIR/run.sh"
+  UPGRADE_SCENARIO_ARGS+=(
+    -v "$UPGRADE_SCENARIO_DIR:/app/scripts/e2e/lib/upgrade-survivor:ro"
   )
 fi
 
@@ -296,8 +298,8 @@ if [ "${OPENCLAW_UPGRADE_SURVIVOR_PUBLISHED_BASELINE:-0}" = "1" ]; then
     -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/clawhub-fixture-server.cjs:/tmp/openclaw-clawhub-fixture-server.cjs:ro" \
     -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/config-parking.mjs:/tmp/openclaw-config-parking.mjs:ro" \
-    -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh:/tmp/openclaw-upgrade-survivor-run.sh:ro" \
-    ${UPGRADE_ASSERTION_ARGS[@]+"${UPGRADE_ASSERTION_ARGS[@]}"} \
+    -v "$UPGRADE_RUNNER:/tmp/openclaw-upgrade-survivor-run.sh:ro" \
+    ${UPGRADE_SCENARIO_ARGS[@]+"${UPGRADE_SCENARIO_ARGS[@]}"} \
     ${DOCKER_E2E_PACKAGE_ARGS[@]+"${DOCKER_E2E_PACKAGE_ARGS[@]}"} \
     ${DOCKER_RUN_USER_ARGS[@]+"${DOCKER_RUN_USER_ARGS[@]}"} \
     "$IMAGE_NAME" \

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -349,7 +349,7 @@ docker_e2e_run_with_harness \
   -v "$ARTIFACT_DIR:/tmp/openclaw-upgrade-survivor-artifacts" \
   -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/clawhub-fixture-server.cjs:/tmp/openclaw-clawhub-fixture-server.cjs:ro" \
   -v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/config-parking.mjs:/tmp/openclaw-config-parking.mjs:ro" \
-  ${UPGRADE_ASSERTION_ARGS[@]+"${UPGRADE_ASSERTION_ARGS[@]}"} \
+  ${UPGRADE_SCENARIO_ARGS[@]+"${UPGRADE_SCENARIO_ARGS[@]}"} \
   ${DOCKER_E2E_PACKAGE_ARGS[@]+"${DOCKER_E2E_PACKAGE_ARGS[@]}"} \
   ${DOCKER_RUN_USER_ARGS[@]+"${DOCKER_RUN_USER_ARGS[@]}"} \
   "$IMAGE_NAME" \

--- a/scripts/lib/frozen-target-compat.sh
+++ b/scripts/lib/frozen-target-compat.sh
@@ -43,6 +43,7 @@ openclaw_resolve_frozen_target_file() {
   local source_root="${1:?missing selected source root}" \
     relative_path="${2:?missing selected relative path}" \
     fallback_path="${3:-}" context_status=0
+  local frozen_missing_path="${4-$fallback_path}"
 
   openclaw_prepare_frozen_target_context "$source_root" || context_status=$?
   case "$context_status" in
@@ -51,6 +52,8 @@ openclaw_resolve_frozen_target_file() {
         printf '%s\n' "$source_root/$relative_path"
         return
       fi
+      printf '%s\n' "$frozen_missing_path"
+      return
       ;;
     1) ;;
     *) return "$context_status" ;;

--- a/src/agents/prepared-model-catalog-worker.test.ts
+++ b/src/agents/prepared-model-catalog-worker.test.ts
@@ -6,7 +6,8 @@ import {
 } from "./prepared-model-catalog-worker.js";
 import type { PreparedModelRuntimeAgentFacts } from "./prepared-model-runtime.catalog-contract.js";
 
-vi.mock("../plugins/manifest-registry-installed.js", () => ({
+vi.mock("../plugins/manifest-registry-installed.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/manifest-registry-installed.js")>()),
   resolveInstalledManifestRegistryIndexFingerprint: () => "test-plugin-index",
 }));
 

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -3162,7 +3162,7 @@ docker_e2e_docker_run_cmd run demo
     );
     expect(upgradeSurvivor).toContain('DOCKER_E2E_HARNESS_ROOT_DIR="$HARNESS_ROOT_DIR"');
     expect(upgradeSurvivor).toContain(
-      '-v "$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh:/tmp/openclaw-upgrade-survivor-run.sh:ro"',
+      '-v "$UPGRADE_RUNNER:/tmp/openclaw-upgrade-survivor-run.sh:ro"',
     );
     expect(upgradeSurvivor).toContain(
       'timeout --kill-after=30s "$DOCKER_RUN_TIMEOUT" bash /tmp/openclaw-upgrade-survivor-run.sh',
@@ -5892,14 +5892,13 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
     );
   });
 
-  it("uses each authorized frozen release's shipped scenario assertions", () => {
+  it("uses each authorized frozen release's shipped scenario contract files", () => {
     for (const [runnerPath, assertionPath] of [
       [CODEX_ON_DEMAND_DOCKER_E2E_PATH, "scripts/e2e/lib/codex-on-demand/assertions.mjs"],
       [
         NPM_ONBOARD_CHANNEL_AGENT_DOCKER_E2E_PATH,
         "scripts/e2e/lib/npm-onboard-channel-agent/assertions.mjs",
       ],
-      [UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "scripts/e2e/lib/upgrade-survivor/assertions.mjs"],
       [
         PLUGIN_UPDATE_CORRUPT_DOCKER_E2E_PATH,
         "scripts/e2e/lib/plugin-update/corrupt-update-scenario.sh",
@@ -5910,6 +5909,32 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
       expect(runner).toContain(`openclaw_resolve_frozen_target_file`);
       expect(runner).toContain(`${assertionPath}:ro`);
     }
+
+    const codexRunner = readFileSync(CODEX_ON_DEMAND_DOCKER_E2E_PATH, "utf8");
+    expectTextToIncludeAll(codexRunner, [
+      "scripts/e2e/lib/codex-on-demand/doctor-checks.mjs",
+      'if [ -n "$CODEX_DOCTOR_CHECKS" ]',
+      "if [ -f scripts/e2e/lib/codex-on-demand/doctor-checks.mjs ]",
+    ]);
+
+    const onboardingRunner = readFileSync(NPM_ONBOARD_CHANNEL_AGENT_DOCKER_E2E_PATH, "utf8");
+    expectTextToIncludeAll(onboardingRunner, [
+      "scripts/e2e/lib/fixtures/mock-openai-config.mjs",
+      "ONBOARD_MOCK_OPENAI_CONFIG",
+      '-v "$ONBOARD_MOCK_OPENAI_CONFIG:/app/scripts/e2e/lib/fixtures/mock-openai-config.mjs:ro"',
+    ]);
+
+    const upgradeRunner = readFileSync(UPGRADE_SURVIVOR_DOCKER_E2E_PATH, "utf8");
+    expectTextToIncludeAll(upgradeRunner, [
+      "scripts/e2e/lib/upgrade-survivor",
+      'UPGRADE_RUNNER="$UPGRADE_SCENARIO_DIR/run.sh"',
+      '-v "$UPGRADE_SCENARIO_DIR:/app/scripts/e2e/lib/upgrade-survivor:ro"',
+      '-v "$UPGRADE_RUNNER:/tmp/openclaw-upgrade-survivor-run.sh:ro"',
+    ]);
+
+    const updateRunner = readFileSync(UPDATE_CHANNEL_SWITCH_DOCKER_E2E_PATH, "utf8");
+    expect(updateRunner).toContain('assert-dirty-update "$git_root" "$fixture_sha"');
+    expect(updateRunner).not.toContain('if [ "$dirty_status" -eq 0 ]');
   });
 
   it("serves the version-matched Codex candidate during package onboarding", () => {

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -5914,7 +5914,8 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
     expectTextToIncludeAll(codexRunner, [
       "scripts/e2e/lib/codex-on-demand/doctor-checks.mjs",
       'if [ -n "$CODEX_DOCTOR_CHECKS" ]',
-      "if [ -f scripts/e2e/lib/codex-on-demand/doctor-checks.mjs ]",
+      "OPENCLAW_CODEX_DOCTOR_CHECKS_ENABLED=$CODEX_DOCTOR_CHECKS_ENABLED",
+      'if [ "$OPENCLAW_CODEX_DOCTOR_CHECKS_ENABLED" = "1" ]',
     ]);
 
     const onboardingRunner = readFileSync(NPM_ONBOARD_CHANNEL_AGENT_DOCKER_E2E_PATH, "utf8");
@@ -5931,10 +5932,12 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
       '-v "$UPGRADE_SCENARIO_DIR:/app/scripts/e2e/lib/upgrade-survivor:ro"',
       '-v "$UPGRADE_RUNNER:/tmp/openclaw-upgrade-survivor-run.sh:ro"',
     ]);
+    expect(upgradeRunner).not.toContain("UPGRADE_ASSERTION_ARGS");
 
     const updateRunner = readFileSync(UPDATE_CHANNEL_SWITCH_DOCKER_E2E_PATH, "utf8");
     expect(updateRunner).toContain('assert-dirty-update "$git_root" "$fixture_sha"');
-    expect(updateRunner).not.toContain('if [ "$dirty_status" -eq 0 ]');
+    expect(updateRunner).toContain('[ "$OPENCLAW_PACKAGE_ACCEPTANCE_LEGACY_COMPAT" != "1" ]');
+    expect(updateRunner).toContain('[ "$dirty_status" -ne 1 ]');
   });
 
   it("serves the version-matched Codex candidate during package onboarding", () => {

--- a/test/scripts/live-docker-stage.test.ts
+++ b/test/scripts/live-docker-stage.test.ts
@@ -373,6 +373,35 @@ export function parseRegistryNpmSpec(spec: string) {
     expect(malformed.stderr).toContain("invalid OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS");
   });
 
+  it("can omit a contract file absent from an authorized frozen target", () => {
+    const selectedSha = execFileSync("git", ["rev-parse", "HEAD"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    }).trim();
+    const result = spawnSync(
+      "bash",
+      [
+        "-c",
+        'set -euo pipefail; source "$1"; openclaw_resolve_frozen_target_file "$2" missing/path current-path ""',
+        "test",
+        stageScriptPath,
+        repoRoot,
+      ],
+      {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1",
+          OPENCLAW_SELECTED_SHA: selectedSha,
+          OPENCLAW_TOOLING_SHA: "b".repeat(40),
+        },
+      },
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toBe("\n");
+  });
+
   it("keeps a matching frozen-source capability under pipefail", () => {
     const root = tempDirs.make("openclaw-frozen-target-capability-");
     const sourcePath = path.join(root, "scripts/e2e/lib/plugins/assertions.mjs");


### PR DESCRIPTION
## Summary

- keep each selected release scenario internally generation-consistent
- mount npm onboarding assertions with their imported mock-model config producer
- mount the complete selected upgrade-survivor runner/assertion/fixture directory
- run Codex doctor qualification only when the selected release shipped that contract
- accept historical zero-exit dirty rejections only after the structured assertion proves no update occurred
- keep current-target behavior unchanged

## Root cause

Merged #141774 selected individual frozen assertion files while retaining current-main producers, helpers, and the upgrade runner. That created mixed-generation scenarios:

- npm onboarding: the 2026.6.35 assertion expected `openai/gpt-5.5`, while current tooling generated `openai/gpt-5.6-luna`
- upgrade survivor: current runner invoked `assert-exec-approvals`, which the selected release assertion did not expose; the same mismatch affected ClawHub fixture expectations
- Codex on demand: current tooling invoked `codex/managed-app-server`, a doctor check the selected release never shipped

The repair uses the existing fail-closed frozen-target resolver. No version/SHA allowlist, new environment mode, or compatibility parser is added. Current and unauthorized targets continue to run the current doctor check strictly.

## Red proof

- [npm onboarding](https://github.com/openclaw/openclaw/actions/runs/34189421223/job/101944733208): expected `openai/gpt-5.5`, got `openai/gpt-5.6-luna`
- [upgrade survivor](https://github.com/openclaw/openclaw/actions/runs/34189437057/job/101944965118): unknown assertion command `assert-exec-approvals`
- [Codex on demand](https://github.com/openclaw/openclaw/actions/runs/34189437057/job/101944965138): unknown health check `codex/managed-app-server`

## Verification

- selected-contract and frozen-resolution regressions: 12 passed
- `bash -n` on all changed runners
- Oxfmt and `git diff --check`
- final AutoReview: scoped-clean, no P0/P1 findings (0.90)

Production/tooling: +38/-16 (net +22). Tests: +57/-3. Application runtime: 0.

Codex dependency gate: inspected `../codex/codex-rs/app-server/README.md:224-239`, `../codex/codex-rs/app-server-protocol/src/protocol/common.rs:705,812`, and `../codex/codex-rs/app-server/src/request_processors/plugins.rs:1481-1908`. Upstream owns `plugin/install`; the failing `codex/managed-app-server` doctor identifier is an OpenClaw release qualification contract, not an upstream Codex API.
