### PR TITLE
refactor(tests): use controlled fetch clock for fatal Git outcomes

### DIFF
--- a/test/scripts/ci-git-owner.test.ts
+++ b/test/scripts/ci-git-owner.test.ts
@@ -737,7 +737,6 @@ linuxIt.each([
       action: "ensure-base-commit",
       baseAvailableAfter: 1,
       fetchResults: [result],
-      realClock: true,
       realDrain: true,
       scenario: "scenario" in entry ? entry.scenario : undefined,
       cancelDuringCleanup: "cancelDuringCleanup" in entry,


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Three fatal Git-policy outcome tests wait on a real fetch clock even though their contract is stopping before availability checks or retry after an inspection failure or cancellation. The existing fixture can advance that deadline after the stalled process is ready while keeping process drainage real.

## Why This Change Was Made

Remove only `realClock: true` from that three-row table. Keep `realDrain: true`, all fatal outcomes, cancellation-during-cleanup checks, process ownership assertions and no-recovery expectations. Separate tests still exercise both real 30-second defaults and the real five-second backoff.

## User Impact

No production behavior or deadline changes. The same three scenarios remain. This removes one test line; no overall test-time or generalized speedup claim.

## Evidence

- Focused Linux measurement with Node 24.19.0 and umask 022: the identical three cases passed before in 39.044s and after in 9.296s.
- A fixture-only lost-cancellation-latch control failed the retained 143 expectation with actual 0 and forbidden recovery output after cleanup cancellation.
- All three owner/sibling files passed: 246/246 cases, zero skipped, with joined process groups. Both real 30-second defaults and real five-second backoff remain covered.
- Relevant source, action, fixture and dependency identities match the Linux-tested revision; no Linux test rerun was attempted on macOS.
- Mapped formatting/type/lint/guard checks, deslop and fresh P2 review passed.
