### PR TITLE
ci(qa): prepare sandbox image for maturity shards

### DIFF
--- a/.github/workflows/qa-profile-evidence.yml
+++ b/.github/workflows/qa-profile-evidence.yml
@@ -621,6 +621,19 @@ jobs:
           [[ -f "$playwright_script" ]] || playwright_script="scripts/ensure-playwright-chromium.mjs"
           node --import tsx "$playwright_script"
 
+      - name: Prepare Docker sandbox image when selected
+        env:
+          SCENARIO_IDS_JSON: ${{ toJSON(matrix.scenarioIds) }}
+        working-directory: selected
+        run: |
+          set -euo pipefail
+          if jq -e '
+            index("openclaw-sandbox-workspace-isolation") != null or
+            index("agent-sandboxed-exec-behavior") != null
+          ' <<<"$SCENARIO_IDS_JSON" >/dev/null; then
+            scripts/sandbox-setup.sh
+          fi
+
       - name: Run QA profile shard
         id: run_profile
         env:

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -16045,6 +16045,25 @@ printf '%s\n' "\${CURL_SUCCESS_IP:-203.0.113.7}"
     );
     expect(ensurePlaywrightStep.run).toContain("scripts/ensure-playwright-chromium.mts");
     expect(ensurePlaywrightStep.run).toContain("scripts/ensure-playwright-chromium.mjs");
+    const prepareSandboxStep = expectDefined(
+      qaShardJob.steps.find(
+        (step: WorkflowStep) => step.name === "Prepare Docker sandbox image when selected",
+      ),
+      "QA sandbox image preparation",
+    );
+    expect(prepareSandboxStep["working-directory"]).toBe("selected");
+    expect(prepareSandboxStep.env?.SCENARIO_IDS_JSON).toBe("${{ toJSON(matrix.scenarioIds) }}");
+    expect(prepareSandboxStep.run).toBe(`set -euo pipefail
+if jq -e '
+  index("openclaw-sandbox-workspace-isolation") != null or
+  index("agent-sandboxed-exec-behavior") != null
+' <<<"$SCENARIO_IDS_JSON" >/dev/null; then
+  scripts/sandbox-setup.sh
+fi
+`);
+    expect(qaShardJob.steps.indexOf(prepareSandboxStep)).toBeLessThan(
+      qaShardJob.steps.findIndex((step: WorkflowStep) => step.name === "Run QA profile shard"),
+    );
     const runProfileStep = qaShardJob.steps.find(
       (step: WorkflowStep) => step.name === "Run QA profile shard",
     );


### PR DESCRIPTION
## Summary

- detect QA shards containing either Docker-sandbox maturity scenario
- build the standard `openclaw-sandbox:bookworm-slim` image before those shards run
- leave unrelated shards unchanged and guard the selection/ordering contract

## Root cause

The full maturity workflow ran sandbox scenarios on a fresh hosted runner without first building the image they require, so both failed during provisioning before exercising product behavior.

## Maturity failures addressed

- `openclaw-sandbox-workspace-isolation`
- `agent-sandboxed-exec-behavior`

## Testing

- `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts` (all assertions outside the subsequently strengthened check passed)
- focused final guard: `node scripts/run-vitest.mjs test/scripts/ci-workflow-guards.test.ts -t "keeps maturity scorecard generated QA evidence handoff strict"`
- `git diff --check`
- autoreview P0-P2: scoped clean
- Docker image preparation requires hosted Linux Docker and was not run locally

## Worked on by

- @RomneyDa