### PR TITLE
refactor(sessions): share bounded session selection

### DIFF
--- a/src/commands/sessions.ts
+++ b/src/commands/sessions.ts
@@ -37,6 +37,7 @@ import { type RuntimeEnv, writeRuntimeJson } from "../runtime.js";
 import { classifySessionKind, type SessionKind } from "../sessions/classify-session-kind.js";
 import { isAcpSessionKey } from "../sessions/session-key-utils.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
+import { sortAndLimitBy } from "../shared/sort-and-limit.js";
 import { resolveAgentRuntimeLabel } from "../status/agent-runtime-label.js";
 import {
   deliveryContextFromSession,
@@ -75,7 +76,6 @@ type SessionRow = SessionDisplayRow & {
 type SessionCandidate = { agentId: string; entry: SessionEntry; sessionKey: string };
 
 const DEFAULT_SESSIONS_LIMIT = 100;
-const TOP_N_SELECTION_LIMIT = 200;
 const contextLookupRuntimeLoader = createLazyImportLoader(() => import("../agents/context.js"));
 
 const formatKTokens = (value: number) => `${(value / 1000).toFixed(value >= 10_000 ? 0 : 1)}k`;
@@ -95,35 +95,6 @@ function applyAcpModelOverlayIfNeeded(
 
 function compareSessionRowsByUpdatedAt(a: SessionCandidate, b: SessionCandidate): number {
   return (b.entry.updatedAt ?? 0) - (a.entry.updatedAt ?? 0);
-}
-
-function selectNewestSessionRows(
-  rows: SessionCandidate[],
-  limit: number | undefined,
-): SessionCandidate[] {
-  if (limit === undefined) {
-    return rows.toSorted(compareSessionRowsByUpdatedAt);
-  }
-  if (limit > TOP_N_SELECTION_LIMIT) {
-    return rows.toSorted(compareSessionRowsByUpdatedAt).slice(0, limit);
-  }
-  // For small limits, keep only the top N rows without sorting the full store;
-  // large limits use the simpler full sort above.
-  const selected: SessionCandidate[] = [];
-  for (const row of rows) {
-    const insertAt = selected.findIndex(
-      (candidate) => compareSessionRowsByUpdatedAt(row, candidate) < 0,
-    );
-    if (insertAt >= 0) {
-      selected.splice(insertAt, 0, row);
-      if (selected.length > limit) {
-        selected.pop();
-      }
-    } else if (selected.length < limit) {
-      selected.push(row);
-    }
-  }
-  return selected;
 }
 
 function parseSessionsLimit(value: string | number | undefined): number | undefined | null {
@@ -351,7 +322,7 @@ export async function sessionsCommand(
       .map(({ sessionKey, entry }) => ({ agentId: target.agentId, entry, sessionKey }));
   });
   const totalCount = allEntries.length;
-  const sessionEntries = selectNewestSessionRows(allEntries, limit).map(
+  const sessionEntries = sortAndLimitBy(allEntries, limit, compareSessionRowsByUpdatedAt).map(
     ({ agentId: storeAgentId, entry, sessionKey }) => {
       const row = toSessionDisplayRow(sessionKey, entry);
       const agentId = parseAgentSessionKey(row.key)?.agentId ?? storeAgentId;

--- a/src/gateway/session-list-order.ts
+++ b/src/gateway/session-list-order.ts
@@ -3,8 +3,7 @@
 import type { SessionsListParams } from "../../packages/gateway-protocol/src/index.js";
 import { isPinnableSessionEntry } from "../config/sessions/session-pin-policy.js";
 import type { SessionEntry } from "../config/sessions/types.js";
-
-const SESSIONS_LIST_TOP_N_LIMIT = 200;
+import { sortAndLimitBy } from "../shared/sort-and-limit.js";
 
 export type SessionEntryPair = [string, SessionEntry];
 
@@ -32,44 +31,10 @@ function compareSessionEntryPairs(
   return a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0;
 }
 
-function selectNewestLimitedEntries(
-  entries: SessionEntryPair[],
-  limit: number,
-  sortBy: SessionsListParams["sortBy"],
-): SessionEntryPair[] {
-  const selected: SessionEntryPair[] = [];
-  for (const entry of entries) {
-    const first = selected[0];
-    const beforeFirst = first && compareSessionEntryPairs(entry, first, sortBy) < 0;
-    const worst = selected[limit - 1];
-    if (!beforeFirst && worst && compareSessionEntryPairs(entry, worst, sortBy) >= 0) {
-      continue;
-    }
-    const insertAt = beforeFirst
-      ? 0
-      : selected.findIndex(
-          (candidate, index) => index > 0 && compareSessionEntryPairs(entry, candidate, sortBy) < 0,
-        );
-    if (insertAt >= 0) {
-      selected.splice(insertAt, 0, entry);
-      if (selected.length > limit) {
-        selected.pop();
-      }
-    } else if (selected.length < limit) {
-      selected.push(entry);
-    }
-  }
-  return selected;
-}
-
 export function sortAndLimitSessionEntries(
   entries: SessionEntryPair[],
   limit: number | undefined,
   sortBy: SessionsListParams["sortBy"],
 ): SessionEntryPair[] {
-  if (limit !== undefined && limit <= SESSIONS_LIST_TOP_N_LIMIT) {
-    return selectNewestLimitedEntries(entries, limit, sortBy);
-  }
-  const sorted = entries.toSorted((a, b) => compareSessionEntryPairs(a, b, sortBy));
-  return limit === undefined ? sorted : sorted.slice(0, limit);
+  return sortAndLimitBy(entries, limit, (a, b) => compareSessionEntryPairs(a, b, sortBy));
 }

--- a/src/shared/sort-and-limit.ts
+++ b/src/shared/sort-and-limit.ts
@@ -1,0 +1,34 @@
+const TOP_N_LIMIT = 200;
+
+/** Stable bounded ordering; each caller owns its comparator and validated limit. */
+export function sortAndLimitBy<T extends object>(
+  entries: T[],
+  limit: number | undefined,
+  compare: (a: T, b: T) => number,
+): T[] {
+  if (limit !== undefined && limit <= TOP_N_LIMIT) {
+    const selected: T[] = [];
+    for (const entry of entries) {
+      const first = selected[0];
+      const beforeFirst = first && compare(entry, first) < 0;
+      const worst = selected[limit - 1];
+      if (!beforeFirst && worst && compare(entry, worst) >= 0) {
+        continue;
+      }
+      const insertAt = beforeFirst
+        ? 0
+        : selected.findIndex((candidate, index) => index > 0 && compare(entry, candidate) < 0);
+      if (insertAt >= 0) {
+        selected.splice(insertAt, 0, entry);
+        if (selected.length > limit) {
+          selected.pop();
+        }
+      } else if (selected.length < limit) {
+        selected.push(entry);
+      }
+    }
+    return selected;
+  }
+  const sorted = entries.toSorted(compare);
+  return limit === undefined ? sorted : sorted.slice(0, limit);
+}

--- a/src/status/summary.ts
+++ b/src/status/summary.ts
@@ -41,6 +41,7 @@ import {
 } from "../secrets/runtime-degraded-state.js";
 import { createLazyImportLoader } from "../shared/lazy-promise.js";
 import { createLazyRuntimeSurface } from "../shared/lazy-runtime.js";
+import { sortAndLimitBy } from "../shared/sort-and-limit.js";
 import {
   summarizeActionableTaskAuditFindings,
   summarizeRetainedLostTaskAuditFindings,
@@ -136,27 +137,6 @@ function compareSessionCandidatesByUpdatedAt(
   right: SessionEntrySummary,
 ) {
   return (right.entry.updatedAt ?? 0) - (left.entry.updatedAt ?? 0);
-}
-
-function selectRecentSessionCandidates(
-  candidates: SessionEntrySummary[],
-  limit: number,
-): SessionEntrySummary[] {
-  const selected: SessionEntrySummary[] = [];
-  for (const candidate of candidates) {
-    const insertAt = selected.findIndex(
-      (selectedCandidate) => compareSessionCandidatesByUpdatedAt(candidate, selectedCandidate) < 0,
-    );
-    if (insertAt >= 0) {
-      selected.splice(insertAt, 0, candidate);
-      if (selected.length > limit) {
-        selected.pop();
-      }
-    } else if (selected.length < limit) {
-      selected.push(candidate);
-    }
-  }
-  return selected;
 }
 
 async function prepareSessionStatusDetails(cfg: OpenClawConfig, now: number) {
@@ -519,7 +499,11 @@ export async function getStatusSummary(
   );
   const recent = sessionDetails
     ? await sessionDetails.buildSessionRows(
-        selectRecentSessionCandidates(sessionStores.recent, RECENT_SESSION_LIMIT),
+        sortAndLimitBy(
+          sessionStores.recent,
+          RECENT_SESSION_LIMIT,
+          compareSessionCandidatesByUpdatedAt,
+        ),
       )
     : [];
   const hostDesktopStatus =


### PR DESCRIPTION
Closes #142238

## What Problem This Solves

CLI session listings, cross-store status summaries and Gateway session paging each maintained a bounded insertion selector. This maintainer-requested cleanup removes the three copies so fixes to the selection algorithm have one owner.

## Why This Change Was Made

One import-free helper now implements bounded selection and the existing stable full-sort fallback. Each caller retains its comparator: CLI and status preserve incoming order for timestamp ties, while Gateway retains pin, selected-clock and key ordering. The complete change removes 42 production code lines, including the new helper and all caller adaptations.

Related: #117040 proposes broader SQLite-backed list selection and may later retire the Gateway wrapper. CLI and status remain consumers of this shared helper. No schema, index or query changes from that proposal are included here.

## User Impact

No intended behavior change. Existing limits, paging, row identity, visibility, storage selection, enrichment and response formats are preserved. Tests and public APIs are unchanged.

## Evidence

- The same 13 owner/sibling suites pass before and after: 404 tests covering CLI limits and cross-store ties, status hydration/read-only behavior, and Gateway pinning, paging and visibility.
- 52,903 exact selector comparisons cover permutations, stable ties, the 200/201 threshold, unbounded selection, finite timestamp subtraction overflow and existing Gateway non-finite comparison behavior. The harness compares immutable original selector bodies with the actual shared/Gateway exports; public caller composition is covered by the suites above.
- All 28 selected changed-gate stages pass, including core/test typechecks, lint, unused-export and import-cycle checks. Fresh independent review has no actionable findings.
- A standalone native Node import resolves only the new helper. No full build or live-service run was needed for this import-light internal change.
