### PR TITLE
fix: diagnose and repair stray macOS Gateway restart jobs

### DIFF
--- a/.agents/skills/openclaw-live-updater/SKILL.md
+++ b/.agents/skills/openclaw-live-updater/SKILL.md
@@ -14,6 +14,7 @@ Keep one operator-selected canonical live checkout as a read-only-to-the-agent d
 - Escalate only irreversible or materially risky security, privacy, auth, destructive migration/data-loss, protocol-version, credential-rotation, dependency patch/override, or product choices.
 - Diagnose ordinary update, runtime, app, CI, test, and release-validation failures; fix them through a focused PR; prove exact head; land with `scripts/pr`.
 - Never edit, stash, reset, clean, or create a branch in the live mirror.
+- Never use `launchctl submit` or create an ad-hoc KeepAlive job to run updates or Gateway lifecycle commands. A submitted job can relaunch `openclaw gateway restart` after every exit and cause a persistent restart storm, even without a plist ([#114967](https://github.com/openclaw/openclaw/issues/114967)).
 
 ## Fast Update And Maintenance
 
@@ -37,6 +38,8 @@ Keep one operator-selected canonical live checkout as a read-only-to-the-agent d
    - After every managed restart, query Gateway logs through RPC, restrict the audit to entries emitted since that restart began, report warning summaries, and fail the pass on any error/fatal entry. If RPC verification or log retrieval fails, still inspect the local structured log for that restart window. Never accept supervisor or RPC health without this restart-window log audit.
 
    Treat supervisor state alone as insufficient. If build or proof fails, leave the new mirror head intact and retry the stale/missing build on the next heartbeat; never run the old `dist` against new source.
+
+   Keep the deterministic helper as the only update/restart owner: acquire its maintenance suspension fence, complete the update and exact-SHA build, restart the managed LaunchAgent through that helper, and verify with status and health. Leave only the managed Gateway LaunchAgent responsible for its lifecycle. `gateway status` and `doctor` report foreign `ai.openclaw.*` jobs; report any such job instead of creating another update job or manually removing a job whose ownership is uncertain. `doctor --fix` can remove confirmed stray lifecycle jobs when separately authorized; it is not a substitute for the suspension fence.
 
    Re-run the canonical freshness check immediately before every `pnpm openclaw` restart or probe so the source runner cannot hide stale output with an implicit auto-build. Every pass, including a no-update/current-build pass, must run deep RPC status and verbose health. If that first probe fails while the build is already exact-current, perform one managed Gateway restart and repeat both probes once. Do not rebuild a current exact-SHA artifact merely to self-heal the managed process; fail and diagnose if the one restart does not recover it.
 

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -128,10 +128,13 @@ openclaw gateway status
 openclaw health
 ```
 
-Doctor only removes foreign OpenClaw-namespace jobs with a confirmed Gateway
-lifecycle invocation. Detection can inspect directly executed, user-owned
-scripts with supported shell shebangs. Lifecycle commands that depend on
-unresolved shell expansions remain report-only.
+Doctor removes a foreign job only when its literal, straight-line script or
+direct arguments invoke an absolute OpenClaw path with a Gateway lifecycle
+subcommand. Shell jobs must also have no launchd environment entries that alter
+shell execution. Everything outside this contract is reported and left unchanged.
+This is command-metadata verification; it does not probe binary executability,
+interpreter availability, or quarantine state.
+
 Doctor preserves managed LaunchAgents, unrelated labels,
 and jobs whose purpose cannot be established, and names every removal even
 in noninteractive runs. Service repair remains disabled for an isolated install

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -97,6 +97,46 @@ openclaw gateway restart
 Launchd provides auto-start at login, crash restarts, and one predictable log
 location without tying the Gateway lifetime to the app process.
 
+### Unexpected repeated restarts
+
+Run these commands if the Gateway repeatedly restarts after an update:
+
+```bash
+openclaw gateway status
+openclaw doctor
+```
+
+On macOS, both commands report foreign loaded jobs in the `ai.openclaw.*`
+namespace, including jobs submitted without a plist. The report shows each
+label, program, KeepAlive flag, and detected `openclaw gateway restart`,
+`start`, or `stop` invocation. Status JSON includes these jobs under
+`service.foreignLaunchdJobs`. When recent external forced restarts appear in
+the lifecycle log, the report includes their count as a possible correlation.
+The count alone does not identify which job caused a restart.
+After three external forced restarts within ten minutes, the managed Gateway
+logs an actionable warning naming likely KeepAlive jobs when available. It
+does not suppress an operator's restart command.
+
+To remove confirmed stray Gateway lifecycle jobs and verify recovery:
+
+```bash
+openclaw doctor --fix
+openclaw gateway status
+openclaw health
+```
+
+Doctor only removes foreign OpenClaw-namespace jobs with a confirmed Gateway
+lifecycle invocation. It preserves managed LaunchAgents, unrelated labels,
+and jobs whose purpose cannot be established, and names every removal even
+in noninteractive runs. Service repair remains disabled for an isolated install
+identity, external supervision, or an update in progress.
+
+Never use `launchctl submit` or an ad-hoc KeepAlive job for updates or Gateway
+lifecycle commands. Such a job can repeatedly run `openclaw gateway restart`
+whenever its script exits, as described in
+[#114967](https://github.com/openclaw/openclaw/issues/114967). Use the managed
+update workflow and its suspension fence, then verify status and health.
+
 ### Attach-only development
 
 When another process already owns the local Gateway, run the development app

--- a/docs/platforms/mac/bundled-gateway.md
+++ b/docs/platforms/mac/bundled-gateway.md
@@ -109,10 +109,13 @@ openclaw doctor
 On macOS, both commands report foreign loaded jobs in the `ai.openclaw.*`
 namespace, including jobs submitted without a plist. The report shows each
 label, program, KeepAlive flag, and detected `openclaw gateway restart`,
-`start`, or `stop` invocation. Status JSON includes these jobs under
-`service.foreignLaunchdJobs`. When recent external forced restarts appear in
-the lifecycle log, the report includes their count as a possible correlation.
-The count alone does not identify which job caused a restart.
+`start`, or `stop` invocation. Plain-text status shows the list as a warning when
+at least one job has KeepAlive or a verified lifecycle invocation. Otherwise,
+the list appears informationally under "Other OpenClaw launchd jobs (macOS)".
+Status JSON includes all these jobs under
+`service.foreignLaunchdJobs`. For warnings, recent external forced restarts in
+the lifecycle log provide a possible correlation; the count alone does not
+identify which job caused a restart.
 After three external forced restarts within ten minutes, the managed Gateway
 logs an actionable warning naming likely KeepAlive jobs when available. It
 does not suppress an operator's restart command.
@@ -126,7 +129,10 @@ openclaw health
 ```
 
 Doctor only removes foreign OpenClaw-namespace jobs with a confirmed Gateway
-lifecycle invocation. It preserves managed LaunchAgents, unrelated labels,
+lifecycle invocation. Detection can inspect directly executed, user-owned
+scripts with supported shell shebangs. Lifecycle commands that depend on
+unresolved shell expansions remain report-only.
+Doctor preserves managed LaunchAgents, unrelated labels,
 and jobs whose purpose cannot be established, and names every removal even
 in noninteractive runs. Service repair remains disabled for an isolated install
 identity, external supervision, or an update in progress.

--- a/src/cli/daemon-cli/status.gather.test.ts
+++ b/src/cli/daemon-cli/status.gather.test.ts
@@ -9,6 +9,7 @@ import { Command } from "commander";
 import { afterEach, assert, beforeEach, describe, expect, it, vi } from "vitest";
 import { WebSocketServer } from "ws";
 import { TEST_TLS_CERT_PEM, TEST_TLS_KEY_PEM } from "../../../test/helpers/tls-fixture.js";
+import type { ForeignLaunchdJob } from "../../daemon/launchd-foreign-jobs.js";
 import type { StaleOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import type { ServiceConfigAudit } from "../../daemon/service-audit.js";
 import { createMockGatewayService } from "../../daemon/service.test-helpers.js";
@@ -65,6 +66,9 @@ const findExtraGatewayServices = vi.fn(async (_env?: unknown, _opts?: unknown) =
 const findStaleOpenClawUpdateLaunchdJobs = vi.fn<
   (env?: NodeJS.ProcessEnv) => Promise<StaleOpenClawUpdateLaunchdJob[]>
 >(async () => []);
+const findForeignLaunchdJobs = vi.fn<(env?: NodeJS.ProcessEnv) => Promise<ForeignLaunchdJob[]>>(
+  async () => [],
+);
 type PortUsageTestSummary = {
   port: number;
   status: PortUsageStatus;
@@ -269,6 +273,15 @@ vi.mock("../../daemon/launchd.js", async (importOriginal) => ({
     findStaleOpenClawUpdateLaunchdJobs(env),
 }));
 
+vi.mock("../../daemon/launchd-foreign-jobs.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../daemon/launchd-foreign-jobs.js")>()),
+  findForeignLaunchdJobs: (env?: NodeJS.ProcessEnv) => findForeignLaunchdJobs(env),
+}));
+
+vi.mock("../../daemon/restart-storm.js", () => ({
+  readGatewayForcedRestartSummary: () => ({ count: 3, windowMs: 600_000 }),
+}));
+
 vi.mock("../../daemon/service-audit.js", () => ({
   auditGatewayServiceConfig: (opts: unknown) => auditGatewayServiceConfig(opts),
 }));
@@ -456,6 +469,7 @@ describe("gatherDaemonStatus", () => {
     createConfigIOCalls.mockClear();
     findStaleOpenClawUpdateLaunchdJobs.mockReset();
     findStaleOpenClawUpdateLaunchdJobs.mockResolvedValue([]);
+    findForeignLaunchdJobs.mockReset().mockResolvedValue([]);
     loadInstalledPluginIndexInstallRecords.mockClear();
     loadInstalledPluginIndexInstallRecords.mockResolvedValue({});
     fetchNpmPackageTargetStatus.mockClear();
@@ -1436,6 +1450,31 @@ describe("gatherDaemonStatus", () => {
       ]);
     },
   );
+
+  it("surfaces foreign launchd jobs and restart correlation without --deep", async () => {
+    const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    try {
+      const job: ForeignLaunchdJob = {
+        label: "ai.openclaw.test.w15.restart",
+        program: "/tmp/openclaw-test/restart.sh",
+        keepAlive: true,
+        gatewayActions: ["restart"],
+        safeToRemove: true,
+      };
+      findForeignLaunchdJobs.mockResolvedValue([job]);
+
+      const status = await gatherStatus({ probe: false });
+
+      expect(status.service.foreignLaunchdJobs).toEqual([job]);
+      expect(status.service.forcedRestartSummary).toEqual({ count: 3, windowMs: 600_000 });
+      expect(findForeignLaunchdJobs.mock.calls[0]?.[0]?.OPENCLAW_STATE_DIR).toBe(
+        "/tmp/openclaw-daemon",
+      );
+    } finally {
+      Object.defineProperty(process, "platform", platform);
+    }
+  });
 
   it("does not read restart handoffs during normal status", async () => {
     await gatherStatus({ probe: false });

--- a/src/cli/daemon-cli/status.gather.ts
+++ b/src/cli/daemon-cli/status.gather.ts
@@ -17,7 +17,6 @@ import { resolveSecretInputRef } from "../../config/types.secrets.js";
 import { readLastGatewayErrorLine } from "../../daemon/diagnostics.js";
 import { inspectGatewayHeapLimit, type GatewayHeapLimitReport } from "../../daemon/gateway-heap.js";
 import type { ExtraGatewayService, FindExtraGatewayServicesOptions } from "../../daemon/inspect.js";
-import type { StaleOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
 import type { ServiceConfigAudit } from "../../daemon/service-audit.js";
 import { summarizeGatewayServiceLayout } from "../../daemon/service-layout.js";
 import type { GatewayServiceRuntime } from "../../daemon/service-runtime.js";
@@ -64,6 +63,7 @@ import {
   type GatewayStatusSummary,
   type PortStatusSummary,
 } from "./status.gateway.js";
+import type { LaunchdJobDiagnostics } from "./status.launchd.js";
 import type { GatewayRpcOpts } from "./types.js";
 
 type ConfigSummary = {
@@ -100,7 +100,7 @@ type GatewayConnectFailureKind = ReturnType<typeof classifyGatewayConnectFailure
 const loadGatewayProbeAuthModule = createLazyPromise(() => import("../../gateway/probe-auth.js"));
 const loadConfigIoRuntime = createLazyPromise(() => import("../../config/io.runtime.js"));
 const loadDaemonInspectModule = createLazyPromise(() => import("../../daemon/inspect.js"));
-const loadLaunchdModule = createLazyPromise(() => import("../../daemon/launchd.js"));
+const loadLaunchdDiagnosticsModule = createLazyPromise(() => import("./status.launchd.js"));
 const loadServiceAuditModule = createLazyPromise(() => import("../../daemon/service-audit.js"));
 const loadGatewayTlsModule = createLazyPromise(() => import("../../infra/tls/gateway.js"));
 const loadDaemonProbeModule = createLazyPromise(() => import("./probe.js"));
@@ -205,7 +205,7 @@ async function readStatusConfig(params: {
 export type DaemonStatus = {
   cli?: CliStatusSummary;
   logFile?: string;
-  service: {
+  service: LaunchdJobDiagnostics & {
     label: string;
     loaded: boolean | null;
     loadState: GatewayServiceLoadState;
@@ -217,7 +217,6 @@ export type DaemonStatus = {
     configAudit?: ServiceConfigAudit;
     gatewayHeap?: GatewayHeapLimitReport;
     restartHandoff?: GatewayRestartHandoff;
-    staleUpdateLaunchdJobs?: StaleOpenClawUpdateLaunchdJob[];
   };
   config?: {
     cli: ConfigSummary;
@@ -459,14 +458,12 @@ export async function gatherDaemonStatus(
         )
         .catch(() => [])
     : [];
-  const staleUpdateLaunchdJobs =
-    opts.deep && process.platform === "darwin"
-      ? await loadLaunchdModule()
-          .then(({ findStaleOpenClawUpdateLaunchdJobs }) =>
-            findStaleOpenClawUpdateLaunchdJobs(serviceEnv),
-          )
-          .catch(() => [])
-      : [];
+  const launchdDiagnostics =
+    process.platform === "darwin"
+      ? await loadLaunchdDiagnosticsModule().then(({ gatherLaunchdJobDiagnostics }) =>
+          gatherLaunchdJobDiagnostics(serviceEnv, Boolean(opts.deep)),
+        )
+      : {};
 
   const tlsEnabled = daemonCfg.gateway?.tls?.enabled === true;
   const localCertificate =
@@ -682,7 +679,7 @@ export async function gatherDaemonStatus(
           }
         : {}),
       ...(restartHandoff ? { restartHandoff } : {}),
-      ...(staleUpdateLaunchdJobs.length > 0 ? { staleUpdateLaunchdJobs } : {}),
+      ...launchdDiagnostics,
     },
     config: {
       cli: cliConfigSummary,

--- a/src/cli/daemon-cli/status.launchd.ts
+++ b/src/cli/daemon-cli/status.launchd.ts
@@ -1,0 +1,43 @@
+/** Live launchd job diagnostics shared by shallow and deep Gateway status. */
+import {
+  findForeignLaunchdJobs,
+  type ForeignLaunchdJob,
+} from "../../daemon/launchd-foreign-jobs.js";
+import type { StaleOpenClawUpdateLaunchdJob } from "../../daemon/launchd.js";
+import {
+  readGatewayForcedRestartSummary,
+  type GatewayForcedRestartSummary,
+} from "../../daemon/restart-storm.js";
+import { formatErrorMessage } from "../../infra/errors.js";
+
+export type LaunchdJobDiagnostics = {
+  staleUpdateLaunchdJobs?: StaleOpenClawUpdateLaunchdJob[];
+  foreignLaunchdJobs?: ForeignLaunchdJob[];
+  foreignLaunchdInspectionError?: string;
+  forcedRestartSummary?: GatewayForcedRestartSummary;
+};
+
+export async function gatherLaunchdJobDiagnostics(
+  env: NodeJS.ProcessEnv,
+  deep: boolean,
+): Promise<LaunchdJobDiagnostics> {
+  const diagnostics: LaunchdJobDiagnostics = {};
+  const stale = deep
+    ? await import("../../daemon/launchd.js")
+        .then(({ findStaleOpenClawUpdateLaunchdJobs }) => findStaleOpenClawUpdateLaunchdJobs(env))
+        .catch(() => [])
+    : [];
+  if (stale.length) {
+    diagnostics.staleUpdateLaunchdJobs = stale;
+  }
+  try {
+    const jobs = await findForeignLaunchdJobs(env);
+    if (jobs.length) {
+      diagnostics.foreignLaunchdJobs = jobs;
+      diagnostics.forcedRestartSummary = readGatewayForcedRestartSummary(env);
+    }
+  } catch (error: unknown) {
+    diagnostics.foreignLaunchdInspectionError = formatErrorMessage(error);
+  }
+  return diagnostics;
+}

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -490,6 +490,48 @@ describe("printDaemonStatus", () => {
     expectMockLineContains(runtime.error, "wsl hint");
   });
 
+  it.each([false, true])("prints foreign launchd jobs and correlation with json=%s", (json) => {
+    const job = {
+      label: "ai.openclaw.test.w15.restart",
+      program: "/tmp/openclaw-test/restart.sh",
+      keepAlive: true,
+      gatewayActions: ["restart" as const],
+      safeToRemove: true,
+    };
+    const forcedRestartSummary = { count: 3, windowMs: 600_000 };
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loadState: { status: "loaded" },
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+          foreignLaunchdJobs: [job],
+          forcedRestartSummary,
+        },
+        extraServices: [],
+      },
+      { json },
+    );
+
+    if (json) {
+      expect(runtime.writeJson).toHaveBeenCalledWith(
+        expect.objectContaining({
+          service: expect.objectContaining({ foreignLaunchdJobs: [job], forcedRestartSummary }),
+        }),
+      );
+    } else {
+      expectMockLineContains(runtime.error, "Foreign launchd jobs detected");
+      expectMockLineContains(runtime.error, job.label);
+      expectMockLineContains(runtime.error, job.program);
+      expectMockLineContains(runtime.error, "keepalive=true");
+      expectMockLineContains(runtime.error, "Gateway lifecycle=restart");
+      expectMockLineContains(runtime.error, "3 external forced Gateway restart(s)");
+      expectMockLineContains(runtime.error, formatCliCommand("openclaw doctor --fix"));
+    }
+  });
+
   it("prints stale updater launchd job guidance", () => {
     printDaemonStatus(
       {

--- a/src/cli/daemon-cli/status.print.test.ts
+++ b/src/cli/daemon-cli/status.print.test.ts
@@ -532,6 +532,59 @@ describe("printDaemonStatus", () => {
     }
   });
 
+  it.each([
+    { name: "report-only", keepAlive: false, gatewayActions: [], warning: false },
+    { name: "keepalive", keepAlive: true, gatewayActions: [], warning: true },
+    {
+      name: "lifecycle",
+      keepAlive: false,
+      gatewayActions: ["restart" as const],
+      warning: true,
+    },
+  ])("uses the appropriate status severity for $name jobs", (testCase) => {
+    const job = {
+      label: "ai.openclaw.test.w15.other",
+      program: "/tmp/openclaw-test/other.sh",
+      keepAlive: testCase.keepAlive,
+      gatewayActions: testCase.gatewayActions,
+      safeToRemove: false,
+    };
+    printDaemonStatus(
+      {
+        service: {
+          label: "LaunchAgent",
+          loadState: { status: "loaded" },
+          loadedText: "loaded",
+          notLoadedText: "not loaded",
+          runtime: { status: "running", pid: 8000 },
+          foreignLaunchdJobs: [job],
+          forcedRestartSummary: { count: 3, windowMs: 600_000 },
+        },
+        extraServices: [],
+      },
+      { json: false },
+    );
+
+    const report = testCase.warning ? runtime.error : runtime.log;
+    const otherOutput = testCase.warning ? runtime.log : runtime.error;
+    expectMockLineContains(
+      report,
+      testCase.warning
+        ? "Foreign launchd jobs detected (macOS)."
+        : "Other OpenClaw launchd jobs (macOS)",
+    );
+    expectMockLineContains(report, job.label);
+    expectMockLineContains(report, job.program);
+    expectMockLineContains(report, "Report only; left unchanged.");
+    expect(otherOutput.mock.calls.map(([line]) => line).join("\n")).not.toContain(job.label);
+    if (!testCase.warning) {
+      expect(runtime.error).not.toHaveBeenCalled();
+      expect(runtime.log.mock.calls.map(([line]) => line).join("\n")).not.toContain(
+        "Listed lifecycle jobs may be responsible",
+      );
+    }
+  });
+
   it("prints stale updater launchd job guidance", () => {
     printDaemonStatus(
       {

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -1,3 +1,4 @@
+import { sanitizeTerminalText } from "../../../packages/terminal-core/src/safe-text.js";
 // Human and JSON rendering for gathered daemon status diagnostics.
 import { colorize } from "../../../packages/terminal-core/src/theme.js";
 import { formatConfigIssueLine } from "../../config/issue-format.js";
@@ -7,6 +8,7 @@ import {
 } from "../../daemon/constants.js";
 import { formatGatewayHeapLimitReport } from "../../daemon/gateway-heap.js";
 import { renderGatewayServiceCleanupHints } from "../../daemon/inspect.js";
+import { formatForeignLaunchdJobs } from "../../daemon/launchd-foreign-jobs.js";
 import {
   resolveGatewayRestartLogPath,
   resolveGatewaySupervisorLogPaths,
@@ -445,9 +447,41 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
     spacer();
   }
 
-  if (service.staleUpdateLaunchdJobs?.length) {
+  if (service.foreignLaunchdInspectionError) {
+    defaultRuntime.error(
+      warnText(
+        `Could not inspect foreign launchd jobs: ${sanitizeTerminalText(service.foreignLaunchdInspectionError)}`,
+      ),
+    );
+    spacer();
+  }
+  if (service.foreignLaunchdJobs?.length) {
+    defaultRuntime.error(warnText("Foreign launchd jobs detected (macOS)."));
+    defaultRuntime.error(warnText(formatForeignLaunchdJobs(service.foreignLaunchdJobs)));
+    const restarts = service.forcedRestartSummary;
+    if (restarts && restarts.count > 0) {
+      defaultRuntime.error(
+        warnText(
+          `${restarts.count} external forced Gateway restart(s) in the last ${Math.round(restarts.windowMs / 60_000)} minutes. Listed lifecycle jobs may be responsible; this is not proof of attribution.`,
+        ),
+      );
+    }
+    if (service.foreignLaunchdJobs.some((job) => job.safeToRemove)) {
+      defaultRuntime.error(
+        warnText(
+          `Remove confirmed stray Gateway lifecycle jobs with ${formatCliCommand("openclaw doctor --fix")}.`,
+        ),
+      );
+    }
+    spacer();
+  }
+
+  const staleUpdateLaunchdJobs = service.staleUpdateLaunchdJobs?.filter(
+    (job) => !service.foreignLaunchdJobs?.some((foreign) => foreign.label === job.label),
+  );
+  if (staleUpdateLaunchdJobs?.length) {
     defaultRuntime.error(errorText("Stale OpenClaw updater launchd job(s) detected."));
-    for (const job of service.staleUpdateLaunchdJobs) {
+    for (const job of staleUpdateLaunchdJobs) {
       const exitStatus =
         job.lastExitStatus !== undefined ? `, last exit ${job.lastExitStatus}` : "";
       const pid = job.pid !== undefined ? `, pid ${job.pid}` : "";

--- a/src/cli/daemon-cli/status.print.ts
+++ b/src/cli/daemon-cli/status.print.ts
@@ -456,17 +456,25 @@ export function printDaemonStatus(status: DaemonStatus, opts: { json: boolean; d
     spacer();
   }
   if (service.foreignLaunchdJobs?.length) {
-    defaultRuntime.error(warnText("Foreign launchd jobs detected (macOS)."));
-    defaultRuntime.error(warnText(formatForeignLaunchdJobs(service.foreignLaunchdJobs)));
+    const shouldWarn = service.foreignLaunchdJobs.some(
+      (job) => job.keepAlive || job.gatewayActions.length > 0,
+    );
+    if (shouldWarn) {
+      defaultRuntime.error(warnText("Foreign launchd jobs detected (macOS)."));
+      defaultRuntime.error(warnText(formatForeignLaunchdJobs(service.foreignLaunchdJobs)));
+    } else {
+      defaultRuntime.log(infoText("Other OpenClaw launchd jobs (macOS)"));
+      defaultRuntime.log(infoText(formatForeignLaunchdJobs(service.foreignLaunchdJobs)));
+    }
     const restarts = service.forcedRestartSummary;
-    if (restarts && restarts.count > 0) {
+    if (shouldWarn && restarts && restarts.count > 0) {
       defaultRuntime.error(
         warnText(
           `${restarts.count} external forced Gateway restart(s) in the last ${Math.round(restarts.windowMs / 60_000)} minutes. Listed lifecycle jobs may be responsible; this is not proof of attribution.`,
         ),
       );
     }
-    if (service.foreignLaunchdJobs.some((job) => job.safeToRemove)) {
+    if (shouldWarn && service.foreignLaunchdJobs.some((job) => job.safeToRemove)) {
       defaultRuntime.error(
         warnText(
           `Remove confirmed stray Gateway lifecycle jobs with ${formatCliCommand("openclaw doctor --fix")}.`,

--- a/src/cli/gateway-cli/run.option-collisions.test.ts
+++ b/src/cli/gateway-cli/run.option-collisions.test.ts
@@ -41,6 +41,9 @@ const forceFreePortAndWait = vi.fn(async (_port: number, _opts: unknown) => ({
 const cleanStaleGatewayProcessesSync = vi.fn(
   (_port?: number, _options?: { protectedPid?: number }) => [],
 );
+const warnAboutGatewayRestartStorm = vi.fn(
+  async (_env: NodeJS.ProcessEnv, _warn: (message: string) => void) => {},
+);
 const waitForPortBindable = vi.fn(async (_port: number, _opts?: unknown) => 0);
 const findVerifiedGatewayListenerPidsOnPortSync = vi.fn((_port: number) => [] as number[]);
 const formatGatewayPidList = vi.fn((pids: number[]) => pids.join(", "));
@@ -277,6 +280,11 @@ vi.mock("../../infra/restart-stale-pids.js", () => ({
     cleanStaleGatewayProcessesSync(port, options),
 }));
 
+vi.mock("../../daemon/restart-storm.js", () => ({
+  warnAboutGatewayRestartStorm: (env: NodeJS.ProcessEnv, warn: (message: string) => void) =>
+    warnAboutGatewayRestartStorm(env, warn),
+}));
+
 vi.mock("../../infra/gateway-processes.js", () => ({
   findVerifiedGatewayListenerPidsOnPortSync: (port: number) =>
     findVerifiedGatewayListenerPidsOnPortSync(port),
@@ -449,6 +457,7 @@ describe("gateway run option collisions", () => {
     parkCurrentLaunchAgentForMaintenance.mockReset();
     parkCurrentLaunchAgentForMaintenance.mockResolvedValue(false);
     cleanStaleGatewayProcessesSync.mockClear();
+    warnAboutGatewayRestartStorm.mockReset();
     waitForPortBindable.mockClear();
     ensureDevGatewayConfig.mockClear();
     runGatewayLoop.mockClear();
@@ -1180,6 +1189,28 @@ describe("gateway run option collisions", () => {
     );
     expect(normalizeStateDirEnv).toHaveBeenCalledWith(process.env);
   });
+
+  it.each([
+    { platform: "darwin", managed: true, warns: true },
+    { platform: "darwin", managed: false, warns: false },
+    { platform: "linux", managed: true, warns: false },
+  ] as const)(
+    "reports restart storms before server startup only for managed macOS Gateways ($platform, managed=$managed)",
+    async ({ platform, managed, warns }) => {
+      const warning = "Gateway restart storm: inspect launchd jobs with openclaw gateway status.";
+      warnAboutGatewayRestartStorm.mockImplementation(async (_env, warn) => warn(warning));
+      startGatewayServer.mockImplementationOnce(async () => {
+        expect(gatewayLogMessages.includes(warning)).toBe(warns);
+        return { close: vi.fn(async () => {}) };
+      });
+      await withMockedPlatform(platform, () =>
+        withEnvAsync({ OPENCLAW_SERVICE_MARKER: managed ? "openclaw" : undefined }, async () => {
+          await runGatewayCli(["gateway", "run", "--allow-unconfigured"]);
+        }),
+      );
+      expect(startGatewayServer).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("protects the inherited service pid before replacing it", async () => {
     await withEnvAsync(

--- a/src/cli/gateway-cli/run.ts
+++ b/src/cli/gateway-cli/run.ts
@@ -707,6 +707,10 @@ async function runGatewayCommandOnce(opts: GatewayRunOpts, hooks: GatewayRunRunt
   }
   if (process.env.OPENCLAW_SERVICE_MARKER?.trim()) {
     process.env[GATEWAY_SERVICE_RUNTIME_PID_ENV] = String(process.pid);
+    if (process.platform === "darwin") {
+      const { warnAboutGatewayRestartStorm } = await import("../../daemon/restart-storm.js");
+      await warnAboutGatewayRestartStorm(process.env, (message) => gatewayLog.warn(message));
+    }
   }
   await hooks.refreshManagedProxy?.(cfg.proxy);
   const portOverride = parsePort(opts.port);

--- a/src/commands/doctor-foreign-launchd-jobs.test.ts
+++ b/src/commands/doctor-foreign-launchd-jobs.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ForeignLaunchdJob } from "../daemon/launchd-foreign-jobs.js";
+import { runGatewayServicesHealth } from "../flows/doctor-health-contribution-runners.gateway.js";
+import { createDoctorHealthFlowContext } from "../flows/doctor-health-contributions.test-support.js";
 import { noteMacForeignLaunchdJobs } from "./doctor-foreign-launchd-jobs.js";
 import type { DoctorOptions } from "./doctor.types.js";
 
@@ -79,8 +81,15 @@ describe("Doctor foreign launchd jobs", () => {
     },
   );
 
-  it("names each confirmed removal in noninteractive --fix output and preserves report-only jobs", async () => {
-    await noteMacForeignLaunchdJobs({ repair: true, nonInteractive: true }, runtime, {});
+  it("names confirmed removals through the maintenance-owned --fix runner and preserves report-only jobs", async () => {
+    await runGatewayServicesHealth(
+      createDoctorHealthFlowContext({
+        options: { repair: true, nonInteractive: true },
+        gatewayMaintenanceActive: true,
+        runtime,
+        env: {},
+      }),
+    );
 
     expect(mocks.repair).toHaveBeenCalledExactlyOnceWith(lifecycleJob, {});
     expect(runtime.log).toHaveBeenCalledWith(

--- a/src/commands/doctor-foreign-launchd-jobs.test.ts
+++ b/src/commands/doctor-foreign-launchd-jobs.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ForeignLaunchdJob } from "../daemon/launchd-foreign-jobs.js";
+import { noteMacForeignLaunchdJobs } from "./doctor-foreign-launchd-jobs.js";
+import type { DoctorOptions } from "./doctor.types.js";
+
+const mocks = vi.hoisted(() => ({
+  find: vi.fn<() => Promise<ForeignLaunchdJob[]>>(),
+  repair: vi.fn<() => Promise<{ removed: boolean; detail: string }>>(),
+  note: vi.fn(),
+  defaultIdentity: vi.fn(() => true),
+  manageService: vi.fn(async () => true),
+}));
+
+vi.mock("../../packages/terminal-core/src/note.js", () => ({ note: mocks.note }));
+vi.mock("../config/paths.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../config/paths.js")>()),
+  isDefaultInstallIdentity: mocks.defaultIdentity,
+}));
+vi.mock("../daemon/launchd-foreign-jobs.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../daemon/launchd-foreign-jobs.js")>()),
+  findForeignLaunchdJobs: mocks.find,
+  repairForeignLaunchdJob: mocks.repair,
+}));
+vi.mock("../daemon/restart-storm.js", () => ({
+  readGatewayForcedRestartSummary: () => ({ count: 3, windowMs: 600_000 }),
+}));
+vi.mock("./doctor-service-repair-policy.js", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("./doctor-service-repair-policy.js")>()),
+  shouldManageGatewayService: mocks.manageService,
+}));
+
+const lifecycleJob: ForeignLaunchdJob = {
+  label: "ai.openclaw.test.w15.restart",
+  program: "/tmp/openclaw-test/restart.sh",
+  keepAlive: true,
+  gatewayActions: ["restart"],
+  safeToRemove: true,
+};
+const reportOnlyJob: ForeignLaunchdJob = {
+  label: "ai.openclaw.test.w15.observer",
+  program: "/usr/bin/true",
+  keepAlive: false,
+  gatewayActions: [],
+  safeToRemove: false,
+};
+
+describe("Doctor foreign launchd jobs", () => {
+  const platform = Object.getOwnPropertyDescriptor(process, "platform")!;
+  const runtime = { log: vi.fn(), error: vi.fn(), exit: vi.fn() };
+
+  beforeEach(() => {
+    Object.defineProperty(process, "platform", { configurable: true, value: "darwin" });
+    mocks.find.mockReset().mockResolvedValue([lifecycleJob, reportOnlyJob]);
+    mocks.repair.mockReset().mockResolvedValue({
+      removed: true,
+      detail: `Removed stray launchd job ${lifecycleJob.label}. Verified unloaded.`,
+    });
+    mocks.note.mockReset();
+    mocks.defaultIdentity.mockReset().mockReturnValue(true);
+    mocks.manageService.mockReset().mockResolvedValue(true);
+    runtime.log.mockReset();
+  });
+
+  afterEach(() => Object.defineProperty(process, "platform", platform));
+
+  it.each<DoctorOptions>([{}, { yes: true }, { nonInteractive: true }])(
+    "reports lifecycle details without removal when --fix is absent: %j",
+    async (options) => {
+      await noteMacForeignLaunchdJobs(options, runtime, {});
+
+      const report = mocks.note.mock.calls[0]?.[0];
+      expect(report).toContain(lifecycleJob.label);
+      expect(report).toContain(lifecycleJob.program);
+      expect(report).toContain("keepalive=true");
+      expect(report).toContain("Gateway lifecycle=restart");
+      expect(report).toContain(reportOnlyJob.label);
+      expect(report).toContain("3 external forced Gateway restart(s)");
+      expect(mocks.repair).not.toHaveBeenCalled();
+    },
+  );
+
+  it("names each confirmed removal in noninteractive --fix output and preserves report-only jobs", async () => {
+    await noteMacForeignLaunchdJobs({ repair: true, nonInteractive: true }, runtime, {});
+
+    expect(mocks.repair).toHaveBeenCalledExactlyOnceWith(lifecycleJob, {});
+    expect(runtime.log).toHaveBeenCalledWith(
+      `Removed stray launchd job ${lifecycleJob.label}. Verified unloaded.`,
+    );
+  });
+
+  it("reports a job rejected by fresh owner inspection as not removed", async () => {
+    mocks.repair.mockResolvedValue({ removed: false, detail: "Lifecycle command changed." });
+
+    await noteMacForeignLaunchdJobs({ repair: true, nonInteractive: true }, runtime, {});
+
+    expect(runtime.log).toHaveBeenCalledWith(
+      `Removal not confirmed for launchd job ${lifecycleJob.label}: Lifecycle command changed.`,
+    );
+  });
+
+  it("reports a repair failure per job and continues to the next candidate", async () => {
+    const secondJob = { ...lifecycleJob, label: "ai.openclaw.test.w15.second" };
+    mocks.find.mockResolvedValue([lifecycleJob, secondJob]);
+    mocks.repair.mockRejectedValueOnce(new Error("launchd job inspection failed"));
+    mocks.repair.mockResolvedValueOnce({
+      removed: true,
+      detail: `Removed stray launchd job ${secondJob.label}. Verified unloaded.`,
+    });
+
+    await noteMacForeignLaunchdJobs({ repair: true }, runtime, {});
+
+    expect(runtime.log).toHaveBeenCalledWith(
+      `Removal not confirmed for launchd job ${lifecycleJob.label}: launchd job inspection failed`,
+    );
+    expect(runtime.log).toHaveBeenCalledWith(
+      `Removed stray launchd job ${secondJob.label}. Verified unloaded.`,
+    );
+  });
+
+  it("reports unavailable inspection without removing jobs or aborting Doctor", async () => {
+    mocks.find.mockRejectedValue(new Error("launchd inspection unavailable"));
+
+    await noteMacForeignLaunchdJobs({ repair: true }, runtime, {});
+
+    expect(mocks.note).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Could not inspect foreign launchd jobs: launchd inspection unavailable",
+      ),
+      "Foreign launchd jobs (macOS)",
+    );
+    expect(mocks.repair).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { reason: "external service policy", env: { OPENCLAW_SERVICE_REPAIR_POLICY: "external" } },
+    { reason: "active update", env: { OPENCLAW_UPDATE_IN_PROGRESS: "1" } },
+    { reason: "nondefault identity", env: {}, defaultIdentity: false },
+    { reason: "external supervisor", env: {}, manageService: false },
+  ])("reports but does not repair with $reason", async (testCase) => {
+    mocks.defaultIdentity.mockReturnValue(testCase.defaultIdentity ?? true);
+    mocks.manageService.mockResolvedValue(testCase.manageService ?? true);
+
+    await noteMacForeignLaunchdJobs({ repair: true }, runtime, testCase.env);
+
+    expect(mocks.note).toHaveBeenCalled();
+    expect(mocks.repair).not.toHaveBeenCalled();
+    expect(runtime.log).toHaveBeenCalledWith(expect.stringContaining("No jobs were removed."));
+  });
+});

--- a/src/commands/doctor-foreign-launchd-jobs.ts
+++ b/src/commands/doctor-foreign-launchd-jobs.ts
@@ -1,0 +1,85 @@
+import { note } from "../../packages/terminal-core/src/note.js";
+import { sanitizeTerminalText } from "../../packages/terminal-core/src/safe-text.js";
+import { formatCliCommand } from "../cli/command-format.js";
+import { isDefaultInstallIdentity } from "../config/paths.js";
+import {
+  findForeignLaunchdJobs,
+  formatForeignLaunchdJobs,
+  repairForeignLaunchdJob,
+  type ForeignLaunchdJob,
+} from "../daemon/launchd-foreign-jobs.js";
+import { readGatewayForcedRestartSummary } from "../daemon/restart-storm.js";
+import { isTruthyEnvValue } from "../infra/env.js";
+import { formatErrorMessage } from "../infra/errors.js";
+import type { RuntimeEnv } from "../runtime.js";
+import type { DoctorOptions } from "./doctor-prompter.js";
+import {
+  resolveServiceRepairPolicy,
+  shouldManageGatewayService,
+} from "./doctor-service-repair-policy.js";
+
+/** Reports foreign launchd jobs; only explicit Doctor repair may remove lifecycle jobs. */
+export async function noteMacForeignLaunchdJobs(
+  options: DoctorOptions,
+  runtime: RuntimeEnv,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<void> {
+  if (process.platform !== "darwin") {
+    return;
+  }
+  let jobs: ForeignLaunchdJob[];
+  try {
+    jobs = await findForeignLaunchdJobs(env);
+  } catch (error) {
+    note(
+      `Could not inspect foreign launchd jobs: ${sanitizeTerminalText(formatErrorMessage(error))}. No jobs were removed.`,
+      "Foreign launchd jobs (macOS)",
+    );
+    return;
+  }
+  if (jobs.length === 0) {
+    return;
+  }
+  const lines = [formatForeignLaunchdJobs(jobs)];
+  const restarts = readGatewayForcedRestartSummary(env);
+  if (restarts.count > 0) {
+    lines.push(
+      `${restarts.count} external forced Gateway restart(s) in the last ${Math.round(restarts.windowMs / 60_000)} minutes. Listed lifecycle jobs may be responsible; this is not proof of attribution.`,
+    );
+  }
+  const candidates = jobs.filter((job) => job.safeToRemove);
+  if (candidates.length > 0) {
+    lines.push(
+      `Run ${formatCliCommand("openclaw doctor --fix", env)} to remove confirmed stray Gateway lifecycle jobs.`,
+    );
+  }
+  note(lines.join("\n"), "Foreign launchd jobs (macOS)");
+  if (options.repair !== true || candidates.length === 0) {
+    return;
+  }
+  if (
+    !isDefaultInstallIdentity(env) ||
+    resolveServiceRepairPolicy(env) === "external" ||
+    !(await shouldManageGatewayService(env)) ||
+    isTruthyEnvValue(env.OPENCLAW_UPDATE_IN_PROGRESS)
+  ) {
+    runtime.log(
+      "Foreign launchd job repair skipped: this Doctor invocation does not own service repair or an update is in progress. No jobs were removed.",
+    );
+    return;
+  }
+  for (const job of candidates) {
+    try {
+      const result = await repairForeignLaunchdJob(job, env);
+      runtime.log(
+        result.removed
+          ? result.detail
+          : `Removal not confirmed for launchd job ${job.label}: ${result.detail}`,
+      );
+    } catch (error) {
+      runtime.log(
+        `Removal not confirmed for launchd job ${job.label}: ${sanitizeTerminalText(formatErrorMessage(error))}`,
+      );
+    }
+  }
+}

--- a/src/commands/doctor.fast-path-mocks.ts
+++ b/src/commands/doctor.fast-path-mocks.ts
@@ -85,6 +85,10 @@ vi.mock("./doctor-gateway-daemon-flow.js", () => ({
   maybeRepairGatewayDaemon: vi.fn().mockResolvedValue(undefined),
 }));
 
+vi.mock("./doctor-foreign-launchd-jobs.js", () => ({
+  noteMacForeignLaunchdJobs: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("./doctor-gateway-health.js", () => ({
   checkGatewayHealth: vi.fn().mockResolvedValue({ healthOk: false }),
   probeGatewayMemoryStatus: vi

--- a/src/daemon/launchd-foreign-jobs.process.test.ts
+++ b/src/daemon/launchd-foreign-jobs.process.test.ts
@@ -103,9 +103,10 @@ it.skipIf(!hasGuiLaunchd).each(["interpreter", "direct"] as const)(
       const cli = path.join(dir, "openclaw");
       const script = path.join(dir, "validator.sh");
       await fs.writeFile(cli, "#!/bin/sh\nexec /bin/sleep 120\n", { mode: 0o700 });
+      expect(cli).toMatch(/^[A-Za-z0-9_./-]+$/);
       await fs.writeFile(
         script,
-        `#!/bin/bash\nopenclaw_bin="${cli}"\n"$openclaw_bin" gateway restart\nfor attempt in 1 2; do\n  "$openclaw_bin" gateway status\n  /bin/sleep 1\ndone\n`,
+        `#!/bin/bash\nopenclaw_bin=${cli}\n"$openclaw_bin" gateway restart\nfor attempt in 1 2; do\n  "$openclaw_bin" gateway status\n  /bin/sleep 1\ndone\n`,
         { mode: 0o700 },
       );
       for (const label of labels) {

--- a/src/daemon/launchd-foreign-jobs.process.test.ts
+++ b/src/daemon/launchd-foreign-jobs.process.test.ts
@@ -1,0 +1,151 @@
+// Native proof uses only task-owned scratch jobs and a harmless synthetic CLI.
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expect, it, vi } from "vitest";
+import { note } from "../../packages/terminal-core/src/note.js";
+import { noteMacForeignLaunchdJobs } from "../commands/doctor-foreign-launchd-jobs.js";
+import { execLaunchctl } from "./launchd-exec.js";
+import { findForeignLaunchdJobs } from "./launchd-foreign-jobs.js";
+
+vi.mock("./launchd-exec.js", async (original) => ({
+  ...(await original<typeof import("./launchd-exec.js")>()),
+  execLaunchctl: vi.fn(),
+}));
+vi.mock("../../packages/terminal-core/src/note.js", () => ({ note: vi.fn() }));
+// Isolate Doctor's account policy and lifecycle history from the operator's install.
+vi.mock("../config/paths.js", async (original) => ({
+  ...(await original<typeof import("../config/paths.js")>()),
+  isDefaultInstallIdentity: () => true,
+}));
+vi.mock("../commands/doctor-service-repair-policy.js", () => ({
+  resolveServiceRepairPolicy: () => "auto",
+  shouldManageGatewayService: async () => true,
+}));
+vi.mock("./restart-storm.js", () => ({
+  readGatewayForcedRestartSummary: () => ({ count: 0, windowMs: 600_000 }),
+}));
+
+const hasGuiLaunchd =
+  process.platform === "darwin" &&
+  spawnSync("/bin/launchctl", ["print", `gui/${process.getuid?.()}`], {
+    stdio: "ignore",
+    timeout: 5000,
+  }).status === 0;
+
+it.skipIf(!hasGuiLaunchd)(
+  "detects, reports and fixes only the scratch lifecycle job using native launchd",
+  async () => {
+    const prefix = `ai.openclaw.test.w15.${process.pid}.${randomUUID()}`;
+    const labels = [prefix, `${prefix}.managed`, `com.example.w15.${process.pid}.${randomUUID()}`];
+    const domain = `gui/${process.getuid?.()}`;
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-w15-native-"));
+    const created: string[] = [];
+    const mutations: string[] = [];
+    const native = (args: string[]) => {
+      const result = spawnSync("/bin/launchctl", args, { encoding: "utf8", timeout: 5000 });
+      if (result.error) {
+        throw result.error;
+      }
+      return {
+        code: result.status ?? 1,
+        stdout: result.stdout,
+        stderr: result.stderr,
+        termination: "exit" as const,
+      };
+    };
+    const env = { HOME: dir, OPENCLAW_LAUNCHD_LABEL: labels[1] };
+    const log = vi.fn();
+    const runtime = { log, error: vi.fn(), exit: vi.fn() };
+    vi.mocked(execLaunchctl).mockImplementation(async (args) => {
+      if (args[0] === "list") {
+        const result = native(args);
+        // Expose real native records for our jobs only. Never grant the Doctor
+        // experiment access to the operator's jobs, even if a regression broadens it.
+        return {
+          ...result,
+          stdout: result.stdout
+            .split("\n")
+            .filter((line) => labels.includes(line.trim().split(/\s+/).at(-1) ?? ""))
+            .join("\n"),
+        };
+      }
+      const label = args[1]?.slice(`${domain}/`.length);
+      if (!label || !labels.includes(label)) {
+        throw new Error("Native test refused an operation outside its scratch labels");
+      }
+      if (args[0] !== "print") {
+        if (label !== prefix || args[0] !== "bootout") {
+          throw new Error("Native test refused a mutation of a protected scratch job");
+        }
+        mutations.push(label);
+      }
+      return native(args);
+    });
+    const errors: unknown[] = [];
+    try {
+      const cli = path.join(dir, "openclaw");
+      const script = path.join(dir, "validator.sh");
+      await fs.writeFile(cli, "#!/bin/sh\nexec /bin/sleep 120\n", { mode: 0o700 });
+      await fs.writeFile(script, `#!/bin/sh\nexec "${cli}" gateway restart\n`);
+      for (const label of labels) {
+        created.push(label);
+        const result = native(["submit", "-l", label, "--", "/bin/sh", script]);
+        expect(result, "scratch launchctl submit must not require privileges").toMatchObject({
+          code: 0,
+        });
+      }
+      const found = await findForeignLaunchdJobs(env);
+      expect(found).toEqual([
+        expect.objectContaining({
+          label: prefix,
+          program: "/bin/sh",
+          keepAlive: true,
+          gatewayActions: ["restart"],
+          safeToRemove: true,
+        }),
+      ]);
+      await noteMacForeignLaunchdJobs({ nonInteractive: true }, runtime, env);
+      expect(vi.mocked(note).mock.calls.flat().join("\n")).toContain(prefix);
+      expect(mutations).toEqual([]);
+      await noteMacForeignLaunchdJobs({ repair: true, nonInteractive: true }, runtime, env);
+      expect(log.mock.calls.flat().join("\n")).toContain(`Removed stray launchd job ${prefix}`);
+      expect(mutations).toEqual([prefix]);
+      expect(native(["print", `${domain}/${prefix}`]).code).not.toBe(0);
+      for (const label of labels.slice(1)) {
+        expect(native(["print", `${domain}/${label}`]).code).toBe(0);
+      }
+      console.log(
+        "Native scratch proof: keepalive lifecycle job detected; Doctor report preserved it; --fix removed it; managed and unrelated scratch jobs remained loaded.",
+      );
+    } catch (error) {
+      errors.push(error);
+    }
+    let cleanupFailed = false;
+    for (const label of created) {
+      try {
+        native(["remove", label]);
+        expect(native(["print", `${domain}/${label}`]).code).not.toBe(0);
+      } catch (error) {
+        cleanupFailed = true;
+        errors.push(error);
+      }
+    }
+    if (!cleanupFailed) {
+      await fs
+        .rm(dir, { recursive: true, force: true })
+        .catch((error: unknown) => errors.push(error));
+    }
+    if (errors.length) {
+      throw new AggregateError(
+        errors,
+        cleanupFailed
+          ? `Scratch launchd cleanup failed; scripts retained at ${dir}`
+          : "Scratch launchd proof failed",
+      );
+    }
+  },
+  30_000,
+);

--- a/src/daemon/launchd-foreign-jobs.process.test.ts
+++ b/src/daemon/launchd-foreign-jobs.process.test.ts
@@ -7,6 +7,8 @@ import path from "node:path";
 import { expect, it, vi } from "vitest";
 import { note } from "../../packages/terminal-core/src/note.js";
 import { noteMacForeignLaunchdJobs } from "../commands/doctor-foreign-launchd-jobs.js";
+import { runGatewayServicesHealth } from "../flows/doctor-health-contribution-runners.gateway.js";
+import { createDoctorHealthFlowContext } from "../flows/doctor-health-contributions.test-support.js";
 import { execLaunchctl } from "./launchd-exec.js";
 import { findForeignLaunchdJobs } from "./launchd-foreign-jobs.js";
 
@@ -27,6 +29,16 @@ vi.mock("../commands/doctor-service-repair-policy.js", () => ({
 vi.mock("./restart-storm.js", () => ({
   readGatewayForcedRestartSummary: () => ({ count: 0, windowMs: 600_000 }),
 }));
+vi.mock("../commands/doctor-gateway-services.js", () => {
+  const forbidden = () => {
+    throw new Error("Native scratch proof must not enter managed-service repair");
+  };
+  return {
+    maybeRepairGatewayServiceConfig: forbidden,
+    maybeResolveDuelingSystemdGatewayScopes: forbidden,
+    maybeScanExtraGatewayServices: forbidden,
+  };
+});
 
 const hasGuiLaunchd =
   process.platform === "darwin" &&
@@ -35,11 +47,13 @@ const hasGuiLaunchd =
     timeout: 5000,
   }).status === 0;
 
-it.skipIf(!hasGuiLaunchd)(
-  "detects, reports and fixes only the scratch lifecycle job using native launchd",
-  async () => {
+it.skipIf(!hasGuiLaunchd).each(["interpreter", "direct"] as const)(
+  "detects, reports and fixes only the scratch lifecycle job using native launchd (%s)",
+  async (mode) => {
     const prefix = `ai.openclaw.test.w15.${process.pid}.${randomUUID()}`;
-    const labels = [prefix, `${prefix}.managed`, `com.example.w15.${process.pid}.${randomUUID()}`];
+    const lifecycleLabel = `${prefix}.restart`;
+    const observerLabel = `${prefix}.observer`;
+    const labels = [lifecycleLabel, `${prefix}.managed`, observerLabel];
     const domain = `gui/${process.getuid?.()}`;
     const dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-w15-native-"));
     const created: string[] = [];
@@ -77,7 +91,7 @@ it.skipIf(!hasGuiLaunchd)(
         throw new Error("Native test refused an operation outside its scratch labels");
       }
       if (args[0] !== "print") {
-        if (label !== prefix || args[0] !== "bootout") {
+        if (label !== lifecycleLabel || args[0] !== "bootout") {
           throw new Error("Native test refused a mutation of a protected scratch job");
         }
         mutations.push(label);
@@ -89,36 +103,63 @@ it.skipIf(!hasGuiLaunchd)(
       const cli = path.join(dir, "openclaw");
       const script = path.join(dir, "validator.sh");
       await fs.writeFile(cli, "#!/bin/sh\nexec /bin/sleep 120\n", { mode: 0o700 });
-      await fs.writeFile(script, `#!/bin/sh\nexec "${cli}" gateway restart\n`);
+      await fs.writeFile(
+        script,
+        `#!/bin/bash\nopenclaw_bin="${cli}"\n"$openclaw_bin" gateway restart\nfor attempt in 1 2; do\n  "$openclaw_bin" gateway status\n  /bin/sleep 1\ndone\n`,
+        { mode: 0o700 },
+      );
       for (const label of labels) {
         created.push(label);
-        const result = native(["submit", "-l", label, "--", "/bin/sh", script]);
+        const command =
+          label === observerLabel
+            ? ["/bin/sleep", "120"]
+            : mode === "direct"
+              ? [script]
+              : ["/bin/bash", script];
+        const result = native(["submit", "-l", label, "--", ...command]);
         expect(result, "scratch launchctl submit must not require privileges").toMatchObject({
           code: 0,
         });
       }
       const found = await findForeignLaunchdJobs(env);
-      expect(found).toEqual([
-        expect.objectContaining({
-          label: prefix,
-          program: "/bin/sh",
-          keepAlive: true,
-          gatewayActions: ["restart"],
-          safeToRemove: true,
-        }),
-      ]);
+      expect(found).toHaveLength(2);
+      expect(found).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            label: lifecycleLabel,
+            program: mode === "direct" ? script : "/bin/bash",
+            keepAlive: true,
+            gatewayActions: ["restart"],
+            safeToRemove: true,
+          }),
+          expect.objectContaining({
+            label: observerLabel,
+            gatewayActions: [],
+            safeToRemove: false,
+          }),
+        ]),
+      );
       await noteMacForeignLaunchdJobs({ nonInteractive: true }, runtime, env);
       expect(vi.mocked(note).mock.calls.flat().join("\n")).toContain(prefix);
       expect(mutations).toEqual([]);
-      await noteMacForeignLaunchdJobs({ repair: true, nonInteractive: true }, runtime, env);
-      expect(log.mock.calls.flat().join("\n")).toContain(`Removed stray launchd job ${prefix}`);
-      expect(mutations).toEqual([prefix]);
-      expect(native(["print", `${domain}/${prefix}`]).code).not.toBe(0);
+      await runGatewayServicesHealth(
+        createDoctorHealthFlowContext({
+          options: { repair: true, nonInteractive: true },
+          gatewayMaintenanceActive: true,
+          runtime,
+          env,
+        }),
+      );
+      expect(log.mock.calls.flat().join("\n")).toContain(
+        `Removed stray launchd job ${lifecycleLabel}`,
+      );
+      expect(mutations).toEqual([lifecycleLabel]);
+      expect(native(["print", `${domain}/${lifecycleLabel}`]).code).not.toBe(0);
       for (const label of labels.slice(1)) {
         expect(native(["print", `${domain}/${label}`]).code).toBe(0);
       }
       console.log(
-        "Native scratch proof: keepalive lifecycle job detected; Doctor report preserved it; --fix removed it; managed and unrelated scratch jobs remained loaded.",
+        `Native scratch proof (${mode}): keepalive lifecycle job detected; Doctor report preserved it; maintenance-owned --fix removed it; managed and observer scratch jobs remained loaded.`,
       );
     } catch (error) {
       errors.push(error);

--- a/src/daemon/launchd-foreign-jobs.test.ts
+++ b/src/daemon/launchd-foreign-jobs.test.ts
@@ -275,6 +275,18 @@ describe("foreign launchd command classification", () => {
           : mode === "direct"
             ? [file]
             : ["/bin/bash", file];
+      for (const block of ["inherited environment", "default environment"]) {
+        addJob(
+          label,
+          args,
+          `\t${block} = {\n\t\tBASH_ENV => /tmp/profile\n\t}\n\tenvironment = {\n\t\tPATH => /usr/bin:/bin\n\t}\n`,
+        );
+        expect((await findForeignLaunchdJobs({}))[0], block).toMatchObject({
+          gatewayActions: [],
+          safeToRemove: false,
+          diagnostic: "Shell environment alters execution; left unchanged.",
+        });
+      }
       for (const name of [
         "SHELLOPTS",
         "BASHOPTS",

--- a/src/daemon/launchd-foreign-jobs.test.ts
+++ b/src/daemon/launchd-foreign-jobs.test.ts
@@ -110,7 +110,39 @@ describe("foreign launchd command classification", () => {
   });
 
   it.each([
-    ['#!/bin/sh\nopenclaw_bin="/opt/bin/openclaw"\n"$openclaw_bin" gateway restart\n', ["restart"]],
+    ['#!/bin/sh\nopenclaw_bin="/opt/bin/openclaw"\n"$openclaw_bin" gateway restart\n', []],
+    [
+      "#!/bin/sh\nset -e\n'openclaw_bin=/opt/bin/openclaw'\n\"$openclaw_bin\" gateway restart\n",
+      [],
+    ],
+    ["#!/bin/sh\n/opt/*/openclaw gateway restart\n", []],
+    ["#!/bin/sh\n~/bin/openclaw gateway restart\n", []],
+    [
+      '#!/bin/sh\nopenclaw_bin=/usr/local/bin/openclaw\n"$openclaw_bin" gateway restart\n',
+      ["restart"],
+    ],
+    [
+      '#!/bin/sh\nopenclaw_bin=/usr/local/bin/openclaw\n"${openclaw_bin}" gateway restart\n',
+      ["restart"],
+    ],
+    [
+      "#!/bin/sh\nopenclaw_bin=/usr/local/bin/openclaw\n$openclaw_bin gateway restart\n",
+      ["restart"],
+    ],
+    [
+      "#!/bin/sh\nopenclaw_bin=/usr/local/bin/openclaw\n${openclaw_bin} gateway restart\n",
+      ["restart"],
+    ],
+    ["#!/bin/sh\nexec /usr/local/bin/openclaw gateway restart --profile work\n", ["restart"]],
+    ["#!/bin/sh\nopenclaw gateway restart --help\n", []],
+    ['#!/bin/sh\n"openclaw" gateway restart\n', []],
+    ['#!/bin/sh\nset "-e"\nopenclaw gateway restart\n', []],
+    ['#!/bin/sh\nopenclaw_bin=/bin/echo\n"$openclaw_bin" gateway restart\n', []],
+    ["#!/bin/sh\nopenclaw gateway restart\u2028", []],
+    [
+      '#!/bin/sh\nopenclaw_bin=/usr/local/bin/openclaw\u2028\n"$openclaw_bin" gateway restart\n',
+      [],
+    ],
     [
       '#!/bin/sh\r\nopenclaw_bin=/usr/local/bin/openclaw\r\n"$openclaw_bin" gateway restart\r\n',
       [],

--- a/src/daemon/launchd-foreign-jobs.test.ts
+++ b/src/daemon/launchd-foreign-jobs.test.ts
@@ -91,7 +91,32 @@ describe("foreign launchd command classification", () => {
       ["start"],
     ],
     ["ai.openclaw.echo", ["/bin/echo", "openclaw", "gateway", "restart"], []],
-    ["ai.openclaw.inline", ["/bin/sh", "-c", "openclaw gateway restart"], ["restart"]],
+    ["ai.openclaw.inline", ["/bin/sh", "-c", "openclaw gateway restart"], []],
+    [
+      "ai.openclaw.inline-absolute",
+      ["/bin/sh", "-c", "/usr/local/bin/openclaw gateway restart"],
+      ["restart"],
+    ],
+    ["ai.openclaw.bare", ["openclaw", "gateway", "restart"], []],
+    ["ai.openclaw.env-bare", ["/usr/bin/env", "openclaw", "gateway", "restart"], []],
+    ["ai.openclaw.node-bare-entry", ["/usr/bin/node", "openclaw.mjs", "gateway", "restart"], []],
+    ["ai.openclaw.node-bare-runtime", ["node", "/opt/openclaw.mjs", "gateway", "restart"], []],
+    ["ai.openclaw.bun", ["/opt/bin/bun", "/opt/openclaw.mjs", "gateway", "restart"], ["restart"]],
+    [
+      "ai.openclaw.bun-relative-entry",
+      ["/opt/bin/bun", "./openclaw.mjs", "gateway", "restart"],
+      [],
+    ],
+    [
+      "ai.openclaw.env-node",
+      ["/usr/bin/env", "/usr/bin/node", "/opt/openclaw.mjs", "gateway", "restart"],
+      ["restart"],
+    ],
+    [
+      "ai.openclaw.env-bare-node",
+      ["/usr/bin/env", "node", "/opt/openclaw.mjs", "gateway", "restart"],
+      [],
+    ],
     ["ai.openclaw.help", ["/opt/bin/openclaw", "gateway", "restart", "--help"], []],
     ["ai.openclaw.help-short", ["/opt/bin/openclaw", "gateway", "restart", "-h"], []],
     ["ai.openclaw.exec", ["exec", "openclaw", "gateway", "restart"], []],
@@ -110,6 +135,9 @@ describe("foreign launchd command classification", () => {
   });
 
   it.each([
+    ["#!/bin/sh\nopenclaw gateway restart\n", []],
+    ["#!/bin/sh\n/usr/local/bin/openclaw gateway restart\n", ["restart"]],
+    ['#!/bin/sh\nopenclaw_bin=openclaw\n"$openclaw_bin" gateway restart\n', []],
     ['#!/bin/sh\nopenclaw_bin="/opt/bin/openclaw"\n"$openclaw_bin" gateway restart\n', []],
     [
       "#!/bin/sh\nset -e\n'openclaw_bin=/opt/bin/openclaw'\n\"$openclaw_bin\" gateway restart\n",
@@ -161,7 +189,7 @@ describe("foreign launchd command classification", () => {
       '#!/bin/sh\nexport OPENCLAW_BIN=/usr/local/bin/openclaw\n"$OPENCLAW_BIN" gateway restart\n',
       ["restart"],
     ],
-    ["#!/bin/sh\nset -e -u -x +e +u +x\nopenclaw gateway restart\n", ["restart"]],
+    ["#!/bin/sh\nset -e -u -x +e +u +x\n/usr/local/bin/openclaw gateway restart\n", ["restart"]],
     ["#!/bin/sh\nset -eu\nopenclaw gateway restart\n", []],
     ["#!/bin/sh\nexec >/dev/null\nopenclaw gateway restart\n", []],
     ["#!/bin/sh\nUID=/usr/local/bin/openclaw gateway restart\n", []],
@@ -235,6 +263,99 @@ describe("foreign launchd command classification", () => {
     }
     expect(exec.mock.calls.map(([args]) => args)).toEqual([["list"]]);
   });
+
+  it.each(["inline", "script", "direct"] as const)(
+    "rejects shell-altering environment names for %s launches without examining values",
+    async (mode) => {
+      const file = path.join(dir, "validate.sh");
+      await fs.writeFile(file, "#!/bin/bash\nset -x\n/usr/local/bin/openclaw gateway restart\n");
+      const args =
+        mode === "inline"
+          ? ["/bin/bash", "-xc", "/usr/local/bin/openclaw gateway restart"]
+          : mode === "direct"
+            ? [file]
+            : ["/bin/bash", file];
+      for (const name of [
+        "SHELLOPTS",
+        "BASHOPTS",
+        "BASH_ENV",
+        "ENV",
+        "ZDOTDIR",
+        "POSIXLY_CORRECT",
+        "IFS",
+        "CDPATH",
+        "PS4",
+        "BASH_XTRACEFD",
+        "BASH_CUSTOM",
+        "BASH_FUNC_example%%",
+      ]) {
+        addJob(
+          label,
+          args,
+          `\tenvironment = {\n\t\t${name} => ${name === "SHELLOPTS" ? "noexec" : "ignored"}\n\t}\n`,
+        );
+        expect((await findForeignLaunchdJobs({}))[0], name).toMatchObject({
+          gatewayActions: [],
+          safeToRemove: false,
+          diagnostic: "Shell environment alters execution; left unchanged.",
+        });
+      }
+      addJob(
+        label,
+        args,
+        "\tenvironment = {\n\t\tPATH => /usr/bin:/bin\n\t\tHOME => /home/operator\n\t\tOPENCLAW_EXAMPLE => SHELLOPTS=noexec BASH_ENV=ignored\n\t}\n",
+      );
+      expect((await findForeignLaunchdJobs({}))[0]).toMatchObject({
+        gatewayActions: ["restart"],
+        safeToRemove: true,
+      });
+    },
+  );
+
+  it.each([false, true])(
+    "leaves non-shell CLI verification unaffected by shell environment names (env: %s)",
+    async (viaEnv) => {
+      const file = path.join(dir, "openclaw");
+      await fs.writeFile(file, "#!/usr/bin/env node\n");
+      addJob(
+        label,
+        [...(viaEnv ? ["/usr/bin/env"] : []), file, "gateway", "restart"],
+        "\tenvironment = {\n\t\tSHELLOPTS => noexec\n\t}\n",
+      );
+      expect((await findForeignLaunchdJobs({}))[0]).toMatchObject({
+        gatewayActions: ["restart"],
+        safeToRemove: true,
+      });
+    },
+  );
+
+  it.each(
+    ["openclaw", "openclaw.mjs", "node", "bun", "env"].flatMap((name) =>
+      (name === "env" ? [false] : [false, true]).map((viaEnv) => ({ name, viaEnv })),
+    ),
+  )(
+    "guards an executed shell script even when its filename is $name (env: $viaEnv)",
+    async ({ name, viaEnv }) => {
+      const file = path.join(dir, name);
+      await fs.writeFile(file, "#!/bin/bash\n/usr/local/bin/openclaw gateway restart\n");
+      const prefix =
+        name === "env"
+          ? [file, "/usr/local/bin/openclaw"]
+          : name === "node" || name === "bun"
+            ? [file, "/opt/openclaw.mjs"]
+            : [file];
+      addJob(
+        label,
+        [...(viaEnv ? ["/usr/bin/env"] : []), ...prefix, "gateway", "restart"],
+        "\tenvironment = {\n\t\tSHELLOPTS => noexec\n\t}\n",
+      );
+      expect((await findForeignLaunchdJobs({}))[0]).toMatchObject({
+        gatewayActions: [],
+        safeToRemove: false,
+        diagnostic: "Shell environment alters execution; left unchanged.",
+      });
+    },
+  );
 
   it.each([
     { shebang: "#!/bin/bash", verified: true },

--- a/src/daemon/launchd-foreign-jobs.test.ts
+++ b/src/daemon/launchd-foreign-jobs.test.ts
@@ -112,6 +112,18 @@ describe("foreign launchd command classification", () => {
   it.each([
     ['#!/bin/sh\nopenclaw_bin="/opt/bin/openclaw"\n"$openclaw_bin" gateway restart\n', ["restart"]],
     [
+      '#!/bin/sh\nset -u\nopenclaw_bin=/usr/local/bin/openclaw\n"$openclaw_bin" gateway restart --profile "$PROFILE"\nopenclaw gateway restart\n',
+      [],
+    ],
+    [
+      '#!/bin/sh\nset -u\nopenclaw_bin=/usr/local/bin/openclaw\n"$openclaw_bin" gateway restart --profile "${PROFILE}"\n',
+      [],
+    ],
+    [
+      '#!/bin/sh\nset -u\nopenclaw_bin=/usr/local/bin/openclaw\n"$openclaw_bin" gateway restart --profile work\n',
+      ["restart"],
+    ],
+    [
       "#!/bin/sh\n/opt/bin/openclaw gateway stop\n/opt/bin/openclaw gateway start\n",
       ["start", "stop"],
     ],
@@ -170,6 +182,46 @@ describe("foreign launchd command classification", () => {
       ).toBe(false);
     }
     expect(exec.mock.calls.map(([args]) => args)).toEqual([["list"]]);
+  });
+
+  it.each([
+    { shebang: "#!/bin/bash", verified: true },
+    { shebang: "#!/bin/sh", verified: true },
+    { shebang: "#!/usr/bin/env bash", verified: true },
+    { shebang: "#!/usr/bin/env sh", verified: true },
+    { shebang: "#!/usr/bin/env zsh", verified: true },
+    { shebang: "#!/usr/bin/python3", verified: false },
+    { shebang: "", verified: false },
+    { shebang: "#!/bin/bash -n", verified: false },
+  ])(
+    "verifies directly executed scripts only with an executing shell shebang ($shebang)",
+    async ({ shebang, verified }) => {
+      const file = path.join(dir, "validate.sh");
+      await fs.writeFile(
+        file,
+        `${shebang}\nopenclaw_bin=/usr/local/bin/openclaw\n"$openclaw_bin" gateway restart\nfor attempt in 1 2; do\n  "$openclaw_bin" gateway status\n  sleep 1\ndone\n`,
+      );
+      addJob(label, [file]);
+      expect(await findForeignLaunchdJobs({})).toEqual([
+        expect.objectContaining({
+          program: file,
+          gatewayActions: verified ? ["restart"] : [],
+          safeToRemove: verified,
+        }),
+      ]);
+    },
+  );
+
+  it("does not inspect positional script arguments as executable files", async () => {
+    const file = path.join(dir, "observer");
+    const argument = path.join(dir, "restart.sh");
+    await fs.writeFile(file, "#!/usr/bin/python3\n");
+    await fs.writeFile(argument, "#!/bin/sh\nopenclaw gateway restart\n");
+    addJob(label, [file, argument]);
+    expect((await findForeignLaunchdJobs({}))[0]).toMatchObject({
+      gatewayActions: [],
+      safeToRemove: false,
+    });
   });
 
   it("protects another profile's generated service even if its command is corrupted", async () => {

--- a/src/daemon/launchd-foreign-jobs.test.ts
+++ b/src/daemon/launchd-foreign-jobs.test.ts
@@ -1,0 +1,293 @@
+// Foreign-job tests protect the live command evidence and Doctor's removal boundary.
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { expectDefined } from "@openclaw/normalization-core";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { execLaunchctl } from "./launchd-exec.js";
+import {
+  findForeignLaunchdJobs,
+  repairForeignLaunchdJob,
+  type ForeignLaunchdJob,
+} from "./launchd-foreign-jobs.js";
+
+vi.mock("./launchd-exec.js", async (original) => ({
+  ...(await original<typeof import("./launchd-exec.js")>()),
+  execLaunchctl: vi.fn(),
+}));
+
+const exec = vi.mocked(execLaunchctl);
+const label = "ai.openclaw.update-validator.20260727.v2";
+const uid = process.getuid?.() ?? 0;
+const domain = `gui/${uid}`;
+const ok = (stdout = "") => ({ code: 0, stdout, stderr: "", termination: "exit" as const });
+const missing = {
+  code: 113,
+  stdout: "",
+  stderr: "Could not find service",
+  termination: "exit" as const,
+};
+let dir: string;
+let jobs: Map<string, string>;
+
+function addJob(name: string, args: string[], extra = "") {
+  jobs.set(
+    name,
+    `${domain}/${name} = {\n\tpath = (submitted by launchctl[123])\n\ttype = Submitted\n\tprogram = ${args[0]}\n\targuments = {\n${args.map((arg) => `\t\t${arg}`).join("\n")}\n\t}\n\tproperties = keepalive | inferred program\n${extra}}\n`,
+  );
+}
+
+beforeEach(async () => {
+  vi.stubGlobal(
+    "process",
+    Object.create(process, {
+      platform: { value: "darwin" },
+      getuid: { value: () => uid },
+    }),
+  );
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-foreign-jobs-"));
+  jobs = new Map();
+  exec.mockReset();
+  exec.mockImplementation(async (args) => {
+    if (args[0] === "list") {
+      return ok([...jobs.keys()].map((name) => `123\t0\t${name}`).join("\n"));
+    }
+    const name = args[1]?.slice(`${domain}/`.length) ?? "";
+    if (args[0] === "print") {
+      return jobs.has(name) ? ok(jobs.get(name)) : missing;
+    }
+    if (args[0] === "bootout") {
+      jobs.delete(name);
+      return ok();
+    }
+    if (args[0] === "disable") {
+      return ok();
+    }
+    throw new Error(`Unexpected launchctl operation ${args[0]}`);
+  });
+});
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe("foreign launchd command classification", () => {
+  it.each([
+    [
+      "ai.openclaw.update-validator.20260727.v2",
+      ["/opt/bin/openclaw", "gateway", "restart"],
+      ["restart"],
+    ],
+    ["ai.openclaw.upgrade-2026-9-1-beta-1", ["/opt/bin/openclaw", "update", "--yes"], []],
+    [
+      "ai.openclaw.maintenance",
+      ["/usr/bin/env", "PATH=/bin", "/opt/bin/openclaw", "gateway", "stop"],
+      ["stop"],
+    ],
+    [
+      "ai.openclaw.profile-watch",
+      ["/bin/node", "/opt/openclaw.mjs", "--profile", "work", "gateway", "start"],
+      ["start"],
+    ],
+    ["ai.openclaw.echo", ["/bin/echo", "openclaw", "gateway", "restart"], []],
+    ["ai.openclaw.inline", ["/bin/sh", "-c", "openclaw gateway restart"], ["restart"]],
+    ["ai.openclaw.help", ["/opt/bin/openclaw", "gateway", "restart", "--help"], []],
+    ["ai.openclaw.help-short", ["/opt/bin/openclaw", "gateway", "restart", "-h"], []],
+    ["ai.openclaw.exec", ["exec", "openclaw", "gateway", "restart"], []],
+  ])("reports %s and verifies only executable lifecycle arguments", async (name, args, actions) => {
+    addJob(name, args);
+    const found = await findForeignLaunchdJobs({});
+    expect(found).toEqual([
+      expect.objectContaining({
+        label: name,
+        program: args[0],
+        keepAlive: true,
+        gatewayActions: actions,
+        safeToRemove: actions.length > 0,
+      }),
+    ]);
+  });
+
+  it.each([
+    ['#!/bin/sh\nopenclaw_bin="/opt/bin/openclaw"\n"$openclaw_bin" gateway restart\n', ["restart"]],
+    [
+      "#!/bin/sh\n/opt/bin/openclaw gateway stop\n/opt/bin/openclaw gateway start\n",
+      ["start", "stop"],
+    ],
+    ['#!/bin/sh\n# openclaw gateway restart\necho "openclaw gateway start"\n', []],
+    ["#!/bin/sh\ncat <<EOF\nopenclaw gateway restart\nEOF\n", []],
+    ['#!/bin/sh\necho "example:\nopenclaw gateway restart\n"\n', []],
+    ["#!/bin/sh\noc=\"/opt/bin/openclaw\"\n'$oc' gateway restart\n", []],
+    ['#!/bin/sh\n"$unknown" gateway restart\n', []],
+    ['#!/bin/sh\noc="/opt/bin/openclaw"\nunset oc\n"$oc" gateway restart\n', []],
+    ["#!/bin/sh\ncleanup() {\nopenclaw gateway restart\n}\nsleep 30\n", []],
+    ["#!/bin/sh\nif false; then\nopenclaw gateway restart\nfi\n", []],
+    ["#!/bin/sh\nexit 0\nopenclaw gateway restart\n", []],
+    ['#!/bin/sh\noc="/opt/bin/openclaw"\nread oc\n"$oc" gateway restart\n', []],
+    ["#!/bin/sh\nopenclaw '' gateway restart\n", []],
+    ["#!/bin/sh\nset -n\nopenclaw gateway restart\n", []],
+    ["#!/bin/sh\nset -o noexec\nopenclaw gateway restart\n", []],
+    ['#!/bin/sh\noc="/opt/bin/openclaw"\nprintf -v oc /bin/echo\n"$oc" gateway restart\n', []],
+    ['#!/bin/sh\noc=/opt/bin/openclaw\nname=oc\nunset "$name"\n"$oc" gateway restart\n', []],
+    ['#!/bin/zsh\noc=/opt/bin/openclaw\nother=${oc::=/bin/echo}\n"$oc" gateway restart\n', []],
+    ['#!/bin/zsh\noc=/opt/bin/openclaw\necho "${oc::=/bin/echo}"\n"$oc" gateway restart\n', []],
+    ['#!/bin/sh\nopenclaw_bin="echo /opt/bin/openclaw"\n$openclaw_bin gateway restart\n', []],
+    ["#!/bin/sh\nIFS=o\nopenclaw_bin=openclaw\n$openclaw_bin gateway restart\n", []],
+    ['#!/bin/bash\nRANDOM=openclaw\n"$RANDOM" gateway restart\n', []],
+    [
+      '#!/bin/zsh\nopenclaw_bin=/opt/bin/openclaw\nexec >${openclaw_bin::=/bin/echo}\n"$openclaw_bin" gateway restart\n',
+      [],
+    ],
+  ])(
+    "reads shell scripts without executing or confusing quoted data with commands (%#)",
+    async (script, actions) => {
+      const file = path.join(dir, "validator.sh");
+      await fs.writeFile(file, script);
+      addJob(label, ["/bin/sh", file]);
+      expect(await findForeignLaunchdJobs({})).toEqual([
+        expect.objectContaining({ gatewayActions: actions, safeToRemove: actions.length > 0 }),
+      ]);
+    },
+  );
+
+  it("does not inspect or remove managed, profile, custom, node, or unrelated labels", async () => {
+    const protectedLabels = [
+      "ai.openclaw.gateway",
+      "ai.openclaw.work",
+      "ai.openclaw.custom",
+      "ai.openclaw.node",
+      "com.example.validator",
+    ];
+    for (const name of protectedLabels) {
+      addJob(name, ["/opt/bin/openclaw", "gateway", "restart"]);
+    }
+    const env = { OPENCLAW_PROFILE: "work", OPENCLAW_LAUNCHD_LABEL: "ai.openclaw.custom" };
+    expect(await findForeignLaunchdJobs(env)).toEqual([]);
+    for (const name of protectedLabels) {
+      expect(
+        (await repairForeignLaunchdJob({ label: name } as ForeignLaunchdJob, env)).removed,
+      ).toBe(false);
+    }
+    expect(exec.mock.calls.map(([args]) => args)).toEqual([["list"]]);
+  });
+
+  it("protects another profile's generated service even if its command is corrupted", async () => {
+    addJob(label, [
+      "/bin/sh",
+      `/home/operator/.openclaw/service-env/${label}-env-wrapper.sh`,
+      "env",
+      "openclaw",
+      "gateway",
+      "restart",
+    ]);
+    expect(await findForeignLaunchdJobs({})).toEqual([]);
+  });
+
+  it("does not remove shell syntax-check jobs", async () => {
+    addJob(label, ["/bin/sh", "-nc", "openclaw gateway restart"]);
+    expect((await findForeignLaunchdJobs({}))[0]).toMatchObject({ safeToRemove: false });
+  });
+
+  it.each([{ prefix: [] }, { prefix: ["--"] }])(
+    "does not treat script positional arguments as shell options ($prefix)",
+    async ({ prefix }) => {
+      const file = path.join(dir, "harmless.sh");
+      await fs.writeFile(file, "#!/bin/sh\nsleep 120\n");
+      addJob(label, ["/bin/sh", ...prefix, file, "-c", "openclaw gateway restart"]);
+      expect((await findForeignLaunchdJobs({}))[0]).toMatchObject({ safeToRemove: false });
+    },
+  );
+
+  it("leaves oversized and symlinked shell scripts unverified", async () => {
+    const file = path.join(dir, "validator.sh");
+    await fs.writeFile(file, `openclaw gateway restart\n${"#".repeat(65536)}`);
+    addJob(label, ["/bin/sh", file]);
+    expect((await findForeignLaunchdJobs({}))[0]).toMatchObject({ safeToRemove: false });
+    const link = path.join(dir, "link.sh");
+    await fs.symlink(file, link);
+    addJob(label, ["/bin/sh", link]);
+    expect((await findForeignLaunchdJobs({}))[0]).toMatchObject({ safeToRemove: false });
+  });
+});
+
+describe("foreign launchd repair", () => {
+  it("revalidates the live command, removes a submitted lifecycle job and confirms absence", async () => {
+    addJob(label, ["/opt/bin/openclaw", "gateway", "restart"]);
+    const job = expectDefined((await findForeignLaunchdJobs({}))[0], "detected foreign job");
+    const result = await repairForeignLaunchdJob(job, {});
+    expect(result).toEqual({
+      removed: true,
+      detail: expect.stringContaining(`Removed stray launchd job ${label}`),
+    });
+    expect(jobs.has(label)).toBe(false);
+    expect(exec.mock.calls.filter(([args]) => args[0] === "disable")).toEqual([]);
+  });
+
+  it("never trusts stale or caller-forged removal evidence", async () => {
+    addJob(label, ["/opt/bin/openclaw", "gateway", "restart"]);
+    const job = expectDefined((await findForeignLaunchdJobs({}))[0], "detected foreign job");
+    addJob(label, ["/bin/echo", "gateway restart"]);
+    expect((await repairForeignLaunchdJob(job, {})).removed).toBe(false);
+    expect(exec.mock.calls.some(([args]) => ["bootout", "disable"].includes(args[0] ?? ""))).toBe(
+      false,
+    );
+  });
+
+  it("disables a verified foreign plist job at login while retaining its file", async () => {
+    const plistPath = path.join(dir, "foreign.plist");
+    await fs.writeFile(plistPath, "<plist><dict></dict></plist>");
+    addJob(label, ["/opt/bin/openclaw", "gateway", "stop"]);
+    jobs.set(
+      label,
+      jobs
+        .get(label)!
+        .replace("(submitted by launchctl[123])", plistPath)
+        .replace("type = Submitted", "type = LaunchAgent"),
+    );
+    const job = expectDefined((await findForeignLaunchdJobs({}))[0], "detected foreign job");
+    expect((await repairForeignLaunchdJob(job, {})).removed).toBe(true);
+    expect(await fs.readFile(plistPath, "utf8")).toContain("<plist>");
+    expect(
+      exec.mock.calls
+        .filter(([args]) => ["disable", "bootout"].includes(args[0] ?? ""))
+        .map(([args]) => args),
+    ).toEqual([
+      ["disable", `${domain}/${label}`],
+      ["bootout", `${domain}/${label}`],
+    ]);
+  });
+
+  it("does not claim success when launchd rejects removal", async () => {
+    addJob(label, ["/opt/bin/openclaw", "gateway", "restart"]);
+    const job = expectDefined((await findForeignLaunchdJobs({}))[0], "detected foreign job");
+    const execute = exec.getMockImplementation()!;
+    exec.mockImplementation(async (args, timeout) =>
+      args[0] === "bootout"
+        ? { ...missing, stderr: "Operation not permitted" }
+        : execute(args, timeout),
+    );
+    expect((await repairForeignLaunchdJob(job, {})).removed).toBe(false);
+    expect(jobs.has(label)).toBe(true);
+  });
+
+  it("revalidates a plist job after disabling it before bootout", async () => {
+    const plistPath = path.join(dir, "foreign.plist");
+    await fs.writeFile(plistPath, "<plist><dict></dict></plist>");
+    addJob(label, ["/opt/bin/openclaw", "gateway", "restart"]);
+    jobs.set(label, jobs.get(label)!.replace("(submitted by launchctl[123])", plistPath));
+    const job = expectDefined((await findForeignLaunchdJobs({}))[0], "detected foreign job");
+    const execute = exec.getMockImplementation()!;
+    exec.mockImplementation(async (args, timeout) => {
+      if (args[0] === "disable") {
+        addJob(label, ["/bin/echo", "unrelated"]);
+      }
+      return execute(args, timeout);
+    });
+    expect(await repairForeignLaunchdJob(job, {})).toMatchObject({
+      removed: false,
+      detail: expect.stringContaining("definition changed before removal"),
+    });
+    expect(exec.mock.calls.some(([args]) => args[0] === "bootout")).toBe(false);
+  });
+});

--- a/src/daemon/launchd-foreign-jobs.test.ts
+++ b/src/daemon/launchd-foreign-jobs.test.ts
@@ -112,6 +112,29 @@ describe("foreign launchd command classification", () => {
   it.each([
     ['#!/bin/sh\nopenclaw_bin="/opt/bin/openclaw"\n"$openclaw_bin" gateway restart\n', ["restart"]],
     [
+      '#!/bin/sh\r\nopenclaw_bin=/usr/local/bin/openclaw\r\n"$openclaw_bin" gateway restart\r\n',
+      [],
+    ],
+    ["#!/bin/sh\nopenclaw gateway restart\n# carriage return\r", []],
+    [
+      '#!/bin/bash\nset -e\nUID=1000\nopenclaw_bin=/usr/local/bin/openclaw\n"$openclaw_bin" gateway restart\n',
+      [],
+    ],
+    [
+      '#!/bin/sh\nPATH=/usr/local/bin\nopenclaw_bin=/usr/local/bin/openclaw\n"$openclaw_bin" gateway restart\n',
+      [],
+    ],
+    ["#!/bin/sh\nexport PATH=/usr/local/bin\nopenclaw gateway restart\n", []],
+    [
+      '#!/bin/sh\nexport OPENCLAW_BIN=/usr/local/bin/openclaw\n"$OPENCLAW_BIN" gateway restart\n',
+      ["restart"],
+    ],
+    ["#!/bin/sh\nset -e -u -x +e +u +x\nopenclaw gateway restart\n", ["restart"]],
+    ["#!/bin/sh\nset -eu\nopenclaw gateway restart\n", []],
+    ["#!/bin/sh\nexec >/dev/null\nopenclaw gateway restart\n", []],
+    ["#!/bin/sh\nUID=/usr/local/bin/openclaw gateway restart\n", []],
+    ["#!/bin/sh\nenv PATH=/usr/local/bin openclaw gateway restart\n", []],
+    [
       '#!/bin/sh\nset -u\nopenclaw_bin=/usr/local/bin/openclaw\n"$openclaw_bin" gateway restart --profile "$PROFILE"\nopenclaw gateway restart\n',
       [],
     ],
@@ -123,10 +146,7 @@ describe("foreign launchd command classification", () => {
       '#!/bin/sh\nset -u\nopenclaw_bin=/usr/local/bin/openclaw\n"$openclaw_bin" gateway restart --profile work\n',
       ["restart"],
     ],
-    [
-      "#!/bin/sh\n/opt/bin/openclaw gateway stop\n/opt/bin/openclaw gateway start\n",
-      ["start", "stop"],
-    ],
+    ["#!/bin/sh\n/opt/bin/openclaw gateway stop\n/opt/bin/openclaw gateway start\n", ["stop"]],
     ['#!/bin/sh\n# openclaw gateway restart\necho "openclaw gateway start"\n', []],
     ["#!/bin/sh\ncat <<EOF\nopenclaw gateway restart\nEOF\n", []],
     ['#!/bin/sh\necho "example:\nopenclaw gateway restart\n"\n', []],

--- a/src/daemon/launchd-foreign-jobs.ts
+++ b/src/daemon/launchd-foreign-jobs.ts
@@ -27,6 +27,27 @@ const MAX_JOBS = 64;
 const INSPECTION_TIMEOUT_MS = 2_000;
 const MAX_FILE_BYTES = 64 * 1024;
 const SHELLS = new Set(["sh", "bash", "zsh", "dash", "ksh"]);
+const SHELL_EXECUTION_ENV_NAMES = new Set([
+  "SHELLOPTS",
+  "BASHOPTS",
+  "BASH_ENV",
+  "ENV",
+  "ZDOTDIR",
+  "POSIXLY_CORRECT",
+  "IFS",
+  "CDPATH",
+  "PS4",
+  "BASH_XTRACEFD",
+]);
+
+function hasShellExecutionEnvironment(environment: string): boolean {
+  for (const [, name] of environment.matchAll(/^\t\t(.+?) => /gm)) {
+    if (name && (SHELL_EXECUTION_ENV_NAMES.has(name) || name.startsWith("BASH_"))) {
+      return true;
+    }
+  }
+  return false;
+}
 
 function isCandidate(label: string, env: NodeJS.ProcessEnv): boolean {
   return (
@@ -40,7 +61,9 @@ function isCandidate(label: string, env: NodeJS.ProcessEnv): boolean {
   );
 }
 
-function lifecycleAction(args: string[]): GatewayAction | undefined {
+function lifecycleInvocation(
+  args: string[],
+): { action: GatewayAction; program: string } | undefined {
   if (args.some((arg) => ["--help", "-h", "--version", "-V"].includes(arg))) {
     return undefined;
   }
@@ -51,13 +74,20 @@ function lifecycleAction(args: string[]): GatewayAction | undefined {
       words = words.slice(1);
     }
   }
+  const program = words[0] ?? "";
+  if (!path.isAbsolute(program)) {
+    return undefined;
+  }
   if (["node", "bun"].includes(path.basename(words[0] ?? ""))) {
     words = words.slice(1);
     if (path.basename(words[0] ?? "") !== "openclaw.mjs") {
       return undefined;
     }
   }
-  if (!["openclaw", "openclaw.mjs"].includes(path.basename(words[0] ?? ""))) {
+  if (
+    !path.isAbsolute(words[0] ?? "") ||
+    !["openclaw", "openclaw.mjs"].includes(path.basename(words[0] ?? ""))
+  ) {
     return undefined;
   }
   words = words.slice(1);
@@ -66,12 +96,12 @@ function lifecycleAction(args: string[]): GatewayAction | undefined {
   }
   const action = words[1];
   return words[0] === "gateway" && (action === "restart" || action === "start" || action === "stop")
-    ? action
+    ? { action, program }
     : undefined;
 }
 
 const SCRIPT_HELPER_NAME = /(?:openclaw_|OPENCLAW_)[A-Za-z0-9_]*/;
-const SCRIPT_LITERAL_EXEC = String.raw`(?:openclaw(?:\.mjs)?|/(?:[A-Za-z0-9_.-]+/)*openclaw(?:\.mjs)?)`;
+const SCRIPT_LITERAL_EXEC = String.raw`/(?:[A-Za-z0-9_.-]+/)*openclaw(?:\.mjs)?`;
 const SCRIPT_HELPER_REF = String.raw`\$(?:${SCRIPT_HELPER_NAME.source}|\{${SCRIPT_HELPER_NAME.source}\})`;
 // JavaScript's $ can stop before a final Unicode separator; require the raw end.
 const SCRIPT_LINE_END = String.raw`$(?![\s\S])`;
@@ -83,9 +113,10 @@ const SCRIPT_INVOCATION = new RegExp(
   String.raw`^[ \t]*(?:exec[ \t]+)?(${SCRIPT_LITERAL_EXEC}|${SCRIPT_HELPER_REF}|"${SCRIPT_HELPER_REF}")[ \t]+gateway[ \t]+(restart|start|stop)((?:[ \t]+[A-Za-z0-9_.=/:-]+)*)[ \t]*${SCRIPT_LINE_END}`,
 );
 
-// Match raw lines only: blank/comments, allowed set flags, unquoted literal
-// helper assignments, then the first lifecycle call (optional exec/helper).
-// Shell syntax is never dequoted or expanded; unmatched text is report-only.
+// Verify literal, straight-line prefixes ending in a Gateway lifecycle call to
+// an absolute OpenClaw path; inspectJob also excludes shell-altering job environments.
+// Other syntax is report-only. This checks metadata, not binary executability,
+// interpreter availability or quarantine, and never dequotes or expands shell words.
 function scriptActions(script: string): GatewayAction[] {
   if (script.includes("\r") || script.includes("<<") || script.includes("\\\n")) {
     return [];
@@ -229,19 +260,39 @@ async function inspectJob(
   }
   let actions: GatewayAction[] = [];
   let diagnostic: string | undefined;
+  const shellEnvironmentDiagnostic = hasShellExecutionEnvironment(environment)
+    ? "Shell environment alters execution; left unchanged."
+    : undefined;
   const command = args.length ? [program, ...args.slice(1)] : [program];
-  const direct = lifecycleAction(command);
-  if (direct) {
-    actions = [direct];
-  } else if (SHELLS.has(path.basename(program))) {
+  const direct = path.isAbsolute(program) ? lifecycleInvocation(command) : undefined;
+  const programName = path.basename(program);
+  const isShell = SHELLS.has(programName);
+  // A CLI basename can also name an owned shell launcher. Check that header
+  // before accepting direct argv when the job carries shell-altering environment.
+  const programScript =
+    !isShell &&
+    (shellEnvironmentDiagnostic ||
+      !["openclaw", "openclaw.mjs", "node", "bun", "env"].includes(programName))
+      ? await readOwnedText(program)
+      : undefined;
+  let isShellScript = programScript !== undefined && hasShellShebang(programScript);
+  // env executes its selected program directly, including an owned shell launcher.
+  if (shellEnvironmentDiagnostic && direct && direct.program !== program) {
+    const selectedScript = await readOwnedText(direct.program);
+    isShellScript ||= selectedScript !== undefined && hasShellShebang(selectedScript);
+  }
+  if (shellEnvironmentDiagnostic && (isShell || isShellScript)) {
+    diagnostic = shellEnvironmentDiagnostic;
+  } else if (direct) {
+    actions = [direct.action];
+  } else if (isShell) {
     const script = await readShellScript(command.slice(1));
     actions = script ? scriptActions(script) : [];
     diagnostic = actions.length
       ? undefined
       : "Shell command could not be verified; left unchanged.";
-  } else if (!["openclaw", "openclaw.mjs", "node", "bun", "env"].includes(path.basename(program))) {
-    const script = await readOwnedText(program);
-    actions = script && hasShellShebang(script) ? scriptActions(script) : [];
+  } else if (isShellScript && programScript !== undefined) {
+    actions = scriptActions(programScript);
   }
   return {
     label,

--- a/src/daemon/launchd-foreign-jobs.ts
+++ b/src/daemon/launchd-foreign-jobs.ts
@@ -246,6 +246,13 @@ async function inspectJob(
     .filter((line) => line.startsWith("\t\t"))
     .map((line) => line.slice(2));
   const environment = output.match(/^\tenvironment = \{\n([\s\S]*?)^\t\}/m)?.[1] ?? "";
+  // launchd also injects the `inherited environment` and `default environment`
+  // blocks into the process; a shell reads BASH_ENV/SHELLOPTS from any of them.
+  const environmentBlocks = [
+    ...output.matchAll(/^\t(?:inherited |default )?environment = \{\n([\s\S]*?)^\t\}/gm),
+  ]
+    .map((match) => match[1] ?? "")
+    .join("\n");
   const plist = plistPath ? await readOwnedText(plistPath) : undefined;
   const hasServiceMarker =
     /^\t\tOPENCLAW_SERVICE_MARKER => openclaw$/m.test(environment) &&
@@ -260,7 +267,7 @@ async function inspectJob(
   }
   let actions: GatewayAction[] = [];
   let diagnostic: string | undefined;
-  const shellEnvironmentDiagnostic = hasShellExecutionEnvironment(environment)
+  const shellEnvironmentDiagnostic = hasShellExecutionEnvironment(environmentBlocks)
     ? "Shell environment alters execution; left unchanged."
     : undefined;
   const command = args.length ? [program, ...args.slice(1)] : [program];

--- a/src/daemon/launchd-foreign-jobs.ts
+++ b/src/daemon/launchd-foreign-jobs.ts
@@ -3,7 +3,6 @@ import { constants } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
-import { hasTopLevelShellControlOperator, splitShellArgs } from "../utils/shell-argv.js";
 import { resolveGatewayLaunchAgentLabel, resolveNodeLaunchAgentLabel } from "./constants.js";
 import {
   execLaunchctl,
@@ -71,73 +70,59 @@ function lifecycleAction(args: string[]): GatewayAction | undefined {
     : undefined;
 }
 
-// Verify blank/comment lines, set -e/-u/-x/+e/+u/+x or -o pipefail, literal
-// openclaw_*/OPENCLAW_* assignments, then the first lifecycle call (optional
-// exec or resolved helper, no unresolved words). CR, heredocs, continuations,
-// control/substitution syntax and other preludes are report-only.
+const SCRIPT_HELPER_NAME = /(?:openclaw_|OPENCLAW_)[A-Za-z0-9_]*/;
+const SCRIPT_LITERAL_EXEC = String.raw`(?:openclaw(?:\.mjs)?|/(?:[A-Za-z0-9_.-]+/)*openclaw(?:\.mjs)?)`;
+const SCRIPT_HELPER_REF = String.raw`\$(?:${SCRIPT_HELPER_NAME.source}|\{${SCRIPT_HELPER_NAME.source}\})`;
+// JavaScript's $ can stop before a final Unicode separator; require the raw end.
+const SCRIPT_LINE_END = String.raw`$(?![\s\S])`;
+const SCRIPT_EXECUTABLE = new RegExp(`^${SCRIPT_LITERAL_EXEC}${SCRIPT_LINE_END}`);
+const SCRIPT_ASSIGNMENT = new RegExp(
+  String.raw`^[ \t]*(?:export[ \t]+)?(${SCRIPT_HELPER_NAME.source})=([A-Za-z0-9_./-]+)[ \t]*${SCRIPT_LINE_END}`,
+);
+const SCRIPT_INVOCATION = new RegExp(
+  String.raw`^[ \t]*(?:exec[ \t]+)?(${SCRIPT_LITERAL_EXEC}|${SCRIPT_HELPER_REF}|"${SCRIPT_HELPER_REF}")[ \t]+gateway[ \t]+(restart|start|stop)((?:[ \t]+[A-Za-z0-9_.=/:-]+)*)[ \t]*${SCRIPT_LINE_END}`,
+);
+
+// Match raw lines only: blank/comments, allowed set flags, unquoted literal
+// helper assignments, then the first lifecycle call (optional exec/helper).
+// Shell syntax is never dequoted or expanded; unmatched text is report-only.
 function scriptActions(script: string): GatewayAction[] {
-  if (
-    script.includes("\r") ||
-    script.includes("<<") ||
-    script.includes("\\\n") ||
-    /''|""/.test(script)
-  ) {
+  if (script.includes("\r") || script.includes("<<") || script.includes("\\\n")) {
     return [];
   }
   const variables = new Map<string, string>();
   for (const line of script.split("\n")) {
-    const words = splitShellArgs(line);
-    if (!words) {
-      return [];
-    }
-    if (!words.length) {
+    if (/^[ \t]*(?:#.*)?$(?![\s\S])/.test(line)) {
       continue;
     }
-    if (hasTopLevelShellControlOperator(line) || /`|\$\(/.test(line)) {
-      return [];
-    }
-    const safeSet =
-      words[0] === "set" &&
-      words.length > 1 &&
-      (words.slice(1).every((word) => ["-e", "-u", "-x", "+e", "+u", "+x"].includes(word)) ||
-        (words.length === 3 && words[1] === "-o" && words[2] === "pipefail"));
-    if (safeSet) {
+    if (
+      /^[ \t]*set(?:[ \t]+[+-][eux])+[ \t]*$(?![\s\S])/.test(line) ||
+      /^[ \t]*set[ \t]+-o[ \t]+pipefail[ \t]*$(?![\s\S])/.test(line)
+    ) {
       continue;
     }
-    const assignmentWords = words[0] === "export" ? words.slice(1) : words;
-    const assignment =
-      assignmentWords.length === 1
-        ? assignmentWords[0]?.match(/^((?:openclaw_|OPENCLAW_)[A-Za-z0-9_]*)=([A-Za-z0-9_./-]+)$/)
-        : null;
+    const assignment = SCRIPT_ASSIGNMENT.exec(line);
     if (assignment?.[1] && assignment[2]) {
       variables.set(assignment[1], assignment[2]);
       continue;
     }
-    const commandIndex = words[0] === "exec" ? 1 : 0;
-    const variable = words[commandIndex]?.match(
-      /^\$(?:([A-Za-z_][A-Za-z0-9_]*)|\{([A-Za-z_][A-Za-z0-9_]*)\})$/,
-    );
-    if (variable) {
-      // Only an explicit literal assignment proves an indirect CLI command.
-      const expandsCommand =
-        /^\s*(?:exec\s+)?"\$(?:[A-Za-z_][A-Za-z0-9_]*|\{[A-Za-z_][A-Za-z0-9_]*\})"\s/.test(line);
-      const name = variable[1] ?? variable[2];
-      words[commandIndex] = expandsCommand && name ? (variables.get(name) ?? "") : "";
-    }
-    if (words.some((word) => /[$`]/.test(word))) {
+    const invocation = SCRIPT_INVOCATION.exec(line);
+    const executable = invocation?.[1];
+    const action = invocation?.[2];
+    if (!executable || (action !== "restart" && action !== "start" && action !== "stop")) {
       return [];
     }
-    const command = words[0] === "exec" ? words.slice(1) : words;
-    const executable = command[0] ?? "";
-    const cliName = path.basename(executable);
-    if (
-      !["openclaw", "openclaw.mjs"].includes(cliName) ||
-      (executable !== cliName && !path.isAbsolute(executable))
-    ) {
+    if (!SCRIPT_EXECUTABLE.test(executable)) {
+      const name = executable.match(SCRIPT_HELPER_NAME)?.[0];
+      const resolved = name && variables.get(name);
+      if (!resolved || !SCRIPT_EXECUTABLE.test(resolved)) {
+        return [];
+      }
+    }
+    if (/(?:^|[ \t])(?:-h|--help|-V|--version)(?:[ \t]|$)/.test(invocation?.[3] ?? "")) {
       return [];
     }
-    const action = lifecycleAction(command);
-    return action ? [action] : [];
+    return [action];
   }
   return [];
 }

--- a/src/daemon/launchd-foreign-jobs.ts
+++ b/src/daemon/launchd-foreign-jobs.ts
@@ -71,41 +71,46 @@ function lifecycleAction(args: string[]): GatewayAction | undefined {
     : undefined;
 }
 
+// Verify blank/comment lines, set -e/-u/-x/+e/+u/+x or -o pipefail, literal
+// openclaw_*/OPENCLAW_* assignments, then the first lifecycle call (optional
+// exec or resolved helper, no unresolved words). CR, heredocs, continuations,
+// control/substitution syntax and other preludes are report-only.
 function scriptActions(script: string): GatewayAction[] {
-  // A diagnostic is not a shell interpreter. Never mistake heredoc/documentation
-  // contents or multiline quoted strings for executable command positions.
-  if (script.includes("<<") || script.includes("\\\n") || /''|""/.test(script)) {
+  if (
+    script.includes("\r") ||
+    script.includes("<<") ||
+    script.includes("\\\n") ||
+    /''|""/.test(script)
+  ) {
     return [];
   }
-  const lines = script.split(/\r?\n/);
-  const parsed = lines.map((line) => splitShellArgs(line));
-  if (parsed.some((words) => words === null)) {
-    return [];
-  }
-  const actions = new Set<GatewayAction>();
   const variables = new Map<string, string>();
-  for (const [i, line] of lines.entries()) {
-    const words = parsed[i] ?? [];
+  for (const line of script.split("\n")) {
+    const words = splitShellArgs(line);
+    if (!words) {
+      return [];
+    }
     if (!words.length) {
       continue;
     }
     if (hasTopLevelShellControlOperator(line) || /`|\$\(/.test(line)) {
-      break;
+      return [];
+    }
+    const safeSet =
+      words[0] === "set" &&
+      words.length > 1 &&
+      (words.slice(1).every((word) => ["-e", "-u", "-x", "+e", "+u", "+x"].includes(word)) ||
+        (words.length === 3 && words[1] === "-o" && words[2] === "pipefail"));
+    if (safeSet) {
+      continue;
     }
     const assignmentWords = words[0] === "export" ? words.slice(1) : words;
     const assignment =
-      assignmentWords.length === 1 && assignmentWords[0]?.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
-    if (assignment) {
-      const [, name, value] = assignment;
-      if (!name || value === undefined || /[`$]/.test(value)) {
-        break;
-      }
-      // Shell-special parameters do not obey ordinary assignment semantics.
-      // Resolve only literal OpenClaw helper variables.
-      variables.delete(name);
-      if (/^(?:openclaw_|OPENCLAW_)/.test(name) && /^[A-Za-z0-9_./-]+$/.test(value)) {
-        variables.set(name, value);
-      }
+      assignmentWords.length === 1
+        ? assignmentWords[0]?.match(/^((?:openclaw_|OPENCLAW_)[A-Za-z0-9_]*)=([A-Za-z0-9_./-]+)$/)
+        : null;
+    if (assignment?.[1] && assignment[2]) {
+      variables.set(assignment[1], assignment[2]);
       continue;
     }
     const commandIndex = words[0] === "exec" ? 1 : 0;
@@ -120,32 +125,21 @@ function scriptActions(script: string): GatewayAction[] {
       words[commandIndex] = expandsCommand && name ? (variables.get(name) ?? "") : "";
     }
     if (words.some((word) => /[$`]/.test(word))) {
-      break;
+      return [];
     }
-    const action = lifecycleAction(words[0] === "exec" ? words.slice(1) : words);
-    if (action) {
-      actions.add(action);
-      continue;
-    }
-    // Stop at unknown execution/control flow rather than treating unreachable
-    // function/conditional bodies or a reassigned command variable as evidence.
-    const safeSet =
-      words[0] === "set" &&
-      words.length > 1 &&
-      (words.slice(1).every((word) => /^[+-][eux]+$/.test(word)) ||
-        (words.length === 3 && words[1] === "-o" && words[2] === "pipefail"));
+    const command = words[0] === "exec" ? words.slice(1) : words;
+    const executable = command[0] ?? "";
+    const cliName = path.basename(executable);
     if (
-      !safeSet &&
-      !(
-        words[0] === "exec" &&
-        !line.includes("$") &&
-        words.slice(1).every((word) => /^\d*>/.test(word))
-      )
+      !["openclaw", "openclaw.mjs"].includes(cliName) ||
+      (executable !== cliName && !path.isAbsolute(executable))
     ) {
-      break;
+      return [];
     }
+    const action = lifecycleAction(command);
+    return action ? [action] : [];
   }
-  return [...actions].toSorted();
+  return [];
 }
 
 async function readShellScript(args: string[]): Promise<string | undefined> {

--- a/src/daemon/launchd-foreign-jobs.ts
+++ b/src/daemon/launchd-foreign-jobs.ts
@@ -1,0 +1,360 @@
+/** Live launchd diagnostics and narrowly scoped Doctor repair for auxiliary jobs. */
+import { constants } from "node:fs";
+import fs from "node:fs/promises";
+import path from "node:path";
+import { sanitizeForLog } from "../../packages/terminal-core/src/ansi.js";
+import { hasTopLevelShellControlOperator, splitShellArgs } from "../utils/shell-argv.js";
+import { resolveGatewayLaunchAgentLabel, resolveNodeLaunchAgentLabel } from "./constants.js";
+import {
+  execLaunchctl,
+  formatLaunchctlResultDetail,
+  isLaunchctlNotLoaded,
+} from "./launchd-exec.js";
+import { resolveLaunchAgentLabel } from "./launchd-label.js";
+import { resolveLaunchAgentGuiDomain } from "./launchd-runtime.js";
+
+type GatewayAction = "restart" | "start" | "stop";
+export type ForeignLaunchdJob = {
+  label: string;
+  program: string;
+  keepAlive: boolean;
+  gatewayActions: GatewayAction[];
+  safeToRemove: boolean;
+  plistPath?: string;
+  diagnostic?: string;
+};
+
+const MAX_JOBS = 64;
+const INSPECTION_TIMEOUT_MS = 2_000;
+const MAX_FILE_BYTES = 64 * 1024;
+const SHELLS = new Set(["sh", "bash", "zsh", "dash", "ksh"]);
+
+function isCandidate(label: string, env: NodeJS.ProcessEnv): boolean {
+  return (
+    /^ai\.openclaw\.[A-Za-z0-9._-]+$/.test(label) &&
+    !new Set([
+      resolveGatewayLaunchAgentLabel(),
+      resolveGatewayLaunchAgentLabel(env.OPENCLAW_PROFILE),
+      resolveLaunchAgentLabel(env),
+      resolveNodeLaunchAgentLabel(),
+    ]).has(label)
+  );
+}
+
+function lifecycleAction(args: string[]): GatewayAction | undefined {
+  if (args.some((arg) => ["--help", "-h", "--version", "-V"].includes(arg))) {
+    return undefined;
+  }
+  let words = args;
+  if (path.basename(words[0] ?? "") === "env") {
+    words = words.slice(1);
+    while (/^[A-Za-z_][A-Za-z0-9_]*=/.test(words[0] ?? "")) {
+      words = words.slice(1);
+    }
+  }
+  if (["node", "bun"].includes(path.basename(words[0] ?? ""))) {
+    words = words.slice(1);
+    if (path.basename(words[0] ?? "") !== "openclaw.mjs") {
+      return undefined;
+    }
+  }
+  if (!["openclaw", "openclaw.mjs"].includes(path.basename(words[0] ?? ""))) {
+    return undefined;
+  }
+  words = words.slice(1);
+  if (words[0] === "--profile" && words[1]) {
+    words = words.slice(2);
+  }
+  const action = words[1];
+  return words[0] === "gateway" && (action === "restart" || action === "start" || action === "stop")
+    ? action
+    : undefined;
+}
+
+function scriptActions(script: string): GatewayAction[] {
+  // A diagnostic is not a shell interpreter. Never mistake heredoc/documentation
+  // contents or multiline quoted strings for executable command positions.
+  if (script.includes("<<") || script.includes("\\\n") || /''|""/.test(script)) {
+    return [];
+  }
+  const lines = script.split(/\r?\n/);
+  const parsed = lines.map((line) => splitShellArgs(line));
+  if (parsed.some((words) => words === null)) {
+    return [];
+  }
+  const actions = new Set<GatewayAction>();
+  const variables = new Map<string, string>();
+  for (const [i, line] of lines.entries()) {
+    const words = parsed[i] ?? [];
+    if (!words.length) {
+      continue;
+    }
+    if (hasTopLevelShellControlOperator(line) || /`|\$\(/.test(line)) {
+      break;
+    }
+    const assignmentWords = words[0] === "export" ? words.slice(1) : words;
+    const assignment =
+      assignmentWords.length === 1 && assignmentWords[0]?.match(/^([A-Za-z_][A-Za-z0-9_]*)=(.*)$/);
+    if (assignment) {
+      const [, name, value] = assignment;
+      if (!name || value === undefined || /[`$]/.test(value)) {
+        break;
+      }
+      // Shell-special parameters do not obey ordinary assignment semantics.
+      // Resolve only literal OpenClaw helper variables.
+      variables.delete(name);
+      if (/^(?:openclaw_|OPENCLAW_)/.test(name) && /^[A-Za-z0-9_./-]+$/.test(value)) {
+        variables.set(name, value);
+      }
+      continue;
+    }
+    const commandIndex = words[0] === "exec" ? 1 : 0;
+    const variable = words[commandIndex]?.match(
+      /^\$(?:([A-Za-z_][A-Za-z0-9_]*)|\{([A-Za-z_][A-Za-z0-9_]*)\})$/,
+    );
+    if (variable) {
+      // Only an explicit literal assignment proves an indirect CLI command.
+      const expandsCommand =
+        /^\s*(?:exec\s+)?"\$(?:[A-Za-z_][A-Za-z0-9_]*|\{[A-Za-z_][A-Za-z0-9_]*\})"\s/.test(line);
+      const name = variable[1] ?? variable[2];
+      words[commandIndex] = expandsCommand && name ? (variables.get(name) ?? "") : "";
+    }
+    const action = lifecycleAction(words[0] === "exec" ? words.slice(1) : words);
+    if (action) {
+      actions.add(action);
+      continue;
+    }
+    // Stop at unknown execution/control flow rather than treating unreachable
+    // function/conditional bodies or a reassigned command variable as evidence.
+    const safeSet =
+      words[0] === "set" &&
+      words.length > 1 &&
+      (words.slice(1).every((word) => /^[+-][eux]+$/.test(word)) ||
+        (words.length === 3 && words[1] === "-o" && words[2] === "pipefail"));
+    if (
+      !safeSet &&
+      !(
+        words[0] === "exec" &&
+        !line.includes("$") &&
+        words.slice(1).every((word) => /^\d*>/.test(word))
+      )
+    ) {
+      break;
+    }
+  }
+  return [...actions].toSorted();
+}
+
+async function readShellScript(args: string[]): Promise<string | undefined> {
+  for (const [index, arg] of args.entries()) {
+    if (arg === "--") {
+      return await readOwnedText(args[index + 1] ?? "");
+    }
+    if (!arg.startsWith("-")) {
+      return await readOwnedText(arg);
+    }
+    // Recognize only executing options, and only before the command file.
+    // Everything after that file is positional data, even a literal '-c'.
+    if (/^-[elux]*c[elux]*$/.test(arg)) {
+      return args[index + 1];
+    }
+    if (!/^-[elux]+$/.test(arg)) {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+async function readOwnedText(filePath: string): Promise<string | undefined> {
+  if (!path.isAbsolute(filePath)) {
+    return undefined;
+  }
+  const file = await fs
+    .open(filePath, constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK)
+    .catch(() => null);
+  if (!file) {
+    return undefined;
+  }
+  try {
+    const stat = await file.stat();
+    if (!stat.isFile() || stat.size > MAX_FILE_BYTES || stat.uid !== process.getuid?.()) {
+      return undefined;
+    }
+    const buffer = Buffer.alloc(MAX_FILE_BYTES + 1);
+    const { bytesRead } = await file.read(buffer, 0, buffer.length, 0);
+    return bytesRead <= MAX_FILE_BYTES ? buffer.subarray(0, bytesRead).toString("utf8") : undefined;
+  } finally {
+    await file.close();
+  }
+}
+
+async function inspectJob(
+  label: string,
+  env: NodeJS.ProcessEnv,
+): Promise<ForeignLaunchdJob | null> {
+  if (!isCandidate(label, env)) {
+    return null;
+  }
+  const target = `${resolveLaunchAgentGuiDomain()}/${label}`;
+  const result = await execLaunchctl(["print", target], INSPECTION_TIMEOUT_MS);
+  if (isLaunchctlNotLoaded(result)) {
+    return null;
+  }
+  if (result.code !== 0) {
+    throw new Error(`Cannot inspect launchd job ${label}: ${formatLaunchctlResultDetail(result)}`);
+  }
+  const output = result.stdout;
+  if (!output.startsWith(`${target} = {\n`)) {
+    throw new Error(`Cannot parse launchd job ${label}`);
+  }
+  const field = (name: string) => output.match(new RegExp(`^\\t${name} = (.+)$`, "m"))?.[1];
+  const program = field("program") ?? "unknown";
+  const rawPath = field("path");
+  const plistPath = rawPath?.startsWith("/") ? rawPath : undefined;
+  const args = (output.match(/^\targuments = \{\n([\s\S]*?)^\t\}/m)?.[1] ?? "")
+    .split("\n")
+    .filter((line) => line.startsWith("\t\t"))
+    .map((line) => line.slice(2));
+  const environment = output.match(/^\tenvironment = \{\n([\s\S]*?)^\t\}/m)?.[1] ?? "";
+  const plist = plistPath ? await readOwnedText(plistPath) : undefined;
+  const hasServiceMarker =
+    /^\t\tOPENCLAW_SERVICE_MARKER => openclaw$/m.test(environment) &&
+    /^\t\tOPENCLAW_SERVICE_KIND => (gateway|node)$/m.test(environment);
+  const generatedWrapper = args.some((arg) => arg.endsWith(`/service-env/${label}-env-wrapper.sh`));
+  if (
+    hasServiceMarker ||
+    generatedWrapper ||
+    /<key>Comment<\/key>\s*<string>OpenClaw (Gateway|Node)\b/.test(plist ?? "")
+  ) {
+    return null;
+  }
+  let actions: GatewayAction[] = [];
+  let diagnostic: string | undefined;
+  const command = args.length ? [program, ...args.slice(1)] : [program];
+  const direct = lifecycleAction(command);
+  if (direct) {
+    actions = [direct];
+  } else if (SHELLS.has(path.basename(program))) {
+    const script = await readShellScript(command.slice(1));
+    actions = script ? scriptActions(script) : [];
+    diagnostic = actions.length
+      ? undefined
+      : "Shell command could not be verified; left unchanged.";
+  }
+  return {
+    label,
+    program: sanitizeForLog(program),
+    keepAlive: /(?:^|\s|\|)keepalive(?:\s|\||$)/.test(field("properties") ?? ""),
+    gatewayActions: actions,
+    safeToRemove: actions.length > 0 && (field("type") === "Submitted" || Boolean(plist)),
+    ...(plistPath ? { plistPath } : {}),
+    ...(diagnostic ? { diagnostic } : {}),
+  };
+}
+
+export async function findForeignLaunchdJobs(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<ForeignLaunchdJob[]> {
+  if (process.platform !== "darwin") {
+    return [];
+  }
+  const result = await execLaunchctl(["list"], INSPECTION_TIMEOUT_MS);
+  if (result.code !== 0) {
+    throw new Error(`Cannot list launchd jobs: ${formatLaunchctlResultDetail(result)}`);
+  }
+  const labels = [
+    ...new Set(
+      result.stdout.split(/\r?\n/).flatMap((line) => {
+        const label = line.trim().match(/^(?:-|\d+)\s+-?\d+\s+(\S+)$/)?.[1];
+        return label && isCandidate(label, env) ? [label] : [];
+      }),
+    ),
+  ].toSorted();
+  if (labels.length > MAX_JOBS) {
+    throw new Error(
+      `Too many OpenClaw launchd jobs to inspect safely (${labels.length}; limit ${MAX_JOBS}).`,
+    );
+  }
+  const jobs: ForeignLaunchdJob[] = [];
+  const deadline = Date.now() + 10_000;
+  for (const label of labels) {
+    if (Date.now() >= deadline) {
+      throw new Error("OpenClaw launchd job inspection exceeded its 10-second budget.");
+    }
+    const job = await inspectJob(label, env);
+    if (job) {
+      jobs.push(job);
+    }
+  }
+  return jobs;
+}
+
+export function formatForeignLaunchdJobs(jobs: ForeignLaunchdJob[]): string {
+  return jobs
+    .map((job) =>
+      [
+        `${job.label}: program=${job.program}, keepalive=${job.keepAlive}, Gateway lifecycle=${job.gatewayActions.join("|") || "not verified"}`,
+        job.safeToRemove
+          ? "  Removable with openclaw doctor --fix."
+          : "  Report only; left unchanged.",
+        ...(job.diagnostic ? [`  ${job.diagnostic}`] : []),
+      ].join("\n"),
+    )
+    .join("\n");
+}
+
+export async function repairForeignLaunchdJob(
+  job: ForeignLaunchdJob,
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<{ removed: boolean; detail: string }> {
+  if (process.platform !== "darwin" || !isCandidate(job.label, env)) {
+    return { removed: false, detail: "Protected or unrelated launchd label; left unchanged." };
+  }
+  // Fresh native inspection, not a caller-supplied removal flag, owns authority.
+  const current = await inspectJob(job.label, env);
+  if (!current?.safeToRemove) {
+    return {
+      removed: false,
+      detail: "Gateway lifecycle command no longer verified; left unchanged.",
+    };
+  }
+  const target = `${resolveLaunchAgentGuiDomain()}/${current.label}`;
+  if (current.plistPath) {
+    // Keep operator files intact, but prevent a plist-backed job returning at login.
+    const disabled = await execLaunchctl(["disable", target], INSPECTION_TIMEOUT_MS);
+    if (disabled.code !== 0) {
+      return {
+        removed: false,
+        detail: `Could not disable ${current.label}: ${formatLaunchctlResultDetail(disabled)}`,
+      };
+    }
+    const refreshed = await inspectJob(current.label, env);
+    if (
+      !refreshed?.safeToRemove ||
+      refreshed.program !== current.program ||
+      refreshed.plistPath !== current.plistPath
+    ) {
+      return {
+        removed: false,
+        detail: `Disabled ${current.label}, but its definition changed before removal; inspect it manually.`,
+      };
+    }
+  }
+  const removed = await execLaunchctl(["bootout", target], INSPECTION_TIMEOUT_MS);
+  if (removed.code !== 0 && !isLaunchctlNotLoaded(removed)) {
+    return {
+      removed: false,
+      detail: `Could not remove ${current.label}: ${formatLaunchctlResultDetail(removed)}`,
+    };
+  }
+  const probe = await execLaunchctl(["print", target], INSPECTION_TIMEOUT_MS);
+  return isLaunchctlNotLoaded(probe)
+    ? {
+        removed: true,
+        detail: `Removed stray launchd job ${current.label} (${current.program}; Gateway ${current.gatewayActions.join("/")}).${current.plistPath ? " Disabled at login; plist retained." : ""}`,
+      }
+    : {
+        removed: false,
+        detail: `Removal of ${current.label} could not be confirmed; inspect launchctl print ${target}.`,
+      };
+}

--- a/src/daemon/launchd-foreign-jobs.ts
+++ b/src/daemon/launchd-foreign-jobs.ts
@@ -119,6 +119,9 @@ function scriptActions(script: string): GatewayAction[] {
       const name = variable[1] ?? variable[2];
       words[commandIndex] = expandsCommand && name ? (variables.get(name) ?? "") : "";
     }
+    if (words.some((word) => /[$`]/.test(word))) {
+      break;
+    }
     const action = lifecycleAction(words[0] === "exec" ? words.slice(1) : words);
     if (action) {
       actions.add(action);
@@ -163,6 +166,23 @@ async function readShellScript(args: string[]): Promise<string | undefined> {
     }
   }
   return undefined;
+}
+
+function hasShellShebang(script: string): boolean {
+  const firstLine = script.split(/\r?\n/, 1)[0] ?? "";
+  if (!firstLine.startsWith("#!")) {
+    return false;
+  }
+  const [interpreter = "", ...options] = firstLine.slice(2).trim().split(/\s+/);
+  if (interpreter === "/usr/bin/env") {
+    return options.length === 1 && SHELLS.has(options[0] ?? "");
+  }
+  // Preserve the same executing-option boundary as explicit shell launches.
+  return (
+    path.isAbsolute(interpreter) &&
+    SHELLS.has(path.basename(interpreter)) &&
+    (options.length === 0 || (options.length === 1 && /^-[elux]+$/.test(options[0] ?? "")))
+  );
 }
 
 async function readOwnedText(filePath: string): Promise<string | undefined> {
@@ -240,6 +260,9 @@ async function inspectJob(
     diagnostic = actions.length
       ? undefined
       : "Shell command could not be verified; left unchanged.";
+  } else if (!["openclaw", "openclaw.mjs", "node", "bun", "env"].includes(path.basename(program))) {
+    const script = await readOwnedText(program);
+    actions = script && hasShellShebang(script) ? scriptActions(script) : [];
   }
   return {
     label,

--- a/src/daemon/restart-storm.test.ts
+++ b/src/daemon/restart-storm.test.ts
@@ -1,0 +1,187 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { appendGatewayLifecycleAuditLog, resolveGatewayRestartLogPath } from "./restart-logs.js";
+import { readGatewayForcedRestartSummary, warnAboutGatewayRestartStorm } from "./restart-storm.js";
+
+const { findForeignLaunchdJobs } = vi.hoisted(() => ({
+  findForeignLaunchdJobs: vi.fn(async () => [
+    {
+      label: "ai.openclaw.test.storm",
+      program: "/tmp/synthetic-updater.sh",
+      keepAlive: true,
+      gatewayActions: ["restart"],
+      safeToRemove: true,
+    },
+  ]),
+}));
+
+vi.mock("./launchd-foreign-jobs.js", () => ({ findForeignLaunchdJobs }));
+
+describe("managed Gateway external restart storm diagnostics", () => {
+  let stateDir: string;
+  let env: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "openclaw-restart-storm-"));
+    env = { OPENCLAW_STATE_DIR: stateDir };
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-09-01T12:00:00.000Z"));
+    findForeignLaunchdJobs.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    fs.rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  function restart() {
+    appendGatewayLifecycleAuditLog(env, {
+      source: "cli",
+      action: "restart",
+      mode: "kickstart",
+      interactive: false,
+    });
+  }
+
+  function record(fields: string, ageMs = 0) {
+    const logPath = resolveGatewayRestartLogPath(env);
+    fs.mkdirSync(path.dirname(logPath), { recursive: true });
+    fs.appendFileSync(
+      logPath,
+      `[${new Date(Date.now() - ageMs).toISOString()}] openclaw gateway lifecycle ${fields}\n`,
+    );
+  }
+
+  it("warns at the third external restart, names the likely job, and deduplicates across startup calls", async () => {
+    const firstStartup = vi.fn();
+    restart();
+    restart();
+    await warnAboutGatewayRestartStorm(env, firstStartup);
+    expect(firstStartup).not.toHaveBeenCalled();
+    expect(findForeignLaunchdJobs).not.toHaveBeenCalled();
+
+    restart();
+    await warnAboutGatewayRestartStorm(env, firstStartup);
+    expect(firstStartup).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining("3 external CLI restarts in 10 minutes"),
+    );
+    expect(firstStartup.mock.calls[0]?.[0]).toContain("ai.openclaw.test.storm");
+    expect(firstStartup.mock.calls[0]?.[0]).toContain("openclaw doctor --fix");
+
+    const nextStartup = vi.fn();
+    restart();
+    await warnAboutGatewayRestartStorm(env, nextStartup);
+    expect(nextStartup).not.toHaveBeenCalled();
+    expect(findForeignLaunchdJobs).toHaveBeenCalledTimes(1);
+    expect(fs.readFileSync(resolveGatewayRestartLogPath(env), "utf8")).toContain(
+      "restart-storm warning Gateway restart storm:",
+    );
+  });
+
+  it("counts only disruptive external CLI restart steps, not safe, internal, or activation events", () => {
+    for (const fields of [
+      "source=safe-rpc action=restart mode=deferred",
+      "source=safe-rpc action=restart mode=rpc",
+      "source=supervisor action=restart mode=sigusr1",
+      "source=handoff action=restart mode=kickstart",
+      "source=cli action=restart mode=handoff-kickstart",
+      "source=cli action=restart mode=handoff-reload",
+      "source=cli action=start mode=kickstart",
+      "source=cli action=stop mode=bootout",
+      "source=cli action=restart mode=enable",
+      "source=cli action=restart mode=bootout",
+      "source=cli action=restart mode=bootstrap",
+    ]) {
+      record(fields);
+    }
+    restart();
+    expect(readGatewayForcedRestartSummary(env)).toEqual({
+      count: 2,
+      windowMs: 600_000,
+      lastRestartAt: "2026-09-01T12:00:00.000Z",
+    });
+  });
+
+  it("expires old restarts and warnings and ignores malformed and future records", async () => {
+    restart();
+    restart();
+    restart();
+    await warnAboutGatewayRestartStorm(env, vi.fn());
+    vi.setSystemTime(new Date("2026-09-01T12:10:00.001Z"));
+    record("source=cli action=restart mode=kickstart", -60_000);
+    fs.appendFileSync(
+      resolveGatewayRestartLogPath(env),
+      "[invalid] openclaw gateway lifecycle source=cli action=restart mode=kickstart\n",
+    );
+    expect(readGatewayForcedRestartSummary(env).count).toBe(0);
+
+    restart();
+    restart();
+    restart();
+    const warn = vi.fn();
+    await warnAboutGatewayRestartStorm(env, warn);
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it("bounds history reads even when the restart log has a large handoff transcript", async () => {
+    restart();
+    restart();
+    restart();
+    fs.appendFileSync(resolveGatewayRestartLogPath(env), `${"x".repeat(256 * 1024)}\n`);
+    restart();
+    restart();
+    const warn = vi.fn();
+    await warnAboutGatewayRestartStorm(env, warn);
+    expect(readGatewayForcedRestartSummary(env).count).toBe(2);
+    expect(warn).not.toHaveBeenCalled();
+    expect(findForeignLaunchdJobs).not.toHaveBeenCalled();
+  });
+
+  it("does not block startup when history is absent or job inspection fails", async () => {
+    const warn = vi.fn();
+    await warnAboutGatewayRestartStorm(env, warn);
+    expect(warn).not.toHaveBeenCalled();
+    restart();
+    restart();
+    restart();
+    findForeignLaunchdJobs.mockRejectedValueOnce(new Error("launchd unavailable"));
+    await warnAboutGatewayRestartStorm(env, warn);
+    expect(warn).toHaveBeenCalledExactlyOnceWith(
+      expect.stringContaining("Check for a stray keepalive launchd job"),
+    );
+  });
+
+  it("does not name protected, unrelated, or non-keepalive jobs as the likely cause", async () => {
+    restart();
+    restart();
+    restart();
+    findForeignLaunchdJobs.mockResolvedValueOnce([
+      {
+        label: "ai.openclaw.gateway",
+        program: "/tmp/gateway",
+        keepAlive: true,
+        gatewayActions: ["restart"],
+        safeToRemove: false,
+      },
+      {
+        label: "ai.openclaw.test.observer",
+        program: "/tmp/observer",
+        keepAlive: true,
+        gatewayActions: [],
+        safeToRemove: false,
+      },
+      {
+        label: "ai.openclaw.test.once",
+        program: "/tmp/once",
+        keepAlive: false,
+        gatewayActions: ["restart"],
+        safeToRemove: true,
+      },
+    ]);
+    const warn = vi.fn();
+    await warnAboutGatewayRestartStorm(env, warn);
+    expect(warn.mock.calls[0]?.[0]).not.toContain("ai.openclaw.");
+  });
+});

--- a/src/daemon/restart-storm.ts
+++ b/src/daemon/restart-storm.ts
@@ -1,0 +1,117 @@
+/** Detect repeated external CLI restarts across Gateway process lifetimes. */
+import fs from "node:fs";
+import { resolveGatewayRestartLogPath } from "./restart-logs.js";
+import type { GatewayServiceEnv } from "./service-types.js";
+
+const RESTART_WINDOW_MS = 10 * 60 * 1000;
+const RESTART_THRESHOLD = 3;
+const MAX_HISTORY_BYTES = 128 * 1024;
+const WARNING_PREFIX = "openclaw gateway restart-storm warning ";
+
+export type GatewayForcedRestartSummary = {
+  count: number;
+  windowMs: number;
+  lastRestartAt?: string;
+  lastWarningAt?: string;
+};
+
+export function readGatewayForcedRestartSummary(
+  env: GatewayServiceEnv,
+): GatewayForcedRestartSummary {
+  const summary: GatewayForcedRestartSummary = { count: 0, windowMs: RESTART_WINDOW_MS };
+  let fd: number | undefined;
+  try {
+    fd = fs.openSync(
+      resolveGatewayRestartLogPath(env),
+      fs.constants.O_RDONLY | fs.constants.O_NONBLOCK | fs.constants.O_NOFOLLOW,
+    );
+    const stat = fs.fstatSync(fd);
+    if (!stat.isFile()) {
+      return summary;
+    }
+    const size = stat.size;
+    const offset = Math.max(0, size - MAX_HISTORY_BYTES);
+    const buffer = Buffer.alloc(Math.min(size, MAX_HISTORY_BYTES));
+    const length = fs.readSync(fd, buffer, 0, buffer.length, offset);
+    let tail = buffer.toString("utf8", 0, length);
+    if (offset > 0) {
+      const newline = tail.indexOf("\n");
+      tail = newline < 0 ? "" : tail.slice(newline + 1);
+    }
+    const now = Date.now();
+    for (const line of tail.split("\n")) {
+      const [, timestampText, body] = /^\[([^\]]+)\] (.*)$/.exec(line) ?? [];
+      if (!timestampText || body === undefined) {
+        continue;
+      }
+      const timestamp = Date.parse(timestampText);
+      if (!Number.isFinite(timestamp) || timestamp <= now - RESTART_WINDOW_MS || timestamp > now) {
+        continue;
+      }
+      const at = new Date(timestamp).toISOString();
+      if (body.startsWith(WARNING_PREFIX)) {
+        if (!summary.lastWarningAt || at > summary.lastWarningAt) {
+          summary.lastWarningAt = at;
+        }
+      } else if (
+        /^openclaw gateway lifecycle source=cli action=restart mode=(?:kickstart|bootout)(?: |$)/.test(
+          body,
+        )
+      ) {
+        // Reloads record bootout then bootstrap; count only the disruptive step.
+        // Safe RPC and managed-tree handoffs have distinct source/mode fields.
+        summary.count += 1;
+        if (!summary.lastRestartAt || at > summary.lastRestartAt) {
+          summary.lastRestartAt = at;
+        }
+      }
+    }
+  } catch {
+    // Missing or unreadable diagnostic history must not prevent Gateway startup.
+  } finally {
+    if (fd !== undefined) {
+      fs.closeSync(fd);
+    }
+  }
+  return summary;
+}
+
+/** Emit once per window, retaining the warning in the existing restart log. */
+export async function warnAboutGatewayRestartStorm(
+  env: GatewayServiceEnv,
+  warn: (message: string) => void,
+): Promise<void> {
+  let summary = readGatewayForcedRestartSummary(env);
+  if (summary.count < RESTART_THRESHOLD || summary.lastWarningAt) {
+    return;
+  }
+  const { findForeignLaunchdJobs } = await import("./launchd-foreign-jobs.js");
+  const jobs = await findForeignLaunchdJobs(env).catch(() => []);
+  // Inspection yields; a concurrent startup may already have reported this storm.
+  summary = readGatewayForcedRestartSummary(env);
+  if (summary.count < RESTART_THRESHOLD || summary.lastWarningAt) {
+    return;
+  }
+  const likelyJobs = jobs
+    .filter((job) => job.keepAlive && job.safeToRemove && job.gatewayActions.includes("restart"))
+    .map((job) => job.label)
+    .toSorted()
+    .slice(0, 5);
+  const message = [
+    `Gateway restart storm: ${summary.count} external CLI restarts in 10 minutes.`,
+    likelyJobs.length > 0
+      ? `Likely stray launchd jobs: ${likelyJobs.join(", ")}.`
+      : "Check for a stray keepalive launchd job invoking openclaw gateway restart.",
+    "Run openclaw gateway status to inspect jobs and openclaw doctor --fix to remove eligible stray jobs.",
+  ].join(" ");
+  try {
+    fs.appendFileSync(
+      resolveGatewayRestartLogPath(env),
+      `[${new Date().toISOString()}] ${WARNING_PREFIX}${message}\n`,
+      "utf8",
+    );
+  } catch {
+    // Still surface the warning when the diagnostic log cannot be written.
+  }
+  warn(message);
+}

--- a/src/flows/doctor-health-contribution-runners.gateway.ts
+++ b/src/flows/doctor-health-contribution-runners.gateway.ts
@@ -24,6 +24,8 @@ export async function runGatewayServicesHealth(ctx: DoctorHealthFlowContext): Pr
   if (ctx.gatewayMaintenanceActive) {
     return;
   }
+  const { noteMacForeignLaunchdJobs } = await import("../commands/doctor-foreign-launchd-jobs.js");
+  await noteMacForeignLaunchdJobs(ctx.options, ctx.runtime, ctx.env ?? process.env);
   if (!isDefaultInstallIdentity(ctx.env ?? process.env)) {
     note(NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON, "Gateway");
     return;

--- a/src/flows/doctor-health-contribution-runners.gateway.ts
+++ b/src/flows/doctor-health-contribution-runners.gateway.ts
@@ -21,11 +21,12 @@ export async function runClaudeCliHealth(ctx: DoctorHealthFlowContext): Promise<
 }
 
 export async function runGatewayServicesHealth(ctx: DoctorHealthFlowContext): Promise<void> {
+  // Stray jobs can disrupt admitted maintenance; managed-service repair stays below the fence.
+  const { noteMacForeignLaunchdJobs } = await import("../commands/doctor-foreign-launchd-jobs.js");
+  await noteMacForeignLaunchdJobs(ctx.options, ctx.runtime, ctx.env ?? process.env);
   if (ctx.gatewayMaintenanceActive) {
     return;
   }
-  const { noteMacForeignLaunchdJobs } = await import("../commands/doctor-foreign-launchd-jobs.js");
-  await noteMacForeignLaunchdJobs(ctx.options, ctx.runtime, ctx.env ?? process.env);
   if (!isDefaultInstallIdentity(ctx.env ?? process.env)) {
     note(NON_DEFAULT_INSTALL_SERVICE_SKIP_REASON, "Gateway");
     return;

--- a/src/flows/doctor-health-contributions.test.ts
+++ b/src/flows/doctor-health-contributions.test.ts
@@ -398,6 +398,10 @@ vi.mock("../commands/doctor-platform-notes.js", () => ({
   noteMacStaleOpenClawUpdateLaunchdJobs: mocks.noteMacStaleOpenClawUpdateLaunchdJobs,
 }));
 
+vi.mock("../commands/doctor-foreign-launchd-jobs.js", () => ({
+  noteMacForeignLaunchdJobs: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("../gateway/credentials-secret-inputs.js", async (importOriginal) => {
   const actual = await importOriginal<typeof import("../gateway/credentials-secret-inputs.js")>();
   return {


### PR DESCRIPTION
Related: #114967 (kept open)

## What Problem This Solves

Agent-created launchd jobs could repeatedly invoke Gateway lifecycle commands after an update while remaining invisible to normal Gateway status and Doctor. Submitted jobs can have inferred KeepAlive behavior without any plist, so the existing stale-updater label/plist scanner missed the reported validator and upgrade labels.

## Why This Change Was Made

The launchd owner now inspects live OpenClaw-namespace job definitions and reports program, KeepAlive, and verified Gateway lifecycle commands. Normal status includes structured JSON diagnostics. Doctor requires explicit `--fix`, re-inspects the current command, and removes only eligible foreign lifecycle jobs; managed labels, generated services, unrelated labels, and ambiguous scripts are preserved. Plist-backed stray jobs are disabled at login and booted out, with their files retained.

The managed Gateway warns after three external CLI forced restarts in ten minutes, naming likely KeepAlive jobs when available. Its existing lifecycle log supplies the bounded history and warning deduplication, with no new configuration or store. The live-updater skill explicitly forbids `launchctl submit` and auxiliary KeepAlive watchdogs and requires its deterministic suspension-fenced update, status, and health flow.

## User Impact

Operators can discover and repair confirmed stray restart jobs through status and Doctor, with explicit noninteractive removal results. The warning preserves operator restart commands. Complex/unverifiable wrappers and jobs outside `ai.openclaw.*` remain outside automatic repair; updater-only commands are reported but not removed by this lifecycle repair.

## Evidence

Validation for `ac88f920a1d19548dc819c65a6c52c318256d603` (final shell-environment and absolute-path follow-up to `57ca23a2c9a`):

- Shell jobs with the specified execution-altering environment names or any `BASH_*` name remain report-only with `Shell environment alters execution; left unchanged.` Inspection reads names only. Direct non-shell programs and PATH/HOME/OPENCLAW-only environments remain unaffected.
- Scripts and direct argv require absolute OpenClaw executable paths, including helper values and accepted `env`/`node`/`bun` chains. The closed raw-line grammar remains intact. The source comment and macOS guide document the metadata-only boundary; no binary executability, quarantine, or interpreter-availability probes were added.
- P2 review exposed two guard-ordering bypasses involving shell launchers with CLI/runtime basenames and executables selected through `env`; both were reproduced and fixed. A concrete `PS4`/xtrace non-execution case was also reproduced in isolated macOS Bash/sh child processes and added to the same environment guard. The final review's request to block `HOME` for zsh was rejected because the accepted contract explicitly preserves HOME-only environments. No accepted finding remains.
- 119 focused tests passed: 106 classifier/repair cases, two native macOS process cases, and 11 Doctor tests. Regressions demonstrated failures before each accepted repair and passed afterward. Command: `pnpm test src/daemon/launchd-foreign-jobs.test.ts src/daemon/launchd-foreign-jobs.process.test.ts src/commands/doctor-foreign-launchd-jobs.test.ts`.
- Native scratch proof passed for interpreter-launched and directly submitted scripts through the maintenance-owned Doctor runner with isolated policy/history. Detection and the report preserved the jobs; explicit repair removed only the lifecycle scratch job. Managed and observer scratch jobs remained loaded until cleanup. All scratch jobs were removed; the real Gateway and LaunchAgents were untouched.
- `pnpm check:changed`: passed on the final patch, including formatting, typechecks, lint, export scans, and repository guards.
- `git diff --check`: passed. Follow-up diff: three files, 195 insertions and 20 deletions.
- Exact-head CI watch: [run 34249182120](https://github.com/openclaw/openclaw/actions/runs/34249182120) is **queued** on this head. The 180-second bounded watch ended with `TIMEOUT state=PENDING pending=106`; the fresh run read has no conclusion yet. CI is not yet green.


Lead follow-up `bacabd4fb7bcfe324f1cff05919d6c7f1fc9c9e7` (inherited launchd environment):

- A fifth independent P2 review found that the environment guard scanned only the job-specific `environment` block, while `launchctl print` also reports `inherited environment` and `default environment` blocks that reach the shell. The guard now scans all three (names only). Three new classifier cases (inline, script, and direct launches with `BASH_ENV` in an inherited or default block) fail with the guard reverted and pass with it; 106 classifier/repair tests pass, `pnpm check:changed` and `git diff --check` passed. A sixth independent P2 review of this head is scoped-clean under the documented contract.
