### PR TITLE
fix(ci): ClawHub postpublish fails on large ancestry comparisons

### DIFF
--- a/scripts/clawhub-postpublish.mjs
+++ b/scripts/clawhub-postpublish.mjs
@@ -240,7 +240,11 @@ export async function verifyClawHubPostpublish({
   if (!/^[a-f0-9]{40}$/u.test(verifierSha)) {
     throw new Error("Invalid trusted verifier SHA.");
   }
-  const ancestry = await githubJson(`compare/${parent.head_sha}...${verifierSha}`, context);
+  // GitHub includes file patches only on page 1; status describes the full comparison.
+  const ancestry = await githubJson(
+    `compare/${parent.head_sha}...${verifierSha}?per_page=1&page=2`,
+    context,
+  );
   if (ancestry.status !== "ahead" && ancestry.status !== "identical") {
     throw new Error("Parent tooling is not an ancestor of trusted verification tooling.");
   }

--- a/test/scripts/clawhub-postpublish.test.ts
+++ b/test/scripts/clawhub-postpublish.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from "node:crypto";
-import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { crc32 } from "node:zlib";
@@ -48,7 +48,7 @@ function zip(name: string, bytes: Buffer) {
   return Buffer.concat([local, fileName, bytes, central, fileName, end]);
 }
 
-function fixture(parentOnMain = false) {
+function fixture(parentOnMain = false, verifierSha = sha) {
   const parentRef = parentOnMain ? "main" : ref;
   const parentFullRef = parentOnMain ? "refs/heads/main" : `refs/tags/${ref}`;
   const directory = mkdtempSync(join(tmpdir(), "clawhub-postpublish-"));
@@ -201,11 +201,13 @@ function fixture(parentOnMain = false) {
     [`git/ref/tags/${ref}`, { ref: `refs/tags/${ref}`, object: { type: "commit", sha } }],
     [`git/matching-refs/heads/${ref}`, []],
     [`compare/${sha}...main`, { status: "identical" }],
-    [`compare/${sha}...${sha}`, { status: "identical" }],
+    [`compare/${sha}...${verifierSha}`, { status: "identical" }],
+    [`compare/${sha}...${verifierSha}?per_page=1&page=2`, { status: "identical" }],
     ...[receiptArtifact, transactionsArtifact, packageArtifact, dispatchArtifact].map(
       (item): [string, unknown] => [`actions/artifacts/${item.id}`, item],
     ),
   ]);
+  const githubReads: string[] = [];
   const registryReads: string[] = [];
   const archiveIdentity = {
     sha256: digest(tarball),
@@ -220,14 +222,20 @@ function fixture(parentOnMain = false) {
     expect(init?.method ?? "GET").toBe("GET");
     if (url.hostname === "api.github.com") {
       const path = `${url.pathname.replace(`/repos/${repository}/`, "")}${url.search}`;
+      githubReads.push(path);
       const download = /^actions\/artifacts\/(\d+)\/zip$/u.exec(path);
-      if (download) return new Response(new Uint8Array(archives.get(Number(download[1]))!));
-      if (!metadata.has(path)) throw new Error(`Unexpected GitHub request: ${path}`);
-      return Response.json(metadata.get(path));
+      if (download) {
+        return new Response(new Uint8Array(archives.get(Number(download[1]))!));
+      }
+      if (!metadata.has(path)) {
+        throw new Error(`Unexpected GitHub request: ${path}`);
+      }
+      const value = metadata.get(path);
+      return value instanceof Response ? value : Response.json(value);
     }
     expect(new Headers(init?.headers).has("authorization")).toBe(false);
     registryReads.push(url.pathname);
-    if (url.pathname.endsWith("/trusted-publisher"))
+    if (url.pathname.endsWith("/trusted-publisher")) {
       return Response.json({
         trustedPublisher: {
           provider: "github-actions",
@@ -235,7 +243,8 @@ function fixture(parentOnMain = false) {
           workflowFilename: "plugin-clawhub-release.yml",
         },
       });
-    if (url.pathname.endsWith("/artifact/download"))
+    }
+    if (url.pathname.endsWith("/artifact/download")) {
       return new Response(new Uint8Array(tarball), {
         headers: {
           "x-clawhub-artifact-sha256": archiveIdentity.sha256,
@@ -243,25 +252,31 @@ function fixture(parentOnMain = false) {
           "x-clawhub-npm-shasum": archiveIdentity.npmShasum,
         },
       });
-    if (url.pathname.endsWith("/artifact"))
+    }
+    if (url.pathname.endsWith("/artifact")) {
       return Response.json({
         package: { name: entry.name },
         version: entry.version,
         artifact: { kind: "npm-pack", ...archiveIdentity },
       });
+    }
     return Response.json({ package: { tags: { latest: entry.version } } });
   };
   const options = {
     event: { workflow_run: parent },
-    verifierSha: sha,
+    verifierSha,
     token: "fixture-token",
     outputDir: join(directory, "result"),
     fetchImpl,
     runGh: (args: string[]) => {
       const apiPath = args[1];
-      if (apiPath === undefined) throw new Error("Missing GitHub API path.");
+      if (apiPath === undefined) {
+        throw new Error("Missing GitHub API path.");
+      }
       const key = apiPath.replace(`repos/${repository}/`, "");
-      if (!metadata.has(key)) throw new Error(`Unexpected gh request: ${key}`);
+      if (!metadata.has(key)) {
+        throw new Error(`Unexpected gh request: ${key}`);
+      }
       return JSON.stringify(metadata.get(key));
     },
   };
@@ -271,6 +286,7 @@ function fixture(parentOnMain = false) {
     child,
     metadata,
     archives,
+    githubReads,
     registryReads,
     transactions,
     entry,
@@ -297,6 +313,86 @@ describe("ClawHub detached postpublish verification", () => {
         publicationAuthentication: "not-verified",
       });
       expect(f.registryReads.length).toBeGreaterThan(0);
+    },
+  );
+
+  it("verifies ancestry when comparison file patches exceed the response limit", async () => {
+    const verifierSha = "c".repeat(40);
+    const f = fixture(false, verifierSha);
+    const comparison = `compare/${sha}...${verifierSha}`;
+    f.metadata.set(comparison, {
+      status: "ahead",
+      files: [{ filename: "large.txt", patch: "+change\n".repeat(300_000) }],
+    });
+    f.metadata.set(`${comparison}?per_page=1&page=2`, {
+      status: "ahead",
+      commits: [{ sha: verifierSha }],
+    });
+
+    const result = await verifyClawHubPostpublish(f.options);
+    expect(result.complete).toBe(true);
+    expect(result.packages).toHaveLength(1);
+    expect(f.registryReads.length).toBeGreaterThan(0);
+    expect(f.githubReads.filter((path) => path.startsWith("compare/"))).toEqual([
+      `${comparison}?per_page=1&page=2`,
+    ]);
+  });
+
+  it.each(["identical", "ahead"])(
+    "accepts %s ancestry even when the comparison page has no commits",
+    async (status) => {
+      const verifierSha = status === "identical" ? sha : "c".repeat(40);
+      const f = fixture(false, verifierSha);
+      const comparison = `compare/${sha}...${verifierSha}`;
+      for (const path of [comparison, `${comparison}?per_page=1&page=2`]) {
+        f.metadata.set(path, { status, commits: [] });
+      }
+      const result = await verifyClawHubPostpublish(f.options);
+      expect(result.complete).toBe(true);
+      expect(result.packages).toHaveLength(1);
+      expect(f.registryReads.length).toBeGreaterThan(0);
+    },
+  );
+
+  it.each(["behind", "diverged", "unknown", undefined])(
+    "rejects %s ancestry before registry reads or completion evidence",
+    async (status) => {
+      const verifierSha = "c".repeat(40);
+      const f = fixture(false, verifierSha);
+      const comparison = `compare/${sha}...${verifierSha}`;
+      for (const path of [comparison, `${comparison}?per_page=1&page=2`]) {
+        f.metadata.set(path, { status, commits: [] });
+      }
+      await expect(verifyClawHubPostpublish(f.options)).rejects.toThrow(
+        "Parent tooling is not an ancestor of trusted verification tooling.",
+      );
+      expect(f.registryReads).toEqual([]);
+      expect(existsSync(f.options.outputDir)).toBe(false);
+    },
+  );
+
+  it.each([
+    {
+      label: "oversized response",
+      response: () => Response.json({ status: "ahead", message: "x".repeat(2 * 1024 * 1024) }),
+      error: "GitHub postpublish response body exceeded 2097152 bytes",
+    },
+    {
+      label: "HTTP failure",
+      response: () => new Response(null, { status: 404 }),
+      error: "GitHub postpublish read returned HTTP 404.",
+    },
+  ])(
+    "rejects a comparison $label before registry reads or evidence",
+    async ({ response, error }) => {
+      const f = fixture();
+      const comparison = `compare/${sha}...${sha}`;
+      for (const path of [comparison, `${comparison}?per_page=1&page=2`]) {
+        f.metadata.set(path, response());
+      }
+      await expect(verifyClawHubPostpublish(f.options)).rejects.toThrow(error);
+      expect(f.registryReads).toEqual([]);
+      expect(existsSync(f.options.outputDir)).toBe(false);
     },
   );
 


### PR DESCRIPTION
Related: https://github.com/openclaw/openclaw/pull/134053

## What Problem This Solves

Resolves a problem where `Plugin ClawHub Postpublish` fails to verify an
otherwise valid release when the release tooling and current verifier span a
large comparison. The GitHub response can exceed the verifier's existing
2 MiB limit before any registry verification occurs.

Observed failure: https://github.com/openclaw/openclaw/actions/runs/34005737668

## Why This Change Was Made

Request one commit on comparison page 2, where GitHub omits changed-file
patches, and continue checking the global ancestry status. Keep the 2 MiB
limit, 60-second deadline, redirect refusal, exact SHA direction, and every
parent, dispatch, tooling, child, receipt and artifact check unchanged.

The existing verifier fixture now exercises oversized comparisons, empty-page
relations, refusal of non-ancestor or missing status, HTTP failure and the
unchanged response cap. Existing fixture branches receive the braces required
by current lint.

## User Impact

Release operators can finish detached ClawHub verification after large source
changes without weakening ancestry or artifact checks. This does not publish
packages, change release authorization, or claim historical publication
authentication.

## Evidence

- Original production code at `d59108045ffc5dd368a47559beadb442fdc0a933`:
  17 tests passed; the new oversized-comparison test failed with
  `GitHub postpublish response body exceeded 2097152 bytes`.
- Candidate: all 18 tests pass through
  `node scripts/run-vitest.mjs test/scripts/clawhub-postpublish.test.ts`,
  using Node 26.8.1 and the baseline's frozen patched Vitest 5.0.0.
- Selected changed-file gates passed, with the failed legacy fixture-brace
  lint corrected and that exact lint gate rerun successfully. This includes
  test-root typechecking, script and test lint, format and relevant guards.
- Fresh independent P2 autoreview: scoped-clean, no accepted/actionable findings.
- Exact-head ready-for-review CI passed on
  `19f510a3db75c2ef55ae3d7e87c70702d797dfba`, including `openclaw/ci-gate`:
  https://github.com/openclaw/openclaw/actions/runs/34210130527
- ClawSweeper reviewed the same head with no findings or before-merge actions:
  https://github.com/openclaw/openclaw/pull/142072#issuecomment-5582817008
- Live read-only GitHub probes on September 8, 2026 at 09:14:33-09:14:35 UTC,
  using production API version `2026-03-10` and `per_page=1&page=2`:

| Comparison | HTTP | Global Status | Page Commits | Response Bytes |
| --- | --- | --- | --- | --- |
| 236 commits ahead | 200 | ahead | 1 | 15,482 |
| identical | 200 | identical | 0 | 23,896 |
| one commit ahead | 200 | ahead | 0 | 19,072 |
| one commit behind | 200 | behind | 0 | 21,483 |
| diverged | 200 | diverged | 0 | 27,344 |

All five omitted `files`. GitHub documents first-page-only comparison files:
https://docs.github.com/en/rest/commits/commits#compare-two-commits

The full verifier test uses synthetic artifacts and registry responses; no
release or registry write was dispatched for proof. The external API relation
checks above are live. Production changes are one query plus its explanatory
comment and formatting; remaining additions are regression tests and fixtures.
