### PR TITLE
test(doctor): avoid repeated compilation in admission checks

### DIFF
--- a/src/commands/doctor-config-preflight.admission.process.test.ts
+++ b/src/commands/doctor-config-preflight.admission.process.test.ts
@@ -2,14 +2,18 @@ import { createHash } from "node:crypto";
 import fs from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath, pathToFileURL } from "node:url";
 import { gunzipSync } from "node:zlib";
 import { afterAll, describe, expect, it } from "vitest";
 import { useAutoCleanupTempDirTracker } from "../../test/helpers/temp-dir.js";
+import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import { repairAuditEventsSchema } from "../state/openclaw-state-db-audit-migration.js";
 import {
+  createBuiltRuntime,
   createSourceRuntime,
   runSourceRuntime,
 } from "./doctor-config-preflight.process.test-support.js";
+import { doctorConfigRuntimeEntrypoints } from "./doctor-config-runtime.test-support.js";
 
 const tempDirs = useAutoCleanupTempDirTracker(afterAll);
 
@@ -143,7 +147,30 @@ describe("startup admission before persistent writes", () => {
       restored,
     }) => {
       const root = fs.realpathSync(tempDirs.make("openclaw-startup-admission-"));
-      const runtimeRoot = createSourceRuntime(root);
+      const preparedPreflightUrl = resolveRuntimeWorkerUrl(
+        doctorConfigRuntimeEntrypoints.preflight,
+      );
+      const compiled = preparedPreflightUrl.pathname.endsWith(".js");
+      const runtimeRoot = compiled
+        ? createBuiltRuntime(root, fileURLToPath(new URL("../", preparedPreflightUrl)))
+        : createSourceRuntime(root);
+      // Keep package discovery fixture-local in both source and prepared subprocesses.
+      const runtimeUrl = (entry: Parameters<typeof resolveRuntimeWorkerUrl>[0]) =>
+        resolveRuntimeWorkerUrl({
+          ...entry,
+          ...(compiled
+            ? { root: runtimeRoot }
+            : {
+                currentModuleUrl: pathToFileURL(
+                  path.join(
+                    runtimeRoot,
+                    "src",
+                    "commands",
+                    "doctor-config-runtime.test-support.ts",
+                  ),
+                ).href,
+              }),
+        }).href;
       const stateDir = path.join(root, "state");
       const workspaceDir = path.join(
         stateDir,
@@ -226,12 +253,12 @@ describe("startup admission before persistent writes", () => {
         const entry =
           workspace || repairedSession
             ? `
-        const { runDoctorConfigPreflight } = await import("./src/commands/doctor-config-preflight.ts");
+        const { runDoctorConfigPreflight } = await import(${JSON.stringify(runtimeUrl(doctorConfigRuntimeEntrypoints.preflight))});
         await runDoctorConfigPreflight({ migrateState: true, migrateLegacyConfig: false, requireStartupMigrationCheckpoint: true });
       `
             : `
-        const { ensureConfigReady } = await import("./src/cli/program/config-guard.ts");
-        const { ExitError } = await import("./src/runtime.ts");
+        const { ensureConfigReady } = await import(${JSON.stringify(runtimeUrl(doctorConfigRuntimeEntrypoints.configGuard))});
+        const { ExitError } = await import(${JSON.stringify(runtimeUrl(doctorConfigRuntimeEntrypoints.runtime))});
         await ensureConfigReady({
           commandPath: ["gateway", "run"],
           runtime: { log: console.log, error: console.error, exit(code) { throw new ExitError(code); } },

--- a/src/commands/doctor-config-runtime.test-support.ts
+++ b/src/commands/doctor-config-runtime.test-support.ts
@@ -1,5 +1,20 @@
 // Fresh Doctor script processes share compiled config and install-index module identities.
 export const doctorConfigRuntimeEntrypoints = {
+  preflight: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "doctor-config-preflight",
+    distWorkerPath: "commands/doctor-config-preflight.js",
+  },
+  configGuard: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "../cli/program/config-guard",
+    distWorkerPath: "cli/program/config-guard.js",
+  },
+  runtime: {
+    currentModuleUrl: import.meta.url,
+    sourceWorkerName: "../runtime",
+    distWorkerPath: "runtime.js",
+  },
   configFlow: {
     currentModuleUrl: import.meta.url,
     sourceWorkerName: "doctor-config-flow",


### PR DESCRIPTION
Related: #141549

## What Problem This Solves

Resolves repeated TypeScript compilation in ten Doctor startup-admission process tests. The Doctor config/state group is the largest group on the critical path of [main CI 34218981685](https://github.com/openclaw/openclaw/actions/runs/34218981685/job/102037583770), which took 9m27s overall despite short runner queues and Node setup.

## Why This Change Was Made

Declare preflight, config-guard and runtime entries in the existing compiled-subprocess registry, then mount that immutable code under each test's private runtime directory using the existing fixture helper. All direct imports share the same compiled module identities. Each case still starts a fresh process with its own package assets, configuration, databases and WAL files.

Standalone Vitest and watch mode retain the documented source path through the same URL resolver. No production, launcher, compiler-policy, environment, deadline, assertion or state-schema changes. The result/assertion suffix remains byte-identical. Test/support LOC: +46/-4; production: 0.

## User Impact

Faster CI while retaining proof that startup admission preserves or migrates existing operator state correctly. The change adds no shards, caches, shared mutable fixtures or production test seams.

## Evidence

- Pinned Node 24.19.0/pnpm 12.3.4, original / changed / restored-original complete ten-case runs, all passing in identical order. Whole-command times: **61.96s / 35.14s / 59.31s**; Vitest: **59.77s / 33.05s / 57.27s**. The measured **24–27s saving includes compilation and fixture-copy overhead**.
- Compiler input/output counts stayed 8,643/4,359; preparation took 4.645s/3.719s/3.891s. This is a count comparison, not a claim that added entries preserve chunk hashes.
- A separate real healthy-backup ownership probe verified all three entry URLs were fixture-local, both package-root observations resolved to the fixture, and fixture/canonical-checkout asset hashes stayed unchanged. It observed 4,465 fixture module resolutions and zero canonical-generation loads. This is bounded ownership proof for the exercised path, not a general claim that every compiled graph is relocatable.
- Supported standalone/source mode: existing healthy-backup case passed. Full unchanged sibling files passed: pristine startup 5, Doctor plugin-install 8, runtime URL owner 9 (**22 total**).
- Full `pnpm build`, required `check:changed` gates and fresh independent P0–P2 review passed. Temporary diagnostics were removed before the clean timing/validation runs.

Fresh processes, released-schema fixture bytes, WAL/consolidation coverage, config backup recovery and all state-preservation assertions remain intact. Portable CI timing will be checked after publication.
