### PR TITLE
fix(cli): explain environment-disabled automation scheduling

### DIFF
--- a/docs/automation/cron-jobs/troubleshooting.md
+++ b/docs/automation/cron-jobs/troubleshooting.md
@@ -28,7 +28,7 @@ openclaw doctor
 
 <AccordionGroup>
   <Accordion title="Automations not firing">
-    - Check `cron.enabled` and the `OPENCLAW_SKIP_CRON` env var.
+    - Check the `cron.enabled` config setting and `OPENCLAW_SKIP_CRON` in the Gateway's launch environment. Either can disable automatic runs; clear both disable settings and restart the Gateway to enable scheduling.
     - Confirm the Gateway is running continuously.
     - For `cron` schedules, verify timezone (`--tz`) vs the host timezone.
     - `reason: not-due` in run output means the manual run was checked with `openclaw automations run <jobId> --due` and the job was not due yet.

--- a/src/cli/cron-cli/register.cron-simple.test.ts
+++ b/src/cli/cron-cli/register.cron-simple.test.ts
@@ -334,11 +334,15 @@ describe("cron scheduler status warnings", () => {
     );
 
     await runCronToggle("enable");
+    expect(defaultRuntime.writeJson).toHaveBeenCalledExactlyOnceWith({ ok: true });
 
     if (disabled) {
       expect(defaultRuntime.error).toHaveBeenCalledWith(
         expect.stringContaining("scheduler is disabled"),
       );
+      for (const setting of ["cron.enabled", "OPENCLAW_SKIP_CRON=1"]) {
+        expect(defaultRuntime.error).toHaveBeenCalledWith(expect.stringContaining(setting));
+      }
     } else {
       expect(defaultRuntime.error).not.toHaveBeenCalled();
     }

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -297,7 +297,7 @@ export async function warnIfCronSchedulerDisabled(opts: GatewayRpcOpts) {
     defaultRuntime.error(
       [
         "warning: the automations scheduler is disabled in the Gateway; jobs are saved but will not run automatically.",
-        "Re-enable with `cron.enabled: true` (or remove `cron.enabled: false`) and restart the Gateway.",
+        "To enable automatic runs, set `cron.enabled: true` (or remove `cron.enabled: false`), remove `OPENCLAW_SKIP_CRON=1` from the Gateway's launch environment, and restart the Gateway.",
         store ? `store: ${store}` : "",
       ]
         .filter(Boolean)


### PR DESCRIPTION
Closes #142180

## What Problem This Solves

Fixes incomplete recovery advice after saving an automation while the Gateway scheduler is disabled. The CLI recommended only `cron.enabled: true` and a restart, even when that setting was already true and `OPENCLAW_SKIP_CRON=1` in the Gateway's launch environment was keeping scheduling off.

## Why This Change Was Made

The shared warning now names both existing controls and locates the environment setting at the Gateway. The status response provides only the effective boolean, so the message covers both prerequisites without guessing the cause from the CLI's environment. Add, edit, enable, and disable continue to use the same warning owner.

## User Impact

Operators receive actionable recovery steps for either documented disable setting. Successful job results remain JSON on stdout, with the advisory warning on stderr.

## Evidence

- The existing warning test table reproduced one intended failure with 26 passing controls. All 27 tests pass after the repair, including unchanged successful JSON and no-warning controls.
- Full changed-file checks and normal build passed. Independent P0–P2 review found no actionable issues.
- Twelve ordinary CLI calls compared baseline and candidate builds against one real isolated Gateway. Config read `cron.enabled: true`; effective status read `enabled: false`; the Gateway had `OPENCLAW_SKIP_CRON=1`, while the CLI environment omitted it. Each build saved a paused command job, read it back, verified empty run history, and removed it. Every call exited 0; job fields and JSON shape were preserved.
- Baseline advice omitted the environment control. The candidate names it explicitly, with Gateway ownership.
- The Gateway shut down normally; its owned PID and port were released, and temporary state was removed. The jobs remained paused throughout. This proves the warning, not scheduler re-enablement.

Production delta is net 0 lines, with four added test lines and a documentation clarification. No scheduling, configuration, protocol, persistence, or authentication logic changes.

Captured candidate recovery sentence:

```text
To enable automatic runs, set `cron.enabled: true` (or remove `cron.enabled: false`), remove `OPENCLAW_SKIP_CRON=1` from the Gateway's launch environment, and restart the Gateway.
```

CI note: run 34232570445 lost 16 self-hosted runners before any recorded step; each leaf check has GitHub’s runner communication-loss annotation. The executed aggregate gate only propagates those failures. The separate OpenGrep runner also lost communication before steps. The PR is now rebased onto main containing #142234, which repairs the independently observed Telegram test prerequisite omission.

Rebase verification: head `419a1de04b5cb98131fd6632bed6672a315224c7` is based on `17cefca633837f2fb773eb26acf71371b091948d`. Git range-diff confirms the patch is unchanged; all 142 simple-command, shared, and shared-error tests passed. The upstream CronCliError repair is preserved. Earlier builds and real CLI observations remain bound to the original head. [Fresh CI](https://github.com/openclaw/openclaw/actions/runs/34241955425) passed with 78 successful and 16 intentionally skipped jobs.

The refreshed CI run completed all test/build lanes; its only failed leaf was the security runner, which lost communication before recording steps. A failed-job-only retry passed on the existing hosted route. Native prepare/merge landed [a731df8fd8ba](https://github.com/openclaw/openclaw/commit/a731df8fd8baaf1ac2766698f6dd9f269d7c77c8) on the unchanged reviewed head. The entire actual-parent merge tree and all three changed files match the reviewed repair.
