### PR TITLE
fix(release): use trusted plugin planner in npm preflight

### DIFF
--- a/.github/workflows/openclaw-npm-preflight.yml
+++ b/.github/workflows/openclaw-npm-preflight.yml
@@ -745,7 +745,9 @@ jobs:
           artifact_dir="$RUNNER_TEMP/openclaw-plugin-npm-preflight"
           rm -rf "$artifact_dir"
           mkdir -p "$artifact_dir"
-          node --import tsx scripts/plugin-npm-release-plan.ts \
+          tooling_dir="${GITHUB_WORKSPACE}/.artifacts/plugin-sdk-release-tooling"
+          TSX_TSCONFIG_PATH="$tooling_dir/tsconfig.json" \
+            node --import "$tooling_dir/scripts/tsx.mjs" "$tooling_dir/scripts/plugin-npm-release-plan.ts" \
             --selection-mode all-publishable \
             --npm-dist-tag extended-stable > "$plan"
           cp "$plan" "$artifact_dir/plugin-npm-release-plan.json"
@@ -760,7 +762,6 @@ jobs:
           for package_dir in "${package_dirs[@]}"; do
             runtime_args+=(--package "$package_dir")
           done
-          tooling_dir="${GITHUB_WORKSPACE}/.artifacts/plugin-sdk-release-tooling"
           TSX_TSCONFIG_PATH="$tooling_dir/tsconfig.json" \
             node --import "$tooling_dir/scripts/tsx.mjs" "$tooling_dir/scripts/check-plugin-npm-runtime-builds.mts" "${runtime_args[@]}"
 

--- a/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/openclaw-npm-extended-stable-workflow.test.ts
@@ -445,6 +445,9 @@ describe("minimal npm extended-stable workflow", () => {
     });
     expect(plugins.run).toContain("--selection-mode all-publishable");
     expect(plugins.run).toContain("--npm-dist-tag extended-stable");
+    expect(plugins.run).toContain(
+      'node --import "$tooling_dir/scripts/tsx.mjs" "$tooling_dir/scripts/plugin-npm-release-plan.ts"',
+    );
     // A validation target can predate this verifier; plugin runtime qualification
     // must run from the trusted workflow checkout while inspecting target packages.
     expect(plugins.run).toMatch(


### PR DESCRIPTION
## Summary
- run the extended-stable plugin release planner from the trusted tooling checkout
- keep candidate package inputs separate from release-policy implementation
- add a workflow contract assertion covering the trusted planner invocation

The failing [artifact producer run 34205873315](https://github.com/openclaw/openclaw/actions/runs/34205873315) executed the candidate branch planner even though the workflow had already checked out trusted release tooling.

## Validation
- pnpm vitest run test/scripts/openclaw-npm-extended-stable-workflow.test.ts (17 tests)
