### PR TITLE
fix(terminal): show CLI progress in supported terminals

### DIFF
--- a/packages/terminal-core/src/osc-progress.test.ts
+++ b/packages/terminal-core/src/osc-progress.test.ts
@@ -9,7 +9,7 @@ describe("OSC progress", () => {
     expect(supportsOscProgress({ WT_SESSION: "1" }, false)).toBe(false);
   });
 
-  it("writes sanitized OSC 9;4 progress sequences", () => {
+  it("writes OSC 9;4 progress sequences without labels", () => {
     const writes: string[] = [];
     const controller = createOscProgressController({
       env: { TERM_PROGRAM: "ghostty" },
@@ -22,9 +22,9 @@ describe("OSC progress", () => {
     controller.clear();
 
     expect(writes).toEqual([
-      "\u001b]9;4;3;;Buildbad\u001b\\",
-      "\u001b]9;4;1;43;Build\u001b\\",
-      "\u001b]9;4;0;0;Build\u001b\\",
+      "\u001b]9;4;3;0\u001b\\",
+      "\u001b]9;4;1;43\u001b\\",
+      "\u001b]9;4;0;0\u001b\\",
     ]);
   });
 });

--- a/packages/terminal-core/src/osc-progress.ts
+++ b/packages/terminal-core/src/osc-progress.ts
@@ -2,8 +2,6 @@
 
 const OSC_PROGRESS_PREFIX = "\u001b]9;4;";
 const OSC_PROGRESS_ST = "\u001b\\";
-const OSC_PROGRESS_BEL = "\u0007";
-const OSC_PROGRESS_C1_ST = "\u009c";
 
 /** Controller for terminal progress state. */
 export type OscProgressController = {
@@ -23,26 +21,10 @@ export function supportsOscProgress(env: NodeJS.ProcessEnv, isTty: boolean): boo
   );
 }
 
-/** Remove OSC terminators and escape introducers from progress labels. */
-function sanitizeOscProgressLabel(label: string): string {
-  return label
-    .replaceAll(OSC_PROGRESS_ST, "")
-    .replaceAll(OSC_PROGRESS_BEL, "")
-    .replaceAll(OSC_PROGRESS_C1_ST, "")
-    .split("\u001b")
-    .join("")
-    .replaceAll("]", "")
-    .trim();
-}
-
 /** Format one OSC progress control sequence. */
-function formatOscProgress(state: number, percent: number | null, label: string): string {
-  const cleanLabel = sanitizeOscProgressLabel(label);
-  if (percent === null) {
-    return `${OSC_PROGRESS_PREFIX}${state};;${cleanLabel}${OSC_PROGRESS_ST}`;
-  }
+function formatOscProgress(state: number, percent: number): string {
   const normalizedPercent = Math.max(0, Math.min(100, Math.round(percent)));
-  return `${OSC_PROGRESS_PREFIX}${state};${normalizedPercent};${cleanLabel}${OSC_PROGRESS_ST}`;
+  return `${OSC_PROGRESS_PREFIX}${state};${normalizedPercent}${OSC_PROGRESS_ST}`;
 }
 
 /** Create a progress controller, returning no-op methods on unsupported terminals. */
@@ -59,19 +41,15 @@ export function createOscProgressController(params: {
     };
   }
 
-  let lastLabel = "";
-
   return {
-    setIndeterminate: (label: string) => {
-      lastLabel = label;
-      params.write(formatOscProgress(3, null, label));
+    setIndeterminate: (_label: string) => {
+      params.write(formatOscProgress(3, 0));
     },
-    setPercent: (label: string, percent: number) => {
-      lastLabel = label;
-      params.write(formatOscProgress(1, percent, label));
+    setPercent: (_label: string, percent: number) => {
+      params.write(formatOscProgress(1, percent));
     },
     clear: () => {
-      params.write(formatOscProgress(0, 0, lastLabel));
+      params.write(formatOscProgress(0, 0));
     },
   };
 }


### PR DESCRIPTION
Closes https://github.com/openclaw/openclaw/issues/142069

## What Problem This Solves

Fixes an issue where users running progress-reporting CLI commands in Ghostty, WezTerm, or Windows Terminal would not receive valid native progress updates because OpenClaw included an unsupported label field in OSC 9;4 sequences.

## Why This Change Was Made

Emit only the protocol-defined state and numeric progress fields. The existing label arguments remain in the controller API because CLI text and spinner rendering still use labels outside the OSC sequence.

## User Impact

Supported terminals can correctly display indeterminate, percentage, and cleared progress states for OpenClaw CLI commands.

## Evidence

- Before the fix, the focused regression test received:
  - `ESC ] 9 ; 4 ; 3 ; ; Buildbad ST`
  - `ESC ] 9 ; 4 ; 1 ; 43 ; Build ST`
  - `ESC ] 9 ; 4 ; 0 ; 0 ; Build ST`
- After the fix, it receives:
  - `ESC ] 9 ; 4 ; 3 ; 0 ST`
  - `ESC ] 9 ; 4 ; 1 ; 43 ST`
  - `ESC ] 9 ; 4 ; 0 ; 0 ST`
- `node scripts/run-vitest.mjs packages/terminal-core/src/osc-progress.test.ts --run` — 2 passed.
- Full `packages/terminal-core/src` test run — 217 passed, 1 Windows-only test skipped.
- `node scripts/check-changed.mjs` — passed.
- `git diff --check` — passed.
- Independent review — no actionable findings.

### Live terminal verification

- Tested the exact PR head, `c96f1364fb5f0093d18c0466b2c7ce8e95bfcb01`, in Ghostty 1.3.1 on macOS 26.5.2.
- Exercised the production `createCliProgress` path with a real terminal stream: `TERM_PROGRAM=ghostty`, `GHOSTTY_RESOURCES_DIR` present, and `stderr.isTTY=true`.
- A live PTY transcript captured the state transitions emitted to Ghostty:
  - Indeterminate: `ESC ] 9 ; 4 ; 3 ; 0 ST`
  - Percentage: `ESC ] 9 ; 4 ; 1 ; 43 ST`
  - Cleared: `ESC ] 9 ; 4 ; 0 ; 0 ST`
- The progress state was refreshed once per second during the indeterminate and percentage phases, then explicitly cleared through `progress.done()`.
- Raw transcript SHA-256: `ff93df57fc14d2924b6bd914a8f0ed000b2e4c16b178eb9a4f5353b91cdc4705`.

This is a live Ghostty verification of the CLI-to-terminal path, not an array-backed unit-test capture.
