### PR TITLE
fix(gateway): trash deleted-agent files from state dirs outside home and tmp

### DIFF
--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -77,7 +77,7 @@ export async function moveToTrashResult(
     const targetPath = path.resolve(pathname);
     const sourcePath = await resolveMoveToTrashSourcePath(targetPath);
     const allowedRoots = trashAllowedRoots(
-      sourcePath,
+      [sourcePath],
       isSymbolicLink ? await resolveSymlinkTargetPath(sourcePath) : undefined,
     );
     // Preparation can outlive its owner; revalidate immediately before Trash dispatch.
@@ -100,14 +100,18 @@ export async function moveToTrash(
 }
 
 /**
- * Allowed Trash roots for an OpenClaw-owned path: its own parent, plus the resolved
- * parent when the path is a symlink (fs-safe checks the link target). The fs-safe
- * default (home + tmp) would refuse state dirs on volumes such as `/data`.
+ * Allowed Trash roots for OpenClaw-owned paths: each declared path's own parent, plus the
+ * resolved parent when the moved path is a symlink (fs-safe checks the link target, and
+ * moving a link never touches the directory behind it). fs-safe's default roots (home + tmp)
+ * alone refuse every path of a state dir on a volume such as `/data`.
  */
-export function trashAllowedRoots(targetPath: string, resolvedTargetPath?: string): string[] {
-  const roots = [path.dirname(targetPath)];
-  if (resolvedTargetPath !== undefined) {
-    roots.push(path.dirname(resolvedTargetPath));
+export function trashAllowedRoots(
+  declaredPaths: readonly string[],
+  resolvedLinkPath?: string,
+): string[] {
+  const roots = declaredPaths.map((declaredPath) => path.dirname(declaredPath));
+  if (resolvedLinkPath !== undefined) {
+    roots.push(path.dirname(resolvedLinkPath));
   }
   return [...new Set(roots)];
 }

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -2,7 +2,6 @@
 import { randomUUID } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import { uniqueStrings } from "@openclaw/normalization-core/string-normalization";
 import type { AgentsDeleteResult } from "../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import { listAgentIds, resolveAgentWorkspaceDir } from "../agents/agent-scope-config.js";
 import { resolveDefaultAgentWorkspaceDir } from "../agents/workspace-default.js";
@@ -16,7 +15,7 @@ import {
 } from "../agents/workspace-state-store.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage, isMissingPathError } from "../infra/errors.js";
-import { movePathToTrash } from "../infra/fs-safe.js";
+import { movePathToTrash, trashAllowedRoots } from "../infra/fs-safe.js";
 import { acquireGatewayLock, GatewayLockError } from "../infra/gateway-lock.js";
 import { hasNodeErrorCode, isPathInside } from "../infra/path-guards.js";
 import { acquireStateDatabaseCoordinator } from "../infra/state-database-coordinator.js";
@@ -66,8 +65,9 @@ export async function moveToTrashResult(
   if (!pathname) {
     return { failed: { path: pathname, reason: "path is empty" } };
   }
+  let isSymbolicLink: boolean;
   try {
-    await fs.lstat(pathname);
+    isSymbolicLink = (await fs.lstat(pathname)).isSymbolicLink();
   } catch (error) {
     return isMissingPathError(error)
       ? { removed: { path: pathname, method: "missing" } }
@@ -76,7 +76,10 @@ export async function moveToTrashResult(
   try {
     const targetPath = path.resolve(pathname);
     const sourcePath = await resolveMoveToTrashSourcePath(targetPath);
-    const allowedRoots = await resolveMoveToTrashAllowedRoots(sourcePath);
+    const allowedRoots = trashAllowedRoots(
+      sourcePath,
+      isSymbolicLink ? await resolveSymlinkTargetPath(sourcePath) : undefined,
+    );
     // Preparation can outlive its owner; revalidate immediately before Trash dispatch.
     assertCurrent?.();
     await movePathToTrash(sourcePath, { allowedRoots });
@@ -100,19 +103,13 @@ async function resolveMoveToTrashSourcePath(targetPath: string): Promise<string>
   return path.join(await fs.realpath(path.dirname(targetPath)), path.basename(targetPath));
 }
 
-async function resolveMoveToTrashAllowedRoots(targetPath: string): Promise<string[]> {
-  const allowedRoots = [path.dirname(targetPath)];
-  const stat = await fs.lstat(targetPath);
-  if (stat.isSymbolicLink()) {
-    try {
-      // fs-safe resolves valid symlinks before allow-root checks; include the
-      // resolved parent so deleting a configured symlink moves the link itself.
-      allowedRoots.push(path.dirname(await fs.realpath(targetPath)));
-    } catch {
-      // Broken symlinks are handled lexically by fs-safe.
-    }
+// fs-safe resolves valid symlinks before allow-root checks; a broken link is handled lexically.
+async function resolveSymlinkTargetPath(linkPath: string): Promise<string | undefined> {
+  try {
+    return await fs.realpath(linkPath);
+  } catch {
+    return undefined;
   }
-  return uniqueStrings(allowedRoots);
 }
 
 function collectWorkspaceDirs(cfg: OpenClawConfig | undefined): string[] {

--- a/src/commands/cleanup-utils.ts
+++ b/src/commands/cleanup-utils.ts
@@ -15,7 +15,7 @@ import {
 } from "../agents/workspace-state-store.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { formatErrorMessage, isMissingPathError } from "../infra/errors.js";
-import { movePathToTrash, trashAllowedRoots } from "../infra/fs-safe.js";
+import { movePathToTrash } from "../infra/fs-safe.js";
 import { acquireGatewayLock, GatewayLockError } from "../infra/gateway-lock.js";
 import { hasNodeErrorCode, isPathInside } from "../infra/path-guards.js";
 import { acquireStateDatabaseCoordinator } from "../infra/state-database-coordinator.js";
@@ -97,6 +97,19 @@ export async function moveToTrash(
   assertCurrent?: () => void,
 ): Promise<boolean> {
   return "removed" in (await moveToTrashResult(pathname, runtime, assertCurrent));
+}
+
+/**
+ * Allowed Trash roots for an OpenClaw-owned path: its own parent, plus the resolved
+ * parent when the path is a symlink (fs-safe checks the link target). The fs-safe
+ * default (home + tmp) would refuse state dirs on volumes such as `/data`.
+ */
+export function trashAllowedRoots(targetPath: string, resolvedTargetPath?: string): string[] {
+  const roots = [path.dirname(targetPath)];
+  if (resolvedTargetPath !== undefined) {
+    roots.push(path.dirname(resolvedTargetPath));
+  }
+  return [...new Set(roots)];
 }
 
 async function resolveMoveToTrashSourcePath(targetPath: string): Promise<string> {

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -311,10 +311,12 @@ vi.mock("../../plugin-sdk/browser-maintenance.js", () => ({
   movePathToTrash: mocks.movePathToTrash,
 }));
 
-function expectTrashedWithinParent(pathname: string): void {
+function expectTrashedWithinParent(pathname: string, declaredPath = pathname): void {
   expect(mocks.movePathToTrash).toHaveBeenCalledWith(
     pathname,
-    expect.objectContaining({ allowedRoots: expect.arrayContaining([path.dirname(pathname)]) }),
+    expect.objectContaining({
+      allowedRoots: expect.arrayContaining([path.dirname(declaredPath)]),
+    }),
   );
 }
 
@@ -2007,7 +2009,7 @@ describe("agents.delete", () => {
     });
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(agentLink);
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/deep");
-    expectTrashedWithinParent(agentTarget);
+    expectTrashedWithinParent(agentTarget, agentLink);
     expect(mocks.unregisterResolvedAgentDir).not.toHaveBeenCalled();
     expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
   });
@@ -2137,8 +2139,8 @@ describe("agents.delete", () => {
     expect(trashedPaths.indexOf(`${workspaceTarget}/agent`)).toBeLessThan(targetIndex);
     expect(trashedPaths.indexOf(`${workspaceTarget}/transcripts`)).toBeLessThan(targetIndex);
     expect(targetIndex).toBeLessThan(trashedPaths.indexOf(canonicalWorkspaceLink));
-    expectTrashedWithinParent(workspaceTarget);
-    expectTrashedWithinParent(canonicalWorkspaceLink);
+    expectTrashedWithinParent(workspaceTarget, workspaceLink);
+    expectTrashedWithinParent(canonicalWorkspaceLink, workspaceLink);
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(workspaceLink);
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
@@ -2235,7 +2237,7 @@ describe("agents.delete", () => {
     expect(mocks.fsRealpath).not.toHaveBeenCalled();
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(retargetedWorkspace);
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(`${retargetedWorkspace}/transcripts`);
-    expectTrashedWithinParent(originalTarget);
+    expectTrashedWithinParent(originalTarget, workspaceLink);
     expectTrashedWithinParent(workspaceLink);
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });

--- a/src/gateway/server-methods/agents-mutate.test.ts
+++ b/src/gateway/server-methods/agents-mutate.test.ts
@@ -311,6 +311,13 @@ vi.mock("../../plugin-sdk/browser-maintenance.js", () => ({
   movePathToTrash: mocks.movePathToTrash,
 }));
 
+function expectTrashedWithinParent(pathname: string): void {
+  expect(mocks.movePathToTrash).toHaveBeenCalledWith(
+    pathname,
+    expect.objectContaining({ allowedRoots: expect.arrayContaining([path.dirname(pathname)]) }),
+  );
+}
+
 vi.mock("../../utils.js", async () => {
   const actual = await vi.importActual<typeof import("../../utils.js")>("../../utils.js");
   return {
@@ -1587,9 +1594,9 @@ describe("agents.delete", () => {
       agentId: "test-agent",
       agentDir: "/journal/agent",
     });
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/workspace");
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/agent");
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/sessions");
+    expectTrashedWithinParent("/journal/workspace");
+    expectTrashedWithinParent("/journal/agent");
+    expectTrashedWithinParent("/journal/sessions");
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
@@ -1734,7 +1741,7 @@ describe("agents.delete", () => {
     // The journal fence blocked legitimate claims while this path was prepared
     // absent, so the appeared occupant is leaked deleted-agent state: sweep it
     // instead of preserving it and finishing over a surviving tree.
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith(workspaceDir);
+    expectTrashedWithinParent(workspaceDir);
     const appearedRecord = journal.cleanupPaths.find((entry) => entry.path === workspaceDir);
     expect(appearedRecord).toMatchObject({ done: true });
     expect(appearedRecord).not.toHaveProperty("note");
@@ -1873,7 +1880,7 @@ describe("agents.delete", () => {
       expect(journal.cleanupPaths.some((entry) => entry.sourcePaths.includes(databasePath))).toBe(
         true,
       );
-      expect(mocks.movePathToTrash).toHaveBeenCalledWith(databasePath);
+      expectTrashedWithinParent(databasePath);
     }
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
@@ -1952,7 +1959,7 @@ describe("agents.delete", () => {
     expectRespondOk(respond, { failed: [] });
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal");
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal/agent");
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/deleted/sessions");
+    expectTrashedWithinParent("/deleted/sessions");
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
@@ -2000,7 +2007,7 @@ describe("agents.delete", () => {
     });
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(agentLink);
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/deep");
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith(agentTarget);
+    expectTrashedWithinParent(agentTarget);
     expect(mocks.unregisterResolvedAgentDir).not.toHaveBeenCalled();
     expect(mocks.beginAgentDeletionFinish).not.toHaveBeenCalled();
   });
@@ -2130,8 +2137,8 @@ describe("agents.delete", () => {
     expect(trashedPaths.indexOf(`${workspaceTarget}/agent`)).toBeLessThan(targetIndex);
     expect(trashedPaths.indexOf(`${workspaceTarget}/transcripts`)).toBeLessThan(targetIndex);
     expect(targetIndex).toBeLessThan(trashedPaths.indexOf(canonicalWorkspaceLink));
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith(workspaceTarget);
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith(canonicalWorkspaceLink);
+    expectTrashedWithinParent(workspaceTarget);
+    expectTrashedWithinParent(canonicalWorkspaceLink);
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(workspaceLink);
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
@@ -2228,8 +2235,8 @@ describe("agents.delete", () => {
     expect(mocks.fsRealpath).not.toHaveBeenCalled();
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(retargetedWorkspace);
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith(`${retargetedWorkspace}/transcripts`);
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith(originalTarget);
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith(workspaceLink);
+    expectTrashedWithinParent(originalTarget);
+    expectTrashedWithinParent(workspaceLink);
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
@@ -2355,7 +2362,7 @@ describe("agents.delete", () => {
       "/journal/agent/openclaw-agent.sqlite",
       "test-agent",
     );
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/agent");
+    expectTrashedWithinParent("/journal/agent");
     expect(directoryOwners.has("/journal/agent")).toBe(false);
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
@@ -2458,8 +2465,8 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, { ok: true });
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/agent/openclaw-agent.sqlite");
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/journal/workspace");
+    expectTrashedWithinParent("/journal/agent/openclaw-agent.sqlite");
+    expectTrashedWithinParent("/journal/workspace");
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal/agent");
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/journal/agent/survivor.sqlite");
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
@@ -2588,7 +2595,7 @@ describe("agents.delete", () => {
       "test-agent",
     );
     expect(mocks.movePathToTrash).not.toHaveBeenCalledWith("/agents/test-agent");
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/agents/test-agent/openclaw-agent.sqlite");
+    expectTrashedWithinParent("/agents/test-agent/openclaw-agent.sqlite");
     expect(mocks.beginAgentDeletionFinish).toHaveBeenCalledOnce();
   });
 
@@ -2810,7 +2817,7 @@ describe("agents.delete", () => {
       "/relocated/other-agent.sqlite",
       "test-agent",
     );
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/relocated/test-agent.sqlite");
+    expectTrashedWithinParent("/relocated/test-agent.sqlite");
     expect(mocks.unregisterOpenClawAgentDatabase).toHaveBeenCalledWith({
       agentId: "test-agent",
       path: "/relocated/test-agent.sqlite",
@@ -2929,7 +2936,7 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, { ok: true });
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/workspace/test-agent");
+    expectTrashedWithinParent("/workspace/test-agent");
     expect(mocks.deleteWorkspaceState).toHaveBeenCalledWith({
       workspaceDir: "/workspace/test-agent",
     });
@@ -2946,7 +2953,7 @@ describe("agents.delete", () => {
     await promise;
 
     expectRespondOk(respond, { ok: true });
-    expect(mocks.movePathToTrash).toHaveBeenCalledWith("/workspace/test-agent");
+    expectTrashedWithinParent("/workspace/test-agent");
     expect(mocks.deleteWorkspaceState).toHaveBeenCalled();
   });
 

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -1,6 +1,7 @@
 // Agents gateway methods expose agent listing, config mutation, workspace file
 // reads/writes, identity merging, and safe deletion for operator clients.
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { normalizeOptionalString as resolveOptionalStringParam } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -413,13 +414,19 @@ async function removeAgentPath(
     // fs-safe pins traversal and identity for validation; Trash has no fd-relative move API, so
     // replacement after this check and before its rename is the accepted residual race bound.
     assertCurrent();
-    // statAgentCleanupPath verified this parent; without explicit roots fs-safe only
-    // allows home/tmp and refuses every path of a volume-backed state dir.
+    // statAgentCleanupPath verified the declared parent; fs-safe's default roots (home/tmp)
+    // alone refuse every path of a volume-backed state dir. Keep those defaults so the
+    // directory behind a workspace symlink stays fenced exactly as shipped, while the link
+    // itself may always move (accepted edge: a link target beside its link is trashed too).
     await movePathToTrash(trashPath, {
-      allowedRoots: trashAllowedRoots(
-        trashPath,
-        cleanupPath.kind === "symlink" ? cleanupPath.canonicalPath : undefined,
-      ),
+      allowedRoots: [
+        ...trashAllowedRoots(
+          cleanupPath.sourcePaths,
+          cleanupPath.kind === "symlink" ? cleanupPath.canonicalPath : undefined,
+        ),
+        os.homedir(),
+        os.tmpdir(),
+      ],
     });
     return { removed: { path: pathname, method: "trash" } };
   } catch (error) {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -92,7 +92,7 @@ import type { IdentityConfig } from "../../config/types.base.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isMissingPathError } from "../../infra/errors.js";
 import { withAgentExecApprovalsRemoved } from "../../infra/exec-approvals.js";
-import { root, FsSafeError, type ReadResult } from "../../infra/fs-safe.js";
+import { root, FsSafeError, trashAllowedRoots, type ReadResult } from "../../infra/fs-safe.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { movePathToTrash } from "../../plugin-sdk/browser-maintenance.js";
 import { normalizeAgentIdStrict } from "../../routing/session-key.js";
@@ -412,7 +412,14 @@ async function removeAgentPath(
     // fs-safe pins traversal and identity for validation; Trash has no fd-relative move API, so
     // replacement after this check and before its rename is the accepted residual race bound.
     assertCurrent();
-    await movePathToTrash(trashPath);
+    // statAgentCleanupPath verified this parent; without explicit roots fs-safe only
+    // allows home/tmp and refuses every path of a volume-backed state dir.
+    await movePathToTrash(trashPath, {
+      allowedRoots: trashAllowedRoots(
+        trashPath,
+        cleanupPath.kind === "symlink" ? cleanupPath.canonicalPath : undefined,
+      ),
+    });
     return { removed: { path: pathname, method: "trash" } };
   } catch (error) {
     if (!isMissingPathError(error)) {

--- a/src/gateway/server-methods/agents.ts
+++ b/src/gateway/server-methods/agents.ts
@@ -82,6 +82,7 @@ import {
   WORKSPACE_BOOTSTRAP_FILENAMES,
 } from "../../agents/workspace.js";
 import { applyAgentConfig } from "../../commands/agents.config.js";
+import { trashAllowedRoots } from "../../commands/cleanup-utils.js";
 import {
   readConfigFileSnapshotForWrite,
   withConfigMutationExclusive,
@@ -92,7 +93,7 @@ import type { IdentityConfig } from "../../config/types.base.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { isMissingPathError } from "../../infra/errors.js";
 import { withAgentExecApprovalsRemoved } from "../../infra/exec-approvals.js";
-import { root, FsSafeError, trashAllowedRoots, type ReadResult } from "../../infra/fs-safe.js";
+import { root, FsSafeError, type ReadResult } from "../../infra/fs-safe.js";
 import { isPathInside } from "../../infra/path-guards.js";
 import { movePathToTrash } from "../../plugin-sdk/browser-maintenance.js";
 import { normalizeAgentIdStrict } from "../../routing/session-key.js";

--- a/src/gateway/server.agent-database-recreation-product-proof.test.ts
+++ b/src/gateway/server.agent-database-recreation-product-proof.test.ts
@@ -1,6 +1,9 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
+import type { AgentsDeleteResult } from "../../packages/gateway-protocol/src/schema/agents-models-skills.js";
+import { isPathInside } from "../infra/path-guards.js";
 import {
   closeOpenClawAgentDatabasesForTest,
   inspectOpenClawAgentDatabaseOwner,
@@ -8,6 +11,7 @@ import {
 } from "../state/openclaw-agent-db.js";
 import { resolveOpenClawAgentSqlitePath } from "../state/openclaw-agent-db.paths.js";
 import { closeOpenClawStateDatabaseForTest } from "../state/openclaw-state-db.js";
+import { withEnvAsync } from "../test-utils/env.js";
 import type { GatewayClient } from "./client.js";
 import { connectGatewayClient, disconnectGatewayClient } from "./test-helpers.e2e.js";
 import {
@@ -17,6 +21,7 @@ import {
 } from "./test-helpers.js";
 
 const AGENT_ID = "recreated-agent";
+const EXTERNAL_STATE_AGENT_ID = "external-state-agent";
 const SESSION_KEY = `agent:${AGENT_ID}:product-proof`;
 
 installGatewayTestHooks();
@@ -109,6 +114,83 @@ describe("agent database recreation product proof", () => {
         await server.close({ reason: "agent database recreation product proof complete" });
         closeOpenClawAgentDatabasesForTest();
         closeOpenClawStateDatabaseForTest();
+      }
+    },
+  );
+});
+
+describe("agent deletion product proof with a state dir outside home and the temp dir", () => {
+  it(
+    "moves the deleted agent's files to Trash through one real Gateway process",
+    { timeout: 180_000 },
+    async () => {
+      // Volume-backed deployments keep OPENCLAW_STATE_DIR outside HOME and os.tmpdir()
+      // (for example /data on Fly), which are fs-safe's default Trash roots.
+      const realTmp = await fs.realpath(os.tmpdir());
+      const tmpOverride = await fs.mkdtemp(path.join(realTmp, "openclaw-tmp-override-"));
+      const stateDir = await fs.mkdtemp(path.join(realTmp, "openclaw-external-state-"));
+      const port = await getGatewayTestPort();
+      const token = "agent-delete-external-state-dir-token";
+      const url = `ws://127.0.0.1:${port}`;
+      try {
+        await withEnvAsync(
+          {
+            OPENCLAW_STATE_DIR: stateDir,
+            TMPDIR: tmpOverride,
+            TMP: tmpOverride,
+            TEMP: tmpOverride,
+          },
+          async () => {
+            expect(isPathInside(await fs.realpath(os.homedir()), stateDir)).toBe(false);
+            expect(isPathInside(await fs.realpath(os.tmpdir()), stateDir)).toBe(false);
+            const server = await startTestGatewayServer(port, {
+              bind: "loopback",
+              auth: { mode: "token", token },
+              controlUiEnabled: false,
+            });
+            let client: GatewayClient | undefined;
+            try {
+              client = await connectGatewayClient({
+                url,
+                token,
+                role: "operator",
+                scopes: ["operator.admin", "operator.read", "operator.write"],
+              });
+              const workspace = path.join(stateDir, "workspace-external-state-agent");
+              await expect(
+                client.request("agents.create", { name: "External State Agent", workspace }),
+              ).resolves.toMatchObject({ agentId: EXTERNAL_STATE_AGENT_ID, ok: true });
+              await fs.writeFile(path.join(workspace, "NOTES.md"), "keep me in Trash\n");
+
+              const result = await client.request<AgentsDeleteResult>("agents.delete", {
+                agentId: EXTERNAL_STATE_AGENT_ID,
+                deleteFiles: true,
+              });
+
+              // Database files are removed by the database-owned deletion first; the
+              // workspace and session directories are what reach Trash here.
+              expect(result).toMatchObject({
+                agentId: EXTERNAL_STATE_AGENT_ID,
+                ok: true,
+                failed: [],
+              });
+              expect(result.removed).toEqual(
+                expect.arrayContaining([{ path: workspace, method: "trash" }]),
+              );
+              await expect(fs.stat(workspace)).rejects.toMatchObject({ code: "ENOENT" });
+            } finally {
+              if (client) {
+                await disconnectGatewayClient(client);
+              }
+              await server.close({ reason: "agent delete external state dir test complete" });
+            }
+          },
+        );
+      } finally {
+        closeOpenClawAgentDatabasesForTest();
+        closeOpenClawStateDatabaseForTest();
+        await fs.rm(stateDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+        await fs.rm(tmpOverride, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
       }
     },
   );

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -68,19 +68,6 @@ export async function root(rootDir: string, defaults?: RootDefaults): Promise<Ro
   return await fsSafeRoot(rootDir, defaults);
 }
 
-/**
- * Allowed Trash roots for an OpenClaw-owned path: its own parent, plus the resolved
- * parent when the path is a symlink (fs-safe checks the link target). The fs-safe
- * default (home + tmp) would refuse state dirs on volumes such as `/data`.
- */
-export function trashAllowedRoots(targetPath: string, resolvedTargetPath?: string): string[] {
-  const roots = [path.dirname(targetPath)];
-  if (resolvedTargetPath !== undefined) {
-    roots.push(path.dirname(resolvedTargetPath));
-  }
-  return [...new Set(roots)];
-}
-
 export type ExternalFileWriteOptions = {
   rootDir: string;
   path: string;

--- a/src/infra/fs-safe.ts
+++ b/src/infra/fs-safe.ts
@@ -68,6 +68,19 @@ export async function root(rootDir: string, defaults?: RootDefaults): Promise<Ro
   return await fsSafeRoot(rootDir, defaults);
 }
 
+/**
+ * Allowed Trash roots for an OpenClaw-owned path: its own parent, plus the resolved
+ * parent when the path is a symlink (fs-safe checks the link target). The fs-safe
+ * default (home + tmp) would refuse state dirs on volumes such as `/data`.
+ */
+export function trashAllowedRoots(targetPath: string, resolvedTargetPath?: string): string[] {
+  const roots = [path.dirname(targetPath)];
+  if (resolvedTargetPath !== undefined) {
+    roots.push(path.dirname(resolvedTargetPath));
+  }
+  return [...new Set(roots)];
+}
+
 export type ExternalFileWriteOptions = {
   rootDir: string;
   path: string;


### PR DESCRIPTION
## What Problem This Solves

`agents.delete` through the Gateway called `movePathToTrash` without allowed roots, so fs-safe fell back to its default roots (the home directory and the temp dir). Any installation whose `OPENCLAW_STATE_DIR` lives elsewhere, such as the documented Fly setup with `OPENCLAW_STATE_DIR=/data` or any volume-backed Docker deployment, saw every agent path refused with `Refusing to trash path outside allowed roots`. The agent left the config, but its workspace, agent dir and session directory stayed on disk, the deletion journal stayed incomplete, and the retained agent tree then tripped the shutdown session-store cleanup for every plugin (`plugin host cleanup failed ... OpenClaw agent database is unavailable while agent <id> is deleted`).

The offline CLI path had already moved to a parent-directory root policy in #125715; the Gateway sibling kept the fs-safe default.

## Why This Change Was Made

The Trash root policy for OpenClaw-owned paths now lives once with the cleanup owner in `src/commands/cleanup-utils.ts` (`trashAllowedRoots`): each declared path's own parent, plus the resolved parent when the moved path is a symlink (moving a link renames the link only). Both delete transports use it. The Gateway additionally keeps fs-safe's shipped home/tmp roots, so the directory behind a symlinked workspace keeps exactly the fence it had before (never widened to arbitrary external targets) while every path of a volume-backed state dir is now allowed. The helper deliberately stays off the fs-safe facade because the plugin SDK infra barrel re-exports that facade wholesale and the public SDK surface is budgeted. The Gateway feeds it the parent it already verified in `statAgentCleanupPath` and the recorded link target for symlink cleanup entries, so no second stat channel is introduced; the CLI path reuses its existing lstat and only resolves a link target when the path is a symlink. The private CLI-only copy is deleted.

## User Impact

Deleting an agent via the Control UI, `openclaw agents delete` with a reachable Gateway, or the `agents.delete` RPC now moves the agent's files to Trash on installations whose state dir is outside the home and temp directories, instead of reporting every path as failed and leaving the tree behind. Installations under `~/.openclaw` are unchanged.

## Evidence

- Live repro on a built `main` dist with an isolated `OPENCLAW_STATE_DIR` under a scratch directory: `agents delete writer --force --json` returned `failed` entries for the workspace, agent dir, session dir and every SQLite file, all with `Refusing to trash path outside allowed roots`; the gateway then logged `plugin host cleanup failed ... agent writer is deleted` for all 19 plugins on shutdown.
- New real-Gateway regression in `src/gateway/server.agent-database-recreation-product-proof.test.ts` (state dir outside `HOME` and `os.tmpdir()`): fails on `main` with the same refusal, passes with the fix (`failed: []`, workspace moved into `.Trash`).
- `src/gateway/server-methods/agents-mutate.test.ts` now asserts every Gateway Trash move carries the declared path's parent as an allowed root (the link's parent for symlink-derived targets); `src/commands/cleanup-utils.test.ts` keeps covering the CLI policy (symlink target parent, dangling links, symlinked parents).
- Local: `node scripts/run-vitest.mjs` over the product proof, `agents-mutate`, `cleanup-utils`, `agents.delete*`, `onboard-helpers`, `fs-safe`, `browser-maintenance` suites; `node scripts/check-changed.mjs` (core + coreTests lanes). Autoreview (Codex) scoped-clean on the final diff.

Production LOC delta: net +14 (policy helper exported from the cleanup owner, private copy removed, Gateway call carries declared-parent roots plus the shipped fence).

Accepted edge, named in the code: a symlink whose target sits beside the link in the same parent now has that target trashed by the Gateway too (the declared parent is a root). Transport divergence that predates this PR and stays out of scope: the Gateway also trashes the resolved directory behind a workspace symlink when it lies under home/tmp, the offline CLI only moves the link.
