### PR TITLE
fix(models): preserve exact catalog row identities

### DIFF
--- a/src/agents/model-catalog-route.test.ts
+++ b/src/agents/model-catalog-route.test.ts
@@ -9,7 +9,6 @@ import * as activeThinkingPolicy from "../plugins/provider-thinking-active.js";
 import { prepareModelCatalogThinkingPolicies } from "../plugins/provider-thinking.js";
 import type { ProviderDefaultThinkingPolicyContext } from "../plugins/provider-thinking.types.js";
 import {
-  findModelCatalogRouteDonor,
   type ModelCatalogRoutePolicy,
   projectModelCatalogEntryForRoute,
   resolveConfiguredModelCatalogOverrides,
@@ -76,14 +75,16 @@ describe("projectModelCatalogEntryForRoute", () => {
       params: { logicalOnly: true },
     },
   ])("prefers the exact physical donor over the $api row", (entry) => {
-    expect(
-      findModelCatalogRouteDonor({
-        entry,
-        route: chatGPTRoute,
-        policy: routePolicy,
-        catalog: [platformEntry, chatGPTEntry],
-      }),
-    ).toBe(chatGPTEntry);
+    const { entry: publicEntry, runtimeEntry } = projectModelCatalogEntryForRoute({
+      entry,
+      projection: { kind: "selected", route: chatGPTRoute, policy: routePolicy },
+      catalog: [platformEntry, chatGPTEntry],
+    });
+    expect(runtimeEntry.params).toEqual({ chatGPTOnly: true });
+    expect(runtimeEntry.compat).toEqual({ supportsTools: true });
+    expect(runtimeEntry.contextWindow).toBe(400_000);
+    expect(publicEntry).not.toHaveProperty("params");
+    expect(publicEntry).not.toHaveProperty("compat");
   });
 
   it("projects one physical row onto the selected route capabilities", () => {
@@ -92,7 +93,7 @@ describe("projectModelCatalogEntryForRoute", () => {
         entry: platformEntry,
         projection: { kind: "selected", route: platformRoute, policy: routePolicy },
         catalog: [platformEntry, chatGPTEntry],
-      }),
+      }).entry,
     ).toEqual({
       provider: "openai",
       id: "gpt-5.5",
@@ -111,7 +112,7 @@ describe("projectModelCatalogEntryForRoute", () => {
         entry: platformEntry,
         projection: { kind: "selected", route: chatGPTRoute, policy: routePolicy },
         catalog: [platformEntry, chatGPTEntry],
-      }),
+      }).entry,
     ).toEqual({
       provider: "openai",
       id: "gpt-5.5",
@@ -132,7 +133,7 @@ describe("projectModelCatalogEntryForRoute", () => {
         entry: platformEntry,
         projection: { kind: "selected", route: chatGPTRoute, policy: routePolicy },
         catalog: [platformEntry],
-      }),
+      }).entry,
     ).toEqual({
       provider: "openai",
       id: "gpt-5.5",
@@ -189,7 +190,7 @@ describe("projectModelCatalogEntryForRoute", () => {
         .spyOn(activeThinkingPolicy, "resolveActiveProviderThinkingProfile")
         .mockReturnValue({ levels: [{ id: "off" }], defaultLevel: "off" });
       try {
-        const projected = projectModelCatalogEntryForRoute({
+        const { entry: projected } = projectModelCatalogEntryForRoute({
           entry: expectDefined(catalog.entries[0], "prepared route test entry"),
           projection: route
             ? { kind: "selected", route, policy: routePolicy }
@@ -224,7 +225,7 @@ describe("projectModelCatalogEntryForRoute", () => {
       projectModelCatalogEntryForRoute({
         entry: platformEntry,
         projection: { kind: "unmanaged" },
-      }),
+      }).entry,
     ).toBe(platformEntry);
   });
 
@@ -233,12 +234,12 @@ describe("projectModelCatalogEntryForRoute", () => {
       projectModelCatalogEntryForRoute({
         entry: platformEntry,
         projection: { kind: "unresolved", policy: routePolicy },
-      }),
+      }).entry,
     ).toEqual({ provider: "openai", id: "gpt-5.5", name: "GPT-5.5" });
   });
 
   it("does not copy private route policy facts into the catalog row", () => {
-    const projected = projectModelCatalogEntryForRoute({
+    const { entry: projected } = projectModelCatalogEntryForRoute({
       entry: platformEntry,
       projection: { kind: "selected", route: chatGPTRoute, policy: routePolicy },
       catalog: [chatGPTEntry],
@@ -274,7 +275,7 @@ describe("projectModelCatalogEntryForRoute", () => {
         projection: { kind: "selected", route: chatGPTRoute, policy: routePolicy },
         catalog: [platformEntry],
         ...(overrides ? { overrides } : {}),
-      }),
+      }).entry,
     ).toEqual({
       provider: "openai",
       id: "gpt-5.5",

--- a/src/agents/model-catalog-route.ts
+++ b/src/agents/model-catalog-route.ts
@@ -1,5 +1,5 @@
 import { normalizeProviderId } from "@openclaw/model-catalog-core/provider-id";
-/** Projects physical catalog rows for browse/presentation; never runtime execution. */
+/** Projects one physical donor into separate public and private runtime metadata. */
 import { isCanonicalDottedDecimalIPv4, isLoopbackIpAddress } from "@openclaw/net-policy/ip";
 import { normalizeLowercaseStringOrEmpty } from "@openclaw/normalization-core/string-coerce";
 import {
@@ -119,7 +119,7 @@ function applyLogicalOverrides(
 }
 
 /** Finds the exact physical row that supplied a selected provider route. */
-export function findModelCatalogRouteDonor(params: {
+function findModelCatalogRouteDonor(params: {
   entry: ModelCatalogEntry;
   route: ProviderModelRouteCandidate;
   policy: ModelCatalogRoutePolicy;
@@ -140,30 +140,32 @@ export function findModelCatalogRouteDonor(params: {
 }
 
 /**
- * Builds one allowlisted logical catalog row.
+ * Builds public and private runtime rows from one selected physical donor.
  *
  * Selected-route capabilities come only from a physical row accepted by the
  * provider-owned matcher. Unresolved managed routes expose identity only.
  * Auth, runtime, request overrides, and other private transport facts never
- * enter the returned catalog shape.
+ * enter the public catalog shape.
  */
 export function projectModelCatalogEntryForRoute(params: {
   entry: ModelCatalogEntry;
   projection: ModelCatalogRouteProjection;
   catalog?: readonly ModelCatalogEntry[];
   overrides?: ModelCatalogLogicalOverrides;
-}): ModelCatalogEntry {
+}): { entry: ModelCatalogEntry; runtimeEntry: ModelCatalogEntry } {
   if (params.projection.kind === "unmanaged") {
-    return applyLogicalOverrides(params.entry, params.overrides);
+    const entry = applyLogicalOverrides(params.entry, params.overrides);
+    return { entry, runtimeEntry: entry };
   }
   const id =
     params.projection.policy.resolveIdentity(params.entry)?.id ??
     splitTrailingAuthProfile(params.entry.id).model;
   if (params.projection.kind === "unresolved") {
-    return applyLogicalOverrides(
+    const entry = applyLogicalOverrides(
       logicalIdentity(params.entry, id, params.entry.name),
       params.overrides,
     );
+    return { entry, runtimeEntry: entry };
   }
 
   const { policy, route } = params.projection;
@@ -182,7 +184,7 @@ export function projectModelCatalogEntryForRoute(params: {
   );
   // Only the selected physical donor can supply its prepared policy owner.
   const thinkingPolicy = donor?.[PREPARED_THINKING_POLICY];
-  return applyLogicalOverrides(
+  const entry = applyLogicalOverrides(
     {
       ...projected,
       api: route.api,
@@ -199,6 +201,16 @@ export function projectModelCatalogEntryForRoute(params: {
     },
     params.overrides,
   );
+  return {
+    entry,
+    runtimeEntry: donor
+      ? {
+          ...entry,
+          ...(Object.hasOwn(donor, "compat") ? { compat: donor.compat } : {}),
+          ...(Object.hasOwn(donor, "params") ? { params: donor.params } : {}),
+        }
+      : entry,
+  };
 }
 
 /** Returns true for loopback, wildcard, and mDNS local base URLs. */

--- a/src/agents/model-catalog-view.ts
+++ b/src/agents/model-catalog-view.ts
@@ -1,20 +1,18 @@
-/** Keeps raw catalog operands and logical row projection on the same captured input. */
+/** Keeps public and private runtime projections on the same captured catalog. */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
 import type { ModelAuthAvailabilityEvaluation } from "./model-auth-availability.js";
 import {
-  findModelCatalogRouteDonor,
   projectModelCatalogEntryForRoute,
   resolveConfiguredModelCatalogOverrides,
   type ModelCatalogRouteProjection,
 } from "./model-catalog-route.js";
 import type { ModelCatalogEntry } from "./model-catalog.types.js";
-import { buildAllowedModelSet } from "./model-selection-shared.js";
 import {
   openAIModelCatalogRoutePolicy,
   resolveModelCatalogIdentityKey,
 } from "./openai-model-routes.js";
 
-/** Captures route variants without filtering the raw catalog used by execution callers. */
+/** Indexes physical variants for paired logical catalog projection. */
 export function createModelCatalogView(params: {
   cfg: OpenClawConfig;
   catalog: ModelCatalogEntry[];
@@ -37,17 +35,8 @@ export function createModelCatalogView(params: {
     }
   }
   return {
-    // A terminal history or setting callback needs this operand, not projected public rows.
-    catalog: params.catalog,
     logicalEntries: [...logicalEntries.values()],
     variantsOf,
-    selectAgent(paramsForAgent: { agentId?: string; defaultProvider: string }) {
-      return buildAllowedModelSet({
-        cfg: params.cfg,
-        catalog: params.catalog,
-        ...paramsForAgent,
-      }).allowedCatalog;
-    },
     project(entry: ModelCatalogEntry, evaluation: ModelAuthAvailabilityEvaluation) {
       const projection: ModelCatalogRouteProjection =
         evaluation.routeResolution === null
@@ -65,23 +54,12 @@ export function createModelCatalogView(params: {
         entry,
         policy: openAIModelCatalogRoutePolicy,
       });
-      return {
-        entry: projectModelCatalogEntryForRoute({
-          entry,
-          projection,
-          ...(variants ? { catalog: variants } : {}),
-          ...(overrides ? { overrides } : {}),
-        }),
-        donor:
-          projection.kind === "selected"
-            ? findModelCatalogRouteDonor({
-                entry,
-                route: projection.route,
-                policy: openAIModelCatalogRoutePolicy,
-                ...(variants ? { catalog: variants } : {}),
-              })
-            : undefined,
-      };
+      return projectModelCatalogEntryForRoute({
+        entry,
+        projection,
+        ...(variants ? { catalog: variants } : {}),
+        ...(overrides ? { overrides } : {}),
+      });
     },
   };
 }

--- a/src/agents/model-catalog-visibility.test.ts
+++ b/src/agents/model-catalog-visibility.test.ts
@@ -13,6 +13,53 @@ import { createModelVisibilityPolicy } from "./model-visibility-policy.js";
 import { openAIModelCatalogRoutePolicy } from "./openai-model-routes.js";
 
 describe("resolveLogicalVisibleModelCatalog", () => {
+  it.each(["all", "configured", "default"] as const)(
+    "keeps case-distinct configured identities in the %s view",
+    async (view) => {
+      const catalog: ModelCatalogEntry[] = [
+        { provider: "fixture", id: "MixedCase", name: "Large", contextWindow: 64_000 },
+        { provider: "fixture", id: "mixedcase", name: "Small", contextWindow: 16_000 },
+      ];
+      const result = await resolveLogicalVisibleModelCatalog({
+        cfg: { agents: { defaults: { modelPolicy: { allow: ["fixture/*"] } } } },
+        catalog,
+        defaultProvider: "fixture",
+        view,
+        routePolicy: openAIModelCatalogRoutePolicy,
+        evaluateEntry: async () =>
+          resolveLogicalModelCatalogEntryState({
+            evaluation: { availability: true, routeResolution: null },
+            routePolicy: openAIModelCatalogRoutePolicy,
+          }),
+      });
+
+      expect(result).toEqual(expect.arrayContaining(catalog));
+      expect(result).toHaveLength(2);
+    },
+  );
+
+  it("keeps a literal catalog suffix distinct from its base model", async () => {
+    const catalog: ModelCatalogEntry[] = [
+      { provider: "fixture", id: "reader", name: "Base" },
+      { provider: "fixture", id: "reader@variant", name: "Literal variant" },
+    ];
+    const result = await resolveLogicalVisibleModelCatalog({
+      cfg: {},
+      catalog,
+      defaultProvider: "fixture",
+      view: "all",
+      routePolicy: openAIModelCatalogRoutePolicy,
+      evaluateEntry: async () =>
+        resolveLogicalModelCatalogEntryState({
+          evaluation: { availability: true, routeResolution: null },
+          routePolicy: openAIModelCatalogRoutePolicy,
+        }),
+    });
+
+    expect(result).toEqual(expect.arrayContaining(catalog));
+    expect(result).toHaveLength(2);
+  });
+
   const selectedRoute = {
     api: "openai-chatgpt-responses" as const,
     baseUrl: "https://chatgpt.com/backend-api/codex",

--- a/src/agents/model-catalog-visibility.ts
+++ b/src/agents/model-catalog-visibility.ts
@@ -4,6 +4,7 @@
  * auth-backed availability.
  */
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import { dedupeByKey } from "../shared/dedupe-by-key.js";
 import type {
   ModelAuthAvailabilityEvaluation,
   ModelAuthAvailabilityRef,
@@ -19,13 +20,13 @@ import type { ModelCatalogEntry } from "./model-catalog.js";
 import {
   buildConfiguredModelCatalog,
   dedupeModelCatalogEntries,
-  modelCatalogLogicalKey,
 } from "./model-selection-shared.js";
 import {
   RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
   createModelVisibilityPolicy,
   type ModelVisibilityPolicy,
 } from "./model-visibility-policy.js";
+import { resolveModelCatalogIdentityKey } from "./openai-model-routes.js";
 
 type ModelCatalogVisibilityView = "default" | "configured" | "all";
 export type ModelCatalogAuthChecker = (
@@ -65,38 +66,15 @@ function sortModelCatalogEntries(entries: ModelCatalogEntry[]): ModelCatalogEntr
   return entries.toSorted(compareModelCatalogEntries);
 }
 
-function resolveLogicalKey(
-  entry: Pick<ModelCatalogEntry, "provider" | "id">,
-  routePolicy: ModelCatalogRoutePolicy,
-): string {
-  return routePolicy.resolveIdentity(entry)?.key ?? modelCatalogLogicalKey(entry);
-}
-
-function dedupeLogicalModelCatalogEntries(
-  entries: readonly ModelCatalogEntry[],
-  routePolicy: ModelCatalogRoutePolicy,
-) {
-  const seen = new Set<string>();
-  return entries.filter((entry) => {
-    const key = resolveLogicalKey(entry, routePolicy);
-    if (seen.has(key)) {
-      return false;
-    }
-    seen.add(key);
-    return true;
-  });
-}
-
 function isPickerVisibleCatalogEntry(
   entry: ModelCatalogEntry,
   configuredKeys: ReadonlySet<string>,
-  routePolicy: ModelCatalogRoutePolicy,
 ): boolean {
   // Deprecated and disabled rows stay selectable but are picker-hidden.
   // Exact configured refs always remain visible so pinned models never disappear.
   return (
     (entry.status !== "deprecated" && entry.status !== "disabled") ||
-    configuredKeys.has(resolveLogicalKey(entry, routePolicy))
+    configuredKeys.has(resolveModelCatalogIdentityKey(entry))
   );
 }
 
@@ -151,8 +129,7 @@ export async function prepareLogicalVisibleModelCatalog(
       agentId: params.agentId,
       ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
     });
-  const keyOf = (entry: Pick<ModelCatalogEntry, "provider" | "id">) =>
-    resolveLogicalKey(entry, params.routePolicy);
+  const keyOf = resolveModelCatalogIdentityKey;
   const projectionCatalog = params.routeVariants?.length ? params.routeVariants : params.catalog;
   const routeVariantsByKey = new Map<string, ModelCatalogEntry[]>();
   for (const entry of projectionCatalog) {
@@ -162,12 +139,7 @@ export async function prepareLogicalVisibleModelCatalog(
     routeVariantsByKey.set(key, variants);
   }
   const variantsOf = (entry: ModelCatalogEntry) => routeVariantsByKey.get(keyOf(entry)) ?? [entry];
-  const normalizePolicyKey = (key: string) => {
-    const slash = key.indexOf("/");
-    return slash > 0 ? keyOf({ provider: key.slice(0, slash), id: key.slice(slash + 1) }) : key;
-  };
-  const configuredKeys = new Set([...policy.configuredKeys].map(normalizePolicyKey));
-  const retainedKeys = new Set([...policy.retainedKeys].map(normalizePolicyKey));
+  const { configuredKeys, retainedKeys } = policy;
   const retained = params.catalog.filter((entry) => retainedKeys.has(keyOf(entry)));
   const wildcard = policy.allowAny || policy.hasProviderWildcards;
   const configuredCatalog = wildcard
@@ -235,14 +207,12 @@ export async function prepareLogicalVisibleModelCatalog(
             projection,
             catalog: variantsOf(entry),
             ...(cached.overrides ? { overrides: cached.overrides } : {}),
-          });
+          }).entry;
           cached.rows.set(route, row);
         }
         return row;
       });
-      return sortModelCatalogEntries(
-        dedupeLogicalModelCatalogEntries(projected, params.routePolicy),
-      );
+      return sortModelCatalogEntries(dedupeByKey(projected, resolveModelCatalogIdentityKey));
     };
     if (params.view === "all") {
       return projectEntries(params.catalog);
@@ -302,7 +272,7 @@ export async function prepareLogicalVisibleModelCatalog(
     });
     // Selected physical routes must lead dedupe so sibling metadata cannot win.
     return projectEntries([...preferred, ...kept, ...retained, ...routeBacked]).filter((entry) =>
-      isPickerVisibleCatalogEntry(entry, configuredKeys, params.routePolicy),
+      isPickerVisibleCatalogEntry(entry, configuredKeys),
     );
   };
 }

--- a/src/agents/model-selection-shared.ts
+++ b/src/agents/model-selection-shared.ts
@@ -35,6 +35,7 @@ import {
   normalizeProviderId,
 } from "./model-ref-shared.js";
 import { findNormalizedProviderValue, parseModelRef } from "./model-selection-normalize.js";
+import { resolveModelCatalogIdentityKey } from "./openai-model-routes.js";
 
 export { resolvePrimaryStringValue as normalizeModelSelection } from "@openclaw/normalization-core/string-coerce";
 
@@ -1644,13 +1645,6 @@ export type ModelVisibilityPolicy = {
   }) => ModelCatalogEntry[];
 };
 
-/** Canonical logical identity shared by visibility and physical route rows. */
-export function modelCatalogLogicalKey(entry: Pick<ModelCatalogEntry, "provider" | "id">): string {
-  const provider = normalizeProviderId(entry.provider);
-  const model = splitTrailingAuthProfile(entry.id).model;
-  return normalizeLowercaseStringOrEmpty(modelKey(provider, model));
-}
-
 export function dedupeModelCatalogEntries(
   entries: readonly ModelCatalogEntry[],
 ): ModelCatalogEntry[] {
@@ -1686,7 +1680,7 @@ export function createModelVisibilityPolicyWithFallbacks(
   const { visibility, policyAliasIndex, selectionAliasIndex, configuredCatalog } = prepared;
   const wildcardModelKeys = visibility.wildcardModelKeys;
   const allowed = buildAllowedModelSetFromPrepared(params, prepared);
-  const configuredKeys = new Set(configuredCatalog.map(modelCatalogLogicalKey));
+  const configuredKeys = new Set(configuredCatalog.map(resolveModelCatalogIdentityKey));
   const retainedKeys = new Set<string>();
   const addConfiguredRef = (
     raw: string | undefined,
@@ -1709,7 +1703,7 @@ export function createModelVisibilityPolicyWithFallbacks(
     if (!resolved) {
       return undefined;
     }
-    const key = modelCatalogLogicalKey({
+    const key = resolveModelCatalogIdentityKey({
       provider: resolved.ref.provider,
       id: resolved.ref.model,
     });

--- a/src/agents/model-visibility-policy.test.ts
+++ b/src/agents/model-visibility-policy.test.ts
@@ -76,7 +76,8 @@ describe("explicit model visibility policy", () => {
       "demo/primary",
       "demo/fallback",
     ];
-    expect(configuredRefs.filter((key) => !policy.configuredKeys.has(key))).toEqual([]);
+    const configuredKeys = configuredRefs.map((ref) => JSON.stringify(["demo", ref.slice(5)]));
+    expect(configuredKeys.filter((key) => !policy.configuredKeys.has(key))).toEqual([]);
   });
 
   it("keeps overrides open when model entries only configure aliases or params", () => {
@@ -150,7 +151,9 @@ describe("explicit model visibility policy", () => {
         (entry) => entry.provider === "external" && entry.id === "sensitive",
       ),
     ).toBe(false);
-    expect(policy.retainedKeys).toEqual(new Set(["openai/gpt-5.5", "external/sensitive"]));
+    expect(policy.retainedKeys).toEqual(
+      new Set(['["openai","gpt-5.5"]', '["external","sensitive"]']),
+    );
   });
 
   it("allows a configured fallback when the explicit policy also allows it", () => {

--- a/src/auto-reply/reply/commands-models.ts
+++ b/src/auto-reply/reply/commands-models.ts
@@ -23,7 +23,6 @@ import { isRetiredModelPickerProvider } from "../../agents/model-runtime-aliases
 import {
   dedupeModelCatalogEntries,
   LEGACY_MODEL_POLICY_ALLOW_CONFIG_PATH,
-  modelCatalogLogicalKey,
 } from "../../agents/model-selection-shared.js";
 import {
   buildModelAliasIndex,
@@ -33,7 +32,10 @@ import {
   resolveModelRefFromString,
 } from "../../agents/model-selection.js";
 import { createModelVisibilityPolicy } from "../../agents/model-visibility-policy.js";
-import { openAIModelCatalogRoutePolicy } from "../../agents/openai-model-routes.js";
+import {
+  openAIModelCatalogRoutePolicy,
+  resolveModelCatalogIdentityKey,
+} from "../../agents/openai-model-routes.js";
 import { listOpenAIAuthProfileProvidersForAgentRuntime } from "../../agents/openai-routing.js";
 import * as preparedModelCatalog from "../../agents/prepared-model-catalog.js";
 import { getPreparedModelRuntimeAuthStore } from "../../agents/prepared-model-runtime-auth.js";
@@ -235,8 +237,6 @@ async function projectPreparedModelsProviderData(
         }
       : {}),
   });
-  const logicalModelKey = (entry: { provider: string; id: string }) =>
-    openAIModelCatalogRoutePolicy.resolveIdentity(entry)?.key ?? modelCatalogLogicalKey(entry);
   // Configured/default rows may remain visible without auth, but must not
   // reintroduce a model that its provider route contract rejected.
   const incompatibleModelKeys = new Set<string>();
@@ -262,7 +262,7 @@ async function projectPreparedModelsProviderData(
         })),
       });
       if (evaluation.routeResolution?.kind === "incompatible") {
-        incompatibleModelKeys.add(logicalModelKey(entry));
+        incompatibleModelKeys.add(resolveModelCatalogIdentityKey(entry));
       }
       return resolveLogicalModelCatalogEntryState({
         evaluation,
@@ -332,7 +332,7 @@ async function projectPreparedModelsProviderData(
     }
     if (
       incompatibleModelKeys.has(
-        logicalModelKey({ provider: resolved.ref.provider, id: resolved.ref.model }),
+        resolveModelCatalogIdentityKey({ provider: resolved.ref.provider, id: resolved.ref.model }),
       )
     ) {
       return;
@@ -363,7 +363,7 @@ async function projectPreparedModelsProviderData(
   };
 
   for (const entry of visibleCatalog) {
-    if (incompatibleModelKeys.has(logicalModelKey(entry))) {
+    if (incompatibleModelKeys.has(resolveModelCatalogIdentityKey(entry))) {
       continue;
     }
     add(entry.provider, entry.id);
@@ -389,7 +389,10 @@ async function projectPreparedModelsProviderData(
 
   if (
     !incompatibleModelKeys.has(
-      logicalModelKey({ provider: resolvedDefault.provider, id: resolvedDefault.model }),
+      resolveModelCatalogIdentityKey({
+        provider: resolvedDefault.provider,
+        id: resolvedDefault.model,
+      }),
     )
   ) {
     add(resolvedDefault.provider, resolvedDefault.model);

--- a/src/gateway/server-methods/models-list-configured-static.ts
+++ b/src/gateway/server-methods/models-list-configured-static.ts
@@ -98,17 +98,7 @@ export function includeConfiguredStaticCatalogEntries(params: {
     ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
     manifestPlugins: params.metadataSnapshot,
   });
-  const configuredKeys = new Set(
-    [...policy.configuredKeys].map((key) => {
-      const separator = key.indexOf("/");
-      return separator > 0
-        ? resolveModelCatalogIdentityKey({
-            provider: key.slice(0, separator),
-            id: key.slice(separator + 1),
-          })
-        : key;
-    }),
-  );
+  const configuredKeys = policy.configuredKeys;
   const catalog = [...params.snapshot.entries];
   const seen = new Set(catalog.map(resolveModelCatalogIdentityKey));
   for (const entry of params.snapshot.staticEntries) {

--- a/src/gateway/server-methods/models-list-result.ts
+++ b/src/gateway/server-methods/models-list-result.ts
@@ -23,10 +23,7 @@ import {
 import type { ModelCatalogSnapshot, ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { createModelFastModeResolver } from "../../agents/model-fast-mode.js";
 import { modelKey } from "../../agents/model-ref-shared.js";
-import {
-  dedupeModelCatalogEntries,
-  modelCatalogLogicalKey,
-} from "../../agents/model-selection-shared.js";
+import { dedupeModelCatalogEntries } from "../../agents/model-selection-shared.js";
 import {
   createModelVisibilityPolicy,
   RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
@@ -34,6 +31,7 @@ import {
 import {
   createOpenAIModelRoutesResolver,
   openAIModelCatalogRoutePolicy,
+  resolveModelCatalogIdentityKey,
 } from "../../agents/openai-model-routes.js";
 import { publishedModelCatalogOwnerMatchesAgent } from "../../agents/prepared-model-catalog-owner.js";
 import type { ResolvedPublishedModelCatalogOwner } from "../../agents/prepared-model-catalog.types.js";
@@ -103,14 +101,7 @@ export function createGatewayAgentModelCatalogProjector(params: ModelsListAuthPr
         view.logicalEntries.map(async (entry) => {
           const routeVariants = view.variantsOf(entry) ?? [entry];
           const evaluation = evaluateNative(entry, await evaluateEntry(entry, routeVariants));
-          const { entry: projected, donor } = view.project(entry, evaluation);
-          if (donor && Object.hasOwn(donor, "compat")) {
-            projected.compat = donor.compat;
-          }
-          if (donor && Object.hasOwn(donor, "params")) {
-            projected.params = donor.params;
-          }
-          return projected;
+          return view.project(entry, evaluation).runtimeEntry;
         }),
       )),
   };
@@ -493,8 +484,6 @@ export async function prepareModelsListResult(
     manifestPlugins: metadataSnapshot,
   });
   const { evaluateEntry } = projector;
-  const evaluationKey = (entry: ModelCatalogEntry) =>
-    openAIModelCatalogRoutePolicy.resolveIdentity(entry)?.key ?? modelCatalogLogicalKey(entry);
   const evaluations = new Map<string, ModelAuthAvailabilityEvaluation>();
   const readCatalog = await prepareLogicalVisibleModelCatalog({
     cfg,
@@ -511,7 +500,7 @@ export async function prepareModelsListResult(
       const host = await evaluateEntry(entry, variants);
       return () => {
         const evaluation = evaluateNative(entry, host);
-        evaluations.set(evaluationKey(entry), evaluation);
+        evaluations.set(resolveModelCatalogIdentityKey(entry), evaluation);
         const routeManaged = evaluation.routeResolution !== null;
         const syntheticLocal =
           !routeManaged &&
@@ -548,7 +537,7 @@ export async function prepareModelsListResult(
       models: readCatalog()
         .filter(matchesProvider)
         .map((entry) => {
-          const evaluation = evaluations.get(evaluationKey(entry));
+          const evaluation = evaluations.get(resolveModelCatalogIdentityKey(entry));
           if (!evaluation) {
             throw new Error("Model catalog publication omitted prepared auth evaluation");
           }

--- a/src/gateway/worker-environments/inference-runtime.ts
+++ b/src/gateway/worker-environments/inference-runtime.ts
@@ -21,7 +21,6 @@ import { mapThinkingLevel } from "../../agents/embedded-agent-runner/utils.js";
 import { resolveAgentHarnessPolicy } from "../../agents/harness/policy.js";
 import type { ModelCatalogEntry } from "../../agents/model-catalog.types.js";
 import { splitTrailingAuthProfile } from "../../agents/model-ref-profile.js";
-import { modelCatalogLogicalKey } from "../../agents/model-selection-shared.js";
 import {
   buildModelAliasIndex,
   normalizeProviderId,
@@ -32,6 +31,7 @@ import {
   createModelVisibilityPolicy,
   RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
 } from "../../agents/model-visibility-policy.js";
+import { resolveModelCatalogIdentityKey } from "../../agents/openai-model-routes.js";
 import {
   acquireAgentRunPreparedModelRuntime,
   type PreparedModelRuntimeSnapshot,
@@ -406,14 +406,14 @@ async function resolveApprovedModel(params: {
         manifestPlugins: manifestSnapshot,
         ...RUNTIME_MODEL_VISIBILITY_NORMALIZATION,
       });
-      const resolvedKey = modelCatalogLogicalKey({
+      const resolvedKey = resolveModelCatalogIdentityKey({
         provider: resolved.ref.provider,
         id: resolved.ref.model,
       });
       // Retained refs stay approved during cold discovery.
       const known =
         policy.allowedCatalog.some(
-          (entry: ModelCatalogEntry) => resolvedKey === modelCatalogLogicalKey(entry),
+          (entry: ModelCatalogEntry) => resolvedKey === resolveModelCatalogIdentityKey(entry),
         ) || policy.retainedKeys.has(resolvedKey);
       if (!known || !policy.allows(resolved.ref)) {
         runtimeLease.release();
@@ -421,7 +421,7 @@ async function resolveApprovedModel(params: {
       }
       const configuredDefaultProfile =
         resolvedKey ===
-        modelCatalogLogicalKey({ provider: defaultModel.provider, id: defaultModel.model })
+        resolveModelCatalogIdentityKey({ provider: defaultModel.provider, id: defaultModel.model })
           ? splitTrailingAuthProfile(
               resolveAgentEffectiveModelPrimary(lifecycleConfig, target.agentId) ?? "",
             ).profile


### PR DESCRIPTION
Related: #136257, #142100.

## What Problem This Solves

Model browsing collapsed distinct configured IDs when a legacy key lowercased names and removed suffixes. A Gateway with two case-distinct models returned only one.

## Why This Change Was Made

Visibility, configured retention, Gateway evaluation, text browsing, and background matching now use the existing exact-identity owner. Public and private route projections use one selected donor. Provider-owned equivalence, account authorization, and generation checks remain intact.

## User Impact

Distinct model IDs retain their own names, context limits, and capabilities. Public results keep private runtime fields hidden.

Consumers: model visibility, catalog rows, text menus, and runtime matching now preserve exact catalog identities.

## Evidence

The original models.list response lost a configured model; four focused cases reproduced case and suffix collisions. The corrected Gateway returned both models through models.list and chat.metadata, including availability states. All 65 focused cases and formatting checks passed. Required continuous integration had one unrelated channel-startup timeout; [failure details](https://github.com/openclaw/openclaw/pull/142285#issuecomment-5588420195) are retained. Public checks used the source CLI; inference, native accounts, and standalone installation were not tested.
