### PR TITLE
fix(ci): keep mobile release source checks clean

### DIFF
--- a/.github/workflows/android-beta-release.yml
+++ b/.github/workflows/android-beta-release.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.workflow_sha }}
-          path: .mobile-release-authority
+          path: apps/android/build/mobile-release-ci/authority
           persist-credentials: false
           fetch-depth: 0
           sparse-checkout: |
@@ -164,7 +164,7 @@ jobs:
           test "$(bundle _2.6.9_ exec ruby -e 'require "fastlane"; print Fastlane::VERSION')" = "2.238.0"
 
       - name: Revalidate release authority immediately before signing access
-        uses: ./.mobile-release-authority/.github/actions/mobile-release-authority
+        uses: ./apps/android/build/mobile-release-ci/authority/.github/actions/mobile-release-authority
         with:
           operation: revalidate
           platform: android
@@ -186,7 +186,7 @@ jobs:
           permission-contents: read
 
       - name: Revalidate release authority immediately before Android signing checkout
-        uses: ./.mobile-release-authority/.github/actions/mobile-release-authority
+        uses: ./apps/android/build/mobile-release-ci/authority/.github/actions/mobile-release-authority
         with:
           operation: revalidate
           platform: android
@@ -207,7 +207,7 @@ jobs:
           persist-credentials: false
 
       - name: Revalidate release authority immediately before Android signing materialization
-        uses: ./.mobile-release-authority/.github/actions/mobile-release-authority
+        uses: ./apps/android/build/mobile-release-ci/authority/.github/actions/mobile-release-authority
         with:
           operation: revalidate
           platform: android
@@ -227,7 +227,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.workflow_sha }}
-          path: .mobile-release-sink
+          path: apps/android/build/mobile-release-ci/sink
           persist-credentials: false
           fetch-depth: 0
           sparse-checkout: |
@@ -240,7 +240,7 @@ jobs:
             apps/ios/CHANGELOG.md
 
       - name: Revalidate release authority immediately before upload
-        uses: ./.mobile-release-sink/.github/actions/mobile-release-authority
+        uses: ./apps/android/build/mobile-release-ci/sink/.github/actions/mobile-release-authority
         with:
           operation: revalidate
           platform: android

--- a/.github/workflows/ios-beta-release.yml
+++ b/.github/workflows/ios-beta-release.yml
@@ -117,7 +117,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.workflow_sha }}
-          path: .mobile-release-authority
+          path: apps/ios/build/mobile-release-ci/authority
           persist-credentials: false
           fetch-depth: 0
           sparse-checkout: |
@@ -135,7 +135,7 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Revalidate release authority immediately before signing access
-        uses: ./.mobile-release-authority/.github/actions/mobile-release-authority
+        uses: ./apps/ios/build/mobile-release-ci/authority/.github/actions/mobile-release-authority
         with:
           operation: revalidate
           platform: ios
@@ -157,7 +157,7 @@ jobs:
           permission-contents: read
 
       - name: Revalidate release authority immediately before iOS signing checkout
-        uses: ./.mobile-release-authority/.github/actions/mobile-release-authority
+        uses: ./apps/ios/build/mobile-release-ci/authority/.github/actions/mobile-release-authority
         with:
           operation: revalidate
           platform: ios
@@ -233,7 +233,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.workflow_sha }}
-          path: .mobile-release-sink
+          path: apps/ios/build/mobile-release-ci/sink
           persist-credentials: false
           fetch-depth: 0
           sparse-checkout: |
@@ -246,7 +246,7 @@ jobs:
             apps/ios/CHANGELOG.md
 
       - name: Revalidate release authority immediately before upload
-        uses: ./.mobile-release-sink/.github/actions/mobile-release-authority
+        uses: ./apps/ios/build/mobile-release-ci/sink/.github/actions/mobile-release-authority
         with:
           operation: revalidate
           platform: ios

--- a/test/scripts/mobile-release-authority.test.ts
+++ b/test/scripts/mobile-release-authority.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parse } from "yaml";
+import { verifyAndroidReleaseSource } from "../../apps/android/scripts/build-release-artifacts.ts";
 import {
   mobileReleasePlanDigest,
   writeMobileReleaseIntent,
@@ -1490,6 +1491,7 @@ describe("mobile release authority", () => {
   it("keeps upload and recovery credentials inside one protected platform boundary", () => {
     const workflows = [
       {
+        authorityRoot: "apps/ios/build/mobile-release-ci",
         environment: "ios-beta-release",
         file: ".github/workflows/ios-beta-release.yml",
         name: "iOS Beta Release",
@@ -1502,6 +1504,7 @@ describe("mobile release authority", () => {
         setupBeforeSigning: [],
       },
       {
+        authorityRoot: "apps/android/build/mobile-release-ci",
         environment: "android-beta-release",
         file: ".github/workflows/android-beta-release.yml",
         name: "Android Beta Release",
@@ -1522,6 +1525,7 @@ describe("mobile release authority", () => {
     ] as const;
 
     for (const {
+      authorityRoot,
       environment,
       file,
       name,
@@ -1587,6 +1591,16 @@ describe("mobile release authority", () => {
       expect(release.if).toBe(
         "inputs.operation == 'upload-and-record' && needs.authorize.outputs.approved == 'true'",
       );
+      const authorityCheckout = release.steps.find(
+        (step) => step.name === "Checkout trusted mobile release authority",
+      );
+      const sinkCheckout = release.steps.find(
+        (step) => step.name === "Refresh trusted authority before store access",
+      );
+      expect(authorityCheckout?.with?.path).toBe(`${authorityRoot}/authority`);
+      expect(sinkCheckout?.with?.path).toBe(`${authorityRoot}/sink`);
+      expect(source).not.toContain(".mobile-release-authority");
+      expect(source).not.toContain(".mobile-release-sink");
       const signingRevalidateIndex = release.steps.findIndex(
         (step) => step.name === "Revalidate release authority immediately before signing access",
       );
@@ -1631,7 +1645,7 @@ describe("mobile release authority", () => {
       }
       for (const stepIndex of signingAuthorityIndexes) {
         expect(release.steps[stepIndex]?.uses, `${file}:${stepIndex}:uses`).toBe(
-          "./.mobile-release-authority/.github/actions/mobile-release-authority",
+          `./${authorityRoot}/authority/.github/actions/mobile-release-authority`,
         );
         expect(release.steps[stepIndex]?.with, `${file}:${stepIndex}:with`).toEqual({
           "authority-run-id": "${{ needs.authorize.outputs.run_id }}",
@@ -1665,6 +1679,9 @@ describe("mobile release authority", () => {
       );
       expect(revalidateIndex).toBeGreaterThan(-1);
       expect(uploadIndex).toBe(revalidateIndex + 1);
+      expect(release.steps[revalidateIndex]?.uses).toBe(
+        `./${authorityRoot}/sink/.github/actions/mobile-release-authority`,
+      );
       expect(intentIndex).toBeGreaterThan(uploadIndex);
       expect(recorderIndex).toBeGreaterThan(intentIndex);
       expect(recordIndex).toBeGreaterThan(recorderIndex);
@@ -1773,6 +1790,103 @@ describe("mobile release authority", () => {
       expect(source).not.toContain("workflow_run");
       expect(source).not.toContain("secrets.MOBILE_RELEASE_REF_TOKEN");
       expect(source).toContain("release/YYYY.M.PATCH-mobile");
+    }
+  });
+
+  it("keeps trusted pre-upload helper checkouts outside release source dirt", () => {
+    const workflows = [
+      {
+        file: ".github/workflows/ios-beta-release.yml",
+        platform: "ios",
+      },
+      {
+        file: ".github/workflows/android-beta-release.yml",
+        platform: "android",
+      },
+    ] as const;
+
+    for (const { file, platform } of workflows) {
+      const source = fs.readFileSync(file, "utf8");
+      const workflow = parse(source) as {
+        jobs: {
+          release: {
+            steps: Array<{
+              name: string;
+              with?: { path?: string };
+            }>;
+          };
+        };
+      };
+      const authorityPath = workflow.jobs.release.steps.find(
+        (step) => step.name === "Checkout trusted mobile release authority",
+      )?.with?.path;
+      const sinkPath = workflow.jobs.release.steps.find(
+        (step) => step.name === "Refresh trusted authority before store access",
+      )?.with?.path;
+      if (!authorityPath || !sinkPath) {
+        throw new Error(`${file}: missing pre-upload helper checkout path`);
+      }
+
+      const repository = tempRoots.make(`openclaw-mobile-release-source-${platform}-`);
+      git(repository, "init");
+      git(repository, "config", "user.email", "release-test@openclaw.invalid");
+      git(repository, "config", "user.name", "OpenClaw Release Test");
+      copyFile(repository, ".gitignore");
+      copyFile(repository, "apps/android/.gitignore");
+      writeFile(repository, "tracked.txt", "clean\n");
+      const expectedCommit = commit(repository, "test: create release source");
+
+      for (const helperPath of [authorityPath, sinkPath]) {
+        writeFile(
+          repository,
+          path.join(helperPath, ".github/actions/mobile-release-authority/action.yml"),
+          "name: trusted helper\n",
+        );
+      }
+
+      const verifyAppleSource = () =>
+        spawnSync(
+          "/bin/bash",
+          [
+            "scripts/apple-release-source-check.sh",
+            "--root",
+            repository,
+            "--expected-commit",
+            expectedCommit,
+          ],
+          { cwd: process.cwd(), encoding: "utf8" },
+        );
+      const expectCleanSource = () => {
+        expect(() =>
+          verifyAndroidReleaseSource(expectedCommit, { rootDir: repository }),
+        ).not.toThrow();
+        const apple = verifyAppleSource();
+        expect(apple.status, apple.stderr).toBe(0);
+      };
+      const expectDirtySource = () => {
+        expect(() => verifyAndroidReleaseSource(expectedCommit, { rootDir: repository })).toThrow(
+          "Android release builds require a clean Git checkout",
+        );
+        const apple = verifyAppleSource();
+        expect(apple.status).toBe(1);
+        expect(apple.stderr).toContain("Apple release builds require a clean Git checkout.");
+      };
+
+      expectCleanSource();
+      writeFile(repository, "unrelated.txt", "dirty\n");
+      expectDirtySource();
+      fs.unlinkSync(path.join(repository, "unrelated.txt"));
+
+      writeFile(repository, "tracked.txt", "dirty\n");
+      expectDirtySource();
+      writeFile(repository, "tracked.txt", "clean\n");
+
+      writeFile(
+        repository,
+        ".mobile-release-authority/.github/actions/mobile-release-authority/action.yml",
+        "name: obsolete root helper\n",
+      );
+      expectDirtySource();
     }
   });
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where the protected iOS and Android beta workflows would make the approved release checkout appear dirty before store upload because trusted authority helper checkouts were staged at the repository root.

## Why This Change Was Made

The pre-upload authority and sink checkouts now live under each platform's existing ignored build directory. Trusted workflow-SHA pinning, authority revalidation, signing-secret placement, upload ordering, intent recording, and immutable release-ref behavior are unchanged.

## User Impact

Release operators can run the guarded mobile beta workflows without their trusted helper checkouts tripping the Android or Apple clean-source enforcement. Unrelated tracked or untracked source changes still fail closed.

## Evidence

- Red regression: the unchanged workflow failed the real Android source verifier with `Android release builds require a clean Git checkout`.
- Green authority/workflow suite: 51/51.
- Android release-artifact sibling suite: 11/11.
- Apple source-checker sibling suite: 3/3.
- Real temporary Git fixtures prove both platform checkers accept the relocated helpers and reject unrelated tracked changes, untracked files, and the obsolete repository-root helper layout.
- `pnpm check:workflows` passed with its temporary Python 3.13 environment; standalone `actionlint`, `oxfmt`, `oxlint`, and `git diff --check` passed.
- Independent P1 autoreview found no actionable findings, confidence 0.96.
- Workflow production delta is net zero; focused regression coverage is +114 net lines.
- The mobile release candidate remains unchanged. No workflow was dispatched and no credentials or stores were accessed.
