### PR TITLE
test(qa): align plugin lifecycle maturity proofs

### DIFF
--- a/extensions/qa-lab/src/scenario-catalog.openai-live.test.ts
+++ b/extensions/qa-lab/src/scenario-catalog.openai-live.test.ts
@@ -148,6 +148,7 @@ describe("qa scenario catalog", () => {
     expect(config?.requiredProvider).toBe("openai");
     expect(config?.pluginSpec).toBe("npm:@openclaw/kitchen-sink@latest");
     expect(JSON.stringify(scenario.execution.flow)).toContain('"--force"');
+    expect(JSON.stringify(scenario.execution.flow)).toContain('"--accept-capabilities"');
     expect(config?.pluginId).toBe("openclaw-kitchen-sink-fixture");
     expect(config?.pluginPersonality).toBe("conformance");
     expect(config?.adversarialPersonality).toBe("adversarial");

--- a/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
+++ b/qa/scenarios/plugins/kitchen-sink-live-openai.yaml
@@ -125,6 +125,7 @@ flow:
               - install
               - expr: config.pluginSpec
               - --force
+              - --accept-capabilities
             - timeoutMs: 180000
         - call: runQaCli
           args:

--- a/scripts/e2e/lib/release-plugin-marketplace/scenario.sh
+++ b/scripts/e2e/lib/release-plugin-marketplace/scenario.sh
@@ -138,7 +138,7 @@ openclaw plugins uninstall release-marketplace-plugin --force >/tmp/openclaw-rel
 node "$marketplace_assertions" \
   assert-update-log \
   /tmp/openclaw-release-plugin-marketplace-uninstall.log \
-  "Removed: config entry, install record, allowlist entry, denylist entry, load path, directory."
+  "Removed: plugin settings, install record, allowlist entry, denylist entry, load path, directory."
 if openclaw release-market ping >/tmp/openclaw-release-plugin-marketplace-cli-after-uninstall.log 2>&1; then
   echo "release-market CLI should be gone after uninstall" >&2
   exit 1

--- a/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
+++ b/test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts
@@ -768,24 +768,14 @@ async function runPluginLifecycleMatrix() {
       `failed to remove plugin code before missing-code uninstall: ${installedPath}`,
     );
 
-    let missingCodeUninstallFailed = false;
-    try {
-      await runMeasured(
-        summaryTsv,
-        "missing-code-uninstall",
-        "node",
-        [entry, "plugins", "uninstall", pluginId, "--force"],
-        runEnv,
-      );
-    } catch {
-      missingCodeUninstallFailed = true;
-    }
-    assertProbe(
-      missingCodeUninstallFailed,
-      "missing-code uninstall must fail closed without authoritative child metadata",
+    await runMeasured(
+      summaryTsv,
+      "missing-code-uninstall",
+      "node",
+      [entry, "plugins", "uninstall", pluginId, "--force"],
+      runEnv,
     );
-    assertProbe(recordFor(pluginId, runEnv), "missing-code uninstall removed the install record");
-    assertEnabled(pluginId, true, runEnv);
+    assertUninstalled(pluginId, runEnv);
 
     await runMeasured(
       summaryTsv,


### PR DESCRIPTION
## Summary

- accept capability consent when installing the kitchen-sink QA plugin
- align marketplace removal proof with the current `plugin settings` output
- verify successful recovery of orphaned plugin installs instead of expecting uninstall to fail

## Root cause

Three maturity scenarios asserted superseded plugin contracts after capability consent and orphan-install recovery were hardened in production.

## Maturity failures addressed

- `plugin-lifecycle-probe`
- `clawhub-marketplace-list`
- `kitchen-sink-live-openai`

## Testing

- `node scripts/run-vitest.mjs extensions/qa-lab/src/scenario-catalog.openai-live.test.ts` (5 passed)
- `pnpm format:check -- extensions/qa-lab/src/scenario-catalog.openai-live.test.ts qa/scenarios/plugins/kitchen-sink-live-openai.yaml scripts/e2e/lib/release-plugin-marketplace/scenario.sh test/e2e/qa-lab/plugins/plugin-lifecycle-probe-runtime.ts`
- `git diff --check`
- autoreview P0-P2: scoped clean
- Docker/live-service scenarios require hosted QA and were not run locally

## Worked on by

- @RomneyDa