### PR TITLE
fix(agents): continue settled empty post-tool turns

### DIFF
--- a/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.test.ts
@@ -25,6 +25,7 @@ import {
   DEFAULT_REASONING_ONLY_RETRY_LIMIT,
   EMPTY_RESPONSE_RETRY_INSTRUCTION,
   REASONING_ONLY_RETRY_INSTRUCTION,
+  SETTLED_TOOL_CONTINUATION_INSTRUCTION,
   resolveEmptyResponseRetryInstruction,
   isIncompleteTerminalAssistantTurn,
   resolveIncompleteTurnPayloadText as resolveIncompleteTurnPayloadTextCore,
@@ -72,14 +73,18 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(warnMessages().join("\n")).not.toContain(text);
   }
 
-  function runAttemptCall(index: number): { prompt?: string } {
+  function runAttemptCall(index: number): {
+    prompt?: string;
+    disableTools?: boolean;
+    clientTools?: unknown[];
+  } {
     // Continuation prompt assertions read the exact prompt passed to the runner
     // attempt rather than derived result metadata.
     const call = mockedRunEmbeddedAttempt.mock.calls[index];
     if (!call) {
       throw new Error(`Expected run embedded attempt call ${index}`);
     }
-    return call[0] as { prompt?: string };
+    return call[0] as { prompt?: string; disableTools?: boolean; clientTools?: unknown[] };
   }
 
   it("emits the before_agent_run hook block message as the agent payload", async () => {
@@ -3232,6 +3237,95 @@ describe("runEmbeddedAgent incomplete-turn safety", () => {
     expect(result.meta.terminalReplyKind).toBeUndefined();
     expect(result.meta.finalAssistantVisibleText).toBe("Visible StepFun answer.");
     expectWarnMessageWith("empty response detected");
+  });
+
+  it("continues once after a settled side-effecting write without exposing tools", async () => {
+    const emptyStopAssistant = {
+      role: "assistant",
+      api: "openai-responses",
+      stopReason: "stop",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [],
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          assistantTexts: [],
+          toolMetas: [{ toolName: "write", meta: "path=note.txt", replaySafe: false }],
+          itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+          lastAssistant: emptyStopAssistant,
+          currentAttemptAssistant: emptyStopAssistant,
+        }),
+      )
+      .mockResolvedValueOnce(
+        makeAttemptResult({
+          assistantTexts: ["Write completed."],
+          lastAssistant: {
+            role: "assistant",
+            api: "openai-responses",
+            stopReason: "stop",
+            provider: "openai",
+            model: "gpt-5.5",
+            content: [{ type: "text", text: "Write completed." }],
+          } as unknown as EmbeddedRunAttemptResult["lastAssistant"],
+        }),
+      );
+
+    const result = await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-settled-write-empty-stop",
+      agentHarnessRuntimeOverride: "openclaw",
+      clientTools: [
+        {
+          type: "function",
+          function: { name: "host_write", description: "Write through the host" },
+        },
+      ],
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(2);
+    expect(runAttemptCall(1)).toMatchObject({
+      disableTools: true,
+      clientTools: undefined,
+      prompt: expect.stringContaining(SETTLED_TOOL_CONTINUATION_INSTRUCTION),
+    });
+    expect(result.meta.finalAssistantVisibleText).toBe("Write completed.");
+    expectWarnMessageWith("settled post-tool turn lacked a final answer");
+  });
+
+  it("does not continue a settled side-effecting turn through a native tool backend", async () => {
+    const emptyStopAssistant = {
+      role: "assistant",
+      api: "openai-responses",
+      stopReason: "stop",
+      provider: "openai",
+      model: "gpt-5.5",
+      content: [],
+    } as unknown as EmbeddedRunAttemptResult["lastAssistant"];
+    mockedClassifyFailoverReason.mockReturnValue(null);
+    mockedRunEmbeddedAttempt.mockResolvedValueOnce(
+      makeAttemptResult({
+        assistantTexts: [],
+        toolMetas: [{ toolName: "write", meta: "path=note.txt", replaySafe: false }],
+        itemLifecycle: { startedCount: 1, completedCount: 1, activeCount: 0 },
+        lastAssistant: emptyStopAssistant,
+        currentAttemptAssistant: emptyStopAssistant,
+      }),
+    );
+
+    await runEmbeddedAgent({
+      ...overflowBaseRunParams,
+      provider: "openai",
+      model: "gpt-5.5",
+      runId: "run-native-settled-write-empty-stop",
+    });
+
+    expect(mockedRunEmbeddedAttempt).toHaveBeenCalledTimes(1);
+    expect(warnMessages().join("\n")).not.toContain("settled post-tool turn lacked a final answer");
   });
 
   it("returns NO_REPLY without retrying post-tool exact silent assistant replies", async () => {

--- a/src/agents/embedded-agent-runner/run.ts
+++ b/src/agents/embedded-agent-runner/run.ts
@@ -215,6 +215,7 @@ import {
   resolveEmptyResponseRetryInstruction,
   resolveIncompleteTurnPayloadText,
   resolveReasoningOnlyRetryInstruction,
+  resolveSettledToolContinuationInstruction,
   resolveSilentToolResultReplyPayload,
   resolveReplayInvalidFlag,
   resolveRunLivenessState,
@@ -1630,6 +1631,8 @@ async function runEmbeddedAgentInternal(
       let lastRetryFailoverReason: FailoverReason | null = null;
       let reasoningOnlyRetryInstruction: string | null = null;
       let emptyResponseRetryInstruction: string | null = null;
+      let settledToolContinuationInstruction: string | null = null;
+      let settledToolContinuationAttempts = 0;
       let compactionContinuationRetryInstruction: string | null = null;
       let nextAttemptPromptOverride: string | null = null;
       let rateLimitProfileRotations = 0;
@@ -1934,6 +1937,7 @@ async function runEmbeddedAgentInternal(
           const promptAdditions = [
             reasoningOnlyRetryInstruction,
             emptyResponseRetryInstruction,
+            settledToolContinuationInstruction,
             compactionContinuationRetryInstruction,
           ].filter(
             (value): value is string => typeof value === "string" && value.trim().length > 0,
@@ -2091,8 +2095,9 @@ async function runEmbeddedAgentInternal(
             currentInboundContext: params.currentInboundContext,
             images: params.images,
             imageOrder: params.imageOrder,
-            clientTools: params.clientTools,
-            disableTools: params.disableTools,
+            clientTools:
+              settledToolContinuationInstruction === null ? params.clientTools : undefined,
+            disableTools: params.disableTools || settledToolContinuationInstruction !== null,
             provider,
             modelId,
             requestedModelId,
@@ -3721,6 +3726,7 @@ async function runEmbeddedAgentInternal(
                 ? [silentToolResultReplyPayload]
                 : payloadsWithToolMedia;
           const payloadCount = payloadsForTerminalPath?.length ?? 0;
+          const afterSettledToolContinuation = settledToolContinuationAttempts > 0;
           const emptyAssistantReplyIsSilent = shouldTreatEmptyAssistantReplyAsSilent({
             allowEmptyAssistantReplyAsSilent: params.allowEmptyAssistantReplyAsSilent,
             payloadCount,
@@ -3728,29 +3734,31 @@ async function runEmbeddedAgentInternal(
             timedOut,
             attempt,
           });
-          const nextReasoningOnlyRetryInstruction = emptyAssistantReplyIsSilent
-            ? null
-            : resolveReasoningOnlyRetryInstruction({
-                provider: activeErrorContext.provider,
-                modelId: activeErrorContext.model,
-                modelApi: effectiveModel.api,
-                executionContract,
-                aborted,
-                timedOut,
-                attempt,
-              });
-          const nextEmptyResponseRetryInstruction = emptyAssistantReplyIsSilent
-            ? null
-            : resolveEmptyResponseRetryInstruction({
-                provider: activeErrorContext.provider,
-                modelId: activeErrorContext.model,
-                modelApi: effectiveModel.api,
-                executionContract,
-                payloadCount,
-                aborted,
-                timedOut,
-                attempt,
-              });
+          const nextReasoningOnlyRetryInstruction =
+            emptyAssistantReplyIsSilent || afterSettledToolContinuation
+              ? null
+              : resolveReasoningOnlyRetryInstruction({
+                  provider: activeErrorContext.provider,
+                  modelId: activeErrorContext.model,
+                  modelApi: effectiveModel.api,
+                  executionContract,
+                  aborted,
+                  timedOut,
+                  attempt,
+                });
+          const nextEmptyResponseRetryInstruction =
+            emptyAssistantReplyIsSilent || afterSettledToolContinuation
+              ? null
+              : resolveEmptyResponseRetryInstruction({
+                  provider: activeErrorContext.provider,
+                  modelId: activeErrorContext.model,
+                  modelApi: effectiveModel.api,
+                  executionContract,
+                  payloadCount,
+                  aborted,
+                  timedOut,
+                  attempt,
+                });
           if (
             nextReasoningOnlyRetryInstruction &&
             reasoningOnlyRetryAttempts < maxReasoningOnlyRetryAttempts
@@ -3769,6 +3777,7 @@ async function runEmbeddedAgentInternal(
             reasoningOnlyRetryAttempts >= maxReasoningOnlyRetryAttempts;
           if (
             !emptyAssistantReplyIsSilent &&
+            !afterSettledToolContinuation &&
             shouldRetryMissingAssistantTurn({
               payloadCount,
               aborted,
@@ -3782,6 +3791,28 @@ async function runEmbeddedAgentInternal(
             log.warn(
               `missing assistant terminal message detected: runId=${params.runId} sessionId=${params.sessionId} ` +
                 `provider=${activeErrorContext.provider}/${activeErrorContext.model} — retrying ${missingAssistantRetryAttempts}/${MAX_MISSING_ASSISTANT_RETRIES} with same prompt`,
+            );
+            continue;
+          }
+          const nextSettledToolContinuationInstruction =
+            emptyAssistantReplyIsSilent || agentHarness.id !== "openclaw"
+              ? null
+              : resolveSettledToolContinuationInstruction({
+                  provider: activeErrorContext.provider,
+                  modelId: activeErrorContext.model,
+                  modelApi: effectiveModel.api,
+                  executionContract,
+                  payloadCount,
+                  aborted,
+                  timedOut,
+                  attempt,
+                });
+          if (nextSettledToolContinuationInstruction && settledToolContinuationAttempts < 1) {
+            settledToolContinuationAttempts += 1;
+            settledToolContinuationInstruction = nextSettledToolContinuationInstruction;
+            log.warn(
+              `settled post-tool turn lacked a final answer: runId=${params.runId} sessionId=${params.sessionId} ` +
+                `provider=${activeErrorContext.provider}/${activeErrorContext.model} — continuing from settled tool results`,
             );
             continue;
           }
@@ -4024,6 +4055,7 @@ async function runEmbeddedAgentInternal(
             suppressNextUserMessagePersistence = true;
             reasoningOnlyRetryInstruction = null;
             emptyResponseRetryInstruction = null;
+            settledToolContinuationInstruction = null;
             compactionContinuationRetryInstruction = null;
             log.warn(
               `before_agent_finalize requested one more pass: ` +

--- a/src/agents/embedded-agent-runner/run/incomplete-turn.ts
+++ b/src/agents/embedded-agent-runner/run/incomplete-turn.ts
@@ -136,6 +136,8 @@ export const REASONING_ONLY_RETRY_INSTRUCTION =
   "The previous assistant turn recorded reasoning but did not produce a user-visible answer. Continue from that partial turn and produce the visible answer now. Do not restate the reasoning or restart from scratch.";
 export const EMPTY_RESPONSE_RETRY_INSTRUCTION =
   "The previous attempt did not produce a user-visible answer. Continue from the current state and produce the visible answer now. Do not restart from scratch.";
+export const SETTLED_TOOL_CONTINUATION_INSTRUCTION =
+  "The previous assistant turn completed its tool calls but did not produce a user-visible answer. Continue from the current transcript and produce the final user-visible answer now. Do not repeat completed tool calls or restart from scratch.";
 
 /**
  * Marks whether retrying the attempt can safely replay the prompt. Concrete
@@ -724,6 +726,43 @@ export function resolveReasoningOnlyRetryInstruction(params: {
   }
 
   return REASONING_ONLY_RETRY_INSTRUCTION;
+}
+
+/** Continues once after a side-effecting tool batch is proven complete. */
+export function resolveSettledToolContinuationInstruction(params: {
+  provider?: string;
+  modelId?: string;
+  modelApi?: string;
+  executionContract?: string;
+  payloadCount: number;
+  aborted: boolean;
+  timedOut: boolean;
+  attempt: IncompleteTurnAttempt;
+}): string | null {
+  const assistant = params.attempt.currentAttemptAssistant;
+  if (
+    params.payloadCount !== 0 ||
+    params.aborted ||
+    params.timedOut ||
+    assistant?.stopReason !== "stop" ||
+    params.attempt.toolMetas.length === 0 ||
+    params.attempt.toolMetas.some((tool) => tool.asyncStarted === true) ||
+    !resolveAttemptReplayMetadata(params.attempt).hadPotentialSideEffects ||
+    params.attempt.itemLifecycle.startedCount === 0 ||
+    params.attempt.itemLifecycle.completedCount !== params.attempt.itemLifecycle.startedCount ||
+    params.attempt.itemLifecycle.activeCount !== 0 ||
+    params.attempt.lastToolError ||
+    params.attempt.clientToolCalls ||
+    params.attempt.yieldDetected ||
+    params.attempt.didSendDeterministicApprovalPrompt ||
+    hasAcceptedSessionSpawn(params.attempt.acceptedSessionSpawns) ||
+    hasMessagingToolDeliveryEvidence(params.attempt) ||
+    !isEmptyResponseAssistantTurn({ payloadCount: params.payloadCount, attempt: params.attempt }) ||
+    !shouldApplyNonVisibleTurnRetryGuard(params)
+  ) {
+    return null;
+  }
+  return SETTLED_TOOL_CONTINUATION_INSTRUCTION;
 }
 
 /**


### PR DESCRIPTION
## Summary

- backport the settled post-tool continuation from #110565 to the 2026.6.35 candidate
- continue exactly once after a side-effecting tool batch is proven complete but the assistant emits no visible answer
- remove built-in and client-provided tools from that continuation so completed effects cannot repeat
- keep replay-safe reads on the existing empty-response path and fail closed for active, failed, asynchronous, delivered, spawned, or approval-bearing work

## Root cause

The package Telegram acceptance scenario `telegram-empty-response-after-write-recovery` completed a write, then received an empty terminal assistant turn. The candidate treated every potentially side-effecting attempt as unrecoverable, so it surfaced the generic incomplete-turn error instead of asking the model for the final visible answer from the already-settled transcript.

Failure: https://github.com/openclaw/openclaw/actions/runs/34189437057/job/101945150686

Canonical main fix: #110565 / `8636bb6981844e4674ee2cdbc0d8d32aa2a8b816`. This backport adapts only that owner invariant to the candidate's pre-split runner.

## Verification

- focused Vitest: OpenClaw settled write continues once with `disableTools: true` and no client tools; native harness does not retry
- exact-head AutoReview: correct, no actionable findings (0.94)
- type-aware OXLint on the three changed files
- Oxfmt and `git diff --check`
- pre-fix release scenario: timeout with two outbound messages and no success marker; gateway logged `payloads=0, tools=1, replaySafe=no`

## Scope

- application production: +71 net lines
- tests: +94 net lines
- no config, protocol, persistence, package, or release-workflow changes
