### PR TITLE
fix(ui): preserve code blocks and paragraphs in reasoning

### DIFF
--- a/docs/tools/thinking.md
+++ b/docs/tools/thinking.md
@@ -115,6 +115,7 @@ title: "Thinking levels"
 - When enabled, reasoning is sent as a **separate message** prefixed with `Thinking`.
 - `stream`: streams reasoning while the reply is generating when the active channel supports reasoning previews, then sends the final answer without reasoning. Channel previews remove recognized internal runtime context before delivery; the original reasoning remains unchanged for model replay.
 - Control UI history shows saved reasoning only for `on`, with **View → Reasoning** enabled. `off` and `stream` keep it hidden, including after reload.
+- Visible Control UI reasoning preserves Markdown paragraphs and fenced code blocks, including blank lines inside code.
 - Alias: `/reason`.
 - Send `/reasoning` (or `/reasoning:`) with no argument to see the current reasoning level.
 - Resolution order: inline directive, then session override, then per-agent default (`agents.entries.*.reasoningDefault`), then global default (`agents.defaults.reasoningDefault`), then fallback (`off`).

--- a/ui/src/e2e/chat-reasoning-visibility.e2e.test.ts
+++ b/ui/src/e2e/chat-reasoning-visibility.e2e.test.ts
@@ -22,6 +22,8 @@ suite.define(() => {
       const page = await context.newPage();
       const sessionKey = "agent:main:dashboard:reasoning-visibility";
       const reasoningText = "Compare the evidence before answering.";
+      const code = 'const label = "*literal*";\n\nconsole.log(label);\n';
+      const conclusion = "Compare both outputs.";
       const finalText = "The answer is ready.";
       const gateway = await installMockGateway(page, {
         sessionKey,
@@ -31,7 +33,12 @@ suite.define(() => {
           { role: "user", content: "Check the evidence.", timestamp: 1_000 },
           {
             role: "assistant",
-            content: [{ type: "thinking", thinking: reasoningText }],
+            content: [
+              {
+                type: "thinking",
+                thinking: `${reasoningText}\n\n\`\`\`ts\n${code}\`\`\`\n\n${conclusion}`,
+              },
+            ],
             timestamp: 2_000,
           },
           ...(withTools
@@ -75,6 +82,14 @@ suite.define(() => {
         await worked.click();
         await expect.poll(() => worked.getAttribute("aria-expanded")).toBe("true");
         await expect.poll(() => reasoning.isVisible()).toBe(reasoningLevel === "on");
+        if (reasoningLevel === "on") {
+          expect(await reasoning.locator("pre code").allTextContents()).toEqual([code]);
+          expect(await reasoning.locator("p").allTextContents()).toEqual([
+            "Reasoning:",
+            reasoningText,
+            conclusion,
+          ]);
+        }
         expect(await answer.isVisible()).toBe(true);
       }
 

--- a/ui/src/lib/chat/message-extract.ts
+++ b/ui/src/lib/chat/message-extract.ts
@@ -157,19 +157,6 @@ export function readTranscriptMediaEntries(message: unknown): Array<{
   });
 }
 
-export function formatReasoningMarkdown(text: string): string {
-  const trimmed = text.trim();
-  if (!trimmed) {
-    return "";
-  }
-  const lines = trimmed
-    .split(/\r?\n/)
-    .map((line) => line.trim())
-    .filter(Boolean)
-    .map((line) => `_${line}_`);
-  return lines.length ? ["_Reasoning:_", ...lines].join("\n") : "";
-}
-
 function isTextOnlyContent(content: unknown): boolean {
   if (typeof content === "string") {
     return true;

--- a/ui/src/pages/chat/components/chat-message-bubble.ts
+++ b/ui/src/pages/chat/components/chat-message-bubble.ts
@@ -15,10 +15,7 @@ import type {
   NormalizedMessage,
   ToolCard,
 } from "../../../lib/chat/chat-types.ts";
-import {
-  extractThinkingCached,
-  formatReasoningMarkdown,
-} from "../../../lib/chat/message-extract.ts";
+import { extractThinkingCached } from "../../../lib/chat/message-extract.ts";
 import {
   isStandaloneToolMessageForDisplay,
   normalizeMessage,
@@ -302,7 +299,7 @@ export function renderGroupedMessage(
   );
   const extractedThinking =
     opts.showReasoning && role === "assistant" ? extractThinkingCached(message) : null;
-  const reasoningMarkdown = extractedThinking ? formatReasoningMarkdown(extractedThinking) : null;
+  const reasoningMarkdown = extractedThinking ? `_Reasoning:_\n\n${extractedThinking}` : null;
   const markdown =
     (normalizedRole === "user" ? opts.messageActions?.markdown : undefined) ??
     (displayMarkdown || null);


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users viewing saved reasoning in Control UI saw fenced examples flattened into inline text with stray underscores, and separate paragraphs collapsed together.

## Why This Change Was Made

The canonical sanitized Markdown renderer now owns reasoning Markdown. Removing the per-line formatter preserves the authored body while retaining the existing “Reasoning:” label and work disclosure. This deletes 16 production lines; extraction and reasoning visibility settings are unchanged.

## User Impact

Reasoning displays readable paragraphs and fenced code blocks, preserving literal characters and blank lines inside code. The existing on/off/stream visibility rules and local View → Reasoning toggle continue to apply after reload.

Release note: Fix Control UI reasoning flattening Markdown paragraphs and corrupting fenced code examples.

## Evidence

- Actual built Control UI in Chromium with a synthetic Gateway fixture: before the fix, both reasoning-on cases failed because no code block rendered; the four hidden-reasoning cases passed. After the fix, all six cases passed, covering exact code bytes, blank lines, separate paragraphs, work disclosure, reload, local visibility toggling, and tool-containing turns.
- 261 focused tests passed across message extraction, thread grouping, and message rendering.
- Full changed-file gate passed, including formatting, typechecks, i18n, declaration/export guards, and lint. Production net −16 lines; tests +15; docs +1.
- Managed P2 review: scoped-clean, no actionable findings. Reviewed source hashes were verified unchanged after commit.

Commands:

```sh
node scripts/run-vitest.mjs run --config test/vitest/vitest.ui-e2e.config.ts --configLoader runner ui/src/e2e/chat-reasoning-visibility.e2e.test.ts
node scripts/run-vitest.mjs ui/src/lib/chat/message-extract.test.ts ui/src/pages/chat/chat-thread-grouping.test.ts ui/src/pages/chat/components/chat-message.test.ts
node scripts/check-changed.mjs -- ui/src/lib/chat/message-extract.ts ui/src/pages/chat/components/chat-message-bubble.ts ui/src/e2e/chat-reasoning-visibility.e2e.test.ts docs/tools/thinking.md
```

The screenshots below were inspected and contain only synthetic test data. This verifies the real UI flow with mocked Gateway responses; no live provider, operator Gateway, or operator clipboard was used. Temporary screenshot capture statements were removed after the green browser run; the fixture and regression assertions remain unchanged.

Before:

![Reasoning before: fenced code flattened into an inline span with stray underscores](https://github.com/user-attachments/assets/18536ba8-1411-4a91-9eb6-02857b280534)

After:

![Reasoning after: separate paragraphs and a code block preserving literal text and a blank line](https://github.com/user-attachments/assets/a4b7101e-0529-49d0-a8fb-f9ecf6c39762)
