### PR TITLE
fix(ui): show provider refresh failures in model consumers

### DIFF
--- a/docs/concepts/models.md
+++ b/docs/concepts/models.md
@@ -106,6 +106,10 @@ with the failed outcome, even when strict discovery returns no rows.
 They cannot widen a retained successful list, including an empty list. Changes to
 provider, plugin, auth, environment, or workspace identity invalidate incompatible inventory.
 
+Automations and command-palette model search show a warning when a provider refresh
+fails, while keeping the models returned by the Gateway. Open Models to retry the
+refresh. A successful empty result clears the discovered choices and warning.
+
 A successful provider result takes precedence over retained rows, even when
 another credential reports failure. Catalog results describe one provider's model
 list; OpenClaw does not guess which old models belonged to each credential.

--- a/ui/src/components/command-palette-catalog-search.test.ts
+++ b/ui/src/components/command-palette-catalog-search.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { createTestGatewayClient } from "../test-helpers/gateway-client.ts";
 import {
   filterCommandPaletteItems,
   getStaticCommandPaletteCatalogItems,
@@ -7,6 +8,26 @@ import {
 } from "./command-palette-catalog-search.ts";
 
 describe("command palette catalog search", () => {
+  it("reports failed acquisition from a successful catalog read while keeping its rows", async () => {
+    const result = await loadCommandPaletteCatalogItems({
+      client: createTestGatewayClient(async () => ({
+        models: [{ provider: "ollama", id: "retained", name: "Retained model", available: true }],
+        providerOutcomes: [{ provider: "ollama", status: "unavailable" }],
+      })),
+      agentId: "main",
+      agents: async () => null,
+      methodAvailable: (method) => method === "models.list",
+    });
+
+    expect(result.items).toContainEqual(
+      expect.objectContaining({ category: "models", label: "Retained model" }),
+    );
+    expect(result.modelSearchError).toBe(
+      "Some models could not be refreshed. Open Models to try again.",
+    );
+    expect(result.modelRequestFailed).toBe(false);
+  });
+
   it("opens meeting transcripts from search without querying agent chat history", () => {
     const items = filterCommandPaletteItems({
       query: "meeting",

--- a/ui/src/components/command-palette-catalog-search.ts
+++ b/ui/src/components/command-palette-catalog-search.ts
@@ -3,7 +3,7 @@ import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type {
   AgentsListResult,
   CronJobsListResult,
-  ModelCatalogEntry,
+  ModelCatalogResult,
   SkillStatusReport,
 } from "../api/types.ts";
 import {
@@ -299,8 +299,12 @@ export async function loadCommandPaletteCatalogItems(params: {
   agentId: string;
   agents: () => Promise<AgentsListResult | null>;
   methodAvailable: (method: string) => boolean;
-}): Promise<{ items: CommandPaletteCatalogItem[]; modelSearchFailed: boolean }> {
-  let modelSearchFailed = false;
+}): Promise<{
+  items: CommandPaletteCatalogItem[];
+  modelRequestFailed: boolean;
+  modelSearchError: string | null;
+}> {
+  let modelRequestFailed = false;
   const requestIfAvailable = async <T>(
     method: string,
     requestParams: unknown,
@@ -322,13 +326,13 @@ export async function loadCommandPaletteCatalogItems(params: {
     requestIfAvailable<PluginListResult>("plugins.list", {}),
     params.methodAvailable("models.list")
       ? params.client
-          .request<{ models: ModelCatalogEntry[] }>("models.list", {
+          .request<ModelCatalogResult>("models.list", {
             view: "configured",
             agentId: params.agentId,
             preparedOnly: true,
           })
           .catch(() => {
-            modelSearchFailed = true;
+            modelRequestFailed = true;
             return null;
           })
       : null,
@@ -389,5 +393,10 @@ export async function loadCommandPaletteCatalogItems(params: {
         .join(" "),
     })),
   ];
-  return { items, modelSearchFailed };
+  const modelSearchError = modelRequestFailed
+    ? t("palette.modelSearchFailed")
+    : models?.providerOutcomes?.some((outcome) => outcome.status !== "ready")
+      ? t("chat.modelControls.modelsRefreshFailed")
+      : null;
+  return { items, modelRequestFailed, modelSearchError };
 }

--- a/ui/src/components/command-palette.test-support.ts
+++ b/ui/src/components/command-palette.test-support.ts
@@ -1,0 +1,35 @@
+import { vi } from "vitest";
+import type { RouteId } from "../app-route-paths.ts";
+import type { ApplicationContext } from "../app/context.ts";
+import { createApplicationContextProvider } from "../test-helpers/application-context.ts";
+import type { CommandPalette } from "./command-palette.ts";
+
+export async function mountPalette(context: ApplicationContext<RouteId>) {
+  const provider = createApplicationContextProvider(context);
+  const palette = document.createElement("openclaw-command-palette") as CommandPalette;
+  palette.onNavigate = vi.fn();
+  palette.onSelectSession = vi.fn();
+  provider.append(palette);
+  document.body.append(provider);
+  await palette.updateComplete;
+  return { palette, provider };
+}
+
+export async function enterQuery(palette: CommandPalette, query: string) {
+  palette.openPalette();
+  await palette.updateComplete;
+  const input = palette.querySelector<HTMLInputElement>(".cmd-palette__input");
+  if (!input) {
+    throw new Error("Expected command palette input");
+  }
+  input.value = query;
+  input.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
+  await palette.updateComplete;
+}
+
+export function findPaletteOption(palette: CommandPalette, label: string, exact = false) {
+  return [...palette.querySelectorAll<HTMLElement>('[role="option"]')].find((item) => {
+    const text = item.textContent?.replace(/\s+/g, " ").trim();
+    return exact ? text === label : text?.includes(label);
+  });
+}

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -13,9 +13,9 @@ import type {
   ApplicationGatewaySnapshot,
 } from "../app/context.ts";
 import { subscribeNativeOverlayOcclusion } from "../lib/native-overlay-occlusion.ts";
-import { createApplicationContextProvider } from "../test-helpers/application-context.ts";
 import { installDialogPolyfill } from "../test-helpers/modal-dialog.ts";
-import { CommandPalette } from "./command-palette.ts";
+import { enterQuery, findPaletteOption, mountPalette } from "./command-palette.test-support.ts";
+import "./command-palette.ts";
 import {
   CUSTODIAN_PANEL_TOGGLE_EVENT,
   DESKTOP_PANEL_TOGGLE_EVENT,
@@ -117,36 +117,6 @@ function createSessionResult(key: string, displayName: string): SessionsListResu
     defaults: {},
     sessions: [{ key, kind: "direct", displayName, updatedAt: 1 }],
   } as SessionsListResult;
-}
-
-async function mountPalette(context: ApplicationContext<RouteId>) {
-  const provider = createApplicationContextProvider(context);
-  const palette = document.createElement("openclaw-command-palette") as CommandPalette;
-  palette.onNavigate = vi.fn();
-  palette.onSelectSession = vi.fn();
-  provider.append(palette);
-  document.body.append(provider);
-  await palette.updateComplete;
-  return { palette, provider };
-}
-
-async function enterQuery(palette: CommandPalette, query: string) {
-  palette.openPalette();
-  await palette.updateComplete;
-  const input = palette.querySelector<HTMLInputElement>(".cmd-palette__input");
-  if (!input) {
-    throw new Error("Expected command palette input");
-  }
-  input.value = query;
-  input.dispatchEvent(new Event("input", { bubbles: true, composed: true }));
-  await palette.updateComplete;
-}
-
-function findPaletteOption(palette: CommandPalette, label: string, exact = false) {
-  return [...palette.querySelectorAll<HTMLElement>('[role="option"]')].find((item) => {
-    const text = item.textContent?.replace(/\s+/g, " ").trim();
-    return exact ? text === label : text?.includes(label);
-  });
 }
 
 describe("CommandPalette lifecycle", () => {

--- a/ui/src/components/command-palette.test.ts
+++ b/ui/src/components/command-palette.test.ts
@@ -498,6 +498,46 @@ describe("CommandPalette lifecycle", () => {
     expect(request.mock.calls.filter(([method]) => method === "cron.list")).toHaveLength(1);
   });
 
+  it("shows a failed acquisition without appending old rows to the successful response", async () => {
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({
+        models: [
+          { provider: "ollama", id: "retained", name: "Needle retained" },
+          { provider: "ollama", id: "obsolete", name: "Needle obsolete" },
+        ],
+      })
+      .mockResolvedValueOnce({
+        models: [{ provider: "ollama", id: "retained", name: "Needle retained" }],
+        providerOutcomes: [{ provider: "ollama", status: "unavailable" }],
+      })
+      .mockResolvedValueOnce({
+        models: [],
+        providerOutcomes: [{ provider: "ollama", status: "ready" }],
+      });
+    const harness = createGateway(true, { methods: ["models.list"], request });
+    const { palette } = await mountPalette(createContext(harness.gateway, async () => null));
+    await enterQuery(palette, "needle");
+    await vi.advanceTimersByTimeAsync(50);
+    await palette.updateComplete;
+    expect(findPaletteOption(palette, "Needle obsolete")).toBeDefined();
+
+    harness.emit("chat.metadata.changed");
+    await vi.advanceTimersByTimeAsync(50);
+    await palette.updateComplete;
+    expect(findPaletteOption(palette, "Needle obsolete")).toBeUndefined();
+    expect(palette.querySelectorAll('[role="option"]')).toHaveLength(1);
+    expect(palette.querySelector('[role="status"]')?.textContent).toContain(
+      "Some models could not be refreshed. Open Models to try again.",
+    );
+
+    harness.emit("chat.metadata.changed");
+    await vi.advanceTimersByTimeAsync(50);
+    await palette.updateComplete;
+    expect(findPaletteOption(palette, "Needle retained")).toBeUndefined();
+    expect(palette.querySelector('[role="status"]')).toBeNull();
+  });
+
   it("retains model results during a failed publication read and retries on input", async () => {
     const request = vi
       .fn()

--- a/ui/src/components/command-palette.ts
+++ b/ui/src/components/command-palette.ts
@@ -57,7 +57,7 @@ type CommandPaletteProps = {
   activeId: string | null;
   sessionItems: readonly PaletteItem[];
   catalogItems: readonly PaletteItem[];
-  modelSearchFailed: boolean;
+  modelSearchError: string | null;
   sessionSearchFailed: boolean;
   sessionSearchPartial: boolean;
   sessionSearchIncomplete: boolean;
@@ -220,10 +220,8 @@ function renderCommandPalette(props: CommandPaletteProps) {
         />
         <div id=${paletteListboxId} class="cmd-palette__results" role="listbox">
           ${
-            props.modelSearchFailed
-              ? html`<div class="cmd-palette__empty" role="status">
-                  ${t("palette.modelSearchFailed")}
-                </div>`
+            props.modelSearchError
+              ? html`<div class="cmd-palette__empty" role="status">${props.modelSearchError}</div>`
               : nothing
           }
           ${
@@ -306,7 +304,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
   @state() private activeId: string | null = null;
   @state() private sessionItems: readonly PaletteItem[] = [];
   @state() private catalogItems: readonly PaletteItem[] = [];
-  @state() private modelSearchFailed = false;
+  @state() private modelSearchError: string | null = null;
   @state() private sessionSearchFailed = false;
   @state() private sessionSearchPartial = false;
   @state() private sessionSearchIncomplete = false;
@@ -413,7 +411,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
   private clearCatalogSearch() {
     this.catalogLoad = undefined;
     this.catalogItems = [];
-    this.modelSearchFailed = false;
+    this.modelSearchError = null;
   }
 
   private ensureCatalogItems(force = false): Promise<void> {
@@ -444,7 +442,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       agentId,
       agents: () => context.agents?.ensureList?.() ?? Promise.resolve(null),
       methodAvailable: (method) => Boolean(isGatewayMethodAdvertised(snapshot, method)),
-    }).then(({ items, modelSearchFailed }) => {
+    }).then(({ items, modelRequestFailed, modelSearchError }) => {
       if (
         this.catalogLoad?.promise === promise &&
         this.context?.gateway === gateway &&
@@ -453,10 +451,10 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       ) {
         this.catalogItems = [
           ...toCommandPaletteItems(items),
-          ...(modelSearchFailed ? previousModels : []),
+          ...(modelRequestFailed ? previousModels : []),
         ];
-        this.modelSearchFailed = modelSearchFailed;
-        this.catalogLoad.loadedAt = modelSearchFailed ? 0 : Date.now();
+        this.modelSearchError = modelSearchError;
+        this.catalogLoad.loadedAt = modelRequestFailed ? 0 : Date.now();
       }
     });
     this.catalogLoad = { client, agentId, promise };
@@ -620,7 +618,7 @@ export class CommandPalette extends OpenClawLightDomContentsElement {
       query: this.query,
       activeId: this.activeId,
       sessionItems: this.sessionItems,
-      modelSearchFailed: this.modelSearchFailed,
+      modelSearchError: this.modelSearchError,
       catalogItems: [
         ...toCommandPaletteItems(
           getStaticCommandPaletteCatalogItems(

--- a/ui/src/e2e/command-palette-catalog.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/command-palette-catalog.real-gateway.e2e.test.ts
@@ -42,9 +42,9 @@ const suite = createControlUiE2eSuite({
     });
     const closeProvider = async () => {
       provider.closeAllConnections();
-      await new Promise<void>((resolve, reject) =>
-        provider.close((error) => (error ? reject(error) : resolve())),
-      );
+      await new Promise<void>((resolve, reject) => {
+        provider.close((error) => (error ? reject(error) : resolve()));
+      });
     };
     provider.listen(0, "127.0.0.1");
     await once(provider, "listening");

--- a/ui/src/e2e/command-palette-catalog.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/command-palette-catalog.real-gateway.e2e.test.ts
@@ -1,4 +1,6 @@
+import { once } from "node:events";
 import fs from "node:fs/promises";
+import http from "node:http";
 import path from "node:path";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { expect, it } from "vitest";
@@ -6,6 +8,7 @@ import {
   createOpenClawTestInstance,
   type OpenClawTestInstance,
 } from "../../../test/helpers/openclaw-test-instance.ts";
+import { runQaGatewayFixture } from "../../../test/helpers/qa-gateway-cleanup.ts";
 import { waitForControlUiGatewayReady } from "../test-helpers/control-ui-e2e-readiness.ts";
 import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
 
@@ -15,47 +18,188 @@ const models = (id: string) => [
   { id, name: id },
 ];
 let instance: OpenClawTestInstance;
+let providerMode: "ready" | "failed" | "empty" = "ready";
+const providerTraffic: Array<{ path: string; status: number }> = [];
 const suite = createControlUiE2eSuite({
   name: "Command Palette catalog publication with a real Gateway",
   startServerBeforeBrowser: true,
   async startServer() {
-    instance = await createOpenClawTestInstance({
-      name: "palette-catalog-publication",
-      env: { OPENCLAW_TEST_MINIMAL_GATEWAY: undefined, VITEST: undefined },
-      config: {
-        gateway: { controlUi: { enabled: true } },
-        cron: { enabled: false },
-        agents: {
-          ownership: "explicit",
-          defaults: { model: "fixture/anchor" },
-          list: [
-            { id: "main", identity: { name: "Main fixture" } },
-            { id: "reviewer", identity: { name: "Reviewer fixture" } },
-          ],
-        },
-        models: {
-          providers: {
-            fixture: {
-              api: "openai-completions",
-              apiKey: "synthetic-catalog-key",
-              baseUrl: "http://127.0.0.1:9/v1",
-              models: models("palette-retiring"),
+    const provider = http.createServer((req, res) => {
+      const status = providerMode === "failed" ? 503 : 200;
+      providerTraffic.push({ path: req.url ?? "", status });
+      const body =
+        status === 503
+          ? { error: "private upstream error body" }
+          : req.url === "/api/tags"
+            ? { models: providerMode === "empty" ? [] : [{ name: "refresh-fixture:latest" }] }
+            : {
+                capabilities: ["completion", "tools"],
+                model_info: { "llama.context_length": 8192 },
+              };
+      req.resume();
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(JSON.stringify(body));
+    });
+    const closeProvider = async () => {
+      provider.closeAllConnections();
+      await new Promise<void>((resolve, reject) =>
+        provider.close((error) => (error ? reject(error) : resolve())),
+      );
+    };
+    provider.listen(0, "127.0.0.1");
+    await once(provider, "listening");
+    const address = provider.address();
+    if (!address || typeof address === "string") {
+      throw new Error("Ollama fixture did not bind a TCP port");
+    }
+    try {
+      instance = await createOpenClawTestInstance({
+        name: "palette-catalog-publication",
+        env: { OPENCLAW_TEST_MINIMAL_GATEWAY: undefined, VITEST: undefined },
+        config: {
+          gateway: { controlUi: { enabled: true } },
+          cron: { enabled: false },
+          agents: {
+            ownership: "explicit",
+            defaults: {
+              model: "fixture/anchor",
+              modelPolicy: { allow: ["fixture/*", "ollama/*"] },
+            },
+            list: [
+              { id: "main", identity: { name: "Main fixture" } },
+              { id: "reviewer", identity: { name: "Reviewer fixture" } },
+            ],
+          },
+          models: {
+            providers: {
+              fixture: {
+                api: "openai-completions",
+                apiKey: "synthetic-catalog-key",
+                baseUrl: "http://127.0.0.1:9/v1",
+                models: models("palette-retiring"),
+              },
+              ollama: { api: "ollama", baseUrl: `http://127.0.0.1:${address.port}`, models: [] },
             },
           },
+          plugins: { allow: ["ollama"], entries: { ollama: { enabled: true } } },
         },
-      },
-    });
-    try {
-      await instance.startGateway();
-      return { baseUrl: `http://127.0.0.1:${instance.port}/`, close: () => instance.cleanup() };
+      });
+      try {
+        await instance.startGateway();
+        return {
+          baseUrl: `http://127.0.0.1:${instance.port}/`,
+          close: () => runQaGatewayFixture(() => instance.cleanup(), closeProvider),
+        };
+      } catch (error) {
+        await instance.cleanup();
+        throw error;
+      }
     } catch (error) {
-      await instance.cleanup();
-      throw error;
+      return await runQaGatewayFixture(async (): Promise<never> => {
+        throw error;
+      }, closeProvider);
     }
   },
 });
 
 suite.define(() => {
+  it("shows actual acquisition failures in Automations and model search without losing compatible rows", async () => {
+    const outcomes: unknown[] = [];
+    const refresh = async () => {
+      const result = await instance.cli([
+        "gateway",
+        "call",
+        "models.list",
+        "--json",
+        "--timeout",
+        "30000",
+        "--params",
+        JSON.stringify({ agentId: "main", view: "configured", refresh: true }),
+      ]);
+      expect(result.code, result.stderr).toBe(0);
+      const payload = requireRecord(JSON.parse(result.stdout));
+      outcomes.push(payload);
+      return payload;
+    };
+    const handoff = await instance.cli(["dashboard", "--json"]);
+    expect(handoff.code, handoff.stderr).toBe(0);
+    const browserUrl = requireRecord(JSON.parse(handoff.stdout)).browserUrl;
+    if (typeof browserUrl !== "string") {
+      throw new Error("Dashboard did not return a browser handoff");
+    }
+    const warning = "Some models could not be refreshed. Open Models to try again.";
+    try {
+      await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+        await page.goto(browserUrl);
+        await waitForControlUiGatewayReady(page);
+        providerMode = "ready";
+        expect((await refresh()).providerOutcomes).toContainEqual({
+          provider: "ollama",
+          status: "ready",
+        });
+        await page.goto(new URL("/automations", browserUrl).href);
+        await waitForControlUiGatewayReady(page);
+        const automations = page.locator("openclaw-cron-page");
+        await automations.waitFor({ state: "visible" });
+
+        providerMode = "failed";
+        const failed = await refresh();
+        expect(failed.providerOutcomes).toContainEqual({
+          provider: "ollama",
+          status: "unavailable",
+        });
+        expect(failed.models).toContainEqual(
+          expect.objectContaining({ provider: "ollama", id: "refresh-fixture:latest" }),
+        );
+        expect(JSON.stringify(failed)).not.toContain("private upstream error body");
+        await automations.getByText(warning, { exact: true }).waitFor({ state: "visible" });
+        await page.keyboard.press("Control+K");
+        await page.locator(".cmd-palette__input").fill("refresh-fixture");
+        const model = page.getByRole("option", {
+          name: "refresh-fixture:latest ollama",
+          exact: true,
+        });
+        await model.waitFor({ state: "visible" });
+        expect(await model.count()).toBe(1);
+        await page
+          .locator(".cmd-palette")
+          .getByText(warning, { exact: true })
+          .waitFor({ state: "visible" });
+        await page.screenshot({ path: path.join(suite.artifactDir, "acquisition-failed.png") });
+
+        providerMode = "empty";
+        expect((await refresh()).providerOutcomes).toContainEqual({
+          provider: "ollama",
+          status: "ready",
+        });
+        await model.waitFor({ state: "hidden" });
+        await automations.getByText(warning, { exact: true }).waitFor({ state: "hidden" });
+        await page
+          .locator(".cmd-palette")
+          .getByText(warning, { exact: true })
+          .waitFor({ state: "hidden" });
+        await page.screenshot({ path: path.join(suite.artifactDir, "acquisition-empty.png") });
+        console.log(
+          "catalog-refresh-consumer-proof",
+          JSON.stringify({
+            providerTraffic,
+            outcomes,
+            automationsWarning: true,
+            paletteWarning: true,
+            retainedModelCount: 1,
+            successfulEmptyClearedModelAndWarnings: true,
+          }),
+        );
+      });
+    } finally {
+      providerMode = "ready";
+      await fs.writeFile(
+        path.join(suite.artifactDir, "acquisition-outcomes.json"),
+        JSON.stringify({ providerTraffic, outcomes }, null, 2),
+      );
+    }
+  }, 120_000);
+
   it("refreshes open search after publication and retains results through a failed read", async () => {
     const handoff = await instance.cli(["dashboard", "--json"]);
     expect(handoff.code).toBe(0);

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -5380,6 +5380,7 @@ export const en: TranslationMap & {
         "This model can chat, but it cannot use tools. Choose another model for files, commands, web, or media tasks.",
       loadingModels: "Loading models…",
       modelsUnavailable: "Models unavailable",
+      modelsRefreshFailed: "Some models could not be refreshed. Open Models to try again.",
       noModelsAvailable: "No models available",
       emptyModelsAction: "Manage models",
       providerModels: "{provider} models",

--- a/ui/src/pages/cron/cron-page.lifecycle.test.ts
+++ b/ui/src/pages/cron/cron-page.lifecycle.test.ts
@@ -20,6 +20,38 @@ afterEach(() => {
 });
 
 describe("CronPage lifecycle", () => {
+  it("shows a fulfilled catalog acquisition failure and clears it after publication recovers", async () => {
+    const fallback = createRequest();
+    let failed = false;
+    const client = createTestGatewayClient((method) =>
+      method === "models.list"
+        ? {
+            models: [{ provider: "ollama", id: "retained", name: "Retained model" }],
+            providerOutcomes: [{ provider: "ollama", status: failed ? "unavailable" : "ready" }],
+          }
+        : fallback(method),
+    );
+    const gateway = createGateway(client, true);
+    const page = createPage(createContext(gateway), { render: true });
+    await waitForCronPage(() => expect(page.cronModelSuggestions).toEqual(["retained"]));
+
+    failed = true;
+    gateway.emitRetiredEvent({ type: "event", event: "chat.metadata.changed", payload: {} });
+    await waitForCronPage(() =>
+      expect(page.textContent).toContain(
+        "Some models could not be refreshed. Open Models to try again.",
+      ),
+    );
+    expect(page.cronModelSuggestions).toEqual(["retained"]);
+
+    failed = false;
+    gateway.emitRetiredEvent({ type: "event", event: "chat.metadata.changed", payload: {} });
+    await waitForCronPage(() =>
+      expect(page.textContent).not.toContain("Some models could not be refreshed"),
+    );
+    expect(page.cronModelSuggestions).toEqual(["retained"]);
+  });
+
   it.each(["publication", "agent", "connection", "gateway", "detach"])(
     "rejects a retired catalog result and error after %s changes",
     async (change) => {

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -298,7 +298,11 @@ class CronPage extends OpenClawLightDomElement {
       });
       if (isCurrent()) {
         this.cronModelSuggestions = result.models.map((entry) => entry.id);
-        this.modelSuggestionsError = null;
+        this.modelSuggestionsError = result.providerOutcomes?.some(
+          (outcome) => outcome.status !== "ready",
+        )
+          ? t("chat.modelControls.modelsRefreshFailed")
+          : null;
       }
     } catch (error) {
       if (isCurrent()) {

--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -1,9 +1,29 @@
 import { describe, expect, it, vi } from "vitest";
 import { GatewayPendingRequests } from "../../../../packages/gateway-client/src/pending-request.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
+import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import { loadModelProviderCost, loadModelProvidersData, loadModelProviderUsage } from "./load.ts";
 
 describe("loadModelProvidersData", () => {
+  it("keeps failed provider outcomes from a fulfilled explicit refresh", async () => {
+    const client = createTestGatewayClient(async (method) => {
+      if (method === "models.list") {
+        return {
+          models: [{ provider: "ollama", id: "retained", name: "Retained model", available: true }],
+          providerOutcomes: [{ provider: "ollama", status: "unavailable" }],
+        };
+      }
+      return method === "models.authStatus"
+        ? { ts: 1, providers: [] }
+        : { config: {}, hash: "hash" };
+    });
+    const result = await loadModelProvidersData(client, { agentId: "main", refresh: true });
+
+    expect(result.providerOutcomes).toEqual([{ provider: "ollama", status: "unavailable" }]);
+    expect(result.models).toContainEqual(expect.objectContaining({ id: "retained" }));
+    expect(result.error).toBeNull();
+  });
+
   it("keeps full catalog discovery out of the initial page load", async () => {
     const request = vi.fn(async (method: string, _params?: unknown) => {
       switch (method) {


### PR DESCRIPTION
## What Problem This Solves

Automations and command search showed retained model choices without warning when provider refresh failed but the model-list request succeeded.

## Why This Change Was Made

Both readers now display the existing provider refresh outcome while keeping returned rows authoritative. Command search retains older rows only on request failure; a successful empty response clears them.

## User Impact

Usable retained models stay selectable with a clear warning, and successful recovery or empty acquisition clears stale warnings and choices.

## Evidence

A real Gateway with a controlled endpoint exercised success, HTTP 503, retained rows, and recovery. Missing-warning regressions failed before the fix; 78 focused tests passed. The real-Gateway browser test passed in CI, showing both warnings, a selectable retained model, and clearing after successful empty acquisition. The existing transport-failure browser case also passed.

Consumers: Automations and command-palette search now show partial refresh failures.
