### PR TITLE
fix(worker): allow long prepared workspace paths

### DIFF
--- a/src/worker/launch-descriptor.test.ts
+++ b/src/worker/launch-descriptor.test.ts
@@ -106,6 +106,43 @@ describe("worker launch descriptor", () => {
     });
   });
 
+  it.each(["workspaceDir", "workerContainmentRoot"] as const)(
+    "accepts absolute %s paths through the project preparation limit",
+    (field) => {
+      for (const root of ["/", "C:\\", "\\\\server\\share\\"]) {
+        for (const length of [257, 4_096]) {
+          const descriptor = launchDescriptor();
+          descriptor.assignment[field] = root + "a".repeat(length - root.length);
+
+          expect(parseWorkerLaunchDescriptor(descriptor)).toEqual(descriptor);
+        }
+      }
+    },
+  );
+
+  it.each(["workspaceDir", "workerContainmentRoot"] as const)(
+    "rejects invalid %s paths",
+    (field) => {
+      for (const value of [
+        "/" + "a".repeat(4_096),
+        "/workspace\0other",
+        " /workspace",
+        "/workspace ",
+        "",
+        "workspace",
+        null,
+      ]) {
+        const descriptor = launchDescriptor();
+        expect(() =>
+          parseWorkerLaunchDescriptor({
+            ...descriptor,
+            assignment: { ...descriptor.assignment, [field]: value },
+          }),
+        ).toThrow("invalid worker launch descriptor");
+      }
+    },
+  );
+
   it("round-trips turn-bound GitHub identity without adding it to worker admission", () => {
     const descriptor = launchDescriptor();
     const identity = {

--- a/src/worker/launch-descriptor.ts
+++ b/src/worker/launch-descriptor.ts
@@ -136,6 +136,17 @@ function isAbsoluteHostPath(value: string): boolean {
   return path.posix.isAbsolute(value) || path.win32.isAbsolute(value);
 }
 
+function isWorkspacePath(value: unknown): value is string {
+  // Project preparation admits paths longer than the worker identifier limit.
+  return (
+    typeof value === "string" &&
+    value.trim() === value &&
+    value.length <= 4_096 &&
+    !value.includes("\0") &&
+    isAbsoluteHostPath(value)
+  );
+}
+
 function isInferenceOptions(value: unknown): value is WorkerInferenceOptions {
   return Value.Check(WorkerInferenceOptionsSchema, value);
 }
@@ -299,9 +310,7 @@ function parseAssignment(value: unknown): WorkerLaunchAssignment | undefined {
     hasPermissionMode !== hasContainmentRoot ||
     (hasPermissionMode &&
       (!Value.Check(SessionPermissionModeSchema, value.permissionMode) ||
-        typeof value.workerContainmentRoot !== "string" ||
-        !isIdentifier(value.workerContainmentRoot) ||
-        !isAbsoluteHostPath(value.workerContainmentRoot)))
+        !isWorkspacePath(value.workerContainmentRoot)))
   ) {
     return undefined;
   }
@@ -324,8 +333,7 @@ function parseAssignment(value: unknown): WorkerLaunchAssignment | undefined {
       })
     ) ||
     typeof value.suppressPromptTranscript !== "boolean" ||
-    !isIdentifier(value.workspaceDir) ||
-    !isAbsoluteHostPath(value.workspaceDir) ||
+    !isWorkspacePath(value.workspaceDir) ||
     (value.systemPrompt !== undefined && typeof value.systemPrompt !== "string") ||
     !Array.isArray(value.initialMessages) ||
     value.initialMessages.length > WORKER_INFERENCE_MAX_CONTEXT_MESSAGES ||


### PR DESCRIPTION
Related: #134931

## What Problem This Solves

Fixes an issue where a cloud worker rejected a deeply nested project path even though project preparation had accepted it. Launch used the 256-character identifier limit for workspace and containment paths.

## Why This Change Was Made

Use the existing 4096-character workspace limit for both launch paths. Preserve absolute POSIX/Windows/UNC validation, whitespace checks, and the permission-mode/containment-root pairing; reject embedded NUL before filesystem operations. Identifier limits and protocol versions are unchanged.

## User Impact

Prepared projects under long directory prefixes can launch and execute commands. This is an independent correction extracted from #134931, with no schema or configuration changes.

## Evidence

- Original source failed the long-path regression and a real child-worker launch before Gateway admission. The corrected descriptor, process protocol, and command suites pass all 61 focused tests.
- Complete changed-file checks and independent P2 review passed.
- A real Node child worker consumed its IPC/JSONL descriptor, resolved a 405-character workspace and 387-character containment root, connected to a synthetic local Gateway, executed a real command in that workspace, committed its successful result, and exited. All owned processes and state were cleaned up. This is local process/transport proof, not a native Windows or cloud-provider test.
