### PR TITLE
test(plugins): drain task heartbeat wakes in the runtime task harness

### DIFF
--- a/src/plugins/runtime/runtime-task-test-harness.ts
+++ b/src/plugins/runtime/runtime-task-test-harness.ts
@@ -1,5 +1,10 @@
 // Runtime task test harness helpers build mocked plugin runtimes for task-flow tests.
-import { vi } from "vitest";
+import { expect, vi } from "vitest";
+import {
+  type HeartbeatWakeRequest,
+  requestHeartbeat,
+  setHeartbeatWakeHandler,
+} from "../../infra/heartbeat-wake.js";
 import {
   resetDetachedTaskLifecycleRuntimeForTests,
   resetTaskFlowRegistryForTests,
@@ -14,13 +19,25 @@ const runtimeTaskMocks = vi.hoisted(() => ({
   sendMessageMock: vi.fn(),
   cancelSessionMock: vi.fn(),
   killSubagentRunAdminMock: vi.fn(),
+  heartbeatWakeMock: vi.fn(async (_request: HeartbeatWakeRequest) => ({
+    status: "skipped" as const,
+    reason: "disabled",
+  })),
 }));
+
+const HEARTBEAT_FLUSH_REASON = "runtime-task-test-flush";
+let disposeHeartbeatWakeHandler: (() => void) | undefined;
 
 export function getRuntimeTaskMocks() {
   return runtimeTaskMocks;
 }
 
 export function installRuntimeTaskDeliveryMock(): void {
+  // Terminal task delivery requests heartbeat wakes. Consume them here: a wake left
+  // pending with no handler is delivered to the next handler any later test file in
+  // the shared worker installs, and that file then observes a foreign wake.
+  disposeHeartbeatWakeHandler?.();
+  disposeHeartbeatWakeHandler = setHeartbeatWakeHandler(runtimeTaskMocks.heartbeatWakeMock);
   setTaskRegistryDeliveryRuntimeForTests({
     sendMessage: runtimeTaskMocks.sendMessageMock,
   });
@@ -37,11 +54,34 @@ export function installRuntimeTaskDeliveryMock(): void {
 // Skipping the reset write leaves those rows behind, and the next
 // ensureTaskRegistryReady() restores them into the process registry as active
 // restart blockers for every later test file in the same worker.
-export function resetRuntimeTaskTestState(): void {
+export async function resetRuntimeTaskTestState(): Promise<void> {
+  await flushHeartbeatWakeRequests();
+  disposeHeartbeatWakeHandler?.();
+  disposeHeartbeatWakeHandler = undefined;
   resetDetachedTaskLifecycleRuntimeForTests();
   resetTaskRegistryControlRuntimeForTests();
   resetTaskRegistryDeliveryRuntimeForTests();
   resetTaskRegistryForTests();
   resetTaskFlowRegistryForTests();
   vi.clearAllMocks();
+}
+
+// A sentinel wake proves every earlier pending wake was delivered to this file's handler.
+async function flushHeartbeatWakeRequests(): Promise<void> {
+  if (!disposeHeartbeatWakeHandler) {
+    return;
+  }
+  requestHeartbeat({
+    source: "other",
+    intent: "immediate",
+    reason: HEARTBEAT_FLUSH_REASON,
+    coalesceMs: 0,
+  });
+  await vi.waitFor(() => {
+    expect(
+      runtimeTaskMocks.heartbeatWakeMock.mock.calls.some(
+        ([request]) => request.reason === HEARTBEAT_FLUSH_REASON,
+      ),
+    ).toBe(true);
+  });
 }

--- a/src/plugins/runtime/runtime-taskflow.test.ts
+++ b/src/plugins/runtime/runtime-taskflow.test.ts
@@ -21,8 +21,8 @@ function requireCreatedFlow<T>(flow: T | null): T {
   return flow;
 }
 
-afterEach(() => {
-  resetRuntimeTaskTestState();
+afterEach(async () => {
+  await resetRuntimeTaskTestState();
 });
 
 describe("runtime TaskFlow", () => {

--- a/src/plugins/runtime/runtime-tasks.test.ts
+++ b/src/plugins/runtime/runtime-tasks.test.ts
@@ -16,8 +16,8 @@ import { createRuntimeTasks } from "./runtime-tasks.js";
 
 const runtimeTaskMocks = getRuntimeTaskMocks();
 
-afterEach(() => {
-  resetRuntimeTaskTestState();
+afterEach(async () => {
+  await resetRuntimeTaskTestState();
 });
 
 const requireRecord = createRequireRecord("record", "expected-non-array-record");


### PR DESCRIPTION
## What Problem This Solves

`src/plugins/runtime/index.test.ts` ("maps deprecated runtime.system.requestHeartbeatNow to an immediate compatibility wake") fails intermittently in the `plugins` lane with:

```
expected 'background-task' to be 'other'
```

It passes alone. Running the two plugin runtime task suites first on one worker reproduces it (1 of 2 attempts locally; the full lane hit it in a sweep of `d662d575372`).

Instrumenting `enqueueRequest` in `src/infra/session-event-wake.ts` shows three `background-task` wakes enqueued with **no handler installed**, from `updateTaskStateByRunId` → `maybeDeliverTaskTerminalUpdate` → `queueTaskSystemEvent` → `requestHeartbeat`, during the runtime task tests. Installing a wake handler intentionally re-arms every pending wake and schedules delivery (`setSessionEventWakeHandler`), so those wakes are delivered to whichever handler a later file in the shared worker installs — `index.test.ts` reads its handler's first call and sees the foreign wake.

## Why This Change Was Made

The producer is the plugin runtime task harness: `installRuntimeTaskDeliveryMock` mocked message delivery but not the heartbeat wake the terminal-update path requests. `src/tasks/task-registry.test.ts` already handles this correctly (handler in `beforeEach`, sentinel-wake drain, dispose in `afterEach`). The harness now does the same: it installs a wake handler alongside the delivery mock and `resetRuntimeTaskTestState` drains with a sentinel wake (Vitest's `vi.waitFor`) before disposing. `resetRuntimeTaskTestState` becomes async; its two callers await it.

No production change. No new test-only production seam.

## User Impact

None at runtime. Removes an order-dependent red in the plugins lane for anyone running it in the non-isolated worker.

## Evidence

- Pre-fix: `OPENCLAW_VITEST_MAX_WORKERS=1 node scripts/run-vitest.mjs src/plugins/runtime/runtime-tasks.test.ts src/plugins/runtime/runtime-taskflow.test.ts src/plugins/runtime/index.test.ts` fails on the `requestHeartbeatNow` case (timing-dependent; 1/2 locally); the full `src/plugins` lane failed the same case once in a sweep.
- Probe (temporary `process.stderr.write` in `enqueueRequest`, with Vitest worker attribution): 3 × `source=background-task handler=false`, all from `src/plugins/runtime/runtime-tasks.test.ts` ("routes runtime task cancellation through the detached task runtime seam", "maps task cancellation results onto canonical task DTOs", "isolates task runs for agents sharing a bare session key"); stack through `task-registry-delivery.ts` and `task-registry-record-api.ts:updateTaskStateByRunId`.
- Post-fix: the same one-worker sequence passes 3/3; both harness users pass alone; `check-changed` on the three touched files passes.

Test-only change, production LOC 0.

Review: independent Codex autoreview (local mode, P0–P2) is scoped-clean with no actionable findings.
