### PR TITLE
fix(llm): retain prepared runtimes through direct completions

### DIFF
--- a/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/run.overflow-compaction.test.ts
@@ -38,7 +38,8 @@ afterEach(() => {
   }
 });
 const completionMocks = vi.hoisted(() => ({
-  prepareSimpleCompletionModelForAgent: vi.fn(),
+  acquireSimpleCompletionModelForAgent:
+    vi.fn<typeof import("../simple-completion-runtime.js").acquireSimpleCompletionModelForAgent>(),
   completeWithPreparedSimpleCompletionModel: vi.fn(),
   resolveSimpleCompletionSelectionForAgent: vi.fn(),
 }));
@@ -172,16 +173,17 @@ function makeRecoveryInput(
 describe("compactEmbeddedRunForRecovery", () => {
   beforeEach(() => {
     compactRuntimeMocks.compactEmbeddedAgentSessionOnDemand.mockReset();
-    completionMocks.prepareSimpleCompletionModelForAgent.mockReset();
+    completionMocks.acquireSimpleCompletionModelForAgent.mockReset();
     completionMocks.completeWithPreparedSimpleCompletionModel.mockReset();
     completionMocks.resolveSimpleCompletionSelectionForAgent.mockReset();
-    completionMocks.prepareSimpleCompletionModelForAgent.mockResolvedValue({
+    completionMocks.acquireSimpleCompletionModelForAgent.mockResolvedValue({
       selection: { provider: "openai", modelId: "gpt-5.5", agentDir: "/tmp/main" },
       model: {
         provider: "openai",
         id: "gpt-5.5",
         name: "gpt-5.5",
         api: "openai",
+        baseUrl: "https://fixture.invalid/v1",
         input: ["text"],
         reasoning: false,
         contextWindow: 128_000,
@@ -189,6 +191,7 @@ describe("compactEmbeddedRunForRecovery", () => {
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
       },
       auth: { apiKey: "test-api-key", source: "test", mode: "api-key" },
+      release: vi.fn(),
     });
     completionMocks.completeWithPreparedSimpleCompletionModel.mockResolvedValue({
       content: [{ type: "text", text: "done" }],
@@ -350,7 +353,7 @@ describe("compactEmbeddedRunForRecovery", () => {
         reason: expect.stringContaining("not bound to an active session agent"),
       },
     });
-    expect(completionMocks.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(completionMocks.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
   it.each(["returned", "failed", "cancelled", "failed-result"] as const)(

--- a/src/agents/simple-completion-runtime.ts
+++ b/src/agents/simple-completion-runtime.ts
@@ -442,8 +442,8 @@ async function prepareSimpleCompletionModelCore(
     pluginMetadataSnapshot: context.preparedModelRuntime.metadataSnapshot,
   });
   const preparedModel = attachModelProviderRuntimePluginHandle(model, providerRuntimeHandle);
-  // Select transport hooks before releasing this generation. Keep the logical
-  // model API visible to callers that build prompts before dispatch.
+  // Capture this generation's transport hooks while keeping the logical model API
+  // visible to callers that build prompts before dispatch.
   const completionTransport = attachModelProviderRuntimePluginHandle(
     prepareModelForSimpleCompletion({
       apiRegistry: modelRuntime.apiRegistry,
@@ -460,7 +460,7 @@ async function prepareSimpleCompletionModelCore(
   };
 }
 
-async function withPreparedSimpleCompletionRuntime<T>(
+async function acquirePreparedSimpleCompletionRuntime(
   params: {
     cfg: OpenClawConfig | undefined;
     agentId?: string;
@@ -472,8 +472,7 @@ async function withPreparedSimpleCompletionRuntime<T>(
     pluginMetadataSnapshot?: PluginMetadataSnapshot;
   },
   runtimePluginSelections: readonly AgentHarnessPluginSelection[],
-  run: (context: PreparedSimpleCompletionResolverContext) => Promise<T>,
-): Promise<T> {
+): Promise<{ context: PreparedSimpleCompletionResolverContext; release: () => void }> {
   const config = params.cfg ?? {};
   const agentId = params.agentId ?? resolveDefaultAgentId(config);
   const agentDir = params.agentDir?.trim() || resolveAgentDir(config, agentId);
@@ -505,16 +504,32 @@ async function withPreparedSimpleCompletionRuntime<T>(
   const preparedModelRuntime = params.preparedModelRuntime ?? lease!.snapshot;
   const workspaceDir =
     params.workspaceDir ?? preparedModelRuntime.workspaceDir ?? requestedWorkspaceDir;
-  const context = createPreparedSimpleCompletionResolverContext({
-    preparedModelRuntime,
-    workspaceDir,
-    modelResolver: params.modelResolver,
-    agentRuntimeId: params.agentRuntimeId,
-  });
   try {
-    return await withPluginRuntimeGenerationScope(preparedModelRuntime, () => run(context));
-  } finally {
+    const context = createPreparedSimpleCompletionResolverContext({
+      preparedModelRuntime,
+      workspaceDir,
+      modelResolver: params.modelResolver,
+      agentRuntimeId: params.agentRuntimeId,
+    });
+    return { context, release: () => lease?.release() };
+  } catch (error) {
     lease?.release();
+    throw error;
+  }
+}
+
+async function withPreparedSimpleCompletionRuntime<T>(
+  params: Parameters<typeof acquirePreparedSimpleCompletionRuntime>[0],
+  runtimePluginSelections: readonly AgentHarnessPluginSelection[],
+  run: (context: PreparedSimpleCompletionResolverContext) => Promise<T>,
+): Promise<T> {
+  const runtime = await acquirePreparedSimpleCompletionRuntime(params, runtimePluginSelections);
+  try {
+    return await withPluginRuntimeGenerationScope(runtime.context.preparedModelRuntime, () =>
+      run(runtime.context),
+    );
+  } finally {
+    runtime.release();
   }
 }
 
@@ -533,6 +548,23 @@ export async function prepareSimpleCompletionModelForAgent(params: {
   bindAuthOwner?: boolean;
   modelResolver?: typeof resolveModelAsync;
 }): Promise<PreparedSimpleCompletionModelForAgent> {
+  const acquired = await acquireSimpleCompletionModelForAgent(params);
+  if ("error" in acquired) {
+    return acquired;
+  }
+  const { release, ...prepared } = acquired;
+  release();
+  return prepared;
+}
+
+type AcquiredSimpleCompletionModelForAgent =
+  | (Extract<PreparedSimpleCompletionModelForAgent, { model: Model }> & { release: () => void })
+  | Extract<PreparedSimpleCompletionModelForAgent, { error: string }>;
+
+/** Keeps prepared facts in use until the internal completion owner releases its lease. */
+export async function acquireSimpleCompletionModelForAgent(
+  params: Parameters<typeof prepareSimpleCompletionModelForAgent>[0],
+): Promise<AcquiredSimpleCompletionModelForAgent> {
   const selectionParams = {
     cfg: params.cfg,
     agentId: params.agentId,
@@ -605,35 +637,49 @@ export async function prepareSimpleCompletionModelForAgent(params: {
       return { error: `No model configured for agent ${params.agentId}.` };
     }
   }
-  return await withPreparedSimpleCompletionRuntime(
+  const runtime = await acquirePreparedSimpleCompletionRuntime(
     {
       ...params,
       agentDir: selection.agentDir,
       pluginMetadataSnapshot: metadataSnapshot,
     },
     [{ provider: selection.provider, modelId: selection.modelId }],
-    async (context) => {
-      const prepared = await prepareSimpleCompletionModelCore(
-        {
-          cfg: params.cfg,
-          agentId: params.agentId,
-          provider: selection.provider,
-          modelId: selection.modelId,
-          agentDir: selection.agentDir,
-          profileId: selection.profileId,
-          preferredProfile: params.preferredProfile,
-          allowMissingApiKeyModes: params.allowMissingApiKeyModes,
-          ...(params.allowBundledStaticCatalogFallback !== undefined
-            ? { allowBundledStaticCatalogFallback: params.allowBundledStaticCatalogFallback }
-            : {}),
-          skipAgentDiscovery: params.skipAgentDiscovery,
-          bindAuthOwner: params.bindAuthOwner,
-        },
-        context,
-      );
-      return { ...prepared, selection };
-    },
   );
+  let transferred = false;
+  try {
+    const prepared = await withPluginRuntimeGenerationScope(
+      runtime.context.preparedModelRuntime,
+      () =>
+        prepareSimpleCompletionModelCore(
+          {
+            cfg: params.cfg,
+            agentId: params.agentId,
+            provider: selection.provider,
+            modelId: selection.modelId,
+            agentDir: selection.agentDir,
+            profileId: selection.profileId,
+            preferredProfile: params.preferredProfile,
+            allowMissingApiKeyModes: params.allowMissingApiKeyModes,
+            ...(params.allowBundledStaticCatalogFallback !== undefined
+              ? { allowBundledStaticCatalogFallback: params.allowBundledStaticCatalogFallback }
+              : {}),
+            skipAgentDiscovery: params.skipAgentDiscovery,
+            bindAuthOwner: params.bindAuthOwner,
+          },
+          runtime.context,
+        ),
+    );
+    if ("error" in prepared) {
+      return { ...prepared, selection };
+    }
+    const acquired = { ...prepared, selection, release: runtime.release };
+    transferred = true;
+    return acquired;
+  } finally {
+    if (!transferred) {
+      runtime.release();
+    }
+  }
 }
 
 export { completeWithPreparedSimpleCompletionModel } from "./simple-completion-execution.js";

--- a/src/plugins/commands.test.ts
+++ b/src/plugins/commands.test.ts
@@ -23,13 +23,16 @@ import type { PluginRuntime } from "./runtime/types.js";
 import { createBundledPluginRecord } from "./status.test-fixtures.js";
 
 const completionMocks = vi.hoisted(() => ({
-  prepareSimpleCompletionModelForAgent: vi.fn(),
+  acquireSimpleCompletionModelForAgent:
+    vi.fn<
+      typeof import("../agents/simple-completion-runtime.js").acquireSimpleCompletionModelForAgent
+    >(),
   completeWithPreparedSimpleCompletionModel: vi.fn(),
   resolveSimpleCompletionSelectionForAgent: vi.fn(),
 }));
 
 vi.mock("../agents/simple-completion-runtime.js", () => ({
-  prepareSimpleCompletionModelForAgent: completionMocks.prepareSimpleCompletionModelForAgent,
+  acquireSimpleCompletionModelForAgent: completionMocks.acquireSimpleCompletionModelForAgent,
   completeWithPreparedSimpleCompletionModel:
     completionMocks.completeWithPreparedSimpleCompletionModel,
   resolveSimpleCompletionSelectionForAgent:
@@ -132,8 +135,9 @@ function expectUnsupportedBindingApiResult(result: { text?: string }) {
 }
 
 beforeEach(() => {
-  completionMocks.prepareSimpleCompletionModelForAgent.mockReset();
-  completionMocks.prepareSimpleCompletionModelForAgent.mockResolvedValue({
+  completionMocks.acquireSimpleCompletionModelForAgent.mockReset();
+  completionMocks.acquireSimpleCompletionModelForAgent.mockResolvedValue({
+    release: vi.fn(),
     selection: {
       provider: "openai",
       modelId: "gpt-5.5",
@@ -144,6 +148,7 @@ beforeEach(() => {
       id: "gpt-5.5",
       name: "GPT-5.5",
       api: "openai",
+      baseUrl: "https://fixture.invalid/v1",
       input: ["text"],
       reasoning: false,
       contextWindow: 128_000,
@@ -1514,7 +1519,7 @@ describe("registerPluginCommand", () => {
       } as never,
     });
 
-    expect(completionMocks.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+    expect(completionMocks.acquireSimpleCompletionModelForAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: "ops",
       }),
@@ -1555,7 +1560,7 @@ describe("registerPluginCommand", () => {
       config: {} as never,
     });
 
-    expect(completionMocks.prepareSimpleCompletionModelForAgent).toHaveBeenCalledWith(
+    expect(completionMocks.acquireSimpleCompletionModelForAgent).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: "codex",
         preferredProfile: "openai:owner@example.com",

--- a/src/plugins/runtime/runtime-llm-diagnostics.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm-diagnostics.runtime.test.ts
@@ -9,13 +9,16 @@ import { markTrustedOtelDiagnosticListener } from "../../infra/diagnostic-otel-l
 import { createRuntimeLlm } from "./runtime-llm.runtime.js";
 
 const hoisted = vi.hoisted(() => ({
-  prepareSimpleCompletionModelForAgent: vi.fn(),
+  acquireSimpleCompletionModelForAgent:
+    vi.fn<
+      typeof import("../../agents/simple-completion-runtime.js").acquireSimpleCompletionModelForAgent
+    >(),
   completeWithPreparedSimpleCompletionModel: vi.fn(),
   resolveSimpleCompletionSelectionForAgent: vi.fn(),
 }));
 
 vi.mock("../../agents/simple-completion-runtime.js", () => ({
-  prepareSimpleCompletionModelForAgent: hoisted.prepareSimpleCompletionModelForAgent,
+  acquireSimpleCompletionModelForAgent: hoisted.acquireSimpleCompletionModelForAgent,
   completeWithPreparedSimpleCompletionModel: hoisted.completeWithPreparedSimpleCompletionModel,
   resolveSimpleCompletionSelectionForAgent: hoisted.resolveSimpleCompletionSelectionForAgent,
 }));
@@ -29,6 +32,7 @@ const cfg = {
 } satisfies OpenClawConfig;
 
 const preparedModel = {
+  release: vi.fn(),
   selection: {
     provider: "openai",
     modelId: "gpt-5.5",
@@ -39,6 +43,7 @@ const preparedModel = {
     id: "gpt-5.5",
     name: "gpt-5.5",
     api: "openai",
+    baseUrl: "https://fixture.invalid/v1",
     input: ["text"],
     reasoning: false,
     contextWindow: 128_000,
@@ -50,7 +55,10 @@ const preparedModel = {
     source: "test",
     mode: "api-key",
   },
-};
+} satisfies Extract<
+  Awaited<ReturnType<typeof hoisted.acquireSimpleCompletionModelForAgent>>,
+  { model: unknown }
+>;
 
 function captureUsageEvents() {
   const events: Array<{
@@ -77,10 +85,10 @@ function captureUsageEvents() {
 describe("runtime.llm.complete diagnostics", () => {
   beforeEach(() => {
     resetDiagnosticEventsForTest();
-    hoisted.prepareSimpleCompletionModelForAgent.mockReset();
+    hoisted.acquireSimpleCompletionModelForAgent.mockReset();
     hoisted.completeWithPreparedSimpleCompletionModel.mockReset();
     hoisted.resolveSimpleCompletionSelectionForAgent.mockReset();
-    hoisted.prepareSimpleCompletionModelForAgent.mockResolvedValue(preparedModel);
+    hoisted.acquireSimpleCompletionModelForAgent.mockResolvedValue(preparedModel);
     hoisted.resolveSimpleCompletionSelectionForAgent.mockReturnValue(preparedModel.selection);
     hoisted.completeWithPreparedSimpleCompletionModel.mockResolvedValue({
       content: [{ type: "text", text: "done" }],

--- a/src/plugins/runtime/runtime-llm-isolated.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm-isolated.runtime.test.ts
@@ -11,7 +11,10 @@ import { withPluginRuntimePluginIdScope } from "./gateway-request-scope.js";
 import { createRuntimeLlm } from "./runtime-llm.runtime.js";
 
 const hoisted = vi.hoisted(() => ({
-  prepareSimpleCompletionModelForAgent: vi.fn(),
+  acquireSimpleCompletionModelForAgent:
+    vi.fn<
+      typeof import("../../agents/simple-completion-runtime.js").acquireSimpleCompletionModelForAgent
+    >(),
   completeWithPreparedSimpleCompletionModel: vi.fn(),
   resolveSimpleCompletionSelectionForAgent: vi.fn(),
   runIsolatedCompletion: vi.fn(),
@@ -22,7 +25,7 @@ vi.mock("../../agents/isolated-completion.js", () => ({
 }));
 
 vi.mock("../../agents/simple-completion-runtime.js", () => ({
-  prepareSimpleCompletionModelForAgent: hoisted.prepareSimpleCompletionModelForAgent,
+  acquireSimpleCompletionModelForAgent: hoisted.acquireSimpleCompletionModelForAgent,
   completeWithPreparedSimpleCompletionModel: hoisted.completeWithPreparedSimpleCompletionModel,
   resolveSimpleCompletionSelectionForAgent: hoisted.resolveSimpleCompletionSelectionForAgent,
 }));
@@ -69,7 +72,7 @@ function expectSingleCallFirstArg(mock: { mock: { calls: unknown[][] } }, expect
 describe("runtime.llm.complete isolated agent runtime", () => {
   beforeEach(() => {
     resetDiagnosticEventsForTest();
-    hoisted.prepareSimpleCompletionModelForAgent.mockReset();
+    hoisted.acquireSimpleCompletionModelForAgent.mockReset();
     hoisted.completeWithPreparedSimpleCompletionModel.mockReset();
     hoisted.resolveSimpleCompletionSelectionForAgent.mockReset();
     hoisted.runIsolatedCompletion.mockReset();
@@ -239,10 +242,11 @@ describe("runtime.llm.complete isolated agent runtime", () => {
       owner: { kind: "cli", id: "fixture-cli" },
       usage,
     });
-    hoisted.prepareSimpleCompletionModelForAgent.mockResolvedValueOnce({
+    hoisted.acquireSimpleCompletionModelForAgent.mockResolvedValueOnce({
+      release: vi.fn(),
       selection,
       model,
-      auth: {},
+      auth: { mode: "api-key", source: "fixture" },
     });
     hoisted.completeWithPreparedSimpleCompletionModel.mockResolvedValueOnce({
       content: [{ type: "text", text: "direct" }],

--- a/src/plugins/runtime/runtime-llm.prepared-owner.test.ts
+++ b/src/plugins/runtime/runtime-llm.prepared-owner.test.ts
@@ -1,0 +1,373 @@
+import fs from "node:fs";
+import { createServer, type ServerResponse } from "node:http";
+import path from "node:path";
+import { performance } from "node:perf_hooks";
+import { expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { resolveAgentDir } from "../../agents/agent-scope-config.js";
+import {
+  clearRuntimeAuthProfileStoreSnapshots,
+  setRuntimeAuthProfileStoreSnapshot,
+} from "../../agents/auth-profiles/runtime-snapshots.js";
+import * as modelResolution from "../../agents/embedded-agent-runner/model.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  prepareModelRuntimeSnapshot,
+  refreshPreparedModelRuntimeSnapshots,
+} from "../../agents/prepared-model-runtime.js";
+import { resetPreparedModelRuntimeSnapshotsForTest } from "../../agents/prepared-model-runtime.test-support.js";
+import { AuthStorage } from "../../agents/sessions/auth-storage.js";
+import { ModelRegistry } from "../../agents/sessions/model-registry.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { withEnvAsync } from "../../test-utils/env.js";
+import { resetPluginLoaderTestStateForTest } from "../loader.test-fixtures.js";
+import { clearPluginMetadataLifecycleCaches } from "../plugin-metadata-lifecycle.js";
+import {
+  createColdPluginFixture,
+  createColdPluginHermeticEnv,
+} from "../test-helpers/cold-plugin-fixtures.js";
+import { createSyncSuiteTempRootTracker } from "../test-helpers/fs-fixtures.js";
+import { createRuntimeLlm } from "./runtime-llm.runtime.js";
+
+it.each([
+  "overlap",
+  "config",
+  "auth",
+  "lru",
+  "fork",
+  "prepare-error",
+  "prepare-throw",
+  "provider-error",
+  "abort",
+] as const)("keeps direct completion ownership coherent: %s", async (mode) => {
+  const roots = createSyncSuiteTempRootTracker("runtime-llm-prepared-owner");
+  const root = fs.realpathSync(roots.makeTempDir());
+  fs.mkdirSync(path.join(root, "provider"));
+  const fixture = createColdPluginFixture({
+    rootDir: path.join(root, "provider"),
+    pluginId: "completion-lease-fixture",
+    providerId: "completion-lease-provider",
+  });
+  fs.writeFileSync(
+    fixture.runtimeSource,
+    `module.exports = {
+      id: ${JSON.stringify(fixture.pluginId)},
+      register(api) {
+        api.registerProvider({ id: ${JSON.stringify(fixture.providerId)}, label: "Lease fixture", auth: [] });
+      },
+    };`,
+  );
+  const requests: ServerResponse[] = [];
+  const requestFacts: Array<{ url: string; authorization: string | undefined }> = [];
+  const arrivals = [createDeferred(), createDeferred(), createDeferred()];
+  let finishing = false;
+  const finish = (response: ServerResponse, index: number) => {
+    if (response.writableEnded || response.destroyed) {
+      return;
+    }
+    response.writeHead(200, { "content-type": "text/event-stream" });
+    response.end(
+      `data: ${JSON.stringify({
+        id: "completion-lease-response",
+        object: "chat.completion.chunk",
+        model: "lease-model",
+        choices: [
+          {
+            index: 0,
+            delta: {
+              content: `result-${index}|${requestFacts[index]?.url}|${requestFacts[index]?.authorization}`,
+            },
+            finish_reason: "stop",
+          },
+        ],
+      })}\n\ndata: [DONE]\n\n`,
+    );
+  };
+  const server = createServer((request, response) => {
+    request.resume();
+    const index = requests.push(response) - 1;
+    requestFacts.push({ url: request.url ?? "/", authorization: request.headers.authorization });
+    arrivals[index]?.resolve();
+    if (finishing) {
+      finish(response, index);
+    }
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.removeListener("error", reject);
+      resolve();
+    });
+  });
+  const pending: Promise<unknown>[] = [];
+  try {
+    const address = server.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Completion fixture did not expose a TCP port");
+    }
+    const cfg: OpenClawConfig = {
+      agents: {
+        defaults: {
+          workspace: root,
+          model: `${fixture.providerId}/lease-model${mode === "auth" ? `@${fixture.providerId}:control` : ""}`,
+        },
+      },
+      models: {
+        providers: {
+          [fixture.providerId]: {
+            api: "openai-completions",
+            ...(mode === "auth" ? {} : { apiKey: "fixture-auth-A" }),
+            baseUrl: `http://127.0.0.1:${address.port}/A/v1`,
+            models: [
+              "lease-model",
+              ...Array.from({ length: 9 }, (_, index) => `churn-${index}`),
+            ].map((id) => ({
+              id,
+              name: "Lease model",
+              reasoning: false,
+              input: ["text"],
+              cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+              contextWindow: 8192,
+              maxTokens: 1024,
+            })),
+          },
+        },
+      },
+      plugins: {
+        load: { paths: [fixture.rootDir] },
+        slots: { memory: "none" },
+        entries: { [fixture.pluginId]: { enabled: true } },
+      },
+    };
+    const env = {
+      ...createColdPluginHermeticEnv(root, { bundledPluginsDir: roots.makeTempDir() }),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: path.join(root, "state"),
+    };
+    await withEnvAsync(env, async () => {
+      const create = vi.spyOn(ModelRegistry, "create");
+      const fork = vi.spyOn(ModelRegistry.prototype, "fork");
+      const setRuntimeKey = vi.spyOn(AuthStorage.prototype, "setRuntimeApiKey");
+      const resolveModel = modelResolution.resolveModelAsync;
+      const resolver = vi.spyOn(modelResolution, "resolveModelAsync");
+      let currentConfig = cfg;
+      const llm = createRuntimeLlm({ getConfig: () => currentConfig });
+      const input = (modelId = "lease-model") => ({
+        config: cfg,
+        agentId: "main",
+        agentDir: resolveAgentDir(cfg, "main"),
+        workspaceDir: root,
+        loadRuntimePlugins: true,
+        runtimePluginSelections: [{ provider: fixture.providerId, modelId, agentId: "main" }],
+      });
+      const publishAuth = (key: string) =>
+        setRuntimeAuthProfileStoreSnapshot(
+          {
+            version: 1,
+            profiles: {
+              [`${fixture.providerId}:control`]: {
+                type: "api_key",
+                provider: fixture.providerId,
+                key,
+              },
+            },
+          },
+          input().agentDir,
+        );
+      if (mode === "auth") {
+        publishAuth("fixture-auth-A");
+      }
+      if (mode === "lru") {
+        await refreshPreparedModelRuntimeSnapshots(cfg, {
+          gatewayLifecycle: true,
+          catalogMode: "static",
+        });
+      }
+      const retained =
+        mode === "config" || mode === "auth"
+          ? await acquireAgentRunPreparedModelRuntime(input(), { catalogMode: "static" })
+          : undefined;
+      const start = (index: number, signal?: AbortSignal) => {
+        const completion = llm.complete({
+          messages: [{ role: "user", content: `request-${index}` }],
+          ...(signal ? { signal } : {}),
+        });
+        pending.push(completion);
+        return completion;
+      };
+      const waitForRequest = (index: number, completion: Promise<unknown>) =>
+        Promise.race([
+          arrivals[index]!.promise,
+          completion.then(() => {
+            throw new Error(`Completion ${index} settled before its provider request`);
+          }),
+        ]);
+      try {
+        if (mode === "fork" || mode === "prepare-error" || mode === "prepare-throw") {
+          if (mode === "fork") {
+            fork.mockImplementationOnce(() => {
+              throw new Error("fixture store fork failure");
+            });
+          }
+          if (mode === "prepare-throw") {
+            setRuntimeKey.mockImplementationOnce(() => {
+              throw new Error("fixture preparation failure");
+            });
+          }
+          if (mode === "prepare-error") {
+            resolver.mockImplementationOnce(async (...args) => ({
+              ...(await resolveModel(...args)),
+              model: undefined,
+              error: "fixture model preparation unavailable",
+            }));
+          }
+          const unexpectedRequest = createDeferred<never>();
+          const rejectProviderRequest = () =>
+            unexpectedRequest.reject(
+              new Error("Preparation failure unexpectedly reached the provider"),
+            );
+          server.once("request", rejectProviderRequest);
+          const failed = start(0);
+          try {
+            await Promise.race([
+              expect(failed).rejects.toThrow(
+                mode === "fork"
+                  ? "fixture store fork failure"
+                  : mode === "prepare-throw"
+                    ? "fixture preparation failure"
+                    : "Plugin LLM completion failed:",
+              ),
+              unexpectedRequest.promise,
+            ]);
+          } finally {
+            server.removeListener("request", rejectProviderRequest);
+          }
+          expect(requests).toHaveLength(0);
+          const buildsAfterFailure = create.mock.calls.length;
+          expect(buildsAfterFailure).toBeGreaterThan(0);
+          const next = start(0);
+          await waitForRequest(0, next);
+          expect.soft(create.mock.calls.length).toBe(buildsAfterFailure + 1);
+          finish(requests[0]!, 0);
+          await expect(next).resolves.toMatchObject({
+            text: "result-0|/A/v1/chat/completions|Bearer fixture-auth-A",
+          });
+          return;
+        }
+        const abortController = mode === "abort" ? new AbortController() : undefined;
+        const firstStarted = performance.now();
+        const first = start(0, abortController?.signal);
+        await waitForRequest(0, first);
+        const firstPreparationMs = performance.now() - firstStarted;
+        const firstBuilds = create.mock.calls.length;
+        expect(firstBuilds).toBeGreaterThan(0);
+        if (mode === "provider-error" || mode === "abort") {
+          if (abortController) {
+            abortController.abort();
+          } else {
+            requests[0]!.writeHead(400, { "content-type": "application/json" });
+            requests[0]!.end(
+              JSON.stringify({
+                error: { message: "fixture provider rejection", type: "invalid_request_error" },
+              }),
+            );
+          }
+          await expect(first).resolves.toMatchObject({ text: "" });
+          const next = start(1);
+          await waitForRequest(1, next);
+          expect(create.mock.calls.length).toBe(firstBuilds + 1);
+          finish(requests[1]!, 1);
+          await expect(next).resolves.toMatchObject({
+            text: "result-1|/A/v1/chat/completions|Bearer fixture-auth-A",
+          });
+          return;
+        }
+        if (mode === "config") {
+          currentConfig = {
+            ...cfg,
+            models: {
+              providers: {
+                ...cfg.models?.providers,
+                [fixture.providerId]: {
+                  ...cfg.models!.providers![fixture.providerId]!,
+                  baseUrl: `http://127.0.0.1:${address.port}/B/v1`,
+                  apiKey: "fixture-auth-B",
+                },
+              },
+            },
+          };
+        }
+        if (mode === "auth") {
+          publishAuth("fixture-auth-B");
+          await prepareModelRuntimeSnapshot(input());
+        }
+        if (mode === "lru") {
+          for (let index = 0; index < 9; index += 1) {
+            const other = await acquireAgentRunPreparedModelRuntime(input(`churn-${index}`), {
+              catalogMode: "static",
+            });
+            other.release();
+          }
+        }
+        const buildsBeforeSecond = create.mock.calls.length;
+        const forksBeforeSecond = fork.mock.calls.length;
+        const secondStarted = performance.now();
+        const second = start(1);
+        await waitForRequest(1, second);
+        const secondPreparationMs = performance.now() - secondStarted;
+        const secondBuilds = create.mock.calls.length;
+        console.info("direct completion owner reuse", {
+          mode,
+          firstBuilds,
+          buildsBeforeSecond,
+          secondBuilds,
+          firstPreparationMs,
+          secondPreparationMs,
+        });
+        if (mode === "overlap" || mode === "lru") {
+          expect.soft(secondBuilds).toBe(buildsBeforeSecond);
+        }
+        expect(fork.mock.calls.length).toBe(forksBeforeSecond + 1);
+        expect(fork.mock.calls[forksBeforeSecond - 1]![0]).not.toBe(
+          fork.mock.calls[forksBeforeSecond]![0],
+        );
+        finish(requests[0]!, 0);
+        await expect(first).resolves.toMatchObject({
+          text: "result-0|/A/v1/chat/completions|Bearer fixture-auth-A",
+        });
+        finish(requests[1]!, 1);
+        await expect(second).resolves.toMatchObject({
+          text: `result-1|/${mode === "config" ? "B" : "A"}/v1/chat/completions|Bearer fixture-auth-${mode === "config" || mode === "auth" ? "B" : "A"}`,
+        });
+        if (mode === "overlap") {
+          const third = start(2);
+          await waitForRequest(2, third);
+          expect(create.mock.calls.length).toBe(secondBuilds + 1);
+          finish(requests[2]!, 2);
+          await expect(third).resolves.toMatchObject({
+            text: "result-2|/A/v1/chat/completions|Bearer fixture-auth-A",
+          });
+        }
+      } finally {
+        finishing = true;
+        requests.forEach(finish);
+        await Promise.allSettled(pending);
+        retained?.release();
+        create.mockRestore();
+        fork.mockRestore();
+        setRuntimeKey.mockRestore();
+        resolver.mockRestore();
+        await resetPreparedModelRuntimeSnapshotsForTest();
+        clearRuntimeAuthProfileStoreSnapshots();
+        clearPluginMetadataLifecycleCaches();
+        resetPluginLoaderTestStateForTest();
+      }
+    });
+  } finally {
+    server.closeAllConnections();
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => (error ? reject(error) : resolve()));
+    });
+    roots.cleanup();
+  }
+});

--- a/src/plugins/runtime/runtime-llm.runtime.test.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.test.ts
@@ -10,13 +10,16 @@ import { createRuntimeLlm } from "./runtime-llm.runtime.js";
 import type { RuntimeLogger } from "./types-core.js";
 
 const hoisted = vi.hoisted(() => ({
-  prepareSimpleCompletionModelForAgent: vi.fn(),
+  acquireSimpleCompletionModelForAgent:
+    vi.fn<
+      typeof import("../../agents/simple-completion-runtime.js").acquireSimpleCompletionModelForAgent
+    >(),
   completeWithPreparedSimpleCompletionModel: vi.fn(),
   resolveSimpleCompletionSelectionForAgent: vi.fn(),
 }));
 
 vi.mock("../../agents/simple-completion-runtime.js", () => ({
-  prepareSimpleCompletionModelForAgent: hoisted.prepareSimpleCompletionModelForAgent,
+  acquireSimpleCompletionModelForAgent: hoisted.acquireSimpleCompletionModelForAgent,
   completeWithPreparedSimpleCompletionModel: hoisted.completeWithPreparedSimpleCompletionModel,
   resolveSimpleCompletionSelectionForAgent: hoisted.resolveSimpleCompletionSelectionForAgent,
 }));
@@ -29,8 +32,14 @@ const cfg = {
   },
 } satisfies OpenClawConfig;
 
-function createPreparedModel(modelId = "gpt-5.5") {
+function createPreparedModel(
+  modelId = "gpt-5.5",
+): Extract<
+  Awaited<ReturnType<typeof hoisted.acquireSimpleCompletionModelForAgent>>,
+  { model: unknown }
+> {
   return {
+    release: vi.fn(),
     selection: {
       provider: "openai",
       modelId,
@@ -41,6 +50,7 @@ function createPreparedModel(modelId = "gpt-5.5") {
       id: modelId,
       name: modelId,
       api: "openai",
+      baseUrl: "https://fixture.invalid/v1",
       input: ["text"],
       reasoning: false,
       contextWindow: 128_000,
@@ -107,7 +117,7 @@ function expectSingleLogPayload(
 }
 
 function primeCompletionMocks() {
-  hoisted.prepareSimpleCompletionModelForAgent.mockResolvedValue(createPreparedModel());
+  hoisted.acquireSimpleCompletionModelForAgent.mockResolvedValue(createPreparedModel());
   hoisted.resolveSimpleCompletionSelectionForAgent.mockImplementation(
     (params: { modelRef?: string; agentId: string }) => {
       if (!params.modelRef) {
@@ -140,7 +150,7 @@ function primeCompletionMocks() {
 
 describe("runtime.llm.complete", () => {
   beforeEach(() => {
-    hoisted.prepareSimpleCompletionModelForAgent.mockReset();
+    hoisted.acquireSimpleCompletionModelForAgent.mockReset();
     hoisted.completeWithPreparedSimpleCompletionModel.mockReset();
     hoisted.resolveSimpleCompletionSelectionForAgent.mockReset();
     primeCompletionMocks();
@@ -158,7 +168,7 @@ describe("runtime.llm.complete", () => {
       purpose: "memory-maintenance",
     });
 
-    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+    expectSingleCallFirstArg(hoisted.acquireSimpleCompletionModelForAgent, {
       cfg,
       agentId: "ada",
       allowBundledStaticCatalogFallback: true,
@@ -185,7 +195,7 @@ describe("runtime.llm.complete", () => {
       messages: [{ role: "user", content: "summarize" }],
     });
 
-    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+    expectSingleCallFirstArg(hoisted.acquireSimpleCompletionModelForAgent, {
       cfg,
       agentId: "ada",
       preferredProfile: "openai:claude@martian.engineering",
@@ -228,7 +238,7 @@ describe("runtime.llm.complete", () => {
         messages: [{ role: "user", content: "summarize" }],
       }),
     ).rejects.toThrow("not bound to an active session agent");
-    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(hoisted.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
   it("does not trust a fallback-derived agent in the after-turn caller", async () => {
@@ -252,7 +262,7 @@ describe("runtime.llm.complete", () => {
         messages: [{ role: "user", content: "summarize" }],
       }),
     ).rejects.toThrow("not bound to an active session agent");
-    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(hoisted.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
 
     const maintain = vi.fn(async (params: { runtimeContext?: typeof runtimeContext }) => {
       await params.runtimeContext?.llm?.complete({
@@ -276,7 +286,7 @@ describe("runtime.llm.complete", () => {
 
     expect(maintain).toHaveBeenCalledOnce();
     expect(maintenanceResult).toBeUndefined();
-    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(hoisted.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
   it("accepts an explicitly trusted pre-fallback agent", async () => {
@@ -305,7 +315,7 @@ describe("runtime.llm.complete", () => {
         messages: [{ role: "user", content: "summarize" }],
       }),
     ).rejects.toThrow("not bound to an active session agent");
-    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(hoisted.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
   it("denies context-engine model overrides without owning plugin llm policy", async () => {
@@ -322,7 +332,7 @@ describe("runtime.llm.complete", () => {
         messages: [{ role: "user", content: "summarize" }],
       }),
     ).rejects.toThrow("cannot override the target model");
-    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(hoisted.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
   it("allows context-engine model overrides through the owning plugin llm policy", async () => {
@@ -351,7 +361,7 @@ describe("runtime.llm.complete", () => {
       messages: [{ role: "user", content: "summarize" }],
     });
 
-    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+    expectSingleCallFirstArg(hoisted.acquireSimpleCompletionModelForAgent, {
       agentId: "main",
       modelRef: "openai/gpt-5.4-mini",
     });
@@ -389,7 +399,7 @@ describe("runtime.llm.complete", () => {
     ).rejects.toThrow(
       'model override "openai/gpt-5.5" is not allowlisted for plugin "lossless-claw"',
     );
-    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(hoisted.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
   it("matches allowlist entries for provider-qualified model ids without doubling the provider prefix", async () => {
@@ -412,7 +422,7 @@ describe("runtime.llm.complete", () => {
       purpose: "context-engine.compaction",
     });
 
-    hoisted.prepareSimpleCompletionModelForAgent.mockResolvedValue(
+    hoisted.acquireSimpleCompletionModelForAgent.mockResolvedValue(
       createPreparedModel("openrouter/gpt-5.4-mini"),
     );
     hoisted.resolveSimpleCompletionSelectionForAgent.mockImplementation(
@@ -429,7 +439,7 @@ describe("runtime.llm.complete", () => {
       messages: [{ role: "user", content: "summarize" }],
     });
 
-    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+    expectSingleCallFirstArg(hoisted.acquireSimpleCompletionModelForAgent, {
       agentId: "main",
       modelRef: "openrouter/gpt-5.4-mini",
     });
@@ -475,7 +485,7 @@ describe("runtime.llm.complete", () => {
     const message = caught instanceof Error ? caught.message : String(caught);
     expect(message).toContain('"openrouter/gpt-5.5"');
     expect(message).not.toContain("openrouter/openrouter/");
-    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(hoisted.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
   it("keeps context-engine attribution and host-derived policy inside plugin runtime scope", async () => {
@@ -512,7 +522,7 @@ describe("runtime.llm.complete", () => {
       kind: "context-engine",
       id: "context-engine.compaction",
     });
-    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+    expectSingleCallFirstArg(hoisted.acquireSimpleCompletionModelForAgent, {
       modelRef: "openai/gpt-5.4-mini",
     });
   });
@@ -528,7 +538,7 @@ describe("runtime.llm.complete", () => {
       agentId: "main",
       messages: [{ role: "user", content: "summarize" }],
     });
-    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+    expectSingleCallFirstArg(hoisted.acquireSimpleCompletionModelForAgent, {
       agentId: "main",
     });
 
@@ -557,7 +567,7 @@ describe("runtime.llm.complete", () => {
       messages: [{ role: "user", content: "draft" }],
     });
 
-    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+    expectSingleCallFirstArg(hoisted.acquireSimpleCompletionModelForAgent, {
       cfg,
       agentId: "worker",
     });
@@ -576,7 +586,7 @@ describe("runtime.llm.complete", () => {
       messages: [{ role: "user", content: "draft" }],
     } as Parameters<typeof llm.complete>[0] & { authProfileId: string });
 
-    const call = expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+    const call = expectSingleCallFirstArg(hoisted.acquireSimpleCompletionModelForAgent, {
       cfg,
       agentId: "main",
     });
@@ -598,7 +608,7 @@ describe("runtime.llm.complete", () => {
       model: "openai/gpt-5.4",
       messages: [{ role: "user", content: "Ping" }],
     });
-    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+    expectSingleCallFirstArg(hoisted.acquireSimpleCompletionModelForAgent, {
       modelRef: "openai/gpt-5.4",
     });
 
@@ -642,7 +652,7 @@ describe("runtime.llm.complete", () => {
     ).rejects.toThrow(
       'model override "openai/gpt-5.5" is not allowlisted for plugin "restricted-plugin"',
     );
-    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(hoisted.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
   it("uses runtime-scoped config and the host preparation/dispatch path", async () => {
@@ -667,7 +677,7 @@ describe("runtime.llm.complete", () => {
       purpose: "test-purpose",
     });
 
-    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+    expectSingleCallFirstArg(hoisted.acquireSimpleCompletionModelForAgent, {
       cfg,
       agentId: "main",
     });
@@ -774,7 +784,7 @@ describe("runtime.llm.complete", () => {
         }),
       ),
     ).rejects.toThrow("cannot override the target model");
-    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(hoisted.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
   it("denies plugin agent overrides by default and allows them only when configured", async () => {
@@ -818,7 +828,7 @@ describe("runtime.llm.complete", () => {
         messages: [{ role: "user", content: "Ping" }],
       }),
     );
-    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+    expectSingleCallFirstArg(hoisted.acquireSimpleCompletionModelForAgent, {
       agentId: "worker",
     });
   });
@@ -849,7 +859,7 @@ describe("runtime.llm.complete", () => {
         messages: [{ role: "user", content: "Ping" }],
       }),
     );
-    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+    expectSingleCallFirstArg(hoisted.acquireSimpleCompletionModelForAgent, {
       agentId: "main",
       modelRef: "openai/gpt-5.4",
     });
@@ -896,7 +906,7 @@ describe("runtime.llm.complete", () => {
         }),
       ),
     ).resolves.toMatchObject({ text: "done" });
-    expectSingleCallFirstArg(hoisted.prepareSimpleCompletionModelForAgent, {
+    expectSingleCallFirstArg(hoisted.acquireSimpleCompletionModelForAgent, {
       agentId: "main",
       modelRef: "openai/gpt-5.4@openai:work",
     });
@@ -944,7 +954,7 @@ describe("runtime.llm.complete", () => {
         llm.complete({ messages: [{ role: "user", content: "Ping" }] }),
       ),
     ).rejects.toThrow('model "openai/gpt-5.5" is not allowlisted for completions');
-    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(hoisted.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
   it("applies the completion model allowlist to explicit overrides too", async () => {
@@ -974,7 +984,7 @@ describe("runtime.llm.complete", () => {
         }),
       ),
     ).rejects.toThrow('model "openai/gpt-5.6" is not allowlisted for completions');
-    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(hoisted.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
   });
 
   it.each([[[]], [["not-a-canonical-model-ref"]]])(
@@ -997,7 +1007,7 @@ describe("runtime.llm.complete", () => {
           llm.complete({ messages: [{ role: "user", content: "Ping" }] }),
         ),
       ).rejects.toThrow("completion model allowlist has no valid models");
-      expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+      expect(hoisted.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
     },
   );
 
@@ -1037,7 +1047,7 @@ describe("runtime.llm.complete", () => {
         messages: [{ role: "user", content: "Ping" }],
       }),
     ).rejects.toThrow("Plugin LLM completion denied: not trusted");
-    expect(hoisted.prepareSimpleCompletionModelForAgent).not.toHaveBeenCalled();
+    expect(hoisted.acquireSimpleCompletionModelForAgent).not.toHaveBeenCalled();
     expectSingleLogPayload(logger.warn as unknown as MockCalls, "plugin llm completion denied", {
       reason: "not trusted",
     });

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -474,7 +474,7 @@ export function createRuntimeLlm(
 
       const [
         {
-          prepareSimpleCompletionModelForAgent,
+          acquireSimpleCompletionModelForAgent,
           completeWithPreparedSimpleCompletionModel,
           resolveSimpleCompletionSelectionForAgent,
         },
@@ -579,7 +579,7 @@ export function createRuntimeLlm(
         });
       }
 
-      const prepared = await prepareSimpleCompletionModelForAgent({
+      const prepared = await acquireSimpleCompletionModelForAgent({
         cfg,
         agentId,
         modelRef: params.model,
@@ -593,52 +593,56 @@ export function createRuntimeLlm(
         throw new Error(`Plugin LLM completion failed: ${prepared.error}`);
       }
 
-      const context = {
-        systemPrompt: buildSystemPrompt(params),
-        messages: buildMessages({
-          request: params,
-          provider: prepared.model.provider,
-          model: prepared.model.id,
-          api: prepared.model.api,
-        }),
-      };
+      try {
+        const context = {
+          systemPrompt: buildSystemPrompt(params),
+          messages: buildMessages({
+            request: params,
+            provider: prepared.model.provider,
+            model: prepared.model.id,
+            api: prepared.model.api,
+          }),
+        };
 
-      const result = await completeWithPreparedSimpleCompletionModel({
-        model: prepared.model,
-        auth: prepared.auth,
-        cfg,
-        context,
-        options: {
-          maxTokens: asFiniteNumber(params.maxTokens),
-          temperature: asFiniteNumber(params.temperature),
-          ...(params.reasoning !== undefined ? { reasoning: params.reasoning } : {}),
-          signal: params.signal,
-        },
-      });
-
-      const text = result.content
-        .filter((c): c is { type: "text"; text: string } => c.type === "text")
-        .map((c) => c.text)
-        .join("");
-      return finalizePluginLlmCompletion({
-        cfg,
-        hostPluginId: pluginPolicyId,
-        // Provider failures resolve as messages; only visible successful output owns usage.
-        suppressUsage: !text.trim() || !["stop", "length", "toolUse"].includes(result.stopReason),
-        rawUsage: result.usage,
-        logger,
-        result: {
-          text,
-          provider: prepared.selection.provider,
-          model: prepared.selection.modelId,
-          agentId,
-          execution: {
-            mode: "direct-provider",
-            owner: { kind: "provider", id: prepared.selection.provider },
+        const result = await completeWithPreparedSimpleCompletionModel({
+          model: prepared.model,
+          auth: prepared.auth,
+          cfg,
+          context,
+          options: {
+            maxTokens: asFiniteNumber(params.maxTokens),
+            temperature: asFiniteNumber(params.temperature),
+            ...(params.reasoning !== undefined ? { reasoning: params.reasoning } : {}),
+            signal: params.signal,
           },
-          audit,
-        },
-      });
+        });
+
+        const text = result.content
+          .filter((c): c is { type: "text"; text: string } => c.type === "text")
+          .map((c) => c.text)
+          .join("");
+        return finalizePluginLlmCompletion({
+          cfg,
+          hostPluginId: pluginPolicyId,
+          // Provider failures resolve as messages; only visible successful output owns usage.
+          suppressUsage: !text.trim() || !["stop", "length", "toolUse"].includes(result.stopReason),
+          rawUsage: result.usage,
+          logger,
+          result: {
+            text,
+            provider: prepared.selection.provider,
+            model: prepared.selection.modelId,
+            agentId,
+            execution: {
+              mode: "direct-provider",
+              owner: { kind: "provider", id: prepared.selection.provider },
+            },
+            audit,
+          },
+        });
+      } finally {
+        prepared.release();
+      }
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

Overlapping direct plugin LLM completions rebuild prepared model facts because preparation releases its lease before execution finishes. In Gateway mode, that also makes an active completion's owner eligible for LRU eviction. A request-store construction failure could instead leak the counted lease.

## Why This Change Was Made

An internal acquisition function transfers the existing lease to the direct `runtime.llm.complete` operation, which releases it after completion and result processing. Failed construction or preparation releases internally. The public SDK preparation adapter retains its existing return shape and immediate-release behavior.

Related: #140674. This eight-file slice changes two production owners and their test fixtures. It adds no physical database/registration disposal, cache key or size, SDK export, configuration option, or protocol change. Generation scope still covers preparation only; isolated and worker inference retain their existing outer owners.

## User Impact

Overlapping completions reuse their prepared generation while keeping independent mutable request stores. Configuration, credential publication, policy checks, provider errors, cancellation, and returned results retain their behavior.

## Evidence

The original production code failed three native cases: overlap reuse, in-use LRU eviction, and a store-fork failure leaking ownership. Six configuration/authentication/error/abort controls passed. All nine pass with the repair, alongside 129 runtime/command tests, 49 core/SDK compatibility tests, and the complete canonical changed checks. Codex review found no actionable findings. The full build passed on the identical production bytes; subsequent corrections were test-only.

Matched compiled probes called the unchanged `createPluginRuntime().llm.complete` entry against a local synthetic SSE provider. Four separate Node 24 processes ran in baseline/candidate/candidate/baseline order, each with a warm-up and five gated request pairs. Pass-through observers preserved the original public registry methods and receivers.

| Observation | Baseline | Candidate |
| --- | ---: | ---: |
| Generation builds per overlapping pair | 2 | 1 |
| Independent request-store forks per pair | 2 | 2 |
| Median second-request preparation, 10 samples | 5.94 ms | 4.24 ms |

Preparation timing ends when the second provider request arrives while the first response is held. These are local synthetic observations, not an end-to-end inference speed guarantee. Source and compiled artifacts stayed unchanged throughout the comparison.

The first CI run exposed one remaining completion mock using the old internal entrypoint. Its typed fixture now follows the acquisition contract while preserving the refusal-before-acquisition assertion; all 13 overflow cases pass. CI also exposed a pre-existing partial metadata mock leaking across shared-worker tests. The unchanged base reproduced that failure, and the same ordered worker passed after replacing the mock with the existing complete fixture. Main independently received that repair in #141930; this PR was rebased and carries no metadata-test change. Production code and the compiled benchmark are unchanged.
