### PR TITLE
refactor(tests): reuse deferred fixtures in chat lifecycle tests

### DIFF
--- a/ui/src/pages/chat/chat-command-executor.test.ts
+++ b/ui/src/pages/chat/chat-command-executor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 // @vitest-environment node
 import { contextBudgetStatusFixture } from "../../../../src/config/sessions/context-budget.test-support.js";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import type {
   GatewaySessionRow,
@@ -230,10 +231,7 @@ describe("executeSlashCommand directives", () => {
   });
 
   it("does not patch through a replacement connection after loading session state", async () => {
-    let resolveList: ((value: SessionsListResult) => void) | undefined;
-    const listResult = new Promise<SessionsListResult>((resolve) => {
-      resolveList = resolve;
-    });
+    const { promise: listResult, resolve: resolveList } = createDeferred<SessionsListResult>();
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.list") {
         return await listResult;
@@ -264,10 +262,7 @@ describe("executeSlashCommand directives", () => {
   });
 
   it("rechecks live scopes before patching after loading session state", async () => {
-    let resolveList: ((value: SessionsListResult) => void) | undefined;
-    const listResult = new Promise<SessionsListResult>((resolve) => {
-      resolveList = resolve;
-    });
+    const { promise: listResult, resolve: resolveList } = createDeferred<SessionsListResult>();
     const request = vi.fn(async (method: string) => {
       if (method === "sessions.list") {
         return await listResult;

--- a/ui/src/pages/chat/chat-commands.test.ts
+++ b/ui/src/pages/chat/chat-commands.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import { GatewayBrowserClient } from "../../api/gateway.ts";
 import type { ApplicationGatewaySnapshot } from "../../app/gateway.ts";
 import {
@@ -105,10 +106,9 @@ describe("refreshSlashCommands", () => {
   it("retires in-flight commands after an explicit selection invalidation", async () => {
     const client = new GatewayBrowserClient({ url: "ws://127.0.0.1:12345" });
     const scope = { agentId: "main", sessionKey: "agent:main:shared" };
-    let settle!: (value: { commands: ReturnType<typeof remoteCommand>[] }) => void;
-    const pending = new Promise<{ commands: ReturnType<typeof remoteCommand>[] }>((resolve) => {
-      settle = resolve;
-    });
+    const { promise: pending, resolve: settle } = createDeferred<{
+      commands: ReturnType<typeof remoteCommand>[];
+    }>();
     const request = vi
       .spyOn(client, "request")
       .mockImplementationOnce(async () => pending)
@@ -234,10 +234,7 @@ describe("refreshSlashCommands", () => {
   });
 
   it("coalesces duplicate refreshes for the same agent", async () => {
-    let resolveFirst: ((value: unknown) => void) | undefined;
-    const first = new Promise((resolve) => {
-      resolveFirst = resolve;
-    });
+    const { promise: first, resolve: resolveFirst } = createDeferred<unknown>();
     const request = vi.fn().mockImplementationOnce(async () => await first);
     const client = { request } as never;
 
@@ -274,10 +271,7 @@ describe("refreshSlashCommands", () => {
   });
 
   it("ignores stale refresh responses after switching agents", async () => {
-    let resolveFirst: ((value: unknown) => void) | undefined;
-    const first = new Promise((resolve) => {
-      resolveFirst = resolve;
-    });
+    const { promise: first, resolve: resolveFirst } = createDeferred<unknown>();
     const request = vi.fn((_: string, params: { agentId?: string }) => {
       if (params.agentId === "main") {
         return first;
@@ -472,10 +466,7 @@ describe("conversation reset confirmation", () => {
   });
 
   it("cancels /reset when the selected session changes during confirmation", async () => {
-    let settleConfirmation: ((confirmed: boolean) => void) | undefined;
-    const confirmation = new Promise<boolean>((resolve) => {
-      settleConfirmation = resolve;
-    });
+    const { promise: confirmation, resolve: settleConfirmation } = createDeferred<boolean>();
     const sendResetMessage = vi.fn(async () => {});
     const host = {
       ...connectedSessionAccess(),
@@ -495,10 +486,7 @@ describe("conversation reset confirmation", () => {
   });
 
   it("does not send /reset through a replacement Gateway after confirmation", async () => {
-    let settleConfirmation: ((confirmed: boolean) => void) | undefined;
-    const confirmation = new Promise<boolean>((resolve) => {
-      settleConfirmation = resolve;
-    });
+    const { promise: confirmation, resolve: settleConfirmation } = createDeferred<boolean>();
     const sendResetMessage = vi.fn(async () => {});
     const host = {
       client: { request: vi.fn() } as unknown as GatewayBrowserClient,
@@ -527,10 +515,7 @@ describe("conversation reset confirmation", () => {
   });
 
   it("rechecks /reset admin scope after confirmation", async () => {
-    let settleConfirmation: ((confirmed: boolean) => void) | undefined;
-    const confirmation = new Promise<boolean>((resolve) => {
-      settleConfirmation = resolve;
-    });
+    const { promise: confirmation, resolve: settleConfirmation } = createDeferred<boolean>();
     const sendResetMessage = vi.fn(async () => {});
     const host = {
       ...connectedSessionAccess(),
@@ -561,10 +546,7 @@ describe("conversation reset confirmation", () => {
   });
 
   it("continues /reset when the session key changes to an equivalent alias", async () => {
-    let settleConfirmation: ((confirmed: boolean) => void) | undefined;
-    const confirmation = new Promise<boolean>((resolve) => {
-      settleConfirmation = resolve;
-    });
+    const { promise: confirmation, resolve: settleConfirmation } = createDeferred<boolean>();
     const sendResetMessage = vi.fn(async () => {});
     const host = {
       ...connectedSessionAccess(),
@@ -597,10 +579,7 @@ describe("conversation reset confirmation", () => {
   it.each(["reset", "clear"])(
     "defers /%s when a run starts during confirmation",
     async (command) => {
-      let settleConfirmation: ((confirmed: boolean) => void) | undefined;
-      const confirmation = new Promise<boolean>((resolve) => {
-        settleConfirmation = resolve;
-      });
+      const { promise: confirmation, resolve: settleConfirmation } = createDeferred<boolean>();
       const sendResetMessage = vi.fn(async () => {});
       const reset = vi.fn();
       const host = {
@@ -666,10 +645,7 @@ describe("conversation reset confirmation", () => {
   });
 
   it("does not clear through a replacement Gateway after confirmation", async () => {
-    let settleConfirmation: ((confirmed: boolean) => void) | undefined;
-    const confirmation = new Promise<boolean>((resolve) => {
-      settleConfirmation = resolve;
-    });
+    const { promise: confirmation, resolve: settleConfirmation } = createDeferred<boolean>();
     const reset = vi.fn();
     const originalClient = { request: vi.fn() } as unknown as GatewayBrowserClient;
     const replacementClient = { request: vi.fn() } as unknown as GatewayBrowserClient;
@@ -706,10 +682,7 @@ describe("conversation reset confirmation", () => {
   });
 
   it("rechecks /clear scope after confirmation", async () => {
-    let settleConfirmation: ((confirmed: boolean) => void) | undefined;
-    const confirmation = new Promise<boolean>((resolve) => {
-      settleConfirmation = resolve;
-    });
+    const { promise: confirmation, resolve: settleConfirmation } = createDeferred<boolean>();
     const reset = vi.fn();
     const host = {
       ...connectedSessionAccess(),

--- a/ui/src/pages/chat/chat-history.inflight.test.ts
+++ b/ui/src/pages/chat/chat-history.inflight.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment node
 import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createChatSubmissions } from "../../app/chat-submissions.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
@@ -826,10 +827,8 @@ describe("chat history in-flight assistant recovery", () => {
   );
 
   it("does not let delayed history overwrite a newer live run", async () => {
-    let resolveHistory!: (result: ChatHistoryResult) => void;
-    const historyPromise = new Promise<ChatHistoryResult>((resolve) => {
-      resolveHistory = resolve;
-    });
+    const { promise: historyPromise, resolve: resolveHistory } =
+      createDeferred<ChatHistoryResult>();
     const request = vi.fn().mockReturnValue(historyPromise);
     const state = createState(activeHistory("run-reconnected"));
     state.client = { request } as unknown as GatewayBrowserClient;
@@ -846,10 +845,8 @@ describe("chat history in-flight assistant recovery", () => {
   });
 
   it("adopts the snapshot when remount reconciliation replaces an unchanged run map", async () => {
-    let resolveHistory!: (result: ChatHistoryResult) => void;
-    const historyPromise = new Promise<ChatHistoryResult>((resolve) => {
-      resolveHistory = resolve;
-    });
+    const { promise: historyPromise, resolve: resolveHistory } =
+      createDeferred<ChatHistoryResult>();
     const request = vi.fn().mockReturnValue(historyPromise);
     const history = activeHistory("run-reconnected");
     history.inFlightRun!.text = "The response survived navigation.";
@@ -885,10 +882,8 @@ describe("chat history in-flight assistant recovery", () => {
   ])(
     "merges $name same-run delta that arrives before history",
     async ({ snapshotText, deltaText, cumulativeText, expectedTail }) => {
-      let resolveHistory!: (result: ChatHistoryResult) => void;
-      const historyPromise = new Promise<ChatHistoryResult>((resolve) => {
-        resolveHistory = resolve;
-      });
+      const { promise: historyPromise, resolve: resolveHistory } =
+        createDeferred<ChatHistoryResult>();
       const request = vi.fn().mockReturnValue(historyPromise);
       const history = activeHistory("run-reconnected");
       history.messages = [
@@ -921,10 +916,8 @@ describe("chat history in-flight assistant recovery", () => {
   );
 
   it("does not duplicate a live delta already covered by a newer history snapshot", async () => {
-    let resolveHistory!: (result: ChatHistoryResult) => void;
-    const historyPromise = new Promise<ChatHistoryResult>((resolve) => {
-      resolveHistory = resolve;
-    });
+    const { promise: historyPromise, resolve: resolveHistory } =
+      createDeferred<ChatHistoryResult>();
     const request = vi.fn().mockReturnValue(historyPromise);
     const history = activeHistory("run-reconnected");
     history.messages = [
@@ -991,10 +984,8 @@ describe("chat history in-flight assistant recovery", () => {
       ],
     },
   ])("does not revive a live delta covered by $name", async ({ messages }) => {
-    let resolveHistory!: (result: ChatHistoryResult) => void;
-    const historyPromise = new Promise<ChatHistoryResult>((resolve) => {
-      resolveHistory = resolve;
-    });
+    const { promise: historyPromise, resolve: resolveHistory } =
+      createDeferred<ChatHistoryResult>();
     const request = vi.fn().mockReturnValue(historyPromise);
     const history = activeHistory("run-reconnected");
     history.messages = messages;
@@ -1024,10 +1015,8 @@ describe("chat history in-flight assistant recovery", () => {
     { name: "the snapshot run", completedRunId: "run-reconnected" },
     { name: "a newer intervening run", completedRunId: "run-newer" },
   ])("does not resurrect delayed history after $name completes", async ({ completedRunId }) => {
-    let resolveHistory!: (result: ChatHistoryResult) => void;
-    const historyPromise = new Promise<ChatHistoryResult>((resolve) => {
-      resolveHistory = resolve;
-    });
+    const { promise: historyPromise, resolve: resolveHistory } =
+      createDeferred<ChatHistoryResult>();
     const request = vi.fn().mockReturnValue(historyPromise);
     const state = createState(activeHistory("run-reconnected"));
     state.client = { request } as unknown as GatewayBrowserClient;

--- a/ui/src/pages/chat/chat-history.test.ts
+++ b/ui/src/pages/chat/chat-history.test.ts
@@ -367,10 +367,7 @@ describe("rewindChatHistory", () => {
   });
 
   it("reconciles committed rewind history without overwriting a replacement draft", async () => {
-    let resolveRewind!: (result: { editorText?: string }) => void;
-    const rewind = new Promise<{ editorText?: string }>((resolve) => {
-      resolveRewind = resolve;
-    });
+    const { promise: rewind, resolve: resolveRewind } = createDeferred<{ editorText?: string }>();
     const canonical = { role: "assistant", content: "canonical history after rewind" };
     const state = createState({ messages: [canonical] }) as TestState & {
       handleChatDraftChange: ReturnType<typeof vi.fn>;
@@ -520,10 +517,8 @@ describe("switchChatHistoryBranch", () => {
   });
 
   it("starts a fresh snapshot and rejects in-flight history after a same-key branch switch", async () => {
-    let resolvePreviousHistory!: (result: ChatHistoryResult) => void;
-    const previousHistory = new Promise<ChatHistoryResult>((resolve) => {
-      resolvePreviousHistory = resolve;
-    });
+    const { promise: previousHistory, resolve: resolvePreviousHistory } =
+      createDeferred<ChatHistoryResult>();
     const previous = { role: "assistant", content: "private old branch" };
     const selected = { role: "assistant", content: "selected branch" };
     const state = createState({ messages: [selected] }) as TestState & {
@@ -701,10 +696,7 @@ describe("canonical history snapshot projection", () => {
   });
 
   it("coalesces stale history while distinct live peer messages update the transcript", async () => {
-    let resolveHistory!: (history: ChatHistoryResult) => void;
-    const history = new Promise<ChatHistoryResult>((resolve) => {
-      resolveHistory = resolve;
-    });
+    const { promise: history, resolve: resolveHistory } = createDeferred<ChatHistoryResult>();
     const first = message("user", "shared prompt", {
       id: "canonical-web-same-text",
       idempotencyKey: "web-same-text-run:user",
@@ -749,10 +741,7 @@ describe("canonical history snapshot projection", () => {
   });
 
   it("preserves pending input appended while the authoritative request is in flight", async () => {
-    let resolveHistory!: (history: ChatHistoryResult) => void;
-    const history = new Promise<ChatHistoryResult>((resolve) => {
-      resolveHistory = resolve;
-    });
+    const { promise: history, resolve: resolveHistory } = createDeferred<ChatHistoryResult>();
     const first = message("user", "first prompt", { id: "first-user", seq: 1 });
     const pending = message("user", "concurrent prompt", {
       idempotencyKey: "concurrent-run:user",

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -2397,18 +2397,11 @@ describe("canonical session message recovery", () => {
       renderFrame = callback;
       return 1;
     });
-    let resolveHistory!: (result: {
+    const { promise: history, resolve: resolveHistory } = createDeferred<{
       messages: unknown[];
       sessionId: string;
       thinkingLevel: null;
-    }) => void;
-    const history = new Promise<{
-      messages: unknown[];
-      sessionId: string;
-      thinkingLevel: null;
-    }>((resolve) => {
-      resolveHistory = resolve;
-    });
+    }>();
     const { request, state } = createSessionEventState({ chatDisplayedLeafEntryId: undefined });
     request.mockReturnValue(history);
 
@@ -3473,10 +3466,7 @@ describe("ChatStateController render lifecycle", () => {
   });
 
   it("requests a render before selecting the commit promise", async () => {
-    let resolveCommit: (value: boolean) => void = () => {};
-    const nextCommit = new Promise<boolean>((resolve) => {
-      resolveCommit = resolve;
-    });
+    const { promise: nextCommit, resolve: resolveCommit } = createDeferred<boolean>();
     let completion = Promise.resolve(true);
     const controllers: ReactiveController[] = [];
     const requestUpdate = vi.fn(() => {
@@ -3507,10 +3497,7 @@ describe("ChatStateController render lifecycle", () => {
   });
 
   it("cancels pending commit effects on disconnect", async () => {
-    let resolveCommit: (value: boolean) => void = () => {};
-    const completion = new Promise<boolean>((resolve) => {
-      resolveCommit = resolve;
-    });
+    const { promise: completion, resolve: resolveCommit } = createDeferred<boolean>();
     const host = createControllerHost({
       updateComplete: completion,
     });
@@ -4151,23 +4138,10 @@ describe("refreshChatMetadata", () => {
   );
 
   it("does not apply session metadata after a same-agent session switch", async () => {
-    let resolveMetadata:
-      | ((value: {
-          commands: never[];
-          models: Array<{
-            id: string;
-            name: string;
-            provider: string;
-            available: boolean;
-          }>;
-        }) => void)
-      | undefined;
-    const metadata = new Promise<{
+    const { promise: metadata, resolve: resolveMetadata } = createDeferred<{
       commands: never[];
       models: Array<{ id: string; name: string; provider: string; available: boolean }>;
-    }>((resolve) => {
-      resolveMetadata = resolve;
-    });
+    }>();
     const request = vi.fn(async (method: string, params?: unknown) => {
       expect(method).toBe("chat.metadata");
       expect(params).toEqual({ agentId: "work", sessionKey: "agent:work:main" });
@@ -4215,18 +4189,10 @@ describe("refreshChatMetadata", () => {
   });
 
   it("ignores metadata after switching to a different agent", async () => {
-    let resolveMetadata:
-      | ((value: {
-          commands: never[];
-          models: Array<{ id: string; name: string; provider: string }>;
-        }) => void)
-      | undefined;
-    const metadata = new Promise<{
+    const { promise: metadata, resolve: resolveMetadata } = createDeferred<{
       commands: never[];
       models: Array<{ id: string; name: string; provider: string }>;
-    }>((resolve) => {
-      resolveMetadata = resolve;
-    });
+    }>();
     const request = vi.fn(async () => await metadata);
     const existingCatalog = [
       { id: "work-model", name: "Work Model", provider: "openai", available: true },
@@ -4246,26 +4212,14 @@ describe("refreshChatMetadata", () => {
   });
 
   it("keeps loading owned by the newest agent metadata request", async () => {
-    let resolveWork: (value: {
+    const { promise: workMetadata, resolve: resolveWork } = createDeferred<{
       commands: never[];
       models: Array<{ id: string; name: string; provider: string }>;
-    }) => void = () => {};
-    let resolveOther: (value: {
+    }>();
+    const { promise: otherMetadata, resolve: resolveOther } = createDeferred<{
       commands: never[];
       models: Array<{ id: string; name: string; provider: string }>;
-    }) => void = () => {};
-    const workMetadata = new Promise<{
-      commands: never[];
-      models: Array<{ id: string; name: string; provider: string }>;
-    }>((resolve) => {
-      resolveWork = resolve;
-    });
-    const otherMetadata = new Promise<{
-      commands: never[];
-      models: Array<{ id: string; name: string; provider: string }>;
-    }>((resolve) => {
-      resolveOther = resolve;
-    });
+    }>();
     const request = vi.fn(
       async (_method: string, params?: { agentId?: string }) =>
         await (params?.agentId === "work" ? workMetadata : otherMetadata),
@@ -4295,16 +4249,10 @@ describe("refreshChatMetadata", () => {
   });
 
   it("does not publish metadata after the pane retires its request owner", async () => {
-    let resolveMetadata: (value: {
+    const { promise: pending, resolve: resolveMetadata } = createDeferred<{
       commands: never[];
       models: Array<{ id: string; name: string; provider: string }>;
-    }) => void = () => {};
-    const pending = new Promise<{
-      commands: never[];
-      models: Array<{ id: string; name: string; provider: string }>;
-    }>((resolve) => {
-      resolveMetadata = resolve;
-    });
+    }>();
     const request = vi.fn().mockReturnValue(pending);
     const existingCatalog = [{ id: "existing-model", name: "Existing Model", provider: "openai" }];
     const state = createMetadataState(request, { chatModelCatalog: existingCatalog });
@@ -4477,12 +4425,11 @@ describe("refreshChatModelAuthStatus", () => {
   it.each(["success", "failure"] as const)(
     "ignores a stale auth status %s after reconnecting the same client",
     async (outcome) => {
-      let resolveStatus!: (value: { ts: number; providers: never[] }) => void;
-      let rejectStatus!: (error: unknown) => void;
-      const response = new Promise<{ ts: number; providers: never[] }>((resolve, reject) => {
-        resolveStatus = resolve;
-        rejectStatus = reject;
-      });
+      const {
+        promise: response,
+        resolve: resolveStatus,
+        reject: rejectStatus,
+      } = createDeferred<{ ts: number; providers: never[] }>();
       const request = vi.fn(() => response);
       const currentStatus = { ts: 2, providers: [] };
       const state = {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Chat state, history and command tests repeatedly construct a pending Promise and separately capture its resolver, sometimes repeating a large payload type. That setup obscures the request ownership and stale-response behavior the cases actually protect.

## Why This Change Was Made

Reuse the existing `createDeferred` helper at 31 capture-only allocation sites. Preserve promise/resolver/rejector names, exact payload types, optional resolver guards, allocation order and all existing callbacks and assertions. Dynamic, embedded and never-settling Promise constructions remain unchanged.

## User Impact

No production or UI behavior changes. All cases remain while test code shrinks by 107 net lines. No runtime savings or aggregate coverage claim.

## Evidence

- Full five-file baseline and final: 276 passing cases each, with identical per-file names and order.
- Structural proof preserves the complete test AST outside the replaced capture scaffolding, including generic types, original promise allocation positions, resolver calls and optional guards.
- Native pending, resolve/reject, payload identity, freshness and single-settlement checks passed against the existing helper.
- Formatting, diff checks, the full mapped gate and fresh P2 review passed. No helper implementation or dependency changes.
