### PR TITLE
refactor(boards): remove unused notice injection inputs

### DIFF
--- a/src/boards/board-notices.ts
+++ b/src/boards/board-notices.ts
@@ -40,13 +40,12 @@ export function appendBoardEventNotice(params: {
   agentId?: string;
   widget: string;
   payload: unknown;
-  now?: number;
 }): boolean {
   const summary = serializePayload(params.payload);
   if (Buffer.byteLength(summary, "utf8") > BOARD_EVENT_MAX_BYTES) {
     throw new BoardEventPayloadError(`board event payload exceeds ${BOARD_EVENT_MAX_BYTES} bytes`);
   }
-  const now = params.now ?? Date.now();
+  const now = Date.now();
   // Global session keys and widget names can coincide across different owners.
   const key = `${params.agentId ?? ""}\0${params.sessionKey}\0${params.widget}`;
   const recent = recentNotices.get(key);

--- a/src/gateway/server-methods/board.test-support.ts
+++ b/src/gateway/server-methods/board.test-support.ts
@@ -4,7 +4,7 @@ import { createTestBoardStore } from "../../boards/board-store.test-support.js";
 import { createBoardHandlers } from "./board.js";
 import type { GatewayClient, GatewayRequestContext, RespondFn } from "./types.js";
 
-type BoardHandlerDependencies = NonNullable<Parameters<typeof createBoardHandlers>[3]>;
+type BoardHandlerDependencies = NonNullable<Parameters<typeof createBoardHandlers>[2]>;
 type BoardMcpAppDependencies = {
   resolveActiveView: NonNullable<BoardHandlerDependencies["resolveActiveView"]>;
   resolveAllowedToolNames: NonNullable<BoardHandlerDependencies["resolveAllowedToolNames"]>;
@@ -68,7 +68,7 @@ export function createMcpAppDependencies(): BoardMcpAppDependencies {
 }
 
 export function createBoardHarness(
-  readCanvasHtml?: Parameters<typeof createBoardHandlers>[2],
+  readCanvasHtml?: Parameters<typeof createBoardHandlers>[1],
   dependencies: BoardHandlerDependencies = {},
   store: BoardStore = createTestBoardStore(),
   contextOverrides: Partial<GatewayRequestContext> = {},
@@ -83,7 +83,7 @@ export function createBoardHarness(
     mintFromTranscript: dependencies.mintFromTranscript ?? defaults.mintFromTranscript,
   };
   const broadcast = vi.fn();
-  const handlers = createBoardHandlers(store, undefined, readCanvasHtml, mcpApp);
+  const handlers = createBoardHandlers(store, readCanvasHtml, mcpApp);
   const context = {
     broadcast,
     getMcpAppSandboxPort: () => 18790,

--- a/src/gateway/server-methods/board.ts
+++ b/src/gateway/server-methods/board.ts
@@ -58,7 +58,6 @@ import { emitSessionsChanged } from "./session-change-event.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { assertValidParams, defineValidatedGatewayMethod } from "./validation.js";
 
-type NoticeAppender = typeof appendBoardEventNotice;
 type CanvasDocumentReader = typeof readCanvasDocumentHtmlSource;
 type McpAppDependencies = {
   resolveActiveView: typeof resolveMcpAppActiveView;
@@ -118,7 +117,6 @@ function assertCapabilityParamsSize(
 
 export function createBoardHandlers(
   store: BoardStore,
-  appendNotice: NoticeAppender = appendBoardEventNotice,
   readCanvasDocument: CanvasDocumentReader = readCanvasDocumentHtmlSource,
   dependencies: BoardHandlerDependencies = {},
 ): GatewayRequestHandlers {
@@ -602,7 +600,7 @@ export function createBoardHandlers(
             return;
           }
           authority.assertActive();
-          const appended = appendNotice({
+          const appended = appendBoardEventNotice({
             sessionKey: identity.sessionKey,
             agentId: identity.agentId,
             widget: identity.name,


### PR DESCRIPTION
## What Problem This Solves

Board notice creation and the board handler factory retained internal inputs that no current caller uses. The harness carried those empty argument positions while the real notice owner already supplied the behavior.

## Why This Change Was Made

Delete the unused clock/appender inputs, call the existing notice owner directly, and adjust only the harness factory argument positions and type indexes. Preserve its active dependencies and existing harness API.

## User Impact

No new behavior or public contract is introduced. Production decreases by three lines; test-support line count is unchanged. All five test files and all 70 existing cases remain unchanged.

## Evidence

- Baseline and candidate: 70 passed each, zero failures or filtered cases, with identical complete inventories.
- All five suite sources are byte-identical to the base, covering board events, runtime boundaries, content kinds, widget tooling, and board broadcasts.
- All 29 configured changed checks passed ([Linux Testbox run](https://github.com/openclaw/openclaw/actions/runs/34210560319)); five routing/classification lines are not counted as checks.
- Independent retained-bundle audit reconstructs the entire base tree with exactly three changed source/support paths and verifies the current bytes.
- The command completed successfully and the one-shot lease, capsule, claim, and recorded processes were closed. The later external portal-sync timeout is retained separately; portal-sync success is not claimed.

This is unused-input cleanup validated by the existing suites, not a new auth, persistence, protocol, or security repair. No live Gateway/provider behavior or fault-injection coverage is claimed. Fresh exact-head PR CI remains required.
