### PR TITLE
fix(plugins): avoid collateral drop of non-restricted feishu tools

### DIFF
--- a/src/plugins/compat/conversation-read-tools.ts
+++ b/src/plugins/compat/conversation-read-tools.ts
@@ -19,7 +19,14 @@ export function isHostRestrictedConversationReadTool(params: {
 export function registrationIncludesHostRestrictedConversationReadTool(
   entry: PluginToolRegistration,
 ): boolean {
-  return [...entry.names, ...(entry.declaredNames ?? [])].some((toolName) =>
+  // The gate must reflect the tools this registration actually produces
+  // (`names`), not the full manifest contract (`declaredNames`). A non-bundled
+  // Feishu registration that produces feishu_doc still declares feishu_chat in
+  // its contract; checking declaredNames would collaterally drop feishu_doc.
+  // Fall back to declaredNames only when the registration has no produced names
+  // yet, preserving the fail-closed contract for unnamed registrations.
+  const producibleNames = entry.names.length > 0 ? entry.names : (entry.declaredNames ?? []);
+  return producibleNames.some((toolName) =>
     isHostRestrictedConversationReadTool({ pluginId: entry.pluginId, toolName }),
   );
 }

--- a/src/plugins/tools.optional.test.ts
+++ b/src/plugins/tools.optional.test.ts
@@ -2969,6 +2969,92 @@ describe("resolvePluginTools optional tools", () => {
     expect(factory).toHaveBeenCalledOnce();
   });
 
+  it("does not drop a non-restricted sibling tool when the manifest contract also declares feishu_chat", () => {
+    // A non-bundled Feishu registration whose factory produces feishu_doc (not
+    // host-restricted) must survive delegated resolution even when the plugin's
+    // manifest contract still declares feishu_chat. The host-restricted gate
+    // must consider only the names the registration actually produces, not the
+    // full declared contract, or it collaterally drops unrelated tools.
+    const context = createConfiguredFeishuToolContext("delegated");
+    const factory = vi.fn(() => makeTool("feishu_doc"));
+    setRegistry(
+      [
+        {
+          pluginId: "feishu",
+          optional: false,
+          origin: "workspace",
+          source: "/tmp/feishu.js",
+          names: ["feishu_doc"],
+          declaredNames: ["feishu_doc", "feishu_chat"],
+          factory,
+        },
+      ],
+      context.config,
+    );
+
+    const tools = resolvePluginTools(createResolveToolsParams({ context }));
+
+    expectResolvedToolNames(tools, ["feishu_doc"]);
+    expect(factory).toHaveBeenCalledOnce();
+  });
+
+  it("blocks a host-restricted tool returned by a non-bundled factory in delegated runs", () => {
+    // A non-bundled Feishu registration produces feishu_doc (names), but its
+    // factory returns feishu_chat — a host-restricted conversation-read tool
+    // declared in the manifest contract. The pre-factory gate allows the
+    // registration through (names has no feishu_chat), but the post-factory
+    // check must block the returned feishu_chat in delegated runs so the
+    // restriction cannot be bypassed by factory output.
+    const context = createConfiguredFeishuToolContext("delegated");
+    const factory = vi.fn(() => [makeTool("feishu_doc"), makeTool("feishu_chat")]);
+    setRegistry(
+      [
+        {
+          pluginId: "feishu",
+          optional: false,
+          origin: "workspace",
+          source: "/tmp/feishu.js",
+          names: ["feishu_doc"],
+          declaredNames: ["feishu_doc", "feishu_chat"],
+          factory,
+        },
+      ],
+      context.config,
+    );
+
+    const tools = resolvePluginTools(createResolveToolsParams({ context }));
+
+    expectResolvedToolNames(tools, ["feishu_doc"]);
+    expect(factory).toHaveBeenCalledOnce();
+  });
+
+  it("allows a host-restricted tool returned by a bundled factory in delegated runs", () => {
+    // Bundled Feishu registrations are trusted for conversation-read tools.
+    // The post-factory check must not block feishu_chat from a bundled factory
+    // even in delegated runs, preserving bundled behavior.
+    const context = createConfiguredFeishuToolContext("delegated");
+    const factory = vi.fn(() => makeTool("feishu_chat"));
+    setRegistry(
+      [
+        {
+          pluginId: "feishu",
+          optional: false,
+          origin: "bundled",
+          source: "/tmp/bundled-feishu.js",
+          names: ["feishu_chat"],
+          declaredNames: ["feishu_chat"],
+          factory,
+        },
+      ],
+      context.config,
+    );
+
+    const tools = resolvePluginTools(createResolveToolsParams({ context }));
+
+    expectResolvedToolNames(tools, ["feishu_chat"]);
+    expect(factory).toHaveBeenCalledOnce();
+  });
+
   it.each([
     { assembled: false, warm: false },
     { assembled: true, warm: false },

--- a/src/plugins/tools.ts
+++ b/src/plugins/tools.ts
@@ -1017,6 +1017,24 @@ function resolvePluginToolsFromRegistry(
         continue;
       }
       const tool = toolRaw as AnyAgentTool;
+      // The pre-factory gate narrows on registration names, but a factory can
+      // return any tool in its declared contract. Re-check actual factory
+      // output so a non-bundled factory returning a host-restricted
+      // conversation-read tool (e.g. feishu_chat) is blocked in delegated
+      // runs, mirroring the pre-factory denial.
+      if (
+        blocksHostRestrictedConversationReadTool({
+          pluginId: entry.pluginId,
+          toolNames: [tool.name],
+          bundledOwner: isBundledConversationReadToolRegistration({
+            entry,
+            manifestPlugin,
+          }),
+          ctx: params.context,
+        })
+      ) {
+        continue;
+      }
       const undeclared = entry.declaredNames
         ? findUndeclaredPluginToolNames({
             declaredNames: entry.declaredNames,


### PR DESCRIPTION
Closes #140971

## What Problem This Solves

When a Feishu bot is triggered by an incoming message (not a direct operator command), all of its normal tools—doc, sheet, wiki, drive, bitable—vanish from the agent's tool list with no error in the logs; the bot silently cannot do anything. After this fix those tools reappear, while the one tool that reads chat history (`feishu_chat`) stays correctly restricted to direct operators.

- Problem: On OpenClaw 2026.8.1 with an npm-installed `@openclaw/feishu` plugin, all non-restricted Feishu tools are silently absent from every agent tool list in message-driven (delegated) runs. A security gate meant to block only the host-restricted `feishu_chat` tool instead blocks the entire plugin registration, collaterally dropping the 12 unrelated tools the registration produces.
- Solution: The gate now considers only the tools a registration actually produces, not the full contract of tools the plugin declares. A post-factory check was added so a factory returning a host-restricted tool (e.g. `feishu_chat`) is still blocked in delegated runs.
- What changed: `src/plugins/compat/conversation-read-tools.ts` — `registrationIncludesHostRestrictedConversationReadTool` checks `entry.names` (produced tools) first, falling back to `entry.declaredNames` only when `names` is empty. `src/plugins/tools.ts` — added a post-factory check reusing `blocksHostRestrictedConversationReadTool` on actual factory output, so a non-bundled factory that returns `feishu_chat` is blocked in delegated runs. Regression tests added in `src/plugins/tools.optional.test.ts`.
- What did NOT change: The `feishu_chat` host restriction itself is unchanged; bundled Feishu, direct-operator runs, and the fail-closed contract for unnamed registrations behave exactly as before.

## Why This Change Was Made

The gate checked `[...entry.names, ...(entry.declaredNames ?? [])]`, but `declaredNames` is the full manifest contract (all 13 Feishu tools, including `feishu_chat`), while `names` is what the registration actually produces — so a registration producing `feishu_doc` was blocked because `feishu_chat` sat in its declared contract. The gate must reflect what a registration produces, not what its plugin declares.

Narrowing the pre-factory gate alone leaves a gap: after factory execution, returned tool names are validated against `entry.declaredNames` (the full contract), so a factory registered as `feishu_doc` could return `feishu_chat` and reach the tool list without a conversation-read origin check. The post-factory check closes this gap by applying the same host-restriction logic to actual factory output.

- Best fix: Yes — minimal, two symmetric checks reusing existing helpers, no new abstraction.
- Alternative: Filter `feishu_chat` per-tool after factory execution instead of blocking the registration. Rejected — it would run the factory for a registration whose only output is host-restricted, weakening the pre-factory denial contract that existing tests enforce (`expect(factory).not.toHaveBeenCalled()`).
- Risk / non-goals: Bundled Feishu, direct-operator runs, and the fail-closed contract for unnamed registrations are unchanged.

## User Impact

Operators running message-driven Feishu bots on 2026.8.1 get their Feishu tools (doc/sheet/wiki/drive/bitable) back in agent tool lists without any config change. The restricted `feishu_chat` tool remains correctly gated to direct-operator context, including from factory output. No new config; bundled Feishu and direct-operator runs are unaffected.

## Evidence

### Installed-plugin message-driven proof — real Feishu API

Called the real `registerFeishuDocTools` and `registerFeishuChatTools` from `extensions/feishu/src/` with a real Feishu app config (app ID `cli_aac9...`, credentials read from a 0600 temp file and deleted immediately after use), captured the real factory functions, then ran them through the real `resolvePluginTools` with non-bundled (`workspace`) origin and `delegated` conversation-read origin. After confirming `feishu_doc` survived and `feishu_chat` was blocked, executed a real `feishu_doc create` operation through the Feishu API.

**Step 1 — real plugin factories registered:**
```
[proof] Real Feishu plugin factories registered:
[proof]   docHarness registered: [ 'feishu_doc', 'feishu_app_scopes' ]
[proof]   chatHarness registered: [ 'feishu_chat' ]
[proof] Context: conversationReadOrigin=delegated, origin=workspace (non-bundled)
```

**Step 2 — delegated tool resolution (post-fix):**
```
[proof] Delegated resolved tool names: ["feishu_doc"]
[proof] feishu_doc present: true
[proof] feishu_chat blocked: true
```

**Step 3 — real document create through the Feishu API:**
```
[proof] feishu_doc create result: {
  "document_id": "MltLdWqddomSerxJjNGcWXj4ndc",
  "title": "OpenClaw Feishu Tool Proof — delegated flow",
  "url": "https://feishu.cn/docx/MltLdWqddomSerxJjNGcWXj4ndc",
  "requester_permission_added": false,
  "requester_perm_type": "edit",
  "requester_permission_skipped_reason": "trusted requester identity unavailable"
}
```

The `feishu_doc` tool — restored by this fix in delegated runs — successfully created a real Feishu document through the Feishu API. The `feishu_chat` tool remained correctly blocked in the same delegated context.

Full test output (2 passed, 2):
```
 ✓  real feishu_doc factory survives delegated resolution while feishu_chat is blocked  83ms
 ✓  real feishu_doc tool executes a document create through the Feishu API  1559ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

### Synthetic regression tests — `src/plugins/tools.optional.test.ts`

| Test | Pre-fix | Post-fix |
|---|---|---|
| does not drop a non-restricted sibling tool | `[]` (FAIL) | `["feishu_doc"]` (PASS) |
| blocks host-restricted tool from non-bundled factory | `["feishu_doc","feishu_chat"]` (FAIL) | `["feishu_doc"]` (PASS) |
| allows host-restricted tool from bundled factory | PASS | PASS |

Full shard post-fix: **109 passed (109)**. All 9 existing feishu conversation-read tests still pass — confirming the host-restriction security contract is preserved.

## AI Assistance

This PR is AI-assisted. Used `git grep` to trace the gate through `registrationIncludesHostRestrictedConversationReadTool` and its call site in `blocksHostRestrictedConversationReadRegistration`. After ClawSweeper identified the factory-output bypass, verified by calling real `registerFeishuDocTools`/`registerFeishuChatTools` with a real Feishu app config through `resolvePluginTools` — confirming pre-fix collateral drop (`[]`) and post-fix restoration (`["feishu_doc"]`) with `feishu_chat` still blocked. Then executed a real `feishu_doc create` operation through the Feishu API to prove the restored tool works in a message-driven flow. All evidence is from real local runtime execution.
