### PR TITLE
docs(release): align validation with final notes preparation

### DIFF
--- a/docs/reference/full-release-validation.md
+++ b/docs/reference/full-release-validation.md
@@ -22,9 +22,12 @@ or `pnpm release:candidate`. Selected lanes still need terminal evidence.
 Normal CI, npm qualification, Docker, Package Acceptance, and the profile's
 performance and soak requirements keep their existing gates.
 
-Freeze the product-complete pre-changelog commit and its target context as the
-**Code SHA/ref**, and select one trusted workflow commit and context as the
-**Tooling SHA/ref**, then run:
+Prepare the complete history manifest and substantive version-matched release
+notes before freezing the product-complete commit and its target context as the
+**Code SHA/ref**. Package source preflight requires a matching release section;
+an empty placeholder is not preparation. If the notes are final, this commit
+can also be the **Release SHA**. Select one trusted workflow commit and context
+as the **Tooling SHA/ref**, then run:
 
 ```bash
 TOOLING_SHA="<recorded-full-main-ancestor-sha>"
@@ -151,8 +154,9 @@ All reads use the normal cache-aware GitHub route; cache and request latency can
 add to these intervals. The helper retains its 12-hour wait deadline. Successful
 temporary-ref cleanup still requires parent completion and strict evidence
 verification. Failed validations retain both refs for reruns and diagnosis. The
-Validation SHA equals the Code SHA for product validation or the Release SHA
-for changelog-only validation; it is not a third release identity. The workflow
+Validation SHA is the exact commit being qualified: the Code SHA, which can
+also be the Release SHA, or a later changelog-only Release SHA. It is not a
+third release identity. The workflow
 rejects malformed or mismatched expected SHAs before child dispatch. Every
 child must report the same Tooling SHA. Pass
 `-f reuse_evidence=false` to force a fresh run. Regular release-branch runs
@@ -218,12 +222,18 @@ frozen-target tooling; retry provider, approval, or runner failures without a
 source change. Any branch change needs a complete new run. Do not omit required
 package, installer, update, channel, or live behavior because the target is old.
 
-For a regular release, when the Code SHA is green, generate and commit only
-`CHANGELOG.md`. This new commit is the **Release SHA**. Run the same helper for
-the Release SHA. Product evidence is reused only when GitHub proves the Release
-SHA descends from the Code SHA and the complete changed path set is exactly
-`CHANGELOG.md`; npm preflight and package/install acceptance still run on the
-Release SHA.
+For a regular release whose qualified Code SHA already contains final notes,
+use that same commit as the **Release SHA**. Retain its successful full
+validation parent and exact prepared publication artifacts; no extra commit or
+validation run is needed solely to separate those roles.
+
+If notes change after qualification, commit only `CHANGELOG.md` as a new
+Release SHA and run the same helper for that commit. Product evidence reuse is
+optional and requires GitHub to prove that the Release SHA descends from the
+green Code SHA with a complete changed path set of exactly `CHANGELOG.md`.
+That path records `changelog-only-release-v1` and still qualifies the changed
+package and image bytes. Any other source change returns to full Code
+validation. See [Releasing](/reference/RELEASING) for the publication sequence.
 
 The conceptual phases map to current inputs:
 
@@ -702,10 +712,13 @@ classification and actual conclusion; an advisory failure can coexist with a
 passing release decision. Keep its diagnostic artifacts for follow-up rather
 than reporting that lane as passed.
 
-For a regular release, record both Code SHA and Release SHA, the reuse policy
-and changed-path set, the green Code SHA parent run, and the lightweight Release
-SHA parent run. For extended-stable, record the canonical branch, exact release
-SHA, fresh parent run id and attempt, workflow ref, every child run, and any
+For a regular release, record Code SHA and Release SHA even when they are the
+same commit. In that case, retain the successful full validation parent and
+its exact prepared publication artifacts for both roles. For a later
+changelog-only Release SHA using evidence reuse, also record the reuse policy,
+complete changed-path set, green Code SHA parent run, and Release SHA parent
+run. For extended-stable, record the canonical branch, exact release SHA,
+fresh parent run id and attempt, workflow ref, every child run, and any
 frozen-target compatibility repair or intentional omission.
 
 Useful artifacts:


### PR DESCRIPTION
## What Problem This Solves

Resolves conflicting release instructions: the full-validation guide still told maintainers to freeze a pre-changelog commit and always create a second release commit afterward. Current release policy prepares meaningful notes before qualification and supports using the same qualified commit for Code SHA and Release SHA.

## Why This Change Was Made

Align the guide's preparation, identity, publication, and evidence-recording paragraphs with the current release policy. Keep optional evidence reuse for a later genuine changelog-only descendant, including fresh qualification of changed package and image bytes.

## User Impact

Release maintainers can follow the guide without omitting required notes or creating an unnecessary commit and validation run solely to separate lifecycle labels. Existing profile, platform, source-identity, and publication gates are unchanged.

## Evidence

- Source and policy comparison against package source preflight and the current release preparation/regular-release guides.
- Targeted MDX check passed; docs link audit checked 9,269 links with zero broken links.
- No code, version, changelog, heading, or navigation changes.
- Docs-only `check:changed`, formatting, and diff checks passed.
- Fresh independent P2 review found no actionable findings.
