### PR TITLE
test(agents): isolate keyless catalog authentication input

### DIFF
--- a/src/agents/models-config.applies-config-env-vars.test.ts
+++ b/src/agents/models-config.applies-config-env-vars.test.ts
@@ -494,23 +494,26 @@ describe("models-config", () => {
     expect(unauthenticatedProviderParsed.providers?.[provider]).toBeUndefined();
   });
 
-  it("leaves keyless catalog authentication to the registry auth owner", () => {
-    expect(unauthenticatedProviderWritePlan.action).toBe("write");
-    expect(unauthenticatedProviderParsed.providers?.["auth-only"]).toBeDefined();
-    if (unauthenticatedProviderWritePlan.action !== "write") {
-      throw new Error("Expected models.json write plan");
-    }
-    const auth = AuthStorage.inMemory();
-    const registry = ModelRegistry.create(auth, "/tmp/openclaw-keyless-catalog/models.json", {
-      includePluginCatalogs: false,
-      modelsJsonContents: unauthenticatedProviderWritePlan.contents,
+  it("leaves keyless catalog authentication to the registry auth owner", async () => {
+    await withTempEnv(["OPENAI_API_KEY"], async () => {
+      unsetEnv(["OPENAI_API_KEY"]);
+      expect(unauthenticatedProviderWritePlan.action).toBe("write");
+      expect(unauthenticatedProviderParsed.providers?.["auth-only"]).toBeDefined();
+      if (unauthenticatedProviderWritePlan.action !== "write") {
+        throw new Error("Expected models.json write plan");
+      }
+      const auth = AuthStorage.inMemory();
+      const registry = ModelRegistry.create(auth, "/tmp/openclaw-keyless-catalog/models.json", {
+        includePluginCatalogs: false,
+        modelsJsonContents: unauthenticatedProviderWritePlan.contents,
+      });
+      const model = registry.find("openai", "gpt-5.5");
+      expect(registry.getError()).toBeUndefined();
+      expect(model).toBeDefined();
+      expect(registry.getAvailable()).not.toContain(model);
+      auth.setRuntimeApiKey("openai", "synthetic-runtime-key");
+      expect(registry.getAvailable()).toContain(model);
     });
-    const model = registry.find("openai", "gpt-5.5");
-    expect(registry.getError()).toBeUndefined();
-    expect(model).toBeDefined();
-    expect(registry.getAvailable()).not.toContain(model);
-    auth.setRuntimeApiKey("openai", "synthetic-runtime-key");
-    expect(registry.getAvailable()).toContain(model);
   });
 
   it("treats empty replace-mode provider sets as authoritative", async () => {


### PR DESCRIPTION
## What Problem This Solves

A keyless catalog test inherited the host's OpenAI environment credential. With a synthetic nonblank credential present, its real registry correctly exposed the model and the test's intended keyless assertion failed.

## Why This Change Was Made

Wrap that existing case in the canonical awaited temporary-environment helper and explicitly unset only its credential input. Keep real registry/AuthStorage behavior and all 50 expectation sites. The helper restores the prior value through its existing finally block.

## User Impact

No production code or authentication policy changes. All 22 test cases remain; the test-only diff is +19/-16.

## Evidence

- Before, with synthetic credential input: 21 pass and the intended keyless case fails.
- After, with synthetic input: all 22 pass. After, with the key absent: all 22 pass.
- Case inventories and all 50 expectation-site lines are retained. No actual credential values were recorded.
- All 20 configured changed checks passed on the retained candidate tree; the one-shot lease completed and its capsule/process cleanup was recorded ([Testbox run](https://github.com/openclaw/openclaw/actions/runs/34204919485)).
- Independent source-bundle audit reconstructs the whole base tree with exactly one changed test file.

The external runner portal-sync timeout warning is retained separately from command exit0 and completed cleanup; portal-sync success is not claimed. Environment restoration is qualified by the unchanged helper source and awaited completion under both input modes, without a separate post-case value observer. This is synthetic registry evidence, not a live-provider or exact-head PR CI result.
