### PR TITLE
fix(plugins): resolve extensionless specifiers to built .cjs runtimes

### DIFF
--- a/src/channels/plugins/module-loader.test.ts
+++ b/src/channels/plugins/module-loader.test.ts
@@ -39,6 +39,35 @@ describe("channel plugin module loader helpers", () => {
     },
   );
 
+  it.each(["cjs", "mjs"])(
+    "resolves extensionless plugin module specifiers to built %s runtimes",
+    (extension) => {
+      const rootDir = tempDirs.make("openclaw-channel-module-loader-");
+      const expectedPath = path.join(rootDir, `configured-state.${extension}`);
+      fs.writeFileSync(expectedPath, "// built runtime artifact\n", "utf8");
+
+      expect(resolveExistingPluginModulePath(rootDir, "./configured-state")).toBe(expectedPath);
+    },
+  );
+
+  it("loads a built .cjs runtime through an extensionless specifier", () => {
+    const rootDir = tempDirs.make("openclaw-channel-module-loader-");
+    const expectedPath = path.join(rootDir, "configured-state.cjs");
+    fs.writeFileSync(
+      expectedPath,
+      "module.exports = { hasConfiguredChannelState: () => true };\n",
+      "utf8",
+    );
+
+    const modulePath = resolveExistingPluginModulePath(rootDir, "./configured-state");
+    expect(modulePath).toBe(expectedPath);
+
+    const loaded = loadChannelPluginModule({ modulePath, rootDir }) as {
+      hasConfiguredChannelState: () => boolean;
+    };
+    expect(loaded.hasConfiguredChannelState()).toBe(true);
+  });
+
   it("preserves explicit JavaScript plugin module specifiers", () => {
     const rootDir = tempDirs.make("openclaw-channel-module-loader-");
     const expectedPath = path.join(rootDir, "checker.js");

--- a/src/channels/plugins/module-loader.ts
+++ b/src/channels/plugins/module-loader.ts
@@ -60,13 +60,22 @@ function loadModule(modulePath: string, rootDir: string): unknown {
   }
 }
 
-function resolveSourceModuleCandidates(rootDir: string, specifier: string): string[] {
+// Node's CJS resolver implicitly appends only .js, .json, and .node. Built plugin
+// runtimes may ship .cjs (runtimeFormat "cjs") or .mjs artifacts, so extensionless
+// specifiers need an explicit fallback for the extensions Node never tries.
+const PLUGIN_BUILT_MODULE_EXTENSIONS: readonly string[] = [".cjs", ".mjs"];
+
+function resolveExtensionlessModuleCandidates(
+  rootDir: string,
+  specifier: string,
+  extensions: readonly string[],
+): string[] {
   const normalizedSpecifier = specifier.replace(/\\/g, "/");
   const resolvedPath = path.resolve(rootDir, normalizedSpecifier);
   if (path.extname(resolvedPath)) {
     return [];
   }
-  return PLUGIN_SOURCE_MODULE_EXTENSIONS.map((extension) => `${resolvedPath}${extension}`);
+  return extensions.map((extension) => `${resolvedPath}${extension}`);
 }
 
 /**
@@ -88,14 +97,17 @@ function resolvePluginModulePath(rootDir: string, specifier: string): string {
   const resolvedPath = path.resolve(rootDir, specifier.replace(/\\/g, "/"));
   try {
     // Match Node package semantics for explicit files, extensionless JavaScript,
-    // package mains, and directory indexes before applying source-only fallbacks.
+    // package mains, and directory indexes before applying extensionless fallbacks.
     return nodeRequire.resolve(resolvedPath);
   } catch (error) {
     if (!hasErrnoCode(error, "MODULE_NOT_FOUND")) {
       throw error;
     }
   }
-  for (const candidate of resolveSourceModuleCandidates(rootDir, specifier)) {
+  for (const candidate of [
+    ...resolveExtensionlessModuleCandidates(rootDir, specifier, PLUGIN_SOURCE_MODULE_EXTENSIONS),
+    ...resolveExtensionlessModuleCandidates(rootDir, specifier, PLUGIN_BUILT_MODULE_EXTENSIONS),
+  ]) {
     if (fs.existsSync(candidate)) {
       return candidate;
     }


### PR DESCRIPTION
## What Problem This Solves

On any built install, the Microsoft Teams channel plugin cannot load its `configuredState` checker, and Doctor reports:

```
[warning] core/doctor/channel-package-state-capabilities - Plugin msteams declared
configuredState, but its checker failed to load: plugin module path not found:
<root>/dist/extensions/msteams/configured-state | ENOENT: no such file or directory,
lstat '<root>/dist/extensions/msteams/configured-state'
```

The artifact is present on disk as `configured-state.cjs`. The resolver cannot reach it.

## Why This Change Was Made

`resolvePluginModulePath()` resolves extensionless specifiers through `nodeRequire.resolve()`, which implicitly appends only `.js`, `.json`, and `.node` — never `.cjs`. It then falls back to source extensions (`.ts`, `.mts`, …), and otherwise returns the nonexistent extensionless path, which fails the boundary open as `plugin module path not found`.

All five plugins declaring `configuredState` use the same extensionless specifier `./configured-state`. Four build as ESM to `.js`, which `require.resolve` appends implicitly, so they resolve by virtue of their format. `msteams` is the only plugin with `build.runtimeFormat: "cjs"`, and `pluginRuntimeExtension()` deliberately emits `.cjs` for it — so it is the only plugin that lands in the gap.

The manifest convention (extensionless, format-agnostic) and the build output (`.cjs`) are both correct. The resolver is the piece that does not account for the extensions the plugin build can emit.

This reproduces only in built installs: from a source checkout the `.ts` fallback matches, which is why it does not surface in dev.

## User Impact

Operators running Teams get a persistent Doctor warning and degraded configured-state detection for the channel, with no available remedy — the file the resolver wants is present, under a name it cannot reach. Operators not running Teams see the warning as recurring noise in `openclaw doctor`.

## Evidence

Negative control — with the source fix reverted and the new tests kept, exactly the three new tests fail and the existing ten pass:

```
× resolves extensionless plugin module specifiers to built cjs runtimes
× resolves extensionless plugin module specifiers to built mjs runtimes
× loads a built .cjs runtime through an extensionless specifier
Tests  3 failed | 10 passed (13)
```

With the fix applied:

- `node scripts/run-vitest.mjs src/channels/plugins/module-loader.test.ts` — 13 passed
- `pnpm test:contracts:channels` — 13 files, 32 passed across 4 shards
- `oxfmt --check` — passed
- Node 24.16.0

Originally observed on a real 2026.8.1 git install on macOS via `openclaw doctor`, while recovering an unrelated failed update.

## Notes

- The new fallback runs *after* the existing source-extension fallback, so resolution precedence for every currently resolving specifier is unchanged. It only adds a path where resolution previously failed outright.
- `.mjs` is included alongside `.cjs` for symmetry, since Node implicitly appends neither. The plugin build currently emits only `.cjs` or `.js`.
