### PR TITLE
fix(ui): retire picker focus listeners together

### DIFF
--- a/ui/src/e2e/chat-picker-interaction-contract.e2e.test.ts
+++ b/ui/src/e2e/chat-picker-interaction-contract.e2e.test.ts
@@ -1,15 +1,120 @@
+import { writeFile } from "node:fs/promises";
+import path from "node:path";
+import type { CDPSession } from "playwright";
 import { expect, it } from "vitest";
 import {
+  captureUiProof,
+  captureUiProofEnabled,
   chatSessionListResponse,
   controlUiSessionUrl,
   createChatFlowE2eSuite,
+  expectDefined,
   installMockGateway,
 } from "./chat-flow.test-support.ts";
 import { createControlUiE2eContextOptions } from "./control-ui-e2e-suite.test-support.ts";
 
 const suite = createChatFlowE2eSuite();
 
+async function focusListenerCounts(protocol: CDPSession, selector: string) {
+  const objectGroup = "picker-focus-listeners";
+  try {
+    const { result } = await protocol.send("Runtime.evaluate", {
+      expression: `document.querySelector(${JSON.stringify(selector)})`,
+      objectGroup,
+    });
+    const { listeners } = await protocol.send("DOMDebugger.getEventListeners", {
+      objectId: expectDefined(result.objectId, "mounted picker trigger"),
+    });
+    return {
+      blur: listeners.filter((listener) => listener.type === "blur").length,
+      keydown: listeners.filter((listener) => listener.type === "keydown").length,
+    };
+  } finally {
+    await protocol.send("Runtime.releaseObjectGroup", { objectGroup });
+  }
+}
+
 suite.define(() => {
+  it.each(["blur", "keydown"] as const)(
+    "keeps retained trigger listeners bounded when %s completes pointer focus",
+    async (completion) => {
+      await suite.withPage(
+        {
+          locale: "en-US",
+          reducedMotion: "reduce",
+          serviceWorkers: "block",
+          viewport: { height: 900, width: 1280 },
+        },
+        async ({ context, page }) => {
+          const gateway = await installMockGateway(page, {});
+          await page.goto(`${suite.server.baseUrl}chat`);
+          await gateway.waitForRequest("chat.startup");
+          const selector =
+            'openclaw-chat-pane[aria-hidden="false"] [data-chat-permission-select="true"]';
+          const trigger = page.locator(selector);
+          const picker = page.locator(
+            'openclaw-chat-pane[aria-hidden="false"] .chat-controls__permission-picker',
+          );
+          const composer = page.locator(
+            'openclaw-chat-pane[aria-hidden="false"] .agent-chat__composer-combobox textarea',
+          );
+          const retainedTrigger = expectDefined(await trigger.elementHandle(), "picker trigger");
+          const protocol = await context.newCDPSession(page);
+          const marker = "data-chat-pointer-restored-focus";
+          try {
+            const cycle = async () => {
+              await trigger.click();
+              await expect.poll(() => trigger.getAttribute(marker)).toBe("");
+              expect(
+                await retainedTrigger.evaluate(
+                  (element, triggerSelector) => element === document.querySelector(triggerSelector),
+                  selector,
+                ),
+              ).toBe(true);
+              expect(await trigger.evaluate((element) => document.activeElement === element)).toBe(
+                true,
+              );
+              if (completion === "blur") {
+                await composer.click();
+              } else {
+                await trigger.press("Shift");
+              }
+              await expect.poll(() => trigger.getAttribute(marker)).toBeNull();
+              if (completion === "keydown") {
+                // Close on the same focused trigger; blur would consume the companion listener.
+                await trigger.click();
+              }
+              await expect.poll(() => picker.getAttribute("open")).toBeNull();
+            };
+            // Warm Web Awesome's own bindings, then compare the same completed phase.
+            await cycle();
+            const before = await focusListenerCounts(protocol, selector);
+            for (let index = 0; index < 20; index += 1) {
+              await cycle();
+            }
+            const after = await focusListenerCounts(protocol, selector);
+            if (captureUiProofEnabled) {
+              await writeFile(
+                path.join(suite.artifactDir, `${completion}-listeners.json`),
+                `${JSON.stringify({ browser: suite.browser.version(), completion, cycles: 20, before, after, retainedTriggerConnected: await retainedTrigger.evaluate((element) => element.isConnected) }, null, 2)}\n`,
+              );
+            }
+            await captureUiProof(suite, page, "picker-focus", `${completion}-completed.png`);
+            await trigger.click();
+            await expect.poll(() => trigger.getAttribute(marker)).toBe("");
+            await captureUiProof(suite, page, "picker-focus", `${completion}-open.png`);
+            await trigger.press("Shift");
+            await expect.poll(() => trigger.getAttribute(marker)).toBeNull();
+            expect(after).toEqual(before);
+          } finally {
+            await protocol.detach();
+            await retainedTrigger.dispose();
+          }
+        },
+      );
+    },
+  );
+
   it("shows the selected permission and disables dropdown motion when requested", async () => {
     const context = await suite.newBrowserContext({
       locale: "en-US",

--- a/ui/src/pages/chat/components/chat-picker-overlay.ts
+++ b/ui/src/pages/chat/components/chat-picker-overlay.ts
@@ -46,6 +46,13 @@ function pickerTrigger(picker: HTMLElement): HTMLElement | null {
     : picker.querySelector<HTMLElement>("[slot=trigger]");
 }
 
+function clearPointerFocus(this: HTMLElement): void {
+  // Blur and keyboard takeover complete the same pointer-focus lifetime.
+  this.removeEventListener("blur", clearPointerFocus);
+  this.removeEventListener("keydown", clearPointerFocus);
+  this.removeAttribute(POINTER_RESTORED_FOCUS_ATTRIBUTE);
+}
+
 function dismissChatComposerPickersOutside(event: PointerEvent): void {
   const path = event.composedPath();
   for (const picker of openChatComposerPickers()) {
@@ -186,7 +193,6 @@ export function restorePointerOpenedChatComposerTrigger(event: Event): void {
       return;
     }
     trigger.setAttribute(POINTER_RESTORED_FOCUS_ATTRIBUTE, "");
-    const clearPointerFocus = () => trigger.removeAttribute(POINTER_RESTORED_FOCUS_ATTRIBUTE);
     trigger.addEventListener("blur", clearPointerFocus, { once: true });
     trigger.addEventListener("keydown", clearPointerFocus, { once: true });
     trigger.focus({ preventScroll: true });


### PR DESCRIPTION
Closes #142257
Related: #134713

<details>
<summary>Additional instructions</summary>

Keep **Allow edits from maintainers** enabled.

</details>

## What Problem This Solves

Repeated mouse opening and blur completion of a chat picker leave unused keydown listeners attached to the mounted trigger. Each opening registered a fresh callback separately for once-only blur and keydown, so firing one event left its companion behind.

## Why This Change Was Made

One stateless native listener now completes the pointer-focus lifetime: either event removes both registrations before clearing the existing marker. Reusing that callback also avoids creating a trigger-capturing closure on every opening. The existing WeakSet admission, focus with preventScroll, keyboard takeover, global dismissal and permission selection stay intact. The broader document-dismissal work in #134713 is separate.

## User Impact

Mouse-only picker use no longer accumulates completion listeners on a retained trigger. Appearance and focus behavior are preserved. Production grows by six lines for paired cleanup; the browser regression adds 105 lines. No configuration, Gateway, authorization, persistent-store or dependency changes, and no heap-byte or latency claim.

## Evidence

- The exact original production source with the final Chromium test fails only the intended mouse-cycle regression: native keydown listeners grow from 1 to 21 across 20 cycles on the identical retained trigger. The candidate remains 0 to 0.
- The keyboard sibling remains bounded on the original implementation because the next Web Awesome opening naturally consumes its blur companion; the candidate retires it immediately. No accumulating keyboard leak is claimed.
- All four candidate browser tests and four existing owner unit tests pass, covering pointer restoration, marker clearing, keyboard/tooltip priority, nested Escape, permission styling and reduced-motion picker behavior. Full selected changed gate and final independent P2 review pass with no findings.
- This maintainer-authored repair uses the complete Control UI in actual Chromium with synthetic mocked-Gateway responses. The inspected before/after captures are byte-identical and show preserved picker appearance; listener retention is measured by native CDP assertions. No live Gateway/account/provider was used.

![Before: synthetic picker appearance after mouse opening](https://github.com/user-attachments/assets/50f7a976-27c9-4f07-8cea-2e9eacfb44f5)

![After: preserved synthetic picker appearance after mouse opening](https://github.com/user-attachments/assets/fe032785-b424-45f4-a68f-4adaf8474c21)