### PR TITLE
refactor(plugins): consolidate install reload metadata

### DIFF
--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -420,61 +420,29 @@ function getPluginInstallRecords(config: unknown): Record<string, unknown> {
   return isPlainObject(installs) ? installs : {};
 }
 
-function listPluginInstallRecordDiffPaths(
-  prevConfig: unknown,
-  nextConfig: unknown,
-  visit: (record: {
-    id: string;
-    prevRecord: unknown;
-    nextRecord: unknown;
-    paths: string[];
-  }) => void,
-): string[] {
+export function resolvePluginInstallReloadMetadata(prevConfig: unknown, nextConfig: unknown) {
   const prevInstalls = getPluginInstallRecords(prevConfig);
   const nextInstalls = getPluginInstallRecords(nextConfig);
   const ids = new Set([...Object.keys(prevInstalls), ...Object.keys(nextInstalls)]);
-  const paths: string[] = [];
+  const noopPaths: string[] = [];
+  const forceChangedPaths: string[] = [];
 
   for (const id of ids) {
-    visit({ id, prevRecord: prevInstalls[id], nextRecord: nextInstalls[id], paths });
+    const prevRecord = prevInstalls[id];
+    const nextRecord = nextInstalls[id];
+    if (!isPlainObject(prevRecord) || !isPlainObject(nextRecord)) {
+      // A dotted install id can collide with a timestamp path; whole records must still reload.
+      forceChangedPaths.push(`plugins.installs.${id}`);
+      continue;
+    }
+    for (const key of PLUGIN_INSTALL_TIMESTAMP_KEYS) {
+      if (prevRecord[key] !== nextRecord[key]) {
+        noopPaths.push(`plugins.installs.${id}.${key}`);
+      }
+    }
   }
 
-  return paths;
-}
-
-export function listPluginInstallTimestampMetadataPaths(
-  prevConfig: unknown,
-  nextConfig: unknown,
-): string[] {
-  return listPluginInstallRecordDiffPaths(
-    prevConfig,
-    nextConfig,
-    ({ id, prevRecord, nextRecord, paths }) => {
-      if (!isPlainObject(prevRecord) || !isPlainObject(nextRecord)) {
-        return;
-      }
-      for (const key of PLUGIN_INSTALL_TIMESTAMP_KEYS) {
-        if (prevRecord[key] !== nextRecord[key]) {
-          paths.push(`plugins.installs.${id}.${key}`);
-        }
-      }
-    },
-  );
-}
-
-export function listPluginInstallWholeRecordPaths(
-  prevConfig: unknown,
-  nextConfig: unknown,
-): string[] {
-  return listPluginInstallRecordDiffPaths(
-    prevConfig,
-    nextConfig,
-    ({ id, prevRecord, nextRecord, paths }) => {
-      if (!isPlainObject(prevRecord) || !isPlainObject(nextRecord)) {
-        paths.push(`plugins.installs.${id}`);
-      }
-    },
-  );
+  return { noopPaths, forceChangedPaths };
 }
 
 function extractAccountIdFromPath(channel: ChannelId, path: string): string | null {

--- a/src/gateway/config-reload.ts
+++ b/src/gateway/config-reload.ts
@@ -40,8 +40,7 @@ import {
   buildGatewayReloadPlan,
   isNoopGatewayReloadPlan,
   listConfigReloadRefinementPrefixes,
-  listPluginInstallTimestampMetadataPaths,
-  listPluginInstallWholeRecordPaths,
+  resolvePluginInstallReloadMetadata,
   type GatewayReloadPlan,
 } from "./config-reload-plan.js";
 import { resolveGatewayReloadSettings } from "./config-reload-settings.js";
@@ -515,11 +514,7 @@ export function startGatewayConfigReloader(opts: {
       nextCompareConfig,
       listConfigReloadRefinementPrefixes(),
     );
-    const configPluginInstallTimestampNoopPaths = listPluginInstallTimestampMetadataPaths(
-      currentCompareConfig,
-      nextCompareConfig,
-    );
-    const configPluginInstallWholeRecordPaths = listPluginInstallWholeRecordPaths(
+    const configInstallMetadata = resolvePluginInstallReloadMetadata(
       currentCompareConfig,
       nextCompareConfig,
     );
@@ -535,23 +530,11 @@ export function startGatewayConfigReloader(opts: {
       previousPluginInstallConfig,
       nextPluginInstallConfig,
     );
-    const pluginInstallRecordTimestampNoopPaths = listPluginInstallTimestampMetadataPaths(
-      previousPluginInstallConfig,
-      nextPluginInstallConfig,
-    );
-    const pluginInstallRecordWholeRecordPaths = listPluginInstallWholeRecordPaths(
+    const installMetadata = resolvePluginInstallReloadMetadata(
       previousPluginInstallConfig,
       nextPluginInstallConfig,
     );
     const changedPaths = [...configChangedPaths, ...pluginInstallRecordChangedPaths];
-    const pluginInstallTimestampNoopPaths = [
-      ...configPluginInstallTimestampNoopPaths,
-      ...pluginInstallRecordTimestampNoopPaths,
-    ];
-    const pluginInstallWholeRecordPaths = [
-      ...configPluginInstallWholeRecordPaths,
-      ...pluginInstallRecordWholeRecordPaths,
-    ];
     // Publication can be superseded after its runtime commit but before its
     // lifecycle owner is applied. Finish that owner before the next candidate
     // prepares state that acceptance or restart policy may discard.
@@ -698,8 +681,11 @@ export function startGatewayConfigReloader(opts: {
       return;
     }
     const plan = buildGatewayReloadPlan(changedPaths, {
-      noopPaths: pluginInstallTimestampNoopPaths,
-      forceChangedPaths: pluginInstallWholeRecordPaths,
+      noopPaths: [...configInstallMetadata.noopPaths, ...installMetadata.noopPaths],
+      forceChangedPaths: [
+        ...configInstallMetadata.forceChangedPaths,
+        ...installMetadata.forceChangedPaths,
+      ],
       candidateConfig: nextConfig,
       candidateCompareConfig: nextCompareConfig,
       previousCompareConfig: currentCompareConfig,


### PR DESCRIPTION
Related: #135599

## What Problem This Solves

The plugin lifecycle refactor needs one consistent classification of install-record changes. The reload planner currently walks the same records twice for timestamp-only changes and whole-record changes. This is a maintainer-requested cleanup split from the larger lifecycle work.

## Why This Change Was Made

Return both classifications from one traversal and remove the callback scaffold and duplicate caller projections. Whole-record changes still take precedence when a dotted plugin ID collides with a timestamp path. Authored config is still classified before the awaited install-record read.

## User Impact

No behavior or public contract change. Production code is 46 lines smaller; tests, configuration, schemas, and dependencies are unchanged.

## Evidence

The same 765 tests across the config-reload, transcript-reload, and reload-handler suites passed before and after the change. All 28 selected canonical changed-code checks passed, including production/test types, typed lint, dead exports, and boundaries. Independent Codex review found no actionable P0–P2 findings.

This is equivalence proof for the classifier; it does not claim the separate restart-free lifecycle feature is complete.
