### PR TITLE
refactor(memory): narrow provider configuration imports

### DIFF
--- a/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
+++ b/extensions/memory-core/src/memory/manager-provider-lifecycle.ts
@@ -1,5 +1,5 @@
 // Memory Core plugin module owns embedding provider lifecycle.
-import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-runtime";
+import { resolveAgentConfig } from "openclaw/plugin-sdk/agent-scope-runtime";
 import {
   formatErrorMessage,
   readErrorName,


### PR DESCRIPTION
Related: #135599

## What Problem This Solves

Memory provider configuration reads import the deprecated broad agent-runtime SDK barrel, bringing unrelated runtime and catalog modules into that import graph.

## Why This Change Was Made

Use the existing focused agent-scope-runtime entrypoint for resolveAgentConfig. Both entrypoints re-export the same implementation; the broad public SDK remains available for external callers.

## User Impact

Memory settings and provider selection behave the same. This removes an unnecessary broad import without adding configuration or dependencies. Production LOC is unchanged (+1/−1).

## Evidence

- 24 existing provider lifecycle, fallback, and state tests passed across three files.
- Full build and canonical changed-code gate passed, including extension types, lint, Doctor contracts, and dead-export checks.
- Independent P2 review found no actionable findings.
- An isolated SDK-entry bundle analysis counted 7,759 local source inputs for the broad entrypoint and 67 for the focused entrypoint. This is import-graph evidence, not a whole-plugin runtime benchmark or a claimed fix for a test timeout.
