### PR TITLE
fix(telegram): isolate private-topic buffering and cancellation

### DIFF
--- a/extensions/telegram/src/bot-handlers.debounce-key.ts
+++ b/extensions/telegram/src/bot-handlers.debounce-key.ts
@@ -1,4 +1,3 @@
-// Telegram plugin module implements bot handlersebounce key behavior.
 import { buildTelegramGroupPeerId, type TelegramThreadSpec } from "./bot/helpers.js";
 export function buildTelegramInboundDebounceKey(params: {
   accountId?: string | null;
@@ -14,5 +13,9 @@ export function buildTelegramInboundDebounceConversationKey(params: {
   chatId: number | string;
   threadSpec: TelegramThreadSpec;
 }): string {
-  return buildTelegramGroupPeerId(params.chatId, params.threadSpec);
+  const { chatId, threadSpec } = params;
+  // Group peer IDs omit private topics; buffers and cancellation must retain them.
+  return threadSpec.scope === "dm" && threadSpec.id != null
+    ? `${chatId}:dm-topic:${threadSpec.id}`
+    : buildTelegramGroupPeerId(chatId, threadSpec);
 }

--- a/extensions/telegram/src/bot-handlers.inbound-pipeline.test.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-pipeline.test.ts
@@ -28,44 +28,47 @@ describe("buildTelegramInboundDebounceKey", () => {
     ).toBe("telegram:default:12345:67890:forward");
   });
 
-  it("keeps scoped topic thread ids in the conversation key", () => {
-    const topic100 = buildTelegramInboundDebounceConversationKey({
-      chatId: 7,
-      threadSpec: { id: 100, scope: "forum" },
-    });
-    const topic200 = buildTelegramInboundDebounceConversationKey({
-      chatId: 7,
-      threadSpec: { id: 200, scope: "forum" },
-    });
-
-    expect(topic100).toBe("7:topic:100");
-    expect(topic200).toBe("7:topic:200");
-    expect(
-      buildTelegramInboundDebounceConversationKey({
+  it.each(["forum", "dm"] as const)(
+    "keeps %s topic thread ids in the conversation key",
+    (scope) => {
+      const topic100 = buildTelegramInboundDebounceConversationKey({
         chatId: 7,
-        threadSpec: { id: 100, scope: "direct-messages" },
-      }),
-    ).toBe("7:direct-topic:100");
-    expect(
-      buildTelegramInboundDebounceKey({
-        accountId: "default",
-        conversationKey: topic100,
-        senderId: "42",
-        debounceLane: "default",
-      }),
-    ).not.toBe(
-      buildTelegramInboundDebounceKey({
-        accountId: "default",
-        conversationKey: topic200,
-        senderId: "42",
-        debounceLane: "default",
-      }),
-    );
-  });
+        threadSpec: { id: 100, scope },
+      });
+      const topic200 = buildTelegramInboundDebounceConversationKey({
+        chatId: 7,
+        threadSpec: { id: 200, scope },
+      });
 
-  it("uses the chat id as the conversation key when no thread is present", () => {
-    expect(
-      buildTelegramInboundDebounceConversationKey({ chatId: 7, threadSpec: { scope: "none" } }),
-    ).toBe("7");
+      expect(topic100).toBe(scope === "dm" ? "7:dm-topic:100" : "7:topic:100");
+      expect(topic200).toBe(scope === "dm" ? "7:dm-topic:200" : "7:topic:200");
+      expect(
+        buildTelegramInboundDebounceConversationKey({
+          chatId: 7,
+          threadSpec: { id: 100, scope: "direct-messages" },
+        }),
+      ).toBe("7:direct-topic:100");
+      expect(
+        buildTelegramInboundDebounceKey({
+          accountId: "default",
+          conversationKey: topic100,
+          senderId: "42",
+          debounceLane: "default",
+        }),
+      ).not.toBe(
+        buildTelegramInboundDebounceKey({
+          accountId: "default",
+          conversationKey: topic200,
+          senderId: "42",
+          debounceLane: "default",
+        }),
+      );
+    },
+  );
+
+  it.each(["none", "dm"] as const)("uses the chat id for unthreaded %s messages", (scope) => {
+    expect(buildTelegramInboundDebounceConversationKey({ chatId: 7, threadSpec: { scope } })).toBe(
+      "7",
+    );
   });
 });

--- a/extensions/telegram/src/bot-handlers.inbound-processing.test.ts
+++ b/extensions/telegram/src/bot-handlers.inbound-processing.test.ts
@@ -1,0 +1,169 @@
+import type { Message } from "grammy/types";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { normalizeAllowFrom } from "./bot-access.js";
+import { createTelegramInboundProcessing } from "./bot-handlers.inbound-processing.js";
+import type { TelegramMessagePipeline } from "./bot-handlers.message-pipeline.js";
+import type { RegisterTelegramHandlerParams } from "./bot-handlers.types.js";
+import type { TelegramContext } from "./bot/types.js";
+
+function createHarness(
+  processMessageWithReplyChain = vi.fn<TelegramMessagePipeline["processMessageWithReplyChain"]>(
+    async () => ({ kind: "completed" }),
+  ),
+) {
+  const cfg = { messages: { inbound: { debounceMs: 50 } }, commands: { useAccessGroups: false } };
+  const message = {
+    resolveMediaRuntime: () => ({ token: "test-token" }),
+    recordMessageResolvedMedia: vi.fn(),
+    promptContextBoundaryOptions: () => ({}),
+    latestPromptContextMinTimestampMs: () => undefined,
+    latestPromptContextAmbientWatermark: () => undefined,
+    mergeDispatchDedupeClaims: () => [],
+    releaseDispatchDedupeClaims: vi.fn(),
+    buildFailedProcessingResult: (error: unknown) => ({ kind: "failed-retryable", error }),
+    settleSpooledReplayParticipants: vi.fn(),
+    createSpooledReplayParticipantForBufferedWork: () => undefined,
+    spooledReplayOptions: () => ({}),
+    buildSyntheticTextMessage: ({ base, text }: { base: Message; text: string }) => ({
+      ...base,
+      text,
+    }),
+    buildSyntheticContext: (ctx: TelegramContext, syntheticMessage: Message) => ({
+      ...ctx,
+      message: syntheticMessage,
+    }),
+    formatTelegramAmbientTranscriptBody: () => undefined,
+    processMessageWithReplyChain,
+  } as unknown as TelegramMessagePipeline;
+  const { processInboundMessage } = createTelegramInboundProcessing({
+    params: {
+      cfg,
+      accountId: "default",
+      bot: { api: { sendMessage: vi.fn() } },
+      runtime: { error: vi.fn(), exit: vi.fn(), log: vi.fn() },
+      opts: { token: "test-token" },
+      mediaMaxBytes: 10_000,
+      logger: { warn: vi.fn() },
+    } as unknown as RegisterTelegramHandlerParams,
+    message,
+  });
+  let messageId = 0;
+  const send = (threadId: number, text: string, forwarded = false) => {
+    const msg = {
+      message_id: ++messageId,
+      date: 1,
+      chat: { id: 42, type: "private", first_name: "Alice" },
+      from: { id: 42, is_bot: false, first_name: "Alice" },
+      message_thread_id: threadId,
+      is_topic_message: true,
+      text,
+      ...(forwarded
+        ? { forward_origin: { type: "hidden_user", date: 1, sender_user_name: "Bob" } }
+        : {}),
+    } as Message;
+    return processInboundMessage({
+      authorizationCfg: cfg,
+      ctx: { message: msg, me: { id: 123, username: "test_bot" } } as TelegramContext,
+      msg,
+      chatId: 42,
+      isGroup: false,
+      isForum: false,
+      threadSpec: { scope: "dm", id: threadId },
+      dmPolicy: "open",
+      storeAllowFrom: [],
+      senderId: "42",
+      effectiveGroupAllow: normalizeAllowFrom(),
+      effectiveDmAllow: normalizeAllowFrom(["42"]),
+      channelIngressResolver: vi.fn(),
+      sendOversizeWarning: false,
+      oversizeLogMessage: "media too large",
+      dispatchDedupeClaims: [],
+    });
+  };
+  return { send, processMessageWithReplyChain };
+}
+
+describe("Telegram private-topic inbound isolation", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it("coalesces one topic without merging another topic's text or reply target", async () => {
+    const { send, processMessageWithReplyChain } = createHarness();
+    await send(100, "first A");
+    await send(200, "only B");
+    await send(100, "second A");
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(processMessageWithReplyChain).toHaveBeenCalledTimes(2);
+    expect(
+      processMessageWithReplyChain.mock.calls.map(([entry]) => ({
+        text: entry.msg.text,
+        thread: entry.options?.threadSpec,
+        messageThread: entry.msg.message_thread_id,
+      })),
+    ).toEqual(
+      expect.arrayContaining([
+        { text: "first A\nsecond A", thread: { scope: "dm", id: 100 }, messageThread: 100 },
+        { text: "only B", thread: { scope: "dm", id: 200 }, messageThread: 200 },
+      ]),
+    );
+  });
+
+  it("admits another topic while the first topic's downstream processing is pending", async () => {
+    let release!: () => void;
+    const pending = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const processMessageWithReplyChain = vi.fn<
+      TelegramMessagePipeline["processMessageWithReplyChain"]
+    >(async ({ options }) => {
+      if (options?.threadSpec?.id === 100) {
+        await pending;
+      }
+      return { kind: "completed" };
+    });
+    const { send } = createHarness(processMessageWithReplyChain);
+    try {
+      await send(100, "long-running A");
+      await vi.advanceTimersByTimeAsync(100);
+      await send(100, "queued A");
+      await send(200, "independent B");
+      await vi.advanceTimersByTimeAsync(100);
+      expect(processMessageWithReplyChain.mock.calls.map(([entry]) => entry.msg.text)).toEqual([
+        "long-running A",
+        "independent B",
+      ]);
+    } finally {
+      release();
+      await vi.advanceTimersByTimeAsync(100);
+    }
+    expect(processMessageWithReplyChain.mock.calls.map(([entry]) => entry.msg.text)).toEqual([
+      "long-running A",
+      "independent B",
+      "queued A",
+    ]);
+  });
+
+  it.each([false, true])(
+    "cancels only the stopped topic's buffered lane (forwarded: %s)",
+    async (forwarded) => {
+      const { send, processMessageWithReplyChain } = createHarness();
+      await send(100, "preserve A", forwarded);
+      await send(200, "cancel B", forwarded);
+      await send(200, "/stop");
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(processMessageWithReplyChain.mock.calls.map(([entry]) => entry.msg.text)).toEqual([
+        "/stop",
+        "preserve A",
+      ]);
+      expect(processMessageWithReplyChain.mock.calls[1]?.[0].options?.threadSpec).toEqual({
+        scope: "dm",
+        id: 100,
+      });
+    },
+  );
+});


### PR DESCRIPTION
Closes #142107

## What Problem This Solves

Fixes an issue where users messaging different private Telegram topics could have their input combined or blocked behind another topic, and an authorized `/stop` in one topic could discard another topic's buffered messages.

## Why This Change Was Made

Preserve the private topic ID in the Telegram inbound debounce key, which owns both enqueue and cancellation identity. Existing forum, channel Direct Messages, and unthreaded keys keep their behavior; public conversation IDs and persisted session routing are unchanged.

## User Impact

Private topics buffer and admit input independently. Stopping one topic preserves pending input in other topics, including forwarded messages.

## Evidence

- Reproduced four failures on main `8342d351b280e18936bfaacf85ab4b78f4e2476c` before changing production code: cross-topic coalescing, blocked admission in original message order, and cross-topic cancellation in default and forward lanes. The private-topic identity test also failed.
- After the repair, all four behavioral regressions pass using the real inbound-processing and buffer owners. The admission test holds downstream processing and verifies both independent topic progress and same-topic ordering after release.
- Focused validation: 81 passing tests across inbound processing, debounce identity, provenance buffering, sequential lanes, and topic conversation parsing. The five-suite run passed 80 tests; a final six-case identity run includes the added unthreaded-private control.
- `git diff --check` passes. Changed-scope checks passed production typechecking; the remaining local check run was stopped during test typechecking to publish at the requester's direction. Full check success is not claimed; GitHub CI is pending.
- Independent autoreview: scoped-clean, no actionable P0–P2 findings.
- Live Telegram proof is unavailable: the Test Server doctor could not access the QA broker through the Convex CLI. The local regressions are deterministic owner-boundary proof, not live Telegram evidence.
- Production delta: +5/-2 lines (net +3), retaining private-topic identity at its producer without broadening the shared conversation serializer. No configuration, schema, or dependency changes.

Thanks @aspalagin for the report and reproduction. The pre-existing ClawSweeper implementation run stopped before completion without publishing a PR.

Maintainer edits and access to this fork's workflow secrets are allowed.
