### PR TITLE
refactor(replies): defer unused code-region scans

### DIFF
--- a/src/utils/directive-tags.ts
+++ b/src/utils/directive-tags.ts
@@ -1,6 +1,5 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { truncateCodePoints } from "@openclaw/normalization-core/code-points";
-// Directive tag helpers parse inline directive tags from user text.
 import { normalizeOptionalString } from "@openclaw/normalization-core/string-coerce";
 import { findCodeRegions, isInsideCode } from "../shared/text/code-regions.js";
 
@@ -58,8 +57,9 @@ export function replaceOutsideCodeRegions(
   regex: RegExp,
   replacement: (match: string, captures: unknown[], offset: number, source: string) => string,
 ): string {
-  const codeRegions = text.includes("[[") ? findCodeRegions(text) : [];
+  let codeRegions: ReturnType<typeof findCodeRegions> | undefined;
   return text.replace(regex, (...args: unknown[]) => {
+    codeRegions ??= text.includes("[[") ? findCodeRegions(text) : [];
     const match = String(args[0]);
     const offset = args.at(-2);
     return typeof offset === "number" && isInsideCode(offset + match.indexOf("[["), codeRegions)
@@ -137,7 +137,7 @@ export function stripInlineDirectiveTagsForDelivery(text: string): StripInlineDi
   }
   // Only malformed prefixes at the absolute message start are control text; keep
   // the regex non-multiline while code-region scanning preserves literal examples.
-  const codeRegions = findCodeRegions(text);
+  let codeRegions: ReturnType<typeof findCodeRegions> | undefined;
   const parts: string[] = [];
   let cursor = 0;
   let searchFrom = 0;
@@ -160,7 +160,7 @@ export function stripInlineDirectiveTagsForDelivery(text: string): StripInlineDi
       continue;
     }
     previousMatchEnd = searchFrom;
-    if (isInsideCode(marker, codeRegions)) {
+    if (isInsideCode(marker, (codeRegions ??= findCodeRegions(text)))) {
       continue;
     }
     parts.push(text.slice(cursor, start), match[0].includes("]]") ? " " : "");


### PR DESCRIPTION
Closes #142219

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

This maintainer-authored and requested optimization addresses avoidable parser work. Reply text containing code and ordinary wiki-style brackets can repeatedly invoke the canonical Markdown code-region scanner even when no directive regex matches. That work is unnecessary for the replacement and delivery checks that have nothing to process.

## Why This Change Was Made

Discover code regions lazily within each parser call, after a replacement or delivery regex actually matches, and reuse the result for later matches in that call. The canonical scanner, directive regexes, replacement callbacks, offsets, whitespace normalization and malformed-prefix rules remain unchanged. Code examples retain the existing literal protection, including the Markdown-container repair from #141767.

## User Impact

Lower parsing work for code-heavy text containing bracket markers that are not directives. The change is +4/-4 lines in one production file with no test, configuration, dependency or public API changes.

In the paired actual `parseReplyDirectives` source probe, the roughly 4 KiB code/wiki fixture without directives measured 7.528 to 0.037 ms per parse. Sampled transient JavaScript allocation across 20 parses changed from 527,931,272 to 2,477,088 bytes. These are fixture-specific parser observations, including collected allocations and profiler overhead, not retained heap, Gateway RSS or overall response-time measurements.

## Evidence

- 535 existing tests passed across five files and three projects; the complete selected changed-file gate and final independent P2 review passed.
- Eight paired fixtures preserve complete output and callback values through the actual reply parser, including marker-free prose/code, wiki brackets, active directives, literal code tags and malformed prefixes. Source, fixture, harness, caller and dependency identities are pinned; only the intended owner source changed.
- Marker-free timing controls are essentially unchanged. Literal-tag timing was slower in this pair (0.333 to 0.381 ms), so no general speedup is claimed.
- Initial harness preparation failures and the exploratory run remain separate from the accepted baseline/after comparison. No product assertion was relaxed. No credentials, provider or Gateway were used.

Related #135208 optimizes reply-ID sanitization and remains distinct. Active #137329 changes TTS callback behavior, and #80396 adds fenced-media result fields in caller code; preserve those changes and recheck the affected caller proof if either lands first. Release-note context: avoid unnecessary code-region scans while preserving directive parsing and code-literal behavior.
