### PR TITLE
chore(release): update appcast for 2026.9.3

### DIFF
--- a/appcast.xml
+++ b/appcast.xml
@@ -3,6 +3,2082 @@
     <channel>
         <title>OpenClaw</title>
         <item>
+            <title>2026.9.3</title>
+            <pubDate>Tue, 08 Sep 2026 04:35:03 +0000</pubDate>
+            <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
+            <sparkle:version>2609000390</sparkle:version>
+            <sparkle:shortVersionString>2026.9.3</sparkle:shortVersionString>
+            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+            <description><![CDATA[<h2>OpenClaw 2026.9.3</h2>
+<h3>Highlights</h3>
+<ul>
+<li><strong>Safer updates:</strong> rehearse core and plugin changes in isolated candidate state before activation, support eligible 2026.9.2 migrations, and recover abandoned update records without stopping a healthy matching Gateway. Related #136997. (#138839, #141109, #141175, #141562)</li>
+<li><strong>Performance:</strong> preserve warm prompt caches, reduce unnecessary work during cold session updates and memory search, and reuse worker builds between sessions. Related #140681. (#140449, #140730, #140799, #140840, #141141) Thanks @justinkirklin-gif, @NianJiuZst, and @obviyus.</li>
+<li><strong>Skill Workshop:</strong> keep skills in one persistent agent-owned collection across workspaces, compare complete skill instructions, and retire missing-draft suggestions safely through Doctor. Related #135291. (#135528, #139248, #140300, #141009) Thanks @khaisis and @obviyus.</li>
+<li><strong>Browser tabs, live and native:</strong> watch agent pages repaint and open external links in native Mac tabs that remain with their window across chat switches. (#140988, #141031)</li>
+<li><strong>Your provider accounts, together:</strong> manage connected accounts and supported account priority directly in Models settings. (#132451) Thanks @jesse-merhi.</li>
+<li><strong>Share selected conversations:</strong> explicitly publish a revocable read-only view of a session’s existing and future conversation text, accessible to anyone with its public link. (#139489)</li>
+<li><strong>A searchable meeting library:</strong> browse saved notes, search full transcripts, download complete Markdown or JSONL archives, and manage capture sources from the Control UI. (#139875, #140084)</li>
+<li><strong>Optional team activity reports:</strong> install and enable Team Reports to browse authenticated GitHub activity and explicitly configured Discord discussion, with stored history and optional model summaries. (#139850, #141327)</li>
+</ul>
+<h3>Changes</h3>
+<ul>
+<li><strong>Breaking — Node runtime:</strong> require Node 24.16.0 or newer on 24.x, or Node 26.1.0 or newer; Node 26 is recommended. Upgrade Node before OpenClaw to prevent SQLite text truncation: Node 22, Node 25, and earlier 24.x/26.x builds are no longer supported. Node-based CLI/Gateway installs on macOS 11–13.4 or official Linux ARMv7 provisioning need a supported host; see <a href="https://docs.openclaw.ai/install/node">Node requirements</a>. (#140672)</li>
+<li><strong>Breaking — execution-policy SDK:</strong> move the retired exec-mode and comparator helpers from <code>infra-runtime</code> to <code>execPolicy</code> on <code>openclaw/plugin-sdk/agent-harness-runtime</code>; use <code>resolveExecModePolicy</code> and select the returned fields needed by the caller. See <a href="https://docs.openclaw.ai/plugins/sdk-runtime/config-and-utilities">runtime utility migration</a>.</li>
+<li><strong>Breaking — approval SDK:</strong> import approval account-resolution helpers from <code>approval-native-runtime</code>, adapt session filtering to the full <code>matchesApprovalRequestFilters</code> contract, and replace the retired generic forwarding evaluator with native channel route gates and shared predicates rather than assuming a drop-in alias. See <a href="https://docs.openclaw.ai/plugins/sdk-migration">SDK migration</a>.</li>
+<li><strong>Breaking — SDK aliases:</strong> replace <code>channel-inbound.buildChannelTurnMediaPayload</code> with <code>buildChannelInboundMediaPayload</code>; infer the retained <code>abortAndDrainAgentHarnessRun</code> callable’s result instead of importing the removed <code>AbortAndDrainAgentHarnessRunResult</code> named type. The callable and its result data remain available. See <a href="https://docs.openclaw.ai/plugins/sdk-migration">SDK migration</a>.</li>
+<li><strong>Breaking — search result callbacks:</strong> read bounded Find/Grep text from <code>details.content</code> instead of <code>details.truncation.content</code>; the outer tool-message <code>content</code> remains unchanged. (#140008) Thanks @ruel225.</li>
+<li><strong>Breaking — directory result callbacks:</strong> use <code>LsToolDetails.content</code> and optional <code>nextAfter</code> in place of the retired <code>truncation</code> and <code>entryLimitReached</code> fields, and pass <code>nextAfter</code> as <code>after</code> to continue listing. See <a href="https://docs.openclaw.ai/tools/code-mode#guest-runtime-api">structured filesystem results</a>.</li>
+<li><strong>MCP prompt adapters:</strong> return the typed MCP <code>GetPromptResult</code> shape from <code>SessionMcpRuntime.getPrompt</code>, preserving its messages and image content; validate external responses instead of returning arbitrary unknown values. (#141421)</li>
+<li><strong>Breaking — agent-owned Workshop skills:</strong> replace workspace ownership with one writable Workshop collection per agent and retire <code>skills.workshop.allowSymlinkTargetWrites</code>; startup and <code>openclaw doctor --fix</code> migrate proven legacy skills, while ambiguous ownership remains in place for review. (#135528) Thanks @obviyus.</li>
+<li><strong>Bounded update repair:</strong> supported candidate-validation failures can enter a bounded repair phase using configured inference in disposable rehearsal state; activate only after independent validation, and retain failure or rollback outcomes when repair cannot recover. Changes requiring configuration edits are reported for operator repair. (#139495)</li>
+<li><strong>Update failure reports:</strong> submit a report from the failed-update action only after explicit consent, using the recorded update attempt and current owner. (#139704) Thanks @fuller-stack-dev.</li>
+<li><strong>Active sessions:</strong> show running and queued permitted sessions in Live activity on entry and reconnect, with a visible limit notice and connection status instead of claiming disconnected sessions are idle. (#141045) Thanks @shakkernerd.</li>
+<li><strong>Code Mode composition:</strong> retain the running JavaScript environment across fast tool replies, add optional TypeScript checks against available tools, and report original-source error locations with bounded console output; explicit yields and resource limits still checkpoint execution. Related #141261. (#141265) Thanks @Takhoffman.</li>
+<li><strong>Code Mode text encoding:</strong> provide sandboxed TextEncoder and TextDecoder instances that survive wait/resume for local text and byte transformations. (#140812) Thanks @Takhoffman.</li>
+<li><strong>Private-session link previews:</strong> copy social-preview links that show a generic OpenClaw card without reading private session content; opening the conversation still requires its normal authentication. (#139250)</li>
+<li><strong>Public session transcripts:</strong> session owners and Gateway admins can explicitly publish existing and future conversation text to anyone with a public URL and revoke access later; the read-only view omits tools, reasoning, files, images, and executable widgets. Review the text before enabling access; private-session preview links remain separate. (#139489)</li>
+<li><strong>Repository-backed cloud sessions:</strong> create sessions from a repository URL and ref with checkout, setup, and recoverable checkpoints owned by the cloud node; materialize a Gateway worktree only when explicitly moving there. (#138900)</li>
+<li><strong>Persistent sessions and subagent runs:</strong> keep persistent sessions created with visible spawning editable and steerable in their parent tree. Subagent runs remain view-only, omit author avatars, and keep live progress in the parent conversation with inactive cards paused. (#139367, #139371, #139381, #139456, #141499)</li>
+<li><strong>Provider account controls:</strong> add and remove individual accounts, manage supported account priority, and clear an agent’s custom order without disconnecting accounts; inherited and provider-managed order remains explicit. (#132451) Thanks @jesse-merhi.</li>
+<li><strong>Model fallback picker:</strong> choose ordered fallback models from a searchable dropdown, remove selections, and add custom references. Related #137410. (#141330) Thanks @najef1979-code and @shakkernerd.</li>
+<li><strong>Prometheus runtime identity:</strong> identify the running process and loaded build behind metrics so operators can verify which runtime is serving a deployment. Related #139268. (#139280)</li>
+<li><strong>Provider setup:</strong> keep provider detection passive until the user chooses a route, preserve consent and model choices through setup and OAuth failures, and leave generated catalog rows to discovery. Retain selected OpenAI credentials and supported Doctor model references; Baseten replace mode still includes the bundled catalog. Related #137033, #139207. (#137120, #139243, #139675, #139924, #139951, #140139, #140154, #140336, #141531, #141552) Thanks @LiuwqGit, @NovaUnboundAi, @obviyus, @shakkernerd, and @vincentkoc.</li>
+<li><strong>Browser panel:</strong> watch Agent browser tabs repaint live, with screenshot fallback when streaming is unavailable. In the macOS app, open external links as native WebKit Mac tabs in the same Browser panel, with navigation and one-shot Annotate/Inspect capture; Mac tabs belong to their window and survive chat switches. (#140988, #141031)</li>
+<li><strong>iOS voice shortcuts:</strong> open the current chat and start Talk with the Start Live Voice App Shortcut; pairing, provider setup, microphone permission, unlock, and foreground requirements still apply. Related #140998. (#141003, #141152) Thanks @shakkernerd.</li>
+<li><strong>Team Reports:</strong> install the optional Team Reports plugin for authenticated daily, weekly, and monthly GitHub reports and explicitly selected Discord sources, with stored history, optional summaries, people timelines and calendars, coverage warnings, scheduler/source health, and theme-aware report pages. (#139850, #141327, #141384)</li>
+<li><strong>Android folding layouts:</strong> keep content clear of separating hinges, show navigation beside content on book folds, and split transcript and composer across suitable tabletop panes while retaining drafts, cursor, and reading position; fall back when available space is insufficient. (#140614, #140710, #140802) Thanks @vincentkoc.</li>
+<li><strong>Native embedded settings:</strong> provide phone-width settings with safe-area handling and Back navigation while retaining existing Gateway scopes and native device capabilities. (#139492)</li>
+<li><strong>Telegram photo albums:</strong> group consecutive eligible photos into native albums of up to ten while preserving order, captions, reply targets, and topics; single photos and messages with controls retain individual delivery. (#141398) Thanks @obviyus.</li>
+<li><strong>CLI and plugin discovery:</strong> limit displayed terminal or JSON documentation results with <code>openclaw docs --limit</code>, and let the system agent read installed-plugin inventory directly. Related #133122. (#131014, #133255) Thanks @Alix-007 and @shakkernerd.</li>
+<li><strong>Recursive delegation:</strong> enable bounded recursive session spawning by default while retaining explicit depth and concurrency limits and existing sandbox restrictions. (#138059) Thanks @fuller-stack-dev.</li>
+<li><strong>Chat navigation:</strong> add a previewable position rail for long conversations, including hover previews and direct jumps. Related #138587. (#138603) Thanks @brokemac79.</li>
+<li><strong>Native dashboard reports:</strong> display bounded report data directly through <code>show_widget</code> and dashboard authoring without an iframe. Related #139263. (#139306)</li>
+<li><strong>Chrome extension setup on Mac:</strong> request the official Chrome Store extension from the local Mac device settings or CLI after native setup is ready; Chrome still owns approval and uninstall decisions, and OpenClaw shows when setup remains pending. Related #139448. (#139466)</li>
+<li><strong>CLI agents by default:</strong> show supported create-capable CLI agents in the new-session model picker without a separate opt-in; set <code>gateway.cliAgents.enabled</code> to <code>false</code> to disable CLI agents and native CLI session creation. (#139459)</li>
+<li><strong>Device aliases:</strong> rename paired devices directly from the Control UI Devices page. Related #138099. (#138852) Thanks @xialonglee.</li>
+<li><strong>Folder navigation:</strong> filter the folder browser immediately as you type a path. (#139417)</li>
+<li><strong>Meeting archives:</strong> browse paginated saved notes, search transcripts, export complete Markdown or JSONL archives, and edit capture sources in Communications settings while retaining existing archive access controls. (#139875, #140084)</li>
+<li><strong>Native desktop:</strong> provide ARM64 Linux AppImage packaging and live Gateway cards with direct window opening in the macOS Gateways menu. (#139522, #139688, #139729) Thanks @vincentkoc.</li>
+<li><strong>Watch voice setup:</strong> include voice in normal Apple Watch setup. (#139712)</li>
+<li><strong>Diagnostics:</strong> expose garbage-collection duration metrics and identify slow phases while opening agent databases. Related #139547. (#138125, #139592)</li>
+<li><strong>Android usage:</strong> distinguish context pressure from cumulative latest-run usage, keep optional model-call details compact, and clear stale usage after compaction and history refresh. (#137494) Thanks @IWhatsskill.</li>
+<li><strong>Installation-owned recovery:</strong> eligible failed updates and recorded startup failures can start a repair using existing authentication and permissions, with only one active repair per installation; verified cleanup, cancellation, and admission limits remain enforced, and recovery does not turn the original failed update into success. (#135868)</li>
+<li><strong>Cloud setup diagnostics:</strong> report cloud bootstrap phase timings so provisioning delays are easier to locate. (#140442)</li>
+<li><strong>macOS app Gateway control CLI:</strong> bundle <code>openclaw-mac</code> to inspect and configure the running Mac app’s primary and saved Gateway connections from Terminal or SSH, including browser sign-in, reconnect, removal, profiles, and JSON output. Browser sign-in still happens on the Mac; credentials enter through protected files or standard input.</li>
+<li><strong>Gateway secret setup:</strong> use one Gateway secret field in Control UI and remote onboarding, and generate a local Gateway token by default without asking users to choose token or password. (#141511, #141514)</li>
+<li><strong>Beam deletion:</strong> delete beamed sessions directly from their sidebar menu without affecting independent continuations. (#141467)</li>
+</ul>
+<h3>Fixes</h3>
+<ul>
+<li><strong>Stale update recovery:</strong> recover abandoned update records without stopping a healthy, matching Gateway when no post-update work remains; retain live-driver protection and require explicit recovery for stale legacy records without driver identity. (#141562)</li>
+<li><strong>Update admission and rehearsal:</strong> rehearse core and plugin changes in isolated candidate copies, including linked and workspace-hoisted dependencies. Check configured plugin targets against the selected or staged core version and reject incompatible agent stores before activation; bound finalization and verify restored package contents before reporting rollback success. Related #136997. (#136329, #138839, #139722, #140648, #140778, #141175, #141478, #141515, #141610) Thanks @fuller-stack-dev.</li>
+<li><strong>Authored configuration:</strong> preserve authored settings, environment and secret references, and omitted defaults through setup, updates, Settings saves, and Doctor migrations. Route supported edits to their owning include, retain explicit values equal to defaults, preserve configuration when recovery fails, apply changed environment values on restart, and reject or repair placeholder Gateway tokens. Related #116107, #137712, #139494. (#116108, #137713, #139358, #139376, #139536, #139844, #139949, #140579, #141296) Thanks @aeoess, @hyspacex, @obviyus, @robojarvis, and @sasan1200.</li>
+<li><strong>Gateway maintenance and restart:</strong> keep ordinary failed restarts recoverable in the foreground process, but stop restart loops when migration or required maintenance blocks startup. Doctor acquires ownership before bounded database inspection, applies supported noninteractive repairs, migrates legacy sign-ins before retired routes, and retains actionable refusal and backup-recovery guidance. (#139612, #139683, #140074, #140135, #140973, #141297, #141412, #141416) Thanks @fuller-stack-dev and @obviyus.</li>
+<li><strong>Update activation and plugins:</strong> run post-update maintenance through the activated CLI, align version-bound official plugins with the selected release, and repair missing configured official installs. Preserve scoped package entries, clear stale development-switch warnings, and report SDK incompatibilities without startup loops. Related #139527. (#121603, #139458, #139709, #140016, #140886, #141478) Thanks @Conan-Scott and @vincentkoc.</li>
+<li><strong>Development-to-package updates:</strong> replace npm’s install link without modifying its development checkout; restoring a link after failed activation remains unverified recovery and does not automatically restart the Gateway. (#141168)</li>
+<li><strong>Update rollback and recovery:</strong> recover eligible verified prior installations after failed activation or service transitions, preserve service profiles, and judge rollback against the actual post-Doctor configuration and database compatibility. Keep update outcomes and Unicode diagnostics accurate, skip automatic triage after verified rollback, and report recovery without turning the failed update into success. Related #127869. (#136285, #137680, #139288, #139393, #140263, #140284, #140313, #140419, #140493, #141219, #141364, #141397) Thanks @cursoragent, @fuller-stack-dev, @Jackten, @ly85206559, @Schimuneck, @TheAngryPit, and @vincentkoc.</li>
+<li><strong>Service recovery:</strong> preserve service-derived targets and authentication during status and repair, retain actionable recovery paths, tolerate systemd clock steps and older launchctl output, and avoid terminating the restarting caller. Let child runtimes drain gracefully under systemd and release Tailscale claims only after the owning process group exits. Related #126445, #135471, #139109, #139226. (#135862, #137253, #139145, #139227, #139261, #139283, #139628, #139836, #140568, #140975) Thanks @coderdailyone, @gaoanze888, @NovaUnboundAi, @PollyBot13, @SebTardif, @SunnyShu0925, and @vincentkoc.</li>
+<li><strong>Update verification:</strong> check service ownership, settled health, matching version and build identity, plugin activation, channel readiness, and HTTP readiness without making a model call; failed checks follow the supported repair or rollback path. See <a href="https://docs.openclaw.ai/cli/update">update verification</a>.</li>
+<li><strong>Update continuity and progress:</strong> preserve active work, queued input, update-history ownership, and terminal progress across long updates; retain current update availability beside history and support npm upgrades from 2026.9.1. Resume cloud provisioning across Gateway restarts and reclaim idle workers after build changes. (#139289, #139437, #139455, #139501, #139660, #139663, #139701) Thanks @obviyus, @TheAngryPit, and @TheCrazyLex.</li>
+<li><strong>Configuration privacy and audit:</strong> preserve sensitive-field and URL-redaction metadata in config responses, retain the original writer in audit history, and report rejected-payload backup failures accurately. Related #139305. (#134198, #139332, #139337) Thanks @SebTardif.</li>
+<li><strong>Skill Workshop reviews:</strong> compare complete skill instructions with inline changes, distinguish installed skills from proposal history, and support reviews through compatible restricted CLI backends. Preserve discovery of skills literally named skills and describe weekly reviews in terms of retained conversation context. (#139656, #139760, #139812, #139827, #139842, #140300, #140822) Thanks @obviyus.</li>
+<li><strong>Skill Workshop recovery:</strong> retire missing-draft suggestions through Doctor while preserving installed skills and recovery evidence, distinguish movable backups from those needing review, and keep relocation lint read-only. Report explicit recovery steps for legacy execution policies and unsafe event paths. Related #137357, #139166, #139187, #141036. (#139143, #139193, #139195, #141009, #141048) Thanks @obviyus, @technicalpickles, and @ylcn91.</li>
+<li><strong>Workshop learning and refresh:</strong> recover memory and skill refresh after watcher exhaustion, keep unavailable-backend status machine-readable, and show stale-search guidance. Review complete Workshop collections before editing, preserve task-specific knowledge, and keep one-time requests or routine repetition from becoming standing instructions. Related #136966, #140184, #140349. (#137105, #140195, #140229, #140315, #140350) Thanks @ericcaiwx-star, @obviyus, and @singletrackandrew.</li>
+<li><strong>Skills:</strong> validate names in skill-library forms. Related #139183. (#139184)</li>
+<li><strong>Session responsiveness:</strong> keep session edits responsive during integrity checks, release writers while worktrees restore, avoid cross-agent initialization and reclamation lock failures, and bound listing and saved-prompt work. Reduce cold catalog stalls, retain transaction-safe input relocation, back off reconciliation retries, and let idle remote sessions stop without unrelated provisioning. Related #139867. (#119126, #127225, #139002, #139051, #139114, #139130, #139146, #139432, #139450, #139467, #139469, #139540, #139689, #139911, #140231, #140368, #140840, #141006, #141246, #141434, #141613) Thanks @ampagent, @fuller-stack-dev, @LiuwqGit, @ly85206559, @obviyus, @shad0wca7, and @VACInc.</li>
+<li><strong>Private runtime context:</strong> distinguish user-authored input from Gateway runtime context and strip recognized internal context, including partial streamed markers, from channel reasoning previews. Preserve stored user transcripts, original reasoning for replay, and existing session projections. (#140859, #141544) Thanks @VACInc.</li>
+<li><strong>MCP session continuity:</strong> keep session-owned MCP servers alive between turns and quiet periods while retaining cleanup on Stop, reset, compaction rollover, and shutdown. Preserve <code>mcp.sessionIdleTtlMs</code> as an optional idle timeout in Doctor. (#141125)</li>
+<li><strong>Conversation durability:</strong> publish transcript rewrites atomically so interruptions do not expose partial history, and preserve already-projected tool history across Gateway restarts. Related #138965, #139201. (#138984, #141090) Thanks @keumhyun and @VACInc.</li>
+<li><strong>Reply and task continuity:</strong> discard superseded deferred tool replies before finalization while preserving commentary and media, and keep task pagination stable across metadata edits that do not change access. (#137975, #141444) Thanks @hannesrudolph.</li>
+<li><strong>Teams reply formatting:</strong> preserve formatting and mentions in edited and final Microsoft Teams replies. (#141348)</li>
+<li><strong>Code Mode results and diagnostics:</strong> preserve complete structured tool results or return a catchable resource-limit error, keep file pages separate from display notices, and retain handled error details. Preserve MCP declarations and search results, identify unawaited promises, report budgets and source locations accurately, and keep command dispatch responsive. Related #138897, #139053. (#138899, #139067, #139910, #140008, #140028, #140051, #140140, #140198, #140321, #140689, #141223) Thanks @lzhan011, @obviyus, @ruel225, and @Takhoffman.</li>
+<li><strong>Code Mode scheduling and delegation:</strong> queue bounded tool batches, honor sequential tools across shared catalogs, reserve available slots for Swarm continuations, and release consumed resume data. Apply destination-agent authorization and execution rules to delegated tools. Related #139407, #140564. (#139368, #139420, #140565, #140767, #140912) Thanks @Takhoffman.</li>
+<li><strong>Session history retention:</strong> archive aged durable conversations with their IDs and transcript generations intact, and raise the default active-session cap to 5,000 while preserving explicit configured limits. (#136639)</li>
+<li><strong>Subagent completion and cancellation:</strong> resume nested orchestrators after yielding, retain child completion through parent recovery, and settle unsuccessful wakes durably. Preserve durable parent identity and replay order, cancel replaced or reset children, and let requester follow-ups finish without stale or duplicate completion. Related #137214, #137643, #137690, #138802, #139121, #139219, #139223, #139537, #139963, #140354, #140355, #140911. (#137235, #137344, #137779, #138821, #138966, #138976, #139125, #139269, #139563, #139986, #140137, #140410, #140417, #140930) Thanks @aaajiao, @Denny22044, @evan-zhang, @FabianJun, @fuller-stack-dev, @gaoanze888, @hannesrudolph, @josephbergvinson, @LiuwqGit, @NianJiuZst, @obviyus, @ratticon, @SunnyShu0925, @Takhoffman, @VACInc, @vincentkoc, and @xydt-juyaohui.</li>
+<li><strong>Conversation reset progress:</strong> clear the previous task progress card during a full conversation reset and prevent an older in-flight write from restoring it. Related #140356. (#140412) Thanks @hannesrudolph.</li>
+<li><strong>Android conversation and accessibility:</strong> keep Android Send and Talk controls usable during active runs and short keyboard viewports without erasing another run’s output; retain delayed-send ownership, publish approval outcomes atomically, and improve large-text readability and contrast. Refresh model status for the selected agent and report failed refreshes without discarding choices; recover health and secondary-Gateway refreshes, reduce retries to unreachable Gateways, reopen chats at the live edge, make settings searchable, and surface workspace-sharing failures. Preserve the complete macOS automation count. Related #139310, #139411, #140109, #140179. (#137682, #138732, #139035, #139141, #139319, #139430, #139692, #139728, #139789, #139931, #140111, #140130, #140182, #140540, #140726, #140796, #140899) Thanks @fuller-stack-dev, @IWhatsskill, @obviyus, and @vincentkoc.</li>
+<li><strong>Conversation text fidelity:</strong> preserve literal final tags inside Markdown code examples and keep bold text, links, and inline code in exported HTML list items. Related #140785. (#138989, #140830) Thanks @Alix-007 and @shakkernerd.</li>
+<li><strong>Context and compaction:</strong> size compaction against the full pending request, preserve complete exchanges and queued turns, and pair hooks even for no-op compaction. Keep runtime-generation ownership, tool schemas and readable results, enforce bounded heartbeat and search context, preserve errors during failed summary recovery, and run optional maintenance after delivery with foreground preemption. Related #127506, #136452, #136622, #139147. (#118094, #127837, #136533, #136623, #139165, #139309, #139429, #139431, #139801, #139822, #140024, #140110) Thanks @altaywtf, @Colton-Harris, @GarySiu, @LiuwqGit, @obviyus, @peterolkhov, @thomasmoenco, @vincentkoc, @vyctorbrzezowski, and @zhangguiping-xydt.</li>
+<li><strong>Conversation recovery and completed replies:</strong> preserve queued input, completed assistant output, and successful tool results through watchdog retries, fallback, disconnects, and delayed history. Keep final delivery independent of stalled maintenance, prevent split or duplicate replies, and retain durable failure notices while preserving message order and session ownership. Related #137125, #138959, #139341, #139440, #140398. (#138985, #139216, #139388, #139439, #139465, #139507, #139661, #139753, #139888, #140023, #140257, #140294, #140362, #140379, #140399, #140523) Thanks @Jackten, @ly85206559, @obviyus, @ruel225, @shakkernerd, @Takhoffman, and @VACInc.</li>
+<li><strong>Long conversations and retained memory:</strong> reduce repeated transcript, branch, compaction, and bounded-text work in large conversations. Bound retained tool observers and projections, release prepared SQLite statements with their database, and avoid discarded waits in queued writes. (#136293, #139074, #139085, #139115, #139157, #139300, #139301, #139324, #139325, #139327) Thanks @edenfunf.</li>
+<li><strong>Reply formatting:</strong> preserve Markdown literals around tables, keep Slack emoji shortcodes intact, prevent long details replies from stalling, and use consistent native progress-card rendering. (#136374, #138829, #139206, #139892) Thanks @lzhan011, @obviyus, @teddytennant, and @vincentkoc.</li>
+<li><strong>Model authentication and selection:</strong> keep model choices and availability tied to the selected chat, agent, runtime, and credential profile; preserve native CLI authentication states, inherited defaults, aliases, and Codex model choices. Avoid duplicate OAuth refreshes, preserve case-distinct routes and metadata, refresh observer catalogs, and reject explicitly blank numeric status or log options. Related #139270, #141222. (#139218, #139222, #139232, #139282, #139413, #140099, #140434, #140438, #140461, #140488, #140506, #140907, #141234, #141293, #141654) Thanks @Alix-007, @ly85206559, @obviyus, and @shakkernerd.</li>
+<li><strong>Memory paths, recall, and budgets:</strong> use the current prompt for LanceDB recall and the prepared LM Studio instance for embeddings, honor profile and workspace paths, and keep blocked provenance out of promotion previews. Use effective model limits for memory flush and compaction, invalidate stale context usage after truncation, preserve transcript-growth freshness, and report skipped roots and read errors. Related #140214, #141510. (#120573, #121287, #137440, #138928, #139402, #140381, #140634, #140984, #141513, #141521) Thanks @bryan, @chelsealong, @hydraxman, @obviyus, @oshaughnessy-junior, @ruel225, @SebTardif, @shojikumaru, and @vincentkoc.</li>
+<li><strong>Memory search and indexing:</strong> keep keyword search available when optional embeddings cannot start, use a cancellable batched scan when SQLite extensions are unavailable, and preserve exact-file and short-query ranking. Resume append-only transcript ingestion, recover indexing after row-limit failures, and keep searches responsive during cleanup while bounding chunks and annotation work. Related #137864, #138722, #138994, #139094, #140103. (#119367, #138391, #138798, #138995, #139112, #139463, #139698, #139777, #139821, #139879, #140104, #141104) Thanks @badmutt, @fisherman86-ai, @jalehman, @lzhan011, @obviyus, @teddytennant, and @wangjx-xydt.</li>
+<li><strong>Runtime diagnostics:</strong> report bounded, redacted database-write causes and codes, distinguish integrity and index-validation stages, and identify internal waits and database admission mode in slow-operation logs. Surface sanitized setup-inference failures, clear stale Gateway diagnostics, and show executable approval scope. Related #137108, #137452. (#138386, #140392, #140426, #140478, #140498, #141507, #141619) Thanks @abacha, @ayaangazali, @obviyus, @shakkernerd, and @ylcn91.</li>
+<li><strong>Android handoff credentials:</strong> prevent a delayed operator connection from overwriting a newer device token issued during Android bootstrap handoff. (#141518)</li>
+<li><strong>Local models:</strong> route LM Studio chat through the prepared instance and use its actual context budget, reload evicted embedding models when enabled, and provide working login guidance. Honor Ollama sampling overrides and reasoning follow-ups, reject embedding-only chat setup, preserve llama.cpp presets and local conversation tools, and recover retired automation model overrides. Related #138589, #138753, #139235, #141356, #141357, #141424, #141430. (#125399, #136363, #138633, #138850, #139523, #139646, #140717, #141381, #141390, #141441, #141450) Thanks @javikas, @ruel225, and @vincentkoc.</li>
+<li><strong>Runtime and package loading:</strong> use the declared WebSocket transport for ClickClack under Bun, restore source catalog-worker provider loading, and rebuild bundled Control UI assets correctly under production mode. Related #138684. (#139075, #141124, #141433) Thanks @eggc-tech, @obviyus, and @ylcn91.</li>
+<li><strong>Prompt cache continuity:</strong> preserve warm conversation and tool prefixes across tool loops, background activity, Windows approvals, and resumed CLI turns. Keep Responses history append-only, Gemini hook instructions and stable-prefix caches intact, Anthropic tool checkpoints independent, and Bedrock checkpoints anchored to conversation history. (#140566, #140651, #140698, #140713, #140744, #140797, #140799, #140804, #140849, #141073, #141077) Thanks @VACInc.</li>
+<li><strong>Native and compatible cache controls:</strong> honor native OpenAI cache-key and retention settings and restore Anthropic-style cache markers on managed Chat Completions routes, including supported DeepInfra and Model Studio routes. (#140781, #140853)</li>
+<li><strong>Cache and billing diagnostics:</strong> report cache misses per completed model request, include Codex /btw tool-loop usage in billing hooks and diagnostics, and preserve recorded service-tier costs while correctly applying Anthropic fast-mode tier pricing. (#140850, #141059, #141080)</li>
+<li><strong>Settings and model choices:</strong> preserve saved and explicitly nullable settings through rejected choices, delayed reads, reconnects, and external changes; wait for the authoritative configuration refresh and recover failed Appearance saves. Keep model-picker search applied through catalog refresh, clear it before closing on Escape, acknowledge remote configuration opens, and return the configuration actually saved after plugin installation. Related #138374. (#138757, #139113, #139167, #139203, #140551, #140846, #140924) Thanks @benmillerat, @obviyus, @SebTardif, and @VasuBansal7576.</li>
+<li><strong>Prometheus read authorization:</strong> require effective operator read permission before serving Prometheus metrics. (#140903) Thanks @pgondhi987.</li>
+<li><strong>Credential setup guidance:</strong> allow user-requested sign-in and pairing code handoffs in private conversations, while keeping reusable secrets in protected entry; warn when shared auth profiles still contain plaintext that secrets configure cannot migrate. (#133843, #139196) Thanks @obviyus, @SunnyShu0925, and @vincentkoc.</li>
+<li><strong>Provider route privacy:</strong> keep opaque realtime routes out of public configuration and catalog projections while preserving supported Talk authentication and relay routing. (#129144) Thanks @vincentkoc.</li>
+<li><strong>Models and providers:</strong> preserve the selected model when resuming managed Codex sessions, show the canonical provider after local-model changes, report Ollama cached-prompt usage, and include the required conversation identity on OpenCode Go/Zen requests. Related #137165, #140050. (#137464, #139990, #140196, #140222) Thanks @GDXbsv, @Ghilteras, @josephbergvinson, @ly85206559, @obviyus, @VACInc, and @vincentkoc.</li>
+<li><strong>Provider retry behavior:</strong> retain explicit same-provider account choices when credentials disappear and offer actionable recovery instead of silently switching accounts. Preserve requests, completed work, and underlying errors through bounded transient retries; send exhausted usage windows to eligible fallback and avoid prematurely aborting CLI background work. Related #118386, #139312. (#132459, #139295, #139397, #140973) Thanks @bytrustu, @LiuwqGit, and @obviyus.</li>
+<li><strong>Provider and media choices:</strong> avoid stale runtime options, transcription models, and PDF defaults across provider changes, and honor global plugin disablement and document allowlists during PDF extraction. (#139101, #139317, #139334)</li>
+<li><strong>Chat formatting, links, and copy:</strong> render GitHub issue and PR references as chips, including URL-only code spans and bare references resolved against a GitHub checkout, while preserving literal code and existing links. Fix code-block copying around HTML comments and closing tags, preserve Unicode download names and copied whitespace, hide proven import wrappers only on user-facing surfaces, and keep saved paragraphs, captions, and nested Markdown block boundaries in order. (#139653, #140306, #140338, #140961, #140980, #141311, #141369, #141431, #141446, #141574) Thanks @fuller-stack-dev, @hugenshen, and @VACInc.</li>
+<li><strong>Drafts, Review, and navigation:</strong> read supported same-origin text attachments directly in Files with indentation preserved. Keep delayed Review results bound to the current selection, preserve newer drafts through rewind and failed steer/redirect, clear Side chat when its parent disappears, and retain board and Home navigation context. Keep uploaded images visible while worktrees start, allow suggested follow-ups without a worktree, show local-link hover cards and line-range file references, and retain panel shortcuts and Review sizing within transcript bounds. Related #139054, #139072, #139939, #139971. (#139055, #139059, #139076, #139323, #139355, #139373, #139384, #139385, #139731, #139940, #139952, #139974, #140066, #141469, #141567) Thanks @fuller-stack-dev.</li>
+<li><strong>Protected HTTPS continuity:</strong> renew protected HTTPS leaf certificates while keeping the Gateway process trust chain stable, so existing subprocesses continue working beyond one day; report certificate failures in status and Doctor. Related #136813. (#141484) Thanks @MaClawd.</li>
+<li><strong>Claude native Bash approvals:</strong> honor the agent exec allowlist for fully bindable Claude native Bash commands under on-miss prompting, while retaining explicit deny and always-prompt behavior. (#141471)</li>
+<li><strong>Native hook startup:</strong> reduce repeated native hook relay startup work and memory overhead with a dedicated lightweight entrypoint while preserving deadlines and command outcomes. (#120340) Thanks @sightingsstellar-beep and @Takhoffman.</li>
+<li><strong>Git worktrees:</strong> batch missing partial-clone objects before sizing worktrees, serialize shared Git ref mutations, and preserve patch bytes despite inherited newline conversion. Report durable setup failures and interrupted commands, explain empty-repository requirements, and retain Git-plugin branch selection. Related #131970, #140204. (#140251, #140683, #140951, #141095, #141537) Thanks @obviyus, @SunnyShu0925, and @TylerGillson.</li>
+<li><strong>Bun transport compatibility:</strong> use the declared WebSocket implementations under Bun across Discord, Mattermost, Signal, Gateway, workers, voice calls, and provider routes, preserving handshake options, payloads, backpressure, and transcription limits. (#139480, #139567, #139717, #139919, #140048, #140071, #140318, #141465)</li>
+<li><strong>Codex and CLI continuity:</strong> preserve current turn context and workspace references across reused Codex sessions, plugin updates, cold resume, and compaction. Retain completed answers through disconnect or settlement expiry, guard failed-session continuation, reject stale hook requests, and finish prior Claude CLI cleanup before starting replacement processes. Related #138835, #139173. (#136926, #139228, #139246, #139353, #140814, #140885, #140973, #141491) Thanks @Colton-Harris, @KirDE, @obviyus, and @srikalyan.</li>
+<li><strong>Usage details and exports:</strong> refresh the selected session’s timeline, conversation, and prompt breakdown with Usage totals, and keep exported data tied to the same concrete session instance. Show context pressure against the matching last-run prompt budget; fall back to the context window after model or cap changes and avoid warnings from stale totals. Related #138590, #140567. (#138666, #140573, #141632) Thanks @DasX and @javikas.</li>
+<li><strong>Channel progress:</strong> preserve every Teams progress reply across stream settlement and fallback, and show Telegram compaction status in enabled answer previews. (#141199, #141551) Thanks @VACInc.</li>
+<li><strong>CLI diagnostics:</strong> report disabled channel accounts as off, use operator-assigned device labels in approval notices, and count missing skill prerequisites separately from intentionally disabled skills. Related #141550, #141606, #141644. (#141560, #141618, #141649)</li>
+<li><strong>MCP prompt content:</strong> preserve fetched prompt descriptions, role labels, and native images for vision-capable models while retaining the original JSON result in Code Mode. (#141421)</li>
+<li><strong>Mentions across restarts:</strong> retain Inbox mentions and dismissals through Gateway restarts and upgrades without replaying old browser alerts. (#141404)</li>
+<li><strong>Gateway lifecycle:</strong> keep startup database and chat-metadata work responsive, finish accepted notices and hook outcomes, and stop admitting new work during shutdown. Drain prepared model runtimes and catalog workers before authentication teardown, handle disconnects safely, and prevent old work from publishing into a later Gateway lifetime. Related #139154, #139242. (#138986, #139061, #139092, #139155, #139192, #139265, #139304, #141280) Thanks @johan-eilertsen, @obviyus, and @vincentkoc.</li>
+<li><strong>Catalog resilience and scope:</strong> retain discovered inventories after failed refreshes and report discovery failures instead of silently losing models. Keep exact model identities and selected-agent catalogs, preserve cold-path credential resolution and deferred tool availability, respect the final context budget, and defer downloaded catalog changes until restart. Related #139498, #139499. (#139231, #139357, #139649, #139749, #139750, #139791, #139817, #139846, #139848, #139849, #139880, #139900, #139907, #139923, #139991, #140086, #140435, #140436, #140441, #140657, #141354, #141402) Thanks @goslingmanagment, @obviyus, @rodrigo-fonseca-oliveira, and @shakkernerd.</li>
+<li><strong>Control UI connection and refresh:</strong> reconnect after pairing approval and missed update notices, preserve loaded sidebar children during roster refreshes, and retain recent dashboard interactions per pane. Keep suspension and offline state in the footer while panels retain data, report chat-search and GitHub-status failures accurately, restore editor focus after preview, and make browser URL copying work on plain HTTP without delayed older copies replacing newer clipboard content. Related #140492. (#140333, #140459, #140484, #140495, #140662, #140893, #141040, #141130, #141362, #141428) Thanks @fuller-stack-dev and @Takhoffman.</li>
+<li><strong>Connection and location boundaries:</strong> bind desktop observer access to the requesting Gateway connection, accept the configured Gateway secret through either connect field without changing the selected auth mode, and honor Android’s Precise Location toggle for cached, fresh, and pending fixes. (#141336, #141344, #141456) Thanks @IWhatsskill.</li>
+<li><strong>Plugin host compatibility:</strong> preserve Discord, llama.cpp, and Voice Call’s declared 2026.9.2 host support through documented optional-helper and local WebSocket fallbacks; this does not restore intentionally retired SDK exports. (#141207, #141267)</li>
+<li><strong>Gateway connection settings:</strong> combine Gateway settings into one connection section and explain switching Gateways; open Activity when selecting an online person. (#141427, #141459)</li>
+<li><strong>Bedrock Nova caching:</strong> add opt-in system and message prompt caching for supported Amazon Nova models with a five-minute cache lifetime. (#141060)</li>
+<li><strong>Anthropic streamed replies:</strong> preserve initial text, thinking, and signature content from Anthropic stream events so replies are not truncated. (#140820)</li>
+<li><strong>Cold worker startup:</strong> wait for the Codex exec server to be ready before starting the initialize handshake, reducing first-turn failures on cold cloud workers. (#140990)</li>
+<li><strong>Worker build reuse:</strong> retain the current worker artifact on persistent nodes between sessions and reduce cloud runtime packaging overhead through bounded streaming preparation. (#140449, #141141)</li>
+<li><strong>Codex tool redaction:</strong> redact credential-shaped dynamic tool text before budgeting and truncation, including adjacent text blocks, while preserving Unicode and image content. (#140873) Thanks @pgondhi987.</li>
+<li><strong>Claude questions:</strong> preserve Claude ask_user deadlines through the CLI tool lifecycle. (#140845) Thanks @vincentkoc.</li>
+<li><strong>Codex stateless transport:</strong> preserve stateless request policy through provider aliases and recognized native Codex response endpoints. (#138741) Thanks @obviyus and @saladinyao-cyber.</li>
+<li><strong>Discord messages and access:</strong> apply Discord policy-only edits to new messages and interactions without waiting for active Control UI turns, and explain blocked allowlists or deferred transport reloads. Keep webhook and bot formatting consistent, preserve multiline code and Components v2 thread text, recognize sender aliases for reset commands, and ignore reply pings in mention-only mode. Reject application IDs pasted as bot tokens and enforce sender media restrictions for emoji, sticker, and event-cover uploads. Related #111821. (#111822, #138948, #140334, #140531, #140635, #140637, #140909, #140929) Thanks @Bruce-Yii, @jason-allen-oneal, @marmar9615-cloud, @obviyus, @ooiuuii, @pgondhi987, and @vincentkoc.</li>
+<li><strong>Feishu routing and messages:</strong> use reloaded Feishu group bindings on the next message, expand quoted merged-forward contents, and preserve mentions in individual and debounced messages. Related #133757, #136200. (#96311, #133775, #136231) Thanks @heden9, @sliverp, @vincentkoc, and @zxdvd.</li>
+<li><strong>Matrix room information and polls:</strong> include alternative Matrix room aliases and correctly recognize disclosed poll results across supported event namespaces. (#140967, #140969)</li>
+<li><strong>Slack structured replies:</strong> deliver valid Slack Block Kit sections intact even when their accessibility text exceeds the preferred chunk size. (#140805)</li>
+<li><strong>Telegram reasoning display:</strong> keep internal reasoning-tag prefixes hidden when streamed tags contain extra whitespace. (#126219) Thanks @vincentkoc and @wangyan2026.</li>
+<li><strong>Browser recovery and captures:</strong> align screenshot labels with the actual image scale and crop, preserve focus for verified visible attached Chrome sessions on macOS and Linux, recover tabs after attachment loss while preserving per-client detach behavior, and keep historical or stopped previews from launching browsers unexpectedly. Related #138999. (#134400, #139064, #139089, #139275, #141103) Thanks @esqandil, @obviyus, @Pondsi, @scotthuang, and @ylcn91.</li>
+<li><strong>Control UI notifications:</strong> restore notification prompting from New Session, route notifications to the relevant question, conversation, automation run, or task, and include later-page cron jobs in attention indicators. Related #141035. (#141081)</li>
+<li><strong>Native terminal starts on Bun:</strong> restore native coding terminal starts from a Bun-hosted Gateway using a Node helper on Linux and macOS, with clearer machine availability and primary local profile selection. (#140876)</li>
+<li><strong>Desktop app reliability:</strong> keep Gateway alerts from blocking macOS shutdown, calculate menu costs using local day boundaries, and omit incompatible worker binaries that trigger unrelated compatibility warnings. Restore tray Stop, wait for onboarding activation consent, recover bundled Control UI and Tauri setup without losing sign-in, start AI setup for externally managed Mac Gateways, and recognize versioned Canvas nodes. Related #138956, #139038, #139086. (#138958, #138964, #139063, #139140, #139241, #139348, #140557, #140575, #140863) Thanks @Colton-Harris.</li>
+<li><strong>Canvas action feedback:</strong> show rejected A2UI action errors immediately. (#140670)</li>
+<li><strong>CLI selection and diagnostics:</strong> show configured channel account names in agent listings, distinguish diagnostic-only service state from the probe target, and report plugin enablement accurately during metadata inspection. Related #140950, #141263. (#140547, #140964, #141302) Thanks @aeoess and @obviyus.</li>
+<li><strong>CLI input, output, and drafts:</strong> reject explicitly blank pairing selectors, numeric inference/scan options, and Gateway ports; preserve escaped whitespace in skills JSON, machine-readable setup JSON, Unicode and Windows note line endings, and quoted Bash completion values. Make bare telemetry help succeed, preserve drafts after picker selection, and prevent multiline exit pastes from closing TUI. Related #138613. (#137209, #139512, #139613, #139639, #140034, #140235, #140238, #140283, #140780, #141070) Thanks @Alix-007, @claw-openclaw, @Grynn, @marmar9615-cloud, @shakkernerd, @TurboTheTurtle, and @vincentkoc.</li>
+<li><strong>Command completion:</strong> preserve successful descendant output after a command exits, clean up failed process trees without replacing their exit result with a later timeout, and honor explicit no-pager overrides safely. (#140594, #140927) Thanks @RomneyDa.</li>
+<li><strong>Plugin lifecycle:</strong> preserve install backups and manifest contents on interrupted writes or ownership loss, and report recovery paths. Validate setup entrypoints before loading, retain exact install receipts and current tool context, honor cache invalidation, remove owned aliases before files, and finish late-starting service cleanup. Related #138815, #140063. (#117370, #138870, #139828, #139908, #140065, #140132, #140328, #140740) Thanks @fuller-stack-dev, @obviyus, and @zenglingbiao.</li>
+<li><strong>OpenShell recovery:</strong> preserve host shadow copies after mirror failures and report exact recovery paths, distinguishing incomplete restoration from leftover backup-directory cleanup. Related #140703. (#140764)</li>
+<li><strong>xAI account and image continuity:</strong> refresh the subscription catalog and route after xAI OAuth login without losing model choices, and preserve historical tool-image positions on compatibility routes. (#140610, #141044)</li>
+<li><strong>Terminal upload limits:</strong> bound terminal staging to 256 MiB and 64 files per directory, preserve unexpired uploads, and let failed batches insert paths for completed files. Related #137116. (#141116) Thanks @shakkernerd.</li>
+<li><strong>Policy tool vocabulary:</strong> use core aliases, groups, and wildcard rules for policy tool requirements so required deny lists cover the actual tools they name. (#140628)</li>
+<li><strong>Capture history protection:</strong> keep supplied-ID and legacy capture history intact when occupancy capture restarts; reopen only a recent transcript whose stored origin confirms a generated ID. (#140563)</li>
+<li><strong>Cloud allocation boundaries:</strong> finish local worker preparation before recording allocation intent, avoiding cleanup requests for leases that were never allocated. (#140945)</li>
+<li><strong>Docker workspace ownership:</strong> preserve ownership of bind-mounted workspace project files during Docker setup. Related #140968. (#140993) Thanks @obviyus and @ooiuuii.</li>
+<li><strong>Windows startup and repository work:</strong> avoid compiler-triggered Windows Gateway startup failures and use Windows-compatible null paths in worker Git preparation and publication. Related #140795. (#140593, #140803)</li>
+<li><strong>Automatic progress visibility:</strong> honor fast-auto progress visibility while retaining required transport lifecycle callbacks, including iMessage typing behavior. Related #97601. (#122221) Thanks @joeykrug, @obviyus, and @vincentkoc.</li>
+<li><strong>Cloud worker address validation:</strong> reject unspecified Gateway IP addresses, including IPv4 embedded in IPv6, during cloud-worker enrollment. (#137059) Thanks @vincentkoc.</li>
+<li><strong>Meeting and desktop shutdown:</strong> cancel active meeting consults and ignore late speech after stopping; retain failed desktop cleanup so it can be retried before replacement. Related #140800. (#140658, #140801)</li>
+<li><strong>Portals on IPv6 loopback:</strong> reach portal servers on either loopback address family even when localhost records list only IPv4 or IPv6. (#140580)</li>
+<li><strong>Doctor compatibility:</strong> refuse an interactive update before writing update history when shared state uses a newer schema, and direct operators to a compatible installation; readable shared state still permits a source update past newer agent schemas.</li>
+<li><strong>Localized controls:</strong> distinguish parent sessions from main sessions and dashboard panels from desktops, and correct selected native translations for pending states, consent, permissions, initial setup, and displayed-versus-total session counts.</li>
+<li><strong>Questions and approvals:</strong> avoid telling users to tap nonexistent answer buttons and keep node-capability approvals available until resolved. Related #132829, #135354. (#137978, #140166) Thanks @dragonnite1221-lgtm, @edenfunf, @harshitgupta31415, and @IWhatsskill.</li>
+<li><strong>Scheduled work and monitor recovery:</strong> preserve scheduled delivery intent, accepted monitor scratch, paced checks, and recovered outcomes across restarts. Keep forced disabled one-shots disabled, produce fresh manual-run results, skip empty scheduled heartbeats without busy-queue retries, and converge or remove monitors through their owners after agents and configuration are ready. Related #131374, #136525, #137492, #138299, #139088, #139488, #139945, #140005, #140080. (#131462, #136589, #137517, #138322, #139017, #139037, #139225, #139491, #139509, #139947, #139967, #139987, #140025, #140083, #140256, #140260) Thanks @Amazingjun-j, @andersonjeccel, @creanet-64, @gaoanze888, @gszj2018, @hartmark, @JLahullier, @lakemike, @LiuwqGit, and @obviyus.</li>
+<li><strong>Meeting and channel lifecycle:</strong> settle duplicate recording auto-start retries and occupancy startup/cancellation diagnostics, retain TTS delivery decisions, report Nostr relay publish outcomes, and settle iMessage failures after errored stdio closure. Related #140287. (#139727, #140202, #140220, #140221, #140289)</li>
+<li><strong>Media and HTTP:</strong> prevent stack overflow when decoding inline images, stop image setup after cancellation, release gracefully closed transcription socket state, and honor HTTP dates when revalidating assets and media. Related #140153. (#140149, #140173, #140226, #140303)</li>
+<li><strong>Command controls:</strong> isolate background-result retention by process, retain Windows Startup fallback environment overrides, accept Swabble executable paths and file options, and avoid mistaking quoted JSON examples for results. (#122373, #122658, #127231, #140291) Thanks @masatohoshino and @ooiuuii.</li>
+<li><strong>Status and setup:</strong> resolve configured channel credentials in fast status scans, defer unrelated CLI options before status and health, count selected bootstrap-hook files accurately, and permit fresh llama.cpp binary validation on macOS26. Related #137217, #137308, #138672. (#137114, #137269, #137351, #139160) Thanks @dmwtech, @LiuwqGit, @obviyus, @pawel-kowalczyk, @qingminglong, @vincentkoc, @waterundman, @ylcn91, and @zyrill.</li>
+<li><strong>Chat presentation:</strong> keep waiting time scoped to the current turn, prevent mobile image-avatar overlap, and clarify the current session’s empty task-run state. Related #127809, #139950, #140340. (#138597, #139972, #140341) Thanks @anyech, @NianJiuZst, @noelillinger, @obviyus, and @sunlit-deng.</li>
+<li><strong>Active-run documents:</strong> retain extracted document text, attachment context, and rendered PDF pages when steering an active run, while preserving normal follow-up delivery when steering cannot be admitted. Related #138225. (#138275) Thanks @alexdhc, @obviyus, and @ruel225.</li>
+<li><strong>Streaming and tools:</strong> enforce idle timeouts when a model stream goes silent between consumer reads, recover truncated OpenCode Go completions after tool use, and accept tool_search calls that combine a single query with a query batch. (#140310, #140335, #140367) Thanks @VACInc.</li>
+<li><strong>Channel and formatting behavior:</strong> preserve silent-reply guidance, fall back from oversized Feishu tables to post mode, restore LINE and Mattermost account promotion, retain indentation in cited memory snippets, and preserve emoji in remote-desktop text input. Related #43690, #136854, #140470. (#136045, #136382, #138345, #140157, #140471) Thanks @Eppiedude, @ltspace, @name5566, @obviyus, @PenguinMiaou, and @wangmiao0668000666.</li>
+<li><strong>Native diagnostics and networking:</strong> keep Android settings diagnostics readable and copyable, preserve complete quoted cache validators, use the installed WebSocket transport for node streams, and support Matrix and the bundled Proxyline runtime on opt-in Bun installations. Related #140528. (#139647, #140411, #140477, #140490, #140529)</li>
+<li><strong>Upgrade continuity:</strong> support 2026.9.2-driven shared-state-only upgrades by deferring publication of the new schema version while the updater still needs its update history. Agent-schema migrations, missing state metadata, and failed state migrations retain typed refusal and the external-install/fresh-Doctor recovery path; see <a href="https://docs.openclaw.ai/reference/database-schemas#schema-bumps-and-older-updaters">schema-bump recovery</a>. (#141109)</li>
+<li><strong>Telegram and Discord:</strong> preserve typing independently across concurrent Telegram forum topics, retain Discord voice input until transcription finishes, and preserve indentation in Discord and session messages. Related #121351, #138763. (#139292, #139390, #139484) Thanks @gaoanze888, @maxschachere, @obviyus, @ruel225, and @yifanxiong272.</li>
+<li><strong>Approvals and task failures:</strong> refresh pending approvals when reopening a chat and identify Gateway storage failures in run-error messages. (#139409, #139457)</li>
+<li><strong>Portable state and installation:</strong> open agent state on SQLite builds without extension support and install required native archive dependencies with bundle manifests. (#139415, #139487)</li>
+<li><strong>Setup recovery:</strong> migrate legacy workspace setup before explicit Doctor preflight consumers, expose sanitized channel startup errors in health output, verify and save provider starter aliases, and list owned cron jobs only once in removal previews. (#139339, #139395, #139473)</li>
+<li><strong>Profile and activity labels:</strong> show the primary user in multi-agent profile headers and keep activity labels visible with consistent row typography. (#136736, #139372) Thanks @jjjhenriksen.</li>
+<li><strong>MCP shutdown:</strong> avoid spurious listener errors when shutdown requests overlap. (#139391)</li>
+<li><strong>Crabbox scripts:</strong> preserve payload output and requested script options. (#139405)</li>
+<li><strong>Native state privacy:</strong> tighten native Apple state-file permissions. (#139623) Thanks @vincentkoc.</li>
+<li><strong>Database and backup integrity:</strong> prevent writes after a failed nested rollback, preserve state artifacts when reading update history, and exclude shared-workspace files from state-only backups. Related #139549. (#138917, #139598, #139700) Thanks @ayaangazali, @fuller-stack-dev, @obviyus, and @TheCrazyLex.</li>
+<li><strong>Tool results and progress:</strong> preserve empty client-tool completions, retain asynchronous tool results, ground exec approvals in actual tool results, and keep Swarm outcomes visible after completion. Related #139515, #139975. (#139490, #139520, #139988, #140043)</li>
+<li><strong>Channel delivery:</strong> send pairing approvals from the approved account, restore bare-user Mattermost DMs on private servers, preserve Matrix thread reply targets, avoid repeated mention alerts on edits, and avoid duplicating Telegram native choices in message text. (#137268, #139479, #139726, #140091, #140108) Thanks @marmar9615-cloud and @obviyus.</li>
+<li><strong>Meeting capture:</strong> keep Discord recording independent of voice conversations and retain transcript capture ownership through failed cleanup. (#139572, #139658)</li>
+<li><strong>Attachments and browser media:</strong> retain fetched and node-proxied filenames, percent sequences, MIME parameters, and ffprobe dimensions or duration; restore browser file uploads in existing sessions and preserve code fences in page evaluation results. Related #138382, #139557. (#137219, #138411, #139508, #139559, #139621, #139904, #139906) Thanks @coderdailyone, @igs-rogenlo, @NianJiuZst, @obviyus, and @ruel225.</li>
+<li><strong>Media access:</strong> keep Control UI assistant media policy consistent and stop input downloads when HTTP clients disconnect. Related #139774. (#139503, #139793) Thanks @zhangguiping-xydt.</li>
+<li><strong>Control UI:</strong> keep interactive dashboard authoring through restart, restore native customization access and configured agent avatars, show unavailable exec-node bindings, and expose agent-list failures on Memory pages. Related #127641, #139594. (#133032, #139510, #139705, #139873, #139899) Thanks @RobertOnline69 and @TurboTheTurtle.</li>
+<li><strong>Background UI work:</strong> stop hidden Inbox and automation refreshes, avoid duplicate PR refreshes after replay, and skip remote node discovery for local-only catalog pages. (#139966, #140090, #140094, #140097)</li>
+<li><strong>Linux and Windows:</strong> keep Linux widget replies connected, explain a missing Linux file opener, accept MSYS Git paths for worktrees and backups, and keep anchored Windows Gateway commands console-free. Related #138706, #139185. (#138751, #139252, #139266, #139664) Thanks @chelsealong, @haoran2025, @keith9681, @ly85206559, @obviyus, and @upple.</li>
+<li><strong>Docker startup:</strong> restore browser-enabled Gateways and stage bundled plugin runtime dependencies in their packaged plugin roots. Related #138777. (#139117, #139686) Thanks @8bitsforge, @gaoanze888, @obviyus, @vincentkoc, and @ylcn91.</li>
+<li><strong>Interactive commands:</strong> prevent stalled PTY prompts and incorrect arrow keys after split output, preserve sent hexadecimal bytes and command output under Bun, and retain log output and errors in Code Mode. (#139648, #139725, #139742, #139965)</li>
+<li><strong>ACP and MCP cleanup:</strong> preserve ACP arguments, queued output, and session ownership, cancel failed deliveries, retire delegates before cleanup, and prevent MCP servers from starting after session shutdown. Related #127128, #136246, #139680. (#127136, #139616, #139685, #139776) Thanks @eddiedon.</li>
+<li><strong>Cloud recovery:</strong> resume provisioning after temporary storage errors, preserve workspace-conflict errors during reclamation, and report failed cloud tools as errors. (#139582, #139758, #140021)</li>
+<li><strong>Forwarded messages and commands:</strong> preserve Discord forwarded text and Teams thread context while keeping commands tied to the current sender, and retain Slack inline shortcuts after mention rendering. (#137313) Thanks @Marvinthebored and @Peetiegonzalez.</li>
+<li><strong>Service-control privacy:</strong> keep application credentials and unrelated parent variables out of native service-manager subprocesses while retaining required operating-system routing. (#139333)</li>
+<li><strong>Activity pages:</strong> preserve the reader’s position during live refreshes and remove misleading per-subagent edit counters from chat rows. (#137868, #139375) Thanks @Solvely-Colin.</li>
+<li><strong>Cron accounting:</strong> retain the scheduled run’s own pricing information through finalization. (#139374)</li>
+<li><strong>Worker retirement and native events:</strong> schedule idle retirement using the worker pool’s own clock and report native plugin broadcast failures. Related #139328. (#139291, #139349) Thanks @ylcn91.</li>
+<li><strong>Streaming responsiveness:</strong> avoid repeated full rescans of native reasoning deltas, reduce discovery overhead for small-context models, and skip unnecessary provider catalog rewarming after rate limits. (#123120, #125906, #139244) Thanks @Grynn and @nierob-cmd.</li>
+<li><strong>Pairing isolation:</strong> bind pairing requests and challenges to the correct channel and account even when callers supply conflicting fields. (#139142) Thanks @obviyus and @SebTardif.</li>
+<li><strong>Agent selection:</strong> keep global session views, local commands, and Stop actions attached to the selected agent. (#138991, #139276)</li>
+<li><strong>Questions and approvals:</strong> deliver loopback questions to their originating channel and show pending Skill Workshop approval controls. Related #135291, #138540. (#138831, #139248) Thanks @cursoragent, @drsnett, @ericcaiwx-star, @khaisis, and @obviyus.</li>
+<li><strong>Tool images:</strong> keep images attached to their originating tool result when converting parallel results for compatible providers. Related #127586. (#133808) Thanks @SunnyShu0925.</li>
+<li><strong>Worker dispatch:</strong> let unrelated sessions start while pending maintenance waits for its original dispatch cohort. (#139251)</li>
+<li><strong>Matrix and Buzz:</strong> exclude archived Matrix state roots from scans and account selection, and keep implicit Buzz replies at the thread root. Related #138812. (#112329, #138879) Thanks @chachi-max, @shad0wca7, and @sunlit-deng.</li>
+<li><strong>Backup and media:</strong> preserve Unicode in stalled backup-entry paths and reject malformed generated-video downloads. (#117339, #137693) Thanks @ly85206559, @obviyus, and @Yigtwxx.</li>
+</ul>
+<h3>Deprecation migration</h3>
+<ul>
+<li><strong>Plugin SDK context aliases:</strong> <code>sdk-untrusted-context-identifier-aliases</code> remains deprecated, with a recorded removal window of <strong>2026-09-08</strong>; the aliases remain exported in this release. Migrate to <code>MsgContext.ChannelPromptContext</code>, <code>MsgContext.ChannelStructuredContext</code>, <code>ChannelStructuredContextEntry</code>, <code>SupplementalContextFacts.channelStructuredContext</code>, and <code>buildChannelMetadata</code>. See the <a href="https://docs.openclaw.ai/plugins/compatibility">plugin compatibility guide</a>.</li>
+</ul>
+<h3>Complete contribution record</h3>
+This audited record covers the complete 0229a108fee749327b2cc60c4d228299dfe2f889..65d735e432ae94cb63a15f942433aa46bc356dcb history: 1,843 in-range PRs + 0 retained seed-only PRs = 1,843 unique PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
+Shipped baseline exclusions: v2026.9.1 (9 PRs: #116740, #131746, #131767, #132420, #133152, #135702, #135728, #135903, #136557); v2026.9.2 (225 PRs: #113611, #114580, #114625, #116157, #118358, #124633, #127177, #127182, #129561, #129897, #131436, #132552, #133318, #133323, #135808, #136146, #136364, #136661, #136755, #136781, #136900, #137030, #137131, #137342, #137368, #137506, #137527, #137637, #137681, #137738, #137830, #137885, #137923, #138111, #138207, #138223, #138246, #138248, #138249, #138280, #138332, #138360, #138394, #138398, #138440, #138449, #138481, #138492, #138500, #138524, #138556, #138568, #138574, #138624, #138625, #138627, #138635, #138641, #138648, #138655, #138656, #138669, #138674, #138675, #138678, #138680, #138687, #138690, #138693, #138694, #138695, #138699, #138701, #138707, #138708, #138709, #138711, #138713, #138715, #138716, #138717, #138718, #138719, #138720, #138725, #138728, #138730, #138731, #138733, #138734, #138737, #138738, #138739, #138740, #138742, #138743, #138744, #138745, #138746, #138747, #138748, #138752, #138754, #138758, #138759, #138764, #138765, #138766, #138767, #138769, #138772, #138776, #138780, #138781, #138782, #138784, #138785, #138792, #138793, #138794, #138796, #138801, #138804, #138805, #138806, #138810, #138813, #138814, #138816, #138818, #138820, #138822, #138824, #138827, #138828, #138830, #138832, #138837, #138838, #138840, #138841, #138845, #138849, #138851, #138854, #138855, #138856, #138857, #138858, #138859, #138860, #138862, #138863, #138865, #138866, #138868, #138872, #138875, #138876, #138877, #138878, #138880, #138884, #138885, #138888, #138889, #138890, #138891, #138894, #138895, #138896, #138898, #138902, #138904, #138907, #138908, #138909, #138910, #138911, #138912, #138914, #138916, #138920, #138921, #138925, #138926, #138927, #138930, #138931, #138932, #138933, #138935, #138937, #138940, #138941, #138942, #138946, #138949, #138957, #138960, #138961, #138962, #138967, #138968, #138969, #138970, #138971, #138973, #138974, #138977, #138978, #138979, #138980, #139018, #139020, #139046, #139056, #139111, #139116, #139126, #139132, #139135, #139136, #139150, #139153).
+<h4>Pull requests</h4>
+<ul>
+<li><strong>PR #138948</strong> Thanks @marmar9615-cloud and @obviyus.</li>
+<li><strong>PR #138848</strong></li>
+<li><strong>PR #138995</strong> Related #138994. Thanks @lzhan011 and @obviyus.</li>
+<li><strong>PR #138976</strong></li>
+<li><strong>PR #138986</strong></li>
+<li><strong>PR #138300</strong></li>
+<li><strong>PR #139051</strong></li>
+<li><strong>PR #138991</strong></li>
+<li><strong>PR #138834</strong></li>
+<li><strong>PR #139049</strong></li>
+<li><strong>PR #139060</strong></li>
+<li><strong>PR #139064</strong> Related #138999. Thanks @obviyus and @Pondsi.</li>
+<li><strong>PR #139062</strong></li>
+<li><strong>PR #139014</strong></li>
+<li><strong>PR #139002</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #139016</strong></li>
+<li><strong>PR #139065</strong></li>
+<li><strong>PR #139055</strong></li>
+<li><strong>PR #139070</strong></li>
+<li><strong>PR #139052</strong></li>
+<li><strong>PR #139039</strong></li>
+<li><strong>PR #138170</strong></li>
+<li><strong>PR #138798</strong> Related #138722. Thanks @wangjx-xydt and @badmutt.</li>
+<li><strong>PR #139073</strong></li>
+<li><strong>PR #139050</strong></li>
+<li><strong>PR #138850</strong> Related #138753.</li>
+<li><strong>PR #132459</strong> Related #118386. Thanks @LiuwqGit and @obviyus and @bytrustu.</li>
+<li><strong>PR #139015</strong></li>
+<li><strong>PR #139058</strong></li>
+<li><strong>PR #139074</strong></li>
+<li><strong>PR #139078</strong></li>
+<li><strong>PR #139076</strong> Related #139072.</li>
+<li><strong>PR #139084</strong></li>
+<li><strong>PR #139077</strong></li>
+<li><strong>PR #138997</strong></li>
+<li><strong>PR #139019</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #139087</strong></li>
+<li><strong>PR #139063</strong> Related #139038.</li>
+<li><strong>PR #139090</strong></li>
+<li><strong>PR #139081</strong></li>
+<li><strong>PR #138964</strong></li>
+<li><strong>PR #138821</strong> Related #138802. Thanks @NianJiuZst and @obviyus and @josephbergvinson.</li>
+<li><strong>PR #117339</strong> Thanks @Yigtwxx and @obviyus.</li>
+<li><strong>PR #139059</strong> Related #139054.</li>
+<li><strong>PR #139080</strong></li>
+<li><strong>PR #136589</strong> Related #136525. Thanks @LiuwqGit and @obviyus and @lakemike.</li>
+<li><strong>PR #138059</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #139085</strong></li>
+<li><strong>PR #139093</strong></li>
+<li><strong>PR #139069</strong></li>
+<li><strong>PR #135528</strong> Thanks @obviyus.</li>
+<li><strong>PR #139123</strong></li>
+<li><strong>PR #139095</strong></li>
+<li><strong>PR #139104</strong></li>
+<li><strong>PR #139118</strong></li>
+<li><strong>PR #137682</strong> Thanks @IWhatsskill.</li>
+<li><strong>PR #111822</strong> Related #111821. Thanks @ooiuuii and @obviyus.</li>
+<li><strong>PR #139130</strong> Thanks @ly85206559 and @obviyus.</li>
+<li><strong>PR #139137</strong></li>
+<li><strong>PR #139115</strong></li>
+<li><strong>PR #139124</strong></li>
+<li><strong>PR #139035</strong></li>
+<li><strong>PR #139114</strong></li>
+<li><strong>PR #139122</strong></li>
+<li><strong>PR #138899</strong> Related #138897. Thanks @lzhan011 and @obviyus.</li>
+<li><strong>PR #139089</strong> Thanks @ylcn91 and @obviyus.</li>
+<li><strong>PR #139127</strong></li>
+<li><strong>PR #139133</strong></li>
+<li><strong>PR #139141</strong></li>
+<li><strong>PR #136623</strong> Related #136622. Thanks @vincentkoc.</li>
+<li><strong>PR #139148</strong></li>
+<li><strong>PR #139156</strong></li>
+<li><strong>PR #139157</strong></li>
+<li><strong>PR #139159</strong></li>
+<li><strong>PR #139112</strong> Related #139094.</li>
+<li><strong>PR #139140</strong> Related #139086.</li>
+<li><strong>PR #139162</strong></li>
+<li><strong>PR #136533</strong> Related #136452. Thanks @LiuwqGit and @zhangguiping-xydt and @vincentkoc and @thomasmoenco.</li>
+<li><strong>PR #139165</strong> Related #139147. Thanks @obviyus and @GarySiu.</li>
+<li><strong>PR #139163</strong></li>
+<li><strong>PR #139146</strong></li>
+<li><strong>PR #139184</strong> Related #139183.</li>
+<li><strong>PR #139174</strong></li>
+<li><strong>PR #139186</strong></li>
+<li><strong>PR #139142</strong> Thanks @SebTardif and @obviyus.</li>
+<li><strong>PR #139189</strong></li>
+<li><strong>PR #139037</strong> Thanks @hartmark and @obviyus.</li>
+<li><strong>PR #139197</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #139143</strong> Related #137357. Thanks @ylcn91 and @obviyus and @technicalpickles.</li>
+<li><strong>PR #139181</strong></li>
+<li><strong>PR #139193</strong> Related #139187.</li>
+<li><strong>PR #139192</strong></li>
+<li><strong>PR #138732</strong> Thanks @IWhatsskill.</li>
+<li><strong>PR #139203</strong> Thanks @obviyus.</li>
+<li><strong>PR #139155</strong> Related #139154. Thanks @vincentkoc.</li>
+<li><strong>PR #139092</strong></li>
+<li><strong>PR #139198</strong></li>
+<li><strong>PR #139096</strong></li>
+<li><strong>PR #139168</strong></li>
+<li><strong>PR #139218</strong> Thanks @obviyus.</li>
+<li><strong>PR #139175</strong></li>
+<li><strong>PR #139067</strong> Related #139053.</li>
+<li><strong>PR #139103</strong></li>
+<li><strong>PR #139195</strong> Related #139166.</li>
+<li><strong>PR #139222</strong></li>
+<li><strong>PR #138958</strong> Related #138956. Thanks @Colton-Harris.</li>
+<li><strong>PR #139106</strong></li>
+<li><strong>PR #139176</strong> Thanks @ylcn91 and @cursoragent and @obviyus.</li>
+<li><strong>PR #139236</strong></li>
+<li><strong>PR #139232</strong> Thanks @obviyus.</li>
+<li><strong>PR #139107</strong></li>
+<li><strong>PR #139227</strong> Related #139226.</li>
+<li><strong>PR #138757</strong> Related #138374. Thanks @VasuBansal7576 and @obviyus and @benmillerat.</li>
+<li><strong>PR #136110</strong> Thanks @obviyus.</li>
+<li><strong>PR #139233</strong></li>
+<li><strong>PR #139224</strong></li>
+<li><strong>PR #138966</strong> Related #137643. Thanks @VACInc and @aaajiao.</li>
+<li><strong>PR #139240</strong></li>
+<li><strong>PR #139245</strong></li>
+<li><strong>PR #139237</strong></li>
+<li><strong>PR #136363</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #139256</strong></li>
+<li><strong>PR #139200</strong></li>
+<li><strong>PR #139246</strong> Related #138835. Thanks @obviyus and @Colton-Harris.</li>
+<li><strong>PR #139250</strong></li>
+<li><strong>PR #139259</strong></li>
+<li><strong>PR #139247</strong></li>
+<li><strong>PR #138879</strong> Related #138812. Thanks @sunlit-deng and @chachi-max.</li>
+<li><strong>PR #139229</strong></li>
+<li><strong>PR #139108</strong></li>
+<li><strong>PR #139261</strong> Related #126445. Thanks @PollyBot13.</li>
+<li><strong>PR #139269</strong> Related #139219, #139223.</li>
+<li><strong>PR #139267</strong></li>
+<li><strong>PR #112329</strong> Thanks @shad0wca7.</li>
+<li><strong>PR #139258</strong></li>
+<li><strong>PR #138831</strong> Related #138540. Thanks @ericcaiwx-star and @cursoragent and @obviyus and @drsnett.</li>
+<li><strong>PR #139248</strong> Related #135291. Thanks @khaisis.</li>
+<li><strong>PR #139167</strong> Thanks @SebTardif and @obviyus.</li>
+<li><strong>PR #139057</strong></li>
+<li><strong>PR #139282</strong> Related #139270.</li>
+<li><strong>PR #139293</strong></li>
+<li><strong>PR #139287</strong></li>
+<li><strong>PR #137517</strong> Related #137492. Thanks @LiuwqGit and @creanet-64.</li>
+<li><strong>PR #138603</strong> Related #138587. Thanks @brokemac79.</li>
+<li><strong>PR #139294</strong></li>
+<li><strong>PR #139297</strong></li>
+<li><strong>PR #138092</strong></li>
+<li><strong>PR #137731</strong></li>
+<li><strong>PR #139264</strong></li>
+<li><strong>PR #139228</strong></li>
+<li><strong>PR #139299</strong></li>
+<li><strong>PR #137693</strong> Thanks @ly85206559.</li>
+<li><strong>PR #138264</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #139300</strong></li>
+<li><strong>PR #139286</strong></li>
+<li><strong>PR #139301</strong></li>
+<li><strong>PR #133808</strong> Related #127586. Thanks @SunnyShu0925.</li>
+<li><strong>PR #139225</strong> Related #139088. Thanks @gaoanze888 and @obviyus and @JLahullier.</li>
+<li><strong>PR #139298</strong></li>
+<li><strong>PR #139017</strong></li>
+<li><strong>PR #139283</strong> Thanks @PollyBot13.</li>
+<li><strong>PR #139295</strong></li>
+<li><strong>PR #139321</strong></li>
+<li><strong>PR #139323</strong></li>
+<li><strong>PR #127837</strong> Related #127506. Thanks @vyctorbrzezowski.</li>
+<li><strong>PR #139302</strong></li>
+<li><strong>PR #139324</strong></li>
+<li><strong>PR #139276</strong></li>
+<li><strong>PR #139332</strong> Related #139305.</li>
+<li><strong>PR #134198</strong> Thanks @SebTardif.</li>
+<li><strong>PR #139307</strong></li>
+<li><strong>PR #139273</strong></li>
+<li><strong>PR #139325</strong></li>
+<li><strong>PR #136926</strong> Thanks @srikalyan and @obviyus.</li>
+<li><strong>PR #139113</strong></li>
+<li><strong>PR #139251</strong></li>
+<li><strong>PR #139336</strong></li>
+<li><strong>PR #139337</strong></li>
+<li><strong>PR #139327</strong></li>
+<li><strong>PR #139331</strong></li>
+<li><strong>PR #139311</strong></li>
+<li><strong>PR #139244</strong></li>
+<li><strong>PR #139101</strong></li>
+<li><strong>PR #139345</strong></li>
+<li><strong>PR #139329</strong></li>
+<li><strong>PR #139326</strong></li>
+<li><strong>PR #139265</strong> Related #139242. Thanks @johan-eilertsen and @obviyus.</li>
+<li><strong>PR #125906</strong> Thanks @Grynn.</li>
+<li><strong>PR #139315</strong></li>
+<li><strong>PR #139306</strong> Related #139263.</li>
+<li><strong>PR #123120</strong> Thanks @nierob-cmd.</li>
+<li><strong>PR #139342</strong></li>
+<li><strong>PR #139280</strong> Related #139268.</li>
+<li><strong>PR #139317</strong></li>
+<li><strong>PR #139314</strong></li>
+<li><strong>PR #139379</strong></li>
+<li><strong>PR #139348</strong></li>
+<li><strong>PR #139241</strong></li>
+<li><strong>PR #96311</strong> Thanks @sliverp.</li>
+<li><strong>PR #139335</strong> Related #139322.</li>
+<li><strong>PR #139382</strong></li>
+<li><strong>PR #139362</strong></li>
+<li><strong>PR #139356</strong></li>
+<li><strong>PR #139275</strong> Thanks @esqandil and @obviyus.</li>
+<li><strong>PR #139363</strong></li>
+<li><strong>PR #139061</strong></li>
+<li><strong>PR #139376</strong></li>
+<li><strong>PR #139350</strong></li>
+<li><strong>PR #139359</strong></li>
+<li><strong>PR #135868</strong></li>
+<li><strong>PR #139291</strong> Thanks @ylcn91.</li>
+<li><strong>PR #139358</strong></li>
+<li><strong>PR #139378</strong></li>
+<li><strong>PR #139349</strong> Related #139328.</li>
+<li><strong>PR #139370</strong></li>
+<li><strong>PR #139399</strong></li>
+<li><strong>PR #137868</strong> Thanks @Solvely-Colin.</li>
+<li><strong>PR #139387</strong></li>
+<li><strong>PR #139352</strong></li>
+<li><strong>PR #139366</strong></li>
+<li><strong>PR #139346</strong></li>
+<li><strong>PR #139369</strong></li>
+<li><strong>PR #139304</strong></li>
+<li><strong>PR #139380</strong></li>
+<li><strong>PR #139353</strong> Related #139173. Thanks @KirDE.</li>
+<li><strong>PR #139374</strong></li>
+<li><strong>PR #139375</strong></li>
+<li><strong>PR #139386</strong></li>
+<li><strong>PR #139333</strong></li>
+<li><strong>PR #139377</strong> Related #139360.</li>
+<li><strong>PR #139401</strong></li>
+<li><strong>PR #139334</strong></li>
+<li><strong>PR #139393</strong></li>
+<li><strong>PR #137313</strong> Thanks @Marvinthebored and @Peetiegonzalez.</li>
+<li><strong>PR #139406</strong></li>
+<li><strong>PR #139419</strong></li>
+<li><strong>PR #138852</strong> Related #138099. Thanks @xialonglee.</li>
+<li><strong>PR #139367</strong></li>
+<li><strong>PR #139417</strong></li>
+<li><strong>PR #139398</strong></li>
+<li><strong>PR #139390</strong> Related #121351. Thanks @ruel225 and @yifanxiong272.</li>
+<li><strong>PR #139405</strong></li>
+<li><strong>PR #139389</strong></li>
+<li><strong>PR #139423</strong> Thanks @hannesrudolph.</li>
+<li><strong>PR #139410</strong></li>
+<li><strong>PR #139339</strong></li>
+<li><strong>PR #139395</strong></li>
+<li><strong>PR #139416</strong></li>
+<li><strong>PR #139434</strong></li>
+<li><strong>PR #139426</strong></li>
+<li><strong>PR #139368</strong></li>
+<li><strong>PR #139425</strong></li>
+<li><strong>PR #139422</strong></li>
+<li><strong>PR #139435</strong></li>
+<li><strong>PR #139415</strong></li>
+<li><strong>PR #139430</strong> Related #139411.</li>
+<li><strong>PR #139427</strong></li>
+<li><strong>PR #139437</strong></li>
+<li><strong>PR #139373</strong></li>
+<li><strong>PR #139420</strong> Related #139407.</li>
+<li><strong>PR #139445</strong></li>
+<li><strong>PR #139447</strong></li>
+<li><strong>PR #139442</strong></li>
+<li><strong>PR #139391</strong></li>
+<li><strong>PR #139446</strong></li>
+<li><strong>PR #139424</strong></li>
+<li><strong>PR #139452</strong></li>
+<li><strong>PR #139403</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #139414</strong></li>
+<li><strong>PR #139431</strong></li>
+<li><strong>PR #139454</strong></li>
+<li><strong>PR #139432</strong></li>
+<li><strong>PR #138196</strong></li>
+<li><strong>PR #139462</strong> Related #137579. Thanks @shakkernerd and @abacha.</li>
+<li><strong>PR #139385</strong></li>
+<li><strong>PR #139371</strong></li>
+<li><strong>PR #139455</strong></li>
+<li><strong>PR #139456</strong></li>
+<li><strong>PR #139355</strong></li>
+<li><strong>PR #139473</strong></li>
+<li><strong>PR #139429</strong></li>
+<li><strong>PR #139397</strong> Related #139312.</li>
+<li><strong>PR #139292</strong> Related #138763. Thanks @gaoanze888 and @obviyus and @maxschachere.</li>
+<li><strong>PR #139474</strong></li>
+<li><strong>PR #139464</strong> Related #139438. Thanks @shakkernerd and @cipp-ashe.</li>
+<li><strong>PR #138351</strong> Thanks @holny.</li>
+<li><strong>PR #138210</strong> Thanks @brokemac79.</li>
+<li><strong>PR #139372</strong></li>
+<li><strong>PR #139461</strong> Related #139449.</li>
+<li><strong>PR #139457</strong></li>
+<li><strong>PR #139463</strong></li>
+<li><strong>PR #139450</strong></li>
+<li><strong>PR #139409</strong></li>
+<li><strong>PR #139484</strong></li>
+<li><strong>PR #139413</strong></li>
+<li><strong>PR #139354</strong></li>
+<li><strong>PR #139467</strong></li>
+<li><strong>PR #139441</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #139482</strong></li>
+<li><strong>PR #136361</strong> Thanks @quangtran88.</li>
+<li><strong>PR #136736</strong> Thanks @jjjhenriksen.</li>
+<li><strong>PR #139478</strong></li>
+<li><strong>PR #139487</strong></li>
+<li><strong>PR #139381</strong></li>
+<li><strong>PR #139400</strong></li>
+<li><strong>PR #139384</strong></li>
+<li><strong>PR #139289</strong> Thanks @TheAngryPit and @obviyus.</li>
+<li><strong>PR #127757</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #139459</strong></li>
+<li><strong>PR #139519</strong></li>
+<li><strong>PR #139466</strong> Related #139448.</li>
+<li><strong>PR #139500</strong></li>
+<li><strong>PR #139502</strong></li>
+<li><strong>PR #139509</strong></li>
+<li><strong>PR #139532</strong></li>
+<li><strong>PR #139533</strong></li>
+<li><strong>PR #139520</strong> Related #139515.</li>
+<li><strong>PR #139535</strong></li>
+<li><strong>PR #139483</strong></li>
+<li><strong>PR #139486</strong></li>
+<li><strong>PR #139125</strong> Related #139121.</li>
+<li><strong>PR #139529</strong> Related #139526.</li>
+<li><strong>PR #139543</strong></li>
+<li><strong>PR #139545</strong></li>
+<li><strong>PR #139552</strong></li>
+<li><strong>PR #139476</strong></li>
+<li><strong>PR #139523</strong> Related #139235.</li>
+<li><strong>PR #139517</strong></li>
+<li><strong>PR #139554</strong></li>
+<li><strong>PR #139522</strong></li>
+<li><strong>PR #139528</strong></li>
+<li><strong>PR #139565</strong></li>
+<li><strong>PR #139566</strong></li>
+<li><strong>PR #139525</strong></li>
+<li><strong>PR #139569</strong></li>
+<li><strong>PR #139576</strong></li>
+<li><strong>PR #139579</strong></li>
+<li><strong>PR #139567</strong></li>
+<li><strong>PR #139458</strong></li>
+<li><strong>PR #139506</strong></li>
+<li><strong>PR #139575</strong></li>
+<li><strong>PR #138392</strong></li>
+<li><strong>PR #139571</strong></li>
+<li><strong>PR #139572</strong></li>
+<li><strong>PR #139587</strong></li>
+<li><strong>PR #139560</strong></li>
+<li><strong>PR #139593</strong></li>
+<li><strong>PR #139479</strong></li>
+<li><strong>PR #139556</strong></li>
+<li><strong>PR #139496</strong></li>
+<li><strong>PR #139516</strong></li>
+<li><strong>PR #136374</strong> Thanks @teddytennant.</li>
+<li><strong>PR #139481</strong></li>
+<li><strong>PR #139589</strong></li>
+<li><strong>PR #139553</strong></li>
+<li><strong>PR #139469</strong></li>
+<li><strong>PR #139581</strong></li>
+<li><strong>PR #139439</strong></li>
+<li><strong>PR #139357</strong> Thanks @obviyus.</li>
+<li><strong>PR #139392</strong> Thanks @jason-allen-oneal.</li>
+<li><strong>PR #139607</strong></li>
+<li><strong>PR #139512</strong></li>
+<li><strong>PR #139531</strong></li>
+<li><strong>PR #139612</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #139491</strong> Related #139488.</li>
+<li><strong>PR #139601</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #139590</strong></li>
+<li><strong>PR #139490</strong></li>
+<li><strong>PR #139539</strong> Related #139365. Thanks @TurboTheTurtle and @obviyus and @Colton-Harris.</li>
+<li><strong>PR #139592</strong> Related #139547.</li>
+<li><strong>PR #139501</strong></li>
+<li><strong>PR #139508</strong></li>
+<li><strong>PR #136699</strong> Thanks @vincentkoc and @RomneyDa.</li>
+<li><strong>PR #139617</strong></li>
+<li><strong>PR #139618</strong></li>
+<li><strong>PR #139628</strong></li>
+<li><strong>PR #139319</strong> Related #139310.</li>
+<li><strong>PR #139507</strong> Related #139440.</li>
+<li><strong>PR #139580</strong></li>
+<li><strong>PR #139559</strong> Related #139557. Thanks @ruel225 and @obviyus.</li>
+<li><strong>PR #134274</strong></li>
+<li><strong>PR #139536</strong> Thanks @robojarvis and @obviyus.</li>
+<li><strong>PR #139598</strong> Related #139549. Thanks @ayaangazali and @obviyus and @TheCrazyLex.</li>
+<li><strong>PR #139645</strong></li>
+<li><strong>PR #139308</strong> Related #139257. Thanks @ylcn91 and @obviyus and @resYuto.</li>
+<li><strong>PR #139605</strong></li>
+<li><strong>PR #139611</strong></li>
+<li><strong>PR #139597</strong></li>
+<li><strong>PR #139595</strong></li>
+<li><strong>PR #139117</strong> Related #138777. Thanks @ylcn91 and @vincentkoc and @8bitsforge.</li>
+<li><strong>PR #139656</strong> Thanks @obviyus.</li>
+<li><strong>PR #139623</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #139564</strong></li>
+<li><strong>PR #139570</strong></li>
+<li><strong>PR #139596</strong></li>
+<li><strong>PR #139631</strong></li>
+<li><strong>PR #139616</strong></li>
+<li><strong>PR #139650</strong></li>
+<li><strong>PR #139610</strong> Related #139609.</li>
+<li><strong>PR #139630</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #139634</strong></li>
+<li><strong>PR #139460</strong></li>
+<li><strong>PR #139626</strong></li>
+<li><strong>PR #135167</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #139252</strong> Thanks @upple and @obviyus.</li>
+<li><strong>PR #139667</strong></li>
+<li><strong>PR #139638</strong></li>
+<li><strong>PR #139665</strong></li>
+<li><strong>PR #139673</strong></li>
+<li><strong>PR #139563</strong> Related #139537.</li>
+<li><strong>PR #138917</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #139679</strong></li>
+<li><strong>PR #139643</strong></li>
+<li><strong>PR #139402</strong> Thanks @SebTardif and @obviyus.</li>
+<li><strong>PR #139666</strong></li>
+<li><strong>PR #139644</strong> Related #139642.</li>
+<li><strong>PR #137219</strong> Thanks @coderdailyone.</li>
+<li><strong>PR #139627</strong></li>
+<li><strong>PR #139687</strong></li>
+<li><strong>PR #139652</strong></li>
+<li><strong>PR #139641</strong></li>
+<li><strong>PR #139659</strong></li>
+<li><strong>PR #139689</strong></li>
+<li><strong>PR #139668</strong></li>
+<li><strong>PR #139696</strong></li>
+<li><strong>PR #139636</strong></li>
+<li><strong>PR #139681</strong></li>
+<li><strong>PR #139684</strong></li>
+<li><strong>PR #139678</strong></li>
+<li><strong>PR #139685</strong> Related #139680.</li>
+<li><strong>PR #139694</strong></li>
+<li><strong>PR #139660</strong> Thanks @TheCrazyLex.</li>
+<li><strong>PR #139651</strong></li>
+<li><strong>PR #139573</strong></li>
+<li><strong>PR #139690</strong></li>
+<li><strong>PR #139702</strong></li>
+<li><strong>PR #139582</strong></li>
+<li><strong>PR #139705</strong></li>
+<li><strong>PR #139697</strong></li>
+<li><strong>PR #137713</strong> Related #137712. Thanks @aeoess.</li>
+<li><strong>PR #139691</strong></li>
+<li><strong>PR #139724</strong></li>
+<li><strong>PR #139510</strong></li>
+<li><strong>PR #139649</strong> Thanks @obviyus.</li>
+<li><strong>PR #139703</strong></li>
+<li><strong>PR #134213</strong> Related #133898. Thanks @xydt-juyaohui and @gmv3892-creator.</li>
+<li><strong>PR #139713</strong></li>
+<li><strong>PR #139688</strong></li>
+<li><strong>PR #139747</strong></li>
+<li><strong>PR #139743</strong></li>
+<li><strong>PR #139726</strong></li>
+<li><strong>PR #139715</strong></li>
+<li><strong>PR #139734</strong></li>
+<li><strong>PR #139753</strong></li>
+<li><strong>PR #139725</strong></li>
+<li><strong>PR #139736</strong></li>
+<li><strong>PR #138829</strong> Thanks @lzhan011 and @obviyus and @vincentkoc.</li>
+<li><strong>PR #139729</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #139745</strong></li>
+<li><strong>PR #139737</strong></li>
+<li><strong>PR #139653</strong></li>
+<li><strong>PR #139674</strong></li>
+<li><strong>PR #138125</strong></li>
+<li><strong>PR #139719</strong></li>
+<li><strong>PR #139746</strong></li>
+<li><strong>PR #139421</strong></li>
+<li><strong>PR #139759</strong></li>
+<li><strong>PR #139716</strong></li>
+<li><strong>PR #139657</strong></li>
+<li><strong>PR #139646</strong></li>
+<li><strong>PR #139764</strong></li>
+<li><strong>PR #139635</strong></li>
+<li><strong>PR #139480</strong></li>
+<li><strong>PR #139738</strong></li>
+<li><strong>PR #139709</strong> Related #139527. Thanks @Conan-Scott.</li>
+<li><strong>PR #139739</strong></li>
+<li><strong>PR #139763</strong></li>
+<li><strong>PR #139720</strong></li>
+<li><strong>PR #139503</strong></li>
+<li><strong>PR #139740</strong></li>
+<li><strong>PR #139698</strong></li>
+<li><strong>PR #139621</strong></li>
+<li><strong>PR #139794</strong></li>
+<li><strong>PR #139695</strong></li>
+<li><strong>PR #139749</strong> Thanks @obviyus.</li>
+<li><strong>PR #139791</strong> Thanks @obviyus.</li>
+<li><strong>PR #139625</strong></li>
+<li><strong>PR #139801</strong> Thanks @obviyus and @Colton-Harris.</li>
+<li><strong>PR #139206</strong> Thanks @obviyus.</li>
+<li><strong>PR #139766</strong></li>
+<li><strong>PR #139731</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #139750</strong> Thanks @obviyus.</li>
+<li><strong>PR #139795</strong></li>
+<li><strong>PR #138199</strong></li>
+<li><strong>PR #117302</strong> Thanks @ayaangazali and @vincentkoc.</li>
+<li><strong>PR #139790</strong></li>
+<li><strong>PR #139741</strong></li>
+<li><strong>PR #139760</strong> Thanks @obviyus.</li>
+<li><strong>PR #139733</strong></li>
+<li><strong>PR #139784</strong></li>
+<li><strong>PR #139640</strong></li>
+<li><strong>PR #139767</strong></li>
+<li><strong>PR #139785</strong></li>
+<li><strong>PR #139773</strong></li>
+<li><strong>PR #139786</strong></li>
+<li><strong>PR #139686</strong> Thanks @gaoanze888 and @obviyus.</li>
+<li><strong>PR #139814</strong></li>
+<li><strong>PR #139757</strong></li>
+<li><strong>PR #139658</strong></li>
+<li><strong>PR #139820</strong></li>
+<li><strong>PR #139755</strong></li>
+<li><strong>PR #139796</strong></li>
+<li><strong>PR #139765</strong></li>
+<li><strong>PR #139798</strong></li>
+<li><strong>PR #139776</strong> Related #136246. Thanks @eddiedon.</li>
+<li><strong>PR #139775</strong></li>
+<li><strong>PR #139803</strong></li>
+<li><strong>PR #139632</strong></li>
+<li><strong>PR #138928</strong> Thanks @chelsealong.</li>
+<li><strong>PR #139717</strong></li>
+<li><strong>PR #139758</strong></li>
+<li><strong>PR #127225</strong> Thanks @ampagent.</li>
+<li><strong>PR #139804</strong></li>
+<li><strong>PR #139807</strong></li>
+<li><strong>PR #139836</strong> Related #139109. Thanks @gaoanze888 and @NovaUnboundAi.</li>
+<li><strong>PR #139661</strong> Related #139341. Thanks @ruel225 and @obviyus and @Jackten.</li>
+<li><strong>PR #139846</strong> Thanks @obviyus.</li>
+<li><strong>PR #139849</strong> Thanks @obviyus.</li>
+<li><strong>PR #139639</strong></li>
+<li><strong>PR #139845</strong></li>
+<li><strong>PR #139823</strong></li>
+<li><strong>PR #139771</strong></li>
+<li><strong>PR #139817</strong> Thanks @obviyus.</li>
+<li><strong>PR #139821</strong></li>
+<li><strong>PR #139835</strong></li>
+<li><strong>PR #139805</strong></li>
+<li><strong>PR #139815</strong></li>
+<li><strong>PR #137120</strong> Related #137033. Thanks @shakkernerd.</li>
+<li><strong>PR #139309</strong> Thanks @altaywtf.</li>
+<li><strong>PR #139783</strong></li>
+<li><strong>PR #139848</strong> Related #139498, #139499. Thanks @goslingmanagment.</li>
+<li><strong>PR #139806</strong></li>
+<li><strong>PR #139777</strong></li>
+<li><strong>PR #139497</strong></li>
+<li><strong>PR #139655</strong></li>
+<li><strong>PR #139860</strong></li>
+<li><strong>PR #139778</strong></li>
+<li><strong>PR #139787</strong></li>
+<li><strong>PR #139730</strong> Related #139671. Thanks @ly85206559 and @obviyus.</li>
+<li><strong>PR #139788</strong></li>
+<li><strong>PR #139779</strong></li>
+<li><strong>PR #139831</strong></li>
+<li><strong>PR #139826</strong></li>
+<li><strong>PR #139851</strong></li>
+<li><strong>PR #138839</strong> Related #136997.</li>
+<li><strong>PR #139829</strong></li>
+<li><strong>PR #139800</strong></li>
+<li><strong>PR #139852</strong></li>
+<li><strong>PR #139819</strong></li>
+<li><strong>PR #139793</strong> Related #139774. Thanks @zhangguiping-xydt.</li>
+<li><strong>PR #139840</strong></li>
+<li><strong>PR #137209</strong> Thanks @marmar9615-cloud.</li>
+<li><strong>PR #139863</strong></li>
+<li><strong>PR #139864</strong></li>
+<li><strong>PR #139683</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #139865</strong></li>
+<li><strong>PR #139465</strong></li>
+<li><strong>PR #133032</strong> Related #127641. Thanks @TurboTheTurtle.</li>
+<li><strong>PR #139880</strong> Thanks @obviyus.</li>
+<li><strong>PR #139816</strong></li>
+<li><strong>PR #139856</strong></li>
+<li><strong>PR #139884</strong> Thanks @obviyus.</li>
+<li><strong>PR #139824</strong></li>
+<li><strong>PR #139825</strong></li>
+<li><strong>PR #139243</strong> Related #139207. Thanks @LiuwqGit and @vincentkoc and @NovaUnboundAi.</li>
+<li><strong>PR #139744</strong></li>
+<li><strong>PR #139876</strong> Thanks @obviyus.</li>
+<li><strong>PR #137344</strong> Thanks @xydt-juyaohui and @fuller-stack-dev.</li>
+<li><strong>PR #139890</strong></li>
+<li><strong>PR #139858</strong></li>
+<li><strong>PR #139894</strong></li>
+<li><strong>PR #139769</strong></li>
+<li><strong>PR #139886</strong></li>
+<li><strong>PR #139712</strong></li>
+<li><strong>PR #139897</strong></li>
+<li><strong>PR #139905</strong></li>
+<li><strong>PR #139732</strong></li>
+<li><strong>PR #139885</strong></li>
+<li><strong>PR #139555</strong></li>
+<li><strong>PR #139663</strong></li>
+<li><strong>PR #139895</strong></li>
+<li><strong>PR #139855</strong></li>
+<li><strong>PR #139873</strong> Related #139594. Thanks @RobertOnline69.</li>
+<li><strong>PR #139844</strong> Related #139494. Thanks @hyspacex.</li>
+<li><strong>PR #139904</strong></li>
+<li><strong>PR #139898</strong></li>
+<li><strong>PR #139866</strong></li>
+<li><strong>PR #139907</strong> Thanks @obviyus.</li>
+<li><strong>PR #139881</strong></li>
+<li><strong>PR #139874</strong></li>
+<li><strong>PR #139906</strong></li>
+<li><strong>PR #139828</strong></li>
+<li><strong>PR #139914</strong></li>
+<li><strong>PR #139913</strong></li>
+<li><strong>PR #139920</strong></li>
+<li><strong>PR #139908</strong></li>
+<li><strong>PR #139901</strong></li>
+<li><strong>PR #139927</strong></li>
+<li><strong>PR #139910</strong></li>
+<li><strong>PR #139827</strong></li>
+<li><strong>PR #139928</strong></li>
+<li><strong>PR #139892</strong></li>
+<li><strong>PR #139862</strong> Related #139857.</li>
+<li><strong>PR #139893</strong></li>
+<li><strong>PR #139772</strong></li>
+<li><strong>PR #139754</strong></li>
+<li><strong>PR #136639</strong></li>
+<li><strong>PR #139888</strong> Related #137125. Thanks @shakkernerd.</li>
+<li><strong>PR #139937</strong></li>
+<li><strong>PR #139799</strong></li>
+<li><strong>PR #139936</strong></li>
+<li><strong>PR #139916</strong> Thanks @obviyus.</li>
+<li><strong>PR #139931</strong> Thanks @obviyus.</li>
+<li><strong>PR #139722</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #139915</strong></li>
+<li><strong>PR #138751</strong> Related #138706. Thanks @chelsealong and @keith9681.</li>
+<li><strong>PR #139923</strong> Thanks @obviyus.</li>
+<li><strong>PR #139940</strong> Related #139939.</li>
+<li><strong>PR #139811</strong></li>
+<li><strong>PR #139879</strong></li>
+<li><strong>PR #139932</strong></li>
+<li><strong>PR #139418</strong> Related #139303.</li>
+<li><strong>PR #139935</strong></li>
+<li><strong>PR #139388</strong></li>
+<li><strong>PR #139930</strong></li>
+<li><strong>PR #139752</strong></li>
+<li><strong>PR #139919</strong></li>
+<li><strong>PR #139704</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #139700</strong></li>
+<li><strong>PR #139912</strong></li>
+<li><strong>PR #139953</strong></li>
+<li><strong>PR #139948</strong></li>
+<li><strong>PR #124476</strong> Thanks @coaiMax.</li>
+<li><strong>PR #139942</strong></li>
+<li><strong>PR #139770</strong></li>
+<li><strong>PR #139947</strong> Related #139945.</li>
+<li><strong>PR #139832</strong></li>
+<li><strong>PR #139969</strong></li>
+<li><strong>PR #139924</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #139957</strong></li>
+<li><strong>PR #139834</strong></li>
+<li><strong>PR #139837</strong></li>
+<li><strong>PR #139861</strong></li>
+<li><strong>PR #139812</strong></li>
+<li><strong>PR #139843</strong></li>
+<li><strong>PR #139664</strong></li>
+<li><strong>PR #139941</strong></li>
+<li><strong>PR #139900</strong></li>
+<li><strong>PR #138768</strong></li>
+<li><strong>PR #139558</strong></li>
+<li><strong>PR #139985</strong></li>
+<li><strong>PR #139648</strong></li>
+<li><strong>PR #139859</strong></li>
+<li><strong>PR #139955</strong></li>
+<li><strong>PR #139968</strong></li>
+<li><strong>PR #139949</strong></li>
+<li><strong>PR #139984</strong></li>
+<li><strong>PR #139988</strong> Related #139975.</li>
+<li><strong>PR #139982</strong></li>
+<li><strong>PR #139991</strong> Thanks @obviyus.</li>
+<li><strong>PR #139992</strong></li>
+<li><strong>PR #139956</strong> Related #139954.</li>
+<li><strong>PR #127113</strong> Related #127095.</li>
+<li><strong>PR #131595</strong></li>
+<li><strong>PR #139997</strong></li>
+<li><strong>PR #139918</strong></li>
+<li><strong>PR #139966</strong></li>
+<li><strong>PR #139965</strong></li>
+<li><strong>PR #139899</strong></li>
+<li><strong>PR #139882</strong></li>
+<li><strong>PR #139842</strong> Thanks @obviyus.</li>
+<li><strong>PR #140004</strong></li>
+<li><strong>PR #140002</strong></li>
+<li><strong>PR #139993</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #139959</strong></li>
+<li><strong>PR #139266</strong> Related #139185. Thanks @ly85206559 and @haoran2025.</li>
+<li><strong>PR #127136</strong> Related #127128.</li>
+<li><strong>PR #140017</strong></li>
+<li><strong>PR #139841</strong></li>
+<li><strong>PR #139973</strong></li>
+<li><strong>PR #139742</strong></li>
+<li><strong>PR #137268</strong> Thanks @marmar9615-cloud.</li>
+<li><strong>PR #140014</strong></li>
+<li><strong>PR #138900</strong></li>
+<li><strong>PR #139808</strong></li>
+<li><strong>PR #139944</strong></li>
+<li><strong>PR #140031</strong></li>
+<li><strong>PR #139967</strong></li>
+<li><strong>PR #140032</strong></li>
+<li><strong>PR #140026</strong></li>
+<li><strong>PR #133400</strong></li>
+<li><strong>PR #140029</strong></li>
+<li><strong>PR #139974</strong> Related #139971.</li>
+<li><strong>PR #140015</strong></li>
+<li><strong>PR #127216</strong> Related #127196.</li>
+<li><strong>PR #140044</strong></li>
+<li><strong>PR #139875</strong></li>
+<li><strong>PR #140013</strong></li>
+<li><strong>PR #140028</strong></li>
+<li><strong>PR #140038</strong></li>
+<li><strong>PR #139958</strong></li>
+<li><strong>PR #140019</strong></li>
+<li><strong>PR #140043</strong></li>
+<li><strong>PR #140048</strong></li>
+<li><strong>PR #139987</strong></li>
+<li><strong>PR #140049</strong></li>
+<li><strong>PR #140059</strong></li>
+<li><strong>PR #140040</strong></li>
+<li><strong>PR #139495</strong></li>
+<li><strong>PR #139951</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #140047</strong></li>
+<li><strong>PR #140058</strong></li>
+<li><strong>PR #140054</strong></li>
+<li><strong>PR #140024</strong></li>
+<li><strong>PR #140046</strong></li>
+<li><strong>PR #140061</strong></li>
+<li><strong>PR #139921</strong></li>
+<li><strong>PR #140057</strong></li>
+<li><strong>PR #140033</strong></li>
+<li><strong>PR #139922</strong></li>
+<li><strong>PR #117370</strong></li>
+<li><strong>PR #140023</strong></li>
+<li><strong>PR #140065</strong> Related #140063.</li>
+<li><strong>PR #140069</strong></li>
+<li><strong>PR #140062</strong></li>
+<li><strong>PR #140056</strong></li>
+<li><strong>PR #140041</strong> Thanks @obviyus.</li>
+<li><strong>PR #140034</strong></li>
+<li><strong>PR #140071</strong></li>
+<li><strong>PR #139692</strong></li>
+<li><strong>PR #140076</strong></li>
+<li><strong>PR #138411</strong> Related #138382. Thanks @NianJiuZst and @igs-rogenlo.</li>
+<li><strong>PR #140066</strong></li>
+<li><strong>PR #139952</strong></li>
+<li><strong>PR #140022</strong></li>
+<li><strong>PR #140016</strong></li>
+<li><strong>PR #140074</strong></li>
+<li><strong>PR #140072</strong></li>
+<li><strong>PR #140018</strong> Thanks @ylcn91 and @vincentkoc.</li>
+<li><strong>PR #140021</strong></li>
+<li><strong>PR #140081</strong></li>
+<li><strong>PR #140051</strong></li>
+<li><strong>PR #140078</strong></li>
+<li><strong>PR #137649</strong> Thanks @ly85206559.</li>
+<li><strong>PR #140087</strong></li>
+<li><strong>PR #140077</strong></li>
+<li><strong>PR #140089</strong></li>
+<li><strong>PR #139789</strong></li>
+<li><strong>PR #140083</strong> Related #140080.</li>
+<li><strong>PR #140068</strong></li>
+<li><strong>PR #131462</strong> Related #131374. Thanks @gaoanze888 and @andersonjeccel.</li>
+<li><strong>PR #140093</strong></li>
+<li><strong>PR #140092</strong></li>
+<li><strong>PR #138448</strong></li>
+<li><strong>PR #140088</strong></li>
+<li><strong>PR #140084</strong></li>
+<li><strong>PR #140070</strong></li>
+<li><strong>PR #140091</strong></li>
+<li><strong>PR #140082</strong></li>
+<li><strong>PR #140098</strong></li>
+<li><strong>PR #140090</strong></li>
+<li><strong>PR #140104</strong> Related #140103.</li>
+<li><strong>PR #140108</strong> Thanks @obviyus.</li>
+<li><strong>PR #140110</strong></li>
+<li><strong>PR #140118</strong></li>
+<li><strong>PR #140095</strong></li>
+<li><strong>PR #135604</strong></li>
+<li><strong>PR #140097</strong></li>
+<li><strong>PR #139701</strong></li>
+<li><strong>PR #140094</strong></li>
+<li><strong>PR #140114</strong></li>
+<li><strong>PR #140122</strong></li>
+<li><strong>PR #118466</strong> Thanks @zeroaltitude.</li>
+<li><strong>PR #138391</strong> Related #137864. Thanks @teddytennant and @obviyus and @fisherman86-ai.</li>
+<li><strong>PR #140105</strong> Thanks @obviyus.</li>
+<li><strong>PR #140086</strong> Thanks @obviyus.</li>
+<li><strong>PR #119126</strong> Thanks @shad0wca7.</li>
+<li><strong>PR #139489</strong></li>
+<li><strong>PR #140126</strong></li>
+<li><strong>PR #140130</strong> Thanks @obviyus.</li>
+<li><strong>PR #137253</strong> Thanks @coderdailyone.</li>
+<li><strong>PR #140139</strong> Thanks @obviyus.</li>
+<li><strong>PR #140134</strong></li>
+<li><strong>PR #120248</strong> Thanks @lucascmg-vx.</li>
+<li><strong>PR #140138</strong></li>
+<li><strong>PR #139613</strong> Related #138613. Thanks @TurboTheTurtle and @vincentkoc.</li>
+<li><strong>PR #140113</strong></li>
+<li><strong>PR #140123</strong></li>
+<li><strong>PR #140124</strong></li>
+<li><strong>PR #140143</strong></li>
+<li><strong>PR #140135</strong></li>
+<li><strong>PR #121603</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140133</strong></li>
+<li><strong>PR #140144</strong></li>
+<li><strong>PR #140112</strong></li>
+<li><strong>PR #140107</strong></li>
+<li><strong>PR #140148</strong> Thanks @mbelinky.</li>
+<li><strong>PR #139970</strong></li>
+<li><strong>PR #140132</strong></li>
+<li><strong>PR #140152</strong></li>
+<li><strong>PR #140149</strong></li>
+<li><strong>PR #140142</strong></li>
+<li><strong>PR #139933</strong> Related #139838. Thanks @be-student and @obviyus and @fray-ai.</li>
+<li><strong>PR #140151</strong></li>
+<li><strong>PR #140154</strong> Thanks @obviyus.</li>
+<li><strong>PR #140120</strong></li>
+<li><strong>PR #140140</strong></li>
+<li><strong>PR #140150</strong></li>
+<li><strong>PR #139728</strong> Thanks @IWhatsskill and @fuller-stack-dev.</li>
+<li><strong>PR #140160</strong></li>
+<li><strong>PR #140163</strong></li>
+<li><strong>PR #137105</strong> Related #136966. Thanks @ericcaiwx-star and @obviyus and @singletrackandrew.</li>
+<li><strong>PR #140167</strong></li>
+<li><strong>PR #139995</strong></li>
+<li><strong>PR #140170</strong></li>
+<li><strong>PR #140025</strong> Related #140005.</li>
+<li><strong>PR #140165</strong></li>
+<li><strong>PR #140175</strong></li>
+<li><strong>PR #140174</strong></li>
+<li><strong>PR #140164</strong></li>
+<li><strong>PR #139911</strong> Related #139867.</li>
+<li><strong>PR #140169</strong></li>
+<li><strong>PR #140176</strong></li>
+<li><strong>PR #139216</strong> Thanks @ly85206559.</li>
+<li><strong>PR #140177</strong></li>
+<li><strong>PR #140145</strong></li>
+<li><strong>PR #139675</strong></li>
+<li><strong>PR #140186</strong></li>
+<li><strong>PR #140188</strong></li>
+<li><strong>PR #140189</strong></li>
+<li><strong>PR #140187</strong></li>
+<li><strong>PR #137494</strong> Thanks @IWhatsskill.</li>
+<li><strong>PR #140196</strong> Related #140050. Thanks @obviyus and @josephbergvinson.</li>
+<li><strong>PR #140190</strong></li>
+<li><strong>PR #140178</strong></li>
+<li><strong>PR #140199</strong></li>
+<li><strong>PR #140208</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140209</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140207</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140197</strong></li>
+<li><strong>PR #140173</strong> Related #140153.</li>
+<li><strong>PR #140185</strong></li>
+<li><strong>PR #140205</strong></li>
+<li><strong>PR #140200</strong></li>
+<li><strong>PR #139972</strong> Related #139950. Thanks @NianJiuZst and @obviyus and @noelillinger.</li>
+<li><strong>PR #137351</strong> Related #137308. Thanks @ylcn91 and @obviyus and @pawel-kowalczyk.</li>
+<li><strong>PR #139662</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140217</strong></li>
+<li><strong>PR #137978</strong> Related #135354. Thanks @harshitgupta31415 and @edenfunf.</li>
+<li><strong>PR #140111</strong> Related #140109.</li>
+<li><strong>PR #140201</strong></li>
+<li><strong>PR #140194</strong></li>
+<li><strong>PR #140224</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #123624</strong> Thanks @yu-xin-c.</li>
+<li><strong>PR #137211</strong> Related #137151. Thanks @Alix-007 and @obviyus and @vladimirkrdzic.</li>
+<li><strong>PR #140181</strong></li>
+<li><strong>PR #139160</strong> Related #138672. Thanks @waterundman and @vincentkoc and @dmwtech.</li>
+<li><strong>PR #140206</strong></li>
+<li><strong>PR #140191</strong></li>
+<li><strong>PR #140221</strong></li>
+<li><strong>PR #140227</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140223</strong></li>
+<li><strong>PR #140008</strong> Thanks @ruel225.</li>
+<li><strong>PR #140198</strong></li>
+<li><strong>PR #140228</strong></li>
+<li><strong>PR #140195</strong> Thanks @obviyus.</li>
+<li><strong>PR #140166</strong> Related #132829. Thanks @dragonnite1221-lgtm and @IWhatsskill.</li>
+<li><strong>PR #140202</strong></li>
+<li><strong>PR #136293</strong> Thanks @edenfunf.</li>
+<li><strong>PR #139727</strong></li>
+<li><strong>PR #140234</strong></li>
+<li><strong>PR #140233</strong></li>
+<li><strong>PR #140210</strong></li>
+<li><strong>PR #140229</strong> Related #140184.</li>
+<li><strong>PR #140226</strong></li>
+<li><strong>PR #140215</strong></li>
+<li><strong>PR #140231</strong> Thanks @VACInc.</li>
+<li><strong>PR #140225</strong></li>
+<li><strong>PR #138322</strong> Related #138299. Thanks @Amazingjun-j and @obviyus and @gszj2018.</li>
+<li><strong>PR #140245</strong></li>
+<li><strong>PR #140218</strong></li>
+<li><strong>PR #140183</strong></li>
+<li><strong>PR #122658</strong> Thanks @masatohoshino.</li>
+<li><strong>PR #140262</strong></li>
+<li><strong>PR #140247</strong></li>
+<li><strong>PR #140236</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #137114</strong> Thanks @qingminglong.</li>
+<li><strong>PR #140259</strong></li>
+<li><strong>PR #140220</strong></li>
+<li><strong>PR #140242</strong></li>
+<li><strong>PR #140271</strong></li>
+<li><strong>PR #140264</strong></li>
+<li><strong>PR #140241</strong></li>
+<li><strong>PR #137269</strong> Related #137217. Thanks @LiuwqGit and @obviyus and @zyrill.</li>
+<li><strong>PR #140237</strong></li>
+<li><strong>PR #140256</strong></li>
+<li><strong>PR #140255</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140275</strong></li>
+<li><strong>PR #127231</strong></li>
+<li><strong>PR #140284</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #140282</strong></li>
+<li><strong>PR #140270</strong></li>
+<li><strong>PR #140276</strong></li>
+<li><strong>PR #140286</strong></li>
+<li><strong>PR #138597</strong> Related #127809. Thanks @sunlit-deng and @obviyus and @anyech.</li>
+<li><strong>PR #140289</strong> Related #140287.</li>
+<li><strong>PR #140219</strong></li>
+<li><strong>PR #140290</strong></li>
+<li><strong>PR #140298</strong></li>
+<li><strong>PR #138985</strong> Related #138959. Thanks @VACInc.</li>
+<li><strong>PR #140293</strong></li>
+<li><strong>PR #140299</strong></li>
+<li><strong>PR #140301</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140302</strong></li>
+<li><strong>PR #118094</strong> Thanks @peterolkhov.</li>
+<li><strong>PR #140313</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #140303</strong></li>
+<li><strong>PR #140222</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #137680</strong> Thanks @ly85206559.</li>
+<li><strong>PR #140307</strong></li>
+<li><strong>PR #140321</strong></li>
+<li><strong>PR #140304</strong></li>
+<li><strong>PR #140257</strong></li>
+<li><strong>PR #140323</strong></li>
+<li><strong>PR #140319</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140317</strong></li>
+<li><strong>PR #140325</strong></li>
+<li><strong>PR #140240</strong></li>
+<li><strong>PR #140297</strong></li>
+<li><strong>PR #140291</strong></li>
+<li><strong>PR #137464</strong> Related #137165. Thanks @Ghilteras and @VACInc and @GDXbsv.</li>
+<li><strong>PR #140306</strong></li>
+<li><strong>PR #140312</strong></li>
+<li><strong>PR #140328</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #140326</strong></li>
+<li><strong>PR #140332</strong></li>
+<li><strong>PR #140327</strong></li>
+<li><strong>PR #140280</strong></li>
+<li><strong>PR #140322</strong></li>
+<li><strong>PR #140337</strong></li>
+<li><strong>PR #140341</strong> Related #140340.</li>
+<li><strong>PR #140263</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #140274</strong> Related #124396. Thanks @fuller-stack-dev and @obviyus.</li>
+<li><strong>PR #140311</strong></li>
+<li><strong>PR #140331</strong></li>
+<li><strong>PR #140343</strong></li>
+<li><strong>PR #140345</strong></li>
+<li><strong>PR #139540</strong> Thanks @LiuwqGit.</li>
+<li><strong>PR #140338</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #140353</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140347</strong></li>
+<li><strong>PR #140260</strong></li>
+<li><strong>PR #140350</strong> Related #140349.</li>
+<li><strong>PR #140342</strong></li>
+<li><strong>PR #139822</strong></li>
+<li><strong>PR #140358</strong></li>
+<li><strong>PR #140329</strong></li>
+<li><strong>PR #122373</strong> Thanks @ooiuuii.</li>
+<li><strong>PR #140360</strong></li>
+<li><strong>PR #140365</strong></li>
+<li><strong>PR #139990</strong> Thanks @ly85206559.</li>
+<li><strong>PR #140368</strong></li>
+<li><strong>PR #140361</strong></li>
+<li><strong>PR #140182</strong> Related #140179.</li>
+<li><strong>PR #140369</strong></li>
+<li><strong>PR #139943</strong></li>
+<li><strong>PR #140364</strong></li>
+<li><strong>PR #140370</strong></li>
+<li><strong>PR #140336</strong></li>
+<li><strong>PR #140315</strong> Thanks @obviyus.</li>
+<li><strong>PR #140157</strong></li>
+<li><strong>PR #140254</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140374</strong></li>
+<li><strong>PR #140382</strong></li>
+<li><strong>PR #140371</strong></li>
+<li><strong>PR #138275</strong> Related #138225. Thanks @ruel225 and @obviyus and @alexdhc.</li>
+<li><strong>PR #140267</strong></li>
+<li><strong>PR #137330</strong> Related #137198. Thanks @ruel225 and @obviyus and @felixboenkost-droid.</li>
+<li><strong>PR #140385</strong></li>
+<li><strong>PR #140362</strong></li>
+<li><strong>PR #140389</strong></li>
+<li><strong>PR #140367</strong> Thanks @VACInc.</li>
+<li><strong>PR #140324</strong></li>
+<li><strong>PR #140372</strong></li>
+<li><strong>PR #140394</strong></li>
+<li><strong>PR #140395</strong></li>
+<li><strong>PR #140400</strong></li>
+<li><strong>PR #140391</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140390</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140386</strong></li>
+<li><strong>PR #140402</strong></li>
+<li><strong>PR #140379</strong></li>
+<li><strong>PR #140403</strong></li>
+<li><strong>PR #140407</strong></li>
+<li><strong>PR #138386</strong> Related #137452. Thanks @ylcn91 and @obviyus and @abacha.</li>
+<li><strong>PR #140377</strong></li>
+<li><strong>PR #140408</strong></li>
+<li><strong>PR #140333</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #140409</strong></li>
+<li><strong>PR #140335</strong> Thanks @VACInc.</li>
+<li><strong>PR #140415</strong></li>
+<li><strong>PR #140384</strong></li>
+<li><strong>PR #140420</strong></li>
+<li><strong>PR #138345</strong> Thanks @Eppiedude.</li>
+<li><strong>PR #140427</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #136045</strong> Related #136854. Thanks @wangmiao0668000666 and @obviyus.</li>
+<li><strong>PR #140330</strong></li>
+<li><strong>PR #140410</strong> Related #140354. Thanks @hannesrudolph.</li>
+<li><strong>PR #140432</strong></li>
+<li><strong>PR #140435</strong></li>
+<li><strong>PR #140433</strong></li>
+<li><strong>PR #140439</strong></li>
+<li><strong>PR #140436</strong></li>
+<li><strong>PR #140417</strong> Related #140355. Thanks @hannesrudolph.</li>
+<li><strong>PR #140430</strong></li>
+<li><strong>PR #140294</strong> Thanks @VACInc.</li>
+<li><strong>PR #140419</strong></li>
+<li><strong>PR #140310</strong> Thanks @VACInc.</li>
+<li><strong>PR #140437</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140442</strong></li>
+<li><strong>PR #140445</strong></li>
+<li><strong>PR #140399</strong> Related #140398. Thanks @Takhoffman.</li>
+<li><strong>PR #140448</strong></li>
+<li><strong>PR #140450</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140440</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140446</strong></li>
+<li><strong>PR #140444</strong></li>
+<li><strong>PR #140411</strong></li>
+<li><strong>PR #136382</strong> Related #43690. Thanks @ltspace and @name5566 and @PenguinMiaou.</li>
+<li><strong>PR #140414</strong></li>
+<li><strong>PR #140453</strong></li>
+<li><strong>PR #140119</strong></li>
+<li><strong>PR #140451</strong></li>
+<li><strong>PR #139231</strong> Thanks @rodrigo-fonseca-oliveira.</li>
+<li><strong>PR #140454</strong></li>
+<li><strong>PR #140434</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #140456</strong></li>
+<li><strong>PR #140438</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #140461</strong></li>
+<li><strong>PR #140459</strong></li>
+<li><strong>PR #140463</strong></li>
+<li><strong>PR #140460</strong></li>
+<li><strong>PR #140462</strong></li>
+<li><strong>PR #140441</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #140426</strong> Related #137108. Thanks @shakkernerd.</li>
+<li><strong>PR #140471</strong> Related #140470.</li>
+<li><strong>PR #140475</strong></li>
+<li><strong>PR #140474</strong></li>
+<li><strong>PR #140469</strong></li>
+<li><strong>PR #140476</strong></li>
+<li><strong>PR #137235</strong> Related #137214. Thanks @LiuwqGit and @obviyus and @Denny22044.</li>
+<li><strong>PR #139647</strong></li>
+<li><strong>PR #140483</strong></li>
+<li><strong>PR #140485</strong></li>
+<li><strong>PR #140490</strong></li>
+<li><strong>PR #140491</strong></li>
+<li><strong>PR #140495</strong> Related #140492.</li>
+<li><strong>PR #140472</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140346</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140496</strong></li>
+<li><strong>PR #140500</strong></li>
+<li><strong>PR #140484</strong> Thanks @Takhoffman.</li>
+<li><strong>PR #140502</strong></li>
+<li><strong>PR #140099</strong> Thanks @ly85206559.</li>
+<li><strong>PR #140486</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140489</strong></li>
+<li><strong>PR #140498</strong></li>
+<li><strong>PR #140478</strong></li>
+<li><strong>PR #140511</strong></li>
+<li><strong>PR #140509</strong></li>
+<li><strong>PR #140510</strong></li>
+<li><strong>PR #140512</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140506</strong></li>
+<li><strong>PR #140481</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140488</strong></li>
+<li><strong>PR #140514</strong></li>
+<li><strong>PR #140513</strong></li>
+<li><strong>PR #140480</strong></li>
+<li><strong>PR #140518</strong></li>
+<li><strong>PR #140519</strong></li>
+<li><strong>PR #140515</strong></li>
+<li><strong>PR #140516</strong></li>
+<li><strong>PR #140520</strong></li>
+<li><strong>PR #140477</strong></li>
+<li><strong>PR #140517</strong></li>
+<li><strong>PR #140521</strong></li>
+<li><strong>PR #140522</strong></li>
+<li><strong>PR #140525</strong></li>
+<li><strong>PR #137976</strong></li>
+<li><strong>PR #140493</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140523</strong></li>
+<li><strong>PR #140527</strong></li>
+<li><strong>PR #140524</strong></li>
+<li><strong>PR #140529</strong> Related #140528.</li>
+<li><strong>PR #140530</strong></li>
+<li><strong>PR #140533</strong></li>
+<li><strong>PR #122595</strong> Thanks @vincentkoc and @ejames-dev.</li>
+<li><strong>PR #140534</strong></li>
+<li><strong>PR #140532</strong></li>
+<li><strong>PR #140536</strong></li>
+<li><strong>PR #140526</strong> Related #139994. Thanks @obviyus and @keith9681.</li>
+<li><strong>PR #140542</strong></li>
+<li><strong>PR #140541</strong></li>
+<li><strong>PR #140538</strong></li>
+<li><strong>PR #139986</strong> Thanks @FabianJun and @obviyus.</li>
+<li><strong>PR #140539</strong></li>
+<li><strong>PR #140543</strong></li>
+<li><strong>PR #140546</strong></li>
+<li><strong>PR #140549</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140548</strong></li>
+<li><strong>PR #140544</strong></li>
+<li><strong>PR #140545</strong></li>
+<li><strong>PR #140552</strong></li>
+<li><strong>PR #140551</strong></li>
+<li><strong>PR #140559</strong></li>
+<li><strong>PR #140565</strong> Related #140564.</li>
+<li><strong>PR #140556</strong></li>
+<li><strong>PR #140568</strong></li>
+<li><strong>PR #140569</strong></li>
+<li><strong>PR #140570</strong></li>
+<li><strong>PR #140557</strong></li>
+<li><strong>PR #140572</strong></li>
+<li><strong>PR #140573</strong> Related #140567.</li>
+<li><strong>PR #140586</strong></li>
+<li><strong>PR #140566</strong> Thanks @VACInc.</li>
+<li><strong>PR #140561</strong> Related #140560.</li>
+<li><strong>PR #138803</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140563</strong></li>
+<li><strong>PR #140580</strong></li>
+<li><strong>PR #140583</strong></li>
+<li><strong>PR #140562</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140588</strong> Related #140584.</li>
+<li><strong>PR #140589</strong> Related #140574. Thanks @vincentkoc.</li>
+<li><strong>PR #129144</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #136231</strong> Related #136200. Thanks @heden9 and @vincentkoc.</li>
+<li><strong>PR #140581</strong></li>
+<li><strong>PR #140597</strong> Related #140595.</li>
+<li><strong>PR #140599</strong></li>
+<li><strong>PR #140458</strong> Related #140416. Thanks @gaoanze888 and @mbundy.</li>
+<li><strong>PR #140412</strong> Related #140356. Thanks @hannesrudolph.</li>
+<li><strong>PR #140571</strong></li>
+<li><strong>PR #140300</strong> Thanks @obviyus.</li>
+<li><strong>PR #140235</strong> Thanks @Alix-007.</li>
+<li><strong>PR #140592</strong> Related #140590.</li>
+<li><strong>PR #140558</strong></li>
+<li><strong>PR #140596</strong></li>
+<li><strong>PR #140504</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140531</strong> Thanks @Bruce-Yii and @obviyus.</li>
+<li><strong>PR #140617</strong></li>
+<li><strong>PR #140594</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #140618</strong> Related #140611.</li>
+<li><strong>PR #140608</strong> Related #140606.</li>
+<li><strong>PR #140626</strong></li>
+<li><strong>PR #140585</strong> Related #140577. Thanks @vincentkoc.</li>
+<li><strong>PR #140602</strong> Related #140601. Thanks @obviyus.</li>
+<li><strong>PR #140598</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #126198</strong> Thanks @vincentkoc and @qingminglong.</li>
+<li><strong>PR #140612</strong></li>
+<li><strong>PR #140613</strong></li>
+<li><strong>PR #138741</strong> Thanks @saladinyao-cyber and @obviyus.</li>
+<li><strong>PR #140305</strong></li>
+<li><strong>PR #140640</strong></li>
+<li><strong>PR #140638</strong></li>
+<li><strong>PR #140642</strong></li>
+<li><strong>PR #140575</strong></li>
+<li><strong>PR #140625</strong></li>
+<li><strong>PR #140593</strong></li>
+<li><strong>PR #140661</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140644</strong></li>
+<li><strong>PR #140553</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140659</strong> Related #140623.</li>
+<li><strong>PR #140624</strong></li>
+<li><strong>PR #140655</strong></li>
+<li><strong>PR #140449</strong></li>
+<li><strong>PR #140652</strong></li>
+<li><strong>PR #140669</strong> Related #140668.</li>
+<li><strong>PR #140614</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140650</strong> Related #140649. Thanks @vincentkoc.</li>
+<li><strong>PR #140637</strong></li>
+<li><strong>PR #140658</strong></li>
+<li><strong>PR #140673</strong></li>
+<li><strong>PR #140665</strong></li>
+<li><strong>PR #140643</strong></li>
+<li><strong>PR #140667</strong></li>
+<li><strong>PR #140679</strong></li>
+<li><strong>PR #140610</strong></li>
+<li><strong>PR #140675</strong></li>
+<li><strong>PR #140600</strong></li>
+<li><strong>PR #140639</strong></li>
+<li><strong>PR #140660</strong></li>
+<li><strong>PR #140670</strong></li>
+<li><strong>PR #140656</strong></li>
+<li><strong>PR #140697</strong> Related #140692.</li>
+<li><strong>PR #140634</strong></li>
+<li><strong>PR #140688</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #134400</strong> Thanks @scotthuang.</li>
+<li><strong>PR #140685</strong></li>
+<li><strong>PR #140694</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #138870</strong> Related #138815.</li>
+<li><strong>PR #140690</strong> Related #140686.</li>
+<li><strong>PR #140693</strong></li>
+<li><strong>PR #140683</strong></li>
+<li><strong>PR #140318</strong></li>
+<li><strong>PR #140698</strong></li>
+<li><strong>PR #137440</strong> Thanks @shojikumaru.</li>
+<li><strong>PR #140722</strong></li>
+<li><strong>PR #140381</strong> Related #140214. Thanks @ruel225 and @obviyus and @oshaughnessy-junior.</li>
+<li><strong>PR #140724</strong> Related #140721.</li>
+<li><strong>PR #140718</strong> Related #140700.</li>
+<li><strong>PR #140714</strong> Related #140709.</li>
+<li><strong>PR #140704</strong></li>
+<li><strong>PR #140676</strong></li>
+<li><strong>PR #140713</strong></li>
+<li><strong>PR #140728</strong> Related #140715.</li>
+<li><strong>PR #140720</strong></li>
+<li><strong>PR #140727</strong></li>
+<li><strong>PR #140726</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140735</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140710</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140651</strong></li>
+<li><strong>PR #140619</strong></li>
+<li><strong>PR #137779</strong> Related #137690. Thanks @SunnyShu0925 and @vincentkoc and @ratticon.</li>
+<li><strong>PR #140707</strong></li>
+<li><strong>PR #140739</strong> Related #140731.</li>
+<li><strong>PR #140712</strong></li>
+<li><strong>PR #140741</strong></li>
+<li><strong>PR #116108</strong> Related #116107. Thanks @sasan1200.</li>
+<li><strong>PR #140701</strong></li>
+<li><strong>PR #140747</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #137699</strong> Thanks @ly85206559.</li>
+<li><strong>PR #140750</strong> Related #140749.</li>
+<li><strong>PR #140635</strong> Thanks @jason-allen-oneal and @vincentkoc.</li>
+<li><strong>PR #140744</strong></li>
+<li><strong>PR #140603</strong></li>
+<li><strong>PR #140641</strong></li>
+<li><strong>PR #140768</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140657</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #140763</strong></li>
+<li><strong>PR #137893</strong> Thanks @RomneyDa and @vincentkoc.</li>
+<li><strong>PR #140753</strong></li>
+<li><strong>PR #140334</strong> Thanks @pgondhi987.</li>
+<li><strong>PR #140771</strong></li>
+<li><strong>PR #140689</strong> Thanks @Takhoffman.</li>
+<li><strong>PR #140746</strong></li>
+<li><strong>PR #140776</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140756</strong></li>
+<li><strong>PR #140251</strong> Related #140204. Thanks @SunnyShu0925 and @obviyus and @TylerGillson.</li>
+<li><strong>PR #140751</strong> Related #140745. Thanks @vincentkoc.</li>
+<li><strong>PR #140789</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140782</strong></li>
+<li><strong>PR #140732</strong> Related #140691.</li>
+<li><strong>PR #140754</strong></li>
+<li><strong>PR #140777</strong></li>
+<li><strong>PR #140767</strong> Thanks @Takhoffman.</li>
+<li><strong>PR #140778</strong></li>
+<li><strong>PR #140662</strong></li>
+<li><strong>PR #140748</strong></li>
+<li><strong>PR #140752</strong></li>
+<li><strong>PR #140769</strong></li>
+<li><strong>PR #140796</strong> Thanks @obviyus.</li>
+<li><strong>PR #140783</strong></li>
+<li><strong>PR #140806</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140788</strong></li>
+<li><strong>PR #140807</strong></li>
+<li><strong>PR #140792</strong></li>
+<li><strong>PR #140802</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140794</strong></li>
+<li><strong>PR #140780</strong></li>
+<li><strong>PR #140653</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #140352</strong> Related #140351. Thanks @Colton-Harris and @obviyus.</li>
+<li><strong>PR #135862</strong> Related #135471. Thanks @SunnyShu0925 and @vincentkoc.</li>
+<li><strong>PR #140811</strong></li>
+<li><strong>PR #140762</strong></li>
+<li><strong>PR #140790</strong></li>
+<li><strong>PR #140797</strong></li>
+<li><strong>PR #140810</strong></li>
+<li><strong>PR #140773</strong> Related #140772.</li>
+<li><strong>PR #140278</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140832</strong></li>
+<li><strong>PR #140824</strong></li>
+<li><strong>PR #140805</strong></li>
+<li><strong>PR #140787</strong> Related #140786.</li>
+<li><strong>PR #140841</strong></li>
+<li><strong>PR #140814</strong></li>
+<li><strong>PR #140813</strong></li>
+<li><strong>PR #140815</strong></li>
+<li><strong>PR #140137</strong> Related #139963. Thanks @gaoanze888 and @evan-zhang.</li>
+<li><strong>PR #140804</strong></li>
+<li><strong>PR #140851</strong></li>
+<li><strong>PR #140848</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140803</strong> Related #140795.</li>
+<li><strong>PR #140781</strong></li>
+<li><strong>PR #140852</strong></li>
+<li><strong>PR #140845</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140830</strong> Related #140785.</li>
+<li><strong>PR #140820</strong></li>
+<li><strong>PR #140801</strong> Related #140800.</li>
+<li><strong>PR #140860</strong></li>
+<li><strong>PR #140855</strong></li>
+<li><strong>PR #139196</strong> Thanks @obviyus.</li>
+<li><strong>PR #140711</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #140844</strong> Thanks @Takhoffman.</li>
+<li><strong>PR #140812</strong> Thanks @Takhoffman.</li>
+<li><strong>PR #140725</strong></li>
+<li><strong>PR #140874</strong></li>
+<li><strong>PR #140779</strong></li>
+<li><strong>PR #140870</strong></li>
+<li><strong>PR #140857</strong></li>
+<li><strong>PR #140869</strong></li>
+<li><strong>PR #140883</strong></li>
+<li><strong>PR #140878</strong></li>
+<li><strong>PR #140664</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140622</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140856</strong></li>
+<li><strong>PR #140884</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140894</strong></li>
+<li><strong>PR #140846</strong></li>
+<li><strong>PR #140895</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140827</strong> Related #140826.</li>
+<li><strong>PR #140784</strong></li>
+<li><strong>PR #140872</strong></li>
+<li><strong>PR #140885</strong></li>
+<li><strong>PR #140862</strong></li>
+<li><strong>PR #136884</strong> Thanks @RomneyDa and @vincentkoc.</li>
+<li><strong>PR #137657</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #136919</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #140901</strong> Thanks @obviyus.</li>
+<li><strong>PR #140880</strong></li>
+<li><strong>PR #139850</strong></li>
+<li><strong>PR #140888</strong></li>
+<li><strong>PR #140822</strong></li>
+<li><strong>PR #140876</strong></li>
+<li><strong>PR #140871</strong></li>
+<li><strong>PR #140858</strong></li>
+<li><strong>PR #140853</strong></li>
+<li><strong>PR #140829</strong> Related #140828.</li>
+<li><strong>PR #140905</strong></li>
+<li><strong>PR #140899</strong> Thanks @obviyus.</li>
+<li><strong>PR #140890</strong></li>
+<li><strong>PR #140906</strong></li>
+<li><strong>PR #140648</strong></li>
+<li><strong>PR #140896</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140913</strong> Thanks @Takhoffman.</li>
+<li><strong>PR #140910</strong></li>
+<li><strong>PR #140816</strong></li>
+<li><strong>PR #140863</strong></li>
+<li><strong>PR #140837</strong> Related #140836.</li>
+<li><strong>PR #140904</strong></li>
+<li><strong>PR #140831</strong></li>
+<li><strong>PR #140886</strong></li>
+<li><strong>PR #140633</strong></li>
+<li><strong>PR #140925</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140868</strong> Related #140867.</li>
+<li><strong>PR #140734</strong></li>
+<li><strong>PR #140716</strong></li>
+<li><strong>PR #140926</strong></li>
+<li><strong>PR #140866</strong> Related #140865.</li>
+<li><strong>PR #140934</strong> Thanks @obviyus.</li>
+<li><strong>PR #140849</strong></li>
+<li><strong>PR #140923</strong></li>
+<li><strong>PR #120573</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140854</strong></li>
+<li><strong>PR #140839</strong> Related #140838.</li>
+<li><strong>PR #140799</strong></li>
+<li><strong>PR #140604</strong></li>
+<li><strong>PR #140909</strong></li>
+<li><strong>PR #140927</strong></li>
+<li><strong>PR #140882</strong> Related #140881.</li>
+<li><strong>PR #140861</strong></li>
+<li><strong>PR #140930</strong> Related #140911. Thanks @Takhoffman.</li>
+<li><strong>PR #124061</strong> Thanks @clawSean.</li>
+<li><strong>PR #140942</strong> Thanks @obviyus.</li>
+<li><strong>PR #140937</strong></li>
+<li><strong>PR #140936</strong></li>
+<li><strong>PR #140629</strong></li>
+<li><strong>PR #140893</strong></li>
+<li><strong>PR #126219</strong> Thanks @vincentkoc and @wangyan2026.</li>
+<li><strong>PR #140938</strong></li>
+<li><strong>PR #140949</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140616</strong></li>
+<li><strong>PR #140740</strong> Thanks @zenglingbiao and @obviyus.</li>
+<li><strong>PR #140953</strong></li>
+<li><strong>PR #140929</strong></li>
+<li><strong>PR #140924</strong></li>
+<li><strong>PR #140946</strong></li>
+<li><strong>PR #140761</strong></li>
+<li><strong>PR #140947</strong></li>
+<li><strong>PR #140952</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #140825</strong></li>
+<li><strong>PR #140766</strong></li>
+<li><strong>PR #140912</strong> Thanks @Takhoffman.</li>
+<li><strong>PR #140842</strong></li>
+<li><strong>PR #140970</strong></li>
+<li><strong>PR #140922</strong></li>
+<li><strong>PR #136329</strong> Thanks @fuller-stack-dev.</li>
+<li><strong>PR #140964</strong> Related #140950.</li>
+<li><strong>PR #140962</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140850</strong></li>
+<li><strong>PR #140945</strong></li>
+<li><strong>PR #140961</strong></li>
+<li><strong>PR #140840</strong></li>
+<li><strong>PR #140540</strong></li>
+<li><strong>PR #140974</strong></li>
+<li><strong>PR #140755</strong></li>
+<li><strong>PR #140859</strong></li>
+<li><strong>PR #140994</strong></li>
+<li><strong>PR #141007</strong></li>
+<li><strong>PR #141001</strong></li>
+<li><strong>PR #140717</strong></li>
+<li><strong>PR #141006</strong></li>
+<li><strong>PR #141014</strong></li>
+<li><strong>PR #140967</strong></li>
+<li><strong>PR #141010</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140958</strong></li>
+<li><strong>PR #140808</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140501</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140975</strong></li>
+<li><strong>PR #140578</strong></li>
+<li><strong>PR #141024</strong></li>
+<li><strong>PR #137059</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140969</strong></li>
+<li><strong>PR #141003</strong> Related #140998.</li>
+<li><strong>PR #140764</strong> Related #140703.</li>
+<li><strong>PR #141026</strong></li>
+<li><strong>PR #141029</strong></li>
+<li><strong>PR #141030</strong></li>
+<li><strong>PR #140990</strong></li>
+<li><strong>PR #141049</strong></li>
+<li><strong>PR #140997</strong></li>
+<li><strong>PR #141040</strong></li>
+<li><strong>PR #141058</strong></li>
+<li><strong>PR #137098</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141050</strong></li>
+<li><strong>PR #141056</strong></li>
+<li><strong>PR #140980</strong></li>
+<li><strong>PR #141016</strong></li>
+<li><strong>PR #140984</strong></li>
+<li><strong>PR #141044</strong></li>
+<li><strong>PR #125399</strong></li>
+<li><strong>PR #141048</strong> Related #141036.</li>
+<li><strong>PR #141053</strong></li>
+<li><strong>PR #141059</strong></li>
+<li><strong>PR #122221</strong> Related #97601. Thanks @vincentkoc and @obviyus and @joeykrug.</li>
+<li><strong>PR #141074</strong></li>
+<li><strong>PR #140935</strong></li>
+<li><strong>PR #132451</strong> Thanks @jesse-merhi.</li>
+<li><strong>PR #141075</strong> Related #141068. Thanks @brokemac79.</li>
+<li><strong>PR #140985</strong></li>
+<li><strong>PR #141055</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141080</strong></li>
+<li><strong>PR #121287</strong> Thanks @hydraxman and @bryan.</li>
+<li><strong>PR #137841</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140951</strong></li>
+<li><strong>PR #141084</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141100</strong></li>
+<li><strong>PR #141106</strong></li>
+<li><strong>PR #141077</strong></li>
+<li><strong>PR #141096</strong></li>
+<li><strong>PR #141082</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141092</strong></li>
+<li><strong>PR #141073</strong></li>
+<li><strong>PR #141021</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141019</strong></li>
+<li><strong>PR #139492</strong></li>
+<li><strong>PR #140903</strong> Thanks @pgondhi987.</li>
+<li><strong>PR #141061</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141070</strong></li>
+<li><strong>PR #141139</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140818</strong> Related #140817. Thanks @Marvinthebored and @obviyus.</li>
+<li><strong>PR #140993</strong> Related #140968. Thanks @ooiuuii and @obviyus.</li>
+<li><strong>PR #141009</strong> Thanks @obviyus.</li>
+<li><strong>PR #141148</strong></li>
+<li><strong>PR #141108</strong></li>
+<li><strong>PR #141158</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141152</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #141085</strong></li>
+<li><strong>PR #141020</strong></li>
+<li><strong>PR #140875</strong> Thanks @pgondhi987.</li>
+<li><strong>PR #141144</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141149</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141169</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #133843</strong> Thanks @SunnyShu0925 and @vincentkoc.</li>
+<li><strong>PR #141118</strong></li>
+<li><strong>PR #140283</strong> Thanks @Grynn and @claw-openclaw.</li>
+<li><strong>PR #141159</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141119</strong></li>
+<li><strong>PR #141031</strong></li>
+<li><strong>PR #141045</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #141137</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141027</strong></li>
+<li><strong>PR #139514</strong></li>
+<li><strong>PR #140960</strong></li>
+<li><strong>PR #141098</strong></li>
+<li><strong>PR #141164</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141120</strong> Related #141111.</li>
+<li><strong>PR #133775</strong> Related #133757. Thanks @zxdvd and @vincentkoc.</li>
+<li><strong>PR #141178</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141160</strong></li>
+<li><strong>PR #139145</strong> Thanks @SebTardif.</li>
+<li><strong>PR #140982</strong></li>
+<li><strong>PR #140628</strong></li>
+<li><strong>PR #141126</strong></li>
+<li><strong>PR #141116</strong> Related #137116. Thanks @shakkernerd.</li>
+<li><strong>PR #141195</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140654</strong></li>
+<li><strong>PR #141166</strong></li>
+<li><strong>PR #140972</strong></li>
+<li><strong>PR #141185</strong></li>
+<li><strong>PR #141089</strong></li>
+<li><strong>PR #140645</strong> Related #131004. Thanks @wangmiao0668000666.</li>
+<li><strong>PR #141154</strong></li>
+<li><strong>PR #141145</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141204</strong></li>
+<li><strong>PR #141094</strong></li>
+<li><strong>PR #141208</strong></li>
+<li><strong>PR #140742</strong></li>
+<li><strong>PR #141193</strong></li>
+<li><strong>PR #141200</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141203</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141047</strong></li>
+<li><strong>PR #140636</strong></li>
+<li><strong>PR #140873</strong> Thanks @pgondhi987.</li>
+<li><strong>PR #140677</strong></li>
+<li><strong>PR #141192</strong></li>
+<li><strong>PR #141212</strong></li>
+<li><strong>PR #141207</strong></li>
+<li><strong>PR #141194</strong></li>
+<li><strong>PR #141173</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140696</strong></li>
+<li><strong>PR #141215</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141188</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140695</strong></li>
+<li><strong>PR #138953</strong> Thanks @brokemac79.</li>
+<li><strong>PR #141063</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140238</strong> Thanks @Alix-007 and @shakkernerd.</li>
+<li><strong>PR #141220</strong> Related #141198.</li>
+<li><strong>PR #141227</strong></li>
+<li><strong>PR #141229</strong></li>
+<li><strong>PR #138989</strong> Thanks @Alix-007 and @shakkernerd.</li>
+<li><strong>PR #141210</strong></li>
+<li><strong>PR #140684</strong></li>
+<li><strong>PR #141095</strong> Related #131970.</li>
+<li><strong>PR #141234</strong> Related #141222.</li>
+<li><strong>PR #141141</strong></li>
+<li><strong>PR #141236</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #141235</strong></li>
+<li><strong>PR #141238</strong></li>
+<li><strong>PR #141241</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141205</strong> Related #140943. Thanks @Takhoffman.</li>
+<li><strong>PR #141223</strong> Thanks @Takhoffman.</li>
+<li><strong>PR #141165</strong></li>
+<li><strong>PR #141135</strong></li>
+<li><strong>PR #140452</strong> Thanks @brokemac79.</li>
+<li><strong>PR #141186</strong></li>
+<li><strong>PR #141244</strong></li>
+<li><strong>PR #141253</strong></li>
+<li><strong>PR #141262</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141109</strong></li>
+<li><strong>PR #141267</strong></li>
+<li><strong>PR #141246</strong></li>
+<li><strong>PR #141258</strong></li>
+<li><strong>PR #140125</strong> Related #139946. Thanks @Dreamer-HIT and @MoerAI and @kip-claw.</li>
+<li><strong>PR #141256</strong></li>
+<li><strong>PR #141282</strong></li>
+<li><strong>PR #140887</strong></li>
+<li><strong>PR #141247</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #141281</strong></li>
+<li><strong>PR #140547</strong> Thanks @aeoess.</li>
+<li><strong>PR #137229</strong> Thanks @qingminglong.</li>
+<li><strong>PR #141251</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #141298</strong></li>
+<li><strong>PR #141293</strong> Thanks @obviyus.</li>
+<li><strong>PR #141294</strong> Thanks @masatohoshino.</li>
+<li><strong>PR #141284</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141302</strong> Related #141263.</li>
+<li><strong>PR #141168</strong></li>
+<li><strong>PR #141125</strong></li>
+<li><strong>PR #141081</strong> Related #141035.</li>
+<li><strong>PR #140973</strong></li>
+<li><strong>PR #141103</strong></li>
+<li><strong>PR #141297</strong> Thanks @obviyus.</li>
+<li><strong>PR #141278</strong></li>
+<li><strong>PR #141183</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141324</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #138633</strong> Related #138589. Thanks @ruel225 and @javikas.</li>
+<li><strong>PR #141296</strong> Thanks @obviyus.</li>
+<li><strong>PR #141105</strong></li>
+<li><strong>PR #141274</strong></li>
+<li><strong>PR #141325</strong></li>
+<li><strong>PR #141060</strong></li>
+<li><strong>PR #141320</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141280</strong></li>
+<li><strong>PR #141131</strong></li>
+<li><strong>PR #141130</strong></li>
+<li><strong>PR #141090</strong></li>
+<li><strong>PR #141087</strong></li>
+<li><strong>PR #141219</strong></li>
+<li><strong>PR #119367</strong> Thanks @jalehman.</li>
+<li><strong>PR #141327</strong></li>
+<li><strong>PR #141336</strong></li>
+<li><strong>PR #141065</strong></li>
+<li><strong>PR #141335</strong></li>
+<li><strong>PR #141343</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141334</strong></li>
+<li><strong>PR #139604</strong> Thanks @teddytennant and @obviyus.</li>
+<li><strong>PR #141127</strong> Related #141099.</li>
+<li><strong>PR #141216</strong></li>
+<li><strong>PR #141329</strong></li>
+<li><strong>PR #141342</strong></li>
+<li><strong>PR #141146</strong></li>
+<li><strong>PR #141175</strong></li>
+<li><strong>PR #141354</strong> Thanks @obviyus.</li>
+<li><strong>PR #141358</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141353</strong> Thanks @shakkernerd.</li>
+<li><strong>PR #141359</strong></li>
+<li><strong>PR #141112</strong></li>
+<li><strong>PR #141344</strong> Thanks @IWhatsskill.</li>
+<li><strong>PR #138451</strong></li>
+<li><strong>PR #141371</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141368</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141232</strong></li>
+<li><strong>PR #133255</strong> Related #133122. Thanks @Alix-007 and @shakkernerd.</li>
+<li><strong>PR #141086</strong></li>
+<li><strong>PR #141362</strong></li>
+<li><strong>PR #141360</strong></li>
+<li><strong>PR #141370</strong></li>
+<li><strong>PR #140672</strong></li>
+<li><strong>PR #141364</strong></li>
+<li><strong>PR #141381</strong> Related #141356.</li>
+<li><strong>PR #141378</strong></li>
+<li><strong>PR #141333</strong></li>
+<li><strong>PR #141376</strong></li>
+<li><strong>PR #141386</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141385</strong></li>
+<li><strong>PR #141390</strong> Related #141357.</li>
+<li><strong>PR #141395</strong> Thanks @obviyus.</li>
+<li><strong>PR #140992</strong></li>
+<li><strong>PR #141402</strong> Thanks @obviyus.</li>
+<li><strong>PR #141405</strong></li>
+<li><strong>PR #141147</strong></li>
+<li><strong>PR #141350</strong></li>
+<li><strong>PR #141396</strong> Thanks @obviyus.</li>
+<li><strong>PR #141404</strong></li>
+<li><strong>PR #141391</strong></li>
+<li><strong>PR #141420</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #140730</strong> Related #140681. Thanks @NianJiuZst and @obviyus and @justinkirklin-gif.</li>
+<li><strong>PR #141372</strong></li>
+<li><strong>PR #141433</strong> Thanks @obviyus.</li>
+<li><strong>PR #141425</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141403</strong></li>
+<li><strong>PR #141440</strong></li>
+<li><strong>PR #141422</strong></li>
+<li><strong>PR #141093</strong></li>
+<li><strong>PR #140699</strong></li>
+<li><strong>PR #140996</strong></li>
+<li><strong>PR #141337</strong></li>
+<li><strong>PR #141442</strong></li>
+<li><strong>PR #141383</strong></li>
+<li><strong>PR #141408</strong></li>
+<li><strong>PR #141441</strong> Related #141424.</li>
+<li><strong>PR #141439</strong> Thanks @vincentkoc.</li>
+<li><strong>PR #141419</strong></li>
+<li><strong>PR #139288</strong> Thanks @TheAngryPit.</li>
+<li><strong>PR #141375</strong></li>
+<li><strong>PR #141348</strong></li>
+<li><strong>PR #141265</strong> Related #141261. Thanks @Takhoffman.</li>
+<li><strong>PR #141398</strong> Thanks @obviyus.</li>
+<li><strong>PR #140981</strong></li>
+<li><strong>PR #141015</strong></li>
+<li><strong>PR #141432</strong></li>
+<li><strong>PR #128454</strong> Thanks @MasterSwords1.</li>
+<li><strong>PR #141444</strong> Thanks @hannesrudolph.</li>
+<li><strong>PR #141447</strong></li>
+<li><strong>PR #141431</strong></li>
+<li><strong>PR #139075</strong> Related #138684. Thanks @ylcn91 and @eggc-tech.</li>
+<li><strong>PR #141142</strong></li>
+<li><strong>PR #141369</strong></li>
+<li><strong>PR #141452</strong></li>
+<li><strong>PR #141013</strong></li>
+<li><strong>PR #141449</strong></li>
+<li><strong>PR #141450</strong> Related #141430.</li>
+<li><strong>PR #136285</strong> Related #127869. Thanks @Schimuneck and @cursoragent and @Jackten.</li>
+<li><strong>PR #141456</strong></li>
+<li><strong>PR #141397</strong></li>
+<li><strong>PR #141427</strong></li>
+<li><strong>PR #141459</strong></li>
+<li><strong>PR #137975</strong></li>
+<li><strong>PR #141428</strong></li>
+<li><strong>PR #141455</strong></li>
+<li><strong>PR #141399</strong></li>
+<li><strong>PR #141460</strong></li>
+<li><strong>PR #141330</strong> Related #137410. Thanks @shakkernerd and @najef1979-code.</li>
+<li><strong>PR #141421</strong></li>
+<li><strong>PR #141124</strong></li>
+<li><strong>PR #131014</strong> Thanks @Alix-007 and @shakkernerd.</li>
+<li><strong>PR #141466</strong></li>
+<li><strong>PR #141485</strong></li>
+<li><strong>PR #141487</strong></li>
+<li><strong>PR #141495</strong></li>
+<li><strong>PR #141479</strong></li>
+<li><strong>PR #138984</strong> Related #138965, #139201. Thanks @VACInc and @keumhyun.</li>
+<li><strong>PR #141497</strong></li>
+<li><strong>PR #141499</strong></li>
+<li><strong>PR #141471</strong></li>
+<li><strong>PR #141446</strong></li>
+<li><strong>PR #141416</strong></li>
+<li><strong>PR #141461</strong> Related #141349.</li>
+<li><strong>PR #141484</strong> Related #136813. Thanks @MaClawd.</li>
+<li><strong>PR #141488</strong></li>
+<li><strong>PR #141500</strong> Related #141498.</li>
+<li><strong>PR #141384</strong></li>
+<li><strong>PR #141513</strong> Related #141510.</li>
+<li><strong>PR #140392</strong> Thanks @ayaangazali.</li>
+<li><strong>PR #141515</strong></li>
+<li><strong>PR #141490</strong></li>
+<li><strong>PR #141462</strong></li>
+<li><strong>PR #141512</strong></li>
+<li><strong>PR #141503</strong> Related #141502.</li>
+<li><strong>PR #141478</strong></li>
+<li><strong>PR #141493</strong></li>
+<li><strong>PR #141507</strong></li>
+<li><strong>PR #140988</strong></li>
+<li><strong>PR #141522</strong></li>
+<li><strong>PR #141434</strong></li>
+<li><strong>PR #141469</strong></li>
+<li><strong>PR #141511</strong></li>
+<li><strong>PR #141491</strong></li>
+<li><strong>PR #141494</strong></li>
+<li><strong>PR #141524</strong> Thanks @obviyus.</li>
+<li><strong>PR #141465</strong></li>
+<li><strong>PR #141506</strong> Related #141505.</li>
+<li><strong>PR #136761</strong> Thanks @vincentkoc and @RomneyDa.</li>
+<li><strong>PR #141189</strong> Related #141180. Thanks @ly85206559 and @colbertlee.</li>
+<li><strong>PR #141199</strong> Thanks @VACInc.</li>
+<li><strong>PR #141519</strong></li>
+<li><strong>PR #141467</strong></li>
+<li><strong>PR #141517</strong></li>
+<li><strong>PR #141516</strong></li>
+<li><strong>PR #141514</strong></li>
+<li><strong>PR #141492</strong></li>
+<li><strong>PR #141518</strong></li>
+<li><strong>PR #141525</strong></li>
+<li><strong>PR #141104</strong></li>
+<li><strong>PR #141423</strong></li>
+<li><strong>PR #141509</strong> Related #141508.</li>
+<li><strong>PR #141530</strong></li>
+<li><strong>PR #141521</strong></li>
+<li><strong>PR #141532</strong></li>
+<li><strong>PR #141533</strong> Thanks @DasX.</li>
+<li><strong>PR #141531</strong> Thanks @obviyus.</li>
+<li><strong>PR #141529</strong></li>
+<li><strong>PR #141546</strong></li>
+<li><strong>PR #141549</strong></li>
+<li><strong>PR #134454</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #141555</strong> Related #141545. Thanks @DasX.</li>
+<li><strong>PR #141537</strong></li>
+<li><strong>PR #137586</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #134390</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #120340</strong> Thanks @sightingsstellar-beep and @Takhoffman.</li>
+<li><strong>PR #137631</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #137601</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #141565</strong></li>
+<li><strong>PR #141534</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #141552</strong> Thanks @obviyus.</li>
+<li><strong>PR #137603</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #141551</strong></li>
+<li><strong>PR #141566</strong></li>
+<li><strong>PR #141554</strong></li>
+<li><strong>PR #134047</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #137585</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #138666</strong> Related #138590. Thanks @DasX and @javikas.</li>
+<li><strong>PR #141560</strong> Related #141550.</li>
+<li><strong>PR #141553</strong></li>
+<li><strong>PR #141584</strong></li>
+<li><strong>PR #141587</strong></li>
+<li><strong>PR #141574</strong> Thanks @VACInc.</li>
+<li><strong>PR #141572</strong></li>
+<li><strong>PR #137661</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #141412</strong></li>
+<li><strong>PR #125900</strong> Thanks @Grynn.</li>
+<li><strong>PR #141580</strong></li>
+<li><strong>PR #141593</strong></li>
+<li><strong>PR #141591</strong></li>
+<li><strong>PR #141557</strong></li>
+<li><strong>PR #137592</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #141594</strong></li>
+<li><strong>PR #139624</strong></li>
+<li><strong>PR #141598</strong></li>
+<li><strong>PR #137604</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #141567</strong></li>
+<li><strong>PR #141595</strong></li>
+<li><strong>PR #128189</strong> Thanks @chelsealong.</li>
+<li><strong>PR #141579</strong></li>
+<li><strong>PR #141589</strong></li>
+<li><strong>PR #137347</strong> Thanks @ylcn91.</li>
+<li><strong>PR #141597</strong></li>
+<li><strong>PR #141571</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #141607</strong></li>
+<li><strong>PR #140907</strong> Thanks @Alix-007.</li>
+<li><strong>PR #141613</strong></li>
+<li><strong>PR #141611</strong> Thanks @RomneyDa.</li>
+<li><strong>PR #141618</strong> Related #141606.</li>
+<li><strong>PR #141622</strong></li>
+<li><strong>PR #141311</strong> Thanks @hugenshen.</li>
+<li><strong>PR #141624</strong></li>
+<li><strong>PR #141601</strong></li>
+<li><strong>PR #141623</strong></li>
+<li><strong>PR #141619</strong></li>
+<li><strong>PR #141612</strong></li>
+<li><strong>PR #141630</strong></li>
+<li><strong>PR #141627</strong></li>
+<li><strong>PR #141609</strong></li>
+<li><strong>PR #141562</strong></li>
+<li><strong>PR #141588</strong></li>
+<li><strong>PR #141631</strong></li>
+<li><strong>PR #140579</strong></li>
+<li><strong>PR #141634</strong></li>
+<li><strong>PR #141636</strong></li>
+<li><strong>PR #141632</strong></li>
+<li><strong>PR #141645</strong></li>
+<li><strong>PR #141650</strong></li>
+<li><strong>PR #141649</strong> Related #141644.</li>
+<li><strong>PR #141543</strong></li>
+<li><strong>PR #141610</strong></li>
+<li><strong>PR #141635</strong></li>
+<li><strong>PR #141629</strong></li>
+<li><strong>PR #141659</strong></li>
+<li><strong>PR #141646</strong></li>
+<li><strong>PR #141662</strong> Related #141661.</li>
+<li><strong>PR #141654</strong> Thanks @obviyus.</li>
+<li><strong>PR #141671</strong></li>
+<li><strong>PR #141544</strong> Thanks @VACInc.</li>
+<li><strong>PR #141681</strong></li>
+</ul>
+<p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
+]]></description>
+            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.9.3/OpenClaw-2026.9.3.zip" length="592452637" type="application/octet-stream" sparkle:edSignature="CHnCyq8RLalEuNKcgLtq7V3pqNgtEQ23mSa6oo2DwKujNPstj9e/xAGAOTh+8CWhGFbnbtryJ19WPfUaWCNXDw=="/>
+        </item>
+        <item>
             <title>2026.9.2</title>
             <pubDate>Sat, 05 Sep 2026 23:48:36 +0000</pubDate>
             <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
@@ -2646,945 +4722,6 @@ Shipped baseline exclusions: v2026.8.1 (14 PRs: #109622, #111527, #112678, #1129
 <p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
 ]]></description>
             <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.9.1/OpenClaw-2026.9.1.zip" length="534673086" type="application/octet-stream" sparkle:edSignature="dfwVKJGzi3OivvXVNxNMvqvyEOEQt1SNLPbUFDfFIWl7Wedb3E3fMSsmDQwpN9CV5P9r/HppP/oRt+ne7chnDw=="/>
-        </item>
-        <item>
-            <title>2026.8.2</title>
-            <pubDate>Tue, 01 Sep 2026 16:49:06 -0700</pubDate>
-            <link>https://raw.githubusercontent.com/openclaw/openclaw/main/appcast.xml</link>
-            <sparkle:version>2608000290</sparkle:version>
-            <sparkle:shortVersionString>2026.8.2</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
-            <description><![CDATA[<h2>OpenClaw 2026.8.2</h2>
-<h3>Highlights</h3>
-<ul>
-<li><strong>Your Home agent, beside your work:</strong> open Home in a right or bottom dock with <code>Cmd/Ctrl+Shift+H</code>, keep your current page in view, and preview or remove its work-context snapshot or attach selected text to your message. Related #133632. (#133676)</li>
-<li><strong>A desktop companion for Linux:</strong> install the <code>.deb</code> or AppImage on x86-64 Linux, connect to a local or remote Gateway, and open Quick Chat from the system tray or an X11 keyboard shortcut. AppImage updates are signature-verified; <code>.deb</code> installs remain under your package manager. See the <a href="https://docs.openclaw.ai/platforms/linux">Linux guide</a>.</li>
-<li><strong>Start work without switching pages:</strong> create and run a background session from New Session, keep its selected local, cloud, or paired-device placement, and open it from the completion notice. Related #128037. (#128050) Thanks @Takhoffman.</li>
-<li><strong>Safer upgrades:</strong> preserve newer configuration, stop incomplete session migrations before claiming success, and recover a stopped Gateway after a failed update when the installed package or rollback is verified safe. Related #118244, #90551, #134206. (#134025, #134228, #119516) Thanks @obviyus, @stuart-minion-ai, @shakkernerd, @zyw02, @Issue-Hunter, @cursoragent, and @sercada.</li>
-<li><strong>Replies that finish the job:</strong> return a final answer after settled tool work and surface failures after an accepted turn, fixing conversations that stopped at tool output or an initial acknowledgement. Related #133960. (#133520, #133979) Thanks @fuller-stack-dev.</li>
-<li><strong>More dependable voice:</strong> keep internal reasoning out of speech, preserve tool-generated audio through delivery, and keep later browser Talk turns working after call setup. Related #90364, #83636, #134081. (#133615, #133324, #134170, #134138) Thanks @camball-strategies, @obviyus, @TurboTheTurtle, @clawSean, @Conan-Scott, and @mastertyko.</li>
-<li><strong>Browser control without a running Gateway:</strong> let supported macOS and Linux Chrome extension builds wake their paired local relay for authenticated CDP clients; this needs the updated native host and an extension build with relay wake-up support. (#128379)</li>
-<li><strong>Four new looks:</strong> personalize the Control UI with CRT, Manuscript, Rosé, or Miami, with theme choices preserved offline and applied without flashing the wrong theme during reload. Related #133416, #132785. (#133495, #133593, #133417, #132789) Thanks @vyctorbrzezowski.</li>
-</ul>
-<h3>Changes</h3>
-<ul>
-<li><strong>Recovery cleanup:</strong> preview retained migration originals with <code>openclaw update cleanup --dry-run</code>, then explicitly remove eligible originals while the selected Gateway is stopped; cleanup preserves current SQLite history but permanently gives up rollback to removed originals. Related #133805. (#133864)</li>
-<li><strong>Session visibility default:</strong> let unsandboxed sessions work with other sessions of the same agent by default, including retained cron sessions; shared-agent operators should set <code>tools.sessions.visibility</code> to <code>tree</code> or <code>self</code> when they need narrower access, while sandbox and cross-agent restrictions remain enforced. Related #133456. (#133469)</li>
-<li><strong>Cross-session conversations:</strong> render forwarded messages as distinct speech bubbles with source-session links and sending-agent identity, preserving attribution when messages steer an active conversation. (#132054, #133439)</li>
-<li><strong>Session organization:</strong> group session actions into clearer menus, copy transcripts as Markdown, open sessions in tabs, windows, or splits, edit icons and colors together, and optionally hide empty session groups. Related #133480, #133629. (#133490, #133638)</li>
-<li><strong>Home without switching pages:</strong> dock the selected agent’s existing Home conversation beside your work, retain its draft and attachments when opening it full page, and inspect or remove the “Working on” context before sending. Related #133632. (#133676)</li>
-<li><strong>Prepared cloud projects:</strong> reuse prepared project snapshots and validated workspace hashes before starting a cloud session, and preserve the required stop, snapshot, and restart cycle for Daytona-backed projects. Related #133436, #133450. (#133447, #134026, #134043)</li>
-<li><strong>Readable Beam links:</strong> share transcripts through readable <code>/beam/</code> URLs named after their sessions, with existing access checks and contextual navigation preserved. Related #125752. (#125755, #133463)</li>
-<li><strong>Chrome relay wake-up:</strong> support standalone local relays that start on demand, share their paired browser with the Gateway, and remain available to other CDP clients when the Gateway disconnects; see the <a href="https://docs.openclaw.ai/tools/chrome-extension#standalone-direct-loopback-relay">Chrome extension guide</a> for supported builds and setup. (#128379)</li>
-</ul>
-<ul>
-<li><strong>Plugin SDK types:</strong> type Telegram <code>botToken</code> as <code>SecretInput</code> (<code>string | SecretRef</code>), matching existing secret-reference support; plugin authors should use the resolved account <code>token</code> and read finalization-context <code>messages</code> only when <code>source === "openclaw-transcript"</code>. (#133988, #134238)</li>
-<li><strong>Background sessions:</strong> start work from New Session without leaving the page with <code>Cmd/Ctrl+Enter</code>, retain the selected local, cloud, or paired-device placement, and open the session from its completion notice; use <code>Cmd/Ctrl+Shift+Enter</code> when Modifier+Enter is already your normal send shortcut, while explicit Draft visibility still creates a draft. Related #128037. (#128050) Thanks @Takhoffman.</li>
-<li><strong>iOS composer:</strong> bring inline model, thinking, permission, attachment, and context controls closer to the web experience, keeping queued sends bound to the session settings that authorized them. (#132683) Thanks @Solvely-Colin.</li>
-<li><strong>Plugin approval verification:</strong> let plugins describe an external verification choice in approval presentations while OpenClaw retains approval identity, authorization, timeouts, and the final decision. (#113517) Thanks @Guardiola31337.</li>
-</ul>
-<h3>Fixes</h3>
-<ul>
-<li><strong>Optional image decoding:</strong> update the release’s managed Sharp dependency to 0.35.4 with libheif 1.23.2, fixing vulnerabilities in image decoding while preserving optional installation. See the plugin dependency caveat under Known issues.</li>
-<li><strong>Workspace permissions:</strong> apply permission changes to active runs and preserve session tool policies on cloud workers, so changing where work runs does not widen what it may do. Related #131947, #131661. (#132407, #131669) Thanks @jalehman, @anyech, and @sallyom.</li>
-<li><strong>Private diagnostics:</strong> redact values explicitly marked private in macOS app logs, keep credential values and prefixes out of routine Clawdock diagnostics, and preserve safe redaction of long secrets. Related #133736, #133535. (#133739, #133547, #134168)</li>
-<li><strong>MCP response limits:</strong> reject oversized HTTP responses and SSE events before parsing while preserving healthy long-lived streams and keepalives. Related #101554. (#123194) Thanks @SebTardif, @obviyus, and @aniruddhaadak80.</li>
-<li><strong>Source-file fidelity:</strong> preserve UTF-8 BOMs, line endings, fuzzy-match context bytes, and end-of-file state when applying patches, including formatting-only edits. Related #124390, #133319. (#124418, #133320) Thanks @synthalorian, @obviyus, and @yetval.</li>
-<li><strong>Migration safety:</strong> coordinate automatic agent-database maintenance with its current owner, check migration readiness before accepting workspace work, and preserve existing voice-call settings and disabled shared heartbeat owners during Doctor repair. Related #133478, #133951, #127596, #133389. (#133563, #133982, #134018, #133444) Thanks @omarshahine, @PollyBot13, and @obviyus.</li>
-<li><strong>Safe session recovery:</strong> preserve independently created files and symlinks during archive restore, repair supported legacy v17 agent databases, and fail updates clearly when session migration still blocks startup. Related #134163, #134206. (#133921, #134208, #134228) Thanks @EthDing, @obviyus, @abacha, and @shakkernerd.</li>
-<li><strong>Keep newer configuration:</strong> migrate a readable active configuration before considering last-known-good recovery, preserving newer valid settings rather than replacing them with an older copy. Related #90551. (#134025) Thanks @obviyus and @stuart-minion-ai.</li>
-<li><strong>Update capability consent:</strong> block a requested Gateway restart and return an actionable failure when a plugin update needs capability review; retain the previous plugin and finish with <code>openclaw update repair</code> after review. Related #134156. (#134183) Thanks @obviyus and @BrunoCerberus.</li>
-<li><strong>Hardened npm updates:</strong> complete OpenClaw’s verified package lifecycle on hosts using npm <code>ignore-scripts=true</code> without enabling scripts for unrelated packages or rolling a valid update back. Related #134177. (#134193) Thanks @obviyus and @botatdovly.</li>
-<li><strong>Update progress and recovery:</strong> show reliable progress and final outcomes, preserve offline diagnostics, refuse unsafe restarts when service state is unknown, and distinguish Gateway service setup from installing the CLI. (#133622, #133842, #132853, #133530) Thanks @jason-allen-oneal, @obviyus, and @RomneyDa.</li>
-<li><strong>Failed-update recovery:</strong> restart the managed Gateway through the selected installed CLI after a failed update when the replacement or restored installation is verified usable; retain backups and leave the Gateway stopped when rollback or package readiness remains uncertain. Related #118244. (#119516) Thanks @zyw02, @Issue-Hunter, @cursoragent, and @sercada.</li>
-<li><strong>Scheduled jobs:</strong> preserve and recover valid migrated cron jobs, avoid needless schedule-repair writes, and emit complete JSON when cron output is piped; heartbeat jobs now report the actual completed, skipped, or failed outcome after the heartbeat settles. Related #133347, #133442, #134327. (#133858, #133552, #133661, #134464) Thanks @fuller-stack-dev, @ejc3, @vincentkoc, @josephbergvinson, and @goslingmanagment.</li>
-<li><strong>Approval migration:</strong> import historical execution approvals and usage metadata, and identify malformed legacy fields without exposing their values so operators can repair the preserved source. Related #118242. (#118282, #133952) Thanks @obviyus and @sercada.</li>
-<li><strong>Plugin SDK compatibility:</strong> preserve the published conversation-binding inspection API and existing command definitions when upgrading from 2026.8.1; legacy <code>docks</code> categories remain visible under Tools without restoring retired docking features.</li>
-<li><strong>Plugin loading and updates:</strong> load packaged TypeScript plugins consistently, normalize file URLs for native loading, preserve bundled provider compatibility, and keep official plugins aligned with targeted beta updates. Related #133306, #123297, #97680. (#117199, #133337, #123416, #124415) Thanks @sunlit-deng, @easyteacher, @lonexreb, @obviyus, @bradenmcleish, @synthalorian, and @chac4l.</li>
-<li><strong>Plugin discovery:</strong> keep bundled plugins bundled when selected through load paths and prune stale path-install records that otherwise shadow the active source. Related #133935. (#133584, #133991) Thanks @ZengWen-DT, @obviyus, @lsr911, @chelsealong, @SebTardif, and @JeffSteinbok.</li>
-<li><strong>Bun Gateway compatibility:</strong> restore authenticated Gateway connections under Bun 1.4 while preserving payload limits and request scheduling. (#134282)</li>
-<li><strong>Docker image builds:</strong> prevent dependency installation from failing on missing package-lifecycle files. (#134231)</li>
-<li><strong>Installer and container access:</strong> repair npm-prefix shell initialization, surface failed install finalization, and restore in-container CLI access when Docker uses a custom host port. Related #133503. (#133869, #133504)</li>
-<li><strong>Channel recovery:</strong> resume recovery after crash-loop suppression, isolate unavailable accounts in diagnostics, and explain why an account recovery start was skipped. Related #134134, #133977, #133954. (#134165, #134044, #133973) Thanks @shakkernerd, @lsr911, @obviyus, @chelsealong, @ZengWen-DT, and @SebTardif.</li>
-<li><strong>Matrix shutdown:</strong> drain active monitor tasks before retiring shared clients, preventing shutdown deadlocks and late reuse of a closed client. (#134033) Thanks @lsr911, @obviyus, @chelsealong, @ZengWen-DT, and @SebTardif.</li>
-<li><strong>Reply completion:</strong> finish settled tool turns with a visible answer, recover failed-tool batches, report failures after accepted turns, and recognize completion replies delivered to internal requesters. Related #133292, #133960. (#133520, #133300, #133979, #133543) Thanks @fuller-stack-dev and @VACInc.</li>
-<li><strong>Subagent ownership:</strong> preserve conversation bindings and task visibility, clear stale owners, and keep status and command targets aligned with the agent that owns the work. Related #127141. (#127147, #133461, #133578, #133715)</li>
-<li><strong>Human priority and cancellation:</strong> prioritize human messages over inter-session work, stop queued Swarm collectors with their parent, and persist blocked completion alerts atomically. Related #70634, #131553, #133058. (#132738, #133076, #133192) Thanks @sylvesterkaczmarek, @obviyus, @ewrurwteurwU, @shojikumaru, @vincentkoc, and @potterdigital.</li>
-<li><strong>Conversation context:</strong> reject summaries that revive superseded tasks, stop repeated byte-triggered compaction, retain policy ownership, and carry saved conversation summaries into a fresh Codex thread when switching runtimes. Related #123668, #126900, #134224. (#123737, #127110, #133912, #134259) Thanks @wangyan2026, @obviyus, @andersonjeccel, @yu-xin-c, @fede-kamel, @lsr911, @chelsealong, @ZengWen-DT, and @SebTardif.</li>
-<li><strong>Draft and queue recovery:</strong> preserve offline drafts and restored draft text, resume draining after canceling a queued edit, and let you discard unconfirmed messages that block the queue. Related #133555, #133603. (#133628, #133575, #133440) Thanks @vincentkoc.</li>
-<li><strong>Starting chats:</strong> preserve typing on the new-session page, prevent duplicate initial prompts during workspace preparation, and avoid duplicate queued messages across clients. Related #132783, #133719. (#132773, #133861, #133542) Thanks @vyctorbrzezowski.</li>
-<li><strong>Workspace continuity:</strong> keep non-Git workspaces usable, preserve the selected worktree base branch through reconnects, and reload projects after startup identity is resolved. (#133664, #133744, #133817)</li>
-<li><strong>Chat refresh and reconnect:</strong> keep images visible while refreshed history loads, recover suspended tabs after Gateway updates, and keep the earlier-history action steady during pagination. Related #134237. (#134310, #134189, #132445) Thanks @Takhoffman and @RomneyDa.</li>
-<li><strong>Chat controls:</strong> restore text selection and simpler GitHub code copying, keep rewind confirmation controls accessible, and integrate Goal mode into the composer. Related #131201, #132786. (#133536, #133791, #132787) Thanks @RomneyDa, @Grynn, and @vyctorbrzezowski.</li>
-<li><strong>Voice privacy and delivery:</strong> exclude internal reasoning from spoken summaries, preserve accepted speech through media delivery, and retain speech and process-output delivery state through nested tools. Related #90364, #83636. (#133615, #133324, #133968, #134170, #134056) Thanks @camball-strategies, @obviyus, @TurboTheTurtle, @clawSean, and @Conan-Scott.</li>
-<li><strong>Browser Talk:</strong> keep later voice turns admitted after call setup, preserve provider conversation order, keep internal consultations out of user history, pass questions literally, and honor the configured agent for default sessions. Related #133855, #134037, #134081. (#133493, #133947, #134093, #133958, #134138) Thanks @vmbbz, @chelsealong, @lsr911, @obviyus, @ZengWen-DT, @SebTardif, @Conan-Scott, @YogevKr, and @mastertyko.</li>
-<li><strong>Microphone and transcription:</strong> explain pending microphone permission, avoid expiring a voice session while permission is pending, report transcription failures, and honor the selected transcription model. Related #133348, #133359, #133448. (#133353, #133384, #133473, #133613) Thanks @lsr911.</li>
-<li><strong>Voice settings and calls:</strong> retain canonical voice selections, discover configured providers, prevent late callbacks from creating phantom calls or obsolete replies, and preserve call capacity after storage failures. Related #112360, #129473. (#117527, #133507, #133811, #133484, #129847) Thanks @itkdm, @ruel225, @DonShelly, and @aniruddhaadak80.</li>
-<li><strong>Speech providers:</strong> resolve persona-level TTS secret references, report malformed MiniMax speech responses clearly, and consume interrupted Google voice-turn completion correctly; support the configured xAI speech origin consistently for synthesis and voice discovery while checking redirects to other origins, and handle silent transcripts correctly. Related #89607, #133351. (#89636, #123245, #133365, #134214, #134377) Thanks @SebTardif, @lsr911, @obviyus, @chelsealong, @ZengWen-DT, @pablonunoutande-source, @coaiMax, and @marmar9615-cloud.</li>
-<li><strong>iMessage and Telegram:</strong> keep iMessage replies in the current conversation and preserve Telegram’s rich button labels when building reply context. Related #133468. (#133499, #133307) Thanks @omarshahine and @obviyus.</li>
-<li><strong>Slack Enterprise approvals:</strong> deliver plugin approval requests to workspace-qualified approvers and accept their buttons only from the intended workspace. Related #133932. (#134251) Thanks @obviyus and @marmar9615-cloud.</li>
-<li><strong>Discord and LINE routing:</strong> suppress replies aimed at other Discord bots, avoid LINE introductions in unauthorized rooms, apply per-group wildcard defaults, and respect quote-as-mention policy. Related #133618. (#130327, #132628, #132918, #133619) Thanks @PollyBot13, @obviyus, and @edenfunf.</li>
-<li><strong>LINE presentation:</strong> preserve recognizable inline emoji, pace block replies using the agent’s configured human delay, and offer LINE card commands only on LINE. Related #132082, #133430. (#132083, #133443, #132895) Thanks @edenfunf.</li>
-<li><strong>Media compatibility:</strong> restore AVI playback and filenames, normalize detected Matroska and ASF media for the right handling, and decode quoted input-file charsets correctly. Related #133328, #133608. (#133329, #133383, #133386, #133610) Thanks @ly85206559.</li>
-<li><strong>Text fidelity:</strong> preserve Unicode when truncating email and runtime text, retain HTML paragraph boundaries, and avoid leaking code-span placeholders into outbound messages; preserve trailing whitespace inside inline code and keep astral Unicode letters separated when stripping model control tokens. Related #132969, #134450. (#132170, #132366, #132998, #125184, #134451, #134357) Thanks @harjothkhara, @ly85206559, @pengzh1, @yifanxiong272, and @wanyongstar.</li>
-<li><strong>Audio language detection:</strong> omit the implicit audio prompt during automatic language detection so it does not bias transcription. Related #123305. (#133674) Thanks @synthalorian and @aleps001.</li>
-<li><strong>Cloud cancellation:</strong> persist canceled queued turns, stop work without waiting for unrelated provider inspection, fence canceled bundle installation, and wait for pending SSH workspace cleanup. Related #133455. (#133241, #133476, #133976, #133472) Stop also cancels pending worker provisioning and project preparation while allowing owned cleanup to finish. (#133735)</li>
-<li><strong>Cloud lifecycle:</strong> prevent archive, delete, and recovery from hanging behind worker moves, preserve actionable execution and workspace-recovery failures, fix bootstrap archive races, and release idle desktops before reuse; settle project snapshots before enrollment, reuse prepared worker archives, and reclaim unused snapshots during idle maintenance. Related #133654, #134199. (#133551, #133663, #133655, #133451, #134200, #134043, #134181, #134326, #134088) Thanks @Takhoffman.</li>
-<li><strong>Native Codex sessions:</strong> continue selected native sessions without scanning an entire large Codex home, preserve conversations across app-server restarts, and avoid intermittent Linux startup failures. Related #133929. (#134073, #134098, #133485)</li>
-<li><strong>Provider failures:</strong> retain provider ownership in errors, explain unavailable selected Codex authentication profiles, and preserve the real retry and rate-limit outcome when a pinned model disables fallbacks. Related #134012, #113169. (#134029, #133970, #133355, #134111) Thanks @vincentkoc, @Jeehut, and @obviyus.</li>
-<li><strong>Model browsing and search:</strong> recover model browsing after catalog replacement and distinguish missing answers from malformed Google and xAI responses. Related #133166, #130550. (#133221, #130583, #133667) Thanks @chelsealong, @vincentkoc, @r3n3x, @Darren2030, and @jailbirt.</li>
-<li><strong>Usage accuracy:</strong> keep output-token counts cumulative and recoverable, restore native-session usage after <code>/new</code>, refresh native pricing without pinning defaults, and correct cached long-context costs; refresh Cerebras and Chutes estimates from provider pricing while preserving explicit user rates, and keep usage pricing on static model metadata. Related #133562, #133346, #133343. (#133605, #133441, #133695, #133349) Related #134248. (#134311, #133699)</li>
-<li><strong>Long-history performance:</strong> avoid excessive context copies, release transcript backing storage after eviction, reuse prepared batch writers, and reduce repeated Control UI history processing while preserving full-fidelity fork evidence. Related #133738, #133939, #123540, #133941. (#133753, #133565, #133680, #133965, #123541, #134238, #133988, #134252, #134209) Thanks @njuboy11 and @obviyus.</li>
-<li><strong>Concurrent session work:</strong> reuse session facts and remove repeated history scans from concurrent turns, status reads, and bounded task pages. Related #133053. (#133061, #133683, #133903, #134176, #132903) Thanks @jason-allen-oneal and @obviyus.</li>
-<li><strong>Browser reliability:</strong> retain accepted browser follow-ups through restarts, preserve contextless workers and iframe sessions, and use CDP for managed role snapshots. Related #133569, #133514. (#133457, #133571, #133614) Thanks @vincentkoc and @josephbergvinson.</li>
-<li><strong>Beam transcript fidelity:</strong> preserve uploader identity, restart delivery when the receiver changes, and omit mixed Claude tool content without losing snapshot state. (#133425, #133533, #133460)</li>
-<li><strong>Windows support:</strong> preserve PowerShell profile encoding and pnpm shim arguments, and retain resource scope across Windows path casing differences. (#133729, #133395, #134052) Thanks @ly85206559 and @vincentkoc.</li>
-<li><strong>CLI output and tools:</strong> keep Unicode session and task tables aligned, fail session tailing on follow-read errors, preserve escaped Code Mode output prefixes, and retain readable grep context and literal <code>@</code>-prefixed paths. Related #133776. (#133758, #133422, #132660, #133777, #131621, #133815) Thanks @Alix-007, @xialonglee, and @qingminglong.</li>
-<li><strong>Skills and memory wiki:</strong> recover colon-rich skill frontmatter, allow disposal of malformed proposals, and reject unsupported wiki operations and self-imported source pages; discover skill roots created after Gateway startup so newly added skills can refresh normally. Related #124486, #125139. (#122884, #124488, #123448, #125160, #134136) Thanks @xydt-tanshanshan, @obviyus, @woodym-dotcom, @wanyongstar, @rajmp999, @YouBeerMe, and @shakkernerd.</li>
-<li><strong>Settings and configuration:</strong> preserve concurrent first saves, retain owners across legacy agent imports and store changes, preserve QQBot multi-account settings, and honor per-agent tool-progress detail overrides. Related #133868, #133889, #133899. (#134072, #133920, #133788, #133948) Thanks @MrSwagatRathod, @obviyus, @lsr911, @chelsealong, @ZengWen-DT, @SebTardif, @marmar9615-cloud, and @yubingjiaocn.</li>
-<li><strong>Native authentication:</strong> preserve Anthropic native authentication when API keys are also stored, retain explicitly pinned npm versions during stale-runtime repair, and keep the correct pnpm installation owner after launcher respawn. Related #134004, #123616, #134037. (#134030, #128250, #134075) Thanks @obviyus, @rayseling, @SunnyShu0925, @sblindt, and @YogevKr.</li>
-<li><strong>macOS ChatGPT login:</strong> finish onboarding after a same-route Gateway reconnect by resubmitting a callback only when it was never dispatched, preserving the existing login session. Related #134182. (#134268) Thanks @obviyus and @Sedrak-Hovhannisyan.</li>
-<li><strong>Gateway setup and repair:</strong> require actual Gateway protocol readiness before declaring setup complete, preserve the operator’s home during sudo service installation, and allow stopping a Gateway even when its state schema is newer. Related #133273, #133953, #134000. (#133434, #133989, #134084, #133595) Thanks @obviyus, @itanyplus, and @RomneyDa.</li>
-<li><strong>Diagnostics stay on target:</strong> keep embedded triage on the installation being diagnosed, and let TLS status and connection checks read certificates without creating or repairing certificate files. Related #133842, #128598, #134222. (#134244, #134223) Thanks @obviyus.</li>
-<li><strong>Doctor maintenance:</strong> coordinate state repair with the matching managed Gateway, preserve its installed service definition, and verify it after any restart; use <code>openclaw gateway install --force</code> when you explicitly want to replace the managed launcher. Related #133957. (#134031)</li>
-<li><strong>Gateway restart after repair:</strong> release Doctor’s database handles before restarting, so completed session migrations no longer leave the Gateway blocked by Doctor’s own database leases. (#134429)</li>
-<li><strong>Update restart ordering:</strong> let the updater control Gateway restarts through Doctor repairs and plugin setup, preventing Doctor from restarting it before the update is ready. (#134470)</li>
-<li><strong>Clearer repair outcomes:</strong> report when configuration errors block state repair, fail unhealthy plugin Doctor checks, preserve newly written stability bundles, and stop warning about canonical database links and nested Git workspaces. Related #134036, #133388, #127418, #133981, #133923. (#134078, #133431, #132626, #134087, #133964) Thanks @obviyus, @YogevKr, @PollyBot13, @Alix-007, @02-dino, and @jeffsteinbok-openclaw.</li>
-<li><strong>Auth archive recovery:</strong> show completed or failed interrupted recovery even when Doctor returns early or another migration is declined, preserving failed source data. Related #133881, #133962. (#134009) Thanks @angeliti999 and @shakkernerd.</li>
-<li><strong>Provider configuration:</strong> migrate retired xAI image-model selections, ignore missing optional secret-backed command environment values, and report plugin-registry persistence differences instead of silently losing changes. Related #124527, #133561, #133901. (#126495, #133582, #133963) Thanks @Schimuneck, @obviyus, @tiniecookie, @pengzh1, @vincentkoc, @jodok, and @yubingjiaocn.</li>
-<li><strong>Automatic update policy:</strong> keep the saved update channel authoritative after a one-off package tag, cancel discovery when checks are disabled, record failed automatic updates, and preserve recovery actions across dashboard reloads; unattended installation requires a managed Gateway service. (#134566)</li>
-<li><strong>Install and channel switches:</strong> finish update-channel and installation switches using the verified installation, recover only when the installed package is safe to restart, and recognize npm installations that have no installer metadata. Related #134203. (#134397, #134475) Thanks @Patrick-Erichsen and @vyctorbrzezowski.</li>
-<li><strong>Runtime capability review:</strong> show the runtime plugin source and capabilities before model activation, keep installation and the live model check in the same setup flow, and let declining or canceling end that attempt without silently choosing another connection. (#134101) Thanks @VACInc.</li>
-<li><strong>Cloud result recovery:</strong> retain worker results before retiring stale owners, recover cloud sessions across Gateway restarts and cancellation, and scope recovery to the requested environment. Related #131713. (#132128, #133728, #134448) Thanks @jalehman and @shakkernerd.</li>
-<li><strong>Retained conversation inputs:</strong> keep retained inputs in transcript order and prevent retired prompts from reappearing after history refresh or remount. (#134261, #134059) Thanks @VACInc.</li>
-<li><strong>Model availability and routing:</strong> pair full model catalogs with native authentication results and retain the selected completion transport, so discovered models and completion requests use the intended provider. Related #134325. (#134463, #134521) Thanks @fuller-stack-dev and @goslingmanagment.</li>
-<li><strong>macOS installation and sign-in:</strong> relaunch the verified app after installation and let stalled provider sign-in exit without late authentication replies reopening a retired flow. Related #134034, #134347. (#134074, #134380) Thanks @Sedrak-Hovhannisyan and @VACInc.</li>
-<li><strong>Linux and npm installation:</strong> preserve Fedora and other RPM-owned Node packages when OpenClaw needs a separate SQLite-safe runtime, restore npm conflict recovery and failure diagnostics, and keep installer dry runs from downloading the terminal UI helper. Related #132828, #134201. (#134166, #134236, #134388) Thanks @beedell-roke, @ly85206559, @mohamedelrefaiy, @sallyom, and @SunnyShu0925.</li>
-<li><strong>IPv6 Gateway access:</strong> keep canvas, boards, and other plugin-hosted surfaces reachable when the Gateway uses bracketed IPv6 hosts, including forwarded host headers. (#134050) Thanks @yangxiansheng.</li>
-<li><strong>Browser relay admission:</strong> limit pending relay authentication and replay records per client source so one source cannot consume the shared capacity. (#134241) Thanks @mmaps.</li>
-<li><strong>Credential reloads and inspection:</strong> stop SMS webhook, media, and Twilio work when its account credentials become unavailable or are superseded, and keep inactive channel credentials out of inspection. Related #133924. (#134145, #134418) Thanks @shakkernerd.</li>
-<li><strong>LINE conversations:</strong> list configured peers and groups, keep typing indicators working for Gateway-driven replies, and avoid answering standby events while another channel owns the conversation. Related #133576, #133597, #133677. (#133599, #133679, #133577) Thanks @edenfunf.</li>
-<li><strong>Slack image downloads:</strong> honor the configured image size limit when downloaded Slack files become tool results. (#134242) Thanks @marmar9615-cloud.</li>
-<li><strong>Tool output fidelity:</strong> keep grep matches whose paths arrive as bytes and stop shell redirections or <code>rg --files</code> arguments from appearing as misleading search targets. (#133358, #133783) Thanks @darioandyoshi-tech and @ly85206559.</li>
-<li><strong>HTML exports:</strong> omit hidden messages from conversation cards while retaining their labeled debugging records; the HTML archive and JSONL download still contain hidden messages, so hiding is not redaction. (#134561)</li>
-<li><strong>Hermes migration:</strong> preserve the selected agent’s model, supported provider metadata, MCP tool restrictions, active organization skills, and disabled skill settings; partial apply failures return a complete JSON report with a nonzero exit. (#134426)</li>
-<li><strong>Plugin repair guidance:</strong> verify exact npm repair targets before suggesting a plugin update, and show a retry diagnostic when the target is unavailable. (#133617) Thanks @vladimirkrdzic.</li>
-<li><strong>Gateway session memory:</strong> bound the session data loaded for lists, health, status, lookup, and cleanup, avoid retaining unused prompt snapshots, and refresh query planning after bulk deletion. (#134395, #134554, #134488, #133925) Thanks @VACInc.</li>
-<li><strong>Failure diagnostics:</strong> retain the real reason in JSON log errors, preserve useful stdout alongside stderr on command failure, and report quiet npm timeouts or termination instead of blank errors. Related #127448, #134427, #134533. (#134534, #134428, #133845) Thanks @aniruddhaadak80 and @vincentkoc.</li>
-<li><strong>Status and restart diagnostics:</strong> honor usage and agent-scope options in full status reports, identify active work delaying a restart, and report declared configuration accurately in triage. Related #134267. (#134269, #133154, #134416) Thanks @VACInc.</li>
-<li><strong>Home and composer continuity:</strong> derive Home titles from the user message rather than its work-context snapshot, keep steady composer edits local in long conversations, and give scheduled-job controls distinct accessible names. Related #127330. (#134591, #133465, #134225) Thanks @SunnyShu0925 and @VACInc.</li>
-<li><strong>Systemd version metadata:</strong> refresh obsolete version metadata during safe restarts without replacing the installed service or suppressing the restart when metadata maintenance fails. Related #134202. (#134482) Thanks @Patrick-Erichsen and @vyctorbrzezowski.</li>
-<li><strong>Legacy state validation:</strong> reject unexpected JSON fields even when their key is empty during supported push, node-host, outgoing-image, and TUI state migrations. (#134577) Thanks @vincentkoc.</li>
-<li><strong>Command help and completion:</strong> keep hidden commands and options out of shell suggestions, retain the accepted legacy <code>message read --include-thread</code> spelling without advertising a no-op, and reject blank Gateway probe timeouts. (#134247, #134212, #134040) Thanks @marmar9615-cloud and @SunnyShu0925.</li>
-<li><strong>Session and shutdown ownership:</strong> retain the selected agent through global native-session operations, keep sends on the selected channel plugin, stop new outbound retry admission during shutdown, and reject language-server tools after their bundle is disposed. Related #127260, #134313. (#134314, #134564, #134381, #133340) Thanks @qingminglong and @VACInc.</li>
-</ul>
-<h3>Known issues</h3>
-<ul>
-<li><strong>Optional memory plugin dependency:</strong> standalone <code>@openclaw/memory-lancedb</code> installs can still resolve an older vulnerable Sharp version through an optional Transformers dependency. The plugin’s reviewed text-embedding and vector-storage path does not load that image adapter; this dependency exposure remains a packaging follow-up.</li>
-<li><strong>Hindi and Korean token labels:</strong> the native app’s token-usage label reverses the wording for used and total tokens; the counts and calculations are unchanged.</li>
-</ul>
-<h3>Upcoming deprecations</h3>
-These already-deprecated Plugin SDK import paths remain available in <strong>2026.8.2</strong>. Their recorded removal target is <strong>2026-09-01</strong>; plugin authors should prepare the following migrations using the <a href="https://docs.openclaw.ai/plugins/sdk-migration">Plugin SDK migration guide</a>.
-<ul>
-<li><strong><code>openclaw/plugin-sdk/config-runtime</code>:</strong> use <code>api.pluginConfig</code> for plugin configuration, <code>openclaw/plugin-sdk/config-contracts</code> for types, <code>openclaw/plugin-sdk/runtime-config-snapshot</code> for snapshot reads, and <code>openclaw/plugin-sdk/config-mutation</code> for writes. (<code>plugin-sdk-config-runtime-subpath</code>)</li>
-<li><strong><code>openclaw/plugin-sdk/channel-reply-pipeline</code>:</strong> import reply pipeline helpers from <code>openclaw/plugin-sdk/channel-outbound</code>. (<code>plugin-sdk-channel-reply-pipeline-subpath</code>)</li>
-<li><strong><code>openclaw/plugin-sdk/infra-runtime</code>:</strong> move helpers to focused imports, including <code>openclaw/plugin-sdk/delivery-queue-runtime</code>, <code>openclaw/plugin-sdk/diagnostic-runtime</code>, <code>openclaw/plugin-sdk/error-runtime</code>, <code>openclaw/plugin-sdk/exec-approvals-runtime</code>, <code>openclaw/plugin-sdk/fetch-runtime</code>, and <code>openclaw/plugin-sdk/ssrf-runtime</code>. The migration guide records that system-event snapshot inspection and consumption still have no modern public replacement. (<code>plugin-sdk-infra-runtime-subpath</code>)</li>
-<li><strong><code>openclaw/plugin-sdk/channel-lifecycle</code>:</strong> use <code>openclaw/plugin-sdk/channel-outbound</code>. (<code>plugin-sdk-channel-lifecycle-subpath</code>)</li>
-<li><strong><code>openclaw/plugin-sdk/channel-message</code>:</strong> use <code>openclaw/plugin-sdk/channel-outbound</code> and <code>openclaw/plugin-sdk/channel-inbound</code>. (<code>plugin-sdk-channel-message-subpath</code>)</li>
-</ul>
-<h3>Complete contribution record</h3>
-This audited record covers the complete 0a6c013be5f50981b12d021b387b4fd1ea7e491e..e01f53cfa01302f03fed4797b0715d11945ddd41 history: 784 in-range PRs + 0 retained seed-only PRs = 784 unique PRs. The generation manifest also supplies direct commits as editorial input; the grouped notes above prioritize user impact.
-Shipped baseline exclusions: v2026.8.1 (10 PRs: #111111, #119051, #122346, #124471, #127978, #129694, #132960, #133260, #133454, #133471).
-<h4>Pull requests</h4>
-<ul>
-<li><strong>PR #125269</strong> <a href="https://github.com/openclaw/openclaw/pull/125269">fix(gateway): reject usage.cost agentScope=all with agentId</a> Related #125268. Thanks @zyw02 and @obviyus.</li>
-<li><strong>PR #132054</strong> <a href="https://github.com/openclaw/openclaw/pull/132054">feat(ui): render cross-session messages as linked speech bubbles</a></li>
-<li><strong>PR #125160</strong> <a href="https://github.com/openclaw/openclaw/pull/125160">fix(memory-wiki): exclude vault's own pages from unsafe-local import</a> Related #125139. Thanks @rajmp999 and @obviyus and @YouBeerMe.</li>
-<li><strong>PR #133293</strong> <a href="https://github.com/openclaw/openclaw/pull/133293">refactor(plugins): reuse the void hook binder</a></li>
-<li><strong>PR #127110</strong> <a href="https://github.com/openclaw/openclaw/pull/127110">fix(compaction): stop repeated transcript byte compaction</a> Related #126900. Thanks @yu-xin-c and @obviyus and @fede-kamel.</li>
-<li><strong>PR #133322</strong> <a href="https://github.com/openclaw/openclaw/pull/133322">test: preserve Vitest project ownership for CLI filters</a></li>
-<li><strong>PR #133320</strong> <a href="https://github.com/openclaw/openclaw/pull/133320">fix: apply formatting-only file edits</a> Related #133319.</li>
-<li><strong>PR #133316</strong> <a href="https://github.com/openclaw/openclaw/pull/133316">perf(history): reuse prepared display and session facts</a></li>
-<li><strong>PR #133326</strong> <a href="https://github.com/openclaw/openclaw/pull/133326">chore(ui): refresh control ui locales</a></li>
-<li><strong>PR #133307</strong> <a href="https://github.com/openclaw/openclaw/pull/133307">fix(telegram): preserve rich button labels in reply context</a> Thanks @obviyus.</li>
-<li><strong>PR #130327</strong> <a href="https://github.com/openclaw/openclaw/pull/130327">fix(discord): prevent bots interrupting replies to other bots</a> Thanks @PollyBot13 and @obviyus.</li>
-<li><strong>PR #133329</strong> <a href="https://github.com/openclaw/openclaw/pull/133329">fix(media): restore AVI attachment playback and file extensions</a> Related #133328.</li>
-<li><strong>PR #133325</strong> <a href="https://github.com/openclaw/openclaw/pull/133325">refactor(tests): isolate planner environment fixtures</a></li>
-<li><strong>PR #122884</strong> <a href="https://github.com/openclaw/openclaw/pull/122884">fix(skills): generalize freeform frontmatter value recovery beyond description</a> Thanks @xydt-tanshanshan and @obviyus.</li>
-<li><strong>PR #133300</strong> <a href="https://github.com/openclaw/openclaw/pull/133300">fix(agents): recover after settled failed-tool batches</a> Related #133292. Thanks @VACInc.</li>
-<li><strong>PR #132789</strong> <a href="https://github.com/openclaw/openclaw/pull/132789">fix(ui): prevent dark flash on light-system reload</a> Related #132785. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #124488</strong> <a href="https://github.com/openclaw/openclaw/pull/124488">fix(skills): allow disposal of malformed proposals</a> Related #124486. Thanks @woodym-dotcom and @obviyus.</li>
-<li><strong>PR #133321</strong> <a href="https://github.com/openclaw/openclaw/pull/133321">fix(release): record approved Telegram waiver for 2026.8.1</a></li>
-<li><strong>PR #133332</strong> <a href="https://github.com/openclaw/openclaw/pull/133332">refactor: simplify command handler registration</a></li>
-<li><strong>PR #133309</strong> <a href="https://github.com/openclaw/openclaw/pull/133309">fix(test): keep complete multi-project JSON reports</a> Related #133305.</li>
-<li><strong>PR #124418</strong> <a href="https://github.com/openclaw/openclaw/pull/124418">fix(agents): preserve file bytes in apply_patch outside the hunk</a> Thanks @synthalorian and @obviyus.</li>
-<li><strong>PR #131621</strong> <a href="https://github.com/openclaw/openclaw/pull/131621">fix(agents): preserve decoded grep context and readable paths</a> Thanks @xialonglee.</li>
-<li><strong>PR #133336</strong> <a href="https://github.com/openclaw/openclaw/pull/133336">fix: remove ignored arguments from agent tools</a> Related #133333.</li>
-<li><strong>PR #133241</strong> <a href="https://github.com/openclaw/openclaw/pull/133241">fix: stop queued cloud work and persist canceled turns</a></li>
-<li><strong>PR #123541</strong> <a href="https://github.com/openclaw/openclaw/pull/123541">fix(sessions): branches.list stalls the event loop for ~12s on long-lived sessions</a> Related #123540. Thanks @njuboy11 and @obviyus.</li>
-<li><strong>PR #133350</strong> <a href="https://github.com/openclaw/openclaw/pull/133350">improve: avoid hashing imported transcript events twice</a></li>
-<li><strong>PR #130583</strong> <a href="https://github.com/openclaw/openclaw/pull/130583">fix(google): distinguish missing search answers from malformed responses</a> Related #130550. Thanks @Darren2030 and @jailbirt.</li>
-<li><strong>PR #133353</strong> <a href="https://github.com/openclaw/openclaw/pull/133353">fix(ui): explain pending voice microphone access</a> Related #133348.</li>
-<li><strong>PR #133375</strong> <a href="https://github.com/openclaw/openclaw/pull/133375">docs: consolidate Crabbox guidance with shared skill</a></li>
-<li><strong>PR #126495</strong> <a href="https://github.com/openclaw/openclaw/pull/126495">fix(xai): doctor migrates retired image models in tools.media.models</a> Related #124527. Thanks @Schimuneck and @obviyus and @tiniecookie.</li>
-<li><strong>PR #133365</strong> <a href="https://github.com/openclaw/openclaw/pull/133365">fix(google): avoid duplicate turn completion after voice interruption</a> Related #133351.</li>
-<li><strong>PR #133357</strong> <a href="https://github.com/openclaw/openclaw/pull/133357">fix(ci): make Telegram release tests best effort</a></li>
-<li><strong>PR #123432</strong> <a href="https://github.com/openclaw/openclaw/pull/123432">fix(agents): default agent-run admissions to static catalog mode</a> Thanks @xialonglee and @obviyus.</li>
-<li><strong>PR #133373</strong> <a href="https://github.com/openclaw/openclaw/pull/133373">fix: reject unsupported Testbox no-sync runs</a></li>
-<li><strong>PR #133362</strong> <a href="https://github.com/openclaw/openclaw/pull/133362">perf: reduce repeated prompt and plugin metadata work</a></li>
-<li><strong>PR #133355</strong> <a href="https://github.com/openclaw/openclaw/pull/133355">fix(codex): explain unavailable selected auth profiles</a> Related #113169. Thanks @vincentkoc and @Jeehut.</li>
-<li><strong>PR #133153</strong> <a href="https://github.com/openclaw/openclaw/pull/133153">refactor: remove channel docking and manual session focus</a></li>
-<li><strong>PR #133378</strong> <a href="https://github.com/openclaw/openclaw/pull/133378">improve: update initialized transcript windows directly</a></li>
-<li><strong>PR #133352</strong> <a href="https://github.com/openclaw/openclaw/pull/133352">chore(ui): refresh control ui locales</a></li>
-<li><strong>PR #123194</strong> <a href="https://github.com/openclaw/openclaw/pull/123194">fix(mcp): cap HTTP/SSE response bodies before SDK parse</a> Related #101554. Thanks @SebTardif and @obviyus and @aniruddhaadak80.</li>
-<li><strong>PR #133061</strong> <a href="https://github.com/openclaw/openclaw/pull/133061">fix: keep Gateway and Control UI responsive during concurrent session updates</a> Related #133053.</li>
-<li><strong>PR #133384</strong> <a href="https://github.com/openclaw/openclaw/pull/133384">fix(ui): avoid voice session expiry while waiting for microphone access</a> Related #133359.</li>
-<li><strong>PR #133401</strong> <a href="https://github.com/openclaw/openclaw/pull/133401">docs: clarify provider normalization ownership</a></li>
-<li><strong>PR #132799</strong> <a href="https://github.com/openclaw/openclaw/pull/132799">fix(ui): unify connected composer stack surface</a> Related #132796. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #132787</strong> <a href="https://github.com/openclaw/openclaw/pull/132787">fix(ui): integrate Goal mode into the composer</a> Related #132786. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #133404</strong> <a href="https://github.com/openclaw/openclaw/pull/133404">docs: retire historical implementation plans</a></li>
-<li><strong>PR #133409</strong> <a href="https://github.com/openclaw/openclaw/pull/133409">refactor(ui): simplify outbox custody and draft persistence</a></li>
-<li><strong>PR #133407</strong> <a href="https://github.com/openclaw/openclaw/pull/133407">fix(channels): preserve long WhatsApp replies with less formatting work</a></li>
-<li><strong>PR #133413</strong> <a href="https://github.com/openclaw/openclaw/pull/133413">refactor(settings): restore one storage load path</a> Thanks @obviyus.</li>
-<li><strong>PR #133356</strong> <a href="https://github.com/openclaw/openclaw/pull/133356">test: reuse performance workflow repository fixtures</a></li>
-<li><strong>PR #133402</strong> <a href="https://github.com/openclaw/openclaw/pull/133402">fix(ui): hide URL tooltips while rich cards are open</a> Related #133397.</li>
-<li><strong>PR #133410</strong> <a href="https://github.com/openclaw/openclaw/pull/133410">fix(ui): avoid restoring retired voice transports after restart failure</a> Related #133387.</li>
-<li><strong>PR #133399</strong> <a href="https://github.com/openclaw/openclaw/pull/133399">fix(openrouter): reject malformed catalog envelopes</a> Thanks @vincentkoc.</li>
-<li><strong>PR #133382</strong> <a href="https://github.com/openclaw/openclaw/pull/133382">fix: preserve conversation order across session catalogs</a> Related #133377.</li>
-<li><strong>PR #125755</strong> <a href="https://github.com/openclaw/openclaw/pull/125755">feat(beam): add readable transcript share URLs</a> Related #125752.</li>
-<li><strong>PR #133420</strong> <a href="https://github.com/openclaw/openclaw/pull/133420">refactor(plugins): consolidate registry snapshot test fixtures</a></li>
-<li><strong>PR #133422</strong> <a href="https://github.com/openclaw/openclaw/pull/133422">fix(cli): keep sessions tail columns aligned for Unicode keys</a></li>
-<li><strong>PR #133403</strong> <a href="https://github.com/openclaw/openclaw/pull/133403">improve: reduce transcript import watermark overhead</a></li>
-<li><strong>PR #133424</strong> <a href="https://github.com/openclaw/openclaw/pull/133424">perf(media): avoid redundant attachment scans and base64 round trips</a></li>
-<li><strong>PR #133411</strong> <a href="https://github.com/openclaw/openclaw/pull/133411">fix(maintainers): block rewritten contributor squashes</a> Thanks @vincentkoc.</li>
-<li><strong>PR #133427</strong> <a href="https://github.com/openclaw/openclaw/pull/133427">improve: speed up Git workflow fixture execution</a></li>
-<li><strong>PR #133433</strong> <a href="https://github.com/openclaw/openclaw/pull/133433">chore(ui): refresh control ui locales</a></li>
-<li><strong>PR #133076</strong> <a href="https://github.com/openclaw/openclaw/pull/133076">fix(agents): stop queued Swarm collectors with their parent</a> Related #131553.</li>
-<li><strong>PR #133434</strong> <a href="https://github.com/openclaw/openclaw/pull/133434">fix: keep Model Setup pending until Gateway settings are active</a> Related #133273.</li>
-<li><strong>PR #133369</strong> <a href="https://github.com/openclaw/openclaw/pull/133369">fix(ui): hide redundant error details</a> Related #133367. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #133425</strong> <a href="https://github.com/openclaw/openclaw/pull/133425">fix: preserve uploader identity in Beam transcripts</a></li>
-<li><strong>PR #133440</strong> <a href="https://github.com/openclaw/openclaw/pull/133440">fix(ui): allow discarding unconfirmed messages blocking the queue</a></li>
-<li><strong>PR #133423</strong> <a href="https://github.com/openclaw/openclaw/pull/133423">fix(release): accept protected-tag npm preflight candidates</a></li>
-<li><strong>PR #129847</strong> <a href="https://github.com/openclaw/openclaw/pull/129847">fix(voice-call): preserve call capacity after storage failure</a> Related #129473. Thanks @aniruddhaadak80.</li>
-<li><strong>PR #133438</strong> <a href="https://github.com/openclaw/openclaw/pull/133438">test: reuse publish workflow repository fixtures</a></li>
-<li><strong>PR #133426</strong> <a href="https://github.com/openclaw/openclaw/pull/133426">fix(ci): keep full release evidence out of argv</a></li>
-<li><strong>PR #133437</strong> <a href="https://github.com/openclaw/openclaw/pull/133437">improve(ui): remove media device refresh buttons</a></li>
-<li><strong>PR #133451</strong> <a href="https://github.com/openclaw/openclaw/pull/133451">fix: release idle desktops and await cleanup before reuse</a></li>
-<li><strong>PR #133441</strong> <a href="https://github.com/openclaw/openclaw/pull/133441">fix: native Codex session usage stays zero after /new</a> Related #133346.</li>
-<li><strong>PR #133429</strong> <a href="https://github.com/openclaw/openclaw/pull/133429">fix(gateway): reduce control-plane stalls during concurrent turns</a></li>
-<li><strong>PR #133458</strong> <a href="https://github.com/openclaw/openclaw/pull/133458">chore(ui): refresh control ui locales</a></li>
-<li><strong>PR #133453</strong> <a href="https://github.com/openclaw/openclaw/pull/133453">refactor(agents): reuse Workshop text result envelopes</a></li>
-<li><strong>PR #133463</strong> <a href="https://github.com/openclaw/openclaw/pull/133463">feat(beam): name share URLs after their sessions</a></li>
-<li><strong>PR #133446</strong> <a href="https://github.com/openclaw/openclaw/pull/133446">improve: reduce session import, compaction, and UI startup overhead</a></li>
-<li><strong>PR #133466</strong> <a href="https://github.com/openclaw/openclaw/pull/133466">perf: reduce repeated diagnostic lifecycle scans</a></li>
-<li><strong>PR #133467</strong> <a href="https://github.com/openclaw/openclaw/pull/133467">fix(ci): update Kova gateway-call contract pin</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133474</strong> <a href="https://github.com/openclaw/openclaw/pull/133474">refactor(ui): simplify chat message rendering and recovery</a></li>
-<li><strong>PR #133473</strong> <a href="https://github.com/openclaw/openclaw/pull/133473">fix(talk): report browser input transcription failures</a> Related #133448.</li>
-<li><strong>PR #133363</strong> <a href="https://github.com/openclaw/openclaw/pull/133363">improve(ui): shimmer while GitHub link previews load</a></li>
-<li><strong>PR #133452</strong> <a href="https://github.com/openclaw/openclaw/pull/133452">fix(status): preserve prepared context windows</a> Related #133405. Thanks @vincentkoc and @Finn763 and @ahmedsaed.</li>
-<li><strong>PR #132660</strong> <a href="https://github.com/openclaw/openclaw/pull/132660">fix(cli): fail sessions tail on follow read errors</a> Thanks @Alix-007.</li>
-<li><strong>PR #133485</strong> <a href="https://github.com/openclaw/openclaw/pull/133485">fix(codex): wait for Linux process command readiness</a></li>
-<li><strong>PR #133349</strong> <a href="https://github.com/openclaw/openclaw/pull/133349">fix(usage): correct cached long-context cost estimates</a> Related #133343.</li>
-<li><strong>PR #133483</strong> <a href="https://github.com/openclaw/openclaw/pull/133483">perf(markdown): reuse fallback and table preparation</a></li>
-<li><strong>PR #117527</strong> <a href="https://github.com/openclaw/openclaw/pull/117527">fix(tts): preserve canonical voice selections through normalization</a></li>
-<li><strong>PR #133472</strong> <a href="https://github.com/openclaw/openclaw/pull/133472">fix: Stop waits for pending SSH workspace cleanup</a> Related #133455.</li>
-<li><strong>PR #132798</strong> <a href="https://github.com/openclaw/openclaw/pull/132798">fix(ui): keep Inbox tabs stable across empty categories</a> Related #132795. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #133484</strong> <a href="https://github.com/openclaw/openclaw/pull/133484">fix(voice-call): fence obsolete automatic replies</a> Related #112360. Thanks @DonShelly.</li>
-<li><strong>PR #133417</strong> <a href="https://github.com/openclaw/openclaw/pull/133417">fix(ui): preserve explicit theme while reconnecting</a> Related #133416. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #133460</strong> <a href="https://github.com/openclaw/openclaw/pull/133460">fix(beam): omit mixed Claude tool content and preserve snapshot state</a></li>
-<li><strong>PR #133492</strong> <a href="https://github.com/openclaw/openclaw/pull/133492">docs(ci): correct performance lane auth and scheduling</a></li>
-<li><strong>PR #133494</strong> <a href="https://github.com/openclaw/openclaw/pull/133494">fix(ui): preserve the original error when a Control UI build fails</a></li>
-<li><strong>PR #133469</strong> <a href="https://github.com/openclaw/openclaw/pull/133469">feat(sessions): default session tools to agent visibility</a> Related #133456.</li>
-<li><strong>PR #133489</strong> <a href="https://github.com/openclaw/openclaw/pull/133489">fix: avoid repeated naming and regressing session startup progress</a> Related #133488.</li>
-<li><strong>PR #133498</strong> <a href="https://github.com/openclaw/openclaw/pull/133498">fix(release): allow guarded stable Docker recovery</a></li>
-<li><strong>PR #133491</strong> <a href="https://github.com/openclaw/openclaw/pull/133491">perf(process): reuse capacity facts within group selection</a></li>
-<li><strong>PR #133439</strong> <a href="https://github.com/openclaw/openclaw/pull/133439">feat(ui): identify sending agents on forwarded messages</a></li>
-<li><strong>PR #133461</strong> <a href="https://github.com/openclaw/openclaw/pull/133461">fix: isolate conversation bindings and align subagent command targets</a></li>
-<li><strong>PR #133496</strong> <a href="https://github.com/openclaw/openclaw/pull/133496">improve: speed up legacy session transcript imports</a></li>
-<li><strong>PR #133443</strong> <a href="https://github.com/openclaw/openclaw/pull/133443">fix(line): pace block replies with the agent's humanDelay</a> Related #133430. Thanks @edenfunf.</li>
-<li><strong>PR #133505</strong> <a href="https://github.com/openclaw/openclaw/pull/133505">test(docker): retain self-upgrade failure diagnostics</a></li>
-<li><strong>PR #133506</strong> <a href="https://github.com/openclaw/openclaw/pull/133506">fix(release): preserve frozen plugin prerelease context</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133504</strong> <a href="https://github.com/openclaw/openclaw/pull/133504">fix(docker): restore container CLI access with custom host ports</a> Related #133503.</li>
-<li><strong>PR #133368</strong> <a href="https://github.com/openclaw/openclaw/pull/133368">fix(ci): drain plugin publication Git before trust and readback</a></li>
-<li><strong>PR #133509</strong> <a href="https://github.com/openclaw/openclaw/pull/133509">refactor: share ordered Claw update rollback handling</a></li>
-<li><strong>PR #133495</strong> <a href="https://github.com/openclaw/openclaw/pull/133495">feat(ui): add CRT terminal theme</a></li>
-<li><strong>PR #133519</strong> <a href="https://github.com/openclaw/openclaw/pull/133519">fix(ui): deduplicate participant and viewer avatars</a></li>
-<li><strong>PR #133493</strong> <a href="https://github.com/openclaw/openclaw/pull/133493">fix(talk): preserve provider conversation order in browser transcripts</a> Thanks @vmbbz.</li>
-<li><strong>PR #133470</strong> <a href="https://github.com/openclaw/openclaw/pull/133470">fix(ui): replace startup hourglasses with capacity-aware rings</a> Related #133464.</li>
-<li><strong>PR #133532</strong> <a href="https://github.com/openclaw/openclaw/pull/133532">test(auto-reply): prepare memory flush model capabilities</a></li>
-<li><strong>PR #133508</strong> <a href="https://github.com/openclaw/openclaw/pull/133508">refactor(ui): consolidate chat rendering ownership</a></li>
-<li><strong>PR #133518</strong> <a href="https://github.com/openclaw/openclaw/pull/133518">perf(plugins): avoid eager loader imports for active registry reads</a></li>
-<li><strong>PR #133364</strong> <a href="https://github.com/openclaw/openclaw/pull/133364">refactor(plugins): simplify registration lifecycle policy</a></li>
-<li><strong>PR #133521</strong> <a href="https://github.com/openclaw/openclaw/pull/133521">refactor(agents): simplify compaction accounting</a></li>
-<li><strong>PR #132895</strong> <a href="https://github.com/openclaw/openclaw/pull/132895">fix(line): offer the card command only on LINE</a> Thanks @edenfunf.</li>
-<li><strong>PR #133512</strong> <a href="https://github.com/openclaw/openclaw/pull/133512">perf(agents): prepare only consumed tool and skill diagnostics</a></li>
-<li><strong>PR #133527</strong> <a href="https://github.com/openclaw/openclaw/pull/133527">perf(terminal): reuse control scans and simplify sanitization</a></li>
-<li><strong>PR #133221</strong> <a href="https://github.com/openclaw/openclaw/pull/133221">fix(models): recover /models browse from a replaced prepared catalog</a> Related #133166. Thanks @chelsealong and @vincentkoc and @r3n3x.</li>
-<li><strong>PR #133533</strong> <a href="https://github.com/openclaw/openclaw/pull/133533">fix(beam): resume sharing when the mirror receiver changes</a></li>
-<li><strong>PR #133544</strong> <a href="https://github.com/openclaw/openclaw/pull/133544">chore(ui): refresh control ui locales</a></li>
-<li><strong>PR #133542</strong> <a href="https://github.com/openclaw/openclaw/pull/133542">fix: prevent duplicate queued user messages in chat clients</a></li>
-<li><strong>PR #133543</strong> <a href="https://github.com/openclaw/openclaw/pull/133543">fix(agents): recognize internal requester completion replies</a></li>
-<li><strong>PR #133548</strong> <a href="https://github.com/openclaw/openclaw/pull/133548">refactor(ui): avoid redundant presence work in avatar lists</a></li>
-<li><strong>PR #133547</strong> <a href="https://github.com/openclaw/openclaw/pull/133547">fix(clawdock): keep credentials out of diagnostic output</a> Related #133535.</li>
-<li><strong>PR #133560</strong> <a href="https://github.com/openclaw/openclaw/pull/133560">fix(memory): clarify default agent scope in command help</a> Related #133559.</li>
-<li><strong>PR #133554</strong> <a href="https://github.com/openclaw/openclaw/pull/133554">test: guard multi-project Vitest cache ownership</a></li>
-<li><strong>PR #133557</strong> <a href="https://github.com/openclaw/openclaw/pull/133557">docs: add draft v2026.8.1 release notes</a> Thanks @hannesrudolph.</li>
-<li><strong>PR #133546</strong> <a href="https://github.com/openclaw/openclaw/pull/133546">improve: speed up legacy imports and transcript replacement</a></li>
-<li><strong>PR #133566</strong> <a href="https://github.com/openclaw/openclaw/pull/133566">test: reduce maturity fixture cleanup time</a></li>
-<li><strong>PR #133567</strong> <a href="https://github.com/openclaw/openclaw/pull/133567">refactor(ui): simplify chat rendering and lifecycle state</a></li>
-<li><strong>PR #133507</strong> <a href="https://github.com/openclaw/openclaw/pull/133507">fix(voice): discover configured provider candidates</a> Thanks @itkdm.</li>
-<li><strong>PR #133571</strong> <a href="https://github.com/openclaw/openclaw/pull/133571">fix(browser): preserve contextless worker and iframe sessions</a> Related #133569.</li>
-<li><strong>PR #133585</strong> <a href="https://github.com/openclaw/openclaw/pull/133585">docs: add complete v2026.8.1 maintainer change index</a> Thanks @hannesrudolph.</li>
-<li><strong>PR #133549</strong> <a href="https://github.com/openclaw/openclaw/pull/133549">fix(package): publish readable dist inventory</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133525</strong> <a href="https://github.com/openclaw/openclaw/pull/133525">fix(release): detect optional target E2E capability</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133526</strong> <a href="https://github.com/openclaw/openclaw/pull/133526">fix(e2e): keep delete fixture target-compatible</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133476</strong> <a href="https://github.com/openclaw/openclaw/pull/133476">fix: stop cloud work before unrelated provider inspection finishes</a></li>
-<li><strong>PR #133581</strong> <a href="https://github.com/openclaw/openclaw/pull/133581">test: include v2026.8.1 release navigation</a> Thanks @fuller-stack-dev.</li>
-<li><strong>PR #133552</strong> <a href="https://github.com/openclaw/openclaw/pull/133552">fix(cron): keep read RPCs from blocking the gateway</a> Related #133442. Thanks @vincentkoc and @josephbergvinson.</li>
-<li><strong>PR #133568</strong> <a href="https://github.com/openclaw/openclaw/pull/133568">test: isolate shared /tmp session-store paths in runner and health suites</a></li>
-<li><strong>PR #133584</strong> <a href="https://github.com/openclaw/openclaw/pull/133584">fix(plugins): keep bundled plugins bundled when selected by plugins.load.paths</a></li>
-<li><strong>PR #133565</strong> <a href="https://github.com/openclaw/openclaw/pull/133565">perf: load web chat history in larger, faster batches</a></li>
-<li><strong>PR #133598</strong> <a href="https://github.com/openclaw/openclaw/pull/133598">perf(browser): reuse snapshot refs and screenshot metadata</a></li>
-<li><strong>PR #133594</strong> <a href="https://github.com/openclaw/openclaw/pull/133594">refactor(docker): retire ClawDock shell helpers</a> Related #133587.</li>
-<li><strong>PR #133383</strong> <a href="https://github.com/openclaw/openclaw/pull/133383">fix(media): preserve Matroska extensions after byte detection</a> Thanks @ly85206559.</li>
-<li><strong>PR #133588</strong> <a href="https://github.com/openclaw/openclaw/pull/133588">test: reduce workflow sanity fixture cleanup time</a></li>
-<li><strong>PR #133572</strong> <a href="https://github.com/openclaw/openclaw/pull/133572">fix: correct MCP URI schema resolution with patched fast-uri</a> Related #133558.</li>
-<li><strong>PR #133575</strong> <a href="https://github.com/openclaw/openclaw/pull/133575">fix(ui): wait for restored draft before clearing</a> Thanks @vincentkoc.</li>
-<li><strong>PR #133556</strong> <a href="https://github.com/openclaw/openclaw/pull/133556">fix(ui): keep branch and editor tooltips beside their buttons</a> Related #133553.</li>
-<li><strong>PR #132830</strong> <a href="https://github.com/openclaw/openclaw/pull/132830">improve(memory-lancedb): reduce plugin startup memory</a> Thanks @jason-allen-oneal.</li>
-<li><strong>PR #132151</strong> <a href="https://github.com/openclaw/openclaw/pull/132151">docs(line): scope the loading animation to one-to-one chats</a> Thanks @edenfunf.</li>
-<li><strong>PR #133601</strong> <a href="https://github.com/openclaw/openclaw/pull/133601">fix(channels): include nested channel diagnostics in logs</a> Related #133600.</li>
-<li><strong>PR #133589</strong> <a href="https://github.com/openclaw/openclaw/pull/133589">fix(release): preserve waiver context when reusing validation</a></li>
-<li><strong>PR #133580</strong> <a href="https://github.com/openclaw/openclaw/pull/133580">fix(sandbox): preserve file data and 308 redirects on Python 3.9</a> Related #133573, #133574.</li>
-<li><strong>PR #133591</strong> <a href="https://github.com/openclaw/openclaw/pull/133591">docs: lead v2026.8.1 notes with install and downgrade guidance</a> Thanks @hannesrudolph.</li>
-<li><strong>PR #132918</strong> <a href="https://github.com/openclaw/openclaw/pull/132918">fix(line): apply a group's wildcard defaults to its own entry</a> Thanks @edenfunf.</li>
-<li><strong>PR #132366</strong> <a href="https://github.com/openclaw/openclaw/pull/132366">fix: avoid malformed Unicode at runtime text limits</a> Thanks @ly85206559.</li>
-<li><strong>PR #133386</strong> <a href="https://github.com/openclaw/openclaw/pull/133386">fix(media): transcode byte-detected ASF audio</a> Thanks @ly85206559.</li>
-<li><strong>PR #133570</strong> <a href="https://github.com/openclaw/openclaw/pull/133570">test: consolidate model and plugin metadata fixtures</a></li>
-<li><strong>PR #133578</strong> <a href="https://github.com/openclaw/openclaw/pull/133578">fix: clear stale binding owners and restore global subagent status</a></li>
-<li><strong>PR #128151</strong> <a href="https://github.com/openclaw/openclaw/pull/128151">docs(channels): document per-account channels.start/stop recovery and selfChatMode</a> Related #127954. Thanks @LiuwqGit and @markswitch83.</li>
-<li><strong>PR #132170</strong> <a href="https://github.com/openclaw/openclaw/pull/132170">fix(imap): keep email prompt truncation code-point-safe</a> Thanks @harjothkhara.</li>
-<li><strong>PR #133595</strong> <a href="https://github.com/openclaw/openclaw/pull/133595">fix: gateway stop fails with a newer state schema</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133607</strong> <a href="https://github.com/openclaw/openclaw/pull/133607">perf(terminal): prepare table home formatting and flex growth</a></li>
-<li><strong>PR #133579</strong> <a href="https://github.com/openclaw/openclaw/pull/133579">perf: separate static provider catalogs from live discovery</a></li>
-<li><strong>PR #133610</strong> <a href="https://github.com/openclaw/openclaw/pull/133610">fix(media): quoted file charsets corrupt extracted text</a> Related #133608.</li>
-<li><strong>PR #132641</strong> <a href="https://github.com/openclaw/openclaw/pull/132641">fix(cli): reject explicit empty nodes RPC --timeout instead of defaulting</a> Thanks @xydt-juyaohui.</li>
-<li><strong>PR #133342</strong> <a href="https://github.com/openclaw/openclaw/pull/133342">fix(ui): remove duplicate emoji from error alerts</a> Related #133341. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #133611</strong> <a href="https://github.com/openclaw/openclaw/pull/133611">improve: reduce legacy transcript scanning overhead</a></li>
-<li><strong>PR #133477</strong> <a href="https://github.com/openclaw/openclaw/pull/133477">perf(gateway): reuse prepared facts across control-plane reads</a></li>
-<li><strong>PR #133620</strong> <a href="https://github.com/openclaw/openclaw/pull/133620">docs: link v2026.8.1 release story</a> Thanks @hannesrudolph.</li>
-<li><strong>PR #133609</strong> <a href="https://github.com/openclaw/openclaw/pull/133609">perf(test): prepare source Gateway runtimes before live shards</a></li>
-<li><strong>PR #133615</strong> <a href="https://github.com/openclaw/openclaw/pull/133615">fix(tts): keep internal reasoning out of spoken summaries</a> Related #90364. Thanks @camball-strategies.</li>
-<li><strong>PR #133457</strong> <a href="https://github.com/openclaw/openclaw/pull/133457">fix: retain accepted browser follow-ups across restarts</a></li>
-<li><strong>PR #133605</strong> <a href="https://github.com/openclaw/openclaw/pull/133605">fix: keep run output token counts cumulative and recoverable</a> Related #133562.</li>
-<li><strong>PR #128379</strong> <a href="https://github.com/openclaw/openclaw/pull/128379">feat(browser): standalone extension relay daemon with native-host wake-up</a></li>
-<li><strong>PR #133614</strong> <a href="https://github.com/openclaw/openclaw/pull/133614">fix(browser): prefer CDP for managed role snapshots</a> Related #133514. Thanks @vincentkoc and @josephbergvinson.</li>
-<li><strong>PR #133604</strong> <a href="https://github.com/openclaw/openclaw/pull/133604">refactor(config): avoid evaluating type-only configuration modules</a></li>
-<li><strong>PR #133613</strong> <a href="https://github.com/openclaw/openclaw/pull/133613">fix(talk): honor advertised transcription model selections</a> Thanks @lsr911.</li>
-<li><strong>PR #133523</strong> <a href="https://github.com/openclaw/openclaw/pull/133523">fix(release): resolve frozen candidate entrypoints</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133524</strong> <a href="https://github.com/openclaw/openclaw/pull/133524">fix(release): seal frozen candidate package metadata</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133192</strong> <a href="https://github.com/openclaw/openclaw/pull/133192">fix(subagents): atomically persist blocked completion alerts</a> Related #133058. Thanks @shojikumaru and @vincentkoc and @potterdigital.</li>
-<li><strong>PR #133626</strong> <a href="https://github.com/openclaw/openclaw/pull/133626">chore(autoreview): sync reviewer-led credential checks</a> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #133627</strong> <a href="https://github.com/openclaw/openclaw/pull/133627">perf(state): streamline SQLite schema comparison</a></li>
-<li><strong>PR #133639</strong> <a href="https://github.com/openclaw/openclaw/pull/133639">chore(ui): refresh control ui locales</a></li>
-<li><strong>PR #133490</strong> <a href="https://github.com/openclaw/openclaw/pull/133490">feat(ui): organize session menus and combine appearance controls</a> Related #133480.</li>
-<li><strong>PR #133634</strong> <a href="https://github.com/openclaw/openclaw/pull/133634">perf(test): shorten escaped-output timeout grace</a></li>
-<li><strong>PR #133635</strong> <a href="https://github.com/openclaw/openclaw/pull/133635">perf: speed up chat history preparation</a></li>
-<li><strong>PR #133638</strong> <a href="https://github.com/openclaw/openclaw/pull/133638">feat(ui): add a preference to hide empty session groups</a> Related #133629.</li>
-<li><strong>PR #133502</strong> <a href="https://github.com/openclaw/openclaw/pull/133502">fix(config): avoid repeated health-state startup warnings</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133640</strong> <a href="https://github.com/openclaw/openclaw/pull/133640">docs: guide routine Gateway updates through their installation owner</a></li>
-<li><strong>PR #133631</strong> <a href="https://github.com/openclaw/openclaw/pull/133631">fix(test): retire repository test APIs after non-isolated files</a> Related #133630.</li>
-<li><strong>PR #133656</strong> <a href="https://github.com/openclaw/openclaw/pull/133656">test(plugins): drive plugin tool registry reuse through the real seam</a></li>
-<li><strong>PR #133622</strong> <a href="https://github.com/openclaw/openclaw/pull/133622">fix(update): show reliable progress and final outcomes</a></li>
-<li><strong>PR #133643</strong> <a href="https://github.com/openclaw/openclaw/pull/133643">improve(ui): tuck Setup preferences into Advanced settings</a></li>
-<li><strong>PR #133641</strong> <a href="https://github.com/openclaw/openclaw/pull/133641">improve: speed up legacy session transcript imports</a></li>
-<li><strong>PR #130207</strong> <a href="https://github.com/openclaw/openclaw/pull/130207">fix(docs): respect nested fenced code boundaries</a> Thanks @qingminglong.</li>
-<li><strong>PR #133652</strong> <a href="https://github.com/openclaw/openclaw/pull/133652">test: assert release navigation shape instead of pinned versions</a></li>
-<li><strong>PR #133657</strong> <a href="https://github.com/openclaw/openclaw/pull/133657">improve(ui): capitalize permission mode names</a></li>
-<li><strong>PR #133655</strong> <a href="https://github.com/openclaw/openclaw/pull/133655">fix(node-host): report container hosting startup failures in the native worker</a> Related #133654.</li>
-<li><strong>PR #133663</strong> <a href="https://github.com/openclaw/openclaw/pull/133663">fix: identify cloud worker bootstrap failures</a></li>
-<li><strong>PR #133659</strong> <a href="https://github.com/openclaw/openclaw/pull/133659">perf(logging): reuse prepared diagnostic facts</a></li>
-<li><strong>PR #133516</strong> <a href="https://github.com/openclaw/openclaw/pull/133516">improve: quiet Discord and Slack progress</a> Related #133479.</li>
-<li><strong>PR #133551</strong> <a href="https://github.com/openclaw/openclaw/pull/133551">fix: prevent cloud session lifecycle actions from hanging behind worker moves</a></li>
-<li><strong>PR #132998</strong> <a href="https://github.com/openclaw/openclaw/pull/132998">fix(infra): preserve block boundaries for attributed p and div tags</a> Related #132969. Thanks @pengzh1 and @yifanxiong272.</li>
-<li><strong>PR #133665</strong> <a href="https://github.com/openclaw/openclaw/pull/133665">docs: link v2026.8.1 release notes to feature guides</a> Thanks @hannesrudolph.</li>
-<li><strong>PR #133624</strong> <a href="https://github.com/openclaw/openclaw/pull/133624">fix(scripts): preserve protected GitHub CLI routing</a></li>
-<li><strong>PR #133670</strong> <a href="https://github.com/openclaw/openclaw/pull/133670">perf(test): trim fixture subprocess overhead</a></li>
-<li><strong>PR #133672</strong> <a href="https://github.com/openclaw/openclaw/pull/133672">chore(ui): refresh control ui locales</a></li>
-<li><strong>PR #133667</strong> <a href="https://github.com/openclaw/openclaw/pull/133667">fix(xai): distinguish missing answer text from malformed JSON</a></li>
-<li><strong>PR #133671</strong> <a href="https://github.com/openclaw/openclaw/pull/133671">fix(config): refresh stale docs baseline for merged settings</a></li>
-<li><strong>PR #127147</strong> <a href="https://github.com/openclaw/openclaw/pull/127147">fix: preserve binding ownership and task visibility</a> Related #127141.</li>
-<li><strong>PR #133664</strong> <a href="https://github.com/openclaw/openclaw/pull/133664">fix(ui): keep non-Git agent workspaces usable for new sessions</a></li>
-<li><strong>PR #133668</strong> <a href="https://github.com/openclaw/openclaw/pull/133668">fix(sessions): keep failed deletions in cleanup accounting</a></li>
-<li><strong>PR #133447</strong> <a href="https://github.com/openclaw/openclaw/pull/133447">feat(workers): snapshot prepared projects before session enrollment</a> Related #133436, #133450.</li>
-<li><strong>PR #133666</strong> <a href="https://github.com/openclaw/openclaw/pull/133666">test: validate upgrades from latest stable</a></li>
-<li><strong>PR #133669</strong> <a href="https://github.com/openclaw/openclaw/pull/133669">refactor(ui): consolidate forwarded message presentation</a></li>
-<li><strong>PR #133680</strong> <a href="https://github.com/openclaw/openclaw/pull/133680">perf: load retained chat history faster</a></li>
-<li><strong>PR #132407</strong> <a href="https://github.com/openclaw/openclaw/pull/132407">fix: apply workspace permission changes to active runs</a> Related #131947. Thanks @jalehman.</li>
-<li><strong>PR #133675</strong> <a href="https://github.com/openclaw/openclaw/pull/133675">fix(release): consume verified historical release evidence</a></li>
-<li><strong>PR #133691</strong> <a href="https://github.com/openclaw/openclaw/pull/133691">perf(sessions): reuse opaque-key matchers and pruning cursors</a></li>
-<li><strong>PR #133673</strong> <a href="https://github.com/openclaw/openclaw/pull/133673">refactor: use canonical installed-plugin index in post-upgrade doctor</a></li>
-<li><strong>PR #133689</strong> <a href="https://github.com/openclaw/openclaw/pull/133689">improve: reduce CPU overhead during session imports</a></li>
-<li><strong>PR #132773</strong> <a href="https://github.com/openclaw/openclaw/pull/132773">fix(ui): preserve typing on new session page</a> Related #132783. Thanks @vyctorbrzezowski.</li>
-<li><strong>PR #133684</strong> <a href="https://github.com/openclaw/openclaw/pull/133684">fix(cli): recover invalidated control-only resumes</a> Related #133475. Thanks @vincentkoc and @jakestenger.</li>
-<li><strong>PR #130258</strong> <a href="https://github.com/openclaw/openclaw/pull/130258">docs: document node install --no-tls option</a> Thanks @qingminglong.</li>
-<li><strong>PR #133696</strong> <a href="https://github.com/openclaw/openclaw/pull/133696">test: simplify runner fixtures and cover in-flight mock registration</a></li>
-<li><strong>PR #133683</strong> <a href="https://github.com/openclaw/openclaw/pull/133683">fix(gateway): reduce control-plane stalls during concurrent turns</a></li>
-<li><strong>PR #133708</strong> <a href="https://github.com/openclaw/openclaw/pull/133708">chore(ui): refresh control ui locales</a></li>
-<li><strong>PR #133712</strong> <a href="https://github.com/openclaw/openclaw/pull/133712">test(line): remove redundant adapter and webhook checks</a></li>
-<li><strong>PR #133697</strong> <a href="https://github.com/openclaw/openclaw/pull/133697">fix(sessions): count successful zero-byte artifact deletions</a> Related #133681.</li>
-<li><strong>PR #133706</strong> <a href="https://github.com/openclaw/openclaw/pull/133706">refactor(browser): simplify relay lifecycle helpers</a></li>
-<li><strong>PR #133688</strong> <a href="https://github.com/openclaw/openclaw/pull/133688">fix: dependency audits miss published upstream advisories</a> Related #133685.</li>
-<li><strong>PR #133698</strong> <a href="https://github.com/openclaw/openclaw/pull/133698">refactor(cli): make update help and planning faster</a></li>
-<li><strong>PR #133710</strong> <a href="https://github.com/openclaw/openclaw/pull/133710">perf(normalization): reuse schema branches and JSON traversal state</a></li>
-<li><strong>PR #133705</strong> <a href="https://github.com/openclaw/openclaw/pull/133705">refactor(ui): simplify workspace discovery and preference restoration</a></li>
-<li><strong>PR #133713</strong> <a href="https://github.com/openclaw/openclaw/pull/133713">refactor(ui): unify working indicator status rendering</a></li>
-<li><strong>PR #133586</strong> <a href="https://github.com/openclaw/openclaw/pull/133586">fix: retain debug capture headers from Undici requests</a></li>
-<li><strong>PR #133718</strong> <a href="https://github.com/openclaw/openclaw/pull/133718">fix(ui): keep submenu parent rows highlighted</a> Related #133711.</li>
-<li><strong>PR #133714</strong> <a href="https://github.com/openclaw/openclaw/pull/133714">refactor: simplify quiet channel progress rendering</a></li>
-<li><strong>PR #133707</strong> <a href="https://github.com/openclaw/openclaw/pull/133707">fix(apple): stop JSON numbers becoming booleans</a> Related #133704.</li>
-<li><strong>PR #122632</strong> <a href="https://github.com/openclaw/openclaw/pull/122632">docs(cli): complete config and backup command tree</a> Thanks @Adkid-Zephyr.</li>
-<li><strong>PR #131684</strong> <a href="https://github.com/openclaw/openclaw/pull/131684">docs: document node installed-app sharing flags</a> Thanks @qingminglong.</li>
-<li><strong>PR #133726</strong> <a href="https://github.com/openclaw/openclaw/pull/133726">improve: speed up managed worktree test fixtures</a></li>
-<li><strong>PR #133582</strong> <a href="https://github.com/openclaw/openclaw/pull/133582">fix(commands): ignore missing SecretRef passEnv values</a> Related #133561. Thanks @pengzh1 and @vincentkoc and @jodok.</li>
-<li><strong>PR #132738</strong> <a href="https://github.com/openclaw/openclaw/pull/132738">fix(agents): deprioritize inter-session turns</a> Related #70634. Thanks @sylvesterkaczmarek and @obviyus and @ewrurwteurwU.</li>
-<li><strong>PR #133701</strong> <a href="https://github.com/openclaw/openclaw/pull/133701">test: consolidate CJK estimator coverage at its owner</a></li>
-<li><strong>PR #133717</strong> <a href="https://github.com/openclaw/openclaw/pull/133717">test: require complete non-isolated runner evidence</a></li>
-<li><strong>PR #123737</strong> <a href="https://github.com/openclaw/openclaw/pull/123737">fix(compaction): reject summaries foregrounding superseded tasks</a> Related #123668. Thanks @wangyan2026 and @obviyus and @andersonjeccel.</li>
-<li><strong>PR #133737</strong> <a href="https://github.com/openclaw/openclaw/pull/133737">test: consolidate token formatting coverage at its owner</a></li>
-<li><strong>PR #133725</strong> <a href="https://github.com/openclaw/openclaw/pull/133725">improve: prepare the first cloud-session runtime archive faster</a></li>
-<li><strong>PR #133623</strong> <a href="https://github.com/openclaw/openclaw/pull/133623">docs: remove v2026.8.1 draft warning</a> Thanks @hannesrudolph.</li>
-<li><strong>PR #133741</strong> <a href="https://github.com/openclaw/openclaw/pull/133741">test(qa): remove duplicate summary file-reader checks</a></li>
-<li><strong>PR #133745</strong> <a href="https://github.com/openclaw/openclaw/pull/133745">test: remove redundant plugin construction and stream smoke checks</a></li>
-<li><strong>PR #133361</strong> <a href="https://github.com/openclaw/openclaw/pull/133361">fix(cli): reject partial approval grant limits</a> Thanks @qingminglong.</li>
-<li><strong>PR #133739</strong> <a href="https://github.com/openclaw/openclaw/pull/133739">fix(macos): redact values marked private in app logs</a> Related #133736.</li>
-<li><strong>PR #133742</strong> <a href="https://github.com/openclaw/openclaw/pull/133742">improve: speed up session imports with less code</a></li>
-<li><strong>PR #133748</strong> <a href="https://github.com/openclaw/openclaw/pull/133748">test(agents): remove duplicate apply-patch byte-preservation cases</a></li>
-<li><strong>PR #133682</strong> <a href="https://github.com/openclaw/openclaw/pull/133682">fix(ui): center the working claw in chat layout</a> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #133734</strong> <a href="https://github.com/openclaw/openclaw/pull/133734">improve: load 800 chat messages with less layout work</a></li>
-<li><strong>PR #133593</strong> <a href="https://github.com/openclaw/openclaw/pull/133593">feat(ui): add Manuscript, Rosé, and Miami themes</a></li>
-<li><strong>PR #133732</strong> <a href="https://github.com/openclaw/openclaw/pull/133732">perf(tooling): simplify guard preparation and bound alias copies</a></li>
-<li><strong>PR #133746</strong> <a href="https://github.com/openclaw/openclaw/pull/133746">refactor: test conflict markers through the real scanner</a></li>
-<li><strong>PR #133744</strong> <a href="https://github.com/openclaw/openclaw/pull/133744">fix(ui): preserve worktree base branch across reconnects</a></li>
-<li><strong>PR #133756</strong> <a href="https://github.com/openclaw/openclaw/pull/133756">test(macos): remove reintroduced onboarding subset checks</a></li>
-<li><strong>PR #132853</strong> <a href="https://github.com/openclaw/openclaw/pull/132853">fix(update): fail closed when gateway service state is unknown</a> Thanks @jason-allen-oneal and @obviyus.</li>
-<li><strong>PR #133754</strong> <a href="https://github.com/openclaw/openclaw/pull/133754">refactor(meetings): share command argv splitting</a> Thanks @vincentkoc.</li>
-<li><strong>PR #133764</strong> <a href="https://github.com/openclaw/openclaw/pull/133764">docs: link latest release notes from changelog</a> Thanks @hannesrudolph.</li>
-<li><strong>PR #133761</strong> <a href="https://github.com/openclaw/openclaw/pull/133761">chore(ui): refresh control ui locales</a></li>
-<li><strong>PR #133762</strong> <a href="https://github.com/openclaw/openclaw/pull/133762">test(ui): remove redundant title and working-phrase renders</a></li>
-<li><strong>PR #133628</strong> <a href="https://github.com/openclaw/openclaw/pull/133628">fix(ui): preserve offline drafts and resume canceled queue edits</a> Related #133555, #133603.</li>
-<li><strong>PR #133759</strong> <a href="https://github.com/openclaw/openclaw/pull/133759">test: remove identical core fixture replays</a></li>
-<li><strong>PR #133753</strong> <a href="https://github.com/openclaw/openclaw/pull/133753">fix: reduce memory spikes when preparing long session histories</a> Related #133738.</li>
-<li><strong>PR #133740</strong> <a href="https://github.com/openclaw/openclaw/pull/133740">fix(macos): unblock builds with custom SwiftPM scratch paths</a></li>
-<li><strong>PR #133765</strong> <a href="https://github.com/openclaw/openclaw/pull/133765">refactor(xai): remove unused web-search credential test seam</a></li>
-<li><strong>PR #133722</strong> <a href="https://github.com/openclaw/openclaw/pull/133722">docs: retire redundant guides and fix gateway package instructions</a></li>
-<li><strong>PR #133646</strong> <a href="https://github.com/openclaw/openclaw/pull/133646">chore(cron): remove duplicate Shanghai schedule assertion</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133645</strong> <a href="https://github.com/openclaw/openclaw/pull/133645">chore(test): remove docs spellcheck source mirror</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133644</strong> <a href="https://github.com/openclaw/openclaw/pull/133644">chore(parallel): remove duplicate session ID test seam</a> Thanks @RomneyDa.</li>
-<li><strong>PR #132903</strong> <a href="https://github.com/openclaw/openclaw/pull/132903">improve(tasks): bound task list page selection</a> Thanks @jason-allen-oneal and @obviyus.</li>
-<li><strong>PR #123416</strong> <a href="https://github.com/openclaw/openclaw/pull/123416">fix(plugins): preserve bundled provider compat across allowlists</a> Related #123297. Thanks @lonexreb and @obviyus and @bradenmcleish.</li>
-<li><strong>PR #133774</strong> <a href="https://github.com/openclaw/openclaw/pull/133774">test: release wizard progress fixture listeners</a></li>
-<li><strong>PR #133790</strong> <a href="https://github.com/openclaw/openclaw/pull/133790">docs: publish 2026.8.1 release notes and macOS update feed</a></li>
-<li><strong>PR #133770</strong> <a href="https://github.com/openclaw/openclaw/pull/133770">test: remove repeated agent transport and recovery fixtures</a></li>
-<li><strong>PR #130370</strong> <a href="https://github.com/openclaw/openclaw/pull/130370">fix(system-agent): normalize route-neutral roster entries</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133324</strong> <a href="https://github.com/openclaw/openclaw/pull/133324">fix(tts): deliver tool audio in private reply mode</a> Related #83636. Thanks @obviyus and @TurboTheTurtle and @clawSean and @Conan-Scott.</li>
-<li><strong>PR #133771</strong> <a href="https://github.com/openclaw/openclaw/pull/133771">test(cli): keep parser coverage without formatter self-comparison</a></li>
-<li><strong>PR #132716</strong> <a href="https://github.com/openclaw/openclaw/pull/132716">feat(test): compile subprocesses once per invocation</a></li>
-<li><strong>PR #133787</strong> <a href="https://github.com/openclaw/openclaw/pull/133787">fix(ci): deduplicate Control UI skeleton styles</a> Thanks @fuller-stack-dev.</li>
-<li><strong>PR #133499</strong> <a href="https://github.com/openclaw/openclaw/pull/133499">fix(imessage): keep replies in the current conversation</a> Related #133468. Thanks @omarshahine.</li>
-<li><strong>PR #133760</strong> <a href="https://github.com/openclaw/openclaw/pull/133760">test: isolate fs-safe default mode fixtures</a></li>
-<li><strong>PR #133769</strong> <a href="https://github.com/openclaw/openclaw/pull/133769">test: avoid duplicate fs-safe boundary scans</a></li>
-<li><strong>PR #133796</strong> <a href="https://github.com/openclaw/openclaw/pull/133796">fix(ui): restore attachment stylesheet build budget</a></li>
-<li><strong>PR #133678</strong> <a href="https://github.com/openclaw/openclaw/pull/133678">refactor(context-engine): simplify compaction and turn handoffs</a></li>
-<li><strong>PR #133715</strong> <a href="https://github.com/openclaw/openclaw/pull/133715">fix: preserve agent ownership across global sessions and bindings</a></li>
-<li><strong>PR #133779</strong> <a href="https://github.com/openclaw/openclaw/pull/133779">test: consolidate audio contract fixtures</a></li>
-<li><strong>PR #133807</strong> <a href="https://github.com/openclaw/openclaw/pull/133807">docs: link the verified 2026.8.1 Mac DMG</a></li>
-<li><strong>PR #133801</strong> <a href="https://github.com/openclaw/openclaw/pull/133801">perf(update): reduce preflight work and unattended prompts</a></li>
-<li><strong>PR #131669</strong> <a href="https://github.com/openclaw/openclaw/pull/131669">fix(workers): honor session tool policies on cloud sessions</a> Related #131661. Thanks @anyech and @sallyom.</li>
-<li><strong>PR #132083</strong> <a href="https://github.com/openclaw/openclaw/pull/132083">fix(line): name the inline emoji LINE leaves as bare parentheses</a> Related #132082. Thanks @edenfunf.</li>
-<li><strong>PR #133520</strong> <a href="https://github.com/openclaw/openclaw/pull/133520">fix(agent): always reply after settled tool work</a> Thanks @fuller-stack-dev.</li>
-<li><strong>PR #132628</strong> <a href="https://github.com/openclaw/openclaw/pull/132628">fix(line): do not introduce the bot in a room it may not act in</a> Thanks @edenfunf.</li>
-<li><strong>PR #133798</strong> <a href="https://github.com/openclaw/openclaw/pull/133798">improve: load and scroll chat history with less repeated work</a></li>
-<li><strong>PR #123448</strong> <a href="https://github.com/openclaw/openclaw/pull/123448">fix(memory-wiki): reject unknown wiki_apply ops instead of falling back to update_metadata</a> Thanks @wanyongstar.</li>
-<li><strong>PR #133304</strong> <a href="https://github.com/openclaw/openclaw/pull/133304">fix(cli): skip the startup config guard for plugin authoring commands</a> Related #133303. Thanks @ruel225.</li>
-<li><strong>PR #133791</strong> <a href="https://github.com/openclaw/openclaw/pull/133791">fix(ui): keep rewind confirmation controls accessible</a></li>
-<li><strong>PR #124688</strong> <a href="https://github.com/openclaw/openclaw/pull/124688">docs(docker): warn against single-file binding openclaw.json</a> Thanks @ericcaiwx-star and @cursoragent.</li>
-<li><strong>PR #125184</strong> <a href="https://github.com/openclaw/openclaw/pull/125184">fix(outbound): skip code-span placeholders consumed by tag stripping</a> Thanks @wanyongstar.</li>
-<li><strong>PR #133809</strong> <a href="https://github.com/openclaw/openclaw/pull/133809">fix(update): keep persisted and printed completion durations consistent</a></li>
-<li><strong>PR #130280</strong> <a href="https://github.com/openclaw/openclaw/pull/130280">refactor(infra): share error cause reader</a> Thanks @vincentkoc.</li>
-<li><strong>PR #133674</strong> <a href="https://github.com/openclaw/openclaw/pull/133674">fix(media): omit English prompts during audio language autodetection</a> Related #123305. Thanks @synthalorian and @aleps001.</li>
-<li><strong>PR #133794</strong> <a href="https://github.com/openclaw/openclaw/pull/133794">test: simplify WhatsApp formatting oracles</a></li>
-<li><strong>PR #133616</strong> <a href="https://github.com/openclaw/openclaw/pull/133616">perf(qa): run isolated live transports with bounded concurrency</a></li>
-<li><strong>PR #133812</strong> <a href="https://github.com/openclaw/openclaw/pull/133812">perf(ci): stripe the tallest node test group across three jobs</a></li>
-<li><strong>PR #133817</strong> <a href="https://github.com/openclaw/openclaw/pull/133817">fix(ui): reload projects after startup identity resolves</a></li>
-<li><strong>PR #133818</strong> <a href="https://github.com/openclaw/openclaw/pull/133818">docs: correct session migration and discovery guidance</a></li>
-<li><strong>PR #133826</strong> <a href="https://github.com/openclaw/openclaw/pull/133826">test(ui): remove duplicate catalog display assertions</a></li>
-<li><strong>PR #133831</strong> <a href="https://github.com/openclaw/openclaw/pull/133831">docs: correct SQLite downgrade restore guidance</a></li>
-<li><strong>PR #133821</strong> <a href="https://github.com/openclaw/openclaw/pull/133821">test(qa): join fixture owners before removing resources</a></li>
-<li><strong>PR #133830</strong> <a href="https://github.com/openclaw/openclaw/pull/133830">test(ai): avoid runtime barrel in environment key tests</a></li>
-<li><strong>PR #133804</strong> <a href="https://github.com/openclaw/openclaw/pull/133804">docs(session): document the fixed main-session key</a></li>
-<li><strong>PR #133763</strong> <a href="https://github.com/openclaw/openclaw/pull/133763">perf(plugins): prepare doctor owners without obsolete setup imports</a></li>
-<li><strong>PR #133530</strong> <a href="https://github.com/openclaw/openclaw/pull/133530">fix(cli): distinguish Gateway service prompts from CLI installation</a> Thanks @RomneyDa.</li>
-<li><strong>PR #118282</strong> <a href="https://github.com/openclaw/openclaw/pull/118282">fix(doctor): import historical exec approval metadata</a> Related #118242. Thanks @obviyus and @sercada.</li>
-<li><strong>PR #133822</strong> <a href="https://github.com/openclaw/openclaw/pull/133822">perf: shrink cloud bootstrap archives and memory use</a></li>
-<li><strong>PR #123245</strong> <a href="https://github.com/openclaw/openclaw/pull/123245">fix(minimax): report malformed speech responses clearly</a> Thanks @coaiMax.</li>
-<li><strong>PR #133833</strong> <a href="https://github.com/openclaw/openclaw/pull/133833">test(ci): streamline Docker pull retry fixtures</a></li>
-<li><strong>PR #133766</strong> <a href="https://github.com/openclaw/openclaw/pull/133766">fix(docs): document nodes invoke transport timeout</a> Thanks @qingminglong.</li>
-<li><strong>PR #133834</strong> <a href="https://github.com/openclaw/openclaw/pull/133834">test(tooling): batch conflict marker fixtures</a></li>
-<li><strong>PR #133824</strong> <a href="https://github.com/openclaw/openclaw/pull/133824">test: remove redundant fixture and helper probes</a></li>
-<li><strong>PR #133835</strong> <a href="https://github.com/openclaw/openclaw/pull/133835">test(docs): batch docs list CLI fixtures</a></li>
-<li><strong>PR #117199</strong> <a href="https://github.com/openclaw/openclaw/pull/117199">fix(plugins): load packaged TypeScript plugins consistently</a></li>
-<li><strong>PR #133838</strong> <a href="https://github.com/openclaw/openclaw/pull/133838">test(tooling): inspect formatter failure once</a></li>
-<li><strong>PR #133851</strong> <a href="https://github.com/openclaw/openclaw/pull/133851">docs: identify v2026.8.1 release notes link</a> Thanks @hannesrudolph.</li>
-<li><strong>PR #133839</strong> <a href="https://github.com/openclaw/openclaw/pull/133839">test(retry): unify Retry-After coverage at scheduler owner</a></li>
-<li><strong>PR #133832</strong> <a href="https://github.com/openclaw/openclaw/pull/133832">fix(pr): avoid drain delays from detached Git maintenance</a> Related #133825.</li>
-<li><strong>PR #133846</strong> <a href="https://github.com/openclaw/openclaw/pull/133846">test(media): mock QR runtime at loader boundary</a></li>
-<li><strong>PR #133837</strong> <a href="https://github.com/openclaw/openclaw/pull/133837">refactor(agents): share trailing empty-line trimming</a> Thanks @vincentkoc.</li>
-<li><strong>PR #133782</strong> <a href="https://github.com/openclaw/openclaw/pull/133782">improve(gateway): reduce repeated turn preparation work</a></li>
-<li><strong>PR #133816</strong> <a href="https://github.com/openclaw/openclaw/pull/133816">test: await QA deadline unwind without sleeps</a></li>
-<li><strong>PR #133842</strong> <a href="https://github.com/openclaw/openclaw/pull/133842">fix(cli): preserve triage diagnostics when the Gateway is offline</a></li>
-<li><strong>PR #133854</strong> <a href="https://github.com/openclaw/openclaw/pull/133854">perf(ci): balance process-heavy tooling checks</a></li>
-<li><strong>PR #133866</strong> <a href="https://github.com/openclaw/openclaw/pull/133866">test(signal): drive control-lane clocks deterministically</a></li>
-<li><strong>PR #133853</strong> <a href="https://github.com/openclaw/openclaw/pull/133853">test(plugins): advance lifecycle lease contention virtually</a></li>
-<li><strong>PR #133872</strong> <a href="https://github.com/openclaw/openclaw/pull/133872">test(feishu): prove concurrent sends without wall-clock waits</a></li>
-<li><strong>PR #133869</strong> <a href="https://github.com/openclaw/openclaw/pull/133869">fix(install): repair set-npm-prefix rc line and surface silent finalization failures</a></li>
-<li><strong>PR #133857</strong> <a href="https://github.com/openclaw/openclaw/pull/133857">fix(ui): re-accent CRT as the monochrome white console</a></li>
-<li><strong>PR #133661</strong> <a href="https://github.com/openclaw/openclaw/pull/133661">fix(cron): preserve complete JSON when run output is piped</a></li>
-<li><strong>PR #133865</strong> <a href="https://github.com/openclaw/openclaw/pull/133865">perf(ci): balance release verification work and trim runtime builds</a></li>
-<li><strong>PR #133859</strong> <a href="https://github.com/openclaw/openclaw/pull/133859">test(gateway): exercise authorized exec suppression</a></li>
-<li><strong>PR #133695</strong> <a href="https://github.com/openclaw/openclaw/pull/133695">fix(models): refresh native pricing without pinning defaults</a></li>
-<li><strong>PR #133751</strong> <a href="https://github.com/openclaw/openclaw/pull/133751">refactor(ui): retire grandfathered oversized chat modules</a></li>
-<li><strong>PR #133873</strong> <a href="https://github.com/openclaw/openclaw/pull/133873">perf(gateway): batch bounded operator request starts</a></li>
-<li><strong>PR #124293</strong> [fix(infra): unify Windows process identity reads \[AI-assisted\]](https://github.com/openclaw/openclaw/pull/124293) Thanks @Chinmayrawat15 and @obviyus.</li>
-<li><strong>PR #133870</strong> <a href="https://github.com/openclaw/openclaw/pull/133870">improve: load Control UI history with less blocking</a></li>
-<li><strong>PR #133874</strong> <a href="https://github.com/openclaw/openclaw/pull/133874">test(ui): consolidate duplicate owner coverage</a></li>
-<li><strong>PR #133887</strong> <a href="https://github.com/openclaw/openclaw/pull/133887">refactor(infra): share Git commit prefix matching</a> Thanks @vincentkoc.</li>
-<li><strong>PR #133840</strong> <a href="https://github.com/openclaw/openclaw/pull/133840">perf(queue): prepare snapshots and bounded diagnostic pruning</a></li>
-<li><strong>PR #133536</strong> <a href="https://github.com/openclaw/openclaw/pull/133536">fix(ui): restore text selection and simplify GitHub code copying</a> Related #131201. Thanks @RomneyDa and @Grynn.</li>
-<li><strong>PR #133875</strong> <a href="https://github.com/openclaw/openclaw/pull/133875">test: consolidate IRC socket fixture lifetimes</a></li>
-<li><strong>PR #133863</strong> <a href="https://github.com/openclaw/openclaw/pull/133863">perf(ci): use runtime build for browser extension proof</a></li>
-<li><strong>PR #133337</strong> <a href="https://github.com/openclaw/openclaw/pull/133337">fix(plugins): normalize file URLs for native require</a> Related #133306. Thanks @sunlit-deng and @easyteacher.</li>
-<li><strong>PR #133861</strong> <a href="https://github.com/openclaw/openclaw/pull/133861">fix: prevent duplicate initial prompts during workspace preparation</a> Related #133719.</li>
-<li><strong>PR #133867</strong> <a href="https://github.com/openclaw/openclaw/pull/133867">fix(ci): honor measured durations for split test groups</a></li>
-<li><strong>PR #133811</strong> <a href="https://github.com/openclaw/openclaw/pull/133811">fix(voice-call): prevent phantom calls from late callbacks</a> Thanks @ruel225.</li>
-<li><strong>PR #133802</strong> <a href="https://github.com/openclaw/openclaw/pull/133802">improve: speed up session projection indexing with less code</a></li>
-<li><strong>PR #133876</strong> <a href="https://github.com/openclaw/openclaw/pull/133876">test: simplify plugin slot selection oracles</a></li>
-<li><strong>PR #133919</strong> <a href="https://github.com/openclaw/openclaw/pull/133919">perf(imessage): prepare code marker offset shifts once</a></li>
-<li><strong>PR #133768</strong> <a href="https://github.com/openclaw/openclaw/pull/133768">test: exercise tooling owners instead of private facades</a></li>
-<li><strong>PR #133858</strong> <a href="https://github.com/openclaw/openclaw/pull/133858">fix(cron): preserve valid jobs during SQLite migration</a> Related #133347. Thanks @fuller-stack-dev and @ejc3.</li>
-<li><strong>PR #133619</strong> <a href="https://github.com/openclaw/openclaw/pull/133619">fix(line): let the configured policy turn off quote-as-mention</a> Related #133618. Thanks @edenfunf.</li>
-<li><strong>PR #133841</strong> <a href="https://github.com/openclaw/openclaw/pull/133841">refactor(cli): consolidate precomputed help caching</a></li>
-<li><strong>PR #133916</strong> <a href="https://github.com/openclaw/openclaw/pull/133916">docs: clarify Swarm progress across chat clients</a></li>
-<li><strong>PR #133903</strong> <a href="https://github.com/openclaw/openclaw/pull/133903">perf(gateway): reuse owned history snapshots</a></li>
-<li><strong>PR #133781</strong> <a href="https://github.com/openclaw/openclaw/pull/133781">fix(cli): reject blank channels capabilities --timeout instead of defaulting</a> Thanks @marmar9615-cloud and @SunnyShu0925.</li>
-<li><strong>PR #133777</strong> <a href="https://github.com/openclaw/openclaw/pull/133777">fix: preserve escaped Code Mode output prefixes</a> Related #133776.</li>
-<li><strong>PR #127524</strong> <a href="https://github.com/openclaw/openclaw/pull/127524">docs: clarify ${VAR} substitution doesn't reach .env file values</a> Thanks @dkling-it.</li>
-<li><strong>PR #133949</strong> <a href="https://github.com/openclaw/openclaw/pull/133949">fix(ui): prevent blank splash proof captures</a></li>
-<li><strong>PR #133948</strong> <a href="https://github.com/openclaw/openclaw/pull/133948">fix(doctor): preserve QQBot multi-account configuration</a> Related #133899. Thanks @obviyus and @yubingjiaocn.</li>
-<li><strong>PR #132626</strong> <a href="https://github.com/openclaw/openclaw/pull/132626">fix(logging): preserve newly written stability bundles</a> Related #127418. Thanks @Alix-007.</li>
-<li><strong>PR #133927</strong> <a href="https://github.com/openclaw/openclaw/pull/133927">refactor(plugins): share LLM completion error construction</a> Thanks @vincentkoc.</li>
-<li><strong>PR #133943</strong> <a href="https://github.com/openclaw/openclaw/pull/133943">test(feishu): consolidate retry policy coverage</a></li>
-<li><strong>PR #129475</strong> <a href="https://github.com/openclaw/openclaw/pull/129475">fix(postinstall): avoid registry state migration</a> Related #128782. Thanks @BryanTegomoh and @obviyus and @BillVerhelle.</li>
-<li><strong>PR #133773</strong> <a href="https://github.com/openclaw/openclaw/pull/133773">fix(doctor): allow legacy exec approvals migration</a> Thanks @dailytrap and @obviyus.</li>
-<li><strong>PR #124286</strong> [\[AI-assisted\] docs(android): clarify fork/source builds need own signing identity](https://github.com/openclaw/openclaw/pull/124286) Related #119609. Thanks @santhiprakash and @minoosara5426-prog.</li>
-<li><strong>PR #133877</strong> <a href="https://github.com/openclaw/openclaw/pull/133877">test: restore inherited logging environment</a></li>
-<li><strong>PR #133431</strong> <a href="https://github.com/openclaw/openclaw/pull/133431">fix(cli): fail unhealthy plugin doctor checks</a> Related #133388. Thanks @PollyBot13 and @obviyus.</li>
-<li><strong>PR #124415</strong> <a href="https://github.com/openclaw/openclaw/pull/124415">fix(plugins): keep official plugins aligned with targeted beta updates</a> Related #97680. Thanks @synthalorian and @chac4l.</li>
-<li><strong>PR #133395</strong> <a href="https://github.com/openclaw/openclaw/pull/133395">fix(canvas): preserve Windows pnpm shim arguments</a> Thanks @ly85206559.</li>
-<li><strong>PR #133945</strong> <a href="https://github.com/openclaw/openclaw/pull/133945">fix(docs): rerun failing validation after translation repair</a></li>
-<li><strong>PR #133973</strong> <a href="https://github.com/openclaw/openclaw/pull/133973">fix(channels): explain skipped account recovery starts</a> Related #133954.</li>
-<li><strong>PR #133878</strong> <a href="https://github.com/openclaw/openclaw/pull/133878">test: consolidate Slack thread-root predicate cases</a></li>
-<li><strong>PR #133942</strong> <a href="https://github.com/openclaw/openclaw/pull/133942">test(ui): classify workspace icon fetch failures</a></li>
-<li><strong>PR #133915</strong> <a href="https://github.com/openclaw/openclaw/pull/133915">refactor(media): simplify image helper tests</a></li>
-<li><strong>PR #133964</strong> <a href="https://github.com/openclaw/openclaw/pull/133964">fix(doctor): stop warning for nested Git workspaces</a> Related #133923. Thanks @obviyus and @jeffsteinbok-openclaw.</li>
-<li><strong>PR #133986</strong> <a href="https://github.com/openclaw/openclaw/pull/133986">refactor(core): share UTF-16 ellipsis truncation</a> Thanks @vincentkoc.</li>
-<li><strong>PR #133879</strong> <a href="https://github.com/openclaw/openclaw/pull/133879">test: drain subsystem log writes before cleanup</a></li>
-<li><strong>PR #128250</strong> <a href="https://github.com/openclaw/openclaw/pull/128250">fix(doctor): preserve explicit npm pin during stale runtime repair</a> Related #123616. Thanks @SunnyShu0925 and @obviyus and @sblindt.</li>
-<li><strong>PR #133993</strong> <a href="https://github.com/openclaw/openclaw/pull/133993">test(scripts): share approved package patch fixtures</a></li>
-<li><strong>PR #133880</strong> <a href="https://github.com/openclaw/openclaw/pull/133880">test: simplify Gradium request fixtures</a></li>
-<li><strong>PR #133913</strong> <a href="https://github.com/openclaw/openclaw/pull/133913">feat(scripts): materialize the scripts/pr trust anchor for mismatched worktrees</a></li>
-<li><strong>PR #133908</strong> <a href="https://github.com/openclaw/openclaw/pull/133908">fix(update): complete package lifecycle outside dist inventory</a> Thanks @obviyus.</li>
-<li><strong>PR #133917</strong> <a href="https://github.com/openclaw/openclaw/pull/133917">test: simplify bound-account routing fixtures</a></li>
-<li><strong>PR #134013</strong> <a href="https://github.com/openclaw/openclaw/pull/134013">test: await bounded concurrency task starts directly</a></li>
-<li><strong>PR #133970</strong> <a href="https://github.com/openclaw/openclaw/pull/133970">perf(agents): reuse loaded provider hooks during error handling</a></li>
-<li><strong>PR #133976</strong> <a href="https://github.com/openclaw/openclaw/pull/133976">fix(node): fence cancelled worker bundle installation</a></li>
-<li><strong>PR #134011</strong> <a href="https://github.com/openclaw/openclaw/pull/134011">refactor(sessions): share session entry admission</a> Thanks @vincentkoc.</li>
-<li><strong>PR #133979</strong> <a href="https://github.com/openclaw/openclaw/pull/133979">fix(reply): report failures after a turn is accepted</a> Related #133960.</li>
-<li><strong>PR #133975</strong> <a href="https://github.com/openclaw/openclaw/pull/133975">test(searxng): remove an unused normalization test exposure</a></li>
-<li><strong>PR #133729</strong> <a href="https://github.com/openclaw/openclaw/pull/133729">fix(completion): preserve Windows PowerShell profile encoding</a> Thanks @ly85206559.</li>
-<li><strong>PR #133788</strong> <a href="https://github.com/openclaw/openclaw/pull/133788">fix(agents): honor per-agent toolProgressDetail overrides</a> Thanks @marmar9615-cloud.</li>
-<li><strong>PR #133989</strong> <a href="https://github.com/openclaw/openclaw/pull/133989">fix(gateway): require protocol evidence for readiness</a> Related #133953.</li>
-<li><strong>PR #133944</strong> <a href="https://github.com/openclaw/openclaw/pull/133944">test: simplify cron delivery planning fixtures</a></li>
-<li><strong>PR #133983</strong> <a href="https://github.com/openclaw/openclaw/pull/133983">fix(cli): resolve agent ownership only where setup needs it</a> Related #133959.</li>
-<li><strong>PR #133965</strong> <a href="https://github.com/openclaw/openclaw/pull/133965">fix(ui): release evicted chat transcript payloads</a> Related #133939.</li>
-<li><strong>PR #134019</strong> <a href="https://github.com/openclaw/openclaw/pull/134019">test(whatsapp): exercise real outbound target policy</a></li>
-<li><strong>PR #129145</strong> <a href="https://github.com/openclaw/openclaw/pull/129145">fix: every agent attempt re-hashes unchanged tool descriptions because the report digest cache can never hit</a> Related #129116. Thanks @quangtran88.</li>
-<li><strong>PR #134030</strong> <a href="https://github.com/openclaw/openclaw/pull/134030">fix(anthropic): preserve native auth with stored API keys</a> Related #134004. Thanks @obviyus and @rayseling.</li>
-<li><strong>PR #133815</strong> <a href="https://github.com/openclaw/openclaw/pull/133815">fix(agents): preserve literal @-prefixed session paths</a> Thanks @qingminglong.</li>
-<li><strong>PR #133961</strong> <a href="https://github.com/openclaw/openclaw/pull/133961">test: share daemon inspection fixture cleanup</a></li>
-<li><strong>PR #133982</strong> <a href="https://github.com/openclaw/openclaw/pull/133982">fix(workspace): verify migration readiness before accepting work</a> Related #133951.</li>
-<li><strong>PR #133444</strong> <a href="https://github.com/openclaw/openclaw/pull/133444">fix(doctor): preserve disabled shared heartbeat owners</a> Related #133389. Thanks @PollyBot13 and @obviyus.</li>
-<li><strong>PR #133968</strong> <a href="https://github.com/openclaw/openclaw/pull/133968">fix(tts): honor delivered audio when finalizing turns</a></li>
-<li><strong>PR #134023</strong> <a href="https://github.com/openclaw/openclaw/pull/134023">test(release): assert current wizard admission contract</a></li>
-<li><strong>PR #133974</strong> <a href="https://github.com/openclaw/openclaw/pull/133974">test(build): import stamp writers from their shared owner</a></li>
-<li><strong>PR #134007</strong> <a href="https://github.com/openclaw/openclaw/pull/134007">perf(heartbeat): reduce queue and diagnostic snapshot scans</a></li>
-<li><strong>PR #134028</strong> <a href="https://github.com/openclaw/openclaw/pull/134028">perf(browser): avoid redundant snapshot traversal allocations</a></li>
-<li><strong>PR #133966</strong> <a href="https://github.com/openclaw/openclaw/pull/133966">test: simplify Microsoft speech fixtures</a></li>
-<li><strong>PR #134027</strong> <a href="https://github.com/openclaw/openclaw/pull/134027">fix(macos): avoid release packaging failures and slow notes</a></li>
-<li><strong>PR #134002</strong> <a href="https://github.com/openclaw/openclaw/pull/134002">fix: keep stable-upgrade validation compatible with older installs</a></li>
-<li><strong>PR #134025</strong> <a href="https://github.com/openclaw/openclaw/pull/134025">fix: prevent Doctor from rolling back migratable config</a> Related #90551. Thanks @obviyus and @stuart-minion-ai.</li>
-<li><strong>PR #133967</strong> <a href="https://github.com/openclaw/openclaw/pull/133967">test: restore native OS module after tool-manager cases</a></li>
-<li><strong>PR #134052</strong> <a href="https://github.com/openclaw/openclaw/pull/134052">fix(resources): preserve source scope for Windows path casing</a> Thanks @vincentkoc.</li>
-<li><strong>PR #133963</strong> <a href="https://github.com/openclaw/openclaw/pull/133963">fix(plugins): report registry persistence differences</a> Related #133901. Thanks @obviyus and @yubingjiaocn.</li>
-<li><strong>PR #133969</strong> <a href="https://github.com/openclaw/openclaw/pull/133969">test: consolidate link-understanding runner cases</a></li>
-<li><strong>PR #133904</strong> <a href="https://github.com/openclaw/openclaw/pull/133904">perf(approvals): reuse redaction views and bounded text checks</a></li>
-<li><strong>PR #133896</strong> <a href="https://github.com/openclaw/openclaw/pull/133896">docs: offer local coding harness help for failed updates</a></li>
-<li><strong>PR #133892</strong> <a href="https://github.com/openclaw/openclaw/pull/133892">test: remove native Promise conformance replays</a></li>
-<li><strong>PR #134018</strong> <a href="https://github.com/openclaw/openclaw/pull/134018">fix(voice-call): preserve current settings during legacy migration</a> Related #127596.</li>
-<li><strong>PR #133971</strong> <a href="https://github.com/openclaw/openclaw/pull/133971">test: share broad tooling routing assertions</a></li>
-<li><strong>PR #134008</strong> <a href="https://github.com/openclaw/openclaw/pull/134008">refactor(agents): avoid unnecessary failure classification</a></li>
-<li><strong>PR #134054</strong> <a href="https://github.com/openclaw/openclaw/pull/134054">ci: resolve OpenGrep base before fetching history</a> Thanks @lsr911 and @obviyus and @chelsealong and @ZengWen-DT and @SebTardif.</li>
-<li><strong>PR #134039</strong> <a href="https://github.com/openclaw/openclaw/pull/134039">test(scripts): batch distribution import fixtures</a> Thanks @lsr911 and @obviyus and @chelsealong and @ZengWen-DT and @SebTardif.</li>
-<li><strong>PR #134075</strong> <a href="https://github.com/openclaw/openclaw/pull/134075">fix(update): retain pnpm owner across launcher respawn</a> Related #134037. Thanks @obviyus and @YogevKr.</li>
-<li><strong>PR #133891</strong> <a href="https://github.com/openclaw/openclaw/pull/133891">test(parallel): assert user agent at the request boundary</a> Thanks @lsr911 and @obviyus and @chelsealong and @ZengWen-DT and @SebTardif.</li>
-<li><strong>PR #134033</strong> <a href="https://github.com/openclaw/openclaw/pull/134033">fix(matrix): drain monitor tasks before retiring clients</a> Thanks @lsr911 and @obviyus and @chelsealong and @ZengWen-DT and @SebTardif.</li>
-<li><strong>PR #134044</strong> <a href="https://github.com/openclaw/openclaw/pull/134044">fix(channels): isolate unavailable accounts from gateway diagnostics</a> Related #133977. Thanks @lsr911 and @obviyus and @chelsealong and @ZengWen-DT and @SebTardif.</li>
-<li><strong>PR #133920</strong> <a href="https://github.com/openclaw/openclaw/pull/133920">fix(config): preserve owners across legacy roster imports and store changes</a> Related #133868, #133889. Thanks @lsr911 and @obviyus and @chelsealong and @ZengWen-DT and @SebTardif.</li>
-<li><strong>PR #133947</strong> <a href="https://github.com/openclaw/openclaw/pull/133947">fix(talk): keep Browser Talk agent-consult turns out of user chat history</a> Related #133855. Thanks @chelsealong and @lsr911 and @obviyus and @ZengWen-DT and @SebTardif and @Conan-Scott.</li>
-<li><strong>PR #133912</strong> <a href="https://github.com/openclaw/openclaw/pull/133912">fix: preserve policy owners across reviews and compaction</a> Thanks @lsr911 and @obviyus and @chelsealong and @ZengWen-DT and @SebTardif.</li>
-<li><strong>PR #133991</strong> <a href="https://github.com/openclaw/openclaw/pull/133991">fix(doctor): prune stale path install records shadowed by load paths</a> Related #133935. Thanks @ZengWen-DT and @obviyus and @lsr911 and @chelsealong and @SebTardif and @JeffSteinbok.</li>
-<li><strong>PR #89636</strong> <a href="https://github.com/openclaw/openclaw/pull/89636">fix(secrets): collect persona-level TTS provider SecretRefs</a> Related #89607. Thanks @SebTardif and @lsr911 and @obviyus and @chelsealong and @ZengWen-DT and @pablonunoutande-source.</li>
-<li><strong>PR #119201</strong> <a href="https://github.com/openclaw/openclaw/pull/119201">fix(state-migrations): isolate a throwing channel plan callback into a warning (#119200)</a> Related #119200. Thanks @ruel225.</li>
-<li><strong>PR #133893</strong> <a href="https://github.com/openclaw/openclaw/pull/133893">test(discord): consolidate successful request signal coverage</a></li>
-<li><strong>PR #134064</strong> <a href="https://github.com/openclaw/openclaw/pull/134064">perf(security): prepare external content scans once</a></li>
-<li><strong>PR #134029</strong> <a href="https://github.com/openclaw/openclaw/pull/134029">fix(agents): preserve provider ownership in error diagnostics</a> Related #134012.</li>
-<li><strong>PR #134098</strong> <a href="https://github.com/openclaw/openclaw/pull/134098">fix(codex): preserve conversations across app-server restarts</a></li>
-<li><strong>PR #133890</strong> <a href="https://github.com/openclaw/openclaw/pull/133890">test(logging): exercise canonical owners without duplicate checks</a></li>
-<li><strong>PR #134107</strong> <a href="https://github.com/openclaw/openclaw/pull/134107">ci: typecheck graphs that consume changed tests</a></li>
-<li><strong>PR #134082</strong> <a href="https://github.com/openclaw/openclaw/pull/134082">test(shared): simplify text assertions</a></li>
-<li><strong>PR #134084</strong> <a href="https://github.com/openclaw/openclaw/pull/134084">fix(gateway): sudo install no longer writes root state</a> Related #134000. Thanks @obviyus and @itanyplus.</li>
-<li><strong>PR #134087</strong> <a href="https://github.com/openclaw/openclaw/pull/134087">fix(memory): stop legacy warnings for canonical database links</a> Related #133981. Thanks @obviyus and @02-dino.</li>
-<li><strong>PR #134078</strong> <a href="https://github.com/openclaw/openclaw/pull/134078">fix(doctor): report state blocked by config errors</a> Related #134036. Thanks @obviyus and @YogevKr.</li>
-<li><strong>PR #134165</strong> <a href="https://github.com/openclaw/openclaw/pull/134165">fix: restore channel recovery after crash-loop suppression</a> Related #134134. Thanks @shakkernerd.</li>
-<li><strong>PR #134118</strong> <a href="https://github.com/openclaw/openclaw/pull/134118">test(scripts): call package consent parser directly</a></li>
-<li><strong>PR #134195</strong> <a href="https://github.com/openclaw/openclaw/pull/134195">docs: restore v2026.8.1 editorial release page</a> Thanks @hannesrudolph.</li>
-<li><strong>PR #134121</strong> <a href="https://github.com/openclaw/openclaw/pull/134121">test(scripts): share Android catalogs and strengthen scanner assertions</a></li>
-<li><strong>PR #134103</strong> <a href="https://github.com/openclaw/openclaw/pull/134103">fix(agents): carry classified provider facts into assistant failure copy</a> Thanks @obviyus.</li>
-<li><strong>PR #134122</strong> <a href="https://github.com/openclaw/openclaw/pull/134122">test(scripts): assert each dated TODO exclusion</a></li>
-<li><strong>PR #134133</strong> <a href="https://github.com/openclaw/openclaw/pull/134133">test(scripts): batch accepted Docker stats fixtures</a></li>
-<li><strong>PR #133958</strong> <a href="https://github.com/openclaw/openclaw/pull/133958">fix(talk): honor configured owners for default sessions</a></li>
-<li><strong>PR #134149</strong> <a href="https://github.com/openclaw/openclaw/pull/134149">test(imessage): reuse RPC client imports</a></li>
-<li><strong>PR #134031</strong> <a href="https://github.com/openclaw/openclaw/pull/134031">fix(doctor): coordinate explicit repair with the managed gateway</a> Related #133957.</li>
-<li><strong>PR #134017</strong> <a href="https://github.com/openclaw/openclaw/pull/134017">test(scripts): avoid duplicate SDK sync cycles</a></li>
-<li><strong>PR #134140</strong> <a href="https://github.com/openclaw/openclaw/pull/134140">ci: remove a serial release candidate queue hop</a></li>
-<li><strong>PR #134080</strong> <a href="https://github.com/openclaw/openclaw/pull/134080">test(ai): colocate JSON parser coverage</a></li>
-<li><strong>PR #134086</strong> <a href="https://github.com/openclaw/openclaw/pull/134086">test(ai): colocate model utility coverage</a></li>
-<li><strong>PR #134072</strong> <a href="https://github.com/openclaw/openclaw/pull/134072">fix(settings): preserve concurrent first saves</a> Thanks @MrSwagatRathod and @obviyus.</li>
-<li><strong>PR #134091</strong> <a href="https://github.com/openclaw/openclaw/pull/134091">test(gateway): await scope upgrade cancellation signals</a></li>
-<li><strong>PR #134092</strong> <a href="https://github.com/openclaw/openclaw/pull/134092">test(scripts): exercise real iOS team selection</a></li>
-<li><strong>PR #134073</strong> <a href="https://github.com/openclaw/openclaw/pull/134073">fix(codex): avoid import timeouts in large native homes</a> Related #133929.</li>
-<li><strong>PR #134094</strong> <a href="https://github.com/openclaw/openclaw/pull/134094">test(agents): derive prompt handle identity from fixture</a></li>
-<li><strong>PR #134108</strong> <a href="https://github.com/openclaw/openclaw/pull/134108">test(infra): await APNS request lifecycle signals</a></li>
-<li><strong>PR #134176</strong> <a href="https://github.com/openclaw/openclaw/pull/134176">perf(gateway): reduce repeated session snapshot copying</a></li>
-<li><strong>PR #134102</strong> <a href="https://github.com/openclaw/openclaw/pull/134102">test: bound concurrency startup observations</a></li>
-<li><strong>PR #134104</strong> <a href="https://github.com/openclaw/openclaw/pull/134104">test(infra): await environment log completion directly</a></li>
-<li><strong>PR #134117</strong> <a href="https://github.com/openclaw/openclaw/pull/134117">test(scripts): set ratchet fixture identity per Git invocation</a></li>
-<li><strong>PR #134128</strong> <a href="https://github.com/openclaw/openclaw/pull/134128">test(scripts): share retry fixture counters</a></li>
-<li><strong>PR #134168</strong> <a href="https://github.com/openclaw/openclaw/pull/134168">fix(logging): keep long secret redaction safe and defer repeated probes</a></li>
-<li><strong>PR #134139</strong> <a href="https://github.com/openclaw/openclaw/pull/134139">test(nostr): exercise cursor retries with virtual time</a></li>
-<li><strong>PR #134146</strong> <a href="https://github.com/openclaw/openclaw/pull/134146">test(teams): reuse prerequisite setup imports</a></li>
-<li><strong>PR #133758</strong> <a href="https://github.com/openclaw/openclaw/pull/133758">fix(cli): keep Unicode session and task tables aligned</a></li>
-<li><strong>PR #134157</strong> <a href="https://github.com/openclaw/openclaw/pull/134157">test(mistral): observe terminal WebSocket completion</a></li>
-<li><strong>PR #134093</strong> <a href="https://github.com/openclaw/openclaw/pull/134093">fix(gateway): preserve literal Talk consult questions</a> Related #133855, #134037. Thanks @lsr911 and @obviyus and @chelsealong and @ZengWen-DT and @SebTardif and @Conan-Scott and @YogevKr.</li>
-<li><strong>PR #134162</strong> <a href="https://github.com/openclaw/openclaw/pull/134162">test(imap): await committed cursor notifications</a></li>
-<li><strong>PR #134147</strong> <a href="https://github.com/openclaw/openclaw/pull/134147">test(ui): remove duplicate status tests</a></li>
-<li><strong>PR #134035</strong> <a href="https://github.com/openclaw/openclaw/pull/134035">fix(ci): bound macOS Swift test concurrency</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134164</strong> <a href="https://github.com/openclaw/openclaw/pull/134164">test(telegram): isolate network imports only for cache cases</a></li>
-<li><strong>PR #133918</strong> <a href="https://github.com/openclaw/openclaw/pull/133918">fix(ui): preserve mocked browser proof across reruns</a></li>
-<li><strong>PR #134171</strong> <a href="https://github.com/openclaw/openclaw/pull/134171">test(telegram): await buffered media task completion</a></li>
-<li><strong>PR #134174</strong> <a href="https://github.com/openclaw/openclaw/pull/134174">test(video): share provider imports across transport cases</a></li>
-<li><strong>PR #134112</strong> <a href="https://github.com/openclaw/openclaw/pull/134112">test(infra): simplify HTTP response assertions</a></li>
-<li><strong>PR #134183</strong> <a href="https://github.com/openclaw/openclaw/pull/134183">fix(update): block restart while plugin consent is pending</a> Related #134156. Thanks @obviyus and @BrunoCerberus.</li>
-<li><strong>PR #133864</strong> <a href="https://github.com/openclaw/openclaw/pull/133864">feat(update): clean up retained migration recovery files</a> Related #133805.</li>
-<li><strong>PR #133563</strong> <a href="https://github.com/openclaw/openclaw/pull/133563">fix(state): fence automatic agent database migrations</a> Related #133478. Thanks @omarshahine.</li>
-<li><strong>PR #134151</strong> <a href="https://github.com/openclaw/openclaw/pull/134151">test(browser): consolidate trash behavior at the SDK owner</a></li>
-<li><strong>PR #134062</strong> <a href="https://github.com/openclaw/openclaw/pull/134062">fix(doctor): refresh SQLite planner stats after migration</a> Thanks @VACInc.</li>
-<li><strong>PR #134005</strong> <a href="https://github.com/openclaw/openclaw/pull/134005">refactor(state): preserve concrete keyed-store capabilities</a></li>
-<li><strong>PR #134207</strong> <a href="https://github.com/openclaw/openclaw/pull/134207">fix: restore gateway recovery fixture lint and types</a> Thanks @shakkernerd.</li>
-<li><strong>PR #134193</strong> <a href="https://github.com/openclaw/openclaw/pull/134193">fix(update): npm-hardened global updates no longer roll back</a> Related #134177. Thanks @obviyus and @botatdovly.</li>
-<li><strong>PR #134014</strong> <a href="https://github.com/openclaw/openclaw/pull/134014">fix(pr): prevent parallel main refreshes from colliding</a> Thanks @shakkernerd.</li>
-<li><strong>PR #134100</strong> <a href="https://github.com/openclaw/openclaw/pull/134100">ci: balance expensive tooling lifecycle tests</a></li>
-<li><strong>PR #134111</strong> <a href="https://github.com/openclaw/openclaw/pull/134111">fix(agents): single-source model fallback availability</a> Thanks @obviyus.</li>
-<li><strong>PR #134260</strong> <a href="https://github.com/openclaw/openclaw/pull/134260">test(plugins): expect structured registry differences</a></li>
-<li><strong>PR #134232</strong> <a href="https://github.com/openclaw/openclaw/pull/134232">ci: remove redundant image readiness queue hops</a></li>
-<li><strong>PR #134251</strong> <a href="https://github.com/openclaw/openclaw/pull/134251">fix(slack): workspace-scoped plugin approvers can approve</a> Related #133932. Thanks @obviyus and @marmar9615-cloud.</li>
-<li><strong>PR #134053</strong> <a href="https://github.com/openclaw/openclaw/pull/134053">fix(release): complete ClawHub publication after parent success</a> Thanks @shakkernerd.</li>
-<li><strong>PR #134189</strong> <a href="https://github.com/openclaw/openclaw/pull/134189">fix(ui): recover suspended tabs after gateway updates</a> Thanks @Takhoffman.</li>
-<li><strong>PR #134105</strong> <a href="https://github.com/openclaw/openclaw/pull/134105">refactor(agents): consolidate session text component reuse</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134223</strong> <a href="https://github.com/openclaw/openclaw/pull/134223">fix(gateway): keep TLS diagnostics from generating certificates</a> Related #134222.</li>
-<li><strong>PR #133914</strong> <a href="https://github.com/openclaw/openclaw/pull/133914">refactor(brave): remove redundant test facade</a></li>
-<li><strong>PR #134009</strong> <a href="https://github.com/openclaw/openclaw/pull/134009">fix(doctor): report interrupted auth archive recovery</a> Thanks @shakkernerd.</li>
-<li><strong>PR #134216</strong> <a href="https://github.com/openclaw/openclaw/pull/134216">perf(ci): bound plugin lint project discovery</a></li>
-<li><strong>PR #132445</strong> <a href="https://github.com/openclaw/openclaw/pull/132445">fix(ui): stop earlier-history loading action from jumping</a> Thanks @RomneyDa.</li>
-<li><strong>PR #134209</strong> <a href="https://github.com/openclaw/openclaw/pull/134209">perf: reduce Control UI startup and history processing</a></li>
-<li><strong>PR #134266</strong> <a href="https://github.com/openclaw/openclaw/pull/134266">test(infra): consolidate abort relay coverage at its owner</a></li>
-<li><strong>PR #134263</strong> <a href="https://github.com/openclaw/openclaw/pull/134263">test(infra): exercise real transport backoff</a></li>
-<li><strong>PR #134208</strong> <a href="https://github.com/openclaw/openclaw/pull/134208">fix(state): let doctor repair legacy v17 agent databases</a> Related #134163. Thanks @EthDing and @obviyus and @abacha.</li>
-<li><strong>PR #133921</strong> <a href="https://github.com/openclaw/openclaw/pull/133921">fix(doctor): preserve files created during session restore</a></li>
-<li><strong>PR #134270</strong> <a href="https://github.com/openclaw/openclaw/pull/134270">test(llm-core): batch event stream sequence assertions</a></li>
-<li><strong>PR #133676</strong> <a href="https://github.com/openclaw/openclaw/pull/133676">feat: keep the Home agent beside your work</a> Related #133632.</li>
-<li><strong>PR #134273</strong> <a href="https://github.com/openclaw/openclaw/pull/134273">test(tooling): remove delayed activity fixture responses</a></li>
-<li><strong>PR #134271</strong> <a href="https://github.com/openclaw/openclaw/pull/134271">perf: avoid scanning unused package-root candidates</a></li>
-<li><strong>PR #134200</strong> <a href="https://github.com/openclaw/openclaw/pull/134200">fix(worker): preserve cloud execution and recovery failures</a> Related #134199. Thanks @Takhoffman.</li>
-<li><strong>PR #134280</strong> <a href="https://github.com/openclaw/openclaw/pull/134280">test(infra): move duration cases to the formatter owner</a></li>
-<li><strong>PR #134259</strong> <a href="https://github.com/openclaw/openclaw/pull/134259">fix(codex): preserve summarized context when switching runtimes</a> Related #134224.</li>
-<li><strong>PR #134284</strong> <a href="https://github.com/openclaw/openclaw/pull/134284">test(infra): synchronize approval shutdown races at callback entry</a></li>
-<li><strong>PR #134138</strong> <a href="https://github.com/openclaw/openclaw/pull/134138">fix(talk): keep later voice turns admitted after call setup</a> Related #134081. Thanks @mastertyko.</li>
-<li><strong>PR #134282</strong> <a href="https://github.com/openclaw/openclaw/pull/134282">fix(gateway): use the npm WebSocket receiver under Bun</a></li>
-<li><strong>PR #134228</strong> <a href="https://github.com/openclaw/openclaw/pull/134228">fix: fail updates when session migration is incomplete</a> Related #134206. Thanks @shakkernerd.</li>
-<li><strong>PR #134287</strong> <a href="https://github.com/openclaw/openclaw/pull/134287">refactor(core): share first-wins keyed dedupe</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134026</strong> <a href="https://github.com/openclaw/openclaw/pull/134026">perf(workers): reuse validated hashes during workspace activation</a></li>
-<li><strong>PR #134289</strong> <a href="https://github.com/openclaw/openclaw/pull/134289">test(feishu): consolidate backoff coverage at its owner</a></li>
-<li><strong>PR #134298</strong> <a href="https://github.com/openclaw/openclaw/pull/134298">perf(ci): report type failures before broad audits</a></li>
-<li><strong>PR #134293</strong> <a href="https://github.com/openclaw/openclaw/pull/134293">test(tooling): use value fixtures for mobile release renderers</a></li>
-<li><strong>PR #134170</strong> <a href="https://github.com/openclaw/openclaw/pull/134170">fix(codex): preserve accepted speech through media delivery</a></li>
-<li><strong>PR #134123</strong> <a href="https://github.com/openclaw/openclaw/pull/134123">test(macos): remove duplicate shell smoke check</a></li>
-<li><strong>PR #134244</strong> <a href="https://github.com/openclaw/openclaw/pull/134244">fix(cli): keep embedded triage on the diagnosed installation</a></li>
-<li><strong>PR #134296</strong> <a href="https://github.com/openclaw/openclaw/pull/134296">test(tooling): batch startup benchmark state cases</a></li>
-<li><strong>PR #134315</strong> <a href="https://github.com/openclaw/openclaw/pull/134315">test(xai): verify OAuth runtime imports stay lazy</a></li>
-<li><strong>PR #134294</strong> <a href="https://github.com/openclaw/openclaw/pull/134294">perf(ci): use runtime-only builds for Node test prerequisites</a></li>
-<li><strong>PR #134252</strong> <a href="https://github.com/openclaw/openclaw/pull/134252">perf(sessions): reuse prepared transcript batch writers</a></li>
-<li><strong>PR #133988</strong> <a href="https://github.com/openclaw/openclaw/pull/133988">fix(gateway): release cached transcript backing storage</a> Related #133941.</li>
-<li><strong>PR #134231</strong> <a href="https://github.com/openclaw/openclaw/pull/134231">fix(docker): include shared lifecycle marker in install stages</a></li>
-<li><strong>PR #133952</strong> <a href="https://github.com/openclaw/openclaw/pull/133952">fix(doctor): identify malformed legacy exec approval fields</a></li>
-<li><strong>PR #134277</strong> <a href="https://github.com/openclaw/openclaw/pull/134277">test(tooling): configure fixture identity in the commit command</a></li>
-<li><strong>PR #134045</strong> <a href="https://github.com/openclaw/openclaw/pull/134045">fix: retain 2026.8.1 release fixes on main</a> Thanks @shakkernerd.</li>
-<li><strong>PR #134268</strong> <a href="https://github.com/openclaw/openclaw/pull/134268">fix(macos): finish ChatGPT login after Gateway reconnect</a> Related #134182. Thanks @obviyus and @Sedrak-Hovhannisyan.</li>
-<li><strong>PR #134246</strong> <a href="https://github.com/openclaw/openclaw/pull/134246">refactor(agents): reduce per-turn policy and tool preparation</a></li>
-<li><strong>PR #134043</strong> <a href="https://github.com/openclaw/openclaw/pull/134043">perf(workers): streamline cloud startup and fix bootstrap archive races</a></li>
-<li><strong>PR #134056</strong> <a href="https://github.com/openclaw/openclaw/pull/134056">fix: preserve speech and process output through nested tools</a></li>
-<li><strong>PR #134328</strong> <a href="https://github.com/openclaw/openclaw/pull/134328">fix(test): preserve Git update fixture identity through postinstall</a></li>
-<li><strong>PR #134238</strong> <a href="https://github.com/openclaw/openclaw/pull/134238">fix(sessions): avoid excessive history copies and preserve fork provenance</a></li>
-<li><strong>PR #134245</strong> <a href="https://github.com/openclaw/openclaw/pull/134245">test(auto-reply): avoid catalog discovery in media fixtures</a></li>
-<li><strong>PR #134324</strong> <a href="https://github.com/openclaw/openclaw/pull/134324">test(browser): remove duplicated profile allocation demonstrations</a></li>
-<li><strong>PR #134310</strong> <a href="https://github.com/openclaw/openclaw/pull/134310">fix(ui): keep images visible during hard refresh</a> Related #134237.</li>
-<li><strong>PR #119516</strong> <a href="https://github.com/openclaw/openclaw/pull/119516">fix(update): recover the managed gateway after a failed CLI update</a> Related #118244. Thanks @zyw02 and @Issue-Hunter and @cursoragent and @sercada.</li>
-<li><strong>PR #134290</strong> <a href="https://github.com/openclaw/openclaw/pull/134290">refactor: reuse prepared plugin facts during Gateway turns</a></li>
-<li><strong>PR #134318</strong> <a href="https://github.com/openclaw/openclaw/pull/134318">perf(ui): prepare usage query predicates once</a></li>
-<li><strong>PR #134319</strong> <a href="https://github.com/openclaw/openclaw/pull/134319">test(infra): load execution policy modules once per suite</a></li>
-<li><strong>PR #134322</strong> <a href="https://github.com/openclaw/openclaw/pull/134322">test(lmstudio): reuse oversized response source chunks</a></li>
-<li><strong>PR #134288</strong> <a href="https://github.com/openclaw/openclaw/pull/134288">test(macos): remove app profile source invariants</a> Thanks @RomneyDa.</li>
-<li><strong>PR #134283</strong> <a href="https://github.com/openclaw/openclaw/pull/134283">fix(ci): record complete native UI file timings</a></li>
-<li><strong>PR #134350</strong> <a href="https://github.com/openclaw/openclaw/pull/134350">test(tooling): reuse Periphery workflow code fixtures</a></li>
-<li><strong>PR #133617</strong> <a href="https://github.com/openclaw/openclaw/pull/133617">fix(plugins): stop suggesting unavailable drift updates</a> Thanks @vladimirkrdzic.</li>
-<li><strong>PR #134166</strong> <a href="https://github.com/openclaw/openclaw/pull/134166">fix(installer): preserve Fedora Node packages with unsafe SQLite</a> Related #132828. Thanks @sallyom and @beedell-roke.</li>
-<li><strong>PR #134335</strong> <a href="https://github.com/openclaw/openclaw/pull/134335">test(sessions): await the conversation owner deadline</a></li>
-<li><strong>PR #134269</strong> <a href="https://github.com/openclaw/openclaw/pull/134269">fix(cli): honor usage options in full status reports</a> Related #134267.</li>
-<li><strong>PR #134214</strong> <a href="https://github.com/openclaw/openclaw/pull/134214">fix(xai): scope TTS network allowance to the configured origin on both paths</a> Thanks @marmar9615-cloud.</li>
-<li><strong>PR #134339</strong> <a href="https://github.com/openclaw/openclaw/pull/134339">refactor(plugin-state): share store option policy</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134355</strong> <a href="https://github.com/openclaw/openclaw/pull/134355">test(process): observe capacity group admission directly</a></li>
-<li><strong>PR #134088</strong> <a href="https://github.com/openclaw/openclaw/pull/134088">fix(workers): expire unused snapshots when projects are idle</a></li>
-<li><strong>PR #134095</strong> <a href="https://github.com/openclaw/openclaw/pull/134095">test(plugins): simplify provider fixtures</a></li>
-<li><strong>PR #134364</strong> <a href="https://github.com/openclaw/openclaw/pull/134364">test(cli): scope module resets to mocked policy cases</a></li>
-<li><strong>PR #134374</strong> <a href="https://github.com/openclaw/openclaw/pull/134374">perf: score Tool Search queries through term postings</a></li>
-<li><strong>PR #134136</strong> <a href="https://github.com/openclaw/openclaw/pull/134136">fix(skills): detect skill roots created after startup</a> Thanks @shakkernerd.</li>
-<li><strong>PR #134358</strong> <a href="https://github.com/openclaw/openclaw/pull/134358">fix(test): align Doctor install-switch proof with maintenance ownership</a></li>
-<li><strong>PR #134184</strong> <a href="https://github.com/openclaw/openclaw/pull/134184">refactor: remove synthetic chat callback recovery</a></li>
-<li><strong>PR #134372</strong> <a href="https://github.com/openclaw/openclaw/pull/134372">fix(agents): stop payload redaction rewriting tool-search counter scopes</a></li>
-<li><strong>PR #134345</strong> <a href="https://github.com/openclaw/openclaw/pull/134345">test(tooling): cover profiler argument variants at the parser</a></li>
-<li><strong>PR #134367</strong> <a href="https://github.com/openclaw/openclaw/pull/134367">test(tooling): reuse mobile release ref lifecycle fixtures</a></li>
-<li><strong>PR #134371</strong> <a href="https://github.com/openclaw/openclaw/pull/134371">test(agents): drive compaction fallback retry clocks</a></li>
-<li><strong>PR #134300</strong> <a href="https://github.com/openclaw/openclaw/pull/134300">refactor(test): reduce compiled-worker fixture scaffolding</a></li>
-<li><strong>PR #134378</strong> <a href="https://github.com/openclaw/openclaw/pull/134378">test(nostr): consolidate metrics coverage at its owner</a></li>
-<li><strong>PR #134382</strong> <a href="https://github.com/openclaw/openclaw/pull/134382">test(whatsapp): unify profile directory import lifecycles</a></li>
-<li><strong>PR #134369</strong> <a href="https://github.com/openclaw/openclaw/pull/134369">perf: reduce repeated work in Control UI history</a></li>
-<li><strong>PR #130663</strong> <a href="https://github.com/openclaw/openclaw/pull/130663">docs: document model-not-found fallback</a> Related #130256. Thanks @MonkeyLeeT and @geekforlife.</li>
-<li><strong>PR #134383</strong> <a href="https://github.com/openclaw/openclaw/pull/134383">test(deepgram): observe realtime transcription completion</a></li>
-<li><strong>PR #130961</strong> <a href="https://github.com/openclaw/openclaw/pull/130961">docs(gateway): define external supervisor acceptance rules</a> Related #130888. Thanks @1052326311 and @josephbergvinson.</li>
-<li><strong>PR #134384</strong> <a href="https://github.com/openclaw/openclaw/pull/134384">test(elevenlabs): observe realtime transcription completion</a></li>
-<li><strong>PR #134145</strong> <a href="https://github.com/openclaw/openclaw/pull/134145">fix: stop SMS work when credentials become unavailable</a> Related #133924. Thanks @shakkernerd.</li>
-<li><strong>PR #134393</strong> <a href="https://github.com/openclaw/openclaw/pull/134393">test(tlon): exercise the real channel authorization resolver</a></li>
-<li><strong>PR #134377</strong> <a href="https://github.com/openclaw/openclaw/pull/134377">fix(xai): handle silent transcripts and order upload options</a></li>
-<li><strong>PR #134181</strong> <a href="https://github.com/openclaw/openclaw/pull/134181">fix(cloud): settle project snapshots before enrollment</a></li>
-<li><strong>PR #134357</strong> <a href="https://github.com/openclaw/openclaw/pull/134357">fix(text): keep astral letters separate when stripping model tokens</a></li>
-<li><strong>PR #134040</strong> <a href="https://github.com/openclaw/openclaw/pull/134040">fix(gateway): reject blank probe --timeout instead of silent default</a> Thanks @SunnyShu0925.</li>
-<li><strong>PR #134401</strong> <a href="https://github.com/openclaw/openclaw/pull/134401">test(openai): reuse the terminal history frontier lifecycle</a></li>
-<li><strong>PR #134399</strong> <a href="https://github.com/openclaw/openclaw/pull/134399">test(tooling): share immutable OpenGrep source fixtures</a></li>
-<li><strong>PR #134356</strong> <a href="https://github.com/openclaw/openclaw/pull/134356">refactor: simplify media-core test assertions</a></li>
-<li><strong>PR #134247</strong> <a href="https://github.com/openclaw/openclaw/pull/134247">fix(cli): omit hidden options from generated shell completions</a> Thanks @marmar9615-cloud.</li>
-<li><strong>PR #134359</strong> <a href="https://github.com/openclaw/openclaw/pull/134359">fix: publish Linux bundles from canonical release branches</a></li>
-<li><strong>PR #133154</strong> <a href="https://github.com/openclaw/openclaw/pull/133154">fix(gateway): name root-request holders in active-work drain diagnostics</a> Thanks @VACInc.</li>
-<li><strong>PR #134405</strong> <a href="https://github.com/openclaw/openclaw/pull/134405">perf(ui): avoid unused Workboard lifecycle lookups</a></li>
-<li><strong>PR #134366</strong> <a href="https://github.com/openclaw/openclaw/pull/134366">fix(scripts): restore missing helpers in materialized PR anchors</a></li>
-<li><strong>PR #133577</strong> <a href="https://github.com/openclaw/openclaw/pull/133577">fix(line): stay quiet while another channel holds the chat</a> Related #133576. Thanks @edenfunf.</li>
-<li><strong>PR #134301</strong> <a href="https://github.com/openclaw/openclaw/pull/134301">chore(ui): refresh control ui locales</a></li>
-<li><strong>PR #134311</strong> <a href="https://github.com/openclaw/openclaw/pull/134311">fix(models): refresh Chutes and Cerebras price estimates</a> Related #134248.</li>
-<li><strong>PR #133926</strong> <a href="https://github.com/openclaw/openclaw/pull/133926">fix(agents): clarify sessions_send delivery state</a> Related #96020. Thanks @VACInc and @RichChen01.</li>
-<li><strong>PR #134408</strong> <a href="https://github.com/openclaw/openclaw/pull/134408">test(tooling): advance the realtime smoke verdict clock</a></li>
-<li><strong>PR #134402</strong> <a href="https://github.com/openclaw/openclaw/pull/134402">test(ui): retain manual agent-file capture artifacts</a></li>
-<li><strong>PR #134286</strong> <a href="https://github.com/openclaw/openclaw/pull/134286">test(ios): trim runtime localization source inventory</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133679</strong> <a href="https://github.com/openclaw/openclaw/pull/133679">fix(line): keep the typing indicator on replies the gateway drives</a> Related #133677. Thanks @edenfunf.</li>
-<li><strong>PR #134309</strong> <a href="https://github.com/openclaw/openclaw/pull/134309">fix(release): support frozen Bun package artifacts</a> Thanks @RomneyDa.</li>
-<li><strong>PR #134363</strong> <a href="https://github.com/openclaw/openclaw/pull/134363">fix(release): scope frozen upgrade baselines</a> Thanks @RomneyDa.</li>
-<li><strong>PR #134416</strong> <a href="https://github.com/openclaw/openclaw/pull/134416">fix: report declared configuration accurately in triage</a></li>
-<li><strong>PR #134261</strong> <a href="https://github.com/openclaw/openclaw/pull/134261">fix: keep retained inputs in transcript order</a> Thanks @VACInc.</li>
-<li><strong>PR #128050</strong> [feat(ui): send new-session drafts to background sessions \[AI-assisted\]](https://github.com/openclaw/openclaw/pull/128050) Related #128037. Thanks @Takhoffman.</li>
-<li><strong>PR #134415</strong> <a href="https://github.com/openclaw/openclaw/pull/134415">refactor: consolidate upgrade recovery ownership</a></li>
-<li><strong>PR #134418</strong> <a href="https://github.com/openclaw/openclaw/pull/134418">fix: keep inactive channel credentials out of inspection</a></li>
-<li><strong>PR #134212</strong> <a href="https://github.com/openclaw/openclaw/pull/134212">fix(cli): stop advertising the inert message read --include-thread flag</a> Thanks @marmar9615-cloud.</li>
-<li><strong>PR #134370</strong> <a href="https://github.com/openclaw/openclaw/pull/134370">test: unmask native link routing and disposal assertions</a></li>
-<li><strong>PR #134395</strong> <a href="https://github.com/openclaw/openclaw/pull/134395">fix: reduce Gateway memory for session lists and cleanup</a></li>
-<li><strong>PR #134381</strong> <a href="https://github.com/openclaw/openclaw/pull/134381">fix(gateway): stop outbound retry admission during shutdown</a> Related #127260. Thanks @VACInc.</li>
-<li><strong>PR #133996</strong> <a href="https://github.com/openclaw/openclaw/pull/133996">fix(agents): expire poll vote echo at TTL</a> Thanks @qingminglong.</li>
-<li><strong>PR #134387</strong> <a href="https://github.com/openclaw/openclaw/pull/134387">refactor: simplify terminal regression fixtures</a></li>
-<li><strong>PR #134417</strong> <a href="https://github.com/openclaw/openclaw/pull/134417">test: keep transient lifecycle markers out of Git fixtures</a></li>
-<li><strong>PR #134441</strong> <a href="https://github.com/openclaw/openclaw/pull/134441">test: seed legacy cron jobs after baseline configuration</a></li>
-<li><strong>PR #133980</strong> <a href="https://github.com/openclaw/openclaw/pull/133980">refactor: consolidate package inventory exclusions</a></li>
-<li><strong>PR #134436</strong> <a href="https://github.com/openclaw/openclaw/pull/134436">fix: CI watcher tests time out while loading fixture evidence</a></li>
-<li><strong>PR #133340</strong> <a href="https://github.com/openclaw/openclaw/pull/133340">fix(agents): reject bundle LSP calls after disposal</a> Thanks @qingminglong.</li>
-<li><strong>PR #134432</strong> <a href="https://github.com/openclaw/openclaw/pull/134432">fix(ui): center the sidebar account row in its footer band</a></li>
-<li><strong>PR #134422</strong> <a href="https://github.com/openclaw/openclaw/pull/134422">fix: release session check expects the retired Doctor backup</a></li>
-<li><strong>PR #134426</strong> <a href="https://github.com/openclaw/openclaw/pull/134426">fix(migrate-hermes): preserve source settings and activation policies</a></li>
-<li><strong>PR #134437</strong> <a href="https://github.com/openclaw/openclaw/pull/134437">fix(config): import shell keys from configured plugins</a></li>
-<li><strong>PR #134433</strong> <a href="https://github.com/openclaw/openclaw/pull/134433">perf: avoid unused system-event snapshots</a></li>
-<li><strong>PR #134424</strong> <a href="https://github.com/openclaw/openclaw/pull/134424">fix(test): avoid lingering CLI helper deadlines</a></li>
-<li><strong>PR #134435</strong> <a href="https://github.com/openclaw/openclaw/pull/134435">refactor(ui): finish the assistant dock rename and drop duplicate work</a></li>
-<li><strong>PR #132128</strong> <a href="https://github.com/openclaw/openclaw/pull/132128">fix: stale cloud workers no longer strand session results</a> Thanks @jalehman.</li>
-<li><strong>PR #134255</strong> <a href="https://github.com/openclaw/openclaw/pull/134255">refactor: use the shared Tavily response reader directly</a></li>
-<li><strong>PR #133596</strong> <a href="https://github.com/openclaw/openclaw/pull/133596">fix(auth): classify managed SecretRef API keys as static</a> Thanks @mateu and @Patrick-Erichsen.</li>
-<li><strong>PR #134038</strong> <a href="https://github.com/openclaw/openclaw/pull/134038">perf(ci): remove repeated setup and balance complete test workloads</a></li>
-<li><strong>PR #134452</strong> <a href="https://github.com/openclaw/openclaw/pull/134452">perf: skip discarded Readability HTML in text mode</a></li>
-<li><strong>PR #134429</strong> <a href="https://github.com/openclaw/openclaw/pull/134429">fix: release doctor database leases before gateway restart</a></li>
-<li><strong>PR #133925</strong> <a href="https://github.com/openclaw/openclaw/pull/133925">fix(sessions): refresh planner stats after bulk cleanup</a> Thanks @VACInc.</li>
-<li><strong>PR #134448</strong> <a href="https://github.com/openclaw/openclaw/pull/134448">fix(workers): avoid unrelated inspection and move cleanup during recovery</a></li>
-<li><strong>PR #133728</strong> <a href="https://github.com/openclaw/openclaw/pull/133728">fix: recover cloud sessions across restart and cancellation</a> Related #131713. Thanks @shakkernerd.</li>
-<li><strong>PR #134419</strong> <a href="https://github.com/openclaw/openclaw/pull/134419">refactor: reuse plugin model policies during Gateway requests</a></li>
-<li><strong>PR #134326</strong> <a href="https://github.com/openclaw/openclaw/pull/134326">perf(cloud): reuse worker archives from project snapshots</a></li>
-<li><strong>PR #133845</strong> <a href="https://github.com/openclaw/openclaw/pull/133845">fix(infra): preserve npm failure identity when subprocess produces no output</a> Related #127448. Thanks @aniruddhaadak80.</li>
-<li><strong>PR #134397</strong> <a href="https://github.com/openclaw/openclaw/pull/134397">fix(update): recover safely across channel and install switches</a></li>
-<li><strong>PR #134459</strong> <a href="https://github.com/openclaw/openclaw/pull/134459">perf(ci): overlap owned fixtures and refresh UI shard timings</a></li>
-<li><strong>PR #134428</strong> <a href="https://github.com/openclaw/openclaw/pull/134428">fix(process): preserve safe mixed-stream command diagnostics</a> Related #134427. Thanks @vincentkoc.</li>
-<li><strong>PR #134414</strong> <a href="https://github.com/openclaw/openclaw/pull/134414">perf(build): reuse staged SDK declarations across profiles</a></li>
-<li><strong>PR #134241</strong> [fix(browser): partition relay pre-auth admission \[AI\]](https://github.com/openclaw/openclaw/pull/134241) Thanks @mmaps.</li>
-<li><strong>PR #134291</strong> <a href="https://github.com/openclaw/openclaw/pull/134291">test: consolidate duplicate Windows runtime import coverage</a></li>
-<li><strong>PR #134410</strong> <a href="https://github.com/openclaw/openclaw/pull/134410">test: initialize upgrade baseline before legacy fixtures</a></li>
-<li><strong>PR #134090</strong> <a href="https://github.com/openclaw/openclaw/pull/134090">fix(cli): avoid unnecessary migrations on pristine startup</a></li>
-<li><strong>PR #134205</strong> <a href="https://github.com/openclaw/openclaw/pull/134205">refactor: remove catalog test-only URL re-exports</a></li>
-<li><strong>PR #134470</strong> <a href="https://github.com/openclaw/openclaw/pull/134470">fix(doctor): preserve updater restart ownership</a></li>
-<li><strong>PR #134474</strong> <a href="https://github.com/openclaw/openclaw/pull/134474">docs(ci): recover original PR runs before full dispatch</a></li>
-<li><strong>PR #133894</strong> <a href="https://github.com/openclaw/openclaw/pull/133894">test(tooling): assert benchmark arguments at worker launch</a></li>
-<li><strong>PR #134465</strong> <a href="https://github.com/openclaw/openclaw/pull/134465">perf: reuse prepared transcript projection queries</a></li>
-<li><strong>PR #134475</strong> <a href="https://github.com/openclaw/openclaw/pull/134475">fix(update): detect metadata-free npm installs</a> Related #134203. Thanks @Patrick-Erichsen and @vyctorbrzezowski.</li>
-<li><strong>PR #134464</strong> <a href="https://github.com/openclaw/openclaw/pull/134464">fix: report settled heartbeat cron outcomes</a> Related #134327. Thanks @fuller-stack-dev and @goslingmanagment.</li>
-<li><strong>PR #134449</strong> <a href="https://github.com/openclaw/openclaw/pull/134449">fix(ci): preserve oxlint shard success after graceful drain</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134476</strong> <a href="https://github.com/openclaw/openclaw/pull/134476">perf(ci): warm macOS dependencies and overlap signing fixtures</a></li>
-<li><strong>PR #134442</strong> <a href="https://github.com/openclaw/openclaw/pull/134442">test(e2e): preserve offline upgrade fixtures and restart proof</a></li>
-<li><strong>PR #134135</strong> <a href="https://github.com/openclaw/openclaw/pull/134135">test: tighten the default truncation boundary</a></li>
-<li><strong>PR #134059</strong> <a href="https://github.com/openclaw/openclaw/pull/134059">fix(chat): prevent retired prompts from reappearing</a></li>
-<li><strong>PR #134101</strong> <a href="https://github.com/openclaw/openclaw/pull/134101">fix(setup): restore runtime capability review</a> Thanks @VACInc.</li>
-<li><strong>PR #134314</strong> <a href="https://github.com/openclaw/openclaw/pull/134314">fix(acp): keep the selected agent through global session operations</a> Related #134313.</li>
-<li><strong>PR #134469</strong> <a href="https://github.com/openclaw/openclaw/pull/134469">fix(ci): stabilize macOS Codex queue deadline test</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134484</strong> <a href="https://github.com/openclaw/openclaw/pull/134484">fix(tooling): expose pako to linked worktrees</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134485</strong> <a href="https://github.com/openclaw/openclaw/pull/134485">test: exercise shared helper fixture contracts</a></li>
-<li><strong>PR #134481</strong> <a href="https://github.com/openclaw/openclaw/pull/134481">fix(tooling): use the pinned anchor component inventory</a></li>
-<li><strong>PR #134491</strong> <a href="https://github.com/openclaw/openclaw/pull/134491">test(codex): cover forced launcher cleanup</a></li>
-<li><strong>PR #133735</strong> <a href="https://github.com/openclaw/openclaw/pull/133735">fix: cancel cloud provisioning when stopping a worker</a></li>
-<li><strong>PR #133699</strong> <a href="https://github.com/openclaw/openclaw/pull/133699">fix(models): keep usage pricing on static model metadata</a></li>
-<li><strong>PR #134492</strong> <a href="https://github.com/openclaw/openclaw/pull/134492">chore(i18n): refresh native locales</a></li>
-<li><strong>PR #134489</strong> <a href="https://github.com/openclaw/openclaw/pull/134489">refactor: streamline agent database read admission</a></li>
-<li><strong>PR #134501</strong> <a href="https://github.com/openclaw/openclaw/pull/134501">perf(build): scope cache inventories to one checkout</a></li>
-<li><strong>PR #134493</strong> <a href="https://github.com/openclaw/openclaw/pull/134493">fix(ci): reuse Swift build caches and balance slow test groups</a></li>
-<li><strong>PR #134512</strong> <a href="https://github.com/openclaw/openclaw/pull/134512">docs: clarify mistaken 2026.9.1 beta publication</a> Thanks @hannesrudolph.</li>
-<li><strong>PR #134420</strong> <a href="https://github.com/openclaw/openclaw/pull/134420">fix(skills): keep release validation current and separate tooling failures</a> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134504</strong> <a href="https://github.com/openclaw/openclaw/pull/134504">fix(agents): keep model identity guidance conditional</a></li>
-<li><strong>PR #134503</strong> <a href="https://github.com/openclaw/openclaw/pull/134503">refactor(wizard): share migration path-entry check</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134505</strong> <a href="https://github.com/openclaw/openclaw/pull/134505">perf(ci): avoid duplicate local release package validation</a></li>
-<li><strong>PR #134511</strong> <a href="https://github.com/openclaw/openclaw/pull/134511">refactor(infra): share filesystem case probes</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134488</strong> <a href="https://github.com/openclaw/openclaw/pull/134488">perf(sessions): bound health and status session reads</a></li>
-<li><strong>PR #113517</strong> <a href="https://github.com/openclaw/openclaw/pull/113517">feat(approvals): add external verification contract</a> Thanks @Guardiola31337.</li>
-<li><strong>PR #134486</strong> <a href="https://github.com/openclaw/openclaw/pull/134486">perf: skip unused ordinary-table SQL normalization</a></li>
-<li><strong>PR #134529</strong> <a href="https://github.com/openclaw/openclaw/pull/134529">fix(build): bind declaration caches to plugin selection</a></li>
-<li><strong>PR #134518</strong> <a href="https://github.com/openclaw/openclaw/pull/134518">fix(release): recognize frozen subagent live-test opt-in</a> Thanks @RomneyDa.</li>
-<li><strong>PR #134513</strong> <a href="https://github.com/openclaw/openclaw/pull/134513">test: cover media aliases at their shared owner</a></li>
-<li><strong>PR #134451</strong> <a href="https://github.com/openclaw/openclaw/pull/134451">fix(markdown): preserve trailing inline-code whitespace</a> Related #134450.</li>
-<li><strong>PR #134074</strong> <a href="https://github.com/openclaw/openclaw/pull/134074">fix: macOS app relaunches normally after installation</a> Related #134034. Thanks @VACInc and @Sedrak-Hovhannisyan.</li>
-<li><strong>PR #134539</strong> <a href="https://github.com/openclaw/openclaw/pull/134539">test(outbound): reuse target normalization across registry lifecycles</a></li>
-<li><strong>PR #134526</strong> <a href="https://github.com/openclaw/openclaw/pull/134526">fix(e2e): let frozen candidates create the agents-delete roster</a> Thanks @RomneyDa.</li>
-<li><strong>PR #133772</strong> <a href="https://github.com/openclaw/openclaw/pull/133772">chore(deps): refresh eligible seven-day npm dependencies</a></li>
-<li><strong>PR #133651</strong> <a href="https://github.com/openclaw/openclaw/pull/133651">fix: reuse plugin metadata during prepared Gateway runs</a></li>
-<li><strong>PR #134535</strong> <a href="https://github.com/openclaw/openclaw/pull/134535">refactor(gateway): share loopback URL policy</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134545</strong> <a href="https://github.com/openclaw/openclaw/pull/134545">test(process): observe lane publication without timer flushing</a></li>
-<li><strong>PR #134528</strong> <a href="https://github.com/openclaw/openclaw/pull/134528">perf(ci): shard UI checks and reuse SDK compiler inputs</a></li>
-<li><strong>PR #134543</strong> <a href="https://github.com/openclaw/openclaw/pull/134543">test: batch Swift cache fixture timestamp setup</a></li>
-<li><strong>PR #134546</strong> <a href="https://github.com/openclaw/openclaw/pull/134546">test(nostr): consolidate key validation under its owner</a></li>
-<li><strong>PR #134551</strong> <a href="https://github.com/openclaw/openclaw/pull/134551">test(nostr): exercise the registered channel plugin</a></li>
-<li><strong>PR #134456</strong> <a href="https://github.com/openclaw/openclaw/pull/134456">fix(ui): remove retained-message inventory banner</a> Thanks @RomneyDa.</li>
-<li><strong>PR #134175</strong> <a href="https://github.com/openclaw/openclaw/pull/134175">refactor(plugins): use canonical command registry projections</a></li>
-<li><strong>PR #134540</strong> <a href="https://github.com/openclaw/openclaw/pull/134540">test(plugins): preserve agent identity in task cancellation</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134556</strong> <a href="https://github.com/openclaw/openclaw/pull/134556">test(ci): observe exact shard concurrency without timers</a></li>
-<li><strong>PR #133940</strong> <a href="https://github.com/openclaw/openclaw/pull/133940">docs(cli): list fleet in CLI command index</a> Thanks @qingminglong.</li>
-<li><strong>PR #132683</strong> <a href="https://github.com/openclaw/openclaw/pull/132683">improve(ios): align composer controls with WebUI</a> Thanks @Solvely-Colin.</li>
-<li><strong>PR #134567</strong> <a href="https://github.com/openclaw/openclaw/pull/134567">chore(ui): refresh control ui locales</a></li>
-<li><strong>PR #134523</strong> <a href="https://github.com/openclaw/openclaw/pull/134523">ci: reuse Watch build products and repair process cleanup</a></li>
-<li><strong>PR #134388</strong> <a href="https://github.com/openclaw/openclaw/pull/134388">fix(install): keep dry runs from downloading gum</a> Thanks @ly85206559.</li>
-<li><strong>PR #134561</strong> <a href="https://github.com/openclaw/openclaw/pull/134561">fix(export): honor hidden messages in HTML conversations</a></li>
-<li><strong>PR #134563</strong> <a href="https://github.com/openclaw/openclaw/pull/134563">test(ci): validate timing fields through the schema owner</a></li>
-<li><strong>PR #134565</strong> <a href="https://github.com/openclaw/openclaw/pull/134565">test: check changed-bench arguments through the parser owner</a></li>
-<li><strong>PR #134578</strong> <a href="https://github.com/openclaw/openclaw/pull/134578">test(flows): load provider flow owners once per suite</a></li>
-<li><strong>PR #134225</strong> <a href="https://github.com/openclaw/openclaw/pull/134225">fix(ui): include job name in Cron row action aria-labels</a> Related #127330. Thanks @SunnyShu0925.</li>
-<li><strong>PR #134564</strong> <a href="https://github.com/openclaw/openclaw/pull/134564">fix: keep channel sends on the selected plugin</a></li>
-<li><strong>PR #134538</strong> <a href="https://github.com/openclaw/openclaw/pull/134538">perf(build): keep boundary caches scoped to one checkout</a></li>
-<li><strong>PR #134106</strong> <a href="https://github.com/openclaw/openclaw/pull/134106">fix(memory): preserve vector worker stderr</a> Thanks @klabir.</li>
-<li><strong>PR #134574</strong> <a href="https://github.com/openclaw/openclaw/pull/134574">docs: clarify configured media fallback selection</a></li>
-<li><strong>PR #134380</strong> <a href="https://github.com/openclaw/openclaw/pull/134380">fix(macos): let stalled provider sign-in exit</a> Related #134347. Thanks @VACInc and @Sedrak-Hovhannisyan.</li>
-<li><strong>PR #134583</strong> <a href="https://github.com/openclaw/openclaw/pull/134583">test(process): reuse supervisor factories across fresh instances</a></li>
-<li><strong>PR #134580</strong> <a href="https://github.com/openclaw/openclaw/pull/134580">test(gateway): prove live compaction pressure and replay contracts</a></li>
-<li><strong>PR #134562</strong> <a href="https://github.com/openclaw/openclaw/pull/134562">fix(memory): preserve abort errors with native response streams</a></li>
-<li><strong>PR #134242</strong> <a href="https://github.com/openclaw/openclaw/pull/134242">fix(slack): honor the configured image downscale limit on downloadFile</a> Thanks @marmar9615-cloud.</li>
-<li><strong>PR #84595</strong> <a href="https://github.com/openclaw/openclaw/pull/84595">fix(browser): honor image sanitization config for screenshots</a> Historical precedent referenced by #134242; already shipped in an earlier release. Thanks @xx205 and @marmar9615-cloud.</li>
-<li><strong>PR #134591</strong> <a href="https://github.com/openclaw/openclaw/pull/134591">fix(ui): stop the Home work snapshot from titling the conversation</a></li>
-<li><strong>PR #133465</strong> <a href="https://github.com/openclaw/openclaw/pull/133465">fix(ui): prevent typing lag in long chat transcripts</a> Thanks @VACInc.</li>
-<li><strong>PR #134285</strong> <a href="https://github.com/openclaw/openclaw/pull/134285">test(ios): remove duplicated Watch source guards</a> Thanks @RomneyDa.</li>
-<li><strong>PR #134534</strong> <a href="https://github.com/openclaw/openclaw/pull/134534">fix(logs): JSON error summaries hide the actual failure reason</a> Related #134533.</li>
-<li><strong>PR #134596</strong> <a href="https://github.com/openclaw/openclaw/pull/134596">improve(ui): simplify chat selection popup</a> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134592</strong> <a href="https://github.com/openclaw/openclaw/pull/134592">fix(release): validate frozen packages with bundled activation fixtures</a></li>
-<li><strong>PR #133599</strong> <a href="https://github.com/openclaw/openclaw/pull/133599">fix(line): answer the directory with the peers and groups the config names</a> Related #133597. Thanks @edenfunf.</li>
-<li><strong>PR #134553</strong> <a href="https://github.com/openclaw/openclaw/pull/134553">test(providers): simplify model helper assertions</a></li>
-<li><strong>PR #134599</strong> <a href="https://github.com/openclaw/openclaw/pull/134599">test(plugin-sdk): clear the completed cancellation deadline</a></li>
-<li><strong>PR #134554</strong> <a href="https://github.com/openclaw/openclaw/pull/134554">fix: reduce Gateway memory during session lookup and cleanup</a></li>
-<li><strong>PR #134236</strong> <a href="https://github.com/openclaw/openclaw/pull/134236">fix(install): drop default npm --silent so EEXIST/ENOTEMPTY recovery sees the log (#134201)</a> Related #134201. Thanks @SunnyShu0925 and @mohamedelrefaiy.</li>
-<li><strong>PR #134602</strong> <a href="https://github.com/openclaw/openclaw/pull/134602">test(azure-speech): clear the socket-close observation timer</a></li>
-<li><strong>PR #133358</strong> <a href="https://github.com/openclaw/openclaw/pull/133358">fix(agents): retain grep matches with byte-form paths</a> Thanks @ly85206559.</li>
-<li><strong>PR #134050</strong> <a href="https://github.com/openclaw/openclaw/pull/134050">fix(gateway): keep plugin surfaces reachable over bracketed IPv6 hosts</a> Thanks @yangxiansheng.</li>
-<li><strong>PR #134606</strong> <a href="https://github.com/openclaw/openclaw/pull/134606">test(msteams): combine parent-context cache lifecycle phases</a></li>
-<li><strong>PR #134541</strong> <a href="https://github.com/openclaw/openclaw/pull/134541">perf(doctor): avoid loading unused plugin runtimes</a></li>
-<li><strong>PR #133783</strong> <a href="https://github.com/openclaw/openclaw/pull/133783">fix(tool-display): don't render shell redirects or <code>rg --files</code> as search targets</a> Thanks @darioandyoshi-tech.</li>
-<li><strong>PR #134571</strong> <a href="https://github.com/openclaw/openclaw/pull/134571">test(firecrawl): check the complete count diagnostic</a></li>
-<li><strong>PR #134609</strong> <a href="https://github.com/openclaw/openclaw/pull/134609">test(media): reuse the stateless provider registry graph</a></li>
-<li><strong>PR #134521</strong> <a href="https://github.com/openclaw/openclaw/pull/134521">fix: retain the selected simple-completion transport</a></li>
-<li><strong>PR #134569</strong> <a href="https://github.com/openclaw/openclaw/pull/134569">test(minimax): clear OAuth observation deadlines</a></li>
-<li><strong>PR #134618</strong> <a href="https://github.com/openclaw/openclaw/pull/134618">test(memory): remove retired inline deduplication copies</a></li>
-<li><strong>PR #134600</strong> <a href="https://github.com/openclaw/openclaw/pull/134600">chore(ui): refresh control ui locales</a></li>
-<li><strong>PR #134463</strong> <a href="https://github.com/openclaw/openclaw/pull/134463">fix(models): pair full catalog with native auth</a> Related #134325. Thanks @fuller-stack-dev and @goslingmanagment.</li>
-<li><strong>PR #134597</strong> <a href="https://github.com/openclaw/openclaw/pull/134597">refactor(audit): share execution identity ordering</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134582</strong> <a href="https://github.com/openclaw/openclaw/pull/134582">refactor(claws): share path containment policy</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134620</strong> <a href="https://github.com/openclaw/openclaw/pull/134620">test(release): use native checksums in ZIP fixtures</a></li>
-<li><strong>PR #134566</strong> <a href="https://github.com/openclaw/openclaw/pull/134566">fix(update): preserve automatic update policy and outcomes</a></li>
-<li><strong>PR #134594</strong> <a href="https://github.com/openclaw/openclaw/pull/134594">fix(control-ui): keep loading model picker beside microphone</a> Thanks @Patrick-Erichsen.</li>
-<li><strong>PR #134611</strong> <a href="https://github.com/openclaw/openclaw/pull/134611">test(changelog): remove fixture-only Git config processes</a></li>
-<li><strong>PR #134623</strong> <a href="https://github.com/openclaw/openclaw/pull/134623">test(build): share the native cache invalidation baseline</a></li>
-<li><strong>PR #134628</strong> <a href="https://github.com/openclaw/openclaw/pull/134628">test(docker): precompute artifact fixture image identities</a></li>
-<li><strong>PR #134577</strong> <a href="https://github.com/openclaw/openclaw/pull/134577">fix(migrations): reject empty unexpected JSON fields</a> Thanks @vincentkoc.</li>
-<li><strong>PR #134482</strong> <a href="https://github.com/openclaw/openclaw/pull/134482">fix(gateway): scrub legacy systemd version metadata on safe restart</a> Related #134202. Thanks @Patrick-Erichsen and @vyctorbrzezowski.</li>
-<li><strong>PR #134629</strong> <a href="https://github.com/openclaw/openclaw/pull/134629">fix(release): run frozen package checks from trusted sparse tooling</a></li>
-<li><strong>PR #134635</strong> <a href="https://github.com/openclaw/openclaw/pull/134635">test(openai): signal transcription socket creation and own cleanup</a></li>
-<li><strong>PR #134640</strong> <a href="https://github.com/openclaw/openclaw/pull/134640">refactor(migrate-hermes): consolidate provider and config plumbing</a></li>
-<li><strong>PR #134624</strong> <a href="https://github.com/openclaw/openclaw/pull/134624">test(memory): remove duplicate nested batch error case</a></li>
-<li><strong>PR #134870</strong> <a href="https://github.com/openclaw/openclaw/pull/134870">fix(release): restore evidence reuse and reconcile advisory ranges</a></li>
-</ul>
-<p><a href="https://github.com/openclaw/openclaw/blob/main/CHANGELOG.md">View full changelog</a></p>
-]]></description>
-            <enclosure url="https://github.com/openclaw/openclaw/releases/download/v2026.8.2/OpenClaw-2026.8.2.zip" length="747814779" type="application/octet-stream" sparkle:edSignature="NQJ4/xvxHfe9s1EVqaPyA/jFQJVfl6ByyC7N4gFgYGTUhhLFyC+L9H3q6csx++Cg3R0uzgZ5Foz9WYWCi9UXAg=="/>
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Mac users are still offered 2026.9.2 through automatic updates after the 2026.9.3 installers have been published.

## Why This Change Was Made

Publish the signed Sparkle feed generated from the exact released source, `1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7`. The new entry points to the existing 2026.9.3 ZIP with build `2609000390`. Sparkle's normal three-version retention keeps 2026.9.2 and 2026.9.1 and ages out 2026.8.2.

## User Impact

The Mac updater can discover and verify 2026.9.3. Existing published installers are reused; this changes only the feed.

## Evidence

- [Published release and native downloads](https://github.com/openclaw/openclaw/releases/tag/v2026.9.3).
- [Public release handoff passed](https://github.com/openclaw/openclaw/actions/runs/34210241995) on the exact released source.
- ZIP, DMG, and dSYM asset sizes and GitHub SHA256 digests match the verified signed/notarized artifacts.
- The ZIP is 592452637 bytes, SHA256 `55178e580fdc4d9e8536e1e08e0ec6a00720ecc17aa51a857db2b6119791a2e5`.
- Appcast version, build, download URL and length match that ZIP. Its Ed25519 signature verifies cryptographically against the public key embedded in the signed app.

<details>
<summary>Additional instructions</summary>
This same-repository branch is editable by repository maintainers. The changelog is already finalized in the published release.
</details>
