### PR TITLE
fix(control-ui): align collapsed native session counts

### DIFF
--- a/scripts/control-ui-mock-dev.ts
+++ b/scripts/control-ui-mock-dev.ts
@@ -2259,7 +2259,7 @@ async function createChatPickerScenario(
           {
             id: "codex",
             label: "Codex",
-            capabilities: { continueSession: true, archive: false },
+            capabilities: { continueSession: true, archive: false, startTerminal: true },
             hosts: [
               {
                 hostId: "gateway",

--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -337,7 +337,7 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
                     disabledReason: params.newSessionDisabledReason,
                     onOpen: params.onOpenNewSession,
                   })
-                : nothing
+                : html`<span class="sidebar-session-catalog-new-spacer" aria-hidden="true"></span>`
             }
           `,
         })}

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -97,7 +97,7 @@ suite.define(() => {
     await page.close();
   });
 
-  it("separates native catalogs from live Coding rows", async () => {
+  it("separates native catalogs from live Coding rows and aligns collapsed counts", async () => {
     const page = await suite.browser.newPage({
       deviceScaleFactor: 2,
       viewport: { height: 900, width: 1280 },
@@ -145,7 +145,12 @@ suite.define(() => {
             {
               id: "codex",
               label: "Codex",
-              capabilities: { continueSession: true, archive: true, createSession: true },
+              capabilities: {
+                continueSession: true,
+                archive: true,
+                createSession: true,
+                startTerminal: true,
+              },
               hosts: [
                 {
                   hostId: "gateway:local",
@@ -243,6 +248,20 @@ suite.define(() => {
           path: path.join(uiProofArtifactDir, "06-coding-catalog-spacing.png"),
         });
       }
+
+      await catalog.locator(".sidebar-session-group-toggle").click();
+      await claudeCatalog.locator(".sidebar-session-group-toggle").click();
+      const [catalogCountBox, claudeCountBox] = await Promise.all([
+        catalog.locator(".sidebar-session-group-count").boundingBox(),
+        claudeCatalog.locator(".sidebar-session-group-count").boundingBox(),
+      ]);
+      if (!catalogCountBox || !claudeCountBox) {
+        throw new Error("Expected visible collapsed catalog counts");
+      }
+      expect(catalogCountBox.x + catalogCountBox.width).toBeCloseTo(
+        claudeCountBox.x + claudeCountBox.width,
+        1,
+      );
     } finally {
       await page.close();
     }

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, expect, it } from "vitest";
 import type { SessionsCatalogHostEvent } from "../../../packages/gateway-protocol/src/index.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
+  assertCatalogCountAlignment,
   controlUiBundledGatewayUrl,
   controlUiBundledSettingsStorageKey,
   controlUiSessionPath,
@@ -97,7 +98,7 @@ suite.define(() => {
     await page.close();
   });
 
-  it("separates native catalogs from live Coding rows and aligns collapsed counts", async () => {
+  it("separates native catalogs from live Coding rows", async () => {
     const page = await suite.browser.newPage({
       deviceScaleFactor: 2,
       viewport: { height: 900, width: 1280 },
@@ -145,12 +146,7 @@ suite.define(() => {
             {
               id: "codex",
               label: "Codex",
-              capabilities: {
-                continueSession: true,
-                archive: true,
-                createSession: true,
-                startTerminal: true,
-              },
+              capabilities: { continueSession: true, archive: true, startTerminal: true },
               hosts: [
                 {
                   hostId: "gateway:local",
@@ -230,10 +226,8 @@ suite.define(() => {
         liveRows.boundingBox(),
         catalog.boundingBox(),
       ]);
-      expect(liveRowsBox).not.toBeNull();
-      expect(catalogBox).not.toBeNull();
-      // Read the rhythm from the token instead of restating it: the guard is
-      // that catalogs are a separate group, not that the gap is any one number.
+      expect([liveRowsBox, catalogBox]).not.toContain(null);
+      // Guard that catalogs are a separate group without restating the gap token.
       const groupGap = await page.evaluate(() => {
         const sidebar = document.querySelector(".sidebar");
         return sidebar
@@ -248,20 +242,7 @@ suite.define(() => {
           path: path.join(uiProofArtifactDir, "06-coding-catalog-spacing.png"),
         });
       }
-
-      await catalog.locator(".sidebar-session-group-toggle").click();
-      await claudeCatalog.locator(".sidebar-session-group-toggle").click();
-      const [catalogCountBox, claudeCountBox] = await Promise.all([
-        catalog.locator(".sidebar-session-group-count").boundingBox(),
-        claudeCatalog.locator(".sidebar-session-group-count").boundingBox(),
-      ]);
-      if (!catalogCountBox || !claudeCountBox) {
-        throw new Error("Expected visible collapsed catalog counts");
-      }
-      expect(catalogCountBox.x + catalogCountBox.width).toBeCloseTo(
-        claudeCountBox.x + claudeCountBox.width,
-        1,
-      );
+      await assertCatalogCountAlignment(page, ["codex", "claude"]);
     } finally {
       await page.close();
     }

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -146,7 +146,7 @@ suite.define(() => {
             {
               id: "codex",
               label: "Codex",
-              capabilities: { continueSession: true, archive: true, createSession: true },
+              capabilities: { continueSession: true, archive: true, startTerminal: true },
               hosts: [
                 {
                   hostId: "gateway:local",

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -146,7 +146,7 @@ suite.define(() => {
             {
               id: "codex",
               label: "Codex",
-              capabilities: { continueSession: true, archive: true, startTerminal: true },
+              capabilities: { continueSession: true, archive: true, createSession: true },
               hosts: [
                 {
                   hostId: "gateway:local",

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -5,7 +5,7 @@ import { beforeEach, expect, it } from "vitest";
 import type { SessionsCatalogHostEvent } from "../../../packages/gateway-protocol/src/index.ts";
 import { createControlUiE2eArtifactDir } from "../test-helpers/control-ui-e2e-artifacts.ts";
 import {
-  assertCatalogCountAlignment,
+  assertSessionSectionCountAlignment,
   controlUiBundledGatewayUrl,
   controlUiBundledSettingsStorageKey,
   controlUiSessionPath,
@@ -123,13 +123,13 @@ suite.define(() => {
             {
               contextTokens: null,
               displayName: "Understanding Startup Phases and Delays",
-              hasActiveRun: true,
+              hasActiveRun: false,
               key: "agent:main:startup-phases",
               kind: "direct",
               label: "Understanding Startup Phases and Delays",
               model: "gpt-5.5",
               modelProvider: "openai",
-              status: "running",
+              status: "idle",
               totalTokens: 0,
               updatedAt: Date.now(),
               worktree: {
@@ -242,7 +242,7 @@ suite.define(() => {
           path: path.join(uiProofArtifactDir, "06-coding-catalog-spacing.png"),
         });
       }
-      await assertCatalogCountAlignment(page, ["codex", "claude"]);
+      await assertSessionSectionCountAlignment(page, ["work", "catalog:codex", "catalog:claude"]);
     } finally {
       await page.close();
     }

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1363,6 +1363,8 @@ openclaw-settings-save-indicator:empty {
 }
 
 .sidebar-recent-sessions__head {
+  --sidebar-session-group-action-size: 22px;
+
   position: relative;
   display: flex;
   align-items: center;
@@ -1608,8 +1610,8 @@ openclaw-settings-save-indicator:empty {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: 22px;
-  height: 22px;
+  width: var(--sidebar-session-group-action-size);
+  height: var(--sidebar-session-group-action-size);
   flex: 0 0 auto;
   border: none;
   border-radius: var(--radius-sm);
@@ -1645,6 +1647,13 @@ openclaw-settings-save-indicator:empty {
   stroke-width: 1.7px;
   stroke-linecap: round;
   stroke-linejoin: round;
+}
+
+/* Keep catalog counts on one axis when a provider cannot create sessions. */
+.sidebar-session-catalog-new-spacer {
+  width: var(--sidebar-session-group-action-size);
+  height: var(--sidebar-session-group-action-size);
+  flex: 0 0 var(--sidebar-session-group-action-size);
 }
 
 @media (hover: none), (pointer: coarse) {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1656,6 +1656,31 @@ openclaw-settings-save-indicator:empty {
   flex: 0 0 var(--sidebar-session-group-action-size);
 }
 
+@media (hover: hover) and (pointer: fine) {
+  /* Hover actions replace the resting count instead of moving its column. */
+  .sidebar-session-catalog-grouping,
+  .sidebar-session-catalog-new {
+    position: absolute;
+    top: 50%;
+    right: 10px;
+    transform: translateY(-50%);
+  }
+
+  .sidebar-session-catalog-grouping:has(+ .sidebar-session-catalog-new) {
+    right: calc(10px + var(--sidebar-session-group-action-size) + 8px);
+  }
+
+  .sidebar-session-catalog-new-spacer {
+    display: none;
+  }
+
+  [data-session-section^="catalog:"]
+    > .sidebar-recent-sessions__head:where(:hover, :has(:focus-visible))
+    .sidebar-session-group-count {
+    opacity: 0;
+  }
+}
+
 @media (hover: none), (pointer: coarse) {
   /* Touch has no hover, so the chevron must be the resting state or
      catalog collapsibility becomes undiscoverable. */

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1650,7 +1650,7 @@ openclaw-settings-save-indicator:empty {
   stroke-linejoin: round;
 }
 
-/* Keep catalog counts on one axis when a provider cannot create sessions. */
+/* Reserve the new-session button's width so provider counts line up. */
 .sidebar-session-catalog-new-spacer {
   width: var(--sidebar-session-group-action-size);
   height: var(--sidebar-session-group-action-size);
@@ -1658,7 +1658,7 @@ openclaw-settings-save-indicator:empty {
 }
 
 @media (hover: hover) and (pointer: fine) {
-  /* Hover actions replace the resting count instead of moving its column. */
+  /* Keep hover actions immediately left of the fixed count. */
   .sidebar-session-catalog-grouping,
   .sidebar-session-catalog-new {
     position: absolute;
@@ -1780,7 +1780,7 @@ openclaw-settings-save-indicator:empty {
   align-items: center;
   gap: 8px;
   min-height: 19px;
-  padding: 1px 12px 1px var(--sidebar-inset);
+  padding: 1px 10px 1px var(--sidebar-inset);
   color: color-mix(in srgb, var(--muted) 82%, var(--text) 18%);
 }
 
@@ -1799,7 +1799,7 @@ openclaw-settings-save-indicator:empty {
   font-size: calc(10px * var(--control-ui-text-scale));
   font-variant-numeric: tabular-nums;
   opacity: 0.68;
-  text-align: center;
+  text-align: right;
 }
 
 .sidebar-session-catalog-host__count--error {
@@ -1823,7 +1823,7 @@ openclaw-settings-save-indicator:empty {
   gap: var(--sidebar-row-gap);
   width: 100%;
   min-height: 18px;
-  padding: 2px 12px 0 var(--sidebar-inset);
+  padding: 2px 10px 0 var(--sidebar-inset);
   border: 0;
   border-radius: var(--radius-sm);
   background: transparent;
@@ -1878,7 +1878,7 @@ openclaw-settings-save-indicator:empty {
   color: color-mix(in srgb, var(--muted) 55%, var(--text) 45%);
   font-size: calc(10px * var(--control-ui-text-scale));
   font-variant-numeric: tabular-nums;
-  text-align: center;
+  text-align: right;
 }
 
 .sidebar-session-catalog-project > .sidebar-session-pagination--catalog {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1364,6 +1364,7 @@ openclaw-settings-save-indicator:empty {
 
 .sidebar-recent-sessions__head {
   --sidebar-session-group-action-size: 22px;
+  --sidebar-session-group-count-slot: 24px;
 
   position: relative;
   display: flex;
@@ -1662,22 +1663,19 @@ openclaw-settings-save-indicator:empty {
   .sidebar-session-catalog-new {
     position: absolute;
     top: 50%;
-    right: 10px;
+    right: calc(10px + var(--sidebar-session-group-count-slot));
     transform: translateY(-50%);
   }
 
   .sidebar-session-catalog-grouping:has(+ .sidebar-session-catalog-new) {
-    right: calc(10px + var(--sidebar-session-group-action-size) + 8px);
+    right: calc(
+      10px + var(--sidebar-session-group-count-slot) + var(--sidebar-session-group-action-size) +
+        8px
+    );
   }
 
   .sidebar-session-catalog-new-spacer {
     display: none;
-  }
-
-  [data-session-section^="catalog:"]
-    > .sidebar-recent-sessions__head:where(:hover, :has(:focus-visible))
-    .sidebar-session-group-count {
-    opacity: 0;
   }
 }
 

--- a/ui/src/test-helpers/app-sidebar-cases/basics.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/basics.ts
@@ -169,6 +169,7 @@ describe("AppSidebar new session navigation", () => {
     await sidebar.updateComplete;
 
     const link = sidebar.querySelector<HTMLAnchorElement>(".sidebar-session-catalog-new")!;
+    expect(sidebar.querySelector(".sidebar-session-catalog-new-spacer")).toBeNull();
     expect(link.getAttribute("aria-label")).toBe("New session — Claude Code");
     expect(link.getAttribute("href")).toBe("/new?agent=research&catalog=claude");
     const contextMenu = new MouseEvent("contextmenu", { bubbles: true, cancelable: true });

--- a/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
+++ b/ui/src/test-helpers/app-sidebar-cases/catalog-live.ts
@@ -133,6 +133,8 @@ describe("AppSidebar session catalog pagination", () => {
     await sidebar.updateComplete;
 
     const section = sidebar.querySelector(`[data-session-section="catalog:${id}"]`);
+    expect(section?.querySelector(".sidebar-session-catalog-new")).toBeNull();
+    expect(section?.querySelector(".sidebar-session-catalog-new-spacer")).not.toBeNull();
     const lead = section?.querySelector(".sidebar-session-group-toggle__lead");
     expect(lead?.querySelector(".sidebar-session-group-toggle__icon")).not.toBeNull();
     const providerIcon = lead?.querySelector(".sidebar-session-catalog-provider-icon");

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -65,6 +65,31 @@ export function controlUiSessionUrl(
   return url.toString();
 }
 
+export async function assertCatalogCountAlignment(page: Page, catalogIds: readonly string[]) {
+  const catalogs = catalogIds.map((catalogId) =>
+    page.locator(`[data-session-section="catalog:${catalogId}"]`),
+  );
+  for (const catalog of catalogs) {
+    const toggle = catalog.locator(".sidebar-session-group-toggle");
+    if ((await toggle.getAttribute("aria-expanded")) !== "false") {
+      await toggle.click();
+    }
+  }
+  const rightEdges = await Promise.all(
+    catalogs.map(async (catalog) => {
+      const bounds = await catalog.locator(".sidebar-session-group-count").boundingBox();
+      if (!bounds) {
+        throw new Error("Expected visible collapsed catalog count");
+      }
+      return bounds.x + bounds.width;
+    }),
+  );
+  const expected = rightEdges[0];
+  if (expected === undefined || rightEdges.some((edge) => Math.abs(edge - expected) > 0.1)) {
+    throw new Error(`Expected aligned catalog count edges, received ${rightEdges.join(", ")}`);
+  }
+}
+
 export async function navigateToControlUiSession(page: Page, sessionKey: string): Promise<void> {
   const expectedPathname = await page.evaluate((sessionPath) => {
     const app = document.querySelector("openclaw-app") as HTMLElement & {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -110,6 +110,23 @@ export async function assertSessionSectionCountAlignment(
         throw new Error("Expected catalog hover actions to stay left of the count");
       }
     }
+    await section.locator(".sidebar-session-group-toggle").click();
+    for (const nestedCount of await section
+      .locator(".sidebar-session-catalog-host__count, .sidebar-session-catalog-project__count")
+      .all()) {
+      const nestedBounds = await nestedCount.boundingBox();
+      const textAlign = await nestedCount.evaluate(
+        (element) => getComputedStyle(element).textAlign,
+      );
+      if (
+        !nestedBounds ||
+        textAlign !== "right" ||
+        Math.abs(nestedBounds.x + nestedBounds.width - expected) > 0.1
+      ) {
+        throw new Error("Expected expanded catalog counts to share the section count edge");
+      }
+    }
+    await section.locator(".sidebar-session-group-toggle").click();
   }
 }
 

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -91,6 +91,26 @@ export async function assertSessionSectionCountAlignment(
   if (expected === undefined || rightEdges.some((edge) => Math.abs(edge - expected) > 0.1)) {
     throw new Error(`Expected aligned section count edges, received ${rightEdges.join(", ")}`);
   }
+  for (const [index, sectionId] of sectionIds.entries()) {
+    const section = sections[index];
+    if (!section || !sectionId.startsWith("catalog:")) {
+      continue;
+    }
+    const header = section.locator(":scope > .sidebar-recent-sessions__head");
+    await header.hover();
+    const count = header.locator(".sidebar-session-group-count");
+    const countBox = await count.boundingBox();
+    const countOpacity = await count.evaluate((element) => getComputedStyle(element).opacity);
+    if (!countBox || Number.parseFloat(countOpacity) <= 0) {
+      throw new Error("Expected visible catalog count on hover");
+    }
+    for (const action of await header.locator(".sidebar-session-group-actions").all()) {
+      const actionBox = await action.boundingBox();
+      if (!actionBox || actionBox.x + actionBox.width > countBox.x) {
+        throw new Error("Expected catalog hover actions to stay left of the count");
+      }
+    }
+  }
 }
 
 export async function navigateToControlUiSession(page: Page, sessionKey: string): Promise<void> {

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -65,28 +65,31 @@ export function controlUiSessionUrl(
   return url.toString();
 }
 
-export async function assertCatalogCountAlignment(page: Page, catalogIds: readonly string[]) {
-  const catalogs = catalogIds.map((catalogId) =>
-    page.locator(`[data-session-section="catalog:${catalogId}"]`),
+export async function assertSessionSectionCountAlignment(
+  page: Page,
+  sectionIds: readonly string[],
+) {
+  const sections = sectionIds.map((sectionId) =>
+    page.locator(`[data-session-section="${sectionId}"]`),
   );
-  for (const catalog of catalogs) {
-    const toggle = catalog.locator(".sidebar-session-group-toggle");
+  for (const section of sections) {
+    const toggle = section.locator(".sidebar-session-group-toggle");
     if ((await toggle.getAttribute("aria-expanded")) !== "false") {
       await toggle.click();
     }
   }
   const rightEdges = await Promise.all(
-    catalogs.map(async (catalog) => {
-      const bounds = await catalog.locator(".sidebar-session-group-count").boundingBox();
+    sections.map(async (section) => {
+      const bounds = await section.locator(".sidebar-session-group-count").boundingBox();
       if (!bounds) {
-        throw new Error("Expected visible collapsed catalog count");
+        throw new Error("Expected visible collapsed section count");
       }
       return bounds.x + bounds.width;
     }),
   );
   const expected = rightEdges[0];
   if (expected === undefined || rightEdges.some((edge) => Math.abs(edge - expected) > 0.1)) {
-    throw new Error(`Expected aligned catalog count edges, received ${rightEdges.join(", ")}`);
+    throw new Error(`Expected aligned section count edges, received ${rightEdges.join(", ")}`);
   }
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes sidebar counts appearing in different columns for Coding, Codex, Claude Code, and expanded project groups.

## Why This Change Was Made

Codex has two hover buttons, while Claude Code has only one. Those hidden buttons used to take up space and push each count to a different position. Expanded project counts were also centered in a wider cell, which pulled their digits left. All counts now share one right edge, and hover buttons appear immediately to the left without hiding or moving the count.

## User Impact

Coding, provider, host, and project counts line up consistently. Provider counts remain visible on hover. The local mock now also advertises Codex session creation correctly, so its `+` button matches a real Codex catalog.

## Evidence

- `pnpm --dir ui exec vitest run --config vitest.config.ts src/components/app-sidebar.test.ts` — 348 passed
- Focused bundled Chromium E2E verifies collapsed and expanded count edges, hover visibility, and action placement — 7 passed
- Local rendered fixture measured Coding and expanded Codex project right edges at `229px`, with the Codex `+` visible on hover
- Focused core oxlint stripe — passed
- `pnpm exec oxfmt --check` on changed files and `git diff --check` — passed

## Worked on by
