### PR TITLE
feat(meta): backport Muse Spark 1.3 models

### DIFF
--- a/docs/providers/meta.md
+++ b/docs/providers/meta.md
@@ -1,5 +1,5 @@
 ---
-summary: "Meta setup (auth + muse-spark-1.1 model selection)"
+summary: "Meta setup (auth + Muse Spark model selection)"
 title: "Meta"
 read_when:
   - You want to use Meta with OpenClaw
@@ -7,7 +7,7 @@ read_when:
 ---
 
 The **Meta API** uses the OpenAI-compatible **Responses API** (`POST /v1/responses`)
-for the `muse-spark-1.1` reasoning model. The provider ships as a bundled OpenClaw
+for the Muse Spark reasoning models. The provider ships as a bundled OpenClaw
 plugin.
 
 | Property          | Value                              |
@@ -19,7 +19,7 @@ plugin.
 | Direct CLI flag   | `--meta-api-key <key>`             |
 | API               | Responses API (`openai-responses`) |
 | Base URL          | `https://api.meta.ai/v1`           |
-| Default model     | `meta/muse-spark-1.1`              |
+| Default model     | `meta/muse-spark-1.3`              |
 | Default reasoning | `high` (`reasoning.effort`)        |
 
 ## Getting started
@@ -50,7 +50,7 @@ export MODEL_API_KEY=<key>
     openclaw models list --provider meta
     ```
 
-    Lists the static `muse-spark-1.1` catalog entry. If `MODEL_API_KEY` is unresolved,
+    Lists the static Muse Spark catalog. If `MODEL_API_KEY` is unresolved,
     `openclaw models status --json` reports the missing credential under
     `auth.unusableProfiles`.
 
@@ -68,9 +68,11 @@ openclaw onboard --non-interactive --accept-risk \
 
 ## Built-in catalog
 
-| Model ref             | Name           | Reasoning | Context window | Max output |
-| --------------------- | -------------- | --------- | -------------- | ---------- |
-| `meta/muse-spark-1.1` | Muse Spark 1.1 | yes       | 1,048,576      | 131,072    |
+| Model ref                         | Name                       | Reasoning | Context window | Max output |
+| --------------------------------- | -------------------------- | --------- | -------------- | ---------- |
+| `meta/muse-spark-1.3`             | Muse Spark 1.3             | yes       | 1,048,576      | 131,072    |
+| `meta/muse-spark-1.3-contributor` | Muse Spark 1.3 Contributor | yes       | 1,048,576      | 131,072    |
+| `meta/muse-spark-1.1`             | Muse Spark 1.1             | yes       | 1,048,576      | 131,072    |
 
 Capabilities:
 
@@ -80,7 +82,7 @@ Capabilities:
 - Stateless encrypted reasoning replay (`store: false`, `include: ["reasoning.encrypted_content"]`)
 
 <Warning>
-`muse-spark-1.1` does not accept `reasoning.effort: "none"`. OpenClaw maps
+Muse Spark does not accept `reasoning.effort: "none"`. OpenClaw maps
 `--thinking off` to `minimal` for this provider.
 </Warning>
 
@@ -91,9 +93,9 @@ Capabilities:
   env: { MODEL_API_KEY: "<key>" },
   agents: {
     defaults: {
-      model: { primary: "meta/muse-spark-1.1" },
+      model: { primary: "meta/muse-spark-1.3" },
       models: {
-        "meta/muse-spark-1.1": { alias: "Muse Spark 1.1" },
+        "meta/muse-spark-1.3": { alias: "Muse Spark 1.3" },
       },
     },
   },
@@ -115,7 +117,7 @@ export MODEL_API_KEY=<key>
 pnpm test:live -- extensions/meta/meta.live.test.ts
 ```
 
-Live tests use `muse-spark-1.1` against `POST /v1/responses`.
+Live tests use `muse-spark-1.3` against `POST /v1/responses`.
 
 ## Related
 
@@ -124,7 +126,7 @@ Live tests use `muse-spark-1.1` against `POST /v1/responses`.
     Choosing providers, model refs, and failover behavior.
   </Card>
   <Card title="Thinking modes" href="/tools/thinking" icon="brain">
-    Reasoning effort levels for muse-spark-1.1.
+    Reasoning effort levels for Muse Spark.
   </Card>
   <Card title="Configuration reference" href="/gateway/config-agents#agent-defaults" icon="gear">
     Agent defaults and model configuration.

--- a/extensions/meta/README.md
+++ b/extensions/meta/README.md
@@ -5,7 +5,8 @@ Bundled OpenClaw provider plugin for the **Meta API** — an OpenAI-compatible
 
 - **Base URL:** `https://api.meta.ai/v1`
 - **Auth:** `Authorization: Bearer $MODEL_API_KEY`
-- **Model:** `muse-spark-1.1` (reasoning model)
+- **Models:** `muse-spark-1.3`, `muse-spark-1.3-contributor`, and `muse-spark-1.1`
+  (reasoning models)
   - Context window: 1,048,576 tokens (input + output share the budget)
   - Maximum output: 131,072 tokens
   - Reasoning effort: `minimal | low | medium | high | xhigh` (default: `high`)
@@ -26,7 +27,7 @@ export MODEL_API_KEY=<key>
 {
   agents: {
     defaults: {
-      model: { primary: "meta/muse-spark-1.1" },
+      model: { primary: "meta/muse-spark-1.3" },
     },
   },
 }
@@ -51,4 +52,4 @@ export MODEL_API_KEY=<key>
 pnpm test:live -- extensions/meta/meta.live.test.ts
 ```
 
-Live tests call `muse-spark-1.1` on `/v1/responses`.
+Live tests call `muse-spark-1.3` on `/v1/responses`.

--- a/extensions/meta/index.test.ts
+++ b/extensions/meta/index.test.ts
@@ -1,7 +1,7 @@
 // Meta tests cover plugin registration and catalog shape.
 import { capturePluginRegistration } from "openclaw/plugin-sdk/plugin-test-runtime";
 import { describe, expect, it } from "vitest";
-import { buildMetaProvider } from "./api.js";
+import { applyMetaConfig, buildMetaProvider } from "./api.js";
 import plugin from "./index.js";
 
 function requireThinkingProfileResolver(
@@ -45,6 +45,29 @@ describe("meta provider", () => {
     expect(model.maxTokens).toBe(131072);
     expect(model.reasoning).toBe(true);
     expect(model.input).toContain("image");
+  });
+
+  it("ships Muse Spark 1.3 as the default with its contributor variant", () => {
+    expect(applyMetaConfig({}).agents?.defaults).toMatchObject({
+      model: { primary: "meta/muse-spark-1.3" },
+      models: { "meta/muse-spark-1.3": { alias: "Muse Spark 1.3" } },
+    });
+
+    const providerConfig = buildMetaProvider();
+    expect(
+      providerConfig.models
+        .filter((model) => model.id.startsWith("muse-spark-1.3"))
+        .map(({ id, cost }) => ({ id, cost })),
+    ).toEqual([
+      {
+        id: "muse-spark-1.3",
+        cost: { input: 1.25, output: 4.25, cacheRead: 0.15, cacheWrite: 0 },
+      },
+      {
+        id: "muse-spark-1.3-contributor",
+        cost: { input: 0.1, output: 0.2, cacheRead: 0.002, cacheWrite: 0 },
+      },
+    ]);
   });
 
   it("advertises a high default thinking profile for muse-spark-1.1", () => {

--- a/extensions/meta/meta.live.test.ts
+++ b/extensions/meta/meta.live.test.ts
@@ -1,4 +1,4 @@
-// Meta live tests prove muse-spark-1.1 auth and Responses API completion.
+// Meta live tests prove current Muse Spark auth and Responses API completion.
 import { streamSimple, type Model } from "openclaw/plugin-sdk/llm";
 import { extractNonEmptyAssistantText, isLiveTestEnabled } from "openclaw/plugin-sdk/test-env";
 import { describe, expect, it } from "vitest";
@@ -6,7 +6,7 @@ import { buildMetaProvider } from "./provider-catalog.js";
 import { wrapMetaProviderStream } from "./stream.js";
 
 const MODEL_API_KEY = process.env.MODEL_API_KEY?.trim() ?? "";
-const LIVE_MODEL_ID = "muse-spark-1.1";
+const LIVE_MODEL_ID = "muse-spark-1.3";
 const LIVE =
   isLiveTestEnabled(["META_LIVE_TEST", "MODEL_API_LIVE_TEST"]) && MODEL_API_KEY.length > 0;
 const describeLive = LIVE ? describe : describe.skip;
@@ -38,7 +38,7 @@ function resolveLiveStreamFn() {
 }
 
 describeLive("meta plugin live", () => {
-  it("lists muse-spark-1.1 via the /models endpoint", async () => {
+  it("lists the current Muse Spark model via the /models endpoint", async () => {
     const provider = buildMetaProvider();
     const response = await fetch(`${provider.baseUrl}/models`, {
       headers: { Authorization: `Bearer ${MODEL_API_KEY}` },
@@ -49,7 +49,7 @@ describeLive("meta plugin live", () => {
     expect(ids).toContain(LIVE_MODEL_ID);
   }, 30_000);
 
-  it("completes a muse-spark-1.1 Responses API turn with high reasoning effort", async () => {
+  it("completes a current Muse Spark Responses API turn with high reasoning effort", async () => {
     const model = resolveLiveModel();
     let capturedPayload: Record<string, unknown> | undefined;
     const stream = await resolveLiveStreamFn()(

--- a/extensions/meta/onboard.ts
+++ b/extensions/meta/onboard.ts
@@ -5,14 +5,10 @@ import {
   createModelCatalogPresetAppliers,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
-import {
-  buildMetaModelDefinition,
-  META_BASE_URL,
-  META_MODEL_CATALOG,
-} from "./models.js";
+import { buildMetaModelDefinition, META_BASE_URL, META_MODEL_CATALOG } from "./models.js";
 
 /** Default Meta model reference used after onboarding. */
-export const META_DEFAULT_MODEL_REF = "meta/muse-spark-1.1";
+export const META_DEFAULT_MODEL_REF = "meta/muse-spark-1.3";
 
 const metaPresetAppliers = createModelCatalogPresetAppliers({
   primaryModelRef: META_DEFAULT_MODEL_REF,
@@ -21,7 +17,7 @@ const metaPresetAppliers = createModelCatalogPresetAppliers({
     api: "openai-responses",
     baseUrl: META_BASE_URL,
     catalogModels: META_MODEL_CATALOG.map(buildMetaModelDefinition),
-    aliases: [{ modelRef: META_DEFAULT_MODEL_REF, alias: "Muse Spark 1.1" }],
+    aliases: [{ modelRef: META_DEFAULT_MODEL_REF, alias: "Muse Spark 1.3" }],
   }),
 });
 

--- a/extensions/meta/openclaw.plugin.json
+++ b/extensions/meta/openclaw.plugin.json
@@ -25,6 +25,72 @@
         "api": "openai-responses",
         "models": [
           {
+            "id": "muse-spark-1.3",
+            "name": "Muse Spark 1.3",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1048576,
+            "maxTokens": 131072,
+            "thinkingLevelMap": {
+              "off": "minimal",
+              "minimal": "minimal",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "xhigh"
+            },
+            "compat": {
+              "supportsTools": true,
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": [
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ]
+            },
+            "cost": {
+              "input": 1.25,
+              "output": 4.25,
+              "cacheRead": 0.15,
+              "cacheWrite": 0
+            }
+          },
+          {
+            "id": "muse-spark-1.3-contributor",
+            "name": "Muse Spark 1.3 Contributor",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "contextWindow": 1048576,
+            "maxTokens": 131072,
+            "thinkingLevelMap": {
+              "off": "minimal",
+              "minimal": "minimal",
+              "low": "low",
+              "medium": "medium",
+              "high": "high",
+              "xhigh": "xhigh"
+            },
+            "compat": {
+              "supportsTools": true,
+              "supportsReasoningEffort": true,
+              "supportedReasoningEfforts": [
+                "minimal",
+                "low",
+                "medium",
+                "high",
+                "xhigh"
+              ]
+            },
+            "cost": {
+              "input": 0.1,
+              "output": 0.2,
+              "cacheRead": 0.002,
+              "cacheWrite": 0
+            }
+          },
+          {
             "id": "muse-spark-1.1",
             "name": "Muse Spark 1.1",
             "reasoning": true,


### PR DESCRIPTION
## Summary

- backport Meta Muse Spark 1.3 Standard and Contributor catalog entries from #136553
- make Muse Spark 1.3 the default for new Meta onboarding
- retain Muse Spark 1.1 for existing configurations

## Architecture

The backport stays inside the Meta provider plugin and uses the plugin SDK already shipped on the 7.33 line. It does not import later catalog/discovery refactors or add core compatibility code.

Source: `194b7f2a16196481a70c139fb31f1777bdfbdc12` (#136553).

## SDK/config backport warning

This intentionally changes one provider default: new Meta onboarding selects `meta/muse-spark-1.3` instead of 1.1. Existing explicit model selections remain valid and unchanged. No public plugin SDK surface changes.

## Proof

- exact pre-fix 7.33 regression: onboarding returned 1.1 and no 1.3 catalog rows
- `node scripts/run-vitest.mjs extensions/meta/index.test.ts` — 4/4 passed
- Meta live test now targets 1.3; authenticated live execution remains required before landing
- Oxfmt, OXLint, `git diff --check`, changed-gate classification passed

Production/plugin metadata: +64/-7. Tests: +24/-1. Docs: +18/-15.
