### PR TITLE
fix(qa): align auth and Workshop proofs with runtime contracts

### DIFF
--- a/test/e2e/qa-lab/runtime/codex-auth-app-server.fixture.mjs
+++ b/test/e2e/qa-lab/runtime/codex-auth-app-server.fixture.mjs
@@ -36,6 +36,22 @@ runFakeCodexAppServer({
         }),
       ),
     "account/login/start": ({ params, sendResult }) => sendResult({ type: params?.type }),
+    "model/list": ({ sendResult }) =>
+      sendResult({
+        data: ["gpt-5.6-luna"].map((model) => ({
+          id: model,
+          model,
+          displayName: model,
+          description: "Synthetic auth product proof model",
+          hidden: false,
+          isDefault: true,
+          defaultReasoningEffort: "low",
+          supportedReasoningEfforts: [{ reasoningEffort: "low", description: "Low" }],
+          multiAgentVersion: "v2",
+          inputModalities: ["text"],
+        })),
+        nextCursor: null,
+      }),
     "account/rateLimits/read": ({ sendResult }) =>
       sendResult({
         rateLimits: {

--- a/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
@@ -451,7 +451,9 @@ describe("Codex auth product proof", () => {
           ).toMatchObject({ runId: setup.runId, status: "ok" });
         };
         await runConfiguredTurn("qa-codex-profile-binding-setup");
-        await expect(client.request("models.list", { agentId: "main" })).resolves.toMatchObject({
+        await expect(
+          client.request("models.list", { agentId: "main", refresh: true }),
+        ).resolves.toMatchObject({
           models: expect.arrayContaining([
             expect.objectContaining({ id: "gpt-5.6-luna", provider: "openai" }),
           ]),

--- a/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
+++ b/test/e2e/qa-lab/runtime/codex-auth-product-proof.e2e.test.ts
@@ -360,7 +360,7 @@ describe("Codex auth product proof", () => {
   );
 
   it(
-    "returns bounded recovery when the configured profile is absent without calling app-server",
+    "returns bounded recovery after the explicitly selected profile is removed",
     { timeout: 180_000 },
     async () => {
       const { CODEX_APP_SERVER_VERSION } = await loadBundledPluginFacade<{
@@ -451,6 +451,11 @@ describe("Codex auth product proof", () => {
           ).toMatchObject({ runId: setup.runId, status: "ok" });
         };
         await runConfiguredTurn("qa-codex-profile-binding-setup");
+        await expect(client.request("models.list", { agentId: "main" })).resolves.toMatchObject({
+          models: expect.arrayContaining([
+            expect.objectContaining({ id: "gpt-5.6-luna", provider: "openai" }),
+          ]),
+        });
         await expect(
           client.request("sessions.patch", {
             key: sessionKey,
@@ -570,24 +575,20 @@ describe("Codex auth product proof", () => {
       expect(JSON.stringify(failedHistory)).not.toContain(MISSING_PROFILE_ID);
       expect(JSON.stringify(failedHistory)).not.toContain("Codex app-server auth profile");
 
-      await waitForRequest(failureAppServerLog, "initialize");
       const failureMethods = failureAppServerLog
         .read()
         .flatMap((entry) => (typeof entry.method === "string" ? [entry.method] : []));
-      expect(failureMethods).toContain("initialize");
-      expect(failureMethods).not.toContain("account/login/start");
-      expect(failureMethods).not.toContain("thread/start");
-      expect(failureMethods).not.toContain("thread/resume");
-      expect(failureMethods).not.toContain("turn/start");
+      const operationalMethods = failureMethods.filter(
+        (method) => method !== "initialize" && method !== "initialized",
+      );
+      expect(operationalMethods).toEqual([]);
 
       console.log(
         `[qa-codex-missing-auth-profile] ${JSON.stringify({
           assistantOutput: SELECTED_AUTH_PROFILE_UNAVAILABLE_USER_TEXT,
           historySessionKey: sessionKey,
-          appServerInitialized: true,
-          appServerOperationalRpcCount: failureMethods.filter(
-            (method) => method !== "initialize" && method !== "initialized",
-          ).length,
+          appServerInitialized: failureMethods.includes("initialize"),
+          appServerOperationalRpcCount: operationalMethods.length,
         })}`,
       );
     },

--- a/test/skills-proposal-manual-target.e2e.test.ts
+++ b/test/skills-proposal-manual-target.e2e.test.ts
@@ -53,6 +53,7 @@ async function setupTempHome() {
   return {
     configPath: path.join(stateDir, "openclaw.json"),
     env,
+    stateDir,
     workspace,
   };
 }
@@ -100,7 +101,15 @@ describe("Skill proposal manual-target product proof", () => {
           status: "pending",
           target: {
             skillKey: "manual-gateway-proof",
-            skillFile: path.join(temp.workspace, "skills", "manual-gateway-proof", "SKILL.md"),
+            skillFile: path.join(
+              temp.stateDir,
+              "agents",
+              "main",
+              "agent",
+              "workshop-skills",
+              "manual-gateway-proof",
+              "SKILL.md",
+            ),
           },
         });
 


### PR DESCRIPTION
Related: #141974

## What Problem This Solves

Release QA still expects Workshop proposals beneath the session workspace and requires app-server initialization even when a missing selected credential is rejected earlier. Its fake app-server also returns an invalid empty object for model discovery. These stale assumptions keep the proofs from exercising the current ownership contracts reliably.

## Why This Change Was Made

Carry the remaining QA corrections from release preparation: advertise the supported model and verify its catalog visibility through explicit refresh, require zero non-handshake RPCs after credential removal, and assert the agent-owned Workshop target before proving manual-install staleness and apply rejection. The logout path and current account/thread fixtures from main are preserved.

## User Impact

No runtime behavior changes. Maintainers regain coverage of auth recovery and Workshop proposal ownership without prescribing when the app-server must initialize.

## Evidence

- Personally checked the Codex model-list protocol and current OpenClaw catalog/Workshop owners.
- Full changed-file checks and independent P2 review passed.
- Isolated Linux Gateway/mock-Codex E2E: all 3 cases passed on the reviewed source, with zero operational RPCs after selected-profile removal. [Testbox run](https://github.com/openclaw/openclaw/actions/runs/34243599571).
- Replayed the original Workshop expectation and confirmed the old-path assertion fails; the corrected proof reaches stale persistence and apply rejection.
- Adapted model discovery to current main’s documented `models.list` `refresh: true` publication boundary after a passive-read readiness failure; no polling or timeout increase.
- Local auth baseline passed; the local Workshop baseline hit startup timeouts on the loaded host, so its causal proof ran on isolated Linux.
