### PR TITLE
fix(release): verify companion-owned packed imports

### DIFF
--- a/scripts/openclaw-npm-postpublish-verify.ts
+++ b/scripts/openclaw-npm-postpublish-verify.ts
@@ -464,6 +464,7 @@ export async function verifyNpmProvenanceAttestation(params: {
 }
 
 export function collectInstalledPackageErrors(params: {
+  additionalCompanionManifestRoots?: string[];
   expectedVersion: string;
   installedVersion: string;
   packageRoot: string;
@@ -487,7 +488,12 @@ export function collectInstalledPackageErrors(params: {
   errors.push(...collectInstalledAlwaysAllowedRuntimeFacadeErrors(params.packageRoot));
   errors.push(...collectInstalledContextEngineRuntimeErrors(params.packageRoot));
   errors.push(...collectInstalledPluginSdkDeclarationErrors(params.packageRoot));
-  errors.push(...collectInstalledRootDependencyManifestErrors(params.packageRoot));
+  errors.push(
+    ...collectInstalledRootDependencyManifestErrors(
+      params.packageRoot,
+      params.additionalCompanionManifestRoots,
+    ),
+  );
 
   return [...new Set(errors)];
 }
@@ -690,7 +696,10 @@ function extractJavaScriptImportSpecifiers(source: string): ParsedImportSpecifie
   }
 }
 
-export function collectInstalledRootDependencyManifestErrors(packageRoot: string): string[] {
+export function collectInstalledRootDependencyManifestErrors(
+  packageRoot: string,
+  additionalCompanionManifestRoots: string[] = [],
+): string[] {
   const packageJsonPath = join(packageRoot, "package.json");
   if (!existsSync(packageJsonPath)) {
     return ["installed package is missing package.json."];
@@ -718,6 +727,10 @@ export function collectInstalledRootDependencyManifestErrors(packageRoot: string
   const missingImporters = new Map<string, Set<string>>();
   const bundledExtensionRuntimeDependencyOwners =
     collectBundledExtensionRuntimeDependencyOwners(packageRoot);
+  const companionManifestRoots = [
+    join(packageRoot, "..", "@openclaw"),
+    ...additionalCompanionManifestRoots,
+  ];
   const companionManifestCache = new Map<string, InstalledPackageJson | null>();
   let runtimeDependencyOwnership: RuntimeDependencyOwnership | null;
   try {
@@ -797,7 +810,7 @@ export function collectInstalledRootDependencyManifestErrors(packageRoot: string
               isInstalledCompanionExtensionOwnedRuntimeImport({
                 dependencyName,
                 extensionId,
-                packageRoot,
+                manifestRoots: companionManifestRoots,
                 manifestCache: companionManifestCache,
               }),
           ))
@@ -821,13 +834,24 @@ export function collectInstalledRootDependencyManifestErrors(packageRoot: string
 function isInstalledCompanionExtensionOwnedRuntimeImport(params: {
   dependencyName: string;
   extensionId: string;
-  packageRoot: string;
+  manifestRoots: string[];
   manifestCache: Map<string, InstalledPackageJson | null>;
 }): boolean {
   const extensionId = params.extensionId;
-  let manifest = params.manifestCache.get(extensionId);
-  if (manifest === undefined) {
-    const manifestPath = join(params.packageRoot, "..", "@openclaw", extensionId, "package.json");
+  for (const manifestRoot of params.manifestRoots) {
+    const cacheKey = `${manifestRoot}\0${extensionId}`;
+    let manifest = params.manifestCache.get(cacheKey);
+    if (manifest !== undefined) {
+      if (
+        manifest &&
+        (Object.hasOwn(manifest.dependencies ?? {}, params.dependencyName) ||
+          Object.hasOwn(manifest.optionalDependencies ?? {}, params.dependencyName))
+      ) {
+        return true;
+      }
+      continue;
+    }
+    const manifestPath = join(manifestRoot, extensionId, "package.json");
     manifest = null;
     if (existsSync(manifestPath)) {
       const stat = lstatSync(manifestPath);
@@ -842,13 +866,16 @@ function isInstalledCompanionExtensionOwnedRuntimeImport(params: {
         }
       }
     }
-    params.manifestCache.set(extensionId, manifest);
+    params.manifestCache.set(cacheKey, manifest);
+    if (
+      manifest &&
+      (Object.hasOwn(manifest.dependencies ?? {}, params.dependencyName) ||
+        Object.hasOwn(manifest.optionalDependencies ?? {}, params.dependencyName))
+    ) {
+      return true;
+    }
   }
-  return Boolean(
-    manifest &&
-    (Object.hasOwn(manifest.dependencies ?? {}, params.dependencyName) ||
-      Object.hasOwn(manifest.optionalDependencies ?? {}, params.dependencyName)),
-  );
+  return false;
 }
 
 function collectBundledExtensionRuntimeDependencyOwners(

--- a/scripts/release-check.ts
+++ b/scripts/release-check.ts
@@ -631,6 +631,7 @@ export function createPackedCompletionSmokeEnv(
 }
 
 export function collectPackedInstalledPackageVerificationErrors(params: {
+  additionalCompanionManifestRoots?: string[];
   expectedVersion: string;
   installedBinaryVersion?: string;
   packageRoot: string;
@@ -639,6 +640,7 @@ export function collectPackedInstalledPackageVerificationErrors(params: {
     readFileSync(join(params.packageRoot, "package.json"), "utf8"),
   ) as { version?: string };
   const errors = collectInstalledPackageErrors({
+    additionalCompanionManifestRoots: params.additionalCompanionManifestRoots,
     expectedVersion: params.expectedVersion,
     installedVersion: packageJson.version?.trim() ?? "",
     packageRoot: params.packageRoot,
@@ -674,6 +676,9 @@ function verifyPackedInstalledPackage(params: {
     },
   ).trim();
   const errors = collectPackedInstalledPackageVerificationErrors({
+    // The selected source checkout is immutable release input. Its companion
+    // manifests are the exact inputs packed by the following plugin preflight.
+    additionalCompanionManifestRoots: [resolve("extensions")],
     expectedVersion: params.expectedVersion,
     installedBinaryVersion,
     packageRoot: params.packageRoot,

--- a/test/openclaw-npm-postpublish-verify.test.ts
+++ b/test/openclaw-npm-postpublish-verify.test.ts
@@ -1203,6 +1203,28 @@ describe("collectInstalledRootDependencyManifestErrors", () => {
     },
   );
 
+  it("accepts byte-matched ownership from an additional trusted companion manifest root", () => {
+    const { installRoot, packageRoot } = makeCompanionImportFixture({
+      companions: [],
+      ownership: companionOwnership,
+      source: companionSource,
+    });
+    const trustedManifestRoot = join(installRoot, "trusted-extensions");
+    writePackageFile(trustedManifestRoot, "discord/package.json", {
+      name: "@openclaw/discord",
+      version: "2026.7.33",
+      dependencies: { "@discordjs/voice": "0.19.2" },
+    });
+
+    try {
+      expect(
+        collectInstalledRootDependencyManifestErrors(packageRoot, [trustedManifestRoot]),
+      ).toStrictEqual([]);
+    } finally {
+      rmSync(installRoot, { recursive: true, force: true });
+    }
+  });
+
   it.each<{
     name: string;
     companions: Array<{ id: string; name?: string; dependencies: Record<string, string> }>;


### PR DESCRIPTION
## Summary
- allow the packed-package verifier to consult trusted companion manifests from the immutable source checkout
- retain byte-exact runtime ownership validation
- fix 2026.7.33 npm preflight run 34199158201

## Validation
- pnpm lint:scripts
- pnpm vitest run test/openclaw-npm-postpublish-verify.test.ts test/release-check.test.ts (211 passed)
- exact 2026.7.33 candidate package verification clears the Discord and Teams ownership errors