### PR TITLE
refactor(xai): reuse shared video response fixtures

### DIFF
--- a/extensions/xai/video-generation-provider.test.ts
+++ b/extensions/xai/video-generation-provider.test.ts
@@ -7,13 +7,12 @@ import {
 } from "openclaw/plugin-sdk/provider-http-test-mocks";
 import { expectExplicitVideoGenerationCapabilities } from "openclaw/plugin-sdk/provider-test-contracts";
 import type { VideoGenerationRequest } from "openclaw/plugin-sdk/video-generation";
-import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeAll, describe, expect, it, vi } from "vitest";
 
 const {
   postJsonRequestMock,
   fetchWithTimeoutGuardedMock,
   fetchWithTimeoutMock,
-  readProviderJsonResponseMock,
   resolveApiKeyForProviderMock,
   resolveProviderHttpRequestConfigMock,
   sanitizeConfiguredModelProviderRequestMock,
@@ -26,51 +25,6 @@ beforeAll(async () => {
 });
 
 installProviderHttpMockCleanup();
-
-beforeEach(() => {
-  readProviderJsonResponseMock.mockImplementation(async <T>(response: Response, label: string) => {
-    const maxBytes = 16 * 1024 * 1024;
-    if (!response.body) {
-      try {
-        return (await response.json()) as T;
-      } catch (cause) {
-        throw new Error(`${label}: malformed JSON response`, { cause });
-      }
-    }
-
-    const reader = response.body.getReader();
-    const chunks: Uint8Array[] = [];
-    let totalBytes = 0;
-    try {
-      for (;;) {
-        const { done, value } = await reader.read();
-        if (done) {
-          break;
-        }
-        totalBytes += value.byteLength;
-        if (totalBytes > maxBytes) {
-          await reader.cancel();
-          throw new Error(`${label}: JSON response exceeds ${maxBytes} bytes`);
-        }
-        chunks.push(value);
-      }
-    } finally {
-      reader.releaseLock();
-    }
-
-    const body = new Uint8Array(totalBytes);
-    let offset = 0;
-    for (const chunk of chunks) {
-      body.set(chunk, offset);
-      offset += chunk.byteLength;
-    }
-    try {
-      return JSON.parse(new TextDecoder().decode(body)) as T;
-    } catch (cause) {
-      throw new Error(`${label}: malformed JSON response`, { cause });
-    }
-  });
-});
 
 function requirePostJsonCall(index = 0): {
   url?: string;
@@ -138,18 +92,6 @@ function mockXaiVideoTask(params: {
       headers: new Headers({ "content-type": params.mimeType ?? "video/mp4" }),
       arrayBuffer: async () => Buffer.from(params.videoBytes),
     });
-}
-
-function streamedVideoResponse(bytes: string, contentType = "video/mp4"): Response {
-  return new Response(
-    new ReadableStream({
-      start(controller) {
-        controller.enqueue(new TextEncoder().encode(bytes));
-        controller.close();
-      },
-    }),
-    { headers: { "content-type": contentType } },
-  );
 }
 
 describe("xai video generation provider", () => {
@@ -430,7 +372,17 @@ describe("xai video generation provider", () => {
           video: { url: "https://cdn.x.ai/too-large.mp4" },
         }),
       })
-      .mockResolvedValueOnce(streamedVideoResponse("too-large"));
+      .mockResolvedValueOnce(
+        new Response(
+          new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode("too-large"));
+              controller.close();
+            },
+          }),
+          { headers: { "content-type": "video/mp4" } },
+        ),
+      );
 
     const provider = buildXaiVideoGenerationProvider();
     await expect(


### PR DESCRIPTION
## What Problem This Solves

The xAI video tests reinstall a bounded JSON-reader mock that the shared provider fixture already supplies. The duplicate survived after the shared fixture was repaired, leaving two copies to maintain. A one-use video stream helper also exposes a MIME option that no caller supplies.

## Why This Change Was Made

Use the existing shared reader fixture and inline the one-use stream at its existing test. Keep every test, assertion, payload and active fixture option; no production code changes.

## User Impact

No user-visible behavior changes. Test code decreases by 48 lines, and all 19 xAI cases remain, including create/poll overflow propagation, cancellation, malformed responses, MIME handling and request-policy isolation.

## Evidence

- Before and after: 76 passed across the xAI video and transport suites, generic provider HTTP reader suite, and provider-assets suite, with identical complete case inventories.
- All 78 xAI expectation sites remain. Formatting and independent Codex review passed.
- Independent retained-bundle audit verified the entire 39,560-entry base tree plus the sole reviewed test change and exact current bytes.
- All 19 configured changed checks passed ([Linux Testbox run](https://github.com/openclaw/openclaw/actions/runs/34215786067)); the command exited successfully, the one-shot lease stopped, and its capsule, claim and recorded processes were removed.

The xAI JSON cases remain consumer tests using the shared mock; they do not establish equivalence between that mock and the production reader. The real reader's UTF-8, timeout and cancellation behavior stays covered separately. No live vendor call or performance improvement is claimed.
