### PR TITLE
fix(agents): recover final replies after terminated streams

### DIFF
--- a/src/agents/embedded-agent-runner/run/attempt-result.ts
+++ b/src/agents/embedded-agent-runner/run/attempt-result.ts
@@ -10,7 +10,10 @@ import {
 import { projectAgentRunAttemptTerminal } from "../../agent-run-terminal-outcome.js";
 import { isCloudCodeAssistFormatError } from "../../embedded-agent-helpers.js";
 import type { subscribeEmbeddedAgentSession } from "../../embedded-agent-subscribe.js";
-import { INCOMPLETE_ASSISTANT_STREAM_RE } from "../../failover/message-patterns.js";
+import {
+  INCOMPLETE_ASSISTANT_STREAM_RE,
+  TERMINATED_TRANSPORT_MESSAGE_RE,
+} from "../../failover/message-patterns.js";
 import type { AgentRuntimeModelAttempt } from "../../runtime-plan/types.js";
 import { markCoreTtsAttemptResult } from "../../tools/tts-tool-result-provenance.js";
 import { log } from "../logger.js";
@@ -117,7 +120,15 @@ function isTransientSettledTurnFailure(failure: unknown): boolean {
     typeof failure.message === "string"
       ? failure.message.trim()
       : "";
-  return INCOMPLETE_ASSISTANT_STREAM_RE.test(message);
+  // An exact `terminated` body-stream failure carries no retryable code, so the
+  // network classifier and the incomplete-stream wording both miss it. The
+  // failover timeout family already treats this transport failure as
+  // recoverable (#56875); the settled-turn context producer must agree so a
+  // completed tool batch keeps its isolated tool-free finalization instead of
+  // failing the whole run (#142149).
+  return (
+    INCOMPLETE_ASSISTANT_STREAM_RE.test(message) || TERMINATED_TRANSPORT_MESSAGE_RE.test(message)
+  );
 }
 
 function normalizeEmbeddedAttemptToolMetas(

--- a/src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.settled-turn-finalization-context.test.ts
@@ -72,6 +72,19 @@ describe("settled post-tool turn finalization context", () => {
       error: new Error("Stream ended without finish_reason"),
       captures: true,
     },
+    {
+      // Undici ends a stream body with this exact bare transport message (#142149).
+      kind: "terminated-transport-body",
+      error: new Error("terminated"),
+      captures: true,
+    },
+    {
+      // Only the exact transport message is recoverable; variants that merely
+      // contain the word keep failing closed like any other provider failure.
+      kind: "terminated-word-variant",
+      error: new Error("the request was terminated by the server"),
+      captures: false,
+    },
   ])("$kind final provider failure captures context=$captures", async ({ error, captures }) => {
     const result = await runSettledTurnWithFailedFinalCall(
       "agent:main:telegram:direct:settled",

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.provider-error.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.provider-error.test.ts
@@ -72,6 +72,26 @@ describe("prepared provider errors after settled tools", () => {
     );
   });
 
+  it("finalizes an exact terminated transport stream reported through the completed assistant", () => {
+    const base = createSettledProviderFailureAttempt({ terminal: { kind: "ok" } });
+    const assistant = base.currentAttemptCompletedAssistant;
+    if (!assistant) {
+      throw new Error("Missing failed assistant");
+    }
+    assistant.errorMessage = "terminated";
+    assistant.errorCode = undefined;
+    const attempt = projectSettledProviderFailureAttempt(base);
+    expect(attempt).toMatchObject({
+      terminal: { kind: "ok" },
+      settledTurnFinalizationContext: { source: "openclaw-transcript" },
+    });
+    const request = prepareRequest(attempt);
+    expect(request.payloadsWithToolMedia).toEqual([expect.objectContaining({ isError: true })]);
+    expect(resolveSettledTurnFinalizationRequest(request)).toContain(
+      "Do not repeat completed tool calls",
+    );
+  });
+
   it.each(["earlier user turn", "current commentary substring"])(
     "does not attribute current output to %s",
     (source) => {

--- a/src/agents/embedded-agent-runner/run/settled-turn-finalization.transport.test.ts
+++ b/src/agents/embedded-agent-runner/run/settled-turn-finalization.transport.test.ts
@@ -113,7 +113,7 @@ beforeEach(() => {
 });
 afterEach(() => admission.close());
 
-it.each(["HTTP", "WebSocket"])("finalizes after %s failure", async (failure) => {
+it.each(["HTTP", "WebSocket", "terminated"])("finalizes after %s failure", async (failure) => {
   const websocket = failure === "WebSocket";
   const apiKey = websocket ? syntheticLoopbackJwt() : "synthetic-loopback-key";
   const requests: Array<{ tools?: unknown[] }> = [];
@@ -126,6 +126,33 @@ it.each(["HTTP", "WebSocket"])("finalizes after %s failure", async (failure) => 
     request.on("end", () => {
       requests.push(JSON.parse(body));
       if (requests.length === 2) {
+        if (failure === "terminated") {
+          // Undici ends a prematurely closed SSE body with a bare
+          // `TypeError: "terminated"` — no retryable code and no recognized
+          // wording, so neither the network classifier nor the
+          // incomplete-stream pattern matches it (#142149).
+          response.writeHead(200, {
+            "content-type": "text/event-stream",
+            "cache-control": "no-store",
+          });
+          response.write(
+            `data: ${JSON.stringify({
+              type: "response.output_item.added",
+              output_index: 0,
+              item: {
+                type: "message",
+                id: "msg_cut",
+                role: "assistant",
+                status: "in_progress",
+                content: [],
+              },
+            })}\n\n`,
+            () => {
+              response.destroy();
+            },
+          );
+          return;
+        }
         response.writeHead(503, { "content-type": "application/json" });
         response.end(
           JSON.stringify({
@@ -234,7 +261,14 @@ it.each(["HTTP", "WebSocket"])("finalizes after %s failure", async (failure) => 
     }
     expect(assistant.stopReason).toBe("error");
     const error = Object.assign(new Error(assistant.errorMessage), { code: assistant.errorCode });
-    expect(isTransientNetworkError(error)).toBe(true);
+    if (failure === "terminated") {
+      // The bare transport message reaches the transcript unclassified; the
+      // recovery below must therefore come from the exact `terminated` match.
+      expect(assistant.errorMessage).toBe("terminated");
+      expect(isTransientNetworkError(error)).toBe(false);
+    } else {
+      expect(isTransientNetworkError(error)).toBe(true);
+    }
     expect(execute).toHaveBeenCalledOnce();
     expect(itemLifecycle).toEqual({ startedCount: 1, completedCount: 1, activeCount: 0 });
     const prefix = await readVisibleSessionTranscriptMessageEntries(target);

--- a/src/agents/failover/message-patterns.ts
+++ b/src/agents/failover/message-patterns.ts
@@ -41,6 +41,9 @@ export function isProviderRequestSizeCeilingError(errorMessage?: string): boolea
 // match — those are not assistant-stream contracts.
 export const INCOMPLETE_ASSISTANT_STREAM_RE =
   /^[\w -]*stream ended (?:before (?:message_?stop|(?:a )?terminal (?:finish reason|response event|event))|without (?:a terminal )?finish[_ ]reason)[.!]?$/i;
+// Undici ends a stream body with this exact bare transport message. Keep it
+// anchored so unrelated failures that merely contain the word do not match.
+export const TERMINATED_TRANSPORT_MESSAGE_RE = /^terminated$/i;
 const PERIODIC_USAGE_LIMIT_RE =
   /\b(?:daily|weekly|monthly)(?:\/(?:daily|weekly|monthly))* (?:usage )?limit(?:s)?(?: (?:exhausted|reached|exceeded))?\b/i;
 
@@ -221,7 +224,7 @@ const ERROR_PATTERNS = {
     // 502 served with an empty body, socket reset mid-response, body-stream
     // aborted). These arrive as bare strings on the outer error and, without
     // an explicit match, the fallback chain is never attempted (#69368).
-    /^terminated$/i,
+    TERMINATED_TRANSPORT_MESSAGE_RE,
     /^stream_read_error$/i,
     /\bund_err_(?:socket|connect|headers?|body|req_content_length_mismatch|aborted|closed)\b/i,
     // shared model runtime's openai provider surfaces `Request failed` when the HTTP

--- a/src/agents/harness/builtin-openclaw.test.ts
+++ b/src/agents/harness/builtin-openclaw.test.ts
@@ -16,6 +16,11 @@ describe("createOpenClawAgentHarness", () => {
     runEmbeddedAttempt.mockImplementation(async (params: EmbeddedRunAttemptParams) => {
       params.onAttemptDeadlineChanged?.({ kind: "bounded", deadlineAtMs: 123_456 });
       params.onAttemptTimeoutArmed?.();
+      await params.onAgentEvent?.({ stream: "lifecycle", data: { phase: "start" } });
+      await params.onAgentEvent?.({
+        stream: "lifecycle",
+        data: { phase: params.deferTerminalLifecycle ? "finishing" : "end" },
+      });
       return {
         terminal: { kind: "ok" },
         sessionIdUsed: "session-1",
@@ -67,10 +72,11 @@ describe("createOpenClawAgentHarness", () => {
     expect(runEmbeddedAttempt).toHaveBeenCalledWith(params);
   });
 
-  it("enforces tool-free finalization while forwarding execution deadline notifications", async () => {
+  it("enforces tool-free finalization while forwarding execution and lifecycle notifications", async () => {
     const prepareAssistantTranscriptMessage = vi.fn();
     const onAttemptDeadlineChanged = vi.fn();
     const onAttemptTimeoutArmed = vi.fn();
+    const onAgentEvent = vi.fn<NonNullable<EmbeddedRunAttemptParams["onAgentEvent"]>>();
     const attempt = {
       prompt: "finalize",
       disableTools: false,
@@ -82,6 +88,8 @@ describe("createOpenClawAgentHarness", () => {
       onPartialReply: vi.fn(),
       onAttemptDeadlineChanged,
       onAttemptTimeoutArmed,
+      onAgentEvent,
+      deferTerminalLifecycle: true,
       prepareAssistantTranscriptMessage,
     } as never;
     const harness = createOpenClawAgentHarness();
@@ -93,6 +101,10 @@ describe("createOpenClawAgentHarness", () => {
       deadlineAtMs: 123_456,
     });
     expect(onAttemptTimeoutArmed).toHaveBeenCalledOnce();
+    expect(onAgentEvent.mock.calls).toEqual([
+      [{ stream: "lifecycle", data: { phase: "start" } }],
+      [{ stream: "lifecycle", data: { phase: "finishing" } }],
+    ]);
     expect(runEmbeddedAttempt).toHaveBeenCalledWith(
       expect.objectContaining({
         prompt: "finalize",

--- a/src/agents/harness/builtin-openclaw.ts
+++ b/src/agents/harness/builtin-openclaw.ts
@@ -46,6 +46,9 @@ function buildRestrictedFinalizationAttempt(
     onExecutionPhase: attempt.onExecutionPhase,
     onLaneWait: attempt.onLaneWait,
     onRunProgress: attempt.onRunProgress,
+    // The caller owns terminal publication across the failed and finalizing attempts.
+    onAgentEvent: attempt.onAgentEvent,
+    deferTerminalLifecycle: attempt.deferTerminalLifecycle,
     onAttemptTimeoutArmed: attempt.onAttemptTimeoutArmed,
     onAttemptDeadlineChanged: attempt.onAttemptDeadlineChanged,
     onAttemptTimeout: attempt.onAttemptTimeout,


### PR DESCRIPTION
AI-assisted: yes

Related: #142149

## What Problem This Solves

Fixes an issue where a completed tool-driven turn loses its final reply when the provider stream ends with bare `terminated` after the ordinary retry window has elapsed. The turn reports `LLM request timed out` even though its run timeout did not fire.

## Why This Change Was Made

Reuse the existing anchored transport-message pattern when capturing settled-turn context. Preserve the caller's lifecycle callback and terminal deferral through the built-in finalizer, so the recovered answer ends the run successfully instead of retaining the prior attempt's error.

The normal transcript-continuation path, timeout-family classification, exact tool-settlement checks, cancellation, refusal and permanent-error guards remain unchanged. The finalizer still has no callable tools.

## User Impact

Eligible completed turns retain their final summary without repeating tool effects. Asynchronous or unfinished work, previously visible answers and unsettled delivery remain excluded.

## Evidence

The real authenticated Gateway proof uses `chat.send` and `agent.wait`, the built-in file tool, an actual interrupted HTTP response body and the built-in finalizer. An initial transient failure starts the existing retry window; the later post-tool stream closes after that window expires. The fixture does not disable retries or change timeout policy.

- Baseline `82d4e9a`: one completed write, persisted `terminated`, no final answer, and the existing timeout-family error.
- The ordinary single-cut continuation control still answers with one write.
- All three new context/transport regressions failed at the intended boundary before the fix; 834 focused checks passed after the context repair.
- The connected lifecycle regression failed because the callback was dropped; 35 lifecycle, cancellation and harness checks passed after forwarding the existing caller fields.

Candidate `96d2cfe4` passes the real late-cut Gateway flow: the existing finalizer sends one request with no callable tools, `agent.wait` returns success, history contains one final answer, the original message prefix is unchanged, and the only added message is the final answer. Normal cache bookkeeping remains separate from messages. The completed write is not repeated.

Fresh source-blind native acceptance independently passed both the late-cut recovery and ordinary-continuation controls on `96d2cfe4`. The full negative-state and source-mechanism gates are covered separately by focused tests and source review. Exact-head hosted CI and the final review gate remain required before landing.

Limits: the provider is a deterministic loopback service. This does not certify a live Windows llama.cpp/llama-swap deployment or make every background-download run eligible. Private internal flags/context are supported by source and observed lifecycle evidence, not claimed as directly exported fields.
