### PR TITLE
fix(ui): show inherited defaults for automation settings

### DIFF
--- a/src/config/schema.hints.test.ts
+++ b/src/config/schema.hints.test.ts
@@ -26,6 +26,12 @@ const BUNDLED_CHANNEL_HINT_PREFIXES = [
   "channels.whatsapp",
 ] as const;
 
+describe("automation default hints", () => {
+  it.each(["cron.enabled", "cron.triggers.enabled"])("names the inherited state for %s", (path) => {
+    expect(buildBaseHints()[path]?.placeholder).toBe("Default: On");
+  });
+});
+
 describe("section docs URLs", () => {
   it("accounts for every root config section", () => {
     const sectionsWithDocsDecisions = new Set([

--- a/src/config/schema.hints.ts
+++ b/src/config/schema.hints.ts
@@ -110,6 +110,8 @@ const FIELD_PLACEHOLDERS: Record<string, string> = {
   "gateway.push.apns.relay.baseUrl": "https://ios-push-relay.openclaw.ai",
   "channels.mattermost.baseUrl": "https://chat.example.com",
   "agents.entries.*.identity.avatar": "avatars/openclaw.png",
+  "cron.enabled": "Default: On",
+  "cron.triggers.enabled": "Default: On",
 };
 
 const CHANNEL_NAMESPACE_PREFIX = "channels.";
@@ -126,10 +128,7 @@ function isKernelOwnedChannelHintPath(path: string): boolean {
 
 /** Return whether a channel hint path belongs to a plugin-owned channel namespace. */
 function isPluginOwnedChannelHintPath(path: string): boolean {
-  if (!path.startsWith(CHANNEL_NAMESPACE_PREFIX)) {
-    return false;
-  }
-  return !isKernelOwnedChannelHintPath(path);
+  return path.startsWith(CHANNEL_NAMESPACE_PREFIX) && !isKernelOwnedChannelHintPath(path);
 }
 
 /** Build core config UI hints while leaving plugin-owned channel hints to plugin schemas. */


### PR DESCRIPTION
Related: #141548

## What Problem This Solves

Fixes an issue where users viewing Automation settings saw an off switch when `cron.enabled` or `cron.triggers.enabled` was omitted, even though its configuration default is enabled.

## Why This Change Was Made

Both fields now use the existing **Default: On / On / Off** selector. The repair belongs to display metadata and preserves configuration defaults and omission. An equivalent simplification in the same metadata owner keeps production LOC at +3/−4; the regression adds two cases in six lines.

Thanks to @nkeil for identifying this repair. The broader inherited-default work in #141548 remains open and untouched.

## User Impact

Operators can distinguish inherited settings from explicit overrides, select On or Off, and restore Default without losing neighboring settings.

## Evidence

The new regression failed before the patch; all 15 schema-hint tests passed afterward. Six isolated Chromium cases passed, including absent parents, explicit On/Off, and six real On→Off→Default selections with preserved raw configuration, siblings, and clean serialization/reload. [Behavior evidence](https://github.com/steipete/openclaw/actions/runs/34189419890).

All 30 selected checks completed in isolated proof across preserved runs. The [final continuation](https://github.com/steipete/openclaw/actions/runs/34204293209) passed the remaining ten checks and all source/input/cleanup guards. Earlier failures were in the external proof fixture and its evidence reader/plan; those failures remain recorded. The production blobs stayed unchanged throughout.

The earlier Triggers baseline was verified through the DOM; candidate captures show both fields and every selected state. Proof covers the actual form, draft, and serialization boundary, not live scheduler status or config-save transport. Videos remain in the original Actions artifacts and are not presented as fully inspected recordings.

![Before: omitted automation setting shown off](https://github.com/user-attachments/assets/0c134be2-8bc4-4649-a0e4-f1c590d9129a)

![After: omitted automation setting shown as Default: On](https://github.com/user-attachments/assets/5c6755f6-ab37-4226-b210-59d4cbcb6114)