### PR TITLE
improve(status): report external and ArrayBuffer memory

### DIFF
--- a/scripts/bench-gateway-concurrency.ts
+++ b/scripts/bench-gateway-concurrency.ts
@@ -20,7 +20,13 @@ import { isRecord } from "../packages/normalization-core/src/record-coerce.ts";
 import { sliceUtf16Safe } from "../packages/normalization-core/src/utf16-slice.ts";
 import { applyMockOpenAiModelConfig } from "./e2e/lib/fixtures/mock-openai-config.mjs";
 import { delay, stopChild } from "./lib/gateway-bench-child.ts";
-import { getFreePort, readProcessRssMb } from "./lib/gateway-bench-probes.ts";
+import {
+  type GatewayMemorySample,
+  type GatewayRpc,
+  getFreePort,
+  readGatewayMemory,
+  readProcessRssMb,
+} from "./lib/gateway-bench-probes.ts";
 import {
   BASE_GATEWAY_BENCH_CONFIG,
   buildGatewayBenchChildArgs,
@@ -84,15 +90,6 @@ type FreshConnectionProbe = {
   error: string | null;
   latencyMs: number;
   ok: boolean;
-};
-
-type GatewayRpc = <T>(method: string, params: unknown, timeoutMs?: number) => Promise<T>;
-
-type GatewayMemorySample = {
-  atMs: number;
-  heapTotalMb: number;
-  heapUsedMb: number;
-  rssMb: number;
 };
 
 type GatewayChildExit = {
@@ -776,29 +773,6 @@ async function connectGateway(
     setDeadlineAt: (value: number) => {
       requestDeadlineAt = value;
     },
-  };
-}
-
-async function readGatewayMemory(
-  rpc: GatewayRpc,
-  runStartedAt: number,
-): Promise<GatewayMemorySample> {
-  const result = await rpc<{
-    processMemory?: { heapTotalBytes?: number; heapUsedBytes?: number; rssBytes?: number };
-  }>("status", { includeChannelSummary: false });
-  const memory = result.processMemory;
-  const heapTotalBytes = asFiniteNumber(memory?.heapTotalBytes);
-  const heapUsedBytes = asFiniteNumber(memory?.heapUsedBytes);
-  const rssBytes = asFiniteNumber(memory?.rssBytes);
-  if (heapTotalBytes === undefined || heapUsedBytes === undefined || rssBytes === undefined) {
-    throw new Error("Gateway status did not report process memory");
-  }
-  const toMb = (bytes: number) => bytes / 1024 / 1024;
-  return {
-    atMs: performance.now() - runStartedAt,
-    heapTotalMb: toMb(heapTotalBytes),
-    heapUsedMb: toMb(heapUsedBytes),
-    rssMb: toMb(rssBytes),
   };
 }
 
@@ -1615,6 +1589,30 @@ function summarizeRuns(
       (run) =>
         run.gatewayExit && (run.gatewayExit.exitCode !== 0 || run.gatewayExit.signal !== null),
     ).length,
+    gatewayExternalGrowthMb: summarizeNumbers(
+      runs.flatMap((run) => {
+        const before = run.memory.before.externalMb;
+        const after = run.memory.after.externalMb;
+        return before === undefined || after === undefined ? [] : [after - before];
+      }),
+    ),
+    gatewayExternalMb: summarizeNumbers(
+      runs.flatMap((run) =>
+        run.memory.after.externalMb === undefined ? [] : [run.memory.after.externalMb],
+      ),
+    ),
+    gatewayArrayBuffersGrowthMb: summarizeNumbers(
+      runs.flatMap((run) => {
+        const before = run.memory.before.arrayBuffersMb;
+        const after = run.memory.after.arrayBuffersMb;
+        return before === undefined || after === undefined ? [] : [after - before];
+      }),
+    ),
+    gatewayArrayBuffersMb: summarizeNumbers(
+      runs.flatMap((run) =>
+        run.memory.after.arrayBuffersMb === undefined ? [] : [run.memory.after.arrayBuffersMb],
+      ),
+    ),
     gatewayHeapGrowthMb: summarizeNumbers(
       runs.map((run) => run.memory.after.heapUsedMb - run.memory.before.heapUsedMb),
     ),

--- a/scripts/lib/gateway-bench-probes.ts
+++ b/scripts/lib/gateway-bench-probes.ts
@@ -2,9 +2,56 @@
 import { spawnSync } from "node:child_process";
 import { request } from "node:http";
 import { createServer } from "node:net";
+import { performance } from "node:perf_hooks";
 import { expectDefined } from "../../packages/normalization-core/src/expect.ts";
+import { asFiniteNumber } from "../../packages/normalization-core/src/number-coercion.ts";
+
+export type GatewayRpc = <T>(method: string, params: unknown, timeoutMs?: number) => Promise<T>;
+
+/** Gateway status observations; the existing Mb fields use MiB (1024 * 1024 bytes). */
+export type GatewayMemorySample = {
+  atMs: number;
+  heapTotalMb: number;
+  heapUsedMb: number;
+  rssMb: number;
+  externalMb?: number;
+  arrayBuffersMb?: number;
+};
 
 const PROBE_REQUEST_TIMEOUT_MS = 100;
+
+export async function readGatewayMemory(
+  rpc: GatewayRpc,
+  runStartedAt: number,
+): Promise<GatewayMemorySample> {
+  const result = await rpc<{
+    processMemory?: {
+      heapTotalBytes?: number;
+      heapUsedBytes?: number;
+      rssBytes?: number;
+      externalBytes?: number;
+      arrayBuffersBytes?: number;
+    };
+  }>("status", { includeChannelSummary: false });
+  const memory = result.processMemory;
+  const heapTotalBytes = asFiniteNumber(memory?.heapTotalBytes);
+  const heapUsedBytes = asFiniteNumber(memory?.heapUsedBytes);
+  const rssBytes = asFiniteNumber(memory?.rssBytes);
+  const externalBytes = asFiniteNumber(memory?.externalBytes);
+  const arrayBuffersBytes = asFiniteNumber(memory?.arrayBuffersBytes);
+  if (heapTotalBytes === undefined || heapUsedBytes === undefined || rssBytes === undefined) {
+    throw new Error("Gateway status did not report process memory");
+  }
+  const toMb = (bytes: number) => bytes / 1024 / 1024;
+  return {
+    atMs: performance.now() - runStartedAt,
+    heapTotalMb: toMb(heapTotalBytes),
+    heapUsedMb: toMb(heapUsedBytes),
+    rssMb: toMb(rssBytes),
+    ...(externalBytes === undefined ? {} : { externalMb: toMb(externalBytes) }),
+    ...(arrayBuffersBytes === undefined ? {} : { arrayBuffersMb: toMb(arrayBuffersBytes) }),
+  };
+}
 
 export async function getFreePort(): Promise<number> {
   return new Promise((resolve, reject) => {

--- a/src/gateway/server-methods/health.owner-routing.test.ts
+++ b/src/gateway/server-methods/health.owner-routing.test.ts
@@ -9,6 +9,7 @@ import { healthHandlers } from "./health.js";
 
 afterEach(() => {
   resetConfigRuntimeState();
+  vi.restoreAllMocks();
 });
 
 async function callStatus(config: OpenClawConfig, scopes = ["operator.read"]) {
@@ -37,6 +38,13 @@ describe("Gateway status owner routing", () => {
         session: { store: path.join(stateDir, "agents", "{agentId}", "sessions.json") },
       } satisfies OpenClawConfig;
 
+      vi.spyOn(process, "memoryUsage").mockReturnValue({
+        rss: 5120,
+        heapUsed: 3072,
+        heapTotal: 4096,
+        external: 2048,
+        arrayBuffers: 1024,
+      });
       const respond = await callStatus(config);
 
       expect(respond).toHaveBeenCalledTimes(1);
@@ -44,9 +52,11 @@ describe("Gateway status owner routing", () => {
       expect(respond.mock.calls[0]?.[1]).toEqual(
         expect.objectContaining({
           processMemory: {
-            rssBytes: expect.any(Number),
-            heapUsedBytes: expect.any(Number),
-            heapTotalBytes: expect.any(Number),
+            rssBytes: 5120,
+            heapUsedBytes: 3072,
+            heapTotalBytes: 4096,
+            externalBytes: 2048,
+            arrayBuffersBytes: 1024,
           },
         }),
       );

--- a/src/gateway/server-methods/health.ts
+++ b/src/gateway/server-methods/health.ts
@@ -197,6 +197,8 @@ export const healthHandlers: GatewayRequestHandlers = {
       rssBytes: memory.rss,
       heapUsedBytes: memory.heapUsed,
       heapTotalBytes: memory.heapTotal,
+      externalBytes: memory.external,
+      arrayBuffersBytes: memory.arrayBuffers,
     };
     respond(true, status, undefined);
   },

--- a/src/status/types.ts
+++ b/src/status/types.ts
@@ -60,6 +60,9 @@ export type StatusSummary = {
     rssBytes: number;
     heapUsedBytes: number;
     heapTotalBytes: number;
+    externalBytes?: number;
+    /** Included in externalBytes, not an additional memory category. */
+    arrayBuffersBytes?: number;
   };
   linkChannel?: {
     id: ChannelId;

--- a/test/scripts/bench-gateway-concurrency.test.ts
+++ b/test/scripts/bench-gateway-concurrency.test.ts
@@ -4,8 +4,9 @@ import { writeFile } from "node:fs/promises";
 import { createServer as createHttpServer } from "node:http";
 import { createServer as createRawServer, type Socket } from "node:net";
 import { performance } from "node:perf_hooks";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { testing } from "../../scripts/bench-gateway-concurrency.ts";
+import { readGatewayMemory } from "../../scripts/lib/gateway-bench-probes.ts";
 import { withTempDir } from "../../src/test-utils/temp-dir.js";
 
 type BenchmarkRun = Parameters<typeof testing.summarizeRuns>[0][number];
@@ -39,6 +40,91 @@ function createBenchmarkRun(overrides: Partial<BenchmarkRun> = {}): BenchmarkRun
 }
 
 describe("gateway concurrency benchmark script", () => {
+  it.each([
+    {
+      name: "populated",
+      fields: { externalBytes: 2_621_440, arrayBuffersBytes: 1_572_864 },
+      expected: { externalMb: 2.5, arrayBuffersMb: 1.5 },
+    },
+    {
+      name: "zero",
+      fields: { externalBytes: 0, arrayBuffersBytes: 0 },
+      expected: { externalMb: 0, arrayBuffersMb: 0 },
+    },
+    { name: "missing", fields: {}, expected: {} },
+    {
+      name: "external-only",
+      fields: { externalBytes: 2_621_440 },
+      expected: { externalMb: 2.5 },
+    },
+    {
+      name: "ArrayBuffers-only",
+      fields: { arrayBuffersBytes: 1_572_864 },
+      expected: { arrayBuffersMb: 1.5 },
+    },
+    {
+      name: "invalid",
+      fields: { externalBytes: "unknown", arrayBuffersBytes: Number.POSITIVE_INFINITY },
+      expected: {},
+    },
+  ])("preserves $name optional Gateway memory in MiB", async ({ fields, expected }) => {
+    const rpc = vi.fn().mockResolvedValue({
+      processMemory: {
+        heapTotalBytes: 1_310_720,
+        heapUsedBytes: 524_288,
+        rssBytes: 3_145_728,
+        ...fields,
+      },
+    });
+
+    const sample = await readGatewayMemory(rpc, performance.now());
+
+    expect(rpc).toHaveBeenCalledExactlyOnceWith("status", { includeChannelSummary: false });
+    expect(sample).toEqual({
+      atMs: expect.any(Number),
+      heapTotalMb: 1.25,
+      heapUsedMb: 0.5,
+      rssMb: 3,
+      ...expected,
+    });
+  });
+
+  it("summarizes only observed optional memory values and complete growth pairs", () => {
+    const memory = createBenchmarkRun().memory;
+    const runs = [
+      {
+        before: { externalMb: 2, arrayBuffersMb: 1 },
+        after: { externalMb: 5, arrayBuffersMb: 2 },
+      },
+      {
+        before: { externalMb: 0, arrayBuffersMb: 0 },
+        after: { externalMb: 0, arrayBuffersMb: 0 },
+      },
+      {
+        before: { externalMb: 8, arrayBuffersMb: 3 },
+        after: { externalMb: 6, arrayBuffersMb: 1.5 },
+      },
+      { before: { externalMb: 100 }, after: { arrayBuffersMb: 6 } },
+      { before: { arrayBuffersMb: 8 }, after: { externalMb: 9 } },
+      { before: {}, after: {} },
+    ].map(({ before, after }) =>
+      createBenchmarkRun({
+        memory: {
+          ...memory,
+          before: { ...memory.before, ...before },
+          after: { ...memory.after, ...after },
+        },
+      }),
+    );
+
+    expect(testing.summarizeRuns(runs)).toMatchObject({
+      gatewayExternalMb: { count: 4, max: 9, p50: 5, p95: 9, p99: 9 },
+      gatewayExternalGrowthMb: { count: 3, max: 3, p50: 0, p95: 3, p99: 3 },
+      gatewayArrayBuffersMb: { count: 4, max: 6, p50: 1.5, p95: 6, p99: 6 },
+      gatewayArrayBuffersGrowthMb: { count: 3, max: 1, p50: 0, p95: 1, p99: 1 },
+    });
+  });
+
   it("parses benchmark controls without booting a gateway", () => {
     expect(
       testing.parseOptions([
@@ -208,6 +294,10 @@ describe("gateway concurrency benchmark script", () => {
       });
 
     expect(testing.summarizeRuns([createRun(2, [10, 20]), createRun(1, [30])])).toMatchObject({
+      gatewayExternalMb: null,
+      gatewayExternalGrowthMb: null,
+      gatewayArrayBuffersMb: null,
+      gatewayArrayBuffersGrowthMb: null,
       gatewayHeapGrowthMb: { count: 2, max: 20, p50: 20, p95: 20, p99: 20 },
       gatewayPeakRssMb: { count: 2, max: 210, p50: 210, p95: 210, p99: 210 },
       gatewayRssGrowthMb: { count: 2, max: 20, p50: 20, p95: 20, p99: 20 },


### PR DESCRIPTION
<!-- PR title: improve(status): report external and ArrayBuffer memory -->

<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers
can help update the branch when needed.

</details>

## What Problem This Solves

Resolves a problem where operators inspecting Gateway status or concurrency
benchmark results could see RSS and V8 heap usage but lacked the corresponding
external and ArrayBuffer memory counters.

## Why This Change Was Made

Add optional `externalBytes` and `arrayBuffersBytes` to the existing
`processMemory` response using the same `process.memoryUsage()` snapshot already
used for RSS and heap. Carry those counters through the existing benchmark
observations and summaries without new polling, forced garbage collection,
runtime configuration, or a protocol version change.

## User Impact

- Gateway status reports the counters in bytes; benchmark samples retain the
  existing `Mb` naming convention with values converted to MiB.
- Responses from older Gateways remain readable. Missing optional counters stay
  unknown rather than becoming zero, while actual zero values are preserved.
- Summaries include only observed values. Growth summaries require both
  before/after observations for that counter and preserve zero or negative
  changes.
- RSS is process-wide; heap, external, and ArrayBuffer counters describe the
  responding Node thread/isolate, not an aggregate across worker threads.
- ArrayBuffer memory is included in external memory, not an additional category
  to sum with it. These observations do not identify individual allocators,
  establish memory peaks, or measure a process tree.

This is an additive diagnostics change, not a claim of lower memory use or
faster runtime performance.

## Evidence

### Reconciled Remote Wire Proof

September 13, 2026: configured Blacksmith Testbox/Linux, Node 24.19.0,
pnpm 12.3.4, Vitest 5.0.0, with source, package, lockfile, and candidate file
hashes bound to the native capsule/receiver. The tested source was
`c6923b4c99a971ef73a943fdc973a2c42a5deb9f`; all seven P00 files, package.json,
and pnpm-lock.yaml remain byte-identical in the main-reconciled head
`55079d16e561f991f129c74340548d9b8d1e9352`.

- **52 tests passed:** 9 in `src/gateway/server.health.test.ts`, 4 in
  `src/gateway/server-methods/health.owner-routing.test.ts`, and 39 in
  `test/scripts/bench-gateway-concurrency.test.ts`.
- The existing connect/health/presence/status test now feeds its actual status
  WebSocket response through `readGatewayMemory`. All five byte counters must
  be finite and nonnegative; each sample field must equal the same response's
  counter divided by 1048576. There is no second memory sample.
- In the earlier 43-test run, removing the added producer fields made that wire test fail for
  `Expected numeric process memory field: externalBytes`. The producer was
  restored byte-for-byte before all three green suites ran. That intended-red
  proof is retained; it was not repeated for the byte-identical reconciliation.
- The fixture mocks summary/collector collaborators; the memory producer,
  status handler, WebSocket transport, and production benchmark reader are
  real. This is not an operator Gateway workload.
- Remote targeted and changed-file formatting, initial changed guards, script
  erasability, and production core types passed. The remaining changed checks
  were interrupted during core-test types by the local controller's disk
  safety guard. No final aggregate success record was emitted.
- Fresh independent P2 review found no actionable findings; the reviewed
  reconciliation did not alter the seven-file patch. Complete client-side
  logs were retained, and exact lease cleanup was confirmed.

The [Actions run](https://github.com/openclaw/openclaw/actions/runs/34758416958)
records the Testbox lifecycle; application results were captured by the client.
Complete captured stdout SHA256:
`b3413319aa17949f34ce34126d9edbad7ad62bd67fefd25031a93e7618021aff`;
stderr SHA256:
`3613de49b1c91e6f23797759c2a344bf8563439c8ec8933e0c0b0e10e0c67b51`.

### Historical Proof and Remaining Gates

The unchanged original six-file candidate previously passed 35 focused tests,
all four tsgo lanes (including all 17 core-test shards), and 13 additional
selected guards with the frozen pnpm 12.3.4 installation. Earlier 16 guard
passes and three targeted type-aware lint passes used a different installation
and are retained only as historical evidence.

The initial changed-check run passed its first 10 steps, then stopped on the
untouched `sdk-untrusted-context-identifier-aliases` compatibility deadline in
the old base. The reconciled run passed main's separate `removal-pending`
disposition before the disk-guard interruption described above. This PR changes
no aliases, deadlines, or exceptions.

The prior exact-head CI failure was in an unrelated SQLite reclamation-memory
test. Its owner fix landed in
[PR147028](https://github.com/openclaw/openclaw/pull/147028), and the native
main reconciliation includes that fix without adding it to this PR's seven-file
delta.

**Landed:** squash-merged on September 13, 2026 as
`c8d4673c294c6b543533c5f03eb09115a4eb60b0` after native review, hosted-evidence
prepare, and merge completed. Required
[CI](https://github.com/openclaw/openclaw/actions/runs/34759420714) passed for
exact head `55079d16e561f991f129c74340548d9b8d1e9352`. The interrupted
changed-check invocation above remains incomplete; it is not relabeled as a
pass. No application tests, checks, builds, or benchmarks ran locally.
