### PR TITLE
fix(daemon): Bun runtime probe ignores the Gateway's SQLite library selection

### DIFF
--- a/docs/install/bun-compatibility.md
+++ b/docs/install/bun-compatibility.md
@@ -54,6 +54,8 @@ Cannot use SQLite library <path>: <reason>. Fix or unset OPENCLAW_SQLITE_LIBRARY
 
 Node and non-macOS Bun ignore this override, with a warning in Gateway startup logs. When a library is selected, Gateway startup logs `SQLite: using <path> (<version>, extension loading enabled)`. `openclaw doctor` reports the selection for the doctor process.
 
+Daemon install, `openclaw gateway start` repair, `openclaw doctor`, and service audits probe candidate Bun executables through the same selection, so they judge and report the library the Gateway will actually open rather than Bun's runtime SQLite. An invalid override fails those probes with the message above instead of advising a Bun upgrade or switching the service to Node.
+
 If you previously used a preload that calls `Database.setCustomSQLite()`, remove it and set `OPENCLAW_SQLITE_LIBRARY` to the same path instead. The hook is one-shot: keeping the preload causes `SQLite already loaded`, even if both selections name the same library. OpenClaw's override also forwards the path to the KNN child.
 
 ## Memory search without an extension-capable library
@@ -73,6 +75,7 @@ See [Bun](/install/bun) for the workflow and lifecycle trust commands.
 
 | Release                            | Change                                                                                                                                                                                               |
 | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Unreleased (main)                  | Daemon install, repair, doctor, and service audits probe Bun executables through the same SQLite library selection as Gateway startup, with a minimal probe environment. #142186                     |
 | Unreleased (main)                  | Automatically selects a WAL-safe, extension-capable macOS SQLite library and propagates it to the memory KNN child. Adds `OPENCLAW_SQLITE_LIBRARY`. #141854                                          |
 | Unreleased (main)                  | Documents Bun 1.4.2 retaining native statements and WAL/shared-memory files after close or disposal, with Node advised when prompt file release matters. #141846                                     |
 | Unreleased (main)                  | Adds batched embedding-scan fallback when the KNN child cannot load extensions, preserving provider/source filters and cancellation between batches. #141104                                         |

--- a/src/cli/daemon-cli/start-repair.test.ts
+++ b/src/cli/daemon-cli/start-repair.test.ts
@@ -285,11 +285,18 @@ describe("repairLoadedGatewayServiceForStart", () => {
     { status: "supported", expectedRuntime: "bun" },
     { status: "unsupported", expectedRuntime: "node" },
     { status: "probe-failed", expectedRuntime: null },
+    { status: "unsupported", sqliteSelectionError: true, expectedRuntime: null },
   ])(
-    "repairs an installed Bun Gateway only when its probe result is known ($status)",
-    async ({ status, expectedRuntime }) => {
+    "repairs an installed Bun Gateway only when its probe result is known ($status, selection error: $sqliteSelectionError)",
+    async ({ status, sqliteSelectionError, expectedRuntime }) => {
       const error = new Error("Bun runtime probe failed (cwd /root): EACCES");
-      resolveBunRuntimeInfoMock.mockResolvedValue({ status, error });
+      const selectionError =
+        "Cannot use SQLite library /opt/broken/libsqlite3.dylib: missing file. Fix or unset OPENCLAW_SQLITE_LIBRARY; install a supported library with brew install sqlite.";
+      resolveBunRuntimeInfoMock.mockResolvedValue({
+        status,
+        error,
+        ...(sqliteSelectionError ? { sqliteSelectionError: selectionError } : {}),
+      });
       const service = {
         install: vi.fn(async () => {}),
         isLoaded: vi.fn(async () => true),
@@ -318,8 +325,11 @@ describe("repairLoadedGatewayServiceForStart", () => {
         json: true,
         stdout: process.stdout,
       });
-      if (status === "probe-failed") {
-        await expect(repair).rejects.toBe(error);
+      if (expectedRuntime === null) {
+        // Neither an unreadable probe nor an operator's broken override may rewrite the service to Node.
+        await expect(repair).rejects.toThrow(
+          status === "probe-failed" ? error.message : selectionError,
+        );
         expect(resolveGatewayInstallTokenMock).not.toHaveBeenCalled();
         expect(service.install).not.toHaveBeenCalled();
         return;

--- a/src/cli/daemon-cli/start-repair.ts
+++ b/src/cli/daemon-cli/start-repair.ts
@@ -193,6 +193,10 @@ export async function repairLoadedGatewayServiceForStart(
   if (runtimeInfo?.status === "probe-failed") {
     throw runtimeInfo.error;
   }
+  // An invalid OPENCLAW_SQLITE_LIBRARY is operator state to fix, not grounds to rewrite the service to Node.
+  if (runtimeInfo?.status === "unsupported" && runtimeInfo.sqliteSelectionError) {
+    throw new Error(runtimeInfo.sqliteSelectionError);
+  }
   const runtime = runtimeInfo?.status === "supported" ? "bun" : "node";
 
   const tokenResolution = await resolveGatewayInstallToken({

--- a/src/daemon/runtime-paths.test.ts
+++ b/src/daemon/runtime-paths.test.ts
@@ -1,4 +1,5 @@
 // Daemon runtime path tests cover executable and config path resolution.
+import { fileURLToPath } from "node:url";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 const fsMocks = vi.hoisted(() => ({
@@ -20,6 +21,8 @@ vi.mock("node:fs/promises", async () => {
   };
 });
 
+import { runtimeProcessEntrypoints } from "../infra/runtime-process-entrypoints.js";
+import { resolveRuntimeWorkerUrl } from "../infra/runtime-worker-url.js";
 import { resolveStableNodePath } from "../infra/stable-node-path.js";
 import { resolveNodeProgramArguments } from "./program-args.js";
 import {
@@ -63,12 +66,16 @@ function bunRuntime(
   bunVersion: string | null,
   hasNodeSqlite = true,
   sqliteVersion: string | null = hasNodeSqlite ? "3.51.3" : null,
+  sqliteSelectionError: string | null = null,
 ) {
   return {
-    stdout: `${JSON.stringify({ bunVersion, hasNodeSqlite, sqliteVersion })}\n`,
+    stdout: `${JSON.stringify({ bunVersion, hasNodeSqlite, sqliteVersion, sqliteSelectionError })}\n`,
     stderr: "",
   };
 }
+
+const INVALID_SQLITE_OVERRIDE =
+  "Cannot use SQLite library /opt/broken/libsqlite3.dylib: missing file. Fix or unset OPENCLAW_SQLITE_LIBRARY; install a supported library with brew install sqlite.";
 
 describe.each(["node", "bun"] as const)("%s probe failures", (runtime) => {
   it.each([
@@ -314,7 +321,7 @@ describe("resolvePreferredNodePath", () => {
     expect(execFile).toHaveBeenCalledWith(
       darwinNode,
       ["-e", expect.stringContaining("SELECT sqlite_version() AS version")],
-      { encoding: "utf8", timeoutMs: 5_000 },
+      { encoding: "utf8", timeoutMs: 5_000, env: expect.any(Object) },
     );
   });
 
@@ -362,7 +369,7 @@ describe("resolvePreferredNodePath", () => {
     expect(execFile).toHaveBeenCalledWith(
       darwinNode,
       ["-e", expect.stringContaining("SELECT sqlite_version() AS version")],
-      { encoding: "utf8", timeoutMs: 5_000 },
+      { encoding: "utf8", timeoutMs: 5_000, env: expect.any(Object) },
     );
   });
 
@@ -459,7 +466,7 @@ describe("resolvePreferredBunPath", () => {
     expect(execFile).toHaveBeenCalledWith(
       bunPath,
       ["-e", expect.stringContaining("SELECT sqlite_version() AS version")],
-      { encoding: "utf8", timeoutMs: 5_000 },
+      { encoding: "utf8", timeoutMs: 5_000, env: expect.any(Object) },
     );
   });
 
@@ -520,6 +527,89 @@ describe("resolvePreferredBunPath", () => {
     const info = await resolveBunRuntimeInfo("/opt/bun", vi.fn().mockResolvedValue(probe));
 
     expect(info.status).toBe("unsupported");
+  });
+
+  it("probes Bun through the Gateway's SQLite library selection with a minimal env", async () => {
+    const bunPath = "/opt/homebrew/bin/bun";
+    // Apple's SQLite would report 3.54.0 here; the selected Homebrew library is what the Gateway opens.
+    const execFile = vi.fn().mockResolvedValue(bunRuntime("1.4.2", true, "3.53.4"));
+    const env = {
+      PATH: "/opt/homebrew/bin",
+      HOMEBREW_PREFIX: "/opt/homebrew",
+      OPENCLAW_SQLITE_LIBRARY: "/opt/homebrew/opt/sqlite/lib/libsqlite3.dylib",
+      OPENCLAW_GATEWAY_TOKEN: "secret",
+    };
+
+    await expect(resolveBunRuntimeInfo(bunPath, execFile, env)).resolves.toEqual({
+      status: "supported",
+      version: "1.4.2",
+      sqliteVersion: "3.53.4",
+      nodeSharedSqlite: false,
+    });
+    const selectionModule = fileURLToPath(
+      resolveRuntimeWorkerUrl(runtimeProcessEntrypoints.bunSqliteLibrary),
+    );
+    expect(execFile).toHaveBeenCalledWith(
+      bunPath,
+      [
+        "-e",
+        expect.stringContaining(
+          `require(${JSON.stringify(selectionModule)}).ensureSqliteLibrarySelected`,
+        ),
+      ],
+      {
+        encoding: "utf8",
+        timeoutMs: 5_000,
+        env: {
+          PATH: env.PATH,
+          HOMEBREW_PREFIX: env.HOMEBREW_PREFIX,
+          OPENCLAW_SQLITE_LIBRARY: env.OPENCLAW_SQLITE_LIBRARY,
+        },
+      },
+    );
+  });
+
+  it("never loads the SQLite library selection module into a Node probe", async () => {
+    mockNodePathPresent("/usr/bin/node");
+    const execFile = vi.fn().mockResolvedValue(nodeRuntime("26.8.1"));
+
+    await resolveSystemNodeInfo({ env: {}, platform: "linux", execFile });
+
+    expect(execFile).toHaveBeenCalledWith(
+      "/usr/bin/node",
+      ["-e", expect.not.stringContaining("ensureSqliteLibrarySelected")],
+      expect.anything(),
+    );
+  });
+
+  it("rejects a Bun executable when its SQLite library override is invalid", async () => {
+    const probe = bunRuntime("1.4.2", true, null, INVALID_SQLITE_OVERRIDE);
+
+    await expect(
+      resolveBunRuntimeInfo("/opt/bun", vi.fn().mockResolvedValue(probe)),
+    ).resolves.toEqual({
+      status: "unsupported",
+      version: "1.4.2",
+      sqliteVersion: null,
+      nodeSharedSqlite: false,
+      sqliteSelectionError: INVALID_SQLITE_OVERRIDE,
+    });
+  });
+
+  it("reports an invalid SQLite library override instead of advising a Bun upgrade", async () => {
+    const execFile = vi
+      .fn()
+      .mockResolvedValue(bunRuntime("1.4.2", true, null, INVALID_SQLITE_OVERRIDE));
+
+    await expect(
+      resolvePreferredBunPath({
+        env: { PATH: "/opt/homebrew/bin:/usr/local/bin" },
+        runtime: "bun",
+        platform: "darwin",
+        execPath: "/fixture/other",
+        execFile,
+      }),
+    ).rejects.toThrow(INVALID_SQLITE_OVERRIDE);
   });
 });
 
@@ -705,7 +795,7 @@ describe("resolveSystemNodeInfo", () => {
     expect(execFile).toHaveBeenCalledWith(
       homebrewOptNode,
       ["-e", expect.stringContaining("SELECT sqlite_version() AS version")],
-      { encoding: "utf8", timeoutMs: 5_000 },
+      { encoding: "utf8", timeoutMs: 5_000, env: expect.any(Object) },
     );
   });
 

--- a/src/daemon/runtime-paths.ts
+++ b/src/daemon/runtime-paths.ts
@@ -1,11 +1,13 @@
 /** Selects stable runtime executable paths for daemon installs across platforms. */
 import fs from "node:fs/promises";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { isRecord } from "@openclaw/normalization-core/record-coerce";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import { SUPPORTED_NODE_VERSIONS } from "../../node-version.mjs";
 import { isMissingPathError } from "../infra/errno.js";
 import { isSupportedBunVersion, isSupportedNodeVersion } from "../infra/runtime-guard.js";
+import { resolveRuntimeProcessEntrypointUrl } from "../infra/runtime-process-url.js";
 import { isSqliteWalResetSafeVersion } from "../infra/sqlite-runtime-version.js";
 import { resolveStableNodePath } from "../infra/stable-node-path.js";
 import { getWindowsProgramFilesRoots } from "../infra/windows-install-roots.js";
@@ -108,29 +110,78 @@ function buildBunCandidates(
 type ExecFileAsync = (
   file: string,
   args: readonly string[],
-  options: { encoding: "utf8"; timeoutMs: number },
+  options: { encoding: "utf8"; timeoutMs: number; env: NodeJS.ProcessEnv },
 ) => Promise<{ stdout: string; stderr: string }>;
 
 const RUNTIME_PROBE_TIMEOUT_MS = 5_000;
 
-const execFileAsync: ExecFileAsync = async (file, args, options) =>
-  await runExec(file, [...args], { logOutput: false, timeoutMs: options.timeoutMs });
+// The probe only needs to launch the runtime and, on Bun, run SQLite library selection
+// with the same inputs Gateway startup reads. Everything else (secrets, NODE_OPTIONS,
+// preloads) stays out of the child.
+const RUNTIME_PROBE_ENV_KEYS = [
+  "PATH",
+  "SystemRoot",
+  "SYSTEMROOT",
+  "WINDIR",
+  "TEMP",
+  "TMP",
+  "TMPDIR",
+  "HOMEBREW_PREFIX",
+  "OPENCLAW_SQLITE_LIBRARY",
+] as const;
 
-const RUNTIME_PROBE = String.raw`
-let sqliteVersion = null;
-try {
-  const { DatabaseSync } = require("node:sqlite");
-  const db = new DatabaseSync(":memory:");
-  try {
-    sqliteVersion = db.prepare("SELECT sqlite_version() AS version").get()?.version ?? null;
-  } finally {
-    db.close();
+const execFileAsync: ExecFileAsync = async (file, args, options) =>
+  await runExec(file, [...args], {
+    baseEnv: options.env,
+    logOutput: false,
+    timeoutMs: options.timeoutMs,
+  });
+
+function buildRuntimeProbeEnv(env: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  const probeEnv: NodeJS.ProcessEnv = {};
+  for (const key of RUNTIME_PROBE_ENV_KEYS) {
+    const value = env[key];
+    if (value) {
+      probeEnv[key] = value;
+    }
   }
-} catch {}
+  return probeEnv;
+}
+
+/**
+ * Bun candidates load the selection module the Gateway itself uses, so the probe rejects
+ * the same invalid overrides and reports the version of the library that will be selected
+ * instead of the runtime's default SQLite. A missing module fails the whole probe.
+ */
+function buildRuntimeProbeScript(sqliteLibraryModulePath: string | undefined): string {
+  const selector = sqliteLibraryModulePath
+    ? `require(${JSON.stringify(sqliteLibraryModulePath)}).ensureSqliteLibrarySelected`
+    : "() => {}";
+  return String.raw`
+const selectSqliteLibrary = ${selector};
+let sqliteVersion = null;
+let sqliteSelectionError = null;
+try {
+  selectSqliteLibrary();
+} catch (error) {
+  sqliteSelectionError = error instanceof Error ? error.message : String(error);
+}
+if (sqliteSelectionError === null) {
+  try {
+    const { DatabaseSync } = require("node:sqlite");
+    const db = new DatabaseSync(":memory:");
+    try {
+      sqliteVersion = db.prepare("SELECT sqlite_version() AS version").get()?.version ?? null;
+    } finally {
+      db.close();
+    }
+  } catch {}
+}
 const variables = (process.config && process.config.variables) || {};
 const nodeSharedSqlite = variables.node_shared_sqlite === true || variables.node_shared_sqlite === "true";
-process.stdout.write(JSON.stringify({ nodeVersion: process.versions.node, bunVersion: process.versions.bun ?? null, sqliteVersion, nodeSharedSqlite }));
+process.stdout.write(JSON.stringify({ nodeVersion: process.versions.node, bunVersion: process.versions.bun ?? null, sqliteVersion, sqliteSelectionError, nodeSharedSqlite }));
 `;
+}
 
 type RuntimeInfo =
   | {
@@ -138,6 +189,8 @@ type RuntimeInfo =
       version: string | null;
       sqliteVersion: string | null;
       nodeSharedSqlite: boolean;
+      /** Set when the runtime's SQLite library selection rejected the operator's override. */
+      sqliteSelectionError?: string;
     }
   | { status: "probe-failed"; error: Error };
 
@@ -147,14 +200,22 @@ async function resolveRuntimeInfo(
   runtimePath: string,
   runtime: "node" | "bun",
   execFileImpl: ExecFileAsync,
+  env: Record<string, string | undefined>,
 ): Promise<RuntimeInfo> {
   const label = runtime === "node" ? "Node" : "Bun";
   let cwd: string | undefined;
   try {
     cwd = process.cwd();
-    const { stdout } = await execFileImpl(runtimePath, ["-e", RUNTIME_PROBE], {
+    // Node never selects a library, and only Bun can load the source module in dev checkouts.
+    const script = buildRuntimeProbeScript(
+      runtime === "bun"
+        ? fileURLToPath(resolveRuntimeProcessEntrypointUrl("bunSqliteLibrary"))
+        : undefined,
+    );
+    const { stdout } = await execFileImpl(runtimePath, ["-e", script], {
       encoding: "utf8",
       timeoutMs: RUNTIME_PROBE_TIMEOUT_MS,
+      env: buildRuntimeProbeEnv(env),
     });
     const parsed: unknown = JSON.parse(stdout);
     if (!isRecord(parsed)) {
@@ -162,9 +223,11 @@ async function resolveRuntimeInfo(
     }
     const version = parsed[`${runtime}Version`];
     const sqliteVersion = parsed.sqliteVersion;
+    const sqliteSelectionError = parsed.sqliteSelectionError;
     if (
       !(typeof version === "string" || (runtime === "bun" && version === null)) ||
-      !(typeof sqliteVersion === "string" || sqliteVersion === null)
+      !(typeof sqliteVersion === "string" || sqliteVersion === null) ||
+      !(typeof sqliteSelectionError === "string" || sqliteSelectionError == null)
     ) {
       throw new Error("Runtime probe returned invalid version metadata");
     }
@@ -172,12 +235,16 @@ async function resolveRuntimeInfo(
       runtime === "node" ? isSupportedNodeVersion(version) : isSupportedBunVersion(version);
     return {
       status:
-        supportedVersion && sqliteVersion !== null && isSqliteWalResetSafeVersion(sqliteVersion)
+        supportedVersion &&
+        !sqliteSelectionError &&
+        sqliteVersion !== null &&
+        isSqliteWalResetSafeVersion(sqliteVersion)
           ? "supported"
           : "unsupported",
       version,
       sqliteVersion,
       nodeSharedSqlite: parsed.nodeSharedSqlite === true || parsed.nodeSharedSqlite === "true",
+      ...(sqliteSelectionError ? { sqliteSelectionError } : {}),
     };
   } catch (cause) {
     // A failed exec says nothing about runtime support. Preserve its cause and launch context.
@@ -193,8 +260,9 @@ async function resolveRuntimeInfo(
 export function resolveBunRuntimeInfo(
   bunPath: string,
   execFileImpl: ExecFileAsync = execFileAsync,
+  env: Record<string, string | undefined> = process.env,
 ) {
-  return resolveRuntimeInfo(bunPath, "bun", execFileImpl);
+  return resolveRuntimeInfo(bunPath, "bun", execFileImpl, env);
 }
 
 async function isVersionManagedRealNodePath(
@@ -268,7 +336,7 @@ export async function resolveSystemNodeInfo(params: {
     if (await isVersionManagedRealNodePath(systemNode, platform)) {
       continue;
     }
-    const runtime = await resolveRuntimeInfo(systemNode, "node", execFileImpl);
+    const runtime = await resolveRuntimeInfo(systemNode, "node", execFileImpl, env);
     const info = { path: systemNode, ...runtime };
     if (info.status === "supported") {
       return info;
@@ -320,11 +388,12 @@ export async function resolvePreferredNodePath(
     return undefined;
   }
 
+  const env = params.env ?? process.env;
   const platform = params.platform ?? process.platform;
   const currentExecPath = params.execPath ?? process.execPath;
   const execFileImpl = params.execFile ?? execFileAsync;
   const currentNode = isNodeExecPath(currentExecPath, platform)
-    ? await resolveRuntimeInfo(currentExecPath, "node", execFileImpl)
+    ? await resolveRuntimeInfo(currentExecPath, "node", execFileImpl, env)
     : null;
   if (currentNode?.status === "supported" && !isVersionManagedNodePath(currentExecPath, platform)) {
     return resolveStableNodePath(currentExecPath);
@@ -360,6 +429,7 @@ export async function resolvePreferredBunPath(
   const execFileImpl = params.execFile ?? execFileAsync;
   const currentExecPath = params.execPath ?? process.execPath;
   let probeFailure: Error | undefined;
+  let selectionError: string | undefined;
   for (const candidate of buildBunCandidates(env, platform, currentExecPath)) {
     try {
       await fs.access(candidate);
@@ -368,13 +438,20 @@ export async function resolvePreferredBunPath(
         continue;
       }
     }
-    const runtime = await resolveBunRuntimeInfo(candidate, execFileImpl);
+    const runtime = await resolveBunRuntimeInfo(candidate, execFileImpl, env);
     if (runtime.status === "probe-failed") {
       probeFailure ??= runtime.error;
+    } else {
+      selectionError ??= runtime.sqliteSelectionError;
     }
     if (runtime.status === "supported") {
       return candidate;
     }
+  }
+  // An invalid override rejects every Bun the same way the Gateway would at startup;
+  // advising a Bun upgrade here would hide the real next step.
+  if (selectionError) {
+    throw new Error(selectionError);
   }
   if (probeFailure) {
     throw probeFailure;

--- a/src/daemon/service-audit.test.ts
+++ b/src/daemon/service-audit.test.ts
@@ -133,14 +133,20 @@ describe("auditGatewayServiceConfig", () => {
   beforeEach(() => {
     execSystemctlUser.mockReset();
     execSystemctlUser.mockResolvedValue({ stdout: "", stderr: "systemd unavailable", code: 1 });
-    resolveBunRuntimeInfo.mockReset();
-    resolveBunRuntimeInfo.mockResolvedValue({
+    resolveBunRuntimeInfo.mockReset().mockResolvedValue({
       version: "1.4.0",
       sqliteVersion: "3.51.3",
       nodeSharedSqlite: false,
       status: "supported",
     });
   });
+
+  const auditBunGateway = (bunPath = "/opt/homebrew/bin/bun") =>
+    auditGatewayServiceConfig({
+      env: { HOME: "/tmp" },
+      platform: "darwin",
+      command: { programArguments: [bunPath, "gateway"], environment: { PATH: "/usr/bin:/bin" } },
+    });
 
   it("flags Bun runtimes without WAL-safe SQLite", async () => {
     resolveBunRuntimeInfo.mockResolvedValue({
@@ -149,47 +155,42 @@ describe("auditGatewayServiceConfig", () => {
       nodeSharedSqlite: false,
       status: "unsupported",
     });
-    const audit = await auditGatewayServiceConfig({
-      env: { HOME: "/tmp" },
-      platform: "darwin",
-      command: {
-        programArguments: ["/opt/homebrew/bin/bun", "gateway"],
-        environment: { PATH: "/usr/bin:/bin" },
-      },
+    const audit = await auditBunGateway();
+    expect(audit.issues).toContainEqual(
+      expect.objectContaining({
+        code: SERVICE_AUDIT_CODES.gatewayRuntimeBun,
+        message: expect.stringContaining("Bun 1.4+ with WAL-reset-safe node:sqlite is required"),
+      }),
+    );
+  });
+
+  it("surfaces an invalid SQLite library override as the Bun runtime issue detail", async () => {
+    const selectionError = "Cannot use SQLite library /opt/broken/libsqlite3.dylib: missing file.";
+    resolveBunRuntimeInfo.mockResolvedValue({
+      version: "1.4.2",
+      sqliteVersion: null,
+      nodeSharedSqlite: false,
+      status: "unsupported",
+      sqliteSelectionError: selectionError,
     });
-    expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayRuntimeBun)).toBe(true);
-    expect(
-      audit.issues.find((issue) => issue.code === SERVICE_AUDIT_CODES.gatewayRuntimeBun)?.message,
-    ).toContain("Bun 1.4+ with WAL-reset-safe node:sqlite is required");
+    const audit = await auditBunGateway();
+    expect(audit.issues).toContainEqual(
+      expect.objectContaining({
+        code: SERVICE_AUDIT_CODES.gatewayRuntimeBun,
+        detail: `/opt/homebrew/bin/bun: ${selectionError}`,
+      }),
+    );
   });
 
   it("accepts Bun 1.4 with WAL-safe node:sqlite", async () => {
-    const audit = await auditGatewayServiceConfig({
-      env: { HOME: "/tmp" },
-      platform: "darwin",
-      command: {
-        programArguments: ["/opt/homebrew/bin/bun", "gateway"],
-        environment: { PATH: "/usr/bin:/bin" },
-      },
-    });
-
+    const audit = await auditBunGateway();
     expect(hasIssue(audit, SERVICE_AUDIT_CODES.gatewayRuntimeBun)).toBe(false);
   });
 
   it("reports a failed Bun probe without recommending runtime migration", async () => {
-    resolveBunRuntimeInfo.mockResolvedValue({
-      status: "probe-failed",
-      error: new Error("Bun runtime probe failed at /opt/bun (cwd /root): EACCES"),
-    });
-    const audit = await auditGatewayServiceConfig({
-      env: { HOME: "/tmp" },
-      platform: "darwin",
-      command: {
-        programArguments: ["/opt/bun", "gateway"],
-        environment: { PATH: "/usr/bin:/bin" },
-      },
-    });
-
+    const error = new Error("Bun runtime probe failed at /opt/bun (cwd /root): EACCES");
+    resolveBunRuntimeInfo.mockResolvedValue({ status: "probe-failed", error });
+    const audit = await auditBunGateway("/opt/bun");
     expect(audit.issues).toContainEqual(
       expect.objectContaining({
         code: SERVICE_AUDIT_CODES.gatewayRuntimeProbeFailed,

--- a/src/daemon/service-audit.ts
+++ b/src/daemon/service-audit.ts
@@ -638,7 +638,12 @@ async function auditGatewayRuntime(
           runtime.status === "probe-failed"
             ? "Gateway service Bun runtime probe failed."
             : "Gateway service uses an unsupported Bun runtime; Bun 1.4+ with WAL-reset-safe node:sqlite is required.",
-        detail: runtime.status === "probe-failed" ? runtime.error.message : execPath,
+        detail:
+          runtime.status === "probe-failed"
+            ? runtime.error.message
+            : runtime.sqliteSelectionError
+              ? `${execPath}: ${runtime.sqliteSelectionError}`
+              : execPath,
         level: "recommended",
       });
     }

--- a/src/infra/runtime-process-entrypoints.ts
+++ b/src/infra/runtime-process-entrypoints.ts
@@ -87,4 +87,11 @@ export const runtimeProcessEntrypoints = {
     sourceWorkerName: "../process/supervisor/service-child-windows-job-anchor",
     distWorkerPath: "process/supervisor/service-child-windows-job-anchor.js",
   },
+  // Not a launcher: the daemon runtime probe requires this module inside candidate Bun
+  // executables so they select the same SQLite library the Gateway will run with.
+  bunSqliteLibrary: {
+    currentModuleUrl,
+    sourceWorkerName: "bun-sqlite-library",
+    distWorkerPath: "infra/bun-sqlite-library.js",
+  },
 } as const;


### PR DESCRIPTION
Related: #141854

## What Problem This Solves

Fixes an issue where `openclaw gateway install --runtime bun`, `openclaw doctor`, and the Gateway service audit would judge a Bun executable by Apple's system SQLite on macOS, while the Gateway itself (since #141854) selects an extension-capable Homebrew/MacPorts library or the `OPENCLAW_SQLITE_LIBRARY` override before its first `node:sqlite` open. On a macOS whose system SQLite is below the WAL-reset safety floor, daemon install rejected a Bun that the Gateway runs fine with Homebrew's library. In every case the probe reported the wrong SQLite version, and an invalid `OPENCLAW_SQLITE_LIBRARY` that makes the Gateway exit at startup was still judged "supported".

## Why This Change Was Made

The probe now applies the same selection semantics as startup: the selection module is registered as a stable runtime process entry (`dist/infra/bun-sqlite-library.js`, or the source module in dev checkouts, which Bun transpiles) and Bun candidates `require` it and call `ensureSqliteLibrarySelected()` before opening `node:sqlite`. Node probes never load it. The probe child gets a minimal environment (PATH, temp and Windows system keys, plus the two selection inputs `HOMEBREW_PREFIX` and `OPENCLAW_SQLITE_LIBRARY`) instead of the full shell environment. A rejected override is reported as an unsupported result carrying the exact startup error: preferred-Bun resolution throws it instead of advising a Bun upgrade, the service audit shows it as the issue detail, and start repair refuses to silently rewrite a Bun service to Node. A missing selection module fails the whole probe (broken install), not "unsupported". No config options were added.

Non-goal: the managed service environment allowlist still does not forward `OPENCLAW_SQLITE_LIBRARY`/`HOMEBREW_PREFIX` to launchd/systemd; the probe mirrors the invoking environment, matching what `openclaw gateway` does in that shell. Persisting the override into the service definition is a separate, approval-gated decision.

## User Impact

Bun daemon installs, repairs, doctor, and service audits now accept and report the SQLite library the Gateway will actually open. An invalid `OPENCLAW_SQLITE_LIBRARY` fails the install or repair with the same "Fix or unset OPENCLAW_SQLITE_LIBRARY" message the Gateway prints at startup, instead of a misleading "install Bun 1.4+" hint or a silent switch of the service to Node. The probe no longer inherits secrets or `NODE_OPTIONS` from the invoking shell.

## Evidence

Live reproduction on a Mac with Bun 1.4.2, Apple SQLite 3.54.0, Homebrew SQLite 3.53.4 (versions differ, so selection is observable without synthetic data). Startup guard under the same Bun selects Homebrew 3.53.4 and, with an invalid override, exits 1.

Before (`resolveBunRuntimeInfo("/opt/homebrew/bin/bun")`, source):

```
daemon probe (no override):      {"status":"supported","version":"1.4.2","sqliteVersion":"3.54.0","nodeSharedSqlite":false}
daemon probe (invalid override): {"status":"supported","version":"1.4.2","sqliteVersion":"3.54.0","nodeSharedSqlite":false}
```

After (source, and identically from the built `dist/runtime-paths-*.mjs` chunk after `pnpm build`):

```
daemon probe (no override):      {"status":"supported","version":"1.4.2","sqliteVersion":"3.53.4","nodeSharedSqlite":false}
daemon probe (invalid override): {"status":"unsupported","version":"1.4.2","sqliteVersion":null,"nodeSharedSqlite":false,"sqliteSelectionError":"Cannot use SQLite library /nonexistent/libsqlite3.dylib: missing file. Fix or unset OPENCLAW_SQLITE_LIBRARY; install a supported library with brew install sqlite."}
resolvePreferredBunPath (invalid override) threw: Cannot use SQLite library /nonexistent/libsqlite3.dylib: missing file. Fix or unset OPENCLAW_SQLITE_LIBRARY; ...
```

Node probe path with the minimal env (Homebrew Node 26.8.1, shared SQLite 3.53.4) still resolves as supported. `bun -e 'require("dist/infra/bun-sqlite-library.js")...'` loads the stable dist entry and selects Homebrew's library.

Tests: `src/daemon/runtime-paths.test.ts` (68), `src/daemon/service-audit.test.ts` (70), `src/cli/daemon-cli/start-repair.test.ts` (20) green, including new cases for the selected-library success (asserting the `require` line and the exact minimal env), Node never loading the module, the invalid-override result shape, the preferred-path throw, the audit detail, and the repair refusal. `check:changed` green (typecheck core + core tests, deadcode, lint after compacting the audit test file under the 1000-line cap), `check:import-cycles` and `check:madge-import-cycles` 0 cycles, Codex autoreview at P1 scoped-clean.
