### PR TITLE
refactor: give root project validation one test owner

### DIFF
--- a/test/vitest-projects-config.test.ts
+++ b/test/vitest-projects-config.test.ts
@@ -1,5 +1,6 @@
 // Vitest project config tests validate aggregate Vitest project wiring.
 import { afterEach, describe, expect, it } from "vitest";
+import { spawnNodeEvalSync } from "../src/test-utils/node-process.js";
 import { createPatternFileHelper } from "./helpers/pattern-file.js";
 import { normalizeConfigPath, normalizeConfigPaths } from "./helpers/vitest-config-paths.js";
 import { auditFullSuiteTestFileOwnership } from "./vitest-projects-config.test-support.js";
@@ -44,6 +45,7 @@ import {
   sharedVitestConfig,
 } from "./vitest/vitest.shared.config.ts";
 import { fullSuiteVitestShards } from "./vitest/vitest.test-shards.mjs";
+import { DEFAULT_VITEST_TEST_TIMEOUT_MS } from "./vitest/vitest.timeouts.ts";
 import { uiIsolatedTestFiles } from "./vitest/vitest.ui-isolated-paths.mjs";
 import { createUiVitestConfig } from "./vitest/vitest.ui.config.ts";
 import { createUnitFastFakeTimersVitestConfig } from "./vitest/vitest.unit-fast-fake-timers.config.ts";
@@ -83,6 +85,30 @@ afterEach(() => {
 });
 
 describe("projects vitest config", () => {
+  it("resolves the complete root watch project graph", () => {
+    const result = spawnNodeEvalSync(
+      `
+        import { resolveConfig } from "vitest/node";
+        import rootConfig from "./vitest.config.ts";
+        const resolved = await resolveConfig({ config: false }, rootConfig);
+        console.log("ROOT_PROJECT_RESOLUTION " + resolved.test.resolvedProjects.length);
+      `,
+      {
+        imports: ["tsx"],
+        env: { ...process.env, GITHUB_ACTIONS: "true", OPENCLAW_VITEST_INCLUDE_FILE: undefined },
+        timeout: DEFAULT_VITEST_TEST_TIMEOUT_MS,
+      },
+    );
+    expect(result.error, result.stderr).toBeUndefined();
+    expect(result.signal, result.stderr).toBeNull();
+    expect(result.status, result.stderr).toBe(0);
+    const report = result.stdout
+      .split("\n")
+      .find((line) => line.startsWith("ROOT_PROJECT_RESOLUTION "));
+    expect(report, result.stdout).toBeDefined();
+    expect(Number(report!.slice("ROOT_PROJECT_RESOLUTION ".length))).toBeGreaterThan(0);
+  });
+
   it("keeps root and full-suite agent projects aligned with canonical owners", () => {
     const agenticShard = fullSuiteVitestShards.find((shard) => shard.name === "agentic");
     const agentConfigs = new Set(agentVitestProjectConfigs);

--- a/test/vitest-reporters-config.test.ts
+++ b/test/vitest-reporters-config.test.ts
@@ -39,16 +39,15 @@ describe("Vitest reporter contracts", () => {
             const root = config.startsWith("ui/") ? path.resolve("ui") : process.cwd();
             const imported = (await import(pathToFileURL(path.resolve(config)).href)).default;
             const options = { root, config: false };
-            const normal = await resolveConfig(options, imported);
-            const cli = parseCLI(["vitest", "--reporter=json"]).options;
-            let cliConfig = imported;
+            let reporterConfig = imported;
             if (config === "vitest.config.ts") {
-              // The default resolution validates the full matrix in both environments.
-              // Reporter CLI overrides do not propagate to child projects.
-              cliConfig = { ...imported, test: { ...imported.test } };
-              delete cliConfig.test.projects;
+              // The project-config suite owns full root graph resolution.
+              reporterConfig = { ...imported, test: { ...imported.test } };
+              delete reporterConfig.test.projects;
             }
-            const override = await resolveConfig({ ...cli, ...options }, cliConfig);
+            const normal = await resolveConfig(options, reporterConfig);
+            const cli = parseCLI(["vitest", "--reporter=json"]).options;
+            const override = await resolveConfig({ ...cli, ...options }, reporterConfig);
             defaults.push({ config, reporters: normal.test.reporters, cli: override.test.reporters });
           }
           const customConfig = {
@@ -75,7 +74,12 @@ describe("Vitest reporter contracts", () => {
         `,
         {
           imports: ["tsx"],
-          env: { ...process.env, AI_AGENT: "vitest-reporter-test", GITHUB_ACTIONS: githubActions },
+          env: {
+            ...process.env,
+            AI_AGENT: "vitest-reporter-test",
+            GITHUB_ACTIONS: githubActions,
+            OPENCLAW_VITEST_INCLUDE_FILE: undefined,
+          },
           timeout: DEFAULT_VITEST_TEST_TIMEOUT_MS,
         },
       );


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves a problem where reporter-contract tests repeatedly initialize the full root project graph even though their assertions only inspect reporter settings. Their child processes also inherit focused test-selection filters, making focused and full-suite configuration resolution differ.

## Why This Change Was Made

Resolve the root reporter settings without expanding projects for both default and CLI reporter checks. Preserve real full-root loading once in the project-config suite, with a successful subprocess exit and a nonempty resolved-project assertion. Both child paths clear inherited include-file filtering; the graph smoke deliberately uses the CI environment.

## User Impact

No product behavior changes. All 19 reporter resolutions per environment and both environment rows remain, with unchanged reporter assertions. The project suite now explicitly protects the root-watch startup contract.

## Evidence

- Complete suites: 26 original cases passed; all 27 cases passed after the change.
- A temporary duplicate name in a real child config made the new smoke fail with Vitest's duplicate-project error. Restoring the config restored the complete passing suite.
- Changed-file gate and fresh P2 review passed.
- This adds 30 test lines. The local run is not a measured full-suite speedup or proof that the historical timeout is fixed. Existing comparison controls must be updated explicitly for the new ownership before another campaign comparison.
