### PR TITLE
fix: desktop keyboard pastes local clipboard text

### DIFF
--- a/docs/gateway/cloud-sessions.md
+++ b/docs/gateway/cloud-sessions.md
@@ -73,6 +73,8 @@ If you choose a source in the Desktop picker, the panel keeps that choice when t
 
 The machine must already support desktop viewing. For cloud workers, enable the [Cloud Worker Desktop lab and desktop profile setting](/gateway/cloud-workers#desktop-interactive). Opening Desktop starts in view-only mode and does not change the machine's permissions or the agent's tool policy. The global Desktop command in the command palette still opens the machine picker, including on chat pages.
 
+To enter text from your local clipboard, take control and choose **Keyboard** before pasting with **Command+V** on macOS or **Ctrl+V** on Windows and Linux. The Keyboard field sends the pasted text to the remote desktop; shortcuts directed at the desktop canvas still operate on the remote machine. Keyboard input stays disabled until the control connection is ready.
+
 ## Desktop and computer control
 
 A desktop-enabled cloud session uses the same machine for the chat Desktop panel and the agent's `computer` tool. Enable the **Cloud Worker Desktop** lab and provision a Crabbox profile with `settings.desktop: true`. OpenClaw starts the worker's CUA provider inside the provisioned desktop session; the agent does not need to discover or choose a paired computer. Both OpenClaw and Codex sessions use this binding. A paired-device session instead uses that device's enabled Computer Control provider.

--- a/ui/src/components/desktop/desktop-client.test.ts
+++ b/ui/src/components/desktop/desktop-client.test.ts
@@ -3,6 +3,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../../test/helpers/promise.js";
 import { DesktopClient } from "./desktop-client.ts";
+import { DesktopMobileKeyboard } from "./desktop-mobile-keyboard.ts";
 
 type RfbConstructor = NonNullable<ConstructorParameters<typeof DesktopClient>[0]>;
 type RfbClient = InstanceType<RfbConstructor>;
@@ -38,6 +39,63 @@ function createFakeRfb() {
 }
 
 describe("DesktopClient", () => {
+  it.each(["blur", "reset", "replacement", "view-only"])(
+    "does not restore old keyboard modifiers after %s",
+    async (transition) => {
+      const { Rfb } = createFakeRfb();
+      const client = new DesktopClient(Rfb, (url) => new FakeSocket(url) as unknown as WebSocket);
+      const target = document.createElement("div");
+      const canvas = document.createElement("canvas");
+      target.append(canvas);
+      const connect = () =>
+        client.connect({
+          target,
+          wsUrl: "ws://control.example.test/desktop/observe",
+          viewOnly: false,
+          isCurrent: () => true,
+        });
+      const original = await connect();
+      let handle = original;
+      let controlling = true;
+      const input = document.createElement("textarea");
+      const keyboard = new DesktopMobileKeyboard({
+        connection: () => handle,
+        controlling: () => controlling,
+        input: () => input,
+      });
+      input.addEventListener("input", (event) => keyboard.handleInput(event as InputEvent));
+      const keys: string[] = [];
+      canvas.addEventListener("keydown", (event) => keys.push(event.key));
+      try {
+        keyboard.reset();
+        keyboard.handleKeyboardEvent(
+          new KeyboardEvent("keydown", {
+            key: "Control",
+            code: "ControlLeft",
+            ctrlKey: true,
+            location: 1,
+          }),
+        );
+        if (transition === "blur") {
+          window.dispatchEvent(new Event("blur"));
+        } else if (transition === "reset") {
+          keyboard.reset();
+        } else if (transition === "replacement") {
+          original.disconnect();
+          handle = await connect();
+        } else {
+          controlling = false;
+        }
+        input.value += "p";
+        input.dispatchEvent(new InputEvent("input", { inputType: "insertFromPaste", data: "p" }));
+        expect(keys).toEqual(transition === "view-only" ? ["Control"] : ["Control", "p"]);
+      } finally {
+        keyboard.reset();
+        handle.disconnect();
+      }
+    },
+  );
+
   it.each([false, true])(
     "opens a socket after the RFB loader only while the operation remains current (%s)",
     async (remainsCurrent) => {

--- a/ui/src/components/desktop/desktop-mobile-keyboard.ts
+++ b/ui/src/components/desktop/desktop-mobile-keyboard.ts
@@ -1,3 +1,4 @@
+import { isApplePlatform } from "../../lib/keyboard-shortcut-contract.ts";
 import type { DesktopConnectionHandle } from "./desktop-client.ts";
 
 /**
@@ -16,6 +17,28 @@ type MobileKeyboardOptions = {
 export class DesktopMobileKeyboard {
   /** The document view renders this so the field always holds deletable padding. */
   value = MOBILE_KEYBOARD_SENTINEL;
+  private modifierConnection: DesktopConnectionHandle | null = null;
+  private readonly modifiers = new Map<string, KeyboardEvent>();
+  private readonly clearModifiers = () => {
+    this.modifiers.clear();
+    window.removeEventListener("blur", this.clearModifiers);
+    window.removeEventListener("keyup", this.handleWindowKeyup, true);
+  };
+  private readonly handleWindowKeyup = (event: KeyboardEvent) => {
+    // noVNC stops canvas keyups from bubbling. Capture physical releases after focus moves,
+    // but ignore our synthetic forwarding and temporary paste releases.
+    if (!event.isTrusted || event.composedPath()[0] === this.options.input()) {
+      return;
+    }
+    const connection = this.currentConnection();
+    if (!connection || !this.modifiers.delete(event.code)) {
+      return;
+    }
+    if (this.modifiers.size === 0) {
+      this.clearModifiers();
+    }
+    connection.sendKeyboardEvent(event);
+  };
 
   constructor(private readonly options: MobileKeyboardOptions) {}
 
@@ -26,6 +49,9 @@ export class DesktopMobileKeyboard {
   }
 
   reset(input?: HTMLTextAreaElement): void {
+    if (!input) {
+      this.clearModifiers();
+    }
     this.value = MOBILE_KEYBOARD_SENTINEL;
     const target = input ?? this.options.input();
     if (target) {
@@ -34,9 +60,31 @@ export class DesktopMobileKeyboard {
   }
 
   handleKeyboardEvent(event: KeyboardEvent): void {
-    const connection = this.options.connection();
-    if (!this.options.controlling() || !connection) {
+    const connection = this.currentConnection();
+    if (!connection) {
       return;
+    }
+    // The textarea owns local paste; forwarding its shortcut suppresses browser input.
+    if (
+      !event.isComposing &&
+      !event.altKey &&
+      (isApplePlatform() ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey) &&
+      event.key.toLowerCase() === "v"
+    ) {
+      return;
+    }
+    if (["Meta", "Control", "Shift", "Alt"].includes(event.key)) {
+      if (event.type === "keydown") {
+        this.modifiers.set(event.code, event);
+        // noVNC releases held keys on window blur; do not restore stale modifiers afterward.
+        window.addEventListener("blur", this.clearModifiers, { once: true });
+        window.addEventListener("keyup", this.handleWindowKeyup, true);
+      } else {
+        this.modifiers.delete(event.code);
+        if (this.modifiers.size === 0) {
+          this.clearModifiers();
+        }
+      }
     }
     connection.sendKeyboardEvent(event);
     event.preventDefault();
@@ -44,12 +92,17 @@ export class DesktopMobileKeyboard {
 
   handleInput(event: InputEvent): void {
     const input = event.currentTarget as HTMLTextAreaElement;
-    if (!this.options.controlling()) {
+    const connection = this.currentConnection();
+    if (!connection) {
       this.reset(input);
       return;
     }
     const nextValue = input.value;
-    const connection = this.options.connection();
+    // Paste is literal text even while the user still physically holds its shortcut modifiers.
+    const modifiers = event.inputType === "insertFromPaste" ? [...this.modifiers.values()] : [];
+    for (const modifier of modifiers) {
+      connection.sendKeyboardEvent(new KeyboardEvent("keyup", modifier));
+    }
     let prefixLength = 0;
     for (const character of this.value) {
       if (!nextValue.startsWith(character, prefixLength)) {
@@ -63,14 +116,26 @@ export class DesktopMobileKeyboard {
       remaining > 0;
       remaining -= 1
     ) {
-      connection?.sendBackspace();
+      connection.sendBackspace();
     }
-    connection?.sendText(nextValue.slice(prefixLength));
+    connection.sendText(nextValue.slice(prefixLength));
+    for (const modifier of modifiers) {
+      connection.sendKeyboardEvent(modifier);
+    }
     // Refill once the field drifts outside the range that keeps further deletes reportable.
     if (nextValue.length < 1 || nextValue.length > MOBILE_KEYBOARD_SENTINEL.length * 2) {
       this.reset(input);
       return;
     }
     this.value = nextValue;
+  }
+
+  private currentConnection(): DesktopConnectionHandle | null {
+    const connection = this.options.controlling() ? this.options.connection() : null;
+    if (connection !== this.modifierConnection) {
+      this.clearModifiers();
+      this.modifierConnection = connection;
+    }
+    return connection;
   }
 }

--- a/ui/src/e2e/desktop-keyboard.e2e.test.ts
+++ b/ui/src/e2e/desktop-keyboard.e2e.test.ts
@@ -53,6 +53,134 @@ function keyPresses(keysyms: readonly number[]) {
 }
 
 suite.define(() => {
+  it.each(["canvas", "toolbar"])(
+    "keeps Shift held across a $0 click but never restores it after release and menu paste",
+    async (destination) => {
+      await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+        const { panel, peer, input } = await openKeyboard(page);
+        await page.keyboard.down("Shift");
+        const held = [{ down: true, keysym: 0xffe1 }];
+        await expect.poll(peer.keyEvents).toEqual(held);
+        const keyboardButton = panel.getByRole("button", { name: "Keyboard", exact: true });
+        await (
+          destination === "canvas"
+            ? panel.locator(".desktop-surface canvas")
+            : panel.getByRole("button", { name: "Use actual size", exact: true })
+        ).click();
+        await expect.poll(peer.keyEvents).toEqual(held);
+        await page.keyboard.up("Shift");
+        await keyboardButton.click();
+        await input.evaluate((element) => {
+          if (!(element instanceof HTMLTextAreaElement)) {
+            throw new Error("Expected the desktop keyboard textarea");
+          }
+          element.setRangeText("p", element.selectionStart, element.selectionEnd, "end");
+          element.dispatchEvent(
+            new InputEvent("input", {
+              bubbles: true,
+              inputType: "insertFromPaste",
+              data: "p",
+            }),
+          );
+        });
+        await expect.poll(peer.keyEvents).toEqual(keyPresses([0xffe1, 0x70]));
+      });
+    },
+  );
+
+  it.each([
+    {
+      platform: "MacIntel",
+      key: "Meta",
+      code: "MetaLeft",
+      location: 1,
+      flag: "metaKey",
+      keysym: 0xffe9,
+    },
+    {
+      platform: "MacIntel",
+      key: "Meta",
+      code: "MetaRight",
+      location: 2,
+      flag: "metaKey",
+      keysym: 0xffeb,
+    },
+    {
+      platform: "Win32",
+      key: "Control",
+      code: "ControlLeft",
+      location: 1,
+      flag: "ctrlKey",
+      keysym: 0xffe3,
+    },
+    {
+      platform: "Win32",
+      key: "Control",
+      code: "ControlRight",
+      location: 2,
+      flag: "ctrlKey",
+      keysym: 0xffe4,
+    },
+  ])(
+    "keeps $code paste local on $platform and sends literal text without held modifiers",
+    async (modifier) => {
+      await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
+        await page.addInitScript((platform) => {
+          Object.defineProperty(navigator, "platform", { value: platform });
+        }, modifier.platform);
+        const { peer, input } = await openKeyboard(page);
+        const text = "Aa7!z?Bb8@x#Cc9$w%Dd0^v&Ee1*f(G)";
+        const defaults = await input.evaluate(
+          (element, paste) => {
+            if (!(element instanceof HTMLTextAreaElement)) {
+              throw new Error("Expected the desktop keyboard textarea");
+            }
+            const dispatch = (type: string, key: string, code: string, held = true) =>
+              element.dispatchEvent(
+                new KeyboardEvent(type, {
+                  key,
+                  code,
+                  location: code === paste.modifier.code ? paste.modifier.location : 0,
+                  [paste.modifier.flag]: held,
+                  bubbles: true,
+                  cancelable: true,
+                }),
+              );
+            dispatch("keydown", paste.modifier.key, paste.modifier.code);
+            const allowed = dispatch("keydown", "v", "KeyV");
+            // Supply synthetic browser paste input without reading or changing the OS clipboard.
+            if (allowed) {
+              element.setRangeText(paste.text, element.selectionStart, element.selectionEnd, "end");
+              element.dispatchEvent(
+                new InputEvent("input", {
+                  bubbles: true,
+                  inputType: "insertFromPaste",
+                  data: paste.text,
+                }),
+              );
+            }
+            const released = dispatch("keyup", "v", "KeyV");
+            dispatch("keydown", "a", "KeyA");
+            dispatch("keyup", "a", "KeyA");
+            dispatch("keyup", paste.modifier.key, paste.modifier.code, false);
+            return { allowed, released };
+          },
+          { modifier, text },
+        );
+        expect(defaults).toEqual({ allowed: true, released: true });
+        await expect
+          .poll(peer.keyEvents)
+          .toEqual([
+            ...keyPresses([modifier.keysym]),
+            ...keyPresses(Array.from(text, (character) => character.charCodeAt(0))),
+            { down: true, keysym: modifier.keysym },
+            ...keyPresses([0x61]),
+            { down: false, keysym: modifier.keysym },
+          ]);
+      });
+    },
+  );
+
   it("accepts 32 pasted ASCII characters only after connected control and disables view-only input", async () => {
     await suite.withPage({ serviceWorkers: "block" }, async ({ page }) => {
       await page.setViewportSize({ width: 720, height: 540 });


### PR DESCRIPTION
Closes #141981
Related: #141378

## What Problem This Solves

Fixes an issue where users pasting local text into the Control UI Desktop **Keyboard** field would send a remote paste shortcut instead of the clipboard contents. A live macOS reproduction pasted a 32-character string but inserted only `v`.

## Why This Change Was Made

The Keyboard textarea now permits the browser's native paste and sends the resulting text through the existing noVNC encoder. It temporarily releases and restores held modifiers around literal text, tracks physical modifier releases after focus moves, and clears stale bookkeeping on blur, reset, control loss, or connection replacement. Direct desktop-canvas shortcuts and provider authorization are unchanged.

## User Impact

Command+V on macOS and Ctrl+V on Windows/Linux insert local clipboard text through **Keyboard**, without leaving remote modifiers stuck. Keyboard input remains disabled until connected control is ready. The usage note documents this distinction from remote desktop shortcuts.

## Evidence

- Mac and Windows shortcut regressions failed on the original implementation because native paste default was prevented.
- Independent review caught a focus-transition edge case; its canvas/toolbar regressions failed before the follow-up repair.
- Final candidate: 72 focused tests passed (60 client/panel and 12 real-noVNC browser cases), full changed-file checks passed, and the UI build passed its existing bundle budgets.
- Independent review is clean through P2.
- Live Chrome → WebVNC → macOS: the original 32-character paste inserted `v`; the repaired bundle inserted the complete `WebVNC paste 0123456789 AaBbCcDd`. Normal macOS sign-in using pasted saved credentials also succeeded, with no password or lock-policy changes.
- Before/after images show the synthetic app field and Desktop controls only; browser account chrome and machine URLs are excluded. The before image preserves the original failed-paste result.

The local checks used the existing ordinary checkout because this linked worktree's external dependency symlink is rejected by the typecheck boundary guard. The touched source bytes were verified identical; no guard was bypassed. CI will validate the PR head.

![Before: the original paste inserted only v](https://github.com/user-attachments/assets/024f87a4-1188-4581-9ed9-1a93abec89b9)

![After: the complete 32-character clipboard text reaches the app](https://github.com/user-attachments/assets/752171e4-13dd-4ec6-a89e-de997f4e4085)