### PR TITLE
fix(feishu): keep replies delivered when Feishu closes a streaming card

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -346,6 +346,8 @@ Feishu/Lark supports streaming replies via interactive cards (Card Kit streaming
 
 Set `streaming.mode: "off"` to send the completed reply without streaming updates; long replies still split at the message limits above. `renderMode: "raw"` (plain text instead of cards) also disables streaming cards. `streaming.block.enabled` is off by default; enable it only when you want completed assistant blocks flushed before the final reply. Legacy boolean `streaming` and the flat `blockStreaming` / `blockStreamingCoalesce` / `chunkMode` keys migrate to this nested shape via `openclaw doctor --fix`.
 
+Feishu can close a card's streaming mode on its own — for example after a long tool phase with no card updates. When that happens the card stops accepting updates, so it keeps whatever text it last showed and the completed reply arrives as a separate static card or message. Expect the visible prefix to appear twice in that case; the full answer is the later message.
+
 Replies with controls use native cards for command buttons and HTTP(S) links, including when streaming is off. The card carries the reply text; attachments remain separate messages. Unsupported controls and cards that exceed Feishu's size limits keep their full labels in a readable fallback. That fallback remains a separate message when a later reply streams. A final controls reply replaces an active streaming preview without sending the preview text again; error controls after a completed answer remain separate. If Feishu cannot delete or clear a replaced preview, delivery reports a failure and retains the original message receipt.
 
 ### Quota optimization

--- a/extensions/feishu/src/reply-dispatcher.test.ts
+++ b/extensions/feishu/src/reply-dispatcher.test.ts
@@ -2716,6 +2716,66 @@ describe("createFeishuReplyDispatcher streaming behavior", () => {
     });
   });
 
+  // Regression coverage for #139443.
+  it("stops queueing streaming patches once the session retires a CardKit-closed stream", async () => {
+    const { result, options } = createDispatcherHarness();
+    await options.onReplyStart?.();
+    result.replyOptions.onPartialReply?.({ text: "Working on it." });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const instance = requireStreamingInstance(0);
+    const patchesBeforeRetirement = instance.update.mock.calls.length;
+    // CardKit retires the stream on the next patch; a repaired session stops reporting
+    // itself active, which is the dispatcher's only liveness signal.
+    instance.update.mockImplementation(async () => {
+      instance.active = false;
+    });
+
+    for (let index = 0; index < 6; index += 1) {
+      result.replyOptions.onPartialReply?.({
+        text: `Working on it.\nstreamed answer paragraph ${String(index).padStart(2, "0")}`,
+      });
+    }
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(
+      instance.update.mock.calls.length - patchesBeforeRetirement,
+      "the dispatcher must not keep patching a stream whose owner reports it retired",
+    ).toBeLessThanOrEqual(1);
+  });
+
+  it("delivers the complete answer statically when a server-closed stream kept only a stale partial", async () => {
+    const { result, options } = createDispatcherHarness();
+    result.replyOptions.onPartialReply?.({ text: "Working on it." });
+    const finalText = "Working on it.\nHere is the complete answer the user must still receive.";
+    const delivery = await options.deliver({ text: finalText }, { kind: "final" });
+    // 200850 froze the card after "Working on it." was accepted, so the final write and
+    // the close were both rejected: the card is visible but the answer never landed.
+    requireStreamingInstance(0).closeWithResult.mockRejectedValueOnce(
+      new FeishuStreamingFinalizationError(
+        new Error("Update card content failed: ErrMsg: streaming mode is closed;  (code=300309)"),
+        {
+          visibleReplySent: true,
+          finalTextAccepted: false,
+          content: "Working on it.",
+          messageId: "om_stream",
+        },
+      ),
+    );
+
+    await Promise.resolve(options.onIdle?.()).catch(() => undefined);
+    await Promise.resolve(delivery?.finalization).catch(() => undefined);
+
+    const staticSends = [
+      ...sendStructuredCardFeishuMock.mock.calls,
+      ...sendMessageFeishuMock.mock.calls,
+    ].map((call) => String((call[0] as { text?: string } | undefined)?.text ?? ""));
+    expect(
+      staticSends,
+      "a card frozen on a stale partial is not a delivered answer; the dispatcher must fall back to the static path",
+    ).toContain(finalText);
+  });
+
   it("allows recovery after a final rewrite leaves only an earlier preview visible", async () => {
     const { result, options } = createDispatcherHarness();
     result.replyOptions.onPartialReply?.({ text: "accepted preview" });

--- a/extensions/feishu/src/reply-dispatcher.ts
+++ b/extensions/feishu/src/reply-dispatcher.ts
@@ -314,6 +314,8 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     result: FeishuReplyDeliveryResult;
     generation?: number;
     error?: unknown;
+    /** The owning session confirmed CardKit accepted the final text. */
+    finalTextAccepted?: boolean;
   };
   type ClosedStreamingSettlement = StreamingCloseOutcome & {
     content: string;
@@ -527,6 +529,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     result: FeishuReplyDeliveryResult,
     error?: unknown,
     disposition: StreamingDisposition = "closed",
+    finalTextAccepted?: boolean,
   ) => {
     if (generation === undefined || (!content && disposition === "closed")) {
       return;
@@ -536,6 +539,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       result,
       content,
       ...(error === undefined ? {} : { error }),
+      ...(finalTextAccepted === undefined ? {} : { finalTextAccepted }),
     });
   };
 
@@ -564,6 +568,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
       await updateQueueToClose;
       let result = noVisibleFeishuReplyDelivery;
       let finalizationError: unknown;
+      let finalTextAccepted: boolean | undefined;
       if (streamingToClose?.isActive()) {
         statusLine = "";
         const text = buildCombinedStreamText(finalizedReasoningText, finalizedAnswerText);
@@ -582,6 +587,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           closed = error.result;
           finalizationError = error;
         }
+        finalTextAccepted = closed.finalTextAccepted;
         result = createFeishuReplyDeliveryResult({
           results: [closed],
           visibleReplySent: closed.visibleReplySent,
@@ -624,11 +630,13 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
           result,
           finalizationError,
           disposition,
+          finalTextAccepted,
         );
       }
       return {
         ...outcome,
         result,
+        ...(finalTextAccepted === undefined ? {} : { finalTextAccepted }),
         ...(finalizationError === undefined ? {} : { error: finalizationError }),
       };
     } catch (error: unknown) {
@@ -993,8 +1001,12 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
     result: FeishuReplyDeliveryResult | undefined,
     content: string | undefined,
     infoKind?: string,
+    finalTextAccepted?: boolean,
   ): Promise<FeishuReplyDeliveryResult | undefined> => {
-    if (result?.visibleReplySent === true || !content?.trim()) {
+    // A card frozen on a stale partial is visible, but it is not the delivered answer.
+    // When its owner reports the final text was never accepted, fall back to the static
+    // path even though a receipt exists; the receipt stays attached to the card.
+    if ((result?.visibleReplySent === true && finalTextAccepted !== false) || !content?.trim()) {
       return result;
     }
     const cardHeader = resolveCardHeader(agentId, identity);
@@ -1059,6 +1071,9 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
               ? {
                   disposition: closeOutcome.disposition,
                   result: finalized,
+                  ...(closeOutcome.finalTextAccepted === undefined
+                    ? {}
+                    : { finalTextAccepted: closeOutcome.finalTextAccepted }),
                   ...(closeOutcome.error === undefined ? {} : { error: closeOutcome.error }),
                 }
               : claimClosedStreamingResult(
@@ -1084,6 +1099,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
                 providerFinalized,
                 completion.result.content,
                 completion.infoKind,
+                claimedSettlement?.finalTextAccepted,
               );
             } catch (fallbackError: unknown) {
               const fallbackPartial = isChannelPartialDeliveryError(fallbackError)
@@ -1202,6 +1218,7 @@ export function createFeishuReplyDispatcher(params: CreateFeishuReplyDispatcherP
             finalized,
             paramsLocal.content,
             paramsLocal.infoKind,
+            settlement?.finalTextAccepted,
           )) ?? finalized;
       }
     } catch (fallbackError: unknown) {

--- a/extensions/feishu/src/streaming-card-terminal-codes.ts
+++ b/extensions/feishu/src/streaming-card-terminal-codes.ts
@@ -1,0 +1,16 @@
+import { isRecord } from "openclaw/plugin-sdk/string-coerce-runtime";
+
+// CardKit codes that retire this card's stream server-side: 200850 is returned
+// when the card's streaming mode times out, 300309 for every request issued after
+// streaming mode is closed. Neither can be recovered by retrying, so the session
+// that owns the card must stop writing to it. Every other code stays retryable —
+// 19001 sequence rejections, HTTP 429, and transport failures are all transient.
+const FEISHU_TERMINAL_STREAM_CODES = new Set([200850, 300309]);
+
+export function isFeishuTerminalStreamCode(code: unknown): boolean {
+  return typeof code === "number" && FEISHU_TERMINAL_STREAM_CODES.has(code);
+}
+
+export function isFeishuTerminalStreamError(error: unknown): boolean {
+  return isRecord(error) && isFeishuTerminalStreamCode(error.code);
+}

--- a/extensions/feishu/src/streaming-card.test.ts
+++ b/extensions/feishu/src/streaming-card.test.ts
@@ -350,6 +350,7 @@ describe("FeishuStreamingSession", () => {
 
       await expect(session.closeWithResult("The accepted answer")).resolves.toEqual({
         visibleReplySent: true,
+        finalTextAccepted: true,
         content: "The accepted answer",
       });
       expect(method === "reply" ? reply : create).toHaveBeenCalledOnce();
@@ -1350,6 +1351,183 @@ describe("FeishuStreamingSession", () => {
 
     expect(authTokens).toEqual(["token-1", "token-2"]);
     dateNow.mockRestore();
+  });
+
+  // Regression coverage for #139443: CardKit retires a card's stream server-side after
+  // an idle window (200850) and rejects every later request against it (300309).
+  const CARD_STREAMING_TIMEOUT_CODE = 200850;
+  const STREAMING_MODE_CLOSED_CODE = 300309;
+
+  function createTerminalStreamSession(
+    appId: string,
+    deps: StreamingFetchDeps,
+    log?: (msg: string) => void,
+    lastUpdateTime?: number,
+  ): FeishuStreamingSession {
+    const session = new FeishuStreamingSession(
+      {} as never,
+      { appId, appSecret: "secret" },
+      log,
+      deps,
+    );
+    setStreamingSessionInternals(session, {
+      state: {
+        cardId: `card_${appId}`,
+        messageId: `om_${appId}`,
+        sequence: 4,
+        currentText: "Working on it.",
+        sentText: "Working on it.",
+        hasNote: false,
+      },
+      ...(lastUpdateTime === undefined ? {} : { lastUpdateTime }),
+    });
+    return session;
+  }
+
+  it("retires a stream CardKit closed with 200850 instead of blind-retrying every later patch", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(10_000);
+
+    const contentUpdateAttempts: string[] = [];
+    const servedCodes: number[] = [];
+    const deps = createMemoryFetch((url, body) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({ code: 0, msg: "ok", tenant_access_token: "token", expire: 7200 });
+      }
+      if (url.pathname.includes("/elements/content/content")) {
+        contentUpdateAttempts.push((JSON.parse(body) as { content: string }).content);
+        // The idle timer fires once; the stream is gone for every later patch.
+        const code =
+          contentUpdateAttempts.length === 1
+            ? CARD_STREAMING_TIMEOUT_CODE
+            : STREAMING_MODE_CLOSED_CODE;
+        servedCodes.push(code);
+        return jsonResponse({
+          code,
+          msg:
+            code === CARD_STREAMING_TIMEOUT_CODE
+              ? "ErrMsg: card streaming timeout; "
+              : "ErrMsg: streaming mode is closed; ",
+        });
+      }
+      return jsonResponse({ code: 0, msg: "ok" });
+    });
+
+    const log = vi.fn();
+    const session = createTerminalStreamSession("terminal_stream_139443", deps, log, 10_000);
+
+    // Every snapshot grows by more than STREAMING_SIGNIFICANT_DELTA_CHARS against the
+    // frozen sentText, so an unretired session force-flushes each one past the 160 ms
+    // throttle and issues one PUT per snapshot without any simulated time passing.
+    let text = "Working on it.";
+    for (let index = 0; index < 6; index += 1) {
+      text = `${text}\nstreamed answer paragraph ${String(index).padStart(2, "0")}`;
+      await session.update(text);
+    }
+
+    // Byte-for-byte the journal line quoted in the issue.
+    expect(String(log.mock.calls[0]?.[0])).toBe(
+      "Update failed: Error: Update card content failed: ErrMsg: card streaming timeout;  (code=200850)",
+    );
+    expect(
+      contentUpdateAttempts,
+      "the session must stop patching a stream CardKit reported closed",
+    ).toHaveLength(1);
+    expect(servedCodes.filter((code) => code === STREAMING_MODE_CLOSED_CODE)).toEqual([]);
+    expect(
+      session.isActive(),
+      "a stream CardKit has closed must not report itself active to the reply dispatcher",
+    ).toBe(false);
+  });
+
+  it("does not PATCH close settings on a stream CardKit already reported as closed", async () => {
+    const requestPaths: string[] = [];
+    const deps = createMemoryFetch((url) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({ code: 0, msg: "ok", tenant_access_token: "token", expire: 7200 });
+      }
+      requestPaths.push(url.pathname);
+      if (url.pathname.includes("/elements/content")) {
+        return jsonResponse({
+          code: CARD_STREAMING_TIMEOUT_CODE,
+          msg: "ErrMsg: card streaming timeout; ",
+        });
+      }
+      return jsonResponse({
+        code: STREAMING_MODE_CLOSED_CODE,
+        msg: "ErrMsg: streaming mode is closed; ",
+      });
+    });
+
+    const session = createTerminalStreamSession("terminal_close_139443", deps);
+    await session.update("Working on it.\nstreamed answer paragraph 00");
+    const closeError = await session
+      .closeWithResult("Working on it.\nfinal answer", { note: "Agent: agent" })
+      .then(() => undefined)
+      .catch((error: unknown) => error);
+
+    expect(
+      requestPaths.filter((pathname) => pathname.endsWith("/settings")),
+      "closeWithResult must not PATCH streaming settings on a stream CardKit reported closed",
+    ).toEqual([]);
+    expect(closeError).toBeInstanceOf(FeishuStreamingFinalizationError);
+    // The card keeps its receipt and its stale visible text, but the final answer was
+    // never accepted, so the caller must still deliver it.
+    expect((closeError as FeishuStreamingFinalizationError).result).toMatchObject({
+      visibleReplySent: true,
+      finalTextAccepted: false,
+      content: "Working on it.",
+      messageId: "om_terminal_close_139443",
+    });
+  });
+
+  it("reports the final text as accepted when CardKit accepts the closing write", async () => {
+    const deps = createMemoryFetch((url) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({ code: 0, msg: "ok", tenant_access_token: "token", expire: 7200 });
+      }
+      return jsonResponse({ code: 0, msg: "ok" });
+    });
+
+    const session = createTerminalStreamSession("accepted_close_139443", deps);
+    const result = await session.closeWithResult("Working on it.\nfinal answer");
+
+    expect(result).toMatchObject({
+      visibleReplySent: true,
+      finalTextAccepted: true,
+      content: "Working on it.\nfinal answer",
+    });
+  });
+
+  it("keeps a stream active after a retryable CardKit body error", async () => {
+    const deps = createMemoryFetch((url) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({ code: 0, msg: "ok", tenant_access_token: "token", expire: 7200 });
+      }
+      return jsonResponse({ code: 19001, msg: "sequence rejected" });
+    });
+
+    const session = createTerminalStreamSession("retryable_body_139443", deps);
+    await session.update("Working on it.\nstreamed answer paragraph 00");
+
+    expect(
+      session.isActive(),
+      "a sequence rejection is retryable and must not retire the stream",
+    ).toBe(true);
+  });
+
+  it("keeps a stream active after an HTTP 429 update rejection", async () => {
+    const deps = createMemoryFetch((url) => {
+      if (url.pathname.includes("/auth/")) {
+        return jsonResponse({ code: 0, msg: "ok", tenant_access_token: "token", expire: 7200 });
+      }
+      return jsonResponse({ code: 0, msg: "rate limited" }, 429);
+    });
+
+    const session = createTerminalStreamSession("retryable_429_139443", deps);
+    await session.update("Working on it.\nstreamed answer paragraph 00");
+
+    expect(session.isActive(), "a rate-limited update must not retire the stream").toBe(true);
   });
 });
 

--- a/extensions/feishu/src/streaming-card.ts
+++ b/extensions/feishu/src/streaming-card.ts
@@ -16,6 +16,7 @@ import { requestFeishuApi } from "./comment-shared.js";
 import { readFeishuJsonResponse } from "./json-response.js";
 import { resolveFeishuCardTemplate, type CardHeaderConfig } from "./send.js";
 import { resolveStreamingCardSendMode } from "./streaming-card-send-mode.js";
+import { isFeishuTerminalStreamError } from "./streaming-card-terminal-codes.js";
 import type { FeishuDomain } from "./types.js";
 
 type Credentials = {
@@ -48,7 +49,29 @@ type FeishuStreamingCloseResult = {
   visibleReplySent: boolean;
   content?: string;
   messageId?: string;
+  /**
+   * CardKit accepted the caller's final text. False when the card is left frozen on
+   * an earlier snapshot, so the caller can still deliver the answer another way.
+   * Visible content and a delivered final answer are separate facts.
+   */
+  finalTextAccepted?: boolean;
 };
+
+/**
+ * A CardKit request the API rejected, keeping the numeric code so callers can tell a
+ * terminal stream closure from a retryable failure.
+ *
+ * `name` is deliberately left as the inherited "Error": operators grep these lines and
+ * the existing log assertions pin `String(error)` byte-for-byte.
+ */
+export class FeishuCardKitError extends Error {
+  readonly code: number | undefined;
+
+  constructor(action: string, data: CardKitResponse) {
+    super(`${action} failed: ${data.msg ?? "unknown error"} (code=${String(data.code)})`);
+    this.code = data.code;
+  }
+}
 
 /** Provider finalization failed after a streaming card may already be visible. */
 export class FeishuStreamingFinalizationError extends Error {
@@ -148,7 +171,7 @@ async function assertSuccessfulCardKitResponse(
   }
   const data = await readFeishuJsonResponse<CardKitResponse>(response, auditContext);
   if (data.code !== 0) {
-    throw new Error(`${action} failed: ${data.msg ?? "unknown error"} (code=${String(data.code)})`);
+    throw new FeishuCardKitError(action, data);
   }
 }
 
@@ -253,6 +276,13 @@ export class FeishuStreamingSession {
   private state: CardState | null = null;
   private queue: Promise<void> = Promise.resolve();
   private closed = false;
+  /**
+   * CardKit retired this card's stream. Kept separate from `closed` ("we finalized"),
+   * because `closeWithResult` and `discard` early-return on `closed` and would drop the
+   * receipt and accepted-content facts the caller still needs.
+   */
+  private streamClosedByServer = false;
+  private streamClosedCause: unknown;
   private log?: (msg: string) => void;
   private lastUpdateTime = 0;
   private pendingText: string | null = null;
@@ -404,6 +434,21 @@ export class FeishuStreamingSession {
     this.log?.(`Started streaming: cardId=${cardId}${messageId ? `, messageId=${messageId}` : ""}`);
   }
 
+  /**
+   * A terminal CardKit rejection means the card's stream no longer exists, so every
+   * later patch is rejected too. Retire the stream at its producer: drop queued text
+   * and cancel the pending flush so nothing already scheduled fires.
+   */
+  private retireIfStreamClosedByServer(error: unknown): void {
+    if (this.streamClosedByServer || !isFeishuTerminalStreamError(error)) {
+      return;
+    }
+    this.streamClosedByServer = true;
+    this.streamClosedCause = error;
+    this.pendingText = null;
+    this.clearFlushTimer();
+  }
+
   private async updateCardContent(
     text: string,
     onError?: (error: unknown) => void,
@@ -449,6 +494,7 @@ export class FeishuStreamingSession {
       }
       return true;
     } catch (error) {
+      this.retireIfStreamClosedByServer(error);
       onError?.(error);
       return false;
     }
@@ -499,6 +545,7 @@ export class FeishuStreamingSession {
       }
       return true;
     } catch (error) {
+      this.retireIfStreamClosedByServer(error);
       onError?.(error);
       return false;
     }
@@ -512,7 +559,7 @@ export class FeishuStreamingSession {
   }
 
   private schedulePendingFlush(): void {
-    if (this.flushTimer || !this.pendingText || this.closed) {
+    if (this.flushTimer || !this.pendingText || this.closed || this.streamClosedByServer) {
       return;
     }
     const delayMs = Math.max(0, this.updateThrottleMs - (Date.now() - this.lastUpdateTime));
@@ -530,7 +577,8 @@ export class FeishuStreamingSession {
 
   private async flushPendingUpdate(): Promise<void> {
     this.queue = this.queue.then(async () => {
-      if (!this.state || this.closed) {
+      // Retirement can land while this flush waits its turn in the queue.
+      if (!this.state || this.closed || this.streamClosedByServer) {
         return;
       }
       const nextText = this.pendingText;
@@ -558,6 +606,11 @@ export class FeishuStreamingSession {
     // The caller supplies the complete current card text. CardKit derives its own
     // display delta, so merging snapshots here can duplicate divergent reasoning.
     this.state.currentText = text;
+    if (this.streamClosedByServer) {
+      // The stream is gone. Keep tracking what the caller wanted so finalization can
+      // report whether that text was ever accepted, but issue no further patches.
+      return;
+    }
     this.pendingText = text;
     this.clearFlushTimer();
 
@@ -625,6 +678,28 @@ export class FeishuStreamingSession {
     this.closed = true;
     this.clearFlushTimer();
     await this.queue;
+
+    if (this.streamClosedByServer) {
+      // CardKit already retired this stream, so the final content write, the note
+      // update and the settings PATCH would each be rejected. Tear down locally and
+      // report only the text CardKit accepted.
+      const retiredState = this.state;
+      const acceptedText = retiredState.sentText;
+      const visibleContentSent = Boolean(acceptedText.trim());
+      const requestedText = finalText ?? this.pendingText ?? retiredState.currentText;
+      this.state = null;
+      this.pendingText = null;
+      this.log?.(`Streaming card closed by server: cardId=${retiredState.cardId}`);
+      const retiredResult: FeishuStreamingCloseResult = {
+        visibleReplySent: visibleContentSent,
+        finalTextAccepted: requestedText === acceptedText,
+        ...(visibleContentSent ? { content: acceptedText } : {}),
+        ...(retiredState.messageId ? { messageId: retiredState.messageId } : {}),
+      };
+      // Streaming mode was never closed by us; report the terminal cause rather than
+      // a silent success, so the caller can still deliver the complete answer.
+      throw new FeishuStreamingFinalizationError(this.streamClosedCause, retiredResult);
+    }
 
     const text = finalText ?? this.pendingText ?? this.state.currentText;
     const apiBase = resolveApiBase(this.creds.domain);
@@ -712,6 +787,8 @@ export class FeishuStreamingSession {
     this.log?.(`Closed streaming: cardId=${finalState.cardId}`);
     const result: FeishuStreamingCloseResult = {
       visibleReplySent: visibleContentSent,
+      // sentText advances only for an accepted write, so this is the accepted-final fact.
+      finalTextAccepted: finalState.sentText === text,
       ...(visibleContentSent ? { content: finalState.sentText } : {}),
       ...(finalState.messageId ? { messageId: finalState.messageId } : {}),
     };
@@ -761,6 +838,6 @@ export class FeishuStreamingSession {
   }
 
   isActive(): boolean {
-    return this.state !== null && !this.closed;
+    return this.state !== null && !this.closed && !this.streamClosedByServer;
   }
 }


### PR DESCRIPTION
Fixes #139443

## What Problem This Solves

Fixes an issue where Feishu users running long tool phases would see the streaming card freeze on a stale partial answer while the bot issued roughly a thousand rejected API calls, and in one branch never received the completed answer at all.

Feishu can close a card's streaming mode server-side (the reporter observed code `200850` after an idle tool phase). Every later request against that card is then rejected with `300309`. Today nothing recognizes that closure: the card keeps its stale text, the failure log fills for the rest of the turn, and if any preview text was accepted before the close, the completed reply is silently skipped because the card already counts as "visible".

## Why This Change Was Made

`assertSuccessfulCardKitResponse` flattened the CardKit numeric code into a message string, so no caller could tell a terminal stream closure from a retryable failure. The session kept reporting `isActive()` — the reply dispatcher's only liveness signal — and because `sentText` advances only on an accepted write, the frozen snapshot made every later delivery exceed the significant-delta threshold and bypass the 160 ms throttle, turning each provider chunk into one immediately-issued PUT.

The repair is owned by the Feishu session:

- Throw a typed `FeishuCardKitError` that keeps the numeric code. The rendered message is byte-identical, so operator log greps and existing log assertions are unaffected.
- Classify `200850` and `300309` as terminal in one small module, mirroring the existing `send-rate-limit.ts` shape. `19001`, HTTP 429, and transport failures stay retryable.
- On a terminal rejection the session retires itself via a dedicated `streamClosedByServer` flag, deliberately kept separate from `closed` (which means "we finalized" and makes `closeWithResult`/`discard` early-return without their receipt). `isActive()` then goes false, which alone ends the retry storm — the dispatcher's existing guards already honor it.
- Finalization on a retired stream skips the final write, the note update, and the settings PATCH instead of issuing three more guaranteed rejections, while still throwing `FeishuStreamingFinalizationError` with the terminal cause.
- A frozen card is visible but is not the delivered answer, so the close result records `finalTextAccepted` at the boundary that made the write, and the dispatcher carries it to `ensureVisibleStreamingDelivery` so a stale-partial card falls back to the static send.

Non-goals: no keepalive, no new configuration options, no retries. A tool-phase keepalive was considered and deliberately left out — the server idle window is unmeasured here, and whether a note or unchanged-content patch resets it is unverified, so any such timer would be a speculative fallback.

## User Impact

A Feishu streaming card that the server closes now stops updating instead of spraying rejected requests, and the completed answer is delivered as a static card or message instead of being lost behind a frozen preview.

Two things to expect:

- The visible prefix appears twice when the card froze mid-answer (stale partial on the card, then the full answer as a separate message). That is the intended trade against losing the answer, and matches the existing recovery-card behavior.
- The underlying server-side idle close is unchanged, so a long tool phase can still freeze the preview. This change makes that bounded and recoverable — one rejected request, then a clean static delivery — rather than a multi-minute storm.

Documented under **Streaming** in `docs/channels/feishu.md`.

## Evidence

Regression tests were confirmed to fail without the production change and pass with it, in the same run.

**Without the fix** (production files reverted, tests kept):

```
FAIL streaming-card.test.ts > retires a stream CardKit closed with 200850 instead of blind-retrying every later patch
  AssertionError: the session must stop patching a stream CardKit reported closed:
  expected [ …(6) ] to have a length of 1 but got 6

FAIL streaming-card.test.ts > does not PATCH close settings on a stream CardKit already reported as closed
  AssertionError: closeWithResult must not PATCH streaming settings on a stream CardKit
  reported closed: expected [ Array(1) ] to deeply equal []

FAIL reply-dispatcher.test.ts > delivers the complete answer statically when a server-closed stream kept only a stale partial
  AssertionError: a card frozen on a stale partial is not a delivered answer; the dispatcher
  must fall back to the static path: expected [] to include 'Working on it.\nHere is the complete …'
```

The first failure is the reported storm: six snapshots produced six PUTs inside a single 160 ms window. The test also pins the journal line from the issue byte-for-byte:

```
Update failed: Error: Update card content failed: ErrMsg: card streaming timeout;  (code=200850)
```

**With the fix:** full `extensions/feishu` suite green — 102 files, 2038 tests.

Over-classification guards are included and were confirmed to pass both with and without the fix, so the retryable contracts cannot silently regress: a `19001` body error and an HTTP 429 both leave `isActive()` true.

**Proof gaps, stated plainly:**

- `200850` is **not confirmed from an authoritative Feishu source.** Attempts to fetch the CardKit error-code reference returned no usable content, and the repository contains no occurrence of either code. The reporter's observation and OpenClaw issue #92708 (closed, different trigger) are the only evidence that `200850` is real on this endpoint. `300309` has independent third-party corroboration from another Feishu client that stopped calling the stream API after close for the same reason. The repair deliberately does not depend on the precise upstream semantics: both codes are terminal for this card's stream by observation, and the handling is identical.
- The `200850` idle close itself is **not reproduced** — that needs a live tenant and a real idle window. The tests inject the code at the transport boundary and prove everything downstream.
- No live Feishu tenant proof.

**Validation still running at the time this draft was opened:** `check-changed` (tsgo typecheck lanes) and `$autoreview`. Both were started before opening and results will be posted as follow-up commits if anything needs fixing. An earlier `check-changed` run on the same tree passed every lane except `oxfmt`, which has since been applied.
