### PR TITLE
fix(qa-channel): preserve inbound references on queued replies

### DIFF
--- a/docs/plugins/sdk-channel-plugins.md
+++ b/docs/plugins/sdk-channel-plugins.md
@@ -889,6 +889,13 @@ native API requires a thread root can resolve a current-message reply against
 the admitted thread without redirecting arbitrary explicit `replyToId` targets.
 Omitted intent keeps the existing explicit-target behavior.
 
+For queued replies to the originating channel, the hook may also receive
+`currentMessageId`, the external inbound message ID captured by the queue owner.
+It is optional context, not an explicit reply target: core does not attach it as
+`replyToId`. The channel decides whether to use it for implicit correlation,
+while preserving explicit targets, null opt-outs, and reply-mode filtering.
+Internal and inter-session turns do not supply this external message fact.
+
 Auth-only channels can usually stop at the default path: core handles
 approvals and the plugin just exposes outbound/auth capabilities. Native
 approval channels such as Matrix, Slack, Telegram, and custom chat transports

--- a/extensions/qa-channel/src/channel.threading.test.ts
+++ b/extensions/qa-channel/src/channel.threading.test.ts
@@ -2,6 +2,66 @@ import { describe, expect, it } from "vitest";
 import { qaChannelPlugin } from "../api.js";
 
 describe("qa-channel thread delivery contracts", () => {
+  it.each<{
+    name: string;
+    currentMessageId?: string;
+    replyToId?: string | null;
+    explicit?: boolean;
+    mode?: "off" | "first" | "all" | "batched";
+    expected: { replyToId: string } | null;
+  }>([
+    {
+      name: "implicit current inbound",
+      currentMessageId: "queued-inbound",
+      expected: { replyToId: "queued-inbound" },
+    },
+    {
+      name: "all mode",
+      currentMessageId: "queued-inbound",
+      mode: "all",
+      expected: { replyToId: "queued-inbound" },
+    },
+    { name: "off mode", currentMessageId: "queued-inbound", mode: "off", expected: null },
+    { name: "first mode", currentMessageId: "queued-inbound", mode: "first", expected: null },
+    { name: "batched mode", currentMessageId: "queued-inbound", mode: "batched", expected: null },
+    {
+      name: "explicit null opt-out",
+      currentMessageId: "queued-inbound",
+      replyToId: null,
+      expected: null,
+    },
+    {
+      name: "explicit target",
+      currentMessageId: "queued-inbound",
+      replyToId: "explicit-target",
+      expected: null,
+    },
+    {
+      name: "explicit empty target",
+      currentMessageId: "queued-inbound",
+      replyToId: "",
+      explicit: true,
+      expected: null,
+    },
+    {
+      name: "explicit intent without target",
+      currentMessageId: "queued-inbound",
+      explicit: true,
+      expected: null,
+    },
+    { name: "missing inbound", expected: null },
+  ])("preserves $name during queued reply resolution", (testCase) => {
+    expect(
+      qaChannelPlugin.threading?.resolveReplyTransport?.({
+        cfg: {},
+        currentMessageId: testCase.currentMessageId,
+        replyToId: testCase.replyToId,
+        replyToIsExplicit: testCase.explicit,
+        ...(testCase.mode ? { replyDelivery: { replyToMode: testCase.mode } } : {}),
+      }),
+    ).toEqual(testCase.expected);
+  });
+
   it.each([
     {
       name: "channel thread with shared-room ChatType",

--- a/extensions/qa-channel/src/channel.ts
+++ b/extensions/qa-channel/src/channel.ts
@@ -243,6 +243,24 @@ export const qaChannelPlugin: ChannelPlugin<ResolvedQaChannelAccount> = createCh
       },
     },
     threading: {
+      resolveReplyTransport: ({
+        currentMessageId,
+        replyToId,
+        replyToIsExplicit,
+        replyDelivery,
+      }) => {
+        if (
+          !currentMessageId ||
+          replyToId !== undefined ||
+          replyToIsExplicit ||
+          (replyDelivery && replyDelivery.replyToMode !== "all")
+        ) {
+          return null;
+        }
+        // Correlate queued replies like the inbound callback, without restoring
+        // references that an earlier first/off/batched policy may have removed.
+        return { replyToId: currentMessageId };
+      },
       matchesToolContextTarget: ({ target, toolContext }) =>
         matchesQaToolContextTarget(target, toolContext),
       resolveAutoThreadId: ({ to, toolContext }) =>

--- a/src/auto-reply/reply/followup-delivery.channel.test.ts
+++ b/src/auto-reply/reply/followup-delivery.channel.test.ts
@@ -156,6 +156,80 @@ afterEach(() => {
 });
 
 describe("follow-up delivery channel boundary", () => {
+  it.each<{
+    name: string;
+    payload?: ReplyPayload;
+    provenance?: AdmittedFollowupTurn["queued"]["run"]["inputProvenance"];
+    sourceChannel?: string;
+    targetChannel?: string;
+    omitMessageId?: boolean;
+    expectedReply: string | null;
+  }>([
+    { name: "implicit current inbound", expectedReply: "new-inbound" },
+    {
+      name: "explicit external provenance",
+      provenance: { kind: "external_user" },
+      expectedReply: "new-inbound",
+    },
+    {
+      name: "explicit reply target",
+      payload: { text: "queued answer", replyToId: "explicit-target" },
+      expectedReply: "explicit-target",
+    },
+    {
+      name: "restart sentinel",
+      provenance: { kind: "internal_system", sourceTool: "restart-sentinel" },
+      expectedReply: null,
+    },
+    {
+      name: "child announcement",
+      provenance: { kind: "inter_session", sourceTool: "subagent_announce" },
+      expectedReply: null,
+    },
+    { name: "different source channel", sourceChannel: "discord", expectedReply: null },
+    { name: "another channel", targetChannel: "imessage", expectedReply: null },
+    { name: "no inbound id", omitMessageId: true, expectedReply: null },
+  ])("passes queued origin message facts to the channel resolver: $name", async (testCase) => {
+    const source = createChannelPlugin("slack");
+    source.threading = {
+      resolveReplyTransport: ({ currentMessageId, replyToId }) => ({
+        replyToId: replyToId ?? currentMessageId,
+      }),
+    };
+    setActivePluginRegistry(
+      createTestRegistry([
+        { pluginId: "slack", plugin: source, source: "test" },
+        { pluginId: "imessage", plugin: createChannelPlugin("imessage"), source: "test" },
+      ]),
+    );
+    const channel = testCase.targetChannel ?? "slack";
+    const turn = createTurn({
+      messageProvider: testCase.sourceChannel ?? channel,
+      originatingChannel: channel,
+    });
+    turn.queued.originatingTo = "dm:qa-peer";
+    turn.queued.messageId = testCase.omitMessageId ? undefined : "new-inbound";
+    turn.queued.originatingChatType = "direct";
+    turn.queued.run.inputProvenance = testCase.provenance;
+    const payload = testCase.payload ?? { text: "queued answer" };
+    channelState.outcomes = ["delivered"];
+    await deliverFollowupDecision({
+      decision: { kind: "deliver", payloads: [payload] },
+      turn,
+      defaults: createDefaults(vi.fn(async () => {})),
+      runId: "run-1",
+      runFollowup: vi.fn(async () => {}),
+    });
+    expect(channelState.deliver).toHaveBeenCalledOnce();
+    expect(channelState.deliver).toHaveBeenCalledWith(
+      expect.objectContaining({
+        channel,
+        to: "dm:qa-peer",
+        replyToId: testCase.expectedReply,
+      }),
+    );
+  });
+
   it.each([true, false])(
     "carries current-reply intent (%s) through queued status delivery",
     async (replyToCurrent) => {

--- a/src/auto-reply/reply/followup-delivery.ts
+++ b/src/auto-reply/reply/followup-delivery.ts
@@ -419,6 +419,12 @@ async function sendFollowupPayloads(params: {
         requesterSenderUsername: turn.queued.run.senderUsername,
         requesterSenderE164: turn.queued.run.senderE164,
         threadId: turn.queued.originatingThreadId,
+        currentMessageId:
+          sameChannelOrigin &&
+          (turn.queued.run.inputProvenance?.kind === undefined ||
+            turn.queued.run.inputProvenance.kind === "external_user")
+            ? turn.queued.messageId
+            : undefined,
         cfg: turn.config,
         mirror:
           metadata?.assistantMessageIndex !== undefined ||

--- a/src/auto-reply/reply/route-reply.ts
+++ b/src/auto-reply/reply/route-reply.ts
@@ -105,6 +105,8 @@ type RouteReplyParams = {
   requesterSenderE164?: string;
   /** Thread id for replies (Telegram topic id or Matrix thread event id). */
   threadId?: string | number;
+  /** Originating inbound message fact for the owning channel's reply resolver. */
+  currentMessageId?: string;
   /** Reply policy fallback for delivery kinds that do not carry payload metadata. */
   replyDelivery?: ReplyDeliveryContext;
   /** Config for provider-specific settings. */
@@ -315,6 +317,7 @@ export async function routeReply(params: RouteReplyParams): Promise<RouteReplyRe
       accountId,
       threadId,
       replyToId,
+      currentMessageId: params.currentMessageId,
       replyToIsExplicit: Boolean(
         payloadMetadata?.replyToIdExplicit || normalized.replyToTag || normalized.replyToCurrent,
       ),

--- a/src/channels/plugins/types.core.ts
+++ b/src/channels/plugins/types.core.ts
@@ -438,6 +438,8 @@ export type ChannelThreadingAdapter = {
   resolveReplyTransport?: (params: {
     cfg: OpenClawConfig;
     accountId?: string | null;
+    /** Originating inbound message in this routed channel; not an explicit reply target. */
+    currentMessageId?: string;
     threadId?: string | number | null;
     replyToId?: string | null;
     /** True when replyToId came from an explicit payload target or reply tag. */


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where QA Channel replies lose their inbound message reference when a new message is queued behind an active turn. A restart-recovery scenario delivered both the recovery answer and the new answer, but the queued answer had no `replyToId`.

## Why This Change Was Made

Carry the queued external inbound message ID through the existing transport resolver as optional context. QA alone uses it for implicit all-mode correlation, matching its ordinary inbound callback. Core does not force a reply target onto other channels.

Explicit targets, null/empty opt-outs, and first/off/batched filtering remain unchanged. Internal and inter-session turns do not supply synthetic IDs; the handoff uses typed provenance and requires the originating channel to match.

## User Impact

Queued QA answers retain the same inbound correlation as ordinary QA replies. Other channel policies and explicit reply targets are preserved. The optional resolver field is documented; there are no configuration, schema, or new SDK-subpath changes.

## Evidence

- A controlled current-main test using the real followup router and QA plugin reproduced the missing reference; the explicit-target control passed. The same probe passed after the repair.
- All 246 affected routing, threading, delivery-custody, and QA inbound tests passed. Final retained tests follow the repository's type-graph boundaries: 39 core handoff and QA-owned policy controls passed after separating the initial combined probe.
- Full scoped checks passed, including core/plugin production and test types, graph boundaries, lint, formatting, exports, and applicable guards. The initial combined test's forbidden extension import was removed without adding a guard exception.
- Independent P2 review and lead review found no actionable issues.

This is transport-boundary proof, not an authenticated live-channel run. The change deliberately leaves first/batched semantics alone and is independent of release qualification.
