### PR TITLE
fix(telegram): preserve multiline text-directive commands at ingress

### DIFF
--- a/extensions/telegram/src/bot-message-context.command-body.test.ts
+++ b/extensions/telegram/src/bot-message-context.command-body.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import { buildTelegramMessageContextForTest } from "./bot-message-context.test-harness.js";
+
+describe("buildTelegramMessageContext multiline command projection", () => {
+  const chat = { id: 999, type: "private" as const, first_name: "Alice" };
+  const sender = { id: 42, first_name: "Alice", is_bot: false };
+
+  it("preserves later lines of multiline text-directive commands", async () => {
+    const context = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 1,
+        chat,
+        from: sender,
+        text: "/think high\nsummarize the thread so far",
+        entities: [{ type: "bot_command", offset: 0, length: "/think".length }],
+      },
+    });
+
+    expect(context?.ctxPayload.CommandBody).toBe("/think high\nsummarize the thread so far");
+  });
+
+  it("keeps the raw multiline reset projection for core-side strict normalization", async () => {
+    const context = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 1,
+        chat,
+        from: sender,
+        text: "/reset\nextra context",
+        entities: [{ type: "bot_command", offset: 0, length: "/reset".length }],
+      },
+    });
+
+    // The ingress projection preserves the tail verbatim; the reset flatten policy
+    // is applied by the core command layer (session-reset-command / commands-context).
+    expect(context?.ctxPayload.CommandBody).toBe("/reset\nextra context");
+  });
+
+  it("keeps single-line command normalization unchanged", async () => {
+    const context = await buildTelegramMessageContextForTest({
+      message: {
+        message_id: 1,
+        chat,
+        from: sender,
+        text: "/status",
+        entities: [{ type: "bot_command", offset: 0, length: "/status".length }],
+      },
+    });
+
+    expect(context?.ctxPayload.CommandBody).toBe("/status");
+  });
+});

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -568,6 +568,9 @@ export async function buildTelegramInboundContextPayload(params: {
   const hasGroupHistoryContext = isGroup;
   const commandBody = normalizeCommandBody(rawBody, {
     botUsername: normalizeOptionalLowercaseString(primaryCtx.me?.username),
+    // Preserve multiline text-directive arguments for the core boundary (#138545);
+    // native strictness is re-derived core-side from the same text.
+    preserveArguments: true,
   });
   const commandSource =
     options?.commandSource ??


### PR DESCRIPTION
## What Problem This Solves

With Telegram native commands disabled, `/think high` followed by a task on later lines could return only the settings acknowledgement. Telegram had discarded the task before core directive routing received it.

## Change

Preserve complete arguments at the existing Telegram command projection with `preserveArguments: true`. Core still owns directive removal, sender authorization, strict native arguments, and command-specific reset/skill/learn handling. No parser, configuration option, dependency or retry is added.

## Evidence

Built main `4f84c11f` and candidate `22f6d528` were exercised through Telegram's Test Server, a leased dedicated user and bot, the real Gateway, and a deterministic HTTP provider. Each paired plan retained one credential lease across its baseline/candidate phases.

| Scenario | Main | Candidate |
| --- | --- | --- |
| Text `/think high` plus multiline task | Settings acknowledgement, zero provider requests, no task transcript | One request containing the task once with high reasoning effort; one unique Telegram answer; matching user/assistant transcript |
| Native `/think high` with an extra task | Strict rejection, zero provider requests | Same strict rejection and zero provider requests |
| Directive only | Settings-only turn | Settings-only turn |

- Independent Telegram controls cover spacing, bot targeting, sender and mention gates, ordinary messages, reset, installed skill and learning inputs, photo captions, forum topics, replies, and stored history. Internal projection and unchanged-owner claims were checked separately against source.
- Telegram normalizes supplied CRLF to LF before OpenClaw receives it. The preserved task retains the recorded spacing, blank lines and LF endings. Reset keeps its strict core command view while preserving the raw task payload.
- Reply proof uses explicit per-turn mock responses with unique response IDs; the default mock could select an earlier conversation marker. Captured Telegram send confirmations bind temporary IDs to settled messages. Each paired run releases its credential and removes its temporary processes, ports and topic fixtures.
- 212 focused tests pass: 51 Telegram context/sibling cases and 161 shared normalizer, parser and routing cases. The new regression file fails twice on original production for the intended dropped-tail/flattened-projection assertions; its single-line control passes.
- Formatting, lint, line-count/environment-count and assertion-safety checks pass. Independent code review found no actionable P0–P2 defect. Exact-head CI run34201939949 completed successfully.

An exploratory overlapping-turn reply control exposed a missing reply target on the queued delivery path. A controlled early second turn reproduces the same failure on pinned main. The plain-text projection and downstream reply owners are unchanged; this existing defect is recorded as a separate follow-up. Ordinary reply proof waits for the first observed answer before sending the next turn.

The deterministic provider does not claim live model reasoning. Native commands remain distinct from text directives; this does not make task tails valid native arguments. Original loopback proof remains useful supporting evidence. AI-assisted maintainer validation preserves contributor authorship.

Fixes #141998.
