### PR TITLE
fix(cli): reject blank automation job ids before calling the Gateway

### DIFF
--- a/src/cli/cron-cli.test.ts
+++ b/src/cli/cron-cli.test.ts
@@ -640,11 +640,21 @@ describe("cron cli", () => {
       args: ["cron", "runs", "job-1", "--id", "job-2"],
       message: 'Conflicting job ids: positional "job-1" and --id "job-2".',
     },
+    ...(["rm", "enable", "disable", "get", "show", "run", "scratch"] as const).map((command) => ({
+      name: `blank ${command} id`,
+      args: ["cron", command, "   "],
+      message: "Missing job id",
+    })),
+    {
+      name: "blank edit id",
+      args: ["cron", "edit", "   ", "--enable"],
+      message: "Missing job id",
+    },
   ])("rejects $name before calling the Gateway", async ({ args, message }) => {
     await expectCronCommandExit(args);
 
     expectRuntimeErrorContaining(message);
-    expect(callGatewayFromCli.mock.calls.some((call) => call[0] === "cron.runs")).toBe(false);
+    expect(callGatewayFromCli).not.toHaveBeenCalled();
   });
 
   it.each([

--- a/src/cli/cron-cli/register.cron-edit.ts
+++ b/src/cli/cron-cli/register.cron-edit.ts
@@ -27,6 +27,7 @@ import {
   getCronChannelOptions,
   handleCronCliError,
   warnIfCronSchedulerDisabled,
+  requireCronJobId,
 } from "./shared.js";
 import { normalizeCronSessionTargetOption, parseCronThreadIdOption } from "./thread-id-shared.js";
 import { readCronTriggerScript } from "./trigger-options.js";
@@ -104,8 +105,9 @@ export function registerCronEditCommand(cron: Command) {
         "--failure-alert-account-id <id>",
         "Account ID for failure alert channel (multi-account setups)",
       )
-      .action(async (id, opts) => {
+      .action(async (idArg, opts) => {
         try {
+          const id = requireCronJobId(idArg);
           if (opts.clearTools && opts.tools !== undefined) {
             throw new CronCliError("Use --tools or --clear-tools, not both");
           }
@@ -116,7 +118,7 @@ export function registerCronEditCommand(cron: Command) {
           let existingJobPromise: Promise<CronJobForEdit> | undefined;
           let expectedConfigRevision: string | undefined;
           const readExistingCronJob = async (): Promise<CronJobForEdit> => {
-            const existing = await (existingJobPromise ??= readCronJobForEdit(opts, String(id)));
+            const existing = await (existingJobPromise ??= readCronJobForEdit(opts, id));
             if (typeof existing.configRevision === "string") {
               expectedConfigRevision = existing.configRevision;
             }

--- a/src/cli/cron-cli/register.cron-scratch.ts
+++ b/src/cli/cron-cli/register.cron-scratch.ts
@@ -4,7 +4,7 @@ import type { Command } from "commander";
 import { addGatewayClientOptions, callGatewayFromCli } from "../gateway-rpc.js";
 import { CronCliError } from "./cron-cli-error.js";
 import { createCronOutputCommand } from "./output-mode.js";
-import { handleCronCliError, printCronJson } from "./shared.js";
+import { handleCronCliError, printCronJson, requireCronJobId } from "./shared.js";
 import { readCronScratchContent } from "./trigger-options.js";
 
 type ScratchRecord = { content: string; revision: number; updatedAtMs: number };
@@ -37,8 +37,9 @@ export function registerCronScratchCommand(cron: Command) {
       .option("--file <path>", "Replace scratch from a file, or - for stdin")
       .option("--unset", "Remove the scratch row", false)
       .option("--expected-revision <n>", "Require the current scratch revision")
-      .action(async (id, opts) => {
+      .action(async (idArg, opts) => {
         try {
+          const id = requireCronJobId(idArg);
           const mutations = [
             opts.set !== undefined,
             opts.file !== undefined,
@@ -48,7 +49,7 @@ export function registerCronScratchCommand(cron: Command) {
             throw new CronCliError("choose only one of --set, --file, or --unset");
           }
           const current = (await callGatewayFromCli("cron.scratch.get", opts, {
-            id: String(id),
+            id,
           })) as ScratchGetResult;
           if (mutations === 0) {
             if (opts.json) {
@@ -67,7 +68,7 @@ export function registerCronScratchCommand(cron: Command) {
               ? await readCronScratchContent(String(opts.file))
               : String(opts.set ?? "");
           const result = (await callGatewayFromCli("cron.scratch.set", opts, {
-            id: String(id),
+            id,
             content,
             expectedRevision,
           })) as ScratchSetResult;

--- a/src/cli/cron-cli/register.cron-simple.ts
+++ b/src/cli/cron-cli/register.cron-simple.ts
@@ -24,6 +24,7 @@ import {
   handleCronCliError,
   printCronJson,
   printCronShow,
+  requireCronJobId,
   warnIfCronSchedulerDisabled,
 } from "./shared.js";
 
@@ -115,7 +116,7 @@ function registerCronToggleCommand(params: {
       .action(async (id, opts) => {
         try {
           const res = await callGatewayFromCli("cron.update", opts, {
-            id,
+            id: requireCronJobId(id),
             patch: { enabled: params.enabled },
           });
           printCronJson(res);
@@ -139,7 +140,7 @@ export function registerCronSimpleCommands(cron: Command) {
       .argument("<id>", "Job id")
       .action(async (id, opts) => {
         try {
-          const res = await callGatewayFromCli("cron.remove", opts, { id });
+          const res = await callGatewayFromCli("cron.remove", opts, { id: requireCronJobId(id) });
           printCronJson(res);
         } catch (err) {
           handleCronCliError(err);
@@ -166,7 +167,7 @@ export function registerCronSimpleCommands(cron: Command) {
       .argument("<id>", "Job id")
       .action(async (id, opts) => {
         try {
-          const res = await callGatewayFromCli("cron.get", opts, { id: String(id) });
+          const res = await callGatewayFromCli("cron.get", opts, { id: requireCronJobId(id) });
           printCronJson(res);
         } catch (err) {
           handleCronCliError(err);
@@ -180,13 +181,14 @@ export function registerCronSimpleCommands(cron: Command) {
       .description("Show an automation")
       .argument("<id>", "Job id or exact name")
       .option("--json", "Output JSON", false)
-      .action(async (id, opts) => {
+      .action(async (idArg, opts) => {
         try {
-          const { job, deliveryPreview } = await findCronJobByIdOrName(opts, String(id), {
+          const id = requireCronJobId(idArg);
+          const { job, deliveryPreview } = await findCronJobByIdOrName(opts, id, {
             includeDeliveryPreview: !opts.json,
           });
           if (!job) {
-            throw new CronCliError(formatCronLookupMiss(String(id)));
+            throw new CronCliError(formatCronLookupMiss(id));
           }
           if (opts.json) {
             printCronJson(enrichCronJsonWithStatus(job));
@@ -215,10 +217,7 @@ export function registerCronSimpleCommands(cron: Command) {
               `Conflicting job ids: positional "${argId}" and --id "${flagId}".`,
             );
           }
-          const id = argId ?? flagId;
-          if (!id) {
-            throw new CronCliError("Missing job id. Pass it positionally or with --id.");
-          }
+          const id = requireCronJobId(argId ?? flagId, "Pass it positionally or with --id.");
           const limit = parseStrictPositiveInteger(opts.limit ?? "50");
           if (limit === undefined) {
             throw new CronCliError("Invalid --limit (must be a positive integer).");
@@ -254,8 +253,9 @@ export function registerCronSimpleCommands(cron: Command) {
         "Polling interval for --wait",
         CRON_RUN_WAIT_POLL_INTERVAL_DEFAULT,
       )
-      .action(async (id, opts, command) => {
+      .action(async (idArg, opts, command) => {
         try {
+          const id = requireCronJobId(idArg);
           let waitTimeoutMs = 0;
           let pollIntervalMs = 0;
           if (opts.wait) {
@@ -276,7 +276,7 @@ export function registerCronSimpleCommands(cron: Command) {
             }
             const run = await waitForCronRunCompletion({
               opts,
-              jobId: String(id),
+              jobId: id,
               runId: result.runId,
               timeoutMs: waitTimeoutMs,
               pollIntervalMs,

--- a/src/cli/cron-cli/shared.ts
+++ b/src/cli/cron-cli/shared.ts
@@ -276,6 +276,16 @@ export const formatCronLookupMiss = (jobId: string) =>
     valueLabel: "automation id",
   });
 
+// A blank id usually comes from an empty shell variable; reject it here instead of
+// letting the Gateway answer with a raw params-schema error.
+export function requireCronJobId(id: unknown, accepted = "Pass it positionally."): string {
+  const jobId = normalizeOptionalString(id);
+  if (!jobId) {
+    throw new CronCliError(`Missing job id. ${accepted}`);
+  }
+  return jobId;
+}
+
 export async function warnIfCronSchedulerDisabled(opts: GatewayRpcOpts) {
   // Old/offline gateways should not make successful cron mutations fail after the fact.
   try {


### PR DESCRIPTION
## What Problem This Solves

Eight automation subcommands (`rm`, `enable`, `disable`, `get`, `show`, `run`, `edit`, `scratch`) accepted a blank positional job id and forwarded it to the Gateway. The operator then saw the Gateway's raw params-schema error instead of the CLI's remedy, for example from `openclaw automations run "$JOB"` with an unset variable (observed live on an isolated Gateway at `1db32b4f4d6`):

```
invalid cron.run params: at /id: must not have fewer than 1 characters; must have required property 'jobId'; at root: unexpected property 'id'; must match a schema in anyOf
```

Only `automations runs` validated the id locally (`Missing job id. Pass it positionally or with --id.`), because #138438 added that check inline for one command.

## Why This Change Was Made

The job-id contract had no owner, so each command cast or passed the raw argument through. `requireCronJobId` in the cron CLI shared module now trims the id, rejects a blank one with `Missing job id.` plus the accepted form, and returns the string every command uses; `runs` delegates to it with its `--id` hint, and the ad-hoc `String(id)` casts go away. The check runs first in each action, before any other option parsing or Gateway round-trip, and surfaces through the existing `handleCronCliError` path in both human and `--json` modes.

## User Impact

A blank job id now fails fast with the CLI's own message on every automation subcommand and never reaches the Gateway. Non-blank ids behave exactly as before, including `show`'s id-or-name lookup and `run --wait`.

## Evidence

- The rejection table in `src/cli/cron-cli.test.ts` gains rows for the eight sibling commands and asserts no Gateway call at all: 8 rows fail on unmodified `main` (the mock Gateway is called with `id: "   "`), all pass with the fix.
- `node scripts/run-vitest.mjs src/cli/cron-cli.test.ts src/cli/cron-cli`: 529 + 17 tests pass.
- `node scripts/check-changed.mjs`: pass. Autoreview (Codex, P0-P2): scoped-clean.

Production LOC delta: +13 (one shared owner replaces one inline check and five casts).
