### PR TITLE
refactor(tests): share timestamped tool-result fixtures

### DIFF
--- a/packages/ai/src/openai-completions-messages.test.ts
+++ b/packages/ai/src/openai-completions-messages.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { makeTextToolResult } from "../../../test/helpers/text-tool-result.js";
 import { convertMessages } from "./openai-completions-messages.js";
 import type { ProviderContext, ProviderModel } from "./provider-types.js";
 import { resolveOpenAICompletionsCompat } from "./transports/openai-completions-compat.js";
@@ -114,17 +115,7 @@ describe("convertMessages assistant text replay", () => {
       const converted = convertMessages(
         model,
         {
-          messages: [
-            assistant,
-            {
-              role: "toolResult",
-              toolCallId: "call_lookup",
-              toolName: "lookup",
-              content: [{ type: "text", text: "found" }],
-              isError: false,
-              timestamp: 3,
-            },
-          ],
+          messages: [assistant, makeTextToolResult("call_lookup", "lookup", "found", false, 3)],
         },
         { ...resolveOpenAICompletionsCompat(model), requiresThinkingAsText },
       );
@@ -391,22 +382,8 @@ describe("convertMessages parallel tool-result image ownership", () => {
     const context: Context = {
       messages: [
         makeToolCallAssistant(["call_a", "call_b"], ["lookup", "search"]),
-        {
-          role: "toolResult",
-          toolCallId: "call_a",
-          toolName: "lookup",
-          content: [{ type: "text", text: "found it" }],
-          isError: false,
-          timestamp: 2,
-        },
-        {
-          role: "toolResult",
-          toolCallId: "call_b",
-          toolName: "search",
-          content: [{ type: "text", text: "no results" }],
-          isError: false,
-          timestamp: 3,
-        },
+        makeTextToolResult("call_a", "lookup", "found it", false, 2),
+        makeTextToolResult("call_b", "search", "no results", false, 3),
       ],
     };
 

--- a/packages/ai/src/providers/anthropic.test.ts
+++ b/packages/ai/src/providers/anthropic.test.ts
@@ -24,6 +24,7 @@ vi.mock("@anthropic-ai/sdk", () => ({
   },
 }));
 
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import { createZeroUsage } from "../usage.test-support.js";
 import { streamAnthropic, streamSimpleAnthropic } from "./anthropic.js";
 
@@ -900,14 +901,7 @@ describe("Anthropic provider", () => {
             ],
             { stopReason: "toolUse" },
           ),
-          {
-            role: "toolResult",
-            toolCallId: "call_1",
-            toolName: "lookup",
-            content: [{ type: "text", text: "42" }],
-            isError: false,
-            timestamp: 0,
-          },
+          makeTextToolResult("call_1", "lookup", "42", false, 0),
         ],
       },
     );
@@ -1011,14 +1005,7 @@ describe("Anthropic provider", () => {
             ],
             { model: model.id, stopReason: "toolUse" },
           ),
-          {
-            role: "toolResult",
-            toolCallId: "call_1",
-            toolName: "lookup",
-            content: [{ type: "text", text: "42" }],
-            isError: false,
-            timestamp: 0,
-          },
+          makeTextToolResult("call_1", "lookup", "42", false, 0),
         ],
       },
     );

--- a/packages/ai/src/providers/google-shared.convert.test.ts
+++ b/packages/ai/src/providers/google-shared.convert.test.ts
@@ -1,5 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import { createEmptyTransportUsage } from "../transports/transport-stream-shared.js";
 import type { Context, Tool } from "../types.js";
 import { convertGoogleTools, projectGoogleMessages } from "./google-messages.js";
@@ -200,14 +201,7 @@ describe("google-shared convertMessages", () => {
         usage: createEmptyTransportUsage(),
         timestamp: 0,
       };
-      const result = {
-        role: "toolResult" as const,
-        toolCallId: "call_1",
-        toolName: "lookup",
-        content: [{ type: "text" as const, text: "ok" }],
-        isError: false,
-        timestamp: 1,
-      };
+      const result = makeTextToolResult("call_1", "lookup", "ok", false, 1);
       const contents = projectGoogleMessages({
         model,
         replay,
@@ -374,14 +368,7 @@ describe("google-shared convertMessages", () => {
           makeGoogleAssistantMessage(model.id, [
             { ...toolCall, arguments: first, thoughtSignature: "c2lnbmVk" },
           ]),
-          {
-            role: "toolResult",
-            toolCallId: "call_1",
-            toolName: "lookup",
-            content: [{ type: "text", text: "cats" }],
-            isError: false,
-            timestamp: 0,
-          },
+          makeTextToolResult("call_1", "lookup", "cats", false, 0),
           makeGoogleAssistantMessage(model.id, [{ ...toolCall, arguments: second }]),
         ],
       } as Context);
@@ -400,14 +387,7 @@ describe("google-shared convertMessages", () => {
     const contents = convertMessagesForTest(model, {
       messages: [
         makeGoogleAssistantMessage(model.id, [{ ...cachedCall, thoughtSignature: "c2lnbmVk" }]),
-        {
-          role: "toolResult",
-          toolCallId: "call_1",
-          toolName: "lookup",
-          content: [{ type: "text", text: "ok" }],
-          isError: false,
-          timestamp: 0,
-        },
+        makeTextToolResult("call_1", "lookup", "ok", false, 0),
         makeGoogleAssistantMessage(model.id, [
           { type: "toolCall", id: "other", name: "different", arguments: {} },
           cachedCall,
@@ -628,14 +608,7 @@ describe("google-shared convertMessages", () => {
             arguments: { arg: "value" },
           },
         ]),
-        {
-          role: "toolResult",
-          toolCallId: "call_1",
-          toolName: "myTool",
-          content: [{ type: "text", text: "Tool result" }],
-          isError: false,
-          timestamp: 0,
-        },
+        makeTextToolResult("call_1", "myTool", "Tool result", false, 0),
         {
           role: "user",
           content: "Now do something else",
@@ -703,14 +676,7 @@ describe("google-shared convertMessages", () => {
             thoughtSignature: "dGVzdA==",
           },
         ]),
-        {
-          role: "toolResult",
-          toolCallId: "call_1",
-          toolName: "myTool",
-          content: [{ type: "text", text: "Tool result" }],
-          isError: false,
-          timestamp: 0,
-        },
+        makeTextToolResult("call_1", "myTool", "Tool result", false, 0),
       ],
     } as unknown as Context;
 
@@ -737,14 +703,7 @@ describe("google-shared convertMessages", () => {
         makeGoogleAssistantMessage(model.id, [
           { type: "toolCall", id: "provider_call_42", name: "lookup", arguments: {} },
         ]),
-        {
-          role: "toolResult",
-          toolCallId: "provider_call_42",
-          toolName: "lookup",
-          content: [{ type: "text", text: "ok" }],
-          isError: false,
-          timestamp: 0,
-        },
+        makeTextToolResult("provider_call_42", "lookup", "ok", false, 0),
       ],
     } as Context);
 

--- a/packages/ai/src/providers/google-shared.parallel-image-repro.test.ts
+++ b/packages/ai/src/providers/google-shared.parallel-image-repro.test.ts
@@ -1,6 +1,7 @@
 import type { Part } from "@google/genai";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import type { Context, Model } from "../types.js";
 import { convertMessages, makeGoogleAssistantMessage } from "./google-shared.test-helpers.js";
 
@@ -56,14 +57,7 @@ describe("google-shared convertMessages — parallel tool results with an image 
           isError: false,
           timestamp: 0,
         },
-        weather: {
-          role: "toolResult",
-          toolCallId: "call_2",
-          toolName: "weather",
-          content: [{ type: "text", text: "Sunny, 21C" }],
-          isError: false,
-          timestamp: 0,
-        },
+        weather: makeTextToolResult("call_2", "weather", "Sunny, 21C", false, 0),
       } as const;
       const context = {
         messages: [

--- a/packages/ai/src/providers/openai-completions.compat.test.ts
+++ b/packages/ai/src/providers/openai-completions.compat.test.ts
@@ -48,6 +48,7 @@ vi.mock("openai", () => {
   return { default: MockOpenAI };
 });
 
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import {
   resolveOpenAICompletionsCompat,
   type ResolvedOpenAICompletionsCompat,
@@ -989,14 +990,7 @@ describe("OpenAI-compatible completions compatibility", () => {
         messages: [
           userMessage,
           assistant,
-          {
-            role: "toolResult",
-            toolCallId: "call_1",
-            toolName: "lookup",
-            content: [{ type: "text", text: "done" }],
-            isError: false,
-            timestamp: 3,
-          },
+          makeTextToolResult("call_1", "lookup", "done", false, 3),
         ],
       },
       {

--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -81,6 +81,7 @@ vi.mock("openai", () => {
   return { default: MockOpenAI };
 });
 
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import { createZeroUsage } from "../usage.test-support.js";
 import {
   streamOpenAICompletions,
@@ -1162,14 +1163,7 @@ describe("OpenAI-compatible completions params", () => {
             ],
             timestamp: 2,
           },
-          {
-            role: "toolResult",
-            toolCallId: "call_search",
-            toolName: "search",
-            content: [{ type: "text", text: "ok" }],
-            isError: false,
-            timestamp: 3,
-          },
+          makeTextToolResult("call_search", "search", "ok", false, 3),
           {
             role: "user",
             content: "continue",

--- a/packages/ai/src/providers/openai-responses-shared.test.ts
+++ b/packages/ai/src/providers/openai-responses-shared.test.ts
@@ -5,6 +5,7 @@ import type {
   Tool as OpenAIResponsesTool,
 } from "openai/resources/responses/responses.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import { configureAiTransportHost } from "../host.js";
 import {
   buildOpenAIResponsesReasoningReplayMetadata,
@@ -575,14 +576,7 @@ describe("convertResponsesMessages", () => {
               },
             ],
           },
-          {
-            role: "toolResult",
-            toolCallId: "call_abc|fc_prior",
-            toolName: "price_lookup",
-            content: [{ type: "text", text: "$83.95" }],
-            isError: false,
-            timestamp: 2,
-          },
+          makeTextToolResult("call_abc|fc_prior", "price_lookup", "$83.95", false, 2),
         ],
       } satisfies Context,
       allowedToolCallProviders,
@@ -2184,14 +2178,7 @@ describe("processResponsesStream", () => {
         systemPrompt: "",
         messages: [
           output,
-          {
-            role: "toolResult",
-            toolCallId: "call_weather|fc_weather",
-            toolName: "weather",
-            content: [{ type: "text", text: "Rain" }],
-            isError: false,
-            timestamp: 1,
-          },
+          makeTextToolResult("call_weather|fc_weather", "weather", "Rain", false, 1),
         ],
       } satisfies Context,
       testAllowedToolCallProviders,

--- a/packages/ai/src/transports/openai-completions-replay.test.ts
+++ b/packages/ai/src/transports/openai-completions-replay.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import type { Model } from "../types.js";
 import { buildOpenAICompletionsParams } from "./openai-completions-params.js";
 import {
@@ -97,14 +98,7 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
               },
             ],
           },
-          {
-            role: "toolResult",
-            toolCallId: "call_1",
-            toolName: "read_file",
-            content: [{ type: "text", text: "{ }" }],
-            isError: false,
-            timestamp: 1,
-          },
+          makeTextToolResult("call_1", "read_file", "{ }", false, 1),
           { role: "user", content: "continue" },
         ],
         tools: [],
@@ -291,14 +285,7 @@ describe("buildOpenAICompletionsParams sanitizes reasoning replay fields", () =>
               },
             ],
           },
-          {
-            role: "toolResult",
-            toolCallId: "call_1",
-            toolName: "lookup",
-            content: [{ type: "text", text: "sunny" }],
-            isError: false,
-            timestamp: 1,
-          },
+          makeTextToolResult("call_1", "lookup", "sunny", false, 1),
           { role: "user", content: "answer" },
         ],
         tools: [],

--- a/packages/ai/src/transports/openai-responses-async-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-async-replay.test.ts
@@ -1,6 +1,7 @@
 import type { AssistantMessage, Context, Model, ToolResultMessage } from "@openclaw/llm-core";
 import type { ResponseOutputItem } from "openai/resources/responses/responses.js";
 import { expect, it } from "vitest";
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import { transformProviderMessages } from "../provider-transcript-transform.js";
 import { resolveResponsesContinuationRequest } from "./openai-responses-continuation.js";
 import {
@@ -102,14 +103,13 @@ it.each([
         },
       ],
     };
-    const toolResult: ToolResultMessage = {
-      role: "toolResult",
-      toolCallId: "call_async|fc_async",
-      toolName: "lookup",
-      content: [{ type: "text", text: "found" }],
-      isError: false,
-      timestamp: 2,
-    };
+    const toolResult: ToolResultMessage = makeTextToolResult(
+      "call_async|fc_async",
+      "lookup",
+      "found",
+      false,
+      2,
+    );
     const context: Context = {
       messages: [
         { role: "user", content: "look up", timestamp: 1 },
@@ -224,14 +224,13 @@ it.each(["before", "after"] as const)(
         { type: "toolCall", id: "call_1|fc_1", name: "lookup", arguments: {}, async: true },
       ],
     };
-    const result: ToolResultMessage = {
-      role: "toolResult",
-      toolCallId: "call_1|fc_1",
-      toolName: "lookup",
-      content: [{ type: "text", text: "found" }],
-      isError: false,
-      timestamp: 2,
-    };
+    const result: ToolResultMessage = makeTextToolResult(
+      "call_1|fc_1",
+      "lookup",
+      "found",
+      false,
+      2,
+    );
     const input = { type: "function_call_output", call_id: "call_1", output: "found" };
     const response: AssistantMessage = {
       ...createOpenAIResponsesAssistantOutput(model),

--- a/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
+++ b/packages/ai/src/transports/openai-responses-compaction-replay.test.ts
@@ -6,6 +6,7 @@ import type {
   ProviderReplayState,
 } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import { convertResponsesMessages as convertProviderResponsesMessages } from "../providers/openai-responses-shared.js";
 import { createZeroUsage } from "../usage.test-support.js";
 import {
@@ -755,23 +756,9 @@ describe("OpenAI Responses compaction replay", () => {
           { role: "user", content: "prefix user", timestamp: 1 },
           createAssistant([{ type: "text", text: "prefix assistant" }]),
           prefixCall,
-          {
-            role: "toolResult",
-            toolCallId: "call_prefix|fc_prefix",
-            toolName: "lookup",
-            content: [{ type: "text", text: "prefix tool result" }],
-            isError: false,
-            timestamp: 2,
-          },
+          makeTextToolResult("call_prefix|fc_prefix", "lookup", "prefix tool result", false, 2),
           owner,
-          {
-            role: "toolResult",
-            toolCallId: "call_after|fc_after",
-            toolName: "lookup",
-            content: [{ type: "text", text: "after tool result" }],
-            isError: false,
-            timestamp: 3,
-          },
+          makeTextToolResult("call_after|fc_after", "lookup", "after tool result", false, 3),
           { role: "user", content: "later user", timestamp: 4 },
           laterAssistant,
           { role: "user", content: "active current user prompt", timestamp: 5 },
@@ -822,14 +809,7 @@ describe("OpenAI Responses compaction replay", () => {
       const input = convert({
         messages: [
           owner,
-          {
-            role: "toolResult",
-            toolCallId: "call_before|fc_before",
-            toolName: "lookup",
-            content: [{ type: "text", text: "before output" }],
-            isError: false,
-            timestamp: 1,
-          },
+          makeTextToolResult("call_before|fc_before", "lookup", "before output", false, 1),
         ],
       });
 

--- a/packages/ai/src/transports/openai-responses-steering.integration.test.ts
+++ b/packages/ai/src/transports/openai-responses-steering.integration.test.ts
@@ -103,6 +103,7 @@ vi.mock("openai/resources/responses/ws.js", () => ({
   },
 }));
 
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import { cleanupSessionResources } from "../session-resources.js";
 import { createOpenAIResponsesTransportStreamFn } from "./openai-responses-client.js";
 import type { ResponsesContinuationRequest } from "./openai-responses-continuation.js";
@@ -405,14 +406,7 @@ describe("Responses WebSocket steering handoff", () => {
     expect(firstAnswer.stopReason).not.toBe("error");
     context.messages.push(
       firstAnswer,
-      {
-        role: "toolResult",
-        toolCallId: "call_1|fc_1",
-        toolName: "lookup",
-        content: [{ type: "text", text: "found" }],
-        isError: false,
-        timestamp: 1,
-      },
+      makeTextToolResult("call_1|fc_1", "lookup", "found", false, 1),
       steeringUser,
     );
     socket.emit({ type: "response.created", response: { id: "resp_2" } });

--- a/packages/ai/src/transports/provider-compaction-replay.test.ts
+++ b/packages/ai/src/transports/provider-compaction-replay.test.ts
@@ -1,5 +1,6 @@
 import type { AssistantMessage, Context, Model, ProviderReplayState } from "@openclaw/llm-core";
 import { describe, expect, it } from "vitest";
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import { createZeroUsage } from "../usage.test-support.js";
 import {
   createCompactionCapture,
@@ -73,17 +74,7 @@ describe("compaction replay owner rewrites", () => {
     const input = convertResponsesMessages(
       model,
       {
-        messages: [
-          reindexed,
-          {
-            role: "toolResult",
-            toolCallId: "call_1",
-            toolName: "read",
-            content: [{ type: "text", text: "ok" }],
-            isError: false,
-            timestamp: 1,
-          },
-        ],
+        messages: [reindexed, makeTextToolResult("call_1", "read", "ok", false, 1)],
       },
       new Set(["openai"]),
       replayIdentity,

--- a/src/agents/compaction-planning-worker.test.ts
+++ b/src/agents/compaction-planning-worker.test.ts
@@ -4,6 +4,7 @@ import { MAX_TIMER_TIMEOUT_MS } from "@openclaw/normalization-core/number-coerci
 import { serializeConversation } from "openclaw/plugin-sdk/agent-core";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 import { estimateTokens } from "../../packages/agent-core/src/harness/compaction/compaction.js";
+import { makeTextToolResult } from "../../test/helpers/text-tool-result.js";
 import * as compactionPlanningWorkerRuntime from "./compaction-planning-worker-runtime.js";
 import {
   CompactionPlanningWorkerError,
@@ -418,14 +419,7 @@ describe("compaction planning worker", () => {
         timestamp: 1,
       }),
       displacedUser,
-      {
-        role: "toolResult",
-        toolCallId: "call_large",
-        toolName: "read",
-        content: [{ type: "text", text: "small result" }],
-        isError: false,
-        timestamp: 3,
-      },
+      makeTextToolResult("call_large", "read", "small result", false, 3),
       ...Array.from({ length: 61 }, (_, index) => makeMessage(index + 4, "keep")),
     ];
 

--- a/src/agents/embedded-agent-runner.run-embedded-agent.finalization-scope.test.ts
+++ b/src/agents/embedded-agent-runner.run-embedded-agent.finalization-scope.test.ts
@@ -4,6 +4,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { makeTextToolResult } from "../../test/helpers/text-tool-result.js";
 import type {
   EmbeddedRunAttemptParams,
   EmbeddedRunAttemptResult,
@@ -103,14 +104,7 @@ describe("nested settled-turn finalization ownership", () => {
       const messages = [
         { role: "user" as const, content: "Write once and summarize.", timestamp: 1 },
         completedTool,
-        {
-          role: "toolResult" as const,
-          toolCallId: "write-once",
-          toolName: "write",
-          content: [{ type: "text" as const, text: "written" }],
-          isError: false,
-          timestamp: 3,
-        },
+        makeTextToolResult("write-once", "write", "written", false, 3),
       ];
       let toolRuns = 0;
       let finalizerRuns = 0;

--- a/src/agents/embedded-agent-runner/compact.hooks.test.ts
+++ b/src/agents/embedded-agent-runner/compact.hooks.test.ts
@@ -9,6 +9,7 @@ import type { AgentMessage, StreamFn } from "openclaw/plugin-sdk/agent-core";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi, type Mock } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { makeTextToolResult } from "../../../test/helpers/text-tool-result.js";
 import { createReplyOperation } from "../../auto-reply/reply/reply-run-registry.js";
 import {
   loadSessionEntryReadOnly,
@@ -3248,14 +3249,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
         content: [{ type: "toolCall", id: "call-1", name: "exec", arguments: {} }],
         timestamp: 2,
       },
-      {
-        role: "toolResult",
-        toolCallId: "call-1",
-        toolName: "exec",
-        content: [{ type: "text", text: "audit output" }],
-        isError: false,
-        timestamp: 3,
-      },
+      makeTextToolResult("call-1", "exec", "audit output", false, 3),
     );
 
     const result = await compactEmbeddedAgentSessionDirect(
@@ -3311,14 +3305,7 @@ describe("compactEmbeddedAgentSessionDirect hooks", () => {
   it("skips compaction when the transcript only contains boilerplate replies and tool output", () => {
     const messages = [
       { role: "user", content: "<b>HEARTBEAT_OK</b>", timestamp: 1 },
-      {
-        role: "toolResult",
-        toolCallId: "t1",
-        toolName: "exec",
-        content: [{ type: "text", text: "checked" }],
-        isError: false,
-        timestamp: 2,
-      },
+      makeTextToolResult("t1", "exec", "checked", false, 2),
     ] as AgentMessage[];
 
     expect(compactTesting.containsRealConversationMessages(messages)).toBe(false);

--- a/src/agents/embedded-agent-runner/run.midturn-precheck-retry.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.midturn-precheck-retry.test-support.ts
@@ -1,5 +1,6 @@
 // Full-entry coverage for retrying an already-capped mid-turn transcript.
 import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { makeTextToolResult } from "../../../test/helpers/text-tool-result.js";
 import { buildEmbeddedRunnerAssistant } from "../test-helpers/embedded-agent-runner-e2e-fixtures.js";
 import {
   makeAttemptResult,
@@ -21,14 +22,7 @@ const settledExecAssistant = buildEmbeddedRunnerAssistant({
   stopReason: "toolUse" as const,
   timestamp: 1,
 });
-const settledExecResult = {
-  role: "toolResult" as const,
-  toolCallId: "call-exec",
-  toolName: "exec",
-  content: [{ type: "text" as const, text: "command completed" }],
-  isError: false,
-  timestamp: 2,
-};
+const settledExecResult = makeTextToolResult("call-exec", "exec", "command completed", false, 2);
 
 let session: Awaited<ReturnType<typeof createSharedRunIntegrationSession>>;
 let runEmbeddedAgent: Awaited<ReturnType<typeof loadSharedRunIntegrationHarness>>;

--- a/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-phase-lifecycle.test.ts
@@ -33,6 +33,7 @@ vi.mock("./attempt-async-tasks.js", () => ({
   waitForCompletionRequiredAsyncTasks: hoisted.waitForCompletionRequiredAsyncTasks,
 }));
 
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import { completeEmbeddedAttemptAfterTurn } from "./attempt-finalize.js";
 import { settleEmbeddedAttemptStream } from "./attempt-stream-settle.js";
 
@@ -553,14 +554,9 @@ describe("embedded attempt phase lifecycle state", () => {
           stopReason: "toolUse",
         }),
       );
-      const toolResultEntryId = sessionManager.appendMessage({
-        role: "toolResult",
-        toolCallId: "call-1",
-        toolName: "read",
-        content: [{ type: "text", text: "Current verified result." }],
-        isError: false,
-        timestamp: 3,
-      });
+      const toolResultEntryId = sessionManager.appendMessage(
+        makeTextToolResult("call-1", "read", "Current verified result.", false, 3),
+      );
       sessionManager.appendMessage(
         makeAgentAssistantMessage({ content: [{ type: "text", text: "Suppressed terminal." }] }),
       );

--- a/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-tool-call-replay-sanitization.test.ts
@@ -2,6 +2,7 @@
 
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it, vi } from "vitest";
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import { textToolResult } from "../../test-helpers/sparse-transcript.test-support.js";
 import {
   sanitizeOpenAIResponsesReplayForStream,
@@ -576,14 +577,7 @@ describe("sanitizeOpenAIResponsesReplayForStream", () => {
         ],
       },
       reasoning,
-      {
-        role: "toolResult",
-        toolCallId: "call_async",
-        toolName: "lookup",
-        content: [{ type: "text", text: "Ready" }],
-        isError: false,
-        timestamp: 2,
-      },
+      makeTextToolResult("call_async", "lookup", "Ready", false, 2),
       { role: "user", content: "Include the queued update", timestamp: 3 },
     ];
 

--- a/src/agents/embedded-agent-runner/run/compaction-timeout.test.ts
+++ b/src/agents/embedded-agent-runner/run/compaction-timeout.test.ts
@@ -1,5 +1,6 @@
 // Coverage for timeout decisions and snapshots during compaction.
 import { describe, expect, it } from "vitest";
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import { castAgentMessage } from "../../test-helpers/agent-message-fixtures.js";
 import {
   resolveRunTimeoutDuringCompaction,
@@ -127,14 +128,7 @@ describe("compaction-timeout helpers", () => {
   });
 
   it("keeps tool-result tails continuable after compaction timeout", () => {
-    const toolResult = castAgentMessage({
-      role: "toolResult",
-      toolCallId: "call-1",
-      toolName: "lookup",
-      content: [{ type: "text", text: "result" }],
-      isError: false,
-      timestamp: 1,
-    });
+    const toolResult = castAgentMessage(makeTextToolResult("call-1", "lookup", "result", false, 1));
     const pre = [
       castAgentMessage({ role: "user", content: "pre-user" }),
       castAgentMessage({ role: "assistant", content: "tool call" }),
@@ -257,14 +251,7 @@ describe("compaction-timeout helpers", () => {
     },
     {
       name: "tool result tail",
-      tail: castAgentMessage({
-        role: "toolResult",
-        toolCallId: "call-1",
-        toolName: "lookup",
-        content: [{ type: "text", text: "result" }],
-        isError: false,
-        timestamp: 2,
-      }),
+      tail: castAgentMessage(makeTextToolResult("call-1", "lookup", "result", false, 2)),
       expectedLength: 2,
     },
     {

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.test-support.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.test-support.ts
@@ -1,4 +1,5 @@
 import { vi } from "vitest";
+import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
 import { getAgentEventLifecycleGeneration } from "../../../infra/agent-events.js";
 import type { AdmittedRunContext } from "../../admitted-run-context.js";
 import {
@@ -27,14 +28,7 @@ export function createSettledProviderFailureAttempt(
         stopReason: "toolUse",
         content: [{ type: "toolCall", id: "call-write", name: "write", arguments: {} }],
       }),
-      {
-        role: "toolResult",
-        toolCallId: "call-write",
-        toolName: "write",
-        content: [{ type: "text", text: "Note saved" }],
-        isError: false,
-        timestamp: 1,
-      },
+      makeTextToolResult("call-write", "write", "Note saved", false, 1),
       buildEmbeddedRunnerAssistant({
         stopReason: "error",
         errorMessage: "503 upstream connection refused",

--- a/src/agents/session-tool-result-guard.persistence-order.test.ts
+++ b/src/agents/session-tool-result-guard.persistence-order.test.ts
@@ -1,6 +1,7 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { describe, expect, it, vi } from "vitest";
+import { makeTextToolResult } from "../../test/helpers/text-tool-result.js";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import {
   makeAgentAssistantMessage,
@@ -11,14 +12,10 @@ const call = makeAgentAssistantMessage({
   content: [{ type: "toolCall", id: "call_order", name: "read", arguments: {} }],
   stopReason: "toolUse",
 });
-const result = {
-  role: "toolResult",
-  toolCallId: "call_order",
-  toolName: "read",
-  content: [{ type: "text", text: "success" }],
-  isError: false,
-  timestamp: 1,
-} satisfies Extract<AgentMessage, { role: "toolResult" }>;
+const result = makeTextToolResult("call_order", "read", "success", false, 1) satisfies Extract<
+  AgentMessage,
+  { role: "toolResult" }
+>;
 
 describe("tool-result persistence ordering", () => {
   it.each(["result", "throw"])(

--- a/src/agents/session-tool-result-guard.transcript-events.test.ts
+++ b/src/agents/session-tool-result-guard.transcript-events.test.ts
@@ -8,6 +8,7 @@ import { closeOpenClawAgentDatabasesForTest } from "openclaw/plugin-sdk/sqlite-r
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { transformMessages } from "../../packages/ai/src/transcript-transform.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { makeTextToolResult } from "../../test/helpers/text-tool-result.js";
 import {
   appendTranscriptMessage,
   listSessionPendingInputs,
@@ -908,14 +909,7 @@ describe("deferred assistant error transcript", () => {
     };
     failed.usage = { ...failed.usage, output: 7, totalTokens: 7 };
     manager.appendMessage(failed);
-    manager.appendMessage({
-      role: "toolResult",
-      toolCallId: "call-terminal",
-      toolName: "read",
-      content: [{ type: "text", text: "Result" }],
-      isError: false,
-      timestamp: 1,
-    });
+    manager.appendMessage(makeTextToolResult("call-terminal", "read", "Result", false, 1));
     await owner.settle(true);
     const messages = SessionManager.open(target).buildSessionContext().messages;
     expect(messages).toMatchObject([

--- a/src/agents/sessions/agent-session-small-context-compaction.test.ts
+++ b/src/agents/sessions/agent-session-small-context-compaction.test.ts
@@ -1,6 +1,7 @@
 import type { Context, Model, SimpleStreamOptions } from "openclaw/plugin-sdk/llm";
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
+import { makeTextToolResult } from "../../../test/helpers/text-tool-result.js";
 import { applyAgentCompactionSettingsFromConfig } from "../agent-settings.js";
 import { buildRuntimeContextCustomMessage } from "../embedded-agent-runner/run/runtime-context-prompt.js";
 import { agentSessionAutomaticCompaction } from "./agent-session-compaction.js";
@@ -216,14 +217,9 @@ describe("AgentSession small-context compaction", () => {
           "toolUse",
         ),
       );
-      sessionManager.appendMessage({
-        role: "toolResult",
-        toolCallId: "archive-read",
-        toolName: "read",
-        content: [{ type: "text", text: "The project uses blue buttons." }],
-        isError: false,
-        timestamp: 3,
-      });
+      sessionManager.appendMessage(
+        makeTextToolResult("archive-read", "read", "The project uses blue buttons.", false, 3),
+      );
       sessionManager.appendMessage({
         role: "user",
         content: "Continue the project.",

--- a/src/agents/transport-message-transform.async.test.ts
+++ b/src/agents/transport-message-transform.async.test.ts
@@ -1,4 +1,5 @@
 import { expect, it } from "vitest";
+import { makeTextToolResult } from "../../test/helpers/text-tool-result.js";
 import type { Context, Model } from "../llm/types.js";
 import { createZeroUsageFixture } from "./test-helpers/usage-fixtures.js";
 import { transformTransportMessages } from "./transport-message-transform.js";
@@ -33,14 +34,7 @@ it.each([
       content: [{ type: "toolCall", id: "lookup", name: "lookup", arguments: {}, async: true }],
     },
     { ...assistant, stopReason: "stop", content: [{ type: "text", text: "independent answer" }] },
-    {
-      role: "toolResult",
-      toolCallId: "lookup",
-      toolName: "lookup",
-      content: [{ type: "text", text: "found" }],
-      isError: false,
-      timestamp: 1,
-    },
+    makeTextToolResult("lookup", "lookup", "found", false, 1),
   ];
   const replay = transformTransportMessages(messages, model);
   expect(replay.map((message) => message.role)).toEqual(["assistant", "toolResult", "assistant"]);

--- a/src/auto-reply/reply/memory-flush-session.test.ts
+++ b/src/auto-reply/reply/memory-flush-session.test.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { expect, it } from "vitest";
+import { makeTextToolResult } from "../../../test/helpers/text-tool-result.js";
 import {
   assembleHarnessContextEngine,
   bootstrapHarnessContextEngine,
@@ -177,14 +178,7 @@ it.each(["compaction", "reset"] as const)(
           stopReason: "toolUse",
         }),
       );
-      source.appendMessage({
-        role: "toolResult",
-        toolCallId: "read-call",
-        toolName: "read",
-        content: [{ type: "text", text: "Paired result" }],
-        isError: false,
-        timestamp: 4,
-      });
+      source.appendMessage(makeTextToolResult("read-call", "read", "Paired result", false, 4));
       const boundary =
         boundaryType === "compaction"
           ? source.appendCompaction("Summary", opaqueCut, 100)

--- a/src/gateway/worker-environments/transcript-commit.test.ts
+++ b/src/gateway/worker-environments/transcript-commit.test.ts
@@ -8,6 +8,7 @@ import type {
   WorkerTranscriptMessage,
 } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
 import { createNoisyPngBuffer } from "../../../test/helpers/image-fixtures.js";
+import { makeTextToolResult } from "../../../test/helpers/text-tool-result.js";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
 import { clearRuntimeConfigSnapshot, setRuntimeConfigSnapshot } from "../../config/io.js";
 import {
@@ -121,14 +122,7 @@ function createTurnMessages(userText = "Inspect the workspace"): WorkerTranscrip
       stopReason: "toolUse",
       timestamp: 200,
     },
-    {
-      role: "toolResult",
-      toolCallId: "call-read-1",
-      toolName: "read",
-      content: [{ type: "text", text: "Workspace ready." }],
-      isError: false,
-      timestamp: 300,
-    },
+    makeTextToolResult("call-read-1", "read", "Workspace ready.", false, 300),
   ];
 }
 

--- a/src/gateway/worker-environments/worker-turn-launcher-remote-handoff.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-remote-handoff.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { Value } from "typebox/value";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { WorkerConnectRequestFrameSchema } from "../../../packages/gateway-protocol/src/schema/worker-admission.js";
+import { makeTextToolResult } from "../../../test/helpers/text-tool-result.js";
 import {
   makeAgentAssistantMessage,
   makeAgentUserMessage,
@@ -87,14 +88,7 @@ describe("worker turn launcher remote handoff", () => {
     );
     manager.appendCustomMessageEntry("context", "Custom durable context", true, {});
     manager.appendCompaction("Compacted durable context", earlierRequestId, 100);
-    manager.appendMessage({
-      role: "toolResult",
-      toolCallId: "call-1",
-      toolName: "read",
-      content: [{ type: "text", text: "result" }],
-      isError: false,
-      timestamp: 12,
-    });
+    manager.appendMessage(makeTextToolResult("call-1", "read", "result", false, 12));
     let descriptor: WorkerLaunchDescriptor | undefined;
     const environment = browserEnvironment();
     const bootstrapReceipt = environment.bootstrapReceipt;
@@ -389,14 +383,9 @@ describe("worker turn launcher remote handoff", () => {
     const firstKeptEntryId = manager.appendMessage(
       makeAgentUserMessage({ content: "Earlier request", timestamp: 17 }),
     );
-    manager.appendMessage({
-      role: "toolResult",
-      toolCallId: "shared-call",
-      toolName: "read",
-      content: [{ type: "text", text: "Discarded owner result" }],
-      isError: false,
-      timestamp: 18,
-    });
+    manager.appendMessage(
+      makeTextToolResult("shared-call", "read", "Discarded owner result", false, 18),
+    );
     manager.appendMessage(
       makeAgentAssistantMessage({
         content: [{ type: "toolCall", id: "shared-call", name: "read", arguments: {} }],
@@ -404,14 +393,9 @@ describe("worker turn launcher remote handoff", () => {
         timestamp: 19,
       }),
     );
-    manager.appendMessage({
-      role: "toolResult",
-      toolCallId: "shared-call",
-      toolName: "read",
-      content: [{ type: "text", text: "Kept owner result" }],
-      isError: false,
-      timestamp: 20,
-    });
+    manager.appendMessage(
+      makeTextToolResult("shared-call", "read", "Kept owner result", false, 20),
+    );
     manager.appendMessage(
       makeAgentAssistantMessage({
         content: [{ type: "text", text: "Earlier reply" }],

--- a/src/gateway/worker-environments/worker-turn-launcher-terminal-results.test.ts
+++ b/src/gateway/worker-environments/worker-turn-launcher-terminal-results.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeTextToolResult } from "../../../test/helpers/text-tool-result.js";
 import {
   buildAgentRunTerminalReplySnapshot,
   type AgentRunTerminalReplySnapshot,
@@ -227,14 +228,9 @@ describe("worker turn launcher terminal results", () => {
                 },
               }),
             );
-            completed.appendMessage({
-              role: "toolResult",
-              toolCallId: "call-usage",
-              toolName: "read",
-              content: [{ type: "text", text: "usage result" }],
-              isError: false,
-              timestamp: 22,
-            });
+            completed.appendMessage(
+              makeTextToolResult("call-usage", "read", "usage result", false, 22),
+            );
             const leafId = completed.appendMessage(
               makeAgentAssistantMessage({
                 content,

--- a/src/skills/workshop/experience-review.live-contract.test.ts
+++ b/src/skills/workshop/experience-review.live-contract.test.ts
@@ -1,18 +1,12 @@
 import { describe, expect, it } from "vitest";
+import { makeTextToolResult } from "../../../test/helpers/text-tool-result.js";
 import type { Message } from "../../llm/types.js";
 import { assertExperienceReviewDecision } from "./experience-review-decision.test-support.js";
 
 type DecisionInput = Parameters<typeof assertExperienceReviewDecision>[0];
 function abstention(): DecisionInput {
   const messages: Message[] = [
-    {
-      role: "toolResult",
-      toolCallId: "history",
-      toolName: "exec",
-      content: [{ type: "text", text: "observed recovery" }],
-      isError: false,
-      timestamp: 0,
-    },
+    makeTextToolResult("history", "exec", "observed recovery", false, 0),
   ];
   return {
     messages,
@@ -80,14 +74,9 @@ describe("Workshop live decision acceptance", () => {
         name: "skill_workshop",
         arguments: { action, name: "existing-skill" },
       });
-      input.observation.toolResults.push({
-        role: "toolResult",
-        toolCallId: "prepare",
-        toolName: "skill_workshop",
-        content: [{ type: "text", text: "Existing skill content" }],
-        isError: false,
-        timestamp: 0,
-      });
+      input.observation.toolResults.push(
+        makeTextToolResult("prepare", "skill_workshop", "Existing skill content", false, 0),
+      );
       expect(assertExperienceReviewDecision(input)).toBe("abstained");
     },
   );
@@ -138,27 +127,17 @@ describe("Workshop live decision acceptance", () => {
           name: "skill_workshop",
           arguments: { action: "create", name: "existing-skill" },
         });
-        input.observation.toolResults.push({
-          role: "toolResult",
-          toolCallId: "read",
-          toolName: "skill_workshop",
-          content: [{ type: "text", text: "Existing skill content" }],
-          isError: false,
-          timestamp: 0,
-        });
+        input.observation.toolResults.push(
+          makeTextToolResult("read", "skill_workshop", "Existing skill content", false, 0),
+        );
       },
     ],
     [
       "rejected tool",
       (input: DecisionInput) => {
-        input.observation.toolResults.push({
-          role: "toolResult",
-          toolCallId: "rejected",
-          toolName: "skill_workshop",
-          content: [{ type: "text", text: "name required" }],
-          isError: true,
-          timestamp: 0,
-        });
+        input.observation.toolResults.push(
+          makeTextToolResult("rejected", "skill_workshop", "name required", true, 0),
+        );
       },
     ],
   ] as const)("rejects %s even when the proposal count is zero", (_label, corrupt) => {

--- a/test/helpers/text-tool-result.ts
+++ b/test/helpers/text-tool-result.ts
@@ -1,0 +1,16 @@
+export function makeTextToolResult(
+  toolCallId: string,
+  toolName: string,
+  text: string,
+  isError: boolean,
+  timestamp: number,
+) {
+  return {
+    role: "toolResult" as const,
+    toolCallId,
+    toolName,
+    content: [{ type: "text" as const, text }],
+    isError,
+    timestamp,
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Agent, worker and provider tests repeat complete text-only tool-result input messages, adding boilerplate around the behavior each case protects.

## Why This Change Was Made

Share a pure test constructor at 49 input sites, removing 273 net test/support lines. All five values are required: call ID, tool name, text, error flag and timestamp. Each call creates a fresh message, content array and text block in the original property order, without defaults or production imports.

Existing sparse-message helpers, independent expected-result literals, casts, typed caller boundaries and shared input bindings remain intact. In particular, worker fixtures retain their ability to append image blocks, and replay fixtures retain their original append order and shared references.

## User Impact

No production behavior changes. The existing scenarios, assertions and deadlines remain intact.

## Evidence

- All 1,077 cases passed before and after in the same 32 complete suites, including consumers of the two changed support files. Per-file ordered case names and statuses match exactly, with no pending cases.
- Inline reconstruction matches the original syntax across all 29 consumers. Runtime checks verify literal values, ordered keys, ordinary prototypes and fresh nested allocations at all 49 sites.
- Independent P2 review and deslop are clean. Mapped changed gate passed.

No overall runtime improvement or coverage-percentage claim.
