### PR TITLE
refactor(outbound): reuse prepared sendability facts

### DIFF
--- a/src/infra/outbound/payloads.ts
+++ b/src/infra/outbound/payloads.ts
@@ -299,14 +299,13 @@ export function projectOutboundPayloadPlanForOutbound(
   for (const entry of plan) {
     const payload = entry.payload;
     const text = entry.parts.text;
+    // Command delivery consumes this fresh plan synchronously, before further modifiers.
     if (
-      !hasReplyPayloadContent(
-        { ...payload, text, mediaUrls: entry.parts.mediaUrls },
-        {
-          hasChannelData: entry.hasChannelData,
-          extraContent: payload.location != null,
-        },
-      )
+      !entry.parts.hasContent &&
+      !entry.hasPresentation &&
+      !entry.hasInteractive &&
+      !entry.hasChannelData &&
+      payload.location == null
     ) {
       continue;
     }


### PR DESCRIPTION
Closes #142251

<details>
<summary>Additional instructions</summary>

Maintainer edits are enabled on this repository-owned branch.

</details>

## What Problem This Solves

This is a maintainer-authored and requested optimization. Command delivery normalizes rich reply content while building its outbound plan, then clones the payload and repeats rich-content normalization when deciding which transport entries to produce. The fresh plan already records the facts needed for that decision.

## Why This Change Was Made

The internal outbound projector now reuses the prepared text/media, presentation, interactive and channel-data flags, together with the existing location-nullness check. Its sole production caller creates and consumes the plan synchronously, before another modifier or external callback runs. Output construction and object references remain unchanged.

Plans remain publicly mutable. The public SDK creator and delivery projector keep their existing behavior; this optimization applies only to the internal fresh-plan transport path. A bare `audioAsVoice` marker still produces a delivery/JSON tracking entry while producing no outbound transport entry. Actual voice media remains sendable.

## User Impact

Less transient allocation while preparing rich command replies, with the same text, media, rich content, status and delivery behavior. Production changes by +6/-7 lines in one file; no tests, public API, configuration, queue or persistence behavior changes.

The actual full plan-plus-projection rich workloads measured approximately 27–30% lower sampled JavaScript allocation. For example, 750 rich-card operations changed from 14,099,488 to 10,165,792 sampled bytes. Separate already-prepared projection measurements showed 89–99% reductions for rich workloads; those exclude plan creation and are not full-path savings.

## Evidence

- 128 existing payload and command-delivery tests passed before and after. The complete selected changed-file gate and direct independent P2 review passed.
- 216 lossless differential cases preserve plan, delivery, outbound, JSON and mirror values, input preservation, optional own fields, reference relationships, continuation markers and public mutable delivery projection. The audio-only tracking/transport distinction is explicitly checked. V8 snapshot hashes identify artifacts; equality is checked after deserialization rather than inferred from binary encoding.
- Measurements use one A/B/B/A sequence per workload and mode, two observations per arm, with separate timing and 16 KiB V8 allocation sampling. Sampling includes collected objects. Plain-text controls vary, timing samples are not statistically conclusive, and larger tables/buttons deliberately amplify normalization work. No retained-heap, RSS, Gateway-memory or general latency claim is made.
- Owner and command-caller bytes match the accepted baseline at captured main `e321e32abde7b91f3ec1e83f599ea78e98c53673`. Source and proof identities remain pinned.

Active #137530, #127653 and #80396 change plan construction independently. Preserve their text/media normalization and new plan facts if they land first, then recheck the corresponding output/reference cases. Release-note context: reuse prepared sendability facts for internal command transport while preserving public SDK and audio-only tracking behavior.
