### PR TITLE
test(ui): await activity cache imports before teardown

### DIFF
--- a/ui/src/pages/activity/activity-page.test.ts
+++ b/ui/src/pages/activity/activity-page.test.ts
@@ -148,7 +148,7 @@ function toolEvent(id: string, sessionKey = "main") {
   });
 }
 
-afterEach(() => {
+afterEach(async () => {
   for (const page of activePages) {
     page.subscriptions.hostDisconnected();
   }
@@ -161,6 +161,8 @@ afterEach(() => {
   for (const source of activeGateways) {
     source.stop();
   }
+  // Credential changes start lazy cache cleanup; finish it before clearing the environment.
+  await vi.dynamicImportSettled();
   activePages.clear();
   activeGateways.clear();
   activeActivities.clear();


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where Activity page tests pass their assertions but fail the Node CI job when lazy cache imports continue after the jsdom environment is torn down. Main run [34241634465](https://github.com/openclaw/openclaw/actions/runs/34241634465/job/102114399109) reported four `EnvironmentTeardownError` rejections after 5,650 passing tests.

## Why This Change Was Made

Gateway changes start asynchronous warm-boot cache invalidation. Stopping the test's Gateway does not join those lazy imports. The fixture now waits for Vitest's native recursive import drain after disposing its owners and before clearing browser state, matching the existing authentication and boot-record fixtures.

## User Impact

More reliable CI, with all 21 Activity page cases and their assertions retained. No application behavior changes, new waits with fixed durations, extended deadlines, mocks, or production seams. Production delta: 0; test delta: +3/-1. The remaining import work is accounted for in teardown rather than leaking into the next environment.

## Evidence

- The original 21-case file passed locally; the exact intermittent CI error was not reproduced locally.
- A temporary counter around the real lazy import promise showed pending work at the end of the complete original teardown. The same 21-case order passed with the native drain. The diagnostic added no delayed imports, fake timers or mocks and was removed before final verification.
- Final diagnostics-free run: 21/21 passed. Required changed checks passed, including UI types, formatting, lint and repository guards. Independent P2 review found no actionable issue.
- Installed Vitest 5.0.0 implementation was checked directly: `dynamicImportSettled()` waits for resolving modules and their nested imports. Existing `gateway-store.auth.test.ts` and `gateway-store.boot-record.test.ts` use the same cleanup boundary.

Local timings had different cache/load states, so no controlled speedup is claimed. This repair prevents a passing test shard from failing during teardown and needing another run. Exact-head Linux CI will verify the final source before landing.
