### PR TITLE
fix(tui): preserve published model availability

### DIFF
--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -79,7 +79,7 @@ openclaw tui --local
 
 ## Pickers + overlays
 
-- Model picker: list available models and set the session override.
+- Model picker: list the selected agent's published models and set the session override. Unavailable choices stay visible with their reason; selecting one shows guidance without changing the session. Choices with unknown availability remain selectable. Gateways predating published catalogs retain their existing selection behavior.
 - Agent picker: choose a different agent.
 - Session picker: shows up to 50 sessions for the current agent updated in the last 7 days. Use `/session <key>` to jump to an older known session.
 - Settings (`/settings`): toggle tool output expansion and thinking visibility. This panel does not control delivery.

--- a/src/tui/embedded-backend.test.ts
+++ b/src/tui/embedded-backend.test.ts
@@ -6,11 +6,17 @@ import {
   INTERNAL_RUNTIME_CONTEXT_BEGIN,
   INTERNAL_RUNTIME_CONTEXT_END,
 } from "../agents/internal-runtime-context.js";
+import type { ModelCatalogEntry } from "../agents/model-catalog.types.js";
+import type { LoadPreparedModelCatalogParams } from "../agents/prepared-model-catalog.js";
+import { setPreparedModelRuntimeAuthStore } from "../agents/prepared-model-runtime-auth.js";
+import type { PreparedModelRuntimeSnapshot } from "../agents/prepared-model-runtime.types.js";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { isEmbeddedMode, setEmbeddedMode } from "../infra/embedded-mode.js";
 import {
   clearEmbeddedPluginApprovalBroker,
   getEmbeddedPluginApprovalBroker,
 } from "../infra/embedded-plugin-approval-broker.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { parseAgentSessionKey } from "../routing/session-key.js";
 import { defaultRuntime } from "../runtime.js";
 import { AGENT_HARNESS_SESSION_KEY_RESERVED_MESSAGE } from "../sessions/agent-harness-session-key.js";
@@ -18,6 +24,7 @@ import { notifyListeners } from "../shared/listeners.js";
 import { withEnvAsync } from "../test-utils/env.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
 import type { EmbeddedTuiBackend as EmbeddedTuiBackendType } from "./embedded-backend.js";
+import type { TuiModelChoice } from "./tui-backend.js";
 
 type EmbeddedAgentResult = {
   payloads: Array<{ text: string }>;
@@ -73,15 +80,51 @@ const loadCombinedSessionStoreForGatewayMock = vi.fn((_options?: unknown) => ({
   store: {},
 }));
 const getRuntimeConfigMock = vi.fn(() => ({}));
-type CatalogLoadParams = Parameters<
-  typeof import("../gateway/server-model-catalog.js").loadGatewayModelCatalog
->[0];
-const loadGatewayModelCatalogMock = vi.fn(
-  (_params?: CatalogLoadParams): Array<{ id: string; name: string; provider: string }> => [],
+const loadPreparedModelCatalogMock = vi.fn(
+  (_params?: LoadPreparedModelCatalogParams): ModelCatalogEntry[] => [],
 );
-const buildAllowedModelSetMock = vi.fn(({ catalog }: { catalog: unknown[] }) => ({
-  allowedCatalog: catalog,
-}));
+const resolveThinkingDefaultMock = vi.fn<(...args: unknown[]) => string | undefined>();
+const buildModelsListResultMock = vi.fn(
+  async (
+    _params: Parameters<
+      typeof import("../gateway/server-methods/models-list-result.js").buildModelsListResult
+    >[0],
+  ): Promise<{ models: TuiModelChoice[] }> => ({ models: [] }),
+);
+const withPreparedModelCatalogOwnerMock = vi.fn(
+  async (
+    params: LoadPreparedModelCatalogParams,
+    read: (snapshot: PreparedModelRuntimeSnapshot) => Promise<unknown>,
+  ) => {
+    const config: OpenClawConfig = params.config ?? {};
+    const agentId = params.agentId ?? "main";
+    let active = true;
+    const snapshot: PreparedModelRuntimeSnapshot = {
+      catalogOwner: { agentId, workspaceDir: "/tmp/tui-catalog-workspace" },
+      agentId,
+      agentDir: "/tmp/tui-catalog-agent",
+      activeProjectKeys: [],
+      config,
+      observationConfig: config,
+      isCurrent: () => active,
+      authModes: {},
+      metadataSnapshot: createPluginMetadataSnapshotFixture(),
+      allowGatewaySubagentBinding: false,
+      modelCatalog: { entries: [], routeVariants: [] },
+      configuredRuntimeModels: [],
+      inlineProviderModels: [],
+      createStores() {
+        throw new Error("Catalog projection must not create execution stores");
+      },
+    };
+    setPreparedModelRuntimeAuthStore(snapshot, { version: 1, profiles: {} });
+    try {
+      return await read(snapshot);
+    } finally {
+      active = false;
+    }
+  },
+);
 const readChatHistoryPageMock = vi.fn(
   async (_params?: unknown): Promise<{ messages: unknown[] }> => ({
     messages: [],
@@ -187,32 +230,29 @@ vi.mock("../agents/context.js", () => ({
 }));
 
 vi.mock("../agents/prepared-model-runtime.js", () => ({
-  refreshPreparedModelRuntimeSnapshots: (config: unknown, options?: unknown) =>
-    refreshPreparedModelRuntimeSnapshotsMock(config, options),
+  refreshPreparedModelRuntimeSnapshots: (
+    ...args: Parameters<typeof refreshPreparedModelRuntimeSnapshotsMock>
+  ) => refreshPreparedModelRuntimeSnapshotsMock(...args),
 }));
 
 vi.mock("../agents/defaults.js", () => ({
   DEFAULT_PROVIDER: "openai",
 }));
 
-vi.mock("../agents/model-selection-shared.js", async (importOriginal) => ({
-  ...(await importOriginal<typeof import("../agents/model-selection-shared.js")>()),
-  buildAllowedModelSet: (params: { catalog: unknown[]; agentId?: string }) =>
-    buildAllowedModelSetMock(params),
+vi.mock("../agents/model-selection.js", () => ({
+  resolveThinkingDefault: (...args: unknown[]) => resolveThinkingDefaultMock(...args),
 }));
 
-vi.mock("../agents/model-selection.js", () => ({
-  buildConfiguredModelCatalog: ({ cfg }: { cfg: { models?: { providers?: unknown } } }) =>
-    Object.entries(
-      (cfg.models?.providers as Record<string, { models?: Array<{ id: string }> }>) ?? {},
-    ).flatMap(([provider, entry]) =>
-      (entry.models ?? []).map((model) => ({
-        id: `${provider}/${model.id}`,
-        name: model.id,
-        provider,
-      })),
-    ),
-  resolveThinkingDefault: () => undefined,
+vi.mock("../agents/prepared-model-catalog.js", () => ({
+  loadPreparedModelCatalog: (params?: LoadPreparedModelCatalogParams) =>
+    loadPreparedModelCatalogMock(params),
+  withPreparedModelCatalogOwner: (...args: Parameters<typeof withPreparedModelCatalogOwnerMock>) =>
+    withPreparedModelCatalogOwnerMock(...args),
+}));
+
+vi.mock("../gateway/server-methods/models-list-result.js", () => ({
+  buildModelsListResult: (...args: Parameters<typeof buildModelsListResultMock>) =>
+    buildModelsListResultMock(...args),
 }));
 
 vi.mock("../config/config.js", () => ({
@@ -284,10 +324,6 @@ vi.mock("../gateway/session-utils.js", () => ({
 
 vi.mock("../gateway/session-utils-model.js", () => ({
   projectSessionPatchResult: (...args: unknown[]) => projectSessionPatchResultMock(...args),
-}));
-
-vi.mock("../gateway/server-model-catalog.js", () => ({
-  loadGatewayModelCatalog: (params?: CatalogLoadParams) => loadGatewayModelCatalogMock(params),
 }));
 
 vi.mock("../gateway/session-create-service.js", () => ({
@@ -452,9 +488,12 @@ describe("EmbeddedTuiBackend", () => {
     );
     getRuntimeConfigMock.mockReset();
     getRuntimeConfigMock.mockReturnValue({});
-    loadGatewayModelCatalogMock.mockReset();
-    loadGatewayModelCatalogMock.mockReturnValue([]);
-    buildAllowedModelSetMock.mockClear();
+    loadPreparedModelCatalogMock.mockReset();
+    loadPreparedModelCatalogMock.mockReturnValue([]);
+    buildModelsListResultMock.mockReset();
+    buildModelsListResultMock.mockResolvedValue({ models: [] });
+    withPreparedModelCatalogOwnerMock.mockClear();
+    resolveThinkingDefaultMock.mockReset();
     readChatHistoryPageMock.mockReset();
     readChatHistoryPageMock.mockResolvedValue({ messages: [] });
     loadSessionEntryMock.mockReset();
@@ -525,6 +564,45 @@ describe("EmbeddedTuiBackend", () => {
       resolved: { modelProvider: "openai", model: "gpt-5.4" },
     });
   });
+
+  it.each([{ key: "agent:work:new" }, { key: "global", agentId: "work" }])(
+    "creates $key using its resolved owner's raw prepared catalog",
+    async (input) => {
+      const config = { agents: { ownership: "explicit", entries: { main: {}, work: {} } } };
+      getRuntimeConfigMock.mockReturnValue(config);
+      const catalog: ModelCatalogEntry[] = [
+        { id: "work-model", name: "Work", provider: "fixture", api: "openai-completions" },
+      ];
+      loadPreparedModelCatalogMock.mockReturnValue(catalog);
+      createGatewaySessionMock.mockImplementation(
+        async ({
+          loadGatewayModelCatalog,
+        }: {
+          loadGatewayModelCatalog: () => Promise<unknown[]>;
+        }) => {
+          expect(await loadGatewayModelCatalog()).toBe(catalog);
+          return {
+            ok: true,
+            key: input.key,
+            entry: { sessionId: "new-session" },
+            resolved: {},
+            resetExisting: false,
+          };
+        },
+      );
+
+      await expect(new EmbeddedTuiBackend().createSession(input)).resolves.toMatchObject({
+        ok: true,
+        key: input.key,
+      });
+      expect(loadPreparedModelCatalogMock).toHaveBeenCalledWith({
+        config,
+        agentId: "work",
+        readOnly: true,
+      });
+      expect(buildModelsListResultMock).not.toHaveBeenCalled();
+    },
+  );
 
   it("bridges assistant and lifecycle events into chat events", async () => {
     const pending = deferred<EmbeddedAgentResult>();
@@ -682,90 +760,54 @@ describe("EmbeddedTuiBackend", () => {
     expect(getEmbeddedPluginApprovalBroker()).toBeNull();
   });
 
-  it("lists configured replace-mode models without loading the gateway catalog", async () => {
-    getRuntimeConfigMock.mockReturnValue({
+  it("lists the published configured replace-mode models without a second catalog read", async () => {
+    const config = {
       models: {
-        mode: "replace",
+        mode: "replace" as const,
         providers: {
-          "tui-pty-mock": {
-            models: [{ id: "gpt-5.5" }],
+          fixture: {
+            baseUrl: "https://fixture.invalid",
+            models: [{ id: "configured", name: "Configured" }],
           },
         },
       },
-    });
+    };
+    getRuntimeConfigMock.mockReturnValue(config);
+    const models = [{ id: "configured", name: "Configured", provider: "fixture", available: true }];
+    buildModelsListResultMock.mockResolvedValue({ models });
 
-    const backend = new EmbeddedTuiBackend();
-
-    await expect(backend.listModels()).resolves.toEqual([
-      {
-        id: "tui-pty-mock/gpt-5.5",
-        name: "gpt-5.5",
-        provider: "tui-pty-mock",
-        contextWindow: undefined,
-        reasoning: undefined,
-      },
-    ]);
-    expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
-  });
-
-  it("preserves empty configured replace-mode model catalogs", async () => {
-    getRuntimeConfigMock.mockReturnValue({
-      models: {
-        mode: "replace",
-        providers: {},
-      },
-    });
-
-    const backend = new EmbeddedTuiBackend();
-
-    await expect(backend.listModels()).resolves.toEqual([]);
-    expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
-  });
-
-  it("loads the gateway catalog for replace-mode provider wildcard allowlists", async () => {
-    getRuntimeConfigMock.mockReturnValue({
-      agents: {
-        defaults: {
-          models: {
-            "tui-pty-mock/*": {},
-          },
-        },
-      },
-      models: {
-        mode: "replace",
-        providers: {
-          "tui-pty-mock": {
-            models: [{ id: "configured" }],
-          },
-        },
-      },
-    });
-    loadGatewayModelCatalogMock.mockReturnValue([
-      {
-        id: "discovered",
-        name: "discovered",
-        provider: "tui-pty-mock",
-      },
-    ]);
-
-    const backend = new EmbeddedTuiBackend();
-
-    await expect(backend.listModels()).resolves.toEqual([
-      {
-        id: "discovered",
-        name: "discovered",
-        provider: "tui-pty-mock",
-        contextWindow: undefined,
-        reasoning: undefined,
-      },
-    ]);
-    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith(
-      expect.objectContaining({ readOnly: false }),
+    await expect(new EmbeddedTuiBackend().listModels()).resolves.toEqual(models);
+    expect(loadPreparedModelCatalogMock).not.toHaveBeenCalled();
+    expect(withPreparedModelCatalogOwnerMock).toHaveBeenCalledWith(
+      { config, agentId: "main", readOnly: true },
+      expect.any(Function),
     );
   });
 
-  it("loads the selected agent catalog before applying its model policy", async () => {
+  it("preserves an empty published replace catalog without fallback discovery", async () => {
+    getRuntimeConfigMock.mockReturnValue({ models: { mode: "replace", providers: {} } });
+    await expect(new EmbeddedTuiBackend().listModels()).resolves.toEqual([]);
+    expect(loadPreparedModelCatalogMock).not.toHaveBeenCalled();
+    expect(buildModelsListResultMock).toHaveBeenCalledOnce();
+  });
+
+  it("lists published discovered rows for a replace-mode provider wildcard", async () => {
     getRuntimeConfigMock.mockReturnValue({
+      agents: { defaults: { modelPolicy: { allow: ["fixture/*"] } } },
+      models: { mode: "replace", providers: { fixture: { models: [{ id: "configured" }] } } },
+    });
+    const models = [{ id: "discovered", name: "Discovered", provider: "fixture" }];
+    buildModelsListResultMock.mockResolvedValue({ models });
+    await expect(new EmbeddedTuiBackend().listModels()).resolves.toEqual(models);
+    expect(withPreparedModelCatalogOwnerMock).toHaveBeenCalledWith(
+      expect.objectContaining({ readOnly: true }),
+      expect.any(Function),
+    );
+    expect(loadPreparedModelCatalogMock).not.toHaveBeenCalled();
+  });
+
+  it("loads the selected agent published projection with its matching owner", async () => {
+    const config = {
       agents: {
         ownership: "explicit",
         entries: {
@@ -773,30 +815,25 @@ describe("EmbeddedTuiBackend", () => {
           work: { modelPolicy: { allow: ["fixture/work-model"] } },
         },
       },
+    };
+    getRuntimeConfigMock.mockReturnValue(config);
+    buildModelsListResultMock.mockImplementation(async ({ source, agentId, params }) => {
+      expect(source.kind).toBe("published");
+      if (source.kind !== "published") {
+        throw new Error("Expected published owner");
+      }
+      expect(source.owner.agentId).toBe(agentId);
+      expect(source.owner.config).toBe(config);
+      expect(params).toEqual({ includeDetails: true });
+      const id = source.owner.agentId + "-model";
+      return { models: [{ id, name: id, provider: "fixture" }] };
     });
-    loadGatewayModelCatalogMock.mockImplementation((params) => {
-      const id = `${params?.agentId ?? "main"}-model`;
-      return [{ id, name: id, provider: "fixture" }];
-    });
-
-    const backend = new EmbeddedTuiBackend();
-
-    await expect(backend.listModels({ agentId: "work" })).resolves.toEqual([
-      {
-        id: "work-model",
-        name: "work-model",
-        provider: "fixture",
-        contextWindow: undefined,
-        reasoning: undefined,
-      },
+    await expect(new EmbeddedTuiBackend().listModels({ agentId: "work" })).resolves.toEqual([
+      { id: "work-model", name: "work-model", provider: "fixture" },
     ]);
-
-    expect(buildAllowedModelSetMock).toHaveBeenCalledWith(
-      expect.objectContaining({ agentId: "work" }),
-    );
   });
 
-  it("preserves an empty restrictive model policy for the selected agent", async () => {
+  it("preserves an empty restrictive published projection for the selected agent", async () => {
     getRuntimeConfigMock.mockReturnValue({
       agents: {
         ownership: "explicit",
@@ -806,69 +843,85 @@ describe("EmbeddedTuiBackend", () => {
         },
       },
     });
-    loadGatewayModelCatalogMock.mockReturnValue([
-      { id: "claude-sonnet", name: "Claude Sonnet", provider: "anthropic" },
-    ]);
-    buildAllowedModelSetMock.mockReturnValueOnce({ allowedCatalog: [] });
-
     await expect(new EmbeddedTuiBackend().listModels({ agentId: "work" })).resolves.toEqual([]);
-    expect(buildAllowedModelSetMock).toHaveBeenCalledWith(
+    expect(buildModelsListResultMock).toHaveBeenCalledWith(
       expect.objectContaining({ agentId: "work" }),
     );
+    expect(loadPreparedModelCatalogMock).not.toHaveBeenCalled();
   });
 
-  it("patches wildcard replace-mode sessions against the same full catalog as model listing", async () => {
-    getRuntimeConfigMock.mockReturnValue({
-      agents: {
-        defaults: {
-          models: {
-            "tui-pty-mock/*": {},
-          },
-        },
-      },
-      models: {
-        mode: "replace",
-        providers: {
-          "tui-pty-mock": {
-            models: [{ id: "configured" }],
-          },
-        },
-      },
-    });
-    loadGatewayModelCatalogMock.mockReturnValue([
+  it("preserves canonical unavailable and unknown published model facts", async () => {
+    const models: TuiModelChoice[] = [
       {
-        id: "discovered",
-        name: "discovered",
-        provider: "tui-pty-mock",
+        id: "waiting",
+        name: "Waiting",
+        provider: "fixture",
+        available: false,
+        unavailableReason: "cooldown",
       },
-    ]);
+      { id: "unknown", name: "Unknown", provider: "fixture" },
+    ];
+    buildModelsListResultMock.mockResolvedValue({ models });
+    await expect(new EmbeddedTuiBackend().listModels()).resolves.toEqual(models);
+    expect(loadPreparedModelCatalogMock).not.toHaveBeenCalled();
+  });
+
+  it("keeps the published owner alive through asynchronous model projection", async () => {
+    const projection = deferred<{ models: TuiModelChoice[] }>();
+    let current: (() => boolean) | undefined;
+    buildModelsListResultMock.mockImplementation(async ({ source }) => {
+      if (source.kind !== "published") {
+        throw new Error("Expected published owner");
+      }
+      current = source.owner.isCurrent;
+      expect(current()).toBe(true);
+      const result = await projection.promise;
+      expect(current()).toBe(true);
+      return result;
+    });
+    const pending = new EmbeddedTuiBackend().listModels();
+    await flushMicrotasks();
+    await flushMicrotasks();
+    expect(current?.()).toBe(true);
+    projection.resolve({ models: [] });
+    await expect(pending).resolves.toEqual([]);
+    expect(current?.()).toBe(false);
+  });
+
+  it("patches wildcard replace-mode sessions with raw execution catalog entries", async () => {
+    const config = {
+      agents: { defaults: { modelPolicy: { allow: ["fixture/*"] } } },
+      models: { mode: "replace" },
+    };
+    getRuntimeConfigMock.mockReturnValue(config);
+    const catalog: ModelCatalogEntry[] = [
+      { id: "discovered", name: "Discovered", provider: "fixture", api: "openai-completions" },
+    ];
+    loadPreparedModelCatalogMock.mockReturnValue(catalog);
+    const models = [{ id: "discovered", name: "Discovered", provider: "fixture", available: true }];
+    buildModelsListResultMock.mockResolvedValue({ models });
     projectSessionsPatchEntryMock.mockImplementation(
       async ({
         loadGatewayModelCatalog,
       }: {
-        loadGatewayModelCatalog?: () => Promise<unknown[]>;
+        loadGatewayModelCatalog: () => Promise<unknown[]>;
       }) => {
-        await loadGatewayModelCatalog?.();
+        expect(await loadGatewayModelCatalog()).toBe(catalog);
         return { ok: true, entry: {} };
       },
     );
-
     const backend = new EmbeddedTuiBackend();
-
+    await expect(backend.listModels()).resolves.toEqual(models);
     await expect(
-      backend.patchSession({
-        key: "agent:main:main",
-        model: "tui-pty-mock/discovered",
-      }),
-    ).resolves.toMatchObject({
-      ok: true,
-      key: "agent:main:main",
+      backend.patchSession({ key: "agent:main:main", model: "fixture/discovered" }),
+    ).resolves.toMatchObject({ ok: true, key: "agent:main:main" });
+    expect(loadPreparedModelCatalogMock).toHaveBeenCalledWith({
+      config,
+      agentId: "main",
+      readOnly: true,
     });
     expect(applySessionPatchProjectionMock).toHaveBeenCalledWith(
       expect.objectContaining({ sessionKeys: ["agent:main:main"] }),
-    );
-    expect(loadGatewayModelCatalogMock).toHaveBeenCalledWith(
-      expect.objectContaining({ agentId: "main", readOnly: false }),
     );
   });
 
@@ -1017,7 +1070,7 @@ describe("EmbeddedTuiBackend", () => {
     });
   });
 
-  it("publishes a static configured runtime before admitting the first local turn", async () => {
+  it("publishes the configured runtime before admitting the first local turn", async () => {
     const initialConfig = { agents: { list: [{ id: "main" }] } };
     getRuntimeConfigMock.mockReturnValue(initialConfig);
     const publication = deferred<void>();
@@ -1029,13 +1082,11 @@ describe("EmbeddedTuiBackend", () => {
     const send = backend.sendChat({
       sessionKey: "agent:main:main",
       message: "hello",
-      runId: "run-waits-for-static-runtime",
+      runId: "run-waits-for-published-runtime",
     });
     await flushMicrotasks();
 
-    expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenCalledWith(initialConfig, {
-      catalogMode: "static",
-    });
+    expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenCalledWith(initialConfig);
     expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
 
     publication.resolve();
@@ -1064,9 +1115,7 @@ describe("EmbeddedTuiBackend", () => {
     });
     await flushMicrotasks();
 
-    expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenLastCalledWith(nextConfig, {
-      catalogMode: "static",
-    });
+    expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenLastCalledWith(nextConfig);
     expect(agentCommandFromIngressMock).not.toHaveBeenCalled();
 
     replacement.resolve();
@@ -1099,12 +1148,8 @@ describe("EmbeddedTuiBackend", () => {
       configWriteListener?.({ runtimeConfig: latestConfig });
       await flushMicrotasks();
 
-      expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenNthCalledWith(2, middleConfig, {
-        catalogMode: "static",
-      });
-      expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenNthCalledWith(3, latestConfig, {
-        catalogMode: "static",
-      });
+      expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenNthCalledWith(2, middleConfig);
+      expect(refreshPreparedModelRuntimeSnapshotsMock).toHaveBeenNthCalledWith(3, latestConfig);
     } finally {
       initial.resolve();
       middle.resolve();
@@ -1273,7 +1318,12 @@ describe("EmbeddedTuiBackend", () => {
     },
   );
 
-  it("loads history thinking defaults from configured replace-mode models", async () => {
+  it("loads history thinking defaults from the selected owner's prepared catalog", async () => {
+    const catalog: ModelCatalogEntry[] = [
+      { id: "gpt-5.4", name: "Reasoning model", provider: "openai", reasoning: true },
+    ];
+    loadPreparedModelCatalogMock.mockReturnValue(catalog);
+    resolveThinkingDefaultMock.mockReturnValueOnce("low");
     loadSessionEntryMock.mockReturnValue({
       cfg: {
         models: {
@@ -1295,9 +1345,14 @@ describe("EmbeddedTuiBackend", () => {
     await expect(backend.loadHistory({ sessionKey: "agent:main:main" })).resolves.toMatchObject({
       sessionKey: "agent:main:main",
       messages: [],
-      thinkingLevel: undefined,
+      thinkingLevel: "low",
     });
-    expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
+    expect(loadPreparedModelCatalogMock).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "main", readOnly: true }),
+    );
+    expect(resolveThinkingDefaultMock).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "openai", model: "gpt-5.4", catalog }),
+    );
   });
 
   it.each(selectedGlobalSessionCases)(
@@ -1506,16 +1561,16 @@ describe("EmbeddedTuiBackend", () => {
     backend.start();
     const choices = backend.listModels({ agentId: "work" });
     await flushMicrotasks();
-    expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
+    expect(withPreparedModelCatalogOwnerMock).not.toHaveBeenCalled();
 
     configWriteListener?.({ runtimeConfig: {} });
     initial.resolve();
     await flushMicrotasks();
-    expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
+    expect(withPreparedModelCatalogOwnerMock).not.toHaveBeenCalled();
 
-    loadGatewayModelCatalogMock.mockReturnValue([
-      { provider: "fixture", id: "updated", name: "Updated" },
-    ]);
+    buildModelsListResultMock.mockResolvedValue({
+      models: [{ provider: "fixture", id: "updated", name: "Updated" }],
+    });
     replacement.resolve();
     await expect(choices).resolves.toMatchObject([{ id: "updated" }]);
     await backend.stop();
@@ -1531,7 +1586,7 @@ describe("EmbeddedTuiBackend", () => {
 
     publication.reject(new Error("catalog publication failed"));
     await failure;
-    expect(loadGatewayModelCatalogMock).not.toHaveBeenCalled();
+    expect(withPreparedModelCatalogOwnerMock).not.toHaveBeenCalled();
     await backend.stop();
   });
 

--- a/src/tui/embedded-backend.ts
+++ b/src/tui/embedded-backend.ts
@@ -12,7 +12,6 @@ import {
   isDefinitiveRunLifecycle,
   type AgentRunTerminalOutcome,
 } from "../agents/agent-run-terminal-outcome.js";
-import { listAgentEntries } from "../agents/agent-scope-config.js";
 import {
   resolveAgentDir,
   resolveAgentWorkspaceDir,
@@ -20,12 +19,16 @@ import {
   resolveSessionAgentId,
 } from "../agents/agent-scope.js";
 import { ensureContextWindowCacheLoaded } from "../agents/context.js";
-import { DEFAULT_PROVIDER } from "../agents/defaults.js";
 import { resolveActiveEmbeddedRunSessionId } from "../agents/embedded-agent-runner/active-run-projections.js";
 import { queueEmbeddedAgentMessageWithOutcomeAsync } from "../agents/embedded-agent-runner/runs.js";
 import { QuestionAnswerUnconfirmedError } from "../agents/harness/gateway-question-dispatch.js";
-import { createModelCatalogView } from "../agents/model-catalog-view.js";
-import { buildConfiguredModelCatalog, resolveThinkingDefault } from "../agents/model-selection.js";
+import { resolveThinkingDefault } from "../agents/model-selection.js";
+import { resolvePublishedModelCatalogOwner } from "../agents/prepared-model-catalog-owner.js";
+import {
+  loadPreparedModelCatalog,
+  withPreparedModelCatalogOwner,
+} from "../agents/prepared-model-catalog.js";
+import { getPreparedModelRuntimeAuthMaterializations } from "../agents/prepared-model-runtime-auth.js";
 import { loadAgentRuntimePluginRegistryHandle } from "../agents/runtime-plugins.js";
 import { readToolValidationErrorSummary } from "../agents/tool-error-summary.js";
 import { resolveTextCommand } from "../auto-reply/commands-registry.js";
@@ -64,7 +67,7 @@ import {
   CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES,
   replaceOversizedChatHistoryMessages,
 } from "../gateway/server-methods/chat.js";
-import { loadGatewayModelCatalog } from "../gateway/server-model-catalog.js";
+import { buildModelsListResult } from "../gateway/server-methods/models-list-result.js";
 import { createGatewaySession } from "../gateway/session-create-service.js";
 import { performGatewaySessionReset } from "../gateway/session-reset-service.js";
 import { capArrayByJsonBytes } from "../gateway/session-transcript-readers.js";
@@ -178,16 +181,6 @@ const embeddedSessionStartupMigrationLog = {
   warn: (message: string) => logWarn(message, silentRuntime),
 };
 
-function hasProviderWildcardModelAllowlist(cfg: OpenClawConfig) {
-  const modelMaps = [
-    cfg.agents?.defaults?.models,
-    ...listAgentEntries(cfg).map((agent) => agent.models),
-  ];
-  return modelMaps.some((models) =>
-    Object.keys(models ?? {}).some((key) => key.trim().endsWith("/*")),
-  );
-}
-
 function ensureEmbeddedHistoryRuntimePluginsLoaded(params: {
   cfg: OpenClawConfig;
   sessionAgentId: string;
@@ -202,20 +195,6 @@ function ensureEmbeddedHistoryRuntimePluginsLoaded(params: {
   } catch (err) {
     return { status: "failed", error: formatTuiErrorMessage(err) };
   }
-}
-
-async function loadEmbeddedModelCatalogView(cfg: OpenClawConfig, agentId?: string) {
-  const replaceMode = cfg.models?.mode === "replace";
-  const fullDiscovery = replaceMode && hasProviderWildcardModelAllowlist(cfg);
-  const catalog =
-    replaceMode && !fullDiscovery
-      ? buildConfiguredModelCatalog({ cfg })
-      : await loadGatewayModelCatalog({
-          agentId,
-          getConfig: () => cfg,
-          ...(fullDiscovery ? { readOnly: false } : {}),
-        });
-  return createModelCatalogView({ cfg, catalog });
 }
 
 function resolveBtwQuestion(message: string): string | undefined {
@@ -685,7 +664,11 @@ export class EmbeddedTuiBackend implements TuiBackend {
 
     let thinkingLevel = entry?.thinkingLevel;
     if (!thinkingLevel) {
-      const { catalog } = await loadEmbeddedModelCatalogView(cfg, sessionAgentId);
+      const catalog = await loadPreparedModelCatalog({
+        config: cfg,
+        agentId: sessionAgentId,
+        readOnly: true,
+      });
       thinkingLevel = resolveThinkingDefault({
         cfg,
         provider: resolvedSessionModel.provider,
@@ -772,8 +755,8 @@ export class EmbeddedTuiBackend implements TuiBackend {
           storeKey: primaryKey,
           agentId: target.agentId,
           patch: opts,
-          loadGatewayModelCatalog: async () =>
-            (await loadEmbeddedModelCatalogView(cfg, target.agentId)).catalog,
+          loadGatewayModelCatalog: () =>
+            loadPreparedModelCatalog({ config: cfg, agentId: target.agentId, readOnly: true }),
         }),
     });
     if (!applied.ok) {
@@ -824,13 +807,16 @@ export class EmbeddedTuiBackend implements TuiBackend {
       armSessionDiffBaselineCapture: true,
       emitCommandHooks: Boolean(opts.parentSessionKey),
       commandSource: "tui:embedded",
-      loadGatewayModelCatalog: async () =>
-        (
-          await loadEmbeddedModelCatalogView(
-            cfg,
-            resolveSessionAgentId({ sessionKey: opts.key, config: cfg, agentId: opts.agentId }),
-          )
-        ).catalog,
+      loadGatewayModelCatalog: () =>
+        loadPreparedModelCatalog({
+          config: cfg,
+          agentId: resolveSessionAgentId({
+            sessionKey: opts.key,
+            config: cfg,
+            agentId: opts.agentId,
+          }),
+          readOnly: true,
+        }),
     });
     if (!result.ok) {
       throw new Error(result.error.message);
@@ -916,16 +902,24 @@ export class EmbeddedTuiBackend implements TuiBackend {
     await this.ready;
     await this.preparedModelRuntime.waitUntilReady();
     const cfg = getRuntimeConfig();
-    const view = await loadEmbeddedModelCatalogView(cfg, opts?.agentId);
-    return view
-      .selectAgent({ defaultProvider: DEFAULT_PROVIDER, agentId: opts?.agentId })
-      .map((entry) => ({
-        id: entry.id,
-        name: entry.name ?? entry.id,
-        provider: entry.provider,
-        contextWindow: entry.contextWindow,
-        reasoning: entry.reasoning,
-      }));
+    const agentId = opts?.agentId ?? resolveDefaultAgentId(cfg);
+    return await withPreparedModelCatalogOwner(
+      { config: cfg, agentId, readOnly: true },
+      async (snapshot) =>
+        (
+          await buildModelsListResult({
+            source: {
+              kind: "published",
+              owner: {
+                ...resolvePublishedModelCatalogOwner(snapshot),
+                authMaterializations: getPreparedModelRuntimeAuthMaterializations(snapshot),
+              },
+            },
+            agentId,
+            params: { includeDetails: true },
+          })
+        ).models,
+    );
   }
 
   async runGoalCommand(opts: Parameters<NonNullable<TuiBackend["runGoalCommand"]>>[0]) {

--- a/src/tui/embedded-prepared-runtime.test.ts
+++ b/src/tui/embedded-prepared-runtime.test.ts
@@ -22,7 +22,7 @@ describe("EmbeddedPreparedModelRuntimeHost", () => {
     await resetPreparedModelRuntimeHarness(state);
   });
 
-  it("reuses its configured publication across two actual run admissions", async () => {
+  it("reuses its live publication across two actual run admissions", async () => {
     mocks.configuredAgentIds = ["default"];
     const config = { agents: { defaults: { model: { primary: "openai/gpt-5.5" } } } };
     const host = new EmbeddedPreparedModelRuntimeHost();
@@ -38,12 +38,13 @@ describe("EmbeddedPreparedModelRuntimeHost", () => {
       runtimePluginSelections: [{ provider: "openai", modelId: "gpt-5.5", agentId: "default" }],
     };
     const first = await acquireAgentRunPreparedModelRuntime(input);
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(1);
     first.release();
     const second = await acquireAgentRunPreparedModelRuntime(input);
     second.release();
 
     expect(second.snapshot).toBe(first.snapshot);
-    expect(mocks.ensureOpenClawModelsJson).not.toHaveBeenCalled();
+    expect(mocks.ensureOpenClawModelsJson).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/tui/embedded-prepared-runtime.ts
+++ b/src/tui/embedded-prepared-runtime.ts
@@ -8,7 +8,7 @@ export class EmbeddedPreparedModelRuntimeHost {
   publish(config: OpenClawConfig): void {
     // The runtime layer synchronously stales the prior generation and coalesces queued requests.
     // Invoke it immediately so overlapping config writes retain those latest-wins semantics.
-    this.ready = refreshPreparedModelRuntimeSnapshots(config, { catalogMode: "static" });
+    this.ready = refreshPreparedModelRuntimeSnapshots(config);
   }
 
   async waitUntilReady(): Promise<void> {

--- a/src/tui/gateway-chat.test.ts
+++ b/src/tui/gateway-chat.test.ts
@@ -1,13 +1,69 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { GATEWAY_SERVER_CAPS } from "../../packages/gateway-protocol/src/server-capabilities.js";
 // Covers gateway-backed chat behavior used by the TUI backend.
 
 const { GatewayChatClient } = await import("./gateway-chat.js");
-const { GatewayClientRequestError } = await import("../gateway/client.js");
+const { GatewayClient, GatewayClientRequestError } = await import("../gateway/client.js");
 
 describe("GatewayChatClient", () => {
   afterEach(() => {
     vi.useRealTimers();
   });
+
+  it.each([true, false])(
+    "preserves model availability semantics for published-catalog capability %s",
+    async (published) => {
+      const models = [
+        {
+          provider: "fixture",
+          id: "waiting",
+          name: "Waiting",
+          available: false,
+          unavailableReason: "cooldown",
+        },
+        { provider: "fixture", id: "unknown", name: "Unknown" },
+      ];
+      const request = vi.spyOn(GatewayClient.prototype, "request").mockResolvedValue({ models });
+      try {
+        const client = new GatewayChatClient({ url: "ws://127.0.0.1:18789", token: "test-token" });
+        client.hello = {
+          type: "hello-ok",
+          protocol: 3,
+          server: { version: "test", connId: "catalog-test" },
+          features: {
+            methods: ["models.list"],
+            events: [],
+            capabilities: published ? [GATEWAY_SERVER_CAPS.PUBLISHED_MODEL_CATALOG] : [],
+          },
+          snapshot: {
+            presence: [],
+            health: {},
+            stateVersion: { presence: 0, health: 0 },
+            uptimeMs: 0,
+          },
+          auth: { role: "operator", scopes: ["operator.admin"] },
+          policy: { maxPayload: 1024, maxBufferedBytes: 1024, tickIntervalMs: 1000 },
+        };
+
+        const result = await client.listModels({ agentId: "work" });
+
+        expect(request).toHaveBeenCalledExactlyOnceWith("models.list", {
+          agentId: "work",
+          ...(published ? { includeDetails: true } : {}),
+        });
+        expect(result).toEqual(
+          published
+            ? models
+            : [
+                { provider: "fixture", id: "waiting", name: "Waiting" },
+                { provider: "fixture", id: "unknown", name: "Unknown" },
+              ],
+        );
+      } finally {
+        request.mockRestore();
+      }
+    },
+  );
 
   it("waits for gateway transport teardown on stop", async () => {
     const client = new GatewayChatClient({

--- a/src/tui/gateway-chat.ts
+++ b/src/tui/gateway-chat.ts
@@ -26,6 +26,7 @@ import {
   type TaskSuggestionsAcceptResult,
   type TaskSuggestionsListResult,
 } from "../../packages/gateway-protocol/src/index.js";
+import { GATEWAY_SERVER_CAPS } from "../../packages/gateway-protocol/src/server-capabilities.js";
 import { isRetryableGatewayStartupUnavailableError } from "../../packages/gateway-protocol/src/startup-unavailable.js";
 import { getRuntimeConfig } from "../config/config.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
@@ -442,8 +443,18 @@ export class GatewayChatClient implements TuiBackend {
   }
 
   async listModels(opts?: { agentId?: string }): Promise<GatewayModelChoice[]> {
-    const res = await this.client.request("models.list", opts ?? {});
-    return Array.isArray(res?.models) ? res.models : [];
+    const published = this.hello?.features.capabilities?.includes(
+      GATEWAY_SERVER_CAPS.PUBLISHED_MODEL_CATALOG,
+    );
+    const res = await this.client.request("models.list", {
+      ...opts,
+      ...(published ? { includeDetails: true } : {}),
+    });
+    const models: GatewayModelChoice[] = Array.isArray(res?.models) ? res.models : [];
+    // Released Gateways reject includeDetails and collapse unknown availability to false.
+    return published
+      ? models
+      : models.map(({ available: _available, unavailableReason: _reason, ...model }) => model);
   }
 
   async listCommands(opts?: CommandsListParams): Promise<CommandEntry[]> {

--- a/src/tui/model-catalog-availability.test.ts
+++ b/src/tui/model-catalog-availability.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import type { ModelDefinitionConfig } from "../config/types.models.js";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import { buildModelsListResult } from "../gateway/server-methods/models-list-result.js";
 import {
@@ -7,6 +8,18 @@ import {
 } from "../gateway/server-methods/models-list-result.openai-routes.test-support.js";
 import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+
+function configuredModel(name: string): ModelDefinitionConfig {
+  return {
+    id: "choice",
+    name,
+    reasoning: false,
+    input: ["text"],
+    cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    contextWindow: 32768,
+    maxTokens: 4096,
+  };
+}
 
 describe("terminal model catalog availability", () => {
   it("keeps ready, unavailable and unknown published facts distinct", async () => {
@@ -27,18 +40,18 @@ describe("terminal model catalog availability", () => {
                 baseUrl: "https://ready.invalid/v1",
                 api: "openai-completions",
                 apiKey: "synthetic-ready-key",
-                models: [{ id: "choice", name: "Ready" }],
+                models: [configuredModel("Ready")],
               },
               waiting: {
                 baseUrl: "https://waiting.invalid/v1",
                 api: "openai-completions",
                 auth: "api-key",
-                models: [{ id: "choice", name: "Waiting" }],
+                models: [configuredModel("Waiting")],
               },
               unknown: {
                 baseUrl: "https://unknown.invalid/v1",
                 api: "openai-completions",
-                models: [{ id: "choice", name: "Unknown" }],
+                models: [configuredModel("Unknown")],
               },
             },
           },

--- a/src/tui/model-catalog-availability.test.ts
+++ b/src/tui/model-catalog-availability.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { buildModelsListResult } from "../gateway/server-methods/models-list-result.js";
+import {
+  createModelsListTestContext,
+  providerCatalogEntry,
+} from "../gateway/server-methods/models-list-result.openai-routes.test-support.js";
+import { createPluginMetadataSnapshotFixture } from "../plugins/plugin-metadata.test-support.js";
+import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
+
+describe("terminal model catalog availability", () => {
+  it("keeps ready, unavailable and unknown published facts distinct", async () => {
+    await withOpenClawTestState(
+      { layout: "state-only", prefix: "terminal-catalog-facts-" },
+      async (state) => {
+        const config: OpenClawConfig = {
+          agents: {
+            defaults: {
+              model: { primary: "ready/choice" },
+              modelPolicy: { allow: ["ready/choice", "waiting/choice", "unknown/choice"] },
+            },
+          },
+          models: {
+            mode: "replace",
+            providers: {
+              ready: {
+                baseUrl: "https://ready.invalid/v1",
+                api: "openai-completions",
+                apiKey: "synthetic-ready-key",
+                models: [{ id: "choice", name: "Ready" }],
+              },
+              waiting: {
+                baseUrl: "https://waiting.invalid/v1",
+                api: "openai-completions",
+                auth: "api-key",
+                models: [{ id: "choice", name: "Waiting" }],
+              },
+              unknown: {
+                baseUrl: "https://unknown.invalid/v1",
+                api: "openai-completions",
+                models: [{ id: "choice", name: "Unknown" }],
+              },
+            },
+          },
+          plugins: { enabled: false },
+        };
+        const context = createModelsListTestContext({
+          cfg: config,
+          agentDir: state.agentDir(),
+          workspaceDir: state.workspaceDir,
+          metadataSnapshot: createPluginMetadataSnapshotFixture(),
+          catalog: ["ready", "waiting", "unknown"].map((provider) =>
+            providerCatalogEntry(provider, "choice"),
+          ),
+        });
+
+        const { models } = await buildModelsListResult({
+          source: { kind: "gateway", context },
+          agentId: "main",
+          params: { includeDetails: true },
+        });
+
+        expect(models.find((model) => model.provider === "ready")).toMatchObject({
+          available: true,
+        });
+        expect(models.find((model) => model.provider === "waiting")).toMatchObject({
+          available: false,
+          unavailableReason: "auth-failed",
+        });
+        expect(models.find((model) => model.provider === "unknown")).not.toHaveProperty(
+          "available",
+        );
+      },
+    );
+  });
+});

--- a/src/tui/tui-backend.ts
+++ b/src/tui/tui-backend.ts
@@ -3,6 +3,7 @@ import type { FastMode } from "@openclaw/normalization-core/string-coerce";
 import type {
   CommandEntry,
   CommandsListParams,
+  ModelChoice,
   SessionsListParams,
   SessionsPatchParams,
   SessionsPatchResult,
@@ -140,13 +141,10 @@ export type TuiAgentsList = {
 };
 
 /** Model choice payload shown by TUI model pickers. */
-export type TuiModelChoice = {
-  id: string;
-  name: string;
-  provider: string;
-  contextWindow?: number;
-  reasoning?: boolean;
-};
+export type TuiModelChoice = Pick<
+  ModelChoice,
+  "id" | "name" | "provider" | "contextWindow" | "reasoning" | "available" | "unavailableReason"
+>;
 
 /** Result shape returned by session mutation commands. */
 export type TuiSessionMutationResult = {

--- a/src/tui/tui-command-handlers.test.ts
+++ b/src/tui/tui-command-handlers.test.ts
@@ -3298,6 +3298,68 @@ describe("tui command handlers", () => {
     expect(addSystem).toHaveBeenCalledWith("fast mode: auto");
   });
 
+  it.each([
+    { reason: "missing-auth", guidance: "Run openclaw models auth login or choose another model." },
+    { reason: "auth-failed", guidance: "Run openclaw models auth login or choose another model." },
+    { reason: "cooldown", guidance: "Wait and retry, or choose another model." },
+    { reason: undefined, guidance: "Run openclaw models auth login or choose another model." },
+  ])(
+    "keeps unavailable model availability $reason visible without applying it",
+    async ({ reason, guidance }) => {
+      const harness = createHarness({
+        listModels: vi.fn().mockResolvedValue([
+          {
+            provider: "fixture",
+            id: "waiting",
+            name: "Waiting model",
+            available: false,
+            unavailableReason: reason,
+          },
+          { provider: "fixture", id: "ready", name: "Ready model", available: true },
+        ]),
+      });
+
+      await harness.handleCommand("/model");
+
+      const selector = firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay;
+      const unavailable = expectDefined(
+        selector.items?.find((item) => item.value === "fixture/waiting"),
+        "unavailable model option",
+      );
+      selector.onSelect?.(unavailable);
+      await flushAsyncSelect();
+
+      expect(harness.patchSession).not.toHaveBeenCalled();
+      expect(unavailable.description).toContain(reason ?? "unavailable");
+      expect(harness.addSystem).toHaveBeenCalledWith(
+        `model unavailable: ${reason ?? "unavailable"}. ${guidance}`,
+      );
+    },
+  );
+
+  it.each([true, undefined])(
+    "applies model availability %s without changing its reference",
+    async (available) => {
+      const harness = createHarness({
+        listModels: vi
+          .fn()
+          .mockResolvedValue([
+            { provider: "fixture", id: "ready", name: "Ready model", available },
+          ]),
+      });
+
+      await harness.handleCommand("/model");
+      const selector = firstMockArg(harness.openOverlay, "openOverlay") as SelectableOverlay;
+      selector.onSelect?.(expectDefined(selector.items?.[0], "model option"));
+      await flushAsyncSelect();
+
+      expect(harness.patchSession).toHaveBeenCalledExactlyOnceWith({
+        key: "agent:main:main",
+        model: "fixture/ready",
+      });
+    },
+  );
+
   it("uses canonical model refs in the model selector", async () => {
     const listModels = vi.fn().mockResolvedValue([
       {

--- a/src/tui/tui-command-handlers.ts
+++ b/src/tui/tui-command-handlers.ts
@@ -353,13 +353,30 @@ export function createCommandHandlers(context: CommandHandlerContext) {
         return {
           value: ref,
           label: ref,
-          description: model.name && model.name !== model.id ? model.name : "",
+          description: [
+            model.name !== model.id ? model.name : "",
+            model.available === false ? (model.unavailableReason ?? "unavailable") : "",
+          ]
+            .filter(Boolean)
+            .join(" · "),
         };
       });
       openSelector(
         createSearchableSelectList(items, 9),
-        (value) =>
-          applySessionSetting({ model: value }, `model set to ${value}`, "model set failed"),
+        async (value) => {
+          const model = models.find((entry) => modelKey(entry.provider, entry.id) === value);
+          if (model?.available === false) {
+            const guidance =
+              model.unavailableReason === "cooldown"
+                ? "Wait and retry, or choose another model."
+                : "Run openclaw models auth login or choose another model.";
+            chatLog.addSystem(
+              `model unavailable: ${model.unavailableReason ?? "unavailable"}. ${guidance}`,
+            );
+            return;
+          }
+          await applySessionSetting({ model: value }, `model set to ${value}`, "model set failed");
+        },
         request,
       );
     } catch (err) {


### PR DESCRIPTION
Related: #139880.

## What Problem This Solves

The terminal picker lost published availability and submitted known unavailable choices as session changes. Embedded mode also maintained separate discovery and filtering.

## Why This Change Was Made

Both terminal backends use the selected agent's published model facts. Display projection retains its prepared owner, while embedded history, patch, and creation use raw prepared entries. Unavailable selection returns before session mutation.

## User Impact

Unavailable choices remain visible with a reason and recovery guidance. Available and unknown choices can still be selected. Older Gateways retain their supported request and selection behavior.

Consumers: terminal model display and selection, plus embedded session operations, now share published catalog facts.

## Evidence

The original selector failed the unavailable-selection regression; all 45 focused cases passed after repair. Four compiled local-terminal scenarios covered replacement, wildcards, another agent's restrictive policy, and empty inventory. Separate session-list commands confirmed saved selections and unchanged state after refusals. Continuous integration passed after one infrastructure retry. Public checks did not cover populated-history refusal or in-flight replacement; those retain owner-level coverage. Live inference, native accounts, and standalone installation were not tested.
