### PR TITLE
feat(pdf-tool): local OCR fallback for scanned PDFs with no vision model

### DIFF
--- a/docs/tools/pdf.md
+++ b/docs/tools/pdf.md
@@ -90,6 +90,24 @@ Details:
 - If image rendering fails, OpenClaw drops the images and continues with the extracted text.
 - If the target model is text-only and extraction produced images, OpenClaw drops the images and sends text only.
 
+### Local OCR fallback (scanned PDFs, no vision model)
+
+When extraction finds a scan with no usable text layer (every page's extracted text is under
+`200` characters _and_ the page rendered images), and every configured vision model is either
+unconfigured or fails, the tool rasterizes the requested pages locally with `pdftoppm` (poppler)
+and reads them with the local `tesseract` binary — no network call, no credentials. The result
+is the raw OCR'd text, returned as-is: this is text **extraction**, not comprehension, so it is
+not sent through any model.
+
+- Default OCR language is `por`.
+- Requires `pdftoppm` and `tesseract` on the host; if either binary is missing the tool raises
+  `Local OCR fallback unavailable: ...` instead of silently degrading.
+- If OCR runs but finds no text either (charts, skewed tables, handwriting), the tool still
+  errors — those need a working vision model, and the error says so explicitly.
+- On success, `details.ocrFallback` is `true` and `details.native` is `false`.
+- A normal textual PDF is unaffected: this path only triggers when text extraction is already
+  near-empty, so nothing changes for the extraction-fallback mode described above.
+
 ## Config
 
 ```json5

--- a/src/agents/tools/pdf-tool.ocr-fallback.test.ts
+++ b/src/agents/tools/pdf-tool.ocr-fallback.test.ts
@@ -1,0 +1,170 @@
+// Local OCR fallback: scanned PDF (near-empty text layer) + every vision model failing
+// or unconfigured should still return text, via local pdftoppm/tesseract rather than a
+// model call. A normal textual PDF must be unaffected by this path.
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useAutoCleanupTempDirTracker } from "../../../test/helpers/temp-dir.js";
+import type { OpenClawConfig } from "../../config/config.js";
+import * as pdfExtractModule from "../../media/pdf-extract.js";
+import * as pdfOcrLocalModule from "../../media/pdf-ocr-local.js";
+import { PdfOcrUnavailableError } from "../../media/pdf-ocr-local.js";
+import { createPdfToolInfraStub, withTempPdfAgentDir } from "./pdf-tool.test-support.js";
+
+const completeMock = vi.hoisted(() => vi.fn());
+const registerProviderStreamForModelMock = vi.hoisted(() => vi.fn());
+useAutoCleanupTempDirTracker(afterEach);
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+vi.mock("../../llm/stream.js", async () => {
+  const actual = await vi.importActual<typeof import("../../llm/stream.js")>("../../llm/stream.js");
+  return { ...actual, complete: completeMock };
+});
+
+vi.mock("../provider-stream.js", () => ({
+  registerProviderStreamForModel: registerProviderStreamForModelMock,
+}));
+
+const { stubPdfToolInfra } = createPdfToolInfraStub(completeMock);
+
+type PdfToolModule = typeof import("./pdf-tool.js");
+let createPdfTool: PdfToolModule["createPdfTool"];
+async function loadCreatePdfTool() {
+  if (!createPdfTool) {
+    ({ createPdfTool } = await import("./pdf-tool.js"));
+  }
+  return createPdfTool;
+}
+
+const OPENAI_PDF_MODEL = "openai/gpt-5.4-mini";
+
+function withPdfModel(primary: string): OpenClawConfig {
+  return { agents: { defaults: { pdfModel: { primary } } } } as OpenClawConfig;
+}
+
+function requirePdfTool(tool: unknown) {
+  if (!tool || typeof (tool as { execute?: unknown }).execute !== "function") {
+    throw new Error("expected pdf tool");
+  }
+  return tool as {
+    execute: (
+      id: string,
+      args: unknown,
+    ) => Promise<{ content: unknown; details: Record<string, unknown> }>;
+  };
+}
+
+const SCAN_EXTRACTION = {
+  text: "  ",
+  images: [{ type: "image" as const, data: "base64img", mimeType: "image/png" }],
+};
+
+describe("pdf tool local OCR fallback", () => {
+  it("falls back to local OCR when a scanned PDF has no text and every vision model fails", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, {
+        provider: "openai",
+        api: "openai-responses",
+        input: ["text", "image"],
+      });
+      vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue(SCAN_EXTRACTION);
+      completeMock.mockRejectedValue(new Error("401 Incorrect API key"));
+      const ocrSpy = vi
+        .spyOn(pdfOcrLocalModule, "runLocalPdfOcr")
+        .mockResolvedValue({
+          text: "Prestação de serviço — Soluções Agrícolas Ltda.",
+          pagesProcessed: 1,
+        });
+
+      const tool = requirePdfTool(
+        (await loadCreatePdfTool())({ config: withPdfModel(OPENAI_PDF_MODEL), agentDir }),
+      );
+      const result = await tool.execute("t1", { prompt: "summarize", pdf: "/tmp/scan.pdf" });
+
+      expect(ocrSpy).toHaveBeenCalledTimes(1);
+      expect(result.content).toEqual([
+        { type: "text", text: "Prestação de serviço — Soluções Agrícolas Ltda." },
+      ]);
+      expect(result.details).toMatchObject({
+        model: "local/tesseract-ocr",
+        ocrFallback: true,
+        native: false,
+      });
+    });
+  });
+
+  it("does not use OCR fallback for a normal textual PDF when the model fails", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, {
+        provider: "openai",
+        api: "openai-responses",
+        input: ["text", "image"],
+      });
+      vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue({
+        text: "This PDF has a perfectly normal text layer with plenty of characters in it.".repeat(
+          4,
+        ),
+        images: [],
+      });
+      completeMock.mockRejectedValue(new Error("401 Incorrect API key"));
+      const ocrSpy = vi.spyOn(pdfOcrLocalModule, "runLocalPdfOcr");
+
+      const tool = requirePdfTool(
+        (await loadCreatePdfTool())({ config: withPdfModel(OPENAI_PDF_MODEL), agentDir }),
+      );
+
+      await expect(
+        tool.execute("t1", { prompt: "summarize", pdf: "/tmp/text.pdf" }),
+      ).rejects.toThrow(/401 Incorrect API key/);
+      expect(ocrSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it("surfaces a clear error when local OCR binaries are unavailable", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, {
+        provider: "openai",
+        api: "openai-responses",
+        input: ["text", "image"],
+      });
+      vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue(SCAN_EXTRACTION);
+      completeMock.mockRejectedValue(new Error("401 Incorrect API key"));
+      vi.spyOn(pdfOcrLocalModule, "runLocalPdfOcr").mockRejectedValue(
+        new PdfOcrUnavailableError(new Error("ENOENT")),
+      );
+
+      const tool = requirePdfTool(
+        (await loadCreatePdfTool())({ config: withPdfModel(OPENAI_PDF_MODEL), agentDir }),
+      );
+
+      await expect(
+        tool.execute("t1", { prompt: "summarize", pdf: "/tmp/scan.pdf" }),
+      ).rejects.toThrow(/Local OCR fallback unavailable/);
+    });
+  });
+
+  it("surfaces a distinct error when OCR runs but finds no text (chart/handwriting territory)", async () => {
+    await withTempPdfAgentDir(async (agentDir) => {
+      await stubPdfToolInfra(agentDir, {
+        provider: "openai",
+        api: "openai-responses",
+        input: ["text", "image"],
+      });
+      vi.spyOn(pdfExtractModule, "extractPdfContent").mockResolvedValue(SCAN_EXTRACTION);
+      completeMock.mockRejectedValue(new Error("401 Incorrect API key"));
+      vi.spyOn(pdfOcrLocalModule, "runLocalPdfOcr").mockResolvedValue({
+        text: "",
+        pagesProcessed: 1,
+      });
+
+      const tool = requirePdfTool(
+        (await loadCreatePdfTool())({ config: withPdfModel(OPENAI_PDF_MODEL), agentDir }),
+      );
+
+      await expect(
+        tool.execute("t1", { prompt: "summarize", pdf: "/tmp/scan.pdf" }),
+      ).rejects.toThrow(/found no readable text either/);
+    });
+  });
+});

--- a/src/agents/tools/pdf-tool.ts
+++ b/src/agents/tools/pdf-tool.ts
@@ -17,6 +17,7 @@ import {
   normalizeMediaReferenceSource,
 } from "../../media/media-reference.js";
 import { extractPdfContent, type PdfExtractedContent } from "../../media/pdf-extract.js";
+import { PdfOcrUnavailableError, runLocalPdfOcr } from "../../media/pdf-ocr-local.js";
 import { loadWebMediaRaw } from "../../media/web-media.js";
 import { resolveUserPath } from "../../utils.js";
 import type { AuthProfileStore } from "../auth-profiles/types.js";
@@ -426,7 +427,7 @@ export function createPdfTool(options?: {
       : DEFAULT_MAX_PAGES;
 
   const description =
-    'Analyze PDF(s): Anthropic/Google native when supported, else text/image extraction. pdf one; pdfs max 10; prompt says inspection. `pages` selects a page range ("1-5", "1,3,5-7"); `password` opens encrypted PDFs (both non-native only).';
+    'Analyze PDF(s): Anthropic/Google native when supported, else text/image extraction. pdf one; pdfs max 10; prompt says inspection. `pages` selects a page range ("1-5", "1,3,5-7"); `password` opens encrypted PDFs (both non-native only). Scanned PDF with no text layer and no working vision model: falls back to local OCR (raw extracted text only, no interpretation).';
   const remoteMediaSsrfPolicy = resolveRemoteMediaSsrfPolicy(options?.config);
 
   return {
@@ -581,7 +582,11 @@ export function createPdfTool(options?: {
         });
       }
 
+      let extractionCache: PdfExtractedContent[] | null = null;
       const getExtractions = async (): Promise<PdfExtractedContent[]> => {
+        if (extractionCache) {
+          return extractionCache;
+        }
         const extractedAll: PdfExtractedContent[] = [];
         for (const pdf of loadedPdfs) {
           // Extraction is sequential and can be CPU-heavy. Do not start the next
@@ -598,28 +603,99 @@ export function createPdfTool(options?: {
           });
           extractedAll.push(extracted);
         }
+        extractionCache = extractedAll;
         return extractedAll;
       };
 
-      // Do not issue a paid PDF-model call for an already-aborted run.
-      signal?.throwIfAborted();
-      const result = await runPdfPrompt({
-        signal,
-        cfg: options?.config,
-        agentId: options?.agentId,
-        agentDir,
-        ...(options?.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
-        ...(options?.preparedModelRuntime
-          ? { preparedModelRuntime: options.preparedModelRuntime }
-          : {}),
-        pdfModelConfig,
-        modelOverride,
-        prompt: promptRaw,
-        pdfBuffers: loadedPdfs,
-        ...(password ? { password } : {}),
-        pageNumbers,
-        getExtractions,
-      });
+      let result: Awaited<ReturnType<typeof runPdfPrompt>>;
+      let usedLocalOcrFallback = false;
+      try {
+        // Do not issue a paid PDF-model call for an already-aborted run.
+        signal?.throwIfAborted();
+        result = await runPdfPrompt({
+          signal,
+          cfg: options?.config,
+          agentId: options?.agentId,
+          agentDir,
+          ...(options?.workspaceDir ? { workspaceDir: options.workspaceDir } : {}),
+          ...(options?.preparedModelRuntime
+            ? { preparedModelRuntime: options.preparedModelRuntime }
+            : {}),
+          pdfModelConfig,
+          modelOverride,
+          prompt: promptRaw,
+          pdfBuffers: loadedPdfs,
+          ...(password ? { password } : {}),
+          pageNumbers,
+          getExtractions,
+        });
+      } catch (visionError) {
+        // Every vision backend is unconfigured or failed. Only worth a local OCR
+        // attempt when the document actually is a scan with no text layer — a
+        // normal textual PDF failing here is a real model/config problem, not an
+        // OCR-shaped one, so it should keep surfacing the original error. Reuse
+        // extraction results if the failed run already computed them (it usually
+        // has, since every non-native candidate needs them); if extraction itself
+        // is what's broken (bad input, wrong password, corrupt PDF), OCR cannot
+        // help either, so the original error is still the right one to surface.
+        let isScannedWithNoTextLayer = false;
+        if (!signal?.aborted) {
+          try {
+            const extractions = await getExtractions();
+            isScannedWithNoTextLayer = extractions.every(
+              (e) => e.text.trim().length < PDF_MIN_TEXT_CHARS && e.images.length > 0,
+            );
+          } catch {
+            isScannedWithNoTextLayer = false;
+          }
+        }
+        if (!isScannedWithNoTextLayer || signal?.aborted) {
+          throw visionError;
+        }
+        const ocrPageNumbers =
+          pageNumbers ?? Array.from({ length: configuredMaxPages }, (_, i) => i + 1);
+        let ocrText: string;
+        try {
+          const ocrTexts: string[] = [];
+          for (const pdf of loadedPdfs) {
+            signal?.throwIfAborted();
+            const ocr = await runLocalPdfOcr({
+              buffer: pdf.buffer,
+              pageNumbers: ocrPageNumbers,
+              ...(password ? { password } : {}),
+            });
+            if (ocr.text) {
+              ocrTexts.push(loadedPdfs.length > 1 ? `[${pdf.filename}]\n${ocr.text}` : ocr.text);
+            }
+          }
+          ocrText = ocrTexts.join("\n\n").trim();
+        } catch (ocrError) {
+          const reason =
+            ocrError instanceof PdfOcrUnavailableError
+              ? ocrError.message
+              : `local OCR failed: ${ocrError instanceof Error ? ocrError.message : String(ocrError)}`;
+          throw new Error(
+            `PDF has no text layer and every vision model failed (${(visionError as Error).message}). ${reason}`,
+            { cause: ocrError },
+          );
+        }
+        if (!ocrText.trim()) {
+          throw new Error(
+            `PDF has no text layer and every vision model failed (${(visionError as Error).message}). ` +
+              "Local OCR ran but found no readable text either — this looks like a chart, a skewed " +
+              "table, or handwriting rather than plain scanned text, and those still need a working vision model.",
+            { cause: visionError },
+          );
+        }
+        usedLocalOcrFallback = true;
+        result = {
+          text: ocrText,
+          provider: "local",
+          model: "tesseract-ocr",
+          native: false,
+          attempts: [],
+        };
+      }
 
       const singlePdf = loadedPdfs.length === 1 ? loadedPdfs.at(0) : undefined;
       const pdfDetails = singlePdf
@@ -636,7 +712,11 @@ export function createPdfTool(options?: {
             ),
           };
 
-      return buildTextToolResult(result, { native: result.native, ...pdfDetails });
+      return buildTextToolResult(result, {
+        native: result.native,
+        ...(usedLocalOcrFallback ? { ocrFallback: true } : {}),
+        ...pdfDetails,
+      });
     },
   };
 }

--- a/src/media/pdf-ocr-local.ts
+++ b/src/media/pdf-ocr-local.ts
@@ -1,0 +1,143 @@
+/**
+ * Local OCR fallback for scanned PDFs.
+ *
+ * No network, no credentials: rasterizes pages with poppler's `pdftoppm` and reads them
+ * with the local `tesseract` binary. Used only when local text extraction comes back
+ * empty/near-empty (a scan with no text layer) and every configured vision model has
+ * failed or none is configured. This is text EXTRACTION, not comprehension — charts,
+ * skewed tables, and handwriting still need a vision model and should keep failing
+ * explicitly rather than silently returning garbage.
+ */
+import { execFile } from "node:child_process";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { promisify } from "node:util";
+
+const execFileAsync = promisify(execFile);
+
+const DEFAULT_RASTER_DPI = 200;
+const DEFAULT_OCR_LANG = "por";
+const OCR_TIMEOUT_MS = 120_000;
+
+/** Thrown when the local OCR toolchain (pdftoppm/tesseract) is not installed. */
+export class PdfOcrUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super(
+      "Local OCR fallback unavailable: pdftoppm/tesseract not found on this host " +
+        "(expects poppler-utils + tesseract-ocr installed by the fleet's 'ocr' ansible role).",
+    );
+    this.name = "PdfOcrUnavailableError";
+    this.cause = cause;
+  }
+}
+
+async function toolExists(bin: string): Promise<boolean> {
+  try {
+    await execFileAsync(bin, ["-v"], { timeout: 5_000 });
+    return true;
+  } catch (error) {
+    // Both binaries print version/usage to stderr and exit non-zero on `-v`;
+    // any execution error other than "binary not found" still proves it exists.
+    const code = (error as NodeJS.ErrnoException)?.code;
+    return code !== "ENOENT";
+  }
+}
+
+async function rasterizePdfPages(params: {
+  pdfPath: string;
+  outDir: string;
+  password?: string;
+  pageNumbers: number[];
+  dpi?: number;
+}): Promise<string[]> {
+  const prefix = path.join(params.outDir, "page");
+  const files: string[] = [];
+  let lastError: unknown;
+  for (const page of params.pageNumbers) {
+    const args = [
+      "-r",
+      String(params.dpi ?? DEFAULT_RASTER_DPI),
+      "-png",
+      "-f",
+      String(page),
+      "-l",
+      String(page),
+      ...(params.password ? ["-upw", params.password] : []),
+      params.pdfPath,
+      `${prefix}-${String(page).padStart(6, "0")}`,
+    ];
+    try {
+      await execFileAsync("pdftoppm", args, { timeout: OCR_TIMEOUT_MS });
+    } catch (error) {
+      // A requested page past the document's real length (the default range is
+      // capped by the tool's maxPages, not the PDF's actual page count) is not
+      // a hard failure as long as at least one earlier page rasterized.
+      lastError = error;
+    }
+  }
+  const entries = await fs.readdir(params.outDir);
+  if (entries.length === 0 && lastError) {
+    throw lastError instanceof Error
+      ? lastError
+      : new Error("pdftoppm failed to rasterize any page", { cause: lastError });
+  }
+  for (const entry of entries.toSorted()) {
+    if (entry.endsWith(".png")) {
+      files.push(path.join(params.outDir, entry));
+    }
+  }
+  return files;
+}
+
+async function ocrImage(imagePath: string, lang: string): Promise<string> {
+  const { stdout } = await execFileAsync("tesseract", [imagePath, "-", "-l", lang], {
+    timeout: OCR_TIMEOUT_MS,
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return stdout.trim();
+}
+
+/**
+ * Rasterizes the given PDF pages and OCRs each one locally, returning the concatenated
+ * page text. Throws `PdfOcrUnavailableError` when the toolchain is missing; throws a plain
+ * `Error` for any other OCR failure (corrupt PDF, wrong password, etc).
+ */
+export async function runLocalPdfOcr(params: {
+  buffer: Buffer;
+  pageNumbers: number[];
+  password?: string;
+  lang?: string;
+}): Promise<{ text: string; pagesProcessed: number }> {
+  if (params.pageNumbers.length === 0) {
+    return { text: "", pagesProcessed: 0 };
+  }
+  if (!(await toolExists("pdftoppm")) || !(await toolExists("tesseract"))) {
+    throw new PdfOcrUnavailableError(new Error("pdftoppm or tesseract binary not found"));
+  }
+
+  const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), "openclaw-pdf-ocr-"));
+  try {
+    const pdfPath = path.join(tmpDir, "input.pdf");
+    await fs.writeFile(pdfPath, params.buffer);
+
+    const pages = await rasterizePdfPages({
+      pdfPath,
+      outDir: tmpDir,
+      pageNumbers: params.pageNumbers,
+      ...(params.password ? { password: params.password } : {}),
+    });
+
+    const lang = params.lang?.trim() || DEFAULT_OCR_LANG;
+    const pageTexts: string[] = [];
+    for (const [i, imagePath] of pages.entries()) {
+      const text = await ocrImage(imagePath, lang);
+      if (text) {
+        pageTexts.push(pages.length > 1 ? `[page ${i + 1}]\n${text}` : text);
+      }
+    }
+    return { text: pageTexts.join("\n\n").trim(), pagesProcessed: pages.length };
+  } finally {
+    await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+  }
+}


### PR DESCRIPTION
## What changed

The `pdf` tool had zero path for a scanned PDF (image-only page, no text
layer) once every configured vision model failed or none was configured —
native providers and the extraction-fallback model call both need a working
vision-capable model, and there was no other option.

Adds a local OCR fallback, gated tightly so it only ever engages for that
exact case:

- Extraction stays lazy (unchanged) so native-provider and normal textual
  PDFs never pay for it.
- When every vision-model candidate fails or none is configured, the tool
  checks whether extraction already showed a near-empty text layer
  (`< 200 chars`) *and* rendered images (the existing scan-detection signal
  reused from the extraction fallback path). If extraction itself never ran
  or also fails, the original vision error is what surfaces — OCR can't help
  there.
- Only for a confirmed scan: rasterize the requested pages with `pdftoppm`
  (poppler) and OCR each page with the local `tesseract` binary (`por` by
  default). No network call, no credentials. The OCR text is returned as-is
  — this is text **extraction**, not comprehension, so it is never fed back
  through a model.
- If the toolchain is missing, the tool raises a clear
  `Local OCR fallback unavailable: ...` instead of degrading silently.
- If OCR runs but finds nothing (chart, skewed table, handwriting), the tool
  still errors, explicitly saying those need a working vision model —
  distinct from "couldn't read the text at all".
- New `src/media/pdf-ocr-local.ts` module; `details.ocrFallback: true` is set
  on a successful OCR-fallback result.

## Validation run

- `node scripts/run-vitest.mjs run src/agents/tools/pdf-tool.test.ts src/agents/tools/pdf-tool.ocr-fallback.test.ts` — 38/38 pass (all pre-existing PDF-tool tests unaffected; 4 new OCR-fallback tests: success, textual-PDF-unaffected, toolchain-missing, OCR-finds-nothing).
- `node scripts/run-vitest.mjs run src/agents/tools/pdf-tool.helpers.test.ts src/agents/tools/pdf-tool.model-catalog.test.ts src/agents/tools/pdf-native-providers.test.ts src/agents/tools/pdf-tool.model-config.test.ts src/agents/tools/pdf-tool.native-providers.test.ts src/agents/tools/pdf-tool.runtime-abort.test.ts src/agents/tools/pdf-tool.static-runtime.test.ts src/media/pdf-extract.test.ts` — 76/76 pass, including "uses native PDF path without eager extraction" (confirms native/textual paths are unaffected).
- `pnpm tsgo:core` — clean.
- `node scripts/run-oxlint.mjs` on the touched files — clean.
- Live end-to-end proof on a host with the toolchain installed: built a fabricated scanned PDF (pure raster page, `pdftotext` confirms empty text layer), ran `runLocalPdfOcr` directly against it — output: `"Prestação de serviço — Soluções Agrícolas Ltda\n\nTotal: R$ 3.947,55\n\nData de emissão: 08/09/2026"`, matching the source image exactly (accentuation included).

## Trade-offs / residual risks

- OCR accuracy/quality is whatever `tesseract` gives at 200 DPI with the
  `por` model — no attempt to tune DPI or language selection beyond the
  existing fleet default.
- Multi-PDF OCR runs pages sequentially per PDF; fine for the occasional
  scan fallback, not optimized for throughput.
- No new tool parameter for OCR language; kept to the minimum surface area
  (default `por`) per the scope of this fix.