### PR TITLE
test: join native controllers before removing triage fixtures

### DIFF
--- a/src/infra/update-managed-service-triage.test-support.ts
+++ b/src/infra/update-managed-service-triage.test-support.ts
@@ -1,11 +1,13 @@
 // Synthetic native boundary only: real Node helpers, IPC, leases and descendants.
 import { spawn } from "node:child_process";
+import { readFileSync, readdirSync } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { DatabaseSync } from "node:sqlite";
 import { vi } from "vitest";
+import { inspectManagedProcessGroup } from "../../scripts/lib/managed-child-process.mts";
 import { resolveServiceManagerEnv } from "../daemon/service-process-env.js";
 import { buildCliRespawnPlan } from "../entry.respawn.js";
 import { getFileLockProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
@@ -64,7 +66,8 @@ export async function createTriageBoundary(
   // The installed candidate can be ESM; native command fixtures remain CommonJS.
   await fs.writeFile(path.join(bin, "package.json"), '{"type":"commonjs"}');
   await fs.mkdir(path.join(root, "members"));
-  await fs.mkdir(path.join(root, "controllers"));
+  const groups = path.join(root, "groups");
+  await fs.mkdir(groups);
   const parent = spawn(process.execPath, ["-e", "process.stdin.resume()"], {
     stdio: ["pipe", "ignore", "ignore"],
   });
@@ -84,11 +87,6 @@ export async function createTriageBoundary(
 const root = ${JSON.stringify(root)};
 const scopeFile = ${JSON.stringify(scopeFile)};
 const primaryFile = ${JSON.stringify(primaryFile)};
-if (/systemctl$|systemd-run$|launchctl$/.test(process.argv[1] || '')) {
-  const controller = root + '/controllers/' + process.pid;
-  fs.writeFileSync(controller, '');
-  process.once('exit', () => fs.rmSync(controller, {force:true}));
-}
 const event = (kind, data = {}) => fs.appendFileSync(${JSON.stringify(events)}, JSON.stringify({kind, pid:process.pid, handoff:process.env.OPENCLAW_UPDATE_RUN_HANDOFF ?? null, sentinel:process.env.OPENCLAW_CONTROL_PLANE_UPDATE_SENTINEL_META ?? null, ...data})+'\\n');
 `;
   // HOME does not fence macOS's gui/UID namespace if a service mock misses.
@@ -108,6 +106,23 @@ const read = fs.readFileSync;
 const native = /systemctl$|systemd-run$|launchctl$/.test(process.argv[1] || '');
 if (/maintenance.mjs$/.test(process.argv[1] || '')) event('maintenance-phase', {phase:'preload',ppid:process.ppid,sequence:0,elapsedMs:0});
 if (!native) fs.writeFileSync(root + '/members/' + process.pid, String(process.pid));
+if (!native) {
+  const childProcess = require('node:child_process'), originalSpawn = childProcess.spawn;
+  childProcess.spawn = function(command, args, options) {
+    if (!options?.detached) return originalSpawn.apply(this, arguments);
+    // Claim before spawn. An open descriptor publishes into the sealed registry
+    // even if cleanup closes admission while this native spawn returns.
+    const receipt = fs.openSync(root + '/groups/' + require('node:crypto').randomUUID(), 'wx');
+    try {
+      const child = originalSpawn.apply(this, arguments);
+      fs.writeSync(receipt, String(child.pid ?? 0));
+      return child;
+    } finally {
+      fs.closeSync(receipt);
+    }
+  };
+  require('node:module').syncBuiltinESMExports();
+}
 fs.readFileSync = function(file, ...args) {
   if (typeof file === 'string' && /^\\/proc\\/(self|[0-9]+)\\/cgroup$/.test(file)) {
     const scope = JSON.parse(read(scopeFile, 'utf8'));
@@ -323,6 +338,7 @@ process.stdout.write(JSON.stringify({status:'error',reason:'original failure'})+
   }
   const helper = spawn(process.execPath, [helperFile, paramsFile], {
     env,
+    detached: true,
     stdio: ["pipe", "pipe", "pipe"],
   });
   let output = "",
@@ -462,28 +478,79 @@ process.stdout.write(JSON.stringify({status:'error',reason:'original failure'})+
         })),
       ),
     cleanup: async () => {
-      for (const pid of await fs.readdir(path.join(root, "members"))) {
+      const deadline = Date.now() + 5000;
+      // Close descendant admission before taking the census. Controllers inherit
+      // their creator's group, including children still starting before registration.
+      const closingGroups = path.join(root, "closing-groups");
+      await fs.rename(groups, closingGroups);
+      const groupIds = new Set([helper.pid!]);
+      const failures: unknown[] = [];
+      try {
+        await vi.waitFor(
+          () => {
+            const pending: string[] = [];
+            for (const entry of readdirSync(closingGroups)) {
+              const value = readFileSync(path.join(closingGroups, entry), "utf8");
+              if (!/^\d+$/u.test(value)) {
+                pending.push(entry);
+              } else if (Number(value) > 0) {
+                groupIds.add(Number(value));
+              }
+            }
+            if (pending.length) {
+              throw new Error(
+                `detached fixture launches have not published: ${pending.join(", ")}`,
+              );
+            }
+          },
+          { timeout: Math.max(1, deadline - Date.now()), interval: 20 },
+        );
+      } catch (error) {
+        failures.push(error);
+      }
+      // An unpublished launch retains the files, but known actors still need joining.
+      for (const pid of groupIds) {
         try {
-          process.kill(Number(pid), "SIGKILL");
-        } catch {}
+          process.kill(-pid, "SIGKILL");
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== "ESRCH") {
+            failures.push(error);
+          }
+        }
       }
       for (const child of [helper, parent]) {
-        if (child.exitCode === null && child.signalCode === null) {
-          child.kill("SIGKILL");
+        try {
+          if (child.exitCode === null && child.signalCode === null) {
+            child.kill("SIGKILL");
+          }
+        } catch (error) {
+          failures.push(error);
         }
       }
       await Promise.all([exit, parentExit]);
-      // Native control children are outside the synthetic scope they stop.
-      await vi.waitFor(
-        async () => {
-          const controllers = await fs.readdir(path.join(root, "controllers"));
-          if (controllers.some((pid) => isPidAlive(Number(pid)))) {
-            throw new Error("native fixture controllers are still running");
-          }
-        },
-        { timeout: 5000, interval: 20 },
-      );
+      try {
+        await vi.waitFor(
+          () => {
+            for (const pid of groupIds) {
+              if (
+                inspectManagedProcessGroup(
+                  { pid, exitCode: 0 },
+                  { errorPolicy: "indeterminate" },
+                ) !== "dead"
+              ) {
+                throw new Error(`native fixture process group ${pid} has not exited`);
+              }
+            }
+          },
+          { timeout: Math.max(1, deadline - Date.now()), interval: 20 },
+        );
+      } catch (error) {
+        failures.push(error);
+      }
       lines.close();
+      if (failures.length) {
+        throw new AggregateError(failures, "Could not join all native fixture process groups");
+      }
       const finalEvents = await readEvents();
       const db = new DatabaseSync(databasePath);
       try {

--- a/src/infra/update-managed-service-triage.test.ts
+++ b/src/infra/update-managed-service-triage.test.ts
@@ -1,4 +1,5 @@
 import fs from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { getFileLockProcessStartTime, isPidAlive } from "../shared/pid-alive.js";
@@ -41,9 +42,11 @@ async function fixing(boundary: Awaited<ReturnType<typeof start>>) {
 async function closed(boundary: Awaited<ReturnType<typeof start>>) {
   await vi.waitFor(
     async () => {
-      expect((await boundary.readEvents()).some((event) => event.kind === "scope-stopped")).toBe(
-        true,
-      );
+      const events = await boundary.readEvents();
+      expect(
+        events.some((event) => event.kind === "scope-stopped"),
+        `${await boundary.log()}\nEvents: ${JSON.stringify(events)}`,
+      ).toBe(true);
       expect((await boundary.members()).filter((member) => member.alive)).toEqual([]);
     },
     { timeout: 5000 },
@@ -56,6 +59,76 @@ async function closed(boundary: Awaited<ReturnType<typeof start>>) {
 }
 
 describe("managed triage attachment cutover (synthetic native boundary)", () => {
+  itUnix.each(["helper", "executor"] as const)(
+    "joins a controller started by the %s before fixture cleanup",
+    async (owner) => {
+      const coordination = await fs.mkdtemp(path.join(os.tmpdir(), "triage-controller-"));
+      const receipt = path.join(coordination, "ready.json");
+      let controller: { pid: number; start: number | null } | undefined;
+      let boundary: Awaited<ReturnType<typeof createTriageBoundary>> | undefined;
+      let cleanupAttempted = false;
+      try {
+        boundary = await createTriageBoundary("startup", undefined, undefined, async (root) => {
+          const native = path.join(root, "bin", "systemctl");
+          const script = await fs.readFile(native, "utf8");
+          const shebangEnd = script.indexOf("\n") + 1;
+          await fs.writeFile(
+            native,
+            script.slice(0, shebangEnd) +
+              `if (process.argv.includes('--fixture-pause')) {
+  require('node:fs').writeFileSync(${JSON.stringify(receipt)}, JSON.stringify({pid:process.pid}));
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0);
+}\n` +
+              script.slice(shebangEnd),
+          );
+          const filename = path.join(root, owner === "helper" ? "handoff.cjs" : "candidate.mjs");
+          const source = await fs.readFile(filename, "utf8");
+          const marker =
+            owner === "helper"
+              ? 'const params = JSON.parse(fs.readFileSync(process.argv[2], "utf-8"));'
+              : "event('fixer', {failure:admission.failure});";
+          await fs.writeFile(
+            filename,
+            source.replace(
+              marker,
+              `${marker}\nspawn(${JSON.stringify(native)}, ['--fixture-pause'], {env:{...process.env,NODE_OPTIONS:''},stdio:'ignore'});`,
+            ),
+          );
+        });
+        await ready(boundary);
+        expect(await boundary.control("commit")).toBe("committed");
+        await fixing(boundary);
+        await vi.waitFor(async () => {
+          const { pid } = JSON.parse(await fs.readFile(receipt, "utf8"));
+          controller = { pid, start: getFileLockProcessStartTime(pid) };
+          expect(isPidAlive(pid)).toBe(true);
+        });
+        expect(
+          (await boundary.readEvents()).filter((event) => event.pid === controller!.pid),
+        ).toEqual([]);
+        cleanupAttempted = true;
+        await boundary.cleanup();
+        expect(isPidAlive(controller!.pid), "cleanup returned before its native controller").toBe(
+          false,
+        );
+        await expect(fs.access(boundary.root)).rejects.toThrow();
+      } finally {
+        if (
+          controller &&
+          isPidAlive(controller.pid) &&
+          getFileLockProcessStartTime(controller.pid) === controller.start
+        ) {
+          process.kill(controller.pid, "SIGKILL");
+          await vi.waitFor(() => expect(isPidAlive(controller!.pid)).toBe(false));
+        }
+        if (boundary && !cleanupAttempted) {
+          await boundary.cleanup();
+        }
+        await fs.rm(coordination, { recursive: true, force: true });
+      }
+    },
+  );
+
   itUnix.each(["allowed", "before-grant", "after-admission"] as const)(
     "retains the chat requester's authority at the repair effect boundary: %s",
     async (window) => {
@@ -537,12 +610,8 @@ const acceptTriageContinuation = async () => {
           script = script.replace(
             "event('branch',{child:branch.pid});",
             `
-event('branch',{child:branch.pid});
-const watcher = fs.watch(${JSON.stringify(root)}, (_event, name) => {
-  if (name !== 'disconnect') return;
-  watcher.close();
-  process.disconnect();
-});`,
+process.once('SIGUSR2', () => process.disconnect());
+event('branch',{child:branch.pid});`,
           );
         }
         await fs.writeFile(file, script);
@@ -557,7 +626,10 @@ const watcher = fs.watch(${JSON.stringify(root)}, (_event, name) => {
       } else if (loss === "cancelled" || loss === "scope") {
         boundary.replaceLease(loss);
       } else if (loss === "disconnect") {
-        await fs.writeFile(path.join(boundary.root, "disconnect"), "");
+        process.kill(
+          (await boundary.readEvents()).find((event) => event.kind === "fixer")!.pid,
+          "SIGUSR2",
+        );
       } else {
         process.kill(
           (await boundary.readEvents()).find((event) => event.kind === "fixer")!.pid,


### PR DESCRIPTION
Related: #142154

## What Problem This Solves

Resolves a native test-fixture cleanup race exposed by [CI 34227269292](https://github.com/openclaw/openclaw/actions/runs/34227269292/job/102064585661). Cleanup could remove its temporary directory while a controller process was still starting and had not registered its PID. The run failed with `ENOTEMPTY`; deterministic regressions independently prove the missing join, although the exact writer from that historical failure was not captured.

## Why This Change Was Made

Give the fixture helper its own process group and record nested detached groups at their creator before launch. Cleanup closes further group admission, waits for ownership publication, stops and joins known groups, and removes files only after verified quiescence. Unknown ownership retains the directory and reports failure. Publication and group completion share the existing five-second cleanup budget.

The disconnect scenario now signals its owned synthetic executor after its handler is installed, replacing a filesystem watcher that could miss the trigger. It still tests actual IPC loss, scope shutdown and absence of late restoration. Failure diagnostics include the existing helper log and event history.

## User Impact

More reliable CI and complete cleanup of test-owned native processes. Production behavior, service control, schemas, deadlines and existing assertions remain unchanged. No removal retry or extra sleep. Production LOC: 0; fixture support: +88/-21; tests: +82/-10.

## Evidence

- Two new regressions hold a controller before it can register, covering helper and executor process groups. Both fail on the original fixture because cleanup returns with the exact controller alive; both pass after repair. Probe cleanup verifies PID start identity before rescuing the old-code child.
- The existing cancelled-loss case passes in the broad sibling runs. Those runs passed **54/55** and exposed the separate disconnect fixture issue; the repaired disconnect then passed a targeted run. This is not presented as one final 55/55 run.
- A forced-order probe demonstrated the old watcher could miss a trigger after advertised readiness. The final signal-based fixture removes that incidental filesystem-notification dependency without changing the IPC-loss assertions.
- All required changed-gate components passed; the initial lint pair was corrected and final focused lint passed. Fresh independent P0–P2 review of the final source found no actionable issue. No additional runtime run after the final error-aggregation cleanup is claimed; exact-head Linux CI remains required before landing.

Local compilation was affected by heavy workstation load, so this PR makes no throughput speedup claim. Its benefit is fixing the demonstrated lifecycle gap and avoiding cleanup-driven CI retries. Temporary diagnostics and held processes were cleaned up.
