### PR TITLE
fix(android): expose the selected connection security option

### DIFF
--- a/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
+++ b/apps/android/app/src/main/java/ai/openclaw/app/ui/OnboardingFlow.kt
@@ -128,6 +128,9 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -2562,9 +2565,10 @@ private fun TogglePill(
   onClick: () -> Unit,
 ) {
   Surface(
+    selected = selected,
     onClick = onClick,
     enabled = enabled,
-    modifier = modifier.heightIn(min = 34.dp),
+    modifier = modifier.heightIn(min = 34.dp).semantics { role = Role.Button },
     shape = RoundedCornerShape(ClawTheme.radii.pill),
     color = if (selected) ClawTheme.colors.primary else ClawTheme.colors.surfaceRaised,
     contentColor = if (selected) ClawTheme.colors.primaryText else ClawTheme.colors.textMuted,

--- a/apps/android/app/src/test/java/ai/openclaw/app/ui/InitialOnboardingLayoutTest.kt
+++ b/apps/android/app/src/test/java/ai/openclaw/app/ui/InitialOnboardingLayoutTest.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.SemanticsActions
 import androidx.compose.ui.semantics.SemanticsProperties
 import androidx.compose.ui.test.DeviceConfigurationOverride
@@ -29,6 +30,8 @@ import androidx.compose.ui.test.assert
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.assertIsEnabled
 import androidx.compose.ui.test.assertIsNotEnabled
+import androidx.compose.ui.test.assertIsNotSelected
+import androidx.compose.ui.test.assertIsSelected
 import androidx.compose.ui.test.getUnclippedBoundsInRoot
 import androidx.compose.ui.test.hasScrollAction
 import androidx.compose.ui.test.hasSetTextAction
@@ -52,7 +55,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModelStore
 import androidx.test.core.app.ApplicationProvider
-import com.google.mlkit.common.internal.MlKitInitProvider
+import com.google.mlkit.common.sdkinternal.MlKitContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
@@ -60,7 +63,6 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
-import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import org.robolectric.util.ReflectionHelpers
@@ -82,17 +84,7 @@ class InitialOnboardingLayoutTest {
 
   @Test
   fun gatewayCredentialsAndSetupCodeAreMasked() {
-    val app = ApplicationProvider.getApplicationContext<NodeApp>()
-    val prefs = SecurePrefs(app, app.getSharedPreferences("onboarding-input-${UUID.randomUUID()}", Context.MODE_PRIVATE))
-    val runtime = NodeRuntime(app, prefs, NodeRuntimeMode.ScreenshotFixture)
-    val models = ViewModelStore()
-    try {
-      Robolectric.buildContentProvider(MlKitInitProvider::class.java).create()
-      val viewModel = MainViewModel(app, prefs, SavedStateHandle())
-      models.put("onboarding", viewModel)
-      ReflectionHelpers.getField<MutableStateFlow<NodeRuntime?>>(viewModel, "runtimeRef").value = runtime
-      setContent(fontScale = 1f, viewportHeight = 720.dp) { OnboardingFlow(viewModel) }
-
+    withOnboarding {
       composeRule.onNodeWithText("Continue").performClick()
       composeRule.onNodeWithText("Set up manually").performClick()
       assertInputPresentation("Host", "127.0.0.1", secret = false, scroll = true)
@@ -104,6 +96,98 @@ class InitialOnboardingLayoutTest {
       composeRule.onNodeWithText("Scan QR or setup code").performClick()
       composeRule.onNodeWithText("Enter setup code").performClick()
       assertInputPresentation("Paste setup code", "synthetic-setup-code", secret = true)
+    }
+  }
+
+  @Test
+  @Config(qualifiers = "w480dp-h800dp-420dpi")
+  fun horizontalTransportChoicesExposeSelectionAndKeepForcedTlsDisabled() = verifyTransportChoices(fontScale = 1f)
+
+  @Test
+  @Config(qualifiers = "w480dp-h800dp-420dpi")
+  fun stackedTransportChoicesExposeSelectionAndKeepForcedTlsDisabled() = verifyTransportChoices(fontScale = 2f)
+
+  private fun verifyTransportChoices(fontScale: Float) {
+    withOnboarding(fontScale = fontScale, viewportWidth = 480.dp) {
+      composeRule.onNodeWithText("Continue").performClick()
+      composeRule.onNodeWithText("Set up manually").performClick()
+
+      fun changeHost(
+        previous: String,
+        next: String,
+      ) {
+        composeRule.onNode(hasSetTextAction() and hasText(previous)).performScrollTo().performTextReplacement(next)
+      }
+      changeHost("Host", "127.0.0.1")
+      val cleartext = composeRule.onNodeWithText("Unencrypted")
+      val tls = composeRule.onNodeWithText("Secure (TLS)")
+
+      fun assertTransport(
+        tlsSelected: Boolean,
+        cleartextEnabled: Boolean = true,
+      ) {
+        tls.performScrollTo().assertIsDisplayed().assertIsEnabled()
+        cleartext.assertIsDisplayed()
+        if (tlsSelected) {
+          tls.assertIsSelected()
+          cleartext.assertIsNotSelected()
+        } else {
+          cleartext.assertIsSelected()
+          tls.assertIsNotSelected()
+        }
+        for (choice in listOf(cleartext, tls)) {
+          choice.assert(SemanticsMatcher.expectValue(SemanticsProperties.Role, Role.Button))
+          val bounds = choice.fetchSemanticsNode().touchBoundsInRoot
+          val minimum = with(composeRule.density) { 48.dp.toPx() }
+          assertTrue("Transport choice keeps its minimum touch width", bounds.width >= minimum)
+          assertTrue("Transport choice keeps its minimum touch height", bounds.height >= minimum)
+        }
+        if (cleartextEnabled) cleartext.assertIsEnabled() else cleartext.assertIsNotEnabled()
+      }
+      assertTransport(tlsSelected = false)
+      val clearBounds = cleartext.getUnclippedBoundsInRoot()
+      val tlsBounds = tls.getUnclippedBoundsInRoot()
+      if (fontScale == 1f) {
+        assertEquals(clearBounds.top, tlsBounds.top)
+        assertTrue("Normal font exercises the horizontal choices", tlsBounds.left >= clearBounds.right)
+      } else {
+        assertEquals(clearBounds.left, tlsBounds.left)
+        assertTrue("Large font exercises the stacked choices", tlsBounds.top >= clearBounds.bottom)
+      }
+      tls.performClick()
+      assertTransport(tlsSelected = true)
+      changeHost("127.0.0.1", "gateway.example.com")
+      assertTransport(tlsSelected = true, cleartextEnabled = false)
+      cleartext.performClick()
+      assertTransport(tlsSelected = true, cleartextEnabled = false)
+      // Returning local exposes an accidental disabled callback that forced TLS would hide.
+      changeHost("gateway.example.com", "127.0.0.1")
+      assertTransport(tlsSelected = true)
+      cleartext.performClick()
+      assertTransport(tlsSelected = false)
+      changeHost("127.0.0.1", "gateway.example.com")
+      assertTransport(tlsSelected = true, cleartextEnabled = false)
+      changeHost("gateway.example.com", "127.0.0.1")
+      assertTransport(tlsSelected = false)
+    }
+  }
+
+  private fun withOnboarding(
+    fontScale: Float = 1f,
+    viewportWidth: Dp = 360.dp,
+    verify: () -> Unit,
+  ) {
+    val app = ApplicationProvider.getApplicationContext<NodeApp>()
+    val prefs = SecurePrefs(app, app.getSharedPreferences("onboarding-input-${UUID.randomUUID()}", Context.MODE_PRIVATE))
+    val runtime = NodeRuntime(app, prefs, NodeRuntimeMode.ScreenshotFixture)
+    val models = ViewModelStore()
+    try {
+      MlKitContext.initializeIfNeeded(app)
+      val viewModel = MainViewModel(app, prefs, SavedStateHandle())
+      models.put("onboarding", viewModel)
+      ReflectionHelpers.getField<MutableStateFlow<NodeRuntime?>>(viewModel, "runtimeRef").value = runtime
+      setContent(fontScale = fontScale, viewportHeight = 720.dp, viewportWidth = viewportWidth) { OnboardingFlow(viewModel) }
+      verify()
     } finally {
       try {
         models.clear()
@@ -303,6 +387,7 @@ class InitialOnboardingLayoutTest {
   private fun setContent(
     fontScale: Float,
     viewportHeight: Dp,
+    viewportWidth: Dp = 360.dp,
     content: @Composable () -> Unit,
   ) {
     composeRule.setContent {
@@ -311,7 +396,7 @@ class InitialOnboardingLayoutTest {
           Box(
             modifier =
               Modifier
-                .size(width = 360.dp, height = viewportHeight)
+                .size(width = viewportWidth, height = viewportHeight)
                 .clipToBounds()
                 .testTag(OnboardingViewportTag),
           ) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where Android users choosing connection security during manual setup could see the active choice by color, but accessibility services had no selected state for either choice.

Related: #142046, where the installed-app audit exposed this gap.

## Why This Change Was Made

The existing pills now use Material3's selectable Surface and the same Button role as the app's standard selectable pills. Material continues to own input handling, disabled behavior, ripple, and minimum touch sizing. No extra state or custom accessibility implementation is introduced.

Production: +5/−1 (net +4), supplying the missing state and role. Tests: +99/−14 (net +85), including a shared onboarding fixture and two layout cases. The fixture uses ML Kit's existing idempotent initialization API so successive tests do not initialize its process singleton twice; scanning behavior is unchanged.

## User Impact

Accessibility services can distinguish the selected transport choice. Appearance, click behavior, forced TLS for public hosts, and the user's remembered localhost choice remain unchanged. No strings, dependencies, configuration, protocol, or storage changes. Existing setup documentation remains accurate.

## Evidence

- Both layout regressions failed on the original production code for the missing selected state. Final onboarding suite: 9 tests, zero failures/errors/skips, covering horizontal/stacked geometry, mutually exclusive selection, button role, 48dp touch bounds, disabled cleartext, and restoration of either localhost preference.
- Changed checks, app ktlint, Play debug APK build, ThirdParty compilation, and both Android lint variants passed. Independent Codex review found no actionable findings.
- Installed the signed candidate APK from `6cc7e6b80a9260391f90b74d0894825d3a26b8d9` on Android API 36 and verified its installed hash. Ordinary onboarding, field edits, and physical taps covered 17 states at font scales 1.0 and 2.0. Disabled taps did not overwrite the prior localhost choice.
- Actual Android accessibility XML changed from neither choice being checkable to mutually exclusive checkable/checked states. Compose emits the Button role on a child node, while the clickable parent carries state and enabled flags. This matches direct inspection of the exact Compose 1.12.0 platform mapping. It is not a claim that XML `selected` becomes true or that spoken TalkBack output was tested.
- The before APK is the actual `5f32d9ccb9998a4775bb820b1db37bd987025206` build. Its Android source, packaged shared resources, and provider icons match this patch's parent; all 199 packaged assets match the candidate. It is not relabeled as a newer build.
- These are inspected synthetic-only screenshots. Their appearance is intentionally unchanged; the XML comparison proves the accessibility improvement. No credentials, connection attempt, Gateway fixture, or provider execution was used. Font scale was restored and the owned emulator exited normally, with PID, device serial, and listeners verified absent.

**Exact-head CI:** [run #34219513326, attempt 2](https://github.com/openclaw/openclaw/actions/runs/34219513326) completed successfully on `6cc7e6b80a9260391f90b74d0894825d3a26b8d9`, including the required CI gate. The initial Play job exceeded its 20-minute execution budget before tests finished; one normal job retry and its dependent gate passed without source or timeout changes. ThirdParty, Wear and ktlint also passed. The latest exact-head ClawSweeper review has no findings or before-merge requests.

![Before — normal text, forced TLS](https://github.com/user-attachments/assets/a2f86a21-cdba-4bcd-930b-d40f30ac2502)

![Before — large text, forced TLS](https://github.com/user-attachments/assets/14f2254f-5a8d-4622-b27d-40bcdad1f209)

![After — normal text, forced TLS](https://github.com/user-attachments/assets/c6df7037-31d4-4d04-8295-256b2b853d26)

![After — large text, forced TLS](https://github.com/user-attachments/assets/e0caf99d-2665-4e93-8087-b4970fe99217)

