### PR TITLE
improve: shorten cloud desktop startup

### DIFF
--- a/extensions/crabbox/src/crabbox-worker-provider.test.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.test.ts
@@ -2085,6 +2085,7 @@ describe("Crabbox worker provider", () => {
       }),
     ).toBe(149 * 60_000 + 15_000);
     expect(setupOrder).toEqual(["desktop", "enrollment"]);
+    expect(calls.filter(({ argv }) => argv[1] === "inspect")).toHaveLength(1);
   });
 
   it.each(["desktop setup", "enrollment preparation", "enrollment completion"] as const)(
@@ -2650,7 +2651,7 @@ describe("Crabbox worker provider", () => {
     expect(calls.filter((argv) => argv[1] === "warmup")).toHaveLength(2);
     expect(
       calls.filter((argv) => argv[1] === "inspect").map((argv) => argv[argv.indexOf("--id") + 1]),
-    ).toEqual([LEASE_ID, LEASE_ID]);
+    ).toEqual([LEASE_ID]);
     expect(calls.at(-1)).toEqual([SIBLING_BINARY, "stop", "--provider", "aws", "--id", LEASE_ID]);
   });
 

--- a/extensions/crabbox/src/crabbox-worker-provider.ts
+++ b/extensions/crabbox/src/crabbox-worker-provider.ts
@@ -347,11 +347,11 @@ export function createCrabboxWorkerProvider(
         });
       }
       if (parsed.desktop) {
-        inspectedParams.inspect = await runProvisionSetupAndWaitReady({
+        // Desktop launchers and XFCE configuration leave SSH and lease metadata unchanged.
+        await runProvisionSetup({
           ...inspectedParams,
           phase: "desktop setup",
           setup: createCrabboxWorkerDesktopSetup(leaseId, wallpaperBase64),
-          sleep,
         });
       }
       if (project && warmImages.lookupLease(leaseId)?.phase !== "enrolled") {


### PR DESCRIPTION
## What Problem This Solves

Cloud desktop startup performs an unnecessary provider request after OpenClaw installs its desktop launchers and configures XFCE. This adds a serial cloud round trip before node enrollment.

## Why This Change Was Made

Use the existing setup command owner without re-inspecting the lease after this trusted script. The script changes only launchers, wallpaper, and the worker-owned XFCE renderer; it does not change SSH, networking, or lease security metadata. Initial readiness/security checks, refresh after operator-provided setup, and refresh after native image capture remain intact. Cancellation and failure cleanup keep the same owner.

## User Impact

Desktop sessions issue one fewer provider inspection during startup. This makes no configuration, storage, authorization, or desktop appearance changes. It does not establish a ten-second end-to-end startup guarantee.

## Evidence

- Five existing desktop cases fail before the change on the extra inspection and pass after it.
- 294 provider, cancellation, project, and cleanup tests pass on the refreshed candidate.
- The full changed-file gate passes in the ordinary source checkout: production/test typechecks, lint, dead-export scan, database guard, and import-cycle checks. The linked checkout correctly refused external dependencies; verification used the ordinary checkout without bypassing that guard.
- Fresh independent review found no actionable P0–P2 issues.
- Exact-head CI passed on the unchanged commit after one failed-jobs rerun. The original failures were self-hosted runners losing communication with no recorded steps; no code or checks were changed to obtain green CI.
- Two baseline live AWS desktop-session attempts failed before this desktop setup path: first during provisioning, then during profile setup on a coordinator HTTP 500/error 1101. Both test leases are released with cleanup complete and allocation pins absent. The coordinator also logged correlated internal Durable Object storage resets. These failed runs are not candidate CUA/WebVNC proof, and no measured end-to-end speedup is claimed.

Maintainer review disposition: the startup benefit established here is one fewer provider invocation, not a measured end-to-end timing claim. The complete trusted desktop script is unchanged and cannot alter SSH or lease metadata; initial inspection and refreshes after operator setup and native capture remain. The before/after request-count regressions, full changed-file gate, full build, and exact-head CI support landing this bounded optimization. Successful cloud CUA/WebVNC verification remains an explicit task-level gap following the upstream failures.
