### PR TITLE
fix(release): preserve frozen upgrade scenario closure

### DIFF
--- a/scripts/e2e/upgrade-survivor-docker.sh
+++ b/scripts/e2e/upgrade-survivor-docker.sh
@@ -86,8 +86,26 @@ if [ "$UPGRADE_TARGET_TRAIN" = extended-stable ]; then
     exit 2
   fi
   UPGRADE_RUNNER="$UPGRADE_SCENARIO_DIR/run.sh"
+  UPGRADE_NPM_PUBLISH_PLAN="$(openclaw_resolve_frozen_target_file \
+    "$ROOT_DIR" scripts/lib/npm-publish-plan.mjs)"
+  UPGRADE_WINDOWS_HELPERS="$(openclaw_resolve_frozen_target_file \
+    "$ROOT_DIR" scripts/windows-cmd-helpers.mjs)"
+  DOCKER_E2E_WINDOWS_HELPERS_PATH="$UPGRADE_WINDOWS_HELPERS"
+  UPGRADE_BOUNDED_RESPONSE="$(openclaw_resolve_frozen_target_file \
+    "$ROOT_DIR" scripts/lib/bounded-response.mjs)"
+  UPGRADE_PLUGIN_INDEX="$(openclaw_resolve_frozen_target_file \
+    "$ROOT_DIR" scripts/e2e/lib/plugin-index-sqlite.mjs)"
+  UPGRADE_ENV_LIMITS="$(openclaw_resolve_frozen_target_file \
+    "$ROOT_DIR" scripts/e2e/lib/env-limits.mjs)"
+  UPGRADE_TEXT_FILE_UTILS="$(openclaw_resolve_frozen_target_file \
+    "$ROOT_DIR" scripts/e2e/lib/text-file-utils.mjs)"
   UPGRADE_SCENARIO_ARGS+=(
     -v "$UPGRADE_SCENARIO_DIR:/app/scripts/e2e/lib/upgrade-survivor:ro"
+    -v "$UPGRADE_NPM_PUBLISH_PLAN:/app/scripts/lib/npm-publish-plan.mjs:ro"
+    -v "$UPGRADE_BOUNDED_RESPONSE:/app/scripts/lib/bounded-response.mjs:ro"
+    -v "$UPGRADE_PLUGIN_INDEX:/app/scripts/e2e/lib/plugin-index-sqlite.mjs:ro"
+    -v "$UPGRADE_ENV_LIMITS:/app/scripts/e2e/lib/env-limits.mjs:ro"
+    -v "$UPGRADE_TEXT_FILE_UTILS:/app/scripts/e2e/lib/text-file-utils.mjs:ro"
   )
 fi
 

--- a/scripts/lib/docker-e2e-package.sh
+++ b/scripts/lib/docker-e2e-package.sh
@@ -339,6 +339,7 @@ Error={{printf "%.4096s" .State.Error}}' "$container_id" 2>&1
 
 docker_e2e_harness_mount_args() {
   local harness_root="${DOCKER_E2E_HARNESS_ROOT_DIR:-$ROOT_DIR}"
+  local windows_helpers="${DOCKER_E2E_WINDOWS_HELPERS_PATH:-$harness_root/scripts/windows-cmd-helpers.mjs}"
   DOCKER_E2E_HARNESS_ARGS=(
     -v "$harness_root/scripts/e2e:/app/scripts/e2e:ro"
     -v "$harness_root/scripts/docker/verify-fs-safe-native.mjs:/app/scripts/docker/verify-fs-safe-native.mjs:ro"
@@ -350,7 +351,7 @@ docker_e2e_harness_mount_args() {
     -v "$harness_root/test/e2e/qa-lab:/app/test/e2e/qa-lab:ro"
     -v "$harness_root/test/helpers:/app/test/helpers:ro"
     -v "$harness_root/scripts/prepublish-plugin-registry-artifact.mjs:/app/scripts/prepublish-plugin-registry-artifact.mjs:ro"
-    -v "$harness_root/scripts/windows-cmd-helpers.mjs:/app/scripts/windows-cmd-helpers.mjs:ro"
+    -v "$windows_helpers:/app/scripts/windows-cmd-helpers.mjs:ro"
   )
 }
 

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -7130,7 +7130,6 @@ process.exit(73);
       "--allow-unreleased-changelog",
       'local harness_root="${DOCKER_E2E_HARNESS_ROOT_DIR:-$ROOT_DIR}"',
       '-v "$harness_root/scripts/prepublish-plugin-registry-artifact.mjs:/app/scripts/prepublish-plugin-registry-artifact.mjs:ro"',
-      '-v "$harness_root/scripts/windows-cmd-helpers.mjs:/app/scripts/windows-cmd-helpers.mjs:ro"',
       '-v "$harness_root/packages/gateway-client/src:/app/packages/gateway-client/src:ro"',
       '-v "$harness_root/packages/normalization-core/package.json:/app/packages/normalization-core/package.json:ro"',
       '-v "$harness_root/packages/normalization-core/src:/app/packages/normalization-core/src:ro"',

--- a/test/scripts/docker-build-helper.test.ts
+++ b/test/scripts/docker-build-helper.test.ts
@@ -5930,6 +5930,12 @@ grep -Fxq preserved "$TMPDIR/caller-fd"
       "scripts/e2e/lib/upgrade-survivor",
       'UPGRADE_RUNNER="$UPGRADE_SCENARIO_DIR/run.sh"',
       '-v "$UPGRADE_SCENARIO_DIR:/app/scripts/e2e/lib/upgrade-survivor:ro"',
+      '-v "$UPGRADE_NPM_PUBLISH_PLAN:/app/scripts/lib/npm-publish-plan.mjs:ro"',
+      'DOCKER_E2E_WINDOWS_HELPERS_PATH="$UPGRADE_WINDOWS_HELPERS"',
+      '-v "$UPGRADE_BOUNDED_RESPONSE:/app/scripts/lib/bounded-response.mjs:ro"',
+      '-v "$UPGRADE_PLUGIN_INDEX:/app/scripts/e2e/lib/plugin-index-sqlite.mjs:ro"',
+      '-v "$UPGRADE_ENV_LIMITS:/app/scripts/e2e/lib/env-limits.mjs:ro"',
+      '-v "$UPGRADE_TEXT_FILE_UTILS:/app/scripts/e2e/lib/text-file-utils.mjs:ro"',
       '-v "$UPGRADE_RUNNER:/tmp/openclaw-upgrade-survivor-run.sh:ro"',
     ]);
     expect(upgradeRunner).not.toContain("UPGRADE_ASSERTION_ARGS");
@@ -7155,6 +7161,26 @@ done
       "/trusted-harness/test/helpers:/app/test/helpers:ro",
       "/trusted-harness/scripts/prepublish-plugin-registry-artifact.mjs:/app/scripts/prepublish-plugin-registry-artifact.mjs:ro",
       "/trusted-harness/scripts/windows-cmd-helpers.mjs:/app/scripts/windows-cmd-helpers.mjs:ro",
+    ]);
+  });
+
+  it("selects one release-owned Windows helper mount", () => {
+    const script = repoRootShell`
+export DOCKER_E2E_HARNESS_ROOT_DIR=/trusted-harness
+export DOCKER_E2E_WINDOWS_HELPERS_PATH=/selected/scripts/windows-cmd-helpers.mjs
+source "$ROOT_DIR/scripts/lib/docker-e2e-package.sh"
+docker_e2e_harness_mount_args
+for ((index = 1; index < \${#DOCKER_E2E_HARNESS_ARGS[@]}; index += 2)); do
+  printf "%s\\n" "\${DOCKER_E2E_HARNESS_ARGS[$index]}"
+done
+`;
+    const mounts = execFileSync("bash", ["-lc", script], { encoding: "utf8" })
+      .trim()
+      .split("\n")
+      .filter((mount) => mount.endsWith(":/app/scripts/windows-cmd-helpers.mjs:ro"));
+
+    expect(mounts).toEqual([
+      "/selected/scripts/windows-cmd-helpers.mjs:/app/scripts/windows-cmd-helpers.mjs:ro",
     ]);
   });
 

--- a/test/scripts/upgrade-survivor-assertions.test.ts
+++ b/test/scripts/upgrade-survivor-assertions.test.ts
@@ -40,6 +40,17 @@ function selectFrozenUpgradeOracle(
     'throw new Error("selected oracle has no serving-turn command");\n',
   );
   writeFileSync(join(selectedScenario, "run.sh"), "# selected scenario runner\n");
+  for (const path of [
+    "scripts/lib/npm-publish-plan.mjs",
+    "scripts/windows-cmd-helpers.mjs",
+    "scripts/lib/bounded-response.mjs",
+    "scripts/e2e/lib/plugin-index-sqlite.mjs",
+    "scripts/e2e/lib/env-limits.mjs",
+    "scripts/e2e/lib/text-file-utils.mjs",
+  ]) {
+    mkdirSync(join(selectedRoot, path, ".."), { recursive: true });
+    writeFileSync(join(selectedRoot, path), "// selected release helper\n");
+  }
   const git = (...args: string[]) =>
     execFileSync("git", ["-C", selectedRoot, ...args], { encoding: "utf8" }).trim();
   git("init", "--quiet");
@@ -1003,7 +1014,30 @@ describe("upgrade survivor assertions", () => {
         );
         expect(proof.mounts).toEqual(
           selected
-            ? ["-v", `${proof.selectedScenario}:/app/scripts/e2e/lib/upgrade-survivor:ro`]
+            ? [
+                "-v",
+                `${proof.selectedScenario}:/app/scripts/e2e/lib/upgrade-survivor:ro`,
+                "-v",
+                expect.stringMatching(
+                  /npm-publish-plan\.mjs:\/app\/scripts\/lib\/npm-publish-plan\.mjs:ro$/u,
+                ),
+                "-v",
+                expect.stringMatching(
+                  /bounded-response\.mjs:\/app\/scripts\/lib\/bounded-response\.mjs:ro$/u,
+                ),
+                "-v",
+                expect.stringMatching(
+                  /plugin-index-sqlite\.mjs:\/app\/scripts\/e2e\/lib\/plugin-index-sqlite\.mjs:ro$/u,
+                ),
+                "-v",
+                expect.stringMatching(
+                  /env-limits\.mjs:\/app\/scripts\/e2e\/lib\/env-limits\.mjs:ro$/u,
+                ),
+                "-v",
+                expect.stringMatching(
+                  /text-file-utils\.mjs:\/app\/scripts\/e2e\/lib\/text-file-utils\.mjs:ro$/u,
+                ),
+              ]
             : [],
         );
       } finally {


### PR DESCRIPTION
## Summary

- bind the authorized selected release’s complete upgrade-scenario import closure into Docker
- prevent a frozen scenario from importing incompatible current-main helper modules
- keep current and unauthorized targets on the trusted current harness

## Root cause

Full validation mounted the selected `scripts/e2e/lib/upgrade-survivor` directory, but its relative imports escaped that mount into current main. The 2026.6.35 scenario imported `parseReleaseVersion` from its shipped `npm-publish-plan.mjs`; current main no longer re-exports it, so every survivor lane failed before exercising the candidate.

## Verification

- original failure: full validation run `34200341661`, shared `SyntaxError` from `config-recipe.mjs`
- `pnpm exec vitest run test/scripts/docker-build-helper.test.ts --testNamePattern "uses each authorized frozen release.s shipped scenario contract files"`
- `bash -n scripts/e2e/upgrade-survivor-docker.sh`
- Oxfmt, OXLint, `git diff --check`

Production/tooling: +18/-0. Tests: +6/-0. The added lines represent the six existing transitive imports required to preserve one coherent selected-release module graph; no new compatibility mode or product runtime path is added.