### PR TITLE
perf(plugin-state): cover live-row quota scans

### DIFF
--- a/docs/reference/database-schemas.md
+++ b/docs/reference/database-schemas.md
@@ -20,6 +20,26 @@ OpenClaw stores control-plane state in a global SQLite database and agent data i
 
 The task registry uses the global control-plane database. Runtime trajectory events live with their sessions in the per-agent database or a configured shared session SQLite store.
 
+### Plugin state listing index
+
+Plugin keyed stores use the shared `plugin_state_entries` table. Its listing
+index includes `expires_at` after the existing plugin, namespace, creation-time,
+and entry-key columns, so live-row counts can read the index without fetching
+stored values. Quotas, TTL cutoffs, ordering, and row contents are unchanged.
+
+Writable startup and `openclaw doctor --fix` replace the older four-column
+definition through canonical index repair, without a schema-version bump. The
+repair builds temporary indexes and runs the existing table and full-file
+integrity checks; allow for extra disk space and work proportional to stored
+entries during the first repair.
+
+An older build can rebuild the same index back to its expected definition.
+Full-schema read-only validation rejects a mismatched definition until a
+writable owner repairs it; lightweight readers that validate only the numeric
+schema version may read either shape. See the
+[accepted index design](https://github.com/openclaw/openclaw/issues/142244) for
+upgrade, reverse-repair, and performance proof requirements.
+
 ### Mentions Inbox
 
 The [mentions Inbox](/concepts/multi-user#temporary-mentions-inbox) uses existing

--- a/src/state/openclaw-state-db.test.ts
+++ b/src/state/openclaw-state-db.test.ts
@@ -4806,6 +4806,69 @@ INSERT INTO macos_port_guardian_records VALUES (4242, 18789, '/usr/bin/ssh', 're
     );
   });
 
+  it.each(["runtime", "doctor"])(
+    "upgrades the plugin listing index through %s without rewriting entries",
+    (repairPath) => {
+      const stateDir = createTempStateDir();
+      const options = { env: { OPENCLAW_STATE_DIR: stateDir } };
+      const databasePath = materializeCurrentStateDatabase(stateDir);
+      const { DatabaseSync } = requireNodeSqlite();
+      const legacy = new DatabaseSync(databasePath);
+      const entriesSql =
+        "SELECT * FROM plugin_state_entries ORDER BY plugin_id, namespace, entry_key";
+      const metadataSql =
+        "SELECT role, agent_id, schema_version, app_version FROM schema_meta WHERE meta_key = 'primary'";
+      let entries: unknown;
+      let metadata: unknown;
+      try {
+        legacy.exec(`
+          DROP INDEX idx_plugin_state_listing;
+          CREATE INDEX idx_plugin_state_listing
+            ON plugin_state_entries(plugin_id, namespace, created_at, entry_key);
+          INSERT INTO plugin_state_entries VALUES
+            ('plugin', 'written', 'live', '{ "value": 1 }', 10, NULL),
+            ('plugin', 'written', 'at-cutoff', '{ "value": 2 }', 10, 1000),
+            ('plugin', 'sibling', 'expired', '{ "value": 3 }', 20, 999),
+            ('plugin', 'sibling', 'future', '{ "value": 4 }', 20, 1001),
+            ('peer', 'written', 'live', '{ "value": 5 }', 10, NULL);
+        `);
+        entries = legacy.prepare(entriesSql).all();
+        metadata = legacy.prepare(metadataSql).get();
+        expect(metadata).toMatchObject({
+          schema_version: OPENCLAW_STATE_SCHEMA_VERSION,
+          app_version: VERSION,
+        });
+      } finally {
+        legacy.close();
+      }
+
+      if (repairPath === "doctor") {
+        const repaired = repairOpenClawStateDatabaseSchema(options);
+        expect(repaired.warnings).toEqual([]);
+        expect(repaired.changes).toContain("Rebuilt canonical shared-state SQLite indexes (1)");
+      }
+      const upgraded = openOpenClawStateDatabase(options);
+      expect(
+        upgraded.db
+          .prepare("PRAGMA index_info(idx_plugin_state_listing)")
+          .all()
+          .map((row) => row.name),
+      ).toEqual(["plugin_id", "namespace", "created_at", "entry_key", "expires_at"]);
+      expect(upgraded.db.prepare(entriesSql).all()).toEqual(entries);
+      expect(upgraded.db.prepare(metadataSql).get()).toEqual(metadata);
+      expect(readSqliteNumberPragma(upgraded.db, "user_version")).toBe(
+        OPENCLAW_STATE_SCHEMA_VERSION,
+      );
+      const schemaVersion = readSqliteNumberPragma(upgraded.db, "schema_version");
+      closeOpenClawStateDatabaseForTest();
+
+      const reopened = openOpenClawStateDatabase(options);
+      expect(readSqliteNumberPragma(reopened.db, "schema_version")).toBe(schemaVersion);
+      expect(reopened.db.prepare(entriesSql).all()).toEqual(entries);
+      expect(reopened.db.prepare(metadataSql).get()).toEqual(metadata);
+    },
+  );
+
   it("repairs same-version Claw bootstrap columns before runtime schema validation", () => {
     const stateDir = createTempStateDir();
     const env = { OPENCLAW_STATE_DIR: stateDir };

--- a/src/state/openclaw-state-schema.sql
+++ b/src/state/openclaw-state-schema.sql
@@ -1274,7 +1274,7 @@ CREATE INDEX IF NOT EXISTS idx_plugin_state_expiry
   WHERE expires_at IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_plugin_state_listing
-  ON plugin_state_entries(plugin_id, namespace, created_at, entry_key);
+  ON plugin_state_entries(plugin_id, namespace, created_at, entry_key, expires_at);
 
 CREATE TABLE IF NOT EXISTS channel_ingress_events (
   queue_name TEXT NOT NULL,

--- a/src/state/sqlite-query-plan.test.ts
+++ b/src/state/sqlite-query-plan.test.ts
@@ -88,18 +88,32 @@ describe("sqlite hot query plans", () => {
          LIMIT 50
       `,
     });
-    expectPlanUsesIndex({
-      db: database.db,
-      indexName: "idx_plugin_state_listing",
-      params: ["telegram", "kv"],
-      sql: `
+    const pluginListingPlan = explainQueryPlan(
+      database.db,
+      `
         SELECT entry_key, value_json
           FROM plugin_state_entries
          WHERE plugin_id = ? AND namespace = ?
          ORDER BY created_at ASC, entry_key
          LIMIT 50
       `,
-    });
+      ["telegram", "kv"],
+    );
+    expect(pluginListingPlan).toContain("idx_plugin_state_listing");
+    expect(pluginListingPlan).not.toContain("USE TEMP B-TREE FOR ORDER BY");
+    for (const namespace of [undefined, "kv"]) {
+      expectPlanIncludes({
+        db: database.db,
+        expected: "USING COVERING INDEX idx_plugin_state_listing",
+        params: namespace ? ["telegram", namespace, 1000] : ["telegram", 1000],
+        sql: `
+          SELECT count(*)
+            FROM plugin_state_entries
+           WHERE plugin_id = ? ${namespace ? "AND namespace = ?" : ""}
+             AND (expires_at IS NULL OR expires_at > ?)
+        `,
+      });
+    }
     expectPlanUsesIndex({
       db: database.db,
       indexName: "idx_channel_ingress_pending",


### PR DESCRIPTION
Closes #142244

## What Problem This Solves

Memory workspace updates and other plugin-state writes do avoidable synchronous database work when a plugin has many stored entries. The namespace and plugin quota checks need expiry data that is absent from the existing listing index, forcing SQLite to look up the corresponding table rows.

## Why This Change Was Made

Append `expires_at` to the existing nonunique listing index so the unchanged live-row counts and namespace expiry selection can use covering access. The index name and ordering prefix remain intact. Existing writable startup and Doctor owners repair the old named definition inside their current fences, transactions, and integrity checks; older writable owners can reverse the definition. The accepted storage and upgrade decision is recorded in #142244.

## User Impact

Plugin-state writes avoid table lookups for these checks while keeping the same scalar calls, expiry cutoffs, quotas, eviction/error ordering, transactions, and scheduling yields. The schema version is unchanged. First repair builds indexes and performs the existing integrity checks, requiring temporary disk space and startup work. Full-schema read-only consumers still require the matching index definition before use.

## Evidence

- Three regression cases failed on the original definition and passed after the change: covering COUNT access, runtime upgrade, and Doctor repair. All 334 focused tests passed, with one existing skip, including rollback, corruption, write authority, expiry/caps, import and workspace fairness. The full changed gate passed.
- Eleven separate-process real-owner stages passed locally and in Linux Testbox: canonical predecessor creation, full-schema read-only refusals, writable upgrade, idempotent reopen, old-owner reverse repair, re-upgrade, Doctor repair, and failed runtime/Doctor validation retaining the old index and data. Every child exited naturally and every owned process group closed. The failure proof combines inspected source ordering with retained final state; it does not trace transient DDL.
- The actual workspace helper and store API passed four fixed shapes on both platforms. Each 64-row replacement still issued 64 plugin COUNTs and 64 namespace COUNTs; counts and namespace expiry selection became covering, peer rows stayed unchanged, and the existing yields exposed committed progress.

Linux Node 24.19.0 results, medians of three warm-cache observations per variant:

| Plugin rows / namespace shape | Original | Changed |
| --- | ---: | ---: |
| 512 dense | 29.083 ms | 18.215 ms |
| 8,192 sparse | 134.351 ms | 32.546 ms |
| 50,000 sparse | 801.268 ms | 149.182 ms |
| 50,000 dense | 2,135.172 ms | 535.457 ms |

Dense fixtures place all plugin rows in the updated namespace; sparse fixtures place only the 64 overwritten rows there. Dense final listing still materializes all namespace entries, and changed dense heartbeat gaps remained 179–192 ms. These are synthetic helper/store measurements under observed, uncontrolled host load; they exclude enclosing workspace-lock admission, plugin trust dispatch, and Gateway/agent handling. No production-latency or CPU claim follows.

A separate canonical-copy supplement measured full owner open at 226.774 ms for the already-canonical predecessor and 561.368 ms for four-to-five-column repair on Linux. The baseline schema cookie stayed unchanged; the candidate advanced it while preserving rows and other schema definitions. Repair grew the 83,124,224-byte database to 89,174,016 bytes, with 1,661 free pages and a 12,281,752-byte WAL observed after open. These are one warm-cache pair and point-in-time footprints, not isolated DDL cost or cumulative write amplification.

The original workload’s separate owner-open fixture also triggered SQL-text normalization on its baseline, so that observation is not used as a no-repair comparison. A later local cost-harness preflight stopped before owner execution on a JSON object-prototype comparison; it remains retained, and the corrected supplement used fresh copies. The 64-write measurements were not repeated or relabeled.

The source-bound Linux proof used [Blacksmith Testbox run 34246080546](https://github.com/openclaw/openclaw/actions/runs/34246080546). Independent source and artifact review passed; managed autoreview found no actionable P0–P2 defect. No query, schema-version, configuration, or production TypeScript changes were needed.
