### PR TITLE
fix(ui): avoid rejected read updates in restricted sessions

### DIFF
--- a/docs/web/control-ui/sessions-and-sidebar.md
+++ b/docs/web/control-ui/sessions-and-sidebar.md
@@ -78,6 +78,8 @@ Enable **Hide empty groups** in the same menu to hide custom groups with no sess
 
 **Mark as unread** creates a reminder that remains unread while the current chat stays open, including while a run streams or completes. Leave and reopen the session, or choose **Mark as read**, to clear it.
 
+Opening a read-only or suggestion session as a viewer leaves its unread marker intact. Draft sessions acknowledge reads automatically only for their owner or an administrator.
+
 **Delete** removes the confirmed selection from loaded session lists immediately and leaves any deleted conversation that is open. The Gateway finishes deletion in the background, safely stopping and reclaiming an attached cloud worker first. If deletion fails, the affected session can reappear with an error; other successful deletions and any navigation you made in the meantime are preserved. Browser drafts are retired only after deletion is confirmed, not while the request is pending.
 
 **Rename** in the sidebar, chat header, and Sessions page starts with your custom name or the generated dashboard title. Edit the text, then save or press Enter. Saving an unchanged generated title leaves automatic naming intact; clearing a custom name restores the generated title. Channel and account decorations stay outside the editable name. Rename targets the session you started editing. If that session is deleted and recreated at the same key before you save, the edit is rejected instead of renaming the replacement. Reopen Rename on the current session to try again. Resetting the conversation keeps the same session identity and does not invalidate the edit.

--- a/ui/src/e2e/session-management.unread.e2e.test.ts
+++ b/ui/src/e2e/session-management.unread.e2e.test.ts
@@ -18,6 +18,125 @@ import {
 const suite = createSessionManagementE2eSuite();
 
 suite.define(() => {
+  it.each([
+    { visibility: "read-only", sharingRole: "viewer", restricted: true },
+    { visibility: "suggest", sharingRole: "viewer", restricted: true },
+    { visibility: "draft", sharingRole: "member", restricted: true },
+    { visibility: "shared", sharingRole: "viewer", restricted: false },
+  ] as const)(
+    "honors $visibility $sharingRole participation when acknowledging unread state",
+    async ({ visibility, sharingRole, restricted }) => {
+      const unreadKey = "agent:main:participation-read";
+      const otherKey = "agent:main:participation-other";
+      const marker = 1_800_000_000_001;
+      const unreadSession = sessionRow(unreadKey, "Unread participation thread", 20, {
+        icon: "📬",
+        markedUnreadAt: marker,
+        unread: true,
+        visibility,
+        sharingRole,
+      });
+      const otherSession = sessionRow(otherKey, "Other thread", 10, { unread: false });
+      const denial = "Synthetic participation restriction";
+      const context = await suite.browser.newContext({
+        colorScheme: "dark",
+        locale: "en-US",
+        serviceWorkers: "block",
+        viewport: { height: 900, width: 1280 },
+      });
+      const page = await context.newPage();
+      const gateway = await installMockGateway(page, {
+        operatorScopes: ["operator.write"],
+        featureCapabilities: [GATEWAY_SERVER_CAPS.SESSION_UNREAD_ACK_CONTRACT],
+        hasMultipleSessionSharingIdentities: false,
+        sessions: [unreadSession, otherSession],
+        methodResponses: {
+          "sessions.list": sessionsListResponse([unreadSession, otherSession]),
+          "sessions.patch": restricted
+            ? { __mockError: { code: "INVALID_REQUEST", message: denial } }
+            : {},
+        },
+        sessionKey: otherKey,
+      });
+      const match = { key: unreadKey, unread: false };
+
+      try {
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, otherKey));
+        const unreadRow = page.locator(`[data-session-key="${unreadKey}"]`);
+        const unreadBadge = unreadRow.locator(
+          ".sidebar-session-indicator .session-glyph__badge--unread",
+        );
+        await unreadBadge.waitFor({ state: "visible" });
+        expect(await gateway.getRequests("sessions.patch", match)).toHaveLength(0);
+        await unreadRow.getByRole("link").click();
+        await expect.poll(() => new URL(page.url()).pathname).toBe(controlUiSessionPath(unreadKey));
+        const pane = page.locator('openclaw-chat-pane[aria-hidden="false"]');
+        await pane.waitFor({ state: "visible" });
+        if (restricted) {
+          await pane
+            .getByText("Only the session owner and members can act in this session.")
+            .waitFor();
+          await expect
+            .poll(() => pane.locator(".agent-chat__composer-combobox textarea").isDisabled())
+            .toBe(true);
+        } else {
+          const acknowledgement = await gateway.waitForRequest("sessions.patch", { match });
+          expect(acknowledgement.params).toMatchObject({ expectedMarkedUnreadAt: marker });
+          await unreadBadge.waitFor({ state: "hidden" });
+        }
+        await captureUiProof(suite, page, `${visibility}-${sharingRole}-opened.png`);
+        await expectRequestCountStable(gateway, "sessions.patch", restricted ? 0 : 1, 500, match);
+        if (!restricted) {
+          return;
+        }
+        await unreadBadge.waitFor({ state: "visible" });
+        expect(await page.getByText(denial, { exact: true }).count()).toBe(0);
+
+        const refreshedSession = {
+          ...unreadSession,
+          label: "Refreshed participation thread",
+          displayName: "Refreshed participation thread",
+          updatedAt: 30,
+        };
+        await gateway.setSessionsListResponse(
+          sessionsListResponse([refreshedSession, otherSession]),
+        );
+        await gateway.emitGatewayEvent("sessions.changed", {
+          agentId: "main",
+          reason: "run",
+          sessionKey: unreadKey,
+          session: refreshedSession,
+        });
+        await unreadRow.getByText("Refreshed participation thread", { exact: true }).waitFor();
+        await expectRequestCountStable(gateway, "sessions.patch", 0, 500, match);
+        await unreadBadge.waitFor({ state: "visible" });
+        expect(await page.getByText(denial, { exact: true }).count()).toBe(0);
+        await captureUiProof(suite, page, `${visibility}-${sharingRole}-refreshed.png`);
+
+        if (visibility === "read-only") {
+          await gateway.setMethodResponse("sessions.patch", {});
+          const eligibleSession = { ...refreshedSession, sharingRole: "member", updatedAt: 40 };
+          await gateway.setSessionsListResponse(
+            sessionsListResponse([eligibleSession, otherSession]),
+          );
+          await gateway.emitGatewayEvent("sessions.changed", {
+            agentId: "main",
+            reason: "run",
+            sessionKey: unreadKey,
+            session: eligibleSession,
+          });
+          const acknowledgement = await gateway.waitForRequest("sessions.patch", { match });
+          expect(acknowledgement.params).toMatchObject({ expectedMarkedUnreadAt: marker });
+          await unreadBadge.waitFor({ state: "hidden" });
+          await expectRequestCountStable(gateway, "sessions.patch", 1, 500, match);
+          await captureUiProof(suite, page, "read-only-member-restored.png");
+        }
+      } finally {
+        await context.close();
+      }
+    },
+  );
+
   it("clears an unread badge before the acknowledgement round trip", async () => {
     const unreadKey = "agent:main:optimistic-read";
     const otherKey = "agent:main:optimistic-other";

--- a/ui/src/pages/chat/chat-pane-session.ts
+++ b/ui/src/pages/chat/chat-pane-session.ts
@@ -265,6 +265,12 @@ export abstract class ChatPaneSession extends ChatPaneTaskSuggestions {
     // not an operation failure and should not latch the unread retry guard.
     if (
       !access.allowed ||
+      this.sessionParticipationTracker.resolve({
+        catalog: parseCatalogSessionKey(state.sessionKey) !== null,
+        listLoading: state.sessionsLoading,
+        sessionKey: `${resolveChatAgentId(state) ?? ""}\0${state.sessionKey}`,
+        session: row,
+      }) ||
       !this.unreadPatchGuard.shouldPatch(state.sessionKey, true, row.markedUnreadAt)
     ) {
       return;

--- a/ui/src/pages/chat/chat-pane.read-marker.test.ts
+++ b/ui/src/pages/chat/chat-pane.read-marker.test.ts
@@ -58,13 +58,27 @@ describe("chat pane read markers", () => {
       name: "read-only scope",
       methods: ["sessions.patch"],
       scopes: ["operator.read"],
+      session: {},
     },
     {
       name: "unadvertised sessions.patch",
       methods: ["sessions.create"],
       scopes: ["operator.write"],
+      session: {},
     },
-  ])("does not mutate unread state with $name", ({ methods, scopes }) => {
+    ...(["read-only", "suggest", "draft"] as const).map((visibility) => ({
+      name: `${visibility} viewer participation`,
+      methods: ["sessions.patch"],
+      scopes: ["operator.write"],
+      session: { visibility, sharingRole: "viewer" as const },
+    })),
+    {
+      name: "draft member participation",
+      methods: ["sessions.patch"],
+      scopes: ["operator.write"],
+      session: { visibility: "draft" as const, sharingRole: "member" as const },
+    },
+  ])("does not mutate unread state with $name", ({ methods, scopes, session }) => {
     const patch = vi.fn().mockResolvedValue(null);
     const { pane, state } = createTestChatPane({
       client: {} as GatewayBrowserClient,
@@ -79,6 +93,7 @@ describe("chat pane read markers", () => {
       kind: "direct" as const,
       updatedAt: 20,
       unread: true,
+      ...session,
     };
 
     pane.markSessionRead(row);
@@ -87,6 +102,40 @@ describe("chat pane read markers", () => {
     expect(patch).not.toHaveBeenCalled();
     expect(state.chatError).toBeNull();
     expect(state.lastError).toBeNull();
+  });
+
+  it.each([
+    { visibility: "shared", sharingRole: "viewer", scopes: ["operator.write"] },
+    { visibility: "read-only", sharingRole: "member", scopes: ["operator.write"] },
+    { visibility: "draft", sharingRole: "owner", scopes: ["operator.write"] },
+    { visibility: "draft", sharingRole: "admin", scopes: ["operator.admin"] },
+  ] as const)("acknowledges unread state for $visibility $sharingRole", (session) => {
+    const patch = vi.fn().mockResolvedValue({});
+    const { pane } = createTestChatPane({
+      client: {} as GatewayBrowserClient,
+      sessions: createSessionCapabilityFixture({ patch }),
+    });
+    pane.context.gateway.snapshot.hello = {
+      auth: { role: "operator", scopes: [...session.scopes] },
+      features: { methods: ["sessions.patch"] },
+    } as ApplicationGatewaySnapshot["hello"];
+    const row = {
+      key: "agent:main:current",
+      kind: "direct" as const,
+      updatedAt: 20,
+      unread: true,
+      visibility: session.visibility,
+      sharingRole: session.sharingRole,
+    };
+
+    pane.markSessionRead(row);
+    pane.markSessionRead(row);
+
+    expect(patch).toHaveBeenCalledExactlyOnceWith(
+      "agent:main:current",
+      { unread: false },
+      { agentId: "main", expectedMarkedUnreadAt: null },
+    );
   });
 
   it("retries the read patch after a null (unsent) resolution", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where viewing a restricted session sent background read acknowledgements that the session's participation rules reject. Refreshing the session could repeat the failed update even though the composer already correctly showed that the viewer could not act.

## Why This Change Was Made

Automatic read acknowledgements now consult the existing session participation tracker before latching an unread update. Read-only and suggestion viewers, and draft viewers or members, stay silent. Eligible members, owners, administrators and uncapped shared viewers keep their existing acknowledgement behavior.

## User Impact

Opening or refreshing a known restricted session preserves its unread marker without sending the rejected background update. If membership changes to permit updates, the same marker can be acknowledged normally. Manual unread reminders and suggestion controls retain their existing behavior.

## Evidence

- The unchanged producer failed four new owner regressions: each restricted case sent one `unread: false` patch. The bundled browser flow also failed by observing that outgoing request for a read-only viewer.
- After the fix, all 26 owner/tracker tests and 12 bundled-browser tests passed. Browser coverage includes fresh restricted rows, restored membership, uncapped shared viewers, manual unread reminders and suggestions.
- The complete changed-file gate passed, including core/UI typechecks, lint, i18n and dead-export checks. Independent P0–P2 review found no actionable issues.
- The Linux [Testbox run](https://github.com/openclaw/openclaw/actions/runs/34202889187) produced a report with all six unread browser cases passed on Chromium 151 / Node 24.19.0, with matching source and lockfile hashes. The wrapper's artifact-return protocol failed after the report was written; a separate successful download recovered all 21 files, which passed independent inventory, source-tree and capture audit. The failed wrapper result is retained separately from the six successful test results.

The attached before/after captures contain synthetic sessions. Outgoing-request assertions establish the behavior change; the visible read-only presentation and unread marker are intentionally preserved.

![Before: restricted viewer sends a rejected read acknowledgement](https://github.com/user-attachments/assets/d4b2bbf8-72e6-4187-b997-e3e513be23e5)

![After: restricted viewer preserves unread state without that request](https://github.com/user-attachments/assets/1fef63d4-bc85-4960-803c-1bb7c22311f5)