### PR TITLE
test(openshell): bound 7.33 policy sandbox fixture name

### DIFF
--- a/extensions/openshell/src/backend.e2e.test.ts
+++ b/extensions/openshell/src/backend.e2e.test.ts
@@ -11,7 +11,7 @@ import {
   createSandboxSshConfig,
 } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
-import { createOpenShellSandboxBackendFactory } from "./backend.js";
+import { buildOpenShellSandboxName, createOpenShellSandboxBackendFactory } from "./backend.js";
 import { resolveOpenShellPluginConfig } from "./config.js";
 
 const OPENCLAW_OPENSHELL_E2E = process.env.OPENCLAW_E2E_OPENSHELL === "1";
@@ -497,7 +497,9 @@ describe("openshell sandbox backend e2e", () => {
       const allowPolicyPath = path.join(rootDir, "allow-policy.yaml");
       const scopeSuffix = `${process.pid}-${Date.now()}`;
       const scopeKey = `session:openshell-e2e-deny:${scopeSuffix}`;
-      const allowSandboxName = `openclaw-policy-allow-${scopeSuffix}`;
+      const allowSandboxName = buildOpenShellSandboxName(
+        `session:openshell-e2e-allow:${scopeSuffix}`,
+      );
       let hostPolicyServer: HostPolicyServer | null | undefined;
       const sandboxCfg = {
         mode: "all" as const,


### PR DESCRIPTION
## Summary

- use the canonical bounded OpenShell sandbox-name builder in the 7.33 policy E2E fixture
- remove the remaining direct timestamp/PID sandbox name that exceeds OpenShell's name limit

## Why

Production naming was fixed by #141830, but this E2E still constructed `openclaw-policy-allow-<pid>-<timestamp>` directly. Full Validation therefore failed before exercising the policy behavior.

## Validation

- `vitest run extensions/openshell/src/backend.test.ts extensions/openshell/src/openshell-core.test.ts` (45/45)
- formatting and diff checks
