### PR TITLE
test(ui): join gateway event-log fixture teardown

### DIFF
--- a/ui/src/app/gateway-store.event-log.test.ts
+++ b/ui/src/app/gateway-store.event-log.test.ts
@@ -34,8 +34,9 @@ describe("application gateway diagnostic history ownership", () => {
     store.current().opts.onEvent?.(A_EVENT);
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     store.gateway.stop();
+    await vi.dynamicImportSettled();
     setAvatarGatewayOrigin(null);
     vi.unstubAllGlobals();
     vi.restoreAllMocks();


### PR DESCRIPTION
## What Problem This Solves

The gateway event-log fixture could finish while its lazy snapshot invalidation import was still running. [CI recorded 17 environment-teardown errors](https://github.com/openclaw/openclaw/actions/runs/34242781974/job/102118548246) after all 5,443 UI assertions passed.

## Why This Change Was Made

Stop the fake gateway, await Vitest's pending dynamic imports, then restore globals and mocks. This matches the existing authentication fixture and lets the actual cleanup finish within its test environment.

## User Impact

Test cleanup follows the asynchronous work it started. Production behavior, assertions, timeouts, mocks and error filters are unchanged.

## Evidence

The unchanged local event-log suite passed 21 cases without reproducing the CI scheduling failure. After the repair, the same 21 cases and 27 authentication/boot-record sibling cases passed without teardown errors. The original CI failure remains the failing evidence; this does not claim a local before/after reproduction.

Selected changed checks and independent managed P0–P2 review passed. Root verified the baseline sources against the exact CI merge. Hosted validation of this fixture change is pending.
