### PR TITLE
fix(release): route Gateway load and preserve assertion ownership

### DIFF
--- a/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
+++ b/.github/workflows/openclaw-live-and-e2e-checks-reusable.yml
@@ -109,6 +109,11 @@ on:
           - beta
           - stable
           - full
+      gateway_repo_e2e_use_github_hosted_runners:
+        description: Use GitHub-hosted Gateway repo E2E when the overall hosted-runner option is enabled
+        required: false
+        default: true
+        type: boolean
       use_github_hosted_runners:
         description: Use GitHub-hosted runners where supported, including OpenWebUI
         required: false
@@ -461,6 +466,11 @@ on:
         required: false
         default: stable
         type: string
+      gateway_repo_e2e_use_github_hosted_runners:
+        description: Use GitHub-hosted Gateway repo E2E when the overall hosted-runner option is enabled
+        required: false
+        default: true
+        type: boolean
       use_github_hosted_runners:
         description: Use GitHub-hosted runners where supported, including OpenWebUI
         required: false
@@ -1083,7 +1093,7 @@ jobs:
          {"name":"Gateway 2/4","command":"pnpm test:e2e:gateway --shard=2/4"},
          {"name":"Gateway 3/4","command":"pnpm test:e2e:gateway --shard=3/4"},
          {"name":"Gateway 4/4","command":"pnpm test:e2e:gateway --shard=4/4"}]
-      use_github_hosted_runners: ${{ inputs.use_github_hosted_runners }}
+      use_github_hosted_runners: ${{ inputs.use_github_hosted_runners && inputs.gateway_repo_e2e_use_github_hosted_runners }}
       advisory: ${{ inputs.advisory }}
       allow_unreleased_changelog: ${{ inputs.allow_unreleased_changelog }}
       allow_frozen_target_scenario_omissions: ${{ inputs.allow_frozen_target_scenario_omissions }}

--- a/.github/workflows/openclaw-release-checks.yml
+++ b/.github/workflows/openclaw-release-checks.yml
@@ -1396,6 +1396,7 @@ jobs:
       live_advisory: ${{ needs.resolve_target.outputs.release_profile == 'beta' }}
       ref: ${{ needs.resolve_target.outputs.revision }}
       include_repo_e2e: true
+      gateway_repo_e2e_use_github_hosted_runners: false
       include_release_path_suites: false
       include_openwebui: false
       include_live_suites: true

--- a/docs/ci/release-validation.md
+++ b/docs/ci/release-validation.md
@@ -224,6 +224,14 @@ see [Testing updates and plugins](/help/testing-updates-plugins).
 
 Release checks call Package Acceptance with `source=artifact`, the prepared release package artifact, `suite_profile=custom`, `docker_lanes='doctor-switch update-channel-switch skill-install update-corrupt-plugin upgrade-survivor published-upgrade-survivor root-managed-vps-upgrade update-restart-auth plugins-offline plugin-update plugin-binding-command-escape'`, and `telegram_mode=mock-openai`. This keeps package migration, update, live ClawHub skill install, stale-plugin-dependency cleanup, configured-plugin install repair, offline plugin, plugin-update, and Telegram proof on the same resolved package tarball. Set `release_package_spec` on Full Release Validation or OpenClaw Release Checks after publishing a beta to run the same matrix against the shipped npm package without rebuilding; set `package_acceptance_package_spec` only when Package Acceptance needs a different package from the rest of release validation. Cross-OS release checks still cover OS-specific onboarding, installer, and platform behavior; package/update product validation should start with Package Acceptance.
 
+Upgrade-survivor assertion ownership follows the selected target's release train,
+read from its immutable package metadata after source-identity validation.
+Extended-stable targets retain their shipped scenario runner, assertions, and
+fixtures; regular targets keep the trusted scenario together, including its
+serving-turn/post-inference assertions.
+The historical baseline does not select the assertion owner. Invalid target
+versions and unsupported extended-stable correction versions fail before Docker.
+
 The `published-upgrade-survivor` Docker lane validates one published package baseline per scenario. In Package Acceptance, the resolved `package-under-test` tarball is always the candidate and `published_upgrade_survivor_baseline` selects the fallback published baseline, defaulting to `openclaw@latest`; failed-lane rerun commands preserve that baseline. Current source release checks set `published_upgrade_survivor_baselines=supported-lines` for `legacy-operator-state`: npm's current `latest`, the preceding stable version, `extended-stable` when that tag exists, and the documented oldest supported baseline `2026.6.34`. The resolver reads `npm view openclaw versions` and `npm view openclaw dist-tags` at run time, pins exact versions before fanout, and deduplicates overlapping lines. Normal current-source release checks retain `base` and add `legacy-operator-state`; release soak selects `reported-issues`, including legacy operator state and the existing issue-shaped fixtures.
 
 Expanded release qualification requires the candidate's `YYYY.M.PATCH` base version
@@ -385,6 +393,7 @@ including generated plugin assets and local build metadata, and install their
 own Chromium and sandbox prerequisites. Each group has four test slots, so long
 UI shards start together without waiting for Gateway declarations or tests.
 A failed producer blocks its own consumers; other diagnostics continue.
+
 Gateway shards retain the existing
 four fresh-process boundaries and two-worker limit. Each UI shard runs its
 bundled files with up to two workers, then its private-server, real-Gateway, and
@@ -394,9 +403,14 @@ existing 90-minute job deadline is unchanged. Local `pnpm test:e2e` still runs
 its suite commands sequentially; each UI command uses the same project policy.
 
 This removes seven builds per invocation and raises peak test concurrency from
-six to eight. Release checks use GitHub-hosted runners, so this adds no
-Blacksmith registrations there. A standalone Blacksmith invocation can register
-eleven runners: two producers and nine test jobs. Producer artifact identities
+six to eight. Release checks route the full Gateway build and four Gateway test
+shards to the existing `blacksmith-32vcpu-ubuntu-2404` profile through
+`gateway_repo_e2e_use_github_hosted_runners: false`. This uses five Blacksmith
+registrations per campaign, with at most four Gateway test runners at once;
+UI, plugin, and other live-suite routing stays unchanged. Other callers default
+the Gateway option to true and retain their overall hosted-runner choice.
+A standalone Blacksmith invocation can register eleven runners: two producers
+and nine test jobs. Producer artifact identities
 survive consumer-only retries; consumers never select an artifact by their own
 current attempt number.
 

--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -51,10 +51,40 @@ source "$HARNESS_ROOT_DIR/scripts/e2e/lib/prepublish-plugin-registry.sh"
 
 UPGRADE_SCENARIO_ARGS=()
 UPGRADE_RUNNER="$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor/run.sh"
-UPGRADE_SCENARIO_DIR="$(openclaw_resolve_frozen_target_file \
-  "$ROOT_DIR" scripts/e2e/lib/upgrade-survivor)"
-if [ -n "$UPGRADE_SCENARIO_DIR" ]; then
-  # The runner, assertions, and fixtures form one shipped scenario contract.
+UPGRADE_SCENARIO_DIR=""
+UPGRADE_TARGET_TRAIN=""
+context_status=0
+openclaw_prepare_frozen_target_context "$ROOT_DIR" || context_status=$?
+case "$context_status" in
+  0)
+    UPGRADE_TARGET_TRAIN="$(node --input-type=module - "$ROOT_DIR" "$OPENCLAW_SELECTED_SHA" "$HARNESS_ROOT_DIR/scripts/lib/release-version.mjs" <<'NODE'
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+const [root, sha, classifier] = process.argv.slice(2);
+const { parseReleaseVersion, classifyReleaseTrain } = await import(pathToFileURL(classifier).href);
+const { version } = JSON.parse(execFileSync("git", ["-C", root, "show", `${sha}:package.json`], { encoding: "utf8" }));
+const parsed = typeof version === "string" ? parseReleaseVersion(version) : null;
+if (!parsed) throw new Error("Selected upgrade target has an invalid release version.");
+const train = classifyReleaseTrain(parsed);
+if (train === "unsupported-extended-stable-correction") {
+  throw new Error("Selected extended-stable target has an unsupported correction version.");
+}
+process.stdout.write(train);
+NODE
+)"
+    ;;
+  1) ;;
+  *) exit "$context_status" ;;
+esac
+if [ "$UPGRADE_TARGET_TRAIN" = extended-stable ]; then
+  # Extended-stable retains shipped state expectations. Regular releases keep
+  # the trusted runner and its serving-turn/post-inference assertions together.
+  UPGRADE_SCENARIO_DIR="$(openclaw_resolve_frozen_target_file \
+    "$ROOT_DIR" scripts/e2e/lib/upgrade-survivor)"
+  if [ -z "$UPGRADE_SCENARIO_DIR" ]; then
+    echo "Selected extended-stable target does not provide an upgrade scenario." >&2
+    exit 2
+  fi
   UPGRADE_RUNNER="$UPGRADE_SCENARIO_DIR/run.sh"
   UPGRADE_SCENARIO_ARGS+=(
     -v "$UPGRADE_SCENARIO_DIR:/app/scripts/e2e/lib/upgrade-survivor:ro"

--- a/test/scripts/release-no-push-workflow.test.ts
+++ b/test/scripts/release-no-push-workflow.test.ts
@@ -315,6 +315,60 @@ function executeParentFilterValidation(
 }
 
 describe("release validation no-push transport", () => {
+  it("scopes release Gateway capacity to the existing repo E2E runner input", () => {
+    const live = readWorkflow(LIVE_E2E);
+    for (const entry of [live.on?.workflow_call, live.on?.workflow_dispatch]) {
+      expect(entry?.inputs?.gateway_repo_e2e_use_github_hosted_runners).toMatchObject({
+        type: "boolean",
+        default: true,
+        required: false,
+      });
+    }
+    const release = readWorkflow(RELEASE_CHECKS);
+    expect(
+      job(release, "live_repo_e2e_release_checks").with?.gateway_repo_e2e_use_github_hosted_runners,
+    ).toBe(false);
+    expect(
+      job(release, "docker_e2e_release_checks").with?.gateway_repo_e2e_use_github_hosted_runners,
+    ).toBeUndefined();
+    expect(
+      job(release, "live_repo_e2e_release_checks").with?.use_github_hosted_runners,
+    ).toBeUndefined();
+  });
+
+  it.each([
+    [true, true],
+    [true, false],
+    [false, true],
+    [false, false],
+  ])(
+    "routes Gateway capacity without changing runtime routing (hosted=%s, gatewayHosted=%s)",
+    (hosted, gatewayHosted) => {
+      const live = readWorkflow(LIVE_E2E);
+      const repo = readWorkflow(".github/workflows/openclaw-repo-e2e-reusable.yml");
+      const inputs = {
+        use_github_hosted_runners: hosted,
+        gateway_repo_e2e_use_github_hosted_runners: gatewayHosted,
+      };
+      for (const [pipeline, expected] of [
+        ["validate_repo_e2e_gateway", hosted && gatewayHosted],
+        ["validate_repo_e2e_runtime", hosted],
+      ] as const) {
+        const expression = String(job(live, pipeline).with?.use_github_hosted_runners);
+        const resolved = runInNewContext(expression.slice(3, -2), { inputs });
+        expect(resolved).toBe(expected);
+        for (const phase of ["build", "test"]) {
+          const runner = job(repo, phase)["runs-on"]!;
+          expect(
+            runInNewContext(runner.slice(3, -2), {
+              inputs: { use_github_hosted_runners: resolved },
+            }),
+          ).toBe(expected ? "ubuntu-24.04" : "blacksmith-32vcpu-ubuntu-2404");
+        }
+      }
+    },
+  );
+
   it.each([
     ["openclaw/openclaw", "hybrid", false, "blacksmith-4vcpu-ubuntu-2404"],
     ["openclaw/openclaw", "github", false, "ubuntu-24.04"],

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -24,6 +24,76 @@ import {
 
 const ASSERTIONS_PATH = "scripts/e2e/lib/upgrade-survivor/assertions.mjs";
 
+function selectFrozenUpgradeOracle(
+  root: string,
+  version: string,
+  baseline = "openclaw@2026.6.35",
+  workingVersion?: string,
+) {
+  const selectedRoot = join(root, "selected");
+  const selectedScenario = join(selectedRoot, "scripts/e2e/lib/upgrade-survivor");
+  const selectedOracle = join(selectedRoot, ASSERTIONS_PATH);
+  mkdirSync(join(selectedOracle, ".."), { recursive: true });
+  writeFileSync(join(selectedRoot, "package.json"), JSON.stringify({ version }));
+  writeFileSync(
+    selectedOracle,
+    'throw new Error("selected oracle has no serving-turn command");\n',
+  );
+  writeFileSync(join(selectedScenario, "run.sh"), "# selected scenario runner\n");
+  const git = (...args: string[]) =>
+    execFileSync("git", ["-C", selectedRoot, ...args], { encoding: "utf8" }).trim();
+  git("init", "--quiet");
+  git("add", ".");
+  git(
+    "-c",
+    "user.name=Fixture",
+    "-c",
+    "user.email=fixture@example.invalid",
+    "commit",
+    "--quiet",
+    "-m",
+    "selected release contract",
+  );
+  const selectedSha = git("rev-parse", "HEAD");
+  if (workingVersion) {
+    writeFileSync(join(selectedRoot, "package.json"), JSON.stringify({ version: workingVersion }));
+  }
+  const source = readFileSync("scripts/e2e/upgrade-survivor-docker.sh", "utf8");
+  const policy = source.slice(
+    source.indexOf("UPGRADE_SCENARIO_ARGS=()"),
+    source.indexOf("\nIMAGE_NAME="),
+  );
+  const result = spawnSync(
+    "bash",
+    [
+      "-euo",
+      "pipefail",
+      "-c",
+      `
+source "$HARNESS_ROOT_DIR/scripts/lib/frozen-target-compat.sh"
+${policy}
+printf '%s\\n' "\${UPGRADE_SCENARIO_DIR:-$HARNESS_ROOT_DIR/scripts/e2e/lib/upgrade-survivor}/assertions.mjs"
+printf '%s\\n' "$UPGRADE_RUNNER"
+printf '%s\\n' \${UPGRADE_SCENARIO_ARGS[@]+"\${UPGRADE_SCENARIO_ARGS[@]}"}
+`,
+    ],
+    {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        ROOT_DIR: selectedRoot,
+        HARNESS_ROOT_DIR: process.cwd(),
+        OPENCLAW_SELECTED_SHA: selectedSha,
+        OPENCLAW_TOOLING_SHA: "f".repeat(40),
+        OPENCLAW_ALLOW_FROZEN_TARGET_SCENARIO_OMISSIONS: "1",
+        OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC: baseline,
+      },
+    },
+  );
+  const [oracle, runner, ...mounts] = result.stdout.trim().split("\n").filter(Boolean);
+  return { result, oracle, runner, mounts, selectedOracle, selectedScenario };
+}
+
 function writeJson(path: string, value: unknown): void {
   writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
 }
@@ -906,6 +976,53 @@ function assertUpdateRunSelfUpgrade(summary: ReturnType<typeof createUpdateRunSe
 }
 
 describe("upgrade survivor assertions", () => {
+  it.each([
+    ["2026.9.3", false, "openclaw@2026.6.35", ""],
+    ["2026.9.3-beta.1", false, "openclaw@2026.6.35", ""],
+    ["2026.4.25", false, "openclaw@2026.6.35", ""],
+    ["2026.6.35", true, "openclaw@2026.9.2", ""],
+    ["2026.7.33", true, "openclaw@2026.9.2", ""],
+    ["2026.9.3", false, "openclaw@2026.6.35", "2026.6.35"],
+  ])(
+    "selects upgrade assertion ownership from immutable target %s",
+    (version, selected, baseline, workingVersion) => {
+      const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-oracle-"));
+      try {
+        const proof = selectFrozenUpgradeOracle(root, version, baseline, workingVersion);
+        expect(proof.result.status, proof.result.stderr).toBe(0);
+        expect(proof.oracle).toBe(
+          selected ? proof.selectedOracle : join(process.cwd(), ASSERTIONS_PATH),
+        );
+        expect(proof.runner).toBe(
+          join(
+            selected
+              ? proof.selectedScenario
+              : join(process.cwd(), "scripts/e2e/lib/upgrade-survivor"),
+            "run.sh",
+          ),
+        );
+        expect(proof.mounts).toEqual(
+          selected
+            ? ["-v", `${proof.selectedScenario}:/app/scripts/e2e/lib/upgrade-survivor:ro`]
+            : [],
+        );
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    },
+  );
+
+  it.each(["invalid", "2026.6.35-1"])("rejects invalid frozen target train %s", (version) => {
+    const root = mkdtempSync(join(tmpdir(), "openclaw-upgrade-invalid-oracle-"));
+    try {
+      const proof = selectFrozenUpgradeOracle(root, version);
+      expect(proof.result.status).not.toBe(0);
+      expect(proof.oracle).toBeUndefined();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
   it.each([
     {
       name: "legacy default-only doctor export",
@@ -1876,6 +1993,7 @@ process.stdout.write(sessionDir + "\\n");
 
   it.each([
     "ok",
+    "frozen-regular",
     "queued",
     "wait-timeout",
     "cli-failed",
@@ -1919,21 +2037,23 @@ process.stdout.write(JSON.stringify(result));
         { mode: 0o755 },
       );
       const receipt = join(root, "receipt.json");
-      const result = spawnSync(
-        process.execPath,
-        [ASSERTIONS_PATH, "assert-restart-serving-turn", receipt],
-        {
-          encoding: "utf8",
-          env: {
-            ...process.env,
-            PATH: `${bin}${delimiter}${process.env.PATH}`,
-            GATEWAY_AUTH_TOKEN_REF: "synthetic-serving-token",
-            PROBE_OUTCOME: outcome,
-            PROBE_MARKER_FILE: join(root, "marker"),
-          },
+      let oracle = ASSERTIONS_PATH;
+      if (outcome === "frozen-regular") {
+        const selection = selectFrozenUpgradeOracle(root, "2026.9.3");
+        expect(selection.result.status, selection.result.stderr).toBe(0);
+        oracle = selection.oracle!;
+      }
+      const result = spawnSync(process.execPath, [oracle, "assert-restart-serving-turn", receipt], {
+        encoding: "utf8",
+        env: {
+          ...process.env,
+          PATH: `${bin}${delimiter}${process.env.PATH}`,
+          GATEWAY_AUTH_TOKEN_REF: "synthetic-serving-token",
+          PROBE_OUTCOME: outcome,
+          PROBE_MARKER_FILE: join(root, "marker"),
         },
-      );
-      const succeeded = outcome === "ok" || outcome === "queued" || outcome === "wait-timeout";
+      });
+      const succeeded = ["ok", "frozen-regular", "queued", "wait-timeout"].includes(outcome);
       expect(result.status, result.stderr).toBe(succeeded ? 0 : 1);
       expect(existsSync(receipt)).toBe(succeeded);
       expect(result.stderr).not.toContain("synthetic-serving-token");


### PR DESCRIPTION
## What Problem This Solves

Resolves two release-validation problems: the Gateway worker-load case exceeds its unchanged deadline on GitHub-hosted capacity, and a blanket frozen-target assertion mount replaces the trusted runner's serving-turn oracle with an older dispatcher that does not implement it.

## Why This Change Was Made

Add a default-true Gateway-specific hosted-runner option, combined with the existing global option. Only the release caller disables it. The existing full Gateway build and four test shards use `blacksmith-32vcpu-ubuntu-2404`; other UI, plugin, and live routing is unchanged. This moves five existing registrations per campaign, with at most four Gateway test runners, without adding jobs or changing workers, coverage, deadlines, or artifact identity.

Select upgrade assertion ownership from the immutable target package version through the existing release-train classifier after source validation. Extended-stable targets retain the shipped scenario directory and runner, including assertions and fixtures; regular targets retain the coherent trusted scenario. Historical baselines and dirty working-tree metadata do not choose the owner. Invalid versions and unsupported extended-stable corrections fail before Docker.

## User Impact

Release validation gets the measured capacity needed for the existing Gateway workload and preserves both regular serving-turn proof and extended-stable state contracts. Release Code and test thresholds remain unchanged.

## Evidence

- Matched diagnostic test/cohort/stages: GitHub-hosted timed out at 240.261 seconds; the existing Blacksmith profile completed the target in 67.140 seconds, including all three 12-turn waves, control latency checks, restart, and cleanup. The latter reported 8 CPUs and about 31 GiB RAM; the configured label is not a claim of 32 measured CPUs. Both overall diagnostic tails were cancelled after the target finished, so this is routing evidence, not full-cohort or release qualification.
- 220 full release/upgrade owner tests, 18 focused track/serving cases, five routing cases, and the existing repo-build workflow guard pass. The original routing and blanket-mount failures were reproduced before their fixes.
- Direct proof against the exact frozen Code checkout selects the trusted regular oracle and produces a completed, persisted synthetic serving reply. Extended-stable runner/directory mounts, baseline independence, immutable metadata, and invalid-version rejection are covered. The bounded main conflict resolution preserved the upstream whole-scenario ownership improvement and passed 18 policy/serving cases plus a fresh independent review.
- Workflow validation, scoped type/script/format checks, and final targeted lint pass. Independent P2 review is clean.
- Broad Docker-helper testing: 277 passed, two platform skips, and six unchanged macOS tar-stream fixture failures before their self-upgrade RPC checks. Those failures were recorded, not fixed or skipped; required hosted CI remains a landing gate.

No frozen release ref, validation plan, artifact, or publication surface is changed. A replacement Tooling selection and fresh qualification remain explicit release-owner actions.
