### PR TITLE
fix(ui): update the expanded file preview tooltip

### DIFF
--- a/ui/src/e2e/agent-file-lifecycle.e2e.test.ts
+++ b/ui/src/e2e/agent-file-lifecycle.e2e.test.ts
@@ -1,5 +1,7 @@
 // Control UI E2E tests cover visible agent-file save outcomes and agent ownership.
+import type WaTooltip from "@awesome.me/webawesome/dist/components/tooltip/tooltip.js";
 import { expect, it } from "vitest";
+import { waitForControlUiProofSurface } from "../test-helpers/control-ui-e2e-screenshot.ts";
 import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
 import {
   agentFileProofDir,
@@ -10,6 +12,7 @@ import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts"
 
 const suite = createControlUiE2eSuite({
   name: "Control UI agent file lifecycle",
+  browserLaunchOptions: { headless: true },
   startServerBeforeBrowser: true,
   unavailableMessage: (executablePath) =>
     `Playwright Chromium is not available at ${executablePath}`,
@@ -65,6 +68,147 @@ function fileGetResponses(mainContent: string) {
 }
 
 suite.define(() => {
+  it("keeps preview tooltip aligned with its expand state", async () => {
+    await suite.withPage(
+      {
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1440 },
+        ...(agentFileProofDir
+          ? { recordVideo: { dir: agentFileProofDir, size: { height: 900, width: 1440 } } }
+          : {}),
+      },
+      async ({ page }) => {
+        const content = "# Preview tooltip fixture\n\nSynthetic preview instructions.\n";
+        const gateway = await installMockGateway(page, {
+          featureMethods: [
+            "agents.files.get",
+            "agents.files.list",
+            "agents.files.set",
+            "agents.list",
+          ],
+          methodResponses: {
+            "agents.list": {
+              defaultId: "main",
+              mainKey: "main",
+              scope: "per-sender",
+              agents: [{ id: "main", name: "Main" }],
+            },
+            "agents.files.get": fileGetResponses(content),
+            "agents.files.list": fileListResponses,
+          },
+          operatorScopes: ["operator.admin", "operator.read", "operator.write"],
+        });
+        await page.goto(`${suite.server.baseUrl}settings/agents/main/files`);
+        const editor = page.locator(".agent-file-textarea");
+        await expect.poll(() => editor.inputValue()).toBe(content);
+        const read = await gateway.waitForRequest("agents.files.get");
+        expect(read.params).toMatchObject({ agentId: "main", name: "AGENTS.md" });
+        const preview = page
+          .locator(".agent-file-actions")
+          .getByRole("button", { name: "Preview", exact: true });
+        const modal = page.locator("openclaw-modal-dialog:has(.md-preview-expand-btn)");
+        const dialog = modal.locator("dialog");
+        const panel = modal.locator(".md-preview-dialog__panel");
+        const reader = modal.locator(".md-preview-dialog__reader");
+        const expand = modal.locator(".md-preview-expand-btn");
+        const tooltip = modal.locator("openclaw-tooltip:has(.md-preview-expand-btn) wa-tooltip");
+        const body = tooltip.locator('[part="body"]');
+        const popup = tooltip.locator('wa-popup [part="popup"]');
+        const hint = tooltip.locator(".tooltip-content");
+        const settlePreview = async () => {
+          await waitForControlUiProofSurface(dialog, [reader]);
+          await waitForControlUiProofSurface(panel, [reader]);
+        };
+        const assertHint = async (label: string, screenshot: string) => {
+          await reader.hover();
+          await expand.hover();
+          await waitForControlUiProofSurface(popup, [body, hint, expand]);
+          const trigger = await expand.elementHandle();
+          expect(trigger).not.toBeNull();
+          try {
+            expect(
+              await tooltip.evaluate(
+                (element, anchor) => (element as WaTooltip).anchor === anchor,
+                trigger,
+              ),
+            ).toBe(true);
+          } finally {
+            await trigger?.dispose();
+          }
+          // Capture the real baseline mismatch before its expected-correct assertion fails.
+          await captureAgentFileScreenshot(page, screenshot);
+          expect((await hint.textContent())?.trim()).toBe(label);
+          expect(await expand.getAttribute("aria-label")).toBe(label);
+          expect(await hint.isVisible()).toBe(true);
+        };
+        const toggle = async () => {
+          await expand.click();
+          await hint.waitFor({ state: "hidden" });
+          await settlePreview();
+        };
+        await preview.click();
+        await settlePreview();
+        const normalBox = await dialog.boundingBox();
+        expect(normalBox).not.toBeNull();
+        expect(await expand.getAttribute("aria-pressed")).toBe("false");
+        expect(await panel.evaluate((element) => element.classList.contains("fullscreen"))).toBe(
+          false,
+        );
+        await assertHint("Expand preview", "tooltip-01-collapsed.png");
+        for (const action of ["collapse", "Close preview", "Edit file", "Escape"]) {
+          await toggle();
+          expect(await expand.getAttribute("aria-pressed")).toBe("true");
+          expect(await panel.evaluate((element) => element.classList.contains("fullscreen"))).toBe(
+            true,
+          );
+          const expandedBox = await dialog.boundingBox();
+          expect(Boolean(normalBox && expandedBox && expandedBox.width > normalBox.width)).toBe(
+            true,
+          );
+          const stage = action.toLowerCase().replaceAll(" ", "-");
+          await assertHint("Collapse preview", `tooltip-${stage}-expanded.png`);
+          if (action === "collapse") {
+            await toggle();
+          } else {
+            if (action === "Escape") {
+              await page.keyboard.press("Escape");
+              await hint.waitFor({ state: "hidden" });
+              expect(await dialog.isVisible()).toBe(true);
+              await page.keyboard.press("Escape");
+            } else {
+              await modal.getByRole("button", { name: action, exact: true }).click();
+            }
+            await dialog.waitFor({ state: "hidden" });
+            expect(await editor.inputValue()).toBe(content);
+            await preview.click();
+            await settlePreview();
+          }
+          expect(await expand.getAttribute("aria-pressed")).toBe("false");
+          expect(await panel.evaluate((element) => element.classList.contains("fullscreen"))).toBe(
+            false,
+          );
+          const resetBox = await dialog.boundingBox();
+          expect(Boolean(resetBox && expandedBox && resetBox.width < expandedBox.width)).toBe(true);
+          await assertHint("Expand preview", `tooltip-${stage}-reset.png`);
+        }
+        await modal.getByRole("button", { name: "Close preview", exact: true }).click();
+        await dialog.waitFor({ state: "hidden" });
+        expect(await editor.inputValue()).toBe(content);
+        expect((await page.locator(".agent-file-sub").textContent())?.trim()).toBe(
+          "/tmp/openclaw-e2e/workspace-main/AGENTS.md",
+        );
+        expect(
+          (await gateway.getRequests()).filter((request) =>
+            ["agents.files.set", "config.set", "config.patch", "config.apply"].includes(
+              request.method,
+            ),
+          ),
+        ).toEqual([]);
+      },
+    );
+  });
+
   it("keeps save errors visible, retries, and rejects stale cross-agent reads", async () => {
     await suite.withPage(
       {

--- a/ui/src/pages/agents/agent-file-preview-state.ts
+++ b/ui/src/pages/agents/agent-file-preview-state.ts
@@ -11,7 +11,7 @@ export function setPreviewExpandButtonState(
   button.classList.toggle("is-fullscreen", isFullscreen);
   button.setAttribute("aria-pressed", String(isFullscreen));
   button.setAttribute("aria-label", label);
-  button.setAttribute("title", label);
+  button.closest("openclaw-tooltip")?.setAttribute("content", label);
 }
 
 export function resetAgentFilePreview(modal: HTMLElement) {

--- a/ui/src/pages/agents/view.test.ts
+++ b/ui/src/pages/agents/view.test.ts
@@ -1022,6 +1022,7 @@ describe("renderAgentFiles", () => {
     ]);
     expect(previewExpandButton.getAttribute("aria-pressed")).toBe("true");
     expect(previewExpandButton.getAttribute("aria-label")).toBe("Collapse preview");
+    expect(previewExpandButton.closest("openclaw-tooltip")?.content).toBe("Collapse preview");
 
     container.querySelector<HTMLButtonElement>('[aria-label="Close preview"]')?.click();
 
@@ -1034,5 +1035,6 @@ describe("renderAgentFiles", () => {
     ]);
     expect(previewExpandButton.getAttribute("aria-pressed")).toBe("false");
     expect(previewExpandButton.getAttribute("aria-label")).toBe("Expand preview");
+    expect(previewExpandButton.closest("openclaw-tooltip")?.content).toBe("Expand preview");
   });
 });


### PR DESCRIPTION
Closes #142014

## What Problem This Solves

Fixes an issue where users expanding an agent file preview would still see “Expand preview” in its tooltip, even though the button now collapses the preview. Its accessible name was already correct.

## Why This Change Was Made

The expand/reset owner now updates the explicit tooltip component's reactive content instead of the button's native title. The existing title adapter intentionally avoids competing with that wrapper. This replaces one production line and preserves the current modal, focus, editor, and translation behavior.

## User Impact

The visible hint says “Collapse preview” while expanded and returns to “Expand preview” after collapse, Close, Edit, or Escape resets. No setting, persistence, protocol, dependency, or generic positioning behavior changes. The attached before/after images show the same expanded state with synthetic file content.

## Evidence

- The existing component regression failed on the original caption mismatch; all 23 component tests pass after the repair. Both existing real-browser focus/typing tests also pass.
- A production-bundled Control UI in real headless Chromium reproduced the visible mismatch through the normal agent-files route. The final case verifies all four reset paths, the actual tooltip anchor, retained file/editor identity, and absence of file/config writes through mocked Gateway transport. Baseline and final were repeated against the final test assertions: one intended baseline failure, one passing final case, with two unrelated cases unselected.
- Complete changed-file checks passed. Earlier attempts caught a test fixture array-access type error and two text-reader lint errors; the assertions were corrected without suppressions. The final UI production source and captured behavior are unchanged by those test-only corrections.
- Independent media review inspected all 12 original PNGs and 60 sampled frames across both recordings. One managed P0–P2 review, automatically split into two passes, was scoped-clean with no findings. Production is +1/−1; tests add 146 net lines across the existing component and routed browser suites.

Evidence is bound to source base `8d11b06ba16e36d4893149a30976b1e26bcae093` and patch `edf31617f68ceb8c9294df757739972c13edc4d2d0d4612507eb92bba8a5a33f`. Committed head `5097c05ed1534d81bb3f112f1f41418a1f0adabc` preserves those exact reviewed source bytes. The affected tooltip, renderer and test sources are unchanged on inspected main `0604bbce80797482228b275eaacec34614942731`. This proves the bundled UI with synthetic Gateway/file data; it does not claim a live Gateway, general geometry repair, live locale-switch repair, or editor-persistence change. Existing wording is restored, so no documentation or translation change is needed.

![before-expanded-tooltip](https://github.com/user-attachments/assets/b0935eb2-9cad-4731-8e37-0327d46d8d69)

![after-expanded-tooltip](https://github.com/user-attachments/assets/22fc4384-6fdd-4085-99be-21af7a081faa)