### PR TITLE
fix(llm): retain prepared runtimes through transport cleanup

### DIFF
--- a/packages/ai/src/host.ts
+++ b/packages/ai/src/host.ts
@@ -129,6 +129,8 @@ type AnthropicInlineContentNormalizer = (
 
 /** Narrow host ports consumed by the built-in provider adapters. */
 export interface AiTransportHost {
+  /** Retains accepted lifecycle work after its caller observes cancellation. */
+  observePendingProviderWork?: (pending: Promise<unknown>) => void;
   /**
    * Builds a policy-guarded fetch for one model request.
    * Returning undefined keeps the provider SDK's default fetch.

--- a/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
+++ b/packages/ai/src/transports/transport-stream-shared.acceptance.test.ts
@@ -1,5 +1,6 @@
 import type { Model, StreamOptions } from "@openclaw/llm-core";
 import { describe, expect, it, vi } from "vitest";
+import { configureAiTransportHost, getAiTransportHost } from "../host.js";
 import {
   copyProviderAcceptanceObserver,
   notifyProviderHttpMetadata,
@@ -139,5 +140,94 @@ describe("private provider acceptance", () => {
     ).rejects.toBe(hookError);
 
     expect(cancelStream).toHaveBeenCalledWith(hookError);
+  });
+
+  it.each(["resolve", "reject"] as const)(
+    "observes actual callback and cancellation work when a callback later %ss",
+    async (outcome) => {
+      const host = getAiTransportHost();
+      const observed: Promise<unknown>[] = [];
+      const events: string[] = [];
+      const controller = new AbortController();
+      let callbackStarted!: () => void;
+      const started = new Promise<void>((resolve) => {
+        callbackStarted = resolve;
+      });
+      const lateCallbackError = new Error("late response failure");
+      const cleanupError = new Error("cancellation failure");
+      let finishCallback!: () => void;
+      const callback = new Promise<void>((resolve, reject) => {
+        finishCallback = () => (outcome === "resolve" ? resolve() : reject(lateCallbackError));
+      });
+      let finishCleanup!: () => void;
+      const cleanup = new Promise<void>((_resolve, reject) => {
+        finishCleanup = () => reject(cleanupError);
+      });
+      configureAiTransportHost({
+        ...host,
+        observePendingProviderWork: (pending) => {
+          events.push("observed");
+          observed.push(pending);
+        },
+      });
+      const cancelStream = vi.fn(() => {
+        events.push("cancel");
+        return cleanup;
+      });
+      const onResponse = vi.fn(() => {
+        events.push("callback");
+        callbackStarted();
+        return callback;
+      });
+      const notification = notifyProviderHttpMetadata({
+        options: { signal: controller.signal, onResponse },
+        response: { status: 200, headers: {} },
+        model,
+        cancelStream,
+      });
+      try {
+        expect(onResponse).not.toHaveBeenCalled();
+        await started;
+        controller.abort();
+        await expect(notification).rejects.toThrow("Request was aborted");
+        expect(events).toEqual(["observed", "callback", "cancel", "observed"]);
+        expect(cancelStream).toHaveBeenCalledOnce();
+        expect(observed[1]).toBe(cleanup);
+        finishCallback();
+        if (outcome === "resolve") {
+          await expect(observed[0]).resolves.toBeUndefined();
+        } else {
+          await expect(observed[0]).rejects.toBe(lateCallbackError);
+        }
+        finishCleanup();
+        await expect(observed[1]).rejects.toBe(cleanupError);
+      } finally {
+        controller.abort();
+        finishCallback();
+        finishCleanup();
+        await Promise.allSettled([notification, callback, cleanup, ...observed]);
+        configureAiTransportHost(host);
+      }
+    },
+  );
+
+  it("preserves the lifecycle failure when cancellation throws synchronously", async () => {
+    const callbackError = new Error("response failure");
+    const cancelStream = vi.fn(() => {
+      throw new Error("cancel failure");
+    });
+    await expect(
+      notifyProviderHttpMetadata({
+        options: {
+          onResponse: () => {
+            throw callbackError;
+          },
+        },
+        response: { status: 200, headers: {} },
+        model,
+        cancelStream,
+      }),
+    ).rejects.toBe(callbackError);
+    expect(cancelStream).toHaveBeenCalledOnce();
   });
 });

--- a/packages/ai/src/transports/transport-stream-shared.ts
+++ b/packages/ai/src/transports/transport-stream-shared.ts
@@ -11,6 +11,7 @@ import type {
   Usage,
 } from "@openclaw/llm-core";
 import { asNonArrayRecord, asOptionalRecord } from "@openclaw/normalization-core/record-coerce";
+import { getAiTransportHost } from "../host.js";
 import {
   appendAssistantMessageDiagnostic,
   createAssistantMessageDiagnostic,
@@ -253,6 +254,7 @@ async function awaitProviderLifecycleCallback(
     return;
   }
   const callbackPromise = Promise.resolve().then(callback);
+  getAiTransportHost().observePendingProviderWork?.(callbackPromise);
   if (!signal) {
     await callbackPromise;
     return;
@@ -280,7 +282,9 @@ function startProviderStreamCancellation(cancelStream: ProviderStreamCancel, err
   const reason = error instanceof Error ? error : new Error(String(error));
   try {
     // The lifecycle failure remains authoritative. Cleanup must not delay or replace it.
-    void Promise.resolve(cancelStream(reason)).catch(() => undefined);
+    const pending = Promise.resolve(cancelStream(reason));
+    void pending.catch(() => undefined);
+    getAiTransportHost().observePendingProviderWork?.(pending);
   } catch {
     // A synchronous cleanup failure cannot replace the lifecycle failure either.
   }

--- a/src/llm/ai-transport-host.ts
+++ b/src/llm/ai-transport-host.ts
@@ -15,6 +15,7 @@ import {
 import { createSubsystemLogger } from "../logging/subsystem.js";
 import { normalizeAnthropicInlineContentBlocks } from "../media/anthropic-inline-images.js";
 import { swapSecretSentinelsInText } from "../secrets/sentinel.js";
+import { trackAsyncWork } from "../shared/async-work-scope.js";
 
 const transportLogBySubsystem = new Map<string, ReturnType<typeof createSubsystemLogger>>();
 
@@ -30,6 +31,9 @@ function transportLog(subsystem: string): ReturnType<typeof createSubsystemLogge
 }
 
 configureAiTransportHost({
+  observePendingProviderWork: (pending) => {
+    void trackAsyncWork(() => pending).catch(() => {});
+  },
   buildModelFetch: buildGuardedModelFetch,
   resolveSecretSentinel: (value) => {
     const swapped = swapSecretSentinelsInText(value);

--- a/src/plugins/runtime/runtime-llm.prepared-owner.test.ts
+++ b/src/plugins/runtime/runtime-llm.prepared-owner.test.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import { createServer, type ServerResponse } from "node:http";
 import path from "node:path";
 import { performance } from "node:perf_hooks";
+import { getAiTransportHost } from "@openclaw/ai";
 import { expect, it, vi } from "vitest";
 import { createDeferred } from "../../../test/helpers/promise.js";
 import { resolveAgentDir } from "../../agents/agent-scope-config.js";
@@ -19,6 +20,7 @@ import { resetPreparedModelRuntimeSnapshotsForTest } from "../../agents/prepared
 import { AuthStorage } from "../../agents/sessions/auth-storage.js";
 import { ModelRegistry } from "../../agents/sessions/model-registry.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { AsyncWorkScope } from "../../shared/async-work-scope.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { resetPluginLoaderTestStateForTest } from "../loader.test-fixtures.js";
 import { clearPluginMetadataLifecycleCaches } from "../plugin-metadata-lifecycle.js";
@@ -39,6 +41,8 @@ it.each([
   "prepare-throw",
   "provider-error",
   "abort",
+  "callback-drain",
+  "cancel-drain",
 ] as const)("keeps direct completion ownership coherent: %s", async (mode) => {
   const roots = createSyncSuiteTempRootTracker("runtime-llm-prepared-owner");
   const root = fs.realpathSync(roots.makeTempDir());
@@ -150,6 +154,97 @@ it.each([
       const setRuntimeKey = vi.spyOn(AuthStorage.prototype, "setRuntimeApiKey");
       const resolveModel = modelResolution.resolveModelAsync;
       const resolver = vi.spyOn(modelResolution, "resolveModelAsync");
+      const drainMode = mode === "callback-drain" || mode === "cancel-drain";
+      const workStarted = createDeferred();
+      let acceptedWorkStarted = false;
+      const finishWork = createDeferred();
+      const workSettled = createDeferred();
+      const parentWork = new AsyncWorkScope();
+      let parentDrain: Promise<void> | undefined;
+      let parentDrained = false;
+      const responseFailure = new Error("fixture response callback failure");
+      const cancellationFailure = new Error("fixture cancellation failure");
+      const transportSpies: Array<{ mockRestore: () => void }> = [];
+      if (drainMode) {
+        const { configureAiTransportRuntimeHost } =
+          await import("../../agents/ai-transport-runtime-host.js");
+        configureAiTransportRuntimeHost();
+        const pluginHost = getAiTransportHost().plugin;
+        const wrap = pluginHost.wrapSimpleCompletionStream;
+        let responses = 0;
+        transportSpies.push(
+          vi.spyOn(pluginHost, "wrapSimpleCompletionStream").mockImplementation((params) => {
+            const stream = wrap(params) ?? params.context.streamFn;
+            return (model, context, options) =>
+              stream(model, context, {
+                ...options,
+                onResponse: async (response, responseModel) => {
+                  await options?.onResponse?.(response, responseModel);
+                  if (++responses !== 1) {
+                    return;
+                  }
+                  if (mode === "cancel-drain") {
+                    throw responseFailure;
+                  }
+                  acceptedWorkStarted = true;
+                  workStarted.resolve();
+                  try {
+                    await finishWork.promise;
+                  } finally {
+                    workSettled.resolve();
+                  }
+                },
+              });
+          }),
+        );
+        if (mode === "cancel-drain") {
+          const realFetch = globalThis.fetch;
+          let wrappedResponse = false;
+          transportSpies.push(
+            vi.spyOn(globalThis, "fetch").mockImplementation(async (...args) => {
+              const response = await realFetch(...args);
+              if (
+                wrappedResponse ||
+                !response.url.startsWith(`http://127.0.0.1:${address.port}/`)
+              ) {
+                return response;
+              }
+              wrappedResponse = true;
+              const reader = response.body?.getReader();
+              if (!reader) {
+                throw new Error("Fixture provider response has no body");
+              }
+              return new Response(
+                new ReadableStream<Uint8Array>({
+                  async pull(controller) {
+                    const { value, done } = await reader.read();
+                    if (done) {
+                      controller.close();
+                    } else {
+                      controller.enqueue(value);
+                    }
+                  },
+                  async cancel(reason) {
+                    acceptedWorkStarted = true;
+                    workStarted.resolve();
+                    try {
+                      await finishWork.promise;
+                      throw cancellationFailure;
+                    } finally {
+                      try {
+                        await reader.cancel(reason);
+                      } finally {
+                        workSettled.resolve();
+                      }
+                    }
+                  },
+                }),
+                { status: response.status, headers: response.headers },
+              );
+            }),
+          );
+        }
+      }
       let currentConfig = cfg;
       const llm = createRuntimeLlm({ getConfig: () => currentConfig });
       const input = (modelId = "lease-model") => ({
@@ -254,13 +349,53 @@ it.each([
           });
           return;
         }
-        const abortController = mode === "abort" ? new AbortController() : undefined;
+        const abortController =
+          mode === "abort" || mode === "callback-drain" ? new AbortController() : undefined;
         const firstStarted = performance.now();
-        const first = start(0, abortController?.signal);
+        const first = drainMode
+          ? parentWork.track(() => start(0, abortController?.signal))
+          : start(0, abortController?.signal);
         await waitForRequest(0, first);
         const firstPreparationMs = performance.now() - firstStarted;
         const firstBuilds = create.mock.calls.length;
         expect(firstBuilds).toBeGreaterThan(0);
+        if (drainMode) {
+          finish(requests[0]!, 0);
+          await Promise.race([
+            workStarted.promise,
+            first.then(() => {
+              throw new Error("Completion settled before accepted fixture work");
+            }),
+          ]);
+          abortController?.abort();
+          await expect(first).resolves.toMatchObject({ text: "" });
+          parentDrain = parentWork.drain().then(() => {
+            parentDrained = true;
+          });
+          const second = start(1);
+          await waitForRequest(1, second);
+          expect.soft(parentDrained).toBe(false);
+          expect.soft(create.mock.calls.length).toBe(firstBuilds);
+          expect(fork.mock.calls).toHaveLength(2);
+          expect(fork.mock.calls[0]![0]).not.toBe(fork.mock.calls[1]![0]);
+          finishWork.resolve();
+          await workSettled.promise;
+          await parentDrain;
+          expect(parentDrained).toBe(true);
+          finish(requests[1]!, 1);
+          await expect(second).resolves.toMatchObject({
+            text: "result-1|/A/v1/chat/completions|Bearer fixture-auth-A",
+          });
+          const buildsAfterSecond = create.mock.calls.length;
+          const third = start(2);
+          await waitForRequest(2, third);
+          expect(create.mock.calls.length).toBe(buildsAfterSecond + 1);
+          finish(requests[2]!, 2);
+          await expect(third).resolves.toMatchObject({
+            text: "result-2|/A/v1/chat/completions|Bearer fixture-auth-A",
+          });
+          return;
+        }
         if (mode === "provider-error" || mode === "abort") {
           if (abortController) {
             abortController.abort();
@@ -349,9 +484,18 @@ it.each([
           });
         }
       } finally {
+        finishWork.resolve();
         finishing = true;
         requests.forEach(finish);
         await Promise.allSettled(pending);
+        if (acceptedWorkStarted) {
+          await workSettled.promise;
+        }
+        await parentDrain;
+        await parentWork.drain();
+        for (const spy of transportSpies) {
+          spy.mockRestore();
+        }
         retained?.release();
         create.mockRestore();
         fork.mockRestore();

--- a/src/plugins/runtime/runtime-llm.runtime.ts
+++ b/src/plugins/runtime/runtime-llm.runtime.ts
@@ -11,6 +11,8 @@ import { markHostPluginUsageDiagnosticEvent } from "../../infra/diagnostic-plugi
 import type { Api, Message } from "../../llm/types.js";
 import { getChildLogger } from "../../logging.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
+import { AsyncWorkScope, captureAsyncWorkTracker } from "../../shared/async-work-scope.js";
+import { createDeferredCore } from "../../shared/deferred.js";
 import { modelKey } from "../../shared/model-key.js";
 import {
   estimateAggregateUsageCost,
@@ -579,70 +581,85 @@ export function createRuntimeLlm(
         });
       }
 
-      const prepared = await acquireSimpleCompletionModelForAgent({
-        cfg,
-        agentId,
-        modelRef: params.model,
-        preferredProfile,
-        allowBundledStaticCatalogFallback: true,
-        allowMissingApiKeyModes: ["aws-sdk"],
-        skipAgentDiscovery: true,
-      });
-
-      if ("error" in prepared) {
-        throw new Error(`Plugin LLM completion failed: ${prepared.error}`);
-      }
-
-      try {
-        const context = {
-          systemPrompt: buildSystemPrompt(params),
-          messages: buildMessages({
-            request: params,
-            provider: prepared.model.provider,
-            model: prepared.model.id,
-            api: prepared.model.api,
-          }),
-        };
-
-        const result = await completeWithPreparedSimpleCompletionModel({
-          model: prepared.model,
-          auth: prepared.auth,
+      const callerResult = createDeferredCore<LlmCompleteResult>();
+      const trackOwner = captureAsyncWorkTracker();
+      // Admit drainage with the parent before acquisition; the caller only waits for its result.
+      void trackOwner(async () => {
+        const prepared = await acquireSimpleCompletionModelForAgent({
           cfg,
-          context,
-          options: {
-            maxTokens: asFiniteNumber(params.maxTokens),
-            temperature: asFiniteNumber(params.temperature),
-            ...(params.reasoning !== undefined ? { reasoning: params.reasoning } : {}),
-            signal: params.signal,
-          },
+          agentId,
+          modelRef: params.model,
+          preferredProfile,
+          allowBundledStaticCatalogFallback: true,
+          allowMissingApiKeyModes: ["aws-sdk"],
+          skipAgentDiscovery: true,
         });
 
-        const text = result.content
-          .filter((c): c is { type: "text"; text: string } => c.type === "text")
-          .map((c) => c.text)
-          .join("");
-        return finalizePluginLlmCompletion({
-          cfg,
-          hostPluginId: pluginPolicyId,
-          // Provider failures resolve as messages; only visible successful output owns usage.
-          suppressUsage: !text.trim() || !["stop", "length", "toolUse"].includes(result.stopReason),
-          rawUsage: result.usage,
-          logger,
-          result: {
-            text,
-            provider: prepared.selection.provider,
-            model: prepared.selection.modelId,
-            agentId,
-            execution: {
-              mode: "direct-provider",
-              owner: { kind: "provider", id: prepared.selection.provider },
-            },
-            audit,
-          },
-        });
-      } finally {
-        prepared.release();
-      }
+        if ("error" in prepared) {
+          throw new Error(`Plugin LLM completion failed: ${prepared.error}`);
+        }
+
+        const work = new AsyncWorkScope();
+        try {
+          callerResult.resolve(
+            await work.track(async () => {
+              const context = {
+                systemPrompt: buildSystemPrompt(params),
+                messages: buildMessages({
+                  request: params,
+                  provider: prepared.model.provider,
+                  model: prepared.model.id,
+                  api: prepared.model.api,
+                }),
+              };
+
+              const result = await completeWithPreparedSimpleCompletionModel({
+                model: prepared.model,
+                auth: prepared.auth,
+                cfg,
+                context,
+                options: {
+                  maxTokens: asFiniteNumber(params.maxTokens),
+                  temperature: asFiniteNumber(params.temperature),
+                  ...(params.reasoning !== undefined ? { reasoning: params.reasoning } : {}),
+                  signal: params.signal,
+                },
+              });
+
+              const text = result.content
+                .filter((c): c is { type: "text"; text: string } => c.type === "text")
+                .map((c) => c.text)
+                .join("");
+              return finalizePluginLlmCompletion({
+                cfg,
+                hostPluginId: pluginPolicyId,
+                // Provider failures resolve as messages; only visible successful output owns usage.
+                suppressUsage:
+                  !text.trim() || !["stop", "length", "toolUse"].includes(result.stopReason),
+                rawUsage: result.usage,
+                logger,
+                result: {
+                  text,
+                  provider: prepared.selection.provider,
+                  model: prepared.selection.modelId,
+                  agentId,
+                  execution: {
+                    mode: "direct-provider",
+                    owner: { kind: "provider", id: prepared.selection.provider },
+                  },
+                  audit,
+                },
+              });
+            }),
+          );
+        } catch (error) {
+          callerResult.reject(error);
+        } finally {
+          await work.drain();
+          prepared.release();
+        }
+      }).catch((error: unknown) => callerResult.reject(error));
+      return await callerResult.promise;
     },
   };
 }


### PR DESCRIPTION
## What Problem This Solves

A direct plugin completion can return after cancellation while its response callback or response-body cancellation is still running. Releasing the prepared runtime at that point drops its last lease, so an overlapping request rebuilds the same generation while accepted work still uses the previous one. Parent shutdown can also finish without joining that work.

## Why This Change Was Made

Keep the existing lease inside the existing AsyncWorkScope until accepted transport callbacks and cancellation promises settle. A narrow transport-host observer records the actual promises before they can be lost behind a cancellation race. The caller receives its result independently; parent cleanup retains and drains the operation before releasing the lease.

This six-file slice follows #141938 and replaces part of #140674. It reuses the existing work-scope implementation and preserves callback deferral, synchronous cancellation invocation, and the original completion error. Physical registration disposal remains a separate change.

## User Impact

Cancelled calls still return before a held cleanup operation finishes. Overlapping calls reuse prepared facts while keeping independent mutable request stores. Once accepted work and the overlapping call finish, the generation can retire normally.

## Evidence

The two new native cases fail on the original code: parent drainage finishes early and the overlapping request creates a second generation. Both pass with the fix, along with all nine existing native ownership cases. The selected native, package transport, and runtime suites pass 124 tests. Full canonical changed checks, a complete build, and independent Codex review pass.

Separate compiled baseline and candidate processes call createPluginRuntime().llm.complete through a registered synthetic provider and real loopback HTTP. Both callback-after-abort and native cancellation cases demonstrate:

| Observation | Baseline | Candidate |
| --- | ---: | ---: |
| Generation builds while cancelled work remains pending | 2 | 1 |
| Independent request-store forks | 2 | 2 |
| Caller result arrives before the held work settles | Yes | Yes |
| Later request rebuilds after drainage | Yes | Yes |

The cancellation probe uses the public guarded-fetch and transport-notification helpers with a native Web Streams cancellation operation. It verifies emitted host/transport ownership, not the private cancellation internals of a particular provider SDK. Source and compiled artifacts remain unchanged through the probes; all owned processes, sockets, and synchronization operations are joined. These are structural reuse observations, not a general inference-latency claim.
