### PR TITLE
test(mac): align build-script fixtures with native Bash

### DIFF
--- a/test/scripts/build-and-run-mac.test.ts
+++ b/test/scripts/build-and-run-mac.test.ts
@@ -1,28 +1,23 @@
-// Build And Run Mac tests cover build and run mac script behavior.
 import { execFileSync, spawnSync } from "node:child_process";
 import {
   chmodSync,
   copyFileSync,
   existsSync,
   mkdirSync,
-  mkdtempSync,
   readFileSync,
-  rmSync,
   statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
-import { tmpdir } from "node:os";
 import path, { dirname, join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../helpers/temp-dir.js";
 
 const scriptPath = "scripts/build-and-run-mac.sh";
-const tempRoots: string[] = [];
+const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 
 function runStopExistingLocalApp(params: { fakeLsof?: string; fakePgrep: string }) {
-  const root = mkdtempSync(join(tmpdir(), "openclaw-build-run-mac-test-"));
-  tempRoots.push(root);
+  const root = tempDirs.make("openclaw-build-run-mac-test-");
   const binDir = join(root, "bin");
   const killCallsPath = join(root, "kill-calls.txt");
   const pgrepCallsPath = join(root, "pgrep-calls.txt");
@@ -89,7 +84,7 @@ function runStopExistingLocalApp(params: { fakeLsof?: string; fakePgrep: string 
   );
   chmodSync(harnessPath, 0o755);
 
-  const result = spawnSync("bash", [harnessPath], {
+  const result = spawnSync("/bin/bash", [harnessPath], {
     encoding: "utf8",
     env: {
       ...process.env,
@@ -105,18 +100,11 @@ function runStopExistingLocalApp(params: { fakeLsof?: string; fakePgrep: string 
   return { killCalls, pgrepCalls, result };
 }
 
-afterEach(() => {
-  for (const root of tempRoots.splice(0)) {
-    rmSync(root, { force: true, recursive: true });
-  }
-});
-
 describe("scripts/build-and-run-mac.sh", () => {
   it.each(["pnpm", "corepack"])(
     "prepares the Apple resource bundle before SwiftPM with %s",
     (runner) => {
-      const root = mkdtempSync(join(tmpdir(), "openclaw-mac-mermaid-test-"));
-      tempRoots.push(root);
+      const root = tempDirs.make("openclaw-mac-mermaid-test-");
       const binDir = join(root, "bin");
       mkdirSync(binDir);
       mkdirSync(join(root, "apps/macos"), { recursive: true });
@@ -172,7 +160,7 @@ describe("scripts/build-and-run-mac.sh", () => {
         chmodSync(target, 0o755);
       }
 
-      const result = spawnSync("bash", [join(root, scriptPath)], {
+      const result = spawnSync("/bin/bash", [join(root, scriptPath)], {
         encoding: "utf8",
         env: {
           ...process.env,
@@ -189,7 +177,7 @@ describe("scripts/build-and-run-mac.sh", () => {
   );
 
   it("prints help before build or launch side effects", () => {
-    const result = spawnSync("bash", [scriptPath, "--help"], {
+    const result = spawnSync("/bin/bash", [scriptPath, "--help"], {
       cwd: process.cwd(),
       encoding: "utf8",
     });
@@ -201,7 +189,7 @@ describe("scripts/build-and-run-mac.sh", () => {
   });
 
   it("rejects unknown options before build or launch side effects", () => {
-    const result = spawnSync("bash", [scriptPath, "--wat"], {
+    const result = spawnSync("/bin/bash", [scriptPath, "--wat"], {
       cwd: process.cwd(),
       encoding: "utf8",
     });
@@ -263,7 +251,6 @@ describe("scripts/build-and-run-mac.sh", () => {
   });
 });
 
-const tempDirs = useAutoCleanupTempDirTracker(afterEach);
 // Platform contract: macOS tooling must not select Homebrew Bash through PATH.
 const nativeScripts = [
   "scripts/lib/plistbuddy.sh",


### PR DESCRIPTION
Related: #141884.

## What Problem This Solves

The older Mac build-script fixtures still selected Bash through PATH after the native scripts adopted `/bin/bash`. They also kept a separate manual temporary-directory list beside the shared cleanup tracker used by the newer tests.

## Why This Change Was Made

Use `/bin/bash` for the four older fixture invocations and let the existing temporary-directory tracker own all fixture directories. This removes duplicate allocation/cleanup bookkeeping and unused imports. The deliberately selected alternate-shell cases and all assertions stay unchanged.

## User Impact

The tests exercise the maintained native interpreter contract and share the existing cleanup behavior. There is no production behavior change; the test file loses 13 lines.

## Evidence

Seven existing synthetic script cases and nine shared-temp-helper cases pass; 163 unselected/platform-filtered cases are excluded from that count. All 15 changed-file check stages and `git diff --check` pass. Independent P0–P2 review has no findings. Only the redundant banner comment was removed after the focused test run; final checks cover that exact source.

The compiler and process fixtures use fake tools and stop before app launch. No actual app build, stop, launch, or failing-Bash experiment was run. This does not claim to reproduce a prior hang or cleanup leak.

The initial CI run failed an unrelated agent Code Mode delivery test before its persistence assertions; the changed Mac fixture did not run in that job. The targeted job rerun passed on the identical tested merge, including the previously failed case, and all required checks are green. All 18 cases in the agent delivery file also passed locally without edits. The first failure's cause remains an investigation follow-up; no timeout or assertion was changed. [Passing rerun](https://github.com/openclaw/openclaw/actions/runs/34212896293/job/102024066486).
