### PR TITLE
fix(gateway): prevent read-only password connection failures

### DIFF
--- a/src/gateway/client.test.ts
+++ b/src/gateway/client.test.ts
@@ -2196,6 +2196,112 @@ describe("GatewayClient connect auth payload", () => {
     client.stop();
   });
 
+  it.each([
+    { label: "default scopes", password: "shared-password", scopes: undefined, token: undefined }, // pragma: allowlist secret
+    {
+      label: "normalized credentials",
+      password: " shared-password ",
+      scopes: ["operator.read"],
+      token: "  ",
+    }, // pragma: allowlist secret
+  ])(
+    "connects read-only password auth without reading unused device credentials ($label)",
+    async ({ password, scopes, token }) => {
+      loadDeviceAuthTokenReadOnlyMock.mockImplementation(() => {
+        throw new Error("SQLite source did not stabilize for read-only inspection");
+      });
+      const onHello = vi.fn();
+      const onConnectError = vi.fn();
+      const client = createClientWithIdentity("device-1", () => {}, {
+        password,
+        token,
+        sharedStateMode: "read-only",
+        scopes,
+        onHelloOk: onHello,
+        onConnectError,
+      });
+
+      try {
+        client.start();
+        const ws = getLatestWs();
+        ws.emitOpen();
+        emitConnectChallenge(ws);
+        expect(onConnectError).not.toHaveBeenCalled();
+        const connect = connectRequestFrom(ws);
+        expect(connect.params).toMatchObject({
+          auth: { password: "shared-password" }, // pragma: allowlist secret
+          scopes: scopes ?? ["operator.admin"],
+          device: { id: "device-1", signature: expect.any(String), nonce: "nonce-1" },
+        });
+        expect(connect.params?.auth).toEqual({ password: "shared-password" }); // pragma: allowlist secret
+        expect(loadDeviceAuthTokenReadOnlyMock).not.toHaveBeenCalled();
+        ws.emitMessage(
+          JSON.stringify({
+            type: "res",
+            id: connect.id,
+            ok: true,
+            payload: {
+              type: "hello-ok",
+              auth: { role: "operator", scopes: ["operator.read"], deviceToken: "issued-token" },
+            },
+          }),
+        );
+        await waitForFast(() => expect(onHello).toHaveBeenCalledOnce());
+        const request = client.request("system.info");
+        const frame = JSON.parse(ws.sent.at(-1) ?? "null");
+        expect(frame.method).toBe("system.info");
+        ws.emitMessage(
+          JSON.stringify({ type: "res", id: frame.id, ok: true, payload: { pid: 123 } }),
+        );
+        await expect(request).resolves.toEqual({ pid: 123 });
+        expect(storeDeviceAuthTokenMock).not.toHaveBeenCalled();
+        expect(clearDeviceAuthTokenMock).not.toHaveBeenCalled();
+      } finally {
+        client.stop();
+      }
+    },
+  );
+
+  it.each([
+    { label: "shared token", options: { token: "shared-token" } },
+    { label: "bootstrap token", options: { bootstrapToken: "bootstrap-token" } },
+    { label: "explicit device token", options: { deviceToken: "device-token" } },
+    { label: "bootstrap preference", options: { preferBootstrapToken: true } },
+    { label: "approval runtime token", options: { approvalRuntimeToken: "approval-token" } },
+    {
+      label: "agent runtime identity token",
+      options: { agentRuntimeIdentityToken: "runtime-token" },
+    },
+    { label: "blank password", options: { password: "  " } },
+    { label: "writable client", options: { sharedStateMode: undefined } },
+  ])("retains stored-device auth failure for $label", ({ options }) => {
+    const failure = new Error("stored device credentials unavailable");
+    loadDeviceAuthTokenReadOnlyMock.mockImplementation(() => {
+      throw failure;
+    });
+    loadDeviceAuthTokenMock.mockImplementation(() => {
+      throw failure;
+    });
+    const onConnectError = vi.fn();
+    const client = createClientWithIdentity("device-1", () => {}, {
+      sharedStateMode: "read-only",
+      password: "shared-password", // pragma: allowlist secret
+      onConnectError,
+      ...options,
+    });
+    try {
+      client.start();
+      const ws = getLatestWs();
+      ws.emitOpen();
+      emitConnectChallenge(ws);
+      expect(onConnectError).toHaveBeenCalledWith(failure);
+      expect(ws.sent).toEqual([]);
+      expect(ws.lastClose).toEqual({ code: 1008, reason: "connect failed" });
+    } finally {
+      client.stop();
+    }
+  });
+
   it("keeps explicit shared auth ahead of origin-scoped auth across reconnects", async () => {
     loadOriginDeviceTokenMock.mockReturnValue({ token: "origin-token" });
     const onReconnectPaused = vi.fn();

--- a/src/gateway/client.ts
+++ b/src/gateway/client.ts
@@ -57,7 +57,7 @@ export type GatewayClientOptions = BaseGatewayClientOptions & {
 function createOpenClawGatewayClientHostDeps(
   overrides?: GatewayClientHostDeps,
   deviceAuthScope?: string,
-  suppressOriginDeviceAuth = false,
+  suppressStoredDeviceAuth = false,
   sharedStateMode?: "read-only",
   preparedDeviceAuth?: DeviceAuthEntry,
 ): GatewayClientHostDeps {
@@ -73,7 +73,7 @@ function createOpenClawGatewayClientHostDeps(
   > = deviceAuthScope
     ? {
         loadDeviceAuthToken: (params) =>
-          suppressOriginDeviceAuth
+          suppressStoredDeviceAuth
             ? null
             : readOnly
               ? loadOriginDeviceTokenReadOnly({ ...params, gatewayScope: deviceAuthScope })
@@ -97,7 +97,7 @@ function createOpenClawGatewayClientHostDeps(
       }
     : readOnly
       ? {
-          loadDeviceAuthToken: loadDeviceAuthTokenReadOnly,
+          loadDeviceAuthToken: suppressStoredDeviceAuth ? () => null : loadDeviceAuthTokenReadOnly,
           storeDeviceAuthToken: () => {},
           clearDeviceAuthToken: () => {},
         }
@@ -139,9 +139,18 @@ export class GatewayClient {
   constructor(opts: GatewayClientOptions) {
     const { deviceAuthScope, preparedDeviceAuth, sharedStateMode, ...baseOptions } = opts;
     const runtimeIdentity = resolveGatewayClientPlatformIdentity(process.platform);
-    const suppressOriginDeviceAuth = Boolean(
-      deviceAuthScope && (baseOptions.token?.trim() || baseOptions.password?.trim()),
-    );
+    // Password-only read-only clients cannot use stored tokens for auth, retry, or persistence.
+    const suppressStoredDeviceAuth =
+      Boolean(deviceAuthScope && (baseOptions.token?.trim() || baseOptions.password?.trim())) ||
+      (!deviceAuthScope &&
+        sharedStateMode === "read-only" &&
+        Boolean(baseOptions.password?.trim()) &&
+        !baseOptions.token?.trim() &&
+        !baseOptions.bootstrapToken?.trim() &&
+        !baseOptions.deviceToken?.trim() &&
+        !baseOptions.approvalRuntimeToken?.trim() &&
+        !baseOptions.agentRuntimeIdentityToken?.trim() &&
+        !baseOptions.preferBootstrapToken);
     for (const value of Object.values(baseOptions.edgeAuthHeaders ?? {})) {
       registerSecretValueForRedaction(value);
     }
@@ -155,7 +164,7 @@ export class GatewayClient {
       hostDeps: createOpenClawGatewayClientHostDeps(
         baseOptions.hostDeps,
         deviceAuthScope,
-        suppressOriginDeviceAuth,
+        suppressStoredDeviceAuth,
         sharedStateMode,
         preparedDeviceAuth,
       ),


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where users making identity-bearing, read-only Gateway calls with only a password could fail before their request was sent when saved device credentials could not be read. Concurrent SQLite WAL writes can trigger this failure even though the connection does not use a saved device token.

## Why This Change Was Made

The OpenClaw client host adapter now skips that unused lookup for unscoped, read-only, password-only connections. Signed device identity, prepared credentials, token/bootstrap routes, writable clients, and SQLite snapshot consistency and source-preservation checks retain their existing behavior.

## User Impact

Password-only read-only clients can connect without depending on unrelated saved device credentials. Connections that need those credentials still fail closed when they cannot be read, and rejected passwords still prevent method dispatch.

## Evidence

- The new WebSocket-flow regression failed on the original production code with the stored-credential read error before `connect` was sent. All 117 client tests pass with the fix, including normalized credentials and excluded authentication routes.
- A separate synthetic API probe uses the real client adapter, actual SQLite token readers, signed device identity and a real localhost WebSocket mock Gateway. With a 16 MiB database and ordinary WAL commits in another process, the baseline fails before dispatch while the fixed password-only client completes `system.info`. Required-token and denied-password controls retain their failures; persisted auth rows remain unchanged and SQLite integrity passes.
- Independent review found no actionable P0–P2 issue. The synthetic API evidence concerns the client connection boundary, not a production Gateway or every SQLite read path.

- Linux Blacksmith Testbox passed all 117 client tests and all six real-WebSocket/SQLite API cases on Node 24.19.0. In one synthetic churn run, the baseline failed before dispatch after 555 ms; the fixed password-only call completed in 24 ms with zero token-snapshot workers. Required-token and denied-password controls remained enforced. [Delegated proof run](https://github.com/openclaw/openclaw/actions/runs/34247757262): the wrapper returned exit 0 and stopped the one-shot lease after success.
