### PR TITLE
perf(plugin-state): avoid a redundant scan after quota eviction

### DIFF
--- a/src/plugin-state/plugin-state-store.sqlite.ts
+++ b/src/plugin-state/plugin-state-store.sqlite.ts
@@ -607,12 +607,8 @@ function enforcePostRegisterLimits(params: {
     params.retention.namespaceCount -= deleted;
     params.retention.pluginCount -= deleted;
   }
-  const remainingPluginCount =
-    params.retention?.pluginCount ??
-    countLivePluginStateEntries(params.store.db, {
-      pluginId: params.pluginId,
-      now: params.now,
-    });
+  // The deletion uses the same live-row predicate and transaction as pluginCount.
+  const remainingPluginCount = params.retention?.pluginCount ?? pluginCount - deleted;
   if (remainingPluginCount > maxPluginEntries) {
     throw createPluginStateError({
       code: "PLUGIN_STATE_LIMIT_EXCEEDED",


### PR DESCRIPTION
## What Problem This Solves

Plugin state writes that exceed the plugin-wide live-row cap scan the plugin's rows again after evicting old entries, adding avoidable synchronous database work at the quota boundary.

## Why This Change Was Made

Reuse the live count already read inside the write transaction and subtract SQLite's actual deleted-row count. The count and eviction share the same live-row predicate and fixed timestamp; the existing retention ledger keeps precedence, and insufficient eviction still fails and rolls back the whole write.

## User Impact

Overflow writes without a retention ledger perform one fewer aggregate scan while preserving namespace isolation, the newly written entry, expiry handling, and quota errors. Under-limit writes and reject-new behavior are unchanged. No schema, index, configuration, or API changes are included.

## Evidence

- Local real-store API proof passed nine scenarios on both original and changed source, including the actual 50,000-row cap. Overflow paths changed from two plugin COUNT executions to one; outcomes, stored values, and transaction closure matched. Separate behavior passes used no statement instrumentation. No latency claim is made.
- All 61 focused tests passed across the store, expiry, error, and import suites, including rollback with 1,031 expired rows and insufficient live eviction candidates.
- Independent review found no actionable P0–P2 findings.
- The same nine candidate scenarios passed through the real store API in isolated Linux Blacksmith Testbox on Node 24.19.0, including persisted values, rollback, statement counts, and owner closure ([run](https://github.com/openclaw/openclaw/actions/runs/34224462113)). The source and harness hashes matched the reviewed candidate. This is store-boundary proof, not a Gateway latency benchmark.
- The full local changed gate passed, including formatting, lint, typechecking, dead-code checks, and database/schema guards.
