### PR TITLE
perf(vllm): keep model metadata reads lightweight

### DIFF
--- a/extensions/vllm/thinking-policy.ts
+++ b/extensions/vllm/thinking-policy.ts
@@ -3,7 +3,7 @@ import type {
   ProviderDefaultThinkingPolicyContext,
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-shared";
+import { normalizeProviderId } from "openclaw/plugin-sdk/provider-model-metadata";
 
 export type VllmQwenThinkingFormat = "chat-template" | "top-level";
 


### PR DESCRIPTION
Related: #141852

## What Problem This Solves

Resolves slow first-use model metadata projection when the catalog contains vLLM models. The Fast-support metadata path now visits provider policy artifacts, and the vLLM thinking policy unnecessarily loaded replay and plugin-registration code just to normalize its provider name. An unchanged metadata test grew from 102ms to 16.85s in [main CI 34213905913](https://github.com/openclaw/openclaw/actions/runs/34213905913).

## Why This Change Was Made

Import `normalizeProviderId` from the existing lightweight `provider-model-metadata` SDK entrypoint. Both entrypoints re-export the identical canonical function; the policy, provider selection, Fast resolver and runtime stream composition stay unchanged. The public policy artifact no longer pulls the broad replay/registration barrel into metadata reads.

## User Impact

Faster cold metadata reads and tests with the same provider behavior. No new SDK API, dependency, cache, shard, timeout, mock, or test change. Production LOC: +1/-1; tests: 0.

## Evidence

- Same checkout, Node 24.19.0 and pnpm 12.3.4: original / changed / restored-original complete chat metadata suite, 43 cases passing in the same order each time. The affected case took **11,768ms / 379ms / 11,747ms**. Vitest suite durations were **23.79s / 8.02s / 19.61s**. Restoring the original import restores the cost after the candidate run, so the result is not attributed merely to a warm cache.
- Existing model-list suite: 52 passed. vLLM thinking-policy and stream-composition suites: 20 passed. Assertions and fixtures are unchanged.
- Full `pnpm build` and the applicable `check:changed` gates passed, including production/test types, lint and boundary guards.
- Independent P0–P2 review found no actionable issue. Source inspection confirms both SDK exports resolve the same `@openclaw/model-catalog-core/provider-id` function.

The remaining mixed-provider policy first-use cost is a separate measured follow-up; this patch makes no claim to resolve it or to bring every CI run below eight minutes.

Post-merge proof: natural main [CI 34218981685, target job 102037583562](https://github.com/openclaw/openclaw/actions/runs/34218981685/job/102037583562) includes merge `6aeb8e46c0898841dbb31de4b4fd2b9dd012e039`. All 43 chat metadata cases passed in the same order; the affected case fell from 16,852ms in the prior main sample to **410ms**. The full workflow subsequently passed in 9m27s with all 27 Node jobs green; Doctor config/state execution remained the critical path.
