### PR TITLE
fix(cron): run scheduled commands with secret egress enabled

### DIFF
--- a/src/agents/bash-tools.exec-run.ts
+++ b/src/agents/bash-tools.exec-run.ts
@@ -29,6 +29,7 @@ import {
 import type { SecretStoreExecEnvironment } from "../secrets/store/secret-store.js";
 import { createDeferredCore } from "../shared/deferred.js";
 import { normalizeDeliveryContext } from "../utils/delivery-context.shared.js";
+import { captureAgentToolSourceExecutionGuard } from "./agent-tool-source-execution-guard.js";
 import { markBackgrounded } from "./bash-process-registry.js";
 import { describeExecTool } from "./bash-tools.descriptions.js";
 import { processGatewayAllowlist } from "./bash-tools.exec-host-gateway.js";
@@ -203,6 +204,7 @@ export function createExecTool(
     finalizeBeforeToolCallParams: requestPreparation.finalizeBeforeToolCallParams,
     execute: async (toolCallId, args, signal, onUpdate) => {
       signal?.throwIfAborted();
+      const assertSourceActive = captureAgentToolSourceExecutionGuard(signal);
       assertSupportedExecParams(args);
       // Capture settings and cancellation per execution; unused reviewers must not load model runtime.
       let autoReviewer: ExecAutoReviewer | undefined = defaults?.autoReviewer;
@@ -428,6 +430,7 @@ export function createExecTool(
           if (!defaults?.operationalRunInstance) {
             throw new Error("Secret egress proxy requires an admitted agent run instance");
           }
+          assertSourceActive();
           secretEgressEnv = registerSecretEgressProxyRun(
             defaults.operationalRunInstance,
             storeEnv.secretEgressBindings ?? [],

--- a/src/agents/bash-tools.exec.egress-closure.test.ts
+++ b/src/agents/bash-tools.exec.egress-closure.test.ts
@@ -1,0 +1,210 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../test/helpers/promise.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { registerAgentRunDelegatedAuthorityClosedHandler } from "../infra/agent-run-registry.js";
+import { getProcessSupervisor } from "../process/supervisor/index.js";
+import {
+  startSecretEgressProxyServer,
+  type SecretEgressProxyHandle,
+} from "../secrets/egress-proxy/proxy-server.js";
+import {
+  clearSecretEgressProxy,
+  publishSecretEgressProxy,
+} from "../secrets/egress-proxy/registry.js";
+import * as secretStore from "../secrets/store/secret-store.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+import {
+  createOperationalRunInstanceRef,
+  getAdmittedRunDelegatedAuthority,
+  prepareAgentRunAdmission,
+  type PreparedAgentRunAdmission,
+} from "./admitted-run-context.js";
+import { createExecTool } from "./bash-tools.exec-run.js";
+import {
+  createAdmittedGatewayToolCallerIdentity,
+  withGatewayToolCallerIdentity,
+} from "./tools/gateway-caller-context.js";
+
+let state: OpenClawTestState | undefined;
+let proxy: SecretEgressProxyHandle | undefined;
+let unsubscribe: (() => void) | undefined;
+const admissions: PreparedAgentRunAdmission[] = [];
+
+afterEach(async () => {
+  for (const admission of admissions.splice(0)) {
+    admission.close();
+  }
+  unsubscribe?.();
+  unsubscribe = undefined;
+  vi.restoreAllMocks();
+  try {
+    if (proxy) {
+      clearSecretEgressProxy(proxy);
+      await proxy.stop();
+      proxy = undefined;
+    }
+  } finally {
+    await state?.cleanup();
+    state = undefined;
+  }
+});
+
+beforeEach(async () => {
+  state = await createOpenClawTestState({
+    prefix: "openclaw-exec-egress-closure-",
+    layout: "state-only",
+    env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
+  });
+  proxy = await startSecretEgressProxyServer({
+    caDir: state.path("proxy-ca"),
+    allowedHosts: [],
+    onAudit: () => {},
+  });
+  publishSecretEgressProxy(proxy);
+  const ownedProxy = proxy;
+  // Use the Gateway's full-run closure event; approval-generation closure is separate.
+  unsubscribe = registerAgentRunDelegatedAuthorityClosedHandler((authority, reason) => {
+    if (!reason) {
+      ownedProxy.revokeRun(authority.operationalRunInstance);
+    }
+  });
+});
+
+describe("exec proxy registration after store preparation", () => {
+  it.each(["close", "abort"] as const)(
+    "mints no proxy credentials after %s and leaves the next invocation usable",
+    async (revocation) => {
+      if (!state || !proxy) {
+        throw new Error("Expected the isolated exec fixture");
+      }
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: { workspace: state.workspaceDir, skipBootstrap: true },
+          entries: { probe: { workspace: state.workspaceDir } },
+        },
+        plugins: { enabled: false },
+        tools: { exec: { host: "gateway", security: "full", ask: "off" } },
+        secrets: { egressProxy: { enabled: true } },
+      };
+      await state.writeConfig(config);
+      const workspaceDir = state.workspaceDir;
+      const registrations = vi.spyOn(proxy, "registerRun");
+      const revocations = vi.spyOn(proxy, "revokeRun");
+      const spawns = vi.spyOn(getProcessSupervisor(), "spawn");
+
+      const createInvocation = async (runId: string) => {
+        const controller = new AbortController();
+        const admission = prepareAgentRunAdmission({
+          cfg: config,
+          operationalRunInstance: createOperationalRunInstanceRef(runId),
+          facts: {
+            runId,
+            agentId: "probe",
+            ingress: { kind: "schedule", boundary: "cron.script", state: "present" },
+          },
+        });
+        admissions.push(admission);
+        const admitted = await admission.admit("gateway");
+        const sessionKey = "agent:probe:cron:egress-closure:trigger";
+        const caller = createAdmittedGatewayToolCallerIdentity({
+          admittedRunContext: admitted,
+          agentId: "probe",
+          sessionKey,
+          approvalSignals: [controller.signal],
+        });
+        if (!caller) {
+          throw new Error("Expected the admitted exec caller");
+        }
+        const tool = createExecTool({
+          config,
+          agentId: "probe",
+          sessionKey,
+          runId,
+          operationalRunInstance: admitted.operationalRunInstance,
+          trigger: "cron",
+          host: "gateway",
+          security: "full",
+          ask: "off",
+          cwd: workspaceDir,
+          allowBackground: false,
+          notifyOnExit: false,
+        });
+        return {
+          admission,
+          admitted,
+          controller,
+          execute: () =>
+            withGatewayToolCallerIdentity(caller, () =>
+              tool.execute(
+                `exec-${runId}`,
+                { command: "printf cron-egress-ok" },
+                controller.signal,
+              ),
+            ),
+        };
+      };
+
+      const retired = await createInvocation(`egress-${revocation}-retired`);
+      const enteredStoreRead = createDeferred();
+      const readStore = secretStore.readSecretStoreExecEnvironment;
+      const storeRead = vi
+        .spyOn(secretStore, "readSecretStoreExecEnvironment")
+        .mockImplementationOnce((params) => {
+          // The waiting test resumes before exec's import/read promise continuation.
+          enteredStoreRead.resolve();
+          return readStore(params);
+        });
+      // Drain the implementation itself: an abort wrapper can settle while exec continues.
+      const retiredExecution = retired.execute().then(
+        (value) => ({ status: "completed" as const, value }),
+        (error: unknown) => ({ status: "rejected" as const, error }),
+      );
+      void retiredExecution.then((outcome) => {
+        enteredStoreRead.reject(
+          outcome.status === "rejected"
+            ? outcome.error
+            : new Error("Exec completed before the store-read boundary"),
+        );
+      });
+      await enteredStoreRead.promise;
+      if (revocation === "abort") {
+        retired.controller.abort();
+      }
+      // Cancellation's cron owner closes admission before a detached exec can resume.
+      retired.admission.close();
+      const retiredOutcome = await retiredExecution;
+      const lateRegistrationCount = registrations.mock.calls.length;
+      const retiredSpawnCount = spawns.mock.calls.length;
+      storeRead.mockRestore();
+
+      const later = await createInvocation(`egress-${revocation}-later`);
+      const laterResult = await later.execute();
+      later.admission.close();
+
+      expect(retiredOutcome.status).toBe("rejected");
+      expect(retired.controller.signal.aborted).toBe(revocation === "abort");
+      expect(retiredSpawnCount).toBe(0);
+      expect(getAdmittedRunDelegatedAuthority(retired.admitted)).toBeUndefined();
+      expect(laterResult.details).toMatchObject({
+        status: "completed",
+        exitCode: 0,
+        aggregated: "cron-egress-ok",
+      });
+      expect(getAdmittedRunDelegatedAuthority(later.admitted)).toBeUndefined();
+      expect(later.admitted.operationalRunInstance).not.toEqual(
+        retired.admitted.operationalRunInstance,
+      );
+      expect(revocations.mock.calls.map(([run]) => run)).toEqual([
+        retired.admitted.operationalRunInstance,
+        later.admitted.operationalRunInstance,
+      ]);
+      expect(lateRegistrationCount).toBe(0);
+      expect(registrations.mock.calls.map(([run]) => run)).toEqual([
+        later.admitted.operationalRunInstance,
+      ]);
+    },
+  );
+});

--- a/src/cron/trigger-script.admission.test.ts
+++ b/src/cron/trigger-script.admission.test.ts
@@ -32,7 +32,7 @@ function toolRuntime(ctx: HeadlessParams["ctx"]) {
 
 function prepareRuntime(config: OpenClawConfig, tool: AnyAgentTool) {
   return vi.fn(async () => ({
-    tools: [tool],
+    createTools: () => [tool],
     context: { config, agentId: "main", sessionKey: "agent:main:cron:probe" },
   }));
 }

--- a/src/cron/trigger-script.preparation.test.ts
+++ b/src/cron/trigger-script.preparation.test.ts
@@ -166,7 +166,7 @@ describe("cron preparation plugin ownership", () => {
         });
       for (const [jobId, agentId, calls] of [
         ["first", "main", 1],
-        ["first", "main", 2],
+        ["first", "main", 1],
         ["second", "main", 1],
         ["first", "other", 1],
       ] as const) {

--- a/src/cron/trigger-script.secret-egress.test.ts
+++ b/src/cron/trigger-script.secret-egress.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  getAdmittedRunDelegatedAuthority,
+  type AdmittedRunContext,
+} from "../agents/admitted-run-context.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { registerAgentRunDelegatedAuthorityClosedHandler } from "../infra/agent-run-registry.js";
+import {
+  startSecretEgressProxyServer,
+  type SecretEgressProxyHandle,
+} from "../secrets/egress-proxy/proxy-server.js";
+import {
+  clearSecretEgressProxy,
+  publishSecretEgressProxy,
+} from "../secrets/egress-proxy/registry.js";
+import { createOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createCronScriptRuntimeFixture as createCronScriptRuntime } from "./trigger-script.test-helpers.js";
+
+let state: Awaited<ReturnType<typeof createOpenClawTestState>> | undefined;
+let proxy: SecretEgressProxyHandle | undefined;
+let unsubscribe: (() => void) | undefined;
+
+afterEach(async () => {
+  unsubscribe?.();
+  unsubscribe = undefined;
+  vi.restoreAllMocks();
+  if (proxy) {
+    clearSecretEgressProxy(proxy);
+    await proxy.stop();
+    proxy = undefined;
+  }
+  await state?.cleanup();
+  state = undefined;
+});
+
+describe("cron script gateway exec with secret egress", () => {
+  it.each(
+    (["trigger", "payload"] as const).flatMap((mode) =>
+      [false, true].map((enabled) => ({ mode, enabled })),
+    ),
+  )(
+    "executes cold and warm $mode commands in a fresh agent with proxy enabled=$enabled",
+    async ({ mode, enabled }) => {
+      state = await createOpenClawTestState({
+        prefix: "openclaw-cron-secret-egress-",
+        layout: "state-only",
+        env: { OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1" },
+      });
+      const config: OpenClawConfig = {
+        agents: {
+          defaults: { workspace: state.workspaceDir, skipBootstrap: true },
+          entries: { probe: { workspace: state.workspaceDir } },
+        },
+        plugins: { enabled: false },
+        tools: { exec: { host: "gateway", security: "full", ask: "off" } },
+        secrets: { egressProxy: { enabled } },
+      };
+      await state.writeConfig(config);
+      if (enabled) {
+        proxy = await startSecretEgressProxyServer({
+          caDir: state.path("proxy-ca"),
+          onAudit: () => {},
+        });
+        publishSecretEgressProxy(proxy);
+        // Mirror the gateway's authority-close hook, without a live gateway or user state.
+        unsubscribe = registerAgentRunDelegatedAuthorityClosedHandler((authority, reason) => {
+          if (!reason) {
+            proxy?.revokeRun(authority.operationalRunInstance);
+          }
+        });
+      }
+      const registrations = proxy ? vi.spyOn(proxy, "registerRun") : undefined;
+      const revocations = proxy ? vi.spyOn(proxy, "revokeRun") : undefined;
+      const runtime = createCronScriptRuntime({ config });
+      const admitted: AdmittedRunContext[] = [];
+      for (let index = 0; index < 2; index += 1) {
+        const params = {
+          jobId: "fresh-agent-check",
+          agentId: "probe",
+          script:
+            'const result = await exec({ command: "printf cron-egress-ok" }); if (!JSON.stringify(result).includes("cron-egress-ok")) throw new Error("Command output missing"); return { fire: false };',
+          state: null,
+          toolsAllow: ["exec", "process"],
+          scheduledToolPolicy: { version: 1, mode: "trusted" } as const,
+          execTarget: { version: 1, host: "gateway" } as const,
+          executionIdentity: {
+            ingress: { kind: "schedule", boundary: "cron.script", state: "present" } as const,
+            onPostAdmission: (context: AdmittedRunContext) => admitted.push(context),
+          },
+        };
+        await expect(
+          mode === "trigger" ? runtime.evaluateTrigger(params) : runtime.executePayload(params),
+        ).resolves.toEqual(
+          mode === "trigger"
+            ? { kind: "evaluated", fire: false }
+            : { kind: "completed", stateChanged: false },
+        );
+        expect(admitted).toHaveLength(index + 1);
+        expect(getAdmittedRunDelegatedAuthority(admitted[index]!)).toBeUndefined();
+        if (enabled) {
+          const expectedRuns = admitted.map((context) => context.operationalRunInstance);
+          expect(registrations?.mock.calls.map(([run]) => run)).toEqual(expectedRuns);
+          expect(revocations?.mock.calls.map(([run]) => run)).toEqual(expectedRuns);
+        }
+      }
+      expect(admitted[1]?.operationalRunInstance).not.toEqual(admitted[0]?.operationalRunInstance);
+    },
+  );
+});

--- a/src/cron/trigger-script.test.ts
+++ b/src/cron/trigger-script.test.ts
@@ -45,7 +45,7 @@ function createPreparedRuntime(config: OpenClawConfig) {
     { config, agentId: "main", sessionKey: "cron:test:trigger" },
   );
   return {
-    tools: [tool],
+    createTools: () => [tool],
     context: { config, agentId: "main", sessionKey: "cron:test:trigger" },
   };
 }
@@ -78,7 +78,7 @@ describe("cron trigger script evaluator", () => {
     let aborts = 0;
     const prepared = createPreparedRuntime(config);
     const gate: AnyAgentTool = {
-      ...prepared.tools[0],
+      ...prepared.createTools()[0],
       name: "gate",
       label: "Gate",
       description: "Wait for the local fixture",
@@ -98,7 +98,7 @@ describe("cron trigger script evaluator", () => {
     };
     const runtime = createCronScriptRuntime({
       config,
-      prepareRuntime: async () => ({ ...prepared, tools: [gate] }),
+      prepareRuntime: async () => ({ ...prepared, createTools: () => [gate] }),
       runHeadless: (params) => {
         context = params.ctx;
         return runCodeModeScriptHeadless(params);
@@ -719,7 +719,10 @@ describe("cron script runtime elapsed-time budgets", () => {
         const preparedRuntime = createPreparedRuntime(config);
         const runtime = createCronScriptRuntime({
           config,
-          prepareRuntime: async () => ({ ...preparedRuntime, tools: [shiftClock, observeClock] }),
+          prepareRuntime: async () => ({
+            ...preparedRuntime,
+            createTools: () => [shiftClock, observeClock],
+          }),
         });
         const sharedScript =
           "await Promise.all([shift_clock({}), observe_clock({})]); await observe_clock({});";

--- a/src/cron/trigger-script.ts
+++ b/src/cron/trigger-script.ts
@@ -3,6 +3,7 @@ import {
   createOperationalRunInstanceRef,
   prepareAgentRunAdmission,
   resolveAdmittedRunActiveAssertion,
+  type AdmittedRunContext,
   type PreparedAgentRunAdmission,
 } from "../agents/admitted-run-context.js";
 import {
@@ -110,7 +111,7 @@ const assertTriggerCodesCoverHeadless: AssertTriggerCodesCoverHeadless = true;
 void assertTriggerCodesCoverHeadless;
 
 type PreparedTriggerRuntime = {
-  tools: AnyAgentTool[];
+  createTools: (admitted: AdmittedRunContext, signal: AbortSignal) => AnyAgentTool[];
   context: HookContext & { config: OpenClawConfig; agentId: string; sessionKey: string };
   pluginRegistry?: PluginRegistry;
 };
@@ -203,34 +204,39 @@ async function prepareTriggerRuntime(
     });
     // Bundle MCP tools are source:"mcp", which the headless bridge excludes.
     // LSP runtimes are session-scoped and intentionally outside trigger v1.
-    const allTools = toolPlan.constructTools
-      ? createOpenClawCodingTools({
-          agentId,
-          exec: { config },
-          sandbox,
-          sessionKey,
-          trigger: "cron",
-          jobId: params.jobId,
-          agentDir,
-          cwd: effectiveWorkspace,
-          workspaceDir: effectiveWorkspace,
-          spawnWorkspaceDir: workspaceDir,
-          config,
-          allowGatewaySubagentBinding: true,
-          includeCoreTools: toolPlan.includeCoreTools,
-          runtimeToolAllowlist: toolPlan.runtimeToolAllowlist,
-          inheritRuntimeToolAllowlist: Boolean(toolPlan.runtimeToolAllowlist),
-          scheduledToolPolicy: resolveScheduledToolPolicyContext({
-            toolsAllow: params.toolsAllow,
-            scheduledToolPolicy: params.scheduledToolPolicy,
-            execTarget: params.execTarget,
-          }),
-          toolConstructionPlan: toolPlan.codingToolConstructionPlan,
-        })
-      : [];
-    const tools = applyEmbeddedAttemptToolsAllow(allTools, params.toolsAllow, {
-      toolMeta: (tool) => getPluginToolMeta(tool),
-    });
+    const createTools: PreparedTriggerRuntime["createTools"] = (admitted, signal) => {
+      const allTools = toolPlan.constructTools
+        ? createOpenClawCodingTools({
+            agentId,
+            runId: admitted.operationalRunInstance.runId,
+            operationalRunInstance: admitted.operationalRunInstance,
+            abortSignal: signal,
+            exec: { config },
+            sandbox,
+            sessionKey,
+            trigger: "cron",
+            jobId: params.jobId,
+            agentDir,
+            cwd: effectiveWorkspace,
+            workspaceDir: effectiveWorkspace,
+            spawnWorkspaceDir: workspaceDir,
+            config,
+            allowGatewaySubagentBinding: true,
+            includeCoreTools: toolPlan.includeCoreTools,
+            runtimeToolAllowlist: toolPlan.runtimeToolAllowlist,
+            inheritRuntimeToolAllowlist: Boolean(toolPlan.runtimeToolAllowlist),
+            scheduledToolPolicy: resolveScheduledToolPolicyContext({
+              toolsAllow: params.toolsAllow,
+              scheduledToolPolicy: params.scheduledToolPolicy,
+              execTarget: params.execTarget,
+            }),
+            toolConstructionPlan: toolPlan.codingToolConstructionPlan,
+          })
+        : [];
+      return applyEmbeddedAttemptToolsAllow(allTools, params.toolsAllow, {
+        toolMeta: (tool) => getPluginToolMeta(tool),
+      });
+    };
     const context = {
       agentId,
       config,
@@ -240,7 +246,7 @@ async function prepareTriggerRuntime(
       loopDetection: resolveToolLoopDetectionConfig({ cfg: config, agentId }),
     };
     return {
-      tools,
+      createTools,
       context,
       ...(pluginRegistry ? { pluginRegistry } : {}),
     };
@@ -270,7 +276,8 @@ function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
   const prepareRuntime =
     deps.prepareRuntime ?? ((params) => prepareTriggerRuntime(params, deps.loadPluginRegistry));
   // Config identity is the reload epoch; caching the preparation promise makes
-  // concurrent cold evaluations for one job single-flight.
+  // concurrent cold evaluations for one job single-flight. Cache only preparation:
+  // tool instances capture run authority, abort signals, and secret egress state.
   const runtimeCache = new Map<string, TriggerRuntimeCacheEntry>();
 
   const resolveCachedRuntime = async (
@@ -433,7 +440,7 @@ function createCronCodeModeRunner(deps: CronTriggerEvaluatorDeps) {
         assertActive();
         registerHeadlessToolSearchCatalog({
           catalogRef,
-          tools: runtime.tools,
+          tools: runtime.createTools(admitted, evaluationScope.signal),
           hookContext: { ...runtime.context, runId },
         });
         const remainingWallClockMs = Math.ceil(evaluationScope.deadline - performance.now());


### PR DESCRIPTION
Closes #142059

## What Problem This Solves

Fixes an issue where model-free automation conditions and script jobs failed to execute allowed Gateway commands when the secret egress proxy was enabled. Even a harmless `printf` failed before the shell started because its tools captured no admitted run.

## Why This Change Was Made

Static preparation stays cached, while each admitted invocation creates its own tools with the current run and cancellation signal. Exec also rechecks the existing live caller guard immediately before proxy registration: environment preparation can finish after the run's only revocation event.

## User Impact

Scheduled conditions and script jobs can keep secret egress enabled and execute their allowed commands. Closed or canceled invocations cannot create a late proxy registration, and later invocations retain their own authority.

## Evidence

The real source Gateway and documented `openclaw automations` CLI ran on one isolated Linux host, with no model, external service, stored secret or production state. Baseline: `6e55c1dfc87d00ff6428d858803b55549e25f170`. Candidate: `1fe31ba2ef22c9962db62d5f9b3ed2e37fb348ae`.

| Scenario | Baseline | Candidate |
| --- | --- | --- |
| Proxy enabled, two natural condition evaluations | Exact missing-admitted-run error | Completed command, `fire: false`, zero errors |
| Proxy enabled, two script payload runs | Failed before shell execution | Both succeeded; exact saved stdout and run history |
| Proxy disabled, condition and script controls | Passed | Passed |
| Close or abort during exec environment preparation | A late proxy registration remained | No late registration or shell spawn; a later invocation succeeded |

Observed successful command result:

```json
{"status":"completed","exitCode":0,"exitReason":"exit","aggregated":"cron-egress-ok","noOutputTimedOut":false}
```

- An independent source-blind validator drove natural scheduling, repeated script runs, exact result/history checks, denied tools, tool-budget and timeout failures, oversized state on both routes, active cancellation, recovery on the same condition, and changing persisted output. It reported no failed public checks. Private run-instance, registration and cache facts are covered by separate real owner tests and source inspection, not inferred from public IDs.
- The original cron regression fails on the pinned baseline. The connected closure test first failed specifically on a late registration after both close and abort. All **121 focused tests across eight files** now pass, including real cron/exec/proxy and existing environment, hook and lifecycle siblings.
- Formatting, max-lines and assertion-safety ratchets, the normal commit hook, and a fresh independent P0–P2 code review passed. Source and matching runtime build are bound to the candidate above; the reviewed commit is signed.
- A successful `fire: false` recovery retains prior cancelled history rather than rewriting it as a successful payload. The validator verified fresh evaluation state and the later effect separately.

The contributor's original CI run failed ACP provisional-session cleanup; that failure and the rejected rerun remain recorded. The current source and regression correction require fresh exact-head CI before landing; no inherited failure waiver is used.

Original cron repair by @tilor; AI-assisted validation and the connected exec closure correction. Proxy policy, scheduled tool limits and existing admission/cleanup owners are preserved.
