### PR TITLE
refactor(sandbox): share pinned filesystem operation encoding

### DIFF
--- a/src/agents/sandbox/fs-bridge-mutation-helper.test.ts
+++ b/src/agents/sandbox/fs-bridge-mutation-helper.test.ts
@@ -5,7 +5,7 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { withTestDir } from "../../test-helpers/temp-dir.js";
-import { buildPinnedWritePlan } from "./fs-bridge-mutation-helper.js";
+import { buildPinnedMutationPlan } from "./fs-bridge-mutation-helper.js";
 import {
   SANDBOX_CREATE_EXISTS_EXIT_CODE,
   SANDBOX_PINNED_MUTATION_PYTHON,
@@ -28,7 +28,8 @@ function runMutationWithSource(source: string, args: string[], input?: string) {
 }
 
 function runWritePlan(args: string[], input?: string) {
-  const plan = buildPinnedWritePlan({
+  const plan = buildPinnedMutationPlan({
+    kind: "write",
     check: {
       target: {
         hostPath: args[1] ?? "",

--- a/src/agents/sandbox/fs-bridge-mutation-helper.ts
+++ b/src/agents/sandbox/fs-bridge-mutation-helper.ts
@@ -21,12 +21,101 @@ const SANDBOX_PINNED_MUTATION_PYTHON_CANDIDATES = [
 
 export const SANDBOX_PINNED_MUTATION_PYTHON_SHELL_LITERAL = `'${SANDBOX_PINNED_MUTATION_PYTHON.replaceAll("'", `'\\''`)}'`;
 
-function buildPinnedMutationPlan(params: {
-  args: string[];
-  checks: PathSafetyCheck[];
-}): SandboxFsCommandPlan {
+export type PinnedSandboxOperation =
+  | {
+      kind: "read";
+      pinned: PinnedSandboxEntry;
+      maxBytes?: number;
+    }
+  | {
+      kind: "write" | "create";
+      pinned: PinnedSandboxEntry;
+      mkdir: boolean;
+    }
+  | {
+      kind: "mkdirp" | "readdir";
+      pinned: PinnedSandboxDirectoryEntry;
+    }
+  | {
+      kind: "remove";
+      pinned: PinnedSandboxEntry;
+      recursive?: boolean;
+      force?: boolean;
+    }
+  | {
+      kind: "copy";
+      source: PinnedSandboxEntry;
+      destination: PinnedSandboxEntry;
+      mkdir: boolean;
+    }
+  | {
+      kind: "rename";
+      source: PinnedSandboxEntry;
+      destination: PinnedSandboxEntry;
+    };
+
+function pinnedEntryArgs(pinned: PinnedSandboxEntry): string[] {
+  return [pinned.mountRootPath, pinned.relativeParentPath, pinned.basename];
+}
+
+/** Encode only already-admitted pinned facts; transport and path checks stay with each bridge. */
+export function buildPinnedMutationArgs(operation: PinnedSandboxOperation): string[] {
+  switch (operation.kind) {
+    case "read":
+      return [
+        operation.kind,
+        ...pinnedEntryArgs(operation.pinned),
+        ...(operation.maxBytes === undefined ? [] : [String(operation.maxBytes)]),
+      ];
+    case "write":
+    case "create":
+      return [operation.kind, ...pinnedEntryArgs(operation.pinned), operation.mkdir ? "1" : "0"];
+    case "mkdirp":
+    case "readdir":
+      return [operation.kind, operation.pinned.mountRootPath, operation.pinned.relativePath];
+    case "remove":
+      return [
+        operation.kind,
+        ...pinnedEntryArgs(operation.pinned),
+        operation.recursive ? "1" : "0",
+        operation.force === false ? "0" : "1",
+      ];
+    case "copy":
+    case "rename":
+      break;
+  }
+  return [
+    operation.kind,
+    ...pinnedEntryArgs(operation.source),
+    ...pinnedEntryArgs(operation.destination),
+    operation.kind === "rename" || operation.mkdir ? "1" : "0",
+  ];
+}
+
+type CheckedPinnedOperation =
+  | (Exclude<PinnedSandboxOperation, { kind: "read" | "copy" | "rename" }> & {
+      check: PathSafetyCheck;
+    })
+  | (Extract<PinnedSandboxOperation, { kind: "copy" | "rename" }> & {
+      sourceCheck: PathSafetyCheck;
+      destinationCheck: PathSafetyCheck;
+    });
+
+export function buildPinnedMutationPlan(operation: CheckedPinnedOperation): SandboxFsCommandPlan {
+  const checks =
+    operation.kind === "copy" || operation.kind === "rename"
+      ? [operation.sourceCheck, operation.destinationCheck]
+      : [operation.check];
+  if (operation.kind === "remove" || operation.kind === "rename") {
+    const check = operation.kind === "remove" ? operation.check : operation.sourceCheck;
+    checks[0] = {
+      target: check.target,
+      options: { ...check.options, aliasPolicy: PATH_ALIAS_POLICIES.unlinkTarget },
+    };
+  }
+  const args = buildPinnedMutationArgs(operation);
   return {
-    checks: params.checks,
+    checks,
     recheckBeforeCommand: true,
     // -c executes reliably on older Python builds while stdin carries payload bytes.
     script: [
@@ -44,139 +133,6 @@ function buildPinnedMutationPlan(params: {
       `python_script=${SANDBOX_PINNED_MUTATION_PYTHON_SHELL_LITERAL}`,
       'exec "$python_cmd" -c "$python_script" "$@"',
     ].join("\n"),
-    args: params.args,
+    args,
   };
-}
-
-export function buildPinnedWritePlan(params: {
-  check: PathSafetyCheck;
-  pinned: PinnedSandboxEntry;
-  mkdir: boolean;
-}): SandboxFsCommandPlan {
-  return buildPinnedMutationPlan({
-    checks: [params.check],
-    args: [
-      "write",
-      params.pinned.mountRootPath,
-      params.pinned.relativeParentPath,
-      params.pinned.basename,
-      params.mkdir ? "1" : "0",
-    ],
-  });
-}
-
-export function buildPinnedCreatePlan(params: {
-  check: PathSafetyCheck;
-  pinned: PinnedSandboxEntry;
-  mkdir: boolean;
-}): SandboxFsCommandPlan {
-  return buildPinnedMutationPlan({
-    checks: [params.check],
-    args: [
-      "create",
-      params.pinned.mountRootPath,
-      params.pinned.relativeParentPath,
-      params.pinned.basename,
-      params.mkdir ? "1" : "0",
-    ],
-  });
-}
-
-export function buildPinnedCopyPlan(params: {
-  sourceCheck: PathSafetyCheck;
-  destinationCheck: PathSafetyCheck;
-  source: PinnedSandboxEntry;
-  destination: PinnedSandboxEntry;
-  mkdir: boolean;
-}): SandboxFsCommandPlan {
-  return buildPinnedMutationPlan({
-    checks: [params.sourceCheck, params.destinationCheck],
-    args: [
-      "copy",
-      params.source.mountRootPath,
-      params.source.relativeParentPath,
-      params.source.basename,
-      params.destination.mountRootPath,
-      params.destination.relativeParentPath,
-      params.destination.basename,
-      params.mkdir ? "1" : "0",
-    ],
-  });
-}
-
-export function buildPinnedMkdirpPlan(params: {
-  check: PathSafetyCheck;
-  pinned: PinnedSandboxDirectoryEntry;
-}): SandboxFsCommandPlan {
-  return buildPinnedMutationPlan({
-    checks: [params.check],
-    args: ["mkdirp", params.pinned.mountRootPath, params.pinned.relativePath],
-  });
-}
-
-export function buildPinnedReadDirectoryPlan(params: {
-  check: PathSafetyCheck;
-  pinned: PinnedSandboxDirectoryEntry;
-}): SandboxFsCommandPlan {
-  return buildPinnedMutationPlan({
-    checks: [params.check],
-    args: ["readdir", params.pinned.mountRootPath, params.pinned.relativePath],
-  });
-}
-
-export function buildPinnedRemovePlan(params: {
-  check: PathSafetyCheck;
-  pinned: PinnedSandboxEntry;
-  recursive?: boolean;
-  force?: boolean;
-}): SandboxFsCommandPlan {
-  return buildPinnedMutationPlan({
-    checks: [
-      {
-        target: params.check.target,
-        options: {
-          ...params.check.options,
-          aliasPolicy: PATH_ALIAS_POLICIES.unlinkTarget,
-        },
-      },
-    ],
-    args: [
-      "remove",
-      params.pinned.mountRootPath,
-      params.pinned.relativeParentPath,
-      params.pinned.basename,
-      params.recursive ? "1" : "0",
-      params.force === false ? "0" : "1",
-    ],
-  });
-}
-
-export function buildPinnedRenamePlan(params: {
-  fromCheck: PathSafetyCheck;
-  toCheck: PathSafetyCheck;
-  from: PinnedSandboxEntry;
-  to: PinnedSandboxEntry;
-}): SandboxFsCommandPlan {
-  return buildPinnedMutationPlan({
-    checks: [
-      {
-        target: params.fromCheck.target,
-        options: {
-          ...params.fromCheck.options,
-          aliasPolicy: PATH_ALIAS_POLICIES.unlinkTarget,
-        },
-      },
-      params.toCheck,
-    ],
-    args: [
-      "rename",
-      params.from.mountRootPath,
-      params.from.relativeParentPath,
-      params.from.basename,
-      params.to.mountRootPath,
-      params.to.relativeParentPath,
-      params.to.basename,
-      "1",
-    ],
-  });
 }

--- a/src/agents/sandbox/fs-bridge.ts
+++ b/src/agents/sandbox/fs-bridge.ts
@@ -12,15 +12,7 @@ import type {
   SandboxFsBridgeContext,
 } from "./backend-handle.types.js";
 import { runDockerSandboxShellCommand } from "./docker-backend.js";
-import {
-  buildPinnedCreatePlan,
-  buildPinnedCopyPlan,
-  buildPinnedMkdirpPlan,
-  buildPinnedReadDirectoryPlan,
-  buildPinnedRemovePlan,
-  buildPinnedRenamePlan,
-  buildPinnedWritePlan,
-} from "./fs-bridge-mutation-helper.js";
+import { buildPinnedMutationPlan } from "./fs-bridge-mutation-helper.js";
 import { SANDBOX_CREATE_EXISTS_EXIT_CODE } from "./fs-bridge-mutation-python.js";
 import { SandboxFsPathGuard } from "./fs-bridge-path-safety.js";
 import { buildStatPlan, type SandboxFsCommandPlan } from "./fs-bridge-shell-command-plans.js";
@@ -93,7 +85,8 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
   }): Promise<DirectoryEntry[]> {
     const target = this.resolveResolvedPath(params);
     const result = await this.runCheckedCommand({
-      ...buildPinnedReadDirectoryPlan({
+      ...buildPinnedMutationPlan({
+        kind: "readdir",
         check: { target, options: { action: "list directories", allowedType: "directory" } },
         pinned: await this.pathGuard.resolveAnchoredPinnedDirectoryEntry(
           target,
@@ -127,7 +120,8 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       options: { action: "copy files", requireWritable: true } as const,
     };
     await this.runCheckedCommand({
-      ...buildPinnedCopyPlan({
+      ...buildPinnedMutationPlan({
+        kind: "copy",
         sourceCheck,
         destinationCheck,
         source: await this.pathGuard.resolveAnchoredPinnedEntry(source, "copy files"),
@@ -161,7 +155,8 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       "write files",
     );
     await this.runCheckedCommand({
-      ...buildPinnedWritePlan({
+      ...buildPinnedMutationPlan({
+        kind: "write",
         check: writeCheck,
         pinned: pinnedWriteTarget,
         mkdir: params.mkdir !== false,
@@ -194,7 +189,8 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       "create files",
     );
     const result = await this.runCheckedCommand({
-      ...buildPinnedCreatePlan({
+      ...buildPinnedMutationPlan({
+        kind: "create",
         check: createCheck,
         pinned: pinnedCreateTarget,
         mkdir: params.mkdir !== false,
@@ -226,7 +222,8 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       } as const,
     };
     await this.runCheckedCommand({
-      ...buildPinnedMkdirpPlan({
+      ...buildPinnedMutationPlan({
+        kind: "mkdirp",
         check: mkdirCheck,
         pinned: this.pathGuard.resolvePinnedDirectoryEntry(target, "create directories"),
       }),
@@ -252,7 +249,8 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       } as const,
     };
     await this.runCheckedCommand({
-      ...buildPinnedRemovePlan({
+      ...buildPinnedMutationPlan({
+        kind: "remove",
         check: removeCheck,
         pinned: this.pathGuard.resolvePinnedEntry(target, "remove files"),
         recursive: params.recursive,
@@ -289,11 +287,12 @@ class SandboxFsBridgeImpl implements SandboxFsBridge {
       } as const,
     };
     await this.runCheckedCommand({
-      ...buildPinnedRenamePlan({
-        fromCheck,
-        toCheck,
-        from: this.pathGuard.resolvePinnedEntry(from, "rename files"),
-        to: this.pathGuard.resolvePinnedEntry(to, "rename files"),
+      ...buildPinnedMutationPlan({
+        kind: "rename",
+        sourceCheck: fromCheck,
+        destinationCheck: toCheck,
+        source: this.pathGuard.resolvePinnedEntry(from, "rename files"),
+        destination: this.pathGuard.resolvePinnedEntry(to, "rename files"),
       }),
       signal: params.signal,
     });

--- a/src/agents/sandbox/remote-fs-bridge.ts
+++ b/src/agents/sandbox/remote-fs-bridge.ts
@@ -10,7 +10,10 @@ import type {
   SandboxFsBridgeContext,
 } from "./backend-handle.types.js";
 import { SANDBOX_FILE_IDENTITY } from "./file-mutation-identity.js";
-import { SANDBOX_PINNED_MUTATION_PYTHON_SHELL_LITERAL } from "./fs-bridge-mutation-helper.js";
+import {
+  buildPinnedMutationArgs,
+  SANDBOX_PINNED_MUTATION_PYTHON_SHELL_LITERAL,
+} from "./fs-bridge-mutation-helper.js";
 import {
   SANDBOX_CREATE_EXISTS_EXIT_CODE,
   SANDBOX_READ_NOT_FOUND_EXIT_CODE,
@@ -110,13 +113,11 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       signal: params.signal,
     });
     const result = await this.runMutation({
-      args: [
-        "read",
-        pinned.mountRootPath,
-        pinned.relativeParentPath,
-        pinned.basename,
-        ...(params.maxBytes === undefined ? [] : [String(params.maxBytes)]),
-      ],
+      args: buildPinnedMutationArgs({
+        kind: "read",
+        pinned,
+        maxBytes: params.maxBytes,
+      }),
       signal: params.signal,
       allowFailure: true,
     });
@@ -147,7 +148,10 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       signal: params.signal,
     });
     const result = await this.runMutation({
-      args: ["readdir", pinned.mountRootPath, pinned.relativeParentPath],
+      args: buildPinnedMutationArgs({
+        kind: "readdir",
+        pinned: { mountRootPath: pinned.mountRootPath, relativePath: pinned.relativeParentPath },
+      }),
       signal: params.signal,
     });
     return parseDirectoryEntries(result.stdout.toString("utf8"));
@@ -185,16 +189,12 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       signal: params.signal,
     });
     await this.runMutation({
-      args: [
-        "copy",
-        sourcePinned.mountRootPath,
-        sourcePinned.relativeParentPath,
-        sourcePinned.basename,
-        destinationPinned.mountRootPath,
-        destinationPinned.relativeParentPath,
-        destinationPinned.basename,
-        params.mkdir !== false ? "1" : "0",
-      ],
+      args: buildPinnedMutationArgs({
+        kind: "copy",
+        source: sourcePinned,
+        destination: destinationPinned,
+        mkdir: params.mkdir !== false,
+      }),
       signal: params.signal,
     });
   }
@@ -225,13 +225,11 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       ? params.data
       : Buffer.from(params.data, params.encoding ?? "utf8");
     await this.runMutation({
-      args: [
-        "write",
-        pinned.mountRootPath,
-        pinned.relativeParentPath,
-        pinned.basename,
-        params.mkdir !== false ? "1" : "0",
-      ],
+      args: buildPinnedMutationArgs({
+        kind: "write",
+        pinned,
+        mkdir: params.mkdir !== false,
+      }),
       stdin: buffer,
       signal: params.signal,
     });
@@ -258,13 +256,11 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       ? params.data
       : Buffer.from(params.data, params.encoding ?? "utf8");
     const result = await this.runMutation({
-      args: [
-        "create",
-        pinned.mountRootPath,
-        pinned.relativeParentPath,
-        pinned.basename,
-        params.mkdir !== false ? "1" : "0",
-      ],
+      args: buildPinnedMutationArgs({
+        kind: "create",
+        pinned,
+        mkdir: params.mkdir !== false,
+      }),
       stdin: buffer,
       allowFailure: true,
       signal: params.signal,
@@ -301,7 +297,10 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       signal: params.signal,
     });
     await this.runMutation({
-      args: ["mkdirp", pinned.mountRootPath, pinned.relativeParentPath],
+      args: buildPinnedMutationArgs({
+        kind: "mkdirp",
+        pinned: { mountRootPath: pinned.mountRootPath, relativePath: pinned.relativeParentPath },
+      }),
       signal: params.signal,
     });
   }
@@ -332,14 +331,12 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       signal: params.signal,
     });
     await this.runMutation({
-      args: [
-        "remove",
-        pinned.mountRootPath,
-        pinned.relativeParentPath,
-        pinned.basename,
-        params.recursive ? "1" : "0",
-        params.force === false ? "0" : "1",
-      ],
+      args: buildPinnedMutationArgs({
+        kind: "remove",
+        pinned,
+        recursive: params.recursive,
+        force: params.force,
+      }),
       signal: params.signal,
       allowFailure: params.force !== false,
     });
@@ -372,16 +369,11 @@ class RemoteShellSandboxFsBridge implements SandboxFsBridge {
       signal: params.signal,
     });
     await this.runMutation({
-      args: [
-        "rename",
-        fromPinned.mountRootPath,
-        fromPinned.relativeParentPath,
-        fromPinned.basename,
-        toPinned.mountRootPath,
-        toPinned.relativeParentPath,
-        toPinned.basename,
-        "1",
-      ],
+      args: buildPinnedMutationArgs({
+        kind: "rename",
+        source: fromPinned,
+        destination: toPinned,
+      }),
       signal: params.signal,
     });
   }


### PR DESCRIPTION
Closes #142265

## What Problem This Solves

Local and remote sandbox filesystem bridges maintained separate encodings of the same pinned-operation arguments. Seven local plan builders also repeated the common shell-plan structure. This maintainer-requested cleanup gives those layouts one owner.

## Why This Change Was Made

One internal encoder now consumes already-prepared pins and existing operation flags. Each bridge keeps its path admission, pinning, payload encoding and transport decisions. The local adapter still requires the appropriate one or two checks, preserves their order and source-only unlink policy, and performs the existing command-time recheck.

The complete change removes 51 production code lines and adds one line to the existing write-plan test adapter. It includes all types, helpers, imports and caller adaptations.

Related: #131604 adds append support against the previous builder API. That separate feature can extend this operation encoder when integrated; this PR retains the current eight-operation surface and leaves its implementation untouched.

## User Impact

Existing filesystem behavior is preserved: flags, scripts, stdin, signals, error handling, exclusive creation, aliases, protected paths and bounded reads keep their current contracts. Local descriptor reads and the public SDK remain unchanged.

## Evidence

- Baseline and final candidate each pass 92 tests across six owner/sibling suites. All existing tests and assertions are retained.
- All ten locally skipped GNU-shell cases passed on Linux x64, Node 24.19.0 and pnpm 12.3.4. The isolated Testbox command verified exact base plus all four final source files before and after execution; its lease is completed. [Provisioning run](https://github.com/openclaw/openclaw/actions/runs/34241669203).
- 108 real-filesystem public bridge cases compare 263 commands, 232 check events, six complete shell scripts, binary stdin, signal/check identity, outcomes, errors and resulting file trees. A separate 54-case corpus compares complete old/new plans. Final observations match the frozen baseline.
- The final changed gate and fresh independent review pass. Two earlier lint probes were corrected with explicit copy/rename cases and a narrowed final return; final tests and corpora were rerun against that source.
- Existing E2E runtime prerequisites were built by the baseline wrapper. Final fixtures import the changed bridge/helper TypeScript directly and reuse unchanged runtime prerequisites; candidate packaging and full PR CI are not claimed by that local proof.
