### PR TITLE
fix(beast-v2-defensive-robust): beast-rocky-runtime-deep-dive-own-the-brain-sep8-0025

### DIFF
--- a/src/auto-reply/reply/inbound-dedupe.test.ts
+++ b/src/auto-reply/reply/inbound-dedupe.test.ts
@@ -37,6 +37,32 @@ describe("inbound dedupe", () => {
     );
   });
 
+  it("refuses one physical inbound re-entering under a different session scope", () => {
+    // A mid-turn model-fallback / harness re-entry can re-present the SAME physical
+    // inbound under a different resolved session scope (main vs direct). Route +
+    // provider messageId are identical, so admission must refuse the re-entry
+    // instead of admitting a duplicate run that re-delivers the final. Before the
+    // session-independent key this second claim returned "claimed" (two runs).
+    const agentScope: MsgContext = {
+      ...sharedInboundContext,
+      SessionKey: "agent:main:discord:channel:c1",
+    };
+    // Re-entry that resolves a DIFFERENT session scope for the same physical
+    // inbound: here the session context is absent (empty scope). Previously this
+    // produced a distinct dedupe key and was admitted as a second run.
+    const reentryWithoutSession: MsgContext = {
+      ...sharedInboundContext,
+      SessionKey: undefined,
+    };
+
+    const firstPass = claim(agentScope);
+    // In-flight re-entry under a different scope must NOT get its own claim.
+    expect(claimInboundDedupe(reentryWithoutSession).status).toBe("inflight");
+    firstPass.commit();
+    // After the first pass commits, the re-entry is a hard duplicate.
+    expect(claimInboundDedupe(reentryWithoutSession).status).toBe("duplicate");
+  });
+
   it.each([
     { CommandSource: "native", CommandBody: "/stop", CommandAuthorized: true },
     { CommandSource: "text", CommandBody: "/steer keep working", CommandAuthorized: true },

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -3,9 +3,9 @@ import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
+import { logVerbose } from "../../globals.js";
 import { resolveGlobalDedupeCache } from "../../infra/dedupe.js";
 import { channelRouteDedupeKey } from "../../plugin-sdk/channel-route.js";
-import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { resolveGlobalSingleton } from "../../shared/global-singleton.js";
 import { resolveCommandTurnTargetSessionKey } from "../command-turn-context.js";
 import type { MsgContext } from "../templating.js";
@@ -37,22 +37,20 @@ const resolveInboundPeerId = (ctx: MsgContext) =>
   ctx.OriginatingTo ?? ctx.To ?? ctx.From ?? ctx.SessionKey;
 
 function resolveInboundDedupeSessionScope(ctx: MsgContext): string {
+  // One command event can legitimately target several distinct sessions, so those
+  // addressed operations must stay separately deduped by their explicit target.
   const commandTarget = resolveCommandTurnTargetSessionKey(ctx);
-  // One command event can target several sessions; dedupe each addressed operation.
   if (commandTarget) {
     return commandTarget;
   }
-  const sessionKey = normalizeOptionalString(ctx.SessionKey) || "";
-  if (!sessionKey) {
-    return "";
-  }
-  const parsed = parseAgentSessionKey(sessionKey);
-  if (!parsed) {
-    return sessionKey;
-  }
-  // The same physical inbound message should never run twice for the same
-  // agent, even if a routing bug presents it under both main and direct keys.
-  return `agent:${parsed.agentId}`;
+  // Normal inbound replies: DO NOT scope on the resolved session. A single
+  // physical inbound can be re-processed under a *different* session scope than
+  // its first pass (empty vs agent:<id>, or main vs direct after a mid-turn
+  // model-fallback/harness re-entry), which previously produced two distinct
+  // dedupe keys and let the same message deliver its final twice. Route + provider
+  // messageId already uniquely identify the physical inbound, so an empty scope
+  // makes the admission claim session-independent and refuses every re-entry.
+  return "";
 }
 
 function buildInboundDedupeKey(ctx: MsgContext): string | null {
@@ -87,6 +85,10 @@ export function claimInboundDedupe(
   }
   const duplicate = inboundDedupeCache.peek(key);
   if (inboundDedupeInFlight.has(key)) {
+    // A re-entry (commonly a mid-turn model-fallback/harness re-run) reached
+    // admission for an inbound whose first pass is still in flight. Refusing it
+    // here is what prevents a duplicate final delivery; surface it for triage.
+    logVerbose(`inbound-dedupe: refused re-entry for in-flight inbound key=${key}`);
     return { status: duplicate ? "duplicate" : "inflight" };
   }
   // Spend recovery on the first claim, even if its old receipt expired. A later


### PR DESCRIPTION
## Summary

Pipeline: **beast-rocky-runtime-deep-dive-own-the-brain-sep8-0025** · lens: **defensive-robust** (variant 2/3).

**Bug (one inbound → two identical final sends).** When an agent harness fails mid-turn (commonly *"Codex app-server X or newer is required"*), the model-fallback layer re-runs the turn. If that re-entry re-presents the *same physical inbound* under a **different resolved session scope** than the first pass (empty vs `agent:<id>`, or main vs direct), the process-local inbound **admission** dedupe produced two *distinct* keys — because `buildInboundDedupeKey` mixed the session scope into the key. The re-run was therefore admitted as a second run and re-delivered the already-produced final.

**Fix (minimal, admission-layer).** For normal inbound replies, make the admission dedupe key **session-independent** — key on `[route, provider-messageId]` only. Route (`channel + to + accountId + threadId`) plus the provider `MessageSid` already uniquely identify one physical inbound, so a re-entry under any session scope now collides with the in-flight/committed claim and is refused at admission. Command-turn fan-out keeps its per-target scope (one command event can legitimately address several sessions), so those distinct operations are still admitted independently.

**Defensive-robust extras (justified by the bug):**
- A `logVerbose` line on the refused in-flight re-entry, so the "one inbound, refused re-run" event is visible for future triage instead of being silent.
- Removed the now-dead `parseAgentSessionKey` import.

### Files
- `src/auto-reply/reply/inbound-dedupe.ts` — session-independent normal-reply key + refusal log.
- `src/auto-reply/reply/inbound-dedupe.test.ts` — RED/GREEN regression.

### Evidence (RED → GREEN)
- **RED** (unfixed impl + new test): `refuses one physical inbound re-entering under a different session scope` → `AssertionError: expected 'claimed' to be 'inflight'` (the second run was admitted = the bug).
- **GREEN** (with fix): full suite **8/8 pass**, including the pre-existing command-fan-out test `admits each explicit target of one command once` (proves no over-dedupe of distinct command targets).
- Typecheck: `inbound-dedupe.ts` reports **zero** tsgo errors; the change alters no exported signatures. (On this base, dispatch callers use the `claim().commit()/.release()` object API and import only `claimInboundDedupe`, so removing the internal scope logic is caller-safe.)

### Scope note
The dispatched task template framed this as `aivoice` / base `rocky`, but the cited symbols (`buildInboundDedupeKey`, `dispatch-from-config`, `cli-runner`) do not exist in aivoice — they are OpenClaw's own runtime. Corrected to the OpenClaw source checkout, base `main`, cross-repo fork PR. The task's activation step (patch installed `dist` + **restart the Gateway**) is intentionally **NOT** performed here: workers run *through* the Gateway, so a restart would kill this run and every parallel variant; that is operator/Rocky work gated on source→installed provenance and explicit authorization. This PR is code review only.

## DEPLOY
- summary: Session-independent inbound admission dedupe so a model-fallback re-run cannot re-deliver a final.
- services-affected: OpenClaw Gateway runtime (auto-reply inbound dedupe). aivoice: none.
- migrations: none
- config-changes: none
- secrets-added: none
- feature-flags: none
- depends-on: none
- supersedes: none (parallel variants v1/v3 of the same pipeline are alternatives; QA picks the cleanest)
- frontend-touched: no
- backend-touched: yes (OpenClaw runtime TypeScript only; no aivoice backend)
- data-backfill: none
- verify: In the OpenClaw source checkout — `node scripts/run-vitest.mjs run src/auto-reply/reply/inbound-dedupe.test.ts` → 8/8 pass. To see RED: revert `resolveInboundDedupeSessionScope` to return `agent:${agentId}` and re-run the `re-entering under a different session scope` test → it fails with `expected 'claimed' to be 'inflight'`.
- rollback: `git revert <merge-commit>` (single 2-file commit; no state/migrations).
- target: none (runtime code review only; activation/restart is operator/Rocky work, not part of this PR).
- risk: low — admission-layer key narrowing; command-fan-out path preserved and covered by an existing green test; no signature or config change.
