### PR TITLE
test: include bounded Code Mode poll failure diagnostics

### DIFF
--- a/src/agents/bash-tools.process.delivery.test.ts
+++ b/src/agents/bash-tools.process.delivery.test.ts
@@ -1,4 +1,4 @@
-import { expectDefined } from "@openclaw/normalization-core";
+import { expectDefined, readStringValue } from "@openclaw/normalization-core";
 import { afterEach, expect, test, vi } from "vitest";
 import { copyInternalToolResultState } from "../../packages/agent-core/src/internal-hooks.js";
 import { runWithAgentToolExecutionContext } from "../../packages/agent-core/src/tool-execution-context.js";
@@ -24,6 +24,7 @@ import {
 import { createProcessSessionFixture } from "./bash-process-registry.test-helpers.js";
 import { resetProcessRegistryForTests } from "./bash-process-registry.test-support.js";
 import { createProcessTool } from "./bash-tools.process.js";
+import { boundCodeModeError } from "./code-mode-json.js";
 import { createSubscribedCodeModeHarness } from "./code-mode.bridge.lifecycle.test-support.js";
 import { applyCodeModeCatalog } from "./code-mode.js";
 import {
@@ -271,7 +272,18 @@ test.each(["transformed", "blocked", "error"] as const)(
       });
     };
     try {
-      expect(await pollThroughBridge("nested-first")).toMatchObject({ status: "completed" });
+      const firstPoll = await pollThroughBridge("nested-first");
+      expect(
+        firstPoll,
+        boundCodeModeError(
+          JSON.stringify({
+            code: readStringValue(firstPoll.code),
+            failurePhase: readStringValue(firstPoll.failurePhase),
+            error: readStringValue(firstPoll.error),
+          }),
+          1_024,
+        ),
+      ).toMatchObject({ status: "completed" });
       expect(harness.nestedToolActivities).toHaveLength(1);
       expect(harness.nestedToolActivities[0]?.details.result.content).toContainEqual(
         expect.objectContaining({ type: "text", text: expect.stringContaining("nested-output") }),


### PR DESCRIPTION
## What Problem This Solves

When the nested process-poll persistence test fails its first Code Mode completion assertion, the matcher shows the unexpected status but omits the error code, failure phase and error message. That happened in [this CI job](https://github.com/openclaw/openclaw/actions/runs/34212896293/job/102018037882), leaving the runtime cause unresolved.

## Why This Change Was Made

Capture the result once and attach those three string fields as a diagnostic capped at 1,024 bytes, using the existing string reader and Code Mode error formatter. The completed-status assertion, execution order, timeout and subsequent persistence assertions retain their original meaning.

## User Impact

Maintainers get useful failure details without dumping tool output or telemetry. This is a test diagnostic improvement; it does not claim to fix the intermittent runtime failure or change production behavior.

## Evidence

All 18 existing delivery tests and all 20 selected canonical checks passed. Mechanical reversal of the diagnostic and import changes reproduces the original test bytes. Independent managed review completed with no actionable findings.

The earlier failed job passed on rerun at the identical tested commit. Its cause remains unknown; this change improves the evidence available if it recurs.
