### PR TITLE
refactor(tests): share API-key credential inputs

### DIFF
--- a/src/agents/auth-profiles/catalog-order.test.ts
+++ b/src/agents/auth-profiles/catalog-order.test.ts
@@ -4,6 +4,7 @@ import {
   createProviderApiKeyResolver,
   createProviderAuthResolver,
 } from "../models-config.providers.secrets.js";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import type { AuthProfileStore } from "./types.js";
 
 vi.mock("../provider-auth-aliases.js", () => ({
@@ -34,16 +35,8 @@ describe("provider catalog auth order", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        [profileA]: {
-          type: "api_key",
-          provider: "openai",
-          key: "key-a",
-        },
-        [profileB]: {
-          type: "api_key",
-          provider: "openai",
-          key: "key-b",
-        },
+        [profileA]: createApiKeyCredential("openai", "key-a"),
+        [profileB]: createApiKeyCredential("openai", "key-b"),
       },
     };
     const config: OpenClawConfig = {

--- a/src/agents/auth-profiles/credential-fixtures.test-support.ts
+++ b/src/agents/auth-profiles/credential-fixtures.test-support.ts
@@ -1,0 +1,6 @@
+export function createApiKeyCredential(
+  provider: string,
+  key: string,
+): { type: "api_key"; provider: string; key: string } {
+  return { type: "api_key", provider, key };
+}

--- a/src/agents/auth-profiles/external-oauth.test.ts
+++ b/src/agents/auth-profiles/external-oauth.test.ts
@@ -8,6 +8,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ProviderExternalAuthProfile } from "../../plugins/provider-external-auth.types.js";
 import { resolveAgentCredentialMapFromStore } from "../agent-auth-credentials.js";
 import { addEnvBackedAgentCredentials } from "../agent-auth-discovery-core.js";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import { overlayExternalAuthProfiles } from "./external-auth-runtime.js";
 import { syncPersistedExternalCliAuthProfiles } from "./external-auth.js";
 import { testing } from "./external-auth.test-support.js";
@@ -589,11 +590,7 @@ describe("auth external oauth helpers", () => {
 
     const overlaid = overlayExternalAuthProfiles(
       createStore({
-        "openai:default": {
-          type: "api_key",
-          provider: "openai",
-          key: "sk-local",
-        },
+        "openai:default": createApiKeyCredential("openai", "sk-local"),
       }),
     );
 

--- a/src/agents/auth-profiles/oauth-identity.test.ts
+++ b/src/agents/auth-profiles/oauth-identity.test.ts
@@ -5,6 +5,7 @@
  */
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it } from "vitest";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import {
   isSafeToCopyOAuthIdentity,
   normalizeAuthEmailToken,
@@ -258,11 +259,7 @@ describe("shouldMirrorRefreshedOAuthCredential", () => {
     },
     {
       name: "api key override",
-      existing: {
-        type: "api_key",
-        provider: "openai",
-        key: "operator-key",
-      },
+      existing: createApiKeyCredential("openai", "operator-key"),
       shouldMirror: false,
       reason: "non-oauth-existing-credential",
     },

--- a/src/agents/auth-profiles/oauth-shared.test.ts
+++ b/src/agents/auth-profiles/oauth-shared.test.ts
@@ -7,6 +7,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import {
   overlayRuntimeExternalOAuthProfiles,
   shouldReplaceStoredOAuthCredential,
@@ -19,11 +20,7 @@ describe("overlayRuntimeExternalOAuthProfiles", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "openai:default": {
-          type: "api_key",
-          provider: "openai",
-          key: "sk-test",
-        },
+        "openai:default": createApiKeyCredential("openai", "sk-test"),
       },
       order: {
         openai: ["openai:default"],

--- a/src/agents/auth-profiles/oauth.test.ts
+++ b/src/agents/auth-profiles/oauth.test.ts
@@ -8,6 +8,7 @@ import type { OpenClawConfig } from "../../config/config.js";
 import { resolveAuthProfileSecretOwnerId } from "../../secrets/runtime-auth-profile-owner.js";
 import { setActiveDegradedSecretOwners } from "../../secrets/runtime-degraded-state.js";
 import { withEnvAsync } from "../../test-utils/env.js";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import type { AuthProfileStore, RuntimeAuthProfileStore } from "./types.js";
 
 vi.hoisted(() => {
@@ -592,11 +593,7 @@ describe("resolveApiKeyForProfile secret refs", () => {
         store: {
           version: 1,
           profiles: {
-            [profileId]: {
-              type: "api_key",
-              provider: "openai",
-              key: "${OPENAI_API_KEY}",
-            },
+            [profileId]: createApiKeyCredential("openai", "${OPENAI_API_KEY}"),
           },
         },
         profileId,

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -10,6 +10,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
 import { isAmbientCredentialAllowedByProviderAuthPin } from "./ambient-auth.js";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import { saveAuthProfileStore } from "./store-runtime.js";
 import type { AuthProfileStore } from "./types.js";
 
@@ -67,11 +68,7 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "fixture-provider:default": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "sk-test",
-        },
+        "fixture-provider:default": createApiKeyCredential("fixture-provider", "sk-test"),
       },
     };
 
@@ -105,11 +102,7 @@ describe("resolveAuthProfileOrder", () => {
           refresh: "oauth-refresh",
           expires: Date.now() + 60_000,
         },
-        "fixture-provider:api-key": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "api-key",
-        },
+        "fixture-provider:api-key": createApiKeyCredential("fixture-provider", "api-key"),
       },
     };
 
@@ -177,16 +170,8 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "fixture-provider:primary": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "sk-primary",
-        },
-        "fixture-provider:secondary": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "sk-secondary",
-        },
+        "fixture-provider:primary": createApiKeyCredential("fixture-provider", "sk-primary"),
+        "fixture-provider:secondary": createApiKeyCredential("fixture-provider", "sk-secondary"),
       },
       order: {
         "fixture-provider": ["fixture-provider:secondary", "fixture-provider:primary"],
@@ -205,16 +190,8 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "fixture-provider:primary": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "sk-primary",
-        },
-        "fixture-provider:secondary": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "sk-secondary",
-        },
+        "fixture-provider:primary": createApiKeyCredential("fixture-provider", "sk-primary"),
+        "fixture-provider:secondary": createApiKeyCredential("fixture-provider", "sk-secondary"),
       },
       order: {
         "fixture-provider-plan": [],
@@ -234,16 +211,8 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "fixture-provider:primary": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "sk-primary",
-        },
-        "fixture-provider:secondary": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "sk-secondary",
-        },
+        "fixture-provider:primary": createApiKeyCredential("fixture-provider", "sk-primary"),
+        "fixture-provider:secondary": createApiKeyCredential("fixture-provider", "sk-secondary"),
       },
     };
 
@@ -267,11 +236,7 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "fixture-provider:primary": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "sk-primary",
-        },
+        "fixture-provider:primary": createApiKeyCredential("fixture-provider", "sk-primary"),
       },
     };
 
@@ -294,11 +259,7 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "fixture-provider:primary": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "sk-primary",
-        },
+        "fixture-provider:primary": createApiKeyCredential("fixture-provider", "sk-primary"),
       },
       order: {
         "fixture-provider": [],
@@ -324,11 +285,7 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "fixture-provider:key": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "sk-primary",
-        },
+        "fixture-provider:key": createApiKeyCredential("fixture-provider", "sk-primary"),
         "fixture-provider:oauth": {
           type: "oauth",
           provider: "fixture-provider",
@@ -427,11 +384,7 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "fixture-provider:primary": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "sk-primary",
-        },
+        "fixture-provider:primary": createApiKeyCredential("fixture-provider", "sk-primary"),
       },
     };
 
@@ -475,11 +428,7 @@ describe("resolveAuthProfileOrder", () => {
       store: {
         version: 1,
         profiles: {
-          "fixture-provider:primary": {
-            type: "api_key",
-            provider: "fixture-provider",
-            key: "sk-primary",
-          },
+          "fixture-provider:primary": createApiKeyCredential("fixture-provider", "sk-primary"),
         },
       },
       provider: "fixture-provider",
@@ -492,16 +441,8 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "fixture-provider:primary": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "sk-primary",
-        },
-        "fixture-provider:backup": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "sk-backup",
-        },
+        "fixture-provider:primary": createApiKeyCredential("fixture-provider", "sk-primary"),
+        "fixture-provider:backup": createApiKeyCredential("fixture-provider", "sk-backup"),
       },
       usageStats: {
         "fixture-provider:primary": {
@@ -541,16 +482,8 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "fixture-provider:primary": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "placeholder",
-        },
-        "fixture-provider:backup": {
-          type: "api_key",
-          provider: "fixture-provider",
-          key: "placeholder",
-        },
+        "fixture-provider:primary": createApiKeyCredential("fixture-provider", "placeholder"),
+        "fixture-provider:backup": createApiKeyCredential("fixture-provider", "placeholder"),
       },
       usageStats: {
         "fixture-provider:primary": {
@@ -630,16 +563,8 @@ describe("resolveAuthProfileOrder", () => {
           refresh: "refresh",
           expires: Date.now() + 60_000,
         },
-        "openai:backup": {
-          type: "api_key",
-          provider: "openai",
-          key: "sk-backup",
-        },
-        "openai:platform": {
-          type: "api_key",
-          provider: "openai",
-          key: "sk-platform",
-        },
+        "openai:backup": createApiKeyCredential("openai", "sk-backup"),
+        "openai:platform": createApiKeyCredential("openai", "sk-platform"),
       },
     };
 
@@ -669,11 +594,7 @@ describe("resolveAuthProfileOrder", () => {
           refresh: "refresh",
           expires: Date.now() + 60_000,
         },
-        "openai:backup": {
-          type: "api_key",
-          provider: "openai",
-          key: "sk-platform",
-        },
+        "openai:backup": createApiKeyCredential("openai", "sk-platform"),
         "openai:oauth": {
           type: "oauth",
           provider: "openai",
@@ -718,11 +639,7 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "openai:default": {
-          type: "api_key",
-          provider: "openai",
-          key: "sk-platform",
-        },
+        "openai:default": createApiKeyCredential("openai", "sk-platform"),
         "openai:personal": {
           type: "oauth",
           provider: "openai",
@@ -759,11 +676,7 @@ describe("resolveAuthProfileOrder", () => {
           refresh: "refresh",
           expires: Date.now() + 60_000,
         },
-        "openai:backup": {
-          type: "api_key",
-          provider: "openai",
-          key: "sk-platform",
-        },
+        "openai:backup": createApiKeyCredential("openai", "sk-platform"),
       },
     };
 
@@ -815,11 +728,7 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "openai:platform": {
-          type: "api_key",
-          provider: "openai",
-          key: "sk-platform",
-        },
+        "openai:platform": createApiKeyCredential("openai", "sk-platform"),
         "openai:work": {
           type: "oauth",
           provider: "openai",

--- a/src/agents/auth-profiles/persisted-boundary.test.ts
+++ b/src/agents/auth-profiles/persisted-boundary.test.ts
@@ -8,6 +8,7 @@ import os from "node:os";
 import path from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
 import { AUTH_STORE_VERSION } from "./constants.js";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import { resolveAuthProfileOrder } from "./order.js";
 import {
   applyLegacyAuthStore,
@@ -274,11 +275,7 @@ describe("persisted auth profile boundary", () => {
         runtimeExternalProfileIds: [],
         runtimeExternalProfileIdsAuthoritative: true,
         profiles: {
-          [profileId]: {
-            type: "api_key",
-            provider: "anthropic",
-            key: "sk-local",
-          },
+          [profileId]: createApiKeyCredential("anthropic", "sk-local"),
         },
         order: {
           anthropic: [profileId],
@@ -306,16 +303,8 @@ describe("persisted auth profile boundary", () => {
         version: AUTH_STORE_VERSION,
         runtimePersistedProfileIds: ["openai:base", "openai:overridden"],
         profiles: {
-          "openai:base": {
-            type: "api_key",
-            provider: "openai",
-            key: "base-key",
-          },
-          "openai:overridden": {
-            type: "api_key",
-            provider: "openai",
-            key: "old-key",
-          },
+          "openai:base": createApiKeyCredential("openai", "base-key"),
+          "openai:overridden": createApiKeyCredential("openai", "old-key"),
         },
       },
       {
@@ -323,16 +312,8 @@ describe("persisted auth profile boundary", () => {
         runtimePersistedProfileIds: ["openai:added"],
         runtimeLocalProfileIds: ["openai:added"],
         profiles: {
-          "openai:overridden": {
-            type: "api_key",
-            provider: "openai",
-            key: "scoped-key",
-          },
-          "openai:added": {
-            type: "api_key",
-            provider: "openai",
-            key: "added-key",
-          },
+          "openai:overridden": createApiKeyCredential("openai", "scoped-key"),
+          "openai:added": createApiKeyCredential("openai", "added-key"),
         },
       },
     );
@@ -446,11 +427,7 @@ describe("persisted auth profile boundary", () => {
       {
         version: AUTH_STORE_VERSION,
         profiles: {
-          "openai:main": {
-            type: "api_key",
-            provider: "OpenAI",
-            key: "main-key",
-          },
+          "openai:main": createApiKeyCredential("OpenAI", "main-key"),
         },
         order: {
           OpenAI: ["openai:main"],
@@ -459,16 +436,8 @@ describe("persisted auth profile boundary", () => {
       {
         version: AUTH_STORE_VERSION,
         profiles: {
-          "openai:agent": {
-            type: "api_key",
-            provider: "openai",
-            key: "agent-key",
-          },
-          "openai:other-agent": {
-            type: "api_key",
-            provider: "openai",
-            key: "other-agent-key",
-          },
+          "openai:agent": createApiKeyCredential("openai", "agent-key"),
+          "openai:other-agent": createApiKeyCredential("openai", "other-agent-key"),
         },
         order: {
           openai: ["openai:agent"],

--- a/src/agents/auth-profiles/portability.test.ts
+++ b/src/agents/auth-profiles/portability.test.ts
@@ -4,6 +4,7 @@
  * copy-to-agent opt-outs.
  */
 import { describe, expect, it } from "vitest";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import {
   buildPortableAuthProfileStoreForAgentCopy,
   resolveAuthProfilePortability,
@@ -15,11 +16,7 @@ describe("auth profile portability", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "openai:api-key": {
-          type: "api_key",
-          provider: "openai",
-          key: "sk-test",
-        },
+        "openai:api-key": createApiKeyCredential("openai", "sk-test"),
         "github-copilot:default": {
           type: "token",
           provider: "github-copilot",

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -16,6 +16,7 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { AUTH_STORE_VERSION } from "./constants.js";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import { testing as externalAuthTesting } from "./external-auth.test-support.js";
 import {
   getRuntimeAuthProfileStoreCredentialMutationToken,
@@ -160,16 +161,8 @@ describe("promoteAuthProfileInOrder", () => {
         const mainStore = (selected: string): AuthProfileStore => ({
           version: AUTH_STORE_VERSION,
           profiles: {
-            "openai:first": {
-              type: "api_key",
-              provider: "openai",
-              key: "sk-first",
-            },
-            "openai:second": {
-              type: "api_key",
-              provider: "openai",
-              key: "sk-second",
-            },
+            "openai:first": createApiKeyCredential("openai", "sk-first"),
+            "openai:second": createApiKeyCredential("openai", "sk-second"),
           },
           order: { openai: [selected] },
         });
@@ -352,11 +345,7 @@ describe("promoteAuthProfileInOrder", () => {
         const siblingStore: RuntimeAuthProfileStore = {
           version: AUTH_STORE_VERSION,
           profiles: {
-            "anthropic:sibling": {
-              type: "api_key",
-              provider: "anthropic",
-              key: "sk-sibling",
-            },
+            "anthropic:sibling": createApiKeyCredential("anthropic", "sk-sibling"),
           },
           runtimeLocalProfileIds: ["anthropic:sibling"],
         };
@@ -411,11 +400,7 @@ describe("promoteAuthProfileInOrder", () => {
           {
             version: AUTH_STORE_VERSION,
             profiles: {
-              "anthropic:broken": {
-                type: "api_key",
-                provider: "anthropic",
-                key: "sk-broken-local",
-              },
+              "anthropic:broken": createApiKeyCredential("anthropic", "sk-broken-local"),
             },
           },
           brokenAgentDir,
@@ -424,11 +409,7 @@ describe("promoteAuthProfileInOrder", () => {
           {
             version: AUTH_STORE_VERSION,
             profiles: {
-              "google:healthy": {
-                type: "api_key",
-                provider: "google",
-                key: "sk-healthy-local",
-              },
+              "google:healthy": createApiKeyCredential("google", "sk-healthy-local"),
             },
           },
           healthyAgentDir,
@@ -725,11 +706,7 @@ describe("promoteAuthProfileInOrder", () => {
         store: {
           version: AUTH_STORE_VERSION,
           profiles: {
-            "openai:temporary": {
-              type: "api_key",
-              provider: "openai",
-              key: "sk-temporary",
-            },
+            "openai:temporary": createApiKeyCredential("openai", "sk-temporary"),
           },
         },
       });
@@ -780,11 +757,7 @@ describe("promoteAuthProfileInOrder", () => {
           const baselineStore: AuthProfileStore = {
             version: AUTH_STORE_VERSION,
             profiles: {
-              "openai:baseline": {
-                type: "api_key",
-                provider: "openai",
-                key: "sk-baseline",
-              },
+              "openai:baseline": createApiKeyCredential("openai", "sk-baseline"),
               "anthropic:external": {
                 type: "oauth",
                 provider: "anthropic",
@@ -828,11 +801,7 @@ describe("promoteAuthProfileInOrder", () => {
             store: {
               version: AUTH_STORE_VERSION,
               profiles: {
-                "openai:temporary": {
-                  type: "api_key",
-                  provider: "openai",
-                  key: "sk-temporary",
-                },
+                "openai:temporary": createApiKeyCredential("openai", "sk-temporary"),
               },
             },
           });
@@ -905,11 +874,7 @@ describe("promoteAuthProfileInOrder", () => {
           store: {
             version: AUTH_STORE_VERSION,
             profiles: {
-              "openai:temporary": {
-                type: "api_key",
-                provider: "openai",
-                key: "sk-temporary",
-              },
+              "openai:temporary": createApiKeyCredential("openai", "sk-temporary"),
             },
           },
         });
@@ -981,11 +946,7 @@ describe("promoteAuthProfileInOrder", () => {
         saveAuthProfileStore({
           version: AUTH_STORE_VERSION,
           profiles: {
-            "openai:baseline": {
-              type: "api_key",
-              provider: "openai",
-              key: "sk-baseline",
-            },
+            "openai:baseline": createApiKeyCredential("openai", "sk-baseline"),
           },
         });
         const capturedRuntime = loadAuthProfileStoreForRuntime(derivedAgentDir);
@@ -998,11 +959,7 @@ describe("promoteAuthProfileInOrder", () => {
           store: {
             version: AUTH_STORE_VERSION,
             profiles: {
-              "openai:temporary": {
-                type: "api_key",
-                provider: "openai",
-                key: "sk-temporary",
-              },
+              "openai:temporary": createApiKeyCredential("openai", "sk-temporary"),
             },
           },
         });
@@ -1123,11 +1080,7 @@ describe("promoteAuthProfileInOrder", () => {
         });
         await upsertAuthProfileWithLock({
           profileId: "anthropic:key",
-          credential: {
-            type: "api_key",
-            provider: "anthropic",
-            key: "  sk-\r\nant\u2502  ",
-          },
+          credential: createApiKeyCredential("anthropic", "  sk-\r\nant\u2502  "),
           agentDir,
         });
 
@@ -1671,11 +1624,7 @@ describe("promoteAuthProfileInOrder", () => {
             refresh: "oauth-refresh",
             expires: Date.now() + 60_000,
           },
-          "openrouter:api-key": {
-            type: "api_key",
-            provider: "openrouter",
-            key: "api-key",
-          },
+          "openrouter:api-key": createApiKeyCredential("openrouter", "api-key"),
         },
         order: { openrouter: ["openrouter:oauth", "openrouter:api-key"] },
         lastGood: { openrouter: "openrouter:oauth" },
@@ -1736,11 +1685,7 @@ describe("promoteAuthProfileInOrder", () => {
       const initialStore: AuthProfileStore = {
         version: AUTH_STORE_VERSION,
         profiles: {
-          "openrouter:api-key": {
-            type: "api_key",
-            provider: "openrouter",
-            key: "api-key",
-          },
+          "openrouter:api-key": createApiKeyCredential("openrouter", "api-key"),
         },
       };
       saveAuthProfileStore(initialStore, agentDir);
@@ -2038,11 +1983,7 @@ describe("setAuthProfileOrder", () => {
         saveAuthProfileStore({
           version: AUTH_STORE_VERSION,
           profiles: {
-            "openai:local": {
-              type: "api_key",
-              provider: "openai",
-              key: "sk-local",
-            },
+            "openai:local": createApiKeyCredential("openai", "sk-local"),
           },
           order: { openai: ["openai:local"] },
         });

--- a/src/agents/auth-profiles/runtime-snapshots.test.ts
+++ b/src/agents/auth-profiles/runtime-snapshots.test.ts
@@ -7,6 +7,7 @@ import path from "node:path";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it, vi } from "vitest";
 import * as authProfileClone from "./clone.js";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import {
   getPreparedRuntimeAuthMaterializations,
   recordRuntimeAuthMaterialization,
@@ -384,11 +385,7 @@ describe("runtime auth profile snapshots", () => {
           ...createStore("inherited"),
           profiles: {
             ...createStore("inherited").profiles,
-            "anthropic:default": {
-              type: "api_key",
-              provider: "anthropic",
-              key: "inherited-key",
-            },
+            "anthropic:default": createApiKeyCredential("anthropic", "inherited-key"),
           },
         },
         inheritedAuthDir,

--- a/src/agents/auth-profiles/session-override.rotation.test.ts
+++ b/src/agents/auth-profiles/session-override.rotation.test.ts
@@ -1,6 +1,7 @@
 import fs from "node:fs/promises";
 import { describe, expect, it } from "vitest";
 import type { SessionEntry } from "../../config/sessions/types.js";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import {
   authStoreMocks,
   configureProviderRoutes,
@@ -27,16 +28,8 @@ function configureMixedOpenAiAuthStore(): void {
   authStoreMocks.state.store = {
     version: 1,
     profiles: {
-      [API_PRIMARY_PROFILE_ID]: {
-        type: "api_key",
-        provider: "openai",
-        key: "sk-primary",
-      },
-      [API_BACKUP_PROFILE_ID]: {
-        type: "api_key",
-        provider: "openai",
-        key: "sk-backup",
-      },
+      [API_PRIMARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-primary"),
+      [API_BACKUP_PROFILE_ID]: createApiKeyCredential("openai", "sk-backup"),
       [OAUTH_PROFILE_ID]: {
         type: "oauth",
         provider: "openai",
@@ -56,11 +49,7 @@ function configureAnthropicFallbackStore(): void {
   authStoreMocks.state.store = {
     version: 1,
     profiles: {
-      [ANTHROPIC_API_PROFILE_ID]: {
-        type: "api_key",
-        provider: "anthropic",
-        key: "sk-anthropic",
-      },
+      [ANTHROPIC_API_PROFILE_ID]: createApiKeyCredential("anthropic", "sk-anthropic"),
       [CLAUDE_CLI_PROFILE_ID]: {
         type: "oauth",
         provider: "claude-cli",

--- a/src/agents/auth-profiles/session-override.selection.test.ts
+++ b/src/agents/auth-profiles/session-override.selection.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import {
   authStoreMocks,
   createAuthStoreWithProfiles,
@@ -18,16 +19,8 @@ function configureProfiles(): void {
   authStoreMocks.state.hasSource = true;
   authStoreMocks.state.store = createAuthStoreWithProfiles({
     profiles: {
-      [TEST_PRIMARY_PROFILE_ID]: {
-        type: "api_key",
-        provider: "openai",
-        key: "sk-primary",
-      },
-      [TEST_SECONDARY_PROFILE_ID]: {
-        type: "api_key",
-        provider: "openai",
-        key: "sk-secondary",
-      },
+      [TEST_PRIMARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-primary"),
+      [TEST_SECONDARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-secondary"),
       [OAUTH_PROFILE_ID]: {
         type: "oauth",
         provider: "openai",
@@ -35,11 +28,7 @@ function configureProfiles(): void {
         refresh: "test-refresh",
         expires: Date.now() + 60_000,
       },
-      [MISMATCHED_PROFILE_ID]: {
-        type: "api_key",
-        provider: "anthropic",
-        key: "sk-mismatched",
-      },
+      [MISMATCHED_PROFILE_ID]: createApiKeyCredential("anthropic", "sk-mismatched"),
     },
     order: { openai: [TEST_PRIMARY_PROFILE_ID, TEST_SECONDARY_PROFILE_ID, OAUTH_PROFILE_ID] },
   });

--- a/src/agents/auth-profiles/session-override.test.ts
+++ b/src/agents/auth-profiles/session-override.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../../config/sessions/session-accessor.js";
 import type { SessionEntry } from "../../config/sessions/types.js";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import {
   authStoreMocks,
   clearSessionAuthProfileOverride,
@@ -152,11 +153,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       authStoreMocks.state.hasSource = true;
       authStoreMocks.state.store = createAuthStoreWithProfiles({
         profiles: {
-          "amazon-bedrock:default": {
-            type: "api_key",
-            provider: "openrouter",
-            key: "sk-drifted",
-          },
+          "amazon-bedrock:default": createApiKeyCredential("openrouter", "sk-drifted"),
         },
       });
 
@@ -211,16 +208,8 @@ describe("resolveSessionAuthProfileOverride", () => {
       authStoreMocks.state.hasSource = true;
       authStoreMocks.state.store = createAuthStoreWithProfiles({
         profiles: {
-          [TEST_PRIMARY_PROFILE_ID]: {
-            type: "api_key",
-            provider: "openai",
-            key: "sk-josh",
-          },
-          [TEST_SECONDARY_PROFILE_ID]: {
-            type: "api_key",
-            provider: "openai",
-            key: "sk-claude",
-          },
+          [TEST_PRIMARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-josh"),
+          [TEST_SECONDARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-claude"),
         },
         order: {
           openai: [TEST_PRIMARY_PROFILE_ID, TEST_SECONDARY_PROFILE_ID],
@@ -259,11 +248,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       authStoreMocks.state.hasSource = true;
       authStoreMocks.state.store = createAuthStoreWithProfiles({
         profiles: {
-          [TEST_PRIMARY_PROFILE_ID]: {
-            type: "api_key",
-            provider: "openai",
-            key: "sk-codex",
-          },
+          [TEST_PRIMARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-codex"),
         },
         order: {
           openai: [TEST_PRIMARY_PROFILE_ID],
@@ -301,11 +286,7 @@ describe("resolveSessionAuthProfileOverride", () => {
       authStoreMocks.state.hasSource = true;
       authStoreMocks.state.store = createAuthStoreWithProfiles({
         profiles: {
-          [TEST_PRIMARY_PROFILE_ID]: {
-            type: "api_key",
-            provider: "openai",
-            key: "sk-codex",
-          },
+          [TEST_PRIMARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-codex"),
         },
         order: {
           openai: [TEST_PRIMARY_PROFILE_ID],
@@ -343,16 +324,8 @@ describe("resolveSessionAuthProfileOverride", () => {
       authStoreMocks.state.hasSource = true;
       authStoreMocks.state.store = createAuthStoreWithProfiles({
         profiles: {
-          "openai:api-key-backup": {
-            type: "api_key",
-            provider: "openai",
-            key: "sk-openai",
-          },
-          [TEST_PRIMARY_PROFILE_ID]: {
-            type: "api_key",
-            provider: "openai",
-            key: "sk-codex",
-          },
+          "openai:api-key-backup": createApiKeyCredential("openai", "sk-openai"),
+          [TEST_PRIMARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-codex"),
         },
         order: {
           openai: [TEST_PRIMARY_PROFILE_ID],
@@ -391,16 +364,8 @@ describe("resolveSessionAuthProfileOverride", () => {
       authStoreMocks.state.hasSource = true;
       authStoreMocks.state.store = createAuthStoreWithProfiles({
         profiles: {
-          [TEST_PRIMARY_PROFILE_ID]: {
-            type: "api_key",
-            provider: "openai",
-            key: "sk-stale",
-          },
-          [TEST_SECONDARY_PROFILE_ID]: {
-            type: "api_key",
-            provider: "openai",
-            key: "sk-healthy",
-          },
+          [TEST_PRIMARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-stale"),
+          [TEST_SECONDARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-healthy"),
         },
         order: {
           openai: [TEST_SECONDARY_PROFILE_ID, TEST_PRIMARY_PROFILE_ID],
@@ -476,16 +441,8 @@ describe("resolveSessionAuthProfileOverride", () => {
       authStoreMocks.state.hasSource = true;
       authStoreMocks.state.store = createAuthStoreWithProfiles({
         profiles: {
-          [TEST_PRIMARY_PROFILE_ID]: {
-            type: "api_key",
-            provider: "openai",
-            key: "sk-primary",
-          },
-          [TEST_SECONDARY_PROFILE_ID]: {
-            type: "api_key",
-            provider: "openai",
-            key: "sk-secondary",
-          },
+          [TEST_PRIMARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-primary"),
+          [TEST_SECONDARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-secondary"),
         },
         order: {
           openai: [TEST_PRIMARY_PROFILE_ID, TEST_SECONDARY_PROFILE_ID],
@@ -589,11 +546,10 @@ describe("resolveSessionAuthProfileOverride", () => {
         });
         const latestProfileId = crossProvider ? "anthropic:manual" : TEST_SECONDARY_PROFILE_ID;
         if (crossProvider) {
-          authStoreMocks.state.store.profiles[latestProfileId] = {
-            type: "api_key",
-            provider: "anthropic",
-            key: "sk-anthropic",
-          };
+          authStoreMocks.state.store.profiles[latestProfileId] = createApiKeyCredential(
+            "anthropic",
+            "sk-anthropic",
+          );
         }
         const sessionKey = "agent:main:main";
         const scope = { storePath: path.join(state.sessionsDir(), "sessions.json"), sessionKey };

--- a/src/agents/auth-profiles/session-override.user-link.test.ts
+++ b/src/agents/auth-profiles/session-override.user-link.test.ts
@@ -15,6 +15,7 @@ import {
   type OpenClawTestState,
   withOpenClawTestState,
 } from "../../test-utils/openclaw-test-state.js";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import { resolveSessionAuthSelection } from "./session-override.js";
 
 const DEFAULT_PROFILE_ID = "openai:shared";
@@ -176,11 +177,7 @@ describe("person-linked session auth", () => {
       await state.writeAuthProfiles({
         version: 1,
         profiles: {
-          [DEFAULT_PROFILE_ID]: {
-            type: "api_key",
-            provider: "openai",
-            key: "synthetic-shared-key",
-          },
+          [DEFAULT_PROFILE_ID]: createApiKeyCredential("openai", "synthetic-shared-key"),
         },
       });
       const alice = ensureProfileForEmail("alice@example.test");
@@ -214,11 +211,7 @@ describe("person-linked session auth", () => {
       await state.writeAuthProfiles({
         version: 1,
         profiles: {
-          [DEFAULT_PROFILE_ID]: {
-            type: "api_key",
-            provider: "openai",
-            key: "synthetic-shared-key",
-          },
+          [DEFAULT_PROFILE_ID]: createApiKeyCredential("openai", "synthetic-shared-key"),
         },
       });
       const alice = ensureProfileForEmail("alice@example.test");

--- a/src/agents/auth-profiles/session-override.user-pin.test.ts
+++ b/src/agents/auth-profiles/session-override.user-pin.test.ts
@@ -1,6 +1,7 @@
 // Focused lifecycle coverage for explicit auth-profile pins.
 import { beforeEach, describe, expect, it } from "vitest";
 import type { SessionEntry } from "../../config/sessions/types.js";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import {
   authStoreMocks,
   createAuthStoreWithProfiles,
@@ -12,16 +13,8 @@ import {
 function createStore(order: string[]) {
   return createAuthStoreWithProfiles({
     profiles: {
-      [TEST_PRIMARY_PROFILE_ID]: {
-        type: "api_key",
-        provider: "openai",
-        key: "sk-primary",
-      },
-      [TEST_SECONDARY_PROFILE_ID]: {
-        type: "api_key",
-        provider: "openai",
-        key: "sk-secondary",
-      },
+      [TEST_PRIMARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-primary"),
+      [TEST_SECONDARY_PROFILE_ID]: createApiKeyCredential("openai", "sk-secondary"),
     },
     order: { openai: order },
   });

--- a/src/agents/auth-profiles/usage.test.ts
+++ b/src/agents/auth-profiles/usage.test.ts
@@ -7,6 +7,7 @@ import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coerc
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { setLoggerOverride } from "../../logging/logger.js";
+import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
 import type { AuthProfileStore, ProfileUsageStats } from "./types.js";
 import { resolveProfileUnusableUntil } from "./usage-state.js";
 import {
@@ -1271,11 +1272,10 @@ describe("markAuthProfileBlockedUntil", () => {
 describe("markAuthProfileFailure — detail-less provider failures", () => {
   it("does not persist unverifiable failures for API-key profiles", async () => {
     const store = makeStore(undefined);
-    store.profiles["azure-foundry:default"] = {
-      type: "api_key",
-      provider: "azure-foundry",
-      key: "azure-foundry-test-key",
-    };
+    store.profiles["azure-foundry:default"] = createApiKeyCredential(
+      "azure-foundry",
+      "azure-foundry-test-key",
+    );
 
     for (const profileId of ["azure-foundry:default", "openai:api-key"]) {
       await markAuthProfileFailure({
@@ -1665,11 +1665,7 @@ describe("markAuthProfileFailure — WHAM-aware Codex cooldowns", () => {
     storeMocks.updateAuthProfileStoreWithLock.mockImplementationOnce(
       async (lockParams: { updater: (store: AuthProfileStore) => boolean }) => {
         const freshStore = structuredClone(store);
-        freshStore.profiles["openai:default"] = {
-          type: "api_key",
-          provider: "openai",
-          key: "rotated-api-key",
-        };
+        freshStore.profiles["openai:default"] = createApiKeyCredential("openai", "rotated-api-key");
         lockParams.updater(freshStore);
         return freshStore;
       },
@@ -1873,11 +1869,7 @@ describe("markAuthProfileFailure — per-model cooldown metadata", () => {
 
   function makeStoreWithCopilot(usageStats: AuthProfileStore["usageStats"]): AuthProfileStore {
     const store = makeStore(usageStats);
-    store.profiles["github-copilot:github"] = {
-      type: "api_key",
-      provider: "github-copilot",
-      key: "ghu_test",
-    };
+    store.profiles["github-copilot:github"] = createApiKeyCredential("github-copilot", "ghu_test");
     return store;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Auth-profile tests repeat the same three-field API-key credential input across ordering, persistence, selection, and mutation scenarios, obscuring the behavior each case exercises.

## Why This Change Was Made

Replace 79 input literals with a small, data-only constructor requiring provider and key. It preserves the exact `type`, `provider`, `key` order, optional-field absence, string values, fresh allocation, and existing bindings. Independent expected objects stay literal. The helper has no runtime dependencies, defaults, normalization, or casts.

## User Impact

No production behavior changes. This removes 288 net test/support lines across 16 suites plus the six-line helper, while retaining every scenario and assertion.

## Evidence

- All 16 complete suites passed 374 tests before and after, with no failures or skips and identical per-file ordered case/status lists.
- All 79 replacements preserve complete expanded test code and argument expressions; fixture checks verify own keys, descriptors, values, prototypes, fresh repeated calls, and mutation independence.
- Mapped changed checks, formatting, and complete 17-file P2 review passed.
- No runtime-performance or aggregate coverage claim. Native Vitest aggregate file scheduling order differed and is not claimed identical.
