### PR TITLE
improve(gateway): reduce temporary work for large agent rosters

### DIFF
--- a/src/gateway/agent-list.ts
+++ b/src/gateway/agent-list.ts
@@ -80,8 +80,7 @@ export function listGatewayAgentsBasic(cfg: OpenClawConfig): GatewayAgentSelecti
   const defaultId = selection.defaultId;
   const mainKey = normalizeMainKey(cfg.session?.mainKey);
   const scope = cfg.session?.scope ?? "per-sender";
-  const configuredById = new Map<string, { name?: string }>();
-  const explicitIds = new Set<string>();
+  const configuredById = new Map<string, string | undefined>();
   const diskIds = new Set<string>();
   const agentIds = new Set<string>();
   agentIds.add(normalizeAgentId(defaultId));
@@ -93,8 +92,7 @@ export function listGatewayAgentsBasic(cfg: OpenClawConfig): GatewayAgentSelecti
     const id = normalizeAgentId(entry.id);
     const configuredName = normalizeOptionalString(entry.name);
     const identityName = normalizeOptionalString(entry.identity?.name);
-    configuredById.set(id, { name: configuredName ?? identityName });
-    explicitIds.add(id);
+    configuredById.set(id, configuredName ?? identityName);
     agentIds.add(id);
   }
 
@@ -103,7 +101,7 @@ export function listGatewayAgentsBasic(cfg: OpenClawConfig): GatewayAgentSelecti
     agentIds.add(id);
   }
 
-  const allowedIds = explicitIds.size > 0 ? new Set(explicitIds) : null;
+  const allowedIds = configuredById.size > 0 ? configuredById : null;
   const visibleIds = [...agentIds].filter(
     (id) =>
       !allowedIds ||
@@ -123,8 +121,10 @@ export function listGatewayAgentsBasic(cfg: OpenClawConfig): GatewayAgentSelecti
   const agents: GatewayAgentListRow[] = orderedIds.map((id) => ({
     id,
     kind:
-      !explicitIds.has(id) && diskIds.has(id) ? (ownerEntries.get(id)?.kind ?? "agent") : "agent",
-    name: configuredById.get(id)?.name,
+      !configuredById.has(id) && diskIds.has(id)
+        ? (ownerEntries.get(id)?.kind ?? "agent")
+        : "agent",
+    name: configuredById.get(id),
   }));
   return { ...selection, mainKey, scope, agents };
 }


### PR DESCRIPTION
## What Problem This Solves

Gateway and status roster projection duplicate configured-agent membership into two temporary Sets and wrap every prepared name in another object. That work grows with agent fleets whenever the roster is rebuilt.

## Why This Change Was Made

Use the existing configured-name Map for membership and store its scalar names directly. This removes two Set constructions and one wrapper object per configured entry without adding a cache or another lookup path. Production LOC is neutral after formatting (7 added, 7 removed); tests are unchanged.

Membership uses Map.has, preserving configured entries whose names are undefined. Duplicate normalized IDs still use the last configured name. Default-first ordering, configured versus disk-only system kinds, visibility, main-key handling, and own undefined name properties are unchanged. No authorization, configuration, protocol, persistence, or public API changes.

## User Impact

Large-fleet roster projection does less temporary collection work. Visible roster content and selection behavior stay the same. Small rosters did not show a consistent latency benefit, and this is not a measured full-Gateway startup or RPC improvement.

## Evidence

The same 17 tests in three whole files passed on baseline and candidate, including actual status consumers and the 200-agent heartbeat roster. All 28 normal changed checks passed. Independent Codex review through P2 found no actionable issues.

A fixed B0/C0/C1/B1 workload invoked the actual listGatewayAgentsBasic function 468 times with isolated synthetic disk state. Each return passed a full literal deep-equality check before serialization. An independent data audit verified all retained initial and edge outputs, own-undefined metadata, 232 paired samples, resource readings, source hashes, and closure. No numeric calls were rerun; earlier disk-admission refusals made zero product calls.

Warm medians, in microseconds per complete function call:

| Configured agents | Forward baseline → candidate | Reverse baseline → candidate |
| --- | --- | --- |
| 1 | 25.083 → 26.292 (+4.82%) | 24.396 → 24.792 (+1.62%) |
| 32 | 48.251 → 47.688 (−1.17%) | 49.167 → 49.750 (+1.19%) |
| 200 | 138.021 → 132.230 (−4.20%) | 139.105 → 134.959 (−2.98%) |
| 1,024, legacy list stress case | 327.042 → 303.271 (−7.27%) | 338.021 → 306.584 (−9.30%) |

All first, warmup, and warm samples remain included in the evidence. Of 232 indexed comparisons, 78 wall-time and 88 CPU comparisons increased. The 32-agent warm maximum increased 61.23%/32.99%; the reverse single-agent maximum increased 24.01%. Ending heap usage was higher by about 11.8/11.6 MB; these were unforced-GC readings, not a retained-memory or allocation measurement. Sampled process-tree RSS increased in the forward order. Whole-child elapsed time was 400.343→328.940 ms forward and 330.325→331.002 ms reverse, including imports, instrumentation, assertions, and serialization. No global speedup, memory improvement, statistical significance, or tail guarantee is claimed.

Local proof used Node 26.8.1 on macOS at base 77c45a9be74. The source and relevant roster consumers were checked against newer main c21fa540: no direct overlap. Newer dependency-ownership tooling is separate; the historical local proof is not relabeled as a current-main install. Fresh PR CI supplies integration evidence for the submitted head.
