### PR TITLE
fix: preserve case-sensitive fallback model references

### DIFF
--- a/ui/src/components/multi-select.test.ts
+++ b/ui/src/components/multi-select.test.ts
@@ -1,5 +1,7 @@
 /* @vitest-environment jsdom */
 import { afterAll, afterEach, beforeAll, expect, it, vi } from "vitest";
+import { normalizeAgentModelRefForConfig } from "../../../src/config/model-input.js";
+import { createPrimaryModelExclusion } from "../lib/agents/display.ts";
 import { MultiSelect, type MultiSelectOption } from "./multi-select.ts";
 
 const MULTI_SELECT_TEST_TAG = `test-openclaw-multi-select-${crypto.randomUUID()}`;
@@ -7,7 +9,8 @@ const MULTI_SELECT_TEST_TAG = `test-openclaw-multi-select-${crypto.randomUUID()}
 type MultiSelectElement = HTMLElement & {
   options: readonly MultiSelectOption[];
   value: readonly string[];
-  exclude: readonly string[];
+  isExcluded: (value: string) => boolean;
+  getValueKey: (value: string) => string;
   placeholder: string;
   allowCustom: boolean;
   disabled: boolean;
@@ -55,7 +58,7 @@ async function createMultiSelect(
   const element = document.createElement(MULTI_SELECT_TEST_TAG) as MultiSelectElement;
   element.options = options;
   element.value = [sonnet];
-  element.exclude = [primary];
+  element.isExcluded = (value) => value === primary;
   element.placeholder = "Add fallback…";
   element.allowCustom = true;
   element.onChange = vi.fn();
@@ -235,10 +238,119 @@ it.each(["Tab", ",", "blur"])("commits typed references on %s", async (action) =
 it("appends pasted references in order without duplicating or adding excluded models", async () => {
   const element = await createMultiSelect();
 
-  await typeText(element, `${gemini}, openrouter/pending, ${primary}, ${gemini.toUpperCase()}`);
+  await typeText(element, `${gemini}, openrouter/pending, ${primary}, ${gemini}`);
   await pressKey(element, "Enter");
 
   expect(element.onChange).toHaveBeenCalledExactlyOnceWith([sonnet, gemini, "openrouter/pending"]);
+});
+
+it.each(["click", "Enter", ","])(
+  "preserves a case-distinct custom model when committed with %s",
+  async (action) => {
+    const lower = "custom/model-a";
+    const custom = "custom/Model-A";
+    const element = await createMultiSelect({
+      options: [{ value: lower, label: "Lowercase model" }],
+      value: [],
+      isExcluded: () => false,
+      getValueKey: normalizeAgentModelRefForConfig,
+    });
+    input(element).focus();
+    await typeText(element, custom);
+
+    expect(rowValues(element)).toEqual([lower, custom]);
+    const customRow = element.querySelector<HTMLElement>(".multi-select__option[data-custom]");
+    expect(customRow?.getAttribute("data-value")).toBe(custom);
+    if (action === "click") {
+      customRow?.click();
+    } else {
+      if (action === "Enter") {
+        await pressKey(element, "ArrowDown");
+      }
+      await pressKey(element, action);
+    }
+    await element.updateComplete;
+
+    expect(element.onChange).toHaveBeenCalledExactlyOnceWith([custom]);
+  },
+);
+
+it("uses caller-owned identity for chips, exclusion, and pasted values", async () => {
+  const lower = "custom/model-a";
+  const upper = "custom/Model-A";
+  const element = await createMultiSelect({
+    options: [
+      { value: lower, label: "Lowercase model" },
+      { value: upper, label: "Uppercase model" },
+    ],
+    value: ["CUSTOM/model-a"],
+    isExcluded: () => false,
+    getValueKey: normalizeAgentModelRefForConfig,
+  });
+
+  expect(element.querySelector(".multi-select__chip-label")?.textContent).toBe("Lowercase model");
+  await clickField(element);
+  expect(rowValues(element)).toEqual([upper]);
+  element.isExcluded = (value) => normalizeAgentModelRefForConfig(value) === upper;
+  await element.updateComplete;
+  expect(rowValues(element)).toEqual([]);
+  element.isExcluded = () => false;
+  await typeText(element, `${lower}, ${upper}, CUSTOM/Model-A`);
+  await pressKey(element, ",");
+
+  expect(element.onChange).toHaveBeenCalledExactlyOnceWith(["CUSTOM/model-a", upper]);
+});
+
+it.each([",", "Enter"])("preserves explicitly confirmed alias bindings on %s", async (action) => {
+  const target = "custom/Model-A";
+  const element = await createMultiSelect({
+    options: [{ value: target, label: "Uppercase model" }],
+    value: [],
+    isExcluded: createPrimaryModelExclusion(
+      { agents: { defaults: { models: { [target]: { alias: "backup" } } } } },
+      primary,
+    ),
+    getValueKey: normalizeAgentModelRefForConfig,
+  });
+
+  await typeText(element, action === "," ? "backup" : `backup, ${target}`);
+  await pressKey(element, action);
+
+  expect(element.onChange).toHaveBeenCalledExactlyOnceWith(
+    action === "," ? ["backup"] : ["backup", target],
+  );
+});
+
+it.each([
+  {
+    name: "a bare fallback",
+    existing: "gpt-5.4-mini",
+    alternate: "local/gpt-5.4-mini",
+    models: { "local/gpt-5.4-mini": {} },
+  },
+  {
+    name: "a profile-qualified fallback alias",
+    existing: "fast@work",
+    alternate: "custom/upper",
+    models: { "custom/lower": { alias: "fast" }, "custom/upper": { alias: "fast@work" } },
+  },
+])("keeps $name separate from a real alternate model", async ({ existing, alternate, models }) => {
+  const primaryModelRef = "openai/gpt-5.4";
+  const element = await createMultiSelect({
+    options: [{ value: alternate, label: "Alternate model" }],
+    value: [existing],
+    isExcluded: createPrimaryModelExclusion(
+      { agents: { defaults: { model: { primary: primaryModelRef }, models } } },
+      primaryModelRef,
+    ),
+    getValueKey: normalizeAgentModelRefForConfig,
+  });
+
+  await clickField(element);
+  expect(rowValues(element)).toEqual([alternate]);
+  await pressKey(element, "Enter");
+
+  expect(element.onChange).toHaveBeenCalledExactlyOnceWith([existing, alternate]);
 });
 
 it("selects the visible highlight when a catalog refresh shortens the open list", async () => {

--- a/ui/src/components/multi-select.ts
+++ b/ui/src/components/multi-select.ts
@@ -41,8 +41,10 @@ export class MultiSelect extends OpenClawLightDomElement {
   @property({ attribute: false }) options: readonly MultiSelectOption[] = [];
   /** Current values in display order. Controlled: the host owns them. */
   @property({ attribute: false }) value: readonly string[] = [];
-  /** Values kept out of the dropdown without being chips, e.g. a primary model. */
-  @property({ attribute: false }) exclude: readonly string[] = [];
+  /** Caller-owned exclusions, such as the effective primary model. */
+  @property({ attribute: false }) isExcluded: (value: string) => boolean = () => false;
+  /** The caller owns value identity; search remains case-insensitive. */
+  @property({ attribute: false }) getValueKey: (value: string) => string = (value) => value;
   @property({ attribute: false }) placeholder = "";
   @property({ attribute: false }) accessibleLabel = "";
   /** Accept typed values, including comma-separated input, outside the option list. */
@@ -64,7 +66,13 @@ export class MultiSelect extends OpenClawLightDomElement {
     if (changed.has("disabled") && this.disabled && this.open) {
       this.closeMenu();
     }
-    if (this.open && (changed.has("options") || changed.has("value") || changed.has("exclude"))) {
+    if (
+      this.open &&
+      (changed.has("options") ||
+        changed.has("value") ||
+        changed.has("isExcluded") ||
+        changed.has("getValueKey"))
+    ) {
       this.activeIndex = Math.min(this.activeIndex, Math.max(0, this.rows().length - 1));
     }
   }
@@ -72,8 +80,8 @@ export class MultiSelect extends OpenClawLightDomElement {
   protected override updated(changed: PropertyValues) {
     if (
       !this.open ||
-      !["open", "query", "activeIndex", "options", "value", "exclude"].some((key) =>
-        changed.has(key),
+      !["open", "query", "activeIndex", "options", "value", "isExcluded", "getValueKey"].some(
+        (key) => changed.has(key),
       )
     ) {
       return;
@@ -94,23 +102,24 @@ export class MultiSelect extends OpenClawLightDomElement {
   }
 
   private optionFor(value: string): MultiSelectOption | undefined {
-    const key = value.toLowerCase();
-    return this.options.find((option) => option.value.toLowerCase() === key);
+    const key = this.getValueKey(value);
+    return this.options.find((option) => this.getValueKey(option.value) === key);
   }
 
   /** Dropdown rows: unchosen options matching the query, then the custom entry. */
   private rows(): MultiSelectRow[] {
-    const taken = new Set([...this.value, ...this.exclude].map((entry) => entry.toLowerCase()));
+    const taken = new Set(this.value.map((entry) => this.getValueKey(entry)));
     const custom = this.query.trim();
+    const customKey = this.getValueKey(custom);
     const query = custom.toLowerCase();
     const rows: MultiSelectRow[] = [];
     let exact: MultiSelectRow | null = null;
     for (const option of this.options) {
-      const key = option.value.toLowerCase();
-      if (taken.has(key)) {
+      const key = this.getValueKey(option.value);
+      if (taken.has(key) || this.isExcluded(option.value)) {
         continue;
       }
-      if (key === query) {
+      if (key === customKey) {
         exact = option;
         continue;
       }
@@ -121,7 +130,7 @@ export class MultiSelect extends OpenClawLightDomElement {
     }
     if (exact) {
       rows.unshift(exact);
-    } else if (this.allowCustom && custom && !taken.has(query)) {
+    } else if (this.allowCustom && custom && !taken.has(customKey) && !this.isExcluded(custom)) {
       rows.push({
         value: custom,
         label: custom,
@@ -151,12 +160,12 @@ export class MultiSelect extends OpenClawLightDomElement {
     if (this.disabled) {
       return;
     }
-    const taken = new Set([...this.value, ...this.exclude].map((entry) => entry.toLowerCase()));
+    const taken = new Set(this.value.map((entry) => this.getValueKey(entry)));
     const additions: string[] = [];
     for (const value of values) {
       const next = value.trim();
-      const key = next.toLowerCase();
-      if (next && !taken.has(key)) {
+      const key = this.getValueKey(next);
+      if (next && !taken.has(key) && !this.isExcluded(next)) {
         taken.add(key);
         additions.push(next);
       }
@@ -169,10 +178,7 @@ export class MultiSelect extends OpenClawLightDomElement {
   }
 
   private commitTypedQuery() {
-    const values = normalizeCsvOrLooseStringList(this.query).map(
-      (value) => this.optionFor(value)?.value ?? value,
-    );
-    this.commit(values);
+    this.commit(normalizeCsvOrLooseStringList(this.query));
   }
 
   private selectRow(row: MultiSelectRow) {

--- a/ui/src/lib/agents/display.test.ts
+++ b/ui/src/lib/agents/display.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   buildAgentContext,
   buildModelOptions,
+  createPrimaryModelExclusion,
   formatBytes,
   listSelectableAgents,
   normalizeAgentLabel,
@@ -56,6 +57,219 @@ describe("buildModelOptions", () => {
       provider: "openai",
       tags: ["default", "configured"],
     });
+  });
+
+  it("keeps case-distinct catalog identities, configured aliases, and current values", () => {
+    const lower = "custom/model-a";
+    const upper = "custom/Model-A";
+    const caseCatalog = [
+      { id: "model-a", name: "Lowercase model", provider: "custom" },
+      { id: "Model-A", name: "Uppercase model", provider: "custom" },
+    ];
+    const config = {
+      agents: {
+        defaults: { models: { [lower]: { alias: "lower" }, [upper]: { alias: "upper" } } },
+      },
+    };
+
+    expect(
+      buildModelOptions(config, null, caseCatalog).map(({ value, label }) => ({ value, label })),
+    ).toEqual([
+      { value: lower, label: "Lowercase model · lower" },
+      { value: upper, label: "Uppercase model · upper" },
+    ]);
+    expect(
+      buildModelOptions(null, upper, caseCatalog.slice(0, 1)).map(({ value }) => value),
+    ).toEqual([upper, lower]);
+  });
+});
+
+describe("createPrimaryModelExclusion", () => {
+  const lower = "custom/model-a";
+  const upper = "custom/Model-A";
+  const other = "other/model-a";
+  type AliasCase = {
+    name: string;
+    primary: string;
+    models: Record<string, { alias?: string } | null>;
+    agentModels?: Record<string, { alias?: string } | null> | Array<{ alias?: string }>;
+    providers?: Record<string, { api?: string; models?: unknown }>;
+    excluded: string[];
+    allowed: string[];
+  };
+  const cases: AliasCase[] = [
+    {
+      name: "resolves a bare primary alias without folding its target model id",
+      primary: "FAST",
+      models: { [upper]: { alias: "fast" } },
+      excluded: [upper, "fast"],
+      allowed: [lower],
+    },
+    {
+      name: "prefers an explicit agent alias over a later default alias",
+      primary: "fast",
+      models: { [lower]: { alias: "fast" }, [other]: { alias: "fast" } },
+      agentModels: { [lower]: { alias: "fast" } },
+      excluded: [lower],
+      allowed: [other],
+    },
+    {
+      name: "preserves default alias priority when agent metadata omits alias",
+      primary: "fast",
+      models: { [lower]: { alias: "fast" }, [other]: { alias: "fast" } },
+      agentModels: { [lower]: {} },
+      excluded: [other],
+      allowed: [lower],
+    },
+    {
+      name: "respects an explicitly disabled inherited alias",
+      primary: "fast",
+      models: { [lower]: { alias: "fast" } },
+      agentModels: { [lower]: { alias: "" } },
+      excluded: ["fast"],
+      allowed: [lower],
+    },
+    {
+      name: "tolerates null editable metadata without replacing inherited aliases",
+      primary: "fast",
+      models: { [lower]: null, [upper]: { alias: "fast" } },
+      agentModels: { [upper]: null },
+      excluded: [upper],
+      allowed: [lower],
+    },
+    {
+      name: "keeps an explicit configured-provider ref ahead of a slash alias",
+      primary: lower,
+      models: { [other]: { alias: lower }, [lower]: { alias: "original" } },
+      providers: { custom: { api: "openai-completions" } },
+      excluded: ["original"],
+      allowed: [lower, other],
+    },
+    {
+      name: "resolves a slash alias when no explicit provider owns the input",
+      primary: lower,
+      models: { [other]: { alias: lower } },
+      excluded: [other, lower, upper],
+      allowed: ["custom/unrelated"],
+    },
+    {
+      name: "does not replace a provider ref with an alias on a bare config key",
+      primary: lower,
+      models: { legacy: { alias: lower }, [lower]: { alias: "original" } },
+      excluded: ["original"],
+      allowed: [lower],
+    },
+    {
+      name: "resolves profile-qualified aliases",
+      primary: "fast@work",
+      models: { [lower]: { alias: "fast" } },
+      excluded: [lower, `${lower}@work`],
+      allowed: [`${lower}@other`, `${lower}@Work`],
+    },
+    {
+      name: "keeps primary literal-alias precedence separate from fallback profile parsing",
+      primary: "fast@work",
+      models: { [lower]: { alias: "fast" }, [upper]: { alias: "fast@work" } },
+      excluded: [upper],
+      allowed: [lower, "fast@work"],
+    },
+    {
+      name: "preserves case-sensitive credential-profile qualifiers",
+      primary: `${lower}@Work`,
+      models: {},
+      excluded: [lower, `${lower}@Work`],
+      allowed: [`${lower}@work`],
+    },
+    {
+      name: "preserves case-distinct explicit references",
+      primary: "CUSTOM/Model-A",
+      models: {},
+      excluded: [upper],
+      allowed: [lower],
+    },
+    {
+      name: "does not guess a provider for an ambiguous bare model id",
+      primary: "model-a",
+      models: { [lower]: {}, [other]: {} },
+      excluded: ["model-a"],
+      allowed: [lower, other],
+    },
+    {
+      name: "does not infer a provider for bare fallback identities from configured model keys",
+      primary: "Model-A",
+      models: { [lower]: {}, [upper]: {} },
+      excluded: ["Model-A"],
+      allowed: [lower, upper],
+    },
+    {
+      name: "does not infer a provider for bare fallback identities from provider model rows",
+      primary: "Model-A",
+      models: {},
+      providers: { custom: { api: "openai-completions", models: [{ id: "Model-A" }] } },
+      excluded: ["Model-A"],
+      allowed: [upper],
+    },
+    {
+      name: "ignores unsaved provider model shapes while resolving configured aliases",
+      primary: "fast",
+      models: { [upper]: { alias: "fast" } },
+      providers: { custom: { api: "openai-completions", models: {} } },
+      excluded: [upper],
+      allowed: [lower],
+    },
+    {
+      name: "ignores invalid agent model arrays without shadowing inherited aliases",
+      primary: "fast",
+      models: { [upper]: { alias: "fast" } },
+      agentModels: [{ alias: "fast" }],
+      excluded: [upper],
+      allowed: [lower],
+    },
+    {
+      name: "preserves a bare id without a configured provider match",
+      primary: "Model-A",
+      models: {},
+      excluded: ["Model-A"],
+      allowed: [upper],
+    },
+    {
+      name: "resolves provider-scoped fallback aliases without borrowing another provider's alias",
+      primary: lower,
+      models: { [lower]: { alias: "fast" }, [other]: { alias: "fast" } },
+      excluded: [lower, "custom/fast"],
+      allowed: ["fast"],
+    },
+    {
+      name: "does not borrow fallback provider-scoped aliases for a configured primary",
+      primary: "anthropic/claude-sonnet-4-6",
+      models: {
+        "anthropic/claude-sonnet-4-6": { alias: "original" },
+        "anthropic/claude-haiku-4-5": { alias: "claude-sonnet-4-6" },
+      },
+      excluded: ["original"],
+      allowed: ["anthropic/claude-haiku-4-5", "anthropic/claude-sonnet-4-6"],
+    },
+    {
+      name: "prefers a global fallback alias before provider-scoped alias lookup",
+      primary: lower,
+      models: { [lower]: { alias: "fast" }, [other]: { alias: "custom/fast" } },
+      excluded: [lower, "fast"],
+      allowed: ["custom/fast"],
+    },
+  ];
+
+  it.each(cases)("$name", ({ primary, models, agentModels, providers, excluded, allowed }) => {
+    const config = {
+      agents: {
+        defaults: { models },
+        entries: { worker: { models: agentModels } },
+      },
+      models: { providers },
+    };
+
+    const isExcluded = createPrimaryModelExclusion(config, primary, "worker");
+    expect(excluded.filter(isExcluded)).toEqual(excluded);
+    expect(allowed.filter(isExcluded)).toEqual([]);
   });
 });
 

--- a/ui/src/lib/agents/display.ts
+++ b/ui/src/lib/agents/display.ts
@@ -1,10 +1,16 @@
 // Control UI view renders agents utils screen content.
+import { parseModelCatalogRef } from "@openclaw/model-catalog-core/model-catalog-refs";
+import { findNormalizedProviderValue } from "@openclaw/model-catalog-core/provider-id";
 import { formatByteSize } from "@openclaw/normalization-core";
+import { asOptionalRecord, isRecord } from "@openclaw/normalization-core/record-coerce";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
 } from "@openclaw/normalization-core/string-coerce";
 import { normalizeStringEntries } from "@openclaw/normalization-core/string-normalization";
+import { splitTrailingAuthProfile } from "../../../../src/agents/model-ref-profile.js";
+import { normalizeAgentModelRefForConfig } from "../../../../src/config/model-input.js";
+import { parseModelPolicyWildcardRef } from "../../../../src/config/model-policy-ref.js";
 import { formatAgentRuntimeLabel } from "../../../../src/shared/agent-runtime-display.js";
 import type {
   AgentIdentityResult,
@@ -347,6 +353,91 @@ function resolveConfiguredModels(
   return options;
 }
 
+/** Resolve primary exclusions from the current draft without changing authored fallback identity. */
+export function createPrimaryModelExclusion(
+  configForm: Record<string, unknown> | null,
+  primary: string | null,
+  agentId?: string,
+): (value: string) => boolean {
+  if (!primary) {
+    return () => false;
+  }
+  const agents = asOptionalRecord(configForm?.agents);
+  const defaults = asOptionalRecord(agents?.defaults);
+  const entry = agentId ? resolveAgentConfigEntryTarget(configForm, agentId)?.entry : undefined;
+  const modelMaps = [asOptionalRecord(defaults?.models), asOptionalRecord(entry?.models)];
+  const aliasesByValue = new Map<string, string>();
+  for (const models of modelMaps) {
+    for (const [model, metadata] of Object.entries(models ?? {})) {
+      if (parseModelPolicyWildcardRef(model)) {
+        continue;
+      }
+      if (!isRecord(metadata) || !Object.hasOwn(metadata, "alias")) {
+        continue;
+      }
+      const key = normalizeAgentModelRefForConfig(model);
+      // Match runtime alias precedence: explicit agent aliases move after defaults.
+      aliasesByValue.delete(key);
+      aliasesByValue.set(key, normalizeOptionalString(metadata.alias) ?? "");
+    }
+  }
+  const aliases = new Map<string, string>();
+  const providerAliases = new Map<string, string>();
+  for (const [model, alias] of aliasesByValue) {
+    if (alias) {
+      const aliasKey = normalizeLowercaseStringOrEmpty(alias);
+      aliases.set(aliasKey, model);
+      const ref = parseModelCatalogRef(model);
+      if (ref) {
+        providerAliases.set(`${ref.provider}/${aliasKey}`, model);
+      }
+    }
+  }
+
+  const trimmed = primary.trim();
+  const { model: primaryModel, profile: primaryProfile } = splitTrailingAuthProfile(trimmed);
+  const exactAlias = aliases.get(normalizeLowercaseStringOrEmpty(trimmed));
+  const profileAlias = primaryProfile
+    ? (exactAlias ?? aliases.get(normalizeLowercaseStringOrEmpty(primaryModel)))
+    : undefined;
+  const primaryRef = parseModelCatalogRef(primaryModel);
+  const configuredModels = asOptionalRecord(configForm?.models);
+  const providers = asOptionalRecord(configuredModels?.providers);
+  const providerConfig = asOptionalRecord(
+    primaryRef ? findNormalizedProviderValue(providers, primaryRef.provider) : undefined,
+  );
+  const providerApi = normalizeLowercaseStringOrEmpty(providerConfig?.api);
+  const ownsProviderRef = Boolean(providerApi && providerApi !== primaryRef?.provider);
+  let selectedPrimary = primaryModel;
+  if (profileAlias) {
+    selectedPrimary = profileAlias;
+  } else if (
+    !primaryProfile &&
+    exactAlias &&
+    !ownsProviderRef &&
+    (!primaryRef || parseModelCatalogRef(exactAlias))
+  ) {
+    selectedPrimary = exactAlias;
+  }
+  const primaryKey = normalizeAgentModelRefForConfig(selectedPrimary);
+
+  return (value) => {
+    const { model, profile } = splitTrailingAuthProfile(value);
+    const ref = parseModelCatalogRef(model);
+    // Fallback aliases are matched after stripping profiles, unlike configured primaries.
+    const candidate =
+      aliases.get(normalizeLowercaseStringOrEmpty(model)) ??
+      (ref
+        ? providerAliases.get(`${ref.provider}/${normalizeLowercaseStringOrEmpty(ref.modelId)}`)
+        : undefined) ??
+      model;
+    return (
+      normalizeAgentModelRefForConfig(candidate) === primaryKey &&
+      (!profile || profile === primaryProfile)
+    );
+  };
+}
+
 export function buildModelOptions(
   configForm: Record<string, unknown> | null,
   current?: string | null,
@@ -358,7 +449,7 @@ export function buildModelOptions(
   const catalogOptions = new Map<string, ConfiguredModelOption>();
   const configuredOptions = resolveConfiguredModels(configForm, agentId);
   const addOption = (option: ConfiguredModelOption) => {
-    const key = normalizeLowercaseStringOrEmpty(option.value);
+    const key = normalizeAgentModelRefForConfig(option.value);
     if (seen.has(key)) {
       return;
     }
@@ -369,11 +460,11 @@ export function buildModelOptions(
   if (catalog) {
     const configuredAliases = new Map(
       configuredOptions.map(
-        (option) => [normalizeLowercaseStringOrEmpty(option.value), option.alias] as const,
+        (option) => [normalizeAgentModelRefForConfig(option.value), option.alias] as const,
       ),
     );
     const displayCatalog = catalog.map((entry) => {
-      const key = normalizeLowercaseStringOrEmpty(`${entry.provider}/${entry.id}`);
+      const key = normalizeAgentModelRefForConfig(`${entry.provider}/${entry.id}`);
       const alias = configuredAliases.get(key);
       if (alias === undefined) {
         return entry;
@@ -383,7 +474,7 @@ export function buildModelOptions(
     const displayLookup = buildCatalogDisplayLookup(displayCatalog);
     for (const entry of displayCatalog) {
       const option = buildChatModelOptionFromLookup(entry, displayLookup);
-      catalogOptions.set(normalizeLowercaseStringOrEmpty(option.value), {
+      catalogOptions.set(normalizeAgentModelRefForConfig(option.value), {
         ...option,
         provider: entry.provider,
         tags: entry.tags,
@@ -394,7 +485,7 @@ export function buildModelOptions(
   for (const opt of configuredOptions) {
     // Raw config supplies rows the Gateway catalog lacks and explicit alias edits;
     // catalog identity and tags remain authoritative for matching rows.
-    const catalogOption = catalogOptions.get(normalizeLowercaseStringOrEmpty(opt.value));
+    const catalogOption = catalogOptions.get(normalizeAgentModelRefForConfig(opt.value));
     addOption(catalogOption ?? opt);
   }
 
@@ -402,7 +493,7 @@ export function buildModelOptions(
     addOption(option);
   }
 
-  if (current && !seen.has(normalizeLowercaseStringOrEmpty(current))) {
+  if (current && !seen.has(normalizeAgentModelRefForConfig(current))) {
     const separator = current.indexOf("/");
     options.unshift({
       value: current,

--- a/ui/src/lib/chat/model-ref.test.ts
+++ b/ui/src/lib/chat/model-ref.test.ts
@@ -74,6 +74,35 @@ describe("chat-model-ref helpers", () => {
     },
   );
 
+  it.each([
+    {
+      names: ["Lowercase model", "Uppercase model"],
+      labels: ["Lowercase model", "Uppercase model"],
+    },
+    {
+      names: ["Shared name", "Shared name"],
+      labels: ["Shared name · model-a · custom", "Shared name · Model-A · custom"],
+    },
+  ] as const)(
+    "keeps case-distinct catalog display identities with names $names",
+    ({ names, labels }) => {
+      const entries = [
+        { id: "model-a", name: names[0], provider: "custom" },
+        { id: "Model-A", name: names[1], provider: "custom" },
+      ];
+      const lookup = buildCatalogDisplayLookup(entries);
+
+      expect(entries.map((entry) => buildChatModelOptionFromLookup(entry, lookup))).toEqual([
+        { value: "custom/model-a", label: labels[0] },
+        { value: "custom/Model-A", label: labels[1] },
+      ]);
+      expect(formatCatalogChatModelDisplayFromLookup("CUSTOM/Model-A", lookup)).toBe(labels[1]);
+      expect(formatCatalogChatModelDisplayFromLookup("custom/MODEL-A", lookup)).toBe(
+        "MODEL-A · custom",
+      );
+    },
+  );
+
   it("normalizes raw overrides when the catalog match is unique", () => {
     expect(normalizeChatModelOverrideValue("gpt-5-mini", catalog)).toBe("openai/gpt-5-mini");
   });

--- a/ui/src/lib/chat/model-ref.ts
+++ b/ui/src/lib/chat/model-ref.ts
@@ -1,4 +1,5 @@
 // Chat model reference normalization.
+import { normalizeAgentModelRefForConfig } from "../../../../src/config/model-input.js";
 import type { ModelCatalogEntry } from "../../api/types.ts";
 
 const LEGACY_OPENAI_PROVIDER_IDS = new Set(["codex", "openai-codex"]);
@@ -179,7 +180,9 @@ export function buildCatalogDisplayLookup(catalog: ModelCatalogEntry[]): Map<str
       continue;
     }
 
-    const qualifiedKey = createQualifiedCatalogKey(entry);
+    const qualifiedKey = normalizeAgentModelRefForConfig(
+      buildQualifiedChatModelValue(entry.id, entry.provider),
+    );
     const normalizedName = name.toLowerCase();
     const providerKey = createNameProviderKey(name, entry.provider);
 
@@ -194,7 +197,9 @@ export function buildCatalogDisplayLookup(catalog: ModelCatalogEntry[]): Map<str
 
   const displayLookup = new Map<string, string>();
   for (const entry of catalog) {
-    const qualifiedKey = createQualifiedCatalogKey(entry);
+    const qualifiedKey = normalizeAgentModelRefForConfig(
+      buildQualifiedChatModelValue(entry.id, entry.provider),
+    );
     const name = resolveCatalogDisplayName(entry);
     if (!name) {
       displayLookup.set(qualifiedKey, formatRawCatalogLabel(entry));
@@ -228,7 +233,9 @@ export function formatCatalogChatModelDisplayFromLookup(
     return "";
   }
 
-  return displayLookup.get(trimmed.toLowerCase()) ?? formatChatModelDisplay(trimmed);
+  return (
+    displayLookup.get(normalizeAgentModelRefForConfig(trimmed)) ?? formatChatModelDisplay(trimmed)
+  );
 }
 
 export function buildChatModelOptionFromLookup(
@@ -238,6 +245,7 @@ export function buildChatModelOptionFromLookup(
   const value = buildQualifiedChatModelValue(entry.id, entry.provider);
   return {
     value,
-    label: displayLookup.get(value.toLowerCase()) ?? formatRawCatalogLabel(entry),
+    label:
+      displayLookup.get(normalizeAgentModelRefForConfig(value)) ?? formatRawCatalogLabel(entry),
   };
 }

--- a/ui/src/pages/agents/panels-overview.test.ts
+++ b/ui/src/pages/agents/panels-overview.test.ts
@@ -196,7 +196,7 @@ describe("fallback field", () => {
     const { field } = renderFallbacks();
 
     expect(field.value).toEqual([existingFallback]);
-    expect(field.exclude).toEqual([primary]);
+    expect(field.isExcluded(primary)).toBe(true);
     expect(field.options.map((option) => option.value)).toEqual(
       expect.arrayContaining([primary, existingFallback, "google/gemini-3-pro"]),
     );
@@ -214,6 +214,47 @@ describe("fallback field", () => {
       "google/gemini-3-pro",
     ]);
   });
+
+  it.each(["fast", "FAST", "fast@work"])(
+    "excludes primary alias %s while retaining case-distinct model choices",
+    (primaryAlias) => {
+      const target = "custom/model-a";
+      const caseDistinct = "custom/Model-A";
+      const { field } = renderFallbacks({
+        agentsList: {
+          defaultId: "alpha",
+          mainKey: "main",
+          scope: "per-sender",
+          agents: [{ id: "alpha" }, { id: "beta", model: { primary: caseDistinct } }],
+        },
+        config: {
+          form: {
+            agents: {
+              defaults: {
+                model: { primary: primaryAlias },
+                models: { [target]: { alias: "fast" } },
+              },
+              entries: { alpha: {}, beta: {} },
+            },
+          },
+          loading: false,
+          saving: false,
+          dirty: false,
+          error: null,
+        },
+        modelCatalog: [
+          { provider: "custom", id: "model-a", name: "Lowercase model" },
+          { provider: "custom", id: "Model-A", name: "Uppercase model" },
+        ],
+      });
+
+      expect(field.isExcluded("FAST")).toBe(true);
+      expect(field.isExcluded(`${target}@other`)).toBe(false);
+      expect(field.options.filter((option) => !field.isExcluded(option.value))).toEqual([
+        expect.objectContaining({ value: caseDistinct, label: "Uppercase model" }),
+      ]);
+    },
+  );
 
   it("disables the field without config write access", () => {
     const access = { ...createProps().access, canUpdateConfig: false };

--- a/ui/src/pages/agents/panels-overview.ts
+++ b/ui/src/pages/agents/panels-overview.ts
@@ -1,5 +1,6 @@
 // Control UI view renders agents panels overview screen content.
 import { html, nothing } from "lit";
+import { normalizeAgentModelRefForConfig } from "../../../../src/config/model-input.js";
 import type {
   AgentIdentityResult,
   AgentsFilesListResult,
@@ -19,6 +20,7 @@ import {
   type AgentContext,
   buildAgentContext,
   buildModelOptions,
+  createPrimaryModelExclusion,
   normalizeModelValue,
   resolveAgentConfig,
   resolveAgentTextAvatar,
@@ -132,6 +134,7 @@ export function renderAgentOverview(params: {
   // Same catalog the primary picker offers; the field hides the effective
   // primary and current chain itself. Order is preserved: a pick appends.
   const fallbackOptions = buildModelOptions(configForm, null, params.modelCatalog, agent.id);
+  const isPrimaryModel = createPrimaryModelExclusion(configForm, effectivePrimary, agent.id);
 
   return html`
     ${renderSettingsSection(
@@ -309,7 +312,8 @@ export function renderAgentOverview(params: {
               class="agent-fallbacks"
               .options=${fallbackOptions}
               .value=${fallbackChips}
-              .exclude=${effectivePrimary ? [effectivePrimary] : []}
+              .isExcluded=${isPrimaryModel}
+              .getValueKey=${normalizeAgentModelRefForConfig}
               .placeholder=${t("agents.overview.addFallback")}
               .accessibleLabel=${t("agents.overview.fallbacks")}
               .allowCustom=${true}


### PR DESCRIPTION
Related: #141330, #141953, #141967

## What Problem This Solves

Fixes an issue where users entering a case-sensitive fallback model reference could have it rewritten or hidden when the catalog contained a differently cased ID. The field could also offer the primary model again when it was selected through a configured alias.

## Why This Change Was Made

Search matching is separated from model identity. Catalog values and labels preserve model suffix case, typed references stay as authored, and primary exclusion uses the current form’s configured aliases with the distinct primary and fallback resolution rules.

## User Impact

References such as `custom/Model-A` and `custom/model-a` remain separate choices. Users can keep custom references and aliases without an automatic rewrite, while configured primary aliases exclude the matching fallback target.

## Evidence

- All 110 focused selector, agent-display, catalog-label, and overview tests pass. Original case-preservation regressions fail because the old component omits the case-distinct Add row.
- Built Control UI at `3fc9dd3f1e1a3cb04958f19cf7f3a11adcd9169f` with the maintained stateful mock Gateway: all 12 browser cases pass config/raw readback. These cover exact custom case through Add/Enter/comma, distinct catalog labels, primary aliases and per-agent overrides, explicit clipboard confirmation, retained alias bindings, and bare/profile-qualified alternatives.
- Remote formatting, lint, UI production/test types, assertion-safety, and line-ratchet checks pass. [CI and required aggregate](https://github.com/openclaw/openclaw/actions/runs/34200906453) pass on the same head.

## Visual evidence

| View | Before | After |
| --- | --- | --- |
| Custom model suffix case is preserved | ![Original fallback behavior with the same synthetic model setup](https://github.com/user-attachments/assets/abe33a2d-dbaa-4d66-a1b9-9fa2e37284e8) | ![Corrected fallback behavior with the same synthetic model setup](https://github.com/user-attachments/assets/f75f7b0f-a968-48a9-ae5e-f3dd694ad087) |
| Case-distinct fallback remains available beside the primary | ![Original fallback behavior with the same synthetic model setup](https://github.com/user-attachments/assets/09dcee3b-8fb1-421c-aa0b-2e2b7262ade5) | ![Corrected fallback behavior with the same synthetic model setup](https://github.com/user-attachments/assets/bcfafeec-9757-4f98-8601-9c3d17c08a91) |

### Exact-head fallback interaction recording

https://github.com/user-attachments/assets/ae3934c1-bfd8-4cc9-acdc-8eb4e7151f31

### Visual verification

- Baseline: 6627766f5bfa403d5425e7c1da40f919fa924b45
- Exact head: `3fc9dd3f1e1a3cb04958f19cf7f3a11adcd9169f`
- Scenario: Explicitly add a case-distinct custom reference and add that same reference beside its lowercase primary; validate alias, catalog label, and clipboard alternatives.
- Runtime/build: Node v24.19.0; Chromium 144.0.7559.0; UI index SHA256 fda4aeb1dddf6ea9a0db4e9c61734bd9ffdd4fd86162d516f2b52dd3ba748960
- Authored suffix case: custom/Model-A is saved exactly through Add, Enter and comma.
- Distinct identities: Lowercase and uppercase catalog entries and labels remain distinct; case-distinct fallback is allowed beside primary model-a.
- Aliases and alternatives: Primary alias/profile exclusion, per-agent override, authored alias/CSV, bare and profile-qualified alternatives pass config.set readback.
- Clean exact-head source and emitted UI index/assets verified
- Retained original audit baseline reused after all eight component/caller/config owner hashes matched the selected base
- Same viewport, dark theme, en-US and equivalent Model Selection framing
- Assertions cover actual stateful mock config.set payload plus config/raw readback
- Original screenshots and source recordings retained
- All comparison screenshots and the complete recording sequence were inspected; inputs, cues and settled results are readable and contain only synthetic data.
