### PR TITLE
fix(usage): show incomplete cache state in cost summaries

### DIFF
--- a/docs/cli/gateway.md
+++ b/docs/cli/gateway.md
@@ -298,6 +298,11 @@ openclaw gateway usage-cost --all-agents
 openclaw gateway usage-cost --json
 ```
 
+Human-readable output warns that totals may be incomplete when the usage cache is
+refreshing, partial, or stale. The command returns the available snapshot from
+one request; run it again later to check for refreshed totals. JSON output preserves
+the `cacheStatus` object so scripts can inspect the same state.
+
 <ParamField path="--days <days>" type="number" default="30">
   Number of days to include.
 </ParamField>

--- a/docs/concepts/usage-tracking.md
+++ b/docs/concepts/usage-tracking.md
@@ -25,6 +25,12 @@ title: "Usage tracking"
 
 `openclaw channels list` no longer prints provider usage; it points users to `openclaw status` or `openclaw models list` instead.
 
+`/usage cost` warns that the **Today** and **Last 30d** totals may be incomplete
+if their aggregate cache is refreshing, partial, or stale, and suggests running
+the command again later. The **Session** total is loaded separately. The CLI
+`openclaw gateway usage-cost` also reports the recorded cache state before its
+totals.
+
 ## Usage date ranges
 
 The Gateway methods `usage.cost` and `sessions.usage` interpret date ranges in

--- a/src/auto-reply/reply/commands-session-cost.runtime.ts
+++ b/src/auto-reply/reply/commands-session-cost.runtime.ts
@@ -5,7 +5,11 @@ import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { loadCostUsageSummary, loadSessionCostSummary } from "../../infra/session-cost-usage.js";
 import { DEFAULT_AGENT_ID, isUnscopedSessionKeySentinel } from "../../routing/session-key.js";
-import { formatTokenCount, formatUsd } from "../../utils/usage-format.js";
+import {
+  formatCostUsageCachePrefix,
+  formatTokenCount,
+  formatUsd,
+} from "../../utils/usage-format.js";
 
 export async function formatSessionUsageCostSummary(params: {
   cfg: OpenClawConfig;
@@ -67,5 +71,7 @@ export async function formatSessionUsageCostSummary(params: {
   const last30Suffix = summary.totals.missingCostEntries > 0 ? " (partial)" : "";
   const last30Line = `Last 30d ${last30Cost ?? "n/a"}${last30Suffix}`;
 
-  return `💸 Usage cost\n${sessionLine}\n${todayLine}\n${last30Line}`;
+  // Only the date-range rows use aggregate freshness; the session total is loaded separately.
+  const cachePrefix = formatCostUsageCachePrefix(summary.cacheStatus);
+  return `💸 Usage cost\n${sessionLine}\n${cachePrefix}${todayLine}\n${last30Line}`;
 }

--- a/src/auto-reply/reply/commands-session-usage.test.ts
+++ b/src/auto-reply/reply/commands-session-usage.test.ts
@@ -191,6 +191,53 @@ describe("handleUsageCommand", () => {
     );
   });
 
+  it.each([
+    ["cold", "refreshing", 0, 2],
+    ["refreshing", "refreshing", 4.56, 2],
+    ["refreshing-current", "refreshing", 4.56, 0],
+    ["partial", "partial", 4.56, 2],
+    ["stale", "stale", 0, 2],
+    ["empty", "fresh", 0, 0],
+    ["fresh", "fresh", 4.56, 0],
+    ["legacy", undefined, 4.56, 0],
+  ] as const)(
+    "qualifies %s aggregate costs without changing the session total",
+    async (_name, status, totalCost, pendingFiles) => {
+      const totals = buildCostTotals({ totalCost });
+      loadCostUsageSummaryMock.mockResolvedValue({
+        updatedAt: 1,
+        days: 30,
+        daily: [],
+        totals,
+        ...(status
+          ? {
+              cacheStatus: {
+                status,
+                cachedFiles: totalCost === 0 ? 0 : 1,
+                pendingFiles,
+                staleFiles: pendingFiles,
+              },
+            }
+          : {}),
+      });
+
+      const result = await handleUsageCommand(buildUsageParams(), true);
+
+      expect(result?.shouldContinue).toBe(false);
+      expect(loadSessionCostSummaryMock).toHaveBeenCalledOnce();
+      expect(loadCostUsageSummaryMock).toHaveBeenCalledOnce();
+      const costLabel = totalCost === 0 ? "$0.0000" : "$4.56";
+      const expectedLines = ["💸 Usage cost", "Session $1.23 · 100 tokens"];
+      if (status && status !== "fresh") {
+        expectedLines.push(
+          `Usage totals may be incomplete (${status}). Run this command again later.`,
+        );
+      }
+      expectedLines.push("Today n/a", `Last 30d ${costLabel}`);
+      expect(result?.reply?.text).toBe(expectedLines.join("\n"));
+    },
+  );
+
   it("keeps the current agent for an unqualified global session key", async () => {
     const params = buildUsageParams();
     params.agentId = "other";

--- a/src/cli/gateway-cli.coverage.test.ts
+++ b/src/cli/gateway-cli.coverage.test.ts
@@ -6,6 +6,7 @@ import { Command } from "commander";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { withEnvOverride } from "../config/test-helpers.js";
+import type { CostUsageSummary } from "../infra/session-cost-usage.js";
 import { ExpectedCliError } from "./failure-output.js";
 import { registerGatewayCli } from "./gateway-cli.js";
 
@@ -285,26 +286,85 @@ describe("gateway-cli coverage", () => {
     );
   });
 
-  it.each(["refreshing", "partial", "stale"] as const)(
-    "returns the first usage-cost RPC result when the cache is %s",
-    async (status) => {
-      const summary = {
-        totals: { totalTokens: 100, totalCost: 0.1 },
-        cacheStatus: { status, cachedFiles: 0, pendingFiles: 2 },
-      };
-      callGateway.mockResolvedValue(summary);
+  describe.each([false, true])("usage-cost completeness (json=%s)", (json) => {
+    it.each([
+      ["cold", "refreshing", 0, 2],
+      ["refreshing", "refreshing", 100, 2],
+      ["refreshing-current", "refreshing", 100, 0],
+      ["partial", "partial", 100, 2],
+      ["stale", "stale", 0, 2],
+      ["empty", "fresh", 0, 0],
+      ["fresh", "fresh", 100, 0],
+      ["legacy", undefined, 100, 0],
+    ] as const)(
+      "preserves the first %s result",
+      async (_name, status, totalTokens, pendingFiles) => {
+        const totalCost = totalTokens === 0 ? 0 : 0.1;
+        const totals = {
+          input: totalTokens,
+          output: 0,
+          cacheRead: 0,
+          cacheWrite: 0,
+          totalTokens,
+          totalCost,
+          inputCost: totalCost,
+          outputCost: 0,
+          cacheReadCost: 0,
+          cacheWriteCost: 0,
+          missingCostEntries: 0,
+        };
+        const summary: CostUsageSummary = {
+          updatedAt: 1,
+          days: 7,
+          daily: [{ date: "2026-09-01", ...totals }],
+          totals,
+          ...(status
+            ? {
+                cacheStatus: {
+                  status,
+                  cachedFiles: totalTokens === 0 ? 0 : 1,
+                  pendingFiles,
+                  staleFiles: pendingFiles,
+                },
+              }
+            : {}),
+        };
+        callGateway.mockResolvedValue(summary);
 
-      await runGatewayCommand(["gateway", "usage-cost", "--all-agents", "--days", "7", "--json"]);
+        await runGatewayCommand([
+          "gateway",
+          "usage-cost",
+          "--all-agents",
+          "--days",
+          "7",
+          ...(json ? ["--json"] : []),
+        ]);
 
-      expect(callGateway).toHaveBeenCalledOnce();
-      expect(firstMockArg(callGateway)).toMatchObject({
-        method: "usage.cost",
-        params: { days: 7, agentScope: "all" },
-        timeoutMs: 10_000,
-      });
-      expect(defaultRuntime.writeJson).toHaveBeenCalledWith(summary);
-    },
-  );
+        expect(callGateway).toHaveBeenCalledOnce();
+        expect(firstMockArg(callGateway)).toMatchObject({
+          method: "usage.cost",
+          params: { days: 7, agentScope: "all" },
+          timeoutMs: 10_000,
+        });
+        if (json) {
+          expect(defaultRuntime.writeJson).toHaveBeenCalledWith(summary);
+          return;
+        }
+        const output = runtimeLogs.join("\n");
+        const costLabel = totalTokens === 0 ? "$0.0000" : "$0.10";
+        expect(output).toContain(`Total: ${costLabel} · ${totalTokens} tokens`);
+        expect(output).toContain(`Latest day: 2026-09-01 · ${costLabel} · ${totalTokens} tokens`);
+        if (status && status !== "fresh") {
+          expect(output).toContain(
+            `Usage totals may be incomplete (${status}). Run this command again later.\nTotal: ${costLabel} · ${totalTokens} tokens`,
+          );
+        } else {
+          expect(output).not.toContain("incomplete");
+          expect(output).not.toContain("Run this command again later.");
+        }
+      },
+    );
+  });
 
   it("rejects combining --agent with --all-agents for usage-cost", async () => {
     callGateway.mockClear();

--- a/src/cli/gateway-cli/register.ts
+++ b/src/cli/gateway-cli/register.ts
@@ -147,12 +147,13 @@ async function renderCostUsageSummaryAsync(
   rich: boolean,
 ): Promise<string[]> {
   const { formatMissingCostEntries } = await import("../../infra/session-cost-usage-totals.js");
-  const { formatTokenCount, formatUsd } = await loadUsageFormatModule();
+  const { formatCostUsageCachePrefix, formatTokenCount, formatUsd } = await loadUsageFormatModule();
   const totalCost = formatUsd(summary.totals.totalCost) ?? "$0.00";
   const totalTokens = formatTokenCount(summary.totals.totalTokens) ?? "0";
+  const cachePrefix = formatCostUsageCachePrefix(summary.cacheStatus);
   const lines = [
     colorize(rich, theme.heading, `Usage cost (${days} days)`),
-    `${colorize(rich, theme.muted, "Total:")} ${totalCost} · ${totalTokens} tokens`,
+    `${cachePrefix}${colorize(rich, theme.muted, "Total:")} ${totalCost} · ${totalTokens} tokens`,
   ];
 
   if (summary.totals.missingCostEntries > 0) {

--- a/src/tui/tui-pty-local.e2e.test.ts
+++ b/src/tui/tui-pty-local.e2e.test.ts
@@ -15,15 +15,24 @@ import {
 } from "../../test/helpers/openclaw-test-instance.js";
 import { isProcessAlive, waitForPidFile } from "../../test/helpers/process-wait.js";
 import { createDeferred } from "../../test/helpers/promise.js";
+import { runQaGatewayFixture } from "../../test/helpers/qa-gateway-cleanup.js";
 import { reloadSharedAuthStoreOwnership } from "../agents/auth-profiles/path-resolve.js";
 import { loadAuthProfileStoreForRuntime } from "../agents/auth-profiles/store-runtime.js";
 import { resolveAgentModelPrimaryValue } from "../config/model-input.js";
+import { loadSessionEntry } from "../config/sessions/session-accessor.js";
 import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { connectGatewayClient } from "../gateway/test-helpers.e2e.js";
+import {
+  acquireSessionCostUsageRefreshLock,
+  isSessionCostUsageRefreshRunning,
+} from "../infra/session-cost-usage-cache.sqlite.js";
+import { listUsageCountedTranscriptStats } from "../infra/session-cost-usage-collection.js";
 import { runExec } from "../process/exec.js";
-import { withEnv } from "../test-utils/env.js";
+import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
+import { withEnv, withEnvAsync } from "../test-utils/env.js";
 import { killPidIfAlive } from "../test-utils/process-tree.js";
+import { cleanupSessionStateForTest } from "../test-utils/session-state-cleanup.js";
 import { sleep } from "../utils/sleep.js";
 import { GatewayChatClient } from "./gateway-chat.js";
 import { extractTextFromMessage } from "./tui-formatters.js";
@@ -1220,22 +1229,87 @@ describe("TUI PTY real backends", () => {
     LOCAL_TEST_TIMEOUT_MS,
   );
 
-  it(
-    "prints local usage costs without submitting a model request",
-    async ({ onTestFinished }) => {
-      const fixture = await startLocalModeTui(onTestFinished);
-      try {
-        await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
-        await fixture.run.write("/usage cost\r", { delay: false });
-        await fixture.run.waitForOutput("Usage cost", LOCAL_OUTPUT_TIMEOUT_MS);
-        await fixture.run.waitForOutput("Last 30d", LOCAL_OUTPUT_TIMEOUT_MS);
-        expect(fixture.mockModel.requests()).toHaveLength(0);
-      } finally {
-        await fixture.cleanup();
-      }
-    },
-    LOCAL_TEST_TIMEOUT_MS,
-  );
+  for (const cacheState of ["fresh", "refreshing"] as const) {
+    it(
+      `prints ${cacheState} local usage costs without submitting a model request`,
+      async ({ onTestFinished }) => {
+        const agentId = "main";
+        const sessionKey = `agent:${agentId}:usage-cost-${cacheState}-unpersisted`;
+        const cleanupState: { run?: () => Promise<void> } = {};
+        const finish = (dispose: () => Promise<void>) =>
+          runQaGatewayFixture(async () => await cleanupState.run?.(), dispose);
+        const fixture = await startLocalModeTui(
+          (dispose) => onTestFinished(() => finish(dispose)),
+          { cliArgs: ["tui", "--local", "--session", sessionKey] },
+        );
+        const databasePath = resolveOpenClawAgentSqlitePath({ agentId, env: fixture.env });
+        const selectedSession = { agentId, sessionKey, storePath: databasePath };
+        let refreshOwner: ReturnType<typeof acquireSessionCostUsageRefreshLock> | undefined;
+        // Repeated teardown must not reopen the removed root through release().
+        cleanupState.run = createIdempotentCleanup(() =>
+          runQaGatewayFixture(
+            async () => withEnv(fixture.env, () => refreshOwner?.release()),
+            () => fixture.run.dispose(),
+            () =>
+              withEnvAsync(fixture.env, () =>
+                cleanupSessionStateForTest({ stateDir: fixture.stateDir }),
+              ),
+          ),
+        );
+
+        await runQaGatewayFixture(
+          async () => {
+            await fixture.run.waitForOutput("local ready", LOCAL_STARTUP_TIMEOUT_MS);
+            withEnv(fixture.env, () => {
+              // An empty existing row still makes the direct Session reader wait.
+              expect(loadSessionEntry(selectedSession)).toBeUndefined();
+              if (cacheState === "refreshing") {
+                refreshOwner = acquireSessionCostUsageRefreshLock(agentId, databasePath);
+                expect(refreshOwner.acquired).toBe(true);
+              }
+              expect(isSessionCostUsageRefreshRunning(agentId, databasePath)).toBe(
+                cacheState === "refreshing",
+              );
+            });
+            expect(
+              await withEnvAsync(fixture.env, () =>
+                listUsageCountedTranscriptStats(agentId, {
+                  storePath: databasePath,
+                  sessionsDir: path.join(fixture.stateDir, "agents", agentId, "sessions"),
+                }),
+              ),
+            ).toEqual([]);
+
+            await fixture.run.write("/usage cost\r", { delay: false });
+            const rows = await waitForSynchronizedFrameRows(
+              fixture.run,
+              (frame) => frame.some((row) => row.includes("Last 30d")),
+              LOCAL_OUTPUT_TIMEOUT_MS,
+            );
+            const text = rows.join(" ").replace(/\s+/gu, " ");
+            const expected = [
+              "Session n/a",
+              ...(cacheState === "refreshing"
+                ? ["Usage totals may be incomplete (refreshing). Run this command again later."]
+                : []),
+              "Today $0.0000",
+              "Last 30d $0.0000",
+            ].join(" ");
+            expect(text).toContain(expected);
+            expect(fixture.mockModel.requests()).toHaveLength(0);
+            withEnv(fixture.env, () => {
+              expect(loadSessionEntry(selectedSession)).toBeUndefined();
+              expect(isSessionCostUsageRefreshRunning(agentId, databasePath)).toBe(
+                cacheState === "refreshing",
+              );
+            });
+          },
+          () => finish(fixture.cleanup),
+        );
+      },
+      LOCAL_TEST_TIMEOUT_MS,
+    );
+  }
 
   it(
     "drives and steers the real local backend with a mocked model endpoint",

--- a/src/utils/usage-format.ts
+++ b/src/utils/usage-format.ts
@@ -29,6 +29,7 @@ import type { ModelProviderConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { tryReadJsonSync } from "../infra/json-files.js";
 import { pruneMapToMaxSize } from "../infra/map-size.js";
+import type { UsageCacheStatus } from "../infra/session-cost-usage.types.js";
 import {
   modelCatalogPricingFingerprint,
   resolveModelPricing,
@@ -73,6 +74,13 @@ export function formatUsd(value?: number): string | undefined {
     return `$${value.toFixed(2)}`;
   }
   return `$${value.toFixed(4)}`;
+}
+
+/** Prefix aggregate totals with their recorded cache-readiness notice. */
+export function formatCostUsageCachePrefix(cacheStatus?: UsageCacheStatus): string {
+  return cacheStatus && cacheStatus.status !== "fresh"
+    ? `Usage totals may be incomplete (${cacheStatus.status}). Run this command again later.\n`
+    : "";
 }
 
 function normalizeRawModelKey(provider: string, model: string): string {


### PR DESCRIPTION
Closes #141914

## What Problem This Solves

Fixes an issue where operators checking `openclaw gateway usage-cost` or `/usage cost` would see unqualified totals when the aggregate cache was refreshing, partial, or stale. A cold snapshot could show $0.0000 while usage remained pending, even though JSON already reported that state.

## Why This Change Was Made

One shared formatter now places the recorded cache state and a next step before aggregate totals. It preserves amounts, pricing, JSON, one RPC per CLI invocation, the existing 30-second cache TTL, and the separately loaded Session row. Fresh results and results without cache metadata keep their existing text.

This adds 15 production lines, including import formatting, one shared notice and its two callers; tests add 181 net lines and docs add 11. It exposes an existing fact without changing refresh policy, adding configuration, or introducing a second cache. There are no schema, persistence, authentication, SDK or protocol changes.

## User Impact

A real cold-cache CLI response now reads:

```text
Usage cost (7 days)
Usage totals may be incomplete (refreshing). Run this command again later.
Total: $0.0000 · 0 tokens
Latest day: 2026-09-08 · $0.0000 · 0 tokens
```

Before the fix, the same response omitted the notice. Once refreshed, both builds print the expected $0.25 and 250 tokens without it. `/usage cost` places the notice after Session and before Today/Last 30d. “May be incomplete” is deliberate: an active refresh can coexist with zero pending or stale files.

## Evidence

- Ten intended baseline text failures and 67 controls; final owner/caller suites pass 77 tests, with 164 passing cache, collection, Gateway and formatting siblings. The complete changed-file gate passed. Its first attempt caught a test-fixture `prefer-const` issue, fixed with an initialized cleanup holder without a rule suppression.
- Normal full build passed in 4m15s. Source, dependencies and semantic index stayed unchanged; all 15,407 output inventory entries were recorded and hashed where applicable.
- Real compiled CLI/Gateway pair: 49 ordinary commands, all exit zero with empty stderr. Each human cold result is bracketed by fully identical JSON responses, within 3.145s on baseline and 1.855s on candidate. Both report an actual refreshing cache with one pending file, then converge to the canonical seeded 250-token/$0.25 usage. Fresh human output is byte-identical across builds. JSON identity is within each fixture's bracket, not across different fixture timestamps.
- Real compiled TUI baseline fails only the missing-notice assertion while its fresh control passes. Candidate passes fresh and refreshing local cases plus the existing ordinary Gateway `chat.send` control: three passes, 25 unselected tests. The selected response frames were inspected independently; each command's no-model-request check passed. The refreshing local case uses the existing committed refresh-owner record over an empty inventory, with an absent selected SessionEntry; it holds no SQLite write transaction. The Gateway chat control proves the complete state, not an incomplete Gateway-chat interleaving.
- Independent artifact audits rechecked the CLI streams, build bindings, completed terminal frames and cleanup evidence. Catchable-signal controls during startup and idle convergence joined the existing fixture cleanup; normal runs also closed their owned processes and released both ports. Final CLI logs use task-owned paths. One final managed P0–P2 review was scoped-clean with no actionable findings.

Build identities remain explicit: retained baseline `2a6b2ed89f0ef27d0dabc436ed4f429f58db7f98` plus unrelated Matrix display patch `364a12c52e3b7e9620c5725b9179f227b86107fb07c7f63d5783daf6de368a41` (committed as `e963cf10bf67b020b58c726dfd9f896b0cacdac2`); candidate `add7dee816462c556c729369033044404e9944cb` plus patch `2bb4bf3e9cfa79d64a0e97fc612a0433636c6a180359f0689facb067c6e18bdf`. Committed head `7e7cba04d0f51548b487939a18f9d0cc92201f1b` preserves those exact built/reviewed source bytes. Relevant usage owners remain unchanged on inspected main `8d11b06ba16e36d4893149a30976b1e26bcae093`. The baseline's unrelated deletion/incognito differences do not enter these fresh durable fixtures.

This is synthetic local Gateway/CLI/TUI proof. No real external channel message or live model response is claimed. Actual PTY bytes and synchronized response frames are retained; physical-terminal screenshots were unavailable because the host desktop was locked. No terminal replay is presented as a physical capture. This display repair does not claim to resolve the separate indefinite-refresh issue #103910.
