### PR TITLE
fix(cli): report JSON-mode command failures as command failures, not startup failures

### DIFF
--- a/src/entry.run-main.test.ts
+++ b/src/entry.run-main.test.ts
@@ -16,6 +16,48 @@ describe("entry run-main boundary", () => {
     });
   });
 
+  it("frames a command-phase failure as a command failure, not a startup failure", async () => {
+    const previousExitCode = process.exitCode;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.exitCode = undefined;
+    try {
+      await runMainOrRootHelp(["node", "openclaw", "onboard", "recommendations"], {
+        loadRunCli: async () => ({
+          runCli: vi.fn(async () => {
+            throw new Error(
+              "Multiple agents are configured, but this operation has no explicit owner.",
+            );
+          }),
+        }),
+      });
+      expect(process.exitCode).toBe(1);
+      expect(errorSpy).toHaveBeenCalledWith("[openclaw] The CLI command failed.");
+      expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("Could not start the CLI"));
+    } finally {
+      errorSpy.mockRestore();
+      process.exitCode = previousExitCode;
+    }
+  });
+
+  it("frames a failure before the command runs as a startup failure", async () => {
+    const previousExitCode = process.exitCode;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    process.exitCode = undefined;
+    try {
+      await runMainOrRootHelp(["node", "openclaw", "status"], {
+        loadRunCli: async () => {
+          throw new Error("cannot load run-main");
+        },
+      });
+      expect(process.exitCode).toBe(1);
+      expect(errorSpy).toHaveBeenCalledWith("[openclaw] Could not start the CLI.");
+      expect(errorSpy).not.toHaveBeenCalledWith(expect.stringContaining("The CLI command failed"));
+    } finally {
+      errorSpy.mockRestore();
+      process.exitCode = previousExitCode;
+    }
+  });
+
   it("keeps expected conditions at exit 1 without crash framing", async () => {
     const previousExitCode = process.exitCode;
     const message =

--- a/src/entry.ts
+++ b/src/entry.ts
@@ -283,6 +283,9 @@ export async function runMainOrRootHelp(
   argv: string[],
   deps: RunMainOrRootHelpDeps = {},
 ): Promise<void> {
+  // Command-phase errors reach this handler too: runCommandWithRuntime rethrows in JSON
+  // mode so the envelope is written here. Only failures before runCli are startup failures.
+  let commandStarted = false;
   await runCliWithExitFinalization({
     run: async () => {
       if (isNativeHookRelayArgv(argv) && !argv.includes("--help") && !argv.includes("-h")) {
@@ -304,6 +307,7 @@ export async function runMainOrRootHelp(
         "run-main-import",
         deps.loadRunCli ?? (() => import("./cli/run-main.js")),
       );
+      commandStarted = true;
       await runCli(argv, {
         additionalStartupTrace: gatewayEntryStartupTrace,
         // Finalizers and process-exit hooks can still emit diagnostics after runCli settles.
@@ -322,7 +326,7 @@ export async function runMainOrRootHelp(
         defaultRuntime.writeJson(formatCliJsonFailure(error));
       }
       for (const line of formatCliFailureLines({
-        title: "Could not start the CLI.",
+        title: commandStarted ? "The CLI command failed." : "Could not start the CLI.",
         error,
         argv,
       })) {


### PR DESCRIPTION
## What Problem This Solves

With `--json`, an ordinary command error is reported as a startup failure. Live on the built CLI at `53cac8a36e8` with two configured agents:

```
$ openclaw onboard recommendations --json
{ "ok": false, "error": { "type": "cli_error", "message": "Multiple agents are configured, but this operation has no explicit owner. …" } }
[openclaw] Could not start the CLI.
[openclaw] Reason: Multiple agents are configured, but this operation has no explicit owner. …
[openclaw] Debug: set OPENCLAW_DEBUG=1 to include the stack trace.
[openclaw] Try: openclaw doctor
```

Without `--json` the same command prints only the message (exit 1). The CLI started fine; the operator is sent to `doctor` for a usage error.

## Why This Change Was Made

`runCommandWithRuntime` (`src/cli/cli-utils.ts`) deliberately rethrows in JSON mode so the entry writes the envelope centrally. The entry (`src/entry.ts`, `runMainOrRootHelp`) wraps both the `run-main` import and `runCli` in a single `onError` whose title is the startup one. The legacy entry in `src/index.ts` already distinguishes this case with "The CLI command failed.", and `failure-output.test.ts` pins that title's semantics. The fix records whether `runCli` began and picks the title accordingly; nothing else in the handler changes (envelope, debug hint, doctor hint, exit code).

Owner boundary: the entry handler owns phase classification; command-level JSON handling (`config`, `agents`, …) is untouched.

## User Impact

JSON-mode command errors now read "The CLI command failed." with the same reason line; failures before the command runs (a broken `run-main` import) still read "Could not start the CLI.". Exit codes and the JSON envelope are unchanged.

## Evidence

- Live before/after on the built CLI in an isolated state dir with two agents (`main`, `analyst`): `onboard recommendations --json` → startup banner before, command-failure banner after; the non-JSON form unchanged.
- `src/entry.run-main.test.ts`: two new cases — a command-phase throw must produce "The CLI command failed." and never "Could not start the CLI"; a `loadRunCli` rejection must produce "Could not start the CLI." and never the command title. The command-phase case fails on the unfixed `entry.ts`.
- `src/cli/failure-output.test.ts` and the entry tests pass; `check-changed` on the two files passes.

Production LOC: +4 (a flag, its set, the title ternary, one comment).

Review: independent Codex autoreview (local mode, P0–P2) is scoped-clean with no actionable findings.
