### PR TITLE
fix(media): preserve converted images with HEIC filenames

### DIFF
--- a/docs/nodes/images.md
+++ b/docs/nodes/images.md
@@ -41,7 +41,7 @@ metadata precedence does not change MIME detection when media bytes are loaded o
 
 - Input: local file path **or** HTTP(S) URL.
 - Flow: load into a buffer, detect media kind, then build the outbound payload per kind:
-  - **Images:** optimized to fit under `channels.whatsapp.mediaMaxMb` (default 50MB). Opaque images are recompressed to JPEG (default side ladder starts at 2048px, descending on repeated size misses); images with transparency are kept as PNG. If the source is already an acceptable JPEG/PNG/WebP within the size and side-length budget, the original bytes are preserved unchanged instead of being recompressed. Animated GIFs are never re-encoded, only size-checked.
+  - **Images:** optimized to fit under `channels.whatsapp.mediaMaxMb` (default 50MB). Opaque images are recompressed to JPEG (default side ladder starts at 2048px, descending on repeated size misses); images with transparency are kept as PNG. If the source is already an acceptable JPEG/PNG/WebP within the size and side-length budget, the original bytes are preserved unchanged instead of being recompressed, even when a stale `.heic` or `.heif` filename remains after conversion. Animated GIFs are never re-encoded, only size-checked.
   - **Audio/voice:** unless already native voice audio (`.ogg`/`.opus`, or `audio/ogg`/`audio/opus`), outbound audio is transcoded via `ffmpeg` to Opus/OGG (48kHz mono, 64kbps, capped at 20 minutes) before sending as a voice note (`ptt: true`).
   - **Video:** pass-through up to 16MB.
   - **Documents:** anything else, up to 100MB, with filename preserved when available.

--- a/src/media/web-media.test.ts
+++ b/src/media/web-media.test.ts
@@ -485,9 +485,13 @@ describe("loadWebMedia", () => {
     expect(many.qualities).toEqual([70, 60, 50, 40]);
   });
 
-  it.each(["png", "jpeg", "webp"] as const)(
-    "preserves accepted original %s bytes and metadata with and without hard limits",
-    async (format) => {
+  it.each(
+    (["png", "jpeg", "webp"] as const).flatMap((format) =>
+      [format, "heic", "heif"].map((extension) => ({ format, extension })),
+    ),
+  )(
+    "preserves original $format bytes with .$extension filename and image limits",
+    async ({ format, extension }) => {
       const { optimizeImageBufferForWebMedia } = await import("./web-media.js");
       const sourcePng = createSolidPngBuffer(32, 16, { r: 12, g: 34, b: 56 });
       let buffer =
@@ -504,11 +508,22 @@ describe("loadWebMedia", () => {
       }
       const original = Buffer.from(buffer);
       const contentType = `image/${format}`;
-      const fileName = `portrait.${format}`;
+      const fileName = `portrait.${extension}`;
+      const filePath = path.join(fixtureRoot, fileName);
+      await fs.writeFile(filePath, buffer);
       for (const imageCompression of [
         undefined,
         { models: [{ maxSidePx: 32, maxPixels: 1024 }] },
       ]) {
+        const loaded = await loadWebMedia(filePath, {
+          localRoots: [fixtureRoot],
+          maxBytes: 1024 * 1024,
+          imageCompression,
+        });
+        expect(loaded.buffer).toEqual(original);
+        expect(loaded.contentType).toBe(contentType);
+        expect(loaded.fileName).toBe(fileName);
+
         const result = await optimizeImageBufferForWebMedia({
           buffer,
           contentType,

--- a/src/media/web-media.ts
+++ b/src/media/web-media.ts
@@ -168,8 +168,6 @@ function resolveWebMediaOptions(params: {
 // without letting a tight channel cap buffer up to the 100MB document bound.
 const IMAGE_OPTIMIZE_HEADROOM_FACTOR = 4;
 
-const HEIC_MIME_RE = /^image\/hei[cf]$/i;
-const HEIC_EXT_RE = /\.(heic|heif)$/i;
 const WINDOWS_DRIVE_RE = /^[A-Za-z]:[\\/]/;
 const HOST_READ_ALLOWED_DOCUMENT_MIMES = new Set([
   "application/msword",
@@ -509,16 +507,6 @@ function formatCapReduce(label: string, cap: number, size: number): string {
   return `${label} could not be reduced below ${formatMediaSize(cap)} (got ${formatMediaSize(size)})`;
 }
 
-function isHeicSource(opts: { contentType?: string; fileName?: string }): boolean {
-  if (opts.contentType && HEIC_MIME_RE.test(opts.contentType.trim())) {
-    return true;
-  }
-  if (opts.fileName && HEIC_EXT_RE.test(opts.fileName.trim())) {
-    return true;
-  }
-  return false;
-}
-
 function assertHostReadMediaAllowed(params: {
   sniffedContentType?: string;
   contentType?: string;
@@ -766,7 +754,6 @@ function resolvePreservableOriginalImageContentType(params: {
   buffer: Buffer;
   cap: number;
   contentType?: string;
-  fileName?: string;
   policy?: ImageCompressionPolicy;
 }): string | null {
   if (params.buffer.length > params.cap) {
@@ -787,10 +774,6 @@ function resolvePreservableOriginalImageContentType(params: {
   if (declaredContentType?.startsWith("image/") && !declaredPreservableContentType) {
     return null;
   }
-  const resolvedContentType = declaredPreservableContentType ?? actualContentType;
-  if (isHeicSource({ contentType: resolvedContentType, fileName: params.fileName })) {
-    return null;
-  }
   const preferredSide =
     resolveImageCompressionGrid(params.policy).sides[0] ?? DEFAULT_VISION_MAX_SIDE;
   if (
@@ -799,7 +782,7 @@ function resolvePreservableOriginalImageContentType(params: {
   ) {
     return null;
   }
-  return resolvedContentType;
+  return declaredPreservableContentType ?? actualContentType;
 }
 
 function isPreservableImageMime(
@@ -949,7 +932,6 @@ export async function optimizeImageBufferForWebMedia(params: {
     buffer: params.buffer,
     cap,
     contentType: params.contentType,
-    fileName: params.fileName,
     policy: params.imageCompression,
   });
   if (originalContentType) {


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This is a same-repository branch; maintainers can update it directly.

</details>

## What Problem This Solves

Fixes an issue where users sending or viewing an already-converted PNG, JPEG, or WebP image would get unnecessary recompression when its original filename still ended in `.heic` or `.heif`. Even images already within the byte and dimension limits could lose their original bytes and metadata; an opaque PNG could also become a larger, lossy JPEG.

## Why This Change Was Made

Remove the obsolete HEIC filename veto and its private argument plumbing. The existing detected-format, byte-budget, and dimension checks remain the authority for preserving supported originals. Genuine HEIC data still goes through conversion, including when its filename has a different suffix.

This deletes **18 production lines** without adding another normalization path. The media documentation now describes retained HEIC filenames.

## User Impact

Already-supported images keep their original quality, metadata, and bytes under stale camera filenames. Genuine HEIC conversion, image limits, transparency handling, and GIF behavior are preserved.

## Evidence

The real public `loadWebMedia` flow was exercised before and after the change using synthetic PNG/JPEG files and a genuine HEIC file produced by macOS `sips`, with isolated state and temporary files:

| Actual bytes and filename | Before | After |
| --- | --- | --- |
| 444-byte PNG, `.heic` or `.heif` | Re-encoded as a 4,191-byte JPEG | Exact original 444-byte PNG |
| 3,288-byte JPEG, `.heic` or `.heif` | Re-encoded as a different 2,573-byte JPEG | Exact original 3,288-byte JPEG |
| 1,907-byte genuine HEIC, `.heic` or `.png` | Converted to JPEG | Converted to the same 3,195-byte JPEG |

The eight-case public-loader proof had four preservation failures before the deletion and zero afterward. The genuine-HEIC output hashes match before and after. No live channel send is claimed.

The existing original-format/EXIF/limit regression matrix was extended through the public loader: six stale-name cases failed on the original implementation while three normal-name controls passed. All **126** media-loader and image-adapter tests now pass. The complete changed-file gate, production and core-test type checks, typed lint, formatting, and docs indexing pass. Independent review explicitly run at **P2** is scoped-clean, with the invocation and unchanged source hashes retained.
