### PR TITLE
fix(update): correct misleading Node compatibility guidance

### DIFF
--- a/src/cli/update-cli.test.ts
+++ b/src/cli/update-cli.test.ts
@@ -10439,8 +10439,10 @@ describe("update-cli", () => {
     expect(serviceStop).not.toHaveBeenCalled();
     expect(defaultRuntime.exit).not.toHaveBeenCalled();
     const report = getLogOutput();
-    expect(report).toContain(`Node 22.18.0 at ${serviceNode} is too old`);
-    expect(report).toContain("Upgrade the Node runtime that owns the managed Gateway service");
+    expect(report).toContain(`Node 22.18.0 at ${serviceNode} is incompatible`);
+    expect(report).toContain(
+      "Use a compatible version of the Node runtime that owns the managed Gateway service",
+    );
   });
 
   it("runs managed service package follow-up commands with the service Node despite heap argv", async () => {

--- a/src/cli/update-cli/update-command-service-plan.test.ts
+++ b/src/cli/update-cli/update-command-service-plan.test.ts
@@ -1,32 +1,47 @@
 import { describe, expect, it } from "vitest";
 import { resolvePackageRuntimePreflight } from "./update-command-service-plan.js";
 
-describe("resolvePackageRuntimePreflight", () => {
-  it("refers to the printed engine range in the upgrade hint", async () => {
-    const result = await resolvePackageRuntimePreflight({
-      target: { version: "2027.1.0", nodeEngine: ">=90.2.0 <91 || >=92.5.0" },
+describe("package runtime compatibility guidance", () => {
+  for (const { name, engine } of [
+    {
+      name: "reports the full target range when Node is below its minimum",
+      engine: ">=90.2.0 <91 || >=92.5.0",
+    },
+    {
+      name: "reports incompatibility when Node exceeds an exclusive upper bound",
+      engine: ">=22.22.3 <23",
+    },
+  ]) {
+    it(name, async () => {
+      const version = "2027.1.0";
+      const result = await resolvePackageRuntimePreflight({
+        target: { version, nodeEngine: engine },
+      });
+      if (result.ok) {
+        throw new Error("Expected an incompatible Node runtime to be refused");
+      }
+      expect(result.error.split("\n")).toHaveLength(5);
+      expect(result.error).toContain(`The requested package requires ${engine}.`);
+      const runtime = `Node ${process.versions.node}`;
+      expect(result.error, "Node compatibility guidance must describe the target range").toBe(
+        [
+          `${runtime} is incompatible with openclaw@${version}.`,
+          `The requested package requires ${engine}.`,
+          "Use a Node runtime that satisfies the engine range above, then rerun `openclaw update`.",
+          "Bare `npm i -g openclaw` can silently install an older compatible release.",
+          "After switching Node versions, use `npm i -g openclaw@latest`.",
+        ].join("\n"),
+      );
     });
+  }
 
-    expect(result.ok).toBe(false);
-    if (result.ok) {
-      return;
-    }
-    expect(result.error).toContain("The requested package requires >=90.2.0 <91 || >=92.5.0.");
-    expect(result.error).toContain(
-      "Upgrade to a Node runtime that satisfies the engine range above",
-    );
+  it("preserves a compatible target", async () => {
+    await expect(
+      resolvePackageRuntimePreflight({ target: { version: "2027.1.0", nodeEngine: ">=20.0.0" } }),
+    ).resolves.toEqual({ ok: true, value: { targetVersion: "2027.1.0" } });
   });
 
-  it("does not suggest a version excluded by an upper bound", async () => {
-    const result = await resolvePackageRuntimePreflight({
-      target: { version: "2027.1.0", nodeEngine: ">=28.0.0 <29" },
-    });
-
-    expect(result.ok).toBe(false);
-    if (result.ok) {
-      return;
-    }
-    expect(result.error).toContain(">=28.0.0 <29");
-    expect(result.error).not.toContain("28.0.0+");
+  it("preserves an absent target", async () => {
+    await expect(resolvePackageRuntimePreflight({})).resolves.toEqual({ ok: true, value: {} });
   });
 });

--- a/src/cli/update-cli/update-command-service-plan.test.ts
+++ b/src/cli/update-cli/update-command-service-plan.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { resolvePackageRuntimePreflight } from "./update-command-service-plan.js";
+
+describe("resolvePackageRuntimePreflight", () => {
+  it("refers to the printed engine range in the upgrade hint", async () => {
+    const result = await resolvePackageRuntimePreflight({
+      target: { version: "2027.1.0", nodeEngine: ">=90.2.0 <91 || >=92.5.0" },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error).toContain("The requested package requires >=90.2.0 <91 || >=92.5.0.");
+    expect(result.error).toContain(
+      "Upgrade to a Node runtime that satisfies the engine range above",
+    );
+  });
+
+  it("does not suggest a version excluded by an upper bound", async () => {
+    const result = await resolvePackageRuntimePreflight({
+      target: { version: "2027.1.0", nodeEngine: ">=28.0.0 <29" },
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+    expect(result.error).toContain(">=28.0.0 <29");
+    expect(result.error).not.toContain("28.0.0+");
+  });
+});

--- a/src/cli/update-cli/update-command-service-plan.ts
+++ b/src/cli/update-cli/update-command-service-plan.ts
@@ -150,7 +150,7 @@ export async function resolvePackageRuntimePreflight(params: {
       `The requested package requires ${target.nodeEngine}.`,
       runtime.nodeRunner
         ? "Upgrade the Node runtime that owns the managed Gateway service, then rerun `openclaw update`."
-        : "Upgrade to Node 24.16.0+ or Node 26.1.0+, then rerun `openclaw update`.",
+        : "Upgrade to a Node runtime that satisfies the engine range above, then rerun `openclaw update`.",
       "Bare `npm i -g openclaw` can silently install an older compatible release.",
       "After upgrading Node, use `npm i -g openclaw@latest`.",
     ].join("\n"),

--- a/src/cli/update-cli/update-command-service-plan.ts
+++ b/src/cli/update-cli/update-command-service-plan.ts
@@ -146,13 +146,13 @@ export async function resolvePackageRuntimePreflight(params: {
     : `Node ${runtime.version ?? "unknown"}`;
   return resultError(
     [
-      `${runtimeLabel} is too old for openclaw@${targetVersion}.`,
+      `${runtimeLabel} is incompatible with openclaw@${targetVersion}.`,
       `The requested package requires ${target.nodeEngine}.`,
       runtime.nodeRunner
-        ? "Upgrade the Node runtime that owns the managed Gateway service, then rerun `openclaw update`."
-        : "Upgrade to a Node runtime that satisfies the engine range above, then rerun `openclaw update`.",
+        ? "Use a compatible version of the Node runtime that owns the managed Gateway service, then rerun `openclaw update`."
+        : "Use a Node runtime that satisfies the engine range above, then rerun `openclaw update`.",
       "Bare `npm i -g openclaw` can silently install an older compatible release.",
-      "After upgrading Node, use `npm i -g openclaw@latest`.",
+      "After switching Node versions, use `npm i -g openclaw@latest`.",
     ].join("\n"),
   );
 }

--- a/src/infra/runtime-guard.ts
+++ b/src/infra/runtime-guard.ts
@@ -158,6 +158,23 @@ function parseMinimumNodeEngine(engine: string | null): Semver | null {
   return parseSemver(match[1] ?? null);
 }
 
+/** Lists the minimum version of each `||` clause in a supported engine range, or null on unsupported syntax. */
+function listNodeEngineMinimums(engine: string | null): Semver[] | null {
+  if (!engine) {
+    return null;
+  }
+  const minimums: Semver[] = [];
+  for (const clause of engine.split("||")) {
+    const match = clause.match(ENGINE_CLAUSE_RE);
+    const minimum = match?.[1] ? parseSemver(match[1]) : null;
+    if (!minimum) {
+      return null;
+    }
+    minimums.push(minimum);
+  }
+  return minimums.length > 0 ? minimums : null;
+}
+
 /** Returns whether a Node version satisfies a supported engine range, or null if unsupported. */
 export function nodeVersionSatisfiesEngine(
   version: string | null,
@@ -168,7 +185,8 @@ export function nodeVersionSatisfiesEngine(
     return isNodeVersionAtLeast(parseNodeReleaseVersion(version), minimum);
   }
 
-  if (!engine) {
+  const clauseMinimums = listNodeEngineMinimums(engine);
+  if (!engine || !clauseMinimums) {
     return null;
   }
   const parsed = parseNodeReleaseVersion(version);
@@ -178,17 +196,13 @@ export function nodeVersionSatisfiesEngine(
 
   const clauses = engine.split("||");
   let satisfied = false;
-  for (const clause of clauses) {
-    const match = clause.match(ENGINE_CLAUSE_RE);
-    if (!match) {
-      return null;
-    }
-    const clauseMinimum = parseSemver(match[1] ?? null);
-    const upperRaw = match[2];
+  for (const [i, clauseMinimum] of clauseMinimums.entries()) {
+    const match = clauses[i]?.match(ENGINE_CLAUSE_RE);
+    const upperRaw = match?.[2];
     const upper = upperRaw
       ? parseSemver(upperRaw.includes(".") ? upperRaw : `${upperRaw}.0.0`)
       : null;
-    if (!clauseMinimum || (upperRaw && !upper)) {
+    if (upperRaw && !upper) {
       return null;
     }
     if (isAtLeast(parsed, clauseMinimum) && (!upper || !isAtLeast(parsed, upper))) {

--- a/src/infra/runtime-guard.ts
+++ b/src/infra/runtime-guard.ts
@@ -158,23 +158,6 @@ function parseMinimumNodeEngine(engine: string | null): Semver | null {
   return parseSemver(match[1] ?? null);
 }
 
-/** Lists the minimum version of each `||` clause in a supported engine range, or null on unsupported syntax. */
-function listNodeEngineMinimums(engine: string | null): Semver[] | null {
-  if (!engine) {
-    return null;
-  }
-  const minimums: Semver[] = [];
-  for (const clause of engine.split("||")) {
-    const match = clause.match(ENGINE_CLAUSE_RE);
-    const minimum = match?.[1] ? parseSemver(match[1]) : null;
-    if (!minimum) {
-      return null;
-    }
-    minimums.push(minimum);
-  }
-  return minimums.length > 0 ? minimums : null;
-}
-
 /** Returns whether a Node version satisfies a supported engine range, or null if unsupported. */
 export function nodeVersionSatisfiesEngine(
   version: string | null,
@@ -185,8 +168,7 @@ export function nodeVersionSatisfiesEngine(
     return isNodeVersionAtLeast(parseNodeReleaseVersion(version), minimum);
   }
 
-  const clauseMinimums = listNodeEngineMinimums(engine);
-  if (!engine || !clauseMinimums) {
+  if (!engine) {
     return null;
   }
   const parsed = parseNodeReleaseVersion(version);
@@ -196,13 +178,17 @@ export function nodeVersionSatisfiesEngine(
 
   const clauses = engine.split("||");
   let satisfied = false;
-  for (const [i, clauseMinimum] of clauseMinimums.entries()) {
-    const match = clauses[i]?.match(ENGINE_CLAUSE_RE);
-    const upperRaw = match?.[2];
+  for (const clause of clauses) {
+    const match = clause.match(ENGINE_CLAUSE_RE);
+    if (!match) {
+      return null;
+    }
+    const clauseMinimum = parseSemver(match[1] ?? null);
+    const upperRaw = match[2];
     const upper = upperRaw
       ? parseSemver(upperRaw.includes(".") ? upperRaw : `${upperRaw}.0.0`)
       : null;
-    if (upperRaw && !upper) {
+    if (!clauseMinimum || (upperRaw && !upper)) {
       return null;
     }
     if (isAtLeast(parsed, clauseMinimum) && (!upper || !isAtLeast(parsed, upper))) {


### PR DESCRIPTION
## What Problem This Solves

Fixes an issue where `openclaw update` recommends Node versions that contradict the requested package's engine range. It also calls an incompatible version “too old” when it exceeds an exclusive upper bound.

## Why This Change Was Made

Refer to the complete target range already displayed and use direction-neutral wording throughout the message. Managed Gateway advice still identifies the runtime that owns the service. Four production lines replace four lines; the canonical parser, runtime selection and update behavior remain unchanged. The latest bot migration-proof checkbox is inapplicable: this four-string diagnostic rewrite changes no configuration, schema or persisted data.

## User Impact

Operators receive consistent guidance for choosing a compatible Node runtime and retrying the update. Thanks to @SunnyShu0925.

Closes #142208
Related: #142321 (the same underlying diagnostic issue).

## Evidence

[Baseline proof](https://github.com/steipete/openclaw/actions/runs/34289891442) reproduced both incorrect messages, with compatible and absent-target controls passing. The [refreshed candidate proof](https://github.com/steipete/openclaw/actions/runs/34310080906) passed all four owner cases and 16 checks, then hit its 15-minute deadline during core-test typechecking. That run remains failed; its retained overlay was not restored. The earlier candidate run also remains failed at a subsequently resolved upstream compatibility-record check.

[CI for the published commit](https://github.com/openclaw/openclaw/actions/runs/34316006896) passed. Its actual checkout and jobs independently cover the complete core-test graph, all five core-lint partitions and the remaining mapped guards. The three repair files match the focused proof, and both committed-head source reviews are clean.

The [two remaining canonical guards](https://github.com/steipete/openclaw/actions/runs/34348780290) passed on the published commit: `check:media-download-helpers` and `check:runtime-sidecar-loaders`. Both completed with exact output, unchanged inputs, joined processes, removed temporary state and clean final source audits. Final native landing gates still apply. This proof does not execute an update, installation or managed-service operation; the broad managed-update suite is not claimed as executed.
