### PR TITLE
fix(ci): keep Docker approval waits outside the publish queue

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -161,13 +161,33 @@ jobs:
       actions: read
       contents: read
 
+  approve:
+    name: Approve Docker images for ${{ inputs.tag }}${{ inputs.image_tag_suffix }}
+    needs: [validate_release_identity, prepare]
+    if: ${{ !cancelled() && needs.validate_release_identity.result == 'success' && (needs.prepare.result == 'success' || needs.prepare.result == 'skipped') }}
+    # An approval wait must not hold the global registry writer lock.
+    # Docker Hub credentials remain required workflow_call secrets for publish.
+    runs-on: ubuntu-24.04
+    environment: docker-release
+    permissions: {}
+    steps:
+      - name: Record Docker publication approval
+        env:
+          RELEASE_TAG: ${{ inputs.tag }}
+          RELEASE_SHA: ${{ inputs.release_sha }}
+          IMAGE_TAG_SUFFIX: ${{ inputs.image_tag_suffix }}
+          PREPARED_MANIFEST_SHA256: ${{ inputs.prepared_manifest_sha256 || needs.prepare.outputs.prepared_manifest_sha256 }}
+        run: |
+          echo "Approved Docker images for ${RELEASE_TAG}${IMAGE_TAG_SUFFIX}"
+          echo "Release SHA: ${RELEASE_SHA}"
+          echo "Prepared manifest SHA256: ${PREPARED_MANIFEST_SHA256}"
+
   publish:
     name: Publish prepared Docker images
-    needs: [validate_release_identity, prepare]
-    if: ${{ always() && needs.validate_release_identity.result == 'success' && (needs.prepare.result == 'success' || needs.prepare.result == 'skipped') }}
+    needs: [validate_release_identity, prepare, approve]
+    if: ${{ !cancelled() && needs.validate_release_identity.result == 'success' && (needs.prepare.result == 'success' || needs.prepare.result == 'skipped') && needs.approve.result == 'success' }}
     runs-on: ubuntu-24.04
     timeout-minutes: 45
-    environment: docker-release
     # The global lock covers every registry mutation and the alias read/write
     # checks. Preparation never queues behind a previous release's promotion.
     concurrency:

--- a/docs/ci/release-validation.md
+++ b/docs/ci/release-validation.md
@@ -46,6 +46,15 @@ Full Release Validation run ID and pin `full_release_validation_run_attempt`.
 The publisher resolves the independent `Full Release Artifacts` producer from
 that validation manifest's sealed `publicationArtifacts.npmPreflight` descriptor.
 The producer ID alone does not carry Full Release Validation authorization.
+
+`Docker Release` requests the `docker-release` environment approval in a
+separate job after source identity and image preparation succeed (or prepared
+artifacts are supplied). Approval waits stay outside `docker-release-publish`;
+only the approved publisher enters that global registry/alias lock. It then
+revalidates the immutable source, prepared artifacts, attestations and alias
+state before writing. Docker Hub credentials remain required caller-provided
+secrets. Failed preparation, denied approval and cancellation cannot publish.
+
 Historical recovery may still supply a separate successful `OpenClaw NPM Release`
 preflight run ID alongside the matching successful Full Release Validation run
 and attempt. Create the tooling tag with the [release publish commands](/reference/RELEASING#regular-release-publish-automation);

--- a/test/scripts/authorized-beta-focused-evidence.test.ts
+++ b/test/scripts/authorized-beta-focused-evidence.test.ts
@@ -636,7 +636,9 @@ describe("authorized beta focused evidence", () => {
       throw new Error("Docker publication gate is missing");
     }
 
-    expect(gate.environment).toBe("docker-release");
+    expect(docker.jobs?.approve?.environment).toBe("docker-release");
+    expect(gate.environment).toBeUndefined();
+    expect(gate.needs).toContain("approve");
     expect(gate.permissions).toMatchObject({
       actions: "read",
       attestations: "read",

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -2826,7 +2826,9 @@ NODE
       contents: "read",
       packages: "write",
     });
-    expect(releaseWorkflow.jobs.publish.environment).toBe("docker-release");
+    expect(releaseWorkflow.jobs.approve.environment).toBe("docker-release");
+    expect(releaseWorkflow.jobs.publish.environment).toBeUndefined();
+    expect(releaseWorkflow.jobs.publish.needs).toContain("approve");
   });
 
   it("forbids moving reusable workflow references", () => {

--- a/test/scripts/docker-channel-promote.test.ts
+++ b/test/scripts/docker-channel-promote.test.ts
@@ -589,7 +589,8 @@ describe("Docker channel promotion", () => {
       "cancel-in-progress": false,
       queue: "max",
     });
-    expect(publish.environment).toBe("docker-release");
+    expect(publish.environment).toBeUndefined();
+    expect(requireJob(releaseWorkflow, "approve").environment).toBe("docker-release");
     expect(publish.permissions).toEqual({
       actions: "read",
       attestations: "read",

--- a/test/scripts/docker-release-artifacts.test.ts
+++ b/test/scripts/docker-release-artifacts.test.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { runInNewContext } from "node:vm";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { parse } from "yaml";
 import {
@@ -770,7 +771,38 @@ describe("prepared Docker publication", () => {
     expect(publish.jobs.prepare.uses).toBe("./.github/workflows/docker-release-prepare.yml");
     expect(publish.jobs.prepare.secrets).toBeUndefined();
     expect(publish.concurrency).toBeUndefined();
-    expect(publish.jobs.publish.environment).toBe("docker-release");
+    const approval = publish.jobs.approve;
+    const writer = publish.jobs.publish;
+    expect(approval, "approval must not hold the global publication lock").toBeDefined();
+    expect(approval.environment).toBe("docker-release");
+    expect(approval.permissions).toEqual({});
+    expect(approval.concurrency).toBeUndefined();
+    expect(JSON.stringify(approval)).not.toContain("secrets.");
+    expect(approval.needs).toEqual(["validate_release_identity", "prepare"]);
+    expect(writer.environment).toBeUndefined();
+    expect(writer.needs).toEqual(["validate_release_identity", "prepare", "approve"]);
+    for (const [identity, prepared, approved, cancelled, canApprove, canPublish] of [
+      ["success", "success", "success", false, true, true],
+      ["success", "skipped", "success", false, true, true],
+      ["failure", "success", "success", false, false, false],
+      ["success", "failure", "success", false, false, false],
+      ["success", "success", "failure", false, true, false],
+      ["success", "success", "skipped", false, true, false],
+      ["success", "success", "cancelled", false, true, false],
+      ["success", "success", "success", true, false, false],
+    ] as const) {
+      const context = {
+        cancelled: () => cancelled,
+        needs: {
+          validate_release_identity: { result: identity },
+          prepare: { result: prepared },
+          approve: { result: approved },
+        },
+      };
+      const evaluate = (condition: string) => runInNewContext(condition.slice(3, -2), context);
+      expect(evaluate(approval.if)).toBe(canApprove);
+      expect(evaluate(writer.if)).toBe(canPublish);
+    }
     expect(publish.jobs.publish.concurrency).toEqual({
       group: "docker-release-publish",
       "cancel-in-progress": false,


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where a Docker refresh waiting for environment approval blocked later release publication for over 34 hours. The waiting job held the global registry writer slot before any publisher step ran.

## Why This Change Was Made

Follow the existing channel-promotion pattern: a separate, unprivileged job requests `docker-release` approval after identity validation and preparation. Only successful approval can admit the publisher to the unchanged `docker-release-publish` mutex. All source, artifact, attestation, credential and alias revalidation stays inside the publisher, after approval and lock acquisition. Failed prerequisites, denied approval and cancellation cannot publish.

## User Impact

One unapproved refresh no longer occupies the global Docker publication queue. Required reviewers remain in force, and actual registry/alias writes remain globally serialized. The extra job is a short GitHub-hosted approval record; no new build fanout or publication is introduced.

## Evidence

- Graph regression failed against the old workflow, then all 66 Docker artifact/promotion tests, the focused scheduled-refresh guard, and 285 tests across the remaining five mapped workflow consumers passed.
- CI exposed two legacy environment-location assertions, which were aligned with the separate approval prerequisite while preserving publication evidence checks. The complete mapped owner inventory is now covered.
- `check:changed`, formatting/diff checks and docs inventory passed.
- `check:workflows` passed, including actionlint and zizmor, with existing Python 3.12 and the unchanged pinned tools. The default Python 3.9 could not install the pinned pre-commit version.
- Fresh independent P2 review and maintainer source review found no actionable defects.
- Parsed workflow comparison confirms the publisher body, environment variables, permissions, outputs, mutex and revalidation steps are unchanged; caller secrets, preparation and identity validation are also unchanged.
- Read-only environment metadata confirmed no environment-specific secrets or variables. Registry credentials remain required workflow-call inputs; the approval job references none.

<details>
<summary>Additional instructions</summary>

This is a repository branch; maintainers retain normal repository edit access.

</details>

