### PR TITLE
fix(tui): preserve long words and addresses while wrapping

### DIFF
--- a/docs/web/tui.md
+++ b/docs/web/tui.md
@@ -237,6 +237,7 @@ Tips:
 - On connect, the TUI loads the latest history (default 200 messages).
 - Reconnect and event-gap recovery reconcile active runs with history, retaining concurrent and newly observed runs without reviving runs that exact history has excluded.
 - Streaming responses update in place until finalized.
+- Long words, email addresses, and identifiers wrap to the terminal width without inserting spaces into message text.
 - Failed assistant attachments show an actionable warning alongside any reply text. Attachment summaries use generic media kinds without exposing filenames or source URLs.
 - Messages sent to the same session from another client appear automatically.
 - The TUI also listens to agent tool events for richer tool cards.

--- a/src/infra/vitest-e2e-config.test.ts
+++ b/src/infra/vitest-e2e-config.test.ts
@@ -1,4 +1,5 @@
 // Covers the standalone Vitest E2E config shape.
+import { readdirSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import {
   normalizeConfigPath,
@@ -6,6 +7,7 @@ import {
 } from "../../test/helpers/vitest-config-paths.js";
 import { BUNDLED_PLUGIN_E2E_TEST_GLOB } from "../../test/vitest/vitest.bundled-plugin-paths.ts";
 import e2eConfig, { createE2EVitestConfig } from "../../test/vitest/vitest.e2e.config.ts";
+import { resolveRepoRootPath } from "../../test/vitest/vitest.shared.config.ts";
 import { createTuiPtyVitestConfig } from "../../test/vitest/vitest.tui-pty.config.ts";
 
 describe("e2e vitest config", () => {
@@ -34,23 +36,16 @@ describe("e2e vitest config", () => {
 
   it("keeps every terminal integration test exclusively in the serial PTY lane", () => {
     const tuiPtyConfig = createTuiPtyVitestConfig({});
-    const tuiPtyTests = [
-      "src/tui/tui-auth-child-pty.e2e.test.ts",
-      "src/tui/tui-pty-harness.e2e.test.ts",
-      "src/tui/tui-session-identity-pty.e2e.test.ts",
-      "src/tui/tui-reset-transition-pty.e2e.test.ts",
-      "src/tui/tui-task-suggestions-pty.e2e.test.ts",
-      "src/tui/tui-error-pty.e2e.test.ts",
-      "src/tui/tui-hyperlinks-pty.e2e.test.ts",
-      "src/tui/tui-picker-cancel-pty.e2e.test.ts",
-      "src/tui/tui-pty-local.e2e.test.ts",
-    ];
+    const tuiPtyTests = readdirSync(resolveRepoRootPath("src/tui"))
+      .filter((name) => name.endsWith(".e2e.test.ts"))
+      .map((name) => `src/tui/${name}`);
 
     expect(e2eConfig.test?.exclude).toEqual(expect.arrayContaining(tuiPtyTests));
-    expect(tuiPtyConfig.test?.include).toEqual(
+    expect(tuiPtyConfig.test?.include?.toSorted()).toEqual(
       tuiPtyTests
         .filter((target) => !target.endsWith("tui-pty-local.e2e.test.ts"))
-        .map((target) => target.replace(/^src\//u, "")),
+        .map((target) => target.replace(/^src\//u, ""))
+        .toSorted(),
     );
     expect(tuiPtyConfig.test?.fileParallelism).toBe(false);
     expect(tuiPtyConfig.test?.maxWorkers).toBe(1);

--- a/src/tui/components/hyperlink-markdown.test.ts
+++ b/src/tui/components/hyperlink-markdown.test.ts
@@ -1,6 +1,7 @@
 import { visibleWidth } from "@earendil-works/pi-tui";
 import { describe, expect, it } from "vitest";
 import { iterateAnsiSegments } from "../../../packages/terminal-core/src/ansi-sequences.js";
+import { stripAnsi } from "../../../packages/terminal-core/src/ansi.js";
 import { normalizeTestText } from "../../../test/helpers/normalize-text.js";
 import { markdownTheme } from "../theme/theme.js";
 import { HyperlinkMarkdown } from "./hyperlink-markdown.js";
@@ -17,6 +18,25 @@ function osc8Targets(raw: string) {
 }
 
 describe("HyperlinkMarkdown", () => {
+  it.each([
+    "alexandertheodorewilliamson@example.org",
+    "pneumonoultramicroscopicsilicovolcanoconiosis",
+    "requireConfirmationForMutatingActions",
+    `${"a".repeat(31)}e\u0301clair`,
+  ])("wraps %s without inserting spaces into its text", (text) => {
+    const constructed = new HyperlinkMarkdown(text, 0, 0, markdownTheme);
+    const updated = new HyperlinkMarkdown("previous text", 0, 0, markdownTheme);
+    updated.setText(text);
+
+    for (const width of [120, 16]) {
+      for (const markdown of [constructed, updated]) {
+        const lines = markdown.render(width);
+        expect(lines.every((line) => visibleWidth(line) <= width)).toBe(true);
+        expect(lines.map((line) => stripAnsi(line).trimEnd()).join("")).toBe(text);
+      }
+    }
+  });
+
   it("does not reallocate prepared lines for an unchanged same-width redraw", () => {
     const markdown = new HyperlinkMarkdown(
       "مرحبا [docs](https://example.test/path)",

--- a/src/tui/components/hyperlink-markdown.ts
+++ b/src/tui/components/hyperlink-markdown.ts
@@ -7,13 +7,13 @@ import type {
 } from "@earendil-works/pi-tui";
 import { Markdown } from "@earendil-works/pi-tui";
 import { addOsc8Hyperlinks, extractUrls } from "../osc8-hyperlinks.js";
-import { isolateRtlRenderedLine, sanitizeMarkdownSource } from "../tui-formatters.js";
+import { isolateRtlRenderedLine, sanitizeTerminalControlsAndBinary } from "../tui-formatters.js";
 
 function sanitizeMarkdownDisplayText(text: string): string {
   if (!text) {
     return text;
   }
-  return sanitizeMarkdownSource(text) || "(no output)";
+  return sanitizeTerminalControlsAndBinary(text) || "(no output)";
 }
 
 /**

--- a/src/tui/components/tool-execution.ts
+++ b/src/tui/components/tool-execution.ts
@@ -34,9 +34,7 @@ class ToolOutputComponent extends HyperlinkMarkdown {
   private literalOutput = new Text("", 0, 0);
 
   override setText(text: string, literal = false): void {
-    const sourceText = literal
-      ? tuiFormatters.sanitizeTerminalControlsAndBinary(text)
-      : tuiFormatters.sanitizeMarkdownSource(text);
+    const sourceText = tuiFormatters.sanitizeTerminalControlsAndBinary(text);
     if (this.sourceText === sourceText && this.literal === literal) {
       return;
     }

--- a/src/tui/tui-formatters.test.ts
+++ b/src/tui/tui-formatters.test.ts
@@ -13,7 +13,7 @@ import {
   isTerminalSafeAutocompleteValue,
   isCommandMarkedMessage,
   resolveFinalAssistantText,
-  sanitizeMarkdownSource,
+  sanitizeTerminalControlsAndBinary,
   sanitizeRenderableLine,
   sanitizeRenderableText,
 } from "./tui-formatters.js";
@@ -690,12 +690,6 @@ describe("formatTuiErrorMessage", () => {
 });
 
 describe("sanitizeRenderableText", () => {
-  function expectTokenWidthUnderLimit(input: string) {
-    const sanitized = sanitizeRenderableText(input);
-    const longestSegment = Math.max(...sanitized.split(/\s+/).map((segment) => segment.length));
-    expect(longestSegment).toBeLessThanOrEqual(32);
-  }
-
   it("strips C1 CSI and OSC without exposing their final byte or payload", () => {
     const input = "before\u009b@middle\u009d0;title\u009cafter";
 
@@ -705,14 +699,14 @@ describe("sanitizeRenderableText", () => {
   it.each([
     { label: "very long", input: "a".repeat(140) },
     { label: "moderately long", input: "b".repeat(90) },
-  ])("breaks $label unbroken tokens to protect narrow terminals", ({ input }) => {
-    expectTokenWidthUnderLimit(input);
+  ])("preserves $label unbroken tokens for renderer wrapping", ({ input }) => {
+    expect(sanitizeRenderableText(input)).toBe(input);
   });
 
-  it("keeps surrogate pairs intact when breaking long prose tokens", () => {
+  it("preserves surrogate pairs in long prose tokens", () => {
     const input = `${"a".repeat(31)}😀b`;
 
-    expect(sanitizeRenderableText(input)).toBe(`${"a".repeat(31)} 😀b`);
+    expect(sanitizeRenderableText(input)).toBe(input);
   });
 
   it("preserves long CJK prose without inserting display spaces", () => {
@@ -863,15 +857,12 @@ describe("sanitizeRenderableText", () => {
     expect(sanitized).toBe(input);
   });
 
-  it("still chunks long unbroken prose tokens outside code spans", () => {
+  it("preserves long unbroken prose tokens outside code spans", () => {
     const input = `prefix ${"x".repeat(120)} suffix`;
-    const sanitized = sanitizeRenderableText(input);
-
-    const longestSegment = Math.max(...sanitized.split(/\s+/).map((s) => s.length));
-    expect(longestSegment).toBeLessThanOrEqual(32);
+    expect(sanitizeRenderableText(input)).toBe(input);
   });
 
-  it("preserves prose around code blocks while chunking long prose tokens", () => {
+  it("preserves long prose tokens around code blocks", () => {
     const input = [
       `before ${"x".repeat(120)}`,
       "```",
@@ -879,11 +870,7 @@ describe("sanitizeRenderableText", () => {
       "```",
       `after ${"y".repeat(80)}`,
     ].join("\n");
-    const sanitized = sanitizeRenderableText(input);
-
-    expect(sanitized).toContain("code line preserved verbatim");
-    expect(sanitized).not.toContain("x".repeat(33));
-    expect(sanitized).not.toContain("y".repeat(33));
+    expect(sanitizeRenderableText(input)).toBe(input);
   });
 
   it("does not chunk box-drawing horizontal rules used in tables", () => {
@@ -928,12 +915,12 @@ describe("sanitizeRenderableText", () => {
 describe("Markdown display safety", () => {
   it("preserves layout controls while removing neighboring C0, DEL, and C1 controls", () => {
     const input = "a\u0008\tb\u000b\nc\u000c\rd\u000e\u001f\u007f\u0080\u009f";
-    expect(sanitizeMarkdownSource(input)).toBe("a\tb\nc\rd");
+    expect(sanitizeTerminalControlsAndBinary(input)).toBe("a\tb\nc\rd");
   });
 
   it("strips hostile controls from source without adding directional isolates", () => {
     const input = "\u202e# مرحبا\u202c\n\u009b31m> שלום\u009b0m";
-    const sanitized = sanitizeMarkdownSource(input);
+    const sanitized = sanitizeTerminalControlsAndBinary(input);
 
     expect(sanitized).toBe("# مرحبا\n> שלום");
     expect(sanitized).not.toMatch(/[\u2066-\u2069]/u);

--- a/src/tui/tui-formatters.ts
+++ b/src/tui/tui-formatters.ts
@@ -11,7 +11,6 @@ import { formatErrorMessage } from "../infra/errors.js";
 import { isImageMediaFact, readPersistedMediaFacts } from "../media/media-facts.js";
 import { formatRawAssistantErrorForUi } from "../shared/assistant-error-format.js";
 import { extractAssistantPhaseText } from "../shared/chat-message-content.js";
-import { chunkTextByBreakResolver } from "../shared/text-chunking.js";
 import { formatTokenCount } from "../utils/token-format.js";
 import type { SessionInfo } from "./tui-types.js";
 
@@ -21,28 +20,13 @@ const RENDER_CONTROL_CHARS_RE = new RegExp(
   String.raw`[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f-\u009f]`,
   "g",
 );
-const MAX_TOKEN_CHARS = 32;
-const LONG_TOKEN_RE = /\S{33,}/g;
-const LONG_TOKEN_TEST_RE = /\S{33,}/;
 const BINARY_LINE_REPLACEMENT_THRESHOLD = 12;
 const MAX_TUI_ABORT_DIAGNOSTIC_LENGTH = 160;
-const URL_PREFIX_RE = /^(https?:\/\/|file:\/\/)/i;
-const WINDOWS_DRIVE_RE = /^[a-zA-Z]:[\\/]/;
-const FILE_LIKE_RE = /^[a-zA-Z0-9._-]+$/;
-const EDGE_PUNCTUATION_RE = /^[`"'([{<]+|[`"')\]}>.,:;!?]+$/g;
-const ALPHANUMERIC_RE = /[A-Za-z0-9]/;
-const TOKENISH_MIN_LENGTH = 24;
 const RTL_SCRIPT_RE = /[\u0590-\u08ff\ufb1d-\ufdff\ufe70-\ufefc]/;
-const CJK_SCRIPT_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u;
 const BIDI_CONTROL_RE = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/;
 const BIDI_CONTROL_GLOBAL_RE = /[\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/g;
 const RTL_ISOLATE_START = "\u2067";
 const RTL_ISOLATE_END = "\u2069";
-// Fenced code blocks (``` or ~~~). Lazy on content; tolerates info string after
-// the opening fence. Closing fence must sit on its own line.
-const FENCED_CODE_RE = /(```|~~~)[^\n]*\n[\s\S]*?\n\1[^\n]*/g;
-// Inline code spans with balanced backtick run (`code`, ``co`de``, ...).
-const INLINE_CODE_RE = /(`+)(?:(?!\1).)+?\1/g;
 
 /** Keep routing/provider/profile details in session state, not the compact footer. */
 function formatModelFooter(params: {
@@ -107,99 +91,6 @@ export function isTerminalSafeAutocompleteValue(value: string): boolean {
   return !hasTerminalControl(value) && !BIDI_CONTROL_RE.test(value);
 }
 
-function isCopySensitiveToken(token: string): boolean {
-  const coreToken = token.replace(EDGE_PUNCTUATION_RE, "");
-  const candidate = coreToken || token;
-
-  if (URL_PREFIX_RE.test(candidate)) {
-    return true;
-  }
-  if (
-    candidate.startsWith("/") ||
-    candidate.startsWith("~/") ||
-    candidate.startsWith("./") ||
-    candidate.startsWith("../")
-  ) {
-    return true;
-  }
-  if (WINDOWS_DRIVE_RE.test(candidate) || candidate.startsWith("\\\\")) {
-    return true;
-  }
-  if (candidate.includes("/") || candidate.includes("\\")) {
-    return true;
-  }
-  // Identifiers that look file-like, dotted, or hyphen/underscore-separated:
-  // package names, entity IDs, kebab/snake CLI flags, dotted module paths.
-  if (
-    FILE_LIKE_RE.test(candidate) &&
-    (candidate.includes("_") || candidate.includes("-") || candidate.includes("."))
-  ) {
-    return true;
-  }
-
-  // Preserve long credential-like tokens (hex/base62/etc.) to avoid introducing
-  // visible spaces that users may copy back into secrets.
-  if (candidate.length >= TOKENISH_MIN_LENGTH && /[a-z]/i.test(candidate) && /\d/.test(candidate)) {
-    return true;
-  }
-  return false;
-}
-
-function normalizeLongTokenForDisplay(token: string): string {
-  // Preserve copy-sensitive tokens exactly (paths/urls/file-like names).
-  if (isCopySensitiveToken(token)) {
-    return token;
-  }
-  // CJK text naturally appears without spaces between words. Inserting spaces
-  // into long CJK runs makes assistant prose render with visible artifacts such
-  // as "苦难 者". Let the TUI renderer wrap these runs at grapheme boundaries.
-  if (CJK_SCRIPT_RE.test(token)) {
-    return token;
-  }
-  // Pure symbol/punctuation runs (table borders made of `─`, `=`, `-`) carry
-  // no copyable identifier; chunking would corrupt the visible structure.
-  if (!ALPHANUMERIC_RE.test(token)) {
-    return token;
-  }
-  return chunkTextByBreakResolver(token, MAX_TOKEN_CHARS, () => MAX_TOKEN_CHARS).join(" ");
-}
-
-type Segment = { kind: "prose" | "code"; text: string };
-
-function partitionByRegex(text: string, re: RegExp): Segment[] {
-  const parts: Segment[] = [];
-  let lastIndex = 0;
-  for (const match of text.matchAll(re)) {
-    const start = match.index ?? 0;
-    if (start > lastIndex) {
-      parts.push({ kind: "prose", text: text.slice(lastIndex, start) });
-    }
-    parts.push({ kind: "code", text: match[0] });
-    lastIndex = start + match[0].length;
-  }
-  if (lastIndex < text.length) {
-    parts.push({ kind: "prose", text: text.slice(lastIndex) });
-  }
-  return parts;
-}
-
-// Apply `transform` only to spans of `text` that are not inside fenced code
-// blocks or inline code spans. Code regions pass through verbatim so long
-// identifiers, dotted IDs, package names, and shell line-continuations the
-// user may copy stay byte-for-byte intact.
-function transformOutsideCode(text: string, transform: (segment: string) => string): string {
-  const fenced = partitionByRegex(text, FENCED_CODE_RE);
-  return fenced
-    .map((seg) => {
-      if (seg.kind === "code") {
-        return seg.text;
-      }
-      const inline = partitionByRegex(seg.text, INLINE_CODE_RE);
-      return inline.map((s) => (s.kind === "code" ? s.text : transform(s.text))).join("");
-    })
-    .join("");
-}
-
 function redactBinaryLikeLine(line: string): string {
   const replacementCount = (line.match(REPLACEMENT_CHAR_RE) || []).length;
   if (
@@ -239,28 +130,8 @@ function applyRtlIsolation(text: string): string {
     .join("\n");
 }
 
-export function sanitizeMarkdownSource(text: string): string {
-  if (!text) {
-    return text;
-  }
-
-  const hasLongTokens = LONG_TOKEN_TEST_RE.test(text);
-  const controlSafe = sanitizeTerminalControlsAndBinary(text);
-  if (controlSafe === text && !hasLongTokens) {
-    return text;
-  }
-
-  return LONG_TOKEN_TEST_RE.test(controlSafe)
-    ? transformOutsideCode(controlSafe, (segment) =>
-        LONG_TOKEN_TEST_RE.test(segment)
-          ? segment.replace(LONG_TOKEN_RE, normalizeLongTokenForDisplay)
-          : segment,
-      )
-    : controlSafe;
-}
-
 export function sanitizeRenderableText(text: string): string {
-  return applyRtlIsolation(sanitizeMarkdownSource(text));
+  return applyRtlIsolation(sanitizeTerminalControlsAndBinary(text));
 }
 
 export function sanitizeRenderableLine(text: string): string {

--- a/src/tui/tui-pty-harness-assertion-test-support.test.ts
+++ b/src/tui/tui-pty-harness-assertion-test-support.test.ts
@@ -14,6 +14,20 @@ const hasHistoricalExpected = (raw: string, dimensions = TERMINAL) =>
   oracle.hasHistoricalSynchronizedFrameRow(raw, MARKERS, EXPECTED, dimensions);
 
 describe("hasSynchronizedFrameRow", () => {
+  it.each(["\x07", "\x1b\\"])("accepts a renderer mailto link terminated by %j", (end) => {
+    const address = "reader@example.test";
+    const link = `\x1b]8;;mailto:${address}${end}${address}\x1b]8;;${end}`;
+    expect(parse(frame(link))).toEqual([[address]]);
+
+    for (const target of [
+      "mailto:",
+      "mailto:reader @example.test",
+      "mailto:reader\t@example.test",
+    ]) {
+      expect(() => parse(frame(`\x1b]8;;${target}${end}label\x1b]8;;${end}`))).toThrow();
+    }
+  });
+
   it("authenticates a bidi-isolated disconnect row before reconnect erases it", () => {
     const markers = ["T08Ia", "T08Ib", "T08Ic", "T08Id"];
     const status = "local runtime stopped: T08IaT08Ib café 東京 👩🏽‍💻 T08Ic مرحبا שלום T08Id";

--- a/src/tui/tui-pty-harness-assertion-test-support.ts
+++ b/src/tui/tui-pty-harness-assertion-test-support.ts
@@ -167,7 +167,7 @@ function assertAllowedOsc(body: string) {
   if (
     target === undefined ||
     (target !== "" &&
-      (!/^https?:\/\/\S+$/u.test(target) ||
+      (!/^(?:https?:\/\/|mailto:)\S+$/u.test(target) ||
         ansi.sanitizeForLog(target) !== target ||
         !URL.canParse(target)))
   ) {

--- a/src/tui/tui-text-wrap-pty.e2e.test.ts
+++ b/src/tui/tui-text-wrap-pty.e2e.test.ts
@@ -1,0 +1,34 @@
+import { expect, it } from "vitest";
+import {
+  objectFieldEquals,
+  startTuiFixture,
+  waitForSynchronizedFrameRows,
+} from "./tui-pty-harness-fixture-test-support.js";
+
+it("preserves a long email address in the user's message and assistant reply", async () => {
+  const address = "alexandertheodorewilliamson@example.org";
+  const fixture = await startTuiFixture({
+    env: {
+      TERM_PROGRAM: "vscode",
+      OPENCLAW_TUI_PTY_COLS: "120",
+      OPENCLAW_TUI_PTY_ROWS: "30",
+    },
+  });
+  try {
+    await fixture.run.waitForOutput("local ready", 20_000);
+    await fixture.run.write(`${address}\r`, { delay: false });
+    await fixture.waitForLogEntry(
+      (entry) => entry.method === "sendChat" && objectFieldEquals(entry, "message", address),
+    );
+    const rows = await waitForSynchronizedFrameRows(
+      fixture.run,
+      (frame) => frame.some((row) => row.includes("PTY_RESPONSE:")),
+      20_000,
+    );
+    console.log("[text-wrap-frame] " + JSON.stringify({ rows }));
+    expect(rows.filter((row) => row.includes(address))).toHaveLength(2);
+  } finally {
+    await fixture.run.forceKill();
+    await fixture.cleanup();
+  }
+}, 30_000);

--- a/test/vitest/vitest.test-shards.mjs
+++ b/test/vitest/vitest.test-shards.mjs
@@ -21,6 +21,7 @@ export const tuiPtyTestFiles = [
   "src/tui/tui-error-pty.e2e.test.ts",
   "src/tui/tui-hyperlinks-pty.e2e.test.ts",
   "src/tui/tui-picker-cancel-pty.e2e.test.ts",
+  "src/tui/tui-text-wrap-pty.e2e.test.ts",
   "src/tui/tui-pty-local.e2e.test.ts",
 ];
 


### PR DESCRIPTION
Related: #69344.

## What Problem This Solves

Fixes an issue where users reading or copying long email addresses, words, and identifiers in the TUI received text with extra spaces inserted into it—even when it fit on one terminal line. A combining accent could also be separated from its letter.

For example, `alexandertheodorewilliamson@example.org` appeared as `alexandertheodorewilliamson@exam ple.org` in both user messages and assistant replies.

## Why This Change Was Made

Make the terminal renderer the sole wrapping owner. The pinned renderer already wraps by display width and grapheme boundary, so the duplicate 32-character pre-wrapping pass, text-classification exceptions, extra Markdown parser, and obsolete wrapper can be deleted. Callers now use the existing terminal sanitizer directly; terminal-control, binary-content and RTL handling remains unchanged, as does literal tool-output rendering.

## User Impact

User messages, assistant replies, and tool output preserve their original long text. It still wraps at the actual terminal width without inventing spaces or separating grapheme sequences.

## Evidence

- Four actual renderer regression cases failed before the change and pass afterward, covering wide/narrow widths and both constructor/update paths.
- The real native PTY reproduction failed before the change with the address corrupted in both message rows. The same email flow passes afterward, exercising the real TUI with its existing synthetic backend.
- All **149 focused tests** pass. The PTY scenario plus the complete evidence-parser suite pass **6/6** (one native PTY scenario and five parser cases).
- The canonical owning test type graph, full-file lint, formatting, and fresh P0–P2 independent review pass. Seven retained terminal-control/binary/RTL functions are byte-identical to the baseline.

The intact email now produces the pinned renderer's intended `mailto:` hyperlink. The test evidence parser was updated to recognize that scheme explicitly, retaining its existing control, whitespace, URL-validation and unsupported-scheme checks. Its new cases accept valid mailto links and reject empty/whitespace/control targets. This is test support for the observed renderer output, not a product URI-policy change.

The initial [CI run 34235928696](https://github.com/openclaw/openclaw/actions/runs/34235928696) exposed a missed PTY configuration assertion: its hand-maintained filename inventory lacked the new scenario. The correction removes that duplicate list and independently discovers the actual TUI E2E files, retaining the inclusion, exclusion, and serial-worker assertions. The old assertion reproduced locally; the corrected configuration tests pass **4/4**, with their owning infrastructure test type graph and full-file lint/format also passing. A fresh P0–P2 review covers the complete eleven-file candidate. The original ten files, including all production code and behavioral proof, are unchanged. The old CI run remains failed; fresh checks are required for this new head.

Production: **−131 lines**. Tests: +50; test-support delta: 0; test inventory: +1; docs: +1. All eleven reviewed file hashes match commit `c4386ea6b057234b6f4240546623155309263d61` over baseline `c21fa540660255762d81053dcf06ee0f8385b357`. Validation used Node 24.19.0, pnpm 12.3.4 and the pinned pi-tui 0.84.4. No live Gateway/provider or operator-state behavior is claimed.

Before and after below are inspected, faithful renderings of captured synthetic PTY text rows with simplified styling; they are not desktop screenshots.

Before: extra spaces corrupt the address in both rows.

![Before: long email address gains an embedded space](https://github.com/user-attachments/assets/d87f9103-8462-4d41-bb11-3b675e847ee4)

After: the complete address is preserved in both rows.

![After: long email address remains intact](https://github.com/user-attachments/assets/fba3016c-51fc-4243-b4a5-c6ffc6563380)
