### PR TITLE
fix(hooks): accept interface-typed inbound mapper contexts

### DIFF
--- a/src/hooks/message-hook-mappers.test.ts
+++ b/src/hooks/message-hook-mappers.test.ts
@@ -24,6 +24,13 @@ type ResolveInboundConversationParams = Parameters<
   NonNullable<ChannelMessagingAdapter["resolveInboundConversation"]>
 >[0];
 
+interface MinimalInboundHookContext {
+  from: string;
+  content: string;
+  channelId: string;
+  isGroup: boolean;
+}
+
 function makeInboundCtx(overrides: Partial<FinalizedMsgContext> = {}): FinalizedMsgContext {
   return {
     From: "demo-chat:user:123",
@@ -131,14 +138,13 @@ describe("message hook mappers", () => {
     derived.mediaStagingPending = true;
     derived.originalMedia = [];
 
-    expect(
-      toPluginMessageContext({
-        from: "sender",
-        content: "hello",
-        channelId: "demo-chat",
-        isGroup: false,
-      }),
-    ).toMatchObject({ channelId: "demo-chat" });
+    const minimal: MinimalInboundHookContext = {
+      from: "sender",
+      content: "hello",
+      channelId: "demo-chat",
+      isGroup: false,
+    };
+    expect(toPluginMessageContext(minimal)).toMatchObject({ channelId: "demo-chat" });
   });
 
   it("derives canonical inbound context with body precedence and group metadata", () => {

--- a/src/hooks/message-hook-mappers.ts
+++ b/src/hooks/message-hook-mappers.ts
@@ -213,13 +213,29 @@ function deriveInboundMessageHookContextBase(
 }
 
 type DerivedInboundMessageHookContext = ReturnType<typeof deriveInboundMessageHookContextBase>;
+type InboundMessageHookMetadataFields = Pick<
+  PluginHookInboundMessageMetadata,
+  | "mediaPath"
+  | "mediaUrl"
+  | "mediaType"
+  | "mediaPaths"
+  | "mediaUrls"
+  | "mediaTypes"
+  | "originalMediaPath"
+  | "originalMediaUrl"
+  | "originalMediaType"
+  | "originalMediaPaths"
+  | "originalMediaUrls"
+  | "originalMediaTypes"
+  | "mediaStagingPending"
+>;
 type CanonicalInboundMessageHookContext = Pick<
   DerivedInboundMessageHookContext,
   "from" | "content" | "channelId" | "isGroup"
 > &
   Partial<DerivedInboundMessageHookContext> &
   Partial<Pick<PluginHookMessageContext, "runId" | "trace" | "callDepth">> &
-  Partial<PluginHookInboundMessageMetadata> & {
+  Partial<InboundMessageHookMetadataFields> & {
     originalMedia?: MessageHookMediaFact[];
     mediaRemoteHost?: string;
   };


### PR DESCRIPTION
Follow-up to #141880.

## What Problem This Solves

Fixes an issue where callers passing interface-typed inbound hook contexts to the mapper would fail TypeScript compilation after #141880, even when they supplied every required field.

## Why This Change Was Made

The canonical mapper input now selects the 13 named legacy media metadata fields instead of inheriting `PluginHookInboundMessageMetadata`'s open string index signature. This preserves the intended media compatibility surface without requiring caller interfaces to declare arbitrary string keys.

## User Impact

Plugin and channel code can pass structurally valid interface-typed inbound contexts to hook mappers again. Runtime behavior is unchanged.

## Evidence

- 29 focused hook mapper tests passed on Node 24.16
- Core and extension test-type checks passed with an interface-typed regression fixture
- Full `pnpm check:changed` passed against current `main`
- P0–P2 autoreview scoped-clean
