### PR TITLE
refactor: strengthen Feishu permission breaker coverage

### DIFF
--- a/extensions/feishu/src/bot-name.test.ts
+++ b/extensions/feishu/src/bot-name.test.ts
@@ -46,18 +46,27 @@ describe("resolveFeishuBotName", () => {
     expect(requestMock).toHaveBeenCalledTimes(1);
   });
 
-  it("does not open the breaker for repeated missing-scope responses", async () => {
+  it.each([
+    ["does not open the breaker for repeated missing-scope responses", true],
+    ["does not open the breaker for resolved missing-scope envelopes", false],
+  ] as const)("%s", async (_name, rejects) => {
     vi.useFakeTimers();
     vi.setSystemTime(0);
-    const scopeError = Object.assign(new Error("scope missing"), {
-      response: { data: { code: 99991672 } },
-    });
-    requestMock.mockRejectedValue(scopeError);
+    if (rejects) {
+      const scopeError = Object.assign(new Error("scope missing"), {
+        response: { data: { code: 99991672 } },
+      });
+      requestMock.mockRejectedValue(scopeError);
+    } else {
+      requestMock.mockResolvedValue({ code: 99991672, msg: "permission denied" });
+    }
 
     for (let index = 0; index < 10; index += 1) {
       await resolveFeishuBotName({ account, openId: `ou_missing_${index}`, log });
+      await resolveFeishuBotName({ account, openId: `ou_suppressed_${index}`, log });
+      expect(requestMock).toHaveBeenCalledTimes(index + 1);
+      vi.advanceTimersByTime(60_001);
     }
-    vi.advanceTimersByTime(60_001);
     requestMock.mockResolvedValueOnce({
       code: 0,
       data: { bots: { ou_available: { name: "Available" } } },
@@ -66,27 +75,7 @@ describe("resolveFeishuBotName", () => {
     await expect(resolveFeishuBotName({ account, openId: "ou_available", log })).resolves.toBe(
       "Available",
     );
-    expect(requestMock).toHaveBeenCalledTimes(2);
-  });
-
-  it("does not open the breaker for resolved missing-scope envelopes", async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(0);
-    requestMock.mockResolvedValue({ code: 99991672, msg: "permission denied" });
-
-    for (let index = 0; index < 10; index += 1) {
-      await resolveFeishuBotName({ account, openId: `ou_missing_${index}`, log });
-    }
-    vi.advanceTimersByTime(60_001);
-    requestMock.mockResolvedValueOnce({
-      code: 0,
-      data: { bots: { ou_available: { name: "Available" } } },
-    });
-
-    await expect(resolveFeishuBotName({ account, openId: "ou_available", log })).resolves.toBe(
-      "Available",
-    );
-    expect(requestMock).toHaveBeenCalledTimes(2);
+    expect(requestMock).toHaveBeenCalledTimes(11);
   });
 
   it("deduplicates concurrent lookups for one account and bot", async () => {


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The missing-scope breaker tests made ten lookup attempts at the same instant, but account-wide permission backoff admitted only one actual response. They could pass even if permission responses incorrectly counted toward the breaker threshold.

## Why This Change Was Made

Keep the rejected SDK error and resolved-envelope cases as two explicitly named table rows. Each now admits ten permission responses across expired backoff windows, verifies a distinct bot lookup stays suppressed within each window, and requires successful recovery afterward. The shared body removes duplication while strengthening the original contract.

## User Impact

No production behavior changes. All four original cases, names, order, module resets, and account lifetime remain. The change removes 11 test lines; no runtime improvement is claimed.

## Evidence

- Original suite: four passed. Adding failure accounting inside the permission branch while retaining backoff still passed all four old tests.
- Strengthened suite: four passed. The same mutation fails each missing-scope row separately at the expected recovery assertion.
- Production source restored byte-for-byte; final complete suite: four passed.
- Changed-file gate and fresh P2 review passed.
