### PR TITLE
test(infra): remove ephemeral port probe race

### DIFF
--- a/src/infra/ports-probe.test.ts
+++ b/src/infra/ports-probe.test.ts
@@ -1,6 +1,6 @@
 // Tests local port probing and availability detection.
 import net from "node:net";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { probePortUsage, tryListenOnPort } from "./ports-probe.js";
 
 async function withListeningServer(
@@ -52,38 +52,55 @@ describe("tryListenOnPort", () => {
     ).rejects.toBe(reason);
   });
 
-  it("can bind and release an ephemeral loopback port", async () => {
-    let port;
+  it("returns an ephemeral port only after its listener closes", async () => {
+    let signalClose: () => void = () => {};
+    const closeSignaled = new Promise<void>((resolve) => {
+      signalClose = resolve;
+    });
+    let releaseClose: () => void = () => {};
+    const closeReleased = new Promise<void>((resolve) => {
+      releaseClose = resolve;
+    });
+    const closeSpy = vi.spyOn(net.Server.prototype, "close").mockImplementation(function (
+      this: net.Server,
+      callback?: (error?: Error) => void,
+    ) {
+      closeSpy.mockRestore();
+      return this.close((error?: Error) => {
+        signalClose();
+        void closeReleased.then(() => callback?.(error));
+      });
+    });
+
     try {
-      port = await tryListenOnPort({ port: 0, host: "127.0.0.1", exclusive: true });
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "EPERM") {
+      let settled = false;
+      const portPromise = tryListenOnPort({
+        port: 0,
+        host: "127.0.0.1",
+        exclusive: true,
+      }).then((port) => {
+        settled = true;
+        return port;
+      });
+
+      const firstEvent = await Promise.race([
+        closeSignaled.then(() => "closing" as const),
+        portPromise.then(
+          () => "settled" as const,
+          (error: unknown) => error,
+        ),
+      ]);
+      if (firstEvent instanceof Error && (firstEvent as NodeJS.ErrnoException).code === "EPERM") {
         return;
       }
-      throw err;
+      expect(firstEvent).toBe("closing");
+      expect(settled).toBe(false);
+      releaseClose();
+      await expect(portPromise).resolves.toBeGreaterThan(0);
+    } finally {
+      releaseClose();
+      closeSpy.mockRestore();
     }
-    expect(port).toBeGreaterThan(0);
-    // Release proof stays tied to the allocated port: a lingering listener
-    // would accept this probe, a released port refuses it. A rebind assertion
-    // instead collides with any foreign outbound socket occupying the port on
-    // busy runners (EADDRINUSE flake) without detecting leaks any better.
-    await expect(
-      new Promise<"accepted" | "unavailable">((resolve, reject) => {
-        const socket = net.connect({ port, host: "127.0.0.1" });
-        socket.once("connect", () => {
-          socket.destroy();
-          resolve("accepted");
-        });
-        socket.once("error", (err) => {
-          const code = (err as NodeJS.ErrnoException).code;
-          if (code === "ECONNREFUSED" || code === "ECONNRESET") {
-            resolve("unavailable");
-            return;
-          }
-          reject(err);
-        });
-      }),
-    ).resolves.toBe("unavailable");
   });
 
   it("rejects when the port is already in use", async () => {


### PR DESCRIPTION
## What Problem This Solves

The ephemeral-port release test could fail under concurrent CI load with `Expected unavailable, received accepted` (`CI` run 34208988753, job 102005424124). After `tryListenOnPort` completes its `Server.close()` callback, the numeric port is deliberately unowned; a different listener can claim it before the test's follow-up connection.

## Why This Change Was Made

Replace the post-release numeric-port observation with an owner-boundary synchronization check. The test wraps the real server close callback, proves the helper promise remains unsettled while that callback is withheld, then releases it and verifies the allocated ephemeral port is returned. This directly protects the implementation contract without retries, sleeps, timeouts, or production changes.

No equivalent open or merged fix was found. #124013 introduced the follow-up connection after an earlier rebind assertion flaked; #126240 broadened refused-socket handling but retained the ownership race.

## User Impact

No runtime behavior changes. CI no longer attributes a replacement listener on a recycled ephemeral port to the already-closed probe server.

## Evidence

- Pre-fix deterministic ownership handoff: 20/20 replacement listeners produced `expected=unavailable received=accepted` after the original close callback.
- Pre-fix natural stress: 320 concurrent focused runs happened to pass, demonstrating the collision is scheduler/load dependent.
- Post-fix focused test: `node scripts/run-vitest.mjs src/infra/ports-probe.test.ts` (5 passed).
- Post-fix concurrent proof: 100/100 focused runs passed at concurrency 16.
- Sibling port suites: 114 passed, 1 platform-only skip.
- Targeted oxfmt, oxlint, and `git diff --check`: passed.
- `node scripts/check-changed.mjs`: all guards passed through core graph validation; local test typecheck could not use a borrowed cross-worktree compiler symlink. First-head CI exposed implicit mock callback types; exact Node types were added before this head.
- Autoreview on final candidate: scoped-clean, no P0 findings (0.99 confidence).
- LOC: production +0/-0; tests +46/-29 (net +17).
