### PR TITLE
fix(sqlite): report why a loadable SQLite override is unusable on macOS Bun

### DIFF
--- a/src/infra/bun-sqlite-library.ts
+++ b/src/infra/bun-sqlite-library.ts
@@ -100,10 +100,13 @@ function createSelector(deps: SelectionDependencies) {
     for (const path of candidates) {
       let probe: LibraryProbe;
       try {
-        if (!deps.exists(path)) {
-          throw new Error("missing file");
+        // dlopen decides loadability: Apple's SQLite lives in the dyld shared cache with no
+        // file on disk, so a stat-first check would hide its real defect (OMIT_LOAD_EXTENSION).
+        try {
+          probe = deps.probe(path);
+        } catch (error) {
+          throw deps.exists(path) ? error : new Error("missing file", { cause: error });
         }
-        probe = deps.probe(path);
         if (!isSqliteWalResetSafeVersion(probe.version)) {
           throw new Error(`SQLite version ${probe.version} below the WAL safety floor`);
         }

--- a/src/infra/node-sqlite.test.ts
+++ b/src/infra/node-sqlite.test.ts
@@ -256,15 +256,31 @@ describe("Bun SQLite library selection", () => {
       const libraryPath = "/missing/sqlite.dylib";
       const f = fixture({
         exists: vi.fn(() => false),
+        probe: vi.fn(() => {
+          throw new Error("dlopen failed");
+        }),
         env: source === "env" ? { OPENCLAW_SQLITE_LIBRARY: libraryPath } : {},
       });
       expect(() => f.ensure(source === "explicit" ? { explicitPath: libraryPath } : {})).toThrow(
         `Cannot use SQLite library ${libraryPath}: missing file. Fix or unset OPENCLAW_SQLITE_LIBRARY; install a supported library with brew install sqlite.`,
       );
-      expect(f.probe).not.toHaveBeenCalled();
+      expect(f.probe).toHaveBeenCalledExactlyOnceWith(libraryPath);
       expect(f.select).not.toHaveBeenCalled();
     },
   );
+
+  it("reports the real defect of a loadable library that has no file on disk", () => {
+    // Apple's SQLite is served from the dyld shared cache: dlopen succeeds, stat does not.
+    const f = fixture({
+      exists: vi.fn(() => false),
+      probe: vi.fn(() => ({ ...safeProbe, extensionLoadingSupported: false })),
+      env: { OPENCLAW_SQLITE_LIBRARY: "/usr/lib/libsqlite3.dylib" },
+    });
+    expect(() => f.ensure()).toThrow(
+      "Cannot use SQLite library /usr/lib/libsqlite3.dylib: built with SQLITE_OMIT_LOAD_EXTENSION",
+    );
+    expect(f.select).not.toHaveBeenCalled();
+  });
 
   it.each([
     {
@@ -333,12 +349,18 @@ describe("Bun SQLite library selection", () => {
   });
 
   it("keeps the runtime default when no library exists, including a blank override", () => {
-    const f = fixture({ exists: vi.fn(() => false), env: { OPENCLAW_SQLITE_LIBRARY: "  " } });
+    const f = fixture({
+      exists: vi.fn(() => false),
+      probe: vi.fn(() => {
+        throw new Error("dlopen failed");
+      }),
+      env: { OPENCLAW_SQLITE_LIBRARY: "  " },
+    });
     const selection = f.ensure();
     expect(selection).toEqual({ source: "runtime" });
     expect(f.ensure()).toBe(selection);
     expect(f.exists).toHaveBeenCalledTimes(3);
-    expect(f.probe).not.toHaveBeenCalled();
+    expect(f.probe).toHaveBeenCalledTimes(3);
     expect(f.select).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## What Problem This Solves

On macOS under Bun, pointing `OPENCLAW_SQLITE_LIBRARY` at Apple's system SQLite (`/usr/lib/libsqlite3.dylib`) fails with a false diagnosis:

```
Cannot use SQLite library /usr/lib/libsqlite3.dylib: missing file. Fix or unset OPENCLAW_SQLITE_LIBRARY; install a supported library with brew install sqlite.
```

The file is not missing. Modern macOS serves system libraries from the dyld shared cache with no file on disk, so `stat` fails while `dlopen` loads the library fine (Bun itself dlopens exactly this library). The real defect is that Apple's build omits extension loading, which the selector's probe already detects (`built with SQLITE_OMIT_LOAD_EXTENSION`) but never reached, because #141854's selector ran a stat-based existence check before the probe.

## Why This Change Was Made

`dlopen` is the owner of loadability; `stat` is not. The selector now probes first and consults `exists` only to name a *failed* probe as `missing file`, so a library that loads but is unusable reports its actual defect. Discovery is unchanged in effect (its candidates are on-disk Homebrew/MacPorts paths); the override path is what misreported.

Same-scope sibling check: the discovery loop, the one-shot `select` commit, the WAL floor check, and the `ignoredOverride` no-op paths are untouched. No configuration, schema, child-environment, or default change.

## User Impact

An operator who pins Apple's SQLite now sees why it cannot be used (`built with SQLITE_OMIT_LOAD_EXTENSION`) instead of being told a present library is missing. A genuinely missing path still reports `missing file`; a non-library file still reports the dlopen error. Guidance text is unchanged.

## Evidence

Reproduced live on the built CLI at `d662d575372` (Bun 1.4.2, macOS 27.0, Homebrew SQLite 3.53.4 installed, isolated `OPENCLAW_STATE_DIR`):

- `OPENCLAW_SQLITE_LIBRARY=/usr/lib/libsqlite3.dylib bun openclaw.mjs status` → `missing file` (wrong). A direct `bun:ffi` `dlopen` of that path returns version 3.54.0 with `OMIT_LOAD_EXTENSION = 1`, and `ls` confirms no file on disk.
- Happy path unchanged: `bun openclaw.mjs gateway --dev` in the isolated state dir logs `SQLite: using /opt/homebrew/opt/sqlite/lib/libsqlite3.dylib (3.53.4, extension loading enabled)`; `memory status --json` exits 0 with and without the Homebrew override; `node openclaw.mjs --version` ignores the override.

Fixed source, live under Bun via `ensureSqliteLibrarySelected({ explicitPath })` in fresh processes:

- `/usr/lib/libsqlite3.dylib` → `built with SQLITE_OMIT_LOAD_EXTENSION`
- `/nonexistent.dylib` → `missing file`
- `/etc/hosts` → dlopen `slice is not valid mach-o file`
- discovery → `{"source":"discovered","path":"/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib","version":"3.53.4"}`

Tests (`src/infra/node-sqlite.test.ts`): new case "reports the real defect of a loadable library that has no file on disk" fails on pre-fix code with the `missing file` misdiagnosis and passes after; the missing-override and no-library cases now model `dlopen` failing (probe throws) and assert the probe runs. 47/47 in the file; `src/infra/runtime-guard.test.ts` and the memory-core KNN subprocess suite pass; `check-changed` on the touched files passes.

Production LOC: +3 net (two lines are the invariant comment at the probe site).

Review: independent Codex autoreview (local mode, P0–P2) is scoped-clean with no actionable findings.

CI note: the first head hit the red `checks-node-compact-large-11` shard on `main` (cross-file `vi.mock` leak from `prepared-model-catalog-worker.test.ts`); I reproduced it locally and had the same partial-mock fix ready, but #141893 landed it first, so this PR is rebased onto that `main` and carries only the SQLite change.
