### PR TITLE
fix(android): prioritize matching threads in search

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/CommandPalette.kt
@@ -99,7 +99,7 @@ internal fun CommandPalette(
   Surface(modifier = Modifier.fillMaxSize(), color = ClawTheme.colors.canvas, contentColor = ClawTheme.colors.text) {
     ClawScaffold(contentPadding = PaddingValues(start = 20.dp, top = 14.dp, end = 20.dp, bottom = 20.dp)) {
       LazyColumn(verticalArrangement = Arrangement.spacedBy(10.dp)) {
-        item {
+        item(key = "header") {
           Row(
             modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
@@ -120,7 +120,7 @@ internal fun CommandPalette(
           }
         }
 
-        item {
+        item(key = "query") {
           ClawTextField(
             value = query,
             onValueChange = { query = it },
@@ -129,26 +129,25 @@ internal fun CommandPalette(
           )
         }
 
-        item {
-          CommandSectionLabel(title = nativeString("Quick actions"))
+        if (actionRows.isNotEmpty() || sessionRows.isEmpty()) {
+          item(key = "actions-heading") {
+            CommandSectionLabel(title = nativeString("Quick actions"))
+          }
+          item(key = "actions") {
+            if (actionRows.isEmpty()) {
+              ClawEmptyState(title = nativeString("No actions found"), body = nativeString("Try Chat, Voice, Threads, Providers, or Settings."))
+            } else {
+              CommandActionList(rows = actionRows, onOpen = onOpen)
+            }
+          }
         }
 
-        if (actionRows.isEmpty()) {
-          item {
-            ClawEmptyState(title = nativeString("No actions found"), body = nativeString("Try Chat, Voice, Threads, Providers, or Settings."))
-          }
-        } else {
-          item {
-            CommandActionList(rows = actionRows, onOpen = onOpen)
-          }
-        }
-
-        item {
+        item(key = "threads-heading") {
           CommandSectionLabel(title = nativeString("Threads"))
         }
 
-        if (sessionRows.isEmpty()) {
-          item {
+        item(key = "threads") {
+          if (sessionRows.isEmpty()) {
             ClawPanel {
               Text(
                 text = if (isConnected) nativeString("No matching threads yet.") else nativeString("Connect the Gateway to search threads."),
@@ -156,9 +155,7 @@ internal fun CommandPalette(
                 color = ClawTheme.colors.textMuted,
               )
             }
-          }
-        } else {
-          item {
+          } else {
             CommandSessionList(
               rows =
                 sessionRows.map { session ->

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/CommandPaletteLogicTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/CommandPaletteLogicTest.kt
@@ -31,7 +31,9 @@ import androidx.compose.ui.test.DeviceConfigurationOverride
 import androidx.compose.ui.test.FontScale
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsFocused
 import androidx.compose.ui.test.assertTextContains
+import androidx.compose.ui.test.assertTextEquals
 import androidx.compose.ui.test.captureToImage
 import androidx.compose.ui.test.hasAnyAncestor
 import androidx.compose.ui.test.hasAnyDescendant
@@ -276,9 +278,57 @@ class CommandPaletteLogicTest {
   @Test
   fun inactiveQueuedSidebarRowsDoNotShowQueuedActivity() = verifyThreadActivity(queued = true, sidebar = true)
 
+  @Test
+  fun matchingThreadsReplaceEmptyActionsWithoutLosingQueryFocus() =
+    verifyThreadActivity(queued = false) { model ->
+      val query = composeRule.onNode(hasSetTextAction())
+      val searchResults = hasScrollAction() and hasAnyDescendant(hasSetTextAction())
+      val actions = composeRule.onNodeWithText(nativeString("Quick actions"), ignoreCase = true)
+      val emptyActions = composeRule.onNodeWithText(nativeString("No actions found"))
+      query.assertIsFocused().assertTextEquals("Activity")
+      emptyActions.assertDoesNotExist()
+      actions.assertDoesNotExist()
+
+      assertTrue(model.isConnected.value)
+      query.performTextReplacement("no-matching-result")
+      emptyActions.assertIsDisplayed()
+      actions.assertIsDisplayed()
+      composeRule.onNodeWithText(nativeString("No matching threads yet.")).assertIsDisplayed()
+      query.assertIsFocused().assertTextEquals("no-matching-result")
+
+      query.performTextReplacement(nativeString("Appearance"))
+      emptyActions.assertDoesNotExist()
+      actions.assertIsDisplayed()
+      composeRule.onNode(hasText(nativeString("Appearance")) and hasClickAction() and hasSetTextAction().not() and hasAnyAncestor(searchResults)).assertIsDisplayed()
+      composeRule.onNodeWithText(nativeString("No matching threads yet.")).assertIsDisplayed()
+
+      query.performTextReplacement("")
+      actions.assertIsDisplayed()
+      composeRule.onNodeWithText(nativeString("Open Chat")).assertIsDisplayed()
+      query.performTextReplacement("Activity")
+      query.assertIsFocused().assertTextEquals("Activity")
+      emptyActions.assertDoesNotExist()
+      actions.assertDoesNotExist()
+      composeRule.onNodeWithText("Activity idle").assertIsDisplayed()
+      assertEquals("agent:main:selected-elsewhere", model.chatSessionKey.value)
+    }
+
+  @Test
+  fun emptyOfflineSearchRetainsConnectionGuidance() {
+    withShell(HomeDestination.Settings) { _, assertRuntimeUnchanged ->
+      composeRule.onNodeWithContentDescription(nativeString("Search settings")).performClick()
+      composeRule.onNode(hasSetTextAction()).performTextReplacement("no-matching-result")
+      composeRule.onNodeWithText(nativeString("No actions found")).assertIsDisplayed()
+      composeRule.onNodeWithText(nativeString("Connect the Gateway to search threads.")).assertIsDisplayed()
+      composeRule.onNode(hasSetTextAction()).assertIsFocused()
+      assertRuntimeUnchanged()
+    }
+  }
+
   private fun verifyThreadActivity(
     queued: Boolean,
     sidebar: Boolean = false,
+    verifySearch: (MainViewModel) -> Unit = {},
   ) {
     val selectedKey = "agent:main:selected-elsewhere"
     val activeKey = "agent:main:activity-active"
@@ -433,6 +483,7 @@ class CommandPaletteLogicTest {
         }
         assertResultActivity()
         assertEquals(0, controller.pendingRunCount.value)
+        verifySearch(model)
       }
     } finally {
       restoreRequest()


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users searching for a thread saw a large “No actions found” card above their matching results. With large text and the keyboard open, this empty section could push most of the useful results out of view.

Related: #141883.

## Why This Change Was Made

Search now omits the entire Quick Actions section only when no actions match and threads do match. The existing list owns that decision; stable lazy-item keys keep the remaining sections identified as result groups appear or disappear. No separate scroll controller or new state is introduced.

No-results guidance, the five default actions, action-only results, offline connection guidance, query focus, navigation, and thread activity labels remain unchanged. Production: 15 additions / 18 deletions (net −3); tests: +51 lines.

## User Impact

Matching threads appear directly beneath the query. In the installed large-text comparison below, all four matching thread cards fit above the keyboard instead of only the first being fully visible. Long subtitles retain their existing ellipsis behavior.

## Evidence

- Regression reproduced against the original UI; the same result-transition test then passed after the fix. Final focused suite: 14 tests, zero failures/errors/skips. An initial test-selector ambiguity was corrected to distinguish the editable query from the real Appearance action; no production workaround or assertion relaxation.
- Changed checks, app ktlint, Play debug APK build, ThirdParty compilation, and both Android lint variants passed. Independent Codex review found no actionable P0–P2 findings.
- Installed the actual signed debug APK at `4ab02076931423dfd3700ee02cc76e24cbda0d41` on Android API 36, using ordinary onboarding and a synthetic loopback TLS Gateway. Verified the installed APK hash. Repeated matching-thread, no-result, and action-only searches; Appearance opened its real settings screen. Query focus and keyboard remained usable at font scales 1.0 and 2.0.
- Before APK was built from `5f32d9ccb9998a4775bb820b1db37bd987025206`: Android/shared source and every Android translation-inventory entry are identical to this PR’s parent `668af410cde2d76d90ec8234f26309b304abdc23`. The complete inventory differs in unrelated Apple entries; the before APK is not mislabeled as a newer build.
- Screenshots are inspected synthetic-only installed-app captures. The Gateway supplied the same seeded activity states; this is UI proof, not live-provider execution. Relative ages differ because the two runs occurred at different times. Both fixtures and the task emulator exited normally, test routing was removed, and font scale restored.

The change adds no strings, dependencies, configuration, protocol, or persistence surface. Existing Search documentation remains accurate.

![Before — Android Search, normal text](https://github.com/user-attachments/assets/f1120be5-18de-44d4-b862-3b8d61d9f421)

![Before — Android Search, large text](https://github.com/user-attachments/assets/958afb8c-88f2-450a-8a31-6eda04ad7ebe)

![After — Android Search, normal text](https://github.com/user-attachments/assets/754210e3-332f-4a76-b138-32e046667936)

![After — Android Search, large text](https://github.com/user-attachments/assets/638f29e7-dcb0-46b8-948d-2077ac508176)

### CI investigation and follow-up

The first Play job ran 2,979 tests and failed once in the unchanged `ChatComposerLayoutTest.detailsBlocksPreImeEnterUntilClosed`, at its one-second wait for a wire send after closing Details. Full ThirdParty, Wear, and ktlint CI passed. The exact failing test passed locally unchanged, as did the combined 61 composer and 14 Search tests. Source tracing found no concrete Search coupling; these non-reproductions are not a root-cause fix. The intermittent Enter-admission-versus-outbox-dispatch investigation remains a named follow-up, with the original failure retained. No timeout or assertion was relaxed.

One failed-job rerun request was accepted, but GitHub changed the run to `startup_failure` with an empty check suite and no second test attempt. The same pull request was closed and reopened once without changing its branch or source. An intervening same-head run was cancelled; the fresh run below is the authoritative result. This did not waive the required green CI gate.


**Final CI:** [CI run #34210598878](https://github.com/openclaw/openclaw/actions/runs/34210598878) completed successfully on `4ab02076931423dfd3700ee02cc76e24cbda0d41`: 34 completed jobs, no failures or pending jobs, including the required CI gate. The latest same-head ClawSweeper review has no actionable findings or before-merge requests. The original composer timeout remains an investigation, not a claimed root-cause fix.
