### PR TITLE
refactor(plugins): share activation config merging

### DIFF
--- a/src/gateway/plugin-activation-runtime-config.test.ts
+++ b/src/gateway/plugin-activation-runtime-config.test.ts
@@ -15,33 +15,43 @@ vi.mock("../config/plugin-auto-enable.js", () => ({
 const applyPluginAutoEnableMock = vi.mocked(applyPluginAutoEnable);
 
 describe("resolveGatewayStartupPluginActivationConfig", () => {
-  it("auto-enables the source config, then merges activation into the runtime config", () => {
-    const runtimeConfig = {
-      plugins: { entries: { keep: { enabled: true, runtimeOnly: 1 } } },
-    } as unknown as OpenClawConfig;
-    const sourceConfig = {
-      plugins: { entries: { keep: { enabled: true } } },
-    } as unknown as OpenClawConfig;
-    // Auto-enable runs against the source config and yields an activation config that
-    // enables an extra plugin; only enable/allow surfaces should carry into runtime config.
-    applyPluginAutoEnableMock.mockReturnValue({
-      config: { plugins: { entries: { added: { enabled: true } } } },
-    } as unknown as ReturnType<typeof applyPluginAutoEnable>);
+  it.each([true, false])(
+    "merges source enablement (%s) without replacing runtime config",
+    (enabled) => {
+      const runtimeConfig: OpenClawConfig = {
+        channels: { telegram: { enabled: !enabled, botToken: "runtime-token" } },
+        plugins: { entries: { keep: { enabled: true, config: { runtimeOnly: 1 } } } },
+      };
+      const sourceConfig: OpenClawConfig = {
+        plugins: { entries: { keep: { enabled: true } } },
+      };
+      // Auto-enable runs against the source config and yields an activation config that
+      // enables an extra plugin; only enable/allow surfaces should carry into runtime config.
+      applyPluginAutoEnableMock.mockReturnValue({
+        config: {
+          channels: { telegram: { enabled, botToken: "stale-source-token" } },
+          plugins: { entries: { keep: { enabled }, added: { enabled: true } } },
+        },
+        changes: [],
+        autoEnabledReasons: {},
+      });
 
-    const result = resolveGatewayStartupPluginActivationConfig({
-      runtimeConfig,
-      activationSourceConfig: sourceConfig,
-      env: {} as NodeJS.ProcessEnv,
-    });
+      const result = resolveGatewayStartupPluginActivationConfig({
+        runtimeConfig,
+        activationSourceConfig: sourceConfig,
+        env: {},
+      });
 
-    // Activation is computed from the operator source config, not the runtime config.
-    expect(applyPluginAutoEnableMock).toHaveBeenCalledWith(
-      expect.objectContaining({ config: sourceConfig }),
-    );
-    // Runtime-only field is preserved; the auto-enabled activation entry is merged in.
-    expect(result.plugins?.entries?.keep).toEqual({ enabled: true, runtimeOnly: 1 });
-    expect(result.plugins?.entries?.added).toEqual({ enabled: true });
-  });
+      // Activation is computed from the operator source config, not the runtime config.
+      expect(applyPluginAutoEnableMock).toHaveBeenCalledWith(
+        expect.objectContaining({ config: sourceConfig }),
+      );
+      // Runtime-only field is preserved; the auto-enabled activation entry is merged in.
+      expect(result.channels?.telegram).toEqual({ enabled, botToken: "runtime-token" });
+      expect(result.plugins?.entries?.keep).toEqual({ enabled, config: { runtimeOnly: 1 } });
+      expect(result.plugins?.entries?.added).toEqual({ enabled: true });
+    },
+  );
 
   it("passes manifestRegistry and discovery through to auto-enable when provided", () => {
     applyPluginAutoEnableMock.mockReturnValue({

--- a/src/gateway/plugin-activation-runtime-config.ts
+++ b/src/gateway/plugin-activation-runtime-config.ts
@@ -11,93 +11,27 @@ import { isRecord } from "../utils.js";
 // runtime config. Other runtime fields stay canonical to avoid stale activation
 // state overriding live config reloads.
 
-function mergeChannelActivationSections(params: {
-  runtimeConfig: OpenClawConfig;
-  activationConfig: OpenClawConfig;
-}): OpenClawConfig {
-  const activationChannels = params.activationConfig.channels;
-  if (!isRecord(activationChannels)) {
-    return params.runtimeConfig;
+function mergeEnabledEntries(
+  runtimeValue: unknown,
+  activationValue: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(activationValue)) {
+    return undefined;
   }
-
-  const runtimeChannels = isRecord(params.runtimeConfig.channels)
-    ? params.runtimeConfig.channels
-    : {};
-  let nextChannels: Record<string, unknown> | undefined;
-
-  for (const [channelId, activationChannel] of Object.entries(activationChannels)) {
-    if (!isRecord(activationChannel) || !Object.hasOwn(activationChannel, "enabled")) {
+  const runtimeEntries = isRecord(runtimeValue) ? runtimeValue : {};
+  let nextEntries: Record<string, unknown> | undefined;
+  for (const [id, activationEntry] of Object.entries(activationValue)) {
+    if (!isRecord(activationEntry) || !Object.hasOwn(activationEntry, "enabled")) {
       continue;
     }
-    const runtimeChannel = runtimeChannels[channelId];
-    const runtimeChannelRecord = isRecord(runtimeChannel) ? runtimeChannel : {};
-    nextChannels ??= { ...runtimeChannels };
-    nextChannels[channelId] = {
-      ...runtimeChannelRecord,
-      enabled: activationChannel.enabled,
+    const runtimeEntry = runtimeEntries[id];
+    nextEntries ??= { ...runtimeEntries };
+    nextEntries[id] = {
+      ...(isRecord(runtimeEntry) ? runtimeEntry : {}),
+      enabled: activationEntry.enabled,
     };
   }
-
-  if (nextChannels === undefined) {
-    return params.runtimeConfig;
-  }
-  return {
-    ...params.runtimeConfig,
-    channels: nextChannels as OpenClawConfig["channels"],
-  };
-}
-
-function mergePluginActivationSections(params: {
-  runtimeConfig: OpenClawConfig;
-  activationConfig: OpenClawConfig;
-}): OpenClawConfig {
-  const activationPlugins = params.activationConfig.plugins;
-  if (!isRecord(activationPlugins)) {
-    return params.runtimeConfig;
-  }
-
-  const runtimePlugins = isRecord(params.runtimeConfig.plugins) ? params.runtimeConfig.plugins : {};
-  let nextPlugins: Record<string, unknown> | undefined;
-
-  if (Array.isArray(activationPlugins.allow)) {
-    nextPlugins = {
-      ...runtimePlugins,
-      allow: [...activationPlugins.allow],
-    };
-  }
-
-  const activationEntries = activationPlugins.entries;
-  if (isRecord(activationEntries)) {
-    const runtimeEntries = isRecord(runtimePlugins.entries) ? runtimePlugins.entries : {};
-    let nextEntries: Record<string, unknown> | undefined;
-    for (const [pluginId, activationEntry] of Object.entries(activationEntries)) {
-      if (!isRecord(activationEntry) || !Object.hasOwn(activationEntry, "enabled")) {
-        continue;
-      }
-      const runtimeEntry = runtimeEntries[pluginId];
-      const runtimeEntryRecord = isRecord(runtimeEntry) ? runtimeEntry : {};
-      nextEntries ??= { ...runtimeEntries };
-      nextEntries[pluginId] = {
-        ...runtimeEntryRecord,
-        enabled: activationEntry.enabled,
-      };
-    }
-    if (nextEntries !== undefined) {
-      nextPlugins = {
-        ...runtimePlugins,
-        ...nextPlugins,
-        entries: nextEntries,
-      };
-    }
-  }
-
-  if (nextPlugins === undefined) {
-    return params.runtimeConfig;
-  }
-  return {
-    ...params.runtimeConfig,
-    plugins: nextPlugins as OpenClawConfig["plugins"],
-  };
+  return nextEntries;
 }
 
 /** Merges plugin/channel activation enablement into the runtime config shape. */
@@ -105,10 +39,28 @@ export function mergeActivationSectionsIntoRuntimeConfig(params: {
   runtimeConfig: OpenClawConfig;
   activationConfig: OpenClawConfig;
 }): OpenClawConfig {
-  return mergePluginActivationSections({
-    ...params,
-    runtimeConfig: mergeChannelActivationSections(params),
-  });
+  const { runtimeConfig, activationConfig } = params;
+  const nextChannels = mergeEnabledEntries(runtimeConfig.channels, activationConfig.channels);
+  const activationPlugins = activationConfig.plugins;
+  let nextPlugins: Record<string, unknown> | undefined;
+  if (isRecord(activationPlugins)) {
+    const runtimePlugins = isRecord(runtimeConfig.plugins) ? runtimeConfig.plugins : {};
+    if (Array.isArray(activationPlugins.allow)) {
+      nextPlugins = { ...runtimePlugins, allow: [...activationPlugins.allow] };
+    }
+    const nextEntries = mergeEnabledEntries(runtimePlugins.entries, activationPlugins.entries);
+    if (nextEntries !== undefined) {
+      nextPlugins = { ...runtimePlugins, ...nextPlugins, entries: nextEntries };
+    }
+  }
+  if (nextChannels === undefined && nextPlugins === undefined) {
+    return runtimeConfig;
+  }
+  return {
+    ...runtimeConfig,
+    ...(nextChannels === undefined ? {} : { channels: nextChannels as OpenClawConfig["channels"] }),
+    ...(nextPlugins === undefined ? {} : { plugins: nextPlugins as OpenClawConfig["plugins"] }),
+  };
 }
 
 // Resolves the effective plugin config the gateway startup *plan* is built from:


### PR DESCRIPTION
Related: #135599

## What Problem This Solves

Plugin and channel activation used duplicate merge loops and separate config wrappers. Both must copy source enablement into the resolved runtime configuration without replacing runtime-only settings.

## Why This Change Was Made

Share the enabled-entry projection and assemble the result once. Remove the two private wrappers while preserving the public startup/reload helpers, explicit enable/disable values, copied plugin allowlists, and original-object identity when nothing changes.

## User Impact

Behavior is unchanged. Startup, reload planning, and plugin health continue using the same activation rules and resolved settings.

## Evidence

- Original owner/startup suites: 33 passing tests. The expanded enable/disable table passes all 34 tests before and after the refactor.
- Complete canonical changed-file gate passed. Final typed fixture cleanup also passed all 34 tests, the selected test typecheck, and typed lint.
- Independent P2 review: scoped-clean, no findings.
- Handwritten production LOC: −48. Tests: +10. No new configuration, dependency, schema, or public API.
