### PR TITLE
fix(control-ui): separate catalog header actions

### DIFF
--- a/ui/src/components/app-sidebar-session-catalog-render.ts
+++ b/ui/src/components/app-sidebar-session-catalog-render.ts
@@ -222,6 +222,7 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
     const sectionClass = [
       "sidebar-recent-sessions__group",
       "sidebar-recent-sessions__group--zone-coding",
+      canCreateSession ? "sidebar-recent-sessions__group--catalog-can-create" : "",
       collapsed ? "sidebar-recent-sessions__group--collapsed" : "",
       params.draggingSectionId === sectionId ? "sidebar-recent-sessions__group--dragging" : "",
       params.sectionDropTarget?.sectionId === sectionId
@@ -295,6 +296,7 @@ export function renderSessionCatalogGroups(params: SessionCatalogGroupsParams) {
                 >${catalog.label}</span
               >
               ${renderCatalogHeaderStatus(hasActiveRun, hasUnread)}
+              <span class="sidebar-session-catalog-action-reserve" aria-hidden="true"></span>
               ${
                 hasError || (collapsed && rows.length > 0)
                   ? html`<span

--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -145,7 +145,7 @@ suite.define(() => {
           catalogs: [
             {
               id: "codex",
-              label: "Codex",
+              label: "Codex Native Sessions with a Deliberately Long Provider Label",
               capabilities: { continueSession: true, archive: true, startTerminal: true },
               hosts: [
                 {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -1657,6 +1657,10 @@ openclaw-settings-save-indicator:empty {
   flex: 0 0 var(--sidebar-session-group-action-size);
 }
 
+.sidebar-session-catalog-action-reserve {
+  display: none;
+}
+
 @media (hover: hover) and (pointer: fine) {
   /* Keep hover actions immediately left of the fixed count. */
   .sidebar-session-catalog-grouping,
@@ -1667,10 +1671,25 @@ openclaw-settings-save-indicator:empty {
     transform: translateY(-50%);
   }
 
-  .sidebar-session-catalog-grouping:has(+ .sidebar-session-catalog-new) {
+  .sidebar-recent-sessions__group--catalog-can-create
+    > .sidebar-recent-sessions__head
+    > .sidebar-session-catalog-grouping {
     right: calc(
       10px + var(--sidebar-session-group-count-slot) + var(--sidebar-session-group-action-size) +
         8px
+    );
+  }
+
+  .sidebar-session-catalog-action-reserve {
+    display: block;
+    flex: 0 0
+      calc(var(--sidebar-session-group-count-slot) + var(--sidebar-session-group-action-size));
+  }
+
+  .sidebar-recent-sessions__group--catalog-can-create .sidebar-session-catalog-action-reserve {
+    flex-basis: calc(
+      var(--sidebar-session-group-count-slot) + var(--sidebar-session-group-action-size) +
+        var(--sidebar-session-group-action-size) + 8px
     );
   }
 

--- a/ui/src/test-helpers/control-ui-e2e.ts
+++ b/ui/src/test-helpers/control-ui-e2e.ts
@@ -104,12 +104,53 @@ export async function assertSessionSectionCountAlignment(
     if (!countBox || Number.parseFloat(countOpacity) <= 0) {
       throw new Error("Expected visible catalog count on hover");
     }
+    const actionBoxes: Array<{ x: number; y: number; width: number; height: number }> = [];
     for (const action of await header.locator(".sidebar-session-group-actions").all()) {
       const actionBox = await action.boundingBox();
       if (!actionBox || actionBox.x + actionBox.width > countBox.x) {
         throw new Error("Expected catalog hover actions to stay left of the count");
       }
+      actionBoxes.push(actionBox);
     }
+    actionBoxes.sort((left, right) => left.x - right.x);
+    if (
+      actionBoxes.some((box, actionIndex) => {
+        const previous = actionBoxes[actionIndex - 1];
+        return previous ? box.x < previous.x + previous.width : false;
+      })
+    ) {
+      throw new Error("Expected catalog hover actions not to overlap");
+    }
+    const contentBoxes = await Promise.all(
+      (
+        await header
+          .locator(
+            ".sidebar-recent-sessions__label-text, .session-run-spinner, .session-unread-dot",
+          )
+          .all()
+      ).map((element) => element.boundingBox()),
+    );
+    const contentRight = Math.max(...contentBoxes.map((box) => (box ? box.x + box.width : 0)));
+    if (contentRight > (actionBoxes[0]?.x ?? Number.POSITIVE_INFINITY)) {
+      throw new Error("Expected catalog content to stay left of hover actions");
+    }
+    const groupingAction = header.locator("[data-session-catalog-view-menu]");
+    await groupingAction.click();
+    await page.waitForFunction(
+      (id) =>
+        document
+          .querySelector(`[data-session-section="${id}"] [data-session-catalog-view-menu]`)
+          ?.getAttribute("aria-expanded") === "true",
+      sectionId,
+    );
+    await page.mouse.move(0, 0);
+    const persistentOpacity = await groupingAction.evaluate(
+      (element) => getComputedStyle(element).opacity,
+    );
+    if (Number.parseFloat(persistentOpacity) <= 0) {
+      throw new Error("Expected an open catalog action to remain visible without hover");
+    }
+    await page.keyboard.press("Escape");
     await section.locator(".sidebar-session-group-toggle").click();
     for (const nestedCount of await section
       .locator(".sidebar-session-catalog-host__count, .sidebar-session-catalog-project__count")


### PR DESCRIPTION
## What Problem This Solves

Follow-up to #141924. Prevents the Codex catalog's tooltip-wrapped new-session action from overlapping View options, and keeps long provider labels or status indicators out of the hover-action region.

## Why This Change Was Made

#141924 positioned actions next to the fixed count, but its selector assumed the `+` anchor was a direct sibling. The link is wrapped in `openclaw-tooltip`, so both buttons landed in the same place. Absolutely positioning them also left label and status content free to paint underneath.

This follow-up marks catalogs that can create sessions explicitly and reserves the matching action width inside the header while leaving the count on its fixed right edge.

## Evidence

- Focused bundled Chromium E2E: 7 passed; covers two-button separation, long-label/content clearance, menu-open persistence without hover, and collapsed/expanded count alignment
- AppSidebar unit suite: 348 passed
- Production and core test typechecks: passed
- Targeted oxlint: passed
- Stylelint, oxfmt, and git diff check: passed

## Worked on by
