### PR TITLE
test(telegram): keep sticker selection off runtime provider discovery

### DIFF
--- a/extensions/telegram/src/sticker-cache.selection.test.ts
+++ b/extensions/telegram/src/sticker-cache.selection.test.ts
@@ -44,7 +44,10 @@ function createFixture(defaults: AgentDefaults, minimaxProvider?: string) {
     agentRuntime: { id: "openclaw" },
   });
   const cfg: OpenClawConfig = {
-    plugins: { allow: ["openai", ...(minimaxProvider ? ["minimax"] : [])] },
+    // Runtime model discovery loads the full plugin entry through the plugin loader.
+    // Without build output, transpiling the core graph can take ~150s, exceeding the 120s budget.
+    // Selection only needs the configured provider rows, so keep MiniMax inactive.
+    plugins: { allow: ["openai"] },
     agents: { ownership: "explicit", defaults, entries: { main: {} } },
     models: {
       mode: "replace",


### PR DESCRIPTION
Related: #142179
Related: #142023
Related: #142234

<details>
<summary>Additional instructions</summary>

Maintainer-owned repair branch; maintainers can update it.

</details>

## What Problem This Solves

Resolves a problem where the Telegram sticker-selection CI shard can exceed its 120-second test budget in a checkout without build output. The supplied CI investigation observed approximately 153 seconds on three #142179 attempts and 90,851 ms on #142023. This is the isolated maintainer-requested repair for that CI blocker.

## Why This Change Was Made

Keep the fixture's plugin allowlist at `['openai']` while preserving its MiniMax provider parameter, configured provider rows, and all assertions. Activating MiniMax invokes runtime model discovery through the plugin loader and makes jiti transpile the core graph without build output; selection itself only needs the configured rows. A short comment protects that boundary.

## User Impact

No runtime behavior changes. This removes the unnecessary MiniMax activation responsible for the shard flake and the blocker affecting #142179's exact-head CI. All seven selection cases remain covered, including all four MiniMax variants.

## Evidence

All performance and mutation checks ran in the task worktree without build output, using the existing wrapper and Telegram config:

```sh
node scripts/run-vitest.mjs --root . --config test/vitest/vitest.extension-telegram.config.ts extensions/telegram/src/sticker-cache.selection.test.ts --reporter verbose
```

- Baseline before editing, filtered with `-t "keeps minimax on VLM"`: **113,834 ms** for the MiniMax case, **135.61 s** total. It narrowly passed on this runner; the CI timeout was not reproduced locally.
- After repair: **7/7 pass**, **19.03 s** total. Per-case milliseconds: explicit image default **9007**, active vision **117**, MiniMax **105**, MiniMax CN **105**, MiniMax portal **268**, MiniMax portal CN **104**, selected-primary failure **94**.
- Meaningfulness: temporarily returning false from `isMinimaxVlmProvider` failed **all four MiniMax variants**. Representative assertion: expected `Described by minimax/MiniMax-VL-01`, received `Described by minimax/MiniMax-M2.7`. The core file was restored; only this test fixture is changed.
- `node scripts/check-changed.mjs`: **passed**, including changed-file lint. The first nested-location attempt failed the declaration-input isolation guard; the same worktree and installed dependencies were moved outside the parent install, then the complete check passed. No reinstall or guard bypass was used.
- Independent autoreview: **scoped-clean**, no accepted/actionable P0/P1 findings; verdict **patch is correct**.
- Exact-head CI: [run 34245767896](https://github.com/openclaw/openclaw/actions/runs/34245767896) **passed** on `def9f67040629586e5923afff37ab0e8a2ace5bd`; no failed jobs or reruns. Native hosted prepare gates passed on that same head.
- ClawSweeper reviewed the same head and found no actionable issues.

The initially prescribed implicit wrapper command attempted an automatic build because #142234 already lists this test as a runtime consumer. That task-owned attempt was stopped and its generated output removed. Explicit root/config selection avoids automatic runtime preparation while preserving the Telegram test configuration; the initial attempt is excluded from performance evidence.

## Known Gaps

Loader-side follow-up, owner **plugins/test infrastructure**: under Vitest, jiti-loaded plugins transpile the core graph when no dist exists. That behavior is unchanged. The runtime-build prerequisite introduced by #142234 also remains outside this one-file repair. This runner demonstrated the near-budget cold baseline and the speedup, but did not reproduce the 120,000 ms timeout reported in CI.
