### PR TITLE
fix(ui): keep menu hover colors consistent across themes

### DIFF
--- a/ui/src/components/menu-surface.browser.test.ts
+++ b/ui/src/components/menu-surface.browser.test.ts
@@ -1,4 +1,10 @@
+import { html, render } from "lit";
 import { afterEach, describe, expect, it } from "vitest";
+import "@awesome.me/webawesome/dist/styles/themes/default.css";
+import { renderComposerLibraryMenu } from "../pages/chat/components/chat-composer-library-menu.ts";
+import { renderChatComposerPlusMenu } from "../pages/chat/components/chat-composer-plus-menu.ts";
+import "../pages/chat/components/browser-tab-card.ts";
+import { renderComposerMenuOption } from "./composer-menu.ts";
 import "../test-helpers/load-styles.ts";
 import "./menu-surface.ts";
 import "./resizable-divider.ts";
@@ -15,9 +21,23 @@ import "./web-awesome.ts";
 // which has neither the Popover API nor real layout; the paint-order
 // assertions only mean anything in the Chromium lane, so skip elsewhere.
 const hasPopoverApi = typeof HTMLElement.prototype.showPopover === "function";
+const originalTheme = document.documentElement.getAttribute("data-theme");
+const originalThemeMode = document.documentElement.getAttribute("data-theme-mode");
+const originalClasses = document.documentElement.className;
 
 afterEach(() => {
   document.body.replaceChildren();
+  if (originalTheme === null) {
+    document.documentElement.removeAttribute("data-theme");
+  } else {
+    document.documentElement.setAttribute("data-theme", originalTheme);
+  }
+  if (originalThemeMode === null) {
+    document.documentElement.removeAttribute("data-theme-mode");
+  } else {
+    document.documentElement.setAttribute("data-theme-mode", originalThemeMode);
+  }
+  document.documentElement.className = originalClasses;
 });
 
 // The default browser-lane viewport (414px) triggers the mobile drawer
@@ -169,6 +189,8 @@ describe.skipIf(!hasPopoverApi)("agent picker surface", () => {
 
 describe.skipIf(!hasPopoverApi)("submenu parent highlight", () => {
   it.each([
+    ["", "keyboard"],
+    ["", "pointer"],
     ["session-menu__item", "keyboard"],
     ["session-menu__item", "pointer"],
     ["sidebar-customize-menu__item", "keyboard"],
@@ -220,4 +242,190 @@ describe.skipIf(!hasPopoverApi)("submenu parent highlight", () => {
     await expect.poll(() => parent.matches(":hover")).toBe(false);
     await expect.poll(() => getComputedStyle(parent).backgroundColor).toBe("rgba(0, 0, 0, 0)");
   });
+});
+
+describe.skipIf(!hasPopoverApi)("platform menu hover", () => {
+  function useTheme(theme: "dark" | "light") {
+    document.documentElement.dataset.theme = theme;
+    document.documentElement.dataset.themeMode = theme;
+    document.documentElement.classList.toggle("wa-dark", theme === "dark");
+    document.documentElement.classList.toggle("wa-light", theme === "light");
+    const swatch = document.createElement("div");
+    swatch.style.backgroundColor = "var(--bg-hover)";
+    document.body.append(swatch);
+    return getComputedStyle(swatch).backgroundColor;
+  }
+
+  async function hoverBackground(element: HTMLElement, expected: string) {
+    const { page } = await import("vitest/browser");
+    await page.elementLocator(element).hover();
+    await expect.poll(() => getComputedStyle(element).backgroundColor).toBe(expected);
+  }
+
+  it.each(["dark", "light"] as const)(
+    "matches attachment and capability actions in %s mode",
+    async (theme) => {
+      await useDesktopViewport();
+      const highlight = useTheme(theme);
+      const host = document.createElement("div");
+      host.style.padding = "400px 40px 0";
+      document.body.append(host);
+      render(
+        renderChatComposerPlusMenu({
+          attachments: {},
+          disabled: false,
+          open: false,
+          view: "root",
+          toolOverrides: null,
+          onOpenChange: () => {},
+          onViewChange: () => {},
+          capabilityMenu: {
+            basePath: "",
+            skills: [],
+            skillsLoading: false,
+            skillsError: false,
+            mcpServers: [],
+            toolsEffectiveResult: null,
+            toolsEffectiveLoading: false,
+            toolsEffectiveError: false,
+            toolAccessMutationBlockedReason: null,
+            webSearchBaseEnabled: true,
+            mutationBlockedReason: null,
+            canAdmin: true,
+            adminBlockedReason: null,
+            onLoadSkills: () => {},
+            onPatchToolOverrides: () => {},
+            onNavigate: () => {},
+          },
+        }),
+        host,
+      );
+      const { page } = await import("vitest/browser");
+      await page.elementLocator(host.querySelector<HTMLElement>('[slot="trigger"]')!).click();
+      const photo = host.querySelector<HTMLElement>('wa-dropdown-item[value="photo"]')!;
+      const skills = host.querySelector<HTMLElement>('wa-dropdown-item[value="open-skills"]')!;
+      await hoverBackground(photo, highlight);
+      const attachmentHover = getComputedStyle(photo).backgroundColor;
+      await hoverBackground(skills, attachmentHover);
+    },
+  );
+
+  it.each(["dark", "light"] as const)(
+    "uses platform hover for library actions in %s mode",
+    async (theme) => {
+      await useDesktopViewport();
+      const highlight = useTheme(theme);
+      const host = document.createElement("div");
+      document.body.append(host);
+      const { page } = await import("vitest/browser");
+      render(
+        html`<wa-dropdown>
+          <button slot="trigger">Library</button>
+          ${renderComposerLibraryMenu({
+            result: null,
+            loading: false,
+            busy: false,
+            error: "Library unavailable",
+            notice: null,
+            canWrite: false,
+            onReload: () => {},
+            onRead: () => {},
+            onActivate: () => {},
+          })}
+        </wa-dropdown>`,
+        host,
+      );
+      await page.elementLocator(host.querySelector<HTMLElement>('[slot="trigger"]')!).click();
+      await hoverBackground(
+        host.querySelector<HTMLElement>('[value="library-reload"]')!,
+        highlight,
+      );
+    },
+  );
+
+  it.each(["dark", "light"] as const)(
+    "reaches browser-card shadow menus in %s mode",
+    async (theme) => {
+      await useDesktopViewport();
+      const highlight = useTheme(theme);
+      const card = document.createElement("openclaw-browser-tab-card");
+      card.preview = {
+        kind: "browser-tab",
+        target: "host",
+        profile: "managed",
+        targetId: "tab-1",
+        url: "https://example.test/page",
+        title: "Example page",
+      };
+      document.body.append(card);
+      await card.updateComplete;
+      const { page } = await import("vitest/browser");
+      await page
+        .elementLocator(card.shadowRoot!.querySelector<HTMLElement>('[slot="trigger"]')!)
+        .click();
+      await hoverBackground(
+        card.shadowRoot!.querySelector<HTMLElement>('[value="copy-url"]')!,
+        highlight,
+      );
+    },
+  );
+
+  it.each(["dark", "light"] as const)(
+    "uses platform hover for slash suggestions in %s mode",
+    async (theme) => {
+      await useDesktopViewport();
+      const highlight = useTheme(theme);
+      const host = document.createElement("div");
+      document.body.append(host);
+      render(
+        renderComposerMenuOption({
+          id: "hover-command",
+          active: false,
+          select: () => {},
+          hover: () => {},
+          icon: "",
+          name: "/help",
+          description: "Show commands",
+        }),
+        host,
+      );
+      await hoverBackground(host.querySelector<HTMLElement>('[role="option"]')!, highlight);
+    },
+  );
+
+  it.each(["dark", "light"] as const)(
+    "preserves disabled and danger states while neutral focus matches hover in %s mode",
+    async (theme) => {
+      await useDesktopViewport();
+      const highlight = useTheme(theme);
+      const host = document.createElement("div");
+      document.body.append(host);
+      render(
+        html`<wa-dropdown>
+          <button slot="trigger">Actions</button>
+          <wa-dropdown-item value="neutral">Open</wa-dropdown-item>
+          <wa-dropdown-item value="disabled" disabled>Unavailable</wa-dropdown-item>
+          <wa-dropdown-item value="danger" variant="danger">Delete</wa-dropdown-item>
+        </wa-dropdown>`,
+        host,
+      );
+      const { page, userEvent } = await import("vitest/browser");
+      const trigger = host.querySelector<HTMLElement>('[slot="trigger"]')!;
+      const neutral = host.querySelector<HTMLElement>('[value="neutral"]')!;
+      const disabled = host.querySelector<HTMLElement>('[value="disabled"]')!;
+      const danger = host.querySelector<HTMLElement>('[value="danger"]')!;
+      await page.elementLocator(trigger).click();
+      await userEvent.keyboard("{ArrowDown}");
+      await userEvent.keyboard("{Home}");
+      await expect.poll(() => document.activeElement).toBe(neutral);
+      await expect.poll(() => getComputedStyle(neutral).backgroundColor).toBe(highlight);
+      await hoverBackground(disabled, "rgba(0, 0, 0, 0)");
+      const dangerSwatch = document.createElement("div");
+      dangerSwatch.style.backgroundColor = "var(--wa-color-danger-fill-normal)";
+      danger.append(dangerSwatch);
+      const dangerHighlight = getComputedStyle(dangerSwatch).backgroundColor;
+      expect(dangerHighlight).not.toBe(highlight);
+      await hoverBackground(danger, dangerHighlight);
+    },
+  );
 });

--- a/ui/src/pages/chat/components/browser-tab-card.ts
+++ b/ui/src/pages/chat/components/browser-tab-card.ts
@@ -43,6 +43,10 @@ class OpenClawBrowserTabCard extends OpenClawLitElement {
       max-width: 320px;
       margin-block: 6px;
     }
+    /* Document menu styles cannot reach dropdown items inside this shadow root. */
+    wa-dropdown {
+      --wa-color-neutral-fill-normal: var(--bg-hover);
+    }
     .card {
       overflow: hidden;
       background: var(--card);

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -880,10 +880,13 @@ wa-switch {
   --wa-color-focus: var(--ring);
 }
 
-/* Web Awesome dropdown items ship `cursor: pointer` on their shadow host.
+/* Keep neutral menu hover, keyboard focus, and open submenus on the active theme.
+   Web Awesome dropdown items ship `cursor: pointer` on their shadow host.
    Document rules beat `:host`, so route them through the policy here — and
    re-add the disabled cue this override would otherwise clobber. */
 wa-dropdown-item {
+  --wa-color-neutral-fill-normal: var(--bg-hover);
+
   cursor: var(--cursor-action);
 }
 

--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -834,7 +834,6 @@
 }
 
 .agent-chat__capability-menu-item {
-  --wa-color-neutral-fill-normal: var(--bg-hover);
   --wa-color-text-normal: var(--text);
 
   display: flex;
@@ -1589,8 +1588,6 @@
 }
 
 .chat-talk-input-picker__item {
-  --wa-color-neutral-fill-normal: var(--bg-hover);
-
   min-height: var(--chat-composer-menu-row-height);
   padding: var(--chat-composer-menu-row-padding);
   border-radius: var(--chat-composer-menu-row-radius);
@@ -2204,7 +2201,7 @@
 
 .slash-menu-item:hover,
 .slash-menu-item--active {
-  background: color-mix(in srgb, var(--bg-hover) 84%, transparent);
+  background: var(--bg-hover);
 }
 
 .slash-menu-copy {
@@ -2856,8 +2853,6 @@
 }
 
 .chat-controls__permission-option {
-  --wa-color-neutral-fill-normal: var(--bg-hover);
-
   display: flex;
   align-items: center;
   gap: var(--chat-composer-menu-row-gap);

--- a/ui/src/styles/components.css
+++ b/ui/src/styles/components.css
@@ -3904,8 +3904,6 @@ td.data-table-key-col {
 }
 
 .agent-select__option {
-  --wa-color-neutral-fill-normal: var(--bg-hover);
-
   padding: 6px 8px;
   border-radius: var(--menu-item-radius);
   color: var(--text);

--- a/ui/src/styles/model-setup.css
+++ b/ui/src/styles/model-setup.css
@@ -334,8 +334,6 @@
 }
 
 .model-setup-provider-select__option {
-  --wa-color-neutral-fill-normal: var(--bg-hover);
-
   padding: 6px 8px;
   border-radius: var(--menu-item-radius);
   color: var(--text);

--- a/ui/src/test-helpers/lit-warnings.setup.ts
+++ b/ui/src/test-helpers/lit-warnings.setup.ts
@@ -49,7 +49,8 @@ if (typeof Element !== "undefined" && !("moveBefore" in Element.prototype)) {
 
 // JSDOM exposes partial ElementInternals. Web Awesome form controls require
 // the form-associated methods even when tests do not mount them in a form.
-if (typeof HTMLElement !== "undefined") {
+// Browser tests need native CustomStateSet so CSS :state() observes real state.
+if (typeof HTMLElement !== "undefined" && !("__vitest_browser__" in globalThis)) {
   Object.defineProperty(HTMLElement.prototype, "attachInternals", {
     configurable: true,
     value() {


### PR DESCRIPTION
Closes #142223

## What Problem This Solves

Fixes an issue where users hovering Take photo, Photo, or File in the chat composer's + menu see a blue-gray highlight that differs from Skills and Connectors. The same mismatch affects neutral actions in other Control UI dropdowns and slash suggestions.

## Why This Change Was Made

Both composer groups already use the same dropdown-item component. Only capability rows mapped its neutral fill to the platform's `--bg-hover`. Move that mapping to the shared dropdown-item owner and remove redundant feature mappings. Apply the same token inside the browser card's shadow boundary and remove the slash menu's transparent blend.

## User Impact

Attachment actions, library retry, queued-message actions, account choices, workspace/gateway/branch/panel actions, file-editor choices, dashboard menus, group defaults, device/secret actions, usage menus, and automation run menus now follow the active theme's neutral hover color. Skills remains the visual reference.

## Evidence

The main comparison shows Photo and the Skills reference in Absolutely dark and light. Click any image for its full size.

<table>
<tr><th>Item / theme</th><th>Before</th><th>After</th></tr>
<tr><td>Photo hover / dark</td><td><a href="https://github.com/user-attachments/assets/7e22b2de-6aa7-4ad4-bb91-9de31a51d06d"><img src="https://github.com/user-attachments/assets/7e22b2de-6aa7-4ad4-bb91-9de31a51d06d" width="480" alt="before: Photo hover, Absolutely dark" /></a></td><td><a href="https://github.com/user-attachments/assets/339958fb-ec6d-450a-8295-084449b1d351"><img src="https://github.com/user-attachments/assets/339958fb-ec6d-450a-8295-084449b1d351" width="480" alt="after: Photo hover, Absolutely dark" /></a></td></tr>
<tr><td>Skills hover (platform reference) / dark</td><td><a href="https://github.com/user-attachments/assets/1c183d52-b064-4930-b52c-6b044665273c"><img src="https://github.com/user-attachments/assets/1c183d52-b064-4930-b52c-6b044665273c" width="480" alt="before: Skills hover (platform reference), Absolutely dark" /></a></td><td><a href="https://github.com/user-attachments/assets/68ffed32-2318-4e80-af74-206b90206bc8"><img src="https://github.com/user-attachments/assets/68ffed32-2318-4e80-af74-206b90206bc8" width="480" alt="after: Skills hover (platform reference), Absolutely dark" /></a></td></tr>
<tr><td>Photo hover / light</td><td><a href="https://github.com/user-attachments/assets/5f783757-89db-49c8-a849-c099a47a11f9"><img src="https://github.com/user-attachments/assets/5f783757-89db-49c8-a849-c099a47a11f9" width="480" alt="before: Photo hover, Absolutely light" /></a></td><td><a href="https://github.com/user-attachments/assets/0841e0a2-5506-40d3-9eb3-f3add7e21e35"><img src="https://github.com/user-attachments/assets/0841e0a2-5506-40d3-9eb3-f3add7e21e35" width="480" alt="after: Photo hover, Absolutely light" /></a></td></tr>
<tr><td>Skills hover (platform reference) / light</td><td><a href="https://github.com/user-attachments/assets/200abd7c-0182-4787-8716-b2123b324134"><img src="https://github.com/user-attachments/assets/200abd7c-0182-4787-8716-b2123b324134" width="480" alt="before: Skills hover (platform reference), Absolutely light" /></a></td><td><a href="https://github.com/user-attachments/assets/76dbbfbb-cbd7-4f7b-acf0-5e691c3ed045"><img src="https://github.com/user-attachments/assets/76dbbfbb-cbd7-4f7b-acf0-5e691c3ed045" width="480" alt="after: Skills hover (platform reference), Absolutely light" /></a></td></tr>
</table>

The remaining 19 menu surfaces are grouped below, one contact image per theme. Each row compares the same crop before (left) and after (right).

<p><strong>Other menus: Absolutely dark</strong></p>
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td colspan="2"><a href="https://github.com/user-attachments/assets/c83ffa83-28ca-424d-a862-ad262a7311c7"><img src="https://github.com/user-attachments/assets/c83ffa83-28ca-424d-a862-ad262a7311c7" width="960" alt="Dark theme: 19 other menu comparisons, before on the left and after on the right" /></a></td></tr>
</table>

<p><strong>Other menus: Absolutely light</strong></p>
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td colspan="2"><a href="https://github.com/user-attachments/assets/077882e0-a5ff-48b9-a89d-03389f427171"><img src="https://github.com/user-attachments/assets/077882e0-a5ff-48b9-a89d-03389f427171" width="960" alt="Light theme: 19 other menu comparisons, before on the left and after on the right" /></a></td></tr>
</table>


- 80 focused browser tests passed across five files after the frozen-lockfile dependency refresh. Regression coverage exercises attachment versus Skills hover, library actions, browser-card shadow menus, slash suggestions, keyboard focus, submenu state, disabled rows, and destructive rows. The corrected setup preserves native browser custom states; the original production styles produced 12 expected failures.
- 42 inspected before/after pairs at 1440 × 900 cover dark and light modes. Every after capture matches the platform hover token. In the 28 isolated-menu pairs, all changed pixels lie within the hovered row.
- Actual composer flow: Take photo, Photo, and File open the corresponding input and show a removable synthetic attachment; Skills and Connectors open their views and return; Manage plugins navigates to Settings. Disabled Web search remains disabled.
- Changed-file checks: passed on `8f314b8fe195f2628e8827de1b1b0cf409715fc0` after `pnpm install --frozen-lockfile --prefer-offline`; manifests and lockfile unchanged. The focused browser proof passed 80 tests in five files with `OPENCLAW_VITEST_MAX_WORKERS=2`.

Focused test files: `menu-surface.browser.test.ts`, `web-awesome-dropdown.browser.test.ts`, `web-awesome-dropdown-owner.browser.test.ts`, `web-awesome-select.browser.test.ts`, and `select-picker.browser.test.ts`, using `ui/vitest.config.ts` with `OPENCLAW_VITEST_MAX_WORKERS=2`.

| Theme | Photo before | Skills reference / corrected after |
| --- | --- | --- |
| Absolutely dark | `rgb(47, 50, 63)` | `rgb(48, 47, 43)` |
| Absolutely light | `rgb(228, 229, 233)` | `rgb(237, 234, 224)` |

The composer, workspace, slash, usage, and device captures use the full application with synthetic Gateway data. Other captures mount the actual production renderer with its owner styles and synthetic state. Before captures use the original styles; after captures use this branch. Contact images combine matching crops of the inspected originals without redrawing their content.

- Diff cleanup and test-value audit: production remains +9/-11 before and after the pass. No unnecessary changes were found. Kept the rendered theme, shadow-root, keyboard/submenu, disabled and danger checks because they protect distinct behavior; original production failed 12 regression cases. No tests removed.

- Review disposition (latest review updated September 8, 2026, 15:12:41 UTC): the sole before-merge item, marking the draft ready, is complete. No code findings or rank-up moves were listed; no items were skipped.

- Hosted CI: [exact-head run passed](https://github.com/openclaw/openclaw/actions/runs/34246477343) for `8f314b8fe195f2628e8827de1b1b0cf409715fc0`; native prepare and merge completed with the same head.

**Risk and coverage**

The shared mapping affects neutral dropdown hover, keyboard focus, and open-submenu fill. Focus/submenu lifecycle and disabled/destructive state tests passed. Menu geometry, actions, and selected-state styling are preserved. Production changes total +9/−11 lines; test/support changes total +210/−1.

Separate follow-ups: the searchable Settings picker and sticky composer Back row lack pointer highlight feedback; the browser card's popup panel retains its existing stock surface palette. Pinned-skill actions already used the correct hover token. This proof uses synthetic data and does not exercise live providers or native camera hardware.
