### PR TITLE
fix(npm): backport runtime chunk ownership to 7.33

### DIFF
--- a/scripts/lib/runtime-dependency-ownership-build-plugin.mts
+++ b/scripts/lib/runtime-dependency-ownership-build-plugin.mts
@@ -1,0 +1,59 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+import type { TsdownPlugin } from "tsdown";
+import {
+  RUNTIME_DEPENDENCY_OWNERSHIP_ASSET_NAME,
+  type RuntimeDependencyOwnership,
+} from "./runtime-dependency-ownership-contract.mts";
+
+export function createRuntimeDependencyOwnershipBuildPlugin(rootDir = process.cwd()): TsdownPlugin {
+  return {
+    name: "openclaw:runtime-dependency-ownership",
+    generateBundle: {
+      order: "post",
+      handler(_options, bundle) {
+        const chunks = Object.values(bundle).filter((output) => output.type === "chunk");
+        const ownersByChunk = new Map<string, Set<string>>();
+        for (const entry of chunks.filter((chunk) => chunk.isEntry)) {
+          const source = entry.facadeModuleId?.split("?", 1)[0];
+          const relative = source ? path.relative(rootDir, source).split(path.sep).join("/") : "";
+          // An empty owner represents a root entry and prevents plugin authorization.
+          const owner = /^extensions\/([a-z0-9][a-z0-9-]*)\//u.exec(relative)?.[1] ?? "";
+          const pending = [entry.fileName];
+          const visited = new Set<string>();
+          while (pending.length > 0) {
+            const fileName = pending.pop()!;
+            if (visited.has(fileName)) {
+              continue;
+            }
+            visited.add(fileName);
+            const chunk = bundle[fileName];
+            if (chunk?.type !== "chunk") {
+              continue;
+            }
+            const owners = ownersByChunk.get(fileName) ?? new Set<string>();
+            owners.add(owner);
+            ownersByChunk.set(fileName, owners);
+            pending.push(...chunk.imports, ...chunk.dynamicImports);
+          }
+        }
+        const ownership: RuntimeDependencyOwnership = { chunks: {} };
+        for (const chunk of chunks.toSorted((a, b) => a.fileName.localeCompare(b.fileName))) {
+          const owners = ownersByChunk.get(chunk.fileName);
+          if (!owners?.size || owners.has("") || chunk.fileName.startsWith("extensions/")) {
+            continue;
+          }
+          ownership.chunks[chunk.fileName] = {
+            sha256: createHash("sha256").update(chunk.code).digest("hex"),
+            extensions: [...owners].toSorted(),
+          };
+        }
+        this.emitFile({
+          type: "asset",
+          fileName: RUNTIME_DEPENDENCY_OWNERSHIP_ASSET_NAME,
+          source: `${JSON.stringify(ownership)}\n`,
+        });
+      },
+    },
+  };
+}

--- a/scripts/lib/runtime-dependency-ownership-contract.mts
+++ b/scripts/lib/runtime-dependency-ownership-contract.mts
@@ -1,0 +1,49 @@
+import fs from "node:fs";
+import { join } from "node:path";
+import { isRecord } from "./record-shared.mjs";
+
+export const RUNTIME_DEPENDENCY_OWNERSHIP_RELATIVE_PATH = "dist/runtime-dependency-ownership.json";
+export const RUNTIME_DEPENDENCY_OWNERSHIP_ASSET_NAME = "runtime-dependency-ownership.json";
+
+export type RuntimeDependencyOwnership = {
+  chunks: Record<string, { sha256: string; extensions: string[] }>;
+};
+
+function parseRuntimeDependencyOwnership(value: unknown): RuntimeDependencyOwnership | null {
+  if (!isRecord(value) || !isRecord(value.chunks)) {
+    return null;
+  }
+  for (const chunk of Object.values(value.chunks)) {
+    if (
+      !isRecord(chunk) ||
+      typeof chunk.sha256 !== "string" ||
+      !/^[a-f0-9]{64}$/u.test(chunk.sha256) ||
+      !Array.isArray(chunk.extensions) ||
+      chunk.extensions.length === 0 ||
+      !chunk.extensions.every((id) => typeof id === "string" && /^[a-z0-9][a-z0-9-]*$/u.test(id)) ||
+      new Set(chunk.extensions).size !== chunk.extensions.length
+    ) {
+      return null;
+    }
+  }
+  return value as RuntimeDependencyOwnership;
+}
+
+export function readRuntimeDependencyOwnership(
+  packageRoot: string,
+  fsImpl: typeof fs = fs,
+): RuntimeDependencyOwnership | null {
+  const file = join(packageRoot, RUNTIME_DEPENDENCY_OWNERSHIP_RELATIVE_PATH);
+  if (!fsImpl.existsSync(file)) {
+    return null;
+  }
+  const stat = fsImpl.lstatSync(file);
+  if (!stat.isFile() || stat.size > 1024 * 1024) {
+    throw new Error("ownership artifact must be a regular file no larger than 1048576 bytes");
+  }
+  const ownership = parseRuntimeDependencyOwnership(JSON.parse(fsImpl.readFileSync(file, "utf8")));
+  if (!ownership) {
+    throw new Error("ownership artifact does not match the supported schema");
+  }
+  return ownership;
+}

--- a/scripts/runtime-postbuild.mjs
+++ b/scripts/runtime-postbuild.mjs
@@ -1,5 +1,6 @@
 // Generates postbuild runtime artifacts: plugin metadata, SDK aliases, stable
 // runtime aliases, static assets, and compatibility chunks for live upgrades.
+import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
@@ -7,6 +8,10 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import { copyBundledPluginMetadata } from "./copy-bundled-plugin-metadata.mjs";
 import { copyPluginSdkRootAlias } from "./copy-plugin-sdk-root-alias.mjs";
 import { escapeRegExp } from "./lib/regexp.mjs";
+import {
+  readRuntimeDependencyOwnership,
+  RUNTIME_DEPENDENCY_OWNERSHIP_RELATIVE_PATH,
+} from "./lib/runtime-dependency-ownership-contract.mts";
 import {
   copyStaticExtensionAssets,
   copyStaticExtensionAssetsToRuntimeOverlay,
@@ -338,6 +343,15 @@ function buildRuntimeAliasSource(params) {
   );
 }
 
+function writeRuntimeDependencyOwnership(rootDir, ownership, fsImpl) {
+  if (ownership) {
+    fsImpl.writeFileSync(
+      path.join(rootDir, RUNTIME_DEPENDENCY_OWNERSHIP_RELATIVE_PATH),
+      `${JSON.stringify({ chunks: Object.fromEntries(Object.entries(ownership.chunks).toSorted(([a], [b]) => a.localeCompare(b))) })}\n`,
+    );
+  }
+}
+
 /**
  * Writes stable aliases for current hashed runtime chunks.
  */
@@ -347,6 +361,7 @@ export function writeStableRootRuntimeAliases(params = {}) {
   const fsImpl = params.fs ?? fs;
   const candidatesByAlias = collectStableRootRuntimeAliasCandidates({ distDir, fs: fsImpl });
 
+  const ownership = readRuntimeDependencyOwnership(rootDir, fsImpl);
   for (const [aliasFileName, candidates] of candidatesByAlias) {
     const aliasPath = path.join(distDir, aliasFileName);
     const candidate = resolveStableRootRuntimeAliasCandidate({
@@ -357,13 +372,30 @@ export function writeStableRootRuntimeAliases(params = {}) {
     });
     if (!candidate) {
       fsImpl.rmSync?.(aliasPath, { force: true });
+      if (ownership) {
+        delete ownership.chunks[aliasFileName];
+      }
       continue;
     }
-    writeTextFileIfChanged(
-      aliasPath,
-      buildRuntimeAliasSource({ distDir, fsImpl, targetFileName: candidate }),
-    );
+    const source = buildRuntimeAliasSource({ distDir, fsImpl, targetFileName: candidate });
+    const owner = ownership?.chunks[candidate];
+    if (ownership && owner) {
+      const targetSource = fsImpl.readFileSync(path.join(distDir, candidate));
+      if (createHash("sha256").update(targetSource).digest("hex") !== owner.sha256) {
+        throw new Error(
+          `runtime dependency ownership no longer matches ${candidate}; rebuild dist`,
+        );
+      }
+      ownership.chunks[aliasFileName] = {
+        extensions: owner.extensions,
+        sha256: createHash("sha256").update(source).digest("hex"),
+      };
+    } else if (ownership) {
+      delete ownership.chunks[aliasFileName];
+    }
+    writeTextFileIfChanged(aliasPath, source);
   }
+  writeRuntimeDependencyOwnership(rootDir, ownership, fsImpl);
 }
 
 /**
@@ -412,6 +444,7 @@ export function rewriteRootRuntimeImportsToStableAliases(params = {}) {
     return;
   }
 
+  const ownership = readRuntimeDependencyOwnership(rootDir, fsImpl);
   for (const entry of entries) {
     if (!entry.isFile() || !entry.name.endsWith(".js")) {
       continue;
@@ -434,9 +467,21 @@ export function rewriteRootRuntimeImportsToStableAliases(params = {}) {
       },
     );
     if (rewritten !== source) {
+      const owner = ownership?.chunks[entry.name];
+      // Carry the producer's proof through this exact transformation; never
+      // rehash unknown or independently modified build outputs.
+      if (owner) {
+        if (createHash("sha256").update(source).digest("hex") !== owner.sha256) {
+          throw new Error(
+            `runtime dependency ownership no longer matches ${entry.name}; rebuild dist`,
+          );
+        }
+        owner.sha256 = createHash("sha256").update(rewritten).digest("hex");
+      }
       writeTextFileIfChanged(filePath, rewritten);
     }
   }
+  writeRuntimeDependencyOwnership(rootDir, ownership, fsImpl);
 }
 
 function resolveRootRuntimeCandidateByMarkers(params) {

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -1,8 +1,17 @@
 // Runtime Postbuild tests cover runtime postbuild script behavior.
+import { createHash } from "node:crypto";
+import fsSync from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
+import { build } from "tsdown";
 import { describe, expect, it, vi } from "vitest";
+import { createRuntimeDependencyOwnershipBuildPlugin } from "../../scripts/lib/runtime-dependency-ownership-build-plugin.mts";
+import {
+  readRuntimeDependencyOwnership,
+  RUNTIME_DEPENDENCY_OWNERSHIP_RELATIVE_PATH,
+  type RuntimeDependencyOwnership,
+} from "../../scripts/lib/runtime-dependency-ownership-contract.mts";
 import {
   copyStaticExtensionAssetsToRuntimeOverlay,
   discoverStaticExtensionAssets,
@@ -894,6 +903,148 @@ describe("runtime postbuild static assets", () => {
       await expect(fs.readFile(path.join(rootDir, "dist", chunk), "utf8")).resolves.toContain(
         "function hasMemoryRuntime()",
       );
+    }
+  });
+});
+
+async function buildInstalledFixture(
+  rootSource: string,
+  pluginSources: Record<string, string> = {},
+) {
+  const root = fsSync.realpathSync(createTempDir("runtime-dependency-ownership-"));
+  const files = {
+    "package.json": JSON.stringify({ name: "openclaw", version: "2026.7.33", type: "module" }),
+    "src/root.js": rootSource,
+    "extensions/example/index.js": `
+      export { value } from "./shared.js";
+      export const load = () => import("./lazy.js");
+    `,
+    "extensions/example/observer.js": 'export { value } from "./shared.js";',
+    "extensions/example/shared.js": 'export { value } from "fixture-runtime";',
+    "extensions/example/lazy.js": 'export { lazy } from "fixture-lazy";',
+    ...pluginSources,
+  };
+  for (const [name, source] of Object.entries(files)) {
+    const file = path.join(root, name);
+    fsSync.mkdirSync(path.dirname(file), { recursive: true });
+    fsSync.writeFileSync(file, source);
+  }
+  const bundles = await build({
+    config: false,
+    tsconfig: false,
+    cwd: root,
+    entry: {
+      root: "src/root.js",
+      "extensions/example/index": "extensions/example/index.js",
+      "extensions/example/observer": "extensions/example/observer.js",
+    },
+    outDir: "dist",
+    format: "esm",
+    outputOptions: { entryFileNames: "[name].js", chunkFileNames: "[name]-[hash].js" },
+    platform: "node",
+    dts: false,
+    logLevel: "silent",
+    deps: { neverBundle: ["fixture-runtime", "fixture-lazy"] },
+    plugins: [createRuntimeDependencyOwnershipBuildPlugin(root)],
+  });
+  for (const bundle of bundles) {
+    await bundle[Symbol.asyncDispose]();
+  }
+  const ownership = JSON.parse(
+    fsSync.readFileSync(path.join(root, RUNTIME_DEPENDENCY_OWNERSHIP_RELATIVE_PATH), "utf8"),
+  ) as RuntimeDependencyOwnership;
+  return { root, ownership };
+}
+
+describe("runtime dependency ownership build contract", () => {
+  it.each([false, true])(
+    "preserves postbuild ownership only for unchanged input bytes (stale=%s)",
+    async (stale) => {
+      const { root, ownership } = await buildInstalledFixture("export const ready = true;", {
+        "extensions/example/index.js": 'export { value, load } from "./shared.runtime.js";',
+        "extensions/example/observer.js": 'export { value, load } from "./shared.runtime.js";',
+        "extensions/example/shared.runtime.js": `
+        export { value } from "fixture-runtime";
+        export const load = () => import("./downstream.runtime.js");
+      `,
+        "extensions/example/downstream.runtime.js": 'export { lazy } from "fixture-lazy";',
+      });
+      const dist = path.join(root, "dist");
+      const sharedChunk = Object.keys(ownership.chunks).find((name) =>
+        /^shared\.runtime-.*\.js$/u.test(name),
+      );
+      expect(sharedChunk).toBeDefined();
+      const sharedPath = path.join(dist, sharedChunk!);
+      const original = fsSync.readFileSync(sharedPath, "utf8");
+      if (stale) {
+        fsSync.writeFileSync(sharedPath, `${original}export const changed = true;\n`);
+        expect(() => rewriteRootRuntimeImportsToStableAliases({ rootDir: root })).toThrow(
+          `runtime dependency ownership no longer matches ${sharedChunk}; rebuild dist`,
+        );
+        expect(readRuntimeDependencyOwnership(root)).toEqual(ownership);
+        expect(() => writeStableRootRuntimeAliases({ rootDir: root })).toThrow(
+          `runtime dependency ownership no longer matches ${sharedChunk}; rebuild dist`,
+        );
+        expect(readRuntimeDependencyOwnership(root)).toEqual(ownership);
+        return;
+      }
+      rewriteRootRuntimeImportsToStableAliases({ rootDir: root });
+      writeStableRootRuntimeAliases({ rootDir: root });
+      const updated = readRuntimeDependencyOwnership(root)!;
+      expect(fsSync.readFileSync(sharedPath, "utf8")).toContain('"./downstream.runtime.js"');
+      for (const file of [sharedChunk!, "shared.runtime.js", "downstream.runtime.js"]) {
+        expect(updated.chunks[file]).toEqual({
+          sha256: createHash("sha256")
+            .update(fsSync.readFileSync(path.join(dist, file)))
+            .digest("hex"),
+          extensions: ["example"],
+        });
+      }
+      expect(updated.chunks[sharedChunk!].sha256).not.toBe(ownership.chunks[sharedChunk!].sha256);
+    },
+  );
+
+  it("binds real static and dynamic plugin chunks to their emitted bytes", async () => {
+    const { root, ownership } = await buildInstalledFixture("export const ready = true;");
+    const sources: string[] = [];
+    expect(Object.keys(ownership.chunks)).not.toContain("root.js");
+    for (const [fileName, chunk] of Object.entries(ownership.chunks)) {
+      const source = fsSync.readFileSync(path.join(root, "dist", fileName), "utf8");
+      expect(chunk).toEqual({
+        sha256: createHash("sha256").update(source).digest("hex"),
+        extensions: ["example"],
+      });
+      sources.push(source);
+    }
+    expect(sources.some((source) => source.includes('"fixture-runtime"'))).toBe(true);
+    expect(sources.some((source) => source.includes('"fixture-lazy"'))).toBe(true);
+  });
+
+  it.each([
+    ["static import", 'export { value } from "fixture-runtime";'],
+    [
+      "createRequire import",
+      `import { createRequire } from "node:module";
+       export const value = createRequire(import.meta.url)("fixture-runtime");`,
+    ],
+    ["root-shared chunk", 'export { value } from "../extensions/example/shared.js";'],
+  ])("omits output reached by a root %s", async (name, source) => {
+    const { root, ownership } = await buildInstalledFixture(source);
+    expect(Object.keys(ownership.chunks)).not.toContain("root.js");
+    if (name === "root-shared chunk") {
+      const sharedChunks = fsSync
+        .readdirSync(path.join(root, "dist"))
+        .filter(
+          (file) =>
+            file.endsWith(".js") &&
+            fsSync
+              .readFileSync(path.join(root, "dist", file), "utf8")
+              .includes('"fixture-runtime"'),
+        );
+      expect(sharedChunks.length).toBeGreaterThan(0);
+      for (const file of sharedChunks) {
+        expect(Object.keys(ownership.chunks)).not.toContain(file);
+      }
     }
   });
 });

--- a/test/scripts/runtime-postbuild.test.ts
+++ b/test/scripts/runtime-postbuild.test.ts
@@ -916,11 +916,11 @@ async function buildInstalledFixture(
     "package.json": JSON.stringify({ name: "openclaw", version: "2026.7.33", type: "module" }),
     "src/root.js": rootSource,
     "extensions/example/index.js": `
-      export { value } from "./shared.js";
+      export { value } from "../../src/shared.js";
       export const load = () => import("./lazy.js");
     `,
-    "extensions/example/observer.js": 'export { value } from "./shared.js";',
-    "extensions/example/shared.js": 'export { value } from "fixture-runtime";',
+    "extensions/example/observer.js": 'export { value } from "../../src/shared.js";',
+    "src/shared.js": 'export { value } from "fixture-runtime";',
     "extensions/example/lazy.js": 'export { lazy } from "fixture-lazy";',
     ...pluginSources,
   };
@@ -1027,7 +1027,7 @@ describe("runtime dependency ownership build contract", () => {
       `import { createRequire } from "node:module";
        export const value = createRequire(import.meta.url)("fixture-runtime");`,
     ],
-    ["root-shared chunk", 'export { value } from "../extensions/example/shared.js";'],
+    ["root-shared chunk", 'export { value } from "./shared.js";'],
   ])("omits output reached by a root %s", async (name, source) => {
     const { root, ownership } = await buildInstalledFixture(source);
     expect(Object.keys(ownership.chunks)).not.toContain("root.js");

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -11,6 +11,7 @@ import {
   pluginSdkEntrypoints,
   publicPluginSdkEntrypoints,
 } from "./scripts/lib/plugin-sdk-entries.mjs";
+import { createRuntimeDependencyOwnershipBuildPlugin } from "./scripts/lib/runtime-dependency-ownership-build-plugin.mts";
 import { tsdownPackageOutputRoot } from "./scripts/lib/tsdown-output-roots.mjs";
 
 type InputOptionsFactory = Extract<NonNullable<UserConfig["inputOptions"]>, Function>;
@@ -787,6 +788,7 @@ const configs = [
     clean: true,
     dts: TSDOWN_DECLARATIONS,
     entry: buildUnifiedDistEntries(),
+    plugins: [createRuntimeDependencyOwnershipBuildPlugin()],
     deps: {
       alwaysBundle: shouldAlwaysBundleDependency,
       neverBundle: shouldNeverBundleDependency,


### PR DESCRIPTION
## What Problem This Solves

Rebuilt `2026.7.33` packages need emitted chunk ownership evidence so current trusted release tooling can verify plugin dependencies without recovering ownership from generated region comments.

## Why This Change Was Made

Backport the producer and postbuild lifecycle changes from #141876 to `extended-stable/2026.7.33`. Emit exact chunk filenames, hashes, and plugin owners, and preserve verified ownership through the branch's actual `runtime-postbuild.mjs` implementation. Keep the real build tests in its existing postbuild test file.

The matching trusted verifier is now published in #141876 at `ac5048ec7b2b4cc5de809eae08d5518cb77ef523`; its chunk contract and producer match this backport exactly. That verifier reports zero dependency-manifest errors against the locally rebuilt branch artifact. Current trusted qualification tooling supplies the verifier. This backport does not require importing the branch's unrelated newer verifier dependencies.

This is the canonical sister backport for #141876 and supersedes the alternative #141920.

## User Impact

The next rebuilt `2026.7.33` artifact can use the same ownership verification as current releases. Existing frozen tarballs must be rebuilt to contain the evidence.

## Evidence

- Full `pnpm build` passed.
- 35 focused real-build and postbuild tests passed, including rejection of altered input bytes.
- All 1,570 final ownership entries match their emitted files and SHA-256 hashes.
- The revised main verifier reports zero dependency-manifest errors against the rebuilt output.
- Scoped production/test lint, formatting, and `git diff --check` passed.
- Strict producer/contract/build-config typecheck passed. The existing postbuild test typecheck has one confirmed baseline error: TypeScript resolves the older `.mjs` import to its incomplete `.mts` sibling; the actual `.mjs` tests pass.
- The branch's changed-check wrapper could not start its configured Crabbox backend. Whole-config lint also reports an existing, unchanged ternary at `tsdown.config.ts:44`; scoped changed production/test files are clean.

- Independent autoreview completed. Its Node 22.12–22.17 concern does not apply: the branch requires Node >=22.22.3. Loading the actual postbuild and `.mts` contract on Node 22.22.3 passed.
- Fixed the CI fixture/boundary collision by moving the generated shared module under the temporary `src/` tree. All 11 extension-boundary tests and 35 postbuild/build tests pass; fresh follow-up autoreview is clean through P2. No boundary rules were weakened.
