### PR TITLE
fix(terminal): keep wrapped multiline cells aligned

### DIFF
--- a/packages/terminal-core/src/table.test.ts
+++ b/packages/terminal-core/src/table.test.ts
@@ -626,18 +626,18 @@ console.log(JSON.stringify({
     ["colored CRLF", "\r\n", "\x1b[31m", "\x1b[39m"],
     ["linked LF", "\n", "\x1b]8;;https://example.com/\x07", "\x1b]8;;\x07"],
   ])(
-    "preserves blank %s lines at their positions across cells",
+    "preserves blank %s lines without adding rows after wrapped spacing",
     (_label, separator, open, close) => {
       const out = renderTable({
         border: "ascii",
-        width: 30,
+        width: 15,
         columns: [
-          { key: "A", header: "A", flex: true },
-          { key: "B", header: "B", flex: true },
+          { key: "A", header: "A", minWidth: 6, maxWidth: 6 },
+          { key: "B", header: "B", minWidth: 6, maxWidth: 6 },
         ],
         rows: [
           {
-            A: `${open}${["", "alpha", "", "omega", "", ""].join(separator)}${close}`,
+            A: `${open}${["", "Read ", "", "Next", "", ""].join(separator)}${close}`,
             B: "0\n1\n2\n3\n4",
           },
         ],
@@ -653,9 +653,9 @@ console.log(JSON.stringify({
         ),
       ).toEqual([
         ["", "0"],
-        ["alpha", "1"],
+        ["Read", "1"],
         ["", "2"],
-        ["omega", "3"],
+        ["Next", "3"],
         ["", "4"],
       ]);
       if (open) {

--- a/packages/terminal-core/src/table.ts
+++ b/packages/terminal-core/src/table.ts
@@ -251,12 +251,13 @@ function wrapLine(text: string, width: number): string[] {
     ch === " " || ch === "/" || ch === "-" || ch === "_" || ch === ".";
   let skipNextLf = false;
   let hasChar = false;
+  let logicalLineHasOutput = false;
 
   const buf: AnsiToken[] = [];
   let bufVisible = 0;
   let lastBreakIndex: number | null = null;
 
-  // Explicit newlines emit empty buffers too, keeping sibling cell rows aligned.
+  // A soft wrap can empty the buffer before a newline without creating a blank logical line.
   const flushAt = (breakAt: number | null) => {
     // Keep the suffix in its buffer: long zero-width runs can exceed the argument
     // limit of a spread-based copy even when their visible width is small.
@@ -286,7 +287,10 @@ function wrapLine(text: string, width: number): string[] {
     const openOsc8 = activeOsc8 ? `${ESC}]8;${activeOsc8.params};${activeOsc8.uri}${BEL}` : "";
     const closeSgr = activeSgr.map((state) => state.close).join("");
 
-    lines.push(`${content.join("")}${closeOsc8}${closeSgr}`.trimEnd());
+    if (bufVisible > 0 || !logicalLineHasOutput) {
+      lines.push(`${content.join("")}${closeOsc8}${closeSgr}`.trimEnd());
+      logicalLineHasOutput = true;
+    }
     if (breakAt == null || breakAt <= 0) {
       buf.length = 0;
       if (openOsc8) {
@@ -331,6 +335,7 @@ function wrapLine(text: string, width: number): string[] {
       if (ch === "\n" || ch === "\r" || ch === "\r\n") {
         skipNextLf = ch === "\r";
         flushAt(buf.length);
+        logicalLineHasOutput = false;
         return;
       }
       // Soft-wrap remainders reuse the width measured when each token entered the buffer.


### PR DESCRIPTION
## What Problem This Solves

A table cell that fills its width and ends with a space before a newline could insert an extra blank row. For example, `Read \nNext` at four content columns moved `Next` below its neighboring cell's second line.

## Why This Change Was Made

Track whether the current logical line has already emitted output. A soft wrap no longer makes the following newline emit an additional empty row. Buffer handling and ANSI/OSC-8 close/reopen processing still run, preserving the intentional blank-line behavior from #142196.

## User Impact

Multiline CLI tables keep neighboring cells aligned, including colored and linked text. No option, dependency or output format is added.

## Evidence

Strengthened the existing five LF, CR, CRLF, colored and linked blank-line cases without adding test cases. All five failed before the repair and passed afterward. The full owner and sibling suites passed 190 tests; one existing Windows-only test was skipped on macOS.

Selected changed checks passed, including core and test types, lint and import-cycle checks. Independent managed P0–P2 review found no actionable issue. The patch adds five production lines and no net test lines.

Exact-head [CI](https://github.com/openclaw/openclaw/actions/runs/34248459284) passed on attempt 2. The first attempt had a profiler-test timeout and an unrelated managed-handoff restoration assertion failure. Their owner paths were unchanged in the actual tested merge; one failed-job-only retry passed without source, assertion or timeout changes. The original failures and source diagnoses remain recorded; this table repair does not claim to fix their unlocated causes.
