### PR TITLE
fix: preserve primary inheritance when editing agent fallbacks

### DIFF
--- a/docs/concepts/model-failover.md
+++ b/docs/concepts/model-failover.md
@@ -61,6 +61,12 @@ The selection source controls whether the fallback chain is allowed:
 - **Legacy session override**: older session entries may have `modelOverride` without `modelOverrideSource`. OpenClaw treats those as user overrides so an explicit old selection is not silently converted into fallback behavior.
 - **Cron payload model**: a cron job `payload.model` / `--model` is a job primary, not a user session override. It uses configured fallbacks unless the job provides `payload.fallbacks`; `payload.fallbacks: []` makes the cron run strict.
 
+An agent can override only its fallback chain with `model: { fallbacks: [...] }`
+and keep inheriting the shared primary. Setting `fallbacks: []` explicitly disables
+fallbacks without pinning that primary. In **Settings → Agents → Overview**, editing
+fallback chips preserves primary inheritance; removing every chip saves an empty
+chain instead of restoring the shared fallbacks.
+
 Outside group and channel conversations, OpenClaw sends a visible notice when a turn moves onto fallback and another notice when a later turn succeeds on the selected primary. Group and channel conversations keep the same fallback state and lifecycle events without posting these notices. Persisted notice state prevents repeated notices when consecutive turns use the same selected/active pair, while model selection itself remains unchanged.
 
 ## Auth failure skip cache

--- a/ui/src/pages/agents/model-config.test.ts
+++ b/ui/src/pages/agents/model-config.test.ts
@@ -61,52 +61,130 @@ describe("agent model config", () => {
     runtimeConfig.dispose();
   });
 
-  it("stages fallbacks without a primary when no model is authored anywhere", async () => {
-    // Fully implicit default model: typing a fallback chip must stage the
-    // { fallbacks }-only shape the gateway honors, not silently no-op.
+  it.each([
+    { name: "an implicit primary", model: undefined },
+    { name: "a shared string primary", model: "openai/gpt-5.4" },
+    {
+      name: "a shared object primary",
+      model: { primary: "openai/gpt-5.4", fallbacks: ["google/gemini-3-pro"] },
+    },
+  ])("preserves $name when editing fallbacks", async ({ model }) => {
+    const defaults = model === undefined ? {} : { model };
     const runtimeConfig = createRuntimeConfig({
-      agents: { entries: { main: { default: true } } },
+      agents: { defaults, entries: { main: { default: true } } },
     });
     await runtimeConfig.ensureLoaded();
 
-    stageAgentModelFallbacks(runtimeConfig, "main", ["openai/gpt-5.4"]);
+    stageAgentModelFallbacks(runtimeConfig, "main", [
+      "google/gemini-3-pro",
+      "anthropic/claude-sonnet-4-6",
+    ]);
 
     expect(runtimeConfig.state.configForm).toEqual({
       agents: {
-        entries: {
-          main: { default: true, model: { fallbacks: ["openai/gpt-5.4"] } },
-        },
-      },
-    });
-    runtimeConfig.dispose();
-  });
-
-  it("keeps authored fallbacks when the primary model is cleared", async () => {
-    const runtimeConfig = createRuntimeConfig({
-      agents: {
-        defaults: { model: { primary: "openai/gpt-5.4" } },
+        defaults,
         entries: {
           main: {
             default: true,
-            model: { primary: "anthropic/claude-sonnet-4-6", fallbacks: ["openai/gpt-5.4"] },
+            model: { fallbacks: ["google/gemini-3-pro", "anthropic/claude-sonnet-4-6"] },
           },
         },
       },
     });
-    await runtimeConfig.ensureLoaded();
+    runtimeConfig.dispose();
+  });
 
-    stageAgentPrimaryModel(runtimeConfig, "main", null);
+  it.each([
+    {
+      name: "an inherited primary",
+      defaultModel: { primary: "openai/gpt-5.4", fallbacks: ["google/gemini-3-pro"] },
+      model: { fallbacks: ["anthropic/claude-sonnet-4-6"] },
+      expectedModel: { fallbacks: [] },
+    },
+    {
+      name: "an implicit primary",
+      defaultModel: { fallbacks: ["google/gemini-3-pro"] },
+      model: { fallbacks: ["anthropic/claude-sonnet-4-6"] },
+      expectedModel: { fallbacks: [] },
+    },
+    {
+      name: "an authored primary",
+      defaultModel: { primary: "google/gemini-3-pro" },
+      model: { primary: "openai/gpt-5.4", fallbacks: ["anthropic/claude-sonnet-4-6"] },
+      expectedModel: { primary: "openai/gpt-5.4", fallbacks: [] },
+    },
+  ])(
+    "keeps an explicitly cleared fallback chain with $name",
+    async ({ defaultModel, model, expectedModel }) => {
+      const defaults = { model: defaultModel };
+      const otherAgent = { model: "google/gemini-3-pro" };
+      const runtimeConfig = createRuntimeConfig({
+        agents: {
+          defaults,
+          entries: { main: { default: true, name: "Main", model }, other: otherAgent },
+        },
+      });
+      await runtimeConfig.ensureLoaded();
+
+      stageAgentModelFallbacks(runtimeConfig, "main", []);
+
+      expect(runtimeConfig.state.configForm).toEqual({
+        agents: {
+          defaults,
+          entries: {
+            main: { default: true, name: "Main", model: expectedModel },
+            other: otherAgent,
+          },
+        },
+      });
+      runtimeConfig.dispose();
+    },
+  );
+
+  it("creates an empty override for an implicit agent only after an explicit clear", async () => {
+    const defaults = { model: { fallbacks: ["google/gemini-3-pro"] } };
+    const runtimeConfig = createRuntimeConfig({ agents: { defaults } });
+    await runtimeConfig.ensureLoaded();
+    expect(runtimeConfig.state.configForm).toEqual({ agents: { defaults } });
+    expect(runtimeConfig.state.configFormDirty).toBe(false);
+
+    stageAgentModelFallbacks(runtimeConfig, "main", []);
 
     expect(runtimeConfig.state.configForm).toEqual({
-      agents: {
-        defaults: { model: { primary: "openai/gpt-5.4" } },
-        entries: {
-          main: { default: true, model: { fallbacks: ["openai/gpt-5.4"] } },
-        },
-      },
+      agents: { defaults, entries: { main: { model: { fallbacks: [] } } } },
     });
     runtimeConfig.dispose();
   });
+
+  it.each([{ fallbacks: ["openai/gpt-5.4"] }, { fallbacks: [] }])(
+    "keeps authored fallbacks $fallbacks when the primary model is cleared",
+    async ({ fallbacks }) => {
+      const runtimeConfig = createRuntimeConfig({
+        agents: {
+          defaults: { model: { primary: "openai/gpt-5.4" } },
+          entries: {
+            main: {
+              default: true,
+              model: { primary: "anthropic/claude-sonnet-4-6", fallbacks },
+            },
+          },
+        },
+      });
+      await runtimeConfig.ensureLoaded();
+
+      stageAgentPrimaryModel(runtimeConfig, "main", null);
+
+      expect(runtimeConfig.state.configForm).toEqual({
+        agents: {
+          defaults: { model: { primary: "openai/gpt-5.4" } },
+          entries: {
+            main: { default: true, model: { fallbacks } },
+          },
+        },
+      });
+      runtimeConfig.dispose();
+    },
+  );
 
   it("still removes the model node when clearing a primary with no fallbacks", async () => {
     const runtimeConfig = createRuntimeConfig({

--- a/ui/src/pages/agents/model-config.ts
+++ b/ui/src/pages/agents/model-config.ts
@@ -2,15 +2,7 @@ import { normalizeStringEntries } from "@openclaw/normalization-core/string-norm
 // Agent model selection staged against the runtime config form, split out of
 // agents-page.ts to keep that page inside the TS LOC ratchet.
 import type { ApplicationContext } from "../../app/context.ts";
-import {
-  resolveAgentConfig,
-  resolveEffectiveModelFallbacks,
-  resolveModelPrimary,
-} from "../../lib/agents/display.ts";
-import {
-  currentConfigObject,
-  type AgentConfigEntryTarget,
-} from "../../lib/config/config-state-model.ts";
+import type { AgentConfigEntryTarget } from "../../lib/config/config-state-model.ts";
 
 type RuntimeConfig = ApplicationContext["runtimeConfig"];
 
@@ -75,29 +67,21 @@ export function stageAgentPrimaryModel(
   stageModelShape(runtimeConfig, entry.path, modelId, existingModelParts(entry.existing).fallbacks);
 }
 
-/** Stage fallback-list edits, preserving the effective primary model shape. */
+/** Stage an explicit fallback chain without changing primary inheritance. */
 export function stageAgentModelFallbacks(
   runtimeConfig: RuntimeConfig,
   agentId: string,
   fallbacks: string[],
 ) {
-  const config = currentConfigObject(runtimeConfig.state);
-  const normalized = normalizeStringEntries(fallbacks);
-  const resolved = resolveAgentConfig(config, agentId);
-  const effective = resolveEffectiveModelFallbacks(resolved.entry?.model, resolved.defaults?.model);
-  const existingTarget = runtimeConfig.agentEntry(agentId);
-  const mustWrite = normalized.length > 0 || (effective?.length ?? 0) > 0 || existingTarget;
-  const target = mustWrite
-    ? (existingTarget ?? runtimeConfig.agentEntry(agentId, { ensure: true }))
-    : null;
+  const target = runtimeConfig.agentEntry(agentId, { ensure: true });
   if (!target) {
     return;
   }
   const entry = modelEntry(target);
-  const primary =
-    existingModelParts(entry.existing).primary ??
-    resolveModelPrimary(resolved.entry?.model) ??
-    resolveModelPrimary(resolved.defaults?.model) ??
-    null;
-  stageModelShape(runtimeConfig, entry.path, primary, normalized.length > 0 ? normalized : null);
+  stageModelShape(
+    runtimeConfig,
+    entry.path,
+    existingModelParts(entry.existing).primary,
+    normalizeStringEntries(fallbacks),
+  );
 }


### PR DESCRIPTION
Related: #137410

## What Problem This Solves

Fixes an issue where users editing an agent’s fallback models in Settings → Agents → Overview would also pin its inherited primary. Removing the last fallback could restore shared fallbacks when no primary was explicitly configured.

## Why This Change Was Made

Fallback edits now preserve the agent’s existing primary choice and save an explicit array, including an empty chain. The change uses the existing fallback-only model shape and leaves shared defaults and other agents intact.

## User Impact

Agents keep following changes to their shared primary after fallback edits. Clearing every fallback disables the chain, including for agents that use an implicit primary.

## Evidence

- All 11 focused writer tests pass. The original owner fails the inherited-primary and explicit-empty regression cases.
- Built Control UI at `609ca7ae74533c537145af01af37e10648d60e72` with the maintained stateful mock Gateway: adding B saves only `[A, B]` and follows shared Q after a page reload; clearing the final fallback saves `[]` and stays empty after config reload. Each edit sends one `config.set`, with defaults and unrelated agent metadata preserved.
- Remote formatting, lint, UI types, assertion/line ratchets, and MDX pass. [CI and required aggregate](https://github.com/openclaw/openclaw/actions/runs/34198332549) pass on the same head.

## Visual evidence

| View | Before | After |
| --- | --- | --- |
| Inherited primary survives fallback edits | ![Original behavior after the same edit and reload](https://github.com/user-attachments/assets/49b7737e-f5e6-428b-b5c7-30a24baa8de4) | ![Corrected writer behavior after the same edit and reload](https://github.com/user-attachments/assets/2794d972-2bb2-4bab-9d24-bc12a53a61a3) |
| Explicit empty fallback list survives reload | ![Original behavior after the same edit and reload](https://github.com/user-attachments/assets/bbd048fc-a93c-4515-a934-c64c1dfdc4e0) | ![Corrected writer behavior after the same edit and reload](https://github.com/user-attachments/assets/1f0bbc38-319b-479d-88d5-b70712dcdf9d) |

### Exact-head fallback inheritance and explicit-empty interactions

https://github.com/user-attachments/assets/d4580016-2040-44b9-a78e-f212f3d51798

### Visual verification

- Baseline: f310ecc64128e33b3ace61e5a66f20ad8414be1f
- Exact head: `609ca7ae74533c537145af01af37e10648d60e72`
- Scenario: Add B to an inherited P+A chain, change the shared primary to Q and reload the page; then clear the last fallback with no authored primary and reload config.
- Runtime/build: Node v24.19.0; Chromium 144.0.7559.0; UI index SHA256 686e8b37e7a50565ad0d12ff70730ab9cc12f670bad52e3c87a15bd91caeb82c
- Writer primary ownership: Before: edits pin P. After: saved model has only fallbacks, then full page reload visibly inherits Q.
- Clearing final fallback: Before: inherited A returns. After: saved fallbacks [] remains empty after reload.
- Config writes: One config.set for each edit; unchanged defaults and unrelated agent metadata verified.
- Clean exact-head source and unchanged reused UI bundle hashes verified
- Equivalent baseline and fixed fixtures at 1440x1000, dark theme, en-US
- Actual stateful mock config.set payload plus config/raw readback asserted
- Source recordings retained; input cues do not cover controls
- In-place WaSelect label caching reproduced without edits on both base and fixed; full page reload verified with Q retained in mock config/raw
- Lead inspected all four original-resolution screenshots and the complete 27.16-second decoded recording sequence; synthetic fixtures only, with readable controls and input cues.
