### PR TITLE
fix(agents): preserve explicit silence through block delivery

### DIFF
--- a/src/agents/embedded-agent-subscribe.stream-rendering.ts
+++ b/src/agents/embedded-agent-subscribe.stream-rendering.ts
@@ -424,6 +424,7 @@ export function createStreamRendering({
 
     // Only check committed (successful) messaging tool texts - checking pending texts
     // is risky because if the tool fails after suppression, the user gets no response
+    const assistantText = chunk;
     const normalizedChunk = normalizeTextForComparison(chunk);
     const normalizedReplaySuffix = prefixReplayCandidate
       ? normalizeTextForComparison(blockReplySuffix.trimStart())
@@ -503,6 +504,11 @@ export function createStreamRendering({
       !audioAsVoice &&
       !hasPendingFinalMedia
     ) {
+      // Presentation removes NO_REPLY, but terminal resolution still needs the
+      // authored silence to distinguish it from a genuinely empty response.
+      if (splitResult.isSilent && assistantText) {
+        pushAssistantText(assistantText, normalizedChunk);
+      }
       if (slicedPrefixReplay) {
         markBlockReplyTextHandled();
       }

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-answer-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-answer-delivery.test.ts
@@ -478,6 +478,28 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(subscription.assistantTexts).toEqual(["Final visible reply."]);
   });
 
+  it("retains a silent message_end block reply for terminal classification", async () => {
+    const onBlockReply = vi.fn();
+    const { emit, subscription } = createTextEndBlockReplyHarness({
+      onBlockReply,
+      blockReplyChunking: { minChars: 64, maxChars: 128, breakPreference: "paragraph" },
+    });
+
+    emit({ type: "message_start", message: { role: "assistant" } });
+    emitAssistantTextDelta({ emit, delta: "NO_REPLY" });
+    emit({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "NO_REPLY" }],
+      } as AssistantMessage,
+    });
+    await subscription.waitForPendingEvents();
+
+    expect(onBlockReply).not.toHaveBeenCalled();
+    expect(subscription.assistantTexts).toEqual(["NO_REPLY"]);
+  });
+
   it("does not duplicate when message_end flushes and a late text_end arrives", async () => {
     const onBlockReply = vi.fn();
     const { emit, subscription } = createTextEndBlockReplyHarness({ onBlockReply });


### PR DESCRIPTION
Closes #141556

## What Problem This Solves

A successful `NO_REPLY` can be buffered for block replies, stripped by presentation filtering, and then misclassified as an empty assistant response. Directed Slack/thread turns are retried and can emit “Agent couldn’t generate a response” despite intentional silence.

## Why This Change Was Made

Preserve the parser’s explicit-silence evidence in `assistantTexts` at the collector boundary before the presentation layer removes `NO_REPLY`. Genuine empty, failed, timed-out, media-only, and visible turns keep their existing behavior.

## User Impact

Intentional `NO_REPLY` turns remain silent without a false retry or error notice.

## Evidence

- Added a regression test that failed before the fix (`[]` instead of `["NO_REPLY"]`).
- Final-answer delivery: 20/20 passed.
- Terminal resolution: 48/48 passed.
- Payloads: 51/51 passed.
- Reply dispatch: 132/132 passed.
- `check:changed` passed.
- `git diff --check` passed.