### PR TITLE
fix(control-ui): sort advanced config sections alphabetically

### DIFF
--- a/ui/src/components/config-form.render.ts
+++ b/ui/src/components/config-form.render.ts
@@ -1,7 +1,7 @@
 // Control UI view renders config form.render screen content.
 import { html, nothing, type TemplateResult } from "lit";
 import type { ConfigUiHints } from "../api/types.ts";
-import { t } from "../i18n/index.ts";
+import { i18n, t } from "../i18n/index.ts";
 import "./web-awesome-popover.ts";
 import { SECTION_META } from "./config-form.meta.ts";
 import { renderNode } from "./config-form.node.ts";
@@ -25,6 +25,8 @@ type ConfigFormProps = {
   searchQuery?: string;
   activeSection?: string | null;
   activeSubsection?: string | null;
+  /** The flat Advanced page sorts section headings; curated pages retain schema order. */
+  alphabeticalSections?: boolean;
   showAdvanced?: boolean;
   forceAdvancedSection?: string | null;
   /** Required: the collapsed advanced disclosure's only action. Optional would
@@ -150,7 +152,18 @@ export function renderConfigForm(props: ConfigFormProps) {
   const activeSection = props.activeSection;
   const activeSubsection = props.activeSubsection ?? null;
 
+  const sectionLabel = (key: string) =>
+    SECTION_META[key]?.label ?? key.charAt(0).toUpperCase() + key.slice(1);
+  const sectionCollator = props.alphabeticalSections
+    ? new Intl.Collator(i18n.getLocale(), { sensitivity: "accent" })
+    : null;
   const entries = Object.entries(properties).toSorted((a, b) => {
+    if (sectionCollator) {
+      return (
+        sectionCollator.compare(sectionLabel(a[0]), sectionLabel(b[0])) ||
+        (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0)
+      );
+    }
     const orderA = hintForPath([a[0]], props.uiHints)?.order ?? 50;
     const orderB = hintForPath([b[0]], props.uiHints)?.order ?? 50;
     if (orderA !== orderB) {
@@ -326,15 +339,10 @@ export function renderConfigForm(props: ConfigFormProps) {
           });
         })()
       : filteredEntries.map(([key, node]) => {
-          const meta = SECTION_META[key] ?? {
-            label: key.charAt(0).toUpperCase() + key.slice(1),
-            description: node.description ?? "",
-          };
-
           return renderSection({
             id: `config-section-${key}`,
-            label: meta.label,
-            description: meta.description,
+            label: sectionLabel(key),
+            description: SECTION_META[key]?.description ?? node.description ?? "",
             node,
             nodeValue: value[key],
             path: [key],

--- a/ui/src/pages/config/view.browser.test.ts
+++ b/ui/src/pages/config/view.browser.test.ts
@@ -4,6 +4,7 @@ import { beforeAll, describe, expect, it, vi } from "vitest";
 import "../../styles.css";
 import type { ThemeMode, ThemeName } from "../../app/theme.ts";
 import { renderConfigForm } from "../../components/config-form.ts";
+import { i18n } from "../../i18n/index.ts";
 import { warmJson5 } from "../../lib/json5-runtime.ts";
 import { renderBrowserLinkPreferencesRow } from "./browser-link-preferences.ts";
 import { createConfigViewState, renderConfig, type ConfigProps } from "./view.ts";
@@ -115,6 +116,82 @@ describe("config view", () => {
     setCatalogOpenTarget: vi.fn(),
     gatewayUrl: "",
     assistantName: "OpenClaw",
+  });
+
+  it.each([
+    { locale: "en" as const, advanced: true, keys: ["cron", "cli", "env", "logging"] },
+    { locale: "de" as const, advanced: true, keys: ["cron", "cli", "logging", "env"] },
+    { locale: "en" as const, advanced: false, keys: ["env", "cli", "cron", "logging"] },
+  ])(
+    "orders top-level sections for $locale with Advanced=$advanced",
+    async ({ locale, advanced, keys }) => {
+      const previousLocale = i18n.getLocale();
+      try {
+        await i18n.setLocale(locale);
+        const { container } = renderConfigView({
+          schema: {
+            type: "object",
+            properties: Object.fromEntries(
+              ["logging", "env", "cli", "cron"].map((key) => [
+                key,
+                { type: "object", properties: { enabled: { type: "boolean" } } },
+              ]),
+            ),
+          },
+          uiHints: {
+            env: { order: -1 },
+            cli: { order: 26 },
+            cron: { order: 100 },
+            logging: { order: 900 },
+          },
+          forceShowAdvanced: advanced,
+          showAdvancedSettings: true,
+        });
+        expect(
+          [...container.querySelectorAll("section.settings-section")].map((section) => section.id),
+        ).toEqual(keys.map((key) => `config-section-${key}`));
+      } finally {
+        await i18n.setLocale(previousLocale);
+      }
+    },
+  );
+
+  it("breaks equal-label ties by key and preserves nested hint ordering", () => {
+    for (const keys of [
+      ["zebra", "alpha", "Alpha", "äther", "zEBRA"],
+      ["zEBRA", "äther", "Alpha", "alpha", "zebra"],
+    ]) {
+      const { container } = renderConfigView({
+        schema: {
+          type: "object",
+          properties: Object.fromEntries(
+            keys.map((key) => [
+              key,
+              {
+                type: "object",
+                properties: { first: { type: "string" }, last: { type: "string" } },
+              },
+            ]),
+          ),
+        },
+        uiHints: Object.fromEntries(
+          keys.flatMap((key) => [
+            [`${key}.first`, { order: 90 }],
+            [`${key}.last`, { order: 1 }],
+          ]),
+        ),
+        forceShowAdvanced: true,
+      });
+      const sections = [...container.querySelectorAll("section.settings-section")];
+      expect(sections.map((section) => section.id)).toEqual(
+        ["Alpha", "alpha", "äther", "zEBRA", "zebra"].map((key) => `config-section-${key}`),
+      );
+      for (const section of sections) {
+        expect(
+          [...section.querySelectorAll("input")].map((input) => input.getAttribute("aria-label")),
+        ).toEqual(["Last", "First"]);
+      }
+    }
   });
 
   it("lets config pages grow with their content instead of creating an inner viewport", async () => {

--- a/ui/src/pages/config/view.ts
+++ b/ui/src/pages/config/view.ts
@@ -512,6 +512,7 @@ export function renderConfig(props: ConfigProps) {
                             onRemove: props.onFormRemove,
                             activeSection: props.activeSection,
                             activeSubsection: null,
+                            alphabeticalSections: props.forceShowAdvanced === true,
                             showAdvanced: effectiveShowAdvanced,
                             forceAdvancedSection: props.forceAdvancedSection,
                             onShowAdvanced: () => props.setShowAdvancedSettings(true),


### PR DESCRIPTION
Related: #137190 (schema-label localization context).

## What Problem This Solves

Fixes an issue where users browsing Settings → Advanced would see top-level configuration sections in a confusing order. For example, CLI and Diagnostics appeared before Broadcast, while Logging appeared after Metadata.

## Why This Change Was Made

The shared form renderer sorted sections by `uiHints.order`, treated missing orders as `50`, and then compared raw schema keys. This split the catch-all list into schema-priority groups. Advanced now sorts only its top-level section headings by their displayed labels, using the active UI locale and a case-insensitive, accent-sensitive `Intl.Collator`. Raw schema keys break equal-label ties deterministically, independent of schema insertion order.

Only the Advanced route enables this behavior. Curated screens retain schema hint ordering, including when their advanced fields are visible. Nested fields, schema hints, navigation controls, and the separate Setup disclosure retain their existing behavior and placement. Displayed labels are the sort source because localized headings can differ from schema keys—for example, `env` is “Environment Variables” in English and “Umgebungsvariablen” in German. This change does not translate schema hints or resolve #137190.

## User Impact

Users can scan the Advanced catch-all alphabetically in their selected language. DOM heading and field order follow the visible order. Existing labels, control semantics, and accessible names are preserved. No translation catalogs, configuration schema, or installed OpenClaw package are changed.

## Evidence

### Real behavior proof

Verified the actual Control UI at `/settings/advanced` in Chromium 151.0.7922.34 on macOS arm64, with Node 24.16.0 and pnpm 12.3.4. The repository Vite server and `installMockGateway` supplied the same six-section synthetic config for both captures. Viewport: 1440 × 1400; light color scheme; English locale. The script asserted the rendered heading order and receipt of `config.schema`. Both runs recorded zero page errors and zero error-level console messages. This is browser proof with a mocked Gateway; no operator Gateway or real configuration was used.

| Before — `fcaf2d34a29` | After — `ef899c5ff26` |
| --- | --- |
| ![Before: Advanced config at fcaf2d34a29, 1440 by 1400, synthetic Gateway](https://github.com/user-attachments/assets/db5fb50d-8441-425d-acd8-b4b342a6dfc7) | ![After: Advanced config at ef899c5ff26, 1440 by 1400, same synthetic Gateway](https://github.com/user-attachments/assets/4e5b6def-847c-4859-abe4-740e80aafc7e) |

Before: CLI → Diagnostics → Broadcast → Environment Variables → Metadata → Logging.

After: Broadcast → CLI → Diagnostics → Environment Variables → Logging → Metadata.

Additional browser proof on the unchanged `ef899c5ff26` commit: Firefox 153.0 and WebKit 26.5 each passed the actual Advanced page flow in English (`en-US`) and German (`de-DE`). Each of the four runs asserted all 11 rendered labels and section IDs, including accent ordering (`Äther`) and deterministic equal-label/case ties (`Alpha`/`alpha`, `zEBRA`/`zebra`). The runs used the same synthetic Gateway and a 1440 × 2200 viewport.

Firefox recorded no page or error-level console errors. WebKit recorded no page errors and one existing viewport diagnostic per run: `Viewport argument key "interactive-widget" not recognized and ignored.` This comes from unchanged `ui/index.html:7`; a separate WebKit probe reproduced the exact diagnostic using the viewport markup from base `fcaf2d34a29`. Initial WebKit runs passed the ordering assertions but failed the zero-console-error assertion. The final proof records and asserts that exact existing diagnostic; no other errors occurred. No product code or test expectation was changed for this diagnostic.

### Validation

- Regression proof on the original renderer: 3 new cases failed for the intended ordering mismatch; the curated-order case passed.
- Final focused browser suites: **84 tests passed** across 2 files. Coverage includes English/German displayed labels, curated ordering with advanced fields visible, mixed-case/equal-label ties, reversed schema insertion order, and nested `uiHints.order`.
- `pnpm check:changed -- <three changed files>`: passed (exit 0), including formatting, repository guards, localization verification, all 17 core test type-check shards, production UI types, dead-export scans, targeted Oxlint, and Stylelint.
- `pnpm ui:build`: passed, including the Control UI performance budgets.
- Repository autoreview at P0–P2: scoped-clean; no actionable findings.
- `codex review --base origin/main`: no actionable findings.
- `git diff --check`: passed.
- Upstream CI on `ef899c5ff26`: passed, including the required `openclaw/ci-gate` ([run 34207380299](https://github.com/openclaw/openclaw/actions/runs/34207380299)).
- GitHub Codex review on the same commit: completed with no findings. ClawSweeper reported no code or security findings; its non-Chromium coverage request is addressed by the four additional browser flows above.

Commands (from the source checkout with the versions above):

```sh
node scripts/run-vitest.mjs ui/src/pages/config/view.browser.test.ts -t 'orders top-level|breaks equal-label'
node_modules/.bin/oxfmt ui/src/components/config-form.render.ts ui/src/pages/config/view.ts ui/src/pages/config/view.browser.test.ts
OPENCLAW_VITEST_FS_MODULE_CACHE_PATH=/private/tmp/advanced-sort-final-vitest-cache node scripts/run-vitest.mjs ui/src/pages/config/view.browser.test.ts ui/src/components/config-form.browser.test.ts
pnpm check:changed -- ui/src/components/config-form.render.ts ui/src/pages/config/view.ts ui/src/pages/config/view.browser.test.ts
pnpm ui:build
.agents/skills/autoreview/scripts/autoreview --mode local --base origin/main --max-priority P2 --dataset .artifacts/advanced-sort/review-context.json --prompt 'Review this focused Advanced-only section-order fix for correctness, localization, deterministic ties, and unintended changes to curated or nested ordering. The supplied context shows forceShowAdvanced is true only for the Advanced page. No schema hints or nested renderer changed.' --output /private/tmp/advanced-sort-autoreview.md --json-output /private/tmp/advanced-sort-autoreview.json
codex review --base origin/main
git diff --check
node --import ./scripts/tsx.mjs /private/tmp/advanced-sort-proof.mjs before
node --import ./scripts/tsx.mjs /private/tmp/advanced-sort-proof.mjs after
node node_modules/playwright/cli.js install firefox webkit
node --import ./scripts/tsx.mjs /private/tmp/advanced-sort-cross-browser-proof.mjs firefox en-US
node --import ./scripts/tsx.mjs /private/tmp/advanced-sort-cross-browser-proof.mjs firefox de-DE
node --import ./scripts/tsx.mjs /private/tmp/advanced-sort-cross-browser-proof.mjs webkit en-US
node --import ./scripts/tsx.mjs /private/tmp/advanced-sort-cross-browser-proof.mjs webkit de-DE
node /private/tmp/advanced-sort-viewport-proof.mjs
node scripts/watch-pr-ci.mjs 142052 ef899c5ff26a5f5afb61e09471a8ceddf1996590 --repo openclaw/openclaw --timeout 3300 --interval 60
```

The before command ran in an isolated worktree at the base revision. The after command ran from the clean committed branch. The temporary proof script uses the repository's `startControlUiE2eServer`, `installMockGateway`, and `createControlUiE2eArtifactDir` helpers; generated media and tooling artifacts are outside the product commit. The initial unscoped gate included generated regression-failure screenshots and was stopped during expanded core lint. The final gate uses only the three committed files. The initial browser run required installing the pinned Chromium build. Autoreview required installing its TruffleHog prerequisite before its completed pass.

English and German collation is verified across Chromium, Firefox, and WebKit. Other locales were not exercised. Browser proof uses synthetic Gateway data rather than a live operator configuration. The existing WebKit viewport diagnostic is outside this ordering change.
