### PR TITLE
fix(macos): make openclaw-mac configure-remote honor app profiles

### DIFF
--- a/apps/macos/Sources/OpenClawMacCLI/ConfigureRemoteCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/ConfigureRemoteCommand.swift
@@ -3,7 +3,6 @@ import Foundation
 import Darwin
 #endif
 
-private let appDefaultsSuites = ["ai.openclaw.mac", "ai.openclaw.mac.debug"]
 private let appOnboardingVersion = 7
 
 struct ConfigureRemoteOptions {
@@ -104,7 +103,7 @@ struct ConfigureRemoteOutput: Encodable {
     var onboardingSkipped: Bool
 }
 
-func runConfigureRemote(_ args: [String]) {
+func runConfigureRemote(_ args: [String], context: MacCLIContext) {
     do {
         let opts = try ConfigureRemoteOptions.parse(args)
         if opts.help {
@@ -122,6 +121,7 @@ func runConfigureRemote(_ args: [String]) {
             Offline preconfiguration; prefer openclaw-mac primary set when the app is running.
 
             Options:
+              --profile <name>   App profile; overrides OPENCLAW_PROFILE (default: default).
               --ssh-target <t>    SSH target for the remote gateway host.
               --direct-url <url>  Direct remote gateway URL; skips SSH tunneling.
               --local-port <p>    Local tunnel port for the mac app/UI. Default: 18789.
@@ -144,7 +144,7 @@ func runConfigureRemote(_ args: [String]) {
             """)
             return
         }
-        let output = try configureRemote(opts)
+        let output = try configureRemote(opts, configURL: context.configURL, defaultsSuites: context.defaultsSuites)
         printConfigureRemoteOutput(output, json: opts.json)
     } catch {
         if args.contains("--json") {
@@ -159,7 +159,8 @@ func runConfigureRemote(_ args: [String]) {
 @discardableResult
 func configureRemote(
     _ opts: ConfigureRemoteOptions,
-    defaultsSuites: [String] = appDefaultsSuites) throws -> ConfigureRemoteOutput
+    configURL: URL,
+    defaultsSuites: [String]) throws -> ConfigureRemoteOutput
 {
     var opts = opts
     for (kind, value) in [("token", opts.token), ("password", opts.password)] where value != nil {
@@ -170,13 +171,18 @@ func configureRemote(
     if let directUrlRaw = opts.directUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
        !directUrlRaw.isEmpty
     {
-        return try configureDirectRemote(opts, directUrlRaw: directUrlRaw, defaultsSuites: defaultsSuites)
+        return try configureDirectRemote(
+            opts,
+            directUrlRaw: directUrlRaw,
+            configURL: configURL,
+            defaultsSuites: defaultsSuites)
     }
-    return try configureSSHRemote(opts, defaultsSuites: defaultsSuites)
+    return try configureSSHRemote(opts, configURL: configURL, defaultsSuites: defaultsSuites)
 }
 
 private func configureSSHRemote(
     _ opts: ConfigureRemoteOptions,
+    configURL: URL,
     defaultsSuites: [String]) throws -> ConfigureRemoteOutput
 {
     let target = opts.sshTarget?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -187,7 +193,6 @@ private func configureSSHRemote(
             userInfo: [NSLocalizedDescriptionKey: "SSH target must look like user@host[:port]"])
     }
 
-    let configURL = resolveOpenClawConfigURL()
     var root = try loadConfigRoot(from: configURL)
     var gateway = root["gateway"] as? [String: Any] ?? [:]
     var remote = gateway["remote"] as? [String: Any] ?? [:]
@@ -234,6 +239,7 @@ private func configureSSHRemote(
 private func configureDirectRemote(
     _ opts: ConfigureRemoteOptions,
     directUrlRaw: String,
+    configURL: URL,
     defaultsSuites: [String]) throws -> ConfigureRemoteOutput
 {
     guard let directURL = normalizeDirectURL(directUrlRaw) else {
@@ -247,7 +253,6 @@ private func configureDirectRemote(
             ])
     }
 
-    let configURL = resolveOpenClawConfigURL()
     var root = try loadConfigRoot(from: configURL)
     var gateway = root["gateway"] as? [String: Any] ?? [:]
     var remote = gateway["remote"] as? [String: Any] ?? [:]

--- a/apps/macos/Sources/OpenClawMacCLI/ConnectCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/ConnectCommand.swift
@@ -133,7 +133,7 @@ actor SnapshotStore {
     }
 }
 
-func runConnect(_ args: [String]) async {
+func runConnect(_ args: [String], configURL: URL) async {
     let opts = ConnectOptions.parse(args)
     if opts.help {
         print("""
@@ -146,6 +146,7 @@ func runConnect(_ args: [String]) async {
                                [--role <role>] [--scopes <a,b,c>]
 
         Options:
+          --profile <name>  App profile; overrides OPENCLAW_PROFILE (default: default)
           --url <url>        Gateway WebSocket URL (overrides config)
           --token <token>    Gateway token (if required)
           --password <pw>    Gateway password (if required)
@@ -163,7 +164,7 @@ func runConnect(_ args: [String]) async {
         return
     }
 
-    let config = loadGatewayConfig()
+    let config = loadGatewayConfig(from: configURL)
     do {
         let endpoint = try resolveGatewayEndpoint(opts: opts, config: config)
         let displayName = opts.displayName ?? Host.current().localizedName ?? "OpenClaw macOS Debug CLI"

--- a/apps/macos/Sources/OpenClawMacCLI/EntryPoint.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/EntryPoint.swift
@@ -19,19 +19,25 @@ enum RootCommandAction: Equatable {
 struct OpenClawMacCLI {
     static func main() async {
         let args = Array(CommandLine.arguments.dropFirst())
-        switch resolveRootCommandAction(args) {
+        let context: MacCLIContext
+        do {
+            context = try MacCLIContext(arguments: args)
+        } catch {
+            exitMacCLI(error, json: args.contains("--json"))
+        }
+        switch resolveRootCommandAction(context.arguments) {
         case .usage:
             printUsage()
-        case let .control(commandArgs):
-            runMacControl(commandArgs)
+        case .control:
+            runMacControl(context)
         case let .connect(commandArgs):
-            await runConnect(commandArgs)
+            await runConnect(commandArgs, configURL: context.configURL)
         case let .configureRemote(commandArgs):
-            runConfigureRemote(commandArgs)
+            runConfigureRemote(commandArgs, context: context)
         case let .discover(commandArgs):
             await runDiscover(commandArgs)
         case let .wizard(commandArgs):
-            await runWizardCommand(commandArgs)
+            await runWizardCommand(commandArgs, configURL: context.configURL)
         case let .unknown(exitCode):
             fputs("openclaw-mac: unknown command\n", stderr)
             printUsage()
@@ -88,6 +94,8 @@ private func printUsage() {
       openclaw-mac discover [--timeout <ms>] [--json] [--include-local]
       openclaw-mac wizard [--url <ws://host:port>] [--token <token>] [--password <password>]
                           [--mode <local|remote>] [--workspace <path>] [--json]
+
+    All commands accept --profile <name>; overrides OPENCLAW_PROFILE (default: default).
 
     Examples:
       openclaw-mac connect

--- a/apps/macos/Sources/OpenClawMacCLI/GatewayConfig.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/GatewayConfig.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OpenClawIPC
 
 struct GatewayConfig {
     var mode: String?
@@ -21,24 +22,28 @@ struct GatewayEndpoint {
 
 /// Keep standalone CLI reads and configure-remote writes on the same profile.
 /// An explicit config path wins; otherwise the selected state directory owns openclaw.json.
-func resolveOpenClawConfigURL() -> URL {
-    if let configPath = openClawEnvironmentPath("OPENCLAW_CONFIG_PATH") {
+func resolveOpenClawConfigURL(
+    profile: MacControlProfile,
+    environment: [String: String],
+    homeDirectory: URL) -> URL
+{
+    if let configPath = openClawEnvironmentPath("OPENCLAW_CONFIG_PATH", environment: environment) {
         return URL(fileURLWithPath: NSString(string: configPath).expandingTildeInPath)
     }
-    let stateDir = openClawEnvironmentPath("OPENCLAW_STATE_DIR").map {
+    let stateDir = openClawEnvironmentPath("OPENCLAW_STATE_DIR", environment: environment).map {
         URL(fileURLWithPath: NSString(string: $0).expandingTildeInPath, isDirectory: true)
-    } ?? FileManager().homeDirectoryForCurrentUser.appendingPathComponent(".openclaw", isDirectory: true)
+    } ?? profile.stateDirectoryURL(homeDirectory: homeDirectory)
     return stateDir.appendingPathComponent("openclaw.json")
 }
 
-private func openClawEnvironmentPath(_ key: String) -> String? {
-    guard let raw = ProcessInfo.processInfo.environment[key] else { return nil }
+private func openClawEnvironmentPath(_ key: String, environment: [String: String]) -> String? {
+    guard let raw = environment[key] else { return nil }
     let value = raw.trimmingCharacters(in: .whitespacesAndNewlines)
     return value.isEmpty ? nil : value
 }
 
-func loadGatewayConfig() -> GatewayConfig {
-    guard let data = try? Data(contentsOf: resolveOpenClawConfigURL()) else { return GatewayConfig() }
+func loadGatewayConfig(from configURL: URL) -> GatewayConfig {
+    guard let data = try? Data(contentsOf: configURL) else { return GatewayConfig() }
     guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
         return GatewayConfig()
     }

--- a/apps/macos/Sources/OpenClawMacCLI/MacCLIContext.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/MacCLIContext.swift
@@ -1,0 +1,42 @@
+import Foundation
+import OpenClawIPC
+
+struct MacCLIContext {
+    let arguments: [String]
+    let profile: MacControlProfile
+    let configURL: URL
+
+    init(
+        arguments: [String],
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) throws
+    {
+        var remaining: [String] = []
+        var profileValue: String?
+        var index = 0
+        while index < arguments.count {
+            if arguments[index] == "--profile" {
+                guard profileValue == nil, index + 1 < arguments.count,
+                      !arguments[index + 1].hasPrefix("--")
+                else {
+                    throw MacControlOptions.usage("A value is required exactly once for --profile.")
+                }
+                index += 1
+                profileValue = arguments[index]
+            } else {
+                remaining.append(arguments[index])
+            }
+            index += 1
+        }
+        self.arguments = remaining
+        self.profile = try MacControlProfile(rawValue: profileValue ?? environment["OPENCLAW_PROFILE"])
+        self.configURL = resolveOpenClawConfigURL(
+            profile: self.profile, environment: environment, homeDirectory: homeDirectory)
+    }
+
+    var defaultsSuites: [String] {
+        // Named profiles share one app domain across release and debug bundle identities.
+        self.profile.name.map { ["ai.openclaw.mac.profile.\($0)"] }
+            ?? ["ai.openclaw.mac", "ai.openclaw.mac.debug"]
+    }
+}

--- a/apps/macos/Sources/OpenClawMacCLI/MacControlCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/MacControlCommand.swift
@@ -2,10 +2,12 @@ import Darwin
 import Foundation
 import OpenClawIPC
 
-func runMacControl(_ args: [String]) {
+func runMacControl(_ context: MacCLIContext) {
+    let args = context.arguments
     do {
-        var options = try MacControlOptions.parse(args, environment: ProcessInfo.processInfo.environment)
-        if options.help { printMacControlUsage()
+        var options = try MacControlOptions.parse(context)
+        if options.help {
+            printMacControlUsage()
             return
         }
         if options.request.operation == "gateway.remove", !options.yes {
@@ -33,19 +35,23 @@ func runMacControl(_ args: [String]) {
             try printMacControlResult(result, operation: options.request.operation, primaryOnly: options.primaryOnly)
         }
     } catch {
-        let controlError = error as? MacControlError
-            ?? MacControlError(code: "operation_failed", message: "The app control operation failed.")
-        if args.contains("--json"),
-           let data = try? JSONEncoder().encode(MacControlResponse<String>(error: controlError)),
-           let text = String(data: data, encoding: .utf8)
-        {
-            fputs(text + "\n", stderr)
-        } else {
-            fputs("openclaw-mac: \(controlError.message)\n", stderr)
-        }
-        exit(controlError.code == "usage" || controlError
-            .code == "invalid_profile" ? 1 : (controlError.code == "unreachable" ? 2 : 3))
+        exitMacCLI(error, json: args.contains("--json"))
     }
+}
+
+func exitMacCLI(_ error: Error, json: Bool) -> Never {
+    let controlError = error as? MacControlError
+        ?? MacControlError(code: "operation_failed", message: "The app control operation failed.")
+    if json,
+       let data = try? JSONEncoder().encode(MacControlResponse<String>(error: controlError)),
+       let text = String(data: data, encoding: .utf8)
+    {
+        fputs(text + "\n", stderr)
+    } else {
+        fputs("openclaw-mac: \(controlError.message)\n", stderr)
+    }
+    exit(controlError.code == "usage" || controlError
+        .code == "invalid_profile" ? 1 : (controlError.code == "unreachable" ? 2 : 3))
 }
 
 func macControlResult(_ response: Data, primaryOnly: Bool) throws -> Data {

--- a/apps/macos/Sources/OpenClawMacCLI/MacControlOptions.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/MacControlOptions.swift
@@ -19,8 +19,12 @@ struct MacControlOptions {
     var passwordSource: SecretSource?
 
     static func parse(_ args: [String], environment: [String: String] = [:]) throws -> Self {
-        let (values, flags, words) = try self.tokenize(args)
-        let profile = try MacControlProfile(rawValue: values["--profile"] ?? environment["OPENCLAW_PROFILE"])
+        try self.parse(MacCLIContext(arguments: args, environment: environment))
+    }
+
+    static func parse(_ context: MacCLIContext) throws -> Self {
+        let (values, flags, words) = try tokenize(context.arguments)
+        let profile = context.profile
         let command = words.first ?? "status"
         let subcommand = words.count > 1 ? words[1] : ""
         let operation = try self.operation(
@@ -49,7 +53,7 @@ struct MacControlOptions {
         guard !(options.tokenSource == .stdin && options.passwordSource == .stdin) else {
             throw self.usage("Standard input can supply only one secret.")
         }
-        let globals: Set = ["--profile", "--timeout", "--json", "--launch", "--no-launch"]
+        let globals: Set = ["--timeout", "--json", "--launch", "--no-launch"]
         let secrets: Set = ["--token-file", "--password-file", "--token-stdin", "--password-stdin"]
         var allowed = globals
         switch operation {
@@ -106,7 +110,7 @@ struct MacControlOptions {
         var flags = Set<String>()
         var words: [String] = []
         let valueFlags: Set = [
-            "--profile", "--timeout", "--ssh-target", "--remote-port", "--local-port", "--identity",
+            "--timeout", "--ssh-target", "--remote-port", "--local-port", "--identity",
             "--ssh-host-key-policy", "--direct-url", "--tls-fingerprint", "--url", "--token-file", "--password-file",
         ]
         let switchFlags: Set = [

--- a/apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift
+++ b/apps/macos/Sources/OpenClawMacCLI/WizardCommand.swift
@@ -61,7 +61,7 @@ enum WizardCliError: Error, CustomStringConvertible {
     }
 }
 
-func runWizardCommand(_ args: [String]) async {
+func runWizardCommand(_ args: [String], configURL: URL) async {
     let opts = WizardCliOptions.parse(args)
     if opts.help {
         print("""
@@ -72,6 +72,7 @@ func runWizardCommand(_ args: [String]) async {
                               [--mode <local|remote>] [--workspace <path>] [--json]
 
         Options:
+          --profile <name>  App profile; overrides OPENCLAW_PROFILE (default: default)
           --url <url>        Gateway WebSocket URL (overrides config)
           --token <token>    Gateway token (if required)
           --password <pw>    Gateway password (if required)
@@ -83,7 +84,7 @@ func runWizardCommand(_ args: [String]) async {
         return
     }
 
-    let config = loadGatewayConfig()
+    let config = loadGatewayConfig(from: configURL)
     do {
         guard isatty(STDIN_FILENO) != 0 else {
             throw WizardCliError.gatewayError("Wizard requires an interactive TTY.")

--- a/apps/macos/Tests/OpenClawIPCTests/ConfigureRemoteCommandTests.swift
+++ b/apps/macos/Tests/OpenClawIPCTests/ConfigureRemoteCommandTests.swift
@@ -5,6 +5,86 @@ import Testing
 
 @Suite(.serialized)
 struct ConfigureRemoteCommandTests {
+    @Test(arguments: ["configure-remote", "connect", "wizard", "status", "discover"])
+    func `all commands share profile selection before dispatch`(command: String) throws {
+        let home = URL(fileURLWithPath: "/synthetic-home", isDirectory: true)
+        for arguments in [["--profile", "research", command], [command, "--profile", "research"]] {
+            let context = try MacCLIContext(
+                arguments: arguments, environment: ["OPENCLAW_PROFILE": "other"], homeDirectory: home)
+            #expect(context.arguments == [command])
+            #expect(context.profile.name == "research")
+            #expect(context.configURL.path == "/synthetic-home/.openclaw-research/openclaw.json")
+            #expect(context.defaultsSuites == ["ai.openclaw.mac.profile.research"])
+        }
+    }
+
+    @Test func `offline profile paths and suites preserve override precedence`() throws {
+        let home = URL(fileURLWithPath: "/synthetic-home", isDirectory: true)
+        let cases: [(arguments: [String], environment: [String: String], path: String, suites: [String])] = [
+            ([], [:], ".openclaw/openclaw.json", ["ai.openclaw.mac", "ai.openclaw.mac.debug"]),
+            (
+                [],
+                ["OPENCLAW_PROFILE": "research"],
+                ".openclaw-research/openclaw.json",
+                ["ai.openclaw.mac.profile.research"]),
+            (
+                ["--profile", "default"],
+                ["OPENCLAW_PROFILE": "research"],
+                ".openclaw/openclaw.json",
+                ["ai.openclaw.mac", "ai.openclaw.mac.debug"]),
+            (
+                ["--profile", "research"],
+                ["OPENCLAW_STATE_DIR": "/synthetic-home/state"],
+                "state/openclaw.json",
+                ["ai.openclaw.mac.profile.research"]),
+            (
+                ["--profile", "research"],
+                [
+                    "OPENCLAW_CONFIG_PATH": "/synthetic-home/explicit.json",
+                    "OPENCLAW_STATE_DIR": "/synthetic-home/state",
+                ],
+                "explicit.json",
+                ["ai.openclaw.mac.profile.research"]),
+        ]
+        for testCase in cases {
+            let context = try MacCLIContext(
+                arguments: testCase.arguments, environment: testCase.environment, homeDirectory: home)
+            #expect(context.configURL.path == home.appendingPathComponent(testCase.path).path)
+            #expect(context.defaultsSuites == testCase.suites)
+        }
+    }
+
+    @Test(arguments: ["ssh", "direct"])
+    func `offline write and legacy reads use the same profile config`(transport: String) throws {
+        let home = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: home) }
+        let context = try MacCLIContext(
+            arguments: ["configure-remote", "--profile", "research"], environment: [:], homeDirectory: home)
+        let options = transport == "ssh"
+            ? ConfigureRemoteOptions(sshTarget: "alice@gateway.example")
+            : ConfigureRemoteOptions(directUrl: "wss://gateway.example")
+        let output = try configureRemote(options, configURL: context.configURL, defaultsSuites: [])
+        #expect(output.configPath == home.appendingPathComponent(".openclaw-research/openclaw.json").path)
+        for command in ["connect", "wizard"] {
+            let reader = try MacCLIContext(
+                arguments: [command], environment: ["OPENCLAW_PROFILE": "research"], homeDirectory: home)
+            let config = loadGatewayConfig(from: reader.configURL)
+            #expect(config.mode == "remote")
+            #expect(config.remoteUrl == output.remoteUrl)
+        }
+        #expect(!FileManager.default.fileExists(atPath: home.appendingPathComponent(".openclaw").path))
+    }
+
+    @Test(arguments: [
+        ["--profile"], ["--profile", "--json"], ["--profile", "research", "--profile", "other"],
+        ["--profile", "../other"], ["--profile", "Research"], ["--profile", "mac"],
+    ])
+    func `offline commands reject invalid profile arguments`(arguments: [String]) {
+        #expect(throws: Error.self) {
+            try MacCLIContext(arguments: ["configure-remote"] + arguments, environment: [:])
+        }
+    }
+
     @Test(arguments: ["token", "password"], ["file", "stdin", "argv"])
     @MainActor func `configure remote reads secret sources and warns only for argv`(
         kind: String,
@@ -48,7 +128,7 @@ struct ConfigureRemoteCommandTests {
             let configure: () throws -> Void = {
                 try configureRemote(
                     ConfigureRemoteOptions.parse(transportArguments + secretArguments),
-                    defaultsSuites: [])
+                    configURL: configURL, defaultsSuites: [])
             }
             if source == "stdin" {
                 let input = try FileHandle(forReadingFrom: secretURL)
@@ -127,7 +207,7 @@ struct ConfigureRemoteCommandTests {
                     identity: nil,
                     projectRoot: nil,
                     cliPath: "/opt/homebrew/bin/openclaw"),
-                defaultsSuites: defaultSuites)
+                configURL: configURL, defaultsSuites: defaultSuites)
 
             #expect(output.status == "ok")
             #expect(output.localUrl == "ws://127.0.0.1:19089")
@@ -173,30 +253,31 @@ struct ConfigureRemoteCommandTests {
                     identity: "/tmp/first-identity",
                     projectRoot: "/srv/first",
                     cliPath: "/opt/first/openclaw"),
-                defaultsSuites: [suite])
-            try configureRemote(.init(sshTarget: "alice@first.example"), defaultsSuites: [suite])
+                configURL: configURL, defaultsSuites: [suite])
+            try configureRemote(.init(sshTarget: "alice@first.example"), configURL: configURL, defaultsSuites: [suite])
             #expect(defaults.string(forKey: "openclaw.remoteIdentity") == "/tmp/first-identity")
             #expect(defaults.string(forKey: "openclaw.remoteProjectRoot") == "/srv/first")
             #expect(defaults.string(forKey: "openclaw.remoteCliPath") == "/opt/first/openclaw")
 
             try configureRemote(
                 .init(sshTarget: "alice@second.example", cliPath: "/opt/second/openclaw"),
-                defaultsSuites: [suite])
+                configURL: configURL, defaultsSuites: [suite])
             #expect(defaults.string(forKey: "openclaw.remoteIdentity") == nil)
             #expect(defaults.string(forKey: "openclaw.remoteProjectRoot") == nil)
             #expect(defaults.string(forKey: "openclaw.remoteCliPath") == "/opt/second/openclaw")
 
-            try configureRemote(.init(directUrl: "wss://third.example"), defaultsSuites: [suite])
+            try configureRemote(.init(directUrl: "wss://third.example"), configURL: configURL, defaultsSuites: [suite])
             #expect(defaults.string(forKey: "openclaw.remoteTarget") == nil)
             #expect(defaults.string(forKey: "openclaw.remoteIdentity") == nil)
             #expect(defaults.string(forKey: "openclaw.remoteProjectRoot") == nil)
             #expect(defaults.string(forKey: "openclaw.remoteCliPath") == nil)
 
             try configureRemote(
-                .init(directUrl: "wss://third.example", projectRoot: "/srv/third"), defaultsSuites: [suite])
-            try configureRemote(.init(directUrl: "wss://third.example"), defaultsSuites: [suite])
+                .init(directUrl: "wss://third.example", projectRoot: "/srv/third"), configURL: configURL,
+                defaultsSuites: [suite])
+            try configureRemote(.init(directUrl: "wss://third.example"), configURL: configURL, defaultsSuites: [suite])
             #expect(defaults.string(forKey: "openclaw.remoteProjectRoot") == "/srv/third")
-            try configureRemote(.init(directUrl: "wss://fourth.example"), defaultsSuites: [suite])
+            try configureRemote(.init(directUrl: "wss://fourth.example"), configURL: configURL, defaultsSuites: [suite])
             #expect(defaults.string(forKey: "openclaw.remoteProjectRoot") == nil)
         }
     }
@@ -221,7 +302,7 @@ struct ConfigureRemoteCommandTests {
         try initialData.write(to: configURL)
 
         try await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configURL.path]) {
-            try configureRemote(.init(sshTarget: "alice@gateway.example"), defaultsSuites: [])
+            try configureRemote(.init(sshTarget: "alice@gateway.example"), configURL: configURL, defaultsSuites: [])
 
             let data = try Data(contentsOf: configURL)
             let root = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
@@ -250,7 +331,10 @@ struct ConfigureRemoteCommandTests {
         try initialData.write(to: configURL)
 
         try await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configURL.path]) {
-            let output = try configureRemote(.init(sshTarget: "gateway-alias"), defaultsSuites: [])
+            let output = try configureRemote(
+                .init(sshTarget: "gateway-alias"),
+                configURL: configURL,
+                defaultsSuites: [])
 
             #expect(output.sshHostKeyPolicy == "strict")
             let data = try Data(contentsOf: configURL)
@@ -286,10 +370,16 @@ struct ConfigureRemoteCommandTests {
 
     @Test func `configure remote rejects ssh targets without a host`() throws {
         #expect(throws: Error.self) {
-            try configureRemote(.init(sshTarget: "user@"))
+            try configureRemote(
+                .init(sshTarget: "user@"),
+                configURL: URL(fileURLWithPath: "/unused"),
+                defaultsSuites: [])
         }
         #expect(throws: Error.self) {
-            try configureRemote(.init(sshTarget: "alice@:2222"))
+            try configureRemote(
+                .init(sshTarget: "alice@:2222"),
+                configURL: URL(fileURLWithPath: "/unused"),
+                defaultsSuites: [])
         }
     }
 
@@ -313,7 +403,7 @@ struct ConfigureRemoteCommandTests {
                 .init(
                     directUrl: "ws://192.168.0.202:18789",
                     token: "test-token"), // pragma: allowlist secret
-                defaultsSuites: [])
+                configURL: configURL, defaultsSuites: [])
 
             #expect(output.transport == "direct")
             #expect(output.remoteUrl == "ws://192.168.0.202:18789")
@@ -346,12 +436,12 @@ struct ConfigureRemoteCommandTests {
             "OPENCLAW_CONFIG_PATH": nil,
             "OPENCLAW_STATE_DIR": stateDir.path,
         ]) {
-            try #require(resolveOpenClawConfigURL().path == configURL.path)
+            try #require(MacCLIContext(arguments: []).configURL.path == configURL.path)
             let output = try configureRemote(
                 .init(
                     directUrl: "ws://192.168.0.203:18789",
                     token: "state-dir-token"), // pragma: allowlist secret
-                defaultsSuites: [])
+                configURL: configURL, defaultsSuites: [])
 
             #expect(output.configPath == configURL.path)
             let data = try Data(contentsOf: configURL)
@@ -372,10 +462,16 @@ struct ConfigureRemoteCommandTests {
 
         _ = await TestIsolation.withIsolatedState(env: ["OPENCLAW_CONFIG_PATH": configURL.path]) {
             #expect(throws: Error.self) {
-                try configureRemote(.init(directUrl: "ws://fd-example.com:18789"))
+                try configureRemote(
+                    .init(directUrl: "ws://fd-example.com:18789"),
+                    configURL: configURL,
+                    defaultsSuites: [])
             }
             #expect(throws: Error.self) {
-                try configureRemote(.init(directUrl: "ws://192.168.0.202.attacker.example:18789"))
+                try configureRemote(
+                    .init(directUrl: "ws://192.168.0.202.attacker.example:18789"),
+                    configURL: configURL,
+                    defaultsSuites: [])
             }
         }
     }
@@ -401,11 +497,11 @@ struct GatewayConfigTests {
             remoteURL: "wss://state-config.example:19102",
             token: "state-config-token") // pragma: allowlist secret
 
-        await TestIsolation.withEnvValues([
+        try await TestIsolation.withEnvValues([
             "OPENCLAW_CONFIG_PATH": explicitConfigURL.path,
             "OPENCLAW_STATE_DIR": stateConfigURL.deletingLastPathComponent().path,
         ]) {
-            let config = loadGatewayConfig()
+            let config = try loadGatewayConfig(from: MacCLIContext(arguments: []).configURL)
 
             #expect(config.port == 19101)
             #expect(config.remoteUrl == "wss://explicit-config.example:19101")
@@ -413,15 +509,16 @@ struct GatewayConfigTests {
         }
     }
 
-    @Test @MainActor func `config path trims surrounding whitespace and expands tilde`() async {
+    @Test @MainActor func `config path trims surrounding whitespace and expands tilde`() async throws {
         let relativePath = ".openclaw-cli-config-\(UUID().uuidString)/openclaw.json"
 
-        await TestIsolation.withEnvValues([
+        try await TestIsolation.withEnvValues([
             "OPENCLAW_CONFIG_PATH": "  ~/\(relativePath)\n",
             "OPENCLAW_STATE_DIR": "/tmp/openclaw-unused-state-dir",
         ]) {
             let expectedURL = FileManager().homeDirectoryForCurrentUser.appendingPathComponent(relativePath)
-            #expect(resolveOpenClawConfigURL().path == expectedURL.path)
+            let configURL = try MacCLIContext(arguments: []).configURL
+            #expect(configURL.path == expectedURL.path)
         }
     }
 
@@ -438,11 +535,11 @@ struct GatewayConfigTests {
             remotePort: 19203,
             token: "state-profile-token") // pragma: allowlist secret
 
-        await TestIsolation.withEnvValues([
+        try await TestIsolation.withEnvValues([
             "OPENCLAW_CONFIG_PATH": nil,
             "OPENCLAW_STATE_DIR": "\t\(stateDir.path)  ",
         ]) {
-            let config = loadGatewayConfig()
+            let config = try loadGatewayConfig(from: MacCLIContext(arguments: []).configURL)
 
             #expect(config.mode == "remote")
             #expect(config.port == 19201)

--- a/docs/platforms/mac/remote.md
+++ b/docs/platforms/mac/remote.md
@@ -190,8 +190,10 @@ read once and trailing newlines are removed. Keep credential files private.
 The new commands reject `--token` and `--password` to keep secrets out of
 process arguments. Status and saved-Gateway output never contain credentials.
 
-Use `--profile <name>` or `OPENCLAW_PROFILE` to select the app profile. For
-example:
+Every command, including offline `configure-remote` and legacy `connect`/`wizard`,
+uses `--profile <name>` first, then `OPENCLAW_PROFILE`, then the default profile.
+Use `--profile default` to override a named environment profile. Profile names
+follow the app's validation rules. For example:
 
 ```bash
 openclaw-mac --profile research status --json
@@ -230,7 +232,15 @@ openclaw-mac configure-remote \
 
 The legacy `connect`, `wizard`, and `configure-remote` commands resolve config
 in this order: `OPENCLAW_CONFIG_PATH`, then
-`$OPENCLAW_STATE_DIR/openclaw.json`, then `~/.openclaw/openclaw.json`.
+`$OPENCLAW_STATE_DIR/openclaw.json`, then the selected profile's config:
+`~/.openclaw-<name>/openclaw.json` for a named profile or
+`~/.openclaw/openclaw.json` for the default profile. Explicit config/state paths
+override the profile's config location but do not change its app defaults suite.
+With a named profile, `configure-remote` writes only
+`ai.openclaw.mac.profile.<name>`, shared by release and debug app bundles.
+The default profile keeps the `ai.openclaw.mac` and `ai.openclaw.mac.debug` suites.
+For example, `openclaw-mac configure-remote --profile research --direct-url wss://gateway.example.com`
+preconfigures only the research profile unless an explicit config/state path is set.
 `configure-remote` supports SSH and `--direct-url` transports, marks onboarding
 complete, and leaves the app to use the selected transport on its next start.
 Its ports default to `18789`. Additional options include `--identity`,


### PR DESCRIPTION
## Problem

Fixes an issue where offline preconfiguration of a named macOS app profile would update the default app's configuration and preferences instead. Legacy `connect` and `wizard` reads also ignored the selected profile.

## Solution

Resolve and validate the CLI profile once before command dispatch, using `--profile` before `OPENCLAW_PROFILE`, with the default profile as the fallback. Pass the resulting config path explicitly to offline readers and writers. Named profiles select only `ai.openclaw.mac.profile.<name>`; the default profile retains both existing app suites.

## Impact

Operators can preconfigure and read the intended profile with `--profile` before or after the command. `OPENCLAW_CONFIG_PATH` still wins over `OPENCLAW_STATE_DIR`, which wins over the selected profile's state directory. Config path overrides do not change the selected defaults suite. Help and remote-control documentation explain these rules.

## Evidence

- Pre-fix resolver probe reproduced selection of `.openclaw` for a named profile.
- Native builds: `OpenClaw`, `openclaw-mac`, and all test targets.
- Requested focused Swift filter: 24 tests passed under private HOME/TMPDIR settings; supplementary config/root filter: 16 passed.
- CLI smoke checks: profile placement before/after each offline command, documented help, and structured invalid-profile rejection before state writes.
- Swift format and lint checks, native localization verification, `node scripts/check-changed.mjs` (including all selected macOS tooling/runtime lanes), and `git diff --check` passed.
- Fresh independent Codex autoreview: scoped-clean with no accepted P0/P1 findings.

## Notes

No UI, control socket protocol, or MacGatewayProfileStore changes. Validation used synthetic paths and test-owned defaults suites without launching or restarting the operator app. The fresh worktree required generated Mermaid resources; the repository preparation script supplied them. Full native runtime testing was intentionally limited to the audited focused filters. No merge or CI waiting requested.
