### PR TITLE
refactor(tests): reuse sparse text tool-result fixtures

### DIFF
--- a/src/agents/compaction-real-conversation.test.ts
+++ b/src/agents/compaction-real-conversation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { isRealConversationMessage } from "./compaction-real-conversation.js";
 import type { AgentMessage } from "./runtime/index.js";
+import { textToolResult } from "./test-helpers/sparse-transcript.test-support.js";
 
 type SummaryRole = "branchSummary" | "compactionSummary";
 
@@ -13,12 +14,7 @@ describe("compaction real conversation classification", () => {
     "treats non-empty %s messages as conversation anchors",
     (role) => {
       const summary = summaryMessage(role, "The user asked for a repository audit.");
-      const toolResult = {
-        role: "toolResult",
-        toolCallId: "call-1",
-        toolName: "exec",
-        content: [{ type: "text", text: "audit output" }],
-      } as AgentMessage;
+      const toolResult = textToolResult("call-1", "exec", "audit output") as AgentMessage;
       const messages = [summary, toolResult];
 
       expect(isRealConversationMessage(summary, messages, 0)).toBe(true);
@@ -49,12 +45,7 @@ describe("compaction real conversation classification", () => {
         excludeFromContext,
         timestamp: 1,
       } satisfies AgentMessage;
-      const toolResult = {
-        role: "toolResult",
-        toolCallId: "call-1",
-        toolName: "exec",
-        content: [{ type: "text", text: "audit output" }],
-      } as AgentMessage;
+      const toolResult = textToolResult("call-1", "exec", "audit output") as AgentMessage;
       const messages = [custom, toolResult];
 
       expect(isRealConversationMessage(custom, messages, 0)).toBe(expected);
@@ -67,12 +58,7 @@ describe("compaction real conversation classification", () => {
       role: "assistant",
       content: [{ type: "toolCall", id: "call-1", name: "exec", arguments: {} }],
     } as AgentMessage;
-    const orphanToolResult = {
-      role: "toolResult",
-      toolCallId: "call-1",
-      toolName: "exec",
-      content: [{ type: "text", text: "audit output" }],
-    } as AgentMessage;
+    const orphanToolResult = textToolResult("call-1", "exec", "audit output") as AgentMessage;
 
     expect(isRealConversationMessage(toolCall, [toolCall], 0)).toBe(false);
     expect(isRealConversationMessage(orphanToolResult, [orphanToolResult], 0)).toBe(false);
@@ -108,12 +94,7 @@ describe("compaction real conversation classification", () => {
       expected: true,
     },
   ])("classifies tool output after a $name", ({ preceding, expected }) => {
-    const toolResult = {
-      role: "toolResult",
-      toolCallId: "call-1",
-      toolName: "exec",
-      content: [{ type: "text", text: "checked" }],
-    } as AgentMessage;
+    const toolResult = textToolResult("call-1", "exec", "checked") as AgentMessage;
     const messages = [...preceding, toolResult] as AgentMessage[];
 
     expect(isRealConversationMessage(toolResult, messages, preceding.length)).toBe(expected);
@@ -126,12 +107,7 @@ describe("compaction real conversation classification", () => {
       content: "prepare the daily report",
       display: true,
     } as AgentMessage;
-    const toolResult = {
-      role: "toolResult",
-      toolCallId: "call-1",
-      toolName: "read",
-      content: [{ type: "text", text: "report source data" }],
-    } as AgentMessage;
+    const toolResult = textToolResult("call-1", "read", "report source data") as AgentMessage;
     const messages = [
       custom,
       {

--- a/src/agents/embedded-agent-helpers.validate-turns.test.ts
+++ b/src/agents/embedded-agent-helpers.validate-turns.test.ts
@@ -4,6 +4,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it } from "vitest";
 import { validateAnthropicTurns, validateGeminiTurns } from "./embedded-agent-helpers.js";
+import { textToolResult } from "./test-helpers/sparse-transcript.test-support.js";
 
 function asMessages(messages: unknown[]): AgentMessage[] {
   return messages as AgentMessage[];
@@ -693,13 +694,7 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
         role: "assistant",
         content: makeSignedThinkingGatewayToolCall("tool-1"),
       },
-      {
-        role: "toolResult",
-        toolCallId: "tool-1",
-        toolName: "gateway",
-        content: [{ type: "text", text: "ok" }],
-        isError: false,
-      },
+      textToolResult("tool-1", "gateway", "ok", { isError: false }),
       { role: "user", content: [{ type: "text", text: "Continue" }] },
     ]);
 
@@ -782,13 +777,7 @@ describe("validateAnthropicTurns strips dangling tool_use blocks", () => {
         role: "assistant",
         content: makeSignedThinkingGatewayToolCall("tool-1"),
       },
-      {
-        role: "toolResult",
-        toolCallId: "tool-1",
-        toolName: "exec",
-        content: [{ type: "text", text: "wrong tool" }],
-        isError: false,
-      },
+      textToolResult("tool-1", "exec", "wrong tool", { isError: false }),
       { role: "user", content: [{ type: "text", text: "Continue" }] },
     ]);
 

--- a/src/agents/embedded-agent-runner.guard.test.ts
+++ b/src/agents/embedded-agent-runner.guard.test.ts
@@ -25,6 +25,7 @@ import { runAgentHarnessBeforeMessageWriteHook } from "./harness/hook-helpers.js
 import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
 import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
+import { textToolResult } from "./test-helpers/sparse-transcript.test-support.js";
 
 function assistantToolCall(id: string): AgentMessage {
   return {
@@ -84,13 +85,7 @@ describe("guardSessionManager integration", () => {
       model: "delivery-mirror",
       content: [{ type: "text", text: "display copy" }],
     } as AgentMessage);
-    appendMessage({
-      role: "toolResult",
-      toolCallId: "call_1",
-      toolName: "n",
-      content: [{ type: "text", text: "real output" }],
-      isError: false,
-    } as AgentMessage);
+    appendMessage(textToolResult("call_1", "n", "real output", { isError: false }) as AgentMessage);
 
     const messages = getMessages(sm);
 
@@ -515,13 +510,9 @@ describe("guardSessionManager integration", () => {
       ],
       stopReason: "toolUse",
     } as AgentMessage);
-    appendMessage({
-      role: "toolResult",
-      toolCallId: "call_1",
-      toolName: "read",
-      content: [{ type: "text", text: "peter@dc.io\n" }],
-      isError: false,
-    } as AgentMessage);
+    appendMessage(
+      textToolResult("call_1", "read", "peter@dc.io\n", { isError: false }) as AgentMessage,
+    );
 
     const messages = getMessages(sm);
 

--- a/src/agents/embedded-agent-runner.openai-tool-id-preservation.test.ts
+++ b/src/agents/embedded-agent-runner.openai-tool-id-preservation.test.ts
@@ -11,6 +11,7 @@ import {
   type SanitizeSessionHistoryHarness,
 } from "./embedded-agent-runner.sanitize-session-history.test-harness.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
+import { textToolResult } from "./test-helpers/sparse-transcript.test-support.js";
 
 vi.mock("./embedded-agent-helpers.js", async () => await createSanitizeSessionHistoryHelpersMock());
 
@@ -75,13 +76,7 @@ describe("sanitizeSessionHistory openai tool id preservation", () => {
         { type: "toolCall", id: "call_123|fc_123", name: "noop", arguments: {} },
       ],
     }),
-    castAgentMessage({
-      role: "toolResult",
-      toolCallId: "call_123|fc_123",
-      toolName: "noop",
-      content: [{ type: "text", text: "ok" }],
-      isError: false,
-    }),
+    castAgentMessage(textToolResult("call_123|fc_123", "noop", "ok", { isError: false })),
   ];
 
   it.each([
@@ -128,13 +123,7 @@ describe("sanitizeSessionHistory openai tool id preservation", () => {
           role: "user",
           content: [{ type: "text", text: "still waiting" }],
         }),
-        castAgentMessage({
-          role: "toolResult",
-          toolCallId: "call_123|fc_123",
-          toolName: "noop",
-          content: [{ type: "text", text: "ok" }],
-          isError: false,
-        }),
+        castAgentMessage(textToolResult("call_123|fc_123", "noop", "ok", { isError: false })),
       ],
       modelApi: "openai-responses",
       provider: "openai",

--- a/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
+++ b/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
@@ -24,6 +24,7 @@ import {
 } from "./embedded-agent-runner.sanitize-session-history.test-harness.js";
 import { validateReplayTurns } from "./embedded-agent-runner/replay-history.js";
 import { castAgentMessage, castAgentMessages } from "./test-helpers/agent-message-fixtures.js";
+import { textToolResult } from "./test-helpers/sparse-transcript.test-support.js";
 import { extractToolCallsFromAssistant } from "./tool-call-id.js";
 import type { TranscriptPolicy } from "./transcript-policy.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
@@ -844,13 +845,12 @@ describe("sanitizeSessionHistory", () => {
         ],
         { stopReason: "toolUse" },
       ),
-      {
-        role: "toolResult",
-        toolCallId: "callmockimagegenerate0b27d8fa84",
-        toolName: "image_generate",
-        content: [{ type: "text", text: "Background task started for image generation." }],
-        isError: false,
-      },
+      textToolResult(
+        "callmockimagegenerate0b27d8fa84",
+        "image_generate",
+        "Background task started for image generation.",
+        { isError: false },
+      ),
       {
         role: "custom",
         content: "Image generation started; wait for completion.",
@@ -1041,13 +1041,7 @@ describe("sanitizeSessionHistory", () => {
         { stopReason: "toolUse" },
       ),
       makeUserMessage("continue"),
-      castAgentMessage({
-        role: "toolResult",
-        toolCallId: "call_2",
-        toolName: "exec",
-        content: [{ type: "text", text: "ok" }],
-        isError: false,
-      }),
+      castAgentMessage(textToolResult("call_2", "exec", "ok", { isError: false })),
     ];
 
     const result = await sanitizeOpenAIHistory(messages);
@@ -1108,30 +1102,12 @@ describe("sanitizeSessionHistory", () => {
 
   it("drops duplicate and orphan OpenAI outputs while preserving the first real result", async () => {
     const messages: AgentMessage[] = [
-      castAgentMessage({
-        role: "toolResult",
-        toolCallId: "call_orphan",
-        toolName: "read",
-        content: [{ type: "text", text: "orphan" }],
-        isError: false,
-      }),
+      castAgentMessage(textToolResult("call_orphan", "read", "orphan", { isError: false })),
       makeAssistantMessage([{ type: "toolCall", id: "call_keep", name: "read", arguments: {} }], {
         stopReason: "toolUse",
       }),
-      castAgentMessage({
-        role: "toolResult",
-        toolCallId: "call_keep",
-        toolName: "read",
-        content: [{ type: "text", text: "first" }],
-        isError: false,
-      }),
-      castAgentMessage({
-        role: "toolResult",
-        toolCallId: "call_keep",
-        toolName: "read",
-        content: [{ type: "text", text: "duplicate" }],
-        isError: false,
-      }),
+      castAgentMessage(textToolResult("call_keep", "read", "first", { isError: false })),
+      castAgentMessage(textToolResult("call_keep", "read", "duplicate", { isError: false })),
       makeUserMessage("continue"),
     ];
 
@@ -1989,13 +1965,7 @@ describe("sanitizeSessionHistory", () => {
           } as unknown as ThinkingContent,
           { type: "toolCall", id: "call_1", name: "lookup", arguments: {} },
         ]),
-        castAgentMessage({
-          role: "toolResult",
-          toolCallId: "call_1",
-          toolName: "lookup",
-          content: [{ type: "text", text: "42" }],
-          isError: false,
-        }),
+        castAgentMessage(textToolResult("call_1", "lookup", "42", { isError: false })),
       ]);
 
       const result = await sanitizeAnthropicHistory({
@@ -2186,13 +2156,7 @@ describe("sanitizeSessionHistory", () => {
           },
           { type: "toolCall", id: "call_1", name: "read", arguments: {} },
         ] as unknown as AssistantMessage["content"]),
-        castAgentMessage({
-          role: "toolResult",
-          toolCallId: "call_1",
-          toolName: "read",
-          content: [{ type: "text", text: "ok" }],
-          isError: false,
-        }),
+        castAgentMessage(textToolResult("call_1", "read", "ok", { isError: false })),
       ]);
 
       const result = await sanitizeAnthropicHistory({
@@ -2228,13 +2192,7 @@ describe("sanitizeSessionHistory", () => {
           },
           { type: "toolCall", id: "call_1", name: "read", arguments: {} },
         ] as unknown as AssistantMessage["content"]),
-        castAgentMessage({
-          role: "toolResult",
-          toolCallId: "call_1",
-          toolName: "read",
-          content: [{ type: "text", text: "ok" }],
-          isError: false,
-        }),
+        castAgentMessage(textToolResult("call_1", "read", "ok", { isError: false })),
       ]);
 
       const result = await sanitizeAnthropicHistory({
@@ -2275,13 +2233,7 @@ describe("sanitizeSessionHistory", () => {
     const messages = castAgentMessages([
       makeUserMessage("first"),
       makeAssistantMessage([{ type: "toolCall", id: "call_1", name: "read", arguments: {} }]),
-      castAgentMessage({
-        role: "toolResult",
-        toolCallId: "call_1",
-        toolName: "read",
-        content: [{ type: "text", text: "first result" }],
-        isError: false,
-      }),
+      castAgentMessage(textToolResult("call_1", "read", "first result", { isError: false })),
       makeUserMessage("second"),
       makeAssistantMessage(
         [
@@ -2290,13 +2242,7 @@ describe("sanitizeSessionHistory", () => {
         ] as unknown as AssistantMessage["content"],
         { stopReason: "toolUse" },
       ),
-      castAgentMessage({
-        role: "toolResult",
-        toolCallId: "call1",
-        toolName: "read",
-        content: [{ type: "text", text: "second result" }],
-        isError: false,
-      }),
+      castAgentMessage(textToolResult("call1", "read", "second result", { isError: false })),
       makeUserMessage("retry"),
     ]);
 
@@ -2371,13 +2317,7 @@ describe("sanitizeSessionHistory", () => {
         ] as unknown as AssistantMessage["content"],
         { stopReason: "toolUse" },
       ),
-      castAgentMessage({
-        role: "toolResult",
-        toolCallId: "call1",
-        toolName: "read",
-        content: [{ type: "text", text: "first result" }],
-        isError: false,
-      }),
+      castAgentMessage(textToolResult("call1", "read", "first result", { isError: false })),
       makeUserMessage("second"),
       makeAssistantMessage(
         [
@@ -2386,13 +2326,7 @@ describe("sanitizeSessionHistory", () => {
         ] as unknown as AssistantMessage["content"],
         { stopReason: "toolUse" },
       ),
-      castAgentMessage({
-        role: "toolResult",
-        toolCallId: "call1",
-        toolName: "read",
-        content: [{ type: "text", text: "second result" }],
-        isError: false,
-      }),
+      castAgentMessage(textToolResult("call1", "read", "second result", { isError: false })),
       makeUserMessage("retry"),
     ]);
 

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.test.ts
@@ -2,6 +2,7 @@
 
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it, vi } from "vitest";
+import { textToolResult } from "../../test-helpers/sparse-transcript.test-support.js";
 import {
   sanitizeOpenAIResponsesReplayForStream,
   sanitizeReplayToolCallIdsForStream,
@@ -644,13 +645,7 @@ describe("sanitizeOpenAIResponsesReplayForStream", () => {
           { type: "toolCall", id: "call_123|fc_123", name: "noop", arguments: {} },
         ],
       } as never,
-      {
-        role: "toolResult",
-        toolCallId: "call_123|fc_123",
-        toolName: "noop",
-        content: [{ type: "text", text: "ok" }],
-        isError: false,
-      } as never,
+      textToolResult("call_123|fc_123", "noop", "ok", { isError: false }) as never,
     ];
 
     expect(sanitizeOpenAIResponsesReplayForStream(messages)).toBe(messages);
@@ -674,13 +669,12 @@ describe("sanitizeOpenAIResponsesReplayForStream", () => {
           },
         ],
       } as never,
-      {
-        role: "toolResult",
-        toolCallId: "call_mock_image_generate_1",
-        toolName: "image_generate",
-        content: [{ type: "text", text: "Background task started for image generation." }],
-        isError: false,
-      } as never,
+      textToolResult(
+        "call_mock_image_generate_1",
+        "image_generate",
+        "Background task started for image generation.",
+        { isError: false },
+      ) as never,
       {
         role: "custom",
         content: "Image generation started; wait for completion.",

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -1,6 +1,7 @@
 // Broad helper coverage for runEmbeddedAttempt prompt, stream, and tool seams.
 import { describe, expect, it, vi } from "vitest";
 import { streamSimple } from "../../../llm/stream.js";
+import { textToolResult } from "../../test-helpers/sparse-transcript.test-support.js";
 
 vi.mock("../context-engine-capabilities.js", () => ({
   resolveContextEngineCapabilities: async () => ({ llm: undefined }),
@@ -1926,12 +1927,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
       role: "assistant",
       content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
     };
-    const firstResult = {
-      role: "toolResult",
-      toolCallId: "call_1",
-      toolName: "read",
-      content: [{ type: "text", text: "mutable result" }],
-    };
+    const firstResult = textToolResult("call_1", "read", "mutable result");
     const userMessage = {
       role: "user",
       content: [{ type: "text", text: "retry" }],
@@ -2104,12 +2100,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
           },
         ],
       },
-      {
-        role: "toolResult",
-        toolCallId: "call_1",
-        toolName: "sessions_spawn",
-        content: [{ type: "text", text: "done" }],
-      },
+      textToolResult("call_1", "sessions_spawn", "done"),
       {
         role: "user",
         content: [{ type: "text", text: "retry" }],
@@ -2379,13 +2370,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
         role: "assistant",
         content: [{ type: "toolCall", id: "call_1", name: "   ", arguments: {} }],
       },
-      {
-        role: "toolResult",
-        toolCallId: "call_1",
-        toolName: "",
-        content: [{ type: "text", text: "stale result" }],
-        isError: true,
-      },
+      textToolResult("call_1", "", "stale result", { isError: true }),
     ];
     const baseFn = vi.fn((_model, _context) =>
       createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
@@ -2433,13 +2418,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
         content: [{ type: "toolCall", name: "read", arguments: {} }],
         stopReason: "error",
       },
-      {
-        role: "toolResult",
-        toolCallId: "call_missing",
-        toolName: "read",
-        content: [{ type: "text", text: "stale result" }],
-        isError: false,
-      },
+      textToolResult("call_missing", "read", "stale result", { isError: false }),
       {
         role: "user",
         content: [{ type: "text", text: "retry" }],
@@ -2473,13 +2452,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
         role: "assistant",
         content: [{ type: "toolCall", id: "call_1", name: "write", arguments: {} }],
       },
-      {
-        role: "toolResult",
-        toolCallId: "call_1",
-        toolName: "write",
-        content: [{ type: "text", text: "stale result" }],
-        isError: false,
-      },
+      textToolResult("call_1", "write", "stale result", { isError: false }),
       {
         role: "user",
         content: [{ type: "text", text: "retry" }],
@@ -2512,13 +2485,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
         role: "assistant",
         content: [{ type: "toolUse", id: "call_1", name: "unknown_tool", input: { path: "." } }],
       },
-      {
-        role: "toolResult",
-        toolCallId: "call_1",
-        toolName: "unknown_tool",
-        content: [{ type: "text", text: "stale result" }],
-        isError: false,
-      },
+      textToolResult("call_1", "unknown_tool", "stale result", { isError: false }),
     ];
     const baseFn = vi.fn((_model, _context) =>
       createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
@@ -2570,13 +2537,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
           { type: "toolCall", name: "read", arguments: {} },
         ],
       },
-      {
-        role: "toolResult",
-        toolCallId: "call_1",
-        toolName: "read",
-        content: [{ type: "text", text: "kept result" }],
-        isError: false,
-      },
+      textToolResult("call_1", "read", "kept result", { isError: false }),
       {
         role: "user",
         content: [{ type: "text", text: "retry" }],

--- a/src/agents/embedded-agent-runner/run/history-image-prune.test.ts
+++ b/src/agents/embedded-agent-runner/run/history-image-prune.test.ts
@@ -13,6 +13,7 @@ import {
 import { buildPersistedUserTurnMessage } from "../../../sessions/user-turn-transcript.js";
 import { castAgentMessage } from "../../test-helpers/agent-message-fixtures.js";
 import { createHostSandboxFsBridge } from "../../test-helpers/host-sandbox-fs-bridge.js";
+import { textToolResult } from "../../test-helpers/sparse-transcript.test-support.js";
 import {
   installHistoryImagePruneContextTransform,
   pruneProcessedHistoryImages,
@@ -483,12 +484,7 @@ describe("pruneProcessedHistoryImages", () => {
         role: "assistant",
         content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
       } as AgentMessage),
-      castAgentMessage({
-        role: "toolResult",
-        toolCallId: "call_1",
-        toolName: "read",
-        content: [{ type: "text", text: "bytes" }],
-      }),
+      castAgentMessage(textToolResult("call_1", "read", "bytes")),
       assistantTurn(),
       userText(),
       assistantTurn(),
@@ -542,12 +538,7 @@ describe("pruneProcessedHistoryImages", () => {
         role: "assistant",
         content: [{ type: "toolCall", id: "call_4", name: "read", arguments: {} }],
       }),
-      castAgentMessage({
-        role: "toolResult",
-        toolCallId: "call_4",
-        toolName: "read",
-        content: [{ type: "text", text: "bytes" }],
-      }),
+      castAgentMessage(textToolResult("call_4", "read", "bytes")),
     );
     const duringLoop = pruneProcessedHistoryImages(messages) ?? messages;
     expect(JSON.stringify(duringLoop.slice(0, retainedLength))).toBe(retainedBytes);

--- a/src/agents/embedded-agent-runner/transcript-file-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parseSessionEntries, SessionManager } from "../sessions/index.js";
+import { textToolResult } from "../test-helpers/sparse-transcript.test-support.js";
 
 const roots: string[] = [];
 
@@ -260,13 +261,7 @@ describe("readTranscriptState", () => {
         id: "tool-result",
         parentId: "assistant-tool",
         timestamp: "2026-05-16T00:00:03.000Z",
-        message: {
-          role: "toolResult",
-          toolCallId: "call-input",
-          toolName: "read",
-          content: [{ type: "text", text: "contents" }],
-          isError: false,
-        },
+        message: textToolResult("call-input", "read", "contents", { isError: false }),
       }),
     ]);
 

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -10,6 +10,7 @@ import { createAssistantErrorTranscript } from "./assistant-error-transcript.js"
 import { buildExecForegroundResult } from "./bash-tools.exec-support.js";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
+import { textToolResult } from "./test-helpers/sparse-transcript.test-support.js";
 import { redactTranscriptMessage } from "./transcript-redact.js";
 
 type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
@@ -254,15 +255,7 @@ describe("installSessionToolResultGuard", () => {
     installSessionToolResultGuard(sm);
 
     sm.appendMessage(toolCallMessage);
-    sm.appendMessage(
-      asAppendMessage({
-        role: "toolResult",
-        toolCallId: "call_1",
-        toolName: "   ",
-        content: [{ type: "text", text: "ok" }],
-        isError: false,
-      }),
-    );
+    sm.appendMessage(asAppendMessage(textToolResult("call_1", "   ", "ok", { isError: false })));
 
     const messages = expectPersistedRoles(sm, ["assistant", "toolResult"]) as Array<{
       role: string;
@@ -437,13 +430,7 @@ describe("installSessionToolResultGuard", () => {
     appendAssistantToolCall(sm, { id: "call_1", name: "read" });
     appendAssistantToolCall(sm, { id: "call_2", name: "exec" });
     sm.appendMessage(
-      asAppendMessage({
-        role: "toolResult",
-        toolCallId: "call_1",
-        toolName: "read",
-        content: [{ type: "text", text: "real output" }],
-        isError: false,
-      }),
+      asAppendMessage(textToolResult("call_1", "read", "real output", { isError: false })),
     );
 
     const messages = expectPersistedRoles(sm, ["assistant", "assistant", "toolResult"]);
@@ -730,13 +717,7 @@ describe("installSessionToolResultGuard", () => {
       sm.appendMessage(toolCallMessage);
       if (blocked) {
         sm.appendMessage(
-          asAppendMessage({
-            role: "toolResult",
-            toolCallId: "call_1",
-            toolName: "read",
-            content: [{ type: "text", text: "blocked" }],
-            isError: false,
-          }),
+          asAppendMessage(textToolResult("call_1", "read", "blocked", { isError: false })),
         );
       }
       guard.flushPendingToolResults();
@@ -772,13 +753,7 @@ describe("installSessionToolResultGuard", () => {
     });
     sm.appendMessage(toolCallMessage);
     sm.appendMessage(
-      asAppendMessage({
-        role: "toolResult",
-        toolCallId: "call_1",
-        toolName: "   ",
-        content: [{ type: "text", text: "original" }],
-        isError: false,
-      }),
+      asAppendMessage(textToolResult("call_1", "   ", "original", { isError: false })),
     );
     expect(observed).toEqual(["read", "read"]);
     expect(getToolResultText(getPersistedMessages(sm))).toBe("hook applied");

--- a/src/agents/session-transcript-repair.test.ts
+++ b/src/agents/session-transcript-repair.test.ts
@@ -228,13 +228,7 @@ describe("sanitizeToolUseResultPairing", () => {
   });
 
   it("reports the original messages discarded during pairing repair", () => {
-    const orphan = {
-      role: "toolResult" as const,
-      toolCallId: "call_orphan",
-      toolName: "read",
-      content: [{ type: "text" as const, text: "orphan" }],
-      isError: false,
-    };
+    const orphan = textToolResult("call_orphan", "read", "orphan", { isError: false });
     const input = castAgentMessages([
       { role: "user", content: "hello" },
       orphan,
@@ -669,13 +663,7 @@ describe("repairToolUseResultPairing prefers real result over synthetic error", 
   it("real error matching custom synthetic text stays first without marker", () => {
     const input = castAgentMessages([
       makeAssistant("call_1"),
-      {
-        role: "toolResult" as const,
-        toolCallId: "call_1",
-        toolName: "read",
-        content: [{ type: "text", text: "aborted" }],
-        isError: true,
-      },
+      textToolResult("call_1", "read", "aborted", { isError: true }),
       makeRealResult("call_1"),
     ]);
 
@@ -717,13 +705,7 @@ describe("repairToolUseResultPairing prefers real result over synthetic error", 
         content: [{ type: "toolCall", id: "call_2", name: "write", arguments: {} }],
       },
       makeRealResult("call_1"),
-      {
-        role: "toolResult" as const,
-        toolCallId: "call_2",
-        toolName: "write",
-        content: [{ type: "text", text: "second output" }],
-        isError: false,
-      },
+      textToolResult("call_2", "write", "second output", { isError: false }),
     ]);
 
     const result = repairToolUseResultPairing(input);


### PR DESCRIPTION
## What Problem This Solves

Agent tests repeat large text-only tool-result fixtures that the existing sparse transcript helper already represents.

## Why This Change Was Made

Reuse `textToolResult` at 42 input construction sites, removing 223 net test lines. Preserve literal values, property order and absence, fresh message/content-array/text-block allocation, existing casts and reference bindings. The helper and independent expected-result literals are unchanged.

## User Impact

No production or user-visible behavior changes. Existing scenarios, assertions and deadlines remain intact.

## Evidence

- All 494 tests passed before and after across the same 12 complete suites, including the existing helper consumer; per-file ordered case names and statuses match.
- Inline expansion matches the original executable structure across all 11 changed files. Runtime fixture checks preserve values, key order, prototypes and independent nested allocations at all 42 sites.
- Mapped changed gate passed; deslop and independent P2 review are clean.

No overall test-runtime or coverage-percentage claim.
