### PR TITLE
fix(ci): prevent catalog fixture from breaking provider transport tests

### DIFF
--- a/src/agents/prepared-model-catalog-worker.test.ts
+++ b/src/agents/prepared-model-catalog-worker.test.ts
@@ -1,14 +1,10 @@
-import { describe, expect, it, vi } from "vitest";
-import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { describe, expect, it } from "vitest";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import {
   createPreparedModelCatalogWorkerInput,
   fingerprintPreparedModelWorkerRequest,
 } from "./prepared-model-catalog-worker.js";
 import type { PreparedModelRuntimeAgentFacts } from "./prepared-model-runtime.catalog-contract.js";
-
-vi.mock("../plugins/manifest-registry-installed.js", () => ({
-  resolveInstalledManifestRegistryIndexFingerprint: () => "test-plugin-index",
-}));
 
 describe("prepared model catalog worker input", () => {
   it("preserves captured auth identity and distinguishes source from built artifacts", () => {
@@ -63,11 +59,9 @@ describe("prepared model catalog worker input", () => {
         templateAuthStorage: {} as never,
       } satisfies PreparedModelRuntimeAgentFacts,
       pluginMetadataSnapshot: {
-        policyHash: "test-policy",
+        ...createPluginMetadataSnapshotFixture(),
         configFingerprint: "test-config",
-        index: {} as never,
-        plugins: [],
-      } as unknown as PluginMetadataSnapshot,
+      },
     };
     const workerInput = createPreparedModelCatalogWorkerInput(params);
 


### PR DESCRIPTION
Closes #141982

## What Problem This Solves

Resolves a problem where the shared agents-core CI worker fails the provider transport integration test after running the prepared-model catalog test. This failure also occurs on main and blocks validation of #141929.

## Why This Change Was Made

The catalog test used an invalid metadata snapshot and replaced the entire installed-manifest module with one fingerprint function. A registered loader retained that incomplete mock after test cleanup, causing the next integration test to fail on a missing export before exercising HTTP egress.

Use the existing complete metadata fixture and remove the unnecessary module mock and snapshot casts. Every assertion remains. The fixture's normalization function also gives the existing structured-clone assertion a real process-local function to exclude.

## User Impact

No production behavior changes. This maintainer CI repair lets the existing catalog and provider transport checks run together without weakening isolation settings, assertions, timeouts, or gates.

## Evidence

- The original ordered pair fails on the clean pre-refactor base: one pass, one failure, matching the [PR CI stack](https://github.com/openclaw/openclaw/actions/runs/34195360805/job/101961942992) and [main failure](https://github.com/openclaw/openclaw/actions/runs/34196418832/job/101965619299).
- The same ordered pair passes after the fixture repair.
- The original 28-file CI order passes: 570 tests and the existing Windows-only skip. The proof retains the actual agents-core setup, shared runner, and non-isolated sequential execution.

- All 20 selected checks pass, including typecheck, lint, formatting, boundaries and Knip scans.
- Fresh independent P2 review found no actionable findings.

The change is confined to one test file; no production code or new test seam is added. No full build or live-provider claim.
