### PR TITLE
fix(status): show available Gateway self metadata

### DIFF
--- a/docs/cli/status.md
+++ b/docs/cli/status.md
@@ -101,6 +101,8 @@ Use `openclaw skills check --agent <id>` to inspect the missing requirements.
 
 - Overview includes Gateway + node host service install/runtime status when
   available, plus compact Gateway process uptime and host system uptime.
+- `status --all` shows returned host, IP, version, and platform in **Gateway self**.
+  It uses `unknown` only when those fields are unavailable.
 - On Linux, a readable installed node service remains listed when the service
   manager is unavailable; its runtime status stays unknown.
 - Overview includes update channel + git SHA (for source checkouts).

--- a/src/commands/status-all/format.ts
+++ b/src/commands/status-all/format.ts
@@ -333,7 +333,7 @@ export function buildStatusOverviewSurfaceRows(params: {
         ? params.gatewayAuthWarningValue
         : params.gatewayProbeAuthWarning,
     middleRows: params.middleRows,
-    gatewaySelfValue: params.gatewaySelfFallbackValue ?? gatewaySelfValue,
+    gatewaySelfValue: gatewaySelfValue ?? params.gatewaySelfFallbackValue,
     gatewayServiceValue,
     nodeServiceValue,
     agentsValue: params.agentsValue,

--- a/src/commands/status-overview-rows.test.ts
+++ b/src/commands/status-overview-rows.test.ts
@@ -287,6 +287,7 @@ describe("status-overview-rows", () => {
     expect(findRowValue(rows, "Version")).toBe(VERSION);
     expect(findRowValue(rows, "OS")).toBe("macOS");
     expect(findRowValue(rows, "Config")).toBe("/tmp/openclaw.json");
+    expect(findRowValue(rows, "Gateway self")).toBe("gateway app 1.2.3");
     expect(findRowValue(rows, "Update")).toContain("behind 2");
     expect(findRowValue(rows, "Update restart")).toBe("restart pending health verification");
     expect(findRowValue(rows, "Security")).toBe("Run: openclaw security audit --deep");
@@ -297,4 +298,23 @@ describe("status-overview-rows", () => {
     expect(findRowValue(rows, "Degraded plugins")).toBe("1 configured-unavailable · discord");
     expect(findRowValue(rows, "Secrets")).toBe("2 diagnostics");
   });
+
+  it.each([null, {}])(
+    "uses unknown only when Gateway self metadata is absent (%j)",
+    (gatewaySelf) => {
+      const params = createStatusCommandOverviewRowsParams();
+      const surface = { ...params.surface, gatewaySelf };
+      const rows = buildStatusAllOverviewRows({
+        ...params,
+        surface,
+        configPath: "/tmp/openclaw.json",
+        secretDiagnosticsCount: 0,
+      });
+
+      expect(findRowValue(rows, "Gateway self")).toBe("unknown");
+      expect(
+        findRowValue(buildStatusCommandOverviewRows({ ...params, surface }), "Gateway self"),
+      ).toBeUndefined();
+    },
+  );
 });

--- a/src/commands/status-overview-surface.test.ts
+++ b/src/commands/status-overview-surface.test.ts
@@ -93,7 +93,7 @@ describe("status-overview-surface", () => {
           "remote · wss://gateway.example.com (config) · ok(reachable 42ms) · auth token · gateway app 1.2.3",
       },
       { Item: "Gateway auth warning", Value: "warn(warn-text)" },
-      { Item: "Gateway self", Value: "gateway-self" },
+      { Item: "Gateway self", Value: "gateway app 1.2.3" },
       { Item: "Gateway service", Value: "LaunchAgent installed · loaded · running" },
       { Item: "Node service", Value: "node loaded · running (pid 42)" },
       { Item: "Agents", Value: "2 total" },


### PR DESCRIPTION
Closes #142164

## What Problem This Solves

Fixes an issue where `openclaw status --all` showed `Gateway self: unknown` even when the Gateway returned host, IP, version, and platform metadata. Ordinary status and the full report's Gateway row already showed those fields.

## Why This Change Was Made

The shared row formatter selected the caller's fallback before the available value. Prefer the computed metadata and use the existing fallback only when it is absent. This keeps one formatting path and preserves plain status, JSON, service reporting, and metadata collection.

## User Impact

The full diagnostic report now shows available Gateway details consistently. Unavailable Gateway metadata still displays `unknown`.

## Evidence

- Two intended baseline failures; 41 passing controls. All 43 focused tests pass with the repair, including missing metadata, plain-status omission, structured/legacy presence, and JSON controls.
- Full changed-file checks passed, including formatting, types, lint, and repository guards. Independent P0–P2 review found no actionable issues.
- Normal baseline and candidate builds passed. Six ordinary CLI calls compared both builds against the same isolated, normally paired Gateway. JSON `gateway.self` was exactly equal; baseline `--all` showed `unknown`, while the candidate displayed the same host/IP/version/platform as plain status. All calls exited 0 with empty stderr.
- After normal Gateway shutdown, four additional CLI calls verified unreachable/null-self JSON and the retained `unknown` fallback in both full reports. Temporary state was removed and the owned PID/port were verified released.

Returned metadata in the real output includes the host's name and IP; those private captures are retained locally. The relevant observed comparison is:

| Surface | Before | After |
| --- | --- | --- |
| Full report, Gateway self | `unknown` | Returned host, IP, app version, platform |
| Plain status, Gateway self | Returned metadata | Same metadata |
| JSON `gateway.self` | Nonempty object | Exactly equal object |
| Unreachable Gateway, full report | `unknown` | `unknown` |

The fresh fixture required normal TUI pairing before its read-only probe could fetch presence. Initial unpaired observations remain setup evidence. No message was submitted; the Gateway had no configured channels and reported zero turns. Update-fetch and missing-skill diagnostics were unrelated to this display assertion and remain recorded.

Production delta: net 0 lines; tests: +20; docs: +2. No configuration, protocol, persistence, or authentication behavior changes.

CI note: the first run recorded 26 self-hosted runner failures with no step results, and the aggregate gate failed. GitHub's build-job annotation reports lost runner communication; its log blob is unavailable. Only the failed jobs were retried on the same head through the existing hybrid retry route. No source or workflow settings changed for the retry.

The retry then exposed an unrelated cold-provider load timeout in the Telegram sticker-selection integration test. Its missing runtime-build prerequisite is repaired separately in #142234. This PR is now rebased onto that repaired main; no timeout or test assertion is weakened.

Rebase verification: head `d662fdb0478077ea0e3180e57b60e0ab35fe9cfc` is based on `17cefca633837f2fb773eb26acf71371b091948d`. Git range-diff confirms the patch is unchanged, and 23 row/surface tests passed on this head. Earlier builds and real CLI observations remain bound to the original head. [Fresh CI](https://github.com/openclaw/openclaw/actions/runs/34241893051) passed with 110 successful and 16 intentionally skipped jobs.

Landed through native prepare/merge as [e7510d8331e5](https://github.com/openclaw/openclaw/commit/e7510d8331e53d7dca14a0483b7e06f7dbe7af54). The full tree matches the reviewed patch merged into its actual parent. It preserves the independent update-staleness documentation that reached main while CI ran; all three code/test blobs match the reviewed candidate.
