### PR TITLE
refactor(tests): reuse named OAuth credential fixtures

### DIFF
--- a/src/agents/auth-profiles.provider-refresh-lifecycle.test.ts
+++ b/src/agents/auth-profiles.provider-refresh-lifecycle.test.ts
@@ -13,11 +13,8 @@ import {
   writePlugin,
 } from "../plugins/loader.test-fixtures.js";
 import { withOpenClawTestState } from "../test-utils/openclaw-test-state.js";
-import {
-  oauthCred,
-  readAuthProfileStoreForTest,
-  storeWith,
-} from "./auth-profiles/oauth-test-utils.js";
+import { oauthCred } from "./auth-profiles/credential-fixtures.test-support.js";
+import { readAuthProfileStoreForTest, storeWith } from "./auth-profiles/oauth-test-utils.js";
 import { resolveApiKeyForProfile } from "./auth-profiles/oauth.js";
 import { clearRuntimeAuthProfileStoreSnapshots } from "./auth-profiles/runtime-snapshots.js";
 

--- a/src/agents/auth-profiles/credential-fixtures.test-support.ts
+++ b/src/agents/auth-profiles/credential-fixtures.test-support.ts
@@ -1,6 +1,20 @@
+import type { OAuthCredential } from "./types.js";
+
 export function createApiKeyCredential(
   provider: string,
   key: string,
 ): { type: "api_key"; provider: string; key: string } {
   return { type: "api_key", provider, key };
+}
+
+/** Build an OAuth credential fixture. */
+export function oauthCred(params: {
+  provider: string;
+  access: string;
+  refresh: string;
+  expires: number;
+  accountId?: string;
+  email?: string;
+}): OAuthCredential {
+  return { type: "oauth", ...params };
 }

--- a/src/agents/auth-profiles/oauth-shared.test.ts
+++ b/src/agents/auth-profiles/oauth-shared.test.ts
@@ -7,7 +7,7 @@
 import { expectDefined } from "@openclaw/normalization-core";
 import { MAX_DATE_TIMESTAMP_MS } from "@openclaw/normalization-core/number-coercion";
 import { describe, expect, it, vi } from "vitest";
-import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
+import { createApiKeyCredential, oauthCred } from "./credential-fixtures.test-support.js";
 import {
   overlayRuntimeExternalOAuthProfiles,
   shouldReplaceStoredOAuthCredential,
@@ -31,13 +31,12 @@ describe("overlayRuntimeExternalOAuthProfiles", () => {
       const overlaid = overlayRuntimeExternalOAuthProfiles(store, [
         {
           profileId: "openai:default",
-          credential: {
-            type: "oauth",
+          credential: oauthCred({
             provider: "openai",
             access: "access-1",
             refresh: "refresh-1",
             expires: Date.now() + 60_000,
-          },
+          }),
         },
       ]);
 
@@ -68,33 +67,30 @@ describe("overlayRuntimeExternalOAuthProfiles", () => {
       version: 1,
       runtimeExternalProfileIds: ["minimax:minimax-cli"],
       profiles: {
-        "anthropic:claude-cli": {
-          type: "oauth",
+        "anthropic:claude-cli": oauthCred({
           provider: "anthropic",
           access: "old-access",
           refresh: "old-refresh",
           expires: 1,
-        },
-        "minimax:minimax-cli": {
-          type: "oauth",
+        }),
+        "minimax:minimax-cli": oauthCred({
           provider: "minimax-portal",
           access: "minimax-access",
           refresh: "minimax-refresh",
           expires: 1,
-        },
+        }),
       },
     };
 
     const overlaid = overlayRuntimeExternalOAuthProfiles(store, [
       {
         profileId: "anthropic:claude-cli",
-        credential: {
-          type: "oauth",
+        credential: oauthCred({
           provider: "anthropic",
           access: "new-access",
           refresh: "new-refresh",
           expires: 2,
-        },
+        }),
       },
     ]);
 
@@ -110,13 +106,12 @@ describe("overlayRuntimeExternalOAuthProfiles", () => {
       runtimeExternalProfileIds: ["minimax:minimax-cli"],
       runtimeExternalProfileIdsAuthoritative: true,
       profiles: {
-        "minimax:minimax-cli": {
-          type: "oauth",
+        "minimax:minimax-cli": oauthCred({
           provider: "minimax-portal",
           access: "minimax-access",
           refresh: "minimax-refresh",
           expires: 1,
-        },
+        }),
       },
     };
 
@@ -133,13 +128,12 @@ describe("overlayRuntimeExternalOAuthProfiles", () => {
       version: 1,
       runtimePersistedProfileIds: ["openai:default"],
       profiles: {
-        "openai:default": {
-          type: "oauth",
+        "openai:default": oauthCred({
           provider: "openai",
           access: "persisted-access",
           refresh: "persisted-refresh",
           expires: 1,
-        },
+        }),
       },
     };
 
@@ -147,13 +141,12 @@ describe("overlayRuntimeExternalOAuthProfiles", () => {
       {
         profileId: "openai:default",
         persistence: "persisted",
-        credential: {
-          type: "oauth",
+        credential: oauthCred({
           provider: "openai",
           access: "external-access",
           refresh: "external-refresh",
           expires: 2,
-        },
+        }),
       },
     ]);
 
@@ -161,20 +154,18 @@ describe("overlayRuntimeExternalOAuthProfiles", () => {
   });
 
   it("replaces an existing OAuth credential with an out-of-range expiry", () => {
-    const existing: OAuthCredential = {
-      type: "oauth",
+    const existing: OAuthCredential = oauthCred({
       provider: "openai-codex",
       access: "poisoned-access",
       refresh: "poisoned-refresh",
       expires: MAX_DATE_TIMESTAMP_MS + 1,
-    };
-    const incoming: OAuthCredential = {
-      type: "oauth",
+    });
+    const incoming: OAuthCredential = oauthCred({
       provider: "openai-codex",
       access: "valid-access",
       refresh: "valid-refresh",
       expires: Date.now() + 60_000,
-    };
+    });
 
     expect(shouldReplaceStoredOAuthCredential(existing, incoming)).toBe(true);
   });

--- a/src/agents/auth-profiles/oauth-test-utils.ts
+++ b/src/agents/auth-profiles/oauth-test-utils.ts
@@ -23,18 +23,6 @@ export function resolveApiKeyForProfileInTest(
   return resolver({ cfg: {}, ...params });
 }
 
-/** Build an OAuth credential fixture. */
-export function oauthCred(params: {
-  provider: string;
-  access: string;
-  refresh: string;
-  expires: number;
-  accountId?: string;
-  email?: string;
-}): OAuthCredential {
-  return { type: "oauth", ...params };
-}
-
 /** Build an auth profile store containing one credential. */
 export function storeWith(profileId: string, cred: OAuthCredential): AuthProfileStore {
   return { version: 1, profiles: { [profileId]: cred } };

--- a/src/agents/auth-profiles/oauth.adopt-identity.test.ts
+++ b/src/agents/auth-profiles/oauth.adopt-identity.test.ts
@@ -9,6 +9,7 @@ import { expectDefined } from "@openclaw/normalization-core";
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 import { resetFileLockStateForTest } from "../../infra/file-lock.js";
 import { captureEnv } from "../../test-utils/env.js";
+import { oauthCred } from "./credential-fixtures.test-support.js";
 import { getOAuthProviderRuntimeMocks } from "./oauth-common-mocks.test-support.js";
 import "./oauth-external-auth-passthrough.test-support.js";
 import "./oauth-file-lock-passthrough.test-support.js";
@@ -16,7 +17,6 @@ import {
   OAUTH_AGENT_ENV_KEYS,
   createOAuthMainAgentDir,
   createOAuthTestTempRoot,
-  oauthCred,
   readAuthProfileStoreForTest,
   removeOAuthTestTempRoot,
   resolveApiKeyForProfileInTest,

--- a/src/agents/auth-profiles/order.test.ts
+++ b/src/agents/auth-profiles/order.test.ts
@@ -10,7 +10,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../../config/types.openclaw.js";
 import { clearPluginMetadataLifecycleCaches } from "../../plugins/plugin-metadata-lifecycle.js";
 import { isAmbientCredentialAllowedByProviderAuthPin } from "./ambient-auth.js";
-import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
+import { createApiKeyCredential, oauthCred } from "./credential-fixtures.test-support.js";
 import { saveAuthProfileStore } from "./store-runtime.js";
 import type { AuthProfileStore } from "./types.js";
 
@@ -95,13 +95,12 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "fixture-provider:oauth": {
-          type: "oauth",
+        "fixture-provider:oauth": oauthCred({
           provider: "fixture-provider",
           access: "oauth-access",
           refresh: "oauth-refresh",
           expires: Date.now() + 60_000,
-        },
+        }),
         "fixture-provider:api-key": createApiKeyCredential("fixture-provider", "api-key"),
       },
     };
@@ -286,13 +285,12 @@ describe("resolveAuthProfileOrder", () => {
       version: 1,
       profiles: {
         "fixture-provider:key": createApiKeyCredential("fixture-provider", "sk-primary"),
-        "fixture-provider:oauth": {
-          type: "oauth",
+        "fixture-provider:oauth": oauthCred({
           provider: "fixture-provider",
           access: "access-token",
           refresh: "refresh-token",
           expires: Date.now() + 60_000,
-        },
+        }),
       },
       order: {
         "fixture-provider": ["fixture-provider:deleted"],
@@ -313,20 +311,18 @@ describe("resolveAuthProfileOrder", () => {
   ])("prefers live OAuth before expired OAuth when %s", (_caseName, profileIds) => {
     const now = Date.now();
     const profiles: AuthProfileStore["profiles"] = {
-      "openai:expired": {
-        type: "oauth",
+      "openai:expired": oauthCred({
         provider: "openai",
         access: "expired-access",
         refresh: "expired-refresh",
         expires: now - 60_000,
-      },
-      "openai:valid": {
-        type: "oauth",
+      }),
+      "openai:valid": oauthCred({
         provider: "openai",
         access: "valid-access",
         refresh: "valid-refresh",
         expires: now + 60_000,
-      },
+      }),
     };
     const orderedProfiles: AuthProfileStore["profiles"] = {};
     for (const profileId of profileIds) {
@@ -356,20 +352,18 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "openai:expired": {
-          type: "oauth",
+        "openai:expired": oauthCred({
           provider: "openai",
           access: "expired-access",
           refresh: "expired-refresh",
           expires: now - 60_000,
-        },
-        "openai:valid": {
-          type: "oauth",
+        }),
+        "openai:valid": oauthCred({
           provider: "openai",
           access: "valid-access",
           refresh: "valid-refresh",
           expires: now + 60_000,
-        },
+        }),
       },
       order: { openai: ["openai:expired", "openai:valid"] },
     };
@@ -556,13 +550,12 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "openai:personal": {
-          type: "oauth",
+        "openai:personal": oauthCred({
           provider: "openai",
           access: "access",
           refresh: "refresh",
           expires: Date.now() + 60_000,
-        },
+        }),
         "openai:backup": createApiKeyCredential("openai", "sk-backup"),
         "openai:platform": createApiKeyCredential("openai", "sk-platform"),
       },
@@ -587,21 +580,19 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "openai:personal": {
-          type: "oauth",
+        "openai:personal": oauthCred({
           provider: "openai",
           access: "access",
           refresh: "refresh",
           expires: Date.now() + 60_000,
-        },
+        }),
         "openai:backup": createApiKeyCredential("openai", "sk-platform"),
-        "openai:oauth": {
-          type: "oauth",
+        "openai:oauth": oauthCred({
           provider: "openai",
           access: "wrong-provider-access",
           refresh: "wrong-provider-refresh",
           expires: Date.now() + 60_000,
-        },
+        }),
       },
     };
 
@@ -617,13 +608,12 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "openai:personal": {
-          type: "oauth",
+        "openai:personal": oauthCred({
           provider: "openai",
           access: "",
           refresh: "",
           expires: Date.now() + 60_000,
-        },
+        }),
       },
     };
 
@@ -640,13 +630,12 @@ describe("resolveAuthProfileOrder", () => {
       version: 1,
       profiles: {
         "openai:default": createApiKeyCredential("openai", "sk-platform"),
-        "openai:personal": {
-          type: "oauth",
+        "openai:personal": oauthCred({
           provider: "openai",
           access: "access",
           refresh: "refresh",
           expires: Date.now() + 60_000,
-        },
+        }),
       },
     };
 
@@ -669,13 +658,12 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "openai:personal": {
-          type: "oauth",
+        "openai:personal": oauthCred({
           provider: "openai",
           access: "access",
           refresh: "refresh",
           expires: Date.now() + 60_000,
-        },
+        }),
         "openai:backup": createApiKeyCredential("openai", "sk-platform"),
       },
     };
@@ -699,13 +687,12 @@ describe("resolveAuthProfileOrder", () => {
     const store: AuthProfileStore = {
       version: 1,
       profiles: {
-        "openai:personal": {
-          type: "oauth",
+        "openai:personal": oauthCred({
           provider: "openai",
           access: "access",
           refresh: "refresh",
           expires: Date.now() + 60_000,
-        },
+        }),
       },
     };
 
@@ -729,13 +716,12 @@ describe("resolveAuthProfileOrder", () => {
       version: 1,
       profiles: {
         "openai:platform": createApiKeyCredential("openai", "sk-platform"),
-        "openai:work": {
-          type: "oauth",
+        "openai:work": oauthCred({
           provider: "openai",
           access: "work-access",
           refresh: "work-refresh",
           expires: Date.now() + 60_000,
-        },
+        }),
       },
       order: {
         openai: ["openai:platform"],
@@ -763,13 +749,12 @@ describe("resolveAuthProfileOrder", () => {
       const store: AuthProfileStore = {
         version: 1,
         profiles: {
-          "fixture-provider:default": {
-            type: "oauth",
+          "fixture-provider:default": oauthCred({
             provider: "fixture-provider",
             access: "token",
             refresh: "refresh",
             expires: Date.now() + 60_000,
-          },
+          }),
         },
         usageStats: {
           "fixture-provider:default": {

--- a/src/agents/auth-profiles/profiles.test.ts
+++ b/src/agents/auth-profiles/profiles.test.ts
@@ -16,7 +16,7 @@ import {
 import { closeOpenClawStateDatabaseForTest } from "../../state/openclaw-state-db.js";
 import { withEnvAsync } from "../../test-utils/env.js";
 import { AUTH_STORE_VERSION } from "./constants.js";
-import { createApiKeyCredential } from "./credential-fixtures.test-support.js";
+import { createApiKeyCredential, oauthCred } from "./credential-fixtures.test-support.js";
 import { testing as externalAuthTesting } from "./external-auth.test-support.js";
 import {
   getRuntimeAuthProfileStoreCredentialMutationToken,
@@ -237,13 +237,12 @@ describe("promoteAuthProfileInOrder", () => {
 
         await upsertAuthProfileWithLock({
           profileId: "openai:default",
-          credential: {
-            type: "oauth",
+          credential: oauthCred({
             provider: "openai",
             access: "new",
             refresh: "refresh-new",
             expires: Date.now() + 60_000,
-          },
+          }),
         });
 
         expect(
@@ -282,13 +281,12 @@ describe("promoteAuthProfileInOrder", () => {
           {
             version: AUTH_STORE_VERSION,
             profiles: {
-              "openai:local": {
-                type: "oauth",
+              "openai:local": oauthCred({
                 provider: "openai",
                 access: "local-old",
                 refresh: "local-refresh-old",
                 expires: Date.now() + 60_000,
-              },
+              }),
             },
           },
           customAgentDir,
@@ -310,13 +308,12 @@ describe("promoteAuthProfileInOrder", () => {
           await upsertAuthProfileWithLock({
             agentDir: customAgentDir,
             profileId: "openai:local",
-            credential: {
-              type: "oauth",
+            credential: oauthCred({
               provider: "openai",
               access: "local-new",
               refresh: "local-refresh-new",
               expires: Date.now() + 120_000,
-            },
+            }),
           });
         } finally {
           externalAuthTesting.resetResolveExternalAuthProfilesForTest();
@@ -687,13 +684,12 @@ describe("promoteAuthProfileInOrder", () => {
             key: "sk-materialized",
             keyRef,
           },
-          "anthropic:external": {
-            type: "oauth",
+          "anthropic:external": oauthCred({
             provider: "anthropic",
             access: "external-access",
             refresh: "external-refresh",
             expires: Date.now() + 60_000,
-          },
+          }),
         },
         runtimeExternalProfileIds: ["anthropic:external"],
       };
@@ -727,13 +723,12 @@ describe("promoteAuthProfileInOrder", () => {
       const runtimeStore: RuntimeAuthProfileStore = {
         version: AUTH_STORE_VERSION,
         profiles: {
-          [profileId]: {
-            type: "oauth",
+          [profileId]: oauthCred({
             provider: "openai",
             access: "external-access",
             refresh: "external-refresh",
             expires: Date.now() + 60_000,
-          },
+          }),
         },
         runtimeExternalProfileIds: [profileId],
         runtimeExternalCliProfileIds: [profileId],
@@ -758,13 +753,12 @@ describe("promoteAuthProfileInOrder", () => {
             version: AUTH_STORE_VERSION,
             profiles: {
               "openai:baseline": createApiKeyCredential("openai", "sk-baseline"),
-              "anthropic:external": {
-                type: "oauth",
+              "anthropic:external": oauthCred({
                 provider: "anthropic",
                 access: "external-before-capture",
                 refresh: "external-refresh",
                 expires: Date.now() + 60_000,
-              },
+              }),
             },
             runtimeExternalProfileIds: ["anthropic:external"],
           };
@@ -780,13 +774,12 @@ describe("promoteAuthProfileInOrder", () => {
                   ...baselineStore,
                   profiles: {
                     ...baselineStore.profiles,
-                    "anthropic:external": {
-                      type: "oauth",
+                    "anthropic:external": oauthCred({
                       provider: "anthropic",
                       access: "external-after-capture",
                       refresh: "external-refresh-new",
                       expires: Date.now() + 120_000,
-                    },
+                    }),
                   },
                 },
               },
@@ -856,13 +849,12 @@ describe("promoteAuthProfileInOrder", () => {
           throw new Error("expected captured derived API-key profile");
         }
         capturedProfile.key = "sk-captured-resolved";
-        capturedRuntime.profiles["anthropic:captured-external"] = {
-          type: "oauth",
+        capturedRuntime.profiles["anthropic:captured-external"] = oauthCred({
           provider: "anthropic",
           access: "captured-external-access",
           refresh: "captured-external-refresh",
           expires: Date.now() + 60_000,
-        };
+        });
         capturedRuntime.runtimeExternalProfileIds = ["anthropic:captured-external"];
         replaceRuntimeAuthProfileStoreSnapshots([
           { agentDir: capturedAgentDir, store: capturedRuntime },
@@ -878,13 +870,12 @@ describe("promoteAuthProfileInOrder", () => {
             },
           },
         });
-        capturedRuntime.profiles["anthropic:captured-external"] = {
-          type: "oauth",
+        capturedRuntime.profiles["anthropic:captured-external"] = oauthCred({
           provider: "anthropic",
           access: "captured-publication-edge-access",
           refresh: "captured-publication-edge-refresh",
           expires: Date.now() + 120_000,
-        };
+        });
         replaceRuntimeAuthProfileStoreSnapshots([
           { agentDir: capturedAgentDir, store: capturedRuntime },
         ]);
@@ -900,13 +891,12 @@ describe("promoteAuthProfileInOrder", () => {
           refresh: "captured-publication-edge-refresh",
         });
         const newerRuntime = loadAuthProfileStoreForRuntime(newerAgentDir);
-        newerRuntime.profiles["anthropic:newer-external"] = {
-          type: "oauth",
+        newerRuntime.profiles["anthropic:newer-external"] = oauthCred({
           provider: "anthropic",
           access: "newer-external-access",
           refresh: "newer-external-refresh",
           expires: Date.now() + 60_000,
-        };
+        });
         newerRuntime.runtimeExternalProfileIds = ["anthropic:newer-external"];
         replaceRuntimeAuthProfileStoreSnapshots([
           { agentDir: capturedAgentDir, store: ownedCapturedRuntime },
@@ -1280,20 +1270,18 @@ describe("promoteAuthProfileInOrder", () => {
         {
           version: AUTH_STORE_VERSION,
           profiles: {
-            [newProfileId]: {
-              type: "oauth",
+            [newProfileId]: oauthCred({
               provider: "openai",
               access: "new-access",
               refresh: "new-refresh",
               expires: Date.now() + 60 * 60 * 1000,
-            },
-            [staleProfileId]: {
-              type: "oauth",
+            }),
+            [staleProfileId]: oauthCred({
               provider: "openai",
               access: "stale-access",
               refresh: "stale-refresh",
               expires: Date.now() + 30 * 60 * 1000,
-            },
+            }),
           },
           order: {
             openai: [staleProfileId],
@@ -1331,34 +1319,30 @@ describe("promoteAuthProfileInOrder", () => {
         {
           version: AUTH_STORE_VERSION,
           profiles: {
-            [primaryProfileId]: {
-              type: "oauth",
+            [primaryProfileId]: oauthCred({
               provider: "openai",
               access: "primary-access",
               refresh: "primary-refresh",
               expires: Date.now() + 30 * 60 * 1000,
-            },
-            [backupProfileId]: {
-              type: "oauth",
+            }),
+            [backupProfileId]: oauthCred({
               provider: "openai",
               access: "backup-access",
               refresh: "backup-refresh",
               expires: Date.now() + 30 * 60 * 1000,
-            },
-            [newProfileId]: {
-              type: "oauth",
+            }),
+            [newProfileId]: oauthCred({
               provider: "openai",
               access: "new-access",
               refresh: "new-refresh",
               expires: Date.now() + 60 * 60 * 1000,
-            },
-            [unrelatedProfileId]: {
-              type: "oauth",
+            }),
+            [unrelatedProfileId]: oauthCred({
               provider: "openai",
               access: "unrelated-access",
               refresh: "unrelated-refresh",
               expires: Date.now() + 30 * 60 * 1000,
-            },
+            }),
           },
         },
         agentDir,
@@ -1394,20 +1378,18 @@ describe("promoteAuthProfileInOrder", () => {
         {
           version: AUTH_STORE_VERSION,
           profiles: {
-            [existingProfileId]: {
-              type: "oauth",
+            [existingProfileId]: oauthCred({
               provider: "openai",
               access: "old-access",
               refresh: "old-refresh",
               expires: Date.now() + 30 * 60 * 1000,
-            },
-            [newProfileId]: {
-              type: "oauth",
+            }),
+            [newProfileId]: oauthCred({
               provider: "openai",
               access: "new-access",
               refresh: "new-refresh",
               expires: Date.now() + 60 * 60 * 1000,
-            },
+            }),
           },
         },
         agentDir,
@@ -1443,13 +1425,12 @@ describe("promoteAuthProfileInOrder", () => {
         {
           version: AUTH_STORE_VERSION,
           profiles: {
-            [newProfileId]: {
-              type: "oauth",
+            [newProfileId]: oauthCred({
               provider: "openai",
               access: "new-access",
               refresh: "new-refresh",
               expires: Date.now() + 60 * 60 * 1000,
-            },
+            }),
           },
         },
         agentDir,
@@ -1475,13 +1456,12 @@ describe("promoteAuthProfileInOrder", () => {
         {
           version: AUTH_STORE_VERSION,
           profiles: {
-            [staleProfileId]: {
-              type: "oauth",
+            [staleProfileId]: oauthCred({
               provider: "openai",
               access: "stale-access-token",
               refresh: "stale-refresh-token",
               expires: Date.now() - 60_000,
-            },
+            }),
           },
           lastGood: { openai: staleProfileId },
         },
@@ -1617,13 +1597,12 @@ describe("promoteAuthProfileInOrder", () => {
       const initialStore: RuntimeAuthProfileStore = {
         version: AUTH_STORE_VERSION,
         profiles: {
-          "openrouter:oauth": {
-            type: "oauth",
+          "openrouter:oauth": oauthCred({
             provider: "openrouter",
             access: "oauth-access",
             refresh: "oauth-refresh",
             expires: Date.now() + 60_000,
-          },
+          }),
           "openrouter:api-key": createApiKeyCredential("openrouter", "api-key"),
         },
         order: { openrouter: ["openrouter:oauth", "openrouter:api-key"] },
@@ -1755,13 +1734,12 @@ describe("promoteAuthProfileInOrder", () => {
         {
           version: AUTH_STORE_VERSION,
           profiles: {
-            [goodProfileId]: {
-              type: "oauth",
+            [goodProfileId]: oauthCred({
               provider: "openai",
               access: "good-access-token",
               refresh: "good-refresh-token",
               expires: Date.now() + 60_000,
-            },
+            }),
           },
           lastGood: { openai: goodProfileId },
         },
@@ -1793,20 +1771,18 @@ describe("setAuthProfileOrder", () => {
         saveAuthProfileStore({
           version: AUTH_STORE_VERSION,
           profiles: {
-            "openai:first": {
-              type: "oauth",
+            "openai:first": oauthCred({
               provider: "openai",
               access: "first",
               refresh: "first-refresh",
               expires: Date.now() + 60_000,
-            },
-            "openai:second": {
-              type: "oauth",
+            }),
+            "openai:second": oauthCred({
               provider: "openai",
               access: "second",
               refresh: "second-refresh",
               expires: Date.now() + 60_000,
-            },
+            }),
           },
           order: { openai: ["openai:first", "openai:second"] },
         });
@@ -1927,20 +1903,18 @@ describe("setAuthProfileOrder", () => {
         const mainStore = (): AuthProfileStore => ({
           version: AUTH_STORE_VERSION,
           profiles: {
-            "openai:profile-a": {
-              type: "oauth",
+            "openai:profile-a": oauthCred({
               provider: "openai",
               access: "access-a",
               refresh: "refresh-a",
               expires: Date.now() + 60_000,
-            },
-            "openai:profile-b": {
-              type: "oauth",
+            }),
+            "openai:profile-b": oauthCred({
               provider: "openai",
               access: "access-b",
               refresh: "refresh-b",
               expires: Date.now() + 60_000,
-            },
+            }),
           },
           order: { openai: ["openai:profile-a"] },
         });


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

Auth-profile tests repeat the same five-field OAuth credential setup, while the existing named-parameter constructor lives in a broader utility module with filesystem and auth-store dependencies.

## Why This Change Was Made

Moves the existing `oauthCred` implementation unchanged into the lightweight credential-fixture owner and migrates its two existing callers. Fifty additional input fixtures reuse it while keeping provider, access, refresh, and expiry labels visible. The old export is removed without a compatibility alias or competing constructor.

## User Impact

No production behavior changes or test cases removed. Explicit expiry expressions, field absence and order, fresh objects, optional account/email semantics, and independent expected values remain intact. The change removes 51 net test/support lines, including three consequential formatter lines from the real import migration.

## Evidence

- All five complete affected suites passed 83 cases before and after, with identical per-file ordered case names.
- Full AST expansion checked all 50 converted inputs, 39 retained clock-expression sites, eight existing calls, and the unchanged helper declaration.
- Runtime controls verified freshness, ordered keys/values, absent versus explicitly undefined optional fields, and erased type-only dependency.
- Full mapped checks, diff-scoped cleanup, and fresh full-scope P2 review passed without findings.

No runtime speedup or aggregate coverage percentage is claimed.
