### PR TITLE
fix(telegram): multiline directive commands drop the task after the first line

### DIFF
--- a/extensions/telegram/src/bot-message-context.command-multiline.test.ts
+++ b/extensions/telegram/src/bot-message-context.command-multiline.test.ts
@@ -1,0 +1,43 @@
+// Telegram tests cover multiline text-directive command projection at ingress.
+import { describe, expect, it } from "vitest";
+
+const { buildTelegramMessageContextForTest } =
+  await import("./bot-message-context.test-harness.js");
+
+function directMessage(text: string) {
+  return {
+    message_id: 1,
+    date: 1_700_000_000,
+    chat: { id: 42, type: "private" as const, first_name: "Pat" },
+    from: { id: 42, first_name: "Pat" },
+    text,
+    entities: [{ type: "bot_command" as const, offset: 0, length: text.indexOf("\n") }],
+  };
+}
+
+async function buildCommandBody(text: string) {
+  const ctx = await buildTelegramMessageContextForTest({ message: directMessage(text) });
+  return ctx?.ctxPayload?.CommandBody;
+}
+
+describe("Telegram ingress multiline command projection", () => {
+  it("preserves the task tail of a multiline text directive", async () => {
+    expect(await buildCommandBody("/think high\nsummarize the release notes")).toBe(
+      "/think high\nsummarize the release notes",
+    );
+  });
+
+  it("preserves the tail raw for /reset so core keeps ownership of flattening", async () => {
+    expect(await buildCommandBody("/reset\nkeep this line")).toBe("/reset\nkeep this line");
+  });
+
+  it("still canonicalizes text aliases on the command line", async () => {
+    expect(await buildCommandBody("/t high\nsummarize the release notes")).toBe(
+      "/think high\nsummarize the release notes",
+    );
+  });
+
+  it("leaves single-line commands unchanged", async () => {
+    expect(await buildCommandBody("/think high")).toBe("/think high");
+  });
+});

--- a/extensions/telegram/src/bot-message-context.session.ts
+++ b/extensions/telegram/src/bot-message-context.session.ts
@@ -566,8 +566,12 @@ export async function buildTelegramInboundContextPayload(params: {
     envelope: envelopeOptions,
   });
   const hasGroupHistoryContext = isGroup;
+  // Keep the multiline tail so text directives such as `/think high\n<task>` still carry
+  // their task past this projection. The core boundary re-normalizes strictly for the
+  // native command view, so per-command argument ownership stays unchanged.
   const commandBody = normalizeCommandBody(rawBody, {
     botUsername: normalizeOptionalLowercaseString(primaryCtx.me?.username),
+    preserveArguments: true,
   });
   const commandSource =
     options?.commandSource ??


### PR DESCRIPTION
Closes #141998

## What Problem This Solves

Fixes an issue where Telegram users sending a multiline text directive would have the task silently discarded. Sending

```
/think high
summarize the release notes
```

in a Telegram DM set the thinking level but never delivered `summarize the release notes` to the agent — the model received only the bare directive, with no indication that a line had been dropped.

#138545 fixed this at the core boundary, but the fix could not take effect on Telegram: the tail was already gone before the core ever saw the message. Channels that pass raw text through were unaffected, which is why this survived as a Telegram-only gap.

## Why This Change Was Made

The Telegram inbound projection called `normalizeCommandBody(rawBody, …)` without `preserveArguments`. Without that option the helper cuts the text at the first newline and applies a per-command tail policy that keeps the tail only for `skill`, `learn`, and `reset` — every other command, including text directives such as `/think`, drops it. That truncated value becomes `ctx.CommandBody`, which the core prefers as `commandText`, so the `preserveArguments` re-normalization added in #138545 was handed `/think high` with the task already removed.

The ingress projection now passes `preserveArguments: true`, matching the option the core boundary already uses for text-slash directives.

Non-goals, and what deliberately did **not** change:

- **Native argument ownership stays strict.** The strict command view is recomputed independently at the core layer without `preserveArguments` (`src/auto-reply/reply/commands-context.ts:44`, `src/auto-reply/reply/session-reset-command.ts:255`), so the per-command tail policy — including the `reset` flatten from #117143 — still applies there. This change only widens what the directive pipeline is able to see.
- No command was renamed, and command detection is untouched: `hasControlCommand` is computed upstream from the raw body, not from this projection.

## User Impact

Telegram users can send a directive and its task in one message and have both take effect:

```
/think high
summarize the release notes
```

now sets thinking to `high` **and** passes `summarize the release notes` to the agent, matching the behavior other channels already had. No configuration change is required, and no existing single-line command behavior changes.

## Evidence

New regression test: `extensions/telegram/src/bot-message-context.command-multiline.test.ts`, driving the real `buildTelegramMessageContext` harness and asserting on the `CommandBody` the core consumes.

**Before the fix** — three of four cases fail for the reported reason (tail dropped at ingress):

```
AssertionError: expected '/think high' to be '/think high\nsummarize the release notes'
  /think high
- summarize the release notes

AssertionError: expected '/reset keep this line' to be '/reset\nkeep this line'

AssertionError: expected '/think high' to be '/think high\nsummarize the release notes'

 Tests  3 failed | 1 passed (4)
```

**After the fix:**

```
 ✓ preserves the task tail of a multiline text directive
 ✓ preserves the tail raw for /reset so core keeps ownership of flattening
 ✓ still canonicalizes text aliases on the command line
 ✓ leaves single-line commands unchanged

 Tests  4 passed (4)
```

The `/reset` and `/t` cases are there on purpose: they pin that flattening and alias canonicalization keep working, so preserving the tail at ingress does not quietly relax per-command argument policy.

Regression scope:

- `node scripts/run-vitest.mjs run extensions/telegram/src` — **218 files, 4060 tests passed**
- `node scripts/run-vitest.mjs run src/auto-reply/commands-registry.test.ts src/auto-reply/reply/directive-handling.levels.test.ts src/auto-reply/reply/directive-handling.auth.test.ts` — **67 passed**
- `node scripts/check-changed.mjs` — **exit 0**, including the `typecheck extensions` and `typecheck extension tests` lanes

**Proof gap:** validation is the isolated harness covering the changed path, not a live Telegram client — I do not have bot credentials for the QA lane. Per `extensions/telegram/AGENTS.md` this path is command-body projection rather than transport, streaming, topics, callbacks, or reply context, but live confirmation of the `/think high\n<task>` DM would still be stronger proof if a maintainer can run it.
