### PR TITLE
fix(slack): long messages show prose as code after Windows root paths

### DIFF
--- a/docs/channels/slack/media.md
+++ b/docs/channels/slack/media.md
@@ -38,6 +38,7 @@ In a channel with `requireMention: true`, a captionless audio clip can satisfy t
     - `channels.slack.streaming.chunkMode="newline"` enables paragraph-first splitting
     - file sends use Slack upload APIs and can include thread replies (`thread_ts`)
     - long file captions use the first Slack-safe text chunk as the upload comment and send remaining chunks as follow-up messages
+    - text and context blocks preserve code formatting and literal backslashes across section boundaries
     - outbound media cap follows `channels.slack.mediaMaxMb` when configured; otherwise channel sends use MIME-kind defaults from media pipeline
 
     Native Block Kit sections retain all fields even when their combined accessibility text exceeds the preferred text chunk size. Slack's block limits and the 40,000-character message text hard limit still apply.

--- a/extensions/slack/src/format.test.ts
+++ b/extensions/slack/src/format.test.ts
@@ -8,6 +8,16 @@ import {
 import { escapeSlackMrkdwn } from "./monitor/mrkdwn.js";
 
 describe("chunkSlackMrkdwnText", () => {
+  it.each(["`", "```"])("keeps %s code boundaries after literal backslashes", (marker) => {
+    const text = `Path: ${marker}C:\\${marker} ${"ordinary prose ".repeat(220)}done`;
+    const chunks = chunkSlackMrkdwnText(text, 3_000);
+
+    expect(chunks.length).toBeGreaterThan(1);
+    expect(chunks.join("")).toBe(text);
+    expect(chunks.slice(1).every((chunk) => !chunk.includes("`"))).toBe(true);
+    expect(chunks.every((chunk) => chunk.length <= 3_000)).toBe(true);
+  });
+
   it("preserves ordinary whitespace at Slack section boundaries", () => {
     const text = `${"x".repeat(2_998)}  tail`;
     const chunks = chunkSlackMrkdwnText(text, 3_000);

--- a/extensions/slack/src/format.ts
+++ b/extensions/slack/src/format.ts
@@ -201,6 +201,7 @@ const SLACK_FORMAT_PROFILE = FormatCapabilityProfile.define({
 type SlackCodeMarker = "`" | "```";
 const SLACK_ASSISTANT_TRANSCRIPT_PREFIX = "`Assistant:` ";
 
+// Slack mrkdwn backslashes are literal, including immediately before code delimiters.
 function tokenizeSlackMrkdwn(text: string): string[] {
   const tokens: string[] = [];
   for (let index = 0; index < text.length;) {
@@ -230,15 +231,6 @@ function tokenizeSlackMrkdwn(text: string): string[] {
     }
     const character = String.fromCodePoint(codePoint);
     index += character.length;
-    if (character === "\\" && index < text.length) {
-      const escapedCodePoint = text.codePointAt(index);
-      if (escapedCodePoint !== undefined) {
-        const escapedCharacter = String.fromCodePoint(escapedCodePoint);
-        tokens.push(character + escapedCharacter);
-        index += escapedCharacter.length;
-        continue;
-      }
-    }
     tokens.push(character);
   }
   return tokens;
@@ -374,8 +366,6 @@ function projectSlackMrkdwnVisibleText(
       visible = "";
     } else if (!activeMarker && token === ">" && !lineHasVisibleContent) {
       visible = "";
-    } else if (token.startsWith("\\") && token.length > 1) {
-      visible = token.slice(1);
     }
 
     appendSlackVisibleProjection(projection, visible, activeMarker !== undefined);
@@ -458,8 +448,7 @@ export function chunkSlackMrkdwnText(text: string, limit: number): string[] {
     text.includes("&amp;") ||
     text.includes("&lt;") ||
     text.includes("&gt;") ||
-    (text.match(/<[^>\n]+>/gu)?.some(isAllowedSlackAngleToken) ?? false) ||
-    /\\[\s\S]/u.test(text);
+    (text.match(/<[^>\n]+>/gu)?.some(isAllowedSlackAngleToken) ?? false);
   if (!hasProtectedToken) {
     return chunkTextForOutbound(text, limit, { preserveWhitespace: true });
   }

--- a/extensions/slack/src/outbound-delivery.test.ts
+++ b/extensions/slack/src/outbound-delivery.test.ts
@@ -157,6 +157,42 @@ describe("slack outbound shared hook wiring", () => {
     expect(result.results[0]?.receipt?.platformMessageIds).toEqual(["171234.567"]);
   });
 
+  it.each(["text", "context"] as const)(
+    "preserves prose after a Windows root path in long %s presentations",
+    async (type) => {
+      const client = createSlackSendTestClient();
+      sendMessageSlackMock.mockImplementation(
+        async (to: string, text: string, opts: Parameters<typeof sendMessageSlack>[2]) =>
+          await sendMessageSlack(to, text, { ...opts, client }),
+      );
+      const intro = "Install in `C:\\` and continue. ";
+      const text = intro + "Ordinary prose. ".repeat(220) + "Done.";
+
+      const result = await sendDurableMessageBatch({
+        cfg,
+        channel: "slack",
+        to: "C123",
+        payloads: [{ presentation: { blocks: [{ type, text }] } }],
+        accountId: "default",
+      });
+
+      assert(result.status === "sent", "error" in result ? String(result.error) : result.status);
+      expect(client.chat.postMessage).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({
+          blocks: [expect.stringContaining(intro), expect.not.stringContaining("`")].map((chunk) =>
+            type === "context"
+              ? {
+                  type: "context",
+                  elements: [{ type: "mrkdwn", text: chunk, verbatim: true }],
+                }
+              : { type: "section", text: { type: "mrkdwn", text: chunk } },
+          ),
+        }),
+      );
+      expect(result.results[0]?.receipt?.platformMessageIds).toEqual(["171234.567"]);
+    },
+  );
+
   it("preserves a field-rich section and every receipt when native table delivery falls back", async () => {
     const client = createSlackSendTestClient();
     client.chat.postMessage


### PR DESCRIPTION
<details>
<summary>Additional instructions</summary>

This repository-owned branch is editable by maintainers.

</details>

## What Problem This Solves

Fixes an issue where long Slack messages could show ordinary prose as code after a Windows root path such as `C:\`. Text and context presentations gained extra backticks when split into Slack sections, even though the original code span ended before the split.

## Why This Change Was Made

[Slack mrkdwn](https://docs.slack.dev/messaging/formatting-message-text/) treats backslashes literally. The chunker's unsupported escape handling consumed the closing backtick after the path, leaving its code-span tracking open. Remove that escape path and its dead companion branches so real code delimiters retain their meaning.

## User Impact

Long presentation messages preserve literal backslashes and keep code formatting confined to the intended text. Existing section limits, entity handling, and code-block balancing remain intact.

## Evidence

Four regression cases failed before the production change: text and context presentations through the real durable sender, Slack adapter, and Slack sender, plus inline and fenced code cases at the formatter boundary. After repair, 129 tests passed across five formatter and delivery suites. The adapter tests use synthetic Slack API responses; live Slack was not exercised.

Scoped test-graph typechecking, typed lint, formatting, and the Slack documentation check passed. Independent P2 review passed with no actionable findings. Production changes: 2 lines added and 13 removed, net -11; tests: 46 added; docs: 1 added.
