### PR TITLE
fix(release): scope status CPU allowance to 2026.7.33

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -119,7 +119,9 @@ jobs:
         with:
           ref: ${{ inputs.target_ref || github.sha }}
           path: .artifacts/performance-target
-          sparse-checkout: src/config/zod-schema.agent-defaults.ts
+          sparse-checkout: |
+            package.json
+            src/config/zod-schema.agent-defaults.ts
           sparse-checkout-cone-mode: false
           fetch-depth: 1
           persist-credentials: false
@@ -148,6 +150,18 @@ jobs:
 
           kova_ref="${KOVA_REF_INPUT:-}"
           kova_config_contract="${KOVA_CONFIG_CONTRACT_INPUT:-}"
+          if [[ -z "$kova_ref" ]]; then
+            target_version="$(node -e '
+              const fs = require("node:fs");
+              const version = JSON.parse(fs.readFileSync(process.argv[1], "utf8")).version;
+              if (typeof version !== "string") process.exit(1);
+              process.stdout.write(version);
+            ' "$TARGET_CHECKOUT_DIR/package.json")"
+            if [[ "$target_version" == "2026.7.33" ]]; then
+              # Kova #116 carries the historical 250% status CLI calibration for this release only.
+              kova_ref="70ea2c5a3bdd206937b4a0bd7460a19a69d8c52a"
+            fi
+          fi
           if [[ "$kova_ref" == *$'\n'* || "$kova_ref" == *$'\r'* ]]; then
             echo "::error::kova_ref must be a single line."
             exit 1

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -267,7 +267,7 @@ describe("OpenClaw performance workflow", () => {
       "${{ inputs.kova_config_contract }}",
     );
     expect(targetCheckout.with?.["sparse-checkout"]).toBe(
-      "src/config/zod-schema.agent-defaults.ts",
+      "package.json\nsrc/config/zod-schema.agent-defaults.ts\n",
     );
     expect(resolveTarget.run).toContain(
       'schema_path="${TARGET_CHECKOUT_DIR}/src/config/zod-schema.agent-defaults.ts"',


### PR DESCRIPTION
Supersedes: #141928
Related: openclaw/Kova#116
Companion Kova revert: openclaw/Kova#117

## What Problem This Solves

Full Release Validation for OpenClaw 2026.7.33 can fail the status CLI CPU gate even though current OpenClaw versions remain below Kova's restored 200% ceiling.

## Why This Change Was Made

The performance workflow now owns the compatibility mapping beside its existing reviewed Kova pins. It inspects the frozen target's `package.json` and selects the calibrated openclaw/Kova#116 revision only for exactly 2026.7.33. Explicit `kova_ref` inputs still take precedence.

Full Release Validation no longer contains or passes a duplicate SHA, and no 2026.7.33-specific behavior is added to Kova main. Every other target continues using the normal fixture-compatible Kova pin and restored 200% ceiling.

## User Impact

Release validation can finish for 2026.7.33 without weakening CPU regression detection for current releases or freezing unrelated Kova development.

## Evidence

- Performance and extended-stable workflow tests: 45/45 passed
- `oxfmt --check` passed
- `git diff --check` passed
