### PR TITLE
fix(release): ClawHub bootstrap fails with missing harness dependencies

### DIFF
--- a/.github/workflows/plugin-clawhub-new.yml
+++ b/.github/workflows/plugin-clawhub-new.yml
@@ -523,6 +523,13 @@ jobs:
           install-bun: "true"
           install-deps: "true"
 
+      - name: Install trusted plugin tooling dependencies
+        working-directory: .release-harness
+        env:
+          CI: "true"
+        # Corepack reads this checkout's packageManager before pnpm processes arguments.
+        run: pnpm install --frozen-lockfile --prefer-offline --ignore-scripts
+
       - name: Materialize locked ClawHub CLI
         id: clawhub_cli
         run: |

--- a/test/scripts/package-acceptance-workflow.test.ts
+++ b/test/scripts/package-acceptance-workflow.test.ts
@@ -2786,47 +2786,63 @@ dispatch_workflow_at_ref "$WORKFLOW_REF" "$PARENT_WORKFLOW_SHA" plugin-clawhub-r
       "preview_plugins_npm",
       "Checkout trusted planning tooling",
       "Validate publishable plugin metadata",
+      ".release-tooling",
+      "${{ github.workflow_sha }}",
     ],
     [
       PLUGIN_NPM_RELEASE_WORKFLOW,
       "preview_plugin_pack",
       "Checkout trusted packaging tooling",
       "Prepare immutable npm preflight artifact",
+      ".release-tooling",
+      "${{ github.workflow_sha }}",
     ],
     [
       PLUGIN_CLAWHUB_RELEASE_WORKFLOW,
       "preview_plugins_clawhub",
       "Checkout trusted planning tooling",
       "Validate publishable plugin metadata",
+      ".release-tooling",
+      "${{ github.workflow_sha }}",
     ],
     [
       ".github/workflows/plugin-clawhub-new.yml",
       "resolve_bootstrap_plan",
       "Checkout trusted planning tooling",
       "Validate publishable plugin metadata",
+      ".release-tooling",
+      "${{ github.workflow_sha }}",
+    ],
+    [
+      ".github/workflows/plugin-clawhub-new.yml",
+      "pack_bootstrap_plugins",
+      "Checkout trusted workflow tooling",
+      "Pack immutable ClawHub bootstrap artifacts",
+      ".release-harness",
+      "${{ github.sha }}",
     ],
   ])(
     "initializes independent plugin tooling before %s/%s",
-    (file, jobName, checkoutName, consumerName) => {
+    (file, jobName, checkoutName, consumerName, toolingPath, toolingRef) => {
       const job = workflowJob(file, jobName);
       const checkout = workflowStep(job, checkoutName);
       const setup = workflowStep(job, "Setup Node environment");
       const install = workflowStep(job, "Install trusted plugin tooling dependencies");
       const consumer = workflowStep(job, consumerName);
       expect(checkout.with).toMatchObject({
-        ref: "${{ github.workflow_sha }}",
-        path: ".release-tooling",
+        ref: toolingRef,
+        path: toolingPath,
         "persist-credentials": false,
       });
       expect(checkout.with?.["sparse-checkout"]).toBeUndefined();
-      expect(install["working-directory"]).toBe(".release-tooling");
+      expect(install["working-directory"]).toBe(toolingPath);
       expect(install.env).toMatchObject({ CI: "true" });
       expect(install.run).toBe("pnpm install --frozen-lockfile --prefer-offline --ignore-scripts");
       expect(job.steps!.indexOf(install)).toBeGreaterThan(job.steps!.indexOf(checkout));
       expect(job.steps!.indexOf(install)).toBeGreaterThan(job.steps!.indexOf(setup));
       expect(job.steps!.indexOf(install)).toBeLessThan(job.steps!.indexOf(consumer));
       const root = tempDirs.make("plugin-tooling-install-");
-      const tooling = join(root, ".release-tooling");
+      const tooling = join(root, toolingPath);
       const bin = join(root, "bin");
       mkdirSync(tooling);
       mkdirSync(bin);


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where first-package ClawHub bootstrap fails before packaging because its independently checked-out release harness has no dependencies. Installing the selected release source does not initialize that separate harness.

## Why This Change Was Made

Install the trusted bootstrap packaging harness's frozen workspace dependencies, with lifecycle scripts disabled, after Node setup and before packaging. Extend the existing independent-checkout regression to cover this fifth consumer with its own trusted ref and path. Packed validation and publication jobs continue using their existing immutable artifact flow.

## User Impact

ClawHub bootstrap can package new plugins such as TeamReports. This repair does not change package versions, dependency policy, release source, qualified core artifacts, or publication gates.

## Evidence

- Reproduced the missing-harness-dependencies error with exact release source `1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7` and tooling `01403169248346f2a6d6dd02955fc956fa9e1fe9`, using the canonical locked ClawHub 0.23.3 CLI.
- The real nonpublishing TeamReports pack succeeds after the independent install. Its seven-file archive identifies @openclaw/team-reports@2026.9.3, SHA256 `1949baa5be4dff6b613d3e12a2dbbd34e47b0e3f314843ab3ea502100c5b32bd`. Tracked candidate files remain unchanged.
- 17 focused ownership/ClawHub workflow tests passed. Full scoped checks and workflow validation, including actionlint and zizmor, passed. Independent P2 review passed. Exact-head hosted CI remains required before landing.
