### PR TITLE
fix: show repaired skills on the first read after watcher acquisition

### DIFF
--- a/src/skills/runtime/refresh.missing-root.integration.test.ts
+++ b/src/skills/runtime/refresh.missing-root.integration.test.ts
@@ -11,6 +11,64 @@ vi.mock("../loading/plugin-skills.js", () => ({
   resolvePluginSkillRootsFromMetadata: () => [],
 }));
 
+it.each(["initial", "closed", "disabled", "evicted"] as const)(
+  "reads repaired skills immediately after %s watcher acquisition",
+  async (lifecycle) => {
+    const root = await fs.realpath(await fs.mkdtemp(path.join(os.tmpdir(), "skills-acquire-")));
+    const workspaceDir = path.join(root, "workspace");
+    const skillDir = path.join(workspaceDir, "skills", "acquire-proof");
+    const skillFile = path.join(skillDir, "SKILL.md");
+    const { ensureSkillsWatcher, closeSkillsWatchers } = await import("./refresh.js");
+    const { getSkillsSnapshotVersion } = await import("./refresh-state.js");
+    const { loadWorkspaceSkills } = await import("../loading/workspace-skill-loader.js");
+    const options = { config: {}, agentId: "main" };
+    try {
+      await fs.mkdir(skillDir, { recursive: true });
+      if (lifecycle !== "initial") {
+        ensureSkillsWatcher({ workspaceDir, ...options });
+        if (lifecycle === "closed") {
+          await closeSkillsWatchers();
+        } else if (lifecycle === "disabled") {
+          ensureSkillsWatcher({
+            workspaceDir,
+            ...options,
+            config: { skills: { load: { watch: false } } },
+          });
+        } else {
+          const clock = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 61 * 60_000);
+          try {
+            ensureSkillsWatcher({ workspaceDir: path.join(root, "other"), ...options });
+          } finally {
+            clock.mockRestore();
+          }
+        }
+      }
+      // Cache the invalid file after teardown, so teardown invalidation cannot
+      // accidentally prove freshness on reacquisition.
+      nativeFs.writeFileSync(skillFile, "not valid skill frontmatter\n");
+      const readSkill = () =>
+        loadWorkspaceSkills(workspaceDir, options).find(
+          (entry) => entry.skill.name === "acquire-proof",
+        );
+      expect(readSkill()).toBeUndefined();
+      nativeFs.writeFileSync(
+        skillFile,
+        "---\nname: acquire-proof\ndescription: Repaired before acquisition\n---\n",
+      );
+      expect(readSkill()).toBeUndefined();
+      // No await: the first synchronous consumer must not need a ready/change event.
+      ensureSkillsWatcher({ workspaceDir, ...options });
+      expect(readSkill()?.skill.description).toBe("Repaired before acquisition");
+      const version = getSkillsSnapshotVersion(workspaceDir);
+      ensureSkillsWatcher({ workspaceDir, ...options });
+      expect(getSkillsSnapshotVersion(workspaceDir)).toBe(version);
+    } finally {
+      await closeSkillsWatchers();
+      await fs.rm(root, { recursive: true, force: true });
+    }
+  },
+);
+
 it.each(["create", "edit"] as const)(
   "refreshes cached skills after %s during initial watcher registration",
   async (operation) => {

--- a/src/skills/runtime/refresh.test.ts
+++ b/src/skills/runtime/refresh.test.ts
@@ -170,6 +170,7 @@ describe("ensureSkillsWatcher", () => {
         config: { skills: { load: {} } },
       });
 
+      seen.length = 0;
       watchForSkillRoot(path.join(workspaceDir, "skills")).watcher.emit(
         "raw",
         "change",
@@ -208,6 +209,7 @@ describe("ensureSkillsWatcher", () => {
     expect(watched.options.depth).toBe(7);
 
     const changedPath = path.join(workspaceDir, "skills", "group", "demo", "SKILL.md");
+    seen.length = 0;
     watched.watcher.emit("all", "change", changedPath);
     await vi.advanceTimersByTimeAsync(250);
 
@@ -233,6 +235,7 @@ describe("ensureSkillsWatcher", () => {
       config: { skills: { load: {} } },
     });
 
+    seen.length = 0;
     watchForSkillRoot(path.join(workspaceDir, "skills")).watcher.emit(
       "raw",
       "rename",
@@ -272,6 +275,7 @@ describe("ensureSkillsWatcher", () => {
       config: { skills: { load: {} } },
     });
 
+    seen.length = 0;
     watchForSkillRoot(path.join(workspaceDir, "skills")).watcher.emit("raw", "rename", undefined, {
       watchedPath: path.join(fixtureWorkspaceDir, "skills"),
     });
@@ -303,6 +307,7 @@ describe("ensureSkillsWatcher", () => {
       config: { skills: { load: {} } },
     });
 
+    seen.length = 0;
     watchForSkillRoot(path.join(workspaceDir, "skills")).watcher.emit("raw", "change", "SKILL.md", {
       watchedPath: skillDir,
     });
@@ -332,6 +337,7 @@ describe("ensureSkillsWatcher", () => {
     const versionBefore = getSkillsSnapshotVersion(fixtureWorkspaceDir);
     const stat = vi.spyOn(fsSync, "statSync");
 
+    seen.length = 0;
     watched.watcher.emit("raw", "change", "SKILL.md", { watchedPath: skillDir });
     await refreshModule.closeSkillsWatchers();
     expect(watched.watcher.close).toHaveBeenCalledOnce();
@@ -764,6 +770,7 @@ describe("ensureSkillsWatcher", () => {
         config: { skills: { load: {} } },
       });
 
+      seen.length = 0;
       watchForSkillRoot(path.join(fixtureWorkspaceDir, "skills")).watcher.emit(
         "all",
         event,
@@ -826,6 +833,7 @@ describe("ensureSkillsWatcher", () => {
       config: { skills: { load: { extraDirs: [sharedA] } } },
     });
     const previousWatcher = watchForSkillRoot(sharedA).watcher;
+    seen.length = 0;
 
     refreshModule.ensureSkillsWatcher({
       workspaceDir: fixtureWorkspaceDir,
@@ -945,6 +953,7 @@ describe("ensureSkillsWatcher", () => {
       });
       refreshModule.ensureSkillsWatcher({ workspaceDir: fixtureWorkspaceDir, config });
       refreshModule.ensureSkillsWatcher({ workspaceDir: secondWorkspace, config });
+      seen.length = 0;
       const changedPath =
         event === "change" ? path.join(sharedRoot, "demo", "SKILL.md") : undefined;
       const watcher = watchForSkillRoot(sharedRoot).watcher;

--- a/src/skills/runtime/refresh.ts
+++ b/src/skills/runtime/refresh.ts
@@ -736,8 +736,6 @@ export function ensureSkillsWatcher(params: {
     evictIdleWorkspaceWatchStates(now);
     return;
   }
-  const watchTargetsChanged = previousTargets.length > 0 && !targetsUnchanged;
-
   const nextTargetKeys = new Set(watchTargets.map((target) => target.path));
   for (const watchTarget of previousTargets) {
     if (!nextTargetKeys.has(watchTarget.path)) {
@@ -749,7 +747,9 @@ export function ensureSkillsWatcher(params: {
   }
   workspaceWatchTargets.set(watcherKey, watchTargets);
 
-  if (watchTargetsChanged) {
+  // Acquisition must invalidate reads cached during an unwatched interval,
+  // before the first consumer runs or the asynchronous initial scan completes.
+  if (!targetsUnchanged) {
     bumpSkillsSnapshotVersion({
       workspaceDir,
       reason: "watch-targets",


### PR DESCRIPTION
Closes #142106

## What Problem This Solves

Fixes an issue where the first skill-status request could still omit a skill repaired while its workspace was not being watched. Later filesystem reconciliation could make a subsequent request current, leaving the first response misleading.

## Why This Change Was Made

Invalidate discovery synchronously when the watcher acquires a changed subscription set, including acquisition from no subscriptions. The existing fast path keeps unchanged active subscriptions as cache hits. Asynchronous initial-scan reconciliation and workspace/agent ownership remain unchanged.

## User Impact

A repaired file is visible in the first status response after observation starts or resumes. Users do not need another status request, another file edit, or a restart after repairing the file. No setting, cache, watcher, retry, dependency or protocol field is added.

## Evidence

Pinned main `ef8d4806` and exact candidate `7f08fd81` were built and exercised through the real Gateway and public CLI with task-owned files and real Chokidar. No provider, model, channel or production credentials were required.

The public `skills.skillCard` request caches the invalid skill without acquiring observation. After repairing the actual `SKILL.md`, the first `gateway call skills.status` and first normal `skills list --json --agent …` give these results:

| Scenario | Pinned main | Candidate |
| --- | --- | --- |
| Initial watcher acquisition | Repaired skill omitted | Repaired description and eligibility present in the first response |
| Watch disabled, then re-enabled | Repaired skill omitted after post-transition prewarm | Repaired skill present in the first response |
| Watchers closed before prewarm and repair | Repaired skill omitted | Repaired skill present without another restart |
| Real one-hour idle eviction, then post-eviction prewarm and repair | Repaired skill omitted | Repaired skill present in the first response |

The full Gateway response also contains the correct source path. Kernel watch records confirm that the fixture was unwatched before acquisition. The disable/re-enable and eviction setups must prewarm after their transition: config application and eviction independently invalidate older cache entries, so a pre-transition cache fill would mask the baseline.

- 250 focused tests pass, with one existing Windows-only skip on Linux. All four new lifecycle regressions fail on original production for the intended stale-read assertion; the three prior real-watcher controls pass.
- Real create, edit, remove, rename, grouped-root, extra-root, trusted-symlink, shared-root, invalid, hidden-root, precedence and missing-binary controls retain their behavior.
- Formatting and lint pass. Fresh independent code review found no actionable P0–P2 defect.
- Independent public-flow proof confirms all four lifecycle results, including 3,602 seconds of real idle time, and a separate first normal skills-list response. Baseline omits the repaired skill and the candidate returns it. Exact source pins and valid prior proof were retained across the replacement test environment.
- Snapshot-version equality, exact before-ready ordering and shared watcher ownership are source/component claims, supported by the real-Chokidar synchronous regression and owner tests; those fields are not invented in public CLI output.

The completed exact-head [CI run](https://github.com/openclaw/openclaw/actions/runs/34218113333) has two pre-existing failures assessed as unrelated to this watcher change. [Standing guarded CI approval](https://github.com/openclaw/openclaw/pull/142123#issuecomment-5585739145) records the exact run and child jobs. The ACP cleanup failure also occurs on main and has a later fixture-only preload repair. The archive transaction-label assertion has an exact earlier occurrence without this patch; the actual archive branch does not invoke watcher acquisition. Its underlying instrumentation mechanism remains unconfirmed. The jobs are not reported as green, and no blind retry or weaker assertion was used.

AI-assisted maintainer validation preserves contributor authorship.
