### PR TITLE
refactor(markdown): remove redundant opening-order bookkeeping

### DIFF
--- a/packages/markdown-core/src/render.annotations.test.ts
+++ b/packages/markdown-core/src/render.annotations.test.ts
@@ -71,6 +71,51 @@ describe("renderMarkdownWithMarkers semantic annotations", () => {
     ).toBe("<blockquote><code>user[Thu 2026-07-02]</code> continue</blockquote>");
   });
 
+  it("preserves equal-bound annotation and link order", () => {
+    const opened: string[] = [];
+    const rendered = renderMarkdownWithMarkers(
+      {
+        text: "x",
+        styles: [],
+        annotations: (["user", "assistant"] as const).map((role) => ({
+          start: 0,
+          end: 1,
+          type: "assistant_transcript_role" as const,
+          kind: "angle_role_header" as const,
+          role,
+        })),
+        links: ["first", "second"].map((href) => ({ start: 0, end: 1, href })),
+      },
+      {
+        styleMarkers: {},
+        annotationMarkers: {
+          assistant_transcript_role: {
+            open: (span) => {
+              opened.push(span.role);
+              return `<role name="${span.role}">`;
+            },
+            close: "</role>",
+          },
+        },
+        escapeText: (text) => text,
+        buildLink: (link) => {
+          opened.push(link.href);
+          return {
+            start: link.start,
+            end: link.end,
+            open: `<link href="${link.href}">`,
+            close: "</link>",
+          };
+        },
+      },
+    );
+
+    expect(rendered).toBe(
+      '<role name="user"><role name="assistant"><link href="first"><link href="second">x</link></link></role></role>',
+    );
+    expect(opened).toEqual(["first", "second", "user", "assistant"]);
+  });
+
   it("renders many independently styled annotations without cross-product scans", () => {
     const markdown = Array.from(
       { length: 256 },

--- a/packages/markdown-core/src/render.ts
+++ b/packages/markdown-core/src/render.ts
@@ -292,15 +292,14 @@ export function renderMarkdownWithMarkers(
   // Links and styles share one stack so equal-end spans close in exact reverse open order.
   const stack: { open: string; close: string; end: number }[] = [];
   type OpeningItem =
-    | { end: number; open: string; close: string; kind: "annotation"; index: number }
-    | { end: number; open: string; close: string; kind: "link"; index: number }
+    | { end: number; open: string; close: string; kind: "annotation" }
+    | { end: number; open: string; close: string; kind: "link" }
     | {
         end: number;
         open: string;
         close: string;
         kind: "style";
         style: MarkdownStyle;
-        index: number;
       };
   let out = "";
 
@@ -325,7 +324,7 @@ export function renderMarkdownWithMarkers(
 
     const openingAnnotations = annotationStarts.get(pos);
     if (openingAnnotations) {
-      for (const [index, span] of openingAnnotations.entries()) {
+      for (const span of openingAnnotations) {
         const marker = annotationMarkers[span.type];
         if (!marker) {
           continue;
@@ -335,14 +334,13 @@ export function renderMarkdownWithMarkers(
           open: typeof marker.open === "function" ? marker.open(span) : marker.open,
           close: marker.close,
           kind: "annotation",
-          index,
         });
       }
     }
 
     const openingLinks = linkStarts.get(pos);
     if (openingLinks && openingLinks.length > 0) {
-      for (const [index, link] of openingLinks.entries()) {
+      for (const link of openingLinks) {
         // A renderer can collapse a link to terminal text. Emit the insertion
         // before new spans open; it must never enter the reopenable marker stack.
         if (link.start === link.end) {
@@ -354,14 +352,13 @@ export function renderMarkdownWithMarkers(
           open: link.open,
           close: link.close,
           kind: "link",
-          index,
         });
       }
     }
 
     const openingStyles = startsAt.get(pos);
     if (openingStyles) {
-      for (const [index, span] of openingStyles.entries()) {
+      for (const span of openingStyles) {
         const marker = styleMarkers[span.style];
         if (!marker) {
           continue;
@@ -372,7 +369,6 @@ export function renderMarkdownWithMarkers(
           close: marker.close,
           kind: "style",
           style: span.style,
-          index,
         });
       }
     }
@@ -393,7 +389,8 @@ export function renderMarkdownWithMarkers(
         if (a.kind === "style" && b.kind === "style") {
           return (STYLE_RANK.get(a.style) ?? 0) - (STYLE_RANK.get(b.style) ?? 0);
         }
-        return a.index - b.index;
+        // Stable sorting preserves source order for equal annotations and links.
+        return 0;
       });
 
       // Open outer spans first (larger end) so LIFO closes stay valid for same-start overlaps.


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

**MUST:** Keep **Allow edits from maintainers** enabled for this PR so maintainers can help update the branch when needed.

</details>

## What Problem This Solves

This maintainer-requested cleanup reduces redundant bookkeeping in the shared Markdown renderer without changing rendered messages. Each temporary opening item carries an extra ordinal even though the existing ordering already preserves that information.

## Why This Change Was Made

Remove the function-local `OpeningItem.index` field and iterate the existing buckets directly. Equal same-kind annotation/link ties return zero, so stable sorting preserves their original insertion order. End-position, structural/kind and style ordering still take precedence.

The change stays in `renderMarkdownWithMarkers`; no new sorting helper, compatibility path, public type, export, dependency or caller change is needed. The added preservation test checks both equal-bound nesting and marker callback order.

## User Impact

No intended user-visible change. Attributed rendering, Telegram and Google Chat callers retain the same output contract. Marker construction order, reverse closing, crossing-span reopening, terminal collapsed links, fallback rendering and link provenance remain unchanged.

Production: +7/-10 (net -3). Tests: +45/-0. Exactly two files. This is a pure internal refactor, not a release-note-worthy behavior change.

## Evidence

- Published signed head: `a021cb478545a756116605c26282166f6a67d345`, sole parent `f659795ee1a1e89571d58bc9c8e5c6a26667bfa0`. Independent source review and fresh whole-commit P3 review found no actionable findings.
- Fresh proof for this head passed **220 tests across eight complete suites**, with zero failures, skips or todos: construct fallbacks (32), annotations (9), render-aware chunking (22), crossing spans (8), link handling (3), Telegram formatting (61), Telegram wrapping (44), and Google Chat formatting (41). The equal-bound case preserves nesting and callback order; this is not an old-red/new-green renderer bug-fix claim.
- **28/28 normally selected checks passed**, including core and core-test types, scoped formatting/lint, and all three Knip unused-export scans with zero entries. Fresh frozen installation matched 14 dependency versions, 12 bound source/dependency hashes and both normalization workspace identities on Node 24.19.0, pnpm 12.3.4 and Vitest 5.0.0. Producer and receiver identities matched this head for every payload; the owned test environment closed normally.
- Previous attached CI [run 34196666526](https://github.com/openclaw/openclaw/actions/runs/34196666526) failed on immutable merge checkout `c7a94d14833553c0259baeb7b93326f45504df10`: a registry mock omitted `loadPluginManifestRegistryForInstalledIndex` when the packed test group reached provider transport integration. This head rebases onto the landed partial-mock repair from [PR 141893](https://github.com/openclaw/openclaw/pull/141893), rather than adding an unrelated fix or retrying the old checkout.
- Fresh attached [CI 34203140454/1](https://github.com/openclaw/openclaw/actions/runs/34203140454) passed, including the required aggregate gate: 77 successful jobs and 17 conditional skips. Actual merge checkout `80eab94803dfeb7897210f956d78874caec614ce` contains this exact head and main parent `454824ffd0d4d60ce2baef522bf3efd93806b66a`. It also includes the later main-owned [PR 141930](https://github.com/openclaw/openclaw/pull/141930), which removes the registry mock entirely and uses a complete shared fixture while preserving all eleven assertions. The producer case passed in its normal `core-unit-fast-2` group; the provider HTTP egress/redaction suffix passed separately. No obsolete producer-to-HTTP same-worker execution is claimed.
- The earlier 219-test proof covered the previous head `6bc037d99f25d78cb1eb67efacb75d9171e3d2a3` and remains historical. The [current ClawSweeper review](https://github.com/openclaw/openclaw/pull/141945#issuecomment-5580855427), updated September 8, 2026 at 08:19 UTC, covers this exact successor and reports no findings, security concerns, before-merge items or Rank-up moves. Its backend completed successfully; the maintainer-review marker is satisfied by the completed independent source review.
- Native review, Testbox-backed preparation and squash merge completed for this unchanged head. Landed as [`c8cb22a899ac31a89d7c9748355048830593d962`](https://github.com/openclaw/openclaw/commit/c8cb22a899ac31a89d7c9748355048830593d962) on September 8, 2026 at 08:42 UTC; native bookkeeping and cleanup completed. No import/export, lazy-loading, package or build-topology changes are introduced. No separate packaged build, visual result or live-channel result is claimed.
