### PR TITLE
fix(release): pin Kova census refresh

### DIFF
--- a/.github/workflows/openclaw-performance.yml
+++ b/.github/workflows/openclaw-performance.yml
@@ -88,9 +88,9 @@ env:
   OCM_VERSION: v0.2.33
   OCM_LINUX_X64_SHA256: 06b0e46791e750eb044e4a898b6643ad5e7b20224fe0c64f160e35a42f08d00a
   KOVA_REPOSITORY: openclaw/Kova
-  KOVA_CANONICAL_CONFIG_REF: 11b56553e4c4e93ddf99a53617a139b2c9e9efef
-  KOVA_LEGACY_LIST_CONFIG_REF: 11b56553e4c4e93ddf99a53617a139b2c9e9efef
-  KOVA_TRUSTED_LIVE_REF: 11b56553e4c4e93ddf99a53617a139b2c9e9efef
+  KOVA_CANONICAL_CONFIG_REF: cf6e26f0ca1241c9e7a626e96e66f392ff58012d
+  KOVA_LEGACY_LIST_CONFIG_REF: cf6e26f0ca1241c9e7a626e96e66f392ff58012d
+  KOVA_TRUSTED_LIVE_REF: cf6e26f0ca1241c9e7a626e96e66f392ff58012d
   PERFORMANCE_MODEL_ID: gpt-5.6-luna
   # Release matrices cold-build the candidate runtime before measurement.
   KOVA_SCENARIO_TIMEOUT_MS: ${{ inputs.profile == 'release' && '900000' || '300000' }}
@@ -161,7 +161,7 @@ jobs:
               # Kova #116 carries the historical 250% status CLI calibration for this release only;
               # Kova #118 keeps process-census time out of CPU scan uncertainty;
               # Kova #119 discovers a starting gateway before its zero baseline is lost.
-              kova_ref="11b56553e4c4e93ddf99a53617a139b2c9e9efef"
+              kova_ref="cf6e26f0ca1241c9e7a626e96e66f392ff58012d"
             fi
           fi
           if [[ "$kova_ref" == *$'\n'* || "$kova_ref" == *$'\r'* ]]; then

--- a/test/scripts/openclaw-performance-workflow.test.ts
+++ b/test/scripts/openclaw-performance-workflow.test.ts
@@ -240,9 +240,9 @@ describe("OpenClaw performance workflow", () => {
 
   it("pins the Kova evaluator with release validation contracts", () => {
     const workflow = readFileSync(WORKFLOW, "utf8");
-    const canonicalKovaRef = "11b56553e4c4e93ddf99a53617a139b2c9e9efef";
-    const legacyKovaRef = "11b56553e4c4e93ddf99a53617a139b2c9e9efef";
-    const trustedLiveKovaRef = "11b56553e4c4e93ddf99a53617a139b2c9e9efef";
+    const canonicalKovaRef = "cf6e26f0ca1241c9e7a626e96e66f392ff58012d";
+    const legacyKovaRef = "cf6e26f0ca1241c9e7a626e96e66f392ff58012d";
+    const trustedLiveKovaRef = "cf6e26f0ca1241c9e7a626e96e66f392ff58012d";
     const install = findStep("Install OCM and Kova");
     const installRun = install.run ?? "";
     const targetCheckout = findStep("Checkout target metadata", "resolve_target");
@@ -277,7 +277,7 @@ describe("OpenClaw performance workflow", () => {
     expect(resolveTarget.run).toContain('detected_kova_config_contract="canonical"');
     expect(resolveTarget.run).toContain('detected_kova_config_contract="legacy-list"');
     expect(resolveTarget.run).toContain('kova_ref="${KOVA_REF_INPUT:-}"');
-    expect(resolveTarget.run).toContain('kova_ref="11b56553e4c4e93ddf99a53617a139b2c9e9efef"');
+    expect(resolveTarget.run).toContain('kova_ref="cf6e26f0ca1241c9e7a626e96e66f392ff58012d"');
     expect(resolveTarget.run).toContain('kova_ref="${kova_ref:-$default_kova_ref}"');
     expect(resolveTarget.run).toContain(
       'if [[ -z "$kova_ref" || -z "$kova_config_contract" ]]; then',


### PR DESCRIPTION
## Summary
- pin OpenClaw performance validation to Kova #120
- update canonical, legacy-list, trusted-live, and 2026.7.33 special-case refs together
- keep workflow contract tests bound to the exact upstream commit

## Why

[Kova #120](https://github.com/openclaw/Kova/pull/120) closes the remaining gateway census/PID-discovery race seen in [proof run 34211366482](https://github.com/openclaw/openclaw/actions/runs/34211366482). Kova #119 reduced the selected matrix from 12 blockers to 2, but repeat 3 of fresh install and bundled plugin startup still first observed the gateway one interval late.

## Validation
- `node scripts/run-vitest.mjs run --config test/vitest/vitest.tooling.config.ts test/scripts/openclaw-performance-workflow.test.ts` (42/42 passed)
