### PR TITLE
fix(plugins): clarify Gateway restart guidance after installs

### DIFF
--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -508,7 +508,7 @@ export async function persistPluginInstall(params: {
         warn,
       });
       runtime.log(
-        "Plugin source changes take effect on the next Gateway start. A running managed Gateway with config reload enabled restarts automatically; otherwise, restart it manually.",
+        "Plugin source changes take effect on the next Gateway start. Installs performed by the running Gateway request an automatic restart when config reload is enabled; installs from a separate shell, or with config reload off, require a manual Gateway restart. Configuration reload can restart connected channels before that Gateway restart.",
       );
       return next;
     });

--- a/src/plugins/install-persistence.ts
+++ b/src/plugins/install-persistence.ts
@@ -507,7 +507,9 @@ export async function persistPluginInstall(params: {
         install: params.install,
         warn,
       });
-      runtime.log("Restart the gateway to load plugins.");
+      runtime.log(
+        "Plugin source changes take effect on the next Gateway start. A running managed Gateway with config reload enabled restarts automatically; otherwise, restart it manually.",
+      );
       return next;
     });
   } finally {

--- a/src/plugins/install-persistence.warning-sink.test.ts
+++ b/src/plugins/install-persistence.warning-sink.test.ts
@@ -63,7 +63,9 @@ describe("plugin install persistence warning audiences", () => {
     );
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("requires configuration first");
     expect(pluginsCliRuntimeLogs).toContain("Installed plugin: workboard");
-    expect(pluginsCliRuntimeLogs).toContain("Restart the gateway to load plugins.");
+    const sourceChangeMessage =
+      "Plugin source changes take effect on the next Gateway start. A running managed Gateway with config reload enabled restarts automatically; otherwise, restart it manually.";
+    expect(pluginsCliRuntimeLogs.filter((line) => line === sourceChangeMessage)).toHaveLength(1);
   });
 
   it("preserves owner-authored exclusive-slot warnings verbatim", async () => {

--- a/src/plugins/install-persistence.warning-sink.test.ts
+++ b/src/plugins/install-persistence.warning-sink.test.ts
@@ -64,7 +64,7 @@ describe("plugin install persistence warning audiences", () => {
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("requires configuration first");
     expect(pluginsCliRuntimeLogs).toContain("Installed plugin: workboard");
     const sourceChangeMessage =
-      "Plugin source changes take effect on the next Gateway start. A running managed Gateway with config reload enabled restarts automatically; otherwise, restart it manually.";
+      "Plugin source changes take effect on the next Gateway start. Installs performed by the running Gateway request an automatic restart when config reload is enabled; installs from a separate shell, or with config reload off, require a manual Gateway restart. Configuration reload can restart connected channels before that Gateway restart.";
     expect(pluginsCliRuntimeLogs.filter((line) => line === sourceChangeMessage)).toHaveLength(1);
   });
 

--- a/src/system-agent/operations.test.ts
+++ b/src/system-agent/operations.test.ts
@@ -1009,6 +1009,9 @@ describe("system agent operations", () => {
     expect(beforePersistentApply).toHaveBeenCalledOnce();
     expectRuntimeArg(installRequest.runtime);
     expect(lines.join("\n")).toContain("[openclaw] done: plugin.install");
+    expect(lines.join("\n")).not.toContain(
+      "Restart the Gateway to apply installed plugin changes.",
+    );
     const audit = readLastAuditEntry();
     expectAuditRecord(
       audit,

--- a/src/system-agent/plugin-artifact.test.ts
+++ b/src/system-agent/plugin-artifact.test.ts
@@ -137,7 +137,9 @@ describe("exact system-agent plugin artifacts", () => {
     ).toMatchObject({ applied: true });
     await expect(fs.access(review.retainedPath)).rejects.toThrow();
     expect(beforePersistentApply).toHaveBeenCalledTimes(3);
-    expect(lines.join("\n")).toContain("Restart the Gateway");
+    expect(lines.join("\n")).toContain(
+      "Artifact installed. After the Gateway restarts, inspect the plugin's Control UI activation status.",
+    );
     expect(mocks.audit).toHaveBeenCalledWith(
       expect.objectContaining({
         details: expect.objectContaining({

--- a/src/system-agent/plugin-artifact.ts
+++ b/src/system-agent/plugin-artifact.ts
@@ -360,7 +360,7 @@ export async function executePluginArtifactActivation(
   });
   if (result.applied) {
     runtime.log(
-      "Artifact installed. Restart the Gateway to load backend changes, then inspect the plugin's Control UI activation status.",
+      "Artifact installed. After the Gateway restarts, inspect the plugin's Control UI activation status.",
     );
   }
   return result;

--- a/src/system-agent/plugin-install.ts
+++ b/src/system-agent/plugin-install.ts
@@ -40,8 +40,5 @@ export async function executePluginInstall(
       return { summary: `Installed plugin ${operation.spec}`, details: { spec: operation.spec } };
     },
   });
-  if (result.applied) {
-    runtime.log("Restart the Gateway to apply installed plugin changes.");
-  }
   return result;
 }


### PR DESCRIPTION
Related: #141801

## What Problem This Solves

Plugin installation always told operators to restart manually, even when a Gateway-hosted install had already requested an automatic restart. The setup agent could print that instruction twice. The output also omitted that configuration reload can restart connected channels before the new plugin source is active.

## Solution

Keep one explanation in the shared install success path. Distinguish installs performed by the running Gateway from separate-shell installs and reload-off mode. Describe automatic restart as a request, preserve next-start source activation, and explain possible earlier channel reload. Remove the duplicate setup-agent instruction and retain the artifact-specific Control UI follow-up.

Real proof showed that managed-service presence and hybrid mode alone do not guarantee an automatic restart for a separate-shell install. The wording preserves that manual case. Install trust, persistence, restart scheduling, channel behavior, and approval policy are unchanged.

## Evidence

- All 71 focused tests passed, plus changed-file formatting and lint.
- Baseline real CLI and setup-agent output reproduced the misleading and duplicate instructions.
- Separate-shell, reload-off, and offline installs completed through the real CLI with the corresponding guidance.
- Gateway-hosted artifact installs accepted a restart plan, deferred until active work completed, restarted through the supervisor, and loaded the plugin after restart. The repaired result contains one shared explanation and the Control UI follow-up.
- Real trust, compatibility, archive-integrity, source-consent, and install-policy refusals reported failure without a success/restart promise. Injected config-publication failure rolled back the installed payload; removing the fault allowed recovery.
- Fresh independent behavior validation passed all 14 observable clauses with varied fixtures, stored-state checks, real restart observation, and negative controls. Source-only obligations were reviewed separately. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34228376739) and final review are enforced at landing.

This is an output correction. It does not claim to fix or reproduce the historical Telegram interruption.
