### PR TITLE
fix(codex): keep replies working after sub-plugin changes

### DIFF
--- a/extensions/codex/index.test.ts
+++ b/extensions/codex/index.test.ts
@@ -62,6 +62,12 @@ describe("codex plugin", () => {
     expect(manifest.providers).toBeUndefined();
   });
 
+  it("keeps only Codex sub-plugin policy changes on the live thread-rotation path", () => {
+    expect(plugin.reload).toEqual({
+      noopPrefixes: ["plugins.entries.codex.config.codexPlugins"],
+    });
+  });
+
   it("does not select an agent or open plugin state while registering", () => {
     const openSyncKeyedStore = vi.fn(() => {
       throw new Error("openSyncKeyedStore is only available through the plugin runtime proxy");

--- a/extensions/codex/index.ts
+++ b/extensions/codex/index.ts
@@ -69,6 +69,9 @@ export default definePluginEntry({
   id: "codex",
   name: "Codex",
   description: "Codex app-server harness and native session supervision.",
+  reload: {
+    noopPrefixes: ["plugins.entries.codex.config.codexPlugins"],
+  },
   register(api) {
     // Bundled modules may execute from a shared dist chunk, so import.meta.url
     // cannot identify the owning plugin package or its pinned dependencies.

--- a/extensions/codex/src/command-plugins-management.test.ts
+++ b/extensions/codex/src/command-plugins-management.test.ts
@@ -327,6 +327,7 @@ describe("Codex /codex plugins subcommand", () => {
     });
     expect(io.currentConfig()).not.toHaveProperty("allow_all_plugins");
     expect(result.text).toContain("installed and authorized");
+    expect(result.text).toContain("Takes effect on your next message.");
   });
 
   it("installs remote plugins with their opaque remote identity and preserves exact summary ids", async () => {
@@ -728,6 +729,7 @@ describe("Codex /codex plugins subcommand", () => {
     );
     expect(installed.text).toContain("points to a different plugin identity");
     expect(enabled.text).toContain("enabled in openclaw.json");
+    expect(enabled.text).toContain("Takes effect on your next message.");
     expect(runtime.install).not.toHaveBeenCalled();
     expect(io.current()["security-review@company-tools"]).toEqual({
       enabled: true,

--- a/extensions/codex/src/command-plugins-management.ts
+++ b/extensions/codex/src/command-plugins-management.ts
@@ -55,11 +55,9 @@ type ConfiguredPluginKeyResolution =
   | { status: "mismatched" };
 
 // Plugin lifecycle changes (enable/disable) write to openclaw.json
-// synchronously. The Codex app-server picks up the new policy when the next
-// thread starts; in-flight conversations keep the old policy until /new or
-// /reset. A full gateway restart is NOT needed.
-const POLICY_REFRESH_HINT =
-  "New Codex conversations pick this up automatically. Use /new or /reset to refresh the current one.";
+// synchronously. The next message rotates the native thread onto the new
+// policy; a conversation reset or full gateway restart is not needed.
+const POLICY_REFRESH_HINT = "Takes effect on your next message.";
 
 export async function handleCodexPluginsSubcommand(
   ctx: PluginCommandContext,
@@ -701,6 +699,6 @@ function formatPluginList(
     ...(globalEnabled
       ? []
       : ["Global codexPlugins.enabled is off; configured sub-plugins are inactive.", ""]),
-    "New Codex conversations pick up policy changes automatically; /new or /reset to refresh the current one.",
+    POLICY_REFRESH_HINT,
   ].join("\n");
 }

--- a/src/gateway/config-diff.ts
+++ b/src/gateway/config-diff.ts
@@ -5,21 +5,36 @@ import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isPlainObject } from "../utils.js";
 
 /** Return dotted config paths whose values differ between two config snapshots. */
-export function diffConfigPaths(prev: unknown, next: unknown, prefix = ""): string[] {
+export function diffConfigPaths(
+  prev: unknown,
+  next: unknown,
+  prefix = "",
+  refinementPrefixes: readonly string[] = [],
+): string[] {
   if (prev === next) {
     return [];
   }
-  if (isPlainObject(prev) && isPlainObject(next)) {
-    const keys = new Set([...Object.keys(prev), ...Object.keys(next)]);
+  const hasNestedRefinement = refinementPrefixes.some((entry) =>
+    prefix ? entry.startsWith(`${prefix}.`) : true,
+  );
+  // A missing parent normally collapses to one path. Registered boundaries must
+  // survive that collapse so a narrow owner rule can still outrank its fallback.
+  if (
+    (isPlainObject(prev) && isPlainObject(next)) ||
+    (hasNestedRefinement && (isPlainObject(prev) || isPlainObject(next)))
+  ) {
+    const prevRecord = isPlainObject(prev) ? prev : {};
+    const nextRecord = isPlainObject(next) ? next : {};
+    const keys = new Set([...Object.keys(prevRecord), ...Object.keys(nextRecord)]);
     const paths: string[] = [];
     for (const key of keys) {
-      const prevValue = prev[key];
-      const nextValue = next[key];
+      const prevValue = prevRecord[key];
+      const nextValue = nextRecord[key];
       if (prevValue === undefined && nextValue === undefined) {
         continue;
       }
       const childPrefix = prefix ? `${prefix}.${key}` : key;
-      const childPaths = diffConfigPaths(prevValue, nextValue, childPrefix);
+      const childPaths = diffConfigPaths(prevValue, nextValue, childPrefix, refinementPrefixes);
       if (childPaths.length > 0) {
         paths.push(...childPaths);
       }
@@ -62,8 +77,9 @@ function projectGatewayReloadBoundaries(config: OpenClawConfig) {
 export function diffGatewayReloadPaths(
   prevConfig: OpenClawConfig,
   nextConfig: OpenClawConfig,
+  reloadPrefixes: Iterable<string>,
 ): string[] {
-  const changedPaths = diffConfigPaths(prevConfig, nextConfig);
+  const changedPaths = diffConfigPaths(prevConfig, nextConfig, "", [...reloadPrefixes]);
   const boundaryPaths = diffConfigPaths(
     projectGatewayReloadBoundaries(prevConfig),
     projectGatewayReloadBoundaries(nextConfig),

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -180,6 +180,7 @@ const BASE_RELOAD_RULES_TAIL: ReloadRule[] = [
 ];
 
 let cachedReloadRules: ReloadRule[] | null = null;
+let cachedRefinementPrefixes: string[] = [];
 let cachedRegistry: ReturnType<typeof getActivePluginHttpRouteRegistry> | null = null;
 let cachedGatewayRegistryVersion = -1;
 
@@ -191,6 +192,7 @@ function listReloadRules(): ReloadRule[] {
   // version changes; cache them to keep every config diff cheap.
   if (registry !== cachedRegistry || gatewayRegistryVersion !== cachedGatewayRegistryVersion) {
     cachedReloadRules = null;
+    cachedRefinementPrefixes = [];
     cachedRegistry = registry;
     cachedGatewayRegistryVersion = gatewayRegistryVersion;
   }
@@ -275,8 +277,16 @@ function listReloadRules(): ReloadRule[] {
   // Narrow config contracts must override broad owner fallbacks. Sort once per
   // registry snapshot so the hot path can retain first-match semantics.
   rules.sort((a, b) => b.prefix.length - a.prefix.length);
+  cachedRefinementPrefixes = [...pluginReloadRules, ...channelReloadRules].map(
+    (rule) => rule.prefix,
+  );
   cachedReloadRules = rules;
   return rules;
+}
+
+export function listConfigReloadRefinementPrefixes(): string[] {
+  listReloadRules();
+  return cachedRefinementPrefixes;
 }
 
 function matchRule(path: string): ReloadRule | null {

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -52,6 +52,7 @@ import {
   buildGatewayReloadPlan,
   type ChannelKind,
   isNoopGatewayReloadPlan,
+  listConfigReloadRefinementPrefixes,
   resolveConfigReloadMetadata,
 } from "./config-reload-plan.js";
 import { resolveGatewayReloadSettings } from "./config-reload-settings.js";
@@ -179,7 +180,7 @@ describe("diffConfigPaths", () => {
     { prev: {}, next: { mcp: { apps: { enabled: true } } } },
     { prev: { mcp: { apps: { enabled: true } } }, next: {} },
   ])("preserves the Apps restart boundary for whole MCP changes", ({ prev, next }) => {
-    const changedPaths = diffGatewayReloadPaths(prev, next);
+    const changedPaths = diffGatewayReloadPaths(prev, next, listConfigReloadRefinementPrefixes());
     expect(changedPaths).toEqual(["mcp", "mcp.apps"]);
     expect(buildGatewayReloadPlan(changedPaths).restartReasons).toContain("mcp.apps");
   });
@@ -196,7 +197,11 @@ describe("diffConfigPaths", () => {
       [configure("first"), configure("second"), true],
       [configure("first", "before"), configure("first", "after"), false],
     ] as const) {
-      expect(buildGatewayReloadPlan(diffGatewayReloadPaths(prev, next)).reloadPlugins).toBe(reload);
+      expect(
+        buildGatewayReloadPlan(
+          diffGatewayReloadPaths(prev, next, listConfigReloadRefinementPrefixes()),
+        ).reloadPlugins,
+      ).toBe(reload);
     }
   });
 
@@ -262,7 +267,11 @@ describe("diffConfigPaths", () => {
       expectedPaths: ["session.scope", "session.store"],
     },
   ])("preserves hook policy dependencies when it $name", ({ prev, next, expectedPaths }) => {
-    const changedPaths = diffGatewayReloadPaths(prev as OpenClawConfig, next as OpenClawConfig);
+    const changedPaths = diffGatewayReloadPaths(
+      prev as OpenClawConfig,
+      next as OpenClawConfig,
+      listConfigReloadRefinementPrefixes(),
+    );
 
     for (const expectedPath of expectedPaths) {
       expect(changedPaths).toContain(expectedPath);
@@ -345,6 +354,12 @@ describe("buildGatewayReloadPlan", () => {
       pluginId: "canvas",
       pluginName: "Canvas",
       registration: { restartPrefixes: ["plugins.entries.canvas"] },
+      source: "test",
+    },
+    {
+      pluginId: "codex",
+      pluginName: "Codex",
+      registration: { noopPrefixes: ["plugins.entries.codex.config.codexPlugins"] },
       source: "test",
     },
   ];
@@ -593,7 +608,7 @@ describe("buildGatewayReloadPlan", () => {
     [{ agents: { defaults: { mediaMaxMb: 4 } } }, { agents: {} }],
     [{ agents: { defaults: { mediaMaxMb: 4 } } }, { agents: { defaults: { mediaMaxMb: 1 } } }],
   ])("refreshes every channel when the global media limit changes: %j → %j", (prev, next) => {
-    const paths = diffGatewayReloadPaths(prev, next);
+    const paths = diffGatewayReloadPaths(prev, next, listConfigReloadRefinementPrefixes());
     expect(paths).toContain("agents.defaults.mediaMaxMb");
     const plan = buildGatewayReloadPlan(paths);
     expect(plan.restartGateway).toBe(false);
@@ -804,6 +819,111 @@ describe("buildGatewayReloadPlan", () => {
     expect(plan.restartReasons).toEqual([path]);
     expect(plan.hotReasons).toStrictEqual([]);
   });
+
+  const codexEntryConfig = (config?: Record<string, unknown>) => ({
+    plugins: {
+      entries: {
+        codex: config ? { config } : {},
+      },
+    },
+  });
+
+  it.each([
+    {
+      name: "plugin restart",
+      config: { plugins: { entries: { canvas: { enabled: true } } } },
+      paths: ["plugins.entries.canvas"],
+      kind: "restart",
+      channels: [],
+    },
+    {
+      name: "plugin hot",
+      config: { browser: { profiles: { qa: { cdpUrl: "http://127.0.0.1:9222" } } } },
+      paths: ["browser.profiles"],
+      kind: "hot",
+      channels: [],
+    },
+    {
+      name: "plugin none",
+      config: codexEntryConfig({ codexPlugins: { enabled: true } }),
+      paths: ["plugins.entries.codex.config.codexPlugins"],
+      kind: "none",
+      channels: [],
+    },
+    {
+      name: "channel hot",
+      config: { channels: { telegram: { enabled: true } } },
+      paths: ["channels.telegram"],
+      kind: "hot",
+      channels: ["telegram"],
+    },
+    {
+      name: "channel noop",
+      config: { channels: { whatsapp: { replyToMode: "all" } } },
+      paths: ["channels.whatsapp.replyToMode"],
+      kind: "none",
+      channels: [],
+    },
+  ] as const)(
+    "preserves registered $name boundaries through parent creation and removal",
+    ({ config, paths, kind, channels }) => {
+      for (const [previous, next] of [
+        [{}, config],
+        [config, {}],
+      ] as const) {
+        const changedPaths = diffGatewayReloadPaths(
+          previous,
+          next,
+          listConfigReloadRefinementPrefixes(),
+        );
+        const plan = buildGatewayReloadPlan(changedPaths);
+
+        expect(changedPaths).toEqual(paths);
+        expect(changedPaths.map((path) => resolveConfigReloadMetadata(path).kind)).toEqual([kind]);
+        expect(plan.restartGateway).toBe(kind === "restart");
+        expect(plan.restartChannels).toEqual(new Set(channels));
+        expect(plan.noopPaths).toEqual(kind === "none" ? paths : []);
+      }
+    },
+  );
+
+  it.each([
+    {
+      name: "creates config on first install",
+      previous: {},
+      next: codexEntryConfig({ codexPlugins: { enabled: true } }),
+      expectedPaths: ["plugins.entries.codex.config.codexPlugins"],
+    },
+    {
+      name: "changes existing sub-plugin policy",
+      previous: codexEntryConfig({ codexPlugins: { enabled: false } }),
+      next: codexEntryConfig({ codexPlugins: { enabled: true } }),
+      expectedPaths: ["plugins.entries.codex.config.codexPlugins.enabled"],
+    },
+    {
+      name: "keeps a mixed first-install write reloadable",
+      previous: {},
+      next: codexEntryConfig({
+        codexPlugins: { enabled: true },
+        appServer: { transport: "websocket" },
+      }),
+      expectedPaths: [
+        "plugins.entries.codex.config.codexPlugins",
+        "plugins.entries.codex.config.appServer",
+      ],
+      reloadPlugins: true,
+    },
+  ])(
+    "classifies Codex config when it $name",
+    ({ previous, next, expectedPaths, reloadPlugins }) => {
+      const paths = diffGatewayReloadPaths(previous, next, listConfigReloadRefinementPrefixes());
+      const plan = buildGatewayReloadPlan(paths);
+
+      expect(paths).toEqual(expectedPaths);
+      expect(plan.reloadPlugins).toBe(reloadPlugins ?? false);
+      expect(isNoopGatewayReloadPlan(plan)).toBe(reloadPlugins !== true);
+    },
+  );
 
   it("uses default reload settings when config is unset", () => {
     expect(resolveGatewayReloadSettings({})).toMatchObject({ mode: "hybrid", debounceMs: 300 });

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -39,6 +39,7 @@ import { diffConfigPaths, diffGatewayReloadPaths } from "./config-diff.js";
 import {
   buildGatewayReloadPlan,
   isNoopGatewayReloadPlan,
+  listConfigReloadRefinementPrefixes,
   listPluginInstallTimestampMetadataPaths,
   listPluginInstallWholeRecordPaths,
   type GatewayReloadPlan,
@@ -537,7 +538,11 @@ export function startGatewayConfigReloader(opts: {
         appliedRevision.defer(plan, nextConfigRevisionHash);
       },
     };
-    const configChangedPaths = diffGatewayReloadPaths(currentCompareConfig, nextCompareConfig);
+    const configChangedPaths = diffGatewayReloadPaths(
+      currentCompareConfig,
+      nextCompareConfig,
+      listConfigReloadRefinementPrefixes(),
+    );
     const configPluginInstallTimestampNoopPaths = listPluginInstallTimestampMetadataPaths(
       currentCompareConfig,
       nextCompareConfig,


### PR DESCRIPTION
Related: #135618

## What Problem This Solves

Fixes an issue where changing Codex sub-plugin policy during a conversation could retire the active plugin generation. Later turns then failed with an inactive host capability until the Gateway restarted. First-time policy installation could take the same broad reload path when its parent config objects were created together.

## Why This Change Was Made

Backports the reviewed fix from #135863 without changing its behavior. Codex sub-plugin policy remains on the live native-thread rotation path, while the Gateway preserves registered reload boundaries through parent-object creation or removal. Other Codex settings still trigger their normal reload.

## User Impact

A policy change takes effect on the next message, and subsequent replies continue without a Gateway restart.

## Evidence

- The upstream change and its focused regression tests cover first install, existing policy, mixed config changes, and other registered plugin and channel rules. Its final-head Autoreview reported `scoped-clean`.
- This cherry-pick applied cleanly to the frozen release head; its stable patch ID `2796268947d07295554dd9145cb8073c8c9db04a` matches upstream, and `git diff --check` passed.
- A fresh independent review of this exact release candidate found no actionable code defect. It checked the Gateway reload boundary and the Codex thread lifecycle against sibling Codex source.
- The repository Autoreview helper could not complete in this host's isolated Codex login environment. Focused local tests were not run in this dependency-free task worktree.
- [PR CI run 1](https://github.com/openclaw/openclaw/actions/runs/34191930160) had 184 successful jobs; lint lost its runner and config shard 48 hit a Matrix binary download `ECONNRESET`. GitHub denied a failed-job rerun to this account, so the PR was reopened to trigger [fresh CI on the same head](https://github.com/openclaw/openclaw/actions/runs/34193995331). In that run, the artifact build, lint, and config shard 48 passed. Config shard 15 timed out in an unchanged Codex test (`default` human wait, 120 seconds); the identical test passed at this head in the first run, taking 75 seconds. Fresh CI finished with 185 successful jobs; config shard 15 was the sole direct failure, so the aggregate gate failed. The log does not identify the blocked await. A maintainer with rerun rights should rerun that shard and verify a green exact-head gate; if it repeats, investigate its first-case startup wait before changing the release patch.
- ClawSweeper found no introduced code or security defect, but requested release-candidate runtime evidence for policy updates, continued replies, and normal reload of mixed settings before merge. That evidence remains outstanding.

## Backport provenance

- `sync_source_run_id`: `sync-20260907-codex-plugin-reload-01`
- `source_repository`: `openclaw/openclaw`
- `upstream_default_branch`: `main`
- `upstream_fix_commit`: `f92a12c5813fb880ed6a05c4a728fd5f4ccc5473`
- `upstream_fix_pull_request`: https://github.com/openclaw/openclaw/pull/135863
- `release_branch`: `sjf_openclaw_2026-09-01`
- `release_base_commit`: `6096144077ff1f28b09a7f47dbcd45c965685475`
- `release_backport_commit`: `ba422faafa44a9697ca2ac5884746635d07e78e6` (`cherry-pick -x`)


