### PR TITLE
fix(update): fail dirty checkout refusals

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -5673,7 +5673,7 @@ describe("update-cli", () => {
       "Commit, stash, or discard the local changes, then rerun `openclaw update`.",
     );
     expect(serviceStop).not.toHaveBeenCalled();
-    expect(defaultRuntime.exit).toHaveBeenCalledWith(0);
+    expect(defaultRuntime.exit).toHaveBeenCalledWith(1);
   });
   it.each([
     {

--- a/src/cli/update-cli/update-command.ts
+++ b/src/cli/update-cli/update-command.ts
@@ -3889,7 +3889,7 @@ async function updateCommandInternal(opts: UpdateCommandOptions): Promise<void> 
         ),
       );
     }
-    defaultRuntime.exit(0);
+    defaultRuntime.exit(result.reason === "dirty" ? 1 : 0);
     return;
   }
 


### PR DESCRIPTION
## Summary

- return exit 1 when a Git update is blocked by local edits
- preserve exit 0 for non-error skipped outcomes
- align the 2026.6.35 CLI with its emitted `Update blocked` result

## Root cause

The candidate correctly refused to mutate a dirty checkout and printed recovery guidance, but the shared skipped-result tail unconditionally called `exit(0)`. Full validation therefore observed a successful process for an explicitly blocked operation.

## Verification

- exact regression failed before the source change (`expected exit(1)`, received `exit(0)`)
- `src/cli/update-cli.test.ts`: 160/160 passed
- OXFmt, OXLint, diff check passed
- production `+1/-1`; tests `+1/-1`

Validation source: full release run 34199223424, candidate child 34200341661.
