### PR TITLE
refactor(diffs): remove unused language test options

### DIFF
--- a/extensions/diffs/src/language-hints.test.ts
+++ b/extensions/diffs/src/language-hints.test.ts
@@ -6,8 +6,8 @@ import {
   normalizeSupportedLanguageHint,
 } from "./language-hints.js";
 
-async function normalizeHints(values: readonly string[], options = {}) {
-  return await Promise.all(values.map((value) => normalizeSupportedLanguageHint(value, options)));
+async function normalizeHints(values: readonly string[]) {
+  return await Promise.all(values.map((value) => normalizeSupportedLanguageHint(value)));
 }
 
 describe("normalizeSupportedLanguageHint", () => {


### PR DESCRIPTION
## What Problem This Solves

The language-hint tests expose an options argument on their local batching helper even though none of its five callers supplies it. Cases that enable the language pack already call the scalar owner directly.

## Why This Change Was Made

Remove the unused helper argument and forwarding. Keep the batching helper and its map callback, every test body and assertion, and the production language-pack options.

## User Impact

No user-visible behavior or production change. The test-only diff is two added and two removed lines. All 13 language-hint cases remain, including aliases, casing, optional language-pack support and hydrated payload repair.

## Evidence

- Full language-hint and renderer suites passed 23 cases before and after, with identical complete inventories.
- All 19 language-hint expectation sites and five batching calls remain. Formatting and independent Codex review passed.
- All 19 configured changed checks passed ([Linux Testbox run](https://github.com/openclaw/openclaw/actions/runs/34216396882)). The command succeeded and the one-shot lease, capsule, claim and recorded processes were closed.
- Independent retained-bundle audit verified the whole 39,561-entry base tree with exactly the reviewed test change.

A portal-sync timeout occurred after command success and completed lease stop; portal-sync success is not claimed. This is test-helper cleanup, with no live-browser or performance claim.
