### PR TITLE
docs(install): add Node.js and Bun compatibility reference pages

### DIFF
--- a/docs/.i18n/glossary.zh-CN.json
+++ b/docs/.i18n/glossary.zh-CN.json
@@ -2586,5 +2586,41 @@
   {
     "source": "Workspace tips and Dreams UI actions",
     "target": "工作区提示与 Dreams UI 操作"
+  },
+  {
+    "source": "Bun",
+    "target": "Bun"
+  },
+  {
+    "source": "Bun compatibility",
+    "target": "Bun 兼容性"
+  },
+  {
+    "source": "Environment variables",
+    "target": "环境变量"
+  },
+  {
+    "source": "Linux",
+    "target": "Linux"
+  },
+  {
+    "source": "Memory configuration",
+    "target": "记忆配置"
+  },
+  {
+    "source": "Node.js",
+    "target": "Node.js"
+  },
+  {
+    "source": "Node.js compatibility",
+    "target": "Node.js 兼容性"
+  },
+  {
+    "source": "Runtimes",
+    "target": "运行时"
+  },
+  {
+    "source": "macOS",
+    "target": "macOS"
   }
 ]

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -21,6 +21,7 @@ This directory owns docs authoring, published link rules, and docs i18n policy.
 
 ## Docs Content Rules
 
+- When `node-version.mjs`, `package.json` engines, the Bun minimum in `src/infra/runtime-guard.ts`, or the SQLite floors in `src/infra/sqlite-runtime-version.ts` change, update the supported-versions and history tables in `docs/install/node-compatibility.md` and `docs/install/bun-compatibility.md`.
 - For docs, UI copy, and picker lists, order services and providers alphabetically. The one exception is a section that explicitly describes runtime order or auto-detection order.
 - Keep bundled plugin naming consistent with the repo-wide plugin terminology rules in the root `AGENTS.md`.
 - CI verifies JSON5 and JSON config fences that look like whole `openclaw.json` documents against the schema. `pnpm docs:check-config-examples` runs that verification. Deliberately partial or legacy snippets opt out with `validate=false` in the fence info string.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -1377,8 +1377,16 @@
                 "group": "Install overview",
                 "pages": [
                   "install/index",
-                  "install/installer",
-                  "install/node"
+                  "install/installer"
+                ]
+              },
+              {
+                "group": "Runtimes",
+                "pages": [
+                  "install/node",
+                  "install/node-compatibility",
+                  "install/bun",
+                  "install/bun-compatibility"
                 ]
               },
               {
@@ -1403,7 +1411,6 @@
                 "group": "Containers",
                 "pages": [
                   "install/ansible",
-                  "install/bun",
                   "install/docker",
                   "install/nix",
                   "install/podman"

--- a/docs/help/environment.md
+++ b/docs/help/environment.md
@@ -28,16 +28,16 @@ The variables below are the supported environment contract for operators. Undocu
 
 ### Paths and instances
 
-| Variable                  | Purpose                                                               |
-| ------------------------- | --------------------------------------------------------------------- |
-| `OPENCLAW_HOME`           | Override the home directory used for OpenClaw path defaults.          |
-| `OPENCLAW_STATE_DIR`      | Override the mutable state directory.                                 |
-| `OPENCLAW_CONFIG_PATH`    | Override the active config file path.                                 |
-| `OPENCLAW_WORKSPACE_DIR`  | Override the default agent workspace.                                 |
-| `OPENCLAW_PROFILE`        | Select a named profile and its isolated defaults.                     |
-| `OPENCLAW_GIT_DIR`        | Override the source checkout used by development-channel updates.     |
-| `OPENCLAW_INCLUDE_ROOTS`  | Allow `$include` to resolve from additional roots.                    |
-| `OPENCLAW_SQLITE_LIBRARY` | Override the SQLite library for [Bun on macOS](/install/bun#caveats). |
+| Variable                  | Purpose                                                                                              |
+| ------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `OPENCLAW_HOME`           | Override the home directory used for OpenClaw path defaults.                                         |
+| `OPENCLAW_STATE_DIR`      | Override the mutable state directory.                                                                |
+| `OPENCLAW_CONFIG_PATH`    | Override the active config file path.                                                                |
+| `OPENCLAW_WORKSPACE_DIR`  | Override the default agent workspace.                                                                |
+| `OPENCLAW_PROFILE`        | Select a named profile and its isolated defaults.                                                    |
+| `OPENCLAW_GIT_DIR`        | Override the source checkout used by development-channel updates.                                    |
+| `OPENCLAW_INCLUDE_ROOTS`  | Allow `$include` to resolve from additional roots.                                                   |
+| `OPENCLAW_SQLITE_LIBRARY` | Override the SQLite library for [Bun on macOS](/install/bun-compatibility#sqlite-library-selection). |
 
 ### Gateway and authentication
 

--- a/docs/install/bun-compatibility.md
+++ b/docs/install/bun-compatibility.md
@@ -1,0 +1,96 @@
+---
+summary: "Bun runtime requirements, macOS SQLite selection, limitations, and release history"
+title: "Bun compatibility"
+read_when:
+  - You want to check Bun runtime support and limitations
+  - You need to select a SQLite library for Bun on macOS
+---
+
+Bun is an explicit opt-in runtime for OpenClaw's CLI, Gateway, and managed node host. Node remains the primary and recommended runtime. This reference covers Bun requirements and compatibility; see [Bun](/install/bun) for installation and opt-in steps, or [Node.js compatibility](/install/node-compatibility) for Node requirements.
+
+## Requirements
+
+OpenClaw requires **Bun 1.4.0+**, an available **`node:sqlite`** API, and the same [WAL-safe SQLite floor as Node](/install/node-compatibility#why-the-floors-exist).
+
+| Platform | SQLite library Bun uses                       | Extension loading              | What OpenClaw does                                   |
+| -------- | --------------------------------------------- | ------------------------------ | ---------------------------------------------------- |
+| Linux    | Statically linked SQLite; 3.53.2 in Bun 1.4.2 | Supported                      | No additional library setup needed.                  |
+| macOS    | Apple system SQLite by default                | Unavailable in Apple's library | Automatically selects a suitable library; see below. |
+| Windows  | Same static SQLite build as Linux             | Supported                      | No additional library setup needed.                  |
+
+The platform defaults come from [Bun's SQLite build policy](https://github.com/oven-sh/bun/blob/bun-v1.4.2/scripts/build/deps/sqlite.ts); the [Bun 1.4.2 version definition](https://github.com/oven-sh/bun/blob/bun-v1.4.2/src/jsc/bindings/sqlite/sqlite3_local.h) pins SQLite 3.53.2.
+
+<a id="sqlite-library-selection" />
+
+## SQLite library selection on macOS
+
+Install Homebrew SQLite for native `sqlite-vec` KNN memory queries:
+
+```sh
+brew install sqlite
+```
+
+Before opening databases, OpenClaw selects a library in this order:
+
+1. An explicit library path supplied internally, otherwise `OPENCLAW_SQLITE_LIBRARY`.
+2. `$HOMEBREW_PREFIX/opt/sqlite/lib/libsqlite3.dylib`.
+3. `/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib`.
+4. `/usr/local/opt/sqlite/lib/libsqlite3.dylib`.
+5. `/opt/local/lib/libsqlite3.dylib` (MacPorts).
+
+Candidates must meet the WAL safety floor and support extension loading before selection. If automatic discovery finds no qualifying library, Bun keeps its runtime library; ordinary agent databases can open if that library meets the WAL floor. The memory KNN child uses the same selected library.
+
+Set `OPENCLAW_SQLITE_LIBRARY` in the process environment before starting OpenClaw to override discovery:
+
+```sh
+OPENCLAW_SQLITE_LIBRARY=/path/to/libsqlite3.dylib bun openclaw.mjs gateway
+```
+
+An invalid override fails with:
+
+```text
+Cannot use SQLite library <path>: <reason>. Fix or unset OPENCLAW_SQLITE_LIBRARY; install a supported library with brew install sqlite.
+```
+
+Node and non-macOS Bun ignore this override, with a warning in Gateway startup logs. When a library is selected, Gateway startup logs `SQLite: using <path> (<version>, extension loading enabled)`. `openclaw doctor` reports the selection for the doctor process.
+
+If you previously used a preload that calls `Database.setCustomSQLite()`, remove it and set `OPENCLAW_SQLITE_LIBRARY` to the same path instead. The hook is one-shot: keeping the preload causes `SQLite already loaded`, even if both selections name the same library. OpenClaw's override also forwards the path to the KNN child.
+
+## Memory search without an extension-capable library
+
+When the KNN child cannot load extensions, memory search falls back to a batched embedding scan. It preserves provider and source filters and cancellation checks between batches, but can be slower on large indexes. See [Memory configuration](/reference/memory-config).
+
+## Known limitations
+
+- **Lifecycle scripts:** Bun blocks dependency lifecycle scripts unless explicitly trusted with `bun pm trust`.
+- **Package scripts:** Some scripts hardcode pnpm, so `bun run` still invokes pnpm internally.
+- **SQLite handles:** Bun 1.4.2 can retain statement handles and WAL/shared-memory files after `DatabaseSync.close()` or `Symbol.dispose()`; OpenClaw cannot finalize them through Bun's public `node:sqlite` API. See the [upstream close fix](https://github.com/oven-sh/bun/pull/40005); use Node when prompt file release matters.
+- **Workspace installation:** `bun install` cannot resolve this repository's pnpm workspace layout. Use `pnpm install`.
+
+See [Bun](/install/bun) for the workflow and lifecycle trust commands.
+
+## History across releases
+
+| Release                            | Change                                                                                                                                                                                               |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unreleased (main)                  | Automatically selects a WAL-safe, extension-capable macOS SQLite library and propagates it to the memory KNN child. Adds `OPENCLAW_SQLITE_LIBRARY`. #141854                                          |
+| Unreleased (main)                  | Documents Bun 1.4.2 retaining native statements and WAL/shared-memory files after close or disposal, with Node advised when prompt file release matters. #141846                                     |
+| Unreleased (main)                  | Adds batched embedding-scan fallback when the KNN child cannot load extensions, preserving provider/source filters and cancellation between batches. #141104                                         |
+| Unreleased (main)                  | Allows ordinary agent databases on SQLite builds without extension loading. Native vector search still needs an extension-capable library. #139487                                                   |
+| v2026.8.2                          | Repairs Bun 1.4 authenticated Gateway WebSocket compatibility with the installed npm receiver, preserving payload limits and request scheduling. #134282                                             |
+| v2026.8.1                          | Restores explicit managed-service selection for the CLI, Gateway, and managed node host, requiring Bun 1.4.0+, `node:sqlite`, and WAL-safe SQLite. #129593                                           |
+| v2026.7.2-beta.5; stable v2026.8.1 | Restores experimental CLI/Gateway support for builds providing `node:sqlite`, documented as 1.4.0 canary and later; the guard uses an API probe without a numeric Bun minimum at this stage. #114256 |
+| v2026.7.2-beta.5; stable v2026.8.1 | Documents `bun install` failing on the pnpm workspace layout and changes dependency instructions to `pnpm install`; Bun remains a script runner. #114256                                             |
+| v2026.7.1; main v2026.7.2-beta.1   | Rejects Bun CLI/Gateway use because `node:sqlite` is unavailable, makes managed runtime selection Node-only, and directs legacy Bun services to Node. Package-script use remains available. #106065  |
+| v2026.1.12                         | Labels Bun Gateway use experimental and not recommended because of WhatsApp/Telegram bugs; recommends Node for production.                                                                           |
+| v2026.1.9                          | Removes Bun from the interactive daemon-runtime picker while the explicit validator still accepts Bun.                                                                                               |
+| v2026.1.8                          | Documents Bun as an optional package-script runner for local builds/tests, with optional dependency installation at that time. pnpm remains primary.                                                 |
+| v2026.1.8                          | Documents ignored pnpm lockfiles, a historical postinstall patch bridge, lifecycle trust, and scripts that invoke pnpm internally. The patch bridge is not a current install recommendation.         |
+| v2026.1.8                          | Introduces optional `--daemon-runtime bun` when WhatsApp is disabled because the Baileys WebSocket reconnect path could corrupt memory under Bun. Node remains the default and recommendation.       |
+
+## Related
+
+- [Bun](/install/bun)
+- [Environment variables](/help/environment)
+- [Memory configuration](/reference/memory-config)
+- [Node.js compatibility](/install/node-compatibility)

--- a/docs/install/bun.md
+++ b/docs/install/bun.md
@@ -8,7 +8,7 @@ title: "Bun"
 ---
 
 <Warning>
-Node remains OpenClaw's primary, default, and recommended runtime. Bun 1.4+ builds that provide WAL-reset-safe `node:sqlite` can run the CLI, Gateway, and managed node host as an explicit opt-in. OpenClaw requires SQLite 3.51.3+, 3.50.7+ within 3.50.x, or 3.44.6+ within 3.44.x; older Bun versions and builds with unsafe SQLite are rejected.
+Node remains OpenClaw's primary, default, and recommended runtime. Bun 1.4+ builds that provide WAL-reset-safe `node:sqlite` can run the CLI, Gateway, and managed node host as an explicit opt-in. [OpenClaw requires SQLite 3.51.3+, 3.50.7+ within 3.50.x, or 3.44.6+ within 3.44.x](/install/bun-compatibility); older Bun versions and builds with unsafe SQLite are rejected.
 </Warning>
 
 Bun remains usable as an optional package-script runner. The default package manager remains `pnpm`, which is fully supported and used by docs tooling. Bun cannot use `pnpm-lock.yaml` and ignores it, and current Bun versions fail to resolve this repo's `pnpm-workspace.yaml` layout during `bun install`, so dependency installs should use `pnpm install`.
@@ -64,54 +64,13 @@ bun pm trust baileys protobufjs
 
 ## Caveats
 
-Bun 1.4.2 can retain SQLite statement handles and WAL/shared-memory files after
-`DatabaseSync.close()` or `Symbol.dispose()`. Use Node when database files must
-be released promptly after closing. This is a temporary runtime workaround while
-the [upstream close fix](https://github.com/oven-sh/bun/pull/40005) is pending;
-OpenClaw cannot finalize these handles through Bun's public `node:sqlite` API.
-
-On macOS, install Homebrew SQLite to enable native `sqlite-vec` KNN memory queries:
-
-```sh
-brew install sqlite
-```
-
-OpenClaw automatically selects a WAL-reset-safe, extension-capable SQLite library
-from Homebrew or MacPorts before opening a database, and uses the same library in
-the memory KNN child process. Discovery checks `$HOMEBREW_PREFIX/opt/sqlite/lib/libsqlite3.dylib`
-first, then the standard Homebrew paths under `/opt/homebrew` and `/usr/local`,
-then `/opt/local/lib/libsqlite3.dylib` for MacPorts. Linux and Windows Bun already
-support extension loading and need no additional SQLite installation.
-
-To override discovery, set `OPENCLAW_SQLITE_LIBRARY` in the process environment
-before starting OpenClaw:
-
-```sh
-OPENCLAW_SQLITE_LIBRARY=/path/to/libsqlite3.dylib bun openclaw.mjs gateway
-```
-
-The override must point to a loadable SQLite library that meets the WAL safety
-floor and supports extension loading. An invalid override fails with an error
-explaining how to fix or unset it. Node and Bun on platforms other than macOS
-ignore this override; Gateway startup logs a warning when it is ignored.
-
-If you previously used a Bun preload script that calls `Database.setCustomSQLite()`,
-remove that preload and set `OPENCLAW_SQLITE_LIBRARY` to the same library path
-instead. Bun permits that hook only once per process; keeping the preload causes
-startup to fail with `SQLite already loaded`, even when both selections name the
-same library. The environment override lets OpenClaw select the library before
-opening databases and forward the path to the memory KNN child.
-
-Without a suitable library on macOS, Bun keeps Apple's system SQLite, which omits
-native extension loading. OpenClaw can open ordinary agent databases when that
-library meets the WAL safety floor. Memory search falls back to a batched
-embedding scan with the same provider and source filters and cancellation checks
-between batches. This can be slower on large indexes.
+On macOS, run `brew install sqlite` for native vector search. Bun 1.4.2 can retain SQLite handles and WAL/shared-memory files after close; use Node when prompt file release matters. See [Bun compatibility](/install/bun-compatibility) for library selection, requirements, and limitations.
 
 Some package scripts hardcode `pnpm` internally (for example `check:docs`, `ui:*`, `protocol:check`). Running them via `bun run` still shells out to `pnpm`, so just run those via `pnpm` directly.
 
 ## Related
 
+- [Bun compatibility](/install/bun-compatibility)
 - [Install overview](/install)
-- [Node.js](/install/node)
+- [Node.js compatibility](/install/node-compatibility)
 - [Updating](/install/updating)

--- a/docs/install/index.md
+++ b/docs/install/index.md
@@ -10,7 +10,7 @@ title: "Install"
 
 ## System requirements
 
-- **Node 24.16+ or 26.1+** - Node 26 is recommended; the installer provisions Node 26 on macOS and Node 24 LTS on Linux when Node is missing.
+- **Node 24.16+ or 26.1+** - Node 26 is recommended; the installer provisions Node 26 on macOS and Node 24 LTS on Linux when Node is missing (see [Node.js compatibility](/install/node-compatibility)).
 - **macOS, Linux, or Windows** - Windows users can start with the native Windows Hub app, the PowerShell CLI installer, or a WSL2 Gateway. See [Windows](/platforms/windows).
 - `pnpm` is only needed if you build from source.
 

--- a/docs/install/node-compatibility.md
+++ b/docs/install/node-compatibility.md
@@ -1,0 +1,88 @@
+---
+summary: "Supported Node.js versions, SQLite requirements, platform limits, and release history"
+title: "Node.js compatibility"
+read_when:
+  - You need to check which Node.js versions OpenClaw supports
+  - You want to understand a Node.js minimum version or platform support change
+---
+
+This reference covers supported Node.js lines, why the minimum versions exist, and how they changed across OpenClaw releases. For installation steps, see [Node.js](/install/node); for macOS companion app requirements, see [macOS](/platforms/macos).
+
+## Supported versions
+
+| Line    | Status      | Minimum         | Notes                                                     |
+| ------- | ----------- | --------------- | --------------------------------------------------------- |
+| Node 26 | Recommended | `>=26.1.0`      | Faster Gateway startup and lower memory use than Node 24. |
+| Node 24 | Supported   | `>=24.16.0 <25` | LTS line used by CI and the Linux installer.              |
+| Node 25 | Unsupported | —               | Excluded by the current TEXT decoder floor.               |
+| Node 23 | Unsupported | —               | Excluded earlier for incompatible `node:sqlite` behavior. |
+| Node 22 | Unsupported | —               | Unsupported since the 24.16.0/26.1.0 floor.               |
+
+The exact engines expression is `>=24.16.0 <25 || >=26.1.0`. It is enforced by `package.json` engines during npm installation, the startup runtime guard for every `openclaw` command, and the installer scripts.
+
+## Why the floors exist
+
+The **SQLite WAL-reset corruption bug** requires a safe loaded library: SQLite **3.51.3+**, **3.50.7+ within 3.50.x**, or **3.44.6+ within 3.44.x**. OpenClaw validates the library actually loaded because Node builds linked to shared system SQLite can use a different version from Node's own metadata.
+
+Separately, the **`node:sqlite` TEXT decoder** in Node 22.23.x, 24.15.0, 25.9.0, and 26.0.0 silently truncates values at embedded NUL characters. The first fixed releases are Node 24.16.0 and 26.1.0; a WAL-safe SQLite library does not fix this decoder. Node 23 was excluded earlier for incompatible `node:sqlite` behavior.
+
+## Platform consequences
+
+Official Node 24+ binaries require **macOS 13.5+**, so macOS 11 through 13.4 no longer support the Node-based CLI or Gateway. The companion app has separate [macOS requirements](/platforms/macos).
+
+Supported Node lines have no official **Linux ARMv7** builds. Use a 64-bit operating system on compatible ARM hardware, or another supported host.
+
+On RPM-based distributions, the installer preserves a supported distro-owned Node package that links unsafe system SQLite and provisions a separate user-space runtime for OpenClaw.
+
+## What the installer provisions
+
+Recommended, supported, and provisioned are three different things.
+
+| Platform        | Installer path                              | Node provisioned                                                                           |
+| --------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Linux           | `install.sh`: apt/dnf/yum via NodeSource    | Node 24.x LTS.                                                                             |
+| Linux and macOS | Rootless `install-cli.sh`                   | Node 24.19.0 by default; existing runtime reuse and explicit version selection can differ. |
+| macOS           | `install.sh`: Homebrew `node`               | Node 26; no exact patch pinned, and an existing supported Node can be retained.            |
+| Windows         | `install.ps1`: Chocolatey, Scoop, or winget | LTS package; no exact patch pinned, validated after installation.                          |
+| Windows         | `install.ps1`: portable fallback            | Latest 26.x Windows zip.                                                                   |
+
+See [Installer internals](/install/installer) for provisioning details.
+
+## Check your runtime
+
+```bash
+node -v
+```
+
+Upgrade Node before updating OpenClaw if your version is unsupported. The startup guard prints this requirement sentence:
+
+> `openclaw requires Node >=24.16.0 <25, or >=26.1.0.`
+
+## History across releases
+
+Rows identify the first effective release, including a beta when applicable. Recommendation and installer changes are listed even when the numeric requirement stayed the same.
+
+| Release                              | Node requirement                                 | What changed and why                                                                                                                                                                                          |
+| ------------------------------------ | ------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unreleased (main)                    | `>=24.16.0 <25 \|\| >=26.1.0`                    | Raises the Node 24 floor and drops Node 22 and 25 to prevent embedded-NUL TEXT truncation; Node 23 remains excluded. Official Node-based support for macOS 11–13.4 and Linux ARMv7 provisioning ends. #140672 |
+| v2026.8.2                            | `>=22.22.3 <23 \|\| >=24.15.0 <25 \|\| >=25.9.0` | Preserves supported RPM-owned Node packages with unsafe system SQLite and provisions a separate user-space runtime. The numeric range and loaded-library safety requirement stay unchanged. #134166           |
+| v2026.8.1                            | `>=22.22.3 <23 \|\| >=24.15.0 <25 \|\| >=25.9.0` | Rootless defaults advance to 24.19.0, or 22.23.2 on ARMv7. Linux package provisioning returns to Node 24 LTS to avoid prerelease repository builds. #130369                                                   |
+| v2026.8.1-beta.3; stable v2026.8.1   | `>=22.22.3 <23 \|\| >=24.15.0 <25 \|\| >=25.9.0` | Centralizes release classification in `node-version.mjs`, rejecting prerelease, nightly, and malformed version labels. #124812                                                                                |
+| v2026.7.2-beta.5; stable v2026.8.1   | `>=22.22.3 <23 \|\| >=24.15.0 <25 \|\| >=25.9.0` | Recommends Node 26 for faster Gateway startup and lower memory use than Node 24. CI and release workflows retain Node 24. #114399                                                                             |
+| v2026.7.1; main v2026.7.2-beta.1     | `>=22.22.3 <23 \|\| >=24.15.0 <25 \|\| >=25.9.0` | Requires builds carrying the SQLite WAL-reset fix, validates the actual loaded SQLite library, and excludes all Node 23. Shipped through a release cherry-pick. #106065                                       |
+| v2026.7.1-beta.2                     | `>=22.19.0 <23 \|\| >=23.11.0`                   | Excludes Node 23.0–23.10 for incompatible SQLite behavior in the dialect's `StatementSync.columns()` path. Superseded before stable v2026.7.1. #99832                                                         |
+| v2026.5.16-beta.7; stable v2026.5.18 | `>=22.19.0`                                      | Raises the floor with the Pi dependencies' update to 0.75.1. Node 24 remains recommended.                                                                                                                     |
+| v2026.5.9-beta.1; stable v2026.5.12  | `>=22.16.0`                                      | Raises the floor for the native SQLite Kysely dialect's use of `StatementSync.columns()` to identify result-producing statements. #78921                                                                      |
+| v2026.3.24-beta.2; stable v2026.3.24 | `>=22.14.0`                                      | Lowers the floor from 22.16 so npm installs and self-updates do not strand existing Node 22.14 users.                                                                                                         |
+| v2026.3.12                           | `>=22.16.0`                                      | Raises the floor from 22.12 and makes Node 24 the default/recommended line for installs, CI, and releases. The recorded change does not identify a specific missing API.                                      |
+| v2026.2.6                            | `>=22.12.0`                                      | Aligns the startup guard with the package requirement because Matrix's SDK requires 22.12 and older runtimes produce misleading module-not-found errors. #5370                                                |
+| v2026.1.5 (earlier v2.0.0-beta3)     | Package `>=22.12.0`; startup `>=22.0.0`          | Raises the package floor from 22.0 to 22.12 without a recorded API-specific reason. Startup validation temporarily retains the older minimum.                                                                 |
+| Before 2026                          | `>=22.0.0`                                       | The earliest package engine declaration requires Node 22; no narrower runtime-feature justification is recorded.                                                                                              |
+
+## Related
+
+- [Bun compatibility](/install/bun-compatibility)
+- [Installer internals](/install/installer)
+- [Linux](/platforms/linux)
+- [macOS](/platforms/macos)
+- [Node.js](/install/node)

--- a/docs/install/node.md
+++ b/docs/install/node.md
@@ -17,9 +17,7 @@ node -v
 
 `v26.1.0` or newer is the recommended default. `v24.16.0` or newer 24.x is also supported and is the LTS line used by CI. Node 22, 23, 25, Node 24 before 24.16.0, and Node 26 before 26.1.0 are unsupported. If Node is missing or outside this range, pick an install method below.
 
-These floors preserve embedded NUL characters when `node:sqlite` reads TEXT values. Node 22.23.x, 24.15.0, 25.9.0, and 26.0.0 contain a broken TEXT decoder that silently truncates values at embedded NUL characters, even when the linked SQLite version is WAL-reset-safe. Node 24.16.0 and 26.1.0 are the first fixed releases on their respective lines. Upgrade Node before updating OpenClaw. The rootless installer already provisions Node 24.19.0 on supported platforms.
-
-This drops supported Node-based CLI/Gateway installations on macOS 11 through 13.4 and official Linux ARMv7 provisioning: Node 24+ binaries require macOS 13.5 or newer and do not provide Linux ARMv7 builds. On compatible ARM hardware, use a 64-bit operating system; otherwise use another supported host. The macOS companion app has its own [platform requirements](/platforms/macos).
+Upgrade Node before updating OpenClaw to avoid SQLite TEXT truncation. See [Node.js compatibility](/install/node-compatibility) for the SQLite safety floors and macOS/ARMv7 support limits.
 
 ## Install Node
 

--- a/docs/reference/memory-config.md
+++ b/docs/reference/memory-config.md
@@ -595,7 +595,7 @@ default `all`:
 | `store.vector.enabled`       | `boolean` | `true`  | Use sqlite-vec for vector queries |
 | `store.vector.extensionPath` | `string`  | bundled | Override sqlite-vec path          |
 
-For Bun on macOS, install Homebrew SQLite to enable extension loading; see [Bun SQLite setup](/install/bun#caveats) for automatic discovery and the `OPENCLAW_SQLITE_LIBRARY` library override.
+For Bun on macOS, install Homebrew SQLite to enable extension loading; see [Bun SQLite setup](/install/bun-compatibility#sqlite-library-selection) for automatic discovery and the `OPENCLAW_SQLITE_LIBRARY` library override.
 
 When sqlite-vec is unavailable, OpenClaw falls back to in-process cosine similarity automatically.
 


### PR DESCRIPTION
## What Problem This Solves

The Node.js requirement has changed nine times in 2026, and the reasons behind the floors (the SQLite WAL-reset corruption fix and the separate `node:sqlite` TEXT decoder bug that truncates at embedded NUL characters) were buried as dense prose in the Node install how-to. There was no history anywhere outside release notes and git. The Bun page's Caveats section had become the de facto Bun compatibility contract while the page itself sat under the Containers navigation group.

## Why This Change Was Made

Two new reference pages separate the contract from the how-to:

- `docs/install/node-compatibility.md`: supported lines with the exact engines expression and where it is enforced; the two SQLite defects explained as independent problems; macOS 13.5+ and Linux ARMv7 consequences; a table of what each installer path actually provisions versus what is recommended; the exact startup-guard diagnostic; and a newest-first history of every effective requirement change back to the Node 22 era with PR references.
- `docs/install/bun-compatibility.md`: Bun 1.4 requirements; a per-platform table showing Linux and Windows need nothing while macOS gets automatic library selection; the selection order, `OPENCLAW_SQLITE_LIBRARY` override with the exact failure text, the preload migration, and how to verify; the memory scan fallback; known limitations including Bun 1.4.2 close/dispose handle retention; and release history.

`docs/install/node.md` and `docs/install/bun.md` remain install how-tos and link to the references. A Runtimes navigation group holds Node, Node compatibility, Bun, and Bun compatibility (Bun leaves Containers); no URLs change. The environment reference, memory config page, and install overview link to the new pages. `docs/AGENTS.md` gains one bullet so the tables are refreshed when the runtime floors in code change. zh-CN glossary entries cover the new titles and labels.

History rows were reconstructed from tagged history and release notes with commit-level citations, not from changelog headings or the package version, which the investigation showed are unreliable release identifiers. Changes not yet in a tagged release are labeled "Unreleased (main)".

## User Impact

Docs only. Operators get one page per runtime that answers which versions are supported, why, what the installer will give them, and how the requirement has moved across releases.

## Evidence

- `pnpm docs:check-mdx`: 884 files pass. `pnpm docs:check-links`: 9,252 internal links, 0 broken. `pnpm docs:check-i18n-glossary`, `pnpm format:docs:check`, and `git diff --check` pass. `pnpm docs:list` indexes both pages with read-when hints.
- `pnpm docs:check-links:anchors` reports only the 39 expected missing `/clawhub` routes without the external ClawHub checkout; no link to the new pages or anchors is broken.
- The quoted guard sentence matches `src/infra/runtime-guard.ts`; the Bun static SQLite 3.53.2 claim links Bun's tagged build definition and version header.
- Preservation map for the trimmed how-to paragraphs is in the PR discussion on request; every removed unit moved to a named section of a new page.
