### PR TITLE
fix(update): derive the Node upgrade hint from the target engine range

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -339,7 +339,9 @@ vi.mock("../infra/update-check-package-target.js", () => ({
   fetchNpmPackageTargetStatus: vi.fn(),
 }));
 
-vi.mock("../infra/runtime-guard.js", () => ({
+vi.mock("../infra/runtime-guard.js", async (importOriginal) => ({
+  // Keep the real range helpers; only the compatibility verdict is scripted here.
+  ...(await importOriginal<typeof import("../infra/runtime-guard.js")>()),
   nodeVersionSatisfiesEngine,
   parseSemver: (version: string | null) => {
     if (!version) {

--- a/src/cli/update-cli/update-command-service-plan.test.ts
+++ b/src/cli/update-cli/update-command-service-plan.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { resolvePackageRuntimePreflight } from "./update-command-service-plan.js";
+
+describe("resolvePackageRuntimePreflight", () => {
+  it("derives the upgrade hint from the target package's engine range", async () => {
+    // A floor above every Node line, so this fails on any runtime the tests run under.
+    const result = await resolvePackageRuntimePreflight({
+      target: { version: "2027.1.0", nodeEngine: ">=90.2.0 <91 || >=92.5.0" },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error).toContain("The requested package requires >=90.2.0 <91 || >=92.5.0.");
+    expect(result.error).toContain(
+      "Upgrade to Node 90.2.0+ below 91 or Node 92.5.0+, then rerun `openclaw update`.",
+    );
+    expect(result.error).not.toContain("24.16.0");
+  });
+});

--- a/src/cli/update-cli/update-command-service-plan.ts
+++ b/src/cli/update-cli/update-command-service-plan.ts
@@ -10,7 +10,7 @@ import { summarizeGatewayServiceLayout } from "../../daemon/service-layout.js";
 import type { GatewayServiceCommandConfig } from "../../daemon/service-types.js";
 import { resolveGatewayService } from "../../daemon/service.js";
 import { assertGatewayServiceMutationAllowed } from "../../infra/gateway-supervision.js";
-import { nodeVersionSatisfiesEngine } from "../../infra/runtime-guard.js";
+import { listNodeEngineClauses, nodeVersionSatisfiesEngine } from "../../infra/runtime-guard.js";
 import { parseTcpPortFromArgs } from "../../infra/tcp-port.js";
 import { runCommandWithTimeout } from "../../process/exec.js";
 import { resolveNodeRunner } from "./shared.js";
@@ -144,13 +144,19 @@ export async function resolvePackageRuntimePreflight(params: {
   const runtimeLabel = runtime.nodeRunner
     ? `Node ${runtime.version ?? "unknown"} at ${runtime.nodeRunner}`
     : `Node ${runtime.version ?? "unknown"}`;
+  // The floors must come from the target package's own engine range: the
+  // installed release predates the target, so any literal here is stale as
+  // soon as the target raises its floor.
+  const targetFloors = listNodeEngineClauses(target.nodeEngine)
+    ?.map(({ minimum, below }) => (below ? `Node ${minimum}+ below ${below}` : `Node ${minimum}+`))
+    .join(" or ");
   return resultError(
     [
       `${runtimeLabel} is too old for openclaw@${targetVersion}.`,
       `The requested package requires ${target.nodeEngine}.`,
       runtime.nodeRunner
         ? "Upgrade the Node runtime that owns the managed Gateway service, then rerun `openclaw update`."
-        : "Upgrade to Node 24.16.0+ or Node 26.1.0+, then rerun `openclaw update`.",
+        : `Upgrade to ${targetFloors ?? "a Node version in that range"}, then rerun \`openclaw update\`.`,
       "Bare `npm i -g openclaw` can silently install an older compatible release.",
       "After upgrading Node, use `npm i -g openclaw@latest`.",
     ].join("\n"),

--- a/src/infra/runtime-guard.ts
+++ b/src/infra/runtime-guard.ts
@@ -172,6 +172,28 @@ function parseMinimumNodeEngine(engine: string | null): Semver | null {
   return parseSemver(match[1] ?? null);
 }
 
+/**
+ * Lists each `||` clause of a supported engine range as its minimum version
+ * and optional exclusive upper bound, in range order, or null when any
+ * clause uses unsupported syntax.
+ */
+export function listNodeEngineClauses(
+  engine: string | null,
+): Array<{ minimum: string; below?: string }> | null {
+  if (!engine) {
+    return null;
+  }
+  const clauses: Array<{ minimum: string; below?: string }> = [];
+  for (const clause of engine.split("||")) {
+    const match = clause.match(ENGINE_CLAUSE_RE);
+    if (!match?.[1]) {
+      return null;
+    }
+    clauses.push(match[2] ? { minimum: match[1], below: match[2] } : { minimum: match[1] });
+  }
+  return clauses;
+}
+
 /** Returns whether a Node version satisfies a supported engine range, or null if unsupported. */
 export function nodeVersionSatisfiesEngine(
   version: string | null,


### PR DESCRIPTION
Fixes #142208

## What Problem This Solves

When `openclaw update` refuses a target because the running Node is too old, the failure prints the target's engine range and then a remediation line naming Node floors that do not satisfy that range. On 2026.9.2 updating to 2026.9.3 the output is:

```
Node 22.23.2 is too old for openclaw@2026.9.3.
The requested package requires >=24.16.0 <25 || >=26.1.0.
Upgrade to Node 22.22.3+, Node 24.15.0+, or Node 25.9.0+, then rerun `openclaw update`.
```

Following the printed advice cannot resolve the failure.

## Why This Change Was Made

The requirement line is interpolated from the target package, but the remediation line was a hardcoded literal describing the *installed* release's engines. #140672 re-synced that literal when it raised the floor, which is exactly why every user still on the previous release now sees contradictory advice. The same drift recurs on every future engine bump.

`resolvePackageRuntimePreflight` now builds the floors from `target.nodeEngine` through a small `listNodeEngineClauses` helper in `runtime-guard.ts`, which already owns the engine-range grammar used by `nodeVersionSatisfiesEngine`. Each clause keeps its exclusive upper bound, so `>=24.16.0 <25 || >=26.1.0` renders as `Node 24.16.0+ below 25 or Node 26.1.0+` rather than implying that Node 25 qualifies. The error path is only reachable when every clause parsed, so the floors are always available there.

Why concrete floors instead of "see the range above": the range line is exact but asks the operator to read semver syntax; the remediation line is where the next useful step belongs, and it now cannot drift from the range it is derived from.

## User Impact

The remediation line always names floors that satisfy the range printed above it, for whichever release is being installed. No behavior change on the managed-service branch, which keeps its generic advice.

## Evidence

**Before (real flow):** `openclaw@2026.9.2` installed with npm into an isolated prefix, run under Node 22.23.2 against the live registry:

```
$ openclaw update --no-restart --yes
⚠️ OpenClaw update failed: node-runtime-preflight.
Node 22.23.2 is too old for openclaw@2026.9.3.
The requested package requires >=24.16.0 <25 || >=26.1.0.
Upgrade to Node 22.22.3+, Node 24.15.0+, or Node 25.9.0+, then rerun `openclaw update`.
```

**Regression test:** `src/cli/update-cli/update-command-service-plan.test.ts` asks for a target whose range is `>=90.2.0 <91 || >=92.5.0` and requires the hint to read `Upgrade to Node 90.2.0+ below 91 or Node 92.5.0+`. On unfixed main it fails with the stale `Node 24.16.0+ or Node 26.1.0+` literal.

**After (packaged build of this head, b960df2) with a same-fixture control:** [this comment](https://github.com/openclaw/openclaw/pull/142321#issuecomment-5589622773). Unfixed 2026.9.2 and this branch run against the same loopback packument (`>=24.20.0 <25 || >=26.4.0`) and the same state directory: the old build prints `Upgrade to Node 22.22.3+, Node 24.15.0+, or Node 25.9.0+`, this branch prints `Upgrade to Node 24.20.0+ below 25 or Node 26.4.0+`. Earlier transcript at 273d9a7: [comment](https://github.com/openclaw/openclaw/pull/142321#issuecomment-5588638348).

### Data-model and upgrade compatibility proof

The diff changes hint construction, the range helper, and tests only; the SQLite schema, its migrations, and the update-run store are untouched. Upgrade compatibility is verified on an existing state directory: the unfixed 2026.9.2 build created the state, then this branch's packaged build (b960df2, identical tree to the current head) opened the same directory and ran the same refusal path. Observed, full transcript in [this comment](https://github.com/openclaw/openclaw/pull/142321#issuecomment-5589622773):

| | 2026.9.2 run | b960df2 run |
|---|---|---|
| `.schema update_runs` | 25 lines | identical (`diff` empty) |
| `update_runs` rows | 1 failed preflight run | existing row preserved unchanged; the new run appended with the same shape |
| `PRAGMA user_version` | 15 | 16, applied by main's existing migration on open, unrelated to this diff |

`check:changed` on this head also passed the repository's native state schema version guard (v16) and the database-first legacy-store guard. No migration is required; existing state remains compatible and upgrade compatibility is verified.
