### PR TITLE
refactor(plugins): drop the dead preferBuiltDist on the source loader and name the graph invariant

### DIFF
--- a/src/plugin-sdk/channel-entry-contract.ts
+++ b/src/plugin-sdk/channel-entry-contract.ts
@@ -393,7 +393,6 @@ function getSourceModuleLoader(
     modulePath,
     rootDir: getPluginCacheSource(modulePath).boundaryRoot,
     importerUrl: import.meta.url,
-    preferBuiltDist: true,
     loaderFilename: import.meta.url,
     transformOpenClawDependencies,
     ...(options.createLoaderForTest ? { createLoader: options.createLoaderForTest } : {}),

--- a/src/plugins/plugin-module-loader-cache.ts
+++ b/src/plugins/plugin-module-loader-cache.ts
@@ -285,7 +285,10 @@ function createPluginModuleLoader(params: {
     return loaded;
   };
   // When the caller has explicitly opted out of native loading, route every
-  // target through jiti so caller-provided alias rewrites still apply.
+  // target through jiti so caller-provided alias rewrites still apply. jiti's
+  // module cache is Node's CJS require cache: a natively required ESM entry is
+  // visible there, but its ESM-imported chunks are not, so this graph re-evaluates
+  // shared chunks beside a native graph. Callers keep the two graphs disjoint.
   if (!params.tryNative) {
     return (target) =>
       loadCachedTarget(target, () => {


### PR DESCRIPTION
## What Problem This Solves

Two leftovers from investigating the `plugins-feature-artifact` test break that #141887 fixed:

- `src/plugin-sdk/channel-entry-contract.ts` passes `preferBuiltDist: true` into `getCachedPluginSourceModuleLoader`, but that wrapper forces `tryNative: false`, and `resolvePluginModuleLoaderCacheEntry` only consults `preferBuiltDist` through `resolvePluginLoaderTryNative` when `tryNative` is undefined. The option is inert on that call and reads as if built dist were preferred there. The other three `preferBuiltDist` callers go through `getCachedPluginModuleLoader` and are live.
- The forced-transform branch in `src/plugins/plugin-module-loader-cache.ts` carries a non-obvious invariant with no comment: jiti's `moduleCache` is Node's CJS `require.cache`, so a natively `require()`d ESM entry is visible to jiti while its ESM-imported chunks are not; a transform graph loaded beside a native graph re-evaluates shared chunks. That is exactly what broke the packed-artifact test and why #141887 keeps the two graphs on separate extractions.

## Why This Change Was Made

Remove the dead option so the call site says what it does, and record the invariant at the code site per the repo's inline-comment rule for lifecycle/cache contracts.

## User Impact

None; behavior-neutral. Production LOC −1 plus a 4-line comment.

## Evidence

- Dead-option proof: `resolvePluginModuleLoaderCacheEntry` computes `tryNative = params.tryNative ?? resolvePluginLoaderTryNative(params.modulePath, params)` (`src/plugins/plugin-module-loader-cache.ts:163`), and `getCachedPluginSourceModuleLoader` always passes `tryNative: false` (`:459`), so `resolvePluginLoaderTryNative` — the only reader of `preferBuiltDist` — never runs on this path. `preferBuiltDist` is not part of the alias/cache key either (`preparePluginLoaderAliases` does not receive it).

- Mechanism proof for the comment: a 20-line plain-Node script (`require(esm)` of a packed entry, then a `createJiti({ tryNative: false })` load of its sibling setup entry) shows `index in require.cache = true`, `chunk in require.cache = false`, and the setup's shared object diverging from the entry's; a jiti-only control shares it. Reproduced in #141887's context.
- Focused tests: `src/plugin-sdk/channel-entry-contract*` (15), `src/plugins/plugin-module-loader-cache.test.ts` + `loader.native-module-loader.test.ts` (16), `src/cli/plugins-feature-artifact.test.ts` (27 incl. the packed-artifact cases) all pass.
- `check-changed` on the two files: core/coreTests/extensions typecheck, formatting, coercion/deprecated-API/deadcode/schema guards pass; the extensions oxlint step aborts before linting on the known nested-worktree declaration boundary (`Declaration input escapes checkout … nested inside another install`, a hoisted `punycode`), identical on an untouched `main` worktree. CI is authoritative for that lane.

Review: independent Codex autoreview (local mode, P0–P2) is scoped-clean with no actionable findings.
