### PR TITLE
fix(qa): preserve package build heap in scorecard shards

### DIFF
--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -99,6 +99,9 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   NODE_VERSION: "24.x"
   OPENCLAW_BUILD_PRIVATE_QA: "1"
+  # Package-candidate builds run after shard concurrency starts and need the same explicit
+  # heap authority as the initial private-QA build on Blacksmith runners.
+  OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB: "8192"
   OPENCLAW_ENABLE_PRIVATE_QA_CLI: "1"
   OPENCLAW_QA_REDACT_PUBLIC_METADATA: "1"
   OPENCLAW_QA_TRANSPORT_READY_TIMEOUT_MS: "180000"

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -15484,6 +15484,8 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
       const protocolOutput = "${{ needs.validate_selected_ref.outputs.protocol_base_revision }}";
       const trustedInput = "${{ inputs.trusted_ref || inputs.ref }}";
 
+      expect(qaWorkflow.env.OPENCLAW_TSDOWN_MAX_OLD_SPACE_MB).toBe("8192");
+
       expect(qaWorkflow.on.workflow_call.inputs.trusted_ref).toEqual({
         description: "Optional trusted branch, tag, or SHA identity for an immutable ref",
         required: false,


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where full maturity-scorecard shards lost their explicit build-heap authority after the initial private-QA build. Package-candidate builds then refused to run on Blacksmith workers, masking twelve scenarios with build infrastructure failures.

## Why This Change Was Made

The reusable QA profile workflow now exports the same explicit 8192 MB tsdown heap authority for every child build in the shard. The existing initial build keeps its Node heap setting; package-candidate and launcher-triggered rebuilds now inherit the build-specific override as well.

## User Impact

Maintainers can run full maturity-scorecard evidence without package builds being rejected solely because the shard's later child processes lost the workflow's intended heap authority.

## Evidence

- Failing run: https://github.com/openclaw/openclaw/actions/runs/34188662486 — 12 scenarios were masked by tsdown heap-guard failures after the initial private-QA build succeeded.
- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t 'wires and fetches one explicit protocol base before QA execution'` (Node 24.16.0): 1 passed, 519 skipped.
- `oxfmt --check .github/workflows/qa-profile-evidence.yml test/scripts/ci-workflow-guards.test.ts`
- `git diff --check`

The complete full scorecard rerun remains the post-merge proof for the affected scenarios.
