### PR TITLE
fix(ui): polish chat mention picker

### DIFF
--- a/ui/src/e2e/chat-mention-popover.e2e.test.ts
+++ b/ui/src/e2e/chat-mention-popover.e2e.test.ts
@@ -1,0 +1,102 @@
+import { assert, expect, it } from "vitest";
+import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+import { waitForGatewayRecoveryScope } from "./new-session-page.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "chat mention popover" });
+
+suite.define(() => {
+  it.each([
+    { route: "chat", count: 2 },
+    { route: "chat", count: 16 },
+    { route: "new", count: 2 },
+  ])(
+    "keeps people identifiable without offline metadata in $route ($count people)",
+    async ({ route, count }) => {
+      await suite.withPage({ viewport: { width: 1440, height: 900 } }, async ({ page }) => {
+        const users = Array.from({ length: count }, (_, index) => ({
+          profileId: `${String(index + 1).padStart(8, "0")}-1111-4111-8111-${String(index + 101).padStart(12, "0")}`,
+          // The directory decorates duplicate names before returning them to the composer.
+          displayName:
+            index < 2 ? `Robin (${String(index + 1).padStart(8, "0")})` : `Viewer ${index + 1}`,
+          online: index === 0,
+        }));
+        const lastPerson = users.at(-1);
+        assert(lastPerson, "The mention fixture must include a selectable person.");
+        const gateway = await installMockGateway(page, {
+          presenceUsers: [
+            {
+              self: true,
+              id: "demo-viewer",
+              identity: { type: "profile", id: "demo-viewer" },
+              name: "Demo viewer",
+            },
+          ],
+          methodResponses: { "users.mentionable": { users, truncated: false } },
+        });
+        await page.goto(
+          route === "new"
+            ? `${suite.server.baseUrl}new`
+            : controlUiSessionUrl(suite.server.baseUrl, "agent:main:main"),
+        );
+        await waitForGatewayRecoveryScope(page);
+        const textarea = page.locator(
+          route === "new"
+            ? ".new-session-page__message"
+            : ".agent-chat__composer-combobox textarea",
+        );
+        await textarea.pressSequentially("@");
+        await gateway.waitForRequest("users.mentionable");
+        const menu = page.getByRole("listbox", { name: "Mention a person" });
+        const options = menu.getByRole("option");
+        await expect.poll(() => options.count()).toBe(count);
+        expect(await menu.textContent()).toContain("Online");
+        expect(await menu.textContent()).not.toContain("Offline");
+        for (const person of users) {
+          expect(await menu.textContent()).not.toContain(person.profileId.slice(-8));
+        }
+        for (const person of users.slice(0, 2)) {
+          expect(await options.filter({ hasText: person.displayName }).count()).toBe(1);
+        }
+
+        await textarea.press("ArrowUp");
+        const last = options.last();
+        await expect.poll(() => last.getAttribute("aria-selected")).toBe("true");
+        const viewports =
+          count > 2
+            ? [
+                { width: 1440, height: 900 },
+                { width: 844, height: 390 },
+              ]
+            : [{ width: 1440, height: 900 }];
+        for (const viewport of viewports) {
+          await page.setViewportSize(viewport);
+          // Re-enter the last option so its owner scrolls after the viewport changes.
+          await textarea.press("ArrowDown");
+          await textarea.press("ArrowUp");
+          await expect
+            .poll(() =>
+              last.evaluate((element) => {
+                const row = element.getBoundingClientRect();
+                const scroll = element.closest(".slash-menu__scroll")!.getBoundingClientRect();
+                const panel = element.closest('[role="listbox"]')!.getBoundingClientRect();
+                return (
+                  row.top >= Math.max(scroll.top, panel.top) &&
+                  row.bottom <= Math.min(scroll.bottom, panel.bottom) + 1
+                );
+              }),
+            )
+            .toBe(true);
+        }
+        await last.hover();
+        expect(await last.textContent()).not.toContain(lastPerson.profileId.slice(-8));
+        await textarea.press("Enter");
+        await expect.poll(() => textarea.inputValue()).toBe(`@${lastPerson.displayName} `);
+        await expect.poll(() => menu.count()).toBe(0);
+        expect(await page.locator(".chat-reply-preview").textContent()).toContain(
+          lastPerson.displayName,
+        );
+      });
+    },
+  );
+});

--- a/ui/src/pages/chat/chat-composer-mentions.test.ts
+++ b/ui/src/pages/chat/chat-composer-mentions.test.ts
@@ -211,7 +211,7 @@ describe.each(["chat", "new-session"] as const)("%s human mentions", (kind) => {
     view.edit("@Al", { data: "@Al" });
     await vi.advanceTimersByTimeAsync(150);
     expect(view.container.querySelectorAll('[role="option"]')).toHaveLength(2);
-    expect(view.container.textContent).toContain("Offline");
+    expect(view.container.textContent).not.toContain("Offline");
     view.key("ArrowDown");
     expect(view.key("Enter").defaultPrevented).toBe(true);
     expect(view.send).not.toHaveBeenCalled();

--- a/ui/src/pages/chat/components/chat-composer-mention-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-mention-menu.ts
@@ -261,8 +261,7 @@ export class HumanMentionMenu {
                   }),
                   iconHidden: true,
                   name: person.displayName,
-                  description: html`${person.online ? t("chat.mentions.online") : t("chat.mentions.offline")}
-                  · ${person.profileId.slice(-8)}`,
+                  description: person.online ? t("chat.mentions.online") : nothing,
                 }),
               )
         }

--- a/ui/src/styles/chat/composer.css
+++ b/ui/src/styles/chat/composer.css
@@ -2106,6 +2106,10 @@
     max-height: min(28vh, 88px);
     margin-bottom: 6px;
   }
+
+  .agent-chat__input > :is(.mention-menu, .skill-menu) {
+    --slash-menu-max-height: min(28vh, 88px);
+  }
 }
 
 @media (max-width: 640px), (max-width: 932px) and (max-height: 500px) and (orientation: landscape) {
@@ -2263,6 +2267,27 @@
 .slash-menu-desc {
   text-align: right;
   font-size: var(--control-ui-text-sm);
+}
+
+.mention-menu,
+.skill-menu {
+  overflow: visible;
+}
+
+.mention-menu .slash-menu-item {
+  grid-template-columns: 22px minmax(0, 1fr);
+}
+
+.mention-menu .slash-menu-icon,
+.mention-menu .chat-author-avatar {
+  width: 22px;
+  height: 22px;
+}
+
+.mention-menu .chat-author-avatar {
+  flex-basis: 22px;
+  border: 0;
+  box-shadow: 0 0 0 1px color-mix(in srgb, var(--border) 68%, transparent);
 }
 
 @media (max-width: 640px) {


### PR DESCRIPTION
Closes #142211

## What Problem This Solves

Fixes an issue where users choosing someone to mention in the chat composer see offline labels and redundant profile IDs competing with useful online status. Small avatars also have a ring separated from the image.

## Why This Change Was Made

Show only online presence, enlarge picker avatars from 20px to 22px with a ring directly against the image, and preserve the existing inset, rounded selection rows without clipping the people or skills panel. The list now respects the same height limit as its panel in short landscape layouts.

The removed ID is the final eight characters of the durable profile UUID. Mention selection and delivery retain the full ID. The Gateway already distinguishes equal names by appending the first eight ID characters to their display labels; those labels remain unchanged. The extra trailing ID provides no additional selection or delivery function.

## User Impact

The people picker is quieter, online people remain identifiable, and people with the same name remain distinguishable. Keyboard selection and scrolling continue to work in Chat and New Session. Avatar changes are scoped to this picker.

## Evidence

Synthetic profiles, 1440 × 900, dark theme, equivalent positions. Each capture was inspected. The base revision already had inset rows and individual rounding; the historical square-edge appearance was not reproduced on this revision.

<table>
<thead><tr><th>State</th><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>Two people; last selected</td><td><a href="https://github.com/user-attachments/assets/9d8c6090-f836-471a-84ca-62a9dfed7ac4"><img src="https://github.com/user-attachments/assets/9d8c6090-f836-471a-84ca-62a9dfed7ac4" width="640" alt="Before: Two people; last selected" /></a></td><td><a href="https://github.com/user-attachments/assets/52811b13-6fde-4184-92b9-fa00235ee63b"><img src="https://github.com/user-attachments/assets/52811b13-6fde-4184-92b9-fa00235ee63b" width="640" alt="After: Two people; last selected" /></a></td></tr>
<tr><td>Long list scrolled to last selection</td><td><a href="https://github.com/user-attachments/assets/2f24edb3-70da-43b8-837e-654518938283"><img src="https://github.com/user-attachments/assets/2f24edb3-70da-43b8-837e-654518938283" width="640" alt="Before: Long list scrolled to last selection" /></a></td><td><a href="https://github.com/user-attachments/assets/15ebb825-869d-4d77-bfc9-ddadca4b6c1c"><img src="https://github.com/user-attachments/assets/15ebb825-869d-4d77-bfc9-ddadca4b6c1c" width="640" alt="After: Long list scrolled to last selection" /></a></td></tr>
<tr><td>Hovered offline person</td><td><a href="https://github.com/user-attachments/assets/fd66b6c9-78f8-4951-ac97-ec35127d7032"><img src="https://github.com/user-attachments/assets/fd66b6c9-78f8-4951-ac97-ec35127d7032" width="640" alt="Before: Hovered offline person" /></a></td><td><a href="https://github.com/user-attachments/assets/bd7acf20-7d26-4e55-b54a-065dfeb8f12b"><img src="https://github.com/user-attachments/assets/bd7acf20-7d26-4e55-b54a-065dfeb8f12b" width="640" alt="After: Hovered offline person" /></a></td></tr>
<tr><td>Avatar detail (4×)</td><td><a href="https://github.com/user-attachments/assets/7a4ba9cf-fa22-45ef-a4ab-8dc7c0fb21a2"><img src="https://github.com/user-attachments/assets/7a4ba9cf-fa22-45ef-a4ab-8dc7c0fb21a2" width="192" alt="Before: Avatar detail (4×)" /></a></td><td><a href="https://github.com/user-attachments/assets/221b5771-d42c-4c25-835d-b0db25bc17f5"><img src="https://github.com/user-attachments/assets/221b5771-d42c-4c25-835d-b0db25bc17f5" width="192" alt="After: Avatar detail (4×)" /></a></td></tr>
</tbody>
</table>

- Canonical mocked browser flow against the production UI bundle: **3/3 passed**, covering Chat with two people, Chat with a 16-person list at desktop and 844 × 390 landscape, and New Session with duplicate names. The new tests failed on the previous offline text and detected the landscape containment regression before its repair.
- Existing composer mention suite: **22/22 passed**, retaining recipient selection and send coverage with full profile IDs.
- Rebased head `de3a7580ff39bfacc04499642564ef40ec55d88f`: **22/22 unit tests, 3/3 canonical browser scenarios, and the complete `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- <four changed files>` passed**. The full check includes test/UI typechecks, formatting, i18n, guards, unused-export scans, and lint.
- [CI run 34257794567](https://github.com/openclaw/openclaw/actions/runs/34257794567) **passed on the same head** (102 jobs); required `openclaw/ci-gate`: **SUCCESS**.

**Risk and coverage**

The shared mention renderer was checked in Chat and New Session. The skills picker shares the menu geometry and was checked for selection and containment; ordinary slash menus retain their existing overflow behavior. The shared author-avatar renderer is unchanged: transcript and pending-send avatars retain their styles, and sidebar/footer viewer avatars are outside the new selector. Visual captures use the mock bench served from source; the final E2E run uses the canonical production UI bundle with mocked Gateway responses. Validation against a live Gateway was not run.
