### PR TITLE
refactor(tests): drop implementation-coupled config assertions

### DIFF
--- a/src/plugins/contracts/config-footprint-guardrails.test.ts
+++ b/src/plugins/contracts/config-footprint-guardrails.test.ts
@@ -139,16 +139,12 @@ describe("config footprint guardrails", () => {
     }
   });
 
-  it("keeps canonical nested streaming paths in channel-owned schemas", () => {
+  it("keeps retired flat streaming aliases out of channel-owned schemas", () => {
     const telegramSource = readSource("extensions/telegram/src/config-schema.ts");
     const discordSource = readSource("extensions/discord/src/config-schema.ts");
     const msTeamsSource = readSource("extensions/msteams/src/config-schema.ts");
     const slackSource = readSource("extensions/slack/src/config-schema.ts");
 
-    expect(telegramSource).toContain("streaming: TelegramPreviewStreamingConfigSchema.optional(),");
-    expect(discordSource).toContain("streaming: DiscordPreviewStreamingConfigSchema.optional(),");
-    expect(msTeamsSource).toContain("streaming: ChannelPreviewStreamingConfigSchema.optional(),");
-    expect(slackSource).toContain("streaming: SlackStreamingConfigSchema.optional(),");
     for (const schemaSource of [telegramSource, discordSource, msTeamsSource, slackSource]) {
       expect(schemaSource).not.toContain(
         'streamMode: z.enum(["replace", "status_final", "append"])',
@@ -156,15 +152,6 @@ describe("config footprint guardrails", () => {
       expect(schemaSource).not.toContain("draftChunk:");
       expect(schemaSource).not.toContain("nativeStreaming:");
     }
-  });
-
-  it("keeps Matrix setup input canonical-first after plugin ownership", () => {
-    const source = readSource("extensions/matrix/src/setup-config.ts");
-    const canonicalIndex = source.indexOf("dangerouslyAllowPrivateNetwork?: boolean;");
-    const aliasIndex = source.indexOf("allowPrivateNetwork?: boolean;");
-
-    expect(canonicalIndex).toBeGreaterThanOrEqual(0);
-    expect(aliasIndex).toBeGreaterThan(canonicalIndex);
   });
 
   it("keeps retired config aliases out of the shared setup input", () => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Config footprint tests enforce private streaming helper names and the declaration order of two erased TypeScript properties. Those assertions can fail after behavior-preserving refactors without detecting a change in accepted configuration or runtime precedence.

## Why This Change Was Made

Remove the Matrix property-order case and four exact private helper-name assertions. Keep every retired streaming alias guard and source read, and rename that case to describe its remaining alias-exclusion contract. Public schema, compatibility and architecture checks remain unchanged.

## User Impact

No production or schema behavior changes. The test suite has less implementation coupling and shrinks by 13 net lines. No speed or aggregate coverage claim.

## Evidence

- Contract suite before: 9 passing cases. After: 8 passing cases, with only the approved deletion and case rename.
- Existing Telegram, Discord, Slack and MSTeams schema tests plus Matrix setup tests: 173 cases passed, retaining nested/optional streaming and canonical Matrix opt-in behavior.
- All retired-alias assertions and their four source reads remain unchanged. No SSRF tests or production code changed.
- Formatting, diff checks, the full changed gate and fresh P2 review passed.
