### PR TITLE
docs(maturity): clarify score run date label

### DIFF
--- a/docs/maturity/scorecard.md
+++ b/docs/maturity/scorecard.md
@@ -2791,4 +2791,4 @@ Open a surface to inspect the evidence state of each category. The list stays co
 
 </AccordionGroup>
 
-> Last updated: 2026-09-08
+> Latest recorded score run: 2026-09-08

--- a/scripts/qa/render-maturity-docs.ts
+++ b/scripts/qa/render-maturity-docs.ts
@@ -1111,7 +1111,7 @@ function renderMaturityScorecard({
     ...renderEvidenceSection(evidenceSummaries, surfaceNames),
   );
   if (updatedDate) {
-    lines.push(`> Last updated: ${updatedDate}`, "");
+    lines.push(`> Latest recorded score run: ${updatedDate}`, "");
   }
   return `${lines.join("\n").trimEnd()}\n`;
 }

--- a/test/scripts/render-maturity-docs.test.ts
+++ b/test/scripts/render-maturity-docs.test.ts
@@ -501,5 +501,6 @@ describe("maturity docs renderer CLI", () => {
     );
     expect(scorecard).toContain("Coverage Experimental - 0%");
     expect(scorecard).toContain("end-to-end coverage above 90%");
+    expect(scorecard).toContain("> Latest recorded score run:");
   });
 });


### PR DESCRIPTION
Related: #141950

## Problem

The scorecard footer said `Last updated`, even though its date is only the newest existing per-surface score-run timestamp. That wording could imply a broader scorecard refresh.

## Change

Rename the generated footer to `Latest recorded score run`.

No score data, schema, process version, or review metadata changes.

## Evidence

- renderer Vitest: 7 passed
- `pnpm maturity:check`
- `pnpm check:docs`

## Worked on by

- @RomneyDa
