### PR TITLE
fix(feishu): update tools after configuration changes

### DIFF
--- a/docs/channels/feishu.md
+++ b/docs/channels/feishu.md
@@ -397,6 +397,10 @@ The plugin ships agent tools for Feishu documents, chats, knowledge base, cloud 
 
 Per-account gates live under `accounts.<id>.tools`.
 
+After a configuration update is applied, new agent turns use the updated tool
+gates and account selection without restarting the Gateway. Tools already created
+for an in-progress turn keep their original configuration.
+
 Bitable operations use the application token from a `/base/` URL or returned
 `app_token`, not the node token in a `/wiki/` URL. If application creation succeeds
 but table metadata is not retrieved, keep the returned `app_token` and URL. Inspect

--- a/extensions/feishu/src/bitable.ts
+++ b/extensions/feishu/src/bitable.ts
@@ -572,24 +572,7 @@ const UpdateRecordSchema = Type.Object({
 // ============ Tool Registration ============
 
 export function registerFeishuBitableTools(api: OpenClawPluginApi) {
-  if (!api.config) {
-    return;
-  }
-
-  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(api.config);
-  if (!toolsCfg.bitable) {
-    return;
-  }
-
   type AccountAwareParams = { accountId?: string };
-
-  const getClient = (params: AccountAwareParams | undefined, defaultAccountId?: string) =>
-    createFeishuToolClient({
-      api,
-      executeParams: params,
-      defaultAccountId,
-      requiredTool: { family: "bitable", label: "Bitable" },
-    });
 
   const registerBitableTool = <
     // oxlint-disable-next-line typescript/no-unnecessary-type-parameters -- Tool params bind each schema-specific executor to its registered tool.
@@ -599,28 +582,40 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: string;
     description: string;
     parameters: TSchema;
-    execute: (args: { params: TParams; defaultAccountId?: string }) => Promise<unknown>;
+    execute: (args: { params: TParams; client: Lark.Client }) => Promise<unknown>;
   }) => {
     api.registerTool(
-      (ctx) => ({
-        name: params.name,
-        resultContentSource: "network",
-        label: params.label,
-        description: params.description,
-        parameters: params.parameters,
-        async execute(_toolCallId, rawParams) {
-          try {
-            return json(
-              await params.execute({
-                params: rawParams as TParams,
-                defaultAccountId: ctx.agentAccountId,
-              }),
-            );
-          } catch (err) {
-            return json({ error: formatErrorMessage(err) });
-          }
-        },
-      }),
+      (ctx) => {
+        const cfg = ctx.runtimeConfig ?? ctx.config ?? api.config;
+        if (!cfg || !resolveAnyEnabledFeishuToolsConfig(cfg).bitable) {
+          return null;
+        }
+        return {
+          name: params.name,
+          resultContentSource: "network",
+          label: params.label,
+          description: params.description,
+          parameters: params.parameters,
+          async execute(_toolCallId, rawParams) {
+            const executeParams = rawParams as TParams;
+            try {
+              return json(
+                await params.execute({
+                  params: executeParams,
+                  client: createFeishuToolClient({
+                    cfg,
+                    executeParams,
+                    defaultAccountId: ctx.agentAccountId,
+                    requiredTool: { family: "bitable", label: "Bitable" },
+                  }),
+                }),
+              );
+            } catch (err) {
+              return json({ error: formatErrorMessage(err) });
+            }
+          },
+        };
+      },
       { name: params.name },
     );
   };
@@ -631,8 +626,8 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     description:
       "Parse a Bitable URL and get app_token, table_id, and table list. Use this first when given a /wiki/ or /base/ URL.",
     parameters: GetMetaSchema,
-    async execute({ params, defaultAccountId }) {
-      return getBitableMeta(getClient(params, defaultAccountId), params.url);
+    async execute({ params, client }) {
+      return getBitableMeta(client, params.url);
     },
   });
 
@@ -641,8 +636,8 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable List Fields",
     description: "List all fields (columns) in a Bitable table with their types and properties",
     parameters: ListFieldsSchema,
-    async execute({ params, defaultAccountId }) {
-      return listFields(getClient(params, defaultAccountId), params.app_token, params.table_id);
+    async execute({ params, client }) {
+      return listFields(client, params.app_token, params.table_id);
     },
   });
 
@@ -657,9 +652,9 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable List Records",
     description: "List records (rows) from a Bitable table with pagination support",
     parameters: ListRecordsSchema,
-    async execute({ params, defaultAccountId }) {
+    async execute({ params, client }) {
       return listRecords(
-        getClient(params, defaultAccountId),
+        client,
         params.app_token,
         params.table_id,
         readBitableListRecordsPageSize(params as Record<string, unknown>),
@@ -678,13 +673,8 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable Get Record",
     description: "Get a single record by ID from a Bitable table",
     parameters: GetRecordSchema,
-    async execute({ params, defaultAccountId }) {
-      return getRecord(
-        getClient(params, defaultAccountId),
-        params.app_token,
-        params.table_id,
-        params.record_id,
-      );
+    async execute({ params, client }) {
+      return getRecord(client, params.app_token, params.table_id, params.record_id);
     },
   });
 
@@ -698,13 +688,8 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable Create Record",
     description: "Create a new record (row) in a Bitable table",
     parameters: CreateRecordSchema,
-    async execute({ params, defaultAccountId }) {
-      return createRecord(
-        getClient(params, defaultAccountId),
-        params.app_token,
-        params.table_id,
-        params.fields,
-      );
+    async execute({ params, client }) {
+      return createRecord(client, params.app_token, params.table_id, params.fields);
     },
   });
 
@@ -719,9 +704,9 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable Update Record",
     description: "Update an existing record (row) in a Bitable table",
     parameters: UpdateRecordSchema,
-    async execute({ params, defaultAccountId }) {
+    async execute({ params, client }) {
       return updateRecord(
-        getClient(params, defaultAccountId),
+        client,
         params.app_token,
         params.table_id,
         params.record_id,
@@ -735,8 +720,8 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable Create App",
     description: "Create a new Bitable (multidimensional table) application",
     parameters: CreateAppSchema,
-    async execute({ params, defaultAccountId }) {
-      return createApp(getClient(params, defaultAccountId), params.name, params.folder_token, {
+    async execute({ params, client }) {
+      return createApp(client, params.name, params.folder_token, {
         debug: (msg) => api.logger.debug?.(msg),
         warn: (msg) => api.logger.warn?.(msg),
       });
@@ -755,9 +740,9 @@ export function registerFeishuBitableTools(api: OpenClawPluginApi) {
     label: "Feishu Bitable Create Field",
     description: "Create a new field (column) in a Bitable table",
     parameters: CreateFieldSchema,
-    async execute({ params, defaultAccountId }) {
+    async execute({ params, client }) {
       return createField(
-        getClient(params, defaultAccountId),
+        client,
         params.app_token,
         params.table_id,
         params.field_name,

--- a/extensions/feishu/src/chat.test.ts
+++ b/extensions/feishu/src/chat.test.ts
@@ -501,9 +501,10 @@ describe("registerFeishuChatTools", () => {
     expect(chatMembersGetMock).toHaveBeenCalledTimes(1);
   });
 
-  it("skips registration when chat tool is disabled", () => {
-    const [, registerTool] = registerChatTool({ account: { tools: { chat: false } } });
-    expect(registerTool).not.toHaveBeenCalled();
+  it("does not expose the disabled chat tool", () => {
+    const [tool] = registerChatTool({ account: { tools: { chat: false } } });
+    expect(tool).toBeFalsy();
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
   });
 
   it("preserves Feishu diagnostics from rejected member lookups", async () => {

--- a/extensions/feishu/src/chat.ts
+++ b/extensions/feishu/src/chat.ts
@@ -238,126 +238,122 @@ export async function getFeishuMemberInfo(
 }
 
 export function registerFeishuChatTools(api: OpenClawPluginApi) {
-  if (!api.config) {
-    return;
-  }
-  const cfg = api.config;
-
-  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(cfg);
-  if (!toolsCfg.chat) {
-    return;
-  }
-
   api.registerTool(
-    (toolContext: OpenClawPluginToolContext) => ({
-      name: "feishu_chat",
-      resultContentSource: "network",
-      label: "Feishu Chat",
-      description: "Feishu chat operations. Actions: members, info, member_info",
-      parameters: FeishuChatSchema,
-      async execute(_toolCallId, params) {
-        const rawParams = params as Record<string, unknown>;
-        const p = params as FeishuChatParams;
-        try {
-          const account = resolveFeishuToolAccount({
-            api,
-            defaultAccountId: toolContext.agentAccountId,
-            requiredTool: { family: "chat", label: "chat" },
-          });
-          const client = createFeishuClient(account);
-          switch (p.action) {
-            case "members":
-              if (!p.chat_id) {
-                return json({ error: "chat_id is required for action members" });
-              }
-              {
-                const chat = await getAuthorizedFeishuChatInfo({
-                  client,
-                  cfg,
-                  account,
-                  chatId: p.chat_id,
-                  ctx: toolContext,
-                });
-                const authorization = authorizeFeishuChatMemberRead({
-                  cfg,
-                  account,
-                  chatId: p.chat_id,
-                  chatType: resolveFeishuChatType(chat),
-                  ctx: toolContext,
-                  memberIdType: p.member_id_type,
-                });
-                if (authorization.kind === "direct") {
-                  return json(buildFeishuDirectChatMembers(authorization));
+    (toolContext: OpenClawPluginToolContext) => {
+      const cfg = toolContext.runtimeConfig ?? toolContext.config ?? api.config;
+      if (!cfg || !resolveAnyEnabledFeishuToolsConfig(cfg).chat) {
+        return null;
+      }
+      return {
+        name: "feishu_chat",
+        resultContentSource: "network",
+        label: "Feishu Chat",
+        description: "Feishu chat operations. Actions: members, info, member_info",
+        parameters: FeishuChatSchema,
+        async execute(_toolCallId, params) {
+          const rawParams = params as Record<string, unknown>;
+          const p = params as FeishuChatParams;
+          try {
+            const account = resolveFeishuToolAccount({
+              cfg,
+              defaultAccountId: toolContext.agentAccountId,
+              requiredTool: { family: "chat", label: "chat" },
+            });
+            const client = createFeishuClient(account);
+            switch (p.action) {
+              case "members":
+                if (!p.chat_id) {
+                  return json({ error: "chat_id is required for action members" });
                 }
-              }
-              return json(
-                await getChatMembers(
-                  client,
-                  p.chat_id,
-                  readChatPageSize(rawParams),
-                  p.page_token,
-                  p.member_id_type,
-                ),
-              );
-            case "info":
-              if (!p.chat_id) {
-                return json({ error: "chat_id is required for action info" });
-              }
-              {
-                const chat = await getAuthorizedFeishuChatInfo({
-                  client,
-                  cfg,
-                  account,
-                  chatId: p.chat_id,
-                  ctx: toolContext,
-                });
-                return json(chat);
-              }
-            case "member_info":
-              if (!p.member_id) {
-                return json({ error: "member_id is required for action member_info" });
-              }
-              if (!p.chat_id) {
-                return json({ error: "chat_id is required for action member_info" });
-              }
-              {
-                const chat = await getAuthorizedFeishuChatInfo({
-                  client,
-                  cfg,
-                  account,
-                  chatId: p.chat_id,
-                  ctx: toolContext,
-                });
-                const authorization = authorizeFeishuChatMemberRead({
-                  cfg,
-                  account,
-                  chatId: p.chat_id,
-                  chatType: resolveFeishuChatType(chat),
-                  ctx: toolContext,
-                  memberId: p.member_id,
-                  memberIdType: p.member_id_type,
-                });
-                if (authorization.kind === "group") {
-                  const memberIdType = p.member_id_type ?? "open_id";
-                  await assertFeishuChatMember(client, p.chat_id, p.member_id, memberIdType);
-                  return json(await getFeishuMemberInfo(client, p.member_id, memberIdType));
+                {
+                  const chat = await getAuthorizedFeishuChatInfo({
+                    client,
+                    cfg,
+                    account,
+                    chatId: p.chat_id,
+                    ctx: toolContext,
+                  });
+                  const authorization = authorizeFeishuChatMemberRead({
+                    cfg,
+                    account,
+                    chatId: p.chat_id,
+                    chatType: resolveFeishuChatType(chat),
+                    ctx: toolContext,
+                    memberIdType: p.member_id_type,
+                  });
+                  if (authorization.kind === "direct") {
+                    return json(buildFeishuDirectChatMembers(authorization));
+                  }
                 }
                 return json(
-                  await getFeishuMemberInfo(
+                  await getChatMembers(
                     client,
-                    authorization.memberId,
-                    authorization.memberIdType,
+                    p.chat_id,
+                    readChatPageSize(rawParams),
+                    p.page_token,
+                    p.member_id_type,
                   ),
                 );
-              }
-            default:
-              return json({ error: `Unknown action: ${String(p.action)}` });
+              case "info":
+                if (!p.chat_id) {
+                  return json({ error: "chat_id is required for action info" });
+                }
+                {
+                  const chat = await getAuthorizedFeishuChatInfo({
+                    client,
+                    cfg,
+                    account,
+                    chatId: p.chat_id,
+                    ctx: toolContext,
+                  });
+                  return json(chat);
+                }
+              case "member_info":
+                if (!p.member_id) {
+                  return json({ error: "member_id is required for action member_info" });
+                }
+                if (!p.chat_id) {
+                  return json({ error: "chat_id is required for action member_info" });
+                }
+                {
+                  const chat = await getAuthorizedFeishuChatInfo({
+                    client,
+                    cfg,
+                    account,
+                    chatId: p.chat_id,
+                    ctx: toolContext,
+                  });
+                  const authorization = authorizeFeishuChatMemberRead({
+                    cfg,
+                    account,
+                    chatId: p.chat_id,
+                    chatType: resolveFeishuChatType(chat),
+                    ctx: toolContext,
+                    memberId: p.member_id,
+                    memberIdType: p.member_id_type,
+                  });
+                  if (authorization.kind === "group") {
+                    const memberIdType = p.member_id_type ?? "open_id";
+                    await assertFeishuChatMember(client, p.chat_id, p.member_id, memberIdType);
+                    return json(await getFeishuMemberInfo(client, p.member_id, memberIdType));
+                  }
+                  return json(
+                    await getFeishuMemberInfo(
+                      client,
+                      authorization.memberId,
+                      authorization.memberIdType,
+                    ),
+                  );
+                }
+              default:
+                return json({ error: `Unknown action: ${String(p.action)}` });
+            }
+          } catch (err) {
+            return json({ error: formatFeishuApiError(err, { includeNestedErrorLogId: true }) });
           }
-        } catch (err) {
-          return json({ error: formatFeishuApiError(err, { includeNestedErrorLogId: true }) });
-        }
-      },
-    }),
+        },
+      };
+    },
     {
       name: "feishu_chat",
     },

--- a/extensions/feishu/src/docx-create-loopback.test.ts
+++ b/extensions/feishu/src/docx-create-loopback.test.ts
@@ -8,11 +8,10 @@ import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 const readRemoteMediaBufferMock = vi.hoisted(() => vi.fn());
 const toolAccountModule = await import("./tool-account.js");
+const clientModule = await import("./client.js");
 const runtimeModule = await import("./runtime.js");
 
-vi.spyOn(toolAccountModule, "createFeishuToolClient").mockImplementation(() =>
-  createFeishuClientMock(),
-);
+vi.spyOn(clientModule, "createFeishuClient").mockImplementation(() => createFeishuClientMock());
 vi.spyOn(toolAccountModule, "resolveAnyEnabledFeishuToolsConfig").mockReturnValue({
   doc: true,
   chat: false,

--- a/extensions/feishu/src/docx-table-actions.test.ts
+++ b/extensions/feishu/src/docx-table-actions.test.ts
@@ -7,9 +7,8 @@ import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
 
 const createFeishuClientMock = vi.hoisted(() => vi.fn());
 const toolAccountModule = await import("./tool-account.js");
-vi.spyOn(toolAccountModule, "createFeishuToolClient").mockImplementation(() =>
-  createFeishuClientMock(),
-);
+const clientModule = await import("./client.js");
+vi.spyOn(clientModule, "createFeishuClient").mockImplementation(() => createFeishuClientMock());
 vi.spyOn(toolAccountModule, "resolveAnyEnabledFeishuToolsConfig").mockReturnValue({
   doc: true,
   chat: false,
@@ -77,7 +76,11 @@ function createClient(httpInstance?: Lark.HttpInstance) {
 
 function resolveTool(client: Lark.Client) {
   createFeishuClientMock.mockReturnValue(client);
-  const harness = createToolFactoryHarness({});
+  const harness = createToolFactoryHarness({
+    channels: {
+      feishu: { enabled: true, appId: "table-app", appSecret: "table-placeholder" }, // pragma: allowlist secret
+    },
+  });
   registerFeishuDocTools(harness.api);
   return harness.resolveTool("feishu_doc");
 }

--- a/extensions/feishu/src/docx.test.ts
+++ b/extensions/feishu/src/docx.test.ts
@@ -24,11 +24,10 @@ const permissionMemberCreateMock = vi.hoisted(() => vi.fn());
 const blockPatchMock = vi.hoisted(() => vi.fn());
 const scopeListMock = vi.hoisted(() => vi.fn());
 const toolAccountModule = await import("./tool-account.js");
+const clientModule = await import("./client.js");
 const runtimeModule = await import("./runtime.js");
 
-vi.spyOn(toolAccountModule, "createFeishuToolClient").mockImplementation(() =>
-  createFeishuClientMock(),
-);
+vi.spyOn(clientModule, "createFeishuClient").mockImplementation(() => createFeishuClientMock());
 vi.spyOn(toolAccountModule, "resolveAnyEnabledFeishuToolsConfig").mockReturnValue({
   doc: true,
   chat: false,

--- a/extensions/feishu/src/docx.ts
+++ b/extensions/feishu/src/docx.ts
@@ -6,6 +6,7 @@ import { normalizeOptionalString, uniqueStrings } from "openclaw/plugin-sdk/stri
 import { Type } from "typebox";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { resolveConfiguredHttpTimeoutMs } from "./client-timeout.js";
+import { createFeishuClient } from "./client.js";
 import { FeishuDocSchema, type FeishuDocParams } from "./doc-schema.js";
 import { BATCH_SIZE, insertBlocksInBatches } from "./docx-batch-insert.js";
 import { updateColorText } from "./docx-color-text.js";
@@ -1158,211 +1159,180 @@ async function listAppScopes(client: Lark.Client) {
 // ============ Tool Registration ============
 
 export function registerFeishuDocTools(api: OpenClawPluginApi) {
-  if (!api.config) {
-    return;
-  }
-
-  // Register if enabled on any account; account routing is resolved per execution.
-  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(api.config);
-
   type FeishuDocExecuteParams = FeishuDocParams & { accountId?: string };
 
-  const getClient = (params: { accountId?: string } | undefined, defaultAccountId?: string) =>
-    createFeishuToolClient({
-      api,
-      executeParams: params,
-      defaultAccountId,
-      requiredTool: { family: "doc", label: "Doc" },
-    });
-
-  const getMediaMaxBytes = (
-    params: { accountId?: string } | undefined,
-    defaultAccountId?: string,
-  ) =>
-    (resolveFeishuToolAccount({
-      api,
-      executeParams: params,
-      defaultAccountId,
-      requiredTool: { family: "doc", label: "Doc" },
-    }).config?.mediaMaxMb ?? 30) *
-    1024 *
-    1024;
-
-  const getImageReadTimeoutMs = (
-    params: { accountId?: string } | undefined,
-    defaultAccountId?: string,
-  ) =>
-    resolveConfiguredHttpTimeoutMs(
-      resolveFeishuToolAccount({
-        api,
-        executeParams: params,
-        defaultAccountId,
-        requiredTool: { family: "doc", label: "Doc" },
-      }),
-    );
-
-  // Main document tool with action-based dispatch
-  if (toolsCfg.doc) {
-    api.registerTool(
-      (ctx) => {
-        const defaultAccountId = ctx.agentAccountId;
-        const mediaLocalRoots = resolveDocToolLocalRoots(ctx);
-        const trustedRequesterOpenId =
-          ctx.messageChannel === "feishu"
-            ? normalizeOptionalString(ctx.requesterSenderId)
-            : undefined;
-        return {
-          name: "feishu_doc",
-          resultContentSource: "network",
-          label: "Feishu Doc",
-          description:
-            "Feishu document operations. Actions: read, write, append, insert, create, list_blocks, get_block, update_block, delete_block, create_table, write_table_cells, create_table_with_values, insert_table_row, insert_table_column, delete_table_rows, delete_table_columns, merge_table_cells, upload_image, upload_file, color_text",
-          parameters: FeishuDocSchema,
-          async execute(_toolCallId, params) {
-            const p = params as FeishuDocExecuteParams;
-            try {
-              // Feishu creates title-only docs; flattened tool schemas can still expose
-              // sibling `content`, so reject it before creating an empty document.
-              if (p.action === "create" && Object.hasOwn(p, "content")) {
-                return json({
-                  error:
-                    'Feishu document creation does not support content. Call action "create" first, then call action "write" with the returned document_id as doc_token.',
-                });
-              }
-              const client = getClient(p, defaultAccountId);
-              switch (p.action) {
-                case "read":
-                  return json(await readDoc(client, p.doc_token));
-                case "write":
-                  return json(
-                    await writeDoc(
-                      client,
-                      p.doc_token,
-                      p.content,
-                      getMediaMaxBytes(p, defaultAccountId),
-                      getImageReadTimeoutMs(p, defaultAccountId),
-                      api.logger,
-                    ),
-                  );
-                case "append":
-                  return json(
-                    await appendDoc(
-                      client,
-                      p.doc_token,
-                      p.content,
-                      getMediaMaxBytes(p, defaultAccountId),
-                      getImageReadTimeoutMs(p, defaultAccountId),
-                      api.logger,
-                    ),
-                  );
-                case "insert":
-                  return json(
-                    await insertDoc(
-                      client,
-                      p.doc_token,
-                      p.content,
-                      p.after_block_id,
-                      getMediaMaxBytes(p, defaultAccountId),
-                      getImageReadTimeoutMs(p, defaultAccountId),
-                      api.logger,
-                    ),
-                  );
-                case "create":
-                  return json(
-                    await createDoc(client, p.title, p.folder_token, {
-                      grantToRequester: p.grant_to_requester,
-                      requesterOpenId: trustedRequesterOpenId,
-                    }),
-                  );
-                case "list_blocks":
-                  return json(await listBlocks(client, p.doc_token));
-                case "get_block":
-                  return json(await getBlock(client, p.doc_token, p.block_id));
-                case "update_block":
-                  return json(await updateBlock(client, p.doc_token, p.block_id, p.content));
-                case "delete_block":
-                  return json(await deleteBlock(client, p.doc_token, p.block_id));
-                case "create_table":
-                  return json(
-                    await createTable(
-                      client,
-                      p.doc_token,
-                      p.row_size,
-                      p.column_size,
-                      p.parent_block_id,
-                      p.column_width,
-                    ),
-                  );
-                case "write_table_cells":
-                  return json(
-                    await writeTableCells(client, p.doc_token, p.table_block_id, p.values),
-                  );
-                case "create_table_with_values":
-                  return json(
-                    await createTableWithValues(
-                      client,
-                      p.doc_token,
-                      p.row_size,
-                      p.column_size,
-                      p.values,
-                      p.parent_block_id,
-                      p.column_width,
-                    ),
-                  );
-                case "upload_image":
-                  return json(
-                    await uploadImageBlock(
-                      client,
-                      p.doc_token,
-                      getMediaMaxBytes(p, defaultAccountId),
-                      getImageReadTimeoutMs(p, defaultAccountId),
-                      mediaLocalRoots,
-                      p.url,
-                      p.file_path,
-                      p.parent_block_id,
-                      p.filename,
-                      p.index,
-                      p.image, // data URI or plain base64
-                    ),
-                  );
-                case "upload_file":
-                  return json(
-                    await uploadFileBlock(
-                      client,
-                      p.doc_token,
-                      getMediaMaxBytes(p, defaultAccountId),
-                      mediaLocalRoots,
-                      p.url,
-                      p.file_path,
-                      p.parent_block_id,
-                      p.filename,
-                    ),
-                  );
-                case "color_text":
-                  return json(await updateColorText(client, p.doc_token, p.block_id, p.content));
-                case "insert_table_row":
-                case "insert_table_column":
-                case "delete_table_rows":
-                case "delete_table_columns":
-                case "merge_table_cells":
-                  return json(await patchTable(client, p));
-                default:
-                  return json({ error: "Unknown action" });
-              }
-            } catch (err) {
-              return json({ error: formatErrorMessage(err) });
+  api.registerTool(
+    (ctx) => {
+      const cfg = ctx.runtimeConfig ?? ctx.config ?? api.config;
+      if (!cfg || !resolveAnyEnabledFeishuToolsConfig(cfg).doc) {
+        return null;
+      }
+      const defaultAccountId = ctx.agentAccountId;
+      const mediaLocalRoots = resolveDocToolLocalRoots(ctx);
+      const trustedRequesterOpenId =
+        ctx.messageChannel === "feishu"
+          ? normalizeOptionalString(ctx.requesterSenderId)
+          : undefined;
+      return {
+        name: "feishu_doc",
+        resultContentSource: "network",
+        label: "Feishu Doc",
+        description:
+          "Feishu document operations. Actions: read, write, append, insert, create, list_blocks, get_block, update_block, delete_block, create_table, write_table_cells, create_table_with_values, insert_table_row, insert_table_column, delete_table_rows, delete_table_columns, merge_table_cells, upload_image, upload_file, color_text",
+        parameters: FeishuDocSchema,
+        async execute(_toolCallId, params) {
+          const p = params as FeishuDocExecuteParams;
+          try {
+            // Feishu creates title-only docs; flattened tool schemas can still expose
+            // sibling `content`, so reject it before creating an empty document.
+            if (p.action === "create" && Object.hasOwn(p, "content")) {
+              return json({
+                error:
+                  'Feishu document creation does not support content. Call action "create" first, then call action "write" with the returned document_id as doc_token.',
+              });
             }
-          },
-        };
-      },
-      { name: "feishu_doc" },
-    );
-  }
+            const account = resolveFeishuToolAccount({
+              cfg,
+              executeParams: p,
+              defaultAccountId,
+              requiredTool: { family: "doc", label: "Doc" },
+            });
+            const client = createFeishuClient(account);
+            const mediaMaxBytes = (account.config.mediaMaxMb ?? 30) * 1024 * 1024;
+            const imageReadTimeoutMs = resolveConfiguredHttpTimeoutMs(account);
+            switch (p.action) {
+              case "read":
+                return json(await readDoc(client, p.doc_token));
+              case "write":
+                return json(
+                  await writeDoc(
+                    client,
+                    p.doc_token,
+                    p.content,
+                    mediaMaxBytes,
+                    imageReadTimeoutMs,
+                    api.logger,
+                  ),
+                );
+              case "append":
+                return json(
+                  await appendDoc(
+                    client,
+                    p.doc_token,
+                    p.content,
+                    mediaMaxBytes,
+                    imageReadTimeoutMs,
+                    api.logger,
+                  ),
+                );
+              case "insert":
+                return json(
+                  await insertDoc(
+                    client,
+                    p.doc_token,
+                    p.content,
+                    p.after_block_id,
+                    mediaMaxBytes,
+                    imageReadTimeoutMs,
+                    api.logger,
+                  ),
+                );
+              case "create":
+                return json(
+                  await createDoc(client, p.title, p.folder_token, {
+                    grantToRequester: p.grant_to_requester,
+                    requesterOpenId: trustedRequesterOpenId,
+                  }),
+                );
+              case "list_blocks":
+                return json(await listBlocks(client, p.doc_token));
+              case "get_block":
+                return json(await getBlock(client, p.doc_token, p.block_id));
+              case "update_block":
+                return json(await updateBlock(client, p.doc_token, p.block_id, p.content));
+              case "delete_block":
+                return json(await deleteBlock(client, p.doc_token, p.block_id));
+              case "create_table":
+                return json(
+                  await createTable(
+                    client,
+                    p.doc_token,
+                    p.row_size,
+                    p.column_size,
+                    p.parent_block_id,
+                    p.column_width,
+                  ),
+                );
+              case "write_table_cells":
+                return json(await writeTableCells(client, p.doc_token, p.table_block_id, p.values));
+              case "create_table_with_values":
+                return json(
+                  await createTableWithValues(
+                    client,
+                    p.doc_token,
+                    p.row_size,
+                    p.column_size,
+                    p.values,
+                    p.parent_block_id,
+                    p.column_width,
+                  ),
+                );
+              case "upload_image":
+                return json(
+                  await uploadImageBlock(
+                    client,
+                    p.doc_token,
+                    mediaMaxBytes,
+                    imageReadTimeoutMs,
+                    mediaLocalRoots,
+                    p.url,
+                    p.file_path,
+                    p.parent_block_id,
+                    p.filename,
+                    p.index,
+                    p.image, // data URI or plain base64
+                  ),
+                );
+              case "upload_file":
+                return json(
+                  await uploadFileBlock(
+                    client,
+                    p.doc_token,
+                    mediaMaxBytes,
+                    mediaLocalRoots,
+                    p.url,
+                    p.file_path,
+                    p.parent_block_id,
+                    p.filename,
+                  ),
+                );
+              case "color_text":
+                return json(await updateColorText(client, p.doc_token, p.block_id, p.content));
+              case "insert_table_row":
+              case "insert_table_column":
+              case "delete_table_rows":
+              case "delete_table_columns":
+              case "merge_table_cells":
+                return json(await patchTable(client, p));
+              default:
+                return json({ error: "Unknown action" });
+            }
+          } catch (err) {
+            return json({ error: formatErrorMessage(err) });
+          }
+        },
+      };
+    },
+    { name: "feishu_doc" },
+  );
 
-  // Keep feishu_app_scopes as independent tool
-  if (toolsCfg.scopes) {
-    api.registerTool(
-      (ctx) => ({
+  api.registerTool(
+    (ctx) => {
+      const cfg = ctx.runtimeConfig ?? ctx.config ?? api.config;
+      if (!cfg || !resolveAnyEnabledFeishuToolsConfig(cfg).scopes) {
+        return null;
+      }
+      return {
         name: "feishu_app_scopes",
         resultContentSource: "network",
         label: "Feishu App Scopes",
@@ -1373,7 +1343,7 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
           try {
             const result = await listAppScopes(
               createFeishuToolClient({
-                api,
+                cfg,
                 defaultAccountId: ctx.agentAccountId,
                 requiredTool: { family: "scopes", label: "App Scopes" },
               }),
@@ -1383,9 +1353,9 @@ export function registerFeishuDocTools(api: OpenClawPluginApi) {
             return json({ error: formatErrorMessage(err) });
           }
         },
-      }),
-      { name: "feishu_app_scopes" },
-    );
-  }
+      };
+    },
+    { name: "feishu_app_scopes" },
+  );
 }
 /* oxlint-disable max-lines -- TODO: split this grandfathered oversized file. */

--- a/extensions/feishu/src/drive.ts
+++ b/extensions/feishu/src/drive.ts
@@ -722,19 +722,14 @@ export async function deliverCommentThreadText(
 // ============ Tool Registration ============
 
 export function registerFeishuDriveTools(api: OpenClawPluginApi) {
-  if (!api.config) {
-    return;
-  }
-
-  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(api.config);
-  if (!toolsCfg.drive) {
-    return;
-  }
-
   type FeishuDriveExecuteParams = FeishuDriveParams & { accountId?: string };
 
   api.registerTool(
     (ctx) => {
+      const cfg = ctx.runtimeConfig ?? ctx.config ?? api.config;
+      if (!cfg || !resolveAnyEnabledFeishuToolsConfig(cfg).drive) {
+        return null;
+      }
       const defaultAccountId = ctx.agentAccountId;
       return {
         name: "feishu_drive",
@@ -747,7 +742,7 @@ export function registerFeishuDriveTools(api: OpenClawPluginApi) {
           const p = params as FeishuDriveExecuteParams;
           try {
             const client = createFeishuToolClient({
-              api,
+              cfg,
               executeParams: p,
               defaultAccountId,
               requiredTool: { family: "drive", label: "Drive" },

--- a/extensions/feishu/src/perm.ts
+++ b/extensions/feishu/src/perm.ts
@@ -113,19 +113,14 @@ async function removeMember(
 // ============ Tool Registration ============
 
 export function registerFeishuPermTools(api: OpenClawPluginApi) {
-  if (!api.config) {
-    return;
-  }
-
-  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(api.config);
-  if (!toolsCfg.perm) {
-    return;
-  }
-
   type FeishuPermExecuteParams = FeishuPermParams & { accountId?: string };
 
   api.registerTool(
     (ctx) => {
+      const cfg = ctx.runtimeConfig ?? ctx.config ?? api.config;
+      if (!cfg || !resolveAnyEnabledFeishuToolsConfig(cfg).perm) {
+        return null;
+      }
       const defaultAccountId = ctx.agentAccountId;
       return {
         name: "feishu_perm",
@@ -137,7 +132,7 @@ export function registerFeishuPermTools(api: OpenClawPluginApi) {
           const p = params as FeishuPermExecuteParams;
           try {
             const client = createFeishuToolClient({
-              api,
+              cfg,
               executeParams: p,
               defaultAccountId,
               requiredTool: { family: "perm", label: "Perm" },

--- a/extensions/feishu/src/tool-account-routing.test.ts
+++ b/extensions/feishu/src/tool-account-routing.test.ts
@@ -2,6 +2,7 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import type { OpenClawPluginApi } from "../runtime-api.js";
 import { createToolFactoryHarness } from "./tool-factory-test-harness.js";
+import type { FeishuToolsConfig } from "./types.js";
 
 const createFeishuClientMock = vi.fn((account: { appId?: string } | undefined) => ({
   __appId: account?.appId,
@@ -27,24 +28,9 @@ let registerFeishuPermTools: typeof import("./perm.js").registerFeishuPermTools;
 let registerFeishuWikiTools: typeof import("./wiki.js").registerFeishuWikiTools;
 
 function createConfig(params: {
-  topTools?: {
-    wiki?: boolean;
-    drive?: boolean;
-    perm?: boolean;
-    bitable?: boolean;
-  };
-  toolsA?: {
-    wiki?: boolean;
-    drive?: boolean;
-    perm?: boolean;
-    bitable?: boolean;
-  };
-  toolsB?: {
-    wiki?: boolean;
-    drive?: boolean;
-    perm?: boolean;
-    bitable?: boolean;
-  };
+  topTools?: FeishuToolsConfig;
+  toolsA?: FeishuToolsConfig;
+  toolsB?: FeishuToolsConfig;
   defaultAccount?: string;
   enabledA?: boolean;
 }): OpenClawPluginApi["config"] {
@@ -108,6 +94,53 @@ describe("feishu tool account routing", () => {
   });
 
   test.each([
+    ["doc", "feishu_doc"],
+    ["scopes", "feishu_app_scopes"],
+    ["chat", "feishu_chat"],
+    ["wiki", "feishu_wiki"],
+    ["drive", "feishu_drive"],
+    ["perm", "feishu_perm"],
+    ["bitable", "feishu_bitable_get_meta"],
+  ] as const)("uses current factory config for %s availability", (family, name) => {
+    const disabled = createConfig({ topTools: { [family]: false } });
+    const enabled = createConfig({ topTools: { [family]: true } });
+    const { api, resolveTool } = createToolFactoryHarness(disabled);
+    for (const register of [
+      registerFeishuDocTools,
+      registerFeishuChatTools,
+      registerFeishuWikiTools,
+      registerFeishuDriveTools,
+      registerFeishuPermTools,
+      registerFeishuBitableTools,
+    ]) {
+      register(api);
+    }
+
+    expect(() => resolveTool(name)).toThrow("Tool not registered");
+    expect(resolveTool(name, { config: disabled, runtimeConfig: enabled }).name).toBe(name);
+    expect(() => resolveTool(name, { config: enabled, runtimeConfig: disabled })).toThrow(
+      "Tool not registered",
+    );
+    expect(resolveTool(name, { config: enabled }).name).toBe(name);
+    expect(createFeishuClientMock).not.toHaveBeenCalled();
+  });
+
+  test("uses the factory config for account selection without changing older tools", async () => {
+    const original = createConfig({ defaultAccount: "a" });
+    const current = createConfig({ defaultAccount: "b" });
+    const { api, resolveTool } = createToolFactoryHarness(original);
+    registerFeishuWikiTools(api);
+    const previousTool = resolveTool("feishu_wiki");
+    const currentTool = resolveTool("feishu_wiki", { config: original, runtimeConfig: current });
+
+    await currentTool.execute("current", { action: "search" });
+    await previousTool.execute("previous", { action: "search" });
+
+    expect(clientAppIdAt(0)).toBe("app-b");
+    expect(clientAppIdAt(1)).toBe("app-a");
+  });
+
+  test.each([
     ["missing channel", {}],
     ["unconfigured account", { channels: { feishu: { accounts: { a: { enabled: true } } } } }],
     [
@@ -126,8 +159,8 @@ describe("feishu tool account routing", () => {
         },
       },
     ],
-  ])("does not register workplace tools for %s", (_label, config) => {
-    const { api, registered } = createToolFactoryHarness(config);
+  ])("does not expose workplace tools for %s", (_label, config) => {
+    const { api, resolveTool } = createToolFactoryHarness(config);
     for (const register of [
       registerFeishuDocTools,
       registerFeishuChatTools,
@@ -138,7 +171,17 @@ describe("feishu tool account routing", () => {
     ]) {
       register(api);
     }
-    expect(registered).toEqual([]);
+    for (const name of [
+      "feishu_doc",
+      "feishu_app_scopes",
+      "feishu_chat",
+      "feishu_wiki",
+      "feishu_drive",
+      "feishu_perm",
+      "feishu_bitable_get_meta",
+    ]) {
+      expect(() => resolveTool(name)).toThrow("Tool not registered");
+    }
     expect(createFeishuClientMock).not.toHaveBeenCalled();
   });
 
@@ -400,21 +443,18 @@ describe("feishu tool account routing", () => {
   });
 
   test("bitable tools are not registered when top-level bitable config disables them", async () => {
-    const { api, registered, resolveTool } = createToolFactoryHarness(
+    const { api, resolveTool } = createToolFactoryHarness(
       createConfig({
         topTools: { bitable: false },
       }),
     );
     registerFeishuBitableTools(api);
 
-    expect(
-      registered.filter((entry) => entry.opts?.name?.startsWith("feishu_bitable_")).length,
-    ).toBe(0);
     expect(() => resolveTool("feishu_bitable_get_meta")).toThrow("Tool not registered");
   });
 
   test("top-level bitable disable wins over account-level bitable enable", async () => {
-    const { api, registered, resolveTool } = createToolFactoryHarness(
+    const { api, resolveTool } = createToolFactoryHarness(
       createConfig({
         topTools: { bitable: false },
         toolsA: { bitable: true },
@@ -423,14 +463,11 @@ describe("feishu tool account routing", () => {
     );
     registerFeishuBitableTools(api);
 
-    expect(
-      registered.filter((entry) => entry.opts?.name?.startsWith("feishu_bitable_")).length,
-    ).toBe(0);
     expect(() => resolveTool("feishu_bitable_get_meta")).toThrow("Tool not registered");
   });
 
   test("bitable tools are not registered when account bitable configs disable them", async () => {
-    const { api, registered, resolveTool } = createToolFactoryHarness(
+    const { api, resolveTool } = createToolFactoryHarness(
       createConfig({
         toolsA: { bitable: false },
         toolsB: { bitable: false },
@@ -438,9 +475,6 @@ describe("feishu tool account routing", () => {
     );
     registerFeishuBitableTools(api);
 
-    expect(
-      registered.filter((entry) => entry.opts?.name?.startsWith("feishu_bitable_")).length,
-    ).toBe(0);
     expect(() => resolveTool("feishu_bitable_get_meta")).toThrow("Tool not registered");
   });
 

--- a/extensions/feishu/src/tool-account.test.ts
+++ b/extensions/feishu/src/tool-account.test.ts
@@ -34,7 +34,7 @@ describe("resolveFeishuToolAccount", () => {
 
   it("prefers the active contextual account over configured defaultAccount", () => {
     const resolved = resolveFeishuToolAccount({
-      api: { config: cfg },
+      cfg,
       defaultAccountId: "work",
       requiredTool,
     });
@@ -44,7 +44,7 @@ describe("resolveFeishuToolAccount", () => {
 
   it("falls back to configured defaultAccount when there is no contextual account", () => {
     const resolved = resolveFeishuToolAccount({
-      api: { config: cfg },
+      cfg,
       requiredTool,
     });
 
@@ -53,13 +53,11 @@ describe("resolveFeishuToolAccount", () => {
 
   it("skips a disabled configured defaultAccount", () => {
     const resolved = resolveFeishuToolAccount({
-      api: {
-        config: {
-          channels: {
-            feishu: {
-              ...cfg.channels.feishu,
-              defaultAccount: "disabled",
-            },
+      cfg: {
+        channels: {
+          feishu: {
+            ...cfg.channels.feishu,
+            defaultAccount: "disabled",
           },
         },
       },
@@ -73,13 +71,11 @@ describe("resolveFeishuToolAccount", () => {
   it("rejects tool account resolution when the channel is disabled", () => {
     expect(() =>
       resolveFeishuToolAccount({
-        api: {
-          config: {
-            channels: {
-              feishu: {
-                ...cfg.channels.feishu,
-                enabled: false,
-              },
+        cfg: {
+          channels: {
+            feishu: {
+              ...cfg.channels.feishu,
+              enabled: false,
             },
           },
         },
@@ -90,7 +86,7 @@ describe("resolveFeishuToolAccount", () => {
 
   it("allows an explicit configured account", () => {
     const resolved = resolveFeishuToolAccount({
-      api: { config: cfg },
+      cfg,
       executeParams: { accountId: "WORK" },
       requiredTool,
     });
@@ -100,14 +96,12 @@ describe("resolveFeishuToolAccount", () => {
 
   it("allows the explicit unlisted default backed by top-level credentials", () => {
     const resolved = resolveFeishuToolAccount({
-      api: {
-        config: {
-          channels: {
-            feishu: {
-              defaultAccount: "ops",
-              appId: "base-app-id",
-              appSecret: "base-app-secret", // pragma: allowlist secret
-            },
+      cfg: {
+        channels: {
+          feishu: {
+            defaultAccount: "ops",
+            appId: "base-app-id",
+            appSecret: "base-app-secret", // pragma: allowlist secret
           },
         },
       },
@@ -126,7 +120,7 @@ describe("resolveFeishuToolAccount", () => {
   ])("rejects an explicit $name account", (testCase) => {
     expect(() =>
       resolveFeishuToolAccount({
-        api: { config: cfg },
+        cfg,
         executeParams: { accountId: testCase.accountId },
         requiredTool,
       }),

--- a/extensions/feishu/src/tool-account.ts
+++ b/extensions/feishu/src/tool-account.ts
@@ -2,7 +2,7 @@
 import type * as Lark from "@larksuiteoapi/node-sdk";
 import { normalizeOptionalAccountId } from "openclaw/plugin-sdk/account-resolution";
 import { normalizeOptionalString } from "openclaw/plugin-sdk/string-coerce-runtime";
-import type { OpenClawPluginApi } from "../runtime-api.js";
+import type { OpenClawConfig } from "../runtime-api.js";
 import {
   listEnabledFeishuAccounts,
   listFeishuAccountIds,
@@ -22,7 +22,7 @@ type FeishuToolRequirement = {
 };
 
 function resolveImplicitToolAccountId(params: {
-  api: Pick<OpenClawPluginApi, "config">;
+  cfg: OpenClawConfig;
   executeParams?: AccountAwareParams;
   defaultAccountId?: string;
   requiredTool: FeishuToolRequirement;
@@ -34,11 +34,11 @@ function resolveImplicitToolAccountId(params: {
       throw new Error(`Invalid Feishu account ID "${explicitAccountId}"`);
     }
     const listedAccountId =
-      listFeishuAccountIds(params.api.config).find(
+      listFeishuAccountIds(params.cfg).find(
         (accountId) => normalizeOptionalAccountId(accountId) === normalizedAccountId,
       ) ??
       (() => {
-        const defaultAccountId = resolveDefaultFeishuAccountId(params.api.config);
+        const defaultAccountId = resolveDefaultFeishuAccountId(params.cfg);
         return normalizeOptionalAccountId(defaultAccountId) === normalizedAccountId
           ? defaultAccountId
           : undefined;
@@ -47,7 +47,7 @@ function resolveImplicitToolAccountId(params: {
       throw new Error(`Unknown Feishu account "${explicitAccountId}"`);
     }
     const account = resolveFeishuAccount({
-      cfg: params.api.config,
+      cfg: params.cfg,
       accountId: normalizedAccountId,
     });
     if (!account.enabled) {
@@ -57,12 +57,9 @@ function resolveImplicitToolAccountId(params: {
   }
 
   const contextualAccountId = normalizeOptionalString(params.defaultAccountId);
-  if (
-    contextualAccountId &&
-    listFeishuAccountIds(params.api.config).includes(contextualAccountId)
-  ) {
+  if (contextualAccountId && listFeishuAccountIds(params.cfg).includes(contextualAccountId)) {
     const contextualAccount = resolveFeishuAccount({
-      cfg: params.api.config,
+      cfg: params.cfg,
       accountId: contextualAccountId,
     });
     if (contextualAccount.enabled) {
@@ -71,27 +68,24 @@ function resolveImplicitToolAccountId(params: {
   }
 
   const configuredDefaultAccountId = normalizeOptionalString(
-    (params.api.config?.channels?.feishu as { defaultAccount?: unknown } | undefined)
-      ?.defaultAccount,
+    (params.cfg.channels?.feishu as { defaultAccount?: unknown } | undefined)?.defaultAccount,
   );
   // A routing preference must not reactivate credentials that the operator disabled.
   if (
     configuredDefaultAccountId &&
-    resolveFeishuAccount({ cfg: params.api.config, accountId: configuredDefaultAccountId }).enabled
+    resolveFeishuAccount({ cfg: params.cfg, accountId: configuredDefaultAccountId }).enabled
   ) {
     return configuredDefaultAccountId;
   }
 
-  if (params.api.config) {
-    for (const accountId of listFeishuAccountIds(params.api.config)) {
-      const account = resolveFeishuAccount({ cfg: params.api.config, accountId });
-      if (
-        account.enabled &&
-        account.configured &&
-        resolveToolsConfig(account.config.tools)[params.requiredTool.family]
-      ) {
-        return accountId;
-      }
+  for (const accountId of listFeishuAccountIds(params.cfg)) {
+    const account = resolveFeishuAccount({ cfg: params.cfg, accountId });
+    if (
+      account.enabled &&
+      account.configured &&
+      resolveToolsConfig(account.config.tools)[params.requiredTool.family]
+    ) {
+      return accountId;
     }
   }
 
@@ -99,16 +93,13 @@ function resolveImplicitToolAccountId(params: {
 }
 
 export function resolveFeishuToolAccount(params: {
-  api: Pick<OpenClawPluginApi, "config">;
+  cfg: OpenClawConfig;
   executeParams?: AccountAwareParams;
   defaultAccountId?: string;
   requiredTool: FeishuToolRequirement;
 }): ResolvedFeishuAccount {
-  if (!params.api.config) {
-    throw new Error("Feishu config unavailable");
-  }
   const account = resolveFeishuRuntimeAccount({
-    cfg: params.api.config,
+    cfg: params.cfg,
     accountId: resolveImplicitToolAccountId(params),
   });
   if (!resolveToolsConfig(account.config.tools)[params.requiredTool.family]) {
@@ -120,7 +111,7 @@ export function resolveFeishuToolAccount(params: {
 }
 
 export function createFeishuToolClient(params: {
-  api: Pick<OpenClawPluginApi, "config">;
+  cfg: OpenClawConfig;
   executeParams?: AccountAwareParams;
   defaultAccountId?: string;
   requiredTool: FeishuToolRequirement;
@@ -129,7 +120,7 @@ export function createFeishuToolClient(params: {
 }
 
 export function resolveAnyEnabledFeishuToolsConfig(
-  config: OpenClawPluginApi["config"],
+  config: OpenClawConfig,
 ): Required<FeishuToolsConfig> {
   const accounts = listEnabledFeishuAccounts(config);
   const merged: Required<FeishuToolsConfig> = {

--- a/extensions/feishu/src/tool-factory-test-harness.ts
+++ b/extensions/feishu/src/tool-factory-test-harness.ts
@@ -1,9 +1,11 @@
+import type { OpenClawPluginToolContext } from "openclaw/plugin-sdk/plugin-entry";
 // Feishu plugin module implements tool factory test harness behavior.
 import type { OpenClawPluginApi } from "../runtime-api.js";
 
-type ToolContextLike = {
-  agentAccountId?: string;
-};
+type ToolContextLike = Pick<
+  OpenClawPluginToolContext,
+  "agentAccountId" | "config" | "runtimeConfig"
+>;
 
 export type ToolLike = {
   name: string;

--- a/extensions/feishu/src/wiki.ts
+++ b/extensions/feishu/src/wiki.ts
@@ -204,19 +204,14 @@ async function renameNode(client: Lark.Client, spaceId: string, nodeToken: strin
 // ============ Tool Registration ============
 
 export function registerFeishuWikiTools(api: OpenClawPluginApi) {
-  if (!api.config) {
-    return;
-  }
-
-  const toolsCfg = resolveAnyEnabledFeishuToolsConfig(api.config);
-  if (!toolsCfg.wiki) {
-    return;
-  }
-
   type FeishuWikiExecuteParams = FeishuWikiParams & { accountId?: string };
 
   api.registerTool(
     (ctx) => {
+      const cfg = ctx.runtimeConfig ?? ctx.config ?? api.config;
+      if (!cfg || !resolveAnyEnabledFeishuToolsConfig(cfg).wiki) {
+        return null;
+      }
       const defaultAccountId = ctx.agentAccountId;
       return {
         name: "feishu_wiki",
@@ -230,7 +225,7 @@ export function registerFeishuWikiTools(api: OpenClawPluginApi) {
           try {
             const createClient = () =>
               createFeishuToolClient({
-                api,
+                cfg,
                 executeParams: p,
                 defaultAccountId,
                 requiredTool: { family: "wiki", label: "Wiki" },


### PR DESCRIPTION
Related: #135599

## What Problem This Solves

Fixes an issue where changing Feishu tool settings or the default account could leave new agent turns using the old settings until the Gateway restarted.

## Why This Change Was Made

Keep the existing tool factories registered and evaluate availability against each turn's configuration. Account and client selection use that same snapshot. Document operations now resolve their account once, and Bitable operations share the prepared client instead of repeating the selection flow.

## User Impact

Applied settings affect newly created tools across documents, app scopes, chat, wiki, drive, permissions, and Bitable. Tools already created for an in-progress turn keep their original configuration. Existing account precedence and disabled-tool rules are preserved.

## Evidence

- Eight regression cases failed on the original code; all 149 focused tests pass after the fix. CI caught one remaining registration-count assertion (2,038 other tests passed); the corrected chat suite passes all 16 cases.
- The complete changed-file gate passes, including plugin production/test types, typed lint, contract checks, and unused-export scans.
- Production registry and tool assembly reused 14 registered factories while chat availability changed off/on/off. The real Lark SDK then requested wiki spaces using the new account, followed by the retained old tool's original account. This proof used synthetic loopback HTTP; it did not exercise an external Feishu account or Gateway config.patch.
- Independent P2 review: scoped-clean, no findings.
- Handwritten production LOC: −73. Tests: +30; test support: +2; docs: +4.
