### PR TITLE
test(gateway): compact network policy cases

### DIFF
--- a/src/gateway/net.test.ts
+++ b/src/gateway/net.test.ts
@@ -51,11 +51,11 @@ function useClearedFlyMachineEnv() {
 
 describe("resolveHostName", () => {
   it.each([
-    { input: "localhost:18789", expected: "localhost" },
-    { input: "127.0.0.1:18789", expected: "127.0.0.1" },
-    { input: "[::1]:18789", expected: "::1" },
-    { input: "::1", expected: "::1" },
-  ] as const)("normalizes host form for $input", ({ input, expected }) => {
+    ["localhost:18789", "localhost"],
+    ["127.0.0.1:18789", "127.0.0.1"],
+    ["[::1]:18789", "::1"],
+    ["::1", "::1"],
+  ] as const)("normalizes host form for %s", (input, expected) => {
     expect(resolveHostName(input), input).toBe(expected);
   });
 });
@@ -110,145 +110,55 @@ describe("isLoopbackGatewayUrl", () => {
 
 describe("isTrustedProxyAddress", () => {
   it.each([
-    {
-      name: "matches exact IP entries",
-      ip: "192.168.1.1",
-      trustedProxies: ["192.168.1.1"],
-      expected: true,
-    },
-    {
-      name: "rejects non-matching exact IP entries",
-      ip: "192.168.1.2",
-      trustedProxies: ["192.168.1.1"],
-      expected: false,
-    },
-    {
-      name: "matches one of multiple exact entries",
-      ip: "10.0.0.5",
-      trustedProxies: ["192.168.1.1", "10.0.0.5", "172.16.0.1"],
-      expected: true,
-    },
-    {
-      name: "ignores surrounding whitespace in exact IP entries",
-      ip: "10.0.0.5",
-      trustedProxies: [" 10.0.0.5 "],
-      expected: true,
-    },
-    {
-      name: "matches /24 CIDR entries",
-      ip: "10.42.0.59",
-      trustedProxies: ["10.42.0.0/24"],
-      expected: true,
-    },
-    {
-      name: "rejects IPs outside /24 CIDR entries",
-      ip: "10.42.1.1",
-      trustedProxies: ["10.42.0.0/24"],
-      expected: false,
-    },
-    {
-      name: "matches /16 CIDR entries",
-      ip: "172.19.255.255",
-      trustedProxies: ["172.19.0.0/16"],
-      expected: true,
-    },
-    {
-      name: "rejects IPs outside /16 CIDR entries",
-      ip: "172.20.0.1",
-      trustedProxies: ["172.19.0.0/16"],
-      expected: false,
-    },
-    {
-      name: "treats /32 as a single-IP CIDR",
-      ip: "10.42.0.0",
-      trustedProxies: ["10.42.0.0/32"],
-      expected: true,
-    },
-    {
-      name: "rejects non-matching /32 CIDR entries",
-      ip: "10.42.0.1",
-      trustedProxies: ["10.42.0.0/32"],
-      expected: false,
-    },
-    {
-      name: "handles mixed exact IP and CIDR entries",
-      ip: "172.19.5.100",
-      trustedProxies: ["192.168.1.1", "10.42.0.0/24", "172.19.0.0/16"],
-      expected: true,
-    },
-    {
-      name: "rejects IPs missing from mixed exact IP and CIDR entries",
-      ip: "10.43.0.1",
-      trustedProxies: ["192.168.1.1", "10.42.0.0/24", "172.19.0.0/16"],
-      expected: false,
-    },
-    {
-      name: "supports IPv6 CIDR notation",
-      ip: "2001:db8::1234",
-      trustedProxies: ["2001:db8::/32"],
-      expected: true,
-    },
-    {
-      name: "rejects IPv6 addresses outside the configured CIDR",
-      ip: "2001:db9::1234",
-      trustedProxies: ["2001:db8::/32"],
-      expected: false,
-    },
-    {
-      name: "preserves exact matching behavior for plain IP entries",
-      ip: "10.42.0.59",
-      trustedProxies: ["10.42.0.1"],
-      expected: false,
-    },
-    {
-      name: "normalizes IPv4-mapped IPv6 addresses",
-      ip: "::ffff:192.168.1.1",
-      trustedProxies: ["192.168.1.1"],
-      expected: true,
-    },
-    {
-      name: "returns false when IP is undefined",
-      ip: undefined,
-      trustedProxies: ["192.168.1.1"],
-      expected: false,
-    },
-    {
-      name: "returns false when trusted proxies are undefined",
-      ip: "192.168.1.1",
-      trustedProxies: undefined,
-      expected: false,
-    },
-    {
-      name: "returns false when trusted proxies are empty",
-      ip: "192.168.1.1",
-      trustedProxies: [],
-      expected: false,
-    },
-    {
-      name: "rejects invalid CIDR prefixes and addresses",
-      ip: "10.42.0.59",
-      trustedProxies: ["10.42.0.0/33", "10.42.0.0/-1", "invalid/24", "2001:db8::/129"],
-      expected: false,
-    },
-    {
-      name: "ignores surrounding whitespace in CIDR entries",
-      ip: "10.42.0.59",
-      trustedProxies: [" 10.42.0.0/24 "],
-      expected: true,
-    },
-    {
-      name: "ignores blank trusted proxy entries",
-      ip: "10.0.0.5",
-      trustedProxies: [" ", "10.0.0.5", ""],
-      expected: true,
-    },
-    {
-      name: "treats all-blank trusted proxy entries as no match",
-      ip: "10.0.0.5",
-      trustedProxies: [" ", "\t"],
-      expected: false,
-    },
-  ])("$name", ({ ip, trustedProxies, expected }) => {
+    ["matches exact IP entries", "192.168.1.1", ["192.168.1.1"], true],
+    ["rejects non-matching exact IP entries", "192.168.1.2", ["192.168.1.1"], false],
+    [
+      "matches one of multiple exact entries",
+      "10.0.0.5",
+      ["192.168.1.1", "10.0.0.5", "172.16.0.1"],
+      true,
+    ],
+    ["ignores surrounding whitespace in exact IP entries", "10.0.0.5", [" 10.0.0.5 "], true],
+    ["matches /24 CIDR entries", "10.42.0.59", ["10.42.0.0/24"], true],
+    ["rejects IPs outside /24 CIDR entries", "10.42.1.1", ["10.42.0.0/24"], false],
+    ["matches /16 CIDR entries", "172.19.255.255", ["172.19.0.0/16"], true],
+    ["rejects IPs outside /16 CIDR entries", "172.20.0.1", ["172.19.0.0/16"], false],
+    ["treats /32 as a single-IP CIDR", "10.42.0.0", ["10.42.0.0/32"], true],
+    ["rejects non-matching /32 CIDR entries", "10.42.0.1", ["10.42.0.0/32"], false],
+    [
+      "handles mixed exact IP and CIDR entries",
+      "172.19.5.100",
+      ["192.168.1.1", "10.42.0.0/24", "172.19.0.0/16"],
+      true,
+    ],
+    [
+      "rejects IPs missing from mixed exact IP and CIDR entries",
+      "10.43.0.1",
+      ["192.168.1.1", "10.42.0.0/24", "172.19.0.0/16"],
+      false,
+    ],
+    ["supports IPv6 CIDR notation", "2001:db8::1234", ["2001:db8::/32"], true],
+    [
+      "rejects IPv6 addresses outside the configured CIDR",
+      "2001:db9::1234",
+      ["2001:db8::/32"],
+      false,
+    ],
+    ["preserves exact matching behavior for plain IP entries", "10.42.0.59", ["10.42.0.1"], false],
+    ["normalizes IPv4-mapped IPv6 addresses", "::ffff:192.168.1.1", ["192.168.1.1"], true],
+    ["returns false when IP is undefined", undefined, ["192.168.1.1"], false],
+    ["returns false when trusted proxies are undefined", "192.168.1.1", undefined, false],
+    ["returns false when trusted proxies are empty", "192.168.1.1", [], false],
+    [
+      "rejects invalid CIDR prefixes and addresses",
+      "10.42.0.59",
+      ["10.42.0.0/33", "10.42.0.0/-1", "invalid/24", "2001:db8::/129"],
+      false,
+    ],
+    ["ignores surrounding whitespace in CIDR entries", "10.42.0.59", [" 10.42.0.0/24 "], true],
+    ["ignores blank trusted proxy entries", "10.0.0.5", [" ", "10.0.0.5", ""], true],
+    ["treats all-blank trusted proxy entries as no match", "10.0.0.5", [" ", "\t"], false],
+  ])("%s", (_name, ip, trustedProxies, expected) => {
     expect(isTrustedProxyAddress(ip, trustedProxies)).toBe(expected);
   });
 });
@@ -264,13 +174,13 @@ describe("resolveLocalInterfaceAddressMatch", () => {
   });
 
   it.each([
-    { input: "10.42.0.59", expected: true },
-    { input: "::ffff:10.42.0.59", expected: true },
-    { input: "fd7a:115c:a1e0::1234", expected: true },
-    { input: "127.0.0.1", expected: true },
-    { input: "10.42.0.60", expected: false },
-    { input: undefined, expected: false },
-  ] as const)("returns $expected for $input", ({ input, expected }) => {
+    ["10.42.0.59", true],
+    ["::ffff:10.42.0.59", true],
+    ["fd7a:115c:a1e0::1234", true],
+    ["127.0.0.1", true],
+    ["10.42.0.60", false],
+    [undefined, false],
+  ] as const)("classifies %s as %s", (input, expected) => {
     expect(resolveLocalInterfaceAddressMatch(input, snapshot)).toBe(expected);
   });
 
@@ -281,87 +191,109 @@ describe("resolveLocalInterfaceAddressMatch", () => {
 
 describe("resolveClientIp", () => {
   it.each([
-    {
-      name: "returns remote IP when remote is not trusted proxy",
-      remoteAddr: "203.0.113.10",
-      forwardedFor: "10.0.0.2",
-      trustedProxies: ["127.0.0.1"],
-      expected: "203.0.113.10",
+    [
+      "returns remote IP when remote is not trusted proxy",
+      "203.0.113.10",
+      "10.0.0.2",
+      ["127.0.0.1"],
+      "203.0.113.10",
+      undefined,
+      undefined,
+    ],
+    [
+      "uses right-most untrusted X-Forwarded-For hop",
+      "127.0.0.1",
+      "198.51.100.99, 10.0.0.9, 127.0.0.1",
+      ["127.0.0.1"],
+      "10.0.0.9",
+      undefined,
+      undefined,
+    ],
+    [
+      "ignores spoofed loopback X-Forwarded-For hops from trusted proxies",
+      "10.0.0.50",
+      "127.0.0.1",
+      ["10.0.0.0/8"],
+      undefined,
+      undefined,
+      undefined,
+    ],
+    [
+      "fails closed when all X-Forwarded-For hops are trusted proxies",
+      "127.0.0.1",
+      "127.0.0.1, ::1",
+      ["127.0.0.1", "::1"],
+      undefined,
+      undefined,
+      undefined,
+    ],
+    [
+      "fails closed when all non-loopback X-Forwarded-For hops are trusted proxies",
+      "10.0.0.50",
+      "10.0.0.2, 10.0.0.1",
+      ["10.0.0.0/8"],
+      undefined,
+      undefined,
+      undefined,
+    ],
+    [
+      "fails closed when trusted proxy omits forwarding headers",
+      "127.0.0.1",
+      undefined,
+      ["127.0.0.1"],
+      undefined,
+      undefined,
+      undefined,
+    ],
+    [
+      "ignores invalid X-Forwarded-For entries",
+      "127.0.0.1",
+      "garbage, 10.0.0.999",
+      ["127.0.0.1"],
+      undefined,
+      undefined,
+      undefined,
+    ],
+    [
+      "does not trust X-Real-IP by default",
+      "127.0.0.1",
+      undefined,
+      ["127.0.0.1"],
+      undefined,
+      "[2001:db8::5]",
+      undefined,
+    ],
+    [
+      "uses X-Real-IP only when explicitly enabled",
+      "127.0.0.1",
+      undefined,
+      ["127.0.0.1"],
+      "2001:db8::5",
+      "[2001:db8::5]",
+      true,
+    ],
+    [
+      "ignores invalid X-Real-IP even when fallback enabled",
+      "127.0.0.1",
+      undefined,
+      ["127.0.0.1"],
+      undefined,
+      "not-an-ip",
+      true,
+    ],
+  ])(
+    "%s",
+    (_name, remoteAddr, forwardedFor, trustedProxies, expected, realIp, allowRealIpFallback) => {
+      const ip = resolveClientIp({
+        remoteAddr,
+        forwardedFor,
+        realIp,
+        trustedProxies,
+        allowRealIpFallback,
+      });
+      expect(ip).toBe(expected);
     },
-    {
-      name: "uses right-most untrusted X-Forwarded-For hop",
-      remoteAddr: "127.0.0.1",
-      forwardedFor: "198.51.100.99, 10.0.0.9, 127.0.0.1",
-      trustedProxies: ["127.0.0.1"],
-      expected: "10.0.0.9",
-    },
-    {
-      name: "ignores spoofed loopback X-Forwarded-For hops from trusted proxies",
-      remoteAddr: "10.0.0.50",
-      forwardedFor: "127.0.0.1",
-      trustedProxies: ["10.0.0.0/8"],
-      expected: undefined,
-    },
-    {
-      name: "fails closed when all X-Forwarded-For hops are trusted proxies",
-      remoteAddr: "127.0.0.1",
-      forwardedFor: "127.0.0.1, ::1",
-      trustedProxies: ["127.0.0.1", "::1"],
-      expected: undefined,
-    },
-    {
-      name: "fails closed when all non-loopback X-Forwarded-For hops are trusted proxies",
-      remoteAddr: "10.0.0.50",
-      forwardedFor: "10.0.0.2, 10.0.0.1",
-      trustedProxies: ["10.0.0.0/8"],
-      expected: undefined,
-    },
-    {
-      name: "fails closed when trusted proxy omits forwarding headers",
-      remoteAddr: "127.0.0.1",
-      trustedProxies: ["127.0.0.1"],
-      expected: undefined,
-    },
-    {
-      name: "ignores invalid X-Forwarded-For entries",
-      remoteAddr: "127.0.0.1",
-      forwardedFor: "garbage, 10.0.0.999",
-      trustedProxies: ["127.0.0.1"],
-      expected: undefined,
-    },
-    {
-      name: "does not trust X-Real-IP by default",
-      remoteAddr: "127.0.0.1",
-      realIp: "[2001:db8::5]",
-      trustedProxies: ["127.0.0.1"],
-      expected: undefined,
-    },
-    {
-      name: "uses X-Real-IP only when explicitly enabled",
-      remoteAddr: "127.0.0.1",
-      realIp: "[2001:db8::5]",
-      trustedProxies: ["127.0.0.1"],
-      allowRealIpFallback: true,
-      expected: "2001:db8::5",
-    },
-    {
-      name: "ignores invalid X-Real-IP even when fallback enabled",
-      remoteAddr: "127.0.0.1",
-      realIp: "not-an-ip",
-      trustedProxies: ["127.0.0.1"],
-      allowRealIpFallback: true,
-      expected: undefined,
-    },
-  ])("$name", (testCase) => {
-    const ip = resolveClientIp({
-      remoteAddr: testCase.remoteAddr,
-      forwardedFor: testCase.forwardedFor,
-      realIp: testCase.realIp,
-      trustedProxies: testCase.trustedProxies,
-      allowRealIpFallback: testCase.allowRealIpFallback,
-    });
-    expect(ip).toBe(testCase.expected);
-  });
+  );
 });
 
 describe("resolveGatewayListenHosts", () => {
@@ -370,43 +302,43 @@ describe("resolveGatewayListenHosts", () => {
   });
 
   it.each([
-    {
-      name: "non-loopback host passthrough",
-      host: "0.0.0.0",
-      canBindToHost: async () => {
+    [
+      "non-loopback host passthrough",
+      "0.0.0.0",
+      async (): Promise<boolean> => {
         throw new Error("should not be called");
       },
-      expected: ["0.0.0.0"],
-    },
-    {
-      name: "IPv6 host passthrough",
-      host: "::1",
-      canBindToHost: async () => {
+      ["0.0.0.0"],
+    ],
+    [
+      "IPv6 host passthrough",
+      "::1",
+      async (): Promise<boolean> => {
         throw new Error("should not be called");
       },
-      expected: ["::1"],
-    },
-    {
-      name: "specific non-loopback host with loopback alias available",
-      host: "100.64.0.1",
-      canBindToHost: async () => {
+      ["::1"],
+    ],
+    [
+      "specific non-loopback host with loopback alias available",
+      "100.64.0.1",
+      async (): Promise<boolean> => {
         throw new Error("should not be called");
       },
-      expected: ["100.64.0.1", "127.0.0.1"],
-    },
-    {
-      name: "loopback with IPv6 available",
-      host: "127.0.0.1",
-      canBindToHost: async () => true,
-      expected: ["127.0.0.1", "::1"],
-    },
-    {
-      name: "loopback with IPv6 unavailable",
-      host: "127.0.0.1",
-      canBindToHost: async () => false,
-      expected: ["127.0.0.1"],
-    },
-  ] as const)("resolves listen hosts: $name", async ({ host, canBindToHost, expected }) => {
+      ["100.64.0.1", "127.0.0.1"],
+    ],
+    [
+      "loopback with IPv6 available",
+      "127.0.0.1",
+      async (): Promise<boolean> => true,
+      ["127.0.0.1", "::1"],
+    ],
+    [
+      "loopback with IPv6 unavailable",
+      "127.0.0.1",
+      async (): Promise<boolean> => false,
+      ["127.0.0.1"],
+    ],
+  ] as const)("resolves listen hosts: %s", async (_name, host, canBindToHost, expected) => {
     vi.spyOn(process, "platform", "get").mockReturnValue("linux");
     const hosts = await resolveGatewayListenHosts(host, {
       canBindToHost,
@@ -456,40 +388,40 @@ describe("pickPrimaryLanIPv4", () => {
   });
 
   it.each([
-    {
-      name: "prefers en0",
-      interfaces: makeNetworkInterfacesSnapshot({
+    [
+      "prefers en0",
+      makeNetworkInterfacesSnapshot({
         lo0: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
         en0: [{ address: "192.168.1.42", family: "IPv4" }],
       }),
-      expected: "192.168.1.42",
-    },
-    {
-      name: "falls back to eth0",
-      interfaces: makeNetworkInterfacesSnapshot({
+      "192.168.1.42",
+    ],
+    [
+      "falls back to eth0",
+      makeNetworkInterfacesSnapshot({
         lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
         eth0: [{ address: "10.0.0.5", family: "IPv4" }],
       }),
-      expected: "10.0.0.5",
-    },
-    {
-      name: "falls back to any non-internal interface",
-      interfaces: makeNetworkInterfacesSnapshot({
+      "10.0.0.5",
+    ],
+    [
+      "falls back to any non-internal interface",
+      makeNetworkInterfacesSnapshot({
         lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
         wlan0: [{ address: "172.16.0.99", family: "IPv4" }],
       }),
-      expected: "172.16.0.99",
-    },
-    {
-      name: "no non-internal interface",
-      interfaces: makeNetworkInterfacesSnapshot({
+      "172.16.0.99",
+    ],
+    [
+      "no non-internal interface",
+      makeNetworkInterfacesSnapshot({
         lo: [{ address: "127.0.0.1", family: "IPv4", internal: true }],
       }),
-      expected: undefined,
-    },
+      undefined,
+    ],
   ] as const)(
-    "prefers en0, then eth0, then any non-internal IPv4: $name",
-    ({ interfaces, expected }) => {
+    "prefers en0, then eth0, then any non-internal IPv4: %s",
+    (_name, interfaces, expected) => {
       vi.spyOn(os, "networkInterfaces").mockReturnValue(interfaces);
       expect(pickPrimaryLanIPv4()).toBe(expected);
     },
@@ -805,43 +737,43 @@ describe("defaultGatewayBindMode", () => {
 describe("isSecureWebSocketUrl", () => {
   it.each([
     // wss:// always accepted
-    { input: "wss://127.0.0.1:18789", expected: true },
-    { input: "wss://localhost:18789", expected: true },
-    { input: "wss://remote.example.com:18789", expected: true },
-    { input: "wss://192.168.1.100:18789", expected: true },
+    ["wss://127.0.0.1:18789", true],
+    ["wss://localhost:18789", true],
+    ["wss://remote.example.com:18789", true],
+    ["wss://192.168.1.100:18789", true],
     // ws:// loopback accepted
-    { input: "ws://127.0.0.1:18789", expected: true },
-    { input: "ws://localhost:18789", expected: true },
-    { input: "ws://[::1]:18789", expected: true },
-    { input: "ws://127.0.0.42:18789", expected: true },
+    ["ws://127.0.0.1:18789", true],
+    ["ws://localhost:18789", true],
+    ["ws://[::1]:18789", true],
+    ["ws://127.0.0.42:18789", true],
     // ws:// trusted LAN/Tailnet endpoints accepted
-    { input: "ws://10.0.0.5:18789", expected: true },
-    { input: "ws://10.42.1.100:18789", expected: true },
-    { input: "ws://172.16.0.1:18789", expected: true },
-    { input: "ws://172.31.255.254:18789", expected: true },
-    { input: "ws://192.168.1.100:18789", expected: true },
-    { input: "ws://169.254.10.20:18789", expected: true },
-    { input: "ws://100.64.0.1:18789", expected: true },
-    { input: "ws://[fc00::1]:18789", expected: true },
-    { input: "ws://[fd12:3456:789a::1]:18789", expected: true },
-    { input: "ws://[fe80::1]:18789", expected: true },
-    { input: "ws://gateway.local:18789", expected: true },
-    { input: "ws://machine.tail123.ts.net:18789", expected: true },
-    { input: "ws://[::]:18789", expected: false },
-    { input: "ws://[ff02::1]:18789", expected: false },
+    ["ws://10.0.0.5:18789", true],
+    ["ws://10.42.1.100:18789", true],
+    ["ws://172.16.0.1:18789", true],
+    ["ws://172.31.255.254:18789", true],
+    ["ws://192.168.1.100:18789", true],
+    ["ws://169.254.10.20:18789", true],
+    ["ws://100.64.0.1:18789", true],
+    ["ws://[fc00::1]:18789", true],
+    ["ws://[fd12:3456:789a::1]:18789", true],
+    ["ws://[fe80::1]:18789", true],
+    ["ws://gateway.local:18789", true],
+    ["ws://machine.tail123.ts.net:18789", true],
+    ["ws://[::]:18789", false],
+    ["ws://[ff02::1]:18789", false],
     // ws:// public addresses rejected
-    { input: "ws://remote.example.com:18789", expected: false },
-    { input: "ws://1.1.1.1:18789", expected: false },
-    { input: "ws://8.8.8.8:18789", expected: false },
-    { input: "ws://203.0.113.10:18789", expected: false },
+    ["ws://remote.example.com:18789", false],
+    ["ws://1.1.1.1:18789", false],
+    ["ws://8.8.8.8:18789", false],
+    ["ws://203.0.113.10:18789", false],
     // invalid URLs
-    { input: "not-a-url", expected: false },
-    { input: "", expected: false },
-    { input: "http://127.0.0.1:18789", expected: true },
-    { input: "https://127.0.0.1:18789", expected: true },
-    { input: "https://remote.example.com:18789", expected: true },
-    { input: "http://remote.example.com:18789", expected: false },
-  ] as const)("defaults secure websocket behavior for $input", ({ input, expected }) => {
+    ["not-a-url", false],
+    ["", false],
+    ["http://127.0.0.1:18789", true],
+    ["https://127.0.0.1:18789", true],
+    ["https://remote.example.com:18789", true],
+    ["http://remote.example.com:18789", false],
+  ] as const)("defaults secure websocket behavior for %s", (input, expected) => {
     expect(isSecureWebSocketUrl(input), input).toBe(expected);
   });
 


### PR DESCRIPTION
## What Problem This Solves

Gateway network-policy test tables repeat small input/expectation contracts as verbose objects, obscuring the policy matrix.

## Why This Change Was Made

Consolidates those tables into typed positional tuples while preserving all URL, host, optional policy, and expected-result cases.

## User Impact

No runtime behavior changes. The same gateway security-policy coverage is retained with 68 fewer lines.

## Evidence

- 142/142 focused tests passed
- `pnpm check:changed` passed on the exact commit
- Exact-base P3 autoreview: clean (0.99)

