### PR TITLE
fix: align chat attachment spacing with message blocks

### DIFF
--- a/ui/src/e2e/chat-attachment-spacing.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-spacing.e2e.test.ts
@@ -10,7 +10,6 @@ const suite = createControlUiE2eSuite({
 
 const neighbors = [
   { name: "paragraph", markdown: "A paragraph after the file." },
-  { name: "bold", markdown: "**A bold paragraph after the file.**" },
   { name: "heading", markdown: "## A heading after the file" },
   { name: "list", markdown: "- First item\n- Second item" },
   { name: "code", markdown: "```js\nconst ready = true;\n```" },
@@ -77,7 +76,8 @@ suite.define(() => {
     );
   }
 
-  it.each([2, 3, 5])("keeps %i files in a column with the text rhythm on mobile", async (count) => {
+  it("keeps multiple files in a column with the text rhythm on mobile", async () => {
+    const count = 5;
     await suite.withPage({ viewport: { width: 390, height: 900 } }, async ({ page }) => {
       await installMockGateway(page, {
         historyMessages: [
@@ -144,6 +144,48 @@ suite.define(() => {
       ] as const) {
         expect(Math.abs((await gap(above, below)) - reference)).toBeLessThanOrEqual(1);
       }
+    });
+  });
+
+  it("shares the block rhythm inside expanded tool output", async () => {
+    await suite.withPage({ viewport: { width: 390, height: 900 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        historyMessages: [
+          {
+            role: "user",
+            content: [{ type: "text", text: "Reference one.\n\nReference two." }],
+          },
+          {
+            role: "toolResult",
+            toolCallId: "spacing-preview",
+            toolName: "image",
+            content: [
+              attachment(),
+              {
+                type: "image",
+                url: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/woAAn8B9FD5fHAAAAAASUVORK5CYII=",
+                alt: "Generated preview",
+              },
+              { type: "text", text: "Generated output." },
+            ],
+          },
+        ],
+      });
+      await page.goto(`${suite.server.baseUrl}chat/main`);
+      await page.locator(".chat-tool-msg-summary").first().click();
+      const body = page.locator(".chat-tool-msg-body");
+      const text = body.locator(":scope > .chat-text");
+      await text.waitFor();
+      const paragraphs = page.locator(".chat-group.user .chat-text > p");
+      await paragraphs.last().waitFor();
+      const reference = await gap(paragraphs.nth(0), paragraphs.nth(1));
+      const attachments = body.locator(":scope > .chat-assistant-attachments");
+      expect(Math.abs((await gap(attachments, text)) - reference)).toBeLessThanOrEqual(1);
+      expect(
+        Math.abs(
+          (await gap(body.locator(":scope > .chat-message-images"), attachments)) - reference,
+        ),
+      ).toBeLessThanOrEqual(1);
     });
   });
 });

--- a/ui/src/e2e/chat-attachment-spacing.e2e.test.ts
+++ b/ui/src/e2e/chat-attachment-spacing.e2e.test.ts
@@ -1,0 +1,149 @@
+import type { Locator } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({
+  name: "Chat attachment block spacing",
+  startServerBeforeBrowser: true,
+});
+
+const neighbors = [
+  { name: "paragraph", markdown: "A paragraph after the file." },
+  { name: "bold", markdown: "**A bold paragraph after the file.**" },
+  { name: "heading", markdown: "## A heading after the file" },
+  { name: "list", markdown: "- First item\n- Second item" },
+  { name: "code", markdown: "```js\nconst ready = true;\n```" },
+  { name: "table", markdown: "| Item | Status |\n| --- | --- |\n| Report | Ready |" },
+  { name: "quote", markdown: "> A quotation after the file." },
+];
+
+function attachment(index = 0) {
+  return {
+    type: "attachment",
+    attachment: {
+      kind: "document",
+      label: `report-${index}.txt`,
+      mimeType: "text/plain",
+      url: `https://example.com/report-${index}.txt`,
+      sizeBytes: 1024,
+    },
+  };
+}
+
+async function gap(above: Locator, below: Locator) {
+  const upper = await above.boundingBox();
+  const lower = await below.boundingBox();
+  if (!upper || !lower) {
+    throw new Error("Both neighboring blocks must be rendered");
+  }
+  return lower.y - upper.y - upper.height;
+}
+
+suite.define(() => {
+  for (const width of [1440, 390]) {
+    it.each(neighbors)(
+      `matches paragraph rhythm before $name at ${width}px`,
+      async ({ markdown }) => {
+        await suite.withPage({ viewport: { width, height: 900 } }, async ({ page }) => {
+          await installMockGateway(page, {
+            historyMessages: [
+              {
+                role: "assistant",
+                content: [
+                  attachment(),
+                  { type: "text", text: `${markdown}\n\nReference one.\n\nReference two.` },
+                ],
+              },
+            ],
+          });
+          await page.goto(`${suite.server.baseUrl}chat/main`);
+          const bubble = page.locator(".chat-bubble").filter({ hasText: "Reference one." });
+          const card = bubble.locator(".chat-assistant-attachment-card");
+          const blocks = bubble.locator(".chat-text > *");
+          await blocks.last().waitFor();
+          const reference = await gap(blocks.nth(1), blocks.nth(2));
+          expect(reference).toBeGreaterThan(0);
+          await expect
+            .poll(async () =>
+              Math.max(
+                Math.abs((await gap(card, blocks.first())) - reference),
+                Math.abs((await gap(blocks.first(), blocks.nth(1))) - reference),
+              ),
+            )
+            .toBeLessThanOrEqual(1);
+        });
+      },
+    );
+  }
+
+  it.each([2, 3, 5])("keeps %i files in a column with the text rhythm on mobile", async (count) => {
+    await suite.withPage({ viewport: { width: 390, height: 900 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        historyMessages: [
+          {
+            role: "user",
+            content: [
+              ...Array.from({ length: count }, (_, index) => attachment(index)),
+              { type: "text", text: "Reference one.\n\nReference two." },
+            ],
+          },
+        ],
+      });
+      await page.goto(`${suite.server.baseUrl}chat/main`);
+      const cards = page.locator(".chat-assistant-attachment-card");
+      const paragraphs = page.locator(".chat-text > p");
+      await paragraphs.last().waitFor();
+      await expect.poll(() => cards.count()).toBe(count);
+      const reference = await gap(paragraphs.nth(0), paragraphs.nth(1));
+      for (let index = 1; index < count; index += 1) {
+        expect(
+          Math.abs((await gap(cards.nth(index - 1), cards.nth(index))) - reference),
+        ).toBeLessThanOrEqual(1);
+      }
+      expect(
+        Math.abs((await gap(cards.last(), paragraphs.first())) - reference),
+      ).toBeLessThanOrEqual(1);
+      expect(
+        await page
+          .locator(".chat-thread")
+          .evaluate((element) => element.scrollWidth <= element.clientWidth),
+      ).toBe(true);
+    });
+  });
+
+  it("preserves nested user fences while sharing the top-level attachment rhythm", async () => {
+    await suite.withPage({ viewport: { width: 390, height: 900 } }, async ({ page }) => {
+      await installMockGateway(page, {
+        historyMessages: [
+          {
+            role: "user",
+            content: [
+              attachment(),
+              {
+                type: "text",
+                text: "```txt\ntop level\n```\n\nReference one.\n\nReference two.\n\n> Before code.\n>\n> ```txt\n> nested code\n> ```\n>\n> After code.",
+              },
+            ],
+          },
+        ],
+      });
+      await page.goto(`${suite.server.baseUrl}chat/main`);
+      const text = page.locator(".chat-text");
+      const nestedCode = text.locator("blockquote pre");
+      await nestedCode.waitFor();
+      const reference = await gap(
+        text.locator(":scope > p").nth(0),
+        text.locator(":scope > p").nth(1),
+      );
+      const card = page.locator(".chat-assistant-attachment-card");
+      for (const [above, below] of [
+        [card, text.locator(":scope > pre")],
+        [text.locator("blockquote > p").first(), nestedCode],
+        [nestedCode, text.locator("blockquote > p").last()],
+      ] as const) {
+        expect(Math.abs((await gap(above, below)) - reference)).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+});

--- a/ui/src/e2e/chat-flow.media-files.e2e.test.ts
+++ b/ui/src/e2e/chat-flow.media-files.e2e.test.ts
@@ -260,7 +260,7 @@ suite.define(() => {
         const rect = element.getBoundingClientRect();
         return { height: rect.height, width: rect.width };
       });
-      expect(metadataSize.height).toBe(14);
+      expect(metadataSize.height).toBeCloseTo(14, 3);
       expect(metadataSize.width).toBeGreaterThanOrEqual(112);
       expect(metadataSize.width).toBeLessThanOrEqual(144);
       const actionSkeletons = checkingCards.locator(

--- a/ui/src/styles/base.css
+++ b/ui/src/styles/base.css
@@ -243,6 +243,7 @@
   --control-ui-text-lg: calc(16px * var(--control-ui-text-scale));
   --control-ui-input-text-size: max(16px, calc(14px * var(--control-ui-text-scale)));
   --chat-text-size: var(--control-ui-text-md);
+  --chat-block-gap: var(--chat-text-size);
 
   /* Shadows - Subtle, layered depth */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.25);

--- a/ui/src/styles/chat/grouped.css
+++ b/ui/src/styles/chat/grouped.css
@@ -1057,7 +1057,6 @@ img.chat-avatar.chat-avatar--logo {
   display: flex;
   flex-direction: column;
   align-items: flex-end;
-  gap: 8px;
   padding: 0;
   border: 0;
   background: transparent;

--- a/ui/src/styles/chat/message-layout.css
+++ b/ui/src/styles/chat/message-layout.css
@@ -213,8 +213,7 @@
   flex-wrap: nowrap;
   align-items: flex-start;
   width: 100%;
-  gap: 12px;
-  margin-bottom: 8px;
+  gap: var(--chat-block-gap);
 }
 
 .chat-message-image-button {
@@ -416,8 +415,7 @@
   flex-direction: column;
   width: 100%;
   max-width: 100%;
-  gap: 12px;
-  margin: 12px 0 8px;
+  gap: var(--chat-block-gap);
 }
 
 .chat-group.assistant .chat-bubble:has(.chat-assistant-attachments),

--- a/ui/src/styles/chat/text.css
+++ b/ui/src/styles/chat/text.css
@@ -3,7 +3,6 @@
    ============================================= */
 
 .chat-thinking {
-  margin-bottom: 10px;
   padding: 10px 12px;
   border-radius: var(--radius-md);
   border: 1px dashed rgba(255, 255, 255, 0.18);
@@ -121,14 +120,6 @@
   margin: 0;
 }
 
-/* Keep every adjacent top-level Markdown block on the same rhythm, including
-   special blocks that otherwise read as part of the preceding block. */
-.chat-text
-  > :where(p, ul, ol, pre, blockquote, table, details, .markdown-table)
-  + :where(p, ul, ol, pre, blockquote, table, details, .markdown-table) {
-  margin-top: 1em;
-}
-
 .chat-text
   :where(blockquote, details, li)
   > :where(p, ul, ol, pre, blockquote, table, details, .markdown-table)
@@ -136,8 +127,6 @@
   margin-top: 0.5em;
 }
 
-/* Tables retain top margin even when first; the adjacent-block rule above gives
-   tables the same rhythm when they follow another Markdown block. */
 .chat-text :where(table) {
   margin-top: 0.75em;
   border: 1px solid color-mix(in srgb, var(--accent) 20%, var(--border));
@@ -979,7 +968,6 @@
 }
 
 .chat-group.user .chat-text :where(pre) {
-  margin-block: 1em;
   padding: 0;
   border: 0;
   border-radius: 0;
@@ -988,6 +976,10 @@
   font: inherit;
   overflow: visible;
   white-space: pre-wrap;
+}
+
+.chat-group.user .chat-text :where(:not(.chat-text) > pre) {
+  margin-block: 1em;
 }
 
 /* A user fence carries no code chrome, so it reads as the message it was typed
@@ -1178,4 +1170,54 @@
   .chat-json-content {
     max-height: 200px;
   }
+}
+
+/* Only top-level blocks share message rhythm; list/quote interiors keep their
+   own spacing. Reset edge margins so a first or last block adds no extra gap. */
+.chat-text > *,
+.chat-text > .markdown-external-image {
+  margin-block: 0;
+}
+
+/* renderBody is shared by normal bubbles and expanded tool output. */
+:is(.chat-bubble, .chat-tool-msg-body) {
+  > :is(
+    .chat-message-images,
+    .chat-assistant-attachments,
+    .chat-assistant-attachment-card,
+    .chat-pairing-qr-notices,
+    .chat-thinking,
+    .chat-tool-card__widget-host,
+    .chat-text,
+    .chat-json-collapse,
+    .chat-message-disclosure,
+    .chat-tools-inline
+  ) {
+    margin-block: 0;
+
+    + :is(
+      .chat-message-images,
+      .chat-assistant-attachments,
+      .chat-assistant-attachment-card,
+      .chat-pairing-qr-notices,
+      .chat-thinking,
+      .chat-tool-card__widget-host,
+      .chat-text,
+      .chat-json-collapse,
+      .chat-message-disclosure,
+      .chat-tools-inline
+    ) {
+      margin-block-start: var(--chat-block-gap);
+    }
+  }
+}
+
+.chat-text > * + *,
+.chat-text > * + .markdown-external-image {
+  margin-block-start: var(--chat-block-gap);
+}
+
+/* Contain the preview's reserved toolbar space within its message block. */
+.chat-bubble > .chat-tool-card__widget-host {
+  display: flow-root;
 }

--- a/ui/src/styles/chat/tool-cards.css
+++ b/ui/src/styles/chat/tool-cards.css
@@ -559,7 +559,6 @@
 
 .chat-bubble--tool-shell .chat-tool-msg-body > .chat-text {
   max-height: min(46vh, 540px);
-  margin: 0;
   padding: 12px 14px 14px;
   overflow: auto;
   font-family: var(--mono);


### PR DESCRIPTION
Closes #142222

## What Problem This Solves

Fixes an issue where users reading chat attachments see text crowded against the bottom of a card and excessive space above it after completed activity.

## Why This Change Was Made

Attachments now share the chat block rhythm with Markdown: one text-size unit, 14px at the default setting. First and last blocks add no extra edge margins. Multiple files retain their column layout; headings, code wrappers, tables, images, widgets, and expanded tool output participate in the same body spacing. The tool output stylesheet no longer overrides the shared vertical spacing.

Nested Markdown, user code fences, reply context, widget toolbar space, and the existing message/activity hierarchy retain their own layout contracts.

## User Impact

Document and media attachments have consistent breathing room beside text on desktop and mobile. Attachment-only messages no longer add unexplained whitespace at their edges.

## Evidence

- After reinstalling locked dependencies, the standard bundled E2E configuration passed all 24 cases across the two touched E2E files in 32.89s with two workers: six Markdown neighbors at both widths, a five-file user message, nested user fences, mixed media in expanded tool output, and nine existing media flows.
- The production diff is +57/−18 lines. Four duplicate test executions were removed (bold paragraphs and 2/3-file collections); their visual cases remain covered. One regression was added for the distinct expanded-tool boundary.
- The original paragraph regression failed at both widths: card-to-paragraph spacing was 8px while paragraph spacing was 14px. The expanded-tool regression also failed before its repair: 0px between the attachment and text container versus a 14px independent paragraph reference.
- The existing managed-document transition test now uses the same three-decimal geometry tolerance as its neighboring action skeleton. This accepts browser rounding (13.999992px) while retaining the 14px skeleton contract and every lifecycle assertion.
- Changed-file validation: PASS on final head `1fbafddd29197b1c20152fe71cbb6c2d478c397c`: all selected formatting, core/UI typechecking, i18n, unused-export and lint stages completed successfully; two workers. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34259867341) passed.
- Latest review inspected (updated September 8, 18:05 UTC) covers this exact head, including the test precision correction: no remaining Before merge items, Rank-up moves, or accepted findings. The earlier draft-readiness item is resolved.
- 39 named scenarios at 1440×900 and 390×900, captured before and after in dark mode: 156 inspected synthetic captures, presented as featured pairs and five visible contact sheets. Each pair uses the same named message and scroll anchor (or transcript end for live states).
- The original report image and local stress fixture are excluded from the branch and uploads.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><th colspan="2">paragraph-below · 1440 × 900</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/f817502c-f1e1-4b71-86a8-de8f561ea3a3"><img src="https://github.com/user-attachments/assets/f817502c-f1e1-4b71-86a8-de8f561ea3a3" width="400" alt="before: paragraph-below, 1440 pixels"></a></td><td><a href="https://github.com/user-attachments/assets/ce16f96a-e12e-4029-9a62-520967237b1d"><img src="https://github.com/user-attachments/assets/ce16f96a-e12e-4029-9a62-520967237b1d" width="400" alt="after: paragraph-below, 1440 pixels"></a></td></tr>
<tr><th colspan="2">recovery-activity · 1440 × 900</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/47575753-e5f0-46f9-ada9-284a51bfc31c"><img src="https://github.com/user-attachments/assets/47575753-e5f0-46f9-ada9-284a51bfc31c" width="400" alt="before: recovery-activity, 1440 pixels"></a></td><td><a href="https://github.com/user-attachments/assets/2d95247b-e1ca-48ef-b655-d7206eefd317"><img src="https://github.com/user-attachments/assets/2d95247b-e1ca-48ef-b655-d7206eefd317" width="400" alt="after: recovery-activity, 1440 pixels"></a></td></tr>
<tr><th colspan="2">paragraph-below · 390 × 900</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/46f38a50-4af4-4142-91ba-7c0a5eaaf526"><img src="https://github.com/user-attachments/assets/46f38a50-4af4-4142-91ba-7c0a5eaaf526" width="400" alt="before: paragraph-below, 390 pixels"></a></td><td><a href="https://github.com/user-attachments/assets/1b13f032-8606-4a02-8c3f-dff2088f2602"><img src="https://github.com/user-attachments/assets/1b13f032-8606-4a02-8c3f-dff2088f2602" width="400" alt="after: paragraph-below, 390 pixels"></a></td></tr>
<tr><th colspan="2">5-attachments · 390 × 900</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/7aafd862-4eb7-441d-ac90-f803408add25"><img src="https://github.com/user-attachments/assets/7aafd862-4eb7-441d-ac90-f803408add25" width="400" alt="before: 5-attachments, 390 pixels"></a></td><td><a href="https://github.com/user-attachments/assets/e097b15e-13cd-4ff2-9e00-b81006579929"><img src="https://github.com/user-attachments/assets/e097b15e-13cd-4ff2-9e00-b81006579929" width="400" alt="after: 5-attachments, 390 pixels"></a></td></tr>
<tr><th colspan="2">recovery-activity · 390 × 900</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/fb8e683c-43fe-4f7b-8241-e73a1771c858"><img src="https://github.com/user-attachments/assets/fb8e683c-43fe-4f7b-8241-e73a1771c858" width="400" alt="before: recovery-activity, 390 pixels"></a></td><td><a href="https://github.com/user-attachments/assets/9d13a0d1-7dae-420c-84bc-9991c70d2515"><img src="https://github.com/user-attachments/assets/9d13a0d1-7dae-420c-84bc-9991c70d2515" width="400" alt="after: recovery-activity, 390 pixels"></a></td></tr>
<tr><th colspan="2">interrupted · 390 × 900</th></tr>
<tr><td><a href="https://github.com/user-attachments/assets/d7ed8353-b7f8-40c5-9ef4-5cf17019df97"><img src="https://github.com/user-attachments/assets/d7ed8353-b7f8-40c5-9ef4-5cf17019df97" width="400" alt="before: interrupted, 390 pixels"></a></td><td><a href="https://github.com/user-attachments/assets/3382be02-0a24-4279-9952-ec020d24fe82"><img src="https://github.com/user-attachments/assets/3382be02-0a24-4279-9952-ec020d24fe82" width="400" alt="after: interrupted, 390 pixels"></a></td></tr>
</table>

Distances below are border-box gaps in CSS pixels, before → after. Text/Markdown-above cases use consecutive messages because the renderer places attachments before a message's joined text. Image-above is an in-message body boundary. Reply context keeps its existing 8px lower margin after the attachment edge offset is removed. Plain consecutive messages keep their 10px boundary; body blocks use 14px. The table action row retains its existing 8px lower margin, reflected in the table-above measurements. A dash means that neighbor is absent.

| Case | 1440: above | 1440: below | 390: above | 390: below | Between cards, both widths |
| --- | ---: | ---: | ---: | ---: | --- |
| paragraph-below | — | 8 → 14 | — | 8 → 14 | — |
| paragraph-above | 22 → 10 | — | 22 → 10 | — | — |
| bold-below | — | 8 → 14 | — | 8 → 14 | — |
| bold-above | 22 → 10 | — | 22 → 10 | — | — |
| heading-below | — | 17.42 → 14 | — | 17.42 → 14 | — |
| heading-above | 39.42 → 10 | — | 39.42 → 10 | — | — |
| list-below | — | 8 → 14 | — | 8 → 14 | — |
| list-above | 22 → 10 | — | 22 → 10 | — | — |
| code-below | — | 14 → 14 | — | 14 → 14 | — |
| code-above | 36 → 10 | — | 36 → 10 | — | — |
| table-below | — | 10.5 → 14 | — | 10.5 → 14 | — |
| table-above | 30 → 18 | — | 30 → 18 | — | — |
| quote-below | — | 8 → 14 | — | 8 → 14 | — |
| quote-above | 22 → 10 | — | 22 → 10 | — | — |
| link-below | — | 8 → 14 | — | 8 → 14 | — |
| link-above | 22 → 10 | — | 22 → 10 | — | — |
| 2-attachments | — | — | — | — | 12 → 14 |
| 3-attachments | — | — | — | — | 12, 12 → 14, 14 |
| 5-attachments | — | — | — | — | 12, 12, 12, 12 → 14, 14, 14, 14 |
| image-above | 12 → 14 | 8 → 14 | 12 → 14 | 8 → 14 | — |
| image-below | — | 18 → 10 | — | 18 → 10 | — |
| only-content | — | — | — | — | — |
| user-attachment | — | 8 → 14 | — | 8 → 14 | — |
| middle-input | — | 8 → 14 | — | 8 → 14 | — |
| recovery-activity | 28 → 16 | 8 → 14 | 28 → 16 | 8 → 14 | — |
| widget | — | 40 → 14 | — | 40 → 14 | — |
| audio | — | 8 → 14 | — | 8 → 14 | 12 → 14 |
| video | — | 8 → 14 | — | 8 → 14 | 12 → 14 |
| external-image-card | — | 10.5 → 14 | — | 10.5 → 14 | — |
| paragraph-reference | — | — | — | — | — |
| omitted-image | 12 → 14 | 8 → 14 | 12 → 14 | 8 → 14 | — |
| expired-qr | 12 → 14 | 8 → 14 | 12 → 14 | 8 → 14 | — |
| long-disclosure | — | 8 → 14 | — | 8 → 14 | — |
| json-disclosure | — | 8 → 14 | — | 8 → 14 | — |
| reply-preview | 12 → 8 | 8 → 14 | 12 → 8 | 8 → 14 | — |
| reasoning | — | 8 → 14 | — | 8 → 14 | — |
| expanded-tool-output | 12 → 14 | 8 → 14 | 12 → 14 | 8 → 14 | — |
| streaming | — | 18 → 10 | — | 18 → 10 | — |
| interrupted | — | 8 → 14 | — | 8 → 14 | — |

The reference paragraph gap stays 14px at both widths. The expanded-tool row measures the text container boundary: 8→14px. Its existing 12px internal padding remains, placing the visible paragraph 20→26px below the card. The widget row measures its host boundary; the existing 40px internal toolbar reservation remains, so the document surface starts 54px below the attachment. Desktop video-to-text spacing is also visible at the top of the following external-image-card capture.

| Message edge | 1440: before → after | 390: before → after |
| --- | ---: | ---: |
| Attachment-only: message start to card | 16 → 4 | 16 → 4 |
| Attachment-only: card to footer | 14 → 6 | 18 → 10 |
| User bubble: start to card | 29 → 17 | 29 → 17 |

The remaining comparisons are grouped below by theme. Each visible contact sheet includes both widths, with before and after labels. Desktop panels crop the surrounding app chrome and whitespace; message content retains its original resolution. Click an image for full resolution.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><th colspan="2">Markdown neighbors · 1440px and 390px</th></tr>
<tr><td colspan="2"><a href="https://github.com/user-attachments/assets/49bb0550-f6a9-46ef-a8f8-4b218111738b"><img src="https://github.com/user-attachments/assets/49bb0550-f6a9-46ef-a8f8-4b218111738b" width="1000" alt="Markdown neighbors: labeled before and after contact sheet"></a></td></tr>
<tr><th colspan="2">File collections and message edges · 1440px and 390px</th></tr>
<tr><td colspan="2"><a href="https://github.com/user-attachments/assets/d9e7f420-dd05-4fb9-9326-e31f0a1f21b5"><img src="https://github.com/user-attachments/assets/d9e7f420-dd05-4fb9-9326-e31f0a1f21b5" width="1000" alt="File collections and message edges: labeled before and after contact sheet"></a></td></tr>
<tr><th colspan="2">Images and media · 1440px and 390px</th></tr>
<tr><td colspan="2"><a href="https://github.com/user-attachments/assets/dde3f611-9c6f-4e3a-9fb3-8dbfa9bc04b4"><img src="https://github.com/user-attachments/assets/dde3f611-9c6f-4e3a-9fb3-8dbfa9bc04b4" width="1000" alt="Images and media: labeled before and after contact sheet"></a></td></tr>
<tr><th colspan="2">Rich content and context · 1440px and 390px</th></tr>
<tr><td colspan="2"><a href="https://github.com/user-attachments/assets/0390131a-0d54-45fb-a543-d68bdec3ca3b"><img src="https://github.com/user-attachments/assets/0390131a-0d54-45fb-a543-d68bdec3ca3b" width="1000" alt="Rich content and context: labeled before and after contact sheet"></a></td></tr>
<tr><th colspan="2">Live turn states · 1440px and 390px</th></tr>
<tr><td colspan="2"><a href="https://github.com/user-attachments/assets/57040dd0-8ff3-46f2-8a98-9723210d8181"><img src="https://github.com/user-attachments/assets/57040dd0-8ff3-46f2-8a98-9723210d8181" width="1000" alt="Live turn states: labeled before and after contact sheet"></a></td></tr>
</table>


## Risk and coverage

Earlier runs through a temporary source-server configuration had two chat-startup timeouts (16/18 passed); both timed out again in focused confirmation before geometry assertions. That configuration omitted the repository's standard bundled setup. The final 24-case suite passes through the standard bundled configuration. The source-server startup delay remains undiagnosed; no startup timeouts were increased.

The shared rule affects top-level Markdown as well as attachments. Focused geometry checks protect the common neighbors and nested user fences; screenshots cover activity, recovery, footer actions, images, links, widgets, audio/video, streaming, interruption, omitted media, expired pairing notices, long and JSON disclosures, reply context, and visible reasoning. Text/attachment/text input retains the existing attachments-first projection. There is no separate link-preview card in this renderer; the fixture exercises actual Markdown links and external-image fallback cards.

Interaction checks exercised attachment opening, image preview, code-copy acknowledgement, table expansion, widget action menu, audio mute/play, native video playback, activity disclosure, long/JSON disclosure expansion, reply navigation, the theme toggle, and the actual Stop action. All produced their expected visible outcomes. The subsecond synthetic audio/video clips explain their 0:00 duration labels.

Proof uses the real Control UI with a mocked Gateway on Linux. Live Gateway delivery and native desktop platforms were not exercised. The widget proof uses a strict hosted document preview. Its export actions visibly report the existing limitation: download falls back to HTML (verified bytes), and copy requests a re-render. PNG export was not exercised.
