### PR TITLE
feat(models): scope implicit catalogs to configured provider endpoints

### DIFF
--- a/docs/cli/models.md
+++ b/docs/cli/models.md
@@ -164,6 +164,7 @@ so it does not require `--all`.
 Notes:
 
 - The `Auth` column uses prepared credential and runtime evidence. A separate API key does not prove a native CLI login. Unknown readiness stays unknown, and catalog metadata does not prove that a model request will succeed. See [Read status correctly](/cli/models#read-status-correctly).
+- A provider-level `models.providers.<id>.baseUrl` outside the plugin’s declared native endpoints excludes its implicit catalog rows, including cached discovery. Add the models supported by your proxy to `models.providers.<id>.models`; explicitly authored rows, names, defaults, and aliases remain intact. A model-level URL override alone does not exclude the provider catalog.
 - Static catalog rows can remain visible without authentication. Listing them does not grant permission to select a restricted model or change `modelPolicy.allow`.
 - `Ctx` shows `contextTokens/contextWindow` when a runtime cap differs from the native context window. JSON retains `contextTokens` when provided.
 - `Input` and `Ctx` use the selected physical route plus explicit configured logical overrides. Unresolved route metadata stays unknown instead of borrowing another route's capabilities.

--- a/docs/plugins/manifest/providers.md
+++ b/docs/plugins/manifest/providers.md
@@ -146,6 +146,8 @@ Each provider entry can include:
 
 Use `providerEndpoints` for endpoint classification that generic request policy must know before provider runtime loads. Core still owns the meaning of each `endpointClass`; plugin manifests own the host and base URL metadata.
 
+The same endpoint metadata controls implicit model catalog eligibility when an operator sets `models.providers.<id>.baseUrl`. Catalog, alias, and native model base URLs also count as declared endpoints. A nonmatching provider-level URL excludes manifest, discovered, static, and generated catalog rows; explicitly authored models remain in the inventory. Plugins without native endpoint declarations keep their existing discovery behavior. Host and suffix matching retain their request-classification rules, so catalog eligibility does not establish exact-origin trust or prove a request can succeed.
+
 Officially externalized provider plugins are excluded from the core dist, so
 their manifests are invisible until installed. Their `providerEndpoints` must
 also be mirrored in `scripts/lib/official-external-provider-catalog.json` so

--- a/src/agents/agent-model-discovery.endpoint.test.ts
+++ b/src/agents/agent-model-discovery.endpoint.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it } from "vitest";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { discoverModelsFromCapturedSources } from "./agent-model-discovery.js";
+import { PLUGIN_MODEL_CATALOG_GENERATED_BY } from "./plugin-model-catalog.js";
+import { AuthStorage } from "./sessions/auth-storage.js";
+
+const pluginMetadataSnapshot = createPluginMetadataSnapshotFixture({
+  plugins: [
+    {
+      id: "catalog-owner",
+      providers: ["fixture"],
+      providerEndpoints: [{ endpointClass: "openai-public", hosts: ["native.example"] }],
+    },
+  ],
+});
+const nativeProvider = {
+  api: "openai-completions",
+  baseUrl: "https://native.example/v1",
+  models: [{ id: "native-model", name: "Discovered name", contextWindow: 128000 }],
+};
+const pluginCatalogs = [
+  {
+    pluginId: "catalog-owner",
+    contents: JSON.stringify({
+      generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+      providers: { fixture: nativeProvider },
+    }),
+  },
+];
+
+describe("captured endpoint catalog sources", () => {
+  it.each([
+    ["https://native.example/v1", ["native-model"]],
+    ["https://proxy.example/v1", []],
+  ])("filters generated inventory at %s", (baseUrl, expected) => {
+    const registry = discoverModelsFromCapturedSources(AuthStorage.inMemory(), {
+      config: { models: { providers: { fixture: { baseUrl, models: [] } } } },
+      modelsJsonContents: null,
+      pluginCatalogs,
+      pluginMetadataSnapshot,
+    });
+    expect(registry.getError()).toBeUndefined();
+    expect(registry.getAll().map((model) => model.id)).toEqual(expected);
+    expect(
+      registry
+        .fork(AuthStorage.inMemory())
+        .getAll()
+        .map((model) => model.id),
+    ).toEqual(expected);
+  });
+
+  it("preserves authored native-named and unique rows while excluding generated rows", () => {
+    const authored = {
+      ...nativeProvider,
+      baseUrl: "https://proxy.example/v1",
+      models: [
+        { id: "native-model", name: "Authored native name", contextWindow: 16384 },
+        { id: "manual-model", name: "Manual name", contextWindow: 8192 },
+      ],
+    };
+    const registry = discoverModelsFromCapturedSources(AuthStorage.inMemory(), {
+      config: { models: { providers: { fixture: { baseUrl: authored.baseUrl, models: [] } } } },
+      modelsJsonContents: JSON.stringify({
+        providers: {
+          fixture: authored,
+          sibling: {
+            ...nativeProvider,
+            models: [{ id: "sibling-model", name: "Unrelated", contextWindow: 64000 }],
+          },
+        },
+      }),
+      pluginCatalogs,
+      pluginMetadataSnapshot,
+    });
+    expect(registry.getError()).toBeUndefined();
+    expect(
+      registry
+        .getAll()
+        .map(({ provider, id, name, contextWindow }) => ({ provider, id, name, contextWindow })),
+    ).toEqual([
+      {
+        provider: "fixture",
+        id: "native-model",
+        name: "Authored native name",
+        contextWindow: 16384,
+      },
+      { provider: "fixture", id: "manual-model", name: "Manual name", contextWindow: 8192 },
+      { provider: "sibling", id: "sibling-model", name: "Unrelated", contextWindow: 64000 },
+    ]);
+  });
+});

--- a/src/agents/agent-model-discovery.ts
+++ b/src/agents/agent-model-discovery.ts
@@ -57,6 +57,7 @@ function createOpenClawModelRegistry(
     useRuntimeConfig: options?.config === undefined,
   });
   const registryOptions = {
+    config: options?.config,
     ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
     ...(options?.includePluginCatalogs !== undefined
       ? { includePluginCatalogs: options.includePluginCatalogs }

--- a/src/agents/embedded-agent-runner/model.inline-provider.ts
+++ b/src/agents/embedded-agent-runner/model.inline-provider.ts
@@ -1,11 +1,14 @@
 /**
  * Converts inline provider model config into runtime model definitions.
  */
+import { normalizeResolvedPricing } from "@openclaw/llm-core";
 import { normalizeOptionalLowercaseString } from "@openclaw/normalization-core/string-coerce";
 import type { ModelDefinitionConfig, ModelProviderConfig } from "../../config/types.js";
 import { normalizeGoogleApiBaseUrl } from "../../infra/google-api-base-url.js";
 import type { Api } from "../../llm/types.js";
 import type { PluginMetadataSnapshotOwnerMaps } from "../../plugins/plugin-metadata-snapshot.types.js";
+import type { ProviderRuntimeModel } from "../../plugins/provider-runtime-model.types.js";
+import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
 import { isSecretRefHeaderValueMarker } from "../model-auth-markers.js";
 import { attachModelProviderLocalService } from "../provider-local-service.js";
 import {
@@ -201,4 +204,29 @@ export function buildInlineProviderModels(
       );
     });
   });
+}
+
+/** Completes captured inline definitions with the same contract used by static catalogs. */
+export function completeInlineProviderModel(
+  model: InlineModelEntry,
+  providerConfig: ModelProviderConfig,
+): ProviderRuntimeModel {
+  return {
+    ...model,
+    name: model.name || model.id,
+    api: model.api ?? providerConfig.api ?? "openai-responses",
+    baseUrl: model.baseUrl ?? "",
+    reasoning: model.reasoning ?? false,
+    input: resolveProviderModelInput({
+      provider: model.provider,
+      modelId: model.id,
+      modelName: model.name,
+      input: model.input,
+    }),
+    cost: model.cost ?? normalizeResolvedPricing({}),
+    contextWindow: model.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
+    contextTokens: model.contextTokens,
+    maxTokens: model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
+    ...(providerConfig.authHeader !== undefined ? { authHeader: providerConfig.authHeader } : {}),
+  };
 }

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -4,7 +4,6 @@
 import { normalizeResolvedPricing } from "@openclaw/llm-core";
 import type { NormalizedModelCatalogRow } from "@openclaw/model-catalog-core/model-catalog-types";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-import type { ModelProviderConfig } from "../../config/types.models.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { planEffectiveModelCatalogRows } from "../../model-catalog/index.js";
 import { normalizePluginsConfig } from "../../plugins/config-state.js";
@@ -32,7 +31,7 @@ import {
 import type { PluginRegistry } from "../../plugins/registry-types.js";
 import { dedupeByKey } from "../../shared/dedupe-by-key.js";
 import { DEFAULT_CONTEXT_TOKENS } from "../defaults.js";
-import { buildInlineProviderModels, type InlineModelEntry } from "./model.inline-provider.js";
+import { buildInlineProviderModels, completeInlineProviderModel } from "./model.inline-provider.js";
 import type { BundledStaticCatalogState } from "./model.static-catalog.types.js";
 import {
   createStaticModelIdMatcher,
@@ -89,25 +88,6 @@ function modelFromStaticCatalogRow(row: NormalizedModelCatalogRow): ProviderRunt
     headers: row.headers,
     compat: row.compat,
     mediaInput: row.mediaInput,
-  };
-}
-
-function completeProviderStaticCatalogModel(
-  model: InlineModelEntry,
-  providerConfig: ModelProviderConfig,
-): ProviderRuntimeModel {
-  return {
-    ...model,
-    name: model.name || model.id,
-    api: model.api ?? providerConfig.api ?? "openai-responses",
-    baseUrl: model.baseUrl ?? "",
-    reasoning: model.reasoning ?? false,
-    input: normalizeStaticCatalogInput(model.input),
-    cost: model.cost ?? normalizeResolvedPricing({}),
-    contextWindow: model.contextWindow ?? DEFAULT_CONTEXT_TOKENS,
-    contextTokens: model.contextTokens,
-    maxTokens: model.maxTokens ?? DEFAULT_CONTEXT_TOKENS,
-    ...(providerConfig.authHeader !== undefined ? { authHeader: providerConfig.authHeader } : {}),
   };
 }
 
@@ -460,7 +440,7 @@ async function loadBundledProviderStaticCatalogModels(params: {
         ...buildInlineProviderModels(
           { [provider]: providerConfig },
           { providerMetadataOwners: params.providerMetadataOwners },
-        ).map((model) => completeProviderStaticCatalogModel(model, providerConfig)),
+        ).map((model) => completeInlineProviderModel(model, providerConfig)),
       );
       modelsByProvider.set(provider, models);
     }

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -16,6 +16,7 @@ import { loadPluginManifestRegistryCore } from "../../plugins/manifest-registry.
 import { loadPluginManifest } from "../../plugins/manifest.js";
 import { getPluginCache, getPluginMetadataSnapshotCache } from "../../plugins/plugin-cache.js";
 import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snapshot.types.js";
+import { isProviderCatalogSourceAllowed } from "../../plugins/provider-config-owner.js";
 import {
   normalizePluginDiscoveryResult,
   resolveRuntimePluginDiscoveryProviders,
@@ -155,7 +156,12 @@ function listBundledStaticCatalogPlugins(
   const plugins: StaticCatalogPlugin[] = metadataSnapshot
     ? metadataSnapshot.plugins
         .filter((plugin) => plugin.origin === "bundled")
-        .map(({ id, providers, modelCatalog }) => ({ id, providers, modelCatalog }))
+        .map(({ id, providers, modelCatalog, providerEndpoints }) => ({
+          id,
+          providers,
+          modelCatalog,
+          providerEndpoints,
+        }))
     : listOpenClawPluginManifestMetadata(params.env).flatMap((record): StaticCatalogPlugin[] => {
         if (record.origin !== "bundled") {
           return [];
@@ -167,6 +173,7 @@ function listBundledStaticCatalogPlugins(
                 id: loaded.manifest.id,
                 providers: loaded.manifest.providers,
                 modelCatalog: loaded.manifest.modelCatalog,
+                providerEndpoints: loaded.manifest.providerEndpoints,
               },
             ]
           : [];
@@ -408,6 +415,14 @@ async function loadBundledProviderStaticCatalogModels(params: {
     : undefined;
   const modelsByProvider = new Map<string, ProviderRuntimeModel[]>();
   for (const catalogProvider of providers) {
+    const plugin = params.pluginMetadataSnapshot?.manifestRegistry.plugins.find(
+      (candidate) => candidate.id === (catalogProvider.pluginId ?? catalogProvider.id),
+    );
+    const includeProvider = (provider: string) =>
+      isProviderCatalogSourceAllowed({ provider, plugin, config: params.cfg });
+    if (!includeProvider(catalogProvider.id)) {
+      continue;
+    }
     const preparedResultKey = `${catalogProvider.pluginId ?? ""}\0${normalizeProviderId(catalogProvider.id)}`;
     const result = preparedResults?.has(preparedResultKey)
       ? preparedResults.get(preparedResultKey)
@@ -421,6 +436,7 @@ async function loadBundledProviderStaticCatalogModels(params: {
       // Empty catalogs never resolve request secrets or transport settings.
       if (
         !provider ||
+        !includeProvider(provider) ||
         !Array.isArray(providerConfig.models) ||
         providerConfig.models.length === 0
       ) {

--- a/src/agents/embedded-agent-runner/model.static-catalog.ts
+++ b/src/agents/embedded-agent-runner/model.static-catalog.ts
@@ -420,7 +420,20 @@ async function loadBundledProviderStaticCatalogModels(params: {
     );
     const includeProvider = (provider: string) =>
       isProviderCatalogSourceAllowed({ provider, plugin, config: params.cfg });
-    if (!includeProvider(catalogProvider.id)) {
+    const soleStaticCatalog =
+      providers.filter(
+        (candidate) =>
+          (candidate.pluginId ?? normalizeProviderId(candidate.id)) ===
+            (catalogProvider.pluginId ?? normalizeProviderId(catalogProvider.id)) &&
+          candidate.staticCatalog,
+      ).length === 1;
+    const providerRefs = [
+      catalogProvider.id,
+      ...(catalogProvider.aliases ?? []),
+      ...(catalogProvider.hookAliases ?? []),
+      ...(soleStaticCatalog ? (plugin?.providers ?? []) : []),
+    ];
+    if (!providerRefs.some(includeProvider)) {
       continue;
     }
     const preparedResultKey = `${catalogProvider.pluginId ?? ""}\0${normalizeProviderId(catalogProvider.id)}`;

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -13,6 +13,7 @@ import { getCurrentPluginMetadataSnapshot } from "../plugins/current-plugin-meta
 import { isManifestPluginAvailableForControlPlane } from "../plugins/manifest-contract-eligibility.js";
 import { resolvePluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { isProviderCatalogSourceAllowed } from "../plugins/provider-config-owner.js";
 import { augmentModelCatalogWithProviderPlugins } from "../plugins/provider-runtime.runtime.js";
 import { createLazyPromise } from "../shared/lazy-promise.js";
 import { modelCatalogRowToEntry } from "./model-catalog-entry.js";
@@ -590,6 +591,16 @@ export async function buildPreparedModelCatalogSnapshot(
         const normalizedSupplemental: ModelCatalogEntry[] = [];
         for (const entry of supplemental) {
           const provider = normalizeProvider(entry.provider);
+          const owners = manifestMetadataSnapshot.owners;
+          const pluginIds =
+            owners.modelCatalogProviders.get(provider) ?? owners.providers.get(provider);
+          const plugin =
+            pluginIds?.length === 1
+              ? manifestMetadataSnapshot.byPluginId.get(pluginIds[0])
+              : undefined;
+          if (!isProviderCatalogSourceAllowed({ provider, config: cfg, plugin })) {
+            continue;
+          }
           const id = normalizeModelId(provider, entry.id);
           // Account-discovered providers own the visible model set. Synthetic
           // metadata can enrich an available or explicitly configured model,

--- a/src/agents/model-catalog.ts
+++ b/src/agents/model-catalog.ts
@@ -594,10 +594,8 @@ export async function buildPreparedModelCatalogSnapshot(
           const owners = manifestMetadataSnapshot.owners;
           const pluginIds =
             owners.modelCatalogProviders.get(provider) ?? owners.providers.get(provider);
-          const plugin =
-            pluginIds?.length === 1
-              ? manifestMetadataSnapshot.byPluginId.get(pluginIds[0])
-              : undefined;
+          const pluginId = pluginIds?.length === 1 ? pluginIds[0] : undefined;
+          const plugin = pluginId ? manifestMetadataSnapshot.byPluginId.get(pluginId) : undefined;
           if (!isProviderCatalogSourceAllowed({ provider, config: cfg, plugin })) {
             continue;
           }

--- a/src/agents/models-config.providers.endpoint.test.ts
+++ b/src/agents/models-config.providers.endpoint.test.ts
@@ -1,0 +1,143 @@
+import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ModelProviderConfig } from "../config/types.models.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import type { ProviderPlugin } from "../plugins/types.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../test-utils/openclaw-test-state.js";
+
+const { resolveRuntimePluginDiscoveryProviders } = vi.hoisted(() => ({
+  resolveRuntimePluginDiscoveryProviders: vi.fn(),
+}));
+vi.mock("../plugins/provider-discovery.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../plugins/provider-discovery.js")>()),
+  resolveRuntimePluginDiscoveryProviders,
+}));
+
+import { planOpenClawModelsJsonSource } from "./models-config.js";
+import {
+  prepareImplicitProviderStaticCatalog,
+  resolveImplicitProviders,
+} from "./models-config.providers.implicit.js";
+import {
+  replacePersistedPluginModelCatalogs,
+  PLUGIN_MODEL_CATALOG_GENERATED_BY,
+} from "./plugin-model-catalog.js";
+
+const nativeCatalog: ModelProviderConfig = {
+  baseUrl: "https://native.example/v1",
+  api: "openai-completions",
+  models: [
+    {
+      id: "native-model",
+      name: "Native model",
+      reasoning: false,
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      contextWindow: 128000,
+      maxTokens: 8192,
+    },
+  ],
+};
+const provider: ProviderPlugin = {
+  id: "fixture",
+  pluginId: "catalog-owner",
+  label: "Fixture",
+  auth: [],
+  staticCatalog: { order: "simple", run: async () => ({ provider: nativeCatalog }) },
+};
+const pluginMetadataSnapshot = createPluginMetadataSnapshotFixture({
+  plugins: [
+    {
+      id: "catalog-owner",
+      providers: ["fixture"],
+      providerEndpoints: [{ endpointClass: "openai-public", hosts: ["native.example"] }],
+    },
+  ],
+});
+
+describe("provider endpoint source eligibility", () => {
+  let state: OpenClawTestState;
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "endpoint-eligibility" });
+    resolveRuntimePluginDiscoveryProviders.mockResolvedValue([provider]);
+  });
+  afterEach(async () => {
+    await state.cleanup();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    { baseUrl: "https://native.example/v1", expected: ["native-model"] },
+    { baseUrl: "https://proxy.example/v1", expected: [] },
+  ])(
+    "applies endpoint eligibility before static discovery at $baseUrl",
+    async ({ baseUrl, expected }) => {
+      const providers = await resolveImplicitProviders({
+        agentDir: state.agentDir(),
+        env: state.env,
+        pluginMetadataSnapshot,
+        providerDiscoveryProviderIds: ["fixture"],
+        providerDiscoveryEntriesOnly: true,
+        config: { models: { providers: { fixture: { baseUrl, models: [] } } } },
+      });
+      expect(providers?.fixture?.models.map((model) => model.id) ?? []).toEqual(expected);
+    },
+  );
+
+  it("keeps auth handles but records excluded prepared catalogs as empty", async () => {
+    const prepared = await prepareImplicitProviderStaticCatalog({
+      env: state.env,
+      pluginMetadataSnapshot,
+      providerDiscoveryProviderIds: ["fixture"],
+      config: {
+        models: { providers: { fixture: { baseUrl: "https://proxy.example/v1", models: [] } } },
+      },
+    });
+    expect(prepared.providers).toEqual([provider]);
+    expect(prepared.entries).toEqual([{ provider, result: { providers: {} } }]);
+  });
+  it("does not recover a generated native endpoint over an authored custom provider", async () => {
+    replacePersistedPluginModelCatalogs({
+      agentDir: state.agentDir(),
+      pluginCatalogWrites: {
+        "plugins/catalog-owner/catalog.json": JSON.stringify({
+          generatedBy: PLUGIN_MODEL_CATALOG_GENERATED_BY,
+          providers: { fixture: nativeCatalog },
+        }),
+      },
+    });
+    const explicit: ModelProviderConfig = {
+      ...nativeCatalog,
+      baseUrl: "https://proxy.example/v1",
+      models: [
+        {
+          reasoning: false,
+          input: ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          maxTokens: 8192,
+          id: "manual-model",
+          name: "Authored model",
+          contextWindow: 16384,
+        },
+      ],
+    };
+    const planned = await planOpenClawModelsJsonSource(
+      { models: { providers: { fixture: explicit } } },
+      state.agentDir(),
+      {
+        env: state.env,
+        pluginMetadataSnapshot,
+        providerDiscoveryProviderIds: ["fixture"],
+        providerDiscoveryEntriesOnly: true,
+      },
+    );
+    const catalog = planned.pluginCatalogs.find((entry) => entry.pluginId === "catalog-owner");
+    assert(catalog, "The source plan must contain the authored provider");
+    expect(JSON.parse(catalog.contents).providers.fixture).toMatchObject({
+      baseUrl: "https://proxy.example/v1",
+      models: [{ id: "manual-model", name: "Authored model", contextWindow: 16384 }],
+    });
+  });
+});

--- a/src/agents/models-config.providers.endpoint.test.ts
+++ b/src/agents/models-config.providers.endpoint.test.ts
@@ -140,4 +140,80 @@ describe("provider endpoint source eligibility", () => {
       models: [{ id: "manual-model", name: "Authored model", contextWindow: 16384 }],
     });
   });
+  it("preserves a selected native alias when its sibling has a custom endpoint", async () => {
+    const aliasedProvider = { ...provider, aliases: ["alternate"] };
+    resolveRuntimePluginDiscoveryProviders.mockResolvedValue([aliasedProvider]);
+    const metadata = createPluginMetadataSnapshotFixture({
+      plugins: [
+        {
+          id: "catalog-owner",
+          providers: ["fixture", "alternate"],
+          providerEndpoints: [{ endpointClass: "openai-public", hosts: ["native.example"] }],
+        },
+      ],
+    });
+    const config = {
+      models: {
+        providers: {
+          fixture: { baseUrl: "https://proxy.example/v1", models: [] },
+          alternate: { baseUrl: "https://native.example/v1", models: [] },
+        },
+      },
+    };
+    const params = {
+      config,
+      env: state.env,
+      pluginMetadataSnapshot: metadata,
+      providerDiscoveryProviderIds: ["alternate"],
+    };
+    const preparedStaticProviderCatalog = await prepareImplicitProviderStaticCatalog(params);
+    const discovered = await resolveImplicitProviders({
+      ...params,
+      agentDir: state.agentDir(),
+      providerDiscoveryEntriesOnly: true,
+      preparedStaticProviderCatalog,
+    });
+    expect(discovered?.alternate?.models.map((model) => model.id)).toEqual(["native-model"]);
+    expect(discovered?.fixture).toBeUndefined();
+  });
+  it.each([false, true])(
+    "preserves an eligible shared-hook output without aliases (scoped: %s)",
+    async (scoped) => {
+      const sharedProvider: ProviderPlugin = {
+        ...provider,
+        staticCatalog: {
+          order: "simple",
+          run: async () => ({ providers: { fixture: nativeCatalog, alternate: nativeCatalog } }),
+        },
+      };
+      resolveRuntimePluginDiscoveryProviders.mockResolvedValue([sharedProvider]);
+      const metadata = createPluginMetadataSnapshotFixture({
+        plugins: [
+          {
+            id: "catalog-owner",
+            providers: ["fixture", "alternate"],
+            providerEndpoints: [{ endpointClass: "openai-public", hosts: ["native.example"] }],
+          },
+        ],
+      });
+      const config = {
+        models: { providers: { fixture: { baseUrl: "https://proxy.example/v1", models: [] } } },
+      };
+      const params = {
+        config,
+        env: state.env,
+        pluginMetadataSnapshot: metadata,
+        ...(scoped ? { providerDiscoveryProviderIds: ["alternate"] } : {}),
+      };
+      const preparedStaticProviderCatalog = await prepareImplicitProviderStaticCatalog(params);
+      const discovered = await resolveImplicitProviders({
+        ...params,
+        agentDir: state.agentDir(),
+        providerDiscoveryEntriesOnly: true,
+        preparedStaticProviderCatalog,
+      });
+      expect(discovered?.alternate?.models.map((model) => model.id)).toEqual(["native-model"]);
+      expect(discovered?.fixture).toBeUndefined();
+    },
+  );
 });

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -13,6 +13,7 @@ import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { ManifestModelIdNormalizationSource } from "../plugins/manifest-model-id-normalization.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.js";
 import type { ProviderCatalogOutcome } from "../plugins/provider-catalog.types.js";
+import { isProviderCatalogSourceAllowed } from "../plugins/provider-config-owner.js";
 import {
   groupPluginDiscoveryProvidersByOrder,
   normalizePluginDiscoveryResult,
@@ -230,13 +231,23 @@ async function resolvePluginImplicitProviders(
   for (const provider of byOrder[order]) {
     const pluginId = provider.pluginId ?? normalizeProviderId(provider.id);
     const ownerProviderIds = ctx.providerDiscoveryScope?.get(pluginId);
-    const providerIds =
+    const manifest = ctx.pluginMetadataSnapshot?.manifestRegistry.plugins.find(
+      (plugin) => plugin.id === pluginId,
+    );
+    const includeProvider = (providerId: string) =>
+      isProviderCatalogSourceAllowed({
+        provider: providerId,
+        config: ctx.config,
+        plugin: manifest,
+      });
+    const scopedProviderIds =
       ctx.providerDiscoveryScope === undefined
         ? undefined
         : catalogCountsByPluginId.get(pluginId) === 1
           ? (ownerProviderIds ?? [])
           : (ownerProviderIds ?? []).filter((id) => matchesProviderPluginRef(provider, id));
-    if (providerIds?.length === 0) {
+    const providerIds = scopedProviderIds?.filter(includeProvider);
+    if (providerIds?.length === 0 || (providerIds === undefined && !includeProvider(provider.id))) {
       continue;
     }
     const catalogConfig = buildPluginCatalogConfig(ctx, provider);
@@ -320,7 +331,10 @@ async function resolvePluginImplicitProviders(
       result,
     });
     for (const [providerId, implicitProvider] of Object.entries(normalizedResult)) {
-      if (selectedProviderIds && !selectedProviderIds.has(normalizeProviderId(providerId))) {
+      if (
+        !includeProvider(providerId) ||
+        (selectedProviderIds && !selectedProviderIds.has(normalizeProviderId(providerId)))
+      ) {
         continue;
       }
       const mergedProvider = mergeImplicitProviderConfig({
@@ -456,9 +470,18 @@ export async function prepareImplicitProviderStaticCatalog(
   const staticCatalogProviderIds = params.staticCatalogProviderIds
     ? new Set(params.staticCatalogProviderIds.map((provider) => normalizeProviderId(provider)))
     : undefined;
+  const eligibleProviders = providers.filter((provider) =>
+    isProviderCatalogSourceAllowed({
+      provider: provider.id,
+      config: params.config,
+      plugin: params.pluginMetadataSnapshot?.manifestRegistry.plugins.find(
+        (plugin) => plugin.id === (provider.pluginId ?? provider.id),
+      ),
+    }),
+  );
   const prepared = await prepareProviderStaticCatalog({
     providers: staticCatalogProviderIds
-      ? providers.filter((provider) => {
+      ? eligibleProviders.filter((provider) => {
           if ([...staticCatalogProviderIds].some((id) => matchesProviderPluginRef(provider, id))) {
             return true;
           }
@@ -473,13 +496,30 @@ export async function prepareImplicitProviderStaticCatalog(
             ).length === 1
           );
         })
-      : providers,
+      : eligibleProviders,
   });
   // Synthetic auth consumes the complete configured provider entrypoint set. Static results may
   // be narrower because startup only executes hooks for unresolved configured model refs.
   return Object.freeze({
     providers: Object.freeze(providers),
-    entries: prepared.entries,
+    // Record excluded hooks as empty so later static consumers cannot execute them again.
+    entries: Object.freeze([
+      ...prepared.entries.map((entry) => {
+        const plugin = params.pluginMetadataSnapshot?.manifestRegistry.plugins.find(
+          (candidate) => candidate.id === (entry.provider.pluginId ?? entry.provider.id),
+        );
+        const providerEntries = Object.entries(normalizePluginDiscoveryResult(entry));
+        const eligible = providerEntries.filter(([provider]) =>
+          isProviderCatalogSourceAllowed({ provider, config: params.config, plugin }),
+        );
+        return eligible.length === providerEntries.length
+          ? entry
+          : { provider: entry.provider, result: { providers: Object.fromEntries(eligible) } };
+      }),
+      ...providers
+        .filter((provider) => !eligibleProviders.includes(provider))
+        .map((provider) => ({ provider, result: { providers: {} } })),
+    ]),
   });
 }
 

--- a/src/agents/models-config.providers.implicit.ts
+++ b/src/agents/models-config.providers.implicit.ts
@@ -247,7 +247,16 @@ async function resolvePluginImplicitProviders(
           ? (ownerProviderIds ?? [])
           : (ownerProviderIds ?? []).filter((id) => matchesProviderPluginRef(provider, id));
     const providerIds = scopedProviderIds?.filter(includeProvider);
-    if (providerIds?.length === 0 || (providerIds === undefined && !includeProvider(provider.id))) {
+    const catalogProviderRefs = [
+      provider.id,
+      ...(provider.aliases ?? []),
+      ...(provider.hookAliases ?? []),
+      ...(catalogCountsByPluginId.get(pluginId) === 1 ? (manifest?.providers ?? []) : []),
+    ];
+    if (
+      providerIds?.length === 0 ||
+      (providerIds === undefined && !catalogProviderRefs.some(includeProvider))
+    ) {
       continue;
     }
     const catalogConfig = buildPluginCatalogConfig(ctx, provider);
@@ -470,15 +479,31 @@ export async function prepareImplicitProviderStaticCatalog(
   const staticCatalogProviderIds = params.staticCatalogProviderIds
     ? new Set(params.staticCatalogProviderIds.map((provider) => normalizeProviderId(provider)))
     : undefined;
-  const eligibleProviders = providers.filter((provider) =>
-    isProviderCatalogSourceAllowed({
-      provider: provider.id,
-      config: params.config,
-      plugin: params.pluginMetadataSnapshot?.manifestRegistry.plugins.find(
-        (plugin) => plugin.id === (provider.pluginId ?? provider.id),
-      ),
-    }),
-  );
+  const eligibleProviders = providers.filter((provider) => {
+    const pluginId = provider.pluginId ?? normalizeProviderId(provider.id);
+    const plugin = params.pluginMetadataSnapshot?.manifestRegistry.plugins.find(
+      (candidate) => candidate.id === pluginId,
+    );
+
+    const soleStaticCatalog =
+      providers.filter(
+        (candidate) =>
+          (candidate.pluginId ?? normalizeProviderId(candidate.id)) === pluginId &&
+          candidate.staticCatalog,
+      ).length === 1;
+    const providerRefs = discoveryScope?.get(pluginId) ?? [
+      provider.id,
+      ...(provider.aliases ?? []),
+      ...(provider.hookAliases ?? []),
+      ...(soleStaticCatalog ? (plugin?.providers ?? []) : []),
+    ];
+    // A shared static hook can still serve an eligible selected sibling identity.
+    return providerRefs.some(
+      (providerRef) =>
+        (soleStaticCatalog || matchesProviderPluginRef(provider, providerRef)) &&
+        isProviderCatalogSourceAllowed({ provider: providerRef, config: params.config, plugin }),
+    );
+  });
   const prepared = await prepareProviderStaticCatalog({
     providers: staticCatalogProviderIds
       ? eligibleProviders.filter((provider) => {
@@ -517,7 +542,7 @@ export async function prepareImplicitProviderStaticCatalog(
           : { provider: entry.provider, result: { providers: Object.fromEntries(eligible) } };
       }),
       ...providers
-        .filter((provider) => !eligibleProviders.includes(provider))
+        .filter((provider) => provider.staticCatalog && !eligibleProviders.includes(provider))
         .map((provider) => ({ provider, result: { providers: {} } })),
     ]),
   });

--- a/src/agents/models-config.ts
+++ b/src/agents/models-config.ts
@@ -40,11 +40,10 @@ import { planOpenClawModelsJson, type PreparedModelsConfigContext } from "./mode
 import { repairPluginModelCatalogTransportMetadata } from "./plugin-model-catalog-repair.js";
 import {
   decodePluginModelCatalogRelativePathPluginId,
-  isGeneratedPluginModelCatalog,
+  filterGeneratedPluginModelCatalogProviders,
   loadPersistedPluginModelCatalogs,
   loadPersistedPluginModelCatalogsReadOnly,
   replacePersistedPluginModelCatalogs,
-  resolvePluginModelCatalogOwnerPluginId,
   type PersistedPluginModelCatalog,
 } from "./plugin-model-catalog.js";
 
@@ -186,7 +185,8 @@ async function mergeGeneratedPluginCatalogProvidersIntoExistingParsed(params: {
   agentDir: string;
   existingParsed: unknown;
   pluginCatalogs?: readonly PersistedPluginModelCatalog[];
-  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "owners">;
+  config: OpenClawConfig;
+  pluginMetadataSnapshot?: Pick<PluginMetadataSnapshot, "owners" | "manifestRegistry">;
 }): Promise<unknown> {
   const root = isRecord(params.existingParsed) ? params.existingParsed : {};
   const providers = isRecord(root.providers) ? { ...root.providers } : {};
@@ -199,21 +199,17 @@ async function mergeGeneratedPluginCatalogProvidersIntoExistingParsed(params: {
     } catch {
       continue;
     }
-    if (
-      !isGeneratedPluginModelCatalog(catalog) ||
-      !isRecord(catalog) ||
-      !isRecord(catalog.providers)
-    ) {
+    if (!isRecord(catalog) || !isRecord(catalog.providers)) {
       continue;
     }
-    for (const [providerId, provider] of Object.entries(catalog.providers)) {
-      const currentOwnerPluginId = resolvePluginModelCatalogOwnerPluginId({
-        providerId,
-        pluginMetadataSnapshot: params.pluginMetadataSnapshot,
-      });
-      if (currentOwnerPluginId !== catalogPluginId) {
-        continue;
-      }
+    const eligibleProviders = filterGeneratedPluginModelCatalogProviders({
+      catalogPluginId,
+      parsedCatalog: catalog,
+      config: params.config,
+      pluginMetadataSnapshot: params.pluginMetadataSnapshot,
+      providers: catalog.providers,
+    });
+    for (const [providerId, provider] of Object.entries(eligibleProviders)) {
       providers[providerId] = provider;
       changed = true;
     }
@@ -372,6 +368,7 @@ async function prepareOpenClawModelsJsonSource(
     const existingModelsFile = await readExistingModelsFile(targetPath);
     const existingParsedForMerge = await mergeGeneratedPluginCatalogProvidersIntoExistingParsed({
       agentDir,
+      config: context.cfg,
       existingParsed: existingModelsFile.parsed,
       ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),
     });
@@ -451,6 +448,7 @@ export async function planOpenClawModelsJsonSource(
   const existingPluginCatalogs = loadPersistedPluginModelCatalogsReadOnly(agentDir);
   const existingParsedForMerge = await mergeGeneratedPluginCatalogProvidersIntoExistingParsed({
     agentDir,
+    config: context.cfg,
     existingParsed: existingModelsFile.parsed,
     pluginCatalogs: existingPluginCatalogs,
     ...(pluginMetadataSnapshot ? { pluginMetadataSnapshot } : {}),

--- a/src/agents/plugin-model-catalog.ts
+++ b/src/agents/plugin-model-catalog.ts
@@ -8,9 +8,11 @@ import { randomUUID } from "node:crypto";
 import { linkSync, readFileSync, readdirSync, renameSync, unlinkSync, type Dirent } from "node:fs";
 import path from "node:path";
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { executeSqliteQuerySync, getNodeSqliteKysely } from "../infra/kysely-sync.js";
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
+import { isProviderCatalogSourceAllowed } from "../plugins/provider-config-owner.js";
 import { withOpenClawAgentDatabaseReadOnly } from "../state/openclaw-agent-db-readonly.js";
 import type { DB as OpenClawAgentKyselyDatabase } from "../state/openclaw-agent-db.generated.js";
 import { runOpenClawAgentWriteTransaction } from "../state/openclaw-agent-db.js";
@@ -655,6 +657,7 @@ export function replacePersistedPluginModelCatalogs(params: {
 }
 
 export type PluginModelCatalogMetadataSnapshot = Pick<PluginMetadataSnapshot, "owners"> & {
+  manifestRegistry?: Pick<PluginMetadataSnapshot["manifestRegistry"], "plugins">;
   index?: {
     plugins: ReadonlyArray<{
       enabled: boolean;
@@ -745,6 +748,7 @@ export function resolvePluginModelCatalogOwnerPluginId(params: {
 /** Keeps generated catalog providers only when the catalog plugin still owns them. */
 export function filterGeneratedPluginModelCatalogProviders<T>(params: {
   catalogPluginId?: string;
+  config?: OpenClawConfig;
   parsedCatalog?: unknown;
   pluginMetadataSnapshot?: PluginModelCatalogMetadataSnapshot;
   providers: Record<string, T>;
@@ -762,7 +766,14 @@ export function filterGeneratedPluginModelCatalogProviders<T>(params: {
         resolvePluginModelCatalogOwnerPluginId({
           providerId,
           pluginMetadataSnapshot: params.pluginMetadataSnapshot,
-        }) === params.catalogPluginId
+        }) === params.catalogPluginId &&
+        isProviderCatalogSourceAllowed({
+          provider: providerId,
+          config: params.config,
+          plugin: params.pluginMetadataSnapshot?.manifestRegistry?.plugins.find(
+            (plugin) => plugin.id === params.catalogPluginId,
+          ),
+        })
       );
     }),
   );

--- a/src/agents/prepared-model-runtime.configured.ts
+++ b/src/agents/prepared-model-runtime.configured.ts
@@ -7,7 +7,10 @@ import {
   parseModelCatalogRef,
   type ModelCatalogRef,
 } from "@openclaw/model-catalog-core/model-catalog-refs";
-import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
+import {
+  findNormalizedProviderValue,
+  normalizeProviderId,
+} from "@openclaw/model-catalog-core/provider-id";
 import { MODEL_APIS } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginMetadataSnapshot } from "../plugins/plugin-metadata-snapshot.types.js";
@@ -17,7 +20,11 @@ import {
 } from "../plugins/provider-discovery.js";
 import type { ProviderRuntimeModel } from "../plugins/provider-runtime-model.types.js";
 import { resolveAgentEntry } from "./agent-scope-config.js";
-import { buildInlineProviderModels } from "./embedded-agent-runner/model.inline-provider.js";
+import {
+  buildInlineProviderModels,
+  completeInlineProviderModel,
+  type InlineModelEntry,
+} from "./embedded-agent-runner/model.inline-provider.js";
 import type { StaticModelIdMatcher } from "./embedded-agent-runner/model.static-id.js";
 import { resolveConfiguredModelHarnessRuntime } from "./harness-runtimes.js";
 import type { ModelCatalogEntry } from "./model-catalog.js";
@@ -174,6 +181,8 @@ export function collectConfiguredProviderIdsNeedingStaticCatalog(params: {
 }
 
 export function prepareConfiguredRuntimeModels(params: {
+  config: OpenClawConfig;
+  inlineProviderModels: readonly InlineModelEntry[];
   configuredModelRefs: readonly ModelCatalogRef[];
   metadataSnapshot: PluginMetadataSnapshot;
   preparedStaticProviderCatalog?: PreparedProviderStaticCatalog;
@@ -194,7 +203,7 @@ export function prepareConfiguredRuntimeModels(params: {
     seen.add(key);
     // Match request-time fallback precedence exactly: manifest/runtime-discovery rows win,
     // and the provider-static catalog fills only models absent from that surface.
-    const model =
+    let model =
       params.resolveStaticCatalogModel({ provider, modelId }) ??
       findPreparedProviderStaticCatalogModel({
         prepared: params.preparedStaticProviderCatalog,
@@ -211,6 +220,24 @@ export function prepareConfiguredRuntimeModels(params: {
           modelId,
         }),
       );
+    if (!model) {
+      const inlineModel = params.inlineProviderModels.find((candidate) =>
+        params.matchesStaticModelId({
+          candidateId: candidate.id,
+          rowProvider: candidate.provider,
+          provider,
+          modelId,
+        }),
+      );
+      const providerConfig =
+        inlineModel &&
+        findNormalizedProviderValue(params.config.models?.providers, inlineModel.provider);
+      // Excluding an implicit catalog must not discard an authored transport definition.
+      // Missing authored API metadata remains unresolved, matching request-time inline lookup.
+      if (inlineModel?.api && providerConfig) {
+        model = completeInlineProviderModel(inlineModel, providerConfig);
+      }
+    }
     if (model) {
       prepared.push({ provider, modelId, model });
     }

--- a/src/agents/prepared-model-runtime.facts.ts
+++ b/src/agents/prepared-model-runtime.facts.ts
@@ -392,6 +392,8 @@ export async function prepareWorkspaceBuildGroup(
     const agentFacts: PreparedModelRuntimeAgentFacts[] = [];
     for (const facts of agentBaseFacts) {
       const configuredRuntimeModels = prepareConfiguredRuntimeModels({
+        config: facts.input.config,
+        inlineProviderModels,
         configuredModelRefs: facts.configuredModelRefs,
         metadataSnapshot: pluginMetadataSnapshot,
         ...(preparedStaticProviderCatalog ? { preparedStaticProviderCatalog } : {}),

--- a/src/agents/provider-attribution.ts
+++ b/src/agents/provider-attribution.ts
@@ -7,7 +7,10 @@ import type {
   PluginManifestProviderEndpoint,
   PluginManifestProviderRequestProvider,
 } from "../plugins/manifest.js";
-import { normalizePluginProviderBaseUrl } from "../plugins/plugin-metadata-provider-facts.js";
+import {
+  matchesPluginProviderEndpoint,
+  normalizePluginProviderBaseUrl,
+} from "../plugins/plugin-metadata-provider-facts.js";
 import {
   getCurrentPluginMetadataSnapshotRequiredRuntime as getCurrentPluginMetadataSnapshot,
   loadPluginMetadataSnapshotRuntime as loadPluginMetadataSnapshot,
@@ -208,15 +211,6 @@ function resolveManifestProviderRequest(params: {
     : undefined;
 }
 
-function hostMatchesSuffix(host: string, suffix: string): boolean {
-  if (!suffix) {
-    return false;
-  }
-  return suffix.startsWith(".") || suffix.startsWith("-")
-    ? host.endsWith(suffix)
-    : host === suffix || host.endsWith(`.${suffix}`);
-}
-
 function buildManifestEndpointResolution(
   endpoint: PluginManifestProviderEndpoint,
   host: string,
@@ -239,13 +233,7 @@ function resolveManifestProviderEndpoint(params: {
 }): ProviderEndpointResolution | undefined {
   for (const endpoint of resolveProviderMetadataOwners(params.providerMetadataOwners)
     .providerEndpoints) {
-    if ((endpoint.hosts ?? []).includes(params.host)) {
-      return buildManifestEndpointResolution(endpoint, params.host);
-    }
-    if ((endpoint.hostSuffixes ?? []).some((suffix) => hostMatchesSuffix(params.host, suffix))) {
-      return buildManifestEndpointResolution(endpoint, params.host);
-    }
-    if (params.normalizedBaseUrl && (endpoint.baseUrls ?? []).includes(params.normalizedBaseUrl)) {
+    if (matchesPluginProviderEndpoint(endpoint, params)) {
       return buildManifestEndpointResolution(endpoint, params.host);
     }
   }

--- a/src/agents/sessions/model-registry.ts
+++ b/src/agents/sessions/model-registry.ts
@@ -7,6 +7,7 @@ import { dirname, join } from "node:path";
 import { type Static, Type } from "typebox";
 import { Compile } from "typebox/compile";
 import type { TLocalizedValidationError } from "typebox/error";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import type {
   AnthropicMessagesCompat,
   Api,
@@ -259,6 +260,7 @@ function emptyCustomModelsResult(error?: string): CustomModelsResult {
 }
 
 type ModelRegistryOptions = {
+  config?: OpenClawConfig;
   includePluginCatalogs?: boolean;
   modelsJsonContents?: string | null;
   pluginCatalogs?: readonly PersistedPluginModelCatalog[];
@@ -317,6 +319,7 @@ function mergeCompat(
  */
 export class ModelRegistry {
   private models: Model[] = [];
+  private config: OpenClawConfig | undefined;
   private providerRequestConfigs: Map<string, ProviderRequestConfig> = new Map();
   private modelRequestHeaders: Map<string, Record<string, string>> = new Map();
   private registeredProviders: Map<string, ProviderConfigInput> = new Map();
@@ -336,6 +339,7 @@ export class ModelRegistry {
     options: ModelRegistryOptions = {},
   ) {
     this.authStorage = authStorage;
+    this.config = options.config ?? options.sourceSnapshot?.config;
     this.includePluginCatalogs = options.includePluginCatalogs !== false;
     initializeModelRegistryRuntime(this);
     if (options.sourceSnapshot) {
@@ -551,6 +555,7 @@ export class ModelRegistry {
         options.requireGeneratedCatalog === true
           ? filterGeneratedPluginModelCatalogProviders({
               catalogPluginId: options.catalogPluginId,
+              config: this.config,
               parsedCatalog: parsed,
               pluginMetadataSnapshot: this.pluginMetadataSnapshot,
               providers: config.providers,

--- a/src/model-catalog/endpoint-eligibility.test.ts
+++ b/src/model-catalog/endpoint-eligibility.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isProviderCatalogSourceAllowed } from "../plugins/provider-config-owner.js";
 import { planEffectiveModelCatalogRows } from "./index.js";
 
 const registry = {
@@ -121,4 +122,18 @@ describe("provider endpoint catalog eligibility", () => {
       }).rows.map((row) => row.id),
     ).toEqual(["adapter-model"]);
   });
+  it.each(["https://NATIVE.example/v1/", "native.example/v1?ignored=1#fragment"])(
+    "normalizes endpoint-only declarations %s",
+    (baseUrl) => {
+      expect(
+        isProviderCatalogSourceAllowed({
+          provider: "fixture",
+          config: providerConfig("https://native.example/v1"),
+          plugin: {
+            providerEndpoints: [{ endpointClass: "openai-public", baseUrls: [baseUrl] }],
+          },
+        }),
+      ).toBe(true);
+    },
+  );
 });

--- a/src/model-catalog/endpoint-eligibility.test.ts
+++ b/src/model-catalog/endpoint-eligibility.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { planEffectiveModelCatalogRows } from "./index.js";
+
+const registry = {
+  plugins: [
+    {
+      id: "catalog-owner",
+      providers: ["fixture"],
+      providerEndpoints: [
+        {
+          endpointClass: "openai-public",
+          hosts: ["native.example"],
+          hostSuffixes: ["region.example"],
+        },
+      ],
+      modelCatalog: {
+        aliases: { alternate: { provider: "fixture", baseUrl: "https://alternate.example/api" } },
+        providers: {
+          fixture: {
+            baseUrl: "https://native.example/v1",
+            api: "openai-completions",
+            models: [
+              { id: "native-model", name: "Native model", baseUrl: "https://model.example/v1" },
+            ],
+          },
+        },
+      },
+    },
+  ],
+} satisfies Parameters<typeof planEffectiveModelCatalogRows>[0]["registry"];
+
+function providerConfig(baseUrl: string): OpenClawConfig {
+  return { models: { providers: { fixture: { baseUrl, models: [] } } } };
+}
+
+describe("provider endpoint catalog eligibility", () => {
+  it.each([
+    "https://native.example/v1",
+    "http://native.example:8080/compatible",
+    "https://us.region.example/v1",
+    "MODEL.example/v1/?ignored=1#fragment",
+  ])("keeps native catalog rows at the declared endpoint %s", (baseUrl) => {
+    expect(
+      planEffectiveModelCatalogRows({ registry, config: providerConfig(baseUrl) }).rows.map(
+        (row) => row.id,
+      ),
+    ).toEqual(["native-model"]);
+  });
+
+  it("excludes native manifest rows for a custom provider endpoint", () => {
+    expect(
+      planEffectiveModelCatalogRows({
+        registry,
+        config: providerConfig("https://proxy.example/v1"),
+      }),
+    ).toMatchObject({ rows: [], entries: [] });
+  });
+
+  it("keeps the alias's declared endpoint independent of the target override", () => {
+    const config = providerConfig("https://proxy.example/v1");
+    const aliasedConfig: OpenClawConfig = {
+      models: {
+        providers: {
+          ...config.models?.providers,
+          alternate: { baseUrl: "https://alternate.example/api", models: [] },
+        },
+      },
+    };
+    expect(
+      planEffectiveModelCatalogRows({
+        registry,
+        config: aliasedConfig,
+        providerFilter: "alternate",
+      }).rows.map((row) => row.ref),
+    ).toEqual(["alternate/native-model"]);
+  });
+
+  it("allows model-level overrides without a provider-level veto", () => {
+    const config: OpenClawConfig = {
+      models: {
+        providers: {
+          fixture: {
+            baseUrl: "",
+            models: [
+              {
+                id: "authored",
+                name: "Authored",
+                baseUrl: "https://proxy.example/v1",
+                reasoning: false,
+                input: ["text"],
+                cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+                maxTokens: 4096,
+              },
+            ],
+          },
+        },
+      },
+    };
+    expect(planEffectiveModelCatalogRows({ registry, config }).rows.map((row) => row.id)).toEqual([
+      "native-model",
+    ]);
+  });
+
+  it("keeps adapters with no native endpoint declaration eligible", () => {
+    const adapter = {
+      plugins: [
+        {
+          id: "adapter",
+          providers: ["fixture"],
+          modelCatalog: {
+            providers: { fixture: { models: [{ id: "adapter-model", name: "Adapter model" }] } },
+          },
+        },
+      ],
+    };
+    expect(
+      planEffectiveModelCatalogRows({
+        registry: adapter,
+        config: providerConfig("https://proxy.example/v1"),
+      }).rows.map((row) => row.id),
+    ).toEqual(["adapter-model"]);
+  });
+});

--- a/src/model-catalog/index.ts
+++ b/src/model-catalog/index.ts
@@ -1,6 +1,7 @@
 // Public model-catalog facade. Keep exports here curated so callers use the
 // normalized planning APIs instead of reaching into catalog internals.
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { isProviderCatalogSourceAllowed } from "../plugins/provider-config-owner.js";
 import {
   planManifestModelCatalogRows,
   type ManifestModelCatalogRowSelection,
@@ -18,6 +19,8 @@ export function planEffectiveModelCatalogRows(params: {
 }) {
   return planManifestModelCatalogRows({
     registry: params.registry,
+    includeProvider: (provider, plugin) =>
+      isProviderCatalogSourceAllowed({ provider, plugin, config: params.config }),
     ...(params.providerFilter ? { providerFilter: params.providerFilter } : {}),
     ...(params.providerFilters ? { providerFilters: params.providerFilters } : {}),
     ...(params.mergeKeyFilter ? { mergeKeyFilter: params.mergeKeyFilter } : {}),

--- a/src/model-catalog/manifest-planner.ts
+++ b/src/model-catalog/manifest-planner.ts
@@ -16,6 +16,7 @@ import { normalizeLowercaseStringOrEmpty } from "../../packages/normalization-co
 import { normalizeUniqueStringEntries } from "../../packages/normalization-core/src/string-normalization.js";
 
 type ManifestModelCatalogPlugin = {
+  providerEndpoints?: readonly import("../plugins/manifest-types.js").PluginManifestProviderEndpoint[];
   id: string;
   providers?: readonly string[];
   modelCatalog?: Pick<
@@ -86,6 +87,7 @@ export function planManifestModelCatalogRows(params: {
   mergeKeyFilter?: ReadonlySet<string>;
   remoteOverlay?: Readonly<Record<string, ModelCatalogProvider>>;
   resolveRemoteProvider?: (provider: string) => ModelCatalogProvider | undefined;
+  includeProvider?: (provider: string, plugin: ManifestModelCatalogPlugin) => boolean;
   selection?: ManifestModelCatalogRowSelection;
 }): ManifestModelCatalogPlan {
   const hasProviderFilter = Boolean(params.providerFilter) || params.providerFilters !== undefined;
@@ -104,6 +106,7 @@ export function planManifestModelCatalogRows(params: {
   for (const plugin of params.registry.plugins) {
     for (const entry of planManifestModelCatalogPluginEntries({
       plugin,
+      includeProvider: params.includeProvider,
       providerFilters,
       mergeKeyFilter: params.mergeKeyFilter,
       remoteOverlay: params.remoteOverlay,
@@ -176,6 +179,7 @@ export function planManifestModelCatalogRows(params: {
 
 function planManifestModelCatalogPluginEntries(params: {
   plugin: ManifestModelCatalogPlugin;
+  includeProvider: ((provider: string, plugin: ManifestModelCatalogPlugin) => boolean) | undefined;
   providerFilters: ReadonlySet<string> | undefined;
   mergeKeyFilter: ReadonlySet<string> | undefined;
   remoteOverlay: Readonly<Record<string, ModelCatalogProvider>> | undefined;
@@ -206,6 +210,9 @@ function planManifestModelCatalogPluginEntries(params: {
       ? params.resolveRemoteProvider(normalizedProvider)
       : params.remoteOverlay?.[normalizedProvider];
     return plannedProviders.flatMap((plannedProvider) => {
+      if (params.includeProvider?.(plannedProvider, params.plugin) === false) {
+        return [];
+      }
       const mergeKeyFilter = params.mergeKeyFilter;
       const selectModels = (models: ModelCatalogModel[]) =>
         mergeKeyFilter

--- a/src/plugins/plugin-metadata-provider-facts.ts
+++ b/src/plugins/plugin-metadata-provider-facts.ts
@@ -63,7 +63,12 @@ export function matchesPluginProviderEndpoint(
     (endpoint.hosts ?? []).includes(params.host) ||
     (endpoint.hostSuffixes ?? []).some((suffix) => hostMatchesSuffix(params.host, suffix)) ||
     Boolean(
-      params.normalizedBaseUrl && (endpoint.baseUrls ?? []).includes(params.normalizedBaseUrl),
+      params.normalizedBaseUrl &&
+      (endpoint.baseUrls ?? []).some(
+        (baseUrl) =>
+          baseUrl === params.normalizedBaseUrl ||
+          normalizePluginProviderBaseUrl(baseUrl) === params.normalizedBaseUrl,
+      ),
     )
   );
 }

--- a/src/plugins/plugin-metadata-provider-facts.ts
+++ b/src/plugins/plugin-metadata-provider-facts.ts
@@ -42,6 +42,32 @@ export function normalizePluginProviderBaseUrl(value: string): string | undefine
   return normalizeOptionalLowercaseString(url.toString().replace(/\/+$/, ""));
 }
 
+function hostMatchesSuffix(host: string, suffix: string): boolean {
+  if (!suffix) {
+    return false;
+  }
+  return suffix.startsWith(".") || suffix.startsWith("-")
+    ? host.endsWith(suffix)
+    : host === suffix || host.endsWith(`.${suffix}`);
+}
+
+/** Shares declared endpoint matching between request classification and catalog eligibility. */
+export function matchesPluginProviderEndpoint(
+  endpoint: PluginManifestProviderEndpoint,
+  params: {
+    host: string;
+    normalizedBaseUrl?: string;
+  },
+): boolean {
+  return (
+    (endpoint.hosts ?? []).includes(params.host) ||
+    (endpoint.hostSuffixes ?? []).some((suffix) => hostMatchesSuffix(params.host, suffix)) ||
+    Boolean(
+      params.normalizedBaseUrl && (endpoint.baseUrls ?? []).includes(params.normalizedBaseUrl),
+    )
+  );
+}
+
 function prepareProviderEndpoints(value: unknown): PluginManifestProviderEndpoint[] {
   if (!Array.isArray(value)) {
     return [];

--- a/src/plugins/provider-config-owner.ts
+++ b/src/plugins/provider-config-owner.ts
@@ -5,6 +5,54 @@ import {
 } from "@openclaw/model-catalog-core/provider-id";
 import { normalizeUniqueSingleOrTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import type { PluginManifestRecord } from "./manifest-registry.types.js";
+import {
+  matchesPluginProviderEndpoint,
+  normalizePluginProviderBaseUrl,
+} from "./plugin-metadata-provider-facts.js";
+
+/** Limits implicit catalogs to endpoints declared by their provider owner. */
+export function isProviderCatalogSourceAllowed(params: {
+  provider: string;
+  config?: OpenClawConfig;
+  plugin?: Pick<PluginManifestRecord, "modelCatalog" | "providerEndpoints">;
+}): boolean {
+  const configuredBaseUrl = findNormalizedProviderValue(
+    params.config?.models?.providers,
+    params.provider,
+  )?.baseUrl;
+  if (!configuredBaseUrl || !params.plugin) {
+    return true;
+  }
+  const catalog = params.plugin.modelCatalog;
+  const alias = findNormalizedProviderValue(catalog?.aliases, params.provider);
+  const provider = findNormalizedProviderValue(
+    catalog?.providers,
+    alias?.provider ?? params.provider,
+  );
+  const baseUrls = [
+    alias?.baseUrl,
+    provider?.baseUrl,
+    ...(provider?.models ?? []).map((model) => model.baseUrl),
+  ].filter((baseUrl): baseUrl is string => Boolean(baseUrl));
+  const endpoints = params.plugin.providerEndpoints ?? [];
+  // Adapters without native declarations keep their existing discovery contract.
+  // Authored rows do not pass through this implicit-source decision.
+  if (baseUrls.length === 0 && endpoints.length === 0) {
+    return true;
+  }
+  const normalizedBaseUrl = normalizePluginProviderBaseUrl(configuredBaseUrl);
+  if (!normalizedBaseUrl) {
+    return false;
+  }
+  const host = new URL(normalizedBaseUrl).hostname;
+  return (
+    baseUrls.some((baseUrl) => normalizePluginProviderBaseUrl(baseUrl) === normalizedBaseUrl) ||
+    endpoints.some((endpoint) =>
+      matchesPluginProviderEndpoint(endpoint, { host, normalizedBaseUrl }),
+    )
+  );
+}
 
 /** Core built-in model API ids that do not imply plugin ownership of a provider config. */
 export const CORE_BUILT_IN_MODEL_APIS = new Set([

--- a/src/plugins/provider-config-owner.ts
+++ b/src/plugins/provider-config-owner.ts
@@ -6,6 +6,7 @@ import {
 import { normalizeUniqueSingleOrTrimmedStringList } from "@openclaw/normalization-core/string-normalization";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { PluginManifestRecord } from "./manifest-registry.types.js";
+import type { PluginManifestProviderEndpoint } from "./manifest-types.js";
 import {
   matchesPluginProviderEndpoint,
   normalizePluginProviderBaseUrl,
@@ -15,7 +16,9 @@ import {
 export function isProviderCatalogSourceAllowed(params: {
   provider: string;
   config?: OpenClawConfig;
-  plugin?: Pick<PluginManifestRecord, "modelCatalog" | "providerEndpoints">;
+  plugin?: Pick<PluginManifestRecord, "modelCatalog"> & {
+    providerEndpoints?: readonly PluginManifestProviderEndpoint[];
+  };
 }): boolean {
   const configuredBaseUrl = findNormalizedProviderValue(
     params.config?.models?.providers,


### PR DESCRIPTION
Related: #136257.

## What Problem This Solves

A custom provider endpoint could advertise unsupported native models. Retained generated catalogs could also restore native rows or the previous endpoint during preparation.

## Why This Change Was Made

One provider-owned eligibility rule covers discovery, static preparation, runtime augmentation, generated catalog reads, and recovery. It shares endpoint matching and inline-model completion with existing owners. Explicit model definitions remain authoritative.

## User Impact

For a custom proxy under an existing provider ID, declare its supported models explicitly. A nonmatching provider-level endpoint excludes implicit and generated rows. Native endpoints remain eligible, and model-level overrides alone do not exclude inventory. Credentials, defaults, aliases, and model settings retain their behavior.

Consumers: catalog planning, discovery, runtime preparation, generated inventory, and recovery now apply the same endpoint rule.

## Evidence

Compiled command-line and Gateway checks verified native inventory, custom-endpoint exclusions, and explicit rows. A persisted historical catalog reproduced stale rows before the fix and excluded them afterward. Shared-provider controls retained eligible siblings. Focused tests and production checks passed. Nineteen continuous-integration jobs lost communication before recording steps; the run was not green. Credentials were synthetic and external networking blocked; inference and standalone installation were not tested.
