### PR TITLE
fix(ci): keep Docker upgrade seed baseline older than target

### DIFF
--- a/.github/actions/git-owner/owner.py
+++ b/.github/actions/git-owner/owner.py
@@ -391,6 +391,7 @@ def checkout_selected_ref():
 def checkout_harness(sha):
     action = ".github/actions/setup-node-env/action.yml"
     evidence_scripts = ("scripts/ios-screenshot-evidence.mjs", "scripts/lib/direct-run.mjs")
+    upgrade_scripts = ("scripts/lib/release-upgrade-baseline.mjs", "scripts/lib/release-version.mjs")
     if kind == "linux-node" and not os.path.isfile(os.path.join(workspace, action)):
         raise GitFailure(1)
     harness = os.path.join(workspace, ".ci-harness")
@@ -411,6 +412,8 @@ def checkout_harness(sha):
             pathspecs += evidence_scripts
         elif kind == "preflight":
             pathspecs += ["scripts/lib/release-context.mjs", "scripts/lib/release-version.mjs"]
+        if kind == "linux-node":
+            pathspecs += upgrade_scripts
         paths = git_output(workspace, "ls-files", "-z", "--", *pathspecs).split("\0")[:-1]
         run_git(workspace, "checkout-index", "--force", f"--prefix={harness}/", "--", *paths)
     else:
@@ -419,6 +422,8 @@ def checkout_harness(sha):
         sparse_paths = ["/.github/actions/"]
         if kind in ("platform", "linux-node"):
             sparse_paths += [f"/{path}" for path in evidence_scripts]
+        if kind == "linux-node":
+            sparse_paths += [f"/{path}" for path in upgrade_scripts]
         # Rooted non-cone patterns keep the kind-owned workflow files exact.
         # Sparse first, then blob-less avoids downloading a second repository snapshot.
         run_git(harness, "sparse-checkout", "set", "--no-cone", *sparse_paths)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5643,12 +5643,23 @@ jobs:
         run: |
           node --input-type=module -e 'import os from "node:os"; console.log(JSON.stringify({ logicalCpuCount: os.availableParallelism(), totalMemoryBytes: os.totalmem() }));'
 
+      - name: Resolve published Docker seed upgrade baseline
+        if: contains(format(' {0} ', needs.preflight.outputs.docker_seed_lanes), ' published-upgrade-survivor ')
+        env:
+          TARGET_CONTEXT_REF: ${{ inputs.target_context_ref || github.base_ref || github.ref_name }}
+        run: |
+          set -euo pipefail
+          candidate_version="$(node -p "require('./package.json').version")"
+          baseline="$(node .ci-harness/scripts/lib/release-upgrade-baseline.mjs \
+            --candidate-version "$candidate_version" \
+            --target-context-ref "$TARGET_CONTEXT_REF")"
+          printf 'OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC=%s\n' "$baseline" >> "$GITHUB_ENV"
+
       - name: Run changed Docker seed owner lanes
         env:
           OPENCLAW_DOCKER_ALL_LANES: ${{ needs.preflight.outputs.docker_seed_lanes }}
           OPENCLAW_DOCKER_ALL_LIVE_MODE: skip
           OPENCLAW_DOCKER_E2E_ALLOW_UNRELEASED_CHANGELOG: "1"
-          OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC: openclaw@latest
           OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS: legacy-operator-state
           OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE: auto-auth
           OPENCLAW_DOCKER_ALL_PARALLELISM: ${{ vars.OPENCLAW_CI_RUNNER_BACKEND != 'github' && github.event_name == 'pull_request' && github.run_attempt == 1 && github.event.pull_request.head.repo.full_name == github.repository && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.pull_request.author_association) && 3 || 1 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -610,6 +610,7 @@ jobs:
           def checkout_harness(sha):
               action = ".github/actions/setup-node-env/action.yml"
               evidence_scripts = ("scripts/ios-screenshot-evidence.mjs", "scripts/lib/direct-run.mjs")
+              upgrade_scripts = ("scripts/lib/release-upgrade-baseline.mjs", "scripts/lib/release-version.mjs")
               if kind == "linux-node" and not os.path.isfile(os.path.join(workspace, action)):
                   raise GitFailure(1)
               harness = os.path.join(workspace, ".ci-harness")
@@ -630,6 +631,8 @@ jobs:
                       pathspecs += evidence_scripts
                   elif kind == "preflight":
                       pathspecs += ["scripts/lib/release-context.mjs", "scripts/lib/release-version.mjs"]
+                  if kind == "linux-node":
+                      pathspecs += upgrade_scripts
                   paths = git_output(workspace, "ls-files", "-z", "--", *pathspecs).split("\0")[:-1]
                   run_git(workspace, "checkout-index", "--force", f"--prefix={harness}/", "--", *paths)
               else:
@@ -638,6 +641,8 @@ jobs:
                   sparse_paths = ["/.github/actions/"]
                   if kind in ("platform", "linux-node"):
                       sparse_paths += [f"/{path}" for path in evidence_scripts]
+                  if kind == "linux-node":
+                      sparse_paths += [f"/{path}" for path in upgrade_scripts]
                   # Rooted non-cone patterns keep the kind-owned workflow files exact.
                   # Sparse first, then blob-less avoids downloading a second repository snapshot.
                   run_git(harness, "sparse-checkout", "set", "--no-cone", *sparse_paths)

--- a/docs/ci/release-validation.md
+++ b/docs/ci/release-validation.md
@@ -232,6 +232,8 @@ serving-turn/post-inference assertions.
 The historical baseline does not select the assertion owner. Invalid target
 versions and unsupported extended-stable correction versions fail before Docker.
 
+Docker seed CI resolves an exact published stable predecessor of the selected source package version before running `published-upgrade-survivor`. It uses the release baseline resolver and selected release context, so publishing `latest` never turns the first upgrade into an already-current operation. Missing predecessors fail before Docker starts; the separate already-current control remains unchanged.
+
 The `published-upgrade-survivor` Docker lane validates one published package baseline per scenario. In Package Acceptance, the resolved `package-under-test` tarball is always the candidate and `published_upgrade_survivor_baseline` selects the fallback published baseline, defaulting to `openclaw@latest`; failed-lane rerun commands preserve that baseline. Current source release checks set `published_upgrade_survivor_baselines=supported-lines` for `legacy-operator-state`: npm's current `latest`, the preceding stable version, `extended-stable` when that tag exists, and the documented oldest supported baseline `2026.6.34`. The resolver reads `npm view openclaw versions` and `npm view openclaw dist-tags` at run time, pins exact versions before fanout, and deduplicates overlapping lines. Normal current-source release checks retain `base` and add `legacy-operator-state`; release soak selects `reported-issues`, including legacy operator state and the existing issue-shaped fixtures.
 
 Expanded release qualification requires the candidate's `YYYY.M.PATCH` base version

--- a/test/scripts/ci-platform-checkout.test.ts
+++ b/test/scripts/ci-platform-checkout.test.ts
@@ -236,7 +236,12 @@ it.concurrent.each([
             report.commands.some(
               ({ args }) =>
                 args.join(" ") ===
-                "sparse-checkout set --no-cone /.github/actions/ /scripts/ios-screenshot-evidence.mjs /scripts/lib/direct-run.mjs",
+                [
+                  "sparse-checkout set --no-cone /.github/actions/ /scripts/ios-screenshot-evidence.mjs /scripts/lib/direct-run.mjs",
+                  ...(linux
+                    ? ["/scripts/lib/release-upgrade-baseline.mjs /scripts/lib/release-version.mjs"]
+                    : []),
+                ].join(" "),
             ),
           ).toBe(true);
           expect(report.commands.at(-1)?.args).toEqual([
@@ -330,10 +335,11 @@ it.concurrent.each([
       "scripts/lib/direct-run.mjs": "workflow direct-run script\n",
     };
     const releasePolicy = Object.fromEntries(
-      ["scripts/lib/release-context.mjs", "scripts/lib/release-version.mjs"].map((name) => [
-        name,
-        readFileSync(name, "utf8"),
-      ]),
+      [
+        "scripts/lib/release-context.mjs",
+        "scripts/lib/release-version.mjs",
+        "scripts/lib/release-upgrade-baseline.mjs",
+      ].map((name) => [name, readFileSync(name, "utf8")]),
     );
     const candidateFiles = {
       "candidate-only.txt": "candidate stays intact\n",
@@ -425,7 +431,10 @@ it.concurrent.each([
           for (const [name, contents] of Object.entries(candidateEvidenceScripts)) {
             writeFileSync(path.join(source, name), contents);
           }
-          run("add", action, ...Object.keys(evidenceScripts));
+          for (const name of Object.keys(releasePolicy)) {
+            writeFileSync(path.join(source, name), "throw new Error('candidate policy');\n");
+          }
+          run("add", action, ...Object.keys(evidenceScripts), ...Object.keys(releasePolicy));
           run("commit", "--no-gpg-sign", "-m", "selected candidate");
           revision = run("rev-parse", "HEAD");
         } else if (workflow === "missing") {
@@ -535,12 +544,32 @@ it.concurrent.each([
           }
         }
         for (const [name, contents] of Object.entries(releasePolicy)) {
-          expect(existsSync(path.join(harness, name))).toBe(preflight);
-          if (preflight) {
+          const ownsPolicy = preflight
+            ? name !== "scripts/lib/release-upgrade-baseline.mjs"
+            : kind === "linux-node" && name !== "scripts/lib/release-context.mjs";
+          expect(existsSync(path.join(harness, name))).toBe(ownsPolicy);
+          if (ownsPolicy) {
             expect(readFileSync(path.join(harness, name), "utf8")).toBe(contents);
             writeFileSync(path.join(workspace, name), "throw new Error('candidate policy');\n");
             expect(readFileSync(path.join(harness, name), "utf8")).toBe(contents);
           }
+        }
+        if (kind === "linux-node") {
+          const versions = path.join(root, "published-versions.json");
+          writeFileSync(versions, JSON.stringify(["2026.9.1", "2026.9.2", "2026.9.3"]));
+          const resolved = spawnSync(
+            process.execPath,
+            [
+              path.join(harness, "scripts/lib/release-upgrade-baseline.mjs"),
+              "--candidate-version",
+              "2026.9.3",
+              "--versions-json",
+              versions,
+            ],
+            { cwd: workspace, encoding: "utf8" },
+          );
+          expect(resolved.status, resolved.stderr).toBe(0);
+          expect(resolved.stdout.trim()).toBe("openclaw@2026.9.2");
         }
         if (posix) {
           // Git tracks only executable state; checkout materialization applies the process umask.
@@ -555,6 +584,9 @@ it.concurrent.each([
             "/.github/actions/",
             "/scripts/ios-screenshot-evidence.mjs",
             "/scripts/lib/direct-run.mjs",
+            ...(kind === "linux-node"
+              ? ["/scripts/lib/release-upgrade-baseline.mjs", "/scripts/lib/release-version.mjs"]
+              : []),
           ]);
         }
         writeFileSync(path.join(workspace, action), "later candidate edit\n");

--- a/test/scripts/ci-workflow-guards.test.ts
+++ b/test/scripts/ci-workflow-guards.test.ts
@@ -3890,13 +3890,107 @@ NODE
         OPENCLAW_DOCKER_ALL_LANES: "${{ needs.preflight.outputs.docker_seed_lanes }}",
         OPENCLAW_DOCKER_ALL_LIVE_MODE: "skip",
         OPENCLAW_DOCKER_E2E_ALLOW_UNRELEASED_CHANGELOG: "1",
-        OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC: "openclaw@latest",
         OPENCLAW_UPGRADE_SURVIVOR_SCENARIOS: "legacy-operator-state",
         OPENCLAW_UPGRADE_SURVIVOR_UPDATE_RESTART_MODE: "auto-auth",
         OPENCLAW_DOCKER_ALL_TAIL_PARALLELISM: parallelism,
       },
     });
     expect(parallelism).toContain("&& 3 || 1");
+    expect(run.env).not.toHaveProperty("OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC");
+    const baseline = job.steps.find(
+      (step: WorkflowStep) => step.name === "Resolve published Docker seed upgrade baseline",
+    ) as WorkflowStep;
+    expect(baseline.if).toBe(
+      "contains(format(' {0} ', needs.preflight.outputs.docker_seed_lanes), ' published-upgrade-survivor ')",
+    );
+    expect(baseline.env).toEqual({
+      TARGET_CONTEXT_REF: "${{ inputs.target_context_ref || github.base_ref || github.ref_name }}",
+    });
+    expect(job.steps.indexOf(baseline)).toBeLessThan(job.steps.indexOf(run));
+  });
+
+  it.each([
+    { candidate: "2026.9.3", expected: "openclaw@2026.9.2" },
+    { candidate: "2026.9.2", expected: "openclaw@2026.9.1" },
+    { candidate: "2026.9.4-beta.1", expected: "openclaw@2026.9.3" },
+    { candidate: "2026.9.3-beta.1", expected: "openclaw@2026.9.2" },
+    {
+      candidate: "2026.6.35",
+      context: "extended-stable/2026.6.33",
+      expected: "openclaw@2026.6.34",
+    },
+    { candidate: "2026.6.34", expected: undefined },
+  ])("hands Docker seed a strictly older published baseline for $candidate", (fixture) => {
+    const job = readCiWorkflow().jobs["docker-seed-e2e"];
+    const baseline = job.steps.find(
+      (step: WorkflowStep) => step.name === "Resolve published Docker seed upgrade baseline",
+    ) as WorkflowStep | undefined;
+    const run = job.steps.find(
+      (step: WorkflowStep) => step.name === "Run changed Docker seed owner lanes",
+    ) as WorkflowStep;
+    const root = mkdtempSync(path.join(tmpdir(), "openclaw-ci-upgrade-baseline-"));
+    try {
+      const bin = path.join(root, "bin");
+      const tooling = path.join(root, ".ci-harness", "scripts", "lib");
+      mkdirSync(bin);
+      mkdirSync(tooling, { recursive: true });
+      for (const name of ["release-upgrade-baseline.mjs", "release-version.mjs"]) {
+        copyFileSync(path.resolve("scripts", "lib", name), path.join(tooling, name));
+      }
+      writeFileSync(
+        path.join(root, "package.json"),
+        JSON.stringify({ version: fixture.candidate }),
+      );
+      writeFileSync(
+        path.join(root, ".ci-harness", "package.json"),
+        JSON.stringify({ version: "2026.10.1" }),
+      );
+      symlinkSync(process.execPath, path.join(bin, "node"));
+      writeFileSync(
+        path.join(bin, "npm"),
+        `#!${process.execPath}
+const args = process.argv.slice(2);
+if (JSON.stringify(args) !== JSON.stringify(["view", "openclaw", "versions", "--json", "--silent", "--prefer-online"])) process.exit(2);
+console.log(JSON.stringify(["2026.6.34", "2026.6.35", "2026.9.1", "2026.9.2", "2026.9.3", "2026.9.4-beta.1"]));
+`,
+        { mode: 0o755 },
+      );
+      writeFileSync(
+        path.join(bin, "pnpm"),
+        `#!${process.execPath}
+if (process.argv.slice(2).join(" ") !== "test:docker:all") process.exit(2);
+require("node:fs").writeFileSync("scheduler-baseline", process.env.OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC ?? "missing");
+`,
+        { mode: 0o755 },
+      );
+      writeFileSync(path.join(root, "github-env"), "");
+      const inheritedBaseline = run.env?.OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC;
+      const result = runWorkflowShellScript(
+        `set -euo pipefail\n${baseline?.run ?? ""}\nset -a\nsource "$GITHUB_ENV"\nset +a\n${run.run}`,
+        {
+          cwd: root,
+          env: {
+            ...process.env,
+            PATH: `${bin}${path.delimiter}${process.env.PATH ?? ""}`,
+            GITHUB_ENV: path.join(root, "github-env"),
+            OPENCLAW_UPGRADE_SURVIVOR_BASELINE_SPEC:
+              typeof inheritedBaseline === "string" ? inheritedBaseline : "",
+            TARGET_CONTEXT_REF: fixture.context ?? "main",
+          },
+        },
+      );
+      const receipt = path.join(root, "scheduler-baseline");
+      if (fixture.expected) {
+        expect(result.status, result.stderr).toBe(0);
+        expect(readFileSync(receipt, "utf8")).toBe(fixture.expected);
+      } else {
+        expect(result.status).not.toBe(0);
+        expect(result.stderr).toContain("no published stable OpenClaw baseline predates candidate");
+        expect(existsSync(receipt)).toBe(false);
+      }
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   it.each([


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Docker seed CI fails its real-upgrade case after npm's latest release reaches the target version. The updater correctly reports already-current, but the test is supposed to prove an actual upgrade before running its separate no-op control.

## Why This Change Was Made

When the published survivor lane is selected, use the existing release baseline resolver to pin a published stable version strictly older than the selected source package version. Pass the release context so frozen extended-stable lines retain their existing predecessor policy. Materialize the resolver and its version helper from the trusted workflow revision through both Git harness checkout paths. Export the exact baseline before the Docker scheduler; unrelated lanes need no registry lookup.

## User Impact

Release publication no longer changes this CI case into a same-version update or downgrade. Current main, future betas, and extended-stable targets keep the same real-upgrade and already-current assertions. No product updater behavior or package version changes.

## Evidence

- Six executed workflow-to-resolver-to-scheduler cases fail on the original floating-latest workflow and pass after the repair. They cover target 9.3, current main 9.2, two beta positions, a frozen extended-stable line, and fail-closed behavior when no predecessor exists.
- 26 existing baseline resolver tests and seven focused CI guard cases passed. Scoped changed checks and workflow validation passed.
- A live npm versions snapshot resolves 9.3 to openclaw@2026.9.2, current main 9.2 to openclaw@2026.9.1, and 9.4-beta.1 to openclaw@2026.9.3.
- Sixteen harness and sibling checks passed, including real Git materialization from both the index and a distinct workflow revision. The materialized resolver executes correctly after candidate policy files are changed; both new Linux cases fail against the original materializer.
- Exact-head CI must pass before landing, including the unchanged Docker seed survivor assertions selected by this workflow change.
