### PR TITLE
fix(release): pin Kova startup gateway accounting

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -88,9 +88,9 @@ env:
   OCM_VERSION: v0.2.33
   OCM_LINUX_X64_SHA256: 06b0e46791e750eb044e4a898b6643ad5e7b20224fe0c64f160e35a42f08d00a
   KOVA_REPOSITORY: openclaw/Kova
-  KOVA_CANONICAL_CONFIG_REF: d1cb301f0577c089b905d20efe5ccbc66b94d226
-  KOVA_LEGACY_LIST_CONFIG_REF: d1cb301f0577c089b905d20efe5ccbc66b94d226
-  KOVA_TRUSTED_LIVE_REF: d1cb301f0577c089b905d20efe5ccbc66b94d226
+  KOVA_CANONICAL_CONFIG_REF: 11b56553e4c4e93ddf99a53617a139b2c9e9efef
+  KOVA_LEGACY_LIST_CONFIG_REF: 11b56553e4c4e93ddf99a53617a139b2c9e9efef
+  KOVA_TRUSTED_LIVE_REF: 11b56553e4c4e93ddf99a53617a139b2c9e9efef
   PERFORMANCE_MODEL_ID: gpt-5.6-luna
   # Release matrices cold-build the candidate runtime before measurement.
   KOVA_SCENARIO_TIMEOUT_MS: ${{ inputs.profile == 'release' && '900000' || '300000' }}
@@ -159,8 +159,9 @@ jobs:
             ' "$TARGET_CHECKOUT_DIR/package.json")"
             if [[ "$target_version" == "2026.7.33" ]]; then
               # Kova #116 carries the historical 250% status CLI calibration for this release only;
-              # Kova #118 keeps process-census time out of CPU scan uncertainty.
-              kova_ref="d1cb301f0577c089b905d20efe5ccbc66b94d226"
+              # Kova #118 keeps process-census time out of CPU scan uncertainty;
+              # Kova #119 discovers a starting gateway before its zero baseline is lost.
+              kova_ref="11b56553e4c4e93ddf99a53617a139b2c9e9efef"
             fi
           fi
           if [[ "$kova_ref" == *$'\n'* || "$kova_ref" == *$'\r'* ]]; then

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -240,9 +240,9 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const canonicalKovaRef = "d1cb301f0577c089b905d20efe5ccbc66b94d226";
-    const legacyKovaRef = "d1cb301f0577c089b905d20efe5ccbc66b94d226";
-    const trustedLiveKovaRef = "d1cb301f0577c089b905d20efe5ccbc66b94d226";
+    const canonicalKovaRef = "11b56553e4c4e93ddf99a53617a139b2c9e9efef";
+    const legacyKovaRef = "11b56553e4c4e93ddf99a53617a139b2c9e9efef";
+    const trustedLiveKovaRef = "11b56553e4c4e93ddf99a53617a139b2c9e9efef";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";
     const targetCheckout = findStep("Checkout target metadata", "resolve_target");
@@ -277,7 +277,7 @@ describe("OpenClaw performance workflow", () => {
     expect(resolveTarget.run).toContain('detected_kova_config_contract="canonical"');
     expect(resolveTarget.run).toContain('detected_kova_config_contract="legacy-list"');
     expect(resolveTarget.run).toContain('kova_ref="${KOVA_REF_INPUT:-}"');
-    expect(resolveTarget.run).toContain('kova_ref="d1cb301f0577c089b905d20efe5ccbc66b94d226"');
+    expect(resolveTarget.run).toContain('kova_ref="11b56553e4c4e93ddf99a53617a139b2c9e9efef"');
     expect(resolveTarget.run).toContain('kova_ref="${kova_ref:-$default_kova_ref}"');
     expect(resolveTarget.run).toContain(
       'if [[ -z "$kova_ref" || -z "$kova_config_contract" ]]; then',


### PR DESCRIPTION
## Summary
- advance the reviewed Kova pins to merged Kova #119
- retain the process-census clock fix from #118
- discover gateways on the next sample before their zero CPU baseline is lost

The isolated [Kova proof 34208309908](https://github.com/openclaw/openclaw/actions/runs/34208309908) showed the #118 pin still produced 12 BLOCKED records. Every block was missing startup gateway baseline evidence; all measured lower bounds passed. [Kova #119](https://github.com/openclaw/Kova/pull/119) fixes the evidence producer without weakening the release gate.

## Validation
- Kova: node --test tests/linux-cpu-accounting.mjs (25 passed, 1 platform skip)
- Kova: node bin/kova.mjs self-check (280/280)
- OpenClaw: pnpm vitest run --config test/vitest/vitest.tooling.config.ts test/scripts/openclaw-performance-workflow.test.ts (42/42)
