### PR TITLE
refactor(tests): share fresh core logger fixtures

### DIFF
--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import nodePath from "node:path";
 import chokidar from "chokidar";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInfoWarnErrorLogger } from "../../test/helpers/mock-logger.js";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import type { ChannelPlugin } from "../channels/plugins/types.js";
@@ -1650,11 +1651,7 @@ function createReloaderHarness(
       }
     };
   });
-  const log = {
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-  };
+  const log = createInfoWarnErrorLogger();
   const initialConfig = options.initialConfig ?? { gateway: { reload: {} } };
   const reloader = startGatewayConfigReloader({
     testDebounceMs: 0,

--- a/src/gateway/server-reload-handlers.test.ts
+++ b/src/gateway/server-reload-handlers.test.ts
@@ -6,6 +6,7 @@ import { readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import chokidar from "chokidar";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInfoWarnErrorLogger } from "../../test/helpers/mock-logger.js";
 import { createDeferred } from "../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import {
@@ -8129,11 +8130,7 @@ describe("deferred channel reload abort generation", () => {
       const application = createRuntimeConfigWriteApplication();
       const settled = vi.fn();
       void application.result.then(settled);
-      const logReload = {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      };
+      const logReload = createInfoWarnErrorLogger();
       const watch = vi.spyOn(chokidar, "watch");
       setActivePluginRegistry(registry);
       const reloader = startManagedGatewayConfigReloader({

--- a/src/gateway/server-runtime-services.test-harness.ts
+++ b/src/gateway/server-runtime-services.test-harness.ts
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+import { createInfoWarnErrorLogger } from "../../test/helpers/mock-logger.js";
 import type { scheduleGatewayPostReadyMaintenance } from "./server-runtime-services.js";
 
 type StartSessionDeliveryRuntime =
@@ -112,11 +113,7 @@ export function waitForFast<T>(
 
 export function createLog() {
   return {
-    child: vi.fn(() => ({
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    })),
+    child: vi.fn(() => createInfoWarnErrorLogger()),
     warn: vi.fn(),
     error: vi.fn(),
   };

--- a/src/gateway/server-startup-config.breaker-secrets.integration.test.ts
+++ b/src/gateway/server-startup-config.breaker-secrets.integration.test.ts
@@ -1,6 +1,7 @@
 /** Integration coverage for breaker-safe startup SecretRef activation. */
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "../secrets/runtime-telegram.test-support.ts";
+import { createInfoWarnErrorLogger } from "../../test/helpers/mock-logger.js";
 import type { ConfigFileSnapshot, OpenClawConfig } from "../config/types.js";
 import {
   asConfig,
@@ -103,11 +104,7 @@ describe("gateway breaker SecretRef integration", () => {
               loadAuthStore: () => loadAuthStoreWithProfiles({}),
             });
           const activateRuntimeSecrets = createRuntimeSecretsActivator({
-            logSecrets: {
-              info: vi.fn(),
-              warn: vi.fn(),
-              error: vi.fn(),
-            },
+            logSecrets: createInfoWarnErrorLogger(),
             emitStateEvent: vi.fn(),
             prepareRuntimeSecretsSnapshot,
             activateRuntimeSecretsSnapshot: activateSecretsRuntimeSnapshot,

--- a/src/gateway/server-startup-post-attach.test.ts
+++ b/src/gateway/server-startup-post-attach.test.ts
@@ -4,6 +4,10 @@
 import fs from "node:fs";
 import path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  createInfoErrorLogger,
+  createInfoWarnErrorLogger,
+} from "../../test/helpers/mock-logger.js";
 import { createDeferred } from "../../test/helpers/promise.js";
 import type { AuthProfileFailureReason } from "../agents/auth-profiles/types.js";
 import * as configPaths from "../config/paths.js";
@@ -2324,15 +2328,8 @@ describe("startGatewayPostAttachRuntime", () => {
           deps: {} as never,
           startChannels,
           log: { warn: vi.fn() },
-          logHooks: {
-            info: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-          },
-          logChannels: {
-            info: vi.fn(),
-            error: vi.fn(),
-          },
+          logHooks: createInfoWarnErrorLogger(),
+          logChannels: createInfoErrorLogger(),
         });
 
         expect(startChannels).toHaveBeenCalledTimes(1);
@@ -3009,11 +3006,7 @@ describe("startGatewayPostAttachRuntime", () => {
           deps: {} as never,
           startChannels: vi.fn(async () => {}),
           log: { warn: vi.fn() },
-          logHooks: {
-            info: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-          },
+          logHooks: createInfoWarnErrorLogger(),
           logChannels,
           startupTrace: trace.startupTrace,
           prewarmPrimaryModel,
@@ -3052,11 +3045,7 @@ describe("startGatewayPostAttachRuntime", () => {
             throw new Error("channel unavailable");
           }),
           log: { warn: vi.fn() },
-          logHooks: {
-            info: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-          },
+          logHooks: createInfoWarnErrorLogger(),
           logChannels,
           startupTrace: trace.startupTrace,
         });
@@ -3082,11 +3071,7 @@ describe("startGatewayPostAttachRuntime", () => {
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log: { warn: vi.fn() },
-      logHooks: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      },
+      logHooks: createInfoWarnErrorLogger(),
       logChannels: { info: vi.fn(), error: vi.fn() },
       startupTrace: trace.startupTrace,
     });
@@ -3318,15 +3303,8 @@ describe("startGatewayPostAttachRuntime", () => {
       startChannels,
       prewarmPrimaryModel,
       log: { warn: vi.fn() },
-      logHooks: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      },
-      logChannels: {
-        info: vi.fn(),
-        error: vi.fn(),
-      },
+      logHooks: createInfoWarnErrorLogger(),
+      logChannels: createInfoErrorLogger(),
     });
 
     await waitForGatewayTestState(() => {
@@ -3492,15 +3470,8 @@ describe("startGatewayPostAttachRuntime", () => {
         startChannels,
         prewarmPrimaryModel,
         log: { warn: vi.fn() },
-        logHooks: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-        },
-        logChannels: {
-          info: vi.fn(),
-          error: vi.fn(),
-        },
+        logHooks: createInfoWarnErrorLogger(),
+        logChannels: createInfoErrorLogger(),
       }),
     ).rejects.toBe(modelRuntimeError);
 
@@ -3523,15 +3494,8 @@ describe("startGatewayPostAttachRuntime", () => {
       deps: {} as never,
       startChannels,
       log,
-      logHooks: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      },
-      logChannels: {
-        info: vi.fn(),
-        error: vi.fn(),
-      },
+      logHooks: createInfoWarnErrorLogger(),
+      logChannels: createInfoErrorLogger(),
     });
 
     expect(log.warn).toHaveBeenCalledWith(
@@ -3588,15 +3552,8 @@ describe("startGatewayPostAttachRuntime", () => {
         onPostReadySidecars(sidecars);
       },
       log,
-      logHooks: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      },
-      logChannels: {
-        info: vi.fn(),
-        error: vi.fn(),
-      },
+      logHooks: createInfoWarnErrorLogger(),
+      logChannels: createInfoErrorLogger(),
     });
     sidecarStartReturned = true;
 
@@ -3642,15 +3599,8 @@ describe("startGatewayPostAttachRuntime", () => {
       shouldCreatePostReadySidecars: () => !closeStarted,
       onPostReadySidecars,
       log: { warn: vi.fn() },
-      logHooks: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      },
-      logChannels: {
-        info: vi.fn(),
-        error: vi.fn(),
-      },
+      logHooks: createInfoWarnErrorLogger(),
+      logChannels: createInfoErrorLogger(),
     });
 
     await waitForGatewayTestState(() => {
@@ -3849,15 +3799,8 @@ describe("startGatewayPostAttachRuntime", () => {
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log,
-      logHooks: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      },
-      logChannels: {
-        info: vi.fn(),
-        error: vi.fn(),
-      },
+      logHooks: createInfoWarnErrorLogger(),
+      logChannels: createInfoErrorLogger(),
     });
 
     expect(result.postReadySidecars).toHaveLength(2);
@@ -3878,15 +3821,8 @@ describe("startGatewayPostAttachRuntime", () => {
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log: { warn: vi.fn() },
-      logHooks: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      },
-      logChannels: {
-        info: vi.fn(),
-        error: vi.fn(),
-      },
+      logHooks: createInfoWarnErrorLogger(),
+      logChannels: createInfoErrorLogger(),
     });
 
     expect(result.postReadySidecars).toHaveLength(2);
@@ -3929,15 +3865,8 @@ describe("startGatewayPostAttachRuntime", () => {
             startChannels: vi.fn(async () => {}),
             shouldCreatePostReadySidecars: () => !closing,
             log: { warn: vi.fn() },
-            logHooks: {
-              info: vi.fn(),
-              warn: vi.fn(),
-              error: vi.fn(),
-            },
-            logChannels: {
-              info: vi.fn(),
-              error: vi.fn(),
-            },
+            logHooks: createInfoWarnErrorLogger(),
+            logChannels: createInfoErrorLogger(),
           }),
         );
 
@@ -3997,15 +3926,8 @@ describe("startGatewayPostAttachRuntime", () => {
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log: { warn: vi.fn() },
-      logHooks: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      },
-      logChannels: {
-        info: vi.fn(),
-        error: vi.fn(),
-      },
+      logHooks: createInfoWarnErrorLogger(),
+      logChannels: createInfoErrorLogger(),
     });
 
     expect(result.postReadySidecars).toHaveLength(2);
@@ -4434,15 +4356,8 @@ describe("startGatewayPostAttachRuntime", () => {
         deps,
         startChannels: vi.fn(async () => {}),
         log: { warn: vi.fn() },
-        logHooks: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-        },
-        logChannels: {
-          info: vi.fn(),
-          error: vi.fn(),
-        },
+        logHooks: createInfoWarnErrorLogger(),
+        logChannels: createInfoErrorLogger(),
       });
 
       expect(hoisted.commitInternalHooks).toHaveBeenCalledWith({ initial: true });
@@ -4483,15 +4398,8 @@ describe("startGatewayPostAttachRuntime", () => {
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log: { warn: vi.fn() },
-      logHooks: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      },
-      logChannels: {
-        info: vi.fn(),
-        error: vi.fn(),
-      },
+      logHooks: createInfoWarnErrorLogger(),
+      logChannels: createInfoErrorLogger(),
       startupTrace: trace.startupTrace,
       waitForPostReadyWork: () => postReadyWork,
     });
@@ -4528,15 +4436,8 @@ describe("startGatewayPostAttachRuntime", () => {
       deps: {} as never,
       startChannels: vi.fn(async () => {}),
       log: { warn: vi.fn() },
-      logHooks: {
-        info: vi.fn(),
-        warn: vi.fn(),
-        error: vi.fn(),
-      },
-      logChannels: {
-        info: vi.fn(),
-        error: vi.fn(),
-      },
+      logHooks: createInfoWarnErrorLogger(),
+      logChannels: createInfoErrorLogger(),
       startupTrace: trace.startupTrace,
     });
 
@@ -5048,15 +4949,8 @@ function createPostAttachParams(overrides: Partial<PostAttachParams> = {}): Post
       sendRecoveryNotice: vi.fn(),
     },
     resolveGatewayContext: vi.fn(() => ({ recoveryRuntime: {} }) as never),
-    logHooks: {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    },
-    logChannels: {
-      info: vi.fn(),
-      error: vi.fn(),
-    },
+    logHooks: createInfoWarnErrorLogger(),
+    logChannels: createInfoErrorLogger(),
     unlockStartupMethods: vi.fn(),
     providerAuthPrewarm: { enabled: false },
     unregisterConnectionDependentSidecar: vi.fn(),

--- a/src/gateway/server.cron.test.ts
+++ b/src/gateway/server.cron.test.ts
@@ -7,6 +7,7 @@ import { setImmediate as setImmediatePromise } from "node:timers/promises";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import type WebSocket from "ws";
+import { createInfoWarnErrorLogger } from "../../test/helpers/mock-logger.js";
 import { createOperationalRunInstanceRef } from "../agents/admitted-run-context.js";
 import { resetConfigRuntimeState } from "../config/config.js";
 import { loadCronStore, saveCronStore } from "../cron/store.js";
@@ -296,11 +297,7 @@ async function directCronReq(
       context: {
         cron: cronState.cron,
         cronStorePath: cronState.storePath,
-        logGateway: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-        },
+        logGateway: createInfoWarnErrorLogger(),
         getRuntimeConfig: cronState.getRuntimeConfig,
       } as never,
       client: options.client ?? null,

--- a/src/infra/session-delivery-queue.recovery.test.ts
+++ b/src/infra/session-delivery-queue.recovery.test.ts
@@ -9,6 +9,7 @@ const sleepMock = vi.hoisted(() => vi.fn<(ms: number) => Promise<void>>());
 
 vi.mock("../utils/sleep.js", () => ({ sleep: sleepMock }));
 
+import { createInfoWarnErrorLogger } from "../../test/helpers/mock-logger.js";
 import {
   drainPendingSessionDelivery,
   recoverPendingSessionDeliveries,
@@ -49,11 +50,7 @@ describe("session-delivery queue recovery", () => {
         deliver,
         onSettled,
         stateDir: tempDir,
-        log: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-        },
+        log: createInfoWarnErrorLogger(),
       });
 
       expect(deliver).toHaveBeenCalledTimes(1);
@@ -213,11 +210,7 @@ describe("session-delivery queue recovery", () => {
       const summary = await recoverPendingSessionDeliveries({
         deliver,
         stateDir: tempDir,
-        log: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-        },
+        log: createInfoWarnErrorLogger(),
       });
 
       expect(deliver).not.toHaveBeenCalled();
@@ -303,11 +296,7 @@ describe("session-delivery queue recovery", () => {
         const recovery = recoverPendingSessionDeliveries({
           deliver,
           stateDir: tempDir,
-          log: {
-            info: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-          },
+          log: createInfoWarnErrorLogger(),
         });
 
         await expect(controlledSleep.started).resolves.toBe(RECOVERY_REPLAY_SPACING_MS);
@@ -351,11 +340,7 @@ describe("session-delivery queue recovery", () => {
           deliver,
           stateDir: tempDir,
           maxRecoveryMs: 1,
-          log: {
-            info: vi.fn(),
-            warn: vi.fn(),
-            error: vi.fn(),
-          },
+          log: createInfoWarnErrorLogger(),
         });
 
         await expect(controlledSleep.started).resolves.toBe(1);
@@ -431,11 +416,7 @@ describe("session-delivery queue recovery", () => {
         }),
         onSettled,
         stateDir: tempDir,
-        log: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-        },
+        log: createInfoWarnErrorLogger(),
       });
 
       const [failedEntry] = await loadPendingSessionDeliveries(tempDir);
@@ -613,11 +594,7 @@ describe("session-delivery queue recovery", () => {
         bypassBackoff: true,
         deliver,
         stateDir: tempDir,
-        log: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-        },
+        log: createInfoWarnErrorLogger(),
       });
 
       expect(deliver).toHaveBeenCalledTimes(1);
@@ -822,11 +799,7 @@ describe("session-delivery queue recovery", () => {
         deliver,
         stateDir: tempDir,
         maxEnqueuedAt,
-        log: {
-          info: vi.fn(),
-          warn: vi.fn(),
-          error: vi.fn(),
-        },
+        log: createInfoWarnErrorLogger(),
       });
 
       expect(deliver).toHaveBeenCalledTimes(1);

--- a/src/plugin-sdk/runtime.test.ts
+++ b/src/plugin-sdk/runtime.test.ts
@@ -2,6 +2,7 @@
  * Tests plugin SDK runtime exports, logging wrappers, and runtime env helpers.
  */
 import { describe, expect, it, vi } from "vitest";
+import { createInfoErrorLogger } from "../../test/helpers/mock-logger.js";
 import type { RuntimeEnv } from "../runtime.js";
 import { resolveRuntimeEnv } from "./runtime.js";
 
@@ -14,10 +15,7 @@ describe("resolveRuntimeEnv", () => {
         throw new Error("exit");
       }),
     };
-    const logger = {
-      info: vi.fn(),
-      error: vi.fn(),
-    };
+    const logger = createInfoErrorLogger();
 
     const resolved = resolveRuntimeEnv({ runtime, logger });
 
@@ -27,10 +25,7 @@ describe("resolveRuntimeEnv", () => {
   });
 
   it("creates logger-backed runtime when runtime is missing", () => {
-    const logger = {
-      info: vi.fn(),
-      error: vi.fn(),
-    };
+    const logger = createInfoErrorLogger();
 
     const resolved = resolveRuntimeEnv({ logger });
     resolved.log?.("hello %s", "world");

--- a/src/plugins/runtime/metadata-registry-loader.test.ts
+++ b/src/plugins/runtime/metadata-registry-loader.test.ts
@@ -1,5 +1,6 @@
 // Metadata registry loader tests cover metadata-only plugin registry assembly.
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInfoWarnErrorLogger } from "../../../test/helpers/mock-logger.js";
 import type { PluginLoadOptions } from "../loader.js";
 
 const loadConfigMock = vi.fn();
@@ -115,11 +116,7 @@ describe("loadPluginMetadataRegistrySnapshot", () => {
   });
 
   it("forwards an explicit logger through metadata snapshots", () => {
-    const logger = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
+    const logger = createInfoWarnErrorLogger();
 
     loadPluginMetadataRegistrySnapshot({
       config: { plugins: {} },
@@ -147,11 +144,7 @@ describe("loadPluginMetadataRegistrySnapshot", () => {
   });
 
   it("honors explicit load options when reusing a resolved runtime context", () => {
-    const logger = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
+    const logger = createInfoWarnErrorLogger();
     const env = { HOME: "/tmp/context-home" } as NodeJS.ProcessEnv;
     const manifestRegistry = { plugins: [], diagnostics: [] };
 

--- a/src/plugins/status.test.ts
+++ b/src/plugins/status.test.ts
@@ -2,6 +2,7 @@
 
 import { expectDefined } from "@openclaw/normalization-core";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { createInfoWarnErrorLogger } from "../../test/helpers/mock-logger.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
 import {
   createAutoEnabledStatusConfig,
@@ -427,11 +428,7 @@ describe("plugin status reports", () => {
   });
 
   it("forwards an explicit logger to plugin loading", () => {
-    const logger = {
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    };
+    const logger = createInfoWarnErrorLogger();
 
     buildPluginSnapshotReport({
       config: {},

--- a/test/helpers/mock-logger.ts
+++ b/test/helpers/mock-logger.ts
@@ -1,0 +1,16 @@
+import { vi, type Mock } from "vitest";
+
+export function createInfoWarnErrorLogger(): { info: Mock; warn: Mock; error: Mock } {
+  return {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  };
+}
+
+export function createInfoErrorLogger(): { info: Mock; error: Mock } {
+  return {
+    info: vi.fn(),
+    error: vi.fn(),
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Core tests repeat identical logger fixtures across startup, reload, delivery recovery, and plugin-runtime tests, adding maintenance noise without additional coverage.

## Why This Change Was Made

Share two small Vitest-only factories for the exact `info/warn/error` and `info/error` shapes. Each invocation creates a fresh object and fresh method mocks at the original evaluation point. Preserve key order, absent methods, child-callback allocation, caller overrides, assertions, and cleanup. This removes 147 net test/support lines across 48 fixture sites.

## User Impact

No production or user-visible behavior changes. Test scenarios and deadlines remain unchanged.

## Evidence

- Before/after: all 998 tests in the 10 affected core suites passed, with identical ordered case names and statuses. The complete broader selection also passed 1,187 tests across 18 files.
- Final core files exactly match the passing candidate. Plugin fixtures remain unchanged to respect their SDK import boundary.
- Final mapped changed checks passed; independent P2 review is clean. No test-runtime reduction is claimed.
