### PR TITLE
test(qa): scope Teams timeout fault to messages

### DIFF
--- a/extensions/msteams/src/qa/bot-framework-server.test.ts
+++ b/extensions/msteams/src/qa/bot-framework-server.test.ts
@@ -53,7 +53,7 @@ describe("Microsoft Teams QA Bot Framework server", () => {
     }
   });
 
-  it("models an ambiguous gateway timeout after accepting the marked activity", async () => {
+  it("models an ambiguous gateway timeout only for a marked message activity", async () => {
     const onOutbound = vi.fn(async () => {});
     const server = await startMSTeamsQaBotFrameworkServer({
       botToken: "bot-token",
@@ -61,6 +61,18 @@ describe("Microsoft Teams QA Bot Framework server", () => {
       onOutbound,
     });
     try {
+      const progressResponse = await fetch(
+        `${server.baseUrl}qa/v3/conversations/channel/activities`,
+        {
+          method: "POST",
+          headers: {
+            authorization: "Bearer bot-token",
+            "content-type": "application/json",
+            "x-openclaw-msteams-qa-nonce": "qa-nonce",
+          },
+          body: JSON.stringify({ type: "typing", text: "QA-MSTEAMS-AMBIGUOUS-504" }),
+        },
+      );
       const response = await fetch(`${server.baseUrl}qa/v3/conversations/channel/activities`, {
         method: "POST",
         headers: {
@@ -71,8 +83,9 @@ describe("Microsoft Teams QA Bot Framework server", () => {
         body: JSON.stringify({ type: "message", text: "QA-MSTEAMS-AMBIGUOUS-504" }),
       });
 
+      expect(progressResponse.status).toBe(200);
       expect(response.status).toBe(504);
-      expect(onOutbound).toHaveBeenCalledOnce();
+      expect(onOutbound).toHaveBeenCalledTimes(2);
     } finally {
       await server.close();
     }

--- a/extensions/msteams/src/qa/bot-framework-server.ts
+++ b/extensions/msteams/src/qa/bot-framework-server.ts
@@ -77,6 +77,7 @@ export async function startMSTeamsQaBotFrameworkServer(options: ServerOptions) {
       // This fixture records the accepted activity before returning 504, modeling a gateway
       // timeout whose upstream side effect cannot safely be replayed by the Teams adapter.
       const acceptedButTimedOut =
+        activity.type === "message" &&
         typeof activity.text === "string" &&
         activity.text.includes(AMBIGUOUS_GATEWAY_TIMEOUT_MARKER);
       sendJson(


### PR DESCRIPTION
## Summary

- limit the Teams accepted-504 QA fault to actual `message` activities
- let progress/typing activities that happen to echo the marker pass normally
- cover both activity types in the loopback Connector regression

## Why

The maturity scenario's marker is present in the message-tool arguments. Teams progress mode can surface those arguments through a native `typing` activity before the actual message tool dispatch. The loopback fault injector matched any activity text, so it injected 504 into the Microsoft SDK stream, whose independent retry loop produced repeated outbound events and prevented final settlement. The scenario is intended to prove OpenClaw does not replay an ambiguous non-idempotent message POST, not to fault an informative typing update.

## Validation

- `node scripts/run-vitest.mjs extensions/msteams/src/qa/bot-framework-server.test.ts` — 4 passed
- `oxfmt --check` — passed
- local autoreview P0-P2 — clean (0.98)

Maturity failure: `msteams-ambiguous-gateway-timeout`
