### PR TITLE
fix(tests): isolate mocked Chromium selection from browser overrides

### DIFF
--- a/extensions/qa-lab/src/web-runtime.test.ts
+++ b/extensions/qa-lab/src/web-runtime.test.ts
@@ -68,6 +68,7 @@ import {
 } from "./web-runtime.js";
 
 beforeEach(async () => {
+  vi.stubEnv("PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH", undefined);
   const page = {
     on: pageOn,
     goto,

--- a/test/scripts/ensure-playwright-chromium.test.ts
+++ b/test/scripts/ensure-playwright-chromium.test.ts
@@ -21,6 +21,7 @@ describe("ensurePlaywrightChromium", () => {
 
     expect(
       ensurePlaywrightChromium({
+        env: {},
         executablePath: "/cache/chromium/chrome",
         existsSync: () => true,
         spawnSync,
@@ -72,6 +73,7 @@ describe("ensurePlaywrightChromium", () => {
 
     expect(
       ensurePlaywrightChromium({
+        env: {},
         executablePath: "/cache/chromium/chrome",
         existsSync: (candidatePath: string) => candidatePath === "/usr/bin/chromium-browser",
         log: (line: string) => logs.push(line),
@@ -244,6 +246,7 @@ describe("ensurePlaywrightChromium", () => {
 
     expect(
       ensurePlaywrightChromium({
+        env: {},
         executablePath: "/cache/chromium/chrome",
         existsSync: (candidatePath: string) =>
           candidatePath === "/snap/bin/chromium" || candidatePath === "/usr/bin/google-chrome",
@@ -512,6 +515,7 @@ describe("ensurePlaywrightChromium", () => {
   it("returns the installer status when Playwright install fails", () => {
     expect(
       ensurePlaywrightChromium({
+        env: {},
         executablePath: "/cache/chromium/chrome",
         existsSync: () => false,
         platform: "darwin",


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Resolves a problem where the test suite reports five false browser-selection failures when developers or test runners configure a Chromium executable override. The affected tests model their own browser paths and should not inherit the host's executable selection.

## Why This Change Was Made

Four installer tests now provide an explicit empty environment through the existing injection option. The QA web-runtime fixture clears the override before each case and restores it through its existing teardown. Explicit-override tests and all fallback, installation-status, launch, and cleanup assertions remain intact.

## User Impact

No production behavior changes. Real browser tests and QA runtime continue to honor the configured Chromium executable. This adds five test lines to make the mocked fixtures independent of host configuration.

## Evidence

- Reproduced four installer failures and one QA system-browser mismatch with a synthetic override in a sanitized child environment.
- After the fix, both complete suites pass all 31 cases with the override and all 31 without it; the existing UI browser-resolution sibling passes seven cases.
- Parent environment remains unchanged. Existing teardown and the installed Vitest restoration behavior were inspected; no raw passing-case order claim is made from the summary logs.
- Full mapped changed checks, diff-scoped cleanup, and fresh independent P2 review passed with no findings.

No aggregate runtime or coverage percentage is claimed.
