### PR TITLE
fix(cli): accept agent selection after recommendation subcommands

### DIFF
--- a/docs/cli/onboard.md
+++ b/docs/cli/onboard.md
@@ -48,6 +48,8 @@ openclaw onboard --skip-bootstrap
 openclaw onboard recommendations --json
 openclaw onboard recommendations --agent writer --json
 openclaw onboard recommendations --agent writer acknowledge
+openclaw onboard recommendations acknowledge --agent writer
+openclaw onboard recommendations refresh --agent writer
 openclaw onboard recommendations acknowledge
 openclaw onboard recommendations acknowledge --retry "<failed-id>"
 openclaw onboard recommendations refresh
@@ -64,9 +66,10 @@ an empty list and future onboarding runs skip the step entirely.
 `openclaw onboard recommendations refresh` clears the stored offer so the next
 onboarding run rescans installed apps and creates a new offer.
 
-Pass `--agent <id>` after `recommendations` to select a configured agent for
-reads, `acknowledge`, `acknowledge --retry`, or `refresh`. These operations use
-only that agent's workspace recommendations. Without the selector, the command
+Pass `--agent <id>` to select a configured agent for reads, `acknowledge`,
+`acknowledge --retry`, or `refresh`. Place it before or after the subcommand;
+an explicit value on the subcommand takes precedence over a parent value.
+These operations use only that agent's workspace recommendations. Without the selector, the command
 keeps its existing default-agent behavior and asks you to select an agent when
 the owner is ambiguous. Blank or unknown agent IDs fail without changing the
 stored recommendations; use `openclaw agents list` to find configured IDs.

--- a/src/cli/program/register.onboard.test.ts
+++ b/src/cli/program/register.onboard.test.ts
@@ -64,7 +64,7 @@ vi.mock("../../runtime.js", async (importOriginal) => ({
 
 describe("registerOnboardCommand", () => {
   async function runCli(args: string[]) {
-    const program = new Command().enablePositionalOptions();
+    const program = new Command().enablePositionalOptions().exitOverride();
     registerOnboardCommand(program);
     await program.parseAsync(args, { from: "user" });
   }
@@ -120,6 +120,112 @@ describe("registerOnboardCommand", () => {
     );
     expect(setupWizardCommandMock).not.toHaveBeenCalled();
   });
+
+  it.each([
+    {
+      args: ["--agent", "writer", "--json"],
+      target: "onboardRecommendationsCommand",
+      expected: { agent: "writer", json: true },
+    },
+    {
+      args: ["--json", "--agent", "writer"],
+      target: "onboardRecommendationsCommand",
+      expected: { agent: "writer", json: true },
+    },
+    {
+      args: ["--agent", "writer", "acknowledge"],
+      target: "acknowledgeOnboardRecommendationsCommand",
+      expected: { agent: "writer", retry: undefined },
+    },
+    {
+      args: ["acknowledge", "--agent", "writer"],
+      target: "acknowledgeOnboardRecommendationsCommand",
+      expected: { agent: "writer", retry: undefined },
+    },
+    {
+      args: ["--agent", "writer", "acknowledge", "--retry", "chat-plugin"],
+      target: "acknowledgeOnboardRecommendationsCommand",
+      expected: { agent: "writer", retry: ["chat-plugin"] },
+    },
+    {
+      args: ["acknowledge", "--agent", "writer", "--retry", "chat-plugin"],
+      target: "acknowledgeOnboardRecommendationsCommand",
+      expected: { agent: "writer", retry: ["chat-plugin"] },
+    },
+    {
+      args: ["acknowledge", "--retry", "chat-plugin", "--agent", "writer"],
+      target: "acknowledgeOnboardRecommendationsCommand",
+      expected: { agent: "writer", retry: ["chat-plugin"] },
+    },
+    {
+      args: ["--agent", "writer", "refresh"],
+      target: "refreshOnboardRecommendationsCommand",
+      expected: { agent: "writer" },
+    },
+    {
+      args: ["refresh", "--agent", "writer"],
+      target: "refreshOnboardRecommendationsCommand",
+      expected: { agent: "writer" },
+    },
+  ] as const)("accepts agent option placement $args", async ({ args, target, expected }) => {
+    await runCli(["onboard", "recommendations", ...args]);
+    expect(mocks[target]).toHaveBeenCalledExactlyOnceWith(expected, runtime);
+  });
+
+  it.each(["acknowledge", "refresh"] as const)(
+    "prefers explicit agent leaf selection for %s",
+    async (leaf) => {
+      await runCli(["onboard", "recommendations", "--agent", "writer", leaf, "--agent", "analyst"]);
+      const target =
+        leaf === "acknowledge"
+          ? mocks.acknowledgeOnboardRecommendationsCommand
+          : mocks.refreshOnboardRecommendationsCommand;
+      expect(target).toHaveBeenCalledWith(expect.objectContaining({ agent: "analyst" }), runtime);
+    },
+  );
+
+  it.each(["", "   ", "ghost"])(
+    "preserves invalid agent leaf value '%s' over its parent",
+    async (agent) => {
+      await runCli([
+        "onboard",
+        "recommendations",
+        "--agent",
+        "writer",
+        "refresh",
+        "--agent",
+        agent,
+      ]);
+      expect(mocks.refreshOnboardRecommendationsCommand).toHaveBeenCalledExactlyOnceWith(
+        { agent },
+        runtime,
+      );
+    },
+  );
+
+  it.each(["acknowledge", "refresh"] as const)(
+    "inherits the parent agent option instead of a %s leaf default",
+    async (leafName) => {
+      const program = new Command().enablePositionalOptions().exitOverride();
+      registerOnboardCommand(program);
+      const recommendations = program.commands
+        .find((command) => command.name() === "onboard")
+        ?.commands.find((command) => command.name() === "recommendations");
+      const leaf = recommendations?.commands.find((command) => command.name() === leafName);
+      if (!leaf) {
+        throw new Error(`Expected registered recommendations ${leafName} command`);
+      }
+      leaf.setOptionValueWithSource("agent", "analyst", "default");
+      await program.parseAsync(["onboard", "recommendations", "--agent", "writer", leafName], {
+        from: "user",
+      });
+      const target =
+        leafName === "acknowledge"
+          ? mocks.acknowledgeOnboardRecommendationsCommand
+          : mocks.refreshOnboardRecommendationsCommand;
+      expect(target).toHaveBeenCalledWith(expect.objectContaining({ agent: "writer" }), runtime);
+    },
+  );
 
   it("routes failed recommendation ids through acknowledgement", async () => {
     await runCli([

--- a/src/cli/program/register.onboard.ts
+++ b/src/cli/program/register.onboard.ts
@@ -19,7 +19,7 @@ import { resolveProviderOnboardAuthFlags } from "../../plugins/provider-auth-cho
 import type { RuntimeEnv } from "../../runtime.js";
 import { runCommandWithRuntime } from "../cli-utils.js";
 import { formatCliCommand } from "../command-format.js";
-import { listExplicitOptionFlagsExcept } from "../command-options.js";
+import { inheritOptionFromParent, listExplicitOptionFlagsExcept } from "../command-options.js";
 import { parseGatewayPortOption } from "../gateway-port-option.js";
 
 function resolveInstallDaemonFlag(command: Command): boolean | undefined {
@@ -66,6 +66,15 @@ async function validateRecommendationParentOptions(
 const AUTH_CHOICE_HELP = formatAuthChoiceChoicesForCli({ includeSkip: true });
 const RECOMMENDATION_READ_PARENT_OPTIONS = new Set(["json"]);
 const RECOMMENDATION_MUTATION_PARENT_OPTIONS = new Set(["agent"]);
+
+function resolveRecommendationAgentOption(command: Command): string | undefined {
+  const source = command.getOptionValueSource("agent");
+  return readStringValue(
+    source && source !== "default"
+      ? command.getOptionValue("agent")
+      : inheritOptionFromParent(command, "agent"),
+  );
+}
 
 type OnboardAuthFlag = {
   readonly cliOption: string;
@@ -327,7 +336,7 @@ export function registerOnboardCommand(program: Command): void {
         }
         const { onboardRecommendationsCommand } =
           await import("../../commands/onboard-recommendations.js");
-        const agent = readStringValue(opts.agent);
+        const agent = resolveRecommendationAgentOption(recommendationsCommand);
         onboardRecommendationsCommand(
           { json, ...(agent !== undefined ? { agent } : {}) },
           defaultRuntime,
@@ -338,8 +347,9 @@ export function registerOnboardCommand(program: Command): void {
   recommendations
     .command("acknowledge")
     .description("Mark the stored onboarding recommendation offer as answered")
+    .option("--agent <id>", "Agent whose onboarding recommendations should be used")
     .option("--retry <id...>", "Leave failed recommendation IDs pending for a later run")
-    .action(async (opts: { retry?: string[] }) => {
+    .action(async (opts: { retry?: string[] }, acknowledgeCommand: Command) => {
       const { defaultRuntime } = await import("../../runtime.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         if (
@@ -350,7 +360,7 @@ export function registerOnboardCommand(program: Command): void {
         }
         const { acknowledgeOnboardRecommendationsCommand } =
           await import("../../commands/onboard-recommendations.js");
-        const agent = readStringValue(recommendations.opts().agent);
+        const agent = resolveRecommendationAgentOption(acknowledgeCommand);
         acknowledgeOnboardRecommendationsCommand(
           { retry: opts.retry, ...(agent !== undefined ? { agent } : {}) },
           defaultRuntime,
@@ -361,7 +371,8 @@ export function registerOnboardCommand(program: Command): void {
   recommendations
     .command("refresh")
     .description("Clear stored app recommendations so the next onboarding run rescans")
-    .action(async () => {
+    .option("--agent <id>", "Agent whose onboarding recommendations should be used")
+    .action(async (_opts, refreshCommand: Command) => {
       const { defaultRuntime } = await import("../../runtime.js");
       await runCommandWithRuntime(defaultRuntime, async () => {
         if (
@@ -372,7 +383,7 @@ export function registerOnboardCommand(program: Command): void {
         }
         const { refreshOnboardRecommendationsCommand } =
           await import("../../commands/onboard-recommendations.js");
-        const agent = readStringValue(recommendations.opts().agent);
+        const agent = resolveRecommendationAgentOption(refreshCommand);
         refreshOnboardRecommendationsCommand(agent !== undefined ? { agent } : {}, defaultRuntime);
       });
     });


### PR DESCRIPTION
## What Problem This Solves

Placing --agent after a recommendation subcommand failed with an unknown-option error even though the same selector worked before it.

## Why This Change Was Made

Register the selector for acknowledge and refresh, including retry. An explicit subcommand value wins; otherwise the existing option-source helper inherits the parent selection. Strict validation remains.

## User Impact

Users can place --agent beside the command they run. Only the selected agent’s recommendations change; blank or unknown selections cannot fall back to another agent.

## Evidence

Real compiled CLI refresh changed from exit 1 to exit 0 and cleared only the selected agent’s offer. Nine parser regressions failed before the fix; 133 focused registration, option-source, recommendation, and storage tests passed afterward. Independent command captures checked both placements, overrides, retry, invalid selection, omission, and unchanged other-agent records.

Related: #141775.
