### PR TITLE
docs: align v2026.9.3 framing with release announcement

### DIFF
--- a/docs/releases/2026.9.3.md
+++ b/docs/releases/2026.9.3.md
@@ -1,7 +1,7 @@
 ---
 title: "v2026.9.3"
-summary: "Live browser views, persistent Workshop skills, update rehearsal, and a searchable meeting archive."
-description: "OpenClaw v2026.9.3 brings live browser viewing, native Mac tabs, agent-owned Workshop skills, update rehearsal, meeting transcript search, and improvements across conversations, models, and native apps."
+summary: "Clean update recovery, faster session reconnects, live browser automation, revocable chat links, searchable meeting transcripts, and repository-backed cloud work."
+description: "OpenClaw v2026.9.3 brings clean update recovery and faster session reconnects, with live browser automation, revocable chat sharing, meeting transcript search, and repository-backed work in the cloud."
 keywords:
   - OpenClaw
   - v2026.9.3
@@ -10,9 +10,9 @@ keywords:
 
 # v2026.9.3
 
-OpenClaw v2026.9.3 brings a live view of supported agent browser tabs into the Browser panel, so you can follow pages as they load and change. In the Mac app, links you open yourself sit beside them as native tabs that stay with the window when you switch conversations. Skill Workshop also gives each agent one persistent collection across workspaces, with complete instructions to compare when reviewing a suggestion.
+Updates recover cleanly and sessions reconnect faster in OpenClaw v2026.9.3, helping you get back to work after an interruption.
 
-Supported updates rehearse core and plugin changes before activation, and the meeting library makes saved notes and transcripts searchable. Models settings adds individual account controls and supported account ordering, while fixes across messaging, memory and the native apps help ongoing work survive more interruptions.
+You can also watch browser automation live, share chats with revocable links, search saved meeting transcripts, and run repository-backed work in the cloud.
 
 **Release scale:** 1,844 pull requests, 40 direct commits, and 190 contributors.
 

--- a/docs/releases/2026.9.3.md
+++ b/docs/releases/2026.9.3.md
@@ -1,7 +1,7 @@
 ---
 title: "v2026.9.3"
 summary: "Clean update recovery, faster session reconnects, live browser automation, revocable chat links, searchable meeting transcripts, and repository-backed cloud work."
-description: "OpenClaw v2026.9.3 brings clean update recovery and faster session reconnects, with live browser automation, revocable chat sharing, meeting transcript search, and repository-backed work in the cloud."
+description: "OpenClaw v2026.9.3 brings clean update recovery and faster session reconnects, with live browser automation, revocable chat sharing, meeting transcript search, and repository-backed work in the cloud. It also adds persistent Workshop skills, native Mac tabs, and provider account controls."
 keywords:
   - OpenClaw
   - v2026.9.3
@@ -10,9 +10,9 @@ keywords:
 
 # v2026.9.3
 
-Updates recover cleanly and sessions reconnect faster in OpenClaw v2026.9.3, helping you get back to work after an interruption.
+Updates recover cleanly and sessions reconnect faster in OpenClaw v2026.9.3, helping you get back to work after an interruption. You can also watch browser automation live, share chats with revocable links, search saved meeting transcripts, and run repository-backed work in the cloud.
 
-You can also watch browser automation live, share chats with revocable links, search saved meeting transcripts, and run repository-backed work in the cloud.
+Alongside those highlights, Skill Workshop now keeps each agent's learned skills together across workspaces. The Mac app gains native browser tabs that stay open when you switch conversations, and Models settings adds individual account controls and supported account ordering.
 
 **Release scale:** 1,844 pull requests, 40 direct commits, and 190 contributors.
 

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -11,7 +11,7 @@ changelog first.
 
 ## Releases
 
-- [v2026.9.3](/releases/2026.9.3) - Safer update rehearsal, persistent Workshop skills, live browser views and native Mac tabs, and a searchable meeting library.
+- [v2026.9.3](/releases/2026.9.3) - Clean update recovery, faster session reconnects, live browser automation, revocable chat links, searchable meeting transcripts, and repository-backed cloud work.
 - [v2026.9.2](/releases/2026.9.2) - Reliability and recovery improvements, OpenAI GPT-6 Astra and Meta Muse Spark 1.3 support, and flexible task workspaces.
 - [v2026.9.1](/releases/2026.9.1) - Mermaid diagrams across chat surfaces, a fuller Android experience, safer update recovery, and lower overhead for long conversations and large installations.
 - [v2026.8.2](/releases/2026.8.2) - Home beside your work, a Linux desktop companion, background sessions, browser control without a running Gateway, four new Control UI looks, and focused reply, voice, update, and recovery fixes.

--- a/docs/releases/index.md
+++ b/docs/releases/index.md
@@ -11,7 +11,7 @@ changelog first.
 
 ## Releases
 
-- [v2026.9.3](/releases/2026.9.3) - Clean update recovery, faster session reconnects, live browser automation, revocable chat links, searchable meeting transcripts, and repository-backed cloud work.
+- [v2026.9.3](/releases/2026.9.3) - Clean update recovery, faster session reconnects, live browser automation, revocable chat links, searchable meeting transcripts, and repository-backed cloud work. Also includes persistent Workshop skills, native Mac tabs, and provider account controls.
 - [v2026.9.2](/releases/2026.9.2) - Reliability and recovery improvements, OpenAI GPT-6 Astra and Meta Muse Spark 1.3 support, and flexible task workspaces.
 - [v2026.9.1](/releases/2026.9.1) - Mermaid diagrams across chat surfaces, a fuller Android experience, safer update recovery, and lower overhead for long conversations and large installations.
 - [v2026.8.2](/releases/2026.8.2) - Home beside your work, a Linux desktop companion, background sessions, browser control without a running Gateway, four new Control UI looks, and focused reply, voice, update, and recovery fixes.


### PR DESCRIPTION
Related: #142277

## What Problem This Solves

The merged v2026.9.3 page leads with a different emphasis from the approved release announcement. Readers should encounter the same principal messages in the announcement and the detailed notes.

## Why This Change Was Made

Aligns the opening, page summary/description, and release-index blurb with the approved talking points, in order: clean update recovery, faster session reconnects, live browser automation, revocable chat links, meeting transcript search, and repository-backed cloud work.

Keeps the previous emphasis on Workshop skills, native Mac tabs, and provider account controls as a secondary paragraph and supporting description/index copy. The six approved announcement themes remain the primary lead.

This is a framing-only follow-up. All detailed release content is preserved.

## User Impact

The release page immediately presents the approved release story. All detailed explanations, platform and recovery limits, source references, contributor credits, and release counts remain unchanged.

## Evidence

- Reviewed the changed copy against the approved announcement and the existing detailed topics.
- Focused MDX checks passed for both changed Markdown files.
- Confirmed the release page from its release-scale line through EOF is byte-for-byte unchanged.
- `git diff --check` passed.
- Docs-only copy edit; no new tests, runtime changes, workflow changes, or release publication.

Page: https://docs.openclaw.ai/releases/2026.9.3
