### PR TITLE
fix(chat): hide browser previews for non-web URLs

### DIFF
--- a/docs/tools/browser.md
+++ b/docs/tools/browser.md
@@ -169,9 +169,10 @@ After an established stream disconnects, the panel refreshes its screenshot
 and retries the stream automatically after a short delay. Annotation and
 inspection keep their captured image until you return to interaction mode.
 
-Preview cards are interactive only when OpenClaw can identify the browser's
-route. Sandbox browser results remain available to the agent but do not open a
-host-browser preview.
+Preview cards appear only for HTTP(S) page URLs when OpenClaw can identify the
+browser's route. Blank or internal pages remain ordinary tool results. Tab
+actions without a page URL still update the Browser panel's selection. Sandbox
+browser results remain available to the agent but do not open a host-browser preview.
 
 If a listed tab cannot be accessed, the panel explains whether navigation rules
 blocked it or its address could not be verified. Select another tab, enter an

--- a/extensions/browser/src/browser-tool.test.ts
+++ b/extensions/browser/src/browser-tool.test.ts
@@ -5062,12 +5062,16 @@ describe("browser observation actions and tab previews", () => {
     browserClientMocks.browserOpenTab.mockResolvedValueOnce({
       targetId: "t".repeat(128),
       title: "a".repeat(600),
-      url: "u".repeat(3000),
+      url: `https://example.com/${"u".repeat(3000)}`,
     });
     const tool = createBrowserTool();
     const opened = await tool.execute("open", { action: "open", url: "https://example.com" });
     expect(opened.details).toMatchObject({
-      browserTab: { targetId: "t".repeat(128), title: "a".repeat(512), url: "u".repeat(2048) },
+      browserTab: {
+        targetId: "t".repeat(128),
+        title: "a".repeat(512),
+        url: `https://example.com/${"u".repeat(3000)}`.slice(0, 2048),
+      },
     });
     browserClientMocks.browserFocusTab.mockResolvedValueOnce({ ok: true, title: 42, url: {} });
     const focused = await tool.execute("focus", { action: "focus", targetId: "known" });
@@ -5078,6 +5082,37 @@ describe("browser observation actions and tab previews", () => {
       profile: "openclaw",
     });
   });
+
+  it.each([
+    ["about:blank", false],
+    ["chrome://newtab/", false],
+    ["data:text/html,hello", false],
+    ["file:///tmp/page.html", false],
+    ["not a URL", false],
+    ["http://example.com/page", true],
+    ["https://example.com/page", true],
+    ["HTTPS://example.com/page", true],
+  ])(
+    "keeps the browser route but only attaches HTTP(S) display URLs (%s)",
+    async (url, eligible) => {
+      browserClientMocks.browserOpenTab.mockResolvedValueOnce({ targetId: "known", url });
+      const result = await createBrowserTool().execute("open", {
+        action: "open",
+        url: "https://example.com",
+      });
+      expect(result.details).toEqual({
+        targetId: "known",
+        url,
+        browserTab: {
+          targetId: "known",
+          target: "host",
+          profile: "openclaw",
+          ...(eligible ? { url } : {}),
+        },
+      });
+      expect(firstResultText(result)).toContain(url);
+    },
+  );
 
   it.each([
     {

--- a/extensions/browser/src/browser-tool.ts
+++ b/extensions/browser/src/browser-tool.ts
@@ -98,6 +98,7 @@ function withBrowserTabDetails(
     return result;
   }
   const url = readStringValue(details.url);
+  const protocol = url ? URL.parse(url)?.protocol : undefined;
   const title = readStringValue(details.title);
   return {
     ...result,
@@ -105,7 +106,9 @@ function withBrowserTabDetails(
       ...details,
       browserTab: {
         ...identity,
-        ...(url ? { url: truncateUtf16Safe(url, 2048) } : {}),
+        ...(url && (protocol === "http:" || protocol === "https:")
+          ? { url: truncateUtf16Safe(url, 2048) }
+          : {}),
         ...(title ? { title: truncateUtf16Safe(title, 512) } : {}),
       },
     },

--- a/ui/src/e2e/browser-route-handoff.e2e.test.ts
+++ b/ui/src/e2e/browser-route-handoff.e2e.test.ts
@@ -275,7 +275,12 @@ suite.define(() => {
             result: {
               content: [{ type: "text", text: "Browser control output" }],
               details: {
-                browserTab: { target: "host", profile: "managed", targetId: "default-tab" },
+                browserTab: {
+                  target: "host",
+                  profile: "managed",
+                  targetId: "default-tab",
+                  url: "https://default.example/",
+                },
               },
             },
           });

--- a/ui/src/e2e/browser-tab-preview-urls.e2e.test.ts
+++ b/ui/src/e2e/browser-tab-preview-urls.e2e.test.ts
@@ -1,0 +1,63 @@
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Control UI browser preview URLs" });
+
+suite.define(() => {
+  it("hides blank-tab previews while retaining HTTPS cards and the original result", async () => {
+    await suite.withPage(
+      { viewport: { width: 1440, height: 900 }, colorScheme: "dark", serviceWorkers: "block" },
+      async ({ page }) => {
+        await installMockGateway(page, {
+          historyMessages: [
+            { role: "user", content: "Open both pages.", timestamp: 1_000 },
+            ...["about:blank", "https://example.com"].flatMap((url, index) => [
+              {
+                role: "assistant",
+                timestamp: 2_000 + index * 1_000,
+                content: [
+                  {
+                    type: "toolCall",
+                    id: `open-${index}`,
+                    name: "browser",
+                    arguments: { action: "open", url },
+                  },
+                ],
+              },
+              {
+                role: "toolResult",
+                toolCallId: `open-${index}`,
+                toolName: "browser",
+                timestamp: 2_500 + index * 1_000,
+                content: [{ type: "text", text: `Opened ${url}` }],
+                details: {
+                  browserTab: { target: "host", profile: "managed", targetId: `tab-${index}`, url },
+                },
+              },
+            ]),
+            {
+              role: "assistant",
+              content: "Ready. A plain link: https://example.org",
+              timestamp: 5_000,
+            },
+          ],
+        });
+        await page.goto(`${suite.server.baseUrl}chat`);
+        await page.getByText("Ready. A plain link:", { exact: false }).waitFor();
+        const cards = page.locator("openclaw-browser-tab-card");
+        await expect.poll(() => cards.count()).toBe(1);
+        expect(await cards.locator(".url").textContent()).toBe("https://example.com");
+        for (const selector of [".chat-activity-group__summary", ".chat-tool-msg-summary"]) {
+          for (const summary of await page.locator(selector).all()) {
+            if ((await summary.getAttribute("aria-expanded")) !== "true") {
+              await summary.click();
+            }
+          }
+        }
+        await page.getByText("Opened about:blank", { exact: true }).waitFor();
+        expect(await cards.count()).toBe(1);
+      },
+    );
+  });
+});

--- a/ui/src/lib/chat/browser-tab-preview.test.ts
+++ b/ui/src/lib/chat/browser-tab-preview.test.ts
@@ -91,18 +91,34 @@ describe("browser tab previews", () => {
       ],
     };
     expect([...latestBrowserTabCards([null, older, latest, other], [failed, running])]).toEqual([
-      [tabKey(), { tab: { ...route, targetId: "tab-1", kind: "browser-tab" }, revision: "new" }],
-      [
-        tabKey("tab-2"),
-        { tab: { ...route, targetId: "tab-2", kind: "browser-tab" }, revision: "other" },
-      ],
+      [tabKey(), { tab: { ...route, targetId: "tab-1" }, revision: "new" }],
+      [tabKey("tab-2"), { tab: { ...route, targetId: "tab-2" }, revision: "other" }],
     ]);
     expect([...latestBrowserTabCards([older], [latest])]).toEqual([
-      [tabKey(), { tab: { ...route, targetId: "tab-1", kind: "browser-tab" }, revision: "new" }],
+      [tabKey(), { tab: { ...route, targetId: "tab-1" }, revision: "new" }],
     ]);
     expect([...latestBrowserTabCards([older, latest], [])]).toEqual([
-      [tabKey(), { tab: { ...route, targetId: "tab-1", kind: "browser-tab" }, revision: "new" }],
+      [tabKey(), { tab: { ...route, targetId: "tab-1" }, revision: "new" }],
     ]);
+  });
+
+  it.each([undefined, "about:blank"])("follows a newer tab without a web preview (%s)", (url) => {
+    const older = browserResult("web", "web-tab");
+    const web = {
+      ...older,
+      details: { browserTab: { ...older.details.browserTab, url: "https://example.com" } },
+    };
+    const next = browserResult("focus", "focused-tab");
+    const focused = {
+      ...next,
+      details: { browserTab: { ...next.details.browserTab, ...(url ? { url } : {}) } },
+    };
+    expect(extractToolCardsCached(web)[0]?.preview?.kind).toBe("browser-tab");
+    expect(extractToolCardsCached(focused)[0]?.preview).toBeUndefined();
+    expect([...latestBrowserTabCards([web], [focused]).values()].at(-1)).toEqual({
+      tab: { ...route, targetId: "focused-tab" },
+      revision: "focus",
+    });
   });
 
   it("shares captures, serializes new revisions, and reads bytes only over HTTP", async () => {

--- a/ui/src/lib/chat/browser-tab-preview.ts
+++ b/ui/src/lib/chat/browser-tab-preview.ts
@@ -31,14 +31,10 @@ export function latestBrowserTabCards(
       }
       for (const card of extractToolCardsCached(message)) {
         const revision = browserTabCardRevision(card);
-        if (
-          card.preview?.kind === "browser-tab" &&
-          revision &&
-          resolveToolCardOutcome(card, false) === "succeeded"
-        ) {
-          const key = browserTabKey(card.preview);
+        if (card.browserTab && revision && resolveToolCardOutcome(card, false) === "succeeded") {
+          const key = browserTabKey(card.browserTab);
           latest.delete(key);
-          latest.set(key, { tab: card.preview, revision });
+          latest.set(key, { tab: card.browserTab, revision });
         }
       }
     }

--- a/ui/src/lib/chat/chat-types.ts
+++ b/ui/src/lib/chat/chat-types.ts
@@ -354,6 +354,8 @@ export type ToolCard = {
   messageId?: string;
   /** UI-local preview identity for results without a call or transcript id. */
   previewRevision?: string;
+  /** Tab actions can identify a route without a previewable page URL. */
+  browserTab?: BrowserTabTarget;
   preview?:
     | {
         kind: "canvas";

--- a/ui/src/lib/chat/tool-cards.ts
+++ b/ui/src/lib/chat/tool-cards.ts
@@ -1,3 +1,4 @@
+import { isHttpUrl } from "@openclaw/net-policy/url-protocol";
 import {
   asNullableObjectRecord as readRecord,
   asNullableRecord,
@@ -197,30 +198,36 @@ export function extractToolPreview(
     : undefined;
 }
 
-function extractToolDetailsPreview(
+function extractToolPresentation(
   details: unknown,
   text: string | undefined,
   name: string,
   browserToolName = name,
-): ToolCard["preview"] | undefined {
+): Pick<ToolCard, "preview" | "browserTab"> {
   const preview = extractCanvasFromDetails(details);
   const canvas =
     preview?.surface === "assistant_message"
       ? { ...preview, surface: "assistant_message" }
       : extractToolPreview(text, name);
   if (canvas) {
-    return { ...canvas, surface: "assistant_message" };
+    return { preview: { ...canvas, surface: "assistant_message" } };
   }
   const tab = asNullableRecord(asNullableRecord(details)?.browserTab);
   const target = readBrowserTabTarget(tab);
   if (browserToolName !== "browser" || !tab || !target) {
-    return undefined;
+    return {};
   }
+  const url = typeof tab.url === "string" ? truncateUtf16Safe(tab.url, 2_048) : "";
   return {
-    kind: "browser-tab",
-    ...target,
-    ...(typeof tab.url === "string" ? { url: truncateUtf16Safe(tab.url, 2_048) } : {}),
-    ...(typeof tab.title === "string" ? { title: truncateUtf16Safe(tab.title, 512) } : {}),
+    browserTab: target,
+    preview: isHttpUrl(url)
+      ? {
+          kind: "browser-tab",
+          ...target,
+          url,
+          ...(typeof tab.title === "string" ? { title: truncateUtf16Safe(tab.title, 512) } : {}),
+        }
+      : undefined,
   };
 }
 
@@ -420,7 +427,7 @@ function extractToolCards(message: unknown): ToolCard[] {
         envelopeName && envelopeName !== "browser"
           ? envelopeName
           : (existing?.name ?? envelopeName ?? name);
-      const preview = extractToolDetailsPreview(details, text, name, browserToolName);
+      const presentation = extractToolPresentation(details, text, name, browserToolName);
       const isError = readToolErrorFlag(item) ?? messageIsError;
       const exitCode = readToolExitCode(item, details, text ? parseJsonRecord(text) : undefined, m);
       if (existing) {
@@ -434,7 +441,8 @@ function extractToolCards(message: unknown): ToolCard[] {
           existing.completed = true;
         }
         existing.outputText = text;
-        existing.preview = preview;
+        existing.preview = presentation.preview;
+        existing.browserTab = presentation.browserTab;
         if (details !== undefined) {
           existing.details = details;
         }
@@ -456,7 +464,7 @@ function extractToolCards(message: unknown): ToolCard[] {
         messageId: transcriptMessageId,
         ...(isError !== undefined ? { isError } : {}),
         ...(exitCode !== undefined ? { exitCode } : {}),
-        preview,
+        ...presentation,
       });
     }
   }
@@ -479,13 +487,13 @@ function extractToolCards(message: unknown): ToolCard[] {
       messageId: transcriptMessageId,
       ...(messageIsError !== undefined ? { isError: messageIsError } : {}),
       ...(exitCode !== undefined ? { exitCode } : {}),
-      preview: extractToolDetailsPreview(m.details, text, name),
+      ...extractToolPresentation(m.details, text, name),
     });
   }
 
   let revision: number | undefined;
   for (const [index, card] of cards.entries()) {
-    if (card.preview?.kind !== "browser-tab" || card.callId || card.messageId) {
+    if (!card.browserTab || card.callId || card.messageId) {
       continue;
     }
     revision ??= ++nextPreviewRevision;

--- a/ui/src/pages/chat/components/browser-tab-card.test.ts
+++ b/ui/src/pages/chat/components/browser-tab-card.test.ts
@@ -162,7 +162,15 @@ describe("browser tab card", () => {
       toolCallId: id,
       toolName: "browser",
       content: "ok",
-      details: { browserTab: { profile: "managed", target: "host", targetId: "tab-1", title: id } },
+      details: {
+        browserTab: {
+          profile: "managed",
+          target: "host",
+          targetId: "tab-1",
+          url: "https://example.com",
+          title: id,
+        },
+      },
     });
     const host = container();
     const messages = [message("old"), message("new")];
@@ -207,43 +215,58 @@ describe("browser tab card", () => {
     await vi.waitFor(() => expect(next[0]?.shadowRoot?.querySelector("img")).not.toBeNull());
   });
 
-  it("keeps one card per distinct tab", async () => {
-    const gateway = gatewayContext();
-    const message = (id: string, targetId: string) => ({
-      role: "toolResult",
-      toolCallId: id,
-      toolName: "browser",
-      content: "ok",
-      details: { browserTab: { profile: "managed", target: "host", targetId, title: id } },
-    });
-    const messages = [message("old", "tab-1"), message("new", "tab-1"), message("other", "tab-2")];
-    const host = container();
-    const group: MessageGroup = {
-      kind: "group",
-      key: "browser-results",
-      role: "tool",
-      visibleContent: "text",
-      isStreaming: false,
-      timestamp: 1,
-      messages: messages.map((result) => ({ key: result.toolCallId, message: result })),
-    };
-    render(
-      renderActivityGroup([group], {
-        showReasoning: false,
-        latestBrowserTabs: latestBrowserTabCards(messages, []),
-        isToolMessageExpanded: () => false,
-      }),
-      host,
-    );
-    const elements = [...host.querySelectorAll("openclaw-browser-tab-card")];
-    for (const element of elements) {
-      element.context = gateway.context;
-      await element.updateComplete;
-    }
-    expect(
-      elements.map((element) => element.shadowRoot?.querySelector(".title")?.textContent),
-    ).toEqual(["new", "other"]);
-  });
+  it.each(["https://example.com/new", "about:blank", undefined])(
+    "uses the latest successful result per tab before deciding to preview %s",
+    async (latestUrl) => {
+      const gateway = gatewayContext();
+      const message = (id: string, targetId: string, url: string | undefined) => ({
+        role: "toolResult",
+        toolCallId: id,
+        toolName: "browser",
+        content: "ok",
+        details: {
+          browserTab: {
+            profile: "managed",
+            target: "host",
+            targetId,
+            url,
+            title: id,
+          },
+        },
+      });
+      const messages = [
+        message("old", "tab-1", "https://example.com/old"),
+        message("new", "tab-1", latestUrl),
+        message("other", "tab-2", "https://example.com/other"),
+      ];
+      const host = container();
+      const group: MessageGroup = {
+        kind: "group",
+        key: "browser-results",
+        role: "tool",
+        visibleContent: "text",
+        isStreaming: false,
+        timestamp: 1,
+        messages: messages.map((result) => ({ key: result.toolCallId, message: result })),
+      };
+      render(
+        renderActivityGroup([group], {
+          showReasoning: false,
+          latestBrowserTabs: latestBrowserTabCards(messages, []),
+          isToolMessageExpanded: () => false,
+        }),
+        host,
+      );
+      const elements = [...host.querySelectorAll("openclaw-browser-tab-card")];
+      for (const element of elements) {
+        element.context = gateway.context;
+        await element.updateComplete;
+      }
+      expect(
+        elements.map((element) => element.shadowRoot?.querySelector(".title")?.textContent),
+      ).toEqual(latestUrl === "https://example.com/new" ? ["new", "other"] : ["other"]);
+    },
+  );
 
   it("discards a pending image when browser access disappears", async () => {
     const gateway = gatewayContext();

--- a/ui/src/pages/chat/components/chat-tool-cards.node.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.node.test.ts
@@ -258,10 +258,10 @@ describe("tool-card extraction", () => {
       const [card] = extractToolCards(message);
       expect(card?.outputText).toBe(output);
       expect(card?.details).toEqual(details);
-      expect(card?.browserTab).toEqual(browserTab);
       expect(card?.preview).toEqual(
         eligible ? { kind: "browser-tab", ...browserTab, url } : undefined,
       );
+      expect(card?.browserTab).toEqual(browserTab);
     }
   });
 

--- a/ui/src/pages/chat/components/chat-tool-cards.node.test.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.node.test.ts
@@ -36,7 +36,12 @@ afterEach(() => {
 
 describe("tool-card extraction", () => {
   const browserDetails = {
-    browserTab: { profile: "managed", target: "host", targetId: "tab-origin" },
+    browserTab: {
+      profile: "managed",
+      target: "host",
+      targetId: "tab-origin",
+      url: "https://example.com",
+    },
   };
 
   it.each(["read", "browser.open", "mcp__other__browser", undefined])(
@@ -65,6 +70,7 @@ describe("tool-card extraction", () => {
         expect(cards).toHaveLength(1);
         expect(cards[0]?.outputText).toBe("ordinary output");
         expect(cards[0]?.preview).toBeUndefined();
+        expect(cards[0]?.browserTab).toBeUndefined();
       }
     },
   );
@@ -95,6 +101,9 @@ describe("tool-card extraction", () => {
       expect(cards[0]?.preview).toEqual(
         browserOrigin ? { kind: "browser-tab", ...browserDetails.browserTab } : undefined,
       );
+      expect(cards[0]?.browserTab).toEqual(
+        browserOrigin ? { profile: "managed", target: "host", targetId: "tab-origin" } : undefined,
+      );
     },
   );
 
@@ -114,6 +123,7 @@ describe("tool-card extraction", () => {
     expect(cards).toHaveLength(2);
     expect(cards[1]?.outputText).toBe("unpaired output");
     expect(cards[1]?.preview).toBeUndefined();
+    expect(cards[1]?.browserTab).toBeUndefined();
   });
 
   it.each(["read", "browser.open", "mcp__other__browser", undefined])(
@@ -135,6 +145,7 @@ describe("tool-card extraction", () => {
         expect(card?.name).toBe("browser");
         expect(card?.outputText).toBe("nested output");
         expect(card?.preview).toBeUndefined();
+        expect(card?.browserTab).toBeUndefined();
         const [paired] = extractToolCards({
           role: "toolResult",
           [nameField]: toolName,
@@ -151,6 +162,7 @@ describe("tool-card extraction", () => {
         });
         expect(paired?.outputText).toBe("nested paired output");
         expect(paired?.preview).toBeUndefined();
+        expect(paired?.browserTab).toBeUndefined();
       }
     },
   );
@@ -207,6 +219,53 @@ describe("tool-card extraction", () => {
   });
 
   it.each([
+    ["about:blank", false],
+    ["about:blank#section", false],
+    ["chrome://newtab", false],
+    ["file:///tmp/page.html", false],
+    ["data:text/html,hello", false],
+    ["javascript:void(0)", false],
+    ["blob:https://example.com/id", false],
+    ["ftp://example.com/file", false],
+    ["/relative", false],
+    ["https://", false],
+    ["", false],
+    [undefined, false],
+    ["http://example.com", true],
+    ["https://example.com/page", true],
+    ["HTTPS://example.com/page", true],
+  ] as const)("keeps routing and raw output while classifying preview URL %s", (url, eligible) => {
+    const browserTab = { profile: "managed", target: "host", targetId: "tab-1" };
+    const details = { browserTab: { ...browserTab, ...(url === undefined ? {} : { url }) } };
+    const output = JSON.stringify({ url });
+    for (const shape of ["standalone", "block", "live"]) {
+      const message =
+        shape === "standalone"
+          ? { role: "toolResult", toolName: "browser", content: output, details }
+          : {
+              role: "assistant",
+              ...(shape === "live"
+                ? {
+                    __openclawToolStreamLive: true,
+                    __openclawToolStreamResultReceived: true,
+                  }
+                : {}),
+              content: [
+                { type: "toolcall", id: "url-call", name: "browser", arguments: {} },
+                { type: "toolresult", id: "url-call", name: "browser", text: output, details },
+              ],
+            };
+      const [card] = extractToolCards(message);
+      expect(card?.outputText).toBe(output);
+      expect(card?.details).toEqual(details);
+      expect(card?.browserTab).toEqual(browserTab);
+      expect(card?.preview).toEqual(
+        eligible ? { kind: "browser-tab", ...browserTab, url } : undefined,
+      );
+    }
+  });
+
+  it.each([
     null,
     [],
     "tab",
@@ -222,9 +281,9 @@ describe("tool-card extraction", () => {
     { targetId: "t1", profile: "p".repeat(129), target: "host" },
     { targetId: "t1", profile: "managed", target: "node", node: "n".repeat(257) },
   ])("ignores malformed browser tabs (%j)", (browserTab) => {
-    expect(
-      extractToolCards({ role: "tool", toolName: "browser", details: { browserTab } })[0]?.preview,
-    ).toBeUndefined();
+    const [card] = extractToolCards({ role: "tool", toolName: "browser", details: { browserTab } });
+    expect(card?.preview).toBeUndefined();
+    expect(card?.browserTab).toBeUndefined();
   });
 
   it("retains exact bounded node identities without provider metadata", () => {
@@ -245,7 +304,8 @@ describe("tool-card extraction", () => {
         },
       },
     });
-    expect(card?.preview).toEqual({ kind: "browser-tab", ...browserTab });
+    expect(card?.browserTab).toEqual(browserTab);
+    expect(card?.preview).toBeUndefined();
   });
 
   it("drops non-string browser metadata and gives canvas previews precedence", () => {
@@ -258,12 +318,7 @@ describe("tool-card extraction", () => {
     };
     expect(
       extractToolCards({ role: "tool", toolName: "browser", details: { browserTab } })[0]?.preview,
-    ).toEqual({
-      kind: "browser-tab",
-      profile: "managed",
-      target: "host",
-      targetId: "tab-1",
-    });
+    ).toBeUndefined();
     const canvas = {
       kind: "canvas",
       view: { id: "cv_app" },

--- a/ui/src/pages/chat/components/chat-tool-cards.ts
+++ b/ui/src/pages/chat/components/chat-tool-cards.ts
@@ -52,11 +52,8 @@ export function renderBrowserTabPreviews(
   // turn all describe the same tab, and stacked near-identical cards are noise.
   const lastCardForTab = new Map<string, (typeof cards)[number]>();
   for (const card of cards) {
-    if (
-      card.preview?.kind === "browser-tab" &&
-      resolveToolCardOutcome(card, false) === "succeeded"
-    ) {
-      lastCardForTab.set(browserTabKey(card.preview), card);
+    if (card.browserTab && resolveToolCardOutcome(card, false) === "succeeded") {
+      lastCardForTab.set(browserTabKey(card.browserTab), card);
     }
   }
   return [...lastCardForTab.values()].map((card) => {

--- a/ui/src/pages/chat/components/chat-transcript-render.test.ts
+++ b/ui/src/pages/chat/components/chat-transcript-render.test.ts
@@ -328,7 +328,13 @@ describe("chat transcript rendering", () => {
           timestamp: 2_000,
           content: "Opened",
           details: {
-            browserTab: { profile: "managed", target: "host", targetId: "tab-1", title: "Example" },
+            browserTab: {
+              profile: "managed",
+              target: "host",
+              targetId: "tab-1",
+              url: "https://example.com",
+              title: "Example",
+            },
           },
         },
         { role: "assistant", content: "Done.", timestamp: 3_000 },

--- a/ui/src/pages/chat/tool-stream.node.test.ts
+++ b/ui/src/pages/chat/tool-stream.node.test.ts
@@ -53,7 +53,13 @@ describe("app-tool-stream approval lifecycle", () => {
         result: {
           content: [],
           details: {
-            browserTab: { profile: "managed", target: "host", targetId: "tab-1", title: "Example" },
+            browserTab: {
+              profile: "managed",
+              target: "host",
+              targetId: "tab-1",
+              url: "https://example.com",
+              title: "Example",
+            },
           },
         },
       }),


### PR DESCRIPTION
Closes #142209

## What Problem This Solves

Fixes an issue where users viewing chat results for a blank browser tab would see a globe preview card with `about:blank` repeated as its title and subtitle.

## Why This Change Was Made

Only parsed HTTP(S) page URLs now become browser preview cards. The Browser result producer filters its optional display URL, and the canonical chat normalizer applies the same eligibility rule to incoming results. Raw output and exact tab routing remain available, including successful actions that return no page URL.

The transcript selects the latest successful result per tab before deciding whether to show a card, so navigating from HTTPS to a blank page cannot leave an older HTTPS card in the same activity group.

## User Impact

Blank/internal browser pages no longer add misleading preview cards. HTTP(S) cards remain available. URL-less focus and emulation actions continue to update the Browser panel's selected tab.

## Evidence

The real Control UI mock reproduces the reported card with a blank tab and a separate HTTPS tab. Inspected captures use the same 1440×900 viewport, dark theme, session, and scroll position.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><a href="https://github.com/user-attachments/assets/9cb88b27-f8ff-4c65-bfc3-fa4a9c2c269a"><img src="https://github.com/user-attachments/assets/9cb88b27-f8ff-4c65-bfc3-fa4a9c2c269a" alt="Before: about:blank and HTTPS browser cards" width="640"></a></td>
<td><a href="https://github.com/user-attachments/assets/1bff0f88-7417-4a73-86b5-08ed467b59ba"><img src="https://github.com/user-attachments/assets/1bff0f88-7417-4a73-86b5-08ed467b59ba" alt="After: only the HTTPS browser card remains" width="640"></a></td>
</tr>
</table>

- **Origin:** [Browser result producer](https://github.com/openclaw/openclaw/blob/2b953f227a106cef57dd0cd19f881db7f97955cb/extensions/browser/src/browser-tool.ts#L83-L117) creates `details.browserTab`; [Gateway display projection](https://github.com/openclaw/openclaw/blob/2b953f227a106cef57dd0cd19f881db7f97955cb/src/gateway/chat-display-projection.canvas.ts#L73-L93) carries it to [chat normalization](https://github.com/openclaw/openclaw/blob/2b953f227a106cef57dd0cd19f881db7f97955cb/ui/src/lib/chat/tool-cards.ts#L201-L234). [Preview selection](https://github.com/openclaw/openclaw/blob/2b953f227a106cef57dd0cd19f881db7f97955cb/ui/src/pages/chat/components/chat-tool-cards.ts#L44-L73) chooses the result, and [browser-tab-card](https://github.com/openclaw/openclaw/blob/2b953f227a106cef57dd0cd19f881db7f97955cb/ui/src/pages/chat/components/browser-tab-card.ts#L230-L263) renders the globe and labels.
- **Link rule:** ordinary text/Markdown links do not generate this card. It comes from structured Browser results with an exact route identity, with one selected result per tab in each rendered group.
- **Cause:** the producer copied arbitrary URL strings and the normalizer did not classify their schemes. A hostless URL became both labels.
- **Checked consumers:** chat preview selection uses the latest normalized route; `latestBrowserTabCards` preserves URL-less routing and anonymous revisions; chat panel layout continues to follow the last successful tab; transcript projection and browser card thumbnails retain their revision checks.
- **Observed:** two cards before, HTTPS only after; activity disclosure exposes both tool rows; the retained card opens the Browser panel and its close control works.
- **Passing regression coverage:** producer scheme classification; standalone/nested/live chat normalization; browser-origin and malformed-route rejection; URL-less routing; same-tab HTTP → blank/URL-less selection; full mocked chat rendering with preserved raw output.
- **Regression proof:** with pre-fix production, normalizer assertions fail because the blank-tab preview is present, the Browser producer retains non-HTTP(S) display URLs, and the mocked render fails with two cards instead of one. The fixed implementation passes these cases.
- **Focused suites:** 417 tests passed across eight touched files: Browser producer (260), chat normalization/rendering/streaming/routing (152), and bundled mocked UI E2E (5). Repeated after `pnpm install --frozen-lockfile --prefer-offline`, with `OPENCLAW_VITEST_MAX_WORKERS=2`, on the linked head. Manifests and the lockfile are unchanged.
- **Changed-file checks:** `node scripts/check-changed.mjs` passed for all 14 PR files on the same head, including types, lint, formatting, boundary guards, and six additional contract tests. The final run used an isolated mount of the same physical checkout to prevent ancestor dependency lookup; no check was skipped or weakened.
- **Review and scope:** fresh review of the rebased head found no actionable issues after the cleanup and test-value audit. Production remained +32/−26 lines before and after that pass. All changed tests were retained: they protect producer/consumer boundaries, URL-less routing, latest-result selection, or actual transcript rendering; existing positive fixtures were updated without duplicating their tests.

- **Before-merge review:** the latest report (updated September 8 at 18:24:57 UTC) reviewed the current head and found no actionable defects, Before-merge items, or Rank-up moves. No skips are needed; the PR is ready.

- **Hosted CI:** [the exact-head run](https://github.com/openclaw/openclaw/actions/runs/34259612360/job/102174336091) failed `checks-ui-e2e (3/7)` in the existing image custody-to-history continuity test (`chat-flow.image-handoff.e2e.test.ts:148`, called from line 229). The failing image case passes locally on this head and on main `bc56ababdb7c564f7495e138b90582af56de1c16`, both alone and within a replay of the original CI file set on main. These comparisons do not establish the CI failure's cause. The single authorized failed-job rerun passed on this exact head: [attempt 2 image shard](https://github.com/openclaw/openclaw/actions/runs/34259612360/job/102183359891) and [final CI gate](https://github.com/openclaw/openclaw/actions/runs/34259612360/job/102187538413) are successful. The repository watcher returned GREEN; no source or assertion changed for the rerun.

## Risk and coverage

The separate normalized route preserves panel following for actions that legitimately omit a URL. Production changes total +32/−26 lines (net +6); fixtures, screenshots, and the standalone harness are excluded. No configuration, dependency, or storage changes. No live Browser/Gateway integration was exercised; browser behavior was proved through the canonical mocked UI flow.


