### PR TITLE
fix: sync source assets with unusual filenames

### DIFF
--- a/scripts/run-node-watch-paths.mts
+++ b/scripts/run-node-watch-paths.mts
@@ -44,30 +44,23 @@ const ignoredRunNodeRepoPathPatterns = [
 ];
 const extensionSourceFilePattern = /\.(?:[cm]?[jt]sx?)$/;
 
-/** Normalizes watch paths to repository-style POSIX separators. */
+/** Canonicalizes native paths without treating POSIX filename backslashes as separators. */
 export const normalizeRunNodePath = (filePath: unknown): string =>
-  (typeof filePath === "string" ? filePath : "").replaceAll("\\", "/");
+  (typeof filePath === "string" ? filePath : "").replaceAll(path.sep, "/").replace(/^\.\/+/, "");
 
-const isIgnoredSourcePath = (relativePath: string): boolean => {
-  const normalizedPath = normalizeRunNodePath(relativePath);
-  return (
-    normalizedPath.endsWith(".test.ts") ||
-    normalizedPath.endsWith(".test.tsx") ||
-    normalizedPath.endsWith("test-helpers.ts")
-  );
-};
+const isIgnoredSourcePath = (relativePath: string): boolean =>
+  relativePath.endsWith(".test.ts") ||
+  relativePath.endsWith(".test.tsx") ||
+  relativePath.endsWith("test-helpers.ts");
 
-const isBuildRelevantSourcePath = (relativePath: string): boolean => {
-  const normalizedPath = normalizeRunNodePath(relativePath);
-  return extensionSourceFilePattern.test(normalizedPath) && !isIgnoredSourcePath(normalizedPath);
-};
+const isBuildRelevantSourcePath = (relativePath: string): boolean =>
+  extensionSourceFilePattern.test(relativePath) && !isIgnoredSourcePath(relativePath);
 
 const isRestartRelevantExtensionPath = (relativePath: string): boolean => {
-  const normalizedPath = normalizeRunNodePath(relativePath);
-  if (extensionRestartMetadataFiles.has(path.posix.basename(normalizedPath))) {
+  if (extensionRestartMetadataFiles.has(path.posix.basename(relativePath))) {
     return true;
   }
-  return isBuildRelevantSourcePath(normalizedPath);
+  return isBuildRelevantSourcePath(relativePath);
 };
 
 const isRelevantRunNodePath = (
@@ -75,7 +68,7 @@ const isRelevantRunNodePath = (
   isRelevantBundledPluginPath: (relativePath: string) => boolean,
   generatedPluginAssetPaths: ReadonlySet<string>,
 ): boolean => {
-  const normalizedPath = normalizeRunNodePath(repoPath).replace(/^\.\/+/, "");
+  const normalizedPath = normalizeRunNodePath(repoPath);
   if (
     generatedPluginAssetPaths.has(normalizedPath) ||
     ignoredRunNodeRepoPathPatterns.some((pattern) => pattern.test(normalizedPath))

--- a/scripts/run-node.mts
+++ b/scripts/run-node.mts
@@ -176,7 +176,8 @@ const resolvePrivateQaRequiredDistEntries = (distRoot: string) => [
 ];
 const isExcludedSource = (filePath: string, sourceRoot: string, sourceRootName: string) => {
   const relativePath = normalizePath(path.relative(sourceRoot, filePath));
-  if (relativePath.startsWith("..")) {
+  // A basename starting with ".." still belongs to the source root.
+  if (relativePath === ".." || relativePath.startsWith("../")) {
     return false;
   }
   return !isBuildRelevantRunNodePath(path.posix.join(sourceRootName, relativePath));
@@ -228,7 +229,16 @@ const readGitStatus = (deps: RunNodeRequirementDeps, paths: string[] = runNodeWa
   try {
     const result = deps.spawnSync(
       "git",
-      ["status", "--porcelain", "--untracked-files=normal", "--", ...paths],
+      // NUL framing preserves filenames; separate delete/add records keep both rename sides.
+      [
+        "status",
+        "--porcelain=v1",
+        "-z",
+        "--no-renames",
+        "--untracked-files=normal",
+        "--",
+        ...paths,
+      ],
       {
         cwd: deps.cwd,
         encoding: "utf8",
@@ -246,9 +256,8 @@ const readGitStatus = (deps: RunNodeRequirementDeps, paths: string[] = runNodeWa
 
 const parseGitStatusPaths = (output: string) =>
   output
-    .split("\n")
-    .flatMap((line) => line.slice(3).split(" -> "))
-    .map((entry) => normalizePath(entry.trim()))
+    .split("\0")
+    .map((entry) => entry.slice(3))
     .filter(Boolean);
 
 const hasDirtySourceTree = (deps: RunNodeRequirementDeps) => {
@@ -256,17 +265,15 @@ const hasDirtySourceTree = (deps: RunNodeRequirementDeps) => {
   if (output === null) {
     return null;
   }
-  return parseGitStatusPaths(output).some((repoPath) => {
-    const normalizedPath = normalizePath(repoPath).replace(/^\.\/+/, "");
-    return (
-      isBuildRelevantRunNodePath(normalizedPath) ||
-      isDirtyBundledPluginPackageEntryChangeWithoutBuiltOutputs(normalizedPath, deps)
-    );
-  });
+  return parseGitStatusPaths(output).some(
+    (repoPath) =>
+      isBuildRelevantRunNodePath(repoPath) ||
+      isDirtyBundledPluginPackageEntryChangeWithoutBuiltOutputs(repoPath, deps),
+  );
 };
 
 const isRuntimePostBuildRelevantPath = (repoPath: string) => {
-  const normalizedPath = normalizePath(repoPath).replace(/^\.\/+/, "");
+  const normalizedPath = normalizePath(repoPath);
   if (runtimePostBuildStaticAssetPaths.has(normalizedPath)) {
     return true;
   }

--- a/scripts/watch-node.mts
+++ b/scripts/watch-node.mts
@@ -8,7 +8,11 @@ import process from "node:process";
 import { pathToFileURL } from "node:url";
 import { toErrorObject } from "./lib/error-format.mts";
 import { sleep } from "./lib/sleep.mjs";
-import { createRunNodePathClassifier, runNodeWatchedPaths } from "./run-node-watch-paths.mts";
+import {
+  createRunNodePathClassifier,
+  normalizeRunNodePath as normalizePath,
+  runNodeWatchedPaths,
+} from "./run-node-watch-paths.mts";
 
 const WATCH_NODE_RUNNER = "scripts/run-node.mjs";
 const WATCH_RESTART_SIGNAL = "SIGTERM";
@@ -102,8 +106,6 @@ type WatchLock = {
 
 const buildRunnerArgs = (args: string[]) => [WATCH_NODE_RUNNER, ...args];
 const buildDoctorRunnerArgs = () => [WATCH_NODE_RUNNER, "doctor", "--fix", "--non-interactive"];
-
-const normalizePath = (filePath: string) => filePath.replaceAll("\\", "/").replace(/^\.\/+/, "");
 
 const resolveRepoPath = (filePath: unknown, cwd: string) => {
   const rawPath = typeof filePath === "string" ? filePath : "";

--- a/src/infra/run-node.test.ts
+++ b/src/infra/run-node.test.ts
@@ -1,5 +1,5 @@
 // Tests node process runner lifecycle and captured output.
-import type { SpawnOptions } from "node:child_process";
+import { execFileSync, spawnSync as realSpawnSync, type SpawnOptions } from "node:child_process";
 import { EventEmitter } from "node:events";
 import fsSync from "node:fs";
 import fs from "node:fs/promises";
@@ -364,6 +364,40 @@ function createBuildRequirementDeps(
     configFiles: [ROOT_TSCONFIG, ROOT_PACKAGE, ROOT_TSDOWN].map((filePath) =>
       path.join(tmp, filePath),
     ),
+  };
+}
+
+async function trackProjectWithGit(tmp: string) {
+  const git = (...args: string[]) =>
+    execFileSync(
+      "git",
+      ["-c", `core.hooksPath=${path.join(tmp, ".git", "disabled-hooks")}`, ...args],
+      { cwd: tmp, encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+    ).trim();
+  git("init", "--quiet", "--template=");
+  git("config", "core.quotePath", "true");
+  git("add", "--all");
+  git(
+    "-c",
+    "user.name=OpenClaw Test",
+    "-c",
+    "user.email=test@openclaw.invalid",
+    "-c",
+    "commit.gpgsign=false",
+    "commit",
+    "--quiet",
+    "-m",
+    "test: track runner fixture",
+  );
+  const stamp = `${JSON.stringify({ head: git("rev-parse", "HEAD") })}\n`;
+  await writeProjectFiles(tmp, {
+    [BUILD_STAMP]: stamp,
+    [RUNTIME_POSTBUILD_STAMP]: stamp,
+  });
+  await touchProjectFiles(tmp, [BUILD_STAMP, RUNTIME_POSTBUILD_STAMP], BUILD_TIME);
+  return {
+    git,
+    deps: { ...createBuildRequirementDeps(tmp), env: {}, spawnSync: realSpawnSync },
   };
 }
 
@@ -1003,7 +1037,7 @@ describe("run-node script", () => {
 
     const runRuntimePostBuild = vi.fn();
     const { spawnCalls, spawn, spawnSync } = createCurrentGitSpawnRecorder({
-      gitStatus: ` M ${EXTENSION_PACKAGE}\n`,
+      gitStatus: ` M ${EXTENSION_PACKAGE}\0`,
     });
     const exitCode = await runStatusCommand({
       tmp,
@@ -1170,7 +1204,7 @@ describe("run-node script", () => {
 
     const runRuntimePostBuild = vi.fn();
     const { spawnCalls, spawn, spawnSync } = createCurrentGitSpawnRecorder({
-      gitStatus: ` M ${EXTENSION_MANIFEST}\n`,
+      gitStatus: ` M ${EXTENSION_MANIFEST}\0`,
     });
     const exitCode = await runStatusCommand({
       tmp,
@@ -1525,7 +1559,7 @@ describe("run-node script", () => {
     });
 
     const { spawnCalls, spawn, spawnSync } = createCurrentGitSpawnRecorder({
-      gitStatus: ` M ${EXTENSION_README}\n`,
+      gitStatus: ` M ${EXTENSION_README}\0`,
     });
     const exitCode = await runStatusCommand({
       tmp,
@@ -1553,7 +1587,7 @@ describe("run-node script", () => {
     });
 
     const { spawnCalls, spawn, spawnSync } = createCurrentGitSpawnRecorder({
-      gitStatus: ` M ${EXTENSION_MANIFEST}\n`,
+      gitStatus: ` M ${EXTENSION_MANIFEST}\0`,
     });
     const exitCode = await runStatusCommand({
       tmp,
@@ -1567,18 +1601,68 @@ describe("run-node script", () => {
     await expectManifestId(tmp, DIST_EXTENSION_MANIFEST, "demo");
   });
 
-  it("reports dirty watched source trees as an explicit build reason", async ({ tmp }) => {
-    await setupStampedProject(tmp, { trackConfig: true });
+  it.for([
+    { filePath: ROOT_SRC, watched: true },
+    { filePath: "src/café.ts", watched: true },
+    { filePath: "extensions/demo/src/café.ts", watched: true },
+    { filePath: "src/café.test.ts", watched: false },
+    { filePath: "src/..ignored.test.ts", watched: false },
+    ...(process.platform === "win32"
+      ? []
+      : [
+          { filePath: "src/left -> right.ts", watched: true },
+          { filePath: 'src/"quoted".ts', watched: true },
+          { filePath: "src/tab\tname.ts", watched: true },
+          { filePath: "src/line\nname.ts", watched: true },
+          { filePath: "src/ignored.test.ts ", watched: true },
+          { filePath: "src/name\\part.ts", watched: true },
+          { filePath: "src/name\\part.test.ts", watched: false },
+        ]),
+  ])(
+    "reports watched source changes with real Git: $filePath",
+    async ({ filePath, watched }, { tmp }) => {
+      await setupStampedProject(tmp, {
+        files: { [filePath]: "export const value = 1;\n" },
+        trackConfig: true,
+      });
+      const { git, deps } = await trackProjectWithGit(tmp);
+      expect(resolveBuildRequirement(deps)).toEqual({ shouldBuild: false, reason: "clean" });
 
-    const requirement = resolveBuildRequirement(
-      createBuildRequirementDeps(tmp, { gitStatus: ` M ${ROOT_SRC}\n` }),
-    );
+      await fs.writeFile(resolvePath(tmp, filePath), "export const value = 2;\n");
+      await touchProjectFiles(tmp, [filePath], NEW_TIME);
+      for (const quotePath of ["true", "false"]) {
+        git("config", "core.quotePath", quotePath);
+        expect(resolveBuildRequirement(deps)).toEqual({
+          shouldBuild: watched,
+          reason: watched ? "dirty_watched_tree" : "clean",
+        });
+      }
+      const { spawnSync } = createSpawnRecorder();
+      expect(resolveBuildRequirement({ ...deps, spawnSync })).toEqual({
+        shouldBuild: watched,
+        reason: watched ? "source_mtime_newer" : "clean",
+      });
+    },
+  );
 
-    expect(requirement).toEqual({
-      shouldBuild: true,
-      reason: "dirty_watched_tree",
-    });
-  });
+  it.for([
+    { source: "src/café.ts", target: "src/café.test.ts", watched: true },
+    { source: "src/café.test.ts", target: "src/café.ts", watched: true },
+    { source: "src/café.test.ts", target: "src/renamed.test.ts", watched: false },
+  ])(
+    "checks both rename sides with real Git: $source to $target",
+    async ({ source, target, watched }, { tmp }) => {
+      await setupStampedProject(tmp, { files: { [source]: "export {};\n" } });
+      const { git, deps } = await trackProjectWithGit(tmp);
+      git("config", "status.renames", "true");
+      git("mv", "--", source, target);
+
+      expect(resolveBuildRequirement(deps)).toEqual({
+        shouldBuild: watched,
+        reason: watched ? "dirty_watched_tree" : "clean",
+      });
+    },
+  );
 
   it.each([
     { label: "gateway RPC", args: ["gateway", "call", "status", "--json"] },
@@ -1594,7 +1678,7 @@ describe("run-node script", () => {
 
       const runRuntimePostBuild = vi.fn();
       const { spawnCalls, spawn, spawnSync } = createCurrentGitSpawnRecorder({
-        gitStatus: ` M ${ROOT_SRC}\n`,
+        gitStatus: ` M ${ROOT_SRC}\0`,
       });
       const exitCode = await runStatusCommand({
         tmp,
@@ -1643,7 +1727,7 @@ describe("run-node script", () => {
     } as unknown as NodeJS.WriteStream;
     const runRuntimePostBuild = vi.fn();
     const { spawnCalls, spawn, spawnSync } = createCurrentGitSpawnRecorder({
-      gitStatus: ` M ${ROOT_SRC}\n`,
+      gitStatus: ` M ${ROOT_SRC}\0`,
     });
     const clientRun = runNodeCommand(tmp, {
       args: ["dashboard", "--no-open", "--yes"],
@@ -1740,7 +1824,7 @@ describe("run-node script", () => {
     });
 
     const requirement = resolveBuildRequirement(
-      createBuildRequirementDeps(tmp, { gitStatus: ` M ${EXTENSION_PACKAGE}\n` }),
+      createBuildRequirementDeps(tmp, { gitStatus: ` M ${EXTENSION_PACKAGE}\0` }),
     );
 
     expect(requirement).toEqual({
@@ -2128,7 +2212,7 @@ describe("run-node script", () => {
       trackConfig: true,
     });
 
-    const deps = createBuildRequirementDeps(tmp, { gitStatus: ` M ${EXTENSION_MANIFEST}\n` });
+    const deps = createBuildRequirementDeps(tmp, { gitStatus: ` M ${EXTENSION_MANIFEST}\0` });
 
     expect(resolveBuildRequirement(deps)).toEqual({
       shouldBuild: false,
@@ -2153,7 +2237,7 @@ describe("run-node script", () => {
         });
 
         const requirement = resolveRuntimePostBuildRequirement(
-          createBuildRequirementDeps(tmp, { gitStatus: ` M ${implementationPath}\n` }),
+          createBuildRequirementDeps(tmp, { gitStatus: ` M ${implementationPath}\0` }),
         );
 
         expect(requirement).toEqual({
@@ -2188,7 +2272,7 @@ describe("run-node script", () => {
 
     const requirement = resolveBuildRequirement(
       createBuildRequirementDeps(tmp, {
-        gitStatus: ` M ${GENERATED_PLUGIN_ASSET_BUNDLE_HASH}\n M ${GENERATED_PLUGIN_ASSET_BUNDLE}\n`,
+        gitStatus: ` M ${GENERATED_PLUGIN_ASSET_BUNDLE_HASH}\0 M ${GENERATED_PLUGIN_ASSET_BUNDLE}\0`,
       }),
     );
 
@@ -2198,23 +2282,61 @@ describe("run-node script", () => {
     });
   });
 
-  it("reports bundled skill edits as runtime postbuild inputs", async ({ tmp }) => {
-    await setupStampedProject(tmp, {
-      files: {
-        [EXTENSION_MANIFEST]: '{"id":"demo","skills":["./skills/SKILL.md"]}\n',
-        [EXTENSION_SKILL]: "# Demo\n",
-        [RUNTIME_POSTBUILD_STAMP]: '{"head":"abc123"}\n',
-      },
-      trackConfig: true,
-    });
+  it.for([
+    { label: "SKILL.md", fileName: "SKILL.md", changedFile: null, shouldSync: true },
+    { label: "café.md", fileName: "café.md", changedFile: null, shouldSync: true },
+    ...(process.platform === "win32"
+      ? []
+      : [
+          {
+            label: "POSIX backslash inside declared skills",
+            fileName: "notes\\part.md",
+            changedFile: null,
+            shouldSync: true,
+          },
+          {
+            label: "POSIX backslash outside declared skills",
+            fileName: "SKILL.md",
+            changedFile: "skills\\notes.md",
+            shouldSync: false,
+          },
+        ]),
+  ])(
+    "reports bundled skill edits as runtime postbuild inputs: $label",
+    async ({ fileName, changedFile, shouldSync }, { tmp }) => {
+      const skillPath = bundledPluginFile("demo", `skills/${fileName}`);
+      const changedPath = changedFile ? bundledPluginFile("demo", changedFile) : skillPath;
+      const manifest = JSON.stringify({ id: "demo", skills: ["./skills"] });
+      await setupStampedProject(tmp, {
+        files: {
+          [EXTENSION_INDEX]: "export default {};\n",
+          [EXTENSION_MANIFEST]: manifest,
+          [skillPath]: "# Demo\n",
+          [DIST_EXTENSION_INDEX]: "export default {};\n",
+          [DIST_EXTENSION_MANIFEST]: manifest,
+          [bundledDistPluginFile("demo", `skills/${fileName}`)]: "# Demo\n",
+          [DIST_RUNTIME_EXTENSION_INDEX]: "export default {};\n",
+          [DIST_RUNTIME_EXTENSION_MANIFEST]: manifest,
+          [`dist-runtime/extensions/demo/skills/${fileName}`]: "# Demo\n",
+          ...(changedFile ? { [changedPath]: "# Notes\n" } : {}),
+        },
+        trackConfig: true,
+      });
+      const { deps } = await trackProjectWithGit(tmp);
+      expect(resolveRuntimePostBuildRequirement(deps)).toEqual({
+        shouldSync: false,
+        reason: "clean",
+      });
 
-    const deps = createBuildRequirementDeps(tmp, { gitStatus: ` M ${EXTENSION_SKILL}\n` });
-
-    expect(resolveRuntimePostBuildRequirement(deps)).toEqual({
-      shouldSync: true,
-      reason: "dirty_runtime_postbuild_inputs",
-    });
-  });
+      await fs.writeFile(resolvePath(tmp, changedPath), "# Updated\n");
+      await touchProjectFiles(tmp, [changedPath], NEW_TIME);
+      expect(resolveBuildRequirement(deps)).toEqual({ shouldBuild: false, reason: "clean" });
+      expect(resolveRuntimePostBuildRequirement(deps)).toEqual({
+        shouldSync,
+        reason: shouldSync ? "dirty_runtime_postbuild_inputs" : "clean",
+      });
+    },
+  );
 
   it("repairs missing bundled plugin metadata without rerunning tsdown", async ({ tmp }) => {
     await setupStampedProject(tmp, {
@@ -2295,7 +2417,7 @@ describe("run-node script", () => {
     });
 
     const { spawnCalls, spawn, spawnSync } = createCurrentGitSpawnRecorder({
-      gitStatus: ` M ${ROOT_TSDOWN}\n`,
+      gitStatus: ` M ${ROOT_TSDOWN}\0`,
     });
     const exitCode = await runStatusCommand({
       tmp,

--- a/test/scripts/bundled-plugin-assets.test.ts
+++ b/test/scripts/bundled-plugin-assets.test.ts
@@ -131,7 +131,7 @@ describe("bundled plugin assets", () => {
 
       const classifier = createRunNodePathClassifier({ rootDir });
       classifier.refreshGeneratedPluginAssetPaths();
-      const generatedPath = "extensions/canvas/assets/generated-runtime.js";
+      const generatedPath = path.join("extensions", "canvas", "assets", "generated-runtime.js");
       expect(classifier.isRestartRelevantRunNodePath(generatedPath)).toBe(true);
 
       packageJson.openclaw.assetScripts.buildOutputs = ["assets/generated-runtime.js"];
@@ -140,6 +140,20 @@ describe("bundled plugin assets", () => {
 
       expect(classifier.isBuildRelevantRunNodePath(generatedPath)).toBe(false);
       expect(classifier.isRestartRelevantRunNodePath(generatedPath)).toBe(false);
+
+      if (process.platform !== "win32") {
+        // Literal backslashes in native basenames do not identify the generated paths.
+        for (const sourcePath of [
+          path.join("extensions", "canvas", "assets\\generated-runtime.js"),
+          path.join("extensions", "canvas", "src", "host", "qa\\widget.bundle.js"),
+        ]) {
+          const absolutePath = path.join(rootDir, sourcePath);
+          fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+          fs.writeFileSync(absolutePath, "export {};\n");
+          expect(classifier.isBuildRelevantRunNodePath(sourcePath), sourcePath).toBe(true);
+          expect(classifier.isRestartRelevantRunNodePath(sourcePath), sourcePath).toBe(true);
+        }
+      }
     });
   });
 


### PR DESCRIPTION
Closes #141996

## What Problem This Solves

Fixes an issue where developers running a source checkout would silently keep stale bundled assets when changed filenames contain Unicode or other characters escaped by Git. For example, adding a declared Canvas skill named `qa-café.md` leaves both runtime copies absent even though `pnpm openclaw --version` succeeds.

## Why This Change Was Made

The runner now asks Git for NUL-delimited porcelain with rename detection disabled, preserving each original filename and both sides of a rename. The shared path normalizer converts only the native separator, and the watcher reuses it; redundant private normalization is removed. A connected mtime-path check now distinguishes actual parent segments from legitimate basenames beginning with `..`.

This keeps filename identity intact through the existing build/postbuild classifiers. It adds no parser fallback, configuration, state, dependency, schema or protocol surface. Production is +36/−34, net +2 across three scripts; tests are +176/−40, net +136. The small net growth includes explicit Git arguments and shared imports while removing duplicate normalization.

## User Impact

Declared skill edits with Unicode, whitespace or other unusual filename characters are recognized. Skill-only changes use the existing postbuild sync, and unrelated filenames do not trigger unnecessary work. JSON and CLI command behavior are unchanged. Chokidar still has its own upstream POSIX-backslash normalization in ignored callbacks; this does not claim to fix or live-verify every watcher filename.

## Evidence

- Original real-Git/classifier baseline: 13 intended failures and six controls. The NUL-only intermediate still failed the two backslash-boundary cases; the complete repair passed. A separate mtime case demonstrated the `..`-basename defect before its guard was corrected. Final runner, watcher and asset suites passed all 141 tests; complete changed-file checks passed.
- Six actual `pnpm openclaw --version` invocations all exited 0 and printed the expected version. The first created genuine baseline outputs/stamps through the normal missing-build path. Clean and outside-file controls stayed quiet. The baseline then missed the new declared Unicode file and left both generated copies absent.
- Normal final `pnpm build` passed in 5m37.4s. The independent outside-only command stayed quiet and preserved both stamps. Adding the Unicode source then triggered actual runtime postbuild, copied the exact 40-byte marker to both `dist` and `dist-runtime`, preserved the build stamp, and advanced only the runtime synchronization stamp.
- Both retained artifact snapshots were independently rehashed: 18 roots with 12,731 baseline entries and 15,427 final entries. Sources, existing private fixtures, owned synthetic files, command results and cleanup receipts were checked; the checkout returned to the exact five-file candidate diff. Exact nanosecond comparisons use original Python captures because JavaScript copies round those large integers.

- One fresh managed P0–P2 review was scoped-clean with no actionable findings; final source and all bound evidence stayed unchanged.

Proof is bound to base `8954f104fb721c30d0f83c86a7cef6cd5f1df795` plus patch `589730d909e1dec6a612e6fc4210863694c970cba12dfd08930ea256cf089a9c`, committed without source changes as `20c41847867af9a781ec8a1734bd5abeadaaa36d`. Baseline uses that base's production scripts with the final tests retained. The five touched files remain unchanged on inspected main `0604bbce80797482228b275eaacec34614942731`. This is real local source-runner/build/postbuild proof on macOS, with real Git; no live Gateway, external channel, installed npm package, all-platform or later-main execution is claimed. Introduction provenance is unknown.
