### PR TITLE
fix(ui): Online sidebar names appear underlined

### DIFF
--- a/ui/src/styles/cursor-policy.browser.test.ts
+++ b/ui/src/styles/cursor-policy.browser.test.ts
@@ -107,7 +107,8 @@ function fixtureDocument(): string {
       <aside class="sidebar">
         <a class="nav-item" href="/chat"><span class="nav-item__text">Home</span></a>
         <a class="sidebar-recent-session__link" href="/chat/test"><span class="sidebar-recent-session__name">Session</span></a>
-        <a class="sidebar-online__person" href="/activity">Person</a>
+        <a class="sidebar-online__person" href="/activity"><span class="sidebar-online__person-name">Person</span></a>
+        <button class="sidebar-online__person" type="button"><span class="sidebar-online__person-name">Viewer</span></button>
         <a class="sidebar-brand__new-thread" href="/new">New session</a>
         <a class="sidebar-new-session" href="/new">New group session</a>
         <a class="sidebar-session-catalog-new" href="/new">New catalog session</a>
@@ -215,6 +216,33 @@ afterAll(async () => {
 });
 
 describeCursorPolicy("Control UI cursor policy", () => {
+  it("keeps Online names undecorated for links and buttons", async () => {
+    const page = await tabBrowser.newPage();
+    try {
+      await page.goto(`file://${fixtureFile}`);
+      const people = await page.locator(".sidebar-online__person").all();
+      expect(people).toHaveLength(2);
+      for (const person of people) {
+        // Ancestor decorations propagate visually without inheriting the computed value.
+        expect(
+          await person.evaluate((element) => getComputedStyle(element).textDecorationLine),
+        ).toBe("none");
+        expect(
+          await person
+            .locator(".sidebar-online__person-name")
+            .evaluate((element) => getComputedStyle(element).textDecorationLine),
+        ).toBe("none");
+      }
+      expect(
+        await page
+          .locator("#real-link")
+          .evaluate((element) => getComputedStyle(element).textDecorationLine),
+      ).toBe("underline");
+    } finally {
+      await page.close().catch(() => {});
+    }
+  });
+
   it("uses semantic cursors in a browser tab", async () => {
     const page = await tabBrowser.newPage();
     try {

--- a/ui/src/styles/layout.css
+++ b/ui/src/styles/layout.css
@@ -2360,6 +2360,7 @@ openclaw-settings-save-indicator:empty {
   color: var(--text);
   font: inherit;
   text-align: left;
+  text-decoration: none;
   transition:
     background var(--duration-fast) ease,
     box-shadow var(--duration-fast) ease,


### PR DESCRIPTION
Closes #142206

## What Problem This Solves

Fixes an issue where users viewing identified people in the Control UI sidebar's Online section would see underlined names, unlike neighboring sidebar rows.

## Why This Change Was Made

Restore the decoration reset on the Online row itself. Identified people render as links, so their rows otherwise pick up the global anchor underline; resetting only the nested name would leave the ancestor's underline visible.

## User Impact

Online names have consistent sidebar styling. Activity navigation and presence cards retain their existing interactions.

## Evidence

Dark theme, identical 1440 × 900 viewport, scroll position, and sidebar crop. The first person has a profile identity; the second remains an unqualified viewer button.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><a href="https://github.com/user-attachments/assets/3702888c-448c-4fc2-8834-9ffbf22174e7"><img src="https://github.com/user-attachments/assets/3702888c-448c-4fc2-8834-9ffbf22174e7" width="258" alt="Before: Colin's Online name is underlined"></a><br><a href="https://github.com/user-attachments/assets/3702888c-448c-4fc2-8834-9ffbf22174e7">Open before screenshot</a></td>
<td><a href="https://github.com/user-attachments/assets/9ed794b7-c410-4ffb-af9b-7ee04c656945"><img src="https://github.com/user-attachments/assets/9ed794b7-c410-4ffb-af9b-7ee04c656945" width="258" alt="After: Colin's Online name has no underline"></a><br><a href="https://github.com/user-attachments/assets/9ed794b7-c410-4ffb-af9b-7ee04c656945">Open after screenshot</a></td>
</tr>
</table>

- Browser regression failed on the original stylesheet (`underline` instead of `none`). The final focused file passes all four tests with `OPENCLAW_VITEST_MAX_WORKERS=2` (no skips), covering parent/name decoration for both links and buttons, ordinary link underlining, and the existing browser/native/installed-window cursor policy. Chromium resolves the production CSS cascade: the parent assertion catches the observed propagation bug, and the ordinary-link assertion protects the global link contract.
- The canonical mocked Control UI kept both row variants undecorated at rest, on hover, and on focus. Online collapse/expand, button-to-card, Escape dismissal, and click/Enter navigation to Activity all worked. All 18 rendered Recent session links remained undecorated.
- Restored the locked development dependencies with `pnpm install --frozen-lockfile --prefer-offline`; all 182 package/lock hashes and head `af7e0cfad961d3bacbf1c3fe3aa144a29bf7047e` remained unchanged. The four browser tests passed again with `OPENCLAW_VITEST_MAX_WORKERS=2`.
- Local changed checks reached all 20 planned stages: guards, 17 test typecheck groups, UI typecheck, coercion checks, three unused-export scans with zero entries, Oxlint, and Stylelint. An initial runner cleanup failure was followed by one unchanged-head retry. The retry's parent session ended with 143 while its detached check continued; its overall exit code was not captured. The final Stylelint step was verified separately with exit 0.
- [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34244137555) and the required `openclaw/ci-gate` passed. The canonical CI watcher completed with `GREEN`.

## Risk and coverage

The production change is one declaration scoped to `.sidebar-online__person`. Checked sibling source owners: Recent session links already reset decoration; Activity session links reset it in normal and interactive states; Activity people-picker rows remain buttons. Their selectors and the global link rule are unchanged. The button fallback is covered alongside the anchor variant.

Visual proof uses synthetic presence data and a mocked Gateway. No live Gateway, provider, or macOS desktop run was needed for this stylesheet change. The local command-session exit limitation is recorded above; exact-head hosted CI completed successfully.
