### PR TITLE
fix(release): scope status CPU allowance to 2026.7.33

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -491,6 +491,42 @@ jobs:
           chmod 0755 "$HOME/.local/bin/kova"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
+      - name: Apply OpenClaw 2026.7.33 Kova compatibility
+        if: steps.lane.outputs.run == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --input-type=module <<'NODE'
+          import fs from "node:fs";
+          import path from "node:path";
+
+          const targetPackage = JSON.parse(
+            fs.readFileSync(path.join(process.env.GITHUB_WORKSPACE, "package.json"), "utf8"),
+          );
+          if (targetPackage.version !== "2026.7.33") {
+            process.exit(0);
+          }
+
+          const surfaceNames = [
+            "cross-platform-smoke",
+            "fresh-install",
+            "gateway-performance",
+          ];
+          for (const name of surfaceNames) {
+            const surfacePath = path.join(process.env.KOVA_SRC, "surfaces", `${name}.json`);
+            const surface = JSON.parse(fs.readFileSync(surfacePath, "utf8"));
+            const threshold = surface.roleThresholds?.["status-cli"];
+            if (threshold?.maxCpuPercent !== 200) {
+              throw new Error(
+                `${name} expected the standard status-cli CPU ceiling of 200 before applying the 2026.7.33 compatibility allowance`,
+              );
+            }
+            threshold.maxCpuPercent = 250;
+            fs.writeFileSync(surfacePath, `${JSON.stringify(surface, null, 2)}\n`);
+          }
+          console.log("Applied the OpenClaw 2026.7.33 status-cli CPU compatibility allowance.");
+          NODE
+
       - name: Kova version and plan sanity
         if: steps.lane.outputs.run == 'true'
         shell: bash

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -327,6 +327,50 @@ describe("OpenClaw performance workflow", () => {
     expect(workflow).toContain("Kova live OpenAI GPT 5.6 agent turn");
   });
 
+  posixIt("scopes the elevated status CLI ceiling to OpenClaw 2026.7.33", () => {
+    const compatibility = findStep("Apply OpenClaw 2026.7.33 Kova compatibility");
+    const surfaceNames = ["cross-platform-smoke", "fresh-install", "gateway-performance"];
+
+    for (const [version, expectedCeiling] of [
+      ["2026.7.33", 250],
+      ["2026.7.34", 200],
+    ] as const) {
+      const root = tempDirs.make(`openclaw-kova-733-${version}-`);
+      const target = join(root, "openclaw");
+      const kova = join(root, "kova");
+      mkdirSync(join(kova, "surfaces"), { recursive: true });
+      mkdirSync(target, { recursive: true });
+      writeFileSync(join(target, "package.json"), JSON.stringify({ version }));
+      for (const name of surfaceNames) {
+        writeFileSync(
+          join(kova, "surfaces", `${name}.json`),
+          JSON.stringify({ roleThresholds: { "status-cli": { maxCpuPercent: 200 } } }),
+        );
+      }
+
+      const result = spawnSync("bash", ["-c", compatibility.run ?? ""], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          GITHUB_WORKSPACE: target,
+          KOVA_SRC: kova,
+        },
+      });
+      expect(result.status, result.stderr).toBe(0);
+      for (const name of surfaceNames) {
+        const surface = JSON.parse(
+          readFileSync(join(kova, "surfaces", `${name}.json`), "utf8"),
+        ) as { roleThresholds: { "status-cli": { maxCpuPercent: number } } };
+        expect(surface.roleThresholds["status-cli"].maxCpuPercent).toBe(expectedCeiling);
+      }
+    }
+
+    const steps = readWorkflow().jobs?.kova?.steps ?? [];
+    expect(steps.findIndex((step) => step.name === compatibility.name)).toBe(
+      steps.findIndex((step) => step.name === "Kova version and plan sanity") - 1,
+    );
+  });
+
   it("keeps live credentials away from custom Kova refs", () => {
     const resolveTarget = findStep("Resolve OpenClaw target ref", "resolve_target");
     const decideLane = findStep("Decide lane");
@@ -1338,7 +1382,8 @@ printf '%s\\n' \
     expect(workflowText).not.toContain("OCM_INTERNAL_NPM_BIN");
     expect(workflowText).not.toContain("OPENCLAW_OCM_NPM_WRAPPER");
     expect(workflowText).not.toContain("OPENCLAW_OCM_WORKSPACE_DEPENDENCY_DIRS");
-    expect(steps[installIndex + 1]?.name).toBe("Kova version and plan sanity");
+    expect(steps[installIndex + 1]?.name).toBe("Apply OpenClaw 2026.7.33 Kova compatibility");
+    expect(steps[installIndex + 2]?.name).toBe("Kova version and plan sanity");
   });
 
   it("fails selected live Kova lanes when live auth is missing", () => {


### PR DESCRIPTION
Related: openclaw/Kova#116
Companion Kova revert: openclaw/Kova#117

## What Problem This Solves

Fixes an issue where full release validation for OpenClaw 2026.7.33 can fail the status CLI CPU gate even though current OpenClaw main remains below Kova's normal 200% ceiling.

## Why This Change Was Made

Keeps Kova's shared ceiling at 200% and applies a 250% compatibility allowance only when the checked-out OpenClaw target declares version 2026.7.33. The workflow fails closed if the expected standard Kova ceiling has changed before applying the allowance.

## User Impact

Release validation can finish for 2026.7.33 without weakening CPU regression detection for current or future OpenClaw versions.

## Evidence

- `test/scripts/openclaw-performance-workflow.test.ts`: 43/43 passed
- Regression coverage proves 2026.7.33 receives 250% and 2026.7.34 remains at 200%
- `oxfmt --check` and `git diff --check` passed
- `pnpm check:workflows` could not install its pinned `pre-commit==4.6.2` from the configured package index; workflow YAML parsing is exercised by the passing focused test
