### PR TITLE
refactor(ui): derive session rows from gateway projection

### DIFF
--- a/ui/src/api/types.ts
+++ b/ui/src/api/types.ts
@@ -12,25 +12,18 @@ import type {
   ModelChoice as ProtocolModelChoice,
 } from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import type { ChannelsStatusResult } from "../../../packages/gateway-protocol/src/schema/channels.js";
-import type { QueueMode } from "../../../packages/gateway-protocol/src/schema/logs-chat.js";
 import type {
   SessionEntryArchiveReason,
   SessionRow,
 } from "../../../packages/gateway-protocol/src/schema/sessions-row.js";
 import type {
   SessionCompactionCheckpoint as ProtocolSessionCompactionCheckpoint,
-  SessionObserverDigest,
   SessionsCompactionBranchResult as ProtocolSessionsCompactionBranchResult,
   SessionsCompactionListResult as ProtocolSessionsCompactionListResult,
   SessionsCompactionRestoreResult as ProtocolSessionsCompactionRestoreResult,
 } from "../../../packages/gateway-protocol/src/schema/sessions.js";
 import type { PresenceEntry as ProtocolPresenceEntry } from "../../../packages/gateway-protocol/src/schema/snapshot.js";
-import type { SessionAgentStatus } from "../../../packages/gateway-protocol/src/session-agent-status.js";
-import type {
-  SessionContextBudgetStatus,
-  SessionGoal,
-} from "../../../src/config/sessions/types.js";
-import type { FastModeSource } from "../../../src/shared/fast-mode.js";
+import type { GatewaySessionRow as GatewayWireSessionRow } from "../../../src/gateway/session-utils.types.js";
 import type {
   GatewayAgentRuntime,
   GatewayAgentRow as SharedGatewayAgentRow,
@@ -239,75 +232,24 @@ export type SessionWorkspaceListResult = ProtocolSessionsFilesListResult & {
   artifacts?: SessionWorkspaceArtifactEntry[];
 };
 
-type SubagentRunState = "active" | "interrupted" | "historical";
-
 export type SessionCompactionCheckpoint = Omit<
   ProtocolSessionCompactionCheckpoint,
   "tokensVersion"
 >;
 
-type SessionCompactionCheckpointPreview = Pick<
-  SessionCompactionCheckpoint,
-  "checkpointId" | "createdAt" | "reason"
->;
-
-export type GatewaySessionRow = SessionRow & {
-  contextBudgetStatus?: SessionContextBudgetStatus;
-  /** Transient UI-owned Swarm note overlays, not persisted session fields. */
-  swarmPhase?: string;
-  swarmPhaseRank?: number;
-  swarmLog?: string;
-  placement?: import("../../../packages/gateway-protocol/src/index.js").SessionPlacement;
-  placementMove?: import("../../../packages/gateway-protocol/src/index.js").SessionPlacementMove;
-  icon?: string;
-  channelAvatarUrl?: string;
-  /** User-defined organization bucket; unrelated to chat-group kind/groupChannel. */
-  category?: string;
-  surface?: string;
-  subject?: string;
-  room?: string;
-  space?: string;
-  agentStatus?: SessionAgentStatus;
-  observerDigest?: Pick<
-    SessionObserverDigest,
-    "agentId" | "runId" | "headline" | "health" | "updatedAt" | "revision"
-  >;
-  systemSent?: boolean;
-  abortedLastRun?: boolean;
-  thinkingLevel?: string;
-  contextWindow?: string;
-  contextWindows?: GatewayContextWindowOption[];
-  contextWindowDefault?: string;
-  thinkingLevels?: GatewayThinkingLevelOption[];
-  thinkingOptions?: string[];
-  thinkingDefault?: string;
-  fastMode?: FastMode;
-  effectiveFastMode?: FastMode;
-  effectiveFastModeSource?: FastModeSource;
-  fastAutoOnSeconds?: number;
-  verboseLevel?: string;
-  reasoningLevel?: string;
-  elevatedLevel?: string;
-  hasActiveRun?: boolean;
-  activeRunIds?: string[];
-  /** An enabled cron job is bound to this session (runs in it or delivers to it). */
-  hasAutomation?: boolean;
-  subagentRunState?: SubagentRunState;
-  hasActiveSubagentRun?: boolean;
-  startedAt?: number;
-  endedAt?: number;
-  runtimeMs?: number;
-  /** UI-local timestamp for the runtimeMs sample; absent on raw Gateway rows. */
-  runtimeSampledAt?: number;
-  modelSelectionLocked?: boolean;
-  effectiveResponseUsage?: "on" | "off" | "tokens" | "full";
-  queueMode?: QueueMode;
-  effectiveQueueMode?: QueueMode;
-  agentRuntime?: GatewayAgentRuntime;
-  compactionCheckpointCount?: number;
-  latestCompactionCheckpoint?: SessionCompactionCheckpointPreview;
-  goal?: SessionGoal;
-};
+export type GatewaySessionRow = Omit<GatewayWireSessionRow, "archivedBy" | "updatedAt"> &
+  Pick<SessionRow, "archivedBy" | "updatedAt"> & {
+    /** Transient UI-owned Swarm note overlays, not persisted session fields. */
+    swarmPhase?: string;
+    swarmPhaseRank?: number;
+    swarmLog?: string;
+    icon?: string;
+    channelAvatarUrl?: string;
+    surface?: string;
+    room?: string;
+    /** UI-local timestamp for the runtimeMs sample; absent on raw Gateway rows. */
+    runtimeSampledAt?: number;
+  };
 
 export type SessionsListResult = SessionsListResultBase<GatewaySessionsDefaults, GatewaySessionRow>;
 


### PR DESCRIPTION
## Summary

- Derive the Control UI session row from the canonical Gateway projection.
- Retain only UI-owned overlays and protocol refinements.
- Remove 58 net production lines of duplicate session-row typing.

## Validation

- UI production and test typechecks
- 10 focused session mutation and reconnect tests
- Full `pnpm check:changed`
- Scoped P0–P2 review
- Clean synthetic merge against current `main`
