### PR TITLE
refactor(setup): preserve plugin configuration types

### DIFF
--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -2689,7 +2689,7 @@ src/flows/doctor-health-contributions-final.ts	1
 src/flows/doctor-health-contributions.ts	1
 src/flows/doctor-removed-workspaces-state-check.ts	2
 src/flows/health-check-adapter.ts	1
-src/flows/search-setup.ts	6
+src/flows/search-setup.ts	1
 src/gateway/agent-runtime-identity-token.ts	1
 src/gateway/agent-turn/agent-dedupe.ts	3
 src/gateway/agent-turn/agent-job.ts	1

--- a/src/flows/search-setup.ts
+++ b/src/flows/search-setup.ts
@@ -346,14 +346,10 @@ function preserveDisabledState(original: OpenClawConfig, result: OpenClawConfig)
   }
 
   const pluginId = providerEntry.pluginId;
-  const originalPluginEntry = (
-    original.plugins?.entries as Record<string, Record<string, unknown>> | undefined
-  )?.[pluginId];
-  const resultPluginEntry = (
-    next.plugins?.entries as Record<string, Record<string, unknown>> | undefined
-  )?.[pluginId];
+  const originalPluginEntry = original.plugins?.entries?.[pluginId];
+  const resultPluginEntry = next.plugins?.entries?.[pluginId];
 
-  const nextPlugins = { ...next.plugins } as Record<string, unknown>;
+  const nextPlugins = { ...next.plugins };
 
   if (Array.isArray(original.plugins?.allow)) {
     nextPlugins.allow = [...original.plugins.allow];
@@ -363,7 +359,7 @@ function preserveDisabledState(original: OpenClawConfig, result: OpenClawConfig)
 
   if (resultPluginEntry || originalPluginEntry) {
     const nextEntries = {
-      ...(nextPlugins.entries as Record<string, Record<string, unknown>> | undefined),
+      ...nextPlugins.entries,
     };
     const patchedEntry = { ...resultPluginEntry };
     if (typeof originalPluginEntry?.enabled === "boolean") {
@@ -377,7 +373,7 @@ function preserveDisabledState(original: OpenClawConfig, result: OpenClawConfig)
 
   return {
     ...next,
-    plugins: nextPlugins as OpenClawConfig["plugins"],
+    plugins: nextPlugins,
   };
 }
 


### PR DESCRIPTION
## What Problem This Solves

Search setup widens already typed plugin configuration to generic records, then asserts it back to OpenClawConfig. This hides type errors while restoring disabled search settings.

## Why This Change Was Made

Remove five unnecessary assertions in the existing function and shrink its assertion baseline from six to one. The real config and plugin-entry types already support each operation. No helper extraction or runtime ownership change is needed.

This two-file cleanup is split from #140674. Production loses four lines. Runtime operations, evaluation order, configuration shape, and caller behavior are unchanged.

## Evidence

All sixteen existing search-setup tests pass, including disabled-state preservation, explicit reenabling, provider-owned setup, credentials, installation, and consent outcomes. Runtime-erased syntax is equivalent across the complete source file; all text outside the changed function is identical. Codex review found no actionable issues.

The complete canonical changed checks passed, including production typechecking and the exact assertion-baseline reduction. No new tests, live provider calls, or full build are needed for this type-only change with unchanged runtime behavior.
