### PR TITLE
fix(skills): watch status workspaces for hot installs

### DIFF
--- a/src/gateway/server-methods/skills.ts
+++ b/src/gateway/server-methods/skills.ts
@@ -52,6 +52,7 @@ import {
 import { installSkill } from "../../skills/lifecycle/install.js";
 import { installUploadedSkillArchive } from "../../skills/lifecycle/upload-install.js";
 import { loadWorkspaceSkills } from "../../skills/loading/workspace-skill-loader.js";
+import { ensureSkillsWatcher } from "../../skills/runtime/refresh.js";
 import { getRemoteSkillEligibility } from "../../skills/runtime/remote.js";
 import {
   collectClawHubVerdictTargets,
@@ -273,6 +274,11 @@ export const skillsHandlers: GatewayRequestHandlers = {
         return;
       }
     }
+    ensureSkillsWatcher({
+      workspaceDir: resolved.workspaceDir,
+      config: resolved.cfg,
+      agentId: resolved.agentId,
+    });
     const report = buildRemoteAwareWorkspaceSkillStatus(
       resolved,
       target?.entry.skillLibrarySelections,

--- a/src/gateway/server.models-voicewake-misc.test.ts
+++ b/src/gateway/server.models-voicewake-misc.test.ts
@@ -713,6 +713,26 @@ describe("gateway server models + voicewake", () => {
           agentId: "ops",
           workspaceDir: path.join(workspaceRoot, "ops-workspace"),
         });
+        const hotSkillDir = path.join(workspaceRoot, "ops-workspace", "skills", "hot-status");
+        await fs.mkdir(hotSkillDir, { recursive: true });
+        await fs.writeFile(
+          path.join(hotSkillDir, "SKILL.md"),
+          "---\nname: hot-status\ndescription: Hot status fixture\n---\n",
+          "utf8",
+        );
+        await expect
+          .poll(
+            async () => {
+              const refreshed = await rpcReq<{
+                skills?: Array<{ name?: string; eligible?: boolean }>;
+              }>(ws, "skills.status", {});
+              return refreshed.payload?.skills?.some(
+                (skill) => skill.name === "hot-status" && skill.eligible === true,
+              );
+            },
+            { interval: 20, timeout: 5_000 },
+          )
+          .toBe(true);
         expect(memory.payload).toMatchObject({ agentId: "ops" });
         expect(health.ok, JSON.stringify(health)).toBe(true);
       } finally {

--- a/src/skills/runtime/refresh.missing-root.integration.test.ts
+++ b/src/skills/runtime/refresh.missing-root.integration.test.ts
@@ -11,6 +11,49 @@ vi.mock("../loading/plugin-skills.js", () => ({
   resolvePluginSkillRootsFromMetadata: () => [],
 }));
 
+it.each(["create", "edit"] as const)(
+  "refreshes cached skills after %s during initial watcher registration",
+  async (operation) => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "skills-scan-proof-")));
+    const workspaceDir = path.join(root, "workspace");
+    const skillDir = path.join(workspaceDir, "skills", "scan-proof");
+    const skillFile = path.join(skillDir, "SKILL.md");
+    const contents = (description: string) =>
+      `---\nname: scan-proof\ndescription: ${description}\n---\n`;
+    const { ensureSkillsWatcher, closeSkillsWatchers } = await import("./refresh.js");
+    const { loadWorkspaceSkills } = await import("../loading/workspace-skill-loader.js");
+    const options = { config: {}, agentId: "main" };
+    try {
+      await fs.mkdir(path.dirname(skillDir), { recursive: true });
+      if (operation === "edit") {
+        await fs.mkdir(skillDir, { recursive: true });
+        await fs.writeFile(skillFile, contents("Before registration"));
+      }
+      ensureSkillsWatcher({ workspaceDir, ...options });
+      const cached = loadWorkspaceSkills(workspaceDir, options);
+      expect(cached.find((entry) => entry.skill.name === "scan-proof")?.skill.description).toBe(
+        operation === "edit" ? "Before registration" : undefined,
+      );
+      // Keep the write in this turn, before native watcher registration, so
+      // refresh cannot depend on receiving a subsequent file-change event.
+      nativeFs.mkdirSync(skillDir, { recursive: true });
+      nativeFs.writeFileSync(skillFile, contents("After registration"));
+      await expect
+        .poll(
+          () =>
+            loadWorkspaceSkills(workspaceDir, options).find(
+              (entry) => entry.skill.name === "scan-proof",
+            )?.skill.description,
+          { timeout: 3_000 },
+        )
+        .toBe("After registration");
+    } finally {
+      await closeSkillsWatchers();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  },
+);
+
 it("refreshes skills created beneath an initially missing project skills root", async () => {
   const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "skills-root-proof-")));
   const workspaceDir = path.join(root, "workspace");
@@ -47,9 +90,8 @@ it("refreshes skills created beneath an initially missing project skills root", 
       });
     });
     const existingSkill = path.join(workspaceDir, "skills", "existing", "SKILL.md");
-    // Chokidar readiness can precede missing-parent registration, and parent
-    // registration does not await child watches. Observe both native watches
-    // before writing the positive control or creating the absent parents.
+    // This control covers writes after registration; the cases above cover
+    // cached discovery while the initial scan is still pending.
     await vi.waitFor(() => {
       expect(registeredPaths.has(workspaceDir)).toBe(true);
       expect(registeredPaths.has(path.dirname(existingSkill))).toBe(true);

--- a/src/skills/runtime/refresh.test.ts
+++ b/src/skills/runtime/refresh.test.ts
@@ -924,26 +924,35 @@ describe("ensureSkillsWatcher", () => {
     ]);
   });
 
-  it("fans out a shared-directory change to every subscribed workspace", async () => {
-    vi.useFakeTimers();
-    const secondWorkspace = await createFixtureDirectory("second-workspace");
-    const sharedRoot = await createFixtureDirectory("shared");
-    const config = { skills: { load: { extraDirs: [sharedRoot] } } };
-    const seen: SkillsChangeEvent[] = [];
-    refreshModule.registerSkillsChangeListener((change) => {
-      seen.push(change);
-    });
-    refreshModule.ensureSkillsWatcher({ workspaceDir: fixtureWorkspaceDir, config });
-    refreshModule.ensureSkillsWatcher({ workspaceDir: secondWorkspace, config });
-    const changedPath = path.join(sharedRoot, "demo", "SKILL.md");
-    watchForSkillRoot(sharedRoot).watcher.emit("all", "change", changedPath);
-    await vi.advanceTimersByTimeAsync(250);
+  it.each(["change", "ready"] as const)(
+    "fans out shared-directory %s to every subscribed workspace",
+    async (event) => {
+      vi.useFakeTimers();
+      const secondWorkspace = await createFixtureDirectory("second-workspace");
+      const sharedRoot = await createFixtureDirectory("shared");
+      const config = { skills: { load: { extraDirs: [sharedRoot] } } };
+      const seen: SkillsChangeEvent[] = [];
+      refreshModule.registerSkillsChangeListener((change) => {
+        seen.push(change);
+      });
+      refreshModule.ensureSkillsWatcher({ workspaceDir: fixtureWorkspaceDir, config });
+      refreshModule.ensureSkillsWatcher({ workspaceDir: secondWorkspace, config });
+      const changedPath =
+        event === "change" ? path.join(sharedRoot, "demo", "SKILL.md") : undefined;
+      const watcher = watchForSkillRoot(sharedRoot).watcher;
+      if (event === "ready") {
+        watcher.emit("ready");
+      } else {
+        watcher.emit("all", event, changedPath);
+      }
+      await vi.advanceTimersByTimeAsync(250);
 
-    expect(seen).toEqual([
-      { workspaceDir: fixtureWorkspaceDir, reason: "watch", changedPath },
-      { workspaceDir: secondWorkspace, reason: "watch", changedPath },
-    ]);
-  });
+      expect(seen).toEqual([
+        { workspaceDir: fixtureWorkspaceDir, reason: "watch", changedPath },
+        { workspaceDir: secondWorkspace, reason: "watch", changedPath },
+      ]);
+    },
+  );
 
   it("stops fanning a shared-directory change to a workspace after it unsubscribes", async () => {
     vi.useFakeTimers();

--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -541,6 +541,9 @@ function createSkillsPathWatcher(target: WatchTarget): SkillsPathWatchState {
       .then(() => schedule(changedPath));
   };
 
+  // ignoreInitial suppresses writes discovered before native watches are ready.
+  // Reconcile snapshots read during that gap once the initial scan completes.
+  watcher.on("ready", () => schedule());
   watcher.on("all", (_event, changedPath) => {
     if (isPathInside(target.path, changedPath) || isPathInside(changedPath, target.path)) {
       schedule(changedPath);

--- a/src/skills/runtime/refresh.watcher.test-support.ts
+++ b/src/skills/runtime/refresh.watcher.test-support.ts
@@ -1,8 +1,9 @@
 import { EventEmitter } from "node:events";
 import path from "node:path";
+import type { FSWatcherEventMap } from "chokidar";
 import { expect, vi } from "vitest";
 
-type WatchEvent = "add" | "addDir" | "all" | "change" | "unlink" | "unlinkDir" | "raw" | "error";
+type WatchEvent = keyof FSWatcherEventMap;
 type WatchCallback = (...args: unknown[]) => void;
 type WatchOptions = {
   depth: number;


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users opening skill status before the first agent turn could keep seeing stale skill availability after installing or editing a workspace skill. It also closes the initialization window where a status read could cache discovery before native file watches were registered.

## Why This Change Was Made

`skills.status` establishes the existing watcher after workspace resolution and session authorization. The watcher invalidates cached discovery after its initial scan completes, using the existing debounce, snapshot version, and shared-subscriber lifecycle. This reconciles changes that Chokidar suppresses with `ignoreInitial` during registration.

The repair stays in the watcher owner. Restarting the Gateway or increasing the status-test timeout would not fix a missed invalidation. Agent ownership, watch configuration, shared watch handles, capacity handling, and shutdown behavior stay on their existing paths. No config, protocol, dependency, or persistent-store changes.

## User Impact

New and edited file-backed skills become visible on subsequent status reads without restarting the Gateway, including changes made while watching starts. Status requests remain nonblocking. This addresses `skill-install-hot-availability`.

## Evidence

Validated in a fresh worktree with its own dependency install on macOS and Node 24.16.0.

- Before the watcher-owner repair, the full Gateway file failed its new hot-status assertion once while focused and later full runs passed. A real-watcher edit-during-registration test retained the old description, and a deterministic shared-readiness test emitted no invalidations; the ordinary change control passed.
- After the repair, 86 selected tests passed, with one Windows-only case skipped. The full Gateway file passed three consecutive runs (18 tests per run), preserving its original execution order.
- Coverage includes real filesystem creation/edits during registration, initially missing roots, shared subscribers, disabled watching, native watch capacity, shutdown/lifetime, and session snapshots.
- Independent autoreview through P2: scoped clean. The complete changed-file checks passed, including core/test typechecks, lint, formatting, architecture/dead-export scans, and state/auth guards. `git diff --check` passed.

Commands:

```sh
node scripts/run-vitest.mjs src/skills/runtime/refresh.test.ts src/skills/runtime/refresh.capacity.test.ts src/skills/runtime/refresh.missing-root.integration.test.ts src/skills/runtime/refresh.windows.test.ts src/skills/runtime/session-snapshot.test.ts src/gateway/server.models-voicewake-misc.test.ts
node scripts/run-vitest.mjs src/gateway/server.models-voicewake-misc.test.ts
node scripts/check-changed.mjs -- src/gateway/server-methods/skills.ts src/gateway/server.models-voicewake-misc.test.ts src/skills/runtime/refresh.ts src/skills/runtime/refresh.test.ts src/skills/runtime/refresh.missing-root.integration.test.ts src/skills/runtime/refresh.watcher.test-support.ts
```

Production LOC: +9/-0 total, including the original six-line status wiring and three-line readiness reconciliation. Tests and test support: +95/-23, including formatting of an existing shared-subscriber case extended to cover readiness.

Direct Chokidar 5.0.0 source inspection confirmed that counted initial directory scans and native watch registration precede `ready`; the existing-prefix watch strategy avoids the normal missing-path fallback. This repair reconciles initialization, rather than claiming atomic filesystem observation or immutable library-revision refresh.

## Worked on by

- @RomneyDa
