### PR TITLE
docs(mac): describe the streamed installer re-exec instead of a /bin/bash requirement

### DIFF
--- a/docs/platforms/mac/dev-setup.md
+++ b/docs/platforms/mac/dev-setup.md
@@ -22,8 +22,9 @@ macOS shell tooling uses the system `/bin/bash` (3.2); Homebrew Bash is not
 required. Run scripts directly or with `/bin/bash`. Bash 5.3+ can stall on a
 heredoc before its reader starts, leaving packaging or signing logs empty under
 pipe-buffer pressure. Portable script entrypoints switch to `/bin/bash` on
-macOS; streamed installers must use `curl ... | /bin/bash` because consumed stdin
-cannot be replayed.
+macOS, and the streamed installers (`curl ... | bash`) do the same by capturing
+the rest of their input into a private temporary file before re-executing, so
+the documented install commands need no change.
 
 ## 1. Install dependencies
 


### PR DESCRIPTION
## Problem

`docs/platforms/mac/dev-setup.md` still said streamed installers "must use `curl ... | /bin/bash` because consumed stdin cannot be replayed". That sentence predates the final shape of #141884, where `scripts/install.sh` and `scripts/install-cli.sh` capture the rest of their stdin into a private temporary file and re-exec under `/bin/bash` on macOS, so the public `curl ... | bash` commands stay as they are.

## Solution

One sentence rewritten to describe the shipped behavior.

## Impact

Docs only; no code changes.

## Evidence

`git diff --check` clean. The described behavior is the merged guard in `scripts/install.sh` (`OPENCLAW_INSTALLER_REEXEC_FILE`, `{ printf '#!/bin/bash\n'; cat; } > "$file"; exec /bin/bash "$file" "$@"`).
