### PR TITLE
fix(release): backport runtime dependency ownership artifact

### DIFF
--- a/scripts/lib/runtime-dependency-ownership-build-plugin.mts
+++ b/scripts/lib/runtime-dependency-ownership-build-plugin.mts
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import { builtinModules } from "node:module";
+import path from "node:path";
+import type { TsdownPlugin } from "tsdown";
+import ts from "typescript";
+import { packageNameFromSpecifier } from "./plugin-package-dependencies.mts";
+import {
+  RUNTIME_DEPENDENCY_OWNERSHIP_ASSET_NAME,
+  RUNTIME_DEPENDENCY_OWNERSHIP_FORMAT_VERSION,
+  type RuntimeDependencyOwnership,
+} from "./runtime-dependency-ownership-contract.mts";
+
+type RuntimeOwner = "root" | `extension:${string}`;
+const NODE_BUILTIN_MODULES = new Set(builtinModules.map((name) => name.replace(/^node:/u, "")));
+
+function moduleOwner(rootDir: string, moduleId: string): RuntimeOwner | null {
+  const sourcePath = moduleId.split("?", 1)[0] ?? moduleId;
+  const relativePath = path.relative(rootDir, sourcePath);
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) return null;
+  const segments = relativePath.split(path.sep);
+  if (segments[0] === "node_modules") return null;
+  return segments[0] === "extensions" && segments[1] ? `extension:${segments[1]}` : "root";
+}
+
+export function collectRuntimeDependencyOwnership(params: {
+  moduleIds: readonly string[];
+  readSource?: (moduleId: string) => string;
+  rootDir: string;
+}): RuntimeDependencyOwnership {
+  const ownersByDependency = new Map<string, Set<RuntimeOwner>>();
+  const readSource = params.readSource ?? ((moduleId: string) => readFileSync(moduleId, "utf8"));
+  for (const moduleId of [...new Set(params.moduleIds)].toSorted()) {
+    const sourcePath = moduleId.split("?", 1)[0] ?? moduleId;
+    const owner = moduleOwner(params.rootDir, sourcePath);
+    if (!owner) continue;
+    let source: string;
+    try {
+      source = readSource(sourcePath);
+    } catch {
+      continue;
+    }
+    for (const importedFile of ts.preProcessFile(source, true, true).importedFiles) {
+      const dependencyName = packageNameFromSpecifier(importedFile.fileName);
+      if (!dependencyName || NODE_BUILTIN_MODULES.has(dependencyName)) continue;
+      const owners = ownersByDependency.get(dependencyName) ?? new Set<RuntimeOwner>();
+      owners.add(owner);
+      ownersByDependency.set(dependencyName, owners);
+    }
+  }
+  return {
+    formatVersion: RUNTIME_DEPENDENCY_OWNERSHIP_FORMAT_VERSION,
+    dependencies: Object.fromEntries(
+      [...ownersByDependency.entries()]
+        .filter(([, owners]) => !owners.has("root"))
+        .toSorted(([left], [right]) => left.localeCompare(right))
+        .map(([dependencyName, owners]) => [
+          dependencyName,
+          {
+            root: false,
+            extensions: [...owners]
+              .filter((owner): owner is `extension:${string}` => owner.startsWith("extension:"))
+              .map((owner) => owner.slice("extension:".length))
+              .toSorted(),
+          },
+        ]),
+    ),
+  };
+}
+
+export function createRuntimeDependencyOwnershipBuildPlugin(rootDir = process.cwd()): TsdownPlugin {
+  const sources = new Map<string, string>();
+  return {
+    name: "openclaw:runtime-dependency-ownership",
+    buildStart() {
+      sources.clear();
+    },
+    transform(code, id) {
+      const sourcePath = id.split("?", 1)[0] ?? id;
+      if (moduleOwner(rootDir, sourcePath)) sources.set(sourcePath, code);
+      return null;
+    },
+    generateBundle() {
+      const ownership = collectRuntimeDependencyOwnership({
+        rootDir,
+        moduleIds: [...sources.keys()],
+        readSource: (moduleId) => sources.get(moduleId) ?? "",
+      });
+      this.emitFile({
+        type: "asset",
+        fileName: RUNTIME_DEPENDENCY_OWNERSHIP_ASSET_NAME,
+        source: `${JSON.stringify(ownership, null, 2)}\n`,
+      });
+    },
+  };
+}

--- a/scripts/lib/runtime-dependency-ownership-build-plugin.mts
+++ b/scripts/lib/runtime-dependency-ownership-build-plugin.mts
@@ -16,9 +16,13 @@ const NODE_BUILTIN_MODULES = new Set(builtinModules.map((name) => name.replace(/
 function moduleOwner(rootDir: string, moduleId: string): RuntimeOwner | null {
   const sourcePath = moduleId.split("?", 1)[0] ?? moduleId;
   const relativePath = path.relative(rootDir, sourcePath);
-  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) return null;
+  if (relativePath.startsWith("..") || path.isAbsolute(relativePath)) {
+    return null;
+  }
   const segments = relativePath.split(path.sep);
-  if (segments[0] === "node_modules") return null;
+  if (segments[0] === "node_modules") {
+    return null;
+  }
   return segments[0] === "extensions" && segments[1] ? `extension:${segments[1]}` : "root";
 }
 
@@ -32,7 +36,9 @@ export function collectRuntimeDependencyOwnership(params: {
   for (const moduleId of [...new Set(params.moduleIds)].toSorted()) {
     const sourcePath = moduleId.split("?", 1)[0] ?? moduleId;
     const owner = moduleOwner(params.rootDir, sourcePath);
-    if (!owner) continue;
+    if (!owner) {
+      continue;
+    }
     let source: string;
     try {
       source = readSource(sourcePath);
@@ -41,7 +47,9 @@ export function collectRuntimeDependencyOwnership(params: {
     }
     for (const importedFile of ts.preProcessFile(source, true, true).importedFiles) {
       const dependencyName = packageNameFromSpecifier(importedFile.fileName);
-      if (!dependencyName || NODE_BUILTIN_MODULES.has(dependencyName)) continue;
+      if (!dependencyName || NODE_BUILTIN_MODULES.has(dependencyName)) {
+        continue;
+      }
       const owners = ownersByDependency.get(dependencyName) ?? new Set<RuntimeOwner>();
       owners.add(owner);
       ownersByDependency.set(dependencyName, owners);
@@ -76,7 +84,9 @@ export function createRuntimeDependencyOwnershipBuildPlugin(rootDir = process.cw
     },
     transform(code, id) {
       const sourcePath = id.split("?", 1)[0] ?? id;
-      if (moduleOwner(rootDir, sourcePath)) sources.set(sourcePath, code);
+      if (moduleOwner(rootDir, sourcePath)) {
+        sources.set(sourcePath, code);
+      }
       return null;
     },
     generateBundle() {

--- a/scripts/lib/runtime-dependency-ownership-contract.mts
+++ b/scripts/lib/runtime-dependency-ownership-contract.mts
@@ -1,0 +1,43 @@
+import { packageNameFromSpecifier } from "./plugin-package-dependencies.mts";
+import { isRecord } from "./record-shared.mjs";
+
+export const RUNTIME_DEPENDENCY_OWNERSHIP_RELATIVE_PATH = "dist/runtime-dependency-ownership.json";
+export const RUNTIME_DEPENDENCY_OWNERSHIP_ASSET_NAME = "runtime-dependency-ownership.json";
+export const RUNTIME_DEPENDENCY_OWNERSHIP_FORMAT_VERSION = 1;
+
+type RuntimeDependencyOwners = { extensions: string[]; root: boolean };
+export type RuntimeDependencyOwnership = {
+  dependencies: Record<string, RuntimeDependencyOwners>;
+  formatVersion: typeof RUNTIME_DEPENDENCY_OWNERSHIP_FORMAT_VERSION;
+};
+
+function isRuntimeDependencyOwners(value: unknown): value is RuntimeDependencyOwners {
+  if (!isRecord(value) || typeof value.root !== "boolean" || !Array.isArray(value.extensions))
+    return false;
+  if (!value.extensions.every((entry) => typeof entry === "string" && entry.length > 0))
+    return false;
+  const extensions = value.extensions as string[];
+  return (
+    new Set(extensions).size === extensions.length &&
+    extensions
+      .toSorted((a, b) => a.localeCompare(b))
+      .every((entry, index) => entry === extensions[index])
+  );
+}
+
+export function parseRuntimeDependencyOwnership(value: unknown): RuntimeDependencyOwnership | null {
+  if (
+    !isRecord(value) ||
+    value.formatVersion !== RUNTIME_DEPENDENCY_OWNERSHIP_FORMAT_VERSION ||
+    !isRecord(value.dependencies)
+  )
+    return null;
+  for (const [dependencyName, owners] of Object.entries(value.dependencies)) {
+    if (
+      packageNameFromSpecifier(dependencyName) !== dependencyName ||
+      !isRuntimeDependencyOwners(owners)
+    )
+      return null;
+  }
+  return value as RuntimeDependencyOwnership;
+}

--- a/scripts/lib/runtime-dependency-ownership-contract.mts
+++ b/scripts/lib/runtime-dependency-ownership-contract.mts
@@ -12,10 +12,12 @@ export type RuntimeDependencyOwnership = {
 };
 
 function isRuntimeDependencyOwners(value: unknown): value is RuntimeDependencyOwners {
-  if (!isRecord(value) || typeof value.root !== "boolean" || !Array.isArray(value.extensions))
+  if (!isRecord(value) || typeof value.root !== "boolean" || !Array.isArray(value.extensions)) {
     return false;
-  if (!value.extensions.every((entry) => typeof entry === "string" && entry.length > 0))
+  }
+  if (!value.extensions.every((entry) => typeof entry === "string" && entry.length > 0)) {
     return false;
+  }
   const extensions = value.extensions as string[];
   return (
     new Set(extensions).size === extensions.length &&
@@ -30,14 +32,16 @@ export function parseRuntimeDependencyOwnership(value: unknown): RuntimeDependen
     !isRecord(value) ||
     value.formatVersion !== RUNTIME_DEPENDENCY_OWNERSHIP_FORMAT_VERSION ||
     !isRecord(value.dependencies)
-  )
+  ) {
     return null;
+  }
   for (const [dependencyName, owners] of Object.entries(value.dependencies)) {
     if (
       packageNameFromSpecifier(dependencyName) !== dependencyName ||
       !isRuntimeDependencyOwners(owners)
-    )
+    ) {
       return null;
+    }
   }
   return value as RuntimeDependencyOwnership;
 }

--- a/src/infra/tsdown-config.test.ts
+++ b/src/infra/tsdown-config.test.ts
@@ -2,6 +2,7 @@
 import { readFileSync } from "node:fs";
 import { bundledPluginRoot } from "openclaw/plugin-sdk/test-fixtures";
 import { describe, expect, it } from "vitest";
+import { collectRuntimeDependencyOwnership } from "../../scripts/lib/runtime-dependency-ownership-build-plugin.mts";
 import tsdownConfig from "../../tsdown.config.ts";
 
 type TsdownConfigEntry = {
@@ -332,5 +333,40 @@ describe("tsdown config", () => {
     configured?.("warn", log, (_level, forwardedLog) => handled.push(forwardedLog));
 
     expect(handled).toEqual([log]);
+  });
+});
+
+describe("runtime dependency ownership build contract", () => {
+  const rootDir = "/repo";
+  const collect = (sources: Record<string, string>) => {
+    const resolved = new Map(
+      Object.entries(sources).map(([file, source]) => [`${rootDir}/${file}`, source]),
+    );
+    return collectRuntimeDependencyOwnership({
+      rootDir,
+      moduleIds: [...resolved.keys()],
+      readSource: (id) => resolved.get(id) ?? "",
+    });
+  };
+
+  it("records extension dependencies without authorizing root-owned imports", () => {
+    expect(
+      collect({
+        "extensions/discord/src/voice.ts": 'require("@discordjs/voice");',
+        "extensions/msteams/src/graph.ts": 'import("@microsoft/teams.apps");',
+      }),
+    ).toEqual({
+      formatVersion: 1,
+      dependencies: {
+        "@discordjs/voice": { root: false, extensions: ["discord"] },
+        "@microsoft/teams.apps": { root: false, extensions: ["msteams"] },
+      },
+    });
+    expect(
+      collect({
+        "extensions/discord/src/voice.ts": 'import "@discordjs/voice";',
+        "src/root.ts": 'require("@discordjs/voice");',
+      }),
+    ).toEqual({ formatVersion: 1, dependencies: {} });
   });
 });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,6 +11,7 @@ import {
   pluginSdkEntrypoints,
   publicPluginSdkEntrypoints,
 } from "./scripts/lib/plugin-sdk-entries.mjs";
+import { createRuntimeDependencyOwnershipBuildPlugin } from "./scripts/lib/runtime-dependency-ownership-build-plugin.mts";
 import { tsdownPackageOutputRoot } from "./scripts/lib/tsdown-output-roots.mjs";
 
 type InputOptionsFactory = Extract<NonNullable<UserConfig["inputOptions"]>, Function>;
@@ -787,6 +788,7 @@ const configs = [
     clean: true,
     dts: TSDOWN_DECLARATIONS,
     entry: buildUnifiedDistEntries(),
+    plugins: [createRuntimeDependencyOwnershipBuildPlugin()],
     deps: {
       alwaysBundle: shouldAlwaysBundleDependency,
       neverBundle: shouldNeverBundleDependency,


### PR DESCRIPTION
## Summary
- emit `dist/runtime-dependency-ownership.json` from the frozen 2026.7.33 tsdown build
- record extension-only ownership without parsing generated bundle comments
- provide the versioned artifact consumed by the mainline verifier from #141876

## Why
The frozen package bundles Discord and Teams runtime dependencies into root dist while their manifests live with the companion extensions. Mainline validation can consume explicit build provenance, but the 2026.7.33 producer must emit it.

The collector uses TypeScript preprocessing over modules actually included by tsdown. Any dependency also imported by root-owned source is omitted, preserving fail-closed root dependency validation.

## Validation
- frozen tsdown build succeeds
- ownership manifest contains `@discordjs/voice` → `discord` and `@microsoft/teams.apps` → `msteams`
- focused tsdown/ownership tests: 17/17
- npm dry-run includes `dist/runtime-dependency-ownership.json`
- formatting and `git diff --check` pass