### PR TITLE
fix(canvas): reject show_widget scripts that do not parse

### DIFF
--- a/docs/tools/show-widget.md
+++ b/docs/tools/show-widget.md
@@ -16,7 +16,7 @@ For a pinned data report, provide a structured `report` with `pin: true`. Report
 
 ## How widgets work
 
-For HTML widgets, OpenClaw core validates `widget_code` and wraps it once in the canonical HTML document. For an inline client, core stores that document as a Canvas document and returns a preview handle. The Control UI reads the document over its authenticated Gateway connection and renders it through the dedicated-origin, double-iframe sandbox used by dashboard widgets and MCP Apps. The widget frame does not need its own login session. iOS, Android, macOS, and Linux Quick Chat use isolated web views. Full chat clients restore the widget after history reload; Quick Chat keeps the widget for its active reply.
+For HTML widgets, OpenClaw core validates `widget_code` by parsing every inline JavaScript `<script>` (classic and module), skipping scripts with `src` or a non-JavaScript `type`, then wraps it once in the canonical HTML document. Core rejects the call with the line and column of the first syntax error, so a widget with a broken script is never hosted. For an inline client, core stores that document as a Canvas document and returns a preview handle. The Control UI reads the document over its authenticated Gateway connection and renders it through the dedicated-origin, double-iframe sandbox used by dashboard widgets and MCP Apps. The widget frame does not need its own login session. iOS, Android, macOS, and Linux Quick Chat use isolated web views. Full chat clients restore the widget after history reload; Quick Chat keeps the widget for its active reply.
 
 Channel plugins can register a contextual presenter behind the same core tool. In a configured Discord session, core hands the composed document to the Discord presenter, which stores it and posts the Activity button in the current channel. The model still makes one `show_widget` call; there is no transport-specific widget tool or content kind.
 
@@ -95,7 +95,7 @@ The core tool requires `title` and one content input: `widget_code` for HTML or 
 </ParamField>
 
 <ParamField path="widget_code" type="string">
-  Required for HTML, SVG, or registered source; omit when providing `report`. For inline-widget clients, input beginning with `<svg` after trimming is rendered in SVG mode; maximum length is 262,144 characters. The Discord presenter accepts HTML source up to 48 KiB. A Discord-only route does not advertise or accept registered non-HTML content kinds.
+  Required for HTML, SVG, or registered source; omit when providing `report`. For HTML, core parses every inline JavaScript `<script>` (classic and module), skipping scripts with `src` or a non-JavaScript `type`. The call is rejected with the line and column of the first syntax error, so a widget with a broken script is never hosted. For inline-widget clients, input beginning with `<svg` after trimming is rendered in SVG mode; maximum length is 262,144 characters. The Discord presenter accepts HTML source up to 48 KiB. A Discord-only route does not advertise or accept registered non-HTML content kinds.
 </ParamField>
 
 <ParamField path="report" type="object">

--- a/src/canvas/widget-script-syntax.test.ts
+++ b/src/canvas/widget-script-syntax.test.ts
@@ -1,0 +1,243 @@
+import { describe, expect, it } from "vitest";
+import { findWidgetScriptSyntaxError } from "./widget-script-syntax.js";
+
+describe("widget script syntax", () => {
+  it("maps a raw newline in a single-quoted string to the original widget line", () => {
+    const widgetCode = "\n<section>\n  <script>const a='x\n'+b;</script>\n</section>";
+    expect(findWidgetScriptSyntaxError(widgetCode)).toEqual({
+      message: "Unterminated string constant",
+      line: 3,
+      column: 18,
+      snippet: "<script>const a='x",
+      scriptIndex: 1,
+    });
+  });
+
+  it.each([
+    "<p>No scripts</p>",
+    '<script>const html = "<!--<script></script>-->";</script>',
+    '<script>a = "<!--"; </script>',
+    '<script>const html = "<!--<script></script>";</script>',
+    '<script>const html = "<!--<script>-->";</script>',
+    '<script>const html = "<!--<ScRiPt/></SCRIPT>-->";</script>',
+    '<script type="&#109;odule">await Promise.resolve();</script>',
+    "<script>#!/usr/bin/env node\nconst a=1;</script>",
+    "<script>const value = 1;",
+    '<script>const value = "</scripture>";</script>',
+    "<script-example>const =</script-example>",
+    "1 < 2 <script>const value = 1;</script>",
+    "<!doctype html><script>const value = 1;</script>",
+    "<script>const a='x\\n'; document.body.textContent = a;</script>",
+    '<script type="module">const value = await Promise.resolve(1); export { value };</script>',
+    '<script type=" Text/JavaScript ">const value = 1;</script>',
+    '<script data-label="src=ignored > type=application/json">const value = 1;</SCRIPT>',
+    '<button onclick="const =">Handlers are not parsed</button>',
+  ])("accepts valid scripts or markup: %s", (widgetCode) => {
+    expect(findWidgetScriptSyntaxError(widgetCode)).toBeUndefined();
+  });
+
+  it.each([
+    "",
+    "type",
+    'type=""',
+    "type='text/javascript'",
+    "type=application/javascript",
+    'TYPE=" TEXT/ECMASCRIPT "',
+    "type=application/ecmascript",
+    "type=application/x-javascript",
+    "type=text/jscript",
+    "type=text/javascript1.5",
+    "type=text/livescript",
+  ])("rejects top-level await in classic scripts: %s", (attributes) => {
+    expect(
+      findWidgetScriptSyntaxError(`<script ${attributes}>await Promise.resolve();</script>`),
+    ).toMatchObject({ scriptIndex: 1 });
+  });
+
+  it("does not allow wrapped-function grammar", () => {
+    expect(findWidgetScriptSyntaxError("<script>return 1;</script>")).toBeDefined();
+  });
+
+  it.each([
+    'type="application/json"',
+    "type='application/ld+json'",
+    "type=importmap",
+    "type=text/template",
+    "type=text/x-handlebars-template",
+    'src="script.js"',
+    "src='script.js'",
+    "SRC=script.js",
+    "src",
+  ])("skips non-JavaScript and external scripts: %s", (attributes) => {
+    expect(findWidgetScriptSyntaxError(`<script ${attributes}>const =</script>`)).toBeUndefined();
+  });
+
+  it.each(["<script>const a = 1;</script>", '<script type="application/json">invalid JS</script>'])(
+    "maps the second script after %s and stops at a case-insensitive raw-text close",
+    (first) => {
+      const widgetCode = `${first}\r\n<p>Text</p>\r\n<script>const a = "</SCRIPT>";</script>`;
+      expect(findWidgetScriptSyntaxError(widgetCode)).toEqual({
+        message: "Unterminated string constant",
+        line: 3,
+        column: 18,
+        snippet: '<script>const a = "</SCRIPT>";</script>',
+        scriptIndex: 2,
+      });
+    },
+  );
+
+  it("reports only the first error across multiple scripts", () => {
+    expect(
+      findWidgetScriptSyntaxError("<script>const =</script><script>let =</script>"),
+    ).toMatchObject({ scriptIndex: 1, line: 1, column: 14 });
+  });
+
+  it.each([
+    "<!-- <script>const =</script> -->",
+    "<!-- <script>const =</script>",
+    '<div title="<script>const =</script>">Text</div>',
+    "<div title='<script>const =</script>'>Text</div>",
+    "<textarea><script>const =</script></textarea>",
+    "<plaintext></plaintext><script>const =</script>",
+    '<div title="<script>const =</script>',
+  ])("ignores script-looking text outside script elements: %s", (widgetCode) => {
+    expect(findWidgetScriptSyntaxError(widgetCode)).toBeUndefined();
+  });
+
+  it.each(["style", "textarea", "title", "xmp", "iframe", "noembed", "noframes", "noscript"])(
+    "skips %s content and resumes at its actual end tag",
+    (tag) => {
+      const prefix = `<${tag}>ignored </${tag}x><script>const =</script></${tag.toUpperCase()} >`;
+      expect(findWidgetScriptSyntaxError(prefix)).toBeUndefined();
+      expect(findWidgetScriptSyntaxError(`${prefix}\n<script>const =</script>`)).toMatchObject({
+        scriptIndex: 1,
+        line: 2,
+        column: 14,
+      });
+      expect(findWidgetScriptSyntaxError(`<${tag}><script>const =</script>`)).toBeUndefined();
+    },
+  );
+
+  it("preserves offsets and script indexes after skipping inert HTML contexts", () => {
+    const widgetCode = [
+      "<!-- <script>const =</script> -->",
+      "<textarea><script>const =</script></textarea>",
+      '<div title="İ <script>const =</script>"></div>',
+      "  <script>const =</script>",
+    ].join("\n");
+    expect(findWidgetScriptSyntaxError(widgetCode)).toEqual({
+      message: "Unexpected token",
+      scriptIndex: 1,
+      line: 4,
+      column: 16,
+      snippet: "<script>const =</script>",
+    });
+  });
+
+  it.each(["</script/>", '</script foo="bar">', "</SCRIPT >", ""])(
+    "parses the script body through its terminator or EOF: %s",
+    (endTag) => {
+      expect(findWidgetScriptSyntaxError(`<script>const =${endTag}`)).toMatchObject({
+        scriptIndex: 1,
+        line: 1,
+        column: 14,
+      });
+      expect(findWidgetScriptSyntaxError(`<script>const value = 1;${endTag}`)).toBeUndefined();
+      if (endTag) {
+        expect(
+          findWidgetScriptSyntaxError(
+            `<script>const value = 1;${endTag}\n<script>const =</script>`,
+          ),
+        ).toMatchObject({ scriptIndex: 2, line: 2, column: 14 });
+      }
+    },
+  );
+
+  it.each([
+    '<script>const html = "<script></script>";</script>',
+    '<script>const html = "<!--<scripture></script>";</script>',
+  ])("ends script data unless the exact script token double-escapes it: %s", (widgetCode) => {
+    expect(findWidgetScriptSyntaxError(widgetCode)?.message).toBe("Unterminated string constant");
+  });
+
+  it.each([
+    "<svg><script><![CDATA[const value = 1;]]></script></svg>",
+    "<svg><svg></svg><script><![CDATA[const value = 1;]]></script></svg>",
+    "<svg><svg/><script><![CDATA[const value = 1;]]></script></svg>",
+    '<svg><script><![CDATA[const text = "</script>";]]></script></svg>',
+    "<svg><title/><style/><script><![CDATA[const value = 1;]]></script></svg>",
+    "<div><svg><text><![CDATA[Example: > <script>const =</script>]]></text></svg></div>",
+    '<div><svg><foreignObject><script>const text = "<![CDATA[";</script></foreignObject></svg></div>',
+    "<svg><foreignObject/><script><![CDATA[const value = 1;]]></script></svg>",
+    '<SVG xmlns="http://www.w3.org/2000/svg"><script> \n<![CDATA[const value = 1;]]> \n</script></SVG>',
+  ])("parses CDATA-wrapped scripts in SVG: %s", (widgetCode) => {
+    expect(findWidgetScriptSyntaxError(widgetCode)).toBeUndefined();
+  });
+
+  it.each([
+    {
+      widgetCode: "<svg><script><![CDATA[const =]]></script></svg>",
+      line: 1,
+      column: 28,
+      snippet: "<svg><script><![CDATA[const =]]></script></svg>",
+    },
+    {
+      widgetCode: "<svg>\n  <script>  <![CDATA[const =]]> </script>\n</svg>",
+      line: 2,
+      column: 27,
+      snippet: "<script>  <![CDATA[const =]]> </script>",
+    },
+    {
+      widgetCode: "<svg>\r\n<script>\n<![CDATA[\nconst =\n]]>\n</script></svg>",
+      line: 4,
+      column: 6,
+      snippet: "const =",
+    },
+  ])(
+    "maps CDATA errors to the original widget: $widgetCode",
+    ({ widgetCode, line, column, snippet }) => {
+      expect(findWidgetScriptSyntaxError(widgetCode)).toEqual({
+        message: "Unexpected token",
+        scriptIndex: 1,
+        line,
+        column,
+        snippet,
+      });
+    },
+  );
+
+  it.each([
+    "<svg><title/></svg><script>const =</script>",
+    "<svg><style/><script>const =</script></svg>",
+    '<svg><script><![CDATA[const text = "</script>";]]></script></svg><script>const =</script>',
+    "<svg><text><![CDATA[text]]></text></svg><script>const =</script>",
+    "<svg><foreignObject><script>const =</script></foreignObject></svg>",
+    "<svg><foreignObject><script><![CDATA[const value = 1;]]></script></foreignObject></svg>",
+  ])("still reaches scripts after self-closing or CDATA foreign content: %s", (widgetCode) => {
+    expect(findWidgetScriptSyntaxError(widgetCode)).toMatchObject({ line: 1 });
+  });
+
+  it.each(["", "<svg/>", "<svg></svg>", "<svg><svg/></svg>"])(
+    "leaves CDATA markers outside SVG untouched after %s",
+    (prefix) => {
+      expect(
+        findWidgetScriptSyntaxError(`${prefix}<script><![CDATA[const value = 1;]]></script>`),
+      ).toMatchObject({ message: "Unexpected token", scriptIndex: 1 });
+    },
+  );
+
+  it.each(["text&#47;javascript", "text&sol;javascript", "&#109;odule"])(
+    "validates scripts whose type contains character references: %s",
+    (type) => {
+      expect(findWidgetScriptSyntaxError(`<script type="${type}">const =</script>`)).toMatchObject({
+        message: "Unexpected token",
+        scriptIndex: 1,
+      });
+    },
+  );
+
+  it("bounds the offending line snippet", () => {
+    const widgetCode = `<script>const = ${"x".repeat(1_000)}</script>`;
+    expect(findWidgetScriptSyntaxError(widgetCode)?.snippet).toBe(widgetCode.slice(0, 160));
+  });
+});

--- a/src/canvas/widget-script-syntax.ts
+++ b/src/canvas/widget-script-syntax.ts
@@ -1,0 +1,220 @@
+import { getLineInfo, parse } from "acorn";
+import { decodeHTMLAttribute } from "entities";
+
+type WidgetScriptSyntaxError = {
+  message: string;
+  /** Location in the supplied widget_code: 1-based line, 0-based UTF-16 column. */
+  line: number;
+  column: number;
+  snippet: string;
+  /** 1-based index among all scanned script elements, including skipped scripts. */
+  scriptIndex: number;
+};
+
+/** JavaScript MIME type essences per https://mimesniff.spec.whatwg.org/#javascript-mime-type. */
+const JAVASCRIPT_MIME_ESSENCES = new Set([
+  "application/ecmascript",
+  "application/javascript",
+  "application/x-ecmascript",
+  "application/x-javascript",
+  "text/ecmascript",
+  "text/javascript",
+  "text/javascript1.0",
+  "text/javascript1.1",
+  "text/javascript1.2",
+  "text/javascript1.3",
+  "text/javascript1.4",
+  "text/javascript1.5",
+  "text/jscript",
+  "text/livescript",
+  "text/x-ecmascript",
+  "text/x-javascript",
+]);
+
+function scriptSourceType(attributes: string): "script" | "module" | undefined {
+  let type: string | undefined;
+  const attributePattern = /([^\s=/>]+)(?:\s*=\s*(?:"([^"]*)"|'([^']*)'|([^\s>]+)))?/g;
+  for (const attribute of attributes.matchAll(attributePattern)) {
+    const name = (attribute[1] ?? "").toLowerCase();
+    if (name === "src") {
+      return undefined;
+    }
+    if (name === "type") {
+      type ??= decodeHTMLAttribute(attribute[2] ?? attribute[3] ?? attribute[4] ?? "")
+        .trim()
+        .toLowerCase();
+    }
+  }
+  if (type === "module") {
+    return "module";
+  }
+  return !type || JAVASCRIPT_MIME_ESSENCES.has(type) ? "script" : undefined;
+}
+
+/** Finds a tag's closing bracket without interpreting quoted attribute values as markup. */
+function findTagEnd(html: string, offset: number): number {
+  let quote = "";
+  for (let index = offset; index < html.length; index++) {
+    const char = html[index];
+    if (quote) {
+      if (char === quote) {
+        quote = "";
+      }
+    } else if (char === '"' || char === "'") {
+      quote = char;
+    } else if (char === ">") {
+      return index;
+    }
+  }
+  return html.length;
+}
+
+/**
+ * Script-looking text in double-escaped data cannot close the script element, and inside
+ * foreign (SVG) content a CDATA section keeps everything up to `]]>` as script text.
+ */
+function findRawTextEnd(html: string, start: number, name: string, foreign: boolean): number {
+  const tokens =
+    name === "script"
+      ? foreign
+        ? /<!\[CDATA\[|\]\]>|<!--|-->|<\/?script(?=[\t\n\f\r />])/gi
+        : /<!--|-->|<\/?script(?=[\t\n\f\r />])/gi
+      : new RegExp(`</${name}(?=[\\t\\n\\f\\r />])`, "gi");
+  tokens.lastIndex = start;
+  let state: "data" | "escaped" | "double-escaped" | "cdata" = "data";
+  for (const match of html.matchAll(tokens)) {
+    const token = match[0].toLowerCase();
+    if (state === "cdata") {
+      if (token === "]]>") {
+        state = "data";
+      }
+    } else if (token === "<![cdata[") {
+      state = "cdata";
+    } else if (token === "<!--" && state === "data") {
+      state = "escaped";
+    } else if (token === "-->") {
+      state = "data";
+    } else if (token.startsWith("</")) {
+      if (state !== "double-escaped") {
+        return match.index;
+      }
+      state = "escaped";
+    } else if (token === "<script" && state === "escaped") {
+      state = "double-escaped";
+    }
+  }
+  return html.length;
+}
+
+/**
+ * Tracks HTML contexts over the original input so script offsets never need normalization.
+ *
+ * Scope: SVG support covers CDATA-wrapped scripts, opaque CDATA sections, self-closing foreign
+ * elements, and foreignObject switching back to HTML rules. Character references inside foreign
+ * script text, CDATA sections interleaved with script text, and SVG nested inside foreignObject
+ * are intentionally not modeled; such input yields an explicit tool error, never a hosted widget
+ * with a script that cannot run.
+ */
+export function findWidgetScriptSyntaxError(
+  widgetCode: string,
+): WidgetScriptSyntaxError | undefined {
+  const tagPattern = /<\/?([a-z][^\t\n\f\r />]*)/iy;
+  let position = 0;
+  let scriptIndex = 0;
+  let svgDepth = 0;
+  let foreignObjectDepth = 0;
+  while (position < widgetCode.length) {
+    const start = widgetCode.indexOf("<", position);
+    if (start < 0) {
+      break;
+    }
+    position = start + 1;
+    if (widgetCode.startsWith("<!--", start)) {
+      const end = widgetCode.indexOf("-->", start + 4);
+      position = end < 0 ? widgetCode.length : end + 3;
+      continue;
+    }
+    // foreignObject is an HTML integration point, so its children follow HTML rules again.
+    const foreign = svgDepth > 0 && foreignObjectDepth === 0;
+    if (foreign && widgetCode.startsWith("<![CDATA[", start)) {
+      const end = widgetCode.indexOf("]]>", start + 9);
+      position = end < 0 ? widgetCode.length : end + 3;
+      continue;
+    }
+    tagPattern.lastIndex = start;
+    const tag = tagPattern.exec(widgetCode);
+    if (!tag) {
+      if (widgetCode[position] === "!" || widgetCode[position] === "/") {
+        position = findTagEnd(widgetCode, position + 1) + 1;
+      }
+      continue;
+    }
+    const attributesStart = tagPattern.lastIndex;
+    const tagEnd = findTagEnd(widgetCode, attributesStart);
+    position = tagEnd + 1;
+    if (tagEnd === widgetCode.length) {
+      continue;
+    }
+    const name = (tag[1] ?? "").toLowerCase();
+    const closing = widgetCode[start + 1] === "/";
+    const selfClosing = widgetCode[tagEnd - 1] === "/";
+    if (name === "svg") {
+      svgDepth = closing ? Math.max(0, svgDepth - 1) : svgDepth + (selfClosing ? 0 : 1);
+    } else if (name === "foreignobject" && svgDepth > 0) {
+      foreignObjectDepth = closing
+        ? Math.max(0, foreignObjectDepth - 1)
+        : foreignObjectDepth + (selfClosing ? 0 : 1);
+    }
+    if (closing) {
+      continue;
+    }
+    if (name === "plaintext") {
+      break;
+    }
+    if (!/^(?:script|style|textarea|title|xmp|iframe|noembed|noframes|noscript)$/.test(name)) {
+      continue;
+    }
+    // Foreign content honors self-closing start tags; HTML content ignores the slash.
+    if (foreign && selfClosing) {
+      continue;
+    }
+    let bodyStart = position;
+    const bodyEnd = findRawTextEnd(widgetCode, bodyStart, name, foreign);
+    const closingBracket = bodyEnd < widgetCode.length ? widgetCode.indexOf(">", bodyEnd) : -1;
+    position = closingBracket < 0 ? widgetCode.length : closingBracket + 1;
+    if (name !== "script") {
+      continue;
+    }
+    scriptIndex++;
+    const sourceType = scriptSourceType(widgetCode.slice(attributesStart, tagEnd));
+    if (!sourceType) {
+      continue;
+    }
+    let body = widgetCode.slice(bodyStart, bodyEnd);
+    const trimmed = body.trim();
+    if (foreign && trimmed.startsWith("<![CDATA[") && trimmed.endsWith("]]>")) {
+      bodyStart += body.length - body.trimStart().length + "<![CDATA[".length;
+      body = trimmed.slice("<![CDATA[".length, -"]]>".length);
+    }
+    try {
+      parse(body, { ecmaVersion: "latest", sourceType });
+    } catch (error) {
+      if (!(error instanceof SyntaxError) || !("pos" in error) || typeof error.pos !== "number") {
+        throw error;
+      }
+      const offset = bodyStart + error.pos;
+      const { line, column } = getLineInfo(widgetCode, offset);
+      const snippet = (widgetCode.slice(offset - column).split(/[\r\n\u2028\u2029]/u, 1)[0] ?? "")
+        .trim()
+        .slice(0, 160);
+      return {
+        message: error.message.replace(/ \(\d+:\d+\)$/u, "").slice(0, 200),
+        line,
+        column,
+        snippet,
+        scriptIndex,
+      };
+    }
+  }
+  return undefined;
+}

--- a/src/canvas/widget-tool.prompt.test.ts
+++ b/src/canvas/widget-tool.prompt.test.ts
@@ -93,7 +93,7 @@ describe("show_widget prompt", () => {
   });
   it("keeps proactive single visualizations inline unless dashboard use meets its threshold", () => {
     const tool = createShowWidgetTool();
-    const directoryDescription = tool.description.slice(0, 177);
+    const directoryDescription = tool.description.slice(0, 184);
     const properties = (
       tool.parameters as {
         properties?: {
@@ -111,7 +111,7 @@ describe("show_widget prompt", () => {
     );
     expect(directoryDescription).toContain("explicit dashboard request");
     expect(directoryDescription).toContain("multiple non-code visualizations");
-    expect(directoryDescription).toContain("Update HTML by name");
+    expect(directoryDescription).toContain("Update pinned HTML by name");
     expect(pinDescription).toContain("explicit dashboard request");
     expect(pinDescription).toContain("multiple non-code visualizations");
     expect(properties?.name?.description).toMatch(/same name.*pin=true.*widget_code/i);

--- a/src/canvas/widget-tool.script-syntax.test.ts
+++ b/src/canvas/widget-tool.script-syntax.test.ts
@@ -1,0 +1,92 @@
+import { access } from "node:fs/promises";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { WidgetHtmlInputError } from "../plugin-sdk/widget-html.js";
+import type { WidgetPresenter } from "../plugins/plugin-registration.types.js";
+import { resetPluginRuntimeStateForTest } from "../plugins/runtime.js";
+import { closeOpenClawAgentDatabasesForTest } from "../state/openclaw-agent-db.js";
+import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { resolveCanvasDocumentsDir } from "./documents.js";
+import { registerTestWidgetContentKind } from "./widget-tool.content-kinds.test-support.js";
+import { createShowWidgetTool } from "./widget-tool.js";
+import { createBoardPutCaller } from "./widget-tool.test-support.js";
+
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
+
+beforeEach(() => resetPluginRuntimeStateForTest());
+afterEach(() => {
+  closeOpenClawAgentDatabasesForTest();
+  closeOpenClawStateDatabaseForTest();
+  resetPluginRuntimeStateForTest();
+});
+
+describe("show_widget script syntax gate", () => {
+  it.each(["inline", "pinned", "current_channel", "node_panel"] as const)(
+    "rejects broken scripts before any side effect on %s",
+    async (route) => {
+      const stateDir = tempDirs.make("openclaw-widget-syntax-");
+      const { mock: gateway, callGateway } = createBoardPutCaller();
+      const present = vi.fn<WidgetPresenter["present"]>();
+      const availability = vi.fn<WidgetPresenter["availability"]>();
+      const presenters: WidgetPresenter[] =
+        route === "current_channel"
+          ? [
+              {
+                target: "current_channel",
+                description: "Test channel",
+                capabilities: { sourceKinds: ["html"] },
+                match: () => true,
+                availability,
+                present,
+              },
+            ]
+          : [{ target: "node_panel", description: "Test panel", availability, present }];
+      const tool = createShowWidgetTool({
+        stateDir,
+        sessionId: "syntax",
+        agentSessionKey: "agent:main:syntax",
+        callGateway,
+        presenters,
+      });
+      const result = tool.execute("broken", {
+        title: "Broken widget",
+        widget_code: "<p>Widget</p>\n<script>const a='x\n'+b;</script>",
+        pin: route === "pinned",
+        ...(route === "node_panel" ? { presentation: { target: "node_panel" } } : {}),
+      });
+      await expect(result).rejects.toThrow(WidgetHtmlInputError);
+      await expect(result).rejects.toThrow(
+        "widget_code has a JavaScript syntax error in inline script 1 at line 2, column 16: Unterminated string constant. Offending line: <script>const a='x. Fix the script and call show_widget again.",
+      );
+      expect(gateway).not.toHaveBeenCalled();
+      expect(present).not.toHaveBeenCalled();
+      expect(availability).not.toHaveBeenCalled();
+      await expect(access(resolveCanvasDocumentsDir(stateDir))).rejects.toThrow();
+    },
+  );
+
+  it("leaves registered source validation to the content kind", async () => {
+    registerTestWidgetContentKind("diagram", () => "<p>Rendered diagram</p>");
+    const stateDir = tempDirs.make("openclaw-widget-syntax-");
+    const tool = createShowWidgetTool({ stateDir, sessionId: "registered-syntax" });
+    const result = await tool.execute("registered", {
+      title: "Diagram",
+      kind: "diagram",
+      widget_code: "diagram:<script>const =</script>",
+    });
+    const text = result.content.find((item) => item.type === "text")?.text;
+    expect(JSON.parse(text ?? "null")).toMatchObject({ kind: "canvas" });
+  });
+
+  it("still hosts a valid script as a canvas widget", async () => {
+    const stateDir = tempDirs.make("openclaw-widget-syntax-");
+    const tool = createShowWidgetTool({ stateDir, sessionId: "valid-syntax" });
+    const result = await tool.execute("valid", {
+      title: "Working widget",
+      widget_code: "<script>document.body.textContent = 'Working';</script>",
+    });
+    const text = result.content.find((item) => item.type === "text")?.text;
+    expect(JSON.parse(text ?? "null")).toMatchObject({ kind: "canvas" });
+    await expect(access(resolveCanvasDocumentsDir(stateDir))).resolves.toBeUndefined();
+  });
+});

--- a/src/canvas/widget-tool.ts
+++ b/src/canvas/widget-tool.ts
@@ -33,6 +33,7 @@ import type {
 import { getActivePluginRegistry } from "../plugins/runtime.js";
 import { getPluginRuntimeGatewayRequestScope } from "../plugins/runtime/gateway-request-scope.js";
 import { createCanvasDocument } from "./documents.js";
+import { findWidgetScriptSyntaxError } from "./widget-script-syntax.js";
 import { buildWidgetDocument } from "./wrap.js";
 
 const SHOW_WIDGET_REQUIRED_CLIENT_CAPS = ["inline-widgets"];
@@ -321,7 +322,7 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
   return {
     label: "Show Widget",
     name: "show_widget",
-    description: `Visual helps? Make widget. Do not wait for ask. ${usageGuidance} Update HTML by name. Use for comparisons, trends, timelines, flows, hierarchies, dashboards, status, progress, layouts, and choices. Text clearer? Skip. ${destinationGuidance}; kind defaults to html${advertisedRegisteredKinds.length ? ` and registered kinds are ${advertisedRegisteredKinds.join(", ")}` : ""}. Reuse the same explicit name with pin=true and new report data or widget_code to update pinned content. Use name for a stable widget id, tab for a tab slug, size sm|md|lg|xl|full, presentation.frame card|full-bleed|frameless, and after for a sibling widget anchor. Pinned widgets may declare capabilities.netOrigins and capabilities.tools for operator approval. HTML widgets are self-contained HTML or SVG. Dashboard host APIs: openclaw.prompt.send(text), openclaw.state.emit(payload), openclaw.data.read(bindingId, params?), openclaw.action.run(actionId, params?), and openclaw.cron.trigger(jobId). openclaw.host.controlUiBaseUrl is the Control UI origin plus base path after dashboard host initialization, otherwise null; read it at click time. Open links in a new tab with target="_blank" and rel="noopener noreferrer". \`title\` is host metadata. Start directly with content; do not repeat the title or recreate dashboard chrome. ${reportGuidance} HTML is pre-themed with --surface --card --elevated --text --text-strong --muted --border --border-strong --accent --accent-fill --accent-fg --ok --warn --danger --info --radius --font-body --font-mono.${presenterPrompt}`,
+    description: `Visual helps? Make widget. Do not wait for ask. ${usageGuidance} Update pinned HTML by name. Use for comparisons, trends, timelines, flows, hierarchies, dashboards, status, progress, layouts, and choices. Text clearer? Skip. ${destinationGuidance}; kind defaults to html${advertisedRegisteredKinds.length ? ` and registered kinds are ${advertisedRegisteredKinds.join(", ")}` : ""}. Reuse the same explicit name with pin=true and new report data or widget_code to update pinned content. Use name for a stable widget id, tab for a tab slug, size sm|md|lg|xl|full, presentation.frame card|full-bleed|frameless, and after for a sibling widget anchor. Pinned widgets may declare capabilities.netOrigins and capabilities.tools for operator approval. HTML widgets are self-contained HTML or SVG. Inline scripts must parse; syntax errors are rejected with line and column. Dashboard host APIs: openclaw.prompt.send(text), openclaw.state.emit(payload), openclaw.data.read(bindingId, params?), openclaw.action.run(actionId, params?), and openclaw.cron.trigger(jobId). openclaw.host.controlUiBaseUrl is the Control UI origin plus base path after dashboard host initialization, otherwise null; read it at click time. Open links in a new tab with target="_blank" and rel="noopener noreferrer". \`title\` is host metadata. Start directly with content; do not repeat the title or recreate dashboard chrome. ${reportGuidance} HTML is pre-themed with --surface --card --elevated --text --text-strong --muted --border --border-strong --accent --accent-fill --accent-fg --ok --warn --danger --info --radius --font-body --font-mono.${presenterPrompt}`,
     parameters: createShowWidgetToolSchema(
       kinds,
       explicitPresenters,
@@ -351,6 +352,15 @@ export function createShowWidgetTool(options: ShowWidgetToolOptions = {}): AnyAg
           inputName: "widget_code",
           unit: "characters",
         });
+        if (kind === "html") {
+          // Untrimmed so reported line/column match the widget_code the model sent.
+          const scriptError = findWidgetScriptSyntaxError(rawWidgetCode);
+          if (scriptError) {
+            throw new WidgetHtmlInputError(
+              `widget_code has a JavaScript syntax error in inline script ${scriptError.scriptIndex} at line ${scriptError.line}, column ${scriptError.column}: ${scriptError.message}. Offending line: ${scriptError.snippet}. Fix the script and call show_widget again.`,
+            );
+          }
+        }
       }
       const shouldPin = params.pin === true;
       if (pinnedOnly && !shouldPin) {


### PR DESCRIPTION
## Problem

`show_widget` hosted whatever `widget_code` the model sent. When an inline `<script>` had a syntax error, the widget was still hosted and rendered as a dead, non-interactive card, and the model got no signal that anything was wrong.

Real case on a team Gateway: the agent built the widget HTML inside a JavaScript template literal, `\n` inside a single-quoted string became a raw line break, the browser reported `Unexpected identifier 'os'`, and the first card was inert. The agent only noticed after a manual `vm.Script` check, fixed the escaping, and called `show_widget` again. The transcript ended up with two widgets: a broken one and a working one. Inline widgets have no replace semantics, so the first card could not be retracted.

## Solution

Core now parses every inline JavaScript `<script>` in HTML `widget_code` with acorn before any side effect and rejects the call with the script index, line, column, and offending line when the first one fails to parse. A widget with a broken script is never hosted, pinned, or presented on any surface.

- `src/canvas/widget-script-syntax.ts`: a small position-tracking HTML tokenizer that skips comments, honors quoted attributes, treats `style`/`textarea`/`title`/`xmp`/`iframe`/`noembed`/`noframes`/`noscript` as raw text, ends script bodies per the script-data escaped and double-escaped states (so `"<!--<script></script>-->"` inside a string does not end the element), and handles SVG foreign content (CDATA-wrapped scripts, opaque CDATA sections, self-closing elements, `foreignObject` back to HTML rules). Classic vs `type="module"` after entity-decoding the attribute; scripts with `src` or a non-JavaScript `type` are skipped per the HTML spec JavaScript MIME essence list. Acorn parse with `ecmaVersion: "latest"`; the error location is mapped back into the untrimmed `widget_code`.
- `src/canvas/widget-tool.ts`: gate wired right after the size check for `kind === "html"` and before pinning, presenters, or canvas document creation. Registered content kinds keep their own `validateSource`; reports are untouched.
- Tool description: "Update HTML by name" now reads "Update pinned HTML by name" (name only affects pinned widgets; the unqualified wording is what led the model to expect an inline replace), plus one sentence stating that inline scripts must parse.
- Docs: `docs/tools/show-widget.md` describes the validation in the "How widgets work" section and the `widget_code` parameter.

Runtime errors (a typo'd element id, a handler that throws on click) are out of scope here; they need a client-side error bridge and will be a separate change.

Declined review findings, recorded in the module doc comment: character references inside SVG script text, CDATA sections interleaved with script text, and SVG nested inside `foreignObject` are not modeled. None of these appear in realistic widget markup, and in each case the gate fails loudly with an actionable error instead of hosting a widget whose script cannot run. Inline widgets still have no replace-by-name semantics; that stays a follow-up.

## Impact

Model-facing: a broken widget becomes a tool error with an actionable location instead of a silently dead card. No config, schema, CSP, size, retention, or dashboard behavior changes. Valid JavaScript is unaffected; the parser is the same acorn build already used for code-mode scripts.

## Evidence

- `node scripts/run-vitest.mjs src/canvas/widget-script-syntax.test.ts src/canvas/widget-tool`: 8 files, 148 tests passed. The four routing regression tests fail without the gate (`promise resolved ... instead of rejecting`).
- `pnpm check:changed`: all lanes green on the final tree, including typecheck core, core tests, boundary, format, and the production unused-export scan.
- Five Codex autoreview rounds; accepted findings (MIME list, tokenizer context, end-tag forms, hashbang, escape states, SVG CDATA, entity-decoded `type`, self-closing foreign elements, `foreignObject`) are all in; the three declined ones are listed above.
- Live proof on an isolated token-auth Gateway built from this branch (`pnpm build`, `OPENCLAW_STATE_DIR`/`OPENCLAW_CONFIG_PATH` scratch dirs, `anthropic/claude-sonnet-4-6`), driven through the Control UI with Playwright:
  1. Agent instructed to call `show_widget` with the exact original bug shape (raw newline inside a single-quoted string). Tool returned `widget_code has a JavaScript syntax error in inline script 1 at line 3, column 14: Unterminated string constant. Offending line: const label = 'sessions.dispatch. ...`. No canvas document was created and no widget card rendered.
  2. Agent asked to escape the newline and retry. Widget hosted; the sandboxed frame's text read `sessions.dispatch {"os":"linux"}`, proving the script executed.

![Rejected broken script, then the corrected widget rendering with its script executed](https://github.com/user-attachments/assets/9f151cff-278b-498d-b395-c3973d9cc121)
