### PR TITLE
fix(cli): keep approvals allowlist --json output parseable on local writes

### DIFF
--- a/src/cli/exec-approvals-cli.test.ts
+++ b/src/cli/exec-approvals-cli.test.ts
@@ -855,6 +855,21 @@ describe("exec approvals CLI", () => {
     expect(loggedOutput()).toContain("Writing local approvals.");
   });
 
+  it("keeps --json output parseable when the allowlist write happens locally", async () => {
+    const updateExecApprovals = vi.mocked(execApprovals.updateExecApprovals);
+    updateExecApprovals.mockClear();
+    defaultRuntime.log.mockClear();
+    defaultRuntime.writeJson.mockClear();
+
+    await runApprovalsCommand(["approvals", "allowlist", "add", "/usr/bin/uname", "--json"]);
+
+    expect(updateExecApprovals).toHaveBeenCalledWith(
+      expect.objectContaining({ baseHash: "hash-local" }),
+    );
+    expect(defaultRuntime.writeJson).toHaveBeenCalledTimes(1);
+    expect(loggedOutput()).not.toContain("Writing local approvals.");
+  });
+
   it.each(["add", "remove"])(
     "rejects an unknown agent before allowlist %s persistence",
     async (operation) => {

--- a/src/cli/exec-approvals-cli.ts
+++ b/src/cli/exec-approvals-cli.ts
@@ -366,7 +366,10 @@ async function saveSnapshotTargeted(params: SaveSnapshotTargetedParams): Promise
   } else if (params.source === "local") {
     // Announced at the write, not at target resolution: no-op allowlist edits and
     // rejected `set` input never reach here and must not claim a write happened.
-    defaultRuntime.log(theme.muted("Writing local approvals."));
+    // JSON mode owns stdout: the written snapshot below is the record of the write.
+    if (!params.opts.json) {
+      defaultRuntime.log(theme.muted("Writing local approvals."));
+    }
     next = await saveSnapshotLocal(params.file, params.baseHash);
   } else {
     next = await saveSnapshot(params.opts, params.nodeId, params.file, params.baseHash);


### PR DESCRIPTION
## What Problem This Solves

`openclaw approvals allowlist add <path> --json` (and `remove`) printed `Writing local approvals.` on stdout before the JSON snapshot whenever the edit really wrote the local approvals file. Scripted callers parsing stdout got a non-JSON first line. The existing JSON matrix only covered no-op edits, which never reach the write and therefore never announced.

## Why This Change Was Made

The announcement is human-facing output at the write site; in JSON mode the written snapshot returned by `writeJson` is the record of the write, so the announcement is suppressed there. No other branch (gateway or node writes) announces.

## User Impact

`approvals allowlist add|remove --json` now emits exactly one JSON document on stdout. Human output is unchanged.

## Evidence

- Live repro on a built `main` dist with an isolated state dir and gateway: `approvals allowlist add --agent main /usr/bin/uname --json` printed `Writing local approvals.` followed by the JSON snapshot.
- New regression in `src/cli/exec-approvals-cli.test.ts` (real local write with `--json`): fails on `main` (`log` called with the announcement), passes with the fix (`writeJson` once, `log` never).
- `node scripts/run-vitest.mjs src/cli/exec-approvals-cli.test.ts src/cli/exec-approvals-cli.allowlist-json.test.ts`: pass; `node scripts/check-changed.mjs`: pass. Autoreview (Codex) scoped-clean.

Production LOC delta: +3 (one guard around the announcement).
