### PR TITLE
feat(xai): use one curated catalog and concrete setup default

### DIFF
--- a/docs/concepts/model-providers.md
+++ b/docs/concepts/model-providers.md
@@ -305,7 +305,7 @@ messages and normalizes `stats.cached` into `cacheRead`; legacy
 | Venice                                  | `venice`                         | `VENICE_API_KEY`                                     | -                                                      |
 | Vercel AI Gateway                       | `vercel-ai-gateway`              | `AI_GATEWAY_API_KEY`                                 | `vercel-ai-gateway/anthropic/claude-opus-4.6`          |
 | Volcano Engine (Doubao)                 | `volcengine` / `volcengine-plan` | `VOLCANO_ENGINE_API_KEY`                             | `volcengine-plan/ark-code-latest`                      |
-| xAI                                     | `xai`                            | SuperGrok/X Premium OAuth or `XAI_API_KEY`           | OAuth: `xai/auto`; API key: `xai/grok-4.3`             |
+| xAI                                     | `xai`                            | SuperGrok/X Premium OAuth or `XAI_API_KEY`           | `xai/grok-4.6`                                         |
 | Xiaomi                                  | `xiaomi` / `xiaomi-token-plan`   | `XIAOMI_API_KEY` / `XIAOMI_TOKEN_PLAN_API_KEY`       | `xiaomi/mimo-v2.5` / `xiaomi-token-plan/mimo-v2.5-pro` |
 
 #### Quirks worth knowing
@@ -324,7 +324,7 @@ messages and normalizes `stats.cached` into `cacheRead`; legacy
     Model ids use a `nvidia/<vendor>/<model>` namespace (for example `nvidia/nvidia/nemotron-...`); pickers preserve the literal `<provider>/<model-id>` composition while the canonical key sent to the API stays single-prefixed.
   </Accordion>
   <Accordion title="xAI">
-    Uses the xAI Responses path. The recommended path is SuperGrok/X Premium OAuth; fresh setup selects `xai/auto`, which follows xAI's authenticated default model without an OpenClaw update. Existing concrete model ids stay pinned. API keys still work via `XAI_API_KEY` or plugin config and keep `grok-4.3` as the regional-safe setup default. Grok `web_search` reuses the same auth profile before API-key fallback. Older `/fast` and `params.fastMode: true` configurations still resolve through xAI's Grok 4.3 compatibility redirects, but new configurations should select a current model directly. `tool_stream` defaults on; disable via `agents.defaults.models["xai/<model>"].params.tool_stream=false`.
+    Uses the xAI Responses path. The recommended path is SuperGrok/X Premium OAuth; OAuth and API-key setup use the curated `xai/grok-4.6` default. Existing primary models stay pinned. Run `openclaw doctor --fix` to repair retired `xai/auto` selections on the subscription route. API keys still work via `XAI_API_KEY` or plugin config. Grok `web_search` reuses the same auth profile before API-key fallback. Older `/fast` and `params.fastMode: true` configurations still resolve through xAI's Grok 4.3 compatibility redirects, but new configurations should select a current model directly. `tool_stream` defaults on; disable via `agents.defaults.models["xai/<model>"].params.tool_stream=false`.
   </Accordion>
 </AccordionGroup>
 

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -41,13 +41,13 @@ OAuth client.
     openclaw models auth login --provider xai --method oauth
     ```
 
-    With no existing primary model, OAuth setup selects `xai/auto`. The plugin
-    resolves that stable ref from xAI's authenticated model catalog and remote
-    default, so future xAI default changes do not require an OpenClaw update.
+    With no existing primary model, OAuth setup selects the curated default,
+    `xai/grok-4.6`. Authenticated discovery updates available model rows without
+    changing that default.
     It preserves an existing primary; opt in explicitly when needed:
 
     ```bash
-    openclaw models set xai/auto
+    openclaw models set xai/grok-4.6
     ```
 
     Rerun full onboarding only if you intentionally want to change Gateway,
@@ -56,8 +56,7 @@ OAuth client.
   </Step>
   <Step title="API-key path">
     API-key setup still works for xAI Console keys and for media surfaces
-    that need key-backed provider config. It keeps Grok 4.3 as the
-    regional-safe setup default:
+    that need key-backed provider config. It uses the same Grok 4.6 setup default:
 
     ```bash
     openclaw models auth login --provider xai --method api-key
@@ -68,7 +67,7 @@ OAuth client.
   <Step title="Pick a model">
     ```json5
     {
-      agents: { defaults: { model: { primary: "xai/auto" } } },
+      agents: { defaults: { model: { primary: "xai/grok-4.6" } } },
     }
     ```
   </Step>
@@ -98,10 +97,9 @@ subscription quota are separate billing buckets.
 - If a previous OAuth login left xAI using the API-key endpoint or catalog,
   rerun `openclaw models auth login --provider xai --method oauth`. A successful
   login refreshes the subscription catalog and proxy route from your account.
-  It preserves your primary model and fallbacks; the moving alias remains
-  discovery-owned so it can follow later default changes.
+  It preserves your primary model and fallbacks.
 - If sign-in succeeds but Grok is not the default model, run
-  `openclaw models set xai/auto`. OAuth login preserves an existing
+  `openclaw models set xai/grok-4.6`. OAuth login preserves an existing
   primary model unless you explicitly change it.
 - Inspect saved xAI auth profiles:
 
@@ -112,6 +110,14 @@ subscription quota are separate billing buckets.
 
 - xAI decides which accounts can receive OAuth API tokens. If an account is
   not eligible, use the API-key path or check the subscription on xAI's side.
+
+Existing `xai/auto` selections on the Grok subscription route are retired.
+Run `openclaw doctor --fix` to replace affected config and session selections
+with `xai/grok-4.6`. Doctor preserves account pins and fallbacks, and leaves
+custom endpoints unchanged. For a pinned session, an unavailable account or a
+disallowed successor keeps the selection unchanged, with a diagnostic explaining
+the required action. Unpinned config can be repaired from its declared
+subscription route. You can also choose a permitted concrete model explicitly.
 
 For a manually managed Grok subscription token, set `models.providers.xai.auth`
 to `"token"` and `models.providers.xai.baseUrl` to
@@ -143,11 +149,15 @@ see [legacy compatibility and moving aliases](#legacy-compatibility-and-moving-a
 | Grok 4.20      | `grok-4.20-0309-reasoning`, `grok-4.20-0309-non-reasoning`   |
 
 <Tip>
-Use `xai/auto` to follow xAI's authenticated OAuth default, or select a concrete
-id such as `xai/grok-4.6` to remain pinned. API-key setup keeps Grok 4.3 as the
-regional-safe default; Grok 4.6, Grok 4.5, `grok-build-0.1`, and both dated
+OAuth and API-key setup use `xai/grok-4.6` as the curated default.
+Grok 4.5, `grok-build-0.1`, Grok 4.3, and both dated
 Grok 4.20 variants remain selectable.
 </Tip>
+
+The plugin manifest owns the curated list. Ordinary API-key setup keeps that
+inventory in the plugin instead of copying it into your configuration;
+`models.mode: "replace"` still receives the curated rows. Explicit model rows
+remain unchanged. OAuth login retains its authenticated account catalog.
 
 Catalog context and token-cost metadata follows xAI's live
 [model pages](https://docs.x.ai/developers/models) and
@@ -158,6 +168,10 @@ OpenClaw's flat catalog cost fields record the short-context rates. The current
 [Grok Build](https://docs.x.ai/build/overview) coding agent uses Grok 4.6. The
 historical OpenClaw `grok-build-latest` compatibility alias remains pinned to
 Grok 4.5.
+
+Models outside the curated list have unknown pricing, recorded as zero until
+the manifest includes them. Zero is an unavailable estimate, not a claim that
+the provider charges nothing.
 
 ## Feature coverage
 
@@ -215,9 +229,8 @@ current Grok 4.20 aliases verbatim so xAI retains control of stable, latest,
 beta, experimental, and dated alias semantics. The global `grok-latest` alias is
 also preserved verbatim.
 
-xAI retired the following exact ids. OpenClaw keeps them as hidden compatibility
-rows for shipped configurations, with the limits and pricing of their current
-redirect targets:
+xAI retired the following exact ids. Existing configurations keep their
+normalization and transport paths; uncurated model names use unknown pricing:
 
 | Retired ids                                                          | Current behavior                 |
 | -------------------------------------------------------------------- | -------------------------------- |

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -169,8 +169,9 @@ OpenClaw's flat catalog cost fields record the short-context rates. The current
 historical OpenClaw `grok-build-latest` compatibility alias remains pinned to
 Grok 4.5.
 
-Models outside the curated list have unknown pricing, recorded as zero until
-the manifest includes them. Zero is an unavailable estimate, not a claim that
+Supported non-curated aliases retain their reasoning, input, and token-limit
+metadata without joining the published inventory. Their pricing remains unknown,
+recorded as zero until the manifest includes them. Zero is an unavailable estimate, not a claim that
 the provider charges nothing.
 
 ## Feature coverage

--- a/docs/providers/xai.md
+++ b/docs/providers/xai.md
@@ -247,6 +247,10 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
 
 ## Features
 
+Unconfigured `web_search`, `x_search`, and `code_execution` requests use Grok 4.6.
+This also applies to existing installations that omit the tool model setting.
+An explicit tool model remains selected; the Grok 4.3 examples below are overrides.
+
 <Warning>
   `x_search` and `code_execution` run on xAI's servers. xAI bills $5 per 1,000
   tool calls, plus the model's input and output tokens. With each tool's
@@ -579,7 +583,7 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
     | Key               | Type    | Default                   | Description                                      |
     | ----------------- | ------- | ------------------------- | ------------------------------------------------ |
     | `enabled`         | boolean | Automatic for xAI models  | Disable, or opt in for a known non-xAI provider |
-    | `model`           | string  | `grok-4.3`                | Model used for x_search requests                 |
+    | `model`           | string  | `grok-4.6`                | Model used for x_search requests                 |
     | `baseUrl`         | string  | -                         | xAI Responses base URL override                  |
     | `inlineCitations` | boolean | -                         | Include inline citations in results              |
     | `maxTurns`        | number  | -                         | Maximum conversation turns                       |
@@ -616,7 +620,7 @@ stale context metadata on active 4.20 rows. It does not pin active 4.20
     | Key              | Type    | Default                  | Description                                      |
     | ---------------- | ------- | ------------------------ | ------------------------------------------------ |
     | `enabled`        | boolean | Automatic for xAI models | Disable, or opt in for a known non-xAI provider |
-    | `model`          | string  | `grok-4.3`               | Model used for code execution requests           |
+    | `model`          | string  | `grok-4.6`               | Model used for code execution requests           |
     | `maxTurns`       | number  | -                        | Maximum conversation turns                       |
     | `timeoutSeconds` | number  | `30`                     | Request timeout in seconds                       |
 

--- a/docs/tools/code-execution.md
+++ b/docs/tools/code-execution.md
@@ -21,9 +21,12 @@ registered by the bundled `xai` plugin under the `tools` contract.
 | Tool name          | `code_execution`                                                                  |
 | Provider plugin    | `xai` (bundled, `enabledByDefault: true`)                                         |
 | Auth               | xAI auth profile, `XAI_API_KEY`, or `plugins.entries.xai.config.webSearch.apiKey` |
-| Default model      | `grok-4.3`                                                                        |
+| Default model      | `grok-4.6`                                                                        |
 | Default timeout    | 30 seconds                                                                        |
 | Default `maxTurns` | unset (xAI applies its own internal limit)                                        |
+
+Existing installations that omit the tool model setting also use Grok 4.6.
+An explicit model setting remains selected.
 
 Use it for calculations, tabulation, quick statistics, and chart-style
 analysis, including data returned by `x_search` or `web_search`. It has no

--- a/extensions/xai/api.test.ts
+++ b/extensions/xai/api.test.ts
@@ -56,14 +56,30 @@ describe("xai api helpers", () => {
     },
   );
 
-  it.each(["xai", "x-ai"])(
-    "restores the native endpoint for materialized %s overlays",
-    (provider) => {
+  it.each([
+    {
+      provider: "xai",
+      modelId: "grok-4.5",
+      cost: { input: 2, output: 6, cacheRead: 0.3, cacheWrite: 0 },
+    },
+    {
+      provider: "x-ai",
+      modelId: "grok-4.5",
+      cost: { input: 2, output: 6, cacheRead: 0.3, cacheWrite: 0 },
+    },
+    {
+      provider: "xai",
+      modelId: "grok-fixture-next",
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    },
+  ])(
+    "resolves materialized $provider/$modelId with its own known or unknown pricing",
+    ({ provider, modelId, cost }) => {
       const model = resolveXaiForwardCompatModel({
         providerId: "xai",
         ctx: {
           provider,
-          modelId: "grok-4.5",
+          modelId,
           modelRegistry: { find: () => null } as never,
           providerConfig: { baseUrl: "", models: [] },
         },
@@ -71,6 +87,7 @@ describe("xai api helpers", () => {
 
       expect(model?.baseUrl).toBe(XAI_BASE_URL);
       expect(model?.reasoning).toBe(true);
+      expect(model?.cost).toEqual(cost);
     },
   );
 });

--- a/extensions/xai/catalog-defaults.test.ts
+++ b/extensions/xai/catalog-defaults.test.ts
@@ -1,11 +1,28 @@
+import { registerSingleProviderPlugin } from "openclaw/plugin-sdk/plugin-test-runtime";
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
 import {
   resolveAgentModelPrimaryValue,
   type ModelProviderConfig,
   type OpenClawConfig,
 } from "openclaw/plugin-sdk/provider-onboard";
-import { expect, it } from "vitest";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
 import { buildXaiCatalogModels } from "./model-definitions.js";
 import { applyXaiConfig, applyXaiOAuthConfig } from "./onboard.js";
+
+vi.mock("openclaw/plugin-sdk/provider-auth-runtime", () => ({
+  resolveApiKeyForProvider: vi.fn().mockRejectedValue(new Error("No runtime credential")),
+}));
+
+import plugin from "./index.js";
+
+beforeEach(() => {
+  clearLiveCatalogCacheForTests();
+  vi.stubEnv("XAI_API_KEY", "");
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
 
 const oauthProvider: ModelProviderConfig = {
   api: "openai-responses",
@@ -48,5 +65,58 @@ it.each(["api-key", "oauth"] as const)(
       primary: "openai/retained-model",
       fallbacks: ["xai/grok-4.3"],
     });
+  },
+);
+
+it.each([
+  {
+    label: "OAuth",
+    mode: "oauth" as const,
+    baseUrl: undefined,
+    expectedUrl: "https://cli-chat-proxy.grok.com/v1",
+    expectedAuth: "oauth",
+  },
+  {
+    label: "subscription token",
+    mode: "token" as const,
+    baseUrl: "https://cli-chat-proxy.grok.com/v1",
+    expectedUrl: "https://cli-chat-proxy.grok.com/v1",
+    expectedAuth: "token",
+  },
+  {
+    label: "API token",
+    mode: "token" as const,
+    baseUrl: "https://api.x.ai/v1",
+    expectedUrl: "https://api.x.ai/v1",
+    expectedAuth: undefined,
+  },
+  {
+    label: "API key",
+    mode: "api-key" as const,
+    baseUrl: undefined,
+    expectedUrl: "https://api.x.ai/v1",
+    expectedAuth: undefined,
+  },
+])(
+  "keeps the static catalog on the selected $label route",
+  async ({ mode, baseUrl, expectedUrl, expectedAuth }) => {
+    const pluginProvider = await registerSingleProviderPlugin(plugin);
+    const result = await pluginProvider.staticCatalog?.run({
+      config: baseUrl ? { models: { providers: { xai: { baseUrl, models: [] } } } } : {},
+      env: {},
+      resolveProviderAuth: () => ({
+        mode,
+        source: "fixture",
+        discoveryApiKey: "selected-fixture",
+      }),
+      resolveProviderApiKey: () => ({ apiKey: "unselected-fixture" }),
+    });
+    if (!result || !("provider" in result)) {
+      throw new Error("expected a static xAI catalog");
+    }
+    expect(result.provider.baseUrl).toBe(expectedUrl);
+    expect(result.provider.auth).toBe(expectedAuth);
+    expect(result.provider.models[0]?.id).toBe("grok-4.6");
+    expect(result.provider.models.some((model) => model.id === "auto")).toBe(false);
   },
 );

--- a/extensions/xai/catalog-defaults.test.ts
+++ b/extensions/xai/catalog-defaults.test.ts
@@ -121,3 +121,50 @@ it.each([
     expect(result.provider.models.some((model) => model.id === "auto")).toBe(false);
   },
 );
+
+it.each([
+  { name: "an existing selection", primary: "xai/grok-4.5", expected: "xai/grok-4.5" },
+  { name: "a fresh selection", primary: undefined, expected: "xai/grok-4.6" },
+])("applies registered API-key setup with $name", async ({ primary, expected }) => {
+  const provider = await registerSingleProviderPlugin(plugin);
+  const method = provider.auth.find((entry) => entry.id === "api-key");
+  if (!method?.runNonInteractive) {
+    throw new Error("expected the registered non-interactive xAI API-key method");
+  }
+  const config: OpenClawConfig = {
+    agents: {
+      defaults: {
+        model: {
+          ...(primary ? { primary } : {}),
+          fallbacks: ["xai/grok-4.3", "xai/grok-build-0.1"],
+        },
+        models: { "xai/grok-4.5": { alias: "Pinned", params: { temperature: 0.7 } } },
+      },
+    },
+  };
+  const result = await method.runNonInteractive({
+    authChoice: "xai-api-key",
+    config,
+    baseConfig: config,
+    opts: {},
+    runtime: {
+      log: vi.fn(),
+      error: vi.fn(),
+      exit: (code) => {
+        throw new Error("Unexpected setup exit: " + code);
+      },
+    },
+    resolveApiKey: async () => ({ key: "synthetic-existing-profile", source: "profile" }),
+    toApiKeyCredential: () => {
+      throw new Error("Existing profile must not be rewritten");
+    },
+  });
+  expect(result?.agents?.defaults?.model).toEqual({
+    primary: expected,
+    fallbacks: ["xai/grok-4.3", "xai/grok-build-0.1"],
+  });
+  expect(result?.agents?.defaults?.models?.["xai/grok-4.5"]).toEqual({
+    alias: "Pinned",
+    params: { temperature: 0.7 },
+  });
+});

--- a/extensions/xai/catalog-defaults.test.ts
+++ b/extensions/xai/catalog-defaults.test.ts
@@ -92,7 +92,7 @@ it.each([
   },
   {
     label: "API key",
-    mode: "api-key" as const,
+    mode: "api_key" as const,
     baseUrl: undefined,
     expectedUrl: "https://api.x.ai/v1",
     expectedAuth: undefined,
@@ -106,7 +106,8 @@ it.each([
       env: {},
       resolveProviderAuth: () => ({
         mode,
-        source: "fixture",
+        source: "profile",
+        apiKey: undefined,
         discoveryApiKey: "selected-fixture",
       }),
       resolveProviderApiKey: () => ({ apiKey: "unselected-fixture" }),

--- a/extensions/xai/catalog-defaults.test.ts
+++ b/extensions/xai/catalog-defaults.test.ts
@@ -1,0 +1,52 @@
+import {
+  resolveAgentModelPrimaryValue,
+  type ModelProviderConfig,
+  type OpenClawConfig,
+} from "openclaw/plugin-sdk/provider-onboard";
+import { expect, it } from "vitest";
+import { buildXaiCatalogModels } from "./model-definitions.js";
+import { applyXaiConfig, applyXaiOAuthConfig } from "./onboard.js";
+
+const oauthProvider: ModelProviderConfig = {
+  api: "openai-responses",
+  auth: "oauth",
+  baseUrl: "https://cli-chat-proxy.grok.com/v1",
+  models: [],
+};
+
+it.each(["api-key", "oauth"] as const)("uses the curated default for fresh %s setup", (method) => {
+  const config = method === "oauth" ? applyXaiOAuthConfig({}, oauthProvider) : applyXaiConfig({});
+  expect(resolveAgentModelPrimaryValue(config.agents?.defaults?.model)).toBe("xai/grok-4.6");
+  expect(config.agents?.defaults?.models?.["xai/grok-4.6"]?.alias).toBe("Grok");
+});
+
+it("keeps a caller's price and input edits out of the curated catalog", () => {
+  const customized = buildXaiCatalogModels();
+  const first = customized[0];
+  if (!first) {
+    throw new Error("expected the default curated model");
+  }
+  first.cost.input = 999;
+  first.input.push("audio");
+
+  const fresh = buildXaiCatalogModels()[0];
+  expect(fresh?.cost.input).toBe(2);
+  expect(fresh?.input).toEqual(["text", "image"]);
+});
+
+it.each(["api-key", "oauth"] as const)(
+  "preserves the existing primary during %s setup",
+  (method) => {
+    const original: OpenClawConfig = {
+      agents: {
+        defaults: { model: { primary: "openai/retained-model", fallbacks: ["xai/grok-4.3"] } },
+      },
+    };
+    const config =
+      method === "oauth" ? applyXaiOAuthConfig(original, oauthProvider) : applyXaiConfig(original);
+    expect(config.agents?.defaults?.model).toEqual({
+      primary: "openai/retained-model",
+      fallbacks: ["xai/grok-4.3"],
+    });
+  },
+);

--- a/extensions/xai/code-execution.test.ts
+++ b/extensions/xai/code-execution.test.ts
@@ -151,7 +151,7 @@ describe("xai code_execution tool", () => {
     expect(mockFetch).toHaveBeenCalled();
     expect(firstFetchUrl(mockFetch)).toContain("api.x.ai/v1/responses");
     const body = parseFirstRequestBody(mockFetch);
-    expect(body.model).toBe("grok-4.3");
+    expect(body.model).toBe("grok-4.6");
     expect(body.store).toBe(false);
     expect(body.reasoning).toEqual({ effort: "low" });
     expect(body.max_turns).toBe(2);

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -285,59 +285,6 @@ describe("xai provider plugin", () => {
 
   it.each([
     {
-      label: "OAuth",
-      mode: "oauth" as const,
-      baseUrl: undefined,
-      expectedUrl: "https://cli-chat-proxy.grok.com/v1",
-      expectedAuth: "oauth",
-    },
-    {
-      label: "subscription token",
-      mode: "token" as const,
-      baseUrl: "https://cli-chat-proxy.grok.com/v1",
-      expectedUrl: "https://cli-chat-proxy.grok.com/v1",
-      expectedAuth: "token",
-    },
-    {
-      label: "API token",
-      mode: "token" as const,
-      baseUrl: "https://api.x.ai/v1",
-      expectedUrl: "https://api.x.ai/v1",
-      expectedAuth: undefined,
-    },
-    {
-      label: "API key",
-      mode: "api-key" as const,
-      baseUrl: undefined,
-      expectedUrl: "https://api.x.ai/v1",
-      expectedAuth: undefined,
-    },
-  ])(
-    "keeps the static catalog on the selected $label route",
-    async ({ mode, baseUrl, expectedUrl, expectedAuth }) => {
-      const pluginProvider = await registerSingleProviderPlugin(plugin);
-      const result = await pluginProvider.staticCatalog?.run({
-        config: baseUrl ? { models: { providers: { xai: { baseUrl, models: [] } } } } : {},
-        env: {},
-        resolveProviderAuth: () => ({
-          mode,
-          source: "fixture",
-          discoveryApiKey: "selected-fixture",
-        }),
-        resolveProviderApiKey: () => ({ apiKey: "unselected-fixture" }),
-      });
-      if (!result || !("provider" in result)) {
-        throw new Error("expected a static xAI catalog");
-      }
-      expect(result.provider.baseUrl).toBe(expectedUrl);
-      expect(result.provider.auth).toBe(expectedAuth);
-      expect(result.provider.models[0]?.id).toBe("grok-4.6");
-      expect(result.provider.models.some((model) => model.id === "auto")).toBe(false);
-    },
-  );
-
-  it.each([
-    {
       route: "Grok proxy",
       baseUrl: "https://cli-chat-proxy.grok.com/v1",
       subscription: true,

--- a/extensions/xai/index.test.ts
+++ b/extensions/xai/index.test.ts
@@ -285,6 +285,59 @@ describe("xai provider plugin", () => {
 
   it.each([
     {
+      label: "OAuth",
+      mode: "oauth" as const,
+      baseUrl: undefined,
+      expectedUrl: "https://cli-chat-proxy.grok.com/v1",
+      expectedAuth: "oauth",
+    },
+    {
+      label: "subscription token",
+      mode: "token" as const,
+      baseUrl: "https://cli-chat-proxy.grok.com/v1",
+      expectedUrl: "https://cli-chat-proxy.grok.com/v1",
+      expectedAuth: "token",
+    },
+    {
+      label: "API token",
+      mode: "token" as const,
+      baseUrl: "https://api.x.ai/v1",
+      expectedUrl: "https://api.x.ai/v1",
+      expectedAuth: undefined,
+    },
+    {
+      label: "API key",
+      mode: "api-key" as const,
+      baseUrl: undefined,
+      expectedUrl: "https://api.x.ai/v1",
+      expectedAuth: undefined,
+    },
+  ])(
+    "keeps the static catalog on the selected $label route",
+    async ({ mode, baseUrl, expectedUrl, expectedAuth }) => {
+      const pluginProvider = await registerSingleProviderPlugin(plugin);
+      const result = await pluginProvider.staticCatalog?.run({
+        config: baseUrl ? { models: { providers: { xai: { baseUrl, models: [] } } } } : {},
+        env: {},
+        resolveProviderAuth: () => ({
+          mode,
+          source: "fixture",
+          discoveryApiKey: "selected-fixture",
+        }),
+        resolveProviderApiKey: () => ({ apiKey: "unselected-fixture" }),
+      });
+      if (!result || !("provider" in result)) {
+        throw new Error("expected a static xAI catalog");
+      }
+      expect(result.provider.baseUrl).toBe(expectedUrl);
+      expect(result.provider.auth).toBe(expectedAuth);
+      expect(result.provider.models[0]?.id).toBe("grok-4.6");
+      expect(result.provider.models.some((model) => model.id === "auto")).toBe(false);
+    },
+  );
+
+  it.each([
+    {
       route: "Grok proxy",
       baseUrl: "https://cli-chat-proxy.grok.com/v1",
       subscription: true,
@@ -351,12 +404,8 @@ describe("xai provider plugin", () => {
           new Error("Token unavailable"),
         );
       }
-      const fetchMock = stubXaiFetch((url) =>
-        Response.json(
-          url.endsWith("/settings")
-            ? { default_model: "grok-4.3" }
-            : { data: [{ id: "grok-4.3", api_backend: "responses" }] },
-        ),
+      const fetchMock = stubXaiFetch(() =>
+        Response.json({ data: [{ id: "grok-4.3", api_backend: "responses" }] }),
       );
       const provider = await registerSingleProviderPlugin(plugin);
       const result = await provider.catalog?.run({
@@ -392,12 +441,7 @@ describe("xai provider plugin", () => {
       const requestedUrls = fetchMock.mock.calls.map(([input]) =>
         typeof input === "string" ? input : input instanceof URL ? input.href : input.url,
       );
-      expect(requestedUrls.toSorted((left, right) => left.localeCompare(right))).toEqual(
-        (subscription
-          ? [`${expectedBaseUrl}/models`, `${expectedBaseUrl}/settings`]
-          : [`${expectedBaseUrl}/models`]
-        ).toSorted((left, right) => left.localeCompare(right)),
-      );
+      expect(requestedUrls).toEqual([`${expectedBaseUrl}/models`]);
       for (const [, init] of fetchMock.mock.calls) {
         expect(new Headers(init?.headers).get("Authorization")).toBe(`Bearer ${apiKey}`);
       }
@@ -406,10 +450,7 @@ describe("xai provider plugin", () => {
 
   it("uses the Grok OAuth proxy catalog for xAI OAuth discovery", async () => {
     mockXaiRuntimeOAuth();
-    const fetchMock = stubXaiFetch((url) => {
-      if (url.endsWith("/settings")) {
-        return Response.json({ default_model: "grok-build" });
-      }
+    const fetchMock = stubXaiFetch(() => {
       return Response.json({
         data: [
           {
@@ -441,18 +482,9 @@ describe("xai provider plugin", () => {
     expect(result.auth).toBe("oauth");
     expect(result.apiKey).toBeUndefined();
     expect(result.models.map((model) => model.id)).toEqual([
-      "auto",
       "grok-composer-2.5-fast",
       "grok-build",
     ]);
-    const auto = result.models.find((model) => model.id === "auto");
-    expect(auto?.params?.canonicalModelId).toBe("grok-build");
-    const normalizedAuto = provider.normalizeResolvedModel?.({
-      provider: "xai",
-      modelId: "auto",
-      model: { ...auto, provider: "xai" },
-    } as never);
-    expect(normalizedAuto?.id).toBe("auto");
     const composer = result.models.find((model) => model.id === "grok-composer-2.5-fast");
     if (!composer) {
       throw new Error("expected OAuth Composer model");
@@ -489,51 +521,35 @@ describe("xai provider plugin", () => {
       lockedProfile: true,
     });
     const modelFetchInit = findXaiFetchInit(fetchMock, "https://cli-chat-proxy.grok.com/v1/models");
-    const settingsFetchInit = findXaiFetchInit(
-      fetchMock,
-      "https://cli-chat-proxy.grok.com/v1/settings",
-    );
     expect(new Headers(modelFetchInit?.headers).get("Authorization")).toBe(
       "Bearer xai-oauth-token",
     );
-    expect(new Headers(settingsFetchInit?.headers).get("Authorization")).toBe(
-      "Bearer xai-oauth-token",
-    );
+    expect(fetchMock).toHaveBeenCalledOnce();
   });
 
-  it("updates xAI OAuth auto from remote settings without a catalog code change", async () => {
-    let remoteDefault = "grok-4-5";
-    const release = vi.fn(async () => undefined);
-    const fetchGuard: LiveModelCatalogFetchGuard = vi.fn(async ({ url }) => ({
-      response: url.endsWith("/settings")
-        ? Response.json({ default_model: remoteDefault })
-        : Response.json({
-            data: [
-              { id: "grok-4.5", api_backend: "responses" },
-              { id: "grok-next", api_backend: "responses" },
-            ],
-          }),
-      finalUrl: url,
-      release,
-    }));
-
-    const first = await buildLiveXaiOAuthProvider({
+  it("publishes concrete OAuth rows without reading remote defaults or inventing prices", async () => {
+    const urls: string[] = [];
+    const fetchGuard: LiveModelCatalogFetchGuard = async ({ url }) => {
+      urls.push(url);
+      return {
+        response: Response.json({
+          data: [
+            { id: "grok-4.6", api_backend: "responses" },
+            { id: "grok-fixture-next", api_backend: "responses" },
+          ],
+        }),
+        finalUrl: url,
+        release: async () => undefined,
+      };
+    };
+    const provider = await buildLiveXaiOAuthProvider({
       discoveryApiKey: "xai-oauth-token",
       fetchGuard,
     });
-    expect(first.models.find((model) => model.id === "auto")?.params?.canonicalModelId).toBe(
-      "grok-4.5",
-    );
 
-    clearLiveCatalogCacheForTests();
-    remoteDefault = "grok-next";
-    const next = await buildLiveXaiOAuthProvider({
-      discoveryApiKey: "xai-oauth-token",
-      fetchGuard,
-    });
-    expect(next.models.find((model) => model.id === "auto")?.params?.canonicalModelId).toBe(
-      "grok-next",
-    );
+    expect(urls).toEqual(["https://cli-chat-proxy.grok.com/v1/models"]);
+    expect(provider.models.map((model) => model.id)).toEqual(["grok-4.6", "grok-fixture-next"]);
+    expect(provider.models[1]?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
   });
 
   it("uses runtime OAuth profiles when xAI catalog auth resolution is empty", async () => {
@@ -550,8 +566,8 @@ describe("xai provider plugin", () => {
 
     expect(result.baseUrl).toBe("https://cli-chat-proxy.grok.com/v1");
     expect(result.auth).toBe("oauth");
-    expect(result.models.map((model) => model.id)).toEqual(["auto", "grok-build"]);
-    expect(result.models[0]?.params?.canonicalModelId).toBe("grok-build");
+    expect(result.models.map((model) => model.id)).toEqual(["grok-build"]);
+    expect(result.models[0]?.params?.canonicalModelId).toBeUndefined();
     expect(providerAuthRuntimeMocks.resolveApiKeyForProvider).toHaveBeenCalledWith({
       provider: "xai",
       cfg: { models: {} },
@@ -1041,24 +1057,22 @@ describe("xai provider plugin", () => {
     expect(normalizedCompat?.unsupportedToolSchemaKeywords).toEqual(["minContains", "maxContains"]);
   });
 
-  it("preserves Grok 4.6 xhigh reasoning through OAuth auto", async () => {
+  it("preserves Grok 4.6 xhigh reasoning through its concrete OAuth identity", async () => {
     mockXaiRuntimeOAuth();
-    stubXaiFetch((url) =>
-      url.endsWith("/settings")
-        ? Response.json({ default_model: "grok-4.6" })
-        : Response.json({
-            data: [{ id: "grok-4.6", api_backend: "responses" }],
-          }),
+    stubXaiFetch(() =>
+      Response.json({
+        data: [{ id: "grok-4.6", api_backend: "responses" }],
+      }),
     );
     const { provider, result } = await runXaiCatalog();
-    const auto = result.models.find((model) => model.id === "auto");
+    const model = result.models.find((entry) => entry.id === "grok-4.6");
     const normalized = provider.normalizeResolvedModel?.({
       provider: "xai",
-      modelId: "auto",
-      model: { ...auto, provider: "xai" },
+      modelId: "grok-4.6",
+      model: { ...model, provider: "xai" },
     } as never);
 
-    expect(normalized?.id).toBe("auto");
+    expect(normalized?.id).toBe("grok-4.6");
     expect(normalized?.thinkingLevelMap?.xhigh).toBe("xhigh");
     expect(normalized?.compat).toMatchObject({
       supportedReasoningEfforts: ["low", "medium", "high", "xhigh"],

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -196,6 +196,7 @@ export default defineSingleProviderPluginEntry({
         envVar: "XAI_API_KEY",
         promptMessage: "Enter xAI API key",
         defaultModel: XAI_DEFAULT_MODEL_REF,
+        preserveExistingPrimary: true,
         applyConfig: (cfg) => applyXaiConfig(cfg),
         wizard: {
           groupLabel: "xAI (Grok)",

--- a/extensions/xai/index.ts
+++ b/extensions/xai/index.ts
@@ -260,9 +260,17 @@ export default defineSingleProviderPluginEntry({
           }),
         });
       },
-      staticRun: async () => ({
-        provider: buildXaiProvider(),
-      }),
+      staticRun: async (ctx) => {
+        const auth = ctx.resolveProviderAuth(PROVIDER_ID);
+        const authMode =
+          auth.mode === "oauth"
+            ? "oauth"
+            : auth.mode === "token" &&
+                isXaiGrokProxyBaseUrl(ctx.config.models?.providers?.[PROVIDER_ID]?.baseUrl)
+              ? "token"
+              : undefined;
+        return { provider: buildXaiProvider("openai-responses", authMode) };
+      },
     },
     ...buildProviderReplayFamilyHooks({ family: "openai-compatible" }),
     prepareExtraParams: (ctx) => defaultToolStreamExtraParams(ctx.extraParams),

--- a/extensions/xai/model-definitions.ts
+++ b/extensions/xai/model-definitions.ts
@@ -4,154 +4,59 @@ import {
   asOptionalRecord,
   normalizeOptionalLowercaseString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { isXaiFrontierModelId, isXaiGrok46ModelId, normalizeXaiModelId } from "./model-id.js";
+import { normalizeXaiModelId } from "./model-id.js";
+import manifest from "./openclaw.plugin.json" with { type: "json" };
 
-export const XAI_BASE_URL = "https://api.x.ai/v1";
+export const XAI_BASE_URL = manifest.modelCatalog.providers.xai.baseUrl;
 export const XAI_DEFAULT_IMAGE_MODEL = "grok-imagine-image";
 export const XAI_IMAGE_MODELS = ["grok-imagine-image", "grok-imagine-image-quality"] as const;
 export const XAI_DEFAULT_CONTEXT_WINDOW = 1_000_000;
-const XAI_FRONTIER_CONTEXT_WINDOW = 500_000;
-const XAI_CODE_CONTEXT_WINDOW = 256_000;
 export const XAI_DEFAULT_MAX_TOKENS = 64_000;
-export const XAI_DEFAULT_MODEL_ID = "grok-4.3";
-
-type XaiCost = ModelDefinitionConfig["cost"];
-
-type XaiCatalogEntry = {
-  id: string;
-  name: string;
-  reasoning: boolean;
-  input?: ModelDefinitionConfig["input"];
-  contextWindow: number;
-  maxTokens?: number;
-  cost: XaiCost;
-};
-
-type XaiCatalogModelRow = readonly [
-  id: string,
-  name: string,
-  reasoning: boolean,
-  input: ModelDefinitionConfig["input"],
-  overrides?: {
-    contextWindow?: number;
-    maxTokens?: number;
-    omitMaxTokens?: true;
-    cost?: XaiCost;
-  },
-];
-
-const XAI_GROK_420_COST = {
-  input: 1.25,
-  output: 2.5,
-  cacheRead: 0.2,
+export const XAI_DEFAULT_MODEL_ID = "grok-4.6";
+/** Models outside the manifest carry no price until the manifest lists them. */
+export const XAI_UNKNOWN_MODEL_COST = {
+  input: 0,
+  output: 0,
+  cacheRead: 0,
   cacheWrite: 0,
-} satisfies XaiCost;
+} satisfies ModelDefinitionConfig["cost"];
 
-const XAI_GROK_43_COST = {
-  input: 1.25,
-  output: 2.5,
-  cacheRead: 0.2,
-  cacheWrite: 0,
-} satisfies XaiCost;
+type XaiModelInput = ModelDefinitionConfig["input"][number];
 
-// xAI publishes separate short-context cached-input rates for Grok 4.5 and 4.6.
-// The flat OpenClaw catalog stores short-context rates; xAI doubles input,
-// cached-input, and output pricing at its documented 200k-token long-context threshold.
-const XAI_GROK_45_COST = {
-  input: 2,
-  output: 6,
-  cacheRead: 0.3,
-  cacheWrite: 0,
-} satisfies XaiCost;
+function isXaiModelInput(value: string): value is XaiModelInput {
+  return value === "text" || value === "image" || value === "video" || value === "audio";
+}
 
-const XAI_GROK_46_COST = {
-  input: 2,
-  output: 6,
-  cacheRead: 0.5,
-  cacheWrite: 0,
-} satisfies XaiCost;
+function toXaiModelDefinition(model: (typeof manifest.modelCatalog.providers.xai.models)[number]) {
+  return { ...model, input: model.input.filter(isXaiModelInput) } satisfies ModelDefinitionConfig;
+}
 
-const XAI_GROK_BUILD_COST = {
-  input: 1,
-  output: 2,
-  cacheRead: 0.2,
-  cacheWrite: 0,
-} satisfies XaiCost;
+function copyXaiModelDefinition(entry: ModelDefinitionConfig): ModelDefinitionConfig {
+  return structuredClone(entry);
+}
 
-const XAI_MODEL_CATALOG_ROWS: readonly XaiCatalogModelRow[] = [
-  [
-    "grok-4.6",
-    "Grok 4.6",
-    true,
-    ["text", "image"],
-    { contextWindow: XAI_FRONTIER_CONTEXT_WINDOW, cost: XAI_GROK_46_COST },
-  ],
-  [
-    "grok-4.5",
-    "Grok 4.5",
-    true,
-    ["text", "image"],
-    { contextWindow: XAI_FRONTIER_CONTEXT_WINDOW, cost: XAI_GROK_45_COST },
-  ],
-  [
-    "grok-build-0.1",
-    "Grok Build 0.1",
-    true,
-    ["text", "image"],
-    { contextWindow: XAI_CODE_CONTEXT_WINDOW, omitMaxTokens: true, cost: XAI_GROK_BUILD_COST },
-  ],
-  ["grok-3", "Grok 3", false, ["text"]],
-  ["grok-3-fast", "Grok 3 Fast", false, ["text"]],
-  ["grok-3-mini", "Grok 3 Mini", true, ["text"]],
-  ["grok-3-mini-fast", "Grok 3 Mini Fast", true, ["text"]],
-  ["grok-4.3", "Grok 4.3", true, ["text", "image"]],
-  ["grok-4", "Grok 4", true, ["text"]],
-  ["grok-4-0709", "Grok 4 0709", true, ["text"]],
-  ["grok-4-fast", "Grok 4 Fast", true, ["text", "image"]],
-  ["grok-4-fast-non-reasoning", "Grok 4 Fast (Non-Reasoning)", false, ["text", "image"]],
-  ["grok-4-1-fast", "Grok 4.1 Fast", true, ["text", "image"]],
-  ["grok-4-1-fast-non-reasoning", "Grok 4.1 Fast (Non-Reasoning)", false, ["text", "image"]],
-  [
-    "grok-4.20-0309-reasoning",
-    "Grok 4.20 0309 (Reasoning)",
-    true,
-    ["text", "image"],
-    { maxTokens: 30_000, cost: XAI_GROK_420_COST },
-  ],
-  [
-    "grok-4.20-0309-non-reasoning",
-    "Grok 4.20 0309 (Non-Reasoning)",
-    false,
-    ["text", "image"],
-    { maxTokens: 30_000, cost: XAI_GROK_420_COST },
-  ],
-];
-const XAI_MODEL_CATALOG: readonly XaiCatalogEntry[] = XAI_MODEL_CATALOG_ROWS.map(
-  ([id, name, reasoning, input, overrides]) => {
-    const model: XaiCatalogEntry = {
-      id,
-      name,
-      reasoning,
-      input,
-      contextWindow: overrides?.contextWindow ?? XAI_DEFAULT_CONTEXT_WINDOW,
-      maxTokens: overrides?.maxTokens ?? XAI_DEFAULT_MAX_TOKENS,
-      cost: overrides?.cost ?? XAI_GROK_43_COST,
-    };
-    if (overrides?.omitMaxTokens) {
-      delete model.maxTokens;
-    }
-    return model;
-  },
-);
+// The manifest is the one curated xAI model list; discovery only adds or prunes around it.
+const XAI_MODEL_CATALOG: readonly ModelDefinitionConfig[] =
+  manifest.modelCatalog.providers.xai.models.map(toXaiModelDefinition);
 
-const XAI_SELECTABLE_MODEL_IDS = new Set<string>([
-  "grok-4.6",
-  "grok-4.5",
-  "grok-build-0.1",
-  "grok-4.3",
-  "grok-4.20-0309-reasoning",
-  "grok-4.20-0309-non-reasoning",
-]);
+/** Exact curated row for a model id, after xAI alias normalization. */
+export function resolveXaiCatalogEntry(modelId: string): ModelDefinitionConfig | undefined {
+  const normalized = normalizeXaiCatalogModelId(modelId);
+  const entry = XAI_MODEL_CATALOG.find((model) => model.id.toLowerCase() === normalized);
+  return entry ? copyXaiModelDefinition(entry) : undefined;
+}
+
+export function buildXaiModelDefinition(): ModelDefinitionConfig {
+  const entry = resolveXaiCatalogEntry(XAI_DEFAULT_MODEL_ID);
+  if (!entry) {
+    throw new Error(`xai manifest omits the default model ${XAI_DEFAULT_MODEL_ID}`);
+  }
+  return entry;
+}
+
+export function buildXaiCatalogModels(): ModelDefinitionConfig[] {
+  return XAI_MODEL_CATALOG.map(copyXaiModelDefinition);
+}
 
 type LegacyXaiBuiltinSignature = readonly [
   name: string,
@@ -254,121 +159,4 @@ export function isLegacyXaiBuiltinModel(model: unknown): boolean {
     cost.cacheRead === cacheReadCost &&
     cost.cacheWrite === cacheWriteCost
   );
-}
-
-function toModelDefinition(entry: XaiCatalogEntry): ModelDefinitionConfig {
-  return {
-    id: entry.id,
-    name: entry.name,
-    reasoning: entry.reasoning,
-    input: entry.input ?? ["text"],
-    cost: entry.cost,
-    contextWindow: entry.contextWindow,
-    maxTokens: entry.maxTokens ?? XAI_DEFAULT_MAX_TOKENS,
-  };
-}
-
-export function buildXaiModelDefinition(): ModelDefinitionConfig {
-  return toModelDefinition(
-    XAI_MODEL_CATALOG.find((entry) => entry.id === XAI_DEFAULT_MODEL_ID) ?? {
-      id: XAI_DEFAULT_MODEL_ID,
-      name: "Grok 4.3",
-      reasoning: true,
-      input: ["text", "image"],
-      contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-      maxTokens: XAI_DEFAULT_MAX_TOKENS,
-      cost: XAI_GROK_43_COST,
-    },
-  );
-}
-
-export function buildXaiCatalogModels(): ModelDefinitionConfig[] {
-  return XAI_MODEL_CATALOG.filter((entry) => XAI_SELECTABLE_MODEL_IDS.has(entry.id)).map((entry) =>
-    toModelDefinition(entry),
-  );
-}
-
-export function resolveXaiCatalogEntry(modelId: string) {
-  const trimmed = modelId.trim();
-  const lower = normalizeXaiCatalogModelId(modelId);
-  const exact = XAI_MODEL_CATALOG.find(
-    (entry) => normalizeOptionalLowercaseString(entry.id) === lower,
-  );
-  if (exact) {
-    return toModelDefinition(exact);
-  }
-  if (lower === "grok-latest") {
-    return toModelDefinition({
-      id: trimmed,
-      name: trimmed,
-      reasoning: true,
-      input: ["text", "image"],
-      contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-      maxTokens: XAI_DEFAULT_MAX_TOKENS,
-      cost: XAI_GROK_43_COST,
-    });
-  }
-  if (lower.includes("multi-agent")) {
-    return undefined;
-  }
-  if (
-    lower.startsWith("grok-3-mini-fast") ||
-    lower.startsWith("grok-3-mini") ||
-    lower.startsWith("grok-3-fast") ||
-    lower.startsWith("grok-3")
-  ) {
-    return toModelDefinition({
-      id: trimmed,
-      name: trimmed,
-      reasoning: lower.includes("mini"),
-      input: ["text"],
-      contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-      maxTokens: XAI_DEFAULT_MAX_TOKENS,
-      cost: XAI_GROK_43_COST,
-    });
-  }
-  if (
-    isXaiFrontierModelId(lower) ||
-    lower.startsWith("grok-4.3") ||
-    lower.startsWith("grok-4.20") ||
-    lower.startsWith("grok-4-1") ||
-    lower.startsWith("grok-4-fast")
-  ) {
-    return toModelDefinition({
-      id: trimmed,
-      name: trimmed,
-      reasoning: !lower.includes("non-reasoning"),
-      input: ["text", "image"],
-      contextWindow: isXaiFrontierModelId(lower)
-        ? XAI_FRONTIER_CONTEXT_WINDOW
-        : XAI_DEFAULT_CONTEXT_WINDOW,
-      maxTokens:
-        isXaiFrontierModelId(lower) || lower.startsWith("grok-4.3")
-          ? XAI_DEFAULT_MAX_TOKENS
-          : lower.startsWith("grok-4.20")
-            ? 30_000
-            : XAI_DEFAULT_MAX_TOKENS,
-      cost: isXaiFrontierModelId(lower)
-        ? isXaiGrok46ModelId(lower)
-          ? XAI_GROK_46_COST
-          : XAI_GROK_45_COST
-        : lower.startsWith("grok-4.3")
-          ? XAI_GROK_43_COST
-          : lower.startsWith("grok-4.20")
-            ? XAI_GROK_420_COST
-            : XAI_GROK_43_COST,
-    });
-  }
-  if (lower.startsWith("grok-4")) {
-    return toModelDefinition({
-      id: modelId.trim(),
-      name: modelId.trim(),
-      reasoning: !lower.includes("non-reasoning"),
-      input: ["text"],
-      contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-      maxTokens: XAI_DEFAULT_MAX_TOKENS,
-      cost: XAI_GROK_43_COST,
-    });
-  }
-  return undefined;
 }

--- a/extensions/xai/model-definitions.ts
+++ b/extensions/xai/model-definitions.ts
@@ -4,7 +4,7 @@ import {
   asOptionalRecord,
   normalizeOptionalLowercaseString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { normalizeXaiModelId } from "./model-id.js";
+import { isXaiFrontierModelId, normalizeXaiModelId } from "./model-id.js";
 import manifest from "./openclaw.plugin.json" with { type: "json" };
 
 export const XAI_BASE_URL = manifest.modelCatalog.providers.xai.baseUrl;
@@ -39,11 +39,61 @@ function copyXaiModelDefinition(entry: ModelDefinitionConfig): ModelDefinitionCo
 const XAI_MODEL_CATALOG: readonly ModelDefinitionConfig[] =
   manifest.modelCatalog.providers.xai.models.map(toXaiModelDefinition);
 
-/** Exact curated row for a model id, after xAI alias normalization. */
+/** Curated pricing and supported-family capabilities share one lookup owner. */
 export function resolveXaiCatalogEntry(modelId: string): ModelDefinitionConfig | undefined {
   const normalized = normalizeXaiCatalogModelId(modelId);
   const entry = XAI_MODEL_CATALOG.find((model) => model.id.toLowerCase() === normalized);
-  return entry ? copyXaiModelDefinition(entry) : undefined;
+  if (entry) {
+    return copyXaiModelDefinition(entry);
+  }
+  if (normalized.includes("multi-agent")) {
+    return undefined;
+  }
+  const grok3 = normalized.startsWith("grok-3");
+  const frontier = isXaiFrontierModelId(normalized);
+  const multimodal =
+    normalized === "grok-latest" ||
+    frontier ||
+    normalized.startsWith("grok-4.3") ||
+    normalized.startsWith("grok-4.20") ||
+    normalized.startsWith("grok-4-1") ||
+    normalized.startsWith("grok-4-fast");
+  if (!grok3 && !multimodal && !normalized.startsWith("grok-4")) {
+    return undefined;
+  }
+  const id = normalizeXaiModelId(modelId.trim());
+  return {
+    id,
+    name: id,
+    reasoning: grok3 ? normalized.includes("mini") : !normalized.includes("non-reasoning"),
+    input: multimodal ? ["text", "image"] : ["text"],
+    cost: { ...XAI_UNKNOWN_MODEL_COST },
+    contextWindow: frontier ? 500_000 : XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: normalized.startsWith("grok-4.20") ? 30_000 : XAI_DEFAULT_MAX_TOKENS,
+  };
+}
+
+export function resolveXaiForwardCompatDefinition(
+  modelId: string,
+): ModelDefinitionConfig | undefined {
+  const known = resolveXaiCatalogEntry(modelId);
+  if (known) {
+    return known;
+  }
+  const id = modelId.trim();
+  const lower = normalizeOptionalLowercaseString(id) ?? "";
+  if (!lower.startsWith("grok-") || lower.includes("multi-agent")) {
+    return undefined;
+  }
+  return {
+    id,
+    name: id,
+    reasoning: !lower.includes("non-reasoning"),
+    input: ["text", "image"],
+    cost: { ...XAI_UNKNOWN_MODEL_COST },
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+  };
 }
 
 export function buildXaiModelDefinition(): ModelDefinitionConfig {

--- a/extensions/xai/model-id.ts
+++ b/extensions/xai/model-id.ts
@@ -1,6 +1,4 @@
 // Xai plugin module implements model id behavior.
-export const XAI_OAUTH_AUTO_MODEL_ID = "auto";
-
 export function isXaiGrok46ModelId(id: string): boolean {
   const normalized = normalizeXaiModelId(id.trim().toLowerCase());
   return normalized === "grok-4.6";
@@ -11,19 +9,6 @@ export function isXaiFrontierModelId(id: string): boolean {
   return (
     normalized === "grok-4.6" || normalized === "grok-4.5" || normalized.startsWith("grok-4.5-")
   );
-}
-
-export function resolveXaiOAuthAutoModelId(
-  id: string,
-  params?: Record<string, unknown> | null,
-): string {
-  if (id.trim().toLowerCase() !== XAI_OAUTH_AUTO_MODEL_ID) {
-    return id;
-  }
-  const canonicalModelId = params?.canonicalModelId;
-  return typeof canonicalModelId === "string" && canonicalModelId.trim()
-    ? canonicalModelId.trim()
-    : id;
 }
 
 export function normalizeXaiModelId(id: string): string {

--- a/extensions/xai/onboard.test.ts
+++ b/extensions/xai/onboard.test.ts
@@ -15,7 +15,6 @@ import {
   applyXaiOAuthConfig,
   applyXaiProviderConfig,
   XAI_DEFAULT_MODEL_REF,
-  XAI_OAUTH_DEFAULT_MODEL_REF,
 } from "./onboard.js";
 
 describe("xai onboard", () => {
@@ -23,11 +22,12 @@ describe("xai onboard", () => {
     const cfg = applyXaiConfig({});
     expect(cfg.models?.providers?.xai?.baseUrl).toBe("https://api.x.ai/v1");
     expect(cfg.models?.providers?.xai?.api).toBe("openai-responses");
-    expect(XAI_DEFAULT_MODEL_REF).toBe("xai/grok-4.3");
+    expect(XAI_DEFAULT_MODEL_REF).toBe("xai/grok-4.6");
     expect(resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model)).toBe(XAI_DEFAULT_MODEL_REF);
+    expect(cfg.models?.providers?.xai?.models).toEqual([]);
   });
 
-  it("merges xAI models and keeps existing provider overrides", () => {
+  it("keeps authored xAI models without pinning the curated inventory", () => {
     const legacy = createLegacyProviderConfig({
       providerId: "xai",
       api: "anthropic-messages",
@@ -78,12 +78,6 @@ describe("xai onboard", () => {
       "grok-3",
       "grok-code-fast-1",
       "grok-4.20-beta-latest-reasoning",
-      "grok-4.6",
-      "grok-4.5",
-      "grok-build-0.1",
-      "grok-4.3",
-      "grok-4.20-0309-reasoning",
-      "grok-4.20-0309-non-reasoning",
     ]);
     expect(
       cfg.models?.providers?.xai?.models.find(
@@ -92,8 +86,8 @@ describe("xai onboard", () => {
     ).toBe("Custom Moving Grok 4.20");
   });
 
-  it("publishes current xAI models newest first for fresh setup", () => {
-    const cfg = applyXaiProviderConfig({});
+  it("fills replace mode with the curated models newest first", () => {
+    const cfg = applyXaiProviderConfig({ models: { mode: "replace" } });
 
     expect(cfg.models?.providers?.xai?.baseUrl).toBe("https://api.x.ai/v1");
     expect(cfg.models?.providers?.xai?.api).toBe("openai-responses");
@@ -112,7 +106,7 @@ describe("xai onboard", () => {
     expect(cfg.agents?.defaults?.models?.[XAI_DEFAULT_MODEL_REF]?.alias).toBe("Grok");
   });
 
-  it("persists the provider-owned auto ref for OAuth setup", () => {
+  it("uses the curated default while retaining the OAuth transport", () => {
     const provider: ModelProviderConfig = {
       api: "openai-responses",
       auth: "oauth",
@@ -122,9 +116,8 @@ describe("xai onboard", () => {
     const cfg = applyXaiOAuthConfig({}, provider);
     expect(cfg.models?.providers?.xai).toMatchObject(provider);
 
-    expect(XAI_OAUTH_DEFAULT_MODEL_REF).toBe("xai/auto");
-    expect(resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model)).toBe("xai/auto");
-    expect(cfg.agents?.defaults?.models?.["xai/auto"]?.alias).toBe("Grok");
+    expect(resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model)).toBe("xai/grok-4.6");
+    expect(cfg.agents?.defaults?.models?.["xai/grok-4.6"]?.alias).toBe("Grok");
   });
 
   it("preserves existing model fallbacks", () => {

--- a/extensions/xai/onboard.ts
+++ b/extensions/xai/onboard.ts
@@ -14,20 +14,16 @@ import {
   XAI_BASE_URL,
   XAI_DEFAULT_MODEL_ID,
 } from "./model-definitions.js";
-import { XAI_OAUTH_AUTO_MODEL_ID } from "./model-id.js";
 
 export const XAI_DEFAULT_MODEL_REF = `xai/${XAI_DEFAULT_MODEL_ID}`;
-// OAuth resolves this stable ref against xAI's authenticated catalog and
-// remote default setting. API-key setup stays on the pinned default above.
-export const XAI_OAUTH_DEFAULT_MODEL_REF = `xai/${XAI_OAUTH_AUTO_MODEL_ID}`;
 
 const xaiPresetAppliers = createModelCatalogPresetAppliers({
   primaryModelRef: XAI_DEFAULT_MODEL_REF,
-  resolveParams: () => ({
+  resolveParams: (cfg) => ({
     providerId: "xai",
     api: "openai-responses",
     baseUrl: XAI_BASE_URL,
-    catalogModels: buildXaiCatalogModels(),
+    catalogModels: cfg.models?.mode === "replace" ? buildXaiCatalogModels() : [],
     aliases: [{ modelRef: XAI_DEFAULT_MODEL_REF, alias: "Grok" }],
   }),
 });
@@ -70,7 +66,7 @@ export function applyXaiOAuthConfig(
 ): OpenClawConfig {
   const next = applyOnboardAuthAgentModelsAndProviders(cfg, {
     agentModels: withAgentModelAliases(cfg.agents?.defaults?.models, [
-      { modelRef: XAI_OAUTH_DEFAULT_MODEL_REF, alias: "Grok" },
+      { modelRef: XAI_DEFAULT_MODEL_REF, alias: "Grok" },
     ]),
     providers: {
       xai: {
@@ -79,12 +75,10 @@ export function applyXaiOAuthConfig(
         authHeader: undefined,
         headers: undefined,
         request: { auth: undefined, headers: undefined },
-        // The moving alias must come from discovery, never a persisted target.
-        models: provider.models.filter((model) => model.id !== XAI_OAUTH_AUTO_MODEL_ID),
       },
     },
   });
   return resolveAgentModelPrimaryValue(cfg.agents?.defaults?.model)
     ? next
-    : applyAgentDefaultModelPrimary(next, XAI_OAUTH_DEFAULT_MODEL_REF);
+    : applyAgentDefaultModelPrimary(next, XAI_DEFAULT_MODEL_REF);
 }

--- a/extensions/xai/openclaw.plugin.json
+++ b/extensions/xai/openclaw.plugin.json
@@ -38,10 +38,79 @@
     }
   },
   "modelCatalog": {
+    "providers": {
+      "xai": {
+        "baseUrl": "https://api.x.ai/v1",
+        "api": "openai-responses",
+        "models": [
+          {
+            "id": "grok-4.6",
+            "name": "Grok 4.6",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "cost": { "input": 2, "output": 6, "cacheRead": 0.5, "cacheWrite": 0 },
+            "contextWindow": 500000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "grok-4.5",
+            "name": "Grok 4.5",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "cost": { "input": 2, "output": 6, "cacheRead": 0.3, "cacheWrite": 0 },
+            "contextWindow": 500000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "grok-build-0.1",
+            "name": "Grok Build 0.1",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "cost": { "input": 1, "output": 2, "cacheRead": 0.2, "cacheWrite": 0 },
+            "contextWindow": 256000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "grok-4.3",
+            "name": "Grok 4.3",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "cost": { "input": 1.25, "output": 2.5, "cacheRead": 0.2, "cacheWrite": 0 },
+            "contextWindow": 1000000,
+            "maxTokens": 64000
+          },
+          {
+            "id": "grok-4.20-0309-reasoning",
+            "name": "Grok 4.20 0309 (Reasoning)",
+            "reasoning": true,
+            "input": ["text", "image"],
+            "cost": { "input": 1.25, "output": 2.5, "cacheRead": 0.2, "cacheWrite": 0 },
+            "contextWindow": 1000000,
+            "maxTokens": 30000
+          },
+          {
+            "id": "grok-4.20-0309-non-reasoning",
+            "name": "Grok 4.20 0309 (Non-Reasoning)",
+            "reasoning": false,
+            "input": ["text", "image"],
+            "cost": { "input": 1.25, "output": 2.5, "cacheRead": 0.2, "cacheWrite": 0 },
+            "contextWindow": 1000000,
+            "maxTokens": 30000
+          }
+        ]
+      }
+    },
     "discovery": {
       "xai": "refreshable"
     },
     "suppressions": [
+      {
+        "provider": "xai",
+        "model": "auto",
+        "reason": "The OpenClaw xAI OAuth auto selector has retired; use a concrete model.",
+        "retirement": { "replacedBy": "grok-4.6" },
+        "when": { "baseUrlHosts": ["cli-chat-proxy.grok.com"] }
+      },
       {
         "provider": "xai",
         "model": "grok-4.20-multi-agent-0309",

--- a/extensions/xai/provider-catalog.ts
+++ b/extensions/xai/provider-catalog.ts
@@ -1,7 +1,6 @@
 // Xai provider module implements model/runtime integration.
 import {
   buildLiveModelProviderConfig,
-  getCachedLiveProviderModelRows,
   readLiveModelCatalogBooleanField,
   readLiveModelCatalogPositiveSafeIntegerField,
   readLiveModelCatalogStringField,
@@ -18,25 +17,18 @@ import {
   XAI_DEFAULT_CONTEXT_WINDOW,
   XAI_IMAGE_MODELS,
   XAI_DEFAULT_MAX_TOKENS,
+  XAI_UNKNOWN_MODEL_COST,
 } from "./model-definitions.js";
-import { XAI_OAUTH_AUTO_MODEL_ID } from "./model-id.js";
 
 const PROVIDER_ID = "xai";
 const XAI_MODELS_ENDPOINT = `${XAI_BASE_URL}/models`;
 const XAI_GROK_OAUTH_BASE_URL = "https://cli-chat-proxy.grok.com/v1";
 const XAI_GROK_OAUTH_MODELS_ENDPOINT = `${XAI_GROK_OAUTH_BASE_URL}/models`;
-const XAI_GROK_OAUTH_SETTINGS_ENDPOINT = `${XAI_GROK_OAUTH_BASE_URL}/settings`;
 const XAI_MODELS_CACHE_TTL_MS = 60_000;
 const XAI_GROK_OAUTH_MODELS_CACHE_TTL_MS = 60_000;
 // Composer emits replayable Responses reasoning, but the OAuth catalog omits that capability.
 // Keep it classified here or the stream wrapper will omit encrypted reasoning from replay.
 const XAI_GROK_OAUTH_REASONING_MODEL_IDS = new Set(["grok-composer-2.5-fast"]);
-const XAI_UNKNOWN_MODEL_COST = {
-  input: 0,
-  output: 0,
-  cacheRead: 0,
-  cacheWrite: 0,
-} satisfies ModelDefinitionConfig["cost"];
 
 export function isXaiGrokProxyBaseUrl(baseUrl: string | undefined): boolean {
   if (!baseUrl) {
@@ -51,99 +43,14 @@ export function isXaiGrokProxyBaseUrl(baseUrl: string | undefined): boolean {
 
 export function buildXaiProvider(
   api: ModelProviderConfig["api"] = "openai-responses",
+  authMode?: "oauth" | "token",
 ): ModelProviderConfig {
   return {
-    baseUrl: XAI_BASE_URL,
-    api,
+    baseUrl: authMode ? XAI_GROK_OAUTH_BASE_URL : XAI_BASE_URL,
+    api: authMode ? "openai-responses" : api,
+    ...(authMode ? { auth: authMode } : {}),
     models: buildXaiCatalogModels(),
   };
-}
-
-function normalizeXaiOAuthModelSelector(value: string): string {
-  return value.trim().toLowerCase().replace(/[._]+/g, "-");
-}
-
-function resolveXaiOAuthAutoTarget(
-  models: readonly ModelDefinitionConfig[],
-  preferredModelId: string | undefined,
-): ModelDefinitionConfig | undefined {
-  const candidates = models.filter((model) => model.id !== XAI_OAUTH_AUTO_MODEL_ID);
-  if (preferredModelId) {
-    const exact = candidates.find((model) => model.id === preferredModelId);
-    if (exact) {
-      return exact;
-    }
-    const selector = normalizeXaiOAuthModelSelector(preferredModelId);
-    const normalizedMatches = candidates.filter(
-      (model) => normalizeXaiOAuthModelSelector(model.id) === selector,
-    );
-    if (normalizedMatches.length === 1) {
-      return normalizedMatches[0];
-    }
-  }
-  // Match Grok Build's fallback when its remote default is absent or stale:
-  // use the first auth-visible model returned by the provider catalog.
-  return candidates[0];
-}
-
-function withXaiOAuthAutoModel(
-  provider: ModelProviderConfig,
-  preferredModelId: string | undefined,
-): ModelProviderConfig {
-  const target = resolveXaiOAuthAutoTarget(provider.models, preferredModelId);
-  if (!target) {
-    return provider;
-  }
-  return {
-    ...provider,
-    models: [
-      {
-        ...target,
-        id: XAI_OAUTH_AUTO_MODEL_ID,
-        params: {
-          ...target.params,
-          canonicalModelId: target.id,
-        },
-      },
-      ...provider.models.filter((model) => model.id !== XAI_OAUTH_AUTO_MODEL_ID),
-    ],
-  };
-}
-
-async function fetchXaiOAuthDefaultModelId(params: {
-  discoveryApiKey: string;
-  fetchGuard?: LiveModelCatalogFetchGuard;
-  signal?: AbortSignal;
-}): Promise<string | undefined> {
-  try {
-    const rows = await getCachedLiveProviderModelRows({
-      providerId: PROVIDER_ID,
-      endpoint: XAI_GROK_OAUTH_SETTINGS_ENDPOINT,
-      discoveryApiKey: params.discoveryApiKey,
-      fetchGuard: params.fetchGuard,
-      signal: params.signal,
-      ttlMs: XAI_GROK_OAUTH_MODELS_CACHE_TTL_MS,
-      auditContext: "xai-grok-oauth-settings-discovery",
-      cacheKeyParts: [
-        PROVIDER_ID,
-        "grok-oauth-settings",
-        XAI_GROK_OAUTH_SETTINGS_ENDPOINT,
-        params.discoveryApiKey,
-      ],
-      readRows: (body) => {
-        if (!body || typeof body !== "object" || Array.isArray(body)) {
-          throw new Error("xAI OAuth settings response must be an object");
-        }
-        return [body];
-      },
-      shouldCacheRows: (candidateRows) =>
-        readLiveModelCatalogStringField(candidateRows[0], "default_model") !== undefined,
-    });
-    return readLiveModelCatalogStringField(rows[0], "default_model");
-  } catch {
-    // Remote settings are advisory. Catalog order remains the provider-owned fallback.
-    return undefined;
-  }
 }
 
 export async function buildLiveXaiProvider(params: {
@@ -248,34 +155,30 @@ export async function buildLiveXaiOAuthProvider(params: {
   fetchGuard?: LiveModelCatalogFetchGuard;
   signal?: AbortSignal;
 }): Promise<ModelProviderConfig> {
-  const [provider, preferredModelId] = await Promise.all([
-    buildLiveModelProviderConfig({
-      discoveryMode: "strict",
-      providerId: PROVIDER_ID,
-      endpoint: XAI_GROK_OAUTH_MODELS_ENDPOINT,
-      providerConfig: {
-        baseUrl: XAI_GROK_OAUTH_BASE_URL,
-        api: "openai-responses",
-        auth: params.authMode ?? "oauth",
-      },
-      models: [],
-      discoveryApiKey: params.discoveryApiKey,
-      fetchGuard: params.fetchGuard,
-      signal: params.signal,
-      ttlMs: XAI_GROK_OAUTH_MODELS_CACHE_TTL_MS,
-      auditContext: "xai-grok-oauth-model-discovery",
-      cacheKeyParts: [
-        PROVIDER_ID,
-        "grok-oauth-model-rows",
-        XAI_GROK_OAUTH_MODELS_ENDPOINT,
-        params.discoveryApiKey,
-      ],
-      projectRows: (rows) =>
-        rows
-          .map(buildXaiOauthModelFromLiveRow)
-          .filter((model): model is ModelDefinitionConfig => Boolean(model)),
-    }),
-    fetchXaiOAuthDefaultModelId(params),
-  ]);
-  return withXaiOAuthAutoModel(provider, preferredModelId);
+  const { models, ...providerConfig } = buildXaiProvider(
+    "openai-responses",
+    params.authMode ?? "oauth",
+  );
+  return await buildLiveModelProviderConfig({
+    discoveryMode: "strict",
+    providerId: PROVIDER_ID,
+    endpoint: XAI_GROK_OAUTH_MODELS_ENDPOINT,
+    providerConfig,
+    models,
+    discoveryApiKey: params.discoveryApiKey,
+    fetchGuard: params.fetchGuard,
+    signal: params.signal,
+    ttlMs: XAI_GROK_OAUTH_MODELS_CACHE_TTL_MS,
+    auditContext: "xai-grok-oauth-model-discovery",
+    cacheKeyParts: [
+      PROVIDER_ID,
+      "grok-oauth-model-rows",
+      XAI_GROK_OAUTH_MODELS_ENDPOINT,
+      params.discoveryApiKey,
+    ],
+    projectRows: (rows) =>
+      rows
+        .map(buildXaiOauthModelFromLiveRow)
+        .filter((model): model is ModelDefinitionConfig => Boolean(model)),
+  });
 }

--- a/extensions/xai/provider-models.ts
+++ b/extensions/xai/provider-models.ts
@@ -3,21 +3,12 @@ import type {
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
-import {
-  normalizeModelCompat,
-  type ModelDefinitionConfig,
-} from "openclaw/plugin-sdk/provider-model-shared";
+import { normalizeModelCompat } from "openclaw/plugin-sdk/provider-model-shared";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import {
-  resolveXaiCatalogEntry,
-  XAI_BASE_URL,
-  XAI_DEFAULT_CONTEXT_WINDOW,
-  XAI_DEFAULT_MAX_TOKENS,
-  XAI_UNKNOWN_MODEL_COST,
-} from "./model-definitions.js";
+import { resolveXaiForwardCompatDefinition, XAI_BASE_URL } from "./model-definitions.js";
 import { normalizeXaiModelId } from "./model-id.js";
 import { applyXaiRuntimeModelCompat } from "./runtime-model-compat.js";
 
@@ -36,27 +27,6 @@ export function isModernXaiModel(modelId: string): boolean {
     return false;
   }
   return XAI_MODERN_MODEL_PREFIXES.some((prefix) => lower.startsWith(prefix));
-}
-
-function resolveXaiForwardCompatDefinition(modelId: string): ModelDefinitionConfig | undefined {
-  const curated = resolveXaiCatalogEntry(modelId);
-  if (curated) {
-    return curated;
-  }
-  const id = modelId.trim();
-  const lower = normalizeOptionalLowercaseString(id) ?? "";
-  if (!lower.startsWith("grok-") || lower.includes("multi-agent")) {
-    return undefined;
-  }
-  return {
-    id,
-    name: id,
-    reasoning: !lower.includes("non-reasoning"),
-    input: ["text", "image"],
-    cost: XAI_UNKNOWN_MODEL_COST,
-    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
-    maxTokens: XAI_DEFAULT_MAX_TOKENS,
-  };
 }
 
 export function resolveXaiForwardCompatModel(params: {

--- a/extensions/xai/provider-models.ts
+++ b/extensions/xai/provider-models.ts
@@ -3,13 +3,22 @@ import type {
   ProviderResolveDynamicModelContext,
   ProviderRuntimeModel,
 } from "openclaw/plugin-sdk/plugin-entry";
-import { normalizeModelCompat } from "openclaw/plugin-sdk/provider-model-shared";
+import {
+  normalizeModelCompat,
+  type ModelDefinitionConfig,
+} from "openclaw/plugin-sdk/provider-model-shared";
 import {
   normalizeOptionalLowercaseString,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { resolveXaiCatalogEntry, XAI_BASE_URL } from "./model-definitions.js";
-import { normalizeXaiModelId, resolveXaiOAuthAutoModelId } from "./model-id.js";
+import {
+  resolveXaiCatalogEntry,
+  XAI_BASE_URL,
+  XAI_DEFAULT_CONTEXT_WINDOW,
+  XAI_DEFAULT_MAX_TOKENS,
+  XAI_UNKNOWN_MODEL_COST,
+} from "./model-definitions.js";
+import { normalizeXaiModelId } from "./model-id.js";
 import { applyXaiRuntimeModelCompat } from "./runtime-model-compat.js";
 
 const XAI_MODERN_MODEL_PREFIXES = [
@@ -29,11 +38,32 @@ export function isModernXaiModel(modelId: string): boolean {
   return XAI_MODERN_MODEL_PREFIXES.some((prefix) => lower.startsWith(prefix));
 }
 
+function resolveXaiForwardCompatDefinition(modelId: string): ModelDefinitionConfig | undefined {
+  const curated = resolveXaiCatalogEntry(modelId);
+  if (curated) {
+    return curated;
+  }
+  const id = modelId.trim();
+  const lower = normalizeOptionalLowercaseString(id) ?? "";
+  if (!lower.startsWith("grok-") || lower.includes("multi-agent")) {
+    return undefined;
+  }
+  return {
+    id,
+    name: id,
+    reasoning: !lower.includes("non-reasoning"),
+    input: ["text", "image"],
+    cost: XAI_UNKNOWN_MODEL_COST,
+    contextWindow: XAI_DEFAULT_CONTEXT_WINDOW,
+    maxTokens: XAI_DEFAULT_MAX_TOKENS,
+  };
+}
+
 export function resolveXaiForwardCompatModel(params: {
   providerId: string;
   ctx: ProviderResolveDynamicModelContext;
 }) {
-  const definition = resolveXaiCatalogEntry(params.ctx.modelId);
+  const definition = resolveXaiForwardCompatDefinition(params.ctx.modelId);
   if (!definition) {
     return undefined;
   }
@@ -55,7 +85,5 @@ export function resolveXaiForwardCompatModel(params: {
 }
 
 export function normalizeXaiResolvedModel(model: ProviderRuntimeModel): ProviderRuntimeModel {
-  const resolvedModelId = resolveXaiOAuthAutoModelId(model.id, model.params);
-  const resolved = resolvedModelId === model.id ? model : { ...model, id: resolvedModelId };
-  return { ...applyXaiRuntimeModelCompat(resolved), id: model.id };
+  return applyXaiRuntimeModelCompat(model);
 }

--- a/extensions/xai/provider-policy-api.test.ts
+++ b/extensions/xai/provider-policy-api.test.ts
@@ -52,25 +52,15 @@ describe("xai provider thinking policy", () => {
     });
   });
 
-  it.each([
-    ["grok-4.6", [{ id: "low" }, { id: "medium" }, { id: "high" }, { id: "xhigh" }]],
-    ["grok-4.5", [{ id: "low" }, { id: "medium" }, { id: "high" }]],
-  ] as const)(
-    "resolves the OAuth auto alias to its canonical %s target",
-    (canonicalModelId, levels) => {
-      expect(
-        resolveThinkingProfile({
-          provider: "xai",
-          modelId: "auto",
-          reasoning: true,
-          params: { canonicalModelId },
-        }),
-      ).toEqual({ levels, defaultLevel: "high" });
-    },
-  );
-
-  it("keeps the OAuth auto alias off-only without a canonical target", () => {
-    expect(resolveThinkingProfile({ provider: "xai", modelId: "auto", reasoning: true })).toEqual({
+  it("does not infer thinking controls from retired canonical-target metadata", () => {
+    expect(
+      resolveThinkingProfile({
+        provider: "xai",
+        modelId: "auto",
+        reasoning: true,
+        params: { canonicalModelId: "grok-4.6" },
+      }),
+    ).toEqual({
       levels: [{ id: "off" }],
       defaultLevel: "off",
     });

--- a/extensions/xai/provider-policy-api.ts
+++ b/extensions/xai/provider-policy-api.ts
@@ -3,22 +3,16 @@ import type {
   ProviderThinkingProfile,
 } from "openclaw/plugin-sdk/plugin-entry";
 import { resolveXaiCatalogEntry } from "./model-definitions.js";
-import {
-  isXaiFrontierModelId,
-  isXaiGrok46ModelId,
-  normalizeXaiModelId,
-  resolveXaiOAuthAutoModelId,
-} from "./model-id.js";
+import { isXaiFrontierModelId, isXaiGrok46ModelId, normalizeXaiModelId } from "./model-id.js";
 import { isXaiProviderId } from "./provider-id.js";
 
 export function resolveThinkingProfile(
   ctx: ProviderDefaultThinkingPolicyContext,
 ): ProviderThinkingProfile {
-  // OAuth catalog rows keep the "auto" alias id and carry the provider-selected
-  // target in params.canonicalModelId. Judge that concrete target here too.
-  const rawModelId = resolveXaiOAuthAutoModelId(ctx.modelId, ctx.params);
-  const modelId = normalizeXaiModelId(rawModelId.trim().toLowerCase());
-  const reasoning = ctx.reasoning ?? resolveXaiCatalogEntry(modelId)?.reasoning;
+  const modelId = normalizeXaiModelId(ctx.modelId.trim().toLowerCase());
+  const isGrok43 =
+    modelId === "grok-latest" || modelId === "grok-4.3" || modelId.startsWith("grok-4.3-");
+  const reasoning = ctx.reasoning ?? resolveXaiCatalogEntry(modelId)?.reasoning ?? isGrok43;
   if (!isXaiProviderId(ctx.provider) || !reasoning) {
     return { levels: [{ id: "off" }], defaultLevel: "off" };
   }
@@ -31,8 +25,6 @@ export function resolveThinkingProfile(
       defaultLevel: "high",
     };
   }
-  const isGrok43 =
-    modelId === "grok-latest" || modelId === "grok-4.3" || modelId.startsWith("grok-4.3-");
   if (!isGrok43) {
     return { levels: [{ id: "off" }], defaultLevel: "off" };
   }

--- a/extensions/xai/responses-tool-policy.test.ts
+++ b/extensions/xai/responses-tool-policy.test.ts
@@ -10,6 +10,7 @@ const connection = { apiKey: "synthetic-tool-fixture", timeoutSeconds: 5 };
 const callers = [
   {
     name: "web_search",
+    grok43Effort: "low",
     run: (model: string) =>
       requestXaiWebSearch({
         ...connection,
@@ -21,6 +22,7 @@ const callers = [
   },
   {
     name: "x_search",
+    grok43Effort: "none",
     run: (model: string) =>
       requestXaiXSearch({
         ...connection,
@@ -32,6 +34,7 @@ const callers = [
   },
   {
     name: "code_execution",
+    grok43Effort: "low",
     run: (model: string) => requestXaiCodeExecution({ ...connection, model, task: "fixture" }),
   },
 ];
@@ -65,4 +68,15 @@ it.each(callers)("preserves an explicit model and omitted effort for $name", asy
   const body = await new Request("https://api.x.ai/v1/responses", init).json();
   expect(body.model).toBe("grok-4.5");
   expect(body.reasoning).toBeUndefined();
+});
+
+it.each(callers)("preserves explicit Grok 4.3 effort for $name", async ({ run, grok43Effort }) => {
+  const request = vi.fn<typeof fetch>(async () => Response.json({ output_text: "fixture result" }));
+  vi.stubGlobal("fetch", withFetchPreconnect(request));
+  await run("grok-4.3");
+  const body = await new Request(
+    "https://api.x.ai/v1/responses",
+    request.mock.calls[0]?.[1],
+  ).json();
+  expect(body).toMatchObject({ model: "grok-4.3", reasoning: { effort: grok43Effort } });
 });

--- a/extensions/xai/responses-tool-policy.test.ts
+++ b/extensions/xai/responses-tool-policy.test.ts
@@ -1,0 +1,68 @@
+import { withFetchPreconnect } from "openclaw/plugin-sdk/test-env";
+import { afterEach, expect, it, vi } from "vitest";
+import { requestXaiCodeExecution } from "./src/code-execution-shared.js";
+import { requestXaiWebSearch } from "./src/web-search-shared.js";
+import { requestXaiXSearch } from "./src/x-search-shared.js";
+
+afterEach(() => vi.unstubAllGlobals());
+
+const connection = { apiKey: "synthetic-tool-fixture", timeoutSeconds: 5 };
+const callers = [
+  {
+    name: "web_search",
+    run: (model: string) =>
+      requestXaiWebSearch({
+        ...connection,
+        model,
+        query: "fixture",
+        endpoint: "https://api.x.ai/v1/responses",
+        inlineCitations: false,
+      }),
+  },
+  {
+    name: "x_search",
+    run: (model: string) =>
+      requestXaiXSearch({
+        ...connection,
+        model,
+        options: { query: "fixture" },
+        endpoint: "https://api.x.ai/v1/responses",
+        inlineCitations: false,
+      }),
+  },
+  {
+    name: "code_execution",
+    run: (model: string) => requestXaiCodeExecution({ ...connection, model, task: "fixture" }),
+  },
+];
+
+it.each(callers)(
+  "keeps the $name default request within supported reasoning efforts",
+  async ({ run }) => {
+    const request = vi.fn<typeof fetch>(async () =>
+      Response.json({ output_text: "fixture result" }),
+    );
+    vi.stubGlobal("fetch", withFetchPreconnect(request));
+    await run("grok-4.6");
+    expect(request).toHaveBeenCalledOnce();
+    const init = request.mock.calls[0]?.[1];
+    expect(init).toEqual(expect.objectContaining({ body: expect.any(String) }));
+    const body = new Request("https://api.x.ai/v1/responses", init);
+    expect(await body.json()).toMatchObject({
+      model: "grok-4.6",
+      store: false,
+      reasoning: { effort: "low" },
+    });
+  },
+);
+
+it.each(callers)("preserves an explicit model and omitted effort for $name", async ({ run }) => {
+  const request = vi.fn<typeof fetch>(async () => Response.json({ output_text: "fixture result" }));
+  vi.stubGlobal("fetch", withFetchPreconnect(request));
+  await run("grok-4.5");
+  const init = request.mock.calls[0]?.[1];
+  expect(init).toEqual(expect.objectContaining({ body: expect.any(String) }));
+  const body = await new Request("https://api.x.ai/v1/responses", init).json();
+  expect(body.model).toBe("grok-4.5");
+  expect(body.reasoning).toBeUndefined();
+});

--- a/extensions/xai/src/code-execution-shared.ts
+++ b/extensions/xai/src/code-execution-shared.ts
@@ -2,6 +2,7 @@
 import { XAI_DEFAULT_MODEL_ID } from "../model-definitions.js";
 import {
   requestXaiResponsesTool,
+  resolveXaiToolDefaultReasoningEffort,
   requireXaiResponseTextAndCitations,
   XAI_RESPONSES_ENDPOINT,
 } from "./responses-tool-shared.js";
@@ -67,7 +68,7 @@ export async function requestXaiCodeExecution(params: {
       endpoint: XAI_CODE_EXECUTION_ENDPOINT,
       inputText: params.task,
       tools: [{ type: "code_interpreter" }],
-      reasoningEffort: params.model === XAI_DEFAULT_CODE_EXECUTION_MODEL ? "low" : undefined,
+      reasoningEffort: resolveXaiToolDefaultReasoningEffort(params.model, "low"),
       errorLabel: "xAI code execution failed",
     },
     (data) => {

--- a/extensions/xai/src/responses-tool-shared.ts
+++ b/extensions/xai/src/responses-tool-shared.ts
@@ -59,6 +59,14 @@ export function resolveXaiResponsesEndpoint(baseUrl?: unknown): string {
   return `${(trimString(baseUrl) ?? XAI_RESPONSES_BASE_URL).replace(/\/+$/, "")}/responses`;
 }
 
+export function resolveXaiToolDefaultReasoningEffort(
+  model: string,
+  preferred: "none" | "low",
+): "none" | "low" | undefined {
+  // Per-model tool defaults must survive changes to the setup default.
+  return model === "grok-4.3" || model === "grok-4.6" ? preferred : undefined;
+}
+
 function buildXaiResponsesToolBody(params: {
   model: string;
   inputText: string;

--- a/extensions/xai/src/responses-tool-shared.ts
+++ b/extensions/xai/src/responses-tool-shared.ts
@@ -7,6 +7,8 @@ import {
   normalizeOptionalString as trimString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { truncateUtf16Safe } from "openclaw/plugin-sdk/text-utility-runtime";
+import { resolveXaiCatalogEntry } from "../model-definitions.js";
+import { applyXaiRuntimeModelCompat } from "../runtime-model-compat.js";
 import type { XaiWebSearchResponse } from "./web-search-response.types.js";
 
 const XAI_CITATION_MAX_COUNT = 20;
@@ -64,12 +66,21 @@ function buildXaiResponsesToolBody(params: {
   maxTurns?: number;
   reasoningEffort?: "none" | "low" | "medium" | "high";
 }): Record<string, unknown> {
+  const requested = params.reasoningEffort;
+  let reasoningEffort: string | undefined = requested;
+  const model = requested ? resolveXaiCatalogEntry(params.model) : undefined;
+  if (requested && model) {
+    const levels = applyXaiRuntimeModelCompat(model).thinkingLevelMap;
+    const level = requested === "none" ? "off" : requested;
+    // Direct tools must obey the same supported efforts as agent requests.
+    reasoningEffort = levels[level] ?? (level === "off" ? levels.minimal : undefined) ?? undefined;
+  }
   return {
     model: params.model,
     input: [{ role: "user", content: params.inputText }],
     tools: params.tools,
     store: false,
-    ...(params.reasoningEffort ? { reasoning: { effort: params.reasoningEffort } } : {}),
+    ...(reasoningEffort ? { reasoning: { effort: reasoningEffort } } : {}),
     ...(params.maxTurns ? { max_turns: params.maxTurns } : {}),
   };
 }

--- a/extensions/xai/src/web-search-shared.ts
+++ b/extensions/xai/src/web-search-shared.ts
@@ -5,6 +5,7 @@ import { XAI_DEFAULT_MODEL_ID } from "../model-definitions.js";
 import { normalizeXaiModelId } from "../model-id.js";
 import {
   requestXaiResponsesTool,
+  resolveXaiToolDefaultReasoningEffort,
   requireXaiResponseTextCitationsAndInline,
   resolveXaiResponsesEndpoint,
 } from "./responses-tool-shared.js";
@@ -112,7 +113,7 @@ export async function requestXaiWebSearch(params: {
       ...params,
       inputText: params.query,
       tools: [{ type: "web_search" }],
-      reasoningEffort: params.model === XAI_DEFAULT_WEB_SEARCH_MODEL ? "low" : undefined,
+      reasoningEffort: resolveXaiToolDefaultReasoningEffort(params.model, "low"),
       errorLabel: "xAI web search failed",
     },
     (data) =>

--- a/extensions/xai/src/x-search-shared.ts
+++ b/extensions/xai/src/x-search-shared.ts
@@ -2,6 +2,7 @@
 import { XAI_DEFAULT_MODEL_ID } from "../model-definitions.js";
 import {
   requestXaiResponsesTool,
+  resolveXaiToolDefaultReasoningEffort,
   requireXaiResponseTextCitationsAndInline,
   resolveXaiResponsesEndpoint,
 } from "./responses-tool-shared.js";
@@ -116,7 +117,7 @@ export async function requestXaiXSearch(params: {
       ...params,
       inputText: params.options.query,
       tools: [buildXSearchTool(params.options)],
-      reasoningEffort: params.model === XAI_DEFAULT_X_SEARCH_MODEL ? "none" : undefined,
+      reasoningEffort: resolveXaiToolDefaultReasoningEffort(params.model, "none"),
       errorLabel: "xAI X search failed",
     },
     (data) =>

--- a/extensions/xai/stream.test.ts
+++ b/extensions/xai/stream.test.ts
@@ -169,7 +169,7 @@ async function captureXaiResponsesPayloadWithThinking(
 
 describe("xai stream wrappers", () => {
   it.each(
-    ["grok-4.5", "auto"].flatMap((id) =>
+    ["grok-4.5", "grok-4.6"].flatMap((id) =>
       ["https://cli-chat-proxy.grok.com/v1", "https://CLI-CHAT-PROXY.GROK.COM:443/v1/"].map(
         (baseUrl) => ({ id, baseUrl }),
       ),
@@ -201,18 +201,18 @@ describe("xai stream wrappers", () => {
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
         contextWindow: 500_000,
         maxTokens: 64_000,
-        params: { canonicalModelId: "grok-4.5" },
+        params: { canonicalModelId: "grok-fixture-unselected" },
         baseUrl,
       },
       { messages: [] },
       { headers: { "X-XAI-Token-Auth": "operator-value", "X-Existing": "kept" } },
     );
 
-    expect(capturedModelId).toBe("grok-4.5");
+    expect(capturedModelId).toBe(id);
     expect(capturedHeaders).toEqual({
       "x-existing": "kept",
       "x-grok-client-version": "2026.7.2",
-      "x-grok-model-override": "grok-4.5",
+      "x-grok-model-override": id,
       "x-xai-token-auth": "xai-grok-cli",
     });
   });

--- a/extensions/xai/stream.ts
+++ b/extensions/xai/stream.ts
@@ -10,7 +10,6 @@ import {
 } from "openclaw/plugin-sdk/provider-stream-shared";
 import { asOptionalRecord, filterStringEntries } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { XAI_BASE_URL } from "./model-definitions.js";
-import { resolveXaiOAuthAutoModelId } from "./model-id.js";
 import { isXaiGrokProxyBaseUrl } from "./provider-catalog.js";
 import { isXaiProviderId } from "./provider-id.js";
 
@@ -40,15 +39,13 @@ function createXaiGrokOAuthHeadersWrapper(
     ) {
       return underlying(model, context, options);
     }
-    // Keep the selected alias stable through auth materialization; resolve only on the wire.
-    const modelId = resolveXaiOAuthAutoModelId(model.id, model.params);
     const headers = new Headers(options?.headers);
     // The Grok OAuth proxy requires its CLI identity and a concrete catalog model.
     // Keep these proxy-only so ordinary xAI API-key traffic retains its public contract.
     headers.set("X-XAI-Token-Auth", "xai-grok-cli");
     headers.set("x-grok-client-version", normalizedClientVersion);
-    headers.set("x-grok-model-override", modelId);
-    return underlying({ ...model, id: modelId }, context, {
+    headers.set("x-grok-model-override", model.id);
+    return underlying(model, context, {
       ...options,
       headers: Object.fromEntries(headers.entries()),
     });

--- a/extensions/xai/supported-capabilities.test.ts
+++ b/extensions/xai/supported-capabilities.test.ts
@@ -1,0 +1,47 @@
+import { clearLiveCatalogCacheForTests } from "openclaw/plugin-sdk/provider-catalog-live-runtime";
+import { afterEach, expect, it } from "vitest";
+import { buildXaiCatalogModels, resolveXaiCatalogEntry } from "./model-definitions.js";
+import { buildLiveXaiOAuthProvider } from "./provider-catalog.js";
+
+afterEach(clearLiveCatalogCacheForTests);
+
+it.each([true, false])(
+  "preserves a supported OAuth alias with backend metadata=%s",
+  async (withBackend) => {
+    const provider = await buildLiveXaiOAuthProvider({
+      discoveryApiKey: "synthetic-capability-fixture",
+      fetchGuard: async ({ url }) => ({
+        response: Response.json({
+          data: [{ id: "grok-latest", ...(withBackend ? { api_backend: "responses" } : {}) }],
+        }),
+        finalUrl: url,
+        release: async () => undefined,
+      }),
+    });
+    expect(provider.models).toEqual([
+      expect.objectContaining({
+        id: "grok-latest",
+        reasoning: true,
+        input: ["text", "image"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      }),
+    ]);
+  },
+);
+
+it.each([
+  { id: "grok-3", reasoning: false, input: ["text"], maxTokens: 64_000 },
+  { id: "grok-3-mini-fast", reasoning: true, input: ["text"], maxTokens: 64_000 },
+  { id: "grok-4.20-reasoning", reasoning: true, input: ["text", "image"], maxTokens: 30_000 },
+  { id: "grok-4.20-non-reasoning", reasoning: false, input: ["text", "image"], maxTokens: 30_000 },
+])(
+  "keeps supported capabilities separate from inventory and pricing for $id",
+  ({ id, ...capabilities }) => {
+    expect(resolveXaiCatalogEntry(id)).toMatchObject({
+      id,
+      ...capabilities,
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    });
+    expect(buildXaiCatalogModels().some((model) => model.id === id)).toBe(false);
+  },
+);

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -831,8 +831,8 @@ describe("xai provider models", () => {
     });
   });
 
-  it("keeps Grok 4.3 selectable with current bundled metadata", () => {
-    const expected = {
+  it("resolves curated rows and their aliases from the manifest", () => {
+    const grok43 = {
       id: "grok-4.3",
       reasoning: true,
       input: ["text", "image"],
@@ -840,25 +840,23 @@ describe("xai provider models", () => {
       maxTokens: 64_000,
       cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
     };
-    expectCatalogEntry("grok-4.3", expected);
-    expectCatalogEntry("grok-4.3-latest", expected);
-    expectCatalogEntry("grok-latest", { ...expected, id: "grok-latest" });
-    expectCatalogEntry("grok-4-latest", {
-      ...expected,
-      id: "grok-4-latest",
-      input: ["text"],
-    });
+    expectCatalogEntry("grok-4.3", grok43);
+    expectCatalogEntry("grok-4.3-latest", grok43);
+    expectCatalogEntry("xai/GROK-4.3", grok43);
   });
 
-  it("keeps retired Grok fast slugs resolving for compatibility", () => {
-    expectCatalogEntry("grok-4-1-fast", {
-      id: "grok-4-1-fast",
-      reasoning: true,
-      input: ["text", "image"],
-      contextWindow: 1_000_000,
-      maxTokens: 64_000,
-      cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
-    });
+  it("leaves ids outside the manifest to forward-compat defaults", () => {
+    for (const modelId of [
+      "grok-latest",
+      "grok-4-latest",
+      "grok-4-1-fast",
+      "grok-4-1-fast-reasoning",
+      "grok-4.20-reasoning",
+      "grok-3-mini-fast",
+      "grok-3",
+    ]) {
+      expect(resolveXaiCatalogEntry(modelId), modelId).toBeUndefined();
+    }
   });
 
   it("resolves Grok Build and its official code aliases", () => {
@@ -886,44 +884,6 @@ describe("xai provider models", () => {
       id: "grok-4.20-0309-non-reasoning",
       reasoning: false,
       contextWindow: 1_000_000,
-    });
-  });
-
-  it("keeps older Grok aliases resolving with current limits", () => {
-    expectCatalogEntry("grok-4-1-fast-reasoning", {
-      id: "grok-4-1-fast",
-      reasoning: true,
-      contextWindow: 1_000_000,
-      maxTokens: 64_000,
-    });
-    expectCatalogEntry("grok-4.20-reasoning", {
-      id: "grok-4.20-reasoning",
-      reasoning: true,
-      contextWindow: 1_000_000,
-      maxTokens: 30_000,
-    });
-  });
-
-  it("publishes the remaining Grok 3 family in the OpenClaw catalog", () => {
-    expectCatalogEntry("grok-3-mini-fast", {
-      id: "grok-3-mini-fast",
-      reasoning: true,
-      contextWindow: 1_000_000,
-      maxTokens: 64_000,
-    });
-    expectCatalogEntry("grok-3-fast", {
-      id: "grok-3-fast",
-      reasoning: false,
-      contextWindow: 1_000_000,
-      maxTokens: 64_000,
-    });
-    expectCatalogEntry("grok-3", {
-      id: "grok-3",
-      reasoning: false,
-      input: ["text"],
-      contextWindow: 1_000_000,
-      maxTokens: 64_000,
-      cost: { input: 1.25, output: 2.5, cacheRead: 0.2, cacheWrite: 0 },
     });
   });
 
@@ -1005,6 +965,7 @@ describe("xai provider models", () => {
     expect(grok41?.api).toBe("openai-responses");
     expect(grok41?.baseUrl).toBe("https://api.x.ai/v1");
     expect(grok41?.reasoning).toBe(true);
+    expect(grok41?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
     expect(grok41?.contextWindow).toBe(1_000_000);
     expect(grok41?.maxTokens).toBe(64_000);
 
@@ -1056,6 +1017,7 @@ describe("xai provider models", () => {
     expect(grok3Mini?.api).toBe("openai-responses");
     expect(grok3Mini?.baseUrl).toBe("https://api.x.ai/v1");
     expect(grok3Mini?.reasoning).toBe(true);
+    expect(grok3Mini?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
     expect(grok3Mini?.contextWindow).toBe(1_000_000);
     expect(grok3Mini?.maxTokens).toBe(64_000);
   });

--- a/extensions/xai/web-search.test.ts
+++ b/extensions/xai/web-search.test.ts
@@ -845,7 +845,7 @@ describe("xai provider models", () => {
     expectCatalogEntry("xai/GROK-4.3", grok43);
   });
 
-  it("leaves ids outside the manifest to forward-compat defaults", () => {
+  it("keeps supported non-curated ids out of the published inventory", () => {
     for (const modelId of [
       "grok-latest",
       "grok-4-latest",
@@ -855,7 +855,10 @@ describe("xai provider models", () => {
       "grok-3-mini-fast",
       "grok-3",
     ]) {
-      expect(resolveXaiCatalogEntry(modelId), modelId).toBeUndefined();
+      expect(
+        buildXaiCatalogModels().some((model) => model.id === modelId),
+        modelId,
+      ).toBe(false);
     }
   });
 
@@ -1017,6 +1020,7 @@ describe("xai provider models", () => {
     expect(grok3Mini?.api).toBe("openai-responses");
     expect(grok3Mini?.baseUrl).toBe("https://api.x.ai/v1");
     expect(grok3Mini?.reasoning).toBe(true);
+    expect(grok3Mini?.input).toEqual(["text"]);
     expect(grok3Mini?.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
     expect(grok3Mini?.contextWindow).toBe(1_000_000);
     expect(grok3Mini?.maxTokens).toBe(64_000);

--- a/extensions/xai/x-search.test.ts
+++ b/extensions/xai/x-search.test.ts
@@ -364,7 +364,7 @@ describe("xai x_search tool", () => {
     expect(mockFetch).toHaveBeenCalled();
     expect(firstFetchUrl(mockFetch)).toContain("api.x.ai/v1/responses");
     const body = parseFirstRequestBody(mockFetch);
-    expect(body.model).toBe("grok-4.3");
+    expect(body.model).toBe("grok-4.6");
     expect(body.input).toEqual([{ role: "user", content: "dinner recipes" }]);
     expect(body.store).toBe(false);
     expect(body.reasoning).toEqual({ effort: "none" });

--- a/extensions/xai/x-search.test.ts
+++ b/extensions/xai/x-search.test.ts
@@ -367,7 +367,7 @@ describe("xai x_search tool", () => {
     expect(body.model).toBe("grok-4.6");
     expect(body.input).toEqual([{ role: "user", content: "dinner recipes" }]);
     expect(body.store).toBe(false);
-    expect(body.reasoning).toEqual({ effort: "none" });
+    expect(body.reasoning).toEqual({ effort: "low" });
     expect(body.max_turns).toBe(2);
     expect(body.tools).toEqual([
       {

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -169,10 +169,6 @@ describe("xAI OAuth", () => {
           refresh_token: "refresh",
           expires_in: 60,
         });
-        transport
-          .get("https://cli-chat-proxy.grok.com")
-          .intercept({ path: "/v1/settings" })
-          .reply(200, { default_model: "grok-4.6" });
       }
       const origin = transport.get(new URL(redirectStart).origin);
       origin.intercept({ path: new URL(redirectStart).pathname }).reply(async () => {
@@ -276,9 +272,6 @@ describe("xAI OAuth", () => {
         }
         if (url.endsWith("/models")) {
           return jsonResponse({ data: [{ id: "grok-4.6", api_backend: "responses" }] });
-        }
-        if (url.endsWith("/settings")) {
-          return jsonResponse({ default_model: "grok-4.6" });
         }
         if (boundary === "token response") {
           await hold();
@@ -648,9 +641,6 @@ describe("xAI OAuth", () => {
         if (url.endsWith("/models")) {
           return jsonResponse({ data: [{ id: "grok-4.6", api_backend: "responses" }] });
         }
-        if (url.endsWith("/settings")) {
-          return jsonResponse({ default_model: "grok-4.6" });
-        }
         throw new Error(`Unexpected catalog URL: ${url}`);
       });
       vi.stubGlobal("fetch", fetchImpl);
@@ -825,9 +815,6 @@ describe("xAI OAuth", () => {
       const url = requestUrl(input);
       if (url.endsWith("/models")) {
         return jsonResponse({ data: [{ id: "grok-4.6", api_backend: "responses" }] });
-      }
-      if (url.endsWith("/settings")) {
-        return jsonResponse({ default_model: "grok-4.6" });
       }
       throw new Error(`Unexpected catalog URL: ${url}`);
     });

--- a/extensions/xai/xai-oauth.test.ts
+++ b/extensions/xai/xai-oauth.test.ts
@@ -172,7 +172,7 @@ describe("xAI OAuth", () => {
         transport
           .get("https://cli-chat-proxy.grok.com")
           .intercept({ path: "/v1/settings" })
-          .reply(200, { default_model: "subscription-fixture" });
+          .reply(200, { default_model: "grok-4.6" });
       }
       const origin = transport.get(new URL(redirectStart).origin);
       origin.intercept({ path: new URL(redirectStart).pathname }).reply(async () => {
@@ -275,10 +275,10 @@ describe("xAI OAuth", () => {
           });
         }
         if (url.endsWith("/models")) {
-          return jsonResponse({ data: [{ id: "subscription-fixture", api_backend: "responses" }] });
+          return jsonResponse({ data: [{ id: "grok-4.6", api_backend: "responses" }] });
         }
         if (url.endsWith("/settings")) {
-          return jsonResponse({ default_model: "subscription-fixture" });
+          return jsonResponse({ default_model: "grok-4.6" });
         }
         if (boundary === "token response") {
           await hold();
@@ -646,10 +646,10 @@ describe("xAI OAuth", () => {
       fetchImpl.mockImplementation(async (input) => {
         const url = requestUrl(input);
         if (url.endsWith("/models")) {
-          return jsonResponse({ data: [{ id: "subscription-fixture", api_backend: "responses" }] });
+          return jsonResponse({ data: [{ id: "grok-4.6", api_backend: "responses" }] });
         }
         if (url.endsWith("/settings")) {
-          return jsonResponse({ default_model: "subscription-fixture" });
+          return jsonResponse({ default_model: "grok-4.6" });
         }
         throw new Error(`Unexpected catalog URL: ${url}`);
       });
@@ -762,10 +762,10 @@ describe("xAI OAuth", () => {
         accountId: "acct-1",
         access: expect.any(String),
       });
-      expect(result.defaultModel).toBe("xai/auto");
+      expect(result.defaultModel).toBe("xai/grok-4.6");
       expect(result.configPatch?.agents?.defaults?.model).toEqual(
         setup === "fresh"
-          ? { primary: "xai/auto" }
+          ? { primary: "xai/grok-4.6" }
           : { primary: "other/selected", fallbacks: ["other/fallback"] },
       );
       expect(result.configPatch?.models?.providers?.xai).toMatchObject({
@@ -774,7 +774,7 @@ describe("xAI OAuth", () => {
         auth: "oauth",
       });
       expect(result.configPatch?.models?.providers?.xai?.models.map((model) => model.id)).toEqual([
-        "subscription-fixture",
+        "grok-4.6",
       ]);
       const savedProvider = result.configPatch?.models?.providers?.xai;
       expect(savedProvider?.models.some((model) => model.id === "auto")).toBe(false);
@@ -785,7 +785,7 @@ describe("xAI OAuth", () => {
       if (setup === "api") {
         expect(savedProvider?.request?.allowPrivateNetwork).toBe(false);
       }
-      expect(result.configPatch?.agents?.defaults?.models?.["xai/auto"]?.alias).toBe("Grok");
+      expect(result.configPatch?.agents?.defaults?.models?.["xai/grok-4.6"]?.alias).toBe("Grok");
       expect(progress.update).toHaveBeenCalledWith("Waiting for xAI device authorization...");
       expect(progress.stop).toHaveBeenCalledWith("xAI OAuth complete");
     },
@@ -824,10 +824,10 @@ describe("xAI OAuth", () => {
     fetchImpl.mockImplementation(async (input) => {
       const url = requestUrl(input);
       if (url.endsWith("/models")) {
-        return jsonResponse({ data: [{ id: "subscription-fixture", api_backend: "responses" }] });
+        return jsonResponse({ data: [{ id: "grok-4.6", api_backend: "responses" }] });
       }
       if (url.endsWith("/settings")) {
-        return jsonResponse({ default_model: "subscription-fixture" });
+        return jsonResponse({ default_model: "grok-4.6" });
       }
       throw new Error(`Unexpected catalog URL: ${url}`);
     });

--- a/extensions/xai/xai-oauth.ts
+++ b/extensions/xai/xai-oauth.ts
@@ -20,7 +20,7 @@ import {
   asOptionalRecord,
   normalizeOptionalString,
 } from "openclaw/plugin-sdk/string-coerce-runtime";
-import { applyXaiOAuthConfig, XAI_OAUTH_DEFAULT_MODEL_REF } from "./onboard.js";
+import { applyXaiOAuthConfig, XAI_DEFAULT_MODEL_REF } from "./onboard.js";
 import { buildLiveXaiOAuthProvider } from "./provider-catalog.js";
 import { xaiUserAgent } from "./src/xai-user-agent.js";
 
@@ -641,7 +641,7 @@ export async function loginXaiDeviceCode(ctx: ProviderAuthContext): Promise<Prov
     progress.stop("xAI OAuth complete");
     return buildOauthProviderAuthResult({
       providerId: PROVIDER_ID,
-      defaultModel: XAI_OAUTH_DEFAULT_MODEL_REF,
+      defaultModel: XAI_DEFAULT_MODEL_REF,
       access: tokens.accessToken,
       refresh: tokens.refreshToken,
       expires: tokens.expires,

--- a/src/agents/runtime-plan/materialize-model.xai.test.ts
+++ b/src/agents/runtime-plan/materialize-model.xai.test.ts
@@ -6,18 +6,18 @@ import type { StreamFn } from "../runtime/index.js";
 import { materializePreparedRuntimeModel } from "./materialize-model.js";
 
 describe("xAI OAuth runtime materialization", () => {
-  it("retains the selected alias through auth resolution and sends its canonical target", async () => {
+  it("retains the selected concrete model through auth resolution and transport", async () => {
     const plugin = await loadBundledPluginPublicSurface<{
       default: Parameters<typeof registerSingleProviderPlugin>[0];
     }>({ pluginId: "xai", artifactBasename: "index.js" });
     const provider = await registerSingleProviderPlugin(plugin.default);
     const model: ProviderRuntimeModel = {
       provider: "xai",
-      id: "auto",
-      name: "Subscription default",
+      id: "grok-4.6",
+      name: "Grok 4.6",
       api: "openai-responses",
       baseUrl: "https://cli-chat-proxy.grok.com/v1",
-      params: { canonicalModelId: "grok-4.6" },
+      params: { canonicalModelId: "grok-fixture-unselected" },
       reasoning: true,
       input: ["text"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
@@ -26,7 +26,7 @@ describe("xAI OAuth runtime materialization", () => {
     };
     const materialized = await materializePreparedRuntimeModel({
       provider: "xai",
-      modelId: "auto",
+      modelId: "grok-4.6",
       model,
       config: {},
       plan: {
@@ -40,11 +40,11 @@ describe("xAI OAuth runtime materialization", () => {
         expect(request.authProfileId).toBe("xai:fixture");
         expect(request.authProfileMode).toBe("oauth");
         return {
-          model: provider.normalizeResolvedModel?.({ provider: "xai", modelId: "auto", model }),
+          model: provider.normalizeResolvedModel?.({ provider: "xai", modelId: "grok-4.6", model }),
         };
       },
     });
-    expect(materialized?.id).toBe("auto");
+    expect(materialized?.id).toBe("grok-4.6");
     expect(materialized?.thinkingLevelMap?.xhigh).toBe("xhigh");
     let wireModelId: string | undefined;
     let wireHeaders: Record<string, string> | undefined;
@@ -55,7 +55,7 @@ describe("xAI OAuth runtime materialization", () => {
     };
     const wrapped = provider.wrapStreamFn?.({
       provider: "xai",
-      modelId: "auto",
+      modelId: "grok-4.6",
       model: materialized,
       streamFn,
       extraParams: { tool_stream: false },

--- a/src/commands/doctor/shared/xai-auto-retirement.test.ts
+++ b/src/commands/doctor/shared/xai-auto-retirement.test.ts
@@ -1,0 +1,168 @@
+import { afterEach, beforeEach, expect, it } from "vitest";
+import type { SessionEntry } from "../../../config/sessions/types.js";
+import type { ModelDefinitionConfig } from "../../../config/types.models.js";
+import type { OpenClawConfig } from "../../../config/types.openclaw.js";
+import { clearPluginMetadataLifecycleCaches } from "../../../plugins/plugin-metadata-lifecycle.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../../test-utils/openclaw-test-state.js";
+import {
+  createRetiredModelRefRepairResolver,
+  repairRetiredConfigModelRefs,
+  repairRetiredSessionModelRef,
+} from "./retired-model-ref-repair.js";
+
+let state: OpenClawTestState;
+beforeEach(async () => {
+  state = await createOpenClawTestState({ label: "xai-auto-retirement" });
+  clearPluginMetadataLifecycleCaches();
+  await state.writeAuthProfiles({
+    version: 1,
+    profiles: {
+      "xai:fixture": { type: "token", provider: "xai", token: "synthetic-subscription-token" },
+    },
+  });
+});
+afterEach(async () => {
+  clearPluginMetadataLifecycleCaches();
+  await state.cleanup();
+});
+
+function configForRoute(baseUrl: string, models: ModelDefinitionConfig[] = []): OpenClawConfig {
+  return {
+    agents: {
+      defaults: {
+        workspace: state.workspaceDir,
+        model: { primary: "xai/auto", fallbacks: ["xai/grok-4.3"] },
+        models: { "xai/auto": { alias: "Grok", params: { temperature: 0.25 } } },
+      },
+      entries: { main: {} },
+    },
+    auth: { profiles: { "xai:fixture": { provider: "xai", mode: "token" } } },
+    models: { providers: { xai: { baseUrl, api: "openai-responses", auth: "token", models } } },
+    plugins: { allow: ["xai"], entries: { xai: { enabled: true } } },
+  };
+}
+
+it("repairs the subscription selector while preserving fallbacks and model settings", async () => {
+  const cfg = configForRoute("https://cli-chat-proxy.grok.com/v1");
+  await state.writeConfig(cfg);
+  const resolve = createRetiredModelRefRepairResolver({ cfg, env: state.env });
+  const repaired = repairRetiredConfigModelRefs(cfg, resolve);
+
+  expect(repaired.config.agents?.defaults?.model).toEqual({
+    primary: "xai/grok-4.6",
+    fallbacks: ["xai/grok-4.3"],
+  });
+  expect(repaired.config.agents?.defaults?.models?.["xai/grok-4.6"]?.params).toEqual({
+    temperature: 0.25,
+  });
+  expect(cfg.agents?.defaults?.model).toEqual({ primary: "xai/auto", fallbacks: ["xai/grok-4.3"] });
+  expect(
+    repairRetiredConfigModelRefs(
+      repaired.config,
+      createRetiredModelRefRepairResolver({ cfg: repaired.config, env: state.env }),
+    ).changes,
+  ).toEqual([]);
+});
+
+it("repairs a session override without changing its selected profile", async () => {
+  const cfg = configForRoute("https://cli-chat-proxy.grok.com/v1");
+  await state.writeConfig(cfg);
+  const entry: SessionEntry = {
+    sessionId: "xai-upgrade-session",
+    updatedAt: 1,
+    providerOverride: "xai",
+    modelOverride: "auto",
+    authProfileOverride: "xai:fixture",
+    authProfileOverrideSource: "user",
+  };
+  const resolve = createRetiredModelRefRepairResolver({ cfg, env: state.env });
+  expect(repairRetiredSessionModelRef(entry, "main", resolve, "xai/grok-4.6", [])).toBe(true);
+  expect(entry.modelOverride).toBe("grok-4.6");
+  expect(entry.authProfileOverride).toBe("xai:fixture");
+  expect(entry.authProfileOverrideSource).toBe("user");
+});
+
+it("preserves a custom endpoint's explicit auto model", async () => {
+  const cfg = configForRoute("https://custom-models.example/v1", [
+    {
+      id: "auto",
+      name: "Custom automatic model",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 1024,
+      maxTokens: 256,
+    },
+  ]);
+  await state.writeConfig(cfg);
+  const resolve = createRetiredModelRefRepairResolver({ cfg, env: state.env });
+  expect(resolve({ modelRef: "xai/auto", agentId: "main" })).toEqual({ kind: "unchanged" });
+  expect(repairRetiredConfigModelRefs(cfg, resolve).config).toBe(cfg);
+});
+
+it("repairs an unpinned config on its declared subscription route without credentials", async () => {
+  const cfg = configForRoute("https://cli-chat-proxy.grok.com/v1");
+  await state.writeConfig(cfg);
+  await state.writeAuthProfiles({ version: 1, profiles: {} });
+  const warnings: string[] = [];
+  const resolve = createRetiredModelRefRepairResolver({ cfg, env: state.env, warnings });
+  expect(resolve({ modelRef: "xai/auto", agentId: "main" })).toEqual({
+    kind: "replace",
+    modelRef: "xai/grok-4.6",
+    reason: "retirement",
+    retirementScope: "route",
+  });
+  expect(warnings).toEqual([]);
+});
+
+it("retains a missing pinned account instead of substituting the available profile", async () => {
+  const cfg = configForRoute("https://cli-chat-proxy.grok.com/v1");
+  await state.writeConfig(cfg);
+  const warnings: string[] = [];
+  const resolve = createRetiredModelRefRepairResolver({ cfg, env: state.env, warnings });
+  expect(
+    resolve({
+      modelRef: "xai/auto",
+      agentId: "main",
+      authProfileId: "xai:missing",
+      authProfileSource: "user",
+    }),
+  ).toEqual({ kind: "unchanged" });
+  expect(warnings).toEqual([expect.stringContaining("authentication route is unavailable")]);
+});
+
+it("keeps a pinned session when its successor is outside the allowed models", async () => {
+  const original = configForRoute("https://cli-chat-proxy.grok.com/v1");
+  const cfg: OpenClawConfig = {
+    ...original,
+    agents: {
+      ...original.agents,
+      defaults: { ...original.agents?.defaults, modelPolicy: { allow: ["xai/auto"] } },
+    },
+  };
+  await state.writeConfig(cfg);
+  const warnings: string[] = [];
+  const entry: SessionEntry = {
+    sessionId: "restricted-xai-session",
+    updatedAt: 1,
+    providerOverride: "xai",
+    modelOverride: "auto",
+    authProfileOverride: "xai:fixture",
+    authProfileOverrideSource: "user",
+  };
+  const resolve = createRetiredModelRefRepairResolver({
+    cfg,
+    env: state.env,
+    warnings,
+    checkModelPolicy: true,
+  });
+  expect(repairRetiredSessionModelRef(entry, "main", resolve, "xai/grok-4.6", warnings)).toBe(
+    false,
+  );
+  expect(entry.modelOverride).toBe("auto");
+  expect(entry.authProfileOverride).toBe("xai:fixture");
+  expect(warnings).toEqual([expect.stringContaining("not permitted")]);
+});


### PR DESCRIPTION
Related: #136257, #132487.

## What Problem This Solves

Two setup methods used different default models, and a virtual automatic selection required another remote settings request. The new default also exposed unsupported tool reasoning settings.

## Why This Change Was Made

The provider plugin owns one concrete setup default and curated catalog. Dynamic resolution shares its model definitions, while tool callers share per-model reasoning defaults. Doctor migrates retired subscription selections through its existing repair owner without replacing explicit models, account pins, settings, or fallback order.

## User Impact

Fresh setup uses one default. Existing primary selections and authored models remain. Doctor replaces retired automatic subscription selections; custom endpoints retain their authored scope. Existing installations without tool overrides receive the new tool default. No schema or credential-store change is added.

Consumers: setup defaults, dynamic model lookup, tool requests, and Doctor selection repair use the shared definitions.

## Evidence

Setup regressions failed before the fix. Source onboarding preserved explicit selections. Compiled commands verified account saving, migration, custom endpoints, and status. Two public agent turns exercised the registered search tool with expected settings against synthetic endpoints. Continuous integration lost communication before 25 jobs started; it was not green. Live account approval and inference were not tested.
