### PR TITLE
fix(channels): stop ingress retry loops during gateway suspension

### DIFF
--- a/src/channels/message/ingress-monitor-types.ts
+++ b/src/channels/message/ingress-monitor-types.ts
@@ -1,0 +1,68 @@
+import type { ChannelIngressQueueClaim } from "./ingress-queue.js";
+
+/** Stable identity and serialization lane extracted before durable admission. */
+export type ChannelIngressMonitorFacts = { eventId: string; laneKey: string };
+
+/** Versioned body presented to a channel's persisted-payload encoder. */
+type ChannelIngressPayloadEnvelope<TBody> = { version: number; body: TBody };
+
+/** Claim ownership lifecycle handed to one channel delivery. */
+export type ChannelIngressMonitorLifecycle = {
+  admission: "exclusive";
+  abortSignal: AbortSignal;
+  onAdopted: () => void | Promise<void>;
+  onDeferred: () => void;
+  onDeferredHeartbeat?: () => void;
+  onAdoptionFinalizing: () => void;
+  onFailed?: (error: unknown) => void | Promise<void>;
+  onCancelled?: () => void | Promise<void>;
+  onAbandoned: () => void | Promise<void>;
+};
+
+/** Optional explicit outcome from a channel delivery. */
+export type ChannelIngressMonitorDeliveryResult =
+  | { kind: "completed" }
+  | { kind: "deferred" }
+  | { kind: "failed-retryable"; error: unknown };
+
+export type ChannelIngressMonitorInspectionContext =
+  | { phase: "admission" }
+  | { phase: "claim"; claimedId: string; claimedLaneKey: string | undefined };
+
+export type ChannelIngressMonitorRetention = {
+  pruneIntervalMs: number;
+  pendingTtlMs?: number;
+  pendingMaxEntries?: number;
+  completedTtlMs?: number;
+  completedMaxEntries?: number;
+  failedTtlMs?: number;
+  failedMaxEntries?: number;
+};
+
+type ChannelIngressMonitorClaimErrorKind = "invalid-version" | "identity-mismatch";
+
+export type ChannelIngressMonitorPayloadCodec<TRaw, TBody, TStoredPayload, TMetadata> = {
+  version: number;
+  serialize: (
+    raw: TRaw,
+    context: { facts: ChannelIngressMonitorFacts; receivedAt: number },
+  ) => TBody;
+  deserialize: (
+    body: TBody,
+    context: { claim: ChannelIngressQueueClaim<TStoredPayload, TMetadata> },
+  ) => TRaw;
+  createClaimError: (
+    kind: ChannelIngressMonitorClaimErrorKind,
+    claim: ChannelIngressQueueClaim<TStoredPayload, TMetadata>,
+  ) => Error;
+} & (
+  | (TBody extends string ? { storage: "raw-event" } : never)
+  | {
+      storage?: "custom";
+      encode: (envelope: ChannelIngressPayloadEnvelope<TBody>) => TStoredPayload;
+      decode: (
+        payload: TStoredPayload,
+        context: { claim: ChannelIngressQueueClaim<TStoredPayload, TMetadata> },
+      ) => { version: unknown; body: TBody };
+    }
+);

--- a/src/channels/message/ingress-monitor.restart-drain.test.ts
+++ b/src/channels/message/ingress-monitor.restart-drain.test.ts
@@ -10,6 +10,7 @@ import {
   beginGatewayRestartSignalAdmission,
   markGatewayRestartDraining,
   resetGatewayWorkAdmission,
+  tryBeginGatewaySuspendAdmission,
 } from "../../process/gateway-work-admission.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
@@ -172,6 +173,40 @@ it("rearms queued ingress after a restart signal rolls back without an idle obse
       await vi.waitFor(() => expect(deliver).toHaveBeenCalledOnce());
     } finally {
       signal?.rollback();
+      await monitor.stop();
+    }
+  });
+});
+
+it("holds queued ingress until host suspension reopens admission", async () => {
+  await withQueue(async (queue) => {
+    const deliver = vi.fn(async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
+      await lifecycle.onAdopted();
+    });
+    const monitor = createMonitor(queue, deliver);
+    const suspension = tryBeginGatewaySuspendAdmission(() => {});
+    expect(suspension).not.toBeNull();
+    try {
+      await queue.enqueue(
+        "event-suspend-release",
+        {
+          version: 1,
+          rawEvent: JSON.stringify({ id: "event-suspend-release", lane: "a", text: "deliver me" }),
+        },
+        { laneKey: "lane:a" },
+      );
+      monitor.start();
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, 50);
+      });
+      expect(deliver).not.toHaveBeenCalled();
+
+      expect(suspension?.rollback()).toBe(true);
+      await vi.waitFor(() => expect(deliver).toHaveBeenCalledOnce());
+      await monitor.waitForIdle();
+    } finally {
+      suspension?.rollback();
       await monitor.stop();
     }
   });

--- a/src/channels/message/ingress-monitor.restart-drain.test.ts
+++ b/src/channels/message/ingress-monitor.restart-drain.test.ts
@@ -8,10 +8,12 @@ import {
 } from "../../infra/runtime-worker-url.js";
 import {
   beginGatewayRestartSignalAdmission,
+  getGatewaySuspendAdmissionPhase,
   markGatewayRestartDraining,
   resetGatewayWorkAdmission,
   tryBeginGatewaySuspendAdmission,
 } from "../../process/gateway-work-admission.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import {
   createChannelIngressMonitor,
@@ -208,6 +210,76 @@ it("holds queued ingress until host suspension reopens admission", async () => {
     } finally {
       suspension?.rollback();
       await monitor.stop();
+    }
+  });
+});
+
+it("releases a claim without an attempt when suspension closes during the claim", async () => {
+  await withQueue(async (queue) => {
+    const raw: RawEvent = {
+      id: "event-suspend-claim",
+      lane: "a",
+      text: "deliver after suspension",
+    };
+    const payload: StoredEvent = { version: 1, rawEvent: JSON.stringify(raw) };
+    const claimReady = createDeferredCore();
+    const returnClaim = createDeferredCore();
+    const claimNext = queue.claimNext.bind(queue);
+    const claimNextSpy = vi.spyOn(queue, "claimNext").mockImplementationOnce(async (...args) => {
+      const claim = await claimNext(...args);
+      // Keep the monitor awaiting the result after the real SQLite claim commits.
+      claimReady.resolve();
+      await returnClaim.promise;
+      return claim;
+    });
+    const deliver = vi.fn(async (_raw: RawEvent, lifecycle: ChannelIngressMonitorLifecycle) => {
+      await lifecycle.onAdopted();
+    });
+    const activity: boolean[] = [];
+    const monitor = createMonitor(queue, deliver, (active) => activity.push(active));
+    let suspension: ReturnType<typeof tryBeginGatewaySuspendAdmission> = null;
+    try {
+      await queue.enqueue(raw.id, payload, { laneKey: "lane:a" });
+      monitor.start();
+      await claimReady.promise;
+      expect(await queue.listClaims()).toEqual([
+        expect.objectContaining({ id: raw.id, payload, attempts: 0 }),
+      ]);
+
+      suspension = tryBeginGatewaySuspendAdmission(() => {});
+      expect(suspension?.drain()).toBe(true);
+      expect(getGatewaySuspendAdmissionPhase()).toBe("draining");
+      returnClaim.resolve();
+      await monitor.waitForIdle();
+
+      expect(deliver).not.toHaveBeenCalled();
+      expect(await queue.listClaims()).toEqual([]);
+      const pending = await queue.listPending();
+      expect(pending).toEqual([
+        expect.objectContaining({ id: raw.id, payload, laneKey: "lane:a", attempts: 0 }),
+      ]);
+      expect(pending[0]).not.toHaveProperty("lastAttemptAt");
+      expect(pending[0]).not.toHaveProperty("lastError");
+      expect(claimNextSpy).toHaveBeenCalledOnce();
+      expect(activity.at(-1)).toBe(false);
+
+      expect(suspension?.release()).toBe(true);
+      await monitor.waitForIdle();
+
+      expect(deliver).toHaveBeenCalledOnce();
+      expect(deliver.mock.calls[0]?.[0]).toEqual(raw);
+      expect(await queue.listPending()).toEqual([]);
+      expect(await queue.listClaims()).toEqual([]);
+      expect(await queue.enqueue(raw.id, payload, { laneKey: "lane:a" })).toMatchObject({
+        kind: "completed",
+        duplicate: true,
+      });
+    } finally {
+      returnClaim.resolve();
+      await monitor.stop();
+      suspension?.rollback();
+      suspension?.release();
+      claimNextSpy.mockRestore();
     }
   });
 });

--- a/src/channels/message/ingress-monitor.ts
+++ b/src/channels/message/ingress-monitor.ts
@@ -2,7 +2,9 @@
 import { formatErrorMessage, toErrorObject } from "../../infra/errors.js";
 import {
   getGatewayRestartDrainSignal,
+  getGatewaySuspendAdmissionPhase,
   isGatewayRestartDraining,
+  onGatewaySuspendAdmissionChange,
   waitForGatewayRestartFenceSettlement,
 } from "../../process/gateway-work-admission.js";
 import { sleep } from "../../utils/sleep.js";
@@ -11,6 +13,14 @@ import {
   type ChannelIngressDrain,
   type CreateChannelIngressDrainOptions,
 } from "./ingress-drain.js";
+import type {
+  ChannelIngressMonitorDeliveryResult,
+  ChannelIngressMonitorFacts,
+  ChannelIngressMonitorInspectionContext,
+  ChannelIngressMonitorLifecycle,
+  ChannelIngressMonitorPayloadCodec,
+  ChannelIngressMonitorRetention,
+} from "./ingress-monitor-types.js";
 import type { ChannelIngressQueue, ChannelIngressQueueClaim } from "./ingress-queue.js";
 import {
   DEFAULT_INGRESS_RETRY_DEAD_LETTER_MIN_AGE_MS,
@@ -20,76 +30,12 @@ import { ChannelIngressUnavailableError } from "./ingress-unavailable.js";
 
 const DEFAULT_APPEND_RETRY_DELAYS_MS = [0, 100, 300] as const;
 
-/** Stable identity and serialization lane extracted before durable admission. */
-export type ChannelIngressMonitorFacts = { eventId: string; laneKey: string };
-
-/** Versioned body presented to a channel's persisted-payload encoder. */
-type ChannelIngressPayloadEnvelope<TBody> = { version: number; body: TBody };
-
-/** Claim ownership lifecycle handed to one channel delivery. */
-export type ChannelIngressMonitorLifecycle = {
-  admission: "exclusive";
-  abortSignal: AbortSignal;
-  onAdopted: () => void | Promise<void>;
-  onDeferred: () => void;
-  onDeferredHeartbeat?: () => void;
-  onAdoptionFinalizing: () => void;
-  onFailed?: (error: unknown) => void | Promise<void>;
-  onCancelled?: () => void | Promise<void>;
-  onAbandoned: () => void | Promise<void>;
-};
-
-/** Optional explicit outcome from a channel delivery. */
-export type ChannelIngressMonitorDeliveryResult =
-  | { kind: "completed" }
-  | { kind: "deferred" }
-  | { kind: "failed-retryable"; error: unknown };
-
-type ChannelIngressMonitorInspectionContext =
-  | { phase: "admission" }
-  | {
-      phase: "claim";
-      claimedId: string;
-      claimedLaneKey: string | undefined;
-    };
-
-type ChannelIngressMonitorClaimErrorKind = "invalid-version" | "identity-mismatch";
-
-export type ChannelIngressMonitorPayloadCodec<TRaw, TBody, TStoredPayload, TMetadata> = {
-  version: number;
-  serialize: (
-    raw: TRaw,
-    context: { facts: ChannelIngressMonitorFacts; receivedAt: number },
-  ) => TBody;
-  deserialize: (
-    body: TBody,
-    context: { claim: ChannelIngressQueueClaim<TStoredPayload, TMetadata> },
-  ) => TRaw;
-  createClaimError: (
-    kind: ChannelIngressMonitorClaimErrorKind,
-    claim: ChannelIngressQueueClaim<TStoredPayload, TMetadata>,
-  ) => Error;
-} & (
-  | (TBody extends string ? { storage: "raw-event" } : never)
-  | {
-      storage?: "custom";
-      encode: (envelope: ChannelIngressPayloadEnvelope<TBody>) => TStoredPayload;
-      decode: (
-        payload: TStoredPayload,
-        context: { claim: ChannelIngressQueueClaim<TStoredPayload, TMetadata> },
-      ) => { version: unknown; body: TBody };
-    }
-);
-
-type ChannelIngressMonitorRetention = {
-  pruneIntervalMs: number;
-  pendingTtlMs?: number;
-  pendingMaxEntries?: number;
-  completedTtlMs?: number;
-  completedMaxEntries?: number;
-  failedTtlMs?: number;
-  failedMaxEntries?: number;
-};
+export type {
+  ChannelIngressMonitorDeliveryResult,
+  ChannelIngressMonitorFacts,
+  ChannelIngressMonitorLifecycle,
+  ChannelIngressMonitorPayloadCodec,
+} from "./ingress-monitor-types.js";
 
 /** Replay-guard retention defaults; changing a value requires a per-channel keyspace audit. */
 export const CHANNEL_INGRESS_RETENTION_DEFAULTS = Object.freeze({
@@ -185,6 +131,8 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
   let drainIdleWakeRequested = false;
   let restartFenceWake: Promise<void> | undefined;
   let releaseRestartFenceWake = () => {};
+  let suspensionDrainPending = false;
+  let unsubscribeSuspension: (() => void) | undefined;
   let pollTimer: ReturnType<typeof setInterval> | undefined;
   let lastPrunedAt = 0;
   let admissionTail: Promise<void> = Promise.resolve();
@@ -192,6 +140,12 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
   const admissionClaimWaiters: Array<() => void> = [];
   let stopTask: Promise<void> | undefined;
   let lastReportedActive = false;
+
+  const clearSuspensionSubscription = (): void => {
+    suspensionDrainPending = false;
+    unsubscribeSuspension?.();
+    unsubscribeSuspension = undefined;
+  };
 
   const reportError = (error: unknown): void => {
     try {
@@ -497,6 +451,7 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
             shouldStop: () =>
               !running ||
               isAborted() ||
+              getGatewaySuspendAdmissionPhase() !== "accepting" ||
               (options.drain?.startLimit !== undefined &&
                 activeDeliveries.size >= options.drain.startLimit),
           }),
@@ -545,7 +500,14 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
       },
     );
   };
-  drainAbortSignal.addEventListener("abort", () => releaseRestartFenceWake(), { once: true });
+  drainAbortSignal.addEventListener(
+    "abort",
+    () => {
+      releaseRestartFenceWake();
+      clearSuspensionSubscription();
+    },
+    { once: true },
+  );
 
   const requestDrain = (): void => {
     if (!running || isAborted() || getGatewayRestartDrainSignal().aborted) {
@@ -562,6 +524,14 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
       publishActivity();
       return;
     }
+    if (getGatewaySuspendAdmissionPhase() !== "accepting") {
+      // Keep durable rows queued without reporting active ingress while suspension drains.
+      suspensionDrainPending = true;
+      requested = false;
+      publishActivity();
+      return;
+    }
+    suspensionDrainPending = false;
     requested = true;
     if (pumping) {
       publishActivity();
@@ -733,6 +703,22 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
       // one more anonymous channel crash.
       ensureQueueAvailable();
       running = true;
+      unsubscribeSuspension ??= onGatewaySuspendAdmissionChange((phase) => {
+        if (!running) {
+          return;
+        }
+        if (phase !== "accepting") {
+          if (requested || pumping) {
+            suspensionDrainPending = true;
+            requested = false;
+            publishActivity();
+          }
+          return;
+        }
+        if (suspensionDrainPending) {
+          requestDrain();
+        }
+      });
       pollTimer = setInterval(requestDrain, options.pollIntervalMs);
       pollTimer.unref?.();
       requestDrain();
@@ -745,6 +731,7 @@ export function createChannelIngressMonitor<TRaw, TBody, TStoredPayload, TMetada
         stopped = true;
         running = false;
         requested = false;
+        clearSuspensionSubscription();
         releaseRestartFenceWake();
         clearPollTimer();
         publishActivity();


### PR DESCRIPTION
Related: #142013. This fixes the durable-ingress retry storm; parked-session drain accounting remains separate.

## What Problem This Solves

Queued channel messages could repeatedly enter delivery while Gateway suspension rejected new work.

## Why This Change Was Made

The shared ingress monitor now retains them without starting the pump while suspension admission is closed, then requests a drain on the existing reopen notification. It also checks suspension after an awaited claim so that a racing claim is released without spending an attempt. Existing monitor types remain available through their original exports.

## User Impact

Incoming messages stay queued while accepted work settles, then resume delivery when Gateway admission opens.

## Evidence

Real Discord/Gateway proof used a leased driver and tested bot with a deterministic provider fixture. One already-admitted chat turn stayed active while a real guild mention entered the durable queue during suspension.

- Baseline `21ad735be2f44143bcd2f53ec2ffa8c128e5ede2`: the target row was claimed under two different tokens during the sampled suspension window, and logs show repeated `GatewayDrainingError` for that same message. Attempts stayed at zero, so attempt counters alone did not expose the repeated work.
- Candidate product `5a5f66abac0e33b918bb1bdd541788f3afdd957e`: all 30 suspended row samples stayed pending, unclaimed, and unchanged. No pump or delivery execution appeared in the closed-phase profiler collection; the same modules executed after resume. The prior active turn settled, suspension reached ready, and explicit resume produced one completed row and one visible reply.
- A fresh source-blind run confirmed retention, idle readiness and one reply after resume. Source-only mechanisms and the internal race/failure matrix were kept separate from that live verdict.
- The added real-SQLite claim-race regression passes on the candidate and fails on original production at the intended suspended-delivery assertion. It then verifies one delivery after reopening, with no timer advance or manual drain request.
- Focused ingress-monitor, drain, cancellation and admission checks passed on the Testbox. The full changed regression file and normal commit hooks passed there before the locally signed test commit. The added commit changes only tests, so the product bytes exercised by the live proof are unchanged.

The original fixture startup failure is retained: explicit agent ownership conflicted with a legacy default marker. Correcting the fixture resolved it before the successful baseline/candidate comparison. Profiler counts are scoped to their recorded intervals and are not target-message counts unless separately correlated. The reported production cadence and failure count were not reproduced as numeric claims.

Only task-owned messages were deleted, and each QA lease was released. Shared Discord infrastructure is preserved. Full private evidence is retained; public summaries omit credentials and infrastructure identifiers.

Disclosure: AI was used to understand the codebase and review the fix.
