### PR TITLE
fix(release): pin Kova CPU scan accounting fix

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -158,8 +158,9 @@ jobs:
               process.stdout.write(version);
             ' "$TARGET_CHECKOUT_DIR/package.json")"
             if [[ "$target_version" == "2026.7.33" ]]; then
-              # Kova #116 carries the historical 250% status CLI calibration for this release only.
-              kova_ref="70ea2c5a3bdd206937b4a0bd7460a19a69d8c52a"
+              # Kova #116 carries the historical 250% status CLI calibration for this release only;
+              # Kova #118 keeps process-census time out of CPU scan uncertainty.
+              kova_ref="d1cb301f0577c089b905d20efe5ccbc66b94d226"
             fi
           fi
           if [[ "$kova_ref" == *$'\n'* || "$kova_ref" == *$'\r'* ]]; then

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -277,6 +277,7 @@ describe("OpenClaw performance workflow", () => {
     expect(resolveTarget.run).toContain('detected_kova_config_contract="canonical"');
     expect(resolveTarget.run).toContain('detected_kova_config_contract="legacy-list"');
     expect(resolveTarget.run).toContain('kova_ref="${KOVA_REF_INPUT:-}"');
+    expect(resolveTarget.run).toContain('kova_ref="d1cb301f0577c089b905d20efe5ccbc66b94d226"');
     expect(resolveTarget.run).toContain('kova_ref="${kova_ref:-$default_kova_ref}"');
     expect(resolveTarget.run).toContain(
       'if [[ -z "$kova_ref" || -z "$kova_config_contract" ]]; then',


### PR DESCRIPTION
## Summary
- update the 2026.7.33-specific Kova pin to the merged process-census accounting fix
- retain the historical 250% status CLI calibration from Kova #116
- assert the reviewed immutable pin in the workflow contract test

[Full Validation 34205831954](https://github.com/openclaw/openclaw/actions/runs/34205831954) failed its mock-provider performance lane because process-census time widened four CPU intervals into BLOCKED results. The owner fix landed in [Kova #118](https://github.com/openclaw/Kova/pull/118).

## Validation
- pnpm vitest run --config test/vitest/vitest.tooling.config.ts test/scripts/openclaw-performance-workflow.test.ts (42 tests)
