### PR TITLE
refactor(tooling): remove TUI watcher timing overrides

### DIFF
--- a/scripts/dev/tui-pty-test-watch.ts
+++ b/scripts/dev/tui-pty-test-watch.ts
@@ -130,23 +130,14 @@ function currentTerminalDimension(value: number | undefined, fallback: number): 
 
 function createChildStopper(
   child: KillableChild,
-  options: {
-    signalChild?: SignalChild;
-    sigtermGraceMs?: number;
-    sigkillGraceMs?: number;
-  } = {},
+  signalChild: SignalChild = (targetChild, signal) =>
+    terminateManagedChild(targetChild, signal, {
+      onChildSignalError(error) {
+        throw error;
+      },
+      taskkillTimeoutMs: null,
+    }),
 ): ChildStopper {
-  const signalChild =
-    options.signalChild ??
-    ((targetChild, signal) =>
-      terminateManagedChild(targetChild, signal, {
-        onChildSignalError(error) {
-          throw error;
-        },
-        taskkillTimeoutMs: null,
-      }));
-  const sigtermGraceMs = options.sigtermGraceMs ?? CHILD_SIGTERM_GRACE_MS;
-  const sigkillGraceMs = options.sigkillGraceMs ?? CHILD_SIGKILL_GRACE_MS;
   let stopping = false;
   let termTimer: ReturnType<typeof setTimeout> | undefined;
   let killTimer: ReturnType<typeof setTimeout> | undefined;
@@ -172,9 +163,9 @@ function createChildStopper(
       signalChild(child, "SIGTERM");
       killTimer = setTimeout(() => {
         signalChild(child, "SIGKILL");
-      }, sigkillGraceMs);
+      }, CHILD_SIGKILL_GRACE_MS);
       unrefTimer(killTimer);
-    }, sigtermGraceMs);
+    }, CHILD_SIGTERM_GRACE_MS);
     unrefTimer(termTimer);
   };
 

--- a/test/scripts/dev-tooling-safety.test.ts
+++ b/test/scripts/dev-tooling-safety.test.ts
@@ -432,22 +432,18 @@ describe("script-specific dev tooling hardening", () => {
     const signals: NodeJS.Signals[] = [];
     const stopper = tuiPtyWatchTesting.createChildStopper(
       { kill: () => true },
-      {
-        signalChild(_child, signal: NodeJS.Signals): void {
-          signals.push(signal);
-        },
-        sigkillGraceMs: 20,
-        sigtermGraceMs: 10,
+      (_child, signal: NodeJS.Signals): void => {
+        signals.push(signal);
       },
     );
 
     stopper.stop();
     expect(signals).toEqual(["SIGINT"]);
 
-    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(500);
     expect(signals).toEqual(["SIGINT", "SIGTERM"]);
 
-    await vi.advanceTimersByTimeAsync(20);
+    await vi.advanceTimersByTimeAsync(5_000);
     expect(signals).toEqual(["SIGINT", "SIGTERM", "SIGKILL"]);
   });
 


### PR DESCRIPTION
## What Problem This Solves

The TUI PTY watcher's child-stop helper exposes two timing overrides used only by a test. That test already uses fake timers, so the overrides add tooling machinery while hiding the real defaults from the regression.

## Why This Change Was Made

Use the existing 500 ms and 5,000 ms grace constants directly, retain the useful signal callback as a direct parameter, and advance the existing test's fake clock through those defaults. Remove the one-property options bag along with the timing overrides.

## User Impact

The watcher's configured grace periods, signal order, cancellation, process ownership, mirror draining, and terminal restoration are unchanged. Tooling decreases by nine lines and tests by four; no cases or assertions are removed.

## Evidence

- All 60 dev-tooling cases pass before and after, with identical inventories.
- Both selected existing PTY namespace cases pass before and after; the other 73 namespace-suite cases are filtered out in these focused runs.
- Temporarily change only the SIGTERM default from 500 to 501 ms: the old named test passes, while the revised named test fails at the missing SIGTERM assertion after 500 ms. The other 59 dev-tooling cases are filtered out in each control. Exact source bytes were restored before the final passing suites.
- Formatting, diff checks, independent Codex review through P2, and all 19 normal changed-file checks passed ([Linux Testbox run](https://github.com/openclaw/openclaw/actions/runs/34209403001)). The retained source bundle matches the reviewed two-file tree.
- The delegated command passed and the lease completed; its capsule and recorded processes are gone. A later portal-sync timeout is recorded separately.

Fake-clock proof establishes default usage and signal ordering, not a wall-clock speedup or universal platform signal timing. The existing real watcher namespace cases retain process and cleanup coverage.
