### PR TITLE
improve(tui): reduce URL preparation work for link-heavy messages

### DIFF
--- a/src/tui/components/hyperlink-markdown.ts
+++ b/src/tui/components/hyperlink-markdown.ts
@@ -23,7 +23,7 @@ function sanitizeMarkdownDisplayText(text: string): string {
  */
 export class HyperlinkMarkdown implements Component {
   private inner: Markdown;
-  private urls: string[];
+  private urls: ReadonlySet<string>;
   private cachedRender?: { width: number; lines: string[] };
 
   constructor(

--- a/src/tui/osc8-hyperlinks.test.ts
+++ b/src/tui/osc8-hyperlinks.test.ts
@@ -6,13 +6,13 @@ import { addOsc8Hyperlinks, extractUrls } from "./osc8-hyperlinks.js";
 describe("extractUrls", () => {
   it("extracts bare URLs", () => {
     const urls = extractUrls("Check out https://example.com for more info");
-    expect(urls).toEqual(["https://example.com"]);
+    expect([...urls]).toEqual(["https://example.com"]);
   });
 
   it.each([".", ",", ";", "!", "?", ":", "*", "_", "~", ".?!"])(
     "excludes trailing GFM punctuation %s from bare URLs",
     (punctuation) => {
-      expect(extractUrls(`Visit https://example.com/path${punctuation}`)).toEqual([
+      expect([...extractUrls(`Visit https://example.com/path${punctuation}`)]).toEqual([
         "https://example.com/path",
       ]);
     },
@@ -20,89 +20,97 @@ describe("extractUrls", () => {
 
   it("stops bare URLs before bidi formatting controls", () => {
     const url = "https://example.com/path";
-    expect(extractUrls(`مرحبا ${url}\u2069`)).toEqual([url]);
-    expect(extractUrls(`مرحبا ${url}\u200f`)).toEqual([url]);
+    expect([...extractUrls(`مرحبا ${url}\u2069`)]).toEqual([url]);
+    expect([...extractUrls(`مرحبا ${url}\u200f`)]).toEqual([url]);
   });
 
   it("extracts multiple bare URLs", () => {
     const urls = extractUrls("Visit https://foo.com and http://bar.com");
     expect(urls).toContain("https://foo.com");
     expect(urls).toContain("http://bar.com");
-    expect(urls).toHaveLength(2);
+    expect(urls.size).toBe(2);
   });
 
   it.each(["", ".", "?", ";"])("preserves authored markdown href suffix %s", (suffix) => {
     const url = `https://example.com/path${suffix}`;
-    expect(extractUrls(`[Click here](${url})`)).toEqual([url]);
+    expect([...extractUrls(`[Click here](${url})`)]).toEqual([url]);
   });
 
   it("extracts markdown links with angle brackets and title text", () => {
     const urls = extractUrls('[Click here](<https://example.com/path> "Example Title")');
-    expect(urls).toEqual(["https://example.com/path"]);
+    expect([...urls]).toEqual(["https://example.com/path"]);
   });
 
-  it("extracts both bare URLs and markdown links", () => {
-    const md = "See [docs](https://docs.example.com) and https://api.example.com";
-    const urls = extractUrls(md);
-    expect(urls).toContain("https://docs.example.com");
-    expect(urls).toContain("https://api.example.com");
-    expect(urls).toHaveLength(2);
+  it("keeps authored destinations before bare URLs in first-seen order", () => {
+    const md =
+      "https://api.example.com [Docs](https://docs.example.com) " +
+      "[Guide](https://guide.example.com) [Docs again](https://docs.example.com)";
+    expect([...extractUrls(md)]).toEqual([
+      "https://docs.example.com",
+      "https://guide.example.com",
+      "https://api.example.com",
+    ]);
+  });
+
+  it("does not extract URL-shaped labels from rejected markdown destinations", () => {
+    const md = "[https://label.test](https://.) https://bare.test";
+    expect([...extractUrls(md)]).toEqual(["https://bare.test"]);
   });
 
   it("deduplicates URLs", () => {
     const md = "Visit https://example.com and [link](https://example.com)";
     const urls = extractUrls(md);
-    expect(urls).toEqual(["https://example.com"]);
+    expect([...urls]).toEqual(["https://example.com"]);
   });
 
-  it("returns empty array for text without URLs", () => {
-    expect(extractUrls("No links here")).toStrictEqual([]);
+  it("returns no URLs for text without URLs", () => {
+    expect([...extractUrls("No links here")]).toStrictEqual([]);
   });
 
   it("handles URLs with query params and fragments", () => {
     const urls = extractUrls("https://example.com/path?q=1&r=2#section");
-    expect(urls).toEqual(["https://example.com/path?q=1&r=2#section"]);
+    expect([...urls]).toEqual(["https://example.com/path?q=1&r=2#section"]);
   });
 
   it("extracts a bare URL with a bracketed IPv6 authority", () => {
     const url = "http://[::1]:8080/path";
-    expect(extractUrls(url)).toEqual([url]);
+    expect([...extractUrls(url)]).toEqual([url]);
   });
 
   it("extracts markdown link hrefs with parentheses in the URL", () => {
     const url = "https://en.wikipedia.org/wiki/URL_(disambiguation)";
-    expect(extractUrls(`[Wikipedia](${url})`)).toEqual([url]);
+    expect([...extractUrls(`[Wikipedia](${url})`)]).toEqual([url]);
   });
 
   it("keeps balanced URL parentheses and internal query punctuation", () => {
     const url = "https://example.com/v1.0/URL_(disambiguation)?a=1&b=2#section";
-    expect(extractUrls(`Visit ${url}.`)).toEqual([url]);
+    expect([...extractUrls(`Visit ${url}.`)]).toEqual([url]);
   });
 
   it("does not extract an incomplete markdown link destination", () => {
-    expect(extractUrls("[broken](https://)")).toEqual([]);
+    expect([...extractUrls("[broken](https://)")]).toEqual([]);
   });
 
   it.each(["[broken](https://.)", "https://.", "https:///path"])(
     "does not extract a URL without a real authority from %s",
     (text) => {
-      expect(extractUrls(text)).toEqual([]);
+      expect([...extractUrls(text)]).toEqual([]);
     },
   );
 
   it("handles bare URLs with trailing closing paren as punctuation", () => {
     const urls = extractUrls("(see https://example.com/path)");
-    expect(urls).toEqual(["https://example.com/path"]);
+    expect([...urls]).toEqual(["https://example.com/path"]);
   });
 
   it("drops punctuation after an unmatched closing paren", () => {
     const urls = extractUrls("(see https://example.com/path).");
-    expect(urls).toEqual(["https://example.com/path"]);
+    expect([...urls]).toEqual(["https://example.com/path"]);
   });
 
   it("handles markdown link with angle brackets and parenthetical URL", () => {
     const url = "https://en.wikipedia.org/wiki/Special_(film)";
-    expect(extractUrls(`[link](<${url}>)`)).toEqual([url]);
+    expect([...extractUrls(`[link](<${url}>)`)]).toEqual([url]);
   });
 });
 
@@ -118,7 +126,7 @@ describe("addOsc8Hyperlinks", () => {
     const authored = `\x1b]8;${params};${target}${terminator}\x1b[32m${label}\x1b[0m\x1b]8;;${terminator}`;
     const line = `${prefix}${authored} then ${bare}`;
 
-    const [rendered] = addOsc8Hyperlinks([line], [target, bare]);
+    const [rendered] = addOsc8Hyperlinks([line], new Set([target, bare]));
 
     expect(rendered).toContain(authored);
     expect(getOsc8LinkAtColumn(rendered!, prefix.length)).toBe(target);
@@ -130,7 +138,7 @@ describe("addOsc8Hyperlinks", () => {
 
   it("returns lines unchanged when no URLs", () => {
     const lines = ["Hello world", "No links here"];
-    expect(addOsc8Hyperlinks(lines, [])).toEqual(lines);
+    expect(addOsc8Hyperlinks(lines, new Set<string>())).toEqual(lines);
   });
 
   it.each([
@@ -138,7 +146,7 @@ describe("addOsc8Hyperlinks", () => {
     { prefix: "🦞 東京 ", url: "https://example.com/😀/e\u0301", suffix: " 🧑‍💻" },
     { prefix: "\ud800 ", url: "https://example.com/\udfff", suffix: " \udc00" },
   ])("wraps a single-line URL with OSC 8 ($url)", ({ prefix, url, suffix }) => {
-    expect(addOsc8Hyperlinks([`${prefix}${url}${suffix}`], [url])).toEqual([
+    expect(addOsc8Hyperlinks([`${prefix}${url}${suffix}`], new Set([url]))).toEqual([
       `${prefix}\x1b]8;;${url}\x07${url}\x1b]8;;\x07${suffix}`,
     ]);
   });
@@ -180,7 +188,7 @@ describe("addOsc8Hyperlinks", () => {
 
   it("keeps bidi isolation outside the exact OSC 8 target", () => {
     const url = "https://example.com/path";
-    expect(addOsc8Hyperlinks([`\u2067مرحبا ${url}\u2069`], [url])).toEqual([
+    expect(addOsc8Hyperlinks([`\u2067مرحبا ${url}\u2069`], new Set([url]))).toEqual([
       `\u2067مرحبا \x1b]8;;${url}\x07${url}\x1b]8;;\x07\u2069`,
     ]);
   });
@@ -188,7 +196,7 @@ describe("addOsc8Hyperlinks", () => {
   it("wraps a URL broken across two lines", () => {
     const fullUrl = "https://example.com/very/long/path/to/resource";
     const lines = ["https://example.com/very/long/pa", "th/to/resource"];
-    const result = addOsc8Hyperlinks(lines, [fullUrl]);
+    const result = addOsc8Hyperlinks(lines, new Set([fullUrl]));
 
     // Line 1: fragment should be wrapped with the full URL
     expect(result[0]).toContain(`\x1b]8;;${fullUrl}\x07`);
@@ -200,7 +208,7 @@ describe("addOsc8Hyperlinks", () => {
     const prefix = "https://example.com/";
     const url = `${prefix}😀/path`;
 
-    expect(addOsc8Hyperlinks([prefix, "😁 next"], [url])).toEqual([
+    expect(addOsc8Hyperlinks([prefix, "😁 next"], new Set([url]))).toEqual([
       `\x1b]8;;${url}\x07${prefix}\x1b]8;;\x07`,
       `\x1b]8;;${url}\x07😁\x1b]8;;\x07 next`,
     ]);
@@ -208,19 +216,21 @@ describe("addOsc8Hyperlinks", () => {
 
   it("wraps a URL with a bracketed IPv6 authority", () => {
     const url = "http://[::1]:8080/path";
-    expect(addOsc8Hyperlinks([url], [url])).toEqual([`\x1b]8;;${url}\x07${url}\x1b]8;;\x07`]);
+    expect(addOsc8Hyperlinks([url], new Set([url]))).toEqual([
+      `\x1b]8;;${url}\x07${url}\x1b]8;;\x07`,
+    ]);
   });
 
   it("wraps a URL broken immediately after its scheme", () => {
     const fullUrl = "https://example.com/path";
-    const result = addOsc8Hyperlinks(["https://", "example.com/path"], [fullUrl]);
+    const result = addOsc8Hyperlinks(["https://", "example.com/path"], new Set([fullUrl]));
 
     expect(result[0]).toBe(`\x1b]8;;${fullUrl}\x07https://\x1b]8;;\x07`);
     expect(result[1]).toBe(`\x1b]8;;${fullUrl}\x07example.com/path\x1b]8;;\x07`);
   });
 
   it("does not cross-link a scheme-only fragment to a partial domain match", () => {
-    const result = addOsc8Hyperlinks(["https://", "example.org"], ["https://example.com"]);
+    const result = addOsc8Hyperlinks(["https://", "example.org"], new Set(["https://example.com"]));
 
     expect(result).toEqual(["https://", "example.org"]);
   });
@@ -228,27 +238,30 @@ describe("addOsc8Hyperlinks", () => {
   it("does not cross-link a scheme-only fragment to a longer URL token", () => {
     const result = addOsc8Hyperlinks(
       ["https://", "example.com/pathology"],
-      ["https://example.com/path"],
+      new Set(["https://example.com/path"]),
     );
 
     expect(result).toEqual(["https://", "example.com/pathology"]);
   });
 
   it("does not recover a punctuated incomplete URL as a wrapped URL", () => {
-    const result = addOsc8Hyperlinks(["broken (https://)", "example.com"], ["https://example.com"]);
+    const result = addOsc8Hyperlinks(
+      ["broken (https://)", "example.com"],
+      new Set(["https://example.com"]),
+    );
 
     expect(result).toEqual(["broken (https://)", "example.com"]);
   });
 
   it("does not wrap a punctuation-only URL body", () => {
-    expect(addOsc8Hyperlinks(["https://."], ["https://."])).toEqual(["https://."]);
+    expect(addOsc8Hyperlinks(["https://."], new Set(["https://."]))).toEqual(["https://."]);
   });
 
   it("handles URL with ANSI styling codes", () => {
     const url = "https://example.com";
     // Simulate styled text: green URL
     const styledLine = `\x1b[32m${url}\x1b[0m`;
-    const result = addOsc8Hyperlinks([styledLine], [url]);
+    const result = addOsc8Hyperlinks([styledLine], new Set([url]));
 
     // Should preserve ANSI codes and add OSC 8 around the visible URL
     expect(result[0]).toContain("\x1b[32m");
@@ -261,7 +274,7 @@ describe("addOsc8Hyperlinks", () => {
     const url = "https://github.com/org/repo";
     // pi-tui renders [text](url) as "text (url)"
     const line = `Click here (${url})`;
-    const result = addOsc8Hyperlinks([line], [url]);
+    const result = addOsc8Hyperlinks([line], new Set([url]));
 
     // The URL part should be wrapped with OSC 8
     expect(result[0]).toContain(`\x1b]8;;${url}\x07`);
@@ -271,7 +284,7 @@ describe("addOsc8Hyperlinks", () => {
     const url1 = "https://foo.com";
     const url2 = "https://bar.com";
     const line = `${url1} and ${url2}`;
-    const result = addOsc8Hyperlinks([line], [url1, url2]);
+    const result = addOsc8Hyperlinks([line], new Set([url1, url2]));
 
     expect(result[0]).toContain(`\x1b]8;;${url1}\x07`);
     expect(result[0]).toContain(`\x1b]8;;${url2}\x07`);
@@ -280,29 +293,52 @@ describe("addOsc8Hyperlinks", () => {
   it("does not modify lines without URL text", () => {
     const url = "https://example.com";
     const lines = ["Just some text", "No URLs here"];
-    const result = addOsc8Hyperlinks(lines, [url]);
+    const result = addOsc8Hyperlinks(lines, new Set([url]));
 
     expect(result).toEqual(lines);
   });
 
-  it("prefers the longest known URL when a fragment matches multiple prefixes", () => {
-    const short = "https://example.com/api/v2/users";
-    const long = "https://example.com/api/v2/users/list";
-    const fragment = "https://example.com/api/v2/u";
-    const result = addOsc8Hyperlinks([fragment], [short, long]);
-    expect(result[0]).toContain(`\x1b]8;;${long}\x07${fragment}\x1b]8;;\x07`);
+  it.each([
+    {
+      name: "longest prefix",
+      known: ["https://example.test/a", "https://example.test/ab"],
+      fragment: "https://example.test/",
+      expected: "https://example.test/ab",
+    },
+    {
+      name: "exact match before longer prefix",
+      known: ["https://example.test/ab", "https://example.test/a"],
+      fragment: "https://example.test/a",
+      expected: "https://example.test/a",
+    },
+    {
+      name: "first equal-length prefix",
+      known: ["https://example.test/ab", "https://example.test/aa"],
+      fragment: "https://example.test/a",
+      expected: "https://example.test/ab",
+    },
+    {
+      name: "reversed equal-length prefixes",
+      known: ["https://example.test/aa", "https://example.test/ab"],
+      fragment: "https://example.test/a",
+      expected: "https://example.test/aa",
+    },
+  ])("resolves a rendered fragment by $name", ({ known, fragment, expected }) => {
+    expect(addOsc8Hyperlinks([fragment], new Set(known))).toEqual([
+      `\x1b]8;;${expected}\x07${fragment}\x1b]8;;\x07`,
+    ]);
   });
 
   it("wraps URLs with parentheses in markdown rendered text", () => {
     const url = "https://en.wikipedia.org/wiki/URL_(disambiguation)";
     const line = `Wikipedia (${url})`;
-    const result = addOsc8Hyperlinks([line], [url]);
+    const result = addOsc8Hyperlinks([line], new Set([url]));
     expect(result[0]).toBe(`Wikipedia (\x1b]8;;${url}\x07${url}\x1b]8;;\x07)`);
   });
 
   it("does not resolve an incomplete URL to another known URL", () => {
     const url = "https://example.com";
-    const result = addOsc8Hyperlinks(["broken (https://)", url], [url]);
+    const result = addOsc8Hyperlinks(["broken (https://)", url], new Set([url]));
     expect(result[0]).toBe("broken (https://)");
     expect(result[1]).toContain(`\x1b]8;;${url}\x07${url}\x1b]8;;\x07`);
   });
@@ -310,7 +346,7 @@ describe("addOsc8Hyperlinks", () => {
   it("handles URL split across three lines", () => {
     const fullUrl = "https://example.com/a/very/long/path/that/keeps/going/and/going";
     const lines = ["https://example.com/a/very/lon", "g/path/that/keeps/going/and/g", "oing"];
-    const result = addOsc8Hyperlinks(lines, [fullUrl]);
+    const result = addOsc8Hyperlinks(lines, new Set([fullUrl]));
 
     // All three lines should have OSC 8 wrapping
     for (const line of result) {

--- a/src/tui/osc8-hyperlinks.ts
+++ b/src/tui/osc8-hyperlinks.ts
@@ -12,7 +12,7 @@ const URL_PATH_WITH_PARENS =
  *  URLs, while preserving balanced parentheses and exact authored Markdown
  *  destinations. `(see https://example.com/path).` must link only the URL,
  *  but `[label](https://example.com/path.)` must retain its authored dot. */
-function trimUrlTrailingPunctuation(url: string, knownUrls?: string[]): string {
+function trimUrlTrailingPunctuation(url: string, knownUrls?: ReadonlySet<string>): string {
   let open = 0;
   for (let index = 0; index < url.length; index++) {
     const ch = url[index];
@@ -21,7 +21,7 @@ function trimUrlTrailingPunctuation(url: string, knownUrls?: string[]): string {
     } else if (ch === ")") {
       if (open === 0) {
         const authoredUrl = url.slice(0, index);
-        return knownUrls?.includes(authoredUrl)
+        return knownUrls?.has(authoredUrl)
           ? authoredUrl
           : trimUrlTrailingPunctuation(authoredUrl, knownUrls);
       }
@@ -29,7 +29,7 @@ function trimUrlTrailingPunctuation(url: string, knownUrls?: string[]): string {
     }
   }
   const trimmed = url.replace(/[?!.,:;*_~]+$/u, "");
-  return knownUrls?.includes(url) && !knownUrls.includes(trimmed) ? url : trimmed;
+  return knownUrls?.has(url) && !knownUrls.has(trimmed) ? url : trimmed;
 }
 
 function hasUrlContent(url: string): boolean {
@@ -44,7 +44,7 @@ function hasUrlContent(url: string): boolean {
  * Extract all unique URLs from raw markdown text.
  * Finds both bare URLs and markdown link hrefs [text](url).
  */
-export function extractUrls(markdown: string): string[] {
+export function extractUrls(markdown: string): ReadonlySet<string> {
   const urls = new Set<string>();
 
   // Markdown link hrefs: [text](url), with optional <...> and optional title.
@@ -52,15 +52,15 @@ export function extractUrls(markdown: string): string[] {
     `\\[(?:[^\\]]*)\\]\\(\\s*<?(${URL_PATH_WITH_PARENS.source})>?(?:\\s+["'][^"']*["'])?\\s*\\)`,
     "g",
   );
-  let m: RegExpExecArray | null;
-  while ((m = mdLinkRe.exec(markdown)) !== null) {
-    if (hasUrlContent(expectDefined(m[1], "m capture group 1"))) {
-      urls.add(expectDefined(m[1], "m capture group 1"));
+  const stripped = markdown.replace(mdLinkRe, (_match, url: string) => {
+    if (hasUrlContent(url)) {
+      urls.add(url);
     }
-  }
+    return "";
+  });
 
-  // Bare URLs (remove markdown links first to avoid double-matching)
-  const stripped = markdown.replace(mdLinkRe, "");
+  // Bare URLs (markdown links were removed above to avoid double-matching)
+  let m: RegExpExecArray | null;
   const bareRe =
     /https?:\/\/(?:\[[0-9a-f:.]+\](?::\d+)?[^\s\]>\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]*|[^\s[\]>\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]+)/gi;
   while ((m = bareRe.exec(stripped)) !== null) {
@@ -70,7 +70,7 @@ export function extractUrls(markdown: string): string[] {
     }
   }
 
-  return [...urls];
+  return urls;
 }
 
 interface UrlRange {
@@ -84,7 +84,7 @@ interface UrlRange {
  */
 function findUrlRanges(
   visibleText: string,
-  knownUrls: string[],
+  knownUrls: ReadonlySet<string>,
   pending: { url: string; consumed: number } | null,
   nextVisibleText?: string,
 ): { ranges: UrlRange[]; pending: { url: string; consumed: number } | null } {
@@ -165,7 +165,7 @@ function findUrlRanges(
       }
     }
 
-    if (!found && knownUrls.includes(fragment)) {
+    if (!found && knownUrls.has(fragment)) {
       found = true;
     }
     if (!found) {
@@ -275,14 +275,14 @@ function applyOsc8Ranges(line: string, ranges: UrlRange[]): string {
 }
 
 /**
- * Add OSC 8 hyperlinks to rendered lines using a pre-extracted URL list.
+ * Add OSC 8 hyperlinks to rendered lines using a pre-extracted URL set.
  *
  * For each line, finds URL-like substrings in the visible text, matches them
  * against known URLs, and wraps each fragment with OSC 8 escape sequences.
  * Handles URLs broken across multiple lines by pi-tui's word wrapping.
  */
-export function addOsc8Hyperlinks(lines: string[], urls: string[]): string[] {
-  if (urls.length === 0) {
+export function addOsc8Hyperlinks(lines: string[], urls: ReadonlySet<string>): string[] {
+  if (urls.size === 0) {
     return lines;
   }
 


### PR DESCRIPTION
## What Problem This Solves

Link-heavy TUI messages repeat URL extraction and membership work when their terminal rendering is rebuilt. This adds avoidable preparation cost to streaming updates and resized messages.

## Why This Change Was Made

Keep the ordered, deduplicated URL set from extraction through OSC8 annotation instead of converting it to an array and repeatedly scanning it. Collect authored Markdown destinations while removing their source spans, preserving exact targets, punctuation, wrapping, ANSI handling and the existing render-cache lifetime. This changes internal preparation only; production LOC is neutral and tests add 36 lines.

## User Impact

Less URL-preparation work for link-heavy messages, with unchanged visible text and clickable destinations. Results are workload-dependent; this is not a claim that all terminal rendering is faster.

## Evidence

Observed warm medians in the two measurement orders:

| Boundary and fixture | First order, before → after | Reverse order, before → after |
|---|---:|---:|
| Extract 128 authored URLs; native hyperlinks off | 38.500 → 33.666 µs | 34.667 → 32.166 µs |
| Annotate prepared lines with those URLs; native hyperlinks off | 280.375 → 102.375 µs | 271.666 → 100.416 µs |
| HyperlinkMarkdown lifecycle, 128 mixed URLs; native hyperlinks on | 14.107 → 13.193 ms | 13.951 → 13.225 ms |

The annotation case improves 63.49%/63.04%; the component lifecycle improves 6.48%/5.20%. Adverses are retained: duplicate-URL extraction plus annotation with native hyperlinks off is 29.56%/32.04% slower, and the duplicate-URL ChatLog lifecycle is 8.03% slower in the first off order (2.28% faster in reverse). Across the complete cohort, 1,224 of 2,564 indexed lifetime comparisons are adverse. Of 300 warm lifecycle median comparisons, 139 were adverse. After forced GC with 641 components/collections retained, whole-process heap was about 0.125–0.172 MiB higher in all four pairs; this is not a per-component allocation estimate or a memory improvement. Lifecycle measurements include frame snapshots and identity bookkeeping; these are descriptive observations, not confidence or tail-latency estimates.

- Four complete suites passed on both variants: **178 baseline + 178 candidate tests**. All **29 normal checks** passed; independent P2 review was clean.
- An independent saved-data audit verified **all 5,128 records and 600 gzip members**, including complete frame strings, ordered URLs, recorded array-identity relations and OSC8 destinations. Collection kind intentionally changes from Array to Set. All timings, adverse cases, resource readings and timer-resolution zeros remain retained.
- The real PTY narrow-Unicode/copy-safe-URL test passed over a **fake backend**: one selected test, 68 skipped. This does not prove live Gateway/provider/network behavior.
- The first B0/off Node target succeeded, but its outer Python 3.9 verifier failed on an unsupported `zip` keyword. Existing data was validated with Python 3.14 **without rerunning the product**. Later parents used Python 3.14; the observer mismatch and interruption gap remain limitations. The ABBA sequence was neither uninterrupted nor randomized.

Attached before/after images present the same inspected synthetic frame from saved terminal output. They are captured-frame proof renderings, not live desktop screenshots or an additional product run. Measurements remain tied to baseline `1e1385e0`; no whole-Gateway speedup is claimed.

![Before: synthetic recorded terminal frame](https://github.com/user-attachments/assets/f64ef121-00f3-4968-8a3b-80c7af5d79a1)

![After: synthetic recorded terminal frame](https://github.com/user-attachments/assets/3efc1c55-9f01-42df-b5d0-c6543b66779f)

Additional integration after main advanced: upstream #142210 replaces the component sanitizer to preserve long words and email addresses. The clean combined tree retains that fix and the ordered URL Set. All **86 tests in the two whole existing HyperlinkMarkdown and OSC8 suites passed** on the combined owner/caller slice; source images were restored after positive process closure. This checks the composition with the newer sanitizer, not an entire-current-main build or a new timing cohort.
