### PR TITLE
test(scripts): source install.sh under system Bash in stdin isolation cases

### DIFF
--- a/test/scripts/install-sh.test.ts
+++ b/test/scripts/install-sh.test.ts
@@ -3342,7 +3342,7 @@ EOF
         { HOME: home, PATH: "/usr/bin:/bin", SHELL: "/bin/bash" },
       );
       const interactive = spawnSync(
-        "bash",
+        "/bin/bash",
         ["-ic", "printf 'openclaw-path=%s\\n' \"$(command -v openclaw)\""],
         {
           encoding: "utf8",
@@ -3350,7 +3350,7 @@ EOF
         },
       );
       const login = spawnSync(
-        "bash",
+        "/bin/bash",
         ["--noprofile", "--norc", "-c", '. "$HOME/.profile"; command -v openclaw'],
         {
           encoding: "utf8",
@@ -4779,7 +4779,7 @@ describe("install.sh duplicate OpenClaw install detection", () => {
 
   it("needs_stdin_isolation returns true when stdin is piped", () => {
     const result = spawnSync(
-      "bash",
+      "/bin/bash",
       [
         "-c",
         `source "${SCRIPT_PATH}" && needs_stdin_isolation && echo "ISOLATED" || echo "INTERACTIVE"`,
@@ -4872,7 +4872,7 @@ describe("install.sh duplicate OpenClaw install detection", () => {
     const marker = join(dir, "stdin-state");
     try {
       const result = spawnSync(
-        "bash",
+        "/bin/bash",
         [
           "-c",
           `source "${SCRIPT_PATH}" && GUM="" && run_quiet_step "test-step" bash -c 'if read -t 1 line 2>/dev/null && [ -n "$line" ]; then echo "LEAKED:$line" > ${JSON.stringify(marker)}; else echo ISOLATED > ${JSON.stringify(marker)}; fi'`,
@@ -4908,7 +4908,7 @@ describe("install.sh duplicate OpenClaw install detection", () => {
     const marker = join(dir, "stdin-state");
     try {
       const result = spawnSync(
-        "bash",
+        "/bin/bash",
         [
           "-c",
           // Bypass run_quiet_step: call the child directly with inherited stdin
@@ -4943,7 +4943,7 @@ describe("install.sh duplicate OpenClaw install detection", () => {
     const marker = join(dir, "stdin-state");
     try {
       const result = spawnSync(
-        "bash",
+        "/bin/bash",
         [
           "-c",
           `source "${SCRIPT_PATH}" && GUM="" && run_quiet_step "test-step" bash -c 'output=$(cat); if [ -n "$output" ]; then echo "LEAKED" > ${JSON.stringify(marker)}; else echo "ISOLATED" > ${JSON.stringify(marker)}; fi'`,


### PR DESCRIPTION
## What Problem This Solves

`test/scripts/install-sh.test.ts` has six cases that spawn bare `bash` to source `scripts/install.sh`. Since #141884 (landed today), a Darwin Bash 5.3+ process that sources the installer prints "Run this installer with /bin/bash on macOS instead of sourcing it." and returns 1. On any Mac where Homebrew Bash is first in `PATH`, the four piped-stdin isolation cases now fail deterministically (`INTERACTIVE` instead of `ISOLATED`, exit 1 instead of 0) while the file's own `runInstallShell` helper already pins `/bin/bash`.

## Why This Change Was Made

Use the same interpreter everywhere the test sources the installer, matching the helper and the installer's supported macOS interpreter. The two `setpriv` cases keep `bash` because they only run on Linux under a dropped-privilege wrapper.

## User Impact

None at runtime; test-only. Maintainers on macOS with Homebrew Bash get a green `install-sh` suite again.

## Evidence

- `node scripts/run-vitest.mjs test/scripts/install-sh.test.ts` on macOS with `/opt/homebrew/bin/bash` (5.3.15) first in `PATH`: 4 failed / 187 passed on `main`; 191/191 with this change.
- `node scripts/check-changed.mjs`: pass.

Production LOC delta: 0.
