### PR TITLE
fix(build): externalize Zod SDK declarations

### DIFF
--- a/test/scripts/tsdown-config.test.ts
+++ b/test/scripts/tsdown-config.test.ts
@@ -36,4 +36,15 @@ describe("tsdown config", () => {
       expect(entry.outExtensions?.(context)).toEqual({ js: ".js", dts: ".d.ts" });
     }
   });
+
+  it("externalizes Zod declarations while retaining bundled runtime output", () => {
+    const unifiedConfig = configs.at(-1) as {
+      deps?: { dts?: { neverBundle?: (id: string) => boolean } };
+    };
+    const neverBundleDeclaration = unifiedConfig.deps?.dts?.neverBundle;
+
+    expect(neverBundleDeclaration?.("zod")).toBe(true);
+    expect(neverBundleDeclaration?.("zod/v4/core")).toBe(true);
+    expect(neverBundleDeclaration?.("unrelated-package")).toBe(false);
+  });
 });

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -218,6 +218,10 @@ function shouldNeverBundleDependency(id: string): boolean {
   });
 }
 
+function shouldNeverBundleDeclarationDependency(id: string): boolean {
+  return shouldNeverBundleDependency(id) || id === "zod" || id.startsWith("zod/");
+}
+
 function shouldAlwaysBundleDependency(id: string): boolean {
   return (
     id === "@openclaw/fs-safe" ||
@@ -793,7 +797,7 @@ const configs = [
       alwaysBundle: shouldAlwaysBundleDependency,
       neverBundle: shouldNeverBundleDependency,
       // Keep dts generation from inlining externalized package types.
-      dts: { neverBundle: shouldNeverBundleDependency },
+      dts: { neverBundle: shouldNeverBundleDeclarationDependency },
     },
   }),
 ] satisfies UserConfig[];


### PR DESCRIPTION
## Summary
- externalize Zod only from declaration bundling while retaining bundled runtime output
- backport the focused declaration behavior already used on main
- prevent malformed bundled Zod variance directives from failing the packed SDK consumer smoke

## Validation
- tsdown config tests: 5 passed
- full build:plugin-sdk:strict-smoke
- all 4 required plugin SDK exports verified