### PR TITLE
test(qa): select compact Slack progress proof

### DIFF
--- a/extensions/qa-lab/src/live-transports/slack/slack-live.config.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.config.ts
@@ -302,6 +302,7 @@ export function buildSlackQaConfig(
                         commandText: "raw" as const,
                         label: false,
                         maxLines: 4,
+                        ...(progressOverrides.style ? { style: progressOverrides.style } : {}),
                         toolProgress: progressOverrides.toolProgress,
                         ...(progressOverrides.commentary === undefined
                           ? {}

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.contracts.ts
@@ -200,6 +200,7 @@ export type SlackQaConfigOverrides = {
   messageTool?: boolean;
   progress?: {
     commentary?: boolean;
+    style?: "compact";
     toolProgress: boolean;
     verboseDefault?: "off" | "on" | "full";
   };

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts
@@ -642,7 +642,7 @@ describe("Slack live QA runtime helpers", () => {
         ?.streaming,
     ).toEqual({ mode: "off" });
     const omitted = progressConfig("slack-progress-commentary-omitted");
-    expect(omitted).toMatchObject({ toolProgress: true });
+    expect(omitted).toMatchObject({ style: "compact", toolProgress: true });
     expect(Object.hasOwn(omitted ?? {}, "commentary")).toBe(false);
     expect(
       buildScenarioConfig("slack-progress-commentary-verbose-dedupe").agents?.defaults

--- a/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-implementations.ts
+++ b/extensions/qa-lab/src/live-transports/slack/slack-live.scenario-implementations.ts
@@ -299,7 +299,9 @@ export const slackQaProgressCommentaryFalseScenario: SlackQaScenarioImplementati
 
 export const slackQaProgressCommentaryOmittedScenario: SlackQaScenarioImplementation = {
   configOverrides: {
-    progress: { toolProgress: true },
+    // This proof inspects chat.update history for one editable text draft.
+    // Native and Block Kit cards have separate transport proofs.
+    progress: { style: "compact", toolProgress: true },
   },
   buildRun: (sutUserId) =>
     buildSlackProgressCommentaryRun(sutUserId, {


### PR DESCRIPTION
## Summary

- run the Slack omitted-commentary maturity scenario on the compact progress surface
- preserve `toolProgress: true` while making the editable draft visible in `chat.update` history
- cover the scenario-specific progress configuration in the runtime contract test

## Why

The maturity run observed commentary but could not find a history-visible tool-progress row. The default progress surface is now card-based, while this scenario explicitly proves the portable editable-text draft contract. Selecting `style: compact` keeps the scenario aligned with the surface it inspects without changing defaults for other Slack QA scenarios.

## Validation

- `pnpm vitest run extensions/qa-lab/src/live-transports/slack/slack-live.runtime.test.ts` (62 passed, before rebase)
- `pnpm prettier --check ...` (passed)
- `pnpm check:diff` (passed)
- local autoreview P0-P2: clean

Post-rebase local Vitest initialization is currently blocked by the shared checkout's dependency drift (`@vitest/browser` startup); hosted exact-head CI is authoritative.

Maturity failure: `slack-progress-commentary-omitted`
