### PR TITLE
perf(ui): preload Inbox panel before opening

### DIFF
--- a/ui/src/components/sidebar-attention.test.ts
+++ b/ui/src/components/sidebar-attention.test.ts
@@ -228,8 +228,7 @@ describe("sidebar attention refresh ownership", () => {
     const { element, trigger } = await mountAttention();
     trigger.click();
 
-    await import("./sidebar-attention-panel.runtime.ts");
-    await element.updateComplete;
+    await waitForFast(() => expect(element.querySelector(".sidebar-issues-panel")).not.toBeNull());
     const panel = element.querySelector(".sidebar-issues-panel");
     expect(panel).not.toBeNull();
     expect(panel?.closest("openclaw-menu-surface")).not.toBeNull();

--- a/ui/src/components/sidebar-attention.ts
+++ b/ui/src/components/sidebar-attention.ts
@@ -8,6 +8,7 @@ import type { MentionsCapability } from "../app/mentions.ts";
 import type { UpdateProgress } from "../app/update-confirmation.ts";
 import { t } from "../i18n/index.ts";
 import { canCallGatewayMethod } from "../lib/gateway-methods.ts";
+import { createIdleImport } from "../lib/idle-import.ts";
 import { OpenClawLightDomElement } from "../lit/openclaw-element.ts";
 import { SubscriptionsController } from "../lit/subscriptions-controller.ts";
 import "../styles/sidebar-attention-floating.css";
@@ -26,7 +27,6 @@ import "./tooltip.ts";
 
 type SidebarAttentionPanelRenderer =
   typeof import("./sidebar-attention-panel.runtime.ts").renderSidebarAttentionPanel;
-type SidebarAttentionPanelRuntime = typeof import("./sidebar-attention-panel.runtime.ts");
 type UpdateProgressWatcher = (listener: (progress: UpdateProgress) => void) => () => void;
 // Display is stylesheet-owned (layout.css `display: contents` in the footer,
 // flex when floating): the LightDomContents base's inline display would defeat
@@ -52,7 +52,9 @@ class SidebarAttention extends OpenClawLightDomElement {
   private panelTrigger: HTMLElement | null = null;
   private mentions: MentionsCapability | null = null;
   private panelRenderer: SidebarAttentionPanelRenderer | null = null;
-  private panelLoad: Promise<SidebarAttentionPanelRuntime> | null = null;
+  private readonly panelLoad = createIdleImport(
+    () => import("./sidebar-attention-panel.runtime.ts"),
+  );
   private panelGeneration = 0;
 
   private readonly subscriptions = new SubscriptionsController(this)
@@ -77,6 +79,8 @@ class SidebarAttention extends OpenClawLightDomElement {
     super.connectedCallback();
     this.mentions =
       this.context?.sidebarAttention.activate(SidebarAttentionStoreController) ?? null;
+    // Idle callbacks can run after the first click on a busy page.
+    this.preloadPanel();
     // Dismissal belongs to the connected Inbox, including while its panel imports.
     document.addEventListener("pointerdown", this.handleOutsideInteraction, true);
     document.addEventListener("keydown", this.handleOutsideInteraction, true);
@@ -85,6 +89,7 @@ class SidebarAttention extends OpenClawLightDomElement {
   override disconnectedCallback() {
     document.removeEventListener("pointerdown", this.handleOutsideInteraction, true);
     document.removeEventListener("keydown", this.handleOutsideInteraction, true);
+    this.panelLoad.dispose();
     this.closePanel(false);
     this.subscriptions.clear();
     super.disconnectedCallback();
@@ -125,12 +130,15 @@ class SidebarAttention extends OpenClawLightDomElement {
     }
   };
 
+  private readonly preloadPanel = () => {
+    void this.panelLoad.load().catch(() => undefined);
+  };
+
   private async openPanel(trigger: HTMLElement) {
     const generation = ++this.panelGeneration;
     // The pending open owns Escape before its lazy panel can handle keyboard events.
     this.panelTrigger = trigger;
-    this.panelLoad ??= import("./sidebar-attention-panel.runtime.ts");
-    const panelRuntime = await this.panelLoad;
+    const panelRuntime = await this.panelLoad.load();
     if (!this.isConnected || generation !== this.panelGeneration) {
       return;
     }
@@ -298,6 +306,9 @@ class SidebarAttention extends OpenClawLightDomElement {
         aria-haspopup="dialog"
         aria-controls="sidebar-issues-panel"
         aria-label=${label}
+        @pointerenter=${this.preloadPanel}
+        @focus=${this.preloadPanel}
+        @pointerdown=${this.preloadPanel}
         @click=${(event: MouseEvent) => {
           const trigger = event.currentTarget;
           if (!(trigger instanceof HTMLElement)) {

--- a/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
+++ b/ui/src/e2e/native-nav-sidebar-toggle.e2e.test.ts
@@ -248,11 +248,16 @@ suite.define(() => {
   it.each(["navigation", "replacement open", "reconnection", "outside pointer", "Escape"] as const)(
     "keeps pending Inbox intent current across %s",
     async (action) => {
-      const page = await openPage({ pathname: "new" });
-      const held = await holdModuleResponse(
-        page,
-        /\/assets\/sidebar-attention-panel\.runtime-[^/?]+\.js(?:\?.*)?$/u,
-      );
+      let held!: Awaited<ReturnType<typeof holdModuleResponse>>;
+      const page = await openPage({
+        pathname: "new",
+        beforeNavigate: async (targetPage) => {
+          held = await holdModuleResponse(
+            targetPage,
+            /\/assets\/sidebar-attention-panel\.runtime-[^/?]+\.js(?:\?.*)?$/u,
+          );
+        },
+      });
       const attention = await page
         .locator("openclaw-app-sidebar openclaw-sidebar-attention")
         .elementHandle();

--- a/ui/src/e2e/sidebar-inbox-latency.e2e.test.ts
+++ b/ui/src/e2e/sidebar-inbox-latency.e2e.test.ts
@@ -87,7 +87,7 @@ suite.define(() => {
       await expectInboxOnNextFrame(page, populated);
 
       await page.locator(".sidebar-recent-session__link").first().click();
-      await page.waitForLoadState("networkidle");
+      await page.getByRole("textbox", { name: "Chat composer", exact: true }).waitFor();
       await expectInboxOnNextFrame(page, populated);
 
       const connections = await gateway.getRequests("connect");

--- a/ui/src/e2e/sidebar-inbox-latency.e2e.test.ts
+++ b/ui/src/e2e/sidebar-inbox-latency.e2e.test.ts
@@ -1,0 +1,109 @@
+import type { Page } from "playwright";
+import { expect, it } from "vitest";
+import { installMockGateway } from "../test-helpers/control-ui-e2e.ts";
+import { chatSessionListResponse } from "./chat-flow.test-support.ts";
+import { createSidebarCustomizationSuite } from "./sidebar-customization.test-support.ts";
+
+const suite = createSidebarCustomizationSuite("Control UI Inbox opening latency");
+
+async function expectInboxOnNextFrame(page: Page, populated: boolean) {
+  const frame = await page.locator(".sidebar-issues-button").evaluate(
+    (button) =>
+      new Promise<{ visible: boolean; hasItem: boolean; hasSkeleton: boolean }>((resolve) => {
+        // Start at a frame boundary so host scheduling cannot turn a paint
+        // contract into a wall-clock timeout on shared CI runners.
+        requestAnimationFrame(() => {
+          (button as HTMLButtonElement).click();
+          requestAnimationFrame(() => {
+            const panel = document.querySelector<HTMLElement>("#sidebar-issues-panel");
+            const style = panel && getComputedStyle(panel);
+            resolve({
+              visible: Boolean(
+                panel &&
+                panel.getBoundingClientRect().height > 0 &&
+                style?.visibility === "visible" &&
+                style.opacity === "1",
+              ),
+              hasItem: Boolean(panel?.querySelector('[data-attention-kind="cronFailed"]')),
+              hasSkeleton: Boolean(panel?.querySelector('[class*="skeleton"]')),
+            });
+          });
+        });
+      }),
+  );
+  expect(frame).toEqual({ visible: true, hasItem: populated, hasSkeleton: false });
+  if (!populated) {
+    await page.locator(".sidebar-issues-panel__empty").waitFor();
+  }
+  await page.keyboard.press("Escape");
+  await page.locator("#sidebar-issues-panel").waitFor({ state: "detached" });
+}
+
+suite.define(() => {
+  it.each([false, true])("opens loaded Inbox on the next frame (items: %s)", async (populated) => {
+    const context = await suite.newBrowserContext({
+      locale: "en-US",
+      reducedMotion: populated ? "no-preference" : "reduce",
+      viewport: { width: 1440, height: 900 },
+    });
+    const page = await context.newPage();
+    const jobs = populated
+      ? [
+          {
+            id: "inbox-latency-job",
+            name: "Daily report",
+            enabled: true,
+            createdAtMs: 0,
+            updatedAtMs: 0,
+            schedule: { kind: "every", everyMs: 60_000 },
+            sessionTarget: "isolated",
+            wakeMode: "now",
+            payload: { kind: "agentTurn", message: "Prepare the report." },
+            state: { lastRunStatus: "error", lastError: "Report failed" },
+          },
+        ]
+      : [];
+    const gateway = await installMockGateway(page, {
+      methodResponses: {
+        "sessions.list": chatSessionListResponse(),
+        "cron.list": {
+          jobs,
+          snapshotRevision: "inbox-latency",
+          total: jobs.length,
+          offset: 0,
+          limit: 50,
+          hasMore: false,
+          nextOffset: null,
+        },
+        "models.authStatus": { ts: 1, providers: [] },
+      },
+    });
+    try {
+      await page.goto(`${suite.server.baseUrl}new`);
+      await gateway.waitForRequest("cron.list");
+      await page.locator(".sidebar-issues-button").waitFor();
+      await page.waitForLoadState("networkidle");
+      await expectInboxOnNextFrame(page, populated);
+      await expectInboxOnNextFrame(page, populated);
+
+      await page.locator(".sidebar-recent-session__link").first().click();
+      await page.waitForLoadState("networkidle");
+      await expectInboxOnNextFrame(page, populated);
+
+      const connections = await gateway.getRequests("connect");
+      await gateway.closeLatest();
+      await gateway.waitForRequest("connect", { after: connections.length });
+      await page.locator(".sidebar-issues-button").waitFor();
+      await expectInboxOnNextFrame(page, populated);
+
+      const reads = await gateway.getRequests("cron.list");
+      await gateway.deferNext("cron.list");
+      await gateway.emitGatewayEvent("cron", { action: "finished" });
+      await gateway.waitForRequest("cron.list", { after: reads.length });
+      await expectInboxOnNextFrame(page, populated);
+      await gateway.resolveDeferred("cron.list");
+    } finally {
+      await suite.closeBrowserContext(context);
+    }
+  });
+});

--- a/ui/src/styles/sidebar-issues.css
+++ b/ui/src/styles/sidebar-issues.css
@@ -19,8 +19,6 @@
   background: var(--bg-elevated);
   color: var(--text);
   box-shadow: var(--shadow-sm);
-  /* Scaling during entry skews the tab group's keyboard-scroll measurements. */
-  animation: fade-in 140ms var(--ease-out);
 }
 
 .sidebar-issues-panel__backdrop,


### PR DESCRIPTION
## What Problem This Solves

Opening the sidebar Inbox waited for the panel's dynamic import before rendering, then started a 140 ms desktop fade from zero opacity. The measured first-click median was 504.5 ms even with Inbox entries already available.

Closes #142254.

## Why This Change Was Made

Prepare the existing lazy panel module when the sidebar connects and on pointer/focus intent, using the existing import helper. Remove the desktop entry fade. Starting preparation at connection matters: waiting for an idle callback still left cold imports on the first click under load.

The panel renders the existing owner's entries directly, including while a refresh is pending. No parallel data cache or skeleton is introduced. Production changes total +15/−6 lines (net +9). Scope-upgrade activation remains at actual opening; cancellation and focus generation checks remain in place.

## User Impact

On a ready desktop sidebar, the populated or empty Inbox appears fully visible on the next available frame after activation. Reopening, switching sessions, and reconnecting retain this behavior. Mobile sheet motion and reduced-motion behavior retain their existing rules.

## Evidence

Ten fresh browser contexts per revision, each exercising first opening, second opening, session change, and reconnection. Synthetic canonical approval fixture, 1440 × 900 desktop viewport, ready data, and completed startup requests. Values are milliseconds from pointerdown to the first sampled frame with a visible panel; nearest-rank percentiles (with ten samples, p95 is the maximum).

| Scenario | Before mean | After mean | Before p50 | After p50 | Before p95 | After p95 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| First click | 530.2 | 173.0 | 504.5 | 157.6 | 701.7 | 323.2 |
| Second click | 116.3 | 76.6 | 111.1 | 73.8 | 213.0 | 118.2 |
| After session change | 131.8 | 130.2 | 134.2 | 97.3 | 251.9 | 253.4 |
| After reconnection | 114.1 | 96.2 | 94.8 | 82.8 | 203.6 | 195.3 |

All 40 final openings were fully visible on the first sampled animation frame after activation, with zero Inbox module requests during their click intervals. The first-opening full-opacity median fell from 609.2 to 157.7 ms. The remaining first/second-click medians (157.6/73.8 ms) include panel rendering/layout and scheduling on the shared host: panel DOM appeared at medians of 109.7/48.6 ms, and trace 0 measured first/repeated click dispatch at 101.9/30.3 ms elapsed and 31.3/16.6 ms thread CPU; no opening RPC or Inbox module request was awaited, and tab initialization was not timed separately. First-opening font requests completed after visibility in all ten samples; two samples also contained an independent background `question.list` request.

The baseline trace separates the causes: click-time panel import began at 8.6 ms, transitive modules/styles loaded through 163.5 ms, panel DOM appeared at 256.8 ms, first visible frame at 369.7 ms, and full opacity at 480.4 ms. A complete-series trace recorded 17 resources and a 161 ms main-thread task spanning module evaluation and tab initialization. Initial/repeated/session opening sent no Gateway RPC; reconnection recovery can fetch mentions independently. Fonts were a separate resource, not the explicit opening gate.

A separate startup comparison used ten paired fresh contexts on warmed development servers, alternating revision order. Navigation to the first visible Inbox trigger plus fixture badge measured mean 6863.2 → 7256.8 ms, p50 6450.3 → 6765.8 ms, and p95 9068.0 → 9436.3 ms (before → after). Main-thread task CPU through network idle averaged 1483.8 → 1490.4 ms. These whole-page measurements include other idle-loaded modules and shared-host scheduling, so they do not isolate Inbox cost or demonstrate zero startup overhead. The panel entry response completed before the visible trigger in nine of ten after samples; in the remaining sample it finished 56.1 ms later. Response completion alone does not prove the full import graph has evaluated.

The pair below was recaptured on the rebased base/head in equivalent synthetic fixtures with the Discord invitation dismissed. It shows the first sampled frame after activation; the timing table above retains the original ten-context campaign.

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td><a href="https://github.com/user-attachments/assets/a761e24c-d0e4-44b3-a945-420be9e2a085"><img src="https://github.com/user-attachments/assets/a761e24c-d0e4-44b3-a945-420be9e2a085" alt="Before: Inbox absent on the first frame, invitation dismissed" width="640"></a><br><a href="https://github.com/user-attachments/assets/a761e24c-d0e4-44b3-a945-420be9e2a085">Open before capture</a></td>
<td><a href="https://github.com/user-attachments/assets/09fac460-6600-44dd-ba2e-54381924446b"><img src="https://github.com/user-attachments/assets/09fac460-6600-44dd-ba2e-54381924446b" alt="After: populated Inbox fully visible on the first frame, invitation dismissed" width="640"></a><br><a href="https://github.com/user-attachments/assets/09fac460-6600-44dd-ba2e-54381924446b">Open after capture</a></td>
</tr>
</table>

Validation:

- 58 component/store/import-helper tests passed.
- Standard bundled browser lane: 10 selected tests passed across four files, covering populated/empty next-frame opening, pending refresh, five delayed-import cancellation paths, passive approvals, mobile sheet motion, and reduced motion. The two new latency cases failed the original implementation at next-frame visibility.
- Canonical control smoke: tab contents/status, two approval decisions, bulk dismissal to empty, Inbox toggle, and Escape/focus after opening passed.
- Post-rebase validation passed on `2a60370378a28fc73a2b211f53d76f56817f1a03`: all 58 owner/helper tests, all 10 selected bundled browser cases, and the full required changed-file check (17 test type graphs, UI types, repository guards, three zero-entry unused-export scans, and targeted lint/stylelint). Each command completed with exit 0.
- Post-rebase validation exposed a test setup race: the session-opening check could click Inbox before the chat route finished applying. The test now waits for the visible Chat composer before measuring the next frame; both populated and empty cases passed, and the timing assertions are unchanged.
- Independent review completed with no remaining actionable findings.
- Exact-head hosted CI completed green on `2a60370378a28fc73a2b211f53d76f56817f1a03` ([run 34276364129](https://github.com/openclaw/openclaw/actions/runs/34276364129)); no reruns were needed.

**Risk and coverage**

Startup tradeoff decision: retain preparation in the existing presenter/import lifecycle, render the shared store directly, and preserve cancellation, focus, scope-upgrade and mobile-motion boundaries. This intentionally pays the module cost earlier, including when Inbox is never opened; the startup sample above does not prove that cost is free. Preparation moves module download/evaluation to sidebar startup; an activation before preparation finishes can still await the module. The measurements cover a ready sidebar, not every possible cold-network condition. The shared host was saturated: an input dispatch took 101.9 ms elapsed but 31.3 ms thread CPU. These results establish first-available-frame rendering in the tested flows; they do not establish a universal <50 ms wall-clock guarantee. The after-session p95 did not improve materially.

Consumers checked: sidebar Inbox presenter and its store/import owner (58 tests); native navigation pending opens (five cancellation cases); approval flow (passive decisions); mobile Inbox sheet (normal and reduced motion). Existing top-layer/Escape/focus assertions remain covered; `native-nav-sidebar-toggle.e2e.test.ts` only moves the delayed-module interceptor before navigation so preloading cannot bypass it; all existing assertions remain unchanged. It removes no fade wait—the fade removal is in production CSS.

Separate existing behavior observed during the control smoke: after bulk dismissal hides its focused button, Escape can lose the panel's keyboard handler. The dismissal and keyboard-handler code is unchanged; this is recorded for a separate repair. Mocked proof does not cover live Gateway latency or an operator's graphical browser session.
