### PR TITLE
test(infra): compact exec wrapper case matrices

### DIFF
--- a/src/infra/exec-wrapper-resolution.test.ts
+++ b/src/infra/exec-wrapper-resolution.test.ts
@@ -42,40 +42,40 @@ function expectTransparentDispatchWrapperCase(params: {
 
 describe("normalizeExecutableToken", () => {
   test.each([
-    { token: "bun.cmd", expected: "bun" },
-    { token: "deno.bat", expected: "deno" },
-    { token: "pwsh.com", expected: "pwsh" },
-    { token: "cmd.exe", expected: "cmd" },
-    { token: "C:\\tools\\bun.cmd", expected: "bun" },
-    { token: "/tmp/deno.exe", expected: "deno" },
-    { token: " /tmp/bash ", expected: "bash" },
-  ])("normalizes executable tokens for %j", ({ token, expected }) => {
+    ["bun.cmd", "bun"],
+    ["deno.bat", "deno"],
+    ["pwsh.com", "pwsh"],
+    ["cmd.exe", "cmd"],
+    ["C:\\tools\\bun.cmd", "bun"],
+    ["/tmp/deno.exe", "deno"],
+    [" /tmp/bash ", "bash"],
+  ])("normalizes executable tokens for %j", (token, expected) => {
     expect(normalizeExecutableToken(token)).toBe(expected);
   });
 });
 
 describe("wrapper classification", () => {
   test.each([
-    { token: "sudo", dispatch: true, shell: false },
-    { token: "caffeinate", dispatch: true, shell: false },
-    { token: "sandbox-exec", dispatch: true, shell: false },
-    { token: "script", dispatch: true, shell: false },
-    { token: "flock", dispatch: true, shell: false },
-    { token: "time", dispatch: true, shell: false },
-    { token: "timeout.exe", dispatch: true, shell: false },
-    { token: "bash", dispatch: false, shell: true },
-    { token: "csh", dispatch: false, shell: true },
-    { token: "elvish", dispatch: false, shell: true },
-    { token: "mksh", dispatch: false, shell: true },
-    { token: "nu", dispatch: false, shell: true },
-    { token: "nu.exe", dispatch: false, shell: true },
-    { token: "osh", dispatch: false, shell: true },
-    { token: "pwsh.exe", dispatch: false, shell: true },
-    { token: "tcsh", dispatch: false, shell: true },
-    { token: "xonsh", dispatch: false, shell: true },
-    { token: "yash", dispatch: false, shell: true },
-    { token: "node", dispatch: false, shell: false },
-  ])("classifies wrappers for %j", ({ token, dispatch, shell }) => {
+    ["sudo", true, false],
+    ["caffeinate", true, false],
+    ["sandbox-exec", true, false],
+    ["script", true, false],
+    ["flock", true, false],
+    ["time", true, false],
+    ["timeout.exe", true, false],
+    ["bash", false, true],
+    ["csh", false, true],
+    ["elvish", false, true],
+    ["mksh", false, true],
+    ["nu", false, true],
+    ["nu.exe", false, true],
+    ["osh", false, true],
+    ["pwsh.exe", false, true],
+    ["tcsh", false, true],
+    ["xonsh", false, true],
+    ["yash", false, true],
+    ["node", false, false],
+  ])("classifies wrappers for %j", (token, dispatch, shell) => {
     expect(isDispatchWrapperExecutable(token)).toBe(dispatch);
     expect(isShellWrapperExecutable(token)).toBe(shell);
   });
@@ -83,210 +83,182 @@ describe("wrapper classification", () => {
 
 describe("unwrapKnownShellMultiplexerInvocation", () => {
   test.each([
-    { argv: [], expected: { kind: "not-wrapper" } },
-    { argv: ["node", "-e", "1"], expected: { kind: "not-wrapper" } },
-    { argv: ["busybox"], expected: { kind: "blocked", wrapper: "busybox" } },
-    { argv: ["busybox", "ls"], expected: { kind: "blocked", wrapper: "busybox" } },
-    {
-      argv: ["busybox", "sh", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "busybox", argv: ["sh", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["busybox", "tcsh", "-c", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "busybox", argv: ["tcsh", "-c", "echo hi"] },
-    },
-    {
-      argv: ["toybox", "--", "pwsh.exe", "-Command", "Get-Date"],
-      expected: {
+    [[], { kind: "not-wrapper" }],
+    [["node", "-e", "1"], { kind: "not-wrapper" }],
+    [["busybox"], { kind: "blocked", wrapper: "busybox" }],
+    [["busybox", "ls"], { kind: "blocked", wrapper: "busybox" }],
+    [
+      ["busybox", "sh", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "busybox", argv: ["sh", "-lc", "echo hi"] },
+    ],
+    [
+      ["busybox", "tcsh", "-c", "echo hi"],
+      { kind: "unwrapped", wrapper: "busybox", argv: ["tcsh", "-c", "echo hi"] },
+    ],
+    [
+      ["toybox", "--", "pwsh.exe", "-Command", "Get-Date"],
+      {
         kind: "unwrapped",
         wrapper: "toybox",
         argv: ["pwsh.exe", "-Command", "Get-Date"],
       },
-    },
-  ])("unwraps shell multiplexers for %j", ({ argv, expected }) => {
+    ],
+  ])("unwraps shell multiplexers for %j", (argv, expected) => {
     expect(unwrapKnownShellMultiplexerInvocation(argv)).toEqual(expected);
   });
 });
 
 describe("unwrapEnvInvocation", () => {
   test.each([
-    {
-      argv: ["env", "FOO=bar", "bash", "-lc", "echo hi"],
-      expected: ["bash", "-lc", "echo hi"],
-    },
-    {
-      argv: ["env", "-i", "--unset", "PATH", "--", "sh", "-lc", "echo hi"],
-      expected: ["sh", "-lc", "echo hi"],
-    },
-    {
-      argv: ["env", "--chdir=/tmp", "pwsh", "-Command", "Get-Date"],
-      expected: ["pwsh", "-Command", "Get-Date"],
-    },
-    {
-      argv: ["env", "-P", "/usr/bin", "python3", "-c", "print(1)"],
-      expected: ["python3", "-c", "print(1)"],
-    },
-    {
-      argv: ["env", "-S", "python3 -c", "print(1)"],
-      expected: ["python3", "-c", "print(1)"],
-    },
-    {
-      argv: ["env", "--split-string=python3 -c", "print(1)"],
-      expected: ["python3", "-c", "print(1)"],
-    },
-    {
-      argv: ["env", "-Spython3 -c", "print(1)"],
-      expected: ["python3", "-c", "print(1)"],
-    },
-    {
-      argv: ["env", "-", "bash", "-lc", "echo hi"],
-      expected: ["bash", "-lc", "echo hi"],
-    },
-    {
-      argv: ["env", "--bogus", "bash", "-lc", "echo hi"],
-      expected: null,
-    },
-    {
-      argv: ["env", "--unset"],
-      expected: null,
-    },
-  ])("unwraps env invocations for %j", ({ argv, expected }) => {
+    [
+      ["env", "FOO=bar", "bash", "-lc", "echo hi"],
+      ["bash", "-lc", "echo hi"],
+    ],
+    [
+      ["env", "-i", "--unset", "PATH", "--", "sh", "-lc", "echo hi"],
+      ["sh", "-lc", "echo hi"],
+    ],
+    [
+      ["env", "--chdir=/tmp", "pwsh", "-Command", "Get-Date"],
+      ["pwsh", "-Command", "Get-Date"],
+    ],
+    [
+      ["env", "-P", "/usr/bin", "python3", "-c", "print(1)"],
+      ["python3", "-c", "print(1)"],
+    ],
+    [
+      ["env", "-S", "python3 -c", "print(1)"],
+      ["python3", "-c", "print(1)"],
+    ],
+    [
+      ["env", "--split-string=python3 -c", "print(1)"],
+      ["python3", "-c", "print(1)"],
+    ],
+    [
+      ["env", "-Spython3 -c", "print(1)"],
+      ["python3", "-c", "print(1)"],
+    ],
+    [
+      ["env", "-", "bash", "-lc", "echo hi"],
+      ["bash", "-lc", "echo hi"],
+    ],
+    [["env", "--bogus", "bash", "-lc", "echo hi"], null],
+    [["env", "--unset"], null],
+  ])("unwraps env invocations for %j", (argv, expected) => {
     expect(unwrapEnvInvocation(argv)).toEqual(expected);
   });
 });
 
 describe("unwrapKnownDispatchWrapperInvocation", () => {
   test.each([
-    {
-      argv: ["caffeinate", "-d", "-w", "42", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "caffeinate", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["env", "--", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "env", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["nice", "-n", "5", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "nice", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["nohup", "--", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "nohup", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["script", "-q", "/dev/null", "bash", "-lc", "echo hi"],
-      expected: supportsScriptPositionalCommandForTests()
+    [
+      ["caffeinate", "-d", "-w", "42", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "caffeinate", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["env", "--", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "env", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["nice", "-n", "5", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "nice", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["nohup", "--", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "nohup", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["script", "-q", "/dev/null", "bash", "-lc", "echo hi"],
+      supportsScriptPositionalCommandForTests()
         ? { kind: "unwrapped", wrapper: "script", argv: ["bash", "-lc", "echo hi"] }
         : { kind: "blocked", wrapper: "script" },
-    },
-    {
-      argv: ["script", "-E", "always", "/dev/null", "bash", "-lc", "echo hi"],
-      expected: { kind: "blocked", wrapper: "script" },
-    },
-    {
-      argv: ["stdbuf", "-o", "L", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "stdbuf", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["time", "-p", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "time", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["flock", "-n", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["flock", "-en", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["flock", "-E", "1", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["flock", "-F", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["flock", "-o", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["flock", "--nb", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["flock", "--wait", "1", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["timeout", "--signal=TERM", "5s", "bash", "-lc", "echo hi"],
-      expected: { kind: "unwrapped", wrapper: "timeout", argv: ["bash", "-lc", "echo hi"] },
-    },
-    {
-      argv: ["sandbox-exec", "-p", "(allow default)", "bash", "-lc", "echo hi"],
-      expected: {
+    ],
+    [
+      ["script", "-E", "always", "/dev/null", "bash", "-lc", "echo hi"],
+      { kind: "blocked", wrapper: "script" },
+    ],
+    [
+      ["stdbuf", "-o", "L", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "stdbuf", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["time", "-p", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "time", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["flock", "-n", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["flock", "-en", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["flock", "-E", "1", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["flock", "-F", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["flock", "-o", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["flock", "--nb", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["flock", "--wait", "1", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "flock", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["timeout", "--signal=TERM", "5s", "bash", "-lc", "echo hi"],
+      { kind: "unwrapped", wrapper: "timeout", argv: ["bash", "-lc", "echo hi"] },
+    ],
+    [
+      ["sandbox-exec", "-p", "(allow default)", "bash", "-lc", "echo hi"],
+      {
         kind: "unwrapped",
         wrapper: "sandbox-exec",
         argv: ["bash", "-lc", "echo hi"],
       },
-    },
-    {
-      argv: ["sandbox-exec", "-D", "PROFILE", "bash", "-lc", "echo hi"],
-      expected: {
+    ],
+    [
+      ["sandbox-exec", "-D", "PROFILE", "bash", "-lc", "echo hi"],
+      {
         kind: "unwrapped",
         wrapper: "sandbox-exec",
         argv: ["bash", "-lc", "echo hi"],
       },
-    },
-    {
-      argv: ["xcrun", "bash", "-lc", "echo hi"],
-      expected:
-        process.platform === "darwin"
-          ? { kind: "unwrapped", wrapper: "xcrun", argv: ["bash", "-lc", "echo hi"] }
-          : { kind: "blocked", wrapper: "xcrun" },
-    },
-    {
-      argv: ["script", "-q", "/dev/null"],
-      expected: { kind: "blocked", wrapper: "script" },
-    },
-    {
-      argv: ["sudo", "bash", "-lc", "echo hi"],
-      expected: { kind: "blocked", wrapper: "sudo" },
-    },
-    {
-      argv: ["timeout", "--bogus", "5s", "bash", "-lc", "echo hi"],
-      expected: { kind: "blocked", wrapper: "timeout" },
-    },
-    {
-      argv: ["flock", "/tmp/openclaw.lock", "-c", "echo hi"],
-      expected: { kind: "blocked", wrapper: "flock" },
-    },
-    {
-      argv: ["flock", "/tmp/openclaw.lock", "--", "bash", "-lc", "echo hi"],
-      expected: { kind: "blocked", wrapper: "flock" },
-    },
-    {
-      argv: ["flock", "-un", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
-      expected: { kind: "blocked", wrapper: "flock" },
-    },
-    {
-      argv: ["flock", "-u", "9"],
-      expected: { kind: "blocked", wrapper: "flock" },
-    },
-    {
-      argv: ["arch", "-e", "FOO=bar", "bash", "-lc", "echo hi"],
-      expected: { kind: "blocked", wrapper: "arch" },
-    },
-    {
-      argv: ["arch", "-arch", "bogus", "bash", "-lc", "echo hi"],
-      expected: { kind: "blocked", wrapper: "arch" },
-    },
-    {
-      argv: ["xcrun", "--sdk", "macosx", "bash", "-lc", "echo hi"],
-      expected: { kind: "blocked", wrapper: "xcrun" },
-    },
-  ])("unwraps known dispatch wrappers for %j", ({ argv, expected }) => {
+    ],
+    [
+      ["xcrun", "bash", "-lc", "echo hi"],
+      process.platform === "darwin"
+        ? { kind: "unwrapped", wrapper: "xcrun", argv: ["bash", "-lc", "echo hi"] }
+        : { kind: "blocked", wrapper: "xcrun" },
+    ],
+    [["script", "-q", "/dev/null"], { kind: "blocked", wrapper: "script" }],
+    [["sudo", "bash", "-lc", "echo hi"], { kind: "blocked", wrapper: "sudo" }],
+    [
+      ["timeout", "--bogus", "5s", "bash", "-lc", "echo hi"],
+      { kind: "blocked", wrapper: "timeout" },
+    ],
+    [["flock", "/tmp/openclaw.lock", "-c", "echo hi"], { kind: "blocked", wrapper: "flock" }],
+    [
+      ["flock", "/tmp/openclaw.lock", "--", "bash", "-lc", "echo hi"],
+      { kind: "blocked", wrapper: "flock" },
+    ],
+    [
+      ["flock", "-un", "/tmp/openclaw.lock", "bash", "-lc", "echo hi"],
+      { kind: "blocked", wrapper: "flock" },
+    ],
+    [["flock", "-u", "9"], { kind: "blocked", wrapper: "flock" }],
+    [["arch", "-e", "FOO=bar", "bash", "-lc", "echo hi"], { kind: "blocked", wrapper: "arch" }],
+    [["arch", "-arch", "bogus", "bash", "-lc", "echo hi"], { kind: "blocked", wrapper: "arch" }],
+    [["xcrun", "--sdk", "macosx", "bash", "-lc", "echo hi"], { kind: "blocked", wrapper: "xcrun" }],
+  ])("unwraps known dispatch wrappers for %j", (argv, expected) => {
     expect(unwrapKnownDispatchWrapperInvocation(argv)).toEqual(expected);
   });
 
@@ -512,265 +484,165 @@ describe("resolveDispatchWrapperTrustPlan", () => {
 
 describe("hasEnvManipulationBeforeShellWrapper", () => {
   test.each([
-    {
-      argv: ["env", "FOO=bar", "bash", "-lc", "echo hi"],
-      expected: true,
-    },
-    {
-      argv: ["timeout", "5s", "env", "--", "bash", "-lc", "echo hi"],
-      expected: false,
-    },
-    {
-      argv: ["timeout", "5s", "env", "FOO=bar", "bash", "-lc", "echo hi"],
-      expected: true,
-    },
-    {
-      argv: ["sudo", "bash", "-lc", "echo hi"],
-      expected: false,
-    },
-  ])("detects env manipulation before shell wrappers for %j", ({ argv, expected }) => {
+    [["env", "FOO=bar", "bash", "-lc", "echo hi"], true],
+    [["timeout", "5s", "env", "--", "bash", "-lc", "echo hi"], false],
+    [["timeout", "5s", "env", "FOO=bar", "bash", "-lc", "echo hi"], true],
+    [["sudo", "bash", "-lc", "echo hi"], false],
+  ])("detects env manipulation before shell wrappers for %j", (argv, expected) => {
     expect(hasEnvManipulationBeforeShellWrapper(argv)).toBe(expected);
   });
 });
 
 describe("resolveShellWrapperTransportArgv", () => {
   test.each([
-    {
-      argv: ["env", "cmd.exe", "/d", "/s", "/c", "echo hi"],
-      expected: ["cmd.exe", "/d", "/s", "/c", "echo hi"],
-    },
-    {
-      argv: ["env", "FOO=bar", "cmd.exe", "/d", "/s", "/c", "echo hi"],
-      expected: ["cmd.exe", "/d", "/s", "/c", "echo hi"],
-    },
-    {
-      argv: ["bash", "script.sh"],
-      expected: null,
-    },
-  ])("resolves wrapper transport argv for %j", ({ argv, expected }) => {
+    [
+      ["env", "cmd.exe", "/d", "/s", "/c", "echo hi"],
+      ["cmd.exe", "/d", "/s", "/c", "echo hi"],
+    ],
+    [
+      ["env", "FOO=bar", "cmd.exe", "/d", "/s", "/c", "echo hi"],
+      ["cmd.exe", "/d", "/s", "/c", "echo hi"],
+    ],
+    [["bash", "script.sh"], null],
+  ])("resolves wrapper transport argv for %j", (argv, expected) => {
     expect(resolveShellWrapperTransportArgv(argv)).toEqual(expected);
   });
 });
 
 describe("isShellWrapperInvocation", () => {
   test.each([
-    {
-      argv: ["bash", "script.sh"],
-      expected: true,
-    },
-    {
-      argv: ["/usr/bin/env", "SHELLOPTS=xtrace", "bash", "-lc", "echo hi"],
-      expected: true,
-    },
-    {
-      argv: ["busybox", "sh", "script.sh"],
-      expected: true,
-    },
-    {
-      argv: ["/usr/bin/env", "FOO=bar", "/usr/bin/printf", "ok"],
-      expected: false,
-    },
-  ])("detects shell-wrapper executable invocations for %j", ({ argv, expected }) => {
+    [["bash", "script.sh"], true],
+    [["/usr/bin/env", "SHELLOPTS=xtrace", "bash", "-lc", "echo hi"], true],
+    [["busybox", "sh", "script.sh"], true],
+    [["/usr/bin/env", "FOO=bar", "/usr/bin/printf", "ok"], false],
+  ])("detects shell-wrapper executable invocations for %j", (argv, expected) => {
     expect(isShellWrapperInvocation(argv)).toBe(expected);
   });
 });
 
 describe("extractEnvAssignmentKeysFromDispatchWrappers", () => {
   test.each([
-    {
-      argv: ["env", "FOO=bar", "BAR=baz", "bash", "-lc", "echo hi"],
-      expected: ["BAR", "FOO"],
-    },
-    {
-      argv: ["nice", "-n", "5", "env", "-u", "PATH", "TERM=xterm", "bash", "-lc", "echo hi"],
-      expected: ["TERM"],
-    },
-    {
-      argv: ["env", "--split-string", "FOO=bar", "bash", "-lc", "echo hi"],
-      expected: [],
-    },
-    {
-      argv: ["env", "--", "bash", "-lc", "echo hi"],
-      expected: [],
-    },
-  ])("extracts env assignment prelude keys for %j", ({ argv, expected }) => {
+    [
+      ["env", "FOO=bar", "BAR=baz", "bash", "-lc", "echo hi"],
+      ["BAR", "FOO"],
+    ],
+    [["nice", "-n", "5", "env", "-u", "PATH", "TERM=xterm", "bash", "-lc", "echo hi"], ["TERM"]],
+    [["env", "--split-string", "FOO=bar", "bash", "-lc", "echo hi"], []],
+    [["env", "--", "bash", "-lc", "echo hi"], []],
+  ])("extracts env assignment prelude keys for %j", (argv, expected) => {
     expect(extractEnvAssignmentKeysFromDispatchWrappers(argv)).toEqual(expected);
   });
 });
 
 describe("extractShellWrapperCommand", () => {
   test.each([
-    {
-      argv: ["bash", "-lc", "echo hi"],
-      expectedInline: "echo hi",
-      expectedCommand: { isWrapper: true, command: null },
-    },
-    {
-      argv: ["busybox", "sh", "-lc", "echo hi"],
-      expectedInline: "echo hi",
-      expectedCommand: { isWrapper: true, command: null },
-    },
-    {
-      argv: ["env", "--", "pwsh", "-Command", "Get-Date"],
-      expectedInline: "Get-Date",
-      expectedCommand: { isWrapper: true, command: "Get-Date" },
-    },
-    {
-      argv: ["pwsh", "-Command", "allowed.exe", ";", "unlisted.exe"],
-      expectedInline: "allowed.exe ; unlisted.exe",
-      expectedCommand: { isWrapper: true, command: "allowed.exe ; unlisted.exe" },
-    },
-    {
-      argv: ["cmd.exe", "-c", "echo", "hi"],
-      expectedInline: "echo hi",
-      expectedCommand: { isWrapper: true, command: "echo hi" },
-    },
-    {
-      argv: ["cmd", "-k", "echo", "hi"],
-      expectedInline: "echo hi",
-      expectedCommand: { isWrapper: true, command: "echo hi" },
-    },
-    {
-      argv: ["tcsh", "-c", "echo hi"],
-      expectedInline: null,
-      expectedCommand: { isWrapper: false, command: null },
-    },
-    {
-      argv: ["nu", "--commands", "echo hi"],
-      expectedInline: "echo hi",
-      expectedCommand: { isWrapper: true, command: "echo hi" },
-    },
-    {
-      argv: ["nu", "--execute", "echo hi"],
-      expectedInline: "echo hi",
-      expectedCommand: { isWrapper: true, command: "echo hi" },
-    },
-    {
-      argv: ["nu", "--execute=echo Hi"],
-      expectedInline: "echo Hi",
-      expectedCommand: { isWrapper: true, command: "echo Hi" },
-    },
-    {
-      argv: ["nu", "--commands=echo hi"],
-      expectedInline: "echo hi",
-      expectedCommand: { isWrapper: true, command: "echo hi" },
-    },
-    {
-      argv: ["nu", "-e", "echo hi"],
-      expectedInline: "echo hi",
-      expectedCommand: { isWrapper: true, command: "echo hi" },
-    },
-    {
-      argv: ["nu", "--interactive", "-e", "echo hi"],
-      expectedInline: "echo hi",
-      expectedCommand: { isWrapper: true, command: null },
-    },
-    {
-      argv: ["nu", "--interactive", "--execute=echo hi"],
-      expectedInline: "echo hi",
-      expectedCommand: { isWrapper: true, command: null },
-    },
-    {
-      argv: ["elvish", "-c", "echo hi"],
-      expectedInline: "echo hi",
-      expectedCommand: { isWrapper: true, command: "echo hi" },
-    },
-    {
-      argv: ["pwsh", "-ec", "ZQBjAGgAbwA="],
-      expectedInline: "ZQBjAGgAbwA=",
-      expectedCommand: { isWrapper: true, command: "ZQBjAGgAbwA=" },
-    },
-    {
-      argv: ["pwsh", "/NoProfile", "/ec", "ZQBjAGgAbwA="],
-      expectedInline: "ZQBjAGgAbwA=",
-      expectedCommand: { isWrapper: true, command: "ZQBjAGgAbwA=" },
-    },
-    {
-      argv: ["pwsh", "-WorkingDir", "/tmp/project", "/ec", "ZQBjAGgAbwA="],
-      expectedInline: "ZQBjAGgAbwA=",
-      expectedCommand: { isWrapper: true, command: "ZQBjAGgAbwA=" },
-    },
-    {
-      argv: ["pwsh", "-if", "XML", "-EncodedCommand", "ZQBjAGgAbwA="],
-      expectedInline: "ZQBjAGgAbwA=",
-      expectedCommand: { isWrapper: true, command: "ZQBjAGgAbwA=" },
-    },
-    {
-      argv: ["pwsh", "-config", "SomeConfig", "-ec", "ZQBjAGgAbwA="],
-      expectedInline: "ZQBjAGgAbwA=",
-      expectedCommand: { isWrapper: true, command: "ZQBjAGgAbwA=" },
-    },
-    {
-      argv: ["pwsh", "-win", "hidden", "/ec", "ZQBjAGgAbwA="],
-      expectedInline: "ZQBjAGgAbwA=",
-      expectedCommand: { isWrapper: true, command: "ZQBjAGgAbwA=" },
-    },
-    {
-      argv: ["pwsh", "-ea", "stop", "-Command", "Get-Date"],
-      expectedInline: "Get-Date",
-      expectedCommand: { isWrapper: true, command: "Get-Date" },
-    },
-    {
-      argv: ["pwsh", "-ep", "Bypass", "-Command", "Get-Date"],
-      expectedInline: "Get-Date",
-      expectedCommand: { isWrapper: true, command: "Get-Date" },
-    },
-    {
-      argv: ["pwsh", "-cus", "pipe-name", "-ec", "ZQBjAGgAbwA="],
-      expectedInline: "ZQBjAGgAbwA=",
-      expectedCommand: { isWrapper: true, command: "ZQBjAGgAbwA=" },
-    },
-    {
-      argv: ["pwsh", "-to", "token-value", "-Command", "Get-Date"],
-      expectedInline: "Get-Date",
-      expectedCommand: { isWrapper: true, command: "Get-Date" },
-    },
-    {
-      argv: ["pwsh", "-utc", "1234", "-Command", "Get-Date"],
-      expectedInline: "Get-Date",
-      expectedCommand: { isWrapper: true, command: "Get-Date" },
-    },
-    {
-      argv: ["pwsh", "-encodeda", "YQByAGcA", "-Command", "Get-Date"],
-      expectedInline: "Get-Date",
-      expectedCommand: { isWrapper: true, command: "Get-Date" },
-    },
-    {
-      argv: ["pwsh", "-en", "ZQBjAGgAbwA="],
-      expectedInline: "ZQBjAGgAbwA=",
-      expectedCommand: { isWrapper: true, command: "ZQBjAGgAbwA=" },
-    },
-    {
-      argv: ["pwsh", "-File", "script.ps1", "-ExtraArg"],
-      expectedInline: "script.ps1",
-      expectedCommand: { isWrapper: true, command: "script.ps1" },
-    },
-    {
-      argv: ["pwsh", "--commandwithargs", "allowed.exe", ";", "unlisted.exe"],
-      expectedInline: "allowed.exe ; unlisted.exe",
-      expectedCommand: { isWrapper: true, command: "allowed.exe ; unlisted.exe" },
-    },
-    {
-      argv: ["pwsh", "-CommandWithArgs", "allowed.exe", ";", "unlisted.exe"],
-      expectedInline: "allowed.exe ; unlisted.exe",
-      expectedCommand: { isWrapper: true, command: "allowed.exe ; unlisted.exe" },
-    },
-    {
-      argv: ["pwsh", "-cwa", "Write-Output", "hi"],
-      expectedInline: "Write-Output hi",
-      expectedCommand: { isWrapper: true, command: "Write-Output hi" },
-    },
-    {
-      argv: ["pwsh", "script.ps1", "-en", "VwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIABoAGkA"],
-      expectedInline: null,
-      expectedCommand: { isWrapper: false, command: null },
-    },
-    {
-      argv: ["bash", "script.sh"],
-      expectedInline: null,
-      expectedCommand: { isWrapper: false, command: null },
-    },
-  ])("extracts inline commands for %j", ({ argv, expectedInline, expectedCommand }) => {
+    [["bash", "-lc", "echo hi"], "echo hi", { isWrapper: true, command: null }],
+    [["busybox", "sh", "-lc", "echo hi"], "echo hi", { isWrapper: true, command: null }],
+    [
+      ["env", "--", "pwsh", "-Command", "Get-Date"],
+      "Get-Date",
+      { isWrapper: true, command: "Get-Date" },
+    ],
+    [
+      ["pwsh", "-Command", "allowed.exe", ";", "unlisted.exe"],
+      "allowed.exe ; unlisted.exe",
+      { isWrapper: true, command: "allowed.exe ; unlisted.exe" },
+    ],
+    [["cmd.exe", "-c", "echo", "hi"], "echo hi", { isWrapper: true, command: "echo hi" }],
+    [["cmd", "-k", "echo", "hi"], "echo hi", { isWrapper: true, command: "echo hi" }],
+    [["tcsh", "-c", "echo hi"], null, { isWrapper: false, command: null }],
+    [["nu", "--commands", "echo hi"], "echo hi", { isWrapper: true, command: "echo hi" }],
+    [["nu", "--execute", "echo hi"], "echo hi", { isWrapper: true, command: "echo hi" }],
+    [["nu", "--execute=echo Hi"], "echo Hi", { isWrapper: true, command: "echo Hi" }],
+    [["nu", "--commands=echo hi"], "echo hi", { isWrapper: true, command: "echo hi" }],
+    [["nu", "-e", "echo hi"], "echo hi", { isWrapper: true, command: "echo hi" }],
+    [["nu", "--interactive", "-e", "echo hi"], "echo hi", { isWrapper: true, command: null }],
+    [["nu", "--interactive", "--execute=echo hi"], "echo hi", { isWrapper: true, command: null }],
+    [["elvish", "-c", "echo hi"], "echo hi", { isWrapper: true, command: "echo hi" }],
+    [["pwsh", "-ec", "ZQBjAGgAbwA="], "ZQBjAGgAbwA=", { isWrapper: true, command: "ZQBjAGgAbwA=" }],
+    [
+      ["pwsh", "/NoProfile", "/ec", "ZQBjAGgAbwA="],
+      "ZQBjAGgAbwA=",
+      { isWrapper: true, command: "ZQBjAGgAbwA=" },
+    ],
+    [
+      ["pwsh", "-WorkingDir", "/tmp/project", "/ec", "ZQBjAGgAbwA="],
+      "ZQBjAGgAbwA=",
+      { isWrapper: true, command: "ZQBjAGgAbwA=" },
+    ],
+    [
+      ["pwsh", "-if", "XML", "-EncodedCommand", "ZQBjAGgAbwA="],
+      "ZQBjAGgAbwA=",
+      { isWrapper: true, command: "ZQBjAGgAbwA=" },
+    ],
+    [
+      ["pwsh", "-config", "SomeConfig", "-ec", "ZQBjAGgAbwA="],
+      "ZQBjAGgAbwA=",
+      { isWrapper: true, command: "ZQBjAGgAbwA=" },
+    ],
+    [
+      ["pwsh", "-win", "hidden", "/ec", "ZQBjAGgAbwA="],
+      "ZQBjAGgAbwA=",
+      { isWrapper: true, command: "ZQBjAGgAbwA=" },
+    ],
+    [
+      ["pwsh", "-ea", "stop", "-Command", "Get-Date"],
+      "Get-Date",
+      { isWrapper: true, command: "Get-Date" },
+    ],
+    [
+      ["pwsh", "-ep", "Bypass", "-Command", "Get-Date"],
+      "Get-Date",
+      { isWrapper: true, command: "Get-Date" },
+    ],
+    [
+      ["pwsh", "-cus", "pipe-name", "-ec", "ZQBjAGgAbwA="],
+      "ZQBjAGgAbwA=",
+      { isWrapper: true, command: "ZQBjAGgAbwA=" },
+    ],
+    [
+      ["pwsh", "-to", "token-value", "-Command", "Get-Date"],
+      "Get-Date",
+      { isWrapper: true, command: "Get-Date" },
+    ],
+    [
+      ["pwsh", "-utc", "1234", "-Command", "Get-Date"],
+      "Get-Date",
+      { isWrapper: true, command: "Get-Date" },
+    ],
+    [
+      ["pwsh", "-encodeda", "YQByAGcA", "-Command", "Get-Date"],
+      "Get-Date",
+      { isWrapper: true, command: "Get-Date" },
+    ],
+    [["pwsh", "-en", "ZQBjAGgAbwA="], "ZQBjAGgAbwA=", { isWrapper: true, command: "ZQBjAGgAbwA=" }],
+    [
+      ["pwsh", "-File", "script.ps1", "-ExtraArg"],
+      "script.ps1",
+      { isWrapper: true, command: "script.ps1" },
+    ],
+    [
+      ["pwsh", "--commandwithargs", "allowed.exe", ";", "unlisted.exe"],
+      "allowed.exe ; unlisted.exe",
+      { isWrapper: true, command: "allowed.exe ; unlisted.exe" },
+    ],
+    [
+      ["pwsh", "-CommandWithArgs", "allowed.exe", ";", "unlisted.exe"],
+      "allowed.exe ; unlisted.exe",
+      { isWrapper: true, command: "allowed.exe ; unlisted.exe" },
+    ],
+    [
+      ["pwsh", "-cwa", "Write-Output", "hi"],
+      "Write-Output hi",
+      { isWrapper: true, command: "Write-Output hi" },
+    ],
+    [
+      ["pwsh", "script.ps1", "-en", "VwByAGkAdABlAC0ATwB1AHQAcAB1AHQAIABoAGkA"],
+      null,
+      { isWrapper: false, command: null },
+    ],
+    [["bash", "script.sh"], null, { isWrapper: false, command: null }],
+  ])("extracts inline commands for %j", (argv, expectedInline, expectedCommand) => {
     expect(extractShellWrapperInlineCommand(argv)).toBe(expectedInline);
     expect(extractShellWrapperCommand(argv)).toEqual(expectedCommand);
   });


### PR DESCRIPTION
## What Problem This Solves

The exec-wrapper tests repeat large object fixtures for a dense matrix of equivalent cases, making the security-sensitive wrapper policy harder to audit and maintain.

## Why This Change Was Made

Compacts the existing parameterized cases into positional tuples while preserving every input, expectation, platform branch, and assertion. Production behavior is unchanged.

## User Impact

No user-visible behavior change. The same exec-wrapper contracts remain covered with 128 fewer test lines.

## Evidence

- `pnpm exec vitest run src/infra/exec-wrapper-resolution.test.ts` — 164/164 passed
- `pnpm check:changed` — passed
- P3 autoreview — clean, no actionable findings

