### PR TITLE
fix(tooling): drop machine squash credit and carry human co-author trailers

### DIFF
--- a/docs/ci/watching-runs.md
+++ b/docs/ci/watching-runs.md
@@ -102,7 +102,14 @@ regular UTF-8 file before verification. Empty files are valid. It preserves
 operator-provided text and trailers, appending any missing co-authors from the
 current GitHub preview and reviewed source commits. This option requires squash
 and a non-queue PR; all review, CI, exact-head, and admission checks still apply.
-Without the option, the existing GitHub preview behavior is unchanged.
+Without the option, the wrapper composes the message from the GitHub preview:
+it keeps credit backed by a non-merge PR commit author or a reviewed source
+trailer, appends human `Co-authored-by` trailers from the PR's commits that the
+preview omitted, and drops machine credit (Claude, Codex, Cursor, Copilot, Amp,
+Trae, and GitHub App `[bot]` accounts) wherever GitHub replayed it, including
+inside per-commit bullets. A reviewed body that still contains machine credit
+is rejected, and a merge-queue PR whose preview needs such edits stops before
+admission.
 
 `merge-recover` accepts the same option after its required outcome ID and
 `--confirmed-operator-recovery`. Repeating `merge-run` with a retained outcome

--- a/scripts/pr-lib/merge-body.mjs
+++ b/scripts/pr-lib/merge-body.mjs
@@ -55,45 +55,116 @@ function trailers(body) {
   return parsed.stdout.split("\n").filter(Boolean);
 }
 
+// Published machine identities: exact addresses plus GitHub App `[bot]`
+// no-reply accounts, which cannot belong to a person. Never match names or
+// provider domains; humans commit from @openai.com and @anthropic.com too.
+const MACHINE_CREDIT_EMAILS = new Set([
+  "noreply@anthropic.com",
+  "cursoragent@cursor.com",
+  "amp@ampcode.com",
+  "codex@openai.com",
+  "noreply@openai.com",
+  "solo-agent@trae.ai",
+  "175728472+copilot@users.noreply.github.com",
+  "198982749+copilot@users.noreply.github.com",
+  "223556219+copilot@users.noreply.github.com",
+  "309084314+roboclaw-bot@users.noreply.github.com",
+]);
+const GITHUB_APP_BOT_EMAIL = /^(?:\d+\+)?[^@\s]*\[bot\]@users\.noreply\.github\.com$/;
+
+function isCredit(line) {
+  return /^Co-authored-by:/i.test(line);
+}
+
+function creditEmail(line) {
+  const match = /^Co-authored-by:\s*[^<>]+<([^<>\r\n]+)>$/i.exec(line);
+  return match ? match[1].trim().toLowerCase() : undefined;
+}
+
 function isMachineCredit(line) {
-  // Match published machine addresses, never names or provider domains that
-  // can also identify human contributors.
-  return /^Co-authored-by:\s*[^<>]+<(?:noreply@anthropic\.com|cursoragent@cursor\.com|amp@ampcode\.com|codex@openai\.com|solo-agent@trae\.ai|309084314\+roboclaw-bot@users\.noreply\.github\.com|274271284\+clawsweeper\[bot\]@users\.noreply\.github\.com)>$/i.test(
-    line,
+  const email = creditEmail(line);
+  return (
+    email !== undefined && (MACHINE_CREDIT_EMAILS.has(email) || GITHUB_APP_BOT_EMAIL.test(email))
   );
 }
 
 function coauthorEmail(line) {
-  const match = /^Co-authored-by:\s*[^<>]+<([^<>\r\n]+)>$/i.exec(line);
-  if (!match) {
+  const email = creditEmail(line);
+  if (email === undefined) {
     throw new Error(`Cannot validate squash preview co-author: ${JSON.stringify(line)}.`);
   }
-  return match[1].trim().toLowerCase();
+  return email;
 }
 
-function removeUnsupportedPreviewCredit(preview, unsupported) {
-  if (unsupported.length === 0) {
-    return preview;
+function splitLines(text) {
+  return text.match(/[^\n]*(?:\n|$)/g)?.filter(Boolean) ?? [];
+}
+
+// Physical line indexes carrying machine credit anywhere in a message,
+// including an indented key line or a trailer folded onto indented
+// continuation lines. The identity is checked at every unfolding step so
+// indented text after a complete trailer cannot hide it.
+function machineCreditLines(lines) {
+  const indexes = new Set();
+  for (let index = 0; index < lines.length; index += 1) {
+    let unfolded = lines[index].trim();
+    if (!isCredit(unfolded)) {
+      continue;
+    }
+    for (let end = index; ; end += 1) {
+      if (isMachineCredit(unfolded)) {
+        for (let line = index; line <= end; line += 1) {
+          indexes.add(line);
+        }
+        break;
+      }
+      if (end + 1 >= lines.length || !/^[ \t]+\S/.test(lines[end + 1])) {
+        break;
+      }
+      unfolded += ` ${lines[end + 1].trim()}`;
+    }
   }
-  const lines = preview.match(/[^\n]*(?:\n|$)/g)?.filter(Boolean) ?? [];
+  return indexes;
+}
+
+function prunePreview(lines, unsupported, machineIndexes) {
   const counts = new Map();
   for (const credit of unsupported) {
     const normalized = credit.toLowerCase();
     counts.set(normalized, (counts.get(normalized) ?? 0) + 1);
   }
+  const dropIndexes = new Set(machineIndexes);
   for (const [expected, count] of counts) {
-    const matches = lines.flatMap((line, index) => {
-      const text = line.replace(/\r?\n$/, "");
-      return text.toLowerCase() === expected ? [index] : [];
-    });
+    const matches = lines.flatMap((line, index) =>
+      line.replace(/\r?\n$/, "").toLowerCase() === expected ? [index] : [],
+    );
     if (matches.length !== count) {
       throw new Error("Cannot remove unsupported squash preview credit unambiguously.");
     }
     for (const index of matches) {
-      lines[index] = "";
+      dropIndexes.add(index);
     }
   }
-  let body = lines.join("");
+  // GitHub replays every commit message, so machine credit also appears inside
+  // per-commit bullets, not only in the terminal trailer block. Drop it
+  // wherever it sits, along with a blank line it no longer separates.
+  const kept = [];
+  let dropped = false;
+  lines.forEach((line, index) => {
+    if (dropIndexes.has(index)) {
+      dropped = true;
+      return;
+    }
+    const blank = line.trim() === "";
+    if (dropped && blank && kept.length > 0 && kept.at(-1).trim() === "") {
+      return;
+    }
+    if (!blank) {
+      dropped = false;
+    }
+    kept.push(line);
+  });
+  let body = kept.join("");
   if (trailers(body).length === 0) {
     body = body.replace(/\r?\n\r?\n---------\r?\n(?:[ \t]*\r?\n)*$/, "");
   }
@@ -110,29 +181,44 @@ function compose({ preview, source, authors, captured, queue }) {
       .filter(Boolean),
   );
   for (const line of sourceTrailers) {
-    if (/^Co-authored-by:/i.test(line) && !isMachineCredit(line)) {
+    if (isCredit(line) && !isMachineCredit(line)) {
       eligibleEmails.add(coauthorEmail(line));
     }
   }
-  const previewTrailers = trailers(preview);
-  const previewCredits = previewTrailers.filter((line) => /^Co-authored-by:/i.test(line));
+  const previewCredits = trailers(preview).filter(isCredit);
   const unsupportedPreviewCredits = previewCredits.filter(
     (line) => !isMachineCredit(line) && !eligibleEmails.has(coauthorEmail(line)),
   );
   const retainedPreviewCredits = previewCredits.filter(
     (line) => !isMachineCredit(line) && eligibleEmails.has(coauthorEmail(line)),
   );
-  if (queue && unsupportedPreviewCredits.length > 0) {
-    throw new Error("Cannot queue a squash message with unsupported preview co-author credit.");
+  const previewLines = splitLines(preview);
+  const previewMachineLines = machineCreditLines(previewLines);
+  // Queue admission cannot override GitHub's message, so a preview that needs
+  // editing must stop here instead of merging with the wrong credit.
+  if (queue && (unsupportedPreviewCredits.length > 0 || previewMachineLines.size > 0)) {
+    throw new Error(
+      "Cannot queue a squash message with machine or unsupported preview co-author credit.",
+    );
   }
-  let body = explicit
-    ? Buffer.from(JSON.parse(captured).base64, "base64").toString("utf8")
-    : removeUnsupportedPreviewCredit(preview, unsupportedPreviewCredits);
+  const machineCreditError = () =>
+    new Error(
+      "Squash message contains machine co-author credit; remove it from the reviewed --body-file message and keep human contributors.",
+    );
+  let body;
+  if (explicit) {
+    // Reviewed bytes are never rewritten, so machine credit anywhere in them,
+    // not only in the parsed terminal block, is the operator's to remove.
+    body = Buffer.from(JSON.parse(captured).base64, "base64").toString("utf8");
+    if (machineCreditLines(splitLines(body)).size > 0) {
+      throw machineCreditError();
+    }
+  } else {
+    body = prunePreview(previewLines, unsupportedPreviewCredits, previewMachineLines);
+  }
   const original = trailers(body);
   if (original.some(isMachineCredit)) {
-    throw new Error(
-      "Squash message contains machine co-author credit; use --body-file with a reviewed message preserving human contributors.",
-    );
+    throw machineCreditError();
   }
   const required = [
     ...original,
@@ -140,6 +226,9 @@ function compose({ preview, source, authors, captured, queue }) {
     ...sourceTrailers,
   ].filter((line) => !isMachineCredit(line));
   const missing = [...new Set(required)].filter((line) => !original.includes(line));
+  if (queue && missing.length > 0) {
+    throw new Error("Cannot queue a squash message that omits required co-author credit.");
+  }
   // Keep explicit bytes, including CRLF and trailing blank lines. Insert new
   // credit before that suffix so all parsed trailers remain one terminal block.
   const suffix = explicit ? (body.match(/(?:\r?\n[ \t]*)+$/)?.[0] ?? "") : "\n";
@@ -162,7 +251,7 @@ function compose({ preview, source, authors, captured, queue }) {
   const excludedEmails = new Set(unsupportedPreviewCredits.map(coauthorEmail));
   if (
     !explicit &&
-    final.some((line) => /^Co-authored-by:/i.test(line) && excludedEmails.has(coauthorEmail(line)))
+    final.some((line) => isCredit(line) && excludedEmails.has(coauthorEmail(line)))
   ) {
     throw new Error("Cannot remove unsupported squash preview credit.");
   }

--- a/test/scripts/pr-merge.test.ts
+++ b/test/scripts/pr-merge.test.ts
@@ -325,28 +325,43 @@ describePosix("native squash attribution", () => {
     expect(result.mergeBody).toBe(overrideBody);
   });
 
-  it.each([false, true])(
-    "rejects a machine source-author preview without a reviewed body (queue=%s)",
-    (previewQueue) => {
-      const result = prepareBody({
-        sourceCommits: [
-          {
-            message: "Repair",
-            author: {
-              name: "roboclaw-bot",
-              email: "309084314+roboclaw-bot@users.noreply.github.com",
-            },
+  it("drops a machine source-author preview credit without a reviewed body", () => {
+    const result = prepareBody({
+      sourceCommits: [
+        {
+          message: "Repair",
+          author: {
+            name: "roboclaw-bot",
+            email: "309084314+roboclaw-bot@users.noreply.github.com",
           },
-        ],
-        previewBody:
-          "Repair\n\nCo-authored-by: roboclaw-bot <309084314+roboclaw-bot@users.noreply.github.com>",
-        previewQueue,
-      });
-      expect(result.status).toBe(1);
-      expect(result.mergeBody).toBeNull();
-      expect(result.stderr).toContain("--body-file");
-    },
-  );
+        },
+      ],
+      previewBody:
+        "Repair\n\nCo-authored-by: roboclaw-bot <309084314+roboclaw-bot@users.noreply.github.com>",
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe("Repair\n");
+  });
+
+  it("rejects queue admission when the preview carries machine credit", () => {
+    const result = prepareBody({
+      sourceCommits: [
+        {
+          message: "Repair",
+          author: {
+            name: "roboclaw-bot",
+            email: "309084314+roboclaw-bot@users.noreply.github.com",
+          },
+        },
+      ],
+      previewBody:
+        "Repair\n\nCo-authored-by: roboclaw-bot <309084314+roboclaw-bot@users.noreply.github.com>",
+      previewQueue: true,
+    });
+    expect(result.status).toBe(1);
+    expect(result.mergeBody).toBeNull();
+    expect(result.stderr).toContain("Cannot queue");
+  });
 
   it("does not trust an unpublished local fixup author for preview credit", () => {
     const previewCredit = "Co-authored-by: Local Fixup <local@example.com>";
@@ -409,6 +424,14 @@ describePosix("native squash attribution", () => {
     "Co-authored-by: clawsweeper <274271284+clawsweeper[bot]@users.noreply.github.com>",
     "co-authored-by: ClawSweeper <274271284+CLAWSWEEPER[BOT]@USERS.NOREPLY.GITHUB.COM>",
     "Co-Authored-By: clawsweeper\n <274271284+clawsweeper[bot]@users.noreply.github.com>",
+    "Co-authored-by: Copilot <175728472+Copilot@users.noreply.github.com>",
+    "Co-authored-by: Copilot <198982749+Copilot@users.noreply.github.com>",
+    "Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>",
+    "Co-authored-by: Codex <noreply@openai.com>",
+    "Co-authored-by: claude <209825114+claude[bot]@users.noreply.github.com>",
+    "Co-authored-by: cursor <206951365+cursor[bot]@users.noreply.github.com>",
+    "Co-authored-by: chatgpt-codex-connector <199175422+chatgpt-codex-connector[bot]@users.noreply.github.com>",
+    "Co-authored-by: Any App <1274271284+clawsweeper[bot]@users.noreply.github.com>",
   ])("omits imported machine credit while preserving human credit: %j", (machineCredit) => {
     const humanCredit = [
       "Co-authored-by: Claude <claude@example.com>",
@@ -433,8 +456,11 @@ describePosix("native squash attribution", () => {
       "Co-authored-by: Other <309084314+roboclaw-bot-human@users.noreply.github.com>",
       "Co-authored-by: clawsweeper <human@example.com>",
       "Co-authored-by: Human <274271284+human@users.noreply.github.com>",
-      "Co-authored-by: Other <1274271284+clawsweeper[bot]@users.noreply.github.com>",
       "Co-authored-by: Other <274271284+clawsweeper[bot]@users.noreply.github.com.example.org>",
+      "Co-authored-by: Copilot <copilot@example.com>",
+      "Co-authored-by: Human <1223556219+copilot@users.noreply.github.com>",
+      "Co-authored-by: Other <person[bot]@example.com>",
+      "Co-authored-by: Other <209825114+claude[bot]@users.noreply.github.com.example.org>",
       "Co-authored-by: Other <274271284+clawsweeperbot@users.noreply.github.com>",
     ].join("\n");
     const server = "Co-authored-by: Server <server@example.com>";
@@ -453,28 +479,26 @@ describePosix("native squash attribution", () => {
   });
 
   it.each([
-    undefined,
     "Reviewed correction.\n\nCo-authored-by: Claude <noreply@anthropic.com>\n",
+    "Reviewed correction.\n\nCo-authored-by: Copilot <198982749+Copilot@users.noreply.github.com>\n",
+    "Reviewed correction.\n\nCo-authored-by: claude <209825114+claude[bot]@users.noreply.github.com>\n",
     "Reviewed correction.\n\nCo-authored-by: Cursor <cursoragent@cursor.com>\n",
     "Reviewed correction.\n\nCo-authored-by: Amp <amp@ampcode.com>\n",
     "Reviewed correction.\n\nCo-authored-by: Codex <codex@openai.com>\n",
     "Reviewed correction.\n\nCo-authored-by: Trae Solo <solo-agent@trae.ai>\n",
     "Reviewed correction.\n\nCo-authored-by: roboclaw-bot <309084314+roboclaw-bot@users.noreply.github.com>\n",
     "Reviewed correction.\n\nCo-authored-by: clawsweeper <274271284+clawsweeper[bot]@users.noreply.github.com>\n",
-  ])(
-    "requires a reviewed body when the chosen message contains machine credit: %j",
-    (overrideBody) => {
-      const machineCredit = "Co-authored-by: Claude <noreply@anthropic.com>";
-      const result = prepareBody({
-        sourceMessages: [`Repair\n\n${machineCredit}`],
-        previewBody: `Server description\n\n${machineCredit}`,
-        overrideBody,
-      });
-      expect(result.status).toBe(1);
-      expect(result.mergeBody).toBeNull();
-      expect(result.stderr).toContain("--body-file");
-    },
-  );
+  ])("rejects a reviewed body that contains machine credit: %j", (overrideBody) => {
+    const machineCredit = "Co-authored-by: Claude <noreply@anthropic.com>";
+    const result = prepareBody({
+      sourceMessages: [`Repair\n\n${machineCredit}`],
+      previewBody: `Server description\n\n${machineCredit}`,
+      overrideBody,
+    });
+    expect(result.status).toBe(1);
+    expect(result.mergeBody).toBeNull();
+    expect(result.stderr).toContain("--body-file");
+  });
 
   it.each([
     "Claude <noreply@anthropic.com>",
@@ -484,14 +508,194 @@ describePosix("native squash attribution", () => {
     "Trae Solo <solo-agent@trae.ai>",
     "roboclaw-bot <309084314+roboclaw-bot@users.noreply.github.com>",
     "clawsweeper <274271284+clawsweeper[bot]@users.noreply.github.com>",
-  ])("rejects machine credit present only in the default server preview: %s", (identity) => {
+    "Copilot <175728472+Copilot@users.noreply.github.com>",
+    "Copilot <198982749+Copilot@users.noreply.github.com>",
+    "Copilot <223556219+Copilot@users.noreply.github.com>",
+    "Codex <noreply@openai.com>",
+    "claude <209825114+claude[bot]@users.noreply.github.com>",
+    "cursor <206951365+cursor[bot]@users.noreply.github.com>",
+    "chatgpt-codex-connector <199175422+chatgpt-codex-connector[bot]@users.noreply.github.com>",
+  ])("drops machine credit present only in the default server preview: %s", (identity) => {
     const result = prepareBody({
       sourceMessages: ["Repair"],
       previewBody: `Server description\n\nCo-authored-by: ${identity}`,
     });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe("Server description\n");
+  });
+
+  it("drops machine credit replayed in commit bullets and keeps human source credit", () => {
+    const machineCredit = "Co-authored-by: Claude <noreply@anthropic.com>";
+    const contributorCredit = "Co-authored-by: Contributor <contributor@example.com>";
+    const reviewerCredit = "Co-authored-by: Reviewer <reviewer@example.com>";
+    const maintainerCredit = "Co-authored-by: Maintainer <maintainer@example.com>";
+    const contributor = { name: "Contributor", email: "contributor@example.com" };
+    // Mirrors PR #126816: contributor commits carry Claude trailers, and the
+    // maintainer's merge commit carries the only trailer for a human reviewer.
+    const result = prepareBody({
+      sourceCommits: [
+        {
+          message: "First repair\n\nDetails.\n\nCo-Authored-By: Claude <noreply@anthropic.com>",
+          author: contributor,
+        },
+        {
+          message: "Second repair\n\nCo-Authored-By: Claude <noreply@anthropic.com>",
+          author: contributor,
+        },
+      ],
+      refreshMergeAuthor: { name: "Maintainer", email: "maintainer@example.com" },
+      refreshMergeMessage: `Integrate the repair\n\n${reviewerCredit}`,
+      previewBody: [
+        "* First repair",
+        "",
+        "Details.",
+        "",
+        machineCredit,
+        "",
+        "* Second repair",
+        "",
+        machineCredit,
+        "",
+        "---------",
+        "",
+        contributorCredit,
+        machineCredit,
+        maintainerCredit,
+        reviewerCredit,
+        "",
+      ].join("\n"),
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe(
+      [
+        "* First repair",
+        "",
+        "Details.",
+        "",
+        "* Second repair",
+        "",
+        "---------",
+        "",
+        contributorCredit,
+        reviewerCredit,
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("appends human source trailers the preview omitted while dropping machine ones", () => {
+    const machineCredit = "Co-authored-by: Codex <codex@openai.com>";
+    const humanCredit = "Co-authored-by: Pair Partner <pair@example.com>";
+    const contributorCredit = "Co-authored-by: Contributor <contributor@example.com>";
+    const result = prepareBody({
+      sourceCommits: [
+        {
+          message: `Repair\n\n${machineCredit}\n${humanCredit}`,
+          author: { name: "Contributor", email: "contributor@example.com" },
+        },
+      ],
+      previewBody: `Repair\n\n${machineCredit}\n\n---------\n\n${contributorCredit}\n${machineCredit}\n`,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe(`Repair\n\n---------\n\n${contributorCredit}\n${humanCredit}\n`);
+  });
+
+  it("drops a folded machine trailer replayed inside a commit bullet", () => {
+    const contributor = { name: "Contributor", email: "contributor@example.com" };
+    const contributorCredit = "Co-authored-by: Contributor <contributor@example.com>";
+    const result = prepareBody({
+      sourceCommits: [
+        {
+          message: "Repair\n\nCo-Authored-By: Claude\n <noreply@anthropic.com>",
+          author: contributor,
+        },
+        { message: "Follow-up", author: contributor },
+      ],
+      previewBody: `* Repair\n\nCo-Authored-By: Claude\n <noreply@anthropic.com>\n\n* Follow-up\n\n---------\n\n${contributorCredit}\n`,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe(`* Repair\n\n* Follow-up\n\n---------\n\n${contributorCredit}\n`);
+  });
+
+  it("rejects a reviewed body with machine credit outside its trailer block", () => {
+    const result = prepareBody({
+      sourceMessages: ["Repair"],
+      overrideBody:
+        "Reviewed correction.\n\nCo-authored-by: Claude <noreply@anthropic.com>\n\nMore context.\n",
+    });
     expect(result.status).toBe(1);
     expect(result.mergeBody).toBeNull();
     expect(result.stderr).toContain("--body-file");
+  });
+
+  it("rejects a reviewed body whose machine trailer is followed by indented text", () => {
+    const result = prepareBody({
+      sourceMessages: ["Repair"],
+      overrideBody:
+        "Reviewed correction.\n\nCo-authored-by: Claude <noreply@anthropic.com>\n  indented note\n\nMore context.\n",
+    });
+    expect(result.status).toBe(1);
+    expect(result.mergeBody).toBeNull();
+    expect(result.stderr).toContain("--body-file");
+  });
+
+  it("rejects a reviewed body with an indented machine credit line", () => {
+    const result = prepareBody({
+      sourceMessages: ["Repair"],
+      overrideBody:
+        "Reviewed correction.\n\n  Co-authored-by: Claude <noreply@anthropic.com>\n\nMore context.\n",
+    });
+    expect(result.status).toBe(1);
+    expect(result.mergeBody).toBeNull();
+    expect(result.stderr).toContain("--body-file");
+  });
+
+  it("drops an indented machine credit line from the default preview", () => {
+    const contributorCredit = "Co-authored-by: Contributor <contributor@example.com>";
+    const result = prepareBody({
+      sourceCommits: [
+        { message: "Repair", author: { name: "Contributor", email: "contributor@example.com" } },
+      ],
+      previewBody: `Repair\n\n  Co-authored-by: Claude <noreply@anthropic.com>\n\n---------\n\n${contributorCredit}\n`,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe(`Repair\n\n---------\n\n${contributorCredit}\n`);
+  });
+
+  it("drops a machine trailer followed by indented text from the default preview", () => {
+    const contributorCredit = "Co-authored-by: Contributor <contributor@example.com>";
+    const result = prepareBody({
+      sourceCommits: [
+        { message: "Repair", author: { name: "Contributor", email: "contributor@example.com" } },
+      ],
+      previewBody: `Repair\n\nCo-authored-by: Claude <noreply@anthropic.com>\n  indented note\n\n---------\n\n${contributorCredit}\n`,
+    });
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.mergeBody).toBe(
+      `Repair\n\n  indented note\n\n---------\n\n${contributorCredit}\n`,
+    );
+  });
+
+  it("refuses queue admission when a human source trailer is missing from the preview", () => {
+    // merge.sh already stops queue PRs that carry any source trailer; the
+    // composer must hold the same contract on its own.
+    const result = spawnSync(
+      process.execPath,
+      [join(process.cwd(), "scripts/pr-lib/merge-body.mjs"), "compose"],
+      {
+        encoding: "utf8",
+        input: JSON.stringify({
+          preview: "Repair\n\nCo-authored-by: Contributor <contributor@example.com>\n",
+          source: "Co-authored-by: Pair Partner <pair@example.com>\n",
+          authors: "contributor@example.com\n",
+          captured: "",
+          queue: true,
+        }),
+      },
+    );
+    expect(result.status).toBe(1);
+    expect(result.stdout).toBe("");
+    expect(result.stderr).toContain("Cannot queue");
   });
 
   it("keeps queue admission without a body override or source trailers", () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where landing a PR through `scripts/pr merge-run` refused GitHub's squash preview whenever any commit carried an agent attribution trailer (Claude, Codex, Cursor, Copilot, Amp, Trae), so maintainers had to hand-write a `--body-file` for every such PR. Landings that bypassed the wrapper, such as #126816 (665d4fadbd4), shipped `Co-authored-by: Claude <noreply@anthropic.com>` in the squash message, once in the trailer block and three more times inside the replayed commit bullets, against the repository rule to preserve human credit and never add agent attribution.

## Why This Change Was Made

The composer now drops machine credit from the default preview wherever GitHub replayed it (terminal trailer block, per-commit bullets, trailers folded onto indented continuation lines, indented key lines) and collapses the blank line it leaves behind. It still keeps preview credit backed by a non-merge commit author and appends every human `Co-authored-by` trailer found in the PR's commits, merge commits included. Reviewed `--body-file` bodies stay byte-preserved and are rejected when machine credit appears anywhere in them. Merge-queue PRs cannot take an override, so the composer refuses queue admission when the preview needs any edit or omits a required human trailer.

Machine identities are exact verified addresses plus GitHub App `[bot]` no-reply accounts, which cannot belong to a person. Copilot (three verified account ids), `claude[bot]`, `cursor[bot]`, the Codex connector bot, and `noreply@openai.com` join the existing list. Names and provider domains are never matched: people commit from `@openai.com` and `@anthropic.com` too. Commit authorship attribution is unchanged.

## User Impact

Maintainers can land PRs whose commits carry agent trailers without writing a body by hand, and the resulting squash message credits only humans. An operator who supplies a reviewed body gets a clear rejection when it still carries agent credit instead of a silently accepted message.

## Evidence

- Dry run of `scripts/pr-lib/merge-body.mjs compose` against the real four commits of #126816, using the actual merge body as the preview input. Before: the composer refused with `Squash message contains machine co-author credit; use --body-file`. After: all four Claude lines are removed and the trailer block is `ruel225` plus `zhang-guiping`.
- `pnpm test test/scripts/pr-merge.test.ts`: 103 passed (previously 78), driving the real `merge.sh` `prepare_squash_merge_body` path with fixture repositories, including a #126816-shaped fixture, folded, indented, and greedy-unfolding cases, explicit-body rejection, and merge-queue refusal.
- `pnpm check:changed` passes; `git diff --check` is clean.
- Four Codex autoreview rounds at P2 threshold: six findings fixed with regression tests; one rejected (a folded unsupported human credit inside GitHub's own terminal block, which GitHub writes one line per co-author, keeps the existing fail-closed error).

Known gap: agent accounts without a `[bot]` suffix, such as Copilot's user-type ids, are only caught by the explicit address list.
