### PR TITLE
improve(agents): avoid unused settings work for reduced prompts

### DIFF
--- a/src/agents/system-prompt-config.test.ts
+++ b/src/agents/system-prompt-config.test.ts
@@ -2,6 +2,7 @@
 // the canonical agent prompt facade.
 import { describe, expect, it, vi } from "vitest";
 import type { OpenClawConfig } from "../config/types.openclaw.js";
+import * as ttsSettings from "../tts/tts-settings.js";
 import { buildConfiguredAgentSystemPrompt } from "./system-prompt-config.js";
 import * as systemPrompt from "./system-prompt.js";
 
@@ -22,6 +23,45 @@ function buildPrompt(config: OpenClawConfig, agentId = "main", sessionKey?: stri
 }
 
 describe("buildConfiguredAgentSystemPrompt", () => {
+  it.each(["minimal", "none"] as const)(
+    "skips full-only preparation in %s mode and refreshes the next full prompt",
+    (promptMode) => {
+      const hint = vi
+        .spyOn(ttsSettings, "buildTtsSystemPromptHint")
+        .mockReturnValue("Fixture first voice guidance.");
+      const models = { "fixture/model": { alias: "Before" } };
+      const params = {
+        config: { agents: { defaults: { models } } },
+        workspaceDir: "/tmp/openclaw",
+        includeMemorySection: false,
+      };
+      try {
+        const full = buildConfiguredAgentSystemPrompt(params);
+        expect(full).toContain("- Before: fixture/model");
+        expect(full).toContain("Fixture first voice guidance.");
+        hint.mockClear();
+        const reduced = buildConfiguredAgentSystemPrompt({ ...params, promptMode });
+        expect(hint).not.toHaveBeenCalled();
+        expect(reduced).not.toContain("## Model Aliases");
+        expect(reduced).not.toContain("## Voice (TTS)");
+        expect(buildConfiguredAgentSystemPrompt(params)).toBe(full);
+
+        models["fixture/model"].alias = "After";
+        hint.mockReturnValue("Fixture current voice guidance.");
+        hint.mockClear();
+        expect(buildConfiguredAgentSystemPrompt({ ...params, promptMode })).toBe(reduced);
+        expect(hint).not.toHaveBeenCalled();
+        const refreshed = buildConfiguredAgentSystemPrompt(params);
+        expect(refreshed).toContain("- After: fixture/model");
+        expect(refreshed).not.toContain("- Before: fixture/model");
+        expect(refreshed).toContain("Fixture current voice guidance.");
+        expect(refreshed).not.toContain("Fixture first voice guidance.");
+      } finally {
+        hint.mockRestore();
+      }
+    },
+  );
+
   it.each([
     { name: "absent", config: undefined },
     { name: "empty", config: {} },

--- a/src/agents/system-prompt-config.ts
+++ b/src/agents/system-prompt-config.ts
@@ -49,19 +49,22 @@ function resolveAgentSystemPromptConfig(params: {
   config?: OpenClawConfig;
   agentId?: string;
   sessionKey?: string;
+  promptMode?: AgentSystemPromptRenderParams["promptMode"];
   sourceReplyDeliveryMode?: AgentSystemPromptRenderParams["sourceReplyDeliveryMode"];
 }): ResolvedAgentSystemPromptConfig {
   const { config, agentId, sessionKey, sourceReplyDeliveryMode } = params;
+  const includeFullSections = params.promptMode !== "minimal" && params.promptMode !== "none";
   return {
     ownerDisplay: "raw",
     ownerDisplaySecret: undefined,
     subagentDelegationMode: resolveMainSessionDelegationMode({ config, agentId, sessionKey }),
-    ttsHint: config
-      ? buildTtsSystemPromptHint(config, agentId, {
-          messageToolOnly: sourceReplyDeliveryMode === "message_tool_only",
-        })
-      : undefined,
-    modelAliasLines: buildModelAliasLines(config),
+    ttsHint:
+      config && includeFullSections
+        ? buildTtsSystemPromptHint(config, agentId, {
+            messageToolOnly: sourceReplyDeliveryMode === "message_tool_only",
+          })
+        : undefined,
+    modelAliasLines: includeFullSections ? buildModelAliasLines(config) : [],
     memoryCitationsMode: config?.memory?.citations,
     fsWorkspaceOnly: resolveEffectiveToolFsWorkspaceOnly({ cfg: config, agentId }),
   };
@@ -75,6 +78,7 @@ export function buildConfiguredAgentSystemPrompt(params: ConfiguredAgentSystemPr
         config,
         agentId,
         sessionKey: renderParams.runtimeInfo?.sessionKey,
+        promptMode: renderParams.promptMode,
         sourceReplyDeliveryMode: renderParams.sourceReplyDeliveryMode,
       })
     : {};


### PR DESCRIPTION
## What Problem This Solves

Minimal and identity-only prompts still read voice preferences and sort configured model aliases, even though neither section is rendered. This adds unused settings I/O and preparation work to reduced-prompt contexts using the configured prompt facade.

## Why This Change Was Made

Pass the existing prompt mode into the private config resolver and prepare voice hints and model aliases only for full prompts. Every later full call still reads current settings. Owner overrides, delegation, memory and filesystem policy stay unchanged; no cache, configuration option or public API is added. Production grows four lines; two transition cases add 40 test lines.

## User Impact

Reduced prompts produce the same text with less preparation work. Full/default behavior stays unchanged, including fresh aliases and voice preferences after a reduced-mode call. These measurements concern the configured prompt builder, not overall agent, Gateway, provider or speech-synthesis latency.

## Evidence

The two new transition cases fail on the original source because reduced modes still call TTS preparation; all 14 existing facade tests pass there. The candidate passes all **222 tests across five complete suites** and **29 normal changed checks**. Independent Codex review through P2 found no actionable issues.

A fixed B0/C0/C1/B1 cohort called the actual facade with unmocked TTS settings and isolated synthetic preference files. Independent data auditing verified all **264 complete returned strings**, including 40 untimed full/reduced/full transitions with real preference-file updates and same-object alias changes. Later full prompts reflect the new values; reduced output remains identical. No product calls were rerun.

Steady medians in microseconds per complete configured-facade call:

| Mode / aliases | Forward baseline → candidate | Reverse baseline → candidate |
| --- | --- | --- |
| Minimal / 32 | 62.625 → 28.292 (−54.82%) | 76.375 → 29.083 (−61.92%) |
| None / 32 | 31.166 → 6.208 (−80.08%) | 40.250 → 6.625 (−83.54%) |
| Minimal / 0 | 42.208 → 24.125 (−42.84%) | 61.083 → 27.667 (−54.71%) |
| Minimal / 512, synthetic stress | 121.167 → 28.667 (−76.34%) | 198.958 → 24.375 (−87.75%) |

First and warmup calls are reported separately; all five steady samples per row remain included. The independent audit reproduced all 80 aggregate comparisons, 112 indexed pairs and 10 resource comparisons. There were 14 adverse aggregates, including three adverse medians, and 16 adverse indexed timings. All three adverse medians were forward full/default controls, higher by 2.958–5.624 µs. Reverse full controls varied substantially in the favorable direction, which is **not attributed to this patch** because those paths are unchanged. Five samples do not establish statistical confidence or population tail latency.

Whole-child wall time, including imports and instrumentation, was 6.033→5.464 seconds forward and 6.238→5.733 seconds reverse. Forward kernel/tree peak RSS rose by approximately 1.0/1.7 MB; reverse kernel peak was unchanged and tree peak slightly lower. No startup or allocation improvement is inferred from those readings. All processes closed and candidate source was restored before committing.

Local proof used Node 26.8.1 on macOS at base `1ff45cad`; the reviewed owners and caller context were unchanged on inspected main `6939d37`. Fresh exact-head PR CI remains the integration gate. Reduced modes intentionally no longer create distinct internal prefix-cache entries for unused alias lists; the existing cache bound, full/minimal separation and resulting prompt bytes are preserved.
