### PR TITLE
fix(terminal): preserve blank lines in multiline table cells

### DIFF
--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -620,6 +620,55 @@ console.log(JSON.stringify({
   );
 
   it.each([
+    ["LF", "\n", "", ""],
+    ["CR", "\r", "", ""],
+    ["CRLF", "\r\n", "", ""],
+    ["colored CRLF", "\r\n", "\x1b[31m", "\x1b[39m"],
+    ["linked LF", "\n", "\x1b]8;;https://example.com/\x07", "\x1b]8;;\x07"],
+  ])(
+    "preserves blank %s lines at their positions across cells",
+    (_label, separator, open, close) => {
+      const out = renderTable({
+        border: "ascii",
+        width: 30,
+        columns: [
+          { key: "A", header: "A", flex: true },
+          { key: "B", header: "B", flex: true },
+        ],
+        rows: [
+          {
+            A: `${open}${["", "alpha", "", "omega", "", ""].join(separator)}${close}`,
+            B: "0\n1\n2\n3\n4",
+          },
+        ],
+      });
+
+      const dataLines = out.trimEnd().split("\n").slice(3, -1);
+      expect(
+        dataLines.map((line) =>
+          stripAnsi(line)
+            .split("|")
+            .slice(1, -1)
+            .map((cell) => cell.trim()),
+        ),
+      ).toEqual([
+        ["", "0"],
+        ["alpha", "1"],
+        ["", "2"],
+        ["omega", "3"],
+        ["", "4"],
+      ]);
+      if (open) {
+        for (const line of dataLines) {
+          const cell = line.split("|")[1] ?? "";
+          expect(cell).toContain(open);
+          expect(cell).toContain(close);
+        }
+      }
+    },
+  );
+
+  it.each([
     ["LF", "line1\n東京 line2", "", "", 0],
     ["CR", "line1\r東京 line2", "", "", 0],
     ["CRLF", "line1\r\n東京 line2", "", "", 0],

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -256,18 +256,8 @@ function wrapLine(text: string, width: number): string[] {
   let bufVisible = 0;
   let lastBreakIndex: number | null = null;
 
-  const pushLine = (value: string) => {
-    const cleaned = value.replace(/\s+$/, "");
-    if (visibleWidth(cleaned) === 0) {
-      return;
-    }
-    lines.push(cleaned);
-  };
-
+  // Explicit newlines emit empty buffers too, keeping sibling cell rows aligned.
   const flushAt = (breakAt: number | null) => {
-    if (buf.length === 0) {
-      return;
-    }
     // Keep the suffix in its buffer: long zero-width runs can exceed the argument
     // limit of a spread-based copy even when their visible width is small.
     const left = breakAt == null || breakAt <= 0 ? buf : buf.splice(0, breakAt);
@@ -296,7 +286,7 @@ function wrapLine(text: string, width: number): string[] {
     const openOsc8 = activeOsc8 ? `${ESC}]8;${activeOsc8.params};${activeOsc8.uri}${BEL}` : "";
     const closeSgr = activeSgr.map((state) => state.close).join("");
 
-    pushLine(`${content.join("")}${closeOsc8}${closeSgr}`);
+    lines.push(`${content.join("")}${closeOsc8}${closeSgr}`.trimEnd());
     if (breakAt == null || breakAt <= 0) {
       buf.length = 0;
       if (openOsc8) {
@@ -338,8 +328,8 @@ function wrapLine(text: string, width: number): string[] {
         return;
       }
       // CRLF is one grapheme; separated CR/LF may retain intervening ANSI controls.
-      skipNextLf = ch === "\r";
       if (ch === "\n" || ch === "\r" || ch === "\r\n") {
+        skipNextLf = ch === "\r";
         flushAt(buf.length);
         return;
       }
@@ -358,8 +348,12 @@ function wrapLine(text: string, width: number): string[] {
 
     buf.push(token);
     bufVisible += token.width;
-    if (token.kind === "char" && isBreakChar(token.value)) {
-      lastBreakIndex = buf.length;
+    if (token.kind === "char") {
+      // Discarded leading spacing must not interrupt a separated CR/LF pair.
+      skipNextLf = false;
+      if (isBreakChar(token.value)) {
+        lastBreakIndex = buf.length;
+      }
     }
   };
 
@@ -395,7 +389,10 @@ function wrapLine(text: string, width: number): string[] {
     return [text];
   }
 
-  flushAt(buf.length);
+  // A trailing newline or reopened style is not another physical row.
+  if (bufVisible > 0) {
+    flushAt(buf.length);
+  }
   return lines.length > 0 ? lines : [""];
 }
 


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users reading multiline CLI tables would see text shift onto the wrong sibling line when a cell contained explicit blank lines. For cells containing `alpha\n\nomega` and `1\n2\n3`, the data rows changed from:

```text
alpha | 1
omega | 2
      | 3
```

To:

```text
alpha | 1
      | 2
omega | 3
```

## Why This Change Was Made

Emit explicit hard line breaks at the table wrapping owner, and suppress only an empty final remainder. Remove the blanket empty-line filters and their one-use wrapper. Clear pending CR state when a character is actually buffered so discarded spacing inside an ANSI sequence cannot split an existing CR/LF pair.

## User Impact

Blank lines in descriptions and other multiline table cells retain their positions. ANSI colors, hyperlinks, CRLF, and neighboring columns stay aligned without adding a phantom trailing row.

## Evidence

- Reproduced the shifted rows through the exported `renderTable` function before changing production code.
- Five new regression cases failed on the original code: LF, CR, CRLF, colored CRLF, and linked LF. They cover leading, internal, and trailing explicit blank lines against a numbered sibling column.
- All 91 table/note tests pass, including existing ANSI/OSC-8, separated CR/CSI-tab/LF, large-row, and wrapping checks. The full suite caught the connected pending-CR issue during implementation; its existing assertion was retained and the owner state transition was repaired.
- The owning package test type graph, full-file typed lint, formatting, and diff checks pass. Independent P2 review found no actionable findings.

Production: 13 added / 16 removed, net -3 lines. Tests: +49 lines. No configuration, protocol, dependency, or persistence changes.
