### PR TITLE
fix(docker): restore source builds after dependency ownership guard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ COPY node-version.mjs ./
 COPY openclaw.mjs ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches
-COPY scripts/check-install-dependency-ownership.mjs scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-warning.mjs scripts/windows-cmd-helpers.mjs scripts/prepare-git-hooks.mjs ./scripts/
+COPY scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-warning.mjs scripts/windows-cmd-helpers.mjs scripts/prepare-git-hooks.mjs scripts/check-install-dependency-ownership.mjs ./scripts/
 COPY scripts/lib/guard-inventory-utils.mjs ./scripts/lib/guard-inventory-utils.mjs
 COPY scripts/lib/package-dist-imports.mjs ./scripts/lib/package-dist-imports.mjs
 COPY scripts/lib/package-lifecycle-marker.mjs ./scripts/lib/package-lifecycle-marker.mjs

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ COPY node-version.mjs ./
 COPY openclaw.mjs ./
 COPY ui/package.json ./ui/package.json
 COPY patches ./patches
-COPY scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-warning.mjs scripts/windows-cmd-helpers.mjs scripts/prepare-git-hooks.mjs ./scripts/
+COPY scripts/check-install-dependency-ownership.mjs scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-warning.mjs scripts/windows-cmd-helpers.mjs scripts/prepare-git-hooks.mjs ./scripts/
 COPY scripts/lib/guard-inventory-utils.mjs ./scripts/lib/guard-inventory-utils.mjs
 COPY scripts/lib/package-dist-imports.mjs ./scripts/lib/package-dist-imports.mjs
 COPY scripts/lib/package-lifecycle-marker.mjs ./scripts/lib/package-lifecycle-marker.mjs

--- a/scripts/docker/cleanup-smoke/Dockerfile
+++ b/scripts/docker/cleanup-smoke/Dockerfile
@@ -20,7 +20,7 @@ COPY ui/package.json ./ui/package.json
 COPY packages ./packages
 COPY extensions ./extensions
 COPY patches ./patches
-COPY scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-warning.mjs scripts/prepare-git-hooks.mjs scripts/windows-cmd-helpers.mjs ./scripts/
+COPY scripts/check-install-dependency-ownership.mjs scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-warning.mjs scripts/prepare-git-hooks.mjs scripts/windows-cmd-helpers.mjs ./scripts/
 COPY scripts/lib/guard-inventory-utils.mjs ./scripts/lib/guard-inventory-utils.mjs
 COPY scripts/lib/package-dist-imports.mjs ./scripts/lib/package-dist-imports.mjs
 COPY scripts/lib/package-lifecycle-marker.mjs ./scripts/lib/package-lifecycle-marker.mjs

--- a/scripts/docker/cleanup-smoke/Dockerfile
+++ b/scripts/docker/cleanup-smoke/Dockerfile
@@ -20,7 +20,7 @@ COPY ui/package.json ./ui/package.json
 COPY packages ./packages
 COPY extensions ./extensions
 COPY patches ./patches
-COPY scripts/check-install-dependency-ownership.mjs scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-warning.mjs scripts/prepare-git-hooks.mjs scripts/windows-cmd-helpers.mjs ./scripts/
+COPY scripts/postinstall-bundled-plugins.mjs scripts/preinstall-package-manager-warning.mjs scripts/prepare-git-hooks.mjs scripts/windows-cmd-helpers.mjs scripts/check-install-dependency-ownership.mjs ./scripts/
 COPY scripts/lib/guard-inventory-utils.mjs ./scripts/lib/guard-inventory-utils.mjs
 COPY scripts/lib/package-dist-imports.mjs ./scripts/lib/package-dist-imports.mjs
 COPY scripts/lib/package-lifecycle-marker.mjs ./scripts/lib/package-lifecycle-marker.mjs


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users building OpenClaw from source with Docker cannot install dependencies after the dependency-ownership guard was introduced. The production image, build image, and cleanup smoke image fail before dependency installation.

Related: https://github.com/openclaw/openclaw/pull/141719

## Why This Change Was Made

Include the existing `check-install-dependency-ownership.mjs` in the early lifecycle-script inputs shared by the production and build stages, and in the independent cleanup image inputs. The guard imports only Node built-ins, so this completes its input closure without copying the source tree early or changing install behavior.

The change is two existing `COPY` instructions only. It preserves the ownership guard, cache boundaries, frozen-lockfile installs, and runtime configuration. No dependency, lockfile, test, or changelog changes.

## User Impact

Docker source builds can execute the required preinstall guard instead of failing because its script is absent. Borrowed dependency installations remain protected.

## Evidence

- Clean Linux Docker baseline `3c79197f5d1d3efe9bb596e742946152219b4132`: `production-deps`, `build`, and cleanup image builds each failed with `MODULE_NOT_FOUND` for `check-install-dependency-ownership.mjs`. Environment: Docker 28.0.4, Node 24.19.0, pnpm 12.3.4.
- Existing hosted failures: [production install](https://github.com/openclaw/openclaw/actions/runs/34183654392/job/101927649530), [build install](https://github.com/openclaw/openclaw/actions/runs/34187395726/job/101938507170), and [manual confirmation](https://github.com/openclaw/openclaw/actions/runs/34190444317/job/101947348471).
- Current candidate `aa83dc88a38951b2dd8a76ea39e57f6782a6b30c`, tree `af43c3e0a4397f2030b78359d19055079a4d38c8`, appends the hook within the same COPY lists, preserving all existing input order and the prefix expected by `src/dockerfile.test.ts`. Relative to `05dc`, the two lists contain exactly the same source paths, bytes, and destination; only the newly added hook's position changes. No lifecycle script or install command changed.
- [Fresh candidate Testbox](https://github.com/openclaw/openclaw/actions/runs/34211037922) verified that exact source and tree. `node scripts/run-vitest.mjs src/dockerfile.test.ts` passed all 34 tests; `node scripts/run-vitest.mjs test/scripts/install-dependency-ownership.test.ts` passed all 9 tests. Both ran on Vitest 5 with physically owned dependencies.
- Current runtime image build exited `0`, including both production and build install boundaries with `OPENCLAW_EXTENSIONS=matrix`. Image ID `sha256:42edb10e3eee9373635f44f776e2be778aa199a03a81b7e68a06c82091c307af`. Network-disabled CLI smoke exited `0` and printed `OpenClaw 2026.9.2 (aa83dc8)`.
- Current cleanup image and `scripts/test-cleanup-docker.sh` exited `0`: source build, seeded-state reset (config, credentials, sessions), minimal-config recreation, and state-only uninstall completed with `OK`. Image ID `sha256:e46aede16cb146aeb3e92ff6021b9e646e964cf773b7898e9bc009c77f1fbf04`. The aggregate candidate proof command exited `0`.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34211045359) passed all 108 jobs, including the required [openclaw/ci-gate](https://github.com/openclaw/openclaw/actions/runs/34211045359/job/102015416073). Native review artifacts validated; `OPENCLAW_TESTBOX=1 scripts/pr prepare-run 142073` passed its hosted gates and verified the unchanged remote head.
- [ClawSweeper's exact-head review](https://github.com/openclaw/openclaw/pull/142073#issuecomment-5583211700) found no actionable or security findings and listed no before-merge work. The first native merge attempt correctly waited for this completed review; its retained lock was recovered only after confirming no task tools remained.
- `scripts/pr merge-run 142073` then passed its native review and CI gates and squashed the reviewed head as [16fe99ff3d37df6fe63ab7b8bf8069534094854c](https://github.com/openclaw/openclaw/commit/16fe99ff3d37df6fe63ab7b8bf8069534094854c). [Native completion](https://github.com/openclaw/openclaw/pull/142073#issuecomment-5583228961) confirms landing and cleanup. Native mainline-drift handling emitted its existing warning for three CI/ClawHub files; no gate flags were changed or bypassed.
- Fresh independent autoreview of the revised diff: scoped-clean through P2. `git diff --check` passed. Production delta is +2/-2, net zero; test delta is zero. The configured formatter does not handle Dockerfiles and matched zero files.
- Historical proof: previous candidate `05dc3e44ac7b2dc359cc761313e13bbda4c381a9`, tree `244fff73b128554d14f7156021b34d07f2b5d2cf`, also passed runtime image/CLI, cleanup and ownership tests in [the first Testbox run](https://github.com/openclaw/openclaw/actions/runs/34208940450). Its [CI failure](https://github.com/openclaw/openclaw/actions/runs/34210248282/job/102009467891) at `src/dockerfile.test.ts:260` identified the displaced literal COPY prefix. The revised patch preserves that prefix without changing or weakening tests; the full unchanged Dockerfile suite now passes on the exact revised head.
- Both proof leases, `tbx_01m204s3fr4mnxq06bqkrsc6n3` and `tbx_01m2062pj6364axk2fddyvr03f`, were stopped through the configured wrapper and independently read back as `completed`. No task proof lease remains active.

The local ownership-test attempt stopped before tests ran because the shared donor still has Vitest 4 while this source requires Vitest 5. The donor was not reconciled; the unchanged test subsequently passed in the prepared Testbox proof.

The PR was created as draft, then marked ready after GitHub reported it mergeable. The native landing workflow requires this because CI skips draft PRs; the initial skipped run is not passing evidence.
