### PR TITLE
fix(update): skip opt-in probes and preserve Doctor warnings

### DIFF
--- a/docs/cli/update.md
+++ b/docs/cli/update.md
@@ -399,6 +399,17 @@ With `--json`, stdout contains one JSON document. Doctor panels and other
 diagnostics go to stderr, so stdout can be parsed directly. Failed doctor or
 plugin finalization steps still exit non-zero.
 
+Doctor repair uses the same enabled-plugin and default-check selection as
+ordinary Doctor lint. Opt-in checks, including the managed Codex version probe,
+do not run during routine finalization. Explicit candidate checks still run
+when requested with `doctor --lint --only codex/managed-app-server`.
+The version probe has a five-second deadline, terminates its process group
+where supported, and bounds output draining when a descendant retains a pipe.
+A timed-out probe cannot be accepted merely because its direct child exited
+successfully. Nonfatal Doctor warnings appear in `postUpdate.doctor.warnings`;
+finalization reports `status: "warning"` and exits successfully when no other
+step fails. Codex runtime readiness remains owned by its plugin after restart.
+
 Finalization (including the supervisor-facing `update finalize` command) records
 phase starts and finishes immediately on stderr and in the update run ledger.
 The defaults are 30 seconds for preflight admission, config validation, config backup, and completion

--- a/extensions/codex/src/doctor.test.ts
+++ b/extensions/codex/src/doctor.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import type { HealthCheck, OpenClawConfig } from "openclaw/plugin-sdk/health";
+import { killProcessTree } from "openclaw/plugin-sdk/process-runtime";
 import { describe, expect, it, vi } from "vitest";
 import { CODEX_APP_SERVER_VERSION } from "./app-server/version.js";
 import {
@@ -135,6 +136,95 @@ describe("managed Codex doctor check", () => {
       }),
     ]);
   });
+
+  it.each(["failed", "mismatched"])(
+    "reports a %s version probe as a warning during update finalization",
+    async (failure) => {
+      const deps = managedDeps("0.146.0");
+      if (failure === "failed") {
+        deps.runVersionCommand.mockRejectedValueOnce(new Error("probe failed"));
+      }
+      const check = createCheck(deps);
+
+      await expect(
+        check.detect({
+          ...context(config()),
+          mode: "fix",
+          env: { OPENCLAW_UPDATE_POST_CORE: "1" },
+        }),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          checkId: CODEX_MANAGED_APP_SERVER_CHECK_ID,
+          severity: "warning",
+          fixHint: expect.stringContaining("after restart"),
+        }),
+      ]);
+    },
+  );
+
+  it("keeps an explicitly selected candidate lint check strict during an update", async () => {
+    const check = createCheck(managedDeps("0.146.0"));
+
+    await expect(
+      check.detect({
+        ...context(config()),
+        env: { OPENCLAW_UPDATE_POST_CORE: "1" },
+      }),
+    ).resolves.toEqual([expect.objectContaining({ severity: "error" })]);
+  });
+
+  it.skipIf(process.platform === "win32")(
+    "bounds a successful probe whose detached descendant retains its output pipes",
+    async () => {
+      const directory = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-codex-orphan-"));
+      const pidPath = path.join(directory, "orphan.pid");
+      try {
+        const command = path.join(directory, "codex");
+        await fs.writeFile(
+          command,
+          `#!${process.execPath}
+const { spawn } = require("node:child_process");
+const fs = require("node:fs");
+const orphan = spawn(process.execPath, ["-e", "setTimeout(() => process.exit(0), 10000)"], {
+  detached: true,
+  stdio: ["ignore", 1, 2],
+});
+fs.writeFileSync(${JSON.stringify(pidPath)}, String(orphan.pid));
+orphan.unref();
+console.log("codex-cli ${CODEX_APP_SERVER_VERSION}");
+`,
+          { mode: 0o755 },
+        );
+        const check = createCheck({
+          ...managedDeps(),
+          resolveNativeCommand: () => command,
+          runVersionCommand: undefined,
+        });
+        const startedAt = performance.now();
+        const findings = await check.detect({
+          ...context(config()),
+          mode: "fix",
+          env: { OPENCLAW_UPDATE_POST_CORE: "1" },
+        });
+
+        expect(performance.now() - startedAt).toBeLessThan(7_000);
+        expect(findings).toEqual([
+          expect.objectContaining({
+            checkId: CODEX_MANAGED_APP_SERVER_CHECK_ID,
+            severity: "warning",
+            message: expect.stringContaining("version check failed:"),
+          }),
+        ]);
+      } finally {
+        const orphanPid = Number(await fs.readFile(pidPath, "utf8").catch(() => ""));
+        if (orphanPid > 0) {
+          killProcessTree(orphanPid, { force: true, detached: true });
+        }
+        await fs.rm(directory, { recursive: true, force: true });
+      }
+    },
+    15_000,
+  );
 
   it("reports a missing managed launcher before execution", async () => {
     const deps = managedDeps();

--- a/extensions/codex/src/doctor.ts
+++ b/extensions/codex/src/doctor.ts
@@ -1,9 +1,8 @@
-import { execFile } from "node:child_process";
-import { promisify } from "node:util";
 import { resolveDefaultModelForAgent } from "openclaw/plugin-sdk/agent-runtime";
 import { listAgentIds, resolveAgentDir } from "openclaw/plugin-sdk/agent-scope-runtime";
 import { resolveEffectiveAgentRuntime } from "openclaw/plugin-sdk/command-auth-native";
 import type { HealthCheck, HealthFinding } from "openclaw/plugin-sdk/health";
+import { runUtf8CommandWithTimeout } from "openclaw/plugin-sdk/process-runtime";
 import {
   resolveCodexAppServerRuntimeOptions,
   resolveCodexAppServerStartOptionsForAgent,
@@ -18,7 +17,6 @@ import { CODEX_APP_SERVER_VERSION } from "./app-server/version.js";
 export const CODEX_MANAGED_APP_SERVER_CHECK_ID = "codex/managed-app-server";
 const CODEX_VERSION_TIMEOUT_MS = 5_000;
 const CODEX_VERSION_MAX_BUFFER_BYTES = 64 * 1024;
-const execFileAsync = promisify(execFile);
 
 type VersionCommandResult = {
   stdout: string;
@@ -41,13 +39,14 @@ type CodexManagedDoctorRegistrationHost = {
 
 function managedCodexFinding(params: {
   message: string;
+  severity?: HealthFinding["severity"];
   path?: string;
   requirement?: string;
   fixHint?: string;
 }): HealthFinding {
   return {
     checkId: CODEX_MANAGED_APP_SERVER_CHECK_ID,
-    severity: "error",
+    severity: params.severity ?? "error",
     source: "codex",
     message: params.message,
     ...(params.path ? { path: params.path } : {}),
@@ -66,15 +65,31 @@ function parseCodexVersion(output: string): string | undefined {
   )?.[1];
 }
 
-function runVersionCommand(command: string): Promise<VersionCommandResult> {
-  return execFileAsync(command, ["--version"], {
-    encoding: "utf8",
-    maxBuffer: CODEX_VERSION_MAX_BUFFER_BYTES,
-    timeout: CODEX_VERSION_TIMEOUT_MS,
-    // A version-only child has nothing to drain; ignored TERM would keep execFile pending.
+async function runVersionCommand(
+  command: string,
+  env: NodeJS.ProcessEnv,
+): Promise<VersionCommandResult> {
+  const result = await runUtf8CommandWithTimeout([command, "--version"], {
+    baseEnv: env,
+    input: "",
+    timeoutMs: CODEX_VERSION_TIMEOUT_MS,
+    maxOutputBytes: CODEX_VERSION_MAX_BUFFER_BYTES,
+    outputCapture: "head",
+    terminateOnOutputLimit: true,
+    killProcessTree: true,
     killSignal: "SIGKILL",
-    windowsHide: true,
+    killGraceMs: 0,
   });
+  if (result.termination !== "exit" || result.code !== 0 || result.outputLimitExceeded) {
+    throw new Error(
+      result.outputLimitExceeded
+        ? "Version output exceeded its capture limit"
+        : result.termination === "timeout"
+          ? `Version probe timed out after ${CODEX_VERSION_TIMEOUT_MS} ms`
+          : `Version probe failed (${result.signal ?? result.code ?? result.termination})`,
+    );
+  }
+  return result;
 }
 
 function createCodexManagedAppServerHealthCheck(params: {
@@ -88,7 +103,6 @@ function createCodexManagedAppServerHealthCheck(params: {
   const isDesktopCommand = params.deps?.isDesktopCommand ?? isManagedCodexDesktopCommand;
   const resolveNativeCommand =
     params.deps?.resolveNativeCommand ?? resolveManagedCodexNativeCommand;
-  const executeVersion = params.deps?.runVersionCommand ?? runVersionCommand;
 
   return {
     id: CODEX_MANAGED_APP_SERVER_CHECK_ID,
@@ -107,6 +121,11 @@ function createCodexManagedAppServerHealthCheck(params: {
       }
 
       const env = ctx.env ?? process.env;
+      const isFinalization = ctx.mode === "fix" && env.OPENCLAW_UPDATE_POST_CORE === "1";
+      const versionFailureSeverity = isFinalization ? "warning" : "error";
+      const versionFailureHint = isFinalization
+        ? "Codex readiness will be rechecked by its plugin after restart; inspect the Codex plugin if the warning persists."
+        : undefined;
       let resolved;
       for (const agentId of listAgentIds(ctx.cfg)) {
         const model = resolveDefaultModelForAgent({ cfg: ctx.cfg, agentId });
@@ -163,14 +182,18 @@ function createCodexManagedAppServerHealthCheck(params: {
 
       let output: VersionCommandResult;
       try {
-        output = await executeVersion(nativeCommand);
+        output = await (params.deps?.runVersionCommand
+          ? params.deps.runVersionCommand(nativeCommand)
+          : runVersionCommand(nativeCommand, env));
       } catch (error) {
         return [
           managedCodexFinding({
             message: `Managed Codex app-server version check failed: ${readErrorMessage(error)}`,
+            severity: versionFailureSeverity,
             path: nativeCommand,
             requirement: `Codex ${CODEX_APP_SERVER_VERSION} must report its version within ${CODEX_VERSION_TIMEOUT_MS} ms`,
             fixHint:
+              versionFailureHint ??
               "Repair or reinstall the staged OpenClaw package, then rerun the candidate check before cutover.",
           }),
         ];
@@ -180,12 +203,14 @@ function createCodexManagedAppServerHealthCheck(params: {
       if (detectedVersion !== CODEX_APP_SERVER_VERSION) {
         return [
           managedCodexFinding({
+            severity: versionFailureSeverity,
             message: detectedVersion
               ? `Managed Codex app-server version mismatch: expected ${CODEX_APP_SERVER_VERSION}, detected ${detectedVersion}.`
               : `Managed Codex app-server did not report a parseable version; expected ${CODEX_APP_SERVER_VERSION}.`,
             path: nativeCommand,
             requirement: `the exact OpenClaw-pinned Codex version ${CODEX_APP_SERVER_VERSION}`,
             fixHint:
+              versionFailureHint ??
               "Reinstall the staged OpenClaw package so its managed @openai/codex dependency matches the pinned version, then rerun the candidate check.",
           }),
         ];

--- a/src/cli/update-cli/update-command-finalize.ts
+++ b/src/cli/update-cli/update-command-finalize.ts
@@ -12,6 +12,7 @@ import {
   UPDATE_EFFECTIVE_CHANNEL_ENV,
 } from "../../infra/update-channels.js";
 import { resolveUpdateInstallKind } from "../../infra/update-check.js";
+import { normalizeUpdatePostInstallDoctorWarnings } from "../../infra/update-doctor-result.js";
 import { POST_CORE_UPDATE_SOURCE_CONFIG_PATH_ENV } from "../../infra/update-post-core-context.js";
 import {
   acknowledgeAbandonedUpdateRun,
@@ -188,6 +189,12 @@ async function updateFinalizeCommandInternal(
   const { root, preFinalizeConfig, requestedChannel, storedChannel, effectiveChannel, channel } =
     prepared;
   let { configSnapshot } = prepared;
+  let doctorWarnings: string[] = [];
+  const onDoctorWarnings = (warnings: string[]) => {
+    doctorWarnings = normalizeUpdatePostInstallDoctorWarnings([
+      ...new Set([...doctorWarnings, ...warnings]),
+    ]);
+  };
 
   const initialPluginUpdate = await withPrePluginUpdateDoctorEnv(async () => {
     await lifecycle.run("configSnapshot", createUpdateConfigSnapshot);
@@ -199,6 +206,7 @@ async function updateFinalizeCommandInternal(
         json: opts.json === true,
         workspaceSuggestions: true,
         timeoutMs: lifecycle.budget("doctor"),
+        onWarnings: onDoctorWarnings,
       }),
     );
     return await lifecycle.run(
@@ -244,6 +252,7 @@ async function updateFinalizeCommandInternal(
         yes: opts.yes === true,
         json: opts.json === true,
         timeoutMs: lifecycle.budget("targetConfigConvergence"),
+        onWarnings: onDoctorWarnings,
       });
       await persistValidatedDowngradeConfig(result.configSnapshot);
       return result;
@@ -269,7 +278,7 @@ async function updateFinalizeCommandInternal(
     status:
       pluginUpdate.status === "error"
         ? "error"
-        : pluginUpdate.status === "warning"
+        : pluginUpdate.status === "warning" || doctorWarnings.length > 0
           ? "warning"
           : "ok",
     mode: "finalize",
@@ -285,7 +294,8 @@ async function updateFinalizeCommandInternal(
     phaseTimings: lifecycle.phaseTimings,
     postUpdate: {
       doctor: {
-        status: "ok",
+        status: doctorWarnings.length > 0 ? "warning" : "ok",
+        ...(doctorWarnings.length > 0 ? { warnings: doctorWarnings } : {}),
       },
       plugins: pluginUpdate,
     },

--- a/src/cli/update-cli/update-command-fresh-doctor.test.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.test.ts
@@ -1,4 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  consumeUpdatePostInstallDoctorResult,
+  createDeferredConfiguredPluginRepairDoctorResult,
+  UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE,
+  UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV,
+  writeUpdatePostInstallDoctorResult,
+} from "../../infra/update-doctor-result.js";
 import type { PostCorePluginUpdateResult } from "./update-command-plugins.js";
 
 const mocks = vi.hoisted(() => ({
@@ -16,7 +23,8 @@ vi.mock("../../daemon/gateway-entrypoint.js", () => ({
   resolveGatewayInstallEntrypoint: mocks.resolveEntrypoint,
 }));
 
-vi.mock("../../process/exec.js", () => ({
+vi.mock("../../process/exec.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../process/exec.js")>()),
   runExec: mocks.runExec,
 }));
 
@@ -29,7 +37,10 @@ vi.mock("./shared.js", async (importOriginal) => ({
   resolveNodeRunner: vi.fn(() => "/usr/bin/node"),
 }));
 
-import { completePostCorePluginUpdate } from "./update-command-fresh-doctor.js";
+import {
+  completePostCorePluginUpdate,
+  runUpdateFinalizationDoctorInFreshProcess,
+} from "./update-command-fresh-doctor.js";
 
 const pluginUpdate: PostCorePluginUpdateResult = {
   status: "ok",
@@ -115,6 +126,55 @@ describe("post-plugin update readiness", () => {
       ["/opt/openclaw/dist/index.js", "doctor", "--lint", "--json", "--severity-min", "error"],
     ]);
   });
+
+  it("consumes nonfatal Doctor warnings before reporting successful convergence", async () => {
+    const warnings = ["Optional probe timed out; recheck after restart."];
+    const onWarnings = vi.fn();
+    let resultPath = "";
+    const runNormally = mocks.runExec.getMockImplementation()!;
+    mocks.runExec.mockImplementation(async (command, args: string[], options) => {
+      if (args.includes("--repair")) {
+        resultPath = options.env[UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV];
+        await writeUpdatePostInstallDoctorResult({
+          resultPath,
+          result: { status: "ok", warnings },
+        });
+      }
+      return await runNormally(command, args, options);
+    });
+
+    const result = await completePostCorePluginUpdate({ ...updateOptions, onWarnings });
+
+    expect(result.pluginUpdate.status).toBe("ok");
+    expect(onWarnings).toHaveBeenCalledExactlyOnceWith(warnings);
+    expect(await consumeUpdatePostInstallDoctorResult(resultPath)).toBeNull();
+  });
+
+  it.each([false, true])(
+    "preserves deferred repair advisory semantics (timed out: %s)",
+    async (timedOut) => {
+      mocks.runExec.mockImplementation(async (_command, _args, options) => {
+        await writeUpdatePostInstallDoctorResult({
+          resultPath: options.env[UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV],
+          result: createDeferredConfiguredPluginRepairDoctorResult(["plugin repair deferred"]),
+        });
+        throw Object.assign(new Error("Doctor advisory"), {
+          failed: true,
+          exitCode: UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE,
+          timedOut,
+        });
+      });
+      const run = runUpdateFinalizationDoctorInFreshProcess({
+        ...updateOptions,
+        phase: "pre-plugin",
+      });
+      if (timedOut) {
+        await expect(run).rejects.toThrow("Doctor advisory");
+      } else {
+        await expect(run).resolves.toBeUndefined();
+      }
+    },
+  );
 
   it("requires the lifecycle owner before starting fresh Doctor maintenance", async () => {
     const beforeDoctor = vi.fn(async () => undefined);

--- a/src/cli/update-cli/update-command-fresh-doctor.ts
+++ b/src/cli/update-cli/update-command-fresh-doctor.ts
@@ -9,10 +9,17 @@ import { readConfigFileSnapshot } from "../../config/config.js";
 import { resolveStateDir } from "../../config/paths.js";
 import type { ConfigFileSnapshot } from "../../config/types.openclaw.js";
 import { resolveGatewayInstallEntrypoint } from "../../daemon/gateway-entrypoint.js";
+import {
+  consumeUpdatePostInstallDoctorResult,
+  createUpdatePostInstallDoctorResultPath,
+  UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE,
+  UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV,
+  type UpdatePostInstallDoctorResult,
+} from "../../infra/update-doctor-result.js";
 import { buildUpdateDoctorEnv } from "../../infra/update-runner-doctor.js";
 import { redactSupportString } from "../../logging/diagnostic-support-redaction.js";
 import { formatCommandOutput } from "../../process/command-error.js";
-import { runExec } from "../../process/exec.js";
+import { isPlainCommandExitFailure, runExec } from "../../process/exec.js";
 import { defaultRuntime } from "../../runtime.js";
 import { truncateUtf8Prefix, truncateUtf8Suffix } from "../../utils/utf8-truncate.js";
 import { resolveNodeRunner } from "./shared.js";
@@ -95,6 +102,7 @@ export async function runUpdateFinalizationDoctorInFreshProcess(params: {
   timeoutMs: number;
   nodeRunner?: string;
   entryPath?: string;
+  onWarnings?: (warnings: string[]) => void;
 }): Promise<void> {
   const entryPath = params.entryPath ?? (await resolveGatewayInstallEntrypoint(params.root));
   if (!entryPath) {
@@ -110,6 +118,8 @@ export async function runUpdateFinalizationDoctorInFreshProcess(params: {
   ];
   const baseEnv = stripGatewayServiceMarkerEnv(disableUpdatedPackageCompileCacheEnv(process.env));
   delete baseEnv[UPDATE_POST_CORE_CONVERGENCE_ENV];
+  const doctorResultPath = createUpdatePostInstallDoctorResultPath();
+  let doctorResult: UpdatePostInstallDoctorResult | null = null;
   let result: { stdout?: unknown; stderr?: unknown } | undefined;
   try {
     result = await runExec(params.nodeRunner ?? resolveNodeRunner(), args, {
@@ -119,6 +129,7 @@ export async function runUpdateFinalizationDoctorInFreshProcess(params: {
       logOutput: false,
       baseEnv,
       env: {
+        [UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV]: doctorResultPath,
         // The outer updater owns service refresh and activation after every
         // migration finishes; a fresh Doctor must not resume its parked service.
         ...buildUpdateDoctorEnv({
@@ -130,8 +141,18 @@ export async function runUpdateFinalizationDoctorInFreshProcess(params: {
       },
     });
   } catch (error) {
+    doctorResult = await consumeUpdatePostInstallDoctorResult(doctorResultPath);
     if (isRecord(error)) {
       result = error;
+      // Enabling the existing result channel gives deferred plugin repair its
+      // advisory exit code. Convergence below still owns that repair.
+      if (
+        error.exitCode === UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE &&
+        isPlainCommandExitFailure({ ...error, failed: error.failed === true }) &&
+        doctorResult?.status === "advisory"
+      ) {
+        return;
+      }
     }
     const redaction = { env: process.env, stateDir: resolveStateDir() };
     const details = (["stderr", "stdout"] as const).flatMap((stream) => {
@@ -159,6 +180,10 @@ export async function runUpdateFinalizationDoctorInFreshProcess(params: {
     }
     throw error;
   } finally {
+    doctorResult ??= await consumeUpdatePostInstallDoctorResult(doctorResultPath);
+    if (doctorResult?.warnings?.length) {
+      params.onWarnings?.(doctorResult.warnings);
+    }
     // Clack writes directly to the child's stdout. Preserve diagnostics on either
     // exit path without letting them share the parent's JSON result stream.
     if (typeof result?.stdout === "string" && result.stdout.trim()) {
@@ -204,6 +229,7 @@ async function completePostPluginInFreshProcess(params: {
   nodeRunner?: string;
   beforeDoctor?: () => Promise<void>;
   freshDoctorRequired: boolean;
+  onWarnings?: (warnings: string[]) => void;
 }): Promise<{ pluginUpdate: PostCorePluginUpdateResult; configValid: boolean }> {
   let entryPath: string | undefined;
   try {
@@ -258,6 +284,7 @@ export async function completePostCorePluginUpdate(params: {
   timeoutMs: number;
   nodeRunner?: string;
   beforeDoctor?: () => Promise<void>;
+  onWarnings?: (warnings: string[]) => void;
 }): Promise<{
   pluginUpdate: PostCorePluginUpdateResult;
   configSnapshot: ConfigFileSnapshot;
@@ -274,6 +301,7 @@ export async function completePostCorePluginUpdate(params: {
       json: params.json,
       timeoutMs: params.timeoutMs,
       beforeDoctor: params.beforeDoctor,
+      onWarnings: params.onWarnings,
       freshDoctorRequired: params.freshDoctorRequired,
       ...(params.nodeRunner ? { nodeRunner: params.nodeRunner } : {}),
     });

--- a/src/cli/update-cli/update-command-lifecycle.test.ts
+++ b/src/cli/update-cli/update-command-lifecycle.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   events: [] as string[],
   leaseActive: false,
   readConfig: vi.fn(),
+  doctorWarnings: [] as string[],
 }));
 
 const validConfigSnapshot = {
@@ -134,9 +135,12 @@ vi.mock("./update-command-fresh-doctor.js", () => ({
       configSnapshot: validConfigSnapshot,
     };
   }),
-  runUpdateFinalizationDoctorInFreshProcess: vi.fn(async () => {
-    record("fresh-doctor");
-  }),
+  runUpdateFinalizationDoctorInFreshProcess: vi.fn(
+    async (params: { onWarnings?: (warnings: string[]) => void }) => {
+      record("fresh-doctor");
+      params.onWarnings?.(mocks.doctorWarnings);
+    },
+  ),
   withPrePluginUpdateDoctorEnv: async (run: () => Promise<unknown>) => await run(),
 }));
 
@@ -181,6 +185,7 @@ describe("update plugin lifecycle lease boundaries", () => {
     vi.unstubAllEnvs();
     mocks.events = [];
     mocks.leaseActive = false;
+    mocks.doctorWarnings = [];
     mocks.readConfig.mockImplementation(async () => {
       record("read-config");
       return validConfigSnapshot;
@@ -249,5 +254,21 @@ describe("update plugin lifecycle lease boundaries", () => {
       mocks.events.lastIndexOf("lease-exit:false"),
     );
     expect(mocks.events).not.toContain("persisted-index:true");
+  });
+
+  it("keeps nonfatal Doctor warnings in terminal JSON without failing finalization", async () => {
+    mocks.doctorWarnings = ["Optional version probe timed out; recheck after restart."];
+    await updateFinalizeCommand({ json: true, yes: true, deferCompletionCache: true });
+
+    expect(defaultRuntime.writeJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "warning",
+        restart: false,
+        postUpdate: expect.objectContaining({
+          doctor: { status: "warning", warnings: mocks.doctorWarnings },
+        }),
+      }),
+    );
+    expect(defaultRuntime.exit).not.toHaveBeenCalledWith(1);
   });
 });

--- a/src/flows/doctor-health-contribution-core.ts
+++ b/src/flows/doctor-health-contribution-core.ts
@@ -1,3 +1,4 @@
+import { normalizeUpdatePostInstallDoctorWarnings } from "../infra/update-doctor-result.js";
 import type {
   DoctorHealthCheckContext,
   DoctorHealthFlowContext,
@@ -6,7 +7,7 @@ import { resolveDoctorWorkspaceDir } from "./doctor-health-contribution-utils.js
 import { renderStructuredHealthFindings } from "./doctor-health-contribution.js";
 import { defineSplitHealthCheckInput } from "./health-check-adapter.js";
 import type { DetectableHealthCheckInput } from "./health-check-runner-types.js";
-import type { HealthFinding } from "./health-checks.js";
+import { isHealthCheckEnabledByDefault, type HealthFinding } from "./health-checks.js";
 
 const loadHealthCheckRegistryModule = async () => await import("./health-check-registry.js");
 
@@ -35,21 +36,30 @@ export async function runStructuredHealthRepairs(
   const { note } = await import("../../packages/terminal-core/src/note.js");
 
   const workspaceDir = resolveDoctorWorkspaceDir(ctx.cfg, ctx.env);
-  registerBundledHealthChecks({ cfg: ctx.cfg, cwd: workspaceDir });
-  const checks = listExtensionHealthChecksForDoctor(await resolveCoreChecks()).map(
-    defineSplitHealthCheckInput,
-  );
+  registerBundledHealthChecks({ cfg: ctx.cfg, cwd: workspaceDir, env: ctx.env });
+  const checks = listExtensionHealthChecksForDoctor(await resolveCoreChecks())
+    .filter(isHealthCheckEnabledByDefault)
+    .map(defineSplitHealthCheckInput);
   const result = await runDoctorHealthRepairs(
     withDoctorHealthCheckFacts(ctx, {
       mode: "fix" as const,
       runtime: ctx.runtime,
       cfg: ctx.cfg,
+      env: ctx.env,
       cwd: workspaceDir,
       configPath: ctx.configPath,
     }),
     { checks },
   );
   ctx.cfg = result.config;
+  renderStructuredHealthFindings(ctx, result.remainingFindings);
+  ctx.updateWarnings = normalizeUpdatePostInstallDoctorWarnings([
+    ...(ctx.updateWarnings ?? []),
+    ...result.remainingFindings
+      .filter((finding) => finding.severity === "warning")
+      .map((finding) => `${finding.checkId}: ${finding.message}`),
+    ...result.warnings,
+  ]);
   if (result.changes.length > 0) {
     note(result.changes.join("\n"), "Doctor changes");
   }

--- a/src/flows/doctor-health-contribution-types.ts
+++ b/src/flows/doctor-health-contribution-types.ts
@@ -72,6 +72,7 @@ export type DoctorHealthFlowContext = {
   gatewayStatus?: import("../status/types.js").StatusSummary;
   gatewayMemoryProbe?: Awaited<ReturnType<typeof probeGatewayMemoryStatus>>;
   postInstallDoctorResult?: UpdatePostInstallDoctorResult;
+  updateWarnings?: string[];
   runWithPluginMetadataSnapshot?: PluginMetadataSnapshotScopeRunner;
   invalidatePluginMetadataSnapshot?: () => void;
 };

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -3935,6 +3935,69 @@ describe("doctor health contributions", () => {
     });
   });
 
+  it("skips opt-in extension checks during routine repair", async () => {
+    mocks.listHealthChecks.mockReturnValue([
+      { id: "plugin/example/regular", kind: "plugin" },
+      { id: "plugin/example/opt-in", kind: "plugin", defaultEnabled: false },
+    ]);
+    const contribution = requireDoctorContribution("doctor:structured-health-repairs");
+    const ctx = createDoctorContext({
+      cfg: {},
+      configResult: { cfg: {} },
+      cfgForPersistence: {},
+      shouldRepair: true,
+      env: { OPENCLAW_UPDATE_POST_CORE: "1" },
+    });
+
+    await contribution.run(ctx);
+
+    expect(mocks.runDoctorHealthRepairs).toHaveBeenCalledWith(
+      expect.objectContaining({ env: { OPENCLAW_UPDATE_POST_CORE: "1" } }),
+      { checks: [{ id: "plugin/example/regular", kind: "plugin", sourceContract: "split" }] },
+    );
+  });
+
+  it("retains extension repair warnings without relabeling errors", async () => {
+    const contribution = requireDoctorContribution("doctor:structured-health-repairs");
+    const ctx = createDoctorContext({
+      cfg: {},
+      configResult: { cfg: {} },
+      cfgForPersistence: {},
+      shouldRepair: true,
+      env: { OPENCLAW_UPDATE_POST_CORE: "1" },
+    });
+    mocks.runDoctorHealthRepairs.mockResolvedValue({
+      config: {},
+      changes: [],
+      warnings: ["optional repair unavailable"],
+      remainingFindings: [
+        {
+          checkId: "plugin/example/probe",
+          severity: "warning",
+          message: "version probe timed out",
+        },
+        {
+          checkId: "plugin/example/broken",
+          severity: "error",
+          message: "required artifact missing",
+        },
+      ],
+    });
+
+    await contribution.run(ctx);
+
+    expect(ctx.updateWarnings).toEqual([
+      "plugin/example/probe: version probe timed out",
+      "optional repair unavailable",
+    ]);
+    expect(ctx.runtime.log).toHaveBeenCalledWith(
+      "[warning] plugin/example/probe - version probe timed out",
+    );
+    expect(ctx.runtime.error).toHaveBeenCalledWith(
+      "[error] plugin/example/broken - required artifact missing",
+    );
+  });
+
   it("rejects extension repairs that claim reserved core doctor ids", async () => {
     mocks.listHealthChecks.mockReturnValue([
       { id: "plugin/example/unrelated", kind: "plugin" },

--- a/src/flows/doctor-health.test-support.ts
+++ b/src/flows/doctor-health.test-support.ts
@@ -210,4 +210,35 @@ export function registerDoctorConfigReceiptTests(
       });
     },
   );
+  it.each([false, true])(
+    "preserves health warnings in the update result (advisory=%s)",
+    async (advisory) => {
+      mocks.runContributions.mockImplementation(async (ctx) => {
+        ctx.updateWarnings = ["plugin/example: version probe timed out"];
+        if (advisory) {
+          ctx.postInstallDoctorResult = postInstallAdvisory;
+        }
+      });
+      const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+      vi.stubEnv(
+        "OPENCLAW_UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH",
+        "/tmp/openclaw-update-doctor-result.json",
+      );
+
+      await runDoctorHealthFlow(runtime, {});
+
+      expect(mocks.writeUpdatePostInstallDoctorResult).toHaveBeenCalledWith({
+        resultPath: "/tmp/openclaw-update-doctor-result.json",
+        result: {
+          ...(advisory ? postInstallAdvisory : { status: "ok" }),
+          configHash: "unchanged",
+          warnings: ["plugin/example: version probe timed out"],
+        },
+      });
+      expect(runtime.exit).not.toHaveBeenCalledWith(1);
+      if (advisory) {
+        expect(runtime.exit).toHaveBeenCalledWith(86);
+      }
+    },
+  );
 }

--- a/src/flows/doctor-health.ts
+++ b/src/flows/doctor-health.ts
@@ -7,6 +7,7 @@ import { resolveConfigPath, resolveStateDir } from "../config/paths.js";
 import { DoctorUnreadableStateDatabaseError } from "../infra/state-repair-message.js";
 import {
   captureUpdateDoctorConfigWrites,
+  normalizeUpdatePostInstallDoctorWarnings,
   UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE,
   UPDATE_POST_INSTALL_DOCTOR_RESULT_PATH_ENV,
   writeUpdatePostInstallDoctorResult,
@@ -221,7 +222,14 @@ async function runDoctorHealthFlowWithResult(
       repairGatewayMaintenanceStartupFailures();
     }
     await maintenance?.finish(ctx.cfg);
-    doctorResult = ctx.postInstallDoctorResult ?? { status: "ok" };
+    const warnings = normalizeUpdatePostInstallDoctorWarnings([
+      ...(ctx.postInstallDoctorResult?.warnings ?? []),
+      ...(ctx.updateWarnings ?? []),
+    ]);
+    doctorResult = {
+      ...(ctx.postInstallDoctorResult ?? { status: "ok" }),
+      ...(warnings.length ? { warnings } : {}),
+    };
     if (updateResult && doctorResult.status === "advisory") {
       exitCode = UPDATE_POST_INSTALL_DOCTOR_ADVISORY_EXIT_CODE;
       return;

--- a/src/flows/doctor-lint-flow.ts
+++ b/src/flows/doctor-lint-flow.ts
@@ -4,6 +4,7 @@ import { listHealthChecks } from "./health-check-registry.js";
 import {
   HEALTH_FINDING_SEVERITY_RANK,
   healthFindingMeetsSeverity,
+  isHealthCheckEnabledByDefault,
   type HealthCheck,
   type HealthCheckContext,
   type HealthFinding,
@@ -39,7 +40,7 @@ export async function runDoctorLintChecks(
     if (only.size > 0 && !only.has(c.id)) {
       return false;
     }
-    if (only.size === 0 && !includeDefaultDisabled && isDefaultDisabled(c)) {
+    if (only.size === 0 && !includeDefaultDisabled && !isHealthCheckEnabledByDefault(c)) {
       return false;
     }
     if (skip.has(c.id)) {
@@ -95,10 +96,6 @@ export function selectUpdateReadinessChecks(
   phase: "post-plugin",
 ): readonly HealthCheck[] {
   return checks.filter((check) => "updateReadiness" in check && check.updateReadiness === phase);
-}
-
-function isDefaultDisabled(check: HealthCheck): boolean {
-  return "defaultEnabled" in check && check.defaultEnabled === false;
 }
 
 // Stable ordering keeps CLI output and tests deterministic across registry order changes.

--- a/src/flows/health-checks.ts
+++ b/src/flows/health-checks.ts
@@ -113,3 +113,8 @@ export interface HealthCheck {
     findings: readonly HealthFinding[],
   ): Promise<HealthRepairResult>;
 }
+
+/** Opt-in diagnostics stay out of routine lint and repair passes. */
+export function isHealthCheckEnabledByDefault(check: HealthCheck): boolean {
+  return !("defaultEnabled" in check && check.defaultEnabled === false);
+}

--- a/src/infra/update-doctor-result.test.ts
+++ b/src/infra/update-doctor-result.test.ts
@@ -18,10 +18,12 @@ afterEach(async () => {
 describe("post-install doctor result IPC", () => {
   it.each([
     { status: "ok" as const, configHash: "unchanged" },
+    { status: "ok" as const, warnings: ["plugin/example: version probe timed out"] },
     { status: "error" as const, configHash: "a".repeat(64), configInputHash: "b".repeat(64) },
     {
       ...createDeferredConfiguredPluginRepairDoctorResult(["deferred repair"]),
       configHash: "b".repeat(64),
+      warnings: ["plugin/example: version probe timed out"],
     },
     createDeferredConfiguredPluginRepairDoctorResult(["legacy child advisory"]),
   ])("round-trips $status results and consumes the file", async (result) => {
@@ -31,6 +33,32 @@ describe("post-install doctor result IPC", () => {
 
     await expect(consumeUpdatePostInstallDoctorResult(resultPath)).resolves.toEqual(result);
     await expect(fs.access(resultPath)).rejects.toThrow();
+  });
+
+  it("bounds warning count and length before writing and after reading", async () => {
+    const resultPath = createUpdatePostInstallDoctorResultPath();
+    resultPaths.push(resultPath);
+    const warnings = [
+      "   ",
+      ...Array.from({ length: 40 }, (_, index) => `${index}: ${"x".repeat(600)}`),
+    ];
+    const expected = warnings.slice(1, 33).map((warning) => warning.slice(0, 500));
+
+    await writeUpdatePostInstallDoctorResult({ resultPath, result: { status: "ok", warnings } });
+    expect(JSON.parse(await fs.readFile(resultPath, "utf8"))).toEqual({
+      status: "ok",
+      warnings: expected,
+    });
+    await expect(consumeUpdatePostInstallDoctorResult(resultPath)).resolves.toEqual({
+      status: "ok",
+      warnings: expected,
+    });
+
+    await fs.writeFile(resultPath, JSON.stringify({ status: "ok", warnings }));
+    await expect(consumeUpdatePostInstallDoctorResult(resultPath)).resolves.toEqual({
+      status: "ok",
+      warnings: expected,
+    });
   });
 
   it("rejects result paths outside the secure OpenClaw temp root", async () => {

--- a/src/infra/update-doctor-result.ts
+++ b/src/infra/update-doctor-result.ts
@@ -31,7 +31,22 @@ export type UpdatePostInstallDoctorResult = (
         details: string[];
       };
     }
-) & { configHash?: string; configInputHash?: string };
+) & { configHash?: string; configInputHash?: string; warnings?: string[] };
+
+/** Keep optional health diagnostics bounded across Doctor and its update parent. */
+export function normalizeUpdatePostInstallDoctorWarnings(warnings: readonly string[]): string[] {
+  const normalized: string[] = [];
+  for (const warning of warnings) {
+    const message = warning.trim().slice(0, 500);
+    if (message) {
+      normalized.push(message);
+      if (normalized.length === 32) {
+        break;
+      }
+    }
+  }
+  return normalized;
+}
 
 type DoctorConfigCapture = { path: string; hash: string; inputHash?: string };
 const doctorConfigWrites = new AsyncLocalStorage<DoctorConfigCapture>();
@@ -99,12 +114,21 @@ export async function writeUpdatePostInstallDoctorResult(params: {
   result: UpdatePostInstallDoctorResult;
 }): Promise<void> {
   const resultPath = resolveSafeUpdatePostInstallDoctorResultPath(params.resultPath);
+  const { warnings, ...result } = params.result;
+  const normalizedWarnings = normalizeUpdatePostInstallDoctorWarnings(warnings ?? []);
   // Advisory details can contain config-derived IDs; pre-existing paths must fail closed.
-  await fs.writeFile(resultPath, `${JSON.stringify(params.result)}\n`, {
-    encoding: "utf8",
-    mode: 0o600,
-    flag: "wx",
-  });
+  await fs.writeFile(
+    resultPath,
+    `${JSON.stringify({
+      ...result,
+      ...(normalizedWarnings.length ? { warnings: normalizedWarnings } : {}),
+    })}\n`,
+    {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    },
+  );
 }
 
 export async function consumeUpdatePostInstallDoctorResult(
@@ -131,6 +155,15 @@ function parseUpdatePostInstallDoctorResult(value: unknown): UpdatePostInstallDo
     return null;
   }
   const record = value as Record<string, unknown>;
+  const warnings = record.warnings;
+  if (
+    warnings !== undefined &&
+    (!Array.isArray(warnings) ||
+      !warnings.every((warning): warning is string => typeof warning === "string"))
+  ) {
+    return null;
+  }
+  const normalizedWarnings = normalizeUpdatePostInstallDoctorWarnings(warnings ?? []);
   const configHash = record.configHash;
   if (
     configHash !== undefined &&
@@ -149,6 +182,7 @@ function parseUpdatePostInstallDoctorResult(value: unknown): UpdatePostInstallDo
   const configWrite = {
     ...(configHash === undefined ? {} : { configHash }),
     ...(configInputHash === undefined ? {} : { configInputHash }),
+    ...(normalizedWarnings.length ? { warnings: normalizedWarnings } : {}),
   };
   if (record.status === "ok" || record.status === "error") {
     return { status: record.status, ...configWrite };


### PR DESCRIPTION
Related: #139485. Follow-up to #140648 and #141740. This does not close #139485.

## What Problem This Solves

Fixes an issue where update finalization runs an opt-in managed Codex version check during ordinary Doctor repair and omits nonfatal Doctor warnings from its JSON report. The probe can also report success after its five-second timeout destroys pipes retained by an already-exited child's descendant.

The daemonized-child experiment did **not** reproduce an indefinite hang on official 2026.9.2 or current main. This PR takes the investigation's requested narrower scope; it does not claim to identify @hannesrudolph's original failure.

## Why This Change Was Made

Doctor repair now shares ordinary lint's default-enabled selection while retaining the existing enabled/configured-plugin policy. Explicit candidate checks remain strict. The managed version probe uses the existing process runner, preserving its five-second deadline, forced process-group termination, bounded capture, immediate stdin EOF, and bounded post-timeout drain. A failed probe invoked in post-core repair is a warning. Routine finalization skips this opt-in check.

Nonfatal repair warnings pass through the existing Doctor result IPC into `postUpdate.doctor.warnings`, capped at 32 messages of 500 characters. Finalization returns warning/exit 0 when no step fails. Enabling that existing IPC also activates the existing deferred-plugin advisory exit 86; it is accepted only with a validated advisory result and an ordinary exit, never a timeout or output failure.

Mechanism references:

- [Node 26.7 `execFile`](https://github.com/nodejs/node/blob/v26.7.0/lib/child_process.js): `kill()` destroys stdout/stderr before signaling; `exithandler()` can still accept an already-recorded exit 0. The original probe regression settled around 5.1 seconds with no finding.
- [Original Codex probe](https://github.com/openclaw/openclaw/blob/1029e3870f23315812565cc02d0504a208173697/extensions/codex/src/doctor.ts) and [repair selection](https://github.com/openclaw/openclaw/blob/1029e3870f23315812565cc02d0504a208173697/src/flows/doctor-health-contribution-core.ts).
- [OCM 0.2.41 finalizer contract](https://github.com/openclaw/ocm/blob/v0.2.41/src/cli/upgrade.rs): `run_post_core_update` and `run_update_mode_openclaw_command_output_with_env` use null stdin, piped output, and the post-core marker.
- #140927 deliberately keeps successful owned-tree output under its command deadline. The shared SDK process-helper contract is preserved. #140648's phase/exit bounds and #141740's child identities are unchanged.

## User Impact

Routine finalization avoids unnecessary opt-in version probes, supervisors receive nonfatal Doctor warnings, and explicit candidate validation cannot mistake a timed-out output drain for successful readiness. Codex runtime readiness remains owned by the plugin after restart. No configuration, environment-name, dependency, schema, or protocol change is introduced.

## Evidence

All state and probes were synthetic and isolated on macOS 27 arm64. No real OpenClaw state, keychain tooling, launchd mutation, merge, or lock recovery was used.

| Case | Observed result |
| --- | --- |
| Official 2026.9.2 + official installed Codex plugin; direct child exits 0, detached descendant retains pipes | Finalizer exit 0 / status ok in 20.714s; orphan remains until harness cleanup. Initial valid run also passed in 31.004s. |
| Main `1029e3870f23`, same probe | Exit 0 / status ok in 14.017s; orphan remains until cleanup. |
| Candidate finalizer, configured Codex, Node 26.7 / 24.19 | Exit 0 / status ok in 9.191s / 7.830s; probe correctly not entered. |
| Candidate explicit lint, orphan, Node 26.7 | Timeout finding / exit 1 in 7.893s including startup. |
| Candidate explicit lint, SIGTERM-resistant child, Node 24.19 | Timeout finding / exit 1 in 6.782s including startup; child stopped. |
| Actual OCM 0.2.41, official 9.2 → candidate, Node 26.7 / 24.19 | `outcome: switched`, exit 0 in 16.737s / 15.862s; source/candidate foreground Gateway health/readiness verified. |

The observers verified entry into the native probe, reparenting to PID 1, process trees, per-process `lsof`, and native samples of the actual finalizer. Official 9.2 showed an idle `kevent` main thread with pipes/kqueues and no SQLite descriptors but still completed. Main additionally retained its update-ledger descriptors. These observations distinguish a reachable pipe-retention mechanism from the unconfirmed incident.

Validation: 334 focused tests across eight files, then 123 final tests across four files on Node 26.7. Main-red regressions cover silent orphan-timeout success, default-check selection, warning IPC, and terminal JSON. `node scripts/check-changed.mjs` (the documented equivalent for ready worktree dependencies) and `git diff --check` pass. Independent P0–P2 review is scoped-clean. A full build and package integrity check pass; the nine changed production files match the tested candidate snapshot byte-for-byte. Later changes only relocated a test into existing support and used the existing tree-cleanup helper.

Limits: the reporter's macOS 26 and actual state remain untested. OCM services stayed disabled because its launchd label is shared; this exercises runtime switching/finalization and foreground verification, not launchd or automatic rollback. The initial Node 26 OCM snapshot returned transient ENOENT before upgrade; an ordinary retry passed. Official 9.1 setup was network-blocked, so this OCM comparison starts at official 9.2. Slow/incomplete dependency installs and unentered probes are excluded from passing evidence. No Windows-native proof was added.

Exact-head CI: [run 34200852921](https://github.com/openclaw/openclaw/actions/runs/34200852921) is attached to `4638117477589f9d7875e77f6ce0482f9bb4e5ec`. The bounded watcher ended at its deadline; the last successful read was `in_progress`. Intermittent GitHub read timeouts occurred. CI is not claimed green. The initial draft-skipped run was excluded. This PR remains unmerged.
