### PR TITLE
perf(copilot): reduce first-use model metadata loading

### DIFF
--- a/extensions/github-copilot/model-metadata.ts
+++ b/extensions/github-copilot/model-metadata.ts
@@ -1,7 +1,7 @@
 // Github Copilot plugin module implements model metadata behavior.
-import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-catalog-shared";
+import { supportsClaudeAdaptiveThinking } from "openclaw/plugin-sdk/claude-model-runtime";
+import { buildManifestModelProviderConfig } from "openclaw/plugin-sdk/provider-model-metadata";
 import type { ModelDefinitionConfig } from "openclaw/plugin-sdk/provider-model-shared";
-import { supportsClaudeAdaptiveThinking } from "openclaw/plugin-sdk/provider-model-shared";
 import { normalizeOptionalLowercaseString } from "openclaw/plugin-sdk/string-coerce-runtime";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 

--- a/src/plugin-sdk/claude-model-runtime.ts
+++ b/src/plugin-sdk/claude-model-runtime.ts
@@ -6,6 +6,7 @@ export {
   resolveClaudeMythos5ModelIdentity,
   resolveClaudeOpus5ModelIdentity,
   resolveClaudeSonnet5ModelIdentity,
+  supportsClaudeAdaptiveThinking,
   supportsClaudeFastMode,
 } from "@openclaw/llm-core";
 export { resolveClaudeThinkingProfile } from "../plugins/provider-claude-thinking.js";


### PR DESCRIPTION
Related: #141852, #142125

## What Problem This Solves

Resolves avoidable first-use delay when model metadata includes GitHub Copilot. Its public thinking policy loads local model metadata, which pulled in broad replay, registration and runtime catalog helpers for two metadata-only functions.

## Why This Change Was Made

Use the existing lightweight metadata SDK for manifest projection and the existing Claude model SDK for adaptive-thinking support. The latter gains a re-export of the same canonical LLM-core function. Existing broad exports remain available; no helper implementation, provider policy, catalog value, resolver or test changes.

## User Impact

Faster cold metadata projection with unchanged thinking capabilities, model selection and streaming behavior. No new SDK subpath, dependency, cache, shard or timeout. Production LOC: +3/-2; tests: 0. The single added export is consumed by production metadata code and avoids duplicating model policy.

## Evidence

- CI-like source layout, Node 24.19.0/pnpm 12.3.4: original / changed / restored-original complete models suite, all **52 cases passing in identical order**. The first mixed-provider capability case took **7,678ms / 3,849ms / 7,367ms**; suite durations **18.15s / 14.06s / 18.07s**. Restoring the original imports restores the cost after the candidate run.
- Compiled plugin artifacts were absent during all three comparison runs, matching the CI source lane. An earlier built-layout baseline is excluded. Task-owned build outputs were restored before final build validation; no loader or environment override was introduced.
- Copilot policy, catalog and streaming suites: **89 passed**, including loopback HTTP streaming and explicit capability opt-outs.
- Full `pnpm build` and required `check:changed` gates passed, including SDK exports/surface, plugin boundaries, Doctor closure checks, production/test types and lint.
- Independent P0–P2 review found no actionable issue. Both functions resolve to their original canonical implementations.

The timing case includes multiple providers; its remaining cost is not attributed exclusively to Copilot or Anthropic. No live GitHub API or authentication behavior change is claimed.

Post-merge: [natural main CI 34222815126](https://github.com/openclaw/openclaw/actions/runs/34222815126) passed all 27 Node jobs. The named capability case passed in 8,814ms (prior main sample: 15,482ms). Independent #142063 changed the models suite before this merge, so the current 51-case run is not presented as an unchanged 52-case or controlled timing comparison. The controlled local comparison above remains the causal evidence. Whole CI took 14m19s, including 190 seconds before preflight; this patch does not claim to resolve the remaining build/test or admission costs.
