### PR TITLE
fix(gateway): recover stuck one-way restart drain after a failed SIGUSR1 handler

### DIFF
--- a/src/cli/gateway-cli/lifecycle.runtime.ts
+++ b/src/cli/gateway-cli/lifecycle.runtime.ts
@@ -14,6 +14,7 @@ export {
   isGatewaySigusr1RestartExternallyAllowed,
   markGatewaySigusr1RestartHandled,
   peekGatewaySigusr1RestartReason,
+  recoverGatewayRestartDrainAfterFailedSignalAdmission,
   resetGatewayRestartStateForInProcessRestart,
   requestGatewayRestartWithSignalAdmission,
   rollbackGatewayRestartSignalAdmission,

--- a/src/cli/gateway-cli/run-loop.test.ts
+++ b/src/cli/gateway-cli/run-loop.test.ts
@@ -54,6 +54,7 @@ const resetGatewaySuspendCoordinatorForLifecycleRestart = vi.fn();
 const consumeGatewaySuspendHandoff =
   vi.fn<typeof import("../../infra/gateway-suspend-coordinator.js").consumeGatewaySuspendHandoff>();
 const disarmGatewaySuspendHandoff = vi.fn();
+const recoverGatewayRestartDrainAfterFailedSignalAdmission = vi.fn();
 const rollbackGatewayRestartSignalAdmission = vi.fn();
 const requestGatewayRestartWithSignalAdmission = vi.fn(() => ({ status: "emitted" as const }));
 const writeGatewayRestartHandoffSync = vi.fn(
@@ -197,6 +198,8 @@ vi.mock("../../infra/restart.js", async (importOriginal) => {
     peekGatewaySigusr1RestartReason: () => peekGatewaySigusr1RestartReason(),
     resetGatewayRestartStateForInProcessRestart: () =>
       resetGatewayRestartStateForInProcessRestart(),
+    recoverGatewayRestartDrainAfterFailedSignalAdmission: () =>
+      recoverGatewayRestartDrainAfterFailedSignalAdmission(),
     rollbackGatewayRestartSignalAdmission: () => rollbackGatewayRestartSignalAdmission(),
     requestGatewayRestartWithSignalAdmission,
     scheduleGatewaySigusr1Restart: (opts?: { delayMs?: number; reason?: string }) =>
@@ -3617,7 +3620,7 @@ describe("runGatewayLoop", () => {
         "SIGUSR1 handler failed: lifecycle module corrupted",
       );
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalled();
-      expect(rollbackGatewayRestartSignalAdmission).toHaveBeenCalledOnce();
+      expect(recoverGatewayRestartDrainAfterFailedSignalAdmission).toHaveBeenCalledOnce();
       expect(close).not.toHaveBeenCalled();
       expect(start).toHaveBeenCalledTimes(1);
 
@@ -3653,7 +3656,7 @@ describe("runGatewayLoop", () => {
       // Restart token must be cleared so future SIGUSR1 restarts are not
       // permanently coalesced as "already in-flight".
       expect(markGatewaySigusr1RestartHandled).toHaveBeenCalled();
-      expect(rollbackGatewayRestartSignalAdmission).toHaveBeenCalledOnce();
+      expect(recoverGatewayRestartDrainAfterFailedSignalAdmission).toHaveBeenCalledOnce();
       expect(close).not.toHaveBeenCalled();
       expect(start).toHaveBeenCalledTimes(1);
 
@@ -3675,8 +3678,8 @@ describe("runGatewayLoop", () => {
 
       sigusr1();
       await waitForLoopCondition(
-        () => rollbackGatewayRestartSignalAdmission.mock.calls.length === 1,
-        "failed SIGUSR1 handler did not roll back restart admission",
+        () => recoverGatewayRestartDrainAfterFailedSignalAdmission.mock.calls.length === 1,
+        "failed SIGUSR1 handler did not recover restart admission",
       );
 
       sigusr1();

--- a/src/cli/gateway-cli/run-loop.ts
+++ b/src/cli/gateway-cli/run-loop.ts
@@ -1176,7 +1176,12 @@ export async function runGatewayLoop(params: {
         // Best-effort: the eager reference itself is the recovery path.
       }
       try {
-        eagerLifecycleRuntime.rollbackGatewayRestartSignalAdmission();
+        // No restart will arrive to reset runtime state, so a drain marked
+        // before the failure must be recovered here: the reversible-fence
+        // rollback is a no-op once one-way drain owns admission, which would
+        // leave this surviving process refusing all new root and subordinate
+        // work (subagents, plugin relays, queued commands) for its lifetime.
+        eagerLifecycleRuntime.recoverGatewayRestartDrainAfterFailedSignalAdmission();
         // A later signal must repeat the synchronous close transition even if
         // this handler failed after marking the one-way drain.
         restartDrainingMarked = false;

--- a/src/infra/restart.ts
+++ b/src/infra/restart.ts
@@ -13,6 +13,7 @@ import {
   beginGatewayRestartSignalAdmission,
   getActiveGatewayRootWorkCount,
   isGatewayRestartDraining,
+  recoverGatewayRestartDrainAfterFailedSignal,
   rollbackGatewayRestartSignalFence,
   runWithGatewayIndependentRootWorkAdmission,
   type GatewayRestartSignalAdmissionLease,
@@ -91,6 +92,16 @@ function clearPendingRestartSignalAdmission(): boolean {
 /** Releases a signal fence when the run loop rejects or fails to handle the signal. */
 export function rollbackGatewayRestartSignalAdmission(): boolean {
   return clearPendingRestartSignalAdmission();
+}
+
+/**
+ * Recovers admission when a restart handler failed after marking the one-way
+ * drain, so the surviving process would otherwise refuse new work forever.
+ * Reversible fences are released first; only a stuck one-way drain escalates.
+ */
+export function recoverGatewayRestartDrainAfterFailedSignalAdmission(): boolean {
+  clearPendingRestartSignalAdmission();
+  return recoverGatewayRestartDrainAfterFailedSignal();
 }
 
 function armPendingRestartTimer(requestedDueAt: number, nowMs: number): void {

--- a/src/process/gateway-work-admission.test.ts
+++ b/src/process/gateway-work-admission.test.ts
@@ -16,6 +16,7 @@ import {
   isGatewayWorkAdmissionClosed,
   markGatewayRestartDraining,
   onGatewaySuspendAdmissionChange,
+  recoverGatewayRestartDrainAfterFailedSignal,
   retainGatewayRootWorkAdmissionContinuation,
   resetGatewayWorkAdmission,
   rollbackGatewayRestartSignalFence,
@@ -696,4 +697,67 @@ it("does not wake deferred internal work into a restart drain", async () => {
   markGatewayRestartDraining();
 
   await expect(pending).rejects.toBeInstanceOf(GatewayDrainingError);
+});
+
+it("recovers stuck one-way drain when a restart handler failed after marking it", () => {
+  markGatewayRestartDraining();
+  // The reversible-fence rollback cannot recover a one-way drain, which is how
+  // a failed restart handler used to wedge admission for the process lifetime.
+  expect(rollbackGatewayRestartSignalFence()).toBe(false);
+  expect(isGatewayWorkAdmissionClosed()).toBe(true);
+  expect(isGatewaySubordinateWorkAdmissionClosed()).toBe(true);
+
+  expect(recoverGatewayRestartDrainAfterFailedSignal()).toBe(true);
+
+  expect(isGatewayWorkAdmissionClosed()).toBe(false);
+  expect(isGatewaySubordinateWorkAdmissionClosed()).toBe(false);
+  // New work must admit again, and observe a fresh (unaborted) drain signal.
+  expect(getGatewayRestartDrainSignal().aborted).toBe(false);
+  const admitted = tryBeginGatewayRootWorkAdmission("after-failed-restart");
+  expect(admitted?.ownsRoot).toBe(true);
+  admitted?.release();
+});
+
+it("recovers a failed restart drain that superseded a suspension", () => {
+  const suspension = tryBeginGatewaySuspendAdmission(() => {});
+  expect(suspension?.commit()).toBe(true);
+  // Marking the drain supersedes the suspension, so the failed restart leaves
+  // the drain as the only thing holding admission closed.
+  markGatewayRestartDraining();
+  expect(getGatewaySuspendAdmissionPhase()).toBe("accepting");
+
+  expect(recoverGatewayRestartDrainAfterFailedSignal()).toBe(true);
+
+  expect(isGatewayWorkAdmissionClosed()).toBe(false);
+  const admitted = tryBeginGatewayRootWorkAdmission("after-superseded-suspension");
+  expect(admitted?.ownsRoot).toBe(true);
+  admitted?.release();
+});
+
+it("reopens a stuck restart drain for a live suspension owner", () => {
+  markGatewayRestartDraining();
+  expect(recoverGatewayRestartDrainAfterFailedSignal()).toBe(true);
+
+  // Recovery restores normal admission control: a later suspension can close
+  // admission again and release it on its own terms.
+  const suspension = tryBeginGatewaySuspendAdmission(() => {});
+  expect(suspension?.commit()).toBe(true);
+  expect(isGatewayWorkAdmissionClosed()).toBe(true);
+  expect(suspension?.release()).toBe(true);
+  expect(isGatewayWorkAdmissionClosed()).toBe(false);
+});
+
+it("leaves a committed restart drain one-way for the reset boundary", () => {
+  markGatewayRestartDraining();
+  const signal = getGatewayRestartDrainSignal();
+  expect(signal.aborted).toBe(true);
+
+  // A committed restart never calls the failed-signal recovery; it resets
+  // runtime state instead, so the drain stays closed until that boundary.
+  expect(isGatewayWorkAdmissionClosed()).toBe(true);
+  markGatewayRestartDraining();
+  expect(isGatewayWorkAdmissionClosed()).toBe(true);
+
+  resetGatewayWorkAdmission();
+  expect(isGatewayWorkAdmissionClosed()).toBe(false);
 });

--- a/src/process/gateway-work-admission.ts
+++ b/src/process/gateway-work-admission.ts
@@ -9,7 +9,7 @@ import { resolveGlobalSingleton } from "../shared/global-singleton.js";
 type GatewaySuspendAdmissionPhase = GatewaySuspension["phase"];
 
 type AdmissionCloseReason = "restart-signal fence" | "restart drain" | "suspend phase";
-type AdmissionReopenReason = "restart-signal fence" | "suspend phase";
+type AdmissionReopenReason = "restart-signal fence" | "suspend phase" | "failed restart drain";
 
 export class GatewayDrainingError extends Error {
   constructor(message = "Gateway is draining; new tasks are not accepted") {
@@ -305,6 +305,42 @@ export function beginGatewayRestartSignalAdmission(): GatewayRestartSignalAdmiss
  */
 export function rollbackGatewayRestartSignalFence(): boolean {
   return clearRestartSignalFence();
+}
+
+/**
+ * Reopens admission after a restart handler failed *after* marking the one-way
+ * drain, so no in-process restart will arrive to reset runtime state.
+ *
+ * `rollbackGatewayRestartSignalFence` cannot recover this: it is a documented
+ * no-op once one-way drain owns admission. Without this escape hatch the
+ * surviving process keeps `restartDraining` set for its whole lifetime and
+ * silently refuses every new root and subordinate work item, while already
+ * admitted work still completes -- so the gateway looks healthy and only
+ * newly submitted work (subagents, plugin relays, queued commands) fails with
+ * `GatewayDrainingError`.
+ *
+ * Only failed-restart recovery may call this. A committed restart must keep the
+ * one-way guarantee and reset state through `resetGatewayWorkAdmission`.
+ */
+export function recoverGatewayRestartDrainAfterFailedSignal(): boolean {
+  if (!GATEWAY_WORK_ADMISSION_STATE.restartDraining) {
+    return clearRestartSignalFence();
+  }
+  GATEWAY_WORK_ADMISSION_STATE.restartDraining = false;
+  GATEWAY_WORK_ADMISSION_STATE.restartSignalPending = false;
+  GATEWAY_WORK_ADMISSION_STATE.restartSignalGeneration += 1;
+  // The old controller stays aborted: work that already observed the drain
+  // signal must not be resurrected. Later admissions get a fresh signal.
+  GATEWAY_WORK_ADMISSION_STATE.restartDrainController = new AbortController();
+  resolveSuspendOpenWaiters();
+  if (GATEWAY_WORK_ADMISSION_STATE.suspendPhase === "accepting") {
+    logAdmissionReopened("failed restart drain");
+  } else {
+    admissionLog.info(
+      "restart drain recovered after failed restart signal; suspension remains closed",
+    );
+  }
+  return true;
 }
 
 /** Root RPC/timer admission. Nested work in the same async chain counts once. */


### PR DESCRIPTION
## What Problem This Solves

A gateway process can permanently refuse all newly submitted work while still looking healthy.

When the `SIGUSR1` restart handler in `runGatewayLoop` rejects *after* `markRestartDraining()` has already closed process-wide admission, no in-process restart arrives, so `resetAllLanes()` / `resetGatewayWorkAdmission()` never runs. The handler's recovery path called `rollbackGatewayRestartSignalAdmission()`, which only clears the **reversible** signal fence — `clearRestartSignalFence()` returns early and is documented as a "no-op while one-way restart drain owns admission".

The result: the surviving process keeps `restartDraining = true` for its entire lifetime.

Because already-admitted root work still completes, the failure is very hard to diagnose:

- `gateway call health` reports healthy, and interactive turns keep answering.
- Every *newly submitted* item — subagents, plugin relays, queued commands — fails with `Gateway is draining; new tasks are not accepted`.
- Only `admission closed: restart drain` appears in the log, with no matching reopen and no restart afterwards.
- Restarting the gateway is the sole workaround, since the flag is a `globalThis` singleton with no persistence.

Operationally this surfaced as a Google Meet realtime agent whose node-relay consults were refused for hours while the same agent answered correctly when invoked directly (`openclaw agent --agent <id>`), because that path was already-admitted root work.

The local mirror `restartDrainingMarked` **is** reset in that handler, and its comment states the intent ("a later signal must repeat the synchronous close transition even if this handler failed after marking the one-way drain") — but the global admission state has no matching recovery, so intent and behaviour diverge.

## What This Changes

- Adds `recoverGatewayRestartDrainAfterFailedSignal()` to `src/process/gateway-work-admission.ts`: an explicit escape hatch that clears a stuck one-way drain, replaces the aborted drain controller so recovered admissions observe a fresh signal (never a pre-aborted one), and falls back to the reversible-fence clear when no one-way drain is set.
- Wires it through `recoverGatewayRestartDrainAfterFailedSignalAdmission()` (`src/infra/restart.ts`) and the lifecycle runtime re-export, and calls it from the failed-`SIGUSR1` recovery path in `src/cli/gateway-cli/run-loop.ts`.
- Keeps the one-way guarantee intact for committed restarts: they continue to reset state through the existing `resetGatewayWorkAdmission()` boundary. Only failed-restart recovery may call the new function, which is stated in its doc comment.

## Evidence

Targeted tests added to `src/process/gateway-work-admission.test.ts`:

- `recovers stuck one-way drain when a restart handler failed after marking it` — asserts the old path cannot recover (`rollbackGatewayRestartSignalFence()` returns `false` while both `isGatewayWorkAdmissionClosed()` and `isGatewaySubordinateWorkAdmissionClosed()` stay `true`), then that recovery reopens admission, exposes a non-aborted drain signal, and admits new root work.
- `recovers a failed restart drain that superseded a suspension` — covers a drain that invalidated a live suspension.
- `reopens a stuck restart drain for a live suspension owner` — after recovery, normal suspension control still closes and releases admission.
- `leaves a committed restart drain one-way for the reset boundary` — regression guard that a committed restart stays closed until `resetGatewayWorkAdmission()`.

Local validation on Node v26.8.1 / pnpm 12.3.4:

```
pnpm vitest run src/process/gateway-work-admission.test.ts \
  src/infra/restart-suspension.test.ts \
  src/infra/restart.deferral-timeout.test.ts
  -> Test Files 3 passed (3) | Tests 57 passed (57)

pnpm vitest run src/infra/gateway-suspend-coordinator.test.ts src/process/command-queue.test.ts
  -> included in the 87-passing run across restart/queue lanes

pnpm run tsgo:prod        -> clean
pnpm run tsgo:test:root   -> clean
pnpm exec oxfmt --check <changed files>  -> all correctly formatted
npx oxlint <changed files>               -> 0 warnings, 0 errors
```

One iteration of `pnpm check` surfaced a real typing issue in an earlier draft (`AdmissionReopenReason` did not allow the new log reason); that is fixed by extending the union with `"failed restart drain"`, and `tsgo:prod` is clean. A full `pnpm check` run was not completed locally — it stalled at ~0.2% CPU on this machine after the typecheck lane, so the lanes covering the touched surface were run individually as shown above.

Diff is 5 files, +119/−2, with no behaviour change on the committed-restart path.

Refs #140455
