### PR TITLE
docs: add v2026.9.3 release notes

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -2603,6 +2603,7 @@
                 "group": "Release notes",
                 "pages": [
                   "releases/index",
+                  "releases/2026.9.3",
                   "releases/2026.9.2",
                   "releases/2026.9.1",
                   "releases/2026.8.2",

--- a/docs/releases/2026.9.3.md
+++ b/docs/releases/2026.9.3.md
@@ -14,6 +14,8 @@ OpenClaw v2026.9.3 brings a live view of supported agent browser tabs into the B
 
 Supported updates rehearse core and plugin changes before activation, and the meeting library makes saved notes and transcripts searchable. Models settings adds individual account controls and supported account ordering, while fixes across messaging, memory and the native apps help ongoing work survive more interruptions.
 
+**Release scale:** 1,844 pull requests, 40 direct commits, and 190 contributors.
+
 ## Installation and Onboarding
 
 Setup keeps the choices you have already made and gives clearer guidance when a connection needs attention, with fixes for existing Mac Gateways, Windows startup and Docker workspaces along the way.
@@ -23,69 +25,109 @@ Upgrade Node before OpenClaw if you use an older runtime. This release requires 
 </Note>
 
 <AccordionGroup>
+
 <Accordion title="Connect and choose a provider">
 
-Connection screens lead with the problem preventing sign-in and what to do next. Remote setup uses one Gateway secret field, while local setup generates a token by default. Provider selection also keeps credentials attached to the provider they belong to, instead of accepting an unrelated sign-in result.
+Connection screens lead with the problem preventing sign-in and what to do next. Remote setup uses one Gateway secret field, while local setup generates a token by default. Provider selection keeps credentials attached to the provider they belong to, instead of accepting an unrelated sign-in result.
 
-Opening desktop or browser setup now detects available providers without activating one until you choose it. Discovery of native conversations starts unchecked, and cancelling or failing setup does not select a different provider.
-
-On a Mac with an independently managed local Gateway, setup can continue into model configuration without waiting for a CLI installation that was deliberately skipped. Finishing that setup still requires a verified model response.
+Opening desktop or browser setup detects available providers without activating one until you choose it. Fresh native-conversation discovery starts unchecked, and cancelling or failing setup does not select a different provider. Guided setup can also finish without an AI provider. Saved consent choices survive reconciliation with an existing agent.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Keep provider detection passive until an explicit choice and leave native-conversation discovery unchecked [#140336](https://github.com/openclaw/openclaw/pull/140336).
-- Lead connection and pairing screens with actionable guidance [#141087](https://github.com/openclaw/openclaw/pull/141087).
-- Use one Gateway secret field and generate a local token by default [#141511](https://github.com/openclaw/openclaw/pull/141511), [#141514](https://github.com/openclaw/openclaw/pull/141514).
+- Require explicit AI provider selection and include official installable providers [#139675](https://github.com/openclaw/openclaw/pull/139675).
+- Require an explicit provider choice and native-conversation discovery consent during setup [#140336](https://github.com/openclaw/openclaw/pull/140336).
+- Make connection and pairing screens lead with actionable guidance [#141087](https://github.com/openclaw/openclaw/pull/141087).
+- Simplify local secret generation and collect one masked secret in remote onboarding [#141511](https://github.com/openclaw/openclaw/pull/141511).
+- Replace token/password selection with a single Gateway secret input [#141514](https://github.com/openclaw/openclaw/pull/141514).
 
 **Bug fixes**
 
-- Match prepared credentials to their provider and reject unmatched sign-in results [#140461](https://github.com/openclaw/openclaw/pull/140461).
-- Start Mac AI setup when an external local Gateway intentionally skips CLI installation [#139063](https://github.com/openclaw/openclaw/pull/139063).
-- Keep desktop model setup recoverable after a failed interactive turn [#139140](https://github.com/openclaw/openclaw/pull/139140).
-- Keep channel choices scoped to the selected agent workspace [#139358](https://github.com/openclaw/openclaw/pull/139358).
-- Refresh installed-plugin ownership before the first dashboard conversation [#140603](https://github.com/openclaw/openclaw/pull/140603). Thanks @DonnieFi.
+- Match prepared model credentials to their provider and reject unmatched sign-in results [#140461](https://github.com/openclaw/openclaw/pull/140461).
+- Accept the active Gateway secret through token or password input [#141456](https://github.com/openclaw/openclaw/pull/141456).
+- Preserve setup consent choices and concurrent saved settings [#141531](https://github.com/openclaw/openclaw/pull/141531). Thanks @obviyus.
+
+</details>
+</Accordion>
+
+<Accordion title="Finish model setup and reach your first conversation">
+
+On a Mac with an independently managed local Gateway, setup can continue into model configuration without waiting for a CLI installation that was deliberately skipped. Finishing model setup still requires a verified response, and failed verification now retains the useful underlying error instead of treating failed or timed-out output as success.
+
+Supported provider setup leaves generated model lists to discovery while preserving existing saved models and explicit replacement modes. Channel choices also follow the selected agent's workspace, while newly installed runtimes become available to the first dashboard conversation.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Start Mac AI setup for external local Gateways without waiting for an intentionally skipped CLI install [#139063](https://github.com/openclaw/openclaw/pull/139063).
+- Keep desktop model setup recoverable and stop failed interactive turns from starting a second planner request [#139140](https://github.com/openclaw/openclaw/pull/139140).
+- Canonicalize starter model aliases before verification and merge their metadata into existing settings [#139339](https://github.com/openclaw/openclaw/pull/139339).
+- Keep channel setup choices scoped to the selected agent workspace [#139358](https://github.com/openclaw/openclaw/pull/139358).
+- Preserve useful plugin-loading and inference failure causes during setup [#140392](https://github.com/openclaw/openclaw/pull/140392). Thanks @ayaangazali.
+- Refresh plugin-cache ownership at onboarding handoff so the first dashboard chat can use the installed runtime [#140603](https://github.com/openclaw/openclaw/pull/140603). Thanks @DonnieFi.
+- Leave generated setup rows to discovery for Fireworks, Kimi Coding, Moonshot, Qianfan, Qwen, StepFun and Xiaomi Token Plan [#140139](https://github.com/openclaw/openclaw/pull/140139). Thanks @obviyus.
+- Leave Cohere, DeepSeek, Kilo Gateway and Tencent setup catalogs to runtime discovery [#140154](https://github.com/openclaw/openclaw/pull/140154). Thanks @obviyus.
 
 </details>
 </Accordion>
 
 <Accordion title="Install on Docker and Windows">
 
-Docker setup preserves the ownership of your project files while repairing the OpenClaw state that needs to be writable. Windows Startup fallback launches also retain saved service environment overrides when inherited variable names use different capitalization.
+Docker setup preserves the ownership of your project files while repairing the OpenClaw state that needs to be writable. Packaged plugin dependencies are reachable from their Docker installation, and browser-enabled images prepare the private cache parent for the non-root runtime user. Operator-mounted cache permissions still belong to the operator.
+
+Windows Startup fallback launches retain saved service environment overrides when inherited variable names use different capitalization. Anchored Windows Gateway commands also avoid opening an unwanted console window.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Preserve bind-mounted project ownership during Docker setup [#140993](https://github.com/openclaw/openclaw/pull/140993). Thanks @ooiuuii.
-- Include the lockfile required by the final Docker runtime image [#134047](https://github.com/openclaw/openclaw/pull/134047). Thanks @RomneyDa.
-- Stage bundled plugin dependencies and reject incomplete Docker image assembly [#139117](https://github.com/openclaw/openclaw/pull/139117). Thanks @ylcn91, @vincentkoc and @8bitsforge.
-- Preserve saved Windows Startup environment overrides [#122658](https://github.com/openclaw/openclaw/pull/122658). Thanks @masatohoshino.
+- Preserve project ownership during Docker setup while repairing writable OpenClaw state [#140993](https://github.com/openclaw/openclaw/pull/140993). Thanks @ooiuuii.
+- Copy the pnpm lockfile into the final Docker runtime image [#134047](https://github.com/openclaw/openclaw/pull/134047). Thanks @RomneyDa.
+- Stage bundled plugin dependencies correctly in Docker images and reject incomplete image assembly [#139117](https://github.com/openclaw/openclaw/pull/139117). Thanks @ylcn91, @vincentkoc, @8bitsforge.
+- Give the image-owned cache parent to the non-root runtime user [#139686](https://github.com/openclaw/openclaw/pull/139686). Thanks @gaoanze888, @obviyus.
+- Resolve the filesystem safety package through its public entrypoint during Docker verification [#141534](https://github.com/openclaw/openclaw/pull/141534). Thanks @RomneyDa.
+- Preserve saved environment overrides in Windows Startup fallback launches [#122658](https://github.com/openclaw/openclaw/pull/122658). Thanks @masatohoshino.
+- Suppress the child console in the Windows Gateway job anchor [#138751](https://github.com/openclaw/openclaw/pull/138751). Thanks @chelsealong, @keith9681.
 
 </details>
 </Accordion>
 
 <Accordion title="Source installation and workspace templates">
 
-Source-install tooling moves to pnpm 12.3.4, and workspace template instructions clarify bootstrap, backup coverage and identity fields.
+Source-install tooling moves to pnpm 12.3.4, and workspace template instructions clarify bootstrap, backup coverage and identity fields. New workspaces receive more direct default agent guidance without rewriting existing personalized files. Setup scripts also receive valid JSON when combining QR setup-code options.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
-**Limits and compatibility**
-
-- Require the supported Node runtime to avoid SQLite text truncation; older macOS CLI/Gateway hosts and official Linux ARMv7 provisioning need a supported host [#140672](https://github.com/openclaw/openclaw/pull/140672).
-
 **Documentation**
 
-- Update source-install tooling to pnpm 12.3.4 [#139065](https://github.com/openclaw/openclaw/pull/139065).
-- Correct workspace template, backup and identity instructions [#140224](https://github.com/openclaw/openclaw/pull/140224). Thanks @vincentkoc.
+- Update source-install tooling and instructions to pnpm 12.3.4 [#139065](https://github.com/openclaw/openclaw/pull/139065).
+- Correct workspace template instructions, backup coverage and identity fields [#140224](https://github.com/openclaw/openclaw/pull/140224). Thanks @vincentkoc.
+- Clarify the first-run path from installation through Gateway service and Telegram pairing [#140390](https://github.com/openclaw/openclaw/pull/140390). Thanks @vincentkoc.
+- Simplify the default workspace AGENTS template while preserving its rules [#140934](https://github.com/openclaw/openclaw/pull/140934). Thanks @obviyus.
+
+**Bug fixes**
+
+- Give JSON output precedence in QR setup-code commands [#137209](https://github.com/openclaw/openclaw/pull/137209). Thanks @marmar9615-cloud.
+- Fix alias-free Bun startup and fresh-runner package acceptance [#140062](https://github.com/openclaw/openclaw/pull/140062).
+- Reject explicitly blank Gateway port options [#139613](https://github.com/openclaw/openclaw/pull/139613). Thanks @TurboTheTurtle, @vincentkoc.
+
+**Improvements**
+
+- Include release-bound npm lock mirrors for downstream offline packaging, outside npm tarballs; consumers must handle documented overrides and reject incomplete workspace mirrors [#140622](https://github.com/openclaw/openclaw/pull/140622).
+
+**Limits and compatibility**
+
+- Require supported Node builds to prevent SQLite text truncation; older Node-based macOS 11–13.4 hosts and official Linux ARMv7 provisioning need a supported host, and explicitly configured older worker images need replacement [#140672](https://github.com/openclaw/openclaw/pull/140672). Thanks @aeoess.
 
 </details>
 </Accordion>
+
 </AccordionGroup>
 
 ## The New Web UI
@@ -93,175 +135,669 @@ Source-install tooling moves to pnpm 12.3.4, and workspace template instructions
 The web app makes current work easier to find and long conversations easier to move through, while keeping drafts and loaded panels in place through more interruptions. Sharing also gets a separate, explicit public-transcript option for conversations you want other people to read.
 
 <AccordionGroup>
+
 <Accordion title="Share a read-only conversation">
 
-Session owners and Gateway admins can publish a revocable link to a conversation's existing and future text. Anyone with that public link can read it until access is revoked, so review the conversation before enabling sharing. Revoking access cannot recall copies that people have already saved. The read-only page leaves out tools, reasoning, files, images and executable widgets.
+Session creators and Gateway admins can publish a revocable link to a conversation's existing and future text. Anyone with that public link can read it until access is revoked, so review the conversation before enabling sharing. Revoking access cannot recall copies people have already saved. The read-only page leaves out tools, reasoning, files, images and executable widgets.
 
-Private-session preview links remain a separate option. They show a generic OpenClaw social card without reading the conversation, and opening the session still requires its normal authentication.
+Private-session preview links remain separate. They show a generic OpenClaw social card without reading the conversation, and opening the session still requires its normal authentication. Public HTTPS proxies may need the documented preview routing configured.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Publish and revoke public read-only conversation transcripts [#139489](https://github.com/openclaw/openclaw/pull/139489).
-- Copy private-session links with generic social previews [#139250](https://github.com/openclaw/openclaw/pull/139250).
+- Share selected sessions publicly through revocable read-only links [#139489](https://github.com/openclaw/openclaw/pull/139489).
+- Add public generic preview documents that link to normally authenticated sessions and dashboards [#139250](https://github.com/openclaw/openclaw/pull/139250).
+- Avoid loading saved prompt payloads while listing session-sharing identities [#140368](https://github.com/openclaw/openclaw/pull/140368).
 
 </details>
 </Accordion>
 
 <Accordion title="Find active work and navigate long conversations">
 
-Live activity shows permitted running and queued sessions when you open it or reconnect, with a visible limit notice and connection status. In wide chat panes, a position rail previews and jumps between loaded conversation landmarks, making earlier exchanges easier to find.
+Live activity shows permitted running and queued sessions when you open it or reconnect, with a visible limit notice and connection status. Its recent open-tab feed follows permitted activity across agents and conversations independently of the selected chat. Reloading or changing Gateway or account clears that temporary feed.
 
-Pins now belong to root conversations. Existing child pins disappear and no longer protect those children from maintenance. Sidebar running indicators move onto row icons, leaving pin and menu controls clear, and notifications lead to the relevant question, conversation or run.
+In wide chat panes, a position rail previews and jumps between loaded conversation landmarks, making earlier exchanges easier to find. Pins now belong to root conversations. Existing child pins disappear and no longer protect those children from maintenance.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Show running and queued permitted sessions above the Live activity feed [#141045](https://github.com/openclaw/openclaw/pull/141045). Thanks @shakkernerd.
-- Add a previewable position rail for loaded conversation landmarks in sufficiently large panes [#138603](https://github.com/openclaw/openclaw/pull/138603).
-- Show recent open-tab activity in the Live feed [#140711](https://github.com/openclaw/openclaw/pull/140711).
+- Show current running and queued sessions above the Live activity event feed [#141045](https://github.com/openclaw/openclaw/pull/141045). Thanks @shakkernerd.
+- Add a previewable position rail for long conversations [#138603](https://github.com/openclaw/openclaw/pull/138603). Thanks @brokemac79.
+- Retain recent Live activity while navigating around the open Control UI [#140711](https://github.com/openclaw/openclaw/pull/140711). Thanks @shakkernerd.
+- Show all permitted incoming sessions in Live activity and retain them across chat changes [#140952](https://github.com/openclaw/openclaw/pull/140952). Thanks @shakkernerd.
 
 **Bug fixes**
 
-- Keep sidebar loading attached to the selected agent during activity [#140459](https://github.com/openclaw/openclaw/pull/140459).
-- Let cleared conversations raise fresh attention notices [#139888](https://github.com/openclaw/openclaw/pull/139888).
-- Place running indicators on row icons without duplicate screen-reader announcements [#141098](https://github.com/openclaw/openclaw/pull/141098).
-- Route notifications to the intended work and include later-page automation failures [#141081](https://github.com/openclaw/openclaw/pull/141081).
+- Show already-running sessions while new session activity keeps arriving [#141236](https://github.com/openclaw/openclaw/pull/141236). Thanks @shakkernerd.
+- Keep active-session status scoped to its owning agent when stores share session IDs [#141247](https://github.com/openclaw/openclaw/pull/141247). Thanks @shakkernerd.
+- Restore critical session notices after clearing a conversation [#139888](https://github.com/openclaw/openclaw/pull/139888). Thanks @shakkernerd.
 
 **Limits and compatibility**
 
-- Restrict pins to root sessions [#140748](https://github.com/openclaw/openclaw/pull/140748).
-- Live activity lists up to 100 permitted current sessions; its recent event feed is temporary and does not replay historical tool events.
+- Restrict session pins to root sessions across the UI and agent tools [#140748](https://github.com/openclaw/openclaw/pull/140748).
 
 </details>
 </Accordion>
 
-<Accordion title="Follow delegated work and keep your draft">
+<Accordion title="Keep the sidebar readable during activity">
 
-Subagent transcripts stay view-only, with a route back to the parent conversation and Stop for runs that can be cancelled. Live progress remains in the parent conversation, while persistent sessions created with visible spawning stay editable and steerable in their parent tree.
-
-Failed steer or redirect attempts restore their text and attachments without overwriting a newer draft. Side chat also clears when its parent is deleted, so recreating a conversation does not bring back the old side discussion.
+Switching agents finishes loading the sidebar even while another conversation receives activity, and expanded children remain visible during roster refreshes. Running and unread indicators sit beside session icons without obscuring row actions or repeating screen-reader announcements. Long action and owner labels also remain within their menus. Aggregate session views preserve the conversation’s actual agent and database.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Keep delegated progress in the parent conversation and distinguish subagent authorship [#139367](https://github.com/openclaw/openclaw/pull/139367), [#139371](https://github.com/openclaw/openclaw/pull/139371).
-- Make subagent transcripts view-only with parent navigation and supported Stop controls [#139381](https://github.com/openclaw/openclaw/pull/139381).
-- Preserve editable persistent sessions created with visible spawning [#139456](https://github.com/openclaw/openclaw/pull/139456).
-- Restore failed steer and redirect drafts without replacing newer input [#139940](https://github.com/openclaw/openclaw/pull/139940).
-- Clear Side chat when its parent disappears [#139974](https://github.com/openclaw/openclaw/pull/139974).
-- Scope waiting time to the current turn [#139972](https://github.com/openclaw/openclaw/pull/139972).
-- Hide Reply when the conversation has no composer [#140014](https://github.com/openclaw/openclaw/pull/140014).
-- Preserve supplied, redacted failure reasons through immediate status and later refresh [#140704](https://github.com/openclaw/openclaw/pull/140704).
+- Finish sidebar roster refreshes during chat activity while preserving newer permission choices [#140459](https://github.com/openclaw/openclaw/pull/140459).
+- Retain expanded child snapshots while refreshing sidebar sessions [#141428](https://github.com/openclaw/openclaw/pull/141428).
+- Move sidebar running indicators onto row icons and avoid duplicate screen-reader announcements [#141098](https://github.com/openclaw/openclaw/pull/141098).
+- Keep sidebar unread marks beside session icons and visible while using row actions [#141335](https://github.com/openclaw/openclaw/pull/141335).
+- Use a smaller running ring for sidebar rows without artwork [#141383](https://github.com/openclaw/openclaw/pull/141383).
+- Keep the Specific owner label readable beside the selected name [#141405](https://github.com/openclaw/openclaw/pull/141405).
+- Truncate long sidebar action labels while preserving their accessible names [#140125](https://github.com/openclaw/openclaw/pull/140125). Thanks @Dreamer-HIT, @MoerAI, @kip-claw.
+- Keep sidebar resources stopped after DOM removal until reconnect [#140856](https://github.com/openclaw/openclaw/pull/140856).
+- Retain logical agent and physical store ownership across aggregate session views and commands [#138991](https://github.com/openclaw/openclaw/pull/138991).
+
+**Improvements**
+
+- Prepare date-group boundaries once per Sessions grouping [#139734](https://github.com/openclaw/openclaw/pull/139734).
+- Avoid rebuilding the sidebar session map during tree projection [#140270](https://github.com/openclaw/openclaw/pull/140270).
+- Reduce repeated model metadata lookups while listing sessions [#140414](https://github.com/openclaw/openclaw/pull/140414).
+- Avoid refetching unrelated hosts during session-catalog pagination [#139570](https://github.com/openclaw/openclaw/pull/139570).
+
+</details>
+</Accordion>
+
+<Accordion title="Return to mentions and follow notifications">
+
+The Mentions Inbox keeps retained mentions and dismissals through restarts and upgrades without replaying old browser alerts. Its existing bounded retention applies, and incognito conversations remain excluded. Notifications open the relevant question, conversation, automation run or task, including failures beyond the first automation page.
+
+Activity retains its layout through refresh failures, and choosing an online person opens their Activity feed. Hidden tabs defer background Inbox inventory work until you return.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Persist the Mentions Inbox with original IDs and expiry times [#141404](https://github.com/openclaw/openclaw/pull/141404).
+- Navigate directly from online people to Activity while retaining hover details [#141459](https://github.com/openclaw/openclaw/pull/141459).
+
+**Bug fixes**
+
+- Fix missing automation alerts, premature completions and notification destinations [#141081](https://github.com/openclaw/openclaw/pull/141081).
+- Reserve Activity feedback space to prevent refresh layout jumps [#137868](https://github.com/openclaw/openclaw/pull/137868). Thanks @Solvely-Colin.
+- Stop background Inbox automation refreshes while preserving dismissals [#140094](https://github.com/openclaw/openclaw/pull/140094).
+
+</details>
+</Accordion>
+
+<Accordion title="Follow delegated work and Review progress">
+
+Subagent transcripts stay view-only, with a route back to the parent conversation and Stop for runs that can be cancelled. Live progress remains in the parent conversation, while visible persistent sessions created by an agent stay editable in their parent tree.
+
+Completed Swarms retain their child counts after cleanup and reload, with fully successful groups collapsing into expandable rows. Child completion still does not mean the parent's final synthesis has been delivered.
+
+Review keeps delayed results attached to the latest selected task or file, and activity rows preserve readable labels without presenting edit-operation totals as checkout diffs. Reopened chats refresh their pending approvals rather than reusing an old set.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep progress cards owned by the parent conversation [#139367](https://github.com/openclaw/openclaw/pull/139367).
+- Hide author avatars in subagent transcripts while preserving sender names [#139371](https://github.com/openclaw/openclaw/pull/139371).
+- Keep activity labels visible and truncate long receipts within their rows [#139372](https://github.com/openclaw/openclaw/pull/139372).
+- Keep expanded tool-card borders inside resized Review panels [#139373](https://github.com/openclaw/openclaw/pull/139373).
+- Remove per-subagent edit counters from inline activity while retaining Review details [#139375](https://github.com/openclaw/openclaw/pull/139375).
+- Make subagent sessions view-only with an Open parent session action [#139381](https://github.com/openclaw/openclaw/pull/139381).
+- Preserve loaded Swarm progress during refresh failures and restore raw-key pane ownership [#139269](https://github.com/openclaw/openclaw/pull/139269).
+- Keep Review on the latest selected task or file [#141567](https://github.com/openclaw/openclaw/pull/141567).
+- Refresh pending approvals when reopening a chat or adding another pane [#139457](https://github.com/openclaw/openclaw/pull/139457).
+- Carry explicit agent ownership through progress cards and revision-safe dismissal [#138976](https://github.com/openclaw/openclaw/pull/138976).
+
+**Improvements**
+
+- Keep completed Swarm outcomes visible and make child details accessible by click or tap [#139490](https://github.com/openclaw/openclaw/pull/139490).
+- Collapse fully successful Swarm groups into compact expandable completion rows [#141205](https://github.com/openclaw/openclaw/pull/141205). Thanks @Takhoffman.
+- Open spawned dashboard sessions as editable conversations [#141499](https://github.com/openclaw/openclaw/pull/141499).
+- Preserve task cursors across display-only session metadata changes [#137975](https://github.com/openclaw/openclaw/pull/137975).
+- Return expired task-page errors promptly when concurrent activity invalidates pagination [#141001](https://github.com/openclaw/openclaw/pull/141001).
+
+</details>
+</Accordion>
+
+<Accordion title="Keep drafts and documents through conversation changes">
+
+Failed steer or redirect attempts restore their text and attachments without overwriting a newer draft, and delayed rewind completion preserves newer text, attachments and Goal mode. Documents attached during an active run retain extracted text and supported rendered pages, while uploaded images remain visible as a new workspace finishes loading.
+
+Resetting a conversation retires old progress cards after the reset succeeds, and deleting its parent clears Side chat. Suggested follow-ups can start without first creating a Git worktree, and generated session titles are available directly in rename dialogs.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Restore rejected steer and redirect drafts in the correct conversation [#139940](https://github.com/openclaw/openclaw/pull/139940).
+- Preserve newer chat drafts when rewind finishes, including split panes [#140066](https://github.com/openclaw/openclaw/pull/140066).
+- Preserve document contents when steering an active agent run [#138275](https://github.com/openclaw/openclaw/pull/138275). Thanks @ruel225, @obviyus, @alexdhc.
+- Preserve mounted upload previews across worktree hydration while retaining policy revalidation [#139323](https://github.com/openclaw/openclaw/pull/139323).
+- Clear stale task progress when resetting a conversation [#140412](https://github.com/openclaw/openclaw/pull/140412). Thanks @hannesrudolph.
+- Clear Side chat when its parent conversation is deleted [#139974](https://github.com/openclaw/openclaw/pull/139974).
+- Hide Reply in conversations whose composer is replaced by guidance [#140014](https://github.com/openclaw/openclaw/pull/140014).
+- Show your avatar in new-session previews and focus empty composers quietly [#141096](https://github.com/openclaw/openclaw/pull/141096).
+- Send queued attachments whose MIME types include parameters [#139621](https://github.com/openclaw/openclaw/pull/139621).
+
+**Improvements**
+
+- Start suggested follow-ups locally without creating a worktree [#139731](https://github.com/openclaw/openclaw/pull/139731). Thanks @fuller-stack-dev.
+- Prefill generated session titles across rename dialogs [#139796](https://github.com/openclaw/openclaw/pull/139796).
+
+</details>
+</Accordion>
+
+<Accordion title="Understand failed turns and successful retries">
+
+A run that fails before producing an assistant reply leaves a notice that remains after reload, and recognized storage failures explain what needs attention. Redacted supplied failure reasons survive immediate status and later refresh.
+
+When a fallback succeeds within the same run, the conversation shows the answer without an empty failed-attempt placeholder. Buffered text is retained before a retry resets the stream, while partial or unresolved failures remain available rather than being hidden.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Explain Gateway storage failures in run errors and recorded assistant displays [#139409](https://github.com/openclaw/openclaw/pull/139409).
+- Record a durable transcript notice when a run fails before replying [#139439](https://github.com/openclaw/openclaw/pull/139439).
+- Retire empty failed-attempt placeholders after same-run success [#139753](https://github.com/openclaw/openclaw/pull/139753).
+- Flush buffered assistant text before error lifecycle cleanup [#139765](https://github.com/openclaw/openclaw/pull/139765).
+- Preserve redacted run failure details in session status and delayed refreshes [#140704](https://github.com/openclaw/openclaw/pull/140704).
+- Keep waiting time tied to the active turn instead of older failed sends [#139972](https://github.com/openclaw/openclaw/pull/139972). Thanks @NianJiuZst, @obviyus, @noelillinger.
+
+**Improvements**
+
+- Reuse pending-frame byte reservations across blocked viewers [#139736](https://github.com/openclaw/openclaw/pull/139736).
 
 </details>
 </Accordion>
 
 <Accordion title="Reconnect without losing your place">
 
-Panels retain their loaded data during connection interruptions and refresh when the connection returns, with offline and restart status in the footer. Suspended tabs can also recover missed update notices while keeping their route and stored draft; unsaved settings still need to be saved or discarded before recovery.
+Panels retain their loaded data during connection interruptions and refresh when the connection returns, with offline and restart status in the footer. Suspended tabs can recover missed update notices while keeping their route and stored draft; unsaved settings still need to be saved or discarded before recovery. A tab already stranded by an earlier missed update may need one manual reload.
+
+A signed-in operator browser with a live pending pairing request reconnects automatically after approval. Paused connection states retain manual guidance, and existing authorization requirements still apply. Bundled UI startup recovery preserves pending sign-in and asks before sending its credential to the captured destination; damaged packages receive reinstall guidance.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Recover suspended tabs after missed updates while preserving routes and stored drafts [#140484](https://github.com/openclaw/openclaw/pull/140484).
-- Keep panel data during interruptions and refresh parked panels after reconnection [#141040](https://github.com/openclaw/openclaw/pull/141040).
-- Restore Home subscriptions after the same panel reconnects [#139059](https://github.com/openclaw/openclaw/pull/139059).
-- Keep cancelled session-placement dialogs closed after delayed loading [#140746](https://github.com/openclaw/openclaw/pull/140746).
-
-**Limits and compatibility**
-
-- A browser document already stranded by an earlier missed update may need one manual reload.
+- Recover suspended Control UI tabs after missed updates while protecting unsaved settings [#140484](https://github.com/openclaw/openclaw/pull/140484). Thanks @Takhoffman.
+- Show connection interruptions in the footer and automatically refresh parked panels [#141040](https://github.com/openclaw/openclaw/pull/141040).
+- Reconnect the Control UI automatically after its pending browser pairing request is approved [#141362](https://github.com/openclaw/openclaw/pull/141362).
+- Revalidate web assets and media consistently across Gateway timezones [#140173](https://github.com/openclaw/openclaw/pull/140173).
+- Repair stale bundled UI startup and preserve destination-bound pairing through reloads [#138964](https://github.com/openclaw/openclaw/pull/138964).
 
 </details>
 </Accordion>
 
-<Accordion title="Open dashboards and use everyday controls">
+<Accordion title="Open dashboards and keep their context">
 
-Dashboards get a themed loading presentation and avoid unnecessary conversation-history reads while opening. Keyboard shortcuts bring supported side panels into reach, local conversation links can show titles and hover cards, and model-picker searches remain filtered when the catalog refreshes.
+Dashboards keep a themed loading presentation until their widgets are ready, and loaded dashboards retain notes, scroll position and chat drafts across navigation and Settings within the existing per-pane cache. Moving to another Gateway or user clears that cache.
+
+Agents can publish bounded native reports containing text, metrics, tables, charts and links without an HTML frame. Report properties are limited to 8 KiB and contain data rather than executable content, and rejected dashboard actions show their error immediately.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Open supported side panels with keyboard shortcuts [#139385](https://github.com/openclaw/openclaw/pull/139385).
-- Show titles and hover cards for resolvable local conversation links [#139384](https://github.com/openclaw/openclaw/pull/139384).
+- Add bounded native dashboard reports through show_widget and dashboard widget_put [#139306](https://github.com/openclaw/openclaw/pull/139306).
+- Show shimmer skeletons while Control UI content loads [#139525](https://github.com/openclaw/openclaw/pull/139525).
+- Replace unstyled dashboard loading text with a shared board skeleton and readable error state [#140675](https://github.com/openclaw/openclaw/pull/140675).
+- Retain loaded dashboards, widget notes, scroll position and chat drafts across navigation and Settings [#141130](https://github.com/openclaw/openclaw/pull/141130).
+- Reuse session-board drag layout calculations [#140151](https://github.com/openclaw/openclaw/pull/140151).
 
 **Bug fixes**
 
-- Avoid unrelated history reads while opening dashboards [#139055](https://github.com/openclaw/openclaw/pull/139055).
-- Keep dashboard loading and widget presentation consistent with the theme [#139076](https://github.com/openclaw/openclaw/pull/139076).
-- Preserve model-picker search and keyboard selection through catalog refresh [#140846](https://github.com/openclaw/openclaw/pull/140846).
-- Keep reopened select menus visible and close disabled menus [#141047](https://github.com/openclaw/openclaw/pull/141047).
-- Show saved unavailable execution-device bindings instead of implying fallback [#133032](https://github.com/openclaw/openclaw/pull/133032). Thanks @TurboTheTurtle.
-- Explain empty-repository requirements and retain specific workspace setup errors [#140251](https://github.com/openclaw/openclaw/pull/140251).
-
-**Documentation**
-
-- Restore old Control UI documentation anchors [#140808](https://github.com/openclaw/openclaw/pull/140808). Thanks @vincentkoc.
+- Reuse resolved dashboard sessions and limit background history loading to visible conversations or explicit navigation intent [#139055](https://github.com/openclaw/openclaw/pull/139055).
+- Restore Home and Ask OpenClaw subscriptions when the same panel reconnects [#139059](https://github.com/openclaw/openclaw/pull/139059).
+- Keep dashboard widgets hidden and unfocusable until their content is ready to display [#139076](https://github.com/openclaw/openclaw/pull/139076).
+- Retain pinned dashboard authoring for admitted restart recovery [#139705](https://github.com/openclaw/openclaw/pull/139705).
+- Restore reactive A2UI v0.9 errors and surfaces so rejected actions render feedback [#140670](https://github.com/openclaw/openclaw/pull/140670).
 
 </details>
 </Accordion>
+
+<Accordion title="Save settings and select devices">
+
+Settings retain submitted values and newer edits through delayed refreshes and reconnects. Failed Appearance patches offer a retry for the rejected change, while separate unsaved drafts keep their own Save action. Rejected choices return keyboard and accessibility state to the saved value, including explicit null choices where supported.
+
+Phone-width and embedded settings keep usable navigation, and Gateway switching shows the destinations clearly. Saved unavailable execution-device bindings stay visibly selected as unavailable, rather than implying that another device was chosen. Profile headers show the connected person's identity when known. Devices also supports editable aliases, and remote configuration-file opens confirm that the file opened on the Gateway host. Unsaved device-alias edits are dismissed on reconnect.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve submitted settings and newer edits across delayed refreshes and reconnects [#139113](https://github.com/openclaw/openclaw/pull/139113).
+- Recover rejected Appearance patches without losing separate unsaved drafts [#139167](https://github.com/openclaw/openclaw/pull/139167). Thanks @SebTardif, @obviyus.
+- Use shared model-catalog ownership and retire abandoned Appearance-page reads [#139282](https://github.com/openclaw/openclaw/pull/139282).
+- Follow superseding configuration reads after successful external mutations [#140551](https://github.com/openclaw/openclaw/pull/140551).
+- Restore rejected Settings enum selections, expose null choices and label message width accessibly [#140924](https://github.com/openclaw/openclaw/pull/140924).
+- Keep reopened select menus visible and close disabled menus [#141047](https://github.com/openclaw/openclaw/pull/141047).
+- Keep missing or unsupported execution-node bindings visibly selected as Unavailable [#133032](https://github.com/openclaw/openclaw/pull/133032). Thanks @TurboTheTurtle.
+- Show the connected person's identity in the multi-agent profile header [#136736](https://github.com/openclaw/openclaw/pull/136736). Thanks @jjjhenriksen.
+- Acknowledge successful Gateway-side configuration-file opens [#138757](https://github.com/openclaw/openclaw/pull/138757). Thanks @VasuBansal7576, @obviyus, @benmillerat.
+
+**Improvements**
+
+- Add embedded settings navigation and responsive phone-width settings layouts [#139492](https://github.com/openclaw/openclaw/pull/139492).
+- Unify Gateway connection settings and show both destinations before a switch [#141427](https://github.com/openclaw/openclaw/pull/141427).
+- Prepare Settings search sections once per current schema and hints [#139805](https://github.com/openclaw/openclaw/pull/139805).
+- Add Edit alias to paired-device actions in the Control UI [#138852](https://github.com/openclaw/openclaw/pull/138852). Thanks @xialonglee.
+
+</details>
+</Accordion>
+
+<Accordion title="Search conversations and browse folders">
+
+The command palette keeps chat-search failures visible alongside usable navigation and catalog results, and model results follow the selected agent's current catalog. Model entries take you to Models rather than silently selecting one. Model-picker search stays applied through refresh, with Escape clearing the query before closing.
+
+Folder browsing filters as you type and supports keyboard completion. Availability-aware shortcuts open supported side panels, while loaded local conversation links show titles and hover cards.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Filter Browse folders as you type and add arrow, Enter and Tab navigation [#139417](https://github.com/openclaw/openclaw/pull/139417).
+- Add availability-aware shortcuts for the remaining built-in side panels [#139385](https://github.com/openclaw/openclaw/pull/139385).
+- Show session hover cards for local chat links and known public-origin aliases [#139384](https://github.com/openclaw/openclaw/pull/139384).
+- Prepare command-palette session results once while preserving ordering and snippets [#139901](https://github.com/openclaw/openclaw/pull/139901).
+
+**Bug fixes**
+
+- Refresh command-palette model results and scope them to the selected agent [#139923](https://github.com/openclaw/openclaw/pull/139923). Thanks @obviyus.
+- Show chat-search failures beside usable command-palette navigation and catalog results [#140662](https://github.com/openclaw/openclaw/pull/140662).
+- Preserve model-picker search and keyboard selection across catalog refreshes [#140846](https://github.com/openclaw/openclaw/pull/140846).
+- Pause automatic expanded-catalog paging in hidden tabs while retaining displayed rows [#140583](https://github.com/openclaw/openclaw/pull/140583).
+
+</details>
+</Accordion>
+
+<Accordion title="Read attachments and copy file content">
+
+Supported same-origin text attachments can be read and selected directly in Files, with a literal UTF-8 preview up to 256 KiB. Unsupported or external documents remain download-only. File references with line ranges open at the first line, and leaving an agent-file preview through Edit restores focus to the editor.
+
+Download names retain literal percent sequences and complete supplementary Unicode characters. Copy actions also avoid a delayed older fallback replacing a newer clipboard choice, and browser-card URLs can be copied on plain HTTP.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Preview supported text attachments directly in the chat Files panel [#141469](https://github.com/openclaw/openclaw/pull/141469).
+
+**Bug fixes**
+
+- Link file line ranges without misidentifying version numbers or shorter filename prefixes [#139355](https://github.com/openclaw/openclaw/pull/139355).
+- Restore agent-file editor focus after closing its preview with Edit [#140495](https://github.com/openclaw/openclaw/pull/140495).
+- Preserve percent sequences in managed-media download filenames [#139508](https://github.com/openclaw/openclaw/pull/139508).
+- Avoid splitting supplementary Unicode characters in widget-export and generated-image filenames [#141311](https://github.com/openclaw/openclaw/pull/141311). Thanks @hugenshen.
+- Prevent stale copy fallbacks and restore browser-card URL copying without the Clipboard API [#140893](https://github.com/openclaw/openclaw/pull/140893).
+
+</details>
+</Accordion>
+
+<Accordion title="Read formatted replies and GitHub references">
+
+GitHub issue and pull-request links appear as recognizable chips, including standalone URL code spans and supported repository-aware shorthand. Other code stays literal. Raw previews, copied code, indented blocks and saved captions preserve their text and ordering, including HTML comments and closing tags.
+
+Verified imported conversations hide generated trust wrappers only in their human-facing presentation; stored history and model-facing protections remain intact. On narrow screens, chat text and working output align with the composer, while avatars avoid overlapping the conversation.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Render GitHub issue and pull-request links as compact reference chips [#139653](https://github.com/openclaw/openclaw/pull/139653).
+- Turn issue and PR shorthand into GitHub chips in checkout-backed chats [#141431](https://github.com/openclaw/openclaw/pull/141431).
+- Render standalone GitHub URLs in inline code as link chips [#141446](https://github.com/openclaw/openclaw/pull/141446).
+- Retain avatar-map publications when refreshed sender images have not changed [#139181](https://github.com/openclaw/openclaw/pull/139181).
+
+**Bug fixes**
+
+- Keep raw source previews literal and preserve copied code whitespace [#140306](https://github.com/openclaw/openclaw/pull/140306).
+- Hide generated trust wrappers in verified imported chat presentation [#140338](https://github.com/openclaw/openclaw/pull/140338). Thanks @fuller-stack-dev.
+- Keep saved WebChat text and captions associated with their original reply payloads [#140980](https://github.com/openclaw/openclaw/pull/140980).
+- Preserve leading indented code, literal punctuation and blank lines through chat streaming and copying [#141369](https://github.com/openclaw/openclaw/pull/141369).
+- Preserve code-copy payloads containing HTML comments and closing tags [#141574](https://github.com/openclaw/openclaw/pull/141574). Thanks @VACInc.
+- Restore configured agent avatars in transcript gutters [#139873](https://github.com/openclaw/openclaw/pull/139873). Thanks @RobertOnline69.
+- Prevent assistant image avatars from overlapping mobile chat text [#140341](https://github.com/openclaw/openclaw/pull/140341). Thanks @Takhoffman.
+- Align mobile chat text, code and working output with the composer and prevent narrow-screen clipping [#140526](https://github.com/openclaw/openclaw/pull/140526). Thanks @obviyus, @keith9681.
+- Render transcript and empty-state identity avatars as circles [#140685](https://github.com/openclaw/openclaw/pull/140685).
+
+</details>
+</Accordion>
+
+<Accordion title="Follow pull-request and GitHub status">
+
+Visible pull-request sessions reuse current Git and GitHub facts and avoid redundant refresh work after replayed messages. Profile status also distinguishes a failed GitHub lookup from a disconnected publishing account, keeping a temporary read failure from looking like a sign-out.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Show GitHub connection lookup failures without falsely marking accounts disconnected [#140333](https://github.com/openclaw/openclaw/pull/140333). Thanks @fuller-stack-dev.
+
+**Improvements**
+
+- Retain PR lookup cache entries for actively watched sessions [#139856](https://github.com/openclaw/openclaw/pull/139856).
+- Avoid scanning unrelated viewers when pull request subscriptions change [#139882](https://github.com/openclaw/openclaw/pull/139882).
+- Avoid duplicate pull request status refreshes after chat replays [#139966](https://github.com/openclaw/openclaw/pull/139966).
+- Skip unused HEAD reads for unrelated pull request landings [#140098](https://github.com/openclaw/openclaw/pull/140098).
+- Deduplicate ancestry probes for merged PRs sharing one head commit [#140191](https://github.com/openclaw/openclaw/pull/140191).
+
+</details>
+</Accordion>
+
+<Accordion title="Start repository work and native coding terminals">
+
+Available create-capable CLI agents appear by default, subject to terminal availability, permissions and node authority; explicit opt-outs remain available. Bun-hosted Gateways can start native Codex and Claude Code terminals on Linux and macOS using Node on the Gateway PATH.
+
+Empty repositories explain that an initial commit is required, and placement failures keep their specific, readable diagnostics. Cancelled placement dialogs stay closed after delayed loading, while pending commands can show instructions before completion.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Enable CLI agents by default while honoring explicit opt-outs [#139459](https://github.com/openclaw/openclaw/pull/139459).
+- Stream private command instructions while pending and filter internal control tokens [#140041](https://github.com/openclaw/openclaw/pull/140041). Thanks @obviyus.
+- Avoid duplicate pending model-auth reads during eligible chat loads [#125900](https://github.com/openclaw/openclaw/pull/125900). Thanks @Grynn.
+- Use exact session lookup for single-target suggestion delivery [#141609](https://github.com/openclaw/openclaw/pull/141609).
+
+**Bug fixes**
+
+- Restore native coding CLI starts and terminal I/O on Linux and macOS Bun Gateways [#140876](https://github.com/openclaw/openclaw/pull/140876). New Codex starts use one primary native profile per machine; existing-session discovery and resume retain their original homes.
+- Explain missing commits and preserve specific worktree session creation errors [#140251](https://github.com/openclaw/openclaw/pull/140251). Thanks @SunnyShu0925, @obviyus, @TylerGillson.
+- Keep Unicode characters intact in placement recovery diagnostics [#137649](https://github.com/openclaw/openclaw/pull/137649). Thanks @ly85206559.
+- Prevent cancelled placement dialogs from recreating detached content [#140746](https://github.com/openclaw/openclaw/pull/140746).
+
+</details>
+</Accordion>
+
+<Accordion title="Start repository work on a remote runner">
+
+Repository sessions can start directly on managed cloud or paired nodes without first cloning on the Gateway. The remote node owns checkout and setup, accepted changes survive Stop through retained checkpoints, and Move to Gateway is an explicit action when local execution is wanted.
+
+Update paired hosts or reprovision cloud nodes with the current worker bundle. Checkpoints retain accepted work; they are not full Git history or backups of unaccepted changes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Create remote repository sessions without first cloning on the Gateway [#138900](https://github.com/openclaw/openclaw/pull/138900).
+
+</details>
+</Accordion>
+
+<Accordion title="Upload files to a terminal">
+
+Terminal staging is bounded to 256 MiB and 64 retained directories, while the existing 16 MiB per-file limit and 24-hour retention remain. A partially failed batch can insert paths for files already uploaded. Recovered uploads retain their original expiry through renames and cleanup retries, and inserting a path does not execute a command.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Bound terminal upload storage and recover completed files from partial batches [#141116](https://github.com/openclaw/openclaw/pull/141116). Thanks @shakkernerd.
+- Preserve recovered terminal uploads' original expiry through renames and cleanup retries [#141251](https://github.com/openclaw/openclaw/pull/141251). Thanks @shakkernerd.
+
+</details>
+</Accordion>
+
+<Accordion title="Understand usage and export matching details">
+
+Context meters use the matching last-run prompt budget and fall back to context capacity when that budget is stale after a model or cap change. Refresh reloads the selected session's timeline, conversation and prompt breakdown alongside totals, while exports stay tied to the concrete session instance being shown.
+
+Repeated tool invocations are counted correctly within selected loaded timeline intervals. Chart sampling, filter preparation and provider history views also avoid repeated local work within those views.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Align context usage displays with the effective last-run prompt budget [#138666](https://github.com/openclaw/openclaw/pull/138666). Thanks @DasX, @javikas.
+- Prevent Usage JSON exports from mixing an old session's usage with replacement-session context [#140573](https://github.com/openclaw/openclaw/pull/140573).
+- Release completed Usage request payloads and reject superseded results [#140588](https://github.com/openclaw/openclaw/pull/140588).
+- Count repeated assistant tool invocations accurately in selected Usage timeline intervals [#141216](https://github.com/openclaw/openclaw/pull/141216).
+- Reload selected Usage timelines, conversations and prompt breakdowns on Refresh [#141632](https://github.com/openclaw/openclaw/pull/141632).
+
+**Improvements**
+
+- Reuse Usage-page filter values within each render [#140218](https://github.com/openclaw/openclaw/pull/140218).
+- Reduce temporary work when sampling Usage chart points [#140286](https://github.com/openclaw/openclaw/pull/140286).
+- Reduce repeated allocation in historical session-family Usage summaries [#140317](https://github.com/openclaw/openclaw/pull/140317).
+- Calculate selected-day session metrics once per Usage render [#140739](https://github.com/openclaw/openclaw/pull/140739).
+- Reuse formatting and aggregate scans within each provider usage-history render [#141194](https://github.com/openclaw/openclaw/pull/141194).
+
+</details>
+</Accordion>
+
+<Accordion title="Read the interface in your language and find help">
+
+Existing translation catalogs follow the current interface, including connection, approval, Swarm and prompt-budget labels. Control UI documentation is split into task-focused pages, with restored legacy anchors keeping older entry points useful.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Refresh generated Control UI translation catalogs [#139060](https://github.com/openclaw/openclaw/pull/139060).
+- Refresh generated Control UI translations for current text [#139084](https://github.com/openclaw/openclaw/pull/139084).
+- Refresh generated Control UI translation catalogs [#139200](https://github.com/openclaw/openclaw/pull/139200).
+- Refresh generated Control UI locale catalogs [#139293](https://github.com/openclaw/openclaw/pull/139293).
+- Refresh generated Control UI locale catalogs [#139345](https://github.com/openclaw/openclaw/pull/139345).
+- Refresh Control UI translations [#139632](https://github.com/openclaw/openclaw/pull/139632).
+- Refresh Control UI translations [#139905](https://github.com/openclaw/openclaw/pull/139905).
+- Refresh Control UI translations [#139927](https://github.com/openclaw/openclaw/pull/139927).
+- Refresh Control UI translations [#139969](https://github.com/openclaw/openclaw/pull/139969).
+- Refresh Control UI translations [#139985](https://github.com/openclaw/openclaw/pull/139985).
+- Refresh Control UI translations [#140031](https://github.com/openclaw/openclaw/pull/140031).
+- Refresh Control UI translations [#140059](https://github.com/openclaw/openclaw/pull/140059).
+- Refresh Control UI translations [#140118](https://github.com/openclaw/openclaw/pull/140118).
+- Refresh Control UI translations [#140144](https://github.com/openclaw/openclaw/pull/140144).
+- Refresh generated Control UI translations [#140271](https://github.com/openclaw/openclaw/pull/140271).
+- Refresh generated Control UI translations [#140384](https://github.com/openclaw/openclaw/pull/140384).
+- Refresh generated Control UI translation assets [#140831](https://github.com/openclaw/openclaw/pull/140831).
+- Refresh generated Web UI locale strings [#141160](https://github.com/openclaw/openclaw/pull/141160).
+- Refresh generated Control UI translations [#141208](https://github.com/openclaw/openclaw/pull/141208).
+- Refresh Control UI connection, approval and Swarm-completion translations [#141350](https://github.com/openclaw/openclaw/pull/141350).
+- Refresh Control UI translation catalogs [#141440](https://github.com/openclaw/openclaw/pull/141440).
+- Refresh Control UI translations after connection and chat changes [#141479](https://github.com/openclaw/openclaw/pull/141479).
+- Refresh Control UI localization data [#141546](https://github.com/openclaw/openclaw/pull/141546).
+- Translate prompt-budget labels across twenty existing UI languages [#141598](https://github.com/openclaw/openclaw/pull/141598).
+
+**Documentation**
+
+- Split the Control UI guide into task-focused documentation pages [#140437](https://github.com/openclaw/openclaw/pull/140437). Thanks @vincentkoc.
+- Restore legacy Control UI section anchors on the documentation index [#140808](https://github.com/openclaw/openclaw/pull/140808). Thanks @vincentkoc.
+- Repair the legacy This Mac documentation anchor to reach the current This device section [#141169](https://github.com/openclaw/openclaw/pull/141169). Thanks @vincentkoc.
+
+</details>
+</Accordion>
+
 </AccordionGroup>
 
 ## Updates and Maintenance
 
-Supported updates now rehearse core and plugin changes before activating them, then check the installation that actually started. Recovery also keeps a clearer distinction between a working restored installation and an update that failed, so the result tells you what happened and what still needs attention.
+Supported updates rehearse core and plugin changes before activating them, then check the installation that actually started. Recovery also keeps a clearer distinction between a working restored installation and an update that failed, so the result tells you what happened and what still needs attention.
 
 <AccordionGroup>
+
 <Accordion title="Rehearse an update before activation">
 
-OpenClaw validates supported core and plugin updates in isolated candidate state before switching the running installation. Enabled npm plugin targets are checked before downtime, and candidate copies can be tested without taking ownership away from the serving Gateway.
+OpenClaw validates supported core and plugin updates in isolated candidate state before switching the running installation. Enabled npm plugin targets are checked before downtime, and private plugin copies preserve supported linked and workspace dependency layouts so rehearsal can load them against the staged host. Incompatible agent stores are rejected before installation changes.
 
-Eligible candidate-validation failures can enter a bounded repair using your configured model in disposable rehearsal state. The candidate must pass independent validation before activation, and changes that require editing your configuration are reported for you to resolve.
+Eligible validation failures can enter a bounded repair using your configured model in disposable rehearsal state. The candidate must pass independent validation before activation, and changes that require editing your configuration are reported for you to resolve. Plugin metadata checks confirm the selected target but do not reserve its eventual download.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Rehearse core and plugin updates in isolated candidate state [#138839](https://github.com/openclaw/openclaw/pull/138839), [#141175](https://github.com/openclaw/openclaw/pull/141175).
-- Attempt bounded candidate repair with configured inference and retain failure or rollback outcomes [#139495](https://github.com/openclaw/openclaw/pull/139495).
+- Validate update candidates before stopping service and retain verified recovery generations [#138839](https://github.com/openclaw/openclaw/pull/138839).
+- Prepare private plugin copies with preserved dependency topology so staged update candidates can load installed plugins [#141175](https://github.com/openclaw/openclaw/pull/141175).
+- Attempt bounded repair during failed transactional updates [#139495](https://github.com/openclaw/openclaw/pull/139495).
 
 **Bug fixes**
 
-- Clear serving-process leases only inside the private rehearsal copy [#140004](https://github.com/openclaw/openclaw/pull/140004).
-- Check enabled npm plugin targets before stopping the serving installation [#140778](https://github.com/openclaw/openclaw/pull/140778).
-- Check the selected plugin payload after switching to a bundled development copy [#121603](https://github.com/openclaw/openclaw/pull/121603). Thanks @vincentkoc.
+- Clear serving-process leases only from the private update rehearsal copy [#140004](https://github.com/openclaw/openclaw/pull/140004).
+- Check enabled npm plugin targets before stopping the Gateway for package updates [#140778](https://github.com/openclaw/openclaw/pull/140778).
+- Inspect caller and managed-service databases before update mutation [#139722](https://github.com/openclaw/openclaw/pull/139722). Thanks @fuller-stack-dev.
+- Preserve dependency owners and aliases in isolated workspace plugin validation [#141515](https://github.com/openclaw/openclaw/pull/141515).
+- Allow artifact updates with matching configured npm plugins [#141610](https://github.com/openclaw/openclaw/pull/141610).
 
 </details>
 </Accordion>
 
 <Accordion title="Verify and recover the activated installation">
 
-Final update verification checks service ownership, health, the running version and build, plugin activation, channel readiness and HTTP readiness without making a model call. A failed check follows the supported repair or rollback path, while a healthy restored service is reported as recovery rather than a successful update.
+Final update verification checks service ownership, health, the running version and build, plugin activation, channel readiness and HTTP readiness without making a model call. A failed check follows the supported repair or rollback path, while a healthy restored service is reported as recovery rather than a successful update. Verified rollback also avoids starting unnecessary automatic triage.
 
-Eligible failed updates and recorded startup failures can also start an installation-owned repair with existing authentication and permissions. Only one repair runs per installation, and cancellation and admission limits remain in effect. Abandoned update records can be recovered without stopping a healthy matching Gateway when no post-update work remains.
+Eligible failed updates and repeated Linux systemd startup failures can start a bounded installation-owned repair with existing authentication and permissions. On macOS, launchd startup recovery provides diagnostics. Only one repair runs per installation, and uncertain cleanup can block an automatic successor while leaving manual diagnosis available.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Add installation-owned recovery for eligible update and startup failures [#135868](https://github.com/openclaw/openclaw/pull/135868).
-- Recover abandoned update records while preserving healthy matching services and live-driver protection [#141562](https://github.com/openclaw/openclaw/pull/141562).
+- Start bounded automatic recovery after eligible update and startup failures [#135868](https://github.com/openclaw/openclaw/pull/135868).
 
 **Bug fixes**
 
-- Verify service and Gateway health without inference, superseding the earlier model-turn requirement [#140725](https://github.com/openclaw/openclaw/pull/140725), [#140274](https://github.com/openclaw/openclaw/pull/140274). Thanks @fuller-stack-dev and @obviyus.
-- Report successful macOS service restoration after a failed update [#139393](https://github.com/openclaw/openclaw/pull/139393).
-- Report failed post-repair verification instead of claiming a successful start [#139145](https://github.com/openclaw/openclaw/pull/139145). Thanks @SebTardif.
-- Preserve the owned service profile when switching package installs to Git [#140263](https://github.com/openclaw/openclaw/pull/140263). Thanks @fuller-stack-dev.
-- Retain successful update notices when local state writes fail within the current process [#141084](https://github.com/openclaw/openclaw/pull/141084). Thanks @vincentkoc.
+- Verify updates through service and Gateway health without running a model turn [#140725](https://github.com/openclaw/openclaw/pull/140725).
+- Introduce update-verification gates, with the model-turn requirement superseded by the later health-only verification change [#140274](https://github.com/openclaw/openclaw/pull/140274). Thanks @fuller-stack-dev, @obviyus.
+- Retain observed service stops so failed updates can restore the Gateway [#136285](https://github.com/openclaw/openclaw/pull/136285). Thanks @Schimuneck.
+- Verify retained npm package trees before and after rollback [#136329](https://github.com/openclaw/openclaw/pull/136329). Thanks @fuller-stack-dev.
+- Report failed post-repair service verification instead of claiming a successful start [#139145](https://github.com/openclaw/openclaw/pull/139145). Thanks @SebTardif.
+- Report successful macOS service restoration after a failed managed update [#139393](https://github.com/openclaw/openclaw/pull/139393).
+- Run normal update recovery when managed-wrapper retirement fails [#140284](https://github.com/openclaw/openclaw/pull/140284). Thanks @fuller-stack-dev.
+- Continue Gateway restart after verified package restoration [#140313](https://github.com/openclaw/openclaw/pull/140313). Thanks @fuller-stack-dev.
+- Preserve compatible fresh-install rollback and report update verification failures accurately [#140419](https://github.com/openclaw/openclaw/pull/140419).
+- Restore the previous version after a fresh installation's first broken update when rollback guards permit it [#141219](https://github.com/openclaw/openclaw/pull/141219).
+- Skip automatic triage after a rollback has restored and verified a healthy previous generation [#141364](https://github.com/openclaw/openclaw/pull/141364).
+- Bound update-finalization phases and cleanup, with immediate diagnostics and failed JSON on overruns [#140648](https://github.com/openclaw/openclaw/pull/140648). Thanks @hannesrudolph.
+- Restore the released updater bridge and prevent orphan finalizer runs [#139660](https://github.com/openclaw/openclaw/pull/139660). Thanks @TheCrazyLex, @coygeek.
+
+</details>
+</Accordion>
+
+<Accordion title="Read update progress and report failures">
+
+Long updates retain their progress watcher until completion, and update history keeps terminal failures, restart outcomes and current update availability distinct. Abandoned records can be recovered without stopping a healthy matching Gateway when no post-update work remains, with conservative checks for active drivers and explicit recovery for records lacking driver identity.
+
+A failed-update action can prepare a sanitized report for your review and submit it only with explicit consent. Missing GitHub authentication offers a browser handoff rather than sending anything automatically.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add consent-based update failure reporting in Control UI [#139704](https://github.com/openclaw/openclaw/pull/139704). Thanks @fuller-stack-dev.
+- Recover abandoned update runs with explicit reasons and conservative process checks [#141562](https://github.com/openclaw/openclaw/pull/141562).
+
+**Bug fixes**
+
+- Finish admitted update runs when progress or triage initialization fails before execution begins [#139288](https://github.com/openclaw/openclaw/pull/139288). Thanks @TheAngryPit.
+- Keep watching active updates until terminal completion or Gateway teardown [#139289](https://github.com/openclaw/openclaw/pull/139289). Thanks @TheAngryPit, @obviyus.
+- Keep current update availability visible beside update history [#139501](https://github.com/openclaw/openclaw/pull/139501).
+- Preserve restart outcomes, phase history, and same-session update notices [#139701](https://github.com/openclaw/openclaw/pull/139701).
+- Retain successful update checks while local state writes are unavailable [#141084](https://github.com/openclaw/openclaw/pull/141084). Thanks @vincentkoc.
+- Preserve Unicode in bounded update run summaries [#137680](https://github.com/openclaw/openclaw/pull/137680). Thanks @ly85206559.
+- Decode split UTF-8 output correctly in update candidate checks [#141397](https://github.com/openclaw/openclaw/pull/141397).
+- Use artifact-preserving readers for update history and status [#138917](https://github.com/openclaw/openclaw/pull/138917). Thanks @fuller-stack-dev.
+
+**Documentation**
+
+- Clarify that bounded triage falls back to an owned child when native PTY startup is unavailable [#140519](https://github.com/openclaw/openclaw/pull/140519).
+
+</details>
+</Accordion>
+
+<Accordion title="Update an existing 2026.9.2 installation">
+
+Eligible updates driven by 2026.9.2 can cross a shared-state schema change while the older updater finishes reading its update history. Agent-schema migrations, missing state metadata and failed state migrations still require the documented external-install and fresh-Doctor recovery path. See [schema-bump recovery](/reference/database-schemas#schema-bumps-and-older-updaters) if your update is refused.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Limits and compatibility**
+
+- Let 2026.9.2 updates finish while the new runtime uses migrated state [#141109](https://github.com/openclaw/openclaw/pull/141109).
+- Guard unsupported 2026.9.2-driven schema upgrades, with eligible shared-state-only migrations supported by the later upgrade fix [#140784](https://github.com/openclaw/openclaw/pull/140784).
+
+</details>
+</Accordion>
+
+<Accordion title="Switch installation channels and align official plugins">
+
+Switching between Git and packaged installations preserves the owned service profile and distinguishes updater staging from unrelated checkout changes. A same-version change can still replace the installation method, and returning from an npm development link preserves the external checkout. Restoring that link after failure does not by itself verify the checkout or authorize an automatic restart.
+
+Post-update maintenance runs through the activated CLI. Version-bound official plugins follow the selected release, missing untracked official plugins receive the matching stable version on their first repair, and explicit pins keep their intended selectors.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Check the selected plugin payload after a dev-channel switch before reporting it missing [#121603](https://github.com/openclaw/openclaw/pull/121603). Thanks @vincentkoc.
+- Preserve the owned Gateway profile when switching package installs to Git [#140263](https://github.com/openclaw/openclaw/pull/140263). Thanks @fuller-stack-dev.
+- Report successful same-version update-channel changes instead of marking them skipped [#140493](https://github.com/openclaw/openclaw/pull/140493). Thanks @vincentkoc.
+- Preserve exact updater-owned staging paths during Git source checks and rollback [#140553](https://github.com/openclaw/openclaw/pull/140553). Thanks @vincentkoc.
+- Complete same-version Git-to-package channel switches with normal validation and rollback [#140598](https://github.com/openclaw/openclaw/pull/140598). Thanks @vincentkoc.
+- Allow a development-linked installation to switch back to the stable package while preserving its external checkout [#141168](https://github.com/openclaw/openclaw/pull/141168).
+- Use newest-of-beta/latest selection for managed npm plugins [#139709](https://github.com/openclaw/openclaw/pull/139709). Thanks @Conan-Scott.
+- Use the activated CLI for post-update plugin maintenance and align version-bound plugin targets [#140886](https://github.com/openclaw/openclaw/pull/140886).
+- Pin first repair of untracked official plugins to the current stable release cohort [#141478](https://github.com/openclaw/openclaw/pull/141478).
+
+**Limits and compatibility**
+
+- Retire the old in-process package updater and keep package updates with the current CLI coordinator [#140676](https://github.com/openclaw/openclaw/pull/140676).
+
+</details>
+</Accordion>
+
+<Accordion title="Keep work available across restarts and updates">
+
+Eligible interrupted work, follow-ups and attachments can resume after an update, while accepted child results wait for their parent to recover. Update the Codex plugin with the Gateway for the corresponding work recovery; unknown submissions remain unconfirmed, and missing attachment bytes need to be sent again.
+
+Cloud provisioning can resume across a Gateway restart, and an idle cloud session whose old worker was deliberately retired can prepare a replacement on its next message. Explicit Stop and destroy intent still take precedence. Shutdown also closes abandoned setup prompts and stops queued startup work from entering a closing Gateway.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve interrupted work and queued inputs across Gateway updates [#139663](https://github.com/openclaw/openclaw/pull/139663).
+- Retain accepted child-result handoffs while the parent session recovers [#140930](https://github.com/openclaw/openclaw/pull/140930). Thanks @Takhoffman.
+- Resume idle cloud sessions after Gateway updates retire their old workers [#139437](https://github.com/openclaw/openclaw/pull/139437).
+- Resume pending cloud-worker provisioning after a Gateway restart [#139455](https://github.com/openclaw/openclaw/pull/139455).
+- Prevent queued startup watchers, hooks and reconciliation from entering a closing Gateway [#139092](https://github.com/openclaw/openclaw/pull/139092).
+- Drain entered update-notice delivery and commit work before Gateway shutdown completes [#139304](https://github.com/openclaw/openclaw/pull/139304).
+- Prevent suspended background admission from hanging Gateway shutdown [#139500](https://github.com/openclaw/openclaw/pull/139500).
+- Close abandoned setup input during Gateway shutdown [#139783](https://github.com/openclaw/openclaw/pull/139783).
+
+**Improvements**
+
+- Reduce duplicate session reads during worker cleanup while retaining full validation [#140469](https://github.com/openclaw/openclaw/pull/140469).
 
 </details>
 </Accordion>
@@ -270,80 +806,189 @@ Eligible failed updates and recorded startup failures can also start an installa
 
 New and reinstalled systemd service units let child work drain while the Gateway shuts down. Existing service definitions are preserved during ordinary updates, so run `openclaw gateway install --force` for the selected profile to receive the changed service configuration. Operator-supplied systemd overrides remain separately editable. See [restart recovery](/gateway/restart-recovery).
 
+Service installation and repair use monotonic deadlines so a wall-clock adjustment does not consume their timeout budget.
+
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Use systemd mixed kill mode to preserve child work during Gateway drain and audit effective overrides [#140568](https://github.com/openclaw/openclaw/pull/140568). Thanks @DonnieFi and @agentzerodao.
+- Use systemd mixed kill mode to preserve child work during Gateway drain and audit effective overrides [#140568](https://github.com/openclaw/openclaw/pull/140568). Thanks @DonnieFi, @agentzerodao.
+- Use monotonic clocks for shared systemd operation deadlines [#137253](https://github.com/openclaw/openclaw/pull/137253). Thanks @coderdailyone.
 
 </details>
 </Accordion>
 
-<Accordion title="Update an existing 2026.9.2 installation">
+<Accordion title="Recover service connections on Mac and Windows">
 
-Eligible updates driven by 2026.9.2 can now cross a shared-state schema change while the older updater finishes reading its update history. Agent-schema migrations, missing state metadata and failed state migrations still require the documented external-install and fresh-Doctor recovery path. See [schema-bump recovery](/reference/database-schemas#schema-bumps-and-older-updaters) if your update is refused.
+Mac lifecycle commands recognize LaunchAgent ancestry so an in-service restart can hand off without killing its own caller, including services without the usual markers. Stop, install and uninstall still require an external shell in that case. Older launchctl status output is also recognized.
+
+Windows startup creates protected SQLite staging directories through native APIs without the compiler subprocess implicated in reported antivirus failures.
+
+Tailscale crash recovery retains cleanup ownership, and foreground route conflicts point to the confirmed owning process rather than suggesting unrelated route removal.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
-**Limits and compatibility**
+**Bug fixes**
 
-- Support eligible 2026.9.2 shared-state-only upgrades while deferring schema-version publication [#141109](https://github.com/openclaw/openclaw/pull/141109).
-- Retain refusal and recovery guidance for unsupported older-updater schema changes, with eligible shared-state upgrades handled by the later change above [#140784](https://github.com/openclaw/openclaw/pull/140784).
+- Detect LaunchAgent ancestry for safe in-service lifecycle commands [#139628](https://github.com/openclaw/openclaw/pull/139628).
+- Accept boolean launchd disabled-state output [#139836](https://github.com/openclaw/openclaw/pull/139836). Thanks @NovaUnboundAi, @gaoanze888.
+- Create protected Windows SQLite staging directories through native APIs without PowerShell compilation [#140593](https://github.com/openclaw/openclaw/pull/140593). Thanks @LegendaryAdventures.
+- Keep route cleanup alive across Gateway process-group termination and handle early IPC loss [#139261](https://github.com/openclaw/openclaw/pull/139261). Thanks @PollyBot13.
+- Distinguish foreground Tailscale claims and provide scoped manual recovery guidance [#139283](https://github.com/openclaw/openclaw/pull/139283). Thanks @PollyBot13.
+- Restore local password authentication for status checks in trusted-proxy mode [#140975](https://github.com/openclaw/openclaw/pull/140975).
+- Preserve node-service identity and macOS inspection timeouts [#141572](https://github.com/openclaw/openclaw/pull/141572).
+- Preserve literal POSIX log paths in shared Gateway recovery hints [#139227](https://github.com/openclaw/openclaw/pull/139227).
+
+**Improvements**
+
+- Label diagnostic-only Service and Runtime lines in Gateway status [#140547](https://github.com/openclaw/openclaw/pull/140547). Thanks @aeoess.
 
 </details>
 </Accordion>
 
 <Accordion title="Preserve the configuration you wrote">
 
-Configuration edits and Doctor repairs keep authored settings, explicit defaults and supported include-file ownership intact. An eligible nested change is written into the fragment that owns it, while unsafe shared-file or mixed-array changes remain refused rather than being flattened into a different configuration.
+Configuration edits and Doctor repairs keep authored settings, explicit defaults and supported include-file ownership intact. An eligible nested change is written into the fragment that owns it, while unsafe shared-file or mixed-array changes remain refused rather than being flattened into a different configuration. Failed prefix recovery preserves the original file, and audit history retains the writer label supplied with a change.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Route eligible edits to their nested configuration include [#116108](https://github.com/openclaw/openclaw/pull/116108). Thanks @sasan1200.
-- Preserve authored settings and root-owned arrays through includes and agent migration [#139949](https://github.com/openclaw/openclaw/pull/139949).
-- Retain explicit defaults and valid null values through supported configuration writes; `config.patch` still uses null for deletion [#140579](https://github.com/openclaw/openclaw/pull/140579).
-- Keep unrelated plugin defaults out of repairs [#139376](https://github.com/openclaw/openclaw/pull/139376).
-- Report a failed rejected-payload backup without claiming a saved file [#134198](https://github.com/openclaw/openclaw/pull/134198). Thanks @SebTardif.
+- Write eligible config changes and Doctor repairs into their nested $include file [#116108](https://github.com/openclaw/openclaw/pull/116108). Thanks @sasan1200.
+- Preserve authored settings and root-owned arrays across configuration includes and agent migration [#139949](https://github.com/openclaw/openclaw/pull/139949).
+- Preserve authored settings, includes and explicit defaults through configuration updates and setup [#140579](https://github.com/openclaw/openclaw/pull/140579). Full `config.set`/`config.apply` writes and runtime-derived replacements preserve valid nullable values; `config.patch` still uses null to delete a value.
+- Keep unrelated plugin defaults out of Doctor and update-channel repairs [#139376](https://github.com/openclaw/openclaw/pull/139376).
+- Report failed rejected-config backup writes without claiming a saved payload path [#134198](https://github.com/openclaw/openclaw/pull/134198). Thanks @SebTardif.
+- Stage prefix-recovered configuration before atomic replacement [#137713](https://github.com/openclaw/openclaw/pull/137713). Thanks @aeoess.
+- Forward writer provenance into persisted configuration audit records [#139332](https://github.com/openclaw/openclaw/pull/139332).
+- Restore LINE and Mattermost credential promotion for installed plugins [#136045](https://github.com/openclaw/openclaw/pull/136045). Thanks @wangmiao0668000666, @obviyus.
+
+**Documentation**
+
+- Clarify configuration reload outcomes and plugin-declared matching rules [#139462](https://github.com/openclaw/openclaw/pull/139462). Thanks @shakkernerd, @abacha.
+- Explain how to repair execution-policy conflicts without guessing incomplete or nonrepresentable policies [#139143](https://github.com/openclaw/openclaw/pull/139143). Thanks @ylcn91, @technicalpickles.
 
 </details>
 </Accordion>
 
-<Accordion title="Run Doctor, backups and source maintenance">
+<Accordion title="Run Doctor and database maintenance">
 
-Doctor moves initial integrity checks off the main event loop and gives more useful recovery guidance when state cannot be read or safely migrated. Large Git backups and restores use bounded batches, reducing the need to hold complete database tables in memory while keeping their verification checks.
+Doctor checks maintenance ownership before expensive database inspection and reports required migration failures without proceeding into later repairs. Initial integrity checks move off the main event loop, while schema repair and compaction retain their own costs. Startup maintenance refusals are distinguished from crashes instead of feeding a channel-suppression restart loop.
 
-Source installations also build browser assets from the checked-out source and can run maintenance from another working directory. Normal source-server updates build the runtime, plugins and UI without regenerating developer declarations unless requested.
+Other conversations can save edits while cleanup checks a database's integrity. Deletion still waits for the complete verification.
+
+General Doctor checks avoid reading personal browser profiles for optional readiness checks, reporting that they were not inspected. Unsupported workspace state and unreadable databases retain actionable manual recovery guidance. Removing an installed Claw also drains its verified monitors, which requires an authenticated running Gateway even when no jobs are listed.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Migrate legacy workspace setup earlier and show why channels failed to start [#139395](https://github.com/openclaw/openclaw/pull/139395).
+- Preserve Doctor migration authority and report required failures [#139683](https://github.com/openclaw/openclaw/pull/139683). Thanks @fuller-stack-dev.
+- Check maintenance ownership before database snapshots and bound stalled inspection [#141412](https://github.com/openclaw/openclaw/pull/141412). Thanks [Rocky_Chuck on X](https://x.com/Rocky_Chuck/status/2096970154622267418).
+- Classify startup maintenance refusals and exclude them from channel-suppression crash counts [#141416](https://github.com/openclaw/openclaw/pull/141416). Thanks [Rocky_Chuck on X](https://x.com/Rocky_Chuck/status/2096970154622267418).
+- Avoid personal browser-profile discovery during general Doctor checks [#139612](https://github.com/openclaw/openclaw/pull/139612). Thanks @fuller-stack-dev.
+- Admit session startup repair databases asynchronously [#139674](https://github.com/openclaw/openclaw/pull/139674).
+- Coordinate session cleanup with the common SQLite write boundary [#139689](https://github.com/openclaw/openclaw/pull/139689).
+- Preserve the original SQLite failure and retire failed transaction connections [#139700](https://github.com/openclaw/openclaw/pull/139700).
+- Run agent maintenance integrity checks off the main event loop [#139918](https://github.com/openclaw/openclaw/pull/139918).
+- Prevent periodic SQLite vacuum from causing session-cleanup approval timeouts [#141006](https://github.com/openclaw/openclaw/pull/141006).
+- Drain config-owned monitors before removing an installed Claw [#140025](https://github.com/openclaw/openclaw/pull/140025).
+- Count selected bootstrap-hook files using canonical source-path budgets [#137351](https://github.com/openclaw/openclaw/pull/137351). Thanks @ylcn91, @obviyus, @pawel-kowalczyk.
+- Let other conversations save edits during cleanup integrity inspection, while deletion still waits for full verification [#141434](https://github.com/openclaw/openclaw/pull/141434).
+- Doctor identifies unreadable state databases and gives backup-recovery guidance; configuration patches also report which settings changed without exposing their values [1391f7c](https://github.com/openclaw/openclaw/commit/1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7).
+- Make startup database preflight asynchronous with cancellation and cleanup ownership [#138986](https://github.com/openclaw/openclaw/pull/138986).
+
+**Improvements**
+
+- Start SQLite snapshot and preflight checks with fewer imports [#139543](https://github.com/openclaw/openclaw/pull/139543).
+- Prepare transcript rewrite statements once per operation [#139770](https://github.com/openclaw/openclaw/pull/139770).
+- Avoid copying unrelated retained output before task maintenance can yield [#140038](https://github.com/openclaw/openclaw/pull/140038).
+- Reuse compatible prepared plugin metadata during multi-agent startup checks [#140135](https://github.com/openclaw/openclaw/pull/140135).
+- Defer unused Memory, Workboard and Canvas migration imports during startup and Doctor [#140178](https://github.com/openclaw/openclaw/pull/140178).
+
+**Documentation**
+
+- Correct the documented files considered by Doctor's bootstrap-size check [#137347](https://github.com/openclaw/openclaw/pull/137347). Thanks @ylcn91.
+- Replace obsolete TUI termination advice with factual diagnostics guidance [#140074](https://github.com/openclaw/openclaw/pull/140074).
+- Explain offline compatibility limits for discovery-only context engines [#140818](https://github.com/openclaw/openclaw/pull/140818). Thanks @Marvinthebored.
+- Give manual recovery steps for unsupported workspace state and preserved exec policy [#140854](https://github.com/openclaw/openclaw/pull/140854).
+
+</details>
+</Accordion>
+
+<Accordion title="Back up state and read Git history">
+
+Large Git backups and restores use bounded batches, reducing the need to hold complete database tables in memory while keeping verification checks. State-only backups leave shared-workspace scratch out of the archive, and oversized required Git output produces an error instead of a partially parsed history.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Stream Git backup creation, restore and verification in bounded batches [#134213](https://github.com/openclaw/openclaw/pull/134213). Thanks @xydt-juyaohui.
+- Stream Git backup creation, materialization, restore and verification in bounded batches [#134213](https://github.com/openclaw/openclaw/pull/134213). Thanks @xydt-juyaohui, @gmv3892-creator.
 
 **Bug fixes**
 
-- Run initial maintenance integrity checks off the main event loop [#139918](https://github.com/openclaw/openclaw/pull/139918).
-- Migrate supported legacy setup earlier and show sanitized channel-start failures [#139395](https://github.com/openclaw/openclaw/pull/139395).
-- Avoid cleanup approval timeouts during periodic SQLite space reclamation [#141006](https://github.com/openclaw/openclaw/pull/141006).
-- Build source browser assets without generated-manifest changes disrupting updates [#139075](https://github.com/openclaw/openclaw/pull/139075). Thanks @ylcn91.
-- Use runtime-only source-server builds by default [#139392](https://github.com/openclaw/openclaw/pull/139392). Thanks @jason-allen-oneal.
-- Resolve the source-mode worker loader from OpenClaw when invoked elsewhere [#140458](https://github.com/openclaw/openclaw/pull/140458). Thanks @gaoanze888 and @mbundy.
-- Identify unreadable state databases and point to verified-backup recovery; `config.patch` also reports changed setting paths without their values [1391f7c](https://github.com/openclaw/openclaw/commit/1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7).
-
-**Documentation**
-
-- Give manual recovery steps for unsupported workspace state and preserved execution policy [#140854](https://github.com/openclaw/openclaw/pull/140854).
-- Explain offline limits for discovery-only context engines [#140818](https://github.com/openclaw/openclaw/pull/140818). Thanks @Marvinthebored.
-- Correct device approval, secret-plan and multi-Gateway port-spacing guidance [#140472](https://github.com/openclaw/openclaw/pull/140472). Thanks @vincentkoc.
+- Exclude shared workspace bases from state-only backups [#139598](https://github.com/openclaw/openclaw/pull/139598). Thanks @ayaangazali, @obviyus, @TheCrazyLex.
+- Reject truncated required Git output before parsing backup history [#139862](https://github.com/openclaw/openclaw/pull/139862).
+- Preserve Unicode in bounded stalled-backup path suffixes [#137693](https://github.com/openclaw/openclaw/pull/137693). Thanks @ly85206559.
 
 </details>
 </Accordion>
+
+<Accordion title="Maintain a source checkout">
+
+Source installations build browser assets from the checked-out source and can run maintenance from another working directory. Normal source-server updates build the runtime, plugins and UI without regenerating developer declarations unless requested. Windows MSYS Git paths are normalized at filesystem boundaries while revision arguments remain intact.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Normalize MSYS Git path output at filesystem boundaries and preserve revision arguments in worktree commands [#139266](https://github.com/openclaw/openclaw/pull/139266). Thanks @ly85206559, @vincentkoc, @haoran2025.
+- Build plugin browser assets from checked-out source to prevent build-dirty update failures [#139075](https://github.com/openclaw/openclaw/pull/139075). Thanks @ylcn91, @eggc-tech.
+- Use runtime-only builds by default in the source-server update script [#139392](https://github.com/openclaw/openclaw/pull/139392). Thanks @jason-allen-oneal.
+- Resolve the TypeScript worker loader from OpenClaw so maintenance works from unrelated directories [#140458](https://github.com/openclaw/openclaw/pull/140458). Thanks @gaoanze888, @mbundy.
+- Refresh compatible dependencies and preserve stream cancellation and focused sidebar menus [#138199](https://github.com/openclaw/openclaw/pull/138199).
+- Emit internal runtime chunks as ESM while retaining public entrypoints [#139754](https://github.com/openclaw/openclaw/pull/139754).
+
+</details>
+</Accordion>
+
+<Accordion title="Understand maintenance and connection diagnostics">
+
+Slow-operation logs distinguish queue, work and completion delays and identify the process or worker that emitted them. Connection diagnostics retain close causes, duration, local ping-write state and last-pong age, helping operators distinguish observations without treating a completed local write as proof that the remote side received it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add process and Worker identity to database-open warnings [#139835](https://github.com/openclaw/openclaw/pull/139835).
+- Break down slow session edits and SQLite writer warnings into queue, work and completion delays [#140478](https://github.com/openclaw/openclaw/pull/140478).
+- Identify the admission mode in slow agent-database warnings [#140498](https://github.com/openclaw/openclaw/pull/140498).
+- Add bounded phase, trigger, status and timing details to maintenance heartbeat startup failures [#140544](https://github.com/openclaw/openclaw/pull/140544).
+- Include process and worker identities in slow session-write diagnostics [#140558](https://github.com/openclaw/openclaw/pull/140558).
+- Reduce duplicate process probes during Unix port diagnostics [#140608](https://github.com/openclaw/openclaw/pull/140608).
+- Preserve WebSocket close causes and connection duration in info-level file logs [#140640](https://github.com/openclaw/openclaw/pull/140640).
+- Include ping-write state and last-pong age in heartbeat-timeout diagnostics [#140783](https://github.com/openclaw/openclaw/pull/140783).
+- Add process and thread identity to embedded stage timing logs [#140832](https://github.com/openclaw/openclaw/pull/140832).
+- Reduce telemetry-exporter summary formatting work in Doctor and status [#140329](https://github.com/openclaw/openclaw/pull/140329).
+- Deduplicate status diagnostic issues by exact path and message [#140364](https://github.com/openclaw/openclaw/pull/140364).
+
+**Documentation**
+
+- Correct device approval steps, disabled legacy-auth scrubbing and Gateway port-spacing guidance [#140472](https://github.com/openclaw/openclaw/pull/140472). Thanks @vincentkoc.
+- Add the detailed page and navigation for the already released v2026.9.2 notes [#139423](https://github.com/openclaw/openclaw/pull/139423). Thanks @hannesrudolph.
+
+</details>
+</Accordion>
+
 </AccordionGroup>
 
 ## Messaging
@@ -351,156 +996,358 @@ Source installations also build browser assets from the checked-out source and c
 Saved meetings are easier to find and return to, with transcript search and complete exports alongside the existing capture workflow. Messaging fixes also carry through channel-specific formatting, reply routing and recovery, including Telegram albums and more deliberate Discord bot handoffs.
 
 <AccordionGroup>
+
 <Accordion title="Browse saved meetings and search transcripts">
 
 The meeting library lets you browse saved notes, search full transcripts and manage capture sources in Communications settings. Exports include the complete selected meeting even when a search filter is active, with Markdown and JSONL available under the existing archive permissions.
 
-The download limit remains 4 MiB. Larger exports fail without producing a partial file and need the documented CLI export path on the host.
+The download limit remains 4 MiB. Larger exports fail without producing a partial file and need the documented CLI export path on the host. Capture status describes subscriptions rather than proving that a recording is active.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Browse paginated saved meetings and search transcript archives [#139875](https://github.com/openclaw/openclaw/pull/139875).
-- Export complete selected meetings and edit capture sources in Communications settings [#140084](https://github.com/openclaw/openclaw/pull/140084).
+- Browse, search, and export saved meeting archives with shared-archive access checks [#139875](https://github.com/openclaw/openclaw/pull/139875).
+- Add a searchable Meetings library and native capture-source controls [#140084](https://github.com/openclaw/openclaw/pull/140084).
+- Reduce discarded collection work in long meeting transcript summaries without changing their content or claiming faster model responses [#140872](https://github.com/openclaw/openclaw/pull/140872).
 
 </details>
 </Accordion>
 
 <Accordion title="Stop and resume meeting capture">
 
-Meeting capture keeps its history and ownership through more interrupted starts and cleanup failures. Duplicate auto-start attempts settle as conflicts instead of creating another recording, and stopping a meeting requests cancellation of active consults and ignores late speech.
+Meeting capture keeps its history and ownership through more interrupted starts and cleanup failures. Duplicate auto-start attempts settle as conflicts instead of creating another recording, and stopping a meeting requests cancellation of active consults and ignores late speech. Cleanup failures remain visible and retryable until termination is confirmed.
+
+Discord recordings stay independent of voice-conversation work. For full room transcription coverage, use batch transcription; realtime-only capture remains limited. Occupancy capture only reopens recent transcripts whose stored origin confirms a generated ID, preserving supplied-ID and unknown legacy history.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Settle duplicate recording auto-start retries without restarting capture under a consumed ID [#140202](https://github.com/openclaw/openclaw/pull/140202).
-- Clear stale occupancy retry diagnostics after startup settles [#140220](https://github.com/openclaw/openclaw/pull/140220).
-- Retire completed capture-verification scratch state [#140750](https://github.com/openclaw/openclaw/pull/140750).
-- Request consult cancellation and ignore late speech after Stop [#140801](https://github.com/openclaw/openclaw/pull/140801).
-- Preserve supplied-ID and legacy capture history across occupancy restarts [#140563](https://github.com/openclaw/openclaw/pull/140563).
-- Keep Discord recording independent of voice conversations and preserve capture ownership after cleanup failures [#139572](https://github.com/openclaw/openclaw/pull/139572), [#139658](https://github.com/openclaw/openclaw/pull/139658).
+- Retain meeting-capture ownership until cleanup is confirmed [#139572](https://github.com/openclaw/openclaw/pull/139572).
+- Preserve authorized Discord recordings across voice lifecycle changes [#139658](https://github.com/openclaw/openclaw/pull/139658).
+- Settle duplicate meeting auto-start requests as session-ID conflicts [#140202](https://github.com/openclaw/openclaw/pull/140202).
+- Clear stale retry diagnostics after meeting occupancy settles [#140220](https://github.com/openclaw/openclaw/pull/140220).
+- Record transcript ID origin and reopen only explicitly generated captures [#140563](https://github.com/openclaw/openclaw/pull/140563).
+- Retire meeting loopback scratch after successful verification or transport stop [#140750](https://github.com/openclaw/openclaw/pull/140750).
+- Cancel active meeting consults and close speech output during shutdown [#140801](https://github.com/openclaw/openclaw/pull/140801).
 
 </details>
 </Accordion>
 
 <Accordion title="Send Telegram albums and follow progress">
 
-Consecutive eligible photos can be sent as native Telegram albums of up to ten, keeping their order, captions, reply targets and forum topics. Single photos and messages with controls continue to send individually. Concurrent forum topics also retain independent typing indicators, while enabled answer previews can show compaction status.
+Consecutive eligible photos can be sent as native Telegram albums of up to ten, keeping their order, captions, reply targets and forum topics. Single photos and messages with controls continue to send individually. Concurrent forum topics retain independently paced typing actions, subject to Telegram's own display and account backoff behavior.
+
+Enabled answer previews can show compaction status, and native choice controls no longer repeat their fallback list in the message text. Telegram conversations also keep visible delegated tasks attached to their parent conversation without relaxing spawn permissions.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- Group consecutive eligible Telegram photos into native albums [#141398](https://github.com/openclaw/openclaw/pull/141398).
+- Send consecutive Telegram photos in albums of two to ten [#141398](https://github.com/openclaw/openclaw/pull/141398). Thanks @obviyus.
 
 **Bug fixes**
 
-- Keep typing independent across concurrent forum topics [#139292](https://github.com/openclaw/openclaw/pull/139292).
-- Show compaction status in enabled answer previews [#141551](https://github.com/openclaw/openclaw/pull/141551).
-- Keep whitespace-split internal reasoning prefixes out of streamed messages [#126219](https://github.com/openclaw/openclaw/pull/126219). Thanks @vincentkoc and @wangyan2026.
+- Scope Telegram typing to each forum topic and pace actions separately from messages [#139292](https://github.com/openclaw/openclaw/pull/139292). Thanks @gaoanze888, @obviyus, @maxschachere.
+- Show compaction progress in Telegram partial and block previews when preview tool progress is enabled [#141199](https://github.com/openclaw/openclaw/pull/141199). Thanks @VACInc.
+- Suppress spaced incomplete internal-reasoning prefixes in Telegram streams [#126219](https://github.com/openclaw/openclaw/pull/126219). Thanks @vincentkoc, @wangyan2026.
+- Avoid duplicate Telegram choices when native controls are available [#140108](https://github.com/openclaw/openclaw/pull/140108). Thanks @obviyus.
+- Use durable parent lineage while preserving spawn policy and media-task ownership [#137779](https://github.com/openclaw/openclaw/pull/137779). Thanks @SunnyShu0925, @vincentkoc, @ratticon.
+- Unify Telegram delivery ownership and format table-heavy HTML with one forward scan [#140602](https://github.com/openclaw/openclaw/pull/140602). Thanks @obviyus.
+- Quiet recognized recoverable album-upload errors while retaining ambiguous failure logs [#141601](https://github.com/openclaw/openclaw/pull/141601).
 
 </details>
 </Accordion>
 
-<Accordion title="Control Discord bot replies and formatting">
+<Accordion title="Control Discord access and bot replies">
 
-Bots in mention-only mode now need an active native or configured mention to reply. A handoff that relied only on Discord's reply ping needs an explicit mention. Policy-only Discord changes apply to new messages and interactions without waiting for an active Control UI turn to finish. Transport changes and mixed edits remain deferred, and work already admitted keeps its original context.
+Bots in mention-only mode need an active native or configured mention to reply. A handoff that relied only on Discord's reply ping needs an explicit mention. Policy-only changes apply to new messages and interactions without waiting for an active Control UI turn to finish, while transport changes and mixed edits remain deferred and work already admitted keeps its original context.
 
-Message formatting also preserves leading indentation, so pasted code and structured text keep their shape.
+Status explains empty allowlists and deferred reloads, and setup catches a numeric application ID pasted where a bot token belongs. Authorized reset commands recognize the supported sender aliases without changing the session ID.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Apply Discord policy-only configuration changes live to new messages and interactions [#140929](https://github.com/openclaw/openclaw/pull/140929).
-- Require an active mention for Discord bot replies in mention-only mode [#111822](https://github.com/openclaw/openclaw/pull/111822). Thanks @ooiuuii and @obviyus.
-- Preserve leading indentation in Discord and inter-session messages [#139390](https://github.com/openclaw/openclaw/pull/139390).
-- Skip unnecessary underscore parsing during Discord formatting [#140186](https://github.com/openclaw/openclaw/pull/140186).
-- Keep Discord voice input until transcription finishes [#139484](https://github.com/openclaw/openclaw/pull/139484).
+- Require an active native or configured mention for Discord bot replies in mention-only mode [#111822](https://github.com/openclaw/openclaw/pull/111822). Thanks @ooiuuii, @obviyus.
+- Apply Discord policy-only edits immediately through validated runtime publication [#140929](https://github.com/openclaw/openclaw/pull/140929). Thanks @DonnieFi.
+- Show actionable Discord policy warnings and deferred channel-reload status in the CLI and Control UI [#140635](https://github.com/openclaw/openclaw/pull/140635). Thanks @jason-allen-oneal, @vincentkoc.
+- Reject numeric Discord application IDs as bot tokens and point users to the Developer Portal's Bot page [#140531](https://github.com/openclaw/openclaw/pull/140531). Thanks @Bruce-Yii, @obviyus, @DonnieFi.
+- Normalize user, discord and pk sender aliases for Discord new/reset authorization [#140637](https://github.com/openclaw/openclaw/pull/140637). Thanks @chrismanderson.
 
 </details>
 </Accordion>
 
-<Accordion title="Keep Slack replies and shared uploads intact">
+<Accordion title="Read Discord replies and use voice conversations">
 
-Slack delivers valid structured sections intact even when their accessibility text exceeds the preferred chunk size. Formatting also retains the surrounding Markdown when tables are converted, while shared Slack and Teams uploads avoid an unnecessary copy of the file data.
+Discord persona and bot replies share Markdown formatting, preserving leading indentation and expanding mentions after multiline code while leaving names inside code literal. Nested Components v2 starter text and forwarded snapshots remain readable when the agent joins a thread.
+
+Voice recordings remain available until transcription finishes. Supported English voice requests that mention farewells can take the request path while recognized closing phrases stay quiet.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Preserve valid multi-field Slack sections within the existing hard limits [#140805](https://github.com/openclaw/openclaw/pull/140805).
-- Preserve Markdown literals around converted tables [#139892](https://github.com/openclaw/openclaw/pull/139892).
-- Reduce repeated native-table preparation [#140167](https://github.com/openclaw/openclaw/pull/140167).
-- Prepare structured Slack reply content once per delivery attempt [#140837](https://github.com/openclaw/openclaw/pull/140837).
-- Avoid one file-data copy in shared Slack and Teams uploads [#140787](https://github.com/openclaw/openclaw/pull/140787).
-- Preserve Teams progress replies through stream settlement and fallback [#141199](https://github.com/openclaw/openclaw/pull/141199).
+- Preserve leading indentation in Discord messages and inter-session text [#139390](https://github.com/openclaw/openclaw/pull/139390). Thanks @ruel225, @yifanxiong272.
+- Skip Discord bold-normalization parsing when no underscore marker is present [#140186](https://github.com/openclaw/openclaw/pull/140186).
+- Preserve Discord persona formatting and resume mention expansion after multiline code [#140909](https://github.com/openclaw/openclaw/pull/140909).
+- Keep Discord voice recordings alive through transcription and clean them up afterward [#139484](https://github.com/openclaw/openclaw/pull/139484).
+- Let Discord voice requests that mention farewells reach the agent's forced-consult path [#141232](https://github.com/openclaw/openclaw/pull/141232).
+- Read Components v2 text and forwarded snapshots through the shared Discord starter parser [#138948](https://github.com/openclaw/openclaw/pull/138948). Thanks @marmar9615-cloud.
+
+</details>
+</Accordion>
+
+<Accordion title="Keep Slack structured replies intact">
+
+Slack delivers valid structured sections intact even when their accessibility text exceeds the preferred chunk size. Custom emoji names that happen to match JavaScript object properties remain usable, and reply preparation avoids repeating table and Markdown work without changing delivery order.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep valid Slack sections intact above fallback batching limits [#140805](https://github.com/openclaw/openclaw/pull/140805).
+- Preserve Slack custom emoji names that match JavaScript prototype keys [#136374](https://github.com/openclaw/openclaw/pull/136374). Thanks @teddytennant.
+
+**Improvements**
+
+- Compare normalized Slack text fragments without repeated copying [#139784](https://github.com/openclaw/openclaw/pull/139784).
+- Reduce temporary work when preparing Slack table replies [#140167](https://github.com/openclaw/openclaw/pull/140167).
+- Prepare Slack structured reply content once per delivery attempt [#140837](https://github.com/openclaw/openclaw/pull/140837).
 
 **Documentation**
 
-- Organize Slack setup, messaging and troubleshooting guidance while retaining existing deep links [#141061](https://github.com/openclaw/openclaw/pull/141061). Thanks @vincentkoc.
+- Organize Slack documentation by task while retaining existing deep links [#141061](https://github.com/openclaw/openclaw/pull/141061). Thanks @vincentkoc.
+
+</details>
+</Accordion>
+
+<Accordion title="Preserve Teams replies and shared uploads">
+
+Multi-part Teams progress replies keep their first segment and deliver later parts in order after stream close. Finalized replies, edits and native file captions preserve supported formatting and mention entities, while unfinished previews can still show Markdown.
+
+Shared Slack and Teams uploads avoid an extra file-data copy at handoff, and cancelled captured responses can release transport without waiting for a diagnostic copy of the body.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep the first Teams stream segment and deliver later replies after close settlement [#141551](https://github.com/openclaw/openclaw/pull/141551).
+- Preserve supported formatting and mention entities in Teams edits, native file captions and finalized streamed replies [#141348](https://github.com/openclaw/openclaw/pull/141348).
+- Avoid stalled request cleanup when HTTP capture retains a response body [#139627](https://github.com/openclaw/openclaw/pull/139627).
+
+**Improvements**
+
+- Skip empty and unmatched token formatting work in Teams [#140057](https://github.com/openclaw/openclaw/pull/140057).
+- Use immutable Blob snapshots for Slack and Teams raw file uploads [#140787](https://github.com/openclaw/openclaw/pull/140787).
 
 </details>
 </Accordion>
 
 <Accordion title="Preserve Feishu mentions and group routing">
 
-Feishu uses accepted group-binding changes on the next message and keeps mention names readable when messages are combined.
+Feishu uses accepted group-binding changes on the next message and keeps mention names readable when messages are combined. Replies to merged-forward cards include bounded, ordered forwarded content, and static replies with too many Markdown tables fall back to post delivery instead of being rejected as cards.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Preserve Feishu mention names through overlapping placeholders and combined messages [#96311](https://github.com/openclaw/openclaw/pull/96311). Thanks @sliverp.
-- Apply reloaded Feishu group bindings to new messages [#133775](https://github.com/openclaw/openclaw/pull/133775). Thanks @zxdvd and @vincentkoc.
+- Preserve Feishu mention names when placeholders overlap or messages are combined [#96311](https://github.com/openclaw/openclaw/pull/96311). Thanks @sliverp.
+- Apply reloaded Feishu group bindings using current runtime configuration [#133775](https://github.com/openclaw/openclaw/pull/133775). Thanks @zxdvd, @vincentkoc.
+- Expand quoted Feishu merged-forward content with bounded rendering [#136231](https://github.com/openclaw/openclaw/pull/136231). Thanks @heden9, @vincentkoc.
+- Use Feishu posts when generated static cards exceed five tables [#136382](https://github.com/openclaw/openclaw/pull/136382). Thanks @ltspace, @name5566, @PenguinMiaou.
+
+**Improvements**
+
+- Reuse Markdown parsing and image-reference traversal in Feishu document planning, without changing split-chunk scope or network operations [#140693](https://github.com/openclaw/openclaw/pull/140693).
+
 </details>
 </Accordion>
 
 <Accordion title="Read Matrix room information and maintain accounts">
 
-Matrix leaves archived state out of active-account selection and Doctor scans, while room information includes alternative aliases and supported disclosed polls are recognized correctly.
+Matrix leaves archived state out of active-account selection and Doctor scans. Explicit replies keep their selected quoted message inside the intended thread, and wording-only edits avoid repeating mention alerts when the required history can be read.
+
+Room information includes alternative aliases, while disclosed polls are recognized across supported event namespaces. Matrix can also start on the opt-in Bun runtime, with native crypto bindings still required for encryption and Node remaining the recommended runtime.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Leave archived Matrix state out of scans and active token selection [#112329](https://github.com/openclaw/openclaw/pull/112329). Thanks @shad0wca7.
-- Normalize Matrix poll namespaces and recognize disclosed results [#140967](https://github.com/openclaw/openclaw/pull/140967).
-- Include alternative Matrix room aliases [#140969](https://github.com/openclaw/openclaw/pull/140969).
+- Exclude archived Matrix state from Doctor scans and active token-root selection [#112329](https://github.com/openclaw/openclaw/pull/112329). Thanks @shad0wca7.
+- Preserve selected Matrix reply targets inside threads [#139479](https://github.com/openclaw/openclaw/pull/139479).
+- Calculate Matrix edit mention notifications from complete current history [#140091](https://github.com/openclaw/openclaw/pull/140091).
+- Normalize Matrix poll namespaces before displaying disclosed results [#140967](https://github.com/openclaw/openclaw/pull/140967).
+- Return Matrix alternative room aliases from existing canonical-alias state [#140969](https://github.com/openclaw/openclaw/pull/140969).
+- Remove Matrix's blanket Bun runtime rejection [#139647](https://github.com/openclaw/openclaw/pull/139647).
+
+**Improvements**
+
+- Bypass spoiler analysis when Matrix replies contain no delimiter [#139738](https://github.com/openclaw/openclaw/pull/139738).
+- Avoid account loading when Matrix Doctor finds no legacy credential files [#140382](https://github.com/openclaw/openclaw/pull/140382).
 
 </details>
 </Accordion>
 
-<Accordion title="Recover channel delivery and iMessage failures">
+<Accordion title="Recover queued replies without sending another copy">
 
-Pending or ambiguous queued deliveries remain with the recovery path instead of automatically sending another copy. iMessage helper failures also settle when their pipes close with an error, and progress visibility respects the selected settings while retaining required transport behavior such as typing indicators.
+Pending or ambiguous queued deliveries remain with the recovery owner instead of automatically sending another copy. Safely abandoned claims can be retried, and authorized reset commands can recover a chat after terminal restart-recovery failure. Accepted or uncertain injections still need to settle before their ownership is released.
+
+Deferred tool continuations discard obsolete interim answers while retaining the final reply and attachments. Broadcast results also report structured native send failures and partial outcomes accurately.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Leave pending or ambiguous delivery with its recovery owner [#139388](https://github.com/openclaw/openclaw/pull/139388).
-- Settle iMessage failures after errored helper pipes close [#140221](https://github.com/openclaw/openclaw/pull/140221).
-- Skip unnecessary inline-code formatting in iMessage replies [#139912](https://github.com/openclaw/openclaw/pull/139912).
-- Honor fast-auto progress visibility across direct and queued replies [#122221](https://github.com/openclaw/openclaw/pull/122221). Thanks @vincentkoc and @joeykrug.
-- Accept the documented IRC health-monitor switch at channel and account scope [#117302](https://github.com/openclaw/openclaw/pull/117302). Thanks @ayaangazali and @vincentkoc.
+- Preserve pending reply ownership across queued delivery failures and fallbacks [#139388](https://github.com/openclaw/openclaw/pull/139388).
+- Release abandoned queue claims while retaining genuine duplicate suppression [#139661](https://github.com/openclaw/openclaw/pull/139661). Thanks @ruel225, @obviyus, @Jackten.
+- Let authorized resets proceed after terminal restart-recovery failures [#137235](https://github.com/openclaw/openclaw/pull/137235). Thanks @LiuwqGit, @obviyus, @Denny22044.
+- Report structured native broadcast failures instead of successful counts and exit status [#139349](https://github.com/openclaw/openclaw/pull/139349).
+- Supersede obsolete deferred tool-turn text while preserving final replies and attachments [#141444](https://github.com/openclaw/openclaw/pull/141444). Thanks @hannesrudolph.
+- Preserve the recovery barrier across live frames and reconnects when draining parked Reef messages [#141127](https://github.com/openclaw/openclaw/pull/141127).
+
+</details>
+</Accordion>
+
+<Accordion title="Finish child delivery and continue the requester’s work">
+
+An answer already delivered to the main conversation stays marked as delivered when an older helper notification or history update arrives. Replies still being sent retain all their parts. Once follow-up work has been accepted by the requesting conversation, it continues under its normal runtime and Stop controls instead of inheriting the shorter notification deadline.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep subagent delivery terminal after requester settlement without truncating active multipart sends [#138821](https://github.com/openclaw/openclaw/pull/138821). Thanks @NianJiuZst, @obviyus, @josephbergvinson.
+- Stop applying the announcement timeout to accepted requester execution [#138966](https://github.com/openclaw/openclaw/pull/138966). Thanks @VACInc, @aaajiao.
+
+</details>
+</Accordion>
+
+<Accordion title="Respond to WhatsApp approvals after an outage">
+
+WhatsApp approval reactions remain available for replay after transient Gateway failures instead of being discarded prematurely. The Gateway still decides which answer is accepted first.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve WhatsApp approval reactions through transient failures and share reaction settlement across channels [#140645](https://github.com/openclaw/openclaw/pull/140645). Thanks @wangmiao0668000666.
+
+</details>
+</Accordion>
+
+<Accordion title="Follow channel progress and answer questions">
+
+Persistent progress cards keep checklists visible through tool calls and clear without erasing unrelated activity. Native subagent progress reaches the supported Slack and Discord displays, while inactive cards pause. Progress visibility follows its configured setting and retains transport behavior such as iMessage typing.
+
+Question prompts explain typed replies when a channel has no buttons, and forwarded context remains separate from the sender's own commands so quoted instructions do not execute a second time. Loopback questions are delivered to their originating channel, and cancelled unsent questions do not replay later.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Unify progress-card rendering and lifecycle across channel previews, including Telegram native checkboxes [#139206](https://github.com/openclaw/openclaw/pull/139206). Thanks @obviyus.
+- Restore native subagent progress and pause cards without an active run [#139456](https://github.com/openclaw/openclaw/pull/139456).
+- Honor fast-auto progress visibility and send one fallback only when visible progress is authorized [#122221](https://github.com/openclaw/openclaw/pull/122221). Thanks @vincentkoc, @joeykrug.
+- Use accurate typed-reply guidance in rich question prompts [#137978](https://github.com/openclaw/openclaw/pull/137978). Thanks @harshitgupta31415, @edenfunf.
+- Preserve forwarded context while separating sender commands from quoted text [#137313](https://github.com/openclaw/openclaw/pull/137313). Thanks @Marvinthebored, @Peetiegonzalez.
+- Carry channel silent-reply policy through embedded attempts [#138345](https://github.com/openclaw/openclaw/pull/138345). Thanks @Eppiedude.
+- Carry the selected agent into global-session stop handling and abort bookkeeping [#139276](https://github.com/openclaw/openclaw/pull/139276).
+- Publish loopback questions to their originating channel and retire cancelled unsent delivery claims [#138831](https://github.com/openclaw/openclaw/pull/138831). Thanks @ericcaiwx-star, @obviyus, @drsnett.
+
+</details>
+</Accordion>
+
+<Accordion title="Keep media and message formatting readable">
+
+Shared Markdown formatting preserves block boundaries inside list items and the surrounding text around fallback tables. Long blank-line runs in details replies avoid repeated formatter scans, and XML examples keep literal final tags inside Markdown code regions.
+
+Video attachments with non-square pixels display at their intended proportions, while one-off speech follows the destination channel’s final voice-versus-audio choice.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve Markdown literals and surrounding formatting when converting tables [#139892](https://github.com/openclaw/openclaw/pull/139892).
+- Preserve block boundaries within Markdown list items [#140961](https://github.com/openclaw/openclaw/pull/140961).
+- Respect non-square video pixels when sizing attachment frames [#141019](https://github.com/openclaw/openclaw/pull/141019).
+- Preserve channel-selected delivery for TTS tools and commands [#140289](https://github.com/openclaw/openclaw/pull/140289).
+- Create attachment staging directories only after the source has been read successfully [#128454](https://github.com/openclaw/openclaw/pull/128454). Thanks @MasterSwords1.
+- Remove repeated scans from long details reply formatting and related delivery normalization [#138829](https://github.com/openclaw/openclaw/pull/138829). Thanks @lzhan011, @obviyus, @vincentkoc.
+- Preserve literal final tags in code while stripping control markers outside code [#138989](https://github.com/openclaw/openclaw/pull/138989). Thanks @Alix-007, @shakkernerd.
+
+**Improvements**
+
+- Avoid adapting every select option twice during message preparation [#139737](https://github.com/openclaw/openclaw/pull/139737).
+- Defer outbound object copies until a descendant changes [#139806](https://github.com/openclaw/openclaw/pull/139806).
+- Reuse Markdown parser configuration while retaining per-document state [#141126](https://github.com/openclaw/openclaw/pull/141126).
+- Reuse admitted media positions instead of rebuilding attachment notes before execution [#141256](https://github.com/openclaw/openclaw/pull/141256).
+
+</details>
+</Accordion>
+
+<Accordion title="Connect the intended channel account">
+
+Pairing notifications come from the approved channel account, and a notification failure does not undo the approval itself. Mattermost direct messages on private servers retain the account's existing network permission, Nostr honors positive relay acknowledgements, and failed iMessage helper pipes stop leaving pending requests waiting.
+
+Signal, Discord and Mattermost select their declared WebSocket implementations on opt-in Bun installations. Account names in CLI listings remain display labels alongside stable IDs, without changing routing.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Route pairing approval notifications through the selected channel account [#137268](https://github.com/openclaw/openclaw/pull/137268). Thanks @marmar9615-cloud.
+- Carry the prepared Mattermost client through DM lookup and delivery [#139726](https://github.com/openclaw/openclaw/pull/139726).
+- Respect Nostr publish outcomes regardless of reason text [#139727](https://github.com/openclaw/openclaw/pull/139727).
+- Fail pending iMessage requests promptly on errored pipe closure [#140221](https://github.com/openclaw/openclaw/pull/140221).
+- Accept the documented IRC healthMonitor.enabled setting at channel and account scope [#117302](https://github.com/openclaw/openclaw/pull/117302). Thanks @ayaangazali, @vincentkoc.
+- Use the declared Signal WebSocket runtime consistently under Bun [#140318](https://github.com/openclaw/openclaw/pull/140318).
+- Load the installed WebSocket package explicitly for Discord and Mattermost [#141465](https://github.com/openclaw/openclaw/pull/141465).
+
+**Improvements**
+
+- Skip unused inline-code projection in iMessage formatting [#139912](https://github.com/openclaw/openclaw/pull/139912).
+- Reuse queue accounting when admitting batched inbound conversations [#139104](https://github.com/openclaw/openclaw/pull/139104).
+- Reuse external-channel manifest inventory within binding batches [#140293](https://github.com/openclaw/openclaw/pull/140293).
+- Show configured channel account names in agent provider listings alongside stable IDs [#141302](https://github.com/openclaw/openclaw/pull/141302).
 
 **Documentation**
 
-- Explain existing unmatched-agent routing without introducing an arbitrary first-agent fallback [#140194](https://github.com/openclaw/openclaw/pull/140194).
+- Clarify unmatched-route ownership and consolidate the binding cache [#140194](https://github.com/openclaw/openclaw/pull/140194).
 
 </details>
 </Accordion>
+
+<Accordion title="Keep Buzz replies at the thread root">
+
+Implicit Buzz replies stay at the active thread root, while an explicitly selected child reply keeps its nesting.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Normalize implicit Buzz replies to the active thread root [#138879](https://github.com/openclaw/openclaw/pull/138879). Thanks @sunlit-deng, @chachi-max.
+
+</details>
+</Accordion>
+
 </AccordionGroup>
 
 ## Memory
@@ -508,66 +1355,142 @@ Pending or ambiguous queued deliveries remain with the recovery path instead of 
 Memory search keeps useful notes available through more backend failures and long-running conversations, while exact filenames, older notes and readable excerpts are easier to recover. Native vector searches also spend less work starting up, with the improvement scoped to that search path.
 
 <AccordionGroup>
+
 <Accordion title="Find notes when semantic search is unavailable">
 
 Keyword indexing can continue when optional embedding credentials or providers are unavailable, so a missing optional model does not make all of your notes disappear from search. When SQLite extensions cannot load, a batched fallback scan can still return vector-backed results, although that degraded path can be costly on larger collections.
 
-Exact filenames retain their ranking in project-aware searches, and older dated notes remain eligible for keyword recall. The native vector-search path also reduces startup overhead without changing its results.
+Exact filenames retain their ranking in project-aware searches, short literal terms match note contents with Unicode case folding, and older dated notes remain eligible for keyword recall. Explicitly required embedding providers still report failures; keyword fallback does not supply semantic vectors.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Keep keyword indexing available without optional embeddings [#139463](https://github.com/openclaw/openclaw/pull/139463).
-- Use the fallback memory scan when SQLite extensions cannot load [#141104](https://github.com/openclaw/openclaw/pull/141104).
-- Preserve exact-filename ranking in project searches [#139879](https://github.com/openclaw/openclaw/pull/139879).
-- Retain keyword recall for older notes in project sessions [#140104](https://github.com/openclaw/openclaw/pull/140104).
-- Restore existing recency weighting, including short CJK queries [#139112](https://github.com/openclaw/openclaw/pull/139112).
+- Index memory notes even when optional embedding credentials or providers are unavailable [#139463](https://github.com/openclaw/openclaw/pull/139463).
+- Use the existing fallback scan when memory search cannot load SQLite extensions [#141104](https://github.com/openclaw/openclaw/pull/141104).
+- Preserve exact filename ranking and qualifying results in project-aware memory searches [#139879](https://github.com/openclaw/openclaw/pull/139879).
+- Preserve keyword recall in project sessions, including older dated notes [#140104](https://github.com/openclaw/openclaw/pull/140104).
+- Restore session recency weighting across keyword, hybrid and vector fallback recall, including short CJK queries [#139112](https://github.com/openclaw/openclaw/pull/139112).
+- Match short literal memory terms with Unicode case folding [#139777](https://github.com/openclaw/openclaw/pull/139777).
+- Split embedding batches after numeric provider row-cap errors [#138391](https://github.com/openclaw/openclaw/pull/138391). Thanks @teddytennant, @saladinyao-cyber, @obviyus, @fisherman86-ai.
 
 **Improvements**
 
-- Reduce native vector-search startup overhead, measured with a Linux fixture [#140730](https://github.com/openclaw/openclaw/pull/140730). Thanks @NianJiuZst and @obviyus.
-
-**Limits and compatibility**
-
-- Explicitly required embedding providers still report failures; keyword fallback does not supply semantic vectors. Node remains recommended for native sqlite-vec on macOS.
+- Reduce native vector-search startup overhead while preserving memory results [#140730](https://github.com/openclaw/openclaw/pull/140730). Thanks @NianJiuZst, @obviyus, @justinkirklin-gif.
 
 </details>
 </Accordion>
 
-<Accordion title="Keep long conversations from reimporting old memories">
+<Accordion title="Search while memory maintenance continues">
 
-Appending to a long conversation now resumes memory ingestion from a validated transcript prefix, avoiding repeated imports caused by the old seen-message window rolling over. Existing memory history stays intact, while edits and truncations still take the conservative rescan path.
+Published memory remains searchable while changed-file writes and cleanup contend for database access. Deadline recovery can return memory-file keyword hits with a warning, while session hits remain outside that fallback. Large state replacements and clears also yield between batches so other queued work can proceed.
 
-Promotion previews also remove blocked-origin entries before ranking, leaving the limited preview space for eligible notes.
+When results may be stale, Memories shows the existing rebuild command with its warning. Exhausted file-watcher capacity falls back to the existing synchronization path, although an initial search may still use the previous index while that refresh finishes.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Resume append-only transcript ingestion without replaying consumed messages [#119367](https://github.com/openclaw/openclaw/pull/119367). Thanks @jalehman and @guarismo.
-- Exclude untrusted and system-origin recall entries before ranking promotion previews [#121287](https://github.com/openclaw/openclaw/pull/121287). Thanks @hydraxman and @bryan.
+- Keep memory search responsive during concurrent maintenance [#139698](https://github.com/openclaw/openclaw/pull/139698). Thanks @anyech, @hannesrudolph.
+- Make memory deletion and cache pruning use cooperative write admission [#139821](https://github.com/openclaw/openclaw/pull/139821). Thanks @anyech, @hannesrudolph.
+- Fall back to existing synchronization after memory and skill watcher exhaustion [#137105](https://github.com/openclaw/openclaw/pull/137105). Thanks @ericcaiwx-star, @singletrackandrew, @obviyus.
+- Yield between batches of memory workspace state writes [#141613](https://github.com/openclaw/openclaw/pull/141613).
+
+**Improvements**
+
+- Display stale memory search warnings and index-rebuild guidance [#140350](https://github.com/openclaw/openclaw/pull/140350).
+- Show collected llama.cpp diagnostics with memory status --index [#141461](https://github.com/openclaw/openclaw/pull/141461).
+
+</details>
+</Accordion>
+
+<Accordion title="Avoid repeated memories from long conversations">
+
+Adding messages to a long conversation now resumes memory import from the previously verified position, avoiding repeated imports of earlier messages. Existing memory history stays intact, while edits and truncations still trigger a conservative rescan.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Resume memory ingestion from a validated transcript prefix instead of replaying consumed messages [#119367](https://github.com/openclaw/openclaw/pull/119367). Thanks @jalehman, @guarismo.
+
+</details>
+</Accordion>
+
+<Accordion title="Keep memory maintenance within the current context budget">
+
+OpenClaw-managed compaction accounts for the full incoming request once that context is prepared, and background memory work stays separate from human prompts. Cold sessions use their prepared model’s context limits while honoring smaller explicit caps, and transcript growth after the last provider report contributes to fresh accounting.
+
+In the built-in agent loop, cancelled or failed tool turns no longer commit unfinished exchanges to context-engine memory. Native runtimes retain their own compaction behavior.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Use prepared model context limits for cold-Gateway maintenance [#137440](https://github.com/openclaw/openclaw/pull/137440). Thanks @shojikumaru.
+- Budget automatic compaction for the full request and isolate background memory work [#139822](https://github.com/openclaw/openclaw/pull/139822).
+- Commit embedded tool-turn context only after the logical turn is accepted [#140024](https://github.com/openclaw/openclaw/pull/140024).
+- Include trailing transcript growth in memory-maintenance token accounting [#138928](https://github.com/openclaw/openclaw/pull/138928). Thanks @chelsealong.
+
+**Improvements**
+
+- Reduce repeated allocation while preparing project-memory prompts [#139650](https://github.com/openclaw/openclaw/pull/139650).
+- Adopt owned bounded transcript entries into detached memory-flush sessions without a redundant copy [#140669](https://github.com/openclaw/openclaw/pull/140669).
+
+</details>
+</Accordion>
+
+<Accordion title="Recall the current question">
+
+LanceDB automatic recall follows the current question when a conversation changes topic. Promotion previews remove blocked-origin entries before ranking, leaving their limited space for eligible notes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Use the current prompt for LanceDB automatic recall [#141521](https://github.com/openclaw/openclaw/pull/141521).
+- Exclude untrusted and system-origin recall entries before ranking promotion previews [#121287](https://github.com/openclaw/openclaw/pull/121287). Thanks @hydraxman, @bryan.
+
+</details>
+</Accordion>
+
+<Accordion title="Use the prepared LM Studio embedding model">
+
+LM Studio embeddings use the prepared model instance and its context capacity, and can reload an evicted embedding model when preloading is enabled. Existing cached vectors are retained rather than recomputed by these fixes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Reload evicted LM Studio embedding models before requests [#141450](https://github.com/openclaw/openclaw/pull/141450).
+- Route LM Studio embeddings to the prepared context-capacity instance [#141513](https://github.com/openclaw/openclaw/pull/141513).
 
 </details>
 </Accordion>
 
 <Accordion title="Read memory results and diagnose failed imports">
 
-Memory and Import Memory now show agent-list errors with a usable retry instead of remaining in a loading cycle. Reads from additional memory folders report relevant permission or file errors, and cited excerpts keep the leading spaces and tabs that make code and structured notes readable.
+Memory and Import Memory show agent-list errors with a usable retry instead of remaining in a loading cycle. Reads from additional memory folders report relevant permission or file errors, and skipped symlink roots point to their canonical directories without silently rewriting the configuration.
 
-For scripts, memory commands distinguish a disabled backend, a backend that failed to open, and a successful search with no results.
+Cited excerpts keep the leading spaces and tabs that make code and structured notes readable. Profile workspaces and Termux home paths are honored by memory-host lookups, while command JSON distinguishes a disabled backend, a backend that failed to open, and a successful search with no results.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- Show agent-list failures on Memory and Import Memory pages [#139899](https://github.com/openclaw/openclaw/pull/139899).
-- Report relevant permission and I/O errors in extra-memory roots without exposing unrelated errors to unauthorized readers [#139402](https://github.com/openclaw/openclaw/pull/139402). Thanks @SebTardif and @obviyus.
-- Preserve indentation in cited memory excerpts [#140471](https://github.com/openclaw/openclaw/pull/140471).
-- Return explicit JSON for disabled or unavailable memory backends [#140229](https://github.com/openclaw/openclaw/pull/140229).
+- Show agent-list errors in Memory and Import Memory instead of repeatedly loading [#139899](https://github.com/openclaw/openclaw/pull/139899).
+- Report relevant permission and I/O errors when reading extra-memory notes [#139402](https://github.com/openclaw/openclaw/pull/139402). Thanks @SebTardif, @obviyus.
+- Report skipped symlink memory roots with recovery guidance [#140381](https://github.com/openclaw/openclaw/pull/140381). Thanks @ruel225, @gaoanze888, @obviyus, @oshaughnessy-junior.
+- Preserve leading spaces and tabs when adding citations to memory-search snippets [#140471](https://github.com/openclaw/openclaw/pull/140471).
+- Honor profile workspaces and Termux home paths in memory-host file lookups [#140984](https://github.com/openclaw/openclaw/pull/140984).
+- Return explicit JSON when memory commands are disabled or cannot open their backend [#140229](https://github.com/openclaw/openclaw/pull/140229).
 
 **Documentation**
 
@@ -575,6 +1498,31 @@ For scripts, memory commands distinguish a disabled backend, a backend that fail
 
 </details>
 </Accordion>
+
+<Accordion title="Read and index larger notes with less repeated work">
+
+Long lines and weighted Unicode stay within embedding chunk budgets, and searches can rebuild an index after the chunking version changes. Curated annotations are scanned without repeated parser work while preserving their recall metadata and project isolation.
+
+Small excerpts from large notes can be selected in one forward pass while preserving continuation offsets and the existing output budget. Memory Wiki pages without link brackets skip unnecessary link parsing, and indexing reuses prepared database statements within each nonempty file.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Select bounded memory-note lines in one forward pass while preserving continuation offsets [#140634](https://github.com/openclaw/openclaw/pull/140634).
+- Skip link-tree parsing for bracket-free Memory Wiki pages while retaining frontmatter validation [#140613](https://github.com/openclaw/openclaw/pull/140613).
+- Reuse typed SQLite statements while publishing memory chunks, recall metadata and provenance [#139350](https://github.com/openclaw/openclaw/pull/139350).
+- Avoid unused default-owner roster work when preparing memory tools for an already-selected agent [#141376](https://github.com/openclaw/openclaw/pull/141376).
+
+**Bug fixes**
+
+- Bound memory overlap and Unicode chunk weights, with search-time chunking-version recovery [#138798](https://github.com/openclaw/openclaw/pull/138798). Thanks @wangjx-xydt, @badmutt.
+- Scan curated annotations linearly while retaining recall metadata and project isolation [#138995](https://github.com/openclaw/openclaw/pull/138995). Thanks @lzhan011, @obviyus.
+
+</details>
+</Accordion>
+
 </AccordionGroup>
 
 ## Skills
@@ -597,6 +1545,10 @@ Startup and Doctor migrate legacy skills when ownership is established. Ambiguou
 - Give every agent its own Skill Workshop and migrate safely owned legacy skills through Doctor. [#135528](https://github.com/openclaw/openclaw/pull/135528) Thanks @obviyus.
 - Simplify Workshop to Skills and Suggestions and show installed-skill differences. [#140105](https://github.com/openclaw/openclaw/pull/140105) Thanks @obviyus.
 
+**Bug fixes**
+
+- Distinguish installed Workshop skills, pending suggestions and retained past decisions. [#139842](https://github.com/openclaw/openclaw/pull/139842) Thanks @obviyus.
+
 </details>
 
 </Accordion>
@@ -618,6 +1570,8 @@ Collection reviews are also instructed to look across related skills while prese
 **Bug fixes**
 
 - Compare complete skill instructions with inline additions and removals. [#140300](https://github.com/openclaw/openclaw/pull/140300) Thanks @obviyus.
+- Simplify Workshop revision routing and preserve inherited review model settings. [#139760](https://github.com/openclaw/openclaw/pull/139760) Thanks @obviyus.
+- Ground Workshop review reads in known generated skills. [725b76a93a](https://github.com/openclaw/openclaw/commit/725b76a93ae2514fb9f832aedb98d7d67b53a7eb)
 
 </details>
 
@@ -655,12 +1609,16 @@ Skill-library creation and import forms check names before continuing and explai
 - Sanitize skills JSON during serialization while preserving output bytes. [#140581](https://github.com/openclaw/openclaw/pull/140581)
 - Detach cached local skill metadata from full source strings. [#139478](https://github.com/openclaw/openclaw/pull/139478)
 - Share concurrent node-host skill-bin refreshes within the same Gateway connection. [#127113](https://github.com/openclaw/openclaw/pull/127113)
+- Reject ignored watcher entries before path normalization. [#139713](https://github.com/openclaw/openclaw/pull/139713)
+- Use metadata projections to avoid redundant archive copies during ZIP import commits. [#139014](https://github.com/openclaw/openclaw/pull/139014)
 
 **Bug fixes**
 
 - Enforce existing skill-name rules in library editor and import forms. [#139184](https://github.com/openclaw/openclaw/pull/139184)
 - Preserve whitespace in skills list, info and check JSON output. [#140780](https://github.com/openclaw/openclaw/pull/140780)
 - Skip retry delays for confirmed-absent ClawHub workspace tracking. [#140958](https://github.com/openclaw/openclaw/pull/140958)
+- Recognize the Workshop container before nested-root promotion. [#139827](https://github.com/openclaw/openclaw/pull/139827)
+- Make status --all agree with skills check on missing prerequisites. [#141618](https://github.com/openclaw/openclaw/pull/141618)
 
 **Documentation**
 
@@ -687,6 +1645,28 @@ Pending Workshop approval requests also regain their Allow Once and Deny control
 **Bug fixes**
 
 - Restore pending Workshop approval buttons by signing requests with the Workspace Skills owner. [#139248](https://github.com/openclaw/openclaw/pull/139248) Thanks @gaoanze888, @khaisis, @stemkat100.
+- Review retained conversation context for durable skill learning. [#139656](https://github.com/openclaw/openclaw/pull/139656) Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Follow weekly collection reviews">
+
+In auto mode, weekly Workshop reviews now run as ordinary isolated automations, with file discovery and run history available through that workflow. They review the agent’s collection using ordinary file edits, so completed changes remain if a later step fails or is cancelled; there is no new whole-collection backup or automatic rollback.
+
+Reviews need a supported backend, such as the embedded runtime or a compatible restricted Claude CLI backend. If sandboxing is enabled, it must allow writes to the Workshop. Codex-harness and node-placed CLI reviews remain unsupported.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Run weekly Workshop review as an ordinary isolated automation. [#136110](https://github.com/openclaw/openclaw/pull/136110) Thanks @obviyus.
+
+**Documentation**
+
+- Correct weekly Workshop collection-review documentation. [#139812](https://github.com/openclaw/openclaw/pull/139812)
 
 </details>
 
@@ -725,6 +1705,7 @@ When the keyboard leaves little height, chat extras move into Details so your dr
 - Keep Android Chat actions and attachment menus clear of fold hinges. [#140884](https://github.com/openclaw/openclaw/pull/140884) Thanks @vincentkoc.
 - Constrain Android model picker sheets and invalidate stale openings after layout changes. [#140896](https://github.com/openclaw/openclaw/pull/140896) Thanks @vincentkoc.
 - Keep Gateway trust, QR errors, Replace and Forget prompts within a hinge-free region with scrolling actions. [#140694](https://github.com/openclaw/openclaw/pull/140694) Thanks @vincentkoc.
+- Let Android settings controls move below complete wrapped labels. [#139789](https://github.com/openclaw/openclaw/pull/139789)
 
 </details>
 
@@ -732,9 +1713,9 @@ When the keyboard leaves little height, chat extras move into Details so your dr
 
 <Accordion title="Keep Android conversations and settings current">
 
-Android keeps completed runs settled when delayed history or send acknowledgements arrive, and overlapping history requests no longer leave the chat’s health refresh unfinished. Resolved approval cards disappear together with their outcome, while a failed file share leaves the preview open so you can retry.
+You can send a follow-up while Android is working without clearing that run’s output, and reopened chats return to the latest content while manual scrolling still pauses following. Android keeps completed runs settled when delayed history or send acknowledgements arrive, and overlapping history requests no longer leave the chat’s health refresh unfinished. Resolved approval cards disappear together with their outcome, while a failed file share leaves the preview open so you can retry.
 
-Settings search finds existing options by name or category, and model settings follow the selected agent’s credentials and accepted configuration changes. Failed model refreshes show a warning while preserving choices and drafts, with another attempt available through Refresh chat.
+During prolonged outages, Android backs off repeated reconnect attempts and resumes retrying when the network returns. Settings search finds existing options by name or category, and model settings follow the selected agent’s credentials and accepted configuration changes. Failed model refreshes show a warning while preserving choices and drafts, with another attempt available through Refresh chat.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -752,6 +1733,43 @@ Settings search finds existing options by name or category, and model settings f
 - Show Android model credentials and status for the selected agent. [#140130](https://github.com/openclaw/openclaw/pull/140130) Thanks @obviyus.
 - Refresh Android Providers and Models after Gateway configuration events. [#140796](https://github.com/openclaw/openclaw/pull/140796) Thanks @obviyus.
 - Show Android model refresh failures and retry them with Refresh chat. [#140899](https://github.com/openclaw/openclaw/pull/140899) Thanks @obviyus.
+- Restore reopened Android chats at their latest content. [#137682](https://github.com/openclaw/openclaw/pull/137682) Thanks @IWhatsskill.
+- Retain bounded secondary-Gateway reconnection requests through lifecycle transitions. [#139319](https://github.com/openclaw/openclaw/pull/139319)
+- Allow Android follow-ups while preserving run output and Talk ownership. [#139728](https://github.com/openclaw/openclaw/pull/139728) Thanks @IWhatsskill, @fuller-stack-dev.
+- Back off Android Gateway retries while preserving network and manual recovery. [#138732](https://github.com/openclaw/openclaw/pull/138732) Thanks @IWhatsskill, @masatohoshino.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Understand Android model usage">
+
+Android’s compact Model sheet keeps more of the conversation visible while distinguishing the space left in the current context from the latest run’s accumulated usage. Stale counters clear after compaction and history refresh, and optional model-call details remain available without treating unknown usage as zero.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Compact Android's Model sheet and preserve accurate cached usage boundaries. [#137494](https://github.com/openclaw/openclaw/pull/137494) Thanks @IWhatsskill.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use Dashboard settings on Apple devices">
+
+The Mac and iOS apps now bring connected administrator settings into Dashboard while keeping connection setup and offline recovery in native controls. Older Gateways need the matching Dashboard support, and sensitive device-capability changes still require native consent.
+
+On iOS, saved app-local Talk provider, voice and language overrides are retired in favor of the Gateway’s Talk configuration. The old default share instruction is also retired; instructions supplied with an individual share remain available.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Move macOS app settings into Dashboard and retain native Connection recovery. [#138092](https://github.com/openclaw/openclaw/pull/138092)
+- Move iOS settings into the Dashboard while keeping connection recovery native. [#139514](https://github.com/openclaw/openclaw/pull/139514)
 
 </details>
 
@@ -792,7 +1810,24 @@ New local messages retain their identity and place in the conversation when hist
 
 </Accordion>
 
+<Accordion title="Connect Apple Watch voice">
+
+Normal Apple Watch setup now includes voice authorization in the same connection action. Existing Watches connected only as nodes need to reconnect, and starting a voice conversation still requires Start and microphone permission.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Unify Apple Watch connection into one voice-capable setup action. [#139712](https://github.com/openclaw/openclaw/pull/139712)
+
+</details>
+
+</Accordion>
+
 <Accordion title="Manage Mac connections and daily costs">
+
+The permanent Gateways menu opens or focuses a window for each connection and shows live status while the menu is open. The Mac automation menu also counts every enabled job for the selected primary Gateway.
 
 The Mac Connection window uses native Settings controls and toolbar tabs, and Gateway alerts can appear without blocking app shutdown. Today’s cost totals follow the Mac’s local calendar day, including daylight-saving changes.
 
@@ -802,15 +1837,48 @@ The Mac Connection window uses native Settings controls and toolbar tabs, and Ga
 **Improvements**
 
 - Rebuild the Mac Connection window with native Settings controls and toolbar tabs. [#140756](https://github.com/openclaw/openclaw/pull/140756)
+- Open Gateway windows from the permanent macOS Gateways menu. [#139522](https://github.com/openclaw/openclaw/pull/139522)
+- Add live Gateway status cards to the macOS menu. [#139688](https://github.com/openclaw/openclaw/pull/139688)
 
 **Bug fixes**
 
 - Replace blocking Gateway alert loops with dashboard sheets or non-modal panels. [#140575](https://github.com/openclaw/openclaw/pull/140575)
 - Align Mac menu cost totals with local time zones and daylight-saving boundaries. [#140863](https://github.com/openclaw/openclaw/pull/140863)
+- Use the Gateway's full enabled-automation count on macOS. [#139692](https://github.com/openclaw/openclaw/pull/139692)
 
 **Documentation**
 
 - Document macOS 15 as the native app minimum and separate voice and source-build requirements. [#140578](https://github.com/openclaw/openclaw/pull/140578)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Control Mac app connections from a shell">
+
+The bundled `openclaw-mac` command lets you inspect and configure the running app’s primary and saved Gateway connections from Terminal or SSH. The app retains ownership of Keychain access, and running-app commands accept secrets through protected files or standard input. A saved connection still needs to connect successfully before it is ready to use.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Bundle openclaw-mac with commands for primary and saved Gateway connections. [#141490](https://github.com/openclaw/openclaw/pull/141490)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Use interactive replies on Linux">
+
+Linux widget replies stay connected, and Quick Chat reopens in the right place so its controls stay usable.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep Linux widget replies connected and position native child views correctly. [#139664](https://github.com/openclaw/openclaw/pull/139664)
 
 </details>
 
@@ -834,6 +1902,11 @@ Persistent paired computers retain the current worker build between sessions, av
 - Refresh generated native app translations. [#141089](https://github.com/openclaw/openclaw/pull/141089)
 - Refresh generated Android, Apple and Watch locale resources. [#139237](https://github.com/openclaw/openclaw/pull/139237)
 - Refresh generated native app translations. [#140874](https://github.com/openclaw/openclaw/pull/140874)
+- Refresh native app translations. [#139655](https://github.com/openclaw/openclaw/pull/139655)
+- Refresh native app translation resources. [#141543](https://github.com/openclaw/openclaw/pull/141543)
+- Refine Mac provider setup and conversation wording. [fd0b89a59e](https://github.com/openclaw/openclaw/commit/fd0b89a59e11b99a8838a12a2dbfd83b110708ea)
+- Refresh native app and watch translations across existing languages. [13eea8e7f7](https://github.com/openclaw/openclaw/commit/13eea8e7f749a928a6e5f5dd50c050f253ce0019)
+- Clarify partial session-list counts and native translator guidance. [2f1d6cf63c](https://github.com/openclaw/openclaw/commit/2f1d6cf63c88c42aee6ee65a95e62010ab7e4a7e)
 
 **Bug fixes**
 
@@ -843,6 +1916,8 @@ Persistent paired computers retain the current worker build between sessions, av
 - Preserve secondary framework architectures during universal macOS packaging. [#141056](https://github.com/openclaw/openclaw/pull/141056)
 - Restore the desktop tray's Stop Gateway action while retaining graceful shutdown and restart. [#139241](https://github.com/openclaw/openclaw/pull/139241)
 - Fix Swabble executable invocation and configuration/output path binding. [#140291](https://github.com/openclaw/openclaw/pull/140291)
+- Protect fresh Android operator tokens from stale reconnect writes and clears. [#141518](https://github.com/openclaw/openclaw/pull/141518)
+- Recognize versioned and case-insensitive macOS platform labels for Canvas. [#138958](https://github.com/openclaw/openclaw/pull/138958) Thanks @Colton-Harris.
 
 </details>
 
@@ -858,7 +1933,7 @@ Models settings adds controls for individual connected accounts, while model sel
 
 <Accordion title="Choose which connected account to use">
 
-Administrators can see each provider account’s credential source and health in Models settings, change supported account priority for the selected agent, and sign out of one account without disconnecting the others. Clearing a custom order removes the saved priority while leaving accounts connected; inherited and provider-managed orders explain their restrictions. When an explicitly selected account disappears, OpenClaw keeps that choice and offers recovery guidance instead of silently choosing another account.
+Administrators can see each provider account’s credential source and health in Models settings, change supported account priority for the selected agent, and sign out of one account without disconnecting the others. Clearing a custom order removes the saved priority while leaving accounts connected; inherited and provider-managed orders explain their restrictions. When an explicitly selected account disappears, OpenClaw keeps that choice and offers recovery guidance instead of silently choosing another account. Missing environment-backed credentials are reported locally, so restore the environment value and reload secrets on a running Gateway before retrying.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -871,6 +1946,10 @@ Administrators can see each provider account’s credential source and health in
 
 - Keep selected account metadata through authentication planning. [#139413](https://github.com/openclaw/openclaw/pull/139413)
 - MiniMax model discovery no longer borrows another account's credentials. [#140438](https://github.com/openclaw/openclaw/pull/140438) Thanks @shakkernerd.
+- Keep model discovery bound to the configured usable auth profile. [#137120](https://github.com/openclaw/openclaw/pull/137120) Thanks @shakkernerd.
+- Report already-resolved configured credentials by their non-secret source marker in model status. [#141354](https://github.com/openclaw/openclaw/pull/141354) Thanks @obviyus.
+- Give catalog hooks their active provider's resolved runtime headers. [#141402](https://github.com/openclaw/openclaw/pull/141402) Thanks @obviyus.
+- Stop sending missing environment-variable names as catalog credentials and preserve selected-account identity. [#140657](https://github.com/openclaw/openclaw/pull/140657) Thanks @shakkernerd.
 
 </details>
 
@@ -878,7 +1957,7 @@ Administrators can see each provider account’s credential source and health in
 
 <Accordion title="Choose an ordered fallback chain">
 
-Agents settings now offers searchable model choices for building a fallback chain. Selected models appear as removable chips in priority order, and you can still add a custom model reference when it is not in the catalog.
+Agents settings now offers searchable model choices for building a fallback chain. Selected models appear as removable chips in priority order, and you can still add a custom model reference when it is not in the catalog. Session diagnostics can also show which fallback completed the answer while keeping your selected primary model distinct.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -887,6 +1966,10 @@ Agents settings now offers searchable model choices for building a fallback chai
 
 - Choose ordered fallback models from a searchable catalog, remove choices and add custom references. [#141330](https://github.com/openclaw/openclaw/pull/141330) Thanks @shakkernerd and @najef1979-code.
 
+**Bug fixes**
+
+- Show the completed fallback model in session diagnostics. [#141396](https://github.com/openclaw/openclaw/pull/141396) Thanks @obviyus.
+
 </details>
 
 </Accordion>
@@ -894,6 +1977,8 @@ Agents settings now offers searchable model choices for building a fallback chai
 <Accordion title="Continue through temporary provider failures">
 
 Temporary rate limits and other eligible provider failures can recover within the same run, keeping completed tool work and attachments available and the recovered answer together. Retry waits remain cancellable, and a terminal error stays visible when recovery is exhausted. Authentication failures, billing problems and refusals retain their own handling, while exhausted usage windows can move to an eligible fallback.
+
+After an eligible transient WebSocket failure, a tool-free final answer can use already-completed work without replaying its actions.
 
 CLI-backed background work also keeps its existing bounded allowance while work or native input remains pending, rather than being stopped as though nothing were happening.
 
@@ -904,14 +1989,15 @@ CLI-backed background work also keeps its existing bounded allowance while work 
 
 - Continue agent tasks after temporary rate limits with bounded, cancellable backoff. [#139397](https://github.com/openclaw/openclaw/pull/139397)
 - Keep rate-limit retries transient and recovered chat replies together. [#139465](https://github.com/openclaw/openclaw/pull/139465)
-- Respect the existing quiet-work allowance when CLI background tasks or native input remain pending. [#132459](https://github.com/openclaw/openclaw/pull/132459) Thanks @LiuwqGit, @obviyus.
+- Respect the existing quiet-work allowance when CLI background tasks or native input remain pending. [#132459](https://github.com/openclaw/openclaw/pull/132459) Thanks @LiuwqGit, @obviyus, @bytrustu.
 - Skip provider-catalog rewarming for ordinary rate-limit cooldowns. [#125906](https://github.com/openclaw/openclaw/pull/125906) Thanks @Grynn.
-- Report safe reasons for Codex history recovery rejection. [#139933](https://github.com/openclaw/openclaw/pull/139933) Thanks @be-student, @obviyus.
+- Report safe reasons for Codex history recovery rejection. [#139933](https://github.com/openclaw/openclaw/pull/139933) Thanks @be-student, @obviyus, @fray-ai.
 - Retire stale metadata refresh work without losing failed-provider state. [#139192](https://github.com/openclaw/openclaw/pull/139192)
 - Retain settled failed Codex threads for guarded continuation and preserve policy-refusal classification. [#139246](https://github.com/openclaw/openclaw/pull/139246) Thanks @Colton-Harris, @obviyus.
 - Apply the model idle watchdog to silent WebSocket streams with parked consumers. [#140335](https://github.com/openclaw/openclaw/pull/140335) Thanks @VACInc.
 - Require a real reasoning constraint before retrying with a different thinking level. [#139295](https://github.com/openclaw/openclaw/pull/139295)
 - Preserve explicit account selections, request context and cleanup ownership during recovery. [#140973](https://github.com/openclaw/openclaw/pull/140973)
+- Recover tool-free final answers from classified transient WebSocket failures. [#138985](https://github.com/openclaw/openclaw/pull/138985) Thanks @VACInc.
 
 </details>
 
@@ -921,7 +2007,7 @@ CLI-backed background work also keeps its existing bounded allowance while work 
 
 Ordinary model changes now apply to the current chat by default, including administrator selections, while explicitly configured agent or global scopes remain available.
 
-Local and CLI-backed model views now preserve the selected agent and canonical provider, and managed Codex conversations use a newly selected model on subsequent turns. Native-owned sessions retain their own selection rules. Missing environment-backed credentials are reported locally, so restore the environment value and reload secrets on a running Gateway before retrying. Catalog refreshes keep compatible previously discovered choices available when a refresh fails, without hiding that failure or treating missing credentials as usable access.
+Local and CLI-backed model views now preserve the selected agent and canonical provider, and managed Codex conversations use a newly selected model on subsequent turns. Native-owned sessions retain their own selection rules.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -934,27 +2020,21 @@ Local and CLI-backed model views now preserve the selected agent and canonical p
 - Show the canonical provider after local terminal model changes. [#139990](https://github.com/openclaw/openclaw/pull/139990) Thanks @ly85206559.
 - Keep case-distinct configured models separate in catalogs and CLI output. [#139991](https://github.com/openclaw/openclaw/pull/139991) Thanks @obviyus.
 - Prevent case-distinct model status routes from mixing. [#140099](https://github.com/openclaw/openclaw/pull/140099) Thanks @ly85206559.
-- Keep compatible learned model choices after a failed provider refresh. [#139357](https://github.com/openclaw/openclaw/pull/139357) Thanks @obviyus.
-- Refresh agent model choices when the catalog changes. [#139916](https://github.com/openclaw/openclaw/pull/139916) Thanks @obviyus.
-- Stop OAuth fallback after catalog discovery times out. [#139924](https://github.com/openclaw/openclaw/pull/139924) Thanks @shakkernerd.
-- Retain compatible full-catalog models and report profile failures when OAuth preparation fails. [#139951](https://github.com/openclaw/openclaw/pull/139951) Thanks @shakkernerd.
-- Preserve plugin catalog results for later discovery after an earlier request times out. [#140441](https://github.com/openclaw/openclaw/pull/140441) Thanks @shakkernerd.
 - Keep provider options and stream hooks bound to the prepared provider for each attempt. [#139101](https://github.com/openclaw/openclaw/pull/139101)
 - Pass the selected provider and model to Codex prompt hooks when OpenClaw owns selection. [#140488](https://github.com/openclaw/openclaw/pull/140488)
 - Bind queued compaction to one admitted runtime configuration. [#139429](https://github.com/openclaw/openclaw/pull/139429)
-- Reduce cold Gateway stalls during model-runtime registration. [#139911](https://github.com/openclaw/openclaw/pull/139911)
-- Keep downloaded hosted catalogs inactive until a full Gateway restart. [#140086](https://github.com/openclaw/openclaw/pull/140086) Thanks @obviyus.
-- Skip paired-node discovery for local-only catalog pages. [#140090](https://github.com/openclaw/openclaw/pull/140090)
 - Keep model-status plugin metadata scoped to its own operation. [#140506](https://github.com/openclaw/openclaw/pull/140506)
 - Preserve unset model defaults when signing in to a provider without opting in to a new default. [#139218](https://github.com/openclaw/openclaw/pull/139218) Thanks @obviyus.
 - Default ordinary chat model selections to session scope, including administrator choices. [#139232](https://github.com/openclaw/openclaw/pull/139232) Thanks @obviyus.
-- Make the Google manifest own the bundled Gemini catalog used by Doctor and runtime fallback. [#139243](https://github.com/openclaw/openclaw/pull/139243) Thanks @LiuwqGit, @vincentkoc.
-- Keep xAI OAuth setup on the subscription catalog and resolve automatic selection at inference dispatch. [#140610](https://github.com/openclaw/openclaw/pull/140610) Thanks @DonnieFi.
 - Use low as Astra's ordinary thinking default across OpenClaw and Codex. [#140625](https://github.com/openclaw/openclaw/pull/140625)
-- Avoid duplicate xAI OAuth refresh attempts during model discovery. [#140434](https://github.com/openclaw/openclaw/pull/140434) Thanks @shakkernerd.
 - Clamp configured output tokens to the model's final context window. [#140436](https://github.com/openclaw/openclaw/pull/140436)
-- Keep Grok token model discovery on the subscription endpoint with the selected credential. [#140653](https://github.com/openclaw/openclaw/pull/140653) Thanks @shakkernerd.
-- Stop sending missing environment-variable names as catalog credentials and preserve selected-account identity. [#140657](https://github.com/openclaw/openclaw/pull/140657) Thanks @shakkernerd.
+- Retain configured alias tags on filtered model-list rows missing from the catalog. [#141234](https://github.com/openclaw/openclaw/pull/141234)
+- Show an agent's inherited global primary in model pickers when it configures only fallbacks. [#141293](https://github.com/openclaw/openclaw/pull/141293) Thanks @obviyus.
+- Honor native CLI auth availability over contradictory provider registry hints. [#141654](https://github.com/openclaw/openclaw/pull/141654) Thanks @obviyus.
+
+**Improvements**
+
+- Load Gemini model-family policy through a lightweight shared entrypoint. [#140922](https://github.com/openclaw/openclaw/pull/140922)
 
 **Limits and compatibility**
 
@@ -980,10 +2060,12 @@ Supported Amazon Nova models on Bedrock also gain opt-in prompt caching with a f
 
 - Add opt-in five-minute prompt caching for supported Amazon Nova models on Bedrock. [#141060](https://github.com/openclaw/openclaw/pull/141060)
 - Honor native OpenAI cache routing and model-specific retention settings. [#140853](https://github.com/openclaw/openclaw/pull/140853)
+- Reuse tool-result costs within one cache-TTL pruning pass. [#139874](https://github.com/openclaw/openclaw/pull/139874)
+- Avoid repeated tool-name preparation while preserving complete prompt bytes. [#141192](https://github.com/openclaw/openclaw/pull/141192)
 
 **Bug fixes**
 
-- Keep Claude CLI conversation prefixes stable across workspace edits and commits. [#140566](https://github.com/openclaw/openclaw/pull/140566) Thanks @VACInc.
+- Keep Claude CLI conversation prefixes stable across workspace edits and commits by disabling its startup Git snapshot and bundled Git commit/PR instructions. Git tools and workspace instructions remain available. [#140566](https://github.com/openclaw/openclaw/pull/140566) Thanks @VACInc.
 - Keep message-action and native Ollama tool ordering stable for prompt caching. [#140698](https://github.com/openclaw/openclaw/pull/140698)
 - Refresh the cache-pruning clock after successful model requests in tool loops. [#140713](https://github.com/openclaw/openclaw/pull/140713)
 - Include the final assembled system prompt in managed Gemini caches. [#140744](https://github.com/openclaw/openclaw/pull/140744)
@@ -1022,6 +2104,10 @@ Cost estimates preserve already recorded service-tier prices and apply the corre
 - Keep recorded service-tier costs and correctly price new Anthropic fast-mode requests. [#141059](https://github.com/openclaw/openclaw/pull/141059)
 - Restore cache and billing counters for Codex /btw side questions. [#141080](https://github.com/openclaw/openclaw/pull/141080)
 
+**Improvements**
+
+- Defer Ollama usage estimation until a provider counter is unavailable. [#139852](https://github.com/openclaw/openclaw/pull/139852)
+
 </details>
 
 </Accordion>
@@ -1030,7 +2116,9 @@ Cost estimates preserve already recorded service-tier prices and apply the corre
 
 [LM Studio](/providers/lmstudio) now budgets against the context of the loaded model instance, and with preload enabled sends chat to an instance that has enough room. If a new instance is loaded, the request uses its returned identity while your configured model reference stays the same. This avoids budgeting for a larger instance and then sending the conversation to a smaller one.
 
-Native Ollama requests honor per-request sampling overrides, including explicit zero values. Fresh llama.cpp installation allows time for the first macOS security check, and managed installs receive updated runtime binaries.
+Local model setup preserves other agents’ capabilities and defaults to compact tool discovery. Run `openclaw doctor --fix` if an upgrade reports retired local-model setup markers.
+
+Native Ollama avoids silently truncating history when a conversation exceeds its available context. Its requests honor per-request sampling overrides, including explicit zero values, and retained reasoning stays with tool follow-ups without becoming visible answer text. Setup rejects models known to support embeddings alone before selecting them for chat. llama.cpp preparation also preserves configured preset defaults, comments and unmanaged options. Fresh llama.cpp installation allows time for the first macOS security check, and managed installs receive updated runtime binaries.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1039,16 +2127,20 @@ Native Ollama requests honor per-request sampling overrides, including explicit 
 
 - Update managed llama.cpp binaries and library manifests to b10809. [#140278](https://github.com/openclaw/openclaw/pull/140278) Thanks @vincentkoc.
 - Keep inference metadata and domain help lazy. [#140327](https://github.com/openclaw/openclaw/pull/140327)
-- Load Gemini model-family policy through a lightweight shared entrypoint. [#140922](https://github.com/openclaw/openclaw/pull/140922)
 
 **Bug fixes**
 
 - Honor native Ollama sampling overrides, including explicit zero values. [#140717](https://github.com/openclaw/openclaw/pull/140717)
-- Allow up to 120 seconds for the first unpublished llama-server version check. [#139160](https://github.com/openclaw/openclaw/pull/139160) Thanks @waterundman, @vincentkoc.
+- Allow up to 120 seconds for the first unpublished llama-server version check. [#139160](https://github.com/openclaw/openclaw/pull/139160) Thanks @waterundman, @vincentkoc, @dmwtech.
 - Point LM Studio auth failures to models auth login --provider lmstudio. [#125399](https://github.com/openclaw/openclaw/pull/125399)
 - Fit discovery text to the active context budget while preserving admitted skills and complete instructions. [#139244](https://github.com/openclaw/openclaw/pull/139244)
 - Use the loaded LM Studio instance’s actual context budget and preserve that target when reloading. [#138633](https://github.com/openclaw/openclaw/pull/138633) Thanks @ruel225 and @javikas.
 - Send LM Studio chat to the prepared instance with enough context while preserving the configured model identity. [#141390](https://github.com/openclaw/openclaw/pull/141390)
+- Reconcile managed llama.cpp router state across direct request paths. [#136363](https://github.com/openclaw/openclaw/pull/136363) Thanks @vincentkoc.
+- Preserve llama.cpp preset defaults, comments, and unmanaged options. [#139646](https://github.com/openclaw/openclaw/pull/139646)
+- Preserve separate Ollama thinking in tool follow-up requests. [#141381](https://github.com/openclaw/openclaw/pull/141381)
+- Reject embedding-only Ollama chat selections during setup and reset validation. [#141441](https://github.com/openclaw/openclaw/pull/141441)
+- Preserve local-model capabilities, tool-result pages and completed answers during bounded maintenance. [#138850](https://github.com/openclaw/openclaw/pull/138850)
 
 **Limits and compatibility**
 
@@ -1060,7 +2152,7 @@ Native Ollama requests honor per-request sampling overrides, including explicit 
 
 <Accordion title="Continue CLI-backed conversations">
 
-Cold managed Codex workers wait until they are ready before starting a first turn. Claude CLI-backed questions can retain their supported waiting deadline, and mixed CLI output handles quoted JSON examples without mistaking them for the answer. Side questions preserve completed answers while forwarding cancellation and reporting a disconnect promptly.
+Cold managed Codex workers wait until they are ready before starting a first turn. Claude CLI-backed questions can retain their supported waiting deadline, and mixed CLI output handles quoted JSON examples without mistaking them for the answer. Confirmed complete Codex replies remain available when final settlement takes too long, with a warning when saving them could not be confirmed. Side questions preserve completed answers while forwarding cancellation and reporting a disconnect promptly.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1073,6 +2165,15 @@ Cold managed Codex workers wait until they are ready before starting a first tur
 - Preserve Codex exec-server WebSocket pause and resume under Bun. [#140048](https://github.com/openclaw/openclaw/pull/140048)
 - Validate file-URL pathname encoding before Codex image conversion. [#140087](https://github.com/openclaw/openclaw/pull/140087)
 - Share Codex ephemeral-turn routing to retain terminal results and forward cancellation. [#139228](https://github.com/openclaw/openclaw/pull/139228)
+- Preserve completed Codex replies with a named settlement warning instead of replacing them with timeout errors. [#139353](https://github.com/openclaw/openclaw/pull/139353) Thanks @KirDE, [SRB]drizzy.
+- Share native Claude availability observations during model preparation. [#139757](https://github.com/openclaw/openclaw/pull/139757) Thanks @609NFT.
+- Refresh Claude Desktop title caches when watcher coverage is unknown. [#141147](https://github.com/openclaw/openclaw/pull/141147)
+- Bind Codex route callbacks to each active attempt's context. [#141491](https://github.com/openclaw/openclaw/pull/141491)
+- Retain Codex stateless request settings after payload hooks and through wrappers. [#138741](https://github.com/openclaw/openclaw/pull/138741) Thanks @saladinyao-cyber, @obviyus.
+
+**Documentation**
+
+- Split Codex harness documentation into nine focused pages with preserved anchors. [#141164](https://github.com/openclaw/openclaw/pull/141164) Thanks @vincentkoc.
 
 </details>
 
@@ -1095,6 +2196,8 @@ Provider adapters preserve initial Anthropic text and thinking, keep images with
 - Reduce temporary copying during Copilot transcript preparation. [#140868](https://github.com/openclaw/openclaw/pull/140868)
 - Bound settled Microsoft Foundry Entra-token retention while preserving active refreshes. [#127216](https://github.com/openclaw/openclaw/pull/127216)
 - Avoid discarded text assembly for Anthropic image tool results. [#140409](https://github.com/openclaw/openclaw/pull/140409)
+- Use the lightweight Claude policy facade for Bedrock PDF requests. [#139732](https://github.com/openclaw/openclaw/pull/139732)
+- Avoid repeated collision scans while preparing large Anthropic tool rosters. [#141210](https://github.com/openclaw/openclaw/pull/141210)
 
 **Bug fixes**
 
@@ -1106,10 +2209,74 @@ Provider adapters preserve initial Anthropic text and thinking, keep images with
 - Keep deferred media providers in the catalog while preserving explicit execution choices. [#139231](https://github.com/openclaw/openclaw/pull/139231) Thanks @rodrigo-fonseca-oliveira.
 - Release completed realtime transcription sockets after final transcript delivery. [#140303](https://github.com/openclaw/openclaw/pull/140303)
 - Recover final summaries after incomplete OpenCode Go and compatible completions streams. [#140367](https://github.com/openclaw/openclaw/pull/140367) Thanks @VACInc.
+- Send OpenCode session identity across all four bundled model transports. [#137464](https://github.com/openclaw/openclaw/pull/137464) Thanks @Ghilteras, @VACInc, @GDXbsv.
+- Scope media defaults to immutable manifest ownership instead of process-wide config caches. [#139317](https://github.com/openclaw/openclaw/pull/139317)
+- Reduce repeated reply filtering and preserve delayed tool results across model changes. [#139520](https://github.com/openclaw/openclaw/pull/139520) Thanks @nierob-cmd.
+- Load the installed WebSocket transport for xAI under Bun. [#139717](https://github.com/openclaw/openclaw/pull/139717)
 
 **Limits and compatibility**
 
 - Reduce Mistral stream preparation work for large parallel tool responses. [#141050](https://github.com/openclaw/openclaw/pull/141050)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Refresh model catalogs after failures">
+
+Failed discovery now stays visible while compatible previously discovered models remain available across more providers, including DeepInfra, NVIDIA, Bedrock, Google, Copilot, Ollama, external llama-server and LM Studio. A successful empty response is still empty, and changing credentials or endpoints can invalidate earlier inventory.
+
+Browsing models can initialize a cold catalog on demand, and source installations can load provider plugins that depend on import-only modules. Downloaded hosted catalog changes activate after a full Gateway restart. Finding a model remains separate from having credentials that can actually run it.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve failed and empty outcomes from bundled model discovery. [#139649](https://github.com/openclaw/openclaw/pull/139649) Thanks @obviyus.
+- Report DeepInfra and NVIDIA discovery failures without losing last-good inventory. [#139749](https://github.com/openclaw/openclaw/pull/139749) Thanks @obviyus.
+- Preserve Bedrock catalog outcomes and isolate Mantle credential caches. [#139750](https://github.com/openclaw/openclaw/pull/139750) Thanks @obviyus.
+- Report Google and Copilot catalog failures through the shared owner. [#139791](https://github.com/openclaw/openclaw/pull/139791) Thanks @obviyus.
+- Report local and cloud Ollama discovery failures. [#139817](https://github.com/openclaw/openclaw/pull/139817) Thanks @obviyus.
+- Report external llama-server catalog failure outcomes. [#139846](https://github.com/openclaw/openclaw/pull/139846) Thanks @obviyus.
+- Initialize cold model catalogs on demand and retain prepared CLI auth facts. [#139848](https://github.com/openclaw/openclaw/pull/139848) Thanks @goslingmanagment.
+- Report LM Studio acquisition outcomes and retain compatible models. [#139849](https://github.com/openclaw/openclaw/pull/139849) Thanks @obviyus.
+- Restore provider plugin loading in source catalog workers. [#141433](https://github.com/openclaw/openclaw/pull/141433) Thanks @obviyus.
+- Keep compatible learned model choices after a failed provider refresh. [#139357](https://github.com/openclaw/openclaw/pull/139357) Thanks @obviyus.
+- Refresh agent model choices when the catalog changes. [#139916](https://github.com/openclaw/openclaw/pull/139916) Thanks @obviyus.
+- Stop OAuth fallback after catalog discovery times out. [#139924](https://github.com/openclaw/openclaw/pull/139924) Thanks @shakkernerd.
+- Retain compatible full-catalog models and report profile failures when OAuth preparation fails. [#139951](https://github.com/openclaw/openclaw/pull/139951) Thanks @shakkernerd.
+- Preserve plugin catalog results for later discovery after an earlier request times out. [#140441](https://github.com/openclaw/openclaw/pull/140441) Thanks @shakkernerd.
+- Reduce cold Gateway stalls during model-runtime registration. [#139911](https://github.com/openclaw/openclaw/pull/139911)
+- Keep downloaded hosted catalogs inactive until a full Gateway restart. [#140086](https://github.com/openclaw/openclaw/pull/140086) Thanks @obviyus.
+- Skip paired-node discovery for local-only catalog pages. [#140090](https://github.com/openclaw/openclaw/pull/140090)
+- Make the Google manifest own the bundled Gemini catalog used by Doctor and runtime fallback. [#139243](https://github.com/openclaw/openclaw/pull/139243) Thanks @LiuwqGit, @vincentkoc, @NovaUnboundAi.
+- Keep xAI OAuth setup on the subscription catalog and resolve automatic selection at inference dispatch. [#140610](https://github.com/openclaw/openclaw/pull/140610) Thanks @DonnieFi.
+- Avoid duplicate xAI OAuth refresh attempts during model discovery. [#140434](https://github.com/openclaw/openclaw/pull/140434) Thanks @shakkernerd.
+- Keep Grok token model discovery on the subscription endpoint with the selected credential. [#140653](https://github.com/openclaw/openclaw/pull/140653) Thanks @shakkernerd.
+- Avoid saving bundled Baseten model rows during ordinary onboarding. [#141552](https://github.com/openclaw/openclaw/pull/141552) Thanks @obviyus.
+
+**Improvements**
+
+- Prepare model suppression rules once per catalog resolver. [#139681](https://github.com/openclaw/openclaw/pull/139681)
+- Defer unnecessary overlay and suppression work when preparing model catalogs. [#141154](https://github.com/openclaw/openclaw/pull/141154)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Repair retired model choices">
+
+Doctor can repair persisted automation choices when a provider explicitly declares a model route retired. Restart after the repair and explicitly re-enable jobs that were automatically disabled. Account pins, restrictive policies and locked native sessions remain in force.
+
+The ChatGPT model retirements handled here leave Platform API routes unaffected. A model merely missing from a catalog is not treated as retired.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Repair automation overrides for provider-declared retired model routes. [#139523](https://github.com/openclaw/openclaw/pull/139523) Thanks [alessi0p](https://x.com/alessi0p), Séraphin.
 
 </details>
 
@@ -1139,7 +2306,8 @@ Recovered work can finish successfully after a spawn was rejected before dispatc
 - Keep paced automation deadlines across Gateway restart. [#140083](https://github.com/openclaw/openclaw/pull/140083)
 - Record successful fallback work correctly after a spawn is rejected before reservation or dispatch. [#139037](https://github.com/openclaw/openclaw/pull/139037) Thanks @hartmark, @obviyus.
 - Report skipped on-exit payloads when an automation is already running. [#139987](https://github.com/openclaw/openclaw/pull/139987)
-- Avoid persisting heartbeat outcomes for nonexistent transient base sessions. [#131462](https://github.com/openclaw/openclaw/pull/131462) Thanks @gaoanze888.
+- Avoid persisting heartbeat outcomes for nonexistent transient base sessions. [#131462](https://github.com/openclaw/openclaw/pull/131462) Thanks @gaoanze888, @andersonjeccel.
+- Check empty scheduled heartbeat scratch before busy-queue deferral. [#137517](https://github.com/openclaw/openclaw/pull/137517) Thanks @LiuwqGit, @creanet-64.
 
 </details>
 
@@ -1157,6 +2325,13 @@ Accepted private monitor notes now survive reply transformations and reach the n
 - Keep Gateway requests responsive during system-monitor reconciliation. [#140260](https://github.com/openclaw/openclaw/pull/140260)
 - Repair known legacy multi-agent owners and keep valid cron jobs running beside unresolved jobs. [#140825](https://github.com/openclaw/openclaw/pull/140825)
 - Carry accepted heartbeat scratch through reply transformations so its stored revision advances. [#139225](https://github.com/openclaw/openclaw/pull/139225) Thanks @gaoanze888, @obviyus, @JLahullier.
+- Clean up removed cron sessions through the Gateway deletion lifecycle. [#138322](https://github.com/openclaw/openclaw/pull/138322) Thanks @Amazingjun-j, @obviyus, @gszj2018.
+- Publish configuration before reconciling heartbeat and Workshop monitors. [#139509](https://github.com/openclaw/openclaw/pull/139509)
+- Wait for the intended agent before setting up cron jobs in the experimental Claws workflow. [#139017](https://github.com/openclaw/openclaw/pull/139017)
+
+**Improvements**
+
+- Reuse heartbeat enrollment for individual wakes. [#139787](https://github.com/openclaw/openclaw/pull/139787)
 
 </details>
 
@@ -1174,6 +2349,7 @@ Automation model suggestions refresh when the catalog changes, and a failed read
 - Reduce per-record work when loading automation history. [#140170](https://github.com/openclaw/openclaw/pull/140170)
 - Stop retaining replaced initial automation-stream job snapshots. [#140256](https://github.com/openclaw/openclaw/pull/140256)
 - Log separate wait and processing times for slow cron list pages. [#140994](https://github.com/openclaw/openclaw/pull/140994)
+- Sort filtered automation arrays without a second copy. [#139778](https://github.com/openclaw/openclaw/pull/139778)
 
 **Bug fixes**
 
@@ -1182,13 +2358,18 @@ Automation model suggestions refresh when the catalog changes, and a failed read
 - Pause automation refreshes in hidden tabs and catch up on return. [#140097](https://github.com/openclaw/openclaw/pull/140097)
 - Show owned cron jobs once in Claw removal previews. [#139473](https://github.com/openclaw/openclaw/pull/139473)
 
+**Documentation**
+
+- Remove the unsupported automations update command from CLI guidance. [#137229](https://github.com/openclaw/openclaw/pull/137229) Thanks @qingminglong.
+- Split automation documentation into eight task-focused pages while preserving existing anchors. [#141173](https://github.com/openclaw/openclaw/pull/141173) Thanks @vincentkoc.
+
 </details>
 
 </Accordion>
 
 <Accordion title="Wait for a direct hook to finish">
 
-Direct agent-hook callers can opt in to `waitForCompletion` and receive bounded status that distinguishes a reply, intentional silence and delivery outcomes. The default remains acknowledgement of admission, and mapped or fan-out calls keep that existing behavior.
+Direct agent-hook callers can opt in to `waitForCompletion` and receive bounded status that distinguishes a reply, intentional silence and delivery outcomes. The completion response contains status rather than the model’s response text. The default remains acknowledgement of admission, and mapped or fan-out calls keep that existing behavior.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1196,6 +2377,40 @@ Direct agent-hook callers can opt in to `waitForCompletion` and receive bounded 
 **Improvements**
 
 - Add waitForCompletion to direct agent hooks with bounded reply and delivery status. [#139155](https://github.com/openclaw/openclaw/pull/139155) Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep scheduled results and delivery intent">
+
+Images produced by a scheduled report remain in the conversation after reload, and a child’s final answer can replace interim media. Reports intended for the current conversation count as delivered there without inventing an external destination; a separately requested external delivery still has to succeed.
+
+Heartbeat and cron execution also preserve pending events when foreground work takes precedence, keeping later recovery tied to the intended result.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve finalized automation media in durable conversation history. [#136589](https://github.com/openclaw/openclaw/pull/136589) Thanks @LiuwqGit, @lakemike, @obviyus.
+- Preserve current-session delivery intent in automation previews and results. [#139491](https://github.com/openclaw/openclaw/pull/139491)
+- Share heartbeat and cron execution while preserving delivery and recovery ownership. [#139624](https://github.com/openclaw/openclaw/pull/139624)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Build managed automation flows">
+
+The [TaskFlow examples](/automation/taskflow) now use supported [Lobster](/tools/lobster) approval and resume flows, with child work linked through its authoritative owner. These are bounded examples using prepared synthetic batches; connecting a real inbox or pull-request source still requires its own adapter.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Replace nonworking TaskFlow recipes with bounded Lobster examples and document authoritative child linking. [#139314](https://github.com/openclaw/openclaw/pull/139314)
 
 </details>
 
@@ -1247,8 +2462,6 @@ Annotate and Inspect take a one-shot capture of a Mac tab. These are pages you b
 
 Chrome relay tabs can also recover after attachment loss without restarting the browser stack. Opening an old browser result keeps a stopped managed browser stopped and offers Start browser when needed. Preview capture preserves focus for verified visible attached Chrome sessions on macOS and Linux, and screenshot annotations follow the actual image scale and crop.
 
-Existing-session browser profiles can upload files again, including multiple files when the page input supports them, and page-evaluation results retain embedded code fences.
-
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
@@ -1258,6 +2471,8 @@ Existing-session browser profiles can upload files again, including multiple fil
 - Assemble iframe snapshot lines in one pass while preserving refs and capture order. [#140304](https://github.com/openclaw/openclaw/pull/140304)
 - Avoid scanning and hashing computer frames when image input is blocked. [#140880](https://github.com/openclaw/openclaw/pull/140880)
 - Count encoded browser response sizes without serializing the payload twice. [#140882](https://github.com/openclaw/openclaw/pull/140882)
+- Reduce temporary allocation in compact Playwright snapshots. [#139652](https://github.com/openclaw/openclaw/pull/139652)
+- Reduce temporary allocations in browser snapshot reference preparation. [#139691](https://github.com/openclaw/openclaw/pull/139691)
 
 **Bug fixes**
 
@@ -1265,8 +2480,6 @@ Existing-session browser profiles can upload files again, including multiple fil
 - Wait for current tab state before selecting historical targets and keep stopped panels on Start browser. [#139089](https://github.com/openclaw/openclaw/pull/139089) Thanks @ylcn91, @obviyus.
 - Preserve tab focus during preview captures for verified headed Chrome on macOS and Linux. [#134400](https://github.com/openclaw/openclaw/pull/134400) Thanks @scotthuang.
 - Align browser screenshot annotations with scaled and cropped images. [#141103](https://github.com/openclaw/openclaw/pull/141103)
-- Restore file uploads and support multiple files in existing-session browser profiles. [#139904](https://github.com/openclaw/openclaw/pull/139904)
-- Preserve embedded code fences in browser page-evaluation results. [#139906](https://github.com/openclaw/openclaw/pull/139906)
 - Recover Chrome relay target identities and wait for matching Playwright pages before listing tabs. [#139275](https://github.com/openclaw/openclaw/pull/139275) Thanks @esqandil, @obviyus.
 
 </details>
@@ -1290,7 +2503,7 @@ The Chrome extension can be set up from the Mac dashboard or local CLI, with Chr
 
 <Accordion title="Type into a remote desktop">
 
-Remote desktop typing and deletion now preserve complete emoji characters, so a character is not split while being sent or removed.
+Remote desktop input sends supplementary Unicode characters as complete code points, avoiding split characters during typing and deletion. The keyboard stays disabled until connected control is ready.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1298,6 +2511,7 @@ Remote desktop typing and deletion now preserve complete emoji characters, so a 
 **Bug fixes**
 
 - Preserve emoji during remote desktop typing and deletion. [#140157](https://github.com/openclaw/openclaw/pull/140157)
+- Disable the desktop keyboard until connected control is ready. [#141378](https://github.com/openclaw/openclaw/pull/141378)
 
 </details>
 
@@ -1305,7 +2519,7 @@ Remote desktop typing and deletion now preserve complete emoji characters, so a 
 
 <Accordion title="Retry an interrupted desktop shutdown">
 
-A failed desktop cleanup remains visible and can be retried before another desktop opens. OpenClaw keeps the resources needed to finish that cleanup, and blocks reopening while the previous desktop remains unresolved.
+Failed cloud-tool results are recorded as failures before they enter conversation history. A failed desktop cleanup remains visible and can be retried before another desktop opens. OpenClaw keeps the resources needed to finish that cleanup, and blocks reopening while the previous desktop remains unresolved.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
@@ -1313,6 +2527,28 @@ A failed desktop cleanup remains visible and can be retried before another deskt
 **Bug fixes**
 
 - Retain desktop cleanup ownership and SSH resources until shutdown and disposal succeed. [#140658](https://github.com/openclaw/openclaw/pull/140658)
+- Finalize structured cloud-tool errors before transcript persistence. [#139758](https://github.com/openclaw/openclaw/pull/139758)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read page content and keep download names">
+
+Existing-session browser profiles can upload files again, including multiple files when the page input supports them, and page-evaluation results retain embedded code fences. Browser-node media keeps its safe node-side filename when saved through the Gateway, making downloaded files easier to recognize. Page extraction also uses the supported bundled DOM entry point when Readability first loads.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve browser-node filenames when saving proxied media. [#139559](https://github.com/openclaw/openclaw/pull/139559) Thanks @ruel225.
+- Restore file uploads and support multiple files in existing-session browser profiles. [#139904](https://github.com/openclaw/openclaw/pull/139904)
+- Preserve embedded code fences in browser page-evaluation results. [#139906](https://github.com/openclaw/openclaw/pull/139906)
+
+**Improvements**
+
+- Use the public bundled LinkeDOM entry for Readability. [#139851](https://github.com/openclaw/openclaw/pull/139851)
 
 </details>
 
@@ -1322,107 +2558,306 @@ A failed desktop cleanup remains visible and can be retried before another deskt
 
 ## Plugins and Integrations
 
-Team Reports gives teams a place to return to the activity happening across their selected GitHub and Discord sources, with reports and history inside OpenClaw. Plugin authors also have several SDK changes to account for, while installed integrations receive fixes to loading, recovery, and connected sessions.
+Team Reports brings selected GitHub and Discord activity into a history you can browse inside OpenClaw, while session-owned MCP connections can stay available between turns. Plugin authors also have several SDK migrations to account for, alongside fixes to installation, connected coding agents, and cloud worker preparation.
 
 <AccordionGroup>
 <Accordion title="Follow team activity in Reports">
 
-Install and enable the optional Team Reports plugin to bring authenticated GitHub activity and explicitly configured Discord sources into daily, weekly, and monthly reports. The Reports tab keeps previous reports available alongside people timelines and calendars, and optional model summaries help you read through the collected activity.
+When installed and enabled, the optional [Team Reports](/plugins/team-reports) plugin collects authenticated GitHub activity and explicitly configured Discord sources into daily, weekly, and monthly reports. It is disabled by default. Stored history, people timelines, calendars, and optional model summaries make it easier to return to what happened across a team.
 
-Reports show source coverage and incomplete periods so a quiet-looking day is not automatically treated as a complete picture. Light and dark themes, recognizable GitHub avatars, and expandable activity lists make the history easier to browse. Reports use UTC periods and remain behind the Gateway's authentication and operator read permission.
+Reports mark incomplete periods and source-coverage gaps, use UTC reporting windows, and remain behind Gateway authentication and operator read permission. Light and dark themes, GitHub avatars, and expandable activity lists help with browsing; collection still has documented limits, including omitted review-submission bodies and some historical commit and attribution cases. In an embedded tab, a theme choice follows in-tab navigation rather than being saved in browser storage.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- [Collect selected team activity and retain authenticated report history](https://github.com/openclaw/openclaw/pull/139850).
-- [Add themed report pages and GitHub avatars](https://github.com/openclaw/openclaw/pull/141327).
-- [Browse activity timelines, calendars, period comparisons, and complete retained item lists](https://github.com/openclaw/openclaw/pull/141384).
-
-**Limits and compatibility**
-
-- Team Reports is an optional external plugin, disabled by default. Collection depends on configured sources and their credentials; review-submission bodies are not collected, and some historical commit and attribution limits remain. See [Team Reports](/plugins/team-reports).
+- Introduce the optional Team Reports plugin with daily, weekly, and monthly reports [#139850](https://github.com/openclaw/openclaw/pull/139850).
+- Give Team Reports consistent dark and light styling and GitHub avatars with initials fallback [#141327](https://github.com/openclaw/openclaw/pull/141327).
+- Add activity cards, history trends, people timelines and calendars to Team Reports [#141384](https://github.com/openclaw/openclaw/pull/141384).
+- Add Team Reports to the official external plugin fallback catalog [c2baa243ee2c](https://github.com/openclaw/openclaw/commit/c2baa243ee2c824c4c113649ce31f0827ed6dd52).
 
 </details>
 </Accordion>
 
 <Accordion title="Update plugins for the current SDK">
 
-Plugin authors should check the SDK migration guidance before updating extensions that use execution policies, approvals, inbound media helpers, or filesystem result callbacks. Several retired aliases have been removed, and the replacement APIs have contracts that need to be followed rather than substituted by name alone.
+Plugin authors should follow the [SDK migration guide](/plugins/sdk-migration) when updating execution-policy, approval, inbound-media, and session integrations. Execution-policy helpers now live under `execPolicy` in `agent-harness-runtime`, approval account helpers belong to `approval-native-runtime`, and approval filtering uses the full `matchesApprovalRequestFilters` contract. The retired generic forwarding evaluator has no drop-in replacement.
 
-MCP prompt adapters now return the typed prompt result, preserving messages and image content. The same prompt can retain its original JSON in Code Mode while vision-capable models receive supported images.
+Use `buildChannelInboundMediaPayload` for inbound media. The `abortAndDrainAgentHarnessRun` callable and its returned data remain available, but its removed named result type must be inferred. MCP prompt adapters return typed prompt results, preserving descriptions, roles, and native images for vision-capable models while Code Mode retains the original JSON.
 
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Limits and compatibility**
-
-- [Replace the retired inbound media helper with the supported channel payload builder](https://github.com/openclaw/openclaw/pull/140716).
-- [Infer the retained abort-and-drain callable's result instead of importing its removed named result type](https://github.com/openclaw/openclaw/pull/141027).
-- [Preserve MCP prompt descriptions, roles, and images through typed results](https://github.com/openclaw/openclaw/pull/141421).
-- Follow the [SDK migration guide](/plugins/sdk-migration) for approval helpers and removed aliases, and the [runtime utility migration](/plugins/sdk-runtime/config-and-utilities) for execution-policy helpers. The retained `abortAndDrainAgentHarnessRun` callable still returns its data; its retired named result type must be inferred instead.
-
-**Documentation**
-
-- [Explain scoped session APIs and the remaining deprecated helpers](https://github.com/openclaw/openclaw/pull/139401).
-- [Clarify plugin reference titles and configuration guidance](https://github.com/openclaw/openclaw/pull/140254). Thanks @vincentkoc.
-
-</details>
-</Accordion>
-
-<Accordion title="Load installed plugins and preserve recovery copies">
-
-Interrupted plugin writes and failed builds now preserve more of the information needed to recover an installation. Package manifests are replaced atomically, scoped package entries stay intact, and refreshed plugin metadata reaches later provider preparation.
-
-OpenShell also keeps host shadow copies after a failed mirror operation and identifies the remaining recovery paths, distinguishing an incomplete restoration from a backup directory that still needs cleanup.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- [Refresh provider-hook metadata after plugin reloads](https://github.com/openclaw/openclaw/pull/139908).
-- [Prepare plugin SDK aliases on demand](https://github.com/openclaw/openclaw/pull/139997).
-- [Preserve scoped package entries during official plugin handling](https://github.com/openclaw/openclaw/pull/140016).
-- [Replace package manifests atomically after builds](https://github.com/openclaw/openclaw/pull/140740). Thanks @zenglingbiao and @obviyus.
-- [Keep OpenShell shadow backups and actionable recovery paths](https://github.com/openclaw/openclaw/pull/140764). Related [mirror recovery issue](https://github.com/openclaw/openclaw/issues/140703).
-
-</details>
-</Accordion>
-
-<Accordion title="Connect tools and finish plugin hooks">
-
-Session MCP servers can finish shutting down even when their listener is still starting, and context-engine plugins receive completion for successful compaction that had nothing to remove. Failed or cancelled compaction remains distinct from successful completion.
-
-<details class="release-source-toggle">
-<summary>Sources and complete change list</summary>
-
-**Bug fixes**
-
-- [Wait for late MCP listener startup during overlapping shutdowns](https://github.com/openclaw/openclaw/pull/139391).
-- [Send completion hooks for successful no-op compaction](https://github.com/openclaw/openclaw/pull/118094). Thanks @peterolkhov.
-- [Release completed observation-hook inputs without freeing timed-out queue capacity early](https://github.com/openclaw/openclaw/pull/140241).
-- [Preserve Gateway WebSocket options under Bun](https://github.com/openclaw/openclaw/pull/139919).
-
-</details>
-</Accordion>
-
-<Accordion title="Prepare cloud workers and inspect startup">
-
-Cloud startup diagnostics separate provisioning phases so operators can locate a delay, while worker preparation handles readiness and Windows Git paths more carefully. These checks describe where startup is progressing without promising a fixed startup time.
+Discord, llama.cpp, and Voice Call preserve their declared 2026.9.2 host support through scoped optional-helper and local transport fallbacks. Those accommodations do not restore intentionally retired SDK exports.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- [Show cloud session download, installation, and activation timings](https://github.com/openclaw/openclaw/pull/140443).
+- Preserve native image content when fetching MCP prompts [#141421](https://github.com/openclaw/openclaw/pull/141421).
+
+**Documentation**
+
+- Clarify which legacy session SDK helpers remain available during the compatibility window [#139401](https://github.com/openclaw/openclaw/pull/139401). This documentation correction does not extend the compatibility window; later removals listed above take precedence.
+- Clarify generated plugin references and fill in plugin configuration guidance [#140254](https://github.com/openclaw/openclaw/pull/140254). Thanks @vincentkoc.
+- Organize plugin manifest documentation into focused domain pages while preserving old anchors [#140504](https://github.com/openclaw/openclaw/pull/140504). Thanks @vincentkoc.
+- Split the Gateway protocol reference into task-focused pages while preserving old anchors [#141055](https://github.com/openclaw/openclaw/pull/141055). Thanks @vincentkoc.
+- Split the plugin runtime SDK reference into eight pages while preserving anchors and examples [#141159](https://github.com/openclaw/openclaw/pull/141159). Thanks @vincentkoc.
+
+**Limits and compatibility**
+
+- Preserve valid MCP inputs in Code Mode API declarations [#140051](https://github.com/openclaw/openclaw/pull/140051).
+- Expose shared execPolicy through agent-harness-runtime and retire unused deprecated minSecurity/maxAsk exports [#140636](https://github.com/openclaw/openclaw/pull/140636). The deprecated minSecurity and maxAsk exports are removed.
+- Share approval terminal interpretation and move account lookup to approval-native-runtime [#140677](https://github.com/openclaw/openclaw/pull/140677). Use the full matchesApprovalRequestFilters contract and the narrow approval-native-runtime account helpers.
+- Share native approval-control registries and retire the unused forwarding evaluator [#140695](https://github.com/openclaw/openclaw/pull/140695). createChannelApprovalForwardingEvaluator is removed; use native channel route gates and shared predicates.
+- Expose shared sandbox bind parsing and retire the deprecated infra-runtime execution-mode projection [#140696](https://github.com/openclaw/openclaw/pull/140696). Use execPolicy.resolveExecModePolicy from agent-harness-runtime and select the returned fields needed by the caller; parsing alone does not authorize a mount.
+- Share channel delivery-result aggregation and retire the deprecated media alias [#140716](https://github.com/openclaw/openclaw/pull/140716).
+- Expose the shared fill-missing configuration primitive for Doctor migrations [#140727](https://github.com/openclaw/openclaw/pull/140727). The fill-missing helper mutates records and assigns missing values by reference; it does not clone or recursively sanitize them.
+- Infer the retained abort-and-drain callable's result instead of importing the removed AbortAndDrainAgentHarnessRunResult type [#141027](https://github.com/openclaw/openclaw/pull/141027).
+- Restore Discord and llama.cpp loading on their declared OpenClaw 2026.9.2 SDK minimum [#141207](https://github.com/openclaw/openclaw/pull/141207).
+- Restore Voice Call realtime-handler loading on the published OpenClaw 2026.9.2 SDK [#141267](https://github.com/openclaw/openclaw/pull/141267).
+
+</details>
+</Accordion>
+
+<Accordion title="Load installed plugins and preserve recovery copies">
+
+Plugin installation stages managed packages before publishing their files, preserves exact recovery information, and replaces package manifests atomically after builds. Failed deletion leaves a disabled installation available for a later retry, while refreshed metadata and SDK modules reach subsequent plugin preparation.
+
+Expired plugin-install owners stop deleting copied source files, and recovery keeps exact ownership and filesystem checks. Retain reported recovery files until the current installation has been checked.
+
+OpenShell retains host shadow copies after mirror failures and reports where recovery data remains. Uncertain backups and concurrent replacements stay preserved, so an incomplete restoration is distinguishable from a backup directory that only needs cleanup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- [Mark successfully completed worker captures ready for first warm reuse](https://github.com/openclaw/openclaw/pull/140766).
-- [Use Windows-compatible null paths in worker Git operations](https://github.com/openclaw/openclaw/pull/140803). Related [Windows Git preparation issue](https://github.com/openclaw/openclaw/issues/140795).
+- Install native archive dependencies even when bundle metadata is present [#139415](https://github.com/openclaw/openclaw/pull/139415).
+- Explain plugin SDK incompatibilities and detect stale plugins after core updates [#139458](https://github.com/openclaw/openclaw/pull/139458).
+- Use the same plugin factory instance for metadata and execution [#139828](https://github.com/openclaw/openclaw/pull/139828).
+- Reuse host SDK modules when loading session plugins [#139829](https://github.com/openclaw/openclaw/pull/139829).
+- Honor runtime cache invalidation when selecting provider hooks [#139908](https://github.com/openclaw/openclaw/pull/139908).
+- Batch keyed-state reads for Matrix, Teams, Voice Call and hosted-media restoration [#139956](https://github.com/openclaw/openclaw/pull/139956).
+- Resolve plugin SDK aliases on demand [#139997](https://github.com/openclaw/openclaw/pull/139997).
+- Fix scoped plugin packing and preserve emitted runtime entries [#140016](https://github.com/openclaw/openclaw/pull/140016).
+- Remove owned plugin load paths before deleting installed files [#140065](https://github.com/openclaw/openclaw/pull/140065).
+- Stage managed npm plugin installs before publishing their files [#140145](https://github.com/openclaw/openclaw/pull/140145).
+- Avoid unused plugin inspection work when collecting compatibility warnings [#140187](https://github.com/openclaw/openclaw/pull/140187).
+- Reuse registered plugin metadata owners during LLM SDK imports [#140372](https://github.com/openclaw/openclaw/pull/140372).
+- Write plugin package manifests atomically so failed builds do not truncate them [#140740](https://github.com/openclaw/openclaw/pull/140740). Thanks @zenglingbiao, @obviyus.
+- Report preserved OpenShell shadow backups when mirror cleanup or restoration fails [#140764](https://github.com/openclaw/openclaw/pull/140764).
+- Use bundled manifests to resolve plugin slots during enablement [#140842](https://github.com/openclaw/openclaw/pull/140842).
+- Resolve remote branch references before detached Git plugin checkout [#140951](https://github.com/openclaw/openclaw/pull/140951).
+- Defer installer loading when changing an installed plugin's enabled policy [#141100](https://github.com/openclaw/openclaw/pull/141100).
+- Share optional channel artifact loading while preserving errors from broken resolved artifacts [#141241](https://github.com/openclaw/openclaw/pull/141241). Thanks @vincentkoc.
+- Defer runtime inspection when bundled plugin metadata already supplies slot information [#141466](https://github.com/openclaw/openclaw/pull/141466).
+- Fence plugin installation cleanup and restoration with current ownership and exact filesystem identities [#138870](https://github.com/openclaw/openclaw/pull/138870).
+
+</details>
+</Accordion>
+
+<Accordion title="Keep MCP connections and plugin hooks available">
+
+Session-owned MCP servers now remain alive between turns by default. An unset or zero idle timeout disables idle eviction; a positive timeout opts into it. Reset, deletion, Stop, and shutdown still clean up their servers, and run-owned servers still end with their run.
+
+Startup and shutdown also coordinate late listeners and service cleanup, and context-engine plugins receive completion for successful compaction that had nothing to remove. Failed, cancelled, and owner-lost compaction attempts remain separate from successful completion.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Keep session-owned MCP servers alive between turns by default [#141125](https://github.com/openclaw/openclaw/pull/141125). Thanks @BottaniCals. The 256-runtime admission limit remains; run-owned servers still end with their run.
+
+**Bug fixes**
+
+- Complete successful engine-owned no-op compaction hooks with a zero compacted count [#118094](https://github.com/openclaw/openclaw/pull/118094). Thanks @peterolkhov.
+- Wait for MCP listener startup before claiming shutdown once [#139391](https://github.com/openclaw/openclaw/pull/139391).
+- Keep MCP server startup retired after session shutdown [#139616](https://github.com/openclaw/openclaw/pull/139616).
+- Return injected plugin hooks through the lazy facade [#139741](https://github.com/openclaw/openclaw/pull/139741).
+- Bound context-engine cleanup at the logical-turn owner [#140023](https://github.com/openclaw/openclaw/pull/140023).
+- Retain plugin service cleanup ownership through pending startup and reload failure [#140132](https://github.com/openclaw/openclaw/pull/140132).
+- Release invoked hook-factory captures while asynchronous work continues [#140241](https://github.com/openclaw/openclaw/pull/140241).
+- Unpublish retired hook endpoints before their listeners close [660726f7037b](https://github.com/openclaw/openclaw/commit/660726f7037b6ffd90fc12e28f1c3d7df177173d).
+
+</details>
+</Accordion>
+
+<Accordion title="Continue connected coding-agent sessions">
+
+Connected coding agents preserve more of the context around their work, including ACP arguments and history, SDK terminal outcomes, replay order, and empty client tool results. Successful closes retire their managed delegates, while failed closes remain retryable and wait deadlines remain distinct from terminal outcomes.
+
+ACP history limits now count UTF-8 bytes consistently, which can make previously undercounted Unicode history eligible for earlier eviction on a later write. Transcript fallback cannot reconstruct every tool or system event, and unsupported saved model overrides may still require resetting the session.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Use a lighter native hook relay entry point while preserving delivery and process cleanup [#120340](https://github.com/openclaw/openclaw/pull/120340). Thanks @sightingsstellar-beep, @Takhoffman.
+- Account for UTF-8 bytes consistently when retaining and repairing ACP replay history [#124476](https://github.com/openclaw/openclaw/pull/124476). Thanks @coaiMax, @lijing.
+- Retire successfully closed ACPX managed delegates before process cleanup [#127136](https://github.com/openclaw/openclaw/pull/127136).
+- Isolate transient Codex plugin state by package version [#136926](https://github.com/openclaw/openclaw/pull/136926). Thanks @srikalyan, @obviyus.
+- Align SDK terminal events and wait results with canonical run outcomes [#139125](https://github.com/openclaw/openclaw/pull/139125).
+- Preserve replay order for late SDK run subscribers [#139563](https://github.com/openclaw/openclaw/pull/139563).
+- Drain ACP output before settling and respect explicit thinking settings [#139685](https://github.com/openclaw/openclaw/pull/139685).
+- Preserve ACP argv, session history, and backend cleanup [#139776](https://github.com/openclaw/openclaw/pull/139776). Thanks @eddiedon.
+- Reuse prepared ACP replay-ledger queries [#139982](https://github.com/openclaw/openclaw/pull/139982).
+- Preserve empty client tool outputs across Gateway API continuations [#139988](https://github.com/openclaw/openclaw/pull/139988).
+- Release buffered SDK events when iterators close and avoid repeated array shifting while draining bursts [#140485](https://github.com/openclaw/openclaw/pull/140485).
+
+</details>
+</Accordion>
+
+<Accordion title="Prepare cloud workers and inspect startup">
+
+Cloud bootstrap reports individual preparation phases so operators can locate delays, and runtime archives use bounded streaming preparation instead of thousands of temporary files. Updated warm images can reuse the installed runtime in later sessions, without implying that every warm session starts faster overall.
+
+Preparation completes before a provider allocation is recorded, failed local preparation can retry, and idle remote sessions can finish Stop without waiting for unrelated provisioning. Worker Git operations preserve patch bytes and use Windows-compatible paths, while portal connections handle either loopback address family.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Avoid duplicate cloud worker cleanup and preserve actual provider timeout causes [#140377](https://github.com/openclaw/openclaw/pull/140377).
+- Report individual cloud bootstrap phase timings through the Crabbox CLI [#140442](https://github.com/openclaw/openclaw/pull/140442).
+- Exclude Gateway dashboard assets from cloud node bootstrap archives [#140556](https://github.com/openclaw/openclaw/pull/140556).
+- Serialize Gateway-to-node duplex frames once at the transport boundary [#140827](https://github.com/openclaw/openclaw/pull/140827).
+- Stream cloud runtime archives instead of creating thousands of temporary files [#141141](https://github.com/openclaw/openclaw/pull/141141).
+
+**Bug fixes**
+
+- Reject mapped and NAT64 unspecified Gateway addresses before cloud-worker provisioning [#137059](https://github.com/openclaw/openclaw/pull/137059). Thanks @vincentkoc.
+- Place default Fleet caches inside writable tenant state [#137211](https://github.com/openclaw/openclaw/pull/137211). Thanks @Alix-007, @obviyus, @vladimirkrdzic.
+- Clear failed cloud artifact preparation so the same Gateway can retry [#140021](https://github.com/openclaw/openclaw/pull/140021).
+- Connect Gateway and worker portals to IPv4 or IPv6 local servers independently of localhost records [#140580](https://github.com/openclaw/openclaw/pull/140580).
+- Disable Git newline conversion for worker workspace patch application and recovery [#140683](https://github.com/openclaw/openclaw/pull/140683).
+- Mark successfully waited cloud-worker captures ready for first warm reuse [#140766](https://github.com/openclaw/openclaw/pull/140766).
+- Use Git-compatible null configuration paths for Windows worker repository operations [#140803](https://github.com/openclaw/openclaw/pull/140803).
+- Separate allocation-free worker preparation from provider provisioning [#140945](https://github.com/openclaw/openclaw/pull/140945).
+- Let an idle remote session finish Stop without waiting for unrelated cloud provisioning [#141246](https://github.com/openclaw/openclaw/pull/141246).
+- Refresh warm cloud images after a runtime update so later sessions can reuse the installed runtime [#141375](https://github.com/openclaw/openclaw/pull/141375).
+
+</details>
+</Accordion>
+
+<Accordion title="Discover installed tools and inspect integration status">
+
+The system agent can read installed plugin versions, sources, and dependency diagnostics directly. Tool assembly continues past a safely reported broken factory, preserves the originating tool context across supported backends, and avoids repeating plugin eligibility work within a single operation. Read-only discovery does not change installation or approval authority.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Let the system agent list installed plugin versions, sources and dependency diagnostics [#133255](https://github.com/openclaw/openclaw/pull/133255). Thanks @Alix-007, @shakkernerd.
+- Restore access to native plugin UI customization controls [#139510](https://github.com/openclaw/openclaw/pull/139510).
+- Collect tool schema search text in one pass [#139786](https://github.com/openclaw/openclaw/pull/139786).
+- Reduce bundled-plugin catalog lookup and static import overhead [#140597](https://github.com/openclaw/openclaw/pull/140597).
+- Reuse installed-plugin eligibility within each tool-selection operation [#140824](https://github.com/openclaw/openclaw/pull/140824).
+
+**Bug fixes**
+
+- Avoid redundant alternate-spelling command scans [#139678](https://github.com/openclaw/openclaw/pull/139678).
+- Materialize the ls tool for explicit loopback grants [#139752](https://github.com/openclaw/openclaw/pull/139752).
+- Preserve originating tool context across agent backends and recovery [#139840](https://github.com/openclaw/openclaw/pull/139840).
+- Stop provider lookup after a complete scoped hit [#139864](https://github.com/openclaw/openclaw/pull/139864).
+- Explain why a plugin's Gateway request is refused [#140352](https://github.com/openclaw/openclaw/pull/140352). Thanks @Colton-Harris, @obviyus.
+- Pass the active configuration consistently to plugin agent admission and execution [#140435](https://github.com/openclaw/openclaw/pull/140435).
+- Safely report plugin tool-factory errors and continue assembling healthy tools [#140534](https://github.com/openclaw/openclaw/pull/140534).
+
+**Documentation**
+
+- Correct the Fetch MCP setup example to use uvx mcp-server-fetch and state the uv prerequisite [#141189](https://github.com/openclaw/openclaw/pull/141189). Thanks @ly85206559, @colbertlee.
+
+</details>
+</Accordion>
+
+<Accordion title="Inspect account and runtime diagnostics">
+
+Personal GitHub connection status no longer needs an agent workspace, and Profile links effective agent authentication to its account settings. An authenticated account still needs access to the repository it will use.
+
+Prometheus can identify the running process and loaded build, while supported diagnostics exporters report elapsed garbage-collection duration. These observations help identify the runtime and its activity; they do not establish health or attribute a particular delay to a collection event.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Resolve personal GitHub connection status without requiring agent selection or an agent workspace [#139222](https://github.com/openclaw/openclaw/pull/139222).
+- Expose one Gateway build-info gauge with canonical process and build identity [#139280](https://github.com/openclaw/openclaw/pull/139280).
+- Expose garbage-collection duration metrics through both diagnostics exporters [#139592](https://github.com/openclaw/openclaw/pull/139592).
+- Preserve a separate exporter flush window after diagnostic event draining [#140046](https://github.com/openclaw/openclaw/pull/140046).
+- Show effective agent GitHub authentication and link its account settings from Profile [#140619](https://github.com/openclaw/openclaw/pull/140619).
+
+**Bug fixes**
+
+- Show enabled status in metadata-only plugin inspections instead of loaded [#140964](https://github.com/openclaw/openclaw/pull/140964).
+
+</details>
+</Accordion>
+
+<Accordion title="Run supported integration transports under Bun">
+
+Affected Gateway, worker, voice-call, and ClickClack connections use their declared transport implementations under Bun, preserving the options and payload behavior those integrations expect. The fixes are scoped to those paths and do not establish complete Bun compatibility across OpenClaw.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Load installed Undici instead of Bun's partial substitute [#139811](https://github.com/openclaw/openclaw/pull/139811).
+- Preserve voice-call WebSocket transport behavior under Bun [#139567](https://github.com/openclaw/openclaw/pull/139567).
+- Bundle WebSocket transport for native worker turns and realtime transcription [#140071](https://github.com/openclaw/openclaw/pull/140071).
+- Preserve Gateway WebSocket options, including Origin, under Bun [#139919](https://github.com/openclaw/openclaw/pull/139919).
+- Load ClickClack's declared WebSocket dependency consistently under Bun [#141124](https://github.com/openclaw/openclaw/pull/141124).
+
+</details>
+</Accordion>
+
+<Accordion title="Load files and media through installed integrations">
+
+Fetched files keep readable names through media staging, PDF extraction respects global plugin disablement and document allowlists, and HTTP cancellation reaches input downloads. Cancellation does not stop a codec that is already running.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve readable fetched-file stems through media staging [#138411](https://github.com/openclaw/openclaw/pull/138411). Thanks @NianJiuZst, @igs-rogenlo.
+- Honor global plugin disablement and restrictive document allowlists during PDF extraction [#139334](https://github.com/openclaw/openclaw/pull/139334).
+- Propagate HTTP cancellation through input URL acquisition [#139793](https://github.com/openclaw/openclaw/pull/139793). Thanks @zhangguiping-xydt.
+- Reuse installed-plugin eligibility preparation within each media-capability batch [#141337](https://github.com/openclaw/openclaw/pull/141337).
+
+</details>
+</Accordion>
+
+<Accordion title="Keep Workboard drafts and Logbook entries readable">
+
+Workboard can refresh pinned navigation names without discarding an open card draft, while Logbook timestamps stay clear of the activity stripe.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep Logbook timestamps clear of the activity stripe [#139539](https://github.com/openclaw/openclaw/pull/139539). Thanks @TurboTheTurtle, @Colton-Harris.
+- Refresh Workboard navigation names without discarding open card drafts [#139952](https://github.com/openclaw/openclaw/pull/139952).
+
+</details>
+</Accordion>
+
+<Accordion title="Delete beamed sessions and archive external entries">
+
+Beam sessions can be deleted after confirmation, and supported external catalogs offer their own archive action. Beam deletion is permanent, although a later upload can recreate the session; a Codex archive follows that catalog's separate, potentially reversible behavior.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add confirmed deletion for Beam sessions and archive actions for capable external catalogs [#141467](https://github.com/openclaw/openclaw/pull/141467).
 
 </details>
 </Accordion>
@@ -1430,56 +2865,183 @@ Cloud startup diagnostics separate provisioning phases so operators can locate a
 
 ## Security and Privacy
 
-Permission checks stay attached to the agent, account, and file they are meant to protect, while pending device-capability requests remain available until you resolve them. Existing telemetry choices are also explained more clearly.
+Permission checks stay attached to the account, agent, connection, and file they protect. Device capability requests remain available until you resolve them, Android honors approximate-location choices, and credential and runtime-context handling receive more narrowly scoped protections.
 
 <AccordionGroup>
 <Accordion title="Review device capabilities and pairing accounts">
 
-Requests for additional capabilities on an already paired device now survive disconnects and restarts until they are resolved. Keeping a request available does not grant the capability, and ordinary device pairing still expires after five minutes.
+Requests for additional capabilities on an already paired device survive disconnects and restarts until they are resolved. Keeping a request available grants no access, and ordinary device pairing still expires after five minutes. Upgrade the Gateway and older CLIs that write directly to its database together, because old writers can remove aged requests that a later upgrade cannot restore.
 
-Pairing commands also reject an explicitly blank account selector instead of silently treating it as a broader default. Upgrade the Gateway and older CLIs that write directly to its database together, because an old writer can still remove aged capability requests.
+Pairing commands reject explicitly blank account selectors, caller-supplied fields cannot replace a request's scope, and revoked node connections lose access before asynchronous cleanup finishes. Approval listings also show the scope of executable grants.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Security and trust**
 
-- [Retain paired-device capability requests until resolution](https://github.com/openclaw/openclaw/pull/140166). Thanks @dragonnite1221-lgtm and @IWhatsskill.
-- [Reject blank account selectors before pairing reads or approvals](https://github.com/openclaw/openclaw/pull/140238). Thanks @Alix-007 and @shakkernerd.
+- Show executable approval grant scope in CLI listings [#138386](https://github.com/openclaw/openclaw/pull/138386). Thanks @ylcn91, @obviyus, @abacha.
+- Prevent caller-supplied fields from replacing pairing request and challenge scope [#139142](https://github.com/openclaw/openclaw/pull/139142). Thanks @SebTardif, @obviyus.
+- Invalidate revoked node connections before asynchronous worker cleanup [#139421](https://github.com/openclaw/openclaw/pull/139421).
+- Keep paired-node capability requests available beyond five minutes [#140166](https://github.com/openclaw/openclaw/pull/140166). Thanks @dragonnite1221-lgtm, @IWhatsskill.
+- Reject blank account selectors before pairing reads or approval changes [#140238](https://github.com/openclaw/openclaw/pull/140238). Thanks @Alix-007, @shakkernerd.
 
 </details>
 </Accordion>
 
-<Accordion title="Keep plugin execution within its permissions">
+<Accordion title="Keep execution within its permissions">
 
-Plugin setup checks the file it is about to load, rejecting substituted setup files that would escape the plugin's installation. Delegated model overrides are checked against the model the destination agent will actually resolve, which can reject an override that previously passed against the wrong context.
+Plugin setup validates the file it is about to load, and delegated model overrides are checked against the destination agent's resolved model. Filesystem transfer checks include exact archive entries and their implicit parent directories, cloud media access stays with the filesystem owner, and eligible Apple state files have unintended extra ACL grants removed within the supported ownership rules.
+
+Tool-policy groups use the same aliases and membership as core. Claude native Bash honors fully bindable exec allowlists under on-miss prompting while retaining deny and always-prompt behavior; an argument policy is not a sandbox. Prometheus scrapers now need effective operator read permission and receive a refusal when it is missing.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Security and trust**
 
-- [Validate replaced setup symlinks and hardlinks before loading](https://github.com/openclaw/openclaw/pull/117370). Existing verified immutable and Nix-root policies remain in place.
-- [Apply the destination agent's model permissions to plugin overrides](https://github.com/openclaw/openclaw/pull/139368).
+- Validate lazy plugin setup entries before loading replaced symlinks or hardlinks [#117370](https://github.com/openclaw/openclaw/pull/117370).
+- Limit each incoming grep JSON record to one MiB before decoding [#136623](https://github.com/openclaw/openclaw/pull/136623). Thanks @vincentkoc. Individual grep JSON records larger than 1 MiB are refused before decoding, without partial search output.
+- Apply destination-agent model rules when authorizing plugin overrides [#139368](https://github.com/openclaw/openclaw/pull/139368).
+- Enforce cloud filesystem ownership for Control UI media access [#139503](https://github.com/openclaw/openclaw/pull/139503).
+- Remove eligible extra ACL grants from Apple native state files [#139623](https://github.com/openclaw/openclaw/pull/139623). Thanks @vincentkoc. ACL normalization is limited to eligible effective-user-owned objects; mixed, delegated, and unsupported ACLs retain their existing behavior.
+- Enforce sender-scoped local media access for Discord guild asset uploads [#140334](https://github.com/openclaw/openclaw/pull/140334). Thanks @pgondhi987.
+- Accept exact cat or empty PAGER and GIT_PAGER overrides and normalize them to empty values [#140594](https://github.com/openclaw/openclaw/pull/140594). Thanks @RomneyDa. Only exact cat or empty PAGER/GIT_PAGER overrides are admitted and normalized to empty values; other commands remain blocked.
+- Align Policy tool requirements with current core groups, including ls, secrets, automations and view_image [#140628](https://github.com/openclaw/openclaw/pull/140628).
+- Require effective operator read access before rendering Prometheus metrics [#140903](https://github.com/openclaw/openclaw/pull/140903). Thanks @pgondhi987.
+- Apply directory-transfer permissions to exact archive entries and their implicit parents [#141086](https://github.com/openclaw/openclaw/pull/141086).
+- Adopt fs-safe 0.8.5 in core, 1Password and OpenShell [#141165](https://github.com/openclaw/openclaw/pull/141165).
+- Honor explicit exec allowlists for Claude native Bash under ask:on-miss [#141471](https://github.com/openclaw/openclaw/pull/141471). Thanks @docfernando.
+
+**Documentation**
+
+- Correct the communication-only tool-policy example and explain global session visibility [#139464](https://github.com/openclaw/openclaw/pull/139464). Thanks @shakkernerd, @cipp-ashe.
+
+</details>
+</Accordion>
+
+<Accordion title="Protect credentials and private connection details">
+
+Unrelated Settings saves preserve plugin secret references, sensitive-field metadata survives plugin ownership changes, and private Talk route identifiers stay out of public configuration and catalog projections. Failed local secret lookups explain the problem without disclosing the secret itself.
+
+Saved CLI context is restored only within verified account and transcript boundaries. Unknown, imported, mixed, or legacy history is not automatically replayed or deleted. Blank or stringified-null Gateway tokens are refused; inline tokens can be repaired with Doctor's token-generation action, while external references need correction at their source and clients need the updated credential.
+
+Documentation also distinguishes authorized, user-requested sign-in handoffs in private conversations from reusable secrets, warns about shared plaintext credentials that still need attention, and includes enabled diagnostic exports when explaining where data can go.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Keep private Talk route identifiers out of public config, catalogs, sessions and errors [#129144](https://github.com/openclaw/openclaw/pull/129144). Thanks @vincentkoc.
+- Warn about remaining shared plaintext credentials without contaminating JSON output [#133843](https://github.com/openclaw/openclaw/pull/133843). Thanks @SunnyShu0925, @vincentkoc.
+- Project restricted environments for native service-manager commands and probes [#139333](https://github.com/openclaw/openclaw/pull/139333).
+- Preserve positive sensitivity and secret-URL metadata across channel owner changes [#139337](https://github.com/openclaw/openclaw/pull/139337).
+- Preserve plugin SecretRefs when saving unrelated Settings changes [#139536](https://github.com/openclaw/openclaw/pull/139536). Thanks @robojarvis, @obviyus.
+- Keep isolated completion configuration and credentials together [#139607](https://github.com/openclaw/openclaw/pull/139607).
+- Reject blank and stringified nullish Gateway tokens [#139844](https://github.com/openclaw/openclaw/pull/139844). Thanks @hyspacex.
+- Restore saved CLI context only within verified account and transcript boundaries [#140294](https://github.com/openclaw/openclaw/pull/140294). Older binaries do not enforce this boundary; writing history after a downgrade breaks its coverage, and recovery fails closed after upgrading again. Thanks @VACInc.
+- Clear stale diagnostics when switching Gateways or authentication scope [#140426](https://github.com/openclaw/openclaw/pull/140426). Thanks @shakkernerd.
+- Explain failed local secret lookup without exposing secret details [#141395](https://github.com/openclaw/openclaw/pull/141395). Thanks @obviyus.
+
+**Documentation**
+
+- Clarify authorized private credential handoffs and require confirmed delivery before group acknowledgement [#139196](https://github.com/openclaw/openclaw/pull/139196). Thanks @obviyus.
+- Explain OpenClaw's independent governance, funding and configured data destinations [#141053](https://github.com/openclaw/openclaw/pull/141053).
+- Include opt-in diagnostics exports in the README's prompt-destination explanation [#141106](https://github.com/openclaw/openclaw/pull/141106).
+
+</details>
+</Accordion>
+
+<Accordion title="Keep private runtime context out of replies">
+
+Private yield context and recognized runtime prefaces are kept out of public tool results and delivered replies, while Codex dynamic-tool text is redacted before budgeting and truncation. Streamed reasoning previews also handle the supported echoed-marker case without stripping ordinary reasoning or final answers.
+
+The updated runtime-context projection applies to genuinely new sessions; existing transcripts retain their earlier policy. These targeted changes do not establish a general prompt-injection or context-disclosure guarantee.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Strip wrapped runtime-context prefaces from delivered replies [#139604](https://github.com/openclaw/openclaw/pull/139604). Thanks @teddytennant, @obviyus, @DeltaEcho3.
+- Keep private yield context out of public tool results and history [#139801](https://github.com/openclaw/openclaw/pull/139801). Thanks @Colton-Harris, @obviyus.
+- Carry runtime-context provenance explicitly and escape matching inbound delimiters [#140859](https://github.com/openclaw/openclaw/pull/140859). Thanks @fstrasz.
+- Sanitize Codex dynamic tool text before output budgeting and truncation [#140873](https://github.com/openclaw/openclaw/pull/140873). Thanks @pgondhi987.
+- Sanitize streamed reasoning previews while preserving ordinary reasoning and final answers [#141544](https://github.com/openclaw/openclaw/pull/141544). Thanks @VACInc.
+
+</details>
+</Accordion>
+
+<Accordion title="Bind desktop access to its connection">
+
+Desktop viewing and control end when the requesting Gateway connection disconnects or loses authority. Connection-bound tickets and both relay directions are checked, while internal callers without a connection retain their existing timeout-based behavior.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- End desktop viewing and control when the requesting Gateway connection disconnects or loses authority [#141336](https://github.com/openclaw/openclaw/pull/141336).
+
+</details>
+</Accordion>
+
+<Accordion title="Honor Android's approximate-location choice">
+
+When Precise Location is off, Android coarsens cached, fresh, and pending location responses and removes altitude, speed, and bearing. The two-kilometre grid is an approximation method, not a guaranteed minimum distance from the real position, and changing the setting does not retract locations already delivered.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Coarsen Android location responses when Precise Location is off, including pending requests [#141344](https://github.com/openclaw/openclaw/pull/141344). Thanks @IWhatsskill.
+
+</details>
+</Accordion>
+
+<Accordion title="Preserve trusted network connections">
+
+Protected HTTPS renews leaf certificates while keeping the process trust chain stable, allowing existing subprocesses to continue beyond the previous one-day boundary. The authority key remains scoped to the process, with a longer-lived certificate; operators should still protect copies of that key.
+
+Realtime transcription retains its payload limits on the affected Bun transport path.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- Preserve realtime transcription payload limits under Bun [#139480](https://github.com/openclaw/openclaw/pull/139480).
+- Renew secret-proxy leaf certificates while keeping the process trust chain stable [#141484](https://github.com/openclaw/openclaw/pull/141484). Thanks @MaClawd. The authority certificate validity becomes ten years while its key remains process-scoped, increasing the exposure window if a key is copied.
 
 </details>
 </Accordion>
 
 <Accordion title="Understand telemetry choices">
 
-Telemetry documentation now explains the opt-in controls, what inventory counts represent, and where network-level IP handling occurs. The local preview command is described as a preview from the current CLI process, keeping it distinct from a record of previously submitted data.
+Telemetry documentation explains opt-in controls, inventory counts, and network-level IP handling. The local preview command is described as a preview from the current CLI process rather than a history of submitted data. These help and documentation corrections do not change payloads or consent defaults.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Documentation**
 
-- [Clarify telemetry counts, consent controls, and IP handling](https://github.com/openclaw/openclaw/pull/140768). Thanks @vincentkoc. Cloudflare receives the client IP at the network boundary; Analytics Engine excludes it.
-- [Label telemetry show as a local preview](https://github.com/openclaw/openclaw/pull/140789). Thanks @vincentkoc.
+- Clarify telemetry inventory counts, opt-in controls and network-level IP handling [#140768](https://github.com/openclaw/openclaw/pull/140768). Thanks @vincentkoc. Cloudflare receives the client IP at the network boundary; Analytics Engine excludes it.
+- Describe telemetry show as a preview from the current CLI process [#140789](https://github.com/openclaw/openclaw/pull/140789). Thanks @vincentkoc.
 
-**Limits and compatibility**
+</details>
+</Accordion>
 
-- These documentation and help corrections do not change telemetry payloads or consent defaults.
+<Accordion title="Understand public transcript sharing">
+
+Public-sharing guidance clarifies who can enable a link and what it exposes. Shared links make existing and future conversation text available to anyone holding the link, and revoking access cannot recall copies someone has already saved.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- Document public session sharing and correct creator-versus-owner publishing authority [#141442](https://github.com/openclaw/openclaw/pull/141442).
 
 </details>
 </Accordion>
@@ -1487,85 +3049,242 @@ Telemetry documentation now explains the opt-in controls, what inventory counts 
 
 ## Quality-of-Life Improvements
 
-Code Mode can carry a running program through fast tool replies without repeatedly saving and restoring its whole environment, and optional TypeScript checks help catch mismatched tool calls before they run. Smaller improvements make file results, task handoffs, and command documentation easier to work with.
+[Code Mode](/tools/code-mode) can keep a program running through fast tool replies and optionally check composed TypeScript calls before execution. Long conversations, session lists, delegated work, and terminal diagnostics also receive improvements that make their results easier to retain and inspect.
 
 <AccordionGroup>
 <Accordion title="Compose tools in Code Mode">
 
-Fast tool replies can now return to the same running JavaScript environment, allowing programs to keep working with larger valid in-memory values. Explicit yields, exhausted budgets, and worker pressure still checkpoint execution and enforce the existing limits.
+Fast tool replies return to the same running JavaScript environment, allowing valid in-memory values to survive without an unnecessary checkpoint. Explicit yields, exhausted budgets, and worker pressure still checkpoint execution and enforce the existing limits.
 
-Agents can opt into TypeScript checks against available tool declarations before execution, read bounded console output, and get error locations mapped back to their original source. TextEncoder and TextDecoder are also available for local text and byte transformations across waits and resumes.
+Optional TypeScript checks use the available tool declarations before execution, errors point back to original source, and bounded console output helps with diagnosis. TextEncoder and TextDecoder remain available across waits and resumes, while unawaited promises are identified instead of appearing as empty objects. These additions do not grant unrestricted filesystem or network access.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- [Continue live Code Mode programs and optionally check tool composition before execution](https://github.com/openclaw/openclaw/pull/141265). Thanks @Takhoffman. Related [continuation and typed composition issue](https://github.com/openclaw/openclaw/issues/141261).
-- [Retain sandboxed text encoders and decoders through wait and resume](https://github.com/openclaw/openclaw/pull/140812). Thanks @Takhoffman.
+- Detach persistent worker listeners from per-task data [#139800](https://github.com/openclaw/openclaw/pull/139800).
+- Reduce compact schema formatting work in Tool Search catalogs [#140228](https://github.com/openclaw/openclaw/pull/140228).
+- Release incoming Code Mode snapshots and delivered results after successful restore and replay [#140565](https://github.com/openclaw/openclaw/pull/140565).
+- Add sandboxed TextEncoder, TextDecoder and encodeInto to Code Mode [#140812](https://github.com/openclaw/openclaw/pull/140812). Thanks @Takhoffman.
+- Reuse values already normalized by Code Mode JSON IPC [#140866](https://github.com/openclaw/openclaw/pull/140866).
+- Keep fast Code Mode tool composition inline and add optional type preflight and clearer diagnostics [#141265](https://github.com/openclaw/openclaw/pull/141265). Thanks @Takhoffman.
 
-**Limits and compatibility**
+**Bug fixes**
 
-- Type checking is optional. These changes do not raise memory limits or add unrestricted filesystem or network access. See [Code Mode](/tools/code-mode).
+- Include process log output and error details in Code Mode results [#139725](https://github.com/openclaw/openclaw/pull/139725).
+- Identify unawaited Code Mode promises instead of displaying empty objects [#140028](https://github.com/openclaw/openclaw/pull/140028).
+- Report accurate Code Mode error locations through waits and headless execution [#140198](https://github.com/openclaw/openclaw/pull/140198).
+- Accept supported mixed query and queries inputs in structured Tool Search [#140310](https://github.com/openclaw/openclaw/pull/140310). Thanks @VACInc.
 
 </details>
 </Accordion>
 
-<Accordion title="Read files and search results in Code Mode">
+<Accordion title="Read files and structured results in Code Mode">
 
-Directory listings and file searches avoid duplicating the same bounded text in their structured results, leaving more room for the result the agent needs. Search also follows Git-compatible ignore patterns, while file paging reduces unnecessary temporary allocations.
+Code Mode receives complete admitted structured tool results for filtering and reduction, with explicit errors when a result exceeds its budget. Directory and search results avoid duplicating bounded text, and file data stays separate from display notices so pagination and handled errors remain usable.
+
+Find and Grep callbacks read text from `details.content`. Directory callbacks use `LsToolDetails.content` and optional `nextAfter`, passing the cursor as `after` for another page. File reading and media preparation also avoid holding some discarded text and buffers longer than needed, while their existing decoding and output limits still apply.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
-**Bug fixes**
-
-- [Keep bounded directory output from consuming the result budget twice](https://github.com/openclaw/openclaw/pull/139910).
-- [Avoid duplicate Find and Grep text in truncation metadata](https://github.com/openclaw/openclaw/pull/140008). Thanks @ruel225.
-- [Apply Git-compatible ignore patterns to file search](https://github.com/openclaw/openclaw/pull/140732).
-
 **Improvements**
 
-- [Reduce temporary allocation when paging large files](https://github.com/openclaw/openclaw/pull/140714).
+- Decode text attachments in bounded chunks up to the existing limit [#139716](https://github.com/openclaw/openclaw/pull/139716).
+- Reuse validated media attachment candidates [#139803](https://github.com/openclaw/openclaw/pull/139803).
+- Preserve directory listings and file/content search results in Code Mode [#139910](https://github.com/openclaw/openclaw/pull/139910).
+- Avoid duplicate search text in Code Mode truncation metadata [#140008](https://github.com/openclaw/openclaw/pull/140008). Thanks @ruel225.
+- Release rejected image buffers while trying later resize candidates [#140175](https://github.com/openclaw/openclaw/pull/140175).
+- Reduce allocation and source-text retention for bounded file reads [#140200](https://github.com/openclaw/openclaw/pull/140200).
+- Reuse image header inspection when preserving PNG, JPEG and WebP originals [#140206](https://github.com/openclaw/openclaw/pull/140206).
+- Avoid repeated complete JSON parsing during Code Mode result fitting [#140242](https://github.com/openclaw/openclaw/pull/140242).
+- Release cache-owned document buffers after extraction settles [#140561](https://github.com/openclaw/openclaw/pull/140561).
+- Copy selected tool-output previews, tails and line prefixes to release discarded backing text [#140570](https://github.com/openclaw/openclaw/pull/140570).
+- Reduce temporary allocations when the agent reads large text files [#140714](https://github.com/openclaw/openclaw/pull/140714).
+- Refresh dependencies, including improved Git-style ignore-pattern matching [#140732](https://github.com/openclaw/openclaw/pull/140732).
+- Copy playback input through bounded buffers before conversion [#140839](https://github.com/openclaw/openclaw/pull/140839).
 
-**Limits and compatibility**
+**Bug fixes**
 
-- Find and Grep callbacks now read bounded text from `details.content`. Directory callbacks use `LsToolDetails.content` and optional `nextAfter`, passing that cursor as `after` for another page. Genuinely oversized results still hit the existing budget.
+- Separate file data from display notices and preserve Code Mode pagination and handled Error details [#140689](https://github.com/openclaw/openclaw/pull/140689). Thanks @Takhoffman.
+- Deliver complete admitted structured tool results to Code Mode programs for filtering and reduction [#141223](https://github.com/openclaw/openclaw/pull/141223). Thanks @Takhoffman. The default structured-result inbox allowance is 10 MiB, subject to the existing clamps; heap, snapshot, and emitted-output budgets still apply.
 
 </details>
 </Accordion>
 
 <Accordion title="Schedule tools and continue delegated work">
 
-Tools that require sequential execution keep that requirement across Code Mode, Tool Search, and MCP, while tools that support parallel work remain concurrent. Core serial subagent handoffs also acknowledge a settled result when the parent accepts its next child and yields, avoiding a duplicate completion turn in that path.
+Bounded recursive session spawning is enabled by default, retaining depth, concurrency, target, and sandbox restrictions. Set `maxSpawnDepth` to `1` to retain leaf-only children. Tool scheduling respects sequential-only tools across Code Mode, Tool Search, and MCP while parallel-capable work can still run concurrently.
+
+Core handoffs acknowledge settled children, yielded orchestrators can resume their original task, and reset or cancellation targets the current child execution. If unfinished native child work cannot be cancelled, the conversation remains uncleared with an actionable error. Ordinary sub-agents are recommended for one or a few tasks, with Swarm reserved in guidance for larger batches.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Enable bounded recursive session spawning by default [#138059](https://github.com/openclaw/openclaw/pull/138059). Thanks @fuller-stack-dev.
+- Use secure OpenClaw scratch storage when preparing worker sessions [#139387](https://github.com/openclaw/openclaw/pull/139387).
+- Reserve released Code Mode capacity for Swarm completion callbacks [#139420](https://github.com/openclaw/openclaw/pull/139420).
+- Avoid loading saved prompt payloads during background-task checks [#139432](https://github.com/openclaw/openclaw/pull/139432).
+- Use session metadata for subagent checks in large session stores [#139450](https://github.com/openclaw/openclaw/pull/139450).
+- Use metadata-only session reads when building subagent lists [#139540](https://github.com/openclaw/openclaw/pull/139540). Thanks @LiuwqGit.
+- Filter session task history before copying retained details [#139992](https://github.com/openclaw/openclaw/pull/139992).
+- Queue bounded Code Mode fan-out without increasing in-flight limits [#140912](https://github.com/openclaw/openclaw/pull/140912). Thanks @Takhoffman. At most 128 ordinary requests wait, and an overflowing synchronous frontier is refused atomically. Swarm quotas and in-flight limits remain separate.
+- Recommend ordinary sub-agents for one or a few tasks and reserve Swarm for larger batches [#141447](https://github.com/openclaw/openclaw/pull/141447).
+
+**Bug fixes**
+
+- Acknowledge settled serial subagent handoffs without replaying the parent [#139986](https://github.com/openclaw/openclaw/pull/139986). Thanks @FabianJun, @obviyus. Core sessions_spawn handoffs are covered; native-only receipt handling is separate.
+- Resume nested orchestrators after sessions_yield and preserve original-task completion [#140137](https://github.com/openclaw/openclaw/pull/140137). Thanks @gaoanze888, @BottaniCals, @evan-zhang.
+- Cancel resumed yielded subagent tasks through their current execution [#140410](https://github.com/openclaw/openclaw/pull/140410). Thanks @hannesrudolph.
+- Stop unfinished native subagent work before resetting or starting a new conversation [#140417](https://github.com/openclaw/openclaw/pull/140417). Thanks @hannesrudolph.
+- Honor sequential-tool contracts in Code Mode, Tool Search and MCP calls [#140767](https://github.com/openclaw/openclaw/pull/140767). Thanks @Takhoffman. Cancellation cannot forcibly terminate an uncooperative external tool.
+
+</details>
+</Accordion>
+
+<Accordion title="Manage long conversations and session lists">
+
+Older durable conversations are archived instead of deleted, retaining their identities and transcript generations for restoration. The default target rises to 5,000 active sessions while explicit configured limits remain in effect, and protected history may exceed disk targets.
+
+Session listing, selection, and single-session actions avoid loading unrelated saved prompts or doing full-inventory work when metadata is sufficient. Long-conversation preparation also reduces repeated copying and projection work, without changing billing totals or turning localized measurements into a universal response-time promise.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Clear stale context usage after prompt truncation while retaining cumulative billing totals [#120573](https://github.com/openclaw/openclaw/pull/120573). Thanks @vincentkoc.
+- Apply the requested session-list limit before enriching display metadata [#127225](https://github.com/openclaw/openclaw/pull/127225).
+- Archive aged durable conversations instead of deleting them and raise the default active-session target [#136639](https://github.com/openclaw/openclaw/pull/136639). Thanks @yetval.
+- Reuse validated metadata to reduce cold session-catalog listing delays [#139146](https://github.com/openclaw/openclaw/pull/139146).
+- Retain compact tool-result replay data instead of full source text and message copies [#139157](https://github.com/openclaw/openclaw/pull/139157).
+- Prepare large branch summaries with append-and-reverse selection instead of repeated prepends [#139301](https://github.com/openclaw/openclaw/pull/139301).
+- Reduce redundant authorization reads during session deletion [#139467](https://github.com/openclaw/openclaw/pull/139467).
+- Use metadata for incognito key collision checks in large stores [#139528](https://github.com/openclaw/openclaw/pull/139528).
+- Avoid loading unrelated saved prompts during session creation and adoption [#139529](https://github.com/openclaw/openclaw/pull/139529).
+- Use metadata for session resolution in large stores [#139610](https://github.com/openclaw/openclaw/pull/139610).
+- Append transcript suffix records in order without repeated prepending [#139690](https://github.com/openclaw/openclaw/pull/139690).
+- Track only admitted history-page sequences [#139715](https://github.com/openclaw/openclaw/pull/139715).
+- Use session metadata projections for explicit and automatic tail selection [#139730](https://github.com/openclaw/openclaw/pull/139730). Thanks @ly85206559, @obviyus.
+- Reuse date and time formatters during prompt preparation [#139740](https://github.com/openclaw/openclaw/pull/139740).
+- Read the exact session and its children without enumerating other prompts [#139773](https://github.com/openclaw/openclaw/pull/139773).
+- Normalize context paths once and reuse their basenames [#139865](https://github.com/openclaw/openclaw/pull/139865).
+- Trim bulk queue overflow summaries in one operation [#140095](https://github.com/openclaw/openclaw/pull/140095).
+- Reduce agent bootstrap accounting overhead while preserving budgets [#140142](https://github.com/openclaw/openclaw/pull/140142).
+- Reduce temporary allocations when planning conversation compaction [#140177](https://github.com/openclaw/openclaw/pull/140177).
+- Avoid full-inventory authorization work for single-session actions in large stores [#141359](https://github.com/openclaw/openclaw/pull/141359).
+- Separate lightweight pending-reply state from outbound delivery imports [#141629](https://github.com/openclaw/openclaw/pull/141629).
+
+**Bug fixes**
+
+- Preserve assistant-item identity and settled output across streaming clients [#139507](https://github.com/openclaw/openclaw/pull/139507).
+
+</details>
+</Accordion>
+
+<Accordion title="Read terminal output and diagnostics">
+
+Terminal pickers close after selection without discarding the next draft, status commands retain channel and account rows, and approval guidance uses operator-assigned device names. Note input preserves line endings and Unicode, while raw hexadecimal input remains available alongside normal terminal keys on supported POSIX paths.
+
+Diagnostic formatting handles very large command output without its earlier stack failure, and explicitly blank numeric options are rejected rather than silently treated as defaults. Scripts should omit an option when they want its default; refreshed Bash completions preserve quoted and escaped option values.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Require command-specific CLI options after their owning command [#137114](https://github.com/openclaw/openclaw/pull/137114). Thanks @qingminglong. Put command-specific options after their command, for example openclaw status --json; global options can remain before it.
+- Resolve configured channel secrets during fast status scans [#137269](https://github.com/openclaw/openclaw/pull/137269). Thanks @LiuwqGit, @obviyus, @zyrill.
+- Record pre-run directive rejections as skipped dispatch turns [#137330](https://github.com/openclaw/openclaw/pull/137330). Thanks @ruel225, @obviyus, @felixboenkost-droid.
+- Report phase durations for slow agent-database opens [#138125](https://github.com/openclaw/openclaw/pull/138125).
+- Clarify the session scope of the task-run empty message [#138597](https://github.com/openclaw/openclaw/pull/138597). Thanks @sunlit-deng, @obviyus, @anyech.
+- Preserve CLI note text across CRLF, CR and Unicode separators [#139512](https://github.com/openclaw/openclaw/pull/139512).
+- Preserve raw hex bytes alongside Unicode and control-key input [#139648](https://github.com/openclaw/openclaw/pull/139648).
+- Reuse repeated structured log context during inspection [#139666](https://github.com/openclaw/openclaw/pull/139666).
+- Shorten long CLI labels without expanding the entire string [#139668](https://github.com/openclaw/openclaw/pull/139668).
+- Release unused TUI tool payloads after preparing their display [#139739](https://github.com/openclaw/openclaw/pull/139739).
+- Avoid measuring unchanged CLI text-cell width twice [#139779](https://github.com/openclaw/openclaw/pull/139779).
+- Defer TUI editor snapshots until autocomplete confirmation [#139785](https://github.com/openclaw/openclaw/pull/139785).
+- Share bounded WebSocket timing records across logging styles [#139804](https://github.com/openclaw/openclaw/pull/139804).
+- Prepare probe-namespace classification once per logger [#139863](https://github.com/openclaw/openclaw/pull/139863).
+- Defer unused health and status formatting [#140123](https://github.com/openclaw/openclaw/pull/140123).
+- Reduce hyperlink rendering work while preserving terminal text and link targets [#140290](https://github.com/openclaw/openclaw/pull/140290).
+- Skip hidden-thinking presentation work in terminal history [#140360](https://github.com/openclaw/openclaw/pull/140360).
+- Reduce formatting work in verbose tool descriptions [#140389](https://github.com/openclaw/openclaw/pull/140389).
+- Prepare terminal session-picker rows once per opening to reduce repeated filtering work [#140462](https://github.com/openclaw/openclaw/pull/140462).
+- Iterate graphemes lazily when wrapping terminal tables and notes [#140773](https://github.com/openclaw/openclaw/pull/140773).
+- Reduce repeated terminal-text scans during TUI text and picker updates [#141244](https://github.com/openclaw/openclaw/pull/141244).
+- Reuse parsed listener facts when preparing Gateway port diagnostics [#141281](https://github.com/openclaw/openclaw/pull/141281).
+- Reduce repeated formatting work in summarized Gateway logs [#141329](https://github.com/openclaw/openclaw/pull/141329).
+- Defer CLI respawn diagnostics until a start failure needs them [#141525](https://github.com/openclaw/openclaw/pull/141525).
+
+**Bug fixes**
+
+- Complete quoted and escaped Bash option-value prefixes [#140034](https://github.com/openclaw/openclaw/pull/140034).
+- Use the canonical session-resolution schema for terminal resume [#140056](https://github.com/openclaw/openclaw/pull/140056).
+- Reject blank values for channel log limits and model status probe options [#140907](https://github.com/openclaw/openclaw/pull/140907). Thanks @Alix-007.
+- Close TUI pickers immediately after selection and preserve the next draft [#141070](https://github.com/openclaw/openclaw/pull/141070).
+- Restore channel and account rows in TUI Gateway status commands [#141120](https://github.com/openclaw/openclaw/pull/141120).
+- Preserve bounded output-limit diagnostics for commands with very large output [#141353](https://github.com/openclaw/openclaw/pull/141353). Thanks @shakkernerd.
+- Show operator device names consistently in node approval guidance [#141649](https://github.com/openclaw/openclaw/pull/141649).
+
+</details>
+</Accordion>
+
+<Accordion title="Preserve formatting in exported conversations">
+
+HTML conversation exports retain Markdown formatting inside tight list items, including bold text, links, and literal inline code.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- [Respect sequential tool contracts across shared tool catalogs](https://github.com/openclaw/openclaw/pull/140767). Thanks @Takhoffman.
-- [Acknowledge settled core subagent handoffs without replaying the parent](https://github.com/openclaw/openclaw/pull/139986). Thanks @FabianJun and @obviyus.
+- Render Markdown correctly inside tight lists in HTML session exports [#140830](https://github.com/openclaw/openclaw/pull/140830).
 
-**Limits and compatibility**
+</details>
+</Accordion>
 
-- Cancellation cannot forcibly stop an uncooperative external tool. The handoff repair applies to core `sessions_spawn`; native-only receipt handling is separate.
+<Accordion title="Follow child worktree setup">
+
+Child worktree failures appear in chat, and missing objects in partial Git clones are fetched in batches before worktree sizing. Interrupted or failed setup remains visible instead of looking like a child that is quietly waiting to start.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Expose child worktree failures in chat and batch missing Git objects before sizing [#141537](https://github.com/openclaw/openclaw/pull/141537).
 
 </details>
 </Accordion>
 
 <Accordion title="Find command and configuration help">
 
-Configuration references are split into more focused pages, repaired redirects preserve familiar entry points, and clearer command titles make the help easier to navigate.
+Configuration references are divided into focused pages with familiar anchors preserved, and corrected redirects keep older entry points useful. CLI documentation searches can limit displayed results, while revised examples explain existing command deadlines, approvals, secrets, hooks, diagnostics, and Code Mode output helpers.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Documentation**
 
-- [Organize focused configuration references](https://github.com/openclaw/openclaw/pull/140440). Thanks @vincentkoc.
-- [Restore configuration documentation redirects](https://github.com/openclaw/openclaw/pull/140450). Thanks @vincentkoc.
-- [Give CLI reference pages distinct command titles](https://github.com/openclaw/openclaw/pull/140208). Thanks @vincentkoc.
+- Limit displayed docs search results with the positive-integer --limit option [#131014](https://github.com/openclaw/openclaw/pull/131014). Thanks @Alix-007, @shakkernerd. The positive-integer --limit option caps displayed results, not the downloaded response.
+- Clarify background command deadlines and the existing zero-timeout option [#140022](https://github.com/openclaw/openclaw/pull/140022).
+- Ground shell approval guidance in actual pending tool results [#140043](https://github.com/openclaw/openclaw/pull/140043).
+- Document text and json emission helpers in Code Mode tool descriptions [#140140](https://github.com/openclaw/openclaw/pull/140140).
+- Give CLI reference pages distinct documentation titles [#140208](https://github.com/openclaw/openclaw/pull/140208). Thanks @vincentkoc.
+- Split the v2026.8.1 release archive and clarify the release index [#140319](https://github.com/openclaw/openclaw/pull/140319). Thanks @vincentkoc.
+- Describe Code Mode execution budgets and suitable shell alternatives [#140321](https://github.com/openclaw/openclaw/pull/140321).
+- Keep release section pages accessible from their index while simplifying sidebar navigation [#140353](https://github.com/openclaw/openclaw/pull/140353). Thanks @vincentkoc.
+- Organize large documentation navigation groups and service lists [#140391](https://github.com/openclaw/openclaw/pull/140391). Thanks @vincentkoc.
+- Remove empty release-section navigation headings [#140427](https://github.com/openclaw/openclaw/pull/140427). Thanks @vincentkoc.
+- Split the configuration reference into focused pages while retaining existing anchors [#140440](https://github.com/openclaw/openclaw/pull/140440). Thanks @vincentkoc.
+- Correct twelve redirects that sent readers to nonexistent English-prefixed pages [#140450](https://github.com/openclaw/openclaw/pull/140450). Thanks @vincentkoc.
+- Split agent configuration reference material into eight domains while retaining old anchors [#141149](https://github.com/openclaw/openclaw/pull/141149). Thanks @vincentkoc.
+- Correct documented secrets, join-code, consent, image, agent-exec, hooks and diagnostic examples [#141158](https://github.com/openclaw/openclaw/pull/141158). Thanks @vincentkoc.
 
 </details>
 </Accordion>
@@ -1573,55 +3292,184 @@ Configuration references are split into more focused pages, repaired redirects p
 
 ## Other Bug Fixes
 
-The remaining fixes cover the work underneath a conversation, including database contention, command completion, and oversized inline images. They keep recoverable failures from turning into unrelated connection crashes or misleading command results.
+The remaining fixes cover conversation storage, command lifecycles, workspace recovery, and runtime startup. They preserve completed results and useful diagnostics while keeping uncertain cleanup or failed recovery visible.
 
 <AccordionGroup>
-<Accordion title="Keep conversation storage responsive">
+<Accordion title="Preserve complete transcript rewrites">
 
-Repeated transcript reconciliation is paced without discarding queued writes, and restoring a worktree releases the conversation writer while the restore continues. Closed databases also release their prepared objects, reducing retained state after that connection is finished.
+Conversation maintenance publishes complete transcript rewrites atomically and preserves the selected history through resets, interruptions, and later messages. Input relocation is published before fallible observers, keeping immediate replay attached to the intended path.
+
+Keep the updated writer and readers together when rolling back code. Older unpatched readers are not a supported rollback for this change, and previously damaged histories are not repaired automatically.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- [Pace transcript reconciliation without discarding queued writes](https://github.com/openclaw/openclaw/pull/119126). Thanks @shad0wca7.
-- [Release the conversation writer during worktree restoration](https://github.com/openclaw/openclaw/pull/139051).
-- [Release prepared SQLite objects with their closed database](https://github.com/openclaw/openclaw/pull/139085).
-- [Avoid full-history cleanup for new internal context-overflow signals](https://github.com/openclaw/openclaw/pull/140231). Thanks @VACInc. Existing amplified histories are not rewritten by this repair.
+- Publish complete transcript rewrites atomically and preserve their selected ancestry across readers [#138984](https://github.com/openclaw/openclaw/pull/138984). Thanks @VACInc, @keumhyun.
+- Publish transcript input relocation before fallible observers and preserve selected-path replay [#139002](https://github.com/openclaw/openclaw/pull/139002). Thanks @fuller-stack-dev.
+
+</details>
+</Accordion>
+
+<Accordion title="Preserve conversation history and task outcomes">
+
+Transcript maintenance is paced without discarding queued writes, and other conversations can save changes while an archived worktree is being restored. Session cleanup and cold updates reduce specific causes of database contention and stalls, while storage errors retain bounded, redacted causes and separate validation stages.
+
+Fresh tool results remain protected until the next assistant response uses them, unsuccessful child completions settle durably, and final replies can survive the end of their launching turn. Cleanup and recovery preserve ownership checks so an older operation cannot clear or publish into a newer one.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Pace repeated transcript reconciliation attempts without discarding queued writes [#119126](https://github.com/openclaw/openclaw/pull/119126). Thanks @shad0wca7.
+- Bound workspace prompt-file caching and retire entries after committed workspace deletion [#127837](https://github.com/openclaw/openclaw/pull/127837). Thanks @vyctorbrzezowski.
+- Honor the active-transcript size cap for heartbeat-driven sessions and preserve committed host compaction even when optional Codex synchronization fails [#136533](https://github.com/openclaw/openclaw/pull/136533). Thanks @LiuwqGit, @zhangguiping-xydt, @vincentkoc, @thomasmoenco.
+- Settle terminal unsuccessful child completion delivery durably [#137344](https://github.com/openclaw/openclaw/pull/137344). Thanks @xydt-juyaohui, @laurenceputra, @fuller-stack-dev.
+- Unify wake scheduling while preserving captured background-session ownership [#138451](https://github.com/openclaw/openclaw/pull/138451).
+- Release the session writer while restoring an archived worktree, retaining ownership checks at commit [#139051](https://github.com/openclaw/openclaw/pull/139051).
+- Release cached SQLite statements with their database lifecycle owner [#139085](https://github.com/openclaw/openclaw/pull/139085).
+- Prepare session restoration outside the SQLite writer and reject stale target changes at commit [#139114](https://github.com/openclaw/openclaw/pull/139114).
+- Scope global-session initialization checks to the selected agent [#139130](https://github.com/openclaw/openclaw/pull/139130). Thanks @ly85206559.
+- Protect fresh tool results until the next assistant response consumes them [#139165](https://github.com/openclaw/openclaw/pull/139165). Thanks @obviyus, @GarySiu.
+- Preserve the owning agent when resolving global sessions for worker execution [#139216](https://github.com/openclaw/openclaw/pull/139216). Thanks @ly85206559.
+- Keep pending placement maintenance from blocking unrelated dispatches behind slow provisioning [#139251](https://github.com/openclaw/openclaw/pull/139251).
+- Bind exact-claim cleanup at admission so force-cleared startup cannot block or release a successor turn [#139265](https://github.com/openclaw/openclaw/pull/139265). Thanks @johan-eilertsen, @obviyus.
+- Preserve original failed completion when summary recovery cannot produce an answer [#139309](https://github.com/openclaw/openclaw/pull/139309). Thanks @altaywtf.
+- Prevent transcript database-lock failures during concurrent session reclamation [#139469](https://github.com/openclaw/openclaw/pull/139469).
+- Validate audit sequence ranges before native numeric decoding [#139587](https://github.com/openclaw/openclaw/pull/139587).
+- Preserve one-shot cleanup mode and runtime tool grants across agent attempts [#140110](https://github.com/openclaw/openclaw/pull/140110).
+- Preserve literal Markdown values and reject redaction-marker insertions before writes or previews [#140150](https://github.com/openclaw/openclaw/pull/140150).
+- Avoid full-history cleanup for new internal context-overflow signals [#140231](https://github.com/openclaw/openclaw/pull/140231). Thanks @VACInc.
+- Preserve error diagnostics and successful tool responses when observers fail [#140362](https://github.com/openclaw/openclaw/pull/140362).
+- Preserve final replies for child tool runs after their launching turn finishes [#140399](https://github.com/openclaw/openclaw/pull/140399). Thanks @Takhoffman.
+- Reduce event-loop stalls during cold session updates while retaining database ownership [#140840](https://github.com/openclaw/openclaw/pull/140840).
+- Yield before row projection when session-list preparation exhausts its work budget [#140862](https://github.com/openclaw/openclaw/pull/140862).
+- Log bounded redacted SQLite write error messages and causes [#141507](https://github.com/openclaw/openclaw/pull/141507).
+- Classify durable background exec tasks correctly in suspension blockers [#141588](https://github.com/openclaw/openclaw/pull/141588).
+- Report separate database validation stages and repaired-index counts [#141619](https://github.com/openclaw/openclaw/pull/141619).
 
 </details>
 </Accordion>
 
 <Accordion title="Finish and cancel commands">
 
-Command cleanup preserves the command's outcome while dealing with remaining processes, and completed Bun commands retain their output. When the operating system reports an error, its underlying cause stays available instead of disappearing behind a generic failure.
+Command cleanup preserves the original result while observing remaining owned processes, and completed output can be returned without waiting indefinitely for retained descendants. Background results retain their process-specific lifetime, SSH diagnostics survive split reads, and terminal control sequences can span output chunks.
+
+Cleanup stays conservative when the operating system cannot confirm that a process group has exited. Some strict cleanup paths use a non-PTY fallback, and deliberately escaped descendants remain outside the owned process group's containment.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- [Clean up sandbox commands through their supported process path](https://github.com/openclaw/openclaw/pull/139948).
-- [Observe process-group exit before reporting cleanup completion](https://github.com/openclaw/openclaw/pull/139957).
-- [Retain completed command output under Bun](https://github.com/openclaw/openclaw/pull/139965).
-- [Preserve underlying operating-system errors in command failures](https://github.com/openclaw/openclaw/pull/140015).
-- [Preserve parent CLI options, literal argument boundaries, and machine-readable errors](https://github.com/openclaw/openclaw/pull/139067).
+- Retain completed command output for each process owner's configured duration [#127231](https://github.com/openclaw/openclaw/pull/127231).
+- Keep background process activity with the managed run until terminal completion [#135604](https://github.com/openclaw/openclaw/pull/135604).
+- Detach the login-shell environment probe so it cannot take the CLI's controlling terminal [#139308](https://github.com/openclaw/openclaw/pull/139308). Thanks @ylcn91, @obviyus, @resYuto.
+- Require confirmed cleanup before releasing owned command work [#139517](https://github.com/openclaw/openclaw/pull/139517).
+- Support supervised command startup under Bun [#139555](https://github.com/openclaw/openclaw/pull/139555).
+- Require resource-cleanup evidence before releasing owned agent work [#139657](https://github.com/openclaw/openclaw/pull/139657).
+- Parse PTY cursor controls across output chunks [#139742](https://github.com/openclaw/openclaw/pull/139742).
+- Preserve sandbox command cleanup outcomes and observe Linux process groups through procfs [#139948](https://github.com/openclaw/openclaw/pull/139948).
+- Wait for command and SCP subprocess groups to exit after force cancellation [#139957](https://github.com/openclaw/openclaw/pull/139957).
+- Release completed command output under Bun without waiting for retained descendants [#139965](https://github.com/openclaw/openclaw/pull/139965).
+- Preserve the cause of process cleanup observation errors [#140015](https://github.com/openclaw/openclaw/pull/140015).
+- Join relay reaping before the process extinction probe [#140134](https://github.com/openclaw/openclaw/pull/140134).
+- Preserve command output deadlines and failure results after the root process exits [#140927](https://github.com/openclaw/openclaw/pull/140927).
+- Preserve SSH diagnostics across split pipe reads [#141399](https://github.com/openclaw/openclaw/pull/141399).
 
 </details>
 </Accordion>
 
-<Accordion title="Handle disconnects and oversized images">
+<Accordion title="Recover connections and runtime startup">
 
-A client disconnect during WebSocket setup no longer leaves its early error unhandled on the affected Gateway and portal path. Oversized inline image data also reaches the intended size error instead of overflowing the parser's stack.
+Early WebSocket errors and rejected connections are handled without leaving unrelated connections exposed to an unhandled failure. Prepared model runtimes finish closing before authentication is torn down, and supported foreground restart failures leave the process available for an operator to correct the cause and retry, serving no requests until startup succeeds.
+
+Other fixes preserve selected-service credentials during status probes, apply configured environment changes after an in-process restart, and support agent state on SQLite builds without native extensions. Native vector extensions still require a compatible SQLite library.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Bug fixes**
 
-- [Handle early WebSocket errors during client disconnects](https://github.com/openclaw/openclaw/pull/139061).
-- [Report oversized inline images without a regular-expression stack failure](https://github.com/openclaw/openclaw/pull/140226).
+- Keep service status probes tied to the selected service and its credentials [#135862](https://github.com/openclaw/openclaw/pull/135862). Thanks @SunnyShu0925, @vincentkoc.
+- Handle socket errors immediately during Gateway and portal WebSocket upgrades [#139061](https://github.com/openclaw/openclaw/pull/139061).
+- Open agent state on SQLite builds without native extensions [#139487](https://github.com/openclaw/openclaw/pull/139487).
+- Flush WebSocket upgrade rejection responses before closing sockets [#139516](https://github.com/openclaw/openclaw/pull/139516).
+- Update Proxyline to 0.3.11 for Bun peer selection and standalone-worker bundling [#140411](https://github.com/openclaw/openclaw/pull/140411).
+- Share one-shot ticket and WebSocket helpers and guard rejected sockets against client resets [#141185](https://github.com/openclaw/openclaw/pull/141185).
+- Close and join prepared model runtimes before tearing down their authentication bindings [#141280](https://github.com/openclaw/openclaw/pull/141280).
+- Apply replacement and removal of configured environment values after an in-process Gateway restart [#141296](https://github.com/openclaw/openclaw/pull/141296). Thanks @obviyus.
+- Keep a foreground Gateway process alive after failed restarts so operators can correct the cause and retry [#141297](https://github.com/openclaw/openclaw/pull/141297). Thanks @obviyus.
+- Keep cloud bootstrap's deploy worker import closure self-contained [#141553](https://github.com/openclaw/openclaw/pull/141553).
+
+</details>
+</Accordion>
+
+<Accordion title="Diagnose workspace conflicts and coordinate Git writes">
+
+Workspace recovery distinguishes unreadable conflict records from verified absence. Shared Git writes are coordinated within the process during cleanup and result publication, while external Git contention remains an error rather than a reason to delete locks. Blocked cloud-worker archives retain bounded explanations without forcing an archive or silently repairing cloud resources.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Distinguish unreadable workspace conflicts from verified absence during recovery [#139582](https://github.com/openclaw/openclaw/pull/139582).
+- Coordinate shared Git writes during worktree cleanup and node-result publication [#141095](https://github.com/openclaw/openclaw/pull/141095).
+- Explain blocked cloud-worker archives and preserve bounded failure diagnoses [#141449](https://github.com/openclaw/openclaw/pull/141449).
+
+</details>
+</Accordion>
+
+<Accordion title="Handle files and media errors">
+
+Oversized inline images reach the intended size-limit error instead of overflowing the parser's stack. Older supported ffprobe diagnostics use the existing fallback, and complete quoted cache validators are compared correctly even when their text contains commas or asterisks.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Recognize older ffprobe diagnostics and use the existing pipe fallback [#137219](https://github.com/openclaw/openclaw/pull/137219). Thanks @coderdailyone.
+- Return the intended size-limit error for oversized inline images [#140226](https://github.com/openclaw/openclaw/pull/140226).
+- Compare complete quoted ETags so literal commas and asterisks do not cause false not-modified responses [#140529](https://github.com/openclaw/openclaw/pull/140529).
+
+</details>
+</Accordion>
+
+<Accordion title="Preserve command arguments and output">
+
+CLI dispatch keeps parent options and literal argument boundaries intact, multiline terminal pastes do not accidentally become exit commands, and Unicode survives delegated-task diagnostics. Disabled accounts display as off, bare telemetry help exits successfully, and headless Linux file opening reports the missing opener clearly.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve Unicode in delegated-task diagnostics [#137699](https://github.com/openclaw/openclaw/pull/137699). Thanks @ly85206559.
+- Preserve loaded-plugin parsing ownership and simplify tool allowlist preparation [#138392](https://github.com/openclaw/openclaw/pull/138392).
+- Preserve command dispatch and machine-readable errors when arguments include parent options or -- boundaries [#139067](https://github.com/openclaw/openclaw/pull/139067).
+- Carry hidden-command metadata through lazy registration so root help stays consistent [#139108](https://github.com/openclaw/openclaw/pull/139108).
+- Show the established headless-environment diagnostic when xdg-open is missing [#139252](https://github.com/openclaw/openclaw/pull/139252). Thanks @upple, @obviyus.
+- Preserve multiline paste boundaries when dispatching local TUI commands [#139639](https://github.com/openclaw/openclaw/pull/139639).
+- Exit successfully when displaying bare telemetry command help [#140283](https://github.com/openclaw/openclaw/pull/140283). Thanks @Grynn.
+- Show disabled channel accounts as OFF in health diagnostics [#141560](https://github.com/openclaw/openclaw/pull/141560).
+
+</details>
+</Accordion>
+
+<Accordion title="Parse malformed Code Mode input">
+
+Malformed assignment-prefixed Code Mode input with repeated quotes reaches a syntax error promptly instead of stalling its worker. The accepted grammar and execution budgets remain unchanged.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Bound repeated-quote shell classification while preserving the existing grammar [#138899](https://github.com/openclaw/openclaw/pull/138899). Thanks @lzhan011, @obviyus.
 
 </details>
 </Accordion>
@@ -1629,42 +3477,913 @@ A client disconnect during WebSocket setup no longer leaves its early error unha
 
 ## Maintainer and Internal Changes
 
-Maintainer work consolidates internal runtime helpers, improves focused test fixtures, and updates review, documentation, and release tooling. These changes support development and qualification without introducing additional user-facing features.
+This release includes 817 maintainer and internal changes covering runtime organization, tests, build and release tooling, and documentation. The release history also contains ten changes already shipped in 2026.9.2 and three records for work that was reverted before this release; those are listed separately below.
 
 <AccordionGroup>
-<Accordion title="Runtime implementation and focused tests">
+<Accordion title="Runtime implementation and resource ownership">
 
-Private runtime consolidation reduces duplicated preparation and ownership code, while test changes isolate temporary state and make platform-specific failures easier to investigate.
+Internal changes consolidate shared runtime helpers, typed contracts, database queries, and resource ownership across agents, providers, channels, and clients. Their source details preserve the specific areas affected without treating implementation cleanup as additional product features or general performance guarantees.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Improvements**
 
-- [Share strict-tool diagnostics without changing OpenAI requests](https://github.com/openclaw/openclaw/pull/140697).
-- [Share native chat operations while preserving platform routing](https://github.com/openclaw/openclaw/pull/140985).
+- Reuse stable route-model metadata across turns with bounded generation-owned caching [#118466](https://github.com/openclaw/openclaw/pull/118466). Thanks @zeroaltitude.
+- Close Gateway startup tracing when startup fails before readiness [#122595](https://github.com/openclaw/openclaw/pull/122595). Thanks @vincentkoc, @ejames-dev.
+- Keep delivery-mode policy in current turn context while preserving stable prompt and tool definitions [#123624](https://github.com/openclaw/openclaw/pull/123624). Thanks @yu-xin-c.
+- Avoid rebuilding unchanged redaction output for large ordinary log messages [#128189](https://github.com/openclaw/openclaw/pull/128189). Thanks @chelsealong.
+- Use shared OpenAI embedding orchestration while retaining canonical inputs and vector-count checks [#131595](https://github.com/openclaw/openclaw/pull/131595).
+- Consolidate compatible embedding batch polling without changing provider retry policies [#133400](https://github.com/openclaw/openclaw/pull/133400).
+- Give the Codex bridge sole ownership of elicitation snapshots and recheck their thread identity [#135167](https://github.com/openclaw/openclaw/pull/135167). Thanks @vincentkoc.
+- Bound code-point prefix allocation across existing text consumers [#136293](https://github.com/openclaw/openclaw/pull/136293). Thanks @edenfunf.
+- Remove one redundant session-payload decode after entry patches [#136361](https://github.com/openclaw/openclaw/pull/136361). Thanks @quangtran88.
+- Remove duplicate casts from browser route registration [#137661](https://github.com/openclaw/openclaw/pull/137661). Thanks @RomneyDa.
+- Compile stored participant identity validation once [#137976](https://github.com/openclaw/openclaw/pull/137976).
+- Avoid duplicate proxy destination parsing and bypass preparation [#138196](https://github.com/openclaw/openclaw/pull/138196).
+- Skip redundant hashing for identical provider configuration objects [#138351](https://github.com/openclaw/openclaw/pull/138351). Thanks @holny, @AS76.
+- Remove redundant media model source-selection plumbing [#138448](https://github.com/openclaw/openclaw/pull/138448).
+- Remove an unused timeout callback field from pending conversation records [#139019](https://github.com/openclaw/openclaw/pull/139019). Thanks @vincentkoc.
+- Consolidate plugin capability-family inventories while preserving existing consent behavior [#139049](https://github.com/openclaw/openclaw/pull/139049).
+- Normalize installed-channel metadata once and share the stable normalizer table [#139050](https://github.com/openclaw/openclaw/pull/139050).
+- Share reply-dispatch hook invocation across ordinary replies and ACP reset tails [#139052](https://github.com/openclaw/openclaw/pull/139052).
+- Consolidate capture cleanup queries without changing transaction or blob-removal boundaries [#139057](https://github.com/openclaw/openclaw/pull/139057).
+- Hand queued worker tasks onward without redundant idle timers or backlog scans [#139069](https://github.com/openclaw/openclaw/pull/139069).
+- Reduce temporary buffer allocation when assembling PNG images [#139070](https://github.com/openclaw/openclaw/pull/139070).
+- Reduce temporary allocation in Gateway-client request tracking [#139073](https://github.com/openclaw/openclaw/pull/139073).
+- Restore protected reply code regions in one pass while preserving delivered text [#139074](https://github.com/openclaw/openclaw/pull/139074).
+- Reduce temporary allocation while streaming tool arguments and projecting fallback HTTP text [#139077](https://github.com/openclaw/openclaw/pull/139077).
+- Read session names directly and avoid redundant parent lookup during navigation [#139080](https://github.com/openclaw/openclaw/pull/139080).
+- Avoid repeated context-key preparation for scoped plugin lookups [#139087](https://github.com/openclaw/openclaw/pull/139087).
+- Separate Matrix storage metadata helpers from client runtime initialization [#139093](https://github.com/openclaw/openclaw/pull/139093).
+- Prepare missing-requirement summaries only when verbose CLI lists display them [#139095](https://github.com/openclaw/openclaw/pull/139095).
+- Consolidate channel-account configuration writes while preserving account and credential policies [#139096](https://github.com/openclaw/openclaw/pull/139096).
+- Centralize typed Talk session queries while preserving transaction and recovery behavior [#139103](https://github.com/openclaw/openclaw/pull/139103).
+- Build Workboard card-tree writes through the shared typed query helper [#139106](https://github.com/openclaw/openclaw/pull/139106).
+- Consolidate outbound message execution context and equivalent core-send paths [#139107](https://github.com/openclaw/openclaw/pull/139107).
+- Reuse per-message token estimates when planning compaction chunks [#139115](https://github.com/openclaw/openclaw/pull/139115).
+- Select bounded head and tail lines without splitting the entire tool output [#139122](https://github.com/openclaw/openclaw/pull/139122).
+- Reuse the shared approval snapshot projection while retaining RPC-only attribution [#139124](https://github.com/openclaw/openclaw/pull/139124).
+- Consolidate media loading options and FFmpeg argument construction [#139127](https://github.com/openclaw/openclaw/pull/139127).
+- Select recent assistant messages without reversing full transcript copies [#139133](https://github.com/openclaw/openclaw/pull/139133).
+- Avoid an unused HEAD lookup when PR-chip landing checks have no merged heads [#139137](https://github.com/openclaw/openclaw/pull/139137).
+- Reuse encoded properties during Gateway broadcast serialization [#139148](https://github.com/openclaw/openclaw/pull/139148).
+- Reuse tool-result budget measurements during projection and compaction recovery planning [#139156](https://github.com/openclaw/openclaw/pull/139156).
+- Avoid rebuilding terminal-link text when an explicit plain fallback is used [#139159](https://github.com/openclaw/openclaw/pull/139159).
+- Avoid a duplicate array copy when normalizing web-search results [#139162](https://github.com/openclaw/openclaw/pull/139162).
+- Avoid repeated scans while retaining action lines in cron command summaries [#139163](https://github.com/openclaw/openclaw/pull/139163).
+- Transfer validated attachment handles to bounded reads instead of reopening the file [#139168](https://github.com/openclaw/openclaw/pull/139168).
+- Release captured audio-cache leases directly while keeping insertion-owned limits [#139174](https://github.com/openclaw/openclaw/pull/139174).
+- Consolidate billing, overload and rate-limit failure summaries without changing retry policy [#139175](https://github.com/openclaw/openclaw/pull/139175).
+- Skip redundant ancestry comparison after PR landing candidates reduce to one [#139186](https://github.com/openclaw/openclaw/pull/139186).
+- Replace obsolete per-session ACP operation counts with one queue-owned total [#139189](https://github.com/openclaw/openclaw/pull/139189).
+- Remove the retired updater's unused FileProvider cache mapping [#139198](https://github.com/openclaw/openclaw/pull/139198).
+- Return committed configuration from plugin-install writer receipts instead of the earlier draft [#139203](https://github.com/openclaw/openclaw/pull/139203). Thanks @obviyus.
+- Remove duplicate filtering before compiling simple channel allowlists [#139224](https://github.com/openclaw/openclaw/pull/139224).
+- Consolidate restart-recovery expected-state construction across Gateway, reply and checkpoint owners [#139233](https://github.com/openclaw/openclaw/pull/139233).
+- Replay wrapped terminal prefixes in one pass while preserving output bytes [#139240](https://github.com/openclaw/openclaw/pull/139240).
+- Unify worker inference payload sequencing and settlement in one operation-owned handler [#139245](https://github.com/openclaw/openclaw/pull/139245).
+- Reuse prepared exact-name matching within each tool-catalog batch [#139267](https://github.com/openclaw/openclaw/pull/139267).
+- Prepare provider endpoint classes in one pass without changing request-policy precedence [#139287](https://github.com/openclaw/openclaw/pull/139287).
+- Reduce temporary allocation during Markdown image attachment extraction [#139298](https://github.com/openclaw/openclaw/pull/139298).
+- Reuse Photon-owned encoded bytes while preserving the exact buffer range and lifetime [#139299](https://github.com/openclaw/openclaw/pull/139299).
+- Allocate transcript cycle-detection sets only for indirect parent traversal [#139300](https://github.com/openclaw/openclaw/pull/139300).
+- Move the unchanged quarantine error factory to its existing lightweight owner [#139302](https://github.com/openclaw/openclaw/pull/139302).
+- Centralize installed-plugin index transaction queries and share the state key [#139307](https://github.com/openclaw/openclaw/pull/139307).
+- Project dispatch fields before environment substitution and remove the redundant deep clone [#139311](https://github.com/openclaw/openclaw/pull/139311).
+- Track eligible compaction boundaries without materializing all candidate indexes [#139324](https://github.com/openclaw/openclaw/pull/139324).
+- Bound pending tool-delivery observers and timer allocation while preserving idle-progress behavior [#139325](https://github.com/openclaw/openclaw/pull/139325).
+- Remove unused spawn retry controls while preserving authority checks and detachment reporting [#139326](https://github.com/openclaw/openclaw/pull/139326).
+- Return early from already-owned store queue pumps while retaining per-operation results and explicit drain joins [#139327](https://github.com/openclaw/openclaw/pull/139327).
+- Avoid re-encoding unchanged inline images after validation [#139329](https://github.com/openclaw/openclaw/pull/139329).
+- Centralize iOS cron pagination while preserving caller budgets, retries and publication ownership [#139335](https://github.com/openclaw/openclaw/pull/139335).
+- Remove unused media-root plumbing and share availability options while retaining Gateway authorization [#139346](https://github.com/openclaw/openclaw/pull/139346).
+- Avoid preparing sorted dispatch lists when only hook availability is needed [#139352](https://github.com/openclaw/openclaw/pull/139352).
+- Reuse node invocation idle timers at existing renewal points [#139354](https://github.com/openclaw/openclaw/pull/139354).
+- Reuse duration and relative-time formatters for the active interface language [#139356](https://github.com/openclaw/openclaw/pull/139356).
+- Share sealed subprocess bootstrap and separate generic process URL resolution [#139359](https://github.com/openclaw/openclaw/pull/139359).
+- Consolidate failure classification, retry bookkeeping and compaction dispatch [#139362](https://github.com/openclaw/openclaw/pull/139362).
+- Skip wrapper-line projection when reply text cannot contain wrapper tags [#139363](https://github.com/openclaw/openclaw/pull/139363).
+- Reuse cached statements for repeated SQLite schema validation [#139366](https://github.com/openclaw/openclaw/pull/139366).
+- Simplify assembly of audio, image and video description sections [#139370](https://github.com/openclaw/openclaw/pull/139370).
+- Remove unused permissive build-manager modes and unreachable nullable command handling [#139378](https://github.com/openclaw/openclaw/pull/139378).
+- Reduce repeated CLI command-argument parsing without changing accepted options [#139386](https://github.com/openclaw/openclaw/pull/139386).
+- Stream Workboard child-table preloads and share revision checks [#139389](https://github.com/openclaw/openclaw/pull/139389).
+- Build typed Workboard board and notification-subscription upserts [#139398](https://github.com/openclaw/openclaw/pull/139398).
+- Reuse unchanged transcript key snapshots during rendering [#139400](https://github.com/openclaw/openclaw/pull/139400).
+- Remove redundant recovery adapters and auth-state accessors [#139410](https://github.com/openclaw/openclaw/pull/139410).
+- Bound UTF-8 encoding work when retaining command-output tails [#139414](https://github.com/openclaw/openclaw/pull/139414).
+- Remove a redundant update CLI subprocess adapter [#139422](https://github.com/openclaw/openclaw/pull/139422).
+- Reuse owned tool-projection arrays at internal handoffs [#139424](https://github.com/openclaw/openclaw/pull/139424).
+- Separate machine-state readers from mutation helpers [#139425](https://github.com/openclaw/openclaw/pull/139425).
+- Avoid full multiline projection for bounded tool-error summaries [#139476](https://github.com/openclaw/openclaw/pull/139476).
+- Consolidate package-manager option scanning for exec analysis [#139482](https://github.com/openclaw/openclaw/pull/139482).
+- Avoid temporary NodeList copies during browser snapshots [#139502](https://github.com/openclaw/openclaw/pull/139502).
+- Reuse parent links to find browser role-tree roots [#139532](https://github.com/openclaw/openclaw/pull/139532).
+- Reuse current-query highlight patterns in TUI pickers [#139533](https://github.com/openclaw/openclaw/pull/139533).
+- Reduce temporary allocations during Prometheus metric rendering [#139535](https://github.com/openclaw/openclaw/pull/139535).
+- Consolidate package-manager argument scanning [#139560](https://github.com/openclaw/openclaw/pull/139560).
+- Consolidate model-selector reference traversal [#139571](https://github.com/openclaw/openclaw/pull/139571).
+- Remove dead code and redundant indirection across repository owners [#139573](https://github.com/openclaw/openclaw/pull/139573).
+- Share integer conversion for iOS automation and usage models [#139581](https://github.com/openclaw/openclaw/pull/139581).
+- Simplify agent attempt execution and recovery plumbing [#139597](https://github.com/openclaw/openclaw/pull/139597).
+- Keep internal SDK helper types private [#139601](https://github.com/openclaw/openclaw/pull/139601). Thanks @vincentkoc.
+- Share pending Skill Workshop proposal creation [#139617](https://github.com/openclaw/openclaw/pull/139617).
+- Share legacy authentication-choice resolution across onboarding [#139636](https://github.com/openclaw/openclaw/pull/139636).
+- Share native session mutation request construction [#139641](https://github.com/openclaw/openclaw/pull/139641).
+- Remove duplicate Gmail CLI option projection [#139659](https://github.com/openclaw/openclaw/pull/139659).
+- Reuse Android automation interval formatting [#139684](https://github.com/openclaw/openclaw/pull/139684).
+- Share Gateway error-detail normalization [#139695](https://github.com/openclaw/openclaw/pull/139695).
+- Remove redundant pristine-startup planning wrappers [#139702](https://github.com/openclaw/openclaw/pull/139702).
+- Reuse the existing Google conversion record guard [#139703](https://github.com/openclaw/openclaw/pull/139703).
+- Derive Gateway method advertisement from the canonical catalog [#139719](https://github.com/openclaw/openclaw/pull/139719).
+- Remove duplicate placement and lifecycle wiring [#139720](https://github.com/openclaw/openclaw/pull/139720).
+- Remove duplicated Gateway request and agent reply plumbing [#139755](https://github.com/openclaw/openclaw/pull/139755).
+- Remove unused detached-task runtime registration facades [#139759](https://github.com/openclaw/openclaw/pull/139759).
+- Simplify plugin diagnostic grouping and state-store wrappers [#139775](https://github.com/openclaw/openclaw/pull/139775).
+- Centralize managed npm installation planning [#139788](https://github.com/openclaw/openclaw/pull/139788).
+- Derive configuration metadata through one schema traversal [#139823](https://github.com/openclaw/openclaw/pull/139823).
+- Share the Settings Gateway lifecycle controller [#139826](https://github.com/openclaw/openclaw/pull/139826).
+- Unify public plugin artifact factory loading [#139831](https://github.com/openclaw/openclaw/pull/139831).
+- Remove unused anchor-exit notifications [#139855](https://github.com/openclaw/openclaw/pull/139855).
+- Share Workboard diagnostic construction [#139866](https://github.com/openclaw/openclaw/pull/139866).
+- Centralize runtime-aware model availability without changing picker behavior [#139881](https://github.com/openclaw/openclaw/pull/139881). Thanks @goslingmanagment for the earlier regression report.
+- Reuse private command inputs and remove obsolete setup adapters [#139885](https://github.com/openclaw/openclaw/pull/139885).
+- Remove redundant integer conversion from Talk configuration parsing [#139893](https://github.com/openclaw/openclaw/pull/139893).
+- Share image and mention delimiter protection in the Teams formatter [#139895](https://github.com/openclaw/openclaw/pull/139895).
+- Bind plugin registration owners once [#139898](https://github.com/openclaw/openclaw/pull/139898).
+- Share memory wiki CLI and tool result presentation [#139913](https://github.com/openclaw/openclaw/pull/139913).
+- Share the APNs registration deletion transaction [#139914](https://github.com/openclaw/openclaw/pull/139914).
+- Remove duplicate embedded prompt contracts and forwarding fields [#139915](https://github.com/openclaw/openclaw/pull/139915).
+- Remove the unused compiled provider setup index [#139930](https://github.com/openclaw/openclaw/pull/139930).
+- Remove the redundant Windows command-helper bridge [#139932](https://github.com/openclaw/openclaw/pull/139932).
+- Share Anthropic and Google message projection and stream handling [#139935](https://github.com/openclaw/openclaw/pull/139935).
+- Reuse shared migration receipts for retired subagent cleanup [#139936](https://github.com/openclaw/openclaw/pull/139936).
+- Share legacy Watch status decoding [#139941](https://github.com/openclaw/openclaw/pull/139941).
+- Share cleanup deadline waits and clear completed LSP grace timers [#139953](https://github.com/openclaw/openclaw/pull/139953).
+- Share embedded skill preparation and environment rollback ownership [#139959](https://github.com/openclaw/openclaw/pull/139959).
+- Share OTEL model and tool terminal recorders [#139968](https://github.com/openclaw/openclaw/pull/139968).
+- Share Voice Wake debug formatting and defer private values [#139970](https://github.com/openclaw/openclaw/pull/139970).
+- Share meeting browser audio-device inspection [#139973](https://github.com/openclaw/openclaw/pull/139973).
+- Separate plugin conversation-binding approval state [#139984](https://github.com/openclaw/openclaw/pull/139984).
+- Share native Gateway agent-list and profile-accent decoding [#139995](https://github.com/openclaw/openclaw/pull/139995).
+- Centralize plugin install recovery metadata [#140002](https://github.com/openclaw/openclaw/pull/140002).
+- Isolate pending plugin conversation-binding requests [#140017](https://github.com/openclaw/openclaw/pull/140017).
+- Reuse authored policy value and diagnostic helpers [#140019](https://github.com/openclaw/openclaw/pull/140019).
+- Replace unused Voice Call event schemas with equivalent types [#140029](https://github.com/openclaw/openclaw/pull/140029).
+- Share managed npm package traversal while preserving caller policies [#140040](https://github.com/openclaw/openclaw/pull/140040).
+- Share auth profile failure-state reset [#140049](https://github.com/openclaw/openclaw/pull/140049).
+- Remove unused Gateway Responses output schemas [#140061](https://github.com/openclaw/openclaw/pull/140061).
+- Separate browser executable probes and consolidate classification [#140068](https://github.com/openclaw/openclaw/pull/140068).
+- Remove test-mock detection from Slack media transport selection [#140070](https://github.com/openclaw/openclaw/pull/140070).
+- Consolidate reporting, Telegram menu, warning and OpenCode effort helpers [#140072](https://github.com/openclaw/openclaw/pull/140072).
+- Unify plugin install configuration snapshot preparation [#140081](https://github.com/openclaw/openclaw/pull/140081).
+- Isolate webhook request schemas and remove duplicate response plumbing [#140092](https://github.com/openclaw/openclaw/pull/140092).
+- Simplify private Mantis CLI option types and forwarding [#140093](https://github.com/openclaw/openclaw/pull/140093).
+- Share plugin install entry validation [#140112](https://github.com/openclaw/openclaw/pull/140112).
+- Reuse canonical worker-recovery dependency types [#140113](https://github.com/openclaw/openclaw/pull/140113).
+- Remove the unreachable pending browser-probe path [#140114](https://github.com/openclaw/openclaw/pull/140114).
+- Remove unused terminal picker mutation hooks [#140120](https://github.com/openclaw/openclaw/pull/140120).
+- Reuse canonical RPC parameter validation [#140122](https://github.com/openclaw/openclaw/pull/140122).
+- Simplify Doctor preview policy warnings without changing output [#140124](https://github.com/openclaw/openclaw/pull/140124).
+- Share workspace recovery construction and publication replay checks [#140133](https://github.com/openclaw/openclaw/pull/140133).
+- Remove the unused internal restart channel input [#140143](https://github.com/openclaw/openclaw/pull/140143).
+- Remove duplicate ACP lifecycle, wrapper and error plumbing [#140163](https://github.com/openclaw/openclaw/pull/140163).
+- Remove obsolete Control UI update-status plumbing [#140164](https://github.com/openclaw/openclaw/pull/140164).
+- Consolidate Doctor preview warning rendering without changing policy [#140165](https://github.com/openclaw/openclaw/pull/140165).
+- Remove an unused ACP index and duplicate terminal and Markdown bookkeeping [#140169](https://github.com/openclaw/openclaw/pull/140169).
+- Consolidate native SMS, TLS, motion, location and MLX adapter plumbing [#140181](https://github.com/openclaw/openclaw/pull/140181).
+- Simplify update repair cancellation and process-scope bookkeeping [#140183](https://github.com/openclaw/openclaw/pull/140183).
+- Remove redundant update render guards and timeout validation [#140185](https://github.com/openclaw/openclaw/pull/140185).
+- Share daemon Gateway status projection and remove redundant wrappers [#140189](https://github.com/openclaw/openclaw/pull/140189).
+- Simplify private Memory Wiki CLI option and output plumbing [#140197](https://github.com/openclaw/openclaw/pull/140197).
+- Remove unused global-update parameters and repeated Doctor environment restoration [#140201](https://github.com/openclaw/openclaw/pull/140201).
+- Derive plugin catalog types from the canonical Gateway protocol [#140205](https://github.com/openclaw/openclaw/pull/140205).
+- Consolidate Chat Completions and Responses tool-choice application [#140210](https://github.com/openclaw/openclaw/pull/140210).
+- Share plugin enablement mutations while retaining CLI and admin policies [#140215](https://github.com/openclaw/openclaw/pull/140215).
+- Remove redundant Gateway discovery host and port wrappers [#140223](https://github.com/openclaw/openclaw/pull/140223).
+- Consolidate Settings defaults, tool overrides, Profile handling and Logs styling [#140225](https://github.com/openclaw/openclaw/pull/140225).
+- Remove one-use read-only channel discovery wrappers [#140233](https://github.com/openclaw/openclaw/pull/140233).
+- Share the canonical daemon port-status summary type [#140234](https://github.com/openclaw/openclaw/pull/140234).
+- Remove duplicate provider-setup model normalization [#140237](https://github.com/openclaw/openclaw/pull/140237).
+- Remove obsolete media-preparation callbacks and test-only timing overrides [#140240](https://github.com/openclaw/openclaw/pull/140240).
+- Consolidate strict Docker and Podman inspection decoding [#140245](https://github.com/openclaw/openclaw/pull/140245).
+- Remove redundant update-verification type scaffolding [#140259](https://github.com/openclaw/openclaw/pull/140259).
+- Remove retired private tool-execution argument decoding [#140280](https://github.com/openclaw/openclaw/pull/140280).
+- Consolidate harness context-engine input types and preserve lazy memory test loading [#140297](https://github.com/openclaw/openclaw/pull/140297).
+- Remove unreachable launchd alias snapshot and rollback code [#140299](https://github.com/openclaw/openclaw/pull/140299).
+- Remove private queue upgrade code and duplicate infrastructure dispatch [#140311](https://github.com/openclaw/openclaw/pull/140311).
+- Share plugin uninstall planning, deletion and final configuration writes [#140322](https://github.com/openclaw/openclaw/pull/140322).
+- Simplify update transaction paths, validation aliases and output bookkeeping [#140323](https://github.com/openclaw/openclaw/pull/140323).
+- Replace duplicate channel and agent-session runtime type definitions [#140324](https://github.com/openclaw/openclaw/pull/140324).
+- Consolidate workspace empty-directory cleanup without changing recovery policy [#140325](https://github.com/openclaw/openclaw/pull/140325).
+- Remove duplicate configuration parent traversal for unset operations [#140326](https://github.com/openclaw/openclaw/pull/140326).
+- Preserve exact installed-plugin index mutation receipts for recovery consumers [#140328](https://github.com/openclaw/openclaw/pull/140328). Thanks @fuller-stack-dev.
+- Consolidate Doctor compaction configuration traversal [#140330](https://github.com/openclaw/openclaw/pull/140330).
+- Share Control UI channel-status type definitions [#140331](https://github.com/openclaw/openclaw/pull/140331).
+- Remove private self-hosted provider setup result forwarding [#140332](https://github.com/openclaw/openclaw/pull/140332).
+- Remove dormant sandbox-image rewrite callbacks from Doctor [#140342](https://github.com/openclaw/openclaw/pull/140342).
+- Remove private GitHub skill-discovery wrappers from Doctor [#140343](https://github.com/openclaw/openclaw/pull/140343).
+- Delete an unused private AI retry-sleep helper and its isolated test [#140346](https://github.com/openclaw/openclaw/pull/140346). Thanks @vincentkoc.
+- Reuse shared Cron migration receipt writes while preserving recovery semantics [#140347](https://github.com/openclaw/openclaw/pull/140347).
+- Consolidate native OpenAI client construction without changing header policy [#140361](https://github.com/openclaw/openclaw/pull/140361).
+- Reuse canonical Workshop status and evaluation protocol types [#140365](https://github.com/openclaw/openclaw/pull/140365).
+- Simplify diagnostic, APNs, backup, session and subprocess plumbing [#140369](https://github.com/openclaw/openclaw/pull/140369).
+- Remove redundant Doctor configuration migration writebacks [#140370](https://github.com/openclaw/openclaw/pull/140370).
+- Consolidate fresh assistant-message initialization across AI adapters [#140371](https://github.com/openclaw/openclaw/pull/140371).
+- Alias the canonical rendered message batch plan in the delivery queue [#140386](https://github.com/openclaw/openclaw/pull/140386).
+- Reuse Gateway protocol handshake credential types [#140394](https://github.com/openclaw/openclaw/pull/140394).
+- Remove unused Feishu document-comment upload policy plumbing [#140395](https://github.com/openclaw/openclaw/pull/140395).
+- Consolidate worker tunnel and desktop eligibility checks [#140400](https://github.com/openclaw/openclaw/pull/140400).
+- Replace duplicate Skills UI requirement and configuration-check types [#140407](https://github.com/openclaw/openclaw/pull/140407).
+- Consolidate Cron runtime feedback schema declarations [#140408](https://github.com/openclaw/openclaw/pull/140408).
+- Consolidate native approval SDK input type declarations [#140415](https://github.com/openclaw/openclaw/pull/140415).
+- Reuse canonical MCP transport normalization and URL redaction [#140439](https://github.com/openclaw/openclaw/pull/140439).
+- Replace duplicated raw-trace counter declarations with a shared private type [#140444](https://github.com/openclaw/openclaw/pull/140444).
+- Consolidate node-host execution-policy result construction without changing permissions [#140446](https://github.com/openclaw/openclaw/pull/140446).
+- Remove the second Unicode repair pass when truncating tool-output tails [#140448](https://github.com/openclaw/openclaw/pull/140448).
+- Remove redundant Codex notification, provider and fingerprint forwarding helpers [#140451](https://github.com/openclaw/openclaw/pull/140451).
+- Avoid repeated session-key parsing and unnecessary allowlist reads during event routing [#140454](https://github.com/openclaw/openclaw/pull/140454).
+- Remove duplicate environment-template scanning from configuration write-back [#140460](https://github.com/openclaw/openclaw/pull/140460).
+- Remove retired Discord presence templates and unread decision fields [#140463](https://github.com/openclaw/openclaw/pull/140463).
+- Consolidate sandbox allow, deny and additive-allow selection without changing policy [#140474](https://github.com/openclaw/openclaw/pull/140474).
+- Reuse validation results while loading unchanged cron jobs [#140476](https://github.com/openclaw/openclaw/pull/140476).
+- Consolidate command configuration and plugin startup under the execution owner [#140480](https://github.com/openclaw/openclaw/pull/140480).
+- Remove unreachable plugin-only allowlist warning state while preserving restrictive policy [#140483](https://github.com/openclaw/openclaw/pull/140483).
+- Reuse plugin facade types and remove redundant configuration and registry relays [#140489](https://github.com/openclaw/openclaw/pull/140489).
+- Replace provider-model forwarding functions with direct canonical re-exports [#140500](https://github.com/openclaw/openclaw/pull/140500).
+- Remove redundant multi-target scaffolding from channel configuration-write authorization [#140510](https://github.com/openclaw/openclaw/pull/140510).
+- Remove repeated country lookups when preparing shared phone calling codes [#140514](https://github.com/openclaw/openclaw/pull/140514).
+- Remove no-op defaults and reuse canonical Talk numeric predicates [#140515](https://github.com/openclaw/openclaw/pull/140515).
+- Consolidate provider preset construction without changing SDK entrypoints or precedence [#140516](https://github.com/openclaw/openclaw/pull/140516).
+- Reuse canonical SQLite URI and ownership checks inside the detached update bundle [#140517](https://github.com/openclaw/openclaw/pull/140517).
+- Remove duplicate DM and group allowlist normalization [#140520](https://github.com/openclaw/openclaw/pull/140520).
+- Simplify LaunchAgent port selection and private environment/error wrappers [#140522](https://github.com/openclaw/openclaw/pull/140522).
+- Avoid building Google Chat resource and link-label buffers when they cannot change the text [#140524](https://github.com/openclaw/openclaw/pull/140524).
+- Consolidate sidebar people-card pointer and focus dismissal handling [#140530](https://github.com/openclaw/openclaw/pull/140530).
+- Remove obsolete pairing-list inventory fallback and use canonical node.list [#140532](https://github.com/openclaw/openclaw/pull/140532).
+- Remove the private package-executor wrapper while retaining staging, activation and recovery owners [#140536](https://github.com/openclaw/openclaw/pull/140536).
+- Consolidate Prometheus metric recording and remove unreachable series-cap state [#140545](https://github.com/openclaw/openclaw/pull/140545).
+- Remove private lazy-loader adapters from baseline setup [#140548](https://github.com/openclaw/openclaw/pull/140548).
+- Remove redundant pending-node acknowledgment and serialization wrappers [#140552](https://github.com/openclaw/openclaw/pull/140552).
+- Consolidate placement-move matching without weakening stale-move checks [#140569](https://github.com/openclaw/openclaw/pull/140569).
+- Consolidate OpenAI Responses function-tool assembly while retaining strict policies [#140592](https://github.com/openclaw/openclaw/pull/140592).
+- Simplify native approval forwarding mode resolution without changing routing defaults [#140596](https://github.com/openclaw/openclaw/pull/140596).
+- Cache prepared installed-index facts within immutable metadata generations [#140600](https://github.com/openclaw/openclaw/pull/140600).
+- Consolidate Chat Completions request assembly while preserving transport-specific policies [#140604](https://github.com/openclaw/openclaw/pull/140604).
+- Remove the redundant LaunchAgent plist facade and unused label default [#140616](https://github.com/openclaw/openclaw/pull/140616).
+- Remove unused route-only plugin-preload policy and test real route selection [#140618](https://github.com/openclaw/openclaw/pull/140618).
+- Consolidate legacy Signal transport migration phases [#140624](https://github.com/openclaw/openclaw/pull/140624).
+- Consolidate Copilot request classification while preserving caller-specific policy [#140629](https://github.com/openclaw/openclaw/pull/140629).
+- Consolidate composer suggestion menus while retaining separate command and argument viewport lifetimes [#140633](https://github.com/openclaw/openclaw/pull/140633).
+- Remove the terminal session picker's test-only filter getter [#140638](https://github.com/openclaw/openclaw/pull/140638).
+- Consolidate stage timing behind the existing time-runtime SDK entrypoint [#140639](https://github.com/openclaw/openclaw/pull/140639).
+- Consolidate tool-schema array-item addition and omission policies [#140642](https://github.com/openclaw/openclaw/pull/140642).
+- Reuse prepared Discord binding expiry candidates while preserving idle-expiry ties [#140643](https://github.com/openclaw/openclaw/pull/140643).
+- Consolidate response-byte consumption while retaining caller decoding, limits and cancellation [#140654](https://github.com/openclaw/openclaw/pull/140654).
+- Simplify Control UI first-run activation outcomes without changing recovery semantics [#140655](https://github.com/openclaw/openclaw/pull/140655).
+- Consolidate Unix port diagnostic collection while preserving unique-PID enrichment [#140656](https://github.com/openclaw/openclaw/pull/140656).
+- Consolidate embedding batch lifecycle and Voyage direct request orchestration [#140660](https://github.com/openclaw/openclaw/pull/140660).
+- Simplify prepared plugin-runtime composition while preserving cold registration and physical client cleanup [#140667](https://github.com/openclaw/openclaw/pull/140667).
+- Remove duplicate bundled-channel source-path probes while retaining fallback containment [#140679](https://github.com/openclaw/openclaw/pull/140679).
+- Consolidate plugin approval request delivery while preserving caller-specific authority and expiry ownership [#140684](https://github.com/openclaw/openclaw/pull/140684).
+- Reuse an internal Apple chat session placeholder factory [#140688](https://github.com/openclaw/openclaw/pull/140688). Thanks @vincentkoc.
+- Remove Claw removal's simulated commit path and test canonical cleanup owners [#140690](https://github.com/openclaw/openclaw/pull/140690).
+- Share OpenAI strict-tool diagnostics without changing requests [#140697](https://github.com/openclaw/openclaw/pull/140697).
+- Consolidate segmented UI controls while preserving existing interactions [#140699](https://github.com/openclaw/openclaw/pull/140699).
+- Consolidate file-copy and hashing primitives used by backup and SQLite publication [#140701](https://github.com/openclaw/openclaw/pull/140701).
+- Remove redundant dreaming configuration coercion wrappers [#140707](https://github.com/openclaw/openclaw/pull/140707).
+- Share subagent generation indexing while preserving display and cron ordering [#140712](https://github.com/openclaw/openclaw/pull/140712).
+- Simplify CLI route preparation while retaining deferred startup and dispatch behavior [#140724](https://github.com/openclaw/openclaw/pull/140724).
+- Consolidate portable redaction parsing and PEM masking mechanics [#140742](https://github.com/openclaw/openclaw/pull/140742).
+- Derive private node invocation result types from their builder [#140752](https://github.com/openclaw/openclaw/pull/140752).
+- Simplify remote attachment filename selection while preserving precedence [#140754](https://github.com/openclaw/openclaw/pull/140754).
+- Use the producer-owned skill status types in the Control UI [#140755](https://github.com/openclaw/openclaw/pull/140755).
+- Reuse common setup helpers for Synology Chat and Feishu account updates [#140761](https://github.com/openclaw/openclaw/pull/140761).
+- Consolidate daemon JSON projection while preserving Node and Gateway differences [#140762](https://github.com/openclaw/openclaw/pull/140762).
+- Reduce per-item summary allocations in message batch preparation [#140763](https://github.com/openclaw/openclaw/pull/140763).
+- Consolidate compact token unit formatting without changing displayed values [#140769](https://github.com/openclaw/openclaw/pull/140769).
+- Share escape detection between native inline math and details parsing [#140776](https://github.com/openclaw/openclaw/pull/140776). Thanks @vincentkoc.
+- Share inline API-key cooldown lookup across credential and availability checks [#140777](https://github.com/openclaw/openclaw/pull/140777).
+- Share flat and scoped group-policy evaluation while retaining existing precedence [#140779](https://github.com/openclaw/openclaw/pull/140779).
+- Remove redundant owner fallbacks in session subscription and deletion handlers [#140782](https://github.com/openclaw/openclaw/pull/140782).
+- Reuse canonical tool-call and tool-result predicates in chat history projection [#140788](https://github.com/openclaw/openclaw/pull/140788).
+- Reuse canonical root/account traversal for private-network configuration migration [#140790](https://github.com/openclaw/openclaw/pull/140790).
+- Consolidate Gateway synchronization lifecycle for presence and pull-request tracking [#140811](https://github.com/openclaw/openclaw/pull/140811).
+- Reuse primary-model preservation across provider onboarding presets [#140813](https://github.com/openclaw/openclaw/pull/140813).
+- Remove redundant plugin configuration assertions and timeout checks [#140815](https://github.com/openclaw/openclaw/pull/140815).
+- Consolidate Gateway unavailable responses while preserving error details and redaction [#140816](https://github.com/openclaw/openclaw/pull/140816).
+- Consolidate model suggestion edit-distance calculation with the shared utility [#140829](https://github.com/openclaw/openclaw/pull/140829).
+- Consolidate health and Telegram probe permit queues [#140852](https://github.com/openclaw/openclaw/pull/140852).
+- Share credential-header classification in debug proxy capture [#140855](https://github.com/openclaw/openclaw/pull/140855).
+- Use one redacted device-pairing list contract across Gateway and clients [#140857](https://github.com/openclaw/openclaw/pull/140857).
+- Consolidate cancellation membership for model catalog and session-reference requests [#140860](https://github.com/openclaw/openclaw/pull/140860).
+- Share schema-derived exec approval types with the Dashboard editor [#140861](https://github.com/openclaw/openclaw/pull/140861).
+- Remove redundant chat session-owner forwarding and text normalization helpers [#140869](https://github.com/openclaw/openclaw/pull/140869).
+- Use one workspace-conflict projection type in worker placement [#140871](https://github.com/openclaw/openclaw/pull/140871).
+- Consolidate model reasoning, media, pricing and nested routing type primitives [#140883](https://github.com/openclaw/openclaw/pull/140883).
+- Consolidate SHA-256 identifier helpers without changing hashes or labels [#140887](https://github.com/openclaw/openclaw/pull/140887).
+- Reuse sanitized background-task text within each projection [#140890](https://github.com/openclaw/openclaw/pull/140890).
+- Consolidate version-manager path classification for bootstrap and services [#140894](https://github.com/openclaw/openclaw/pull/140894).
+- Reuse one nearest-palette lookup in terminal themes [#140895](https://github.com/openclaw/openclaw/pull/140895). Thanks @vincentkoc.
+- Remove duplicate group reply guidance while preserving its meaning [#140901](https://github.com/openclaw/openclaw/pull/140901). Thanks @obviyus.
+- Remove redundant plugin configuration policy forwarding [#140904](https://github.com/openclaw/openclaw/pull/140904).
+- Use one widget-theme token and message contract across Canvas and UI [#140905](https://github.com/openclaw/openclaw/pull/140905).
+- Remove duplicate sorting and unreachable fallback parsing from provider usage caching [#140910](https://github.com/openclaw/openclaw/pull/140910).
+- Consolidate worker input and node observer byte framing [#140923](https://github.com/openclaw/openclaw/pull/140923).
+- Share presentation action rewriting for diagnostic buttons and selects [#140925](https://github.com/openclaw/openclaw/pull/140925). Thanks @vincentkoc.
+- Remove duplicate web-provider credential text normalization [#140926](https://github.com/openclaw/openclaw/pull/140926).
+- Consolidate structural session-key parsing and main-key construction [#140935](https://github.com/openclaw/openclaw/pull/140935).
+- Inline provider usage-status loading while retaining cache refresh policy [#140937](https://github.com/openclaw/openclaw/pull/140937).
+- Share ClawHub plugin compatibility declarations with the package contract [#140938](https://github.com/openclaw/openclaw/pull/140938).
+- Consolidate memory recall guidance without changing tool contracts or execution [#140942](https://github.com/openclaw/openclaw/pull/140942). Thanks @obviyus.
+- Consolidate Git cloning and revision acquisition for plugins and skills [#140946](https://github.com/openclaw/openclaw/pull/140946).
+- Share Claws command option types without changing flags or consent rules [#140947](https://github.com/openclaw/openclaw/pull/140947).
+- Consolidate agent-session reuse evaluation while retaining concurrent-rotation protection [#140960](https://github.com/openclaw/openclaw/pull/140960).
+- Consolidate iMessage RPC stdout and stderr line framing [#140962](https://github.com/openclaw/openclaw/pull/140962). Thanks @vincentkoc.
+- Consolidate Google Meet's local and node browser open-or-recover sequence [#140972](https://github.com/openclaw/openclaw/pull/140972).
+- Consolidate Perplexity search response envelopes without changing cache or transport behavior [#140982](https://github.com/openclaw/openclaw/pull/140982).
+- Share common native chat operations while retaining platform routing rules [#140985](https://github.com/openclaw/openclaw/pull/140985).
+- Consolidate duplicate macOS model-setup entry checks [#140996](https://github.com/openclaw/openclaw/pull/140996).
+- Simplify desktop shutdown plumbing while preserving cancellation and cleanup ownership [#141007](https://github.com/openclaw/openclaw/pull/141007).
+- Consolidate companion error-detail parsing without changing displayed hints [#141010](https://github.com/openclaw/openclaw/pull/141010). Thanks @vincentkoc.
+- Reuse bounded response readers in Claude usage and Firecrawl diagnostics [#141015](https://github.com/openclaw/openclaw/pull/141015).
+- Share media-generation candidate iteration while preserving each provider's policies [#141016](https://github.com/openclaw/openclaw/pull/141016).
+- Remove unused internal status scan modes while retaining public command behavior [#141021](https://github.com/openclaw/openclaw/pull/141021). Thanks @vincentkoc.
+- Consolidate session-maintenance planning across existing storage paths [#141026](https://github.com/openclaw/openclaw/pull/141026).
+- Reuse runtime-owned option types in Devices CLI registration [#141029](https://github.com/openclaw/openclaw/pull/141029).
+- Share LINE reply presentation preparation while retaining native controls and fallbacks [#141030](https://github.com/openclaw/openclaw/pull/141030).
+- Share DM-policy schema refinement across six channel plugins [#141074](https://github.com/openclaw/openclaw/pull/141074).
+- Reuse the cross-origin attachment predicate in SVG and sidebar rendering [#141082](https://github.com/openclaw/openclaw/pull/141082). Thanks @vincentkoc.
+- Remove duplicate MiniMax video-asset download handling [#141094](https://github.com/openclaw/openclaw/pull/141094).
+- Share DashScope response acquisition while retaining existing retry and decoding policies [#141108](https://github.com/openclaw/openclaw/pull/141108).
+- Consolidate transcript input repair without changing replay payloads [#141118](https://github.com/openclaw/openclaw/pull/141118).
+- Share request-option preparation within image provider implementations [#141119](https://github.com/openclaw/openclaw/pull/141119).
+- Consolidate native socket-generation handling [#141135](https://github.com/openclaw/openclaw/pull/141135).
+- Share Zalouser identifier coercion [#141144](https://github.com/openclaw/openclaw/pull/141144). Thanks @vincentkoc.
+- Remove the unused in-memory ACP event ledger and adjust CLI test helpers [#141145](https://github.com/openclaw/openclaw/pull/141145). Thanks @vincentkoc.
+- Share npm version querying and parsing while keeping caller policy local [#141166](https://github.com/openclaw/openclaw/pull/141166).
+- Share pointer and focus hold listeners across portaled hovercards [#141178](https://github.com/openclaw/openclaw/pull/141178). Thanks @vincentkoc.
+- Remove the unused private meeting close timestamp [#141183](https://github.com/openclaw/openclaw/pull/141183). Thanks @vincentkoc.
+- Share plugin manifest contribution projection without changing registry policy [#141193](https://github.com/openclaw/openclaw/pull/141193).
+- Share group and direct-message prompt selection while preserving empty-value suppression [#141195](https://github.com/openclaw/openclaw/pull/141195). Thanks @vincentkoc.
+- Remove unused link-preprocessing return metadata while preserving fetched summaries and context effects [#141200](https://github.com/openclaw/openclaw/pull/141200). Thanks @vincentkoc.
+- Share turn-envelope normalization for Codex startup and completion [#141215](https://github.com/openclaw/openclaw/pull/141215). Thanks @vincentkoc.
+- Share common imported-source wiki orchestration while preserving source-specific authority and failure ordering [#141227](https://github.com/openclaw/openclaw/pull/141227).
+- Share HTTPS presentation-URL validation between plugin authentication and recommendations [#141229](https://github.com/openclaw/openclaw/pull/141229).
+- Share bounded paired-node catalog lookup for continuation and terminal opening [#141235](https://github.com/openclaw/openclaw/pull/141235).
+- Share admitted skill metadata construction and the structural skill type [#141253](https://github.com/openclaw/openclaw/pull/141253).
+- Share whitespace compaction and safe truncation for node event summaries [#141262](https://github.com/openclaw/openclaw/pull/141262). Thanks @vincentkoc.
+- Share gateway discovery bookkeeping and text parsing between Apple clients [#141274](https://github.com/openclaw/openclaw/pull/141274).
+- Share lazy feature schema initialization using the existing canonical SQL [#141278](https://github.com/openclaw/openclaw/pull/141278).
+- Share bounded recall orchestration while retaining distinct automatic and explicit recall policies [#141282](https://github.com/openclaw/openclaw/pull/141282).
+- Share ordered-array comparison for watcher targets and remote skill catalogs [#141284](https://github.com/openclaw/openclaw/pull/141284). Thanks @vincentkoc.
+- Share CLI and image-tool enum parsing while retaining existing errors and admission rules [#141294](https://github.com/openclaw/openclaw/pull/141294). Thanks @masatohoshino.
+- Share active hook and skill root selection while preserving their distinct activation policies [#141298](https://github.com/openclaw/openclaw/pull/141298).
+- Inline constant config-backed owner-display settings and remove obsolete indirection [#141320](https://github.com/openclaw/openclaw/pull/141320). Thanks @vincentkoc.
+- Share cron history status-filter normalization while preserving plural-filter precedence [#141324](https://github.com/openclaw/openclaw/pull/141324). Thanks @vincentkoc.
+- Derive shared SDK Gateway options from existing client contracts [#141325](https://github.com/openclaw/openclaw/pull/141325).
+- Retain framework-consumed live-voice intent description metadata during dead-code scans [#141334](https://github.com/openclaw/openclaw/pull/141334).
+- Share immutable Talk configuration facts while retaining platform-specific routing and defaults [#141342](https://github.com/openclaw/openclaw/pull/141342).
+- Share the existing terminal-control-character predicate across agent diagnostics [#141343](https://github.com/openclaw/openclaw/pull/141343). Thanks @vincentkoc.
+- Share disabled-install configuration preparation across bundled and persisted plugin paths [#141358](https://github.com/openclaw/openclaw/pull/141358). Thanks @vincentkoc.
+- Remove obsolete terminal typing reset bookkeeping and duplicate silent-text checks [#141368](https://github.com/openclaw/openclaw/pull/141368). Thanks @vincentkoc.
+- Share validated ElevenLabs request construction across Apple speech paths [#141370](https://github.com/openclaw/openclaw/pull/141370).
+- Share the existing tool-call input-presence predicate across replay paths [#141371](https://github.com/openclaw/openclaw/pull/141371). Thanks @vincentkoc.
+- Derive private Team Reports and Mattermost types from their existing validators [#141372](https://github.com/openclaw/openclaw/pull/141372).
+- Simplify prompt-cache preparation without changing request content [#141385](https://github.com/openclaw/openclaw/pull/141385).
+- Consolidate Anthropic tool-result and Gemini cache request construction [#141391](https://github.com/openclaw/openclaw/pull/141391).
+- Separate embeddings lifecycle ownership from HTTP request initialization [#141403](https://github.com/openclaw/openclaw/pull/141403).
+- Prepare Chat Completions assistant replay blocks in one pass [#141419](https://github.com/openclaw/openclaw/pull/141419).
+- Reuse SQLite data-version reading for device-pairing cache checks [#141420](https://github.com/openclaw/openclaw/pull/141420). Thanks @vincentkoc.
+- Remove redundant retired-orphan bookkeeping from the TUI [#141425](https://github.com/openclaw/openclaw/pull/141425). Thanks @vincentkoc.
+- Consolidate the CUA MCP adapter onto a core-owned strict stdio client [#141432](https://github.com/openclaw/openclaw/pull/141432).
+- Reuse transcript page-limit normalization without changing limits [#141439](https://github.com/openclaw/openclaw/pull/141439). Thanks @vincentkoc.
+- Share skill catalog construction while preserving prompt bytes and discovery rules [#141455](https://github.com/openclaw/openclaw/pull/141455).
+- Reuse edit-distance row storage without changing suggestions [#141460](https://github.com/openclaw/openclaw/pull/141460).
+- Remove Feishu's duplicate raw-buffer attachment saver [#141462](https://github.com/openclaw/openclaw/pull/141462).
+- Expose existing logging helpers through the lightweight diagnostics entrypoint [#141488](https://github.com/openclaw/openclaw/pull/141488).
+- Keep cleared memory plugin registries absent during lookup [#141492](https://github.com/openclaw/openclaw/pull/141492).
+- Remove redundant package module captions while preserving executable code [#141500](https://github.com/openclaw/openclaw/pull/141500).
+- Remove an ineffective meeting fingerprint retry [#141503](https://github.com/openclaw/openclaw/pull/141503).
+- Consolidate Worktrees action completion without changing UI behavior [#141506](https://github.com/openclaw/openclaw/pull/141506).
+- Consolidate local provider inventory setup while preserving command output [#141509](https://github.com/openclaw/openclaw/pull/141509).
+- Simplify dispatcher registration to pending counts and an unregister function [#141517](https://github.com/openclaw/openclaw/pull/141517).
+- Forward Copilot's prepared spawn workspace and remove its redundant fallback [#141522](https://github.com/openclaw/openclaw/pull/141522).
+- Record subordinate catalog failures without invalidating the usable prepared runtime [#141524](https://github.com/openclaw/openclaw/pull/141524). Thanks @obviyus.
+- Reuse the candidate array for breadth-first error traversal [#141530](https://github.com/openclaw/openclaw/pull/141530).
+- Prepare model table tag formatting once while preserving output [#141554](https://github.com/openclaw/openclaw/pull/141554).
+- Remove duplicate plugin-root MCP configuration construction [#141557](https://github.com/openclaw/openclaw/pull/141557).
+- Reuse Gateway wire result types in the Control UI [#141589](https://github.com/openclaw/openclaw/pull/141589).
+- Reuse provider grouping logic in the native chat model picker [#141612](https://github.com/openclaw/openclaw/pull/141612).
+- Remove duplicate provider HTTP error normalization [#141623](https://github.com/openclaw/openclaw/pull/141623).
+- Consolidate skills readiness formatting without changing visible output [#141646](https://github.com/openclaw/openclaw/pull/141646).
+- Remove unused prompt-side channel action discovery [#141659](https://github.com/openclaw/openclaw/pull/141659).
+- Remove unused task snapshot-write fallbacks and consolidate store fixtures [#141662](https://github.com/openclaw/openclaw/pull/141662).
+- Simplify the unchanged downgrade confirmation string [#141671](https://github.com/openclaw/openclaw/pull/141671).
+- Share plugin admission preparation between runtime and CLI loaders [#138768](https://github.com/openclaw/openclaw/pull/138768).
+- Simplify avatar resource cleanup and chat-loading fixtures [#138834](https://github.com/openclaw/openclaw/pull/138834).
+- Consolidate proxy defaults and simplify dispatcher initialization [#138848](https://github.com/openclaw/openclaw/pull/138848).
+- Move Claw MCP provenance queries onto canonical typed database helpers [#138997](https://github.com/openclaw/openclaw/pull/138997).
+- Centralize typed capture-session, preset and legacy-blob queries [#139015](https://github.com/openclaw/openclaw/pull/139015).
+- Share eager task-flow snapshot construction in the SQLite owner [#139016](https://github.com/openclaw/openclaw/pull/139016).
 
 </details>
 </Accordion>
 
-<Accordion title="Review infrastructure and release tooling">
+<Accordion title="Focused tests and fixtures">
 
-Maintainer guidance describes review commands and coordinated infrastructure activation, while qualification and release tools retain clearer records of their own work.
+Test work improves temporary-state isolation, cleanup, synchronization, and platform-specific fixtures while retaining checks on the behaviors those tests own. Several suites move coverage to public boundaries or remove duplicated scenarios; test-only repairs do not establish new runtime capabilities.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Keep real-Gateway browser proof artifacts separate across reruns and capture stages [#134274](https://github.com/openclaw/openclaw/pull/134274).
+- Run installer test turns through the Gateway instead of conflicting local execution [#134390](https://github.com/openclaw/openclaw/pull/134390). Thanks @RomneyDa.
+- Accept image or view_image in installer smoke-test transcript assertions [#134454](https://github.com/openclaw/openclaw/pull/134454). Thanks @RomneyDa.
+- Move Active Memory helper coverage out of the private test facade [#137601](https://github.com/openclaw/openclaw/pull/137601). Thanks @RomneyDa.
+- Consolidate Firecrawl parser regression coverage [#137603](https://github.com/openclaw/openclaw/pull/137603). Thanks @RomneyDa.
+- Move SearXNG helper coverage through the search-client boundary [#137604](https://github.com/openclaw/openclaw/pull/137604). Thanks @RomneyDa.
+- Test Brave search behavior through its public tool boundary [#137631](https://github.com/openclaw/openclaw/pull/137631). Thanks @RomneyDa.
+- End detached agent-to-agent tails in session-send tests [#137731](https://github.com/openclaw/openclaw/pull/137731).
+- Remove a duplicate media test mock-call helper [#138170](https://github.com/openclaw/openclaw/pull/138170).
+- Migrate the test harness to stable Vitest5 [#138264](https://github.com/openclaw/openclaw/pull/138264). Thanks @vincentkoc.
+- Simplify diagnostic test yields without changing their boundaries [#138300](https://github.com/openclaw/openclaw/pull/138300).
+- Share SQLite reliability proof lifecycle helpers while preserving crash and recovery scenarios [#139058](https://github.com/openclaw/openclaw/pull/139058).
+- Honor the existing opt-in switch for chat-loading test media capture [#139062](https://github.com/openclaw/openclaw/pull/139062).
+- Run prepared real-Gateway CI suites in a guarded two-worker pool [#139081](https://github.com/openclaw/openclaw/pull/139081).
+- Make provider teardown deadline tests release held mocks and restore real timers before cleanup [#139090](https://github.com/openclaw/openclaw/pull/139090).
+- Restore prebuilt UI test admission after the startup asset-health refactor [#139123](https://github.com/openclaw/openclaw/pull/139123).
+- Use the established 15-second completion tolerance in the sibling-drain authority test [#139176](https://github.com/openclaw/openclaw/pull/139176). Thanks @ylcn91.
+- Replace a retired Watch localization fixture with the existing Talk to Claw key [#139197](https://github.com/openclaw/openclaw/pull/139197). Thanks @vincentkoc.
+- Capture restricted widget-fixture diagnostics before browser cleanup on failure [#139229](https://github.com/openclaw/openclaw/pull/139229).
+- Observe normal Gateway shutdown under the test lifetime before invoking forced cleanup [#139247](https://github.com/openclaw/openclaw/pull/139247).
+- Include shared real-Gateway test families and suffixed harness configs in browser CI routing [#139256](https://github.com/openclaw/openclaw/pull/139256).
+- Wait for selected session identity before inspecting external-catalog authors in E2Es [#139286](https://github.com/openclaw/openclaw/pull/139286).
+- Bind worker-pool idle timers at construction while leaving task deadlines on caller clocks [#139291](https://github.com/openclaw/openclaw/pull/139291). Thanks @ylcn91.
+- Replace the local Zalo fetch-call assertion adapter with the shared SDK helper [#139294](https://github.com/openclaw/openclaw/pull/139294).
+- Remove duplicate OpenAI-compatible speech request assertions [#139315](https://github.com/openclaw/openclaw/pull/139315).
+- Use shared typed guards for Tlon mock-call assertions [#139336](https://github.com/openclaw/openclaw/pull/139336).
+- Consolidate OpenRouter request assertions without changing security or response-release coverage [#139342](https://github.com/openclaw/openclaw/pull/139342).
+- Return onboarding activation tasks so consent tests join real settlement instead of sleeping [#139348](https://github.com/openclaw/openclaw/pull/139348).
+- Simplify Vitest startup, preserve option operands and register isolated UI discovery [#139377](https://github.com/openclaw/openclaw/pull/139377).
+- Preserve typed comparison arguments in Nextcloud Talk regression tests [#139379](https://github.com/openclaw/openclaw/pull/139379).
+- Simplify Moonshot catalog tests while retaining model and property checks [#139416](https://github.com/openclaw/openclaw/pull/139416).
+- Consolidate Tlon acknowledgement coverage around failure and replay outcomes [#139419](https://github.com/openclaw/openclaw/pull/139419).
+- Remove unused hybrid fixture inputs and name actual minimum-score cases accurately [#139426](https://github.com/openclaw/openclaw/pull/139426).
+- Drain Git stdin in merge-authorization fixtures and retain diagnostics [#139427](https://github.com/openclaw/openclaw/pull/139427).
+- Consolidate image-runtime test setup and reset owned mocks between cases [#139434](https://github.com/openclaw/openclaw/pull/139434).
+- Simplify pure configuration-validation imports and table-driven cases [#139435](https://github.com/openclaw/openclaw/pull/139435).
+- Remove obsolete Vitest configuration adapters and consolidate scheduler tests [#139442](https://github.com/openclaw/openclaw/pull/139442).
+- Remove a vacuous Ollama model test and share discovery fixtures [#139445](https://github.com/openclaw/openclaw/pull/139445).
+- Avoid real cleanup delays in Gateway lifecycle fixtures [#139446](https://github.com/openclaw/openclaw/pull/139446).
+- Correct schema-test request fields and share read-only Gateway setup [#139454](https://github.com/openclaw/openclaw/pull/139454).
+- Retire isolated UI test forks when cleanup rejects [#139460](https://github.com/openclaw/openclaw/pull/139460).
+- Consolidate shared channel-account tests and strengthen default selection assertions [#139474](https://github.com/openclaw/openclaw/pull/139474).
+- Replace fixed Gateway lifecycle waits with real owner barriers [#139483](https://github.com/openclaw/openclaw/pull/139483).
+- Consolidate Windows CI routing test bodies [#139486](https://github.com/openclaw/openclaw/pull/139486).
+- Simplify catalog assertions and restore real process probes in report fixtures [#139496](https://github.com/openclaw/openclaw/pull/139496).
+- Preserve targeted test glob selection under Bun [#139497](https://github.com/openclaw/openclaw/pull/139497).
+- Synchronize cloud retry fixtures and dashboard iframe input in CI [#139506](https://github.com/openclaw/openclaw/pull/139506).
+- Remove the obsolete storage-failure retry assertion blocking CI [#139519](https://github.com/openclaw/openclaw/pull/139519).
+- Retain storage-failure no-retry and no-credential-rotation coverage [#139531](https://github.com/openclaw/openclaw/pull/139531).
+- Use consistent media factory test snapshots [#139545](https://github.com/openclaw/openclaw/pull/139545).
+- Reuse the accounting test database with distinct session identities [#139552](https://github.com/openclaw/openclaw/pull/139552).
+- Reuse Vitest transforms within confirmed scheduler-slot lifetimes [#139553](https://github.com/openclaw/openclaw/pull/139553).
+- Isolate Workshop marker-casing test identities [#139554](https://github.com/openclaw/openclaw/pull/139554).
+- Serve macOS dashboard fixtures on a private transport queue [#139556](https://github.com/openclaw/openclaw/pull/139556).
+- Consolidate compaction classification tests and remove test-only exports [#139564](https://github.com/openclaw/openclaw/pull/139564).
+- Keep Unix socket test fixtures within platform path limits [#139565](https://github.com/openclaw/openclaw/pull/139565).
+- Make QA cleanup-child logging deterministic [#139566](https://github.com/openclaw/openclaw/pull/139566).
+- Consolidate Memory visibility fixtures without policy defaults [#139569](https://github.com/openclaw/openclaw/pull/139569).
+- Use call-through observation for native Gateway drain tests [#139576](https://github.com/openclaw/openclaw/pull/139576).
+- Consolidate literal sanitizer test cases [#139579](https://github.com/openclaw/openclaw/pull/139579).
+- Separate long maintenance proofs from the hot-reload QA umbrella [#139580](https://github.com/openclaw/openclaw/pull/139580).
+- Share sparse transcript-repair input fixtures [#139589](https://github.com/openclaw/openclaw/pull/139589).
+- Make plugin-state and QA tests portable to Bun [#139590](https://github.com/openclaw/openclaw/pull/139590).
+- Preserve held-work close failures in Gateway tests [#139593](https://github.com/openclaw/openclaw/pull/139593).
+- Stop test HTTP servers before destroying tracked sockets [#139595](https://github.com/openclaw/openclaw/pull/139595).
+- Remove duplicate process-census setup from report tests [#139596](https://github.com/openclaw/openclaw/pull/139596).
+- Make CLI final-result precedence tests discriminating [#139605](https://github.com/openclaw/openclaw/pull/139605).
+- Share HTTP authority test scenarios while preserving endpoint contracts [#139611](https://github.com/openclaw/openclaw/pull/139611).
+- Scope dashboard test settings preload to the top frame [#139618](https://github.com/openclaw/openclaw/pull/139618).
+- Make QA CLI exit-state and cleanup assertions portable to Bun [#139625](https://github.com/openclaw/openclaw/pull/139625).
+- Consolidate configuration-redaction coverage [#139626](https://github.com/openclaw/openclaw/pull/139626).
+- Exercise Gateway status deadline boundaries without wall-clock waiting [#139631](https://github.com/openclaw/openclaw/pull/139631).
+- Reuse HTTP request readers in DeepInfra tests [#139634](https://github.com/openclaw/openclaw/pull/139634).
+- Retry board-widget test pointer entry before clicking [#139635](https://github.com/openclaw/openclaw/pull/139635).
+- Reuse Google speech request guards [#139638](https://github.com/openclaw/openclaw/pull/139638).
+- Close shared HTTP test connections through their fixture owner [#139640](https://github.com/openclaw/openclaw/pull/139640).
+- Rebalance services and infrastructure test roots [#139645](https://github.com/openclaw/openclaw/pull/139645).
+- Overlap independent SOCKS deadline tests without shortening deadlines [#139651](https://github.com/openclaw/openclaw/pull/139651).
+- Share channel-view test fixture defaults [#139665](https://github.com/openclaw/openclaw/pull/139665).
+- Consolidate repeated CI runner-routing assertions [#139667](https://github.com/openclaw/openclaw/pull/139667).
+- Share worker-session tool fixtures and reset one-shot overrides [#139673](https://github.com/openclaw/openclaw/pull/139673).
+- Consolidate theme contrast coverage without changing styling [#139679](https://github.com/openclaw/openclaw/pull/139679).
+- Consolidate agent-deletion test preparation [#139687](https://github.com/openclaw/openclaw/pull/139687).
+- Consolidate LaunchAgent and Scheduled Task lifecycle coverage [#139694](https://github.com/openclaw/openclaw/pull/139694).
+- Share channel account-policy inheritance fixtures [#139696](https://github.com/openclaw/openclaw/pull/139696).
+- Restore retry and fallback fixtures for bounded continuation [#139697](https://github.com/openclaw/openclaw/pull/139697).
+- Share neutral scheduler-state test fixtures [#139724](https://github.com/openclaw/openclaw/pull/139724).
+- Align recovery and history fixtures with current runtime behavior [#139733](https://github.com/openclaw/openclaw/pull/139733).
+- Remove duplicate scoped environment restoration in daemon tests [#139743](https://github.com/openclaw/openclaw/pull/139743).
+- Use owned mutable stream fields in process-registration fixtures [#139744](https://github.com/openclaw/openclaw/pull/139744).
+- Consolidate fresh zero-usage inputs in agent tests [#139745](https://github.com/openclaw/openclaw/pull/139745).
+- Share fresh zero-usage AI test fixtures [#139746](https://github.com/openclaw/openclaw/pull/139746).
+- Reuse shared child-process close waiters [#139764](https://github.com/openclaw/openclaw/pull/139764).
+- Prepare Doctor fixtures without repeated full bootstraps [#139767](https://github.com/openclaw/openclaw/pull/139767).
+- Use runtime-appropriate collection checks in UI lifetime tests [#139772](https://github.com/openclaw/openclaw/pull/139772).
+- Separate synthetic launchd caller identities from host PIDs [#139790](https://github.com/openclaw/openclaw/pull/139790).
+- Update renamed history projection fields in tests [#139794](https://github.com/openclaw/openclaw/pull/139794).
+- Repair runtime-specific Control UI test fixtures for Bun [#139799](https://github.com/openclaw/openclaw/pull/139799).
+- Await Gateway trust lifecycle changes in Android tests [#139807](https://github.com/openclaw/openclaw/pull/139807).
+- Preserve runtime-specific process census fixtures [#139808](https://github.com/openclaw/openclaw/pull/139808).
+- Consolidate duplicate chat-history trace scenarios [#139814](https://github.com/openclaw/openclaw/pull/139814).
+- Reuse zero-usage inputs across provider stream suites [#139815](https://github.com/openclaw/openclaw/pull/139815).
+- Share desktop browser-context test defaults [#139816](https://github.com/openclaw/openclaw/pull/139816).
+- Consolidate empty successful CLI process fixtures [#139819](https://github.com/openclaw/openclaw/pull/139819).
+- Observe both queue settlement and client receipt in clock-jump tests [#139820](https://github.com/openclaw/openclaw/pull/139820).
+- Register server closure before destroying fixture sockets [#139824](https://github.com/openclaw/openclaw/pull/139824).
+- Strengthen existing timeout completion assertions [#139825](https://github.com/openclaw/openclaw/pull/139825).
+- Mock project-owned UUID generation in custodian tests [#139832](https://github.com/openclaw/openclaw/pull/139832).
+- Repair managed-child test mocks and failed-spawn cleanup for Bun [#139834](https://github.com/openclaw/openclaw/pull/139834).
+- Avoid echoing unbounded parser details in test errors [#139837](https://github.com/openclaw/openclaw/pull/139837).
+- Resolve explicit Node tools in script and installer fixtures [#139841](https://github.com/openclaw/openclaw/pull/139841).
+- Repair timeout-error and tool-planning fixtures under Bun [#139843](https://github.com/openclaw/openclaw/pull/139843).
+- Supply prepared plugin context in cache-TTL fixtures [#139845](https://github.com/openclaw/openclaw/pull/139845).
+- Invalidate cached install records before Doctor persistence assertions [#139858](https://github.com/openclaw/openclaw/pull/139858).
+- Await filesystem access without requiring a Node-specific return value [#139859](https://github.com/openclaw/openclaw/pull/139859).
+- Use the existing short opening budget for one negative fixture [#139860](https://github.com/openclaw/openclaw/pull/139860).
+- Keep environment values out of registry-test failure output [#139886](https://github.com/openclaw/openclaw/pull/139886).
+- Supply the paired-node backend directly in learn policy tests [#139890](https://github.com/openclaw/openclaw/pull/139890).
+- Give skill and sandbox browser tests their own workspaces [#139894](https://github.com/openclaw/openclaw/pull/139894).
+- Disable unnecessary bind retries in occupied-port startup fixtures [#139897](https://github.com/openclaw/openclaw/pull/139897).
+- Reuse the existing runtime fixture in setup tests [#139920](https://github.com/openclaw/openclaw/pull/139920).
+- Repair Bun runner fixture preload and readiness handling [#139922](https://github.com/openclaw/openclaw/pull/139922).
+- Isolate plugin runtime fixture environments [#139928](https://github.com/openclaw/openclaw/pull/139928).
+- Consolidate cleanup timeout and revocation tests [#139937](https://github.com/openclaw/openclaw/pull/139937).
+- Bind the setup shutdown fixture to the detection worker [#139942](https://github.com/openclaw/openclaw/pull/139942).
+- Consolidate Ollama endpoint alias migration tests [#139943](https://github.com/openclaw/openclaw/pull/139943).
+- Recheck completed presence operations before reporting test timeouts [#139944](https://github.com/openclaw/openclaw/pull/139944).
+- Use existing fixture metadata instead of loading unrelated plugins in core tests [#139955](https://github.com/openclaw/openclaw/pull/139955).
+- Release memory-search fixtures after failed phases [#140013](https://github.com/openclaw/openclaw/pull/140013).
+- Drain chat-pane imports during UI test cleanup [#140026](https://github.com/openclaw/openclaw/pull/140026).
+- Use a synthetic provider in the catalog-window fixture [#140032](https://github.com/openclaw/openclaw/pull/140032).
+- Make failed iOS approval readback explicit in the existing fixture [#140033](https://github.com/openclaw/openclaw/pull/140033).
+- Isolate Serve hello lifecycle tests from the full method catalog [#140044](https://github.com/openclaw/openclaw/pull/140044).
+- Make filesystem-access tests portable across Node and Bun [#140047](https://github.com/openclaw/openclaw/pull/140047).
+- Consolidate Crabbox wrapper boundary tests [#140058](https://github.com/openclaw/openclaw/pull/140058).
+- Move model-selection fixtures out of production auto-reply paths [#140069](https://github.com/openclaw/openclaw/pull/140069).
+- Advance cron timeout tests through both cleanup phases [#140076](https://github.com/openclaw/openclaw/pull/140076).
+- Fix plugin HTTP fixture shutdown under Bun [#140078](https://github.com/openclaw/openclaw/pull/140078).
+- Preserve IRC import smoke coverage under Bun [#140082](https://github.com/openclaw/openclaw/pull/140082).
+- Avoid false macOS catalog timeout fixture failures [#140088](https://github.com/openclaw/openclaw/pull/140088).
+- Make plugin filesystem and memory CLI fixture outcomes portable under Bun [#140089](https://github.com/openclaw/openclaw/pull/140089).
+- Prepare captured routes for iOS approval event tests [#140107](https://github.com/openclaw/openclaw/pull/140107).
+- Avoid false native polling timeouts in test helpers [#140119](https://github.com/openclaw/openclaw/pull/140119).
+- Simplify update fixtures and honor stable Homebrew Node paths [#140126](https://github.com/openclaw/openclaw/pull/140126).
+- Consolidate iMessage approval reaction tests [#140138](https://github.com/openclaw/openclaw/pull/140138).
+- Consolidate browser interaction navigation-guard tests [#140152](https://github.com/openclaw/openclaw/pull/140152).
+- Test Tavily proxy endpoints through their client and remove a private test export [#140160](https://github.com/openclaw/openclaw/pull/140160).
+- Consolidate browser SSRF guard tests while retaining independent boundary coverage [#140174](https://github.com/openclaw/openclaw/pull/140174).
+- Reset browser CLI fixture exit status explicitly for Bun [#140188](https://github.com/openclaw/openclaw/pull/140188).
+- Consolidate installed-plugin metadata tests and correct prototype-name coverage [#140190](https://github.com/openclaw/openclaw/pull/140190).
+- Use a module-level crypto mock in Teams formatter tests [#140199](https://github.com/openclaw/openclaw/pull/140199).
+- Track native watcher closure directly in memory filesystem tests [#140217](https://github.com/openclaw/openclaw/pull/140217).
+- Remove unnecessary Android fixture waits and observe actual outbox publication [#140219](https://github.com/openclaw/openclaw/pull/140219).
+- Use the current approval inbox snapshot in Android readiness tests [#140247](https://github.com/openclaw/openclaw/pull/140247).
+- Consolidate full and discovery plugin CLI metadata test fixtures [#140262](https://github.com/openclaw/openclaw/pull/140262).
+- Consolidate unanswered-update-request and refused-retry tests [#140264](https://github.com/openclaw/openclaw/pull/140264).
+- Consolidate native update restart-helper profile tests [#140275](https://github.com/openclaw/openclaw/pull/140275).
+- Keep the RTC offer smoke offline and launch its Bun child from the plugin directory [#140276](https://github.com/openclaw/openclaw/pull/140276).
+- Strengthen disabled-plugin metadata coverage while consolidating enablement tests [#140282](https://github.com/openclaw/openclaw/pull/140282).
+- Consolidate bundled and memory-slot CLI metadata exclusion fixtures [#140298](https://github.com/openclaw/openclaw/pull/140298).
+- Preserve native timer handles in the Signal timeout-cap fixture [#140305](https://github.com/openclaw/openclaw/pull/140305).
+- Declare the synthetic Ollama failed-response Content-Type explicitly [#140307](https://github.com/openclaw/openclaw/pull/140307).
+- Simplify MCP and LSP fixtures and correct shared-lane capacity assumptions [#140312](https://github.com/openclaw/openclaw/pull/140312).
+- Update the docs route-shape test for release section pages [#140337](https://github.com/openclaw/openclaw/pull/140337).
+- Consolidate relay startup and supervisor cleanup fixtures [#140345](https://github.com/openclaw/openclaw/pull/140345).
+- Consolidate ClawHub trust-error UI fixtures and verify no acknowledgement retry [#140374](https://github.com/openclaw/openclaw/pull/140374).
+- Inline the one-shot exec cleanup fixture while retaining all finalization cases [#140385](https://github.com/openclaw/openclaw/pull/140385).
+- Speed up large-upload fixture byte comparisons without sampling [#140402](https://github.com/openclaw/openclaw/pull/140402).
+- Consolidate device token wake-cancellation and response-ordering tests [#140403](https://github.com/openclaw/openclaw/pull/140403).
+- Remove redundant direct-state onboarding tests and DEBUG-only hooks [#140430](https://github.com/openclaw/openclaw/pull/140430).
+- Remove test-only TUI shutdown timer and process-sink hooks [#140432](https://github.com/openclaw/openclaw/pull/140432).
+- Preserve saved configuration when testing logging-only Gateway reloads [#140433](https://github.com/openclaw/openclaw/pull/140433).
+- Remove unused Docker heartbeat executables and environment fixtures [#140445](https://github.com/openclaw/openclaw/pull/140445).
+- Preserve saved fields when Gateway reload fixtures update logging and UI settings [#140453](https://github.com/openclaw/openclaw/pull/140453).
+- Remove unused parent context-cache reset setup from worker tests [#140456](https://github.com/openclaw/openclaw/pull/140456).
+- Replace repeated config-reload test gates with the existing deferred helper [#140475](https://github.com/openclaw/openclaw/pull/140475).
+- Reset Matrix CLI test exit status explicitly between commands [#140491](https://github.com/openclaw/openclaw/pull/140491).
+- Use native Bun instrumentation for Matrix fixture loaders while retaining Node hooks [#140496](https://github.com/openclaw/openclaw/pull/140496).
+- Reuse existing deferred gates in post-attach startup tests [#140502](https://github.com/openclaw/openclaw/pull/140502).
+- Reuse deferred synchronization gates in Gateway reload-handler tests [#140509](https://github.com/openclaw/openclaw/pull/140509).
+- Batch release-ancestry fixture commits through Git fast-import [#140513](https://github.com/openclaw/openclaw/pull/140513).
+- Simplify Doctor SQLite migration fixtures while retaining real storage checks [#140518](https://github.com/openclaw/openclaw/pull/140518).
+- Reuse Doctor recovery-report and output-runtime test fixtures [#140521](https://github.com/openclaw/openclaw/pull/140521).
+- Reuse identical agent-turn failure setup across authentication, conversation and terminal tests [#140525](https://github.com/openclaw/openclaw/pull/140525).
+- Reuse model-fallback configuration construction while preserving order and fresh wrappers [#140533](https://github.com/openclaw/openclaw/pull/140533).
+- Reuse Voice Call test record builders without changing routing or cancellation cases [#140539](https://github.com/openclaw/openclaw/pull/140539).
+- Remove redundant Perplexity private-helper tests and their testing export [#140541](https://github.com/openclaw/openclaw/pull/140541).
+- Remove redundant dead-code scanner source assertions and restore fixture method ownership [#140543](https://github.com/openclaw/openclaw/pull/140543).
+- Reuse remaining CLI success fixtures while preserving held-run identities [#140546](https://github.com/openclaw/openclaw/pull/140546).
+- Isolate compact-planner growth inventories to prevent false job-cap failures [#140549](https://github.com/openclaw/openclaw/pull/140549). Thanks @vincentkoc.
+- Isolate safe-bin and unresolved-command test fixtures from host PATH and symlink differences [#140559](https://github.com/openclaw/openclaw/pull/140559).
+- Isolate macOS build-test PATHs from host pnpm and Corepack installations [#140571](https://github.com/openclaw/openclaw/pull/140571).
+- Move Exa response-reader coverage to the tool boundary and remove private testing overrides [#140572](https://github.com/openclaw/openclaw/pull/140572).
+- Consolidate LINE Markdown replay tests into shared parser coverage [#140599](https://github.com/openclaw/openclaw/pull/140599).
+- Remove the ninety-five-second idle wait from exec-retention regression coverage [#140612](https://github.com/openclaw/openclaw/pull/140612).
+- Capture bounded A2UI action-delivery diagnostics only on test failure [#140626](https://github.com/openclaw/openclaw/pull/140626).
+- Move SearXNG category-fallback tests to the request boundary [#140644](https://github.com/openclaw/openclaw/pull/140644).
+- Consolidate Doctor sidecar timestamp fixtures while preserving independent assertions [#140665](https://github.com/openclaw/openclaw/pull/140665).
+- Remove redundant Parallels exec test scaffolding and unreachable post-exec code [#140673](https://github.com/openclaw/openclaw/pull/140673).
+- Measure Workshop blank-line layout heights consistently in browser tests [#140718](https://github.com/openclaw/openclaw/pull/140718).
+- Share Discord plugin-owner test setup without removing scenarios [#140722](https://github.com/openclaw/openclaw/pull/140722).
+- Remove MCP resolver test-only registry and timer overrides [#140734](https://github.com/openclaw/openclaw/pull/140734).
+- Share E2E environment-limit parsing while preserving validation and diagnostics [#140735](https://github.com/openclaw/openclaw/pull/140735). Thanks @vincentkoc.
+- Exercise LanceDB embedding fallback through requests and remove the testing export [#140741](https://github.com/openclaw/openclaw/pull/140741).
+- Reserve idle Gateway fixture ports to reduce parallel test collisions [#140747](https://github.com/openclaw/openclaw/pull/140747). Thanks @vincentkoc.
+- Stop Windows test cleanup from targeting known-exited child process IDs [#140753](https://github.com/openclaw/openclaw/pull/140753).
+- Use umask-aware permission expectations for Git-materialized worker files [#140771](https://github.com/openclaw/openclaw/pull/140771).
+- Test Google Meet platform guards through the registered tool [#140792](https://github.com/openclaw/openclaw/pull/140792).
+- Share home-relative path expansion in plugin E2E assertions [#140806](https://github.com/openclaw/openclaw/pull/140806). Thanks @vincentkoc.
+- Share fresh single-button Slack interaction fixtures while retaining all scenarios [#140807](https://github.com/openclaw/openclaw/pull/140807).
+- Declare text capability in memory-budget test fixtures [#140841](https://github.com/openclaw/openclaw/pull/140841).
+- Reuse background context-engine maintenance fixtures without removing coverage [#140851](https://github.com/openclaw/openclaw/pull/140851).
+- Check Swift build-cache retry behavior through executed command sequences [#140858](https://github.com/openclaw/openclaw/pull/140858).
+- Consolidate generic Twitch Markdown cases into shared parser coverage [#140878](https://github.com/openclaw/openclaw/pull/140878).
+- Simplify serial UI ownership inventory scans [#140888](https://github.com/openclaw/openclaw/pull/140888).
+- Use restorable spies in status reply tests [#140906](https://github.com/openclaw/openclaw/pull/140906).
+- Add opt-in Code Mode evaluation scenarios and observed telemetry summaries [#140913](https://github.com/openclaw/openclaw/pull/140913). Thanks @Takhoffman.
+- Wait for completed picker dismissal in cron catalog browser tests [#140974](https://github.com/openclaw/openclaw/pull/140974).
+- Wait for picker animations before asserting mobile layout geometry [#140997](https://github.com/openclaw/openclaw/pull/140997).
+- Correct synthetic child-session lists in permission-refresh browser tests [#141020](https://github.com/openclaw/openclaw/pull/141020).
+- Report credential-less Copilot and media live tests as skipped [#141024](https://github.com/openclaw/openclaw/pull/141024).
+- Finish cancelled profiling workloads before test cleanup [#141049](https://github.com/openclaw/openclaw/pull/141049).
+- Prevent mock-server port collisions in SQLite lifecycle tests [#141063](https://github.com/openclaw/openclaw/pull/141063). Thanks @vincentkoc.
+- Correct CI growth-test classification of split and unsplit tooling jobs [#141075](https://github.com/openclaw/openclaw/pull/141075). Thanks @brokemac79.
+- Join Mermaid rendering before clipboard fixture teardown [#141085](https://github.com/openclaw/openclaw/pull/141085).
+- Remove a clipboard-test mock that contaminated native Mermaid tests [#141092](https://github.com/openclaw/openclaw/pull/141092).
+- Make migration file-access assertions portable across Node and Bun [#141093](https://github.com/openclaw/openclaw/pull/141093).
+- Use shared HTTP fixture cleanup in Slack thread-resolution tests [#141112](https://github.com/openclaw/openclaw/pull/141112).
+- Share CI fixture startup and discovery work [#141137](https://github.com/openclaw/openclaw/pull/141137). Thanks @vincentkoc.
+- Consolidate duplicate Telegram test setup to stay within the line cap [#141139](https://github.com/openclaw/openclaw/pull/141139). Thanks @vincentkoc.
+- Remove unused inputs from the Parallels test-server path [#141142](https://github.com/openclaw/openclaw/pull/141142).
+- Split Telegram test files without changing behavior [#141148](https://github.com/openclaw/openclaw/pull/141148).
+- Serialize managed-service fixture updates to prevent torn reads and lost state [#141186](https://github.com/openclaw/openclaw/pull/141186).
+- Repair gallery fixtures so loaded previews receive real event-listener contracts [#141203](https://github.com/openclaw/openclaw/pull/141203). Thanks @vincentkoc.
+- Wait for actual loopback prompt reception instead of a short polling window [#141204](https://github.com/openclaw/openclaw/pull/141204).
+- Finish the initial service-worker update check before simulating deployment [#141212](https://github.com/openclaw/openclaw/pull/141212).
+- Align auth-profile rotation fixtures with the existing rate-limit retry budget [#141238](https://github.com/openclaw/openclaw/pull/141238).
+- Share readiness-fallback fixture setup across speech and telephony tests [#141258](https://github.com/openclaw/openclaw/pull/141258).
+- Check archive access without depending on Node and Bun's different success return values [#141333](https://github.com/openclaw/openclaw/pull/141333).
+- Join owned Windows Startup fixture children before deleting their working directory [#141360](https://github.com/openclaw/openclaw/pull/141360).
+- Check selected plugin IDs and kinds without rejecting extra manifest fields [#141386](https://github.com/openclaw/openclaw/pull/141386). Thanks @vincentkoc.
+- Compile catalog workers once per test invocation [#141422](https://github.com/openclaw/openclaw/pull/141422).
+- Require successful native CLI fixture completion and cover Windows launch behavior [#141423](https://github.com/openclaw/openclaw/pull/141423).
+- Scope first-open palette assertions to the palette shell [#141452](https://github.com/openclaw/openclaw/pull/141452).
+- Split streaming Markdown tests into a sibling suite [#141485](https://github.com/openclaw/openclaw/pull/141485).
+- Consolidate repeated CI scope expectations without changing routing [#141487](https://github.com/openclaw/openclaw/pull/141487).
+- Decode split UTF-8 safely in package and smoke-test helpers [#141493](https://github.com/openclaw/openclaw/pull/141493).
+- Move code-block rendering tests beside related clipboard coverage [#141494](https://github.com/openclaw/openclaw/pull/141494).
+- Combine duplicate mock-provider retention tests while preserving content assertions [#141495](https://github.com/openclaw/openclaw/pull/141495).
+- Move Markdown render-cache and large-text tests into a sibling suite [#141497](https://github.com/openclaw/openclaw/pull/141497).
+- Use synthetic external requesters in repair-effect fixtures [#141512](https://github.com/openclaw/openclaw/pull/141512).
+- Reduce repeated setup in reporter contract tests [#141516](https://github.com/openclaw/openclaw/pull/141516).
+- Remove the duplicate streaming Markdown suite [#141519](https://github.com/openclaw/openclaw/pull/141519).
+- Consolidate WebSocket ping test doubles [#141529](https://github.com/openclaw/openclaw/pull/141529).
+- Avoid FIFO reopening hangs in Docker test error capture [#141532](https://github.com/openclaw/openclaw/pull/141532).
+- Wait for native link menu creation before asserting its trigger [#141533](https://github.com/openclaw/openclaw/pull/141533).
+- Reduce repeated source transforms in Doctor configuration tests [#141549](https://github.com/openclaw/openclaw/pull/141549).
+- Align credential scenario selection and criteria with the single-secret UI [#141555](https://github.com/openclaw/openclaw/pull/141555).
+- Consolidate Anthropic guest Code Mode test fixtures [#141566](https://github.com/openclaw/openclaw/pull/141566).
+- Make pinned Codex response and notification tests cancellation-safe [#141579](https://github.com/openclaw/openclaw/pull/141579).
+- Expand Gateway configuration fixture isolation checks without duplicate setup [#141580](https://github.com/openclaw/openclaw/pull/141580).
+- Prepare real SDK bridge entries for native compatibility-test loading [#141584](https://github.com/openclaw/openclaw/pull/141584).
+- Correct quota failover fixtures and retain worker-load failure diagnostics [#141587](https://github.com/openclaw/openclaw/pull/141587).
+- Share plain user-message fixtures in model-boundary tests [#141593](https://github.com/openclaw/openclaw/pull/141593).
+- Match the resolved worker argument vector in update test fixtures [#141594](https://github.com/openclaw/openclaw/pull/141594).
+- Replace copied TTS provider fixtures with actual-provider contract coverage [#141595](https://github.com/openclaw/openclaw/pull/141595).
+- Simplify queued steering message fixtures [#141607](https://github.com/openclaw/openclaw/pull/141607).
+- Consolidate Discord allowlist fixtures without changing coverage [#141622](https://github.com/openclaw/openclaw/pull/141622).
+- Keep both missing-plugin refusal and available-package recovery coverage [#141624](https://github.com/openclaw/openclaw/pull/141624).
+- Select Linux test listener blocks outside the kernel client range [#141627](https://github.com/openclaw/openclaw/pull/141627).
+- Remove duplicate collapsed-chat activity coverage [#141630](https://github.com/openclaw/openclaw/pull/141630).
+- Remove duplicate wake-scheduler scenarios from legacy heartbeat suites [#141631](https://github.com/openclaw/openclaw/pull/141631).
+- Forward selected PID lists through containment test adapters [#141634](https://github.com/openclaw/openclaw/pull/141634).
+- Stabilize Android wake-word save assertions [#141635](https://github.com/openclaw/openclaw/pull/141635).
+- Share repeated session and silence-policy test inputs [#141636](https://github.com/openclaw/openclaw/pull/141636).
+- Keep denied Linux test-port probes outside the client range [#141645](https://github.com/openclaw/openclaw/pull/141645).
+- Remove redundant memory embedding resolver cases [#141650](https://github.com/openclaw/openclaw/pull/141650).
+- Synchronize Codex containment tests with actual SIGSTOP delivery [28bb07290844](https://github.com/openclaw/openclaw/commit/28bb072908447bc982aaf3bfad361e70b269d2f0). Equivalent PR context is [#141681](https://github.com/openclaw/openclaw/pull/141681); the canonical release source is this direct commit.
+- Update ownership expectations after agent roster deduplication [cdda5ea4aaba](https://github.com/openclaw/openclaw/commit/cdda5ea4aaba5a7454bd57acac82dae7623eb2ce).
+- Bind Exa test cancellation to the request listener [c296ab183498](https://github.com/openclaw/openclaw/commit/c296ab183498b26ba0a8abaaa3947c0cde2e8d84).
+- Resolve release-verifier test conflicts and remove an obsolete Thai cache entry [2519a25e2b67](https://github.com/openclaw/openclaw/commit/2519a25e2b672336c7d2da0fa42d9209cda69a54).
+- Distinguish verified workflow-run references from unresolved issues [cafdeb78b798](https://github.com/openclaw/openclaw/commit/cafdeb78b798058811836a4829f6fb42bcc5038f).
+- Exercise targeted auth logout in the product-proof fixture [7bdac8e668ba](https://github.com/openclaw/openclaw/commit/7bdac8e668ba8906b67388f61cb578706212ff4c).
+- Correct selected-profile recovery fixtures and operational RPC assertions [cf7a740c0b1b](https://github.com/openclaw/openclaw/commit/cf7a740c0b1b4cfc46f7a97e9c0b39fdc6458c9b).
+- Align authentication and skill-proposal fixtures with runtime contracts [045a1400a75a](https://github.com/openclaw/openclaw/commit/045a1400a75aaf32ea93d49228289625d9164d65).
+- Disable retries only in the permanently occupied-port tracing fixture [a681f6f42676](https://github.com/openclaw/openclaw/commit/a681f6f4267682ee9743beca30979e3431af0355).
+- Consolidate deterministic Talk media fixtures for shared browser runs [#138803](https://github.com/openclaw/openclaw/pull/138803). Thanks @vincentkoc.
+
+</details>
+</Accordion>
+
+<Accordion title="Build, review, and release tooling">
+
+Build and release tools preserve frozen source identities, improve validation routing and failure evidence, and keep contribution credit tied to verified identities. Changes to routine CI do not replace the fuller manual qualification required for release artifacts.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Preserve unusual Git filenames through changed-file check routing [#126198](https://github.com/openclaw/openclaw/pull/126198). Thanks @vincentkoc, @qingminglong.
+- Record Gateway output ownership at build time to avoid unrelated artifact scans [#127757](https://github.com/openclaw/openclaw/pull/127757). Thanks @fuller-stack-dev.
+- Validate frozen package declarations and isolate archive extraction and npm inventory [#136699](https://github.com/openclaw/openclaw/pull/136699). Thanks @RomneyDa, @vincentkoc.
+- Consolidate frozen-target harness selection and capability checks [#136761](https://github.com/openclaw/openclaw/pull/136761). Thanks @RomneyDa, @vincentkoc.
+- Select frozen dependency evidence locks from target package ownership [#136884](https://github.com/openclaw/openclaw/pull/136884). Thanks @RomneyDa, @vincentkoc.
+- Select the frozen bundled-channel smoke entrypoint and its loader [#136919](https://github.com/openclaw/openclaw/pull/136919). Thanks @RomneyDa.
+- Keep native app assets pending until their digests are verified [#137098](https://github.com/openclaw/openclaw/pull/137098). Thanks @vincentkoc.
+- Add the exact2026.7.33 plugin security inventory policy [#137585](https://github.com/openclaw/openclaw/pull/137585). Thanks @RomneyDa.
+- Adapt CI smoke and QA planning to frozen target capabilities [#137586](https://github.com/openclaw/openclaw/pull/137586). Thanks @RomneyDa.
+- Sanitize selected declaration output roots after successful direct tsdown builds [#137592](https://github.com/openclaw/openclaw/pull/137592). Thanks @RomneyDa.
+- Bind historical package verifiers to the trusted tooling checkout [#137657](https://github.com/openclaw/openclaw/pull/137657). Thanks @RomneyDa.
+- Require Crabbox0.48 for Blacksmith Testbox admission [#137841](https://github.com/openclaw/openclaw/pull/137841). Thanks @vincentkoc.
+- Derive fs-safe native verification applicability from authorized frozen source [#137893](https://github.com/openclaw/openclaw/pull/137893). Thanks @RomneyDa, @vincentkoc.
+- Keep targeted lint for small edits accompanied by assertion-baseline changes [#139039](https://github.com/openclaw/openclaw/pull/139039).
+- Share package-script change classification and remove duplicate metadata projections [#139078](https://github.com/openclaw/openclaw/pull/139078).
+- Select Watch RTC build prerequisites from the frozen source capability [#139118](https://github.com/openclaw/openclaw/pull/139118).
+- Run release-tooling installs from the harness directory so Corepack selects its own pnpm version [#139259](https://github.com/openclaw/openclaw/pull/139259).
+- Exclude the documented machine coauthor identity and validate native merge previews [#139264](https://github.com/openclaw/openclaw/pull/139264).
+- Reconcile candidate dependencies and reverify source identity before remote validation payloads run [#139273](https://github.com/openclaw/openclaw/pull/139273).
+- Omit latest promotion from existing release-draft edits [#139297](https://github.com/openclaw/openclaw/pull/139297).
+- Pin the ClawHub workflow revision that resolves the original authorized recovery child [#139331](https://github.com/openclaw/openclaw/pull/139331).
+- Bring published 2026.9.2 version metadata and changelog onto main [#139369](https://github.com/openclaw/openclaw/pull/139369).
+- Register the 2026.9.3 release context in plugin security qualification [#139399](https://github.com/openclaw/openclaw/pull/139399).
+- Repair iOS and Watch release-qualification fixtures and guards [#139403](https://github.com/openclaw/openclaw/pull/139403). Thanks @vincentkoc.
+- Preserve Crabbox payload output, script options and source-policy exclusions [#139405](https://github.com/openclaw/openclaw/pull/139405).
+- Use a guarded installed-SDK transport for Parallels 27 macOS smoke commands [#139418](https://github.com/openclaw/openclaw/pull/139418).
+- Authorize frozen mobile candidates against trusted tooling and inspect every candidate commit [#139441](https://github.com/openclaw/openclaw/pull/139441). Thanks @vincentkoc.
+- Preserve configured Git hook choices during contributor installation [#139461](https://github.com/openclaw/openclaw/pull/139461).
+- Exclude Cursor and Amp machine identities from composed squash credit [#139558](https://github.com/openclaw/openclaw/pull/139558).
+- Promote the qualified2026.9.2 macOS appcast [#139575](https://github.com/openclaw/openclaw/pull/139575).
+- Enforce the documented AMD64 AppImage ABI floor in packaging checks [#139630](https://github.com/openclaw/openclaw/pull/139630). Thanks @vincentkoc.
+- Stop replaying sent QA Gateway requests after response loss [#139644](https://github.com/openclaw/openclaw/pull/139644).
+- Register Koffi's process-execution dependency ownership [#139662](https://github.com/openclaw/openclaw/pull/139662). Thanks @vincentkoc.
+- Add native ARM64 AppImage tooling and qualification [#139729](https://github.com/openclaw/openclaw/pull/139729). Thanks @vincentkoc.
+- Resynchronize suppression inventory line references [#139747](https://github.com/openclaw/openclaw/pull/139747).
+- Prepare source-scan paths before sorting [#139763](https://github.com/openclaw/openclaw/pull/139763).
+- Explain escaped declaration dependencies and refresh stale history fixtures [#139766](https://github.com/openclaw/openclaw/pull/139766).
+- Compare suppression directives independently of line numbers [#139769](https://github.com/openclaw/openclaw/pull/139769).
+- Materialize the trusted archive before extracting it on macOS [#139795](https://github.com/openclaw/openclaw/pull/139795).
+- Refill release preflight workers and check registry plans earlier [#139798](https://github.com/openclaw/openclaw/pull/139798).
+- Load TypeScript tooling through existing Jiti aliases on Bun [#139861](https://github.com/openclaw/openclaw/pull/139861).
+- Validate squash-preview coauthors against genuine contribution evidence [#139993](https://github.com/openclaw/openclaw/pull/139993). Thanks @vincentkoc.
+- Compress CI test-group outputs while preserving historical target support [#140018](https://github.com/openclaw/openclaw/pull/140018). Thanks @ylcn91, @vincentkoc.
+- Record user and system CPU time for Node test jobs [#140054](https://github.com/openclaw/openclaw/pull/140054).
+- Skip screenshot capture for iOS and Watch unit-test-only changes [#140077](https://github.com/openclaw/openclaw/pull/140077).
+- Reuse runtime alias discovery across build-output consumers [#140358](https://github.com/openclaw/openclaw/pull/140358).
+- Exclude Codex machine attribution from reviewed squash messages [#140420](https://github.com/openclaw/openclaw/pull/140420).
+- Resolve Parallels smoke-test host networking from configured adapters before live-interface fallback [#140481](https://github.com/openclaw/openclaw/pull/140481). Thanks @vincentkoc.
+- Keep release-validation refs, dispatch and evidence reads on the selected GitHub transport [#140486](https://github.com/openclaw/openclaw/pull/140486). Thanks @vincentkoc.
+- Pack compatible hosted tooling groups without exceeding the eighty-job CI cap [#140512](https://github.com/openclaw/openclaw/pull/140512). Thanks @vincentkoc.
+- Replace duplicate QA process-counter parsers with existing SDK helpers [#140527](https://github.com/openclaw/openclaw/pull/140527).
+- Use authenticated loopback setup for fresh macOS and Linux computer-use proof rigs [#140542](https://github.com/openclaw/openclaw/pull/140542).
+- Exclude Trae Solo machine attribution from native squash messages [#140562](https://github.com/openclaw/openclaw/pull/140562). Thanks @vincentkoc.
+- Reduce routine iOS CI to build smoke and preserve full manual release qualification [#140585](https://github.com/openclaw/openclaw/pull/140585). Thanks @vincentkoc.
+- Defer Linux app packaging and graphical smoke tests from pull requests to full manual validation [#140589](https://github.com/openclaw/openclaw/pull/140589). Thanks @vincentkoc.
+- Explain nested declaration failures and direct validation to a separately installed physical checkout [#140617](https://github.com/openclaw/openclaw/pull/140617).
+- Reduce routine macOS and Android CI while preserving full manual release coverage [#140650](https://github.com/openclaw/openclaw/pull/140650). Thanks @vincentkoc.
+- Align declaration-preparation child PWD with its canonical working directory [#140652](https://github.com/openclaw/openclaw/pull/140652).
+- Escape pipes and newlines in QA confidence-report impact cells [#140659](https://github.com/openclaw/openclaw/pull/140659).
+- Reuse shrink-ratchet argument parsing across max-lines and assertion checks [#140661](https://github.com/openclaw/openclaw/pull/140661). Thanks @vincentkoc.
+- Repartition bounded tooling tails and anchor non-hosted CI placement within existing job caps [#140664](https://github.com/openclaw/openclaw/pull/140664). Thanks @vincentkoc.
+- Avoid rebuilding the Watch app during combined iOS screenshot validation [#140751](https://github.com/openclaw/openclaw/pull/140751). Thanks @vincentkoc.
+- Account for reviewed Codex cleanup fixtures in package security validation [#140794](https://github.com/openclaw/openclaw/pull/140794).
+- Recognize the exact RoboClaw machine identity when preparing squash attribution [#140844](https://github.com/openclaw/openclaw/pull/140844). Thanks @Takhoffman.
+- Share TypeScript comment traversal for line and suppression inventories [#140848](https://github.com/openclaw/openclaw/pull/140848). Thanks @vincentkoc.
+- Remove benchmark test-only forwarding members from startup and restart CLIs [#140870](https://github.com/openclaw/openclaw/pull/140870).
+- Replace branch-tip shell installation in duplicate-triage setup with pinned Go installation [#140875](https://github.com/openclaw/openclaw/pull/140875). Thanks @pgondhi987.
+- Remove millisecond suffixes from Gateway startup benchmark counts [#140936](https://github.com/openclaw/openclaw/pull/140936).
+- Share current Git commit discovery across build and package tooling [#140949](https://github.com/openclaw/openclaw/pull/140949). Thanks @vincentkoc.
+- Remove the unused optional process-metric switch from startup benchmarks [#140970](https://github.com/openclaw/openclaw/pull/140970).
+- Repair release-verification inputs, upgrade fixtures and transient GitHub retry handling [#140981](https://github.com/openclaw/openclaw/pull/140981).
+- Add an explicit completion command for recovered merges without merging again [#140992](https://github.com/openclaw/openclaw/pull/140992).
+- Bind trusted PR wrappers to installed package directories instead of mutable aliases [#141058](https://github.com/openclaw/openclaw/pull/141058).
+- Recognize ClawSweeper's exact machine identity in squash attribution [#141105](https://github.com/openclaw/openclaw/pull/141105).
+- Enumerate profiling hashes before TLS imports to avoid the Node 24 startup race [#141131](https://github.com/openclaw/openclaw/pull/141131).
+- Exercise published-package upgrades and legacy state in scheduled CI [#141146](https://github.com/openclaw/openclaw/pull/141146).
+- Reject unexpected remote branch changes during native PR preparation and publication [#141188](https://github.com/openclaw/openclaw/pull/141188). Thanks @vincentkoc.
+- Prepare runtime-consumer matches once to avoid repeated glob compilation in CI planning [#141220](https://github.com/openclaw/openclaw/pull/141220).
+- Permit attested first stable plugin publication with exact release identity checks [#141408](https://github.com/openclaw/openclaw/pull/141408).
+- Correct package scan inventory and repeated-install verification contracts [#141565](https://github.com/openclaw/openclaw/pull/141565).
+- Hydrate release ancestry separately while preserving the frozen verdict target [#141571](https://github.com/openclaw/openclaw/pull/141571). Thanks @RomneyDa.
+- Preserve bounded plugin test batches when forwarding release flags [#141591](https://github.com/openclaw/openclaw/pull/141591).
+- Correct release QA environment and configuration ownership [#141597](https://github.com/openclaw/openclaw/pull/141597).
+- Bound frozen fs-safe qualification to exact known package and source facts [#141611](https://github.com/openclaw/openclaw/pull/141611). Thanks @RomneyDa.
+- Seed the frozen ancestry hydration ref before deepening [65d735e432ae](https://github.com/openclaw/openclaw/commit/65d735e432ae94cb63a15f942433aa46bc356dcb).
+- Align Team Reports package and plugin API metadata to 2026.9.3 [f86b35db6d09](https://github.com/openclaw/openclaw/commit/f86b35db6d09320dad6a56ca6da7e53674f8288f).
+- Bind contribution membership to frozen Git history [caab070cf405](https://github.com/openclaw/openclaw/commit/caab070cf40581c334c9b87c2eced6f0f6c7af5b).
+- Verify multi-commit reversals before excluding release contributions [06ca07d61c67](https://github.com/openclaw/openclaw/commit/06ca07d61c6728aac6b3ceabfc7e15f680220321).
+- Align package versions and compatibility declarations for release preparation [22816da5c1ae](https://github.com/openclaw/openclaw/commit/22816da5c1ae72a6681a8bdce88cf46490b0c293).
+- Bump the Chrome extension manifest version to 2.3.0 [747e4c49ff52](https://github.com/openclaw/openclaw/commit/747e4c49ff52c2f5490d2e44ef086466588bf519).
+- Add request-bound isolated behavioral observations for inline review tooling [#138953](https://github.com/openclaw/openclaw/pull/138953). Thanks @brokemac79.
+
+</details>
+</Accordion>
+
+<Accordion title="Maintainer documentation and translation tooling">
+
+Maintainer references describe review commands, release operations, and validation ownership more clearly. Translation-memory and glossary updates support the documentation and localization process without implying that every tooling update changes visible app text.
 
 <details class="release-source-toggle">
 <summary>Sources and complete change list</summary>
 
 **Documentation**
 
-- [Document Mantis review commands and coordinated activation](https://github.com/openclaw/openclaw/pull/140452). Thanks @brokemac79 and @obviyus.
-- [Explain read-only ClawSweeper status checks](https://github.com/openclaw/openclaw/pull/139958).
-- [Document maintainer skill and tooling entry points](https://github.com/openclaw/openclaw/pull/139380).
+- Correct Mantis proof-publication and QA dispatch documentation [#138210](https://github.com/openclaw/openclaw/pull/138210). Thanks @brokemac79.
+- Reduce repeated root instructions and clarify when validation is complete [#139236](https://github.com/openclaw/openclaw/pull/139236).
+- Reduce universal agent-policy context and remove the separately owned ClawSweeper rubric [#139258](https://github.com/openclaw/openclaw/pull/139258).
+- Clarify standing PR landing authorization without weakening review, CI or outcome reconciliation [#139321](https://github.com/openclaw/openclaw/pull/139321).
+- Simplify maintainer skill entrypoints and synchronize canonical review tooling [#139380](https://github.com/openclaw/openclaw/pull/139380).
+- Refresh generated Control UI translation memory and locale metadata [#139382](https://github.com/openclaw/openclaw/pull/139382).
+- Refresh Control UI translation-memory and locale metadata artifacts [#139447](https://github.com/openclaw/openclaw/pull/139447).
+- Clarify macOS scope within authorized stable release operations [#139452](https://github.com/openclaw/openclaw/pull/139452).
+- Refresh generated Control UI locale artifacts [#139481](https://github.com/openclaw/openclaw/pull/139481).
+- Keep generated translation PR commits when refresh inputs become stale [#139643](https://github.com/openclaw/openclaw/pull/139643).
+- Remove repetitive provider-policy header comments [#139771](https://github.com/openclaw/openclaw/pull/139771).
+- Keep ClawSweeper status inspection guidance read-only [#139958](https://github.com/openclaw/openclaw/pull/139958).
+- Exclude six known false positives from documentation spell checking [#140207](https://github.com/openclaw/openclaw/pull/140207). Thanks @vincentkoc.
+- Consolidate locale publishing instructions and date locale-support guidance [#140209](https://github.com/openclaw/openclaw/pull/140209). Thanks @vincentkoc.
+- Repair Russian and Chinese glossary omissions and document locale-code mappings [#140236](https://github.com/openclaw/openclaw/pull/140236). Thanks @vincentkoc.
+- Remove stale lint and formatting exclusions for legacy docs layouts [#140255](https://github.com/openclaw/openclaw/pull/140255). Thanks @vincentkoc.
+- Mark generated maturity pages and document their render command [#140301](https://github.com/openclaw/openclaw/pull/140301). Thanks @vincentkoc.
+- Clarify Mantis inline-proof commands, shared time limits and coordinated deployment requirements [#140452](https://github.com/openclaw/openclaw/pull/140452). Thanks @brokemac79, @obviyus.
+- Split the CI reference into focused pipeline, runner, proof and release-validation pages [#140501](https://github.com/openclaw/openclaw/pull/140501). Thanks @vincentkoc.
+- Refresh Control UI translation memory and locale metadata [#140511](https://github.com/openclaw/openclaw/pull/140511).
+- Refresh Control UI locale metadata and translation-memory records [#140586](https://github.com/openclaw/openclaw/pull/140586).
+- Refresh Control UI locale metadata and translation-memory records [#140641](https://github.com/openclaw/openclaw/pull/140641).
+- Correct iOS source-build instructions for the embedded Watch toolchain [#141014](https://github.com/openclaw/openclaw/pull/141014).
+- Expand release preparation notes and contributor accounting [6b569054a459](https://github.com/openclaw/openclaw/commit/6b569054a4593f3a90b5eb20593fdc9aafd599ab).
+- Refresh release verification candidate notes [c9e70b366ae2](https://github.com/openclaw/openclaw/commit/c9e70b366ae21948adb45ae65d2360d95e8cc05d).
+- Record update rehearsal repairs in preparation notes [789d2e88bf56](https://github.com/openclaw/openclaw/commit/789d2e88bf56ba8f588b22d36d754cf9af307a6e).
+- Refresh the draft changelog after verification repairs [27bd0e8c721d](https://github.com/openclaw/openclaw/commit/27bd0e8c721d73f479519b8301bad7c17ef9b3c8).
+- Document CI bundle names for different build modes [a67963edab31](https://github.com/openclaw/openclaw/commit/a67963edab31a7462db16d13a8caf904855ac0a9).
+- Refresh draft changes and contribution records for current main [6243495cf00b](https://github.com/openclaw/openclaw/commit/6243495cf00b59b9b9ff2f096e625bd19fd997e4).
+- Retain Italian parent-session and Polish dashboard wording in translation memory [35733629a9f4](https://github.com/openclaw/openclaw/commit/35733629a9f48ff585bbcacf2a536f7312c88d84).
+- Refresh preparation notes after main rebase [e78b9931e4df](https://github.com/openclaw/openclaw/commit/e78b9931e4dfc63c9a64b430f0a6e1d5c2774d60).
+- Refresh release preparation and SDK deprecation notes [bc54cb482af8](https://github.com/openclaw/openclaw/commit/bc54cb482af8e070cbb015b7996f390f9655a905).
+- Carry native code excerpts into translation requests without persisting them [87ab903220c5](https://github.com/openclaw/openclaw/commit/87ab903220c5521fdb9d091c9d95ff6bdb21d167).
+- Correct Spanish, Portuguese and Thai translation-memory terminology [8ad7f39330da](https://github.com/openclaw/openclaw/commit/8ad7f39330da6d8f9b232406e7f8c173d71d29b4).
+- Add bounded targeted Control UI translation refreshes [d078fc9376a4](https://github.com/openclaw/openclaw/commit/d078fc9376a4218c9c22446e1aeb81352f62bd63).
+- Add selected native translation refreshes and source-path context [7e5e00c5371d](https://github.com/openclaw/openclaw/commit/7e5e00c5371daf538caa7338ef732661933158eb).
+- Finalize draft credential recovery and contribution wording [622b588e979c](https://github.com/openclaw/openclaw/commit/622b588e979c8ffb87aea90129e443796064992a).
+- Refresh the 2026.9.3 draft changelog and contribution record [0a554a0e019e](https://github.com/openclaw/openclaw/commit/0a554a0e019eaa6f3c91a3ab9f513e6f0e1f1a45).
+- Clarify Control UI parent-session, sub-agent and panel glossary terms [cb42ee4e88a9](https://github.com/openclaw/openclaw/commit/cb42ee4e88a90a80766711516fb8532b77befa4d).
+- Correct draft-note and source-preflight ordering in release instructions [d4ca30089a14](https://github.com/openclaw/openclaw/commit/d4ca30089a14defdb2865c336e95b823ea6f776b).
+- Add the initial 2026.9.3 changelog section [78f841747a2b](https://github.com/openclaw/openclaw/commit/78f841747a2b095dc5ce632a3ba26cf979eab335).
 
-**Improvements**
+</details>
+</Accordion>
 
-- [Validate genuine squash credit in release tooling](https://github.com/openclaw/openclaw/pull/139993). Thanks @vincentkoc.
-- [Bound CI group output](https://github.com/openclaw/openclaw/pull/140018). Thanks @ylcn91 and @vincentkoc.
-- [Discover the test network for Parallels smoke runs](https://github.com/openclaw/openclaw/pull/140481). Thanks @vincentkoc.
+<Accordion title="Previously shipped changes in release history">
+
+These ten changes are present in the release ancestry but were already backported into 2026.9.2. They are retained here for traceability and are not new 2026.9.3 behavior.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Limits and compatibility**
+
+- Already shipped in 2026.9.2 — Register the reviewed hardware probe in release security inventories without changing runtime code [#139046](https://github.com/openclaw/openclaw/pull/139046).
+- Already shipped in 2026.9.2 — Update Undici security fixes and preserve DNS checks for dotted NO_PROXY hostnames [#139056](https://github.com/openclaw/openclaw/pull/139056).
+- Already shipped in 2026.9.2 — Resolve the Claude CLI pin through ACPX and transfer MCP runtime leases in packaged smoke tests [#139111](https://github.com/openclaw/openclaw/pull/139111). Thanks @vincentkoc.
+- Already shipped in 2026.9.2 — Give campaign RPC fixtures an isolated temporary state home and awaited cleanup [#139116](https://github.com/openclaw/openclaw/pull/139116).
+- Already shipped in 2026.9.2 — Remove a conflicting platform override from the Gateway steering handshake fixture [#139126](https://github.com/openclaw/openclaw/pull/139126).
+- Already shipped in 2026.9.2 — Stop acquired Matrix SDK test clients before resetting runtime state and temporary homes [#139132](https://github.com/openclaw/openclaw/pull/139132).
+- Already shipped in 2026.9.2 — Update cancellation E2Es to verify offline refusal, live cancellation and subsequent heartbeat work [#139135](https://github.com/openclaw/openclaw/pull/139135).
+- Already shipped in 2026.9.2 — Preserve concrete SQLite diagnostics when preparing stable malformed databases for inspection [#139136](https://github.com/openclaw/openclaw/pull/139136).
+- Already shipped in 2026.9.2 — Use the native built-runtime facade in update-repair E2E tests [#139150](https://github.com/openclaw/openclaw/pull/139150).
+- Already shipped in 2026.9.2 — Use the fixture's OPENCLAW_HOME for node-routing test effects [#139153](https://github.com/openclaw/openclaw/pull/139153).
+
+</details>
+</Accordion>
+
+<Accordion title="Reverted work retained in release history">
+
+The updater-policy and recorded-owner Workshop migration changes listed here were reverted before release. Their original changes and the revert remain accounted for, without presenting the withdrawn behavior as a shipped fix.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Limits and compatibility**
+
+- Reverted before release — proposed updater execution-policy recovery [#138771](https://github.com/openclaw/openclaw/pull/138771). Thanks @RileyJJY, @chac4l.
+- Reverted before release — proposed recorded-owner Workshop backup migration [#140117](https://github.com/openclaw/openclaw/pull/140117). Thanks @mbelinky.
+- Revert the updater-policy and recorded-owner Workshop migration changes before release [#140148](https://github.com/openclaw/openclaw/pull/140148). Thanks @mbelinky.
 
 </details>
 </Accordion>

--- a/docs/releases/2026.9.3.md
+++ b/docs/releases/2026.9.3.md
@@ -1,0 +1,1671 @@
+---
+title: "v2026.9.3"
+summary: "Live browser views, persistent Workshop skills, update rehearsal, and a searchable meeting archive."
+description: "OpenClaw v2026.9.3 brings live browser viewing, native Mac tabs, agent-owned Workshop skills, update rehearsal, meeting transcript search, and improvements across conversations, models, and native apps."
+keywords:
+  - OpenClaw
+  - v2026.9.3
+  - release notes
+---
+
+# v2026.9.3
+
+OpenClaw v2026.9.3 brings a live view of supported agent browser tabs into the Browser panel, so you can follow pages as they load and change. In the Mac app, links you open yourself sit beside them as native tabs that stay with the window when you switch conversations. Skill Workshop also gives each agent one persistent collection across workspaces, with complete instructions to compare when reviewing a suggestion.
+
+Supported updates rehearse core and plugin changes before activation, and the meeting library makes saved notes and transcripts searchable. Models settings adds individual account controls and supported account ordering, while fixes across messaging, memory and the native apps help ongoing work survive more interruptions.
+
+## Installation and Onboarding
+
+Setup keeps the choices you have already made and gives clearer guidance when a connection needs attention, with fixes for existing Mac Gateways, Windows startup and Docker workspaces along the way.
+
+<Note>
+Upgrade Node before OpenClaw if you use an older runtime. This release requires Node 24.16.0 or newer on 24.x, or Node 26.1.0 or newer. Node 26 is recommended. See the [Node requirements](/install/node) for supported hosts.
+</Note>
+
+<AccordionGroup>
+<Accordion title="Connect and choose a provider">
+
+Connection screens lead with the problem preventing sign-in and what to do next. Remote setup uses one Gateway secret field, while local setup generates a token by default. Provider selection also keeps credentials attached to the provider they belong to, instead of accepting an unrelated sign-in result.
+
+Opening desktop or browser setup now detects available providers without activating one until you choose it. Discovery of native conversations starts unchecked, and cancelling or failing setup does not select a different provider.
+
+On a Mac with an independently managed local Gateway, setup can continue into model configuration without waiting for a CLI installation that was deliberately skipped. Finishing that setup still requires a verified model response.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Keep provider detection passive until an explicit choice and leave native-conversation discovery unchecked [#140336](https://github.com/openclaw/openclaw/pull/140336).
+- Lead connection and pairing screens with actionable guidance [#141087](https://github.com/openclaw/openclaw/pull/141087).
+- Use one Gateway secret field and generate a local token by default [#141511](https://github.com/openclaw/openclaw/pull/141511), [#141514](https://github.com/openclaw/openclaw/pull/141514).
+
+**Bug fixes**
+
+- Match prepared credentials to their provider and reject unmatched sign-in results [#140461](https://github.com/openclaw/openclaw/pull/140461).
+- Start Mac AI setup when an external local Gateway intentionally skips CLI installation [#139063](https://github.com/openclaw/openclaw/pull/139063).
+- Keep desktop model setup recoverable after a failed interactive turn [#139140](https://github.com/openclaw/openclaw/pull/139140).
+- Keep channel choices scoped to the selected agent workspace [#139358](https://github.com/openclaw/openclaw/pull/139358).
+- Refresh installed-plugin ownership before the first dashboard conversation [#140603](https://github.com/openclaw/openclaw/pull/140603). Thanks @DonnieFi.
+
+</details>
+</Accordion>
+
+<Accordion title="Install on Docker and Windows">
+
+Docker setup preserves the ownership of your project files while repairing the OpenClaw state that needs to be writable. Windows Startup fallback launches also retain saved service environment overrides when inherited variable names use different capitalization.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve bind-mounted project ownership during Docker setup [#140993](https://github.com/openclaw/openclaw/pull/140993). Thanks @ooiuuii.
+- Include the lockfile required by the final Docker runtime image [#134047](https://github.com/openclaw/openclaw/pull/134047). Thanks @RomneyDa.
+- Stage bundled plugin dependencies and reject incomplete Docker image assembly [#139117](https://github.com/openclaw/openclaw/pull/139117). Thanks @ylcn91, @vincentkoc and @8bitsforge.
+- Preserve saved Windows Startup environment overrides [#122658](https://github.com/openclaw/openclaw/pull/122658). Thanks @masatohoshino.
+
+</details>
+</Accordion>
+
+<Accordion title="Source installation and workspace templates">
+
+Source-install tooling moves to pnpm 12.3.4, and workspace template instructions clarify bootstrap, backup coverage and identity fields.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Limits and compatibility**
+
+- Require the supported Node runtime to avoid SQLite text truncation; older macOS CLI/Gateway hosts and official Linux ARMv7 provisioning need a supported host [#140672](https://github.com/openclaw/openclaw/pull/140672).
+
+**Documentation**
+
+- Update source-install tooling to pnpm 12.3.4 [#139065](https://github.com/openclaw/openclaw/pull/139065).
+- Correct workspace template, backup and identity instructions [#140224](https://github.com/openclaw/openclaw/pull/140224). Thanks @vincentkoc.
+
+</details>
+</Accordion>
+</AccordionGroup>
+
+## The New Web UI
+
+The web app makes current work easier to find and long conversations easier to move through, while keeping drafts and loaded panels in place through more interruptions. Sharing also gets a separate, explicit public-transcript option for conversations you want other people to read.
+
+<AccordionGroup>
+<Accordion title="Share a read-only conversation">
+
+Session owners and Gateway admins can publish a revocable link to a conversation's existing and future text. Anyone with that public link can read it until access is revoked, so review the conversation before enabling sharing. Revoking access cannot recall copies that people have already saved. The read-only page leaves out tools, reasoning, files, images and executable widgets.
+
+Private-session preview links remain a separate option. They show a generic OpenClaw social card without reading the conversation, and opening the session still requires its normal authentication.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Publish and revoke public read-only conversation transcripts [#139489](https://github.com/openclaw/openclaw/pull/139489).
+- Copy private-session links with generic social previews [#139250](https://github.com/openclaw/openclaw/pull/139250).
+
+</details>
+</Accordion>
+
+<Accordion title="Find active work and navigate long conversations">
+
+Live activity shows permitted running and queued sessions when you open it or reconnect, with a visible limit notice and connection status. In wide chat panes, a position rail previews and jumps between loaded conversation landmarks, making earlier exchanges easier to find.
+
+Pins now belong to root conversations. Existing child pins disappear and no longer protect those children from maintenance. Sidebar running indicators move onto row icons, leaving pin and menu controls clear, and notifications lead to the relevant question, conversation or run.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Show running and queued permitted sessions above the Live activity feed [#141045](https://github.com/openclaw/openclaw/pull/141045). Thanks @shakkernerd.
+- Add a previewable position rail for loaded conversation landmarks in sufficiently large panes [#138603](https://github.com/openclaw/openclaw/pull/138603).
+- Show recent open-tab activity in the Live feed [#140711](https://github.com/openclaw/openclaw/pull/140711).
+
+**Bug fixes**
+
+- Keep sidebar loading attached to the selected agent during activity [#140459](https://github.com/openclaw/openclaw/pull/140459).
+- Let cleared conversations raise fresh attention notices [#139888](https://github.com/openclaw/openclaw/pull/139888).
+- Place running indicators on row icons without duplicate screen-reader announcements [#141098](https://github.com/openclaw/openclaw/pull/141098).
+- Route notifications to the intended work and include later-page automation failures [#141081](https://github.com/openclaw/openclaw/pull/141081).
+
+**Limits and compatibility**
+
+- Restrict pins to root sessions [#140748](https://github.com/openclaw/openclaw/pull/140748).
+- Live activity lists up to 100 permitted current sessions; its recent event feed is temporary and does not replay historical tool events.
+
+</details>
+</Accordion>
+
+<Accordion title="Follow delegated work and keep your draft">
+
+Subagent transcripts stay view-only, with a route back to the parent conversation and Stop for runs that can be cancelled. Live progress remains in the parent conversation, while persistent sessions created with visible spawning stay editable and steerable in their parent tree.
+
+Failed steer or redirect attempts restore their text and attachments without overwriting a newer draft. Side chat also clears when its parent is deleted, so recreating a conversation does not bring back the old side discussion.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep delegated progress in the parent conversation and distinguish subagent authorship [#139367](https://github.com/openclaw/openclaw/pull/139367), [#139371](https://github.com/openclaw/openclaw/pull/139371).
+- Make subagent transcripts view-only with parent navigation and supported Stop controls [#139381](https://github.com/openclaw/openclaw/pull/139381).
+- Preserve editable persistent sessions created with visible spawning [#139456](https://github.com/openclaw/openclaw/pull/139456).
+- Restore failed steer and redirect drafts without replacing newer input [#139940](https://github.com/openclaw/openclaw/pull/139940).
+- Clear Side chat when its parent disappears [#139974](https://github.com/openclaw/openclaw/pull/139974).
+- Scope waiting time to the current turn [#139972](https://github.com/openclaw/openclaw/pull/139972).
+- Hide Reply when the conversation has no composer [#140014](https://github.com/openclaw/openclaw/pull/140014).
+- Preserve supplied, redacted failure reasons through immediate status and later refresh [#140704](https://github.com/openclaw/openclaw/pull/140704).
+
+</details>
+</Accordion>
+
+<Accordion title="Reconnect without losing your place">
+
+Panels retain their loaded data during connection interruptions and refresh when the connection returns, with offline and restart status in the footer. Suspended tabs can also recover missed update notices while keeping their route and stored draft; unsaved settings still need to be saved or discarded before recovery.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Recover suspended tabs after missed updates while preserving routes and stored drafts [#140484](https://github.com/openclaw/openclaw/pull/140484).
+- Keep panel data during interruptions and refresh parked panels after reconnection [#141040](https://github.com/openclaw/openclaw/pull/141040).
+- Restore Home subscriptions after the same panel reconnects [#139059](https://github.com/openclaw/openclaw/pull/139059).
+- Keep cancelled session-placement dialogs closed after delayed loading [#140746](https://github.com/openclaw/openclaw/pull/140746).
+
+**Limits and compatibility**
+
+- A browser document already stranded by an earlier missed update may need one manual reload.
+
+</details>
+</Accordion>
+
+<Accordion title="Open dashboards and use everyday controls">
+
+Dashboards get a themed loading presentation and avoid unnecessary conversation-history reads while opening. Keyboard shortcuts bring supported side panels into reach, local conversation links can show titles and hover cards, and model-picker searches remain filtered when the catalog refreshes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Open supported side panels with keyboard shortcuts [#139385](https://github.com/openclaw/openclaw/pull/139385).
+- Show titles and hover cards for resolvable local conversation links [#139384](https://github.com/openclaw/openclaw/pull/139384).
+
+**Bug fixes**
+
+- Avoid unrelated history reads while opening dashboards [#139055](https://github.com/openclaw/openclaw/pull/139055).
+- Keep dashboard loading and widget presentation consistent with the theme [#139076](https://github.com/openclaw/openclaw/pull/139076).
+- Preserve model-picker search and keyboard selection through catalog refresh [#140846](https://github.com/openclaw/openclaw/pull/140846).
+- Keep reopened select menus visible and close disabled menus [#141047](https://github.com/openclaw/openclaw/pull/141047).
+- Show saved unavailable execution-device bindings instead of implying fallback [#133032](https://github.com/openclaw/openclaw/pull/133032). Thanks @TurboTheTurtle.
+- Explain empty-repository requirements and retain specific workspace setup errors [#140251](https://github.com/openclaw/openclaw/pull/140251).
+
+**Documentation**
+
+- Restore old Control UI documentation anchors [#140808](https://github.com/openclaw/openclaw/pull/140808). Thanks @vincentkoc.
+
+</details>
+</Accordion>
+</AccordionGroup>
+
+## Updates and Maintenance
+
+Supported updates now rehearse core and plugin changes before activating them, then check the installation that actually started. Recovery also keeps a clearer distinction between a working restored installation and an update that failed, so the result tells you what happened and what still needs attention.
+
+<AccordionGroup>
+<Accordion title="Rehearse an update before activation">
+
+OpenClaw validates supported core and plugin updates in isolated candidate state before switching the running installation. Enabled npm plugin targets are checked before downtime, and candidate copies can be tested without taking ownership away from the serving Gateway.
+
+Eligible candidate-validation failures can enter a bounded repair using your configured model in disposable rehearsal state. The candidate must pass independent validation before activation, and changes that require editing your configuration are reported for you to resolve.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Rehearse core and plugin updates in isolated candidate state [#138839](https://github.com/openclaw/openclaw/pull/138839), [#141175](https://github.com/openclaw/openclaw/pull/141175).
+- Attempt bounded candidate repair with configured inference and retain failure or rollback outcomes [#139495](https://github.com/openclaw/openclaw/pull/139495).
+
+**Bug fixes**
+
+- Clear serving-process leases only inside the private rehearsal copy [#140004](https://github.com/openclaw/openclaw/pull/140004).
+- Check enabled npm plugin targets before stopping the serving installation [#140778](https://github.com/openclaw/openclaw/pull/140778).
+- Check the selected plugin payload after switching to a bundled development copy [#121603](https://github.com/openclaw/openclaw/pull/121603). Thanks @vincentkoc.
+
+</details>
+</Accordion>
+
+<Accordion title="Verify and recover the activated installation">
+
+Final update verification checks service ownership, health, the running version and build, plugin activation, channel readiness and HTTP readiness without making a model call. A failed check follows the supported repair or rollback path, while a healthy restored service is reported as recovery rather than a successful update.
+
+Eligible failed updates and recorded startup failures can also start an installation-owned repair with existing authentication and permissions. Only one repair runs per installation, and cancellation and admission limits remain in effect. Abandoned update records can be recovered without stopping a healthy matching Gateway when no post-update work remains.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add installation-owned recovery for eligible update and startup failures [#135868](https://github.com/openclaw/openclaw/pull/135868).
+- Recover abandoned update records while preserving healthy matching services and live-driver protection [#141562](https://github.com/openclaw/openclaw/pull/141562).
+
+**Bug fixes**
+
+- Verify service and Gateway health without inference, superseding the earlier model-turn requirement [#140725](https://github.com/openclaw/openclaw/pull/140725), [#140274](https://github.com/openclaw/openclaw/pull/140274). Thanks @fuller-stack-dev and @obviyus.
+- Report successful macOS service restoration after a failed update [#139393](https://github.com/openclaw/openclaw/pull/139393).
+- Report failed post-repair verification instead of claiming a successful start [#139145](https://github.com/openclaw/openclaw/pull/139145). Thanks @SebTardif.
+- Preserve the owned service profile when switching package installs to Git [#140263](https://github.com/openclaw/openclaw/pull/140263). Thanks @fuller-stack-dev.
+- Retain successful update notices when local state writes fail within the current process [#141084](https://github.com/openclaw/openclaw/pull/141084). Thanks @vincentkoc.
+
+</details>
+</Accordion>
+
+<Accordion title="Let Linux child work finish during shutdown">
+
+New and reinstalled systemd service units let child work drain while the Gateway shuts down. Existing service definitions are preserved during ordinary updates, so run `openclaw gateway install --force` for the selected profile to receive the changed service configuration. Operator-supplied systemd overrides remain separately editable. See [restart recovery](/gateway/restart-recovery).
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Use systemd mixed kill mode to preserve child work during Gateway drain and audit effective overrides [#140568](https://github.com/openclaw/openclaw/pull/140568). Thanks @DonnieFi and @agentzerodao.
+
+</details>
+</Accordion>
+
+<Accordion title="Update an existing 2026.9.2 installation">
+
+Eligible updates driven by 2026.9.2 can now cross a shared-state schema change while the older updater finishes reading its update history. Agent-schema migrations, missing state metadata and failed state migrations still require the documented external-install and fresh-Doctor recovery path. See [schema-bump recovery](/reference/database-schemas#schema-bumps-and-older-updaters) if your update is refused.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Limits and compatibility**
+
+- Support eligible 2026.9.2 shared-state-only upgrades while deferring schema-version publication [#141109](https://github.com/openclaw/openclaw/pull/141109).
+- Retain refusal and recovery guidance for unsupported older-updater schema changes, with eligible shared-state upgrades handled by the later change above [#140784](https://github.com/openclaw/openclaw/pull/140784).
+
+</details>
+</Accordion>
+
+<Accordion title="Preserve the configuration you wrote">
+
+Configuration edits and Doctor repairs keep authored settings, explicit defaults and supported include-file ownership intact. An eligible nested change is written into the fragment that owns it, while unsafe shared-file or mixed-array changes remain refused rather than being flattened into a different configuration.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Route eligible edits to their nested configuration include [#116108](https://github.com/openclaw/openclaw/pull/116108). Thanks @sasan1200.
+- Preserve authored settings and root-owned arrays through includes and agent migration [#139949](https://github.com/openclaw/openclaw/pull/139949).
+- Retain explicit defaults and valid null values through supported configuration writes; `config.patch` still uses null for deletion [#140579](https://github.com/openclaw/openclaw/pull/140579).
+- Keep unrelated plugin defaults out of repairs [#139376](https://github.com/openclaw/openclaw/pull/139376).
+- Report a failed rejected-payload backup without claiming a saved file [#134198](https://github.com/openclaw/openclaw/pull/134198). Thanks @SebTardif.
+
+</details>
+</Accordion>
+
+<Accordion title="Run Doctor, backups and source maintenance">
+
+Doctor moves initial integrity checks off the main event loop and gives more useful recovery guidance when state cannot be read or safely migrated. Large Git backups and restores use bounded batches, reducing the need to hold complete database tables in memory while keeping their verification checks.
+
+Source installations also build browser assets from the checked-out source and can run maintenance from another working directory. Normal source-server updates build the runtime, plugins and UI without regenerating developer declarations unless requested.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Stream Git backup creation, restore and verification in bounded batches [#134213](https://github.com/openclaw/openclaw/pull/134213). Thanks @xydt-juyaohui.
+
+**Bug fixes**
+
+- Run initial maintenance integrity checks off the main event loop [#139918](https://github.com/openclaw/openclaw/pull/139918).
+- Migrate supported legacy setup earlier and show sanitized channel-start failures [#139395](https://github.com/openclaw/openclaw/pull/139395).
+- Avoid cleanup approval timeouts during periodic SQLite space reclamation [#141006](https://github.com/openclaw/openclaw/pull/141006).
+- Build source browser assets without generated-manifest changes disrupting updates [#139075](https://github.com/openclaw/openclaw/pull/139075). Thanks @ylcn91.
+- Use runtime-only source-server builds by default [#139392](https://github.com/openclaw/openclaw/pull/139392). Thanks @jason-allen-oneal.
+- Resolve the source-mode worker loader from OpenClaw when invoked elsewhere [#140458](https://github.com/openclaw/openclaw/pull/140458). Thanks @gaoanze888 and @mbundy.
+- Identify unreadable state databases and point to verified-backup recovery; `config.patch` also reports changed setting paths without their values [1391f7c](https://github.com/openclaw/openclaw/commit/1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7).
+
+**Documentation**
+
+- Give manual recovery steps for unsupported workspace state and preserved execution policy [#140854](https://github.com/openclaw/openclaw/pull/140854).
+- Explain offline limits for discovery-only context engines [#140818](https://github.com/openclaw/openclaw/pull/140818). Thanks @Marvinthebored.
+- Correct device approval, secret-plan and multi-Gateway port-spacing guidance [#140472](https://github.com/openclaw/openclaw/pull/140472). Thanks @vincentkoc.
+
+</details>
+</Accordion>
+</AccordionGroup>
+
+## Messaging
+
+Saved meetings are easier to find and return to, with transcript search and complete exports alongside the existing capture workflow. Messaging fixes also carry through channel-specific formatting, reply routing and recovery, including Telegram albums and more deliberate Discord bot handoffs.
+
+<AccordionGroup>
+<Accordion title="Browse saved meetings and search transcripts">
+
+The meeting library lets you browse saved notes, search full transcripts and manage capture sources in Communications settings. Exports include the complete selected meeting even when a search filter is active, with Markdown and JSONL available under the existing archive permissions.
+
+The download limit remains 4 MiB. Larger exports fail without producing a partial file and need the documented CLI export path on the host.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Browse paginated saved meetings and search transcript archives [#139875](https://github.com/openclaw/openclaw/pull/139875).
+- Export complete selected meetings and edit capture sources in Communications settings [#140084](https://github.com/openclaw/openclaw/pull/140084).
+
+</details>
+</Accordion>
+
+<Accordion title="Stop and resume meeting capture">
+
+Meeting capture keeps its history and ownership through more interrupted starts and cleanup failures. Duplicate auto-start attempts settle as conflicts instead of creating another recording, and stopping a meeting requests cancellation of active consults and ignores late speech.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Settle duplicate recording auto-start retries without restarting capture under a consumed ID [#140202](https://github.com/openclaw/openclaw/pull/140202).
+- Clear stale occupancy retry diagnostics after startup settles [#140220](https://github.com/openclaw/openclaw/pull/140220).
+- Retire completed capture-verification scratch state [#140750](https://github.com/openclaw/openclaw/pull/140750).
+- Request consult cancellation and ignore late speech after Stop [#140801](https://github.com/openclaw/openclaw/pull/140801).
+- Preserve supplied-ID and legacy capture history across occupancy restarts [#140563](https://github.com/openclaw/openclaw/pull/140563).
+- Keep Discord recording independent of voice conversations and preserve capture ownership after cleanup failures [#139572](https://github.com/openclaw/openclaw/pull/139572), [#139658](https://github.com/openclaw/openclaw/pull/139658).
+
+</details>
+</Accordion>
+
+<Accordion title="Send Telegram albums and follow progress">
+
+Consecutive eligible photos can be sent as native Telegram albums of up to ten, keeping their order, captions, reply targets and forum topics. Single photos and messages with controls continue to send individually. Concurrent forum topics also retain independent typing indicators, while enabled answer previews can show compaction status.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Group consecutive eligible Telegram photos into native albums [#141398](https://github.com/openclaw/openclaw/pull/141398).
+
+**Bug fixes**
+
+- Keep typing independent across concurrent forum topics [#139292](https://github.com/openclaw/openclaw/pull/139292).
+- Show compaction status in enabled answer previews [#141551](https://github.com/openclaw/openclaw/pull/141551).
+- Keep whitespace-split internal reasoning prefixes out of streamed messages [#126219](https://github.com/openclaw/openclaw/pull/126219). Thanks @vincentkoc and @wangyan2026.
+
+</details>
+</Accordion>
+
+<Accordion title="Control Discord bot replies and formatting">
+
+Bots in mention-only mode now need an active native or configured mention to reply. A handoff that relied only on Discord's reply ping needs an explicit mention. Policy-only Discord changes apply to new messages and interactions without waiting for an active Control UI turn to finish. Transport changes and mixed edits remain deferred, and work already admitted keeps its original context.
+
+Message formatting also preserves leading indentation, so pasted code and structured text keep their shape.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Apply Discord policy-only configuration changes live to new messages and interactions [#140929](https://github.com/openclaw/openclaw/pull/140929).
+- Require an active mention for Discord bot replies in mention-only mode [#111822](https://github.com/openclaw/openclaw/pull/111822). Thanks @ooiuuii and @obviyus.
+- Preserve leading indentation in Discord and inter-session messages [#139390](https://github.com/openclaw/openclaw/pull/139390).
+- Skip unnecessary underscore parsing during Discord formatting [#140186](https://github.com/openclaw/openclaw/pull/140186).
+- Keep Discord voice input until transcription finishes [#139484](https://github.com/openclaw/openclaw/pull/139484).
+
+</details>
+</Accordion>
+
+<Accordion title="Keep Slack replies and shared uploads intact">
+
+Slack delivers valid structured sections intact even when their accessibility text exceeds the preferred chunk size. Formatting also retains the surrounding Markdown when tables are converted, while shared Slack and Teams uploads avoid an unnecessary copy of the file data.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve valid multi-field Slack sections within the existing hard limits [#140805](https://github.com/openclaw/openclaw/pull/140805).
+- Preserve Markdown literals around converted tables [#139892](https://github.com/openclaw/openclaw/pull/139892).
+- Reduce repeated native-table preparation [#140167](https://github.com/openclaw/openclaw/pull/140167).
+- Prepare structured Slack reply content once per delivery attempt [#140837](https://github.com/openclaw/openclaw/pull/140837).
+- Avoid one file-data copy in shared Slack and Teams uploads [#140787](https://github.com/openclaw/openclaw/pull/140787).
+- Preserve Teams progress replies through stream settlement and fallback [#141199](https://github.com/openclaw/openclaw/pull/141199).
+
+**Documentation**
+
+- Organize Slack setup, messaging and troubleshooting guidance while retaining existing deep links [#141061](https://github.com/openclaw/openclaw/pull/141061). Thanks @vincentkoc.
+
+</details>
+</Accordion>
+
+<Accordion title="Preserve Feishu mentions and group routing">
+
+Feishu uses accepted group-binding changes on the next message and keeps mention names readable when messages are combined.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve Feishu mention names through overlapping placeholders and combined messages [#96311](https://github.com/openclaw/openclaw/pull/96311). Thanks @sliverp.
+- Apply reloaded Feishu group bindings to new messages [#133775](https://github.com/openclaw/openclaw/pull/133775). Thanks @zxdvd and @vincentkoc.
+</details>
+</Accordion>
+
+<Accordion title="Read Matrix room information and maintain accounts">
+
+Matrix leaves archived state out of active-account selection and Doctor scans, while room information includes alternative aliases and supported disclosed polls are recognized correctly.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Leave archived Matrix state out of scans and active token selection [#112329](https://github.com/openclaw/openclaw/pull/112329). Thanks @shad0wca7.
+- Normalize Matrix poll namespaces and recognize disclosed results [#140967](https://github.com/openclaw/openclaw/pull/140967).
+- Include alternative Matrix room aliases [#140969](https://github.com/openclaw/openclaw/pull/140969).
+
+</details>
+</Accordion>
+
+<Accordion title="Recover channel delivery and iMessage failures">
+
+Pending or ambiguous queued deliveries remain with the recovery path instead of automatically sending another copy. iMessage helper failures also settle when their pipes close with an error, and progress visibility respects the selected settings while retaining required transport behavior such as typing indicators.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Leave pending or ambiguous delivery with its recovery owner [#139388](https://github.com/openclaw/openclaw/pull/139388).
+- Settle iMessage failures after errored helper pipes close [#140221](https://github.com/openclaw/openclaw/pull/140221).
+- Skip unnecessary inline-code formatting in iMessage replies [#139912](https://github.com/openclaw/openclaw/pull/139912).
+- Honor fast-auto progress visibility across direct and queued replies [#122221](https://github.com/openclaw/openclaw/pull/122221). Thanks @vincentkoc and @joeykrug.
+- Accept the documented IRC health-monitor switch at channel and account scope [#117302](https://github.com/openclaw/openclaw/pull/117302). Thanks @ayaangazali and @vincentkoc.
+
+**Documentation**
+
+- Explain existing unmatched-agent routing without introducing an arbitrary first-agent fallback [#140194](https://github.com/openclaw/openclaw/pull/140194).
+
+</details>
+</Accordion>
+</AccordionGroup>
+
+## Memory
+
+Memory search keeps useful notes available through more backend failures and long-running conversations, while exact filenames, older notes and readable excerpts are easier to recover. Native vector searches also spend less work starting up, with the improvement scoped to that search path.
+
+<AccordionGroup>
+<Accordion title="Find notes when semantic search is unavailable">
+
+Keyword indexing can continue when optional embedding credentials or providers are unavailable, so a missing optional model does not make all of your notes disappear from search. When SQLite extensions cannot load, a batched fallback scan can still return vector-backed results, although that degraded path can be costly on larger collections.
+
+Exact filenames retain their ranking in project-aware searches, and older dated notes remain eligible for keyword recall. The native vector-search path also reduces startup overhead without changing its results.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep keyword indexing available without optional embeddings [#139463](https://github.com/openclaw/openclaw/pull/139463).
+- Use the fallback memory scan when SQLite extensions cannot load [#141104](https://github.com/openclaw/openclaw/pull/141104).
+- Preserve exact-filename ranking in project searches [#139879](https://github.com/openclaw/openclaw/pull/139879).
+- Retain keyword recall for older notes in project sessions [#140104](https://github.com/openclaw/openclaw/pull/140104).
+- Restore existing recency weighting, including short CJK queries [#139112](https://github.com/openclaw/openclaw/pull/139112).
+
+**Improvements**
+
+- Reduce native vector-search startup overhead, measured with a Linux fixture [#140730](https://github.com/openclaw/openclaw/pull/140730). Thanks @NianJiuZst and @obviyus.
+
+**Limits and compatibility**
+
+- Explicitly required embedding providers still report failures; keyword fallback does not supply semantic vectors. Node remains recommended for native sqlite-vec on macOS.
+
+</details>
+</Accordion>
+
+<Accordion title="Keep long conversations from reimporting old memories">
+
+Appending to a long conversation now resumes memory ingestion from a validated transcript prefix, avoiding repeated imports caused by the old seen-message window rolling over. Existing memory history stays intact, while edits and truncations still take the conservative rescan path.
+
+Promotion previews also remove blocked-origin entries before ranking, leaving the limited preview space for eligible notes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Resume append-only transcript ingestion without replaying consumed messages [#119367](https://github.com/openclaw/openclaw/pull/119367). Thanks @jalehman and @guarismo.
+- Exclude untrusted and system-origin recall entries before ranking promotion previews [#121287](https://github.com/openclaw/openclaw/pull/121287). Thanks @hydraxman and @bryan.
+
+</details>
+</Accordion>
+
+<Accordion title="Read memory results and diagnose failed imports">
+
+Memory and Import Memory now show agent-list errors with a usable retry instead of remaining in a loading cycle. Reads from additional memory folders report relevant permission or file errors, and cited excerpts keep the leading spaces and tabs that make code and structured notes readable.
+
+For scripts, memory commands distinguish a disabled backend, a backend that failed to open, and a successful search with no results.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Show agent-list failures on Memory and Import Memory pages [#139899](https://github.com/openclaw/openclaw/pull/139899).
+- Report relevant permission and I/O errors in extra-memory roots without exposing unrelated errors to unauthorized readers [#139402](https://github.com/openclaw/openclaw/pull/139402). Thanks @SebTardif and @obviyus.
+- Preserve indentation in cited memory excerpts [#140471](https://github.com/openclaw/openclaw/pull/140471).
+- Return explicit JSON for disabled or unavailable memory backends [#140229](https://github.com/openclaw/openclaw/pull/140229).
+
+**Documentation**
+
+- Explain recovery from unsafe legacy memory-event paths and distinguish shared-note indexing from event import [#139195](https://github.com/openclaw/openclaw/pull/139195).
+
+</details>
+</Accordion>
+</AccordionGroup>
+
+## Skills
+
+Skill Workshop now gives each agent one persistent collection across its workspaces, with full instruction comparisons for suggestions and clearer recovery when an old suggestion can no longer be applied.
+
+<AccordionGroup>
+
+<Accordion title="Keep learned skills with the agent">
+
+A skill your agent learns now belongs to that agent’s [Workshop](/tools/skill-workshop), so moving between workspaces no longer means moving the collection along with it. Installed skills and suggestions have separate views, keeping what the agent can already use distinct from changes awaiting review.
+
+Startup and Doctor migrate legacy skills when ownership is established. Ambiguous or conflicting copies remain available for review, and the old `skills.workshop.allowSymlinkTargetWrites` option is retired.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Give every agent its own Skill Workshop and migrate safely owned legacy skills through Doctor. [#135528](https://github.com/openclaw/openclaw/pull/135528) Thanks @obviyus.
+- Simplify Workshop to Skills and Suggestions and show installed-skill differences. [#140105](https://github.com/openclaw/openclaw/pull/140105) Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read and review complete skill instructions">
+
+Workshop comparisons now show the complete instructions with additions and removals inline, including changes near the end of a long skill. Current instructions remain readable while the comparison loads; the comparison covers the instruction body rather than frontmatter or supporting files.
+
+Collection reviews are also instructed to look across related skills while preserving useful task boundaries. Compatible CLI backends, including Claude CLI, can perform these reviews within the permitted root using the existing sandbox and approval settings.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Review Skill Workshop collections for duplicated procedures and clear task boundaries. [#140195](https://github.com/openclaw/openclaw/pull/140195) Thanks @obviyus.
+- Allow rooted Skill Workshop reviews through supported CLI backends, including Claude CLI. [#140822](https://github.com/openclaw/openclaw/pull/140822) Thanks @tragicwinds.
+
+**Bug fixes**
+
+- Compare complete skill instructions with inline additions and removals. [#140300](https://github.com/openclaw/openclaw/pull/140300) Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recover interrupted Workshop changes">
+
+Doctor now explains what to do when a suggestion’s draft is missing and distinguishes recoverable work from preserved backups that need your review. Installed skills and remaining recovery files stay intact, and an unfinished apply must be recovered before its suggestion can be dismissed.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Handle missing Skill Workshop drafts with guarded dismissal and Doctor recovery guidance. [#141009](https://github.com/openclaw/openclaw/pull/141009) Thanks @obviyus.
+- Keep Workshop relocation inspection read-only and reserve destination verification for migration. [#139193](https://github.com/openclaw/openclaw/pull/139193)
+
+**Limits and compatibility**
+
+- Explain why preserved Skill Workshop backups need manual review. [#141048](https://github.com/openclaw/openclaw/pull/141048)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Create skills and use skill commands">
+
+Skill-library creation and import forms check names before continuing and explain the existing naming rules. For scripts, skill JSON keeps meaningful whitespace in descriptions and paths while continuing to remove terminal control sequences.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Sanitize skills JSON during serialization while preserving output bytes. [#140581](https://github.com/openclaw/openclaw/pull/140581)
+- Detach cached local skill metadata from full source strings. [#139478](https://github.com/openclaw/openclaw/pull/139478)
+- Share concurrent node-host skill-bin refreshes within the same Gateway connection. [#127113](https://github.com/openclaw/openclaw/pull/127113)
+
+**Bug fixes**
+
+- Enforce existing skill-name rules in library editor and import forms. [#139184](https://github.com/openclaw/openclaw/pull/139184)
+- Preserve whitespace in skills list, info and check JSON output. [#140780](https://github.com/openclaw/openclaw/pull/140780)
+- Skip retry delays for confirmed-absent ClawHub workspace tracking. [#140958](https://github.com/openclaw/openclaw/pull/140958)
+
+**Documentation**
+
+- Replace removed Peekaboo commands in the bundled skill with current commands and installed help. [#124061](https://github.com/openclaw/openclaw/pull/124061) Thanks @clawSean.
+- Clarify OpenProse migration and replace private paths in documentation examples. [#140227](https://github.com/openclaw/openclaw/pull/140227) Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Choose how Workshop learns">
+
+[Automatic learning](/tools/self-learning) can maintain complete Workshop packages with normal file tools while foreground work continues. In auto mode those are direct edits without an automatic rollback copy, and completed writes remain if the background run later fails or is cancelled. Choose propose mode when you want to review each capture before it changes a skill.
+
+Pending Workshop approval requests also regain their Allow Once and Deny controls in the authorized Telegram DM, including requests that began in a group.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Let automatic background learning maintain complete Workshop skills with normal file tools. [#140315](https://github.com/openclaw/openclaw/pull/140315) Thanks @obviyus.
+
+**Bug fixes**
+
+- Restore pending Workshop approval buttons by signing requests with the Workspace Skills owner. [#139248](https://github.com/openclaw/openclaw/pull/139248) Thanks @gaoanze888, @khaisis, @stemkat100.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Native Apps
+
+Android makes better use of folding screens and small windows, while Apple apps improve conversation history, connection controls, and the path into a live voice conversation.
+
+<AccordionGroup>
+
+<Accordion title="Use Android across folds and small windows">
+
+Android keeps content clear of separating hinges, and on suitable book folds it keeps navigation beside the content. In tabletop posture, the conversation sits above the fold and the composer below it, with the layout falling back when the available panes are too small.
+
+When the keyboard leaves little height, chat extras move into Details so your draft and Send controls remain accessible. Larger text can wrap in more settings and quick actions, and approval details gain clearer contrast. Chat and attachment menus, plus Model and Permissions sheets, also stay within usable fold-safe regions.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Use both safe panes for Android navigation and content on book folds. [#140710](https://github.com/openclaw/openclaw/pull/140710) Thanks @vincentkoc.
+- Use separate conversation and composer panes for Android tabletop posture. [#140802](https://github.com/openclaw/openclaw/pull/140802) Thanks @vincentkoc.
+- Move Android chat extras into Details when the keyboard leaves little height. [#140726](https://github.com/openclaw/openclaw/pull/140726) Thanks @vincentkoc.
+
+**Bug fixes**
+
+- Let Android voice, security and Gateway controls wrap at large text sizes. [#140182](https://github.com/openclaw/openclaw/pull/140182)
+- Wrap Android search quick-action text and fit both initials in the header mark. [#140540](https://github.com/openclaw/openclaw/pull/140540)
+- Improve contrast for Android automation help and approval details. [#139931](https://github.com/openclaw/openclaw/pull/139931)
+- Wrap Android settings metrics and make Instance ID copyable with one tap. [#140477](https://github.com/openclaw/openclaw/pull/140477)
+- Keep Android onboarding, chat and navigation clear of separating hinges. [#140614](https://github.com/openclaw/openclaw/pull/140614) Thanks @vincentkoc.
+- Keep Android Chat actions and attachment menus clear of fold hinges. [#140884](https://github.com/openclaw/openclaw/pull/140884) Thanks @vincentkoc.
+- Constrain Android model picker sheets and invalidate stale openings after layout changes. [#140896](https://github.com/openclaw/openclaw/pull/140896) Thanks @vincentkoc.
+- Keep Gateway trust, QR errors, Replace and Forget prompts within a hinge-free region with scrolling actions. [#140694](https://github.com/openclaw/openclaw/pull/140694) Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep Android conversations and settings current">
+
+Android keeps completed runs settled when delayed history or send acknowledgements arrive, and overlapping history requests no longer leave the chat’s health refresh unfinished. Resolved approval cards disappear together with their outcome, while a failed file share leaves the preview open so you can retry.
+
+Settings search finds existing options by name or category, and model settings follow the selected agent’s credentials and accepted configuration changes. Failed model refreshes show a warning while preserving choices and drafts, with another attempt available through Refresh chat.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Make existing Android settings discoverable through search while preserving Back navigation. [#139035](https://github.com/openclaw/openclaw/pull/139035)
+
+**Bug fixes**
+
+- Keep completed Android runs settled when delayed history and send acknowledgements arrive. [#140523](https://github.com/openclaw/openclaw/pull/140523)
+- Finish Android chat health refresh after overlapping history requests. [#139430](https://github.com/openclaw/openclaw/pull/139430)
+- Retire resolved Android approval cards together with their outcome. [#140111](https://github.com/openclaw/openclaw/pull/140111)
+- Keep Android workspace previews available when export preparation or the share sheet fails. [#139141](https://github.com/openclaw/openclaw/pull/139141)
+- Show Android model credentials and status for the selected agent. [#140130](https://github.com/openclaw/openclaw/pull/140130) Thanks @obviyus.
+- Refresh Android Providers and Models after Gateway configuration events. [#140796](https://github.com/openclaw/openclaw/pull/140796) Thanks @obviyus.
+- Show Android model refresh failures and retry them with Refresh chat. [#140899](https://github.com/openclaw/openclaw/pull/140899) Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Start an iPhone voice conversation from Shortcuts">
+
+The Start Live Voice action opens the current chat and starts Talk from Siri or Shortcuts. Your phone still needs to be unlocked and the app in the foreground, with pairing, provider setup and microphone permission completed.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add an iOS Start Live Voice action for Siri and Shortcuts. [#141003](https://github.com/openclaw/openclaw/pull/141003)
+
+**Bug fixes**
+
+- Expose the intended Start Live Voice description to Apple’s shortcut metadata consumers. [#141152](https://github.com/openclaw/openclaw/pull/141152) Thanks @shakkernerd.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep Apple conversation history in order">
+
+New local messages retain their identity and place in the conversation when history refreshes, even when device clocks differ. Delayed history also keeps completed runs settled so the composer remains available.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve native Apple message identity and order across history refreshes. [#140257](https://github.com/openclaw/openclaw/pull/140257)
+- Keep completed native chat runs settled when older history arrives. [#140379](https://github.com/openclaw/openclaw/pull/140379)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Manage Mac connections and daily costs">
+
+The Mac Connection window uses native Settings controls and toolbar tabs, and Gateway alerts can appear without blocking app shutdown. Today’s cost totals follow the Mac’s local calendar day, including daylight-saving changes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Rebuild the Mac Connection window with native Settings controls and toolbar tabs. [#140756](https://github.com/openclaw/openclaw/pull/140756)
+
+**Bug fixes**
+
+- Replace blocking Gateway alert loops with dashboard sheets or non-modal panels. [#140575](https://github.com/openclaw/openclaw/pull/140575)
+- Align Mac menu cost totals with local time zones and daylight-saving boundaries. [#140863](https://github.com/openclaw/openclaw/pull/140863)
+
+**Documentation**
+
+- Document macOS 15 as the native app minimum and separate voice and source-build requirements. [#140578](https://github.com/openclaw/openclaw/pull/140578)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Maintain paired devices and app packages">
+
+Persistent paired computers retain the current worker build between sessions, avoiding another installation when that build is already present. A new build still needs installation on first use. Android setup also saves replacement access before retiring setup credentials, so a newly supplied setup code keeps its intended meaning.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Retain the current worker build between sessions and maintain nodes independently. [#140449](https://github.com/openclaw/openclaw/pull/140449)
+- Refresh native locale resources and Android generated strings. [#140953](https://github.com/openclaw/openclaw/pull/140953)
+- Restore current native locale resources after the macOS settings migration. [#139406](https://github.com/openclaw/openclaw/pull/139406)
+- Refresh native app translations. [#139921](https://github.com/openclaw/openclaw/pull/139921)
+- Refresh generated native app translations. [#140267](https://github.com/openclaw/openclaw/pull/140267)
+- Refresh native app translations and generated Android string resources. [#140538](https://github.com/openclaw/openclaw/pull/140538)
+- Refresh generated native app translations. [#141089](https://github.com/openclaw/openclaw/pull/141089)
+- Refresh generated Android, Apple and Watch locale resources. [#139237](https://github.com/openclaw/openclaw/pull/139237)
+- Refresh generated native app translations. [#140874](https://github.com/openclaw/openclaw/pull/140874)
+
+**Bug fixes**
+
+- Honor new Android setup codes and save replacement access before retiring setup credentials. [#141013](https://github.com/openclaw/openclaw/pull/141013)
+- Use the installed WebSocket transport for node streams and honor cancellation during loading. [#140490](https://github.com/openclaw/openclaw/pull/140490)
+- Filter incompatible worker prebuilds from Apple silicon macOS app bundles. [#140557](https://github.com/openclaw/openclaw/pull/140557)
+- Preserve secondary framework architectures during universal macOS packaging. [#141056](https://github.com/openclaw/openclaw/pull/141056)
+- Restore the desktop tray's Stop Gateway action while retaining graceful shutdown and restart. [#139241](https://github.com/openclaw/openclaw/pull/139241)
+- Fix Swabble executable invocation and configuration/output path binding. [#140291](https://github.com/openclaw/openclaw/pull/140291)
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Models and Providers
+
+Models settings adds controls for individual connected accounts, while model selection, temporary failure recovery and prompt caching receive changes that keep ongoing work attached to the choices you made.
+
+<AccordionGroup>
+
+<Accordion title="Choose which connected account to use">
+
+Administrators can see each provider account’s credential source and health in Models settings, change supported account priority for the selected agent, and sign out of one account without disconnecting the others. Clearing a custom order removes the saved priority while leaving accounts connected; inherited and provider-managed orders explain their restrictions. When an explicitly selected account disappears, OpenClaw keeps that choice and offers recovery guidance instead of silently choosing another account.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Manage individual provider accounts, supported priority and targeted logout in Models settings. [#132451](https://github.com/openclaw/openclaw/pull/132451) Thanks @jesse-merhi.
+
+**Bug fixes**
+
+- Keep selected account metadata through authentication planning. [#139413](https://github.com/openclaw/openclaw/pull/139413)
+- MiniMax model discovery no longer borrows another account's credentials. [#140438](https://github.com/openclaw/openclaw/pull/140438) Thanks @shakkernerd.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Choose an ordered fallback chain">
+
+Agents settings now offers searchable model choices for building a fallback chain. Selected models appear as removable chips in priority order, and you can still add a custom model reference when it is not in the catalog.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Choose ordered fallback models from a searchable catalog, remove choices and add custom references. [#141330](https://github.com/openclaw/openclaw/pull/141330) Thanks @shakkernerd and @najef1979-code.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Continue through temporary provider failures">
+
+Temporary rate limits and other eligible provider failures can recover within the same run, keeping completed tool work and attachments available and the recovered answer together. Retry waits remain cancellable, and a terminal error stays visible when recovery is exhausted. Authentication failures, billing problems and refusals retain their own handling, while exhausted usage windows can move to an eligible fallback.
+
+CLI-backed background work also keeps its existing bounded allowance while work or native input remains pending, rather than being stopped as though nothing were happening.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Continue agent tasks after temporary rate limits with bounded, cancellable backoff. [#139397](https://github.com/openclaw/openclaw/pull/139397)
+- Keep rate-limit retries transient and recovered chat replies together. [#139465](https://github.com/openclaw/openclaw/pull/139465)
+- Respect the existing quiet-work allowance when CLI background tasks or native input remain pending. [#132459](https://github.com/openclaw/openclaw/pull/132459) Thanks @LiuwqGit, @obviyus.
+- Skip provider-catalog rewarming for ordinary rate-limit cooldowns. [#125906](https://github.com/openclaw/openclaw/pull/125906) Thanks @Grynn.
+- Report safe reasons for Codex history recovery rejection. [#139933](https://github.com/openclaw/openclaw/pull/139933) Thanks @be-student, @obviyus.
+- Retire stale metadata refresh work without losing failed-provider state. [#139192](https://github.com/openclaw/openclaw/pull/139192)
+- Retain settled failed Codex threads for guarded continuation and preserve policy-refusal classification. [#139246](https://github.com/openclaw/openclaw/pull/139246) Thanks @Colton-Harris, @obviyus.
+- Apply the model idle watchdog to silent WebSocket streams with parked consumers. [#140335](https://github.com/openclaw/openclaw/pull/140335) Thanks @VACInc.
+- Require a real reasoning constraint before retrying with a different thinking level. [#139295](https://github.com/openclaw/openclaw/pull/139295)
+- Preserve explicit account selections, request context and cleanup ownership during recovery. [#140973](https://github.com/openclaw/openclaw/pull/140973)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep model choices attached to the right agent">
+
+Ordinary model changes now apply to the current chat by default, including administrator selections, while explicitly configured agent or global scopes remain available.
+
+Local and CLI-backed model views now preserve the selected agent and canonical provider, and managed Codex conversations use a newly selected model on subsequent turns. Native-owned sessions retain their own selection rules. Missing environment-backed credentials are reported locally, so restore the environment value and reload secrets on a running Gateway before retrying. Catalog refreshes keep compatible previously discovered choices available when a refresh fails, without hiding that failure or treating missing credentials as usable access.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Honor model changes when resuming managed Codex sessions. [#140196](https://github.com/openclaw/openclaw/pull/140196) Thanks @obviyus, @josephbergvinson.
+- Scope local terminal model catalogs to the selected agent. [#139880](https://github.com/openclaw/openclaw/pull/139880) Thanks @obviyus.
+- Show and search the correct provider identity for CLI-backed sessions. [#139884](https://github.com/openclaw/openclaw/pull/139884) Thanks @obviyus.
+- Show the canonical provider after local terminal model changes. [#139990](https://github.com/openclaw/openclaw/pull/139990) Thanks @ly85206559.
+- Keep case-distinct configured models separate in catalogs and CLI output. [#139991](https://github.com/openclaw/openclaw/pull/139991) Thanks @obviyus.
+- Prevent case-distinct model status routes from mixing. [#140099](https://github.com/openclaw/openclaw/pull/140099) Thanks @ly85206559.
+- Keep compatible learned model choices after a failed provider refresh. [#139357](https://github.com/openclaw/openclaw/pull/139357) Thanks @obviyus.
+- Refresh agent model choices when the catalog changes. [#139916](https://github.com/openclaw/openclaw/pull/139916) Thanks @obviyus.
+- Stop OAuth fallback after catalog discovery times out. [#139924](https://github.com/openclaw/openclaw/pull/139924) Thanks @shakkernerd.
+- Retain compatible full-catalog models and report profile failures when OAuth preparation fails. [#139951](https://github.com/openclaw/openclaw/pull/139951) Thanks @shakkernerd.
+- Preserve plugin catalog results for later discovery after an earlier request times out. [#140441](https://github.com/openclaw/openclaw/pull/140441) Thanks @shakkernerd.
+- Keep provider options and stream hooks bound to the prepared provider for each attempt. [#139101](https://github.com/openclaw/openclaw/pull/139101)
+- Pass the selected provider and model to Codex prompt hooks when OpenClaw owns selection. [#140488](https://github.com/openclaw/openclaw/pull/140488)
+- Bind queued compaction to one admitted runtime configuration. [#139429](https://github.com/openclaw/openclaw/pull/139429)
+- Reduce cold Gateway stalls during model-runtime registration. [#139911](https://github.com/openclaw/openclaw/pull/139911)
+- Keep downloaded hosted catalogs inactive until a full Gateway restart. [#140086](https://github.com/openclaw/openclaw/pull/140086) Thanks @obviyus.
+- Skip paired-node discovery for local-only catalog pages. [#140090](https://github.com/openclaw/openclaw/pull/140090)
+- Keep model-status plugin metadata scoped to its own operation. [#140506](https://github.com/openclaw/openclaw/pull/140506)
+- Preserve unset model defaults when signing in to a provider without opting in to a new default. [#139218](https://github.com/openclaw/openclaw/pull/139218) Thanks @obviyus.
+- Default ordinary chat model selections to session scope, including administrator choices. [#139232](https://github.com/openclaw/openclaw/pull/139232) Thanks @obviyus.
+- Make the Google manifest own the bundled Gemini catalog used by Doctor and runtime fallback. [#139243](https://github.com/openclaw/openclaw/pull/139243) Thanks @LiuwqGit, @vincentkoc.
+- Keep xAI OAuth setup on the subscription catalog and resolve automatic selection at inference dispatch. [#140610](https://github.com/openclaw/openclaw/pull/140610) Thanks @DonnieFi.
+- Use low as Astra's ordinary thinking default across OpenClaw and Codex. [#140625](https://github.com/openclaw/openclaw/pull/140625)
+- Avoid duplicate xAI OAuth refresh attempts during model discovery. [#140434](https://github.com/openclaw/openclaw/pull/140434) Thanks @shakkernerd.
+- Clamp configured output tokens to the model's final context window. [#140436](https://github.com/openclaw/openclaw/pull/140436)
+- Keep Grok token model discovery on the subscription endpoint with the selected credential. [#140653](https://github.com/openclaw/openclaw/pull/140653) Thanks @shakkernerd.
+- Stop sending missing environment-variable names as catalog credentials and preserve selected-account identity. [#140657](https://github.com/openclaw/openclaw/pull/140657) Thanks @shakkernerd.
+
+**Limits and compatibility**
+
+- Prefer exact model matches in session SDK selection. [#139900](https://github.com/openclaw/openclaw/pull/139900)
+- Preserve exact model identities in SDK catalog lookups and leave ambiguous requests unresolved. [#139907](https://github.com/openclaw/openclaw/pull/139907) Thanks @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Keep prompt caches warm during ongoing work">
+
+Tool loops and changing background progress now preserve more of the stable conversation and tool content that supported providers can reuse. Responses history stays append-only, Claude CLI avoids repeatedly changing its startup context, and Codex resends workspace references when they need introduction or refresh.
+
+Provider-specific fixes preserve Gemini’s final instructions and stable caches, keep Anthropic tool checkpoints independent of system edits, and place Bedrock checkpoints against retained conversation history. Native OpenAI cache settings reach supported transports, while supported Anthropic-compatible routes receive their cache markers. These changes follow each route’s retention settings and capabilities.
+
+Supported Amazon Nova models on Bedrock also gain opt-in prompt caching with a five-minute lifetime.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add opt-in five-minute prompt caching for supported Amazon Nova models on Bedrock. [#141060](https://github.com/openclaw/openclaw/pull/141060)
+- Honor native OpenAI cache routing and model-specific retention settings. [#140853](https://github.com/openclaw/openclaw/pull/140853)
+
+**Bug fixes**
+
+- Keep Claude CLI conversation prefixes stable across workspace edits and commits. [#140566](https://github.com/openclaw/openclaw/pull/140566) Thanks @VACInc.
+- Keep message-action and native Ollama tool ordering stable for prompt caching. [#140698](https://github.com/openclaw/openclaw/pull/140698)
+- Refresh the cache-pruning clock after successful model requests in tool loops. [#140713](https://github.com/openclaw/openclaw/pull/140713)
+- Include the final assembled system prompt in managed Gemini caches. [#140744](https://github.com/openclaw/openclaw/pull/140744)
+- Apply Anthropic cache checkpoints consistently on supported OpenRouter, DeepInfra and Model Studio routes. [#140781](https://github.com/openclaw/openclaw/pull/140781)
+- Preserve Bedrock conversation checkpoints and separate stable system prefixes. [#140797](https://github.com/openclaw/openclaw/pull/140797)
+- Keep exec, subagent and media progress in current-turn context to preserve prompt caches. [#140799](https://github.com/openclaw/openclaw/pull/140799)
+- Allocate Anthropic tool and conversation cache checkpoints independently of system changes. [#140804](https://github.com/openclaw/openclaw/pull/140804)
+- Send Codex workspace reference files only when threads need introduction or refresh. [#140814](https://github.com/openclaw/openclaw/pull/140814)
+- Preserve Responses history prefixes and keep runtime carriers attached during compaction. [#140849](https://github.com/openclaw/openclaw/pull/140849)
+- Preserve image-history prefixes on xAI Responses compatibility routes. [#141044](https://github.com/openclaw/openclaw/pull/141044)
+- Preserve Responses reasoning-update history across idle gaps and Gateway restarts. [#141065](https://github.com/openclaw/openclaw/pull/141065)
+- Keep Gemini's stable prompt cache when runtime context changes. [#141073](https://github.com/openclaw/openclaw/pull/141073)
+- Keep prompt definitions stable when Windows executable approvals change. [#141077](https://github.com/openclaw/openclaw/pull/141077)
+- Persist stable tool-history projections across Gateway restarts. [#141090](https://github.com/openclaw/openclaw/pull/141090)
+- Acknowledge Codex workspace references only when the full block survives fitting and is accepted. [#140885](https://github.com/openclaw/openclaw/pull/140885)
+- Advance image-history pruning only when the next user turn begins. [#140651](https://github.com/openclaw/openclaw/pull/140651)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Read cache usage and cost estimates">
+
+Usage separates cached and fresh prompt tokens when Ollama reports the required counters, and request-level diagnostics help explain cache misses. Codex side questions now reach the usage hooks with their tool-loop counters intact.
+
+Cost estimates preserve already recorded service-tier prices and apply the corrected rates to new eligible Anthropic requests. These are OpenClaw’s estimates and diagnostics; the provider remains responsible for its bill.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Report Ollama cached prompt tokens without double-counting input. [#140222](https://github.com/openclaw/openclaw/pull/140222) Thanks @vincentkoc.
+- Remove the canceled Sonnet 5 price increase from direct Anthropic cost estimates. [#140810](https://github.com/openclaw/openclaw/pull/140810)
+- Report request-level prompt-cache changes and explicit zero cache counters. [#140850](https://github.com/openclaw/openclaw/pull/140850)
+- Keep recorded service-tier costs and correctly price new Anthropic fast-mode requests. [#141059](https://github.com/openclaw/openclaw/pull/141059)
+- Restore cache and billing counters for Codex /btw side questions. [#141080](https://github.com/openclaw/openclaw/pull/141080)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Run local models">
+
+[LM Studio](/providers/lmstudio) now budgets against the context of the loaded model instance, and with preload enabled sends chat to an instance that has enough room. If a new instance is loaded, the request uses its returned identity while your configured model reference stays the same. This avoids budgeting for a larger instance and then sending the conversation to a smaller one.
+
+Native Ollama requests honor per-request sampling overrides, including explicit zero values. Fresh llama.cpp installation allows time for the first macOS security check, and managed installs receive updated runtime binaries.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Update managed llama.cpp binaries and library manifests to b10809. [#140278](https://github.com/openclaw/openclaw/pull/140278) Thanks @vincentkoc.
+- Keep inference metadata and domain help lazy. [#140327](https://github.com/openclaw/openclaw/pull/140327)
+- Load Gemini model-family policy through a lightweight shared entrypoint. [#140922](https://github.com/openclaw/openclaw/pull/140922)
+
+**Bug fixes**
+
+- Honor native Ollama sampling overrides, including explicit zero values. [#140717](https://github.com/openclaw/openclaw/pull/140717)
+- Allow up to 120 seconds for the first unpublished llama-server version check. [#139160](https://github.com/openclaw/openclaw/pull/139160) Thanks @waterundman, @vincentkoc.
+- Point LM Studio auth failures to models auth login --provider lmstudio. [#125399](https://github.com/openclaw/openclaw/pull/125399)
+- Fit discovery text to the active context budget while preserving admitted skills and complete instructions. [#139244](https://github.com/openclaw/openclaw/pull/139244)
+- Use the loaded LM Studio instance’s actual context budget and preserve that target when reloading. [#138633](https://github.com/openclaw/openclaw/pull/138633) Thanks @ruel225 and @javikas.
+- Send LM Studio chat to the prepared instance with enough context while preserving the configured model identity. [#141390](https://github.com/openclaw/openclaw/pull/141390)
+
+**Limits and compatibility**
+
+- Reject empty numeric options in inference commands and model scans. [#140235](https://github.com/openclaw/openclaw/pull/140235) Thanks @Alix-007.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Continue CLI-backed conversations">
+
+Cold managed Codex workers wait until they are ready before starting a first turn. Claude CLI-backed questions can retain their supported waiting deadline, and mixed CLI output handles quoted JSON examples without mistaking them for the answer. Side questions preserve completed answers while forwarding cancellation and reporting a disconnect promptly.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Wait for cold Codex workers to become ready before starting their first turn. [#140990](https://github.com/openclaw/openclaw/pull/140990)
+- Preserve supported ask_user deadlines for Claude CLI-backed agents. [#140845](https://github.com/openclaw/openclaw/pull/140845) Thanks @vincentkoc, @josh-cornelius.
+- Ignore quoted JSON examples while reading mixed CLI backend output. [#122373](https://github.com/openclaw/openclaw/pull/122373) Thanks @ooiuuii.
+- Preserve Codex exec-server WebSocket pause and resume under Bun. [#140048](https://github.com/openclaw/openclaw/pull/140048)
+- Validate file-URL pathname encoding before Codex image conversion. [#140087](https://github.com/openclaw/openclaw/pull/140087)
+- Share Codex ephemeral-turn routing to retain terminal results and forward cancellation. [#139228](https://github.com/openclaw/openclaw/pull/139228)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Preserve streamed answers and tool media">
+
+Provider adapters preserve initial Anthropic text and thinking, keep images with the tool results they came from, and retain tool-schema constraints. Generated-video downloads reject malformed responses, while image setup stops after cancellation or timeout. If an OpenCode Go or compatible completion stream ends after its tools have finished, OpenClaw can recover a final summary without replaying those tools. Several streaming paths also reduce repeated local parsing or copying without changing the provider’s generation speed.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Project verified native reasoning appends without repeatedly rescanning the full prefix. [#123120](https://github.com/openclaw/openclaw/pull/123120) Thanks @nierob-cmd.
+- Reduce repeated parsing of Bedrock tool-argument previews during streaming. [#120248](https://github.com/openclaw/openclaw/pull/120248) Thanks @lucascmg-vx.
+- Reduce xAI OAuth and custom-endpoint tool-result preparation work. [#140176](https://github.com/openclaw/openclaw/pull/140176)
+- Reduce local Google request-building work for tool histories without reusable signatures. [#140720](https://github.com/openclaw/openclaw/pull/140720)
+- Process large streamed OpenRouter music responses with less repeated parsing work. [#140728](https://github.com/openclaw/openclaw/pull/140728)
+- Reduce temporary copying during Copilot transcript preparation. [#140868](https://github.com/openclaw/openclaw/pull/140868)
+- Bound settled Microsoft Foundry Entra-token retention while preserving active refreshes. [#127216](https://github.com/openclaw/openclaw/pull/127216)
+- Avoid discarded text assembly for Anthropic image tool results. [#140409](https://github.com/openclaw/openclaw/pull/140409)
+
+**Bug fixes**
+
+- Preserve image ownership across parallel tool results in Chat Completions and xAI conversion. [#133808](https://github.com/openclaw/openclaw/pull/133808) Thanks @SunnyShu0925.
+- Preserve tool-schema references and constraints in Anthropic requests. [#139431](https://github.com/openclaw/openclaw/pull/139431)
+- Preserve initial content and thinking signatures in Anthropic streamed replies. [#140820](https://github.com/openclaw/openclaw/pull/140820)
+- Reject malformed generated-video downloads while preserving existing provider timeout behavior. [#117339](https://github.com/openclaw/openclaw/pull/117339) Thanks @Yigtwxx, @obviyus.
+- Stop image setup after cancellation or timeout. [#140149](https://github.com/openclaw/openclaw/pull/140149)
+- Keep deferred media providers in the catalog while preserving explicit execution choices. [#139231](https://github.com/openclaw/openclaw/pull/139231) Thanks @rodrigo-fonseca-oliveira.
+- Release completed realtime transcription sockets after final transcript delivery. [#140303](https://github.com/openclaw/openclaw/pull/140303)
+- Recover final summaries after incomplete OpenCode Go and compatible completions streams. [#140367](https://github.com/openclaw/openclaw/pull/140367) Thanks @VACInc.
+
+**Limits and compatibility**
+
+- Reduce Mistral stream preparation work for large parallel tool responses. [#141050](https://github.com/openclaw/openclaw/pull/141050)
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Automations and Scheduling
+
+Scheduled work preserves more of its intent through restarts and recovery, with clearer manual-run results and a way for direct hook callers to tell how their work finished.
+
+<AccordionGroup>
+
+<Accordion title="Keep scheduled and manual runs distinct">
+
+Manually running an overdue automation now delivers a fresh result without changing the stale-delivery rules for ordinary scheduled runs. A forced run of a disabled one-shot reminder keeps that reminder disabled, and paced checks retain their deadlines through a restart.
+
+Recovered work can finish successfully after a spawn was rejected before dispatch, while skipped on-exit work is reported rather than silently queued for later.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Deliver fresh results from manually run overdue automations. [#139967](https://github.com/openclaw/openclaw/pull/139967)
+- Keep disabled one-shot reminders paused after a forced run with heartbeats disabled. [#139947](https://github.com/openclaw/openclaw/pull/139947)
+- Keep paced automation deadlines across Gateway restart. [#140083](https://github.com/openclaw/openclaw/pull/140083)
+- Record successful fallback work correctly after a spawn is rejected before reservation or dispatch. [#139037](https://github.com/openclaw/openclaw/pull/139037) Thanks @hartmark, @obviyus.
+- Report skipped on-exit payloads when an automation is already running. [#139987](https://github.com/openclaw/openclaw/pull/139987)
+- Avoid persisting heartbeat outcomes for nonexistent transient base sessions. [#131462](https://github.com/openclaw/openclaw/pull/131462) Thanks @gaoanze888.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Recover monitors and legacy job ownership">
+
+Accepted private monitor notes now survive reply transformations and reach the next check without appearing in public replies or notifications. Monitor reconciliation yields so other Gateway requests can make progress during startup or reload. Doctor can repair known legacy multi-agent job owners, and an unresolved owner no longer stops valid jobs from running alongside it. Ambiguous jobs remain inspectable and are skipped until their ownership is resolved.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Keep Gateway requests responsive during system-monitor reconciliation. [#140260](https://github.com/openclaw/openclaw/pull/140260)
+- Repair known legacy multi-agent owners and keep valid cron jobs running beside unresolved jobs. [#140825](https://github.com/openclaw/openclaw/pull/140825)
+- Carry accepted heartbeat scratch through reply transformations so its stored revision advances. [#139225](https://github.com/openclaw/openclaw/pull/139225) Thanks @gaoanze888, @obviyus, @JLahullier.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Choose models and inspect automation history">
+
+Automation model suggestions refresh when the catalog changes, and a failed read leaves your draft intact. History and status views avoid some repeated preparation and pause hidden-tab refreshes until you return, while scheduled cost estimates retain the run’s own model prices.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Reduce per-record work when loading automation history. [#140170](https://github.com/openclaw/openclaw/pull/140170)
+- Stop retaining replaced initial automation-stream job snapshots. [#140256](https://github.com/openclaw/openclaw/pull/140256)
+- Log separate wait and processing times for slow cron list pages. [#140994](https://github.com/openclaw/openclaw/pull/140994)
+
+**Bug fixes**
+
+- Refresh automation model suggestions when the catalog changes and preserve drafts during read failures. [#139876](https://github.com/openclaw/openclaw/pull/139876) Thanks @obviyus.
+- Use the scheduled agent's model prices through run finalization. [#139374](https://github.com/openclaw/openclaw/pull/139374)
+- Pause automation refreshes in hidden tabs and catch up on return. [#140097](https://github.com/openclaw/openclaw/pull/140097)
+- Show owned cron jobs once in Claw removal previews. [#139473](https://github.com/openclaw/openclaw/pull/139473)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Wait for a direct hook to finish">
+
+Direct agent-hook callers can opt in to `waitForCompletion` and receive bounded status that distinguishes a reply, intentional silence and delivery outcomes. The default remains acknowledgement of admission, and mapped or fan-out calls keep that existing behavior.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Add waitForCompletion to direct agent hooks with bounded reply and delivery status. [#139155](https://github.com/openclaw/openclaw/pull/139155) Thanks @vincentkoc.
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Browser and Computer Use
+
+The Browser panel now lets you follow supported agent pages as they change, and the Mac app brings links you open yourself into native tabs beside them. The two kinds of tabs share a panel while keeping their own controls and lifetime.
+
+<AccordionGroup>
+
+<Accordion title="Follow the agent’s browser live">
+
+The [Browser panel](/tools/browser) shows page repaints as they happen, so you can follow a page loading, scrolling or responding without waiting for the next screenshot. Existing click, type, scroll, Annotate and Inspect controls remain available.
+
+Paired-node browsers, Chrome MCP existing-session profiles and routes where streaming is unavailable continue to use screenshots. Frames remain subject to the requesting connection’s access and the browser’s navigation rules.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Stream the agent browser live in the Control UI with automatic screenshot fallback. [#141031](https://github.com/openclaw/openclaw/pull/141031)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Open links as native Mac tabs">
+
+Links opened in the Mac app now appear as native WebKit tabs in the Browser panel, replacing the separate link sidebar. They stay with that window when you switch conversations, with a URL bar, navigation controls and the option to open the page in your default browser.
+
+Annotate and Inspect take a one-shot capture of a Mac tab. These are pages you browse directly, separate from the Agent browser tabs your agent controls; links from Settings still open in the default browser.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Open dashboard links as native Mac tabs in the Browser panel. [#140988](https://github.com/openclaw/openclaw/pull/140988)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Return to browser results and capture the right page">
+
+Chrome relay tabs can also recover after attachment loss without restarting the browser stack. Opening an old browser result keeps a stopped managed browser stopped and offers Start browser when needed. Preview capture preserves focus for verified visible attached Chrome sessions on macOS and Linux, and screenshot annotations follow the actual image scale and crop.
+
+Existing-session browser profiles can upload files again, including multiple files when the page input supports them, and page-evaluation results retain embedded code fences.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Bound geometry requests for full-page screenshot labels. [#140302](https://github.com/openclaw/openclaw/pull/140302)
+- Assemble iframe snapshot lines in one pass while preserving refs and capture order. [#140304](https://github.com/openclaw/openclaw/pull/140304)
+- Avoid scanning and hashing computer frames when image input is blocked. [#140880](https://github.com/openclaw/openclaw/pull/140880)
+- Count encoded browser response sizes without serializing the payload twice. [#140882](https://github.com/openclaw/openclaw/pull/140882)
+
+**Bug fixes**
+
+- Resolve historical browser targets without launching a browser or creating a blank tab. [#139064](https://github.com/openclaw/openclaw/pull/139064) Thanks @obviyus, @Pondsi.
+- Wait for current tab state before selecting historical targets and keep stopped panels on Start browser. [#139089](https://github.com/openclaw/openclaw/pull/139089) Thanks @ylcn91, @obviyus.
+- Preserve tab focus during preview captures for verified headed Chrome on macOS and Linux. [#134400](https://github.com/openclaw/openclaw/pull/134400) Thanks @scotthuang.
+- Align browser screenshot annotations with scaled and cropped images. [#141103](https://github.com/openclaw/openclaw/pull/141103)
+- Restore file uploads and support multiple files in existing-session browser profiles. [#139904](https://github.com/openclaw/openclaw/pull/139904)
+- Preserve embedded code fences in browser page-evaluation results. [#139906](https://github.com/openclaw/openclaw/pull/139906)
+- Recover Chrome relay target identities and wait for matching Playwright pages before listing tabs. [#139275](https://github.com/openclaw/openclaw/pull/139275) Thanks @esqandil, @obviyus.
+
+</details>
+
+</Accordion>
+
+<Accordion title="Set up the Chrome extension on a Mac">
+
+The Chrome extension can be set up from the Mac dashboard or local CLI, with Chrome’s approval and any required restart still part of the connection process. The dashboard action applies to that Mac even when its Gateway is remote.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- Set up the Chrome extension from the Mac dashboard or local CLI. [#139466](https://github.com/openclaw/openclaw/pull/139466)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Type into a remote desktop">
+
+Remote desktop typing and deletion now preserve complete emoji characters, so a character is not split while being sent or removed.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Preserve emoji during remote desktop typing and deletion. [#140157](https://github.com/openclaw/openclaw/pull/140157)
+
+</details>
+
+</Accordion>
+
+<Accordion title="Retry an interrupted desktop shutdown">
+
+A failed desktop cleanup remains visible and can be retried before another desktop opens. OpenClaw keeps the resources needed to finish that cleanup, and blocks reopening while the previous desktop remains unresolved.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- Retain desktop cleanup ownership and SSH resources until shutdown and disposal succeed. [#140658](https://github.com/openclaw/openclaw/pull/140658)
+
+</details>
+
+</Accordion>
+
+</AccordionGroup>
+
+## Plugins and Integrations
+
+Team Reports gives teams a place to return to the activity happening across their selected GitHub and Discord sources, with reports and history inside OpenClaw. Plugin authors also have several SDK changes to account for, while installed integrations receive fixes to loading, recovery, and connected sessions.
+
+<AccordionGroup>
+<Accordion title="Follow team activity in Reports">
+
+Install and enable the optional Team Reports plugin to bring authenticated GitHub activity and explicitly configured Discord sources into daily, weekly, and monthly reports. The Reports tab keeps previous reports available alongside people timelines and calendars, and optional model summaries help you read through the collected activity.
+
+Reports show source coverage and incomplete periods so a quiet-looking day is not automatically treated as a complete picture. Light and dark themes, recognizable GitHub avatars, and expandable activity lists make the history easier to browse. Reports use UTC periods and remain behind the Gateway's authentication and operator read permission.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- [Collect selected team activity and retain authenticated report history](https://github.com/openclaw/openclaw/pull/139850).
+- [Add themed report pages and GitHub avatars](https://github.com/openclaw/openclaw/pull/141327).
+- [Browse activity timelines, calendars, period comparisons, and complete retained item lists](https://github.com/openclaw/openclaw/pull/141384).
+
+**Limits and compatibility**
+
+- Team Reports is an optional external plugin, disabled by default. Collection depends on configured sources and their credentials; review-submission bodies are not collected, and some historical commit and attribution limits remain. See [Team Reports](/plugins/team-reports).
+
+</details>
+</Accordion>
+
+<Accordion title="Update plugins for the current SDK">
+
+Plugin authors should check the SDK migration guidance before updating extensions that use execution policies, approvals, inbound media helpers, or filesystem result callbacks. Several retired aliases have been removed, and the replacement APIs have contracts that need to be followed rather than substituted by name alone.
+
+MCP prompt adapters now return the typed prompt result, preserving messages and image content. The same prompt can retain its original JSON in Code Mode while vision-capable models receive supported images.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Limits and compatibility**
+
+- [Replace the retired inbound media helper with the supported channel payload builder](https://github.com/openclaw/openclaw/pull/140716).
+- [Infer the retained abort-and-drain callable's result instead of importing its removed named result type](https://github.com/openclaw/openclaw/pull/141027).
+- [Preserve MCP prompt descriptions, roles, and images through typed results](https://github.com/openclaw/openclaw/pull/141421).
+- Follow the [SDK migration guide](/plugins/sdk-migration) for approval helpers and removed aliases, and the [runtime utility migration](/plugins/sdk-runtime/config-and-utilities) for execution-policy helpers. The retained `abortAndDrainAgentHarnessRun` callable still returns its data; its retired named result type must be inferred instead.
+
+**Documentation**
+
+- [Explain scoped session APIs and the remaining deprecated helpers](https://github.com/openclaw/openclaw/pull/139401).
+- [Clarify plugin reference titles and configuration guidance](https://github.com/openclaw/openclaw/pull/140254). Thanks @vincentkoc.
+
+</details>
+</Accordion>
+
+<Accordion title="Load installed plugins and preserve recovery copies">
+
+Interrupted plugin writes and failed builds now preserve more of the information needed to recover an installation. Package manifests are replaced atomically, scoped package entries stay intact, and refreshed plugin metadata reaches later provider preparation.
+
+OpenShell also keeps host shadow copies after a failed mirror operation and identifies the remaining recovery paths, distinguishing an incomplete restoration from a backup directory that still needs cleanup.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- [Refresh provider-hook metadata after plugin reloads](https://github.com/openclaw/openclaw/pull/139908).
+- [Prepare plugin SDK aliases on demand](https://github.com/openclaw/openclaw/pull/139997).
+- [Preserve scoped package entries during official plugin handling](https://github.com/openclaw/openclaw/pull/140016).
+- [Replace package manifests atomically after builds](https://github.com/openclaw/openclaw/pull/140740). Thanks @zenglingbiao and @obviyus.
+- [Keep OpenShell shadow backups and actionable recovery paths](https://github.com/openclaw/openclaw/pull/140764). Related [mirror recovery issue](https://github.com/openclaw/openclaw/issues/140703).
+
+</details>
+</Accordion>
+
+<Accordion title="Connect tools and finish plugin hooks">
+
+Session MCP servers can finish shutting down even when their listener is still starting, and context-engine plugins receive completion for successful compaction that had nothing to remove. Failed or cancelled compaction remains distinct from successful completion.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- [Wait for late MCP listener startup during overlapping shutdowns](https://github.com/openclaw/openclaw/pull/139391).
+- [Send completion hooks for successful no-op compaction](https://github.com/openclaw/openclaw/pull/118094). Thanks @peterolkhov.
+- [Release completed observation-hook inputs without freeing timed-out queue capacity early](https://github.com/openclaw/openclaw/pull/140241).
+- [Preserve Gateway WebSocket options under Bun](https://github.com/openclaw/openclaw/pull/139919).
+
+</details>
+</Accordion>
+
+<Accordion title="Prepare cloud workers and inspect startup">
+
+Cloud startup diagnostics separate provisioning phases so operators can locate a delay, while worker preparation handles readiness and Windows Git paths more carefully. These checks describe where startup is progressing without promising a fixed startup time.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- [Show cloud session download, installation, and activation timings](https://github.com/openclaw/openclaw/pull/140443).
+
+**Bug fixes**
+
+- [Mark successfully completed worker captures ready for first warm reuse](https://github.com/openclaw/openclaw/pull/140766).
+- [Use Windows-compatible null paths in worker Git operations](https://github.com/openclaw/openclaw/pull/140803). Related [Windows Git preparation issue](https://github.com/openclaw/openclaw/issues/140795).
+
+</details>
+</Accordion>
+</AccordionGroup>
+
+## Security and Privacy
+
+Permission checks stay attached to the agent, account, and file they are meant to protect, while pending device-capability requests remain available until you resolve them. Existing telemetry choices are also explained more clearly.
+
+<AccordionGroup>
+<Accordion title="Review device capabilities and pairing accounts">
+
+Requests for additional capabilities on an already paired device now survive disconnects and restarts until they are resolved. Keeping a request available does not grant the capability, and ordinary device pairing still expires after five minutes.
+
+Pairing commands also reject an explicitly blank account selector instead of silently treating it as a broader default. Upgrade the Gateway and older CLIs that write directly to its database together, because an old writer can still remove aged capability requests.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- [Retain paired-device capability requests until resolution](https://github.com/openclaw/openclaw/pull/140166). Thanks @dragonnite1221-lgtm and @IWhatsskill.
+- [Reject blank account selectors before pairing reads or approvals](https://github.com/openclaw/openclaw/pull/140238). Thanks @Alix-007 and @shakkernerd.
+
+</details>
+</Accordion>
+
+<Accordion title="Keep plugin execution within its permissions">
+
+Plugin setup checks the file it is about to load, rejecting substituted setup files that would escape the plugin's installation. Delegated model overrides are checked against the model the destination agent will actually resolve, which can reject an override that previously passed against the wrong context.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Security and trust**
+
+- [Validate replaced setup symlinks and hardlinks before loading](https://github.com/openclaw/openclaw/pull/117370). Existing verified immutable and Nix-root policies remain in place.
+- [Apply the destination agent's model permissions to plugin overrides](https://github.com/openclaw/openclaw/pull/139368).
+
+</details>
+</Accordion>
+
+<Accordion title="Understand telemetry choices">
+
+Telemetry documentation now explains the opt-in controls, what inventory counts represent, and where network-level IP handling occurs. The local preview command is described as a preview from the current CLI process, keeping it distinct from a record of previously submitted data.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- [Clarify telemetry counts, consent controls, and IP handling](https://github.com/openclaw/openclaw/pull/140768). Thanks @vincentkoc. Cloudflare receives the client IP at the network boundary; Analytics Engine excludes it.
+- [Label telemetry show as a local preview](https://github.com/openclaw/openclaw/pull/140789). Thanks @vincentkoc.
+
+**Limits and compatibility**
+
+- These documentation and help corrections do not change telemetry payloads or consent defaults.
+
+</details>
+</Accordion>
+</AccordionGroup>
+
+## Quality-of-Life Improvements
+
+Code Mode can carry a running program through fast tool replies without repeatedly saving and restoring its whole environment, and optional TypeScript checks help catch mismatched tool calls before they run. Smaller improvements make file results, task handoffs, and command documentation easier to work with.
+
+<AccordionGroup>
+<Accordion title="Compose tools in Code Mode">
+
+Fast tool replies can now return to the same running JavaScript environment, allowing programs to keep working with larger valid in-memory values. Explicit yields, exhausted budgets, and worker pressure still checkpoint execution and enforce the existing limits.
+
+Agents can opt into TypeScript checks against available tool declarations before execution, read bounded console output, and get error locations mapped back to their original source. TextEncoder and TextDecoder are also available for local text and byte transformations across waits and resumes.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- [Continue live Code Mode programs and optionally check tool composition before execution](https://github.com/openclaw/openclaw/pull/141265). Thanks @Takhoffman. Related [continuation and typed composition issue](https://github.com/openclaw/openclaw/issues/141261).
+- [Retain sandboxed text encoders and decoders through wait and resume](https://github.com/openclaw/openclaw/pull/140812). Thanks @Takhoffman.
+
+**Limits and compatibility**
+
+- Type checking is optional. These changes do not raise memory limits or add unrestricted filesystem or network access. See [Code Mode](/tools/code-mode).
+
+</details>
+</Accordion>
+
+<Accordion title="Read files and search results in Code Mode">
+
+Directory listings and file searches avoid duplicating the same bounded text in their structured results, leaving more room for the result the agent needs. Search also follows Git-compatible ignore patterns, while file paging reduces unnecessary temporary allocations.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- [Keep bounded directory output from consuming the result budget twice](https://github.com/openclaw/openclaw/pull/139910).
+- [Avoid duplicate Find and Grep text in truncation metadata](https://github.com/openclaw/openclaw/pull/140008). Thanks @ruel225.
+- [Apply Git-compatible ignore patterns to file search](https://github.com/openclaw/openclaw/pull/140732).
+
+**Improvements**
+
+- [Reduce temporary allocation when paging large files](https://github.com/openclaw/openclaw/pull/140714).
+
+**Limits and compatibility**
+
+- Find and Grep callbacks now read bounded text from `details.content`. Directory callbacks use `LsToolDetails.content` and optional `nextAfter`, passing that cursor as `after` for another page. Genuinely oversized results still hit the existing budget.
+
+</details>
+</Accordion>
+
+<Accordion title="Schedule tools and continue delegated work">
+
+Tools that require sequential execution keep that requirement across Code Mode, Tool Search, and MCP, while tools that support parallel work remain concurrent. Core serial subagent handoffs also acknowledge a settled result when the parent accepts its next child and yields, avoiding a duplicate completion turn in that path.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- [Respect sequential tool contracts across shared tool catalogs](https://github.com/openclaw/openclaw/pull/140767). Thanks @Takhoffman.
+- [Acknowledge settled core subagent handoffs without replaying the parent](https://github.com/openclaw/openclaw/pull/139986). Thanks @FabianJun and @obviyus.
+
+**Limits and compatibility**
+
+- Cancellation cannot forcibly stop an uncooperative external tool. The handoff repair applies to core `sessions_spawn`; native-only receipt handling is separate.
+
+</details>
+</Accordion>
+
+<Accordion title="Find command and configuration help">
+
+Configuration references are split into more focused pages, repaired redirects preserve familiar entry points, and clearer command titles make the help easier to navigate.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- [Organize focused configuration references](https://github.com/openclaw/openclaw/pull/140440). Thanks @vincentkoc.
+- [Restore configuration documentation redirects](https://github.com/openclaw/openclaw/pull/140450). Thanks @vincentkoc.
+- [Give CLI reference pages distinct command titles](https://github.com/openclaw/openclaw/pull/140208). Thanks @vincentkoc.
+
+</details>
+</Accordion>
+</AccordionGroup>
+
+## Other Bug Fixes
+
+The remaining fixes cover the work underneath a conversation, including database contention, command completion, and oversized inline images. They keep recoverable failures from turning into unrelated connection crashes or misleading command results.
+
+<AccordionGroup>
+<Accordion title="Keep conversation storage responsive">
+
+Repeated transcript reconciliation is paced without discarding queued writes, and restoring a worktree releases the conversation writer while the restore continues. Closed databases also release their prepared objects, reducing retained state after that connection is finished.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- [Pace transcript reconciliation without discarding queued writes](https://github.com/openclaw/openclaw/pull/119126). Thanks @shad0wca7.
+- [Release the conversation writer during worktree restoration](https://github.com/openclaw/openclaw/pull/139051).
+- [Release prepared SQLite objects with their closed database](https://github.com/openclaw/openclaw/pull/139085).
+- [Avoid full-history cleanup for new internal context-overflow signals](https://github.com/openclaw/openclaw/pull/140231). Thanks @VACInc. Existing amplified histories are not rewritten by this repair.
+
+</details>
+</Accordion>
+
+<Accordion title="Finish and cancel commands">
+
+Command cleanup preserves the command's outcome while dealing with remaining processes, and completed Bun commands retain their output. When the operating system reports an error, its underlying cause stays available instead of disappearing behind a generic failure.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- [Clean up sandbox commands through their supported process path](https://github.com/openclaw/openclaw/pull/139948).
+- [Observe process-group exit before reporting cleanup completion](https://github.com/openclaw/openclaw/pull/139957).
+- [Retain completed command output under Bun](https://github.com/openclaw/openclaw/pull/139965).
+- [Preserve underlying operating-system errors in command failures](https://github.com/openclaw/openclaw/pull/140015).
+- [Preserve parent CLI options, literal argument boundaries, and machine-readable errors](https://github.com/openclaw/openclaw/pull/139067).
+
+</details>
+</Accordion>
+
+<Accordion title="Handle disconnects and oversized images">
+
+A client disconnect during WebSocket setup no longer leaves its early error unhandled on the affected Gateway and portal path. Oversized inline image data also reaches the intended size error instead of overflowing the parser's stack.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Bug fixes**
+
+- [Handle early WebSocket errors during client disconnects](https://github.com/openclaw/openclaw/pull/139061).
+- [Report oversized inline images without a regular-expression stack failure](https://github.com/openclaw/openclaw/pull/140226).
+
+</details>
+</Accordion>
+</AccordionGroup>
+
+## Maintainer and Internal Changes
+
+Maintainer work consolidates internal runtime helpers, improves focused test fixtures, and updates review, documentation, and release tooling. These changes support development and qualification without introducing additional user-facing features.
+
+<AccordionGroup>
+<Accordion title="Runtime implementation and focused tests">
+
+Private runtime consolidation reduces duplicated preparation and ownership code, while test changes isolate temporary state and make platform-specific failures easier to investigate.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Improvements**
+
+- [Share strict-tool diagnostics without changing OpenAI requests](https://github.com/openclaw/openclaw/pull/140697).
+- [Share native chat operations while preserving platform routing](https://github.com/openclaw/openclaw/pull/140985).
+
+</details>
+</Accordion>
+
+<Accordion title="Review infrastructure and release tooling">
+
+Maintainer guidance describes review commands and coordinated infrastructure activation, while qualification and release tools retain clearer records of their own work.
+
+<details class="release-source-toggle">
+<summary>Sources and complete change list</summary>
+
+**Documentation**
+
+- [Document Mantis review commands and coordinated activation](https://github.com/openclaw/openclaw/pull/140452). Thanks @brokemac79 and @obviyus.
+- [Explain read-only ClawSweeper status checks](https://github.com/openclaw/openclaw/pull/139958).
+- [Document maintainer skill and tooling entry points](https://github.com/openclaw/openclaw/pull/139380).
+
+**Improvements**
+
+- [Validate genuine squash credit in release tooling](https://github.com/openclaw/openclaw/pull/139993). Thanks @vincentkoc.
+- [Bound CI group output](https://github.com/openclaw/openclaw/pull/140018). Thanks @ylcn91 and @vincentkoc.
+- [Discover the test network for Parallels smoke runs](https://github.com/openclaw/openclaw/pull/140481). Thanks @vincentkoc.
+
+</details>
+</Accordion>
+</AccordionGroup>

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -11,6 +11,7 @@ changelog first.
 
 ## Releases
 
+- [v2026.9.3](/releases/2026.9.3) - Safer update rehearsal, persistent Workshop skills, live browser views and native Mac tabs, and a searchable meeting library.
 - [v2026.9.2](/releases/2026.9.2) - Reliability and recovery improvements, OpenAI GPT-6 Astra and Meta Muse Spark 1.3 support, and flexible task workspaces.
 - [v2026.9.1](/releases/2026.9.1) - Mermaid diagrams across chat surfaces, a fuller Android experience, safer update recovery, and lower overhead for long conversations and large installations.
 - [v2026.8.2](/releases/2026.8.2) - Home beside your work, a Linux desktop companion, background sessions, browser control without a running Gateway, four new Control UI looks, and focused reply, voice, update, and recovery fixes.


### PR DESCRIPTION
## What Problem This Solves

OpenClaw v2026.9.3 is released, but the docs do not yet have a reader-facing page explaining its changes. The release changelog is useful for individual entries, but it is not organized like the detailed release pages people already use.

## Why This Change Was Made

Adds the v2026.9.3 page using the established release-note categories, readable topic summaries, and collapsed source lists. Adds it to the release index and navigation. The story covers update rehearsal and recovery, persistent Workshop skills, live browser views and native Mac tabs, meeting archives, account controls, and the broader fixes.

The page is pinned to the final `v2026.9.3` tag at `1391f7cd2d40ab5bbcf2f5f831d3a64f520e72d7`. It does not change runtime code, `CHANGELOG.md`, or the GitHub release body.

## User Impact

Readers can browse what changed by the product area they use, with practical limitations and source links available without making every paragraph a PR inventory. Installation guidance includes the supported Node versions, and sharing/browser descriptions distinguish their actual access and platform boundaries.

## Evidence

- Every one of the 1,894 raw-range units received direct editorial evidence review. The page accounts for 1,844 PRs and 40 direct commits, with ten already-shipped backports separately identified and withdrawn work kept out of new-feature claims.
- Complete source disclosures retain 190 credited contributors, including verified coauthors and reporters. The equivalent PR reference #141681 is contextual to an already-counted direct commit, not an extra unit.
- An independent editor read the complete page, and independent reviewers checked every unit-to-copy decision. Six targeted outcome/compatibility corrections were applied and reviewed; the final verdict is **approved for human review**, with no material finding remaining.
- The checked 4,390-line page has SHA-256 `90b8443462d1ffb3210908aba1613ccefb1778a4b9023c6043c139001e062a4d`. Exact source readback confirms all 1,894 primary records once, with no placement differences.
- Focused MDX checks passed for the new page and release index. Navigation JSON parses; all 12 root-relative documentation links resolve to local source pages. `git diff --check` passes.
- No runtime tests were run for this docs-only change.

The source and contributor accounting is now complete. The compact release-scale line is included, and the maintainer section separates 817 internal changes, three reverted-work records, and ten previously shipped changes. This replaces the initial draft's partial source lists; merging and publication remain separate review decisions.

Release reference: https://github.com/openclaw/openclaw/releases/tag/v2026.9.3
