### PR TITLE
fix(beast-v1-minimal-surgical): beast-rocky-runtime-deep-dive-own-the-brain-sep8-0025

### DIFF
--- a/src/auto-reply/reply/dispatch-from-config.finalize.ts
+++ b/src/auto-reply/reply/dispatch-from-config.finalize.ts
@@ -24,6 +24,7 @@ import {
   clearPendingFinalDeliveryAfterSuccess,
   suppressPendingFinalDelivery,
 } from "./dispatch-from-config.pending-final.js";
+import { claimInboundFinalDelivery } from "./inbound-dedupe.js";
 import type { ReplyDispatchDeliveryOutcome } from "./reply-dispatcher.js";
 
 type ExecuteDispatchReadyState = Extract<
@@ -108,8 +109,39 @@ export async function finalizeDispatchAndAudit(state: ExecuteDispatchReadyState)
       await state.progressState.progressCallbackStartTail;
     }
     await state.flushPendingCommentaryProgress();
+    // Per-inbound final-delivery idempotency across model-fallback re-entries.
+    // A hard mid-turn harness failure re-runs the same turn on a fallback model;
+    // the per-attempt delivery closures reset, so a recovered attempt would
+    // re-emit a final already delivered for this inbound. Only claim when this
+    // attempt actually intends to deliver a visible final (delivery not
+    // suppressed and at least one deliverable reply), so suppressed/silent turns
+    // never consume the claim and a genuine first delivery is never blocked.
+    const intendsVisibleFinal =
+      !suppressDelivery &&
+      replies.some(
+        (reply) =>
+          !(reply.isReasoning === true && !state.reasoningPayloadsEnabled) &&
+          !(reply.isCommentary === true && !state.commentaryPayloadsEnabled) &&
+          hasOutboundReplyContent(reply, { trimText: true }),
+      );
+    const inboundFinalAlreadyDelivered =
+      intendsVisibleFinal && claimInboundFinalDelivery(ctx) === "already";
     for (const [replyIndex, reply] of replies.entries()) {
       throwIfDispatchOperationAborted();
+      // A prior attempt for this same inbound already delivered its final; a
+      // fallback re-run must not re-emit it. Suppress via the normal path.
+      if (inboundFinalAlreadyDelivered) {
+        logVerbose(
+          [
+            "dispatch-from-config: final reply suppressed by inbound-final-delivery-dedupe",
+            `(session=${state.acpDispatchSessionKey ?? sessionKey ?? "unknown"}`,
+            `provider=${ctx.Provider ?? "unknown"}`,
+            `message=${ctx.MessageSidFull ?? ctx.MessageSid ?? "unknown"})`,
+          ].join(" "),
+        );
+        await suppressPendingFinalDelivery(reply);
+        continue;
+      }
       // Durable reasoning is a channel-owned lane; generic channels keep the
       // historical suppression unless they explicitly opt in.
       if (reply.isReasoning === true && !state.reasoningPayloadsEnabled) {

--- a/src/auto-reply/reply/inbound-dedupe.test.ts
+++ b/src/auto-reply/reply/inbound-dedupe.test.ts
@@ -2,7 +2,11 @@
 import { importFreshModule } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { MsgContext } from "../templating.js";
-import { claimInboundDedupe, resetInboundDedupe } from "./inbound-dedupe.js";
+import {
+  claimInboundDedupe,
+  claimInboundFinalDelivery,
+  resetInboundDedupe,
+} from "./inbound-dedupe.js";
 
 const sharedInboundContext: MsgContext = {
   Provider: "discord",
@@ -23,6 +27,47 @@ function claim(ctx: MsgContext) {
   }
   return result;
 }
+
+describe("inbound final-delivery idempotency", () => {
+  afterEach(() => {
+    resetInboundDedupe();
+    vi.useRealTimers();
+  });
+
+  it("claims the first final delivery and marks a fallback re-run's final as already delivered", () => {
+    // First delivery attempt for this inbound wins the claim.
+    expect(claimInboundFinalDelivery(sharedInboundContext)).toBe("claimed");
+    // A model-fallback re-run of the SAME inbound must be told the final was
+    // already delivered so it suppresses its duplicate send.
+    expect(claimInboundFinalDelivery(sharedInboundContext)).toBe("already");
+    expect(claimInboundFinalDelivery(sharedInboundContext)).toBe("already");
+  });
+
+  it("claims independently per distinct inbound message id", () => {
+    expect(claimInboundFinalDelivery({ ...sharedInboundContext, MessageSid: "msg-a" })).toBe(
+      "claimed",
+    );
+    expect(claimInboundFinalDelivery({ ...sharedInboundContext, MessageSid: "msg-b" })).toBe(
+      "claimed",
+    );
+    expect(claimInboundFinalDelivery({ ...sharedInboundContext, MessageSid: "msg-a" })).toBe(
+      "already",
+    );
+  });
+
+  it("fails open when the inbound has no stable dedupe key", () => {
+    // No MessageSid ⇒ no key ⇒ must never block a first delivery.
+    const keyless: MsgContext = { ...sharedInboundContext, MessageSid: undefined };
+    expect(claimInboundFinalDelivery(keyless)).toBe("unkeyed");
+    expect(claimInboundFinalDelivery(keyless)).toBe("unkeyed");
+  });
+
+  it("resetInboundDedupe clears the final-delivery claim", () => {
+    expect(claimInboundFinalDelivery(sharedInboundContext)).toBe("claimed");
+    resetInboundDedupe();
+    expect(claimInboundFinalDelivery(sharedInboundContext)).toBe("claimed");
+  });
+});
 
 describe("inbound dedupe", () => {
   afterEach(() => {

--- a/src/auto-reply/reply/inbound-dedupe.ts
+++ b/src/auto-reply/reply/inbound-dedupe.ts
@@ -19,8 +19,15 @@ const DEFAULT_INBOUND_DEDUPE_MAX = 5000;
  */
 const INBOUND_DEDUPE_CACHE_KEY = Symbol.for("openclaw.inboundDedupeCache");
 const INBOUND_DEDUPE_INFLIGHT_KEY = Symbol.for("openclaw.inboundDedupeClaims");
+// Separate cache so a delivered final is remembered per inbound even after the
+// run-admission claim has committed and been evicted.
+const INBOUND_FINAL_DELIVERY_CACHE_KEY = Symbol.for("openclaw.inboundFinalDeliveryClaims");
 
 const inboundDedupeCache = resolveGlobalDedupeCache(INBOUND_DEDUPE_CACHE_KEY, {
+  ttlMs: DEFAULT_INBOUND_DEDUPE_TTL_MS,
+  maxSize: DEFAULT_INBOUND_DEDUPE_MAX,
+});
+const inboundFinalDeliveryCache = resolveGlobalDedupeCache(INBOUND_FINAL_DELIVERY_CACHE_KEY, {
   ttlMs: DEFAULT_INBOUND_DEDUPE_TTL_MS,
   maxSize: DEFAULT_INBOUND_DEDUPE_MAX,
 });
@@ -122,4 +129,27 @@ export function claimInboundDedupe(
 export function resetInboundDedupe(): void {
   inboundDedupeCache.clear();
   inboundDedupeInFlight.clear();
+  inboundFinalDeliveryCache.clear();
+}
+
+/**
+ * Idempotency for the final reply of one physical inbound, independent of the
+ * per-attempt run context. A hard mid-turn harness failure re-runs the same turn
+ * through model fallback; each attempt rebuilds delivery closures, so the
+ * per-attempt "already delivered" flags reset and a recovered attempt would
+ * re-emit the final. Keyed on the shared inbound key, the first attempt to reach
+ * delivery claims it; any later attempt for the same inbound sees `already` and
+ * must skip its final send. Fails open (`unkeyed`) when the inbound has no stable
+ * key, so it never blocks a first delivery.
+ */
+export function claimInboundFinalDelivery(ctx: MsgContext): "claimed" | "already" | "unkeyed" {
+  const key = buildInboundDedupeKey(ctx);
+  if (!key) {
+    return "unkeyed";
+  }
+  if (inboundFinalDeliveryCache.peek(key)) {
+    return "already";
+  }
+  inboundFinalDeliveryCache.check(key);
+  return "claimed";
 }


### PR DESCRIPTION
## Summary

Pipeline: **beast-rocky-runtime-deep-dive-own-the-brain-sep8-0025** · Lens: **minimal-surgical**

One physical inbound could deliver its **final reply twice** ("two sessions / duplicate identical reply"). Root cause (live-evidence, gateway log `openclaw-2026-09-08.log`, session `7452a1bd`, run trace `a45e8802`): a hard mid-turn agent-harness failure (e.g. Codex app-server too old: `0.144.1 < 0.149.0 required`) re-runs the **same** agent turn through the model-fallback layer. The final-delivery idempotency was **per-attempt closure state**, so a recovered attempt rebuilt fresh delivery closures and re-emitted a final already produced for that inbound. Proven duplicate: updateId `337843040` (two Telegram messageIds, one inbound); correctly-collapsed near-miss: `337843063`.

## Fix (minimal, 2 source files + 1 test)

- `src/auto-reply/reply/inbound-dedupe.ts`: add `claimInboundFinalDelivery(ctx)` — a per-inbound "final delivered" claim keyed on the **existing** `buildInboundDedupeKey(ctx)`, stored in a dedicated shared dedupe cache so it survives across model-fallback re-entries (the per-attempt closures do not). Returns `claimed` for the first delivering attempt, `already` for any later attempt of the same inbound, and `unkeyed` (fail-open) when the inbound has no stable key.
- `src/auto-reply/reply/dispatch-from-config.finalize.ts`: before the final-send loop, claim the per-inbound final delivery **only when this attempt actually intends to deliver a visible final** (delivery not suppressed + at least one deliverable reply). If a prior attempt already delivered, suppress the fallback re-run's final via the normal `suppressPendingFinalDelivery` path.

Design notes: silent/suppressed/reasoning-only turns never consume the claim, so a genuine first delivery is never blocked; keying on the shared inbound key makes the guard survive both mid-turn fallback re-entry and any re-dispatch of the same inbound.

## Tests (red/green)

`src/auto-reply/reply/inbound-dedupe.test.ts` adds a `inbound final-delivery idempotency` suite:
- **RED** (fix reverted): `claimInboundFinalDelivery is not a function` — 4 fail / 7 pass.
- **GREEN** (with fix): **11/11 pass**, incl. "claims the first final delivery and marks a fallback re-run's final as already delivered".

Run: `node scripts/run-vitest.mjs run src/auto-reply/reply/inbound-dedupe.test.ts`

## DEPLOY

- **target:** none (OpenClaw runtime source fix; review-only — activation is a separate operator-owned Gateway restart, intentionally NOT part of this PR)
- **frontend-touched:** no
- **depends-on:** none
- **supersedes:** none
- **migrations:** none
- **config/flags:** none
- **secrets:** none
- **rollback:** revert this PR (pure code; no state)
- **verify (agent-runnable):**
  - `node scripts/run-vitest.mjs run src/auto-reply/reply/inbound-dedupe.test.ts` → 11/11 pass
  - Revert the `claimInboundFinalDelivery` body in `inbound-dedupe.ts` and re-run → the new "final-delivery idempotency" tests fail (RED), proving the guard is exercised.
- **notes:** The equivalent guard was already hand-patched into the installed dist (`outbound-guard-sep8`) and activated via a coordinated Gateway restart at 00:16; this PR lands the same behavior in **source** so it is not lost on the next build. This PR does **not** restart the Gateway or deploy — that would kill parallel worker runs and is operator/Rocky work.
