### PR TITLE
refactor: verify native merge methods at dispatch

### DIFF
--- a/test/scripts/pr-merge-outcome.test.ts
+++ b/test/scripts/pr-merge-outcome.test.ts
@@ -843,6 +843,11 @@ describePosix("native merge outcome with real Git and supervised lock recovery",
       const run = f.run(false, f.repo, method);
       expect(run.status, run.output).toBe(0);
       const state = f.state();
+      const submissions = state.calls.filter((call) => call[1] === "pr" && call[2] === "merge");
+      expect(submissions).toHaveLength(1);
+      expect(
+        submissions[0]?.filter((arg) => ["--squash", "--merge", "--rebase"].includes(arg)),
+      ).toEqual([`--${method}`]);
       const landed = state.pr.mergeCommit!.oid;
       expect(state.observationReads).toBe(5);
       expect(state.mainAdvances).toHaveLength(2);

--- a/test/scripts/pr-wrappers.test.ts
+++ b/test/scripts/pr-wrappers.test.ts
@@ -1166,17 +1166,6 @@ exit 99
     expect(script).toContain('exec "$base" merge-run "$pr"');
   });
 
-  it("defaults to squash and allows commit-preserving merge methods", () => {
-    const script = readScript("scripts/pr-lib/merge.sh");
-
-    expect(script).toContain("OPENCLAW_PR_MERGE_METHOD:-squash");
-    expect(script).toContain("--squash");
-    expect(script).toContain("--merge");
-    expect(script).toContain("--rebase");
-    expect(script).toContain("--auto");
-    expect(script).toContain('--match-head-commit "$PREP_HEAD_SHA"');
-  });
-
   it("keeps prepare wrapper modes delegated to the main PR helper", () => {
     const script = readScript("scripts/pr-prepare");
 


### PR DESCRIPTION
Related: #139428

## What Problem This Solves

The native merge tests could accept a rebase request dispatched with `--squash`: the resulting source tree and completion receipt still matched their assertions. A source-string guard also passed because the correct flag remained declared elsewhere in the script.

## Why This Change Was Made

The existing four-row method/queue table now checks the actual synthetic `gh pr merge` arguments, requiring one dispatch and exactly the requested method flag. Remove the source-shape guard whose default-squash, method-selection, auto-routing and exact-head contracts are covered by executable tests.

## User Impact

No production change. This strengthens regression detection while removing six net test lines. All four method scenarios and their existing receipt, tree, ordering and cleanup assertions remain; one source-only case is removed.

## Evidence

Original table plus source guard: five passed normally and five passed with a controlled rebase-to-squash dispatch mutation. The strengthened table passed all four normal rows; the same mutation failed the rebase row directly on expected `--rebase` versus actual `--squash`. The production script was restored byte-for-byte before final verification. These tests use synthetic `gh` and private file-only Git repositories.

The three full wrapper/hosted/outcome suites passed all 343 tests with no skips. Required changed-file checks and independent P2 review passed. No runtime improvement is claimed.
