### PR TITLE
fix(sessions): prevent cross-agent follow-up failures from stale runtime context

### DIFF
--- a/src/agents/tools/sessions-send-tool.a2a-generation.test.ts
+++ b/src/agents/tools/sessions-send-tool.a2a-generation.test.ts
@@ -1,0 +1,182 @@
+// Keep the provider/auth fixture setup before imports that consume it.
+// oxfmt-ignore
+import {
+  cleanupPreparedModelRuntimeHarness,
+  getPreparedModelRuntimeMocks,
+  resetPreparedModelRuntimeHarness,
+} from "../prepared-model-runtime.test-harness.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createDeferred } from "../../../test/helpers/promise.js";
+import {
+  getActiveGatewayRootWorkCount,
+  resetGatewayWorkAdmission,
+  runWithGatewayIndependentRootWorkContinuation,
+} from "../../process/gateway-work-admission.js";
+import {
+  createOpenClawTestState,
+  type OpenClawTestState,
+} from "../../test-utils/openclaw-test-state.js";
+import {
+  getPreparedModelRuntimeBorrowedSnapshot,
+  getPreparedModelRuntimePluginGeneration,
+  withPreparedModelRuntimePluginGenerationScope,
+} from "../prepared-model-runtime-generation-scope.js";
+import {
+  acquireAgentRunPreparedModelRuntime,
+  loadPublishedGatewayReplyDispatchRuntime,
+  refreshPreparedModelRuntimeSnapshots,
+} from "../prepared-model-runtime.js";
+import { testing } from "./agent-step.test-support.js";
+import { resolveAnnounceTarget } from "./sessions-announce-target.js";
+import { runSessionsSendA2AFlow } from "./sessions-send-tool.a2a.js";
+
+vi.mock("./sessions-announce-target.js", () => ({ resolveAnnounceTarget: vi.fn() }));
+
+const mocks = getPreparedModelRuntimeMocks();
+let state: OpenClawTestState;
+
+// The real peer flow and direct agent-step route reach the real prepared lease
+// guard. Only provider/auth preparation, target discovery and inference are fake.
+describe("detached peer announce prepared generation", () => {
+  beforeEach(async () => {
+    state = await createOpenClawTestState({ label: "peer-announce-generation" });
+    await resetPreparedModelRuntimeHarness(state);
+    resetGatewayWorkAdmission();
+  });
+  afterEach(async () => {
+    testing.setDepsForTest();
+    vi.clearAllMocks();
+    resetGatewayWorkAdmission();
+    await cleanupPreparedModelRuntimeHarness(state, false);
+  });
+
+  it.each([
+    { releaseParent: false, reload: false },
+    { releaseParent: false, reload: true },
+    { releaseParent: true, reload: false },
+    { releaseParent: true, reload: true },
+  ])(
+    "re-admits target (releaseParent=$releaseParent, reload=$reload)",
+    async ({ releaseParent, reload }) => {
+      mocks.configuredAgentIds = ["sender", "target"];
+      mocks.configuredWorkspaces.set("sender", state.agentDir("sender"));
+      mocks.configuredWorkspaces.set("target", state.agentDir("target"));
+      const config = { messages: { responsePrefix: "before" } };
+      const publication = { gatewayLifecycle: true, catalogMode: "static" as const };
+      await refreshPreparedModelRuntimeSnapshots(config, publication);
+      const admitted = await loadPublishedGatewayReplyDispatchRuntime({ agentId: "sender" });
+      expect(admitted).toBeDefined();
+      const input = (agentId: string) => ({
+        config,
+        agentId,
+        agentDir: state.agentDir(agentId),
+        workspaceDir: state.agentDir(agentId),
+      });
+      const parent = await acquireAgentRunPreparedModelRuntime(input("sender"), {
+        pluginGeneration: admitted!.pluginGeneration,
+      });
+      let parentOpen = true;
+      const entered = createDeferred();
+      const proceed = createDeferred();
+      vi.mocked(resolveAnnounceTarget).mockImplementation(async () => {
+        entered.resolve();
+        await proceed.promise;
+        return null;
+      });
+      const errors: string[] = [];
+      const acceptedOwners: string[] = [];
+      testing.setDepsForTest({
+        agentCommandFromIngress: async (opts) => {
+          expect(opts.agentId).toBe("target");
+          expect(opts.transcriptMessage).toBe("");
+          expect(opts.deliver).toBe(false);
+          expect(opts.allowModelOverride).toBe(false);
+          expect(getActiveGatewayRootWorkCount()).toBe(1);
+          try {
+            // Same ambient-generation acquisition as the embedded run orchestrator;
+            // no model, gateway, credentials or plugin process is invoked.
+            const lease = await acquireAgentRunPreparedModelRuntime(input("target"), {
+              pluginGeneration: getPreparedModelRuntimePluginGeneration(),
+            });
+            expect(lease.snapshot.config.messages?.responsePrefix).toBe(
+              reload ? "after" : "before",
+            );
+            const currentTarget = await loadPublishedGatewayReplyDispatchRuntime({
+              agentId: "target",
+            });
+            expect(lease.pluginGeneration).toBe(currentTarget?.pluginGeneration);
+            acceptedOwners.push(lease.snapshot.agentId!);
+            lease.release();
+            return {
+              payloads: [{ text: "ANNOUNCE_SKIP", mediaUrl: null }],
+              meta: { durationMs: 0 },
+            };
+          } catch (error) {
+            errors.push(String(error));
+            throw error;
+          }
+        },
+      });
+      const flow = withPreparedModelRuntimePluginGenerationScope(
+        admitted!.pluginGeneration,
+        async () => {
+          const detached = runWithGatewayIndependentRootWorkContinuation(
+            () =>
+              runSessionsSendA2AFlow({
+                targetSessionKey: "agent:target:main",
+                targetAgentId: "target",
+                requesterSessionKey: "agent:sender:main",
+                requesterAgentId: "sender",
+                displayKey: "agent:target:main",
+                message: "Return evidence once",
+                roundOneReply: "Evidence already returned",
+                announceTimeoutMs: 1000,
+                maxPingPongTurns: 0,
+                callGateway: async () => {
+                  throw new Error("No gateway calls permitted");
+                },
+              }),
+            "session:a2a-send",
+          );
+          expect(getPreparedModelRuntimePluginGeneration()).toBe(admitted!.pluginGeneration);
+          expect(getPreparedModelRuntimeBorrowedSnapshot(admitted!.pluginGeneration)).toBe(
+            parent.snapshot,
+          );
+          await detached;
+          expect(getPreparedModelRuntimePluginGeneration()).toBe(admitted!.pluginGeneration);
+          expect(getPreparedModelRuntimeBorrowedSnapshot(admitted!.pluginGeneration)).toBe(
+            parentOpen ? parent.snapshot : undefined,
+          );
+        },
+        () => (parentOpen ? parent.snapshot : undefined),
+      );
+      await entered.promise;
+      if (releaseParent) {
+        parentOpen = false;
+        parent.release();
+      }
+      if (reload) {
+        await refreshPreparedModelRuntimeSnapshots(
+          { messages: { responsePrefix: "after" } },
+          publication,
+        );
+      }
+      proceed.resolve();
+      await flow;
+      if (parentOpen) {
+        parentOpen = false;
+        parent.release();
+      }
+      expect(getPreparedModelRuntimePluginGeneration()).toBeUndefined();
+      expect(errors).toEqual([]);
+      expect(acceptedOwners).toEqual(["target"]);
+      expect(getActiveGatewayRootWorkCount()).toBe(0);
+      // Clearing detached scope must not weaken explicitly owned stale admissions.
+      await expect(
+        acquireAgentRunPreparedModelRuntime(input("target"), {
+          pluginGeneration: admitted!.pluginGeneration,
+        }),
+      ).rejects.toThrow("plugin generation was superseded");
+    },
+  );
+});

--- a/src/agents/tools/sessions-send-tool.a2a.ts
+++ b/src/agents/tools/sessions-send-tool.a2a.ts
@@ -10,6 +10,7 @@ import { splitMediaFromOutput } from "../../media/parse.js";
 import { normalizeAgentId } from "../../routing/session-key.js";
 import { parseAgentSessionKey } from "../../sessions/session-key-utils.js";
 import { resolveNestedAgentLaneForSession } from "../lanes.js";
+import { runOutsidePreparedModelRuntimePluginGenerationScope } from "../prepared-model-runtime-generation-scope.js";
 import { type AgentWaitResult, waitForAgentRunReply } from "../run-wait.js";
 import { runAgentStep } from "./agent-step.js";
 import {
@@ -108,180 +109,184 @@ export async function runSessionsSendA2AFlow(params: {
   waitRunId?: string;
   notifyRequesterOnWaitFailure?: boolean;
 }) {
-  const runContextId = params.waitRunId ?? "unknown";
-  const gatewayCall = params.callGateway ?? callAgentToolGatewayRequest;
-  try {
-    let primaryReply = params.roundOneReply;
-    let sourceReplyDelivered = params.sourceReplyDelivered;
-    if (!primaryReply && params.waitRunId) {
-      const wait = await waitForAgentRunReply({
-        runId: params.waitRunId,
-        timeoutMs: Math.min(params.announceTimeoutMs, 60_000),
-        callGateway: gatewayCall,
+  // Peer bookkeeping outlives its sender lease and may target a different owner.
+  // Re-admit each turn on its target generation, retaining gateway work authority.
+  return runOutsidePreparedModelRuntimePluginGenerationScope(async () => {
+    const runContextId = params.waitRunId ?? "unknown";
+    const gatewayCall = params.callGateway ?? callAgentToolGatewayRequest;
+    try {
+      let primaryReply = params.roundOneReply;
+      let sourceReplyDelivered = params.sourceReplyDelivered;
+      if (!primaryReply && params.waitRunId) {
+        const wait = await waitForAgentRunReply({
+          runId: params.waitRunId,
+          timeoutMs: Math.min(params.announceTimeoutMs, 60_000),
+          callGateway: gatewayCall,
+        });
+        if (wait.status === "ok") {
+          primaryReply = wait.replyText;
+          sourceReplyDelivered = wait.sourceReplyDelivered;
+        } else {
+          if (
+            params.notifyRequesterOnWaitFailure === true &&
+            params.requesterSessionKey &&
+            isDeliveryFailureWait(wait)
+          ) {
+            const error =
+              typeof wait.error === "string" && wait.error.trim() ? `: ${wait.error.trim()}` : "";
+            await runAgentStep({
+              agentId: params.requesterAgentId,
+              sessionKey: params.requesterSessionKey,
+              message: wait.sourceReplyDelivered
+                ? `sessions_send target run for ${params.displayKey} failed${error}. The target's final reply was already delivered to its source conversation. Do not resend; report the run failure.`
+                : `sessions_send delivery to ${params.displayKey} failed${error}. The target may not have received the message; retry or report the failure instead of assuming delivery succeeded.`,
+              extraSystemPrompt: wait.sourceReplyDelivered
+                ? "The target run failed after its final source reply was delivered. Preserve the run error diagnosis. Do not resend the message or the reply."
+                : "A previous sessions_send delivery failed after it was accepted. Decide whether to retry, use another route, or report the failure. Do not assume the target received the message.",
+              timeoutMs: params.announceTimeoutMs,
+              lane: resolveNestedAgentLaneForSession(params.requesterSessionKey),
+              sourceSessionKey: params.targetSessionKey,
+              sourceTool: "sessions_send",
+              callGateway: gatewayCall,
+            });
+          }
+          return;
+        }
+      }
+      let latestReply = primaryReply;
+      if (!latestReply) {
+        return;
+      }
+      if (isNonDeliverableSessionsReply(latestReply)) {
+        return;
+      }
+
+      // A same-session send is a human-facing source-channel reply, not a true
+      // agent-to-agent announcement. Asking the same session to decide whether to
+      // announce can re-run the same prompt and duplicate source-reply side effects.
+      const sameSessionSourceReply = sameOwnedSession({
+        leftKey: params.requesterSessionKey,
+        leftAgentId: params.requesterAgentId,
+        rightKey: params.targetSessionKey,
+        rightAgentId: params.targetAgentId,
       });
-      if (wait.status === "ok") {
-        primaryReply = wait.replyText;
-        sourceReplyDelivered = wait.sourceReplyDelivered;
-      } else {
-        if (
-          params.notifyRequesterOnWaitFailure === true &&
-          params.requesterSessionKey &&
-          isDeliveryFailureWait(wait)
-        ) {
-          const error =
-            typeof wait.error === "string" && wait.error.trim() ? `: ${wait.error.trim()}` : "";
-          await runAgentStep({
-            agentId: params.requesterAgentId,
-            sessionKey: params.requesterSessionKey,
-            message: wait.sourceReplyDelivered
-              ? `sessions_send target run for ${params.displayKey} failed${error}. The target's final reply was already delivered to its source conversation. Do not resend; report the run failure.`
-              : `sessions_send delivery to ${params.displayKey} failed${error}. The target may not have received the message; retry or report the failure instead of assuming delivery succeeded.`,
-            extraSystemPrompt: wait.sourceReplyDelivered
-              ? "The target run failed after its final source reply was delivered. Preserve the run error diagnosis. Do not resend the message or the reply."
-              : "A previous sessions_send delivery failed after it was accepted. Decide whether to retry, use another route, or report the failure. Do not assume the target received the message.",
+      if (sameSessionSourceReply && sourceReplyDelivered) {
+        return;
+      }
+      const announceTarget = await resolveAnnounceTarget({
+        sessionKey: params.targetSessionKey,
+        displayKey: params.displayKey,
+        callGateway: gatewayCall,
+        agentId: params.targetAgentId,
+      });
+      const targetChannel = announceTarget?.channel ?? "unknown";
+      const canDirectDeliverSameSessionReply =
+        announceTarget &&
+        (!params.requesterChannel || params.requesterChannel === announceTarget.channel);
+      if (sameSessionSourceReply && canDirectDeliverSameSessionReply) {
+        await deliverAnnounceReply({
+          announceTarget,
+          callGateway: gatewayCall,
+          message: latestReply,
+          runContextId,
+          targetSessionKey: params.targetSessionKey,
+        });
+        return;
+      }
+      if (sameSessionSourceReply && !announceTarget) {
+        return;
+      }
+
+      if (params.maxPingPongTurns > 0 && params.requesterSessionKey && !sameSessionSourceReply) {
+        let currentSessionKey = params.requesterSessionKey;
+        let nextSessionKey = params.targetSessionKey;
+        let currentAgentId = params.requesterAgentId;
+        let nextAgentId = params.targetAgentId;
+        let currentRole: "requester" | "target" = "requester";
+        let nextRole: "requester" | "target" = "target";
+        let incomingMessage = latestReply;
+        for (let turn = 1; turn <= params.maxPingPongTurns; turn += 1) {
+          const replyPrompt = buildAgentToAgentReplyContext({
+            requesterSessionKey: params.requesterSessionKey,
+            requesterChannel: params.requesterChannel,
+            targetSessionKey: params.displayKey,
+            targetChannel,
+            currentRole,
+            turn,
+            maxTurns: params.maxPingPongTurns,
+          });
+          const replyText = await runAgentStep({
+            agentId: currentAgentId,
+            sessionKey: currentSessionKey,
+            message: incomingMessage,
+            extraSystemPrompt: replyPrompt,
             timeoutMs: params.announceTimeoutMs,
-            lane: resolveNestedAgentLaneForSession(params.requesterSessionKey),
-            sourceSessionKey: params.targetSessionKey,
+            lane: resolveNestedAgentLaneForSession(currentSessionKey),
+            sourceAgentId: nextAgentId,
+            sourceSessionKey: nextSessionKey,
+            sourceChannel: nextRole === "requester" ? params.requesterChannel : targetChannel,
             sourceTool: "sessions_send",
             callGateway: gatewayCall,
           });
+          if (!replyText || isReplySkip(replyText) || isNonDeliverableSessionsReply(replyText)) {
+            break;
+          }
+          latestReply = replyText;
+          incomingMessage = replyText;
+          const swap = currentSessionKey;
+          currentSessionKey = nextSessionKey;
+          nextSessionKey = swap;
+          const agentSwap = currentAgentId;
+          currentAgentId = nextAgentId;
+          nextAgentId = agentSwap;
+          const roleSwap: "requester" | "target" = currentRole;
+          currentRole = nextRole;
+          nextRole = roleSwap;
         }
-        return;
       }
-    }
-    let latestReply = primaryReply;
-    if (!latestReply) {
-      return;
-    }
-    if (isNonDeliverableSessionsReply(latestReply)) {
-      return;
-    }
 
-    // A same-session send is a human-facing source-channel reply, not a true
-    // agent-to-agent announcement. Asking the same session to decide whether to
-    // announce can re-run the same prompt and duplicate source-reply side effects.
-    const sameSessionSourceReply = sameOwnedSession({
-      leftKey: params.requesterSessionKey,
-      leftAgentId: params.requesterAgentId,
-      rightKey: params.targetSessionKey,
-      rightAgentId: params.targetAgentId,
-    });
-    if (sameSessionSourceReply && sourceReplyDelivered) {
-      return;
-    }
-    const announceTarget = await resolveAnnounceTarget({
-      sessionKey: params.targetSessionKey,
-      displayKey: params.displayKey,
-      callGateway: gatewayCall,
-      agentId: params.targetAgentId,
-    });
-    const targetChannel = announceTarget?.channel ?? "unknown";
-    const canDirectDeliverSameSessionReply =
-      announceTarget &&
-      (!params.requesterChannel || params.requesterChannel === announceTarget.channel);
-    if (sameSessionSourceReply && canDirectDeliverSameSessionReply) {
-      await deliverAnnounceReply({
-        announceTarget,
-        callGateway: gatewayCall,
-        message: latestReply,
-        runContextId,
-        targetSessionKey: params.targetSessionKey,
+      const announcePrompt = buildAgentToAgentAnnounceContext({
+        requesterSessionKey: params.requesterSessionKey,
+        requesterChannel: params.requesterChannel,
+        targetSessionKey: params.displayKey,
+        targetChannel,
+        originalMessage: params.message,
+        roundOneReply: primaryReply,
+        latestReply,
       });
-      return;
-    }
-    if (sameSessionSourceReply && !announceTarget) {
-      return;
-    }
-
-    if (params.maxPingPongTurns > 0 && params.requesterSessionKey && !sameSessionSourceReply) {
-      let currentSessionKey = params.requesterSessionKey;
-      let nextSessionKey = params.targetSessionKey;
-      let currentAgentId = params.requesterAgentId;
-      let nextAgentId = params.targetAgentId;
-      let currentRole: "requester" | "target" = "requester";
-      let nextRole: "requester" | "target" = "target";
-      let incomingMessage = latestReply;
-      for (let turn = 1; turn <= params.maxPingPongTurns; turn += 1) {
-        const replyPrompt = buildAgentToAgentReplyContext({
-          requesterSessionKey: params.requesterSessionKey,
-          requesterChannel: params.requesterChannel,
-          targetSessionKey: params.displayKey,
-          targetChannel,
-          currentRole,
-          turn,
-          maxTurns: params.maxPingPongTurns,
-        });
-        const replyText = await runAgentStep({
-          agentId: currentAgentId,
-          sessionKey: currentSessionKey,
-          message: incomingMessage,
-          extraSystemPrompt: replyPrompt,
-          timeoutMs: params.announceTimeoutMs,
-          lane: resolveNestedAgentLaneForSession(currentSessionKey),
-          sourceAgentId: nextAgentId,
-          sourceSessionKey: nextSessionKey,
-          sourceChannel: nextRole === "requester" ? params.requesterChannel : targetChannel,
-          sourceTool: "sessions_send",
+      const announceReply = await runAgentStep({
+        agentId: params.targetAgentId,
+        sessionKey: params.targetSessionKey,
+        message: "Agent-to-agent announce step.",
+        extraSystemPrompt: announcePrompt,
+        timeoutMs: params.announceTimeoutMs,
+        lane: resolveNestedAgentLaneForSession(params.targetSessionKey),
+        transcriptMessage: "",
+        sourceSessionKey: params.requesterSessionKey,
+        sourceChannel: params.requesterChannel,
+        sourceTool: "sessions_send",
+        callGateway: gatewayCall,
+      });
+      if (
+        announceTarget &&
+        announceReply &&
+        announceReply.trim() &&
+        !isAnnounceSkip(announceReply) &&
+        !isNonDeliverableSessionsReply(announceReply)
+      ) {
+        await deliverAnnounceReply({
+          announceTarget,
           callGateway: gatewayCall,
+          message: announceReply,
+          runContextId,
+          targetSessionKey: params.targetSessionKey,
         });
-        if (!replyText || isReplySkip(replyText) || isNonDeliverableSessionsReply(replyText)) {
-          break;
-        }
-        latestReply = replyText;
-        incomingMessage = replyText;
-        const swap = currentSessionKey;
-        currentSessionKey = nextSessionKey;
-        nextSessionKey = swap;
-        const agentSwap = currentAgentId;
-        currentAgentId = nextAgentId;
-        nextAgentId = agentSwap;
-        const roleSwap: "requester" | "target" = currentRole;
-        currentRole = nextRole;
-        nextRole = roleSwap;
       }
-    }
-
-    const announcePrompt = buildAgentToAgentAnnounceContext({
-      requesterSessionKey: params.requesterSessionKey,
-      requesterChannel: params.requesterChannel,
-      targetSessionKey: params.displayKey,
-      targetChannel,
-      originalMessage: params.message,
-      roundOneReply: primaryReply,
-      latestReply,
-    });
-    const announceReply = await runAgentStep({
-      agentId: params.targetAgentId,
-      sessionKey: params.targetSessionKey,
-      message: "Agent-to-agent announce step.",
-      extraSystemPrompt: announcePrompt,
-      timeoutMs: params.announceTimeoutMs,
-      lane: resolveNestedAgentLaneForSession(params.targetSessionKey),
-      transcriptMessage: "",
-      sourceSessionKey: params.requesterSessionKey,
-      sourceChannel: params.requesterChannel,
-      sourceTool: "sessions_send",
-      callGateway: gatewayCall,
-    });
-    if (
-      announceTarget &&
-      announceReply &&
-      announceReply.trim() &&
-      !isAnnounceSkip(announceReply) &&
-      !isNonDeliverableSessionsReply(announceReply)
-    ) {
-      await deliverAnnounceReply({
-        announceTarget,
-        callGateway: gatewayCall,
-        message: announceReply,
-        runContextId,
-        targetSessionKey: params.targetSessionKey,
+    } catch (err) {
+      log.warn("sessions_send announce flow failed", {
+        runId: runContextId,
+        error: formatErrorMessage(err),
       });
     }
-  } catch (err) {
-    log.warn("sessions_send announce flow failed", {
-      runId: runContextId,
-      error: formatErrorMessage(err),
-    });
-  }
+  });
 }


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where cross-agent `sessions_send` follow-up bookkeeping can fail before inference with `prepared model runtime plugin generation was superseded`, even though the initial reply was returned successfully. The detached follow-up inherits the sender's prepared generation but executes for another agent; it can also outlive the sender or a configuration reload.

## Why This Change Was Made

Exit the inherited prepared-model-runtime generation scope at the detached A2A flow boundary, using the existing helper already used by detached queue drains. Each follow-up is admitted against its target's current owner. The independent gateway work root, caller authority and explicit stale-generation rejection remain unchanged.

This is one runtime repair: no tool-description changes, plugin upgrades, configuration options or permission changes. The production change is five net lines; most displayed churn is indentation around the existing flow.

## User Impact

Cross-agent follow-up bookkeeping can acquire the correct target runtime instead of failing because it inherited the sender's generation. The original sender's context remains intact while it is still running.

## Evidence

Based on upstream `865f1bbdbf44b467a461e984faa45d888573b900`.

- Before the production patch: all four new regression cases fail with the superseded-generation error.
- After the patch: all four pass, covering open/released sender leases with/without reload, current target configuration/generation, restoration of the sender's ambient generation and borrowed snapshot, independent gateway-root cleanup, and rejection of explicit stale admission.
- Focused regression and sibling tests: **66 passed** across four files using:

```sh
node scripts/run-vitest.mjs src/agents/tools/sessions-send-tool.a2a-generation.test.ts src/agents/tools/sessions-send-tool.a2a.test.ts src/agents/tools/agent-step.test.ts src/agents/prepared-model-runtime.owner-selection.test.ts
```

The regression runs the production A2A flow, direct agent-step route and prepared-runtime lease guard. Provider/auth preparation and inference are fixtures. It does not prove successful real-provider inference or external delivery. This is a draft pending end-to-end gateway verification; the operator's installed OpenClaw has not been patched.

Full `corepack pnpm build` passed (3m 4.3s). Fresh repository `autoreview --mode uncommitted --max-priority P2` passed with no accepted/actionable P0–P2 findings. `pnpm check:changed --staged` passed, including source/test type checks, lint, unused-export checks and repository guards. The task-local package-store override was needed because the shared cache is read-only; no repository dependency or configuration files were changed.
