### PR TITLE
refactor(media): exercise quota through the cache writer

### DIFF
--- a/src/media/store.playback-cache.test.ts
+++ b/src/media/store.playback-cache.test.ts
@@ -6,22 +6,6 @@ import { createTempHomeEnv, type TempHomeEnv } from "../test-utils/temp-home.js"
 let store: typeof import("./store.js");
 let tempHome: TempHomeEnv;
 
-type PlaybackCacheTestApi = {
-  enforcePlaybackTranscodeCacheLimit(): Promise<void>;
-  PLAYBACK_TRANSCODE_MAX_CACHE_BYTES: number;
-  PLAYBACK_TRANSCODE_TTL_MS: number;
-};
-
-function getPlaybackCacheTestApi(): PlaybackCacheTestApi {
-  const api = (globalThis as Record<PropertyKey, unknown>)[
-    Symbol.for("openclaw.mediaStoreTestApi")
-  ];
-  if (!api) {
-    throw new Error("media store test API is unavailable");
-  }
-  return api as PlaybackCacheTestApi;
-}
-
 beforeAll(async () => {
   tempHome = await createTempHomeEnv("openclaw-playback-cache-");
   store = await import("./store.js");
@@ -36,27 +20,32 @@ afterEach(async () => {
 });
 
 it("evicts oldest playback transcodes when insertion enforcement exceeds its byte budget", async () => {
-  const testApi = getPlaybackCacheTestApi();
   const mediaDir = await store.ensureMediaDir();
   const cacheDir = path.join(mediaDir, store.PLAYBACK_TRANSCODE_SUBDIR);
   await fs.mkdir(cacheDir, { recursive: true });
   const oldPath = path.join(cacheDir, "v2-old.mp4");
   const newPath = path.join(cacheDir, "v2-new.mp4");
-  const sparseSize = Math.floor(testApi.PLAYBACK_TRANSCODE_MAX_CACHE_BYTES * 0.6);
+  const sparseSize = (512 * 1024 * 1024) / 2;
   await Promise.all([fs.writeFile(oldPath, ""), fs.writeFile(newPath, "")]);
   await Promise.all([fs.truncate(oldPath, sparseSize), fs.truncate(newPath, sparseSize)]);
   const nowMs = Date.now();
   await fs.utimes(oldPath, (nowMs - 2_000) / 1000, (nowMs - 2_000) / 1000);
   await fs.utimes(newPath, (nowMs - 1_000) / 1000, (nowMs - 1_000) / 1000);
 
-  await testApi.enforcePlaybackTranscodeCacheLimit();
+  const inserted = Buffer.from("inserted");
+  const insertedPath = await store.writePlaybackTranscodeCache({
+    buffer: inserted,
+    fileName: "v2-inserted.mp4",
+    maxBytes: inserted.byteLength,
+    tempPrefix: ".playback-cache-test",
+  });
 
   await expect(fs.stat(oldPath)).rejects.toMatchObject({ code: "ENOENT" });
   await expect(fs.stat(newPath)).resolves.toMatchObject({ size: sparseSize });
+  await expect(fs.readFile(insertedPath)).resolves.toEqual(inserted);
 });
 
 it("prunes only playback entries using the fixed seven-day retention", async () => {
-  const testApi = getPlaybackCacheTestApi();
   const mediaDir = await store.ensureMediaDir();
   const cacheDir = path.join(mediaDir, store.PLAYBACK_TRANSCODE_SUBDIR);
   await fs.mkdir(cacheDir, { recursive: true });
@@ -70,7 +59,7 @@ it("prunes only playback entries using the fixed seven-day retention", async () 
   ]);
   const nowMs = Date.now();
   await fs.utimes(freshPath, (nowMs - 5 * 60_000) / 1000, (nowMs - 5 * 60_000) / 1000);
-  const expiredMs = nowMs - testApi.PLAYBACK_TRANSCODE_TTL_MS - 1_000;
+  const expiredMs = nowMs - 7 * 24 * 60 * 60 * 1000 - 1_000;
   await Promise.all([
     fs.utimes(oldPath, expiredMs / 1000, expiredMs / 1000),
     fs.utimes(transientPath, expiredMs / 1000, expiredMs / 1000),

--- a/src/media/store.ts
+++ b/src/media/store.ts
@@ -61,9 +61,6 @@ function setMediaStoreNetworkDepsForTest(deps?: {
 
 if (process.env.VITEST || process.env.NODE_ENV === "test") {
   (globalThis as Record<PropertyKey, unknown>)[Symbol.for("openclaw.mediaStoreTestApi")] = {
-    enforcePlaybackTranscodeCacheLimit,
-    PLAYBACK_TRANSCODE_MAX_CACHE_BYTES,
-    PLAYBACK_TRANSCODE_TTL_MS,
     setMediaStoreNetworkDepsForTest,
   };
 }
@@ -302,11 +299,6 @@ export async function writePlaybackTranscodeCache(params: {
     await prunePlaybackTranscodeCacheToSize();
     return filePath;
   });
-}
-
-/** Serializes maintenance quota scans with cache insertions. */
-async function enforcePlaybackTranscodeCacheLimit(): Promise<void> {
-  await queuePlaybackCacheOperation(prunePlaybackTranscodeCacheToSize);
 }
 
 /** Prunes expired playback renditions and reapplies the fixed cache size budget. */


### PR DESCRIPTION
## What Problem This Solves

The playback-cache eviction test called a private quota hook, so it could pass even if writing a new rendition stopped enforcing the cache budget.

## Why This Change Was Made

Exercise the existing cache writer directly, then remove the unused private enforcement wrapper and its three test-global members. The fixture starts exactly at an independently stated 512 MiB budget; inserting eight bytes must evict the oldest file before the writer resolves. The retention case keeps checking the fixed seven-day policy independently of production constants.

## User Impact

Runtime cache policy and public APIs are unchanged. Both existing cases and all five original expectations remain, with an inserted-content check added. Production code shrinks by eight lines and tests by eleven. The network-test hook and the shared publication remain intact.

## Evidence

- Original and final store/cache/transcode/staging suites: 152 passed each, with identical case inventories.
- Controlled removal of only the writer's quota call: old tests still pass all 152; migrated tests fail exactly the oldest-file eviction assertion, while 151 pass.
- Correct code restored before final proof; no control change remains.
- Independent Codex review through P2 is clean; formatting and diff checks passed.
- All 29 normal changed-file checks passed, including production and core-test types, dead-export scans, scoped lint, and remaining guards ([Linux Testbox run](https://github.com/openclaw/openclaw/actions/runs/34193344856)). The one-shot lease, temporary capsule, and recorded processes are cleaned up.

These tests use isolated temporary state and synthetic media. No operator cache, live provider, or actual ffmpeg process was exercised by this cleanup. Sparse-file logical sizes are known; physical allocation was not measured.

### CI integration

The first exact-head CI run failed because an earlier catalog-worker test left a partial registry mock behind. The same missing-export failure reproduced on the base without this media patch. Main now contains the canonical fixture repair in #141930; the branch was refreshed onto it with the two-file media patch byte-identical. All 152 media/store/transcode cases passed again after that refresh.

An ordered control confirmed that the canonical repair changes the failing sentinel integration to passing. That local cohort also exposed a separate keyless-auth fixture failure under ambient credentials, retained for follow-up; it is not reported as a wholly green cohort. The earlier 29-check gate remains evidence for the unchanged media patch, and fresh exact-head CI is required on this revision.
