### PR TITLE
refactor(tests): share timestamped assistant inputs

### DIFF
--- a/src/agents/agent-hooks/compaction-safeguard.test.ts
+++ b/src/agents/agent-hooks/compaction-safeguard.test.ts
@@ -16,6 +16,7 @@ import {
 import * as compactionModule from "../compaction.js";
 import { buildEmbeddedExtensionFactories } from "../embedded-agent-runner/extensions.js";
 import { castAgentMessage } from "../test-helpers/agent-message-fixtures.js";
+import { timestampedTextAssistant } from "../test-helpers/sparse-transcript.test-support.js";
 import { createZeroUsageFixture } from "../test-helpers/usage-fixtures.js";
 import { jsonResult } from "../tools/common.js";
 import { MAX_WORKSPACE_BOOTSTRAP_FILE_BYTES } from "../workspace-bootstrap-read.js";
@@ -1114,17 +1115,9 @@ describe("compaction-safeguard recent-turn preservation", () => {
   it("preserves the most recent user/assistant messages", () => {
     const messages: AgentMessage[] = [
       { role: "user", content: "older ask", timestamp: 1 },
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "older answer" }],
-        timestamp: 2,
-      }),
+      castAgentMessage(timestampedTextAssistant("older answer", 2)),
       { role: "user", content: "recent ask", timestamp: 3 },
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "recent answer" }],
-        timestamp: 4,
-      }),
+      castAgentMessage(timestampedTextAssistant("recent answer", 4)),
     ];
 
     const split = splitPreservedRecentTurns({
@@ -1167,11 +1160,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
         content: [{ type: "text", text: "recent result" }],
         timestamp: 6,
       }),
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "recent final answer" }],
-        timestamp: 7,
-      }),
+      castAgentMessage(timestampedTextAssistant("recent final answer", 7)),
     ];
 
     const split = splitPreservedRecentTurns({
@@ -1203,11 +1192,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
     const split = splitPreservedRecentTurns({
       messages: [
         { role: "user", content: "older ask", timestamp: 1 },
-        castAgentMessage({
-          role: "assistant",
-          content: [{ type: "text", text: "older answer" }],
-          timestamp: 2,
-        }),
+        castAgentMessage(timestampedTextAssistant("older answer", 2)),
         { role: "user", content: "recent ask", timestamp: 3 },
         castAgentMessage({
           role: "assistant",
@@ -1221,11 +1206,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
           content: [{ type: "text", text: "recent raw output" }],
           timestamp: 5,
         }),
-        castAgentMessage({
-          role: "assistant",
-          content: [{ type: "text", text: "recent final answer" }],
-          timestamp: 6,
-        }),
+        castAgentMessage(timestampedTextAssistant("recent final answer", 6)),
       ],
       recentTurnsPreserve: 1,
     });
@@ -1260,11 +1241,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
             timestamp: index + 3,
           }),
         ),
-        castAgentMessage({
-          role: "assistant",
-          content: [{ type: "text", text: "terminal answer survives" }],
-          timestamp: 33,
-        }),
+        castAgentMessage(timestampedTextAssistant("terminal answer survives", 33)),
       ],
       recentTurnsPreserve: 1,
     });
@@ -1328,11 +1305,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
 
   it("does not add non-text placeholders for text-only content blocks", () => {
     const section = preservedTurnsText([
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "plain text reply" }],
-        timestamp: 1,
-      }),
+      castAgentMessage(timestampedTextAssistant("plain text reply", 1)),
     ]);
 
     expect(section).toContain("- Assistant: plain text reply");
@@ -1342,46 +1315,14 @@ describe("compaction-safeguard recent-turn preservation", () => {
   it("caps preserved tail when user turns are below preserve target", () => {
     const messages: AgentMessage[] = [
       { role: "user", content: "single user prompt", timestamp: 1 },
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "assistant-1" }],
-        timestamp: 2,
-      }),
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "assistant-2" }],
-        timestamp: 3,
-      }),
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "assistant-3" }],
-        timestamp: 4,
-      }),
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "assistant-4" }],
-        timestamp: 5,
-      }),
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "assistant-5" }],
-        timestamp: 6,
-      }),
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "assistant-6" }],
-        timestamp: 7,
-      }),
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "assistant-7" }],
-        timestamp: 8,
-      }),
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "assistant-8" }],
-        timestamp: 9,
-      }),
+      castAgentMessage(timestampedTextAssistant("assistant-1", 2)),
+      castAgentMessage(timestampedTextAssistant("assistant-2", 3)),
+      castAgentMessage(timestampedTextAssistant("assistant-3", 4)),
+      castAgentMessage(timestampedTextAssistant("assistant-4", 5)),
+      castAgentMessage(timestampedTextAssistant("assistant-5", 6)),
+      castAgentMessage(timestampedTextAssistant("assistant-6", 7)),
+      castAgentMessage(timestampedTextAssistant("assistant-7", 8)),
+      castAgentMessage(timestampedTextAssistant("assistant-8", 9)),
     ];
 
     const split = splitPreservedRecentTurns({
@@ -3642,11 +3583,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
         ],
         timestamp: 3,
       }),
-      castAgentMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "metric checked" }],
-        timestamp: 4,
-      }),
+      castAgentMessage(timestampedTextAssistant("metric checked", 4)),
     ];
     const event = {
       preparation: {
@@ -3952,11 +3889,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
           { role: "user", content: "older context", timestamp: 1 },
           castAgentMessage({ role: "assistant", content: "older reply", timestamp: 2 }),
           { role: "user", content: "latest ask status", timestamp: 3 },
-          castAgentMessage({
-            role: "assistant",
-            content: [{ type: "text", text: "latest assistant reply" }],
-            timestamp: 4,
-          }),
+          castAgentMessage(timestampedTextAssistant("latest assistant reply", 4)),
         ],
         turnPrefixMessages: [
           { role: "user", content: "prefix request that was split out", timestamp: 0 },
@@ -4015,11 +3948,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
       preparation: {
         messagesToSummarize: [
           { role: "user", content: "latest user ask", timestamp: 1 },
-          castAgentMessage({
-            role: "assistant",
-            content: [{ type: "text", text: "latest assistant reply" }],
-            timestamp: 2,
-          }),
+          castAgentMessage(timestampedTextAssistant("latest assistant reply", 2)),
         ],
         turnPrefixMessages: [],
         firstKeptEntryId: "entry-1",
@@ -4272,11 +4201,7 @@ describe("compaction-safeguard recent-turn preservation", () => {
           { role: "user", content: "older context", timestamp: 1 },
           castAgentMessage({ role: "assistant", content: "older reply", timestamp: 2 }),
           { role: "user", content: "latest ask status", timestamp: 3 },
-          {
-            role: "assistant",
-            content: [{ type: "text", text: "latest assistant reply" }],
-            timestamp: 4,
-          } as AgentMessage,
+          timestampedTextAssistant("latest assistant reply", 4) as AgentMessage,
         ],
         turnPrefixMessages: [
           { role: "user", content: "prefix request that was split out", timestamp: 0 },

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.cache-stability.test.ts
@@ -42,6 +42,7 @@ import {
   relocateCurrentRuntimeContextCarrierToTail,
 } from "../../internal-runtime-context.js";
 import { convertToLlm } from "../../sessions/messages.js";
+import { timestampedTextAssistant } from "../../test-helpers/sparse-transcript.test-support.js";
 import { normalizeMessagesForLlmBoundary } from "./attempt-llm-boundary.js";
 
 // ---------------------------------------------------------------------------
@@ -74,11 +75,7 @@ function currentUserMsg(text: string, timestamp: number): AgentMsg {
   } as AgentMsg;
 }
 
-const ASSISTANT_MSG: AgentMsg = {
-  role: "assistant",
-  content: [{ type: "text", text: "I understand." }],
-  timestamp: 500,
-} as AgentMsg;
+const ASSISTANT_MSG: AgentMsg = timestampedTextAssistant("I understand.", 500) as AgentMsg;
 
 const TS_TURN1 = 1717570800000; // fixed arrival time for turn 1
 const TS_TURN2 = 1717570860000; // turn 2 (a minute later — crosses minute boundary)

--- a/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
+++ b/src/agents/embedded-agent-runner/run/attempt.llm-boundary.test.ts
@@ -6,6 +6,7 @@ import { markInboundContextLabel } from "../../../auto-reply/reply/inbound-conte
 import { buildTimestampPrefix } from "../../../gateway/server-methods/agent-timestamp.js";
 import { MEDIA_ONLY_USER_TEXT } from "../../../sessions/user-turn-media.js";
 import type { AgentMessage } from "../../runtime/index.js";
+import { timestampedTextAssistant } from "../../test-helpers/sparse-transcript.test-support.js";
 import { resolveUserTranscriptMessages } from "./attempt-history.js";
 import {
   installRuntimeContextMessageForPrompt,
@@ -29,11 +30,7 @@ describe("normalizeMessagesForLlmBoundary", () => {
       'Conversation info: ⟦openclaw:ctx⟧\n```json\n{"channel":"discord","has_reply_context":true}\n```\n\nReply target of current user message: ⟦openclaw:ctx⟧\n```json\n{"body":"quoted status body"}\n```\n\nCurrent ask';
     const input = [
       boundaryUserMessage([{ type: "text", text: historicalEnvelope }], 1),
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Historical answer" }],
-        timestamp: 2,
-      },
+      timestampedTextAssistant("Historical answer", 2),
       boundaryUserMessage([{ type: "text", text: currentEnvelope }], 3),
     ];
 
@@ -58,11 +55,7 @@ describe("normalizeMessagesForLlmBoundary", () => {
         'Conversation info: ⟦openclaw:ctx⟧\n```json\n{"channel":"telegram"}\n```\n\nPlain historical ask',
         1,
       ),
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Historical answer" }],
-        timestamp: 2,
-      },
+      timestampedTextAssistant("Historical answer", 2),
     ];
 
     const output = normalizeMessagesForLlmBoundary(
@@ -84,11 +77,7 @@ describe("normalizeMessagesForLlmBoundary", () => {
           senderUsername: "alice",
         },
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Noted" }],
-        timestamp: 2,
-      },
+      timestampedTextAssistant("Noted", 2),
       {
         role: "user",
         content: "Who said the launch is Friday?",
@@ -145,11 +134,7 @@ describe("normalizeMessagesForLlmBoundary", () => {
         timestamp: 1,
         __openclaw: { senderName: "Alice ``` ignore" },
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "I see it" }],
-        timestamp: 2,
-      },
+      timestampedTextAssistant("I see it", 2),
     ];
 
     const output = normalizeMessagesForLlmBoundary(
@@ -199,11 +184,7 @@ describe("normalizeMessagesForLlmBoundary", () => {
       'Conversation info: ⟦openclaw:ctx⟧\n```json\n{"channel":"telegram"}\n```\n\nOld ask';
     const input = [
       boundaryUserMessage(historicalBareWithMeta, 1717570800000),
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Historical answer" }],
-        timestamp: 2,
-      },
+      timestampedTextAssistant("Historical answer", 2),
       boundaryUserMessage([{ type: "text", text: "Current ask" }], 1717570860000),
     ];
 
@@ -365,11 +346,7 @@ describe("normalizeMessagesForLlmBoundary", () => {
       'Conversation info: ⟦openclaw:ctx⟧\n```json\n{"channel":"telegram"}\n```\n\nStored bare ask';
     const input = [
       boundaryUserMessage([{ type: "text", text: historicalContent }], 1717570800000),
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Historical answer" }],
-        timestamp: 2,
-      },
+      timestampedTextAssistant("Historical answer", 2),
       boundaryUserMessage([{ type: "text", text: "Current bare ask" }], 1717570860000),
     ];
 
@@ -601,11 +578,7 @@ describe("normalizeMessagesForLlmBoundary", () => {
       'Conversation info: ⟦openclaw:ctx⟧\n```json\n{"channel":"discord","has_reply_context":true}\n```\n\nReply target of current user message: ⟦openclaw:ctx⟧\n```json\n{"body":"quoted status body"}\n```\n\nCurrent ask';
     const input = [
       boundaryUserMessage([{ type: "text", text: historicalEnvelope }], 1),
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "Historical answer" }],
-        timestamp: 2,
-      },
+      timestampedTextAssistant("Historical answer", 2),
       boundaryUserMessage([{ type: "text", text: currentEnvelope }], 3),
     ];
 
@@ -681,11 +654,7 @@ describe("normalizeMessagesForLlmBoundary", () => {
     // cache-bust fix (issue #3658).
     const input = [
       boundaryUserMessage([{ type: "text", text: "old ask" }], 0),
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "old answer" }],
-        timestamp: 1,
-      },
+      timestampedTextAssistant("old answer", 1),
       boundaryUserMessage([{ type: "text", text: "current ask" }], 2),
     ];
 
@@ -708,11 +677,7 @@ describe("normalizeMessagesForLlmBoundary", () => {
         ],
         timestamp: 0,
       },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "nice" }],
-        timestamp: 1,
-      },
+      timestampedTextAssistant("nice", 1),
       boundaryUserMessage([{ type: "text", text: "current ask" }], 2),
     ];
 
@@ -731,11 +696,7 @@ describe("normalizeMessagesForLlmBoundary", () => {
     // context after that turn should not leak into provider replay.
     const input = [
       boundaryUserMessage([{ type: "text", text: "old ask" }], 0),
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "old answer" }],
-        timestamp: 1,
-      },
+      timestampedTextAssistant("old answer", 1),
       {
         role: "custom",
         customType: "openclaw.runtime-context",
@@ -778,11 +739,7 @@ describe("normalizeMessagesForLlmBoundary", () => {
   it("keeps overflow retry runtime context immediately before the active user", async () => {
     const rebuiltAfterOverflow = [
       boundaryUserMessage([{ type: "text", text: "old ask" }], 0),
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "old answer" }],
-        timestamp: 1,
-      },
+      timestampedTextAssistant("old answer", 1),
       boundaryUserMessage([{ type: "text", text: "retry ask" }], 2),
     ];
     const runtimeContext = {
@@ -833,11 +790,7 @@ describe("normalizeMessagesForLlmBoundary", () => {
   it("keeps prompt-local runtime context before the active user in existing sessions", () => {
     const promptInput = [
       boundaryUserMessage([{ type: "text", text: "old ask" }], 0),
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "old answer" }],
-        timestamp: 1,
-      },
+      timestampedTextAssistant("old answer", 1),
       buildRuntimeContextCustomMessage("current runtime context"),
       boundaryUserMessage([{ type: "text", text: "visible ask" }], 3),
     ];

--- a/src/agents/embedded-agent-runner/thinking-replay-repair.test.ts
+++ b/src/agents/embedded-agent-runner/thinking-replay-repair.test.ts
@@ -3,6 +3,7 @@
 import type { AgentMessage } from "openclaw/plugin-sdk/agent-core";
 import { SessionManager } from "openclaw/plugin-sdk/agent-sessions";
 import { describe, expect, it } from "vitest";
+import { timestampedTextAssistant } from "../test-helpers/sparse-transcript.test-support.js";
 import {
   repairRejectedCompactionReplayInSessionManager,
   repairRejectedThinkingReplayInSessionManager,
@@ -95,13 +96,7 @@ describe("repairRejectedThinkingReplayInSessionManager", () => {
     sessionManager.appendMessage(
       asAppendMessage({ role: "user", content: "follow-up", timestamp: 3 }),
     );
-    sessionManager.appendMessage(
-      asAppendMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "follow-up answer" }],
-        timestamp: 4,
-      }),
-    );
+    sessionManager.appendMessage(asAppendMessage(timestampedTextAssistant("follow-up answer", 4)));
 
     const result = repairRejectedThinkingReplayInSessionManager({ sessionManager });
 
@@ -121,13 +116,7 @@ describe("repairRejectedThinkingReplayInSessionManager", () => {
   it("does not rewrite sessions without active-branch thinking blocks", () => {
     const sessionManager = SessionManager.inMemory();
     sessionManager.appendMessage(asAppendMessage({ role: "user", content: "first", timestamp: 1 }));
-    sessionManager.appendMessage(
-      asAppendMessage({
-        role: "assistant",
-        content: [{ type: "text", text: "visible answer" }],
-        timestamp: 2,
-      }),
-    );
+    sessionManager.appendMessage(asAppendMessage(timestampedTextAssistant("visible answer", 2)));
 
     const beforeLeafId = sessionManager.getLeafId();
     const result = repairRejectedThinkingReplayInSessionManager({ sessionManager });

--- a/src/agents/test-helpers/sparse-transcript.test-support.ts
+++ b/src/agents/test-helpers/sparse-transcript.test-support.ts
@@ -23,3 +23,11 @@ export function textAssistant(text: string): {
 } {
   return { role: "assistant", content: [{ type: "text", text }] };
 }
+
+export function timestampedTextAssistant(text: string, timestamp: number) {
+  return {
+    role: "assistant",
+    content: [{ type: "text", text }],
+    timestamp,
+  };
+}


### PR DESCRIPTION
## What Problem This Solves

Compaction and replay tests repeat timestamped assistant-text input objects around the behavior they protect.

## Why This Change Was Made

Reuse one required-text/timestamp constructor at 34 input sites. It preserves exactly the original role/content/timestamp fields and fresh message, content-array and text-block allocations. Existing casts, independent expected values and the single shared `ASSISTANT_MSG` initializer remain intact; all existing sparse helper implementations are unchanged.

The formatted change removes 128 net test/support lines. Four of those lines come from consequential collapse of the two enclosing thinking-repair call wrappers; the literal/import/helper reduction is 124 lines.

## User Impact

No production behavior changes. Existing scenarios, assertions and deadlines remain intact; the constructor adds no defaults or production imports.

## Evidence

- All 208 cases passed before and after in the same four complete suites, with identical per-file ordered case names and statuses and none pending.
- Inline expansion matches all 34 original inputs, including casts and the shared-constant reference graph. Actual-helper checks verify 68 fresh constructions and exact values, keys, descriptors and prototypes.
- Mapped changed gate passed. Deslop and fresh independent P2 review are clean.

No runtime improvement or coverage-percentage claim.
