### PR TITLE
refactor(tests): remove unused database setup from recall timeout case

### DIFF
--- a/extensions/memory-lancedb/index.test.ts
+++ b/extensions/memory-lancedb/index.test.ts
@@ -1254,18 +1254,7 @@ describe("memory plugin e2e", () => {
     vi.useFakeTimers();
     const ensureGlobalUndiciEnvProxyDispatcher = vi.fn();
     const post = vi.fn(() => new Promise(() => {}));
-    const loadLanceDbModule = vi.fn(async () => ({
-      connect: vi.fn(async () => ({
-        tableNames: vi.fn(async () => ["memories"]),
-        openTable: vi.fn(async () => ({
-          schema: createAgentScopedSchemaMock(),
-          vectorSearch: vi.fn(),
-          countRows: vi.fn(async () => 0),
-          add: vi.fn(async () => undefined),
-          delete: vi.fn(async () => undefined),
-        })),
-      })),
-    }));
+    const loadLanceDbModule = vi.fn(async () => undefined);
 
     try {
       await withMockedOpenAiMemoryPlugin({


### PR DESCRIPTION
## What Problem This Solves

The never-settling embedding test carries a complete mock database implementation even though both calls explicitly require that the database loader is never invoked.

## Why This Change Was Made

Replace that unused implementation with a fresh asynchronous spy. Embedding must finish before recall can search the database; this case instead times out and then returns the cooldown result. Both zero-load assertions remain, so an unexpected database load still fails the test.

## User Impact

No production behavior changes. Removes 11 lines of unused test setup while retaining every case, assertion, timeout, and cleanup action.

## Evidence

- The complete Memory-LanceDB index suite passes 189/189 before and after, with identical ordered case names and results and no skips.
- Every byte outside the single initializer replacement is unchanged.
- The mapped changed gate and fresh independent P2 review pass with no findings.

No runtime savings are claimed.
