### PR TITLE
test(ui): use a valid core session status in catalog fixture

### DIFF
--- a/ui/src/e2e/codex-sessions.e2e.test.ts
+++ b/ui/src/e2e/codex-sessions.e2e.test.ts
@@ -129,7 +129,7 @@ suite.define(() => {
               label: "Understanding Startup Phases and Delays",
               model: "gpt-5.5",
               modelProvider: "openai",
-              status: "idle",
+              status: "done",
               totalTokens: 0,
               updatedAt: Date.now(),
               worktree: {


### PR DESCRIPTION
## What Problem This Solves

The catalog/sidebar browser fixture supplied `idle` for a core `sessions.list` row, even though that value is outside the core session run-status schema. It belongs to the separate native catalog fixtures in the same case.

## Why This Change Was Made

Use the valid inactive core status `done`, consistent with `hasActiveRun: false`. The native catalog rows and every existing assertion remain unchanged.

## User Impact

The browser test now exercises a valid core response. Production behavior is unchanged.

## Evidence

The existing mocked-Gateway case, “separates native catalogs from live Coding rows,” passes with the corrected input; six other cases were filtered. All 19 changed-file check stages and `git diff --check` pass. Independent P0–P2 review has no findings. The browser and temporary build closed through the existing teardown.

This is fixture fidelity, not a reproduced product bug or native/provider runtime proof. No new test, production seam, or screenshot was added.
