### PR TITLE
fix(gateway): config edits fail after successful agent mutations

### DIFF
--- a/src/gateway/config-get-response.ts
+++ b/src/gateway/config-get-response.ts
@@ -52,8 +52,8 @@ export async function readConfigGetResponse(params: {
   }
   const appliedConfigHash = getRuntimeConfigAppliedHash();
   const pluginRegistryVersion = getActivePluginRegistryVersion();
-  // With an active watcher, cache hits never re-read the file. External edits
-  // become visible after its successful commit; the write path invalidates early.
+  // With an active watcher, cache hits never re-read the file. Candidate
+  // observation invalidates persisted bytes before runtime acceptance.
   if (
     configGetResponseCache?.getHotReloadStatus === getHotReloadStatus &&
     configGetResponseCache.revisionProjector === params.revisionProjector &&
@@ -87,7 +87,7 @@ export async function readConfigGetResponse(params: {
   }
 }
 
-/** Invalidates cached config.get work after the watcher accepts a config candidate. */
+/** Invalidates cached config.get work when the watcher observes or accepts a candidate. */
 export function invalidateConfigGetResponseCache(): void {
   configGetResponseCache = undefined;
 }

--- a/src/gateway/server-methods/config-write-flow.ts
+++ b/src/gateway/server-methods/config-write-flow.ts
@@ -24,7 +24,6 @@ import { captureGatewayRootWorkAdmissionContinuationScope } from "../../process/
 import { getActiveSecretsRuntimeSnapshotState } from "../../secrets/runtime-state.js";
 import { isRecord } from "../../utils.js";
 import { resolveGatewayAuth } from "../auth.js";
-import { invalidateConfigGetResponseCache } from "../config-get-response.js";
 import { buildGatewayReloadPlan, isNoopGatewayReloadPlan } from "../config-reload-plan.js";
 import { resolveGatewayReloadSettings } from "../config-reload-settings.js";
 import { formatControlPlaneActor, type ControlPlaneActor } from "../control-plane-audit.js";
@@ -268,9 +267,6 @@ export async function commitGatewayConfigWrite(params: {
     ),
     afterWrite: { mode: "auto" },
   });
-  // Watcher acceptance is debounced; clear now so the writer's immediate
-  // follow-up config.get observes the committed bytes before that hook runs.
-  invalidateConfigGetResponseCache();
   return {
     path: resolveGatewayConfigPath(params.snapshot),
     config: result.nextConfig,

--- a/src/gateway/server-reload-managed.ts
+++ b/src/gateway/server-reload-managed.ts
@@ -375,7 +375,11 @@ export function startManagedGatewayConfigReloader(
     readSnapshot: params.readSnapshot,
     promoteSnapshot: async (snapshot, _reason) => await params.promoteSnapshot(snapshot),
     subscribeToWrites: params.subscribeToWrites,
-    onConfigCandidateObserved: pauseGatewayRestartForConfigCandidate,
+    onConfigCandidateObserved: () => {
+      // Every writer must expose persisted revisions before runtime acceptance.
+      invalidateConfigGetResponseCache();
+      pauseGatewayRestartForConfigCandidate();
+    },
     onConfigChange: (plan, nextConfig) => {
       assertIrreversibleReloadPlanHasRecoveryOwner(plan, restartRecoveryAvailable);
       params.prepareTerminalConfig(plan, applyRuntimeConfigOverrides(nextConfig));

--- a/src/gateway/server.config-patch.test.ts
+++ b/src/gateway/server.config-patch.test.ts
@@ -24,6 +24,25 @@ import { GatewayClient, GatewayClientRequestError } from "./client.js";
 import { invalidateConfigGetResponseCache } from "./config-get-response.js";
 import { startGatewayServerCore } from "./server-start.js";
 
+const reloadBarrier = vi.hoisted(() => ({ wait: undefined as Promise<void> | undefined }));
+
+vi.mock("./config-reload.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./config-reload.js")>();
+  return {
+    ...actual,
+    startGatewayConfigReloader: (
+      options: Parameters<typeof actual.startGatewayConfigReloader>[0],
+    ) =>
+      actual.startGatewayConfigReloader({
+        ...options,
+        onHotReload: async (...args) => {
+          await reloadBarrier.wait;
+          return await options.onHotReload(...args);
+        },
+      }),
+  };
+});
+
 const CONFIG_SECRETREF_RPC_TIMEOUT_MS = 20_000;
 const GATEWAY_TOKEN = "config-rpc-synthetic-token";
 
@@ -414,6 +433,39 @@ describe("gateway config methods", () => {
     expect(res.error?.message ?? "").toContain("active SecretRef resolution failed");
     const afterHash = await getConfigHash();
     expect(afterHash).toBe(current.hash);
+  });
+
+  it("uses fresh revisions after agent create, update, and delete before reload applies", async () => {
+    vi.mocked(Date.now).mockRestore();
+    const operations = [
+      {
+        method: "agents.create",
+        params: { name: "revision-worker", workspace: state.path("revision-workspace") },
+      },
+      { method: "agents.update", params: { agentId: "revision-worker", name: "Ready" } },
+      { method: "agents.delete", params: { agentId: "revision-worker", deleteFiles: false } },
+    ];
+    for (const operation of operations) {
+      const before = await getConfigHash();
+      const gate = createDeferredCore();
+      reloadBarrier.wait = gate.promise;
+      try {
+        const changed = await rpcReq(requireClient(), operation.method, operation.params);
+        expect(changed.ok, changed.error?.message).toBe(true);
+
+        const current = await getCurrentConfigObject();
+        gate.resolve();
+        const patched = await rpcReq(requireClient(), "config.patch", {
+          baseHash: current.hash,
+          raw: JSON.stringify({ agents: { entries: { main: { name: operation.method } } } }),
+        });
+        expect(patched.ok, patched.error?.message).toBe(true);
+        expect(current.hash).not.toBe(before);
+      } finally {
+        gate.resolve();
+        reloadBarrier.wait = undefined;
+      }
+    }
   });
 
   it("round-trips config.set and returns the live config path", async () => {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where clients creating, updating, or deleting an agent could immediately read an old configuration revision and then have their next `config.patch` rejected with `config changed since last load; re-run config.get and retry`, despite no competing writer.

## Why This Change Was Made

Invalidate the configuration read cache when the managed reloader observes persisted writes. This shared boundary covers agent mutations, configuration RPCs, and file-watcher observations. Remove the configuration-RPC-only exception while keeping committed notifications and applied-runtime tracking separate.

## User Impact

A fresh `config.get` exposes the persisted revision before runtime reload finishes. Clients can use that revision for their next conditional edit. Genuine stale edits still fail, and `config.patch` still waits for its exact runtime application before acknowledging success.

## Evidence

A real source Gateway and authenticated WebSocket client exercised both pinned main `d559bcda4f9d45ee0c610c8e109e80ffdbb8fcd5` and candidate `c3ce9d1dec75eeafba4dc4cae0e3439a09b26efe` on one isolated Testbox. A documented local SecretRef resolver held normal runtime preparation after persistence. No Gateway implementation was replaced, and no external provider, channel, service, or production credential was used.

| Operation | Baseline fresh read while preparation is held | Candidate fresh read while preparation is held |
| --- | --- | --- |
| `agents.create` | Old persisted revision; follow-up patch rejected | New persisted revision; follow-up patch succeeds after release |
| `agents.update` | Old persisted revision; follow-up patch rejected | New persisted revision; follow-up patch succeeds after release |
| `agents.delete` | Old persisted revision; follow-up patch rejected | New persisted revision; follow-up patch succeeds after release |
| External watched file edit | Old persisted revision | New persisted revision |
| Direct `config.set` | New persisted revision | New persisted revision |

Observed candidate RPC sequence, with opaque revisions renamed for privacy:

```text
config.get                         -> hash R0, applied A0
agents.create                      -> success; disk now R1
runtime preparation                -> held
config.get                         -> hash R1, resolved A1, applied A0
config.patch(baseHash: R0)          -> INVALID_REQUEST: config changed since last load
config.patch(baseHash: R1)          -> pending while preparation is held
release runtime preparation
config.patch                       -> success
config.changed                     -> final committed revision R2, once
config.get                         -> persisted and applied revisions converge
```

Update and delete produced the same fresh-read and guarded-write results. The public raw-revision tokens matched separately measured file bytes using the existing installation projection; the key was never exported. No `config.changed` event arrived during the hold. A superseded candidate emitted no committed event; only its replacement did.

Invalid configuration and an injected strict preparation failure did not become applied runtime revisions or emit committed events. Restoring valid preparation and making a new observed edit recovered normally. A genuine competing write still rejected the older token. Sensitive values and secret references stayed redacted in RPC output.

All 805 focused Gateway configuration, cache, reload, and lifecycle tests passed, including the 53-test configuration-RPC file. Formatting and changed-file lint passed. These checks also cover redaction, included-file preservation, conditional guards, and explicit replacement paths.

A fresh source-blind run independently confirmed the core persisted-read, stale-write, watcher, event, supersession, and failure-recovery outcomes. Its broader source-only and unexercised negative controls remain explicitly separated from live passes. Full private RPC, file-hash, resolver, event, and Gateway traces are retained. AI-assisted.
