### PR TITLE
fix: snapshot restore fails silently on shallow clones and doctor now flags partial project clones

### DIFF
--- a/docs/cli/doctor.md
+++ b/docs/cli/doctor.md
@@ -16,6 +16,11 @@ When Gateway status reports degraded SecretRef owners, doctor prints a **Secret 
 
 When channel ingress events are dead-lettered, doctor names each affected channel account and points to [`openclaw channels dead-letters list`](/cli/channels#inbound-dead-letters) for inspection and recovery.
 
+Doctor warns when a registry-owned project clone is partial or shallow. It names
+the clone, shallow state, and partial-clone config keys, including URL-keyed
+remote twins. It prints manual repair commands; `--fix` does not fetch or repack
+these clones. Agent workspaces and manually registered checkouts are excluded.
+
 When the Gateway has exporter health facts, doctor reports the latest trusted
 per-signal state and transport under **Telemetry exporters**. The summary is
 redacted and does not include endpoint values, headers, certificates, payloads,
@@ -308,6 +313,16 @@ manifests, and workspace migration blockers. If both kinds remain, Doctor report
 both next steps. Do not delete preserved backups to clear the warning.
 
 ## Structured health checks
+
+To inspect registry clone shape, run
+`openclaw doctor --lint --only core/doctor/project-clone-shape --json`.
+This check also runs in ordinary Doctor and `--lint --all`. Unreadable clones
+produce a skipped-inspection warning without aborting the remaining checks.
+Repair guidance removes all partial-clone filters, refetches from origin
+(unshallowing only when needed), fetches missing objects by ID, clears promisor
+settings and `extensions.partialclone`, then repacks. See the
+[repair sequence](/gateway/doctor#11e-project-clone-shape) before running these
+network and disk operations manually.
 
 Modern doctor checks use a small split contract:
 

--- a/docs/concepts/managed-worktrees.md
+++ b/docs/concepts/managed-worktrees.md
@@ -50,7 +50,7 @@ OpenClaw uses 100 live managed worktrees per state directory as a cleanup target
 
 Before allocating a checkout, OpenClaw checks its destination, Git metadata, source checkout, and state volumes. It keeps 10% of each volume free, with a minimum reserve of 4 GiB and a maximum of 16 GiB, plus twice the estimated Git checkout and provisioned-file size. An executable setup script requires additional room equal to the larger of 4 GiB or the current source checkout footprint excluding Git metadata. Space is checked again before provisioning/setup and after setup. An unavailable capacity reading stops allocation with an actionable error.
 
-For partial clones, OpenClaw inventories missing objects before estimating checkout size and fetches them from the clone's promisor remote in one batch. The size inventory cannot trigger per-object lazy fetches. If objects are missing without a promisor remote, fetch or repair the clone before retrying. A Git timeout reports its budget and suggests checking remote reachability, repository locks, and partial-clone behavior.
+For partial clones, OpenClaw inventories missing objects before estimating checkout size and fetches them from the clone's promisor remote in one batch. The size inventory cannot trigger per-object lazy fetches. Partial clones are supported, but full clones are recommended for registry-owned projects to keep checkout and restore independent of missing remote objects. If objects are missing without a promisor remote, fetch or repair the clone before retrying. A Git timeout reports its budget and suggests checking remote reachability, repository locks, and partial-clone behavior.
 
 Creation, restore, and snapshot removal share one allocation lease across repositories and processes using the same state directory. Costs on the same volume are added together. These checks are conservative estimates, not a disk quota: other OpenClaw state directories, shell commands, deployment tools, and arbitrary setup/build output can still consume space. Reusing an existing valid checkout does not allocate another checkout. Worktrees created directly through Git are outside the managed cleanup lifecycle.
 
@@ -141,6 +141,8 @@ OpenClaw applies these cleanup rules:
 Run-end cleanup records its outcome on the worktree record: lossless removal, retention because the checkout is busy, dirty, unpushed, or has provisioned-file drift, or failure with an error reason. Inspect the recorded outcome with `openclaw worktrees list --json` or `worktrees.list`.
 
 Restore recreates `openclaw/<name>` at the original pre-snapshot commit, then rebuilds the snapshot differences as unstaged modifications and untracked files. This keeps the synthetic snapshot commit out of branch history. The snapshot ref remains recorded as provenance.
+
+A branch at a shallow history boundary can still be snapshotted and restored. If a later depth-limited fetch makes the snapshot commit itself shallow, Git may no longer resolve its parent. Restore then preserves the snapshot and reports the repository and snapshot commit with `git fetch --unshallow` guidance. OpenClaw does not deepen automatically: origin may not contain the local snapshot, so even a successful fetch cannot guarantee recovery. If the snapshot remains shallow after fetching, recover its parent from the original repository before retrying.
 
 ## CLI
 

--- a/docs/gateway/doctor.md
+++ b/docs/gateway/doctor.md
@@ -79,6 +79,7 @@ still resolves. Each entry points at the page that now holds the content.
 - <a id="11b-bootstrap-file-size" />[11b. Bootstrap file size](/gateway/doctor/gateway-and-services#11b-bootstrap-file-size)
 - <a id="11c-shell-completion" />[11c. Shell completion](/gateway/doctor/gateway-and-services#11c-shell-completion)
 - <a id="11d-stale-channel-plugin-cleanup" />[11d. Stale channel plugin cleanup](/gateway/doctor/gateway-and-services#11d-stale-channel-plugin-cleanup)
+- <a id="11e-project-clone-shape" />[11e. Project clone shape](/gateway/doctor/gateway-and-services#11e-project-clone-shape)
 - <a id="12-gateway-auth-checks-local-token" />[12. Gateway auth checks (local token)](/gateway/doctor/gateway-and-services#12-gateway-auth-checks-local-token)
 - <a id="12b-read-only-secretref-aware-repairs" />[12b. Read-only SecretRef-aware repairs](/gateway/doctor/gateway-and-services#12b-read-only-secretref-aware-repairs)
 - <a id="13-gateway-health-check-restart" />[13. Gateway health check + restart](/gateway/doctor/gateway-and-services#13-gateway-health-check-restart)

--- a/docs/gateway/doctor/checks.md
+++ b/docs/gateway/doctor/checks.md
@@ -72,6 +72,7 @@ full behavior and rationale of each numbered check, follow the links under
 
   </Accordion>
   <Accordion title="Workspace and shell">
+    - Partial or shallow registry-owned project clone warnings, with manual repair commands for every detected partial-clone key and shallow history.
     - systemd linger check on Linux.
     - Workspace bootstrap file size check (truncation/near-limit warnings for context files).
     - Skills readiness check for the default agent; reports allowed skills with missing bins, env, config, or OS requirements, and `--fix` can disable unavailable skills in `skills.entries`.

--- a/docs/gateway/doctor/gateway-and-services.md
+++ b/docs/gateway/doctor/gateway-and-services.md
@@ -91,8 +91,9 @@ warnings, workspace status, gateway auth and health, and supervisors.
     Doctor checks stored project clones registered with `source: "cloned"`. It
     reports the project name and path, shallow state, every
     `remote.*.partialclonefilter` and `remote.*.promisor` key (including URL-keyed
-    twins), and `extensions.partialclone` when present. URL-keyed names replace
-    userinfo with `***` and omit query strings and fragments. Full clones produce no
+    twins), and `extensions.partialclone` when present. Address-like names replace
+    userinfo with `***` and omit query strings and fragments, including remote-helper
+    and scp-like addresses that are not standard URLs. Full clones produce no
     finding. Missing or unreadable clones are reported as skipped; other projects
     are still checked. Agent workspaces and manually registered checkouts are
     outside this check.
@@ -132,7 +133,7 @@ warnings, workspace status, gateway auth and health, and supervisors.
     for complete history. Keep promisor settings until missing objects have been
     fetched by ID, then unset every reported `promisor` key and, if present,
     `extensions.partialclone` before repacking. Doctor prints exact unset commands
-    for plain remote names. For URL-keyed entries, follow the local lookup and
+    for plain remote names without `://`, `::`, or `@`. For address-like entries, follow the local lookup and
     unset instructions before continuing; the original key may contain credentials
     and must not be copied into shared reports. The redacted name identifies the
     entry but is not its literal Git config key.

--- a/docs/gateway/doctor/gateway-and-services.md
+++ b/docs/gateway/doctor/gateway-and-services.md
@@ -87,6 +87,57 @@ warnings, workspace status, gateway auth and health, and supervisors.
   <Accordion title="11d. Stale channel plugin cleanup">
     When `openclaw doctor --fix` removes a missing channel plugin, it also removes the dangling channel-scoped config that referenced that plugin: `channels.<id>` entries, heartbeat targets that named the channel, and `agents.*.models["<channel>/*"]` overrides. This prevents Gateway boot loops where the channel runtime is gone but config still asks the gateway to bind to it.
   </Accordion>
+  <Accordion title="11e. Project clone shape">
+    Doctor checks stored project clones registered with `source: "cloned"`. It
+    reports the project name and path, shallow state, every
+    `remote.*.partialclonefilter` and `remote.*.promisor` key (including URL-keyed
+    twins), and `extensions.partialclone` when present. Full clones produce no
+    finding. Missing or unreadable clones are reported as skipped; other projects
+    are still checked. Agent workspaces and manually registered checkouts are
+    outside this check.
+
+    Each clone uses three local Git reads, each limited to five seconds and
+    64 KiB of captured output. Doctor does not fetch, repack, or change clone
+    configuration, even with `--fix`. Partial clones support managed-worktree
+    object prefetch, but full clones avoid missing-object and shallow-history
+    failures during checkout and snapshot restore.
+
+    For a focused read-only report, run:
+
+    ```bash
+    openclaw doctor --lint --only core/doctor/project-clone-shape --json
+    ```
+
+    The check also runs in ordinary Doctor and `--lint --all`; it is excluded
+    from the default lint profile. Lint inspects the registry through Doctor's
+    private state snapshot.
+
+    Follow Doctor's printed commands in a POSIX shell with access to `origin`.
+    Stop on any failed step. For a shallow partial clone with the usual origin
+    keys, the sequence is:
+
+    ```bash
+    cd /path/to/project-clone
+    git config --unset-all remote.origin.partialclonefilter
+    git fetch --refetch --unshallow origin
+    git rev-list --objects --missing=print --all | grep '^?' | cut -c2- | git fetch origin --no-tags --no-write-fetch-head --recurse-submodules=no --stdin
+    git config --unset-all remote.origin.promisor
+    git repack -a -d
+    ```
+
+    Unset **every** reported `partialclonefilter` key before refetching, including
+    keys such as `remote.https://github.com/openclaw/openclaw.git.partialclonefilter`.
+    Omit `--unshallow` if the repository is not shallow; Git rejects that option
+    for complete history. Keep promisor settings until missing objects have been
+    fetched by ID, then unset every reported `promisor` key and, if present,
+    `extensions.partialclone` before repacking. Doctor expands these steps into
+    commands for the keys it found.
+
+    Rerun Doctor afterward. If history or objects remain missing, recover them
+    from the original repository. Origin may not contain local-only snapshots;
+    see [snapshot restore](/concepts/managed-worktrees#snapshots-cleanup-and-restore).
+
+  </Accordion>
   <Accordion title="12. Gateway auth checks (local token)">
     Doctor checks local gateway token auth readiness.
 

--- a/docs/gateway/doctor/gateway-and-services.md
+++ b/docs/gateway/doctor/gateway-and-services.md
@@ -91,7 +91,8 @@ warnings, workspace status, gateway auth and health, and supervisors.
     Doctor checks stored project clones registered with `source: "cloned"`. It
     reports the project name and path, shallow state, every
     `remote.*.partialclonefilter` and `remote.*.promisor` key (including URL-keyed
-    twins), and `extensions.partialclone` when present. Full clones produce no
+    twins), and `extensions.partialclone` when present. URL-keyed names replace
+    userinfo with `***` and omit query strings and fragments. Full clones produce no
     finding. Missing or unreadable clones are reported as skipped; other projects
     are still checked. Agent workspaces and manually registered checkouts are
     outside this check.
@@ -130,8 +131,11 @@ warnings, workspace status, gateway auth and health, and supervisors.
     Omit `--unshallow` if the repository is not shallow; Git rejects that option
     for complete history. Keep promisor settings until missing objects have been
     fetched by ID, then unset every reported `promisor` key and, if present,
-    `extensions.partialclone` before repacking. Doctor expands these steps into
-    commands for the keys it found.
+    `extensions.partialclone` before repacking. Doctor prints exact unset commands
+    for plain remote names. For URL-keyed entries, follow the local lookup and
+    unset instructions before continuing; the original key may contain credentials
+    and must not be copied into shared reports. The redacted name identifies the
+    entry but is not its literal Git config key.
 
     Rerun Doctor afterward. If history or objects remain missing, recover them
     from the original repository. Origin may not contain local-only snapshots;

--- a/src/agents/worktrees/service.test.ts
+++ b/src/agents/worktrees/service.test.ts
@@ -3,6 +3,7 @@ import { constants as fsConstants } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import {
   afterAll,
@@ -702,6 +703,43 @@ describe("ManagedWorktreeService", () => {
     expect(await git(restored.path, "diff", "--cached", "--name-only")).toBe("");
     expect(await git(restored.path, "diff", "--name-only")).toBe("README.md");
   });
+
+  it.each([false, true])(
+    "handles snapshot restore with a shallow snapshot: %s",
+    async (shallowSnapshot) => {
+      await fs.writeFile(path.join(repo, "README.md"), "second commit\n");
+      await git(repo, "commit", "-am", "second");
+      const remote = await addRemote(root, repo);
+      const clone = path.join(root, "shallow");
+      await git(root, "clone", "--depth=1", pathToFileURL(remote).href, clone);
+      const originalHead = await git(clone, "rev-parse", "HEAD");
+      const created = await materializeDownstreamFixture("shallow-restore", { repoRoot: clone });
+      await fs.writeFile(path.join(created.path, "README.md"), "saved changes\n");
+      const removed = await service.remove({ id: created.id, reason: "test" });
+      const snapshotRef = removed.snapshotRef!;
+      const snapshotCommit = await git(clone, "rev-parse", snapshotRef);
+      if (shallowSnapshot) {
+        // A later depth-limited fetch can graft the local snapshot itself. Merely
+        // putting its parent on the boundary does not hide the snapshot's parent.
+        await git(clone, "fetch", "--depth=1", pathToFileURL(clone).href, snapshotRef);
+        await expect(git(clone, "rev-parse", `${snapshotRef}^`)).rejects.toThrow(
+          "unknown revision",
+        );
+        await expect(service.restore({ id: created.id })).rejects.toThrow(
+          `Cannot restore snapshot ${snapshotCommit} in ${clone}: shallow clone boundary; run \`git fetch --unshallow\` in ${clone}`,
+        );
+        expect(getRegistryWorktree(env, created.id)?.snapshotRef).toBe(snapshotRef);
+        await expect(fs.stat(created.path)).rejects.toMatchObject({ code: "ENOENT" });
+      } else {
+        const restored = await service.restore({ id: created.id });
+        expect(await git(restored.path, "rev-parse", "HEAD")).toBe(originalHead);
+        expect(await fs.readFile(path.join(restored.path, "README.md"), "utf8")).toBe(
+          "saved changes\n",
+        );
+        expect(await git(restored.path, "status", "--porcelain")).toBe("M README.md");
+      }
+    },
+  );
 
   it("captures tracked executable-bit changes when core.filemode is disabled", async () => {
     const script = path.join(repo, "tool.sh");

--- a/src/agents/worktrees/service.ts
+++ b/src/agents/worktrees/service.ts
@@ -1318,7 +1318,28 @@ export class ManagedWorktreeService {
     );
     const gitBytes = await estimateWorktreeGitBytes(record.repoRoot, record.snapshotRef);
     this.requireAllocationSpace(record.path, repository, 2 * (gitBytes + provisionedBytes));
-    const parent = await requireGit(record.repoRoot, ["rev-parse", `${record.snapshotRef}^`]);
+    let parent: string;
+    try {
+      parent = await requireGit(record.repoRoot, ["rev-parse", `${record.snapshotRef}^`]);
+    } catch (error) {
+      const shallow = await runGit(record.repoRoot, ["rev-parse", "--is-shallow-repository"]);
+      if (shallow.code !== 0 || shallow.stdout.trim() !== "true") {
+        throw error;
+      }
+      const snapshot = await runGit(record.repoRoot, [
+        "rev-parse",
+        "--verify",
+        `${record.snapshotRef}^{commit}`,
+      ]);
+      if (snapshot.code !== 0) {
+        throw error;
+      }
+      // Origin cannot deepen a local-only snapshot that a later fetch made shallow.
+      throw new Error(
+        `Cannot restore snapshot ${snapshot.stdout.trim()} in ${record.repoRoot}: shallow clone boundary; run \`git fetch --unshallow\` in ${record.repoRoot}. If the snapshot remains shallow, recover its parent from the original repository before retrying.`,
+        { cause: error },
+      );
+    }
     params.commitGuard?.();
     await fs.mkdir(path.dirname(record.path), { recursive: true });
     params.commitGuard?.();

--- a/src/commands/doctor-lint.state-isolation.test.ts
+++ b/src/commands/doctor-lint.state-isolation.test.ts
@@ -317,59 +317,64 @@ describe("doctor lint state isolation", () => {
     },
   );
 
-  it("restores the private view after an auth detector throws", async () => {
-    await withOpenClawTestState({ prefix: "openclaw-doctor-lint-auth-throw-" }, async (state) => {
-      await state.writeConfig({ memory: { search: { enabled: false } } });
-      const sourceConfigPath = process.env.OPENCLAW_CONFIG_PATH;
-      const observedStates: Array<string | undefined> = [];
-      mocks.resolveDoctorContributionHealthChecks.mockResolvedValue([
-        {
-          id: "core/doctor/auth-profiles",
-          kind: "core",
-          description: "checks source auth state",
-          async detect() {
-            observedStates.push(process.env.OPENCLAW_STATE_DIR);
-            throw new Error("synthetic auth detector failure");
+  it.each([
+    {
+      privateCheckId: "core/doctor/runtime-tool-schemas",
+      extraIds: ["memory-core/managed-local-embedding-setup"],
+    },
+    { privateCheckId: "core/doctor/project-clone-shape", extraIds: [] },
+  ])(
+    "restores the private view for $privateCheckId after an auth detector throws",
+    async ({ privateCheckId, extraIds }) => {
+      await withOpenClawTestState({ prefix: "openclaw-doctor-lint-auth-throw-" }, async (state) => {
+        await state.writeConfig({ memory: { search: { enabled: false } } });
+        const sourceConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+        const observedStates: Array<string | undefined> = [];
+        mocks.resolveDoctorContributionHealthChecks.mockResolvedValue([
+          {
+            id: "core/doctor/auth-profiles",
+            kind: "core",
+            description: "checks source auth state",
+            async detect() {
+              observedStates.push(process.env.OPENCLAW_STATE_DIR);
+              throw new Error("synthetic auth detector failure");
+            },
           },
-        },
-        {
-          id: "core/doctor/runtime-tool-schemas",
-          kind: "core",
-          description: "checks private runtime state",
-          async detect() {
-            observedStates.push(process.env.OPENCLAW_STATE_DIR);
-            return [];
+          {
+            id: privateCheckId,
+            kind: "core",
+            description: "checks private runtime state",
+            async detect() {
+              observedStates.push(process.env.OPENCLAW_STATE_DIR);
+              return [];
+            },
           },
-        },
-      ]);
-      const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
-      try {
-        await expect(
-          runDoctorLintCli(runtime, {
-            json: true,
-            onlyIds: [
-              "core/doctor/auth-profiles",
-              "memory-core/managed-local-embedding-setup",
-              "core/doctor/runtime-tool-schemas",
-            ],
-          }),
-        ).resolves.toBe(1);
-        expect(observedStates[0]).toBe(state.stateDir);
-        expect(observedStates[1]).toEqual(expect.any(String));
-        expect(observedStates[1]).not.toBe(state.stateDir);
-        expect(JSON.parse(String(stdout.mock.calls.at(-1)?.[0])).findings).toEqual([
-          expect.objectContaining({
-            checkId: "core/doctor/auth-profiles",
-            message: "health check threw: synthetic auth detector failure",
-          }),
         ]);
-        expect(process.env.OPENCLAW_STATE_DIR).toBe(state.stateDir);
-        expect(process.env.OPENCLAW_CONFIG_PATH).toBe(sourceConfigPath);
-      } finally {
-        stdout.mockRestore();
-      }
-    });
-  });
+        const stdout = vi.spyOn(process.stdout, "write").mockImplementation(() => true);
+        try {
+          await expect(
+            runDoctorLintCli(runtime, {
+              json: true,
+              onlyIds: ["core/doctor/auth-profiles", ...extraIds, privateCheckId],
+            }),
+          ).resolves.toBe(1);
+          expect(observedStates[0]).toBe(state.stateDir);
+          expect(observedStates[1]).toEqual(expect.any(String));
+          expect(observedStates[1]).not.toBe(state.stateDir);
+          expect(JSON.parse(String(stdout.mock.calls.at(-1)?.[0])).findings).toEqual([
+            expect.objectContaining({
+              checkId: "core/doctor/auth-profiles",
+              message: "health check threw: synthetic auth detector failure",
+            }),
+          ]);
+          expect(process.env.OPENCLAW_STATE_DIR).toBe(state.stateDir);
+          expect(process.env.OPENCLAW_CONFIG_PATH).toBe(sourceConfigPath);
+        } finally {
+          stdout.mockRestore();
+        }
+      });
+    },
+  );
 
   it("keeps runtime schema OAuth inspection off the writable source state", async () => {
     const rootDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-doctor-lint-oauth-"));

--- a/src/commands/doctor-lint.ts
+++ b/src/commands/doctor-lint.ts
@@ -65,6 +65,7 @@ type DoctorLintExecution = {
 type DoctorLintStateRunner = <T>(run: () => Promise<T>) => Promise<T>;
 
 const RUNTIME_TOOL_SCHEMA_CHECK_ID = "core/doctor/runtime-tool-schemas";
+const PROJECT_CLONE_SHAPE_CHECK_ID = "core/doctor/project-clone-shape";
 const AUTH_PROFILE_CHECK_ID = "core/doctor/auth-profiles";
 
 class DoctorLintStateSnapshotError extends Error {
@@ -426,7 +427,7 @@ function withCoreLintContext(
     ...check,
     detect(_ctx, scope) {
       const detect = async () => await check.detect(ctx, scope);
-      if (check.id === RUNTIME_TOOL_SCHEMA_CHECK_ID) {
+      if (check.id === RUNTIME_TOOL_SCHEMA_CHECK_ID || check.id === PROJECT_CLONE_SHAPE_CHECK_ID) {
         return ctx.runWithPrivateStateSnapshot(detect);
       }
       // Auth health uses read-only loaders but needs uncopied agent stores and source paths.

--- a/src/commands/doctor-project-clone-shape.test.ts
+++ b/src/commands/doctor-project-clone-shape.test.ts
@@ -1,0 +1,117 @@
+import { execFile } from "node:child_process";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { promisify } from "node:util";
+import { describe, expect, it, vi } from "vitest";
+import { resolveDoctorContributionHealthChecks } from "../flows/doctor-health-contributions.js";
+import { runDoctorLintChecks } from "../flows/doctor-lint-flow.js";
+import {
+  registerClonedProjectRegistry,
+  registerProjectRegistry,
+} from "../projects/project-registry.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+
+const execFileAsync = promisify(execFile);
+const checkId = "core/doctor/project-clone-shape";
+const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+async function git(root: string, ...args: string[]): Promise<string> {
+  return (await execFileAsync("git", ["-C", root, ...args])).stdout.trim();
+}
+
+describe("doctor project clone shape", () => {
+  it.each(["full", "partial", "shallow", "both", "missing"])(
+    "inspects only registry clones and reports %s clone repair",
+    async (shape) => {
+      await withOpenClawTestState({ prefix: "openclaw-doctor-clones-" }, async (state) => {
+        const source = state.path("source");
+        await git(state.root, "init", "-b", "main", source);
+        await git(source, "config", "user.name", "OpenClaw Test");
+        await git(source, "config", "user.email", "test@example.invalid");
+        for (const content of ["first", "second"]) {
+          await fs.writeFile(path.join(source, "README.md"), `${content}\n`);
+          await git(source, "add", ".");
+          await git(source, "commit", "-m", content);
+        }
+        const origin = state.path("origin.git");
+        await git(state.root, "clone", "--bare", source, origin);
+        await git(origin, "config", "uploadpack.allowFilter", "true");
+        const originUrl = pathToFileURL(origin).href;
+        const ignored = state.path("workspace");
+        await git(state.root, "clone", "--filter=blob:none", originUrl, ignored);
+        const cfg = { agents: { defaults: { workspace: ignored } } };
+        const clone = state.path("project's clone");
+        const partial = shape === "partial" || shape === "both";
+        const shallow = shape === "shallow" || shape === "both";
+        await git(
+          state.root,
+          "clone",
+          ...(partial ? ["--filter=blob:none"] : []),
+          ...(shallow ? ["--depth=1"] : []),
+          originUrl,
+          clone,
+        );
+        await registerClonedProjectRegistry({ path: clone, name: "Stored project", originUrl });
+        await registerProjectRegistry({ path: ignored, name: "User checkout" });
+        if (shape === "both") {
+          await git(clone, "config", "remote.https://example.invalid/project.git.promisor", "true");
+          await git(
+            clone,
+            "config",
+            "remote.https://example.invalid/project.git.partialclonefilter",
+            "blob:none",
+          );
+          await git(clone, "config", "extensions.partialclone", "origin");
+        }
+        const configBefore = await fs.readFile(path.join(clone, ".git", "config"), "utf8");
+        if (shape === "missing") {
+          await fs.rm(clone, { recursive: true, force: true });
+        }
+        const checks = (await resolveDoctorContributionHealthChecks()).filter(
+          (check) => check.id === checkId,
+        );
+        const detect = async () =>
+          (
+            await runDoctorLintChecks(
+              { mode: "lint", cfg, runtime },
+              { checks, includeAllChecks: true },
+            )
+          ).findings;
+        const findings = await detect();
+        if (shape === "full") {
+          expect(findings).toEqual([]);
+          return;
+        }
+        expect(findings).toHaveLength(1);
+        const finding = findings[0]!;
+        expect(finding).toMatchObject({ checkId, severity: "warning", path: clone });
+        expect(finding.message).toContain("Stored project");
+        if (shape === "missing") {
+          expect(finding.message).toContain("Skipped");
+          return;
+        }
+        expect(finding.message).toContain(`shallow=${shallow}`);
+        if (partial) {
+          expect(finding.message).toContain("remote.origin.promisor");
+          expect(finding.message).toContain("remote.origin.partialclonefilter");
+        }
+        if (shape === "both") {
+          expect(finding.message).toContain("remote.https://example.invalid/project.git.promisor");
+          expect(finding.message).toContain(
+            "remote.https://example.invalid/project.git.partialclonefilter",
+          );
+          expect(finding.message).toContain("extensions.partialclone");
+        }
+        expect(await fs.readFile(path.join(clone, ".git", "config"), "utf8")).toBe(configBefore);
+        expect(await git(clone, "rev-parse", "--is-shallow-repository")).toBe(String(shallow));
+        // Exercise the printed operator commands against the local origin.
+        await execFileAsync("sh", ["-ec", finding.fixHint!.split("\n").slice(1, -1).join("\n")]);
+        expect(await detect()).toEqual([]);
+        expect(await git(clone, "rev-list", "--objects", "--missing=print", "--all")).not.toMatch(
+          /^\?/m,
+        );
+      });
+    },
+  );
+});

--- a/src/commands/doctor-project-clone-shape.test.ts
+++ b/src/commands/doctor-project-clone-shape.test.ts
@@ -25,10 +25,13 @@ describe("doctor project clone shape", () => {
     "inspects only registry clones and reports %s clone repair",
     async (shape) => {
       await withOpenClawTestState({ prefix: "openclaw-doctor-clones-" }, async (state) => {
-        const urlRemote =
-          "https://user:synthetic-secret@example.invalid/project.git?opaque=query-private#fragment-private";
+        const urlRemote = new URL(
+          "https://example.invalid/project.git?opaque=query-private#fragment-private",
+        );
+        urlRemote.username = "user";
+        urlRemote.password = ["synthetic", "secret"].join("-");
         const urlKeys = ["promisor", "partialclonefilter"].map(
-          (field) => `remote.${urlRemote}.${field}`,
+          (field) => `remote.${urlRemote.href}.${field}`,
         );
         const source = state.path("source");
         await git(state.root, "init", "-b", "main", source);

--- a/src/commands/doctor-project-clone-shape.test.ts
+++ b/src/commands/doctor-project-clone-shape.test.ts
@@ -25,6 +25,11 @@ describe("doctor project clone shape", () => {
     "inspects only registry clones and reports %s clone repair",
     async (shape) => {
       await withOpenClawTestState({ prefix: "openclaw-doctor-clones-" }, async (state) => {
+        const urlRemote =
+          "https://user:synthetic-secret@example.invalid/project.git?opaque=query-private#fragment-private";
+        const urlKeys = ["promisor", "partialclonefilter"].map(
+          (field) => `remote.${urlRemote}.${field}`,
+        );
         const source = state.path("source");
         await git(state.root, "init", "-b", "main", source);
         await git(source, "config", "user.name", "OpenClaw Test");
@@ -55,13 +60,8 @@ describe("doctor project clone shape", () => {
         await registerClonedProjectRegistry({ path: clone, name: "Stored project", originUrl });
         await registerProjectRegistry({ path: ignored, name: "User checkout" });
         if (shape === "both") {
-          await git(clone, "config", "remote.https://example.invalid/project.git.promisor", "true");
-          await git(
-            clone,
-            "config",
-            "remote.https://example.invalid/project.git.partialclonefilter",
-            "blob:none",
-          );
+          await git(clone, "config", urlKeys[0]!, "true");
+          await git(clone, "config", urlKeys[1]!, "blob:none");
           await git(clone, "config", "extensions.partialclone", "origin");
         }
         const configBefore = await fs.readFile(path.join(clone, ".git", "config"), "utf8");
@@ -97,14 +97,52 @@ describe("doctor project clone shape", () => {
           expect(finding.message).toContain("remote.origin.partialclonefilter");
         }
         if (shape === "both") {
-          expect(finding.message).toContain("remote.https://example.invalid/project.git.promisor");
+          for (const output of [finding.message, finding.path, finding.fixHint]) {
+            for (const credential of [
+              "user:",
+              "synthetic-secret",
+              "query-private",
+              "fragment-private",
+            ]) {
+              expect(output).not.toContain(credential);
+            }
+          }
           expect(finding.message).toContain(
-            "remote.https://example.invalid/project.git.partialclonefilter",
+            "remote.https://***@example.invalid/project.git.promisor",
+          );
+          expect(finding.message).toContain(
+            "remote.https://***@example.invalid/project.git.partialclonefilter",
           );
           expect(finding.message).toContain("extensions.partialclone");
+          expect(finding.fixHint).toContain(
+            "git config --get-regexp '^remote\\..*\\.(promisor|partialclonefilter)$'",
+          );
+          expect(finding.fixHint).toContain(
+            "git config --unset-all <the key shown by that command>",
+          );
+          expect(finding.fixHint).toContain(
+            "git config --unset-all remote.origin.partialclonefilter",
+          );
+          expect(finding.fixHint).toContain("git config --unset-all remote.origin.promisor");
+          expect(finding.fixHint).not.toMatch(/git config --unset-all .*https:/);
         }
         expect(await fs.readFile(path.join(clone, ".git", "config"), "utf8")).toBe(configBefore);
         expect(await git(clone, "rev-parse", "--is-shallow-repository")).toBe(String(shallow));
+        if (shape === "both") {
+          // The operator locates and removes URL-keyed entries locally; Doctor
+          // cannot print their raw keys as executable repair commands.
+          const localKeys = await git(
+            clone,
+            "config",
+            "--name-only",
+            "--get-regexp",
+            "^remote\\..*\\.(promisor|partialclonefilter)$",
+          );
+          for (const key of urlKeys) {
+            expect(localKeys.split("\n")).toContain(key);
+            await git(clone, "config", "--unset-all", key);
+          }
+        }
         // Exercise the printed operator commands against the local origin.
         await execFileAsync("sh", ["-ec", finding.fixHint!.split("\n").slice(1, -1).join("\n")]);
         expect(await detect()).toEqual([]);

--- a/src/commands/doctor-project-clone-shape.test.ts
+++ b/src/commands/doctor-project-clone-shape.test.ts
@@ -30,8 +30,22 @@ describe("doctor project clone shape", () => {
         );
         urlRemote.username = "user";
         urlRemote.password = ["synthetic", "secret"].join("-");
-        const urlKeys = ["promisor", "partialclonefilter"].map(
-          (field) => `remote.${urlRemote.href}.${field}`,
+        const userInfo = [urlRemote.username, urlRemote.password].join(":");
+        const addressRemotes = [
+          urlRemote.href,
+          ["https", urlRemote.href].join("::"),
+          [userInfo, "example.invalid:org/project.git?opaque=query-private#fragment-private"].join(
+            "@",
+          ),
+          [
+            "odd_scheme",
+            [userInfo, "example.invalid/project.git?opaque=query-private#fragment-private"].join(
+              "@",
+            ),
+          ].join("://"),
+        ];
+        const urlKeys = addressRemotes.flatMap((remote) =>
+          ["promisor", "partialclonefilter"].map((field) => `remote.${remote}.${field}`),
         );
         const source = state.path("source");
         await git(state.root, "init", "-b", "main", source);
@@ -63,8 +77,9 @@ describe("doctor project clone shape", () => {
         await registerClonedProjectRegistry({ path: clone, name: "Stored project", originUrl });
         await registerProjectRegistry({ path: ignored, name: "User checkout" });
         if (shape === "both") {
-          await git(clone, "config", urlKeys[0]!, "true");
-          await git(clone, "config", urlKeys[1]!, "blob:none");
+          for (const key of urlKeys) {
+            await git(clone, "config", key, key.endsWith(".promisor") ? "true" : "blob:none");
+          }
           await git(clone, "config", "extensions.partialclone", "origin");
         }
         const configBefore = await fs.readFile(path.join(clone, ".git", "config"), "utf8");
@@ -116,6 +131,15 @@ describe("doctor project clone shape", () => {
           expect(finding.message).toContain(
             "remote.https://***@example.invalid/project.git.partialclonefilter",
           );
+          for (const remote of [
+            "https::https://***@example.invalid/project.git",
+            "***@example.invalid:org/project.git",
+            "odd_scheme://***@example.invalid/project.git",
+          ]) {
+            for (const field of ["promisor", "partialclonefilter"]) {
+              expect(finding.message).toContain(`remote.${remote}.${field}`);
+            }
+          }
           expect(finding.message).toContain("extensions.partialclone");
           expect(finding.fixHint).toContain(
             "git config --get-regexp '^remote\\..*\\.(promisor|partialclonefilter)$'",
@@ -127,7 +151,7 @@ describe("doctor project clone shape", () => {
             "git config --unset-all remote.origin.partialclonefilter",
           );
           expect(finding.fixHint).toContain("git config --unset-all remote.origin.promisor");
-          expect(finding.fixHint).not.toMatch(/git config --unset-all .*https:/);
+          expect(finding.fixHint).not.toMatch(/git config --unset-all .*(?::\/\/|::|@)/);
         }
         expect(await fs.readFile(path.join(clone, ".git", "config"), "utf8")).toBe(configBefore);
         expect(await git(clone, "rev-parse", "--is-shallow-repository")).toBe(String(shallow));

--- a/src/commands/doctor-project-clone-shape.ts
+++ b/src/commands/doctor-project-clone-shape.ts
@@ -1,0 +1,113 @@
+import { note } from "../../packages/terminal-core/src/note.js";
+import { gitEnvironment } from "../agents/worktrees/git.js";
+import { quoteCliArg } from "../cli/quote-cli-arg.js";
+import type { OpenClawConfig } from "../config/config.js";
+import type { HealthFinding } from "../flows/health-checks.js";
+import { executeGitCommand } from "../infra/git-exec.js";
+import { listProjectRegistry } from "../projects/project-registry.js";
+
+const CHECK_ID = "core/doctor/project-clone-shape";
+
+async function readCloneGit(root: string, args: string[], optional = false): Promise<string> {
+  const result = await executeGitCommand(root, args, {
+    env: gitEnvironment({ ...process.env, GIT_NO_LAZY_FETCH: "1" }),
+    timeoutMs: 5_000,
+    maxOutputBytes: 64 * 1024,
+  });
+  if (
+    result.termination !== "exit" ||
+    result.stdoutTruncatedBytes ||
+    (result.code !== 0 && !(optional && result.code === 1))
+  ) {
+    throw new Error("clone inspection unavailable");
+  }
+  return result.stdout;
+}
+
+export async function collectProjectCloneShapeHealthFindings(
+  cfg: OpenClawConfig,
+): Promise<readonly HealthFinding[]> {
+  const findings: HealthFinding[] = [];
+  let projects;
+  try {
+    projects = listProjectRegistry(cfg).filter((project) => project.source === "cloned");
+  } catch {
+    return [
+      {
+        checkId: CHECK_ID,
+        severity: "warning",
+        message: "Skipped project clone inspection: the project registry is unreadable.",
+        fixHint: "Restore access to the project registry and rerun openclaw doctor.",
+      },
+    ];
+  }
+  for (const project of projects) {
+    try {
+      const config = await readCloneGit(
+        project.repoRoot,
+        ["config", "--null", "--get-regexp", "^remote\\..*\\.(promisor|partialclonefilter)$"],
+        true,
+      );
+      const shallow = (
+        await readCloneGit(project.repoRoot, ["rev-parse", "--is-shallow-repository"])
+      ).trim();
+      const extension = await readCloneGit(
+        project.repoRoot,
+        ["config", "--get", "extensions.partialclone"],
+        true,
+      );
+      const keys = [
+        ...new Set(
+          config
+            .split("\0")
+            .filter(Boolean)
+            .map((entry) => entry.split("\n", 1)[0]!),
+        ),
+      ].toSorted();
+      if (extension) {
+        keys.push("extensions.partialclone");
+      }
+      if (shallow !== "true" && keys.length === 0) {
+        continue;
+      }
+      const unset = (key: string) => `git config --unset-all ${quoteCliArg(key)}`;
+      findings.push({
+        checkId: CHECK_ID,
+        severity: "warning",
+        path: project.repoRoot,
+        message: `Project clone ${project.displayName} (${project.id}): shallow=${shallow}; partial-clone keys: ${keys.join(", ") || "none"}. Full clones are recommended for managed worktrees.`,
+        fixHint: [
+          "Manual repair only (POSIX shell); stop on any failed step:",
+          `cd ${quoteCliArg(project.repoRoot)}`,
+          ...keys.filter((key) => key.endsWith(".partialclonefilter")).map(unset),
+          `git fetch --refetch${shallow === "true" ? " --unshallow" : ""} origin`,
+          "git rev-list --objects --missing=print --all | grep '^?' | cut -c2- | git fetch origin --no-tags --no-write-fetch-head --recurse-submodules=no --stdin",
+          ...keys
+            .filter((key) => key.endsWith(".promisor") || key === "extensions.partialclone")
+            .map(unset),
+          "git repack -a -d",
+          "Rerun openclaw doctor. If history or objects remain missing, recover them from the original repository.",
+        ].join("\n"),
+      });
+    } catch {
+      findings.push({
+        checkId: CHECK_ID,
+        severity: "warning",
+        path: project.repoRoot,
+        message: `Skipped project clone ${project.displayName} (${project.id}): repository is missing, unreadable, or Git inspection did not complete.`,
+        fixHint:
+          "Check the clone path, permissions, and Git installation, then rerun openclaw doctor.",
+      });
+    }
+  }
+  return findings;
+}
+
+export async function noteProjectCloneShape(cfg: OpenClawConfig): Promise<void> {
+  for (const finding of await collectProjectCloneShapeHealthFindings(cfg)) {
+    note(
+      [finding.message, finding.path, finding.fixHint].filter(Boolean).join("\n"),
+      "Project clones",
+    );
+  }
+}

--- a/src/commands/doctor-project-clone-shape.ts
+++ b/src/commands/doctor-project-clone-shape.ts
@@ -9,18 +9,27 @@ import { listProjectRegistry } from "../projects/project-registry.js";
 const CHECK_ID = "core/doctor/project-clone-shape";
 
 function describeCloneConfigKey(key: string) {
-  const fieldOffset = key.lastIndexOf(".");
-  const url = key.startsWith("remote.")
-    ? URL.parse(key.slice("remote.".length, fieldOffset))
-    : null;
-  if (!url) {
+  if (!key.startsWith("remote.")) {
     return { name: key, urlKey: false };
   }
-  url.username = url.username || url.password ? "***" : "";
-  url.password = "";
-  url.search = "";
-  url.hash = "";
-  return { name: `remote.${url.href}${key.slice(fieldOffset)}`, urlKey: true };
+  const fieldOffset = key.lastIndexOf(".");
+  const remote = key.slice("remote.".length, fieldOffset);
+  if (!/(:\/\/|::|@)/.test(remote)) {
+    return { name: key, urlKey: false };
+  }
+  // Git addresses include remote-helper and scp forms, not just WHATWG URLs.
+  // Preserve transport/scheme labels but conservatively mask through the final @.
+  const transport = /^(?:[^:/?#@]+::)+/.exec(remote)?.[0] ?? "";
+  let address = remote.slice(transport.length);
+  const userInfoEnd = address.lastIndexOf("@");
+  if (userInfoEnd >= 0) {
+    const schemeEnd = address.indexOf("://");
+    const prefixLength =
+      schemeEnd >= 0 && schemeEnd < userInfoEnd ? schemeEnd + 3 : address.startsWith("//") ? 2 : 0;
+    address = `${address.slice(0, prefixLength)}***@${address.slice(userInfoEnd + 1)}`;
+  }
+  address = address.split(/[?#]/, 1)[0] ?? "";
+  return { name: `remote.${transport}${address}${key.slice(fieldOffset)}`, urlKey: true };
 }
 
 async function readCloneGit(root: string, args: string[], optional = false): Promise<string> {

--- a/src/commands/doctor-project-clone-shape.ts
+++ b/src/commands/doctor-project-clone-shape.ts
@@ -8,6 +8,21 @@ import { listProjectRegistry } from "../projects/project-registry.js";
 
 const CHECK_ID = "core/doctor/project-clone-shape";
 
+function describeCloneConfigKey(key: string) {
+  const fieldOffset = key.lastIndexOf(".");
+  const url = key.startsWith("remote.")
+    ? URL.parse(key.slice("remote.".length, fieldOffset))
+    : null;
+  if (!url) {
+    return { name: key, urlKey: false };
+  }
+  url.username = url.username || url.password ? "***" : "";
+  url.password = "";
+  url.search = "";
+  url.hash = "";
+  return { name: `remote.${url.href}${key.slice(fieldOffset)}`, urlKey: true };
+}
+
 async function readCloneGit(root: string, args: string[], optional = false): Promise<string> {
   const result = await executeGitCommand(root, args, {
     env: gitEnvironment({ ...process.env, GIT_NO_LAZY_FETCH: "1" }),
@@ -45,7 +60,13 @@ export async function collectProjectCloneShapeHealthFindings(
     try {
       const config = await readCloneGit(
         project.repoRoot,
-        ["config", "--null", "--get-regexp", "^remote\\..*\\.(promisor|partialclonefilter)$"],
+        [
+          "config",
+          "--null",
+          "--name-only",
+          "--get-regexp",
+          "^remote\\..*\\.(promisor|partialclonefilter)$",
+        ],
         true,
       );
       const shallow = (
@@ -56,35 +77,39 @@ export async function collectProjectCloneShapeHealthFindings(
         ["config", "--get", "extensions.partialclone"],
         true,
       );
-      const keys = [
-        ...new Set(
-          config
-            .split("\0")
-            .filter(Boolean)
-            .map((entry) => entry.split("\n", 1)[0]!),
-        ),
-      ].toSorted();
+      const keys = [...new Set(config.split("\0").filter(Boolean))]
+        .toSorted()
+        .map(describeCloneConfigKey);
       if (extension) {
-        keys.push("extensions.partialclone");
+        keys.push(describeCloneConfigKey("extensions.partialclone"));
       }
       if (shallow !== "true" && keys.length === 0) {
         continue;
       }
-      const unset = (key: string) => `git config --unset-all ${quoteCliArg(key)}`;
+      const unset = (key: ReturnType<typeof describeCloneConfigKey>) =>
+        key.urlKey
+          ? [
+              `# Before continuing, locate ${key.name} locally; the raw output may contain credentials:`,
+              "# git config --get-regexp '^remote\\..*\\.(promisor|partialclonefilter)$'",
+              "# Then run: git config --unset-all <the key shown by that command>",
+            ]
+          : [`git config --unset-all ${quoteCliArg(key.name)}`];
       findings.push({
         checkId: CHECK_ID,
         severity: "warning",
         path: project.repoRoot,
-        message: `Project clone ${project.displayName} (${project.id}): shallow=${shallow}; partial-clone keys: ${keys.join(", ") || "none"}. Full clones are recommended for managed worktrees.`,
+        message: `Project clone ${project.displayName} (${project.id}): shallow=${shallow}; partial-clone keys: ${keys.map((key) => key.name).join(", ") || "none"}. Full clones are recommended for managed worktrees.`,
         fixHint: [
           "Manual repair only (POSIX shell); stop on any failed step:",
           `cd ${quoteCliArg(project.repoRoot)}`,
-          ...keys.filter((key) => key.endsWith(".partialclonefilter")).map(unset),
+          ...keys.filter((key) => key.name.endsWith(".partialclonefilter")).flatMap(unset),
           `git fetch --refetch${shallow === "true" ? " --unshallow" : ""} origin`,
           "git rev-list --objects --missing=print --all | grep '^?' | cut -c2- | git fetch origin --no-tags --no-write-fetch-head --recurse-submodules=no --stdin",
           ...keys
-            .filter((key) => key.endsWith(".promisor") || key === "extensions.partialclone")
-            .map(unset),
+            .filter(
+              (key) => key.name.endsWith(".promisor") || key.name === "extensions.partialclone",
+            )
+            .flatMap(unset),
           "git repack -a -d",
           "Rerun openclaw doctor. If history or objects remain missing, recover them from the original repository.",
         ].join("\n"),

--- a/src/flows/doctor-health-contributions-initial.ts
+++ b/src/flows/doctor-health-contributions-initial.ts
@@ -291,6 +291,23 @@ export function resolveInitialDoctorHealthContributions(params: {
       run: runDiskSpaceHealth,
     }),
     createDoctorHealthContribution({
+      id: "doctor:project-clone-shape",
+      label: "Project clones",
+      healthChecks: {
+        description: "Partial and shallow registry-owned project clones need manual repair.",
+        defaultEnabled: false,
+        async detect(ctx) {
+          const { collectProjectCloneShapeHealthFindings } =
+            await import("../commands/doctor-project-clone-shape.js");
+          return await collectProjectCloneShapeHealthFindings(ctx.cfg);
+        },
+      },
+      async run(ctx) {
+        const { noteProjectCloneShape } = await import("../commands/doctor-project-clone-shape.js");
+        await noteProjectCloneShape(ctx.cfg);
+      },
+    }),
+    createDoctorHealthContribution({
       id: "doctor:db-bloat",
       label: "SQLite database size",
       run: runDatabaseBloatHealth,


### PR DESCRIPTION
Related: #141537.

## What Problem This Solves

Fixes two gaps exposed when a registry-owned project clone on the team Gateway was turned into a shallow, blobless partial clone by agent-run `git fetch --filter=blob:none --depth` commands. Restoring a managed-worktree snapshot whose commit had become shallow failed with git's raw "unknown revision" text, and nothing in OpenClaw reported that the clone had that shape until the next failure.

## Why This Change Was Made

Snapshot restore keeps its normal parent lookup; only when that lookup fails does it check whether the repository is shallow and the snapshot commit exists, and it then reports the repository, the snapshot commit, and the recovery step (`git fetch --unshallow`, or recovering the parent from the original repository) instead of the raw git error. A new doctor check inspects registry-owned cloned projects with three bounded read-only git reads, warns when any promisor or partial-clone filter key (including URL-keyed twins) or shallow state is present, and prints the exact manual repair sequence. Doctor never runs the network-heavy repair itself, adds no CLI or config option, and skips unreadable roots with a warning. Docs for managed worktrees and doctor describe both. Non-goals: an exec-policy warning when an agent runs a filtered fetch inside a registry clone is left as a follow-up; project cloning is unchanged.

## User Impact

Operators learn that a project clone is partial or shallow from `openclaw doctor`, with a copyable repair sequence, before it breaks a session. A snapshot restore that cannot proceed says why and what to do.

## Evidence

Real git fixtures: a bare origin with a two-commit history, `--depth=1` and `--filter=blob:none` clones, a URL-keyed promisor twin, an ignored non-registry workspace, and a missing clone. The restore regression reproduces the raw "unknown revision" failure by making the snapshot itself shallow with `git fetch --depth=1` and fails on the pre-fix code for that reason; the doctor tests verify every finding shape and execute the printed repair commands against a local origin. `node scripts/check-changed.mjs` passed; focused suites pass. Codex-backed autoreview at P1 before landing. Team host: the affected clone was normalized by hand with the same sequence on 2026-09-07.

## Known Gaps

Restore reports rather than deepens: origin cannot deepen a local-only snapshot that a later fetch made shallow. Doctor detection needs a stored registry row; workspace directories that are not registry clones are intentionally not inspected.
