### PR TITLE
fix(release): plugin previews fail with missing tooling dependencies

### DIFF
--- a/.github/workflows/plugin-clawhub-new.yml
+++ b/.github/workflows/plugin-clawhub-new.yml
@@ -212,6 +212,13 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"
 
+      - name: Install trusted plugin tooling dependencies
+        working-directory: .release-tooling
+        env:
+          CI: "true"
+        # Corepack reads this checkout's packageManager before pnpm processes arguments.
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+
       - name: Validate publishable plugin metadata
         env:
           TSX_TSCONFIG_PATH: ${{ github.workspace }}/.release-tooling/tsconfig.json

--- a/.github/workflows/plugin-clawhub-release.yml
+++ b/.github/workflows/plugin-clawhub-release.yml
@@ -302,6 +302,13 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"
 
+      - name: Install trusted plugin tooling dependencies
+        working-directory: .release-tooling
+        env:
+          CI: "true"
+        # Corepack reads this checkout's packageManager before pnpm processes arguments.
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+
       - name: Validate publishable plugin metadata
         env:
           TSX_TSCONFIG_PATH: ${{ github.workspace }}/.release-tooling/tsconfig.json

--- a/.github/workflows/plugin-npm-release.yml
+++ b/.github/workflows/plugin-npm-release.yml
@@ -324,6 +324,13 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"
 
+      - name: Install trusted plugin tooling dependencies
+        working-directory: .release-tooling
+        env:
+          CI: "true"
+        # Corepack reads this checkout's packageManager before pnpm processes arguments.
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+
       - name: Validate publishable plugin metadata
         env:
           TSX_TSCONFIG_PATH: ${{ github.workspace }}/.release-tooling/tsconfig.json
@@ -495,10 +502,6 @@ jobs:
           ref: ${{ github.workflow_sha }}
           path: .release-tooling
           fetch-depth: 1
-          sparse-checkout: |
-            packages/normalization-core
-            scripts
-            src/plugins
 
       - name: Setup Node environment
         uses: ./.github/actions/setup-node-env
@@ -506,6 +509,13 @@ jobs:
           cache-mode: restore
           node-version: ${{ env.NODE_VERSION }}
           install-bun: "false"
+
+      - name: Install trusted plugin tooling dependencies
+        working-directory: .release-tooling
+        env:
+          CI: "true"
+        # Corepack reads this checkout's packageManager before pnpm processes arguments.
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
 
       - name: Prepare immutable npm preflight artifact
         id: preflight_artifact

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2780,6 +2780,79 @@ dispatch_workflow_at_ref "$WORKFLOW_REF" "$PARENT_WORKFLOW_SHA" plugin-clawhub-r
     );
   });
 
+  it.each([
+    [
+      PLUGIN_NPM_RELEASE_WORKFLOW,
+      "preview_plugins_npm",
+      "Checkout trusted planning tooling",
+      "Validate publishable plugin metadata",
+    ],
+    [
+      PLUGIN_NPM_RELEASE_WORKFLOW,
+      "preview_plugin_pack",
+      "Checkout trusted packaging tooling",
+      "Prepare immutable npm preflight artifact",
+    ],
+    [
+      PLUGIN_CLAWHUB_RELEASE_WORKFLOW,
+      "preview_plugins_clawhub",
+      "Checkout trusted planning tooling",
+      "Validate publishable plugin metadata",
+    ],
+    [
+      ".github/workflows/plugin-clawhub-new.yml",
+      "resolve_bootstrap_plan",
+      "Checkout trusted planning tooling",
+      "Validate publishable plugin metadata",
+    ],
+  ])(
+    "initializes independent plugin tooling before %s/%s",
+    (file, jobName, checkoutName, consumerName) => {
+      const job = workflowJob(file, jobName);
+      const checkout = workflowStep(job, checkoutName);
+      const setup = workflowStep(job, "Setup Node environment");
+      const install = workflowStep(job, "Install trusted plugin tooling dependencies");
+      const consumer = workflowStep(job, consumerName);
+      expect(checkout.with).toMatchObject({
+        ref: "${{ github.workflow_sha }}",
+        path: ".release-tooling",
+        "persist-credentials": false,
+      });
+      expect(checkout.with?.["sparse-checkout"]).toBeUndefined();
+      expect(install["working-directory"]).toBe(".release-tooling");
+      expect(install.env).toMatchObject({ CI: "true" });
+      expect(install.run).toBe("pnpm install --frozen-lockfile --prefer-offline --ignore-scripts");
+      expect(job.steps!.indexOf(install)).toBeGreaterThan(job.steps!.indexOf(checkout));
+      expect(job.steps!.indexOf(install)).toBeGreaterThan(job.steps!.indexOf(setup));
+      expect(job.steps!.indexOf(install)).toBeLessThan(job.steps!.indexOf(consumer));
+      const root = tempDirs.make("plugin-tooling-install-");
+      const tooling = join(root, ".release-tooling");
+      const bin = join(root, "bin");
+      mkdirSync(tooling);
+      mkdirSync(bin);
+      writeFileSync(join(root, "candidate-sentinel"), "unchanged");
+      writeFileSync(
+        join(bin, "pnpm"),
+        `#!${process.execPath}
+const fs=require("node:fs");fs.writeFileSync("install-proof.json",JSON.stringify({cwd:process.cwd(),args:process.argv.slice(2),ci:process.env.CI}));
+`,
+        { mode: 0o755 },
+      );
+      const result = spawnSync("bash", ["-euo", "pipefail", "-c", install.run!], {
+        cwd: tooling,
+        encoding: "utf8",
+        env: { ...process.env, ...install.env, PATH: `${bin}:${process.env.PATH}` },
+      });
+      expect(result.status, result.stderr).toBe(0);
+      expect(JSON.parse(readFileSync(join(tooling, "install-proof.json"), "utf8"))).toMatchObject({
+        args: ["install", "--frozen-lockfile", "--prefer-offline", "--ignore-scripts"],
+        ci: "true",
+      });
+      expect(existsSync(join(root, "install-proof.json"))).toBe(false);
+      expect(readFileSync(join(root, "candidate-sentinel"), "utf8")).toBe("unchanged");
+    },
+  );
+
   it("runs plugin npm preflight trust from the exact workflow tooling checkout", () => {
     const job = workflowJob(PLUGIN_NPM_RELEASE_WORKFLOW, "preview_plugins_npm");
     const checkout = workflowStep(job, "Checkout trusted planning tooling");

--- a/test/scripts/plugin-clawhub-new-workflow.test.ts
+++ b/test/scripts/plugin-clawhub-new-workflow.test.ts
@@ -355,7 +355,7 @@ describe("Plugin ClawHub New workflow", () => {
     expect(materializerSource).toContain("integrity=${clawhub_integrity}");
     expect(materializerSource).toContain("cli=${clawhub_cli}");
     expect(source).not.toContain("npm exec");
-    expect(source).not.toContain("npm install");
+    expect(source).not.toMatch(/\bnpm\s+install\b/u);
     expect(source).not.toContain("CLAWHUB_CLI_PACKAGE");
     expect(source).toContain("OPENCLAW_CLAWHUB_CLI: ${{ steps.clawhub_cli.outputs.cli }}");
     expect(source).toContain('"${OPENCLAW_CLAWHUB_CLI}" package trusted-publisher set');

--- a/test/scripts/plugin-npm-extended-stable-workflow.test.ts
+++ b/test/scripts/plugin-npm-extended-stable-workflow.test.ts
@@ -323,8 +323,9 @@ describe("plugin npm extended-stable workflow", () => {
     expect(preflightCheckout.with).toMatchObject({
       ref: "${{ github.workflow_sha }}",
       path: ".release-tooling",
-      "sparse-checkout": "packages/normalization-core\nscripts\nsrc/plugins\n",
+      "persist-credentials": false,
     });
+    expect(preflightCheckout.with).not.toHaveProperty("sparse-checkout");
     const pack = step(parsed.jobs?.preview_plugin_pack, "Prepare immutable npm preflight artifact");
     expect(pack.run).toContain(".release-tooling/scripts/plugin-npm-publish.sh");
     expect(pack.run).toContain('--repo-root "$GITHUB_WORKSPACE"');


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where plugin release previews fail before packaging because the independently checked-out trusted tooling has no dependencies, even though the selected release source was installed successfully.

## Why This Change Was Made

Initialize the frozen dependency graph in `.release-tooling` before each of its four npm and ClawHub preview/planning consumers, with lifecycle scripts disabled. The npm pack preview now checks out the full trusted workspace so its lockfile, workspace packages, and patches are available to that install. The existing checkout-local loader guard stays unchanged.

## User Impact

Release operators can complete plugin previews using the selected release source and trusted publisher tooling. This changes publisher preparation only; it does not rebuild core, alter the qualified release artifacts, or publish packages.

## Evidence

- Reproduced the missing-dependencies error from the actual trusted TSX loader before the independent install; the same loader succeeds afterward.
- Ran the real nonpublishing `--pack extensions/acpx` flow against unchanged release source `1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7`, with independently installed candidate/tooling checkouts and publication tokens removed. The package-local runtime build, lockfile check, and npm pack completed successfully on Node 24.20.0. Neither checkout built core or changed tracked candidate files.
- Four consumer regressions execute the install command and verify checkout ownership, ordering, frozen lockfile, and disabled lifecycle scripts. Focused workflow tests passed, as did the ClawHub and Git lifecycle sibling tests; the existing npm-command guard now distinguishes `npm install` from `pnpm install`.
- Workflow validation, scoped changed checks, affected test lint, and independent P2 review passed. Hosted exact-head CI remains required before landing.
