### PR TITLE
fix(ui): keep subagent task progress above the view-only footer

### DIFF
--- a/ui/src/e2e/subagent-task-notice.e2e.test.ts
+++ b/ui/src/e2e/subagent-task-notice.e2e.test.ts
@@ -1,0 +1,122 @@
+import { expect, it } from "vitest";
+import { controlUiSessionUrl, installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { createControlUiE2eSuite } from "./control-ui-e2e-suite.test-support.ts";
+
+const suite = createControlUiE2eSuite({ name: "Subagent task notice" });
+
+suite.define(() => {
+  it.each([1440, 768])("keeps task progress above the view-only footer at %ipx", async (width) => {
+    await suite.withPage(
+      { viewport: { width, height: 900 }, colorScheme: "dark" },
+      async ({ page }) => {
+        const parent = { key: "agent:main:task-parent", kind: "direct", label: "Workspace review" };
+        const child = {
+          key: "agent:main:subagent:task-child",
+          kind: "direct",
+          label: "Review report",
+          spawnedBy: parent.key,
+          parentSessionKey: parent.key,
+          status: "done",
+          hasActiveRun: false,
+          endedAt: Date.now() - 8 * 86_400_000,
+        };
+        const gateway = await installMockGateway(page, {
+          sessionKey: child.key,
+          communityInvite: false,
+          sessions: [parent, child],
+          historyMessages: [{ role: "assistant", content: "The workspace review is complete." }],
+          featureMethods: ["chat.metadata", "chat.startup", "progressCard.get"],
+          methodResponses: {
+            "progressCard.get": {
+              cases: [child.key, parent.key].map((sessionKey) => ({
+                match: { sessionKey },
+                response: {
+                  card: {
+                    sessionKey,
+                    markdown: Array.from(
+                      { length: 12 },
+                      (_, index) => `## Area ${index + 1}\n\nThe review of this area is complete.`,
+                    ).join("\n\n"),
+                    revision: 1,
+                    updatedAt: child.endedAt,
+                  },
+                },
+              })),
+            },
+          },
+        });
+        await page.goto(controlUiSessionUrl(suite.server.baseUrl, child.key));
+        const pane = page.locator("openclaw-chat-pane.chat-pane-cache__pane--active");
+        const shell = pane.locator(".agent-chat__composer-shell");
+        const notice = shell.locator(".agent-chat__disabled-banner--replacement");
+        const progress = shell.locator(".session-progress-card--composer");
+        const body = progress.locator(".session-progress-card__body");
+        await notice.getByText("View-only subagent", { exact: true }).waitFor();
+        await progress.waitFor();
+        expect(await shell.locator("textarea").count()).toBe(0);
+        expect(
+          await notice.evaluate((element) =>
+            Boolean(
+              element.previousElementSibling?.classList.contains("agent-chat__progress-float"),
+            ),
+          ),
+        ).toBe(true);
+        expect(
+          await notice.evaluate((element) => element === element.parentElement?.lastElementChild),
+        ).toBe(true);
+        if (!(await progress.evaluate((element) => element.hasAttribute("open")))) {
+          await progress.locator("summary").click();
+        }
+        await expect
+          .poll(() =>
+            body.evaluate((element) => {
+              const bounds = element.getBoundingClientRect();
+              const footer = element
+                .closest(".agent-chat__composer-shell")!
+                .querySelector(".agent-chat__disabled-banner--replacement")!
+                .getBoundingClientRect();
+              return (
+                bounds.height > 0 && bounds.bottom <= footer.top + 1 && footer.bottom <= innerHeight
+              );
+            }),
+          )
+          .toBe(true);
+        expect(await body.evaluate((element) => getComputedStyle(element).overflowY)).toBe("auto");
+        expect(await body.evaluate((element) => element.scrollHeight > element.clientHeight)).toBe(
+          true,
+        );
+        const footerTop = await notice.evaluate((element) => element.getBoundingClientRect().top);
+        await body.evaluate((element) => {
+          element.scrollTop = element.scrollHeight;
+        });
+        expect(await body.evaluate((element) => element.scrollTop)).toBeGreaterThan(0);
+        expect(await notice.evaluate((element) => element.getBoundingClientRect().top)).toBeCloseTo(
+          footerTop,
+          0,
+        );
+        await progress.locator("summary").click();
+        await expect.poll(() => progress.getAttribute("open")).toBeNull();
+        await notice.getByRole("button", { name: "Open parent session", exact: true }).click();
+        const input = shell.locator(".agent-chat__input");
+        await input.locator("textarea").fill("Continue the review");
+        await progress.waitFor();
+        expect(
+          await input.evaluate((element) =>
+            Boolean(
+              element.previousElementSibling?.classList.contains("agent-chat__progress-float"),
+            ),
+          ),
+        ).toBe(true);
+        expect(
+          await input.evaluate((element) => element === element.parentElement?.lastElementChild),
+        ).toBe(true);
+        expect(await pane.getByText("View-only subagent", { exact: true }).count()).toBe(0);
+        expect(await gateway.getRequests("progressCard.get")).toContainEqual(
+          expect.objectContaining({
+            params: expect.objectContaining({ sessionKey: parent.key }),
+          }),
+        );
+      },
+    );
+  });
+});

--- a/ui/src/pages/chat/components/chat-composer-view.ts
+++ b/ui/src/pages/chat/components/chat-composer-view.ts
@@ -346,7 +346,8 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
             `
           : nothing
       }
-      ${disabledBanner} ${progressCard} ${queue} ${goalCard}
+      ${props.disabledBanner?.kind === "above-composer" ? disabledBanner : nothing} ${progressCard}
+      ${queue} ${goalCard}
       ${
         showComposerInput
           ? html`<div
@@ -566,7 +567,9 @@ export function renderChatComposerView(context: ChatComposerViewContext) {
                 </div>
               </div>
             </div> `
-          : nothing
+          : props.disabledBanner?.kind === "composer-replacement"
+            ? disabledBanner
+            : nothing
       }
       ${composerUnderlaps}
     </div>

--- a/ui/src/styles/chat/layout.css
+++ b/ui/src/styles/chat/layout.css
@@ -2532,6 +2532,8 @@ button.chat-pr__diff {
    not a blue information callout inside it. Match the Question surface so the
    frame does not change shape when composition is unavailable. */
 .agent-chat__disabled-banner.agent-chat__disabled-banner--replacement.callout {
+  position: relative;
+  z-index: 1;
   border: 1px solid var(--chat-composer-hairline, var(--border));
   border-radius: calc(20px * var(--openclaw-corner-radius-scale));
   corner-shape: superellipse(1.5);


### PR DESCRIPTION
Closes #142216

## What Problem This Solves

Fixes an issue where users opening a view-only subagent with Task progress would see the parent-session notice above the report and the report clipped at the bottom of the chat viewport.

## Why This Change Was Made

Composer-replacement notices now occupy the message input's existing slot, below Task progress. The notice uses the input's foreground stacking while the shared shell continues to own spacing and the task report retains its existing height limit and internal scrolling. Notices intended to appear above an available composer keep their position.

## User Impact

The task report sits directly above the view-only notice, and **Open parent session** remains visible at the bottom. Long reports scroll within Task progress.

## Evidence

- Exact-head [CI run 34274313730](https://github.com/openclaw/openclaw/actions/runs/34274313730) passed on `c518ba4d38d00c367e5845100594b92f2e78a258`; all effective checks are green. Final independent review of this head found no actionable issues.

- Landing validation on rebased head `c518ba4d38d00c367e5845100594b92f2e78a258`: the touched bundled E2E passed **2/2**, and the full three-file `check-changed` gate passed with `OPENCLAW_VITEST_MAX_WORKERS=2`. The rebase preserves the reviewed patch; no visual design changes were made.
- Focused mocked browser regression: **2/2 passed**, at 1440 × 900 and 768 × 900. Covers task-before-notice order, the shared input slot, hidden message input, internal scrolling, a stationary visible footer, task collapse, parent navigation, and the normal task/composer order.
- The original code failed the new ordering assertion at 768px. The original task panel extended to 910px in a 900px viewport; after the repair, the notice ends at 886px with the normal 14px bottom margin.
- Native bundled E2E configuration passed after a successful UI production build, with `OPENCLAW_VITEST_MAX_WORKERS=2` and a mocked Gateway. The separate source-server attempts encountered a recorded browser network interruption and a cold-start timeout; neither required test or timeout changes.
- Changed-file validation: `OPENCLAW_VITEST_MAX_WORKERS=2 node scripts/check-changed.mjs -- ui/src/pages/chat/components/chat-composer-view.ts ui/src/styles/chat/layout.css ui/src/e2e/subagent-task-notice.e2e.test.ts` **passed**. Includes all 17 test type graphs, UI production types, formatting, UI catalog verification, lint, and export/declaration guards. Dependencies were refreshed with the frozen lockfile; package manifests and the lockfile are unchanged.
- Fresh independent review: no actionable findings.

Inspected synthetic captures use dark mode and the same report scroll position. No personal session data is included.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td>Full viewport · 1440 × 900<br><a href="https://github.com/user-attachments/assets/a3bd6241-b7a0-41c4-8bac-91801e0469ee"><img src="https://github.com/user-attachments/assets/a3bd6241-b7a0-41c4-8bac-91801e0469ee" width="600" alt="Before: Full viewport · 1440 × 900"></a></td><td>Full viewport · 1440 × 900<br><a href="https://github.com/user-attachments/assets/c090d120-1c2d-4540-9d0d-6f8d6e4062be"><img src="https://github.com/user-attachments/assets/c090d120-1c2d-4540-9d0d-6f8d6e4062be" width="600" alt="After: Full viewport · 1440 × 900"></a></td></tr>
<tr><td>Footer detail<br><a href="https://github.com/user-attachments/assets/b5a29ed8-4b73-4b9c-9099-ccb870a1d03e"><img src="https://github.com/user-attachments/assets/b5a29ed8-4b73-4b9c-9099-ccb870a1d03e" width="600" alt="Before: Footer detail"></a></td><td>Footer detail<br><a href="https://github.com/user-attachments/assets/7d60cb5c-408f-4f00-bb37-0814ac503248"><img src="https://github.com/user-attachments/assets/7d60cb5c-408f-4f00-bb37-0814ac503248" width="600" alt="After: Footer detail"></a></td></tr>
<tr><td>Narrow viewport · 768 × 900<br><a href="https://github.com/user-attachments/assets/20693412-fe5a-4326-a26c-0309b373159d"><img src="https://github.com/user-attachments/assets/20693412-fe5a-4326-a26c-0309b373159d" width="600" alt="Before: Narrow viewport · 768 × 900"></a></td><td>Narrow viewport · 768 × 900<br><a href="https://github.com/user-attachments/assets/7ccb9388-c4fd-4257-9ac1-b16c10c9c8c3"><img src="https://github.com/user-attachments/assets/7ccb9388-c4fd-4257-9ac1-b16c10c9c8c3" width="600" alt="After: Narrow viewport · 768 × 900"></a></td></tr>
<tr><td>Normal task + composer reference<br><a href="https://github.com/user-attachments/assets/004c9760-3a51-4901-9bbb-2500b18677ba"><img src="https://github.com/user-attachments/assets/004c9760-3a51-4901-9bbb-2500b18677ba" width="600" alt="Before: Normal task + composer reference"></a></td><td>Normal task + composer reference<br><a href="https://github.com/user-attachments/assets/a472b0c6-b6e2-430a-b47f-462a7a4d226d"><img src="https://github.com/user-attachments/assets/a472b0c6-b6e2-430a-b47f-462a7a4d226d" width="600" alt="After: Normal task + composer reference"></a></td></tr>
</table>

**Risk and coverage**

The shared replacement path also serves archived sessions, restart recovery, and model setup; each producer and action path was checked in source. Normal composition and subagent parent navigation were exercised in the browser. Above-composer placement notices, question suppression, and queue/goal ordering were checked in source. Light mode, phone widths, and live Gateway behavior were not newly exercised.


