### PR TITLE
fix: wiki_apply fails with an unhandled error when a synthesis has no sourceId

### DIFF
--- a/extensions/memory-wiki/src/apply.test.ts
+++ b/extensions/memory-wiki/src/apply.test.ts
@@ -64,6 +64,30 @@ describe("applyMemoryWikiMutation", () => {
     ).toThrow("confidence must be a finite number");
   });
 
+  it("reports missing create_synthesis sourceIds as a validation result", () => {
+    const rejection = {
+      op: "invalid_input",
+      message: "wiki mutation requires at least one sourceId for create_synthesis.",
+    };
+
+    expect(
+      normalizeMemoryWikiMutationInput({
+        op: "create_synthesis",
+        title: "Alpha Synthesis",
+        body: "Alpha summary body.",
+      }),
+    ).toEqual(rejection);
+
+    expect(
+      normalizeMemoryWikiMutationInput({
+        op: "synthesis",
+        title: "Alpha Synthesis",
+        body: "Alpha summary body.",
+        sourceIds: [],
+      }),
+    ).toEqual(rejection);
+  });
+
   it("creates synthesis pages with managed summary blocks and refreshed indexes", async () => {
     const { rootDir, config } = await createVault({ prefix: "memory-wiki-apply-" });
 

--- a/extensions/memory-wiki/src/apply.ts
+++ b/extensions/memory-wiki/src/apply.ts
@@ -60,6 +60,18 @@ type UpdateMetadataMemoryWikiMutation = {
 
 type ApplyMemoryWikiMutation = CreateSynthesisMemoryWikiMutation | UpdateMetadataMemoryWikiMutation;
 
+/**
+ * Rejected mutation input. Missing provenance is an ordinary caller mistake, so
+ * it is reported as a result the caller can render as a validation failure
+ * instead of an exception that escapes the tool call.
+ */
+type InvalidMemoryWikiMutationInput = {
+  op: "invalid_input";
+  message: string;
+};
+
+export type MemoryWikiMutationInput = ApplyMemoryWikiMutation | InvalidMemoryWikiMutationInput;
+
 type ApplyMemoryWikiMutationResult = {
   changed: boolean;
   operation: ApplyMemoryWikiMutation["op"];
@@ -116,7 +128,7 @@ function normalizeMemoryWikiMutationOp(op: unknown): ApplyMemoryWikiMutation["op
   );
 }
 
-export function normalizeMemoryWikiMutationInput(rawParams: unknown): ApplyMemoryWikiMutation {
+export function normalizeMemoryWikiMutationInput(rawParams: unknown): MemoryWikiMutationInput {
   const params = asNonArrayRecord(rawParams) as {
     op: unknown;
     title?: string;
@@ -138,7 +150,10 @@ export function normalizeMemoryWikiMutationInput(rawParams: unknown): ApplyMemor
       throw new Error("wiki mutation requires body for create_synthesis.");
     }
     if (!params.sourceIds || params.sourceIds.length === 0) {
-      throw new Error("wiki mutation requires at least one sourceId for create_synthesis.");
+      return {
+        op: "invalid_input",
+        message: "wiki mutation requires at least one sourceId for create_synthesis.",
+      };
     }
     const confidence = normalizeMutationConfidence(params as Record<string, unknown>, {
       allowNull: false,

--- a/extensions/memory-wiki/src/gateway.test.ts
+++ b/extensions/memory-wiki/src/gateway.test.ts
@@ -941,6 +941,31 @@ describe("memory-wiki gateway methods", () => {
     expect(readRespondError(respond)).toEqual({ code: "internal_error", message });
   });
 
+  it("rejects wiki.apply without sourceIds before source sync or mutation", async () => {
+    const { config } = await createVault({ prefix: "memory-wiki-gateway-" });
+    const { api, registerGatewayMethod } = createPluginApi();
+    const message = "wiki mutation requires at least one sourceId for create_synthesis.";
+    vi.mocked(normalizeMemoryWikiMutationInput).mockReturnValueOnce({
+      op: "invalid_input",
+      message,
+    });
+
+    registerMemoryWikiGatewayMethods({ api, config });
+    const handler = findGatewayHandler(registerGatewayMethod, "wiki.apply");
+    if (!handler) {
+      throw new Error("wiki.apply handler missing");
+    }
+    const respond = vi.fn();
+    const params = { op: "create_synthesis", title: "Gateway Alpha", body: "Gateway summary." };
+
+    await handler({ params, respond });
+
+    expect(normalizeMemoryWikiMutationInput).toHaveBeenCalledWith(params);
+    expect(syncMemoryWikiImportedSources).not.toHaveBeenCalled();
+    expect(applyMemoryWikiMutation).not.toHaveBeenCalled();
+    expect(readRespondError(respond)).toEqual({ code: "internal_error", message });
+  });
+
   it("applies wiki mutations over the gateway", async () => {
     const { config } = await createVault({ prefix: "memory-wiki-gateway-" });
     const { api, registerGatewayMethod } = createPluginApi();

--- a/extensions/memory-wiki/src/gateway.ts
+++ b/extensions/memory-wiki/src/gateway.ts
@@ -398,6 +398,10 @@ export function registerMemoryWikiGatewayMethods(params: {
         const { appConfig, config, signal } = resolveRequestContext(requestParams);
         // Source sync can write imported pages and indexes, so validate first.
         const mutation = normalizeMemoryWikiMutationInput(requestParams);
+        if (mutation.op === "invalid_input") {
+          respondError(respond, new Error(mutation.message));
+          return;
+        }
         await syncMemoryWikiImportedSources({ config, appConfig, ...(signal ? { signal } : {}) });
         respond(
           true,

--- a/extensions/memory-wiki/src/tool.test.ts
+++ b/extensions/memory-wiki/src/tool.test.ts
@@ -15,6 +15,18 @@ function asSchemaObject(value: unknown): Record<string, unknown> {
   return value as Record<string, unknown>;
 }
 
+async function readVaultSnapshot(rootDir: string): Promise<Array<[string, string]>> {
+  const entries = await fs.readdir(rootDir, { recursive: true, withFileTypes: true });
+  const files = entries.filter((entry) => entry.isFile());
+  const snapshot = await Promise.all(
+    files.map(async (entry): Promise<[string, string]> => {
+      const absolute = path.join(entry.parentPath, entry.name);
+      return [path.relative(rootDir, absolute), await fs.readFile(absolute, "utf8")];
+    }),
+  );
+  return snapshot.toSorted(([left], [right]) => left.localeCompare(right));
+}
+
 function unionLiteralValues(schema: Record<string, unknown>): string[] {
   const variants = schema.anyOf ?? schema.oneOf;
   if (!Array.isArray(variants)) {
@@ -149,6 +161,23 @@ describe("memory-wiki tools", () => {
       await expect(fs.readFile(pagePath, "utf8")).resolves.toBe(original);
     },
   );
+
+  it("fails wiki_apply for missing sourceIds without mutating the vault", async () => {
+    const { rootDir, config } = await harness.createVault({ initialize: true });
+    const before = await readVaultSnapshot(rootDir);
+    const tool = createWikiApplyTool(config);
+    const message = "wiki mutation requires at least one sourceId for create_synthesis.";
+
+    const result = await tool.execute("missing-source-ids", {
+      op: "create_synthesis",
+      title: "Alpha Synthesis",
+      body: "Alpha summary body.",
+    });
+
+    expect(result.content).toEqual([{ type: "text", text: message }]);
+    expect(result.details).toEqual({ changed: false, error: message });
+    expect(await readVaultSnapshot(rootDir)).toEqual(before);
+  });
 
   it("returns tool-safe relative report paths from wiki_lint", async () => {
     const { rootDir, config } = await harness.createVault({ initialize: true });

--- a/extensions/memory-wiki/src/tool.ts
+++ b/extensions/memory-wiki/src/tool.ts
@@ -237,6 +237,10 @@ export function createWikiApplyTool(
     parameters: WikiApplySchema,
     execute: async (_toolCallId, rawParams) => {
       const mutation = normalizeMemoryWikiMutationInput(rawParams);
+      if (mutation.op === "invalid_input") {
+        // Report the rejection before source sync or any vault write.
+        return textResult(mutation.message, { changed: false, error: mutation.message });
+      }
       await syncImportedSourcesIfNeeded(config, appConfig, signal);
       const result = await applyMemoryWikiMutation({
         config,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where an agent or Gateway client calling `wiki_apply` with `op: create_synthesis` and no `sourceIds` got an unhandled tool error instead of the validation message. The requirement itself is correct — a synthesis needs provenance — but the rejection escaped `wiki_apply` as a thrown exception, so the caller saw a failed tool call rather than the sentence explaining what to fix, and a runtime that treats a thrown tool as a fault rather than a rejected argument had to recover from an exception for an ordinary bad-argument case.

## Why This Change Was Made

`normalizeMemoryWikiMutationInput` now returns an `invalid_input` variant for this one case instead of throwing. `wiki_apply` renders it as an ordinary failed result carrying the same sentence, returning before source sync and before any vault write — the same shape `wiki_get` already uses for an empty `lookup`. The Gateway `wiki.apply` method keeps its existing behaviour and still responds `internal_error` with the identical message.

Non-goals: the message text is unchanged, the input is still rejected, and no mutation happens. The other validation throws in this module are untouched — they are listed below as possible follow-ups rather than folded into this change.

## User Impact

A `create_synthesis` call with missing provenance now comes back as a normal `wiki_apply` failure that says `wiki mutation requires at least one sourceId for create_synthesis.`, with `details.changed === false` and `details.error` set, so an agent can correct the arguments and retry instead of handling a thrown tool call. Gateway clients see no change.

## Evidence

Three tests were added; each one fails on `main` and passes with the change (verified by reverting the three source files in the same working tree and re-running):

- `extensions/memory-wiki/src/apply.test.ts` — the normalizer returns `{ op: "invalid_input", message }` for both a missing `sourceIds` and an empty array, and does not throw.
- `extensions/memory-wiki/src/tool.test.ts` — `wiki_apply` returns the exact message as its text content with `details` `{ changed: false, error: message }`, and a full recursive snapshot of the vault (paths and file contents) is byte-identical before and after the call, so nothing is written.
- `extensions/memory-wiki/src/gateway.test.ts` — `wiki.apply` still responds `{ code: "internal_error", message }` and calls neither `syncMemoryWikiImportedSources` nor `applyMemoryWikiMutation`.

Local runs:

- `vitest run extensions/memory-wiki` — 43 files, 515 tests passed.
- Same three files with the fix reverted — 3 failed, 65 passed, exactly the new tests.
- `oxfmt --check` on the six changed files — clean.
- `oxlint --config .oxlintrc.json` on the six changed files — 0 warnings, 0 errors.
- `tsgo -p` over the changed files and their graph — 0 diagnostics in `extensions/memory-wiki`. The only two diagnostics were `TS7016 qrcode` in `src/media/qr-runtime.ts`, an artifact of the reviewer's local dependency layout rather than this change. The repo's `run-oxlint.mjs` and `run-tsgo.mjs` wrappers could not run end to end in that layout because the extension package-boundary step rejects a shared dependency install; CI runs both properly.

## Similar throws in this module

Listed for reviewers, deliberately not changed here. Line numbers are on this branch.

- `extensions/memory-wiki/src/apply.ts:111` — `claims[i].confidence must be a number between 0 and 1`
- `extensions/memory-wiki/src/apply.ts:126` — `wiki mutation op must be one of ...`
- `extensions/memory-wiki/src/apply.ts:147` — `wiki mutation requires title for create_synthesis.`
- `extensions/memory-wiki/src/apply.ts:150` — `wiki mutation requires body for create_synthesis.`
- `extensions/memory-wiki/src/apply.ts:174` — `wiki mutation requires lookup for update_metadata.`
- `extensions/memory-wiki/src/apply.ts:374` — `Wiki page not found: <lookup>`
- `extensions/memory-wiki/src/gateway.ts:61` and `:78` — required and enum parameter readers shared by every wiki Gateway method
- `extensions/memory-wiki/src/cli.ts:327` and `:616` — the CLI-side equivalents of the body and source-id requirements

If maintainers want the whole family converted to results, that is a larger and more opinionated change: `apply.ts:374` is a runtime miss rather than an argument problem, and the Gateway readers are shared, so each one deserves its own decision.

## Scope and deployment

Six files under `extensions/memory-wiki/src`, three source and three test. No workflow, CI, CODEOWNERS, security or governance file is touched, and nothing here changes release or deployment behaviour. The work was done in a throwaway checkout branched from `openclaw/openclaw@1b011fe705`; the branch lives on the fork `Atlas-crete/openclaw`, which is the only place this account can push, and this PR is the path into `main`. The change has not been shipped to or loaded by any running instance.

## Rollback

Revert the single commit. The change is confined to `extensions/memory-wiki`, adds no configuration, no migration and no persisted state, and does not alter the message, the rejection, or the Gateway response.
