### PR TITLE
fix(release): omit unsupported corrupt-plugin update proof

### DIFF
--- a/scripts/lib/docker-e2e-plan.mts
+++ b/scripts/lib/docker-e2e-plan.mts
@@ -339,6 +339,13 @@ function supportsMobilePairingReconnectForTarget(targetRoot: string | undefined)
   );
 }
 
+function supportsCorruptPluginUpdateForTarget(targetRoot: string | undefined): boolean {
+  return (
+    !targetRoot ||
+    existsSync(resolve(targetRoot, "src/cli/update-cli/update-command-plugin-preflight.ts"))
+  );
+}
+
 function expandedUpgradeSurvivorLaneName(
   poolLaneName: string,
   baselineSpec: string | undefined,
@@ -812,30 +819,32 @@ export function resolveDockerE2ePlan(options: DockerE2ePlanOptions) {
       : options.liveMode === "only"
         ? applyLiveMode([...retriedMainLanes, ...retriedTailLanes], options.liveMode)
         : applyLiveMode(retriedMainLanes, options.liveMode);
-  if (
-    options.allowFrozenTargetScenarioOmissions &&
-    !supportsUpdateFirstHopCompatForTarget(options.upgradeSurvivorTargetRoot)
-  ) {
-    const filteredLanes = configuredLanes.filter((lane) => lane.name !== "update-first-hop-compat");
-    if (filteredLanes.length !== configuredLanes.length) {
-      omittedUnsupportedLaneNames.add("update-first-hop-compat");
-      configuredLanes = filteredLanes;
-    }
-  }
-  if (
-    options.allowFrozenTargetScenarioOmissions &&
-    !supportsMobilePairingReconnectForTarget(options.upgradeSurvivorTargetRoot)
-  ) {
-    const filteredLanes = configuredLanes.filter(
-      (lane) => !lane.name.includes("mobile-pairing-reconnect"),
-    );
-    if (filteredLanes.length !== configuredLanes.length) {
-      for (const lane of configuredLanes) {
-        if (lane.name.includes("mobile-pairing-reconnect")) {
+  if (options.allowFrozenTargetScenarioOmissions) {
+    const unsupportedLaneRules = [
+      {
+        matches: (lane: DockerE2eLane) => lane.name === "update-first-hop-compat",
+        supported: supportsUpdateFirstHopCompatForTarget(options.upgradeSurvivorTargetRoot),
+      },
+      {
+        matches: (lane: DockerE2eLane) => lane.name.includes("mobile-pairing-reconnect"),
+        supported: supportsMobilePairingReconnectForTarget(options.upgradeSurvivorTargetRoot),
+      },
+      {
+        matches: (lane: DockerE2eLane) => lane.name === "update-corrupt-plugin",
+        supported: supportsCorruptPluginUpdateForTarget(options.upgradeSurvivorTargetRoot),
+      },
+    ];
+    for (const rule of unsupportedLaneRules) {
+      if (rule.supported) {
+        continue;
+      }
+      const retainedLanes = configuredLanes.filter((lane) => !rule.matches(lane));
+      if (retainedLanes.length !== configuredLanes.length) {
+        for (const lane of configuredLanes.filter(rule.matches)) {
           omittedUnsupportedLaneNames.add(lane.name);
         }
+        configuredLanes = retainedLanes;
       }
-      configuredLanes = filteredLanes;
     }
   }
   const configuredTailLanes =

--- a/test/scripts/docker-e2e-plan.test.ts
+++ b/test/scripts/docker-e2e-plan.test.ts
@@ -214,6 +214,32 @@ describe("scripts/lib/docker-e2e-plan", () => {
     },
   );
 
+  it("omits corrupt-plugin update admission only for authorized targets without the owner", () => {
+    const targetRoot = tempDirs.make("openclaw-corrupt-update-target-");
+    const unsupported = planFor({
+      selectedLaneNames: ["update-corrupt-plugin"],
+      upgradeSurvivorTargetRoot: targetRoot,
+    });
+    expect(unsupported.lanes).toEqual([]);
+    expect(unsupported.omittedUnsupportedLanes).toEqual(["update-corrupt-plugin"]);
+
+    const unauthorized = planFor({
+      allowFrozenTargetScenarioOmissions: false,
+      selectedLaneNames: ["update-corrupt-plugin"],
+      upgradeSurvivorTargetRoot: targetRoot,
+    });
+    expect(unauthorized.lanes.map((lane) => lane.name)).toEqual(["update-corrupt-plugin"]);
+
+    const preflight = join(targetRoot, "src/cli/update-cli/update-command-plugin-preflight.ts");
+    mkdirSync(dirname(preflight), { recursive: true });
+    writeFileSync(preflight, "export {};\n");
+    const supported = planFor({
+      selectedLaneNames: ["update-corrupt-plugin"],
+      upgradeSurvivorTargetRoot: targetRoot,
+    });
+    expect(supported.lanes.map((lane) => lane.name)).toEqual(["update-corrupt-plugin"]);
+  });
+
   it.each([
     ["catalog", "docker-package-install", {}, 0, ""],
     ["missing package", "docker-package-install", { needsPackage: false }, 1, "package Docker"],


### PR DESCRIPTION
## Summary

- classify corrupt-plugin update admission as unsupported when an authorized frozen target lacks its owning preflight module
- consolidate the three source-qualified Docker omission rules through one planner loop
- keep current, supported, and omission-disabled targets strict

## Root cause

The current corrupt-plugin scenario requires the core-update admission behavior introduced by #140778. The 2026.6.35 target predates that owner. Its historical scenario also installs the moving latest baseline and is no longer a valid proof for the frozen product. Full validation therefore demanded a refusal that the selected release cannot implement.

Backporting #140778 would import a 673-line product/doctor/plugin-update feature neighborhood. This planner repair records the scenario as not applicable only under the existing authorized frozen-target omission contract.

## Verification

- exact pre-fix planner regression failed with the lane still scheduled
- post-fix Docker planner suite: 103/103
- supported target retains the lane
- omission-disabled target retains the lane
- Oxfmt, OXLint, diff check

Production/tooling: +30/-21 (net +9), including consolidation of two existing omission branches. Tests: +26.