### PR TITLE
fix(release): calculate Sparkle builds in symlinked checkouts

### DIFF
--- a/scripts/sparkle-build.ts
+++ b/scripts/sparkle-build.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env -S node --import tsx
 // Sparkle Build script supports OpenClaw repository automation.
 
-import { pathToFileURL } from "node:url";
+import { realpathSync } from "node:fs";
+import { isDirectRunUrl } from "./lib/direct-run.mjs";
 
 export type SparkleBuildFloors = {
   releaseKey: number;
@@ -135,6 +136,6 @@ function runCli(args: string[]): number {
   return 0;
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+if (process.argv[1] && isDirectRunUrl(realpathSync(process.argv[1]), import.meta.url)) {
   process.exit(runCli(process.argv.slice(2)));
 }

--- a/test/appcast.test.ts
+++ b/test/appcast.test.ts
@@ -1,5 +1,9 @@
 // Appcast tests validate generated update appcast metadata.
-import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { expectDefined } from "@openclaw/normalization-core";
 import { describe, expect, it } from "vitest";
 import { canonicalSparkleBuildFromVersion } from "../scripts/sparkle-build.ts";
@@ -13,6 +17,35 @@ type AppcastItem = {
 };
 
 describe("canonicalSparkleBuildFromVersion", () => {
+  it.each(["direct", "linked"])("runs the CLI from a %s checkout path", (kind) => {
+    const fixture = mkdtempSync(path.join(tmpdir(), "sparkle-cli-"));
+    try {
+      const repo = fileURLToPath(new URL("../", import.meta.url));
+      const linkedRepo = path.join(fixture, "checkout");
+      symlinkSync(repo, linkedRepo, "junction");
+      const script = path.join(kind === "linked" ? linkedRepo : repo, "scripts/sparkle-build.ts");
+      for (const [version, status, stdout] of [
+        ["2026.9.3", 0, "2609000390\n"],
+        ["invalid", 1, ""],
+      ] as const) {
+        const result = spawnSync(
+          process.execPath,
+          ["--import", "tsx", script, "canonical-build", version],
+          {
+            cwd: repo,
+            encoding: "utf8",
+            timeout: 10_000,
+          },
+        );
+        expect(result.error).toBeUndefined();
+        expect(result.status, result.stderr).toBe(status);
+        expect(result.stdout).toBe(stdout);
+      }
+    } finally {
+      rmSync(fixture, { recursive: true, force: true });
+    }
+  });
+
   it("keeps pre-transition appcast builds on the legacy date key", () => {
     expect(canonicalSparkleBuildFromVersion("2026.6.2")).toBe(2026060290);
   });


### PR DESCRIPTION
## What Problem This Solves

Resolves a problem where local Mac release packaging cannot calculate its Sparkle build number when the checkout path contains a directory symlink, including macOS `/tmp`. The CLI exits successfully but prints nothing.

## Why This Change Was Made

Resolve the executable path before comparing it with the module URL through the existing direct-run helper, matching the repository's Android CLI pattern. Canonical build calculations and packaging callers are unchanged. The existing appcast suite now invokes the actual CLI through direct and linked checkout paths, including invalid input.

## User Impact

Maintainers can run release packaging from symlinked worktrees. No published artifact, appcast, package version, or signing policy changes.

## Evidence

On the current main source, the direct CLI returns `2609000390`, while the linked path exits zero with empty output. Both paths return the correct number after this repair. All eight appcast tests pass, including valid and invalid CLI inputs; independent P2 review is clean. The complete changed-file gate also passes. [Exact-head CI passed](https://github.com/openclaw/openclaw/actions/runs/34249550909).

The directory-link case uses a Windows junction-compatible fixture, but local execution was on macOS; no Windows execution is claimed.

<details>
<summary>Additional instructions</summary>
This same-repository branch is editable by maintainers. Release-note context stays here; the release-owned changelog is unchanged.
</details>
