### PR TITLE
fix(qa): keep fresh write scenarios from inheriting completion

### DIFF
--- a/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/mock-openai-contracts.ts
@@ -277,10 +277,8 @@ export const QA_THINKING_VISIBILITY_OFF_PROMPT_RE = /qa thinking visibility chec
 export const QA_THINKING_VISIBILITY_MAX_PROMPT_RE = /qa thinking visibility check max/i;
 export const QA_EMPTY_RESPONSE_RECOVERY_PROMPT_RE = /empty response continuation qa check/i;
 export const QA_EMPTY_RESPONSE_EXHAUSTION_PROMPT_RE = /empty response exhaustion qa check/i;
-export const QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT_RE =
-  /empty response after write recovery qa check/i;
-export const QA_EMPTY_RESPONSE_SIDE_EFFECT_EXHAUSTION_PROMPT_RE =
-  /empty response after write exhaustion qa check/i;
+export const QA_EMPTY_RESPONSE_SIDE_EFFECT_PROMPT_RE =
+  /empty response after write (recovery|exhaustion) qa check/i;
 export const QA_REPEATED_REQUEST_RECOVERY_PROMPT_RE = /repeated request recovery gateway qa check/i;
 export const QA_REPEATED_REQUEST_QUEUED_REPLY_PROMPT_RE =
   /repeated request queued reply gateway qa check/i;

--- a/extensions/qa-lab/src/providers/mock-openai/server.test.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.test.ts
@@ -1,6 +1,5 @@
 import { once } from "node:events";
 import { runInNewContext } from "node:vm";
-// Qa Lab tests cover server plugin behavior.
 import { createDeferred } from "openclaw/plugin-sdk/extension-shared";
 import { createRequireRecord } from "openclaw/plugin-sdk/test-fixtures";
 import { afterEach, describe, expect, it } from "vitest";
@@ -334,6 +333,28 @@ function makeToolOutput(output: unknown) {
 
 function makeToolOutputWithCallId(callId: string, output: unknown) {
   return { type: "function_call_output" as const, call_id: callId, output };
+}
+
+async function completeSideEffectScenario(server: MockServer, kind: "recovery" | "exhaustion") {
+  const kickoff = makeUserInput(
+    kind === "recovery"
+      ? QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT
+      : QA_EMPTY_RESPONSE_SIDE_EFFECT_EXHAUSTION_PROMPT,
+  );
+  const plan = await expectOpenAiNonStreamingResponsesJson(server, { input: [kickoff] });
+  const write = outputToolCall(plan, "write");
+  const input = [
+    kickoff,
+    ...outputItems(plan),
+    makeToolOutputWithCallId(
+      outputToolCallId(write, "previous-write"),
+      "Successfully wrote 27 bytes to qa-empty-response-side-effect.txt",
+    ),
+    makeUserInput(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION),
+  ];
+  const settled = await expectOpenAiNonStreamingResponsesJson(server, { input });
+  expect(outputText(settled)).toBe(kind === "recovery" ? "TELEGRAM-EMPTY-WRITE-RECOVERED-OK" : "");
+  return [...input, ...outputItems(settled)];
 }
 
 function makeAnthropicUserText(text: string) {
@@ -8251,13 +8272,18 @@ Update and merge these partial structured summaries.`,
       history: "earlier reply directive",
       precedingInput: [makeUserInput("Earlier check: exact marker: `PREVIOUS-SCENARIO-OK`.")],
     },
+    { history: "settled recovery", completedScenario: "recovery" as const },
+    { history: "settled exhaustion", completedScenario: "exhaustion" as const },
   ])(
     "scripts settled continuation after a side-effecting write with $history",
-    async ({ precedingInput }) => {
+    async ({ precedingInput = [], completedScenario }) => {
       const server = await startMockServer();
+      const historyInput = completedScenario
+        ? await completeSideEffectScenario(server, completedScenario)
+        : precedingInput;
 
       const toolPlan = await expectOpenAiStreamingResponsesText(server, {
-        input: [...precedingInput, makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT)],
+        input: [...historyInput, makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT)],
       });
       expect(toolPlan).toContain('"name":"write"');
 
@@ -8269,7 +8295,7 @@ Update and merge these partial structured summaries.`,
         output?: Array<{ content?: Array<{ text?: string }> }>;
       }>(server, {
         input: [
-          ...precedingInput,
+          ...historyInput,
           makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT),
           toolOutput,
         ],
@@ -8280,7 +8306,7 @@ Update and merge these partial structured summaries.`,
         output?: Array<{ content?: Array<{ text?: string }> }>;
       }>(server, {
         input: [
-          ...precedingInput,
+          ...historyInput,
           makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT),
           makeUserInput(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION),
           toolOutput,
@@ -8290,7 +8316,7 @@ Update and merge these partial structured summaries.`,
 
       const statefulRecoveredPayload = await expectOpenAiNonStreamingResponsesJson(server, {
         input: [
-          ...precedingInput,
+          ...historyInput,
           makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT),
           makeUserInput(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION),
         ],
@@ -8329,32 +8355,60 @@ Update and merge these partial structured summaries.`,
     },
   );
 
-  it("keeps settled write finalization empty for host fallback coverage", async () => {
-    const server = await startMockServer();
-    const toolPlan = await expectOpenAiStreamingResponsesText(server, {
-      input: [makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_EXHAUSTION_PROMPT)],
-    });
-    expect(toolPlan).toContain('"name":"write"');
+  it.each(["fresh", "recovery", "exhaustion"] as const)(
+    "keeps settled write finalization empty for host fallback coverage with %s history",
+    async (history) => {
+      const server = await startMockServer();
+      const precedingInput =
+        history === "fresh" ? [] : await completeSideEffectScenario(server, history);
+      const toolPlan = await expectOpenAiStreamingResponsesText(server, {
+        input: [...precedingInput, makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_EXHAUSTION_PROMPT)],
+      });
+      expect(toolPlan).toContain('"name":"write"');
 
-    const toolOutput = {
-      type: "function_call_output" as const,
-      output: "Successfully wrote 27 bytes to qa-empty-response-side-effect.txt",
-    };
-    for (const includeFinalizationPrompt of [false, true, true]) {
-      const payload = await expectOpenAiNonStreamingResponsesJson<{
-        output?: Array<{ content?: Array<{ text?: string }> }>;
-      }>(server, {
+      const toolOutput = {
+        type: "function_call_output" as const,
+        output: "Successfully wrote 27 bytes to qa-empty-response-side-effect.txt",
+      };
+      for (const includeFinalizationPrompt of [false, true, true]) {
+        const payload = await expectOpenAiNonStreamingResponsesJson<{
+          output?: Array<{ content?: Array<{ text?: string }> }>;
+        }>(server, {
+          input: [
+            ...precedingInput,
+            makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_EXHAUSTION_PROMPT),
+            ...(includeFinalizationPrompt
+              ? [makeUserInput(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION)]
+              : []),
+            toolOutput,
+          ],
+        });
+        expect(payload.output?.[0]?.content?.[0]?.text).toBe("");
+      }
+    },
+  );
+
+  it.each(["recovery", "exhaustion"] as const)(
+    "starts a fresh %s scenario after projected settled history",
+    async (kind) => {
+      const server = await startMockServer();
+      const history = await completeSideEffectScenario(server, "exhaustion");
+      const prompt =
+        kind === "recovery"
+          ? QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT
+          : QA_EMPTY_RESPONSE_SIDE_EFFECT_EXHAUSTION_PROMPT;
+      const response = await expectOpenAiNonStreamingResponsesJson(server, {
         input: [
-          makeUserInput(QA_EMPTY_RESPONSE_SIDE_EFFECT_EXHAUSTION_PROMPT),
-          ...(includeFinalizationPrompt
-            ? [makeUserInput(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_INSTRUCTION)]
-            : []),
-          toolOutput,
+          makeUserInput(
+            `<conversation_context>\n${JSON.stringify(history)}\n</conversation_context>\n\nCurrent user request:\n${prompt}`,
+          ),
         ],
       });
-      expect(payload.output?.[0]?.content?.[0]?.text).toBe("");
-    }
-  });
+      expect(outputToolArgsFromItem(outputToolCall(response, "write"))).toMatchObject({
+        path: "qa-empty-response-side-effect.txt",
+      });
+    },
+  );
 
   it("reports a failed Code Mode read honestly through ordinary continuation", async () => {
     const server = await startMockServer();

--- a/extensions/qa-lab/src/providers/mock-openai/server.ts
+++ b/extensions/qa-lab/src/providers/mock-openai/server.ts
@@ -46,8 +46,7 @@ import {
   QA_THINKING_VISIBILITY_MAX_PROMPT_RE,
   QA_EMPTY_RESPONSE_RECOVERY_PROMPT_RE,
   QA_EMPTY_RESPONSE_EXHAUSTION_PROMPT_RE,
-  QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT_RE,
-  QA_EMPTY_RESPONSE_SIDE_EFFECT_EXHAUSTION_PROMPT_RE,
+  QA_EMPTY_RESPONSE_SIDE_EFFECT_PROMPT_RE,
   QA_REPEATED_REQUEST_RECOVERY_PROMPT_RE,
   QA_REPEATED_REQUEST_QUEUED_REPLY_PROMPT_RE,
   QA_REPEATED_REQUEST_QUEUED_REPLY_MARKER,
@@ -332,10 +331,13 @@ function isStreamingToolProgressContinuationText(text: string) {
   );
 }
 
-function extractLatestScenarioFamilyPrompt(texts: string[]) {
+function extractLatestScenarioFamilyPrompt(
+  texts: string[],
+  familyPattern = QA_STREAMING_TOOL_PROGRESS_FAMILY_PROMPT_RE,
+) {
   let envelope = "";
   for (const text of texts.toReversed()) {
-    if (QA_STREAMING_TOOL_PROGRESS_FAMILY_PROMPT_RE.test(text)) {
+    if (familyPattern.test(text)) {
       envelope = text;
       break;
     }
@@ -346,10 +348,7 @@ function extractLatestScenarioFamilyPrompt(texts: string[]) {
   if (!envelope) {
     return "";
   }
-  const pattern = new RegExp(
-    QA_STREAMING_TOOL_PROGRESS_FAMILY_PROMPT_RE.source,
-    `${QA_STREAMING_TOOL_PROGRESS_FAMILY_PROMPT_RE.flags}g`,
-  );
+  const pattern = new RegExp(familyPattern.source, `${familyPattern.flags}g`);
   let latestIndex = -1;
   for (const match of envelope.matchAll(pattern)) {
     latestIndex = match.index;
@@ -1209,14 +1208,17 @@ async function buildResponsesPayload(
   const hasEmptyResponseRetryInstruction =
     allInputText.includes(QA_EMPTY_RESPONSE_RETRY_NEEDLE) ||
     allInputText.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE);
-  const isActiveEmptyResponseSideEffectRecovery =
-    QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT_RE.test(prompt) ||
-    (prompt.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE) &&
-      QA_EMPTY_RESPONSE_SIDE_EFFECT_RECOVERY_PROMPT_RE.test(allInputText));
-  const isActiveEmptyResponseSideEffectExhaustion =
-    QA_EMPTY_RESPONSE_SIDE_EFFECT_EXHAUSTION_PROMPT_RE.test(prompt) ||
-    (prompt.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE) &&
-      QA_EMPTY_RESPONSE_SIDE_EFFECT_EXHAUSTION_PROMPT_RE.test(allInputText));
+  const currentPrompt = splitMockConversationContext(prompt).current;
+  const isSettledToolContinuation = currentPrompt.includes(
+    QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE,
+  );
+  // Only a current continuation may reuse a previous scenario prompt.
+  const sideEffectPrompt = extractLatestScenarioFamilyPrompt(
+    isSettledToolContinuation ? allUserTexts : [currentPrompt],
+    QA_EMPTY_RESPONSE_SIDE_EFFECT_PROMPT_RE,
+  );
+  const sideEffectKind =
+    QA_EMPTY_RESPONSE_SIDE_EFFECT_PROMPT_RE.exec(sideEffectPrompt)?.[1]?.toLowerCase();
   const hasCallableCodeMode = hasCodeModeExecSurface(toolDeclarationBody);
   const canCallSessionsSpawn =
     hasToolDefinition(toolDeclarationBody, "sessions_spawn") || hasCallableCodeMode;
@@ -1530,12 +1532,14 @@ async function buildResponsesPayload(
   if (/remember this fact/i.test(prompt)) {
     return buildAssistantEvents(buildAssistantText(input, body));
   }
-  if (isActiveEmptyResponseSideEffectRecovery || isActiveEmptyResponseSideEffectExhaustion) {
-    if (allInputText.includes(QA_SETTLED_TOOL_TERMINAL_CONTINUATION_NEEDLE)) {
+  if (sideEffectKind) {
+    if (isSettledToolContinuation) {
       return buildAssistantEvents(
-        isActiveEmptyResponseSideEffectExhaustion
+        sideEffectKind === "exhaustion"
           ? ""
-          : (exactMarkerDirective ?? exactReplyDirective ?? "TELEGRAM-EMPTY-WRITE-RECOVERED-OK"),
+          : (extractExactMarkerDirective(sideEffectPrompt) ??
+              extractExactReplyDirective(sideEffectPrompt) ??
+              "TELEGRAM-EMPTY-WRITE-RECOVERED-OK"),
       );
     }
     if (!hasCompletedToolOutput) {


### PR DESCRIPTION
Related: #142060.

## What Problem This Solves

Fixes an issue where a fresh mock QA recovery or exhaustion scenario could return final output before planning its required write when the conversation retained an earlier settled-tool continuation. An earlier exhaustion scenario could also determine a later recovery scenario's result.

## Why This Change Was Made

Use the existing scenario selector to identify one current recovery/exhaustion kind. Only a current continuation may reuse the earlier scenario prompt; recovery takes its marker from that selected prompt. This preserves the tool-free continuation behavior added by #142060 while preventing historical completion markers from satisfying a fresh kickoff.

## User Impact

Repeated QA scenarios plan their own initial write and retain their intended recovery or exhaustion behavior. This changes only the deterministic mock provider; it does not change the write tool or a real provider/channel.

## Evidence

Ordered requests first obtain an earlier write plan and settle that scenario, then start a fresh one. All four old/new recovery/exhaustion combinations failed at the fresh write-plan assertion before repair, while three controls passed. Two cases using the existing projected-input envelope separately reproduced the same omission. All nine pass after repair, preserving tool-free continuation, cron, heartbeat and finalization assertions.

There are 45 distinct passing focused cases including the related current-input, scenario-family and mock WebSocket coverage. All 25 canonical changed-check stages passed. Only a redundant test banner was deleted afterward; exact comment-only continuity and final formatting/diff checks are recorded. Independent managed review completed two passes with no actionable findings.

Synthetic requests inspect returned plans without executing the write tool, a Gateway, live QA/provider, native app or browser. The projected-input cases exercise the mock's accepted envelope; they do not certify an external runtime or arbitrary opaque transcript history. The two private scenario regexes become one kind matcher; net change is +2 mock implementation lines and +54 test lines.
