### PR TITLE
fix(update): retain core Doctor warnings in finalization

### DIFF
--- a/src/flows/doctor-health-contribution-core.ts
+++ b/src/flows/doctor-health-contribution-core.ts
@@ -1,15 +1,34 @@
-import { normalizeUpdatePostInstallDoctorWarnings } from "../infra/update-doctor-result.js";
 import type {
   DoctorHealthCheckContext,
   DoctorHealthFlowContext,
 } from "./doctor-health-contribution-types.js";
 import { resolveDoctorWorkspaceDir } from "./doctor-health-contribution-utils.js";
-import { renderStructuredHealthFindings } from "./doctor-health-contribution.js";
+import {
+  recordDoctorHealthWarnings,
+  renderStructuredHealthFindings,
+} from "./doctor-health-contribution.js";
 import { defineSplitHealthCheckInput } from "./health-check-adapter.js";
 import type { DetectableHealthCheckInput } from "./health-check-runner-types.js";
 import { isHealthCheckEnabledByDefault, type HealthFinding } from "./health-checks.js";
 
 const loadHealthCheckRegistryModule = async () => await import("./health-check-registry.js");
+
+function reportDoctorRepairResult(
+  ctx: DoctorHealthFlowContext,
+  result: Awaited<ReturnType<typeof import("./doctor-repair-flow.js").runDoctorHealthRepairs>>,
+  findings: readonly HealthFinding[],
+  note: typeof import("../../packages/terminal-core/src/note.js").note,
+): void {
+  ctx.cfg = result.config;
+  renderStructuredHealthFindings(ctx, findings);
+  recordDoctorHealthWarnings(ctx, findings, result.warnings);
+  if (result.changes.length > 0) {
+    note(result.changes.join("\n"), "Doctor changes");
+  }
+  if (result.warnings.length > 0) {
+    note(result.warnings.join("\n"), "Doctor warnings");
+  }
+}
 
 function withDoctorHealthCheckFacts<T extends object>(
   ctx: DoctorHealthFlowContext,
@@ -51,21 +70,7 @@ export async function runStructuredHealthRepairs(
     }),
     { checks },
   );
-  ctx.cfg = result.config;
-  renderStructuredHealthFindings(ctx, result.remainingFindings);
-  ctx.updateWarnings = normalizeUpdatePostInstallDoctorWarnings([
-    ...(ctx.updateWarnings ?? []),
-    ...result.remainingFindings
-      .filter((finding) => finding.severity === "warning")
-      .map((finding) => `${finding.checkId}: ${finding.message}`),
-    ...result.warnings,
-  ]);
-  if (result.changes.length > 0) {
-    note(result.changes.join("\n"), "Doctor changes");
-  }
-  if (result.warnings.length > 0) {
-    note(result.warnings.join("\n"), "Doctor warnings");
-  }
+  reportDoctorRepairResult(ctx, result, result.remainingFindings, note);
 }
 
 export async function runCoreContributionHealth(
@@ -97,14 +102,7 @@ export async function runCoreContributionHealth(
     }),
     { checks, dryRun },
   );
-  ctx.cfg = result.config;
-  renderStructuredHealthFindings(ctx, dryRun ? result.findings : result.remainingFindings);
-  if (result.changes.length > 0) {
-    note(result.changes.join("\n"), "Doctor changes");
-  }
-  if (result.warnings.length > 0) {
-    note(result.warnings.join("\n"), "Doctor warnings");
-  }
+  reportDoctorRepairResult(ctx, result, dryRun ? result.findings : result.remainingFindings, note);
 }
 
 function formatHealthFindings(findings: readonly HealthFinding[]): string {
@@ -149,6 +147,7 @@ export async function runCoreHealthFindingNote(
   if (findings.length === 0) {
     return;
   }
+  recordDoctorHealthWarnings(ctx, findings);
   const information = findings.filter((finding) => finding.severity === "info");
   const warnings = findings.filter((finding) => finding.severity !== "info");
   if (information.length > 0) {

--- a/src/flows/doctor-health-contribution.ts
+++ b/src/flows/doctor-health-contribution.ts
@@ -1,3 +1,4 @@
+import { normalizeUpdatePostInstallDoctorWarnings } from "../infra/update-doctor-result.js";
 import type {
   DoctorContributionHealthCheck,
   DoctorHealthContribution,
@@ -110,12 +111,32 @@ async function runStructuredDoctorHealthContribution(params: {
   );
   params.ctx.cfg = result.config;
   renderStructuredHealthFindings(params.ctx, result.findings);
+  // Display retains original findings; finalization records only unresolved warnings.
+  recordDoctorHealthWarnings(
+    params.ctx,
+    dryRun ? result.findings : result.remainingFindings,
+    result.warnings,
+  );
   for (const warning of result.warnings) {
     params.ctx.runtime.error(warning);
   }
   for (const change of result.changes) {
     params.ctx.runtime.log(change);
   }
+}
+
+export function recordDoctorHealthWarnings(
+  ctx: DoctorHealthFlowContext,
+  findings: readonly HealthFinding[],
+  warnings: readonly string[] = [],
+): void {
+  ctx.updateWarnings = normalizeUpdatePostInstallDoctorWarnings([
+    ...(ctx.updateWarnings ?? []),
+    ...findings
+      .filter((finding) => finding.severity === "warning")
+      .map((finding) => `${finding.checkId}: ${finding.message}`),
+    ...warnings,
+  ]);
 }
 
 export function renderStructuredHealthFindings(

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -911,7 +911,7 @@ describe("doctor health contributions", () => {
         id: "doctor:test-failure",
         label: "Test failure",
         run: async () => {
-          throw new Error("media migration required");
+          throw new Error("media migration\nrequired");
         },
       }),
       createDoctorHealthContribution({
@@ -926,6 +926,7 @@ describe("doctor health contributions", () => {
       configResult: { cfg: {} },
       shouldRepair: true,
       env: {},
+      updateWarnings: ["earlier warning"],
     });
 
     await runDoctorHealthContributionList(ctx, contributions);
@@ -935,6 +936,11 @@ describe("doctor health contributions", () => {
       "doctor:test-failure run failed: media migration required",
       "Doctor warnings",
     );
+    expect(ctx.updateWarnings).toEqual([
+      "earlier warning",
+      "doctor:test-failure run failed: media migration required",
+    ]);
+    expect(mocks.note).toHaveBeenCalledBefore(laterRun);
   });
 
   it("rejects a failed initial config write before later work runs", async () => {
@@ -946,6 +952,7 @@ describe("doctor health contributions", () => {
       configResult: { cfg, shouldWriteConfig: true },
       shouldRepair: true,
       env: {},
+      updateWarnings: ["earlier warning"],
     });
     mocks.replaceConfigFile.mockRejectedValueOnce(new Error("Config validation failed"));
 
@@ -963,6 +970,7 @@ describe("doctor health contributions", () => {
     expect(laterRun).not.toHaveBeenCalled();
     expect(ctx.configResultWriteCommitted).not.toBe(true);
     expect(ctx.cfgForPersistence).toEqual(cfg);
+    expect(ctx.updateWarnings).toEqual(["earlier warning"]);
   });
 
   it("keeps legacy plugin manifest lint opt-in for structured findings", async () => {
@@ -3957,46 +3965,78 @@ describe("doctor health contributions", () => {
     );
   });
 
-  it("retains extension repair warnings without relabeling errors", async () => {
-    const contribution = requireDoctorContribution("doctor:structured-health-repairs");
+  it.each([
+    ["doctor:structured-health-repairs", "plugin/example/probe"],
+    ["doctor:browser", "core/doctor/browser-clawd-profile-residue"],
+    ["doctor:default-account-routing", "core/doctor/default-account-routing"],
+  ])("retains %s update warnings without resolved or non-warning findings", async (id, checkId) => {
+    const contribution = requireDoctorContribution(id);
     const ctx = createDoctorContext({
       cfg: {},
       configResult: { cfg: {} },
       cfgForPersistence: {},
       shouldRepair: true,
       env: { OPENCLAW_UPDATE_POST_CORE: "1" },
+      updateWarnings: ["earlier warning"],
     });
+    const remainingFindings: HealthFinding[] = [
+      { checkId, severity: "warning", message: "optional maintenance incomplete" },
+      { checkId, severity: "error", message: "required artifact missing" },
+      { checkId, severity: "info", message: "optional setup is available" },
+    ];
     mocks.runDoctorHealthRepairs.mockResolvedValue({
       config: {},
       changes: [],
       warnings: ["optional repair unavailable"],
-      remainingFindings: [
-        {
-          checkId: "plugin/example/probe",
-          severity: "warning",
-          message: "version probe timed out",
-        },
-        {
-          checkId: "plugin/example/broken",
-          severity: "error",
-          message: "required artifact missing",
-        },
+      remainingFindings,
+      findings: [
+        ...remainingFindings,
+        { checkId, severity: "warning", message: "already repaired" },
       ],
     });
 
     await contribution.run(ctx);
 
     expect(ctx.updateWarnings).toEqual([
-      "plugin/example/probe: version probe timed out",
+      "earlier warning",
+      `${checkId}: optional maintenance incomplete`,
       "optional repair unavailable",
     ]);
     expect(ctx.runtime.log).toHaveBeenCalledWith(
-      "[warning] plugin/example/probe - version probe timed out",
+      `[warning] ${checkId} - optional maintenance incomplete`,
     );
     expect(ctx.runtime.error).toHaveBeenCalledWith(
-      "[error] plugin/example/broken - required artifact missing",
+      `[error] ${checkId} - required artifact missing`,
     );
+    expect(ctx.runtime.exit).not.toHaveBeenCalled();
   });
+
+  it.each(["warning", "info", "error"] as const)(
+    "records %s finding-only output without changing health or exit policy",
+    async (severity) => {
+      const contribution = requireDoctorContribution("doctor:model-references");
+      const check = CORE_HEALTH_CHECKS.find(
+        (entry) => entry.id === "core/doctor/model-references",
+      )!;
+      vi.spyOn(check, "detect").mockResolvedValue([
+        { checkId: check.id, severity, message: "configured model needs attention" },
+      ]);
+      const ctx = createDoctorContext({ healthOk: true, updateWarnings: ["earlier warning"] });
+
+      await contribution.run(ctx);
+
+      expect(ctx.updateWarnings).toEqual([
+        "earlier warning",
+        ...(severity === "warning" ? [`${check.id}: configured model needs attention`] : []),
+      ]);
+      expect(ctx.healthOk).toBe(severity === "info");
+      expect(mocks.note).toHaveBeenCalledWith(
+        "- configured model needs attention",
+        severity === "info" ? "Doctor information" : "Doctor warnings",
+      );
+      expect(ctx.runtime.exit).not.toHaveBeenCalled();
+    },
+  );
 
   it("rejects extension repairs that claim reserved core doctor ids", async () => {
     mocks.listHealthChecks.mockReturnValue([

--- a/src/flows/doctor-health-contributions.ts
+++ b/src/flows/doctor-health-contributions.ts
@@ -22,6 +22,7 @@ import {
   resolveDoctorMode,
   resolveDoctorWorkspaceDir,
 } from "./doctor-health-contribution-utils.js";
+import { recordDoctorHealthWarnings } from "./doctor-health-contribution.js";
 import { resolveFinalDoctorHealthContributions } from "./doctor-health-contributions-final.js";
 import { resolveInitialDoctorHealthContributions } from "./doctor-health-contributions-initial.js";
 import { normalizeHealthCheck } from "./health-check-adapter.js";
@@ -537,7 +538,9 @@ async function runDoctorHealthContributionList(
         throw error;
       }
       const { note } = await loadNoteModule();
-      note(`${contribution.id} run failed: ${scrubDoctorErrorMessage(error)}`, "Doctor warnings");
+      const message = `${contribution.id} run failed: ${scrubDoctorErrorMessage(error)}`;
+      note(message, "Doctor warnings");
+      recordDoctorHealthWarnings(ctx, [], [message]);
     }
   }
 }

--- a/src/flows/doctor-health.test-support.ts
+++ b/src/flows/doctor-health.test-support.ts
@@ -4,6 +4,7 @@ import { createConfigIO } from "../config/io.factory.js";
 import { hashConfigRaw } from "../config/io.read-helpers.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+import { createDoctorHealthContribution } from "./doctor-health-contribution.js";
 import type { DoctorHealthFlowContext } from "./doctor-health-contributions.js";
 
 const mocks = vi.hoisted(() => ({
@@ -214,7 +215,20 @@ export function registerDoctorConfigReceiptTests(
     "preserves health warnings in the update result (advisory=%s)",
     async (advisory) => {
       mocks.runContributions.mockImplementation(async (ctx) => {
-        ctx.updateWarnings = ["plugin/example: version probe timed out"];
+        await createDoctorHealthContribution({
+          id: "doctor:fixture-warning",
+          label: "Fixture warning",
+          healthChecks: {
+            description: "Optional fixture maintenance",
+            detect: async () => [
+              {
+                checkId: "core/doctor/fixture-warning",
+                severity: "warning",
+                message: "optional maintenance incomplete",
+              },
+            ],
+          },
+        }).run(ctx);
         if (advisory) {
           ctx.postInstallDoctorResult = postInstallAdvisory;
         }
@@ -232,7 +246,7 @@ export function registerDoctorConfigReceiptTests(
         result: {
           ...(advisory ? postInstallAdvisory : { status: "ok" }),
           configHash: "unchanged",
-          warnings: ["plugin/example: version probe timed out"],
+          warnings: ["core/doctor/fixture-warning: optional maintenance incomplete"],
         },
       });
       expect(runtime.exit).not.toHaveBeenCalledWith(1);


### PR DESCRIPTION
Related: #141995.

## What Problem This Solves

Fixes an issue where operators running `openclaw update finalize --json` could see Doctor report `ok` even though a core health contribution had printed a nonfatal warning. The existing result collection covered plugin repairs but missed core repairs, default structured checks, finding-only checks, and caught optional-contribution failures.

## Why This Change Was Made

One shared recorder carries warning findings and repair warnings into the existing bounded Doctor result. Core and plugin repair panels share their result plumbing. Finalization receives unresolved warnings; repaired findings remain available in the original diagnostic display without becoming outstanding warnings. Required failures retain their existing failure policy.

The stored data model is unchanged: this PR does not add or alter a schema, migration, repair effect, persisted identifier, or result format. The [existing Doctor result type, bounds, writer and parser](https://github.com/openclaw/openclaw/blob/5010a232b1620aa1d072a256d9685f597f3897b1/src/infra/update-doctor-result.ts) are byte-identical to the base, as are the repair runner, finalizer, Doctor result assembly and migration-refusal owner. The new callers fill the existing optional warning array. Existing ordinary/advisory result tests and all three migration-refusal cases pass; no data migration or compatibility adapter is required.

## User Impact

Supervisors receive these nonfatal diagnostics in `postUpdate.doctor.warnings`, with Doctor status `warning` and a successful exit when no step fails. Repair decisions, configuration, human-readable output, and the existing 32-message/500-character bounds remain unchanged.

## Evidence

Controlled regressions reproduced five missing-warning failures across the three contribution paths and ordinary/advisory result payloads, then passed after the repair. The existing optional-contribution test separately failed on its missing warning and passed with the same scrubbed message retained; its required-failure control remained unchanged.

Final validation: 273 focused cases across contribution, migration-refusal, Doctor flow, repair, result-normalization and finalization tests; all 29 stages of `node scripts/check-changed.mjs`; `git diff --check`; independent P0–P2 review with no findings. The shared recorder and reporting consolidation add 23 production lines while covering the previously missing result paths.

Tests use isolated synthetic fixtures. No operator Doctor/update command, browser archive, live Gateway, native service, or credential probe was run. The repair covers structured contribution warnings and caught optional failures; it does not reinterpret arbitrary informational panels.
