### PR TITLE
refactor(tests): share user and sparse assistant inputs

### DIFF
--- a/packages/ai/src/providers/openai-completions.test.ts
+++ b/packages/ai/src/providers/openai-completions.test.ts
@@ -82,6 +82,7 @@ vi.mock("openai", () => {
 });
 
 import { makeTextToolResult } from "../../../../test/helpers/text-tool-result.js";
+import { makeUserMessage } from "../../../../test/helpers/user-message.js";
 import { createZeroUsage } from "../usage.test-support.js";
 import {
   streamOpenAICompletions,
@@ -1141,11 +1142,7 @@ describe("OpenAI-compatible completions params", () => {
       },
       {
         messages: [
-          {
-            role: "user",
-            content: "search first",
-            timestamp: 1,
-          },
+          makeUserMessage("search first", 1),
           {
             role: "assistant",
             api: "openai-completions",
@@ -1164,11 +1161,7 @@ describe("OpenAI-compatible completions params", () => {
             timestamp: 2,
           },
           makeTextToolResult("call_search", "search", "ok", false, 3),
-          {
-            role: "user",
-            content: "continue",
-            timestamp: 4,
-          },
+          makeUserMessage("continue", 4),
         ],
       },
       {

--- a/packages/ai/src/transports/anthropic-transport-stream.test.ts
+++ b/packages/ai/src/transports/anthropic-transport-stream.test.ts
@@ -6,6 +6,7 @@ import type { AssistantMessage, Model } from "@openclaw/llm-core";
  */
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeUserMessage } from "../../../../test/helpers/user-message.js";
 import {
   configureAiTransportHost,
   getAiTransportHost,
@@ -3270,13 +3271,7 @@ describe("anthropic transport stream", () => {
     {
       name: "blank user content",
       context: {
-        messages: [
-          {
-            role: "user",
-            content: " \n\t ",
-            timestamp: 0,
-          },
-        ],
+        messages: [makeUserMessage(" \n\t ", 0)],
       } as AnthropicStreamContext,
     },
   ])(

--- a/packages/memory-host-sdk/src/host/session-files.test.ts
+++ b/packages/memory-host-sdk/src/host/session-files.test.ts
@@ -17,6 +17,7 @@ import {
 } from "../../../../src/config/sessions/session-accessor.js";
 import { closeOpenClawAgentDatabasesForTest } from "../../../../src/state/openclaw-agent-db.js";
 import { closeOpenClawStateDatabaseForTest } from "../../../../src/state/openclaw-state-db.js";
+import { makeUserMessage } from "../../../../test/helpers/user-message.js";
 import {
   buildSessionEntry,
   listSessionTranscriptCorpusEntriesForAgent,
@@ -991,11 +992,7 @@ describe("buildSessionEntry", () => {
     const jsonlLines = [
       JSON.stringify({
         type: "message",
-        message: {
-          role: "user",
-          content: "Hello",
-          timestamp: 8_640_000_000_000_001,
-        },
+        message: makeUserMessage("Hello", 8_640_000_000_000_001),
       }),
     ];
     const filePath = path.join(tmpDir, "invalid-timestamp-session.jsonl");

--- a/src/agents/bootstrap-files.test.ts
+++ b/src/agents/bootstrap-files.test.ts
@@ -7,6 +7,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeUserMessage } from "../../test/helpers/user-message.js";
 import {
   upsertSessionEntryCore,
   type SessionTranscriptRuntimeTarget,
@@ -884,11 +885,7 @@ describe("hasCompletedBootstrapTurn", () => {
   });
 
   it("invalidates a completion marker after compaction", async () => {
-    const firstEntryId = sessionManager.appendMessage({
-      role: "user",
-      content: "hello",
-      timestamp: 1,
-    });
+    const firstEntryId = sessionManager.appendMessage(makeUserMessage("hello", 1));
     sessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, { timestamp: 2 });
     sessionManager.appendCompaction("trimmed", firstEntryId, 10);
 
@@ -896,11 +893,7 @@ describe("hasCompletedBootstrapTurn", () => {
   });
 
   it("accepts a newer full bootstrap marker after compaction", async () => {
-    const firstEntryId = sessionManager.appendMessage({
-      role: "user",
-      content: "hello",
-      timestamp: 1,
-    });
+    const firstEntryId = sessionManager.appendMessage(makeUserMessage("hello", 1));
     sessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, { timestamp: 2 });
     sessionManager.appendCompaction("trimmed", firstEntryId, 10);
     sessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, { timestamp: 3 });
@@ -926,11 +919,7 @@ describe("hasCompletedBootstrapTurn", () => {
   });
 
   it("ignores completion markers on an inactive transcript branch", async () => {
-    const firstEntryId = sessionManager.appendMessage({
-      role: "user",
-      content: "hello",
-      timestamp: 1,
-    });
+    const firstEntryId = sessionManager.appendMessage(makeUserMessage("hello", 1));
     sessionManager.appendCustomEntry(FULL_BOOTSTRAP_COMPLETED_CUSTOM_TYPE, { timestamp: 2 });
     expect(await hasCompletedBootstrapTurn(sessionTarget)).toBe(true);
 

--- a/src/agents/cli-runner/prepare.test.ts
+++ b/src/agents/cli-runner/prepare.test.ts
@@ -9,6 +9,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { Type } from "typebox";
 import { afterEach, beforeEach, describe, expect, it, vi, type MockInstance } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import { buildGroupChatContext, buildGroupIntro } from "../../auto-reply/reply/groups.js";
 import {
   createReplyOperation,
@@ -2420,11 +2421,7 @@ describe("prepareCliRunContext", () => {
         id: "msg-1",
         parentId: null,
         timestamp: new Date(1).toISOString(),
-        message: {
-          role: "user",
-          content: "prior room event",
-          timestamp: 1,
-        },
+        message: makeUserMessage("prior room event", 1),
       });
       // Room resumes carry compact event text into the CLI prompt but keep the
       // richer room context in OpenClaw history for reseed and audits.
@@ -3384,11 +3381,7 @@ describe("prepareCliRunContext", () => {
         id: "msg-1",
         parentId: null,
         timestamp: new Date(1).toISOString(),
-        message: {
-          role: "user",
-          content: "prior no-compaction ask",
-          timestamp: 1,
-        },
+        message: makeUserMessage("prior no-compaction ask", 1),
       });
 
       const context = await prepare({
@@ -3420,11 +3413,7 @@ describe("prepareCliRunContext", () => {
         id: "msg-1",
         parentId: null,
         timestamp: new Date(1).toISOString(),
-        message: {
-          role: "user",
-          content: "prior resumable ask",
-          timestamp: 1,
-        },
+        message: makeUserMessage("prior resumable ask", 1),
       });
 
       const context = await prepare({
@@ -5690,11 +5679,7 @@ describe("prepareCliRunContext", () => {
           id: "msg-1",
           parentId: null,
           timestamp: recoveredAt,
-          message: {
-            role: "user",
-            content: "prior claude-cli ask",
-            timestamp: 1,
-          },
+          message: makeUserMessage("prior claude-cli ask", 1),
         });
         fixture.appendTranscript({
           id: "result-1",
@@ -5870,11 +5855,7 @@ describe("prepareCliRunContext", () => {
         id: "msg-warm-1",
         parentId: null,
         timestamp: new Date(1).toISOString(),
-        message: {
-          role: "user",
-          content: "earlier warm context",
-          timestamp: 1,
-        },
+        message: makeUserMessage("earlier warm context", 1),
       });
       setCliBackendForPrepareTest({
         liveSession: true,
@@ -6272,11 +6253,7 @@ describe("prepareCliRunContext", () => {
     const { dir, sessionTarget } = fixture.session;
     const durable = SessionManager.open(sessionTarget, dir);
     durable.appendMessage({ role: "user", content: "BORROWED_PREFIX", timestamp: 1 });
-    const retained = durable.appendMessage({
-      role: "user",
-      content: "BORROWED_RETAINED",
-      timestamp: 2,
-    });
+    const retained = durable.appendMessage(makeUserMessage("BORROWED_RETAINED", 2));
     durable.appendCompaction("BORROWED_SUMMARY", retained, 1000);
     durable.appendMessage({ role: "user", content: "BORROWED_TAIL", timestamp: 3 });
     durable.flushPendingPersistence();
@@ -6351,11 +6328,7 @@ describe("prepareCliRunContext", () => {
           ? { ...fixtureTarget, storePath: path.join(dir, "absent", "openclaw-agent.sqlite") }
           : fixtureTarget;
       const durable = SessionManager.open(fixtureTarget, dir);
-      const retained = durable.appendMessage({
-        role: "user",
-        content: "BORROWED_RETAINED",
-        timestamp: 1,
-      });
+      const retained = durable.appendMessage(makeUserMessage("BORROWED_RETAINED", 1));
       durable.appendCompaction("BORROWED_SUMMARY", retained, 1000);
       durable.appendMessage({ role: "user", content: "BORROWED_TAIL", timestamp: 2 });
       durable.flushPendingPersistence();
@@ -6363,11 +6336,7 @@ describe("prepareCliRunContext", () => {
       const entryBefore = loadSessionEntryReadOnly(fixtureTarget);
       const sessionManager = SessionManager.inMemory(dir);
       if (scenario === "raw" || scenario === "compacted") {
-        const kept = sessionManager.appendMessage({
-          role: "user",
-          content: "OWNED_RETAINED",
-          timestamp: 1,
-        });
+        const kept = sessionManager.appendMessage(makeUserMessage("OWNED_RETAINED", 1));
         if (scenario === "compacted") {
           sessionManager.appendCompaction("OWNED_SUMMARY", kept, 1000);
         }
@@ -6648,11 +6617,7 @@ describe("prepareCliRunContext", () => {
         setCliBackendForPrepareTest({ modelAliases: testCase.modelAliases });
       }
       const manager = SessionManager.open(sessionTarget, dir);
-      const firstKeptEntryId = manager.appendMessage({
-        role: "user",
-        content: "RESEED_RETAINED_PREFIX",
-        timestamp: 1,
-      });
+      const firstKeptEntryId = manager.appendMessage(makeUserMessage("RESEED_RETAINED_PREFIX", 1));
       manager.appendCompaction(
         `${testCase.marker} ${"x".repeat(testCase.padding)}`,
         firstKeptEntryId,

--- a/src/agents/cli-runner/session-history.test.ts
+++ b/src/agents/cli-runner/session-history.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import {
   appendTranscriptEvent,
   appendTranscriptMessage,
@@ -79,11 +80,7 @@ it("recovers SQLite-only compacted history across every CLI reader", async () =>
     };
     await upsertSessionEntryCore(target, { sessionId: target.sessionId, updatedAt: 1 });
     const manager = SessionManager.open(target, stateDir);
-    const kept = manager.appendMessage({
-      role: "user",
-      content: "CANONICAL_HISTORY",
-      timestamp: 1,
-    });
+    const kept = manager.appendMessage(makeUserMessage("CANONICAL_HISTORY", 1));
     manager.appendCompaction("CANONICAL_SUMMARY", kept, 1000);
     manager.appendMessage({ role: "user", content: "CANONICAL_TAIL", timestamp: 3 });
     manager.flushPendingPersistence();
@@ -237,11 +234,7 @@ describe("canonical CLI history", () => {
       durable.appendMessage({ role: "user", content: "BORROWED_TAIL", timestamp: 1 });
       const manager = SessionManager.inMemory();
       const first = manager.appendMessage({ role: "user", content: "OWNED_PREFIX", timestamp: 11 });
-      const retained = manager.appendMessage({
-        role: "user",
-        content: "OWNED_RETAINED",
-        timestamp: 12,
-      });
+      const retained = manager.appendMessage(makeUserMessage("OWNED_RETAINED", 12));
       if (shape === "compacted") {
         manager.appendCompaction("OWNED_SUMMARY", retained, 1000, { source: "owned" });
       }

--- a/src/agents/compaction.abort-http.test.ts
+++ b/src/agents/compaction.abort-http.test.ts
@@ -1,6 +1,7 @@
 import { createServer } from "node:http";
 import { performance } from "node:perf_hooks";
 import { describe, expect, it } from "vitest";
+import { makeUserMessage } from "../../test/helpers/user-message.js";
 import { summarizeInStages } from "./compaction.js";
 import type { AgentMessage } from "./runtime/index.js";
 import type { ExtensionContext } from "./sessions/index.js";
@@ -67,11 +68,7 @@ describe("compaction retry backoff over real HTTP", () => {
       } satisfies NonNullable<ExtensionContext["model"]>;
 
       const messages: AgentMessage[] = [
-        {
-          role: "user",
-          content: "Keep this original conversation and opaque ID 5cf86ba9 unchanged.",
-          timestamp: 1,
-        },
+        makeUserMessage("Keep this original conversation and opaque ID 5cf86ba9 unchanged.", 1),
       ];
       const originalHistory = Buffer.from(JSON.stringify(messages));
 

--- a/src/agents/compaction.summarize-fallback.test.ts
+++ b/src/agents/compaction.summarize-fallback.test.ts
@@ -4,6 +4,7 @@ import type { ExtensionContext } from "openclaw/plugin-sdk/agent-sessions";
 import type { UserMessage } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CompactionError } from "../../packages/agent-core/src/harness/types.js";
+import { makeUserMessage } from "../../test/helpers/user-message.js";
 import { isAbortError } from "../infra/abort-signal.js";
 import { summarizeWithFallback } from "./compaction.test-support.js";
 
@@ -66,13 +67,7 @@ describe("summarizeWithFallback", () => {
     async ({ error, attempts }) => {
       agentSessionMocks.generateSummary.mockRejectedValue(error);
       const signal = new AbortController().signal;
-      const messages: AgentMessage[] = [
-        {
-          role: "user",
-          content: "hello",
-          timestamp: 1,
-        } satisfies UserMessage,
-      ];
+      const messages: AgentMessage[] = [makeUserMessage("hello", 1) satisfies UserMessage];
 
       const result = expect(
         summarizeWithFallback({
@@ -110,13 +105,7 @@ describe("summarizeWithFallback", () => {
       .mockResolvedValueOnce("recovered summary after provider disconnect");
 
     const summary = summarizeWithFallback({
-      messages: [
-        {
-          role: "user",
-          content: "hello",
-          timestamp: 1,
-        } satisfies UserMessage,
-      ],
+      messages: [makeUserMessage("hello", 1) satisfies UserMessage],
       model: testModel,
       apiKey: "test-key", // pragma: allowlist secret
       signal: new AbortController().signal, // not aborted
@@ -143,13 +132,7 @@ describe("summarizeWithFallback", () => {
 
     const result = expect(
       summarizeWithFallback({
-        messages: [
-          {
-            role: "user",
-            content: "hello",
-            timestamp: 1,
-          } satisfies UserMessage,
-        ],
+        messages: [makeUserMessage("hello", 1) satisfies UserMessage],
         model: testModel,
         apiKey: "test-key", // pragma: allowlist secret
         signal: new AbortController().signal,
@@ -168,13 +151,7 @@ describe("summarizeWithFallback", () => {
 
     const result = expect(
       summarizeWithFallback({
-        messages: [
-          {
-            role: "user",
-            content: "hello",
-            timestamp: 1,
-          } satisfies UserMessage,
-        ],
+        messages: [makeUserMessage("hello", 1) satisfies UserMessage],
         model: testModel,
         apiKey: "test-key", // pragma: allowlist secret
         signal: controller.signal, // already aborted
@@ -197,13 +174,7 @@ describe("summarizeWithFallback", () => {
 
     const startedAt = Date.now();
     const promise = summarizeWithFallback({
-      messages: [
-        {
-          role: "user",
-          content: "hello",
-          timestamp: 1,
-        } satisfies UserMessage,
-      ],
+      messages: [makeUserMessage("hello", 1) satisfies UserMessage],
       model: testModel,
       apiKey: "test-key", // pragma: allowlist secret
       signal: controller.signal,
@@ -225,11 +196,7 @@ describe("summarizeWithFallback", () => {
     // Oversized-message fallback tries the safe subset so a huge attachment or
     // tool output does not prevent summarizing the rest of the transcript.
     const messages: AgentMessage[] = [
-      {
-        role: "user",
-        content: "small",
-        timestamp: 1,
-      } satisfies UserMessage,
+      makeUserMessage("small", 1) satisfies UserMessage,
       {
         role: "user",
         content: "x".repeat(500_000),

--- a/src/agents/compaction.token-sanitize.test.ts
+++ b/src/agents/compaction.token-sanitize.test.ts
@@ -1,6 +1,7 @@
 // Verifies compaction token planning strips private/non-model fields first.
 import { serializeConversation, type AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it } from "vitest";
+import { makeUserMessage } from "../../test/helpers/user-message.js";
 import {
   buildOversizedFallbackPlan,
   estimateMessagesTokens,
@@ -29,11 +30,7 @@ describe("compaction token accounting sanitization", () => {
         content: "internal",
         timestamp: 2,
       } as AgentMessage,
-      {
-        role: "user",
-        content: "next",
-        timestamp: 3,
-      },
+      makeUserMessage("next", 3),
     ];
 
     const sanitized = projectCompactionMessagesForPlanning(messages);

--- a/src/agents/embedded-agent-helpers.validate-turns.test.ts
+++ b/src/agents/embedded-agent-helpers.validate-turns.test.ts
@@ -3,8 +3,9 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { describe, expect, it } from "vitest";
+import { makeUserMessage } from "../../test/helpers/user-message.js";
 import { validateAnthropicTurns, validateGeminiTurns } from "./embedded-agent-helpers.js";
-import { textToolResult } from "./test-helpers/sparse-transcript.test-support.js";
+import { textToolResult, textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 
 function asMessages(messages: unknown[]): AgentMessage[] {
   return messages as AgentMessage[];
@@ -162,14 +163,8 @@ describe("validateGeminiTurns", () => {
         toolUseId: "tool-1",
         content: [{ type: "text", text: "Found data" }],
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Here's the answer" }],
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Extra thoughts" }],
-      },
+      textAssistant("Here's the answer"),
+      textAssistant("Extra thoughts"),
       { role: "user", content: "Request 2" },
     ]);
 
@@ -202,10 +197,7 @@ describe("validateAnthropicTurns", () => {
   it("should return alternating user/assistant unchanged", () => {
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Question" }] },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Answer" }],
-      },
+      textAssistant("Answer"),
       { role: "user", content: [{ type: "text", text: "Follow-up" }] },
     ]);
     const result = validateAnthropicTurns(msgs);
@@ -335,14 +327,8 @@ describe("validateAnthropicTurns", () => {
   it("merges consecutive assistant messages", () => {
     const msgs = asMessages([
       { role: "user", content: [{ type: "text", text: "Question" }] },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Answer 1" }],
-      },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Answer 2" }],
-      },
+      textAssistant("Answer 1"),
+      textAssistant("Answer 2"),
     ]);
 
     const result = validateAnthropicTurns(msgs);
@@ -475,16 +461,8 @@ describe("validateAnthropicTurns consecutive user turns", () => {
   });
 
   it("preserves string content while merging content", () => {
-    const previous = {
-      role: "user",
-      content: "before",
-      timestamp: 1000,
-    } as Extract<AgentMessage, { role: "user" }>;
-    const current = {
-      role: "user",
-      content: "after",
-      timestamp: 2000,
-    } as Extract<AgentMessage, { role: "user" }>;
+    const previous = makeUserMessage("before", 1000) as Extract<AgentMessage, { role: "user" }>;
+    const current = makeUserMessage("after", 2000) as Extract<AgentMessage, { role: "user" }>;
 
     const [merged] = validateAnthropicTurns([previous, current]);
     expect(merged?.role).toBe("user");

--- a/src/agents/embedded-agent-runner.guard.test.ts
+++ b/src/agents/embedded-agent-runner.guard.test.ts
@@ -13,6 +13,7 @@ import { createMockPluginRegistry } from "openclaw/plugin-sdk/plugin-test-runtim
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createFileBackedSessionManagerForTest } from "../../test/helpers/session-manager-file-fixture.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { makeUserMessage } from "../../test/helpers/user-message.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { attachRuntimeUserTurnTranscriptContext } from "../sessions/user-turn-transcript-runtime-context.js";
 import {
@@ -25,7 +26,7 @@ import { runAgentHarnessBeforeMessageWriteHook } from "./harness/hook-helpers.js
 import { guardSessionManager } from "./session-tool-result-guard-wrapper.js";
 import { sanitizeToolUseResultPairing } from "./session-transcript-repair.js";
 import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
-import { textToolResult } from "./test-helpers/sparse-transcript.test-support.js";
+import { textToolResult, textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 
 function assistantToolCall(id: string): AgentMessage {
   return {
@@ -56,10 +57,7 @@ describe("guardSessionManager integration", () => {
     const appendMessage = sm.appendMessage.bind(sm) as unknown as (message: AgentMessage) => void;
 
     appendMessage(assistantToolCall("call_1"));
-    appendMessage({
-      role: "assistant",
-      content: [{ type: "text", text: "followup" }],
-    } as AgentMessage);
+    appendMessage(textAssistant("followup") as AgentMessage);
 
     const messages = getMessages(sm);
 
@@ -435,11 +433,7 @@ describe("guardSessionManager integration", () => {
     });
     const preparedMessage = expectDefined(recorder.message, "expected prepared queued turn");
     const runtimeMessage = attachRuntimeUserTurnTranscriptContext(
-      {
-        role: "user",
-        content: "runtime queued prompt",
-        timestamp: 456,
-      },
+      makeUserMessage("runtime queued prompt", 456),
       { message: preparedMessage, recorder },
     );
     const sm = guardSessionManager(SessionManager.inMemory());

--- a/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
+++ b/src/agents/embedded-agent-runner.sanitize-session-history.test.ts
@@ -24,7 +24,7 @@ import {
 } from "./embedded-agent-runner.sanitize-session-history.test-harness.js";
 import { validateReplayTurns } from "./embedded-agent-runner/replay-history.js";
 import { castAgentMessage, castAgentMessages } from "./test-helpers/agent-message-fixtures.js";
-import { textToolResult } from "./test-helpers/sparse-transcript.test-support.js";
+import { textToolResult, textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 import { extractToolCallsFromAssistant } from "./tool-call-id.js";
 import type { TranscriptPolicy } from "./transcript-policy.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
@@ -404,12 +404,7 @@ describe("sanitizeSessionHistory", () => {
     const sessionManager = makeInMemorySessionManager(sessionEntries);
 
     const result = await sanitizeSessionHistory({
-      messages: castAgentMessages([
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "hello from previous turn" }],
-        },
-      ]),
+      messages: castAgentMessages([textAssistant("hello from previous turn")]),
       modelApi: "google-generative-ai",
       provider: "google-vertex",
       sessionManager,
@@ -485,12 +480,7 @@ describe("sanitizeSessionHistory", () => {
   it("prepends a bootstrap user turn for strict OpenAI-compatible assistant-first history", async () => {
     const sessionEntries: Array<{ type: string; customType: string; data: unknown }> = [];
     const sessionManager = makeInMemorySessionManager(sessionEntries);
-    const messages = castAgentMessages([
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "hello from previous turn" }],
-      },
-    ]);
+    const messages = castAgentMessages([textAssistant("hello from previous turn")]);
 
     const result = await sanitizeSessionHistory({
       messages,
@@ -583,10 +573,7 @@ describe("sanitizeSessionHistory", () => {
     const assistant = await getSingleAssistantUsage(
       castAgentMessages([
         { role: "user", content: "question" },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "answer without usage" }],
-        },
+        textAssistant("answer without usage"),
       ]),
     );
 

--- a/src/agents/embedded-agent-runner/run-orchestrator.suspension.test.ts
+++ b/src/agents/embedded-agent-runner/run-orchestrator.suspension.test.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 import { createAssistantMessageEventStream, type Context } from "openclaw/plugin-sdk/llm";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import { resolveSessionStorePathCore } from "../../config/sessions/paths.js";
 import {
   loadSessionEntryReadOnly as loadSessionEntry,
@@ -439,11 +440,7 @@ describe("embedded run detached session metadata", () => {
       const { params, scope, stateDir, database } = await createRun("research", "detached");
       params.config.agents!.defaults!.compaction = { mode: "default", keepRecentTokens: 1 };
       const manager = params.sessionManager;
-      manager.appendMessage({
-        role: "user",
-        content: "Remember the memory-only project.",
-        timestamp: 1,
-      });
+      manager.appendMessage(makeUserMessage("Remember the memory-only project.", 1));
       manager.appendMessage(
         buildEmbeddedRunnerAssistant({
           content: [{ type: "text", text: "The project is called Blue Heron." }],
@@ -458,11 +455,9 @@ describe("embedded run detached session metadata", () => {
           providerOverride: "openai",
           modelOverride: "mock-1",
         });
-        SessionManager.open({ ...scope, sessionId: params.sessionId }).appendMessage({
-          role: "user",
-          content: "BORROWED DURABLE HISTORY MUST NOT BE READ",
-          timestamp: 1,
-        });
+        SessionManager.open({ ...scope, sessionId: params.sessionId }).appendMessage(
+          makeUserMessage("BORROWED DURABLE HISTORY MUST NOT BE READ", 1),
+        );
       }
       const before = loadSessionEntry(scope);
       closeOpenClawAgentDatabasesForTest();

--- a/src/agents/embedded-agent-runner/run.incomplete-turn.payload-resolution.test.ts
+++ b/src/agents/embedded-agent-runner/run.incomplete-turn.payload-resolution.test.ts
@@ -1,5 +1,6 @@
 // Focused incomplete-turn behavior coverage.
 import { describe, expect, it } from "vitest";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import {
   buildEmbeddedRunnerAssistant,
   makeEmbeddedRunnerAttempt,
@@ -42,11 +43,7 @@ describe("incomplete-turn payload resolution", () => {
       assistantTexts: [],
       toolMetas: [{ toolName: "bash", meta: "workspace" }],
       messagesSnapshot: [
-        {
-          role: "user",
-          content: "check running processes",
-          timestamp: 1,
-        },
+        makeUserMessage("check running processes", 1),
         {
           role: "toolResult",
           content: "",

--- a/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test-support.ts
+++ b/src/agents/embedded-agent-runner/run.timeout-triggered-compaction.test-support.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import type { OpenClawTestState } from "../../test-utils/openclaw-test-state.js";
 import type { AgentHarness } from "../harness/types.js";
 import { makeAttemptResult, makeCompactionSuccess } from "./run.overflow-compaction.fixture.js";
@@ -71,11 +72,7 @@ describe("runEmbeddedAgent timeout recovery composition", () => {
     mockedBuildEmbeddedRunPayloads.mockReturnValue([{ text: "timeout recovery complete" }]);
     mockedRunEmbeddedAttempt
       .mockImplementationOnce(async (params) => {
-        params.onUserMessagePersisted?.({
-          role: "user",
-          content: "hello",
-          timestamp: 1,
-        });
+        params.onUserMessagePersisted?.(makeUserMessage("hello", 1));
         return makeAttemptResult({
           timedOut: true,
           lastAssistant: { usage: { input: 160_000 } } as never,

--- a/src/agents/embedded-agent-runner/run/attempt-stream-finalize.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-stream-finalize.test.ts
@@ -28,6 +28,7 @@ vi.mock("./attempt-stream-settle.js", () => ({
   settleEmbeddedAttemptStream: mocks.settleStream,
 }));
 
+import { makeUserMessage } from "../../../../test/helpers/user-message.js";
 import { createSubscribedSessionHarness } from "../../embedded-agent-subscribe.e2e-harness.js";
 import { SessionManager } from "../../sessions/index.js";
 import { runEmbeddedAttemptSettledPhase } from "./attempt-settle.js";
@@ -315,11 +316,7 @@ describe("runEmbeddedAttemptSettledPhase stream finalization", () => {
 
   it("rewinds the exact rejected branch before the hidden retry can choose NO_REPLY", async () => {
     const sessionManager = SessionManager.inMemory();
-    const promptId = sessionManager.appendMessage({
-      role: "user",
-      content: "Original request",
-      timestamp: 1,
-    });
+    const promptId = sessionManager.appendMessage(makeUserMessage("Original request", 1));
     const rejectedId = sessionManager.appendMessage({
       role: "assistant",
       content: [{ type: "text", text: "Rejected first answer" }],
@@ -574,11 +571,7 @@ describe("runEmbeddedAttemptSettledPhase stream finalization", () => {
 
   it("restores the rewound in-memory branch when settlement fails", async () => {
     const sessionManager = SessionManager.inMemory();
-    const promptId = sessionManager.appendMessage({
-      role: "user",
-      content: "Original request",
-      timestamp: 1,
-    });
+    const promptId = sessionManager.appendMessage(makeUserMessage("Original request", 1));
     const rejectedId = sessionManager.appendMessage({
       role: "assistant",
       content: [{ type: "text", text: "Rejected first answer" }],

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.steering.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.steering.test.ts
@@ -1,5 +1,6 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
+import { makeUserMessage } from "../../../../test/helpers/user-message.js";
 import { relocateCurrentRuntimeContextCarrierToTail } from "../../internal-runtime-context.js";
 import { Agent, type AgentMessage } from "../../runtime/index.js";
 import {
@@ -275,11 +276,7 @@ describe("active prompt steering context", () => {
         normalizeMessagesForLlmBoundary(session.messages, options),
       );
     const prefix = project();
-    session.agent.state.messages.push({
-      role: "user",
-      content: "new requirement",
-      timestamp: 1717570860000,
-    });
+    session.agent.state.messages.push(makeUserMessage("new requirement", 1717570860000));
     const steered = project();
     cleanup();
 

--- a/src/agents/embedded-agent-runner/run/attempt.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.test.ts
@@ -1,7 +1,10 @@
 // Broad helper coverage for runEmbeddedAttempt prompt, stream, and tool seams.
 import { describe, expect, it, vi } from "vitest";
 import { streamSimple } from "../../../llm/stream.js";
-import { textToolResult } from "../../test-helpers/sparse-transcript.test-support.js";
+import {
+  textToolResult,
+  textAssistant,
+} from "../../test-helpers/sparse-transcript.test-support.js";
 
 vi.mock("../context-engine-capabilities.js", () => ({
   resolveContextEngineCapabilities: async () => ({ llm: undefined }),
@@ -1102,10 +1105,7 @@ describe("wrapStreamFnTrimToolCallNames", () => {
               message: { role: "assistant", content: [{ type: "toolCall", name: " read " }] },
             },
           ],
-          resultMessage: {
-            role: "assistant",
-            content: [{ type: "text", text: "resolved to allowed tool" }],
-          },
+          resultMessage: textAssistant("resolved to allowed tool"),
         }),
       )
       .mockImplementationOnce(() =>
@@ -1682,10 +1682,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
         role: "user",
         content: [{ type: "text", text: "earlier question" }],
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "stale assistant answer" }],
-      },
+      textAssistant("stale assistant answer"),
     ];
     const baseFn = vi.fn((_model, _context) =>
       createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),
@@ -1720,10 +1717,7 @@ describe("wrapStreamFnSanitizeMalformedToolCalls", () => {
         role: "user",
         content: [{ type: "text", text: "earlier question" }],
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "stale model answer" }],
-      },
+      textAssistant("stale model answer"),
     ];
     const baseFn = vi.fn((_model, _context) =>
       createFakeStream({ events: [], resultMessage: { role: "assistant", content: [] } }),

--- a/src/agents/embedded-agent-runner/sanitize-session-history.tool-result-details.test.ts
+++ b/src/agents/embedded-agent-runner/sanitize-session-history.tool-result-details.test.ts
@@ -4,6 +4,7 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import type { ToolResultMessage, UserMessage } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import { makeAgentAssistantMessage } from "../test-helpers/agent-message-fixtures.js";
 import { sanitizeSessionHistory } from "./replay-history.js";
 
@@ -43,11 +44,7 @@ describe("sanitizeSessionHistory toolResult details stripping", () => {
         },
         timestamp: 2,
       } satisfies ToolResultMessage<{ raw: string }>,
-      {
-        role: "user",
-        content: "continue",
-        timestamp: 3,
-      } satisfies UserMessage,
+      makeUserMessage("continue", 3) satisfies UserMessage,
     ];
 
     const sanitized = await sanitizeSessionHistory({

--- a/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
+++ b/src/agents/embedded-agent-runner/server-endpoint-compaction.test.ts
@@ -13,6 +13,7 @@ vi.mock("@openclaw/ai/transports", async (importOriginal) => ({
   requestPreparedOpenAIResponsesCompaction: requestPreparedCompactionMock,
 }));
 
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import { testing } from "../openai-transport-stream.test-support.js";
 import { attemptServerEndpointCompaction } from "./server-endpoint-compaction.js";
 
@@ -234,11 +235,7 @@ describe("attemptServerEndpointCompaction", () => {
   });
 
   it("does not compact transcript entries that remain after the checkpoint owner", async () => {
-    const messages = createSession().messages.concat({
-      role: "user",
-      content: "trailing turn",
-      timestamp: 3,
-    });
+    const messages = createSession().messages.concat(makeUserMessage("trailing turn", 3));
     const { result } = attempt({ context: { systemPrompt: "system", messages } });
 
     await expect(result).resolves.toBeUndefined();

--- a/src/agents/embedded-agent-runner/thinking.test.ts
+++ b/src/agents/embedded-agent-runner/thinking.test.ts
@@ -4,6 +4,7 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { createAssistantMessageEventStream } from "openclaw/plugin-sdk/llm";
 import { describe, expect, it, vi } from "vitest";
 import { castAgentMessage, castAgentMessages } from "../test-helpers/agent-message-fixtures.js";
+import { textAssistant } from "../test-helpers/sparse-transcript.test-support.js";
 import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { stripStaleThinkingSignaturesForCompactionReplay } from "../thinking-signatures.js";
 import {
@@ -148,10 +149,7 @@ describe("dropThinkingBlocks", () => {
         content: [{ type: "redacted_thinking", data: "opaque" }],
       }),
       castAgentMessage({ role: "user", content: "second" }),
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "latest text" }],
-      }),
+      castAgentMessage(textAssistant("latest text")),
     ];
 
     const result = dropThinkingBlocks(messages);

--- a/src/agents/embedded-agent-runner/transcript-file-state.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-file-state.test.ts
@@ -5,7 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { parseSessionEntries, SessionManager } from "../sessions/index.js";
-import { textToolResult } from "../test-helpers/sparse-transcript.test-support.js";
+import { textToolResult, textAssistant } from "../test-helpers/sparse-transcript.test-support.js";
 
 const roots: string[] = [];
 
@@ -171,10 +171,7 @@ describe("readTranscriptState", () => {
         id: "legacy-orphan-child",
         parentId: "legacy-orphan",
         timestamp: "2026-05-16T00:00:08.000Z",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "still reachable from the orphan root" }],
-        },
+        message: textAssistant("still reachable from the orphan root"),
       }),
     ]);
 

--- a/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
+++ b/src/agents/embedded-agent-runner/transcript-rewrite.test.ts
@@ -7,6 +7,7 @@ import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { afterEach, beforeAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
 import {
   appendTranscriptMessage,
@@ -64,11 +65,7 @@ function createReadRewriteSession(options?: { tailAssistantText?: string }) {
   // must re-append downstream entries after replacing the tool result.
   const sessionManager = SessionManager.inMemory();
   const entryIds = appendSessionMessages(sessionManager, [
-    asAppendMessage({
-      role: "user",
-      content: "read file",
-      timestamp: 1,
-    }),
+    asAppendMessage(makeUserMessage("read file", 1)),
     asAppendMessage({
       role: "assistant",
       content: [{ type: "toolCall", id: "call_1", name: "read", arguments: {} }],
@@ -98,11 +95,7 @@ function createReadRewriteSession(options?: { tailAssistantText?: string }) {
 function createExecRewriteSession() {
   const sessionManager = SessionManager.inMemory();
   const entryIds = appendSessionMessages(sessionManager, [
-    asAppendMessage({
-      role: "user",
-      content: "run tool",
-      timestamp: 1,
-    }),
+    asAppendMessage(makeUserMessage("run tool", 1)),
     asAppendMessage({
       role: "toolResult",
       toolCallId: "call_1",
@@ -621,11 +614,9 @@ describe("rewriteTranscriptEntriesInSessionManager", () => {
         }).changed,
       ).toBe(false);
       expect(await loadTranscriptEvents(target)).toEqual(rowsBeforeNoop);
-      SessionManager.openBounded(target, { maxBytes: 64_000, maxEvents: 20 }).appendMessage({
-        role: "user",
-        content: "next turn",
-        timestamp: 5,
-      });
+      SessionManager.openBounded(target, { maxBytes: 64_000, maxEvents: 20 }).appendMessage(
+        makeUserMessage("next turn", 5),
+      );
       manager = SessionManager.open(target);
       expect(manager.getBranch()).toHaveLength(expectedLength + 1);
       await waitForSessionTranscriptProjection(target);

--- a/src/agents/embedded-agent-subscribe.reply-tags.test.ts
+++ b/src/agents/embedded-agent-subscribe.reply-tags.test.ts
@@ -8,6 +8,7 @@ import {
   emitAssistantTextEnd,
 } from "./embedded-agent-subscribe.e2e-harness.js";
 import { subscribeEmbeddedAgentSession } from "./embedded-agent-subscribe.js";
+import { textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 
 describe("subscribeEmbeddedAgentSession reply tags", () => {
   type ReplyPayload = { text?: string; replyToCurrent?: boolean; replyToTag?: boolean };
@@ -56,10 +57,7 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
     emitAssistantTextDelta({ emit, delta: "[[reply_to_current]]\nHello" });
     emitAssistantTextEnd({ emit });
 
-    const assistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "[[reply_to_current]]\nHello" }],
-    } as AssistantMessage;
+    const assistantMessage = textAssistant("[[reply_to_current]]\nHello") as AssistantMessage;
     emit({ type: "message_end", message: assistantMessage });
 
     expect(onBlockReply).toHaveBeenCalledTimes(1);
@@ -192,10 +190,7 @@ describe("subscribeEmbeddedAgentSession reply tags", () => {
     emitAssistantTextDelta({ emit, delta: "current] Visible reply" });
     emitAssistantTextEnd({ emit });
 
-    const assistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "[[reply_to_current] Visible reply" }],
-    } as AssistantMessage;
+    const assistantMessage = textAssistant("[[reply_to_current] Visible reply") as AssistantMessage;
     emit({ type: "message_end", message: assistantMessage });
     await subscription.waitForPendingEvents();
 

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.block-reply-flushing.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.block-reply-flushing.test.ts
@@ -5,6 +5,7 @@ import {
   emitAssistantTextDelta,
 } from "./embedded-agent-subscribe.e2e-harness.js";
 import { subscribeEmbeddedAgentSession } from "./embedded-agent-subscribe.js";
+import { textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 
 function firstBlockReplyText(onBlockReply: ReturnType<typeof vi.fn>): string | undefined {
   // Flush tests only care about the first emitted user-visible chunk.
@@ -161,10 +162,7 @@ describe("subscribeEmbeddedAgentSession", () => {
 
     emit({
       type: "message_end",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Final reply before lifecycle end." }],
-      },
+      message: textAssistant("Final reply before lifecycle end."),
     });
     await Promise.resolve();
 
@@ -201,10 +199,7 @@ describe("subscribeEmbeddedAgentSession", () => {
 
     emit({
       type: "message_end",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Final reply before lifecycle end." }],
-      },
+      message: textAssistant("Final reply before lifecycle end."),
     });
     await vi.waitFor(() => {
       expect(delivered).toEqual(["Final reply before lifecycle end."]);

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.compaction-and-tool-summaries.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.compaction-and-tool-summaries.test.ts
@@ -11,6 +11,7 @@ import {
 import { subscribeEmbeddedAgentSession } from "./embedded-agent-subscribe.js";
 import type { AgentSessionEvent } from "./sessions/index.js";
 import { makeAgentAssistantMessage } from "./test-helpers/agent-message-fixtures.js";
+import { textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
 
 type SessionEventHandler = (evt: unknown) => void;
@@ -217,10 +218,7 @@ describe("fenced output and compaction retries", () => {
       runId: "run-1",
     });
 
-    const assistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "oops" }],
-    } as AssistantMessage;
+    const assistantMessage = textAssistant("oops") as AssistantMessage;
 
     for (const listener of listeners) {
       listener({ type: "message_end", message: assistantMessage });
@@ -524,10 +522,7 @@ describe("subscribeEmbeddedAgentSession", () => {
     const { emit, subscription } = createSubscribedSessionHarness({
       runId: "run-compaction-assistant",
     });
-    const assistant = {
-      role: "assistant",
-      content: [{ type: "text", text: "Reply before compaction" }],
-    } as AssistantMessage;
+    const assistant = textAssistant("Reply before compaction") as AssistantMessage;
 
     emit({ type: "message_end", message: assistant });
     expect(subscription.getCurrentAttemptAssistant()).toEqual(assistant);

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-answer-delivery.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-answer-delivery.test.ts
@@ -22,6 +22,7 @@ import {
   createOpenAiResponsesTextEvent,
   type OpenAiResponsesTextEventPhase,
 } from "./embedded-agent-subscribe.openai-responses.test-helpers.js";
+import { textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 
 describe("text_end snapshot reconciliation", () => {
   it.each([
@@ -441,10 +442,7 @@ describe("subscribeEmbeddedAgentSession", () => {
     expect(extractTextPayloads(onBlockReply.mock.calls)).toEqual(["Hello block"]);
     expect(subscription.assistantTexts).toEqual(["Hello block"]);
 
-    const assistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "Hello block" }],
-    } as AssistantMessage;
+    const assistantMessage = textAssistant("Hello block") as AssistantMessage;
 
     emit({ type: "message_end", message: assistantMessage });
 
@@ -464,10 +462,7 @@ describe("subscribeEmbeddedAgentSession", () => {
 
     emit({
       type: "message_end",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Final visible reply." }],
-      } as AssistantMessage,
+      message: textAssistant("Final visible reply.") as AssistantMessage,
     });
     await Promise.resolve();
 
@@ -486,10 +481,7 @@ describe("subscribeEmbeddedAgentSession", () => {
 
     emitAssistantTextDelta({ emit, delta: "Hello block" });
 
-    const assistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "Hello block" }],
-    } as AssistantMessage;
+    const assistantMessage = textAssistant("Hello block") as AssistantMessage;
 
     // Simulate a provider that ends the message without emitting text_end.
     emit({ type: "message_end", message: assistantMessage });
@@ -521,10 +513,7 @@ describe("subscribeEmbeddedAgentSession", () => {
 
     emit({
       type: "message_end",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Legacy answer" }],
-      } as AssistantMessage,
+      message: textAssistant("Legacy answer") as AssistantMessage,
     });
 
     expect(onBlockReply).toHaveBeenCalledTimes(1);

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-tag-streaming.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.final-tag-streaming.test.ts
@@ -9,6 +9,7 @@ import {
   extractAgentEventPayloads,
 } from "./embedded-agent-subscribe.e2e-harness.js";
 import { subscribeEmbeddedAgentSession } from "./embedded-agent-subscribe.js";
+import { textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 
 type ReplyMock = ReturnType<typeof vi.fn>;
 type ReplyPayload = { text?: string };
@@ -544,10 +545,7 @@ describe("subscribeEmbeddedAgentSession", () => {
       blockReplyBreak: "message_end",
     });
 
-    const assistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "Hello block" }],
-    } as AssistantMessage;
+    const assistantMessage = textAssistant("Hello block") as AssistantMessage;
 
     emit({ type: "message_end", message: assistantMessage });
     await Promise.resolve();

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.subscribeembeddedagentsession.test.ts
@@ -34,6 +34,7 @@ import {
 } from "./embedded-agent-subscribe.openai-responses.test-helpers.js";
 import { SessionManager } from "./sessions/session-manager.js";
 import { recordSessionModelUsage } from "./sessions/session-model-usage.js";
+import { textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 import { markCoreTtsToolResult } from "./tools/tts-tool-result-provenance.js";
 import { makeZeroUsageSnapshot } from "./usage.js";
 
@@ -935,10 +936,7 @@ describe("subscribeEmbeddedAgentSession", () => {
     // No live preview events while suppressed (the per-chunk parsing path is skipped).
     expect(extractAgentEventPayloads(onAgentEvent.mock.calls)).toHaveLength(0);
 
-    const assistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "Hello world" }],
-    } as AssistantMessage;
+    const assistantMessage = textAssistant("Hello world") as AssistantMessage;
     emit({ type: "message_end", message: assistantMessage });
     expectSingleAgentEventText(onAgentEvent.mock.calls, "Hello world");
   });
@@ -988,10 +986,7 @@ describe("subscribeEmbeddedAgentSession", () => {
     }
     emit({
       type: "message_end",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Here is the image." }],
-      },
+      message: textAssistant("Here is the image."),
     });
     await subscription.waitForPendingEvents();
 
@@ -1133,15 +1128,7 @@ describe("subscribeEmbeddedAgentSession", () => {
     });
     emit({
       type: "message_end",
-      message: {
-        role: "assistant",
-        content: [
-          {
-            type: "text",
-            text: "Generated 1 image.\nMEDIA:/tmp/generated.png",
-          },
-        ],
-      },
+      message: textAssistant("Generated 1 image.\nMEDIA:/tmp/generated.png"),
     });
     emit({ type: "agent_end" });
     await subscription.waitForPendingEvents();
@@ -1182,10 +1169,7 @@ describe("subscribeEmbeddedAgentSession", () => {
     emitAssistantTextDelta(emit, "Here it is.");
     emit({
       type: "message_end",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Here it is." }],
-      },
+      message: textAssistant("Here it is."),
     });
     emit({ type: "agent_end" });
     await flushBlockReplyCallbacks();
@@ -2086,10 +2070,7 @@ describe("subscribeEmbeddedAgentSession", () => {
   it("does not emit duplicate agent events when message_end repeats", () => {
     const { emit, onAgentEvent } = createAgentEventHarness();
 
-    const assistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "Hello world" }],
-    } as AssistantMessage;
+    const assistantMessage = textAssistant("Hello world") as AssistantMessage;
 
     emit({ type: "message_start", message: assistantMessage });
     emit({ type: "message_end", message: assistantMessage });
@@ -2107,10 +2088,7 @@ describe("subscribeEmbeddedAgentSession", () => {
     emitAssistantTextDelta(emit, " https://example.com/a.png\nCaption");
     emit({
       type: "message_end",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "MEDIA: https://example.com/a.png\nCaption" }],
-      } as AssistantMessage,
+      message: textAssistant("MEDIA: https://example.com/a.png\nCaption") as AssistantMessage,
     });
 
     const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);
@@ -2133,10 +2111,7 @@ describe("subscribeEmbeddedAgentSession", () => {
     });
     emit({
       type: "message_end",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "MEDIA: https://example.com/a.png" }],
-      } as AssistantMessage,
+      message: textAssistant("MEDIA: https://example.com/a.png") as AssistantMessage,
     });
 
     const payloads = extractAgentEventPayloads(onAgentEvent.mock.calls);

--- a/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.text-end-reconciliation.test.ts
+++ b/src/agents/embedded-agent-subscribe.subscribe-embedded-agent-session.text-end-reconciliation.test.ts
@@ -8,6 +8,7 @@ import {
   emitAssistantTextEnd,
   extractTextPayloads,
 } from "./embedded-agent-subscribe.e2e-harness.js";
+import { textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 
 function createUnphasedAssistant(texts: string[]) {
   return {
@@ -722,10 +723,7 @@ describe("text_end snapshot reconciliation", () => {
     await Promise.resolve();
     emit({
       type: "message_end",
-      message: {
-        role: "assistant",
-        content: [{ type: "text", text: "Checking: Fetched prices" }],
-      },
+      message: textAssistant("Checking: Fetched prices"),
     });
     await Promise.resolve();
 
@@ -873,10 +871,7 @@ describe("assistant snapshot replay", () => {
   });
   it("keeps the completed assistant independent from transcript mutation", () => {
     const { emit, subscription } = createSubscribedSessionHarness({ runId: "run" });
-    const assistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "Current run reply" }],
-    } as AssistantMessage;
+    const assistantMessage = textAssistant("Current run reply") as AssistantMessage;
 
     emit({ type: "message_end", message: assistantMessage });
     assistantMessage.content = [{ type: "text", text: "Rewritten transcript reply" }];
@@ -898,10 +893,7 @@ describe("assistant snapshot replay", () => {
     // Simulate non-streaming model: only message_start and message_end, no text_delta
     emit({ type: "message_start", message: { role: "assistant" } });
 
-    const assistantMessage = {
-      role: "assistant",
-      content: [{ type: "text", text: "Response from non-streaming model" }],
-    } as AssistantMessage;
+    const assistantMessage = textAssistant("Response from non-streaming model") as AssistantMessage;
 
     emit({ type: "message_end", message: assistantMessage });
 

--- a/src/agents/openclaw-tools.sessions.test.ts
+++ b/src/agents/openclaw-tools.sessions.test.ts
@@ -70,6 +70,7 @@ import {
   streamMocks,
 } from "./sessions/agent-session-loop-correctness.test-support.js";
 import { SessionManager } from "./sessions/session-manager.js";
+import { textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 import { compactToolOutputHint } from "./tool-schema-hints.js";
 import { testing as agentStepTesting } from "./tools/agent-step.test-support.js";
 import { withGatewayToolCallerIdentity } from "./tools/gateway-caller-context.js";
@@ -520,13 +521,7 @@ describe("sessions tools", () => {
       }
       if (request.method === "chat.history") {
         return {
-          messages: [
-            { role: "toolResult", content: [] },
-            {
-              role: "assistant",
-              content: [{ type: "text", text: "hi" }],
-            },
-          ],
+          messages: [{ role: "toolResult", content: [] }, textAssistant("hi")],
         };
       }
       return {};
@@ -897,14 +892,7 @@ describe("sessions tools", () => {
       const request = opts as { method?: string };
       if (request.method === "chat.history") {
         return {
-          messages: [
-            {
-              role: "assistant",
-              content: [
-                { type: "text", text: "Use sk-1234567890abcdef1234 to authenticate with the API." },
-              ],
-            },
-          ],
+          messages: [textAssistant("Use sk-1234567890abcdef1234 to authenticate with the API.")],
         };
       }
       return {};

--- a/src/agents/run-wait.test.ts
+++ b/src/agents/run-wait.test.ts
@@ -20,6 +20,7 @@ import {
   waitForAgentRunsToDrain,
   waitForAgentRunReply,
 } from "./run-wait.js";
+import { textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 
 type AgentWaitGatewayRequest = {
   method?: string;
@@ -79,10 +80,7 @@ describe("readLatestAssistantReply", () => {
   it("returns the most recent assistant message when compaction markers trail history", async () => {
     callGatewayMock.mockResolvedValue({
       messages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "All checks passed and changes were pushed." }],
-        },
+        textAssistant("All checks passed and changes were pushed."),
         { role: "toolResult", content: [{ type: "text", text: "tool output" }] },
         { role: "system", content: [{ type: "text", text: "Compaction" }] },
       ],

--- a/src/agents/session-tool-result-guard.test.ts
+++ b/src/agents/session-tool-result-guard.test.ts
@@ -10,7 +10,7 @@ import { createAssistantErrorTranscript } from "./assistant-error-transcript.js"
 import { buildExecForegroundResult } from "./bash-tools.exec-support.js";
 import { installSessionToolResultGuard } from "./session-tool-result-guard.js";
 import { castAgentMessage } from "./test-helpers/agent-message-fixtures.js";
-import { textToolResult } from "./test-helpers/sparse-transcript.test-support.js";
+import { textToolResult, textAssistant } from "./test-helpers/sparse-transcript.test-support.js";
 import { redactTranscriptMessage } from "./transcript-redact.js";
 
 type AppendMessage = Parameters<SessionManager["appendMessage"]>[0];
@@ -285,12 +285,7 @@ describe("installSessionToolResultGuard", () => {
         isError: false,
       }),
     );
-    sm.appendMessage(
-      asAppendMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "after tools" }],
-      }),
-    );
+    sm.appendMessage(asAppendMessage(textAssistant("after tools")));
 
     const messages = expectPersistedRoles(sm, [
       "assistant", // tool calls

--- a/src/agents/session-tool-result-guard.transcript-events.test.ts
+++ b/src/agents/session-tool-result-guard.transcript-events.test.ts
@@ -9,6 +9,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { transformMessages } from "../../packages/ai/src/transcript-transform.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
 import { makeTextToolResult } from "../../test/helpers/text-tool-result.js";
+import { makeUserMessage } from "../../test/helpers/user-message.js";
 import {
   appendTranscriptMessage,
   listSessionPendingInputs,
@@ -124,11 +125,7 @@ describe("guardSessionManager transcript updates", () => {
 
   it("reloads the session manager after atomic compaction persistence rolls back", async () => {
     const { sessionManager, root, target } = await openPersistedSessionManager();
-    const keptId = sessionManager.appendMessage({
-      role: "user",
-      content: "keep",
-      timestamp: 1,
-    });
+    const keptId = sessionManager.appendMessage(makeUserMessage("keep", 1));
     const guarded = guardSessionManager(sessionManager, {
       withCompactionPersistence: (append, validateAppend) =>
         persistCompactionBoundaryWithSessionEntrySync(target, {
@@ -225,11 +222,7 @@ describe("guardSessionManager transcript updates", () => {
       expect(listSessionPendingInputs(target)).toEqual({ items: [], total: 0 });
       expect(approvalHook).toHaveBeenCalledOnce();
 
-      const unstagedId = guarded.appendMessage({
-        role: "user",
-        content: "Unstaged source",
-        timestamp: 3,
-      });
+      const unstagedId = guarded.appendMessage(makeUserMessage("Unstaged source", 3));
       expect(approvalHook).toHaveBeenCalledTimes(2);
       expect(guarded.getEntry(unstagedId)).toMatchObject({
         message: { role: "user", content: "[approved] Unstaged source" },

--- a/src/agents/sessions/agent-session-compaction-headroom.test.ts
+++ b/src/agents/sessions/agent-session-compaction-headroom.test.ts
@@ -1,5 +1,6 @@
 import type { Context, Model, SimpleStreamOptions } from "openclaw/plugin-sdk/llm";
 import { expect, it, vi } from "vitest";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import type { PersistedUserTurnMessage } from "../../sessions/user-turn-transcript.types.js";
 import { buildRuntimeContextCustomMessage } from "../embedded-agent-runner/run/runtime-context-prompt.js";
 import { agentSessionAutomaticCompaction } from "./agent-session-compaction.js";
@@ -203,11 +204,7 @@ it.each([
     retry: { enabled: false },
   });
   const sessionManager = SessionManager.inMemory();
-  const keptId = sessionManager.appendMessage({
-    role: "user",
-    content: "Continue the project.",
-    timestamp: 1,
-  });
+  const keptId = sessionManager.appendMessage(makeUserMessage("Continue the project.", 1));
   const originalSummary = "The project uses blue buttons. ".repeat(40);
   sessionManager.appendCompaction(originalSummary, keptId, 2_000);
   sessionManager.appendMessage(createAssistant(model, [{ type: "text", text: "Ready." }]));

--- a/src/agents/sessions/agent-session-compaction.test.ts
+++ b/src/agents/sessions/agent-session-compaction.test.ts
@@ -8,6 +8,7 @@ import type {
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
 import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
 import type { CompactionProvider } from "../../plugins/compaction-provider.js";
@@ -505,11 +506,7 @@ describe("AgentSession compaction", () => {
   it("accounts branch-summary responses through the same run owner", async () => {
     const sessionManager = SessionManager.inMemory();
     const rootId = sessionManager.appendMessage({ role: "user", content: "root", timestamp: 1 });
-    const abandonedId = sessionManager.appendMessage({
-      role: "user",
-      content: "abandoned branch",
-      timestamp: 2,
-    });
+    const abandonedId = sessionManager.appendMessage(makeUserMessage("abandoned branch", 2));
     sessionManager.branch(rootId);
     const targetId = sessionManager.appendMessage({
       ...createAssistant(testModel, [{ type: "text", text: "target branch" }]),
@@ -758,21 +755,13 @@ describe("AgentSession compaction", () => {
   it("reports replacement tokens and the exact equal-summary entry before a post-commit hook finishes", async () => {
     const sessionManager = SessionManager.inMemory();
     const summary = "The same bounded summary";
-    const oldUserId = sessionManager.appendMessage({
-      role: "user",
-      content: "old prompt",
-      timestamp: 1,
-    });
+    const oldUserId = sessionManager.appendMessage(makeUserMessage("old prompt", 1));
     sessionManager.appendMessage({
       ...createAssistant(testModel, [{ type: "text", text: "old answer" }]),
       timestamp: 2,
     });
     const oldCompactionId = sessionManager.appendCompaction(summary, oldUserId, 100);
-    const recentUserId = sessionManager.appendMessage({
-      role: "user",
-      content: "recent prompt",
-      timestamp: 3,
-    });
+    const recentUserId = sessionManager.appendMessage(makeUserMessage("recent prompt", 3));
     sessionManager.appendMessage({
       ...createAssistant(testModel, [{ type: "text", text: "recent answer" }]),
       timestamp: 4,

--- a/src/agents/sessions/agent-session-small-context-compaction.test.ts
+++ b/src/agents/sessions/agent-session-small-context-compaction.test.ts
@@ -2,6 +2,7 @@ import type { Context, Model, SimpleStreamOptions } from "openclaw/plugin-sdk/ll
 import { Type } from "typebox";
 import { describe, expect, it } from "vitest";
 import { makeTextToolResult } from "../../../test/helpers/text-tool-result.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import { applyAgentCompactionSettingsFromConfig } from "../agent-settings.js";
 import { buildRuntimeContextCustomMessage } from "../embedded-agent-runner/run/runtime-context-prompt.js";
 import { agentSessionAutomaticCompaction } from "./agent-session-compaction.js";
@@ -205,11 +206,9 @@ describe("AgentSession small-context compaction", () => {
       });
       const sessionManager = SessionManager.inMemory();
       const file = "/workspace/archive.md";
-      sessionManager.appendMessage({
-        role: "user",
-        content: "Read the archive and preserve its project decisions.",
-        timestamp: 1,
-      });
+      sessionManager.appendMessage(
+        makeUserMessage("Read the archive and preserve its project decisions.", 1),
+      );
       sessionManager.appendMessage(
         createAssistant(
           model,
@@ -220,11 +219,7 @@ describe("AgentSession small-context compaction", () => {
       sessionManager.appendMessage(
         makeTextToolResult("archive-read", "read", "The project uses blue buttons.", false, 3),
       );
-      sessionManager.appendMessage({
-        role: "user",
-        content: "Continue the project.",
-        timestamp: 4,
-      });
+      sessionManager.appendMessage(makeUserMessage("Continue the project.", 4));
       sessionManager.appendMessage(
         createAssistant(model, [{ type: "text", text: "Ready to continue." }]),
       );
@@ -282,11 +277,7 @@ describe("AgentSession small-context compaction", () => {
       retry: { enabled: false },
     });
     const sessionManager = SessionManager.inMemory();
-    sessionManager.appendMessage({
-      role: "user",
-      content: "Read the large archive.",
-      timestamp: 1,
-    });
+    sessionManager.appendMessage(makeUserMessage("Read the large archive.", 1));
     sessionManager.appendMessage(
       createAssistant(
         model,

--- a/src/agents/sessions/sdk.test.ts
+++ b/src/agents/sessions/sdk.test.ts
@@ -30,6 +30,7 @@ vi.mock("../../auto-reply/thinking.js", () => ({
 vi.mock("../../llm/stream.js", () => ({
   streamSimple: streamMocks.streamSimple,
 }));
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import { takeRuntimeUserTurnTranscriptContext } from "../../sessions/user-turn-transcript-runtime-context.js";
 import {
   createCompactionHandlers,
@@ -300,16 +301,8 @@ describe("AgentSession tree navigation", () => {
     const authStorage = AuthStorage.inMemory();
     authStorage.setRuntimeApiKey(testModel.provider, "test-api-key");
     const sessionManager = SessionManager.inMemory();
-    const rootId = sessionManager.appendMessage({
-      role: "user",
-      content: "shared root",
-      timestamp: 1,
-    });
-    const abandonedLeafId = sessionManager.appendMessage({
-      role: "user",
-      content: "abandoned branch",
-      timestamp: 2,
-    });
+    const rootId = sessionManager.appendMessage(makeUserMessage("shared root", 1));
+    const abandonedLeafId = sessionManager.appendMessage(makeUserMessage("abandoned branch", 2));
     sessionManager.branch(rootId);
     const targetId = sessionManager.appendMessage({
       role: "assistant",
@@ -656,11 +649,7 @@ describe("createAgentSession tool defaults", () => {
       content: "Earlier context. ".repeat(100),
       timestamp: 1,
     });
-    sessionManager.appendMessage({
-      role: "user",
-      content: "Current question",
-      timestamp: 2,
-    });
+    sessionManager.appendMessage(makeUserMessage("Current question", 2));
     const authStorage = AuthStorage.inMemory();
     authStorage.setRuntimeApiKey(testModel.provider, "test-api-key");
     const { session } = await createAgentSession({

--- a/src/agents/sessions/sdk.tool-outcomes.test.ts
+++ b/src/agents/sessions/sdk.tool-outcomes.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { Type } from "typebox";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import { disposeOpenClawAgentDatabaseByPath } from "../../state/openclaw-agent-db.js";
 import { toToolDefinitions } from "../agent-tool-definition-adapter.js";
 import type { AgentTool } from "../runtime/index.js";
@@ -125,11 +126,7 @@ describe("session tool outcomes", () => {
         return createAssistantResultStream(createAssistant(testModel, calls, "toolUse"));
       };
       try {
-        await session.agent.prompt({
-          role: "user",
-          content: "Run the synthetic tools.",
-          timestamp: 1,
-        });
+        await session.agent.prompt(makeUserMessage("Run the synthetic tools.", 1));
         expect(completed).toHaveLength(expected.length);
         expect(completed).toEqual(expect.arrayContaining(expected));
         expect(replay).toMatchObject(expected);

--- a/src/agents/sessions/session-manager-bounded.test.ts
+++ b/src/agents/sessions/session-manager-bounded.test.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { afterEach, expect, it, vi } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import {
   appendTranscriptMessage,
   loadTranscriptEvents,
@@ -220,11 +221,7 @@ it("keeps generated entry ids unique outside a bounded transcript tail", async (
   const messageId = "deadbeef-0000-4000-8000-000000000000";
   const thinkingId = "deadbeef-0000-4000-8000-000000000001";
   uuidQueue.push(messageId);
-  const appended = manager.appendMessageWithTranscriptAnchor({
-    role: "user",
-    content: "persisted",
-    timestamp: 2,
-  });
+  const appended = manager.appendMessageWithTranscriptAnchor(makeUserMessage("persisted", 2));
 
   expect(appended).toMatchObject({ entryId: messageId, anchor: { effectiveParentId: "tail" } });
   uuidQueue.push(thinkingId);
@@ -276,11 +273,7 @@ it("excludes interleaved display payloads without inventing events or losing fen
   const bounded = SessionManager.openBounded(scope, limits);
   expect(bounded.getAppendParentId()).toBe(tailId);
   expect(bounded.buildSessionContext()).toEqual(manager.buildSessionContext());
-  const appended = bounded.appendMessageWithTranscriptAnchor({
-    role: "user",
-    content: "current",
-    timestamp: 2,
-  });
+  const appended = bounded.appendMessageWithTranscriptAnchor(makeUserMessage("current", 2));
   expect(appended.anchor?.effectiveParentId).toBe(tailId);
   if (!appended.anchor) {
     throw new Error("missing admission anchor");
@@ -449,11 +442,7 @@ it("preserves explicit reset retention of excluded user input in a bounded reope
     excludeFromContext: true,
   } as Parameters<SessionManager["appendMessage"]>[0]);
   manager.appendResetBoundary("new", retained);
-  const current = manager.appendMessageWithTranscriptAnchor({
-    role: "user",
-    content: "fresh",
-    timestamp: 3,
-  });
+  const current = manager.appendMessageWithTranscriptAnchor(makeUserMessage("fresh", 3));
   const raw = await loadTranscriptEvents(scope);
   expect(manager.buildSessionContext().messages).toMatchObject([
     { content: "explicitly retained" },

--- a/src/agents/sessions/session-manager-branching.test.ts
+++ b/src/agents/sessions/session-manager-branching.test.ts
@@ -18,6 +18,7 @@ import {
   withOwnedSessionTranscriptWrites,
 } from "../../config/sessions/transcript-write-context.js";
 import { openOpenClawAgentDatabase } from "../../state/openclaw-agent-db.js";
+import { textAssistant } from "../test-helpers/sparse-transcript.test-support.js";
 import { SessionManager } from "./session-manager.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterEach);
@@ -265,10 +266,7 @@ describe("SessionManager branch replacement", () => {
       const assistant = await appendTranscriptMessage(scope, {
         cwd: dir,
         eventId: "branch-race-assistant",
-        message: {
-          role: "assistant",
-          content: [{ type: "text", text: "answer before raced branch" }],
-        },
+        message: textAssistant("answer before raced branch"),
         parentId: user.messageId,
       });
       const sessionManager = SessionManager.open(scope, dir);

--- a/src/agents/sessions/session-manager-model-context.test.ts
+++ b/src/agents/sessions/session-manager-model-context.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import type { StatementSync } from "node:sqlite";
 import { expect, it, vi } from "vitest";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import {
   appendTranscriptEvent,
   replaceTranscriptEvents,
@@ -254,11 +255,7 @@ it.each(["whole", "reset", "compaction", "reset-compaction", "leaf", "opaque"])(
       expect(fingerprint()).toBe(before);
       source.branch(source.getLeafId()!);
       await waitForSessionTranscriptProjection(scope);
-      const admitted = source.appendMessageWithTranscriptAnchor({
-        role: "user",
-        content: "current turn",
-        timestamp: 7,
-      });
+      const admitted = source.appendMessageWithTranscriptAnchor(makeUserMessage("current turn", 7));
       if (!admitted.anchor) {
         throw new Error("missing admission");
       }
@@ -539,11 +536,7 @@ it.each(
       const source = SessionManager.open(scope);
       source.appendMessage({ role: "user", content: "previous", timestamp: 1 });
       await waitForSessionTranscriptProjection(scope);
-      const admitted = source.appendMessageWithTranscriptAnchor({
-        role: "user",
-        content: "current",
-        timestamp: 2,
-      });
+      const admitted = source.appendMessageWithTranscriptAnchor(makeUserMessage("current", 2));
       if (!admitted.anchor) {
         throw new Error("missing admission");
       }

--- a/src/agents/sessions/session-manager.persistence-compat.test.ts
+++ b/src/agents/sessions/session-manager.persistence-compat.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { openFileBackedSessionManagerForTest } from "../../../test/helpers/session-manager-file-fixture.js";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import {
   formatSqliteSessionFileMarker,
   parseSqliteSessionFileMarker,
@@ -337,11 +338,7 @@ describe("SessionManager persistence compatibility", () => {
       }),
     );
     const manager = openFileBackedSessionManagerForTest(sessionFile, dir);
-    manager.appendMessage({
-      role: "user",
-      content: "appended",
-      timestamp: 1,
-    });
+    manager.appendMessage(makeUserMessage("appended", 1));
     expect(
       openFileBackedSessionManagerForTest(sessionFile, dir).buildSessionContext().messages,
     ).toEqual([expect.objectContaining({ content: "appended", role: "user" })]);

--- a/src/agents/sessions/session-manager.test.ts
+++ b/src/agents/sessions/session-manager.test.ts
@@ -4,6 +4,7 @@ import path from "node:path";
 import { redactIdentifier } from "@openclaw/normalization-core/node-crypto";
 import { afterEach, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import {
   formatSqliteSessionFileMarker,
   parseSqliteSessionFileMarker,
@@ -296,11 +297,7 @@ describe("SessionManager.open", () => {
     expect(loadSessionEntry(scope)).toBeUndefined();
     const manager = SessionManager.open(scope, dir);
     expect(loadSessionEntry(scope)).toBeUndefined();
-    const messageId = manager.appendMessage({
-      role: "user",
-      content: "first message",
-      timestamp: 1,
-    });
+    const messageId = manager.appendMessage(makeUserMessage("first message", 1));
 
     await expect(loadTranscriptEvents(scope)).resolves.toEqual([
       expect.objectContaining({

--- a/src/agents/subagents/announce/subagent-announce-output.test.ts
+++ b/src/agents/subagents/announce/subagent-announce-output.test.ts
@@ -1,6 +1,7 @@
 // Subagent announce output tests cover transcript reads, completion extraction,
 // compact stats, and wait-outcome text used in announce messages.
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { textAssistant } from "../../test-helpers/sparse-transcript.test-support.js";
 import {
   testing,
   applySubagentWaitOutcome,
@@ -322,10 +323,7 @@ describe("readSubagentOutput", () => {
   it("does not keep earlier visible progress across a trailing tool-only turn", async () => {
     installOutputDeps({
       messages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "Mapped the code path." }],
-        },
+        textAssistant("Mapped the code path."),
         {
           role: "assistant",
           stopReason: "toolUse",
@@ -452,12 +450,7 @@ describe("readSubagentOutput", () => {
 
   it("reads recovered output from the private SQLite transcript before gateway history", async () => {
     const deps = installOutputDeps({
-      messages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "stale visible output" }],
-        },
-      ],
+      messages: [textAssistant("stale visible output")],
       transcriptMessages: [
         {
           role: "assistant",
@@ -493,12 +486,7 @@ describe("readSubagentOutput", () => {
 
   it("does not read visible gateway history when a private transcript is empty", async () => {
     const deps = installOutputDeps({
-      messages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "stale visible output" }],
-        },
-      ],
+      messages: [textAssistant("stale visible output")],
       transcriptMessages: [],
     });
 

--- a/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.format.e2e.test.ts
@@ -33,6 +33,7 @@ import {
 } from "../../announce-idempotency.js";
 import * as embeddedRuns from "../../embedded-agent-runner/runs.js";
 import { FailoverError } from "../../failover-error.js";
+import { textAssistant } from "../../test-helpers/sparse-transcript.test-support.js";
 import { testing as subagentAnnounceDeliveryTesting } from "./subagent-announce-delivery.test-support.js";
 import { runSubagentAnnounceDispatch } from "./subagent-announce-dispatch.js";
 import { testing as subagentAnnounceOutputTesting } from "./subagent-announce-output.test-support.js";
@@ -651,12 +652,7 @@ describe("subagent announce formatting", () => {
       }
       if (typed.method === "chat.history") {
         return {
-          messages: [
-            {
-              role: "assistant",
-              content: [{ type: "text", text: "Worker executed successfully" }],
-            },
-          ],
+          messages: [textAssistant("Worker executed successfully")],
         };
       }
       if (typed.method === "sessions.delete") {
@@ -715,10 +711,7 @@ describe("subagent announce formatting", () => {
     async (testCase) => {
       chatHistoryMock.mockResolvedValueOnce({
         messages: [
-          {
-            role: "assistant",
-            content: [{ type: "text", text: "" }],
-          },
+          textAssistant(""),
           {
             role: testCase.role,
             content: [{ type: "text", text: testCase.toolOutput }],
@@ -750,10 +743,7 @@ describe("subagent announce formatting", () => {
           role: "tool",
           content: [{ type: "text", text: "tool output line" }],
         },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "assistant final line" }],
-        },
+        textAssistant("assistant final line"),
       ],
     });
     readLatestAssistantReplyMock.mockResolvedValue("");
@@ -2238,10 +2228,7 @@ describe("subagent announce formatting", () => {
           role: "toolResult",
           content: [{ type: "text", text: "old tool output" }],
         },
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "assistant completion text" }],
-        },
+        textAssistant("assistant completion text"),
       ],
     });
     readLatestAssistantReplyMock.mockResolvedValue("");
@@ -2268,10 +2255,7 @@ describe("subagent announce formatting", () => {
   it("does not fall back to latest tool output for completion-mode when assistant output is empty", async () => {
     chatHistoryMock.mockResolvedValueOnce({
       messages: [
-        {
-          role: "assistant",
-          content: [{ type: "text", text: "" }],
-        },
+        textAssistant(""),
         {
           role: "toolResult",
           content: [{ type: "text", text: "tool output only" }],

--- a/src/agents/subagents/announce/subagent-announce.timeout.test.ts
+++ b/src/agents/subagents/announce/subagent-announce.timeout.test.ts
@@ -68,10 +68,7 @@ function createTimeoutHistoryWithNoReply() {
       ],
     },
     { role: "toolResult", toolCallId: "call1", content: [{ type: "text", text: "data" }] },
-    {
-      role: "assistant",
-      content: [{ type: "text", text: "NO_REPLY" }],
-    },
+    textAssistant("NO_REPLY"),
   ];
 }
 
@@ -209,6 +206,7 @@ vi.mock("../registry/subagent-registry-read.js", () => ({
 vi.mock("../registry/subagent-registry-runtime.js", () => ({
   replaceSubagentRunAfterSteer: () => true,
 }));
+import { textAssistant } from "../../test-helpers/sparse-transcript.test-support.js";
 import { runSubagentAnnounceFlow } from "./subagent-announce.js";
 type AnnounceFlowParams = Parameters<
   typeof import("./subagent-announce.js").runSubagentAnnounceFlow
@@ -580,10 +578,7 @@ describe("subagent announce timeout config", () => {
           { type: "toolCall", id: "call-1", name: "read", arguments: {} },
         ],
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "NO_REPLY" }],
-      },
+      textAssistant("NO_REPLY"),
       {
         role: "assistant",
         content: [{ type: "toolCall", id: "call-2", name: "exec", arguments: {} }],
@@ -603,10 +598,7 @@ describe("subagent announce timeout config", () => {
 
   it("prefers visible assistant progress over a later raw tool result", async () => {
     chatHistoryMessages = [
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Read 12 files. Narrowing the search now." }],
-      },
+      textAssistant("Read 12 files. Narrowing the search now."),
       {
         role: "toolResult",
         content: [{ type: "text", text: "grep output" }],
@@ -650,10 +642,7 @@ describe("subagent announce timeout config", () => {
   it("prefers later visible assistant progress over an earlier NO_REPLY marker", async () => {
     chatHistoryMessages = [
       ...createTimeoutHistoryWithNoReply(),
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "A longer partial summary that should stay silent." }],
-      },
+      textAssistant("A longer partial summary that should stay silent."),
     ];
 
     await runAnnounceFlowForTest("run-timeout-no-reply-overrides-latest-text", {

--- a/src/agents/test-helpers/sparse-transcript.test-support.ts
+++ b/src/agents/test-helpers/sparse-transcript.test-support.ts
@@ -16,3 +16,10 @@ export function textToolResult(
     ...fields,
   };
 }
+
+export function textAssistant(text: string): {
+  role: "assistant";
+  content: { type: "text"; text: string }[];
+} {
+  return { role: "assistant", content: [{ type: "text", text }] };
+}

--- a/src/agents/tools/cron-tool.test.ts
+++ b/src/agents/tools/cron-tool.test.ts
@@ -27,6 +27,7 @@ import {
   runWithCronCreatorAuthorityCapability,
   runWithCronCreatorAuthorityResolver,
 } from "../cron-creator-authority-context.js";
+import { textAssistant } from "../test-helpers/sparse-transcript.test-support.js";
 import { createCronTool } from "./cron-tool.js";
 import { getGatewayToolCallerIdentity } from "./gateway-caller-context.js";
 
@@ -2176,10 +2177,7 @@ describe("cron tool", () => {
       .mockResolvedValueOnce({
         messages: [
           { role: "user", content: [{ type: "text", text: "Discussed Q2 budget" }] },
-          {
-            role: "assistant",
-            content: [{ type: "text", text: "We agreed to review on Tuesday." }],
-          },
+          textAssistant("We agreed to review on Tuesday."),
           { role: "user", content: [{ type: "text", text: "Remind me about the thing at 2pm" }] },
         ],
       })

--- a/src/agents/tools/sessions.test.ts
+++ b/src/agents/tools/sessions.test.ts
@@ -19,6 +19,7 @@ import { GatewayClientRequestError } from "../../gateway/client.js";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
 import { createTestRegistry } from "../../test-utils/channel-plugins.js";
 import { createSessionConversationTestRegistry } from "../../test-utils/session-conversation-registry.js";
+import { textAssistant } from "../test-helpers/sparse-transcript.test-support.js";
 import { extractStoredAssistantText } from "./chat-history-text.js";
 
 const callGatewayMock = vi.fn();
@@ -637,15 +638,9 @@ describe("extractStoredAssistantText", () => {
   });
 
   it("keeps normal status text that mentions billing", () => {
-    const message = {
-      role: "assistant",
-      content: [
-        {
-          type: "text",
-          text: "Firebase downgraded us to the free Spark plan. Check whether billing should be re-enabled.",
-        },
-      ],
-    };
+    const message = textAssistant(
+      "Firebase downgraded us to the free Spark plan. Check whether billing should be re-enabled.",
+    );
     expect(extractStoredAssistantText(message)).toBe(
       "Firebase downgraded us to the free Spark plan. Check whether billing should be re-enabled.",
     );

--- a/src/auto-reply/reply/agent-runner-memory.private-transcript.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.private-transcript.test.ts
@@ -2,6 +2,7 @@ import { createServer } from "node:http";
 import path from "node:path";
 import { expect, it } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import { waitForSessionMaintenance } from "../../agents/session-maintenance/coordinator.js";
 import { createSessionMaintenanceFollowup } from "../../agents/session-maintenance/run.js";
 import { SessionManager } from "../../agents/sessions/session-manager.js";
@@ -151,11 +152,7 @@ it.each(["completed", "interrupted"] as const)(
           totalTokensVersion: SESSION_TOTAL_TOKENS_VERSION,
         });
         const transcript = SessionManager.open(scope, state.workspaceDir);
-        transcript.appendMessage({
-          role: "user",
-          content: "Remember the Cedar project receipt.",
-          timestamp: 1,
-        });
+        transcript.appendMessage(makeUserMessage("Remember the Cedar project receipt.", 1));
         transcript.appendMessage(
           makeAssistantMessageFixture({
             provider: "test-provider",

--- a/src/auto-reply/reply/agent-runner-memory.test.ts
+++ b/src/auto-reply/reply/agent-runner-memory.test.ts
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import {
   getAdmittedRunDelegatedAuthority,
   type AdmittedRunContext,
@@ -719,11 +720,7 @@ describe("runMemoryFlushIfNeeded", () => {
         expect(memorySession.getSessionTarget()).toBeUndefined();
         admittedContext = await admission.admit("embedded");
         expect(getAdmittedRunDelegatedAuthority(admittedContext)).toBeDefined();
-        const retained = memorySession.appendMessage({
-          role: "user",
-          content: "Private retained work",
-          timestamp: 1,
-        });
+        const retained = memorySession.appendMessage(makeUserMessage("Private retained work", 1));
         memorySession.appendCompaction("Private summary", retained, 120);
         throw primaryError;
       })

--- a/src/auto-reply/reply/memory-flush-session.test.ts
+++ b/src/auto-reply/reply/memory-flush-session.test.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { expect, it } from "vitest";
 import { makeTextToolResult } from "../../../test/helpers/text-tool-result.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import {
   assembleHarnessContextEngine,
   bootstrapHarnessContextEngine,
@@ -49,11 +50,7 @@ async function withAdmittedInput(
         stopReason: "stop",
       }),
     );
-    const retained = source.appendMessage({
-      role: "user",
-      content: "Keep the Cedar project receipt.",
-      timestamp: 3,
-    });
+    const retained = source.appendMessage(makeUserMessage("Keep the Cedar project receipt.", 3));
     source.appendMessage(
       makeAgentAssistantMessage({
         content: [{ type: "text", text: "Cedar receipt is maple-17." }],
@@ -129,11 +126,9 @@ it.each([false, true])(
         }
         checkpoint.sessionManager.branch(first.id);
       }
-      const instruction = checkpoint.sessionManager.appendMessage({
-        role: "user",
-        content: "Checkpoint instruction",
-        timestamp: 5,
-      });
+      const instruction = checkpoint.sessionManager.appendMessage(
+        makeUserMessage("Checkpoint instruction", 5),
+      );
       checkpoint.sessionManager.appendMessage(
         makeAgentAssistantMessage({
           content: [{ type: "text", text: "NO_REPLY" }],

--- a/src/config/sessions/session-accessor.test.ts
+++ b/src/config/sessions/session-accessor.test.ts
@@ -6,6 +6,7 @@ import { redactIdentifier } from "@openclaw/normalization-core/node-crypto";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { createDeferred, withTestTimeout } from "../../../test/helpers/promise.js";
 import { cleanupTempDirs, makeTempDir } from "../../../test/helpers/temp-dir.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import type { MsgContext } from "../../auto-reply/templating.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import {
@@ -3580,11 +3581,7 @@ describe("session accessor seam", () => {
       cwd: tempDir,
       messages: [
         {
-          message: {
-            role: "user",
-            content: "hello",
-            timestamp: 100,
-          },
+          message: makeUserMessage("hello", 100),
         },
         {
           message: {
@@ -4149,11 +4146,7 @@ describe("session accessor seam", () => {
     }
     const queuedAppendPromise = appendTranscriptMessage(scope, {
       cwd: tempDir,
-      message: {
-        role: "user",
-        content: "queued prompt",
-        timestamp: 200,
-      },
+      message: makeUserMessage("queued prompt", 200),
     });
     resumeShouldAppend();
 

--- a/src/gateway/server-methods/chat.abort-persistence.test.ts
+++ b/src/gateway/server-methods/chat.abort-persistence.test.ts
@@ -6,6 +6,7 @@ import os from "node:os";
 import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import { formatSqliteSessionFileMarker } from "../../config/sessions/legacy-sqlite-marker.js";
 import {
   appendTranscriptMessageSync,
@@ -685,11 +686,7 @@ describe("chat abort transcript persistence", () => {
       idempotencyKey,
       sessionId,
       storePath,
-      message: {
-        role: "user",
-        content: "colliding user key",
-        timestamp: 1,
-      },
+      message: makeUserMessage("colliding user key", 1),
     });
 
     const respond = vi.fn();

--- a/src/gateway/server-methods/server-methods.test.ts
+++ b/src/gateway/server-methods/server-methods.test.ts
@@ -19,6 +19,7 @@ import {
 } from "vitest";
 import { GATEWAY_CLIENT_IDS } from "../../../packages/gateway-protocol/src/client-info.js";
 import { validateExecApprovalRequestParams } from "../../../packages/gateway-protocol/src/index.js";
+import { makeUserMessage } from "../../../test/helpers/user-message.js";
 import { STREAM_ERROR_FALLBACK_TEXT } from "../../agents/stream-message-shared.js";
 import { HEARTBEAT_PROMPT } from "../../auto-reply/heartbeat.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
@@ -1960,11 +1961,7 @@ describe("projectChatDisplayMessages", () => {
 
   it("drops channel-final delivery mirrors that duplicate the preceding assistant reply", () => {
     const result = projectChatDisplayMessages([
-      {
-        role: "user",
-        content: "yo big boy",
-        timestamp: 1,
-      },
+      makeUserMessage("yo big boy", 1),
       assistantHistoryMessage("Yo Peter. I’m here.", {
         provider: "openai",
         model: "gpt-5.5",
@@ -1997,11 +1994,7 @@ describe("projectChatDisplayMessages", () => {
         __openclaw: { mirrorIdentity: "run-1:assistant" },
         timestamp: 1,
       }),
-      {
-        role: "user",
-        content: "",
-        timestamp: 2,
-      },
+      makeUserMessage("", 2),
       deliveryMirrorHistoryMessage("Repeated reply", "message-2", 3),
     ]);
 

--- a/src/gateway/server.auth.presence-audience.test.ts
+++ b/src/gateway/server.auth.presence-audience.test.ts
@@ -7,6 +7,7 @@ import { Value } from "typebox/value";
 import { afterEach, describe, expect, test } from "vitest";
 import { PresenceEntrySchema } from "../../packages/gateway-protocol/src/schema/snapshot.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { makeUserMessage } from "../../test/helpers/user-message.js";
 import { writeConfigFile } from "../config/config.js";
 import {
   persistSessionTranscriptTurn,
@@ -133,11 +134,7 @@ describe("gateway presence audience", () => {
           updateMode: "none",
           messages: [
             {
-              message: {
-                role: "user",
-                content: "foreign draft transcript",
-                timestamp: 1,
-              },
+              message: makeUserMessage("foreign draft transcript", 1),
               now: Date.parse("2026-09-04T08:00:00.000Z"),
             },
           ],

--- a/src/sessions/user-turn-transcript.test.ts
+++ b/src/sessions/user-turn-transcript.test.ts
@@ -5,6 +5,7 @@ import { castAgentMessage } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it } from "vitest";
 import { trackSqliteStatementExecutions } from "../../test/helpers/sqlite-statement-execution-counter.js";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { makeUserMessage } from "../../test/helpers/user-message.js";
 import { formatSqliteSessionFileMarker } from "../config/sessions/legacy-sqlite-marker.js";
 import {
   loadTranscriptEvents,
@@ -813,11 +814,7 @@ describe("user turn transcript persistence", () => {
         updateMode: "none",
       });
 
-      recorder.markRuntimePersisted({
-        role: "user",
-        content: "runtime-owned turn",
-        timestamp: 123,
-      });
+      recorder.markRuntimePersisted(makeUserMessage("runtime-owned turn", 123));
 
       await expect(recorder.persistFallback()).resolves.toBeUndefined();
       await expect(readTranscriptMessages(target)).resolves.toEqual([]);
@@ -837,11 +834,7 @@ describe("user turn transcript persistence", () => {
         updateMode: "none",
       });
 
-      recorder.markRuntimePersisted({
-        role: "user",
-        content: "runtime-owned turn",
-        timestamp: 123,
-      });
+      recorder.markRuntimePersisted(makeUserMessage("runtime-owned turn", 123));
 
       await expect(recorder.persistApproved()).resolves.toBeUndefined();
       await expect(readTranscriptMessages(target)).resolves.toEqual([]);
@@ -867,11 +860,7 @@ describe("user turn transcript persistence", () => {
         updateMode: "none",
       });
 
-      recorder.markRuntimePersisted({
-        role: "user",
-        content: "runtime-owned turn",
-        timestamp: 123,
-      });
+      recorder.markRuntimePersisted(makeUserMessage("runtime-owned turn", 123));
 
       await expect(recorder.persistApproved()).resolves.toBeUndefined();
       await expect(
@@ -1015,11 +1004,7 @@ describe("user turn transcript persistence", () => {
       });
       recorder.markRuntimePersistencePending(
         runtimePersistenceStarted.then(() => {
-          recorder.markRuntimePersisted({
-            role: "user",
-            content: "pending runtime turn",
-            timestamp: 123,
-          });
+          recorder.markRuntimePersisted(makeUserMessage("pending runtime turn", 123));
         }),
       );
 

--- a/test/helpers/user-message.ts
+++ b/test/helpers/user-message.ts
@@ -1,0 +1,3 @@
+export function makeUserMessage(content: string, timestamp: number) {
+  return { role: "user" as const, content, timestamp };
+}


### PR DESCRIPTION
## What Problem This Solves

Agent, session and provider tests repeat user-message and sparse assistant-text input objects, obscuring the behavior each case protects with fixture boilerplate.

## Why This Change Was Made

Share 75 user inputs through a neutral constructor requiring content and timestamp, and 54 sparse assistant inputs through the existing agent test-helper owner. This removes 427 net test/support lines. Each constructor preserves the original property order and creates fresh writable objects; assistant content arrays and text blocks are also fresh.

Keep the existing sparse helpers unchanged, and retain independent expected objects, explicit casts, caller bindings, optional-callback evaluation, append order and JSON envelopes. Neither constructor supplies defaults or imports production code.

## User Impact

No production behavior changes. Existing scenarios, assertions and deadlines remain intact.

## Evidence

- All 2,888 cases passed before and after across 63 complete test files, including support-file consumers. Per-file ordered case names and statuses match exactly, with none pending.
- The initial combined JSON run rejected the E2E inline project before its cases ran. Its 62 successful file reports were retained, and the remaining E2E suite passed separately. The after run used the same supported split: 62 ordinary files plus the 87-case E2E suite. No reporter check was weakened.
- Inline reconstruction matches the original syntax at all 129 sites. Actual-helper checks preserve values, key order, descriptors, extensibility and fresh allocations. Existing sparse helper implementations remain byte-identical.
- Deslop and fresh independent P2 review are clean. Mapped changed gate passed.

No overall runtime improvement or coverage-percentage claim.
