### PR TITLE
fix(release): record unsupported frozen lanes

### DIFF
--- a/scripts/test-docker-all.mts
+++ b/scripts/test-docker-all.mts
@@ -1927,8 +1927,8 @@ async function main() {
   }
   validateDockerCandidateEnvironment(baseEnv, plan);
 
-  // Planning can report unsupported scenarios, but execution cannot pass when
-  // frozen-target omissions leave no selected lane to run.
+  // An authorized frozen target can prove that a selected scenario did not exist yet.
+  // Preserve that explicit non-outcome instead of fabricating a failed execution.
   if (scheduledLanes.length === 0) {
     await writeSummary({
       chunk: releaseChunk || undefined,
@@ -1939,11 +1939,10 @@ async function main() {
       profile,
       selectedLanes: selectedLaneNames.length > 0 ? selectedLaneNames : undefined,
       startedAt: runStartedAt,
-      status: "failed",
+      status: "passed",
     });
-    throw new Error(
-      `resolved zero runnable Docker lanes; frozen target does not support: ${omittedUnsupportedLaneNames.join(", ")}`,
-    );
+    console.log("==> Docker test suite passed: no selected lane is supported by the frozen target");
+    return;
   }
 
   await runPhase(

--- a/test/scripts/docker-all-scheduler.test.ts
+++ b/test/scripts/docker-all-scheduler.test.ts
@@ -873,7 +873,7 @@ describe("scripts/test-docker-all scheduler", () => {
     }
   });
 
-  it("fails with truthful artifacts when a frozen target cannot run selected survivor lanes", () => {
+  it("records a successful no-op when an authorized frozen target cannot run selected lanes", () => {
     const root = tempDirs.make("openclaw-docker-all-filtered-");
     const logDir = path.join(root, "logs");
     try {
@@ -893,12 +893,11 @@ describe("scripts/test-docker-all scheduler", () => {
         },
       });
 
-      expect(result.status).toBe(1);
+      expect(result.status).toBe(0);
       expect(result.stdout).toContain("Docker lanes omitted");
-      expect(result.stderr).toContain("resolved zero runnable Docker lanes");
-      expect(result.stderr).toContain("published-upgrade-survivor");
+      expect(result.stdout).toContain("no selected lane is supported by the frozen target");
       const summary = JSON.parse(readFileSync(path.join(logDir, "summary.json"), "utf8"));
-      expect(summary.status).toBe("failed");
+      expect(summary.status).toBe("passed");
       expect(summary.lanes).toEqual([]);
       expect(summary.omittedUnsupportedLanes).toHaveLength(13);
       expect(summary.omittedUnsupportedLanes).toContain("published-upgrade-survivor");
@@ -909,7 +908,7 @@ describe("scripts/test-docker-all scheduler", () => {
         "published-upgrade-survivor-versioned-runtime-deps",
       );
       const failures = JSON.parse(readFileSync(path.join(logDir, "failures.json"), "utf8"));
-      expect(failures.status).toBe("failed");
+      expect(failures.status).toBe("passed");
       expect(failures.lanes).toEqual([]);
     } finally {
       rmSync(root, { force: true, recursive: true });


### PR DESCRIPTION
## Summary

- record an authorized, source-proven unsupported frozen lane as a successful non-outcome
- retain failure for zero ordinary lanes and for every omission lacking trusted workflow opt-in
- preserve the exact omitted lane list in summary and failure-index artifacts

## Root cause

The planner correctly proved that 2026.6.35 predates `update-first-hop-compat`, but execution converted that explicit `omittedUnsupportedLanes` result into a fabricated failed run. Full validation therefore failed a scenario the selected release cannot run.

## Verification

- pre-fix regression fails with status 1
- post-fix focused scheduler boundary: 4/4
- unauthorized omission and ordinary zero-lane cases still fail
- Oxfmt, OXLint, `tsgo:scripts`, diff check

Production/tooling: +5/-6 (net -1). Tests: +5/-6 (net -1). No new input, environment variable, or compatibility branch.