### PR TITLE
test: use complete metadata in catalog worker fixture

### DIFF
--- a/src/agents/prepared-model-catalog-worker.test.ts
+++ b/src/agents/prepared-model-catalog-worker.test.ts
@@ -1,15 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
-import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { describe, expect, it } from "vitest";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import {
   createPreparedModelCatalogWorkerInput,
   fingerprintPreparedModelWorkerRequest,
 } from "./prepared-model-catalog-worker.js";
 import type { PreparedModelRuntimeAgentFacts } from "./prepared-model-runtime.catalog-contract.js";
-
-vi.mock("../plugins/manifest-registry-installed.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../plugins/manifest-registry-installed.js")>()),
-  resolveInstalledManifestRegistryIndexFingerprint: () => "test-plugin-index",
-}));
 
 describe("prepared model catalog worker input", () => {
   it("preserves captured auth identity and distinguishes source from built artifacts", () => {
@@ -63,12 +58,7 @@ describe("prepared model catalog worker input", () => {
         configuredGeneratedCatalogPluginIds: [],
         templateAuthStorage: {} as never,
       } satisfies PreparedModelRuntimeAgentFacts,
-      pluginMetadataSnapshot: {
-        policyHash: "test-policy",
-        configFingerprint: "test-config",
-        index: {} as never,
-        plugins: [],
-      } as unknown as PluginMetadataSnapshot,
+      pluginMetadataSnapshot: createPluginMetadataSnapshotFixture(),
     };
     const workerInput = createPreparedModelCatalogWorkerInput(params);
 


### PR DESCRIPTION
**Superseded by the complete fixture fix in #141930, merged as db25ae4e56e978e98ddef4fbc425563b34f3ef6f while this PR was being prepared. This proposal is redundant; no merge is needed. The evidence below records the independently verified candidate.**

Related: #141942, #141893

## What Problem This Solves

The catalog-worker input test uses an incomplete metadata snapshot and a module mock to supply its fingerprint. That mock previously broke a subsequent provider transport integration test: a process-global metadata reader retained the mocked dependency and could not find the real registry export.

Main's partial-mock fix in #141893 restores the missing export. This follow-up removes the remaining mock and incomplete-snapshot casts.

## Why This Change Was Made

Use the existing `createPluginMetadataSnapshotFixture()` to provide a complete empty index and its derived metadata views. The test now exercises the real fingerprint function. All credential-serialization, source/built-artifact, generation-fingerprint and request-fingerprint assertions remain unchanged.

## User Impact

A smaller fixture with no mocked registry left for later tests to inherit. Production behavior, runner configuration, isolation and assertions are unchanged. Test diff: three additions and thirteen deletions; production LOC: zero.

Dallin Romney independently proposed removing this mock in closed #141942. The earlier ordering investigation is recorded in [#141852's causal evidence](https://github.com/openclaw/openclaw/pull/141852#issuecomment-5580268906).

## Evidence

- Reproduced the original failure on pre-partial-fix main `abd45414`: catalog input passes, then transport fails with the missing-export error in the same non-isolated worker.
- With the complete fixture, the original two-file topology passes. The original 28-file agents-core group also passes **570 cases with one existing skip**, preserving every file and executed case name/order from the retained CI log.
- Rechecked the original two-file topology on current base `a6046641`, which includes the partial-mock fix: both pass.
- Normal automatic routing passes both tests. Removing the mock naturally classifies the input test into the existing unit-fast lane; a temporary proof-only config retained the original shared-worker topology for the ordering checks. No routing configuration was committed.
- Frozen dependencies were unchanged across these bases. The required current-base changed gate passed, including test types, lint, guards and Knip.

Independent managed P2 review of the current-base diff passed with no findings.
