### PR TITLE
refactor(tests): simplify Google image fixtures

### DIFF
--- a/extensions/google/image-generation-provider.test.ts
+++ b/extensions/google/image-generation-provider.test.ts
@@ -23,14 +23,7 @@ function mockGoogleApiKeyAuth() {
   });
 }
 
-function installGoogleFetchMock(params?: {
-  data?: string;
-  mimeType?: string;
-  inlineDataKey?: "inlineData" | "inline_data";
-}) {
-  const mimeType = params?.mimeType ?? "image/png";
-  const data = params?.data ?? "png-data";
-  const inlineDataKey = params?.inlineDataKey ?? "inlineData";
+function installGoogleFetchMock() {
   const fetchMock = vi.fn().mockResolvedValue(
     jsonResponse({
       candidates: [
@@ -38,9 +31,9 @@ function installGoogleFetchMock(params?: {
           content: {
             parts: [
               {
-                [inlineDataKey]: {
-                  [inlineDataKey === "inlineData" ? "mimeType" : "mime_type"]: mimeType,
-                  data: Buffer.from(data).toString("base64"),
+                inlineData: {
+                  mimeType: "image/png",
+                  data: Buffer.from("png-data").toString("base64"),
                 },
               },
             ],


### PR DESCRIPTION
## What Problem This Solves

The Google image-test fixture carried three optional response settings even though every caller used the same defaults. The unused branches made the shared fixture harder to read and maintain.

## Why This Change Was Made

Replace the unused options with the existing PNG response literals. Keep the shared helper, response construction, mock lifetime, and all callers unchanged. Special response formats continue to use their explicit fixtures.

## User Impact

No runtime or provider behavior changes. This removes seven test-support lines. Every test body, title, assertion, and setup/cleanup operation is byte-identical.

## Evidence

- Baseline and candidate: all 22 Google image-provider tests pass, with identical case inventories.
- All six helper call sites pass no arguments; the complete test-body suffix is byte-identical.
- Independent Codex review through P2 is clean; formatting and diff checks passed.
- All 19 normal changed-file checks passed, including plugin test types, dead-export scans, and scoped lint ([Linux Testbox run](https://github.com/openclaw/openclaw/actions/runs/34194108437)). The one-shot lease, temporary capsule, and recorded processes are cleaned up.

All responses are synthetic injected fixtures. No live Google request was made, and no auth or request-policy behavior was changed.
