### PR TITLE
fix(mattermost): keep sibling accounts connected during secret-reference reloads

### DIFF
--- a/extensions/mattermost/src/channel-actions-setup-status.contract.test.ts
+++ b/extensions/mattermost/src/channel-actions-setup-status.contract.test.ts
@@ -5,7 +5,7 @@ import {
   installChannelStatusContractSuite,
 } from "openclaw/plugin-sdk/channel-test-helpers";
 import type { OpenClawConfig } from "openclaw/plugin-sdk/config-contracts";
-import { describe, expect } from "vitest";
+import { describe, expect, it } from "vitest";
 import { mattermostPlugin, mattermostSetupPlugin } from "../channel-plugin-api.js";
 
 describe("mattermost actions contract", () => {
@@ -138,5 +138,31 @@ describe("mattermost status contract", () => {
         },
       },
     ],
+  });
+});
+
+describe.each([
+  ["runtime", mattermostPlugin],
+  ["setup", mattermostSetupPlugin],
+] as const)("mattermost %s account inspection", (_name, plugin) => {
+  it("inspects source SecretRefs while strict account resolution rejects them", () => {
+    const cfg = {
+      channels: {
+        mattermost: {
+          baseUrl: "https://chat.example.com",
+          accounts: {
+            alpha: { botToken: { source: "env", provider: "default", id: "BOT_TOKEN" } },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    expect(plugin.config.listAccountIds(cfg)).toContain("alpha");
+    expect(plugin.config.inspectAccount?.(cfg, "alpha")).toMatchObject({
+      accountId: "alpha",
+      configured: true,
+      botTokenStatus: "configured_unavailable",
+      botToken: undefined,
+    });
+    expect(() => plugin.config.resolveAccount(cfg, "alpha")).toThrow();
   });
 });

--- a/extensions/mattermost/src/channel-config-shared.ts
+++ b/extensions/mattermost/src/channel-config-shared.ts
@@ -8,6 +8,7 @@ import {
 import { normalizeLowercaseStringOrEmpty } from "openclaw/plugin-sdk/string-coerce-runtime";
 import { resolveMattermostGatewayAuthBypassPaths } from "./gateway-auth-bypass.js";
 import {
+  inspectMattermostAccount,
   isMattermostConfigured,
   listMattermostAccountIds,
   resolveDefaultMattermostAccountId,
@@ -55,6 +56,7 @@ export const mattermostConfigAdapter = createScopedChannelConfigAdapter<Resolved
   sectionKey: "mattermost",
   listAccountIds: listMattermostAccountIds,
   resolveAccount: adaptScopedAccountAccessor(resolveMattermostAccount),
+  inspectAccount: adaptScopedAccountAccessor(inspectMattermostAccount),
   defaultAccountId: resolveDefaultMattermostAccountId,
   clearBaseFields: ["botToken", "baseUrl", "name"],
   resolveAllowFrom: (account) => account.config.allowFrom,

--- a/extensions/mattermost/src/channel.ts
+++ b/extensions/mattermost/src/channel.ts
@@ -5,7 +5,6 @@ import {
   readStringParam,
   withNormalizedTimestamp,
 } from "openclaw/plugin-sdk/channel-actions";
-import { adaptScopedAccountAccessor } from "openclaw/plugin-sdk/channel-config-helpers";
 import type {
   ChannelMessageActionAdapter,
   ChannelMessageActionName,
@@ -755,7 +754,6 @@ export const mattermostPlugin: ChannelPlugin<ResolvedMattermostAccount> = create
     configSchema: MattermostChannelConfigSchema,
     config: {
       ...mattermostConfigAdapter,
-      inspectAccount: adaptScopedAccountAccessor(inspectMattermostAccount),
       isConfigured: isMattermostConfigured,
       describeAccount: describeMattermostAccount,
     },

--- a/src/gateway/config-reload-plan.ts
+++ b/src/gateway/config-reload-plan.ts
@@ -452,7 +452,7 @@ function extractAccountIdFromPath(channel: ChannelId, path: string): string | nu
   return id && id !== DEFAULT_ACCOUNT_ID ? id : null;
 }
 
-function isResolvableChannelAccount(params: {
+function isInspectableChannelAccount(params: {
   plugin: ChannelPlugin;
   accountId: string;
   config: OpenClawConfig;
@@ -461,7 +461,9 @@ function isResolvableChannelAccount(params: {
     if (!params.plugin.config.listAccountIds(params.config).includes(params.accountId)) {
       return false;
     }
-    params.plugin.config.resolveAccount(params.config, params.accountId);
+    const inspectAccount =
+      params.plugin.config.inspectAccount ?? params.plugin.config.resolveAccount;
+    inspectAccount(params.config, params.accountId);
     return true;
   } catch {
     return false;
@@ -545,7 +547,7 @@ export function buildGatewayReloadPlan(
       if (
         accountId === null ||
         (options.candidateConfig &&
-          !isResolvableChannelAccount({ plugin, accountId, config: options.candidateConfig }))
+          !isInspectableChannelAccount({ plugin, accountId, config: options.candidateConfig }))
       ) {
         plan.restartChannels.add(plugin.id);
         continue;

--- a/src/gateway/config-reload.test.ts
+++ b/src/gateway/config-reload.test.ts
@@ -1260,6 +1260,76 @@ describe("buildGatewayReloadPlan", () => {
     expect(isNoopGatewayReloadPlan(plan)).toBe(false);
   });
 
+  it.each([
+    {
+      label: "inspects unresolved account secrets",
+      inspection: "available",
+      resolves: false,
+      scoped: true,
+    },
+    {
+      label: "promotes failed inspection without falling back to resolution",
+      inspection: "throws",
+      resolves: true,
+      scoped: false,
+    },
+    {
+      label: "resolves accounts when inspection is unavailable",
+      inspection: "absent",
+      resolves: true,
+      scoped: true,
+    },
+    {
+      label: "promotes failed resolution when inspection is unavailable",
+      inspection: "absent",
+      resolves: false,
+      scoped: false,
+    },
+  ])("$label", ({ inspection, resolves, scoped }) => {
+    const plugin: ChannelPlugin = {
+      ...mattermostPlugin,
+      config: {
+        ...mattermostPlugin.config,
+        resolveAccount: () => {
+          if (!resolves) {
+            throw new Error("SecretRef has not been activated");
+          }
+          return {};
+        },
+        ...(inspection === "absent"
+          ? {}
+          : {
+              inspectAccount: () => {
+                if (inspection === "throws") {
+                  throw new Error("Account cannot be inspected");
+                }
+                return { configured: true, botTokenStatus: "configured_unavailable" };
+              },
+            }),
+      },
+    };
+    setActivePluginRegistry(
+      createTestRegistry([{ pluginId: "mattermost", plugin, source: "test" }]),
+    );
+    const candidateConfig = {
+      channels: {
+        mattermost: {
+          accounts: {
+            alpha: { botToken: { source: "env", provider: "default", id: "BOT_TOKEN" } },
+            beta: { enabled: true },
+          },
+        },
+      },
+    } as OpenClawConfig;
+    const plan = buildGatewayReloadPlan(["channels.mattermost.accounts.alpha.botToken"], {
+      candidateConfig,
+    });
+    expect(plan.restartChannels).toEqual(new Set(scoped ? [] : ["mattermost"]));
+    expect(plan.restartChannelAccounts).toEqual(
+      new Map(scoped ? [["mattermost", new Set(["alpha"])]] : []),
+    );
+  });
+
   it("restarts every channel whose config prefix matches", () => {
     const plan = buildGatewayReloadPlan(["web.enabled", "channels.telegram.botToken"]);
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where changing one Mattermost account's settings disconnected other accounts when bot tokens used secret references, even when those references resolved successfully at runtime.

## Why This Change Was Made

Reload planning now uses the existing account inspection hook, with strict resolution as the fallback when a plugin has no inspector. Mattermost exposes its existing inspector through the shared runtime/setup adapter. Restart execution, secret activation, and transport authentication retain their strict checks.

## User Impact

Operators can change a named account's non-secret settings without interrupting other working accounts. Global changes still restart the channel. Unavailable credentials retain the existing strict failure and recovery behavior.

## Evidence

Verified with the built Gateway, watched configuration writes, an isolated official Mattermost server, two bot accounts, and file-based secret references. Authentication used real REST responses and matched WebSocket acknowledgments. Connection continuity and replies were observed through the real transport; a deterministic local provider supplied only reply text.

| Scenario | Pinned main | Candidate |
| --- | --- | --- |
| First account-only change | Both connections replaced | Only the changed account replaced; both accounts replied |
| Second account-only change | Not repeated | Same sibling connection retained; both accounts replied |
| Global change | Not repeated | Both connections replaced; both accounts replied |

- Baseline planner regression failed on the unwanted whole-channel target. The setup-adapter regression failed on the absent inspection hook.
- 430 focused tests passed across planning, Mattermost adapters and authentication, secret publication, restart ordering, deferral, and failure handling.
- Missing, empty, unavailable, and invalid credentials did not create authenticated service. Existing valid service was distinguished from new startup. Valid token rotation used normal secret activation and real authentication.
- A held ordinary reply deferred the account reload. The reply completed before connection replacement, and the sibling connection remained unchanged.
- A cold-account negative initially had an incorrect same-sibling-connection expectation. The retained observations show the existing strict executor's whole-channel fallback: the unavailable account remained blocked while the valid sibling reauthenticated and replied. Independent source review confirmed this preserved behavior; the original failed harness result remains recorded.
- Fresh source-blind acceptance passed 13 independently exercised runtime cases and independently checked the raw baseline and cold-account records.
- Native builds, formatting, and focused lint passed. Full hosted checks and the final exact-head review are separate landing gates.

Private raw fixtures and observations retain the complete before/after evidence and failure history. Credentials, account and room details, messages, connection identities, and infrastructure metadata are omitted here.

Preserves @ceckert's original contribution and commit ancestry. AI-assisted repair and validation.
