### PR TITLE
test(ui): exercise scroll reset on the existing preview

### DIFF
--- a/ui/src/components/file-preview-modal.test.ts
+++ b/ui/src/components/file-preview-modal.test.ts
@@ -215,11 +215,13 @@ describe("openclaw-file-preview-modal", () => {
     expect(firstChunks.map((chunk) => chunk.textContent ?? "").join("\n")).toBe(firstContents);
 
     body!.scrollTop = 2200;
+    expect(body!.scrollTop).toBe(2200);
 
-    const updatedModal = await renderPreview({ activePath: "second.ts", previewFiles });
-    const updatedBody = updatedModal.shadowRoot?.querySelector<HTMLElement>(".detail-body");
+    modal.activePath = "second.ts";
+    await modal.updateComplete;
+    const updatedBody = modal.shadowRoot?.querySelector<HTMLElement>(".detail-body");
     const secondChunks = [
-      ...(updatedModal.shadowRoot?.querySelectorAll<HTMLElement>(".code-chunk") ?? []),
+      ...(modal.shadowRoot?.querySelectorAll<HTMLElement>(".code-chunk") ?? []),
     ];
 
     expect(updatedBody?.scrollTop).toBe(0);


### PR DESCRIPTION
## What Problem This Solves

The file-preview test claimed to check scroll reset when changing files, but it created a new modal for the second file. That only checked a fresh element's zero scroll position and could miss removal of the real reset.

## Why This Change Was Made

Change the existing modal's public activePath property and await its update before checking scroll position and complete file contents. Keep the unique custom-element fixture isolation and every existing chunk assertion.

## User Impact

No product behavior changes: the reset already works. Its regression test now observes the actual transition. All 12 cases remain; production is unchanged and the test grows by two lines.

## Evidence

- Original and final full unit suites: 12 passed each with identical case inventories.
- Temporarily omit only the production scrollTop reset: the old named case passes; the repaired named case fails with 2200 instead of 0. The other 11 cases are filtered out in these controls.
- Production was restored exactly. The final formatted test passed all 12 cases, formatting, diff checks, and independent Codex review through P2.
- All 18 normal changed-file checks passed ([Linux Testbox run](https://github.com/openclaw/openclaw/actions/runs/34201047617)); the one-shot lease, source capsule, and recorded processes are cleaned up.

This is jsdom component-state proof, not browser-layout or physical-scrolling proof. No production scrolling bug is claimed or runtime implementation changed.
