### PR TITLE
fix(qa): finish stateful settled-tool continuations

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -8288,6 +8288,15 @@ Update and merge these partial structured summaries.`,
       });
       expect(outputText(recoveredPayload)).toBe("TELEGRAM-EMPTY-WRITE-RECOVERED-OK");
 
+      const statefulRecoveredPayload = await expectOpenAiNonStreamingResponsesJson(server, {
+        input: [
+          ...precedingInput,
+          makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT),
+          makeUserInput(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION),
+        ],
+      });
+      expect(outputText(statefulRecoveredPayload)).toBe("TELEGRAM-EMPTY-WRITE-RECOVERED-OK");
+
       const cronRecoveredPayload = await expectOpenAiNonStreamingResponsesJson<{
         output?: Array<{ content?: Array<{ text?: string }> }>;
       }>(server, {

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -1531,19 +1531,18 @@ async function buildResponsesPayload(
     return buildAssistantEvents(buildAssistantText(input, body));
   }
   if (isActiveEmptyResponseSideEffectRecovery || isActiveEmptyResponseSideEffectExhaustion) {
+    if (allInputText.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE)) {
+      return buildAssistantEvents(
+        isActiveEmptyResponseSideEffectExhaustion
+          ? ""
+          : (exactMarkerDirective ?? exactReplyDirective ?? "TELEGRAM-EMPTY-WRITE-RECOVERED-OK"),
+      );
+    }
     if (!hasCompletedToolOutput) {
       return buildToolCallEventsWithArgs("write", {
         path: "qa-empty-response-side-effect.txt",
         content: "side effect completed once\n",
       });
-    }
-    if (isActiveEmptyResponseSideEffectExhaustion) {
-      return buildAssistantEvents("");
-    }
-    if (allInputText.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE)) {
-      return buildAssistantEvents(
-        exactMarkerDirective ?? exactReplyDirective ?? "TELEGRAM-EMPTY-WRITE-RECOVERED-OK",
-      );
     }
     return buildAssistantEvents("");
   }


### PR DESCRIPTION
## Summary

- recognize a settled-tool continuation before deciding that missing inline tool output means the write is still pending
- keep the exhaustion fixture empty and the ordinary first request write-producing
- cover the Responses API stateful continuation shape where prior tool output is provider state rather than repeated input

## Root cause

Full validation's Telegram scenario observed two write plans. The runtime correctly disabled tools and sent the settled-tool continuation instruction, but the mock provider first tested for inline tool output. Stateful Responses continuations need not repeat that output, so the fixture planned the write again.

## Verification

- exact pre-fix focused regression: 2 failures
- post-fix focused mock-provider suite: 3 passed
- Oxfmt, OXLint, diff check

Production: +7/-8 (net -1). Tests: +9. The live scenario's one-write assertion remains unchanged.