### PR TITLE
fix(e2e): align Bun install smoke with Node runtime policy

### DIFF
--- a/scripts/e2e/bun-global-install-smoke.sh
+++ b/scripts/e2e/bun-global-install-smoke.sh
@@ -37,6 +37,7 @@ INSTALL_LOG=""
 UNTRUSTED_LOG=""
 CLI_STATUS_LOG=""
 CLI_PLUGINS_LOG=""
+DIRECT_BUN_LOG=""
 MOCK_LOG=""
 MOCK_REQUEST_LOG=""
 LOCAL_AGENT_LOG=""
@@ -64,6 +65,7 @@ dump_debug_logs() {
     "$UNTRUSTED_LOG" \
     "$CLI_STATUS_LOG" \
     "$CLI_PLUGINS_LOG" \
+    "$DIRECT_BUN_LOG" \
     "$MOCK_LOG" \
     "$MOCK_REQUEST_LOG" \
     "$LOCAL_AGENT_LOG" \
@@ -334,20 +336,22 @@ NODE
   echo "==> OpenClaw help through Bun global install"
   run_with_timeout "$COMMAND_TIMEOUT_MS" "$openclaw_bin" --help >/dev/null
 
-  run_bun_cli() {
-    run_with_timeout "$COMMAND_TIMEOUT_MS" "$bun_path" "$openclaw_entry" "$@"
+  run_installed_cli() {
+    run_with_timeout "$COMMAND_TIMEOUT_MS" "$openclaw_bin" "$@"
   }
 
-  echo "==> Installed package entry under Bun"
-  run_bun_cli --version
-  run_bun_cli --help >/dev/null
-  pushd "$HOME" >/dev/null
-  run_with_timeout "$COMMAND_TIMEOUT_MS" "$bun_path" run --bun openclaw --version
-  popd >/dev/null
+  echo "==> Installed package rejects direct Bun runtime execution"
+  DIRECT_BUN_LOG="$SMOKE_DIR/direct-bun.log"
+  if run_with_timeout "$COMMAND_TIMEOUT_MS" "$bun_path" "$openclaw_entry" --version \
+    >"$DIRECT_BUN_LOG" 2>&1; then
+    echo "OpenClaw unexpectedly ran under the unsupported Bun runtime" >&2
+    exit 1
+  fi
+  grep -F "Bun runtime is unsupported" "$DIRECT_BUN_LOG" >/dev/null
 
-  echo "==> OpenClaw image providers under Bun"
+  echo "==> OpenClaw image providers from Bun global install"
   local providers_json
-  providers_json="$(run_bun_cli infer image providers --json)"
+  providers_json="$(run_installed_cli infer image providers --json)"
   OPENCLAW_IMAGE_PROVIDERS_JSON="$providers_json" node scripts/e2e/lib/bun-global-install/assertions.mjs assert-image-providers
 
   read -r gateway_port mock_port < <(reserve_runtime_ports)
@@ -359,15 +363,15 @@ NODE
     "$mock_port" \
     "$gateway_port"
 
-  echo "==> Representative CLI state under Bun"
-  run_bun_cli status --json --timeout 1 >"$CLI_STATUS_LOG" 2>&1
-  run_bun_cli plugins list --json >"$CLI_PLUGINS_LOG" 2>&1
+  echo "==> Representative CLI state from Bun global install"
+  run_installed_cli status --json --timeout 1 >"$CLI_STATUS_LOG" 2>&1
+  run_installed_cli plugins list --json >"$CLI_PLUGINS_LOG" 2>&1
 
-  echo "==> Local mocked agent turn under Bun"
+  echo "==> Local mocked agent turn from Bun global install"
   MOCK_PID="$(openclaw_e2e_start_mock_openai "$mock_port" "$MOCK_LOG")"
   openclaw_e2e_wait_mock_openai "$mock_port"
   : >"$MOCK_REQUEST_LOG"
-  run_bun_cli agent --local \
+  run_installed_cli agent --local \
     --agent main \
     --session-id bun-global-local-agent \
     --message "Return marker $success_marker" \
@@ -379,22 +383,21 @@ NODE
     "$LOCAL_AGENT_LOG" \
     "$MOCK_REQUEST_LOG"
 
-  echo "==> Gateway health and mocked agent turn under Bun"
+  echo "==> Gateway health and mocked agent turn from Bun global install"
   : >"$MOCK_REQUEST_LOG"
   GATEWAY_PID="$(
     openclaw_e2e_start_tracked_process \
       "$GATEWAY_LOG" \
-      "$bun_path" \
-      "$openclaw_entry" \
+      "$openclaw_bin" \
       gateway \
       --port "$gateway_port" \
       --bind loopback
   )"
   openclaw_e2e_wait_gateway_ready "$GATEWAY_PID" "$GATEWAY_LOG" 300 "$gateway_port"
-  run_bun_cli gateway health \
+  run_installed_cli gateway health \
     --token "$OPENCLAW_GATEWAY_TOKEN" \
     --json >"$GATEWAY_HEALTH_LOG" 2>&1
-  run_bun_cli agent \
+  run_installed_cli agent \
     --agent main \
     --session-id bun-global-gateway-agent \
     --message "Return marker $success_marker" \
@@ -406,7 +409,7 @@ NODE
     "$GATEWAY_AGENT_LOG" \
     "$MOCK_REQUEST_LOG"
 
-  echo "bun-global-install-smoke: Bun $bun_version package, CLI, local agent, and Gateway runtime OK"
+  echo "bun-global-install-smoke: Bun $bun_version package install and Node CLI/runtime OK"
 
   if [ -n "${OPENCLAW_BUN_GLOBAL_SMOKE_PROOF_PATH:-}" ]; then
     node --input-type=module - \

--- a/test/scripts/test-install-sh-docker.test.ts
+++ b/test/scripts/test-install-sh-docker.test.ts
@@ -2568,38 +2568,8 @@ if [[ "\${1:-}" == */verify-fs-safe-native.mjs ]]; then
   exit 0
 fi
 if [[ "\${1:-}" == */openclaw.mjs ]]; then
-  shift
-  if [ "\${1:-}" = "--version" ]; then
-    echo "OpenClaw 2026.6.17"
-  elif [ "\${1:-}" = "--help" ]; then
-    echo "Usage: openclaw"
-  elif [ "\${1:-}" = "infer" ]; then
-    printf '[{"id":"google"},{"id":"openai"},{"id":"xai"}]\n'
-  elif [ "\${1:-}" = "status" ] && [ "$FAKE_STATUS_EXIT" != "0" ]; then
-    echo "synthetic Bun status failure" >&2
-    exit "$FAKE_STATUS_EXIT"
-  elif [ "\${1:-}" = "status" ] || { [ "\${1:-}" = "plugins" ] && [ "\${2:-}" = "list" ]; }; then
-    echo '{}'
-  elif [ "\${1:-}" = "agent" ]; then
-    printf '{"path":"/v1/responses"}\n' >>"$MOCK_REQUEST_LOG"
-    printf '{"payloads":[{"text":"%s"}]}\n' "$SUCCESS_MARKER"
-  elif [ "\${1:-}" = "gateway" ] && [ "\${2:-}" = "health" ]; then
-    echo '{"ok":true}'
-  elif [ "\${1:-}" = "gateway" ]; then
-    port=""
-    while [ "$#" -gt 0 ]; do
-      if [ "$1" = "--port" ]; then
-        port="$2"
-        break
-      fi
-      shift
-    done
-    exec node -e 'const http=require("node:http"); const port=Number(process.argv[1]); http.createServer((req,res)=>{res.writeHead(200,{"content-type":"text/plain"});res.end("ok")}).listen(port,"127.0.0.1",()=>console.log("[gateway] ready at http://127.0.0.1:"+port))' "$port"
-  else
-    echo "unsupported fake OpenClaw command: $*" >&2
-    exit 1
-  fi
-  exit 0
+  echo "openclaw: the Bun runtime is unsupported because OpenClaw requires node:sqlite." >&2
+  exit 1
 fi
 test "\${1:-}" = "install"
 case " $* " in
@@ -2632,6 +2602,9 @@ exports.redactSensitiveText = (text) => text;
 REDACTOR
 cat >"$package_root/openclaw.mjs" <<'OPENCLAW'
 #!/usr/bin/env node
+import fs from "node:fs";
+import http from "node:http";
+
 const args = process.argv.slice(2);
 if (args[0] === "--version") {
   console.log("OpenClaw 2026.6.17");
@@ -2639,6 +2612,23 @@ if (args[0] === "--version") {
   console.log("Usage: openclaw");
 } else if (args[0] === "infer") {
   console.log(JSON.stringify([{ id: "google" }, { id: "openai" }, { id: "xai" }]));
+} else if (args[0] === "status" && process.env.FAKE_STATUS_EXIT !== "0") {
+  console.error("synthetic Bun status failure");
+  process.exit(Number(process.env.FAKE_STATUS_EXIT));
+} else if (args[0] === "status" || (args[0] === "plugins" && args[1] === "list")) {
+  console.log("{}");
+} else if (args[0] === "agent") {
+  fs.appendFileSync(process.env.MOCK_REQUEST_LOG, '{"path":"/v1/responses"}\\n');
+  console.log(JSON.stringify({ payloads: [{ text: process.env.SUCCESS_MARKER }] }));
+} else if (args[0] === "gateway" && args[1] === "health") {
+  console.log('{"ok":true}');
+} else if (args[0] === "gateway") {
+  const port = Number(args[args.indexOf("--port") + 1]);
+  http.createServer((_req, res) => {
+      res.writeHead(200, { "content-type": "text/plain" });
+      res.end("ok");
+    })
+    .listen(port, "127.0.0.1", () => console.log("[gateway] ready at http://127.0.0.1:" + port));
 } else {
   process.exit(1);
 }
@@ -2673,13 +2663,13 @@ node -e 'const fs=require("node:fs");const p=process.argv[1];const value=JSON.pa
     expect(result.stdout).toContain("bun-global-install-smoke: image providers OK (3 providers)");
     if (statusExit === 0) {
       expect(result.stdout).toContain(
-        "bun-global-install-smoke: Bun 1.4.0 package, CLI, local agent, and Gateway runtime OK",
+        "bun-global-install-smoke: Bun 1.4.0 package install and Node CLI/runtime OK",
       );
     } else {
       expect(result.stderr).toContain("bun global install smoke failed with exit code 23");
       expect(result.stderr).toContain("synthetic Bun status failure");
       expect(result.stderr).not.toContain("failure log omitted");
-      expect(result.stdout).not.toContain("Gateway runtime OK");
+      expect(result.stdout).not.toContain("Node CLI/runtime OK");
     }
   });
 


### PR DESCRIPTION
## Summary
- keep Bun global installation and lifecycle trust coverage
- assert direct Bun runtime execution is rejected as intended
- run CLI, local-agent, and gateway checks through the installed Node launcher
- fix the Bun smoke failure in full validation run 34199266455

## Validation
- bash -n scripts/e2e/bun-global-install-smoke.sh
- pnpm lint:scripts
- three affected prebuilt-package fixture lanes pass