### PR TITLE
fix(test): prevent catalog mock from breaking provider integration

### DIFF
--- a/src/agents/prepared-model-catalog-worker.test.ts
+++ b/src/agents/prepared-model-catalog-worker.test.ts
@@ -1,14 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
 import {
   createPreparedModelCatalogWorkerInput,
   fingerprintPreparedModelWorkerRequest,
 } from "./prepared-model-catalog-worker.js";
 import type { PreparedModelRuntimeAgentFacts } from "./prepared-model-runtime.catalog-contract.js";
-
-vi.mock("../plugins/manifest-registry-installed.js", () => ({
-  resolveInstalledManifestRegistryIndexFingerprint: () => "test-plugin-index",
-}));
 
 describe("prepared model catalog worker input", () => {
   it("preserves captured auth identity and distinguishes source from built artifacts", () => {
@@ -65,7 +61,17 @@ describe("prepared model catalog worker input", () => {
       pluginMetadataSnapshot: {
         policyHash: "test-policy",
         configFingerprint: "test-config",
-        index: {} as never,
+        index: {
+          version: 1,
+          hostContractVersion: "test-host",
+          compatRegistryVersion: "test-compat",
+          migrationVersion: 1,
+          policyHash: "test-policy",
+          generatedAtMs: 0,
+          installRecords: {},
+          plugins: [],
+          diagnostics: [],
+        },
         plugins: [],
       } as unknown as PluginMetadataSnapshot,
     };


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where the shared agent CI worker fails `provider-transport-fetch.integration.test.ts` after running the catalog-worker test. The earlier test replaces the entire installed-manifest registry with a one-export mock, so the real provider metadata path later cannot call `loadPluginManifestRegistryForInstalledIndex`.

Observed independently of the runtime-ownership changes in [#141876's CI](https://github.com/openclaw/openclaw/actions/runs/34195359941/job/101961995681). Reproduced on current main with the two existing tests in that order in one non-isolated worker.

## Why This Change Was Made

Remove the unnecessary module mock and supply a complete empty installed-plugin index fixture. The catalog-worker test now uses the real fingerprint function and leaves the registry available to subsequent integration tests.

The mock was introduced in `1cb9f70cb304` by Josh Avant in #122350, merged August 13, 2026. Its parent already exported the missing function. This identifies the latent mock defect's origin, not the first CI run or release that exposed the ordering dependency.

## User Impact

Restores the existing CI integration coverage without changing runtime behavior, test isolation, or assertions.

## Evidence

- Before: catalog-worker test passes, then provider transport fails with the exact missing-export error in the same worker.
- Independent autoreview: no actionable P0–P2 findings.
- After: both existing tests pass in the same original order and non-isolated worker. A local proof-only sequencer preserves the order; the catalog test also passes in its normal automatic unit-fast lane after mock removal.
