### PR TITLE
test(plugins): activate the hook-only compatibility fixture through the runtime context

### DIFF
--- a/src/plugins/status.compatibility.integration.test.ts
+++ b/src/plugins/status.compatibility.integration.test.ts
@@ -11,6 +11,8 @@ import {
   useNoBundledPlugins,
   writePlugin,
 } from "./loader.test-fixtures.js";
+import { buildPluginRuntimeLoadOptions } from "./runtime/load-context.js";
+import { resolvePluginRuntimeLoadContext } from "./runtime/load-context.resolve.js";
 import { buildPluginCompatibilitySnapshotNotices } from "./status.js";
 
 function addStartupActivation(pluginDir: string, onStartup: boolean): void {
@@ -91,7 +93,12 @@ describe("plugin compatibility snapshot notices", () => {
       expect(buildPluginCompatibilitySnapshotNotices(params)).toStrictEqual([]);
       expect(fs.existsSync(runtimeMarker)).toBe(false);
 
-      const registry = loadOpenClawPlugins({ ...params, cache: false });
+      // Activate through the resolved runtime context like Gateway and CLI loads do:
+      // the load identity includes the resolved physical sources, and the snapshot
+      // path only reuses an active registry whose identity matches exactly.
+      const registry = loadOpenClawPlugins(
+        buildPluginRuntimeLoadOptions(resolvePluginRuntimeLoadContext(params), { cache: false }),
+      );
       expect(fs.existsSync(runtimeMarker)).toBe(true);
       expect(registry.typedHooks).toEqual([
         expect.objectContaining({ pluginId: plugin.id, hookName: "message_received" }),


### PR DESCRIPTION
## What Problem This Solves

`src/plugins/status.compatibility.integration.test.ts` ("reports actual hook-only registrations without activating cold plugin modules") fails deterministically on current `main` when run on its own:

```
expected [] to deeply equal [ ObjectContaining{ pluginId: "runtime-hook-only", code: "hook-only" } ]
```

`git bisect` over `aa947ec2812~1..main` lands on #141679 (`ccd3a4414e5`). That change made a supplied manifest registry's physical source facts part of the plugin load identity (`manifestSources` in `buildCacheKey`), which is the intended binding for provider reuse. The test activates its registry with the plain shape `loadOpenClawPlugins({ config, workspaceDir, env, cache: false })`; with no process-current metadata snapshot published in the test process, that identity carries no physical sources, while `buildPluginCompatibilitySnapshotNotices` resolves the runtime load context and hashes an explicit registry. `resolveCompatibleRuntimePluginRegistry` requires exact identity equality, so the live registry is not reused and hook shape is never observed.

Production is consistent with itself: Gateway startup (`src/gateway/server-plugins.ts`) and the runtime registry loaders activate through `buildPluginRuntimeLoadOptions(resolvePluginRuntimeLoadContext(...))`, the same path the snapshot notices use; the plain activating shape exists only in this test.

## Why This Change Was Made

The test now activates through the resolved runtime context exactly as Gateway and CLI loads do, with a comment naming the identity contract. No production change: the identity binding from #141679 is the correct owner behavior, and the notice path's exact-match reuse is its documented contract ("return the exact active registry without triggering a fresh load on cache miss").

## User Impact

None at runtime. Restores a deterministic local red on `main` for anyone running the plugins suite on a checkout at or after #141679.

## Evidence

- Pre-fix, isolated on `main` (`a6046641e91`) and on `d662d575372`: 2/2 and 3/3 runs fail with the assertion above; identical under default, canonical, and private-per-user `TMPDIR`, so not the macOS `/var` symlink.
- Probe of the hasher inputs for both option shapes: everything equal except `manifestSources` (`undefined` for the plain load, the resolved `[id, origin, rootDir, source, ...]` tuple for the snapshot path); the active registry key equals the plain-load key and differs from the snapshot key.
- `git bisect run` with this single test: good at `aa947ec2812~1` and `d12106ef815`, first bad `ccd3a4414e5` (#141679).
- Post-fix: the file passes 3/3 in isolation; the cold call still returns `[]` without creating the runtime marker; the `src/plugins/status` suites pass together; `check-changed` on the touched file passes.
- CI did not catch the break because none of the inspected node shard logs for #140187's and #141679's exact-head runs mention this file; the changed-target shard for this PR runs it directly.

Test-only change, production LOC 0.

Review: independent Codex autoreview (local mode, P0–P2) is scoped-clean with no actionable findings.
