### PR TITLE
improve: reduce repeated validation during session listing

### DIFF
--- a/src/config/sessions/combined-store-gateway.ts
+++ b/src/config/sessions/combined-store-gateway.ts
@@ -31,7 +31,6 @@ import {
 import type { SessionEntryListScope } from "./session-accessor.types.js";
 import { canonicalSessionKeyMigrationRequiredError } from "./session-canonical-key.js";
 import { resolvePersistedSessionStoreOwner } from "./session-store-owner.js";
-import { resolveDeliveryProvenCanonicalSessionKey } from "./store-entry.js";
 import {
   dedupeSessionStoreTargetsBySqliteTarget,
   listConfiguredSessionStoreAgentIds,
@@ -165,6 +164,7 @@ function loadGatewayStoreEntries(params: {
   });
 }
 
+// The listing accessor owns delivery-key validation; federation owns config aliases and targets.
 function mergeSessionEntryIntoCombined(params: {
   cfg: OpenClawConfig;
   combined: Record<string, SessionEntry>;
@@ -185,12 +185,6 @@ function mergeSessionEntryIntoCombined(params: {
   if (existing) {
     throw canonicalSessionKeyMigrationRequiredError(
       `duplicate rows resolve to canonical session key ${canonicalKey}`,
-    );
-  }
-  const deliveryCanonicalKey = resolveDeliveryProvenCanonicalSessionKey(canonicalKey, entry);
-  if (deliveryCanonicalKey !== canonicalKey) {
-    throw canonicalSessionKeyMigrationRequiredError(
-      `non-canonical persisted row resolves to session key ${deliveryCanonicalKey}`,
     );
   }
   const projected = { ...entry };

--- a/src/config/sessions/session-accessor.conformance.test.ts
+++ b/src/config/sessions/session-accessor.conformance.test.ts
@@ -2191,6 +2191,7 @@ describe("sqlite session normalization", () => {
     const env = { ...process.env, OPENCLAW_STATE_DIR: paths.stateDir };
     const canonicalKey = "agent:main:matrix:channel:!MixedCase:example.org";
     const legacyKey = canonicalKey.toLowerCase();
+    const canonicalError = `non-canonical persisted row resolves to session key ${canonicalKey}`;
     const entry = {
       delivery: normalizeSessionDeliveryState({
         context: {
@@ -2208,6 +2209,10 @@ describe("sqlite session normalization", () => {
         "INSERT INTO session_nodes (session_key, current_session_id, entry_json, updated_at) VALUES (?, ?, ?, ?)",
       )
       .run(legacyKey, entry.sessionId, JSON.stringify(entry), entry.updatedAt);
+    // Exercise delivery-key rejection, not the INSERT trigger's pending-entry state.
+    database.db
+      .prepare("UPDATE session_nodes SET entry_valid = 1 WHERE session_key = ?")
+      .run(legacyKey);
 
     expect(() =>
       loadSessionEntry({
@@ -2216,10 +2221,10 @@ describe("sqlite session normalization", () => {
         sessionKey: canonicalKey,
         storePath: paths.sqlitePath,
       }),
-    ).toThrow("openclaw doctor --fix");
+    ).toThrow(canonicalError);
     expect(() =>
       listSessionEntryRows({ agentId: "main", env, storePath: paths.sqlitePath }),
-    ).toThrow("openclaw doctor --fix");
+    ).toThrow(canonicalError);
     await expect(
       appendTranscriptEvent(
         {


### PR DESCRIPTION
## What Problem This Solves

Session listing repeats delivery-key validation for every row after the store accessor has already validated the same key and entry. That adds avoidable work when users list larger session histories.

## Why This Change Was Made

Keep delivery-key validation at the listing accessor and remove the redundant federation check. Federation still owns config-aware aliases, duplicate detection, row copies, physical targets, and lineage projection. The existing malformed-delivery fixture now marks its synthetic row valid before asserting the precise canonical-key error, so it reaches the intended validation instead of stopping at the INSERT trigger's pending-entry flag.

## User Impact

Session listing does less repeated work while preserving existing visibility, ownership, ordering, and invalid-row rejection. This is a small request-cost cleanup, with no configuration, schema, or storage-lifecycle change.

## Evidence

- Focused session accessor, federation, key preservation, ownership, visibility, subagent, and history HTTP tests: 8 files / 253 tests passed. The repository test wrapper also completed its required full build.
- The strengthened fixture first failed on the prior pending-entry error; correcting its setup made the exact delivery-key assertions pass with the original production code, before removing the duplicate check.
- Complete changed gate passed all 29 selected stages, including production/test typechecks, lint, schema, boundary, and import checks.
- Independent managed code review found no actionable issues.

Exact-head [CI passed](https://github.com/openclaw/openclaw/actions/runs/34201562804) for `b0dbe37d109ae7051d38e63df2a6b53bc706ad10`.

Candidate Gateway proof completed in a separately labeled recovery operation on the [same Testbox hosting run](https://github.com/openclaw/openclaw/actions/runs/34201446532), after rechecking the existing candidate source/build and using fresh fixture state. The native wrapper exited 0. All four semantic/64/512/2048-row cases passed: 230 received request/response pairs covering 143 lists, 71 patches (including expected denials), profile checks, and handshakes. Gateway, socket, and fixture closure were verified; no pending requests or holds remained. The full 136-file archive matches its receipt and per-file inventory; independent full audit passed, including all 230 wire pairs, 8,424 row-response checks, pacing, source/build pins, persisted-state audit records, and natural closure.

This is candidate-only Linux x64 / Node 24.19.0 proof with four available CPUs. The largest list call was a 221.65 ms warmup; the largest measured fresh-list call was 65.82 ms. It establishes the tested listing behavior, not a before/after speedup or a diagnosis of unrelated runtime stalls. Reuse-eligible timings do not establish cache-hit attribution.

The first operation remains failed: native transport exited 255 during its build and withheld artifacts. The build later completed, but no Gateway fixture ran in that attempt. All 26 surviving evidence files were recovered and verified before the new operation. A portal-status sync warning also occurred after the successful recovery command; it is separate from the successful native command/artifact result.

ClawSweeper compatibility disposition: no stored-data migration applies to this diff. The only production change removes a redundant in-memory validation after the [listing accessor already validates the same key and entry](https://github.com/openclaw/openclaw/blob/b0dbe37d109ae7051d38e63df2a6b53bc706ad10/src/config/sessions/session-accessor.sqlite-entry.ts#L333). Schema, migrations, write paths, serialized entry bytes, and invalid-row rejection are unchanged. Federation still copies entries and applies the same config aliases, lineage, and target mappings. The fixture's `entry_valid` UPDATE is test setup for one deliberately malformed synthetic row, not a production migration. Focused normalization, federation, ownership, and visibility tests passed as listed above.
