### PR TITLE
test(qa): remove selected auth through gateway

### DIFF
--- a/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
@@ -466,9 +466,17 @@ describe("Codex auth product proof", () => {
         // A metadata patch alone does not prove the selected profile reaches native execution.
         await runConfiguredTurn("qa-codex-profile-binding-pinned");
 
-        await instance.state.writeAuthProfiles({ version: 1, profiles: {} });
-        // Publish this offline write through the supported activation boundary before the next turn.
-        await expect(client.request("secrets.reload", {})).resolves.toMatchObject({ ok: true });
+        await expect(
+          client.request("models.authLogout", {
+            provider: "openai",
+            agentId: "main",
+            profileIds: [MISSING_PROFILE_ID],
+          }),
+        ).resolves.toEqual({
+          provider: "openai",
+          removedProfiles: [MISSING_PROFILE_ID],
+          abortedRunIds: [],
+        });
         await fs.writeFile(requestLog, "", "utf8");
         events.length = 0;
         await client.request("sessions.messages.subscribe", { key: sessionKey });


### PR DESCRIPTION
## Summary

- remove the selected Codex auth profile through `models.authLogout`
- assert the exact persisted removal and zero aborted runs
- retain all bounded recovery and no-app-server-turn assertions

## Root cause

The maturity proof edited `auth-profiles.json` offline and then called `secrets.reload`. That did not mutate the running auth owner, so its healthy snapshot remained active and the supposedly missing-profile turn correctly completed. The test now uses the supported atomic persistence/publication boundary.

## Maturity failure addressed

- `auth-profile-codex-mixed-profiles`

## Testing

- `pnpm format:check -- test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts`
- `git diff --check`
- autoreview P0-P2: scoped clean
- local E2E setup could not use the adjacent checkout because the shared dependency install violates package-boundary isolation; hosted CI owns the clean-install proof

## Worked on by

- @RomneyDa