### PR TITLE
fix(ui): show saved automation display names

### DIFF
--- a/ui/src/pages/cron/view-description.test.ts
+++ b/ui/src/pages/cron/view-description.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import type { CronJob } from "../../api/types.ts";
+import { createInitialCronState, startCronEdit } from "../../lib/cron/index.ts";
 import { DEFAULT_CRON_FORM } from "../../test-helpers/cron.ts";
-import { createCronViewJob, renderCronView } from "./view.test-support.ts";
+import { createCronViewJob, getElement, renderCronView } from "./view.test-support.ts";
 
 const payloadCases = [
   { kind: "systemEvent", payload: { kind: "systemEvent", text: "check status" } },
@@ -11,7 +12,80 @@ const payloadCases = [
   { kind: "heartbeat", payload: { kind: "heartbeat" } },
 ] satisfies Array<{ kind: CronJob["payload"]["kind"]; payload: CronJob["payload"] }>;
 
-describe("cron view saved descriptions", () => {
+describe("cron view saved metadata", () => {
+  it.each([
+    { displayName: "Morning health report", expected: "Morning health report", enabled: true },
+    { displayName: "Morning health report", expected: "Morning health report", enabled: false },
+    { displayName: undefined, expected: "cron:ops:weekday-health", enabled: false },
+  ])(
+    "uses saved label $expected (enabled=$enabled) without replacing action or editor identity",
+    ({ displayName, expected, enabled }) => {
+      const onSelectJob = vi.fn();
+      const onRun = vi.fn();
+      const onToggle = vi.fn();
+      const job = createCronViewJob("display-name-job", {
+        name: "cron:ops:weekday-health",
+        configRevision: "fixture-config-revision",
+        enabled,
+        ...(displayName === undefined ? {} : { displayName }),
+      });
+      const row = renderCronView({ jobs: [job], onSelectJob, onRun, onToggle });
+      const name = row.querySelector<HTMLSpanElement>(".cron-table__name-text");
+      expect(name?.textContent).toBe(expected);
+      expect(row.querySelector(".cron-row-run")?.getAttribute("aria-label")).toContain(expected);
+      expect(row.querySelector(".cron-job-menu__trigger")?.getAttribute("aria-label")).toContain(
+        expected,
+      );
+      const toggle = getElement(row, `[data-test-id="cron-row-toggle-${job.id}"]`, HTMLSpanElement);
+      const toggleInput = getElement(toggle, "wa-switch", HTMLElement) as HTMLElement & {
+        checked: boolean;
+      };
+      const actionLabel = `${enabled ? "Pause" : "Resume"}: ${expected}`;
+      expect(toggleInput.querySelector(".settings-control__sr-label")?.textContent).toBe(
+        actionLabel,
+      );
+      expect(toggle.title).toBe(actionLabel);
+      expect(toggleInput.checked).toBe(enabled);
+
+      getElement(row, ".cron-row-run", HTMLButtonElement).click();
+      expect(onRun).toHaveBeenCalledExactlyOnceWith(job, "force");
+      toggleInput.checked = !enabled;
+      toggleInput.dispatchEvent(new Event("change", { bubbles: true }));
+      expect(onToggle).toHaveBeenCalledExactlyOnceWith(job, !enabled);
+      const dueItem = getElement(row, 'wa-dropdown-item[value="run-if-due"]', HTMLElement);
+      getElement(row, "wa-dropdown", HTMLElement).dispatchEvent(
+        new CustomEvent("wa-select", { detail: { item: dueItem }, bubbles: true }),
+      );
+      expect(onRun).toHaveBeenLastCalledWith(job, "due");
+      expect(onRun).toHaveBeenCalledTimes(2);
+      expect(onSelectJob).not.toHaveBeenCalled();
+      name?.click();
+      expect(onSelectJob).toHaveBeenCalledExactlyOnceWith(job);
+      expect(job.enabled).toBe(enabled);
+
+      const state = createInitialCronState();
+      startCronEdit(state, job);
+      expect(state.cronEditingJobId).toBe(job.id);
+      expect(state.cronEditingConfigRevision).toBe(job.configRevision);
+      const detail = renderCronView({ editingJob: state.cronEditingJob, form: state.cronForm });
+      expect(detail.querySelector(".cron-detail-title")?.textContent).toBe(expected);
+      expect(detail.querySelector<HTMLInputElement>("#cron-name")?.value).toBe(
+        "cron:ops:weekday-health",
+      );
+
+      const draft = renderCronView({
+        editingJob: state.cronEditingJob,
+        form: { ...state.cronForm, name: "Unsaved stable name" },
+      });
+      expect(draft.querySelector(".cron-detail-title")?.textContent).toBe(expected);
+      expect(draft.querySelector<HTMLInputElement>("#cron-name")?.value).toBe(
+        "Unsaved stable name",
+      );
+      expect(job.name).toBe("cron:ops:weekday-health");
+      expect(job.displayName).toBe(displayName);
+    },
+  );
+
   it.each(payloadCases)(
     "shows the saved description inline for $kind tasks without changing row selection",
     ({ kind, payload }) => {
@@ -45,9 +119,10 @@ describe("cron view saved descriptions", () => {
 
   it("renders saved descriptions as escaped text", () => {
     const description = '<img src="x" onerror="alert(1)"> & <script>alert(1)</script>';
-    const job = createCronViewJob("escaped-description", { description });
+    const job = createCronViewJob("escaped-description", { description, displayName: description });
     const container = renderCronView({ jobs: [job] });
 
+    expect(container.querySelector(".cron-table__name-text")?.textContent).toBe(description);
     expect(container.querySelector(".cron-table__description")?.textContent).toContain(description);
     expect(container.querySelector(".cron-table__name img")).toBeNull();
     expect(container.querySelector(".cron-table__name script")).toBeNull();

--- a/ui/src/pages/cron/view.ts
+++ b/ui/src/pages/cron/view.ts
@@ -820,6 +820,7 @@ function isSystemOwnedCronJob(job: CronJob | null | undefined): boolean {
 }
 
 function renderJobRow(job: CronJob, props: CronProps) {
+  const displayName = job.displayName ?? job.name;
   const description = job.description?.trim();
   const systemOwned = isSystemOwnedCronJob(job);
   const nextRunAtMs = job.state?.nextRunAtMs;
@@ -839,7 +840,7 @@ function renderJobRow(job: CronJob, props: CronProps) {
         ${renderJobStateIndicator(job)}
         <span class="cron-table__name-copy">
           <span class="cron-table__name-line">
-            <span class="cron-table__name-text">${job.name}</span>
+            <span class="cron-table__name-text">${displayName}</span>
             ${job.trigger ? renderTriggerIndicator() : nothing}
           </span>
           ${
@@ -881,8 +882,8 @@ function renderJobRow(job: CronJob, props: CronProps) {
                   type="button"
                   class="btn btn--sm btn--ghost cron-row-run"
                   data-test-id=${`cron-row-run-${job.id}`}
-                  title=${t("cron.actions.runNowJob", { name: job.name })}
-                  aria-label=${t("cron.actions.runNowJob", { name: job.name })}
+                  title=${t("cron.actions.runNowJob", { name: displayName })}
+                  aria-label=${t("cron.actions.runNowJob", { name: displayName })}
                   ?disabled=${props.busy}
                   @click=${() => props.onRun(job, "force")}
                 >
@@ -1026,6 +1027,7 @@ function renderJobMenu(props: CronProps, job: CronJob) {
     return nothing;
   }
   const systemOwned = isSystemOwnedCronJob(job);
+  const displayName = job.displayName ?? job.name;
   return html`
     <wa-dropdown
       class="cron-job-menu"
@@ -1057,8 +1059,8 @@ function renderJobMenu(props: CronProps, job: CronJob) {
         slot="trigger"
         type="button"
         class="btn btn--sm btn--ghost cron-job-menu__trigger"
-        aria-label=${t("cron.actions.moreJob", { name: job.name })}
-        title=${t("cron.actions.moreJob", { name: job.name })}
+        aria-label=${t("cron.actions.moreJob", { name: displayName })}
+        title=${t("cron.actions.moreJob", { name: displayName })}
       >
         ${icon("moreHorizontal")}
       </button>
@@ -1160,7 +1162,10 @@ function renderDetailView(props: CronProps, mode: CronPanelMode) {
 }
 
 function renderDetailHeader(props: CronProps, mode: CronPanelMode, selectedJob?: CronJob) {
-  const title = mode === "job" ? (selectedJob?.name ?? props.form.name) : t("cron.detail.newTitle");
+  const title =
+    mode === "job"
+      ? (selectedJob?.displayName ?? selectedJob?.name ?? props.form.name)
+      : t("cron.detail.newTitle");
   const description = mode === "job" ? selectedJob?.description?.trim() : undefined;
   const systemOwned = isSystemOwnedCronJob(selectedJob);
   // Header describes the SAVED job (schedule + next run); the form's live
@@ -1225,7 +1230,7 @@ function renderEnabledSwitch(
 ) {
   const stateLabel = job.enabled ? t("cron.detail.active") : t("cron.detail.paused");
   const actionLabel = t(job.enabled ? "cron.actions.pauseJob" : "cron.actions.resumeJob", {
-    name: job.name,
+    name: job.displayName ?? job.name,
   });
   return html`
     <span


### PR DESCRIPTION
Closes #142062

## What Problem This Solves

Fixes an issue where users setting an automation's display name would still see its stable name in the Automations list, saved detail heading, and adjacent action descriptions. The friendly name was already stored correctly.

## Why This Change Was Made

The existing view now uses the saved `displayName` with the documented stable-name fallback. The Name editor, job objects and IDs, configuration revision, callbacks, scheduling, and delivery remain unchanged. No schema, configuration, protocol, or persistence behavior is added.

Production changes are +12/−7, net +5; tests are +78/−3, net +75. The small display-only change covers list/detail labels and Run/More/Pause/Resume descriptions, including existing built-in automations.

## User Impact

Friendly names appear where operators identify their saved automations. Clearing a friendly name through the existing CLI restores the stable name. The editor continues to show the stable Name value.

## Evidence

- Component baseline: three intended label failures with 17 controls. The final component suite passes all 20 tests, including escaped text, stable editor identity and unchanged action arguments; the current lifecycle sibling passes 18 tests. Complete changed-file checks pass after formatting the test overlay without suppressions.
- Normal baseline full build passed in 4m30.3s. Its source, dependencies, genuine stamps and 15,436 artifact entries were qualified. The candidate's UI was rebuilt separately, preserving the baseline UI copy and the same compiled Gateway. Both variants use source base `0604bbce80797482228b275eaacec34614942731`.
- Real isolated Gateway, ordinary compiled CLI and headless browser: 14 successful CLI calls across baseline/candidate. Baseline JSON contains the friendly label before the UI still displays the stable name. Candidate list/detail show the friendly label; clearing it removes only that metadata plus its normal timestamp/revision changes, preserving ID, stable name, agent, schedule, payload and delivery. Add/edit print the expected scheduler-disabled warning.
- The synthetic job stays paused with no last-run timestamp, the scheduler stays disabled, and browser traffic contains no cron mutations or chat send. All served JavaScript/CSS observations match the bound assets. Existing fixture cleanup completed; root independently observed both recorded Gateway PIDs absent, both ports available again, and both private fixture homes/state directories absent.

- Independent runtime and image audits passed; all six panel crops are pixel-exact. One fresh managed P0–P2 review was scoped-clean with no findings, with source and evidence unchanged.

The reviewed patch `a768791807d317c20b9868da970fef5a0ad4eb1da3b588ee24a8d170e3310e0b` is committed without source changes as `ffa3c60579e82f5cb47f223878ebad56d5a70f05`. The affected view/caller/library sources remain unchanged on inspected main `eef591b0413d0b3e3c66989ae27f8689f669941c`.

The attached images are **sanitized crops** of the Automations panel. Original sidebar macOS-account personalization is excluded; the retained crop pixels are unchanged. This is a seeded isolated fixture, not normal dev onboarding. It does not claim editor-save/restart/enabled-job execution, provider inference, failed-provider recovery, or a new backend build for the candidate UI. The existing display-name documentation remains accurate.

![baseline-list-sanitized](https://github.com/user-attachments/assets/a87fb678-6e45-43a5-910d-bf35490d9029)

![baseline-detail-sanitized](https://github.com/user-attachments/assets/3a7ddca3-4cb8-4943-9bbf-e413d68e2574)

![candidate-list-sanitized](https://github.com/user-attachments/assets/71d08ee8-3159-4706-9b1f-8fe690144966)

![candidate-detail-sanitized](https://github.com/user-attachments/assets/f3cb9578-0320-4653-9813-665396a75122)

![candidate-cleared-detail-sanitized](https://github.com/user-attachments/assets/3dd64918-817e-4e01-b813-b6964a8aa47b)

![candidate-cleared-list-sanitized](https://github.com/user-attachments/assets/0d7deb99-0514-4a07-8f0b-cb460f05db9d)