### PR TITLE
fix: keep recursive Code Mode cells recoverable

### DIFF
--- a/src/agents/code-mode-worker-lifecycle.test.ts
+++ b/src/agents/code-mode-worker-lifecycle.test.ts
@@ -338,6 +338,56 @@ describe("Code Mode worker lifecycle", () => {
   });
 
   it.each(["exec", "resume"] as const)(
+    "bounds recursive guest execution after %s VM creation",
+    async (kind) => {
+      const config = resolveCodeModeConfig({ tools: { codeMode: true } } as never);
+      const recursion = "function recurse() { return recurse(); } return recurse();";
+      let input: Parameters<typeof runCodeModeWorker>[0] = {
+        kind: "exec",
+        source: recursion,
+        config,
+        catalog: [],
+      };
+      if (kind === "resume") {
+        const suspended = await runCodeModeWorker(
+          {
+            kind: "exec",
+            source: `await yield_control(); ${recursion}`,
+            config,
+            catalog: [],
+          },
+          10_000,
+        );
+        expect(suspended.status).toBe("waiting");
+        if (suspended.status !== "waiting") {
+          throw new Error("expected a suspended guest before recursive execution");
+        }
+        input = {
+          kind,
+          snapshot: suspended.snapshot,
+          config,
+          settledRequests: suspended.pendingRequests.map(({ id }) => ({
+            id,
+            ok: true,
+            json: "null",
+          })),
+        };
+      }
+
+      const result = await runCodeModeWorker(input, 10_000);
+      expect(result).toMatchObject({
+        status: "failed",
+        code: "internal_error",
+        error: expect.stringContaining("RangeError: Maximum call stack size exceeded"),
+        failurePhase: "guest",
+      });
+      if (result.status === "failed") {
+        expect(result.error).not.toContain("memory access out of bounds");
+      }
+    },
+  );
+
+  it.each(["exec", "resume"] as const)(
     "terminates a real CPU-active %s worker when its catalog closes",
     async (phase) => {
       // Finish hooks unwind in reverse order: stop workers before restoring their

--- a/src/agents/code-mode.worker.ts
+++ b/src/agents/code-mode.worker.ts
@@ -2,7 +2,14 @@
  * QuickJS worker for Code Mode guest execution and suspended VM snapshots.
  */
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
-import { EvalFlags, JSException, QuickJS, type JSValueHandle, type Snapshot } from "quickjs-wasi";
+import {
+  EvalFlags,
+  JSException,
+  MAX_STACK_SIZE,
+  QuickJS,
+  type JSValueHandle,
+  type Snapshot,
+} from "quickjs-wasi";
 import { serveWorkerTasks, type WorkerTaskChannel } from "../infra/worker-task-pool.js";
 import { CODE_MODE_CONTROLLER_SOURCE } from "./code-mode-controller-source.js";
 import {
@@ -197,6 +204,7 @@ async function createVm(input: CodeModeWorkerPayload, bridge: BridgeState): Prom
     // on restore so retained encoder/decoder instances keep their native methods.
     extensions: input.wasmExtensions,
     memoryLimit: input.config.memoryLimitBytes,
+    maxStackSize: MAX_STACK_SIZE,
     timezoneOffset: 0,
     onUnhandledRejection: trackPromiseRejection,
     interruptHandler: () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where recursively authored Code Mode cells could trap the QuickJS WASM runtime with `memory access out of bounds` instead of returning a normal failed-cell result.

## Why This Change Was Made

Pass the `quickjs-wasi` exported `MAX_STACK_SIZE` into the canonical VM options shared by fresh creation and snapshot restoration. This keeps both execution paths on the dependency's supported recursion bound.

## User Impact

Recursive guest code now fails visibly with `RangeError: Maximum call stack size exceeded`, allowing the normal Code Mode recovery loop to continue instead of surfacing a low-level WASM trap.

## Evidence

- pre-fix fresh-exec and resumed-snapshot cases both failed with `WebAssembly.RuntimeError: memory access out of bounds`
- post-fix lifecycle suite: 24/24 passed, including both recursion cases
- changed-file lint, typecheck, dead-code, formatting, and repository guards passed on the implementation base
- exact-head GitHub CI will rerun the clean checkout because the shared local worktree install currently has a stale Vitest 4/5 mismatch
- production delta: +9/-1; regression tests: +50
