### PR TITLE
feat(cli): add --offset and --limit pagination to automations list

### DIFF
--- a/docs/cli/cron.md
+++ b/docs/cli/cron.md
@@ -318,6 +318,7 @@ Manual run and inspection:
 ```bash
 openclaw automations list
 openclaw automations list --agent ops
+openclaw automations list --offset 50 --limit 25
 openclaw automations get <job-id>
 openclaw automations get <job-id> --json
 openclaw automations show <job-id>
@@ -334,6 +335,12 @@ openclaw automations runs <job-id> --run-id <run-id>
 `--id <job-id>` form remain supported compatibility aliases.
 
 `openclaw automations list` shows enabled jobs across agents by default, including jobs whose owner cannot be resolved. Pass `--all` to include disabled jobs, or `--agent <id>` to filter by the effective normalized agent ID. Ownership resolves from the job's declared agent, its agent-scoped session key, then the configured system-agent owner. Unresolved jobs do not match an agent filter. The `cron list` alias has the same behavior.
+
+By default `automations list` returns every matching automation across all bounded
+Gateway pages. Pass `--offset <n>` to skip the first `n` automations and
+`--limit <n>` (1-200) to cap the result to a single page; the JSON output then
+also includes `total`, `offset`, `limit`, `hasMore`, and `nextOffset` so scripts
+can walk the inventory manually instead of pulling it all at once.
 
 The human-readable Agent ID column shows the effective owner. JSON list rows preserve the declared `agentId` and include `effectiveAgentId`, which is `null` when ownership is unresolved.
 

--- a/src/cli/cron-cli/cron-pagination.gateway.test.ts
+++ b/src/cli/cron-cli/cron-pagination.gateway.test.ts
@@ -333,12 +333,35 @@ describe("cron CLI with the real Gateway pagination contract", () => {
     installRealCronGateway(Array.from({ length: 201 }, (_, index) => createJob(index)), {
       transformListPage(page) {
         const response = page as Record<string, unknown>;
+        const responseJobs = Array.isArray(response.jobs) ? response.jobs : [];
+        const firstJob = responseJobs[0];
         // A canonical terminal page advertises total=2 but returns only one job
         // from offset 0; scripts must not treat a partial page as complete.
         return {
           ...response,
-          jobs: [response.jobs[0]],
+          jobs: [firstJob],
           total: 2,
+          hasMore: false,
+          nextOffset: null,
+        };
+      },
+    });
+
+    await expect(runCron(["list", "--json", "--limit", "50"])).rejects.toThrow("exit 1");
+  });
+
+  it("rejects a canonical terminal single page whose rows exceed the advertised total", async () => {
+    installRealCronGateway(Array.from({ length: 201 }, (_, index) => createJob(index)), {
+      transformListPage(page) {
+        const response = page as Record<string, unknown>;
+        const responseJobs = Array.isArray(response.jobs) ? response.jobs : [];
+        // A malformed page claims offset === total (3) but still returns a job
+        // beyond the inventory; offset + jobs.length (4) must not equal total.
+        return {
+          ...response,
+          jobs: responseJobs.slice(0, 1),
+          offset: 3,
+          total: 3,
           hasMore: false,
           nextOffset: null,
         };

--- a/src/cli/cron-cli/cron-pagination.gateway.test.ts
+++ b/src/cli/cron-cli/cron-pagination.gateway.test.ts
@@ -329,6 +329,25 @@ describe("cron CLI with the real Gateway pagination contract", () => {
     await expect(runCron(["list", "--json", "--limit", "50"])).rejects.toThrow("exit 1");
   });
 
+  it("rejects a truncated canonical terminal single page that does not reach total", async () => {
+    installRealCronGateway(Array.from({ length: 201 }, (_, index) => createJob(index)), {
+      transformListPage(page) {
+        const response = page as Record<string, unknown>;
+        // A canonical terminal page advertises total=2 but returns only one job
+        // from offset 0; scripts must not treat a partial page as complete.
+        return {
+          ...response,
+          jobs: [response.jobs[0]],
+          total: 2,
+          hasMore: false,
+          nextOffset: null,
+        };
+      },
+    });
+
+    await expect(runCron(["list", "--json", "--limit", "50"])).rejects.toThrow("exit 1");
+  });
+
   it("keeps a legacy single-page total unknown instead of fabricating one", async () => {
     installRealCronGateway(Array.from({ length: 201 }, (_, index) => createJob(index)), {
       transformListPage(page) {

--- a/src/cli/cron-cli/cron-pagination.gateway.test.ts
+++ b/src/cli/cron-cli/cron-pagination.gateway.test.ts
@@ -264,6 +264,58 @@ describe("cron CLI with the real Gateway pagination contract", () => {
     ).toHaveLength(1);
   });
 
+  it("preserves an explicitly supplied zero offset as a single page", async () => {
+    installRealCronGateway(Array.from({ length: 201 }, (_, index) => createJob(index)));
+
+    await runCron(["list", "--json", "--offset", "0", "--limit", "50"]);
+
+    const result = mocks.runtime.writeJson.mock.calls.at(-1)?.[0] as {
+      jobs: CronJob[];
+      offset: number;
+      total: number;
+      hasMore: boolean;
+    };
+    // A zero offset still selects single-page mode: exactly one bounded page is
+    // returned instead of walking the full 201-job inventory.
+    expect(result.jobs).toHaveLength(50);
+    expect(result.jobs[0].id).toBe("job-000");
+    expect(result.offset).toBe(0);
+    expect(result.total).toBe(201);
+    expect(result.hasMore).toBe(true);
+    expect(
+      mocks.callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.list"),
+    ).toHaveLength(1);
+  });
+
+  it("keeps a legacy single-page total unknown instead of fabricating one", async () => {
+    installRealCronGateway(Array.from({ length: 201 }, (_, index) => createJob(index)), {
+      transformListPage(page) {
+        const response = page as Record<string, unknown>;
+        // Protocol-v4 legacy page: jobs and cursor, but no total/snapshot/offset/limit.
+        return {
+          jobs: response.jobs,
+          hasMore: response.hasMore,
+          nextOffset: response.nextOffset,
+          deliveryPreviews: response.deliveryPreviews,
+        };
+      },
+    });
+    disableCronGetForProtocolV4Gateway();
+
+    await runCron(["list", "--json", "--limit", "50"]);
+
+    const result = mocks.runtime.writeJson.mock.calls.at(-1)?.[0] as {
+      jobs: CronJob[];
+      total?: number;
+      hasMore: boolean;
+    };
+    expect(result.jobs).toHaveLength(50);
+    expect(result.hasMore).toBe(true);
+    // The legacy page advertises no total; the CLI must not invent a per-page
+    // row count as the inventory size.
+    expect(result.total).toBeUndefined();
+  });
+
   it("rejects a non-numeric --limit", async () => {
     installRealCronGateway([]);
 

--- a/src/cli/cron-cli/cron-pagination.gateway.test.ts
+++ b/src/cli/cron-cli/cron-pagination.gateway.test.ts
@@ -235,7 +235,7 @@ describe("cron CLI with the real Gateway pagination contract", () => {
       nextOffset: number | null;
     };
     expect(result.jobs).toHaveLength(50);
-    expect(result.jobs[0].id).toBe("job-000");
+    expect(expectDefined(result.jobs[0], "expected first job").id).toBe("job-000");
     expect(result.total).toBe(201);
     expect(result.hasMore).toBe(true);
     expect(result.nextOffset).toBe(50);
@@ -256,7 +256,7 @@ describe("cron CLI with the real Gateway pagination contract", () => {
       total: number;
     };
     expect(result.jobs).toHaveLength(50);
-    expect(result.jobs[0].id).toBe("job-150");
+    expect(expectDefined(result.jobs[0], "expected first job").id).toBe("job-150");
     expect(result.offset).toBe(150);
     expect(result.total).toBe(201);
     expect(
@@ -278,13 +278,55 @@ describe("cron CLI with the real Gateway pagination contract", () => {
     // A zero offset still selects single-page mode: exactly one bounded page is
     // returned instead of walking the full 201-job inventory.
     expect(result.jobs).toHaveLength(50);
-    expect(result.jobs[0].id).toBe("job-000");
+    expect(expectDefined(result.jobs[0], "expected first job").id).toBe("job-000");
     expect(result.offset).toBe(0);
     expect(result.total).toBe(201);
     expect(result.hasMore).toBe(true);
     expect(
       mocks.callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.list"),
     ).toHaveLength(1);
+  });
+
+  it("accepts a Gateway-clamped terminal offset for an empty single page", async () => {
+    installRealCronGateway(Array.from({ length: 3 }, (_, index) => createJob(index)));
+
+    // The real Gateway clamps a requested offset above the filtered total down
+    // to `total` and returns an empty terminal page. The CLI must accept that
+    // contract-defined clamp instead of rejecting it as an offset mismatch.
+    await runCron(["list", "--json", "--offset", "150", "--limit", "50"]);
+
+    const result = mocks.runtime.writeJson.mock.calls.at(-1)?.[0] as {
+      jobs: CronJob[];
+      offset: number;
+      total: number;
+      hasMore: boolean;
+      nextOffset: number | null;
+    };
+    expect(result.jobs).toHaveLength(0);
+    expect(result.offset).toBe(3);
+    expect(result.total).toBe(3);
+    expect(result.hasMore).toBe(false);
+    expect(result.nextOffset).toBeNull();
+    expect(
+      mocks.callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.list"),
+    ).toHaveLength(1);
+  });
+
+  it("rejects a single-page continuation page with a non-advancing cursor", async () => {
+    installRealCronGateway(Array.from({ length: 201 }, (_, index) => createJob(index)), {
+      transformListPage(page) {
+        const response = page as Record<string, unknown>;
+        // A malformed canonical page advertises hasMore=true but supplies no
+        // usable nextOffset; scripts must not stop early or repeat a page.
+        return {
+          ...response,
+          hasMore: true,
+          nextOffset: null,
+        };
+      },
+    });
+
+    await expect(runCron(["list", "--json", "--limit", "50"])).rejects.toThrow("exit 1");
   });
 
   it("keeps a legacy single-page total unknown instead of fabricating one", async () => {

--- a/src/cli/cron-cli/cron-pagination.gateway.test.ts
+++ b/src/cli/cron-cli/cron-pagination.gateway.test.ts
@@ -223,6 +223,65 @@ describe("cron CLI with the real Gateway pagination contract", () => {
     ).toHaveLength(2);
   });
 
+  it("returns a single bounded page when --limit is provided", async () => {
+    installRealCronGateway(Array.from({ length: 201 }, (_, index) => createJob(index)));
+
+    await runCron(["list", "--json", "--limit", "50"]);
+
+    const result = mocks.runtime.writeJson.mock.calls.at(-1)?.[0] as {
+      jobs: CronJob[];
+      total: number;
+      hasMore: boolean;
+      nextOffset: number | null;
+    };
+    expect(result.jobs).toHaveLength(50);
+    expect(result.jobs[0].id).toBe("job-000");
+    expect(result.total).toBe(201);
+    expect(result.hasMore).toBe(true);
+    expect(result.nextOffset).toBe(50);
+    // Single-page mode issues exactly one cron.list RPC regardless of the total.
+    expect(
+      mocks.callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.list"),
+    ).toHaveLength(1);
+  });
+
+  it("offsets the single returned page when --offset is provided", async () => {
+    installRealCronGateway(Array.from({ length: 201 }, (_, index) => createJob(index)));
+
+    await runCron(["list", "--json", "--offset", "150", "--limit", "50"]);
+
+    const result = mocks.runtime.writeJson.mock.calls.at(-1)?.[0] as {
+      jobs: CronJob[];
+      offset: number;
+      total: number;
+    };
+    expect(result.jobs).toHaveLength(50);
+    expect(result.jobs[0].id).toBe("job-150");
+    expect(result.offset).toBe(150);
+    expect(result.total).toBe(201);
+    expect(
+      mocks.callGatewayFromCli.mock.calls.filter(([method]) => method === "cron.list"),
+    ).toHaveLength(1);
+  });
+
+  it("rejects a non-numeric --limit", async () => {
+    installRealCronGateway([]);
+
+    await expect(runCron(["list", "--limit", "not-a-number"])).rejects.toThrow("exit 1");
+  });
+
+  it("rejects a --limit above 200", async () => {
+    installRealCronGateway([]);
+
+    await expect(runCron(["list", "--limit", "201"])).rejects.toThrow("exit 1");
+  });
+
+  it("rejects a non-numeric --offset", async () => {
+    installRealCronGateway([]);
+
+    await expect(runCron(["list", "--offset", "not-a-number"])).rejects.toThrow("exit 1");
+  });
+
   it("never combines Gateway pages from different cron snapshots", async () => {
     const original = Array.from({ length: 201 }, (_, index) => createJob(index));
     installRealCronGateway(original, {

--- a/src/cli/cron-cli/list-jobs.ts
+++ b/src/cli/cron-cli/list-jobs.ts
@@ -154,11 +154,15 @@ export async function listCronJobsFromGateway(
           throw new Error("cron.list returned an inconsistent terminal inventory page");
         } else if (page.total !== undefined) {
           // A canonical terminal page must cover the advertised inventory from
-          // its offset: the returned rows must reach total. The one exception is
-          // the Gateway-clamped empty terminal page (offset === total, no rows),
-          // which represents a requested offset beyond the inventory end.
-          const reachedTotal = page.offset !== undefined && page.offset === page.total;
-          if (!reachedTotal && page.offset + page.jobs.length !== page.total) {
+          // its offset: offset + jobs.length must equal total. The Gateway
+          // clamps a requested offset beyond the end down to total and returns
+          // an empty terminal page, so a valid clamped page has offset === total
+          // and jobs.length === 0 — it satisfies the equality without a special
+          // case, and a page with rows beyond the advertised total is rejected.
+          if (
+            page.offset === undefined ||
+            page.offset + page.jobs.length !== page.total
+          ) {
             throw new Error("cron.list returned an inconsistent terminal inventory page");
           }
         }

--- a/src/cli/cron-cli/list-jobs.ts
+++ b/src/cli/cron-cli/list-jobs.ts
@@ -32,15 +32,22 @@ export function isUnknownCronGetMethodError(error: unknown): error is Error {
   );
 }
 
-/** Read every bounded Gateway page from one complete cron inventory revision. */
+/** Read every bounded Gateway page from one complete cron inventory revision, or a single page when offset/limit are provided. */
 export async function listCronJobsFromGateway(
   opts: GatewayRpcOpts,
-  filters: Pick<CronListPageOptions, "includeDisabled" | "agentId" | "query">,
+  filters: Pick<CronListPageOptions, "includeDisabled" | "agentId" | "query"> & {
+    offset?: number;
+    limit?: number;
+  },
   options: { allowLegacyUnversionedPagination?: boolean } = {},
 ): Promise<GatewayCronJobInventory> {
   let allowLegacyUnversionedPagination = options.allowLegacyUnversionedPagination === true;
+  const userOffset = filters.offset;
+  const userLimit = filters.limit;
+  const singlePage = userOffset !== undefined || userLimit !== undefined;
+
   for (let restart = 0; restart <= CRON_LIST_MAX_SNAPSHOT_RESTARTS; restart += 1) {
-    let offset = 0;
+    let offset = userOffset ?? 0;
     let snapshotRevision: string | undefined;
     let total: number | undefined;
     let pageMetadataMode: "canonical" | "legacy" | undefined;
@@ -52,9 +59,23 @@ export async function listCronJobsFromGateway(
     for (let pageNumber = 0; pageNumber < CRON_LIST_MAX_PAGES; pageNumber += 1) {
       const page = (await callGatewayFromCli("cron.list", opts, {
         ...filters,
-        limit: CRON_LIST_PAGE_SIZE,
+        limit: userLimit ?? CRON_LIST_PAGE_SIZE,
         offset,
       })) as GatewayCronListPage | null;
+
+      // In single-page mode, return just this page with its metadata
+      if (singlePage && pageNumber === 0 && page) {
+        return {
+          jobs: page.jobs ?? [],
+          deliveryPreviews: page.deliveryPreviews,
+          snapshotRevision: page.snapshotRevision,
+          total: page.total ?? page.jobs?.length ?? 0,
+          offset: page.offset ?? offset,
+          limit: page.limit ?? userLimit ?? CRON_LIST_PAGE_SIZE,
+          hasMore: page.hasMore ?? false,
+          nextOffset: page.nextOffset ?? null,
+        };
+      }
 
       const hasCanonicalMetadata =
         page !== null &&

--- a/src/cli/cron-cli/list-jobs.ts
+++ b/src/cli/cron-cli/list-jobs.ts
@@ -152,6 +152,15 @@ export async function listCronJobsFromGateway(
           }
         } else if (page.nextOffset !== undefined && page.nextOffset !== null) {
           throw new Error("cron.list returned an inconsistent terminal inventory page");
+        } else if (page.total !== undefined) {
+          // A canonical terminal page must cover the advertised inventory from
+          // its offset: the returned rows must reach total. The one exception is
+          // the Gateway-clamped empty terminal page (offset === total, no rows),
+          // which represents a requested offset beyond the inventory end.
+          const reachedTotal = page.offset !== undefined && page.offset === page.total;
+          if (!reachedTotal && page.offset + page.jobs.length !== page.total) {
+            throw new Error("cron.list returned an inconsistent terminal inventory page");
+          }
         }
         // Preserve the page's own metadata only when the
         // Gateway actually supplied it: a legacy page has no `total`, so we must

--- a/src/cli/cron-cli/list-jobs.ts
+++ b/src/cli/cron-cli/list-jobs.ts
@@ -122,12 +122,38 @@ export async function listCronJobsFromGateway(
       }
 
       if (page.offset !== undefined && page.offset !== offset) {
-        throw new Error("cron.list returned an invalid inventory page");
+        // The Gateway clamps a requested offset above the filtered total down to
+        // `total` and returns an empty terminal page (hasMore=false). Accept that
+        // contract-defined terminal clamp; any other offset mismatch is invalid.
+        const isTerminalClamp =
+          page.hasMore === false &&
+          page.total !== undefined &&
+          page.offset === page.total;
+        if (!isTerminalClamp) {
+          throw new Error("cron.list returned an invalid inventory page");
+        }
       }
 
       if (singlePage) {
         // Single-page mode returns the one validated page without walking the
-        // rest of the snapshot. Preserve the page's own metadata only when the
+        // rest of the snapshot. Apply the same continuation and terminal
+        // invariants the multi-page path enforces, so an advertised cursor or
+        // terminal state cannot be internally inconsistent:
+        // - a continuation page must carry an advancing, exact nextOffset;
+        // - a terminal page must not advertise a nextOffset.
+        if (page.hasMore === true) {
+          if (
+            typeof page.nextOffset !== "number" ||
+            !Number.isSafeInteger(page.nextOffset) ||
+            page.nextOffset <= offset ||
+            (page.total !== undefined && page.nextOffset !== offset + page.jobs.length)
+          ) {
+            throw new Error("cron.list pagination did not advance while looking up automation");
+          }
+        } else if (page.nextOffset !== undefined && page.nextOffset !== null) {
+          throw new Error("cron.list returned an inconsistent terminal inventory page");
+        }
+        // Preserve the page's own metadata only when the
         // Gateway actually supplied it: a legacy page has no `total`, so we must
         // not fabricate one from the row count or fabricated totals would mislead
         // scripts that compute completion from the advertised inventory size.

--- a/src/cli/cron-cli/list-jobs.ts
+++ b/src/cli/cron-cli/list-jobs.ts
@@ -63,20 +63,6 @@ export async function listCronJobsFromGateway(
         offset,
       })) as GatewayCronListPage | null;
 
-      // In single-page mode, return just this page with its metadata
-      if (singlePage && pageNumber === 0 && page) {
-        return {
-          jobs: page.jobs ?? [],
-          deliveryPreviews: page.deliveryPreviews,
-          snapshotRevision: page.snapshotRevision,
-          total: page.total ?? page.jobs?.length ?? 0,
-          offset: page.offset ?? offset,
-          limit: page.limit ?? userLimit ?? CRON_LIST_PAGE_SIZE,
-          hasMore: page.hasMore ?? false,
-          nextOffset: page.nextOffset ?? null,
-        };
-      }
-
       const hasCanonicalMetadata =
         page !== null &&
         typeof page === "object" &&
@@ -137,6 +123,27 @@ export async function listCronJobsFromGateway(
 
       if (page.offset !== undefined && page.offset !== offset) {
         throw new Error("cron.list returned an invalid inventory page");
+      }
+
+      if (singlePage) {
+        // Single-page mode returns the one validated page without walking the
+        // rest of the snapshot. Preserve the page's own metadata only when the
+        // Gateway actually supplied it: a legacy page has no `total`, so we must
+        // not fabricate one from the row count or fabricated totals would mislead
+        // scripts that compute completion from the advertised inventory size.
+        return {
+          jobs: page.jobs,
+          ...(page.deliveryPreviews ? { deliveryPreviews: page.deliveryPreviews } : {}),
+          ...(page.snapshotRevision !== undefined
+            ? { snapshotRevision: page.snapshotRevision }
+            : {}),
+          ...(page.total !== undefined ? { total: page.total } : {}),
+          ...(page.offset !== undefined ? { offset: page.offset } : { offset }),
+          ...(page.limit !== undefined ? { limit: page.limit } : {}),
+          ...(page.hasMore !== undefined
+            ? { hasMore: page.hasMore, nextOffset: page.nextOffset ?? null }
+            : {}),
+        };
       }
 
       if (!hasCanonicalMetadata && !allowLegacyUnversionedPagination) {

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -81,9 +81,10 @@ export function registerCronListCommand(cron: Command) {
             if (offset === undefined) {
               throw new Error("Invalid --offset (must be a non-negative integer).");
             }
-            if (offset > 0) {
-              listParams.offset = offset;
-            }
+            // Preserve an explicitly supplied zero offset: it still selects
+            // single-page mode, so `--offset 0 --json` must not fall back to
+            // the full-inventory walk.
+            listParams.offset = offset;
           }
           if (opts.limit !== undefined) {
             const limit = parseStrictPositiveInteger(opts.limit);

--- a/src/cli/cron-cli/register.cron-add.ts
+++ b/src/cli/cron-cli/register.cron-add.ts
@@ -1,5 +1,8 @@
 // Cron status/list/add command registration and create-payload normalization.
-import { parseStrictPositiveInteger } from "@openclaw/normalization-core/number-coercion";
+import {
+  parseStrictNonNegativeInteger,
+  parseStrictPositiveInteger,
+} from "@openclaw/normalization-core/number-coercion";
 import {
   normalizeLowercaseStringOrEmpty,
   normalizeOptionalString,
@@ -53,10 +56,17 @@ export function registerCronListCommand(cron: Command) {
       .description("List automations")
       .option("--all", "Include disabled jobs", false)
       .option("--agent <id>", "Filter by agent id")
+      .option("--offset <n>", "Skip the first N automations")
+      .option("--limit <n>", "Maximum automations to return (1-200)")
       .option("--json", "Output JSON", false)
       .action(async (opts) => {
         try {
-          const listParams: { includeDisabled: boolean; agentId?: string } = {
+          const listParams: {
+            includeDisabled: boolean;
+            agentId?: string;
+            offset?: number;
+            limit?: number;
+          } = {
             includeDisabled: Boolean(opts.all),
           };
           const agentId = normalizeOptionalString(opts.agent);
@@ -65,6 +75,22 @@ export function registerCronListCommand(cron: Command) {
           }
           if (agentId) {
             listParams.agentId = sanitizeAgentId(agentId);
+          }
+          if (opts.offset !== undefined) {
+            const offset = parseStrictNonNegativeInteger(opts.offset);
+            if (offset === undefined) {
+              throw new Error("Invalid --offset (must be a non-negative integer).");
+            }
+            if (offset > 0) {
+              listParams.offset = offset;
+            }
+          }
+          if (opts.limit !== undefined) {
+            const limit = parseStrictPositiveInteger(opts.limit);
+            if (limit === undefined || limit > 200) {
+              throw new Error("Invalid --limit (must be a positive integer, max 200).");
+            }
+            listParams.limit = limit;
           }
           const res = await listCronJobsFromGateway(opts, listParams);
           if (opts.json) {


### PR DESCRIPTION
## What Problem This Solves

Operators with many automations have no way to page through `openclaw automations list` (alias `cron list`) from the CLI. The command always fetches and renders the entire inventory by internally walking every bounded Gateway page, even when the caller only needs a slice or wants to walk the inventory incrementally. Scripts that want `N` jobs starting at an offset must download everything and slice it locally.

The underlying `cron.list` RPC already supports `offset`, `limit`, and returns `total`/`hasMore`/`nextOffset` pagination metadata, but none of that is reachable through the CLI.

## Why This Change Was Made

Add `--offset <n>` and `--limit <n>` (1-200) to `openclaw automations list`. When either flag is present, the CLI performs a single bounded Gateway page instead of auto-paginating across all pages, and the JSON output exposes `total`, `offset`, `limit`, `hasMore`, and `nextOffset` so scripts can walk the inventory manually.

- Default behavior is unchanged and safe: with no flags, the command still returns every matching automation exactly as before.
- Pure CLI plumbing onto an existing RPC — no new config, schema, protocol, storage, or dependency.
- `--offset` and `--limit` follow the same validation style as the existing `runs`/`show` command (`--limit` capped at 200, non-numeric values rejected).

## User Impact

Operators and scripts can now page the automation inventory without pulling the whole list:

```bash
openclaw automations list --offset 0 --limit 50   # first page
openclaw automations list --offset 50 --limit 50  # next page
openclaw automations list --limit 50 --json       # page + pagination metadata
```

## Evidence

Focused tests added against the real Gateway pagination contract (`src/cli/cron-cli/cron-pagination.gateway.test.ts`):

- returns a single bounded page when `--limit` is provided
- offsets the single returned page when `--offset` is provided
- rejects a non-numeric `--limit` / `--limit` above 200 / non-numeric `--offset`

Local validation (Node 26.8.1):

```
node scripts/run-vitest.mjs src/cli/cron-cli/cron-pagination.gateway.test.ts   # 30 passed
node scripts/run-vitest.mjs src/cli/cron-cli/register.cron-edit.test.ts src/cli/cron-cli/register.cron-simple.test.ts  # 123 passed
git diff --check  # clean
oxfmt --check     # clean
```

Known gap: the structured `$autoreview` helper could not produce a clean verdict in this environment (Codex engine output truncated), so this PR relies on the focused test suite, formatting, and manual review above; CI will run the full gate.

Related: none (no existing issue tracks CLI-side pagination on `automations list`; the neighboring `runs`/`show` commands already expose their own paging flags).

---

Fixes / addresses feature request: #142142

## Real Behavior Proof (running Gateway + real CLI)

A real, isolated OpenClaw Gateway process was spawned on a free localhost port
with an isolated state directory (`createOpenClawTestInstance`). Five real cron
jobs (`proof-job-0`…`proof-job-4`) were added through the **real** CLI
(`openclaw cron add …`), then the **real** `automations list` CLI was driven
against the same Gateway — no mocked transport.

Proof test: `test/automations-list-pagination.proof.e2e.test.ts` — ran green
twice (test, 30.8s each).

| CLI invocation (all `--json`) | jobs returned | metadata |
|---|---|---|
| `automations list` (no flags) | 5 (all) | unchanged full inventory |
| `automations list --limit 2` | 2 | total=5, limit=2, offset=0, hasMore=true, nextOffset=2 |
| `automations list --offset 1 --limit 2` | 2 | total=5, offset=1, hasMore=true, nextOffset=3 |
| `automations list --offset 4 --limit 2` | 1 (tail) | offset=4, hasMore=false, nextOffset=null |

This shows bounded pages and metadata from a running Gateway after the fix,
plus the unchanged default (no-flags) listing. All job ids are synthetic
(`proof-job-N`); no credentials, IP addresses, private endpoints, or personal
data appear.

### Additional ClawSweeper P2 fixes in this head

- **Accept the Gateway-clamped terminal offset**: the real Gateway clamps a
  requested offset above `total` to `total` and returns an empty terminal page;
  the CLI now accepts that contract-defined clamp instead of throwing.
  Regression: `accepts a Gateway-clamped terminal offset for an empty single page`.
- **Validate single-page continuation metadata**: a single page now enforces
  the same cursor/terminal invariants as the multi-page path.
  Regression: `rejects a single-page continuation page with a non-advancing cursor`.
- **Narrow first-job reads** with `expectDefined` for `noUncheckedIndexedAccess`.

Focused suite: `src/cli/cron-cli/cron-pagination.gateway.test.ts` — **34/34
passed** through the real `cronHandlers` and real `listPage`.


### Additional fix (Revision 5 finding: validate terminal row coverage)

A canonical terminal single page must cover the advertised inventory from its
offset — `offset + jobs.length` must reach `total` — with the sole exception of
the Gateway-clamped empty terminal page (`offset === total`, requested offset
beyond inventory end). Regression:
`rejects a truncated canonical terminal single page that does not reach total`.
Focused suite: `src/cli/cron-cli/cron-pagination.gateway.test.ts` — **35/35
passed**.


### Revision 7 fixes (defined offset + exact terminal coverage + fixture typing)

Two ClawSweeper P2 findings addressed:

- **Require a defined offset and exact terminal row coverage**: a canonical
  terminal single page now requires `page.offset + page.jobs.length === total`
  for every canonical terminal page. The previous `reachedTotal` shortcut
  (`offset === total`) could accept a malformed page whose rows exceeded the
  advertised inventory; a valid Gateway-clamped empty page (`offset === total`,
  `jobs.length === 0`) satisfies the equality naturally, so no special case is
  needed. `page.offset` is explicitly narrowed (it is guaranteed defined for a
  canonical page) so the arithmetic satisfies strict TypeScript.
  Regressions: `rejects a canonical terminal single page whose rows exceed the
  advertised total` and `rejects a truncated canonical terminal single page that
  does not reach total`.
- **Narrow the regression fixture's jobs before indexing**: the terminal-page
  fixture now narrows `jobs` with `Array.isArray` before indexing the first
  element, fixing the strict-TypeScript error on indexing an `unknown` value.

Focused suite: `src/cli/cron-cli/cron-pagination.gateway.test.ts` — **36/36
passed**; full `src/cli/cron-cli/` — **328/328 across 12 files passed**.
