### PR TITLE
fix(plugins): name the changed facet in plugin registry differences

### DIFF
--- a/src/cli/plugins-cli.list.test.ts
+++ b/src/cli/plugins-cli.list.test.ts
@@ -970,14 +970,16 @@ describe("plugins cli list", () => {
   });
 
   it("reports persisted plugin registry state without refreshing", async () => {
+    // Identical sources: only the changed facets tell the operator what moved.
     inspectPluginRegistryMock.mockResolvedValue({
       state: "stale",
       refreshReasons: ["stale-manifest"],
       differences: [
         {
           pluginId: "demo",
+          changed: ["install", "diagnostics"],
           persistedSource: "/plugins/demo/index.js",
-          derivedSource: "/plugins/demo/dist/index.js",
+          derivedSource: "/plugins/demo/index.js",
         },
       ],
       persisted: {
@@ -999,7 +1001,7 @@ describe("plugins cli list", () => {
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("stale");
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("Refresh reasons:");
     expect(pluginsCliRuntimeLogs.join("\n")).toContain(
-      "demo: persisted /plugins/demo/index.js; derived /plugins/demo/dist/index.js",
+      "demo: install+diagnostics changed; persisted /plugins/demo/index.js; derived /plugins/demo/index.js",
     );
     expect(pluginsCliRuntimeLogs.join("\n")).toContain("openclaw plugins registry --refresh");
   });
@@ -1037,6 +1039,7 @@ describe("plugins cli list", () => {
       differences: [
         {
           pluginId: "demo",
+          changed: ["record"],
           persistedSource: "/plugins/demo/index.js",
           derivedSource: "/plugins/demo/dist/index.js",
         },
@@ -1046,7 +1049,7 @@ describe("plugins cli list", () => {
     });
 
     await expect(runPluginsCommand(["plugins", "registry", "--refresh"])).rejects.toThrow(
-      /demo: persisted \/plugins\/demo\/index\.js; derived \/plugins\/demo\/dist\/index\.js.*openclaw plugins registry --refresh/su,
+      /demo: record changed; persisted \/plugins\/demo\/index\.js; derived \/plugins\/demo\/dist\/index\.js.*openclaw plugins registry --refresh/su,
     );
   });
 
@@ -1058,6 +1061,7 @@ describe("plugins cli list", () => {
       differences: [
         {
           pluginId: "demo",
+          changed: ["record"],
           persistedSource: "/plugins/demo/index.js",
           derivedSource: "/plugins/demo/dist/index.js",
         },
@@ -1077,6 +1081,7 @@ describe("plugins cli list", () => {
       differences: [
         {
           pluginId: "demo",
+          changed: ["record"],
           persistedSource: "/plugins/demo/index.js",
           derivedSource: "/plugins/demo/dist/index.js",
         },

--- a/src/cli/plugins-cli.runtime.ts
+++ b/src/cli/plugins-cli.runtime.ts
@@ -260,7 +260,7 @@ export async function runPluginsRegistryCommand(opts: PluginRegistryOptions): Pr
       source ? sanitizeTerminalText(shortenHomeInString(source)) : "missing";
     return differences.map(
       (difference) =>
-        `${sanitizeTerminalText(difference.pluginId)}: persisted ${formatSource(difference.persistedSource)}; derived ${formatSource(difference.derivedSource)}`,
+        `${sanitizeTerminalText(difference.pluginId)}: ${difference.changed.join("+")} changed; persisted ${formatSource(difference.persistedSource)}; derived ${formatSource(difference.derivedSource)}`,
     );
   };
 

--- a/src/commands/doctor-config-preflight-plugin-index.ts
+++ b/src/commands/doctor-config-preflight-plugin-index.ts
@@ -52,7 +52,7 @@ function formatPluginRegistryDifferences(
     )
     .map(
       (difference) =>
-        `${sanitizeTerminalText(difference.pluginId)} (persisted source: ${JSON.stringify(difference.persistedSource)}; derived source: ${JSON.stringify(difference.derivedSource)})`,
+        `${sanitizeTerminalText(difference.pluginId)} (${difference.changed.join("+")} changed; persisted source: ${JSON.stringify(difference.persistedSource)}; derived source: ${JSON.stringify(difference.derivedSource)})`,
     )
     .join(", ");
 }

--- a/src/commands/doctor-config-preflight.plugin-persistence.test.ts
+++ b/src/commands/doctor-config-preflight.plugin-persistence.test.ts
@@ -647,7 +647,7 @@ describe("Doctor plugin persistence", () => {
             throw new Error("expected plugin registry persistence to fail", { cause: failure });
           }
           expect(failure.message).toMatch(
-            /differences: preflight-fixture .*persisted source: .*fixture-plugin.*derived source: .*fixture-plugin.*openclaw plugins registry --refresh/u,
+            /differences: preflight-fixture \(record changed; persisted source: .*fixture-plugin.*derived source: .*fixture-plugin.*openclaw plugins registry --refresh/u,
           );
           expect(failure.message).not.toContain("\u001b");
         } finally {

--- a/src/plugins/plugin-registry-comparison.ts
+++ b/src/plugins/plugin-registry-comparison.ts
@@ -6,7 +6,10 @@ import type {
   InstalledPluginIndexRecord,
 } from "./installed-plugin-index-types.js";
 import { isPathInside, safeRealpathSync } from "./path-safety.js";
-import type { PluginRegistryDifference } from "./plugin-registry-snapshot.types.js";
+import type {
+  PluginRegistryDifference,
+  PluginRegistryDifferenceFacet,
+} from "./plugin-registry-snapshot.types.js";
 
 export function isContainedPluginPath(
   rootPath: string,
@@ -134,25 +137,34 @@ export function diffPluginRegistryRecords(
     .flatMap((pluginId) => {
       const persistedPlugin = persistedPlugins.get(pluginId);
       const derivedPlugin = derivedPlugins.get(pluginId);
-      const persistedContent = [
-        persistedPlugin
-          ? resolvePluginRegistryRecordContent(persistedPlugin, comparePackageJsonPath)
-          : undefined,
-        persisted.installRecords[pluginId],
-        persisted.diagnostics.filter((diagnostic) => diagnostic.pluginId === pluginId),
+      // Name the differing facet: the two source paths are often identical when only
+      // the install record or a diagnostic changed, so sources alone explain nothing.
+      const facets: Array<[PluginRegistryDifferenceFacet, unknown, unknown]> = [
+        [
+          "record",
+          persistedPlugin
+            ? resolvePluginRegistryRecordContent(persistedPlugin, comparePackageJsonPath)
+            : undefined,
+          derivedPlugin
+            ? resolvePluginRegistryRecordContent(derivedPlugin, comparePackageJsonPath)
+            : undefined,
+        ],
+        ["install", persisted.installRecords[pluginId], derived.installRecords[pluginId]],
+        [
+          "diagnostics",
+          persisted.diagnostics.filter((diagnostic) => diagnostic.pluginId === pluginId),
+          derived.diagnostics.filter((diagnostic) => diagnostic.pluginId === pluginId),
+        ],
       ];
-      const derivedContent = [
-        derivedPlugin
-          ? resolvePluginRegistryRecordContent(derivedPlugin, comparePackageJsonPath)
-          : undefined,
-        derived.installRecords[pluginId],
-        derived.diagnostics.filter((diagnostic) => diagnostic.pluginId === pluginId),
-      ];
-      return isDeepStrictEqual(persistedContent, derivedContent)
+      const changed = facets
+        .filter(([, before, after]) => !isDeepStrictEqual(before, after))
+        .map(([facet]) => facet);
+      return changed.length === 0
         ? []
         : [
             {
               pluginId,
+              changed,
               persistedSource: persistedPlugin?.source ?? persistedPlugin?.manifestPath ?? null,
               derivedSource: derivedPlugin?.source ?? derivedPlugin?.manifestPath ?? null,
             },

--- a/src/plugins/plugin-registry-inspection.test.ts
+++ b/src/plugins/plugin-registry-inspection.test.ts
@@ -11,6 +11,7 @@ import {
 import { readPersistedInstalledPluginIndex } from "./installed-plugin-index-store.js";
 import type { InstalledPluginIndex } from "./installed-plugin-index.js";
 import { clearPluginMetadataLifecycleCaches } from "./plugin-metadata-lifecycle.js";
+import { diffPluginRegistryRecords } from "./plugin-registry-comparison.js";
 import { refreshPluginRegistry } from "./plugin-registry-refresh.js";
 import {
   inspectPluginRegistry,
@@ -191,6 +192,7 @@ describe("plugin registry inspection", () => {
     expect(inspection.differences).toEqual([
       {
         pluginId: "demo",
+        changed: ["record"],
         persistedSource: sourceCandidate.source,
         derivedSource: builtSource,
       },
@@ -286,10 +288,57 @@ describe("plugin registry inspection", () => {
     expect(inspection.differences).toEqual([
       {
         pluginId: "demo",
+        changed: ["record"],
         persistedSource: candidate.source,
         derivedSource: candidate.source,
       },
     ]);
+  });
+
+  it("names the changed facets when persisted and derived sources are identical", async () => {
+    const stateDir = makeTempDir();
+    const pluginDir = path.join(stateDir, "extensions", "demo");
+    fs.mkdirSync(pluginDir, { recursive: true });
+    const candidate = createPackagedCandidate(pluginDir);
+    const env = {
+      ...hermeticEnv(),
+      OPENCLAW_DISABLE_BUNDLED_PLUGINS: "1",
+      OPENCLAW_STATE_DIR: stateDir,
+    };
+    const config = { plugins: { entries: { demo: { enabled: true } } } };
+    await refreshPluginRegistry({
+      reason: "manual",
+      stateDir,
+      config,
+      env,
+      installRecords: {
+        demo: { source: "path", sourcePath: pluginDir, installPath: pluginDir, version: "1.0.0" },
+      },
+    });
+    const persisted = expectDefined(
+      await readPersistedInstalledPluginIndex({ stateDir }),
+      "persisted plugin registry",
+    );
+    const persistedInstall = expectDefined(persisted.installRecords.demo, "persisted install");
+    const derived: InstalledPluginIndex = {
+      ...persisted,
+      installRecords: { demo: { ...persistedInstall, version: "1.1.0" } },
+      diagnostics: [
+        ...persisted.diagnostics,
+        { level: "warn", code: "plugin-verification", pluginId: "demo", message: "moved" },
+      ],
+    };
+
+    // Both source paths point at the same file; only the facets tell an operator what moved.
+    expect(diffPluginRegistryRecords(persisted, derived, true, new Map())).toEqual([
+      {
+        pluginId: "demo",
+        changed: ["install", "diagnostics"],
+        persistedSource: candidate.source,
+        derivedSource: candidate.source,
+      },
+    ]);
+    expect(diffPluginRegistryRecords(persisted, persisted, true, new Map())).toEqual([]);
   });
 
   it("uses the configured system-agent workspace for the freshness verdict", async () => {

--- a/src/plugins/plugin-registry-snapshot.types.ts
+++ b/src/plugins/plugin-registry-snapshot.types.ts
@@ -1,8 +1,12 @@
 /** Source class for plugin registry snapshots used by diagnostics and cache decisions. */
 export type PluginRegistrySnapshotSource = "provided" | "persisted" | "derived";
 
+/** Which registry facts differ for one plugin; the sources alone can be identical. */
+export type PluginRegistryDifferenceFacet = "record" | "install" | "diagnostics";
+
 export type PluginRegistryDifference = {
   pluginId: string;
+  changed: readonly PluginRegistryDifferenceFacet[];
   persistedSource: string | null;
   derivedSource: string | null;
 };

--- a/src/plugins/status.registry-snapshot.test.ts
+++ b/src/plugins/status.registry-snapshot.test.ts
@@ -541,6 +541,7 @@ describe("buildPluginRegistrySnapshotReport", () => {
           differences: [
             {
               pluginId: fixture.pluginId,
+              changed: ["record"],
               persistedSource: fixture.runtimeSource,
               derivedSource: fixture.runtimeSource,
             },


### PR DESCRIPTION
## What Problem This Solves

A plugin registry difference is computed over the whole record, its install record and its per-plugin diagnostics, but the difference object only carried the persisted and derived *source paths*. Whenever the record or diagnostics changed while the source stayed put, both surfaces printed a self-contradicting line: the Gateway refused to start with `could not verify the persisted replacement (reread source was derived; differences: longcat (persisted source: "…/extensions/longcat/index.ts"; derived source: "…/extensions/longcat/index.ts"); diagnostics: persisted-registry-stale-source)` (observed live while a plugin package was being rebuilt), and `openclaw plugins registry` printed `longcat: persisted …/index.ts; derived …/index.ts`. Neither tells the operator what actually moved.

## Why This Change Was Made

`PluginRegistryDifference` now carries a non-empty `changed` list naming the differing facets (`record`, `install`, `diagnostics`), computed where the comparison already runs (`diffPluginRegistryRecords`). Both renderers print it: the startup refusal reads `longcat (record changed; persisted source: …; derived source: …)` and the CLI reads `longcat: record changed; persisted …; derived …`. The `plugins registry --json` output gains the same field additively.

## User Impact

Operators hitting a stale persisted registry see which part of the plugin changed instead of two identical paths. No behavior change beyond the message and the additive JSON field.

## Evidence

- Live: an isolated Gateway start on a built `main` dist failed with the identical-sources message while `pnpm test:extensions` rebuilt a plugin in the same checkout; the retry started cleanly.
- New case in `src/plugins/plugin-registry-inspection.test.ts` calls the comparison owner with identical sources and a changed install record plus diagnostic: fails on `main` (no `changed` field), passes with the fix (`["install", "diagnostics"]`); identical inputs yield no difference.
- The `plugins registry` report case in `src/cli/plugins-cli.list.test.ts` now uses identical sources and asserts `demo: install+diagnostics changed; persisted /plugins/demo/index.js; derived /plugins/demo/index.js`; the startup-refusal regression in `doctor-config-preflight.plugin-persistence.test.ts` now requires the facet.
- `node scripts/run-vitest.mjs` over plugin-registry-inspection (10), plugins-cli.list (42), doctor-config-preflight.plugin-persistence (15), status.registry-snapshot (30): pass. `node scripts/check-changed.mjs`: pass. Autoreview (Codex): scoped-clean.

Production LOC delta: +21 (facet computation replaces the single deep-equal; two format strings; one type).
