### PR TITLE
fix(ui): show saved agent avatars on authenticated gateways

### DIFF
--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -55,6 +55,7 @@ import {
   canCallGatewayMethod,
   type GatewayMethodOperatorScope,
 } from "../../lib/gateway-methods.ts";
+import { IdentityAvatarController } from "../../lib/identity-avatar-loader.ts";
 import { parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
 import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -117,6 +118,7 @@ class AgentsPage
   @state() agentIdentityLoading = false;
   @state() agentIdentityError: string | null = null;
   @state() identityDraft: AgentIdentityDraft = { name: null, emoji: null, avatar: null };
+  private readonly identityAvatarLoader = new IdentityAvatarController(this);
   @state() identitySaving = false;
   @state() identityError: string | null = null;
   @state() agentSkillsLoading = false;
@@ -964,231 +966,234 @@ class AgentsPage
         </div>
       </section>
       ${renderSettingsWorkspace(
-        renderAgents({
-          access,
-          basePath: this.context.basePath,
-          loading: agentsState.agentsLoading,
-          error: agentsState.agentsError,
-          agentsList: this.agentsList,
-          selectedAgentId,
-          activePanel: this.agentsPanel,
-          config: {
-            form: config,
-            loading: configState.configLoading,
-            saving: configState.configSaving,
-            dirty: configState.configFormDirty,
-            error: configState.lastError,
-          },
-          channels: {
-            snapshot: this.context.channels.state.channelsSnapshot,
-            loading: this.context.channels.state.channelsLoading,
-            error: this.context.channels.state.channelsError,
-            lastSuccess: this.context.channels.state.channelsLastSuccess,
-          },
-          cron: {
-            status: this.cron.cronStatus,
-            jobs: this.cron.cronJobs,
-            jobsTotal: this.cron.cronJobsTotal,
-            jobsHasMore: this.cron.cronJobsHasMore,
-            jobsLoadingMore: this.cron.cronJobsLoadingMore,
-            scopedTotal: this.cron.cronScopedTotal,
-            scopedNextWakeAtMs: this.cron.cronScopedNextWakeAtMs,
-            loading: this.cron.cronLoading,
-            error: this.cron.cronError,
-          },
-          agentFiles: {
-            list: this.agentFilesList,
-            loading: this.agentFilesLoading,
-            error: this.agentFilesError ?? this.context.agents.files(selectedAgentId).error,
-            active: this.agentFileActive,
-            contents: this.agentFileContents,
-            drafts: this.agentFileDrafts,
-            saving: this.agentFileSaving,
-          },
-          agentIdentityLoading: this.agentIdentityLoading,
-          agentIdentityError: this.agentIdentityError,
-          agentIdentityById: this.agentIdentityById(),
-          identityDraft: this.identityDraft,
-          identitySaving: this.identitySaving,
-          identityError: this.identityError,
-          agentSkills: {
-            report: this.agentSkillsReport,
-            loading: this.agentSkillsLoading,
-            error: this.agentSkillsError,
-            agentId: this.agentSkillsAgentId,
-            filter: this.skillsFilter,
-          },
-          toolsCatalog: {
-            loading: this.toolsCatalogLoading,
-            error: this.toolsCatalogError,
-            result: this.toolsCatalogResult,
-          },
-          toolsEffective: {
-            loading: this.toolsEffectiveLoading,
-            error: this.toolsEffectiveError,
-            result: this.toolsEffectiveResult,
-          },
-          githubIdentity: this.githubIdentity,
-          onOpenGitHubConnections: () =>
-            this.context.navigate("profile", { hash: "#settings-profile-github-connections" }),
-          runtimeSessionKey: this.sessionKey,
-          runtimeSessionMatchesSelectedAgent: selectedAgentId === this.chatAgentId(),
-          modelCatalog: this.chatModelCatalog,
-          modelCatalogStatus: this.chatModelCatalogStatus,
-          pinnedAgentIds: this.context.navigation.snapshot.pinnedAgentIds,
-          onTogglePinnedAgent: (agentId) => togglePinnedAgent(this.context.navigation, agentId),
-          onRefresh: () => this.refreshAgents(),
-          onSelectAgent: (agentId) =>
-            navigateToAgent(this.context, agentId, selectedAgentId, this.agentsPanel),
-          onCreateAgent: () => {
-            if (this.canCall("openclaw.chat", "operator.admin")) {
-              this.context.navigate("custodian", { search: "?intent=new-agent" });
-            }
-          },
-          onSelectPanel: (panel) =>
-            navigateToAgentPanel(this.context, selectedAgentId, this.agentsPanel, panel),
-          onLoadFiles: (agentId) => void this.loadAgentFiles(agentId, true),
-          onSelectFile: (name) => {
-            this.agentFileActive = name;
-            if (selectedAgentId) {
-              void loadAgentFileContent(this, selectedAgentId, name);
-            }
-          },
-          onFileDraftChange: (name, content) => {
-            this.agentFileDrafts = { ...this.agentFileDrafts, [name]: content };
-          },
-          onFileReset: (name) => {
-            this.agentFileDrafts = {
-              ...this.agentFileDrafts,
-              [name]: this.agentFileContents[name] ?? "",
-            };
-          },
-          onFileSave: (name) => {
-            if (selectedAgentId) {
-              this.saveSelectedAgentFile(
-                selectedAgentId,
-                name,
-                this.agentFileDrafts[name] ?? this.agentFileContents[name] ?? "",
-              );
-            }
-          },
-          onToolsProfileChange: (agentId, profile, clearAllow) => {
-            if (!this.canCall("config.set", "operator.admin")) {
-              return;
-            }
-            const path = this.toolsPath(agentId, Boolean(profile || clearAllow));
-            if (!path) {
-              return;
-            }
-            if (profile) {
-              this.context.runtimeConfig.patchForm([...path, "profile"], profile);
-            } else {
-              this.context.runtimeConfig.removeFormValue([...path, "profile"]);
-            }
-            if (clearAllow) {
-              this.context.runtimeConfig.removeFormValue([...path, "allow"]);
-            }
-          },
-          onToolsOverridesChange: (agentId, alsoAllow, deny) => {
-            if (!this.canCall("config.set", "operator.admin")) {
-              return;
-            }
-            const path = this.toolsPath(agentId, alsoAllow.length > 0 || deny.length > 0);
-            if (!path) {
-              return;
-            }
-            if (alsoAllow.length) {
-              this.context.runtimeConfig.patchForm([...path, "alsoAllow"], alsoAllow);
-            } else {
-              this.context.runtimeConfig.removeFormValue([...path, "alsoAllow"]);
-            }
-            if (deny.length) {
-              this.context.runtimeConfig.patchForm([...path, "deny"], deny);
-            } else {
-              this.context.runtimeConfig.removeFormValue([...path, "deny"]);
-            }
-          },
-          onConfigReload: () => this.reloadConfig(),
-          onConfigSave: () => this.saveAgentConfig(),
-          onIdentityFieldChange: (field, value) => {
-            if (this.canCall("agents.update", "operator.admin")) {
-              setIdentityDraftField(this, field, value);
-            }
-          },
-          onIdentityAvatarSelect: (file) => {
-            if (this.canCall("agents.update", "operator.admin")) {
-              selectIdentityAvatar(this, file);
-            }
-          },
-          onIdentitySave: () => this.saveIdentityDraft(),
-          onChannelsRefresh: () => void this.context.channels.refresh(false),
-          onOpenMemoryImport: () => this.context.navigate("memory-import"),
-          onOpenMemorySettings: () => this.context.navigate("memory"),
-          onOpenAgentDefaults: () => this.context.navigate("ai-agents"),
-          onCronRefresh: () => void this.refreshCron(),
-          onCronLoadMore: () =>
-            void this.runCronTask((cronState) =>
-              loadCronJobsPage(cronState, { append: true, tableFilters: true }),
-            ),
-          onCronRunNow: (jobId) => this.runCronJobNow(jobId),
-          onSkillsFilterChange: (next) => (this.skillsFilter = next),
-          onSkillsRefresh: () => {
-            if (selectedAgentId) {
-              void loadAgentSkills(this, selectedAgentId);
-            }
-          },
-          onAgentSkillToggle: (agentId, skillName, enabled) => {
-            if (!this.canCall("config.set", "operator.admin")) {
-              return;
-            }
-            const target = this.context.runtimeConfig.agentEntry(agentId, { ensure: true });
-            if (!target || !skillName.trim()) {
-              return;
-            }
-            const base =
-              resolveAgentSkillsFilter(
-                currentConfigObject(this.context.runtimeConfig.state),
-                agentId,
-              ) ??
-              this.agentSkillsReport?.agentSkillFilter ??
-              this.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
-              [];
-            const next = new Set(base);
-            if (enabled) {
-              next.add(skillName.trim());
-            } else {
-              next.delete(skillName.trim());
-            }
-            this.context.runtimeConfig.patchForm([...target.path, "skills"], [...next]);
-          },
-          onAgentSkillsClear: (agentId) => this.clearAgentSkills(agentId),
-          onAgentSkillsDisableAll: (agentId) => {
-            if (!this.canCall("config.set", "operator.admin")) {
-              return;
-            }
-            const target = this.context.runtimeConfig.agentEntry(agentId, { ensure: true });
-            if (target) {
-              this.context.runtimeConfig.patchForm([...target.path, "skills"], []);
-            }
-          },
-          onModelChange: (agentId, modelId) => {
-            if (!this.canCall("config.set", "operator.admin")) {
-              return;
-            }
-            stageAgentPrimaryModel(this.context.runtimeConfig, agentId, modelId);
-            void refreshVisibleToolsEffectiveForCurrentSession(this);
-          },
-          // Availability facts (provider keys added/removed, new models) go
-          // stale in the per-agent cache; opening the picker re-reads them,
-          // mirroring the chat composer's on-open refresh.
-          onModelCatalogOpen: () => this.ensureModelCatalog({ refresh: true }),
-          onModelFallbacksChange: (agentId, fallbacks) => {
-            if (this.canCall("config.set", "operator.admin")) {
-              stageAgentModelFallbacks(this.context.runtimeConfig, agentId, fallbacks);
-            }
-          },
-          onSetDefault: (agentId) => this.setDefaultAgent(agentId),
-        }),
+        this.identityAvatarLoader.withActiveRoutes(() =>
+          renderAgents({
+            access,
+            basePath: this.context.basePath,
+            loading: agentsState.agentsLoading,
+            error: agentsState.agentsError,
+            agentsList: this.agentsList,
+            selectedAgentId,
+            activePanel: this.agentsPanel,
+            config: {
+              form: config,
+              loading: configState.configLoading,
+              saving: configState.configSaving,
+              dirty: configState.configFormDirty,
+              error: configState.lastError,
+            },
+            channels: {
+              snapshot: this.context.channels.state.channelsSnapshot,
+              loading: this.context.channels.state.channelsLoading,
+              error: this.context.channels.state.channelsError,
+              lastSuccess: this.context.channels.state.channelsLastSuccess,
+            },
+            cron: {
+              status: this.cron.cronStatus,
+              jobs: this.cron.cronJobs,
+              jobsTotal: this.cron.cronJobsTotal,
+              jobsHasMore: this.cron.cronJobsHasMore,
+              jobsLoadingMore: this.cron.cronJobsLoadingMore,
+              scopedTotal: this.cron.cronScopedTotal,
+              scopedNextWakeAtMs: this.cron.cronScopedNextWakeAtMs,
+              loading: this.cron.cronLoading,
+              error: this.cron.cronError,
+            },
+            agentFiles: {
+              list: this.agentFilesList,
+              loading: this.agentFilesLoading,
+              error: this.agentFilesError ?? this.context.agents.files(selectedAgentId).error,
+              active: this.agentFileActive,
+              contents: this.agentFileContents,
+              drafts: this.agentFileDrafts,
+              saving: this.agentFileSaving,
+            },
+            agentIdentityLoading: this.agentIdentityLoading,
+            agentIdentityError: this.agentIdentityError,
+            agentIdentityById: this.agentIdentityById(),
+            identityDraft: this.identityDraft,
+            identityAvatarLoader: this.identityAvatarLoader,
+            identitySaving: this.identitySaving,
+            identityError: this.identityError,
+            agentSkills: {
+              report: this.agentSkillsReport,
+              loading: this.agentSkillsLoading,
+              error: this.agentSkillsError,
+              agentId: this.agentSkillsAgentId,
+              filter: this.skillsFilter,
+            },
+            toolsCatalog: {
+              loading: this.toolsCatalogLoading,
+              error: this.toolsCatalogError,
+              result: this.toolsCatalogResult,
+            },
+            toolsEffective: {
+              loading: this.toolsEffectiveLoading,
+              error: this.toolsEffectiveError,
+              result: this.toolsEffectiveResult,
+            },
+            githubIdentity: this.githubIdentity,
+            onOpenGitHubConnections: () =>
+              this.context.navigate("profile", { hash: "#settings-profile-github-connections" }),
+            runtimeSessionKey: this.sessionKey,
+            runtimeSessionMatchesSelectedAgent: selectedAgentId === this.chatAgentId(),
+            modelCatalog: this.chatModelCatalog,
+            modelCatalogStatus: this.chatModelCatalogStatus,
+            pinnedAgentIds: this.context.navigation.snapshot.pinnedAgentIds,
+            onTogglePinnedAgent: (agentId) => togglePinnedAgent(this.context.navigation, agentId),
+            onRefresh: () => this.refreshAgents(),
+            onSelectAgent: (agentId) =>
+              navigateToAgent(this.context, agentId, selectedAgentId, this.agentsPanel),
+            onCreateAgent: () => {
+              if (this.canCall("openclaw.chat", "operator.admin")) {
+                this.context.navigate("custodian", { search: "?intent=new-agent" });
+              }
+            },
+            onSelectPanel: (panel) =>
+              navigateToAgentPanel(this.context, selectedAgentId, this.agentsPanel, panel),
+            onLoadFiles: (agentId) => void this.loadAgentFiles(agentId, true),
+            onSelectFile: (name) => {
+              this.agentFileActive = name;
+              if (selectedAgentId) {
+                void loadAgentFileContent(this, selectedAgentId, name);
+              }
+            },
+            onFileDraftChange: (name, content) => {
+              this.agentFileDrafts = { ...this.agentFileDrafts, [name]: content };
+            },
+            onFileReset: (name) => {
+              this.agentFileDrafts = {
+                ...this.agentFileDrafts,
+                [name]: this.agentFileContents[name] ?? "",
+              };
+            },
+            onFileSave: (name) => {
+              if (selectedAgentId) {
+                this.saveSelectedAgentFile(
+                  selectedAgentId,
+                  name,
+                  this.agentFileDrafts[name] ?? this.agentFileContents[name] ?? "",
+                );
+              }
+            },
+            onToolsProfileChange: (agentId, profile, clearAllow) => {
+              if (!this.canCall("config.set", "operator.admin")) {
+                return;
+              }
+              const path = this.toolsPath(agentId, Boolean(profile || clearAllow));
+              if (!path) {
+                return;
+              }
+              if (profile) {
+                this.context.runtimeConfig.patchForm([...path, "profile"], profile);
+              } else {
+                this.context.runtimeConfig.removeFormValue([...path, "profile"]);
+              }
+              if (clearAllow) {
+                this.context.runtimeConfig.removeFormValue([...path, "allow"]);
+              }
+            },
+            onToolsOverridesChange: (agentId, alsoAllow, deny) => {
+              if (!this.canCall("config.set", "operator.admin")) {
+                return;
+              }
+              const path = this.toolsPath(agentId, alsoAllow.length > 0 || deny.length > 0);
+              if (!path) {
+                return;
+              }
+              if (alsoAllow.length) {
+                this.context.runtimeConfig.patchForm([...path, "alsoAllow"], alsoAllow);
+              } else {
+                this.context.runtimeConfig.removeFormValue([...path, "alsoAllow"]);
+              }
+              if (deny.length) {
+                this.context.runtimeConfig.patchForm([...path, "deny"], deny);
+              } else {
+                this.context.runtimeConfig.removeFormValue([...path, "deny"]);
+              }
+            },
+            onConfigReload: () => this.reloadConfig(),
+            onConfigSave: () => this.saveAgentConfig(),
+            onIdentityFieldChange: (field, value) => {
+              if (this.canCall("agents.update", "operator.admin")) {
+                setIdentityDraftField(this, field, value);
+              }
+            },
+            onIdentityAvatarSelect: (file) => {
+              if (this.canCall("agents.update", "operator.admin")) {
+                selectIdentityAvatar(this, file);
+              }
+            },
+            onIdentitySave: () => this.saveIdentityDraft(),
+            onChannelsRefresh: () => void this.context.channels.refresh(false),
+            onOpenMemoryImport: () => this.context.navigate("memory-import"),
+            onOpenMemorySettings: () => this.context.navigate("memory"),
+            onOpenAgentDefaults: () => this.context.navigate("ai-agents"),
+            onCronRefresh: () => void this.refreshCron(),
+            onCronLoadMore: () =>
+              void this.runCronTask((cronState) =>
+                loadCronJobsPage(cronState, { append: true, tableFilters: true }),
+              ),
+            onCronRunNow: (jobId) => this.runCronJobNow(jobId),
+            onSkillsFilterChange: (next) => (this.skillsFilter = next),
+            onSkillsRefresh: () => {
+              if (selectedAgentId) {
+                void loadAgentSkills(this, selectedAgentId);
+              }
+            },
+            onAgentSkillToggle: (agentId, skillName, enabled) => {
+              if (!this.canCall("config.set", "operator.admin")) {
+                return;
+              }
+              const target = this.context.runtimeConfig.agentEntry(agentId, { ensure: true });
+              if (!target || !skillName.trim()) {
+                return;
+              }
+              const base =
+                resolveAgentSkillsFilter(
+                  currentConfigObject(this.context.runtimeConfig.state),
+                  agentId,
+                ) ??
+                this.agentSkillsReport?.agentSkillFilter ??
+                this.agentSkillsReport?.skills?.map((skill) => skill.name).filter(Boolean) ??
+                [];
+              const next = new Set(base);
+              if (enabled) {
+                next.add(skillName.trim());
+              } else {
+                next.delete(skillName.trim());
+              }
+              this.context.runtimeConfig.patchForm([...target.path, "skills"], [...next]);
+            },
+            onAgentSkillsClear: (agentId) => this.clearAgentSkills(agentId),
+            onAgentSkillsDisableAll: (agentId) => {
+              if (!this.canCall("config.set", "operator.admin")) {
+                return;
+              }
+              const target = this.context.runtimeConfig.agentEntry(agentId, { ensure: true });
+              if (target) {
+                this.context.runtimeConfig.patchForm([...target.path, "skills"], []);
+              }
+            },
+            onModelChange: (agentId, modelId) => {
+              if (!this.canCall("config.set", "operator.admin")) {
+                return;
+              }
+              stageAgentPrimaryModel(this.context.runtimeConfig, agentId, modelId);
+              void refreshVisibleToolsEffectiveForCurrentSession(this);
+            },
+            // Availability facts (provider keys added/removed, new models) go
+            // stale in the per-agent cache; opening the picker re-reads them,
+            // mirroring the chat composer's on-open refresh.
+            onModelCatalogOpen: () => this.ensureModelCatalog({ refresh: true }),
+            onModelFallbacksChange: (agentId, fallbacks) => {
+              if (this.canCall("config.set", "operator.admin")) {
+                stageAgentModelFallbacks(this.context.runtimeConfig, agentId, fallbacks);
+              }
+            },
+            onSetDefault: (agentId) => this.setDefaultAgent(agentId),
+          }),
+        ),
       )}
     `;
   }

--- a/ui/src/pages/agents/agents-view.test-helpers.ts
+++ b/ui/src/pages/agents/agents-view.test-helpers.ts
@@ -1,18 +1,5 @@
 import { GitHubIdentityController } from "../../features/github-connections/github-identity-controller.ts";
-import { IdentityAvatarController } from "../../lib/identity-avatar-loader.ts";
 import type { renderAgents } from "./view.ts";
-
-/** Connected controller fake for pure-render tests; re-renders via onUpdate. */
-export function createIdentityAvatarLoader(onUpdate?: () => void): IdentityAvatarController {
-  const loader = new IdentityAvatarController({
-    addController: () => undefined,
-    removeController: () => undefined,
-    requestUpdate: () => onUpdate?.(),
-    updateComplete: Promise.resolve(true),
-  });
-  loader.hostConnected();
-  return loader;
-}
 
 type AgentsViewProps = Parameters<typeof renderAgents>[0];
 
@@ -76,7 +63,10 @@ export function createAgentViewTestProps(
     agentIdentityError: null,
     agentIdentityById: {},
     identityDraft: { name: null, emoji: null, avatar: null },
-    identityAvatarLoader: createIdentityAvatarLoader(),
+    identityAvatarLoader: {
+      resolve: (url) => url,
+      imageErrorHandler: () => () => undefined,
+    },
     identitySaving: false,
     identityError: null,
     agentSkills: {

--- a/ui/src/pages/agents/agents-view.test-helpers.ts
+++ b/ui/src/pages/agents/agents-view.test-helpers.ts
@@ -1,5 +1,18 @@
 import { GitHubIdentityController } from "../../features/github-connections/github-identity-controller.ts";
+import { IdentityAvatarController } from "../../lib/identity-avatar-loader.ts";
 import type { renderAgents } from "./view.ts";
+
+/** Connected controller fake for pure-render tests; re-renders via onUpdate. */
+export function createIdentityAvatarLoader(onUpdate?: () => void): IdentityAvatarController {
+  const loader = new IdentityAvatarController({
+    addController: () => undefined,
+    removeController: () => undefined,
+    requestUpdate: () => onUpdate?.(),
+    updateComplete: Promise.resolve(true),
+  });
+  loader.hostConnected();
+  return loader;
+}
 
 type AgentsViewProps = Parameters<typeof renderAgents>[0];
 
@@ -63,6 +76,7 @@ export function createAgentViewTestProps(
     agentIdentityError: null,
     agentIdentityById: {},
     identityDraft: { name: null, emoji: null, avatar: null },
+    identityAvatarLoader: createIdentityAvatarLoader(),
     identitySaving: false,
     identityError: null,
     agentSkills: {

--- a/ui/src/pages/agents/panels-overview.ts
+++ b/ui/src/pages/agents/panels-overview.ts
@@ -31,12 +31,16 @@ import {
 } from "../../lib/agents/display.ts";
 import type { AgentsPanel } from "../../lib/agents/index.ts";
 import { deriveAvatarInitial, resolveAgentAvatarUrl } from "../../lib/avatar.ts";
+import type { IdentityAvatarController } from "../../lib/identity-avatar-loader.ts";
 
 export type AgentIdentityDraft = {
   name: string | null;
   emoji: string | null;
   avatar: string | null;
 };
+
+/** Authenticated image lease the settings preview shares with the roster. */
+export type IdentityAvatarLoader = Pick<IdentityAvatarController, "resolve" | "imageErrorHandler">;
 
 export function renderAgentOverview(params: {
   agent: AgentsListResult["agents"][number];
@@ -48,6 +52,7 @@ export function renderAgentOverview(params: {
   agentIdentityLoading: boolean;
   agentIdentityError: string | null;
   identityDraft: AgentIdentityDraft;
+  identityAvatarLoader: IdentityAvatarLoader;
   identitySaving: boolean;
   identityError: string | null;
   canUpdateConfig: boolean;
@@ -110,8 +115,14 @@ export function renderAgentOverview(params: {
     identityDraft.name ?? params.agentIdentity?.name ?? agent.identity?.name ?? agent.name ?? "";
   const identityEmoji =
     identityDraft.emoji ?? params.agentIdentity?.emoji ?? agent.identity?.emoji ?? "";
+  // Upload previews are local data URLs; persisted avatars live on a protected
+  // Gateway route and must resolve through the authenticated image lease.
+  const persistedAvatarUrl = identityDraft.avatar
+    ? null
+    : resolveAgentAvatarUrl(agent, params.agentIdentity);
   const identityAvatarUrl =
-    identityDraft.avatar ?? resolveAgentAvatarUrl(agent, params.agentIdentity);
+    identityDraft.avatar ??
+    (persistedAvatarUrl ? params.identityAvatarLoader.resolve(persistedAvatarUrl) : null);
   const identityAvatarText =
     resolveAgentTextAvatar(agent, params.agentIdentity) ??
     (deriveAvatarInitial(identityName || agent.id) || "?");
@@ -145,7 +156,16 @@ export function renderAgentOverview(params: {
             <span class="agent-identity-editor__avatar" aria-hidden="true">
               ${
                 identityAvatarUrl
-                  ? html`<img src=${identityAvatarUrl} alt="" decoding="async" />`
+                  ? html`<img
+                      src=${identityAvatarUrl}
+                      alt=""
+                      decoding="async"
+                      @error=${
+                        persistedAvatarUrl
+                          ? params.identityAvatarLoader.imageErrorHandler(persistedAvatarUrl)
+                          : undefined
+                      }
+                    />`
                   : html`<span class="agent-identity-editor__avatar-text"
                       >${identityAvatarText}</span
                     >`

--- a/ui/src/pages/agents/view.identity-avatar.test.ts
+++ b/ui/src/pages/agents/view.identity-avatar.test.ts
@@ -1,21 +1,57 @@
-// Control UI tests cover the agents identity editor avatar rendering.
-import { render } from "lit";
-import { expect, it, vi } from "vitest";
+import { LitElement } from "lit";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { setAvatarGatewayOrigin } from "../../lib/identity-avatar-context.ts";
+import { IdentityAvatarController } from "../../lib/identity-avatar-loader.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
-import {
-  createAgentViewTestProps as createProps,
-  createIdentityAvatarLoader,
-} from "./agents-view.test-helpers.ts";
+import { createAgentViewTestProps as createProps } from "./agents-view.test-helpers.ts";
 import { renderAgents } from "./view.ts";
 
+const avatarPng =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+aDOsAAAAASUVORK5CYII=";
 const identityWithAvatar = {
-  beta: { agentId: "beta", name: "Fetched Beta", avatar: "/avatar/beta", emoji: "" },
+  beta: { agentId: "beta", name: "Fetched Beta", avatar: "/avatar/beta?v=1", emoji: "" },
 };
 
-it("fetches a persisted identity avatar with the bearer credential when token auth is active", async () => {
-  const createObjectURL = vi.fn(() => "blob:agent-avatar");
-  const revokeObjectURL = vi.fn();
+class AgentAvatarView extends LitElement {
+  private readonly avatarLoader = new IdentityAvatarController(this);
+  props = createProps({
+    agentsList: {
+      defaultId: "beta",
+      mainKey: "main",
+      scope: "per-sender",
+      agents: [{ id: "beta", name: "Beta" }],
+    },
+    agentIdentityById: identityWithAvatar,
+    identityAvatarLoader: this.avatarLoader,
+  });
+
+  override createRenderRoot() {
+    return this;
+  }
+
+  override render() {
+    return this.avatarLoader.withActiveRoutes(() => renderAgents(this.props));
+  }
+}
+
+customElements.define(`test-agent-avatar-view-${crypto.randomUUID()}`, AgentAvatarView);
+
+const views: AgentAvatarView[] = [];
+const fetchAvatar = vi.fn<typeof fetch>();
+const createObjectURL = vi.fn<typeof URL.createObjectURL>();
+const revokeObjectURL = vi.fn<typeof URL.revokeObjectURL>();
+
+beforeEach(() => {
+  const nativeFetch = globalThis.fetch;
+  fetchAvatar.mockReset();
+  vi.spyOn(globalThis, "fetch").mockImplementation((input, init) => {
+    const url = input instanceof Request ? input.url : String(input);
+    return url.startsWith("data:") ? nativeFetch(input, init) : fetchAvatar(input, init);
+  });
+  let sequence = 0;
+  createObjectURL.mockReset().mockImplementation(() => `blob:settings-avatar-${++sequence}`);
+  revokeObjectURL.mockReset();
   vi.stubGlobal(
     "URL",
     class extends URL {
@@ -23,131 +59,142 @@ it("fetches a persisted identity avatar with the bearer credential when token au
       static override revokeObjectURL = revokeObjectURL;
     },
   );
-  const fetchMock = vi.fn().mockResolvedValue({
-    ok: true,
-    blob: async () => new Blob(["avatar"], { type: "image/png" }),
-  });
-  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-  setAvatarGatewayOrigin(globalThis.location.origin, ["tok"]);
+  setAvatarGatewayOrigin(globalThis.location.origin, ["avatar-token"]);
+});
 
-  const container = document.createElement("div");
-  // The loader re-renders through its host once the blob URL settles.
-  const state: { props?: ReturnType<typeof createProps> } = {};
-  const props = createProps({
-    agentIdentityById: identityWithAvatar,
-    identityAvatarLoader: createIdentityAvatarLoader(() => {
-      if (state.props) {
-        render(renderAgents(state.props), container);
-      }
-    }),
-  });
-  state.props = props;
-  render(renderAgents(props), container);
+afterEach(() => {
+  for (const view of views.splice(0)) {
+    view.remove();
+  }
+  setAvatarGatewayOrigin(null);
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+function avatarResponse() {
+  return new Response(
+    Uint8Array.from(atob(avatarPng), (character) => character.charCodeAt(0)),
+    {
+      headers: { "content-type": "image/png" },
+    },
+  );
+}
+
+async function createView(overrides: Partial<ReturnType<typeof createProps>> = {}) {
+  const view = new AgentAvatarView();
+  view.props = { ...view.props, ...overrides };
+  views.push(view);
+  document.body.append(view);
+  await view.updateComplete;
+  return view;
+}
+
+function avatarImage(view: AgentAvatarView) {
+  return view.querySelector<HTMLImageElement>(".agent-identity-editor__avatar img");
+}
+
+function avatarText(view: AgentAvatarView) {
+  return view.querySelector(".agent-identity-editor__avatar-text")?.textContent;
+}
+
+async function changeAvatarRevision(view: AgentAvatarView, revision: number) {
+  view.props.agentIdentityById = {
+    beta: { ...identityWithAvatar.beta, avatar: `/avatar/beta?v=${revision}` },
+  };
+  view.requestUpdate();
+  await view.updateComplete;
+}
+
+it("fetches a persisted settings avatar with the bearer credential", async () => {
+  const response = createDeferred<Response>();
+  fetchAvatar.mockReturnValue(response.promise);
+  const view = await createView();
 
   try {
-    // The text fallback renders while the authenticated fetch is in flight.
-    expect(container.querySelector(".agent-identity-editor__avatar img")).toBeNull();
-    expect(container.querySelector(".agent-identity-editor__avatar-text")?.textContent).toBe("F");
-    expect(fetchMock).toHaveBeenCalledWith(`${globalThis.location.origin}/avatar/beta`, {
-      credentials: "include",
-      headers: { Authorization: "Bearer tok" },
-      signal: expect.any(AbortSignal),
-    });
+    expect(avatarImage(view)).toBeNull();
+    expect(avatarText(view)).toBe("F");
+    expect(fetchAvatar).toHaveBeenCalledWith(
+      `${globalThis.location.origin}/avatar/beta?v=1`,
+      expect.objectContaining({
+        credentials: "include",
+        headers: { Authorization: "Bearer avatar-token" },
+        signal: expect.any(AbortSignal),
+      }),
+    );
 
+    response.resolve(avatarResponse());
     await waitForFast(() => {
-      expect(
-        container
-          .querySelector<HTMLImageElement>(".agent-identity-editor__avatar img")
-          ?.getAttribute("src"),
-      ).toBe("blob:agent-avatar");
+      expect(avatarImage(view)?.getAttribute("src")).toBe("blob:settings-avatar-1");
     });
-    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(fetchAvatar).toHaveBeenCalledOnce();
+    expect(createObjectURL).toHaveBeenCalledOnce();
   } finally {
-    setAvatarGatewayOrigin(null);
-    vi.unstubAllGlobals();
+    response.resolve(avatarResponse());
   }
 });
 
-it("renders the in-progress upload preview directly without an authenticated fetch", () => {
-  const fetchMock = vi.fn();
-  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-  setAvatarGatewayOrigin(globalThis.location.origin, ["tok"]);
-
-  const container = document.createElement("div");
-  const preview = "data:image/png;base64,cmVwbGFjZW1lbnQ=";
-  render(
-    renderAgents(
-      createProps({
-        identityDraft: { name: null, emoji: null, avatar: preview },
-        agentIdentityById: identityWithAvatar,
-      }),
-    ),
-    container,
-  );
-
-  try {
-    expect(
-      container
-        .querySelector<HTMLImageElement>(".agent-identity-editor__avatar img")
-        ?.getAttribute("src"),
-    ).toBe(preview);
-    expect(fetchMock).not.toHaveBeenCalled();
-  } finally {
-    setAvatarGatewayOrigin(null);
-    vi.unstubAllGlobals();
-  }
-});
-
-it("falls back to the identity initial when the authenticated avatar cannot load", async () => {
-  const fetchMock = vi.fn().mockResolvedValue({
-    ok: false,
-    status: 404,
-    blob: async () => new Blob([], { type: "image/png" }),
+it("renders the upload preview without fetching the persisted settings avatar", async () => {
+  const preview = `data:image/png;base64,${avatarPng}`;
+  const view = await createView({
+    identityDraft: { name: null, emoji: null, avatar: preview },
   });
-  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
-  setAvatarGatewayOrigin(globalThis.location.origin, ["tok"]);
 
-  const container = document.createElement("div");
-  render(
-    renderAgents(
-      createProps({
-        agentIdentityById: identityWithAvatar,
-      }),
-    ),
-    container,
-  );
-
-  try {
-    await waitForFast(() => expect(fetchMock).toHaveBeenCalledTimes(1));
-    await Promise.resolve();
-    expect(container.querySelector(".agent-identity-editor__avatar img")).toBeNull();
-    expect(container.querySelector(".agent-identity-editor__avatar-text")?.textContent).toBe("F");
-  } finally {
-    setAvatarGatewayOrigin(null);
-    vi.unstubAllGlobals();
-  }
+  expect(avatarImage(view)?.getAttribute("src")).toBe(preview);
+  expect(fetchAvatar).not.toHaveBeenCalled();
 });
 
-it("keeps a broken persisted avatar on its text fallback", async () => {
-  const container = document.createElement("div");
-  // The loader re-renders through its host once the blob URL settles.
-  const state: { props?: ReturnType<typeof createProps> } = {};
-  const props = createProps({
-    agentIdentityById: identityWithAvatar,
-    identityAvatarLoader: createIdentityAvatarLoader(() => {
-      if (state.props) {
-        render(renderAgents(state.props), container);
-      }
-    }),
-  });
-  state.props = props;
-  render(renderAgents(props), container);
-
-  const image = container.querySelector<HTMLImageElement>(".agent-identity-editor__avatar img");
-  expect(image?.getAttribute("src")).toBe("/avatar/beta");
-  image?.dispatchEvent(new Event("error"));
+it("keeps a missing settings avatar on its fallback and recovers on a new revision", async () => {
+  fetchAvatar
+    .mockResolvedValueOnce(avatarResponse())
+    .mockResolvedValueOnce(new Response(null, { status: 404 }))
+    .mockResolvedValueOnce(avatarResponse());
+  const view = await createView();
   await waitForFast(() => {
-    expect(container.querySelector(".agent-identity-editor__avatar img")).toBeNull();
+    expect(avatarImage(view)?.getAttribute("src")).toBe("blob:settings-avatar-1");
   });
-  expect(container.querySelector(".agent-identity-editor__avatar-text")?.textContent).toBe("F");
+
+  await changeAvatarRevision(view, 2);
+  await waitForFast(() => expect(fetchAvatar).toHaveBeenCalledTimes(2));
+  view.props.identityDraft = { name: "Renamed Beta", emoji: null, avatar: null };
+  view.requestUpdate();
+  await view.updateComplete;
+  expect(avatarImage(view)).toBeNull();
+  expect(avatarText(view)).toBe("R");
+  expect(fetchAvatar).toHaveBeenCalledTimes(2);
+
+  await changeAvatarRevision(view, 3);
+  await waitForFast(() => {
+    expect(avatarImage(view)?.getAttribute("src")).toBe("blob:settings-avatar-2");
+  });
+  expect(fetchAvatar).toHaveBeenCalledTimes(3);
+});
+
+it("keeps a decode failure on its fallback across rerenders until the revision changes", async () => {
+  fetchAvatar.mockImplementation(async () => avatarResponse());
+  const view = await createView();
+  const failedImage = await waitForFast(() => {
+    const image = avatarImage(view);
+    expect(image?.getAttribute("src")).toBe("blob:settings-avatar-1");
+    return image;
+  });
+  failedImage?.dispatchEvent(new Event("error"));
+  await view.updateComplete;
+  expect(avatarImage(view)).toBeNull();
+  expect(avatarText(view)).toBe("F");
+
+  view.props.identityDraft = { name: "Renamed Beta", emoji: null, avatar: null };
+  view.requestUpdate();
+  await view.updateComplete;
+  expect(avatarImage(view)).toBeNull();
+  expect(avatarText(view)).toBe("R");
+  expect(fetchAvatar).toHaveBeenCalledOnce();
+
+  await changeAvatarRevision(view, 2);
+  await waitForFast(() => {
+    expect(avatarImage(view)?.getAttribute("src")).toBe("blob:settings-avatar-2");
+  });
+  failedImage?.dispatchEvent(new Event("error"));
+  await view.updateComplete;
+  expect(avatarImage(view)?.getAttribute("src")).toBe("blob:settings-avatar-2");
+  expect(fetchAvatar).toHaveBeenCalledTimes(2);
 });

--- a/ui/src/pages/agents/view.identity-avatar.test.ts
+++ b/ui/src/pages/agents/view.identity-avatar.test.ts
@@ -1,0 +1,153 @@
+// Control UI tests cover the agents identity editor avatar rendering.
+import { render } from "lit";
+import { expect, it, vi } from "vitest";
+import { setAvatarGatewayOrigin } from "../../lib/identity-avatar-context.ts";
+import { waitForFast } from "../../test-helpers/wait-for.ts";
+import {
+  createAgentViewTestProps as createProps,
+  createIdentityAvatarLoader,
+} from "./agents-view.test-helpers.ts";
+import { renderAgents } from "./view.ts";
+
+const identityWithAvatar = {
+  beta: { agentId: "beta", name: "Fetched Beta", avatar: "/avatar/beta", emoji: "" },
+};
+
+it("fetches a persisted identity avatar with the bearer credential when token auth is active", async () => {
+  const createObjectURL = vi.fn(() => "blob:agent-avatar");
+  const revokeObjectURL = vi.fn();
+  vi.stubGlobal(
+    "URL",
+    class extends URL {
+      static override createObjectURL = createObjectURL;
+      static override revokeObjectURL = revokeObjectURL;
+    },
+  );
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: true,
+    blob: async () => new Blob(["avatar"], { type: "image/png" }),
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+  setAvatarGatewayOrigin(globalThis.location.origin, ["tok"]);
+
+  const container = document.createElement("div");
+  // The loader re-renders through its host once the blob URL settles.
+  const state: { props?: ReturnType<typeof createProps> } = {};
+  const props = createProps({
+    agentIdentityById: identityWithAvatar,
+    identityAvatarLoader: createIdentityAvatarLoader(() => {
+      if (state.props) {
+        render(renderAgents(state.props), container);
+      }
+    }),
+  });
+  state.props = props;
+  render(renderAgents(props), container);
+
+  try {
+    // The text fallback renders while the authenticated fetch is in flight.
+    expect(container.querySelector(".agent-identity-editor__avatar img")).toBeNull();
+    expect(container.querySelector(".agent-identity-editor__avatar-text")?.textContent).toBe("F");
+    expect(fetchMock).toHaveBeenCalledWith(`${globalThis.location.origin}/avatar/beta`, {
+      credentials: "include",
+      headers: { Authorization: "Bearer tok" },
+      signal: expect.any(AbortSignal),
+    });
+
+    await waitForFast(() => {
+      expect(
+        container
+          .querySelector<HTMLImageElement>(".agent-identity-editor__avatar img")
+          ?.getAttribute("src"),
+      ).toBe("blob:agent-avatar");
+    });
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+  } finally {
+    setAvatarGatewayOrigin(null);
+    vi.unstubAllGlobals();
+  }
+});
+
+it("renders the in-progress upload preview directly without an authenticated fetch", () => {
+  const fetchMock = vi.fn();
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+  setAvatarGatewayOrigin(globalThis.location.origin, ["tok"]);
+
+  const container = document.createElement("div");
+  const preview = "data:image/png;base64,cmVwbGFjZW1lbnQ=";
+  render(
+    renderAgents(
+      createProps({
+        identityDraft: { name: null, emoji: null, avatar: preview },
+        agentIdentityById: identityWithAvatar,
+      }),
+    ),
+    container,
+  );
+
+  try {
+    expect(
+      container
+        .querySelector<HTMLImageElement>(".agent-identity-editor__avatar img")
+        ?.getAttribute("src"),
+    ).toBe(preview);
+    expect(fetchMock).not.toHaveBeenCalled();
+  } finally {
+    setAvatarGatewayOrigin(null);
+    vi.unstubAllGlobals();
+  }
+});
+
+it("falls back to the identity initial when the authenticated avatar cannot load", async () => {
+  const fetchMock = vi.fn().mockResolvedValue({
+    ok: false,
+    status: 404,
+    blob: async () => new Blob([], { type: "image/png" }),
+  });
+  vi.stubGlobal("fetch", fetchMock as unknown as typeof fetch);
+  setAvatarGatewayOrigin(globalThis.location.origin, ["tok"]);
+
+  const container = document.createElement("div");
+  render(
+    renderAgents(
+      createProps({
+        agentIdentityById: identityWithAvatar,
+      }),
+    ),
+    container,
+  );
+
+  try {
+    await waitForFast(() => expect(fetchMock).toHaveBeenCalledTimes(1));
+    await Promise.resolve();
+    expect(container.querySelector(".agent-identity-editor__avatar img")).toBeNull();
+    expect(container.querySelector(".agent-identity-editor__avatar-text")?.textContent).toBe("F");
+  } finally {
+    setAvatarGatewayOrigin(null);
+    vi.unstubAllGlobals();
+  }
+});
+
+it("keeps a broken persisted avatar on its text fallback", async () => {
+  const container = document.createElement("div");
+  // The loader re-renders through its host once the blob URL settles.
+  const state: { props?: ReturnType<typeof createProps> } = {};
+  const props = createProps({
+    agentIdentityById: identityWithAvatar,
+    identityAvatarLoader: createIdentityAvatarLoader(() => {
+      if (state.props) {
+        render(renderAgents(state.props), container);
+      }
+    }),
+  });
+  state.props = props;
+  render(renderAgents(props), container);
+
+  const image = container.querySelector<HTMLImageElement>(".agent-identity-editor__avatar img");
+  expect(image?.getAttribute("src")).toBe("/avatar/beta");
+  image?.dispatchEvent(new Event("error"));
+  await waitForFast(() => {
+    expect(container.querySelector(".agent-identity-editor__avatar img")).toBeNull();
+  });
+  expect(container.querySelector(".agent-identity-editor__avatar-text")?.textContent).toBe("F");
+});

--- a/ui/src/pages/agents/view.ts
+++ b/ui/src/pages/agents/view.ts
@@ -33,7 +33,7 @@ import "../../styles/agents.css";
 import "../../styles/sidebar-markdown.css";
 import "./memory/memory-panel.ts";
 import type { AgentsPanel } from "../../lib/agents/index.ts";
-import type { AgentIdentityDraft } from "./panels-overview.ts";
+import type { AgentIdentityDraft, IdentityAvatarLoader } from "./panels-overview.ts";
 import { renderAgentOverview } from "./panels-overview.ts";
 import { renderAgentFiles, renderAgentChannels, renderAgentCron } from "./panels-status-files.ts";
 import { renderAgentTools, renderAgentSkills } from "./panels-tools-skills.ts";
@@ -118,6 +118,7 @@ type AgentsProps = {
   agentIdentityError: string | null;
   agentIdentityById: Record<string, AgentIdentityResult>;
   identityDraft: AgentIdentityDraft;
+  identityAvatarLoader: IdentityAvatarLoader;
   identitySaving: boolean;
   identityError: string | null;
   agentSkills: AgentSkillsState;
@@ -374,6 +375,7 @@ export function renderAgents(props: AgentsProps) {
                             agentIdentityError: props.agentIdentityError,
                             agentIdentityLoading: props.agentIdentityLoading,
                             identityDraft: props.identityDraft,
+                            identityAvatarLoader: props.identityAvatarLoader,
                             identitySaving: props.identitySaving,
                             identityError: props.identityError,
                             canUpdateConfig: props.access.canUpdateConfig,


### PR DESCRIPTION
Closes #141976

## What Problem This Solves

Fixes an issue where saved agent avatars appeared broken in the Agents settings Overview on a token-authenticated Gateway, while the agent picker displayed them correctly.

## Why This Change Was Made

The settings preview now uses the existing authenticated image loader and its page lifecycle. Local upload previews still render before Save, and failed images use the existing emoji or initial fallback.

## User Impact

Saved local avatars render in agent settings with the current Gateway credentials. Switching agents shows the selected agent's image, and credential changes discard the prior image result.

## Evidence

Real matching Gateway and Control UI builds ran on one isolated Linux host with Chromium and synthetic credentials. The baseline was pinned at `4f84c11feed3ed3d6cc8de4210d124789497eb84`; the final tested source tree is `0cd748b677861c9843bd396c5315413423a82bdb`.

| Before | After |
| --- | --- |
| ![Overview shows a broken saved avatar](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjIyMDMxMTE0/pr-142015/public-proof-media/20260908-105102-137375580/baseline-identity-safe.png?X-Amz-Expires=604800&X-Amz-Date=20260908T105103Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=f60db99ea888cd140e33bcc07482fb370855765f18c8ed00a93ae053d1f2e904) | ![Overview renders the saved red avatar](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjIyMDMxMTE0/pr-142015/public-proof-media/20260908-105102-137375580/candidate-main-safe.png?X-Amz-Expires=604800&X-Amz-Date=20260908T105103Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=a53261fe2d2498b85b628027d9771eeca55034fc5e814614ba8b1f5cee742826) |

![Switching agents renders the saved blue avatar](https://91b59577e757131d68d55a471fe32aca.r2.cloudflarestorage.com/openclaw-crabbox-artifacts/crabbox-artifacts/v2/org/b3BlbmNsYXc/owner/Z2l0aHViOjIyMDMxMTE0/pr-142015/public-proof-media/20260908-105102-137375580/candidate-beta-safe.png?X-Amz-Expires=604800&X-Amz-Date=20260908T105103Z&X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=a677a1e59413a4e54bcc2da5fec6164a%2F20260908%2Fauto%2Fs3%2Faws4_request&X-Amz-SignedHeaders=host&X-Amz-Signature=799bc82c4deeabea46b822f00a5506c7a8e09ffda646d2e9c5e988c620a1a1ac)

- Before: Overview issued an unauthenticated image request, received 401, and decoded 0×0 pixels; the authenticated picker worked.
- After: red and blue 16×16 fixtures decoded the expected pixels in Overview and picker through authenticated 200 responses and blob images. Independent peer fixtures also rendered the correct yellow and purple pixels.
- Independent browser acceptance exercised ordinary upload/save/reload, agent switching, origin and credential invalidation, invalid/missing/unreadable/removed/unsupported image fallback, profile avatars, name/emoji persistence, draft reset, and ordering. Direct requests without a token or with a wrong token remained 401.
- The regression fails on the original panel. All 130 focused owner and sibling tests pass. Mounted-view tests cover authenticated loading, local preview precedence, settled failure fallback, revision recovery, and stale image errors. Format, UI catalog and ratchet checks pass; fresh code review found no actionable findings.
- [Hosted CI for the published head](https://github.com/openclaw/openclaw/actions/runs/34216731304).

Two additional failures were reproduced independently on the baseline and remain separate follow-ups: the shared thumbnail decoder changes the color of a browser-produced WebP, and cross-origin agent-avatar requests fail the existing HTTP preflight. The saved upload payload is preserved exactly; the first defect occurs in the shared decoder before either consumer receives the image. Origin changes revoke old images even when replacement delivery hits the second defect. This PR repairs the remaining settings consumer and does not claim those broader image paths are fixed.

Original repair by @LiuwqGit; AI-assisted validation and test cleanup.

The image mirror links expire September 15, 2026. The request and decoded-pixel evidence above remain recorded in this PR.
