### PR TITLE
fix(release): keep changelog credits within verified history

### DIFF
--- a/.agents/skills/openclaw-changelog-update/SKILL.md
+++ b/.agents/skills/openclaw-changelog-update/SKILL.md
@@ -76,6 +76,13 @@ every human `Thanks @...` attribution.
    `--refresh-github-snapshot` after suspect API data, `--github-snapshot
 <path>` for an explicit artifact, or `--no-github-snapshot` for a live-only
    audit. GitHub release bodies are always read live.
+   Explicit `CI #`, `CI run #`, `Actions run #`, and `workflow run #` references
+   in active source are classified separately only when issue/PR resolution
+   fails and a live same-repository Actions lookup confirms the exact run ID.
+   Any ordinary occurrence of that number in active source, notes, or the
+   contribution record remains a strict issue/PR requirement. Confirmed runs
+   appear as `workflowRuns` in verification output and the manifest, never as
+   PR associations or contributor credit.
    - the manifest is the required input to the rewrite, not an after-the-fact
      audit; it contains every referenced PR, eligible contributor credit,
      inline issue context, every direct commit, and an editorial-eligibility
@@ -100,10 +107,24 @@ every human `Thanks @...` attribution.
      target prose, or target record. The manifest and generated provenance retain
      each tag plus the exact excluded PR inventory and count for deterministic
      candidate validation
-   - source PR discovery combines merged GitHub commit associations with merged
-     PR references explicitly present in active commit subjects/bodies so
-     cherry-picks and squash commits remain accounted for. Resolve every
-     association page and exclude PRs merged after the target release commit
+   - source PR discovery bounds GitHub commit associations to the selected target
+     history, or the frozen main history for canonical carriers. A contextual
+     source reference becomes a contribution only when its merged commit is
+     reachable in the target history and its merge time is within the target.
+     Keep all references resolvable, but do not promote unrelated PRs merely
+     because they merge while release preparation continues. Explicit seeds
+     retain their historical membership and remain seed-only unless independently
+     proven in-range. Resolve every association page; existing canonical,
+     cherry-pick, and provenance contracts remain authoritative.
+   - explicit multi-commit reverts require a revert subject and one standalone
+     `Reverts <full SHA> and <full SHA>.` declaration (comma-separated lists
+     with final `and` also work). The exact ending ` to restore the previous behavior.`
+     is accepted. Duplicate, abbreviated, embedded, or repeated declarations do
+     not establish reversal. Each named commit must be a single-parent ancestor,
+     and reverse-applying all named patches must reproduce the complete revert
+     tree. Recognized declarations that fail this proof stop verification. Proof
+     uses private Git index/object storage without hooks or external diffs;
+     canonical single-revert and revert-of-revert accounting stays intact.
    - canonicalize backports to the original merged PR on `main`: explicit
      cherry-pick origins win, then a unique normalized-subject match requires
      the same author and an overlapping changed path. Suppress release/backport
@@ -162,11 +183,12 @@ every human `Thanks @...` attribution.
      infer a PR relationship from a generic cross-reference event, invent an
      unrelated PR link for a standalone report, or recreate the retired
      inventory
-   - the complete contribution record lists every merged source PR exactly once
-     as `**PR #NNN**`; source PRs include GitHub commit associations and merged
-     PR references explicitly present in active commit subjects/bodies. It
-     preserves author/co-author credit and any issue references in the original
-     title
+   - the complete contribution record lists every verified in-range PR and
+     explicitly retained seed-only PR exactly once as `**PR #NNN**`. Discovery
+     preserves canonical/cherry-pick provenance and requires frozen-history
+     membership for contextual references; inline context alone cannot create a
+     contribution row. It preserves author/co-author credit and any issue
+     references in the original title
    - the provenance arithmetic and unique total must match the rendered PR
      rows exactly; candidate validation rejects malformed or forged counts
    - direct commits remain in the manifest with GitHub-resolved author,

--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -10,6 +10,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import {
@@ -582,6 +583,98 @@ export function standardRevertedHash(message) {
   return undefined;
 }
 
+function verifiedMultiRevertedHashes(hash, subject, body) {
+  if (!/^(?:[a-z][a-z0-9-]*(?:\([^)]+\))?!?:\s*)?revert\b/i.test(subject)) {
+    return [];
+  }
+  const declarations = body
+    .trim()
+    .split(/\n\s*\n/)
+    .map((paragraph) => paragraph.trim())
+    .map((paragraph) =>
+      paragraph.match(
+        /^Reverts ([0-9a-f]{40}(?:, [0-9a-f]{40})*(?:,? and [0-9a-f]{40}))(?:\.| to restore the previous behavior\.)$/i,
+      ),
+    )
+    .filter(Boolean);
+  if (declarations.length !== 1) {
+    return [];
+  }
+  const targets = declarations[0][1].toLowerCase().match(/[0-9a-f]{40}/g);
+  if (new Set(targets).size !== targets.length) {
+    return [];
+  }
+
+  let temporaryDirectory;
+  try {
+    const parents = git(["rev-list", "--parents", "-n", "1", hash]).split(/\s+/);
+    if (parents.length !== 2) {
+      throw new Error("the revert must have exactly one parent");
+    }
+    const parent = parents[1];
+    for (const target of targets) {
+      if (gitCommit(target) !== target || !gitIsAncestor(target, parent)) {
+        throw new Error(`target ${target} must be an existing ancestor of the revert parent`);
+      }
+      if (git(["rev-list", "--parents", "-n", "1", target]).split(/\s+/).length !== 2) {
+        throw new Error(`target ${target} must have exactly one parent`);
+      }
+    }
+    const orderedTargets = git(["rev-list", "--topo-order", parent])
+      .split("\n")
+      .filter((candidate) => targets.includes(candidate));
+    const originalObjects = git(["rev-parse", "--path-format=absolute", "--git-path", "objects"]);
+    temporaryDirectory = mkdtempSync(path.join(tmpdir(), "openclaw-release-revert-"));
+    const objects = path.join(temporaryDirectory, "objects");
+    mkdirSync(objects);
+    const env = {
+      ...process.env,
+      GIT_NO_LAZY_FETCH: "1",
+      GIT_INDEX_FILE: path.join(temporaryDirectory, "index"),
+      GIT_OBJECT_DIRECTORY: objects,
+      GIT_ALTERNATE_OBJECT_DIRECTORIES: [
+        JSON.stringify(originalObjects),
+        process.env.GIT_ALTERNATE_OBJECT_DIRECTORIES,
+      ]
+        .filter(Boolean)
+        .join(path.delimiter),
+    };
+    const privateGit = (args, input) =>
+      execFileSync(
+        "git",
+        ["-c", `core.hooksPath=${path.join(temporaryDirectory, "hooks")}`, ...args],
+        { env, input, maxBuffer: 16 * 1024 * 1024, stdio: ["pipe", "pipe", "pipe"] },
+      );
+    privateGit(["read-tree", parent]);
+    for (const target of orderedTargets) {
+      // Keep patch bytes intact; text decoding corrupts binary/non-UTF-8 reversals.
+      const patch = privateGit([
+        "diff-tree",
+        "--binary",
+        "--full-index",
+        "--no-ext-diff",
+        "--no-textconv",
+        "--no-renames",
+        "-p",
+        `${target}^`,
+        target,
+      ]);
+      privateGit(["apply", "--cached", "--reverse", "--whitespace=nowarn", "-"], patch);
+    }
+    const reversedTree = privateGit(["write-tree"]).toString("utf8").trim();
+    if (reversedTree !== git(["rev-parse", `${hash}^{tree}`])) {
+      throw new Error("declared inverse patches do not reproduce the complete revert tree");
+    }
+    return targets;
+  } catch (error) {
+    fail(`could not verify explicit multi-commit revert ${hash}: ${error.message}`);
+  } finally {
+    if (temporaryDirectory) {
+      rmSync(temporaryDirectory, { recursive: true, force: true });
+    }
+  }
+}
+
 function handlesIn(text) {
   const thanksStart = text.lastIndexOf(" Thanks ");
   if (thanksStart < 0) {
@@ -817,17 +910,26 @@ export function contaminatingPullRequestReferences({
   nodes,
 }) {
   const allowed = new Set([...sourcePullRequests, ...seededPullRequests]);
+  const allowedEditorial = new Set(allowed);
   for (const number of sourceReferences) {
     if (nodes.get(number)?.__typename === "PullRequest") {
-      allowed.add(number);
+      allowedEditorial.add(number);
     }
   }
   const effectiveRecordedReferences = recordedReferences.filter(
     (number) => !excludedRecordedReferences.has(number),
   );
-  return [...new Set([...noteReferences, ...effectiveRecordedReferences])].filter(
-    (number) => nodes.get(number)?.__typename === "PullRequest" && !allowed.has(number),
-  );
+  return [
+    ...new Set([
+      ...noteReferences.filter(
+        (number) =>
+          nodes.get(number)?.__typename === "PullRequest" && !allowedEditorial.has(number),
+      ),
+      ...effectiveRecordedReferences.filter(
+        (number) => nodes.get(number)?.__typename === "PullRequest" && !allowed.has(number),
+      ),
+    ]),
+  ];
 }
 
 function appendReferences(references, additions) {
@@ -1037,6 +1139,9 @@ function canonicalMainCommits(base, mainRef) {
 
 function sourceCommits(base, target, mainRef, releaseProvenance = []) {
   const targetCommit = git(["rev-parse", `${target}^{commit}`]);
+  const targetHistory = new Set(git(["rev-list", targetCommit]).split("\n"));
+  const mainCommit = mainRef ? gitCommit(mainRef, true) : undefined;
+  const mainHistory = mainCommit ? new Set(git(["rev-list", mainCommit]).split("\n")) : new Set();
   if (!gitIsAncestor(base, targetCommit)) {
     fail(`release range base ${base} must be an ancestor of target ${target}`);
   }
@@ -1053,6 +1158,17 @@ function sourceCommits(base, target, mainRef, releaseProvenance = []) {
     "--format=%H%x1f%s%x1f%an%x1f%ae%x1f%cI%x1f%B%x1e",
     `${mergeBase}..${targetCommit}`,
   ]);
+  const revertedTargetsByCommit = new Map();
+  const revertedHashesFor = (hash, subject, body) => {
+    if (!revertedTargetsByCommit.has(hash)) {
+      const standard = standardRevertedHash(body);
+      revertedTargetsByCommit.set(
+        hash,
+        standard ? [standard] : verifiedMultiRevertedHashes(hash, subject, body),
+      );
+    }
+    return revertedTargetsByCommit.get(hash);
+  };
   const commits = new Map();
   const revertsByTarget = new Map();
   for (const record of output.split("\x1e")) {
@@ -1063,8 +1179,8 @@ function sourceCommits(base, target, mainRef, releaseProvenance = []) {
       record.split("\x1f");
     const hash = rawHash.trim();
     const body = bodyParts.join("\x1f");
-    const revertedHash = standardRevertedHash(body);
-    const isRevert = Boolean(revertedHash) || subject.startsWith('Revert "');
+    const revertedHashes = revertedHashesFor(hash, subject, body);
+    const isRevert = revertedHashes.length > 0 || subject.startsWith('Revert "');
     commits.set(hash, {
       authorEmail,
       authorName,
@@ -1072,21 +1188,20 @@ function sourceCommits(base, target, mainRef, releaseProvenance = []) {
       committedAt,
       hash,
       isRevert,
-      revertedHash,
+      revertedHashes,
       subject,
     });
   }
   for (const commit of commits.values()) {
-    if (!commit.revertedHash) {
-      continue;
-    }
-    const targetHash = [...commits.keys()].find((candidate) =>
-      candidate.startsWith(commit.revertedHash),
-    );
-    if (targetHash) {
-      const reverts = revertsByTarget.get(targetHash) ?? [];
-      reverts.push(commit.hash);
-      revertsByTarget.set(targetHash, reverts);
+    for (const revertedHash of commit.revertedHashes) {
+      const targetHash = [...commits.keys()].find((candidate) =>
+        candidate.startsWith(revertedHash),
+      );
+      if (targetHash) {
+        const reverts = revertsByTarget.get(targetHash) ?? [];
+        reverts.push(commit.hash);
+        revertsByTarget.set(targetHash, reverts);
+      }
     }
   }
   const active = new Map();
@@ -1100,7 +1215,7 @@ function sourceCommits(base, target, mainRef, releaseProvenance = []) {
     return value;
   }
   const revertedCommitStates = new Map();
-  function revertedCommitState(ref, seen = new Set()) {
+  function revertedCommitStatesFor(ref, seen = new Set()) {
     let hash;
     try {
       hash = git(["rev-parse", `${ref}^{commit}`]);
@@ -1119,13 +1234,16 @@ function sourceCommits(base, target, mainRef, releaseProvenance = []) {
     const [subject, ...bodyParts] = commitOutput.split("\x1f");
     const body = bodyParts.join("\x1f");
     const message = `${subject}\n${body}`;
-    const revertedHash = standardRevertedHash(body);
-    const targetState = revertedHash ? revertedCommitState(revertedHash, seen) : undefined;
-    const state = targetState
-      ? { ...targetState, depth: targetState.depth + 1 }
-      : { depth: 0, hash, references: referencesIn(message) };
-    revertedCommitStates.set(hash, state);
-    return state;
+    const targets = revertedHashesFor(hash, subject, body);
+    const targetStates = targets.flatMap(
+      (target) => revertedCommitStatesFor(target, new Set(seen)) ?? [],
+    );
+    const states =
+      targetStates.length > 0
+        ? targetStates.map((state) => ({ ...state, depth: state.depth + 1 }))
+        : [{ depth: 0, hash, references: referencesIn(message) }];
+    revertedCommitStates.set(hash, states);
+    return states;
   }
 
   const references = [];
@@ -1187,34 +1305,31 @@ function sourceCommits(base, target, mainRef, releaseProvenance = []) {
     });
   }
   for (const commit of commits.values()) {
-    if (!commit.isRevert || !commit.revertedHash || !isActive(commit.hash)) {
+    if (!commit.isRevert || !isActive(commit.hash)) {
       continue;
     }
-    const targetInRange = [...commits.keys()].some((candidate) =>
-      candidate.startsWith(commit.revertedHash),
-    );
-    if (targetInRange) {
-      continue;
-    }
-    const revertedState = revertedCommitState(commit.revertedHash);
-    if (!revertedState) {
-      continue;
-    }
-    if (revertedState.depth % 2 !== 0) {
-      continue;
-    }
-    revertedCommitHashes.add(revertedState.hash);
-    for (const number of revertedState.references) {
-      revertedReferences.add(number);
+    for (const revertedHash of commit.revertedHashes) {
+      if ([...commits.keys()].some((candidate) => candidate.startsWith(revertedHash))) {
+        continue;
+      }
+      for (const state of revertedCommitStatesFor(revertedHash) ?? []) {
+        if (state.depth % 2 !== 0) {
+          continue;
+        }
+        revertedCommitHashes.add(state.hash);
+        for (const number of state.references) {
+          revertedReferences.add(number);
+        }
+      }
     }
   }
   const activePullRequests = resolveAssociatedPullRequests(
     activeCommits.map((commit) => commit.hash),
     targetTimestamp,
+    targetHistory,
   );
   const provenanceOverrides = collectReleaseProvenanceOverrides(activeCommits, releaseProvenance);
-  const mainCommits = canonicalMainCommits(base, mainRef);
-  const mainCommit = provenanceOverrides.size > 0 ? gitCommit(mainRef, true) : undefined;
+  const mainCommits = canonicalMainCommits(base, mainCommit);
   const mainCommitsByHash = new Map(mainCommits.map((commit) => [commit.hash, commit]));
   const mainCommitsBySubject = new Map();
   for (const commit of mainCommits) {
@@ -1278,6 +1393,7 @@ function sourceCommits(base, target, mainRef, releaseProvenance = []) {
   const candidateMainPullRequests = resolveAssociatedPullRequests(
     [...mainAssociationCandidateHashes],
     Number.POSITIVE_INFINITY,
+    mainHistory,
   );
   for (const { candidates, commit, pullRequestOrigins } of pendingCanonicalMatches) {
     const matches = canonicalMainCommitMatches(
@@ -1305,6 +1421,7 @@ function sourceCommits(base, target, mainRef, releaseProvenance = []) {
   const canonicalMainPullRequests = resolveAssociatedPullRequests(
     [...canonicalMainHashes],
     Number.POSITIVE_INFINITY,
+    mainHistory,
   );
   const resolvedCoauthors = resolveCommitCoauthors(activeCommits);
   const pullRequests = new Set();
@@ -1361,6 +1478,7 @@ function sourceCommits(base, target, mainRef, releaseProvenance = []) {
   for (const revertedPullRequestNumbers of resolveAssociatedPullRequests(
     [...revertedCommitHashes],
     targetTimestamp,
+    new Set([...targetHistory, ...mainHistory]),
   ).values()) {
     for (const number of revertedPullRequestNumbers) {
       revertedPullRequests.add(number);
@@ -1399,6 +1517,7 @@ function sourceCommits(base, target, mainRef, releaseProvenance = []) {
     revertedReferences,
     target: targetCommit,
     targetTimestamp,
+    targetHistory,
   };
 }
 
@@ -1436,7 +1555,7 @@ function graphql(query) {
   throw lastError;
 }
 
-function resolveAssociatedPullRequests(commitHashes, targetTimestamp) {
+function resolveAssociatedPullRequests(commitHashes, targetTimestamp, history) {
   const pullRequestsByCommit = new Map();
   const pending = [];
   function appendPullRequests(commitHash, connection) {
@@ -1448,6 +1567,7 @@ function resolveAssociatedPullRequests(commitHashes, targetTimestamp) {
       const isExactMergeCommit = pullRequest.mergeCommit?.oid === commitHash;
       if (
         pullRequest.mergedAt &&
+        history.has(pullRequest.mergeCommit?.oid) &&
         (isExactMergeCommit || mergedByTarget(pullRequest.mergedAt, targetTimestamp)) &&
         !seen.has(pullRequest.number)
       ) {
@@ -1577,6 +1697,48 @@ function resolveIssueRelationshipPages(nodes) {
     }
   }
   return nodes;
+}
+
+function resolveSourceWorkflowRuns(source, nodes, requiredReferences) {
+  const candidates = new Set();
+  const required = new Set([...requiredReferences, ...source.pullRequests]);
+  for (const commit of source.activeCommits) {
+    if (commit.isRevert) {
+      continue;
+    }
+    const message = `${commit.subject}\n${commit.body}`;
+    // Mask only explicitly labelled, unqualified occurrences. The same number
+    // anywhere else remains an issue/PR requirement, even in a different commit.
+    const remaining = message.replace(
+      /(?<![A-Za-z0-9_])(?:CI(?:[ \t]+run)?|Actions[ \t]+run|workflow[ \t]+run)[ \t]+#([1-9]\d*)(?![A-Za-z0-9_])/gi,
+      (_match, number) => {
+        candidates.add(Number(number));
+        return " ";
+      },
+    );
+    for (const number of referencesIn(remaining)) {
+      required.add(number);
+    }
+  }
+  const runs = [];
+  for (const number of candidates) {
+    if (!source.references.includes(number) || nodes.has(number) || required.has(number)) {
+      continue;
+    }
+    const run = githubApi([`repos/${repo}/actions/runs/${number}`]);
+    if (run?.id === number && run.repository?.full_name === repo) {
+      runs.push({ id: number, repository: repo });
+    }
+  }
+  const runIds = new Set(runs.map((run) => run.id));
+  source.references = source.references.filter((number) => !runIds.has(number));
+  for (const commit of source.activeCommits) {
+    commit.references = commit.references.filter((number) => !runIds.has(number));
+  }
+  for (const number of runIds) {
+    source.coauthorsByReference.delete(number);
+  }
+  return runs;
 }
 
 function resolveReferences(numbers) {
@@ -2043,11 +2205,11 @@ export function ledgerFor(
   priorRecord,
   sourcePullRequests,
   sourceReferences,
-  noteReferences,
   legacyIssuePullRequests,
   revertedReferences,
   shippedBaselines,
   targetTimestamp,
+  targetHistory,
 ) {
   const entries = references.map((number) => {
     const node = nodes.get(number);
@@ -2065,10 +2227,20 @@ export function ledgerFor(
     };
   });
 
-  const recordedPullRequests = new Set([
+  // A resolved reference supplies context; only shipped graph evidence supplies membership.
+  const inRangePullRequestNumbers = new Set([
     ...sourcePullRequests,
-    ...sourceReferences,
-    ...noteReferences,
+    ...[...sourceReferences].filter((number) => {
+      const node = nodes.get(number);
+      return (
+        node?.__typename === "PullRequest" &&
+        targetHistory.has(node.mergeCommit?.oid) &&
+        mergedByTarget(node.mergedAt, targetTimestamp)
+      );
+    }),
+  ]);
+  const recordedPullRequests = new Set([
+    ...inRangePullRequestNumbers,
     ...legacyIssuePullRequests,
     ...priorRecord.pullRequests.keys(),
   ]);
@@ -2081,10 +2253,6 @@ export function ledgerFor(
       !revertedReferences.has(entry.number),
   );
   const issues = entries.filter((entry) => entry.type === "Issue");
-  const inRangePullRequestNumbers = new Set([
-    ...sourcePullRequests,
-    ...[...sourceReferences].filter((number) => nodes.get(number)?.__typename === "PullRequest"),
-  ]);
   const legacyIssues = legacyIssuesByPullRequest(priorRecord, nodes);
   const records = pullRequests.map((entry) => {
     const priorEntry = priorRecord.pullRequests.get(entry.number);
@@ -2354,6 +2522,7 @@ function manifestFor(options, source, ledger, directCommitRecords) {
     mergeBase: source.mergeBase,
     version: options.version,
     shippedBaselines: source.shippedBaselines,
+    workflowRuns: source.workflowRuns,
     source: {
       references: ledger.entries.length,
       ...ledger.provenance,
@@ -2497,27 +2666,11 @@ function main() {
         .join(", ")}`,
     );
   }
-  const references = [...source.references];
+  let references = [...source.references];
   appendReferences(references, noteReferences);
   appendReferences(references, effectiveRenderedRecordReferences);
   appendReferences(references, recordedReferences);
   let nodes = resolveReferences(references);
-  const contamination = contaminatingPullRequestReferences({
-    noteReferences,
-    recordedReferences: effectiveRenderedRecordReferences,
-    excludedRecordedReferences,
-    sourcePullRequests: source.pullRequests,
-    sourceReferences: source.references,
-    seededPullRequests: new Set(priorRecord.pullRequests.keys()),
-    nodes,
-  });
-  if (contamination.length > 0) {
-    fail(
-      `release section contains PRs outside ${options.base}..${options.target}: ${contamination
-        .map((number) => `#${number}`)
-        .join(", ")}; use --seed-ref only for an intentional historical backfill`,
-    );
-  }
   const legacyIssuePullRequests = [...legacyIssuesByPullRequest(priorRecord, nodes).keys()].filter(
     (number) => !shippedExclusions.pullRequests.has(number),
   );
@@ -2530,6 +2683,15 @@ function main() {
     recordTarget: committedRecordTarget,
     source,
   });
+  const workflowRuns = resolveSourceWorkflowRuns(source, nodes, [
+    ...noteReferences,
+    ...effectiveRenderedRecordReferences,
+    ...recordedReferences,
+    ...legacyIssuePullRequests,
+  ]);
+  source.workflowRuns = workflowRuns;
+  const workflowRunIds = new Set(workflowRuns.map((run) => run.id));
+  references = references.filter((number) => !workflowRunIds.has(number));
   const unresolvedSourceReferences = references.filter((number) => !nodes.has(number));
   if (unresolvedSourceReferences.length > 0) {
     fail(
@@ -2600,12 +2762,28 @@ function main() {
     priorRecord,
     source.pullRequests,
     source.references,
-    noteReferences,
     legacyIssuePullRequests,
     source.revertedReferences,
     source.shippedBaselines,
     source.targetTimestamp,
+    source.targetHistory,
   );
+  const contamination = contaminatingPullRequestReferences({
+    noteReferences,
+    recordedReferences: options.writeLedger ? [] : [...renderedRecord.pullRequests.keys()],
+    excludedRecordedReferences,
+    sourcePullRequests: new Set(ledger.pullRequests.map((entry) => entry.number)),
+    sourceReferences: source.references,
+    seededPullRequests: new Set(priorRecord.pullRequests.keys()),
+    nodes,
+  });
+  if (contamination.length > 0) {
+    fail(
+      `release section contains PRs outside ${options.base}..${options.target}: ${contamination
+        .map((number) => `#${number}`)
+        .join(", ")}; use --seed-ref only for an intentional historical backfill`,
+    );
+  }
   const manifest = manifestFor(
     { ...options, target: source.target },
     source,
@@ -2653,6 +2831,7 @@ function main() {
   }
 
   const result = {
+    workflowRuns,
     base: options.base,
     target: source.target,
     mergeBase: source.mergeBase,

--- a/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
+++ b/.agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs
@@ -1743,8 +1743,10 @@ function resolveSourceWorkflowRuns(source, nodes, requiredReferences) {
 
 function resolveReferences(numbers) {
   const nodes = new Map();
-  for (let index = 0; index < numbers.length; index += 40) {
-    const chunk = numbers.slice(index, index + 40);
+  // GitHub's issue-number argument is GraphQL Int; Actions run IDs can exceed it.
+  const issueNumbers = numbers.filter((number) => number <= 2147483647);
+  for (let index = 0; index < issueNumbers.length; index += 40) {
+    const chunk = issueNumbers.slice(index, index + 40);
     const fields = chunk
       .map(
         (number) => `n${number}: repository(owner: "openclaw", name: "openclaw") {

--- a/test/scripts/release-notes-ledger.test.ts
+++ b/test/scripts/release-notes-ledger.test.ts
@@ -39,10 +39,10 @@ function contributionLedger({
     new Set(sourcePullRequests),
     sourceReferences,
     [],
-    [],
     new Set(),
     [],
     Date.parse("2026-08-05T00:00:00Z"),
+    new Set([targetSha]),
   ) as ReturnType<typeof ledgerFor> & {
     provenance: {
       inRangePullRequests: number;
@@ -210,15 +210,15 @@ describe("renderContributionRecordEntry", () => {
       new Set(),
       new Set(),
       new Set(),
-      new Set(),
       [],
       Date.parse("2026-07-09T00:00:00Z"),
+      new Set([targetSha]),
     );
 
     expect(result.ledger).toContain("- **PR #125** Thanks @carol and @alice and @bob.");
   });
 
-  it("counts associated and PR-typed source refs before retained seed-only rows", () => {
+  it("counts associated and reachable source PRs before retained seed-only rows", () => {
     const nodes = new Map(
       [1, 2, 3].map((number) => [
         number,
@@ -227,6 +227,7 @@ describe("renderContributionRecordEntry", () => {
           closingIssuesReferences: { nodes: [] },
           mergedAt: "2026-08-04T00:00:00Z",
           title: `fix: contribution ${number}`,
+          mergeCommit: { oid: targetSha },
         },
       ]),
     );

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -1,5 +1,13 @@
 import { execFileSync, spawnSync } from "node:child_process";
-import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -36,7 +44,7 @@ const verifier = resolve(
   ".agents/skills/openclaw-changelog-update/scripts/verify-release-notes.mjs",
 );
 
-function git(cwd: string, args: string[]): string {
+function git(cwd: string, args: string[], extraEnv: Record<string, string> = {}): string {
   return execFileSync("git", args, {
     cwd,
     encoding: "utf8",
@@ -46,6 +54,7 @@ function git(cwd: string, args: string[]): string {
       GIT_AUTHOR_EMAIL: "test@openclaw.invalid",
       GIT_COMMITTER_NAME: "OpenClaw Test",
       GIT_COMMITTER_EMAIL: "test@openclaw.invalid",
+      ...extraEnv,
     },
   }).trim();
 }
@@ -1103,6 +1112,534 @@ console.log(JSON.stringify({ data }));
       }
     },
   );
+
+  it.each([
+    { message: "Exact-head CI #41 passed.", accepted: true },
+    { message: "CI run #41 passed.", accepted: true },
+    { message: "Actions run #41 passed.", accepted: true },
+    { message: "workflow run #41 passed.", accepted: true },
+    { message: "CI #41 passed.", node: "Issue", accepted: true },
+    { message: "CI #41 passed.", node: "PullRequest", accepted: true },
+    { message: "Related #41.", accepted: false },
+    { message: "CI #41 passed.", reverted: true, other: "Related #41.", accepted: false },
+    { message: "CI #41 passed. Fixes #41.", accepted: false },
+    { message: "CI openclaw/openclaw#41 passed.", accepted: false },
+    { message: "CI #41 passed.", other: "Related #41.", accepted: false },
+    { message: "CI #41 passed.", note: "Related #41.", accepted: false },
+    { message: "CI #41 passed.", identity: "missing", accepted: false },
+    { message: "CI #41 passed.", identity: "wrong-id", accepted: false },
+    { message: "CI #41 passed.", identity: "wrong-repo", accepted: false },
+  ])("classifies active workflow references without losing issue accounting: %j", (scenario) => {
+    const cwd = mkdtempSync(join(tmpdir(), "openclaw-release-notes-runs-"));
+    try {
+      git(cwd, ["init", "-q", "-b", "main"]);
+      writeFileSync(
+        join(cwd, "CHANGELOG.md"),
+        [
+          "# Changelog",
+          "",
+          "## 2026.7.1",
+          "",
+          "### Highlights",
+          "",
+          "- One.",
+          "- Two.",
+          "- Three.",
+          "- Four.",
+          "- Five.",
+          "",
+          "### Changes",
+          "",
+          "### Fixes",
+          "",
+          scenario.note ?? "",
+          "",
+        ].join("\n"),
+      );
+      git(cwd, ["add", "CHANGELOG.md"]);
+      git(cwd, ["commit", "-qm", "chore: base"]);
+      const base = git(cwd, ["rev-parse", "HEAD"]);
+      writeFileSync(join(cwd, "validation.txt"), scenario.message);
+      git(cwd, ["add", "validation.txt"]);
+      git(cwd, ["commit", "-qm", "chore: validation", "-m", scenario.message]);
+      if (scenario.reverted) {
+        git(cwd, ["revert", "--no-edit", "HEAD"]);
+      }
+      if (scenario.other) {
+        git(cwd, ["commit", "--allow-empty", "-qm", "chore: follow-up", "-m", scenario.other]);
+      }
+      const target = git(cwd, ["rev-parse", "HEAD"]);
+      const gh = join(cwd, "gh");
+      writeFileSync(
+        gh,
+        `#!${process.execPath}\n
+const scenario = ${JSON.stringify(scenario)};
+if (process.argv[3] === "repos/openclaw/openclaw/actions/runs/41") {
+  require("node:fs").appendFileSync("run-requests", "41\\n");
+  console.log(JSON.stringify(scenario.identity === "missing" ? { message: "Not Found" } : {
+    id: scenario.identity === "wrong-id" ? 42 : 41,
+    repository: { full_name: scenario.identity === "wrong-repo" ? "other/repository" : "openclaw/openclaw" },
+    pull_requests: [],
+  }));
+  process.exit(0);
+}
+const query = process.argv.find((arg) => arg.startsWith("query="))?.slice(6) ?? "";
+const data = {};
+for (const [, alias] of query.matchAll(/(c\\d+): repository/g)) {
+  data[alias] = { object: { associatedPullRequests: { nodes: [], pageInfo: { hasNextPage: false } }, author: { user: { login: "steipete" } } } };
+}
+for (const [, alias] of query.matchAll(/(n\\d+): repository/g)) {
+  data[alias] = { issueOrPullRequest: scenario.node ? {
+    __typename: scenario.node, number: 41, title: "chore: validation", baseRefName: "main",
+    mergedAt: "2026-01-01T00:00:00Z", mergeCommit: { oid: ${JSON.stringify(target)} }, author: { __typename: "User", login: "steipete" },
+    closingIssuesReferences: { nodes: [], pageInfo: { hasNextPage: false } },
+    closedByPullRequestsReferences: { nodes: [], pageInfo: { hasNextPage: false } },
+  } : null };
+}
+console.log(JSON.stringify({ data }));
+`,
+      );
+      chmodSync(gh, 0o755);
+      const manifestPath = join(cwd, "manifest.json");
+      const result = spawnSync(
+        process.execPath,
+        [
+          verifier,
+          "--base",
+          base,
+          "--target",
+          target,
+          "--main-ref",
+          target,
+          "--version",
+          "2026.7.1",
+          "--manifest",
+          manifestPath,
+          "--write-ledger",
+          "--json",
+        ],
+        { cwd, encoding: "utf8", env: { ...process.env, PATH: `${cwd}:${process.env.PATH}` } },
+      );
+      if (!scenario.accepted) {
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("GitHub could not resolve source references: #41");
+        return;
+      }
+      expect(result.stderr).toBe("");
+      expect(result.status, result.stdout).toBe(0);
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+      expect(manifest.source.references).toBe(scenario.node ? 1 : 0);
+      expect(manifest.pullRequests.map((entry: { number: number }) => entry.number)).toEqual(
+        scenario.node === "PullRequest" ? [41] : [],
+      );
+      if (!scenario.node) {
+        expect(manifest.directCommits[0].references).toEqual([]);
+        expect(manifest.workflowRuns).toEqual([{ id: 41, repository: "openclaw/openclaw" }]);
+      } else {
+        expect(() => readFileSync(join(cwd, "run-requests"))).toThrow();
+      }
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    "exact",
+    "double-revert",
+    "before-base",
+    "before-base-double",
+    "before-base-triple",
+    "three-targets",
+    "non-utf8",
+    "overlapping",
+    "extra-change",
+    "partial",
+    "unknown-target",
+    "nonancestor",
+    "merge-target",
+    "abbreviated",
+    "duplicate",
+    "multiple-declarations",
+    "prose",
+    "non-revert-subject",
+  ])("proves explicit multi-commit reversal accounting: %s", (mode) => {
+    const cwd = mkdtempSync(join(tmpdir(), "openclaw-release-notes-multi-revert-"));
+    try {
+      git(cwd, ["init", "-q", "-b", "main"]);
+      const prose = [
+        "# Changelog",
+        "",
+        "## 2026.7.1",
+        "",
+        "### Highlights",
+        "",
+        "- One.",
+        "- Two.",
+        "- Three.",
+        "- Four.",
+        "- Five.",
+        "",
+        "### Changes",
+        "",
+        "### Fixes",
+        "",
+      ].join("\n");
+      writeFileSync(join(cwd, "CHANGELOG.md"), prose);
+      writeFileSync(join(cwd, "alpha.txt"), "original\n");
+      writeFileSync(join(cwd, "beta.bin"), Buffer.from([0, 255, 1]));
+      const commit = (subject: string) => {
+        git(cwd, ["add", "."]);
+        git(cwd, ["commit", "-qm", subject]);
+        return git(cwd, ["rev-parse", "HEAD"]);
+      };
+      const originalBase = commit("chore: baseline");
+      writeFileSync(
+        join(cwd, "alpha.txt"),
+        mode === "non-utf8" ? Buffer.from([97, 255, 10]) : "first\n",
+      );
+      const first = commit("chore: first source (#21)");
+      writeFileSync(join(cwd, "beta.bin"), Buffer.from([0, 254, 2]));
+      if (mode === "overlapping") {
+        writeFileSync(join(cwd, "alpha.txt"), "second\n");
+      }
+      const second = commit("chore: second source (#22)");
+      let third: string | undefined;
+      if (mode === "three-targets") {
+        writeFileSync(join(cwd, "third.txt"), "third\n");
+        third = commit("chore: third source (#23)");
+      }
+      writeFileSync(
+        join(cwd, "CHANGELOG.md"),
+        `${prose}\n### Complete contribution record\n\nThis audited record covers the complete ${originalBase}..${second} history: 2 in-range PRs + 0 retained seed-only PRs = 2 unique PRs.\n\n#### Pull requests\n\n- **PR #21** chore: first source.\n- **PR #22** chore: second source.\n`,
+      );
+      const seed = commit("docs: preserve source ledger");
+      let declaredSecond = second;
+      if (mode === "nonancestor" || mode === "merge-target") {
+        git(cwd, ["checkout", "-qb", "side", originalBase]);
+        writeFileSync(join(cwd, "side.txt"), "side\n");
+        declaredSecond = commit("chore: side source");
+        git(cwd, ["checkout", "-q", "main"]);
+        if (mode === "merge-target") {
+          git(cwd, ["merge", "--no-ff", "-qm", "merge side", "side"]);
+          declaredSecond = git(cwd, ["rev-parse", "HEAD"]);
+        }
+      }
+      git(cwd, [
+        "revert",
+        "--no-commit",
+        ...(third ? [third] : []),
+        second,
+        ...(mode === "partial" ? [] : [first]),
+      ]);
+      if (mode === "extra-change") {
+        writeFileSync(join(cwd, "extra.txt"), "unrelated change\n");
+      }
+      if (mode === "unknown-target") {
+        declaredSecond = "1".repeat(40);
+      }
+      if (mode === "duplicate") {
+        declaredSecond = first;
+      }
+      let declaration = `Reverts ${first} and ${declaredSecond} to restore the previous behavior.`;
+      if (third) {
+        declaration = `Reverts ${first}, ${second}, and ${third}.`;
+      }
+      if (mode === "abbreviated") {
+        declaration = `Reverts ${first.slice(0, 12)} and ${second.slice(0, 12)}.`;
+      } else if (mode === "multiple-declarations") {
+        declaration = `${declaration}\n\n${declaration}`;
+      } else if (mode === "prose") {
+        declaration = `Discussion: ${declaration}`;
+      }
+      git(cwd, ["add", "."]);
+      git(cwd, [
+        "commit",
+        "-qm",
+        mode === "non-revert-subject" ? "chore: describe changes" : "chore: revert source changes",
+        "-m",
+        declaration,
+      ]);
+      let base = mode.startsWith("before-base") ? seed : originalBase;
+      if (mode === "before-base-double") {
+        base = git(cwd, ["rev-parse", "HEAD"]);
+      }
+      if (["double-revert", "before-base-double", "before-base-triple"].includes(mode)) {
+        git(cwd, ["revert", "--no-edit", "HEAD"]);
+      }
+      if (mode === "before-base-triple") {
+        base = git(cwd, ["rev-parse", "HEAD"]);
+        git(cwd, ["revert", "--no-edit", "HEAD"]);
+      }
+      const target = git(cwd, ["rev-parse", "HEAD"]);
+      const associations = { [first]: 21, [second]: 22, ...(third ? { [third]: 23 } : {}) };
+      const gh = join(cwd, "gh");
+      writeFileSync(
+        gh,
+        `#!${process.execPath}\n
+const associations = ${JSON.stringify(associations)};
+const query = process.argv.find((arg) => arg.startsWith("query="))?.slice(6) ?? "";
+const data = {};
+for (const [, alias, hash] of query.matchAll(/(c\\d+): repository[\\s\\S]*?object\\(expression: "([0-9a-f]+)"\\)/g)) {
+ const number = associations[hash];
+ data[alias] = { object: { associatedPullRequests: { nodes: number ? [{ number, mergedAt: "2020-01-01T00:00:00Z", mergeCommit: { oid: hash } }] : [], pageInfo: { hasNextPage: false } }, author: { user: { login: "steipete" } } } };
+}
+for (const [, alias, number] of query.matchAll(/(n\\d+): repository[\\s\\S]*?issueOrPullRequest\\(number: (\\d+)\\)/g)) {
+ data[alias] = { issueOrPullRequest: { __typename: "PullRequest", number: Number(number), title: "chore: source", baseRefName: "main", mergedAt: "2020-01-01T00:00:00Z", author: { __typename: "User", login: "steipete" }, closingIssuesReferences: { nodes: [], pageInfo: { hasNextPage: false } } } };
+}
+console.log(JSON.stringify({ data }));
+`,
+      );
+      chmodSync(gh, 0o755);
+      const privateTmp = join(cwd, "private-proof-tmp");
+      mkdirSync(privateTmp);
+      const index = join(cwd, git(cwd, ["rev-parse", "--git-path", "index"]));
+      const originalIndex = readFileSync(index);
+      const originalObjects = git(cwd, ["count-objects", "-v"]);
+      const hooks = join(cwd, "test-hooks");
+      mkdirSync(hooks);
+      const hook = join(hooks, "post-index-change");
+      writeFileSync(hook, "#!/bin/sh\nprintf unexpected > hook-fired\n");
+      chmodSync(hook, 0o755);
+      git(cwd, ["config", "core.hooksPath", hooks]);
+      git(cwd, ["config", "diff.external", hook]);
+
+      const manifestPath = join(cwd, "manifest.json");
+      const result = spawnSync(
+        process.execPath,
+        [
+          verifier,
+          "--base",
+          base,
+          "--target",
+          target,
+          "--main-ref",
+          target,
+          "--seed-ref",
+          seed,
+          "--version",
+          "2026.7.1",
+          "--manifest",
+          manifestPath,
+          "--write-ledger",
+          "--json",
+        ],
+        {
+          cwd,
+          encoding: "utf8",
+          env: { ...process.env, TMPDIR: privateTmp, PATH: `${cwd}:${process.env.PATH}` },
+        },
+      );
+      expect(readFileSync(index)).toEqual(originalIndex);
+      expect(git(cwd, ["rev-parse", "HEAD"])).toBe(target);
+      expect(git(cwd, ["count-objects", "-v"])).toBe(originalObjects);
+      expect(readdirSync(privateTmp)).toEqual([]);
+      expect(readdirSync(cwd)).not.toContain("hook-fired");
+      if (
+        ["extra-change", "partial", "unknown-target", "nonancestor", "merge-target"].includes(mode)
+      ) {
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("could not verify explicit multi-commit revert");
+        return;
+      }
+      expect(result.stderr).toBe("");
+      expect(result.status, result.stdout).toBe(0);
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+      const removed = [
+        "exact",
+        "before-base",
+        "before-base-triple",
+        "three-targets",
+        "non-utf8",
+        "overlapping",
+      ].includes(mode);
+      expect(
+        manifest.pullRequests.map((entry: { number: number }) => entry.number).toSorted(),
+      ).toEqual(removed ? [] : [21, 22]);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it.each([
+    "body-only",
+    "future-associated",
+    "stale-row",
+    "reachable-body",
+    "explicit-seed",
+    "canonical-carrier",
+    "backport-carrier",
+    "provenance-carrier",
+    "unresolved-body",
+  ])("bounds contribution membership to the frozen source graph: %s", (mode) => {
+    const cwd = mkdtempSync(join(tmpdir(), "openclaw-release-notes-membership-"));
+    try {
+      git(cwd, ["init", "-q", "-b", "release"]);
+      const prose = [
+        "# Changelog",
+        "",
+        "## 2026.7.1",
+        "",
+        "### Highlights",
+        "",
+        "- One.",
+        "- Two.",
+        "- Three.",
+        "- Four.",
+        "- Five.",
+        "",
+        "### Changes",
+        "",
+        "### Fixes",
+        "",
+      ].join("\n");
+      writeFileSync(join(cwd, "CHANGELOG.md"), prose);
+      const commitAt = (message: string, day: number) => {
+        git(cwd, ["add", "."]);
+        const date = `2026-07-0${day}T12:00:00Z`;
+        git(cwd, ["commit", "--allow-empty", "-qm", message], {
+          GIT_AUTHOR_DATE: date,
+          GIT_COMMITTER_DATE: date,
+        });
+        return git(cwd, ["rev-parse", "HEAD"]);
+      };
+      const base = commitAt("chore: baseline", 1);
+      writeFileSync(join(cwd, "support.txt"), "independent supporting repair\n");
+      const source = commitAt(
+        "chore: supporting repair (#21)\n\nRelated: #22\nThis repair is independent of the performance work.",
+        2,
+      );
+      git(cwd, ["checkout", "-qb", "later-main"]);
+      writeFileSync(join(cwd, "performance.txt"), "performance implementation\n");
+      const future = commitAt("chore: performance work (#22)", 3);
+      git(cwd, ["checkout", "-q", "release"]);
+      let main = source;
+      let carrier: string | undefined;
+      if (mode === "reachable-body") {
+        git(cwd, ["merge", "--ff-only", "later-main"]);
+      } else if (mode.endsWith("-carrier")) {
+        main = future;
+        commitAt("chore: release preparation", 4);
+        if (mode === "canonical-carrier") {
+          git(cwd, ["cherry-pick", "-x", future], { GIT_COMMITTER_DATE: "2026-07-05T12:00:00Z" });
+          carrier = git(cwd, ["rev-parse", "HEAD"]);
+        } else {
+          writeFileSync(join(cwd, "performance.txt"), "performance implementation\n");
+          carrier = commitAt(
+            mode === "backport-carrier"
+              ? "chore: release performance backport\n\nBackport of #22 to release/fixture."
+              : "chore: carry selected implementation",
+            5,
+          );
+        }
+      }
+      let seed: string | undefined;
+      if (mode === "explicit-seed") {
+        writeFileSync(
+          join(cwd, "CHANGELOG.md"),
+          `${prose}\n### Complete contribution record\n\nThis audited record covers the complete ${base}..${source} history: 1 in-range PR + 1 retained seed-only PR = 2 unique PRs.\n\n#### Pull requests\n\n- **PR #21** chore: supporting repair.\n- **PR #22** chore: performance work.\n`,
+        );
+        seed = commitAt("docs: retain an explicit historical seed", 4);
+      }
+      const target = commitAt("chore: final release preparation", 6);
+      if (
+        [
+          "body-only",
+          "future-associated",
+          "stale-row",
+          "explicit-seed",
+          "unresolved-body",
+        ].includes(mode)
+      ) {
+        expect(() => git(cwd, ["merge-base", "--is-ancestor", future, target])).toThrow();
+        expect(() => git(cwd, ["merge-base", "--is-ancestor", future, main])).toThrow();
+        expect(() => git(cwd, ["cat-file", "-e", `${target}:performance.txt`])).toThrow();
+      }
+      if (mode === "stale-row") {
+        writeFileSync(
+          join(cwd, "CHANGELOG.md"),
+          `${prose}\n### Complete contribution record\n\nThis audited record covers the complete ${base}..${target} history: 2 in-range PRs + 0 retained seed-only PRs = 2 unique PRs.\n\n#### Pull requests\n\n- **PR #21** chore: supporting repair.\n- **PR #22** chore: performance work.\n`,
+        );
+      }
+      const gh = join(cwd, "gh");
+      writeFileSync(
+        gh,
+        `#!${process.execPath}\n
+const mode = ${JSON.stringify(mode)};
+const source = ${JSON.stringify(source)};
+const future = ${JSON.stringify(future)};
+const query = process.argv.find((arg) => arg.startsWith("query="))?.slice(6) ?? "";
+const data = {};
+const nodeFor = (number) => ({ number, mergedAt: number === 21 ? "2026-07-02T12:00:00Z" : "2026-07-03T12:00:00Z", mergeCommit: { oid: number === 21 ? source : future } });
+for (const [, alias, hash] of query.matchAll(/(c\\d+): repository[\\s\\S]*?object\\(expression: "([0-9a-f]+)"\\)/g)) {
+ const numbers = hash === source ? (mode === "future-associated" ? [21, 22] : [21]) : hash === future && mode.endsWith("-carrier") ? [22] : [];
+ data[alias] = { object: { associatedPullRequests: { nodes: numbers.map(nodeFor), pageInfo: { hasNextPage: false } }, author: { user: { login: "steipete" } } } };
+}
+for (const [, alias, rawNumber] of query.matchAll(/(n\\d+): repository[\\s\\S]*?issueOrPullRequest\\(number: (\\d+)\\)/g)) {
+ const number = Number(rawNumber);
+ data[alias] = { issueOrPullRequest: mode === "unresolved-body" && number === 22 ? null : { ...nodeFor(number), __typename: "PullRequest", title: number === 21 ? (mode === "body-only" ? "chore: supporting repair (Related #22)" : "chore: supporting repair") : "chore: performance work", baseRefName: "main", author: { __typename: "User", login: "steipete" }, closingIssuesReferences: { nodes: [], pageInfo: { hasNextPage: false } } } };
+}
+console.log(JSON.stringify({ data }));
+`,
+      );
+      chmodSync(gh, 0o755);
+      const manifestPath = join(cwd, "manifest.json");
+      const args = [
+        verifier,
+        "--base",
+        base,
+        "--target",
+        target,
+        "--main-ref",
+        main,
+        "--version",
+        "2026.7.1",
+        "--manifest",
+        manifestPath,
+        "--json",
+        ...(seed ? ["--seed-ref", seed] : []),
+        ...(mode === "provenance-carrier" ? ["--release-provenance", `${carrier} -> #22`] : []),
+      ];
+      const run = (write: boolean) =>
+        spawnSync(process.execPath, [...args, ...(write ? ["--write-ledger"] : [])], {
+          cwd,
+          encoding: "utf8",
+          env: { ...process.env, PATH: `${cwd}:${process.env.PATH}` },
+        });
+      if (mode === "stale-row") {
+        const stale = run(false);
+        expect(stale.status).not.toBe(0);
+        expect(stale.stderr).toContain("outside");
+      }
+      const result = run(true);
+      if (mode === "unresolved-body") {
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("could not resolve source references: #22");
+        return;
+      }
+      expect(result.stderr).toBe("");
+      expect(result.status, result.stdout).toBe(0);
+      const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+      const included = mode === "reachable-body" || mode.endsWith("-carrier") || Boolean(seed);
+      expect(
+        manifest.pullRequests.map((entry: { number: number }) => entry.number).toSorted(),
+      ).toEqual(included ? [21, 22] : [21]);
+      expect(manifest.source.inRangePullRequests).toBe(included && !seed ? 2 : 1);
+      expect(manifest.source.retainedSeedOnlyPullRequests).toBe(seed ? 1 : 0);
+      expect(manifest.source.references).toBe(2);
+      if (mode === "body-only") {
+        const generated = readFileSync(join(cwd, "CHANGELOG.md"), "utf8");
+        writeFileSync(
+          join(cwd, "CHANGELOG.md"),
+          generated.replace("**PR #21**", "**PR #21** Related #22."),
+        );
+        const verified = run(false);
+        expect(verified.stderr).toBe("");
+        expect(verified.status, verified.stdout).toBe(0);
+      }
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
 
   it.each([
     { mode: "recover", attempts: 2, error: undefined },

--- a/test/scripts/verify-release-notes.test.ts
+++ b/test/scripts/verify-release-notes.test.ts
@@ -1129,7 +1129,15 @@ console.log(JSON.stringify({ data }));
     { message: "CI #41 passed.", identity: "missing", accepted: false },
     { message: "CI #41 passed.", identity: "wrong-id", accepted: false },
     { message: "CI #41 passed.", identity: "wrong-repo", accepted: false },
+    { message: "CI #2147483647 passed.", node: "Issue", accepted: true },
+    { message: "CI run #34244092230 passed.", accepted: true },
+    { message: "Related #34244092230.", accepted: false },
+    { message: "CI #34244092230 passed. Fixes #34244092230.", accepted: false },
+    { message: "CI #34244092230 passed.", identity: "missing", accepted: false },
+    { message: "CI #34244092230 passed.", identity: "wrong-id", accepted: false },
+    { message: "CI #34244092230 passed.", identity: "wrong-repo", accepted: false },
   ])("classifies active workflow references without losing issue accounting: %j", (scenario) => {
+    const referenceNumber = Number(scenario.message.match(/#(\d+)/)?.[1]);
     const cwd = mkdtempSync(join(tmpdir(), "openclaw-release-notes-runs-"));
     try {
       git(cwd, ["init", "-q", "-b", "main"]);
@@ -1174,23 +1182,28 @@ console.log(JSON.stringify({ data }));
         gh,
         `#!${process.execPath}\n
 const scenario = ${JSON.stringify(scenario)};
-if (process.argv[3] === "repos/openclaw/openclaw/actions/runs/41") {
-  require("node:fs").appendFileSync("run-requests", "41\\n");
+const referenceNumber = ${referenceNumber};
+if (process.argv[3] === "repos/openclaw/openclaw/actions/runs/" + referenceNumber) {
+  require("node:fs").appendFileSync("run-requests", referenceNumber + "\\n");
   console.log(JSON.stringify(scenario.identity === "missing" ? { message: "Not Found" } : {
-    id: scenario.identity === "wrong-id" ? 42 : 41,
+    id: scenario.identity === "wrong-id" ? referenceNumber + 1 : referenceNumber,
     repository: { full_name: scenario.identity === "wrong-repo" ? "other/repository" : "openclaw/openclaw" },
     pull_requests: [],
   }));
   process.exit(0);
 }
 const query = process.argv.find((arg) => arg.startsWith("query="))?.slice(6) ?? "";
+if ([...query.matchAll(/issueOrPullRequest\\(number: (\\d+)\\)/g)].some(([, number]) => Number(number) > 2147483647)) {
+  console.log(JSON.stringify({ errors: [{ message: "Int cannot represent non 32-bit signed integer value" }] }));
+  process.exit(1);
+}
 const data = {};
 for (const [, alias] of query.matchAll(/(c\\d+): repository/g)) {
   data[alias] = { object: { associatedPullRequests: { nodes: [], pageInfo: { hasNextPage: false } }, author: { user: { login: "steipete" } } } };
 }
 for (const [, alias] of query.matchAll(/(n\\d+): repository/g)) {
   data[alias] = { issueOrPullRequest: scenario.node ? {
-    __typename: scenario.node, number: 41, title: "chore: validation", baseRefName: "main",
+    __typename: scenario.node, number: referenceNumber, title: "chore: validation", baseRefName: "main",
     mergedAt: "2026-01-01T00:00:00Z", mergeCommit: { oid: ${JSON.stringify(target)} }, author: { __typename: "User", login: "steipete" },
     closingIssuesReferences: { nodes: [], pageInfo: { hasNextPage: false } },
     closedByPullRequestsReferences: { nodes: [], pageInfo: { hasNextPage: false } },
@@ -1222,7 +1235,9 @@ console.log(JSON.stringify({ data }));
       );
       if (!scenario.accepted) {
         expect(result.status).not.toBe(0);
-        expect(result.stderr).toContain("GitHub could not resolve source references: #41");
+        expect(result.stderr).toContain(
+          `GitHub could not resolve source references: #${referenceNumber}`,
+        );
         return;
       }
       expect(result.stderr).toBe("");
@@ -1230,11 +1245,13 @@ console.log(JSON.stringify({ data }));
       const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
       expect(manifest.source.references).toBe(scenario.node ? 1 : 0);
       expect(manifest.pullRequests.map((entry: { number: number }) => entry.number)).toEqual(
-        scenario.node === "PullRequest" ? [41] : [],
+        scenario.node === "PullRequest" ? [referenceNumber] : [],
       );
       if (!scenario.node) {
         expect(manifest.directCommits[0].references).toEqual([]);
-        expect(manifest.workflowRuns).toEqual([{ id: 41, repository: "openclaw/openclaw" }]);
+        expect(manifest.workflowRuns).toEqual([
+          { id: referenceNumber, repository: "openclaw/openclaw" },
+        ]);
       } else {
         expect(() => readFileSync(join(cwd, "run-requests"))).toThrow();
       }


### PR DESCRIPTION
Related: #103429

## What Problem This Solves

Resolves a problem where release-note generation rejected explicit CI run references, credited changes that had been reverted together, or promoted contextual PR references from outside the selected release history into the contribution record.

## Why This Change Was Made

Bring the accounting repairs qualified during 2026.9.3 preparation back to main. An unresolved reference is classified as an Actions run only with explicit source context and an exact same-repository run identity; actual issue/PR resolution still wins. Explicit multi-commit reversals require an independently reconstructed inverse tree. Contribution membership follows the frozen source graph and verified backport provenance, while contextual references remain available for inline resolution and explicit seeds retain historical credit.

The current EOF transport handling and newer release preparation policy are preserved. This addresses related accounting boundaries reported in #103429; it does not claim to complete that issue's broader historical reconciliation.

## User Impact

Release maintainers can generate notes for a frozen cut without crediting unrelated later work or genuinely reverted changes. Valid CI references no longer block generation, and unresolved or unproven references still fail strictly. Runtime behavior and published release artifacts are unchanged.

## Evidence

- CLI/fake-GitHub regression cases failed on unchanged main for the intended defects: 19 failures, with 23 controls passing.
- The repaired verifier and ledger suites pass all 122 tests, including existing EOF retry coverage.
- The verifier body matches the implementation already qualified for 2026.9.3.
- Full `check:changed` passed, including all typecheck lanes, repository guards, lint, runtime import cycles, and changed root-test lint.
- Fresh independent P2 review found no actionable findings.

### Review follow-up

Keep Actions IDs above GraphQL's signed 32-bit `Int` range out of issue queries, while retaining strict unresolved-reference errors and exact workflow-run identity checks. A schema-aware CLI fixture reproduced six failures before this follow-up; the repaired full suites pass 129 tests, including the inclusive maximum issue-number boundary. A direct live query currently returned partial data with `NOT_FOUND`, so this is a documented API-contract repair rather than a claim of a reproduced live outage. Independent P2 review is clean.

This changes release-generation accounting only. It does not change runtime database schemas or stored user state; manifest schema identity remains unchanged, with compatibility covered by the existing seed, snapshot, and ledger fixtures.
