### PR TITLE
fix(ui): keep person mention suggestions stable while typing

### DIFF
--- a/ui/src/e2e/chat-mention-search.e2e.test.ts
+++ b/ui/src/e2e/chat-mention-search.e2e.test.ts
@@ -1,0 +1,96 @@
+import { expect, it } from "vitest";
+import { defaultControlUiFeatureMethods } from "../test-helpers/control-ui-e2e.ts";
+import {
+  createChatFlowE2eSuite,
+  expectRequestCountStable,
+  installMockGateway,
+} from "./chat-flow.test-support.ts";
+
+const suite = createChatFlowE2eSuite();
+const people = [
+  { profileId: "harper", displayName: "Harper", online: true },
+  { profileId: "henry", displayName: "Henry", online: false },
+];
+
+suite.define(() => {
+  it("keeps complete mention results while refining and backspacing without another request", async () => {
+    await suite.withPage(
+      { viewport: { width: 1440, height: 900 }, colorScheme: "dark" },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: [...defaultControlUiFeatureMethods, "users.mentionable"],
+          presenceUsers: [
+            {
+              self: true,
+              id: "sender",
+              identity: { type: "profile", id: "sender" },
+              name: "Sender",
+            },
+          ],
+          methodResponses: { "users.mentionable": { users: people, truncated: false } },
+        });
+        await page.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+        const input = page.locator(".agent-chat__composer-combobox textarea");
+        await input.fill("@h");
+        const menu = page.getByRole("listbox", { name: "Mention a person" });
+        await expect.poll(() => menu.getByRole("option").count()).toBe(2);
+        await input.press("a");
+        await expect.poll(() => menu.getByRole("option").count()).toBe(1);
+        expect(await menu.textContent()).toContain("Harper");
+        expect(await menu.textContent()).not.toContain("Henry");
+        await input.press("Backspace");
+        await expect.poll(() => menu.getByRole("option").count()).toBe(2);
+        await expectRequestCountStable(gateway, "users.mentionable", 1);
+        await input.press("ArrowDown");
+        await input.press("Enter");
+        expect(await input.inputValue()).toBe("@Henry ");
+      },
+    );
+  });
+
+  it("reserves one person row while loading and respects reduced motion", async () => {
+    await suite.withPage(
+      { viewport: { width: 1440, height: 900 }, colorScheme: "dark", reducedMotion: "reduce" },
+      async ({ page }) => {
+        const gateway = await installMockGateway(page, {
+          featureMethods: [...defaultControlUiFeatureMethods, "users.mentionable"],
+          presenceUsers: [
+            {
+              self: true,
+              id: "sender",
+              identity: { type: "profile", id: "sender" },
+              name: "Sender",
+            },
+          ],
+          deferredMethods: ["users.mentionable"],
+        });
+        await page.goto(`${suite.server.baseUrl}chat`, { waitUntil: "domcontentloaded" });
+        await page.locator(".agent-chat__composer-combobox textarea").fill("@ha");
+        await gateway.waitForRequest("users.mentionable");
+        const menu = page.getByRole("listbox", { name: "Mention a person" });
+        expect(await menu.textContent()).toContain("Mention a person");
+        expect(await menu.textContent()).not.toContain("Loading people");
+        const skeleton = menu.locator(".mention-menu__loading");
+        expect(await skeleton.count()).toBe(1);
+        expect(await menu.getByRole("option").count()).toBe(0);
+        expect(
+          await skeleton
+            .locator(".skeleton")
+            .first()
+            .evaluate((element) => getComputedStyle(element, "::after").animationName),
+        ).toBe("none");
+        const loading = await menu.boundingBox();
+        await gateway.resolveDeferred("users.mentionable", {
+          users: people.slice(0, 1),
+          truncated: false,
+        });
+        await menu.getByRole("option").waitFor();
+        const ready = await menu.boundingBox();
+        expect(loading).not.toBeNull();
+        expect(ready).not.toBeNull();
+        expect(ready!.height).toBeCloseTo(loading!.height, 1);
+        expect(ready!.y).toBeCloseTo(loading!.y, 1);
+      },
+    );
+  });
+});

--- a/ui/src/i18n/locales/en.ts
+++ b/ui/src/i18n/locales/en.ts
@@ -4633,7 +4633,6 @@ export const en: TranslationMap & {
     },
     mentions: {
       menu: "Mention a person",
-      loading: "Loading people…",
       empty: "No eligible people found.",
       truncated: "Keep typing to find more people.",
       online: "Online",

--- a/ui/src/pages/chat/chat-composer-mentions.test.ts
+++ b/ui/src/pages/chat/chat-composer-mentions.test.ts
@@ -206,6 +206,152 @@ describe.each(["chat", "new-session"] as const)("%s human mentions", (kind) => {
     });
   });
 
+  it("reuses complete searches while refining and restoring cached queries", async () => {
+    const view = composerFixture(kind);
+    const roster: UsersMentionableResult = {
+      users: [
+        { profileId: "harper", displayName: "Harper", online: true },
+        { profileId: "henry", displayName: "Henry", online: false },
+        { profileId: "robin", displayName: "Robin", online: false },
+      ],
+      truncated: false,
+    };
+    view.request.mockResolvedValue(roster);
+    view.edit("@");
+    await vi.advanceTimersByTimeAsync(150);
+    for (const [query, count] of [
+      ["@h", 2],
+      ["@ha", 1],
+      ["@h", 2],
+      ["@", 3],
+    ] as const) {
+      view.edit(query);
+      expect(view.container.querySelectorAll('[role="option"]')).toHaveLength(count);
+      await vi.advanceTimersByTimeAsync(150);
+    }
+    expect(view.request).toHaveBeenCalledTimes(1);
+    view.edit("@ha");
+    view.key("Enter");
+    expect(view.value()).toEqual({
+      draft: "@Harper ",
+      mentions: [{ profileId: "harper", start: 0, end: 7 }],
+    });
+  });
+
+  it.each([
+    {
+      label: "truncated",
+      query: "@ha",
+      result: {
+        users: [{ profileId: "harper", displayName: "Harper", online: true }],
+        truncated: true,
+      },
+    },
+    {
+      label: "unrelated",
+      query: "@r",
+      result: {
+        users: [{ profileId: "harper", displayName: "Harper", online: true }],
+        truncated: false,
+      },
+    },
+    {
+      label: "server-only match",
+      query: "@ha",
+      result: {
+        users: [{ profileId: "harper", displayName: "Robin", online: true }],
+        truncated: false,
+      },
+    },
+    {
+      label: "disambiguated name",
+      query: "@ha",
+      result: {
+        users: [{ profileId: "harper01", displayName: "Henry (harper01)", online: true }],
+        truncated: false,
+      },
+    },
+  ])("refetches $label queries and preserves exact cached results", async ({ query, result }) => {
+    const view = composerFixture(kind);
+    view.request.mockResolvedValueOnce(result).mockResolvedValue({ users: [], truncated: false });
+    view.edit("@h");
+    await vi.advanceTimersByTimeAsync(150);
+    expect(view.container.querySelectorAll('[role="option"]')).toHaveLength(1);
+    view.edit(query);
+    await vi.advanceTimersByTimeAsync(150);
+    expect(view.request).toHaveBeenCalledTimes(2);
+    expect(view.container.querySelectorAll('[role="option"]')).toHaveLength(0);
+    view.edit("@h");
+    expect(view.container.querySelectorAll('[role="option"]')).toHaveLength(1);
+    await vi.advanceTimersByTimeAsync(150);
+    expect(view.request).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps server-locale matching authoritative for case-sensitive query identities", async () => {
+    const view = composerFixture(kind);
+    const dotless = {
+      users: [{ profileId: "isik", displayName: "Işık", online: true }],
+      truncated: false,
+    };
+    const dotted = {
+      users: [{ profileId: "ipek", displayName: "İpek", online: true }],
+      truncated: false,
+    };
+    view.request.mockResolvedValueOnce(dotless).mockResolvedValueOnce(dotted);
+    view.edit("@I");
+    await vi.advanceTimersByTimeAsync(150);
+    view.edit("@i");
+    await vi.advanceTimersByTimeAsync(150);
+    expect(view.request).toHaveBeenCalledTimes(2);
+    expect(view.container.textContent).toContain("İpek");
+    expect(view.container.textContent).not.toContain("Işık");
+    view.edit("@I");
+    expect(view.container.textContent).toContain("Işık");
+    expect(view.request).toHaveBeenCalledTimes(2);
+  });
+
+  it.each([
+    ["Ipek", "i"],
+    ["J\u0301onas", "j\u0301"],
+  ])("refetches locale-sensitive names such as %s", async (displayName, query) => {
+    const view = composerFixture(kind);
+    view.request
+      .mockResolvedValueOnce({
+        users: [{ profileId: "person", displayName, online: true }],
+        truncated: false,
+      })
+      .mockResolvedValueOnce({ users: [], truncated: false });
+    view.edit("@");
+    await vi.advanceTimersByTimeAsync(150);
+    view.edit(`@${query}`);
+    await vi.advanceTimersByTimeAsync(150);
+    expect(view.request).toHaveBeenCalledTimes(2);
+    expect(view.container.querySelectorAll('[role="option"]')).toHaveLength(0);
+  });
+
+  it("fences late searches when restoring a cached query and clears snapshots on owner change", async () => {
+    const view = composerFixture(kind);
+    view.edit("@A");
+    await vi.advanceTimersByTimeAsync(150);
+    let resolve!: (result: UsersMentionableResult) => void;
+    view.request.mockReturnValueOnce(
+      new Promise((done) => {
+        resolve = done;
+      }),
+    );
+    view.edit("@B");
+    await vi.advanceTimersByTimeAsync(150);
+    view.edit("@A");
+    resolve({ users: [], truncated: false });
+    await vi.advanceTimersByTimeAsync(0);
+    expect(view.container.querySelectorAll('[role="option"]')).toHaveLength(2);
+    expect(view.request).toHaveBeenCalledTimes(2);
+    view.replaceOwner();
+    view.edit("@A");
+    await vi.advanceTimersByTimeAsync(150);
+    expect(view.request).toHaveBeenCalledTimes(3);
+  });
+
   it("selects an offline same-name profile before Enter can send", async () => {
     const view = composerFixture(kind);
     view.edit("@Al", { data: "@Al" });

--- a/ui/src/pages/chat/components/chat-composer-mention-menu.ts
+++ b/ui/src/pages/chat/components/chat-composer-mention-menu.ts
@@ -11,6 +11,7 @@ import { t } from "../../../i18n/index.ts";
 import type { HumanMention } from "../../../lib/chat/chat-types.ts";
 import { MAX_HUMAN_MENTIONS, updateHumanMentions } from "../../../lib/chat/human-mentions.ts";
 import "../../../styles/chat/reply-preview.css";
+import "../../../styles/chat/mention-menu.css";
 import { renderChatAuthorAvatar } from "./chat-author-avatar.ts";
 import { paneDomId } from "./chat-composer-dom.ts";
 
@@ -61,6 +62,12 @@ function findMentionTarget(value: string, caret: number): MentionTarget | null {
   return { start, end, query };
 }
 
+function canFilterMentionText(value: string): boolean {
+  // Browser and Gateway locales are independent. ASCII without capital I has
+  // invariant lowercase; leave locale-sensitive and Unicode matching to the server.
+  return /^[\x20-\x7e]*$/u.test(value) && !value.includes("I");
+}
+
 /** One bounded suggestion lifecycle shared by existing- and new-session composers. */
 export class HumanMentionMenu {
   private directory?: HumanMentionDirectory;
@@ -69,6 +76,7 @@ export class HumanMentionMenu {
   private target: MentionTarget | null = null;
   private search: MentionSearch | null = null;
   private index = 0;
+  private results = new Map<string, UsersMentionableResult>();
 
   get open(): boolean {
     return this.target !== null;
@@ -88,18 +96,57 @@ export class HumanMentionMenu {
     this.directory = directory;
   }
 
-  close() {
+  private cancelSearch() {
     this.generation += 1;
     clearTimeout(this.timer);
     this.timer = undefined;
+    this.index = 0;
+  }
+
+  close() {
+    this.cancelSearch();
+    this.results.clear();
     this.target = null;
     this.search = null;
-    this.index = 0;
   }
 
   dispose() {
     this.close();
     this.directory = undefined;
+  }
+
+  private cachedResult(query: string): UsersMentionableResult | undefined {
+    const exact = this.results.get(query);
+    if (exact) {
+      return exact;
+    }
+    if (!canFilterMentionText(query)) {
+      return undefined;
+    }
+    const normalizedQuery = query.toLowerCase();
+    for (const [prefix, result] of this.results) {
+      // Gateway matches names before adding duplicate-name ID suffixes. Opaque matches
+      // (for example a server-only ID lookup) and ambiguous labels must refetch;
+      // exact queries keep the server response unchanged, including truncated results.
+      if (
+        !result.truncated &&
+        query.startsWith(prefix) &&
+        result.users.every(
+          (person) =>
+            canFilterMentionText(person.displayName) &&
+            person.displayName.toLowerCase().includes(prefix.toLowerCase()) &&
+            !person.displayName.endsWith(` (${person.profileId.slice(0, 8)})`),
+        )
+      ) {
+        return {
+          users: result.users.filter((person) =>
+            person.displayName.toLowerCase().includes(normalizedQuery),
+          ),
+          truncated: false,
+        };
+      }
+    }
+    return undefined;
   }
 
   update(value: string, caret: number, requestUpdate: () => void, typedAtSign = false) {
@@ -114,8 +161,18 @@ export class HumanMentionMenu {
     if (this.target?.start === target.start && this.target.query === target.query) {
       return;
     }
-    this.close();
+    if (this.target?.start !== target.start) {
+      this.results.clear();
+    }
+    this.cancelSearch();
     this.target = target;
+    const query = target.query;
+    const cached = this.cachedResult(query);
+    if (cached) {
+      this.search = { kind: "ready", result: cached };
+      requestUpdate();
+      return;
+    }
     this.search = { kind: "loading" };
     const directory = this.directory;
     if (!directory) {
@@ -132,6 +189,10 @@ export class HumanMentionMenu {
         .then(
           (result) => {
             if (generation === this.generation) {
+              if (this.results.size === 16) {
+                this.results.delete(this.results.keys().next().value!);
+              }
+              this.results.set(query, result);
               this.search = { kind: "ready", result };
               requestUpdate();
             }
@@ -223,47 +284,53 @@ export class HumanMentionMenu {
     }
     const result = this.search?.kind === "ready" ? this.search.result : undefined;
     const limited = host.getMentions().length >= MAX_HUMAN_MENTIONS;
+    const loading = this.search?.kind === "loading";
     const message = limited
       ? t("chat.mentions.limit")
       : this.search?.kind === "error"
         ? t("chat.mentions.unavailable")
-        : this.search?.kind === "loading"
-          ? t("chat.mentions.loading")
-          : !result?.users.length
-            ? t("chat.mentions.empty")
-            : null;
+        : !loading && !result?.users.length
+          ? t("chat.mentions.empty")
+          : null;
     return renderComposerMenu({
       id: paneDomId(host.paneId, "mention-menu-listbox"),
       className: "mention-menu",
       label: t("chat.mentions.menu"),
       trackScroll: false,
-      content: html` <div class="slash-menu-group">
+      content: html` <div class="slash-menu-group" aria-busy=${loading}>
         <div class="slash-menu-group__label" role="status">
           ${message ?? t("chat.mentions.menu")}
         </div>
         ${
           message
             ? nothing
-            : result?.users.map((person, index) =>
-                renderComposerMenuOption({
-                  id: paneDomId(host.paneId, `mention-option-${index}`),
-                  active: index === this.index,
-                  select: () => this.select(person, host, requestUpdate),
-                  hover: () => {
-                    this.index = index;
-                    requestUpdate();
-                  },
-                  icon: renderChatAuthorAvatar({
-                    id: person.profileId,
+            : loading
+              ? html`<div class="slash-menu-item mention-menu__loading" aria-hidden="true">
+                  <span class="slash-menu-icon"
+                    ><span class="skeleton mention-menu__avatar"></span
+                  ></span>
+                  <span class="skeleton skeleton-line skeleton-line--medium"></span>
+                </div>`
+              : result?.users.map((person, index) =>
+                  renderComposerMenuOption({
+                    id: paneDomId(host.paneId, `mention-option-${index}`),
+                    active: index === this.index,
+                    select: () => this.select(person, host, requestUpdate),
+                    hover: () => {
+                      this.index = index;
+                      requestUpdate();
+                    },
+                    icon: renderChatAuthorAvatar({
+                      id: person.profileId,
+                      name: person.displayName,
+                      identity: { type: "profile", id: person.profileId },
+                      profileAvatarUrl: person.avatarUrl,
+                    }),
+                    iconHidden: true,
                     name: person.displayName,
-                    identity: { type: "profile", id: person.profileId },
-                    profileAvatarUrl: person.avatarUrl,
+                    description: person.online ? t("chat.mentions.online") : nothing,
                   }),
-                  iconHidden: true,
-                  name: person.displayName,
-                  description: person.online ? t("chat.mentions.online") : nothing,
-                }),
-              )
+                )
         }
         ${
           result?.truncated

--- a/ui/src/styles/chat/mention-menu.css
+++ b/ui/src/styles/chat/mention-menu.css
@@ -1,0 +1,15 @@
+.mention-menu__avatar {
+  width: 100%;
+  height: 100%;
+  border-radius: 50%;
+}
+
+.mention-menu__loading:hover {
+  background: transparent;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .mention-menu__loading .skeleton::after {
+    animation: none;
+  }
+}


### PR DESCRIPTION
Builds on merged #142274 by @vyctorbrzezowski.

Closes #142212

## What Problem This Solves
Fixes an issue where users refining a person mention search would lose an already loaded list and see the popover collapse to a loading label after each edit.

## Why This Change Was Made
Keep bounded query snapshots within the open person picker. Exact cached queries retain their server responses; refinements filter complete, unambiguous results locally when name matching is independent of locale. New queries, limited results, and ambiguous server-projected labels still fetch. Closing the picker or changing its owner discards the snapshots.

Necessary searches retain “Mention a person” and show one skeleton row using the same row geometry and shared skeleton styling. Reduced motion disables its animation. Removing the unused English loading key removes it from every generated runtime locale through the existing source-key projection.

## User Impact
With complete Harper/Henry results, typing `@h → @ha → @h` keeps useful suggestions available with one directory request instead of three. People can still select offline recipients and use the same picker in an existing chat or a new session.

## Evidence
<table>
<tr><th>Before</th><th>After</th></tr>
<tr><td><strong>Necessary search: loading</strong><br /><a href="https://github.com/user-attachments/assets/03b7eee7-b84c-4513-b36f-1a3b43e02a7c"><img src="https://github.com/user-attachments/assets/03b7eee7-b84c-4513-b36f-1a3b43e02a7c" width="600" alt="Before: Necessary search: loading" /></a><br /><a href="https://github.com/user-attachments/assets/03b7eee7-b84c-4513-b36f-1a3b43e02a7c">Open before image</a></td><td><strong>Necessary search: loading</strong><br /><a href="https://github.com/user-attachments/assets/afa6cf8f-5019-47d6-8a21-ae0352782326"><img src="https://github.com/user-attachments/assets/afa6cf8f-5019-47d6-8a21-ae0352782326" width="600" alt="After: Necessary search: loading" /></a><br /><a href="https://github.com/user-attachments/assets/afa6cf8f-5019-47d6-8a21-ae0352782326">Open after image</a></td></tr>
<tr><td><strong>Filtered result for @ha</strong><br /><a href="https://github.com/user-attachments/assets/683d08f3-3a9b-42ee-b1fe-26129b1ac8ac"><img src="https://github.com/user-attachments/assets/683d08f3-3a9b-42ee-b1fe-26129b1ac8ac" width="600" alt="Before: Filtered result for @ha" /></a><br /><a href="https://github.com/user-attachments/assets/683d08f3-3a9b-42ee-b1fe-26129b1ac8ac">Open before image</a></td><td><strong>Filtered result for @ha</strong><br /><a href="https://github.com/user-attachments/assets/b3e54981-05d0-496a-99bb-07fc63b3711b"><img src="https://github.com/user-attachments/assets/b3e54981-05d0-496a-99bb-07fc63b3711b" width="600" alt="After: Filtered result for @ha" /></a><br /><a href="https://github.com/user-attachments/assets/b3e54981-05d0-496a-99bb-07fc63b3711b">Open after image</a></td></tr>
</table>

- Synthetic mocked Gateway, dark appearance, 1440 × 900.
- Search sequence `h → ha → h`: **3 requests before → 1 after**.
- A necessary `ha` search: before **36.5 → 70.5 px**; after **70.5 → 70.5 px** loading/loaded, with unchanged vertical position for a single result.
- Both production consumers checked: existing chat composer and new-session composer, including selection and owner-change fencing.
- Validation passed on `86b3b441d6c0`: **40 unit tests, 2 mocked browser E2E tests, and `node scripts/check-changed.mjs`**, with `OPENCLAW_VITEST_MAX_WORKERS=2`. [Exact-head CI](https://github.com/openclaw/openclaw/actions/runs/34260251835) completed successfully (102 jobs); the standard PR CI watcher reported green.
- The final diff review found no actionable issues. The previous stacked-base prerequisite is resolved: #142274 by @vyctorbrzezowski is merged, and this PR now targets main.

**Risk and coverage**
Server limits and matching semantics are unchanged. Local refinement is limited to printable ASCII without capital I because browser and Gateway locales can differ. Unicode or locale-sensitive names, duplicate-name suffixes, and matches that cannot be reproduced from returned names trigger a refetch. Exact cached responses remain intact, including server-only matches. Pending responses cannot replace a newer query or another owner's state. Suggestions remain snapshots until the picker closes; the Gateway still rechecks recipient eligibility when accepting a mention. Proof uses a mocked Gateway; no live profile directory or model request was used.
