### PR TITLE
feat(models): read session catalogs directly in the Control UI

### DIFF
--- a/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
+++ b/apps/shared/OpenClawKit/Sources/OpenClawProtocol/GatewayModels.swift
@@ -16693,6 +16693,8 @@ public struct ModelsAuthStatusParams: Codable, Sendable {
 
 public struct ModelsListParams: Codable, Sendable {
     public let agentid: String?
+    public let sessionkey: String?
+    public let authprofileid: String?
     public let provider: String?
     public let includedetails: Bool?
     public let includeprovidercapabilities: Bool?
@@ -16702,6 +16704,8 @@ public struct ModelsListParams: Codable, Sendable {
 
     public init(
         agentid: String? = nil,
+        sessionkey: String? = nil,
+        authprofileid: String? = nil,
         provider: String? = nil,
         includedetails: Bool? = nil,
         includeprovidercapabilities: Bool? = nil,
@@ -16710,6 +16714,8 @@ public struct ModelsListParams: Codable, Sendable {
         view: AnyCodable? = nil)
     {
         self.agentid = agentid
+        self.sessionkey = sessionkey
+        self.authprofileid = authprofileid
         self.provider = provider
         self.includedetails = includedetails
         self.includeprovidercapabilities = includeprovidercapabilities
@@ -16720,6 +16726,8 @@ public struct ModelsListParams: Codable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case agentid = "agentId"
+        case sessionkey = "sessionKey"
+        case authprofileid = "authProfileId"
         case provider
         case includedetails = "includeDetails"
         case includeprovidercapabilities = "includeProviderCapabilities"
@@ -16731,18 +16739,26 @@ public struct ModelsListParams: Codable, Sendable {
 
 public struct ModelsListResult: Codable, Sendable {
     public let models: [ModelChoice]
+    public let refreshfailed: Bool?
+    public let accountselection: ChatAccountSelection?
     public let provideroutcomes: [[String: AnyCodable]]?
 
     public init(
         models: [ModelChoice],
+        refreshfailed: Bool? = nil,
+        accountselection: ChatAccountSelection? = nil,
         provideroutcomes: [[String: AnyCodable]]? = nil)
     {
         self.models = models
+        self.refreshfailed = refreshfailed
+        self.accountselection = accountselection
         self.provideroutcomes = provideroutcomes
     }
 
     private enum CodingKeys: String, CodingKey {
         case models
+        case refreshfailed = "refreshFailed"
+        case accountselection = "accountSelection"
         case provideroutcomes = "providerOutcomes"
     }
 }

--- a/config/assertion-safety-baseline.txt
+++ b/config/assertion-safety-baseline.txt
@@ -3802,7 +3802,7 @@ ui/src/lib/chat/tool-display.ts	1
 ui/src/lib/config-form-utils.ts	7
 ui/src/lib/config/config-draft-model.ts	5
 ui/src/lib/cron/index.ts	11
-ui/src/lib/gateway-diagnostics.ts	3
+ui/src/lib/gateway-diagnostics.ts	2
 ui/src/lib/gateway-errors.ts	1
 ui/src/lib/keyboard-shortcuts.ts	1
 ui/src/lib/nodes/index.ts	3

--- a/docs/gateway/protocol/operator-methods.md
+++ b/docs/gateway/protocol/operator-methods.md
@@ -140,6 +140,25 @@ whose owner becomes stale during projection is rejected for retry.
   `contextTokens`, and a `local` endpoint classification. It does not expose
   endpoint URLs, headers, credentials, costs or runtime request parameters.
 
+For a conversation picker, pass `sessionKey` to read the session's canonical
+agent and saved account selection. A conflicting `agentId` is rejected. The
+viewer's current account default does not replace a saved session's selection.
+For a new draft, `authProfileId` previews a retained account owned by the
+identified caller with `operator.read` access. It does not save an account
+default. `sessionKey` and `authProfileId` are mutually exclusive.
+
+Session and identified-account results include `accountSelection` display facts
+with the models. Collaborators do not receive another person's private account
+locator. The `provider-config` view remains shared authored inventory and omits
+account selection. `refreshFailed: true` reports a failed acquisition while
+compatible rows remain usable; recovery clears it. A successful empty catalog
+remains empty.
+
+The Gateway advertises `session-scoped-model-catalog` for this contract.
+`chat.metadata` remains available to legacy clients; the Control UI reads models
+directly and keeps commands in its metadata cache. Opening its picker performs a
+passive read, without a model-cache timer or implicit provider refresh.
+
 `preparedOnly: true` and `refresh: true` remain mutually exclusive.
 The Gateway advertises these published-read and details controls as
 `published-model-catalog`. Clients that require this contract must check the

--- a/packages/gateway-protocol/src/index.test.ts
+++ b/packages/gateway-protocol/src/index.test.ts
@@ -1020,6 +1020,8 @@ describe("validateModelsListParams", () => {
   it("accepts the supported model catalog views", () => {
     expectAccepted(validateModelsListParams, [
       {},
+      { sessionKey: "agent:work:saved", view: "configured" },
+      { agentId: "work", authProfileId: "personal:reader:account" },
       { view: "default" },
       { view: "configured" },
       { view: "all" },
@@ -1032,6 +1034,10 @@ describe("validateModelsListParams", () => {
   it("rejects unknown model catalog views and extra fields", () => {
     expectRejected(validateModelsListParams, [
       { view: "available" },
+      { sessionKey: "agent:work:saved", authProfileId: "personal:reader:account" },
+      { sessionKey: "" },
+      { authProfileId: "" },
+      { preparedOnly: true, refresh: true },
       { view: "configured", unexpected: true },
       { provider: "" },
       { includeDetails: "yes" },

--- a/packages/gateway-protocol/src/schema/agents-models-skills.ts
+++ b/packages/gateway-protocol/src/schema/agents-models-skills.ts
@@ -3,6 +3,7 @@ import type { Static } from "typebox";
 import { Type } from "typebox";
 import { closedObject } from "./closed-object.js";
 import { WorkerExecutionModeSchema } from "./environments.js";
+import { ChatAccountSelectionSchema, ModelAuthProfileIdSchema } from "./model-account-selection.js";
 import { NonEmptyString } from "./primitives.js";
 import { GitHubSetupHandleSchema } from "./secrets.js";
 import { SessionPermissionModeSchema } from "./sessions-row.js";
@@ -280,6 +281,8 @@ export const AgentsFilesSetResultSchema = closedObject({
 export const ModelsListParamsSchema = Type.Object(
   {
     agentId: Type.Optional(NonEmptyString),
+    sessionKey: Type.Optional(NonEmptyString),
+    authProfileId: Type.Optional(ModelAuthProfileIdSchema),
     provider: Type.Optional(NonEmptyString),
     includeDetails: Type.Optional(Type.Boolean()),
     includeProviderCapabilities: Type.Optional(Type.Boolean()),
@@ -298,10 +301,15 @@ export const ModelsListParamsSchema = Type.Object(
   },
   {
     additionalProperties: false,
-    not: {
-      properties: { preparedOnly: { const: true }, refresh: { const: true } },
-      required: ["preparedOnly", "refresh"],
-    },
+    allOf: [
+      {
+        not: {
+          properties: { preparedOnly: { const: true }, refresh: { const: true } },
+          required: ["preparedOnly", "refresh"],
+        },
+      },
+      { not: { required: ["sessionKey", "authProfileId"] } },
+    ],
   },
 );
 
@@ -338,6 +346,8 @@ export const ModelCatalogProviderOutcomeSchema = closedObject({
 
 export const ModelsListResultSchema = closedObject({
   models: Type.Array(ModelChoiceSchema),
+  refreshFailed: Type.Optional(Type.Boolean()),
+  accountSelection: Type.Optional(ChatAccountSelectionSchema),
   providerOutcomes: Type.Optional(Type.Array(ModelCatalogProviderOutcomeSchema)),
 });
 

--- a/packages/gateway-protocol/src/schema/model-account-selection.ts
+++ b/packages/gateway-protocol/src/schema/model-account-selection.ts
@@ -1,0 +1,29 @@
+import type { Static } from "typebox";
+import { Type } from "typebox";
+import { closedObject } from "./closed-object.js";
+
+export const ModelAuthProfileIdSchema = Type.String({ minLength: 1, maxLength: 256 });
+
+const ChatAccountSelectionSourceSchema = Type.Optional(
+  Type.Union([Type.Literal("auto"), Type.Literal("user"), Type.Literal("user-link")]),
+);
+const ChatAccountSelectionLabelSchema = Type.String({ minLength: 1, maxLength: 256 });
+/** Configured preference only; provider failover can use a different account. */
+export const ChatAccountSelectionSchema = Type.Union([
+  closedObject({ kind: Type.Literal("automatic"), label: ChatAccountSelectionLabelSchema }),
+  closedObject({
+    kind: Type.Literal("personal"),
+    label: ChatAccountSelectionLabelSchema,
+    // Collaborators see the person, not private credential identifiers or labels.
+    authProfileId: Type.Optional(ModelAuthProfileIdSchema),
+    source: ChatAccountSelectionSourceSchema,
+  }),
+  closedObject({
+    kind: Type.Literal("shared"),
+    label: ChatAccountSelectionLabelSchema,
+    authProfileId: ModelAuthProfileIdSchema,
+    source: ChatAccountSelectionSourceSchema,
+  }),
+]);
+
+export type ChatAccountSelection = Static<typeof ChatAccountSelectionSchema>;

--- a/packages/gateway-protocol/src/schema/users.ts
+++ b/packages/gateway-protocol/src/schema/users.ts
@@ -12,8 +12,14 @@ import {
   ToolsGitHubAuthorizeFailedResultSchema,
 } from "./agents-models-skills.js";
 import { closedObject } from "./closed-object.js";
+import { ModelAuthProfileIdSchema } from "./model-account-selection.js";
 import { NonEmptyString } from "./primitives.js";
 import { WizardAnswerSchema, WizardStepSchema } from "./wizard.js";
+
+export {
+  ChatAccountSelectionSchema,
+  type ChatAccountSelection,
+} from "./model-account-selection.js";
 
 export const USER_PREFS_ENTRY_LIMIT = 32;
 export const USER_PREFS_PROFILE_KEY_LIMIT = 128;
@@ -101,7 +107,6 @@ export const UsersSetAvatarResultSchema = closedObject({
   avatarRevision: NonEmptyString,
 });
 
-const ModelAuthProfileIdSchema = Type.String({ minLength: 1, maxLength: 256 });
 const ModelAuthProviderIdSchema = Type.String({ minLength: 1, maxLength: 128 });
 const ModelAuthConnectIdSchema = Type.String({ minLength: 1, maxLength: 128 });
 export const UserProfileAuthLinkSchema = closedObject({
@@ -134,28 +139,6 @@ export const UsersSelectModelAccountParamsSchema = closedObject({
 export const UsersSelectModelAccountResultSchema = closedObject({
   links: Type.Array(UserProfileAuthLinkSchema),
 });
-
-const ChatAccountSelectionSourceSchema = Type.Optional(
-  Type.Union([Type.Literal("auto"), Type.Literal("user"), Type.Literal("user-link")]),
-);
-const ChatAccountSelectionLabelSchema = Type.String({ minLength: 1, maxLength: 256 });
-/** Configured preference only; provider failover can use a different account. */
-export const ChatAccountSelectionSchema = Type.Union([
-  closedObject({ kind: Type.Literal("automatic"), label: ChatAccountSelectionLabelSchema }),
-  closedObject({
-    kind: Type.Literal("personal"),
-    label: ChatAccountSelectionLabelSchema,
-    // Collaborators see the person, not private credential identifiers or labels.
-    authProfileId: Type.Optional(ModelAuthProfileIdSchema),
-    source: ChatAccountSelectionSourceSchema,
-  }),
-  closedObject({
-    kind: Type.Literal("shared"),
-    label: ChatAccountSelectionLabelSchema,
-    authProfileId: ModelAuthProfileIdSchema,
-    source: ChatAccountSelectionSourceSchema,
-  }),
-]);
 
 export const UsersListAuthLinksParamsSchema = closedObject({ profileId: UserProfileIdSchema });
 export const UsersListAuthLinksResultSchema = closedObject({
@@ -288,7 +271,7 @@ export type UsersListModelAccountsParams = Static<typeof UsersListModelAccountsP
 export type UsersListModelAccountsResult = Static<typeof UsersListModelAccountsResultSchema>;
 export type UsersSelectModelAccountParams = Static<typeof UsersSelectModelAccountParamsSchema>;
 export type UsersSelectModelAccountResult = Static<typeof UsersSelectModelAccountResultSchema>;
-export type ChatAccountSelection = Static<typeof ChatAccountSelectionSchema>;
+
 export type UsersAuthConnectStartParams = Static<typeof UsersAuthConnectStartParamsSchema>;
 export type UsersAuthConnectStartResult = Static<typeof UsersAuthConnectStartResultSchema>;
 export type UsersAuthConnectAnswerParams = Static<typeof UsersAuthConnectAnswerParamsSchema>;

--- a/packages/gateway-protocol/src/server-capabilities.ts
+++ b/packages/gateway-protocol/src/server-capabilities.ts
@@ -10,6 +10,7 @@ export const GATEWAY_SERVER_CAPS = {
   PUBLISHED_MODEL_CATALOG: "published-model-catalog",
   PROGRESS_CARD_AGENT_SCOPE: "progress-card-agent-scope-v1",
   SESSION_SCOPED_CHAT_METADATA: "session-scoped-chat-metadata",
+  SESSION_SCOPED_MODEL_CATALOG: "session-scoped-model-catalog",
   SESSION_UNREAD_ACK_CONTRACT: "session-unread-ack-contract",
   SESSION_GOAL_START: "session-goal-start-v1",
   SESSION_SETTINGS_CONTRACT: "session-settings-contract",

--- a/src/agents/model-catalog.types.ts
+++ b/src/agents/model-catalog.types.ts
@@ -57,6 +57,8 @@ export type ModelCatalogSnapshot = {
   routeVariants: ModelCatalogEntry[];
   /** Provider-owned outcome of each live catalog request in this generation. */
   providerOutcomes?: readonly ProviderCatalogOutcome[];
+  /** The current acquisition failed while this published inventory remained available. */
+  refreshFailed?: boolean;
   /** Static provider-hook rows captured alongside the full lifecycle generation. */
   staticEntries?: ModelCatalogEntry[];
   /**

--- a/src/agents/prepared-model-runtime.build.ts
+++ b/src/agents/prepared-model-runtime.build.ts
@@ -180,7 +180,7 @@ function createFullModelCatalogAccess(params: {
       metadataSnapshot: params.pluginGeneration.pluginMetadataSnapshot,
       providers: params.pluginGeneration.pluginRegistry?.providers,
     });
-    return projected;
+    return attempt.withRefreshStatus(projected);
   };
   const inventoryKey = preparedModelInventoryKey(params.agentFacts.input);
   const normalizeProvider = createPreparedModelCatalogProviderNormalizer(
@@ -236,6 +236,7 @@ function createFullModelCatalogAccess(params: {
   });
   return {
     isCurrent: params.isCurrent,
+    withRefreshStatus: attempt.withRefreshStatus,
     loadAuth: ({ providerIds, profileIds }) => {
       const cacheKey = [providerIds, profileIds ?? []]
         .map((ids) =>

--- a/src/agents/prepared-model-runtime.full-catalog.ts
+++ b/src/agents/prepared-model-runtime.full-catalog.ts
@@ -294,6 +294,7 @@ export function markPreparedModelCatalogFull(snapshot: ModelCatalogSnapshot): Mo
 
 export type PreparedModelRuntimeCatalogAccess = Readonly<{
   isCurrent: () => boolean;
+  withRefreshStatus: (catalog: ModelCatalogSnapshot) => ModelCatalogSnapshot;
   readFullModelCatalog: () => ModelCatalogSnapshot | undefined;
   loadFullModelCatalog: (options?: { refresh?: boolean }) => Promise<ModelCatalogSnapshot>;
   loadAuth: (scope: PreparedModelRuntimeAuthScope) => Promise<PreparedModelRuntimeAuth>;
@@ -341,7 +342,7 @@ export function createPreparedModelRuntimeSnapshot(
     ...(pluginRegistry ? { pluginRegistry } : {}),
     ...(messageToolCatalog ? { messageToolCatalog } : {}),
     ...(mediaCapabilityProviders ? { mediaCapabilityProviders } : {}),
-    modelCatalog,
+    modelCatalog: catalogAccess.withRefreshStatus(modelCatalog),
     readFullModelCatalog: catalogAccess.readFullModelCatalog,
     loadFullModelCatalog: catalogAccess.loadFullModelCatalog,
     configuredRuntimeModels,

--- a/src/agents/prepared-model-runtime.publication-events.ts
+++ b/src/agents/prepared-model-runtime.publication-events.ts
@@ -1,5 +1,6 @@
 import { toStringifiedError } from "@openclaw/normalization-core/error-coercion";
 import { createSubsystemLogger } from "../logging/subsystem.js";
+import type { ModelCatalogSnapshot } from "./model-catalog.types.js";
 import { PreparedModelRuntimePublicationSupersededError } from "./prepared-model-runtime.errors.js";
 import type { PreparedModelRuntimeOwner } from "./prepared-model-runtime.types.js";
 
@@ -15,8 +16,23 @@ const publicationListeners = new Set<(event: PreparedModelRuntimePublicationEven
 export function createCatalogAttemptReporter(
   owner: Pick<PreparedModelRuntimeOwner, "catalogAttemptError">,
   isCurrent: () => boolean,
-): { published: () => void; failed: (error: unknown) => never } {
+): {
+  published: () => void;
+  failed: (error: unknown) => never;
+  withRefreshStatus: (catalog: ModelCatalogSnapshot) => ModelCatalogSnapshot;
+} {
   return {
+    withRefreshStatus: (catalog) => {
+      // Keep the status live on retained inventory without copying an error into its successor.
+      Object.defineProperty(catalog, "refreshFailed", {
+        enumerable: true,
+        get: () =>
+          owner.catalogAttemptError !== undefined ||
+          catalog.providerOutcomes?.some((outcome) => outcome.status !== "ready") ||
+          undefined,
+      });
+      return catalog;
+    },
     published: () => {
       delete owner.catalogAttemptError;
       notifyPreparedModelRuntimePublication({ phase: "catalog-published" });

--- a/src/agents/prepared-model-runtime.reload-auth.test.ts
+++ b/src/agents/prepared-model-runtime.reload-auth.test.ts
@@ -76,6 +76,8 @@ describe("prepared model runtime reload auth adoption", () => {
         .soft(await loadPublishedGatewayReplyDispatchRuntime({ agentId: "default" }))
         .toBe(dispatch);
       expect.soft(owner.catalogAttemptError).toBe(failure);
+      expect.soft(snapshot.modelCatalog.refreshFailed).toBe(true);
+      expect.soft(original.refreshFailed).toBe(true);
       expect.soft(events).toContainEqual({ phase: "catalog-failed", error: failure });
       expect.soft(events.map((event) => event.phase)).not.toContain("failed");
       const runInput = {
@@ -116,6 +118,8 @@ describe("prepared model runtime reload auth adoption", () => {
         throw new Error("catalog attempt test lost its internal inventory after recovery");
       }
       expect.soft(owner.catalogAttemptError).toBeUndefined();
+      expect.soft(snapshot.modelCatalog.refreshFailed).toBeUndefined();
+      expect.soft(snapshot.readFullModelCatalog()?.refreshFailed).toBeUndefined();
     } finally {
       unregister();
     }
@@ -145,11 +149,13 @@ describe("prepared model runtime reload auth adoption", () => {
     mocks.runPreparedModelCatalogWorker.mockRejectedValueOnce(failure);
     await expect(snapshot.loadFullModelCatalog()).rejects.toBe(failure);
     expect(owner.catalogAttemptError).toBe(failure);
+    expect(snapshot.modelCatalog.refreshFailed).toBe(true);
     expect(owner.catalogInventory).toBeUndefined();
     expect(snapshot.readFullModelCatalog()).toBeUndefined();
     expect(snapshot.isCurrent()).toBe(true);
     await snapshot.loadFullModelCatalog();
     expect(owner.catalogAttemptError).toBeUndefined();
+    expect(snapshot.modelCatalog.refreshFailed).toBeUndefined();
     expect(snapshot.readFullModelCatalog()).toBeDefined();
   });
 

--- a/src/gateway/chat-auth-readiness.integration.test.ts
+++ b/src/gateway/chat-auth-readiness.integration.test.ts
@@ -46,7 +46,8 @@ it("refreshes a retained pane from a persisted profile-only selection through th
       { ...entry, sessionId: "other-session" },
     );
     const request = makeRequestMock({
-      "chat.metadata": async (params: unknown) => {
+      "chat.metadata": async () => ({ commands: [] }),
+      "models.list": async (params: unknown) => {
         const selected = loadGatewaySessionEntryReadOnly(
           (params as { sessionKey: string }).sessionKey,
           { agentId: "main" },

--- a/src/gateway/server-methods/chat-metadata-contract.ts
+++ b/src/gateway/server-methods/chat-metadata-contract.ts
@@ -1,3 +1,4 @@
+import type { ModelChoice } from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import type { ChatAccountSelection } from "../../../packages/gateway-protocol/src/schema/users.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { UserModelAccountSelection } from "../model-account-authority.js";
@@ -27,7 +28,7 @@ export type ChatMetadataReadParams = {
 
 export type ChatMetadataResult = {
   commands?: unknown[];
-  models?: unknown[];
+  models?: ModelChoice[];
   swarmEnabled: boolean;
   accountSelection?: ChatAccountSelection;
 };

--- a/src/gateway/server-methods/chat-metadata-handler.ts
+++ b/src/gateway/server-methods/chat-metadata-handler.ts
@@ -3,86 +3,90 @@ import {
   errorShape,
   validateChatMetadataParams,
 } from "../../../packages/gateway-protocol/src/index.js";
+import type { ChatMetadataParams } from "../../../packages/gateway-protocol/src/index.js";
 import { resolveSessionAgentId } from "../../agents/agent-scope.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { ModelAccountConnectAuthorityError } from "../model-account-connect.js";
 import { resolveRequestedSessionAgentId } from "../session-request-agent.js";
 import { loadGatewaySessionEntryReadOnly } from "../session-utils.js";
 import { resolveAgentIdOrRespondError } from "./agent-id-shared.js";
+import type { ChatMetadataReadParams } from "./chat-metadata-contract.js";
 import { normalizeOptionalChatText } from "./chat-text-normalization.js";
 import type { GatewayRequestHandlerOptions } from "./types.js";
 import { preparePersonalModelAccountSelection } from "./users-model-account-access.js";
 import { resolveAuthenticatedProfileId } from "./users-profile-access.js";
 import { assertValidParams } from "./validation.js";
 
-export async function handleChatMetadataRequest({
-  params,
-  respond,
-  context,
-  client,
-  signal,
-}: GatewayRequestHandlerOptions): Promise<void> {
-  if (!assertValidParams(params, validateChatMetadataParams, "chat.metadata", respond)) {
-    return;
-  }
-  const metadataParams = params;
+/** Resolve saved-session grants or capture a new draft's current human authority. */
+export function resolveChatMetadataReadParams(
+  options: Pick<GatewayRequestHandlerOptions, "respond" | "context" | "client" | "signal">,
+  params: ChatMetadataParams,
+): ChatMetadataReadParams | undefined {
+  const { respond, context, client, signal } = options;
   const cfg = context.getRuntimeConfig();
-  if (metadataParams.sessionKey) {
+  if (params.sessionKey) {
     const requested = resolveRequestedSessionAgentId(
       cfg,
-      metadataParams.sessionKey,
-      normalizeOptionalChatText(metadataParams.agentId),
+      params.sessionKey,
+      normalizeOptionalChatText(params.agentId),
     );
     if (!requested.ok) {
       respond(false, undefined, requested.error);
       return;
     }
-    // The router authorizes the session selector; only the persisted entry supplies auth profiles.
-    const session = loadGatewaySessionEntryReadOnly(metadataParams.sessionKey, {
+    // Persisted session state owns account pins; a caller cannot replace them with a draft id.
+    const session = loadGatewaySessionEntryReadOnly(params.sessionKey, {
       agentId: requested.agentId,
       projection: "list",
     });
-    respond(
-      true,
-      await context.readChatMetadata({
-        agentId: resolveSessionAgentId({
-          sessionKey: metadataParams.sessionKey,
-          config: session.cfg,
-          agentId: requested.agentId,
-        }),
-        sessionKey: session.canonicalKey,
-        sessionEntry: session.entry,
-        requesterProfileId: resolveAuthenticatedProfileId(client),
+    return {
+      agentId: resolveSessionAgentId({
+        sessionKey: params.sessionKey,
+        config: session.cfg,
+        agentId: requested.agentId,
       }),
-    );
-    return;
+      sessionKey: session.canonicalKey,
+      sessionEntry: session.entry,
+      requesterProfileId: resolveAuthenticatedProfileId(client),
+    };
   }
-  const resolvedAgent = resolveAgentIdOrRespondError({
-    rawAgentId: metadataParams.agentId,
+  const resolved = resolveAgentIdOrRespondError({
+    rawAgentId: params.agentId,
     respond,
     cfg,
-    normalize: (rawAgentId) =>
-      typeof rawAgentId === "string" && rawAgentId.trim()
-        ? normalizeAgentId(rawAgentId)
-        : undefined,
+    normalize: (id) => (typeof id === "string" && id.trim() ? normalizeAgentId(id) : undefined),
   });
-  if (!resolvedAgent) {
+  if (!resolved) {
+    return;
+  }
+  const draftAccountSelection = params.authProfileId
+    ? preparePersonalModelAccountSelection(
+        { client, context, signal },
+        params.authProfileId,
+        "operator.read",
+      )
+    : undefined;
+  return {
+    agentId: resolved.agentId,
+    requesterProfileId: draftAccountSelection?.owner ?? resolveAuthenticatedProfileId(client),
+    ...(draftAccountSelection ? { draftAccountSelection } : {}),
+  };
+}
+
+export async function handleChatMetadataRequest(
+  options: GatewayRequestHandlerOptions,
+): Promise<void> {
+  const { params, respond, context } = options;
+  if (!assertValidParams(params, validateChatMetadataParams, "chat.metadata", respond)) {
     return;
   }
   try {
-    const draftAccountSelection = metadataParams.authProfileId
-      ? preparePersonalModelAccountSelection(
-          { client, context, signal },
-          metadataParams.authProfileId,
-          "operator.read",
-        )
-      : undefined;
-    const metadata = await context.readChatMetadata({
-      agentId: resolvedAgent.agentId,
-      requesterProfileId: draftAccountSelection?.owner ?? resolveAuthenticatedProfileId(client),
-      ...(draftAccountSelection ? { draftAccountSelection } : {}),
-    });
-    draftAccountSelection?.assertCurrent();
+    const scope = resolveChatMetadataReadParams(options, params);
+    if (!scope) {
+      return;
+    }
+    const metadata = await context.readChatMetadata(scope);
+    scope.draftAccountSelection?.assertCurrent();
     respond(true, metadata);
   } catch (error) {
     if (!(error instanceof ModelAccountConnectAuthorityError)) {

--- a/src/gateway/server-methods/chat-metadata-handler.ts
+++ b/src/gateway/server-methods/chat-metadata-handler.ts
@@ -32,7 +32,7 @@ export function resolveChatMetadataReadParams(
     );
     if (!requested.ok) {
       respond(false, undefined, requested.error);
-      return;
+      return undefined;
     }
     // Persisted session state owns account pins; a caller cannot replace them with a draft id.
     const session = loadGatewaySessionEntryReadOnly(params.sessionKey, {
@@ -57,7 +57,7 @@ export function resolveChatMetadataReadParams(
     normalize: (id) => (typeof id === "string" && id.trim() ? normalizeAgentId(id) : undefined),
   });
   if (!resolved) {
-    return;
+    return undefined;
   }
   const draftAccountSelection = params.authProfileId
     ? preparePersonalModelAccountSelection(

--- a/src/gateway/server-methods/chat-metadata-runtime.test-support.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.test-support.ts
@@ -187,7 +187,10 @@ export function createChatMetadataHarness(
     },
   );
   const readProjection = vi.fn(
-    (projection: { modelCatalog: ModelCatalogEntry[]; models?: unknown[] }) => projection,
+    (projection: {
+      modelCatalog: ModelCatalogEntry[];
+      models?: import("../../../packages/gateway-protocol/src/index.js").ModelChoice[];
+    }) => projection,
   );
   const context = {
     getRuntimeConfig: () => config,

--- a/src/gateway/server-methods/chat-metadata-runtime.ts
+++ b/src/gateway/server-methods/chat-metadata-runtime.ts
@@ -12,7 +12,6 @@ import { getPreparedModelFullCatalogAuth } from "../../agents/prepared-model-run
 import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.js";
 import { resolveSwarmConfig } from "../../agents/subagents/swarm/swarm-config.js";
 import { resolveRuntimeConfigCacheKey } from "../../config/runtime-snapshot.js";
-import { resolveCollapsedSessionAuthPinSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { formatErrorMessage } from "../../infra/errors.js";
 import { pruneMapToMaxSize } from "../../infra/map-size.js";
@@ -29,6 +28,7 @@ import type {
 } from "./chat-metadata-contract.js";
 import {
   prepareChatMetadataModelProjection,
+  resolveSessionCatalogProfiles,
   projectChatSessionMetadata,
   type ChatMetadataProjectionFacts,
   type PreparedAgentProjection,
@@ -178,24 +178,9 @@ function generationFactsMatch(
   });
 }
 
-function resolveSessionProfiles(sessionEntry: ChatMetadataSessionEntry | undefined): {
-  preferredProfileId?: string;
-  pinnedProfileId?: string;
-} {
-  const profileId = sessionEntry?.authProfileOverride?.trim();
-  if (!profileId) {
-    return {};
-  }
-  const profileSource = resolveCollapsedSessionAuthPinSource(sessionEntry);
-  return {
-    preferredProfileId: profileId,
-    ...(profileSource === "user" ? { pinnedProfileId: profileId } : {}),
-  };
-}
-
 function sessionProjectionKey(
   agentId: string,
-  profiles: ReturnType<typeof resolveSessionProfiles>,
+  profiles: ReturnType<typeof resolveSessionCatalogProfiles>,
 ): string {
   return [
     normalizeAgentId(agentId),
@@ -286,7 +271,7 @@ export function createGatewayChatMetadataRuntime(params: {
   ): Promise<PreparedAgentProjection> => {
     assertOpen();
     assertCurrent?.();
-    const profiles = resolveSessionProfiles(sessionEntry);
+    const profiles = resolveSessionCatalogProfiles(sessionEntry);
     const neutral =
       profiles.preferredProfileId === undefined && profiles.pinnedProfileId === undefined;
     const defaultProfileId = useRequesterDefaults ? requesterProfileId : undefined;
@@ -615,7 +600,7 @@ export function createGatewayChatMetadataRuntime(params: {
   const readStartup = async (
     readParams: ChatStartupProjectionReadParams,
   ): Promise<ChatStartupProjectionResult | undefined> => {
-    const profiles = resolveSessionProfiles(readParams.sessionEntry);
+    const profiles = resolveSessionCatalogProfiles(readParams.sessionEntry);
     const assemble = (
       neutral: PreparedAgentProjection,
       session: PreparedAgentProjection,

--- a/src/gateway/server-methods/chat-metadata-session-projection.ts
+++ b/src/gateway/server-methods/chat-metadata-session-projection.ts
@@ -1,4 +1,4 @@
-import { asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import type { ModelChoice } from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import type { PreparedAgentCredentialModes } from "../../agents/agent-auth-credential-modes.js";
 import type { AuthProfileStore } from "../../agents/auth-profiles/types.js";
 import { readSessionRuntimeOwnership } from "../../agents/harness/session-runtime-ownership.js";
@@ -6,8 +6,13 @@ import type { ModelCatalogEntry, ModelCatalogSnapshot } from "../../agents/model
 import { getPreparedModelRuntimeAuthMaterializations } from "../../agents/prepared-model-runtime-auth.js";
 import type { PreparedModelRuntimeSnapshot } from "../../agents/prepared-model-runtime.js";
 import { resolveSessionModelRef } from "../../agents/session-model-ref.js";
+import { resolveCollapsedSessionAuthPinSource } from "../../config/sessions/auth-profile-override-provenance.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
-import type { ChatMetadataReadParams, ChatMetadataResult } from "./chat-metadata-contract.js";
+import type {
+  ChatMetadataReadParams,
+  ChatMetadataResult,
+  ChatMetadataSessionEntry,
+} from "./chat-metadata-contract.js";
 import type { GatewayRequestContext } from "./types.js";
 
 export type ChatMetadataProjectionFacts = {
@@ -31,7 +36,7 @@ export async function prepareChatMetadataModelProjection(params: {
   preferredProfileId?: string;
   pinnedProfileId?: string;
   assertCurrent?: () => void;
-}): Promise<PreparedAgentProjection<{ models?: unknown[] }>> {
+}): Promise<PreparedAgentProjection<{ models?: ModelChoice[] }>> {
   const { prepareModelsListResult, createGatewayAgentModelCatalogProjector } =
     await import("./models-list-result.js");
   // A draft has no persisted session grant: recheck its live human before hydrating private auth.
@@ -79,37 +84,57 @@ export async function prepareChatMetadataModelProjection(params: {
   };
 }
 
-// Read session ownership after the shared profile projection; never cache this overlay.
-export function projectChatSessionMetadata(
-  readParams: ChatMetadataReadParams,
-  metadata: ChatMetadataResult,
-  config: OpenClawConfig,
-): ChatMetadataResult {
-  const ownership = readSessionRuntimeOwnership({ ...readParams, config });
-  if (ownership?.auth !== "native" || !metadata.models) {
-    return metadata;
+export function resolveSessionCatalogProfiles(sessionEntry: ChatMetadataSessionEntry | undefined): {
+  preferredProfileId?: string;
+  pinnedProfileId?: string;
+} {
+  const profileId = sessionEntry?.authProfileOverride?.trim();
+  if (!profileId) {
+    return {};
   }
-  // Pending native branches have no tuple yet. Remove the host-only gate from
-  // the rendered placeholder, without calling it a native selection or proving credentials.
+  const profileSource = resolveCollapsedSessionAuthPinSource(sessionEntry);
+  return {
+    preferredProfileId: profileId,
+    ...(profileSource === "user" ? { pinnedProfileId: profileId } : {}),
+  };
+}
+
+// Read native ownership after profile projection; never cache this session overlay.
+export function projectSessionModelCatalog(
+  readParams: ChatMetadataReadParams,
+  models: ModelChoice[],
+  config: OpenClawConfig,
+): ModelChoice[] {
+  const ownership = readSessionRuntimeOwnership({ ...readParams, config });
+  if (ownership?.auth !== "native") {
+    return models;
+  }
+  // Pending native branches have no tuple. Omit host readiness without claiming native login.
   const renderedModel =
     ownership.modelRef ??
     resolveSessionModelRef(config, readParams.sessionEntry, readParams.agentId, {
       allowPluginNormalization: false,
     });
-  return {
-    ...metadata,
-    models: metadata.models.map((model) => {
-      const row = asOptionalRecord(model);
-      if (row?.provider !== renderedModel.provider || row.id !== renderedModel.model) {
-        return model;
-      }
-      const {
-        available: _available,
-        unavailableReason: _reason,
-        unavailableUntil: _until,
-        ...native
-      } = row;
-      return native;
-    }),
-  };
+  return models.map((model) => {
+    if (model.provider !== renderedModel.provider || model.id !== renderedModel.model) {
+      return model;
+    }
+    const {
+      available: _available,
+      unavailableReason: _reason,
+      unavailableUntil: _until,
+      ...native
+    } = model;
+    return native;
+  });
+}
+
+export function projectChatSessionMetadata(
+  readParams: ChatMetadataReadParams,
+  metadata: ChatMetadataResult,
+  config: OpenClawConfig,
+): ChatMetadataResult {
+  return metadata.models
+    ? { ...metadata, models: projectSessionModelCatalog(readParams, metadata.models, config) }
+    : metadata;
 }

--- a/src/gateway/server-methods/models-list-result.configured-static.test.ts
+++ b/src/gateway/server-methods/models-list-result.configured-static.test.ts
@@ -53,7 +53,12 @@ describe("models.list configured static entries", () => {
           return respond.mock.calls[0]?.[1];
         };
         const shared = await read();
-        expect(await read(alice.id)).toEqual(shared);
+        expect(shared).toEqual({ models: [] });
+        const unconfiguredPersonal = {
+          models: [],
+          accountSelection: { kind: "automatic", label: "Automatic account selection" },
+        };
+        expect(await read(alice.id)).toEqual(unconfiguredPersonal);
         connectUserModelAccount({
           ownerProfileId: alice.id,
           credential: {
@@ -72,14 +77,14 @@ describe("models.list configured static entries", () => {
             expect.objectContaining({ id: "gpt-5.6-luna", available: true }),
           ]),
         });
-        expect(await read(bob.id)).toEqual(shared);
+        expect(await read(bob.id)).toEqual(unconfiguredPersonal);
         expect(await read()).toEqual(shared);
 
         const merged = ensureProfileForEmail("alice-new@example.test");
         linkEmail("alice@example.test", merged.id);
         expect(await read(alice.id)).toEqual(connected);
         clearUserProfileAuthLink({ profileId: merged.id, provider: "openai" });
-        expect(await read(alice.id)).toEqual(shared);
+        expect(await read(alice.id)).toEqual(unconfiguredPersonal);
       },
     );
   });

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -3,6 +3,7 @@ import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
 import type {
   ModelChoice,
   ModelsListParams,
+  ModelsListResult,
 } from "../../../packages/gateway-protocol/src/schema/agents-models-skills.js";
 import { resolveAgentWorkspaceDir, resolveDefaultAgentId } from "../../agents/agent-scope.js";
 import type { RuntimeAuthMaterialization } from "../../agents/auth-profiles/runtime-materializations.js";
@@ -50,6 +51,9 @@ import type { PluginMetadataSnapshot } from "../../plugins/plugin-metadata-snaps
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { loadDeferredCatalog, readPreparedCatalog } from "../server-model-catalog-auth.js";
 import { resolveGatewayModelThinkingProfile } from "../session-utils-model.js";
+import { resolveChatAccountSelection } from "./chat-account-selection.js";
+import type { ChatMetadataReadParams, ChatMetadataSessionEntry } from "./chat-metadata-contract.js";
+import { resolveSessionCatalogProfiles } from "./chat-metadata-session-projection.js";
 import { resolveModelProviderCapabilities } from "./model-provider-capabilities.js";
 import {
   createModelsListAuthProjection,
@@ -71,10 +75,6 @@ type ModelsListEntryWithCapabilities = ModelChoice;
 type ApiKeyProviderCapabilities = {
   providers: ReadonlyMap<string, boolean>;
   resolveProvider(provider: string): string;
-};
-type ModelsListResult = {
-  models: ModelsListEntryWithCapabilities[];
-  providerOutcomes?: ReturnType<typeof projectProviderCatalogOutcomes>;
 };
 type PreparedModelsListResult = {
   read: () => ModelsListResult;
@@ -234,6 +234,7 @@ type BuildModelsListResultParams = {
   source: ModelsListCatalogSource;
   agentId?: string;
   requesterProfileId?: string;
+  readScope?: ChatMetadataReadParams;
   params: ModelsListParams;
   preloadedCatalog?: {
     agentId: string;
@@ -254,6 +255,7 @@ export async function buildModelsListResult(
       "Model catalog changed while preparing this result. Retry the request.",
     );
   }
+  params.readScope?.draftAccountSelection?.assertCurrent();
   return prepared.read();
 }
 
@@ -262,6 +264,14 @@ export async function prepareModelsListResult(
   params: BuildModelsListResultParams,
 ): Promise<PreparedModelsListResult> {
   const { source } = params;
+  const scope = params.readScope;
+  const draft = scope?.draftAccountSelection;
+  const sessionEntry: ChatMetadataSessionEntry | undefined = draft
+    ? { authProfileOverride: draft.authProfileId, authProfileOverrideSource: "user" }
+    : scope?.sessionEntry;
+  const profiles = resolveSessionCatalogProfiles(sessionEntry);
+  const useRequesterDefaults = !scope?.sessionKey && !scope?.sessionEntry;
+  draft?.assertCurrent();
   const currentConfig =
     source.kind === "gateway" ? source.context.getRuntimeConfig : getRuntimeConfig;
   const publishedOwner = source.kind === "published" ? source.owner : undefined;
@@ -348,6 +358,8 @@ export async function prepareModelsListResult(
   const { defaultModel } = preparedCatalog;
   const preparedRuntimeAuthModes = preparedProjectionOwner?.authModes;
   const preparedRuntimeAuthMaterializations = preparedProjectionOwner?.authMaterializations;
+  // Capture authority again after acquisition and before hydrating a personal projection.
+  draft?.assertCurrent();
   const projector =
     (usedPreloadedCatalog ? params.catalogProjector : undefined) ??
     createGatewayAgentModelCatalogProjector({
@@ -365,7 +377,11 @@ export async function prepareModelsListResult(
         ? isPreparedModelCatalogFull(publishedOwner.modelCatalog)
         : ownerSnapshot?.catalogComplete === true,
       // Provider-config inventory describes shared authored configuration, not personal accounts.
-      requesterProfileId: view === "provider-config" ? undefined : params.requesterProfileId,
+      requesterProfileId:
+        view === "provider-config" || !useRequesterDefaults
+          ? undefined
+          : (draft?.owner ?? params.requesterProfileId),
+      ...(view === "provider-config" ? {} : profiles),
       routeResolverFactory: params.routeResolverFactory,
       pluginRegistry: preparedPluginRegistry,
       isCurrent,
@@ -404,9 +420,21 @@ export async function prepareModelsListResult(
     !providerFilter || normalizeProvider(entry.provider) === providerFilter;
   const { routeVariants, providerOutcomes } = projector.snapshot;
   const publicProviderOutcomes = projectProviderCatalogOutcomes(providerOutcomes);
-  const outcomeProjection = publicProviderOutcomes?.length
-    ? { providerOutcomes: publicProviderOutcomes }
-    : {};
+  draft?.assertCurrent();
+  const outcomeProjection = {
+    ...(publicProviderOutcomes?.length ? { providerOutcomes: publicProviderOutcomes } : {}),
+    ...(snapshot.refreshFailed ? { refreshFailed: true } : {}),
+    ...(view === "provider-config" || (!scope && !params.requesterProfileId)
+      ? {}
+      : {
+          accountSelection: resolveChatAccountSelection({
+            authStore: projector.authStore,
+            sessionEntry,
+            requesterProfileId:
+              draft?.owner ?? scope?.requesterProfileId ?? params.requesterProfileId,
+          }),
+        }),
+  };
   const includeProviderCapabilities = params.params.includeProviderCapabilities === true;
   const capableProviders = includeProviderCapabilities
     ? apiKeyProviderCapabilities({ cfg, metadataSnapshot, workspaceDir })

--- a/src/gateway/server-methods/models-session.test.ts
+++ b/src/gateway/server-methods/models-session.test.ts
@@ -52,9 +52,9 @@ function fixture() {
   const authStore = expectDefined(getPreparedModelRuntimeAuthStore(owner), "prepared auth store");
   const snapshot: PreparedGatewayModelCatalogSnapshot = {
     ...owner.modelCatalog,
-    agentId: owner.agentId,
+    agentId: expectDefined(owner.agentId, "fixture agent"),
     agentDir: owner.agentDir,
-    workspaceDir: owner.workspaceDir,
+    workspaceDir: expectDefined(owner.workspaceDir, "fixture workspace"),
     config,
     observationConfig: config,
     metadataSnapshot: owner.metadataSnapshot,
@@ -136,6 +136,13 @@ describe("direct session model catalogs", () => {
   it("uses a saved session pin after the viewer changes their default and keeps agent reads separate", async () => {
     await withOpenClawTestState(isolated, async (state) => {
       const f = fixture();
+      f.config.agents = {
+        ...f.config.agents,
+        list: [
+          { id: "main", default: true },
+          { id: "other", default: false },
+        ],
+      };
       await state.writeConfig(f.config);
       const sessionKey = "agent:main:saved";
       await upsertSessionEntryCore(

--- a/src/gateway/server-methods/models-session.test.ts
+++ b/src/gateway/server-methods/models-session.test.ts
@@ -1,0 +1,387 @@
+import { expectDefined } from "@openclaw/normalization-core";
+import { describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import { getPreparedModelRuntimeAuthStore } from "../../agents/prepared-model-runtime-auth.js";
+import { upsertSessionEntryCore } from "../../config/sessions/session-accessor.js";
+import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createEmptyPluginRegistry } from "../../plugins/registry-empty.js";
+import { resetPluginRuntimeStateForTest, setActivePluginRegistry } from "../../plugins/runtime.js";
+import {
+  clearUserProfileAuthLink,
+  listUserProfileAuthLinks,
+  readUserModelAuthProfile,
+} from "../../state/user-model-accounts.js";
+import { ensureProfileForEmail, setDisplayName } from "../../state/user-profiles.js";
+import { withOpenClawTestState } from "../../test-utils/openclaw-test-state.js";
+import { createDirectChatContext } from "../server-chat.agent-events.test-helpers.js";
+import {
+  registerGatewayModelCatalogPrivateAccess,
+  type PreparedGatewayModelCatalogSnapshot,
+} from "../server-model-catalog-auth.js";
+import {
+  connectChatMetadataAccount,
+  createChatMetadataOwner,
+  createOpenAIChatMetadataConfig,
+} from "./chat-metadata-runtime.test-support.js";
+import { WITHOUT_OPENAI_ENV_AUTH } from "./models-list-result.openai-routes.test-support.js";
+import { modelsHandlers } from "./models.js";
+import type { GatewayRequestHandlerOptions, RespondFn } from "./types.js";
+
+function fixture() {
+  const person = ensureProfileForEmail("catalog-reader@example.test");
+  setDisplayName(person.id, "Catalog Reader");
+  const authProfileId = connectChatMetadataAccount(person.id);
+  const config = {
+    ...createOpenAIChatMetadataConfig(),
+    gateway: {
+      roles: {
+        default: "reader",
+        definitions: {
+          reader: { agents: "*", scopes: ["operator.read"], sessions: { others: "none" } },
+        },
+      },
+    },
+  } satisfies OpenClawConfig;
+  const owner = createChatMetadataOwner(
+    config,
+    "gpt-5.6-sol",
+    {},
+    "openai",
+    "openai-chatgpt-responses",
+  );
+  const authStore = expectDefined(getPreparedModelRuntimeAuthStore(owner), "prepared auth store");
+  const snapshot: PreparedGatewayModelCatalogSnapshot = {
+    ...owner.modelCatalog,
+    agentId: owner.agentId,
+    agentDir: owner.agentDir,
+    workspaceDir: owner.workspaceDir,
+    config,
+    observationConfig: config,
+    metadataSnapshot: owner.metadataSnapshot,
+    isCurrent: owner.isCurrent,
+    authStore,
+    authModes: owner.authModes,
+    authMaterializations: [],
+  };
+  const client: NonNullable<GatewayRequestHandlerOptions["client"]> & { connId: string } = {
+    connId: "catalog-reader-connection",
+    connect: {
+      minProtocol: 1,
+      maxProtocol: 1,
+      client: { id: "openclaw-control-ui", version: "test", platform: "test", mode: "webchat" },
+      role: "operator",
+      scopes: ["operator.read"],
+    },
+    authenticatedUserProfile: {
+      profileId: person.id,
+      displayName: person.displayName,
+      hasAvatar: false,
+      updatedAt: person.updatedAt,
+    },
+  };
+  const clients = new Set([client]);
+  const readPrepared = vi.fn(async () => snapshot);
+  const loadDeferred = vi.fn(async () => snapshot);
+  const loader = async () => snapshot;
+  registerGatewayModelCatalogPrivateAccess(loader, { readPrepared, loadDeferred });
+  const context = createDirectChatContext({
+    getRuntimeConfig: () => config,
+    loadGatewayModelCatalogSnapshot: loader,
+    getClientConnIds: (filter) =>
+      new Set(
+        [...clients]
+          .filter((current) => !filter || filter(current))
+          .map((current) => current.connId),
+      ),
+  });
+  const request = async (
+    params: Record<string, unknown>,
+    overrides: Partial<Pick<GatewayRequestHandlerOptions, "client" | "signal">> = {},
+  ) => {
+    const respond = vi.fn<RespondFn>();
+    await expectDefined(
+      modelsHandlers["models.list"],
+      "models.list handler",
+    )({
+      req: { type: "req", id: "session-catalog", method: "models.list", params },
+      params,
+      context,
+      client,
+      respond,
+      isWebchatConnect: () => false,
+      ...overrides,
+    });
+    return respond;
+  };
+  return {
+    person,
+    authProfileId,
+    config,
+    client,
+    clients,
+    snapshot,
+    readPrepared,
+    loadDeferred,
+    request,
+  };
+}
+
+const isolated = {
+  layout: "state-only",
+  prefix: "direct-session-catalog-",
+  env: WITHOUT_OPENAI_ENV_AUTH,
+} as const;
+
+describe("direct session model catalogs", () => {
+  it("uses a saved session pin after the viewer changes their default and keeps agent reads separate", async () => {
+    await withOpenClawTestState(isolated, async (state) => {
+      const f = fixture();
+      await state.writeConfig(f.config);
+      const sessionKey = "agent:main:saved";
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey },
+        {
+          sessionId: "saved-catalog-session",
+          updatedAt: 1,
+          authProfileOverride: f.authProfileId,
+          authProfileOverrideSource: "user",
+        },
+      );
+      clearUserProfileAuthLink({ profileId: f.person.id, provider: "openai" });
+      const saved = await f.request({ sessionKey, view: "configured" });
+      expect(saved).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          models: [expect.objectContaining({ id: "gpt-5.6-sol", available: true })],
+          accountSelection: expect.objectContaining({
+            kind: "personal",
+            authProfileId: f.authProfileId,
+            source: "user",
+          }),
+        }),
+        undefined,
+      );
+      const neutral = await f.request({ agentId: "main", view: "configured" });
+      expect(neutral).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          models: [expect.objectContaining({ available: false })],
+          accountSelection: { kind: "automatic", label: "Automatic account selection" },
+        }),
+        undefined,
+      );
+      const mismatch = await f.request({ agentId: "other", sessionKey, view: "configured" });
+      expect(mismatch).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({ code: "INVALID_REQUEST" }),
+      );
+      expect(f.loadDeferred).not.toHaveBeenCalled();
+      expect(f.snapshot.authStore.profiles).toEqual({});
+    });
+  });
+
+  it("projects a saved native session without borrowing host authentication state", async () => {
+    await withOpenClawTestState(isolated, async (state) => {
+      const f = fixture();
+      await state.writeConfig(f.config);
+      clearUserProfileAuthLink({ profileId: f.person.id, provider: "openai" });
+      const sessionKey = "agent:main:harness:catalog-native:saved";
+      await upsertSessionEntryCore(
+        { agentId: "main", sessionKey },
+        {
+          sessionId: "catalog-native-session",
+          updatedAt: 1,
+          agentHarnessId: "catalog-native",
+          modelSelectionLocked: true,
+        },
+      );
+      const registry = createEmptyPluginRegistry();
+      registry.agentHarnesses.push({
+        pluginId: "catalog-native",
+        source: "test",
+        harness: {
+          id: "catalog-native",
+          label: "Native catalog fixture",
+          supports: () => ({ supported: true }),
+          runAttempt: async () => {
+            throw new Error("A model read must not run inference");
+          },
+          resolveSessionRuntimeOwnership: (params) => {
+            params.assertCurrent();
+            return params.sessionKey === sessionKey && params.sessionId === "catalog-native-session"
+              ? { model: "native", auth: "native" }
+              : undefined;
+          },
+        },
+      });
+      setActivePluginRegistry(registry);
+      try {
+        const direct = await f.request({ sessionKey, view: "configured" });
+        expect(direct.mock.calls[0]?.[1]).toMatchObject({
+          models: [{ id: "gpt-5.6-sol", provider: "openai" }],
+        });
+        const payload = direct.mock.calls[0]?.[1];
+        expect(payload).not.toEqual(
+          expect.objectContaining({
+            models: [expect.objectContaining({ available: expect.anything() })],
+          }),
+        );
+        const neutral = await f.request({ agentId: "main", view: "configured" });
+        expect(neutral).toHaveBeenCalledWith(
+          true,
+          expect.objectContaining({ models: [expect.objectContaining({ available: false })] }),
+          undefined,
+        );
+        expect(f.snapshot.entries[0]).not.toHaveProperty("available");
+      } finally {
+        resetPluginRuntimeStateForTest();
+      }
+    });
+  });
+
+  it("does not substitute a viewer default for a session with no saved pin", async () => {
+    await withOpenClawTestState(isolated, async (state) => {
+      const f = fixture();
+      await state.writeConfig(f.config);
+      const agent = await f.request({ agentId: "main", view: "configured" });
+      expect(agent).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ models: [expect.objectContaining({ available: true })] }),
+        undefined,
+      );
+      const session = await f.request({ sessionKey: "agent:main:uncreated", view: "configured" });
+      expect(session).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({ models: [expect.objectContaining({ available: false })] }),
+        undefined,
+      );
+    });
+  });
+
+  it("previews a retained self-owned draft without changing shared inventory or account defaults", async () => {
+    await withOpenClawTestState(isolated, async () => {
+      const f = fixture();
+      clearUserProfileAuthLink({ profileId: f.person.id, provider: "openai" });
+      const before = readUserModelAuthProfile(f.authProfileId);
+      const preview = await f.request({
+        agentId: "main",
+        authProfileId: f.authProfileId,
+        view: "configured",
+      });
+      expect(preview).toHaveBeenCalledWith(
+        true,
+        expect.objectContaining({
+          models: [expect.objectContaining({ available: true })],
+          accountSelection: expect.objectContaining({
+            kind: "personal",
+            authProfileId: f.authProfileId,
+            source: "user",
+          }),
+        }),
+        undefined,
+      );
+      const inventory = await f.request({
+        agentId: "main",
+        authProfileId: f.authProfileId,
+        view: "provider-config",
+      });
+      expect(inventory.mock.calls[0]?.[1]).not.toHaveProperty("accountSelection");
+      expect(listUserProfileAuthLinks(f.person.id)).toEqual([]);
+      expect(readUserModelAuthProfile(f.authProfileId)).toEqual(before);
+      expect(f.snapshot.authStore.profiles).toEqual({});
+      expect(f.loadDeferred).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each(["foreign admin", "anonymous", "synthetic", "forged locator"] as const)(
+    "rejects %s before reading private catalog state",
+    async (caller) => {
+      await withOpenClawTestState(isolated, async () => {
+        const f = fixture();
+        let authProfileId = f.authProfileId;
+        if (caller === "foreign admin") {
+          const other = ensureProfileForEmail("other-reader@example.test");
+          f.client.connect.scopes = ["operator.admin"];
+          f.client.authenticatedUserProfile = {
+            profileId: other.id,
+            displayName: other.displayName,
+            hasAvatar: false,
+            updatedAt: other.updatedAt,
+          };
+        } else if (caller === "synthetic") {
+          f.client.internal = { syntheticClient: true };
+        } else if (caller === "forged locator") {
+          authProfileId = "personal:missing:missing";
+        }
+        const result = await f.request(
+          { agentId: "main", authProfileId },
+          caller === "anonymous" ? { client: null } : {},
+        );
+        expect(result).toHaveBeenCalledWith(
+          false,
+          undefined,
+          expect.objectContaining({ code: "FORBIDDEN" }),
+        );
+        expect(f.readPrepared).not.toHaveBeenCalled();
+      });
+    },
+  );
+
+  it("rejects a combined saved-session and draft-account request", async () => {
+    await withOpenClawTestState(isolated, async () => {
+      const f = fixture();
+      const result = await f.request({
+        sessionKey: "agent:main:saved",
+        authProfileId: f.authProfileId,
+      });
+      expect(result).toHaveBeenCalledWith(
+        false,
+        undefined,
+        expect.objectContaining({ code: "INVALID_REQUEST" }),
+      );
+      expect(f.readPrepared).not.toHaveBeenCalled();
+    });
+  });
+
+  it.each(["disconnect", "role loss", "abort"] as const)(
+    "rechecks draft authority after a snapshot await and %s",
+    async (loss) => {
+      await withOpenClawTestState(isolated, async () => {
+        const f = fixture();
+        const entered = createDeferred();
+        const release = createDeferred();
+        const abort = new AbortController();
+        f.readPrepared.mockImplementationOnce(async () => {
+          entered.resolve();
+          await release.promise;
+          return f.snapshot;
+        });
+        const pending = f.request(
+          { agentId: "main", authProfileId: f.authProfileId },
+          { signal: abort.signal },
+        );
+        try {
+          await Promise.race([entered.promise, pending]);
+          expect(f.readPrepared).toHaveBeenCalledOnce();
+          if (loss === "disconnect") {
+            f.clients.delete(f.client);
+          } else if (loss === "role loss") {
+            f.config.gateway.roles.definitions.reader.scopes = [];
+          } else {
+            abort.abort();
+          }
+        } finally {
+          release.resolve();
+        }
+        const result = await pending;
+        expect(result).toHaveBeenCalledWith(
+          false,
+          undefined,
+          expect.objectContaining({ code: "FORBIDDEN" }),
+        );
+        expect(f.snapshot.authStore.profiles).toEqual({});
+      });
+    },
+  );
+});

--- a/src/gateway/server-methods/models-session.test.ts
+++ b/src/gateway/server-methods/models-session.test.ts
@@ -52,6 +52,7 @@ function fixture() {
   const authStore = expectDefined(getPreparedModelRuntimeAuthStore(owner), "prepared auth store");
   const snapshot: PreparedGatewayModelCatalogSnapshot = {
     ...owner.modelCatalog,
+    catalogComplete: false,
     agentId: expectDefined(owner.agentId, "fixture agent"),
     agentDir: owner.agentDir,
     workspaceDir: expectDefined(owner.workspaceDir, "fixture workspace"),

--- a/src/gateway/server-methods/models.ts
+++ b/src/gateway/server-methods/models.ts
@@ -1,40 +1,69 @@
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 // Models gateway methods expose prepared, cached, and explicitly refreshed catalog views.
-import { validateModelsListParams } from "../../../packages/gateway-protocol/src/index.js";
+import {
+  ErrorCodes,
+  errorShape,
+  validateModelsListParams,
+} from "../../../packages/gateway-protocol/src/index.js";
 import { tryResolveAmbientOwnerAgentId } from "../../agents/agent-scope-config.js";
+import { ModelAccountConnectAuthorityError } from "../model-account-connect.js";
 import { resolveAgentIdOrRespondError } from "./agent-id-shared.js";
+import { resolveChatMetadataReadParams } from "./chat-metadata-handler.js";
+import { projectSessionModelCatalog } from "./chat-metadata-session-projection.js";
 import { buildModelsListResult } from "./models-list-result.js";
 import type { GatewayRequestHandlers } from "./types.js";
 import { resolveAuthenticatedProfileId } from "./users-profile-access.js";
 import { assertValidParams } from "./validation.js";
-
 export { buildModelsListResult };
 
 // Ordinary reads consume published facts; only an explicit refresh starts discovery.
 export const modelsHandlers: GatewayRequestHandlers = {
-  "models.list": async ({ params, respond, context, client }) => {
+  "models.list": async (options) => {
+    const { params, respond, context, client } = options;
     if (!assertValidParams(params, validateModelsListParams, "models.list", respond)) {
       return;
     }
-    const cfg = context.getRuntimeConfig();
-    const resolved = resolveAgentIdOrRespondError({
-      rawAgentId: params.agentId ?? tryResolveAmbientOwnerAgentId(cfg),
-      respond,
-      cfg,
-      normalize: normalizeOptionalString,
-    });
-    if (!resolved) {
-      return;
-    }
-    respond(
-      true,
-      await buildModelsListResult({
+    try {
+      const scoped = Boolean(params.sessionKey || params.authProfileId);
+      const scope = scoped ? resolveChatMetadataReadParams(options, params) : undefined;
+      if (scoped && !scope) {
+        return;
+      }
+      const cfg = context.getRuntimeConfig();
+      const resolved =
+        scope ??
+        resolveAgentIdOrRespondError({
+          rawAgentId: params.agentId ?? tryResolveAmbientOwnerAgentId(cfg),
+          respond,
+          cfg,
+          normalize: normalizeOptionalString,
+        });
+      if (!resolved) {
+        return;
+      }
+      const result = await buildModelsListResult({
         source: { kind: "gateway", context },
         agentId: resolved.agentId,
         params,
-        requesterProfileId: resolveAuthenticatedProfileId(client),
-      }),
-      undefined,
-    );
+        requesterProfileId: scope?.requesterProfileId ?? resolveAuthenticatedProfileId(client),
+        ...(scope ? { readScope: scope } : {}),
+      });
+      scope?.draftAccountSelection?.assertCurrent();
+      respond(
+        true,
+        scope && params.view !== "provider-config"
+          ? {
+              ...result,
+              models: projectSessionModelCatalog(scope, result.models, context.getRuntimeConfig()),
+            }
+          : result,
+        undefined,
+      );
+    } catch (error) {
+      if (!(error instanceof ModelAccountConnectAuthorityError)) {
+        throw error;
+      }
+      respond(false, undefined, errorShape(ErrorCodes.FORBIDDEN, error.message));
+    }
   },
 };

--- a/src/gateway/server.chat.gateway-server-chat-b.test.ts
+++ b/src/gateway/server.chat.gateway-server-chat-b.test.ts
@@ -2218,7 +2218,10 @@ describe("gateway server chat", () => {
                 string,
                 Promise<{
                   modelCatalog: ModelCatalogEntry[];
-                  metadata: { models: unknown[]; swarmEnabled: boolean };
+                  metadata: {
+                    models: import("../../packages/gateway-protocol/src/index.js").ModelChoice[];
+                    swarmEnabled: boolean;
+                  };
                 }>
               >();
               const projectAgent = (

--- a/ui/src/app/app-host.chat-metadata.test.ts
+++ b/ui/src/app/app-host.chat-metadata.test.ts
@@ -3,12 +3,11 @@
 import { afterEach, expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
-import type { ModelAuthStatusResult } from "../api/types.ts";
+import type { ModelAuthStatusResult, ModelCatalogResult } from "../api/types.ts";
 import {
   invalidateChatMetadataStore,
   peekChatMetadata,
   beginChatMetadataPublication,
-  type ChatMetadataResult,
 } from "../lib/chat/chat-metadata-store.ts";
 import { loadModelAuthStatus } from "../lib/model-auth.ts";
 import { makeChatHost } from "../pages/chat/chat-host.test-support.ts";
@@ -36,8 +35,7 @@ it.each(["config.changed", "chat.metadata.changed"])(
   async (event) => {
     const model = { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" };
     let ready = false;
-    const request = vi.fn(async (): Promise<ChatMetadataResult> => ({
-      commands: [],
+    const catalogRequest = vi.fn(async (): Promise<ModelCatalogResult> => ({
       models: [
         {
           ...model,
@@ -46,6 +44,9 @@ it.each(["config.changed", "chat.metadata.changed"])(
         },
       ],
     }));
+    const request = vi.fn((method: string) =>
+      method === "models.list" ? catalogRequest() : Promise.resolve({ commands: [] }),
+    );
     const client = { request } as unknown as GatewayBrowserClient;
     const state = {
       client,
@@ -84,7 +85,7 @@ it.each(["config.changed", "chat.metadata.changed"])(
         commands: never[];
         models: typeof state.chatModelCatalog;
       }>();
-      request.mockImplementationOnce(() => pending.promise);
+      catalogRequest.mockImplementationOnce(() => pending.promise);
       shell.handleGatewayEvent({ event, payload: {} });
       expect(state.chatModelCatalog[0]?.available).toBe(false);
       pending.resolve({
@@ -94,7 +95,7 @@ it.each(["config.changed", "chat.metadata.changed"])(
       await vi.waitFor(() =>
         expect(state.chatModelCatalog[0]?.unavailableReason).toBe("auth-failed"),
       );
-      request.mockRejectedValueOnce(new Error("metadata transport failed"));
+      catalogRequest.mockRejectedValueOnce(new Error("metadata transport failed"));
       shell.handleGatewayEvent({ event, payload: {} });
       await vi.waitFor(() =>
         expect(state.chatModelCatalogError).toContain("metadata transport failed"),
@@ -108,7 +109,7 @@ it.each(["config.changed", "chat.metadata.changed"])(
       expect(state.chatMessages).toBe(messages);
       expect(state.chatQueue).toBe(queue);
       expect(state.chatRunId).toBeNull();
-      expect(request.mock.calls).toHaveLength(4);
+      expect(catalogRequest.mock.calls).toHaveLength(4);
     } finally {
       retireChatMetadataRequests(state);
     }

--- a/ui/src/app/app-host.ts
+++ b/ui/src/app/app-host.ts
@@ -22,7 +22,6 @@ import type { BoardFace } from "../lib/board/settings.ts";
 import { invalidateChatMetadataStore } from "../lib/chat/chat-metadata-store.ts";
 import { createIdleImport } from "../lib/idle-import.ts";
 import { invalidateModelAuthStatusRequests } from "../lib/model-auth-request-state.ts";
-import { invalidateModelCatalogCache } from "../lib/model-catalog-store.ts";
 import { resolveSessionDisplayName } from "../lib/session-display.ts";
 import {
   isUiGlobalSessionKey,
@@ -497,7 +496,6 @@ class OpenClawShell
     if (event.event === "config.changed" || event.event === "chat.metadata.changed") {
       const client = this.context?.gateway?.snapshot.client;
       if (client) {
-        invalidateModelCatalogCache(client);
         invalidateModelAuthStatusRequests(client);
         invalidateChatMetadataStore(client);
       }
@@ -686,7 +684,6 @@ class OpenClawShell
       // A disconnect can retain the browser client, so object identity alone
       // cannot keep metadata alive across logical Gateway connections.
       if (snapshot.client) {
-        invalidateModelCatalogCache(snapshot.client);
         invalidateModelAuthStatusRequests(snapshot.client);
         invalidateChatMetadataStore(snapshot.client);
       }

--- a/ui/src/components/command-palette-catalog-search.ts
+++ b/ui/src/components/command-palette-catalog-search.ts
@@ -1,11 +1,6 @@
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
-import type {
-  AgentsListResult,
-  CronJobsListResult,
-  ModelCatalogResult,
-  SkillStatusReport,
-} from "../api/types.ts";
+import type { AgentsListResult, CronJobsListResult, SkillStatusReport } from "../api/types.ts";
 import {
   SETTINGS_SEARCHABLE_SUBPAGE_ROUTES,
   settingsNavigationLabelForRoute,
@@ -15,6 +10,7 @@ import {
 import type { RouteId } from "../app-route-paths.ts";
 import type { NativeDeviceSettingsCapability } from "../app/native-device-settings.ts";
 import { t } from "../i18n/index.ts";
+import { loadModelCatalog } from "../lib/model-catalog-store.ts";
 import type { PluginListResult } from "../lib/plugins/index.ts";
 import { SETTINGS_SEARCH_TARGETS } from "../pages/config/settings-targets.ts";
 import type { IconName } from "./icons.ts";
@@ -325,16 +321,14 @@ export async function loadCommandPaletteCatalogItems(params: {
     requestIfAvailable<SkillStatusReport>("skills.status", { agentId: params.agentId }),
     requestIfAvailable<PluginListResult>("plugins.list", {}),
     params.methodAvailable("models.list")
-      ? params.client
-          .request<ModelCatalogResult>("models.list", {
-            view: "configured",
-            agentId: params.agentId,
-            preparedOnly: true,
-          })
-          .catch(() => {
-            modelRequestFailed = true;
-            return null;
-          })
+      ? loadModelCatalog(params.client, {
+          view: "configured",
+          agentId: params.agentId,
+          preparedOnly: true,
+        }).catch(() => {
+          modelRequestFailed = true;
+          return null;
+        })
       : null,
   ]);
 

--- a/ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts
+++ b/ui/src/e2e/agent-file-lifecycle.real-gateway.e2e.test.ts
@@ -134,11 +134,11 @@ catalogSuite.define(() => {
     url.hash = new URL(browserUrl).hash;
     const frames: unknown[] = [];
     const commands: unknown[] = [];
-    const metadataRequests = new Set<string>();
+    const catalogRequests = new Set<string>();
     const mutations: string[] = [];
-    let rejectMetadata = false;
-    let holdMetadata = false;
-    const heldMetadata: Array<() => void> = [];
+    let rejectCatalog = false;
+    let holdCatalog = false;
+    const heldCatalogs: Array<() => void> = [];
     const publish = async (id: string) => {
       const args = [
         "config",
@@ -167,8 +167,8 @@ catalogSuite.define(() => {
               const frame = requireRecord(JSON.parse(message.toString()));
               if (frame.type === "req" && frame.method !== "connect") {
                 frames.push({ direction: "sent", frame });
-                if (frame.method === "chat.metadata" && typeof frame.id === "string") {
-                  metadataRequests.add(frame.id);
+                if (frame.method === "models.list" && typeof frame.id === "string") {
+                  catalogRequests.add(frame.id);
                 }
                 if (
                   ["config.set", "config.patch", "config.apply", "agents.update"].includes(
@@ -182,21 +182,21 @@ catalogSuite.define(() => {
             });
             server.onMessage((message) => {
               const frame = requireRecord(JSON.parse(message.toString()));
-              const metadataReply = typeof frame.id === "string" && metadataRequests.has(frame.id);
+              const catalogReply = typeof frame.id === "string" && catalogRequests.has(frame.id);
               if (
-                metadataReply ||
+                catalogReply ||
                 frame.event === "config.changed" ||
                 frame.event === "chat.metadata.changed"
               ) {
                 frames.push({
                   direction: "received",
                   frame,
-                  transportFailure: metadataReply && rejectMetadata,
+                  transportFailure: catalogReply && rejectCatalog,
                 });
               }
-              if (metadataReply && holdMetadata) {
-                heldMetadata.push(() => socket.send(message));
-              } else if (metadataReply && rejectMetadata) {
+              if (catalogReply && holdCatalog) {
+                heldCatalogs.push(() => socket.send(message));
+              } else if (catalogReply && rejectCatalog) {
                 socket.send(
                   JSON.stringify({
                     type: "res",
@@ -261,17 +261,17 @@ catalogSuite.define(() => {
             0,
           );
 
-          holdMetadata = true;
+          holdCatalog = true;
           inventoryModel = "inventory-held";
           commands.push(await owner.cli(refreshInventoryArgs));
-          await expect.poll(() => heldMetadata.length).toBeGreaterThan(0);
-          holdMetadata = false;
+          await expect.poll(() => heldCatalogs.length).toBeGreaterThan(0);
+          holdCatalog = false;
           inventoryModel = "inventory-latest";
           commands.push(await owner.cli(refreshInventoryArgs));
           await expect
             .poll(() => picker.locator('wa-option[value="ollama/inventory-latest"]').count())
             .toBe(1);
-          for (const release of heldMetadata) {
+          for (const release of heldCatalogs) {
             release();
           }
           await page.screenshot({
@@ -282,7 +282,7 @@ catalogSuite.define(() => {
           );
           expect(await picker.locator('wa-option[value="ollama/inventory-held"]').count()).toBe(0);
 
-          rejectMetadata = true;
+          rejectCatalog = true;
           await publish("held");
           const error = editor
             .getByRole("alert")
@@ -291,7 +291,7 @@ catalogSuite.define(() => {
           expect(await picker.locator('wa-option[value="fixture/published"]').count()).toBe(1);
           await page.screenshot({ path: path.join(catalogSuite.artifactDir, "read-failure.png") });
 
-          rejectMetadata = false;
+          rejectCatalog = false;
           await publish("recovered");
           await expect
             .poll(() => picker.locator('wa-option[value="fixture/recovered"]').count())

--- a/ui/src/e2e/chat-composer-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-catalog.e2e.test.ts
@@ -55,19 +55,19 @@ suite.define(() => {
         const startupCount = (await gateway.getRequests("chat.startup")).length;
         const socketCount = await gateway.getSocketCount();
 
-        await gateway.deferNext("chat.metadata");
-        await gateway.setMethodResponse("chat.metadata", {
+        await gateway.deferNext("models.list");
+        await gateway.setMethodResponse("models.list", {
           commands: [],
           models: [{ ...model, available: true }],
         });
         await gateway.emitGatewayEvent(event, {});
-        await gateway.waitForRequest("chat.metadata");
+        await gateway.waitForRequest("models.list", { after: 1 });
         expect(await textarea.isDisabled()).toBe(true);
-        await gateway.resolveDeferred("chat.metadata");
+        await gateway.resolveDeferred("models.list");
         await expect.poll(() => textarea.isDisabled()).toBe(false);
         await expect.poll(() => page.getByText("Earlier reply", { exact: true }).count()).toBe(1);
         expect(await gateway.getRequests("chat.startup")).toHaveLength(startupCount);
-        expect(await gateway.getRequests("models.list")).toHaveLength(0);
+        expect(await gateway.getRequests("models.list")).toHaveLength(2);
         expect(await gateway.getSocketCount()).toBe(socketCount);
       });
     },
@@ -270,7 +270,7 @@ suite.define(() => {
 
       await page.goto(`${suite.server.baseUrl}chat`);
       await gateway.waitForRequest("chat.metadata");
-      expect(await gateway.getRequests("models.list")).toHaveLength(0);
+      await gateway.waitForRequest("models.list");
 
       const composer = page.locator(".agent-chat__input");
       const providers = composer.locator(
@@ -345,7 +345,7 @@ suite.define(() => {
       });
 
       await page.goto(`${suite.server.baseUrl}chat`);
-      expect(await gateway.getRequests("models.list")).toHaveLength(0);
+      await gateway.waitForRequest("models.list");
 
       const composer = page.locator(".agent-chat__input");
       const picker = composer.locator("details.chat-controls__model-picker");
@@ -499,9 +499,10 @@ suite.define(() => {
           activeComposer().locator('[data-chat-model-option="openai/work-model"]').count(),
         )
         .toBe(1);
-      expect(await gateway.getRequests("models.list")).toHaveLength(0);
+      await gateway.waitForRequest("models.list");
 
       await gateway.deferNext("chat.startup", { sessionKey: "agent:other:main" });
+      await gateway.deferNext("models.list", { sessionKey: "agent:other:main" });
       await navigateToControlUiSession(page, "agent:other:main");
       await gateway.waitForRequest("chat.startup", { after: 1 });
       const targetModelTrigger = activeComposer().locator('[data-chat-model-select="true"]');
@@ -523,6 +524,8 @@ suite.define(() => {
         });
       }
       await gateway.resolveDeferred("chat.startup");
+      expect(await activeComposer().locator("[data-chat-model-option]").count()).toBe(0);
+      await gateway.resolveDeferred("models.list");
       const startupRequests = await gateway.getRequests("chat.startup");
       expect(
         startupRequests.filter(
@@ -542,11 +545,11 @@ suite.define(() => {
           activeComposer().locator('[data-chat-model-option="openai/work-model"]').count(),
         )
         .toBe(0);
-      expect(await gateway.getRequests("models.list")).toHaveLength(0);
+      await gateway.waitForRequest("models.list");
     });
   });
 
-  it("keeps startup models visible and retries discovery when the picker reopens", async () => {
+  it("keeps published models visible and retries a failed passive read on reopen", async () => {
     await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
       const startupModel = {
         id: "startup-model",
@@ -563,9 +566,9 @@ suite.define(() => {
       const gateway = await installMockGateway(page, {
         models: [startupModel],
         methodResponses: {
-          "chat.metadata": { commands: [], models: [startupModel, discoveredModel] },
           "models.list": {
             sequence: [
+              { models: [startupModel] },
               {
                 __mockError: {
                   code: "UNAVAILABLE",
@@ -580,12 +583,14 @@ suite.define(() => {
 
       await page.goto(`${suite.server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
-      expect(await gateway.getRequests("models.list")).toHaveLength(0);
+      await gateway.waitForRequest("models.list");
 
       const composer = page.locator(".agent-chat__input");
       await composer.locator('[data-chat-model-select="true"]').click();
-      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(1);
-      await expect.poll(() => composer.locator("[data-chat-model-catalog-state]").count()).toBe(0);
+      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(2);
+      await expect
+        .poll(() => composer.locator("[data-chat-model-catalog-state]").textContent())
+        .toContain("Some models could not be refreshed.");
       await expect
         .poll(() => composer.locator('[data-chat-model-option="openai/startup-model"]').isVisible())
         .toBe(true);
@@ -593,7 +598,7 @@ suite.define(() => {
       await composer.locator('[data-chat-model-select="true"]').click();
       await composer.locator('[data-chat-model-select="true"]').click();
 
-      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(2);
+      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(3);
       await expect
         .poll(() =>
           composer.locator('[data-chat-model-option="anthropic/discovered-model"]').isVisible(),
@@ -626,7 +631,7 @@ suite.define(() => {
             ],
           },
           "models.list": {
-            sequence: [{ models: [] }, { models: [routedModel] }],
+            sequence: [{ models: [] }, { models: [] }, { models: [routedModel] }],
           },
         },
       });
@@ -664,7 +669,7 @@ suite.define(() => {
         .toBe(1);
 
       await pickerTrigger.click();
-      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(2);
+      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(4);
       await expect
         .poll(() => composer.locator('[data-chat-model-option="openai/gpt-5.6-luna"]').isVisible())
         .toBe(true);
@@ -679,93 +684,37 @@ suite.define(() => {
     });
   });
 
-  it("refreshes a successful account catalog after the picker cooldown", async () => {
+  it("reads a newer account catalog on reopen without a cooldown or provider discovery", async () => {
     await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
-      const initialTime = new Date("2026-08-21T12:00:00Z");
-      await page.clock.setFixedTime(initialTime);
-      const existingModel = {
-        id: "gpt-5.6-luna",
-        name: "GPT-5.6 Luna",
-        provider: "openai",
+      const existing = { id: "existing", name: "Existing", provider: "example", available: true };
+      const published = {
+        id: "published",
+        name: "Published",
+        provider: "example",
         available: true,
       };
-      const newlyAvailableModel = {
-        id: "gpt-5.6-terra",
-        name: "GPT-5.6 Terra",
-        provider: "openai",
-        available: true,
-      };
-      const gateway = await installMockGateway(page, {
-        models: [existingModel],
-        methodResponses: {
-          "chat.metadata": {
-            sequence: [
-              { commands: [], models: [existingModel] },
-              { commands: [], models: [existingModel, newlyAvailableModel] },
-            ],
-          },
-          "models.list": {
-            sequence: [
-              { models: [existingModel] },
-              { models: [existingModel, newlyAvailableModel] },
-            ],
-          },
-        },
-      });
-
+      const gateway = await installMockGateway(page, { models: [existing] });
       await page.goto(`${suite.server.baseUrl}chat`);
-      await gateway.waitForRequest("chat.startup");
-
       const composer = page.locator(".agent-chat__input");
-      const pickerTrigger = composer.locator('[data-chat-model-select="true"]');
-      const metadataRequestCount = (await gateway.getRequests("chat.metadata")).length;
-      await pickerTrigger.click();
-      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(1);
-      // The startup snapshot is already visible. Wait for the refresh to commit
-      // its cooldown before moving Date; completion invalidates chat metadata.
-      await gateway.waitForRequest("chat.metadata", { after: metadataRequestCount });
       await expect
-        .poll(() => composer.locator('[data-chat-model-option="openai/gpt-5.6-luna"]').isVisible())
+        .poll(() => composer.locator('[data-chat-model-option="example/existing"]').count())
+        .toBe(1);
+      const trigger = composer.locator('[data-chat-model-select="true"]');
+      await trigger.click();
+      await gateway.waitForRequest("models.list", { after: 1 });
+      await trigger.click();
+      await gateway.setMethodResponse("models.list", { models: [existing, published] });
+      await trigger.click();
+      await expect
+        .poll(() => composer.locator('[data-chat-model-option="example/published"]').isVisible())
         .toBe(true);
-      const artifactRoot = process.env.OPENCLAW_UI_E2E_ARTIFACT_DIR?.trim();
-      const artifactDir = artifactRoot
-        ? createControlUiE2eArtifactDir("chat-composer-catalog", artifactRoot)
-        : undefined;
-      if (artifactDir) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: `${artifactDir}/01-account-catalog-before-refresh.png`,
-        });
-      }
-
-      await pickerTrigger.click();
-      await page.clock.setFixedTime(new Date(initialTime.getTime() + 60_000 + 1));
-      await pickerTrigger.click();
-      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(1);
-      await expect
-        .poll(() => composer.locator('[data-chat-model-option="openai/gpt-5.6-terra"]').count())
-        .toBe(0);
-
-      await pickerTrigger.click();
-      await page.clock.setFixedTime(new Date(initialTime.getTime() + 5 * 60_000 + 1));
-      await pickerTrigger.click();
-
-      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(2);
-      await expect
-        .poll(() => composer.locator('[data-chat-model-option="openai/gpt-5.6-terra"]').isVisible())
-        .toBe(true);
-      if (artifactDir) {
-        await page.screenshot({
-          animations: "disabled",
-          fullPage: true,
-          path: `${artifactDir}/02-account-catalog-after-refresh.png`,
-        });
-      }
       for (const request of await gateway.getRequests("models.list")) {
-        expect(request.params).toEqual(
-          expect.objectContaining({ agentId: "main", refresh: true, view: "configured" }),
-        );
+        expect(request.params).toMatchObject({
+          view: "configured",
+          agentId: "main",
+          sessionKey: "main",
+        });
+        expect(request.params).not.toHaveProperty("refresh");
       }
     });
   });

--- a/ui/src/e2e/chat-composer-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-catalog.e2e.test.ts
@@ -693,8 +693,11 @@ suite.define(() => {
         provider: "example",
         available: true,
       };
-      const gateway = await installMockGateway(page, { models: [existing] });
-      await page.goto(`${suite.server.baseUrl}chat`);
+      const gateway = await installMockGateway(page, {
+        models: [existing],
+        sessionKey: "agent:main:main",
+      });
+      await page.goto(controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"));
       const composer = page.locator(".agent-chat__input");
       await expect
         .poll(() => composer.locator('[data-chat-model-option="example/existing"]').count())
@@ -712,7 +715,7 @@ suite.define(() => {
         expect(request.params).toMatchObject({
           view: "configured",
           agentId: "main",
-          sessionKey: "main",
+          sessionKey: "agent:main:main",
         });
         expect(request.params).not.toHaveProperty("refresh");
       }

--- a/ui/src/e2e/chat-composer-redesign.e2e.test.ts
+++ b/ui/src/e2e/chat-composer-redesign.e2e.test.ts
@@ -146,7 +146,7 @@ suite.define(() => {
       : undefined;
     await suite.withPage({ viewport: { width: 1280, height: 900 } }, async ({ page }) => {
       const gateway = await installMockGateway(page, {
-        deferredMethods: ["chat.startup"],
+        deferredMethods: ["chat.startup", "models.list"],
       });
       await page.goto(`${suite.server.baseUrl}chat`);
       await gateway.waitForRequest("chat.startup");
@@ -420,7 +420,7 @@ suite.define(() => {
 
       await expect.poll(() => model.isVisible()).toBe(true);
       expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
-      expect(await gateway.getRequests("models.list")).toHaveLength(0);
+      await gateway.waitForRequest("models.list");
       await expect.poll(() => contextUsage.isVisible()).toBe(true);
       await expect.poll(() => usage.isVisible()).toBe(false);
       await expect.poll(() => settings.isVisible()).toBe(true);

--- a/ui/src/e2e/chat-flow.dynamic-catalog.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.dynamic-catalog.e2e.test.ts
@@ -95,7 +95,7 @@ suite.define(() => {
         },
         "sessions.list": sessionResponse(preparedLevels, 8_192),
       },
-      models: [discoveredModel],
+      models: [preparedModel],
       sessionKey,
     });
 
@@ -108,7 +108,7 @@ suite.define(() => {
       await effortSelect.click();
       await expect.poll(() => main.locator('[data-chat-thinking-option="off"]').count()).toBe(1);
       expect(await main.locator('[data-chat-thinking-slider="true"]').count()).toBe(0);
-      expect(await gateway.getRequests("models.list")).toHaveLength(0);
+      expect(await gateway.getRequests("models.list")).toHaveLength(1);
       if (dynamicCatalogProofDir) {
         await page.screenshot({
           animations: "disabled",
@@ -118,13 +118,14 @@ suite.define(() => {
 
       await page.keyboard.press("Escape");
       await gateway.setMethodResponse("sessions.list", sessionResponse(discoveredLevels, 65_536));
+      await gateway.setMethodResponse("models.list", { models: [discoveredModel] });
       const sessionListCount = (await gateway.getRequests("sessions.list", rosterMatch)).length;
       await modelSelect.click();
-      const modelsRequest = await gateway.waitForRequest("models.list");
+      const modelsRequest = await gateway.waitForRequest("models.list", { after: 1 });
       expect(modelsRequest.params).toEqual({
         view: "configured",
         agentId: "main",
-        refresh: true,
+        sessionKey,
       });
       const refreshedSessionsRequest = await gateway.waitForRequest("sessions.list", {
         after: sessionListCount,

--- a/ui/src/e2e/chat-flow.model-picker-refresh.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.model-picker-refresh.e2e.test.ts
@@ -262,10 +262,14 @@ suite.define(() => {
       await picker.locator("[data-chat-model-option]").first().waitFor({ state: "attached" });
 
       // Freeze the operator-signaled revalidation so the in-flight state is observable.
-      await gateway.deferNext("models.list", { refresh: true });
+      await gateway.deferNext("models.list", { view: "configured" });
       await picker.locator('[data-chat-model-select="true"]').click();
-      const request = await gateway.waitForRequest("models.list");
-      expect(requireRecord(request.params)).toMatchObject({ refresh: true, view: "configured" });
+      const request = await gateway.waitForRequest("models.list", { after: 1 });
+      expect(requireRecord(request.params)).toMatchObject({
+        sessionKey: "agent:main:main",
+        view: "configured",
+      });
+      expect(request.params).not.toHaveProperty("refresh");
 
       // The warm list stays rendered and selectable with no refresh/loading interstitial.
       await expect
@@ -277,21 +281,8 @@ suite.define(() => {
         await picker.locator('[data-chat-model-option="openai/gpt-5.6-luna"]').isDisabled(),
       ).toBe(false);
 
-      // Discovery invalidates the session projection; only that projection can update readiness.
-      await gateway.deferNext("chat.metadata");
+      // The direct scoped response owns model readiness; commands remain independent.
       await gateway.resolveDeferred("models.list", {
-        models: [
-          { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
-          { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai" },
-        ],
-      });
-      const metadataRequest = await gateway.waitForRequest("chat.metadata");
-      expect(metadataRequest.params).toEqual({ agentId: "main", sessionKey: "agent:main:main" });
-      expect(
-        await picker.locator('[data-chat-model-option="openai/gpt-5.6-luna"]').isVisible(),
-      ).toBe(true);
-      await gateway.resolveDeferred("chat.metadata", {
-        commands: [],
         models: [
           { id: "gpt-5.6-sol", name: "GPT-5.6 Sol", provider: "openai" },
           { id: "gpt-5.6-terra", name: "GPT-5.6 Terra", provider: "openai" },
@@ -329,7 +320,7 @@ suite.define(() => {
       const previous = picker.locator('[data-chat-model-option="anthropic/claude-haiku-4-5"]');
       await previous.waitFor({ state: "attached" });
       const discoveryCount = (await gateway.getRequests("models.list")).length;
-      await gateway.deferNext("models.list", { refresh: true });
+      await gateway.deferNext("models.list", { view: "configured" });
       await picker.locator('[data-chat-model-select="true"]').click();
       await gateway.waitForRequest("models.list", { after: discoveryCount });
       const search = picker.locator("[data-chat-model-search]");
@@ -343,17 +334,13 @@ suite.define(() => {
         });
       }
 
-      const metadataCount = (await gateway.getRequests("chat.metadata")).length;
-      await gateway.deferNext("chat.metadata");
       const refreshedModels = [
         { id: "gpt-5.5", name: "GPT-5.5", provider: "openai" },
         { id: "gpt-5.4-mini", name: "GPT-5.4 mini", provider: "openai" },
         { id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6", provider: "anthropic" },
       ];
       await gateway.resolveDeferred("models.list", { models: refreshedModels });
-      await gateway.waitForRequest("chat.metadata", { after: metadataCount });
-      expect(await previous.isVisible()).toBe(true);
-      await gateway.resolveDeferred("chat.metadata", { commands: [], models: refreshedModels });
+
       const replacement = picker.locator('[data-chat-model-option="anthropic/claude-sonnet-4-6"]');
       await replacement.waitFor({ state: "attached" });
       await previous.waitFor({ state: "detached" });

--- a/ui/src/e2e/chat-flow.session-start.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.session-start.e2e.test.ts
@@ -57,7 +57,7 @@ suite.define(() => {
       // chat.metadata request was only a synchronization point for this test.
       expect(await gateway.getRequests("chat.metadata")).toHaveLength(0);
       expect(await gateway.getRequests("commands.list")).toHaveLength(0);
-      expect(await gateway.getRequests("models.list")).toHaveLength(0);
+      await gateway.waitForRequest("models.list");
       const composer = page.locator(".agent-chat__composer-combobox textarea");
       const sendButton = page.getByRole("button", { name: "Send message" });
       await composer.waitFor({ state: "visible", timeout: 10_000 });
@@ -143,7 +143,7 @@ suite.define(() => {
         commands: (await gateway.getRequests("commands.list")).length,
         metadata: (await gateway.getRequests("chat.metadata")).length,
         models: (await gateway.getRequests("models.list")).length,
-      }).toEqual({ commands: 0, metadata: 0, models: 0 });
+      }).toEqual({ commands: 0, metadata: 0, models: 1 });
       expect(await gateway.getRequests("agents.list")).toHaveLength(1);
     } finally {
       await suite.closeBrowserContext(context);
@@ -155,7 +155,7 @@ suite.define(() => {
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       agentModel: "openai/hydrated-model",
-      deferredMethods: ["agents.list", "chat.metadata"],
+      deferredMethods: ["agents.list", "chat.metadata", "models.list"],
       methodResponses: {
         "chat.startup": {
           messages: [
@@ -189,8 +189,8 @@ suite.define(() => {
         mainKey: "main",
         scope: "agent",
       });
-      await gateway.resolveDeferred("chat.metadata", {
-        commands: [],
+      await gateway.resolveDeferred("chat.metadata", { commands: [] });
+      await gateway.resolveDeferred("models.list", {
         models: [
           {
             available: true,

--- a/ui/src/e2e/chat-model-controls.e2e.test.ts
+++ b/ui/src/e2e/chat-model-controls.e2e.test.ts
@@ -63,7 +63,7 @@ suite.define(() => {
           deferredMethods: ["sessions.patch"],
           methodResponses: {
             "sessions.list": sessionList,
-            "chat.metadata": {
+            "models.list": {
               commands: [],
               models,
               accountSelection: {
@@ -161,7 +161,7 @@ suite.define(() => {
         await expect.poll(() => trigger.textContent()).toContain(personal.label);
         await gateway.resolveDeferred("sessions.patch", { ok: true });
         await gateway.setMethodResponse("sessions.list", sessionList);
-        await gateway.setMethodResponse("chat.metadata", {
+        await gateway.setMethodResponse("models.list", {
           commands: [],
           models,
           accountSelection: {

--- a/ui/src/e2e/debug-diagnostics.e2e.test.ts
+++ b/ui/src/e2e/debug-diagnostics.e2e.test.ts
@@ -100,7 +100,7 @@ suite.define(() => {
           const requests = await gateway.getRequests(method);
           expect(requests.length).toBeGreaterThanOrEqual(1);
           expect(requests[0]?.params).toEqual(
-            method === "models.list" ? { agentId: "main", preparedOnly: true } : {},
+            method === "models.list" ? { agentId: "main", view: "default" } : {},
           );
         }
 

--- a/ui/src/e2e/model-alias-display.e2e.test.ts
+++ b/ui/src/e2e/model-alias-display.e2e.test.ts
@@ -57,7 +57,7 @@ suite.define(() => {
     const context = await createProofContext();
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
-      featureMethods: ["chat.metadata", "chat.startup", "sessions.patch"],
+      featureMethods: ["models.list", "chat.startup", "sessions.patch"],
       models,
       sessionKey: "agent:main:main",
     });
@@ -144,9 +144,9 @@ suite.define(() => {
       expect(response?.status()).toBe(200);
       await gateway.waitForRequest("agents.list");
       await gateway.waitForRequest("config.get");
-      const modelRequest = await gateway.waitForRequest("chat.metadata");
-      expect(modelRequest.params).toEqual({ agentId: "main" });
-      expect(await gateway.getRequests("models.list")).toHaveLength(0);
+      const modelRequest = await gateway.waitForRequest("models.list");
+      expect(modelRequest.params).toEqual({ agentId: "main", view: "configured" });
+      expect(await gateway.getRequests("models.list")).toHaveLength(1);
 
       const select = page.locator("wa-select.model-picker__select").first();
       await select.waitFor({ state: "visible", timeout: 10_000 });

--- a/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.cloud-startup.recovery.e2e.test.ts
@@ -54,7 +54,7 @@ suite.define(() => {
       workspaceGit: true,
       methodResponses: {
         "users.listModelAccounts": { profileId: "person-a", accounts: [account], links: [] },
-        "chat.metadata": {
+        "models.list": {
           cases: [
             {
               match: { authProfileId: account.authProfileId },
@@ -174,7 +174,7 @@ suite.define(() => {
       await pollLocatorText(
         page.locator("#new-session-where-trigger .new-session-page__trigger-label"),
       ).toBe("aws · fast");
-      await gateway.waitForRequest("chat.metadata");
+      await gateway.waitForRequest("models.list");
       try {
         await expect
           .poll(() =>

--- a/ui/src/e2e/new-session-page.environment-metadata.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.environment-metadata.e2e.test.ts
@@ -107,7 +107,7 @@ suite.define(() => {
 
     try {
       await page.goto(`${suite.server.baseUrl}new`);
-      await gateway.waitForRequest("chat.metadata");
+      await gateway.waitForRequest("models.list");
       await gateway.waitForRequest("environments.list");
       const whereTrigger = page.locator("#new-session-where-trigger");
       const where = page.locator("wa-popover.new-session-page__where-popover");

--- a/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
@@ -26,7 +26,7 @@ function catalogDiscoveryRequests(
 }
 
 suite.define(() => {
-  it("starts with a retained personal account while leaving the new-chat default cleared", async () => {
+  it("starts with a usable retained account despite a refresh warning and leaves the default cleared", async () => {
     const context = await suite.browser.newContext({
       locale: "en-US",
       serviceWorkers: "block",
@@ -71,7 +71,7 @@ suite.define(() => {
       available: true,
     };
     const preview = {
-      commands: [],
+      refreshFailed: true,
       models: [model],
       accountSelection: {
         kind: "personal",
@@ -86,7 +86,7 @@ suite.define(() => {
       models: [{ ...model, available: false, unavailableReason: "missing-auth" }],
       methodResponses: {
         "users.listModelAccounts": { profileId: "person-a", accounts: [account], links: [] },
-        "chat.metadata": {
+        "models.list": {
           cases: [
             { match: { authProfileId: account.authProfileId }, response: preview },
             {
@@ -124,11 +124,11 @@ suite.define(() => {
         });
       }
       await accountTrigger.click();
-      await gateway.deferNext("chat.metadata", { authProfileId: account.authProfileId });
+      await gateway.deferNext("models.list", { authProfileId: account.authProfileId });
       await picker.getByRole("menuitemradio", { name: account.label, exact: true }).click();
       await expect.poll(() => startHint.getAttribute("content")).toBe("Loading models…");
       expect(await start.getAttribute("aria-disabled")).toBe("true");
-      await gateway.rejectDeferred("chat.metadata", { code: "UNAVAILABLE", message: "Try again" });
+      await gateway.rejectDeferred("models.list", { code: "UNAVAILABLE", message: "Try again" });
       await expect.poll(() => startHint.getAttribute("content")).toBe("Models unavailable");
       expect(await start.getAttribute("aria-disabled")).toBe("true");
 
@@ -136,6 +136,15 @@ suite.define(() => {
       await modelTrigger.click();
       await expect.poll(() => accountTrigger.textContent()).toContain(account.label);
       await expect.poll(() => start.getAttribute("aria-disabled")).toBe("false");
+      await expect
+        .poll(() =>
+          page
+            .getByText("Some models could not be refreshed. Open Models to try again.", {
+              exact: true,
+            })
+            .isVisible(),
+        )
+        .toBe(true);
       await expect.poll(accountHintFitsMenu).toBe(true);
       if (captureUiProof) {
         await page.screenshot({
@@ -173,7 +182,7 @@ suite.define(() => {
     const page = await context.newPage();
     const gateway = await installMockGateway(page, {
       agentModel: "openai/gpt-5.6-luna",
-      heldMethods: ["chat.metadata"],
+      heldMethods: ["models.list"],
       models: [
         {
           available: true,
@@ -208,7 +217,7 @@ suite.define(() => {
         });
       }
 
-      await gateway.resolveDeferred("chat.metadata");
+      await gateway.resolveDeferred("models.list");
       const effortPicker = page.locator(
         ".new-session-page__composer .chat-controls__effort-picker:not(.chat-controls__effort-picker--reserved)",
       );
@@ -306,7 +315,7 @@ suite.define(() => {
     const gateway = await installMockGateway(page, {
       agentModel: "openai/gpt-5.6-luna",
       methodResponses: {
-        "chat.metadata": {
+        "models.list": {
           sequence: [
             {
               __mockError: {
@@ -323,7 +332,7 @@ suite.define(() => {
 
     try {
       await page.goto(`${suite.server.baseUrl}new`);
-      await gateway.waitForRequest("chat.metadata");
+      await gateway.waitForRequest("models.list");
 
       const modelSelect = page.locator('[data-chat-model-select="true"]');
       await expect.poll(() => modelSelect.getAttribute("title")).toBe("Models unavailable");
@@ -331,8 +340,8 @@ suite.define(() => {
 
       await modelSelect.click();
 
-      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
-      expect((await gateway.getRequests("chat.metadata"))[1]?.params).toMatchObject({
+      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(2);
+      expect((await gateway.getRequests("models.list"))[1]?.params).toMatchObject({
         agentId: "main",
       });
       await expect.poll(() => page.locator("[data-chat-model-option]").count()).toBe(3);
@@ -342,7 +351,7 @@ suite.define(() => {
     }
   });
 
-  it("restores the model picker after startup-sidecars metadata becomes available", async () => {
+  it("restores the model picker when startup publishes its catalog", async () => {
     const context = await suite.browser.newContext(createControlUiE2eContextOptions());
     const page = await context.newPage();
     const recoveredModel = {
@@ -354,7 +363,7 @@ suite.define(() => {
     };
     const gateway = await installMockGateway(page, {
       methodResponses: {
-        "chat.metadata": {
+        "models.list": {
           sequence: [
             {
               __mockError: {
@@ -373,7 +382,12 @@ suite.define(() => {
 
     try {
       await page.goto(`${suite.server.baseUrl}new`);
-      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
+      await gateway.waitForRequest("models.list");
+      await expect
+        .poll(() => page.getByText("Models unavailable", { exact: true }).count())
+        .toBeGreaterThan(0);
+      await gateway.emitGatewayEvent("chat.metadata.changed", {});
+      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(2);
 
       const modelSelect = page.locator(
         '.new-session-page__composer [data-chat-model-select="true"]',
@@ -384,18 +398,10 @@ suite.define(() => {
         .poll(() => page.locator('[data-chat-model-option="openai/gpt-5.6-luna"]').textContent())
         .toContain(recoveredModel.name);
 
-      // Explicit picker discovery refreshes the recovered metadata owner once.
-      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(3);
-      expect(await gateway.getRequests("models.list")).toEqual([
-        expect.objectContaining({
-          params: { view: "configured", agentId: "main", refresh: true },
-        }),
-      ]);
-      expect(await gateway.getRequests("chat.metadata")).toEqual([
-        expect.objectContaining({ params: { agentId: "main" } }),
-        expect.objectContaining({ params: { agentId: "main" } }),
-        expect.objectContaining({ params: { agentId: "main" } }),
-      ]);
+      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(3);
+      for (const request of await gateway.getRequests("models.list")) {
+        expect(request.params).toEqual({ view: "configured", agentId: "main" });
+      }
     } finally {
       await context.close();
     }
@@ -437,7 +443,7 @@ suite.define(() => {
     const gateway = await installMockGateway(page, {
       cliAgentsEnabled: true,
       featureMethods: [
-        "chat.metadata",
+        "models.list",
         "chat.startup",
         "sessions.create",
         "sessions.dispatch",
@@ -485,7 +491,7 @@ suite.define(() => {
         ),
       ).toBe("GPT-5.6 Luna");
       expect(await page.getByText("Models unavailable", { exact: true }).count()).toBe(0);
-      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
+      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(2);
       if (captureUiProof) {
         await writeFile(
           path.join(suite.artifactDir, "new-session-catalog-retry", "01-cli-agents-retry.png"),
@@ -526,7 +532,7 @@ suite.define(() => {
           catalogDiscoveryRequests(await gateway.getRequests("sessions.catalog.list")),
         )
         .toHaveLength(3);
-      await expect.poll(async () => (await gateway.getRequests("chat.metadata")).length).toBe(2);
+      await expect.poll(async () => (await gateway.getRequests("models.list")).length).toBe(2);
       await expect
         .poll(() => page.locator('[data-chat-model-target="anthropic"]').isVisible())
         .toBe(true);

--- a/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.model-catalog.e2e.test.ts
@@ -157,6 +157,13 @@ suite.define(() => {
       await expect.poll(() => start.getAttribute("aria-disabled")).toBe("true");
       await expect.poll(() => accountTrigger.textContent()).toContain("Automatic");
       await accountTrigger.click();
+      await gateway.deferNext("models.list", { authProfileId: account.authProfileId });
+      await picker.getByRole("menuitemradio", { name: account.label, exact: true }).click();
+      await expect.poll(() => startHint.getAttribute("content")).toBe("Loading models…");
+      await gateway.rejectDeferred("models.list", { code: "UNAVAILABLE", message: "Try again" });
+      await expect.poll(() => startHint.getAttribute("content")).toBe("Models unavailable");
+      expect(await start.getAttribute("aria-disabled")).toBe("true");
+      await accountTrigger.click();
       await picker.getByRole("menuitemradio", { name: account.label, exact: true }).click();
       await expect.poll(() => start.getAttribute("aria-disabled")).toBe("false");
       await page.keyboard.press("Escape");

--- a/ui/src/e2e/new-session-page.places-live.e2e.test.ts
+++ b/ui/src/e2e/new-session-page.places-live.e2e.test.ts
@@ -131,7 +131,7 @@ suite.define(() => {
     try {
       await page.goto(`${suite.server.baseUrl}new`);
       await gateway.waitForRequest("environments.list");
-      await gateway.waitForRequest("chat.metadata");
+      await gateway.waitForRequest("models.list");
       const where = page.locator("#new-session-where-trigger");
       const model = page.locator('[data-chat-model-select="true"]');
       const start = page.getByRole("button", { name: "Start session" });
@@ -218,7 +218,7 @@ suite.define(() => {
       try {
         await page.goto(`${suite.server.baseUrl}new`);
         await gateway.waitForRequest("environments.list");
-        await gateway.waitForRequest("chat.metadata");
+        await gateway.waitForRequest("models.list");
         await page.locator("#new-session-where-trigger").click();
 
         const profile = page.locator('[data-value="cloud:aws"]');

--- a/ui/src/lib/chat/chat-metadata-store.test.ts
+++ b/ui/src/lib/chat/chat-metadata-store.test.ts
@@ -28,10 +28,9 @@ function clientWith(request: ReturnType<typeof vi.fn>): GatewayBrowserClient {
   return { request } as unknown as GatewayBrowserClient;
 }
 
-function metadata(modelId: string): ChatMetadataResult {
+function metadata(name: string): ChatMetadataResult {
   return {
-    commands: [],
-    models: [{ id: modelId, name: modelId, provider: "openai" }],
+    commands: [{ name, description: name, source: "native", scope: "text", acceptsArgs: false }],
   };
 }
 
@@ -50,6 +49,21 @@ afterEach(() => {
 });
 
 describe("chat metadata store", () => {
+  it("keeps legacy startup and RPC models out of the commands cache", async () => {
+    const commands = metadata("status");
+    const legacy = {
+      ...commands,
+      models: [{ id: "old", name: "Old", provider: "example" }],
+      accountSelection: { kind: "automatic", label: "Automatic" },
+    };
+    const client = clientWith(vi.fn().mockResolvedValue(legacy));
+    beginChatMetadataPublication(client, { agentId: "main" }).publish(legacy);
+    expect(peekChatMetadata(client, { agentId: "main" })).toEqual(commands);
+    invalidateChatMetadataStore(client);
+    expect(await loadChatMetadata(client, { agentId: "main" })).toEqual(commands);
+    expect(peekChatMetadata(client, { agentId: "main" })).toEqual(commands);
+  });
+
   it.each([
     { sessionKey: "agent:main:locked" },
     { authProfileId: "personal:person-a:anthropic:one" },
@@ -87,11 +101,11 @@ describe("chat metadata store", () => {
     const startup = beginChatMetadataPublication(client, scope);
     const oldRead = loadChatMetadata(client, scope).catch(() => undefined);
     invalidateChatMetadataStore(client);
-    await vi.waitFor(() => expect(peekChatMetadata(client, scope)).toBe(replacement));
+    await vi.waitFor(() => expect(peekChatMetadata(client, scope)).toEqual(replacement));
     startup.publish(metadata("obsolete-startup"));
     older.reject(new Error("obsolete-read"));
     await oldRead;
-    expect(peekChatMetadata(client, scope)).toBe(replacement);
+    expect(peekChatMetadata(client, scope)).toEqual(replacement);
     expect(updates).not.toContain("error");
     expect(request).toHaveBeenLastCalledWith("chat.metadata", scope);
     unsubscribe();
@@ -102,8 +116,8 @@ describe("chat metadata store", () => {
     const request = vi.fn().mockResolvedValue(result);
     const client = clientWith(request);
 
-    await expect(loadChatMetadata(client, { agentId: "main" })).resolves.toBe(result);
-    await expect(loadChatMetadata(client, { agentId: "main" })).resolves.toBe(result);
+    await expect(loadChatMetadata(client, { agentId: "main" })).resolves.toEqual(result);
+    await expect(loadChatMetadata(client, { agentId: "main" })).resolves.toEqual(result);
 
     expect(request).toHaveBeenCalledOnce();
   });
@@ -133,7 +147,7 @@ describe("chat metadata store", () => {
     await expect(loadChatMetadata(client, { agentId: "main" })).rejects.toThrow(
       "metadata unavailable",
     );
-    await expect(loadChatMetadata(client, { agentId: "main" })).resolves.toBe(result);
+    await expect(loadChatMetadata(client, { agentId: "main" })).resolves.toEqual(result);
 
     expect(request).toHaveBeenCalledTimes(2);
   });
@@ -145,8 +159,8 @@ describe("chat metadata store", () => {
 
     beginChatMetadataPublication(client, { agentId: "main" }).publish(result);
 
-    expect(peekChatMetadata(client, { agentId: "main" })).toBe(result);
-    await expect(loadChatMetadata(client, { agentId: "main" })).resolves.toBe(result);
+    expect(peekChatMetadata(client, { agentId: "main" })).toEqual(result);
+    await expect(loadChatMetadata(client, { agentId: "main" })).resolves.toEqual(result);
     expect(request).not.toHaveBeenCalled();
   });
 
@@ -174,8 +188,8 @@ describe("chat metadata store", () => {
 
     unsubscribe();
 
-    expect(peekChatMetadata(client, { agentId: "main" })).toBe(result);
-    await expect(loadChatMetadata(client, { agentId: "main" })).resolves.toBe(result);
+    expect(peekChatMetadata(client, { agentId: "main" })).toEqual(result);
+    await expect(loadChatMetadata(client, { agentId: "main" })).resolves.toEqual(result);
     expect(request).not.toHaveBeenCalled();
   });
 
@@ -191,7 +205,7 @@ describe("chat metadata store", () => {
 
     expect(peekChatMetadata(client, { agentId: "main" })).toBeUndefined();
     expect(peekChatMetadata(client, { agentId: "worker" })).toBeUndefined();
-    await expect(loadChatMetadata(client, { agentId: "main" })).resolves.toBe(main);
+    await expect(loadChatMetadata(client, { agentId: "main" })).resolves.toEqual(main);
     expect(request).toHaveBeenCalledOnce();
   });
 
@@ -207,11 +221,11 @@ describe("chat metadata store", () => {
     const second = revalidateChatMetadata(client, { agentId: "main" });
 
     expect(second).toBe(first);
-    expect(peekChatMetadata(client, { agentId: "main" })).toBe(oldResult);
+    expect(peekChatMetadata(client, { agentId: "main" })).toEqual(oldResult);
     expect(request).toHaveBeenCalledOnce();
     refresh.resolve(nextResult);
-    await expect(first).resolves.toBe(nextResult);
-    expect(peekChatMetadata(client, { agentId: "main" })).toBe(nextResult);
+    await expect(first).resolves.toEqual(nextResult);
+    expect(peekChatMetadata(client, { agentId: "main" })).toEqual(nextResult);
   });
 
   it("does not let an older plain load clobber a newer revalidation", async () => {
@@ -230,7 +244,7 @@ describe("chat metadata store", () => {
     expect(peekChatMetadata(client, { agentId: "main" })).toEqual(metadata("new-model"));
   });
 
-  it("retries canonical startup unavailability and caches the recovered catalog", async () => {
+  it("retries canonical startup unavailability and caches the recovered commands", async () => {
     vi.useFakeTimers();
     const result = metadata("recovered-model");
     const request = vi
@@ -250,9 +264,9 @@ describe("chat metadata store", () => {
     expect(request).toHaveBeenCalledOnce();
     await vi.advanceTimersByTimeAsync(1);
 
-    await expect(refresh).resolves.toBe(result);
+    await expect(refresh).resolves.toEqual(result);
     expect(request).toHaveBeenCalledTimes(2);
-    expect(peekChatMetadata(client, { agentId: "main" })).toBe(result);
+    expect(peekChatMetadata(client, { agentId: "main" })).toEqual(result);
   });
 
   it("does not retry unrelated retryable unavailable errors", async () => {

--- a/ui/src/lib/chat/chat-metadata-store.ts
+++ b/ui/src/lib/chat/chat-metadata-store.ts
@@ -3,17 +3,12 @@ import {
   resolveGatewayStartupRetryAfterMs,
 } from "@openclaw/gateway-client/browser";
 import type {
-  ChatAccountSelection,
   ChatMetadataParams,
   CommandsListResult,
 } from "../../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
-import type { ModelCatalogEntry } from "../../api/types.ts";
 
-export type ChatMetadataResult = CommandsListResult & {
-  models?: ModelCatalogEntry[];
-  accountSelection?: ChatAccountSelection;
-};
+export type ChatMetadataResult = CommandsListResult;
 
 type ChatMetadataUpdate =
   | { type: "invalidated" }
@@ -141,12 +136,15 @@ function beginPublication(entry: ChatMetadataEntry) {
   notifyChatMetadataListeners(entry, { type: "loading" });
   return {
     isCurrent,
-    publish: (result: ChatMetadataResult) => {
+    publish: (result: ChatMetadataResult & { models?: unknown; accountSelection?: unknown }) => {
+      // Legacy/startup responses can carry models. The direct catalog is their only UI owner.
+      const { models: _models, accountSelection: _accountSelection, ...metadata } = result;
       if (isCurrent()) {
-        entry.result = result;
-        notifyChatMetadataListeners(entry, { type: "result", result });
+        entry.result = metadata;
+        notifyChatMetadataListeners(entry, { type: "result", result: metadata });
       }
       entry.release();
+      return metadata;
     },
     fail: (error: unknown) => {
       if (isCurrent()) {
@@ -166,8 +164,7 @@ function beginChatMetadataRequest(
   const pending = request
     .then(
       (result) => {
-        publication.publish(result);
-        return result;
+        return publication.publish(result);
       },
       (error: unknown) => {
         publication.fail(error);

--- a/ui/src/lib/gateway-diagnostics.test.ts
+++ b/ui/src/lib/gateway-diagnostics.test.ts
@@ -3,7 +3,7 @@ import type { GatewayBrowserClient } from "../api/gateway.ts";
 import { loadGatewayDiagnostics } from "./gateway-diagnostics.ts";
 
 describe("loadGatewayDiagnostics", () => {
-  it("reads only the prepared model catalog during automatic diagnostics", async () => {
+  it("reads the published default view during automatic diagnostics", async () => {
     const request = vi.fn(async (method: string) => {
       if (method === "models.list") {
         return { models: [] };
@@ -16,11 +16,7 @@ describe("loadGatewayDiagnostics", () => {
 
     await loadGatewayDiagnostics({ request } as unknown as GatewayBrowserClient, "writer");
 
-    expect(request).toHaveBeenCalledWith(
-      "models.list",
-      { agentId: "writer", preparedOnly: true },
-      { signal: undefined },
-    );
+    expect(request).toHaveBeenCalledWith("models.list", { view: "default", agentId: "writer" });
   });
 
   it("keeps diagnostics available without requesting models before agent selection", async () => {

--- a/ui/src/lib/gateway-diagnostics.ts
+++ b/ui/src/lib/gateway-diagnostics.ts
@@ -1,5 +1,6 @@
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { HealthSnapshot, StatusSummary } from "../api/types.ts";
+import { loadModelCatalog } from "./model-catalog-store.ts";
 
 type CommandLaneBlockReason = "lane" | "group-budget" | "sibling-reservation" | null;
 
@@ -51,7 +52,7 @@ export async function loadGatewayDiagnostics(
   signal?: AbortSignal,
 ): Promise<GatewayDiagnosticsSnapshot> {
   const modelsRequest = agentId
-    ? client.request("models.list", { agentId, preparedOnly: true }, { signal })
+    ? loadModelCatalog(client, { agentId, view: "default", signal })
     : Promise.resolve({ models: [] });
   const lanesRequest = loadCommandLaneDiagnostics(client, signal);
   const [status, health, models, heartbeat, laneDiagnostics] = await Promise.all([
@@ -61,11 +62,10 @@ export async function loadGatewayDiagnostics(
     client.request("last-heartbeat", {}, { signal }),
     lanesRequest,
   ]);
-  const modelPayload = models as { models?: unknown[] } | undefined;
   return {
     status: status as StatusSummary,
     health: health as HealthSnapshot,
-    models: Array.isArray(modelPayload?.models) ? modelPayload.models : [],
+    models: models.models,
     heartbeat,
     ...laneDiagnostics,
   };

--- a/ui/src/lib/model-catalog-store.test.ts
+++ b/ui/src/lib/model-catalog-store.test.ts
@@ -89,7 +89,7 @@ describe("direct model catalog reads", () => {
         throw new Error("Expected caller cancellation signal");
       }
       return new Promise<ModelCatalogResult>((resolve, reject) => {
-        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        signal.addEventListener("abort", () => reject(reason), { once: true });
         if (signal === second.signal) {
           finishSecond = resolve;
         }

--- a/ui/src/lib/model-catalog-store.test.ts
+++ b/ui/src/lib/model-catalog-store.test.ts
@@ -1,402 +1,119 @@
-// Control UI tests cover models behavior.
-import { describe, expect, it, vi } from "vitest";
-import type { GatewayBrowserClient } from "../api/gateway.ts";
+import { describe, expect, it } from "vitest";
+import type { ModelCatalogResult } from "../api/types.ts";
 import {
-  peekChatMetadata,
-  loadChatMetadata,
-  beginChatMetadataPublication,
-  subscribeChatMetadata,
-} from "./chat/chat-metadata-store.ts";
-import { invalidateModelCatalogCache, loadModelCatalog } from "./model-catalog-store.ts";
+  createGatewayRequestMock,
+  createTestGatewayClient,
+} from "../test-helpers/gateway-client.ts";
+import { loadModelCatalog } from "./model-catalog-store.ts";
 
-const loadModels = async (...args: Parameters<typeof loadModelCatalog>) =>
-  (await loadModelCatalog(...args)).models;
+const prepared = { id: "prepared", name: "Prepared", provider: "example" };
+const published = { id: "published", name: "Published", provider: "example" };
 
-describe("loadModels", () => {
-  it("requests the configured model list view", async () => {
-    const request = vi.fn(async () => ({
-      models: [
-        { id: "MiniMax-M2.7-highspeed", name: "MiniMax M2.7 Highspeed", provider: "minimax" },
-      ],
-    }));
-
-    const models = await loadModels({ request } as unknown as GatewayBrowserClient, {
-      agentId: "main",
-    });
-
-    expect(request).toHaveBeenCalledWith("models.list", {
-      view: "configured",
-      agentId: "main",
-    });
-    expect(models).toEqual([
-      { id: "MiniMax-M2.7-highspeed", name: "MiniMax M2.7 Highspeed", provider: "minimax" },
+describe("direct model catalog reads", () => {
+  it("reads the latest published generation without a timer or discovery", async () => {
+    const request = createGatewayRequestMock()
+      .mockResolvedValueOnce({ models: [prepared] })
+      .mockResolvedValueOnce({ models: [published] });
+    const client = createTestGatewayClient(request);
+    expect((await loadModelCatalog(client, { agentId: "writer" })).models).toEqual([prepared]);
+    expect((await loadModelCatalog(client, { agentId: "writer" })).models).toEqual([published]);
+    expect(request.mock.calls.map(([, params]) => params)).toEqual([
+      { view: "configured", agentId: "writer" },
+      { view: "configured", agentId: "writer" },
     ]);
   });
 
-  it("requests only the prepared catalog for automatic reads", async () => {
-    const request = vi.fn(async () => ({ models: [] }));
-
-    await loadModels({ request } as unknown as GatewayBrowserClient, {
-      agentId: "main",
-      preparedOnly: true,
+  it("keeps agent, saved-session and draft-account results separate", async () => {
+    const request = createGatewayRequestMock()
+      .mockResolvedValueOnce({ models: [prepared] })
+      .mockResolvedValueOnce({ models: [published] })
+      .mockResolvedValueOnce({
+        models: [],
+        accountSelection: { kind: "automatic", label: "Automatic" },
+      });
+    const client = createTestGatewayClient(request);
+    const agent = await loadModelCatalog(client, { agentId: " writer " });
+    const saved = await loadModelCatalog(client, {
+      agentId: "writer",
+      sessionKey: "agent:writer:saved",
     });
+    const draft = await loadModelCatalog(client, {
+      agentId: "writer",
+      authProfileId: "personal:reader:example:one",
+    });
+    expect(agent.models).toEqual([prepared]);
+    expect(saved.models).toEqual([published]);
+    expect(draft).toEqual({
+      models: [],
+      accountSelection: { kind: "automatic", label: "Automatic" },
+    });
+    expect(request.mock.calls.map(([, params]) => params)).toEqual([
+      { view: "configured", agentId: "writer" },
+      { view: "configured", agentId: "writer", sessionKey: "agent:writer:saved" },
+      { view: "configured", agentId: "writer", authProfileId: "personal:reader:example:one" },
+    ]);
+  });
 
-    expect(request).toHaveBeenCalledWith("models.list", {
-      view: "configured",
-      agentId: "main",
-      preparedOnly: true,
+  it("preserves explicit view and refresh without invalidating command metadata", async () => {
+    const request = createGatewayRequestMock(async () => ({ models: [published] }));
+    const client = createTestGatewayClient(request);
+    expect(
+      (await loadModelCatalog(client, { view: "provider-config", refresh: true })).models,
+    ).toEqual([published]);
+    expect(request).toHaveBeenCalledExactlyOnceWith("models.list", {
+      view: "provider-config",
+      refresh: true,
     });
   });
 
-  it("revalidates existing metadata after explicit account-model discovery", async () => {
-    const prepared = [{ id: "prepared", name: "Prepared", provider: "openai" }];
-    const discovered = [
-      ...prepared,
-      { id: "discovered", name: "Discovered", provider: "openai", contextWindow: 262_144 },
-    ];
-    const request = vi.fn(async (method: string) => ({
-      models: discovered,
-      ...(method === "chat.metadata" ? { commands: [] } : {}),
-    }));
-    const client = { request } as unknown as GatewayBrowserClient;
-    beginChatMetadataPublication(client, { agentId: "main" }).publish({
-      commands: [],
-      models: prepared,
-    });
-    const listener = vi.fn((update: { type: string }) => {
-      if (update.type === "invalidated") {
-        void loadChatMetadata(client, { agentId: "main" });
+  it("preserves failed refresh facts, successful empty results and recovery", async () => {
+    const request = createGatewayRequestMock()
+      .mockResolvedValueOnce({ models: [prepared], refreshFailed: true })
+      .mockResolvedValueOnce({ models: [] })
+      .mockRejectedValueOnce(new Error("transport closed"))
+      .mockResolvedValueOnce({ models: [published] });
+    const client = createTestGatewayClient(request);
+    expect(await loadModelCatalog(client, {})).toEqual({ models: [prepared], refreshFailed: true });
+    expect(await loadModelCatalog(client, {})).toEqual({ models: [] });
+    await expect(loadModelCatalog(client, {})).rejects.toThrow("transport closed");
+    expect(await loadModelCatalog(client, {})).toEqual({ models: [published] });
+  });
+
+  it("does not let one consumer cancel another consumer's request", async () => {
+    let finishSecond!: (result: ModelCatalogResult) => void;
+    const first = new AbortController();
+    const second = new AbortController();
+    const request = createGatewayRequestMock((_method, _params, options) => {
+      const signal = options?.signal;
+      if (!signal) {
+        throw new Error("Expected caller cancellation signal");
       }
-    });
-    const unsubscribe = subscribeChatMetadata(client, { agentId: "main" }, listener);
-
-    await loadModels(client, { agentId: "main" });
-
-    await vi.waitFor(() =>
-      expect(peekChatMetadata(client, { agentId: "main" })?.models).toEqual(discovered),
-    );
-    expect(request).toHaveBeenCalledWith("chat.metadata", { agentId: "main" });
-    expect(listener.mock.calls.filter(([update]) => update.type === "result")).toHaveLength(1);
-    unsubscribe();
-  });
-
-  it("does not revalidate metadata for automatic prepared-only catalog reads", async () => {
-    const models = [{ id: "prepared", name: "Prepared", provider: "openai" }];
-    const request = vi.fn(async () => ({ models }));
-    const client = { request } as unknown as GatewayBrowserClient;
-    beginChatMetadataPublication(client, { agentId: "main" }).publish({ commands: [], models });
-
-    await loadModels(client, { agentId: "main", preparedOnly: true });
-
-    expect(request).toHaveBeenCalledOnce();
-    expect(request).not.toHaveBeenCalledWith("chat.metadata", expect.anything());
-  });
-
-  it("reuses the configured model list while the cache is fresh", async () => {
-    const request = vi.fn(async () => ({
-      models: [{ id: "gpt-5.5", name: "GPT-5.5", provider: "openai" }],
-    }));
-    const client = { request } as unknown as GatewayBrowserClient;
-
-    const first = await loadModels(client, { agentId: "main" });
-    const second = await loadModels(client, { agentId: "main" });
-
-    expect(request).toHaveBeenCalledTimes(1);
-    expect(first).toBe(second);
-  });
-
-  it("keeps model catalogs scoped by agent", async () => {
-    const request = vi.fn(async (_method: string, params: { agentId?: string }) => ({
-      models: [
-        {
-          id: params.agentId ?? "default-model",
-          name: params.agentId ?? "Default Model",
-          provider: "openai",
-        },
-      ],
-    }));
-    const client = { request } as unknown as GatewayBrowserClient;
-
-    const writer = await loadModels(client, { agentId: "writer" });
-    const reviewer = await loadModels(client, { agentId: "reviewer" });
-    await loadModels(client, { agentId: "writer" });
-
-    expect(writer[0]?.id).toBe("writer");
-    expect(reviewer[0]?.id).toBe("reviewer");
-    expect(request).toHaveBeenCalledTimes(2);
-    expect(request).toHaveBeenCalledWith("models.list", {
-      view: "configured",
-      agentId: "writer",
-    });
-  });
-
-  it("keeps a Models refresh visible when route re-entry uses a prepared read", async () => {
-    const prepared = [{ id: "prepared", name: "Prepared", provider: "openai" }];
-    const exact = [{ id: "exact", name: "Exact", provider: "openai" }];
-    const request = vi
-      .fn()
-      .mockResolvedValueOnce({ models: prepared })
-      .mockResolvedValueOnce({ models: exact });
-    const client = { request } as unknown as GatewayBrowserClient;
-
-    expect(await loadModels(client, { agentId: "main", preparedOnly: true })).toEqual(prepared);
-    expect(await loadModels(client, { agentId: "main", refresh: true })).toEqual(exact);
-    expect(await loadModels(client, { agentId: "main", preparedOnly: true })).toEqual(exact);
-    expect(request).toHaveBeenCalledTimes(2);
-  });
-
-  it("keeps a late stale response from clobbering a fresher refresh result", async () => {
-    const stale = [{ id: "stale", name: "Stale", provider: "openai" }];
-    const fresh = [{ id: "fresh", name: "Fresh", provider: "openai" }];
-    let releaseStale: (() => void) | undefined;
-    const staleGate = new Promise<void>((resolve) => {
-      releaseStale = resolve;
-    });
-    const request = vi
-      .fn()
-      .mockImplementationOnce(async () => {
-        await staleGate;
-        return { models: stale };
-      })
-      .mockImplementationOnce(async () => ({ models: fresh }));
-    const client = { request } as unknown as GatewayBrowserClient;
-
-    const stalePromise = loadModels(client, { agentId: "main" });
-    const freshModels = await loadModels(client, { agentId: "main", refresh: true });
-    releaseStale?.();
-    await stalePromise;
-
-    expect(freshModels).toEqual(fresh);
-    expect(await loadModels(client, { agentId: "main" })).toEqual(fresh);
-    expect(request).toHaveBeenCalledTimes(2);
-  });
-
-  it("coalesces concurrent refreshes without reusing a completed refresh", async () => {
-    let releaseRefresh: (() => void) | undefined;
-    const refreshGate = new Promise<void>((resolve) => {
-      releaseRefresh = resolve;
-    });
-    const request = vi.fn(async () => {
-      await refreshGate;
-      return { models: [{ id: "fresh", name: "Fresh", provider: "openai" }] };
-    });
-    const client = { request } as unknown as GatewayBrowserClient;
-
-    const first = loadModels(client, { agentId: "writer", refresh: true });
-    const concurrent = loadModels(client, { agentId: "writer", refresh: true });
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(1));
-    releaseRefresh?.();
-    expect(await concurrent).toBe(await first);
-
-    await loadModels(client, { agentId: "writer", refresh: true });
-
-    expect(request).toHaveBeenCalledTimes(2);
-  });
-
-  it("keeps a shared refresh alive until its final subscriber aborts", async () => {
-    let requestSignal: AbortSignal | undefined;
-    const request = vi.fn(
-      async (_method: string, _params: unknown, options?: { signal?: AbortSignal }) => {
-        const signal = options?.signal;
-        if (!signal) {
-          throw new Error("expected a cancellable model-catalog request");
+      return new Promise<ModelCatalogResult>((resolve, reject) => {
+        signal.addEventListener("abort", () => reject(signal.reason), { once: true });
+        if (signal === second.signal) {
+          finishSecond = resolve;
         }
-        requestSignal = signal;
-        return await new Promise<never>((_resolve, reject) => {
-          signal.addEventListener(
-            "abort",
-            () =>
-              reject(
-                signal.reason instanceof Error
-                  ? signal.reason
-                  : new DOMException("model catalog request aborted", "AbortError"),
-              ),
-            { once: true },
-          );
-        });
-      },
-    );
-    const client = { request } as unknown as GatewayBrowserClient;
-    const firstAbort = new AbortController();
-    const secondAbort = new AbortController();
-    const firstReason = new DOMException("first page retired", "AbortError");
-    const secondReason = new DOMException("last page retired", "AbortError");
-
-    const first = loadModels(client, {
-      agentId: "writer",
-      refresh: true,
-      signal: firstAbort.signal,
-    });
-    const second = loadModels(client, {
-      agentId: "writer",
-      refresh: true,
-      signal: secondAbort.signal,
-    });
-    await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-
-    firstAbort.abort(firstReason);
-    await expect(first).rejects.toBe(firstReason);
-    expect(requestSignal?.aborted).toBe(false);
-
-    secondAbort.abort(secondReason);
-    await expect(second).rejects.toBe(secondReason);
-    expect(requestSignal?.aborted).toBe(true);
-    expect(request).toHaveBeenCalledOnce();
-  });
-
-  it.each([
-    { label: "explicit refresh", refresh: { refresh: true } },
-    { label: "picker refresh", refresh: { refreshIfDue: true } },
-  ])(
-    "starts a replacement $label when the retired request is already aborted",
-    async (testCase) => {
-      const fresh = [{ id: "fresh", name: "Fresh", provider: "openai" }];
-      let requestCount = 0;
-      const request = vi.fn(
-        (_method: string, _params: unknown, options?: { signal?: AbortSignal }) => {
-          const signal = options?.signal;
-          if (!signal) {
-            throw new Error("expected a cancellable model-catalog request");
-          }
-          requestCount += 1;
-          if (requestCount > 1) {
-            return Promise.resolve({ models: fresh });
-          }
-          return new Promise<never>((_resolve, reject) => {
-            signal.addEventListener(
-              "abort",
-              () =>
-                reject(
-                  signal.reason instanceof Error
-                    ? signal.reason
-                    : new DOMException("model catalog request aborted", "AbortError"),
-                ),
-              { once: true },
-            );
-          });
-        },
-      );
-      const client = { request } as unknown as GatewayBrowserClient;
-      const retired = new AbortController();
-      const replacementTask = new AbortController();
-      const reason = new DOMException("page retired", "AbortError");
-      const first = loadModels(client, {
-        agentId: "writer",
-        ...testCase.refresh,
-        signal: retired.signal,
       });
-      const firstResult = first.catch((error: unknown) => error);
-      await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
-
-      retired.abort(reason);
-      const replacement = loadModels(client, {
-        agentId: "writer",
-        ...testCase.refresh,
-        signal: replacementTask.signal,
-      });
-
-      expect(await firstResult).toBe(reason);
-      await expect(replacement).resolves.toEqual(fresh);
-      expect(request).toHaveBeenCalledTimes(2);
-    },
-  );
-
-  it("joins an active picker refresh instead of returning the cooldown cache", async () => {
-    const initial = [{ id: "initial", name: "Initial", provider: "openai" }];
-    const refreshed = [{ id: "refreshed", name: "Refreshed", provider: "openai" }];
-    let releaseRefresh: (() => void) | undefined;
-    const refreshGate = new Promise<void>((resolve) => {
-      releaseRefresh = resolve;
     });
-    const request = vi
-      .fn()
-      .mockResolvedValueOnce({ models: initial })
-      .mockImplementationOnce(async () => {
-        await refreshGate;
-        return { models: refreshed };
-      });
-    const client = { request } as unknown as GatewayBrowserClient;
-
-    expect(await loadModels(client, { agentId: "main" })).toEqual(initial);
-    const first = loadModels(client, { agentId: "main", refreshIfDue: true });
-    await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(2));
-    const concurrent = loadModels(client, { agentId: "main", refreshIfDue: true });
-    releaseRefresh?.();
-
-    expect(await concurrent).toBe(await first);
-    expect(request).toHaveBeenCalledTimes(2);
+    const client = createTestGatewayClient(request);
+    const retired = loadModelCatalog(client, { agentId: "writer", signal: first.signal });
+    const active = loadModelCatalog(client, { agentId: "writer", signal: second.signal });
+    const reason = new DOMException("Page retired", "AbortError");
+    first.abort(reason);
+    await expect(retired).rejects.toBe(reason);
+    expect(second.signal.aborted).toBe(false);
+    finishSecond({ models: [published] });
+    expect(await active).toEqual({ models: [published] });
   });
 
-  it("refreshes an account catalog once per picker cooldown", async () => {
-    const initial = [{ id: "initial", name: "Initial", provider: "openai" }];
-    const refreshed = [{ id: "refreshed", name: "Refreshed", provider: "openai" }];
-    const later = [{ id: "later", name: "Later", provider: "openai" }];
-    const request = vi
-      .fn()
-      .mockResolvedValueOnce({ models: initial })
-      .mockResolvedValueOnce({ models: refreshed })
-      .mockResolvedValueOnce({ models: later });
-    const client = { request } as unknown as GatewayBrowserClient;
-    const now = vi.spyOn(Date, "now").mockReturnValue(1_000);
-
-    try {
-      expect(await loadModels(client, { agentId: "main" })).toEqual(initial);
-      expect(await loadModels(client, { agentId: "main", refreshIfDue: true })).toEqual(refreshed);
-      expect(await loadModels(client, { agentId: "main", refreshIfDue: true })).toEqual(refreshed);
-      expect(request).toHaveBeenCalledTimes(2);
-
-      now.mockReturnValue(1_000 + 60_000 + 1);
-      expect(await loadModels(client, { agentId: "main", refreshIfDue: true })).toEqual(refreshed);
-      expect(request).toHaveBeenCalledTimes(2);
-
-      now.mockReturnValue(1_000 + 5 * 60_000 + 1);
-      expect(await loadModels(client, { agentId: "main", refreshIfDue: true })).toEqual(later);
-      expect(request).toHaveBeenCalledTimes(3);
-      expect(request.mock.calls.slice(1).map((call) => call[1])).toEqual([
-        { view: "configured", agentId: "main", refresh: true },
-        { view: "configured", agentId: "main", refresh: true },
-      ]);
-    } finally {
-      now.mockRestore();
-    }
-  });
-
-  it("retires a picker catalog when its logical Gateway connection changes", async () => {
-    const beforeReconnect = [{ id: "before", name: "Before", provider: "openai" }];
-    const afterReconnect = [{ id: "after", name: "After", provider: "openai" }];
-    const request = vi
-      .fn()
-      .mockResolvedValueOnce({ models: beforeReconnect })
-      .mockResolvedValueOnce({ models: afterReconnect });
-    const client = { request } as unknown as GatewayBrowserClient;
-
-    expect(await loadModels(client, { agentId: "main", refreshIfDue: true })).toEqual(
-      beforeReconnect,
-    );
-
-    invalidateModelCatalogCache(client);
-
-    expect(await loadModels(client, { agentId: "main", refreshIfDue: true })).toEqual(
-      afterReconnect,
-    );
-    expect(request).toHaveBeenCalledTimes(2);
-  });
-
-  it("keeps a failed account catalog refresh retryable", async () => {
-    const initial = [{ id: "initial", name: "Initial", provider: "openai" }];
-    const recovered = [{ id: "recovered", name: "Recovered", provider: "openai" }];
-    const request = vi
-      .fn()
-      .mockResolvedValueOnce({ models: initial })
-      .mockRejectedValueOnce(new Error("probe timed out"))
-      .mockResolvedValueOnce({ models: recovered });
-    const client = { request } as unknown as GatewayBrowserClient;
-
-    expect(await loadModels(client, { agentId: "main" })).toEqual(initial);
-    await expect(loadModels(client, { agentId: "main", refreshIfDue: true })).rejects.toThrow(
-      "probe timed out",
-    );
-    expect(await loadModels(client, { agentId: "main", refreshIfDue: true })).toEqual(recovered);
-    expect(request).toHaveBeenCalledTimes(3);
+  it("rejects an already retired request before transport", async () => {
+    const request = createGatewayRequestMock();
+    const controller = new AbortController();
+    const reason = new DOMException("Page retired", "AbortError");
+    controller.abort(reason);
+    await expect(
+      loadModelCatalog(createTestGatewayClient(request), { signal: controller.signal }),
+    ).rejects.toBe(reason);
+    expect(request).not.toHaveBeenCalled();
   });
 });

--- a/ui/src/lib/model-catalog-store.ts
+++ b/ui/src/lib/model-catalog-store.ts
@@ -1,145 +1,48 @@
-// Control UI model metadata boundary.
+import type { ModelsListParams } from "../../../packages/gateway-protocol/src/index.js";
 import type { GatewayBrowserClient } from "../api/gateway.ts";
 import type { ModelCatalogResult } from "../api/types.ts";
-import { invalidateChatMetadataStore } from "./chat/chat-metadata-store.ts";
-import { subscribeToSharedRequest } from "./shared-request-subscription.ts";
+import type { ApplicationGateway } from "../app/context.ts";
+import { t } from "../i18n/index.ts";
 
-const MODEL_CATALOG_CACHE_TTL_MS = 60_000;
-// A picker open is an operator signal to revalidate, but full provider discovery can be slow.
-const MODEL_CATALOG_REFRESH_COOLDOWN_MS = 5 * 60_000;
+export type ModelCatalogReadScope = Pick<
+  ModelsListParams,
+  "agentId" | "sessionKey" | "authProfileId"
+>;
 
-type ModelCatalogCacheEntry = {
-  expiresAt: number;
-  refreshEligibleAt?: number;
-  result: ModelCatalogResult;
-  inFlight?: ModelCatalogPendingRequest;
-  inFlightRefresh?: boolean;
-};
-
-type ModelCatalogPendingRequest = {
-  controller?: AbortController;
-  promise: Promise<ModelCatalogResult>;
-  subscribers: Set<object>;
-};
-
-const modelCatalogCache = new WeakMap<GatewayBrowserClient, Map<string, ModelCatalogCacheEntry>>();
-
-export function invalidateModelCatalogCache(client: GatewayBrowserClient): void {
-  modelCatalogCache.delete(client);
+export function modelCatalogRefreshError(result: ModelCatalogResult): string | null {
+  return result.refreshFailed
+    ? t(
+        result.models.length
+          ? "chat.modelControls.modelsRefreshFailed"
+          : "chat.modelControls.modelsUnavailable",
+      )
+    : null;
 }
 
-function modelCatalogCacheFor(client: GatewayBrowserClient): Map<string, ModelCatalogCacheEntry> {
-  let cache = modelCatalogCache.get(client);
-  if (!cache) {
-    cache = new Map();
-    modelCatalogCache.set(client, cache);
-  }
-  return cache;
-}
-
+/** The Gateway owns publication and freshness; callers own their request lifetime. */
 export async function loadModelCatalog(
-  client: GatewayBrowserClient,
-  opts: {
-    agentId: string;
-    preparedOnly?: boolean;
-    refresh?: boolean;
-    refreshIfDue?: boolean;
-    signal?: AbortSignal;
-  },
+  client: Pick<GatewayBrowserClient, "request">,
+  options: ModelsListParams & { signal?: AbortSignal },
 ): Promise<ModelCatalogResult> {
-  opts.signal?.throwIfAborted();
-  const cache = modelCatalogCacheFor(client);
-  const agentId = opts.agentId.trim();
-  const cacheKey = `${agentId}\0${opts.preparedOnly ? "prepared" : "exact"}`;
-  const preparedCacheKey = `${agentId}\0prepared`;
-  const cached = cache.get(cacheKey);
-  const now = Date.now();
-  // Abort is synchronous, but cache cleanup runs in a promise reaction. A
-  // replacement during that gap must not inherit the retired producer/cooldown.
-  const pendingRequestAborted = cached?.inFlight?.controller?.signal.aborted === true;
-  const refresh =
-    opts.refresh === true ||
-    (opts.refreshIfDue === true &&
-      (pendingRequestAborted || (cached?.refreshEligibleAt ?? 0) <= now));
-  const nextRefreshEligibleAt = refresh
-    ? now + MODEL_CATALOG_REFRESH_COOLDOWN_MS
-    : cached?.refreshEligibleAt;
-  const refreshCooldownActive =
-    opts.refreshIfDue === true && (cached?.refreshEligibleAt ?? 0) > now;
-  if (
-    opts.refreshIfDue === true &&
-    cached?.inFlight &&
-    !pendingRequestAborted &&
-    cached.inFlightRefresh === true
-  ) {
-    return await subscribeToSharedRequest(cached.inFlight, {}, opts.signal);
-  }
-  if (!refresh && cached?.result && (cached.expiresAt > now || refreshCooldownActive)) {
-    return cached.result;
-  }
-  if (cached?.inFlight && !pendingRequestAborted && (!refresh || cached.inFlightRefresh === true)) {
-    return await subscribeToSharedRequest(cached.inFlight, {}, opts.signal);
-  }
-
-  // The cache write happens here, gated on inFlight identity: a refresh call
-  // replaces inFlight, so an older request resolving late cannot clobber the
-  // fresher result with pre-mutation catalog data.
-  const controller = opts.signal ? new AbortController() : undefined;
+  const { signal, agentId, view = "configured", ...optionsWithoutScope } = options;
+  signal?.throwIfAborted();
   const params = {
-    view: "configured",
-    agentId,
-    ...(opts.preparedOnly === true ? { preparedOnly: true } : {}),
-    ...(refresh ? { refresh: true } : {}),
+    view,
+    ...optionsWithoutScope,
+    ...(agentId === undefined ? {} : { agentId: agentId.trim() }),
   };
-  const inFlight: ModelCatalogPendingRequest = {
-    controller,
-    subscribers: new Set(),
-    promise: (controller
-      ? client.request<ModelCatalogResult>("models.list", params, { signal: controller.signal })
-      : client.request<ModelCatalogResult>("models.list", params)
-    )
-      .then((result) => {
-        const latest = cache.get(cacheKey);
-        if (modelCatalogCache.get(client) === cache && latest?.inFlight === inFlight) {
-          const refreshEligibleAt = refresh
-            ? Date.now() + MODEL_CATALOG_REFRESH_COOLDOWN_MS
-            : nextRefreshEligibleAt;
-          const entry = {
-            expiresAt: Date.now() + MODEL_CATALOG_CACHE_TTL_MS,
-            ...(refreshEligibleAt ? { refreshEligibleAt } : {}),
-            result,
-          };
-          cache.set(cacheKey, entry);
-          if (opts.preparedOnly !== true) {
-            // An exact catalog supersedes the prepared projection. Reusing it for
-            // automatic reads prevents route re-entry from restoring stale data.
-            cache.set(preparedCacheKey, entry);
-            // Discovery changes prepared metadata, including session-locked projections.
-            invalidateChatMetadataStore(client, { agentId });
-          }
-        }
-        return result;
-      })
-      .catch((error: unknown) => {
-        const latest = cache.get(cacheKey);
-        if (refresh && latest?.inFlight === inFlight) {
-          delete latest.refreshEligibleAt;
-        }
-        throw error;
-      })
-      .finally(() => {
-        const latest = cache.get(cacheKey);
-        if (latest?.inFlight === inFlight) {
-          delete latest.inFlight;
-        }
-      }),
-  };
-  cache.set(cacheKey, {
-    expiresAt: cached?.expiresAt ?? 0,
-    ...(nextRefreshEligibleAt ? { refreshEligibleAt: nextRefreshEligibleAt } : {}),
-    result: cached?.result ?? { models: [] },
-    inFlight,
-    ...(refresh ? { inFlightRefresh: true } : {}),
+  return signal
+    ? await client.request<ModelCatalogResult>("models.list", params, { signal })
+    : await client.request<ModelCatalogResult>("models.list", params);
+}
+
+export function subscribeModelCatalogChanges(
+  gateway: ApplicationGateway,
+  listener: () => void,
+): () => void {
+  return gateway.subscribeEvents((event) => {
+    if (event.event === "config.changed" || event.event === "chat.metadata.changed") {
+      listener();
+    }
   });
-  return await subscribeToSharedRequest(inFlight, {}, opts.signal);
 }

--- a/ui/src/pages/agents/agents-page.test-support.ts
+++ b/ui/src/pages/agents/agents-page.test-support.ts
@@ -69,6 +69,9 @@ export function setPageGateway(
   connected = true,
   sourceChanged = false,
 ) {
+  if (!page.context?.gateway || sourceChanged) {
+    page.context = { ...page.context, gateway: gateway(snapshot(client, connected)) };
+  }
   page.gateway.applySnapshot(snapshot(client, connected), { initial: false, sourceChanged });
 }
 
@@ -99,9 +102,29 @@ export function snapshot(
   };
 }
 
+const eventListeners = new WeakMap<
+  ApplicationContext["gateway"],
+  Set<Parameters<ApplicationContext["gateway"]["subscribeEvents"]>[0]>
+>();
+
+export function emitCatalogChanged(currentGateway: ApplicationContext["gateway"]) {
+  for (const listener of eventListeners.get(currentGateway) ?? []) {
+    listener({ type: "event", event: "chat.metadata.changed", payload: {} });
+  }
+}
+
 export function gateway(current: ApplicationGatewaySnapshot): ApplicationContext["gateway"] {
-  return {
+  const listeners = new Set<Parameters<ApplicationContext["gateway"]["subscribeEvents"]>[0]>();
+  const result = {
+    subscribeEvents: (
+      listener: Parameters<ApplicationContext["gateway"]["subscribeEvents"]>[0],
+    ) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
     snapshot: current,
     subscribe: vi.fn(() => () => undefined),
   } as unknown as ApplicationContext["gateway"];
+  eventListeners.set(result, listeners);
+  return result;
 }

--- a/ui/src/pages/agents/agents-page.test.ts
+++ b/ui/src/pages/agents/agents-page.test.ts
@@ -12,11 +12,11 @@ import type {
 } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { refreshVisibleToolsEffectiveForCurrentSession } from "../../lib/agents/index.ts";
-import { invalidateChatMetadataStore } from "../../lib/chat/chat-metadata-store.ts";
 import { loadCronJobsPage } from "../../lib/cron/index.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import {
   deferred,
+  emitCatalogChanged,
   gateway,
   setPageGateway,
   snapshot,
@@ -288,10 +288,14 @@ describe("AgentsPage gateway lifecycle", () => {
 
     await waitForFast(() => expect(page.chatModelCatalog).toEqual(models));
     expect(request).toHaveBeenCalledOnce();
-    expect(request).toHaveBeenCalledWith("chat.metadata", { agentId: "main" });
+    expect(request).toHaveBeenCalledWith(
+      "models.list",
+      { view: "configured", agentId: "main" },
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
-  it("caches separate configured model catalogs for the default and worker agents", async () => {
+  it("reads separate configured model catalogs when switching default and worker agents", async () => {
     const defaultModels = [
       { id: "default-model", name: "Default account model", provider: "openai" },
     ];
@@ -315,10 +319,20 @@ describe("AgentsPage gateway lifecycle", () => {
 
     page.agentsSelectedId = "main";
     page.loadActivePanelData();
-    expect(page.chatModelCatalog).toEqual(defaultModels);
-    expect(request).toHaveBeenCalledTimes(2);
-    expect(request).toHaveBeenNthCalledWith(1, "chat.metadata", { agentId: "main" });
-    expect(request).toHaveBeenNthCalledWith(2, "chat.metadata", { agentId: "worker" });
+    await waitForFast(() => expect(page.chatModelCatalog).toEqual(defaultModels));
+    expect(request).toHaveBeenCalledTimes(3);
+    expect(request).toHaveBeenNthCalledWith(
+      1,
+      "models.list",
+      { view: "configured", agentId: "main" },
+      { signal: expect.any(AbortSignal) },
+    );
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "models.list",
+      { view: "configured", agentId: "worker" },
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it("rejects a stale default-agent catalog after switching to a worker agent", async () => {
@@ -350,7 +364,12 @@ describe("AgentsPage gateway lifecycle", () => {
 
     expect(page.chatModelCatalog).toEqual(workerModels);
     expect(request).toHaveBeenCalledTimes(2);
-    expect(request).toHaveBeenNthCalledWith(2, "chat.metadata", { agentId: "worker" });
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "models.list",
+      { view: "configured", agentId: "worker" },
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it("re-reads a cached model catalog when the picker asks for a refresh", async () => {
@@ -368,8 +387,7 @@ describe("AgentsPage gateway lifecycle", () => {
     page.loadActivePanelData();
     await waitForFast(() => expect(page.chatModelCatalog).toEqual(oldModels));
 
-    // Without refresh the per-agent cache answers; provider-key changes would
-    // stay invisible for the connection lifetime.
+    // Repeated render work retains this page snapshot; a picker read requests current facts.
     page.ensureModelCatalog();
     expect(request).toHaveBeenCalledTimes(1);
 
@@ -398,7 +416,7 @@ describe("AgentsPage gateway lifecycle", () => {
 
       page.loadActivePanelData();
       if (replacement === "publication") {
-        invalidateChatMetadataStore(client);
+        emitCatalogChanged(page.context.gateway);
       } else {
         if (replacement === "reconnect") {
           setPageGateway(page, client, false);
@@ -409,7 +427,7 @@ describe("AgentsPage gateway lifecycle", () => {
           true,
           replacement === "gateway source",
         );
-        invalidateChatMetadataStore(client);
+        emitCatalogChanged(page.context.gateway);
         page.agentsSelectedId = "main";
         page.loadActivePanelData();
       }
@@ -442,13 +460,18 @@ describe("AgentsPage gateway lifecycle", () => {
 
     setPageGateway(page, client, false);
     expect(page.chatModelCatalog).toEqual([]);
-    invalidateChatMetadataStore(client);
+    emitCatalogChanged(page.context.gateway);
     setPageGateway(page, client);
     page.loadActivePanelData();
 
     await waitForFast(() => expect(page.chatModelCatalog).toEqual(nextModels));
     expect(request).toHaveBeenCalledTimes(2);
-    expect(request).toHaveBeenNthCalledWith(2, "chat.metadata", { agentId: "main" });
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "models.list",
+      { view: "configured", agentId: "main" },
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it("surfaces a rejected agent-scoped metadata RPC and retries without marking an empty catalog loaded", async () => {
@@ -473,7 +496,12 @@ describe("AgentsPage gateway lifecycle", () => {
 
     expect(page.chatModelCatalogStatus.error).toBeNull();
     expect(request).toHaveBeenCalledTimes(2);
-    expect(request).toHaveBeenNthCalledWith(2, "chat.metadata", { agentId: "main" });
+    expect(request).toHaveBeenNthCalledWith(
+      2,
+      "models.list",
+      { view: "configured", agentId: "main" },
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it("requests the selected agent's implicit default cron job before the first 50 unrelated jobs", async () => {

--- a/ui/src/pages/agents/agents-page.ts
+++ b/ui/src/pages/agents/agents-page.ts
@@ -34,12 +34,6 @@ import {
   type AgentsState,
 } from "../../lib/agents/index.ts";
 import { DEFAULT_AGENT_PANEL, type AgentsPanel } from "../../lib/agents/panels.ts";
-import {
-  loadChatMetadata,
-  peekChatMetadata,
-  revalidateChatMetadata,
-  subscribeChatMetadata,
-} from "../../lib/chat/chat-metadata-store.ts";
 import { currentConfigObject } from "../../lib/config/config-state-model.ts";
 import {
   createInitialCronState,
@@ -56,6 +50,11 @@ import {
   type GatewayMethodOperatorScope,
 } from "../../lib/gateway-methods.ts";
 import { IdentityAvatarController } from "../../lib/identity-avatar-loader.ts";
+import {
+  loadModelCatalog,
+  modelCatalogRefreshError,
+  subscribeModelCatalogChanges,
+} from "../../lib/model-catalog-store.ts";
 import { parseAgentSessionKey } from "../../lib/sessions/session-key.ts";
 import { GatewayPageController } from "../../lit/gateway-page-controller.ts";
 import { OpenClawLightDomElement } from "../../lit/openclaw-element.ts";
@@ -107,6 +106,7 @@ class AgentsPage
   @state() chatModelCatalog: ModelCatalogEntry[] = [];
   @state() chatModelCatalogStatus = createPanelRefreshStatus();
   private chatModelCatalogPending: Promise<unknown> | null = null;
+  private chatModelCatalogRequest: AbortController | null = null;
   @state() agentFilesLoading = false;
   @state() agentFilesError: string | null = null;
   @state() agentFilesList: AgentsFilesListResult | null = null;
@@ -600,6 +600,8 @@ class AgentsPage
   }
 
   private resetModelCatalog() {
+    this.chatModelCatalogRequest?.abort();
+    this.chatModelCatalogRequest = null;
     this.chatModelCatalogSubscription?.unsubscribe();
     this.chatModelCatalogSubscription = null;
     this.chatModelCatalog = [];
@@ -623,36 +625,17 @@ class AgentsPage
           this.chatModelCatalogSubscription === subscription &&
           this.context?.gateway === gateway &&
           this.isCurrentRequest(client, generation, agentId, { agents }),
-        unsubscribe: subscribeChatMetadata(client, { agentId }, (update) => {
+        unsubscribe: subscribeModelCatalogChanges(this.context.gateway, () => {
           if (!subscription.isCurrent()) {
             return;
           }
-          if (update.type === "invalidated") {
-            this.chatModelCatalogPending = null;
-            this.ensureModelCatalog({ refresh: true });
-          } else if (update.type === "error") {
-            this.chatModelCatalogStatus = failPanelRefresh(
-              this.chatModelCatalogStatus,
-              update.error,
-              this.gateway.snapshot,
-            );
-          } else {
-            this.chatModelCatalogStatus =
-              update.type === "loading"
-                ? beginPanelRefresh(this.chatModelCatalogStatus)
-                : completePanelRefresh();
-            if (update.type === "result") {
-              this.chatModelCatalog = update.result.models ?? [];
-            }
-          }
+          this.chatModelCatalogRequest?.abort();
+          this.chatModelCatalogRequest = null;
+          this.chatModelCatalogPending = null;
+          this.ensureModelCatalog({ refresh: true });
         }),
       };
       this.chatModelCatalogSubscription = subscription;
-      const cached = peekChatMetadata(client, { agentId });
-      if (cached) {
-        this.chatModelCatalog = cached.models ?? [];
-        this.chatModelCatalogStatus = completePanelRefresh();
-      }
     }
     if (
       this.chatModelCatalogPending ||
@@ -660,16 +643,38 @@ class AgentsPage
     ) {
       return;
     }
-    // The store owns current publications and pending reads. A superseded promise
-    // must not overwrite its newer result or erase retained choices on failure.
-    const metadataRequest = options.refresh
-      ? revalidateChatMetadata(client, { agentId })
-      : loadChatMetadata(client, { agentId });
-    const pending = metadataRequest
-      .catch(() => undefined)
+    const subscription = this.chatModelCatalogSubscription;
+    const controller = new AbortController();
+    this.chatModelCatalogRequest = controller;
+    const ownsRequest = () =>
+      subscription?.isCurrent() && this.chatModelCatalogRequest === controller;
+    this.chatModelCatalogStatus = beginPanelRefresh(this.chatModelCatalogStatus);
+    const pending = loadModelCatalog(client, { agentId, signal: controller.signal })
+      .then(
+        (result) => {
+          if (!ownsRequest()) {
+            return;
+          }
+          this.chatModelCatalog = result.models;
+          const error = modelCatalogRefreshError(result);
+          this.chatModelCatalogStatus = error
+            ? failPanelRefresh(completePanelRefresh(), new Error(error), this.gateway.snapshot)
+            : completePanelRefresh();
+        },
+        (error: unknown) => {
+          if (ownsRequest()) {
+            this.chatModelCatalogStatus = failPanelRefresh(
+              this.chatModelCatalogStatus,
+              error,
+              this.gateway.snapshot,
+            );
+          }
+        },
+      )
       .finally(() => {
         if (this.chatModelCatalogPending === pending) {
           this.chatModelCatalogPending = null;
+          this.chatModelCatalogRequest = null;
         }
       });
     this.chatModelCatalogPending = pending;

--- a/ui/src/pages/chat/chat-command-executor.test.ts
+++ b/ui/src/pages/chat/chat-command-executor.test.ts
@@ -334,6 +334,7 @@ describe("executeSlashCommand directives", () => {
     );
     expect(request).toHaveBeenNthCalledWith(1, "sessions.list", {});
     expect(request).toHaveBeenNthCalledWith(2, "models.list", {
+      sessionKey: "main",
       agentId: "main",
       view: "configured",
     });
@@ -418,6 +419,7 @@ describe("executeSlashCommand directives", () => {
     );
     expect(request).toHaveBeenCalledWith("sessions.list", { agentId: "work" });
     expect(request).toHaveBeenCalledWith("models.list", {
+      sessionKey: "agent:work:main",
       agentId: "work",
       view: "configured",
     });

--- a/ui/src/pages/chat/chat-command-executor.ts
+++ b/ui/src/pages/chat/chat-command-executor.ts
@@ -32,6 +32,7 @@ import {
 } from "../../lib/chat/thinking.ts";
 import { formatUiError, formatUiExternalText } from "../../lib/format-error.ts";
 import { formatCompactTokenCount } from "../../lib/format.ts";
+import { loadModelCatalog } from "../../lib/model-catalog-store.ts";
 import { readSessionMethodAccess } from "../../lib/session-method-access.ts";
 import { resolveSessionContextLimit } from "../../lib/sessions/context-budget.ts";
 import type { SessionCapability } from "../../lib/sessions/index.ts";
@@ -255,7 +256,9 @@ async function executeModel(
     try {
       const [sessions, models] = await Promise.all([
         listSessions(context, selectedAgentListScope(sessionKey, context)),
-        modelCatalog ? Promise.resolve(modelCatalog) : loadModelCatalog(client, agentId),
+        modelCatalog
+          ? Promise.resolve(modelCatalog)
+          : loadModelCatalog(client, { agentId, sessionKey }).then((result) => result.models),
       ]);
       const { session, defaults } = resolveCommandSessionState(context, sessionKey, sessions);
       const model = session?.model || defaults?.model || "default";
@@ -742,27 +745,15 @@ async function loadThinkingCommandState(
   const agentId = resolveSelectedAgentId(sessionKey, context);
   const [sessions, models] = await Promise.all([
     listSessions(context, selectedAgentListScope(sessionKey, context)),
-    modelCatalog ? Promise.resolve(modelCatalog) : loadModelCatalog(client, agentId),
+    modelCatalog
+      ? Promise.resolve(modelCatalog)
+      : loadModelCatalog(client, { agentId, sessionKey }).then((result) => result.models),
   ]);
   const state = resolveCommandSessionState(context, sessionKey, sessions);
   return {
     ...state,
     models,
   };
-}
-
-async function loadModelCatalog(
-  client: GatewayBrowserClient,
-  agentId: string | undefined,
-): Promise<ModelCatalogEntry[]> {
-  if (!agentId) {
-    return [];
-  }
-  const result = await client.request<{ models: ModelCatalogEntry[] }>("models.list", {
-    agentId,
-    view: "configured",
-  });
-  return result?.models ?? [];
 }
 
 function resolveCommandMessage(

--- a/ui/src/pages/chat/chat-host.test-support.ts
+++ b/ui/src/pages/chat/chat-host.test-support.ts
@@ -22,7 +22,7 @@ export function makeRequestMock(handlers: RequestHandlers = {}): GatewayRequestM
   return createGatewayRequestMock((method: string, params?: unknown) => {
     if (!Object.hasOwn(handlers, method)) {
       // Keep unrelated Gateway traffic inert so each test declares only the responses it observes.
-      return Promise.resolve({});
+      return Promise.resolve(method === "models.list" ? { models: [] } : {});
     }
     try {
       const handler = handlers[method];

--- a/ui/src/pages/chat/chat-pane-companion-lifecycle.test.ts
+++ b/ui/src/pages/chat/chat-pane-companion-lifecycle.test.ts
@@ -29,6 +29,7 @@ describe("chat pane companion connection lifecycle", () => {
       switch (method) {
         case "chat.startup":
           return { messages: [], sessionId: "session-current", hasMore: false, totalMessages: 0 };
+        case "models.list":
         case "chat.metadata":
           return { commands: [], models, swarmEnabled: false };
         default:

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -960,11 +960,15 @@ describe("chat pane composer controls", () => {
 
       expect(state.chatModelPickerOpenSessionKey).toBe("main");
       expect(request).toHaveBeenCalledOnce();
-      expect(request).toHaveBeenCalledWith("models.list", {
-        view: "configured",
-        agentId: "main",
-        refresh: true,
-      });
+      expect(request).toHaveBeenCalledWith(
+        "models.list",
+        {
+          view: "configured",
+          agentId: "main",
+          sessionKey: "main",
+        },
+        { signal: expect.any(AbortSignal) },
+      );
       expect(state.chatModelsLoading).toBe(cachedModels.length === 0);
       render(renderChatPaneComposerControls(controlParams).composerControls, container);
       if (cachedModels.length > 0) {

--- a/ui/src/pages/chat/chat-pane-session-controls.test.ts
+++ b/ui/src/pages/chat/chat-pane-session-controls.test.ts
@@ -231,7 +231,7 @@ describe("chat pane composer controls", () => {
       cached: true,
       connected: true,
       error: "metadata unavailable",
-      message: null,
+      message: "Some models could not be refreshed. Open Models to try again.",
     },
     {
       label: "failed without a snapshot",

--- a/ui/src/pages/chat/chat-pane.test.ts
+++ b/ui/src/pages/chat/chat-pane.test.ts
@@ -713,6 +713,7 @@ describe("chat pane initialization", () => {
     const authStatus = { ts: 1, providers: [] };
     const request = createGatewayRequestMock(async (method) => {
       switch (method) {
+        case "models.list":
         case "chat.metadata":
           return { commands: [], models, swarmEnabled: false };
         case "models.authStatus":

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -658,6 +658,7 @@ describe("refreshChat", () => {
       const retained = makeChatHost({
         requestHandlers: {
           "chat.metadata": () => metadata.promise,
+          "models.list": () => metadata.promise,
           "chat.startup": () => startup.promise,
         },
       });

--- a/ui/src/pages/chat/chat-send.test.ts
+++ b/ui/src/pages/chat/chat-send.test.ts
@@ -459,12 +459,17 @@ describe("refreshChat", () => {
     expect(requestUpdate).not.toHaveBeenCalled();
   });
 
-  it("uses prepared models delivered with startup metadata", async () => {
+  it("uses direct catalog models instead of a competing startup projection", async () => {
     const startup = createDeferred<unknown>();
     const host = makeChatHost({
       hello: gatewayHelloForMethods(["chat.metadata", "chat.startup"], []),
       requestHandlers: {
         "chat.startup": () => startup.promise,
+        "models.list": async () => ({
+          models: [
+            { available: true, id: "direct-model", name: "Direct Model", provider: "example" },
+          ],
+        }),
       },
     });
 
@@ -474,7 +479,10 @@ describe("refreshChat", () => {
       startup: true,
     });
 
-    expect(host.request.mock.calls.map(([method]) => method)).toEqual(["chat.startup"]);
+    expect(host.request.mock.calls.map(([method]) => method)).toEqual([
+      "models.list",
+      "chat.startup",
+    ]);
     expect(await raceWithMacrotask(refresh)).toBe("pending");
 
     startup.resolve({
@@ -494,16 +502,15 @@ describe("refreshChat", () => {
     await expect(refresh).resolves.toBeUndefined();
     await waitForFast(() =>
       expect(host.chatModelCatalog).toEqual([
-        {
-          available: true,
-          id: "startup-model",
-          name: "Startup Model",
-          provider: "openai",
-        },
+        { available: true, id: "direct-model", name: "Direct Model", provider: "example" },
       ]),
     );
     expect(host.request).not.toHaveBeenCalledWith("chat.metadata", expect.anything());
-    expect(host.request).not.toHaveBeenCalledWith("models.list", expect.anything());
+    expect(host.request).toHaveBeenCalledWith(
+      "models.list",
+      { view: "configured", agentId: "main", sessionKey: host.sessionKey },
+      { signal: expect.any(AbortSignal) },
+    );
     expect(host.request).not.toHaveBeenCalledWith("commands.list", expect.anything());
   });
 
@@ -518,6 +525,7 @@ describe("refreshChat", () => {
       requestHandlers: {
         "chat.startup": async () => ({ messages: [message] }),
         "chat.metadata": () => metadata.promise,
+        "models.list": () => metadata.promise,
       },
     });
 
@@ -546,13 +554,15 @@ describe("refreshChat", () => {
     await waitForFast(() => expect(host.chatModelCatalog).toEqual([model]));
   });
 
-  it("keeps cached models interactive while startup metadata revalidates silently", async () => {
+  it("keeps current models interactive while the direct catalog revalidates", async () => {
     const startup = createDeferred<unknown>();
+    const catalog = createDeferred<unknown>();
     const host = makeChatHost({
       chatModelSwitchPromises: {},
       hello: gatewayHelloForMethods(["chat.metadata", "chat.startup"], []),
       requestHandlers: {
         "chat.startup": () => startup.promise,
+        "models.list": () => catalog.promise,
       },
     });
     const cachedModel = {
@@ -569,6 +579,7 @@ describe("refreshChat", () => {
       models: [cachedModel],
     });
 
+    host.chatModelCatalog = [cachedModel];
     const refresh = refreshPageChat(asChatPageHost(host), {
       awaitHistory: true,
       deferBranches: true,
@@ -601,6 +612,7 @@ describe("refreshChat", () => {
         models: [{ ...cachedModel, id: "fresh-model", name: "Fresh Model" }],
       },
     });
+    catalog.resolve({ models: [{ ...cachedModel, id: "fresh-model", name: "Fresh Model" }] });
     await expect(refresh).resolves.toBeUndefined();
     await waitForFast(() =>
       expect(host.chatModelCatalog).toEqual([
@@ -615,7 +627,8 @@ describe("refreshChat", () => {
     const host = makeChatHost({
       requestHandlers: {
         "chat.startup": () => startup.promise,
-        "chat.metadata": async () => ({ commands: [], models: [ready] }),
+        "chat.metadata": async () => ({ commands: [] }),
+        "models.list": async () => ({ models: [ready] }),
       },
     });
     const refresh = refreshPageChat(asChatPageHost(host), {
@@ -637,7 +650,7 @@ describe("refreshChat", () => {
   });
 
   it.each(["closes", "disconnects", "changes session"])(
-    "publishes shared startup metadata after its initiating pane %s",
+    "keeps direct catalog reads alive after another pane %s",
     async (retirement) => {
       const startup = createDeferred<unknown>();
       const metadata = createDeferred<unknown>();
@@ -684,7 +697,8 @@ describe("refreshChat", () => {
       const host = makeChatHost({
         requestHandlers: {
           "chat.startup": async () => ({ messages: [] }),
-          "chat.metadata": async () => ({ commands: [], models: [ready] }),
+          "chat.metadata": async () => ({ commands: [] }),
+          "models.list": async () => ({ models: [ready] }),
         },
       });
       const client = expectDefined(host.client, "chat client");

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -50,7 +50,7 @@ type ChatMetadataBinding = {
   client: GatewayBrowserClient;
   scope: { agentId?: string; sessionKey: string };
   version: number;
-  catalogRequest?: { version: number; controller: AbortController; promise: Promise<void> };
+  catalogRequest?: { version: number; controller: AbortController; promise: Promise<boolean> };
   isCurrent: () => boolean;
   unsubscribe: () => void;
 };
@@ -129,20 +129,6 @@ export function applyChatAgentOwnerTransition(
   host.requestUpdate?.();
 }
 
-function applyChatMetadataResult(
-  host: ChatPageHost,
-  client: GatewayBrowserClient,
-  agentId: string | null | undefined,
-  result: ChatMetadataResult,
-): void {
-  // Missing commands keep the built-ins: commands.list uses the same server builder and fails too.
-  applyRemoteSlashCommandsResult({
-    client,
-    agentId,
-    result,
-  });
-}
-
 function bindChatMetadata(host: ChatPageHost): ChatMetadataBinding | undefined {
   const previous = metadataBindings.get(host);
   if (previous?.isCurrent()) {
@@ -179,7 +165,7 @@ function bindChatMetadata(host: ChatPageHost): ChatMetadataBinding | undefined {
       if (update.type === "loading") {
         binding.version += 1;
       } else if (update.type === "result") {
-        applyChatMetadataResult(host, client, scope.agentId, update.result);
+        applyRemoteSlashCommandsResult({ client, agentId: scope.agentId, result: update.result });
       }
       host.requestUpdate?.();
     }),
@@ -187,7 +173,7 @@ function bindChatMetadata(host: ChatPageHost): ChatMetadataBinding | undefined {
   metadataBindings.set(host, binding);
   const cached = peekChatMetadata(client, scope);
   if (cached) {
-    applyChatMetadataResult(host, client, scope.agentId, cached);
+    applyRemoteSlashCommandsResult({ client, agentId: scope.agentId, result: cached });
   }
   return binding;
 }
@@ -239,7 +225,7 @@ export async function refreshChatModelAuthStatus(host: ChatPageHost, opts?: { re
 async function loadChatModelCatalog(
   host: ChatPageHost,
   binding: ChatMetadataBinding,
-): Promise<void> {
+): Promise<boolean> {
   if (binding.catalogRequest?.version === binding.version) {
     return binding.catalogRequest.promise;
   }
@@ -254,16 +240,18 @@ async function loadChatModelCatalog(
     .then(
       (result) => {
         if (!ownsRequest()) {
-          return;
+          return false;
         }
         host.chatModelCatalog = result.models;
         host.chatAccountSelection = result.accountSelection ?? null;
         host.chatModelCatalogError = modelCatalogRefreshError(result);
+        return true;
       },
       (error: unknown) => {
         if (ownsRequest()) {
           host.chatModelCatalogError = formatUiError(error);
         }
+        return false;
       },
     )
     .finally(() => {
@@ -279,8 +267,9 @@ async function loadChatModelCatalog(
 
 export async function refreshChatModelCatalogOnDemand(host: ChatPageHost): Promise<void> {
   const binding = bindChatMetadata(host);
-  if (binding) {
-    await loadChatModelCatalog(host, binding);
+  if (binding && (await loadChatModelCatalog(host, binding)) && binding.isCurrent()) {
+    // Session-owned thinking/context facts must converge with the published model catalog.
+    await refreshCurrentChatSessionList(host).catch(() => undefined);
   }
 }
 

--- a/ui/src/pages/chat/chat-state-refresh.ts
+++ b/ui/src/pages/chat/chat-state-refresh.ts
@@ -9,7 +9,7 @@ import {
 } from "../../lib/chat/chat-metadata-store.ts";
 import { formatUiError } from "../../lib/format-error.ts";
 import { loadModelAuthStatus } from "../../lib/model-auth.ts";
-import { loadModelCatalog } from "../../lib/model-catalog-store.ts";
+import { loadModelCatalog, modelCatalogRefreshError } from "../../lib/model-catalog-store.ts";
 import { isSessionRunActive } from "../../lib/session-run-state.ts";
 import { reconcileSessionHistory } from "../../lib/sessions/reconcile.ts";
 import {
@@ -50,12 +50,14 @@ type ChatMetadataBinding = {
   client: GatewayBrowserClient;
   scope: { agentId?: string; sessionKey: string };
   version: number;
+  catalogRequest?: { version: number; controller: AbortController; promise: Promise<void> };
   isCurrent: () => boolean;
   unsubscribe: () => void;
 };
 const metadataBindings = new WeakMap<ChatPageHost, ChatMetadataBinding>();
 
 export function retireChatMetadataRequests(host: ChatPageHost): void {
+  metadataBindings.get(host)?.catalogRequest?.controller.abort();
   metadataBindings.get(host)?.unsubscribe();
   metadataBindings.delete(host);
   host.chatModelCatalog = [];
@@ -133,12 +135,6 @@ function applyChatMetadataResult(
   agentId: string | null | undefined,
   result: ChatMetadataResult,
 ): void {
-  const models = Array.isArray(result.models) ? result.models : undefined;
-  host.chatAccountSelection = result.accountSelection ?? null;
-  if (models) {
-    host.chatModelCatalog = models;
-    host.chatModelCatalogError = null;
-  }
   // Missing commands keep the built-ins: commands.list uses the same server builder and fails too.
   applyRemoteSlashCommandsResult({
     client,
@@ -182,15 +178,8 @@ function bindChatMetadata(host: ChatPageHost): ChatMetadataBinding | undefined {
       }
       if (update.type === "loading") {
         binding.version += 1;
-        host.chatModelsLoading = host.chatModelCatalog.length === 0;
-        host.chatModelCatalogError = null;
-      } else {
-        host.chatModelsLoading = false;
-        if (update.type === "result") {
-          applyChatMetadataResult(host, client, scope.agentId, update.result);
-        } else {
-          host.chatModelCatalogError = formatUiError(update.error);
-        }
+      } else if (update.type === "result") {
+        applyChatMetadataResult(host, client, scope.agentId, update.result);
       }
       host.requestUpdate?.();
     }),
@@ -210,7 +199,8 @@ export async function refreshChatMetadata(host: ChatPageHost): Promise<void> {
     return;
   }
   // Only accepted store publications update availability or fetch errors.
-  await loadChatMetadata(binding.client, binding.scope).catch(() => undefined);
+  const metadata = loadChatMetadata(binding.client, binding.scope).catch(() => undefined);
+  await Promise.all([metadata, loadChatModelCatalog(host, binding)]);
 }
 
 export async function refreshChatModelAuthStatus(host: ChatPageHost, opts?: { refresh?: boolean }) {
@@ -246,46 +236,51 @@ export async function refreshChatModelAuthStatus(host: ChatPageHost, opts?: { re
   }
 }
 
-export async function refreshChatModelCatalogOnDemand(host: ChatPageHost): Promise<void> {
-  if (!host.client || !host.connected) {
-    return;
+async function loadChatModelCatalog(
+  host: ChatPageHost,
+  binding: ChatMetadataBinding,
+): Promise<void> {
+  if (binding.catalogRequest?.version === binding.version) {
+    return binding.catalogRequest.promise;
   }
-  const binding = bindChatMetadata(host);
-  if (!binding) {
-    return;
-  }
-  const {
-    client,
-    scope: { agentId },
-  } = binding;
+  binding.catalogRequest?.controller.abort();
+  const controller = new AbortController();
   const version = binding.version;
-  const ownsRequest = () => binding.isCurrent() && binding.version === version;
+  const ownsRequest = () =>
+    binding.isCurrent() && binding.catalogRequest?.controller === controller;
   host.chatModelsLoading = host.chatModelCatalog.length === 0;
-  host.chatModelCatalogError = null;
   host.requestUpdate?.();
-  try {
-    await loadModelCatalog(client, {
-      agentId: agentId ?? "",
-      refreshIfDue: true,
+  const promise = loadModelCatalog(binding.client, { ...binding.scope, signal: controller.signal })
+    .then(
+      (result) => {
+        if (!ownsRequest()) {
+          return;
+        }
+        host.chatModelCatalog = result.models;
+        host.chatAccountSelection = result.accountSelection ?? null;
+        host.chatModelCatalogError = modelCatalogRefreshError(result);
+      },
+      (error: unknown) => {
+        if (ownsRequest()) {
+          host.chatModelCatalogError = formatUiError(error);
+        }
+      },
+    )
+    .finally(() => {
+      if (ownsRequest()) {
+        binding.catalogRequest = undefined;
+        host.chatModelsLoading = false;
+        host.requestUpdate?.();
+      }
     });
-    if (binding.isCurrent()) {
-      await refreshChatMetadata(host);
-      // Full model discovery can complete after the session projection used at mount time.
-      // Refresh through the normal session owner so thinking/context metadata converges without
-      // letting the UI guess which provider- or runtime-specific levels are valid.
-      await refreshCurrentChatSessionList(host).catch(() => undefined);
-    }
-  } catch (error) {
-    if (ownsRequest()) {
-      // Keep the startup/prepared snapshot usable while recording the failed
-      // discovery. Reopening the picker starts another uncached load.
-      host.chatModelCatalogError = formatUiError(error);
-    }
-  } finally {
-    if (ownsRequest()) {
-      host.chatModelsLoading = false;
-      host.requestUpdate?.();
-    }
+  binding.catalogRequest = { version, controller, promise };
+  return promise;
+}
+
+export async function refreshChatModelCatalogOnDemand(host: ChatPageHost): Promise<void> {
+  const binding = bindChatMetadata(host);
+  if (binding) {
+    await loadChatModelCatalog(host, binding);
   }
 }
 
@@ -419,6 +414,9 @@ export function refreshPageChat(host: ChatPageHost, opts?: ChatRefreshOptions) {
   const publication = binding
     ? beginChatMetadataPublication(binding.client, binding.scope)
     : undefined;
+  if (binding) {
+    void loadChatModelCatalog(host, binding);
+  }
   const refresh = refreshChat(host, {
     ...opts,
     onStartupMetadata: async (metadata) => {

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -4132,7 +4132,9 @@ describe("refreshChatMetadata", () => {
           reasoning: true,
         },
       ]);
-      expect(refreshSessions).not.toHaveBeenCalled();
+      expect(refreshSessions).toHaveBeenCalledWith(
+        expect.objectContaining({ agentId: "work", force: true }),
+      );
       expect(state.chatModelCatalogError).toBeNull();
     },
   );
@@ -4198,7 +4200,7 @@ describe("refreshChatMetadata", () => {
       commands: never[];
       models: Array<{ id: string; name: string; provider: string }>;
     }>();
-    const request = vi.fn(async () => await metadata);
+    const request = vi.fn(async (_method: string) => await metadata);
     const existingCatalog = [
       { id: "work-model", name: "Work Model", provider: "openai", available: true },
     ];

--- a/ui/src/pages/chat/chat-state.test.ts
+++ b/ui/src/pages/chat/chat-state.test.ts
@@ -13,7 +13,6 @@ import {
   SLASH_COMMANDS,
 } from "../../lib/chat/commands.ts";
 import { extractText } from "../../lib/chat/message-extract.ts";
-import { invalidateModelCatalogCache } from "../../lib/model-catalog-store.ts";
 import type { ChatHistoryResult } from "./chat-history-snapshot.ts";
 import { loadChatHistory } from "./chat-history.ts";
 import { makeChatHost } from "./chat-host.test-support.ts";
@@ -3957,7 +3956,7 @@ describe("loadPageAssistantIdentity", () => {
     identities.invalidate(["main"]);
     let holdMainIdentity = true;
     request.mockImplementation((method: string, params?: { agentId?: string }) => {
-      if (method === "chat.metadata") {
+      if (method === "chat.metadata" || method === "models.list") {
         return Promise.resolve({ commands: [], models: [] });
       }
       if (method === "models.authStatus") {
@@ -4025,17 +4024,20 @@ describe("refreshChatMetadata", () => {
         authProfileId: "test:current",
         source: "user",
       };
-      const request = vi
-        .fn()
-        .mockReturnValueOnce(old.promise)
-        .mockResolvedValue({ commands: [], models: [ready], accountSelection });
+      let reads = 0;
+      const request = vi.fn((method: string) =>
+        method === "chat.metadata"
+          ? Promise.resolve({ commands: [] })
+          : ++reads === 1
+            ? old.promise
+            : Promise.resolve({ models: [ready], accountSelection }),
+      );
       const state = createMetadataState(request);
       state.chatAccountSelection = { kind: "automatic", label: "Automatic account selection" };
       const pending =
         kind === "picker" ? refreshChatModelCatalogOnDemand(state) : refreshChatMetadata(state);
       state.connected = false;
       retireChatMetadataRequests(state);
-      invalidateModelCatalogCache(state.client!);
       invalidateChatMetadataStore(state.client!);
       expect(state.chatModelCatalog).toEqual([]);
       expect(state.chatAccountSelection).toBeNull();
@@ -4095,7 +4097,7 @@ describe("refreshChatMetadata", () => {
     },
     { label: "cold", existingModels: [] },
   ])(
-    "refreshes $label session metadata after full model discovery completes",
+    "reads the $label session catalog without provider acquisition",
     async ({ existingModels }) => {
       const refreshSessions = vi.fn().mockResolvedValue(undefined);
       const discovery = createDeferred<{
@@ -4104,7 +4106,7 @@ describe("refreshChatMetadata", () => {
       const request = vi.fn((method: string, params?: unknown) => {
         expect(params).toEqual(
           method === "models.list"
-            ? { view: "configured", agentId: "work", refresh: true }
+            ? { view: "configured", agentId: "work", sessionKey: "agent:work:main" }
             : { agentId: "work", sessionKey: "agent:work:main" },
         );
         return discovery.promise;
@@ -4130,9 +4132,7 @@ describe("refreshChatMetadata", () => {
           reasoning: true,
         },
       ]);
-      expect(refreshSessions).toHaveBeenCalledWith(
-        expect.objectContaining({ agentId: "work", force: true }),
-      );
+      expect(refreshSessions).not.toHaveBeenCalled();
       expect(state.chatModelCatalogError).toBeNull();
     },
   );
@@ -4143,8 +4143,11 @@ describe("refreshChatMetadata", () => {
       models: Array<{ id: string; name: string; provider: string; available: boolean }>;
     }>();
     const request = vi.fn(async (method: string, params?: unknown) => {
-      expect(method).toBe("chat.metadata");
-      expect(params).toEqual({ agentId: "work", sessionKey: "agent:work:main" });
+      expect(params).toEqual({
+        agentId: "work",
+        sessionKey: "agent:work:main",
+        ...(method === "models.list" ? { view: "configured" } : {}),
+      });
       return await metadata;
     });
     const state = createMetadataState(request);
@@ -4158,7 +4161,7 @@ describe("refreshChatMetadata", () => {
     await refresh;
 
     expect(state.chatModelCatalog).toEqual([]);
-    expect(request).toHaveBeenCalledTimes(1);
+    expect(request.mock.calls.filter(([method]) => method === "models.list")).toHaveLength(1);
   });
 
   it("isolates metadata across sessions and agents", async () => {
@@ -4177,15 +4180,17 @@ describe("refreshChatMetadata", () => {
     await refreshChatMetadata(state);
     state.sessionKey = "agent:work:second";
     await refreshChatMetadata(state);
-    expect(request).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls.filter(([method]) => method === "models.list")).toHaveLength(2);
 
     state.sessionKey = "agent:other:main";
     await refreshChatMetadata(state);
-    expect(request).toHaveBeenCalledTimes(3);
-    expect(request).toHaveBeenLastCalledWith("chat.metadata", {
-      agentId: "other",
-      sessionKey: "agent:other:main",
-    });
+    expect(request.mock.calls.filter(([method]) => method === "models.list")).toHaveLength(3);
+    expect(state.chatModelCatalog[0]?.id).toBe("other-model");
+    expect(request).toHaveBeenLastCalledWith(
+      "models.list",
+      { view: "configured", agentId: "other", sessionKey: "agent:other:main" },
+      { signal: expect.any(AbortSignal) },
+    );
   });
 
   it("ignores metadata after switching to a different agent", async () => {
@@ -4208,7 +4213,7 @@ describe("refreshChatMetadata", () => {
     await refresh;
 
     expect(state.chatModelCatalog).toBe(existingCatalog);
-    expect(request).toHaveBeenCalledTimes(1);
+    expect(request.mock.calls.filter(([method]) => method === "models.list")).toHaveLength(1);
   });
 
   it("keeps loading owned by the newest agent metadata request", async () => {
@@ -4268,26 +4273,40 @@ describe("refreshChatMetadata", () => {
     expect(state.chatModelCatalog).toEqual([]);
   });
 
-  it("keeps the seeded catalog and reports chat metadata failures without model fallback", async () => {
-    const seededCatalog = [
-      { id: "seeded-model", name: "Seeded Model", provider: "openai", available: true },
-    ];
+  it("keeps model reads independent of command metadata failures", async () => {
+    const model = { id: "published", name: "Published", provider: "example", available: true };
     const request = vi.fn(async (method: string) => {
       if (method === "chat.metadata") {
-        throw new Error("metadata unavailable");
+        throw new Error("commands unavailable");
       }
-      if (method === "models.list") {
-        return { models: [{ id: "substitute-model", name: "Substitute Model" }] };
-      }
-      return { commands: [] };
+      return { models: [model], accountSelection: { kind: "automatic", label: "Automatic" } };
     });
-    const state = createMetadataState(request, { chatModelCatalog: seededCatalog });
-
+    const state = createMetadataState(request);
     await refreshChatMetadata(state);
+    expect(state.chatModelCatalog).toEqual([model]);
+    expect(state.chatAccountSelection).toEqual({ kind: "automatic", label: "Automatic" });
+    expect(state.chatModelCatalogError).toBeNull();
+  });
 
-    expect(state.chatModelCatalog).toBe(seededCatalog);
-    expect(state.chatModelCatalogError).toBe("metadata unavailable");
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["chat.metadata"]);
+  it("retains rows after catalog failure and clears failure on a successful empty publication", async () => {
+    const model = { id: "retained", name: "Retained", provider: "example" };
+    const request = vi
+      .fn()
+      .mockResolvedValueOnce({ models: [model], refreshFailed: true })
+      .mockRejectedValueOnce(new Error("catalog transport failed"))
+      .mockResolvedValueOnce({ models: [] });
+    const state = createMetadataState(request);
+    await refreshChatModelCatalogOnDemand(state);
+    expect(state.chatModelCatalog).toEqual([model]);
+    expect(state.chatModelCatalogError).toBe(
+      "Some models could not be refreshed. Open Models to try again.",
+    );
+    await refreshChatModelCatalogOnDemand(state);
+    expect(state.chatModelCatalog).toEqual([model]);
+    expect(state.chatModelCatalogError).toBe("catalog transport failed");
+    await refreshChatModelCatalogOnDemand(state);
+    expect(state.chatModelCatalog).toEqual([]);
+    expect(state.chatModelCatalogError).toBeNull();
   });
 
   it("keeps fallback slash commands when chat metadata omits commands", async () => {
@@ -4297,6 +4316,9 @@ describe("refreshChatMetadata", () => {
         return {
           models: [{ id: "metadata-model", name: "Metadata Model", provider: "openai" }],
         };
+      }
+      if (method === "models.list") {
+        return { models: [] };
       }
       return {
         commands: [
@@ -4315,7 +4337,7 @@ describe("refreshChatMetadata", () => {
 
     await refreshChatMetadata(state);
 
-    expect(request.mock.calls.map(([method]) => method)).toEqual(["chat.metadata"]);
+    expect(request.mock.calls.map(([method]) => method)).toEqual(["chat.metadata", "models.list"]);
     expect(SLASH_COMMANDS.some((command) => command.name === "help")).toBe(true);
     expect(SLASH_COMMANDS.some((command) => command.name === "remote-command")).toBe(false);
   });

--- a/ui/src/pages/chat/chat-view.test.ts
+++ b/ui/src/pages/chat/chat-view.test.ts
@@ -7175,7 +7175,7 @@ describe("chat model controls", () => {
 
   it.each([
     { status: "offline", catalogState: "offline", triggerLabel: "GPT-5.6 Sol" },
-    { status: "error", catalogState: null, triggerLabel: "GPT-5.6 Sol" },
+    { status: "error", catalogState: "error", triggerLabel: "GPT-5.6 Sol" },
   ] as const)(
     "renders $status over a stale all-cold catalog",
     ({ status, catalogState, triggerLabel }) => {

--- a/ui/src/pages/chat/components/chat-model-catalog-state.ts
+++ b/ui/src/pages/chat/components/chat-model-catalog-state.ts
@@ -4,6 +4,7 @@ import { t } from "../../../i18n/index.ts";
 
 export type ChatModelCatalogState = {
   hasSnapshot: boolean;
+  refreshFailed?: boolean;
   status: "idle" | "loading" | "ready" | "error" | "offline";
 };
 
@@ -15,17 +16,21 @@ export function renderChatModelCatalogState(
   errorLabel = t("chat.modelControls.modelsUnavailable"),
   retryTarget?: { disabled: boolean; groupId: string; onRetry: (groupId: string) => unknown },
 ) {
-  if (!state || (state.status === "ready" && hasSelectableOptions)) {
+  if (!state) {
+    return nothing;
+  }
+  const status = state.status === "ready" && state.refreshFailed ? "error" : state.status;
+  if (status === "ready" && hasSelectableOptions) {
     return nothing;
   }
   const label =
-    state.status === "offline"
+    status === "offline"
       ? t("common.offline")
-      : state.status === "error"
+      : status === "error"
         ? hasOptions
           ? t("chat.modelControls.modelsRefreshFailed")
           : errorLabel
-        : state.status === "ready"
+        : status === "ready"
           ? t("chat.modelControls.noModelsAvailable")
           : t("chat.modelControls.loadingModels");
   return html`
@@ -33,15 +38,15 @@ export function renderChatModelCatalogState(
       class="chat-controls__model-catalog-state ${
         hasOptions ? "" : "chat-controls__model-catalog-state--empty"
       }"
-      data-chat-model-catalog-state=${state.status}
+      data-chat-model-catalog-state=${status}
       aria-live="polite"
     >
       <span class="chat-controls__model-catalog-state-label">
-        ${state.status === "error" ? icons.alertTriangle : nothing}
+        ${status === "error" ? icons.alertTriangle : nothing}
         <span>${label}</span>
       </span>
       ${
-        state.status === "error" && retryTarget
+        status === "error" && retryTarget
           ? html`
               <button
                 class="chat-controls__model-catalog-action"
@@ -59,7 +64,7 @@ export function renderChatModelCatalogState(
           : nothing
       }
       ${
-        state.status === "ready" && !hasSelectableOptions && onModelSetup
+        status === "ready" && !hasSelectableOptions && onModelSetup
           ? html`
               <button
                 class="chat-controls__model-catalog-action"

--- a/ui/src/pages/chat/components/chat-model-catalog-state.ts
+++ b/ui/src/pages/chat/components/chat-model-catalog-state.ts
@@ -18,14 +18,13 @@ export function renderChatModelCatalogState(
   if (!state || (state.status === "ready" && hasSelectableOptions)) {
     return nothing;
   }
-  if (state.status === "error" && hasOptions) {
-    return nothing;
-  }
   const label =
     state.status === "offline"
       ? t("common.offline")
       : state.status === "error"
-        ? errorLabel
+        ? hasOptions
+          ? t("chat.modelControls.modelsRefreshFailed")
+          : errorLabel
         : state.status === "ready"
           ? t("chat.modelControls.noModelsAvailable")
           : t("chat.modelControls.loadingModels");

--- a/ui/src/pages/config/config-page.session-observer.test.ts
+++ b/ui/src/pages/config/config-page.session-observer.test.ts
@@ -177,9 +177,17 @@ describe("ConfigPage session observer models", () => {
         return Promise.resolve({});
       }
       signals.push(options.signal);
-      return signals.length === 2
-        ? stale.promise
-        : Promise.resolve({ models: signals.length === 1 ? original : fresh });
+      if (signals.length !== 2) {
+        return Promise.resolve({ models: signals.length === 1 ? original : fresh });
+      }
+      return new Promise<ModelCatalogResult>((resolve, reject) => {
+        options.signal.addEventListener(
+          "abort",
+          () => reject(new DOMException("Page retired", "AbortError")),
+          { once: true },
+        );
+        void stale.promise.then(resolve, reject);
+      });
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const { page, state, provider } = await mount(client);

--- a/ui/src/pages/config/config-page.session-observer.test.ts
+++ b/ui/src/pages/config/config-page.session-observer.test.ts
@@ -140,7 +140,6 @@ describe("ConfigPage session observer models", () => {
     await writerLoad;
     expect(state.sessionObserverModels).toEqual(writerModels);
 
-    modelCatalogStore.invalidateModelCatalogCache(client);
     selection.selectedId = "main";
     page.requestUpdate();
     await settleLitElement(page);
@@ -184,7 +183,6 @@ describe("ConfigPage session observer models", () => {
     });
     const client = { request } as unknown as GatewayBrowserClient;
     const { page, state, provider } = await mount(client);
-    modelCatalogStore.invalidateModelCatalogCache(client);
     const pending = state.sessionObserverModelsTask.run();
     expect(state.sessionObserverModels).toEqual(original);
     await vi.advanceTimersByTimeAsync(30_000);

--- a/ui/src/pages/cron/cron-page.ts
+++ b/ui/src/pages/cron/cron-page.ts
@@ -1,12 +1,7 @@
 import { consume } from "@lit/context";
 import { html, type PropertyValues } from "lit";
 import { property, state } from "lit/decorators.js";
-import type {
-  AgentsListResult,
-  CronJob,
-  CronScratchGetResult,
-  ModelCatalogResult,
-} from "../../api/types.ts";
+import type { AgentsListResult, CronJob, CronScratchGetResult } from "../../api/types.ts";
 import { subtitleForRoute, titleForRoute } from "../../app-navigation.ts";
 import { applicationContext, type ApplicationContext } from "../../app/context.ts";
 import { readGatewayOperatorAccess } from "../../app/operator-access.ts";
@@ -39,6 +34,7 @@ import {
   type CronState,
 } from "../../lib/cron/index.ts";
 import { formatUiError } from "../../lib/format-error.ts";
+import { loadModelCatalog } from "../../lib/model-catalog-store.ts";
 import {
   resolveSessionNavigationAgentId,
   sessionNavigationTarget,
@@ -291,7 +287,7 @@ class CronPage extends OpenClawLightDomElement {
       this.modelSuggestionsRequest === request &&
       this.context.agentSelection.state.selectedId === agentId;
     try {
-      const result = await client.request<ModelCatalogResult>("models.list", {
+      const result = await loadModelCatalog(client, {
         agentId,
         view: "configured",
         preparedOnly: true,

--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -89,7 +89,6 @@ describe("loadModelProvidersData", () => {
     });
     expect(request.mock.calls.filter(([method]) => method === "models.list")).toEqual([
       ["models.list", { view: "configured", agentId: "writer", refresh: true }],
-      ["models.list", { view: "configured", agentId: "writer", preparedOnly: true }],
     ]);
     expect(result.providerOutcomes).toEqual([]);
     expect(request.mock.calls.some(([method]) => method === "usage.status")).toBe(false);
@@ -368,6 +367,7 @@ describe("loadModelProvidersData", () => {
     expect(result.models).toEqual([{ id: "cached", name: "Cached", provider: "openai" }]);
     expect(request.mock.calls.filter(([method]) => method === "models.list")).toEqual([
       ["models.list", { view: "configured", agentId: "writer", refresh: true }],
+      ["models.list", { view: "configured", agentId: "writer", preparedOnly: true }],
     ]);
   });
 });

--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -1,10 +1,84 @@
 import { describe, expect, it, vi } from "vitest";
 import { GatewayPendingRequests } from "../../../../packages/gateway-client/src/pending-request.js";
+import { createDeferred } from "../../../../test/helpers/promise.js";
 import type { GatewayBrowserClient } from "../../api/gateway.ts";
 import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import { loadModelProviderCost, loadModelProvidersData, loadModelProviderUsage } from "./load.ts";
 
 describe("loadModelProvidersData", () => {
+  it.each([false, true])(
+    "reads the refreshed catalog after auth publication, including auth failure %s",
+    async (authFails) => {
+      const auth = createDeferred<void>();
+      let authPending = true;
+      const client = createTestGatewayClient(async (method) => {
+        if (method === "models.authStatus") {
+          try {
+            await auth.promise;
+          } finally {
+            authPending = false;
+          }
+          return { ts: 1, providers: [] };
+        }
+        if (method === "models.list") {
+          if (authPending) {
+            throw new Error(
+              "Model catalog changed while preparing this result. Retry the request.",
+            );
+          }
+          return { models: [{ id: "published", name: "Published", provider: "ollama" }] };
+        }
+        if (method === "config.get") {
+          return { config: {}, hash: "hash" };
+        }
+        throw new Error(`Unexpected request: ${method}`);
+      });
+
+      const loading = loadModelProvidersData(client, { agentId: "writer", refresh: true });
+      if (authFails) {
+        auth.reject(new Error("Authentication status unavailable"));
+      } else {
+        auth.resolve();
+      }
+      const result = await loading;
+
+      expect(result.models).toEqual([{ id: "published", name: "Published", provider: "ollama" }]);
+      expect(result.catalogError).toBeNull();
+      expect(result.error).toBe(authFails ? "Authentication status unavailable" : null);
+    },
+  );
+
+  it("does not acquire models when the page retires during auth publication", async () => {
+    const auth = createDeferred<void>();
+    const modelRequests: unknown[] = [];
+    const client = createTestGatewayClient(async (method, params) => {
+      if (method === "models.authStatus") {
+        await auth.promise;
+        return { ts: 1, providers: [] };
+      }
+      if (method === "models.list") {
+        modelRequests.push(params);
+        return { models: [] };
+      }
+      if (method === "config.get") {
+        return { config: {}, hash: "hash" };
+      }
+      throw new Error(`Unexpected request: ${method}`);
+    });
+    const controller = new AbortController();
+
+    const loading = loadModelProvidersData(client, {
+      agentId: "writer",
+      refresh: true,
+      signal: controller.signal,
+    });
+    controller.abort();
+    auth.resolve();
+    await loading;
+
+    expect(modelRequests).toEqual([]);
+  });
+
   it("keeps failed provider outcomes from a fulfilled explicit refresh", async () => {
     const client = createTestGatewayClient(async (method) => {
       if (method === "models.list") {

--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -89,6 +89,7 @@ describe("loadModelProvidersData", () => {
     });
     expect(request.mock.calls.filter(([method]) => method === "models.list")).toEqual([
       ["models.list", { view: "configured", agentId: "writer", refresh: true }],
+      ["models.list", { view: "configured", agentId: "writer", preparedOnly: true }],
     ]);
     expect(result.providerOutcomes).toEqual([]);
     expect(request.mock.calls.some(([method]) => method === "usage.status")).toBe(false);

--- a/ui/src/pages/model-providers/load.test.ts
+++ b/ui/src/pages/model-providers/load.test.ts
@@ -9,7 +9,7 @@ describe("loadModelProvidersData", () => {
   it.each([false, true])(
     "reads the refreshed catalog after auth publication, including auth failure %s",
     async (authFails) => {
-      const auth = createDeferred<void>();
+      const auth = createDeferred();
       let authPending = true;
       const client = createTestGatewayClient(async (method) => {
         if (method === "models.authStatus") {
@@ -49,7 +49,7 @@ describe("loadModelProvidersData", () => {
   );
 
   it("does not acquire models when the page retires during auth publication", async () => {
-    const auth = createDeferred<void>();
+    const auth = createDeferred();
     const modelRequests: unknown[] = [];
     const client = createTestGatewayClient(async (method, params) => {
       if (method === "models.authStatus") {

--- a/ui/src/pages/model-providers/load.ts
+++ b/ui/src/pages/model-providers/load.ts
@@ -84,14 +84,18 @@ export async function loadModelProvidersData(
         ...(opts.signal ? { signal: opts.signal } : {}),
       }),
     );
-  const catalogRefresh = opts.refresh ? loadConfiguredCatalog({ refresh: true }) : undefined;
+  const authStatusLoad = settleRequest(loadModelAuthStatus(client, opts));
+  // Auth refresh publishes the runtime owner that the catalog must read.
+  const catalogRefresh = opts.refresh
+    ? authStatusLoad.then(() => loadConfiguredCatalog({ refresh: true }))
+    : undefined;
   const catalogLoad = catalogRefresh
     ? catalogRefresh.then((refreshResult) =>
         refreshResult.ok ? refreshResult : loadConfiguredCatalog({ preparedOnly: true }),
       )
     : loadConfiguredCatalog({ preparedOnly: true });
   const [authStatus, catalog, refreshResult, config] = await Promise.all([
-    settleRequest(loadModelAuthStatus(client, opts)),
+    authStatusLoad,
     catalogLoad,
     catalogRefresh ?? Promise.resolve(undefined),
     client

--- a/ui/src/pages/new-session/draft-place-state.test.ts
+++ b/ui/src/pages/new-session/draft-place-state.test.ts
@@ -27,12 +27,15 @@ function createRepositoryFixture(
   const persistPreference = vi.fn();
   const readPreference = vi.fn<() => NewSessionPreference>(() => ({ worktree: true }));
   const request = vi.fn<(method: string) => Promise<unknown>>(async (method) =>
-    method === "fs.listDir"
-      ? { path: "/plain", entries: [] }
-      : { repositoryStatus: options.unavailable ? "unavailable" : "not_git", branches: [] },
+    method === "models.list"
+      ? { models: [] }
+      : method === "fs.listDir"
+        ? { path: "/plain", entries: [] }
+        : { repositoryStatus: options.unavailable ? "unavailable" : "not_git", branches: [] },
   );
   const context = {
     gateway: {
+      subscribeEvents: () => () => undefined,
       snapshot: {
         phase: "connected",
         client: { request },

--- a/ui/src/pages/new-session/draft-submission-flow.test-support.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test-support.ts
@@ -18,10 +18,14 @@ type FixtureOptions = {
   selfUser?: { id: string };
   data?: NewSessionRouteData;
   request?: (method: string, params?: unknown) => Promise<unknown>;
+  modelCatalog?: (params?: unknown) => Promise<unknown>;
 };
 
 export function createDraftFixture(options: FixtureOptions = {}) {
   const request = vi.fn((method: string, params?: unknown) => {
+    if (method === "models.list") {
+      return options.modelCatalog ? options.modelCatalog(params) : Promise.resolve({ models: [] });
+    }
     if (options.request) {
       return options.request(method, params);
     }

--- a/ui/src/pages/new-session/draft-submission-flow.test-support.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test-support.ts
@@ -31,6 +31,7 @@ export function createDraftFixture(options: FixtureOptions = {}) {
   const phase = options.phase ?? "connected";
   const context = {
     gateway: {
+      subscribeEvents: () => () => undefined,
       connection: { gatewayUrl: "ws://gateway.example" },
       snapshot: {
         phase,

--- a/ui/src/pages/new-session/draft-submission-flow.test.ts
+++ b/ui/src/pages/new-session/draft-submission-flow.test.ts
@@ -563,6 +563,9 @@ describe("DraftSubmissionFlow", () => {
       recoveryScope: "principal-a",
       recoveryScopeReady: true,
       request: vi.fn(async (method: string) => {
+        if (method === "models.list") {
+          return { models: [] };
+        }
         if (method === "worktrees.branches") {
           return { repositoryStatus: "git", branches: [] };
         }
@@ -588,6 +591,7 @@ describe("DraftSubmissionFlow", () => {
     const context = {
       basePath: "",
       gateway: {
+        subscribeEvents: () => () => undefined,
         connection: { gatewayUrl: "ws://gateway.example" },
         snapshot: {
           phase: "connected",

--- a/ui/src/pages/new-session/draft-submission-title.test.ts
+++ b/ui/src/pages/new-session/draft-submission-title.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { UserModelAccount } from "../../../../packages/gateway-protocol/src/index.js";
 import { createDeferred } from "../../../../test/helpers/promise.ts";
-import type { ChatMetadataResult } from "../../lib/chat/chat-metadata-store.ts";
+import type { ModelCatalogResult } from "../../api/types.ts";
 import { createDraftTitleFixture } from "./draft-title.test-support.ts";
 import { renderControl } from "./model-control.test-support.ts";
 
@@ -12,7 +12,7 @@ afterEach(() => {
   localStorage.clear();
 });
 
-function accountTitleFixture(preview?: Promise<ChatMetadataResult>) {
+function accountTitleFixture(preview?: Promise<ModelCatalogResult>) {
   const makeAccount = (id: string): UserModelAccount => ({
     authProfileId: `personal:person-a:test:${id}`,
     provider: "test",
@@ -21,8 +21,7 @@ function accountTitleFixture(preview?: Promise<ChatMetadataResult>) {
     selected: false,
   });
   const accounts: [UserModelAccount, UserModelAccount] = [makeAccount("one"), makeAccount("two")];
-  const confirmed: ChatMetadataResult = {
-    commands: [],
+  const confirmed: ModelCatalogResult = {
     models: [{ id: "primary", name: "Primary", provider: "test", available: true }],
     accountSelection: {
       kind: "personal",
@@ -38,7 +37,7 @@ function accountTitleFixture(preview?: Promise<ChatMetadataResult>) {
       if (method === "users.listModelAccounts") {
         return { profileId: "person-a", accounts, links: [] };
       }
-      if (method === "chat.metadata") {
+      if (method === "models.list") {
         const account =
           params && typeof params === "object" && "authProfileId" in params
             ? accounts.find((candidate) => candidate.authProfileId === params.authProfileId)
@@ -53,8 +52,7 @@ function accountTitleFixture(preview?: Promise<ChatMetadataResult>) {
               },
             })
           : {
-              commands: [],
-              models: confirmed.models?.map((model) =>
+              models: confirmed.models.map((model) =>
                 Object.assign({}, model, { available: false, unavailableReason: "missing-auth" }),
               ),
               accountSelection: { kind: "automatic", label: "Automatic" },
@@ -140,7 +138,7 @@ describe("prepared title creation handoff", () => {
   it.each(["pending", "unconfirmed", "different provider"])(
     "pauses personal title inference for a %s preview without disabling ordinary naming",
     async (outcome) => {
-      const preview = createDeferred<ChatMetadataResult>();
+      const preview = createDeferred<ModelCatalogResult>();
       const fixture = accountTitleFixture(preview.promise);
       const { accounts, confirmed, flow, titles, titleRequest, chooseAccount, select } = fixture;
       try {

--- a/ui/src/pages/new-session/draft-title.test-support.ts
+++ b/ui/src/pages/new-session/draft-title.test-support.ts
@@ -11,7 +11,8 @@ export function createDraftTitleFixture(
     title: DEFAULT_PREPARED_TITLE,
   }),
   data?: NewSessionRouteData,
-  requestOther = async (_method: string, _params?: unknown): Promise<unknown> => ({}),
+  requestOther = async (method: string, _params?: unknown): Promise<unknown> =>
+    method === "models.list" ? { models: [] } : {},
 ) {
   const fixture = createDraftFixture({
     data,
@@ -31,6 +32,7 @@ export function createDraftTitleFixture(
         : method === "worktrees.branches"
           ? { repositoryStatus: "git", branches: [], defaultBranch: "main" }
           : requestOther(method, params),
+    modelCatalog: (params) => requestOther("models.list", params),
     takePreparedTitle: () => titles.takePreparedTitle(),
   });
   const titles = new NewSessionTitleController(new TestReactiveControllerHost(), () => ({

--- a/ui/src/pages/new-session/model-control.catalog-targets.test.ts
+++ b/ui/src/pages/new-session/model-control.catalog-targets.test.ts
@@ -54,8 +54,8 @@ describe("new-session CLI-agent model targets", () => {
     picker!.dispatchEvent(new Event("toggle"));
 
     await vi.waitFor(() => {
-      expect(request.mock.calls.filter(([method]) => method === "chat.metadata")).toHaveLength(2);
-      expect(request.mock.calls.filter(([method]) => method === "models.list")).toHaveLength(1);
+      expect(request.mock.calls.filter(([method]) => method === "models.list")).toHaveLength(2);
+      expect(request.mock.calls.some(([, params]) => params?.refresh)).toBe(false);
       expect(catalogCalls(request)).toHaveLength(2);
     });
     await vi.waitFor(() => {
@@ -97,7 +97,7 @@ describe("new-session CLI-agent model targets", () => {
     });
 
     await vi.waitFor(() => {
-      expect(request.mock.calls.filter(([method]) => method === "chat.metadata")).toHaveLength(1);
+      expect(request.mock.calls.filter(([method]) => method === "models.list")).toHaveLength(1);
       expect(catalogCalls(request)).toHaveLength(2);
     });
     expect(

--- a/ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts
+++ b/ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts
@@ -83,44 +83,55 @@ function retainedAccountDraft() {
 }
 
 describe("new-session model metadata lifecycle", () => {
-  it("selects a retained account for an unavailable draft without changing saved preferences", async () => {
-    const {
-      account,
-      agent,
-      control,
-      request,
-      preview,
-      connected,
-      draw,
-      select,
-      chooseAccount,
-      savePreference,
-    } = retainedAccountDraft();
-    const { completion } = await chooseAccount();
-    expect(request).toHaveBeenLastCalledWith(
-      "models.list",
-      { view: "configured", agentId: "main", authProfileId: account.authProfileId },
-      { signal: expect.any(AbortSignal) },
-    );
-    expect(control.modelSelectionBlockedReason(agent)).toBe("Loading models…");
-    preview.resolve(connected);
-    await completion;
-    expect(control.modelSelectionBlockedReason(agent)).toBeUndefined();
-    expect(draw().querySelector("[data-chat-account-trigger]")?.textContent).toContain(
-      account.label,
-    );
-    expect(control.modelForSubmission()).toBe(`anthropic/model@${account.authProfileId}`);
-    expect(control.selected).toBe("");
-    select("automatic");
-    await vi.waitFor(() => expect(control.modelUnavailableReason(agent)).toBe("missing-auth"));
-    expect(control.modelForSubmission()).toBe("");
-    expect(draw().querySelector("[data-chat-account-trigger]")?.textContent).toContain("Automatic");
-    expect(savePreference).not.toHaveBeenCalled();
-    expect(
-      request.mock.calls.some(([method]) => /users\.(selectModelAccount|prefs\.set)/.test(method)),
-    ).toBe(false);
-    control.reset();
-  });
+  it.each([false, true])(
+    "selects a usable retained account with refresh warning %s without changing saved preferences",
+    async (refreshFailed) => {
+      const {
+        account,
+        agent,
+        control,
+        request,
+        preview,
+        connected,
+        draw,
+        select,
+        chooseAccount,
+        savePreference,
+      } = retainedAccountDraft();
+      const { completion } = await chooseAccount();
+      expect(request).toHaveBeenLastCalledWith(
+        "models.list",
+        { view: "configured", agentId: "main", authProfileId: account.authProfileId },
+        { signal: expect.any(AbortSignal) },
+      );
+      expect(control.modelSelectionBlockedReason(agent)).toBe("Loading models…");
+      preview.resolve({ ...connected, refreshFailed });
+      await completion;
+      expect(control.modelSelectionBlockedReason(agent)).toBeUndefined();
+      expect(control.accountSelectionReady()).toBe(true);
+      expect(draw().textContent?.includes("Some models could not be refreshed.")).toBe(
+        refreshFailed,
+      );
+      expect(draw().querySelector("[data-chat-account-trigger]")?.textContent).toContain(
+        account.label,
+      );
+      expect(control.modelForSubmission()).toBe(`anthropic/model@${account.authProfileId}`);
+      expect(control.selected).toBe("");
+      select("automatic");
+      await vi.waitFor(() => expect(control.modelUnavailableReason(agent)).toBe("missing-auth"));
+      expect(control.modelForSubmission()).toBe("");
+      expect(draw().querySelector("[data-chat-account-trigger]")?.textContent).toContain(
+        "Automatic",
+      );
+      expect(savePreference).not.toHaveBeenCalled();
+      expect(
+        request.mock.calls.some(([method]) =>
+          /users\.(selectModelAccount|prefs\.set)/.test(method),
+        ),
+      ).toBe(false);
+      control.reset();
+    },
+  );
 
   it.each(["request failure", "missing model", "unconfirmed account", "unknown availability"])(
     "keeps an explicit account blocked after a preview with $0",
@@ -277,12 +288,11 @@ describe("new-session model metadata lifecycle", () => {
         ),
       ).not.toBeNull(),
     );
-    request.mockResolvedValueOnce({ models: published });
+    request.mockResolvedValue({ models: published });
     const picker = renderControl(control, context).querySelector<HTMLDetailsElement>(
       ".chat-controls__model-picker",
     )!;
-    picker.open = true;
-    picker.dispatchEvent(new Event("toggle"));
+    picker.querySelector("summary")!.click();
     await vi.waitFor(() =>
       expect(
         renderControl(control, context).querySelector(

--- a/ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts
+++ b/ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts
@@ -133,6 +133,40 @@ describe("new-session model metadata lifecycle", () => {
     },
   );
 
+  it("retries the same draft account after failed previews and accepts its successful result", async () => {
+    const { account, agent, control, request, preview, connected, draw, select, chooseAccount } =
+      retainedAccountDraft();
+    const { completion } = await chooseAccount();
+    preview.reject(new Error("Preview unavailable"));
+    await completion;
+    expect(control.modelSelectionBlockedReason(agent)).toBe("Models unavailable");
+    expect(control.accountSelectionReady()).toBe(false);
+
+    draw().querySelector(".chat-model-account__picker")!.dispatchEvent(new Event("wa-show"));
+    await vi.waitFor(() => expect(draw().textContent).toContain(account.label));
+    const failedRetry = deferred<ModelCatalogResult>();
+    request.mockReturnValueOnce(failedRetry.promise);
+    select(`account:${account.authProfileId}`);
+    expect(control.modelSelectionBlockedReason(agent)).toBe("Loading models…");
+    failedRetry.reject(new Error("Preview still unavailable"));
+    await vi.waitFor(() =>
+      expect(control.modelSelectionBlockedReason(agent)).toBe("Models unavailable"),
+    );
+    expect(control.accountSelectionReady()).toBe(false);
+
+    draw().querySelector(".chat-model-account__picker")!.dispatchEvent(new Event("wa-show"));
+    await vi.waitFor(() => expect(draw().textContent).toContain(account.label));
+    request.mockResolvedValueOnce(connected);
+    select(`account:${account.authProfileId}`);
+    await vi.waitFor(() => expect(control.accountSelectionReady()).toBe(true));
+    expect(control.modelSelectionBlockedReason(agent)).toBeUndefined();
+    expect(draw().querySelector("[data-chat-account-trigger]")?.textContent).toContain(
+      account.label,
+    );
+    expect(control.modelForSubmission()).toBe(`anthropic/model@${account.authProfileId}`);
+    control.reset();
+  });
+
   it.each(["request failure", "missing model", "unconfirmed account", "unknown availability"])(
     "keeps an explicit account blocked after a preview with $0",
     async (outcome) => {

--- a/ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts
+++ b/ui/src/pages/new-session/model-control.metadata-lifecycle.test.ts
@@ -1,12 +1,8 @@
-import { DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS } from "@openclaw/gateway-client/browser";
 import { describe, expect, it, vi } from "vitest";
-import type { ModelCatalogEntry } from "../../api/types.ts";
+import type { ModelCatalogEntry, ModelCatalogResult } from "../../api/types.ts";
 import {
   beginChatMetadataPublication,
-  revalidateChatMetadata,
-  invalidateChatMetadataStore,
   subscribeChatMetadata,
-  type ChatMetadataResult,
 } from "../../lib/chat/chat-metadata-store.ts";
 import { createTestGatewayClient } from "../../test-helpers/gateway-client.ts";
 import { contextWith, deferred, renderControl } from "./model-control.test-support.ts";
@@ -30,14 +26,12 @@ function retainedAccountDraft() {
   const agent = { id: "main", model: { primary: "anthropic/model" } };
   const { context, request } = contextWith([model]);
   Object.assign(context.gateway.snapshot, { selfUser: { id: "person-a", name: "Person A" } });
-  const preview = deferred<ChatMetadataResult>();
-  const neutral: ChatMetadataResult = {
-    commands: [],
+  const preview = deferred<ModelCatalogResult>();
+  const neutral: ModelCatalogResult = {
     models: [model],
     accountSelection: { kind: "automatic", label: "Automatic" },
   };
-  const connected: ChatMetadataResult = {
-    commands: [],
+  const connected: ModelCatalogResult = {
     models: [{ ...model, available: true, unavailableReason: undefined }],
     accountSelection: {
       kind: "personal",
@@ -67,10 +61,9 @@ function retainedAccountDraft() {
     await vi.waitFor(() => expect(draw().textContent).toContain(account.label));
     select(`account:${account.authProfileId}`);
     return {
-      completion: revalidateChatMetadata(context.gateway.snapshot.client!, {
-        agentId: "main",
-        authProfileId: account.authProfileId,
-      }).catch(() => undefined),
+      completion: vi.waitFor(() =>
+        expect(control.modelSelectionBlockedReason(agent)).not.toBe("Loading models…"),
+      ),
     };
   };
   return {
@@ -105,9 +98,9 @@ describe("new-session model metadata lifecycle", () => {
     } = retainedAccountDraft();
     const { completion } = await chooseAccount();
     expect(request).toHaveBeenLastCalledWith(
-      "chat.metadata",
-      { agentId: "main", authProfileId: account.authProfileId },
-      { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
+      "models.list",
+      { view: "configured", agentId: "main", authProfileId: account.authProfileId },
+      { signal: expect.any(AbortSignal) },
     );
     expect(control.modelSelectionBlockedReason(agent)).toBe("Loading models…");
     preview.resolve(connected);
@@ -119,7 +112,7 @@ describe("new-session model metadata lifecycle", () => {
     expect(control.modelForSubmission()).toBe(`anthropic/model@${account.authProfileId}`);
     expect(control.selected).toBe("");
     select("automatic");
-    expect(control.modelUnavailableReason(agent)).toBe("missing-auth");
+    await vi.waitFor(() => expect(control.modelUnavailableReason(agent)).toBe("missing-auth"));
     expect(control.modelForSubmission()).toBe("");
     expect(draw().querySelector("[data-chat-account-trigger]")?.textContent).toContain("Automatic");
     expect(savePreference).not.toHaveBeenCalled();
@@ -236,7 +229,7 @@ describe("new-session model metadata lifecycle", () => {
       unavailableReason: "missing-auth",
     };
     const agent = { id: "main", model: { primary: "test/model" } };
-    const { context, request } = contextWith([model]);
+    const { context, request, emitCatalogChanged } = contextWith([model]);
     const client = context.gateway.snapshot.client!;
     const control = new NewSessionModelControl(() => undefined);
     control.load(context, "main", true, { agent });
@@ -250,72 +243,61 @@ describe("new-session model metadata lifecycle", () => {
     expect(control.modelUnavailableReason(agent)).toBe("missing-auth");
     const pending = deferred<{ models: ModelCatalogEntry[] }>();
     request.mockReturnValueOnce(pending.promise);
-    invalidateChatMetadataStore(client);
+    emitCatalogChanged();
     expect(control.modelUnavailableReason(agent)).toBe("missing-auth");
     pending.resolve({ models: [{ ...model, unavailableReason: "auth-failed" }] });
     await vi.waitFor(() => expect(control.modelUnavailableReason(agent)).toBe("auth-failed"));
     request.mockRejectedValueOnce(new Error("transport failed"));
-    invalidateChatMetadataStore(client);
-    await expect(revalidateChatMetadata(client, { agentId: "main" })).rejects.toThrow(
-      "transport failed",
+    emitCatalogChanged();
+    await vi.waitFor(() =>
+      expect(renderControl(control, context, "main", agent).textContent).toContain(
+        "Some models could not be refreshed.",
+      ),
     );
     expect(control.modelUnavailableReason(agent)).toBe("auth-failed");
     request.mockResolvedValueOnce({
       models: [{ ...model, available: true, unavailableReason: undefined }],
     });
-    invalidateChatMetadataStore(client);
+    emitCatalogChanged();
     await vi.waitFor(() => expect(control.modelUnavailableReason(agent)).toBeUndefined());
     release();
     control.reset();
   });
 
-  it("discovers account models when an operator opens the New Session picker", async () => {
-    const prepared = [{ id: "prepared", name: "Prepared", provider: "openai" }];
-    const discovered = [
-      ...prepared,
-      { id: "discovered", name: "Discovered", provider: "openai", contextWindow: 262_144 },
-    ];
+  it("reads published models when the picker opens without acquiring providers", async () => {
+    const prepared = [{ id: "prepared", name: "Prepared", provider: "example" }];
+    const published = [...prepared, { id: "published", name: "Published", provider: "example" }];
     const { context, request } = contextWith(prepared);
-    const client = context.gateway.snapshot.client!;
-    beginChatMetadataPublication(client, { agentId: "main" }).publish({
-      commands: [],
-      models: prepared,
-    });
-    request.mockImplementation((method: string) =>
-      Promise.resolve({
-        models: discovered,
-        ...(method === "chat.metadata" ? { commands: [] } : {}),
-      }),
-    );
     const control = new NewSessionModelControl(() => undefined);
     control.load(context, "main", true);
-
+    await vi.waitFor(() =>
+      expect(
+        renderControl(control, context).querySelector(
+          '[data-chat-model-option="example/prepared"]',
+        ),
+      ).not.toBeNull(),
+    );
+    request.mockResolvedValueOnce({ models: published });
     const picker = renderControl(control, context).querySelector<HTMLDetailsElement>(
       ".chat-controls__model-picker",
-    );
-    picker!.open = true;
-    picker!.dispatchEvent(new Event("toggle"));
-
-    await vi.waitFor(() => {
-      const container = renderControl(control, context);
-      expect(container.querySelector('[data-chat-model-option="openai/prepared"]')).not.toBeNull();
+    )!;
+    picker.open = true;
+    picker.dispatchEvent(new Event("toggle"));
+    await vi.waitFor(() =>
       expect(
-        container.querySelector('[data-chat-model-option="openai/discovered"]'),
-      ).not.toBeNull();
-    });
-    expect(request).toHaveBeenCalledWith("models.list", {
-      view: "configured",
-      agentId: "main",
-      refresh: true,
-    });
-    expect(request).toHaveBeenCalledWith(
-      "chat.metadata",
-      { agentId: "main" },
-      { timeoutMs: DEFAULT_GATEWAY_REQUEST_TIMEOUT_MS },
+        renderControl(control, context).querySelector(
+          '[data-chat-model-option="example/published"]',
+        ),
+      ).not.toBeNull(),
     );
+    expect(request.mock.calls.map(([method, params]) => [method, params])).toEqual([
+      ["models.list", { view: "configured", agentId: "main" }],
+      ["models.list", { view: "configured", agentId: "main" }],
+    ]);
+    control.reset();
   });
 
-  it("keeps a ready catalog authoritative across control teardown", async () => {
+  it("reads current catalog state on remount after control teardown", async () => {
     const models: ModelCatalogEntry[] = [
       {
         id: "gpt-5.6-luna",
@@ -334,6 +316,9 @@ describe("new-session model metadata lifecycle", () => {
 
     const remountedControl = new NewSessionModelControl(() => undefined);
     remountedControl.load(context, "main", true, { agent });
+    await vi.waitFor(() =>
+      expect(remountedControl.modelUnavailableReason(agent)).toBe("missing-auth"),
+    );
 
     const container = renderControl(remountedControl, context, "main", agent);
     expect(container.querySelector('[data-chat-model-catalog-state="ready"]')).not.toBeNull();
@@ -342,10 +327,11 @@ describe("new-session model metadata lifecycle", () => {
       container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]'),
     ).not.toBeNull();
     expect(container.textContent).toContain("No models available");
-    expect(request).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledTimes(2);
+    remountedControl.reset();
   });
 
-  it("keeps a shared metadata request alive when its first control is torn down", async () => {
+  it("aborts a retired control request and gives the remounted control its own result", async () => {
     const models: ModelCatalogEntry[] = [
       { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" },
     ];
@@ -364,6 +350,7 @@ describe("new-session model metadata lifecycle", () => {
     await vi.waitFor(() => expect(request).toHaveBeenCalledOnce());
 
     firstControl.reset();
+    request.mockResolvedValueOnce({ models });
     const remountedControl = new NewSessionModelControl(() => undefined);
     remountedControl.load(context, "main", true);
     pending.resolve({ models });
@@ -375,7 +362,9 @@ describe("new-session model metadata lifecycle", () => {
         container.querySelector('[data-chat-model-option="openai/gpt-5.6-luna"]'),
       ).not.toBeNull();
     });
-    expect(request).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(request.mock.calls[0]?.[2]?.signal.aborted).toBe(true);
+    remountedControl.reset();
   });
 
   it("reapplies an updated preference against the attached ready snapshot", async () => {
@@ -396,27 +385,25 @@ describe("new-session model metadata lifecycle", () => {
       },
     ];
     const refresh = deferred<{ models: ModelCatalogEntry[] }>();
-    const { context, request } = contextWith([]);
-    const client = context.gateway.snapshot.client!;
-    beginChatMetadataPublication(client, { agentId: "main" }).publish({ commands: [], models });
-    request.mockReturnValueOnce(refresh.promise);
-    const pendingRefresh = revalidateChatMetadata(client, { agentId: "main" });
+    const { context, request, emitCatalogChanged } = contextWith(models);
     const control = new NewSessionModelControl(() => undefined);
 
     control.load(context, "main", true, {
       preference: { model: "openai/gpt-5.6-sol", thinkingLevel: "high" },
     });
-    expect(control.selected).toBe("openai/gpt-5.6-sol");
+    await vi.waitFor(() => expect(control.selected).toBe("openai/gpt-5.6-sol"));
     expect(control.thinkingLevel).toBe("high");
+    request.mockReturnValueOnce(refresh.promise);
+    emitCatalogChanged();
 
     control.load(context, "main", true, {
       preference: { model: "openai/gpt-5.6-luna", thinkingLevel: "low" },
     });
 
-    expect(control.selected).toBe("openai/gpt-5.6-luna");
-    expect(control.thinkingLevel).toBe("low");
-    expect(request).toHaveBeenCalledOnce();
     refresh.resolve({ models });
-    await pendingRefresh;
+    await vi.waitFor(() => expect(control.selected).toBe("openai/gpt-5.6-luna"));
+    expect(control.thinkingLevel).toBe("low");
+    expect(request).toHaveBeenCalledTimes(2);
+    control.reset();
   });
 });

--- a/ui/src/pages/new-session/model-control.test-support.ts
+++ b/ui/src/pages/new-session/model-control.test-support.ts
@@ -1,7 +1,7 @@
 import { render } from "lit";
 import { vi } from "vitest";
 import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
-import type { ApplicationContext } from "../../app/context.ts";
+import type { ApplicationContext, ApplicationGateway } from "../../app/context.ts";
 import { NewSessionModelControl } from "./model-control.ts";
 
 export function contextWith(
@@ -13,9 +13,19 @@ export function contextWith(
 ) {
   const request = vi.fn().mockResolvedValue({ models });
   const navigate = vi.fn();
+  const listeners = new Set<Parameters<ApplicationGateway["subscribeEvents"]>[0]>();
+  const emitCatalogChanged = () => {
+    for (const listener of listeners) {
+      listener({ type: "event", event: "chat.metadata.changed", payload: {} });
+    }
+  };
   const context = {
     navigate,
     gateway: {
+      subscribeEvents: (listener: Parameters<ApplicationGateway["subscribeEvents"]>[0]) => {
+        listeners.add(listener);
+        return () => listeners.delete(listener);
+      },
       snapshot: {
         phase: "connected",
         client: { request },
@@ -40,7 +50,7 @@ export function contextWith(
       },
     },
   } as unknown as ApplicationContext;
-  return { context, navigate, request };
+  return { context, navigate, request, emitCatalogChanged };
 }
 
 export function deferred<T>() {

--- a/ui/src/pages/new-session/model-control.test.ts
+++ b/ui/src/pages/new-session/model-control.test.ts
@@ -1,10 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
-import {
-  invalidateChatMetadataStore,
-  beginChatMetadataPublication,
-} from "../../lib/chat/chat-metadata-store.ts";
 import { waitForFast } from "../../test-helpers/wait-for.ts";
 import { contextWith, deferred, renderControl } from "./model-control.test-support.ts";
 import { NewSessionModelControl } from "./model-control.ts";
@@ -132,7 +128,11 @@ describe("new-session model runtime", () => {
     picker!.open = true;
     picker!.dispatchEvent(new Event("toggle"));
 
-    expect(request).toHaveBeenCalledOnce();
+    expect(
+      request.mock.calls.every(
+        ([method, params]) => method === "models.list" && params.refresh === undefined,
+      ),
+    ).toBe(true);
     expect(request.mock.calls.some(([method]) => method === "sessions.catalog.list")).toBe(false);
     expect(container.querySelector("[data-chat-model-target-group]")).toBeNull();
   });
@@ -328,7 +328,11 @@ describe("new-session model runtime", () => {
     control.load(context, "main", true);
     await vi.waitFor(() => {
       expect(request).toHaveBeenCalledOnce();
-      expect(notify).toHaveBeenCalledTimes(2);
+      expect(
+        renderControl(control, context).querySelector(
+          '[data-chat-model-option="openai/gpt-5.6-luna"]',
+        ),
+      ).not.toBeNull();
     });
 
     let container = renderControl(control, context, "main", null);
@@ -568,8 +572,8 @@ describe("new-session model runtime", () => {
     expect(container.textContent).not.toContain("GPT-5.6 Luna");
   });
 
-  it("updates a verified-empty catalog when shared chat metadata publishes models", async () => {
-    const { context, request } = contextWith([]);
+  it("updates a verified-empty catalog after a catalog publication", async () => {
+    const { context, request, emitCatalogChanged } = contextWith([]);
     const control = new NewSessionModelControl(() => undefined);
 
     control.load(context, "main", true);
@@ -580,10 +584,10 @@ describe("new-session model runtime", () => {
     );
     expect(renderControl(control, context).textContent).toContain("No models available");
 
-    beginChatMetadataPublication(context.gateway.snapshot.client!, { agentId: "main" }).publish({
-      commands: [],
+    request.mockResolvedValueOnce({
       models: [{ id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai" }],
     });
+    emitCatalogChanged();
 
     await vi.waitFor(() =>
       expect(
@@ -593,7 +597,7 @@ describe("new-session model runtime", () => {
       ).not.toBeNull(),
     );
     expect(renderControl(control, context).textContent).not.toContain("No models available");
-    expect(request).toHaveBeenCalledOnce();
+    expect(request).toHaveBeenCalledTimes(2);
   });
 
   it("treats a disconnected stale all-cold catalog as offline and non-authoritative", async () => {
@@ -606,7 +610,7 @@ describe("new-session model runtime", () => {
         unavailableReason: "missing-auth",
       },
     ];
-    const { context, request } = contextWith(coldModels);
+    const { context, request, emitCatalogChanged } = contextWith(coldModels);
     const control = new NewSessionModelControl(() => undefined);
     const agent = { id: "main", model: { primary: "openai/gpt-5.6-luna" } };
     control.load(context, "main", true, { agent });
@@ -621,7 +625,7 @@ describe("new-session model runtime", () => {
     } as unknown as ApplicationContext;
     (context.gateway as { snapshot: ApplicationContext["gateway"]["snapshot"] }).snapshot =
       offlineContext.gateway.snapshot;
-    invalidateChatMetadataStore(context.gateway.snapshot.client!);
+    emitCatalogChanged();
 
     const container = renderControl(control, offlineContext, "main", agent);
     expect(container.querySelector('[data-chat-model-catalog-state="offline"]')).not.toBeNull();
@@ -644,7 +648,7 @@ describe("new-session model runtime", () => {
     const availableModels: ModelCatalogEntry[] = [
       { id: "gpt-5.6-luna", name: "GPT-5.6 Luna", provider: "openai", available: true },
     ];
-    const { context, request } = contextWith(coldModels);
+    const { context, request, emitCatalogChanged } = contextWith(coldModels);
     const control = new NewSessionModelControl(() => undefined);
     const agent = { id: "main", model: { primary: "openai/gpt-5.6-luna" } };
     control.load(context, "main", true, { agent });
@@ -658,7 +662,7 @@ describe("new-session model runtime", () => {
         renderControl(control, context, "main", agent).querySelector(
           "[data-chat-model-catalog-state]",
         ),
-      ).toBeNull(),
+      ).not.toBeNull(),
     );
     let container = renderControl(control, context, "main", agent);
     expect(container.querySelector('[data-chat-model-select="true"]')?.textContent).toContain(
@@ -668,6 +672,7 @@ describe("new-session model runtime", () => {
     expect(control.modelUnavailableReason(agent)).toBe("missing-auth");
 
     request.mockResolvedValueOnce({ models: availableModels });
+    emitCatalogChanged();
     control.load(context, "main", true, { agent });
     await vi.waitFor(() => expect(request).toHaveBeenCalledTimes(3));
     await vi.waitFor(() =>
@@ -718,7 +723,9 @@ describe("new-session model runtime", () => {
 
     await vi.waitFor(() => {
       expect(request).toHaveBeenCalledTimes(2);
-      expect(notify).toHaveBeenCalledTimes(4);
+      expect(
+        renderControl(control, context).querySelector('[data-chat-model-catalog-state="error"]'),
+      ).not.toBeNull();
     });
     expect(control.selected).toBe("anthropic/claude-sonnet-4-6");
     expect(control.thinkingLevel).toBe("high");
@@ -767,8 +774,8 @@ describe("new-session model runtime", () => {
     refresh.reject(new Error("refresh failed"));
     await vi.waitFor(() =>
       expect(
-        renderControl(control, context).querySelector("[data-chat-model-catalog-state]"),
-      ).toBeNull(),
+        renderControl(control, context).querySelector('[data-chat-model-catalog-state="error"]'),
+      ).not.toBeNull(),
     );
     container = renderControl(control, context);
     expect(container.querySelectorAll("[data-chat-model-option]")).toHaveLength(2);
@@ -813,7 +820,6 @@ describe("new-session model runtime", () => {
     );
 
     request.mockReturnValueOnce(reconnect.promise);
-    invalidateChatMetadataStore(context.gateway.snapshot.client!);
     control.invalidate(false);
     control.load(context, "main", true);
 

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -130,13 +130,14 @@ export class NewSessionModelControl {
 
   private bindMetadataSubscription(client: NewSessionMetadataClient, scope: ModelCatalogReadScope) {
     if (
+      this.metadataScope &&
       this.metadataClient === client &&
       this.metadataGateway === this.pendingContext?.gateway &&
-      this.metadataScope?.agentId === scope.agentId &&
-      this.metadataScope?.authProfileId === scope.authProfileId &&
+      this.metadataScope.agentId === scope.agentId &&
+      this.metadataScope.authProfileId === scope.authProfileId &&
       this.metadataUnsubscribe
     ) {
-      return;
+      return this.metadataScope;
     }
     this.clearMetadataSubscription();
     this.metadataClient = client;
@@ -155,6 +156,7 @@ export class NewSessionModelControl {
           void this.startMetadataRequest(client, scope);
         })
       : undefined;
+    return scope;
   }
 
   loadCatalogTargets(context: ApplicationContext | undefined, agentId: string, enabled: boolean) {
@@ -232,14 +234,14 @@ export class NewSessionModelControl {
     this.selectionGeneration += 1;
     this.restoringPreference = false;
     this.draftAccount = { authProfileId: account.authProfileId, provider: account.provider, model };
-    const scope = { agentId: this.agentId, authProfileId: account.authProfileId };
+    const requestedScope = { agentId: this.agentId, authProfileId: account.authProfileId };
     this.metadataState = {
       catalog: [],
       accountSelection: this.metadataState.accountSelection,
       hasSnapshot: false,
       status: "loading",
     };
-    this.bindMetadataSubscription(client, scope);
+    const scope = this.bindMetadataSubscription(client, requestedScope);
     return this.startMetadataRequest(client, scope).then(
       (result) => Boolean(result) && this.ownsMetadata(client, scope),
     );
@@ -271,7 +273,6 @@ export class NewSessionModelControl {
     if (resetSelection) {
       this.agentId = "";
       this.metadataClient = undefined;
-      this.clearMetadataSubscription();
       this.selected = "";
       this.contextWindow = "";
       this.thinkingLevel = "";
@@ -351,8 +352,8 @@ export class NewSessionModelControl {
       ...(this.draftAccount ? { authProfileId: this.draftAccount.authProfileId } : {}),
     };
     const previousScope = this.metadataScope;
-    this.bindMetadataSubscription(client, scope);
-    const rebound = this.metadataScope !== previousScope;
+    const boundScope = this.bindMetadataSubscription(client, scope);
+    const rebound = boundScope !== previousScope;
     this.pendingPreference = options.preference;
     this.pendingAgent = options.agent;
     this.pendingSelectionGeneration = selectionGeneration;
@@ -376,7 +377,7 @@ export class NewSessionModelControl {
       this.restoringPreference = false;
       return;
     }
-    void this.startMetadataRequest(client, this.metadataScope ?? scope);
+    void this.startMetadataRequest(client, boundScope);
   }
 
   isRestoringPreference(): boolean {

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -1,18 +1,16 @@
 import type {
   ChatAccountSelection,
-  ChatMetadataParams,
   UserModelAccount,
 } from "../../../../packages/gateway-protocol/src/index.ts";
-import type { FastMode, GatewayAgentRow, ModelCatalogEntry } from "../../api/types.ts";
+import type {
+  FastMode,
+  GatewayAgentRow,
+  ModelCatalogEntry,
+  ModelCatalogResult,
+} from "../../api/types.ts";
 import type { ApplicationContext } from "../../app/context.ts";
 import { hasOperatorWriteAccess } from "../../app/operator-access.ts";
 import { t } from "../../i18n/index.ts";
-import {
-  peekChatMetadata,
-  revalidateChatMetadata,
-  subscribeChatMetadata,
-  type ChatMetadataResult,
-} from "../../lib/chat/chat-metadata-store.ts";
 import { buildQualifiedChatModelValue } from "../../lib/chat/model-ref.ts";
 import {
   isChatFastModeProviderSupported,
@@ -21,7 +19,11 @@ import {
   resolveChatModelUnavailableReason,
 } from "../../lib/chat/model-select-state.ts";
 import { normalizeThinkingOptionValue } from "../../lib/chat/thinking.ts";
-import { loadModelCatalog } from "../../lib/model-catalog-store.ts";
+import {
+  loadModelCatalog,
+  subscribeModelCatalogChanges,
+  type ModelCatalogReadScope,
+} from "../../lib/model-catalog-store.ts";
 import { normalizeAgentId } from "../../lib/sessions/session-key.ts";
 import { renderChatModelAccountControl } from "../chat/components/chat-model-account-control.ts";
 import {
@@ -63,10 +65,11 @@ export class NewSessionModelControl {
     hasSnapshot: false,
     status: "idle",
   };
-  private metadataLoading = false;
+  private metadataRequest: AbortController | undefined;
   private metadataClient: NewSessionMetadataClient | undefined;
-  private metadataScope: ChatMetadataParams | undefined;
+  private metadataScope: ModelCatalogReadScope | undefined;
   private metadataIdentityId: string | undefined;
+  private metadataGateway: ApplicationContext["gateway"] | undefined;
   private metadataHello: ApplicationContext["gateway"]["snapshot"]["hello"] | undefined;
   private metadataUnsubscribe: (() => void) | undefined;
   private draftAccount:
@@ -103,15 +106,19 @@ export class NewSessionModelControl {
   }
 
   private clearMetadataSubscription() {
+    this.metadataRequest?.abort();
+    this.metadataRequest = undefined;
     this.metadataUnsubscribe?.();
     this.metadataUnsubscribe = undefined;
     this.metadataScope = undefined;
+    this.metadataGateway = undefined;
   }
 
-  private ownsMetadata(client: NewSessionMetadataClient, scope: ChatMetadataParams): boolean {
+  private ownsMetadata(client: NewSessionMetadataClient, scope: ModelCatalogReadScope): boolean {
     const snapshot = this.pendingContext?.gateway.snapshot;
     return (
       this.metadataClient === client &&
+      this.metadataGateway === this.pendingContext?.gateway &&
       this.metadataScope === scope &&
       snapshot?.phase === "connected" &&
       snapshot.client === client &&
@@ -120,9 +127,10 @@ export class NewSessionModelControl {
     );
   }
 
-  private bindMetadataSubscription(client: NewSessionMetadataClient, scope: ChatMetadataParams) {
+  private bindMetadataSubscription(client: NewSessionMetadataClient, scope: ModelCatalogReadScope) {
     if (
       this.metadataClient === client &&
+      this.metadataGateway === this.pendingContext?.gateway &&
       this.metadataScope?.agentId === scope.agentId &&
       this.metadataScope?.authProfileId === scope.authProfileId &&
       this.metadataUnsubscribe
@@ -132,44 +140,20 @@ export class NewSessionModelControl {
     this.clearMetadataSubscription();
     this.metadataClient = client;
     this.metadataScope = scope;
-    this.metadataUnsubscribe = subscribeChatMetadata(client, scope, (update) => {
-      if (this.metadataClient !== client || this.metadataScope !== scope) {
-        return;
-      }
-      if (!this.ownsMetadata(client, scope)) {
-        this.metadataLoading = false;
-        this.restoringPreference = false;
-        this.draftAccount = undefined;
-        this.clearMetadataSubscription();
-        this.updateMetadataState({ catalog: [], hasSnapshot: false, status: "offline" });
-        return;
-      }
-      if (update.type === "invalidated") {
-        void this.startMetadataRequest(client, scope);
-        return;
-      }
-      this.metadataLoading = update.type === "loading";
-      if (update.type === "result") {
-        this.publishMetadataCatalog(update.result);
-      } else if (update.type === "loading") {
-        const status = this.metadataState.hasSnapshot ? "ready" : "loading";
-        if (this.metadataState.status !== status) {
-          this.updateMetadataState({ ...this.metadataState, status });
-        }
-      } else {
-        if (
-          !this.draftAccount &&
-          this.pendingSelectionGeneration === this.selectionGeneration &&
-          (this.pendingPreference?.model || this.pendingPreference?.thinkingLevel)
-        ) {
-          // A transport failure cannot authorize a model or replace the requested preference.
-          this.selected = this.pendingPreference.model ?? "";
-          this.thinkingLevel = this.pendingPreference.thinkingLevel ?? "";
-        }
-        this.restoringPreference = false;
-        this.updateMetadataState({ ...this.metadataState, status: "error" });
-      }
-    });
+    const gateway = this.pendingContext?.gateway;
+    this.metadataGateway = gateway;
+    this.metadataUnsubscribe = gateway
+      ? subscribeModelCatalogChanges(gateway, () => {
+          if (!this.ownsMetadata(client, scope)) {
+            this.restoringPreference = false;
+            this.draftAccount = undefined;
+            this.clearMetadataSubscription();
+            this.updateMetadataState({ catalog: [], hasSnapshot: false, status: "offline" });
+            return;
+          }
+          void this.startMetadataRequest(client, scope);
+        })
+      : undefined;
   }
 
   loadCatalogTargets(context: ApplicationContext | undefined, agentId: string, enabled: boolean) {
@@ -181,12 +165,12 @@ export class NewSessionModelControl {
     this.notify();
   }
 
-  private publishMetadataCatalog(result: ChatMetadataResult) {
+  private publishMetadataCatalog(result: ModelCatalogResult) {
     this.metadataState = {
-      catalog: Array.isArray(result.models) ? result.models : [],
+      catalog: result.models,
       accountSelection: result.accountSelection,
       hasSnapshot: true,
-      status: "ready",
+      status: result.refreshFailed ? "error" : "ready",
     };
     if (!this.draftAccount && this.pendingSelectionGeneration === this.selectionGeneration) {
       this.restorePreference(this.pendingPreference, this.pendingAgent, this.pendingContext);
@@ -195,21 +179,47 @@ export class NewSessionModelControl {
     this.notify();
   }
 
-  private startMetadataRequest(client: NewSessionMetadataClient, scope: ChatMetadataParams) {
-    this.metadataLoading = true;
-    const cached = peekChatMetadata(client, scope);
-    if (Array.isArray(cached?.models)) {
-      this.publishMetadataCatalog(cached);
-    } else {
-      this.updateMetadataState({
-        ...this.metadataState,
-        status: this.metadataState.hasSnapshot ? "ready" : "loading",
-      });
-    }
-
-    return revalidateChatMetadata(client, scope, {
-      startupRetryWindowMs: 60_000,
-    }).catch(() => undefined);
+  private startMetadataRequest(client: NewSessionMetadataClient, scope: ModelCatalogReadScope) {
+    this.metadataRequest?.abort();
+    const controller = new AbortController();
+    this.metadataRequest = controller;
+    const ownsRequest = () =>
+      this.metadataRequest === controller && this.ownsMetadata(client, scope);
+    this.updateMetadataState({
+      ...this.metadataState,
+      status: this.metadataState.hasSnapshot
+        ? this.metadataState.status === "error"
+          ? "error"
+          : "ready"
+        : "loading",
+    });
+    return loadModelCatalog(client, { ...scope, signal: controller.signal }).then(
+      (result) => {
+        if (!ownsRequest()) {
+          return undefined;
+        }
+        this.metadataRequest = undefined;
+        this.publishMetadataCatalog(result);
+        return result;
+      },
+      () => {
+        if (!ownsRequest()) {
+          return undefined;
+        }
+        this.metadataRequest = undefined;
+        if (
+          !this.draftAccount &&
+          this.pendingSelectionGeneration === this.selectionGeneration &&
+          (this.pendingPreference?.model || this.pendingPreference?.thinkingLevel)
+        ) {
+          this.selected = this.pendingPreference.model ?? "";
+          this.thinkingLevel = this.pendingPreference.thinkingLevel ?? "";
+        }
+        this.restoringPreference = false;
+        this.updateMetadataState({ ...this.metadataState, status: "error" });
+        return undefined;
+      },
+    );
   }
 
   private selectDraftAccount(account: UserModelAccount, model: string): Promise<boolean> {
@@ -238,38 +248,22 @@ export class NewSessionModelControl {
       return;
     }
     this.draftAccount = undefined;
-    this.metadataLoading = false;
     this.clearMetadataSubscription();
     this.metadataState = { catalog: [], hasSnapshot: false, status: "idle" };
   }
 
-  private retryPickerCatalogs(refreshReadyMetadata = false) {
-    const metadataClient = this.metadataClient;
+  private retryPickerCatalogs() {
+    const client = this.metadataClient;
     const scope = this.metadataScope;
-    if (this.metadataState.status === "error" && metadataClient && scope) {
-      void this.startMetadataRequest(metadataClient, scope);
-    } else if (
-      refreshReadyMetadata &&
-      this.metadataState.status === "ready" &&
-      metadataClient &&
-      this.agentId
-    ) {
-      const agentId = this.agentId;
-      void loadModelCatalog(metadataClient, {
-        agentId,
-        refreshIfDue: true,
-      }).catch(() => {
-        if (this.metadataClient === metadataClient && this.metadataScope === scope) {
-          this.updateMetadataState({ ...this.metadataState, status: "error" });
-        }
-      });
+    if (!this.metadataRequest && client && scope) {
+      void this.startMetadataRequest(client, scope);
     }
-    this.catalogTargets.retry(metadataClient, this.agentId);
+    this.catalogTargets.retry(client, this.agentId);
   }
 
   invalidate(resetSelection = false) {
-    this.metadataLoading = false;
     this.clearDraftAccount();
+    this.clearMetadataSubscription();
     this.catalogTargets.clear();
     this.restoringPreference = false;
     if (resetSelection) {
@@ -289,7 +283,7 @@ export class NewSessionModelControl {
     }
     this.updateMetadataState({
       ...this.metadataState,
-      status: this.metadataState.hasSnapshot ? "error" : "idle",
+      status: this.metadataState.hasSnapshot ? this.metadataState.status : "idle",
     });
   }
 
@@ -310,12 +304,12 @@ export class NewSessionModelControl {
     if (
       this.agentId !== normalizedAgentId ||
       (this.metadataClient && this.metadataClient !== client) ||
+      (this.metadataGateway && this.metadataGateway !== context?.gateway) ||
       this.metadataIdentityId !== snapshot?.selfUser?.id ||
       (this.metadataHello && this.metadataHello !== snapshot?.hello)
     ) {
       // Model preferences belong to the agent; an explicit account belongs to this connection.
       // Neither its availability nor an in-flight preview can cross an identity change.
-      this.metadataLoading = false;
       this.draftAccount = undefined;
       this.clearMetadataSubscription();
       if (this.agentId !== normalizedAgentId) {
@@ -336,7 +330,6 @@ export class NewSessionModelControl {
     this.metadataHello = snapshot?.hello;
     const selectionGeneration = this.selectionGeneration;
     if (!context || snapshot?.phase !== "connected" || !client || !normalizedAgentId || !enabled) {
-      this.metadataLoading = false;
       this.clearDraftAccount();
       this.clearMetadataSubscription();
       this.metadataClient = undefined;
@@ -355,24 +348,30 @@ export class NewSessionModelControl {
       agentId: normalizedAgentId,
       ...(this.draftAccount ? { authProfileId: this.draftAccount.authProfileId } : {}),
     };
+    const previousScope = this.metadataScope;
     this.bindMetadataSubscription(client, scope);
+    const rebound = this.metadataScope !== previousScope;
     this.pendingPreference = options.preference;
     this.pendingAgent = options.agent;
     this.pendingSelectionGeneration = selectionGeneration;
     this.restoringPreference = Boolean(
       !this.draftAccount && (options.preference?.model || options.preference?.thinkingLevel),
     );
-    const cached = peekChatMetadata(client, scope);
-    if (this.metadataLoading) {
-      if (cached) {
-        this.publishMetadataCatalog(cached);
-      } else {
-        this.notify();
-      }
+    if (this.metadataRequest) {
+      this.notify();
       return;
     }
-    if (cached && this.metadataState.status !== "error") {
-      this.publishMetadataCatalog(cached);
+    // Render passes do not retry a failed read; publication events and picker opens do.
+    if (!rebound && this.metadataState.status !== "idle") {
+      if (
+        this.metadataState.status === "ready" &&
+        this.metadataState.hasSnapshot &&
+        !this.draftAccount &&
+        this.pendingSelectionGeneration === this.selectionGeneration
+      ) {
+        this.restorePreference(this.pendingPreference, this.pendingAgent, this.pendingContext);
+      }
+      this.restoringPreference = false;
       return;
     }
     void this.startMetadataRequest(client, this.metadataScope ?? scope);
@@ -399,7 +398,7 @@ export class NewSessionModelControl {
       if (this.metadataState.status === "error") {
         return t("chat.modelControls.modelsUnavailable");
       }
-      if (this.metadataLoading || !this.metadataState.hasSnapshot) {
+      if (this.metadataRequest || !this.metadataState.hasSnapshot) {
         return t("chat.modelControls.loadingModels");
       }
       if (!this.accountSelectionReady()) {
@@ -429,7 +428,7 @@ export class NewSessionModelControl {
       !this.metadataClient ||
       !this.metadataScope ||
       !this.ownsMetadata(this.metadataClient, this.metadataScope) ||
-      this.metadataLoading ||
+      this.metadataRequest ||
       this.metadataState.status !== "ready" ||
       selection?.kind !== "personal" ||
       selection.authProfileId !== this.draftAccount.authProfileId
@@ -647,7 +646,7 @@ export class NewSessionModelControl {
       loading: false,
       modelCatalog: this.catalog,
       modelCatalogState: {
-        // chat.metadata and agents.list hydrate independently. Do not expose a
+        // The model catalog and agents.list hydrate independently. Do not expose a
         // ready catalog until the selected agent can supply its concrete defaults.
         hasSnapshot: agentDefaultsAvailable && this.metadataState.hasSnapshot,
         status:
@@ -713,7 +712,7 @@ export class NewSessionModelControl {
       },
       onModelPickerTargetRetry: (groupId) => {
         if (groupId === "cliAgents") {
-          this.retryPickerCatalogs();
+          this.catalogTargets.retry(this.metadataClient, this.agentId);
         }
       },
       onThinkingSelect: (value) => {
@@ -735,7 +734,7 @@ export class NewSessionModelControl {
         this.notify();
       },
       onModelSetup: () => options.context?.navigate("model-setup"),
-      onModelPickerOpen: () => this.retryPickerCatalogs(true),
+      onModelPickerOpen: () => this.retryPickerCatalogs(),
       onRequestUpdate: this.notify,
     });
   }

--- a/ui/src/pages/new-session/model-control.ts
+++ b/ui/src/pages/new-session/model-control.ts
@@ -43,6 +43,7 @@ type NewSessionMetadataStatus = ChatModelCatalogState["status"];
 type NewSessionMetadataState = {
   catalog: ModelCatalogEntry[];
   accountSelection?: ChatAccountSelection;
+  refreshFailed?: boolean;
   hasSnapshot: boolean;
   status: NewSessionMetadataStatus;
 };
@@ -170,7 +171,8 @@ export class NewSessionModelControl {
       catalog: result.models,
       accountSelection: result.accountSelection,
       hasSnapshot: true,
-      status: result.refreshFailed ? "error" : "ready",
+      status: "ready",
+      refreshFailed: result.refreshFailed,
     };
     if (!this.draftAccount && this.pendingSelectionGeneration === this.selectionGeneration) {
       this.restorePreference(this.pendingPreference, this.pendingAgent, this.pendingContext);
@@ -649,6 +651,7 @@ export class NewSessionModelControl {
         // The model catalog and agents.list hydrate independently. Do not expose a
         // ready catalog until the selected agent can supply its concrete defaults.
         hasSnapshot: agentDefaultsAvailable && this.metadataState.hasSnapshot,
+        refreshFailed: this.metadataState.refreshFailed,
         status:
           !agentDefaultsAvailable && this.metadataState.status !== "error"
             ? "loading"

--- a/ui/src/pages/new-session/submit-gates.test.ts
+++ b/ui/src/pages/new-session/submit-gates.test.ts
@@ -32,7 +32,7 @@ describe("DraftSubmissionFlow submit gates", () => {
     "blocks new sessions only for actionable $reason model availability",
     async ({ reason, message }) => {
       const { context, flow, place } = createDraftFixture({
-        request: async () => ({
+        modelCatalog: async () => ({
           models: [
             {
               id: "gpt-5.6-luna",
@@ -69,7 +69,7 @@ describe("DraftSubmissionFlow submit gates", () => {
       const { context, flow, place } = createDraftFixture({
         methods: ["sessions.create", "sessions.dispatch"],
         scopes: ["operator.admin", "operator.read", "operator.write"],
-        request: async () => ({
+        modelCatalog: async () => ({
           models: [
             {
               id: "gpt-5.6-luna",

--- a/ui/src/pages/new-session/submit-gates.test.ts
+++ b/ui/src/pages/new-session/submit-gates.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { CHAT_ROUTE_READY_EVENT } from "../../app/route-transition.ts";
-import { peekChatMetadata } from "../../lib/chat/chat-metadata-store.ts";
 import { createDraftFixture } from "./draft-submission-flow.test-support.ts";
+import { renderControl } from "./model-control.test-support.ts";
 import { patchNewSessionPreference } from "./preferences.ts";
 
 // The closed list of gates allowed to block without a visible reason: the busy
@@ -47,7 +47,12 @@ describe("DraftSubmissionFlow submit gates", () => {
       place.modelControl.load(context, "main", true, { agent: place.selectedAgent() });
       await vi.waitFor(() =>
         expect(
-          peekChatMetadata(context.gateway.snapshot.client!, { agentId: "main" })?.models,
+          renderControl(
+            place.modelControl,
+            context,
+            "main",
+            place.selectedAgent(),
+          ).querySelectorAll("[data-chat-model-option]"),
         ).toHaveLength(1),
       );
       flow.setMessage("Start this session");


### PR DESCRIPTION
Related: #136257, #142063.

## What Problem This Solves

Chat and New Session used competing catalog state instead of directly reading choices for the saved session or selected draft account. Refresh failures and account changes could leave misleading choices.

## Why This Change Was Made

Both surfaces use the published inventory owner. Gateway requests preserve saved account pins, validate draft-account ownership around asynchronous work, and return account display facts with the catalog. Shared direct readers replace the UI cache and implicit picker discovery. Explicit refresh waits for authentication publication.

## User Impact

Failed refreshes retain compatible rows with a warning; successful empty results clear them. Same-account preview retry can recover. Request and response additions preserve the protocol version and stored account defaults; the legacy metadata endpoint remains available.

Consumers: Chat, New Session, Agents, slash commands, and diagnostics share direct catalog reads.

## Evidence

The original models.list rejected session selectors. Gateway checks passed direct reads, ownership refusal, failed refresh, and empty results. A real built UI/Gateway preserved saved pins, showed refresh warnings, and made usable personal-account selections without inference. Its final check failed on an existing first-visit preference marker; subsequent readback confirmed no account-default change. Browser regressions and continuous integration passed. Native client adoption and live credentials were not tested.
