### PR TITLE
fix(cli): --url without credentials was framed as a CLI startup crash

### DIFF
--- a/src/cli/failure-output.test.ts
+++ b/src/cli/failure-output.test.ts
@@ -1,6 +1,10 @@
 // Failure output tests cover CLI error formatting and failure summaries.
 import { describe, expect, it } from "vitest";
-import { GatewayCredentialsRequiredError, GatewayTransportError } from "../gateway/call.js";
+import {
+  GatewayCredentialsRequiredError,
+  GatewayExplicitAuthRequiredError,
+  GatewayTransportError,
+} from "../gateway/call.js";
 import { UpdateSchemaRefusalError } from "../state/openclaw-update-schema-refusal.js";
 import {
   ExpectedCliError,
@@ -11,6 +15,14 @@ import {
 
 const PLUGIN_POLICY_MESSAGE =
   'The `openclaw workboard` command is provided by the "workboard" plugin, but that bundled plugin is disabled by default. Run `openclaw plugins enable workboard` to enable that CLI surface.';
+
+// Mirrors the producer in ensureExplicitGatewayAuth: the message already carries the remedy.
+const EXPLICIT_GATEWAY_AUTH_MESSAGE = [
+  "gateway url override requires explicit credentials",
+  "Fix: pass --token or --password with --url (or gatewayToken in tools).",
+  "For the default local or SSH-tunneled Gateway, remove --url to use the configured target.",
+  "Config: /tmp/openclaw.json",
+].join("\n");
 
 describe("formatCliJsonFailure", () => {
   it("preserves the typed schema refusal when a runner migration fails before Doctor starts", () => {
@@ -121,6 +133,26 @@ describe("formatCliJsonFailure", () => {
       },
     });
   });
+
+  it.each([
+    { label: "default output", env: {} },
+    { label: "debug output", env: { OPENCLAW_DEBUG: "1" } },
+  ])("keeps explicit gateway auth guidance in the envelope in $label", ({ env }) => {
+    const error = new GatewayExplicitAuthRequiredError(EXPLICIT_GATEWAY_AUTH_MESSAGE);
+
+    const payload = formatCliJsonFailure(error, { env });
+
+    expect(payload).toEqual({
+      ok: false,
+      error: {
+        type: "cli_error",
+        message: expect.stringContaining("gateway url override requires explicit credentials"),
+      },
+    });
+    // The shared machine-output redaction still applies; the remedy lines survive it.
+    expect(payload.error.message).toContain("remove --url to use the configured target.");
+    expect(payload.error.message).toContain("Config: /tmp/openclaw.json");
+  });
 });
 
 describe("formatCliFailureLines", () => {
@@ -183,6 +215,10 @@ describe("formatCliFailureLines", () => {
           method: "device.pair.list",
           configPath: "/tmp/openclaw.json",
         }),
+    },
+    {
+      label: "gateway URL override without explicit credentials",
+      createError: () => new GatewayExplicitAuthRequiredError(EXPLICIT_GATEWAY_AUTH_MESSAGE),
     },
     {
       label: "unreachable gateway",

--- a/src/cli/failure-output.ts
+++ b/src/cli/failure-output.ts
@@ -78,10 +78,17 @@ export function isGatewayCredentialsCliError(
   );
 }
 
+function isGatewayExplicitAuthCliError(error: unknown): error is Error {
+  // Same lean structural classification as the credentials preflight above: the
+  // producer message already carries the complete --url/--token remedy.
+  return error instanceof Error && error.name === "GatewayExplicitAuthRequiredError";
+}
+
 export function isExpectedCliError(error: unknown): error is Error {
   return (
     error instanceof ExpectedCliError ||
     isGatewayCredentialsCliError(error) ||
+    isGatewayExplicitAuthCliError(error) ||
     isGatewayTransportError(error)
   );
 }

--- a/src/cli/gateway-backed-exit.process.test.ts
+++ b/src/cli/gateway-backed-exit.process.test.ts
@@ -25,6 +25,7 @@ import {
   snapshotDirectoryContents,
   snapshotSharedStateArtifacts,
   tempDirs,
+  UNREACHABLE_GATEWAY_URL,
 } from "./gateway-backed-exit.process.test-support.js";
 import {
   EMPTY_STABILITY_SNAPSHOT,
@@ -761,6 +762,55 @@ describe("gateway-backed CLI process exit", () => {
         }
         await lock?.release();
       }
+    },
+  );
+
+  it.each([
+    { label: "devices list", args: ["devices", "list"], machineOutput: false },
+    { label: "devices list --json", args: ["devices", "list", "--json"], machineOutput: true },
+    { label: "nodes status", args: ["nodes", "status"], machineOutput: false },
+    { label: "nodes status --json", args: ["nodes", "status", "--json"], machineOutput: true },
+  ])(
+    "renders a $label URL override without explicit credentials as expected guidance, not a crash",
+    async ({ label, args, machineOutput }) => {
+      const root = tempDirs.make(`openclaw-${label.replaceAll(/[ -]+/g, "-")}-explicit-auth-`);
+      // Configured credentials must not leak to a caller-supplied URL; the producer
+      // rejects the override before any socket opens, so the target never listens.
+      const { stateDir, configPath } = await prepareGatewayCliFixture(root, {
+        mode: "local",
+        auth: { mode: "token", token: "configured-token" },
+      });
+
+      const result = await runIsolatedGatewayCli({
+        args: [...args, "--url", UNREACHABLE_GATEWAY_URL, "--timeout", "250"],
+        root,
+        stateDir,
+        configPath,
+      });
+
+      expect(result).toMatchObject({ code: 1, signal: null });
+      if (machineOutput) {
+        expect(JSON.parse(result.stdout)).toEqual({
+          ok: false,
+          error: {
+            type: "cli_error",
+            message: expect.stringContaining("gateway url override requires explicit credentials"),
+          },
+        });
+      } else {
+        expect(result.stdout).toBe("");
+      }
+      expect(result.stderr).toContain("gateway url override requires explicit credentials");
+      // The shared console redaction masks the word after "--password"; assert around it.
+      expect(result.stderr).toContain("Fix: pass --token or --password");
+      expect(result.stderr).toContain("--url (or gatewayToken in tools).");
+      expect(result.stderr).toContain("remove --url to use the configured target.");
+      expect(result.stderr).toContain(`Config: ${configPath}`);
+      expect(result.stderr).not.toContain("The CLI command failed");
+      expect(result.stderr).not.toContain("Could not start the CLI");
+      expect(result.stderr).not.toContain("OPENCLAW_DEBUG");
+      expect(result.stderr).not.toContain("Stack:");
+      expect(result.stderr).not.toContain("openclaw doctor");
     },
   );
 


### PR DESCRIPTION
Closes #142111.

## What Problem This Solves

When `--url` or `OPENCLAW_GATEWAY_URL` lacks matching explicit credentials, the CLI now prints the existing credential remedy directly. It no longer adds a command/startup failure banner or unrelated Doctor, debug, and help hints.

## Why This Change Was Made

The change extends the shared expected-error predicate without importing the Gateway client. Credential enforcement, producer messages, exit code 1, and the canonical `cli_error` JSON structure remain intact. Human `nodes` commands now use that shared path. Command-owned machine error formats retain their existing handling. This builds on #125007, #125304, and #125556.

## User Impact

Operators get the existing credential remedy without misleading crash advice. Credential rejection, exit status, and machine output remain intact.

## Evidence

Verified full source CLI entry processes on pinned main `6e55c1df` and candidate `e785a1b6`, using isolated synthetic configuration and a loopback connection observer with no Gateway service:

- Nine missing-credential cases made zero connections. Human stdout stayed empty; stderr contained the complete remedy. JSON contained one canonical error object.
- Explicit token, password, and matching environment-token controls each reached the connection observer once, then reported the normal transport failure.
- Devices, nodes, environment URL, debug, JSON, and credential-shaped text masking passed independent behavior acceptance. The masking control preserves the remedy; it does not promise an identical replacement string.
- 22 shared-renderer tests and four entry-boundary controls passed on the current head. Four full-entry regressions passed on the original candidate; unchanged regression/producer inputs and fresh current-head CLI proof justify reuse after the contributor rebase. Three process cases and the added classification unit case failed on pinned main for the intended reason.
- Focused formatting, syntax lint, line/assertion checks, and `git diff --check` passed. Full CI owns broad typechecks and suites. Fresh independent AutoReview found no actionable findings.

Example candidate stderr (config path normalized):

```text
gateway url override requires explicit credentials
Fix: pass --token or --password *** --url (or gatewayToken in tools).
For the default local or SSH-tunneled Gateway, remove --url to use the configured target.
Config: <isolated-config>
```

The `***` in the remedy is existing console redaction. No live Gateway, external credential, or production state was used.

Implementation and regression coverage by @DasX. AI-assisted verification.

CI history: the original head hit a Matrix native-addon download HTTP500. A stale-head rerun collided with the PR concurrency group and cancelled the first rebased run; both attempts were reconciled before one current-head rerun. [Current-head run34223670630, attempt2](https://github.com/openclaw/openclaw/actions/runs/34223670630/attempts/2) completed with one child failure: a120-second timeout in Telegram sticker model selection ([job102058607784](https://github.com/openclaw/openclaw/actions/runs/34223670630/job/102058607784)). All other children passed or skipped. This is recorded separately from the CLI behavior proof; it is not reported as green CI.

CI causality was checked against a later natural recurrence: [run34228376739, job102069062439](https://github.com/openclaw/openclaw/actions/runs/34228376739/job/102069062439) timed out in the same first MiniMax case at128626ms. Its tested merge `4f921a82` has the old CLI classifier and neither added CLI test, with unchanged relevant selector, loader, setup, and lock source. It ran the same selected file order on different Node, CPU, memory, and cache inputs. This is independent recurrence evidence, not a matching main-push run or exact main A/B experiment.

The changed predicate runs only in CLI error handling and adds no import or initialization work to the failing selection path. The retained main profile also measures expensive plugin loading. Together these establish that the failed child is unrelated to this patch; the exact original157482ms duration remains unattributed. The original CI restored its Node compile cache; only its transform-cache restore missed. Main-only comparisons used fresh Node caches and do not reproduce that cache state. Any landing exception uses the guarded, exact-run approval path.
